### PR TITLE
chore(js): bump package patch versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.9.8",
@@ -137,7 +137,7 @@
     },
     "js/loc": {
       "name": "@moq/loc",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@moq/net": "workspace:^",
       },
@@ -181,7 +181,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/net": "workspace:^",
@@ -219,7 +219,7 @@
     },
     "js/signals": {
       "name": "@moq/signals",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/bun": "^1.3.11",
         "@types/react": "^19.2.17",
@@ -241,7 +241,7 @@
     },
     "js/token": {
       "name": "@moq/token",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "bin": {
         "moq-token": "./src/cli.ts",
       },
@@ -264,7 +264,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/msf": "workspace:^",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/loc/package.json
+++ b/js/loc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/loc",
 	"type": "module",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Low Overhead Container (LOC) frame encoding for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/signals",
 	"type": "module",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/token",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Media over QUIC - Token Generation and Validation",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.4.3",
+	"version": "0.4.4",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

- bump seven independently versioned JavaScript packages for their unreleased fixes and compatibility updates
- keep the Bun workspace lockfile versions aligned with package manifests

## Public API changes

None. This PR only advances package versions for changes already on `main`.

## Test plan

- `nix develop --command just ci`

(Written by GPT-5)