### PR TITLE
fix(libmoq): retain CUDA kernel in Nix source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -357,7 +357,20 @@
         # environment), so a Cargo.lock change recompiles only the changed crate
         # + its reverse-deps. That's a runner-side concern -- nothing here or in
         # the workflows configures it.
-        checks = { };
+        checks = {
+          libmoq-source-assets = pkgs.runCommand "libmoq-source-assets" { } ''
+            for asset in \
+              rs/libmoq/moq.pc.in \
+              rs/libmoq/native-libs/apple.txt \
+              rs/libmoq/native-libs/linux.txt \
+              rs/libmoq/native-libs/windows.txt \
+              rs/moq-video/src/frame/nv12_resize.ptx
+            do
+              test -f "${overlayPkgs.libmoq.src}/$asset"
+            done
+            touch "$out"
+          '';
+        };
       }
     );
 }

--- a/justfile
+++ b/justfile
@@ -86,7 +86,7 @@ ci BASE="":
 
     # Validate the flake (eval + dev shell build) via `nix flake check`. This no
     # longer compiles the workspace -- the heavy Rust CI (clippy/doc/test) moved
-    # to `just rs ci` (plain cargo) and `checks` is unwired (see flake.nix) -- so
+    # to `just rs ci` (plain cargo), leaving only lightweight Nix checks -- so
     # it's cheap. Gate it to Nix/Rust input changes anyway: a pure doc/JS PR
     # can't affect flake eval. Empty $files is a force-run, so run then.
     if [[ -z "$files" ]] || echo "$files" | grep -qE '(^rs/|^Cargo\.(toml|lock)$|^flake\.lock$|\.nix$)'; then

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -124,13 +124,15 @@ let
     # generate the pkgconfig file. craneLib.cleanCargoSource's default filter
     # drops both, which makes build.rs skip pkgconfig generation (see the
     # `if let Ok(template)` in rs/libmoq/build.rs) or fail reading the lib list,
-    # and the installPhase's `cp .../moq.pc` then fails.
+    # and the installPhase's `cp .../moq.pc` then fails. moq-video's Linux NVDEC
+    # path also includes a vendored PTX kernel at compile time.
     src = final.lib.cleanSourceWith {
       src = ../.;
       name = "source";
       filter =
         path: type:
         (final.lib.hasSuffix ".pc.in" path)
+        || (final.lib.hasSuffix ".ptx" path)
         || (final.lib.hasInfix "/rs/libmoq/native-libs/" path)
         || (craneLib.filterCargoSources path type);
     };


### PR DESCRIPTION
## Summary

- Preserve vendored PTX kernels in the filtered Nix source used to build `libmoq`.
- Add a lightweight flake regression check for every non-Cargo source asset required by the package.
- Restore Linux `libmoq` release builds with NVDEC enabled.

The Linux release jobs failed because `craneLib.filterCargoSources` removed `nv12_resize.ptx` before Rust evaluated the `include_str!` in `moq-video`. The file was committed, but absent from the Nix build source.

## Public API changes

None.

## Test plan

- [x] Confirmed the new source-assets check fails without the filter change.
- [x] `nix build .#checks.aarch64-darwin.libmoq-source-assets --no-link`
- [x] `nix develop --command just fix`
- [x] `nix develop --command just check`
- [ ] `nix flake check` is blocked locally by the existing x86_64-darwin GStreamer package after nixpkgs dropped that target.

(Written by GPT-5)