### PR TITLE
fix(moq-net): subscribe to the ietf peer's namespace, not our own root

### DIFF
--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -440,3 +440,58 @@ async fn run_goaway<R: web_transport_trait::RecvStream>(
 		Err(Error::UnexpectedMessage)
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn occurrences(log: &crate::lite::test_transport::Log, needle: &[u8]) -> usize {
+		let writes = log.writes.lock().unwrap();
+		writes.windows(needle.len()).filter(|window| *window == needle).count()
+	}
+
+	/// A subscriber issues one SUBSCRIBE_NAMESPACE per PERMITTED PREFIX, and asks for
+	/// those prefixes rather than the root it mounts replies under. Driven through
+	/// `start` so the per-prefix fan-out is exercised, not just one stream in
+	/// isolation: a loop that opened a single stream would still satisfy a test that
+	/// called `run_subscribe_namespace` itself.
+	#[tokio::test]
+	async fn every_permitted_prefix_gets_its_own_subscribe_namespace() {
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let scoped = origin
+			.with_root("rootns")
+			.and_then(|rooted| rooted.scope(&[crate::Path::new("cam"), crate::Path::new("mic")]))
+			.expect("scope the origin to two prefixes");
+
+		let gate = kio::Producer::new(true);
+		let session = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
+		let log = session.log.clone();
+
+		let driver = start(
+			session,
+			None,
+			None,
+			true,
+			None,
+			Some(scoped),
+			None,
+			Version::Draft18,
+			None,
+			None,
+		)
+		.expect("start the session");
+		let _driver = tokio::spawn(driver);
+
+		// Both requests are written before either peer response, which never comes.
+		for _ in 0..100 {
+			if occurrences(&log, b"cam") > 0 && occurrences(&log, b"mic") > 0 {
+				break;
+			}
+			tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+		}
+
+		assert_eq!(occurrences(&log, b"cam"), 1, "one SUBSCRIBE_NAMESPACE for cam");
+		assert_eq!(occurrences(&log, b"mic"), 1, "one SUBSCRIBE_NAMESPACE for mic");
+		assert_eq!(occurrences(&log, b"rootns"), 0, "asked the peer for our local root");
+	}
+}

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -55,7 +55,7 @@ pub fn start<S: web_transport_trait::Session>(
 				let subscriber = Subscriber::new(adapter.clone(), subscribe, control, peer_origin, version, tasks);
 
 				let dispatch_session = adapter.clone();
-				let mut sub_ns = subscriber.clone();
+				let sub_ns = subscriber.clone();
 				let sub_ns_adapter = adapter.clone();
 
 				// Every half only ends the session on error (err_only parks on clean
@@ -69,19 +69,32 @@ pub fn start<S: web_transport_trait::Session>(
 					version
 				)));
 				let mut publisher_run = std::pin::pin!(err_only(publisher.run()));
+				// One SUBSCRIBE_NAMESPACE per permitted prefix, like `lite::Subscriber`:
+				// the scope is what we may ask for, and it is not the origin's root.
 				let mut sub_ns_run = std::pin::pin!(err_only(async {
-					let stream = match version {
-						Version::Draft16 => {
-							let (send, recv) = sub_ns_adapter.open_native_bi().await?;
-							Stream {
-								writer: crate::coding::Writer::new(send, version),
-								reader: crate::coding::Reader::new(recv, version),
+					let mut prefixes = futures::stream::FuturesUnordered::new();
+					for prefix in sub_ns.subscribe_prefixes() {
+						let mut sub_ns = sub_ns.clone();
+						let sub_ns_adapter = sub_ns_adapter.clone();
+						prefixes.push(async move {
+							let stream = match version {
+								Version::Draft16 => {
+									let (send, recv) = sub_ns_adapter.open_native_bi().await?;
+									Stream {
+										writer: crate::coding::Writer::new(send, version),
+										reader: crate::coding::Reader::new(recv, version),
+									}
+								}
+								_ => Stream::open(&sub_ns_adapter, version).await?,
+							};
+							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix).await {
+								tracing::warn!(%err, "subscribe_namespace failed, continuing without");
 							}
-						}
-						_ => Stream::open(&sub_ns_adapter, version).await?,
-					};
-					if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
-						tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+							Ok::<(), Error>(())
+						});
+					}
+					while let Some(result) = futures::StreamExt::next(&mut prefixes).await {
+						result?;
 					}
 					Ok(())
 				}));
