### PR TITLE
feat(hang): declare a configurable 30s retention on media tracks, and fix relayed cache misses

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -362,6 +362,16 @@ Import formats:
 - `flv` - FLV / RTMP (H.264 video, AAC audio)
 - `capture` - capture local devices directly (camera H.264 + microphone Opus; requires the `capture` build feature; does not read stdin)
 
+`import --latency-max <duration>` (default `30s`) declares how long relays keep a
+non-latest group of the published media tracks fetchable. It is a retention
+budget, so raising it never makes a subscriber play further behind live: it caps
+how far back a fetch can still reach. The default is sized for a segmented
+egress (HLS/DASH), which may only advertise segments that are still fetchable;
+lower it when nothing reads history and the memory matters. It applies to the
+media tracks only, and to the sources whose catalog this binary builds (the
+stdin containers, `hls`, and `capture`) - the other gateways reject the flag
+rather than accepting it and publishing at the default.
+
 Export formats:
 
 - `fmp4` - fragmented MP4 / CMAF
@@ -403,7 +413,10 @@ stdout containers and `rtmp` take `--latency-max` (default `500ms`), and `srt`
 reuses its `--latency` (the receive buffer doubles as the skip threshold).
 WebRTC (`rtc`) is real-time and doesn't buffer, so it has no such knob. HLS
 export doesn't subscribe to media at all (segments are fetched on demand), so
