### PR TITLE
fix(moq-net): suppress cached group drop warnings

### DIFF
--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -222,26 +222,52 @@ pub struct Producer {
 	// [`Self::with_meter`]. Empty (no-op) for an untagged group.
 	stats: stats::Meter,
 
-	// Shared by every clone: its `Drop` is the abrupt-teardown, running exactly once
-	// when the last of them goes.
-	alive: Arc<Alive>,
+	// Shared teardown state tagged with this handle's ownership role.
+	liveness: Liveness,
 }
 
-/// Ends the group when the last [`Producer`] clone drops, including the clone the
-/// parent track holds in its cache.
-///
-/// A refcount rather than a "am I the last one?" check inside `Drop`: that answer is
-/// a snapshot, and acting on it is exactly what can invalidate it. Holding a producer
-/// of its own also keeps the state writable until the teardown has run, whatever order
-/// the last owner's fields drop in.
+#[derive(Clone, Copy)]
+enum Role {
+	Publisher,
+	Cache,
+}
+
+/// Runs teardown with the role of whichever handle releases the final reference.
+struct Liveness {
+	alive: Option<Arc<Alive>>,
+	role: Role,
+}
+
+impl Liveness {
+	fn new(alive: Arc<Alive>, role: Role) -> Self {
+		Self {
+			alive: Some(alive),
+			role,
+		}
+	}
+
+	fn clone_as(&self, role: Role) -> Self {
+		Self::new(self.alive.as_ref().expect("a live handle owns its guard").clone(), role)
+	}
+}
+
+impl Drop for Liveness {
+	fn drop(&mut self) {
+		let alive = self.alive.take().expect("a live handle owns its guard");
+		if let Some(alive) = Arc::into_inner(alive) {
+			alive.teardown(self.role);
+		}
+	}
+}
+
+/// Shared state used when the final publisher or cache handle tears down the group.
 struct Alive {
 	info: Info,
 	state: kio::Producer<GroupState>,
-	warn_on_drop: bool,
 }
 
