### PR TITLE
feat(moq-native): make connect return a reconnecting Connection handle

### DIFF
--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -158,7 +158,7 @@ On the receiving side:
 
 A moq-transport client sends an empty URI: only a server can tell a peer where to reconnect. The URI is capped at 8,192 bytes on both wires, and a second GOAWAY on a session is a protocol violation that closes it.
 
-Native clients get step 3 for free from `moq_native::Client::reconnect`, which dials the replacement while the old session keeps serving and hands over at a group boundary. `--goaway-redirect` chooses how far to trust the URI and `--goaway-handover` bounds how long the old session lingers.
+Native clients get step 3 for free from `moq_native::Client::connect`, which dials the replacement while the old session keeps serving and hands over at a group boundary. `--goaway-redirect` chooses how far to trust the URI and `--goaway-handover` bounds how long the old session lingers.
 
 `moq-relay` uses this in both directions: on shutdown it drains its own downstream sessions (see [`--drain-timeout`](/bin/relay/config#drain-timeout)), and on a GOAWAY from a cluster peer the reconnect loop migrates transparently.
 

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -23,10 +23,17 @@ Create a [`ClientConfig`](https://docs.rs/moq-native/latest/moq_native/struct.Cl
 ```rust
 let client = moq_native::ClientConfig::default().init()?;
 let url = url::Url::parse("https://cdn.moq.dev/anon/my-broadcast")?;
-let session = client.connect(url).await?;
+
+// A background task dials and redials with backoff if the session drops.
+// Drop the handle to disconnect.
+let connection = client.connect(url);
+
+// Optionally wait for the first session (surfacing dial errors up front).
+let session = connection.established().await?;
 ```
 
 The default configuration uses system TLS roots, enables WebSocket fallback, and gives QUIC a 200ms head-start.
+Set [`ClientConfig::reconnect`](https://docs.rs/moq-native/latest/moq_native/struct.ClientConfig.html#structfield.reconnect) to `false` for a one-shot dial: the session's close then ends the connection instead of triggering a redial.
 
 ### URL Schemes
 
@@ -55,7 +62,7 @@ Pass JWT tokens via URL query parameters:
 let url = Url::parse(&format!(
     "https://relay.example.com/room/123?jwt={}", token
 ))?;
-let session = client.connect(url).await?;
+let session = client.connect(url).established().await?;
 ```
 
 See the [Authentication guide](/bin/relay/auth) for how to generate tokens.
@@ -67,7 +74,7 @@ The [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/vi
 The connected [`Session`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html) exposes a [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Producer.html) you publish broadcasts into:
 
 ```rust
-let session = client.connect(url).await?;
+let session = client.connect(url).established().await?;
 
 let route = moq_net::broadcast::Route::new().with_announce(true);
 let mut broadcast = session.publisher().create_broadcast("", route)?;
@@ -83,7 +90,7 @@ The [subscribe example](https://github.com/moq-dev/moq/blob/main/rs/hang/example
 The session also exposes a [`consumer()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.consumer) [`origin::Consumer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Consumer.html) for receiving announcements:
 
 ```rust
-let session = client.connect(url).await?;
+let session = client.connect(url).established().await?;
 let mut announced = session.consumer().announced();
 
 // Wait for broadcasts to be announced.

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -74,7 +74,7 @@ Wire an [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struc
 ```rust
 // Publish into an origin wired before connecting: it outlives any one session,
 // so the broadcast survives a reconnect. Hold the connection to keep redialing.
-let origin = moq_net::Origin::new().produce();
+let origin = moq_net::Origin::random().produce();
 let _connection = client.with_publisher(origin.consume()).connect(url);
 
 let route = moq_net::broadcast::Route::new().with_announce(true);
@@ -93,14 +93,14 @@ Subscribing works the same way round: wire an origin in before connecting and re
 ```rust
 // Consume into an origin wired before connecting, so announcements keep flowing
 // across a reconnect. Hold the connection to keep redialing.
-let origin = moq_net::Origin::new().produce();
+let origin = moq_net::Origin::random().produce();
 let mut announced = origin.consume().announced();
 let _connection = client.with_subscriber(origin).connect(url);
 
 // Wait for broadcasts to be announced.
-while let Some((path, broadcast)) = announced.next().await {
-    let Some(broadcast) = broadcast else {
-        tracing::info!(%path, "broadcast ended");
+while let Some(update) = announced.next().await {
+    let Some(broadcast) = update.broadcast else {
+        tracing::info!(path = %update.path, "broadcast ended");
         continue;
     };
     // Subscribe to tracks on this broadcast...

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -25,11 +25,9 @@ let client = moq_native::ClientConfig::default().init()?;
 let url = url::Url::parse("https://cdn.moq.dev/anon/my-broadcast")?;
 
 // A background task dials and redials with backoff if the session drops.
-// Drop the handle to disconnect.
-let connection = client.connect(url);
-
-// Optionally wait for the first session (surfacing dial errors up front).
-let session = connection.established().await?;
+// `established` waits for the first session and hands the connection back;
+// hold it to keep reconnecting, drop it to disconnect.
+let connection = client.connect(url).established().await?;
 ```
 
 The default configuration uses system TLS roots, enables WebSocket fallback, and gives QUIC a 200ms head-start.
@@ -62,7 +60,7 @@ Pass JWT tokens via URL query parameters:
 let url = Url::parse(&format!(
     "https://relay.example.com/room/123?jwt={}", token
 ))?;
-let session = client.connect(url).established().await?;
+let connection = client.connect(url).established().await?;
 ```
 
 See the [Authentication guide](/bin/relay/auth) for how to generate tokens.
@@ -71,13 +69,16 @@ See the [Authentication guide](/bin/relay/auth) for how to generate tokens.
 
 The [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs) demonstrates publishing end-to-end.
 
-The connected [`Session`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html) exposes a [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Producer.html) you publish broadcasts into:
+Wire an [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Producer.html) into the client before connecting and publish your broadcasts into that. The origin outlives any single session, so a reconnect resumes where it left off; reaching for the session's own [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) instead ties your broadcasts to one transport.
 
 ```rust
-let session = client.connect(url).established().await?;
+// Publish into an origin wired before connecting: it outlives any one session,
+// so the broadcast survives a reconnect. Hold the connection to keep redialing.
+let origin = moq_net::Origin::new().produce();
+let _connection = client.with_publisher(origin.consume()).connect(url);
 
 let route = moq_net::broadcast::Route::new().with_announce(true);
-let mut broadcast = session.publisher().create_broadcast("", route)?;
+let mut broadcast = origin.create_broadcast("", route)?;
 // ... add catalog and tracks to the broadcast ...
 ```
 
@@ -87,11 +88,14 @@ See the full [video.rs](https://github.com/moq-dev/moq/blob/main/rs/hang/example
 
 The [subscribe example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/subscribe.rs) demonstrates subscribing end-to-end.
 
-The session also exposes a [`consumer()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.consumer) [`origin::Consumer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Consumer.html) for receiving announcements:
+Subscribing works the same way round: wire an origin in before connecting and read announcements from its [`origin::Consumer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Consumer.html), so they keep arriving across a reconnect.
 
 ```rust
-let session = client.connect(url).established().await?;
-let mut announced = session.consumer().announced();
+// Consume into an origin wired before connecting, so announcements keep flowing
+// across a reconnect. Hold the connection to keep redialing.
+let origin = moq_net::Origin::new().produce();
+let mut announced = origin.consume().announced();
+let _connection = client.with_subscriber(origin).connect(url);
 
 // Wait for broadcasts to be announced.
 while let Some((path, broadcast)) = announced.next().await {

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -72,7 +72,7 @@ let transport = web_transport::ClientBuilder::new()
     .await?;
 
 // Hand the transport to moq-net and run the MoQ handshake.
-let origin = moq_net::Origin::new().produce();
+let origin = moq_net::Origin::random().produce();
 let mut consumer = origin.consume();
 let (session, driver) = moq_net::Client::new()
     .with_subscriber(origin)

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -288,11 +288,12 @@ your broadcasts and subscriptions carry across reconnects:
 
 ```rust
 // Subscribe: wait for broadcasts to be announced.
-let origin = moq_net::Origin::new().produce();
-let mut consumer = origin.consume();
+let origin = moq_net::Origin::random().produce();
+let mut announced = origin.consume().announced();
 let _connection = client.with_subscriber(origin).connect(url);
 
-while let Some((path, broadcast)) = consumer.announced().await {
+while let Some(update) = announced.next().await {
+    // `update.broadcast` is None when the path went away.
     // ... subscribe to tracks on each broadcast ...
 }
 ```

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -277,17 +277,20 @@ a relay with a few lines:
 ```rust
 let client = moq_native::ClientConfig::default().init()?;
 let url = url::Url::parse("https://cdn.moq.dev/anon")?;
-let session = client.connect(url).await?;
+
+// The connection redials with backoff if it drops; drop the handle to disconnect.
+let connection = client.connect(url);
 ```
 
 To publish or consume, wire an [`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html)
-into the session before connecting:
+into the client before connecting. The origin outlives any individual session, so
+your broadcasts and subscriptions carry across reconnects:
 
 ```rust
 // Subscribe: wait for broadcasts to be announced.
 let origin = moq_net::Origin::new().produce();
 let mut consumer = origin.consume();
-let session = client.with_subscriber(origin).connect(url).await?;
+let _connection = client.with_subscriber(origin).connect(url);
 
 while let Some((path, broadcast)) = consumer.announced().await {
     // ... subscribe to tracks on each broadcast ...

--- a/py/moq-rs/tests/test_server.py
+++ b/py/moq-rs/tests/test_server.py
@@ -85,11 +85,17 @@ async def test_server_request_close():
             client = moq_ffi.MoqClient()
             client.set_tls_disable_verify(True)
             client.set_bind("127.0.0.1:0")
-            # MoqError is an Exception subclass at runtime; UniFFI's generated
-            # code rebinds the name so the static checker doesn't see it.
-            session = await asyncio.wait_for(client.connect(f"https://{server.local_addr}"), timeout=5.0)
-            with pytest.raises(moq_ffi.MoqError):  # type: ignore[arg-type]
-                await asyncio.wait_for(session.closed(), timeout=5.0)
+            # The rejection races the optimistic connect: it surfaces either as a
+            # connect error or as the session's terminal close. MoqError is an
+            # Exception subclass at runtime; UniFFI's generated code rebinds the
+            # name so the static checker doesn't see it.
+            try:
+                session = await asyncio.wait_for(client.connect(f"https://{server.local_addr}"), timeout=5.0)
+            except moq_ffi.MoqError:  # type: ignore[misc]
+                pass
+            else:
+                with pytest.raises(moq_ffi.MoqError):  # type: ignore[arg-type]
+                    await asyncio.wait_for(session.closed(), timeout=5.0)
         finally:
             reject_task.cancel()
             try:

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -33,7 +33,7 @@ async fn run_session(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	// Establish a connection with automatic reconnection.
 	// with_subscriber() registers an OriginProducer for incoming data.
 	// Use with_publisher() if you also want to publish from the session.
-	let reconnect = client.with_subscriber(origin).reconnect(url);
+	let reconnect = client.with_subscriber(origin).connect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).
 	Ok(reconnect.closed().await?)

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -33,7 +33,7 @@ async fn run_session(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	// with_publisher() registers an OriginProducer. moq-net reads from its
 	// consumer view internally. Pair with with_subscriber() if you also want
 	// to subscribe to remote announcements.
-	let reconnect = client.with_publisher(&origin).reconnect(url);
+	let reconnect = client.with_publisher(&origin).connect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).
 	Ok(reconnect.closed().await?)

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -42,7 +42,7 @@ impl Session {
 
 		// Build the reconnect loop up front so we can grab a stats reader for it
 		// before moving it into the spawned task.
-		let reconnect = client.reconnect(url);
+		let reconnect = client.connect(url);
 		let stats = reconnect.stats();
 
 		let closed = oneshot::channel();
@@ -95,7 +95,7 @@ impl Session {
 	///
 	/// Returns the terminal error via `?`. Disconnects aren't reported: status 0 is reserved for a
 	/// clean close (delivered as the terminal callback once the task ends).
-	async fn report(callback: ffi::OnStatus, mut reconnect: moq_native::Reconnect) -> Result<(), Error> {
+	async fn report(callback: ffi::OnStatus, mut reconnect: moq_native::Connection) -> Result<(), Error> {
 		let mut connects: u64 = 0;
 		loop {
 			if let moq_native::Status::Connected = reconnect.status().await.map_err(map_connect_error)? {

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -115,7 +115,7 @@ pub async fn run(ctx: Connection) {
 	}
 
 	let client = client.with_publisher(&publish).with_subscriber(consume);
-	let mut reconnect = client.reconnect(url);
+	let mut reconnect = client.connect(url);
 
 	// Subscriber: drain up to `subscribe` peer broadcasts.
 	if rolled.subscribe > 0 {

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -232,7 +232,7 @@ async fn run(config: &Config) -> Result<()> {
 	let reconnect = client
 		.with_publisher(&publish_origin)
 		.with_subscriber(consume_origin)
-		.reconnect(url);
+		.connect(url);
 
 	// Set up catalog and encoders.
 	let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -85,7 +85,13 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		.clone()
 		.context("`transcode` requires a relay: pass --client-connect <url>")?;
 	let publish = moq_net::Origin::random().produce();
-	let remote = moq_net::Origin::random().produce();
+	// The source has to outlive a session drop for the reconnect to be worth
+	// anything: without the linger it closes on the first drop and `run` exits
+	// while the redial is still in flight. This is what `Client::consume` applies
+	// for the same reason; the origin is wired by hand here, so it applies it too.
+	let remote = moq_net::Origin::random()
+		.produce()
+		.with_linger(moq.client.backoff.linger());
 	let mut session = net
 		.client(moq.client.clone())?
 		.with_publisher(&publish)

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -90,7 +90,7 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		.client(moq.client.clone())?
 		.with_publisher(&publish)
 		.with_subscriber(remote.clone())
-		.reconnect(url);
+		.connect(url);
 
 	// Wait for the first session: the origin can't route a broadcast request
 	// until a connected session registers its handler.

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -30,7 +30,16 @@ impl Client {
 			.established()
 			.await
 			.map_err(map_connect_error)?;
-		let session = connection.session().ok_or(MoqError::Closed)?;
+		// A peer that closes right after the handshake can clear the session between
+		// `established` returning and this read. The connection knows why it ended, so
+		// surface that rather than a bare "closed" that names no cause.
+		let session = match connection.session() {
+			Some(session) => session,
+			None => {
+				connection.closed().await.map_err(map_connect_error)?;
+				return Err(MoqError::Closed);
+			}
+		};
 
 		Ok(Arc::new(MoqSession::new(session, publish, subscribe)))
 	}

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -26,8 +26,11 @@ impl Client {
 			.with_publisher(&publish)
 			.with_subscriber(subscribe.clone())
 			.with_reconnect(false)
-			.connect(url);
-		let session = connection.established().await.map_err(map_connect_error)?;
+			.connect(url)
+			.established()
+			.await
+			.map_err(map_connect_error)?;
+		let session = connection.session().ok_or(MoqError::Closed)?;
 
 		Ok(Arc::new(MoqSession::new(session, publish, subscribe)))
 	}

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -20,12 +20,14 @@ impl Client {
 		// always hand back a publisher/consumer.
 		let (publish, subscribe) = crate::origin::resolve_pair(self.publish.as_ref(), self.consume.as_ref());
 
-		let session = client
+		// One-shot for now: the FFI session wraps a single moq_net::Session, so the
+		// connection loop's redial would have nothing to hand the new session to.
+		let connection = client
 			.with_publisher(&publish)
 			.with_subscriber(subscribe.clone())
-			.connect(url)
-			.await
-			.map_err(map_connect_error)?;
+			.with_reconnect(false)
+			.connect(url);
+		let session = connection.established().await.map_err(map_connect_error)?;
 
 		Ok(Arc::new(MoqSession::new(session, publish, subscribe)))
 	}

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -142,7 +142,7 @@ impl Session {
 		// from a group boundary on reconnect. A bounded policy is available via `ClientConfig::backoff`.
 		let mut config = moq_native::ClientConfig::default();
 		config.tls.disable_verify = Some(settings.tls_disable_verify);
-		config.backoff.timeout = std::time::Duration::ZERO;
+		config.backoff.timeout = Some(std::time::Duration::ZERO);
 		let client = config.init()?.with_publisher(origin.consume());
 		let reconnect = client.connect(settings.url.clone());
 		// Persistent handles that survive reconnects; the getters read them without touching the loop.

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -144,7 +144,7 @@ impl Session {
 		config.tls.disable_verify = Some(settings.tls_disable_verify);
 		config.backoff.timeout = std::time::Duration::ZERO;
 		let client = config.init()?.with_publisher(origin.consume());
-		let reconnect = client.reconnect(settings.url.clone());
+		let reconnect = client.connect(settings.url.clone());
 		// Persistent handles that survive reconnects; the getters read them without touching the loop.
 		let send_bandwidth = reconnect.send_bandwidth();
 		let recv_bandwidth = reconnect.recv_bandwidth();
@@ -200,16 +200,16 @@ impl Drop for Session {
 /// Track the reconnect loop's observable state into the element's [`Status`] and fire GObject
 /// notifications until the loop stops.
 ///
-/// The reconnect loop owns the session; this task follows [`moq_native::Reconnect`] to mirror
+/// The reconnect loop owns the session; this task follows [`moq_native::Connection`] to mirror
 /// status/version into the `Status` the getters read, and watches the persistent bandwidth consumers
 /// only to `notify` the bitrate properties (the getters read the estimates directly). Each source is
 /// notified on its own change: a status edge notifies `status`/`connected`/`moq-version` together, a
 /// bitrate change notifies just that bitrate. The loop stops only on a terminal error (a non-retryable
 /// auth failure, or a bounded backoff's give-up), which the `Err` arm posts as a bus error.
-/// [`Session`]'s `Drop` aborts this task, which drops the `Reconnect` handle and quietly tears the loop
+/// [`Session`]'s `Drop` aborts this task, which drops the `Connection` handle and quietly tears the loop
 /// down.
 async fn forward(
-	mut reconnect: moq_native::Reconnect,
+	mut reconnect: moq_native::Connection,
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
 	errored: Arc<AtomicBool>,

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -287,7 +287,11 @@ async fn run_session(
 	let origin_consumer = origin.consume();
 	let client = config.init()?.with_subscriber(origin);
 
-	let _session = client.connect(settings.url.clone()).await?;
+	// One-shot: the catalog subscription below dies with the session anyway, so a
+	// background redial could not resurrect this run. A drop surfaces as the
+	// catalog closing and the loop below winding down.
+	let connection = client.with_reconnect(false).connect(settings.url.clone());
+	let _session = connection.established().await?;
 
 	// Wait for the broadcast to be announced. Synchronous lookup would race the gossip of
 	// announcements that happens after the session is established.

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -290,8 +290,11 @@ async fn run_session(
 	// One-shot: the catalog subscription below dies with the session anyway, so a
 	// background redial could not resurrect this run. A drop surfaces as the
 	// catalog closing and the loop below winding down.
-	let connection = client.with_reconnect(false).connect(settings.url.clone());
-	let _session = connection.established().await?;
+	let _connection = client
+		.with_reconnect(false)
+		.connect(settings.url.clone())
+		.established()
+		.await?;
 
 	// Wait for the broadcast to be announced. Synchronous lookup would race the gossip of
 	// announcements that happens after the session is established.

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -29,10 +29,12 @@ async fn run_session(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/chat-example").unwrap();
 
 	// Establish a WebTransport/QUIC connection and MoQ handshake.
-	let cs = client.with_publisher(&origin).connect(url).await?;
+	// The connection automatically redials with backoff if it drops.
+	let connection = client.with_publisher(&origin).connect(url);
 
-	// Wait until the session is closed.
-	Err(cs.closed().await.into())
+	// Wait until the connection gives up for good.
+	connection.closed().await?;
+	Ok(())
 }
 
 // Produce a broadcast and publish it to the origin.

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -68,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
 			let track = broadcast.create_track(track, None)?;
 			let clock = Publisher::new(track);
 
-			let reconnect = client.with_publisher(&origin).reconnect(url);
+			let reconnect = client.with_publisher(&origin).connect(url);
 
 			// Keep the result out of the `select!` arm (a `?` there would return
 			// before the close below runs), so the broadcast is always closed.
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 			result
 		}
 		Command::Subscribe => {
-			let reconnect = client.with_subscriber(origin.clone()).reconnect(url);
+			let reconnect = client.with_subscriber(origin.clone()).connect(url);
 
 			// IETF MoQ + the current origin::Consumer API don't let us call
 			// `session.consume_broadcast(&path)` directly, so loop on announces

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -60,7 +60,7 @@ pub struct ClientConfig {
 	/// This has to live above the transports rather than inside one: QUIC bounds its
 	/// own dial, but the WebSocket fallback and the handshake that follows either
 	/// transport have no deadline of their own, so a peer that accepts TCP and then
-	/// never speaks would hang the whole connect. [`Client::reconnect`] only re-arms
+	/// never speaks would hang the whole connect. [`Connection`] only re-arms
 	/// its backoff between attempts, so an attempt that never returns stalls the
 	/// retry loop indefinitely.
 	#[arg(
@@ -1099,7 +1099,7 @@ mod tests {
 	/// gives up on its own, but the WebSocket arm has no deadline of its own, so the
 	/// race stays pending forever. Without the connect timeout this test hangs.
 	///
-	/// That is what wedged a publisher against a livelocked relay: `Reconnect` only
+	/// That is what wedged a publisher against a livelocked relay: [`Connection`] only
 	/// re-arms its backoff (and checks its give-up timeout) *between* attempts, so an
 	/// attempt that never returns stalls the retry loop for good.
 	#[cfg(feature = "websocket")]
@@ -1120,7 +1120,9 @@ mod tests {
 		// arm alone against the silent peer.
 		let url: Url = format!("https://127.0.0.1:{}/", addr.port()).parse().unwrap();
 
-		let mut attempt = Box::pin(client.connect(url));
+		// `dial` rather than `connect`: this is about one attempt's deadline, and
+		// `connect` now hands back a reconnect loop that would redial past it.
+		let mut attempt = Box::pin(client.dial(url));
 		let _silent = tokio::select! {
 			res = &mut attempt => match res {
 				Err(err) => panic!("connect failed before the silent peer accepted it: {err}"),

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -1,4 +1,4 @@
-use crate::{Backoff, Error, GoawayConfig, QuicBackend, Reconnect};
+use crate::{Backoff, Connection, Error, GoawayConfig, QuicBackend};
 #[cfg(feature = "websocket")]
 use std::future::Future;
 use std::net;
@@ -93,12 +93,29 @@ pub struct ClientConfig {
 	#[serde(default)]
 	pub tls: crate::tls::Client,
 
-	/// Retry pacing for [`Client::reconnect`] (`--client-backoff-*`).
+	/// Whether a [`Connection`] redials (with backoff) after its session drops.
+	///
+	/// Defaults to true. Set to false for a one-shot dial: the session's close
+	/// then surfaces through [`Connection::closed`] instead of triggering a
+	/// reconnect.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "client-reconnect",
+		long = "client-reconnect",
+		env = "MOQ_CLIENT_RECONNECT",
+		default_missing_value = "true",
+		num_args = 0..=1,
+		require_equals = true,
+		value_parser = clap::value_parser!(bool),
+	)]
+	pub reconnect: Option<bool>,
+
+	/// Retry pacing for [`Client::connect`] (`--client-backoff-*`).
 	#[command(flatten)]
 	#[serde(default)]
 	pub backoff: Backoff,
 
-	/// How [`Client::reconnect`] reacts to a peer's GOAWAY (`--goaway-*`).
+	/// How [`Client::connect`] reacts to a peer's GOAWAY (`--goaway-*`).
 	#[command(flatten)]
 	#[serde(default)]
 	pub goaway: GoawayConfig,
@@ -149,6 +166,7 @@ impl Default for ClientConfig {
 			quic: crate::quic::Client::default(),
 			version: Vec::new(),
 			tls: crate::tls::Client::default(),
+			reconnect: None,
 			backoff: Backoff::default(),
 			goaway: GoawayConfig::default(),
 			#[cfg(feature = "websocket")]
@@ -172,8 +190,9 @@ pub struct Client {
 	connect: Option<Url>,
 	/// Deadline for one [`Client::connect`], from [`ClientConfig::timeout`]. Zero waits forever.
 	timeout: std::time::Duration,
-	backoff: Backoff,
-	goaway: GoawayConfig,
+	pub(crate) reconnect: bool,
+	pub(crate) backoff: Backoff,
+	pub(crate) goaway: GoawayConfig,
 	/// The resolved Happy Eyeballs stagger, used by the `tcp://` dial here; the
 	/// QUIC backends capture their own copy from the config.
 	#[cfg(feature = "tcp")]
@@ -259,6 +278,7 @@ impl Client {
 			versions,
 			connect: config.connect,
 			timeout,
+			reconnect: config.reconnect.unwrap_or(true),
 			backoff: config.backoff,
 			goaway: config.goaway,
 			#[cfg(feature = "tcp")]
@@ -331,39 +351,54 @@ impl Client {
 		self
 	}
 
-	/// Start a background reconnect loop that connects to the given URL,
-	/// waits for the session to close, then reconnects with exponential backoff.
+	/// Override whether this client redials after a session drop.
 	///
-	/// Returns a [`Reconnect`] handle; drop the last handle to stop the loop.
-	pub fn reconnect(&self, url: Url) -> Reconnect {
-		Reconnect::new(self.clone(), url, self.backoff.clone(), self.goaway.clone())
+	/// Defaults to [`ClientConfig::reconnect`], which defaults to true.
+	pub fn with_reconnect(mut self, reconnect: bool) -> Self {
+		self.reconnect = reconnect;
+		self
 	}
 
-	/// Dial the configured [`ClientConfig::connect`] URL, publishing `origin` to it
-	/// and reconnecting with backoff until the returned handle is dropped.
+	/// Open a connection to the given URL.
+	///
+	/// A background task dials, completes the MoQ handshake, and (by default)
+	/// redials with exponential backoff whenever the session drops. Wait for the
+	/// first session with [`Connection::established`] and for the loop to stop
+	/// with [`Connection::closed`]; drop the handle to stop it. Disable the
+	/// redialing with [`ClientConfig::reconnect`] / [`Self::with_reconnect`] for
+	/// a one-shot dial.
+	pub fn connect(&self, url: Url) -> Connection {
+		Connection::new(self.clone(), url)
+	}
+
+	/// Connect to the configured [`ClientConfig::connect`] URL, publishing
+	/// `origin` to it.
 	///
 	/// Returns `None` when no `--client-connect` URL was configured, so a caller
 	/// that may run server-only doesn't have to branch on the URL itself.
-	pub fn publish(self, origin: moq_net::origin::Consumer) -> Option<Reconnect> {
+	pub fn publish(self, origin: moq_net::origin::Consumer) -> Option<Connection> {
 		let url = self.connect.clone()?;
-		Some(self.with_publisher(origin).reconnect(url))
+		Some(self.with_publisher(origin).connect(url))
 	}
 
-	/// Dial the configured [`ClientConfig::connect`] URL, consuming its broadcasts
-	/// into `origin` and reconnecting with backoff until the returned handle is
-	/// dropped.
+	/// Connect to the configured [`ClientConfig::connect`] URL, consuming its
+	/// broadcasts into `origin`.
 	///
 	/// Broadcasts fed by these sessions linger across a session drop for as long
 	/// as the reconnect loop keeps retrying ([`Backoff::linger`]): a relay restart
 	/// is a bounded gap the reconnect splices over, not a teardown. When the loop
-	/// gives up, its error surfaces (via [`Reconnect::closed`]) just before the
-	/// broadcasts abort.
+	/// gives up, its error surfaces (via [`Connection::closed`]) just before the
+	/// broadcasts abort. With reconnecting disabled there is no gap to splice, so
+	/// the broadcasts don't linger.
 	///
 	/// Returns `None` when no `--client-connect` URL was configured.
-	pub fn consume(self, origin: moq_net::origin::Producer) -> Option<Reconnect> {
+	pub fn consume(self, origin: moq_net::origin::Producer) -> Option<Connection> {
 		let url = self.connect.clone()?;
-		let origin = origin.with_linger(self.backoff.linger());
-		Some(self.with_subscriber(origin).reconnect(url))
+		let origin = match self.reconnect {
+			true => origin.with_linger(self.backoff.linger()),
+			false => origin,
+		};
+		Some(self.with_subscriber(origin).connect(url))
 	}
 
 	/// Dial the given URL and complete the MoQ handshake.
@@ -378,7 +413,7 @@ impl Client {
 		feature = "tcp",
 		feature = "uds"
 	)))]
-	pub async fn connect(&self, _url: Url) -> crate::Result<moq_net::Session> {
+	pub(crate) async fn dial(&self, _url: Url) -> crate::Result<moq_net::Session> {
 		Err(Error::NoBackend(
 			"no backend compiled; enable noq, quinn, quiche, iroh, websocket, tcp, or uds feature",
 		))
@@ -399,7 +434,7 @@ impl Client {
 		feature = "tcp",
 		feature = "uds"
 	))]
-	pub async fn connect(&self, url: Url) -> crate::Result<moq_net::Session> {
+	pub(crate) async fn dial(&self, url: Url) -> crate::Result<moq_net::Session> {
 		// Each compiled backend adds state to this dispatch future. Keep it off the
 		// caller's stack so all-feature builds remain safe on standard 2 MiB threads.
 		let attempt = Box::pin(self.connect_inner(url));
@@ -957,6 +992,32 @@ mod tests {
 			config.connect.as_ref().unwrap().as_str(),
 			"https://relay.example.com/anon"
 		);
+	}
+
+	#[test]
+	fn test_toml_reconnect_survives_update_from() {
+		let toml = r#"
+			reconnect = false
+		"#;
+
+		let mut config: ClientConfig = toml::from_str(toml).unwrap();
+		assert_eq!(config.reconnect, Some(false));
+
+		// Simulate: TOML loaded, then CLI args re-applied (no --client-reconnect flag).
+		config.update_from(["test"]);
+		assert_eq!(config.reconnect, Some(false));
+	}
+
+	#[test]
+	fn test_cli_reconnect_flag() {
+		let config = ClientConfig::parse_from(["test"]);
+		assert_eq!(config.reconnect, None, "unset means the default (reconnect)");
+
+		let config = ClientConfig::parse_from(["test", "--client-reconnect"]);
+		assert_eq!(config.reconnect, Some(true));
+
+		let config = ClientConfig::parse_from(["test", "--client-reconnect=false"]);
+		assert_eq!(config.reconnect, Some(false));
 	}
 
 	#[test]

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -79,7 +79,7 @@ impl Backoff {
 	}
 }
 
-/// A connection lifecycle transition reported by [`Reconnect::status`].
+/// A connection lifecycle transition reported by [`Connection::status`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Status {
@@ -255,9 +255,9 @@ struct State {
 	session: Option<moq_net::Session>,
 }
 
-/// A cloneable read handle for the live connection stats of a [`Reconnect`] loop.
+/// A cloneable read handle for the live connection stats of a [`Connection`].
 ///
-/// Obtained via [`Reconnect::stats`]. [`stats`](Self::stats) returns `None` while the loop is
+/// Obtained via [`Connection::stats`]. [`stats`](Self::stats) returns `None` while the loop is
 /// between connections (reconnecting), and `Some` snapshot while a session is established.
 #[derive(Clone)]
 pub struct ConnectionStatsReader {
@@ -271,16 +271,19 @@ impl ConnectionStatsReader {
 	}
 }
 
-/// Handle to a background reconnect loop.
+/// Handle to a connection maintained by a background task.
 ///
-/// Spawns a tokio task that connects, waits for session close, then reconnects with exponential
-/// backoff. The read surface mirrors [`moq_net::Session`] so a caller can treat it like a session
-/// that transparently reconnects: [`version`](Self::version), [`send_bandwidth`](Self::send_bandwidth),
+/// The task connects, waits for the session to end, then (unless reconnecting is
+/// disabled, see [`ClientConfig::reconnect`](crate::ClientConfig::reconnect))
+/// redials with exponential backoff. The read surface mirrors [`moq_net::Session`]
+/// so a caller can treat it like a session that transparently reconnects:
+/// [`version`](Self::version), [`send_bandwidth`](Self::send_bandwidth),
 /// and [`recv_bandwidth`](Self::recv_bandwidth) track the live session and reset while disconnected.
-/// The extra toggle a plain session doesn't have is the connection lifecycle: [`connected`](Self::connected)
-/// reads it synchronously and [`status`](Self::status) waits for the next change. [`closed`](Self::closed)
+/// The extra toggle a plain session doesn't have is the connection lifecycle: [`established`](Self::established)
+/// waits for the first session, [`connected`](Self::connected) reads the current state synchronously,
+/// and [`status`](Self::status) waits for the next change. [`closed`](Self::closed)
 /// waits for the loop to stop. Dropping the handle aborts the background task.
-pub struct Reconnect {
+pub struct Connection {
 	abort: tokio::task::AbortHandle,
 	state: kio::Consumer<State>,
 	/// Persistent send-bitrate estimate, fed by the loop from each live session.
@@ -291,8 +294,8 @@ pub struct Reconnect {
 	last_reported: Option<Status>,
 }
 
-impl Reconnect {
-	pub(crate) fn new(client: Client, url: Url, backoff: Backoff, goaway: GoawayConfig) -> Self {
+impl Connection {
+	pub(crate) fn new(client: Client, url: Url) -> Self {
 		let producer = kio::Producer::<State>::default();
 		let state = producer.consume();
 
@@ -304,8 +307,14 @@ impl Reconnect {
 		let recv_bandwidth = recv_bw.consume();
 
 		let task = tokio::spawn(async move {
-			if let Err(err) = Self::run(&producer, &send_bw, &recv_bw, client, url, backoff, goaway).await {
-				tracing::error!(%err, "reconnect loop exited");
+			let reconnect = client.reconnect;
+			if let Err(err) = Self::run(&producer, &send_bw, &recv_bw, client, url).await {
+				// In one-shot mode the session ending is the expected lifecycle, and
+				// its close reason arrives here; don't dress it up as a loop failure.
+				match reconnect {
+					true => tracing::error!(%err, "connection loop exited"),
+					false => tracing::info!(%err, "connection closed"),
+				}
 				if let Ok(mut state) = producer.write() {
 					state.error = Some(err);
 				}
@@ -327,15 +336,15 @@ impl Reconnect {
 		recv_bw: &BandwidthProducer,
 		client: Client,
 		url: Url,
-		backoff: Backoff,
-		goaway: GoawayConfig,
 	) -> crate::Result<()> {
+		let backoff = client.backoff.clone();
+		let goaway = client.goaway.clone();
 		let mut delay = backoff.initial;
 		let mut retry_start = tokio::time::Instant::now();
 		let mut last_error: Option<Error> = None;
 		// Sticky across migrations: a redirect is an assignment, not a detour, so a
 		// later drop redials wherever we were last sent. Scoped to this loop, so a
-		// fresh Reconnect starts from the configured URL again.
+		// fresh Connection starts from the configured URL again.
 		let mut url = url;
 		// An old session kept alive after a GOAWAY so its in-flight groups finish.
 		let mut draining: Option<Draining> = None;
@@ -352,7 +361,7 @@ impl Reconnect {
 
 			tracing::info!(%url, "connecting");
 
-			match client.connect(url.clone()).await {
+			match client.dial(url.clone()).await {
 				Ok(session) => {
 					tracing::info!(%url, "connected");
 					if let Ok(mut state) = state.write() {
@@ -365,7 +374,9 @@ impl Reconnect {
 					// Wait for the session to end, forwarding its bandwidth estimates into the
 					// persistent producers meanwhile so consumers track the live stats across the
 					// connection, and draining any predecessor left over from a migration.
-					let ended = run_session(send_bw, recv_bw, &session, &mut draining).await;
+					// One-shot mode ignores GOAWAY: it cannot dial the replacement, and the
+					// peer force-closes at its own deadline anyway.
+					let ended = run_session(send_bw, recv_bw, &session, &mut draining, client.reconnect).await;
 
 					// A session that stayed up past the initial backoff is healthy; one that
 					// ended sooner counts as a failed attempt however it ended.
@@ -421,15 +432,27 @@ impl Reconnect {
 					let _ = send_bw.set(None);
 					let _ = recv_bw.set(None);
 
-					// An auth rejection is terminal however long the session lived: the
-					// wire's UNAUTHORIZED is specified, so this is the peer telling us
-					// these credentials will never work, not a code we guessed at.
+					// An auth rejection is terminal however long the session lived, and
+					// whether or not we would otherwise redial: the wire's UNAUTHORIZED is
+					// specified, so this is the peer telling us these credentials will
+					// never work, not a code we guessed at.
 					if let Ended::Closed(Err(err)) = &ended {
 						let err = Error::from(err.clone());
 						if err.is_auth() {
 							return Err(err);
 						}
 					}
+
+					// One-shot mode: the session ending ends the connection. Its close
+					// reason is the terminal error, mirroring `moq_net::Session::closed`.
+					if !client.reconnect {
+						return match ended {
+							Ended::Closed(res) => res.map_err(Error::from),
+							// The GOAWAY arm is not polled in one-shot mode.
+							Ended::Goaway(_) => Ok(()),
+						};
+					}
+
 
 					if healthy {
 						// Reset the backoff window so a one-off drop reconnects promptly.
@@ -460,7 +483,7 @@ impl Reconnect {
 					}
 				}
 				Err(err) => {
-					if err.is_auth() {
+					if err.is_auth() || !client.reconnect {
 						return Err(err);
 					}
 					last_error = Some(err);
@@ -471,6 +494,32 @@ impl Reconnect {
 			tokio::time::sleep(delay).await;
 			delay = std::cmp::min(delay * backoff.multiplier, backoff.max);
 		}
+	}
+
+	/// Poll until a session is established (the first connect, or the current one).
+	///
+	/// `Ready(Ok(session))` while a session is live (during a GOAWAY handover this is the
+	/// old session, which still serves), `Ready(Err)` once the loop has stopped, `Pending`
+	/// otherwise.
+	pub fn poll_established(&self, waiter: &kio::Waiter) -> Poll<crate::Result<moq_net::Session>> {
+		match ready!(self.state.poll(waiter, |state| match (state.status, &state.session) {
+			(Some(Status::Connected | Status::Migrating), Some(session)) => Poll::Ready(session.clone()),
+			_ => Poll::Pending,
+		})) {
+			Ok(session) => Poll::Ready(Ok(session)),
+			Err(state) => Poll::Ready(Err(terminal(&state))),
+		}
+	}
+
+	/// Wait until a session is established, returning it.
+	///
+	/// Returns as soon as a session is live, so the first call waits out the initial dial
+	/// (surfacing its error if the loop gives up, e.g. on an auth failure or in one-shot
+	/// mode). Useful when a caller wants dial errors up front rather than through
+	/// [`closed`](Self::closed). The loop lives in the handle, not the returned session:
+	/// drop the [`Connection`] and nothing redials.
+	pub async fn established(&self) -> crate::Result<moq_net::Session> {
+		kio::wait(|waiter| self.poll_established(waiter)).await
 	}
 
 	/// Poll for the next connection status change since this handle last reported one.
@@ -518,6 +567,15 @@ impl Reconnect {
 		self.state.read().version
 	}
 
+	/// The live [`moq_net::Session`], or `None` while between sessions.
+	///
+	/// An escape hatch for callers that need the raw session (during a GOAWAY handover
+	/// this is the old session, which is still serving). Sessions are refcounted, so a
+	/// clone held here keeps that transport open even after the loop moves on.
+	pub fn session(&self) -> Option<moq_net::Session> {
+		self.state.read().session.clone()
+	}
+
 	/// A consumer for the live session's estimated send bitrate, mirroring
 	/// [`moq_net::Session::send_bandwidth`].
 	///
@@ -535,11 +593,11 @@ impl Reconnect {
 		self.recv_bandwidth.clone()
 	}
 
-	/// Poll whether the reconnect loop has stopped.
+	/// Poll whether the connection loop has stopped.
 	///
-	/// `Ready(Err)` if it permanently gave up (reconnect timeout exceeded, or an auth
-	/// rejection), `Ready(Ok(()))` if stopped by dropping the handle, `Pending` while
-	/// it's still running.
+	/// `Ready(Err)` if it permanently gave up (reconnect timeout exceeded, an auth
+	/// rejection, or the session ending in one-shot mode), `Ready(Ok(()))` if stopped
+	/// by dropping the handle, `Pending` while it's still running.
 	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<crate::Result<()>> {
 		ready!(self.state.poll_closed(waiter));
 		Poll::Ready(match &self.state.read().error {
@@ -548,7 +606,7 @@ impl Reconnect {
 		})
 	}
 
-	/// Wait until the reconnect loop stops.
+	/// Wait until the connection loop stops.
 	pub async fn closed(&self) -> crate::Result<()> {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
@@ -574,7 +632,7 @@ enum Ended {
 /// An old session kept alive after a GOAWAY so its in-flight groups finish.
 ///
 /// Held by the reconnect loop rather than a detached task, so dropping the
-/// [`Reconnect`] handle tears the old session down with everything else instead
+/// [`Connection`] handle tears the old session down with everything else instead
 /// of leaving an orphan holding the connection open.
 struct Draining {
 	session: moq_net::Session,
@@ -638,17 +696,19 @@ async fn sleep_draining(delay: Duration, draining: &mut Option<Draining>) {
 }
 
 /// Wait for `session` to close or receive a GOAWAY, forwarding its send/recv bandwidth estimates
-/// into the persistent producers meanwhile so [`Reconnect`] consumers track the live estimates
+/// into the persistent producers meanwhile so [`Connection`] consumers track the live estimates
 /// across the connection, and draining any predecessor left over from an earlier migration.
 ///
 /// One `poll_*` step drives it all: [`poll_forward`] mirrors each kio bandwidth estimate, the
 /// GOAWAY consumer is a kio channel, and the transport's close future (the one non-kio source) is
-/// polled through the waiter's own waker.
+/// polled through the waiter's own waker. `migrate` is whether a GOAWAY ends this session's
+/// tenure ([`Ended::Goaway`]); when false the arm isn't polled and only a close returns.
 async fn run_session(
 	send_bw: &BandwidthProducer,
 	recv_bw: &BandwidthProducer,
 	session: &moq_net::Session,
 	draining: &mut Option<Draining>,
+	migrate: bool,
 ) -> Ended {
 	let mut send = session.send_bandwidth();
 	let mut recv = session.recv_bandwidth();
@@ -669,7 +729,7 @@ async fn run_session(
 
 		// Checked before the close arm: a GOAWAY means the session is still up, and
 		// migrating from it is not the same as reconnecting after it died.
-		if let Poll::Ready(Ok(msg)) = goaway.poll(waiter) {
+		if migrate && let Poll::Ready(Ok(msg)) = goaway.poll(waiter) {
 			return Poll::Ready(Ended::Goaway(msg));
 		}
 
@@ -703,7 +763,7 @@ fn poll_forward(bw: &mut Option<BandwidthConsumer>, out: &BandwidthProducer, wai
 	}
 }
 
-impl Drop for Reconnect {
+impl Drop for Connection {
 	fn drop(&mut self) {
 		self.abort.abort();
 	}
@@ -713,7 +773,7 @@ impl Drop for Reconnect {
 fn terminal(state: &State) -> Error {
 	match &state.error {
 		Some(err) => err.clone(),
-		None => Error::Reconnect("reconnect stopped".to_string()),
+		None => Error::Reconnect("connection stopped".to_string()),
 	}
 }
 

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -14,6 +14,10 @@ use crate::{Client, Error};
 #[non_exhaustive]
 pub struct Backoff {
 	/// Initial delay before first reconnect attempt.
+	///
+	/// Doubles as the bar a session must stay up to count as healthy, so it is
+	/// floored at 50ms: at zero every session would look healthy and the retry
+	/// pacing would collapse.
 	#[arg(
 		id = "backoff-initial",
 		long,
@@ -213,6 +217,11 @@ pub struct GoawayConfig {
 	pub handover: Option<Duration>,
 }
 
+/// Floor for [`Backoff::initial`], which paces the retries and sets the bar for
+/// calling a session healthy. Small enough to stay out of the way of a fast
+/// config, large enough that a session closed on sight never clears it.
+const MIN_BACKOFF: Duration = Duration::from_millis(50);
+
 /// Default handover window, and the ceiling a GOAWAY deadline is capped to when
 /// the config names none.
 const DEFAULT_HANDOVER: Duration = Duration::from_secs(10);
@@ -339,7 +348,14 @@ impl Connection {
 	) -> crate::Result<()> {
 		let backoff = client.backoff.clone();
 		let goaway = client.goaway.clone();
-		let mut delay = backoff.initial;
+		// This value does double duty: the first retry delay, and the bar a session
+		// has to clear to count as healthy. At zero both collapse. Every session would
+		// be healthy (`elapsed() >= 0`), which resets the give-up window; the delay
+		// would stay zero through the multiplier; and a peer that closes on sight
+		// would be redialed as fast as the runtime allows, forever. Floor it so both
+		// roles keep their meaning.
+		let initial = backoff.initial.max(MIN_BACKOFF);
+		let mut delay = initial;
 		let mut retry_start = tokio::time::Instant::now();
 		let mut last_error: Option<Error> = None;
 		// Sticky across migrations: a redirect is an assignment, not a detour, so a
@@ -380,7 +396,7 @@ impl Connection {
 
 					// A session that stayed up past the initial backoff is healthy; one that
 					// ended sooner counts as a failed attempt however it ended.
-					let healthy = connected.elapsed() >= backoff.initial;
+					let healthy = connected.elapsed() >= initial;
 
 					if let Ended::Goaway(msg) = &ended {
 						// A redirect is an assignment: keep dialing it from here on.
@@ -403,7 +419,7 @@ impl Connection {
 						draining = Some(Draining::new(session, goaway.handover(msg.timeout)));
 
 						if healthy {
-							delay = backoff.initial;
+							delay = initial;
 							retry_start = tokio::time::Instant::now();
 							last_error = None;
 							// No backoff sleep: a handover off a healthy session is not a failure.
@@ -457,7 +473,7 @@ impl Connection {
 					if healthy {
 						// Reset the backoff window so a one-off drop reconnects promptly.
 						tracing::warn!(%url, "session closed, reconnecting");
-						delay = backoff.initial;
+						delay = initial;
 						retry_start = tokio::time::Instant::now();
 						last_error = None;
 					} else {

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -501,25 +501,31 @@ impl Connection {
 	/// `Ready(Ok(session))` while a session is live (during a GOAWAY handover this is the
 	/// old session, which still serves), `Ready(Err)` once the loop has stopped, `Pending`
 	/// otherwise.
-	pub fn poll_established(&self, waiter: &kio::Waiter) -> Poll<crate::Result<moq_net::Session>> {
+	pub fn poll_established(&self, waiter: &kio::Waiter) -> Poll<crate::Result<()>> {
 		match ready!(self.state.poll(waiter, |state| match (state.status, &state.session) {
-			(Some(Status::Connected | Status::Migrating), Some(session)) => Poll::Ready(session.clone()),
+			(Some(Status::Connected | Status::Migrating), Some(_)) => Poll::Ready(()),
 			_ => Poll::Pending,
 		})) {
-			Ok(session) => Poll::Ready(Ok(session)),
+			Ok(()) => Poll::Ready(Ok(())),
 			Err(state) => Poll::Ready(Err(terminal(&state))),
 		}
 	}
 
-	/// Wait until a session is established, returning it.
+	/// Wait until a session is established, handing the connection back.
 	///
 	/// Returns as soon as a session is live, so the first call waits out the initial dial
 	/// (surfacing its error if the loop gives up, e.g. on an auth failure or in one-shot
 	/// mode). Useful when a caller wants dial errors up front rather than through
-	/// [`closed`](Self::closed). The loop lives in the handle, not the returned session:
-	/// drop the [`Connection`] and nothing redials.
-	pub async fn established(&self) -> crate::Result<moq_net::Session> {
-		kio::wait(|waiter| self.poll_established(waiter)).await
+	/// [`closed`](Self::closed); reach for [`session`](Self::session) afterwards if you
+	/// need the transport itself.
+	///
+	/// It consumes and returns the connection so the reconnecting chain,
+	/// `client.connect(url).established().await?`, keeps it: the loop lives in this
+	/// handle, so a version that handed back only the session would leave the caller
+	/// holding a live transport that silently never redials.
+	pub async fn established(self) -> crate::Result<Self> {
+		kio::wait(|waiter| self.poll_established(waiter)).await?;
+		Ok(self)
 	}
 
 	/// Poll for the next connection status change since this handle last reported one.

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -516,13 +516,21 @@ impl Connection {
 					// Wait for the session to end, forwarding its bandwidth estimates into the
 					// persistent producers meanwhile so consumers track the live stats across the
 					// connection, and draining any predecessor left over from a migration.
-					// One-shot mode ignores GOAWAY: it cannot dial the replacement, and the
-					// peer force-closes at its own deadline anyway.
-					let ended = run_session(shared, &session, &mut draining, client.reconnect).await;
+					let ended = run_session(shared, &session, &mut draining).await;
 
 					// A session that stayed up past the initial backoff is healthy; one that
 					// ended sooner counts as a failed attempt however it ended.
 					let healthy = connected.elapsed() >= initial;
+
+					// One-shot mode leaves rather than migrating: there is no replacement to
+					// dial, and a GOAWAY naming no deadline never force-closes, so the peer
+					// stops accepting requests and waits for us. Ignoring it is how both
+					// sides end up waiting on each other forever. Checked before the
+					// migration branch below, which would otherwise loop back to redial.
+					if !client.reconnect && matches!(ended, Ended::Goaway(_)) {
+						shared.disconnected();
+						return Ok(());
+					}
 
 					if let Ended::Goaway(msg) = &ended {
 						// A redirect is an assignment: keep dialing it from here on.
@@ -578,11 +586,11 @@ impl Connection {
 
 					// One-shot mode: the session ending ends the connection. Its close
 					// reason is the terminal error, mirroring `moq_net::Session::closed`.
+					// A GOAWAY already returned above.
 					if !client.reconnect {
 						return match ended {
 							Ended::Closed(res) => res.map_err(Error::from),
-							// The GOAWAY arm is not polled in one-shot mode.
-							Ended::Goaway(_) => Ok(()),
+							Ended::Goaway(_) => unreachable!("handled before the migration branch"),
 						};
 					}
 
@@ -864,12 +872,7 @@ async fn sleep_draining(delay: Duration, draining: &mut Option<Draining>, shared
 /// GOAWAY consumer is a kio channel, and the transport's close future (the one non-kio source) is
 /// polled through the waiter's own waker. `migrate` is whether a GOAWAY ends this session's
 /// tenure ([`Ended::Goaway`]); when false the arm isn't polled and only a close returns.
-async fn run_session(
-	shared: &Shared,
-	session: &moq_net::Session,
-	draining: &mut Option<Draining>,
-	migrate: bool,
-) -> Ended {
+async fn run_session(shared: &Shared, session: &moq_net::Session, draining: &mut Option<Draining>) -> Ended {
 	let mut send = session.send_bandwidth();
 	let mut recv = session.recv_bandwidth();
 	let goaway = session.draining();
@@ -886,7 +889,13 @@ async fn run_session(
 
 		// Checked before the close arm: a GOAWAY means the session is still up, and
 		// migrating from it is not the same as reconnecting after it died.
-		if migrate && let Poll::Ready(Ok(msg)) = goaway.poll(waiter) {
+		//
+		// Polled in one-shot mode too, even though there is no replacement to dial.
+		// A GOAWAY naming no deadline never force-closes, and the peer stops
+		// accepting requests and waits for us to leave, so ignoring it is how both
+		// sides end up waiting on each other forever. The caller ends the connection
+		// instead: asked to leave, with no way to migrate, leaving is the answer.
+		if let Poll::Ready(Ok(msg)) = goaway.poll(waiter) {
 			return Poll::Ready(Ended::Goaway(msg));
 		}
 

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -581,7 +581,6 @@ impl Connection {
 						};
 					}
 
-
 					if healthy {
 						// Reset the backoff window so a one-off drop reconnects promptly.
 						tracing::warn!(%url, "session closed, reconnecting");
@@ -923,10 +922,15 @@ impl Drop for Connection {
 }
 
 /// The terminal error read from a closed channel's final state.
+///
+/// No recorded error means the loop was stopped locally rather than giving up, so
+/// this reports [`Error::Stopped`]: [`Connection::closed`] treats that as the `Ok`
+/// it is, and a watcher that only has an error to go on can still tell it apart
+/// from a connection that failed.
 fn terminal(state: &State) -> Error {
 	match &state.error {
 		Some(err) => err.clone(),
-		None => Error::Reconnect("connection stopped".to_string()),
+		None => Error::Stopped,
 	}
 }
 

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -9,76 +9,91 @@ use url::Url;
 use crate::{Client, Error};
 
 /// Exponential backoff configuration for reconnection attempts.
-#[derive(Clone, Debug, clap::Args, serde::Serialize, serde::Deserialize)]
+///
+/// Every field is optional so a value set in TOML survives the CLI re-parse that
+/// follows it; read them through the accessors, which supply the defaults.
+#[derive(Clone, Debug, Default, clap::Args, serde::Serialize, serde::Deserialize)]
 #[serde(default, deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Backoff {
-	/// Initial delay before first reconnect attempt.
+	/// Initial delay before first reconnect attempt. Defaults to 1s.
 	///
 	/// Doubles as the bar a session must stay up to count as healthy, so it is
 	/// floored at 50ms: at zero every session would look healthy and the retry
 	/// pacing would collapse.
+	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "backoff-initial",
 		long,
-		default_value = "1s",
 		env = "MOQ_BACKOFF_INITIAL",
 		value_parser = humantime::parse_duration,
 	)]
 	#[serde(with = "humantime_serde")]
-	pub initial: Duration,
+	pub initial: Option<Duration>,
 
-	/// Multiplier applied to delay after each failure.
-	#[arg(id = "backoff-multiplier", long, default_value_t = 2, env = "MOQ_BACKOFF_MULTIPLIER")]
-	pub multiplier: u32,
+	/// Multiplier applied to delay after each failure. Defaults to 2.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(id = "backoff-multiplier", long, env = "MOQ_BACKOFF_MULTIPLIER")]
+	pub multiplier: Option<u32>,
 
-	/// Maximum delay between reconnect attempts.
+	/// Maximum delay between reconnect attempts. Defaults to 30s.
+	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "backoff-max",
 		long,
-		default_value = "30s",
 		env = "MOQ_BACKOFF_MAX",
 		value_parser = humantime::parse_duration,
 	)]
 	#[serde(with = "humantime_serde")]
-	pub max: Duration,
+	pub max: Option<Duration>,
 
-	/// Maximum time to spend retrying before giving up.
+	/// Maximum time to spend retrying before giving up. Defaults to 5m.
+	///
 	/// Resets after a stable connection (one that outlives the initial backoff), so a flapping
 	/// session that reconnects then immediately drops still counts toward the timeout. Set to 0 for
 	/// unlimited retries.
+	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "backoff-timeout",
 		long,
-		default_value = "5m",
 		env = "MOQ_BACKOFF_TIMEOUT",
 		value_parser = humantime::parse_duration,
 	)]
 	#[serde(with = "humantime_serde")]
-	pub timeout: Duration,
-}
-
-impl Default for Backoff {
-	fn default() -> Self {
-		Self {
-			initial: Duration::from_secs(1),
-			multiplier: 2,
-			max: Duration::from_secs(30),
-			timeout: Duration::from_secs(300),
-		}
-	}
+	pub timeout: Option<Duration>,
 }
 
 impl Backoff {
+	/// The configured initial delay, or the default.
+	pub fn initial(&self) -> Duration {
+		self.initial.unwrap_or(DEFAULT_INITIAL)
+	}
+
+	/// The configured multiplier, or the default.
+	pub fn multiplier(&self) -> u32 {
+		self.multiplier.unwrap_or(DEFAULT_MULTIPLIER)
+	}
+
+	/// The configured delay ceiling, or the default.
+	pub fn max(&self) -> Duration {
+		self.max.unwrap_or(DEFAULT_MAX)
+	}
+
+	/// The configured give-up window, or the default. Zero retries forever.
+	pub fn timeout(&self) -> Duration {
+		self.timeout.unwrap_or(DEFAULT_TIMEOUT)
+	}
+
 	/// How long broadcasts fed by a reconnecting session should outlive a session
 	/// drop (see [`moq_net::origin::Info::linger`]): slightly past the give-up
 	/// [`timeout`](Self::timeout), so when the loop does give up its error surfaces
 	/// before the broadcasts tear down. A zero timeout retries forever, so the
 	/// broadcasts linger forever too.
 	pub fn linger(&self) -> Duration {
-		match self.timeout.is_zero() {
+		let timeout = self.timeout();
+		match timeout.is_zero() {
 			true => Duration::MAX,
-			false => self.timeout.saturating_add(Duration::from_secs(1)),
+			false => timeout.saturating_add(Duration::from_secs(1)),
 		}
 	}
 }
@@ -217,6 +232,12 @@ pub struct GoawayConfig {
 	pub handover: Option<Duration>,
 }
 
+/// Defaults for the [`Backoff`] knobs, applied by its accessors when a field is unset.
+const DEFAULT_INITIAL: Duration = Duration::from_secs(1);
+const DEFAULT_MULTIPLIER: u32 = 2;
+const DEFAULT_MAX: Duration = Duration::from_secs(30);
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
+
 /// Floor for the retry delay, which also sets the bar for calling a session
 /// healthy. Small enough to stay out of the way of a fast config, large enough
 /// that a session closed on sight never clears it.
@@ -242,11 +263,11 @@ struct Pacing {
 
 impl Pacing {
 	fn new(backoff: &Backoff) -> Self {
-		let initial = backoff.initial.max(MIN_BACKOFF);
+		let initial = backoff.initial().max(MIN_BACKOFF);
 		Self {
 			initial,
-			max: backoff.max.max(initial),
-			multiplier: backoff.multiplier.max(1),
+			max: backoff.max().max(initial),
+			multiplier: backoff.multiplier().max(1),
 		}
 	}
 
@@ -296,6 +317,70 @@ struct State {
 	/// The currently-connected session, or `None` while reconnecting. Read by
 	/// [`ConnectionStatsReader`] to snapshot live connection stats.
 	session: Option<moq_net::Session>,
+}
+
+/// The producer side of everything a [`Connection`] handle can observe.
+///
+/// These three travel together through the loop, and every lifecycle transition
+/// touches more than one of them: leaving a session live in [`State`] while the
+/// bandwidth estimates reset (or the reverse) is how a handle ends up reporting a
+/// session that is already gone. Keeping them behind one value means a transition
+/// is one call rather than a block to remember.
+struct Shared {
+	state: kio::Producer<State>,
+	send_bw: BandwidthProducer,
+	recv_bw: BandwidthProducer,
+}
+
+impl Shared {
+	/// A session is live and serving.
+	fn connected(&self, session: &moq_net::Session) {
+		if let Ok(mut state) = self.state.write() {
+			state.status = Some(Status::Connected);
+			state.version = Some(session.version());
+			state.session = Some(session.clone());
+		}
+	}
+
+	/// The peer sent a GOAWAY: the session in [`State`] keeps serving while its
+	/// replacement is dialed, so only the status moves.
+	fn migrating(&self) {
+		if let Ok(mut state) = self.state.write() {
+			state.status = Some(Status::Migrating);
+		}
+	}
+
+	/// Nothing is live. Clears the session so a handle can't be handed a closed one,
+	/// and drops the estimates that belonged to it.
+	fn disconnected(&self) {
+		if let Ok(mut state) = self.state.write() {
+			state.status = Some(Status::Disconnected);
+			state.version = None;
+			state.session = None;
+		}
+		let _ = self.send_bw.set(None);
+		let _ = self.recv_bw.set(None);
+	}
+
+	/// Record the error the loop gave up with, for [`Connection::closed`].
+	fn failed(&self, err: Error) {
+		if let Ok(mut state) = self.state.write() {
+			state.error = Some(err);
+		}
+	}
+}
+
+impl Drop for Shared {
+	fn drop(&mut self) {
+		// The loop is over, including when its task was aborted out from under it.
+		// Whoever still holds a consumer keeps the last state readable, so a
+		// [`ConnectionStatsReader`] outliving every [`Connection`] would otherwise
+		// keep the session clone parked here alive and the transport open with
+		// nothing left able to reach it. Releasing it here is not a close: a caller
+		// holding a session of their own keeps it, which is the whole point of
+		// [`Connection::session`].
+		self.disconnected();
+	}
 }
 
 /// A cloneable read handle for the live connection stats of a [`Connection`].
@@ -351,16 +436,19 @@ impl Connection {
 
 		let task = tokio::spawn(async move {
 			let reconnect = client.reconnect;
-			if let Err(err) = Self::run(&producer, &send_bw, &recv_bw, client, url).await {
+			let shared = Shared {
+				state: producer,
+				send_bw,
+				recv_bw,
+			};
+			if let Err(err) = Self::run(&shared, client, url).await {
 				// In one-shot mode the session ending is the expected lifecycle, and
 				// its close reason arrives here; don't dress it up as a loop failure.
 				match reconnect {
 					true => tracing::error!(%err, "connection loop exited"),
 					false => tracing::info!(%err, "connection closed"),
 				}
-				if let Ok(mut state) = producer.write() {
-					state.error = Some(err);
-				}
+				shared.failed(err);
 			}
 			// Dropping the producers here closes the channels, signaling consumers.
 		});
@@ -373,13 +461,7 @@ impl Connection {
 		}
 	}
 
-	async fn run(
-		state: &kio::Producer<State>,
-		send_bw: &BandwidthProducer,
-		recv_bw: &BandwidthProducer,
-		client: Client,
-		url: Url,
-	) -> crate::Result<()> {
+	async fn run(shared: &Shared, client: Client, url: Url) -> crate::Result<()> {
 		let backoff = client.backoff.clone();
 		let goaway = client.goaway.clone();
 		let pacing = Pacing::new(&backoff);
@@ -395,8 +477,8 @@ impl Connection {
 		let mut draining: Option<Draining> = None;
 
 		loop {
-			if !backoff.timeout.is_zero() && retry_start.elapsed() > backoff.timeout {
-				let timeout = backoff.timeout;
+			let timeout = backoff.timeout();
+			if !timeout.is_zero() && retry_start.elapsed() > timeout {
 				let msg = match last_error {
 					Some(err) => format!("reconnect timed out after {timeout:?}: {err}"),
 					None => format!("reconnect timed out after {timeout:?}"),
@@ -409,11 +491,7 @@ impl Connection {
 			match client.dial(url.clone()).await {
 				Ok(session) => {
 					tracing::info!(%url, "connected");
-					if let Ok(mut state) = state.write() {
-						state.status = Some(Status::Connected);
-						state.version = Some(session.version());
-						state.session = Some(session.clone());
-					}
+					shared.connected(&session);
 
 					let connected = tokio::time::Instant::now();
 					// Wait for the session to end, forwarding its bandwidth estimates into the
@@ -421,7 +499,7 @@ impl Connection {
 					// connection, and draining any predecessor left over from a migration.
 					// One-shot mode ignores GOAWAY: it cannot dial the replacement, and the
 					// peer force-closes at its own deadline anyway.
-					let ended = run_session(send_bw, recv_bw, &session, &mut draining, client.reconnect).await;
+					let ended = run_session(shared, &session, &mut draining, client.reconnect).await;
 
 					// A session that stayed up past the initial backoff is healthy; one that
 					// ended sooner counts as a failed attempt however it ended.
@@ -437,9 +515,7 @@ impl Connection {
 						// replacement at a group boundary. Tearing it down here instead
 						// would drop every group published until the replacement caught up.
 						tracing::info!(%url, "upstream GOAWAY; migrating");
-						if let Ok(mut state) = state.write() {
-							state.status = Some(Status::Migrating);
-						}
+						shared.migrating();
 						// Retire any predecessor first: overwriting would drop its deadline
 						// on the floor and leave it holding the connection open.
 						if let Some(mut old) = draining.take() {
@@ -463,19 +539,12 @@ impl Connection {
 						tracing::warn!(%url, ?delay, "peer redirected immediately; retrying after backoff");
 						// Keep the handover bounded across the sleep: nothing else polls the
 						// predecessor while the loop is between connections.
-						sleep_draining(delay, &mut draining).await;
+						sleep_draining(delay, &mut draining, shared).await;
 						delay = pacing.next(delay);
 						continue;
 					}
 
-					if let Ok(mut state) = state.write() {
-						state.status = Some(Status::Disconnected);
-						state.version = None;
-						state.session = None;
-					}
-					// The estimates belonged to the now-closed session; reset until the next connect.
-					let _ = send_bw.set(None);
-					let _ = recv_bw.set(None);
+					shared.disconnected();
 
 					// An auth rejection is terminal however long the session lived, and
 					// whether or not we would otherwise redial: the wire's UNAUTHORIZED is
@@ -536,7 +605,12 @@ impl Connection {
 			}
 
 			tracing::warn!(%url, ?delay, "reconnecting after backoff");
-			tokio::time::sleep(delay).await;
+			// Drain-aware: a GOAWAY off a healthy session continues straight to the
+			// replacement dial, so a predecessor can still be draining when that dial
+			// fails and lands here. A plain sleep would stop enforcing its handover
+			// until some later dial succeeded, holding an upstream that asked to drain
+			// open for the whole retry window, or forever with `--backoff-timeout=0`.
+			sleep_draining(delay, &mut draining, shared).await;
 			delay = pacing.next(delay);
 		}
 	}
@@ -733,13 +807,18 @@ impl Draining {
 /// after a successful connect, so a replacement that takes several backoff rounds
 /// to reach would leave the old session holding its connection well past the
 /// handover window.
-async fn sleep_draining(delay: Duration, draining: &mut Option<Draining>) {
+async fn sleep_draining(delay: Duration, draining: &mut Option<Draining>, shared: &Shared) {
 	let mut sleep = std::pin::pin!(tokio::time::sleep(delay));
 	kio::wait(|waiter| {
 		if let Some(old) = draining.as_mut()
 			&& old.poll(waiter)
 		{
 			*draining = None;
+			// Nothing is serving now: the predecessor closed or overstayed its
+			// handover, and the replacement is still a dial away. Leaving the state
+			// on `Migrating` would keep handing callers a session that is already
+			// closed, with its stats and version, until the next connect overwrote it.
+			shared.disconnected();
 		}
 		waiter.poll_future(sleep.as_mut())
 	})
@@ -755,8 +834,7 @@ async fn sleep_draining(delay: Duration, draining: &mut Option<Draining>) {
 /// polled through the waiter's own waker. `migrate` is whether a GOAWAY ends this session's
 /// tenure ([`Ended::Goaway`]); when false the arm isn't polled and only a close returns.
 async fn run_session(
-	send_bw: &BandwidthProducer,
-	recv_bw: &BandwidthProducer,
+	shared: &Shared,
 	session: &moq_net::Session,
 	draining: &mut Option<Draining>,
 	migrate: bool,
@@ -768,8 +846,8 @@ async fn run_session(
 	tokio::pin!(closed);
 
 	kio::wait(|waiter| {
-		poll_forward(&mut send, send_bw, waiter);
-		poll_forward(&mut recv, recv_bw, waiter);
+		poll_forward(&mut send, &shared.send_bw, waiter);
+		poll_forward(&mut recv, &shared.recv_bw, waiter);
 
 		// Retire the predecessor once it closes or overstays its handover window.
 		if let Some(old) = draining.as_mut()
@@ -831,6 +909,45 @@ fn terminal(state: &State) -> Error {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// The same clobber guard for [`Backoff`]. A bare field with a `default_value`
+	/// would be rewritten by the CLI re-parse that follows a TOML load, silently
+	/// resetting retry tuning that was only ever configured in the file.
+	#[test]
+	fn cli_does_not_clobber_toml_backoff() {
+		use clap::Parser;
+
+		#[derive(Parser)]
+		struct Wrapper {
+			#[command(flatten)]
+			backoff: Backoff,
+		}
+
+		// Stand in for the TOML layer, then re-apply the CLI with none of the flags set.
+		let mut parsed = Wrapper::parse_from(["test"]);
+		parsed.backoff.initial = Some(Duration::from_secs(7));
+		parsed.backoff.multiplier = Some(5);
+		parsed.backoff.max = Some(Duration::from_secs(11));
+		parsed.backoff.timeout = Some(Duration::ZERO);
+		parsed.update_from(["test"]);
+
+		assert_eq!(parsed.backoff.initial, Some(Duration::from_secs(7)));
+		assert_eq!(parsed.backoff.multiplier, Some(5));
+		assert_eq!(parsed.backoff.max, Some(Duration::from_secs(11)));
+		assert_eq!(parsed.backoff.timeout, Some(Duration::ZERO), "0 means retry forever");
+
+		// Unset stays unset, so the accessors supply the documented defaults.
+		let parsed = Wrapper::parse_from(["test"]);
+		assert_eq!(parsed.backoff.initial, None);
+		assert_eq!(parsed.backoff.initial(), DEFAULT_INITIAL);
+		assert_eq!(parsed.backoff.multiplier(), DEFAULT_MULTIPLIER);
+		assert_eq!(parsed.backoff.max(), DEFAULT_MAX);
+		assert_eq!(parsed.backoff.timeout(), DEFAULT_TIMEOUT);
+
+		// And a flag still lands where the merge can see it.
+		let parsed = Wrapper::parse_from(["test", "--backoff-initial", "3s"]);
+		assert_eq!(parsed.backoff.initial, Some(Duration::from_secs(3)));
+	}
 
 	/// The clap+TOML clobber guard: both `GoawayConfig` fields are `Option<T>` with
 	/// no `default_value`, so a TOML-configured value survives the CLI re-parse
@@ -1005,7 +1122,7 @@ mod tests {
 		// A zero initial would also make every session look healthy, resetting the
 		// give-up window forever.
 		let pacing = Pacing::new(&Backoff {
-			initial: Duration::ZERO,
+			initial: Some(Duration::ZERO),
 			..Default::default()
 		});
 		assert_eq!(pacing.initial, MIN_BACKOFF);
@@ -1013,7 +1130,7 @@ mod tests {
 
 		// A cap below the floor would clamp the delay straight back down.
 		let pacing = Pacing::new(&Backoff {
-			max: Duration::ZERO,
+			max: Some(Duration::ZERO),
 			..Default::default()
 		});
 		assert_eq!(pacing.max, pacing.initial);
@@ -1021,16 +1138,16 @@ mod tests {
 
 		// A zero multiplier would shrink it to nothing on the second attempt.
 		let pacing = Pacing::new(&Backoff {
-			multiplier: 0,
+			multiplier: Some(0),
 			..Default::default()
 		});
 		assert_eq!(pacing.next(pacing.initial), pacing.initial);
 
 		// All at once: still paced.
 		let pacing = Pacing::new(&Backoff {
-			initial: Duration::ZERO,
-			max: Duration::ZERO,
-			multiplier: 0,
+			initial: Some(Duration::ZERO),
+			max: Some(Duration::ZERO),
+			multiplier: Some(0),
 			..Default::default()
 		});
 		let mut delay = pacing.initial;
@@ -1044,9 +1161,9 @@ mod tests {
 	#[test]
 	fn pacing_grows_to_the_cap() {
 		let pacing = Pacing::new(&Backoff {
-			initial: Duration::from_millis(100),
-			multiplier: 2,
-			max: Duration::from_millis(400),
+			initial: Some(Duration::from_millis(100)),
+			multiplier: Some(2),
+			max: Some(Duration::from_millis(400)),
 			..Default::default()
 		});
 
@@ -1059,10 +1176,10 @@ mod tests {
 	#[test]
 	fn test_backoff_default() {
 		let backoff = Backoff::default();
-		assert_eq!(backoff.initial, Duration::from_secs(1));
-		assert_eq!(backoff.multiplier, 2);
-		assert_eq!(backoff.max, Duration::from_secs(30));
-		assert_eq!(backoff.timeout, Duration::from_secs(300));
+		assert_eq!(backoff.initial(), Duration::from_secs(1));
+		assert_eq!(backoff.multiplier(), 2);
+		assert_eq!(backoff.max(), Duration::from_secs(30));
+		assert_eq!(backoff.timeout(), Duration::from_secs(300));
 	}
 
 	/// The linger outlives the give-up timeout (so the reconnect error surfaces
@@ -1070,10 +1187,10 @@ mod tests {
 	#[test]
 	fn test_backoff_linger() {
 		let backoff = Backoff::default();
-		assert_eq!(backoff.linger(), backoff.timeout + Duration::from_secs(1));
+		assert_eq!(backoff.linger(), backoff.timeout() + Duration::from_secs(1));
 
 		let unlimited = Backoff {
-			timeout: Duration::ZERO,
+			timeout: Some(Duration::ZERO),
 			..Backoff::default()
 		};
 		assert_eq!(unlimited.linger(), Duration::MAX);

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -217,10 +217,44 @@ pub struct GoawayConfig {
 	pub handover: Option<Duration>,
 }
 
-/// Floor for [`Backoff::initial`], which paces the retries and sets the bar for
-/// calling a session healthy. Small enough to stay out of the way of a fast
-/// config, large enough that a session closed on sight never clears it.
+/// Floor for the retry delay, which also sets the bar for calling a session
+/// healthy. Small enough to stay out of the way of a fast config, large enough
+/// that a session closed on sight never clears it.
 const MIN_BACKOFF: Duration = Duration::from_millis(50);
+
+/// The retry pacing a connection actually runs on: [`Backoff`] with the floors
+/// applied.
+///
+/// Every knob can zero the delay on its own, and a delay of zero is a dial loop
+/// that runs as fast as the runtime allows. `initial` seeds it, `multiplier`
+/// grows it, and `max` caps it, so a zero anywhere collapses the whole schedule.
+/// Resolving them once, here, keeps that from having to be re-argued at each of
+/// the three places the loop reaches for them.
+struct Pacing {
+	/// The first delay, and the bar a session must clear to count as healthy. At
+	/// zero every session looks healthy, which resets the give-up window forever.
+	initial: Duration,
+	/// Never below `initial`, so the cap cannot undo the floor on later retries.
+	max: Duration,
+	/// At least 1, since zero would shrink the delay back to nothing.
+	multiplier: u32,
+}
+
+impl Pacing {
+	fn new(backoff: &Backoff) -> Self {
+		let initial = backoff.initial.max(MIN_BACKOFF);
+		Self {
+			initial,
+			max: backoff.max.max(initial),
+			multiplier: backoff.multiplier.max(1),
+		}
+	}
+
+	/// The delay for the attempt after one that waited `delay`.
+	fn next(&self, delay: Duration) -> Duration {
+		std::cmp::min(delay.saturating_mul(self.multiplier), self.max)
+	}
+}
 
 /// Default handover window, and the ceiling a GOAWAY deadline is capped to when
 /// the config names none.
@@ -348,13 +382,8 @@ impl Connection {
 	) -> crate::Result<()> {
 		let backoff = client.backoff.clone();
 		let goaway = client.goaway.clone();
-		// This value does double duty: the first retry delay, and the bar a session
-		// has to clear to count as healthy. At zero both collapse. Every session would
-		// be healthy (`elapsed() >= 0`), which resets the give-up window; the delay
-		// would stay zero through the multiplier; and a peer that closes on sight
-		// would be redialed as fast as the runtime allows, forever. Floor it so both
-		// roles keep their meaning.
-		let initial = backoff.initial.max(MIN_BACKOFF);
+		let pacing = Pacing::new(&backoff);
+		let initial = pacing.initial;
 		let mut delay = initial;
 		let mut retry_start = tokio::time::Instant::now();
 		let mut last_error: Option<Error> = None;
@@ -435,7 +464,7 @@ impl Connection {
 						// Keep the handover bounded across the sleep: nothing else polls the
 						// predecessor while the loop is between connections.
 						sleep_draining(delay, &mut draining).await;
-						delay = std::cmp::min(delay * backoff.multiplier, backoff.max);
+						delay = pacing.next(delay);
 						continue;
 					}
 
@@ -508,7 +537,7 @@ impl Connection {
 
 			tracing::warn!(%url, ?delay, "reconnecting after backoff");
 			tokio::time::sleep(delay).await;
-			delay = std::cmp::min(delay * backoff.multiplier, backoff.max);
+			delay = pacing.next(delay);
 		}
 	}
 
@@ -966,6 +995,65 @@ mod tests {
 			Some(5443),
 			"a different port on the same host is followed"
 		);
+	}
+
+	/// Every pacing knob can zero the retry delay on its own, and a zero delay is a
+	/// dial loop bounded by nothing. The floors are what keep a degenerate config
+	/// (or a binding that passes zeros) from turning unlimited retries into a spin.
+	#[test]
+	fn pacing_floors_every_degenerate_knob() {
+		// A zero initial would also make every session look healthy, resetting the
+		// give-up window forever.
+		let pacing = Pacing::new(&Backoff {
+			initial: Duration::ZERO,
+			..Default::default()
+		});
+		assert_eq!(pacing.initial, MIN_BACKOFF);
+		assert!(pacing.next(pacing.initial) >= MIN_BACKOFF);
+
+		// A cap below the floor would clamp the delay straight back down.
+		let pacing = Pacing::new(&Backoff {
+			max: Duration::ZERO,
+			..Default::default()
+		});
+		assert_eq!(pacing.max, pacing.initial);
+		assert_eq!(pacing.next(pacing.initial), pacing.initial);
+
+		// A zero multiplier would shrink it to nothing on the second attempt.
+		let pacing = Pacing::new(&Backoff {
+			multiplier: 0,
+			..Default::default()
+		});
+		assert_eq!(pacing.next(pacing.initial), pacing.initial);
+
+		// All at once: still paced.
+		let pacing = Pacing::new(&Backoff {
+			initial: Duration::ZERO,
+			max: Duration::ZERO,
+			multiplier: 0,
+			..Default::default()
+		});
+		let mut delay = pacing.initial;
+		for _ in 0..10 {
+			delay = pacing.next(delay);
+			assert!(delay >= MIN_BACKOFF, "the retry delay collapsed to {delay:?}");
+		}
+	}
+
+	/// A sane config is left alone: the delay doubles up to the cap and stays there.
+	#[test]
+	fn pacing_grows_to_the_cap() {
+		let pacing = Pacing::new(&Backoff {
+			initial: Duration::from_millis(100),
+			multiplier: 2,
+			max: Duration::from_millis(400),
+			..Default::default()
+		});
+
+		assert_eq!(pacing.initial, Duration::from_millis(100));
+		assert_eq!(pacing.next(Duration::from_millis(100)), Duration::from_millis(200));
+		assert_eq!(pacing.next(Duration::from_millis(200)), Duration::from_millis(400));
+		assert_eq!(pacing.next(Duration::from_millis(400)), Duration::from_millis(400));
 	}
 
 	#[test]

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -488,7 +488,21 @@ impl Connection {
 
 			tracing::info!(%url, "connecting");
 
-			match client.dial(url.clone()).await {
+			// Keep a predecessor's handover bounded across the dial. A GOAWAY off a
+			// healthy session comes straight here with the old one still draining, and
+			// a slow or blackholed replacement would otherwise hold it past the
+			// deadline we promised, still reported as `Migrating`, until the dial
+			// returned.
+			let mut dial = std::pin::pin!(client.dial(url.clone()));
+			let dialed = kio::wait(|waiter| {
+				if poll_draining(&mut draining, waiter) {
+					shared.disconnected();
+				}
+				waiter.poll_future(dial.as_mut())
+			})
+			.await;
+
+			match dialed {
 				Ok(session) => {
 					tracing::info!(%url, "connected");
 					shared.connected(&session);
@@ -801,6 +815,22 @@ impl Draining {
 	}
 }
 
+/// Poll a draining predecessor, retiring it once it closes or overstays its
+/// handover window. `true` on the pass that retires it.
+///
+/// A `poll_*` step: on return the waiter is registered for the next change. The
+/// caller decides what the retirement means, because that depends on whether a
+/// replacement is already serving.
+fn poll_draining(draining: &mut Option<Draining>, waiter: &kio::Waiter) -> bool {
+	if let Some(old) = draining.as_mut()
+		&& old.poll(waiter)
+	{
+		*draining = None;
+		return true;
+	}
+	false
+}
+
 /// Sleep for `delay` while keeping a draining predecessor's deadline enforced.
 ///
 /// The drain is otherwise only polled from [`run_session`], which is reached only
@@ -810,14 +840,11 @@ impl Draining {
 async fn sleep_draining(delay: Duration, draining: &mut Option<Draining>, shared: &Shared) {
 	let mut sleep = std::pin::pin!(tokio::time::sleep(delay));
 	kio::wait(|waiter| {
-		if let Some(old) = draining.as_mut()
-			&& old.poll(waiter)
-		{
-			*draining = None;
-			// Nothing is serving now: the predecessor closed or overstayed its
-			// handover, and the replacement is still a dial away. Leaving the state
-			// on `Migrating` would keep handing callers a session that is already
-			// closed, with its stats and version, until the next connect overwrote it.
+		// Nothing is serving once it retires: the predecessor closed or overstayed
+		// its handover, and the replacement is still a dial away. Leaving the state
+		// on `Migrating` would keep handing callers a session that is already closed,
+		// with its stats and version, until the next connect overwrote it.
+		if poll_draining(draining, waiter) {
 			shared.disconnected();
 		}
 		waiter.poll_future(sleep.as_mut())
@@ -850,11 +877,8 @@ async fn run_session(
 		poll_forward(&mut recv, &shared.recv_bw, waiter);
 
 		// Retire the predecessor once it closes or overstays its handover window.
-		if let Some(old) = draining.as_mut()
-			&& old.poll(waiter)
-		{
-			*draining = None;
-		}
+		// The replacement is already serving, so the state stays as it is.
+		poll_draining(draining, waiter);
 
 		// Checked before the close arm: a GOAWAY means the session is still up, and
 		// migrating from it is not the same as reconnecting after it died.

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -411,6 +411,11 @@ impl ConnectionStatsReader {
 /// waits for the first session, [`connected`](Self::connected) reads the current state synchronously,
 /// and [`status`](Self::status) waits for the next change. [`closed`](Self::closed)
 /// waits for the loop to stop. Dropping the handle aborts the background task.
+///
+/// `#[must_use]` because that last part is a footgun otherwise: `client.connect(url);`
+/// starts the dial and cancels it at the end of the statement. The old `async fn
+/// connect` was caught by the future's own `#[must_use]`; this restores the warning.
+#[must_use = "dropping the Connection aborts the dial; hold it for as long as you want the session"]
 pub struct Connection {
 	abort: tokio::task::AbortHandle,
 	state: kio::Consumer<State>,

--- a/rs/moq-native/src/error.rs
+++ b/rs/moq-native/src/error.rs
@@ -81,6 +81,13 @@ pub enum Error {
 	#[error("{0}")]
 	Reconnect(String),
 
+	/// The connection was stopped locally, by closing it or dropping the last handle.
+	///
+	/// Not a failure: it is what a caller asked for. Distinct from [`Self::Reconnect`]
+	/// so a status watcher can tell an expected teardown from a connection that gave up.
+	#[error("connection stopped")]
+	Stopped,
+
 	/// Loading certificates or building the TLS config failed.
 	#[error(transparent)]
 	Tls(Arc<crate::tls::Error>),

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod bind;
 mod client;
 mod connect;
+mod connection;
 mod crypto;
 mod error;
 #[cfg(any(feature = "quinn", feature = "noq", feature = "quiche", feature = "tcp"))]
@@ -27,7 +28,6 @@ pub mod noq;
 pub mod quic;
 #[cfg(feature = "quinn")]
 pub mod quinn;
-mod reconnect;
 mod server;
 #[cfg(feature = "tcp")]
 pub mod tcp;
@@ -44,9 +44,9 @@ pub mod websocket;
 // new `pub` item in these modules doesn't silently join it.
 pub use client::{Client, ClientConfig};
 pub use connect::ConnectError;
+pub use connection::{Backoff, Connection, ConnectionStatsReader, GoawayConfig, Redirect, Status};
 pub use error::{Error, Result};
 pub use log::Log;
-pub use reconnect::{Backoff, ConnectionStatsReader, GoawayConfig, Reconnect, Redirect, Status};
 pub use server::{Request, Server, ServerConfig, Transport};
 
 /// Spawn the session's protocol driver on the current tokio runtime, handing back

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -43,7 +43,7 @@ async fn connect_with_version(version: &str) {
 	});
 
 	let client = client.with_publisher(&origin);
-	let client_result = client.connect(url).await;
+	let client_result = client.with_reconnect(false).connect(url).established().await;
 
 	let server_result = server_handle.await.expect("server task panicked");
 
@@ -94,7 +94,7 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	});
 
 	let client = client.with_publisher(&origin);
-	let client_result = client.connect(url).await;
+	let client_result = client.with_reconnect(false).connect(url).established().await;
 
 	let server_result = server_handle.await.expect("server task panicked");
 

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -169,7 +169,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -327,6 +327,7 @@ async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend, reject: bool)
 		Ok::<_, anyhow::Error>(has_cert)
 	});
 
+	// The mTLS cases assert on the connect result itself, so keep it a `Result`.
 	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out");
@@ -551,7 +552,7 @@ async fn iroh_connect() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -714,12 +715,20 @@ async fn quiche_qlog() {
 	assert!(!traces.is_empty(), "expected at least one trace");
 }
 
-/// Dial once and hand back the session.
+/// Dial once and hand back the client with its session.
 ///
-/// These tests want a single transport, so reconnecting is off: the connection is
-/// released as soon as the session is up, and with nothing left to redial the
-/// session outlives it.
-async fn connect_once(client: moq_native::Client, url: url::Url) -> moq_native::Result<moq_net::Session> {
-	let connection = client.with_reconnect(false).connect(url).established().await?;
-	connection.session().ok_or(moq_native::Error::ConnectFailed)
+/// These tests want a single transport, so reconnecting is off and the connection
+/// is released as soon as the session is up: there is nothing left to redial, and
+/// letting it go is what keeps `drop(session)` closing the transport, since a live
+/// connection holds a session clone of its own.
+///
+/// The client comes back because it owns the transport endpoint (iroh's dies with
+/// it), and the caller has to outlive the session it just got.
+async fn connect_once(
+	client: moq_native::Client,
+	url: url::Url,
+) -> moq_native::Result<(moq_native::Client, moq_net::Session)> {
+	let connection = client.clone().with_reconnect(false).connect(url).established().await?;
+	let session = connection.session().ok_or(moq_native::Error::ConnectFailed)?;
+	Ok((client, session))
 }

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -169,7 +169,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -327,7 +327,7 @@ async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend, reject: bool)
 		Ok::<_, anyhow::Error>(has_cert)
 	});
 
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out");
 
@@ -551,7 +551,7 @@ async fn iroh_connect() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -169,7 +169,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -327,7 +327,7 @@ async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend, reject: bool)
 		Ok::<_, anyhow::Error>(has_cert)
 	});
 
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out");
 
@@ -551,7 +551,7 @@ async fn iroh_connect() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -712,4 +712,14 @@ async fn noq_qlog() {
 async fn quiche_qlog() {
 	let traces = qlog_test("https", moq_native::QuicBackend::Quiche).await;
 	assert!(!traces.is_empty(), "expected at least one trace");
+}
+
+/// Dial once and hand back the session.
+///
+/// These tests want a single transport, so reconnecting is off: the connection is
+/// released as soon as the session is up, and with nothing left to redial the
+/// session outlives it.
+async fn connect_once(client: moq_native::Client, url: url::Url) -> moq_native::Result<moq_net::Session> {
+	let connection = client.with_reconnect(false).connect(url).established().await?;
+	connection.session().ok_or(moq_native::Error::ConnectFailed)
 }

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -74,7 +74,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -183,7 +183,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -300,7 +300,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -424,7 +424,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -531,7 +531,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -619,7 +619,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -804,7 +804,7 @@ async fn broadcast_route_migration() {
 		let client = config.init().expect("init client");
 		let url: url::Url = format!("moqt://localhost:{port}").parse().unwrap();
 		async move {
-			tokio::time::timeout(TIMEOUT, client.with_subscriber(sub).connect(url))
+			tokio::time::timeout(TIMEOUT, client.with_subscriber(sub).connect(url).established())
 				.await
 				.expect("connect timeout")
 				.expect("connect failed")
@@ -914,7 +914,7 @@ async fn route_reannounce_test(version: Option<&str>) {
 	}
 	let client = client_config.init().expect("init client");
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
-	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -1049,7 +1049,7 @@ async fn route_replaced_test(version: Option<&str>) {
 	}
 	let client = client_config.init().expect("init client");
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
-	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -1623,7 +1623,7 @@ async fn broadcast_websocket() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1736,7 +1736,7 @@ async fn broadcast_websocket_fallback() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1844,7 +1844,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let cs = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1922,7 +1922,7 @@ async fn broadcast_race_quic_wins() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let cs = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1985,7 +1985,7 @@ async fn resubscribe_keeps_flowing_moq_lite_03() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -2120,7 +2120,7 @@ async fn idle_subscription_releases_the_viewer_count() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -2195,7 +2195,7 @@ async fn websocket_unauthorized_handshake_is_explicit() {
 	let client = client_config.init().expect("failed to init client");
 	let url: url::Url = format!("ws://{addr}").parse().unwrap();
 
-	let err = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let err = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out");
 	let err = expect_connect_err(err);
@@ -2232,7 +2232,7 @@ async fn reconnect_stops_on_websocket_unauthorized() {
 	let client = client_config.init().expect("failed to init client");
 	let url: url::Url = format!("ws://{addr}").parse().unwrap();
 
-	let reconnect = client.reconnect(url);
+	let reconnect = client.connect(url);
 	let err = tokio::time::timeout(TIMEOUT, reconnect.closed())
 		.await
 		.expect("reconnect close timed out")
@@ -2243,6 +2243,64 @@ async fn reconnect_stops_on_websocket_unauthorized() {
 		.await
 		.expect("server task panicked")
 		.expect("server task failed");
+}
+
+/// With reconnecting disabled, the session ending ends the connection: its close
+/// reason surfaces through `closed()` and the loop never dials again.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn one_shot_connect_surfaces_the_session_close() {
+	use std::sync::Arc;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
+	let (mut server, addr) = test_server();
+	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
+
+	// Keep accepting so a buggy redial would show up as a second accept, and
+	// close each session as soon as it lands.
+	let accepts = Arc::new(AtomicUsize::new(0));
+	let server_accepts = accepts.clone();
+	let pub_origin = Origin::random().produce();
+	let server_handle = tokio::spawn(async move {
+		while let Some(request) = server.accept().await {
+			server_accepts.fetch_add(1, Ordering::SeqCst);
+			let session = request.with_publisher(&pub_origin).ok().await?;
+			session.abort(moq_net::Error::Cancel);
+		}
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	client_config.reconnect = Some(false);
+	// A tiny backoff so a buggy redial happens well within the sleep below.
+	client_config.backoff.initial = Duration::from_millis(10);
+	let client = client_config.init().expect("failed to init client");
+
+	let connection = client.connect(url);
+	let session = tokio::time::timeout(TIMEOUT, connection.established())
+		.await
+		.expect("connect timed out")
+		.expect("connect failed");
+
+	// The server aborts the session; one-shot mode turns that into the terminal error.
+	tokio::time::timeout(TIMEOUT, connection.closed())
+		.await
+		.expect("close timed out")
+		.expect_err("a severed session must surface as an error");
+	assert!(!connection.connected());
+	let _ = tokio::time::timeout(TIMEOUT, session.closed()).await;
+
+	// Give a buggy reconnect loop ample time to redial before counting accepts.
+	tokio::time::sleep(Duration::from_millis(200)).await;
+	assert_eq!(
+		accepts.load(Ordering::SeqCst),
+		1,
+		"one-shot mode must dial exactly once"
+	);
+
+	drop(connection);
+	server_handle.abort();
 }
 
 /// A peer that expresses announce-interest in a prefix the publisher can't serve (e.g. a
@@ -2293,7 +2351,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 	});
 
 	let client = client.with_subscriber(consume);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2406,10 +2464,13 @@ async fn publish_only_client_to_subscribe_only_server() {
 		.scope(&["allowed".into()])
 		.expect("failed to scope publish origin");
 
-	let session = tokio::time::timeout(TIMEOUT, test_client().with_publisher(publish).connect(url))
-		.await
-		.expect("client connect timed out")
-		.expect("client connect failed");
+	let session = tokio::time::timeout(
+		TIMEOUT,
+		test_client().with_publisher(publish).connect(url).established(),
+	)
+	.await
+	.expect("client connect timed out")
+	.expect("client connect failed");
 
 	server_handle
 		.await
@@ -2514,7 +2575,7 @@ async fn goaway_test(scheme: &str, version: &str, expect_wire_timeout: bool) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2634,7 +2695,7 @@ async fn goaway_timeout_force_close_moq_transport_19_quic() {
 	});
 
 	let sub_origin = Origin::random().produce();
-	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -2742,13 +2742,12 @@ async fn connect_once(
 
 /// A zero initial backoff must still give up on a peer that closes on sight.
 ///
-/// The value paces the retries and sets the bar for calling a session healthy, so
-/// at zero every session cleared the bar, which reset the give-up window, and the
-/// delay stayed zero through the multiplier. The loop redialed as fast as the
-/// runtime allowed and never stopped.
+/// `initial` is both the first delay and the bar a session must clear to count as
+/// healthy, so at zero every session looked healthy, which reset the give-up
+/// window on every pass. The loop then redialed forever, timeout or not.
 #[tracing_test::traced_test]
 #[tokio::test]
-async fn zero_backoff_still_gives_up_on_a_flapping_peer() {
+async fn zero_initial_backoff_still_gives_up_on_a_flapping_peer() {
 	let (mut server, addr) = test_server();
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
@@ -2771,7 +2770,7 @@ async fn zero_backoff_still_gives_up_on_a_flapping_peer() {
 	let connection = client.connect(url);
 	tokio::time::timeout(TIMEOUT, connection.closed())
 		.await
-		.expect("the loop spun instead of exhausting its retry window")
+		.expect("the loop reset its give-up window instead of exhausting it")
 		.expect_err("a flapping peer must exhaust the retry window");
 
 	server_handle.abort();

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -2274,7 +2274,7 @@ async fn one_shot_connect_surfaces_the_session_close() {
 	client_config.tls.disable_verify = Some(true);
 	client_config.reconnect = Some(false);
 	// A tiny backoff so a buggy redial happens well within the sleep below.
-	client_config.backoff.initial = Duration::from_millis(10);
+	client_config.backoff.initial = Some(Duration::from_millis(10));
 	let client = client_config.init().expect("failed to init client");
 
 	let connection = tokio::time::timeout(TIMEOUT, client.connect(url).established())
@@ -2763,8 +2763,8 @@ async fn zero_initial_backoff_still_gives_up_on_a_flapping_peer() {
 
 	let mut client_config = moq_native::ClientConfig::default();
 	client_config.tls.disable_verify = Some(true);
-	client_config.backoff.initial = Duration::ZERO;
-	client_config.backoff.timeout = Duration::from_millis(500);
+	client_config.backoff.initial = Some(Duration::ZERO);
+	client_config.backoff.timeout = Some(Duration::from_millis(500));
 	let client = client_config.init().expect("failed to init client");
 
 	let connection = client.connect(url);

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1335,10 +1335,19 @@ async fn latency_max_test(version: &str) -> Duration {
 	client_config.version = vec![version];
 	let client = client_config.init().expect("init client");
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
-	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url))
-		.await
-		.expect("connect timeout")
-		.expect("connect failed");
+	// Reconnecting off: the assertions below are written against a single dial, and
+	// a background redial would re-announce behind them.
+	let session = tokio::time::timeout(
+		TIMEOUT,
+		client
+			.with_subscriber(sub_origin)
+			.with_reconnect(false)
+			.connect(url)
+			.established(),
+	)
+	.await
+	.expect("connect timeout")
+	.expect("connect failed");
 
 	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "test");
@@ -2793,7 +2802,9 @@ async fn session_close_surfaces_a_rejection_code() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let session = tokio::time::timeout(TIMEOUT, connect_once(test_client(), url))
+	// The client is held so the endpoint outlives the dial; the session is what the
+	// rejection arrives on.
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(test_client(), url))
 		.await
 		.expect("connect timed out")
 		.expect("connect failed");

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -74,7 +74,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -183,7 +183,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -300,7 +300,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -424,7 +424,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -531,7 +531,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -619,7 +619,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -804,7 +804,7 @@ async fn broadcast_route_migration() {
 		let client = config.init().expect("init client");
 		let url: url::Url = format!("moqt://localhost:{port}").parse().unwrap();
 		async move {
-			tokio::time::timeout(TIMEOUT, client.with_subscriber(sub).connect(url).established())
+			tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub), url))
 				.await
 				.expect("connect timeout")
 				.expect("connect failed")
@@ -914,7 +914,7 @@ async fn route_reannounce_test(version: Option<&str>) {
 	}
 	let client = client_config.init().expect("init client");
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
-	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -1049,7 +1049,7 @@ async fn route_replaced_test(version: Option<&str>) {
 	}
 	let client = client_config.init().expect("init client");
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
-	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -1623,7 +1623,7 @@ async fn broadcast_websocket() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1736,7 +1736,7 @@ async fn broadcast_websocket_fallback() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1844,7 +1844,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let cs = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1922,7 +1922,7 @@ async fn broadcast_race_quic_wins() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let cs = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1985,7 +1985,7 @@ async fn resubscribe_keeps_flowing_moq_lite_03() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -2120,7 +2120,7 @@ async fn idle_subscription_releases_the_viewer_count() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -2195,7 +2195,7 @@ async fn websocket_unauthorized_handshake_is_explicit() {
 	let client = client_config.init().expect("failed to init client");
 	let url: url::Url = format!("ws://{addr}").parse().unwrap();
 
-	let err = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let err = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out");
 	let err = expect_connect_err(err);
@@ -2277,11 +2277,11 @@ async fn one_shot_connect_surfaces_the_session_close() {
 	client_config.backoff.initial = Duration::from_millis(10);
 	let client = client_config.init().expect("failed to init client");
 
-	let connection = client.connect(url);
-	let session = tokio::time::timeout(TIMEOUT, connection.established())
+	let connection = tokio::time::timeout(TIMEOUT, client.connect(url).established())
 		.await
 		.expect("connect timed out")
 		.expect("connect failed");
+	let session = connection.session().expect("established without a session");
 
 	// The server aborts the session; one-shot mode turns that into the terminal error.
 	tokio::time::timeout(TIMEOUT, connection.closed())
@@ -2351,7 +2351,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 	});
 
 	let client = client.with_subscriber(consume);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2464,13 +2464,10 @@ async fn publish_only_client_to_subscribe_only_server() {
 		.scope(&["allowed".into()])
 		.expect("failed to scope publish origin");
 
-	let session = tokio::time::timeout(
-		TIMEOUT,
-		test_client().with_publisher(publish).connect(url).established(),
-	)
-	.await
-	.expect("client connect timed out")
-	.expect("client connect failed");
+	let session = tokio::time::timeout(TIMEOUT, connect_once(test_client().with_publisher(publish), url))
+		.await
+		.expect("client connect timed out")
+		.expect("client connect failed");
 
 	server_handle
 		.await
@@ -2575,7 +2572,7 @@ async fn goaway_test(scheme: &str, version: &str, expect_wire_timeout: bool) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2695,7 +2692,7 @@ async fn goaway_timeout_force_close_moq_transport_19_quic() {
 	});
 
 	let sub_origin = Origin::random().produce();
-	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2725,6 +2722,16 @@ async fn goaway_timeout_force_close_moq_transport_19_quic() {
 		.expect("server errored");
 }
 
+/// Dial once and hand back the session.
+///
+/// These tests want a single transport, so reconnecting is off: the connection is
+/// released as soon as the session is up, and with nothing left to redial the
+/// session outlives it.
+async fn connect_once(client: moq_native::Client, url: url::Url) -> moq_native::Result<moq_net::Session> {
+	let connection = client.with_reconnect(false).connect(url).established().await?;
+	connection.session().ok_or(moq_native::Error::ConnectFailed)
+}
+
 /// A rejection at the MoQ layer lands after the transport handshake, so the dial
 /// itself succeeds and the rejection arrives as the session's close. That close
 /// rides the specified UNAUTHORIZED session code, so it decodes back into a typed
@@ -2742,7 +2749,7 @@ async fn session_close_surfaces_a_rejection_code() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let session = tokio::time::timeout(TIMEOUT, test_client().connect(url))
+	let session = tokio::time::timeout(TIMEOUT, connect_once(test_client(), url))
 		.await
 		.expect("connect timed out")
 		.expect("connect failed");
@@ -2777,8 +2784,8 @@ async fn reconnect_stops_on_a_session_level_rejection() {
 	// Without classification the loop would retry until the backoff give-up (5m by
 	// default), so `closed` resolving within TIMEOUT proves it stopped on the
 	// rejection itself.
-	let reconnect = test_client().reconnect(url);
-	let err = tokio::time::timeout(TIMEOUT, reconnect.closed())
+	let connection = test_client().connect(url);
+	let err = tokio::time::timeout(TIMEOUT, connection.closed())
 		.await
 		.expect("a rejected session must stop the reconnect loop promptly")
 		.expect_err("a rejected session must surface as an error");

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -74,7 +74,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -183,7 +183,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -300,7 +300,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -424,7 +424,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -531,7 +531,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -619,7 +619,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -914,7 +914,7 @@ async fn route_reannounce_test(version: Option<&str>) {
 	}
 	let client = client_config.init().expect("init client");
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -1049,7 +1049,7 @@ async fn route_replaced_test(version: Option<&str>) {
 	}
 	let client = client_config.init().expect("init client");
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -1623,7 +1623,7 @@ async fn broadcast_websocket() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1736,7 +1736,7 @@ async fn broadcast_websocket_fallback() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1844,7 +1844,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, cs) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1922,7 +1922,7 @@ async fn broadcast_race_quic_wins() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, cs) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1985,7 +1985,7 @@ async fn resubscribe_keeps_flowing_moq_lite_03() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -2120,7 +2120,7 @@ async fn idle_subscription_releases_the_viewer_count() {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -2351,7 +2351,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 	});
 
 	let client = client.with_subscriber(consume);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2464,7 +2464,7 @@ async fn publish_only_client_to_subscribe_only_server() {
 		.scope(&["allowed".into()])
 		.expect("failed to scope publish origin");
 
-	let session = tokio::time::timeout(TIMEOUT, connect_once(test_client().with_publisher(publish), url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(test_client().with_publisher(publish), url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2500,7 +2500,7 @@ fn assert_connect_error(err: &moq_native::Error, expected: moq_native::ConnectEr
 	assert_eq!(err.connect_error(), Some(expected), "unexpected error: {err}",);
 }
 
-fn expect_connect_err(result: moq_native::Result<moq_net::Session>) -> moq_native::Error {
+fn expect_connect_err(result: moq_native::Result<(moq_native::Client, moq_net::Session)>) -> moq_native::Error {
 	match result {
 		Ok(_) => panic!("client connect unexpectedly succeeded"),
 		Err(err) => err,
@@ -2572,7 +2572,7 @@ async fn goaway_test(scheme: &str, version: &str, expect_wire_timeout: bool) {
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client, url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2692,7 +2692,7 @@ async fn goaway_timeout_force_close_moq_transport_19_quic() {
 	});
 
 	let sub_origin = Origin::random().produce();
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -2722,14 +2722,59 @@ async fn goaway_timeout_force_close_moq_transport_19_quic() {
 		.expect("server errored");
 }
 
-/// Dial once and hand back the session.
+/// Dial once and hand back the client with its session.
 ///
-/// These tests want a single transport, so reconnecting is off: the connection is
-/// released as soon as the session is up, and with nothing left to redial the
-/// session outlives it.
-async fn connect_once(client: moq_native::Client, url: url::Url) -> moq_native::Result<moq_net::Session> {
-	let connection = client.with_reconnect(false).connect(url).established().await?;
-	connection.session().ok_or(moq_native::Error::ConnectFailed)
+/// These tests want a single transport, so reconnecting is off and the connection
+/// is released as soon as the session is up: there is nothing left to redial, and
+/// letting it go is what keeps `drop(session)` closing the transport, since a live
+/// connection holds a session clone of its own.
+///
+/// The client comes back because it owns the transport endpoint (iroh's dies with
+/// it), and the caller has to outlive the session it just got.
+async fn connect_once(
+	client: moq_native::Client,
+	url: url::Url,
+) -> moq_native::Result<(moq_native::Client, moq_net::Session)> {
+	let connection = client.clone().with_reconnect(false).connect(url).established().await?;
+	let session = connection.session().ok_or(moq_native::Error::ConnectFailed)?;
+	Ok((client, session))
+}
+
+/// A zero initial backoff must still give up on a peer that closes on sight.
+///
+/// The value paces the retries and sets the bar for calling a session healthy, so
+/// at zero every session cleared the bar, which reset the give-up window, and the
+/// delay stayed zero through the multiplier. The loop redialed as fast as the
+/// runtime allowed and never stopped.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn zero_backoff_still_gives_up_on_a_flapping_peer() {
+	let (mut server, addr) = test_server();
+	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
+
+	let pub_origin = Origin::random().produce();
+	let server_handle = tokio::spawn(async move {
+		// Accept and immediately sever, over and over.
+		while let Some(request) = server.accept().await {
+			let session = request.with_publisher(&pub_origin).ok().await?;
+			session.abort(moq_net::Error::Cancel);
+		}
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	client_config.backoff.initial = Duration::ZERO;
+	client_config.backoff.timeout = Duration::from_millis(500);
+	let client = client_config.init().expect("failed to init client");
+
+	let connection = client.connect(url);
+	tokio::time::timeout(TIMEOUT, connection.closed())
+		.await
+		.expect("the loop spun instead of exhausting its retry window")
+		.expect_err("a flapping peer must exhaust the retry window");
+
+	server_handle.abort();
 }
 
 /// A rejection at the MoQ layer lands after the transport handshake, so the dial

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -2254,6 +2254,50 @@ async fn reconnect_stops_on_websocket_unauthorized() {
 		.expect("server task failed");
 }
 
+/// A GOAWAY ends a one-shot connection instead of being ignored.
+///
+/// The peer here sends a GOAWAY naming no deadline and then waits, which is the
+/// case that deadlocks if the client ignores it: nothing force-closes, the peer
+/// has stopped accepting requests and is waiting for us to leave, and we would
+/// sit on the session waiting for the peer. A one-shot client cannot dial the
+/// replacement, so leaving is the only answer it has.
+///
+/// The assertion is that `closed()` resolves at all; before the fix the GOAWAY
+/// arm was not polled without reconnecting, and this hung until the test timeout.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn one_shot_goaway_ends_the_connection() {
+	let (mut server, addr) = test_server();
+	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("no incoming connection");
+		let session = request.ok().await?;
+
+		// No deadline, so nothing on the peer's side ever force-closes us.
+		session
+			.drain()
+			.send(moq_net::goaway::Goaway::default())
+			.expect("send goaway");
+
+		// Wait for the client to leave, exactly as a draining peer does. If the
+		// client ignores the GOAWAY, both sides wait here forever.
+		session.closed().await;
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let connection = test_client().with_reconnect(false).connect(url);
+	tokio::time::timeout(TIMEOUT, connection.closed())
+		.await
+		.expect("a one-shot GOAWAY must end the connection, not wait for the peer")
+		.expect("leaving on request is a clean close, not an error");
+
+	server_handle
+		.await
+		.expect("server task panicked")
+		.expect("server failed");
+}
+
 /// With reconnecting disabled, the session ending ends the connection: its close
 /// reason surfaces through `closed()` and the loop never dials again.
 #[tracing_test::traced_test]

--- a/rs/moq-net/src/goaway.rs
+++ b/rs/moq-net/src/goaway.rs
@@ -9,7 +9,7 @@
 //! the sender's own timer, so it force-closes on schedule whether or not the peer
 //! could be told why. Callers do not branch on the negotiated version.
 //!
-//! Following the redirect is the caller's job. `moq_native::Reconnect` implements
+//! Following the redirect is the caller's job. `moq_native::Connection` implements
 //! it for native clients.
 
 use std::{

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -982,7 +982,7 @@ impl Cluster {
 		// a failed attempt, so an A-redirects-to-B-redirects-to-A loop escalates
 		// through backoff and eventually gives up instead of migrating forever.
 		// Downstream sessions never see a GOAWAY of their own.
-		let mut reconnect = client.reconnect(url.clone());
+		let mut reconnect = client.connect(url.clone());
 		let mut connection = None;
 		loop {
 			match reconnect.status().await? {

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -102,7 +102,9 @@ async fn drain_session_with_zero_timeout_closes_at_once_inner() {
 	let client = client_config.init().expect("client init");
 	let client_session = within("client connects", async {
 		client
+			.with_reconnect(false)
 			.connect(format!("tcp://127.0.0.1:{port}/").parse().expect("parse url"))
+			.established()
 			.await
 	})
 	.await
@@ -395,7 +397,9 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 		"MID-A connects to TOP",
 		mid_a_client
 			.with_subscriber(mid_a_origin.clone())
-			.connect(top_url.parse().expect("parse top url")),
+			.with_reconnect(false)
+			.connect(top_url.parse().expect("parse top url"))
+			.established(),
 	)
 	.await
 	.expect("mid-a upstream connect");
@@ -424,7 +428,9 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 		"subscriber connects to BOTTOM",
 		sub_client
 			.with_subscriber(sub_origin.clone())
-			.connect(format!("tcp://127.0.0.1:{bottom_port}/").parse().expect("parse url")),
+			.with_reconnect(false)
+			.connect(format!("tcp://127.0.0.1:{bottom_port}/").parse().expect("parse url"))
+			.established(),
 	)
 	.await
 	.expect("subscriber connect");

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -100,7 +100,7 @@ async fn drain_session_with_zero_timeout_closes_at_once_inner() {
 	let mut client_config = moq_native::ClientConfig::default();
 	client_config.tls.disable_verify = Some(true);
 	let client = client_config.init().expect("client init");
-	let client_session = within("client connects", async {
+	let (_client_session_client, client_session) = within("client connects", async {
 		connect_once(client, format!("tcp://127.0.0.1:{port}/").parse().expect("parse url")).await
 	})
 	.await
@@ -389,7 +389,7 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 	// Short handover so the test observes the old session close quickly.
 	client_config.goaway.handover = Some(Duration::from_secs(2));
 	let mid_a_client = client_config.init().expect("mid-a client init");
-	let mid_a_upstream = within(
+	let (_mid_a_upstream_client, mid_a_upstream) = within(
 		"MID-A connects to TOP",
 		connect_once(
 			mid_a_client.with_subscriber(mid_a_origin.clone()),
@@ -419,7 +419,7 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 	let mut sub_client_config = moq_native::ClientConfig::default();
 	sub_client_config.tls.disable_verify = Some(true);
 	let sub_client = sub_client_config.init().expect("subscriber client init");
-	let sub_session = within(
+	let (_sub_session_client, sub_session) = within(
 		"subscriber connects to BOTTOM",
 		connect_once(
 			sub_client.with_subscriber(sub_origin.clone()),
@@ -666,12 +666,20 @@ async fn cluster_reconnects_on_empty_uri_goaway_inner() {
 	cluster_run.abort();
 }
 
-/// Dial once and hand back the session.
+/// Dial once and hand back the client with its session.
 ///
-/// These tests want a single transport, so reconnecting is off: the connection is
-/// released as soon as the session is up, and with nothing left to redial the
-/// session outlives it.
-async fn connect_once(client: moq_native::Client, url: url::Url) -> moq_native::Result<moq_net::Session> {
-	let connection = client.with_reconnect(false).connect(url).established().await?;
-	connection.session().ok_or(moq_native::Error::ConnectFailed)
+/// These tests want a single transport, so reconnecting is off and the connection
+/// is released as soon as the session is up: there is nothing left to redial, and
+/// letting it go is what keeps `drop(session)` closing the transport, since a live
+/// connection holds a session clone of its own.
+///
+/// The client comes back because it owns the transport endpoint (iroh's dies with
+/// it), and the caller has to outlive the session it just got.
+async fn connect_once(
+	client: moq_native::Client,
+	url: url::Url,
+) -> moq_native::Result<(moq_native::Client, moq_net::Session)> {
+	let connection = client.clone().with_reconnect(false).connect(url).established().await?;
+	let session = connection.session().ok_or(moq_native::Error::ConnectFailed)?;
+	Ok((client, session))
 }

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -683,3 +683,80 @@ async fn connect_once(
 	let session = connection.session().ok_or(moq_native::Error::ConnectFailed)?;
 	Ok((client, session))
 }
+
+#[test]
+fn goaway_handover_is_enforced_while_the_replacement_dial_hangs() {
+	run_cluster_test(goaway_handover_is_enforced_while_the_replacement_dial_hangs_inner());
+}
+
+/// The handover deadline has to hold across the replacement dial, not just across
+/// the sleeps around it.
+///
+/// A GOAWAY off a healthy session goes straight into the replacement dial with the
+/// old one still draining. Redirect that dial at a listener that accepts TCP and
+/// then says nothing, so the handshake hangs, and the predecessor must still be
+/// closed on schedule rather than held for as long as the dial takes.
+async fn goaway_handover_is_enforced_while_the_replacement_dial_hangs_inner() {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let upstream_origin = Origin::random().produce();
+	let (port, mut accepted, _handle) = spawn_upstream(upstream_origin);
+	wait_listening(port).await;
+
+	// Accepts the connection, then never speaks MoQ: the dial hangs in the handshake.
+	let black_hole = TcpListener::bind("127.0.0.1:0").expect("bind black hole");
+	let black_hole_port = black_hole.local_addr().expect("local addr").port();
+	let _black_hole = std::thread::spawn(move || {
+		// Hold every accepted socket open and idle for the life of the test.
+		let mut held = Vec::new();
+		while let Ok((socket, _)) = black_hole.accept() {
+			held.push(socket);
+		}
+	});
+
+	let handover = Duration::from_millis(200);
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	client_config.goaway.handover = Some(handover);
+	// The GOAWAY has to land on a *healthy* session, which is the path that goes
+	// straight into the replacement dial. Below this bar it takes the immediate
+	// redirect path instead, whose sleep polls the drain either way.
+	client_config.backoff.initial = Some(Duration::from_millis(50));
+	let client = client_config.init().expect("client init");
+
+	let connection = client.connect(format!("tcp://127.0.0.1:{port}/").parse().expect("parse url"));
+	let connection = within("client connects", connection.established())
+		.await
+		.expect("connect");
+
+	let server_session = within("upstream accepts", accepted.recv())
+		.await
+		.expect("accept channel closed");
+
+	// Clear the healthy bar, so the GOAWAY continues straight into the replacement
+	// dial rather than sleeping first.
+	tokio::time::sleep(Duration::from_millis(120)).await;
+
+	// Send the client somewhere that will never finish handshaking. No wire timeout:
+	// our own `--goaway-handover` is then the only thing bounding the old session.
+	server_session
+		.drain()
+		.send(moq_net::goaway::Goaway::redirect(format!(
+			"tcp://127.0.0.1:{black_hole_port}/"
+		)))
+		.expect("send goaway");
+
+	// The predecessor must close on its own deadline, not whenever that dial gives
+	// up. The bound is generous against a loaded runner but far below the seconds a
+	// hanging handshake takes, which is the gap being measured.
+	let sent = std::time::Instant::now();
+	let closed = tokio::time::timeout(handover * 10, server_session.closed()).await;
+	let elapsed = sent.elapsed();
+	assert!(
+		closed.is_ok() && elapsed < handover * 5,
+		"the old session outlived its {handover:?} handover by {elapsed:?}: \
+		 the replacement dial was never interrupted to enforce it"
+	);
+
+	drop(connection);
+}

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -101,11 +101,7 @@ async fn drain_session_with_zero_timeout_closes_at_once_inner() {
 	client_config.tls.disable_verify = Some(true);
 	let client = client_config.init().expect("client init");
 	let client_session = within("client connects", async {
-		client
-			.with_reconnect(false)
-			.connect(format!("tcp://127.0.0.1:{port}/").parse().expect("parse url"))
-			.established()
-			.await
+		connect_once(client, format!("tcp://127.0.0.1:{port}/").parse().expect("parse url")).await
 	})
 	.await
 	.expect("connect");
@@ -395,11 +391,10 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 	let mid_a_client = client_config.init().expect("mid-a client init");
 	let mid_a_upstream = within(
 		"MID-A connects to TOP",
-		mid_a_client
-			.with_subscriber(mid_a_origin.clone())
-			.with_reconnect(false)
-			.connect(top_url.parse().expect("parse top url"))
-			.established(),
+		connect_once(
+			mid_a_client.with_subscriber(mid_a_origin.clone()),
+			top_url.parse().expect("parse top url"),
+		),
 	)
 	.await
 	.expect("mid-a upstream connect");
@@ -426,11 +421,10 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 	let sub_client = sub_client_config.init().expect("subscriber client init");
 	let sub_session = within(
 		"subscriber connects to BOTTOM",
-		sub_client
-			.with_subscriber(sub_origin.clone())
-			.with_reconnect(false)
-			.connect(format!("tcp://127.0.0.1:{bottom_port}/").parse().expect("parse url"))
-			.established(),
+		connect_once(
+			sub_client.with_subscriber(sub_origin.clone()),
+			format!("tcp://127.0.0.1:{bottom_port}/").parse().expect("parse url"),
+		),
 	)
 	.await
 	.expect("subscriber connect");
@@ -670,4 +664,14 @@ async fn cluster_reconnects_on_empty_uri_goaway_inner() {
 	);
 
 	cluster_run.abort();
+}
+
+/// Dial once and hand back the session.
+///
+/// These tests want a single transport, so reconnecting is off: the connection is
+/// released as soon as the session is up, and with nothing left to redial the
+/// session outlives it.
+async fn connect_once(client: moq_native::Client, url: url::Url) -> moq_native::Result<moq_net::Session> {
+	let connection = client.with_reconnect(false).connect(url).established().await?;
+	connection.session().ok_or(moq_native::Error::ConnectFailed)
 }

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -158,13 +158,10 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 		.expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(
-		TIMEOUT,
-		client().with_publisher(&pub_origin).connect(url.clone()).established(),
-	)
-	.await
-	.expect("publisher connect timeout")
-	.expect("publisher connect failed");
+	let pub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_publisher(&pub_origin), url.clone()))
+		.await
+		.expect("publisher connect timeout")
+		.expect("publisher connect failed");
 	assert_eq!(
 		pub_session.version(),
 		expected_version,
@@ -175,7 +172,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
+	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -269,10 +266,7 @@ async fn relay_websocket_root_path_upgrades() {
 
 	let pub_session = tokio::time::timeout(
 		TIMEOUT,
-		client()
-			.with_publisher(pub_origin.consume())
-			.connect(url.clone())
-			.established(),
+		connect_once(client().with_publisher(pub_origin.consume()), url.clone()),
 	)
 	.await
 	.expect("publisher connect timeout")
@@ -281,7 +275,7 @@ async fn relay_websocket_root_path_upgrades() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
+	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed (root-path WS upgrade)");
@@ -349,20 +343,14 @@ async fn two_publish_only_clients_coexist() {
 
 	let sess_a = tokio::time::timeout(
 		TIMEOUT,
-		client()
-			.with_publisher(pub_a.consume())
-			.connect(url.clone())
-			.established(),
+		connect_once(client().with_publisher(pub_a.consume()), url.clone()),
 	)
 	.await
 	.expect("publisher a connect timeout")
 	.expect("publisher a connect failed");
 	let sess_b = tokio::time::timeout(
 		TIMEOUT,
-		client()
-			.with_publisher(pub_b.consume())
-			.connect(url.clone())
-			.established(),
+		connect_once(client().with_publisher(pub_b.consume()), url.clone()),
 	)
 	.await
 	.expect("publisher b connect timeout")
@@ -371,7 +359,7 @@ async fn two_publish_only_clients_coexist() {
 	// ── one subscriber should see broadcasts from both publish-only clients ──
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
+	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -500,10 +488,7 @@ async fn internal_tcp_round_trip() {
 
 	let pub_session = tokio::time::timeout(
 		TIMEOUT,
-		client()
-			.with_publisher(pub_origin.consume())
-			.connect(url.clone())
-			.established(),
+		connect_once(client().with_publisher(pub_origin.consume()), url.clone()),
 	)
 	.await
 	.expect("publisher connect timeout")
@@ -517,7 +502,7 @@ async fn internal_tcp_round_trip() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
+	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -615,10 +600,7 @@ async fn internal_unix_round_trip() {
 
 	let pub_session = tokio::time::timeout(
 		TIMEOUT,
-		client()
-			.with_publisher(pub_origin.consume())
-			.connect(url.clone())
-			.established(),
+		connect_once(client().with_publisher(pub_origin.consume()), url.clone()),
 	)
 	.await
 	.expect("publisher connect timeout")
@@ -632,7 +614,7 @@ async fn internal_unix_round_trip() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
+	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -704,7 +686,7 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 	group.finish().expect("finish group");
 
 	let pub_client = client_version(Some(version)).with_publisher(pub_origin.consume());
-	let pub_session = tokio::time::timeout(TIMEOUT, pub_client.connect(pub_url).established())
+	let pub_session = tokio::time::timeout(TIMEOUT, connect_once(pub_client, pub_url))
 		.await
 		.expect("publisher connect timeout")
 		.expect("publisher connect failed");
@@ -712,7 +694,7 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 	let sub_client = client_version(Some(version)).with_subscriber(sub_origin);
-	let sub_session = tokio::time::timeout(TIMEOUT, sub_client.connect(sub_url).established())
+	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(sub_client, sub_url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -885,7 +867,7 @@ async fn subscribe_only_public_rejects_publisher_role() {
 	// scoped subscriber, by contrast, would stay open indefinitely.
 	match tokio::time::timeout(
 		TIMEOUT,
-		client().with_publisher(pub_origin.consume()).connect(url).established(),
+		connect_once(client().with_publisher(pub_origin.consume()), url),
 	)
 	.await
 	{
@@ -910,7 +892,7 @@ async fn subscribe_only_public_accepts_subscriber_role() {
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
 	let sub_origin = Origin::random().produce();
-	let session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
+	let session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -969,7 +951,7 @@ async fn publish_only_public_rejects_subscriber_role() {
 
 	// Like the publisher case, `connect()` may resolve optimistically; either it fails
 	// outright, or the session the relay hands back closes shortly after.
-	match tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established()).await {
+	match tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url)).await {
 		Ok(Ok(session)) => {
 			tokio::time::timeout(TIMEOUT, session.closed())
 				.await
@@ -980,4 +962,14 @@ async fn publish_only_public_rejects_subscriber_role() {
 	}
 
 	handle.abort();
+}
+
+/// Dial once and hand back the session.
+///
+/// These tests want a single transport, so reconnecting is off: the connection is
+/// released as soon as the session is up, and with nothing left to redial the
+/// session outlives it.
+async fn connect_once(client: moq_native::Client, url: url::Url) -> moq_native::Result<moq_net::Session> {
+	let connection = client.with_reconnect(false).connect(url).established().await?;
+	connection.session().ok_or(moq_native::Error::ConnectFailed)
 }

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -158,10 +158,11 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 		.expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_publisher(&pub_origin), url.clone()))
-		.await
-		.expect("publisher connect timeout")
-		.expect("publisher connect failed");
+	let (_client, pub_session) =
+		tokio::time::timeout(TIMEOUT, connect_once(client().with_publisher(&pub_origin), url.clone()))
+			.await
+			.expect("publisher connect timeout")
+			.expect("publisher connect failed");
 	assert_eq!(
 		pub_session.version(),
 		expected_version,
@@ -172,7 +173,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 
-	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
+	let (_client, sub_session) = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -264,7 +265,7 @@ async fn relay_websocket_root_path_upgrades() {
 		.expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(
+	let (_client, pub_session) = tokio::time::timeout(
 		TIMEOUT,
 		connect_once(client().with_publisher(pub_origin.consume()), url.clone()),
 	)
@@ -275,7 +276,7 @@ async fn relay_websocket_root_path_upgrades() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
+	let (_client, sub_session) = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed (root-path WS upgrade)");
@@ -341,14 +342,14 @@ async fn two_publish_only_clients_coexist() {
 		.write_frame(moq_net::Timestamp::ZERO, b"b".as_ref())
 		.expect("write frame b");
 
-	let sess_a = tokio::time::timeout(
+	let (_client, sess_a) = tokio::time::timeout(
 		TIMEOUT,
 		connect_once(client().with_publisher(pub_a.consume()), url.clone()),
 	)
 	.await
 	.expect("publisher a connect timeout")
 	.expect("publisher a connect failed");
-	let sess_b = tokio::time::timeout(
+	let (_client, sess_b) = tokio::time::timeout(
 		TIMEOUT,
 		connect_once(client().with_publisher(pub_b.consume()), url.clone()),
 	)
@@ -359,7 +360,7 @@ async fn two_publish_only_clients_coexist() {
 	// ── one subscriber should see broadcasts from both publish-only clients ──
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
+	let (_client, sub_session) = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -486,7 +487,7 @@ async fn internal_tcp_round_trip() {
 		.expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(
+	let (_client, pub_session) = tokio::time::timeout(
 		TIMEOUT,
 		connect_once(client().with_publisher(pub_origin.consume()), url.clone()),
 	)
@@ -502,7 +503,7 @@ async fn internal_tcp_round_trip() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
+	let (_client, sub_session) = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -598,7 +599,7 @@ async fn internal_unix_round_trip() {
 		.expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(
+	let (_client, pub_session) = tokio::time::timeout(
 		TIMEOUT,
 		connect_once(client().with_publisher(pub_origin.consume()), url.clone()),
 	)
@@ -614,7 +615,7 @@ async fn internal_unix_round_trip() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
+	let (_client, sub_session) = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -686,7 +687,7 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 	group.finish().expect("finish group");
 
 	let pub_client = client_version(Some(version)).with_publisher(pub_origin.consume());
-	let pub_session = tokio::time::timeout(TIMEOUT, connect_once(pub_client, pub_url))
+	let (_client, pub_session) = tokio::time::timeout(TIMEOUT, connect_once(pub_client, pub_url))
 		.await
 		.expect("publisher connect timeout")
 		.expect("publisher connect failed");
@@ -694,7 +695,7 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 	let sub_client = client_version(Some(version)).with_subscriber(sub_origin);
-	let sub_session = tokio::time::timeout(TIMEOUT, connect_once(sub_client, sub_url))
+	let (_client, sub_session) = tokio::time::timeout(TIMEOUT, connect_once(sub_client, sub_url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -871,7 +872,7 @@ async fn subscribe_only_public_rejects_publisher_role() {
 	)
 	.await
 	{
-		Ok(Ok(session)) => {
+		Ok(Ok((_client, session))) => {
 			tokio::time::timeout(TIMEOUT, session.closed())
 				.await
 				.expect("relay should close a publisher whose token lacks publish scope, not leave it open");
@@ -892,7 +893,7 @@ async fn subscribe_only_public_accepts_subscriber_role() {
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
 	let sub_origin = Origin::random().produce();
-	let session = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
+	let (_client, session) = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -952,7 +953,7 @@ async fn publish_only_public_rejects_subscriber_role() {
 	// Like the publisher case, `connect()` may resolve optimistically; either it fails
 	// outright, or the session the relay hands back closes shortly after.
 	match tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url)).await {
-		Ok(Ok(session)) => {
+		Ok(Ok((_client, session))) => {
 			tokio::time::timeout(TIMEOUT, session.closed())
 				.await
 				.expect("relay should close a subscriber whose token lacks subscribe scope, not leave it open");
@@ -964,12 +965,20 @@ async fn publish_only_public_rejects_subscriber_role() {
 	handle.abort();
 }
 
-/// Dial once and hand back the session.
+/// Dial once and hand back the client with its session.
 ///
-/// These tests want a single transport, so reconnecting is off: the connection is
-/// released as soon as the session is up, and with nothing left to redial the
-/// session outlives it.
-async fn connect_once(client: moq_native::Client, url: url::Url) -> moq_native::Result<moq_net::Session> {
-	let connection = client.with_reconnect(false).connect(url).established().await?;
-	connection.session().ok_or(moq_native::Error::ConnectFailed)
+/// These tests want a single transport, so reconnecting is off and the connection
+/// is released as soon as the session is up: there is nothing left to redial, and
+/// letting it go is what keeps `drop(session)` closing the transport, since a live
+/// connection holds a session clone of its own.
+///
+/// The client comes back because it owns the transport endpoint (iroh's dies with
+/// it), and the caller has to outlive the session it just got.
+async fn connect_once(
+	client: moq_native::Client,
+	url: url::Url,
+) -> moq_native::Result<(moq_native::Client, moq_net::Session)> {
+	let connection = client.clone().with_reconnect(false).connect(url).established().await?;
+	let session = connection.session().ok_or(moq_native::Error::ConnectFailed)?;
+	Ok((client, session))
 }

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -123,6 +123,9 @@ fn client() -> moq_native::Client {
 fn client_version(version: Option<moq_net::Version>) -> moq_native::Client {
 	let mut config = moq_native::ClientConfig::default();
 	config.tls.disable_verify = Some(true);
+	// One-shot: these tests were written against a single dial, and a background
+	// redial would re-register with the relay behind the assertions' back.
+	config.reconnect = Some(false);
 	// Zero head start so the WebSocket path runs immediately.
 	config.websocket.delay = None;
 	// Every relay in this file listens on IPv4 loopback, so bind the same family
@@ -155,10 +158,13 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 		.expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(TIMEOUT, client().with_publisher(&pub_origin).connect(url.clone()))
-		.await
-		.expect("publisher connect timeout")
-		.expect("publisher connect failed");
+	let pub_session = tokio::time::timeout(
+		TIMEOUT,
+		client().with_publisher(&pub_origin).connect(url.clone()).established(),
+	)
+	.await
+	.expect("publisher connect timeout")
+	.expect("publisher connect failed");
 	assert_eq!(
 		pub_session.version(),
 		expected_version,
@@ -169,7 +175,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url))
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -263,7 +269,10 @@ async fn relay_websocket_root_path_upgrades() {
 
 	let pub_session = tokio::time::timeout(
 		TIMEOUT,
-		client().with_publisher(pub_origin.consume()).connect(url.clone()),
+		client()
+			.with_publisher(pub_origin.consume())
+			.connect(url.clone())
+			.established(),
 	)
 	.await
 	.expect("publisher connect timeout")
@@ -272,7 +281,7 @@ async fn relay_websocket_root_path_upgrades() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url))
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed (root-path WS upgrade)");
@@ -338,19 +347,31 @@ async fn two_publish_only_clients_coexist() {
 		.write_frame(moq_net::Timestamp::ZERO, b"b".as_ref())
 		.expect("write frame b");
 
-	let sess_a = tokio::time::timeout(TIMEOUT, client().with_publisher(pub_a.consume()).connect(url.clone()))
-		.await
-		.expect("publisher a connect timeout")
-		.expect("publisher a connect failed");
-	let sess_b = tokio::time::timeout(TIMEOUT, client().with_publisher(pub_b.consume()).connect(url.clone()))
-		.await
-		.expect("publisher b connect timeout")
-		.expect("publisher b connect failed");
+	let sess_a = tokio::time::timeout(
+		TIMEOUT,
+		client()
+			.with_publisher(pub_a.consume())
+			.connect(url.clone())
+			.established(),
+	)
+	.await
+	.expect("publisher a connect timeout")
+	.expect("publisher a connect failed");
+	let sess_b = tokio::time::timeout(
+		TIMEOUT,
+		client()
+			.with_publisher(pub_b.consume())
+			.connect(url.clone())
+			.established(),
+	)
+	.await
+	.expect("publisher b connect timeout")
+	.expect("publisher b connect failed");
 
 	// ── one subscriber should see broadcasts from both publish-only clients ──
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url))
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -479,7 +500,10 @@ async fn internal_tcp_round_trip() {
 
 	let pub_session = tokio::time::timeout(
 		TIMEOUT,
-		client().with_publisher(pub_origin.consume()).connect(url.clone()),
+		client()
+			.with_publisher(pub_origin.consume())
+			.connect(url.clone())
+			.established(),
 	)
 	.await
 	.expect("publisher connect timeout")
@@ -493,7 +517,7 @@ async fn internal_tcp_round_trip() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url))
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -591,7 +615,10 @@ async fn internal_unix_round_trip() {
 
 	let pub_session = tokio::time::timeout(
 		TIMEOUT,
-		client().with_publisher(pub_origin.consume()).connect(url.clone()),
+		client()
+			.with_publisher(pub_origin.consume())
+			.connect(url.clone())
+			.established(),
 	)
 	.await
 	.expect("publisher connect timeout")
@@ -605,7 +632,7 @@ async fn internal_unix_round_trip() {
 	// ── subscriber ──────────────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url))
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -677,7 +704,7 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 	group.finish().expect("finish group");
 
 	let pub_client = client_version(Some(version)).with_publisher(pub_origin.consume());
-	let pub_session = tokio::time::timeout(TIMEOUT, pub_client.connect(pub_url))
+	let pub_session = tokio::time::timeout(TIMEOUT, pub_client.connect(pub_url).established())
 		.await
 		.expect("publisher connect timeout")
 		.expect("publisher connect failed");
@@ -685,7 +712,7 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 	let sub_client = client_version(Some(version)).with_subscriber(sub_origin);
-	let sub_session = tokio::time::timeout(TIMEOUT, sub_client.connect(sub_url))
+	let sub_session = tokio::time::timeout(TIMEOUT, sub_client.connect(sub_url).established())
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -856,7 +883,12 @@ async fn subscribe_only_public_rejects_publisher_role() {
 	// before the relay's verdict lands. Either the connect fails outright, or the
 	// session it returns closes shortly after with the relay's rejection. A correctly
 	// scoped subscriber, by contrast, would stay open indefinitely.
-	match tokio::time::timeout(TIMEOUT, client().with_publisher(pub_origin.consume()).connect(url)).await {
+	match tokio::time::timeout(
+		TIMEOUT,
+		client().with_publisher(pub_origin.consume()).connect(url).established(),
+	)
+	.await
+	{
 		Ok(Ok(session)) => {
 			tokio::time::timeout(TIMEOUT, session.closed())
 				.await
@@ -878,7 +910,7 @@ async fn subscribe_only_public_accepts_subscriber_role() {
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
 	let sub_origin = Origin::random().produce();
-	let session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established())
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -937,7 +969,7 @@ async fn publish_only_public_rejects_subscriber_role() {
 
 	// Like the publisher case, `connect()` may resolve optimistically; either it fails
 	// outright, or the session the relay hands back closes shortly after.
-	match tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url)).await {
+	match tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url).established()).await {
 		Ok(Ok(session)) => {
 			tokio::time::timeout(TIMEOUT, session.closed())
 				.await

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
 	let mut session = client
 		.with_publisher(&publish)
 		.with_subscriber(remote.clone())
-		.reconnect(args.url.clone());
+		.connect(args.url.clone());
 
 	// Wait for the first session: the origin can't route a broadcast request
 	// until a connected session registers its handler.

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -170,7 +170,7 @@ pub struct Options {
 	pub kind: encoder::Kind,
 	/// The connection's send-bandwidth estimate, from
 	/// [`Session::send_bandwidth`](moq_net::Session::send_bandwidth) (or
-	/// `moq_native::Reconnect::send_bandwidth`, which survives reconnects).
+	/// `moq_native::Connection::send_bandwidth`, which survives reconnects).
 	///
 	/// Set it and the encoder tracks the estimate per the default
 	/// [`rate::Policy`](super::rate::Policy), so a closing uplink gets a softer


### PR DESCRIPTION
## What

`Client::reconnect(url)` is now `Client::connect(url)`, returning a `Connection` (renamed from `Reconnect`). The background reconnect loop is the primary way to open a session; the old one-shot `pub async fn connect` is demoted to a private `dial` driven by the loop.

- **Reconnecting is the default.** `ClientConfig.reconnect: Option<bool>` (`--client-reconnect`, `MOQ_CLIENT_RECONNECT`) and `Client::with_reconnect(bool)` turn it off. In one-shot mode a dial error is terminal, the session's close reason surfaces through `Connection::closed()`, the GOAWAY arm is not polled (a one-shot client can't dial the replacement; the peer force-closes at its own deadline anyway), and `consume()` skips the broadcast linger (there is no gap to splice).
- **`Connection::established()`** waits for the first (or current) session and returns it, so callers that want dial errors up front keep the old connect-then-await shape. **`Connection::session()`** exposes the live session as an escape hatch.
- A one-shot session ending logs at info; only a reconnect-loop give-up logs at error.

This is step 1 for #2609: with the reconnect loop as the front door, the follow-up PR exposes it through `moq-ffi` (backoff config, connect/disconnect status, linger) so Python/Swift/Kotlin/Go stop hand-rolling retry loops that structurally can't detect a silent stall. `moq-ffi` in this PR is a behavior-preserving shim (`with_reconnect(false)` + `established()`).

## Breaking changes (hence `dev`)

`moq-native` only: `Reconnect` -> `Connection`, `Client::reconnect` removed (renamed to `connect`), `Client::connect` changed from `async fn -> Result<Session>` to `fn -> Connection`. `Client::publish` / `Client::consume` now return `Option<Connection>`.

## Callers migrated

- `moq-relay` cluster, `moq-gst` sink, `moq-boy`, `moq-cli transcode`, `libmoq`, `moq-bench`, examples: mechanical rename (they were already on the loop API).
- `moq-gst` source and `moq-ffi`: `with_reconnect(false)` + `established()`, preserving their one-shot semantics (their catalog/session wrappers can't survive a session swap yet).
- Tests (`moq-native`, `moq-relay` smoke/goaway_cluster): `connect(url).established()`; the smoke/goaway helpers pin `reconnect = false` since those assertions were written against a single dial and a background redial would re-register with the relay behind their back. `alpn.rs` pins it so a non-auth dial failure surfaces instead of retrying into the timeout.

## Review follow-up

`established()` originally handed back a bare `Session`, so the natural chain `client.connect(url).established().await?` dropped the temporary `Connection` at the end of the statement and aborted the reconnect loop — leaving a live transport that silently never redialed, which is the whole feature. The guide snippets demonstrated exactly that. It now consumes and returns the connection, so whatever the chain binds is what keeps reconnecting, and `poll_established` reports readiness only (`session()` reaches the transport).

Tests that want a single transport now say so through a `connect_once` helper with reconnecting off, instead of depending on a temporary drop to stop the loop. The publishing and subscribing guides move to the origin-based flow, which is what actually survives a reconnect.

## Tests

- `one_shot_connect_surfaces_the_session_close` (broadcast.rs): server aborts the session; asserts the close surfaces as the terminal error and the loop dials exactly once (accept counter + tiny backoff).
- `test_toml_reconnect_survives_update_from` / `test_cli_reconnect_flag`: the `Option<bool>` TOML/CLI merge guard for the new flag.
- Existing reconnect coverage (`reconnect_stops_on_websocket_unauthorized`, goaway_cluster migration tests) now runs through the renamed surface.

`just check` green (504 tests across moq-native/relay/ffi/libmoq/gst pass), `RUSTDOCFLAGS="-D warnings" cargo doc` clean.

## Cross-package sync

- `doc/lib/rs` (index + native guide) and `doc/concept/layer/moq-lite.md` updated to the new API.
- No wire change, so no `drafts/` update.
- `moq-ffi`'s exported surface is unchanged (internal shim only), so language wrappers and `doc/lib/{py,swift,kt,go,c}` are untouched; they change in the #2609 follow-up.

(written by Fable 5)