@@ -128,7 +141,7 @@ pub fn start<S: web_transport_trait::Session>(
 				let subscriber = Subscriber::new(session.clone(), subscribe, control, peer_origin, version, tasks);
 
 				let sub_ns_session = session.clone();
-				let mut sub_ns = subscriber.clone();
+				let sub_ns = subscriber.clone();
 
 				// When the peer's SETUP was pre-read (a gated server accept), monitor
 				// GOAWAY on that stream here; otherwise `run_unis` does it when the SETUP
@@ -153,10 +166,22 @@ pub fn start<S: web_transport_trait::Session>(
 				let mut publisher_run = std::pin::pin!(err_only(publisher.run()));
 				let mut goaway = std::pin::pin!(err_only(goaway));
 				let mut setup = std::pin::pin!(setup);
+				// One SUBSCRIBE_NAMESPACE per permitted prefix; see the draft-16 arm.
 				let mut sub_ns_run = std::pin::pin!(err_only(async {
-					let stream = Stream::open(&sub_ns_session, version).await?;
-					if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
-						tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+					let mut prefixes = futures::stream::FuturesUnordered::new();
+					for prefix in sub_ns.subscribe_prefixes() {
+						let mut sub_ns = sub_ns.clone();
+						let sub_ns_session = sub_ns_session.clone();
+						prefixes.push(async move {
+							let stream = Stream::open(&sub_ns_session, version).await?;
+							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix).await {
+								tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+							}
+							Ok::<(), Error>(())
+						});
+					}
+					while let Some(result) = futures::StreamExt::next(&mut prefixes).await {
+						result?;
 					}
 					Ok(())
 				}));

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -155,13 +155,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	/// The prefixes to issue SUBSCRIBE_NAMESPACE for: this handle's permitted scope,
-	/// relative to its root, exactly as `lite::Subscriber` uses.
+	/// relative to its root.
 	///
-	/// NOT the root. The root says where a remote broadcast MOUNTS locally; the scope
-	/// says what we may ask for. They coincide only when the peer shares our namespace,
-	/// and conflating them broke both halves for a rooted subscriber: we asked the peer
-	/// for a prefix it had never heard of (nothing matched), and re-joined that same
-	/// root onto the reply so anything that did match landed at `<root>/<root>/...`.
+	/// The scope is what we may ASK the peer for; the root is where what comes back
+	/// MOUNTS locally. Those are independent, and only coincide when the peer shares
+	/// our namespace -- a peer outside it has never heard of our root, so a rooted
+	/// subscriber asks for its scope and mounts the replies under the root.
 	pub fn subscribe_prefixes(&self) -> Vec<PathOwned> {
 		self.origin.allowed().map(|p| p.to_owned()).collect()
 	}
@@ -1035,6 +1034,92 @@ mod tests {
 			resolve_track_alias(aliases.consume(), 7).await,
 			Err(Error::NotFound)
 		));
+	}
+
+	async fn settle() {
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+	}
+
+	fn occurrences(log: &crate::lite::test_transport::Log, needle: &[u8]) -> usize {
+		let writes = log.writes.lock().unwrap();
+		writes.windows(needle.len()).filter(|window| *window == needle).count()
+	}
+
+	/// A rooted subscriber asks the peer for its permitted SCOPE. The root names where
+	/// replies mount on our side, which is meaningless to a peer outside our namespace,
+	/// so sending it asks for a prefix that matches nothing there.
+	#[tokio::test]
+	async fn a_rooted_subscriber_asks_for_its_scope_not_its_root() {
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let scoped = origin
+			.with_root("rootns")
+			.and_then(|rooted| rooted.scope(&[crate::Path::new("cam")]))
+			.expect("scope the origin");
+
+		let gate = kio::Producer::new(true);
+		let session = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
+		let log = session.log.clone();
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+		let mut subscriber = Subscriber::new(
+			session.clone(),
+			scoped,
+			Control::new(None, false),
+			None,
+			Version::Draft16,
+			tasks,
+		);
+
+		assert_eq!(
+			subscriber.subscribe_prefixes(),
+			vec![crate::Path::new("cam").to_owned()],
+			"one SUBSCRIBE_NAMESPACE per permitted prefix, relative to the root",
+		);
+
+		let stream = Stream::open(&session, Version::Draft16).await.unwrap();
+		let mut run = std::pin::pin!(subscriber.run_subscribe_namespace(stream, crate::Path::new("cam").to_owned()));
+		// Parks awaiting the peer's response; the request is already on the wire.
+		assert!(futures::poll!(run.as_mut()).is_pending());
+
+		assert_eq!(occurrences(&log, b"cam"), 1, "asked the peer for our scope");
+		assert_eq!(occurrences(&log, b"rootns"), 0, "asked the peer for our local root");
+	}
+
+	/// A suffix the peer returns is relative to the prefix we asked for, and mounts
+	/// under our root exactly once.
+	#[tokio::test]
+	async fn a_rooted_subscriber_mounts_a_reply_under_its_root_once() {
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let consumer = origin.consume();
+		let scoped = origin
+			.with_root("rootns")
+			.and_then(|rooted| rooted.scope(&[crate::Path::new("cam")]))
+			.expect("scope the origin");
+
+		let session = crate::lite::test_transport::SinkSession::new(Default::default());
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+		let mut subscriber = Subscriber::new(
+			session,
+			scoped,
+			Control::new(None, false),
+			None,
+			Version::Draft16,
+			tasks,
+		);
+
+		// What the NAMESPACE arm does with a suffix, using the prefix we subscribed.
+		let prefix = subscriber.subscribe_prefixes().pop().expect("one prefix");
+		let path = prefix.join(crate::Path::new("x.hang"));
+		subscriber.start_announce(path).unwrap();
+		settle().await;
+
+		assert!(
+			consumer.get_broadcast("rootns/cam/x.hang").is_some(),
+			"the reply mounts under the root once",
+		);
+		assert!(
+			consumer.get_broadcast("rootns/rootns/cam/x.hang").is_none(),
+			"the root was applied twice",
+		);
 	}
 
 	#[test]

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -154,14 +154,26 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Some(track)
 	}
 