-impl Drop for Alive {
-	fn drop(&mut self) {
+impl Alive {
+	fn teardown(self, role: Role) {
 		// See track::Alive: the last producer dropping without a clean finish releases
 		// the cached frames so a stale consumer can't pin their buffers forever. A
 		// finished group keeps its cache so consumers can drain.
@@ -252,7 +278,7 @@ impl Drop for Alive {
 				if state.fin.is_some() || state.abort.is_some() {
 					return;
 				}
-				if self.warn_on_drop {
+				if matches!(role, Role::Publisher) {
 					tracing::warn!(
 						sequence = self.info.sequence,
 						"group::Producer dropped without finish() or abort()"
@@ -264,7 +290,7 @@ impl Drop for Alive {
 				if state.fin.is_some() || state.abort.is_some() {
 					return;
 				}
-				if self.warn_on_drop {
+				if matches!(role, Role::Publisher) {
 					tracing::warn!(
 						sequence = self.info.sequence,
 						"group::Producer dropped without finish() or abort()"
@@ -300,7 +326,6 @@ impl Producer {
 		let alive = Arc::new(Alive {
 			info,
 			state: state.clone(),
-			warn_on_drop: true,
 		});
 		Self {
 			info,
@@ -308,7 +333,7 @@ impl Producer {
 			track,
 			cache,
 			stats: stats::Meter::default(),
-			alive,
+			liveness: Liveness::new(alive, Role::Publisher),
 		}
 	}
 
@@ -325,14 +350,20 @@ impl Producer {
 		self.info
 	}
 
-	/// Drop the cache's handle, suppressing its unfinished warning if it is final.
-	pub(crate) fn drop_cached(self) {
-		let Self { alive, .. } = self;
-		if let Some(mut alive) = Arc::into_inner(alive) {
-			// Only the final strong handle can enter here, so a concurrent publisher
-			// drop still owns and reports its own unfinished teardown.
-			alive.warn_on_drop = false;
+	fn clone_as(&self, role: Role) -> Self {
+		Self {
+			info: self.info,
+			state: self.state.clone(),
+			track: self.track.clone(),
+			cache: self.cache.clone(),
+			stats: self.stats.clone(),
+			liveness: self.liveness.clone_as(role),
 		}
+	}
+
+	/// Clone a handle owned by the parent track's cache.
+	pub(crate) fn clone_cached(&self) -> Self {
+		self.clone_as(Role::Cache)
 	}
 
 	/// The parent track's timescale.
@@ -549,14 +580,7 @@ impl Producer {
 
 impl Clone for Producer {
 	fn clone(&self) -> Self {
-		Self {
-			info: self.info,
-			state: self.state.clone(),
-			track: self.track.clone(),
-			cache: self.cache.clone(),
-			stats: self.stats.clone(),
-			alive: self.alive.clone(),
-		}
+		self.clone_as(Role::Publisher)
 	}
 }
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -237,6 +237,7 @@ pub struct Producer {
 struct Alive {
 	info: Info,
 	state: kio::Producer<GroupState>,
+	warn_on_drop: bool,
 }
 
 impl Drop for Alive {
@@ -251,20 +252,24 @@ impl Drop for Alive {
 				if state.fin.is_some() || state.abort.is_some() {
 					return;
 				}
-				tracing::warn!(
-					sequence = self.info.sequence,
-					"group::Producer dropped without finish() or abort()"
-				);
+				if self.warn_on_drop {
+					tracing::warn!(
+						sequence = self.info.sequence,
+						"group::Producer dropped without finish() or abort()"
+					);
+				}
 				state.release();
 			}
 			Err(state) => {
 				if state.fin.is_some() || state.abort.is_some() {
 					return;
 				}
-				tracing::warn!(
-					sequence = self.info.sequence,
-					"group::Producer dropped without finish() or abort()"
-				);
+				if self.warn_on_drop {
+					tracing::warn!(
+						sequence = self.info.sequence,
+						"group::Producer dropped without finish() or abort()"
+					);
+				}
 			}
 		}
 	}
@@ -295,6 +300,7 @@ impl Producer {
 		let alive = Arc::new(Alive {
 			info,
 			state: state.clone(),
+			warn_on_drop: true,
 		});
 		Self {
 			info,
@@ -317,6 +323,16 @@ impl Producer {
 	/// The group header.
 	pub(crate) fn info(&self) -> Info {
 		self.info
+	}
+
+	/// Drop the cache's handle, suppressing its unfinished warning if it is final.
+	pub(crate) fn drop_cached(self) {
+		let Self { alive, .. } = self;
+		if let Some(mut alive) = Arc::into_inner(alive) {
+			// Only the final strong handle can enter here, so a concurrent publisher
+			// drop still owns and reports its own unfinished teardown.
+			alive.warn_on_drop = false;
+		}
 	}
 
 	/// The parent track's timescale.
@@ -985,6 +1001,16 @@ mod test {
 			drop(keep);
 		});
 		assert_eq!(warns, 0, "abort-then-drop must not emit unfinished-producer WARN");
+	}
+
+	#[test]
+	fn drop_after_unmarked_close_warns() {
+		let warns = count_drop_warnings("group::Producer dropped without finish", || {
+			let producer = Info { sequence: 0 }.produce();
+			assert!(producer.state.close().is_ok());
+			drop(producer);
+		});
+		assert_eq!(warns, 1, "a closed group without a terminal marker must warn");
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -560,9 +560,7 @@ impl TrackState {
 	/// Drop every cached group and reset the eviction bookkeeping. Each group's
 	/// access sample lives in its own charge, released when the group itself dies.
 	fn clear_cache(&mut self) {
-		for (_, slot) in self.lookup.drain() {
-			slot.group.drop_cached();
-		}
+		self.lookup.clear();
 		self.arrival.clear();
 		self.evict.clear();
 		self.latest_group = None;
@@ -644,7 +642,7 @@ impl TrackState {
 		self.lookup.insert(
 			sequence,
 			Slot {
-				group: group.clone(),
+				group: group.clone_cached(),
 				stamp,
 			},
 		);

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -560,7 +560,9 @@ impl TrackState {
 	/// Drop every cached group and reset the eviction bookkeeping. Each group's
 	/// access sample lives in its own charge, released when the group itself dies.
 	fn clear_cache(&mut self) {
-		self.lookup.clear();
+		for (_, slot) in self.lookup.drain() {
+			slot.group.drop_cached();
+		}
 		self.arrival.clear();
 		self.evict.clear();
 		self.latest_group = None;
@@ -3414,8 +3416,8 @@ mod test {
 
 	#[tokio::test]
 	async fn drop_after_abort_does_not_warn() {
-		// abort() closes the channel after recording `abort`. Drop must treat the
-		// read-only guard returned by write() as clean or it emits a false WARN.
+		// abort() records its terminal marker before closing the channel, so the
+		// read-only guard returned by write() represents a deliberate teardown.
 		let warns = count_drop_warnings("track::Producer dropped without finish", || {
 			let producer = track_producer("test", None);
 			let keep = producer.clone();
@@ -3427,6 +3429,47 @@ mod test {
 			drop(keep);
 		});
 		assert_eq!(warns, 0, "abort-then-drop must not emit unfinished-producer WARN");
+	}
+
+	#[test]
+	fn abort_with_cached_unfinished_group_does_not_warn() {
+		let warns = count_drop_warnings("group::Producer dropped without finish", || {
+			let mut producer = track_producer("test", None);
+			producer.append_group().unwrap();
+			producer.abort(Error::Cancel).unwrap();
+		});
+		assert_eq!(warns, 0, "track abort must not blame its cache-owned group");
+	}
+
+	#[test]
+	fn abort_does_not_suppress_a_live_unfinished_group() {
+		let warns = count_drop_warnings("group::Producer dropped without finish", || {
+			let mut producer = track_producer("test", None);
+			let group = producer.append_group().unwrap();
+			producer.abort(Error::Cancel).unwrap();
+			drop(group);
+		});
+		assert_eq!(warns, 1, "a surviving unfinished group producer must still warn");
+	}
+
+	#[test]
+	fn unfinished_track_drop_does_not_duplicate_the_group_warning() {
+		let warns = count_drop_warnings("group::Producer dropped without finish", || {
+			let mut producer = track_producer("test", None);
+			producer.append_group().unwrap();
+			drop(producer);
+		});
+		assert_eq!(warns, 0, "the parent track warning identifies the abandoned producer");
+	}
+
+	#[test]
+	fn drop_after_unmarked_close_warns() {
+		let warns = count_drop_warnings("track::Producer dropped without finish", || {
+			let producer = track_producer("test", None);
+			assert!(producer.state.close().is_ok());
+			drop(producer);
+		});
+		assert_eq!(warns, 1, "a closed track without a terminal marker must warn");
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

- suppress the child-group warning when track teardown intentionally releases a cache-owned final producer
- tag each group liveness handle with an explicit `Publisher` or `Cache` role; the role of the final `Arc` owner determines whether unfinished teardown warns
- retain the terminal-state handling from #2580 and test the closed-without-terminal behavior it actually changed

## Root cause

`track::abort()` cleared its group cache by dropping ordinary `group::Producer` handles. When the cache owned the final handle for an unfinished group, group teardown interpreted that intentional parent cleanup as an abandoned publisher and emitted a warning. External group producers must remain independent, so cascading an abort into every child would be incorrect.

The cache now stores a cache-role clone. `Arc::into_inner` atomically selects the final owner, which performs teardown using its own role. A final publisher warns; a final cache owner does not. No shared drop-control flag or refcount snapshot is required.

## Public API changes

None. The ownership role and cache clone are crate-private and do not change wire behavior.

## Test plan

- mutation check: treating the cached clone as a publisher makes the new regression test fail with one unexpected group warning
- `nix develop --command just rs test -p moq-net` (630 passed)
- `nix develop --command just check`

Cross-package sync is not applicable because this changes neither public APIs nor the wire format.

(Written by GPT-5)