### PR TITLE
feat(kio): add Fan, a waker for a whole WaiterList

### DIFF
--- a/rs/kio/README.md
+++ b/rs/kio/README.md
@@ -17,7 +17,10 @@ The channel auto-closes when all producers are dropped.
 `Shared` is the role-less sibling for state that both sides mutate, and `Queue` is a
 poll-native FIFO queue (bounded or unbounded) built in the same style. `Park` holds a
 waiter for as long as a poll stays pending, bridging a `std::task::Context` to kio's
-waiter-based polls when implementing `Future` or `poll_*` on top of kio channels.
+waiter-based polls when implementing `Future` or `poll_*` on top of kio channels, and
+`Fan` hands out a waker that wakes a whole waiter list, for driving a foreign future on
+behalf of everyone parked on it — either over a list it owns, or over one already inside
+a `Lock`.
 
 It's used internally by [moq-net](https://github.com/moq-dev/moq/tree/main/rs/moq-net) and friends, but is generic enough to be useful on its own.
 

--- a/rs/kio/README.md
+++ b/rs/kio/README.md
@@ -19,8 +19,8 @@ poll-native FIFO queue (bounded or unbounded) built in the same style. `Park` ho
 waiter for as long as a poll stays pending, bridging a `std::task::Context` to kio's
 waiter-based polls when implementing `Future` or `poll_*` on top of kio channels, and
 `Fan` hands out a waker that wakes a whole waiter list, for driving a foreign future on
-behalf of everyone parked on it — either over a list it owns, or over one already inside
-a `Lock`.
+behalf of everyone parked on it. It either owns the list or reaches one already inside a
+`Lock`.
 
 It's used internally by [moq-net](https://github.com/moq-dev/moq/tree/main/rs/moq-net) and friends, but is generic enough to be useful on its own.
 

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -12,6 +12,11 @@
 //! [`Queue`] is a poll-native FIFO queue built in the same style: role-less
 //! clone-able handles, bounded or unbounded, with separate wake lists for the
 //! push and pop sides.