-	/// Send SUBSCRIBE_NAMESPACE on a bidi stream.
+	/// The prefixes to issue SUBSCRIBE_NAMESPACE for: this handle's permitted scope,
+	/// relative to its root, exactly as `lite::Subscriber` uses.
+	///
+	/// NOT the root. The root says where a remote broadcast MOUNTS locally; the scope
+	/// says what we may ask for. They coincide only when the peer shares our namespace,
+	/// and conflating them broke both halves for a rooted subscriber: we asked the peer
+	/// for a prefix it had never heard of (nothing matched), and re-joined that same
+	/// root onto the reply so anything that did match landed at `<root>/<root>/...`.
+	pub fn subscribe_prefixes(&self) -> Vec<PathOwned> {
+		self.origin.allowed().map(|p| p.to_owned()).collect()
+	}
+
+	/// Send SUBSCRIBE_NAMESPACE for one prefix on a bidi stream.
 	/// The caller is responsible for opening the appropriate stream type
-	/// (virtual for v14/v15, real bidi for v16+).
+	/// (virtual for v14/v15, real bidi for v16+), one per prefix.
 	pub async fn run_subscribe_namespace<T: web_transport_trait::Session>(
 		&mut self,
 		mut stream: Stream<T, Version>,
+		prefix: PathOwned,
 	) -> Result<(), Error> {
-		let prefix = self.origin.root().to_owned();
 		let request_id = self.control.next_request_id().await?;
 
 		// Draft-18+ uses SUBSCRIBE_NAMESPACE (0x50); earlier drafts use the legacy
@@ -225,6 +237,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let mut data = stream.reader.read_exact(size as usize).await?;
 
 			match type_id {
+				// The suffix is relative to the prefix we subscribed, which is itself
+				// relative to our root -- so the join is too, which is what everything
+				// below wants (`create_broadcast` joins the root itself).
 				ietf::Namespace::ID => {
 					let msg = ietf::Namespace::decode_msg(&mut data, self.version)?;
 					let path = prefix.join(&msg.suffix);


### PR DESCRIPTION
`ietf::Subscriber` used `origin.root()` for two different jobs, and both were
wrong for any subscriber whose origin is rooted:

- it sent the LOCAL root as the `SUBSCRIBE_NAMESPACE` prefix, asking the peer for
  a namespace the peer has never heard of, so nothing ever matched; and
- it re-joined that same root onto the reply before `start_announce`, which takes
  a path relative to the origin root (`create_broadcast` joins the root itself),
  so anything that *did* match landed at `<root>/<root>/...`.

The root says where a remote broadcast **mounts** locally. The permitted scope
says what we may **ask** for. They coincide only when the peer shares our
namespace, which is why this stayed invisible: with an empty root both mistakes
are no-ops, and every existing ietf subscriber has an empty root.

`lite::Subscriber` already had this right -- it iterates `origin.allowed()` and
opens one announce stream per prefix. This does the same for ietf:
`subscribe_prefixes()` exposes the scope, `run_subscribe_namespace` takes the
prefix as a parameter, and the session opens one stream per prefix.

Asking for the scope rather than something wider also keeps the existing
`start_announce(path)?` correct. Every announce that arrives is in scope, so an
out-of-scope path can no longer return `Unauthorized` and fail the *whole*
namespace subscription -- which is why "subscribe to a wider prefix and let the
local scope filter" is not a viable alternative here.

## How it was found

Federating a project with a Cloudflare (draft-16) relay. The publish direction
worked; the subscribe direction asked Cloudflare for `<project-id>` and received
nothing. Forcing a match by publishing under that name instead produced the
double mount:

```
namespace path=<pid>/x.hang
announce broadcast=<pid>/<pid>/x.hang
```

## Verification

Against a real Cloudflare draft-16 relay, with a rooted subscriber:

```
subscribe_namespace sent prefix=            (was prefix=<pid>)
namespace path=cfin.hang
announce broadcast=<pid>/cfin.hang          (was <pid>/<pid>/cfin.hang)
```

5.07 MB of h264 1280x720 + AAC pulled back through the local relay for a
broadcast published into Cloudflare, and no doubled paths anywhere in the log.

`cargo test -p moq-net --lib` 616/616 and `cargo test -p moq-relay --test smoke`
13/13.

(written by Opus 5)
