### PR TITLE
feat(moq-video): resize Direct3D11 textures on the GPU

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -318,9 +318,8 @@ moq --client-connect https://relay.example.com/anon --broadcast cam.hang     tra
 moq --client-connect https://relay.example.com/anon --broadcast cam.hang transcode --output ladder.hang
 ```
 
-Windows defaults to CPU resizing because some drivers can wedge when a cold
-Direct3D11 video processor runs beside a live DXVA decoder. Pass
-`--resize-acceleration gpu` to opt into GPU resizing after validating the driver.
+Windows uses the Direct3D11 video processor by default. Pass
+`--resize-acceleration cpu` to force frames through CPU resizing.
 
 On an NVIDIA GPU the pipeline is fully GPU-resident: one shared NVDEC session
 decodes the source for all active rungs, a CUDA kernel resizes each rung's copy,

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -318,6 +318,10 @@ moq --client-connect https://relay.example.com/anon --broadcast cam.hang     tra
 moq --client-connect https://relay.example.com/anon --broadcast cam.hang transcode --output ladder.hang
 ```
 
+Windows defaults to CPU resizing because some drivers can wedge when a cold
+Direct3D11 video processor runs beside a live DXVA decoder. Pass
+`--resize-acceleration gpu` to opt into GPU resizing after validating the driver.
+
 On an NVIDIA GPU the pipeline is fully GPU-resident: one shared NVDEC session
 decodes the source for all active rungs, a CUDA kernel resizes each rung's copy,
 and NVENC encodes it in place, with no CPU copies. Without a GPU it falls back

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -131,15 +131,16 @@ rather than a blanket promise:
 | --- | --- | --- | --- |
 | macOS | `PixelBuffer` (VideoToolbox) | yes | yes, via `CVMetalTextureCache` |
 | Linux | `Cuda` (NVDEC) | yes, straight into NVENC | no, downloaded to I420 first |
-| Windows | `Texture` (Media Foundation / DXVA) | yes, straight into a hardware encoder MFT | no, downloaded to I420 first |
+| Windows | `Texture` (Media Foundation / DXVA) | yes without resize; GPU resize is opt-in | no, downloaded to I420 first |
 
