### PR TITLE
docs(drafts): spec broadcast epochs and ended broadcasts for moq-lite-06

### DIFF
--- a/drafts/CLAUDE.md
+++ b/drafts/CLAUDE.md
@@ -66,6 +66,10 @@ like a table that silently degrades into a paragraph.
 
 ## Conventions
 
+- **Brevity.** Less text is better: state each rule once, normatively, where it
+  belongs, and cross-reference instead of restating. Cut consequences a reader
+  can derive, edge cases the general rule already decides, and motivation
+  beyond a sentence. When editing, prefer deleting a sentence over qualifying it.
 - Draft sources are kramdown-rfc markdown; `remark` (the repo's CommonMark
   linter) skips them. A successful `kramdown-rfc` run also validates syntax.
 - The `docname` frontmatter field ends in `-latest`; `publish` rewrites it to

--- a/drafts/draft-lcurley-moq-broadcast.md
+++ b/drafts/draft-lcurley-moq-broadcast.md
@@ -66,7 +66,7 @@ A relay forwarding into such a session strips EPOCH, and downstream receivers tr
 
 # EPOCH Parameter
 The EPOCH parameter carries the generation of the broadcast.
-It is a parameter (see {{moqt}} Section 2.5) carried in a namespace advertisement (PUBLISH_NAMESPACE, {{moqt}} Section 10.15, or an extended NAMESPACE, {{relay-hops}}), and in SUBSCRIBE and FETCH to pin the request (see [Pinning Subscriptions and Fetches](#pinning-subscriptions-and-fetches)).
+It is a parameter (see {{moqt}} Section 2.5) carried in a namespace advertisement (PUBLISH_NAMESPACE, {{moqt}} Section 10.15, or an extended NAMESPACE, {{relay-hops}}), and in SUBSCRIBE, FETCH, and PUBLISH to pin the request (see [Pinning Subscriptions, Fetches, and Publishes](#pinning-subscriptions-fetches-and-publishes)).
 
 ~~~
 EPOCH Parameter {
@@ -79,8 +79,7 @@ EPOCH Parameter {
 **Epoch**:
 The generation of content at this namespace, chosen by the original publisher and forwarded unchanged by relays.
 Each new generation MUST use a non-zero Epoch greater than every Epoch still observable at the namespace (the incumbent advertisement and any generation the publisher retains), and MUST NOT equal another publisher's Epoch except by deliberate agreement: equal Epochs declare interchangeable content.
-RECOMMENDED construction: wall-clock milliseconds shifted left 16 bits with the low 16 bits random; the timestamp preserves ordering across restarts without persisted state, and the random bits make an accidental collision within the same millisecond improbable.
-Clocks roll back and skew, so a publisher that observes a higher incumbent Epoch MUST exceed it instead of trusting its clock.
+RECOMMENDED construction: wall-clock milliseconds shifted left 16 bits with the low 16 bits random, clamped to at least one more than the highest observable Epoch; the timestamp preserves ordering across restarts without persisted state, the random bits make accidental collisions improbable, and the clamp covers same-millisecond generations, clock rollback, and skew.
 A violation is not fatal: receivers keep no high-water mark, so an erroneously high Epoch suppresses newer generations only while its advertisement remains available.
 A value of 0 is equivalent to omitting the parameter.
 
@@ -98,11 +97,13 @@ When combined with {{relay-hops}}, Epoch comparison happens first; its path-leng
 An advertisement without EPOCH carries no generation: the publisher predates this extension, or the parameter was stripped crossing a non-supporting session.
 Unspecified advertisements are never interchangeable with specified ones; among themselves, the identity rules otherwise in effect apply ({{relay-hops}} origin identity, or plain {{moqt}} semantics).
 
-## Pinning Subscriptions and Fetches
+## Pinning Subscriptions, Fetches, and Publishes
 On a session that negotiated this extension, a subscriber MAY include EPOCH in SUBSCRIBE or FETCH; the request then targets exactly that generation, and the publisher MUST reject it rather than serve a different one.
 A publisher that retains an older generation (e.g. a recording) MAY serve a FETCH pinned to it even after a newer generation replaced the namespace.
 A request without EPOCH targets whatever generation the publisher currently serves, matching {{moqt}}'s default behavior.
 Echoing the Epoch of the advertisement acted on closes the race where a request crosses a replacement in flight.
+
+The same race exists in the push direction: a publisher SHOULD include EPOCH in PUBLISH, and a receiver MUST reject a PUBLISH whose Epoch differs from the generation it currently holds for the namespace, so a stale push cannot attach its tracks to a replacement.
 
 
 # Security Considerations
@@ -129,9 +130,9 @@ This document requests a registration in the "MOQT Setup Options" registry ({{mo
 
 This document requests a registration in the "MOQT Message Parameters" registry ({{moqt}} Section 15.7).
 
-| Value   | Name  | Carried In                                    | Reference     |
-|:--------|:------|:----------------------------------------------|:--------------|
-| 0x40B5B | EPOCH | PUBLISH_NAMESPACE, NAMESPACE, SUBSCRIBE, FETCH | This Document |
+| Value   | Name  | Carried In                                             | Reference     |
+|:--------|:------|:-------------------------------------------------------|:--------------|
+| 0x40B5B | EPOCH | PUBLISH_NAMESPACE, NAMESPACE, SUBSCRIBE, FETCH, PUBLISH | This Document |
 
 
 --- back

--- a/drafts/draft-lcurley-moq-broadcast.md
+++ b/drafts/draft-lcurley-moq-broadcast.md
@@ -78,8 +78,9 @@ EPOCH Parameter {
 
 **Epoch**:
 The generation of content at this namespace, chosen by the original publisher and forwarded unchanged by relays.
-Each new generation MUST use a non-zero Epoch greater than the last, minted with enough entropy that independent publishers cannot collide by accident: equal Epochs declare interchangeable content, so equality must only happen by deliberate opt-in.
-Wall-clock milliseconds with random low-order bits appended is a good source; clocks roll back and skew, so a publisher SHOULD also exceed the highest Epoch it can observe at the namespace.
+Each new generation MUST use a non-zero Epoch greater than every Epoch still observable at the namespace (the incumbent advertisement and any generation the publisher retains), and MUST NOT equal another publisher's Epoch except by deliberate agreement: equal Epochs declare interchangeable content.
+RECOMMENDED construction: wall-clock milliseconds shifted left 16 bits with the low 16 bits random; the timestamp preserves ordering across restarts without persisted state, and the random bits make an accidental collision within the same millisecond improbable.
+Clocks roll back and skew, so a publisher that observes a higher incumbent Epoch MUST exceed it instead of trusting its clock.
 A violation is not fatal: receivers keep no high-water mark, so an erroneously high Epoch suppresses newer generations only while its advertisement remains available.
 A value of 0 is equivalent to omitting the parameter.
 

--- a/drafts/draft-lcurley-moq-broadcast.md
+++ b/drafts/draft-lcurley-moq-broadcast.md
@@ -78,8 +78,8 @@ EPOCH Parameter {
 
 **Epoch**:
 The generation of content at this namespace, chosen by the original publisher and forwarded unchanged by relays.
-Each new generation MUST use a non-zero Epoch greater than the last.
-Wall-clock milliseconds are a convenient source, but clocks roll back and skew, so a publisher SHOULD take the maximum of its clock and one more than the highest Epoch it can observe at the namespace.
+Each new generation MUST use a non-zero Epoch greater than the last, minted with enough entropy that independent publishers cannot collide by accident: equal Epochs declare interchangeable content, so equality must only happen by deliberate opt-in.
+Wall-clock milliseconds with random low-order bits appended is a good source; clocks roll back and skew, so a publisher SHOULD also exceed the highest Epoch it can observe at the namespace.
 A violation is not fatal: receivers keep no high-water mark, so an erroneously high Epoch suppresses newer generations only while its advertisement remains available.
 A value of 0 is equivalent to omitting the parameter.
 

--- a/drafts/draft-lcurley-moq-broadcast.md
+++ b/drafts/draft-lcurley-moq-broadcast.md
@@ -1,0 +1,141 @@
+---
+title: "MoQ Broadcast Extension"
+abbrev: "moq-broadcast"
+category: info
+
+docname: draft-lcurley-moq-broadcast-latest
+submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
+number:
+date:
+v: 3
+area: wit
+workgroup: moq
+
+author:
+ -
+    fullname: Luke Curley
+    email: kixelated@gmail.com
+
+normative:
+  moqt: I-D.ietf-moq-transport
+  relay-hops: I-D.lcurley-moq-relay-hops
+
+informative:
+
+--- abstract
+
+This document defines a Broadcast extension for MoQ Transport {{moqt}}.
+Each namespace advertisement carries an Epoch identifying the generation of content published under the namespace.
+Receivers resolve competing advertisements by Epoch rather than arrival order, and a subscriber can pin a subscription or fetch to a specific generation.
+
+--- middle
+
+# Conventions and Definitions
+{::boilerplate bcp14-tagged}
+
+A **broadcast** is one generation of the content published under a namespace: when a publisher restarts with new content, or a different publisher takes over the name, a new broadcast occupies the same namespace.
+
+
+# Introduction
+{{moqt}} identifies content by namespace, but a namespace is reused across time: a restarted or replacement publisher advertises the same name for entirely new content.
+A receiver cannot tell that apart from the same content arriving over another path, so implementations fall back to preferring the most recently received advertisement, which is a race: a stale advertisement on a fresh session looks newer than the generation it predates.
+The origin identity of {{relay-hops}} does not close the gap either: the same publisher producing new content after a restart is indistinguishable from a route change.
+
+This extension adds an **Epoch** to each namespace advertisement.
+The original publisher assigns it, relays forward it unchanged, and a larger value identifies a newer generation, so replacement is decided by value rather than arrival order.
+A subscriber can also echo the Epoch in a subscription or fetch, turning "give me the content I saw advertised" into a check the publisher enforces.
+
+
+# Setup Negotiation
+The Broadcast extension is negotiated during the SETUP exchange as defined in {{moqt}} Section 10.3.
+An endpoint indicates support by including the following Setup Option; it carries no value.
+
+~~~
+BROADCAST Setup Option {
+  Option Key (vi64) = 0x40B59
+  Option Value Length (vi64) = 0
+}
+~~~
+
+The extension is negotiated independently per session.
+Negotiating it also enables the extended NAMESPACE message format of {{relay-hops}}, which appends a Parameters field to NAMESPACE; the appended field carries whichever parameters the negotiated extensions define.
+
+Message parameters in {{moqt}} have no generic skip rule, so an endpoint MUST NOT send EPOCH on a session that did not negotiate this extension.
+A relay forwarding into such a session strips EPOCH, and downstream receivers treat the advertisement as unspecified (see [Unspecified Epochs](#unspecified-epochs)).
+
+
+# EPOCH Parameter
+The EPOCH parameter carries the generation of the broadcast.
+It is a parameter (see {{moqt}} Section 2.5) carried in a namespace advertisement (PUBLISH_NAMESPACE, {{moqt}} Section 10.15, or an extended NAMESPACE, {{relay-hops}}), and in SUBSCRIBE and FETCH to pin the request (see [Pinning Subscriptions and Fetches](#pinning-subscriptions-and-fetches)).
+
+~~~
+EPOCH Parameter {
+  Type (vi64) = 0x40B5B
+  Length (vi64)
+  Epoch (vi64)
+}
+~~~
+
+**Epoch**:
+The generation of content at this namespace, chosen by the original publisher and forwarded unchanged by relays.
+Each new generation MUST use a non-zero Epoch greater than the last.
+Wall-clock milliseconds are a convenient source, but clocks roll back and skew, so a publisher SHOULD take the maximum of its clock and one more than the highest Epoch it can observe at the namespace.
+A violation is not fatal: receivers keep no high-water mark, so an erroneously high Epoch suppresses newer generations only while its advertisement remains available.
+A value of 0 is equivalent to omitting the parameter.
+
+## Selection by Epoch
+A receiver holding advertisements for the same namespace MUST prefer the highest Epoch (a specified Epoch outranks an unspecified one): a lower Epoch is a stale generation, never an alternate path, regardless of arrival order or path length.
+A relay SHOULD end its advertisement of a lower generation once it holds a higher one, rather than wait for it to end on its own, which would hold the namespace for however long the transport takes to notice a publisher is gone.
+
+Advertisements with the same non-zero Epoch carry interchangeable content: a receiver MAY hold them as redundant paths and switch between them, including failing an active subscription over when the serving path ends.
+Cooperating redundant publishers opt in by minting the same Epoch, e.g. derived from the event rather than from each process.
+Any other pair is two generations: cached immutable track properties MUST be discarded on replacement, and existing subscriptions do not carry over.
+
+When combined with {{relay-hops}}, Epoch comparison happens first; its path-length tie-break and origin-identity rules apply only among advertisements with the same Epoch.
+
+## Unspecified Epochs
+An advertisement without EPOCH carries no generation: the publisher predates this extension, or the parameter was stripped crossing a non-supporting session.
+Unspecified advertisements are never interchangeable with specified ones; among themselves, the identity rules otherwise in effect apply ({{relay-hops}} origin identity, or plain {{moqt}} semantics).
+
+## Pinning Subscriptions and Fetches
+On a session that negotiated this extension, a subscriber MAY include EPOCH in SUBSCRIBE or FETCH; the request then targets exactly that generation, and the publisher MUST reject it rather than serve a different one.
+A publisher that retains an older generation (e.g. a recording) MAY serve a FETCH pinned to it even after a newer generation replaced the namespace.
+A request without EPOCH targets whatever generation the publisher currently serves, matching {{moqt}}'s default behavior.
+Echoing the Epoch of the advertisement acted on closes the race where a request crosses a replacement in flight.
+
+
+# Security Considerations
+A wall-clock-derived Epoch reveals approximately when a broadcast started; a publisher that considers this sensitive can use any other increasing scheme.
+
+A misbehaving publisher or relay can advertise an arbitrarily high Epoch and suppress legitimate content at that namespace, but only while its advertisement remains available, since receivers keep no high-water mark.
+This is the same trust already placed in namespace advertisements themselves; receivers MUST NOT treat an Epoch as proof of freshness or authenticity.
+
+
+# IANA Considerations
+
+This document requests the following registrations.
+High, distinctive values are requested to avoid the low ranges reserved by {{moqt}} and to minimize collisions with provisional registrations by other extensions.
+
+## MOQT Setup Options
+
+This document requests a registration in the "MOQT Setup Options" registry ({{moqt}} Section 15.4), whose policy is Specification Required.
+
+| Value   | Name      | Reference     |
+|:--------|:----------|:--------------|
+| 0x40B59 | BROADCAST | This Document |
+
+## MOQT Message Parameters
+
+This document requests a registration in the "MOQT Message Parameters" registry ({{moqt}} Section 15.7).
+
+| Value   | Name  | Carried In                                    | Reference     |
+|:--------|:------|:----------------------------------------------|:--------------|
+| 0x40B5B | EPOCH | PUBLISH_NAMESPACE, NAMESPACE, SUBSCRIBE, FETCH | This Document |
+
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+This document was drafted with the assistance of Claude, an AI assistant by Anthropic.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -1009,7 +1009,7 @@ Subscriber properties (see [SUBSCRIBE](#subscribe)) are the opposite: they fan *
 
 **Epoch**:
 The generation these properties belong to (see [ANNOUNCE_START](#announce-start)), or 0 when the publisher assigns none.
-Subscribers key their TRACK_INFO cache by it and MAY echo it in SUBSCRIBE and FETCH to pin the same generation.
+Subscribers key their TRACK_INFO cache by it, and a SUBSCRIBE or FETCH that will parse frames against a cached non-zero Epoch MUST send that Epoch: no data response identifies the generation actually served, so an unpinned request can silently cross a replacement.
 
 **Publisher Priority**:
 The publisher's priority for this Track, represented as a u8, used only to resolve ties between subscriptions of equal subscriber priority.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -780,8 +780,9 @@ This is combined with the broadcast path prefix to form the full broadcast path.
 
 **Epoch**:
 The generation of content at this path, chosen by the original publisher and forwarded unchanged by relays.
-Each new generation MUST use a non-zero Epoch greater than the last, minted with enough entropy that independent publishers cannot collide by accident: equal Epochs declare interchangeable content, so equality must only happen by deliberate opt-in.
-Wall-clock milliseconds with random low-order bits appended is a good source; clocks roll back and skew, so a publisher SHOULD also exceed the highest Epoch it can observe at the path (e.g. the incumbent advertisement).
+Each new generation MUST use a non-zero Epoch greater than every Epoch still observable at the path (the incumbent advertisement and any generation the publisher retains), and MUST NOT equal another publisher's Epoch except by deliberate agreement: equal Epochs declare interchangeable content.
+RECOMMENDED construction: wall-clock milliseconds shifted left 16 bits with the low 16 bits random; the timestamp preserves ordering across restarts without persisted state, and the random bits make an accidental collision within the same millisecond improbable.
+Clocks roll back and skew, so a publisher that observes a higher incumbent Epoch MUST exceed it instead of trusting its clock.
 A violation is not fatal: receivers keep no high-water mark, so an erroneously high Epoch suppresses newer generations only while its advertisement remains available.
 A value of 0 means unspecified: identity falls back to the first entry of the path (see below), e.g. when bridging from an endpoint that does not assign Epochs.
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -325,7 +325,8 @@ A subscriber opens Subscribe Streams to request a Track.
 The subscriber MUST start a Subscribe Stream with a SUBSCRIBE message followed by any number of SUBSCRIBE_UPDATE messages.
 When a start group can be resolved, the publisher replies with a SUBSCRIBE_OK message (confirming the subscription and resolving its start group), followed by any number of SUBSCRIBE_END and SUBSCRIBE_DROP messages.
 When the accepted track has already ended with no matching groups there is no start group to resolve, so the publisher sends SUBSCRIBE_END with no preceding SUBSCRIBE_OK.
-A rejection is a stream reset: if the publisher cannot serve the subscription — the track does not exist, the broadcast has ended (see `Ended` in [ANNOUNCE_START](#announce-start)), the requested `Epoch` is not the one being served, or it otherwise refuses — it MUST reset the stream rather than leave it pending, and SHOULD do so promptly (within roughly a round trip) so the subscriber is not left waiting.
+A rejection is a stream reset.
+If the publisher cannot serve the subscription (no such track, an ended broadcast, an `Epoch` that is not the one being served, or any other refusal), it MUST reset the stream rather than leave it pending, and SHOULD do so promptly (within roughly a round trip) so the subscriber is not left waiting.
 A subscription the publisher accepts but has no groups for yet is not a rejection: for a live track the publisher MAY withhold SUBSCRIBE_OK until the first matching group resolves the start. A subscriber therefore distinguishes "pending" from "refused" by the stream reset, not by a timeout.
 The Subscribe Stream does not carry the track's publisher properties — those are immutable and fetched once via a [Track Stream](#track-stream) (see [TRACK_INFO](#track-info)).
 The subscriber MUST have the track's TRACK_INFO before it can fully interpret the FRAME messages that arrive on Group Streams, since the timescale is needed to interpret each timestamp; it MAY open the Track and Subscribe streams concurrently and buffer frames until TRACK_INFO arrives.
@@ -355,7 +356,8 @@ The subscriber sends a TRACK message containing the broadcast path, track name, 
 The publisher replies with a single TRACK_INFO message carrying the resolved epoch and then FINs the stream, or resets the stream on error (e.g. the track does not exist, or a non-zero epoch does not match).
 The returned properties are fixed for the lifetime of that generation, so the subscriber SHOULD cache TRACK_INFO keyed by broadcast path, track name, and epoch, and reuse it across every SUBSCRIBE and FETCH of the same generation.
 An announcement that changes the broadcast's Epoch replaces the content (see [ANNOUNCE_UPDATE](#announce-update)); cached TRACK_INFO from another generation MUST NOT be used to parse its frames, since the timescale may differ.
-A subscriber without announcements (a path known out of band) gets the same protection by echoing the resolved epoch in SUBSCRIBE and FETCH, so a concurrent replacement is a reset rather than misparsed frames.
+A subscriber without announcements (a path known out of band) gets the same protection by echoing a non-zero resolved epoch in SUBSCRIBE and FETCH, so a concurrent replacement is a reset rather than misparsed frames.
+A resolved epoch of 0 pins nothing, so such a cache SHOULD NOT outlive the connection.
 If FRAME messages cannot be decoded against the cached TRACK_INFO, the subscriber MUST reset the affected stream with a protocol violation and re-request it.
 
 Because a subscriber MAY open the Track stream concurrently with a SUBSCRIBE or FETCH (see [Subscribe](#subscribe) and [Fetch](#fetch)) and cannot parse any buffered group frames until TRACK_INFO arrives, the publisher SHOULD prioritize TRACK_INFO ahead of group data on the connection.
@@ -778,8 +780,8 @@ This is combined with the broadcast path prefix to form the full broadcast path.
 
 **Epoch**:
 The generation of content at this path, chosen by the original publisher and forwarded unchanged by relays.
-Each new generation MUST use a non-zero Epoch greater than the last.
-Wall-clock milliseconds are a convenient source, but clocks roll back and skew, so a publisher SHOULD take the maximum of its clock and one more than the highest Epoch it can observe at the path (e.g. the incumbent advertisement).
+Each new generation MUST use a non-zero Epoch greater than the last, minted with enough entropy that independent publishers cannot collide by accident: equal Epochs declare interchangeable content, so equality must only happen by deliberate opt-in.
+Wall-clock milliseconds with random low-order bits appended is a good source; clocks roll back and skew, so a publisher SHOULD also exceed the highest Epoch it can observe at the path (e.g. the incumbent advertisement).
 A violation is not fatal: receivers keep no high-water mark, so an erroneously high Epoch suppresses newer generations only while its advertisement remains available.
 A value of 0 means unspecified: identity falls back to the first entry of the path (see below), e.g. when bridging from an endpoint that does not assign Epochs.
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -356,7 +356,8 @@ The subscriber sends a TRACK message containing the broadcast path, track name, 
 The publisher replies with a single TRACK_INFO message carrying the resolved epoch and then FINs the stream, or resets the stream on error (e.g. the track does not exist, or a non-zero epoch does not match).
 The returned properties are fixed for the lifetime of that generation, so the subscriber SHOULD cache TRACK_INFO keyed by broadcast path, track name, and epoch, and reuse it across every SUBSCRIBE and FETCH of the same generation.
 An announcement that changes the broadcast's Epoch replaces the content (see [ANNOUNCE_UPDATE](#announce-update)); cached TRACK_INFO from another generation MUST NOT be used to parse its frames, since the timescale may differ.
-A subscriber without announcements (a path known out of band) gets the same protection by echoing a non-zero resolved epoch in SUBSCRIBE and FETCH, so a concurrent replacement is a reset rather than misparsed frames.
+A subscriber without announcements (a path known out of band) gets the same protection by waiting for TRACK_INFO and echoing its non-zero resolved epoch in SUBSCRIBE and FETCH, so a concurrent replacement is a reset rather than misparsed frames.
+Opening those streams concurrently with Epoch 0 forfeits this: the streams can resolve on opposite sides of a replacement, so the single-round-trip open is only safe when the epoch is already known (from an advertisement or a prior TRACK_INFO).
 A resolved epoch of 0 pins nothing and cannot key the cache: a subscriber following announcements MUST discard such a cache when the broadcast's advertisement is replaced (see [ANNOUNCE_UPDATE](#announce-update)), and one without announcements SHOULD NOT keep it beyond the connection.
 If FRAME messages cannot be decoded against the cached TRACK_INFO, the subscriber MUST reset the affected stream with a protocol violation and re-request it.
 
@@ -781,8 +782,7 @@ This is combined with the broadcast path prefix to form the full broadcast path.
 **Epoch**:
 The generation of content at this path, chosen by the original publisher and forwarded unchanged by relays.
 Each new generation MUST use a non-zero Epoch greater than every Epoch still observable at the path (the incumbent advertisement and any generation the publisher retains), and MUST NOT equal another publisher's Epoch except by deliberate agreement: equal Epochs declare interchangeable content.
-RECOMMENDED construction: wall-clock milliseconds shifted left 16 bits with the low 16 bits random; the timestamp preserves ordering across restarts without persisted state, and the random bits make an accidental collision within the same millisecond improbable.
-Clocks roll back and skew, so a publisher that observes a higher incumbent Epoch MUST exceed it instead of trusting its clock.
+RECOMMENDED construction: wall-clock milliseconds shifted left 16 bits with the low 16 bits random, clamped to at least one more than the highest observable Epoch; the timestamp preserves ordering across restarts without persisted state, the random bits make accidental collisions improbable, and the clamp covers same-millisecond generations, clock rollback, and skew.
 A violation is not fatal: receivers keep no high-water mark, so an erroneously high Epoch suppresses newer generations only while its advertisement remains available.
 A value of 0 means unspecified: identity falls back to the first entry of the path (see below), e.g. when bridging from an endpoint that does not assign Epochs.
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -268,24 +268,25 @@ There's a 1-byte STREAM_TYPE at the beginning of each stream.
 
 ### Announce
 A subscriber can open an Announce Stream to discover broadcasts matching a prefix.
+By default only live broadcasts are announced; the subscriber can opt into ended broadcasts too, e.g. to enumerate available recordings (see [ANNOUNCE_REQUEST](#announce-request)).
 
 The subscriber creates the stream with an ANNOUNCE_REQUEST message.
-The publisher replies with a single ANNOUNCE_OK message followed by ANNOUNCE_START, ANNOUNCE_END, and ANNOUNCE_RESTART messages for any matching broadcasts and any future changes.
+The publisher replies with a single ANNOUNCE_OK message followed by ANNOUNCE_START, ANNOUNCE_END, and ANNOUNCE_UPDATE messages for any matching broadcasts and any future changes.
 
 ANNOUNCE_OK carries metadata that applies to every announcement on this stream and is sent exactly once at the start of the response:
 
-- The publisher's own `Hop ID`, which is the implicit trailing entry of every ANNOUNCE_START and ANNOUNCE_RESTART Hop ID list. Hoisting it out of every announcement saves bytes since it is identical for every announcement on the session.
+- The publisher's own `Hop ID`, which is the implicit trailing entry of every ANNOUNCE_START and ANNOUNCE_UPDATE Hop ID list. Hoisting it out of every announcement saves bytes since it is identical for every announcement on the session.
 - The number of ANNOUNCE_START messages (`Active Count`) the publisher will send immediately as the initial set. The subscriber MAY buffer until all `Active Count` initial announcements arrive before reporting them to the application, avoiding a trickle. Any announcements beyond `Active Count` are live updates and SHOULD be reported to the application as they arrive.
 
 Availability changes are carried by three message types:
 
 - ANNOUNCE_START: a matching broadcast is available.
 - ANNOUNCE_END: a previously started broadcast is no longer available.
-- ANNOUNCE_RESTART: a previously started broadcast was atomically replaced.
+- ANNOUNCE_UPDATE: a previously started advertisement was atomically replaced.
 
 Each ANNOUNCE_START implicitly assigns the next Announce ID on the stream: a counter starting at 0 that increments by 1 per ANNOUNCE_START.
 The id never appears inside the ANNOUNCE_START message itself; both endpoints derive it from the message order on the (reliable, ordered) stream.
-ANNOUNCE_END and ANNOUNCE_RESTART reference the Announce ID instead of repeating the broadcast path, since the path can be arbitrarily long while the id is a compact ordinal.
+ANNOUNCE_END and ANNOUNCE_UPDATE reference the Announce ID instead of repeating the broadcast path, since the path can be arbitrarily long while the id is a compact ordinal.
 
 Each broadcast starts unavailable.
 An ANNOUNCE_START makes the broadcast available; a subsequent ANNOUNCE_END makes it unavailable again and retires its Announce ID.
@@ -293,25 +294,26 @@ An ANNOUNCE_START makes the broadcast available; a subsequent ANNOUNCE_END makes
 A publisher SHOULD advertise, for each broadcast, the best path it knows whose entries avoid the origin the subscriber declared in its SETUP (see [Origin Parameter](#origin-parameter)); when every known path contains it, the publisher SHOULD advertise nothing for that broadcast.
 A subscriber that declared no origin is subject to no exclusion and receives the best path outright; an unknown Hop ID of 0 in a path never matches anything.
 Selection is per stream: two subscribers can legitimately receive different paths for the same broadcast, and in particular a subscriber that the serving path flows through receives the best standby path instead of nothing, which is what lets it fail over to that standby if its own copy dies.
-The per-subscriber winner changing travels as an ANNOUNCE_RESTART; it swinging into or out of existence (the last qualifying path appearing or disappearing) travels as a fresh ANNOUNCE_START or an ANNOUNCE_END.
-If the best path changes (e.g. a relay failover or upstream restart), the publisher MAY send an ANNOUNCE_RESTART referencing the advertisement's Announce ID: the new announcement atomically replaces the prior one (equivalent to ANNOUNCE_END+ANNOUNCE_START) and the id stays live.
-The first entry of the reconstructed path identifies the original publisher (see [ANNOUNCE_START](#announce-start)); a restart that preserves it is an alternate route to the same broadcast, while one that changes it replaces the broadcast entirely (see [ANNOUNCE_RESTART](#announce-restart)).
-A publisher MUST NOT keep multiple current advertisements for the same broadcast on the same stream: each broadcast has at most one current advertisement at a time, and a second ANNOUNCE_START for an already-available path is a protocol violation (use ANNOUNCE_RESTART).
-A subscriber that sees the same broadcast advertised across multiple streams SHOULD route subscriptions to the advertisement with the lowest Route Cost after adding each arriving link's cost, breaking ties by the shortest total path length (see [ANNOUNCE_START](#announce-start)).
+The per-subscriber winner changing travels as an ANNOUNCE_UPDATE; it swinging into or out of existence (the last qualifying path appearing or disappearing) travels as a fresh ANNOUNCE_START or an ANNOUNCE_END.
+If the best path changes (e.g. a relay failover or upstream restart), the publisher MAY send an ANNOUNCE_UPDATE referencing the advertisement's Announce ID: the new announcement atomically replaces the prior one (equivalent to ANNOUNCE_END+ANNOUNCE_START) and the id stays live.
+Each advertisement carries an `Epoch` identifying the generation of content at the path (see [ANNOUNCE_START](#announce-start)); an update that preserves it is an alternate route to the same broadcast, while one that changes it replaces the broadcast entirely (see [ANNOUNCE_UPDATE](#announce-update)).
+A publisher MUST NOT keep multiple current advertisements for the same broadcast on the same stream: each broadcast has at most one current advertisement at a time, and a second ANNOUNCE_START for an already-available path is a protocol violation (use ANNOUNCE_UPDATE).
+A subscriber that sees the same broadcast advertised across multiple streams MUST prefer the highest `Epoch` (any non-zero value outranks 0): a lower Epoch never displaces a higher one, regardless of cost or arrival order.
+Among advertisements with the same Epoch, the subscriber SHOULD route subscriptions to the advertisement with the lowest Route Cost after adding each arriving link's cost, breaking ties by the shortest total path length (see [ANNOUNCE_START](#announce-start)).
 Advertisements from peers that predate the Route Cost carry an effective cost of 0, so a mixed mesh degrades to shortest-path routing.
 Advertisements that tie on every advertised property SHOULD be broken toward the most recently received: they are indistinguishable to the rest of the mesh, and a publisher reconnecting over a new session is otherwise outranked by the session it replaced until the transport declares that one gone.
 
-Advertisements for the same broadcast path whose reconstructed paths share the same first entry carry interchangeable content: a relay MAY hold them as redundant routes for one broadcast and splice a live subscription across them at a Group boundary, e.g. when the serving route ends.
-Cooperating redundant publishers MAY share a Hop ID to opt into this.
-Advertisements whose first entries differ are distinct broadcasts colliding on one path: a relay MUST NOT splice between them, and SHOULD treat the later as a replacement for the earlier, ending the earlier advertisement before starting the later one.
-Serving the earlier until it ends on its own instead would hold the path for however long the transport takes to notice a publisher is gone, which is exactly the case a reconnecting publisher hits.
+Advertisements for the same broadcast path with the same non-zero `Epoch` carry interchangeable content: a relay MAY hold them as redundant routes and splice a live subscription across them at a Group boundary.
+Cooperating redundant publishers opt in by minting the same Epoch, e.g. derived from the event rather than from each process.
+Any other pair is two generations colliding on one path: a relay MUST NOT splice between them and MUST end the lower-Epoch advertisement rather than wait for it to end on its own, which would hold the path for however long the transport takes to notice a publisher is gone.
+Only when both Epochs are 0 does identity fall back to the first entry of the reconstructed path: a shared first entry is spliceable, and differing first entries are a replacement decided toward the most recently received.
 
 When serving a subscription, a publisher MUST select the source by the same rule it uses for advertisements to that session: a path whose entries avoid the origin the subscriber declared in its SETUP (see [Origin Parameter](#origin-parameter)).
 A subscriber that declared no origin is served from the publisher's preferred source as usual.
 If only excluded sources remain, the subscription is unroutable; serving it would hand the subscriber data that already flowed through itself.
 Advertisement and dispatch being one selection keeps advertised paths truthful, which is what makes the declared-origin filter sufficient to prevent subscription cycles of any length: any would-be cycle surfaces the subscriber's own Hop ID inside the candidate path, where the filter removes it.
 
-The subscriber MUST reset the stream if it receives an ANNOUNCE_END or ANNOUNCE_RESTART referencing an Announce ID that was never assigned or already retired, an ANNOUNCE_START for a path that is already available, or any announcement before ANNOUNCE_OK.
+The subscriber MUST reset the stream if it receives an ANNOUNCE_END or ANNOUNCE_UPDATE referencing an Announce ID that was never assigned or already retired, an ANNOUNCE_START for a path that is already available, or any announcement before ANNOUNCE_OK.
 When the stream is closed, the subscriber MUST assume that all broadcasts are now unavailable.
 
 Path prefix matching and equality is done on a byte-by-byte basis.
@@ -323,7 +325,7 @@ A subscriber opens Subscribe Streams to request a Track.
 The subscriber MUST start a Subscribe Stream with a SUBSCRIBE message followed by any number of SUBSCRIBE_UPDATE messages.
 When a start group can be resolved, the publisher replies with a SUBSCRIBE_OK message (confirming the subscription and resolving its start group), followed by any number of SUBSCRIBE_END and SUBSCRIBE_DROP messages.
 When the accepted track has already ended with no matching groups there is no start group to resolve, so the publisher sends SUBSCRIBE_END with no preceding SUBSCRIBE_OK.
-A rejection is a stream reset: if the publisher cannot serve the subscription — the track does not exist, or it otherwise refuses — it MUST reset the stream rather than leave it pending, and SHOULD do so promptly (within roughly a round trip) so the subscriber is not left waiting.
+A rejection is a stream reset: if the publisher cannot serve the subscription — the track does not exist, the broadcast has ended (see `Ended` in [ANNOUNCE_START](#announce-start)), the requested `Epoch` is not the one being served, or it otherwise refuses — it MUST reset the stream rather than leave it pending, and SHOULD do so promptly (within roughly a round trip) so the subscriber is not left waiting.
 A subscription the publisher accepts but has no groups for yet is not a rejection: for a live track the publisher MAY withhold SUBSCRIBE_OK until the first matching group resolves the start. A subscriber therefore distinguishes "pending" from "refused" by the stream reset, not by a timeout.
 The Subscribe Stream does not carry the track's publisher properties — those are immutable and fetched once via a [Track Stream](#track-stream) (see [TRACK_INFO](#track-info)).
 The subscriber MUST have the track's TRACK_INFO before it can fully interpret the FRAME messages that arrive on Group Streams, since the timescale is needed to interpret each timestamp; it MAY open the Track and Subscribe streams concurrently and buffer frames until TRACK_INFO arrives.
@@ -337,10 +339,11 @@ Either endpoint MAY reset/cancel the stream at any time.
 ### Fetch
 A subscriber opens a Fetch Stream (0x3) to request a single Group from a Track.
 
-The subscriber sends a FETCH message containing the broadcast path, track name, priority, and group sequence.
+The subscriber sends a FETCH message containing the broadcast path, track name, epoch, priority, and group sequence.
+Unlike SUBSCRIBE, FETCH works on both live and ended broadcasts; it is the only way to read an ended one, and a non-zero epoch pins the fetch to a specific content generation (see [FETCH](#fetch)).
 The publisher responds with FRAME messages directly on the same bidirectional stream — there is no response header.
 The Subscribe ID and Group Sequence for the returned FRAME messages are implicit, taken from the original FETCH request.
-As with a subscription, the subscriber MUST already have the track's [TRACK_INFO](#track-info) to parse the returned frames; because the properties are immutable, a single Track Stream lookup is reused across every FETCH of that track (group-by-group fetches do not re-fetch it).
+As with a subscription, the subscriber MUST already have the track's [TRACK_INFO](#track-info) to parse the returned frames; because the properties are immutable, a single Track Stream lookup is reused across every FETCH of that generation (group-by-group fetches do not re-fetch it).
 The publisher FINs the stream after the last frame, or resets the stream on error.
 
 Fetch behaves like HTTP: a single request/response per stream.
@@ -348,14 +351,12 @@ Fetch behaves like HTTP: a single request/response per stream.
 ### Track {#track-stream}
 A subscriber opens a Track Stream (0x6) to learn a Track's immutable publisher properties without subscribing or fetching.
 
-The subscriber sends a TRACK message containing the broadcast path and track name.
-The publisher replies with a single TRACK_INFO message and then FINs the stream, or resets the stream on error (e.g. the track does not exist).
-The returned properties are fixed for the lifetime of the track, so the subscriber SHOULD cache TRACK_INFO and reuse it across every SUBSCRIBE and FETCH for that track rather than requesting it again.
-When the track was discovered via an announcement, the cached value is tied to the broadcast's original publisher, identified by the first entry of the advertisement's reconstructed path (see [ANNOUNCE_RESTART](#announce-restart)).
-A re-announce that preserves the first entry is a route change for the same broadcast, and the cached TRACK_INFO remains valid.
-If the first entry changed, the broadcast was replaced: the subscriber MUST discard the cached TRACK_INFO and MUST re-request it before parsing any further FRAME messages, since the timescale may have changed.
-If FRAME messages cannot be decoded against the cached TRACK_INFO (for example a malformed delta or payload after a missed re-announcement), the subscriber MUST reset the affected stream with a protocol violation and re-request TRACK_INFO.
-A subscriber that reached the track without an advertisement (e.g. a path known out of band) has no such invalidation signal; it MAY re-request TRACK_INFO whenever it needs to confirm freshness (for example on a new session). A stale cache only risks misparsing frames from a changed track, so the subscriber that cannot observe re-announcements SHOULD NOT cache TRACK_INFO beyond a single connection.
+The subscriber sends a TRACK message containing the broadcast path, track name, and epoch (0 for the current generation).
+The publisher replies with a single TRACK_INFO message carrying the resolved epoch and then FINs the stream, or resets the stream on error (e.g. the track does not exist, or a non-zero epoch does not match).
+The returned properties are fixed for the lifetime of that generation, so the subscriber SHOULD cache TRACK_INFO keyed by broadcast path, track name, and epoch, and reuse it across every SUBSCRIBE and FETCH of the same generation.
+An announcement that changes the broadcast's Epoch replaces the content (see [ANNOUNCE_UPDATE](#announce-update)); cached TRACK_INFO from another generation MUST NOT be used to parse its frames, since the timescale may differ.
+A subscriber without announcements (a path known out of band) gets the same protection by echoing the resolved epoch in SUBSCRIBE and FETCH, so a concurrent replacement is a reset rather than misparsed frames.
+If FRAME messages cannot be decoded against the cached TRACK_INFO, the subscriber MUST reset the affected stream with a protocol violation and re-request it.
 
 Because a subscriber MAY open the Track stream concurrently with a SUBSCRIBE or FETCH (see [Subscribe](#subscribe) and [Fetch](#fetch)) and cannot parse any buffered group frames until TRACK_INFO arrives, the publisher SHOULD prioritize TRACK_INFO ahead of group data on the connection.
 Otherwise the concurrent case — intended to keep a cold subscribe or fetch to a single round trip — would stall behind queued group frames that the subscriber cannot yet decode.
@@ -701,16 +702,22 @@ A subscriber sends an ANNOUNCE_REQUEST message to indicate it wants to receive a
 ANNOUNCE_REQUEST Message {
   Message Length (i)
   Broadcast Path Prefix (s),
+  Ended (i),
 }
 ~~~
 
 **Broadcast Path Prefix**:
 Indicate interest for any broadcasts with a path that starts with this prefix.
 
+**Ended**:
+Whether ended broadcasts match this request (see `Ended` in [ANNOUNCE_START](#announce-start)).
+When 0, only live broadcasts are announced; when 1, ended broadcasts are announced too, e.g. to enumerate available recordings.
+Values other than 0 and 1 are a protocol violation.
+
 The publisher SHOULD skip announcements for broadcasts whose reconstructed path (including the publisher's own `Hop ID` from ANNOUNCE_OK) contains the origin the subscriber declared in its SETUP, when it declared one (see [Origin Parameter](#origin-parameter)).
 This is used by relays to avoid routing loops in a cluster; earlier versions carried the identity here as a per-stream `Exclude Hop` field.
 
-The publisher MUST respond with an ANNOUNCE_OK message followed by ANNOUNCE_START messages for any matching and available broadcasts, followed by ANNOUNCE_START, ANNOUNCE_END, and ANNOUNCE_RESTART messages for any future updates.
+The publisher MUST respond with an ANNOUNCE_OK message followed by ANNOUNCE_START messages for any matching and available broadcasts, followed by ANNOUNCE_START, ANNOUNCE_END, and ANNOUNCE_UPDATE messages for any future updates.
 Implementations SHOULD consider reasonable limits on the number of matching broadcasts to prevent resource exhaustion.
 
 
@@ -728,7 +735,7 @@ ANNOUNCE_OK Message {
 
 **Hop ID**:
 The publisher's own Hop ID.
-This is treated as the implicit trailing entry of every ANNOUNCE_START and ANNOUNCE_RESTART Hop ID list on this stream; those messages MUST NOT repeat this value as the last entry of their `Hop ID` list.
+This is treated as the implicit trailing entry of every ANNOUNCE_START and ANNOUNCE_UPDATE Hop ID list on this stream; those messages MUST NOT repeat this value as the last entry of their `Hop ID` list.
 The value 0 is reserved to mean "unknown": either no Hop ID was assigned (e.g. when bridging from an older protocol version) or the endpoint deliberately withholds it to obscure the underlying routing.
 A publisher that assigns a Hop ID MUST choose a non-zero value.
 Receivers reconstruct the full path as `Hop IDs ++ [ANNOUNCE_OK.Hop ID]`.
@@ -744,10 +751,10 @@ A value of `0` is valid and means the publisher is offering no initial available
 A publisher sends an ANNOUNCE_START message to advertise that a broadcast is available.
 Each ANNOUNCE_START implicitly assigns the next Announce ID on the stream: a counter starting at 0 that increments by 1 per ANNOUNCE_START.
 The id is not carried on the wire; both endpoints derive it from message order.
-ANNOUNCE_END and ANNOUNCE_RESTART later reference this id (see [ANNOUNCE_END](#announce-end) and [ANNOUNCE_RESTART](#announce-restart)).
+ANNOUNCE_END and ANNOUNCE_UPDATE later reference this id (see [ANNOUNCE_END](#announce-end) and [ANNOUNCE_UPDATE](#announce-update)).
 
 Only the suffix is encoded on the wire, as the full path can be constructed by prepending the requested prefix.
-An ANNOUNCE_START for a path that is already available on this stream is a protocol violation (use ANNOUNCE_RESTART).
+An ANNOUNCE_START for a path that is already available on this stream is a protocol violation (use ANNOUNCE_UPDATE).
 Any announcement before ANNOUNCE_OK is a protocol violation.
 
 ~~~
@@ -755,6 +762,8 @@ ANNOUNCE_START Message {
   Type (i) = 0x0
   Message Length (i)
   Broadcast Path Suffix (s),
+  Epoch (i),
+  Ended (i),
   Hop Count (i),
   Hop ID (i) ...,
   Route Cost (i),
@@ -767,6 +776,20 @@ Set to 0x0 to indicate an ANNOUNCE_START message.
 **Broadcast Path Suffix**:
 This is combined with the broadcast path prefix to form the full broadcast path.
 
+**Epoch**:
+The generation of content at this path, chosen by the original publisher and forwarded unchanged by relays.
+Each new generation MUST use a non-zero Epoch greater than the last.
+Wall-clock milliseconds are a convenient source, but clocks roll back and skew, so a publisher SHOULD take the maximum of its clock and one more than the highest Epoch it can observe at the path (e.g. the incumbent advertisement).
+A violation is not fatal: receivers keep no high-water mark, so an erroneously high Epoch suppresses newer generations only while its advertisement remains available.
+A value of 0 means unspecified: identity falls back to the first entry of the path (see below), e.g. when bridging from an endpoint that does not assign Epochs.
+
+**Ended**:
+Whether the broadcast has ended (1) or is live (0).
+An ended broadcast is complete or static content, such as a recording: the publisher MUST reset a Subscribe Stream for it, and subscribers read its groups via FETCH instead.
+`Ended` describes the content; retracting the advertisement itself is ANNOUNCE_END, and an ended broadcast may stay advertised indefinitely.
+Ended broadcasts are only advertised on Announce Streams that requested them (see [ANNOUNCE_REQUEST](#announce-request)); on other streams, a broadcast that ends but remains available is retracted with ANNOUNCE_END.
+Values other than 0 and 1 are a protocol violation.
+
 **Hop Count**:
 The number of Hop ID entries that follow, NOT including the publisher's own `Hop ID` from ANNOUNCE_OK.
 A value of 0 means no Hop ID entries are present, indicating either that the announcement originated locally on the publisher (the publisher itself is the origin) or that the upstream peer does not support hop tracking.
@@ -777,7 +800,7 @@ A unique identifier for each relay in the path from the origin publisher, ordere
 The responding publisher's own Hop ID is NOT included in this list; it is carried once in ANNOUNCE_OK as `Hop ID`.
 When forwarding an announcement received from an upstream peer, a relay MUST append the upstream peer's ANNOUNCE_OK `Hop ID` to this list (since that ID is no longer implicit downstream) and then send its own `Hop ID` in the ANNOUNCE_OK it sends to the downstream subscriber.
 The total path length is `Hop Count + 1` (including the implicit ANNOUNCE_OK `Hop ID`).
-The first entry of the reconstructed path (the first Hop ID, or the ANNOUNCE_OK `Hop ID` when the list is empty) identifies the original publisher of the broadcast; ANNOUNCE_RESTART uses it to distinguish a route change from a replacement (see [ANNOUNCE_RESTART](#announce-restart)).
+The first entry of the reconstructed path (the first Hop ID, or the ANNOUNCE_OK `Hop ID` when the list is empty) identifies the original publisher of the broadcast; it is the fallback content identity when `Epoch` is 0 (see [ANNOUNCE_UPDATE](#announce-update)).
 A Hop ID value of 0 means the hop is unknown: either it was never assigned (e.g. when bridging from an older protocol version) or a relay deliberately withholds it to obscure the underlying routing; the Hop Count still reflects the total number of entries including unknown hops.
 
 A receiver MUST discard an announcement whose reconstructed path contains its own Hop ID.
@@ -794,7 +817,7 @@ When forwarding an announcement received from an upstream peer, a relay adds the
 A relay that is actively carrying the broadcast (a live subscription exists for at least one of its tracks) SHOULD advertise 0 instead of the accumulated value: its ingress is already paid for, so the marginal cost of one more subscriber is only the links between them, which downstream receivers add themselves.
 This is what lets a cluster deduplicate: a subscriber that sees both a warm copy at cost 0 and the original at the full path cost pulls the copy that already exists.
 The discount applies only to an advertisement selecting the path the relay actually serves from; a standby path advertised to a subscriber whose declared origin filtered the serving path keeps its accumulated value, since serving that subscriber means opening a fresh ingest.
-When the relay stops carrying the broadcast it SHOULD restore the accumulated value via ANNOUNCE_RESTART, optionally after a grace period so brief subscriber churn does not flap routing across the mesh.
+When the relay stops carrying the broadcast it SHOULD restore the accumulated value via ANNOUNCE_UPDATE, optionally after a grace period so brief subscriber churn does not flap routing across the mesh.
 
 Two relays that independently begin carrying the same broadcast will each see the other's zero-cost advertisement as cheaper than their own source, and switching simultaneously would leave the broadcast with no source at all.
 An actively-carrying relay SHOULD therefore apply a deterministic tie-break before re-parenting onto a strictly cheaper advertisement from another actively-carrying relay (one that advertised a Route Cost of 0 from a path of two or more hops; a single-hop path is the original publisher, which can never adopt a route to its own broadcast), such as comparing a stable hash of the broadcast path and each endpoint's Hop ID, so that exactly one side moves.
@@ -823,26 +846,28 @@ Referencing an id that was never assigned, or one already retired, is a protocol
 Announce IDs are never reused within a stream; a broadcast that is announced again after an ANNOUNCE_END gets a fresh id from its next ANNOUNCE_START.
 
 
-## ANNOUNCE_RESTART {#announce-restart}
-A publisher sends an ANNOUNCE_RESTART message to atomically replace a previously started broadcast, referencing its Announce ID.
+## ANNOUNCE_UPDATE {#announce-update}
+A publisher sends an ANNOUNCE_UPDATE message to atomically replace a previously started advertisement, referencing its Announce ID.
 The advertisement is replaced in place (equivalent to ANNOUNCE_END+ANNOUNCE_START) and the id stays live.
 The Hop ID list MAY differ from the original (e.g. after a relay failover or upstream restart).
 
-The first entry of the reconstructed path identifies the original publisher (see [ANNOUNCE_START](#announce-start)), and it determines what the restart means:
+The `Epoch` determines what the update means (see [ANNOUNCE_START](#announce-start)):
 
-- The first entry is unchanged: the same publisher's broadcast is reachable over a different route.
-  The broadcast's content and track properties are continuous, so cached TRACK_INFO stays valid (see [Track](#track-stream)) and the subscriber MAY resume in-flight subscriptions on the new route at a group boundary instead of resubscribing.
-- The first entry changed: a different publisher replaced the broadcast at this path.
-  The subscriber MUST treat it as a new broadcast: cached TRACK_INFO MUST be discarded, and existing subscriptions do not carry over (the group sequences and track set of the new broadcast are unrelated to the old one).
-
-The first entry only identifies the publisher, not a particular broadcast instance: a publisher that restarts its own broadcast (same path, new content) is indistinguishable from a route change.
-A future extension may add an explicit epoch to announcements to make that case detectable.
+- Unchanged (non-zero): the same content over a different route, or a changed `Ended` flag or Route Cost.
+  Cached TRACK_INFO stays valid (see [Track](#track-stream)) and the subscriber MAY resume in-flight subscriptions at a group boundary.
+- Changed: a different generation occupies the path.
+  Cached TRACK_INFO MUST be discarded and existing subscriptions do not carry over.
+  A publisher SHOULD only move to a lower Epoch when the higher generation is gone entirely, e.g. a live broadcast vanished and only an older recording remains.
+- Both 0: the first entry of the reconstructed path decides instead, a preserved entry meaning a route change and a changed one a replacement.
+  The first entry only identifies the publisher, so a restart with new content is indistinguishable from a route change; assigning Epochs is what makes it detectable.
 
 ~~~
-ANNOUNCE_RESTART Message {
+ANNOUNCE_UPDATE Message {
   Type (i) = 0x2
   Message Length (i)
   Announce ID (i),
+  Epoch (i),
+  Ended (i),
   Hop Count (i),
   Hop ID (i) ...,
   Route Cost (i),
@@ -850,15 +875,16 @@ ANNOUNCE_RESTART Message {
 ~~~
 
 **Type**:
-Set to 0x2 to indicate an ANNOUNCE_RESTART message.
+Set to 0x2 to indicate an ANNOUNCE_UPDATE message.
 
 **Announce ID**:
 The ordinal implicitly assigned by a prior ANNOUNCE_START on this stream.
 Referencing an id that was never assigned, or one already retired by an ANNOUNCE_END, is a protocol violation.
 
-**Hop Count**, **Hop ID**, and **Route Cost**:
+**Epoch**, **Ended**, **Hop Count**, **Hop ID**, and **Route Cost**:
 As defined for [ANNOUNCE_START](#announce-start).
-A restart whose only change is the Route Cost is valid: it is how a relay advertises that it started or stopped actively carrying the broadcast.
+An update whose only change is the Route Cost is valid: it is how a relay advertises that it started or stopped actively carrying the broadcast.
+An update whose only change is the `Ended` flag is likewise valid: it is how a live broadcast ends into a recording without retiring its Announce ID.
 
 
 ## SUBSCRIBE
@@ -870,6 +896,7 @@ SUBSCRIBE Message {
   Subscribe ID (i)
   Broadcast Path (s)
   Track Name (s)
+  Epoch (i)
   Subscriber Priority (8)
   Subscriber Ordered (8)
   Subscriber Max Latency (i)
@@ -881,6 +908,10 @@ SUBSCRIBE Message {
 **Subscribe ID**:
 A unique identifier chosen by the subscriber.
 A Subscribe ID MUST NOT be reused within the same session, even if the prior subscription has been closed.
+
+**Epoch**:
+The generation to subscribe to (see [ANNOUNCE_START](#announce-start)): 0 for the current one, or a non-zero value that MUST match the generation being served (the publisher resets the stream otherwise).
+Echoing the Epoch of the advertisement acted on closes the race where a SUBSCRIBE crosses a replacement in flight.
 
 **Subscriber Priority**:
 The priority of the subscription within the session, represented as a u8.
@@ -939,6 +970,7 @@ TRACK Message {
   Message Length (i)
   Broadcast Path (s)
   Track Name (s)
+  Epoch (i)
 }
 ~~~
 
@@ -948,6 +980,9 @@ The broadcast path of the track.
 **Track Name**:
 The name of the track.
 
+**Epoch**:
+The generation to resolve (see [ANNOUNCE_START](#announce-start)): 0 for the current one, or a non-zero value that MUST match a generation the publisher can serve (it resets the stream otherwise).
+
 ## TRACK_INFO {#track-info}
 TRACK_INFO is sent by the publisher in response to a TRACK message.
 It is the sole message on the Track Stream; the publisher FINs immediately afterward, or resets the stream on error (e.g. the track does not exist).
@@ -955,6 +990,7 @@ It is the sole message on the Track Stream; the publisher FINs immediately after
 ~~~
 TRACK_INFO Message {
   Message Length (i)
+  Epoch (i)
   Publisher Priority (8)
   Publisher Ordered (8)
   Publisher Max Latency (i)
@@ -966,6 +1002,10 @@ Every field is **fixed for the lifetime of the Track** and MUST NOT change; a ch
 This immutability is what lets the properties live on their own stream — fetched once and cached — instead of being echoed on every SUBSCRIBE and FETCH response.
 It is also deliberate for relays: a relay serving one upstream subscription to many downstream subscribers would otherwise have to fan a single publisher-side change out to every downstream (and invalidate any cached groups) — publisher changes fan *out*.
 Subscriber properties (see [SUBSCRIBE](#subscribe)) are the opposite: they fan *in* at the relay, which already merges them, so they MAY change freely via SUBSCRIBE_UPDATE.
+
+**Epoch**:
+The generation these properties belong to (see [ANNOUNCE_START](#announce-start)), or 0 when the publisher assigns none.
+Subscribers key their TRACK_INFO cache by it and MAY echo it in SUBSCRIBE and FETCH to pin the same generation.
 
 **Publisher Priority**:
 The publisher's priority for this Track, represented as a u8, used only to resolve ties between subscriptions of equal subscriber priority.
@@ -1079,6 +1119,7 @@ FETCH Message {
   Message Length (i)
   Broadcast Path (s)
   Track Name (s)
+  Epoch (i)
   Subscriber Priority (8)
   Group Sequence (i)
 }
@@ -1089,6 +1130,10 @@ The broadcast path of the track to fetch from.
 
 **Track Name**:
 The name of the track to fetch from.
+
+**Epoch**:
+The generation to fetch from (see [ANNOUNCE_START](#announce-start)): 0 for the current one.
+A publisher that retains a non-current generation (e.g. a recording) MAY serve it, but MUST reset the stream rather than serve a group from a different generation than requested.
 
 **Subscriber Priority**:
 The priority of the fetch within the session, represented as a u8.
@@ -1194,18 +1239,19 @@ The `Message Length` describes the payload size on the wire.
 - Extended the SETUP `Path` parameter to carry the URI query: a client appends `?` and the query component after the path, matching moq-transport's PATH option. The credential a deployment puts in the query was previously unrepresentable on a binding with no request URI.
 - Allowed an empty SETUP `Path` parameter, equivalent to omitting it; both request the server's default path. Previously an empty value was a protocol violation, which made the two ways of asking for the default disagree.
 - Corrected SUBSCRIBE_END `Group` to an exclusive bound: the first sequence that will never be delivered, with 0 meaning no groups were produced. It was previously specified as the inclusive last group, which could not distinguish an empty track from one whose only group was 0.
-- Split ANNOUNCE_BROADCAST into three typed messages: ANNOUNCE_START (0x0), ANNOUNCE_END (0x1), and ANNOUNCE_RESTART (0x2), each prefixed with a Type discriminator like the subscribe stream's responses.
+- Split ANNOUNCE_BROADCAST into three typed messages: ANNOUNCE_START (0x0), ANNOUNCE_END (0x1), and ANNOUNCE_UPDATE (0x2), each prefixed with a Type discriminator like the subscribe stream's responses.
 - Added implicit Announce IDs: each ANNOUNCE_START assigns the next per-stream ordinal.
-- ANNOUNCE_END and ANNOUNCE_RESTART reference the Announce ID instead of repeating the broadcast path.
-- Replaced the duplicate-`active` restart idiom with ANNOUNCE_RESTART; a second ANNOUNCE_START for an already-available path is now a protocol violation.
-- Defined the first entry of the reconstructed path as the original publisher's identity: a restart that preserves it is a route change (TRACK_INFO stays valid, subscriptions may resume), one that changes it replaces the broadcast (TRACK_INFO discarded, nothing resumes).
-- Added a `Route Cost` field to ANNOUNCE_START and ANNOUNCE_RESTART: the accumulated cost of the transfers a subscription via this advertisement would newly cause. Route selection prefers the lowest cost, with path length as the tie-break, and the most recently received advertisement below that.
+- ANNOUNCE_END and ANNOUNCE_UPDATE reference the Announce ID instead of repeating the broadcast path.
+- Replaced the duplicate-`active` restart idiom with ANNOUNCE_UPDATE; a second ANNOUNCE_START for an already-available path is now a protocol violation.
+- Added an `Epoch` to ANNOUNCE_START and ANNOUNCE_UPDATE: a per-path content generation minted by the original publisher and forwarded unchanged, 0 meaning unspecified. The highest Epoch wins (non-zero outranks 0) and replacement is decided by value rather than arrival order; equal non-zero Epochs splice, and the first entry of the path remains the identity only when both are 0.
+- Added an `Ended` flag to ANNOUNCE_START and ANNOUNCE_UPDATE, and as an opt-in filter on ANNOUNCE_REQUEST: ended broadcasts reject SUBSCRIBE, are read via FETCH, and are only announced to subscribers that asked for them.
+- Added an `Epoch` to SUBSCRIBE, FETCH, and TRACK (0 = current, mismatch = reset) and the resolved `Epoch` to TRACK_INFO, so metadata and groups always come from the same generation and requests cannot race a replacement.
+- Added a `Route Cost` field to ANNOUNCE_START and ANNOUNCE_UPDATE: the accumulated cost of the transfers a subscription via this advertisement would newly cause. Route selection prefers the lowest cost, with path length as the tie-break, and the most recently received advertisement below that.
 - Added a SETUP `Cost` parameter (0x4) declaring the price a link adds to every announcement crossing it; unpriced links default to 1, degrading to shortest-path routing.
 - Removed `Exclude Hop` from ANNOUNCE_REQUEST. The receiver's hop-based loop check already discards a looped announcement, so the field only saved the wasted send.
 - Stated the receiver's loop check normatively in ANNOUNCE_START: an announcement whose reconstructed path contains the receiver's own Hop ID is neither forwarded nor selected as a route.
 - Added a SETUP `Origin` parameter (0x5): each endpoint declares its Hop ID at session setup, carrying session-wide the identity `Exclude Hop` carried per announce stream, and filtering subscriptions as well as announcements (including sessions that never open an Announce Stream).
-- Made advertisement selection per subscriber: the publisher advertises the best path avoiding each subscriber's declared origin (a subscriber the serving path flows through receives the best standby instead of nothing), MUST serve subscriptions by the same exclusion, and the actively-carrying cost discount applies only to the serving path. This is how redundant (shared first hop) publishers fail over across a mesh.
-- Defined same-path advertisements sharing a first entry as interchangeable content a relay may splice across at a Group boundary; differing first entries never splice, the later replacing the earlier.
+- Made advertisement selection per subscriber: the publisher advertises the best path avoiding each subscriber's declared origin (a subscriber the serving path flows through receives the best standby instead of nothing), MUST serve subscriptions by the same exclusion, and the actively-carrying cost discount applies only to the serving path. This is how redundant (shared Epoch) publishers fail over across a mesh.
 
 ## moq-lite-05
 - Renamed ANNOUNCE_INTEREST to ANNOUNCE_REQUEST and ANNOUNCE to ANNOUNCE_BROADCAST.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -357,7 +357,7 @@ The publisher replies with a single TRACK_INFO message carrying the resolved epo
 The returned properties are fixed for the lifetime of that generation, so the subscriber SHOULD cache TRACK_INFO keyed by broadcast path, track name, and epoch, and reuse it across every SUBSCRIBE and FETCH of the same generation.
 An announcement that changes the broadcast's Epoch replaces the content (see [ANNOUNCE_UPDATE](#announce-update)); cached TRACK_INFO from another generation MUST NOT be used to parse its frames, since the timescale may differ.
 A subscriber without announcements (a path known out of band) gets the same protection by echoing a non-zero resolved epoch in SUBSCRIBE and FETCH, so a concurrent replacement is a reset rather than misparsed frames.
-A resolved epoch of 0 pins nothing, so such a cache SHOULD NOT outlive the connection.
+A resolved epoch of 0 pins nothing and cannot key the cache: a subscriber following announcements MUST discard such a cache when the broadcast's advertisement is replaced (see [ANNOUNCE_UPDATE](#announce-update)), and one without announcements SHOULD NOT keep it beyond the connection.
 If FRAME messages cannot be decoded against the cached TRACK_INFO, the subscriber MUST reset the affected stream with a protocol violation and re-request it.
 
 Because a subscriber MAY open the Track stream concurrently with a SUBSCRIBE or FETCH (see [Subscribe](#subscribe) and [Fetch](#fetch)) and cannot parse any buffered group frames until TRACK_INFO arrives, the publisher SHOULD prioritize TRACK_INFO ahead of group data on the connection.
@@ -787,7 +787,8 @@ A value of 0 means unspecified: identity falls back to the first entry of the pa
 
 **Ended**:
 Whether the broadcast has ended (1) or is live (0).
-An ended broadcast is complete or static content, such as a recording: the publisher MUST reset a Subscribe Stream for it, and subscribers read its groups via FETCH instead.
+An ended broadcast is complete or static content, such as a recording: the publisher MUST reset a new Subscribe Stream for it, and subscribers read its groups via FETCH instead.
+A broadcast ending does not disturb subscriptions already in flight: they conclude normally with SUBSCRIBE_END.
 `Ended` describes the content; retracting the advertisement itself is ANNOUNCE_END, and an ended broadcast may stay advertised indefinitely.
 Ended broadcasts are only advertised on Announce Streams that requested them (see [ANNOUNCE_REQUEST](#announce-request)); on other streams, a broadcast that ends but remains available is retracted with ANNOUNCE_END.
 Values other than 0 and 1 are a protocol violation.


### PR DESCRIPTION
## What

Spec-first half of #2610: the wire design for broadcast epochs, ended (VOD) broadcasts, and epoch-pinned requests.

- **`drafts/draft-lcurley-moq-lite.md`** (moq-lite-06 WIP section, unpublished, amended in place):
  - `ANNOUNCE_START` / `ANNOUNCE_UPDATE` (renamed from `ANNOUNCE_RESTART`) gain `Epoch (i)` and `Ended (i)`; `ANNOUNCE_REQUEST` gains an `Ended (i)` opt-in filter.
  - Epoch is the per-path content generation: highest wins (non-zero outranks 0), replacement decided by value rather than arrival order, equal non-zero epochs splice, first-entry identity only for zero-vs-zero.
  - Ended broadcasts reject SUBSCRIBE, are read via FETCH, and are announced only to opted-in streams (the VOD enumeration path).
  - `SUBSCRIBE` / `FETCH` / `TRACK` gain `Epoch (i)` (0 = current, mismatch = reset); `TRACK_INFO` returns the resolved epoch so metadata caches key by generation.
- **`drafts/draft-lcurley-moq-broadcast.md`** (new): the moq-transport counterpart, EPOCH as a negotiated setup option + message parameter, structured like relay-hops.
- **`drafts/CLAUDE.md`**: brevity rule for spec prose.

## Why

Broadcast identity currently rides on the first hop of the route chain, which conflates routing identity with content identity: a restarting publisher with a stable origin id gets falsely spliced, a restarted process cannot resume content it legitimately could, and the newest-announcement tie-break races a stale generation arriving over a fresh connection. There is also no wire representation for complete (VOD) content or for enumerating it.

## Reviewer notes

- An adversarial review pass already ran against an earlier revision; its three findings are addressed here: TRACK/TRACK_INFO carry the epoch so metadata binds to a generation, epoch-0 has a total order (non-zero outranks 0, first-entry fallback scoped to zero-vs-zero), and the wall-clock minting text no longer claims strict monotonicity (receivers keep no high-water mark, which bounds a bad epoch to its advertisement's lifetime).
- No code changes in this PR: the implementation plan with phases and regression tests is #2610. This intentionally inverts the usual same-PR draft/code rule (Cross-Package Sync) because lite-06 is unpublished and unshipped; the code currently speaking the older lite-06 framing must be updated before the ALPN ships anywhere.
- `just drafts check` passes; the doc-site render test (`bun test ./.vitepress` in `doc/`) passes at 27/27, picking up the new draft automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Fable 5)