+//!
+//! [`Fan`] hands out a [`Waker`](std::task::Waker) that wakes a whole [`WaiterList`], for
+//! driving a foreign future — one that keeps a single waker — on behalf of everyone parked
+//! on it. It either owns the list or, via [`Fan::project`], wakes one already inside a
+//! [`Lock`].
 
 use std::{
 	fmt,
@@ -44,11 +49,12 @@ mod loom;
 mod tests;
 
 pub use consumer::Consumer;
+pub use lock::{Lock, LockGuard, WeakLock};
 pub use pollable::{Pending, Pollable};
 pub use producer::{Mut, Producer, Ref};
 pub use queue::{PushError, Queue};
 pub use shared::Shared;
-pub use waiter::{Park, Waiter, WaiterList, wait};
+pub use waiter::{Fan, Hold, Park, Waiter, WaiterList, wait};
 pub use weak::{ConsumerWeak, ProducerWeak, Weak};
 
 /// The channel closed before the awaited condition held.

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -14,9 +14,8 @@
 //! push and pop sides.
 //!
 //! [`Fan`] hands out a [`Waker`](std::task::Waker) that wakes a whole [`WaiterList`], for
-//! driving a foreign future — one that keeps a single waker — on behalf of everyone parked
-//! on it. It either owns the list or, via [`Fan::project`], wakes one already inside a
-//! [`Lock`].
+//! driving a foreign future that keeps a single waker on behalf of everyone parked on it.
+//! It either owns the list or, via [`Fan::project`], wakes one already inside a [`Lock`].
 
 use std::{
 	fmt,

--- a/rs/kio/src/lock.rs
+++ b/rs/kio/src/lock.rs
@@ -10,23 +10,37 @@ use std::{
 use crate::sync::{Mutex, MutexGuard};
 
 /// A cloneable mutex wrapper backed by `Arc<Mutex<T>>`.
+///
+/// Every kio channel keeps its state in one of these, with its [`WaiterList`]s inside,
+/// so a state change and the wake it owes are decided under a single lock. [`Fan`] can
+/// hand out a [`Waker`](std::task::Waker) for one of those lists — see
+/// [`Fan::project`](crate::Fan::project).
+///
+/// Poisoning is not part of the contract: a panic while the lock is held poisons it, and
+/// every method here panics in turn rather than handing back a `Result`.
+///
+/// [`WaiterList`]: crate::WaiterList
+/// [`Fan`]: crate::Fan
 pub struct Lock<T> {
 	inner: Arc<Mutex<T>>,
 }
 
 impl<T> Lock<T> {
+	/// Wrap a value.
 	pub fn new(value: T) -> Self {
 		Self {
 			inner: Arc::new(Mutex::new(value)),
 		}
 	}
 
+	/// Lock the state, blocking until it is free. Panics if the lock was poisoned.
 	pub fn lock(&self) -> LockGuard<'_, T> {
 		LockGuard {
 			inner: self.inner.lock().expect("mutex poisoned"),
 		}
 	}
 
+	/// Whether both handles point at the same state.
 	pub fn is_clone(&self, other: &Self) -> bool {
 		Arc::ptr_eq(&self.inner, &other.inner)
 	}

--- a/rs/kio/src/lock.rs
+++ b/rs/kio/src/lock.rs
@@ -13,7 +13,7 @@ use crate::sync::{Mutex, MutexGuard};
 ///
 /// Every kio channel keeps its state in one of these, with its [`WaiterList`]s inside,
 /// so a state change and the wake it owes are decided under a single lock. [`Fan`] can
-/// hand out a [`Waker`](std::task::Waker) for one of those lists — see
+/// hand out a [`Waker`](std::task::Waker) for one of those lists. See
 /// [`Fan::project`](crate::Fan::project).
 ///
 /// Poisoning is not part of the contract: a panic while the lock is held poisons it, and

--- a/rs/kio/src/loom.rs
+++ b/rs/kio/src/loom.rs
@@ -15,7 +15,10 @@
 //!
 //! Run with `just rs loom`; `cfg(loom)` is never set in a normal build.
 
-use std::task::Poll;
+use std::{
+	sync::Arc as StdArc,
+	task::{Poll, Wake},
+};
 
 use loom::{
 	future::block_on,
@@ -27,6 +30,19 @@ use loom::{
 };
 
 use crate::{Closed, Fan, Lock, Producer, Queue, Ref, Shared, Waiter, WaiterList, wait};
+
+/// Records whether it was woken using Loom's atomic ordering model.
+struct Flag(AtomicBool);
+
+impl Wake for Flag {
+	fn wake(self: StdArc<Self>) {
+		self.wake_by_ref();
+	}
+
+	fn wake_by_ref(self: &StdArc<Self>) {
+		self.0.store(true, Ordering::SeqCst);
+	}
+}
 
 /// Ready once the value equals `n`.
 fn equals(n: u32) -> impl FnMut(&Ref<'_, u32>) -> Poll<()> + Unpin {
@@ -280,20 +296,6 @@ fn a_held_wake_is_never_lost() {
 #[test]
 fn a_hold_covers_a_wake_waiting_for_the_list() {
 	loom::model(|| {
-		use std::sync::Arc as StdArc;
-
-		struct Flag(AtomicBool);
-
-		impl std::task::Wake for Flag {
-			fn wake(self: StdArc<Self>) {
-				self.wake_by_ref();
-			}
-
-			fn wake_by_ref(self: &StdArc<Self>) {
-				self.0.store(true, Ordering::SeqCst);
-			}
-		}
-
 		let state = Lock::new(WaiterList::new());
 		let fan = Fan::project(&state, |waiters| waiters);
 		let flag = StdArc::new(Flag(AtomicBool::new(false)));
@@ -311,6 +313,28 @@ fn a_hold_covers_a_wake_waiting_for_the_list() {
 		waking.join().unwrap();
 		assert!(!flag.0.load(Ordering::SeqCst), "wake escaped a live hold");
 
+		drop(hold);
+		assert!(flag.0.load(Ordering::SeqCst), "deferred wake never arrived");
+	});
+}
+
+/// A projected fan must see a hold before it tries to reacquire the projected state.
+/// An inline wake runs on the thread already holding that state lock.
+#[test]
+fn a_projected_hold_defers_before_relocking() {
+	loom::model(|| {
+		let state = Lock::new(WaiterList::new());
+		let fan = Fan::project(&state, |waiters| waiters);
+		let flag = StdArc::new(Flag(AtomicBool::new(false)));
+		let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+		waiter.register(&mut state.lock());
+
+		let state_guard = state.lock();
+		let hold = fan.hold();
+		fan.wake();
+		assert!(!flag.0.load(Ordering::SeqCst), "wake escaped a live hold");
+
+		drop(state_guard);
 		drop(hold);
 		assert!(flag.0.load(Ordering::SeqCst), "deferred wake never arrived");
 	});

--- a/rs/kio/src/loom.rs
+++ b/rs/kio/src/loom.rs
@@ -26,7 +26,7 @@ use loom::{
 	thread,
 };
 
-use crate::{Closed, Fan, Producer, Queue, Ref, Shared, wait};
+use crate::{Closed, Fan, Lock, Producer, Queue, Ref, Shared, Waiter, WaiterList, wait};
 
 /// Ready once the value equals `n`.
 fn equals(n: u32) -> impl FnMut(&Ref<'_, u32>) -> Poll<()> + Unpin {
@@ -271,5 +271,47 @@ fn a_held_wake_is_never_lost() {
 		}));
 
 		waker.join().unwrap();
+	});
+}
+
+/// A wake blocked on the projected list must recheck the hold after it acquires the
+/// list lock. Otherwise it can pass the deferral check, stall on the list, and deliver
+/// while a hold created in that window is still live.
+#[test]
+fn a_hold_covers_a_wake_waiting_for_the_list() {
+	loom::model(|| {
+		use std::sync::Arc as StdArc;
+
+		struct Flag(AtomicBool);
+
+		impl std::task::Wake for Flag {
+			fn wake(self: StdArc<Self>) {
+				self.wake_by_ref();
+			}
+
+			fn wake_by_ref(self: &StdArc<Self>) {
+				self.0.store(true, Ordering::SeqCst);
+			}
+		}
+
+		let state = Lock::new(WaiterList::new());
+		let fan = Fan::project(&state, |waiters| waiters);
+		let flag = StdArc::new(Flag(AtomicBool::new(false)));
+		let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+		waiter.register(&mut state.lock());
+
+		let state_guard = state.lock();
+		let waking = thread::spawn({
+			let fan = fan.clone();
+			move || fan.wake()
+		});
+
+		let hold = fan.hold();
+		drop(state_guard);
+		waking.join().unwrap();
+		assert!(!flag.0.load(Ordering::SeqCst), "wake escaped a live hold");
+
+		drop(hold);
+		assert!(flag.0.load(Ordering::SeqCst), "deferred wake never arrived");
 	});
 }

--- a/rs/kio/src/loom.rs
+++ b/rs/kio/src/loom.rs
@@ -17,9 +17,16 @@
 
 use std::task::Poll;
 
-use loom::{future::block_on, thread};
+use loom::{
+	future::block_on,
+	sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	},
+	thread,
+};
 
-use crate::{Closed, Producer, Queue, Ref, Shared};
+use crate::{Closed, Fan, Producer, Queue, Ref, Shared, wait};
 
 /// Ready once the value equals `n`.
 fn equals(n: u32) -> impl FnMut(&Ref<'_, u32>) -> Poll<()> + Unpin {
@@ -227,5 +234,42 @@ fn queue_close_wakes_a_parked_pop() {
 
 		assert_eq!(block_on(queue.pop()), Err(Closed), "the close was lost");
 		close.join().unwrap();
+	});
+}
+
+/// `Fan` holds wakes back while a guard is out and delivers them when the last
+/// one drops. A wake racing that window must still reach the parked waiter, whichever
+/// side of the hold it lands on.
+#[test]
+fn a_held_wake_is_never_lost() {
+	loom::model(|| {
+		let fan = Fan::new();
+		let ready = Arc::new(AtomicBool::new(false));
+
+		let waker = {
+			let fan = fan.clone();
+			let ready = ready.clone();
+
+			thread::spawn(move || {
+				let hold = fan.hold();
+				ready.store(true, Ordering::SeqCst);
+				fan.wake();
+				// The deferred wake is delivered here.
+				drop(hold);
+			})
+		};
+
+		// Register before reading `ready`: the other order has a window where the store
+		// and the wake both land between the read and the registration.
+		block_on(wait(|waiter| {
+			fan.register(waiter);
+
+			match ready.load(Ordering::SeqCst) {
+				true => Poll::Ready(()),
+				false => Poll::Pending,
+			}
+		}));
+
+		waker.join().unwrap();
 	});
 }

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -274,7 +274,7 @@ enum Target<T> {
 	Owned(Lock<T>),
 
 	/// It belongs to state someone else owns. Weak on purpose: that state routinely
-	/// holds the fan's waker — the future being polled with it usually lives there —
+	/// holds the fan's waker (the future being polled with it usually lives there),
 	/// and a strong handle would make that a cycle.
 	Projected(WeakLock<T>),
 }
@@ -311,21 +311,20 @@ struct Defer {
 
 impl<T> FanInner<T> {
 	fn notify(&self) {
-		{
-			let mut defer = self.defer.lock().expect("mutex poisoned");
-			if defer.held > 0 {
-				defer.owed = true;
-				return;
-			}
-		}
-
 		// Gone already: whatever was parked went with it.
 		let Some(lock) = self.target.upgrade() else {
 			return;
 		};
 
 		let mut waiters = {
+			// Check the hold only after taking the target lock. A wake blocked on that
+			// lock must observe any hold created while it was waiting.
 			let mut state = lock.lock();
+			let mut defer = self.defer.lock().expect("mutex poisoned");
+			if defer.held > 0 {
+				defer.owed = true;
+				return;
+			}
 			(self.project)(&mut state).take()
 		};
 
@@ -360,7 +359,7 @@ impl<T: Send + 'static> Fan<T> {
 	/// A fan over a [`WaiterList`] that lives inside `state`.
 	///
 	/// One lock and one list: parking stays a plain `&mut` call on that list wherever
-	/// the state is already locked, and this supplies only what a `WaiterList` cannot —
+	/// the state is already locked, and this supplies only what a `WaiterList` cannot:
 	/// a [`Waker`] of its own, and [`hold`](Self::hold).
 	///
 	/// The reference is weak, so `state` may hold this fan (or its waker) without
@@ -385,7 +384,7 @@ impl<T: Send + 'static> Fan<T> {
 	/// caller that gives up releases its slot by dropping.
 	///
 	/// This takes the lock the list lives under, so a *projected* fan cannot use it from
-	/// inside that lock — park on the list directly there, which is the point of
+	/// inside that lock. Park on the list directly there, which is the point of
 	/// [`project`](Self::project).
 	pub fn register(&self, waiter: &Waiter) {
 		if let Some(lock) = self.inner.target.upgrade() {
@@ -415,7 +414,7 @@ impl<T: Send + 'static> Fan<T> {
 	///
 	/// For polling a foreign future with [`waker`](Self::waker) while holding a lock that
 	/// the parked waiters will take when they resume. Such a future can wake its waker
-	/// *inline* — `FuturesUnordered`, for one, notifies its parent from a child's `wake` —
+	/// *inline* (`FuturesUnordered`, for one, notifies its parent from a child's `wake`),
 	/// and delivering that would resume a waiter straight into the lock the waker fired
 	/// under.
 	///

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -3,12 +3,18 @@ use std::{
 	future::Future,
 	marker::PhantomData,
 	pin::Pin,
-	// std, not `crate::sync`: loom's Arc has no `downgrade`. See `sync.rs`.
+	// std, not `crate::sync`: loom's Arc has no `downgrade`, and `Waker::from` takes
+	// std's. See `sync.rs`.
 	sync::{Arc, OnceLock, Weak},
-	task::{Context, Poll, Waker},
+	task::{Context, Poll, Wake, Waker},
 };
 
 use smallvec::SmallVec;
+
+use crate::{
+	lock::{Lock, WeakLock},
+	sync::Mutex,
+};
 
 /// Number of slots stored inline before spilling to the heap.
 const INLINE_WAITERS: usize = 32;
@@ -240,6 +246,247 @@ impl fmt::Debug for Park {
 	}
 }
 
+/// A [`WaiterList`] that is shared, and that a [`Waker`] can wake.
+///
+/// A plain [`WaiterList`] is a field, woken by whoever owns the state around it. That is
+/// enough until the thing being waited on is a *foreign* future, which takes a `Waker`
+/// and keeps exactly one. Hand it a caller's waker and the most recent caller owns the
+/// wakeup for everybody: when that one walks away the notification goes nowhere, while
+/// the others sit parked with live registrations. Poll such a future with
+/// [`waker`](Self::waker) instead. It outlives every caller, and waking it fans out to
+/// the whole list.
+///
+/// Two shapes, depending on where the list should live:
+///
+/// - [`new`](Fan::new) owns one, for a caller whose state is behind its own lock.
+/// - [`project`](Self::project) reaches into a list already inside a [`Lock`], so there
+///   is one lock and one list rather than two. Prefer it when the state is a `Lock`.
+///
+/// Role-less and cloneable like [`Queue`](crate::Queue): every handle can wake or hand
+/// out the waker.
+pub struct Fan<T = WaiterList> {
+	inner: Arc<FanInner<T>>,
+}
+
+/// Where the list a [`Fan`] wakes actually lives.
+enum Target<T> {
+	/// The fan owns it.
+	Owned(Lock<T>),
+
+	/// It belongs to state someone else owns. Weak on purpose: that state routinely
+	/// holds the fan's waker — the future being polled with it usually lives there —
+	/// and a strong handle would make that a cycle.
+	Projected(WeakLock<T>),
+}
+
+impl<T> Target<T> {
+	fn upgrade(&self) -> Option<Lock<T>> {
+		match self {
+			Self::Owned(lock) => Some(lock.clone()),
+			Self::Projected(weak) => weak.upgrade(),
+		}
+	}
+}
+
+struct FanInner<T> {
+	target: Target<T>,
+
+	/// Reaches the list inside `T`. Identity when the fan owns a bare [`WaiterList`].
+	project: fn(&mut T) -> &mut WaiterList,
+
+	/// Deferral state, under a lock of its own. It cannot ride along inside the list's
+	/// state, because a projected fan does not own that state's layout.
+	defer: Mutex<Defer>,
+}
+
+#[derive(Default)]
+struct Defer {
+	/// How many [`Hold`]s are outstanding. While this is non-zero a wake is recorded
+	/// rather than delivered.
+	held: usize,
+
+	/// A wake arrived while held, and is still owed to the list.
+	owed: bool,
+}
+
+impl<T> FanInner<T> {
+	fn notify(&self) {
+		{
+			let mut defer = self.defer.lock().expect("mutex poisoned");
+			if defer.held > 0 {
+				defer.owed = true;
+				return;
+			}
+		}
+
+		// Gone already: whatever was parked went with it.
+		let Some(lock) = self.target.upgrade() else {
+			return;
+		};
+
+		let mut waiters = {
+			let mut state = lock.lock();
+			(self.project)(&mut state).take()
+		};
+
+		// Outside both locks: a waker may resume its task inline, and a resumed waiter's
+		// first move is to take the lock its list lives under.
+		waiters.wake();
+	}
+}
+
+impl<T: Send + 'static> Wake for FanInner<T> {
+	fn wake(self: Arc<Self>) {
+		self.notify();
+	}
+
+	fn wake_by_ref(self: &Arc<Self>) {
+		self.notify();
+	}
+}
+
+impl Fan<WaiterList> {
+	/// Create a fan that owns its list.
+	///
+	/// For a caller whose own state is not a [`Lock`]. When it is, prefer
+	/// [`project`](Self::project): it wakes a list already in there, instead of adding a
+	/// second list behind a second lock.
+	pub fn new() -> Self {
+		Self::build(Target::Owned(Lock::new(WaiterList::new())), |list| list)
+	}
+}
+
+impl<T: Send + 'static> Fan<T> {
+	/// A fan over a [`WaiterList`] that lives inside `state`.
+	///
+	/// One lock and one list: parking stays a plain `&mut` call on that list wherever
+	/// the state is already locked, and this supplies only what a `WaiterList` cannot —
+	/// a [`Waker`] of its own, and [`hold`](Self::hold).
+	///
+	/// The reference is weak, so `state` may hold this fan (or its waker) without
+	/// leaking itself. Once `state` is dropped, waking is a no-op.
+	pub fn project(state: &Lock<T>, project: fn(&mut T) -> &mut WaiterList) -> Self {
+		Self::build(Target::Projected(state.downgrade()), project)
+	}
+
+	fn build(target: Target<T>, project: fn(&mut T) -> &mut WaiterList) -> Self {
+		Self {
+			inner: Arc::new(FanInner {
+				target,
+				project,
+				defer: Mutex::new(Defer::default()),
+			}),
+		}
+	}
+
+	/// Park a waiter until the next wake.
+	///
+	/// The registration is weak and owned by the waiter, exactly as in [`WaiterList`]: a
+	/// caller that gives up releases its slot by dropping.
+	///
+	/// This takes the lock the list lives under, so a *projected* fan cannot use it from
+	/// inside that lock — park on the list directly there, which is the point of
+	/// [`project`](Self::project).
+	pub fn register(&self, waiter: &Waiter) {
+		if let Some(lock) = self.inner.target.upgrade() {
+			let mut state = lock.lock();
+			waiter.register((self.inner.project)(&mut state));
+		}
+	}
+
+	/// Wake every parked waiter, draining the list.
+	///
+	/// Records the wake instead while a [`hold`](Self::hold) is outstanding. Takes the
+	/// list's lock, so the same caveat as [`register`](Self::register) applies.
+	pub fn wake(&self) {
+		self.inner.notify();
+	}
+
+	/// A [`Waker`] that wakes every parked waiter.
+	///
+	/// Cache it rather than building one per poll: a foreign future compares the waker it
+	/// was given against the new one with `will_wake` to decide whether to re-register,
+	/// and a fresh handle each time defeats that.
+	pub fn waker(&self) -> Waker {
+		Waker::from(self.inner.clone())
+	}
+
+	/// Hold back wakes until the returned guard drops.
+	///
+	/// For polling a foreign future with [`waker`](Self::waker) while holding a lock that
+	/// the parked waiters will take when they resume. Such a future can wake its waker
+	/// *inline* — `FuturesUnordered`, for one, notifies its parent from a child's `wake` —
+	/// and delivering that would resume a waiter straight into the lock the waker fired
+	/// under.
+	///
+	/// **Drop the guard once that lock is released, not before**: the deferred wake is
+	/// delivered where the guard drops, so dropping it early puts the hazard back. Nested
+	/// holds are fine, and only the last one out delivers.
+	#[must_use = "wakes are held back only while the guard is alive"]
+	pub fn hold(&self) -> Hold<T> {
+		self.inner.defer.lock().expect("mutex poisoned").held += 1;
+
+		Hold { fan: self.clone() }
+	}
+}
+
+impl Default for Fan<WaiterList> {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl<T> Clone for Fan<T> {
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+		}
+	}
+}
+
+impl<T> fmt::Debug for Fan<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let defer = self.inner.defer.lock().expect("mutex poisoned");
+		f.debug_struct("Fan")
+			.field("held", &defer.held)
+			.field("owed", &defer.owed)
+			.finish_non_exhaustive()
+	}
+}
+
+/// Defers wakes on a [`Fan`] until dropped. Created by [`Fan::hold`].
+pub struct Hold<T = WaiterList> {
+	fan: Fan<T>,
+}
+
+impl<T> Drop for Hold<T> {
+	fn drop(&mut self) {
+		let owed = {
+			let mut defer = self.fan.inner.defer.lock().expect("mutex poisoned");
+			defer.held -= 1;
+
+			// Still held by someone else: the wake stays owed, and the last one out
+			// delivers it.
+			match defer.held {
+				0 => std::mem::take(&mut defer.owed),
+				_ => false,
+			}
+		};
+
+		if owed {
+			// `notify`, not `wake`: `Drop` may not ask for bounds the struct does not
+			// carry, and the notify path needs none.
+			self.fan.inner.notify();
+		}
+	}
+}
+
+impl<T> fmt::Debug for Hold<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("Hold").finish_non_exhaustive()
+	}
+}
+
 /// Future that drives a poll function, managing waiter lifetime across polls.
 struct WaiterFn<F, R> {
 	poll: F,
@@ -280,6 +527,132 @@ where
 #[cfg(all(test, not(loom)))]
 mod tests {
 	use super::*;
+
+	/// A waker that records whether it fired.
+	#[derive(Default)]
+	struct Flag(std::sync::atomic::AtomicBool);
+
+	impl Flag {
+		fn woken(&self) -> bool {
+			self.0.load(std::sync::atomic::Ordering::SeqCst)
+		}
+	}
+
+	impl Wake for Flag {
+		fn wake(self: Arc<Self>) {
+			self.wake_by_ref();
+		}
+
+		fn wake_by_ref(self: &Arc<Self>) {
+			self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+		}
+	}
+
+	fn flagged(fan: &Fan) -> (Arc<Flag>, Waiter) {
+		let flag = Arc::new(Flag::default());
+		let waiter = Waiter::new(Waker::from(flag.clone()));
+		fan.register(&waiter);
+
+		// The waiter goes back to the caller: the registration is weak, and dies with it.
+		(flag, waiter)
+	}
+
+	#[test]
+	fn the_waker_fans_out_to_everyone_parked() {
+		let fan = Fan::new();
+		let (first, _first_waiter) = flagged(&fan);
+		let (second, _second_waiter) = flagged(&fan);
+
+		fan.waker().wake();
+
+		assert!(first.woken() && second.woken(), "one wake must reach every waiter");
+	}
+
+	#[test]
+	fn a_departed_waiter_releases_its_slot() {
+		let fan = Fan::new();
+		let (gone, waiter) = flagged(&fan);
+		drop(waiter);
+
+		let (live, _live_waiter) = flagged(&fan);
+		fan.wake();
+
+		assert!(live.woken());
+		assert!(!gone.woken(), "a dropped waiter should have no registration left");
+	}
+
+	/// Waking while holding the fan's own lock deadlocks the moment a waker resumes its
+	/// task inline, because a resumed waiter registers again.
+	#[test]
+	fn waking_does_not_hold_the_lock() {
+		struct Reentrant(Fan);
+
+		impl Wake for Reentrant {
+			fn wake(self: Arc<Self>) {
+				self.wake_by_ref();
+			}
+
+			fn wake_by_ref(self: &Arc<Self>) {
+				self.0.register(&Waiter::noop());
+			}
+		}
+
+		let fan = Fan::new();
+		let waiter = Waiter::new(Waker::from(Arc::new(Reentrant(fan.clone()))));
+		fan.register(&waiter);
+
+		// On a deadlock this thread never finishes, so the test cannot hang.
+		let (tx, rx) = std::sync::mpsc::channel();
+		std::thread::spawn({
+			let fan = fan.clone();
+			move || {
+				fan.wake();
+				let _ = tx.send(());
+			}
+		});
+
+		rx.recv_timeout(std::time::Duration::from_secs(5))
+			.expect("wake reached a waker while holding the lock, and the wake re-entered it");
+	}
+
+	#[test]
+	fn a_held_wake_lands_when_the_hold_drops() {
+		let fan = Fan::new();
+		let (flag, _waiter) = flagged(&fan);
+
+		let hold = fan.hold();
+		fan.wake();
+		assert!(!flag.woken(), "the wake was delivered while the fan was held");
+
+		drop(hold);
+		assert!(flag.woken(), "the held wake never arrived");
+	}
+
+	#[test]
+	fn only_the_last_hold_out_delivers() {
+		let fan = Fan::new();
+		let (flag, _waiter) = flagged(&fan);
+
+		let outer = fan.hold();
+		let inner = fan.hold();
+		fan.wake();
+
+		drop(inner);
+		assert!(!flag.woken(), "a hold is still outstanding");
+
+		drop(outer);
+		assert!(flag.woken());
+	}
+
+	#[test]
+	fn a_quiet_hold_wakes_nobody() {
+		let fan = Fan::new();
+		let (flag, _waiter) = flagged(&fan);
+
+		drop(fan.hold());
+
+		assert!(!flag.woken(), "nothing woke, so nothing was owed");
+	}
 
 	#[test]
 	fn poll_future_bridges_a_std_future() {
@@ -447,5 +820,71 @@ mod tests {
 		let mut fut = std::pin::pin!(crate::wait(|_| Poll::Ready(NotUnpin(std::marker::PhantomPinned))));
 		let mut cx = Context::from_waker(Waker::noop());
 		assert!(fut.as_mut().poll(&mut cx).is_ready());
+	}
+
+	/// The point of projecting: one lock, one list. Parking happens on the list inside
+	/// the state, and the fan's waker still reaches it.
+	#[test]
+	fn a_projected_fan_wakes_the_list_inside_the_state() {
+		#[derive(Default)]
+		struct State {
+			waiters: WaiterList,
+			other: WaiterList,
+		}
+
+		let state = Lock::new(State::default());
+		let fan = Fan::project(&state, |s| &mut s.waiters);
+
+		let flag = Arc::new(Flag::default());
+		let waiter = Waiter::new(Waker::from(flag.clone()));
+
+		// Parked directly on the list, as a caller already holding the lock would.
+		waiter.register(&mut state.lock().waiters);
+
+		let bystander = Arc::new(Flag::default());
+		let bystander_waiter = Waiter::new(Waker::from(bystander.clone()));
+		bystander_waiter.register(&mut state.lock().other);
+
+		fan.waker().wake();
+
+		assert!(flag.woken(), "the projected list was not woken");
+		assert!(!bystander.woken(), "only the projected list should be woken");
+	}
+
+	/// A projected fan is weak, so the state it points at can hold the fan (or its
+	/// waker) without leaking. Waking after that state is gone does nothing.
+	#[test]
+	fn a_projected_fan_outlives_its_state_harmlessly() {
+		let state = Lock::new(WaiterList::new());
+		let fan = Fan::project(&state, |list| list);
+
+		let flag = Arc::new(Flag::default());
+		let waiter = Waiter::new(Waker::from(flag.clone()));
+		waiter.register(&mut state.lock());
+
+		drop(state);
+
+		// No panic, and nothing to wake: the list went with the state.
+		fan.wake();
+		fan.waker().wake();
+		assert!(!flag.woken());
+	}
+
+	/// Deferral is the same either way round.
+	#[test]
+	fn a_projected_fan_defers_a_held_wake() {
+		let state = Lock::new(WaiterList::new());
+		let fan = Fan::project(&state, |list| list);
+
+		let flag = Arc::new(Flag::default());
+		let waiter = Waiter::new(Waker::from(flag.clone()));
+		waiter.register(&mut state.lock());
+
+		let hold = fan.hold();
+		fan.wake();
+		assert!(!flag.woken(), "the wake was delivered while the fan was held");
+
+		drop(hold);
+		assert!(flag.woken(), "the held wake never arrived");
 	}
 }

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -310,21 +310,39 @@ struct Defer {
 }
 
 impl<T> FanInner<T> {
+	fn defer_if_held(&self) -> bool {
+		let mut defer = self.defer.lock().expect("mutex poisoned");
+		if defer.held == 0 {
+			return false;
+		}
+
+		defer.owed = true;
+		true
+	}
+
 	fn notify(&self) {
+		// A projected fan can wake inline while the caller holds the target lock.
+		if self.defer_if_held() {
+			return;
+		}
+
 		// Gone already: whatever was parked went with it.
 		let Some(lock) = self.target.upgrade() else {
 			return;
 		};
 
 		let mut waiters = {
-			// Check the hold only after taking the target lock. A wake blocked on that
-			// lock must observe any hold created while it was waiting.
 			let mut state = lock.lock();
+
+			// A wake can block on the target after the first check. Recheck while the
+			// target is locked, and keep both locks through the drain, so a hold
+			// created in that window defers it.
 			let mut defer = self.defer.lock().expect("mutex poisoned");
 			if defer.held > 0 {
 				defer.owed = true;
 				return;
 			}
+
 			(self.project)(&mut state).take()
 		};
 


### PR DESCRIPTION
## Summary

- Add `Fan<T>`, a cloneable owner or projection of a `WaiterList` that exposes one stable `Waker` for polling a foreign future on behalf of every parked caller.
- Add `Hold<T>`, which records wakes while a caller is polling that foreign future under a lock, then delivers the deferred wake after the last hold drops.
- Keep projected fans weak so state can retain the fan or its waker without creating a reference cycle.
- Fix two opposing lock-order races found during review. `notify` first checks for a hold before acquiring projected state, which lets an inline wake defer instead of self-deadlocking on the caller's lock. It then re-checks under the target lock and keeps the deferral guard through the waiter drain, which covers a hold created while the wake was blocked on that target. User wakers are still invoked after both locks are released.
- Document the new primitive and remove prohibited em dashes from the changed prose.

## Public API changes

- Add `Fan<T = WaiterList>` with `new`, `project`, `register`, `wake`, `waker`, and `hold`.
- Add the `Hold<T = WaiterList>` guard returned by `Fan::hold`.
- Export the existing `Lock`, `LockGuard`, and `WeakLock` types required by `Fan::project`.

All changes are additive and target `main`.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just rs loom`: 15 kio models and 5 moq-net models passed.
- Mutation checks: the blocked-target model fails on the original ordering with `wake escaped a live hold`; the projected inline-wake model deadlocks when the pre-lock check is removed. Both pass with the two-phase fix.
- `nix develop --command just ci`: dependency policy, clippy, docs with warnings denied, and all 2,545 tests passed. The final flake evaluation then hit an unrelated host-toolchain limitation because Nixpkgs 26.11 dropped `x86_64-darwin`, which the current flake still evaluates. Fresh GitHub CI is required before merge.

No cross-package update is needed because this adds a runtime-independent kio primitive without changing a wire format or binding surface.

(Written by Opus 5 and GPT-5)