-So the transcode path is real everywhere: a decoded frame feeds the encoder
-without leaving the GPU, and `Frame::resize` scales it there too, on a
-`VTPixelTransferSession` (macOS), a CUDA kernel (Linux), or a Direct3D11 video
-processor (Windows). A driver that refuses the GPU scaler downloads and scales on
-the CPU instead, warning once. Rendering is zero-copy on macOS only; the Vulkan
-and EGL importers that would extend it to Linux are tracked in
-[#2481](https://github.com/moq-dev/moq/issues/2481).
+On macOS and Linux, `Frame::resize` stays on the GPU through a
+`VTPixelTransferSession` or CUDA kernel. Windows defaults to downloading and
+scaling on the CPU because some drivers can block indefinitely when a cold
+Direct3D11 video processor runs beside a live DXVA decoder. Call
+`Frame::resize_with` with `resize::Acceleration::Gpu` to opt into the GPU path;
+a driver that rejects it returns to CPU scaling and warns once. Rendering is
+zero-copy on macOS only; the Vulkan and EGL importers that would extend it are
+tracked in [#2481](https://github.com/moq-dev/moq/issues/2481).
 
 Matching on `Surface` stays portable because every variant has a universal
 fallback in `Surface::into_i420()`: take the fast path you recognize and let the

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -131,14 +131,12 @@ rather than a blanket promise:
 | --- | --- | --- | --- |
 | macOS | `PixelBuffer` (VideoToolbox) | yes | yes, via `CVMetalTextureCache` |
 | Linux | `Cuda` (NVDEC) | yes, straight into NVENC | no, downloaded to I420 first |
-| Windows | `Texture` (Media Foundation / DXVA) | yes without resize; GPU resize is opt-in | no, downloaded to I420 first |
+| Windows | `Texture` (Media Foundation / DXVA) | yes, through the Direct3D11 video processor | no, downloaded to I420 first |
 
-On macOS and Linux, `Frame::resize` stays on the GPU through a
-`VTPixelTransferSession` or CUDA kernel. Windows defaults to downloading and
-scaling on the CPU because some drivers can block indefinitely when a cold
-Direct3D11 video processor runs beside a live DXVA decoder. Call
-`Frame::resize_with` with `resize::Acceleration::Gpu` to opt into the GPU path;
-a driver that rejects it returns to CPU scaling and warns once. Rendering is
+`Frame::resize` stays on the GPU through a `VTPixelTransferSession`, CUDA kernel,
+or Direct3D11 video processor. Call `Frame::resize_with` with
+`resize::Acceleration::Cpu` to force a download and CPU resize. A driver that
+rejects GPU resizing returns to CPU scaling and warns once. Rendering is
 zero-copy on macOS only; the Vulkan and EGL importers that would extend it are
 tracked in [#2481](https://github.com/moq-dev/moq/issues/2481).
 

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -131,13 +131,14 @@ rather than a blanket promise:
 | --- | --- | --- | --- |
 | macOS | `PixelBuffer` (VideoToolbox) | yes | yes, via `CVMetalTextureCache` |
 | Linux | `Cuda` (NVDEC) | yes, straight into NVENC | no, downloaded to I420 first |
-| Windows | `I420` (Media Foundation downloads its DXVA texture) | no | no |
+| Windows | `Texture` (Media Foundation / DXVA) | yes, straight into a hardware encoder MFT | no, downloaded to I420 first |
 
-So the transcode path is real on macOS and Linux: a decoded frame feeds the
-encoder without leaving the GPU, and `decode::Config::resize` scales it there too.
-Rendering is zero-copy on macOS only. The Vulkan and EGL importers that would
-extend it to Linux, and the Media Foundation decode-surface retention that would
-give Windows a GPU frame at all, are both tracked in
+So the transcode path is real everywhere: a decoded frame feeds the encoder
+without leaving the GPU, and `Frame::resize` scales it there too, on a
+`VTPixelTransferSession` (macOS), a CUDA kernel (Linux), or a Direct3D11 video
+processor (Windows). A driver that refuses the GPU scaler downloads and scales on
+the CPU instead, warning once. Rendering is zero-copy on macOS only; the Vulkan
+and EGL importers that would extend it to Linux are tracked in
 [#2481](https://github.com/moq-dev/moq/issues/2481).
 
 Matching on `Surface` stays portable because every variant has a universal

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -35,6 +35,10 @@ pub struct Args {
 	/// backend name like `nvdec`.
 	#[arg(long, default_value = "auto")]
 	pub decoder: String,
+
+	/// Frame resize acceleration: `auto`, `cpu`, or `gpu`.
+	#[arg(long, default_value = "auto", value_parser = parse_resize_acceleration)]
+	pub resize_acceleration: moq_video::resize::Acceleration,
 }
 
 /// Parse a `height:bitrate` rung, e.g. `720:2500000`.
@@ -47,6 +51,16 @@ fn parse_rung(arg: &str) -> Result<moq_transcode::Rung, String> {
 		.parse()
 		.map_err(|e| format!("invalid bitrate `{bitrate}`: {e}"))?;
 	Ok(moq_transcode::Rung::new(height, bitrate))
+}
+
+/// Parse a frame resize acceleration preference.
+fn parse_resize_acceleration(arg: &str) -> Result<moq_video::resize::Acceleration, String> {
+	match arg {
+		"auto" => Ok(moq_video::resize::Acceleration::Auto),
+		"cpu" => Ok(moq_video::resize::Acceleration::Cpu),
+		"gpu" => Ok(moq_video::resize::Acceleration::Gpu),
+		_ => Err(format!("expected auto, cpu, or gpu, got `{arg}`")),
+	}
 }
 
 /// Run the transcoder: subscribe to the source through the relay, publish the
@@ -104,6 +118,7 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		"software" => moq_video::decode::Kind::Software,
 		name => moq_video::decode::Kind::Named(name.to_string()),
 	};
+	config.resize.acceleration = args.resize_acceleration;
 	// Reference the source renditions relatively when the output nests under
 	// the source (`a/b` -> `a/b/transcode.hang` is `..`, one `..` per level);
 	// otherwise the derivative catalog advertises only the rungs.

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -36,7 +36,8 @@ pub struct Args {
 	#[arg(long, default_value = "auto")]
 	pub decoder: String,
 
-	/// Frame resize acceleration: `auto`, `cpu`, or `gpu`.
+	/// Frame resize acceleration: `auto` (GPU-backed frames stay resident), `cpu`,
+	/// or `gpu`.
 	#[arg(long, default_value = "auto", value_parser = parse_resize_acceleration)]
 	pub resize_acceleration: moq_video::resize::Acceleration,
 }

--- a/rs/moq-transcode/README.md
+++ b/rs/moq-transcode/README.md
@@ -24,9 +24,9 @@ the H.264 software fallback. H.264, H.265, and 8-bit 4:2:0 AV1 source renditions
 are eligible when a matching decoder is available. On an NVIDIA GPU the pipeline
 is fully GPU-resident: NVDEC decodes and scales in hardware and NVENC encodes the
 CUDA frame in place, with no CPU copies. macOS also resizes on the GPU. Windows
-defaults to CPU resize because some drivers can wedge in the Direct3D11 video
-processor; set `Config::resize.acceleration` to `resize::Acceleration::Gpu` to
-opt in.
+uses the Direct3D11 video processor by default; set
+`Config::resize.acceleration` to `resize::Acceleration::Cpu` to force a download
+and CPU resize.
 
 ## Library
 

--- a/rs/moq-transcode/README.md
+++ b/rs/moq-transcode/README.md
@@ -23,7 +23,10 @@ NVENC on Linux, VideoToolbox on macOS, Media Foundation on Windows), openh264 as
 the H.264 software fallback. H.264, H.265, and 8-bit 4:2:0 AV1 source renditions
 are eligible when a matching decoder is available. On an NVIDIA GPU the pipeline
 is fully GPU-resident: NVDEC decodes and scales in hardware and NVENC encodes the
-CUDA frame in place, with no CPU copies. Other decoders fall back to CPU scaling.
+CUDA frame in place, with no CPU copies. macOS also resizes on the GPU. Windows
+defaults to CPU resize because some drivers can wedge in the Direct3D11 video
+processor; set `Config::resize.acceleration` to `resize::Acceleration::Gpu` to
+opt in.
 
 ## Library
 

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -56,8 +56,7 @@ pub struct Config {
 	/// need a hardware decoder).
 	pub decoder: moq_video::decode::Kind,
 
-	/// Frame resize behavior. Automatic mode keeps Direct3D11 resizing on the CPU
-	/// because some Windows drivers can wedge beside a live DXVA decoder.
+	/// Frame resize behavior. Automatic mode keeps GPU-backed frames on the GPU.
 	pub resize: moq_video::resize::Config,
 }
 

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -55,6 +55,10 @@ pub struct Config {
 	/// prefers hardware and falls back to openh264 (H.264 only; H.265 sources
 	/// need a hardware decoder).
 	pub decoder: moq_video::decode::Kind,
+
+	/// Frame resize behavior. Automatic mode keeps Direct3D11 resizing on the CPU
+	/// because some Windows drivers can wedge beside a live DXVA decoder.
+	pub resize: moq_video::resize::Config,
 }
 
 impl Default for Config {
@@ -72,6 +76,7 @@ impl Default for Config {
 			source: None,
 			encoder: moq_video::encode::Kind::default(),
 			decoder: moq_video::decode::Kind::default(),
+			resize: moq_video::resize::Config::default(),
 		}
 	}
 }

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -358,6 +358,10 @@ mod tests {
 	/// The multi-rung live path on real hardware: one shared NVDEC session
 	/// decodes the source, the GPU box filter resizes per rung, and each rung's
 	/// NVENC session encodes the CUDA frame in place. Skips without a GPU.
+	#[cfg_attr(
+		target_os = "windows",
+		ignore = "explicit live-DXVA GPU probe; VideoProcessorBlt can hang on affected drivers"
+	)]
 	#[tokio::test]
 	async fn live_multi_rung_hardware() {
 		if !hardware_available() {
@@ -436,6 +440,10 @@ mod tests {
 	/// decoder) into hardware encode (NVENC, consuming the CUDA frame in place).
 	/// Skips on machines without both; on a Linux + NVIDIA box this is the
 	/// zero-copy transcode path under the real broadcast plumbing.
+	#[cfg_attr(
+		target_os = "windows",
+		ignore = "explicit live-DXVA GPU probe; VideoProcessorBlt can hang on affected drivers"
+	)]
 	#[tokio::test]
 	async fn end_to_end_hardware() {
 		if !hardware_available() {

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -109,6 +109,7 @@ pub async fn run(
 							config: source_config.clone(),
 							encoder: config.encoder.clone(),
 							decoder: config.decoder.clone(),
+							resize: config.resize,
 							info: info.clone(),
 						};
 						tasks.spawn(rung::serve(rung, request));
@@ -316,6 +317,7 @@ mod tests {
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Software,
 			source: None,
+			..Default::default()
 		};
 
 		let output = moq_net::broadcast::Info::default().produce();
@@ -368,12 +370,14 @@ mod tests {
 		// 180p and 120p: NVENC rejects tiny frames (80x60 is below its minimum
 		// encode resolution), so the hardware ladder stays a bit larger than the
 		// software test's.
-		let config = Config {
+		let mut config = Config {
 			rungs: vec![Rung::new(180, 200_000), Rung::new(120, 100_000)],
 			encoder: moq_video::encode::Kind::Hardware,
 			decoder: moq_video::decode::Kind::Hardware,
 			source: None,
+			..Default::default()
 		};
+		config.resize.acceleration = moq_video::resize::Acceleration::Gpu;
 
 		let output = moq_net::broadcast::Info::default().produce();
 		let consumer = output.consume();
@@ -440,12 +444,14 @@ mod tests {
 		}
 
 		let source = source_broadcast(2, 5);
-		let config = Config {
+		let mut config = Config {
 			rungs: vec![Rung::new(120, 100_000)],
 			encoder: moq_video::encode::Kind::Hardware,
 			decoder: moq_video::decode::Kind::Hardware,
 			source: None,
+			..Default::default()
 		};
+		config.resize.acceleration = moq_video::resize::Acceleration::Gpu;
 
 		let output = moq_net::broadcast::Info::default().produce();
 		let consumer = output.consume();
@@ -482,6 +488,7 @@ mod tests {
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Software,
 			source: Some(moq_net::PathRelativeOwned::from("..".to_string())),
+			..Default::default()
 		};
 
 		let output = moq_net::broadcast::Info::default().produce();
@@ -579,6 +586,7 @@ mod tests {
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Software,
 			source: None,
+			..Default::default()
 		};
 
 		let output = moq_net::broadcast::Info::default().produce();

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -392,11 +392,11 @@ fn write(output: &mut moq_net::group::Producer, encoded: Vec<moq_video::encode::
 
 /// Decode -> resize -> encode for one fetched group of one rung.
 ///
-/// The decoder is asked to emit frames at the rung's resolution
-/// (`decode::Config::resize`). A decoder with a hardware scaler (NVDEC) does,
-/// and its GPU frames feed the encoder in place: the NVDEC -> NVENC path never
-/// touches the CPU. Frames that come back at any other size (software decode,
-/// or a hardware decoder without a scaler) get `Frame::resize_with` instead.
+/// Unless CPU scaling is forced, the decoder is asked to emit frames at the
+/// rung's resolution (`decode::Config::resize`). A decoder with a hardware
+/// scaler (NVDEC) does, and its GPU frames feed the encoder in place: the NVDEC
+/// -> NVENC path never touches the CPU. Frames that come back at any other size
+/// get `Frame::resize_with` instead.
 struct Pipeline {
 	decoder: moq_video::decode::Decoder,
 	/// Opened from the first decoded frame, whose color space it has to declare.
@@ -412,7 +412,7 @@ impl Pipeline {
 	fn new(rung: &Rung) -> Result<Self, Error> {
 		let mut decode = moq_video::decode::Config::new();
 		decode.kind = rung.decoder.clone();
-		decode.resize = Some(rung.info.size);
+		decode.resize = decoder_resize(rung.info.size, rung.resize.acceleration);
 		let decoder = moq_video::decode::Decoder::new(&rung.config, &decode)?;
 
 		Ok(Self {
@@ -479,5 +479,27 @@ impl Pipeline {
 			Some(encoder) => encoder.finish().map_err(Into::into),
 			None => Ok(Vec::new()),
 		}
+	}
+}
+
+/// Let a hardware decoder scale only when the caller has not forced the CPU.
+fn decoder_resize(size: moq_video::Size, acceleration: moq_video::resize::Acceleration) -> Option<moq_video::Size> {
+	(acceleration != moq_video::resize::Acceleration::Cpu).then_some(size)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::decoder_resize;
+	use moq_video::resize::Acceleration;
+
+	/// A fetched NVDEC group reaches `Frame::resize_with` at native size when
+	/// CPU scaling is forced, rather than being resized in the decoder first.
+	#[test]
+	fn forced_cpu_skips_the_decoder_scaler() {
+		let size = moq_video::Size::new(160, 120);
+
+		assert_eq!(decoder_resize(size, Acceleration::Cpu), None);
+		assert_eq!(decoder_resize(size, Acceleration::Auto), Some(size));
+		assert_eq!(decoder_resize(size, Acceleration::Gpu), Some(size));
 	}
 }

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -48,6 +48,8 @@ pub(crate) struct Rung {
 	pub encoder: moq_video::encode::Kind,
 	/// Which decoder implementation to use.
 	pub decoder: moq_video::decode::Kind,
+	/// How to resize decoded frames.
+	pub resize: moq_video::resize::Config,
 }
 
 impl Rung {
@@ -186,15 +188,15 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 					let Some(output) = &mut current else { continue };
 
 					// The feed decodes at the source's native size; size this rung's copy
-					// here. A GPU frame resizes on the GPU and feeds the encoder without
-					// touching the CPU. The resize carries the source's color space
-					// across, which is why the encoder is opened from the scaled frame
-					// rather than from this rung's size.
+					// here. Supported GPU paths feed the encoder without touching the
+					// CPU. The resize carries the source's color space across, which is
+					// why the encoder is opened from the scaled frame rather than from
+					// this rung's size.
 					let resized;
 					let frame: &moq_video::Frame = match frame.size() == rung.info.size {
 						true => &frame,
 						false => {
-							resized = frame.resize(rung.info.size)?;
+							resized = frame.resize_with(rung.info.size, &rung.resize)?;
 							&resized
 						}
 					};
@@ -394,7 +396,7 @@ fn write(output: &mut moq_net::group::Producer, encoded: Vec<moq_video::encode::
 /// (`decode::Config::resize`). A decoder with a hardware scaler (NVDEC) does,
 /// and its GPU frames feed the encoder in place: the NVDEC -> NVENC path never
 /// touches the CPU. Frames that come back at any other size (software decode,
-/// or a hardware decoder without a scaler) get `Frame::resize` instead.
+/// or a hardware decoder without a scaler) get `Frame::resize_with` instead.
 struct Pipeline {
 	decoder: moq_video::decode::Decoder,
 	/// Opened from the first decoded frame, whose color space it has to declare.
@@ -448,7 +450,7 @@ impl Pipeline {
 			let raw: &moq_video::Frame = match raw.size() == self.size {
 				true => &raw,
 				false => {
-					resized = raw.resize(self.size)?;
+					resized = raw.resize_with(self.size, &self.rung.resize)?;
 					&resized
 				}
 			};

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -60,7 +60,7 @@ fn main() -> anyhow::Result<()> {
 #[cfg(target_os = "windows")]
 mod probe {
 	use std::ffi::c_void;
-	use std::mem::ManuallyDrop;
+	use std::mem::{ManuallyDrop, size_of};
 	use std::ptr;
 	use std::sync::Mutex;
 	use std::sync::atomic::{AtomicBool, Ordering};
@@ -75,12 +75,13 @@ mod probe {
 		D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_DEBUG,
 		D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_MESSAGE, D3D11_SDK_VERSION,
 		D3D11_SUBRESOURCE_DATA, D3D11_TEX2D_VPIV, D3D11_TEX2D_VPOV, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT,
-		D3D11_USAGE_STAGING, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE, D3D11_VIDEO_PROCESSOR_CONTENT_DESC,
-		D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC, D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0,
-		D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC, D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0, D3D11_VIDEO_PROCESSOR_STREAM,
-		D3D11_VIDEO_USAGE_PLAYBACK_NORMAL, D3D11_VPIV_DIMENSION_TEXTURE2D, D3D11_VPOV_DIMENSION_TEXTURE2D,
-		D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext, ID3D11InfoQueue, ID3D11Texture2D, ID3D11VideoContext,
-		ID3D11VideoDevice, ID3D11VideoProcessor, ID3D11VideoProcessorEnumerator, ID3D11VideoProcessorInputView,
+		D3D11_USAGE_STAGING, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE, D3D11_VIDEO_PROCESSOR_COLOR_SPACE,
+		D3D11_VIDEO_PROCESSOR_CONTENT_DESC, D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC,
+		D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0, D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC,
+		D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0, D3D11_VIDEO_PROCESSOR_STREAM, D3D11_VIDEO_USAGE_PLAYBACK_NORMAL,
+		D3D11_VPIV_DIMENSION_TEXTURE2D, D3D11_VPOV_DIMENSION_TEXTURE2D, D3D11CreateDevice, ID3D11Device,
+		ID3D11DeviceContext, ID3D11InfoQueue, ID3D11Texture2D, ID3D11VideoContext, ID3D11VideoDevice,
+		ID3D11VideoProcessor, ID3D11VideoProcessorEnumerator, ID3D11VideoProcessorInputView,
 		ID3D11VideoProcessorOutputView,
 	};
 	use moq_video::windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_NV12, DXGI_RATIONAL, DXGI_SAMPLE_DESC};
@@ -145,7 +146,9 @@ mod probe {
 			if unsafe { queue.GetMessage(index, None, &mut len) }.is_err() || len == 0 {
 				continue;
 			}
-			let mut buffer = vec![0u8; len];
+			// The message contains pointers, so its backing allocation must carry
+			// pointer alignment rather than the byte vector's alignment of one.
+			let mut buffer = vec![0u64; len.div_ceil(size_of::<u64>())];
 			let message = buffer.as_mut_ptr().cast::<D3D11_MESSAGE>();
 			if unsafe { queue.GetMessage(index, Some(message), &mut len) }.is_err() {
 				continue;
@@ -306,6 +309,14 @@ mod probe {
 
 			step("VideoProcessorSetStreamFrameFormat", || unsafe {
 				video_context.VideoProcessorSetStreamFrameFormat(&processor, 0, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE);
+			});
+			step("VideoProcessorSetStreamAutoProcessingMode", || unsafe {
+				video_context.VideoProcessorSetStreamAutoProcessingMode(&processor, 0, false);
+			});
+			step("VideoProcessorSetColorSpace", || unsafe {
+				let space = D3D11_VIDEO_PROCESSOR_COLOR_SPACE::default();
+				video_context.VideoProcessorSetStreamColorSpace(&processor, 0, &space);
+				video_context.VideoProcessorSetOutputColorSpace(&processor, &space);
 			});
 
 			Ok(Self {

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -879,15 +879,13 @@ mod probe {
 			.surface
 			.into_i420()
 			.context("cpu resize download")?;
-		// Packed I420, so the luma plane is the leading width * height bytes.
-		let luma = (TARGET.width * TARGET.height) as usize;
 		eprintln!(
 			"    scaled {}x{} -> {}x{}, luma MAE vs the CPU resize: {}",
 			SOURCE.width,
 			SOURCE.height,
 			TARGET.width,
 			TARGET.height,
-			mae(got.y(), &expected[..luma])
+			mae(got.y(), expected.y())
 		);
 		Ok(())
 	}

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -18,7 +18,7 @@
 //! | `live` | Decoder bound and decoding first, scaler built after. The reported failure. |
 //! | `concurrent` | Decode loop on one thread, scaler on another, one shared device. |
 //! | `crate` | Like `live`, but through the real `decode::Decoder`, to confirm the probe's decoder matches it. |
-//! | `ladder` | One decoder, four hardware encoders, and a scaler on one device. The full `moq-transcode` shape. |
+//! | `ladder` | One decoder and four GPU-resize plus hardware-encode rungs on one device. The full `moq-transcode` shape. |
 //!
 //! Run one mode per process: a wedge leaves the device unusable, so a second
 //! mode in the same process would measure the wreckage rather than itself.
@@ -39,7 +39,8 @@
 //! The probe prints its PID on startup and a watchdog line every two seconds
 //! naming the call in flight, so a wedge is one `procdump -ma <pid>` away from
 //! a stack. Pass `--debug-layer` to add `D3D11_CREATE_DEVICE_DEBUG`, which
-//! often names the problem before the wedge does.
+//! often names the problem before the wedge does. The `crate` and `ladder`
+//! modes reject this flag because the production decoder owns device creation.
 //!
 //! The decode session here is a deliberately minimal reimplementation of
 //! `decode::backend::mediafoundation`. The question is which ordering of device
@@ -1027,7 +1028,9 @@ mod probe {
 	/// The same ordering as `live`, but the pictures come from the crate's own
 	/// decoder, so the probe's minimal MFT can be checked against the real one.
 	fn mode_crate(debug_layer: bool) -> Result<()> {
-		let _ = debug_layer;
+		if debug_layer {
+			bail!("crate mode cannot enable the debug layer because the decoder owns its Direct3D device");
+		}
 		eprintln!("[crate] decode via moq_video::decode::Decoder, then scale its device");
 
 		let mut catalog = hang::catalog::VideoConfig::new(hang::catalog::H264 {
@@ -1059,9 +1062,9 @@ mod probe {
 		report(&device, &scaled, &gradient(0))
 	}
 
-	/// The full `moq-transcode` shape: one DXVA decoder, `RUNGS` hardware encoder
-	/// MFTs, and a scaler, all on the single device the decoded textures belong
-	/// to, all on separate threads.
+	/// The full `moq-transcode` shape: one DXVA decoder plus `RUNGS` GPU-resize and
+	/// hardware-encode paths on the decoded textures' device, all on separate
+	/// threads.
 	///
 	/// The encoders are the ingredient the other modes lack. `encode::Encoder`
 	/// binds the device of the texture it is handed, so a ladder puts one decode
@@ -1070,8 +1073,25 @@ mod probe {
 	fn mode_ladder(debug_layer: bool) -> Result<()> {
 		const RUNGS: usize = 4;
 		const PASSES: usize = 200;
-		let _ = debug_layer;
-		eprintln!("[ladder] one decoder + {RUNGS} hardware encoders + a scaler on one device");
+		const SIZES: [Size; RUNGS] = [
+			Size {
+				width: 256,
+				height: 192,
+			},
+			Size {
+				width: 224,
+				height: 168,
+			},
+			Size {
+				width: 192,
+				height: 144,
+			},
+			TARGET,
+		];
+		if debug_layer {
+			bail!("ladder mode cannot enable the debug layer because the decoder owns its Direct3D device");
+		}
+		eprintln!("[ladder] one decoder + {RUNGS} GPU-resize and hardware-encode rungs on one device");
 
 		let mut catalog = hang::catalog::VideoConfig::new(hang::catalog::H264 {
 			inline: true,
@@ -1101,13 +1121,13 @@ mod probe {
 		let stop = &AtomicBool::new(false);
 		let frames = &frames;
 		std::thread::scope(|scope| -> Result<()> {
-			for rung in 0..RUNGS {
+			for (rung, target) in SIZES.into_iter().enumerate() {
 				scope.spawn(move || {
 					let _com = match ComGuard::new() {
 						Ok(com) => com,
 						Err(e) => return eprintln!("[ladder] rung {rung} has no COM: {e}"),
 					};
-					let mut config = moq_video::encode::Config::new(SOURCE.width, SOURCE.height, 30);
+					let mut config = moq_video::encode::Config::new(target.width, target.height, 30);
 					config.kind = moq_video::encode::Kind::Named("mediafoundation".into());
 					let mut encoder = match moq_video::encode::Encoder::new(&config) {
 						Ok(encoder) => encoder,
@@ -1118,7 +1138,14 @@ mod probe {
 							if stop.load(Ordering::Relaxed) {
 								return;
 							}
-							if let Err(e) = encoder.encode(frame) {
+							let resized = match frame.resize(target) {
+								Ok(resized) => resized,
+								Err(e) => return eprintln!("[ladder] rung {rung} stopped resizing: {e}"),
+							};
+							if !matches!(&resized.surface, Surface::Texture(_)) {
+								return eprintln!("[ladder] rung {rung} resize left the GPU");
+							}
+							if let Err(e) = encoder.encode(&resized) {
 								return eprintln!("[ladder] rung {rung} stopped encoding: {e}");
 							}
 						}

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -1,10 +1,10 @@
 //! Instrumented probe for the Direct3D11 GPU-resize wedge (Windows only).
 //!
-//! Direct3D11 GPU resizing is opt-in because a `VideoProcessorBlt` scaler wedged
-//! on the device a DXVA decoder was running on. This binary is the harness for
-//! finding out which call blocks and under which ordering: it runs one scaler
-//! under several orderings and logs every Direct3D call around it, so the last
-//! line before a wedge names the call that blocked.
+//! A `VideoProcessorBlt` scaler wedged on the device a DXVA decoder was running
+//! on. GPU resizing remains the default so the failure stays visible. This
+//! binary isolates the suspected interactions under several orderings and logs
+//! every Direct3D call around them, so the last line before a wedge names the
+//! call that blocked.
 //!
 //! ```text
 //! cargo run -p moq-video --example d3d11-resize-probe -- live

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -1,0 +1,1187 @@
+//! Instrumented probe for the Direct3D11 GPU-resize wedge (Windows only).
+//!
+//! `Surface::resize` downloads a `Surface::Texture` and scales it on the CPU,
+//! once per rung, because a `VideoProcessorBlt` scaler wedged on the device a
+//! DXVA decoder was running on. This binary is the harness for finding out
+//! which call blocks and under which ordering: it runs one scaler under several
+//! orderings and logs every Direct3D call around it, so the last line before a
+//! wedge names the call that blocked.
+//!
+//! ```text
+//! cargo run -p moq-video --example d3d11-resize-probe -- live
+//! ```
+//!
+//! | Mode | Ordering |
+//! | --- | --- |
+//! | `bindflags` | Which input bind flags a video processor accepts. Not a wedge question, but the fix depends on it. |
+//! | `cold` | Scaler on a device with no decoder. The control: proves the scaler itself works. |
+//! | `warm` | Scaler built and blitted first, decoder bound to the same device after. |
+//! | `live` | Decoder bound and decoding first, scaler built after. The reported failure. |
+//! | `concurrent` | Decode loop on one thread, scaler on another, one shared device. |
+//! | `crate` | Like `live`, but through the real `decode::Decoder`, to confirm the probe's decoder matches it. |
+//! | `ladder` | One decoder, four hardware encoders, and a scaler on one device. The full `moq-transcode` shape. |
+//!
+//! Run one mode per process: a wedge leaves the device unusable, so a second
+//! mode in the same process would measure the wreckage rather than itself.
+//!
+//! Every mode passes on an NVIDIA RTX 3070 Ti (driver 32.0.15.9186), including
+//! `ladder` at 200 blits against four live encode sessions, so the wedge needs
+//! hardware, a driver, or an ingredient this does not yet reproduce. Run it on a
+//! machine that does wedge and the log names the call.
+//!
+//! `bindflags` did turn up a constraint that holds everywhere: a video processor
+//! rejects an input view over a resource whose bind flags are
+//! `D3D11_BIND_SHADER_RESOURCE` alone. It needs one of `DECODER`,
+//! `VIDEO_ENCODER`, `RENDER_TARGET`, `UNORDERED_ACCESS`, or none at all. What
+//! `frame::d3d11::bind_flags` asks for is accepted, but only because the driver
+//! granted `RENDER_TARGET` on NV12; a driver that grants only shader sampling
+//! leaves a texture that cannot be scaled by a video processor at all.
+//!
+//! The probe prints its PID on startup and a watchdog line every two seconds
+//! naming the call in flight, so a wedge is one `procdump -ma <pid>` away from
+//! a stack. Pass `--debug-layer` to add `D3D11_CREATE_DEVICE_DEBUG`, which
+//! often names the problem before the wedge does.
+//!
+//! The decode session here is a deliberately minimal reimplementation of
+//! `decode::backend::mediafoundation`. The question is which ordering of device
+//! creation, MFT binding, and scaler creation wedges, and the crate's backend
+//! creates its own device and binds the MFT to it before any caller can see it.
+//! The `crate` mode cross-checks the two against each other.
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+	eprintln!("d3d11-resize-probe only runs on Windows");
+}
+
+#[cfg(target_os = "windows")]
+fn main() -> anyhow::Result<()> {
+	probe::main()
+}
+
+#[cfg(target_os = "windows")]
+mod probe {
+	use std::ffi::c_void;
+	use std::mem::ManuallyDrop;
+	use std::ptr;
+	use std::sync::Mutex;
+	use std::sync::atomic::{AtomicBool, Ordering};
+	use std::time::{Duration, Instant};
+
+	use anyhow::{Context, Result, anyhow, bail};
+	use moq_video::windows::Win32::Foundation::{HMODULE, RECT};
+	use moq_video::windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
+	use moq_video::windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
+	use moq_video::windows::Win32::Graphics::Direct3D11::{
+		D3D11_BIND_DECODER, D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_BIND_VIDEO_ENCODER, D3D11_BOX,
+		D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_DEBUG,
+		D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_MESSAGE, D3D11_SDK_VERSION,
+		D3D11_SUBRESOURCE_DATA, D3D11_TEX2D_VPIV, D3D11_TEX2D_VPOV, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT,
+		D3D11_USAGE_STAGING, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE, D3D11_VIDEO_PROCESSOR_CONTENT_DESC,
+		D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC, D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0,
+		D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC, D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0, D3D11_VIDEO_PROCESSOR_STREAM,
+		D3D11_VIDEO_USAGE_PLAYBACK_NORMAL, D3D11_VPIV_DIMENSION_TEXTURE2D, D3D11_VPOV_DIMENSION_TEXTURE2D,
+		D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext, ID3D11InfoQueue, ID3D11Texture2D, ID3D11VideoContext,
+		ID3D11VideoDevice, ID3D11VideoProcessor, ID3D11VideoProcessorEnumerator, ID3D11VideoProcessorInputView,
+		ID3D11VideoProcessorOutputView,
+	};
+	use moq_video::windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_NV12, DXGI_RATIONAL, DXGI_SAMPLE_DESC};
+	use moq_video::windows::Win32::Media::MediaFoundation::{
+		IMFActivate, IMFDXGIBuffer, IMFDXGIDeviceManager, IMFSample, IMFTransform, MF_E_NO_MORE_TYPES,
+		MF_E_NOTACCEPTING, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE, MF_LOW_LATENCY,
+		MF_MT_FRAME_SIZE, MF_MT_MAJOR_TYPE, MF_MT_SUBTYPE, MF_VERSION, MFCreateDXGIDeviceManager, MFCreateMediaType,
+		MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video, MFSTARTUP_FULL, MFShutdown, MFStartup,
+		MFT_CATEGORY_VIDEO_DECODER, MFT_ENUM_FLAG_SORTANDFILTER, MFT_ENUM_FLAG_SYNCMFT,
+		MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER,
+		MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_NV12,
+	};
+	use moq_video::windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoTaskMemFree, CoUninitialize};
+	use moq_video::windows::core::Interface;
+	use moq_video::{Frame, I420, Size, Surface};
+
+	/// The source stream the probe decodes, and the size it scales down to.
+	const SOURCE: Size = Size {
+		width: 320,
+		height: 240,
+	};
+	const TARGET: Size = Size {
+		width: 160,
+		height: 120,
+	};
+	/// Frames to decode before the scaler runs. More than the decoder's pool has
+	/// slices, so it is recycling by the time the scaler shows up.
+	const FRAMES: u64 = 12;
+
+	// ---------------------------------------------------------------- tracing
+
+	/// The Direct3D or Media Foundation call currently in flight, and when it
+	/// started. The watchdog reads it; a wedge leaves the culprit here.
+	static IN_FLIGHT: Mutex<Option<(&'static str, Instant)>> = Mutex::new(None);
+
+	/// The debug layer's message queue, when `--debug-layer` is on. Drained after
+	/// every step, so a complaint is attributed to the call that provoked it.
+	static INFO_QUEUE: Mutex<Option<ID3D11InfoQueue>> = Mutex::new(None);
+
+	/// Run `f` as a named step, logging entry and exit. The last `-->` printed
+	/// with no matching `<--` is the call that blocked.
+	fn step<T>(name: &'static str, f: impl FnOnce() -> T) -> T {
+		eprintln!("--> {name}");
+		*IN_FLIGHT.lock().unwrap() = Some((name, Instant::now()));
+		let started = Instant::now();
+		let out = f();
+		*IN_FLIGHT.lock().unwrap() = None;
+		eprintln!("<-- {name} ({:.1?})", started.elapsed());
+		drain_info_queue();
+		out
+	}
+
+	/// Print and clear whatever the debug layer has to say. A no-op without
+	/// `--debug-layer`.
+	fn drain_info_queue() {
+		let guard = INFO_QUEUE.lock().unwrap();
+		let Some(queue) = guard.as_ref() else { return };
+
+		for index in 0..unsafe { queue.GetNumStoredMessages() } {
+			// Two passes: the first sizes the message, the second fills it in.
+			let mut len = 0usize;
+			if unsafe { queue.GetMessage(index, None, &mut len) }.is_err() || len == 0 {
+				continue;
+			}
+			let mut buffer = vec![0u8; len];
+			let message = buffer.as_mut_ptr().cast::<D3D11_MESSAGE>();
+			if unsafe { queue.GetMessage(index, Some(message), &mut len) }.is_err() {
+				continue;
+			}
+			// SAFETY: the queue just filled `buffer` with a D3D11_MESSAGE whose
+			// description points into the same allocation.
+			let message = unsafe { &*message };
+			let text = unsafe {
+				std::slice::from_raw_parts(
+					message.pDescription.cast::<u8>(),
+					message.DescriptionByteLength.saturating_sub(1),
+				)
+			};
+			eprintln!("    [d3d11] {}", String::from_utf8_lossy(text));
+		}
+		unsafe { queue.ClearStoredMessages() };
+	}
+
+	/// Report the in-flight call every two seconds, so a wedged run says what it
+	/// is wedged on without a debugger attached.
+	fn watchdog() {
+		std::thread::spawn(|| {
+			loop {
+				std::thread::sleep(Duration::from_secs(2));
+				if let Some((name, since)) = *IN_FLIGHT.lock().unwrap() {
+					eprintln!("[watchdog] blocked {:.0?} in {name}", since.elapsed());
+				}
+			}
+		});
+	}
+
+	// ------------------------------------------------------------------ setup
+
+	/// COM (MTA) plus Media Foundation for this thread, undone on drop.
+	struct ComGuard;
+
+	impl ComGuard {
+		fn new() -> Result<Self> {
+			unsafe {
+				CoInitializeEx(None, COINIT_MULTITHREADED)
+					.ok()
+					.context("CoInitializeEx")?;
+				MFStartup(MF_VERSION, MFSTARTUP_FULL).context("MFStartup")?;
+			}
+			Ok(Self)
+		}
+	}
+
+	impl Drop for ComGuard {
+		fn drop(&mut self) {
+			unsafe {
+				let _ = MFShutdown();
+				CoUninitialize();
+			}
+		}
+	}
+
+	/// A hardware Direct3D11 device shaped exactly like `frame::d3d11::create_device`:
+	/// video support on, multithread protection on.
+	fn create_device(mut debug_layer: bool) -> Result<ID3D11Device> {
+		let mut flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT;
+		if debug_layer {
+			flags |= D3D11_CREATE_DEVICE_DEBUG;
+		}
+
+		let create = |flags| {
+			let mut device: Option<ID3D11Device> = None;
+			step("D3D11CreateDevice", || unsafe {
+				D3D11CreateDevice(
+					None,
+					D3D_DRIVER_TYPE_HARDWARE,
+					HMODULE::default(),
+					flags,
+					None,
+					D3D11_SDK_VERSION,
+					Some(&mut device),
+					None,
+					None,
+				)
+			})
+			.map(|()| device)
+		};
+
+		let device = match create(flags) {
+			Ok(device) => device,
+			// The debug layer needs the Graphics Tools optional feature; without
+			// it the flag is the only reason this failed, so say so and go on.
+			Err(e) if debug_layer => {
+				eprintln!("debug layer unavailable ({e}); retrying without it");
+				*INFO_QUEUE.lock().unwrap() = None;
+				debug_layer = false;
+				create(flags & !D3D11_CREATE_DEVICE_DEBUG).context("D3D11CreateDevice")?
+			}
+			Err(e) => return Err(e).context("D3D11CreateDevice"),
+		};
+		let device = device.ok_or_else(|| anyhow!("D3D11CreateDevice returned null"))?;
+
+		let multithread = device.cast::<ID3D10Multithread>().context("query ID3D10Multithread")?;
+		unsafe {
+			let _ = multithread.SetMultithreadProtected(true);
+		}
+
+		if debug_layer {
+			match device.cast::<ID3D11InfoQueue>() {
+				Ok(queue) => *INFO_QUEUE.lock().unwrap() = Some(queue),
+				Err(e) => eprintln!("no ID3D11InfoQueue ({e}); debug-layer messages will not be printed"),
+			}
+		}
+		Ok(device)
+	}
+
+	// ----------------------------------------------------------------- scaler
+
+	/// A `VideoProcessorBlt` scaler: the thing that wedges. Every call it makes
+	/// is a named step, so the log pins which one blocked.
+	struct Scaler {
+		context: ID3D11VideoContext,
+		enumerator: ID3D11VideoProcessorEnumerator,
+		processor: ID3D11VideoProcessor,
+		device: ID3D11VideoDevice,
+	}
+
+	impl Scaler {
+		fn new(device: &ID3D11Device, src: Size, dst: Size) -> Result<Self> {
+			let video_device = step("QI ID3D11VideoDevice", || device.cast::<ID3D11VideoDevice>())
+				.context("device is not an ID3D11VideoDevice")?;
+			let immediate = step("GetImmediateContext", || unsafe { device.GetImmediateContext() })
+				.context("GetImmediateContext")?;
+			let video_context = step("QI ID3D11VideoContext", || immediate.cast::<ID3D11VideoContext>())
+				.context("context is not an ID3D11VideoContext")?;
+
+			let desc = D3D11_VIDEO_PROCESSOR_CONTENT_DESC {
+				InputFrameFormat: D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE,
+				InputFrameRate: DXGI_RATIONAL {
+					Numerator: 30,
+					Denominator: 1,
+				},
+				InputWidth: src.width,
+				InputHeight: src.height,
+				OutputFrameRate: DXGI_RATIONAL {
+					Numerator: 30,
+					Denominator: 1,
+				},
+				OutputWidth: dst.width,
+				OutputHeight: dst.height,
+				Usage: D3D11_VIDEO_USAGE_PLAYBACK_NORMAL,
+			};
+
+			let enumerator = step("CreateVideoProcessorEnumerator", || unsafe {
+				video_device.CreateVideoProcessorEnumerator(&desc)
+			})
+			.context("CreateVideoProcessorEnumerator")?;
+
+			let processor = step("CreateVideoProcessor", || unsafe {
+				video_device.CreateVideoProcessor(&enumerator, 0)
+			})
+			.context("CreateVideoProcessor")?;
+
+			step("VideoProcessorSetStreamFrameFormat", || unsafe {
+				video_context.VideoProcessorSetStreamFrameFormat(&processor, 0, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE);
+			});
+
+			Ok(Self {
+				context: video_context,
+				enumerator,
+				processor,
+				device: video_device,
+			})
+		}
+
+		/// A video-processor input view over `texture`. Split out because which
+		/// textures this accepts is a question on its own; see `mode_bindflags`.
+		fn input_view(&self, texture: &ID3D11Texture2D) -> Result<ID3D11VideoProcessorInputView> {
+			let desc = D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
+				FourCC: 0,
+				ViewDimension: D3D11_VPIV_DIMENSION_TEXTURE2D,
+				Anonymous: D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
+					Texture2D: D3D11_TEX2D_VPIV {
+						MipSlice: 0,
+						ArraySlice: 0,
+					},
+				},
+			};
+			let mut view: Option<ID3D11VideoProcessorInputView> = None;
+			step("CreateVideoProcessorInputView", || unsafe {
+				self.device
+					.CreateVideoProcessorInputView(texture, &self.enumerator, &desc, Some(&mut view))
+			})
+			.context("CreateVideoProcessorInputView")?;
+			view.ok_or_else(|| anyhow!("input view is null"))
+		}
+
+		/// A video-processor output view over `texture`.
+		fn output_view(&self, texture: &ID3D11Texture2D) -> Result<ID3D11VideoProcessorOutputView> {
+			let desc = D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
+				ViewDimension: D3D11_VPOV_DIMENSION_TEXTURE2D,
+				Anonymous: D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
+					Texture2D: D3D11_TEX2D_VPOV { MipSlice: 0 },
+				},
+			};
+			let mut view: Option<ID3D11VideoProcessorOutputView> = None;
+			step("CreateVideoProcessorOutputView", || unsafe {
+				self.device
+					.CreateVideoProcessorOutputView(texture, &self.enumerator, &desc, Some(&mut view))
+			})
+			.context("CreateVideoProcessorOutputView")?;
+			view.ok_or_else(|| anyhow!("output view is null"))
+		}
+
+		/// Scale `src` into a freshly allocated `dst`-sized NV12 texture.
+		fn scale(
+			&self,
+			device: &ID3D11Device,
+			src: &ID3D11Texture2D,
+			src_size: Size,
+			dst: Size,
+		) -> Result<ID3D11Texture2D> {
+			let output = alloc_nv12(device, dst, D3D11_BIND_RENDER_TARGET.0 as u32)?;
+			let input_view = self.input_view(src)?;
+			let output_view = self.output_view(&output)?;
+
+			// Whole source into the whole destination: the scale itself.
+			let source_rect = RECT {
+				left: 0,
+				top: 0,
+				right: src_size.width as i32,
+				bottom: src_size.height as i32,
+			};
+			let dest_rect = RECT {
+				left: 0,
+				top: 0,
+				right: dst.width as i32,
+				bottom: dst.height as i32,
+			};
+			step("VideoProcessorSetStreamSourceRect", || unsafe {
+				self.context
+					.VideoProcessorSetStreamSourceRect(&self.processor, 0, true, Some(&source_rect));
+			});
+			step("VideoProcessorSetStreamDestRect", || unsafe {
+				self.context
+					.VideoProcessorSetStreamDestRect(&self.processor, 0, true, Some(&dest_rect));
+			});
+
+			let streams = [D3D11_VIDEO_PROCESSOR_STREAM {
+				Enable: true.into(),
+				OutputIndex: 0,
+				InputFrameOrField: 0,
+				PastFrames: 0,
+				FutureFrames: 0,
+				ppPastSurfaces: ptr::null_mut(),
+				pInputSurface: ManuallyDrop::new(Some(input_view)),
+				ppFutureSurfaces: ptr::null_mut(),
+				ppPastSurfacesRight: ptr::null_mut(),
+				pInputSurfaceRight: ManuallyDrop::new(None),
+				ppFutureSurfacesRight: ptr::null_mut(),
+			}];
+
+			let result = step("VideoProcessorBlt", || unsafe {
+				self.context
+					.VideoProcessorBlt(&self.processor, &output_view, 0, &streams)
+			});
+			// The stream borrowed the view; drop it by hand since the struct can't.
+			let mut streams = streams;
+			let _ = ManuallyDrop::into_inner(unsafe { ptr::read(&streams[0].pInputSurface) });
+			unsafe { ptr::write(&mut streams[0].pInputSurface, ManuallyDrop::new(None)) };
+			result.context("VideoProcessorBlt")?;
+
+			// The wedge has been reported at the Blt, which is asynchronous: a
+			// flush is where a queued command actually lands, so it is a candidate
+			// too and gets its own step.
+			let immediate = unsafe { device.GetImmediateContext() }.context("GetImmediateContext")?;
+			step("Flush", || unsafe { immediate.Flush() });
+
+			Ok(output)
+		}
+	}
+
+	// --------------------------------------------------------------- textures
+
+	/// A plain NV12 texture bound for exactly `bind`.
+	///
+	/// Exactly, not "at least": a video processor rejects an input view over a
+	/// resource carrying `D3D11_BIND_SHADER_RESOURCE`, so the flags a texture is
+	/// allocated with decide whether it can be scaled at all.
+	fn alloc_nv12(device: &ID3D11Device, size: Size, bind: u32) -> Result<ID3D11Texture2D> {
+		let desc = D3D11_TEXTURE2D_DESC {
+			Width: size.width,
+			Height: size.height,
+			MipLevels: 1,
+			ArraySize: 1,
+			Format: DXGI_FORMAT_NV12,
+			SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+			Usage: D3D11_USAGE_DEFAULT,
+			BindFlags: bind,
+			CPUAccessFlags: 0,
+			MiscFlags: 0,
+		};
+		let mut texture: Option<ID3D11Texture2D> = None;
+		unsafe {
+			device
+				.CreateTexture2D(&desc, None, Some(&mut texture))
+				.context("CreateTexture2D")?;
+		}
+		texture.ok_or_else(|| anyhow!("CreateTexture2D returned null"))
+	}
+
+	/// Upload packed I420 as an NV12 texture with exactly `bind`, for the modes
+	/// that need a picture without a decoder having produced one.
+	fn upload_nv12(device: &ID3D11Device, i420: &I420, bind: u32) -> Result<ID3D11Texture2D> {
+		let size = Size::new(i420.width(), i420.height());
+		let (w, h) = (size.width as usize, size.height as usize);
+		let (cw, ch) = (w / 2, h / 2);
+
+		let mut nv12 = vec![0u8; w * h * 3 / 2];
+		nv12[..w * h].copy_from_slice(i420.y());
+		let (u, v) = (i420.u(), i420.v());
+		for row in 0..ch {
+			for col in 0..cw {
+				nv12[w * h + row * w + col * 2] = u[row * cw + col];
+				nv12[w * h + row * w + col * 2 + 1] = v[row * cw + col];
+			}
+		}
+
+		let desc = D3D11_TEXTURE2D_DESC {
+			Width: size.width,
+			Height: size.height,
+			MipLevels: 1,
+			ArraySize: 1,
+			Format: DXGI_FORMAT_NV12,
+			SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+			Usage: D3D11_USAGE_DEFAULT,
+			BindFlags: bind,
+			CPUAccessFlags: 0,
+			MiscFlags: 0,
+		};
+		let initial = D3D11_SUBRESOURCE_DATA {
+			pSysMem: nv12.as_ptr().cast::<c_void>(),
+			SysMemPitch: size.width,
+			SysMemSlicePitch: 0,
+		};
+		let mut texture: Option<ID3D11Texture2D> = None;
+		unsafe {
+			device
+				.CreateTexture2D(&desc, Some(&initial), Some(&mut texture))
+				.context("CreateTexture2D (upload)")?;
+		}
+		texture.ok_or_else(|| anyhow!("CreateTexture2D returned null"))
+	}
+
+	/// Download an NV12 texture to packed I420, so a scaled result can be checked
+	/// against a CPU resize of the same picture.
+	fn download_i420(device: &ID3D11Device, texture: &ID3D11Texture2D, size: Size) -> Result<I420> {
+		let context = unsafe { device.GetImmediateContext() }.context("GetImmediateContext")?;
+
+		let mut desc = D3D11_TEXTURE2D_DESC::default();
+		unsafe { texture.GetDesc(&mut desc) };
+		let tex_height = desc.Height as usize;
+		desc.ArraySize = 1;
+		desc.MipLevels = 1;
+		desc.Usage = D3D11_USAGE_STAGING;
+		desc.BindFlags = 0;
+		desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ.0 as u32;
+		desc.MiscFlags = 0;
+
+		let mut staging: Option<ID3D11Texture2D> = None;
+		unsafe {
+			device
+				.CreateTexture2D(&desc, None, Some(&mut staging))
+				.context("CreateTexture2D (staging)")?;
+		}
+		let staging = staging.ok_or_else(|| anyhow!("staging texture is null"))?;
+
+		unsafe { context.CopySubresourceRegion(&staging, 0, 0, 0, 0, texture, 0, None) };
+
+		let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+		step("Map (staging)", || unsafe {
+			context.Map(&staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
+		})
+		.context("Map")?;
+		let _guard = UnmapGuard {
+			context: &context,
+			resource: &staging,
+		};
+
+		let (w, h) = (size.width as usize, size.height as usize);
+		let (cw, ch) = (w / 2, h / 2);
+		let pitch = mapped.RowPitch as usize;
+		let base = mapped.pData as *const u8;
+
+		let mut data = vec![0u8; I420::len(size.width, size.height)];
+		let (luma, chroma) = data.split_at_mut(w * h);
+		let (u_plane, v_plane) = chroma.split_at_mut(cw * ch);
+		for row in 0..h {
+			unsafe { ptr::copy_nonoverlapping(base.add(row * pitch), luma[row * w..].as_mut_ptr(), w) };
+		}
+		let uv = unsafe { base.add(pitch * tex_height) };
+		for row in 0..ch {
+			let src = unsafe { uv.add(row * pitch) };
+			for col in 0..cw {
+				unsafe {
+					u_plane[row * cw + col] = *src.add(col * 2);
+					v_plane[row * cw + col] = *src.add(col * 2 + 1);
+				}
+			}
+		}
+
+		I420::new(size.width, size.height, data).context("I420::new")
+	}
+
+	struct UnmapGuard<'a> {
+		context: &'a ID3D11DeviceContext,
+		resource: &'a ID3D11Texture2D,
+	}
+
+	impl Drop for UnmapGuard<'_> {
+		fn drop(&mut self) {
+			unsafe { self.context.Unmap(self.resource, 0) };
+		}
+	}
+
+	// ------------------------------------------------------------ mft decoder
+
+	/// A minimal DXVA H.264 decode session on a device the caller owns, so the
+	/// probe controls when the MFT binds relative to the scaler.
+	struct Decoder {
+		transform: IMFTransform,
+		device: ID3D11Device,
+		size: Size,
+		configured: bool,
+		provides_samples: bool,
+		index: i64,
+		_manager: IMFDXGIDeviceManager,
+	}
+
+	// Touched from one thread at a time; `concurrent` moves the whole session to
+	// its decode thread rather than sharing it.
+	unsafe impl Send for Decoder {}
+
+	impl Decoder {
+		/// Bind a hardware H.264 decoder MFT to `device`.
+		fn open(device: &ID3D11Device) -> Result<Self> {
+			let transform = step("MFTEnumEx + ActivateObject", enumerate_decoder)?;
+
+			let mut token = 0u32;
+			let mut manager: Option<IMFDXGIDeviceManager> = None;
+			unsafe {
+				MFCreateDXGIDeviceManager(&mut token, &mut manager).context("MFCreateDXGIDeviceManager")?;
+			}
+			let manager = manager.ok_or_else(|| anyhow!("MFCreateDXGIDeviceManager returned null"))?;
+			step("IMFDXGIDeviceManager::ResetDevice", || unsafe {
+				manager.ResetDevice(device, token)
+			})
+			.context("ResetDevice")?;
+
+			step("MFT_MESSAGE_SET_D3D_MANAGER", || unsafe {
+				transform.ProcessMessage(MFT_MESSAGE_SET_D3D_MANAGER, manager.as_raw() as usize)
+			})
+			.context("set D3D manager")?;
+
+			let attrs = unsafe { transform.GetAttributes() }.context("MFT GetAttributes")?;
+			unsafe {
+				let _ = attrs.SetUINT32(&MF_LOW_LATENCY, 1);
+			}
+
+			let media = unsafe { MFCreateMediaType() }.context("MFCreateMediaType")?;
+			unsafe {
+				media
+					.SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Video)
+					.context("major type")?;
+				media.SetGUID(&MF_MT_SUBTYPE, &MFVideoFormat_H264).context("subtype")?;
+				transform.SetInputType(0, &media, 0).context("SetInputType")?;
+				transform
+					.ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0)
+					.context("begin streaming")?;
+			}
+
+			Ok(Self {
+				transform,
+				device: device.clone(),
+				size: Size::new(0, 0),
+				configured: false,
+				provides_samples: false,
+				index: 0,
+				_manager: manager,
+			})
+		}
+
+		/// Feed one Annex-B access unit, returning a texture per decoded picture.
+		fn decode(&mut self, access_unit: &[u8]) -> Result<Vec<ID3D11Texture2D>> {
+			let sample = self.build_sample(access_unit)?;
+			let mut out = Vec::new();
+
+			loop {
+				match unsafe { self.transform.ProcessInput(0, &sample, 0) } {
+					Ok(()) => break,
+					Err(e) if e.code() == MF_E_NOTACCEPTING => {
+						if !self.drain(&mut out)? {
+							bail!("decoder rejected the access unit with no output to drain");
+						}
+					}
+					Err(e) => return Err(anyhow!("ProcessInput: {e}")),
+				}
+			}
+			self.index += 1;
+
+			if !self.configured {
+				self.configure_output()?;
+			}
+			self.drain(&mut out)?;
+			Ok(out)
+		}
+
+		fn build_sample(&self, access_unit: &[u8]) -> Result<IMFSample> {
+			let buffer = unsafe { MFCreateMemoryBuffer(access_unit.len() as u32) }.context("MFCreateMemoryBuffer")?;
+			let mut dst: *mut u8 = ptr::null_mut();
+			unsafe { buffer.Lock(&mut dst, None, None) }.context("lock input buffer")?;
+			unsafe { std::slice::from_raw_parts_mut(dst, access_unit.len()) }.copy_from_slice(access_unit);
+			unsafe {
+				let _ = buffer.Unlock();
+				buffer
+					.SetCurrentLength(access_unit.len() as u32)
+					.context("SetCurrentLength")?;
+			}
+
+			let sample = unsafe { MFCreateSample() }.context("MFCreateSample")?;
+			// 30fps ticks in Media Foundation's 100ns units: the decoder only needs
+			// them to increase.
+			let tick = 10_000_000 / 30;
+			unsafe {
+				sample.AddBuffer(&buffer).context("AddBuffer")?;
+				sample.SetSampleTime(self.index * tick).context("SetSampleTime")?;
+				sample.SetSampleDuration(tick).context("SetSampleDuration")?;
+			}
+			Ok(sample)
+		}
+
+		fn configure_output(&mut self) -> Result<()> {
+			let mut index = 0;
+			loop {
+				let media = match unsafe { self.transform.GetOutputAvailableType(0, index) } {
+					Ok(media) => media,
+					Err(e) if e.code() == MF_E_NO_MORE_TYPES => bail!("decoder offers no NV12 output type"),
+					Err(e) => return Err(anyhow!("GetOutputAvailableType: {e}")),
+				};
+				let subtype = unsafe { media.GetGUID(&MF_MT_SUBTYPE) }.context("output subtype")?;
+				if subtype == MFVideoFormat_NV12 {
+					unsafe { self.transform.SetOutputType(0, &media, 0) }.context("SetOutputType")?;
+					let packed = unsafe { media.GetUINT64(&MF_MT_FRAME_SIZE) }.context("frame size")?;
+					self.size = Size::new((packed >> 32) as u32, packed as u32);
+					let info = unsafe { self.transform.GetOutputStreamInfo(0) }.context("GetOutputStreamInfo")?;
+					self.provides_samples = info.dwFlags & MFT_OUTPUT_STREAM_PROVIDES_SAMPLES.0 as u32 != 0;
+					if !self.provides_samples {
+						bail!("decoder is not DXVA-backed (no GPU textures), so there is nothing to probe");
+					}
+					self.configured = true;
+					return Ok(());
+				}
+				index += 1;
+			}
+		}
+
+		fn drain(&mut self, out: &mut Vec<ID3D11Texture2D>) -> Result<bool> {
+			if !self.configured {
+				return Ok(false);
+			}
+			let mut progressed = false;
+			while self.process_output(out)? {
+				progressed = true;
+			}
+			Ok(progressed)
+		}
+
+		fn process_output(&mut self, out: &mut Vec<ID3D11Texture2D>) -> Result<bool> {
+			let mut data = [MFT_OUTPUT_DATA_BUFFER {
+				dwStreamID: 0,
+				pSample: ManuallyDrop::new(None),
+				dwStatus: 0,
+				pEvents: ManuallyDrop::new(None),
+			}];
+			let mut status = 0u32;
+			let result = unsafe { self.transform.ProcessOutput(0, &mut data, &mut status) };
+			let sample = ManuallyDrop::into_inner(unsafe { ptr::read(&data[0].pSample) });
+			let _events = ManuallyDrop::into_inner(unsafe { ptr::read(&data[0].pEvents) });
+
+			match result {
+				Ok(()) => {
+					if let Some(sample) = sample {
+						out.push(self.copy_out(&sample)?);
+					}
+					Ok(true)
+				}
+				Err(e) if e.code() == MF_E_TRANSFORM_NEED_MORE_INPUT => Ok(false),
+				Err(e) if e.code() == MF_E_TRANSFORM_STREAM_CHANGE => {
+					self.configure_output()?;
+					Ok(true)
+				}
+				Err(e) => Err(anyhow!("ProcessOutput: {e}")),
+			}
+		}
+
+		/// Blit the picture out of the decoder's pool into a texture of ours, the
+		/// same move `Texture::copy_from_sample` makes and for the same reason.
+		fn copy_out(&self, sample: &IMFSample) -> Result<ID3D11Texture2D> {
+			let buffer = unsafe { sample.GetBufferByIndex(0) }.context("GetBufferByIndex")?;
+			let dxgi = buffer.cast::<IMFDXGIBuffer>().context("sample is not DXGI-backed")?;
+
+			let mut raw: *mut c_void = ptr::null_mut();
+			unsafe { dxgi.GetResource(&ID3D11Texture2D::IID, &mut raw) }.context("GetResource")?;
+			let source = unsafe { ID3D11Texture2D::from_raw(raw) };
+			let subresource = unsafe { dxgi.GetSubresourceIndex() }.context("GetSubresourceIndex")?;
+
+			let owned = alloc_nv12(&self.device, SOURCE, D3D11_BIND_RENDER_TARGET.0 as u32)?;
+			let region = D3D11_BOX {
+				left: 0,
+				top: 0,
+				front: 0,
+				right: SOURCE.width,
+				bottom: SOURCE.height,
+				back: 1,
+			};
+			let context = unsafe { self.device.GetImmediateContext() }.context("GetImmediateContext")?;
+			unsafe { context.CopySubresourceRegion(&owned, 0, 0, 0, 0, &source, subresource, Some(&region)) };
+			Ok(owned)
+		}
+	}
+
+	/// The first synchronous hardware H.264 decoder MFT.
+	fn enumerate_decoder() -> Result<IMFTransform> {
+		let input = MFT_REGISTER_TYPE_INFO {
+			guidMajorType: MFMediaType_Video,
+			guidSubtype: MFVideoFormat_H264,
+		};
+		let output = MFT_REGISTER_TYPE_INFO {
+			guidMajorType: MFMediaType_Video,
+			guidSubtype: MFVideoFormat_NV12,
+		};
+
+		let mut activates: *mut Option<IMFActivate> = ptr::null_mut();
+		let mut count = 0u32;
+		unsafe {
+			MFTEnumEx(
+				MFT_CATEGORY_VIDEO_DECODER,
+				MFT_ENUM_FLAG_SYNCMFT | MFT_ENUM_FLAG_SORTANDFILTER,
+				Some(&input),
+				Some(&output),
+				&mut activates,
+				&mut count,
+			)
+			.context("MFTEnumEx")?;
+		}
+		if count == 0 {
+			bail!("no H.264 decoder MFT on this machine");
+		}
+
+		let entries = unsafe { std::slice::from_raw_parts_mut(activates, count as usize) };
+		let mut transform = None;
+		for slot in entries.iter_mut() {
+			let Some(activate) = slot.take() else { continue };
+			if transform.is_none()
+				&& let Ok(mft) = unsafe { activate.ActivateObject::<IMFTransform>() }
+			{
+				transform = Some(mft);
+			}
+		}
+		unsafe { CoTaskMemFree(Some(activates as *const c_void)) };
+		transform.ok_or_else(|| anyhow!("failed to activate a decoder MFT"))
+	}
+
+	// ------------------------------------------------------------ test stream
+
+	/// `FRAMES` access units of a gradient, encoded by openh264 (Annex-B with
+	/// inline parameter sets, which is what the MFT wants).
+	fn stream() -> Result<Vec<Vec<u8>>> {
+		let mut config = moq_video::encode::Config::new(SOURCE.width, SOURCE.height, 30);
+		config.kind = moq_video::encode::Kind::Software;
+		let mut encoder = moq_video::encode::Encoder::new(&config).context("openh264 encoder")?;
+
+		let mut out = Vec::new();
+		for index in 0..FRAMES {
+			if index == 0 {
+				encoder.keyframe();
+			}
+			let frame = Frame::new(
+				Surface::I420(gradient(index)),
+				moq_net::Timestamp::from_micros(index * 33_333).unwrap(),
+			);
+			for encoded in encoder.encode(&frame).context("encode")? {
+				out.push(encoded.payload.to_vec());
+			}
+		}
+		Ok(out)
+	}
+
+	/// A gradient that shifts with the frame index, so a scaled result is checkable
+	/// and two frames are never identical.
+	fn gradient(index: u64) -> I420 {
+		let (w, h) = (SOURCE.width as usize, SOURCE.height as usize);
+		let mut data = vec![128u8; I420::len(SOURCE.width, SOURCE.height)];
+		for y in 0..h {
+			for x in 0..w {
+				data[y * w + x] = ((x * 255 / w + y * 255 / h) / 2 + index as usize * 4) as u8;
+			}
+		}
+		I420::new(SOURCE.width, SOURCE.height, data).expect("gradient")
+	}
+
+	/// Mean absolute error between two planes, the same check the CUDA and
+	/// pixel-buffer resize tests use.
+	fn mae(a: &[u8], b: &[u8]) -> u64 {
+		a.iter().zip(b).map(|(&x, &y)| x.abs_diff(y) as u64).sum::<u64>() / a.len() as u64
+	}
+
+	/// Compare a scaled texture against a CPU downscale of the same source, so a
+	/// mode that does not wedge still says whether it produced a picture.
+	fn report(device: &ID3D11Device, scaled: &ID3D11Texture2D, source: &I420) -> Result<()> {
+		let got = download_i420(device, scaled, TARGET)?;
+		let expected = Frame::new(Surface::I420(source.clone()), moq_net::Timestamp::ZERO)
+			.resize(TARGET)
+			.context("cpu resize")?
+			.surface
+			.into_i420()
+			.context("cpu resize download")?;
+		// Packed I420, so the luma plane is the leading width * height bytes.
+		let luma = (TARGET.width * TARGET.height) as usize;
+		eprintln!(
+			"    scaled {}x{} -> {}x{}, luma MAE vs the CPU resize: {}",
+			SOURCE.width,
+			SOURCE.height,
+			TARGET.width,
+			TARGET.height,
+			mae(got.y(), &expected[..luma])
+		);
+		Ok(())
+	}
+
+	// ------------------------------------------------------------------ modes
+
+	/// Which bind flags a video processor will accept as input, and whether the
+	/// combination the crate's own `bind_flags` picks is among them.
+	///
+	/// Not a deadlock question, but the fix depends on the answer: a decoded
+	/// texture that cannot be an input view has to be reallocated or re-bound
+	/// before any of this matters.
+	fn mode_bindflags(debug_layer: bool) -> Result<()> {
+		eprintln!("[bindflags] which input bind flags a video processor accepts");
+		let device = create_device(debug_layer)?;
+		let source = gradient(0);
+		let scaler = Scaler::new(&device, SOURCE, TARGET)?;
+
+		let shader = D3D11_BIND_SHADER_RESOURCE.0 as u32;
+		let target = D3D11_BIND_RENDER_TARGET.0 as u32;
+		let encoder = D3D11_BIND_VIDEO_ENCODER.0 as u32;
+		let decoder = D3D11_BIND_DECODER.0 as u32;
+		let candidates = [
+			("none", 0),
+			("SHADER_RESOURCE", shader),
+			("RENDER_TARGET", target),
+			("VIDEO_ENCODER", encoder),
+			("DECODER", decoder),
+			("SHADER_RESOURCE | RENDER_TARGET", shader | target),
+			("RENDER_TARGET | VIDEO_ENCODER", target | encoder),
+			// What frame::d3d11::bind_flags asks for today, driver permitting.
+			(
+				"SHADER_RESOURCE | RENDER_TARGET | VIDEO_ENCODER (the crate's)",
+				shader | target | encoder,
+			),
+		];
+
+		for (label, bind) in candidates {
+			let outcome =
+				upload_nv12(&device, &source, bind).and_then(|texture| scaler.input_view(&texture).map(|_| ()));
+			match outcome {
+				Ok(()) => eprintln!("    accepted: {label}"),
+				Err(e) => eprintln!("    rejected: {label} ({})", e.root_cause()),
+			}
+		}
+		Ok(())
+	}
+
+	fn mode_cold(debug_layer: bool) -> Result<()> {
+		eprintln!("[cold] scaler on a device with no decoder bound");
+		let device = create_device(debug_layer)?;
+		let source = gradient(0);
+		let texture = upload_nv12(&device, &source, D3D11_BIND_RENDER_TARGET.0 as u32)?;
+		let scaler = Scaler::new(&device, SOURCE, TARGET)?;
+		let scaled = scaler.scale(&device, &texture, SOURCE, TARGET)?;
+		report(&device, &scaled, &source)
+	}
+
+	fn mode_warm(debug_layer: bool) -> Result<()> {
+		eprintln!("[warm] scaler built and blitted before the decoder binds");
+		let device = create_device(debug_layer)?;
+		let source = gradient(0);
+		let warmup = upload_nv12(&device, &source, D3D11_BIND_RENDER_TARGET.0 as u32)?;
+		let scaler = Scaler::new(&device, SOURCE, TARGET)?;
+		scaler.scale(&device, &warmup, SOURCE, TARGET)?;
+		eprintln!("[warm] scaler is warm; binding the decoder now");
+
+		let mut decoder = Decoder::open(&device)?;
+		let decoded = decode_all(&mut decoder)?;
+		eprintln!("[warm] decoded {} frames; scaling one", decoded.len());
+		let scaled = scaler.scale(&device, &decoded[0], SOURCE, TARGET)?;
+		report(&device, &scaled, &source)
+	}
+
+	fn mode_live(debug_layer: bool) -> Result<()> {
+		eprintln!("[live] decoder bound and decoding before the scaler is built");
+		let device = create_device(debug_layer)?;
+		let mut decoder = Decoder::open(&device)?;
+		let decoded = decode_all(&mut decoder)?;
+		eprintln!("[live] decoded {} frames; building the scaler now", decoded.len());
+
+		let scaler = Scaler::new(&device, SOURCE, TARGET)?;
+		let scaled = scaler.scale(&device, &decoded[0], SOURCE, TARGET)?;
+		report(&device, &scaled, &gradient(0))
+	}
+
+	/// The `moq-transcode` shape: decode on one thread while a scaler runs on
+	/// another, both against the one device the decoder owns.
+	fn mode_concurrent(debug_layer: bool) -> Result<()> {
+		eprintln!("[concurrent] decode loop and scaler on separate threads, one device");
+		let device = create_device(debug_layer)?;
+		let mut decoder = Decoder::open(&device)?;
+		let first = decode_all(&mut decoder)?;
+
+		let stop = &AtomicBool::new(false);
+		std::thread::scope(|scope| -> Result<()> {
+			let decode_device = device.clone();
+			scope.spawn(move || {
+				// Its own COM/MF lifetime: the guard is per thread.
+				let _com = ComGuard::new().expect("decode thread COM");
+				let mut decoder = decoder;
+				let units = stream().expect("test stream");
+				while !stop.load(Ordering::Relaxed) {
+					// A fresh session per pass, so the decoder keeps hitting the
+					// device rather than idling once the stream runs out.
+					for unit in &units {
+						if stop.load(Ordering::Relaxed) {
+							break;
+						}
+						if let Err(e) = decoder.decode(unit) {
+							eprintln!("[concurrent] decode thread stopped: {e}");
+							return;
+						}
+					}
+					match Decoder::open(&decode_device) {
+						Ok(next) => decoder = next,
+						Err(e) => {
+							eprintln!("[concurrent] could not reopen the decoder: {e}");
+							return;
+						}
+					}
+				}
+			});
+
+			eprintln!("[concurrent] decode is running; building the scaler now");
+			let result = (|| -> Result<()> {
+				let scaler = Scaler::new(&device, SOURCE, TARGET)?;
+				for pass in 0..8 {
+					eprintln!("[concurrent] scale pass {pass}");
+					scaler.scale(&device, &first[0], SOURCE, TARGET)?;
+				}
+				Ok(())
+			})();
+			stop.store(true, Ordering::Relaxed);
+			result
+		})
+	}
+
+	/// The same ordering as `live`, but the pictures come from the crate's own
+	/// decoder, so the probe's minimal MFT can be checked against the real one.
+	fn mode_crate(debug_layer: bool) -> Result<()> {
+		let _ = debug_layer;
+		eprintln!("[crate] decode via moq_video::decode::Decoder, then scale its device");
+
+		let mut catalog = hang::catalog::VideoConfig::new(hang::catalog::H264 {
+			inline: true,
+			profile: 0x42,
+			constraints: 0,
+			level: 0x1f,
+		});
+		catalog.coded_width = Some(SOURCE.width);
+		catalog.coded_height = Some(SOURCE.height);
+
+		let mut config = moq_video::decode::Config::new();
+		config.kind = moq_video::decode::Kind::Named("mediafoundation".into());
+		let mut decoder = moq_video::decode::Decoder::new(&catalog, &config).context("Media Foundation decoder")?;
+
+		let mut frames = Vec::new();
+		for (index, unit) in stream()?.into_iter().enumerate() {
+			let timestamp = moq_net::Timestamp::from_micros(index as u64 * 33_333).unwrap();
+			frames.extend(decoder.decode(&unit.into(), timestamp, index == 0).context("decode")?);
+		}
+		let Some(Surface::Texture(texture)) = frames.first().map(|f| &f.surface) else {
+			bail!("the crate's decoder did not produce a GPU texture on this machine");
+		};
+		eprintln!("[crate] decoded {} frames; building the scaler now", frames.len());
+
+		let device = texture.device().clone();
+		let scaler = Scaler::new(&device, SOURCE, TARGET)?;
+		let scaled = scaler.scale(&device, texture.texture(), SOURCE, TARGET)?;
+		report(&device, &scaled, &gradient(0))
+	}
+
+	/// The full `moq-transcode` shape: one DXVA decoder, `RUNGS` hardware encoder
+	/// MFTs, and a scaler, all on the single device the decoded textures belong
+	/// to, all on separate threads.
+	///
+	/// The encoders are the ingredient the other modes lack. `encode::Encoder`
+	/// binds the device of the texture it is handed, so a ladder puts one decode
+	/// session and one encode session per rung on the same device, and every one
+	/// of them wants the GPU's video engine.
+	fn mode_ladder(debug_layer: bool) -> Result<()> {
+		const RUNGS: usize = 4;
+		const PASSES: usize = 200;
+		let _ = debug_layer;
+		eprintln!("[ladder] one decoder + {RUNGS} hardware encoders + a scaler on one device");
+
+		let mut catalog = hang::catalog::VideoConfig::new(hang::catalog::H264 {
+			inline: true,
+			profile: 0x42,
+			constraints: 0,
+			level: 0x1f,
+		});
+		catalog.coded_width = Some(SOURCE.width);
+		catalog.coded_height = Some(SOURCE.height);
+
+		let mut config = moq_video::decode::Config::new();
+		config.kind = moq_video::decode::Kind::Named("mediafoundation".into());
+		let mut decoder = moq_video::decode::Decoder::new(&catalog, &config).context("Media Foundation decoder")?;
+
+		let mut frames = Vec::new();
+		for (index, unit) in stream()?.into_iter().enumerate() {
+			let timestamp = moq_net::Timestamp::from_micros(index as u64 * 33_333).unwrap();
+			frames.extend(decoder.decode(&unit.into(), timestamp, index == 0).context("decode")?);
+		}
+		let Some(Surface::Texture(first)) = frames.first().map(|f| &f.surface) else {
+			bail!("the decoder did not produce a GPU texture on this machine");
+		};
+		let device = first.device().clone();
+		let source = first.texture().clone();
+		eprintln!("[ladder] decoded {} frames; starting the rungs", frames.len());
+
+		let stop = &AtomicBool::new(false);
+		let frames = &frames;
+		std::thread::scope(|scope| -> Result<()> {
+			for rung in 0..RUNGS {
+				scope.spawn(move || {
+					let _com = match ComGuard::new() {
+						Ok(com) => com,
+						Err(e) => return eprintln!("[ladder] rung {rung} has no COM: {e}"),
+					};
+					let mut config = moq_video::encode::Config::new(SOURCE.width, SOURCE.height, 30);
+					config.kind = moq_video::encode::Kind::Named("mediafoundation".into());
+					let mut encoder = match moq_video::encode::Encoder::new(&config) {
+						Ok(encoder) => encoder,
+						Err(e) => return eprintln!("[ladder] rung {rung} has no hardware encoder: {e}"),
+					};
+					while !stop.load(Ordering::Relaxed) {
+						for frame in frames {
+							if stop.load(Ordering::Relaxed) {
+								return;
+							}
+							if let Err(e) = encoder.encode(frame) {
+								return eprintln!("[ladder] rung {rung} stopped encoding: {e}");
+							}
+						}
+					}
+				});
+			}
+
+			// Let the encoders bind the device and get busy before the scaler
+			// shows up, so the blit lands mid-session rather than before one.
+			std::thread::sleep(Duration::from_millis(500));
+			eprintln!("[ladder] rungs are encoding; building the scaler now");
+
+			let result = (|| -> Result<()> {
+				let scaler = Scaler::new(&device, SOURCE, TARGET)?;
+				for pass in 0..PASSES {
+					if pass % 25 == 0 {
+						eprintln!("[ladder] scale pass {pass}/{PASSES}");
+					}
+					scaler.scale(&device, &source, SOURCE, TARGET)?;
+				}
+				Ok(())
+			})();
+			stop.store(true, Ordering::Relaxed);
+			result
+		})
+	}
+
+	fn decode_all(decoder: &mut Decoder) -> Result<Vec<ID3D11Texture2D>> {
+		let mut out = Vec::new();
+		for unit in stream()? {
+			out.extend(decoder.decode(&unit)?);
+		}
+		if out.is_empty() {
+			bail!("the decoder produced no frames");
+		}
+		Ok(out)
+	}
+
+	// ------------------------------------------------------------------- main
+
+	pub fn main() -> Result<()> {
+		let args: Vec<String> = std::env::args().skip(1).collect();
+		let debug_layer = args.iter().any(|a| a == "--debug-layer");
+		let mode = args.iter().find(|a| !a.starts_with("--")).cloned();
+
+		eprintln!(
+			"pid {} (attach with: procdump -ma {})",
+			std::process::id(),
+			std::process::id()
+		);
+		watchdog();
+		let _com = ComGuard::new()?;
+
+		match mode.as_deref() {
+			Some("bindflags") => mode_bindflags(debug_layer),
+			Some("cold") => mode_cold(debug_layer),
+			Some("warm") => mode_warm(debug_layer),
+			Some("live") => mode_live(debug_layer),
+			Some("concurrent") => mode_concurrent(debug_layer),
+			Some("crate") => mode_crate(debug_layer),
+			Some("ladder") => mode_ladder(debug_layer),
+			other => {
+				if let Some(other) = other {
+					eprintln!("unknown mode: {other}");
+				}
+				eprintln!(
+					"usage: d3d11-resize-probe <bindflags|cold|warm|live|concurrent|crate|ladder> [--debug-layer]"
+				);
+				eprintln!("run one mode per process; a wedge leaves the device unusable");
+				std::process::exit(2);
+			}
+		}
+	}
+}

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -18,15 +18,15 @@
 //! | `live` | Decoder bound and decoding first, scaler built after. The reported failure. |
 //! | `concurrent` | Decode loop on one thread, scaler on another, one shared device. |
 //! | `crate` | Like `live`, but through the real `decode::Decoder`, to confirm the probe's decoder matches it. |
-//! | `ladder` | One decoder and four GPU-resize plus hardware-encode rungs on one device. The full `moq-transcode` shape. |
+//! | `ladder` | One live decoder and four GPU-resize plus hardware-encode rungs on one device. The full `moq-transcode` shape. |
 //!
 //! Run one mode per process: a wedge leaves the device unusable, so a second
 //! mode in the same process would measure the wreckage rather than itself.
 //!
-//! Every mode passes on an NVIDIA RTX 3070 Ti (driver 32.0.15.9186), including
-//! `ladder` at 200 blits against four live encode sessions, so the wedge needs
-//! hardware, a driver, or an ingredient this does not yet reproduce. Run it on a
-//! machine that does wedge and the log names the call.
+//! The modes through `crate` pass on an NVIDIA RTX 3070 Ti (driver
+//! 32.0.15.9186). The production-shaped live `ladder` overlap still needs a
+//! native Windows run. Run it on a machine that wedges and the log names the
+//! call.
 //!
 //! `bindflags` did turn up a constraint that holds everywhere: a video processor
 //! rejects an input view over a resource whose bind flags are
@@ -64,7 +64,7 @@ mod probe {
 	use std::mem::{ManuallyDrop, size_of};
 	use std::ptr;
 	use std::sync::atomic::{AtomicBool, Ordering};
-	use std::sync::{LazyLock, Mutex};
+	use std::sync::{Barrier, LazyLock, Mutex};
 	use std::time::{Duration, Instant};
 
 	use anyhow::{Context, Result, anyhow, bail};
@@ -1070,7 +1070,8 @@ mod probe {
 	/// of them wants the GPU's video engine.
 	fn mode_ladder(debug_layer: bool) -> Result<()> {
 		const RUNGS: usize = 4;
-		const PASSES: usize = 200;
+		const SCALE_PASSES: usize = 200;
+		const DECODE_PASSES: usize = 16;
 		const SIZES: [Size; RUNGS] = [
 			Size {
 				width: 256,
@@ -1104,17 +1105,26 @@ mod probe {
 		config.kind = moq_video::decode::Kind::Named("mediafoundation".into());
 		let mut decoder = moq_video::decode::Decoder::new(&catalog, &config).context("Media Foundation decoder")?;
 
+		let units = stream()?;
 		let mut frames = Vec::new();
-		for (index, unit) in stream()?.into_iter().enumerate() {
+		for (index, unit) in units.iter().enumerate() {
 			let timestamp = moq_net::Timestamp::from_micros(index as u64 * 33_333).unwrap();
-			frames.extend(decoder.decode(&unit.into(), timestamp, index == 0).context("decode")?);
+			frames.extend(
+				decoder
+					.decode(&unit.clone().into(), timestamp, index == 0)
+					.context("decode")?,
+			);
 		}
-		let Some(Surface::Texture(first)) = frames.first().map(|f| &f.surface) else {
+		let Some(first) = frames.into_iter().next() else {
+			bail!("the decoder did not produce a frame on this machine");
+		};
+		let Surface::Texture(texture) = &first.surface else {
 			bail!("the decoder did not produce a GPU texture on this machine");
 		};
-		let device = first.device().clone();
-		let source = first.texture().clone();
-		eprintln!("[ladder] decoded {} frames; starting the rungs", frames.len());
+		let device = texture.device().clone();
+		let source = texture.texture().clone();
+		let frames = [first];
+		eprintln!("[ladder] primed the decoder; starting live decode and the rungs");
 
 		let stop = &AtomicBool::new(false);
 		let frames = &frames;
@@ -1147,26 +1157,53 @@ mod probe {
 				}));
 			}
 
-			// Let the encoders bind the device and get busy before the scaler
-			// shows up, so the blit lands mid-session rather than before one.
-			std::thread::sleep(Duration::from_millis(500));
-			eprintln!("[ladder] rungs are encoding; building the scaler now");
-
-			let result = (|| -> Result<()> {
-				let scaler = Scaler::new(&device, SOURCE, TARGET)?;
-				for pass in 0..PASSES {
+			let start = &Barrier::new(2);
+			let scale_device = device.clone();
+			let scale_source = source.clone();
+			let scale_worker = scope.spawn(move || -> Result<()> {
+				let _com = ComGuard::new().context("ladder scaler COM")?;
+				start.wait();
+				eprintln!("[ladder] live decode is running; building the instrumented scaler now");
+				let scaler = Scaler::new(&scale_device, SOURCE, TARGET)?;
+				for pass in 0..SCALE_PASSES {
 					if pass % 25 == 0 {
-						eprintln!("[ladder] scale pass {pass}/{PASSES}");
+						eprintln!("[ladder] scale pass {pass}/{SCALE_PASSES}");
 					}
-					scaler.scale(&device, &source, SOURCE, TARGET)?;
+					scaler.scale(&scale_device, &scale_source, SOURCE, TARGET)?;
+				}
+				Ok(())
+			});
+
+			// Let the encoders bind the device and get busy, then release live
+			// decode and the instrumented scaler together.
+			std::thread::sleep(Duration::from_millis(500));
+			eprintln!("[ladder] rungs are encoding; starting live decode and scaler");
+			start.wait();
+			let decode_result = (|| -> Result<()> {
+				let mut timestamp_index = units.len() as u64;
+				for pass in 0..DECODE_PASSES {
+					if pass % 4 == 0 {
+						eprintln!("[ladder] decode pass {pass}/{DECODE_PASSES}");
+					}
+					for (index, unit) in units.iter().enumerate() {
+						let timestamp = moq_net::Timestamp::from_micros(timestamp_index * 33_333).unwrap();
+						decoder
+							.decode(&unit.clone().into(), timestamp, index == 0)
+							.context("live ladder decode")?;
+						timestamp_index += 1;
+					}
 				}
 				Ok(())
 			})();
 			stop.store(true, Ordering::Relaxed);
+			let scale_result = scale_worker
+				.join()
+				.map_err(|_| anyhow!("ladder scaler thread panicked"))?;
 			for worker in workers {
 				worker.join().map_err(|_| anyhow!("ladder rung thread panicked"))??;
 			}
-			result
+			decode_result?;
+			scale_result
 		})
 	}
 

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -1,11 +1,10 @@
 //! Instrumented probe for the Direct3D11 GPU-resize wedge (Windows only).
 //!
-//! `Surface::resize` downloads a `Surface::Texture` and scales it on the CPU,
-//! once per rung, because a `VideoProcessorBlt` scaler wedged on the device a
-//! DXVA decoder was running on. This binary is the harness for finding out
-//! which call blocks and under which ordering: it runs one scaler under several
-//! orderings and logs every Direct3D call around it, so the last line before a
-//! wedge names the call that blocked.
+//! Direct3D11 GPU resizing is opt-in because a `VideoProcessorBlt` scaler wedged
+//! on the device a DXVA decoder was running on. This binary is the harness for
+//! finding out which call blocks and under which ordering: it runs one scaler
+//! under several orderings and logs every Direct3D call around it, so the last
+//! line before a wedge names the call that blocked.
 //!
 //! ```text
 //! cargo run -p moq-video --example d3d11-resize-probe -- live

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -984,11 +984,11 @@ mod probe {
 		let stop = &AtomicBool::new(false);
 		std::thread::scope(|scope| -> Result<()> {
 			let decode_device = device.clone();
-			scope.spawn(move || {
+			let worker = scope.spawn(move || -> Result<()> {
 				// Its own COM/MF lifetime: the guard is per thread.
-				let _com = ComGuard::new().expect("decode thread COM");
+				let _com = ComGuard::new().context("decode thread COM")?;
 				let mut decoder = decoder;
-				let units = stream().expect("test stream");
+				let units = stream().context("decode thread test stream")?;
 				while !stop.load(Ordering::Relaxed) {
 					// A fresh session per pass, so the decoder keeps hitting the
 					// device rather than idling once the stream runs out.
@@ -996,19 +996,11 @@ mod probe {
 						if stop.load(Ordering::Relaxed) {
 							break;
 						}
-						if let Err(e) = decoder.decode(unit) {
-							eprintln!("[concurrent] decode thread stopped: {e}");
-							return;
-						}
+						decoder.decode(unit).context("concurrent decode")?;
 					}
-					match Decoder::open(&decode_device) {
-						Ok(next) => decoder = next,
-						Err(e) => {
-							eprintln!("[concurrent] could not reopen the decoder: {e}");
-							return;
-						}
-					}
+					decoder = Decoder::open(&decode_device).context("reopen concurrent decoder")?;
 				}
+				Ok(())
 			});
 
 			eprintln!("[concurrent] decode is running; building the scaler now");
@@ -1021,7 +1013,11 @@ mod probe {
 				Ok(())
 			})();
 			stop.store(true, Ordering::Relaxed);
-			result
+			let decode_result = worker
+				.join()
+				.map_err(|_| anyhow!("concurrent decode thread panicked"))?;
+			result?;
+			decode_result
 		})
 	}
 

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -63,8 +63,8 @@ mod probe {
 	use std::ffi::c_void;
 	use std::mem::{ManuallyDrop, size_of};
 	use std::ptr;
-	use std::sync::Mutex;
 	use std::sync::atomic::{AtomicBool, Ordering};
+	use std::sync::{LazyLock, Mutex};
 	use std::time::{Duration, Instant};
 
 	use anyhow::{Context, Result, anyhow, bail};
@@ -114,9 +114,10 @@ mod probe {
 
 	// ---------------------------------------------------------------- tracing
 
-	/// The Direct3D or Media Foundation call currently in flight, and when it
-	/// started. The watchdog reads it; a wedge leaves the culprit here.
-	static IN_FLIGHT: Mutex<Option<(&'static str, Instant)>> = Mutex::new(None);
+	/// The Direct3D or Media Foundation calls currently in flight, keyed by
+	/// thread. The watchdog reads them; a wedge leaves every culprit here.
+	static IN_FLIGHT: LazyLock<Mutex<std::collections::HashMap<std::thread::ThreadId, (&'static str, Instant)>>> =
+		LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 
 	/// The debug layer's message queue, when `--debug-layer` is on. Drained after
 	/// every step, so a complaint is attributed to the call that provoked it.
@@ -126,10 +127,11 @@ mod probe {
 	/// with no matching `<--` is the call that blocked.
 	fn step<T>(name: &'static str, f: impl FnOnce() -> T) -> T {
 		eprintln!("--> {name}");
-		*IN_FLIGHT.lock().unwrap() = Some((name, Instant::now()));
+		let thread = std::thread::current().id();
+		IN_FLIGHT.lock().unwrap().insert(thread, (name, Instant::now()));
 		let started = Instant::now();
 		let out = f();
-		*IN_FLIGHT.lock().unwrap() = None;
+		IN_FLIGHT.lock().unwrap().remove(&thread);
 		eprintln!("<-- {name} ({:.1?})", started.elapsed());
 		drain_info_queue();
 		out
@@ -174,8 +176,8 @@ mod probe {
 		std::thread::spawn(|| {
 			loop {
 				std::thread::sleep(Duration::from_secs(2));
-				if let Some((name, since)) = *IN_FLIGHT.lock().unwrap() {
-					eprintln!("[watchdog] blocked {:.0?} in {name}", since.elapsed());
+				for (thread, (name, since)) in IN_FLIGHT.lock().unwrap().iter() {
+					eprintln!("[watchdog] thread {thread:?} blocked {:.0?} in {name}", since.elapsed());
 				}
 			}
 		});

--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -1121,36 +1121,32 @@ mod probe {
 		let stop = &AtomicBool::new(false);
 		let frames = &frames;
 		std::thread::scope(|scope| -> Result<()> {
+			let mut workers = Vec::with_capacity(RUNGS);
 			for (rung, target) in SIZES.into_iter().enumerate() {
-				scope.spawn(move || {
-					let _com = match ComGuard::new() {
-						Ok(com) => com,
-						Err(e) => return eprintln!("[ladder] rung {rung} has no COM: {e}"),
-					};
+				workers.push(scope.spawn(move || -> Result<()> {
+					let _com = ComGuard::new().with_context(|| format!("ladder rung {rung} COM"))?;
 					let mut config = moq_video::encode::Config::new(target.width, target.height, 30);
 					config.kind = moq_video::encode::Kind::Named("mediafoundation".into());
-					let mut encoder = match moq_video::encode::Encoder::new(&config) {
-						Ok(encoder) => encoder,
-						Err(e) => return eprintln!("[ladder] rung {rung} has no hardware encoder: {e}"),
-					};
+					let mut encoder = moq_video::encode::Encoder::new(&config)
+						.with_context(|| format!("ladder rung {rung} hardware encoder"))?;
 					while !stop.load(Ordering::Relaxed) {
 						for frame in frames {
 							if stop.load(Ordering::Relaxed) {
-								return;
+								return Ok(());
 							}
-							let resized = match frame.resize(target) {
-								Ok(resized) => resized,
-								Err(e) => return eprintln!("[ladder] rung {rung} stopped resizing: {e}"),
-							};
+							let resized = frame
+								.resize(target)
+								.with_context(|| format!("ladder rung {rung} resize"))?;
 							if !matches!(&resized.surface, Surface::Texture(_)) {
-								return eprintln!("[ladder] rung {rung} resize left the GPU");
+								bail!("ladder rung {rung} resize left the GPU");
 							}
-							if let Err(e) = encoder.encode(&resized) {
-								return eprintln!("[ladder] rung {rung} stopped encoding: {e}");
-							}
+							encoder
+								.encode(&resized)
+								.with_context(|| format!("ladder rung {rung} encode"))?;
 						}
 					}
-				});
+					Ok(())
+				}));
 			}
 
 			// Let the encoders bind the device and get busy before the scaler
@@ -1169,6 +1165,9 @@ mod probe {
 				Ok(())
 			})();
 			stop.store(true, Ordering::Relaxed);
+			for worker in workers {
+				worker.join().map_err(|_| anyhow!("ladder rung thread panicked"))??;
+			}
 			result
 		})
 	}

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -639,6 +639,48 @@ mod tests {
 		}
 	}
 
+	/// The multi-rung transcode path stays on hardware through decode, resize, and
+	/// encode: the Direct3D11 video processor scales the decoded texture on its own
+	/// device and the encoder MFT reads the result in place. The residency
+	/// assertion catches a CPU fallback even when the pixels and dimensions still
+	/// look right, which is what a ladder pays for once per rung.
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn mediafoundation_resized_texture_reencodes_in_place() {
+		let target = crate::Size::new(160, 120);
+		let Some((decoded, _decoder)) = decode_levels(3, gray_size()) else {
+			return;
+		};
+		let resized: Vec<_> = decoded.iter().map(|frame| frame.resize(target).unwrap()).collect();
+		for frame in &resized {
+			assert_eq!(frame.size(), target);
+			assert!(
+				matches!(frame.surface, Surface::Texture(_)),
+				"Direct3D11 resize downloaded to the CPU"
+			);
+		}
+
+		let encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Named("mediafoundation".into()),
+			..EncodeConfig::new(target.width, target.height, 30)
+		});
+		let Ok(mut encoder) = encoder else {
+			eprintln!("skipping: no Media Foundation H.264 hardware encoder available");
+			return;
+		};
+
+		let mut packets = 0;
+		for (i, out) in resized.iter().enumerate() {
+			if i == 0 {
+				encoder.keyframe();
+			}
+			packets += encoder.encode(out).unwrap().len();
+		}
+		packets += encoder.finish().unwrap().len();
+
+		assert!(packets > 0, "re-encoding resized textures produced no packets");
+	}
+
 	/// H.265 has no software encoder or decoder, so the HEVC round-trip rides the
 	/// Media Foundation hardware path on both ends: NVENC/QSV/AMF encode through an
 	/// HEVC encoder MFT, DXVA decode through an HEVC decoder MFT. Skips cleanly when

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -646,6 +646,7 @@ mod tests {
 	/// look right, which is what a ladder pays for once per rung.
 	#[cfg(target_os = "windows")]
 	#[test]
+	#[ignore = "explicit live-DXVA GPU probe; VideoProcessorBlt can hang on affected drivers"]
 	fn mediafoundation_resized_texture_reencodes_in_place() {
 		let target = crate::Size::new(160, 120);
 		let resize = crate::resize::Config {
@@ -655,6 +656,16 @@ mod tests {
 		let Some((decoded, _decoder)) = decode_levels(3, gray_size()) else {
 			return;
 		};
+		let Some(device) = decoded.iter().find_map(|frame| match &frame.surface {
+			Surface::Texture(texture) => Some(texture.device()),
+			_ => None,
+		}) else {
+			panic!("Media Foundation decode did not return a Direct3D11 texture");
+		};
+		if !crate::frame::d3d11::supports_nv12_render_target(device) {
+			eprintln!("skipping: driver cannot render to NV12");
+			return;
+		}
 		let resized: Vec<_> = decoded
 			.iter()
 			.map(|frame| frame.resize_with(target, &resize).unwrap())

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -648,10 +648,17 @@ mod tests {
 	#[test]
 	fn mediafoundation_resized_texture_reencodes_in_place() {
 		let target = crate::Size::new(160, 120);
+		let resize = crate::resize::Config {
+			acceleration: crate::resize::Acceleration::Gpu,
+			..Default::default()
+		};
 		let Some((decoded, _decoder)) = decode_levels(3, gray_size()) else {
 			return;
 		};
-		let resized: Vec<_> = decoded.iter().map(|frame| frame.resize(target).unwrap()).collect();
+		let resized: Vec<_> = decoded
+			.iter()
+			.map(|frame| frame.resize_with(target, &resize).unwrap())
+			.collect();
 		for frame in &resized {
 			assert_eq!(frame.size(), target);
 			assert!(

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -1954,6 +1954,13 @@ pub mod d3d11 {
 		flags
 	}
 
+	/// Whether explicit GPU-resize tests can render to an NV12 destination.
+	#[cfg(test)]
+	pub(crate) fn supports_nv12_render_target(device: &ID3D11Device) -> bool {
+		let support = unsafe { device.CheckFormatSupport(DXGI_FORMAT_NV12) }.unwrap_or_default();
+		support & D3D11_FORMAT_SUPPORT_RENDER_TARGET.0 as u32 != 0
+	}
+
 	struct UnmapGuard<'a> {
 		context: &'a ID3D11DeviceContext,
 		resource: &'a ID3D11Texture2D,
@@ -2274,6 +2281,7 @@ mod tests {
 	/// A Direct3D11 texture stays on the GPU when the caller opts in.
 	#[cfg(target_os = "windows")]
 	#[test]
+	#[ignore = "explicit D3D11 GPU probe; VideoProcessorBlt can hang on affected drivers"]
 	fn d3d11_resize_stays_on_the_gpu() {
 		let Ok(device) = super::d3d11::create_device() else {
 			eprintln!("skipping: no Direct3D11 hardware device");
@@ -2283,6 +2291,10 @@ mod tests {
 			eprintln!("skipping: driver will not allocate a usable NV12 texture");
 			return;
 		};
+		if !super::d3d11::supports_nv12_render_target(&device) {
+			eprintln!("skipping: driver cannot render to NV12");
+			return;
+		}
 
 		let config = crate::resize::Config {
 			acceleration: crate::resize::Acceleration::Gpu,
@@ -2320,6 +2332,7 @@ mod tests {
 	/// Runs on real hardware; skips without a Direct3D11 device.
 	#[cfg(target_os = "windows")]
 	#[test]
+	#[ignore = "explicit D3D11 GPU probe; VideoProcessorBlt can hang on affected drivers"]
 	fn d3d11_resize_matches_cpu() {
 		let Ok(device) = super::d3d11::create_device() else {
 			eprintln!("skipping: no Direct3D11 hardware device");
@@ -2330,6 +2343,10 @@ mod tests {
 			eprintln!("skipping: driver will not allocate a usable NV12 texture");
 			return;
 		};
+		if !super::d3d11::supports_nv12_render_target(&device) {
+			eprintln!("skipping: driver cannot render to NV12");
+			return;
+		}
 
 		let gpu = texture.resize(160, 120).unwrap().download_i420().unwrap();
 		let cpu = source.resize(160, 120).unwrap();

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -1682,13 +1682,14 @@ pub mod d3d11 {
 			};
 			let texture = match result {
 				Ok(texture) => texture,
-				Err(err) => {
+				Err(ScaleError::Unsupported(err)) => {
 					*state = ScalerState::Unsupported {
 						_device: self.device.clone(),
 						reason: err.to_string(),
 					};
 					return Err(err);
 				}
+				Err(ScaleError::Transient(err)) => return Err(err),
 			};
 			drop(state);
 			drop(scaler);
@@ -1773,6 +1774,12 @@ pub mod d3d11 {
 		target: Size,
 	}
 
+	/// Whether a failed scale proves this key unsupported or can succeed later.
+	enum ScaleError {
+		Unsupported(Error),
+		Transient(Error),
+	}
+
 	impl Scaler {
 		fn new(device: &ID3D11Device, source: Size, target: Size) -> Result<Self, Error> {
 			let video = device
@@ -1845,10 +1852,11 @@ pub mod d3d11 {
 		}
 
 		/// Blit `source` into a new texture at the target size.
-		fn scale(&self, source: &ID3D11Texture2D) -> Result<ID3D11Texture2D, Error> {
+		fn scale(&self, source: &ID3D11Texture2D) -> Result<ID3D11Texture2D, ScaleError> {
 			let mut desc = D3D11_TEXTURE2D_DESC::default();
 			unsafe { source.GetDesc(&mut desc) };
-			let output = alloc(&self.device, self.target.width, self.target.height, desc.Format)?;
+			let output = alloc(&self.device, self.target.width, self.target.height, desc.Format)
+				.map_err(ScaleError::Transient)?;
 
 			let input_desc = D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
 				FourCC: 0,
@@ -1864,9 +1872,10 @@ pub mod d3d11 {
 			unsafe {
 				self.video
 					.CreateVideoProcessorInputView(source, &self.enumerator, &input_desc, Some(&mut input))
-					.map_err(|e| err("CreateVideoProcessorInputView", e))?;
+					.map_err(|e| ScaleError::Unsupported(err("CreateVideoProcessorInputView", e)))?;
 			}
-			let input = input.ok_or_else(|| Error::Codec(anyhow::anyhow!("input view is null")))?;
+			let input =
+				input.ok_or_else(|| ScaleError::Unsupported(Error::Codec(anyhow::anyhow!("input view is null"))))?;
 
 			let output_desc = D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
 				ViewDimension: D3D11_VPOV_DIMENSION_TEXTURE2D,
@@ -1878,9 +1887,10 @@ pub mod d3d11 {
 			unsafe {
 				self.video
 					.CreateVideoProcessorOutputView(&output, &self.enumerator, &output_desc, Some(&mut view))
-					.map_err(|e| err("CreateVideoProcessorOutputView", e))?;
+					.map_err(|e| ScaleError::Unsupported(err("CreateVideoProcessorOutputView", e)))?;
 			}
-			let view = view.ok_or_else(|| Error::Codec(anyhow::anyhow!("output view is null")))?;
+			let view =
+				view.ok_or_else(|| ScaleError::Unsupported(Error::Codec(anyhow::anyhow!("output view is null"))))?;
 
 			let streams = [D3D11_VIDEO_PROCESSOR_STREAM {
 				Enable: true.into(),
@@ -1902,7 +1912,7 @@ pub mod d3d11 {
 			drop(std::mem::ManuallyDrop::into_inner(unsafe {
 				ptr::read(&streams[0].pInputSurface)
 			}));
-			result.map_err(|e| err("VideoProcessorBlt", e))?;
+			result.map_err(|e| ScaleError::Transient(err("VideoProcessorBlt", e)))?;
 
 			Ok(output)
 		}

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -56,13 +56,13 @@ impl Frame {
 	}
 
 	/// A copy of this frame scaled to `size` (both dimensions even and non-zero),
-	/// preserving the timestamp. CUDA and macOS `CVPixelBuffer` frames scale on
-	/// the GPU and stay there, so resize ->
-	/// [`encode`](crate::encode::Encoder::encode) never touches the CPU. Other
-	/// frames scale on the CPU. When one output size is enough, prefer decoding
-	/// straight to it ([`decode::Config::resize`](crate::decode::Config)), which
-	/// is free on decoders with a hardware scaler; this method is for fanning one
-	/// decoded stream out to several sizes.
+	/// preserving the timestamp. Every GPU surface scales on the GPU and stays
+	/// there, so resize -> [`encode`](crate::encode::Encoder::encode) never
+	/// touches the CPU; only a CPU frame scales on the CPU. When one output size
+	/// is enough, prefer decoding straight to it
+	/// ([`decode::Config::resize`](crate::decode::Config)), which is free on
+	/// decoders with a hardware scaler; this method is for fanning one decoded
+	/// stream out to several sizes.
 	pub fn resize(&self, size: Size) -> Result<Frame, Error> {
 		Ok(Frame {
 			timestamp: self.timestamp,
@@ -158,9 +158,13 @@ impl Surface {
 		)?))
 	}
 
-	/// A copy scaled to `size`, staying on the GPU for CUDA and macOS pixel-buffer
-	/// surfaces. The pixel half of [`Frame::resize`], which is what you usually
-	/// want since it carries the timestamp across too.
+	/// A copy scaled to `size`, staying on the GPU for every GPU surface: CUDA,
+	/// macOS pixel buffers, and Direct3D11 textures. The pixel half of
+	/// [`Frame::resize`], which is what you usually want since it carries the
+	/// timestamp across too.
+	///
+	/// A GPU scaler that a driver refuses falls back to downloading and scaling
+	/// on the CPU, warning once, rather than failing the frame.
 	pub fn resize(&self, size: Size) -> Result<Surface, Error> {
 		size.validate("resize to")?;
 		let Size { width, height } = size;
@@ -189,8 +193,18 @@ impl Surface {
 					Surface::I420(cuda.download_i420()?.resize(width, height)?)
 				}
 			},
-			// D3D11 textures have no GPU scaler wired up yet, so a ladder fanning one
-			// decoded frame out to several sizes downloads it once per rung.
+			#[cfg(target_os = "windows")]
+			Surface::Texture(texture) => match texture.resize(width, height) {
+				Ok(scaled) => Surface::Texture(scaled),
+				// A driver that won't render to NV12 has no video-processor path
+				// at all: degrade to a CPU resize (download once) instead of
+				// killing the stream.
+				Err(err) => {
+					static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+					WARN_ONCE.call_once(|| tracing::warn!(%err, "GPU resize failed; falling back to the CPU"));
+					Surface::I420(texture.download_i420()?.resize(width, height)?)
+				}
+			},
 			#[allow(unreachable_patterns)]
 			other => Surface::I420(other.to_i420()?.into_owned().resize(width, height)?),
 		})
@@ -604,17 +618,122 @@ pub(crate) fn deinterleave_uv(uv: &[u8], u: &mut [u8], v: &mut [u8]) {
 	}
 }
 
+/// A bounded least-recently-used cache that never evicts a value in use.
+///
+/// Both GPU scalers want the same thing: the object that does the scaling is
+/// expensive to build, cheap to reuse, and not safe to drive from two threads at
+/// once, while a rendition ladder resizes on a thread per rung. So each key owns
+/// a serialized value, rungs share rather than contend, and a long-lived process
+/// does not retain every size it has ever seen.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+struct Cache<K, T> {
+	values: std::collections::HashMap<K, std::sync::Arc<std::sync::Mutex<T>>>,
+	order: std::collections::VecDeque<K>,
+	capacity: usize,
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+impl<K: Clone + Eq + std::hash::Hash, T> Cache<K, T> {
+	fn new(capacity: usize) -> Self {
+		Self {
+			values: std::collections::HashMap::new(),
+			order: std::collections::VecDeque::new(),
+			capacity,
+		}
+	}
+
+	fn get_or_insert_with<E>(
+		&mut self,
+		key: K,
+		create: impl FnOnce() -> Result<T, E>,
+	) -> Result<std::sync::Arc<std::sync::Mutex<T>>, E> {
+		if let Some(value) = self.values.get(&key).cloned() {
+			self.touch(&key);
+			return Ok(value);
+		}
+
+		let value = std::sync::Arc::new(std::sync::Mutex::new(create()?));
+		self.values.insert(key.clone(), std::sync::Arc::clone(&value));
+		self.touch(&key);
+		self.prune();
+		Ok(value)
+	}
+
+	fn touch(&mut self, key: &K) {
+		self.order.retain(|entry| entry != key);
+		self.order.push_back(key.clone());
+	}
+
+	fn prune(&mut self) {
+		let mut remaining = self.order.len();
+		while self.values.len() > self.capacity && remaining > 0 {
+			let key = self.order.pop_front().expect("remaining entries");
+			let idle = self
+				.values
+				.get(&key)
+				.is_some_and(|value| std::sync::Arc::strong_count(value) == 1);
+			if idle {
+				self.values.remove(&key);
+			} else {
+				self.order.push_back(key);
+			}
+			remaining -= 1;
+		}
+	}
+}
+
+#[cfg(all(test, any(target_os = "macos", target_os = "windows")))]
+mod cache_tests {
+	use super::Cache;
+
+	#[test]
+	fn evicts_the_least_recently_used_idle_value() {
+		let mut cache = Cache::new(2);
+
+		let first = cache.get_or_insert_with((1, 1), || Ok::<_, ()>(())).unwrap();
+		drop(first);
+		let second = cache.get_or_insert_with((2, 2), || Ok::<_, ()>(())).unwrap();
+		drop(second);
+
+		let first = cache
+			.get_or_insert_with((1, 1), || Err::<(), _>("cached value was recreated"))
+			.unwrap();
+		drop(first);
+		let third = cache.get_or_insert_with((3, 3), || Ok::<_, ()>(())).unwrap();
+		drop(third);
+
+		assert!(cache.values.contains_key(&(1, 1)));
+		assert!(!cache.values.contains_key(&(2, 2)));
+		assert!(cache.values.contains_key(&(3, 3)));
+		assert_eq!(cache.values.len(), 2);
+	}
+
+	#[test]
+	fn defers_eviction_until_an_active_value_is_released() {
+		let mut cache = Cache::new(1);
+		let first = cache.get_or_insert_with((1, 1), || Ok::<_, ()>(())).unwrap();
+		let second = cache.get_or_insert_with((2, 2), || Ok::<_, ()>(())).unwrap();
+		assert_eq!(cache.values.len(), 2);
+
+		drop(first);
+		cache.prune();
+		assert!(!cache.values.contains_key(&(1, 1)));
+		assert!(cache.values.contains_key(&(2, 2)));
+		assert_eq!(cache.values.len(), 1);
+		drop(second);
+	}
+}
+
 #[cfg(target_os = "macos")]
 pub mod macos {
 	//! macOS CoreVideo surfaces: the [`PixelBuffer`] behind
 	//! `Surface::PixelBuffer`, GPU resize, and download/upload between it and CPU
 	//! I420.
 
-	use std::collections::{HashMap, VecDeque};
 	use std::ffi::c_void;
 	use std::ptr;
 	use std::ptr::NonNull;
-	use std::sync::{Arc, LazyLock, Mutex};
+	use std::sync::{LazyLock, Mutex};
 
 	use objc2_core_foundation::{CFDictionary, CFNumber, CFNumberType, CFRetained, CFString};
 	use objc2_core_video::{
@@ -627,7 +746,7 @@ pub mod macos {
 	};
 	use objc2_video_toolbox::VTPixelTransferSession;
 
-	use super::I420;
+	use super::{Cache, I420};
 	use crate::{Color, Error};
 
 	/// Read-only lock flag (`kCVPixelBufferLock_ReadOnly`).
@@ -640,61 +759,8 @@ pub mod macos {
 	/// Transfer sessions and destination pools are reusable, but VideoToolbox does
 	/// not promise concurrent access to a session. Each cached output size gets
 	/// its own serialized scaler so independent ladder rungs do not contend.
-	type ScalerCache = Mutex<Cache<Scaler>>;
+	type ScalerCache = Mutex<Cache<(u32, u32), Scaler>>;
 	static SCALERS: LazyLock<ScalerCache> = LazyLock::new(|| Mutex::new(Cache::new(SCALER_CACHE_CAPACITY)));
-
-	/// A bounded least-recently-used cache that never evicts a value in use.
-	struct Cache<T> {
-		values: HashMap<(u32, u32), Arc<Mutex<T>>>,
-		order: VecDeque<(u32, u32)>,
-		capacity: usize,
-	}
-
-	impl<T> Cache<T> {
-		fn new(capacity: usize) -> Self {
-			Self {
-				values: HashMap::new(),
-				order: VecDeque::new(),
-				capacity,
-			}
-		}
-
-		fn get_or_insert_with<E>(
-			&mut self,
-			key: (u32, u32),
-			create: impl FnOnce() -> Result<T, E>,
-		) -> Result<Arc<Mutex<T>>, E> {
-			if let Some(value) = self.values.get(&key).cloned() {
-				self.touch(key);
-				return Ok(value);
-			}
-
-			let value = Arc::new(Mutex::new(create()?));
-			self.values.insert(key, Arc::clone(&value));
-			self.touch(key);
-			self.prune();
-			Ok(value)
-		}
-
-		fn touch(&mut self, key: (u32, u32)) {
-			self.order.retain(|entry| *entry != key);
-			self.order.push_back(key);
-		}
-
-		fn prune(&mut self) {
-			let mut remaining = self.order.len();
-			while self.values.len() > self.capacity && remaining > 0 {
-				let key = self.order.pop_front().expect("remaining entries");
-				let idle = self.values.get(&key).is_some_and(|value| Arc::strong_count(value) == 1);
-				if idle {
-					self.values.remove(&key);
-				} else {
-					self.order.push_back(key);
-				}
-				remaining -= 1;
-			}
-		}
-	}
 
 	/// A captured GPU surface. Cloning is a cheap retain (no pixel copy), which
 	/// is what keeps the capture -> encode path zero-copy.
@@ -1056,48 +1122,6 @@ pub mod macos {
 			}
 		}
 	}
-
-	#[cfg(test)]
-	mod cache_tests {
-		use super::Cache;
-
-		#[test]
-		fn evicts_the_least_recently_used_idle_value() {
-			let mut cache = Cache::new(2);
-
-			let first = cache.get_or_insert_with((1, 1), || Ok::<_, ()>(())).unwrap();
-			drop(first);
-			let second = cache.get_or_insert_with((2, 2), || Ok::<_, ()>(())).unwrap();
-			drop(second);
-
-			let first = cache
-				.get_or_insert_with((1, 1), || Err::<(), _>("cached value was recreated"))
-				.unwrap();
-			drop(first);
-			let third = cache.get_or_insert_with((3, 3), || Ok::<_, ()>(())).unwrap();
-			drop(third);
-
-			assert!(cache.values.contains_key(&(1, 1)));
-			assert!(!cache.values.contains_key(&(2, 2)));
-			assert!(cache.values.contains_key(&(3, 3)));
-			assert_eq!(cache.values.len(), 2);
-		}
-
-		#[test]
-		fn defers_eviction_until_an_active_value_is_released() {
-			let mut cache = Cache::new(1);
-			let first = cache.get_or_insert_with((1, 1), || Ok::<_, ()>(())).unwrap();
-			let second = cache.get_or_insert_with((2, 2), || Ok::<_, ()>(())).unwrap();
-			assert_eq!(cache.values.len(), 2);
-
-			drop(first);
-			cache.prune();
-			assert!(!cache.values.contains_key(&(1, 1)));
-			assert!(cache.values.contains_key(&(2, 2)));
-			assert_eq!(cache.values.len(), 1);
-			drop(second);
-		}
-	}
 }
 
 #[cfg(all(target_os = "linux", feature = "nvdec"))]
@@ -1336,8 +1360,9 @@ pub mod d3d11 {
 
 	use std::ffi::c_void;
 	use std::ptr;
+	use std::sync::{LazyLock, Mutex};
 
-	use windows::Win32::Foundation::HMODULE;
+	use windows::Win32::Foundation::{HMODULE, RECT};
 	use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
 	use windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
 	use windows::Win32::Graphics::Direct3D11::{
@@ -1345,15 +1370,23 @@ pub mod d3d11 {
 		D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
 		D3D11_FORMAT_SUPPORT, D3D11_FORMAT_SUPPORT_RENDER_TARGET, D3D11_FORMAT_SUPPORT_SHADER_SAMPLE,
 		D3D11_FORMAT_SUPPORT_VIDEO_ENCODER, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_SDK_VERSION,
-		D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING, D3D11CreateDevice, ID3D11Device,
-		ID3D11DeviceContext, ID3D11Texture2D,
+		D3D11_TEX2D_VPIV, D3D11_TEX2D_VPOV, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING,
+		D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE, D3D11_VIDEO_PROCESSOR_COLOR_SPACE, D3D11_VIDEO_PROCESSOR_CONTENT_DESC,
+		D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC, D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0,
+		D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC, D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0, D3D11_VIDEO_PROCESSOR_STREAM,
+		D3D11_VIDEO_USAGE_PLAYBACK_NORMAL, D3D11_VPIV_DIMENSION_TEXTURE2D, D3D11_VPOV_DIMENSION_TEXTURE2D,
+		D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D, ID3D11VideoContext, ID3D11VideoDevice,
+		ID3D11VideoProcessor, ID3D11VideoProcessorEnumerator, ID3D11VideoProcessorInputView,
+		ID3D11VideoProcessorOutputView,
 	};
-	use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT, DXGI_SAMPLE_DESC};
+	#[cfg(test)]
+	use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_NV12;
+	use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT, DXGI_RATIONAL, DXGI_SAMPLE_DESC};
 	use windows::Win32::Media::MediaFoundation::{IMFDXGIBuffer, IMFSample};
 	use windows::core::Interface;
 
-	use super::I420;
-	use crate::Error;
+	use super::{Cache, I420};
+	use crate::{Error, Size};
 
 	fn err(ctx: &str, e: windows::core::Error) -> Error {
 		Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
@@ -1570,6 +1603,224 @@ pub mod d3d11 {
 				color: None,
 			})
 		}
+
+		/// Scale to `width` x `height` on the GPU, staying on this texture's device.
+		/// The Windows half of [`Frame::resize`](crate::Frame::resize).
+		///
+		/// Errors rather than falling back, so the caller decides. Two things a
+		/// driver can refuse: rendering to NV12 at all (no output view, so no
+		/// scale), and an input view over a texture bound only for shader
+		/// sampling. [`bind_flags`] asks for render-target and video-encoder
+		/// support up front, so both come down to what the driver granted.
+		pub(crate) fn resize(&self, width: u32, height: u32) -> Result<Self, Error> {
+			let source = Size::new(self.width, self.height);
+			let target = Size::new(width, height);
+
+			let scaler = {
+				let mut scalers = SCALERS
+					.lock()
+					.map_err(|_| Error::Codec(anyhow::anyhow!("video-processor cache lock poisoned")))?;
+				scalers.get_or_insert_with(ScalerKey::new(&self.device, source, target), || {
+					Scaler::new(&self.device, source, target)
+				})?
+			};
+			let texture = scaler
+				.lock()
+				.map_err(|_| Error::Codec(anyhow::anyhow!("video processor lock poisoned")))?
+				.scale(&self.texture)?;
+			drop(scaler);
+			if let Ok(mut scalers) = SCALERS.lock() {
+				scalers.prune();
+			}
+
+			Ok(Self {
+				device: self.device.clone(),
+				texture,
+				width,
+				height,
+			})
+		}
+	}
+
+	/// Enough reusable video processors for a large rendition ladder without
+	/// retaining every device and scale a long-lived process has ever seen.
+	const SCALER_CACHE_CAPACITY: usize = 16;
+
+	/// Building a video processor costs orders of magnitude more than using one,
+	/// and `ID3D11VideoContext` is not safe to drive from two threads at once, so
+	/// each device and scale gets one serialized processor that its ladder rungs
+	/// share.
+	static SCALERS: LazyLock<Mutex<Cache<ScalerKey, Scaler>>> =
+		LazyLock::new(|| Mutex::new(Cache::new(SCALER_CACHE_CAPACITY)));
+
+	/// Which device and which scale a cached processor is for.
+	///
+	/// The device is keyed by pointer because `ID3D11Device` is not hashable. That
+	/// is sound only because the cached [`Scaler`] holds a reference to the same
+	/// device: the address cannot be freed and handed to a different device while
+	/// an entry keyed on it is alive.
+	#[derive(Clone, PartialEq, Eq, Hash)]
+	struct ScalerKey {
+		device: usize,
+		source: Size,
+		target: Size,
+	}
+
+	impl ScalerKey {
+		fn new(device: &ID3D11Device, source: Size, target: Size) -> Self {
+			Self {
+				device: device.as_raw() as usize,
+				source,
+				target,
+			}
+		}
+	}
+
+	/// One Direct3D11 video processor, configured for a single source and target
+	/// size. The GPU scaler behind [`Texture::resize`].
+	struct Scaler {
+		/// Keeps the device keying this entry alive, so its address stays unique.
+		device: ID3D11Device,
+		video: ID3D11VideoDevice,
+		context: ID3D11VideoContext,
+		enumerator: ID3D11VideoProcessorEnumerator,
+		processor: ID3D11VideoProcessor,
+		target: Size,
+	}
+
+	impl Scaler {
+		fn new(device: &ID3D11Device, source: Size, target: Size) -> Result<Self, Error> {
+			let video = device
+				.cast::<ID3D11VideoDevice>()
+				.map_err(|e| err("query ID3D11VideoDevice", e))?;
+			let immediate = unsafe { device.GetImmediateContext() }.map_err(|e| err("GetImmediateContext", e))?;
+			let context = immediate
+				.cast::<ID3D11VideoContext>()
+				.map_err(|e| err("query ID3D11VideoContext", e))?;
+
+			// The frame rates are what a processor uses to decide it should
+			// deinterlace or interpolate; matching them says neither.
+			let rate = DXGI_RATIONAL {
+				Numerator: 30,
+				Denominator: 1,
+			};
+			let desc = D3D11_VIDEO_PROCESSOR_CONTENT_DESC {
+				InputFrameFormat: D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE,
+				InputFrameRate: rate,
+				InputWidth: source.width,
+				InputHeight: source.height,
+				OutputFrameRate: rate,
+				OutputWidth: target.width,
+				OutputHeight: target.height,
+				Usage: D3D11_VIDEO_USAGE_PLAYBACK_NORMAL,
+			};
+
+			let enumerator = unsafe { video.CreateVideoProcessorEnumerator(&desc) }
+				.map_err(|e| err("CreateVideoProcessorEnumerator", e))?;
+			let processor =
+				unsafe { video.CreateVideoProcessor(&enumerator, 0) }.map_err(|e| err("CreateVideoProcessor", e))?;
+
+			let full = RECT {
+				left: 0,
+				top: 0,
+				right: source.width as i32,
+				bottom: source.height as i32,
+			};
+			let scaled = RECT {
+				left: 0,
+				top: 0,
+				right: target.width as i32,
+				bottom: target.height as i32,
+			};
+			unsafe {
+				context.VideoProcessorSetStreamFrameFormat(&processor, 0, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE);
+				// The whole picture into the whole destination: the scale itself.
+				context.VideoProcessorSetStreamSourceRect(&processor, 0, true, Some(&full));
+				context.VideoProcessorSetStreamDestRect(&processor, 0, true, Some(&scaled));
+				// Drivers ship denoise and edge enhancement on by default here.
+				// This is a resize, not a filter chain, so a rung must not come out
+				// looking different from the frame it was scaled from.
+				context.VideoProcessorSetStreamAutoProcessingMode(&processor, 0, false);
+				// One space in, the same space out. Resampling moves samples
+				// around, it must not reinterpret them, and a processor left to
+				// its own devices will happily convert between ranges.
+				let space = D3D11_VIDEO_PROCESSOR_COLOR_SPACE::default();
+				context.VideoProcessorSetStreamColorSpace(&processor, 0, &space);
+				context.VideoProcessorSetOutputColorSpace(&processor, &space);
+			}
+
+			Ok(Self {
+				device: device.clone(),
+				video,
+				context,
+				enumerator,
+				processor,
+				target,
+			})
+		}
+
+		/// Blit `source` into a new texture at the target size.
+		fn scale(&self, source: &ID3D11Texture2D) -> Result<ID3D11Texture2D, Error> {
+			let mut desc = D3D11_TEXTURE2D_DESC::default();
+			unsafe { source.GetDesc(&mut desc) };
+			let output = alloc(&self.device, self.target.width, self.target.height, desc.Format)?;
+
+			let input_desc = D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
+				FourCC: 0,
+				ViewDimension: D3D11_VPIV_DIMENSION_TEXTURE2D,
+				Anonymous: D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
+					Texture2D: D3D11_TEX2D_VPIV {
+						MipSlice: 0,
+						ArraySlice: 0,
+					},
+				},
+			};
+			let mut input: Option<ID3D11VideoProcessorInputView> = None;
+			unsafe {
+				self.video
+					.CreateVideoProcessorInputView(source, &self.enumerator, &input_desc, Some(&mut input))
+					.map_err(|e| err("CreateVideoProcessorInputView", e))?;
+			}
+			let input = input.ok_or_else(|| Error::Codec(anyhow::anyhow!("input view is null")))?;
+
+			let output_desc = D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
+				ViewDimension: D3D11_VPOV_DIMENSION_TEXTURE2D,
+				Anonymous: D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
+					Texture2D: D3D11_TEX2D_VPOV { MipSlice: 0 },
+				},
+			};
+			let mut view: Option<ID3D11VideoProcessorOutputView> = None;
+			unsafe {
+				self.video
+					.CreateVideoProcessorOutputView(&output, &self.enumerator, &output_desc, Some(&mut view))
+					.map_err(|e| err("CreateVideoProcessorOutputView", e))?;
+			}
+			let view = view.ok_or_else(|| Error::Codec(anyhow::anyhow!("output view is null")))?;
+
+			let streams = [D3D11_VIDEO_PROCESSOR_STREAM {
+				Enable: true.into(),
+				OutputIndex: 0,
+				InputFrameOrField: 0,
+				PastFrames: 0,
+				FutureFrames: 0,
+				ppPastSurfaces: ptr::null_mut(),
+				pInputSurface: std::mem::ManuallyDrop::new(Some(input)),
+				ppFutureSurfaces: ptr::null_mut(),
+				ppPastSurfacesRight: ptr::null_mut(),
+				pInputSurfaceRight: std::mem::ManuallyDrop::new(None),
+				ppFutureSurfacesRight: ptr::null_mut(),
+			}];
+			let result = unsafe { self.context.VideoProcessorBlt(&self.processor, &view, 0, &streams) };
+			// The stream struct holds the view in a `ManuallyDrop`, so releasing it
+			// is ours to do whether or not the blit succeeded.
+			// SAFETY: the field is live and read exactly once.
+			drop(std::mem::ManuallyDrop::into_inner(unsafe {
+				ptr::read(&streams[0].pInputSurface)
+			}));
+			result.map_err(|e| err("VideoProcessorBlt", e))?;
+
+			Ok(output)
+		}
 	}
 
 	/// A plain single-slice texture on `device`, bound for whatever the driver
@@ -1595,6 +1846,42 @@ pub mod d3d11 {
 				.map_err(|e| err("CreateTexture2D", e))?;
 		}
 		texture.ok_or_else(|| Error::Codec(anyhow::anyhow!("CreateTexture2D returned null")))
+	}
+
+	/// Upload packed I420 as an NV12 texture on `device`, the inverse of
+	/// [`Texture::download_i420`]. Only the tests need it: every texture in a live
+	/// pipeline comes from a producer that already put it on the GPU.
+	#[cfg(test)]
+	pub(crate) fn upload_i420(device: &ID3D11Device, frame: &I420) -> Result<Texture, Error> {
+		let (width, height) = (frame.width, frame.height);
+		let texture = alloc(device, width, height, DXGI_FORMAT_NV12)?;
+
+		let (w, h) = (width as usize, height as usize);
+		let mut nv12 = vec![0u8; w * h * 3 / 2];
+		let (luma, chroma) = nv12.split_at_mut(w * h);
+		luma.copy_from_slice(frame.y());
+		super::interleave_uv(frame.u(), frame.v(), chroma);
+
+		let context = unsafe { device.GetImmediateContext() }.map_err(|e| err("GetImmediateContext", e))?;
+		// Tightly packed, so the row pitch is the width and the depth pitch is
+		// the whole buffer.
+		unsafe {
+			context.UpdateSubresource(
+				&texture,
+				0,
+				None,
+				nv12.as_ptr().cast::<c_void>(),
+				width,
+				nv12.len() as u32,
+			);
+		}
+
+		Ok(Texture {
+			device: device.clone(),
+			texture,
+			width,
+			height,
+		})
 	}
 
 	/// The Direct3D11 texture behind a Media Foundation sample, and which slice of
@@ -1943,6 +2230,54 @@ mod tests {
 		unsafe { CVPixelBufferUnlockBaseAddress(&buffer, flags) };
 
 		super::macos::PixelBuffer::new(buffer, frame.width, frame.height)
+	}
+
+	/// A decoded Windows frame scales without leaving the GPU. The regression
+	/// test for the fix: before it, a ladder fanning one frame out to several
+	/// sizes downloaded it once per rung, and this arm came back `I420`.
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn d3d11_resize_stays_on_the_gpu() {
+		let Ok(device) = super::d3d11::create_device() else {
+			eprintln!("skipping: no Direct3D11 hardware device");
+			return;
+		};
+		let Ok(texture) = super::d3d11::upload_i420(&device, &gradient_i420(320, 240)) else {
+			eprintln!("skipping: driver will not allocate a usable NV12 texture");
+			return;
+		};
+
+		let scaled = Surface::Texture(texture).resize(crate::Size::new(160, 120)).unwrap();
+		assert!(
+			matches!(scaled, Surface::Texture(_)),
+			"Direct3D11 resize downloaded to the CPU"
+		);
+		assert_eq!((scaled.width(), scaled.height()), (160, 120));
+	}
+
+	/// GPU (video processor) and CPU (bilinear convolution) resizes agree on a
+	/// smooth gradient, so the scaler is scaling rather than merely not failing.
+	/// Runs on real hardware; skips without a Direct3D11 device.
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn d3d11_resize_matches_cpu() {
+		let Ok(device) = super::d3d11::create_device() else {
+			eprintln!("skipping: no Direct3D11 hardware device");
+			return;
+		};
+		let source = gradient_i420(320, 240);
+		let Ok(texture) = super::d3d11::upload_i420(&device, &source) else {
+			eprintln!("skipping: driver will not allocate a usable NV12 texture");
+			return;
+		};
+
+		let gpu = texture.resize(160, 120).unwrap().download_i420().unwrap();
+		let cpu = source.resize(160, 120).unwrap();
+
+		assert_eq!((gpu.width, gpu.height), (160, 120));
+		assert!(mae(gpu.y(), cpu.y()) < 4, "GPU and CPU luma disagree");
+		assert!(mae(gpu.u(), cpu.u()) < 4, "GPU and CPU u disagree");
+		assert!(mae(gpu.v(), cpu.v()) < 4, "GPU and CPU v disagree");
 	}
 
 	/// GPU (box filter) and CPU (bilinear convolution) resizes agree on a

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -56,10 +56,8 @@ impl Frame {
 	}
 
 	/// A copy of this frame scaled to `size` (both dimensions even and non-zero),
-	/// preserving the timestamp. CUDA and macOS pixel-buffer surfaces scale on
-	/// the GPU and stay there. Direct3D11 textures use the CPU unless explicitly
-	/// enabled through [`resize_with`](Self::resize_with). When one output size
-	/// is enough, prefer decoding straight to it
+	/// preserving the timestamp. GPU-backed surfaces scale on the GPU and stay
+	/// there. When one output size is enough, prefer decoding straight to it
 	/// ([`decode::Config::resize`](crate::decode::Config)), which is free on
 	/// decoders with a hardware scaler; this method is for fanning one decoded
 	/// stream out to several sizes.
@@ -163,9 +161,8 @@ impl Surface {
 		)?))
 	}
 
-	/// A copy scaled to `size`. CUDA and macOS pixel-buffer surfaces stay on the
-	/// GPU. Direct3D11 textures use the CPU unless explicitly enabled through
-	/// [`resize_with`](Self::resize_with). The pixel half of [`Frame::resize`],
+	/// A copy scaled to `size`. GPU-backed surfaces stay on the GPU. The pixel
+	/// half of [`Frame::resize`],
 	/// which is what you usually want since it carries the timestamp across too.
 	///
 	/// A GPU scaler that a driver refuses falls back to downloading and scaling
@@ -214,7 +211,7 @@ impl Surface {
 				}
 			},
 			#[cfg(target_os = "windows")]
-			Surface::Texture(texture) if config.acceleration != crate::resize::Acceleration::Gpu => {
+			Surface::Texture(texture) if config.acceleration == crate::resize::Acceleration::Cpu => {
 				Surface::I420(texture.download_i420()?.resize(width, height)?)
 			}
 			#[cfg(target_os = "windows")]
@@ -2278,11 +2275,11 @@ mod tests {
 		super::macos::PixelBuffer::new(buffer, frame.width, frame.height)
 	}
 
-	/// A Direct3D11 texture stays on the GPU when the caller opts in.
+	/// A Direct3D11 texture stays on the GPU by default.
 	#[cfg(target_os = "windows")]
 	#[test]
-	#[ignore = "explicit D3D11 GPU probe; VideoProcessorBlt can hang on affected drivers"]
-	fn d3d11_resize_stays_on_the_gpu() {
+	#[ignore = "D3D11 GPU reproducer; VideoProcessorBlt can hang on affected drivers"]
+	fn d3d11_resize_defaults_to_the_gpu() {
 		let Ok(device) = super::d3d11::create_device() else {
 			eprintln!("skipping: no Direct3D11 hardware device");
 			return;
@@ -2296,13 +2293,7 @@ mod tests {
 			return;
 		}
 
-		let config = crate::resize::Config {
-			acceleration: crate::resize::Acceleration::Gpu,
-			..Default::default()
-		};
-		let scaled = Surface::Texture(texture)
-			.resize_with(crate::Size::new(160, 120), &config)
-			.unwrap();
+		let scaled = Surface::Texture(texture).resize(crate::Size::new(160, 120)).unwrap();
 		assert!(
 			matches!(scaled, Surface::Texture(_)),
 			"Direct3D11 resize downloaded to the CPU"
@@ -2310,10 +2301,10 @@ mod tests {
 		assert_eq!((scaled.width(), scaled.height()), (160, 120));
 	}
 
-	/// Direct3D11 resize defaults to the CPU until the live-DXVA wedge is fixed.
+	/// Direct3D11 resize can be forced onto the CPU.
 	#[cfg(target_os = "windows")]
 	#[test]
-	fn d3d11_resize_defaults_to_the_cpu() {
+	fn d3d11_resize_can_force_the_cpu() {
 		let Ok(device) = super::d3d11::create_device() else {
 			eprintln!("skipping: no Direct3D11 hardware device");
 			return;
@@ -2323,8 +2314,14 @@ mod tests {
 			return;
 		};
 
-		let scaled = Surface::Texture(texture).resize(crate::Size::new(160, 120)).unwrap();
-		assert!(matches!(scaled, Surface::I420(_)), "Direct3D11 resize was not opt-in");
+		let config = crate::resize::Config {
+			acceleration: crate::resize::Acceleration::Cpu,
+			..Default::default()
+		};
+		let scaled = Surface::Texture(texture)
+			.resize_with(crate::Size::new(160, 120), &config)
+			.unwrap();
+		assert!(matches!(scaled, Surface::I420(_)), "Direct3D11 resize ignored CPU mode");
 	}
 
 	/// GPU (video processor) and CPU (bilinear convolution) resizes agree on a

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -56,17 +56,22 @@ impl Frame {
 	}
 
 	/// A copy of this frame scaled to `size` (both dimensions even and non-zero),
-	/// preserving the timestamp. Every GPU surface scales on the GPU and stays
-	/// there, so resize -> [`encode`](crate::encode::Encoder::encode) never
-	/// touches the CPU; only a CPU frame scales on the CPU. When one output size
+	/// preserving the timestamp. CUDA and macOS pixel-buffer surfaces scale on
+	/// the GPU and stay there. Direct3D11 textures use the CPU unless explicitly
+	/// enabled through [`resize_with`](Self::resize_with). When one output size
 	/// is enough, prefer decoding straight to it
 	/// ([`decode::Config::resize`](crate::decode::Config)), which is free on
 	/// decoders with a hardware scaler; this method is for fanning one decoded
 	/// stream out to several sizes.
 	pub fn resize(&self, size: Size) -> Result<Frame, Error> {
+		self.resize_with(size, &crate::resize::Config::default())
+	}
+
+	/// A copy of this frame scaled with explicit platform options.
+	pub fn resize_with(&self, size: Size, config: &crate::resize::Config) -> Result<Frame, Error> {
 		Ok(Frame {
 			timestamp: self.timestamp,
-			surface: self.surface.resize(size)?,
+			surface: self.surface.resize_with(size, config)?,
 		})
 	}
 }
@@ -158,19 +163,30 @@ impl Surface {
 		)?))
 	}
 
-	/// A copy scaled to `size`, staying on the GPU for every GPU surface: CUDA,
-	/// macOS pixel buffers, and Direct3D11 textures. The pixel half of
-	/// [`Frame::resize`], which is what you usually want since it carries the
-	/// timestamp across too.
+	/// A copy scaled to `size`. CUDA and macOS pixel-buffer surfaces stay on the
+	/// GPU. Direct3D11 textures use the CPU unless explicitly enabled through
+	/// [`resize_with`](Self::resize_with). The pixel half of [`Frame::resize`],
+	/// which is what you usually want since it carries the timestamp across too.
 	///
 	/// A GPU scaler that a driver refuses falls back to downloading and scaling
 	/// on the CPU, warning once, rather than failing the frame.
 	pub fn resize(&self, size: Size) -> Result<Surface, Error> {
+		self.resize_with(size, &crate::resize::Config::default())
+	}
+
+	/// A copy scaled with explicit platform options.
+	pub fn resize_with(&self, size: Size, config: &crate::resize::Config) -> Result<Surface, Error> {
+		// Counts as a use on builds where every GPU arm is compiled out.
+		let _ = config;
 		size.validate("resize to")?;
 		let Size { width, height } = size;
 
 		Ok(match self {
 			Surface::I420(i420) => Surface::I420(i420.resize(width, height)?),
+			#[cfg(target_os = "macos")]
+			Surface::PixelBuffer(pixels) if config.acceleration == crate::resize::Acceleration::Cpu => {
+				Surface::I420(pixels.download_i420()?.resize(width, height)?)
+			}
 			#[cfg(target_os = "macos")]
 			Surface::PixelBuffer(pixels) => match pixels.resize(width, height) {
 				Ok(scaled) => Surface::PixelBuffer(scaled),
@@ -183,6 +199,10 @@ impl Surface {
 				}
 			},
 			#[cfg(all(target_os = "linux", feature = "nvdec"))]
+			Surface::Cuda(cuda) if config.acceleration == crate::resize::Acceleration::Cpu => {
+				Surface::I420(cuda.download_i420()?.resize(width, height)?)
+			}
+			#[cfg(all(target_os = "linux", feature = "nvdec"))]
 			Surface::Cuda(cuda) => match cuda.resize(width, height) {
 				Ok(scaled) => Surface::Cuda(scaled),
 				// E.g. the driver rejected the vendored PTX: degrade to a CPU
@@ -193,6 +213,10 @@ impl Surface {
 					Surface::I420(cuda.download_i420()?.resize(width, height)?)
 				}
 			},
+			#[cfg(target_os = "windows")]
+			Surface::Texture(texture) if config.acceleration != crate::resize::Acceleration::Gpu => {
+				Surface::I420(texture.download_i420()?.resize(width, height)?)
+			}
 			#[cfg(target_os = "windows")]
 			Surface::Texture(texture) => match texture.resize(width, height) {
 				Ok(scaled) => Surface::Texture(scaled),
@@ -1605,7 +1629,8 @@ pub mod d3d11 {
 		}
 
 		/// Scale to `width` x `height` on the GPU, staying on this texture's device.
-		/// The Windows half of [`Frame::resize`](crate::Frame::resize).
+		/// The Windows path opted into by
+		/// [`Frame::resize_with`](crate::Frame::resize_with).
 		///
 		/// Errors rather than falling back, so the caller decides. Two things a
 		/// driver can refuse: rendering to NV12 at all (no output view, so no
@@ -2176,6 +2201,20 @@ mod tests {
 		assert!(mae(gpu.v(), cpu.v()) < 4, "GPU and CPU v disagree");
 	}
 
+	/// Explicit CPU acceleration downloads a macOS pixel buffer before scaling.
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn pixel_buffer_resize_can_force_the_cpu() {
+		let config = crate::resize::Config {
+			acceleration: crate::resize::Acceleration::Cpu,
+			..Default::default()
+		};
+		let source = Surface::PixelBuffer(nv12_surface(&gradient_i420(320, 240)));
+		let scaled = source.resize_with(Size::new(160, 120), &config).unwrap();
+
+		assert!(matches!(scaled, Surface::I420(_)), "CPU resize stayed on the GPU");
+	}
+
 	/// Upload a packed I420 test picture as NV12, including CoreVideo row
 	/// padding, so the transfer test starts from the decoder's surface format.
 	#[cfg(target_os = "macos")]
@@ -2232,9 +2271,7 @@ mod tests {
 		super::macos::PixelBuffer::new(buffer, frame.width, frame.height)
 	}
 
-	/// A decoded Windows frame scales without leaving the GPU. The regression
-	/// test for the fix: before it, a ladder fanning one frame out to several
-	/// sizes downloaded it once per rung, and this arm came back `I420`.
+	/// A Direct3D11 texture stays on the GPU when the caller opts in.
 	#[cfg(target_os = "windows")]
 	#[test]
 	fn d3d11_resize_stays_on_the_gpu() {
@@ -2247,12 +2284,35 @@ mod tests {
 			return;
 		};
 
-		let scaled = Surface::Texture(texture).resize(crate::Size::new(160, 120)).unwrap();
+		let config = crate::resize::Config {
+			acceleration: crate::resize::Acceleration::Gpu,
+			..Default::default()
+		};
+		let scaled = Surface::Texture(texture)
+			.resize_with(crate::Size::new(160, 120), &config)
+			.unwrap();
 		assert!(
 			matches!(scaled, Surface::Texture(_)),
 			"Direct3D11 resize downloaded to the CPU"
 		);
 		assert_eq!((scaled.width(), scaled.height()), (160, 120));
+	}
+
+	/// Direct3D11 resize defaults to the CPU until the live-DXVA wedge is fixed.
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn d3d11_resize_defaults_to_the_cpu() {
+		let Ok(device) = super::d3d11::create_device() else {
+			eprintln!("skipping: no Direct3D11 hardware device");
+			return;
+		};
+		let Ok(texture) = super::d3d11::upload_i420(&device, &gradient_i420(320, 240)) else {
+			eprintln!("skipping: driver will not allocate a usable NV12 texture");
+			return;
+		};
+
+		let scaled = Surface::Texture(texture).resize(crate::Size::new(160, 120)).unwrap();
+		assert!(matches!(scaled, Surface::I420(_)), "Direct3D11 resize was not opt-in");
 	}
 
 	/// GPU (video processor) and CPU (bilinear convolution) resizes agree on a

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -743,6 +743,28 @@ mod cache_tests {
 		assert_eq!(cache.values.len(), 1);
 		drop(second);
 	}
+
+	#[test]
+	fn caches_failure_markers() {
+		let mut attempts = 0;
+		let mut cache = Cache::new(1);
+		let failed = cache
+			.get_or_insert_with(1, || {
+				attempts += 1;
+				Ok::<_, ()>(Err::<(), _>("unsupported"))
+			})
+			.unwrap();
+		drop(failed);
+		let failed = cache
+			.get_or_insert_with(1, || {
+				attempts += 1;
+				Ok::<_, ()>(Ok::<_, &str>(()))
+			})
+			.unwrap();
+
+		assert_eq!(attempts, 1);
+		assert!(failed.lock().unwrap().is_err());
+	}
 }
 
 #[cfg(target_os = "macos")]
@@ -1626,7 +1648,7 @@ pub mod d3d11 {
 		}
 
 		/// Scale to `width` x `height` on the GPU, staying on this texture's device.
-		/// The Windows path opted into by
+		/// The Windows GPU path used by
 		/// [`Frame::resize_with`](crate::Frame::resize_with).
 		///
 		/// Errors rather than falling back, so the caller decides. Two things a
@@ -1637,19 +1659,38 @@ pub mod d3d11 {
 		pub(crate) fn resize(&self, width: u32, height: u32) -> Result<Self, Error> {
 			let source = Size::new(self.width, self.height);
 			let target = Size::new(width, height);
+			let key = ScalerKey::new(&self.device, source, target);
 
 			let scaler = {
 				let mut scalers = SCALERS
 					.lock()
 					.map_err(|_| Error::Codec(anyhow::anyhow!("video-processor cache lock poisoned")))?;
-				scalers.get_or_insert_with(ScalerKey::new(&self.device, source, target), || {
-					Scaler::new(&self.device, source, target)
-				})?
+				scalers
+					.get_or_insert_with(key, || {
+						Ok::<_, std::convert::Infallible>(ScalerState::discover(&self.device, source, target))
+					})
+					.expect("scaler discovery is infallible")
 			};
-			let texture = scaler
+			let mut state = scaler
 				.lock()
-				.map_err(|_| Error::Codec(anyhow::anyhow!("video processor lock poisoned")))?
-				.scale(&self.texture)?;
+				.map_err(|_| Error::Codec(anyhow::anyhow!("video processor lock poisoned")))?;
+			let result = match &*state {
+				ScalerState::Ready(scaler) => scaler.scale(&self.texture),
+				ScalerState::Unsupported { reason, .. } => {
+					return Err(Error::Codec(anyhow::anyhow!("GPU resize is unsupported: {reason}")));
+				}
+			};
+			let texture = match result {
+				Ok(texture) => texture,
+				Err(err) => {
+					*state = ScalerState::Unsupported {
+						_device: self.device.clone(),
+						reason: err.to_string(),
+					};
+					return Err(err);
+				}
+			};
+			drop(state);
 			drop(scaler);
 			if let Ok(mut scalers) = SCALERS.lock() {
 				scalers.prune();
@@ -1672,15 +1713,37 @@ pub mod d3d11 {
 	/// and `ID3D11VideoContext` is not safe to drive from two threads at once, so
 	/// each device and scale gets one serialized processor that its ladder rungs
 	/// share.
-	static SCALERS: LazyLock<Mutex<Cache<ScalerKey, Scaler>>> =
+	static SCALERS: LazyLock<Mutex<Cache<ScalerKey, ScalerState>>> =
 		LazyLock::new(|| Mutex::new(Cache::new(SCALER_CACHE_CAPACITY)));
+
+	/// A usable scaler, or a remembered capability failure for this exact key.
+	enum ScalerState {
+		Ready(Scaler),
+		Unsupported {
+			/// Keeps the pointer in the cache key unique while this marker exists.
+			_device: ID3D11Device,
+			reason: String,
+		},
+	}
+
+	impl ScalerState {
+		fn discover(device: &ID3D11Device, source: Size, target: Size) -> Self {
+			match Scaler::new(device, source, target) {
+				Ok(scaler) => Self::Ready(scaler),
+				Err(err) => Self::Unsupported {
+					_device: device.clone(),
+					reason: err.to_string(),
+				},
+			}
+		}
+	}
 
 	/// Which device and which scale a cached processor is for.
 	///
 	/// The device is keyed by pointer because `ID3D11Device` is not hashable. That
-	/// is sound only because the cached [`Scaler`] holds a reference to the same
-	/// device: the address cannot be freed and handed to a different device while
-	/// an entry keyed on it is alive.
+	/// is sound only because every cached [`ScalerState`] holds a reference to the
+	/// same device: the address cannot be freed and handed to a different device
+	/// while an entry keyed on it is alive.
 	#[derive(Clone, PartialEq, Eq, Hash)]
 	struct ScalerKey {
 		device: usize,

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -68,6 +68,7 @@ pub mod decode;
 pub mod encode;
 #[cfg(feature = "render")]
 pub mod render;
+pub mod resize;
 
 mod color;
 mod error;

--- a/rs/moq-video/src/resize.rs
+++ b/rs/moq-video/src/resize.rs
@@ -15,11 +15,9 @@ pub struct Config {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Acceleration {
-	/// Use the stable platform default.
+	/// Use the platform default.
 	///
-	/// CUDA and macOS pixel buffers stay on the GPU. Direct3D11 textures use the
-	/// CPU because some drivers can block indefinitely when a cold video
-	/// processor first runs on a device with a live DXVA decoder.
+	/// GPU-backed surfaces stay on the GPU on every supported platform.
 	#[default]
 	Auto,
 	/// Always download GPU surfaces and scale on the CPU.

--- a/rs/moq-video/src/resize.rs
+++ b/rs/moq-video/src/resize.rs
@@ -1,0 +1,29 @@
+//! Frame resizing options.
+
+/// Options for [`Frame::resize_with`](crate::Frame::resize_with).
+///
+/// Build with `Config::default()` and set fields, so future options stay
+/// additive.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Config {
+	/// Whether to prefer GPU or CPU scaling.
+	pub acceleration: Acceleration,
+}
+
+/// Which device should scale a frame when both paths are available.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Acceleration {
+	/// Use the stable platform default.
+	///
+	/// CUDA and macOS pixel buffers stay on the GPU. Direct3D11 textures use the
+	/// CPU because some drivers can block indefinitely when a cold video
+	/// processor first runs on a device with a live DXVA decoder.
+	#[default]
+	Auto,
+	/// Always download GPU surfaces and scale on the CPU.
+	Cpu,
+	/// Scale on the GPU where supported, falling back to the CPU on an error.
+	Gpu,
+}


### PR DESCRIPTION
## Summary

- Adds a Direct3D11 video-processor path for resizing Windows NV12 textures without leaving the GPU.
- Keeps GPU-backed frames resident under the default `Auto` resize policy on Windows, macOS, and Linux.
- Adds a generic `resize::Config` with `Auto`, `Cpu`, and `Gpu` acceleration preferences. Library callers configure it with `Frame::resize_with`; the transcoder exposes `Config::resize`, and the CLI exposes `--resize-acceleration`.
- Honors forced CPU scaling in both live and fetched transcode paths. Fetched groups skip the decoder's resize path in CPU mode so the native-size frame reaches `Frame::resize_with`.
- Configures matched input/output frame rates and color spaces and disables automatic processing so scaling does not introduce deinterlacing, interpolation, denoise, sharpening, or range conversion.
- Reuses one serialized processor per device/source/target tuple through the shared bounded scaler cache. A driver capability rejection returns to CPU scaling, warns once, and remembers the unsupported key instead of retrying failed Direct3D setup every frame. Transient texture allocation and blit failures remain retryable.
- Includes `d3d11-resize-probe`, an instrumented Windows harness for reproducing the unresolved live-DXVA interaction and identifying the blocked Direct3D call. Its ladder mode keeps decode active while four resized GPU textures feed four matching Media Foundation encoders, and it fails if decode, resize, or encode stops. Its watchdog retains each thread's in-flight operation independently.

## Reproduction

A prior implementation in #2584 observed a cold `VideoProcessorBlt` blocking after DXVA started, while a processor warmed before decoder startup worked. This PR keeps D3D11 GPU resize enabled by default so the interaction remains observable rather than hidden behind an opt-in.

The dedicated probe exercises processor creation and blits before, during, and after live DXVA decode. It logs every Direct3D call, reports the in-flight operation from a watchdog, and separates modes by process because a wedged device may remain unusable. Modes that own device creation support the D3D11 debug layer. The production-shaped `crate` and `ladder` modes reject `--debug-layer` because the decoder owns its device. Tests that can deliberately wedge remain manual hardware reproducers so routine CI can still terminate. Operators can use `--resize-acceleration cpu` as an explicit diagnostic or operational fallback.

## Public API changes

Additive only, so this targets `main`.

- New `moq_video::resize::{Config, Acceleration}`.
- New `Frame::resize_with` and `Surface::resize_with`.
- New `moq_transcode::Config::resize`.
- New `moq transcode --resize-acceleration auto|cpu|gpu`.

## Test plan

Current branch:

- `nix develop --command just fix`
- `nix develop --command just check`
- `just rs test -p moq-video -p moq-transcode`: 81 passed
- `cargo clippy -p moq-video -p moq-transcode --all-targets -- -D warnings`
- `cargo check -p moq-cli --features transcode --all-targets`
- `cargo clippy -p moq-cli --features transcode --all-targets -- -D warnings`
- `cargo check -p moq-video --example d3d11-resize-probe`
- macOS VideoToolbox resize, forced-CPU resize, and re-encode tests pass on hardware.
- Hosted `Check` passed on final commit `4ac8abdbd`.

Original Windows hardware validation on Windows 11 with an RTX 3070 Ti:

- Direct3D11 default residency and pixel-agreement tests pass with GPU acceleration.
- Media Foundation decode, resize, and re-encode stays GPU-resident.
- All seven original probe modes pass, including live DXVA and a four-rung load.

The final GPU-default and ladder dataflow adjustments have not been run on a Windows host in this follow-up. PR CI does not exercise GPU hardware paths. Cross-check attempts from macOS were blocked in the vendored OpenH264 C++ build before Rust compiled the probe, so native Windows execution remains required.

## Cross-package sync

Updated `doc/lib/rs/crate/moq-video.md`, `doc/bin/cli.md`, and the `moq-transcode` README. No wire format, catalog format, FFI, or binding surface changed.

(Written by GPT-5)