-it has no latency knob either.
+it has no latency knob either. This is the subscriber half of the pair the
+protocol names: the export knob is how long *this* consumer waits, while
+[`import --latency-max`](#container-formats) is how long the publisher keeps a
+group around for anyone to fetch.
 
 ### MPEG-TS
 

--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -115,6 +115,10 @@ Each Subscription consists of a few properties:
 The publisher also keeps old groups around for a best-effort **Publisher Max Latency** cache window so relays and late subscribers can still fetch them. This defaults to 5 seconds.
 The subscriber's maximum latency is bounded by this window: a group can't be waited for longer than it's actually kept around.
 
+It is declared per track, so a publisher raises it on the tracks that are read as history rather than followed at the live edge.
+hang media tracks ask for 30 seconds on that basis: a segmented egress (HLS/DASH) may only advertise segments a fetch can still reach, and a standard player starts several segments behind the live edge.
+This is a retention budget rather than a delivery one, so a longer window never makes a subscriber play further behind live.
+
 By utilizing these properties, you can choose how your application behaves during congestion.
 For example, consider a conference room with Alice and Bob:
 

--- a/js/hang/src/container/index.ts
+++ b/js/hang/src/container/index.ts
@@ -11,4 +11,5 @@ export { Consumer, type ConsumerProps } from "./consumer";
 export type { Format } from "./format";
 export * as Legacy from "./legacy";
 export * as Timeline from "./timeline";
+export { LATENCY_MAX_MS, trackInfo } from "./track";
 export * from "./types";

--- a/js/hang/src/container/index.ts
+++ b/js/hang/src/container/index.ts
@@ -11,5 +11,5 @@ export { Consumer, type ConsumerProps } from "./consumer";
 export type { Format } from "./format";
 export * as Legacy from "./legacy";
 export * as Timeline from "./timeline";
-export { trackInfo } from "./track";
+export { type TrackInfoOptions, trackInfo } from "./track";
 export * from "./types";

--- a/js/hang/src/container/index.ts
+++ b/js/hang/src/container/index.ts
@@ -11,5 +11,5 @@ export { Consumer, type ConsumerProps } from "./consumer";
 export type { Format } from "./format";
 export * as Legacy from "./legacy";
 export * as Timeline from "./timeline";
-export { LATENCY_MAX_MS, trackInfo } from "./track";
+export { trackInfo } from "./track";
 export * from "./types";

--- a/js/hang/src/container/track.ts
+++ b/js/hang/src/container/track.ts
@@ -1,38 +1,32 @@
 /**
  * Track properties for the media tracks a hang broadcast publishes.
  *
- * The TypeScript twin of `hang::container::{LATENCY_MAX, track_info}`; keep the two in step,
- * since a browser publisher and a Rust one feed the same relays and the same segmented egress.
+ * The TypeScript twin of `hang::container::track_info`; keep the two in step, since a browser
+ * publisher and a Rust one feed the same relays and the same segmented egress.
  *
  * @module
  */
 import { Time, type Track } from "@moq/net";
 
-/**
- * How long a media track asks its publisher (and, through TRACK_INFO, every relay) to keep a
- * non-latest group fetchable, in milliseconds.
- *
- * Media is the one thing on a broadcast read as HISTORY rather than followed at the live edge: a
- * segmented egress (HLS/DASH) may only advertise segments a FETCH can still reach, and a standard
- * player starts several target durations behind live. moq-net's default is sized for a live-edge
- * follower, and leaves such a player addressing groups that are already gone.
- *
- * This is a RETENTION budget, not a delivery one, so it does not make anyone play further behind
- * live: it caps what a subscriber may ask to wait for, and a subscriber's own budget still defaults
- * to zero (skip the moment a newer group arrives).
- *
- * Must match `hang::container::LATENCY_MAX` in rs/hang/src/container/frame.rs.
- */
-export const LATENCY_MAX_MS = 30_000;
+// How long a media track asks its publisher (and, through TRACK_INFO, every relay) to keep a
+// non-latest group fetchable. Must match `hang::container::LATENCY_MAX` in
+// rs/hang/src/container/frame.rs.
+const LATENCY_MAX_MS = 30_000;
 
 /**
  * Track properties for a track carrying media frames, for `Request.accept`.
  *
- * Pins the timescale to microseconds (the timestamps hang's containers stamp) and declares
- * {@link LATENCY_MAX_MS} so a FETCH-based consumer can reach back over a full playlist window.
- * Every media track a publisher accepts should use this rather than the bare defaults, which are
- * sized for the catalog and timeline: both are read at the live edge, which is retained
- * unconditionally, so neither pays for history it never serves.
+ * Pins the timescale to microseconds (the timestamps hang's containers stamp), and declares a
+ * retention long enough for a FETCH-based consumer to reach back over a full playlist window: a
+ * segmented egress (HLS/DASH) may only advertise segments a fetch can still reach, and a standard
+ * player starts several target durations behind live. Every media track a publisher accepts should
+ * use this rather than the bare defaults, which are sized for the catalog and timeline: both are
+ * read at the live edge, which is retained unconditionally, so neither pays for history it never
+ * serves.
+ *
+ * `latencyMax` (milliseconds) overrides that retention. It is a RETENTION budget, not a delivery
+ * one, so it never makes anyone play further behind live and lowering it does not reduce latency:
+ * it only shortens how far back a fetch can reach.
  */
 export function trackInfo(latencyMax: number = LATENCY_MAX_MS): Partial<Track.Info> {
 	return { timescale: Time.Timescale.MICRO, latencyMax };

--- a/js/hang/src/container/track.ts
+++ b/js/hang/src/container/track.ts
@@ -24,10 +24,20 @@ const LATENCY_MAX_MS = 30_000;
  * read at the live edge, which is retained unconditionally, so neither pays for history it never
  * serves.
  *
- * `latencyMax` (milliseconds) overrides that retention. It is a RETENTION budget, not a delivery
- * one, so it never makes anyone play further behind live and lowering it does not reduce latency:
- * it only shortens how far back a fetch can reach.
+ * Options override that retention; see {@link TrackInfoOptions.latencyMax}.
  */
-export function trackInfo(latencyMax: number = LATENCY_MAX_MS): Partial<Track.Info> {
-	return { timescale: Time.Timescale.MICRO, latencyMax };
+export function trackInfo(options?: TrackInfoOptions): Partial<Track.Info> {
+	return { timescale: Time.Timescale.MICRO, latencyMax: options?.latencyMax ?? LATENCY_MAX_MS };
 }
+
+/** Overrides for {@link trackInfo}. */
+export type TrackInfoOptions = {
+	/**
+	 * How long a relay keeps a non-latest group fetchable, in milliseconds, replacing the
+	 * retention {@link trackInfo} declares by default.
+	 *
+	 * A RETENTION budget, not a delivery one, so it never makes anyone play further behind live
+	 * and lowering it does not reduce latency: it only shortens how far back a fetch can reach.
+	 */
+	latencyMax?: number;
+};

--- a/js/hang/src/container/track.ts
+++ b/js/hang/src/container/track.ts
@@ -1,0 +1,39 @@
+/**
+ * Track properties for the media tracks a hang broadcast publishes.
+ *
+ * The TypeScript twin of `hang::container::{LATENCY_MAX, track_info}`; keep the two in step,
+ * since a browser publisher and a Rust one feed the same relays and the same segmented egress.
+ *
+ * @module
+ */
+import { Time, type Track } from "@moq/net";
+
+/**
+ * How long a media track asks its publisher (and, through TRACK_INFO, every relay) to keep a
+ * non-latest group fetchable, in milliseconds.
+ *
+ * Media is the one thing on a broadcast read as HISTORY rather than followed at the live edge: a
+ * segmented egress (HLS/DASH) may only advertise segments a FETCH can still reach, and a standard
+ * player starts several target durations behind live. moq-net's default is sized for a live-edge
+ * follower, and leaves such a player addressing groups that are already gone.
+ *
+ * This is a RETENTION budget, not a delivery one, so it does not make anyone play further behind
+ * live: it caps what a subscriber may ask to wait for, and a subscriber's own budget still defaults
+ * to zero (skip the moment a newer group arrives).
+ *
+ * Must match `hang::container::LATENCY_MAX` in rs/hang/src/container/frame.rs.
+ */
+export const LATENCY_MAX_MS = 30_000;
+
+/**
+ * Track properties for a track carrying media frames, for `Request.accept`.
+ *
+ * Pins the timescale to microseconds (the timestamps hang's containers stamp) and declares
+ * {@link LATENCY_MAX_MS} so a FETCH-based consumer can reach back over a full playlist window.
+ * Every media track a publisher accepts should use this rather than the bare defaults, which are
+ * sized for the catalog and timeline: both are read at the live edge, which is retained
+ * unconditionally, so neither pays for history it never serves.
+ */
+export function trackInfo(latencyMax: number = LATENCY_MAX_MS): Partial<Track.Info> {
+	return { timescale: Time.Timescale.MICRO, latencyMax };
+}

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -231,7 +231,7 @@ export class Broadcast {
 			// Media, so declare the retention a FETCH-based consumer needs (the catalog above
 			// keeps the bare defaults: it is read at the live edge, which is always retained).
 			// Matches what a Rust publisher declares via `hang::container::track_info`.
-			const track = request.accept(Container.trackInfo(this.in.latencyMax.peek()));
+			const track = request.accept(Container.trackInfo({ latencyMax: this.in.latencyMax.peek() }));
 
 			// A second subscription for the same name supersedes the first: close the old producer.
 			signal.peek()?.close();

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -1,4 +1,5 @@
 import * as Catalog from "@moq/hang/catalog";
+import * as Container from "@moq/hang/container";
 import * as Moq from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, Signal } from "@moq/signals";
 import { CatalogProducer } from "./catalog";
@@ -219,7 +220,10 @@ export class Broadcast {
 				continue;
 			}
 
-			const track = request.accept();
+			// Media, so declare the retention a FETCH-based consumer needs (the catalog above
+			// keeps the bare defaults: it is read at the live edge, which is always retained).
+			// Matches what a Rust publisher declares via `hang::container::track_info`.
+			const track = request.accept(Container.trackInfo());
 
 			// A second subscription for the same name supersedes the first: close the old producer.
 			signal.peek()?.close();

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -22,6 +22,13 @@ export type BroadcastInput = {
 
 	// Whether the video should be flipped horizontally on playback. Catalog video-section metadata.
 	flip: Getter<boolean>;
+
+	// How long relays keep a non-latest group of this broadcast's media tracks fetchable, in
+	// milliseconds. Declared on every media track we accept; see {@link Container.trackInfo}.
+	// Defaults to {@link Container.LATENCY_MAX_MS}, sized so a segmented egress (HLS/DASH) can
+	// serve a full playlist window. A retention budget, not a delivery one, so lowering it does
+	// not reduce latency -- it only shortens how far back a fetch can reach.
+	latencyMax: Getter<number>;
 };
 
 /**
@@ -69,6 +76,7 @@ export class Broadcast {
 			name: getter(props?.name ?? Moq.Path.empty()),
 			display: getter(props?.display),
 			flip: getter(props?.flip ?? false),
+			latencyMax: getter(props?.latencyMax ?? Container.LATENCY_MAX_MS),
 		};
 
 		this.#signals.run(this.#runCatalog.bind(this));
@@ -223,7 +231,7 @@ export class Broadcast {
 			// Media, so declare the retention a FETCH-based consumer needs (the catalog above
 			// keeps the bare defaults: it is read at the live edge, which is always retained).
 			// Matches what a Rust publisher declares via `hang::container::track_info`.
-			const track = request.accept(Container.trackInfo());
+			const track = request.accept(Container.trackInfo(this.in.latencyMax.peek()));
 
 			// A second subscription for the same name supersedes the first: close the old producer.
 			signal.peek()?.close();

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -23,11 +23,15 @@ export type BroadcastInput = {
 	// Whether the video should be flipped horizontally on playback. Catalog video-section metadata.
 	flip: Getter<boolean>;
 
-	// How long relays keep a non-latest group of this broadcast's media tracks fetchable, in
-	// milliseconds. Declared on every media track we accept; see {@link Container.trackInfo},
-	// whose default is sized so a segmented egress (HLS/DASH) can serve a full playlist window.
-	// A retention budget, not a delivery one, so lowering it does not reduce latency -- it only
-	// shortens how far back a fetch can reach.
+	/**
+	 * How long relays keep a non-latest group of this broadcast's media tracks fetchable, in
+	 * milliseconds. Declared on every media track we accept; see {@link Container.trackInfo},
+	 * whose default (`undefined` here) is sized so a segmented egress (HLS/DASH) can serve a
+	 * full playlist window.
+	 *
+	 * A retention budget, not a delivery one, so lowering it does not reduce latency: it only
+	 * shortens how far back a fetch can reach.
+	 */
 	latencyMax: Getter<number | undefined>;
 };
 

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -24,11 +24,11 @@ export type BroadcastInput = {
 	flip: Getter<boolean>;
 
 	// How long relays keep a non-latest group of this broadcast's media tracks fetchable, in
-	// milliseconds. Declared on every media track we accept; see {@link Container.trackInfo}.
-	// Defaults to {@link Container.LATENCY_MAX_MS}, sized so a segmented egress (HLS/DASH) can
-	// serve a full playlist window. A retention budget, not a delivery one, so lowering it does
-	// not reduce latency -- it only shortens how far back a fetch can reach.
-	latencyMax: Getter<number>;
+	// milliseconds. Declared on every media track we accept; see {@link Container.trackInfo},
+	// whose default is sized so a segmented egress (HLS/DASH) can serve a full playlist window.
+	// A retention budget, not a delivery one, so lowering it does not reduce latency -- it only
+	// shortens how far back a fetch can reach.
+	latencyMax: Getter<number | undefined>;
 };
 
 /**
@@ -76,7 +76,7 @@ export class Broadcast {
 			name: getter(props?.name ?? Moq.Path.empty()),
 			display: getter(props?.display),
 			flip: getter(props?.flip ?? false),
-			latencyMax: getter(props?.latencyMax ?? Container.LATENCY_MAX_MS),
+			latencyMax: getter(props?.latencyMax),
 		};
 
 		this.#signals.run(this.#runCatalog.bind(this));

--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -12,6 +12,25 @@ pub use moq_net::{Timescale, Timestamp};
 /// so encoders normalize to this scale and decoders attach it.
 pub const TIMESCALE: Timescale = Timescale::MICRO;
 
+/// How long a media track asks its publisher (and, through TRACK_INFO, every relay) to keep a
+/// non-latest group fetchable.
+///
+/// Media is the one thing on a broadcast that is read as HISTORY rather than followed at the live
+/// edge: a segmented egress (HLS/DASH) may only advertise segments a FETCH can still reach, and a
+/// standard player starts several target durations behind live. `moq_net`'s conservative default
+/// is sized for a live-edge follower and leaves such a player addressing groups that are already
+/// gone.
+///
+/// Declared per track rather than by raising that default, so the tracks that do NOT index history
+/// keep the cheap default: the catalog is snapshot mode and the timeline is a single never-rolled
+/// group, and in both the useful value is the live edge, which is retained unconditionally.
+///
+/// Raising this does not make anyone play further behind live. It is a retention budget and a
+/// CEILING on what a subscriber may ask to wait for; a subscriber's own
+/// [`Subscription::latency_max`](moq_net::track::Subscription::latency_max) defaults to zero (skip
+/// the moment a newer group arrives) and should be set from that consumer's real latency target.
+pub const LATENCY_MAX: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Track properties for creating a track that carries [`Frame`]s, via
 /// [`create_track`](moq_net::broadcast::Producer::create_track) or
 /// [`accept`](moq_net::track::Request::accept).
@@ -21,7 +40,20 @@ pub const TIMESCALE: Timescale = Timescale::MICRO;
 /// moq-lite-05 and later delta-encode on the wire, even though the container prefix
 /// stays at microseconds.
 pub fn track_info() -> moq_net::track::Info {
-	moq_net::track::Info::default().with_timescale(TIMESCALE)
+	track_info_at(TIMESCALE)
+}
+
+/// [`track_info`] at an explicit timescale, for a container that carries the source's own
+/// (CMAF and Matroska both do) rather than normalizing to [`TIMESCALE`].
+///
+/// Every media track should be created through one of these two rather than
+/// `moq_net::track::Info::default()`, so [`LATENCY_MAX`] is declared in one place instead of at
+/// each call site -- a track that silently keeps the default is one a segmented egress cannot
+/// serve a full playlist window from.
+pub fn track_info_at(timescale: Timescale) -> moq_net::track::Info {
+	moq_net::track::Info::default()
+		.with_timescale(timescale)
+		.with_latency_max(LATENCY_MAX)
 }
 
 /// A media frame with a timestamp and codec-specific payload.
@@ -144,5 +176,29 @@ mod test {
 	#[test]
 	fn track_info_uses_container_timescale() {
 		assert_eq!(track_info().timescale, TIMESCALE);
+	}
+
+	#[test]
+	fn media_tracks_declare_their_retention() {
+		// A media track is read as history (a segmented egress FETCHes segments a playlist
+		// advertised), so it declares a retention rather than inheriting the live-edge default.
+		// Both constructors must carry it: `track_info_at` exists for the containers that keep
+		// the source's timescale, and it is exactly those that would otherwise fall back to
+		// `Info::default()` and quietly lose the retention.
+		assert_eq!(track_info().latency_max, LATENCY_MAX);
+		assert_eq!(track_info_at(Timescale::MILLI).latency_max, LATENCY_MAX);
+		assert_eq!(track_info_at(Timescale::MILLI).timescale, Timescale::MILLI);
+		assert!(LATENCY_MAX > moq_net::track::DEFAULT_LATENCY_MAX);
+	}
+
+	#[test]
+	fn non_media_tracks_keep_the_default_retention() {
+		// The catalog is snapshot mode and the timeline is a single never-rolled group: in both
+		// the useful value is the live edge, which is retained unconditionally, so neither pays
+		// for history it never serves.
+		assert_eq!(
+			crate::Catalog::default_track_info().latency_max,
+			moq_net::track::DEFAULT_LATENCY_MAX
+		);
 	}
 }

--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -24,35 +24,27 @@ pub const TIMESCALE: Timescale = Timescale::MICRO;
 /// Declared per track rather than by raising that default, so the tracks that do NOT index history
 /// keep the cheap default: the catalog is snapshot mode and the timeline is a single never-rolled
 /// group, and in both the useful value is the live edge, which is retained unconditionally.
-///
-/// Raising this does not make anyone play further behind live. It is a retention budget and a
-/// CEILING on what a subscriber may ask to wait for; a subscriber's own
-/// [`Subscription::latency_max`](moq_net::track::Subscription::latency_max) defaults to zero (skip
-/// the moment a newer group arrives) and should be set from that consumer's real latency target.
-pub const LATENCY_MAX: std::time::Duration = std::time::Duration::from_secs(30);
+const LATENCY_MAX: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Track properties for creating a track that carries [`Frame`]s, via
 /// [`create_track`](moq_net::broadcast::Producer::create_track) or
 /// [`accept`](moq_net::track::Request::accept).
 ///
-/// This pins the track's timescale to [`TIMESCALE`]. `moq_net::track::Info::default()`
-/// is milliseconds, which would quantize the net-level frame timestamps that
-/// moq-lite-05 and later delta-encode on the wire, even though the container prefix
-/// stays at microseconds.
-pub fn track_info() -> moq_net::track::Info {
-	track_info_at(TIMESCALE)
-}
-
-/// [`track_info`] at an explicit timescale, for a container that carries the source's own
-/// (CMAF and Matroska both do) rather than normalizing to [`TIMESCALE`].
+/// Pins the track's timescale to [`TIMESCALE`]. `moq_net::track::Info::default()` is milliseconds,
+/// which would quantize the net-level frame timestamps that moq-lite-05 and later delta-encode on
+/// the wire, even though the container prefix stays at microseconds. Chain
+/// [`with_timescale`](moq_net::track::Info::with_timescale) for a container that carries the
+/// source's own scale instead (CMAF and Matroska both do).
 ///
-/// Every media track should be created through one of these two rather than
-/// `moq_net::track::Info::default()`, so [`LATENCY_MAX`] is declared in one place instead of at
-/// each call site -- a track that silently keeps the default is one a segmented egress cannot
-/// serve a full playlist window from.
-pub fn track_info_at(timescale: Timescale) -> moq_net::track::Info {
+/// Also declares a retention long enough for a segmented egress to serve a full playlist window,
+/// which is why every media track should start here rather than at `Info::default()`. It is a
+/// retention budget and a CEILING on what a subscriber may ask to wait for, so it never makes
+/// anyone play further behind live: a subscriber's own
+/// [`Subscription::latency_max`](moq_net::track::Subscription::latency_max) still defaults to zero
+/// (skip the moment a newer group arrives).
+pub fn track_info() -> moq_net::track::Info {
 	moq_net::track::Info::default()
-		.with_timescale(timescale)
+		.with_timescale(TIMESCALE)
 		.with_latency_max(LATENCY_MAX)
 }
 
@@ -182,13 +174,14 @@ mod test {
 	fn media_tracks_declare_their_retention() {
 		// A media track is read as history (a segmented egress FETCHes segments a playlist
 		// advertised), so it declares a retention rather than inheriting the live-edge default.
-		// Both constructors must carry it: `track_info_at` exists for the containers that keep
-		// the source's timescale, and it is exactly those that would otherwise fall back to
-		// `Info::default()` and quietly lose the retention.
 		assert_eq!(track_info().latency_max, LATENCY_MAX);
-		assert_eq!(track_info_at(Timescale::MILLI).latency_max, LATENCY_MAX);
-		assert_eq!(track_info_at(Timescale::MILLI).timescale, Timescale::MILLI);
 		assert!(LATENCY_MAX > moq_net::track::DEFAULT_LATENCY_MAX);
+
+		// Retimescaling for a container that carries the source's own scale keeps it, since that
+		// is the shape that would otherwise reach for `Info::default()` and lose the retention.
+		let at = track_info().with_timescale(Timescale::MILLI);
+		assert_eq!(at.timescale, Timescale::MILLI);
+		assert_eq!(at.latency_max, LATENCY_MAX);
 	}
 
 	#[test]

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -130,15 +130,13 @@ impl<E: CatalogExt> Producer<E> {
 		};
 
 		let track = match &options.track {
-			// Audio hang frames carry microsecond timestamps; advertise that on the
-			// track so Lite05 subscribers know what scale to expect and the model
-			// layer accepts Frame::timestamp on append. `unique_track` does the same.
+			// The catalog's info carries the microsecond timescale audio hang frames stamp, so
+			// Lite05 subscribers know what scale to expect and the model layer accepts
+			// Frame::timestamp on append, plus whatever retention the broadcast declared.
 			Some(name) => broadcast.create_track(name.clone(), catalog.track_info())?,
 			// Mirrors the video side, which derives a unique name from the codec
 			// rather than making every caller invent one.
-			None => {
-				moq_mux::import::unique_track_with(broadcast, &format!(".{}", options.codec), catalog.track_info())?
-			}
+			None => broadcast.unique_track(&format!(".{}", options.codec), catalog.track_info())?,
 		};
 		let name = track.name().to_string();
 		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -136,7 +136,9 @@ impl<E: CatalogExt> Producer<E> {
 			Some(name) => broadcast.create_track(name.clone(), catalog.track_info())?,
 			// Mirrors the video side, which derives a unique name from the codec
 			// rather than making every caller invent one.
-			None => moq_mux::import::unique_track(broadcast, &format!(".{}", options.codec), catalog.track_info())?,
+			None => {
+				moq_mux::import::unique_track_with(broadcast, &format!(".{}", options.codec), catalog.track_info())?
+			}
 		};
 		let name = track.name().to_string();
 		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -133,10 +133,10 @@ impl<E: CatalogExt> Producer<E> {
 			// Audio hang frames carry microsecond timestamps; advertise that on the
 			// track so Lite05 subscribers know what scale to expect and the model
 			// layer accepts Frame::timestamp on append. `unique_track` does the same.
-			Some(name) => broadcast.create_track(name.clone(), hang::container::track_info())?,
+			Some(name) => broadcast.create_track(name.clone(), catalog.track_info())?,
 			// Mirrors the video side, which derives a unique name from the codec
 			// rather than making every caller invent one.
-			None => moq_mux::import::unique_track(broadcast, &format!(".{}", options.codec))?,
+			None => moq_mux::import::unique_track(broadcast, &format!(".{}", options.codec), catalog.track_info())?,
 		};
 		let name = track.name().to_string();
 		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -155,7 +155,7 @@ pub enum Command {
 #[derive(Args, Clone)]
 pub struct Import {
 	/// How long relays keep a non-latest group of the published media tracks fetchable,
-	/// e.g. "30s" or "5s".
+	/// e.g. "30s" or "5s". Defaults to hang's 30s.
 	///
 	/// A RETENTION budget, not a delivery one: it never makes a subscriber play further behind
 	/// live, it caps how far back a FETCH can still reach (and how long a subscriber may ask to
@@ -163,8 +163,8 @@ pub struct Import {
 	/// advertise segments that are still fetchable; lower it when nothing reads history and the
 	/// memory matters. Media tracks only -- the catalog and timeline are read at the live edge,
 	/// which is retained unconditionally.
-	#[arg(long, value_parser = humantime::parse_duration, default_value = "30s")]
-	pub latency_max: std::time::Duration,
+	#[arg(long, value_parser = humantime::parse_duration)]
+	pub latency_max: Option<std::time::Duration>,
 
 	/// The single source feeding the Origin.
 	#[command(subcommand)]
@@ -323,6 +323,34 @@ mod tests {
 	#[test]
 	fn valid() {
 		Cli::command().debug_assert();
+	}
+
+	#[test]
+	fn latency_max_is_unset_unless_asked_for() {
+		// Unset rather than defaulted to hang's constant, so a source that cannot apply the
+		// retention can tell "the user asked for one" from "nobody asked", and refuse only the
+		// former. A `default_value` here would make an explicit `--latency-max 30s` on such a
+		// source indistinguishable from the default, which is the silent no-op the guard exists
+		// to stop.
+		let cli = Cli::try_parse_from(["moq", "import", "ts"]).unwrap();
+		let Command::Import(import) = cli.command else {
+			panic!("expected import")
+		};
+		assert_eq!(import.latency_max, None);
+		assert!(import.source.honors_latency_max());
+
+		let cli = Cli::try_parse_from(["moq", "import", "--latency-max", "5s", "ts"]).unwrap();
+		let Command::Import(import) = cli.command else {
+			panic!("expected import")
+		};
+		assert_eq!(import.latency_max, Some(std::time::Duration::from_secs(5)));
+
+		// The gateways build their catalogs in their own crates, so they cannot apply it.
+		let cli = Cli::try_parse_from(["moq", "import", "rtmp", "--listen", "127.0.0.1:1935"]).unwrap();
+		let Command::Import(import) = cli.command else {
+			panic!("expected import")
+		};
+		assert!(!import.source.honors_latency_max());
 	}
 
 	#[test]

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -208,6 +208,23 @@ impl ImportSource {
 			_ => return None,
 		})
 	}
+
+	/// Whether this source threads [`Import::latency_max`] into the catalog it publishes.
+	///
+	/// The stdin containers, HLS, and capture build their catalog in this crate, so they honor
+	/// it. The remaining gateways build theirs inside moq-rtmp / moq-srt / moq-rtc, which take
+	/// no retention yet -- so the flag is REFUSED there rather than silently ignored.
+	pub fn honors_latency_max(&self) -> bool {
+		if self.stdin_format().is_some() {
+			return true;
+		}
+		match self {
+			Self::Hls(_) => true,
+			#[cfg(feature = "capture")]
+			Self::Capture(_) => true,
+			_ => false,
+		}
+	}
 }
 
 // ------------------------------------------------------------------ export

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -154,6 +154,18 @@ pub enum Command {
 /// import = one source -> MoQ.
 #[derive(Args, Clone)]
 pub struct Import {
+	/// How long relays keep a non-latest group of the published media tracks fetchable,
+	/// e.g. "30s" or "5s".
+	///
+	/// A RETENTION budget, not a delivery one: it never makes a subscriber play further behind
+	/// live, it caps how far back a FETCH can still reach (and how long a subscriber may ask to
+	/// wait for a late group). The default suits a segmented egress (HLS/DASH), which may only
+	/// advertise segments that are still fetchable; lower it when nothing reads history and the
+	/// memory matters. Media tracks only -- the catalog and timeline are read at the live edge,
+	/// which is retained unconditionally.
+	#[arg(long, value_parser = humantime::parse_duration, default_value = "30s")]
+	pub latency_max: std::time::Duration,
+
 	/// The single source feeding the Origin.
 	#[command(subcommand)]
 	pub source: ImportSource,

--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -52,7 +52,8 @@ pub async fn import(
 
 	// Create catalog tracks before the broadcast becomes visible so a subscriber
 	// can consume the catalog as soon as it observes the announcement.
-	let catalog = crate::publish::apply_latency_max(moq_mux::catalog::Producer::new(&mut producer)?, latency_max);
+	let config = moq_mux::catalog::Config::default().with_latency_max(latency_max);
+	let catalog = moq_mux::catalog::Producer::with_config(&mut producer, config)?;
 
 	let mut importer = moq_hls::import::Import::new(producer, catalog, moq_hls::import::Config::new(playlist))?;
 

--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -40,14 +40,19 @@ pub struct ExportArgs {
 }
 
 /// Pull a remote HLS/LL-HLS playlist (URL or file path) into the Origin under `name`.
-pub async fn import(origin: &moq_net::origin::Producer, name: String, playlist: String) -> anyhow::Result<()> {
+pub async fn import(
+	origin: &moq_net::origin::Producer,
+	name: String,
+	playlist: String,
+	latency_max: std::time::Duration,
+) -> anyhow::Result<()> {
 	let mut producer = origin
 		.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
 		.context("failed to create broadcast")?;
 
 	// Create catalog tracks before the broadcast becomes visible so a subscriber
 	// can consume the catalog as soon as it observes the announcement.
-	let catalog = moq_mux::catalog::Producer::new(&mut producer)?;
+	let catalog = moq_mux::catalog::Producer::new(&mut producer)?.with_latency_max(latency_max);
 
 	let mut importer = moq_hls::import::Import::new(producer, catalog, moq_hls::import::Config::new(playlist))?;
 

--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -44,7 +44,7 @@ pub async fn import(
 	origin: &moq_net::origin::Producer,
 	name: String,
 	playlist: String,
-	latency_max: std::time::Duration,
+	latency_max: Option<std::time::Duration>,
 ) -> anyhow::Result<()> {
 	let mut producer = origin
 		.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
@@ -52,7 +52,7 @@ pub async fn import(
 
 	// Create catalog tracks before the broadcast becomes visible so a subscriber
 	// can consume the catalog as soon as it observes the announcement.
-	let catalog = moq_mux::catalog::Producer::new(&mut producer)?.with_latency_max(latency_max);
+	let catalog = crate::publish::apply_latency_max(moq_mux::catalog::Producer::new(&mut producer)?, latency_max);
 
 	let mut importer = moq_hls::import::Import::new(producer, catalog, moq_hls::import::Config::new(playlist))?;
 

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -142,7 +142,6 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		"--latency-max is not supported for this source yet; it applies to the stdin container \
 		 formats, hls, and capture"
 	);
-	let latency_max = import.latency_max.unwrap_or(hang::container::LATENCY_MAX);
 
 	// The uplink's bandwidth estimate, for sources that can encode to fit it. Only
 	// an outbound client has one: a `--server-bind` publisher's sessions are
@@ -181,12 +180,13 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		let broadcast = origin
 			.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
 			.context("failed to create broadcast")?;
-		local = Some(Publish::new(broadcast, &format, latency_max)?);
+		local = Some(Publish::new(broadcast, &format, import.latency_max)?);
 	} else {
 		match import.source {
 			ImportSource::Hls(hls) => {
 				warn_if_missing_format(&name);
 				let origin = origin.clone();
+				let latency_max = import.latency_max;
 				tasks.spawn(async move { hls::import(&origin, name, hls.playlist, latency_max).await });
 			}
 			ImportSource::Rtmp(rtmp) => {
@@ -226,7 +226,12 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 				let broadcast = origin
 					.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
 					.context("failed to create broadcast")?;
-				local = Some(Publish::capture(broadcast, &capture, send_bandwidth, latency_max)?);
+				local = Some(Publish::capture(
+					broadcast,
+					&capture,
+					send_bandwidth,
+					import.latency_max,
+				)?);
 			}
 			_ => unreachable!("container formats are handled by stdin_format above"),
 		}

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -135,6 +135,14 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		reject_listener_cors(&rtc.cors, "import rtc")?;
 	}
 
+	// Refuse a retention this source can't apply rather than accepting the flag and quietly
+	// publishing at the default: the gateways build their catalogs inside their own crates.
+	anyhow::ensure!(
+		import.latency_max == hang::container::LATENCY_MAX || import.source.honors_latency_max(),
+		"--latency-max is not supported for this source yet; it applies to the stdin container \
+		 formats, hls, and capture"
+	);
+
 	// The uplink's bandwidth estimate, for sources that can encode to fit it. Only
 	// an outbound client has one: a `--server-bind` publisher's sessions are
 	// inbound and never surfaced here, so it stays `None` and those sources encode
@@ -178,7 +186,8 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 			ImportSource::Hls(hls) => {
 				warn_if_missing_format(&name);
 				let origin = origin.clone();
-				tasks.spawn(async move { hls::import(&origin, name, hls.playlist).await });
+				let latency_max = import.latency_max;
+				tasks.spawn(async move { hls::import(&origin, name, hls.playlist, latency_max).await });
 			}
 			ImportSource::Rtmp(rtmp) => {
 				if let Some(addr) = rtmp.listen {
@@ -217,7 +226,12 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 				let broadcast = origin
 					.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
 					.context("failed to create broadcast")?;
-				local = Some(Publish::capture(broadcast, &capture, send_bandwidth)?);
+				local = Some(Publish::capture(
+					broadcast,
+					&capture,
+					send_bandwidth,
+					import.latency_max,
+				)?);
 			}
 			_ => unreachable!("container formats are handled by stdin_format above"),
 		}

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -172,7 +172,7 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		let broadcast = origin
 			.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
 			.context("failed to create broadcast")?;
-		local = Some(Publish::new(broadcast, &format)?);
+		local = Some(Publish::new(broadcast, &format, import.latency_max)?);
 	} else {
 		match import.source {
 			ImportSource::Hls(hls) => {

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -138,10 +138,11 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	// Refuse a retention this source can't apply rather than accepting the flag and quietly
 	// publishing at the default: the gateways build their catalogs inside their own crates.
 	anyhow::ensure!(
-		import.latency_max == hang::container::LATENCY_MAX || import.source.honors_latency_max(),
+		import.latency_max.is_none() || import.source.honors_latency_max(),
 		"--latency-max is not supported for this source yet; it applies to the stdin container \
 		 formats, hls, and capture"
 	);
+	let latency_max = import.latency_max.unwrap_or(hang::container::LATENCY_MAX);
 
 	// The uplink's bandwidth estimate, for sources that can encode to fit it. Only
 	// an outbound client has one: a `--server-bind` publisher's sessions are
@@ -180,13 +181,12 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		let broadcast = origin
 			.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
 			.context("failed to create broadcast")?;
-		local = Some(Publish::new(broadcast, &format, import.latency_max)?);
+		local = Some(Publish::new(broadcast, &format, latency_max)?);
 	} else {
 		match import.source {
 			ImportSource::Hls(hls) => {
 				warn_if_missing_format(&name);
 				let origin = origin.clone();
-				let latency_max = import.latency_max;
 				tasks.spawn(async move { hls::import(&origin, name, hls.playlist, latency_max).await });
 			}
 			ImportSource::Rtmp(rtmp) => {
@@ -226,12 +226,7 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 				let broadcast = origin
 					.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
 					.context("failed to create broadcast")?;
-				local = Some(Publish::capture(
-					broadcast,
-					&capture,
-					send_bandwidth,
-					import.latency_max,
-				)?);
+				local = Some(Publish::capture(broadcast, &capture, send_bandwidth, latency_max)?);
 			}
 			_ => unreachable!("container formats are handled by stdin_format above"),
 		}

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -242,7 +242,7 @@ impl Publish {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?.with_latency_max(latency_max);
 		let source = match format {
 			PublishFormat::Avc3 => {
-				let track = moq_mux::import::unique_track(&mut broadcast, ".avc3", catalog.track_info())?;
+				let track = moq_mux::import::unique_track_with(&mut broadcast, ".avc3", catalog.track_info())?;
 				let import = moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?;
 				let split = Box::new(moq_mux::codec::h264::Split::new());
 				Source::Stream(PublishDecoder::Avc3 {
@@ -275,6 +275,7 @@ impl Publish {
 		mut broadcast: moq_net::broadcast::Producer,
 		args: &CaptureArgs,
 		bandwidth: Option<moq_net::bandwidth::Consumer>,
+		latency_max: std::time::Duration,
 	) -> anyhow::Result<Self> {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?.with_latency_max(latency_max);
 

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -204,18 +204,6 @@ enum Source {
 	},
 }
 
-/// Apply `--latency-max` to a freshly built catalog, leaving hang's own default in place when the
-/// flag is unset. Shared with the HLS import, which builds its catalog the same way.
-pub fn apply_latency_max<E: moq_mux::catalog::hang::CatalogExt>(
-	catalog: moq_mux::catalog::Producer<E>,
-	latency_max: Option<std::time::Duration>,
-) -> moq_mux::catalog::Producer<E> {
-	match latency_max {
-		Some(latency_max) => catalog.with_latency_max(latency_max),
-		None => catalog,
-	}
-}
-
 /// A single-broadcast publisher: decodes stdin (or captures local devices) into
 /// a broadcast that the MoQ side announces.
 pub struct Publish {
@@ -238,12 +226,11 @@ impl Publish {
 		// verbatim, so it uses the `mpegts` catalog extension rather than the media-only
 		// `()`. The catalog producer owns the broadcast's catalog tracks, so each broadcast
 		// gets exactly one; TS builds its `Ext` catalog here instead of the shared `()` below.
+		let config = moq_mux::catalog::Config::default().with_latency_max(latency_max);
+
 		if let PublishFormat::Ts = format {
-			let catalog = moq_mux::catalog::Producer::with_catalog(
-				&mut broadcast,
-				moq_mux::catalog::hang::Catalog::<ts::Ext>::default(),
-			)?;
-			let catalog = apply_latency_max(catalog, latency_max);
+			let config = config.with_catalog(moq_mux::catalog::hang::Catalog::<ts::Ext>::default());
+			let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 			let ts = ts::Import::new(broadcast.clone(), catalog.reserve());
 			return Ok(Self {
 				source: Source::Stream(PublishDecoder::Ts(Box::new(ts))),
@@ -251,7 +238,7 @@ impl Publish {
 			});
 		}
 
-		let catalog = apply_latency_max(moq_mux::catalog::Producer::new(&mut broadcast)?, latency_max);
+		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 		let source = match format {
 			PublishFormat::Avc3 => {
 				let track = broadcast.unique_track(".avc3", catalog.track_info())?;
@@ -289,7 +276,8 @@ impl Publish {
 		bandwidth: Option<moq_net::bandwidth::Consumer>,
 		latency_max: Option<std::time::Duration>,
 	) -> anyhow::Result<Self> {
-		let catalog = apply_latency_max(moq_mux::catalog::Producer::new(&mut broadcast)?, latency_max);
+		let config = moq_mux::catalog::Config::default().with_latency_max(latency_max);
+		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 
 		let video = (!args.no_video).then(|| (args.video_config(), args.video_encode(bandwidth)));
 		let audio = (!args.no_audio).then(|| (args.audio_config(), args.audio_encode()));

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -204,6 +204,18 @@ enum Source {
 	},
 }
 
+/// Apply `--latency-max` to a freshly built catalog, leaving hang's own default in place when the
+/// flag is unset. Shared with the HLS import, which builds its catalog the same way.
+pub fn apply_latency_max<E: moq_mux::catalog::hang::CatalogExt>(
+	catalog: moq_mux::catalog::Producer<E>,
+	latency_max: Option<std::time::Duration>,
+) -> moq_mux::catalog::Producer<E> {
+	match latency_max {
+		Some(latency_max) => catalog.with_latency_max(latency_max),
+		None => catalog,
+	}
+}
+
 /// A single-broadcast publisher: decodes stdin (or captures local devices) into
 /// a broadcast that the MoQ side announces.
 pub struct Publish {
@@ -220,7 +232,7 @@ impl Publish {
 	pub fn new(
 		mut broadcast: moq_net::broadcast::Producer,
 		format: &PublishFormat,
-		latency_max: std::time::Duration,
+		latency_max: Option<std::time::Duration>,
 	) -> anyhow::Result<Self> {
 		// TS carries undecoded elementary streams (SCTE-35, teletext, DVB AC-3, ...)
 		// verbatim, so it uses the `mpegts` catalog extension rather than the media-only
@@ -230,8 +242,8 @@ impl Publish {
 			let catalog = moq_mux::catalog::Producer::with_catalog(
 				&mut broadcast,
 				moq_mux::catalog::hang::Catalog::<ts::Ext>::default(),
-			)?
-			.with_latency_max(latency_max);
+			)?;
+			let catalog = apply_latency_max(catalog, latency_max);
 			let ts = ts::Import::new(broadcast.clone(), catalog.reserve());
 			return Ok(Self {
 				source: Source::Stream(PublishDecoder::Ts(Box::new(ts))),
@@ -239,10 +251,10 @@ impl Publish {
 			});
 		}
 
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?.with_latency_max(latency_max);
+		let catalog = apply_latency_max(moq_mux::catalog::Producer::new(&mut broadcast)?, latency_max);
 		let source = match format {
 			PublishFormat::Avc3 => {
-				let track = moq_mux::import::unique_track_with(&mut broadcast, ".avc3", catalog.track_info())?;
+				let track = broadcast.unique_track(".avc3", catalog.track_info())?;
 				let import = moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?;
 				let split = Box::new(moq_mux::codec::h264::Split::new());
 				Source::Stream(PublishDecoder::Avc3 {
@@ -275,9 +287,9 @@ impl Publish {
 		mut broadcast: moq_net::broadcast::Producer,
 		args: &CaptureArgs,
 		bandwidth: Option<moq_net::bandwidth::Consumer>,
-		latency_max: std::time::Duration,
+		latency_max: Option<std::time::Duration>,
 	) -> anyhow::Result<Self> {
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?.with_latency_max(latency_max);
+		let catalog = apply_latency_max(moq_mux::catalog::Producer::new(&mut broadcast)?, latency_max);
 
 		let video = (!args.no_video).then(|| (args.video_config(), args.video_encode(bandwidth)));
 		let audio = (!args.no_audio).then(|| (args.audio_config(), args.audio_encode()));
@@ -583,7 +595,7 @@ mod tests {
 			.create_broadcast("cli", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();
 		settle().await;
-		let mut publish = Publish::new(broadcast, &PublishFormat::Ts, hang::container::LATENCY_MAX).unwrap();
+		let mut publish = Publish::new(broadcast, &PublishFormat::Ts, None).unwrap();
 		#[allow(irrefutable_let_patterns)]
 		let Source::Stream(decoder) = &mut publish.source else {
 			panic!("expected a stream source");

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -217,7 +217,11 @@ pub struct Publish {
 impl Publish {
 	/// Build a publisher decoding the given container format from stdin into
 	/// `broadcast` (typically created on the origin that announces it).
-	pub fn new(mut broadcast: moq_net::broadcast::Producer, format: &PublishFormat) -> anyhow::Result<Self> {
+	pub fn new(
+		mut broadcast: moq_net::broadcast::Producer,
+		format: &PublishFormat,
+		latency_max: std::time::Duration,
+	) -> anyhow::Result<Self> {
 		// TS carries undecoded elementary streams (SCTE-35, teletext, DVB AC-3, ...)
 		// verbatim, so it uses the `mpegts` catalog extension rather than the media-only
 		// `()`. The catalog producer owns the broadcast's catalog tracks, so each broadcast
@@ -226,7 +230,8 @@ impl Publish {
 			let catalog = moq_mux::catalog::Producer::with_catalog(
 				&mut broadcast,
 				moq_mux::catalog::hang::Catalog::<ts::Ext>::default(),
-			)?;
+			)?
+			.with_latency_max(latency_max);
 			let ts = ts::Import::new(broadcast.clone(), catalog.reserve());
 			return Ok(Self {
 				source: Source::Stream(PublishDecoder::Ts(Box::new(ts))),
@@ -234,10 +239,10 @@ impl Publish {
 			});
 		}
 
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?.with_latency_max(latency_max);
 		let source = match format {
 			PublishFormat::Avc3 => {
-				let track = moq_mux::import::unique_track(&mut broadcast, ".avc3")?;
+				let track = moq_mux::import::unique_track(&mut broadcast, ".avc3", catalog.track_info())?;
 				let import = moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?;
 				let split = Box::new(moq_mux::codec::h264::Split::new());
 				Source::Stream(PublishDecoder::Avc3 {
@@ -271,7 +276,7 @@ impl Publish {
 		args: &CaptureArgs,
 		bandwidth: Option<moq_net::bandwidth::Consumer>,
 	) -> anyhow::Result<Self> {
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?.with_latency_max(latency_max);
 
 		let video = (!args.no_video).then(|| (args.video_config(), args.video_encode(bandwidth)));
 		let audio = (!args.no_audio).then(|| (args.audio_config(), args.audio_encode()));
@@ -577,7 +582,7 @@ mod tests {
 			.create_broadcast("cli", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();
 		settle().await;
-		let mut publish = Publish::new(broadcast, &PublishFormat::Ts).unwrap();
+		let mut publish = Publish::new(broadcast, &PublishFormat::Ts, hang::container::LATENCY_MAX).unwrap();
 		#[allow(irrefutable_let_patterns)]
 		let Source::Stream(decoder) = &mut publish.source else {
 			panic!("expected a stream source");

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -412,19 +412,17 @@ fn is_cache_miss(err: &moq_net::Error) -> bool {
 		|| code == moq_net::Error::Evicted.to_code()
 }
 
-/// [`is_cache_miss`] through every layer a group read wraps a transport error in.
+/// [`is_cache_miss`] for a group read, which reaches us wrapped in whichever container the track
+/// uses: plain transport for a raw read, `Hang` for the legacy container (what the JS and native
+/// encoders publish), `Cmaf` for fMP4.
 ///
-/// A read goes through the track's container, and each one re-wraps differently: plain transport
-/// for a raw read, `Hang` for the legacy container (what the JS and native encoders publish), and
-/// `Cmaf` for fMP4. Miss one and that container's evictions surface as server errors while the
-/// others 404, so keep this exhaustive over the wrappings rather than the codecs.
+/// Walks the source chain rather than matching those wrappings, since missing one turns that
+/// container's evictions back into server errors while the rest 404, and `moq_mux::Error` is
+/// `#[non_exhaustive]`: a container added later would silently reintroduce the bug.
 fn is_cache_miss_mux(err: &moq_mux::Error) -> bool {
-	match err {
-		moq_mux::Error::Moq(err) => is_cache_miss(err),
-		moq_mux::Error::Hang(hang::Error::Moq(err)) => is_cache_miss(err),
-		moq_mux::Error::Cmaf(moq_mux::container::fmp4::Error::Moq(err)) => is_cache_miss(err),
-		_ => false,
-	}
+	std::iter::successors(Some(err as &(dyn std::error::Error + 'static)), |err| err.source())
+		.filter_map(|err| err.downcast_ref::<moq_net::Error>())
+		.any(is_cache_miss)
 }
 
 /// Spawn the per-rendition watcher: resolve the (possibly sibling) broadcast, subscribe to
@@ -506,9 +504,8 @@ mod tests {
 	#[test]
 	fn a_cache_miss_is_recognised_through_the_mux_error_layers() {
 		// A group read wraps the same miss differently per container, and every wrapping has to
-		// resolve to 404. The `Hang` one is the shape a real relay produces most: it is what the
-		// legacy container (the JS and native encoders) surfaces, and an eviction there read as
-		// `mux: hang: moq error: remote error: code=13` -- a 500 -- until it was classified here.
+		// resolve to 404. `Hang` is the shape a real relay produces most, since it is what the
+		// legacy container (the JS and native encoders) surfaces.
 		let remote = moq_net::Error::Remote(moq_net::Error::NotFound.to_code());
 		assert!(is_cache_miss_mux(&moq_mux::Error::Moq(remote.clone())));
 		assert!(is_cache_miss_mux(&moq_mux::Error::Hang(hang::Error::Moq(
@@ -518,9 +515,11 @@ mod tests {
 			moq_mux::container::fmp4::Error::Moq(remote)
 		)));
 
-		// A genuine failure stays a failure through the same wrappings.
+		// A genuine failure stays a failure through the same wrappings, and an error carrying no
+		// transport error at all is never a miss.
 		let denied = moq_net::Error::Unauthorized;
 		assert!(!is_cache_miss_mux(&moq_mux::Error::Moq(denied.clone())));
 		assert!(!is_cache_miss_mux(&moq_mux::Error::Hang(hang::Error::Moq(denied))));
+		assert!(!is_cache_miss_mux(&moq_mux::Error::UnknownFormat("nope".to_string())));
 	}
 }

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -399,11 +399,18 @@ async fn read_group(
 
 /// True if a moq-net error means the group left (or hasn't reached) the relay cache: a 404, not
 /// a 500.
+///
+/// Compares WIRE CODES rather than variants, because the same miss reaches us in two shapes. A
+/// group missing from the LOCAL cache answers with the named variant, but anything that crossed a
+/// session arrives as [`moq_net::Error::Remote`]: `from_transport` decodes only code 0 (back to
+/// `Cancel`) and leaves every other reset code raw. In a relay the publisher we FETCH from is
+/// always remote, so matching variants alone made the ordinary "that group aged out" answer a 500
+/// instead of a 404 -- for every segment past the cache's retention, on every request.
 fn is_cache_miss(err: &moq_net::Error) -> bool {
-	matches!(
-		err,
-		moq_net::Error::NotFound | moq_net::Error::Old | moq_net::Error::Evicted
-	)
+	let code = err.to_code();
+	code == moq_net::Error::NotFound.to_code()
+		|| code == moq_net::Error::Old.to_code()
+		|| code == moq_net::Error::Evicted.to_code()
 }
 
 /// [`is_cache_miss`] through the moq-mux error layers a group read surfaces (plain transport, or
@@ -459,4 +466,48 @@ async fn watch(
 		live.push(entry, window);
 	}
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn a_cache_miss_that_crossed_a_session_is_still_a_cache_miss() {
+		// REGRESSION: a relay always FETCHes from a REMOTE publisher, and moq-net decodes every
+		// wire reset code as `Error::Remote(code)` -- only code 0 maps back to a named variant
+		// (`Cancel`). Matching the named variants alone therefore missed every miss that actually
+		// happens in a relay, and the serve path turned "that group aged out" into a 500 rather
+		// than the 404 the caller documents. That is every segment past the cache's retention.
+		for local in [moq_net::Error::NotFound, moq_net::Error::Old, moq_net::Error::Evicted] {
+			assert!(is_cache_miss(&local), "{local:?} locally");
+			let remote = moq_net::Error::Remote(local.to_code());
+			assert!(is_cache_miss(&remote), "{local:?} over the wire ({remote:?})");
+		}
+	}
+
+	#[test]
+	fn a_real_failure_is_not_a_cache_miss() {
+		// The mapping must not swallow genuine errors into a 404, in either shape.
+		for err in [
+			moq_net::Error::Unauthorized,
+			moq_net::Error::ProtocolViolation,
+			moq_net::Error::Timeout,
+		] {
+			assert!(!is_cache_miss(&err), "{err:?} locally");
+			let remote = moq_net::Error::Remote(err.to_code());
+			assert!(!is_cache_miss(&remote), "{err:?} over the wire ({remote:?})");
+		}
+	}
+
+	#[test]
+	fn a_cache_miss_is_recognised_through_the_mux_error_layers() {
+		// A group read surfaces the same miss wrapped one or two layers deep, and both wrappings
+		// have to keep resolving to 404.
+		let remote = moq_net::Error::Remote(moq_net::Error::NotFound.to_code());
+		assert!(is_cache_miss_mux(&moq_mux::Error::Moq(remote.clone())));
+		assert!(is_cache_miss_mux(&moq_mux::Error::Cmaf(
+			moq_mux::container::fmp4::Error::Moq(remote)
+		)));
+	}
 }

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -400,12 +400,11 @@ async fn read_group(
 /// True if a moq-net error means the group left (or hasn't reached) the relay cache: a 404, not
 /// a 500.
 ///
-/// Compares WIRE CODES rather than variants, because the same miss reaches us in two shapes. A
-/// group missing from the LOCAL cache answers with the named variant, but anything that crossed a
-/// session arrives as [`moq_net::Error::Remote`]: `from_transport` decodes only code 0 (back to
-/// `Cancel`) and leaves every other reset code raw. In a relay the publisher we FETCH from is
-/// always remote, so matching variants alone made the ordinary "that group aged out" answer a 500
-/// instead of a 404 -- for every segment past the cache's retention, on every request.
+/// Compares WIRE CODES rather than variants, because the same miss arrives in two shapes: a
+/// LOCAL cache answers with the named variant, while anything that crossed a session arrives as
+/// [`moq_net::Error::Remote`] carrying the raw code (`from_transport` decodes only code 0, back
+/// to `Cancel`). In a relay the publisher we FETCH from is always remote, so the remote shape is
+/// the common one and matching variants alone would classify it as a server error.
 fn is_cache_miss(err: &moq_net::Error) -> bool {
 	let code = err.to_code();
 	code == moq_net::Error::NotFound.to_code()
@@ -474,11 +473,10 @@ mod tests {
 
 	#[test]
 	fn a_cache_miss_that_crossed_a_session_is_still_a_cache_miss() {
-		// REGRESSION: a relay always FETCHes from a REMOTE publisher, and moq-net decodes every
-		// wire reset code as `Error::Remote(code)` -- only code 0 maps back to a named variant
-		// (`Cancel`). Matching the named variants alone therefore missed every miss that actually
-		// happens in a relay, and the serve path turned "that group aged out" into a 500 rather
-		// than the 404 the caller documents. That is every segment past the cache's retention.
+		// A miss must classify the same whichever shape it arrives in. The remote shape is the
+		// one a relay actually sees: it always FETCHes from a remote publisher, and moq-net
+		// surfaces every wire reset code as `Error::Remote(code)` (only code 0 maps back to a
+		// named variant, `Cancel`).
 		for local in [moq_net::Error::NotFound, moq_net::Error::Old, moq_net::Error::Evicted] {
 			assert!(is_cache_miss(&local), "{local:?} locally");
 			let remote = moq_net::Error::Remote(local.to_code());

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -412,11 +412,16 @@ fn is_cache_miss(err: &moq_net::Error) -> bool {
 		|| code == moq_net::Error::Evicted.to_code()
 }
 
-/// [`is_cache_miss`] through the moq-mux error layers a group read surfaces (plain transport, or
-/// wrapped in a CMAF decode error).
+/// [`is_cache_miss`] through every layer a group read wraps a transport error in.
+///
+/// A read goes through the track's container, and each one re-wraps differently: plain transport
+/// for a raw read, `Hang` for the legacy container (what the JS and native encoders publish), and
+/// `Cmaf` for fMP4. Miss one and that container's evictions surface as server errors while the
+/// others 404, so keep this exhaustive over the wrappings rather than the codecs.
 fn is_cache_miss_mux(err: &moq_mux::Error) -> bool {
 	match err {
 		moq_mux::Error::Moq(err) => is_cache_miss(err),
+		moq_mux::Error::Hang(hang::Error::Moq(err)) => is_cache_miss(err),
 		moq_mux::Error::Cmaf(moq_mux::container::fmp4::Error::Moq(err)) => is_cache_miss(err),
 		_ => false,
 	}
@@ -500,12 +505,22 @@ mod tests {
 
 	#[test]
 	fn a_cache_miss_is_recognised_through_the_mux_error_layers() {
-		// A group read surfaces the same miss wrapped one or two layers deep, and both wrappings
-		// have to keep resolving to 404.
+		// A group read wraps the same miss differently per container, and every wrapping has to
+		// resolve to 404. The `Hang` one is the shape a real relay produces most: it is what the
+		// legacy container (the JS and native encoders) surfaces, and an eviction there read as
+		// `mux: hang: moq error: remote error: code=13` -- a 500 -- until it was classified here.
 		let remote = moq_net::Error::Remote(moq_net::Error::NotFound.to_code());
 		assert!(is_cache_miss_mux(&moq_mux::Error::Moq(remote.clone())));
+		assert!(is_cache_miss_mux(&moq_mux::Error::Hang(hang::Error::Moq(
+			remote.clone()
+		))));
 		assert!(is_cache_miss_mux(&moq_mux::Error::Cmaf(
 			moq_mux::container::fmp4::Error::Moq(remote)
 		)));
+
+		// A genuine failure stays a failure through the same wrappings.
+		let denied = moq_net::Error::Unauthorized;
+		assert!(!is_cache_miss_mux(&moq_mux::Error::Moq(denied.clone())));
+		assert!(!is_cache_miss_mux(&moq_mux::Error::Hang(hang::Error::Moq(denied))));
 	}
 }

--- a/rs/moq-mux/src/catalog/mod.rs
+++ b/rs/moq-mux/src/catalog/mod.rs
@@ -34,7 +34,7 @@ mod tracks;
 pub use consumer::Consumer;
 pub use estimate::{Estimate, Estimator};
 pub use format::*;
-pub use producer::{Guard, Producer};
+pub use producer::{Config, Guard, Producer};
 pub use select::Select;
 pub use stream::Stream;
 pub use tracks::{AudioTrack, Rendition, RenditionConfig, Reserved, VideoHint, VideoTrack};

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -63,9 +63,9 @@ pub struct Producer<E: CatalogExt = ()> {
 	/// section and the media track's group recorder share one track. See [`media_producer`](Self::media_producer).
 	timelines: Arc<Mutex<BTreeMap<String, crate::timeline::Producer>>>,
 
-	/// Retention declared on the media tracks minted under this catalog. See
-	/// [`with_latency_max`](Self::with_latency_max).
-	latency_max: std::time::Duration,
+	/// Retention override for the media tracks minted under this catalog, or `None` to keep
+	/// hang's default. See [`with_latency_max`](Self::with_latency_max).
+	latency_max: Option<std::time::Duration>,
 }
 
 // Manual Clone so a producer is cheaply clonable regardless of whether `E` is.
@@ -126,14 +126,14 @@ impl<E: CatalogExt> Producer<E> {
 			clock: crate::Clock::new(),
 			broadcast: broadcast.clone(),
 			timelines: Arc::new(Mutex::new(BTreeMap::new())),
-			latency_max: hang::container::LATENCY_MAX,
+			latency_max: None,
 		})
 	}
 
-	/// Declare how long the media tracks minted under this catalog keep a non-latest group
-	/// fetchable, overriding [`hang::container::LATENCY_MAX`].
+	/// Override how long the media tracks minted under this catalog keep a non-latest group
+	/// fetchable, replacing hang's default.
 	///
-	/// The default suits a segmented egress (HLS/DASH), which may only advertise segments a
+	/// That default suits a segmented egress (HLS/DASH), which may only advertise segments a
 	/// FETCH can still reach. Lower it when nothing reads history and the memory matters;
 	/// raise it for a deeper seek window. It is a RETENTION budget, not a delivery one, so it
 	/// never makes a subscriber play further behind live -- it caps what one may ask to wait
@@ -142,25 +142,21 @@ impl<E: CatalogExt> Producer<E> {
 	/// Applies to the media tracks this catalog mints. The catalog and timeline tracks keep
 	/// moq-net's default: both are read at the live edge, which is retained unconditionally.
 	pub fn with_latency_max(mut self, latency_max: std::time::Duration) -> Self {
-		self.latency_max = latency_max;
+		self.latency_max = Some(latency_max);
 		self
 	}
 
-	/// The retention this catalog declares on its media tracks.
-	pub fn latency_max(&self) -> std::time::Duration {
-		self.latency_max
-	}
-
-	/// Track properties for a media track under this catalog, at the container's default
-	/// timescale. Carries [`latency_max`](Self::latency_max).
+	/// Track properties for a media track under this catalog: hang's media defaults, plus any
+	/// [`with_latency_max`](Self::with_latency_max) override.
+	///
+	/// Chain [`with_timescale`](moq_net::track::Info::with_timescale) for a container that
+	/// carries the source's own scale (CMAF and Matroska both do).
 	pub fn track_info(&self) -> moq_net::track::Info {
-		hang::container::track_info().with_latency_max(self.latency_max)
-	}
-
-	/// [`track_info`](Self::track_info) at an explicit timescale, for a container that keeps
-	/// the source's own (CMAF and Matroska both do).
-	pub fn track_info_at(&self, timescale: moq_net::Timescale) -> moq_net::track::Info {
-		hang::container::track_info_at(timescale).with_latency_max(self.latency_max)
+		let info = hang::container::track_info();
+		match self.latency_max {
+			Some(latency_max) => info.with_latency_max(latency_max),
+			None => info,
+		}
 	}
 
 	/// Resolve a timestamp, synthesizing one from the broadcast's shared
@@ -519,22 +515,24 @@ mod test {
 	fn media_tracks_inherit_the_catalogs_declared_retention() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 
-		// The default is hang's media retention, sized so a segmented egress can serve a full
-		// playlist window rather than moq-net's live-edge default.
+		// Unset, a catalog mints hang's media defaults, sized so a segmented egress can serve a
+		// full playlist window rather than moq-net's live-edge default.
 		let catalog = Producer::new(&mut broadcast).unwrap();
-		assert_eq!(catalog.track_info().latency_max, hang::container::LATENCY_MAX);
+		assert_eq!(
+			catalog.track_info().latency_max,
+			hang::container::track_info().latency_max
+		);
 		assert!(catalog.track_info().latency_max > moq_net::track::DEFAULT_LATENCY_MAX);
 
-		// An override reaches every media track this catalog mints, through either constructor,
-		// and does NOT disturb the timescale each one pins.
+		// An override reaches every media track this catalog mints, and does NOT disturb the
+		// timescale hang pins (or survive a retimescale for a source-scale container).
 		let catalog = catalog.with_latency_max(std::time::Duration::from_secs(3));
-		assert_eq!(catalog.latency_max(), std::time::Duration::from_secs(3));
 
 		let info = catalog.track_info();
 		assert_eq!(info.latency_max, std::time::Duration::from_secs(3));
 		assert_eq!(info.timescale, hang::container::TIMESCALE);
 
-		let at = catalog.track_info_at(moq_net::Timescale::MILLI);
+		let at = info.with_timescale(moq_net::Timescale::MILLI);
 		assert_eq!(at.latency_max, std::time::Duration::from_secs(3));
 		assert_eq!(at.timescale, moq_net::Timescale::MILLI);
 

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -62,6 +62,10 @@ pub struct Producer<E: CatalogExt = ()> {
 	/// The per-rendition timeline producers, memoized by media-track name so the catalog
 	/// section and the media track's group recorder share one track. See [`media_producer`](Self::media_producer).
 	timelines: Arc<Mutex<BTreeMap<String, crate::timeline::Producer>>>,
+
+	/// Retention declared on the media tracks minted under this catalog. See
+	/// [`with_latency_max`](Self::with_latency_max).
+	latency_max: std::time::Duration,
 }
 
 // Manual Clone so a producer is cheaply clonable regardless of whether `E` is.
@@ -76,6 +80,7 @@ impl<E: CatalogExt> Clone for Producer<E> {
 			clock: self.clock,
 			broadcast: self.broadcast.clone(),
 			timelines: self.timelines.clone(),
+			latency_max: self.latency_max,
 		}
 	}
 }
@@ -121,7 +126,41 @@ impl<E: CatalogExt> Producer<E> {
 			clock: crate::Clock::new(),
 			broadcast: broadcast.clone(),
 			timelines: Arc::new(Mutex::new(BTreeMap::new())),
+			latency_max: hang::container::LATENCY_MAX,
 		})
+	}
+
+	/// Declare how long the media tracks minted under this catalog keep a non-latest group
+	/// fetchable, overriding [`hang::container::LATENCY_MAX`].
+	///
+	/// The default suits a segmented egress (HLS/DASH), which may only advertise segments a
+	/// FETCH can still reach. Lower it when nothing reads history and the memory matters;
+	/// raise it for a deeper seek window. It is a RETENTION budget, not a delivery one, so it
+	/// never makes a subscriber play further behind live -- it caps what one may ask to wait
+	/// for, and a subscriber's own budget still defaults to zero.
+	///
+	/// Applies to the media tracks this catalog mints. The catalog and timeline tracks keep
+	/// moq-net's default: both are read at the live edge, which is retained unconditionally.
+	pub fn with_latency_max(mut self, latency_max: std::time::Duration) -> Self {
+		self.latency_max = latency_max;
+		self
+	}
+
+	/// The retention this catalog declares on its media tracks.
+	pub fn latency_max(&self) -> std::time::Duration {
+		self.latency_max
+	}
+
+	/// Track properties for a media track under this catalog, at the container's default
+	/// timescale. Carries [`latency_max`](Self::latency_max).
+	pub fn track_info(&self) -> moq_net::track::Info {
+		hang::container::track_info().with_latency_max(self.latency_max)
+	}
+
+	/// [`track_info`](Self::track_info) at an explicit timescale, for a container that keeps
+	/// the source's own (CMAF and Matroska both do).
+	pub fn track_info_at(&self, timescale: moq_net::Timescale) -> moq_net::track::Info {
+		hang::container::track_info_at(timescale).with_latency_max(self.latency_max)
 	}
 
 	/// Resolve a timestamp, synthesizing one from the broadcast's shared
@@ -475,6 +514,37 @@ mod test {
 	use hang::catalog::{AudioCodec, AudioConfig, Container, H264, VideoConfig};
 
 	use super::*;
+
+	#[test]
+	fn media_tracks_inherit_the_catalogs_declared_retention() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+
+		// The default is hang's media retention, sized so a segmented egress can serve a full
+		// playlist window rather than moq-net's live-edge default.
+		let catalog = Producer::new(&mut broadcast).unwrap();
+		assert_eq!(catalog.track_info().latency_max, hang::container::LATENCY_MAX);
+		assert!(catalog.track_info().latency_max > moq_net::track::DEFAULT_LATENCY_MAX);
+
+		// An override reaches every media track this catalog mints, through either constructor,
+		// and does NOT disturb the timescale each one pins.
+		let catalog = catalog.with_latency_max(std::time::Duration::from_secs(3));
+		assert_eq!(catalog.latency_max(), std::time::Duration::from_secs(3));
+
+		let info = catalog.track_info();
+		assert_eq!(info.latency_max, std::time::Duration::from_secs(3));
+		assert_eq!(info.timescale, hang::container::TIMESCALE);
+
+		let at = catalog.track_info_at(moq_net::Timescale::MILLI);
+		assert_eq!(at.latency_max, std::time::Duration::from_secs(3));
+		assert_eq!(at.timescale, moq_net::Timescale::MILLI);
+
+		// And a reservation hands importers the same policy, since that is what the codec
+		// paths mint their tracks from.
+		assert_eq!(
+			catalog.reserve().track_info().latency_max,
+			std::time::Duration::from_secs(3)
+		);
+	}
 
 	#[test]
 	fn publishes_plain_and_compressed_tracks() {

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -64,7 +64,9 @@ pub struct Producer<E: CatalogExt = ()> {
 	timelines: Arc<Mutex<BTreeMap<String, crate::timeline::Producer>>>,
 
 	/// Retention override for the media tracks minted under this catalog, or `None` to keep
-	/// hang's default. See [`with_latency_max`](Self::with_latency_max).
+	/// hang's default. Fixed at construction, so every clone and every
+	/// [`Reserved`](super::Reserved) mints tracks under one policy. See
+	/// [`Config::with_latency_max`].
 	latency_max: Option<std::time::Duration>,
 }
 
@@ -85,14 +87,63 @@ impl<E: CatalogExt> Clone for Producer<E> {
 	}
 }
 
+/// Everything a catalog [`Producer`] is built from: the initial catalog and any overrides.
+///
+/// Start from [`default`](Default::default), which is the media-only catalog with hang's own
+/// defaults, and chain the setters.
+///
+/// These are constructor arguments rather than setters on a live producer, so a clone or a
+/// [`Reserved`](super::Reserved) taken at any point mints tracks under the same policy.
+#[derive(Clone)]
+pub struct Config<E: CatalogExt = ()> {
+	catalog: Catalog<E>,
+	latency_max: Option<std::time::Duration>,
+}
+
+impl Default for Config<()> {
+	fn default() -> Self {
+		Self {
+			catalog: Catalog::default(),
+			latency_max: None,
+		}
+	}
+}
+
+impl<E: CatalogExt> Config<E> {
+	/// Start from an extended catalog rather than the media-only one, e.g. the untyped
+	/// [`Extra`] for the by-name / FFI path. Set application sections through
+	/// [`Producer::lock`](Producer::lock) afterwards.
+	pub fn with_catalog<F: CatalogExt>(self, catalog: Catalog<F>) -> Config<F> {
+		Config {
+			catalog,
+			latency_max: self.latency_max,
+		}
+	}
+
+	/// Override how long the media tracks minted under this catalog keep a non-latest group
+	/// fetchable, replacing hang's default. `None` keeps it.
+	///
+	/// That default suits a segmented egress (HLS/DASH), which may only advertise segments a
+	/// FETCH can still reach. Lower it when nothing reads history and the memory matters;
+	/// raise it for a deeper seek window. It is a RETENTION budget, not a delivery one, so it
+	/// never makes a subscriber play further behind live -- it caps what one may ask to wait
+	/// for, and a subscriber's own budget still defaults to zero.
+	///
+	/// Applies to the media tracks the catalog mints. The catalog and timeline tracks keep
+	/// moq-net's default: both are read at the live edge, which is retained unconditionally.
+	pub fn with_latency_max(mut self, latency_max: impl Into<Option<std::time::Duration>>) -> Self {
+		self.latency_max = latency_max.into();
+		self
+	}
+}
+
 impl Producer<()> {
 	/// Create a new media-only catalog producer with the default (empty) catalog.
 	///
-	/// For an extended catalog, use [`with_catalog`](Self::with_catalog) with a
-	/// `Catalog<E>` (e.g. the untyped [`Extra`] for the by-name / FFI path). Set
-	/// application sections through [`lock`](Self::lock).
+	/// For an extended catalog or a retention override, use
+	/// [`with_config`](Self::with_config).
 	pub fn new(broadcast: &mut moq_net::broadcast::Producer) -> Result<Self, moq_net::Error> {
-		Self::with_catalog(broadcast, Catalog::default())
+		Self::with_config(broadcast, Config::default())
 	}
 }
 
@@ -101,6 +152,14 @@ impl<E: CatalogExt> Producer<E> {
 	pub fn with_catalog(
 		broadcast: &mut moq_net::broadcast::Producer,
 		catalog: Catalog<E>,
+	) -> Result<Self, moq_net::Error> {
+		Self::with_config(broadcast, Config::default().with_catalog(catalog))
+	}
+
+	/// Create a new catalog producer from a full [`Config`].
+	pub fn with_config(
+		broadcast: &mut moq_net::broadcast::Producer,
+		config: Config<E>,
 	) -> Result<Self, moq_net::Error> {
 		let hang_track = broadcast.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())?;
 		let hangz_track =
@@ -121,33 +180,17 @@ impl<E: CatalogExt> Producer<E> {
 			hang,
 			hangz,
 			msf_track,
-			current: Arc::new(Mutex::new(catalog)),
+			current: Arc::new(Mutex::new(config.catalog)),
 			reservations: Arc::new(Mutex::new(Reservations::default())),
 			clock: crate::Clock::new(),
 			broadcast: broadcast.clone(),
 			timelines: Arc::new(Mutex::new(BTreeMap::new())),
-			latency_max: None,
+			latency_max: config.latency_max,
 		})
 	}
 
-	/// Override how long the media tracks minted under this catalog keep a non-latest group
-	/// fetchable, replacing hang's default.
-	///
-	/// That default suits a segmented egress (HLS/DASH), which may only advertise segments a
-	/// FETCH can still reach. Lower it when nothing reads history and the memory matters;
-	/// raise it for a deeper seek window. It is a RETENTION budget, not a delivery one, so it
-	/// never makes a subscriber play further behind live -- it caps what one may ask to wait
-	/// for, and a subscriber's own budget still defaults to zero.
-	///
-	/// Applies to the media tracks this catalog mints. The catalog and timeline tracks keep
-	/// moq-net's default: both are read at the live edge, which is retained unconditionally.
-	pub fn with_latency_max(mut self, latency_max: std::time::Duration) -> Self {
-		self.latency_max = Some(latency_max);
-		self
-	}
-
 	/// Track properties for a media track under this catalog: hang's media defaults, plus any
-	/// [`with_latency_max`](Self::with_latency_max) override.
+	/// [`Config::with_latency_max`] override.
 	///
 	/// Chain [`with_timescale`](moq_net::track::Info::with_timescale) for a container that
 	/// carries the source's own scale (CMAF and Matroska both do).
@@ -526,7 +569,9 @@ mod test {
 
 		// An override reaches every media track this catalog mints, and does NOT disturb the
 		// timescale hang pins (or survive a retimescale for a source-scale container).
-		let catalog = catalog.with_latency_max(std::time::Duration::from_secs(3));
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let config = Config::default().with_latency_max(std::time::Duration::from_secs(3));
+		let catalog = Producer::with_config(&mut broadcast, config).unwrap();
 
 		let info = catalog.track_info();
 		assert_eq!(info.latency_max, std::time::Duration::from_secs(3));
@@ -536,10 +581,14 @@ mod test {
 		assert_eq!(at.latency_max, std::time::Duration::from_secs(3));
 		assert_eq!(at.timescale, moq_net::Timescale::MILLI);
 
-		// And a reservation hands importers the same policy, since that is what the codec
-		// paths mint their tracks from.
+		// Every handle mints under the same policy, whatever order it was taken in: the codec
+		// paths hold a reservation and the container paths hold a clone.
 		assert_eq!(
 			catalog.reserve().track_info().latency_max,
+			std::time::Duration::from_secs(3)
+		);
+		assert_eq!(
+			catalog.clone().track_info().latency_max,
 			std::time::Duration::from_secs(3)
 		);
 	}

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -211,16 +211,10 @@ impl<E: CatalogExt> Reserved<E> {
 		Self { catalog }
 	}
 
-	/// Track properties for a media track under this catalog, carrying its declared retention.
-	/// See [`Producer::with_latency_max`](super::Producer::with_latency_max).
+	/// Track properties for a media track under this catalog, carrying any retention it declares.
+	/// See [`Producer::track_info`](super::Producer::track_info).
 	pub fn track_info(&self) -> moq_net::track::Info {
 		self.catalog.track_info()
-	}
-
-	/// [`track_info`](Self::track_info) at an explicit timescale, for a container that keeps the
-	/// source's own rather than normalizing to the container default.
-	pub fn track_info_at(&self, timescale: moq_net::Timescale) -> moq_net::track::Info {
-		self.catalog.track_info_at(timescale)
 	}
 
 	/// Reserve a rendition of config type `C` under `name`, returning a guard to fill it in.

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -211,6 +211,18 @@ impl<E: CatalogExt> Reserved<E> {
 		Self { catalog }
 	}
 
+	/// Track properties for a media track under this catalog, carrying its declared retention.
+	/// See [`Producer::with_latency_max`](super::Producer::with_latency_max).
+	pub fn track_info(&self) -> moq_net::track::Info {
+		self.catalog.track_info()
+	}
+
+	/// [`track_info`](Self::track_info) at an explicit timescale, for a container that keeps the
+	/// source's own rather than normalizing to the container default.
+	pub fn track_info_at(&self, timescale: moq_net::Timescale) -> moq_net::track::Info {
+		self.catalog.track_info_at(timescale)
+	}
+
 	/// Reserve a rendition of config type `C` under `name`, returning a guard to fill it in.
 	///
 	/// The guard holds its own `Reserved` clone, so the catalog stays withheld until the returned

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -120,9 +120,9 @@ pub(crate) struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track, reserving the rendition from `reserved`. Mint the
-	/// track at the descriptor's suffix with [`hang::container::track_info`] (e.g. via
-	/// [`crate::import::unique_track`]).
+	/// Publish on an existing track, reserving the rendition from `reserved`. Mint the track at
+	/// the descriptor's suffix with the catalog's
+	/// [`track_info`](crate::catalog::Producer::track_info).
 	pub fn new(
 		descriptor: &'static Descriptor,
 		track: moq_net::track::Producer,

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -541,7 +541,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			old.track.finish()?;
 			self.catalog.lock().video.renditions.remove(old.track.name());
 		}
-		Ok(self.broadcast.unique_track(".flv-v", hang::container::track_info())?)
+		Ok(self.broadcast.unique_track(".flv-v", self.catalog.track_info())?)
 	}
 
 	/// Drop any existing audio track `track_id` (finishing it and clearing its
@@ -551,7 +551,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			old.track.finish()?;
 			self.catalog.lock().audio.renditions.remove(old.track.name());
 		}
-		Ok(self.broadcast.unique_track(".flv-a", hang::container::track_info())?)
+		Ok(self.broadcast.unique_track(".flv-a", self.catalog.track_info())?)
 	}
 
 	/// Close the current group on every track and reopen at `sequence`.

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -236,7 +236,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 			let track = self.broadcast.create_track(
 				self.broadcast.unique_name(suffix),
-				hang::container::track_info_at(timescale),
+				self.catalog.track_info_at(timescale),
 			)?;
 
 			// Each track indexes its own group opens: audio and video group boundaries differ, so a

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -236,7 +236,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 			let track = self.broadcast.create_track(
 				self.broadcast.unique_name(suffix),
-				moq_net::track::Info::default().with_timescale(timescale),
+				hang::container::track_info_at(timescale),
 			)?;
 
 			// Each track indexes its own group opens: audio and video group boundaries differ, so a

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -236,7 +236,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 			let track = self.broadcast.create_track(
 				self.broadcast.unique_name(suffix),
-				self.catalog.track_info_at(timescale),
+				self.catalog.track_info().with_timescale(timescale),
 			)?;
 
 			// Each track indexes its own group opens: audio and video group boundaries differ, so a

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -272,7 +272,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 		let track = self
 			.broadcast
-			.create_track(self.broadcast.unique_name(suffix), hang::container::track_info())?;
+			.create_track(self.broadcast.unique_name(suffix), self.catalog.track_info())?;
 		let name = track.name().to_string();
 
 		// Build the media producer before publishing the rendition. It is fallible (its

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -333,7 +333,7 @@ impl<E: catalog::Catalog> Import<E> {
 
 		let stream = match stream_type {
 			StreamType::H264 => {
-				let track = crate::import::unique_track(&mut self.broadcast, ".avc3", self.catalog.track_info())?;
+				let track = crate::import::unique_track_with(&mut self.broadcast, ".avc3", self.catalog.track_info())?;
 				Stream::H264 {
 					split: h264::Split::new(),
 					import: Box::new(h264::Import::new(track, self.catalog.reserve(), Default::default())?),
@@ -341,7 +341,7 @@ impl<E: catalog::Catalog> Import<E> {
 				}
 			}
 			StreamType::H265 => {
-				let track = crate::import::unique_track(&mut self.broadcast, ".hev1", self.catalog.track_info())?;
+				let track = crate::import::unique_track_with(&mut self.broadcast, ".hev1", self.catalog.track_info())?;
 				Stream::H265 {
 					split: h265::Split::new(),
 					import: Box::new(h265::Import::new(track, self.catalog.reserve(), Default::default())?),
@@ -368,7 +368,7 @@ impl<E: catalog::Catalog> Import<E> {
 			// come from the descriptors, so the importer is built up front.
 			StreamType::Mpeg2PacketizedData if registration_format(descriptors) == Some(*b"Opus") => {
 				let channel_count = opus_channel_count(descriptors).unwrap_or(2);
-				let track = crate::import::unique_track(&mut self.broadcast, ".opus", self.catalog.track_info())?;
+				let track = crate::import::unique_track_with(&mut self.broadcast, ".opus", self.catalog.track_info())?;
 				let config = opus::Config::new(48_000, channel_count);
 				Stream::Opus(Box::new(OpusStream {
 					import: opus::Import::new(track, self.catalog.reserve(), config.into())?,
@@ -1248,7 +1248,7 @@ impl<E: CatalogExt> AacStream<E> {
 					// The importer synthesizes the AudioSpecificConfig `description` from the config so
 					// out-of-band consumers (fMP4/MKV export, WebCodecs) can configure the decoder.
 					let reserved = self.reserved.take().expect("aac reservation already consumed");
-					let track = crate::import::unique_track(&mut self.broadcast, ".aac", reserved.track_info())?;
+					let track = crate::import::unique_track_with(&mut self.broadcast, ".aac", reserved.track_info())?;
 					let aac = aac::Import::new(track, reserved, config.into())?;
 					self.import.insert(aac)
 				}
@@ -1535,7 +1535,7 @@ impl<E: CatalogExt> LegacyStream<E> {
 					// Consume the reservation held since the PMT: this resolves the gated rendition,
 					// and carries the catalog's declared media retention onto the track.
 					let reserved = self.reserved.take().expect("legacy reservation already consumed");
-					let track = crate::import::unique_track(
+					let track = crate::import::unique_track_with(
 						&mut self.broadcast,
 						self.descriptor.track_suffix,
 						reserved.track_info(),

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -333,7 +333,7 @@ impl<E: catalog::Catalog> Import<E> {
 
 		let stream = match stream_type {
 			StreamType::H264 => {
-				let track = crate::import::unique_track_with(&mut self.broadcast, ".avc3", self.catalog.track_info())?;
+				let track = self.broadcast.unique_track(".avc3", self.catalog.track_info())?;
 				Stream::H264 {
 					split: h264::Split::new(),
 					import: Box::new(h264::Import::new(track, self.catalog.reserve(), Default::default())?),
@@ -341,7 +341,7 @@ impl<E: catalog::Catalog> Import<E> {
 				}
 			}
 			StreamType::H265 => {
-				let track = crate::import::unique_track_with(&mut self.broadcast, ".hev1", self.catalog.track_info())?;
+				let track = self.broadcast.unique_track(".hev1", self.catalog.track_info())?;
 				Stream::H265 {
 					split: h265::Split::new(),
 					import: Box::new(h265::Import::new(track, self.catalog.reserve(), Default::default())?),
@@ -368,7 +368,7 @@ impl<E: catalog::Catalog> Import<E> {
 			// come from the descriptors, so the importer is built up front.
 			StreamType::Mpeg2PacketizedData if registration_format(descriptors) == Some(*b"Opus") => {
 				let channel_count = opus_channel_count(descriptors).unwrap_or(2);
-				let track = crate::import::unique_track_with(&mut self.broadcast, ".opus", self.catalog.track_info())?;
+				let track = self.broadcast.unique_track(".opus", self.catalog.track_info())?;
 				let config = opus::Config::new(48_000, channel_count);
 				Stream::Opus(Box::new(OpusStream {
 					import: opus::Import::new(track, self.catalog.reserve(), config.into())?,
@@ -1248,7 +1248,7 @@ impl<E: CatalogExt> AacStream<E> {
 					// The importer synthesizes the AudioSpecificConfig `description` from the config so
 					// out-of-band consumers (fMP4/MKV export, WebCodecs) can configure the decoder.
 					let reserved = self.reserved.take().expect("aac reservation already consumed");
-					let track = crate::import::unique_track_with(&mut self.broadcast, ".aac", reserved.track_info())?;
+					let track = self.broadcast.unique_track(".aac", reserved.track_info())?;
 					let aac = aac::Import::new(track, reserved, config.into())?;
 					self.import.insert(aac)
 				}
@@ -1535,11 +1535,9 @@ impl<E: CatalogExt> LegacyStream<E> {
 					// Consume the reservation held since the PMT: this resolves the gated rendition,
 					// and carries the catalog's declared media retention onto the track.
 					let reserved = self.reserved.take().expect("legacy reservation already consumed");
-					let track = crate::import::unique_track_with(
-						&mut self.broadcast,
-						self.descriptor.track_suffix,
-						reserved.track_info(),
-					)?;
+					let track = self
+						.broadcast
+						.unique_track(self.descriptor.track_suffix, reserved.track_info())?;
 					let legacy = legacy::Import::new(self.descriptor, track, reserved, config)?;
 					self.import.insert(legacy)
 				}

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -723,7 +723,7 @@ fn register_verbatim<E: catalog::Catalog>(
 	// Verbatim payloads ride the legacy container, which normalizes the per-frame
 	// timestamp to microseconds on the wire (see `hang::container::Frame::encode`),
 	// so the track declares that timescale to match.
-	let track = broadcast.unique_track(".ts", hang::container::track_info())?;
+	let track = broadcast.unique_track(".ts", catalog.track_info())?;
 	let name = track.name().to_string();
 
 	// Build the media producer before advertising the track. It is fallible (its

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -333,7 +333,7 @@ impl<E: catalog::Catalog> Import<E> {
 
 		let stream = match stream_type {
 			StreamType::H264 => {
-				let track = crate::import::unique_track(&mut self.broadcast, ".avc3")?;
+				let track = crate::import::unique_track(&mut self.broadcast, ".avc3", self.catalog.track_info())?;
 				Stream::H264 {
 					split: h264::Split::new(),
 					import: Box::new(h264::Import::new(track, self.catalog.reserve(), Default::default())?),
@@ -341,7 +341,7 @@ impl<E: catalog::Catalog> Import<E> {
 				}
 			}
 			StreamType::H265 => {
-				let track = crate::import::unique_track(&mut self.broadcast, ".hev1")?;
+				let track = crate::import::unique_track(&mut self.broadcast, ".hev1", self.catalog.track_info())?;
 				Stream::H265 {
 					split: h265::Split::new(),
 					import: Box::new(h265::Import::new(track, self.catalog.reserve(), Default::default())?),
@@ -368,7 +368,7 @@ impl<E: catalog::Catalog> Import<E> {
 			// come from the descriptors, so the importer is built up front.
 			StreamType::Mpeg2PacketizedData if registration_format(descriptors) == Some(*b"Opus") => {
 				let channel_count = opus_channel_count(descriptors).unwrap_or(2);
-				let track = crate::import::unique_track(&mut self.broadcast, ".opus")?;
+				let track = crate::import::unique_track(&mut self.broadcast, ".opus", self.catalog.track_info())?;
 				let config = opus::Config::new(48_000, channel_count);
 				Stream::Opus(Box::new(OpusStream {
 					import: opus::Import::new(track, self.catalog.reserve(), config.into())?,
@@ -1243,11 +1243,12 @@ impl<E: CatalogExt> AacStream<E> {
 						sample_rate: header.sample_rate,
 						channel_count: header.channel_count,
 					};
-					let track = crate::import::unique_track(&mut self.broadcast, ".aac")?;
-					// Consume the reservation held since the PMT: this resolves the gated rendition.
+					// Consume the reservation held since the PMT: this resolves the gated rendition,
+					// and carries the catalog's declared media retention onto the track.
 					// The importer synthesizes the AudioSpecificConfig `description` from the config so
 					// out-of-band consumers (fMP4/MKV export, WebCodecs) can configure the decoder.
 					let reserved = self.reserved.take().expect("aac reservation already consumed");
+					let track = crate::import::unique_track(&mut self.broadcast, ".aac", reserved.track_info())?;
 					let aac = aac::Import::new(track, reserved, config.into())?;
 					self.import.insert(aac)
 				}
@@ -1531,9 +1532,14 @@ impl<E: CatalogExt> LegacyStream<E> {
 						sample_rate: header.sample_rate,
 						channel_count: header.channel_count,
 					};
-					let track = crate::import::unique_track(&mut self.broadcast, self.descriptor.track_suffix)?;
-					// Consume the reservation held since the PMT: this resolves the gated rendition.
+					// Consume the reservation held since the PMT: this resolves the gated rendition,
+					// and carries the catalog's declared media retention onto the track.
 					let reserved = self.reserved.take().expect("legacy reservation already consumed");
+					let track = crate::import::unique_track(
+						&mut self.broadcast,
+						self.descriptor.track_suffix,
+						reserved.track_info(),
+					)?;
 					let legacy = legacy::Import::new(self.descriptor, track, reserved, config)?;
 					self.import.insert(legacy)
 				}

--- a/rs/moq-mux/src/import/mod.rs
+++ b/rs/moq-mux/src/import/mod.rs
@@ -27,12 +27,16 @@ pub use track::*;
 
 /// Mint a fresh unique track for a legacy single-codec importer.
 ///
-/// Picks a unique name from `suffix` and applies [`hang::container::track_info`], so the
-/// relay gets timing without parsing the payload. Hand the result to the importer's `new`.
+/// Picks a unique name from `suffix` and applies `info`, so the relay gets timing without
+/// parsing the payload. Hand the result to the importer's `new`.
+///
+/// Pass the catalog's own [`track_info`](crate::catalog::Producer::track_info) rather than
+/// `hang::container::track_info()` directly, so the track inherits whatever retention that
+/// catalog declares instead of silently taking the default.
 pub fn unique_track(
 	broadcast: &mut moq_net::broadcast::Producer,
 	suffix: &str,
+	info: moq_net::track::Info,
 ) -> crate::Result<moq_net::track::Producer> {
-	let info = hang::container::track_info();
 	Ok(broadcast.unique_track(suffix, info)?)
 }

--- a/rs/moq-mux/src/import/mod.rs
+++ b/rs/moq-mux/src/import/mod.rs
@@ -27,13 +27,23 @@ pub use track::*;
 
 /// Mint a fresh unique track for a legacy single-codec importer.
 ///
-/// Picks a unique name from `suffix` and applies `info`, so the relay gets timing without
-/// parsing the payload. Hand the result to the importer's `new`.
+/// Picks a unique name from `suffix` and applies [`hang::container::track_info`], so the
+/// relay gets timing without parsing the payload. Hand the result to the importer's `new`.
 ///
-/// Pass the catalog's own [`track_info`](crate::catalog::Producer::track_info) rather than
-/// `hang::container::track_info()` directly, so the track inherits whatever retention that
-/// catalog declares instead of silently taking the default.
+/// Use [`unique_track_with`] when a catalog is in scope, so the track inherits whatever
+/// retention that catalog declares rather than the default.
 pub fn unique_track(
+	broadcast: &mut moq_net::broadcast::Producer,
+	suffix: &str,
+) -> crate::Result<moq_net::track::Producer> {
+	unique_track_with(broadcast, suffix, hang::container::track_info())
+}
+
+/// [`unique_track`] with explicit track properties.
+///
+/// Pass the catalog's own [`track_info`](crate::catalog::Producer::track_info), so a broadcast
+/// that declared a non-default media retention actually gets it on every track it mints.
+pub fn unique_track_with(
 	broadcast: &mut moq_net::broadcast::Producer,
 	suffix: &str,
 	info: moq_net::track::Info,

--- a/rs/moq-mux/src/import/mod.rs
+++ b/rs/moq-mux/src/import/mod.rs
@@ -15,7 +15,9 @@
 //! own catalog rendition (see [`crate::catalog::VideoTrack`] /
 //! [`crate::catalog::AudioTrack`]).
 //!
-//! [`unique_track`] mints a track for the single-codec importers.
+//! A single-codec importer takes a track the caller mints, typically
+//! `broadcast.unique_track(suffix, catalog.track_info())`, so the retention the catalog
+//! declares reaches the track.
 
 mod container;
 mod init;
@@ -25,28 +27,13 @@ pub use container::*;
 pub use init::Init;
 pub use track::*;
 
-/// Mint a fresh unique track for a legacy single-codec importer.
-///
-/// Picks a unique name from `suffix` and applies [`hang::container::track_info`], so the
-/// relay gets timing without parsing the payload. Hand the result to the importer's `new`.
-///
-/// Use [`unique_track_with`] when a catalog is in scope, so the track inherits whatever
-/// retention that catalog declares rather than the default.
+#[doc(hidden)]
+#[deprecated(
+	note = "call broadcast.unique_track(suffix, info) directly, with the catalog's track_info() when one is in scope so a declared retention reaches the track"
+)]
 pub fn unique_track(
 	broadcast: &mut moq_net::broadcast::Producer,
 	suffix: &str,
 ) -> crate::Result<moq_net::track::Producer> {
-	unique_track_with(broadcast, suffix, hang::container::track_info())
-}
-
-/// [`unique_track`] with explicit track properties.
-///
-/// Pass the catalog's own [`track_info`](crate::catalog::Producer::track_info), so a broadcast
-/// that declared a non-default media retention actually gets it on every track it mints.
-pub fn unique_track_with(
-	broadcast: &mut moq_net::broadcast::Producer,
-	suffix: &str,
-	info: moq_net::track::Info,
-) -> crate::Result<moq_net::track::Producer> {
-	Ok(broadcast.unique_track(suffix, info)?)
+	Ok(broadcast.unique_track(suffix, hang::container::track_info())?)
 }

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -173,7 +173,7 @@ impl<E: CatalogExt> Track<E> {
 		// Accept at the legacy microsecond timescale, matching the frame timestamps
 		// the container stamps. A codec-specific timescale (e.g. the opus sample
 		// rate) would be chosen here instead.
-		let track = request.accept(hang::container::track_info());
+		let track = request.accept(reserved.track_info());
 		let data = init.data.as_ref();
 		let kind = match init.format.as_str() {
 			"avc1" | "avcc" => {
@@ -476,7 +476,7 @@ impl<E: CatalogExt> TrackStream<E> {
 	/// timescale would be chosen). A [`VideoHint`] carrying a codec publishes the catalog before the
 	/// first frame; any [`Init::data`] seeds the stream (as a call to [`initialize`](Self::initialize)).
 	pub fn new(request: moq_net::track::Request, reserved: crate::catalog::Reserved<E>, init: Init) -> Result<Self> {
-		let track = request.accept(hang::container::track_info());
+		let track = request.accept(reserved.track_info());
 		let hint = video_hint(&init, None);
 		// Only the self-delimiting codecs can be recovered from a raw byte stream.
 		let kind = match init.format.as_str() {

--- a/rs/moq-rtc/src/codec/av1.rs
+++ b/rs/moq-rtc/src/codec/av1.rs
@@ -15,7 +15,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish an `.av1` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track(&mut broadcast, ".av1", catalog.track_info())?;
+		let track = moq_mux::import::unique_track_with(&mut broadcast, ".av1", catalog.track_info())?;
 		let import = moq_mux::codec::av1::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::av1::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/av1.rs
+++ b/rs/moq-rtc/src/codec/av1.rs
@@ -15,7 +15,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish an `.av1` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track_with(&mut broadcast, ".av1", catalog.track_info())?;
+		let track = broadcast.unique_track(".av1", catalog.track_info())?;
 		let import = moq_mux::codec::av1::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::av1::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/av1.rs
+++ b/rs/moq-rtc/src/codec/av1.rs
@@ -15,7 +15,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish an `.av1` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track(&mut broadcast, ".av1")?;
+		let track = moq_mux::import::unique_track(&mut broadcast, ".av1", catalog.track_info())?;
 		let import = moq_mux::codec::av1::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::av1::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/h264.rs
+++ b/rs/moq-rtc/src/codec/h264.rs
@@ -14,7 +14,7 @@ pub struct Bridge {
 
 impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track_with(&mut broadcast, ".avc3", catalog.track_info())?;
+		let track = broadcast.unique_track(".avc3", catalog.track_info())?;
 		let import = moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::h264::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/h264.rs
+++ b/rs/moq-rtc/src/codec/h264.rs
@@ -14,7 +14,7 @@ pub struct Bridge {
 
 impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track(&mut broadcast, ".avc3")?;
+		let track = moq_mux::import::unique_track(&mut broadcast, ".avc3", catalog.track_info())?;
 		let import = moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::h264::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/h264.rs
+++ b/rs/moq-rtc/src/codec/h264.rs
@@ -14,7 +14,7 @@ pub struct Bridge {
 
 impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track(&mut broadcast, ".avc3", catalog.track_info())?;
+		let track = moq_mux::import::unique_track_with(&mut broadcast, ".avc3", catalog.track_info())?;
 		let import = moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::h264::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/h265.rs
+++ b/rs/moq-rtc/src/codec/h265.rs
@@ -16,7 +16,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish a `.hev1` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track_with(&mut broadcast, ".hev1", catalog.track_info())?;
+		let track = broadcast.unique_track(".hev1", catalog.track_info())?;
 		let import = moq_mux::codec::h265::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::h265::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/h265.rs
+++ b/rs/moq-rtc/src/codec/h265.rs
@@ -16,7 +16,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish a `.hev1` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track(&mut broadcast, ".hev1")?;
+		let track = moq_mux::import::unique_track(&mut broadcast, ".hev1", catalog.track_info())?;
 		let import = moq_mux::codec::h265::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::h265::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/h265.rs
+++ b/rs/moq-rtc/src/codec/h265.rs
@@ -16,7 +16,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish a `.hev1` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = moq_mux::import::unique_track(&mut broadcast, ".hev1", catalog.track_info())?;
+		let track = moq_mux::import::unique_track_with(&mut broadcast, ".hev1", catalog.track_info())?;
 		let import = moq_mux::codec::h265::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::h265::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -17,7 +17,7 @@ impl Bridge {
 		channel_count: u32,
 	) -> Result<Self> {
 		let config = moq_mux::codec::opus::Config::new(sample_rate, channel_count);
-		let track = moq_mux::import::unique_track(&mut broadcast, ".opus", catalog.track_info())?;
+		let track = moq_mux::import::unique_track_with(&mut broadcast, ".opus", catalog.track_info())?;
 		let import = moq_mux::codec::opus::Import::new(track, catalog.reserve(), config.into())?;
 		Ok(Self { import })
 	}

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -17,7 +17,7 @@ impl Bridge {
 		channel_count: u32,
 	) -> Result<Self> {
 		let config = moq_mux::codec::opus::Config::new(sample_rate, channel_count);
-		let track = moq_mux::import::unique_track_with(&mut broadcast, ".opus", catalog.track_info())?;
+		let track = broadcast.unique_track(".opus", catalog.track_info())?;
 		let import = moq_mux::codec::opus::Import::new(track, catalog.reserve(), config.into())?;
 		Ok(Self { import })
 	}

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -17,7 +17,7 @@ impl Bridge {
 		channel_count: u32,
 	) -> Result<Self> {
 		let config = moq_mux::codec::opus::Config::new(sample_rate, channel_count);
-		let track = moq_mux::import::unique_track(&mut broadcast, ".opus")?;
+		let track = moq_mux::import::unique_track(&mut broadcast, ".opus", catalog.track_info())?;
 		let import = moq_mux::codec::opus::Import::new(track, catalog.reserve(), config.into())?;
 		Ok(Self { import })
 	}

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -17,7 +17,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish a `.vp8` track on `broadcast`; the catalog rendition is added on the first frame.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.create_track(broadcast.unique_name(".vp8"), hang::container::track_info())?;
+		let track = broadcast.create_track(broadcast.unique_name(".vp8"), catalog.track_info())?;
 		let name = track.name().to_string();
 		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy)?;
 		Ok(Self {

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -16,7 +16,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish a `.vp9` track on `broadcast`; the catalog rendition is added on the first frame.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.create_track(broadcast.unique_name(".vp9"), hang::container::track_info())?;
+		let track = broadcast.create_track(broadcast.unique_name(".vp9"), catalog.track_info())?;
 		let name = track.name().to_string();
 		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy)?;
 		Ok(Self {

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -60,14 +60,14 @@ impl<E: CatalogExt> Producer<E> {
 	) -> Result<Self, Error> {
 		let codecs = match codec {
 			Codec::H264 => {
-				let track = moq_mux::import::unique_track(&mut broadcast, ".avc3", catalog.track_info())?;
+				let track = moq_mux::import::unique_track_with(&mut broadcast, ".avc3", catalog.track_info())?;
 				Codecs::H264 {
 					split: moq_mux::codec::h264::Split::new(),
 					import: moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?,
 				}
 			}
 			Codec::H265 => {
-				let track = moq_mux::import::unique_track(&mut broadcast, ".hev1", catalog.track_info())?;
+				let track = moq_mux::import::unique_track_with(&mut broadcast, ".hev1", catalog.track_info())?;
 				Codecs::H265 {
 					split: moq_mux::codec::h265::Split::new(),
 					import: moq_mux::codec::h265::Import::new(track, catalog.reserve(), Default::default())?,

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -60,14 +60,14 @@ impl<E: CatalogExt> Producer<E> {
 	) -> Result<Self, Error> {
 		let codecs = match codec {
 			Codec::H264 => {
-				let track = moq_mux::import::unique_track(&mut broadcast, ".avc3")?;
+				let track = moq_mux::import::unique_track(&mut broadcast, ".avc3", catalog.track_info())?;
 				Codecs::H264 {
 					split: moq_mux::codec::h264::Split::new(),
 					import: moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?,
 				}
 			}
 			Codec::H265 => {
-				let track = moq_mux::import::unique_track(&mut broadcast, ".hev1")?;
+				let track = moq_mux::import::unique_track(&mut broadcast, ".hev1", catalog.track_info())?;
 				Codecs::H265 {
 					split: moq_mux::codec::h265::Split::new(),
 					import: moq_mux::codec::h265::Import::new(track, catalog.reserve(), Default::default())?,

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -60,14 +60,14 @@ impl<E: CatalogExt> Producer<E> {
 	) -> Result<Self, Error> {
 		let codecs = match codec {
 			Codec::H264 => {
-				let track = moq_mux::import::unique_track_with(&mut broadcast, ".avc3", catalog.track_info())?;
+				let track = broadcast.unique_track(".avc3", catalog.track_info())?;
 				Codecs::H264 {
 					split: moq_mux::codec::h264::Split::new(),
 					import: moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?,
 				}
 			}
 			Codec::H265 => {
-				let track = moq_mux::import::unique_track_with(&mut broadcast, ".hev1", catalog.track_info())?;
+				let track = broadcast.unique_track(".hev1", catalog.track_info())?;
 				Codecs::H265 {
 					split: moq_mux::codec::h265::Split::new(),
 					import: moq_mux::codec::h265::Import::new(track, catalog.reserve(), Default::default())?,


### PR DESCRIPTION
## Summary

Three changes that together let a segmented egress (HLS/DASH) serve the playlist it advertises. Found while debugging a live HLS origin that showed a black screen in every browser player.

- **Media tracks declare a 30s `latency_max`.** A media track is the one thing on a broadcast read as HISTORY rather than followed at the live edge: a playlist may only advertise segments a FETCH can still reach, and a standard player starts several target durations behind live. moq-net's default is sized for a live-edge follower, so a playlist built over it named segments that were already gone.

  Declared per track rather than by raising `DEFAULT_LATENCY_MAX`, so the tracks that do NOT index history keep the cheap default: the catalog is snapshot mode and the timeline is a single never-rolled group, and in both the useful value is the live edge, which is retained unconditionally. It also avoids moving a cross-language constant (`js/net` carries its own copy and the encoded default is pinned byte-for-byte on both sides) for something already per-track on the wire.

  This does not make anyone play further behind live. `Info::latency_max` is a retention budget and a *ceiling* on what a subscriber may ask to wait for; `Subscription::latency_max` still defaults to zero (skip the moment a newer group arrives).

- **It is configurable, not hardcoded.** `catalog::Producer::with_latency_max` sets it; `track_info` / `track_info_at` mint from it and `Reserved` delegates, so the codec paths that hold only a reservation get the same policy. Every media-track site now goes through one of those rather than reaching for the constant — fMP4, MKV, TS (including the two inner streams that hold only a reservation), WHIP, and the native encoders. `moq import --latency-max` exposes it, defaulting to the same 30s. `unique_track` takes the info for the same reason: it has no catalog in scope and would otherwise silently keep the default.

- **A relayed cache miss was a 500, not a 404.** Root cause: `Rendition::segment` maps an evicted group to `Ok(None)` so the server can answer 404, but `is_cache_miss` matched only the local `NotFound` / `Old` / `Evicted` variants. `Error::from_transport` decodes an error that arrived off the wire as `Error::Remote(code)` and maps only code 0 back to a named variant (`Cancel`), so in a relay — where the publisher we FETCH from is always remote — a real miss arrives as `Remote(13)` and escaped the mapping. Every segment past the cache's retention 500'd, on every request. It now compares wire codes.

Measured against a live broadcast before the fix: 17 of 23 advertised segments returned 500. A browser player failed on each and never buffered a frame; ffmpeg hid the bug by tolerating the errors and skipping ahead to the segments that did serve.

### Memory

A relay bounds this by `cache::Pool` (bytes) and `cache.duration` (age); 30s is meant to sit under a deployment's ceiling rather than replace it. The pool evicts by access order and will reclaim *below* the declared age under pressure, so `latency_max` is a ceiling on retention rather than a guarantee — which is the other reason the 404 fix matters: the tail of any window races by construction.

## Public API changes

Additive in the published crates, so targeting `main`:

- **New** `hang::container::LATENCY_MAX` and `hang::container::track_info_at(Timescale)`. `track_info()` keeps its name, signature, and visibility; only the `Info` it returns gains a `latency_max`.
- **New** in `js/hang`: `Container.LATENCY_MAX_MS` and `Container.trackInfo()`.
- `moq-mux` (not a semver-published surface per CONTRIBUTING): new `catalog::Producer::{with_latency_max, latency_max, track_info, track_info_at}` and `Reserved::{track_info, track_info_at}`; `import::unique_track` takes the track `Info`.
- `is_cache_miss` is private.

Cross-Package Sync: the `rs/hang` container row is covered — `js/hang` gains the matching helper, wired into the media `accept()` in `js/publish` (the catalog accept keeps the bare defaults deliberately), and `doc/concept/layer/moq-lite.md` now notes that the window is per-track and what hang asks for. No draft pins a retention value, so no spec change. `DEFAULT_LATENCY_MAX` and the cross-language wire goldens are untouched.

## Test plan

- `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets`, `cargo fmt --check`: clean.
- `cargo test`: moq-mux 442, hang 46, moq-hls 59, moq-cli 14, plus doctests.
- `just js check`: clean (356 files).
- New `moq-mux` test pins that an override reaches every media track a catalog mints, through both constructors and through `Reserved`, without disturbing the timescale each pins. New `hang` tests pin the split both ways: media constructors carry `LATENCY_MAX` and exceed `DEFAULT_LATENCY_MAX`, and `Catalog::default_track_info()` still does not.
- New `moq-hls` regressions cover the miss in both shapes, through both `moq_mux` error wrappings, and assert genuine errors (`Unauthorized`, `ProtocolViolation`, `Timeout`) still surface rather than being swallowed into a 404.
- End to end on a live relay serving Big Buck Bunny as HLS: every advertised segment serves, and hls.js plays 1280x720 with a continuous ~32s buffer and no fatal errors. Before, the same setup was a black screen.

## Follow-ups, not in this PR

- **moq-hls should window off the track's real `latency_max`** (it holds the track handle) rather than a configured duration, so a publisher declaring *less* shrinks the playlist automatically. Doing it properly means awaiting TRACK_INFO in the rendition watcher, which can stall segment indexing.
- **The timeline should arguably be a snapshot, not an append-log.** It rides a single never-rolled group (effectively unbounded history) while the media it indexes ages out in seconds, so any consumer window is a duration guess bridging two unrelated things. A publisher-trimmed snapshot would let the window derive from truth and would remove the `Lagged` cliff a long-running broadcast eventually hits when that group outgrows its byte budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 5)

## Takeover update

Rebased onto `main` (was 32 commits behind), and fixed two things the review rounds circled without landing on:

- **The cache-miss classifier walks the error source chain** instead of matching container wrappings. Three review rounds each found another missing arm (`Cmaf`, then `Hang`, then `Hang` again for the legacy container). That is the code being the wrong shape, not three separate oversights: `moq_mux::Error` is `#[non_exhaustive]`, so the `_ => false` arm turns every container added later into the same 500. The chain walk is depth- and variant-independent. Tests now also pin that an error carrying no transport error at all is never a miss.
- **`--latency-max` is `Option<Duration>`.** It defaulted to `hang::container::LATENCY_MAX` and the guard compared against that constant to decide whether the user had asked for anything, which duplicated the 30s default (clap's `default_value` string plus the constant) and made `moq import --latency-max 30s rtmp` indistinguishable from an unset flag: accepted and ignored, the exact no-op the guard exists to stop. Verified both ways against the built binary. A new `moq-cli` test pins the unset/explicit/refused triple.
- **Filled the Cross-Package Sync row the flag skipped**: `doc/bin/cli.md` documents `import --latency-max`, and distinguishes it from the export sinks' same-named knob (the subscriber half of the same protocol pair, default `500ms`).

Verification: `just fix` + `just check` clean; `cargo check -p moq-cli --features capture --all-targets` clean (that feature is off by default and broke once already here); 565 tests pass across moq-hls / moq-cli / moq-mux / hang; `just js check` clean.

(written by Opus 5)


### API cleanup

The `_at` / `_with` variants and the public constants are gone. Both variants were redundant with builders `moq_net::track::Info` already has: `track_info_at(ts)` was a second spelling of `track_info().with_timescale(ts)`, and `unique_track_with` was `broadcast.unique_track(suffix, info)` with the error mapped. Each spent a name on a published crate for something the caller could chain.

Removed: `hang::container::track_info_at`, `catalog::Producer::{track_info_at, latency_max}`, `catalog::Reserved::track_info_at`, `import::unique_track_with`, and the exported `Container.LATENCY_MAX_MS`. `import::unique_track` had no callers left once the sites chained instead, so it is `#[doc(hidden)]` + `#[deprecated]` rather than a name still advertised.

`LATENCY_MAX` is private in both languages. Nothing outside hang needs to read it: `catalog::Producer` holds an `Option` and overrides only when set, moq-cli threads its own `Option` (unset means "publisher's default", which the guard already keys on), and `Container.trackInfo()` takes the override as a defaulted parameter. The number now lives in exactly one place per language rather than being a cross-language constant that two crates and a package reach for.

Net public surface for the whole feature:

- `hang::container::track_info()` -- unchanged signature, now carries the retention
- `moq_mux::catalog::Producer::{with_latency_max, track_info}`
- `moq_mux::catalog::Reserved::track_info`
- `Container.trackInfo(latencyMax?)` in `js/hang`
- `BroadcastInput.latencyMax` in `js/publish`, and `moq import --latency-max`

Re-verified after the reshape: `just fix` / `just check` clean, 670 tests pass across moq-hls / moq-cli / moq-mux / hang / moq-audio / moq-video, `cargo check -p moq-cli --features capture --all-targets` clean, `just js check` clean, and the CLI guard still refuses `--latency-max` on the gateways.

(written by Opus 5)


### Review round: the retention is a constructor argument now

Two P2 findings from the last Codex pass, both about shape rather than behavior.

**`with_latency_max` on a live producer let handles disagree.** It set a per-handle field, so a clone or a `reserve()` taken *before* the call kept the old value and quietly minted default-retention tracks under a catalog that reported the configured one. Every other piece of catalog state is shared across handles; this was the one that was not. No call site hits it today (they all configure immediately after construction), but nothing in the type made that mandatory.

It is a constructor argument now, in a `moq_mux::catalog::Config` that carries the initial catalog too. `Producer::with_config` is the real constructor and `new` / `with_catalog` delegate to it, so a divergent handle cannot be written. `Config::with_latency_max` takes an `Option`, which deletes moq-cli's `apply_latency_max` helper: unset is just the default. The bag is also where the next knob goes -- the JSON delta ratio and compression flags are still hardcoded in that constructor.

**`trackInfo(latencyMax)` was positional.** On a surface exported from `@moq/hang/container`, so the next track knob (priority, ordered delivery, a different retention unit) would have had to grow a second positional argument or break callers. It takes a `TrackInfoOptions` object now, before it is published.

Net change to the surface listed above: `moq_mux::catalog::{Config, Producer::with_config}` replace `Producer::with_latency_max`, and `Container.trackInfo(options?)` replaces the positional parameter.

Verified: `just fix` / `just check` clean, `RUSTDOCFLAGS=-D warnings cargo doc` clean on moq-mux + moq-cli, 517 Rust tests and 117 JS tests pass.

(written by Opus 5)
