### PR TITLE
feat(moq-net): specify the error code registries and split SessionError from StreamError

### DIFF
--- a/doc/lib/js/@moq/net.md
+++ b/doc/lib/js/@moq/net.md
@@ -92,6 +92,8 @@ if (err instanceof Moq.RemoteError && err.code === Moq.SessionCode.Unauthorized)
 }
 ```
 
+`Connection.closed` rejects with that same error when the reconnect loop gives up, and an `Unauthorized` close ends it immediately: the same credentials cannot start working, so retrying only burns the window. Every other close keeps retrying under the usual backoff.
+
 Errors this side detects keep their own messages, like the `Group.Lagged` a read throws after frames were evicted before it got to them.
 
 ### Authentication

--- a/doc/lib/js/@moq/net.md
+++ b/doc/lib/js/@moq/net.md
@@ -79,7 +79,9 @@ try {
 
 The code arrives the same way whether the session negotiated WebTransport or the WebSocket fallback, so nothing has to feature-detect `WebTransportError`.
 
-There are two code registries, and which one applies depends on what failed. A stream reset carries a `Moq.StreamCode`; a session close carries a `Moq.SessionCode`. They are disjoint, so the same number means different things in each: `0` ends a session cleanly but is an internal error on a stream, where a cancellation is `1`. Below 32 the codes are moq-transport's, with moq-transport's meaning; 32-63 are moq-lite's; 64 and up are yours.
+There are two code registries, and which one applies depends on what failed. A stream reset carries a `Moq.StreamCode`; a session close carries a `Moq.SessionCode`. They are disjoint, so the same number means different things in each: `0` ends a session cleanly but is an internal error on a stream, where a cancellation is `1`. Both tables reuse moq-transport's codes unchanged, and 64 and up are yours.
+
+Anything outside those tables is an unspecified error, so treat it as opaque rather than guessing. That includes 32-63, which the draft reserves: an implementation may send a code there for a condition the shared ones don't cover, but it carries no agreed meaning yet.
 
 A session close surfaces through `connection.closed`, which resolves with `null` for a clean close or a `Moq.RemoteError` when the peer sent a code:
 

--- a/doc/lib/js/@moq/net.md
+++ b/doc/lib/js/@moq/net.md
@@ -77,7 +77,18 @@ try {
 }
 ```
 
-The code arrives the same way whether the session negotiated WebTransport or the WebSocket fallback, so nothing has to feature-detect `WebTransportError`. The codes themselves are not standardized: each number means whatever the peer's implementation decided, so `@moq/net` hands it over without interpreting it. Code 0 is the exception worth knowing, since that is what a transport sends for a stream dropped or aborted with no code of its own.
+The code arrives the same way whether the session negotiated WebTransport or the WebSocket fallback, so nothing has to feature-detect `WebTransportError`.
+
+There are two code registries, and which one applies depends on what failed. A stream reset carries a `Moq.StreamCode`; a session close carries a `Moq.SessionCode`. They are disjoint, so the same number means different things in each: `0` ends a session cleanly but is an internal error on a stream, where a cancellation is `1`. Below 32 the codes are moq-transport's, with moq-transport's meaning; 32-63 are moq-lite's; 64 and up are yours.
+
+A session close surfaces through `connection.closed`, which resolves with `null` for a clean close or a `Moq.RemoteError` when the peer sent a code:
+
+```ts
+const err = await connection.closed;
+if (err instanceof Moq.RemoteError && err.code === Moq.SessionCode.Unauthorized) {
+	console.warn("server rejected the session:", err.message);
+}
+```
 
 Errors this side detects keep their own messages, like the `Group.Lagged` a read throws after frames were evicted before it got to them.
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -237,6 +237,70 @@ To terminate a stream, an endpoint may:
 After resetting the send direction, an endpoint MAY close the recv direction (STOP_SENDING).
 However, it is ultimately the other peer's responsibility to close their send direction.
 
+## Error Codes {#error-codes}
+There are two independent error code spaces, matching {{moqt}}: one for terminating the session and one for resetting a stream.
+The same numeric value means different things in each, so an endpoint MUST select the code from the space matching what it is terminating.
+
+Each space is divided into three ranges:
+
+| Range | Assigned by | Description |
+| ------- | ------------- | ----------- |
+|  0-31   | {{moqt}} | Used unchanged, with the meaning {{moqt}} assigns. |
+| ------- | ------------- | ----------- |
+|  32-63  | moq-lite | Specific to moq-lite; listed below. |
+| ------- | ------------- | ----------- |
+|  64+    | the application | Opaque to moq-lite. |
+| ------- | ------------- | ----------- |
+
+Sharing the low range means an endpoint that speaks both protocols has one vocabulary, and a relay can forward a peer's code without translating it.
+An endpoint MUST NOT assign a moq-lite specific meaning to a code below 32.
+
+An endpoint MUST ignore a code it does not recognize, treating it as an unspecified error.
+An endpoint MUST NOT infer a meaning for an unregistered code; in particular, it MUST NOT assume a code is an authorization failure unless it is UNAUTHORIZED.
+
+### Session Error Codes
+Sent when terminating the session, via the transport's session close.
+
+The following {{moqt}} session codes are used unchanged: NO_ERROR (0x0), INTERNAL_ERROR (0x1), UNAUTHORIZED (0x2), PROTOCOL_VIOLATION (0x3), KEY_VALUE_FORMATTING_ERROR (0x6), GOAWAY_TIMEOUT (0x10), CONTROL_MESSAGE_TIMEOUT (0x11), and VERSION_NEGOTIATION_FAILED (0x15).
+
+moq-lite adds:
+
+| Code | Name | Description |
+| ------- | ------------- | ----------- |
+|  0x20  | Required Extension | A required extension was not offered by the peer. |
+| ------- | ------------- | ----------- |
+|  0x21  | Invalid Role | The peer acted against the role it advertised in SETUP. |
+| ------- | ------------- | ----------- |
+|  0x22  | Unexpected Stream | A stream was opened with an unknown or disallowed type. |
+| ------- | ------------- | ----------- |
+
+### Stream Error Codes
+Sent when resetting a stream (RESET_STREAM), or when refusing to receive one (STOP_SENDING).
+
+The following {{moqt}} stream codes are used unchanged: INTERNAL_ERROR (0x0), CANCELED (0x1), DELIVERY_TIMEOUT (0x2), SESSION_CLOSED (0x3), GOING_AWAY (0x4), TOO_FAR_BEHIND (0x5), and MALFORMED_TRACK (0x12).
+
+Note that CANCELED is 0x1, not 0x0: a stream reset with 0x0 is an INTERNAL_ERROR, not a routine cancellation.
+An endpoint terminating a stream because the session is ending SHOULD use SESSION_CLOSED rather than the session's own code, since the two spaces are disjoint.
+
+moq-lite adds:
+
+| Code | Name | Description |
+| ------- | ------------- | ----------- |
+|  0x20  | Not Found | The requested broadcast or track does not exist. |
+| ------- | ------------- | ----------- |
+|  0x21  | Unroutable | The broadcast is neither announced nor served, so there is no route to it. |
+| ------- | ------------- | ----------- |
+|  0x22  | Old | The group was superseded by a newer group and dropped. See [Expiration](#expiration). |
+| ------- | ------------- | ----------- |
+|  0x23  | Evicted | The group was dropped under memory pressure. Unlike Old it was still current, so it MAY be re-fetched. |
+| ------- | ------------- | ----------- |
+|  0x24  | Wrong Size | A frame's payload length disagreed with its declared size. |
+| ------- | ------------- | ----------- |
+|  0x25  | Frame Too Large | A frame declared a payload larger than the receiver accepts. |
+| ------- | ------------- | ----------- |
+|  0x26  | Timestamp Mismatch | A frame's timestamp did not match the track's negotiated timescale. |
+| ------- | ------------- | ----------- |
+
 ## Handshake
 See the [Session](#session) section for ALPN negotiation and session activation details.
 
@@ -1275,6 +1339,7 @@ The `Message Length` describes the payload size on the wire.
 - Capped the GOAWAY New Session URI at 8,192 bytes, matching moq-transport.
 - Restricted the GOAWAY New Session URI to servers, specified a duplicate GOAWAY as a protocol violation, and recommended scheme continuity and sticky redirects.
 - Exempted a ceiling-cost serving path from the actively-carrying cost discount: a relay whose serving path costs the saturation ceiling (primarily a session that received a GOAWAY) advertises the ceiling instead of 0, so the drain propagates downstream instead of being re-masked by each carrying hop. Keyed on the value, not the reason, which does not travel on the wire.
+- Added the Error Codes section, defining separate session and stream code spaces, each split into three ranges: 0-31 assigned by moq-transport and used unchanged, 32-63 specific to moq-lite, and 64+ opaque application codes. Previously the codes were unspecified, so an endpoint could neither send one a peer would understand nor safely interpret one it received. Note this renumbers every code an existing implementation sent, and that a stream reset of 0x0 is now INTERNAL_ERROR rather than a cancellation (CANCELED is 0x1).
 
 ## moq-lite-05
 - Renamed ANNOUNCE_INTEREST to ANNOUNCE_REQUEST and ANNOUNCE to ANNOUNCE_BROADCAST.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -238,68 +238,64 @@ After resetting the send direction, an endpoint MAY close the recv direction (ST
 However, it is ultimately the other peer's responsibility to close their send direction.
 
 ## Error Codes {#error-codes}
-There are two independent error code spaces, matching {{moqt}}: one for terminating the session and one for resetting a stream.
+There are two independent error code spaces, one for terminating the session and one for resetting a stream.
 The same numeric value means different things in each, so an endpoint MUST select the code from the space matching what it is terminating.
 
-Each space is divided into three ranges:
+Both spaces reuse the codes moq-transport assigns, unchanged and with the same meaning, so an endpoint that speaks both protocols has one vocabulary and a relay can forward a peer's code without translating it.
+The codes moq-lite uses are listed in full below; an endpoint MUST NOT assign a moq-lite specific meaning to any code below 32.
 
-| Range | Assigned by | Description |
-| ------- | ------------- | ----------- |
-|  0-31   | {{moqt}} | Used unchanged, with the meaning {{moqt}} assigns. |
-| ------- | ------------- | ----------- |
-|  32-63  | moq-lite | Specific to moq-lite; listed below. |
-| ------- | ------------- | ----------- |
-|  64+    | the application | Opaque to moq-lite. |
-| ------- | ------------- | ----------- |
-
-Sharing the low range means an endpoint that speaks both protocols has one vocabulary, and a relay can forward a peer's code without translating it.
-An endpoint MUST NOT assign a moq-lite specific meaning to a code below 32.
-
+Codes 64 and above are the application's, opaque to moq-lite.
 An endpoint MUST ignore a code it does not recognize, treating it as an unspecified error.
 An endpoint MUST NOT infer a meaning for an unregistered code; in particular, it MUST NOT assume a code is an authorization failure unless it is UNAUTHORIZED.
+
+Codes 32 through 63 are reserved and MUST NOT be interpreted.
+Implementations currently emit values in this range for conditions with no code above, but those values are provisional placeholders, not assignments: a receiver MUST treat one as an unspecified error, exactly as it would any other unregistered code.
+A future revision will assign this range, or fold the conditions into the shared codes.
 
 ### Session Error Codes
 Sent when terminating the session, via the transport's session close.
 
-The following {{moqt}} session codes are used unchanged: NO_ERROR (0x0), INTERNAL_ERROR (0x1), UNAUTHORIZED (0x2), PROTOCOL_VIOLATION (0x3), KEY_VALUE_FORMATTING_ERROR (0x6), GOAWAY_TIMEOUT (0x10), CONTROL_MESSAGE_TIMEOUT (0x11), and VERSION_NEGOTIATION_FAILED (0x15).
-
-moq-lite adds:
-
 | Code | Name | Description |
 | ------- | ------------- | ----------- |
-|  0x20  | Required Extension | A required extension was not offered by the peer. |
+|  0x0   | NO_ERROR | The session was terminated without error. |
 | ------- | ------------- | ----------- |
-|  0x21  | Invalid Role | The peer acted against the role it advertised in SETUP. |
+|  0x1   | INTERNAL_ERROR | An implementation-specific error. |
 | ------- | ------------- | ----------- |
-|  0x22  | Unexpected Stream | A stream was opened with an unknown or disallowed type. |
+|  0x2   | UNAUTHORIZED | The endpoint is not authorized to establish the session, or to perform an operation on it. |
+| ------- | ------------- | ----------- |
+|  0x3   | PROTOCOL_VIOLATION | The peer violated this specification. |
+| ------- | ------------- | ----------- |
+|  0x6   | KEY_VALUE_FORMATTING_ERROR | A key-value pair was malformed, or repeated more than allowed. |
+| ------- | ------------- | ----------- |
+|  0x10  | GOAWAY_TIMEOUT | The peer did not close within the GOAWAY drain deadline. |
+| ------- | ------------- | ----------- |
+|  0x11  | CONTROL_MESSAGE_TIMEOUT | The peer took too long to respond to a control message. |
+| ------- | ------------- | ----------- |
+|  0x15  | VERSION_NEGOTIATION_FAILED | No version could be negotiated. |
 | ------- | ------------- | ----------- |
 
 ### Stream Error Codes
 Sent when resetting a stream (RESET_STREAM), or when refusing to receive one (STOP_SENDING).
 
-The following {{moqt}} stream codes are used unchanged: INTERNAL_ERROR (0x0), CANCELED (0x1), DELIVERY_TIMEOUT (0x2), SESSION_CLOSED (0x3), GOING_AWAY (0x4), TOO_FAR_BEHIND (0x5), and MALFORMED_TRACK (0x12).
-
-Note that CANCELED is 0x1, not 0x0: a stream reset with 0x0 is an INTERNAL_ERROR, not a routine cancellation.
-An endpoint terminating a stream because the session is ending SHOULD use SESSION_CLOSED rather than the session's own code, since the two spaces are disjoint.
-
-moq-lite adds:
-
 | Code | Name | Description |
 | ------- | ------------- | ----------- |
-|  0x20  | Not Found | The requested broadcast or track does not exist. |
+|  0x0   | INTERNAL_ERROR | An implementation-specific error. |
 | ------- | ------------- | ----------- |
-|  0x21  | Unroutable | The broadcast is neither announced nor served, so there is no route to it. |
+|  0x1   | CANCELLED | The stream was cancelled by either endpoint. A routine unsubscribe. |
 | ------- | ------------- | ----------- |
-|  0x22  | Old | The group was superseded by a newer group and dropped. See [Expiration](#expiration). |
+|  0x2   | DELIVERY_TIMEOUT | The content missed its delivery deadline. |
 | ------- | ------------- | ----------- |
-|  0x23  | Evicted | The group was dropped under memory pressure. Unlike Old it was still current, so it MAY be re-fetched. |
+|  0x3   | SESSION_CLOSED | The session is closing, taking this stream with it. |
 | ------- | ------------- | ----------- |
-|  0x24  | Wrong Size | A frame's payload length disagreed with its declared size. |
+|  0x4   | GOING_AWAY | A GOAWAY was sent or received. |
 | ------- | ------------- | ----------- |
-|  0x25  | Frame Too Large | A frame declared a payload larger than the receiver accepts. |
+|  0x5   | TOO_FAR_BEHIND | The reader fell too far behind and content was dropped to catch up. |
 | ------- | ------------- | ----------- |
-|  0x26  | Timestamp Mismatch | A frame's timestamp did not match the track's negotiated timescale. |
+|  0x12  | MALFORMED_TRACK | The track's content could not be parsed. |
 | ------- | ------------- | ----------- |
+
+Note that CANCELLED is 0x1, not 0x0: a stream reset with 0x0 is an INTERNAL_ERROR, not a routine cancellation.
+An endpoint terminating a stream because the session is ending SHOULD use SESSION_CLOSED rather than the session's own code, since the two spaces are disjoint.
 
 ## Handshake
 See the [Session](#session) section for ALPN negotiation and session activation details.
@@ -1339,7 +1335,7 @@ The `Message Length` describes the payload size on the wire.
 - Capped the GOAWAY New Session URI at 8,192 bytes, matching moq-transport.
 - Restricted the GOAWAY New Session URI to servers, specified a duplicate GOAWAY as a protocol violation, and recommended scheme continuity and sticky redirects.
 - Exempted a ceiling-cost serving path from the actively-carrying cost discount: a relay whose serving path costs the saturation ceiling (primarily a session that received a GOAWAY) advertises the ceiling instead of 0, so the drain propagates downstream instead of being re-masked by each carrying hop. Keyed on the value, not the reason, which does not travel on the wire.
-- Added the Error Codes section, defining separate session and stream code spaces, each split into three ranges: 0-31 assigned by moq-transport and used unchanged, 32-63 specific to moq-lite, and 64+ opaque application codes. Previously the codes were unspecified, so an endpoint could neither send one a peer would understand nor safely interpret one it received. Note this renumbers every code an existing implementation sent, and that a stream reset of 0x0 is now INTERNAL_ERROR rather than a cancellation (CANCELED is 0x1).
+- Added the Error Codes section, defining separate session and stream code spaces and listing the codes moq-lite uses, reused unchanged from moq-transport. Codes 64+ are the application's; 32-63 are reserved and MUST NOT be interpreted, pending a future revision. Previously the codes were unspecified, so an endpoint could neither send one a peer would understand nor safely interpret one it received. Note this renumbers every code an existing implementation sent, and that a stream reset of 0x0 is now INTERNAL_ERROR rather than a cancellation (CANCELLED is 0x1).
 
 ## moq-lite-05
 - Renamed ANNOUNCE_INTEREST to ANNOUNCE_REQUEST and ANNOUNCE to ANNOUNCE_BROADCAST.

--- a/js/net/src/connection/established.ts
+++ b/js/net/src/connection/established.ts
@@ -63,6 +63,10 @@ export interface Established {
 	/** Close the session. */
 	close(): void;
 
-	/** Resolves when the session closes. */
-	closed: Promise<void>;
+	/**
+	 * Resolves when the session closes: `null` for a clean close, a `RemoteError` when the
+	 * peer closed with a code (e.g. `SessionCode.Unauthorized` for an auth rejection), or the
+	 * transport's own failure. Never rejects.
+	 */
+	closed: Promise<Error | null>;
 }

--- a/js/net/src/connection/reload.test.ts
+++ b/js/net/src/connection/reload.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
+import { Effect } from "@moq/signals";
 import { Producer as BroadcastProducer } from "../broadcast.ts";
+import { RemoteError, SessionCode } from "../error.ts";
 import * as Lite from "../lite/index.ts";
 import { createMockTransportPair } from "../mock.ts";
 import * as Path from "../path.ts";
@@ -171,6 +173,53 @@ test("announcedBroadcast follows the reconnect loop", async () => {
 		reload.close();
 		for (const broadcast of published) broadcast.close();
 		for (const session of sessions) session.close();
+		globalThis.WebTransport = original;
+	}
+});
+
+test("a session closed with a code surfaces it to the app, and still reconnects", async () => {
+	const original = globalThis.WebTransport;
+	const url = new URL("https://example.com/");
+	const closes: (Error | null)[] = [];
+	const stub = function StubWebTransport() {
+		const pair = createMockTransportPair(Lite.ALPN_06_WIP);
+		// Reject at the MoQ layer: accept the transport, then close with a code, the
+		// way a relay's Request::close does after it has already accepted the transport.
+		void accept(pair.server, url).then(() => {
+			pair.server.close({ closeCode: SessionCode.Unauthorized, reason: "unauthorized" });
+		});
+		return pair.client;
+	};
+	globalThis.WebTransport = stub as unknown as typeof WebTransport;
+
+	const reload = new Reload({
+		enabled: true,
+		url,
+		websocket: { enabled: false },
+		delay: { initial: 1, multiplier: 2, max: 1, timeout: 0 },
+	});
+	const watch = new Effect();
+	watch.run((effect) => {
+		const conn = effect.get(reload.established);
+		if (conn) {
+			effect.spawn(async () => {
+				closes.push(await conn.closed);
+			});
+		}
+	});
+
+	try {
+		// The code reaches the app verbatim rather than being flattened away. What it
+		// means is between the app and its peer, so the loop keeps reconnecting: the
+		// library has no basis to call an arbitrary code terminal.
+		await Bun.sleep(50);
+		const err = closes.find((e) => e instanceof RemoteError);
+		expect(err).toBeInstanceOf(RemoteError);
+		expect((err as RemoteError).code).toBe(SessionCode.Unauthorized);
+		expect(closes.length).toBeGreaterThan(1);
+	} finally {
+		watch.close();
+		reload.close();
 		globalThis.WebTransport = original;
 	}
 });

--- a/js/net/src/connection/reload.test.ts
+++ b/js/net/src/connection/reload.test.ts
@@ -177,7 +177,7 @@ test("announcedBroadcast follows the reconnect loop", async () => {
 	}
 });
 
-test("a session closed with a code surfaces it to the app, and still reconnects", async () => {
+test("a session rejected as unauthorized surfaces the code and stops retrying", async () => {
 	const original = globalThis.WebTransport;
 	const url = new URL("https://example.com/");
 	const closes: (Error | null)[] = [];
@@ -209,14 +209,19 @@ test("a session closed with a code surfaces it to the app, and still reconnects"
 	});
 
 	try {
-		// The code reaches the app verbatim rather than being flattened away. What it
-		// means is between the app and its peer, so the loop keeps reconnecting: the
-		// library has no basis to call an arbitrary code terminal.
-		await Bun.sleep(50);
-		const err = closes.find((e) => e instanceof RemoteError);
+		// The code reaches the app rather than being flattened away, and because
+		// UNAUTHORIZED is specified rather than guessed at, the loop treats it as terminal
+		// instead of retrying credentials that cannot work. `timeout: 0` means unlimited
+		// retries, so `closed` settling at all is what proves it stopped on the rejection.
+		const err = await reload.closed.then(
+			() => undefined,
+			(err: unknown) => err,
+		);
 		expect(err).toBeInstanceOf(RemoteError);
 		expect((err as RemoteError).code).toBe(SessionCode.Unauthorized);
-		expect(closes.length).toBeGreaterThan(1);
+
+		// It still surfaced through the established session before the loop gave up.
+		expect(closes.find((e) => e instanceof RemoteError)).toBeInstanceOf(RemoteError);
 	} finally {
 		watch.close();
 		reload.close();

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -173,12 +173,13 @@ export class Reload {
 				connected = performance.now();
 
 				// A cancelled effect resolves undefined, so the sentinel tells the session
-				// closing apart from this run being torn down.
-				const closed = await Promise.race([effect.cancel, connection.closed.then(() => true)]);
-				if (!closed) return;
+				// closing (null for clean, an Error otherwise) apart from this run being
+				// torn down.
+				const closed = await Promise.race([effect.cancel, connection.closed]);
+				if (closed === undefined) return;
 
 				console.warn("connection closed, reconnecting");
-				this.#retry(effect, connected);
+				this.#retry(effect, connected, closed ?? undefined);
 			} catch (err) {
 				// Treat teardown as cancellation, not a connection failure.
 				if (signal.aborted) return;

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -1,5 +1,6 @@
 import { Effect, type Getter, Signal } from "@moq/signals";
 import * as Announce from "../announced.ts";
+import { RemoteError, SessionCode } from "../error.ts";
 import type * as Path from "../path.ts";
 import { empty as emptyPath } from "../path.ts";
 import { type ConnectProps, connect, type WebSocketOptions, type WebTransportProps } from "./connect.ts";
@@ -208,6 +209,16 @@ export class Reload {
 		if (connected !== undefined && performance.now() - connected >= this.delay.initial) {
 			this.#delay = this.delay.initial;
 			this.#retryStart = undefined;
+		}
+
+		// An auth rejection is terminal however long the session lived. UNAUTHORIZED is a
+		// specified code rather than one we guessed at, so this is the peer saying these
+		// credentials will never work; retrying them just burns the window. Matches
+		// moq-native's reconnect loop, which stops on the same close.
+		if (cause instanceof RemoteError && cause.code === SessionCode.Unauthorized) {
+			console.warn("session rejected as unauthorized, not retrying");
+			this.#closedReject(cause);
+			return;
 		}
 
 		// Track retry start for timeout.

--- a/js/net/src/error.test.ts
+++ b/js/net/src/error.test.ts
@@ -1,18 +1,26 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { StreamError } from "@moq/qmux";
-import { fromClose, fromTransport, RemoteError, reason, SessionCode, StreamCode } from "./error.ts";
+import { fromClose, fromTransport, RemoteError, reason, SessionCode, StreamCode, toTransport } from "./error.ts";
 
-// Minimal stand-in for the DOM WebTransportError, which the test runtime may not define.
+// Stand-in for the DOM WebTransportError, which the test runtime may not define. The
+// constructor mirrors the real `(message, options)` signature rather than a convenient one,
+// since code under test calls it: a differently-shaped stub silently passes arguments to the
+// wrong fields and reports a correct caller as broken.
 class FakeWebTransportError extends Error {
 	readonly source: string;
 	readonly streamErrorCode: number | null;
 
-	constructor(source: string, streamErrorCode: number | null, message = "") {
-		super(message);
+	constructor(message?: string, options?: { source?: string; streamErrorCode?: number | null }) {
+		super(message ?? "");
 		this.name = "WebTransportError";
-		this.source = source;
-		this.streamErrorCode = streamErrorCode;
+		this.source = options?.source ?? "stream";
+		this.streamErrorCode = options?.streamErrorCode ?? null;
 	}
+}
+
+/** The old positional shape, kept so the existing cases stay readable. */
+function fake(source: string, streamErrorCode: number | null, message = ""): FakeWebTransportError {
+	return new FakeWebTransportError(message, { source, streamErrorCode });
 }
 
 const globals = globalThis as { WebTransportError?: unknown };
@@ -29,7 +37,7 @@ afterEach(() => {
 });
 
 test("fromTransport: a stream reset keeps the peer's code verbatim", () => {
-	const src = new FakeWebTransportError("stream", 2);
+	const src = fake("stream", 2);
 	const err = fromTransport(src);
 	expect(err).toBeInstanceOf(RemoteError);
 	expect((err as RemoteError).code).toBe(2);
@@ -41,7 +49,7 @@ test("fromTransport: a stream reset keeps the peer's code verbatim", () => {
 test("fromTransport: code 0 is a code like any other", () => {
 	// 0 is what a transport sends for a stream dropped with no code of its own. What it
 	// means is up to the peer, so it gets no special treatment here.
-	expect((fromTransport(new FakeWebTransportError("stream", 0)) as RemoteError).code).toBe(0);
+	expect((fromTransport(fake("stream", 0)) as RemoteError).code).toBe(0);
 });
 
 test("fromTransport: decodes a fallback error with no WebTransportError global", () => {
@@ -54,7 +62,7 @@ test("fromTransport: decodes a fallback error with no WebTransportError global",
 });
 
 test("fromTransport: a session failure has no stream code, so it passes through", () => {
-	const src = new FakeWebTransportError("session", null, "connection lost");
+	const src = fake("session", null, "connection lost");
 	expect(fromTransport(src)).toBe(src);
 });
 
@@ -80,17 +88,15 @@ test("reason: empty message falls back to the type name", () => {
 
 test("reason: WebTransportError with a blank message surfaces source and code", () => {
 	// The Safari case from the bug report: a RESET_STREAM with no message.
-	expect(reason(new FakeWebTransportError("stream", 0))).toBe("WebTransportError: source=stream code=0");
+	expect(reason(fake("stream", 0))).toBe("WebTransportError: source=stream code=0");
 });
 
 test("reason: WebTransportError omits a null stream error code", () => {
-	expect(reason(new FakeWebTransportError("session", null))).toBe("WebTransportError: source=session");
+	expect(reason(fake("session", null))).toBe("WebTransportError: source=session");
 });
 
 test("reason: WebTransportError keeps a populated message and appends details", () => {
-	expect(reason(new FakeWebTransportError("stream", 42, "Received RESET_STREAM."))).toBe(
-		"Received RESET_STREAM. (source=stream code=42)",
-	);
+	expect(reason(fake("stream", 42, "Received RESET_STREAM."))).toBe("Received RESET_STREAM. (source=stream code=42)");
 });
 
 test("reason: a decoded remote error names its code", () => {
@@ -140,4 +146,29 @@ test("fromTransport: decodes a real qmux stream reset", () => {
 	const err = fromTransport(new StreamError(2, "RESET_STREAM"));
 	expect(err).toBeInstanceOf(RemoteError);
 	expect((err as RemoteError).code).toBe(2);
+});
+
+// The transports read the reset code off a WebTransportError's `streamErrorCode` and send 0
+// for anything else. 0 is INTERNAL_ERROR, so cancelling with a bare Error tells the peer we
+// failed: every routine unsubscribe would land as a publisher-side error rather than a cancel.
+test("toTransport: carries a code the transports will actually send", () => {
+	const reason = toTransport(StreamCode.Cancel, "cancel");
+	expect((reason as unknown as { source: string }).source).toBe("stream");
+	expect((reason as unknown as { streamErrorCode: number }).streamErrorCode).toBe(StreamCode.Cancel);
+
+	// A plain Error carries nothing, which is what makes the mistake silent.
+	expect(fromTransport(new Error("cancel"))).not.toBeInstanceOf(RemoteError);
+
+	// Round trip: what we send is what a peer decodes.
+	const decoded = fromTransport(reason);
+	expect(decoded).toBeInstanceOf(RemoteError);
+	expect((decoded as RemoteError).code).toBe(StreamCode.Cancel);
+	expect((decoded as RemoteError).code).not.toBe(StreamCode.Internal);
+});
+
+// Without the global, the fallback must still produce the shape qmux and fromTransport read.
+test("toTransport: works with no WebTransportError global", () => {
+	globals.WebTransportError = undefined;
+	const decoded = fromTransport(toTransport(StreamCode.TooFarBehind, "lagged"));
+	expect((decoded as RemoteError).code).toBe(StreamCode.TooFarBehind);
 });

--- a/js/net/src/error.test.ts
+++ b/js/net/src/error.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { StreamError } from "@moq/qmux";
-import { fromTransport, RemoteError, reason } from "./error.ts";
+import { fromClose, fromTransport, RemoteError, reason, SessionCode, StreamCode } from "./error.ts";
 
 // Minimal stand-in for the DOM WebTransportError, which the test runtime may not define.
 class FakeWebTransportError extends Error {
@@ -95,6 +95,42 @@ test("reason: WebTransportError keeps a populated message and appends details", 
 
 test("reason: a decoded remote error names its code", () => {
 	expect(reason(new RemoteError(31))).toBe("remote error: 31");
+});
+
+test("fromClose: a clean close is null, a coded close keeps its code", () => {
+	expect(fromClose({ closeCode: SessionCode.Cancel, reason: "" })).toBeNull();
+	// A missing code is what a transport reports for a close with no code of its own.
+	expect(fromClose({})).toBeNull();
+
+	const err = fromClose({ closeCode: SessionCode.Unauthorized, reason: "unauthorized" });
+	expect(err).toBeInstanceOf(RemoteError);
+	expect(err?.code).toBe(0x2);
+	expect(err?.message).toBe("remote error: 2 (unauthorized)");
+
+	expect(fromClose({ closeCode: SessionCode.GoawayTimeout })?.message).toBe("remote error: 16");
+});
+
+// The two registries are wire contracts (draft-lcurley-moq-lite, Error Codes) and must match
+// the Rust tables, since the two implementations talk to each other.
+test("the code tables match the spec", () => {
+	// moq-transport's, reused unchanged.
+	expect(SessionCode.Cancel).toBe(0x0);
+	expect(SessionCode.Unauthorized).toBe(0x2);
+	expect(SessionCode.GoawayTimeout).toBe(0x10);
+	expect(SessionCode.Version).toBe(0x15);
+	expect(StreamCode.Cancel).toBe(0x1);
+	expect(StreamCode.SessionClosed).toBe(0x3);
+	expect(StreamCode.TooFarBehind).toBe(0x5);
+
+	// Ours sit in the moq-lite range, clear of both moq-transport and the app range.
+	for (const code of [SessionCode.RequiredExtension, StreamCode.Old, StreamCode.Evicted]) {
+		expect(code).toBeGreaterThanOrEqual(32);
+		expect(code).toBeLessThan(64);
+	}
+
+	// The spaces are disjoint: 0 ends a session cleanly but fails a stream.
+	expect(SessionCode.Cancel).not.toBe(StreamCode.Cancel);
+	expect(StreamCode.Internal).toBe(0x0);
 });
 
 test("fromTransport: decodes a real qmux stream reset", () => {

--- a/js/net/src/error.test.ts
+++ b/js/net/src/error.test.ts
@@ -122,10 +122,10 @@ test("the code tables match the spec", () => {
 	expect(StreamCode.SessionClosed).toBe(0x3);
 	expect(StreamCode.TooFarBehind).toBe(0x5);
 
-	// Ours sit in the moq-lite range, clear of both moq-transport and the app range.
-	for (const code of [SessionCode.RequiredExtension, StreamCode.Old, StreamCode.Evicted]) {
-		expect(code).toBeGreaterThanOrEqual(32);
-		expect(code).toBeLessThan(64);
+	// The tables carry only what the draft assigns. 32-63 is reserved, so a code there is
+	// something an implementation happens to send, not a meaning to publish.
+	for (const code of [...Object.values(SessionCode), ...Object.values(StreamCode)]) {
+		expect(code).toBeLessThan(32);
 	}
 
 	// The spaces are disjoint: 0 ends a session cleanly but fails a stream.

--- a/js/net/src/error.ts
+++ b/js/net/src/error.ts
@@ -7,9 +7,13 @@
 /**
  * Codes a peer sends when terminating the session, mirroring the Rust `SessionError`.
  *
- * Specified by moq-lite: 0-31 are moq-transport's codes with moq-transport's meaning,
- * 32-63 are moq-lite's, and 64+ are the application's. {@link StreamCode} is the other
- * registry, and the two are disjoint, so the same integer means different things in each.
+ * Specified by moq-lite, which reuses moq-transport's codes unchanged; 64 and up are the
+ * application's. {@link StreamCode} is the other registry, and the two are disjoint, so the
+ * same integer means different things in each.
+ *
+ * Codes 32-63 are reserved rather than assigned. An implementation may send one for a
+ * condition with no code here, but the draft gives it no meaning, so treat anything not
+ * listed below as an unspecified error rather than guessing.
  *
  * @public
  */
@@ -30,12 +34,6 @@ export const SessionCode = {
 	Timeout: 0x11,
 	/** No version could be negotiated. */
 	Version: 0x15,
-	/** A required extension was not offered. */
-	RequiredExtension: 0x20,
-	/** The peer acted against the role it advertised at SETUP. */
-	InvalidRole: 0x21,
-	/** A stream was opened with an unknown or disallowed type. */
-	UnexpectedStream: 0x22,
 } as const;
 
 /** A session termination code. See {@link SessionCode}. */
@@ -46,6 +44,8 @@ export type SessionCode = (typeof SessionCode)[keyof typeof SessionCode];
  *
  * The counterpart to {@link SessionCode}, and a disjoint space: a stream reset of 0 is
  * {@link StreamCode.Internal}, not a cancellation ({@link StreamCode.Cancel} is 1).
+ *
+ * Codes 32-63 are reserved rather than assigned, same as {@link SessionCode}.
  *
  * @public
  */
@@ -64,20 +64,6 @@ export const StreamCode = {
 	TooFarBehind: 0x5,
 	/** The track's content could not be parsed. */
 	MalformedTrack: 0x12,
-	/** The requested broadcast or track does not exist. */
-	NotFound: 0x20,
-	/** The broadcast is neither announced nor served, so there is no route to it. */
-	Unroutable: 0x21,
-	/** The group was superseded by a newer group and dropped. */
-	Old: 0x22,
-	/** The group was dropped under memory pressure; unlike Old, it can be re-fetched. */
-	Evicted: 0x23,
-	/** A frame's payload length disagreed with its declared size. */
-	WrongSize: 0x24,
-	/** A frame declared a payload larger than the receiver accepts. */
-	FrameTooLarge: 0x25,
-	/** A frame's timestamp doesn't match its track's negotiated timescale. */
-	TimestampMismatch: 0x26,
 } as const;
 
 /** A stream reset code. See {@link StreamCode}. */
@@ -97,7 +83,7 @@ export type StreamCode = (typeof StreamCode)[keyof typeof StreamCode];
  * try {
  *   frame = await group.readFrame();
  * } catch (err) {
- *   if (err instanceof RemoteError && err.code === StreamCode.Old) return;
+ *   if (err instanceof RemoteError && err.code === StreamCode.Cancel) return;
  *   throw err;
  * }
  * ```

--- a/js/net/src/error.ts
+++ b/js/net/src/error.ts
@@ -1,26 +1,103 @@
 /**
- * Errors, including the code a peer reports when it resets a stream.
+ * Errors, including the code a peer reports when it resets a stream or closes the session.
  *
  * @module
  */
 
 /**
- * An error the peer reported by resetting a stream, carrying the raw code it sent.
+ * Codes a peer sends when terminating the session, mirroring the Rust `SessionError`.
  *
- * The codes are not standardized, so this deliberately does not translate one into a local
- * error: the number means whatever the peer's implementation says it means. A read or write
- * rejects with this on every transport, so branch on {@link code} rather than feature-detecting
- * `WebTransportError`, which a non-browser runtime never defines and the WebSocket fallback
- * never throws.
+ * Specified by moq-lite: 0-31 are moq-transport's codes with moq-transport's meaning,
+ * 32-63 are moq-lite's, and 64+ are the application's. {@link StreamCode} is the other
+ * registry, and the two are disjoint, so the same integer means different things in each.
  *
- * Code 0 is what a transport sends when a stream is dropped or aborted with no code of its own.
+ * @public
+ */
+export const SessionCode = {
+	/** Ending the session normally, with no error. */
+	Cancel: 0x0,
+	/** Something went wrong that isn't worth a dedicated code. */
+	Internal: 0x1,
+	/** The credentials don't grant the requested path or operation. Retrying will fail again. */
+	Unauthorized: 0x2,
+	/** A protocol rule was broken; the session is unusable. */
+	ProtocolViolation: 0x3,
+	/** A key-value pair was malformed or repeated more than allowed. */
+	KeyValueFormatting: 0x6,
+	/** The peer did not close within the GOAWAY drain deadline. */
+	GoawayTimeout: 0x10,
+	/** A control message took too long. */
+	Timeout: 0x11,
+	/** No version could be negotiated. */
+	Version: 0x15,
+	/** A required extension was not offered. */
+	RequiredExtension: 0x20,
+	/** The peer acted against the role it advertised at SETUP. */
+	InvalidRole: 0x21,
+	/** A stream was opened with an unknown or disallowed type. */
+	UnexpectedStream: 0x22,
+} as const;
+
+/** A session termination code. See {@link SessionCode}. */
+export type SessionCode = (typeof SessionCode)[keyof typeof SessionCode];
+
+/**
+ * Codes a peer sends when resetting a stream, mirroring the Rust `StreamError`.
+ *
+ * The counterpart to {@link SessionCode}, and a disjoint space: a stream reset of 0 is
+ * {@link StreamCode.Internal}, not a cancellation ({@link StreamCode.Cancel} is 1).
+ *
+ * @public
+ */
+export const StreamCode = {
+	/** Something went wrong that isn't worth a dedicated code. */
+	Internal: 0x0,
+	/** The sender is done with this stream, not failing. A routine unsubscribe. */
+	Cancel: 0x1,
+	/** The content missed its delivery deadline. */
+	DeliveryTimeout: 0x2,
+	/** The session ended, taking this stream with it. */
+	SessionClosed: 0x3,
+	/** The session is going away (a GOAWAY was received). */
+	GoingAway: 0x4,
+	/** The reader fell too far behind and content was dropped to catch up. */
+	TooFarBehind: 0x5,
+	/** The track's content could not be parsed. */
+	MalformedTrack: 0x12,
+	/** The requested broadcast or track does not exist. */
+	NotFound: 0x20,
+	/** The broadcast is neither announced nor served, so there is no route to it. */
+	Unroutable: 0x21,
+	/** The group was superseded by a newer group and dropped. */
+	Old: 0x22,
+	/** The group was dropped under memory pressure; unlike Old, it can be re-fetched. */
+	Evicted: 0x23,
+	/** A frame's payload length disagreed with its declared size. */
+	WrongSize: 0x24,
+	/** A frame declared a payload larger than the receiver accepts. */
+	FrameTooLarge: 0x25,
+	/** A frame's timestamp doesn't match its track's negotiated timescale. */
+	TimestampMismatch: 0x26,
+} as const;
+
+/** A stream reset code. See {@link StreamCode}. */
+export type StreamCode = (typeof StreamCode)[keyof typeof StreamCode];
+
+/**
+ * An error the peer reported by resetting a stream or closing the session, carrying the
+ * code it sent.
+ *
+ * Which registry {@link code} belongs to depends on what failed: a stream read or write
+ * rejects with a {@link StreamCode}, while a session close carries a {@link SessionCode}.
+ * The two spaces are disjoint, so read it against the right one. This surfaces on every
+ * transport, so branch on {@link code} rather than feature-detecting `WebTransportError`,
+ * which a non-browser runtime never defines and the WebSocket fallback never throws.
  *
  * ```ts
  * try {
  *   frame = await group.readFrame();
  * } catch (err) {
- *   // Whatever this peer's code 2 means to it.
- *   if (err instanceof RemoteError && err.code === 2) return;
+ *   if (err instanceof RemoteError && err.code === StreamCode.Old) return;
  *   throw err;
  * }
  * ```
@@ -31,8 +108,8 @@ export class RemoteError extends Error {
 	/** The code the peer sent, verbatim. */
 	readonly code: number;
 
-	constructor(code: number, options?: { cause?: unknown }) {
-		super(`remote error: ${code}`, options);
+	constructor(code: number, options?: { cause?: unknown; reason?: string }) {
+		super(options?.reason ? `remote error: ${code} (${options.reason})` : `remote error: ${code}`, options);
 		this.name = "RemoteError";
 		this.code = code;
 	}
@@ -64,6 +141,18 @@ export function fromTransport(err: unknown): Error {
 	const code = streamCode(err);
 	if (code === undefined) return error(err);
 	return new RemoteError(code, { cause: err });
+}
+
+/**
+ * Decode a session close into its terminal error: `null` for a clean close
+ * ({@link SessionCode.Cancel}), otherwise a {@link RemoteError} carrying the peer's code.
+ *
+ * @internal Applied to the transport's `closed` info so the code survives to the application.
+ */
+export function fromClose(info: WebTransportCloseInfo): RemoteError | null {
+	const code = info.closeCode ?? SessionCode.Cancel;
+	if (code === SessionCode.Cancel) return null;
+	return new RemoteError(code, { reason: info.reason });
 }
 
 /**

--- a/js/net/src/error.ts
+++ b/js/net/src/error.ts
@@ -130,6 +130,27 @@ export function fromTransport(err: unknown): Error {
 }
 
 /**
+ * Build the `reason` to hand `abort()` / `cancel()` so the transport puts `code` on the wire.
+ *
+ * Both the WebTransport spec and the WebSocket fallback take the reset code from a
+ * `WebTransportError`'s `streamErrorCode` and send 0 for anything else, a plain `Error`
+ * included. Since 0 is {@link StreamCode.Internal}, cancelling with a bare `Error` tells the
+ * peer we failed rather than that we are done.
+ *
+ * The native constructor exists exactly where native WebTransport does, which is where the
+ * fallback isn't used, so mint a matching shape elsewhere rather than feature-detect a global
+ * that will not be there.
+ *
+ * @internal
+ */
+export function toTransport(code: number, message: string): Error {
+	const Native = (globalThis as { WebTransportError?: typeof WebTransportError }).WebTransportError;
+	if (Native) return new Native(message, { source: "stream", streamErrorCode: code });
+
+	return Object.assign(new Error(message), { source: "stream" as const, streamErrorCode: code });
+}
+
+/**
  * Decode a session close into its terminal error: `null` for a clean close
  * ({@link SessionCode.Cancel}), otherwise a {@link RemoteError} carrying the peer's code.
  *

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -4,6 +4,7 @@ import type * as broadcast from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
 import { type Probe, type Stats, transportStats } from "../connection/stats.ts";
 import { type Transport, transportOf } from "../connection/transport.ts";
+import { error, fromClose } from "../error.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, type Stream } from "../stream.ts";
 import { ControlStreamAdapter, NativeSession, type Session } from "./adapter.ts";
@@ -306,11 +307,8 @@ export class Connection implements Established {
 		}
 	}
 
-	/**
-	 * Returns a promise that resolves when the connection is closed.
-	 * @returns A promise that resolves when closed
-	 */
-	get closed(): Promise<void> {
-		return this.#quic.closed.then(() => undefined);
+	/** Resolves when the session closes, decoding the peer's close code; see {@link Established.closed}. */
+	get closed(): Promise<Error | null> {
+		return this.#quic.closed.then(fromClose, (err: unknown) => error(err));
 	}
 }

--- a/js/net/src/index.ts
+++ b/js/net/src/index.ts
@@ -13,8 +13,8 @@ export * as Announce from "./announced.ts";
 export * as Broadcast from "./broadcast.ts";
 /** Connection helpers: connect to or accept a MoQ session and reconnect on failure. */
 export * as Connection from "./connection/index.ts";
-/** The error a read or write rejects with when the peer resets a stream, carrying its code. */
-export { RemoteError } from "./error.ts";
+/** The error a read, write, or session close rejects with when the peer sends a code, carrying it. */
+export { RemoteError, SessionCode, StreamCode } from "./error.ts";
 /** Group role handles and frame helpers. */
 export * as Group from "./group.ts";
 /** Broadcast path utilities with delimiter-aware prefix matching. */

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -4,6 +4,7 @@ import type * as broadcast from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
 import { type Probe, type Stats, transportStats } from "../connection/stats.ts";
 import { type Transport, transportOf } from "../connection/transport.ts";
+import { error, fromClose } from "../error.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, Stream, Writer } from "../stream.ts";
 import { AnnounceRequest } from "./announce.ts";
@@ -301,7 +302,8 @@ export class Connection implements Established {
 		return transportStats(this.#quic);
 	}
 
-	get closed(): Promise<void> {
-		return this.#quic.closed.then(() => undefined);
+	/** Resolves when the session closes, decoding the peer's close code; see {@link Established.closed}. */
+	get closed(): Promise<Error | null> {
+		return this.#quic.closed.then(fromClose, (err: unknown) => error(err));
 	}
 }

--- a/js/net/src/stream.ts
+++ b/js/net/src/stream.ts
@@ -1,7 +1,13 @@
-import { fromTransport } from "./error.ts";
+import { fromTransport, RemoteError, StreamCode, toTransport } from "./error.ts";
 import type { IetfVersion } from "./ietf/version.ts";
 import { Version } from "./ietf/version.ts";
 import * as Varint from "./varint.ts";
+
+// Forwarding a peer's reset must keep its code, or a relay flattens it to 0 (INTERNAL_ERROR).
+// Anything else is a local failure, which 0 already describes, so leave it alone.
+function withCode(reason: unknown): unknown {
+	return reason instanceof RemoteError ? toTransport(reason.code, reason.message) : reason;
+}
 
 const MAX_U31 = 2 ** 31 - 1;
 const MAX_READ_SIZE = 1024 * 1024 * 64; // don't allocate more than 64MB for a message
@@ -50,7 +56,10 @@ export class Stream {
 
 	close() {
 		this.writer.close();
-		this.reader.stop(new Error("cancel"));
+		// A routine unsubscribe, so send CANCELLED. A bare Error would put 0 on the wire,
+		// which the stream registry reads as INTERNAL_ERROR: the peer would log a failure
+		// for every subscription we walk away from.
+		this.reader.stop(toTransport(StreamCode.Cancel, "cancel"));
 	}
 
 	abort(reason: Error) {
@@ -263,7 +272,7 @@ export class Reader {
 	}
 
 	stop(reason: unknown) {
-		this.#reader?.cancel(reason).catch(() => void 0);
+		this.#reader?.cancel(withCode(reason)).catch(() => void 0);
 	}
 
 	// Decoded like #fill: a caller racing this against a read must not get a different error
@@ -368,7 +377,7 @@ export class Writer {
 	}
 
 	reset(reason: unknown) {
-		this.#writer.abort(reason).catch(() => void 0);
+		this.#writer.abort(withCode(reason)).catch(() => void 0);
 	}
 
 	static async open(quic: WebTransport, version?: IetfVersion): Promise<Writer> {

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -421,6 +421,16 @@ impl Reconnect {
 					let _ = send_bw.set(None);
 					let _ = recv_bw.set(None);
 
+					// An auth rejection is terminal however long the session lived: the
+					// wire's UNAUTHORIZED is specified, so this is the peer telling us
+					// these credentials will never work, not a code we guessed at.
+					if let Ended::Closed(Err(err)) = &ended {
+						let err = Error::from(err.clone());
+						if err.is_auth() {
+							return Err(err);
+						}
+					}
+
 					if healthy {
 						// Reset the backoff window so a one-off drop reconnects promptly.
 						tracing::warn!(%url, "session closed, reconnecting");
@@ -527,8 +537,9 @@ impl Reconnect {
 
 	/// Poll whether the reconnect loop has stopped.
 	///
-	/// `Ready(Err)` if it permanently gave up (reconnect timeout exceeded), `Ready(Ok(()))` if
-	/// stopped by dropping the handle, `Pending` while it's still running.
+	/// `Ready(Err)` if it permanently gave up (reconnect timeout exceeded, or an auth
+	/// rejection), `Ready(Ok(()))` if stopped by dropping the handle, `Pending` while
+	/// it's still running.
 	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<crate::Result<()>> {
 		ready!(self.state.poll_closed(waiter));
 		Poll::Ready(match &self.state.read().error {

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -2663,3 +2663,65 @@ async fn goaway_timeout_force_close_moq_transport_19_quic() {
 		.expect("server task panicked")
 		.expect("server errored");
 }
+
+/// A rejection at the MoQ layer lands after the transport handshake, so the dial
+/// itself succeeds and the rejection arrives as the session's close. That close
+/// rides the specified UNAUTHORIZED session code, so it decodes back into a typed
+/// error rather than an opaque transport string.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn session_close_surfaces_a_rejection_code() {
+	let (mut server, addr) = test_server();
+	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		while let Some(request) = server.accept().await {
+			request.close(403).await?;
+		}
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let session = tokio::time::timeout(TIMEOUT, test_client().connect(url))
+		.await
+		.expect("connect timed out")
+		.expect("connect failed");
+	let err = tokio::time::timeout(TIMEOUT, session.closed())
+		.await
+		.expect("close timed out");
+	// `Request::close` maps both 401 and 403 onto the wire's single UNAUTHORIZED.
+	assert!(
+		matches!(err, moq_net::Error::Unauthorized),
+		"unexpected close error: {err}"
+	);
+
+	server_handle.abort();
+}
+
+/// The same rejection under the reconnect loop: UNAUTHORIZED is specified, so
+/// the loop treats it as terminal instead of retrying the same credentials with
+/// backoff until the give-up timeout.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn reconnect_stops_on_a_session_level_rejection() {
+	let (mut server, addr) = test_server();
+	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		while let Some(request) = server.accept().await {
+			request.close(401).await?;
+		}
+		Ok::<_, anyhow::Error>(())
+	});
+
+	// Without classification the loop would retry until the backoff give-up (5m by
+	// default), so `closed` resolving within TIMEOUT proves it stopped on the
+	// rejection itself.
+	let reconnect = test_client().reconnect(url);
+	let err = tokio::time::timeout(TIMEOUT, reconnect.closed())
+		.await
+		.expect("a rejected session must stop the reconnect loop promptly")
+		.expect_err("a rejected session must surface as an error");
+	assert_connect_error(&err, moq_native::ConnectError::Unauthorized);
+
+	server_handle.abort();
+}

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -451,6 +451,7 @@ mod tests {
 		sync::{Arc, Mutex},
 	};
 
+	use crate::SessionError;
 	use crate::coding::{Decode, Encode};
 	use bytes::{BufMut, Bytes};
 
@@ -696,7 +697,9 @@ mod tests {
 		// with no origin; RequiredExtension (or similar) is what an
 		// auto-created origin's first interaction with a Lite01 peer trips.
 		let (code, _) = fake.wait_for_first_close().await;
-		assert_ne!(code, Error::Version.to_code(), "SessionInfo failed to decode");
+		// Session closes encode through the session registry, so compare against that one:
+		// `Error::Version.to_code()` is the local table's value and would never match.
+		assert_ne!(code, SessionError::Version.to_code(), "SessionInfo failed to decode");
 	}
 
 	#[tokio::test(start_paused = true)]

--- a/rs/moq-net/src/coding/reader.rs
+++ b/rs/moq-net/src/coding/reader.rs
@@ -2,7 +2,7 @@ use std::{cmp, fmt::Debug, io};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-use crate::{Error, coding::*};
+use crate::{Error, StreamError, coding::*};
 
 /// A reader for decoding messages from a stream.
 pub struct Reader<S: web_transport_trait::RecvStream, V> {
@@ -149,7 +149,9 @@ impl<S: web_transport_trait::RecvStream, V> Reader<S, V> {
 
 	/// Abort the stream with the given error.
 	pub fn abort(&mut self, err: &Error) {
-		self.stream.stop(err.to_code());
+		// STOP_SENDING is a stream operation, so it carries a stream code. Sending the
+		// session code here would have the peer read it against the wrong registry.
+		self.stream.stop(StreamError::from(err).to_code());
 	}
 
 	/// Cast the reader to a different version, used during version negotiation.
@@ -159,5 +161,52 @@ impl<S: web_transport_trait::RecvStream, V> Reader<S, V> {
 			buffer: self.buffer,
 			version,
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::StreamError;
+
+	/// Records the STOP_SENDING code so a test can assert which registry it came from.
+	#[derive(Default)]
+	struct StopLog {
+		stops: Vec<u32>,
+	}
+
+	impl web_transport_trait::RecvStream for StopLog {
+		type Error = crate::lite::test_transport::SinkError;
+
+		async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+			Ok(None)
+		}
+
+		fn stop(&mut self, code: u32) {
+			self.stops.push(code);
+		}
+
+		async fn closed(&mut self) -> Result<(), Self::Error> {
+			Ok(())
+		}
+	}
+
+	/// STOP_SENDING refuses a stream, so it must carry a stream code. Reusing the session
+	/// table here would have the peer decode it against the wrong registry: `Cancel` would
+	/// arrive as INTERNAL_ERROR, and `Unauthorized` as KEY_VALUE_FORMATTING_ERROR.
+	#[test]
+	fn abort_stops_with_a_stream_code() {
+		for (err, expected) in [
+			(Error::Cancel, StreamError::Cancel.to_code()),
+			(Error::Lagged, StreamError::TooFarBehind.to_code()),
+			(Error::Unauthorized, StreamError::Session(crate::SessionError::Unauthorized).to_code()),
+		] {
+			let mut reader = Reader::new(StopLog::default(), ());
+			reader.abort(&err);
+			assert_eq!(reader.stream.stops, vec![expected], "{err:?} used the wrong registry");
+		}
+
+		// The two registries disagree about 0 and 1, which is what makes the mix-up silent.
+		assert_ne!(StreamError::Cancel.to_code(), crate::SessionError::Cancel.to_code());
 	}
 }

--- a/rs/moq-net/src/coding/reader.rs
+++ b/rs/moq-net/src/coding/reader.rs
@@ -199,7 +199,10 @@ mod tests {
 		for (err, expected) in [
 			(Error::Cancel, StreamError::Cancel.to_code()),
 			(Error::Lagged, StreamError::TooFarBehind.to_code()),
-			(Error::Unauthorized, StreamError::Session(crate::SessionError::Unauthorized).to_code()),
+			(
+				Error::Unauthorized,
+				StreamError::Session(crate::SessionError::Unauthorized).to_code(),
+			),
 		] {
 			let mut reader = Reader::new(StopLog::default(), ());
 			reader.abort(&err);

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::{Error, coding::*, ietf};
+use crate::{Error, StreamError, coding::*, ietf};
 
 /// A wrapper around a [web_transport_trait::SendStream] that will reset on Drop.
 pub struct Writer<S: web_transport_trait::SendStream, V> {
@@ -79,7 +79,7 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 	/// reset a second time and overwrite the reason with a plain [`Error::Cancel`].
 	pub fn abort(mut self, err: &Error) {
 		if let Some(mut stream) = self.stream.take() {
-			stream.reset(err.to_code());
+			stream.reset(StreamError::from(err).to_code());
 		}
 	}
 
@@ -140,7 +140,7 @@ impl<S: web_transport_trait::SendStream, V> Drop for Writer<S, V> {
 	fn drop(&mut self) {
 		if let Some(mut stream) = self.stream.take() {
 			// Unlike the Quinn default, we abort the stream on drop.
-			stream.reset(Error::Cancel.to_code());
+			stream.reset(StreamError::Cancel.to_code());
 		}
 	}
 }

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -741,7 +741,10 @@ mod tests {
 		}
 
 		// So do app codes, in both spaces.
-		assert_eq!(StreamError::from(&Error::from(StreamError::from_code(64 + 7))).to_code(), 64 + 7);
+		assert_eq!(
+			StreamError::from(&Error::from(StreamError::from_code(64 + 7))).to_code(),
+			64 + 7
+		);
 		assert_eq!(
 			SessionError::from(&Error::from(SessionError::from_code(64 + 7))).to_code(),
 			64 + 7
@@ -752,7 +755,11 @@ mod tests {
 		// on a stream. Downgrade to the unspecified-error code instead.
 		for code in [0x4, 0x5, 0x1f] {
 			let crossed = StreamError::from(&Error::from(SessionError::from_code(code)));
-			assert_eq!(crossed, StreamError::Internal, "session {code:#x} leaked into the stream space");
+			assert_eq!(
+				crossed,
+				StreamError::Internal,
+				"session {code:#x} leaked into the stream space"
+			);
 		}
 	}
 

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -395,6 +395,15 @@ pub enum Error {
 	#[error("goaway timeout")]
 	GoawayTimeout,
 
+	/// The peer could not parse the track's content.
+	#[error("malformed track")]
+	MalformedTrack,
+
+	/// The stream was torn down because the session closed. The specific reason travels on
+	/// the session close, not here.
+	#[error("session closed")]
+	SessionClosed,
+
 	/// A remote error received via a stream/session reset code.
 	#[error("remote error: code={0}")]
 	Remote(u32),
@@ -434,6 +443,8 @@ impl Error {
 			Self::Evicted => 31,
 			Self::GoingAway => 32,
 			Self::GoawayTimeout => 33,
+			Self::MalformedTrack => 22,
+			Self::SessionClosed => 25,
 			Self::App(app) => *app as u32 + 64,
 			Self::Remote(code) => *code,
 		}
@@ -498,9 +509,14 @@ impl From<StreamError> for Error {
 			StreamError::FrameTooLarge => Self::FrameTooLarge,
 			StreamError::TimestampMismatch => Self::TimestampMismatch,
 			StreamError::App(app) => Self::App(app),
-			StreamError::Session(inner) => inner.into(),
+			// Deliberately not `inner.into()`: that yields a session-space value, which the
+			// stream re-encode would then put back on a stream. The inner reason is always
+			// Internal off the wire anyway, since the stream never carried it.
+			StreamError::Session(_) => Self::SessionClosed,
 			// No local counterpart, so keep the code rather than inventing a meaning.
-			StreamError::Internal | StreamError::MalformedTrack => Self::Remote(err.to_code()),
+			StreamError::MalformedTrack => Self::MalformedTrack,
+			// No local counterpart, so keep the code rather than inventing a meaning.
+			StreamError::Internal => Self::Remote(err.to_code()),
 			StreamError::Unknown(code) => Self::Remote(code),
 		}
 	}
@@ -514,7 +530,7 @@ impl From<StreamError> for Error {
 impl From<&Error> for SessionError {
 	fn from(err: &Error) -> Self {
 		match err {
-			Error::Cancel | Error::Closed | Error::GoingAway => Self::Cancel,
+			Error::Cancel | Error::Closed | Error::GoingAway | Error::SessionClosed => Self::Cancel,
 			Error::Unauthorized => Self::Unauthorized,
 			Error::Version | Error::UnknownAlpn(_) => Self::Version,
 			Error::RequiredExtension => Self::RequiredExtension,
@@ -527,9 +543,15 @@ impl From<&Error> for SessionError {
 			| Error::UnexpectedMessage
 			| Error::Duplicate
 			| Error::Decode(_)
+			| Error::Encode(_)
+			| Error::WrongSize
 			| Error::BoundsExceeded(_) => Self::ProtocolViolation,
 			Error::App(app) => Self::App(*app),
-			Error::Remote(code) => Self::Unknown(*code),
+			// A code we did not recognize, so we cannot say which space it came from.
+			// Forwarding it into this one risks landing on a value that IS registered here
+			// (a session 0x4 would become the stream's GOING_AWAY), and the draft already
+			// says an unrecognized code is an unspecified error. Send that instead.
+			Error::Remote(_) => Self::Internal,
 			_ => Self::Internal,
 		}
 	}
@@ -543,6 +565,7 @@ impl From<&Error> for StreamError {
 	fn from(err: &Error) -> Self {
 		match err {
 			Error::Cancel | Error::Closed => Self::Cancel,
+			Error::SessionClosed => Self::Session(SessionError::Cancel),
 			Error::Old => Self::Old,
 			Error::Evicted => Self::Evicted,
 			Error::Lagged => Self::TooFarBehind,
@@ -553,9 +576,12 @@ impl From<&Error> for StreamError {
 			Error::TimestampMismatch => Self::TimestampMismatch,
 			Error::Timeout => Self::DeliveryTimeout,
 			Error::GoingAway => Self::GoingAway,
-			Error::Decode(_) | Error::BoundsExceeded(_) => Self::MalformedTrack,
+			// Our own parse failure is, from the peer's side, a malformed track.
+			Error::Decode(_) | Error::BoundsExceeded(_) | Error::MalformedTrack => Self::MalformedTrack,
 			Error::App(app) => Self::App(*app),
-			Error::Remote(code) => Self::Unknown(*code),
+			// See the SessionError impl: an unregistered code carries no registry, so
+			// re-sending the number could mistranslate it.
+			Error::Remote(_) => Self::Internal,
 			// Session-scoped: the peer learns the detail from the session close.
 			Error::Unauthorized
 			| Error::Version
@@ -697,6 +723,37 @@ mod tests {
 			StreamError::from_code(0x3),
 			StreamError::Session(SessionError::Internal)
 		);
+	}
+
+	// A relay decodes a peer's code into `Error` and re-encodes it when it tears down the
+	// corresponding downstream stream. That hop must not change what the code means.
+	#[test]
+	fn relaying_a_code_does_not_change_registries() {
+		// SESSION_CLOSED used to decode into a session-space value, which came back out as
+		// 0x1: downstream read a routine CANCELLED for an upstream session teardown.
+		let relayed = StreamError::from(&Error::from(StreamError::from_code(0x3)));
+		assert_eq!(relayed.to_code(), 0x3);
+
+		// Registered stream codes survive the hop unchanged.
+		for code in [0x0, 0x1, 0x2, 0x4, 0x5, 0x12] {
+			let relayed = StreamError::from(&Error::from(StreamError::from_code(code)));
+			assert_eq!(relayed.to_code(), code, "stream {code:#x} changed across a relay");
+		}
+
+		// So do app codes, in both spaces.
+		assert_eq!(StreamError::from(&Error::from(StreamError::from_code(64 + 7))).to_code(), 64 + 7);
+		assert_eq!(
+			SessionError::from(&Error::from(SessionError::from_code(64 + 7))).to_code(),
+			64 + 7
+		);
+
+		// An unregistered code carries no registry, so it must not be re-sent as a number
+		// that means something here: session 0x4 and 0x5 are GOING_AWAY and TOO_FAR_BEHIND
+		// on a stream. Downgrade to the unspecified-error code instead.
+		for code in [0x4, 0x5, 0x1f] {
+			let crossed = StreamError::from(&Error::from(SessionError::from_code(code)));
+			assert_eq!(crossed, StreamError::Internal, "session {code:#x} leaked into the stream space");
+		}
 	}
 
 	// The registry a code is read with depends on what failed, and picking the wrong one

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -1,5 +1,245 @@
 use crate::coding;
 
+/// A code sent when terminating the session.
+///
+/// One of the two wire registries specified by moq-lite, which mirror moq-transport's:
+/// 0-31 are moq-transport's codes with moq-transport's meaning, 32-63 are moq-lite's, and
+/// 64+ are the application's. The stream registry is [`StreamError`] and the two are
+/// disjoint, so the same integer means different things in each.
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SessionError {
+	/// Ending the session normally, with no error.
+	#[error("no error")]
+	Cancel,
+
+	/// Something went wrong that isn't worth a dedicated code.
+	#[error("internal error")]
+	Internal,
+
+	/// The peer's token does not grant the requested path or operation. Retrying with the
+	/// same credentials will fail again.
+	#[error("unauthorized")]
+	Unauthorized,
+
+	/// The peer broke a protocol rule; the session is unusable.
+	#[error("protocol violation")]
+	ProtocolViolation,
+
+	/// A key-value pair was malformed or repeated more than allowed.
+	#[error("key-value formatting error")]
+	KeyValueFormatting,
+
+	/// The peer did not close within the GOAWAY drain deadline.
+	#[error("goaway timeout")]
+	GoawayTimeout,
+
+	/// A control message took too long.
+	#[error("control message timeout")]
+	Timeout,
+
+	/// No version could be negotiated.
+	#[error("version negotiation failed")]
+	Version,
+
+	/// A required extension was not offered by the peer.
+	#[error("extension required")]
+	RequiredExtension,
+
+	/// The peer acted against the [`Role`](crate::Role) it advertised at SETUP.
+	#[error("invalid role")]
+	InvalidRole,
+
+	/// A stream was opened with an unknown or disallowed type.
+	#[error("unexpected stream type")]
+	UnexpectedStream,
+
+	/// An application-chosen code, offset into the 64+ range on the wire.
+	#[error("app code={0}")]
+	App(u16),
+
+	/// A code this version does not recognize, kept verbatim.
+	#[error("unknown code={0}")]
+	Unknown(u32),
+}
+
+impl SessionError {
+	/// The integer sent on the wire.
+	pub fn to_code(&self) -> u32 {
+		match self {
+			Self::Cancel => 0x0,
+			Self::Internal => 0x1,
+			Self::Unauthorized => 0x2,
+			Self::ProtocolViolation => 0x3,
+			Self::KeyValueFormatting => 0x6,
+			Self::GoawayTimeout => 0x10,
+			Self::Timeout => 0x11,
+			Self::Version => 0x15,
+			Self::RequiredExtension => 0x20,
+			Self::InvalidRole => 0x21,
+			Self::UnexpectedStream => 0x22,
+			Self::App(app) => *app as u32 + 64,
+			Self::Unknown(code) => *code,
+		}
+	}
+
+	/// Decode a code received off the wire.
+	///
+	/// Unlike a raw peer code, these are specified, so decoding is a wire contract rather
+	/// than an assumption. Anything unregistered stays [`Self::Unknown`].
+	pub fn from_code(code: u32) -> Self {
+		match code {
+			0x0 => Self::Cancel,
+			0x1 => Self::Internal,
+			0x2 => Self::Unauthorized,
+			0x3 => Self::ProtocolViolation,
+			0x6 => Self::KeyValueFormatting,
+			0x10 => Self::GoawayTimeout,
+			0x11 => Self::Timeout,
+			0x15 => Self::Version,
+			0x20 => Self::RequiredExtension,
+			0x21 => Self::InvalidRole,
+			0x22 => Self::UnexpectedStream,
+			code @ 64.. => match u16::try_from(code - 64) {
+				Ok(app) => Self::App(app),
+				Err(_) => Self::Unknown(code),
+			},
+			code => Self::Unknown(code),
+		}
+	}
+}
+
+/// A code sent when resetting a stream, or refusing to receive one.
+///
+/// The counterpart to [`SessionError`], and a disjoint space: a stream reset of 0 is
+/// [`Internal`](Self::Internal), not a cancellation ([`Cancel`](Self::Cancel) is 1).
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StreamError {
+	/// The session ended, taking this stream with it.
+	///
+	/// The specific [`SessionError`] is local only: the two registries are disjoint, so
+	/// this encodes to a single `SESSION_CLOSED` and the peer learns the reason from the
+	/// session close itself.
+	#[error("session closed: {0}")]
+	Session(#[from] SessionError),
+
+	/// Something went wrong that isn't worth a dedicated code.
+	#[error("internal error")]
+	Internal,
+
+	/// The sender is done with this stream, not failing. A routine unsubscribe.
+	#[error("cancelled")]
+	Cancel,
+
+	/// The content missed its delivery deadline.
+	#[error("delivery timeout")]
+	DeliveryTimeout,
+
+	/// The session is going away (a GOAWAY was received).
+	#[error("going away")]
+	GoingAway,
+
+	/// The reader fell too far behind and content was dropped to catch up.
+	#[error("too far behind")]
+	TooFarBehind,
+
+	/// The track's content could not be parsed.
+	#[error("malformed track")]
+	MalformedTrack,
+
+	/// The requested broadcast or track does not exist at the peer.
+	#[error("not found")]
+	NotFound,
+
+	/// The broadcast is neither announced nor served, so there is no route to it.
+	#[error("unroutable")]
+	Unroutable,
+
+	/// The group was superseded by a newer group and dropped.
+	#[error("old")]
+	Old,
+
+	/// The group was dropped under memory pressure. Unlike [`Old`](Self::Old) it was still
+	/// current, so it can be re-fetched.
+	#[error("evicted")]
+	Evicted,
+
+	/// A frame's payload length disagreed with its declared size.
+	#[error("wrong frame size")]
+	WrongSize,
+
+	/// A frame declared a payload larger than the receiver accepts.
+	#[error("frame too large")]
+	FrameTooLarge,
+
+	/// A frame's timestamp doesn't match its track's negotiated timescale.
+	#[error("frame timestamp doesn't match track timescale")]
+	TimestampMismatch,
+
+	/// An application-chosen code, offset into the 64+ range on the wire.
+	#[error("app code={0}")]
+	App(u16),
+
+	/// A code this version does not recognize, kept verbatim.
+	#[error("unknown code={0}")]
+	Unknown(u32),
+}
+
+impl StreamError {
+	/// The integer sent on the wire.
+	pub fn to_code(&self) -> u32 {
+		match self {
+			Self::Internal => 0x0,
+			Self::Cancel => 0x1,
+			Self::DeliveryTimeout => 0x2,
+			// Flattened: the session registry is disjoint, so the specific reason
+			// doesn't fit here and travels on the session close instead.
+			Self::Session(_) => 0x3,
+			Self::GoingAway => 0x4,
+			Self::TooFarBehind => 0x5,
+			Self::MalformedTrack => 0x12,
+			Self::NotFound => 0x20,
+			Self::Unroutable => 0x21,
+			Self::Old => 0x22,
+			Self::Evicted => 0x23,
+			Self::WrongSize => 0x24,
+			Self::FrameTooLarge => 0x25,
+			Self::TimestampMismatch => 0x26,
+			Self::App(app) => *app as u32 + 64,
+			Self::Unknown(code) => *code,
+		}
+	}
+
+	/// Decode a code received off the wire.
+	///
+	/// `SESSION_CLOSED` decodes to `Session(SessionError::Internal)`: the peer's actual
+	/// session code is not on this stream, so the specific reason is unknown here.
+	pub fn from_code(code: u32) -> Self {
+		match code {
+			0x0 => Self::Internal,
+			0x1 => Self::Cancel,
+			0x2 => Self::DeliveryTimeout,
+			0x3 => Self::Session(SessionError::Internal),
+			0x4 => Self::GoingAway,
+			0x5 => Self::TooFarBehind,
+			0x12 => Self::MalformedTrack,
+			0x20 => Self::NotFound,
+			0x21 => Self::Unroutable,
+			0x22 => Self::Old,
+			0x23 => Self::Evicted,
+			0x24 => Self::WrongSize,
+			0x25 => Self::FrameTooLarge,
+			0x26 => Self::TimestampMismatch,
+			code @ 64.. => match u16::try_from(code - 64) {
+				Ok(app) => Self::App(app),
+				Err(_) => Self::Unknown(code),
+			},
+			code => Self::Unknown(code),
+		}
+	}
+}
+
 /// A list of possible errors that can occur during the session.
 #[derive(thiserror::Error, Debug, Clone)]
 #[non_exhaustive]
@@ -193,18 +433,136 @@ impl Error {
 		}
 	}
 
-	/// Convert a transport error into an [Error], decoding stream reset codes.
+	/// Convert a transport error into an [Error], decoding session close and stream reset
+	/// codes through their respective registries.
+	///
+	/// The two spaces are disjoint, so which one applies depends on what failed: a session
+	/// close decodes via [`SessionError::from_code`], a stream reset via
+	/// [`StreamError::from_code`]. Reading a stream reset with the session table (or the
+	/// reverse) silently mistranslates, since e.g. 0 is "no error" for a session but an
+	/// internal error for a stream.
 	pub fn from_transport(err: impl web_transport_trait::Error) -> Self {
-		match err.stream_error() {
-			// Code 0 is what [`Self::Cancel`] encodes to, and what a plain stream
-			// drop sends: the peer is done with the stream, not failing. Decoding it
-			// back keeps a routine unsubscribe out of the error paths.
-			Some(0) => return Self::Cancel,
-			Some(code) => return Self::Remote(code),
-			None => {}
+		if let Some((code, _reason)) = err.session_error() {
+			return SessionError::from_code(code).into();
+		}
+
+		if let Some(code) = err.stream_error() {
+			return StreamError::from_code(code).into();
 		}
 
 		Self::Transport(err.to_string())
+	}
+}
+
+/// Map a decoded session code back into the crate's error type.
+impl From<SessionError> for Error {
+	fn from(err: SessionError) -> Self {
+		match err {
+			SessionError::Cancel => Self::Cancel,
+			SessionError::Unauthorized => Self::Unauthorized,
+			SessionError::ProtocolViolation => Self::ProtocolViolation,
+			SessionError::Version => Self::Version,
+			SessionError::RequiredExtension => Self::RequiredExtension,
+			SessionError::InvalidRole => Self::InvalidRole,
+			SessionError::UnexpectedStream => Self::UnexpectedStream,
+			SessionError::KeyValueFormatting => Self::TooManyParameters,
+			SessionError::GoawayTimeout => Self::GoawayTimeout,
+			SessionError::Timeout => Self::Timeout,
+			SessionError::App(app) => Self::App(app),
+			// No local counterpart, so keep the code rather than inventing a meaning.
+			SessionError::Internal => Self::Remote(err.to_code()),
+			SessionError::Unknown(code) => Self::Remote(code),
+		}
+	}
+}
+
+/// Map a decoded stream code back into the crate's error type.
+impl From<StreamError> for Error {
+	fn from(err: StreamError) -> Self {
+		match err {
+			StreamError::Cancel => Self::Cancel,
+			StreamError::DeliveryTimeout => Self::Timeout,
+			StreamError::GoingAway => Self::GoingAway,
+			StreamError::TooFarBehind => Self::Lagged,
+			StreamError::NotFound => Self::NotFound,
+			StreamError::Unroutable => Self::Unroutable,
+			StreamError::Old => Self::Old,
+			StreamError::Evicted => Self::Evicted,
+			StreamError::WrongSize => Self::WrongSize,
+			StreamError::FrameTooLarge => Self::FrameTooLarge,
+			StreamError::TimestampMismatch => Self::TimestampMismatch,
+			StreamError::App(app) => Self::App(app),
+			StreamError::Session(inner) => inner.into(),
+			// No local counterpart, so keep the code rather than inventing a meaning.
+			StreamError::Internal | StreamError::MalformedTrack => Self::Remote(err.to_code()),
+			StreamError::Unknown(code) => Self::Remote(code),
+		}
+	}
+}
+
+/// Which session code to send for a local error.
+///
+/// Lossy on purpose: [`Error`] describes what went wrong locally, while the registry is what
+/// the peer can act on. Anything stream-scoped reaching a session close is a bug on our side,
+/// so it degrades to [`SessionError::Internal`] rather than inventing a code.
+impl From<&Error> for SessionError {
+	fn from(err: &Error) -> Self {
+		match err {
+			Error::Cancel | Error::Closed | Error::GoingAway => Self::Cancel,
+			Error::Unauthorized => Self::Unauthorized,
+			Error::Version | Error::UnknownAlpn(_) => Self::Version,
+			Error::RequiredExtension => Self::RequiredExtension,
+			Error::InvalidRole => Self::InvalidRole,
+			Error::UnexpectedStream => Self::UnexpectedStream,
+			Error::TooManyParameters => Self::KeyValueFormatting,
+			Error::GoawayTimeout => Self::GoawayTimeout,
+			Error::Timeout => Self::Timeout,
+			Error::ProtocolViolation
+			| Error::UnexpectedMessage
+			| Error::Duplicate
+			| Error::Decode(_)
+			| Error::BoundsExceeded(_) => Self::ProtocolViolation,
+			Error::App(app) => Self::App(*app),
+			Error::Remote(code) => Self::Unknown(*code),
+			_ => Self::Internal,
+		}
+	}
+}
+
+/// Which stream code to send for a local error.
+///
+/// Session-scoped conditions route through [`StreamError::Session`], which flattens to
+/// `SESSION_CLOSED` on the wire.
+impl From<&Error> for StreamError {
+	fn from(err: &Error) -> Self {
+		match err {
+			Error::Cancel | Error::Closed => Self::Cancel,
+			Error::Old => Self::Old,
+			Error::Evicted => Self::Evicted,
+			Error::Lagged => Self::TooFarBehind,
+			Error::NotFound => Self::NotFound,
+			Error::Unroutable => Self::Unroutable,
+			Error::WrongSize => Self::WrongSize,
+			Error::FrameTooLarge => Self::FrameTooLarge,
+			Error::TimestampMismatch => Self::TimestampMismatch,
+			Error::Timeout => Self::DeliveryTimeout,
+			Error::GoingAway => Self::GoingAway,
+			Error::Decode(_) | Error::BoundsExceeded(_) => Self::MalformedTrack,
+			Error::App(app) => Self::App(*app),
+			Error::Remote(code) => Self::Unknown(*code),
+			// Session-scoped: the peer learns the detail from the session close.
+			Error::Unauthorized
+			| Error::Version
+			| Error::UnknownAlpn(_)
+			| Error::RequiredExtension
+			| Error::InvalidRole
+			| Error::UnexpectedStream
+			| Error::TooManyParameters
+			| Error::GoawayTimeout
+			| Error::ProtocolViolation
+			| Error::UnexpectedMessage => Self::Session(SessionError::from(err)),
+			_ => Self::Internal,
+		}
 	}
 }
 
@@ -221,8 +579,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 mod tests {
 	use super::*;
 
-	// The wire codes are a stable contract with every other implementation, so a variant
-	// rename (e.g. CacheFull -> Lagged) must not shift them. Pin the load-bearing ones.
+	// The codes this implementation *sends* must stay put across a variant rename
+	// (e.g. CacheFull -> Lagged), since peers and logs already see them. Pin the
+	// load-bearing ones. This is our table, not a wire-wide registry: see
+	// `from_transport` for why a received code is never mapped back through it.
 	#[test]
 	fn to_code_is_stable() {
 		assert_eq!(Error::Cancel.to_code(), 0);
@@ -236,5 +596,132 @@ mod tests {
 		assert_eq!(Error::App(0).to_code(), 64);
 		assert_eq!(Error::App(404).to_code(), 468);
 		assert_eq!(Error::Remote(468).to_code(), 468);
+	}
+
+	// Both registries are wire contracts now (draft-lcurley-moq-lite, Error Codes), so
+	// every code we send must decode back to what we meant.
+	#[test]
+	fn session_codes_round_trip() {
+		let variants = [
+			SessionError::Cancel,
+			SessionError::Internal,
+			SessionError::Unauthorized,
+			SessionError::ProtocolViolation,
+			SessionError::KeyValueFormatting,
+			SessionError::GoawayTimeout,
+			SessionError::Timeout,
+			SessionError::Version,
+			SessionError::RequiredExtension,
+			SessionError::InvalidRole,
+			SessionError::UnexpectedStream,
+			SessionError::App(0),
+			SessionError::App(404),
+		];
+		for err in variants {
+			assert_eq!(
+				SessionError::from_code(err.to_code()),
+				err,
+				"{err:?} did not round trip"
+			);
+		}
+
+		// The moq-transport codes we reuse must keep moq-transport's values.
+		assert_eq!(SessionError::Unauthorized.to_code(), 0x2);
+		assert_eq!(SessionError::GoawayTimeout.to_code(), 0x10);
+		assert_eq!(SessionError::Version.to_code(), 0x15);
+		// Ours sit in the moq-lite range, clear of both.
+		assert!((0x20..0x40).contains(&SessionError::RequiredExtension.to_code()));
+		// Unregistered codes keep their value instead of being given a meaning.
+		assert_eq!(SessionError::from_code(0x1f), SessionError::Unknown(0x1f));
+	}
+
+	#[test]
+	fn stream_codes_round_trip() {
+		let variants = [
+			StreamError::Internal,
+			StreamError::Cancel,
+			StreamError::DeliveryTimeout,
+			StreamError::GoingAway,
+			StreamError::TooFarBehind,
+			StreamError::MalformedTrack,
+			StreamError::NotFound,
+			StreamError::Unroutable,
+			StreamError::Old,
+			StreamError::Evicted,
+			StreamError::WrongSize,
+			StreamError::FrameTooLarge,
+			StreamError::TimestampMismatch,
+			StreamError::App(7),
+		];
+		for err in variants {
+			assert_eq!(StreamError::from_code(err.to_code()), err, "{err:?} did not round trip");
+		}
+
+		// The spaces are disjoint: 0 is a cancellation for a session but an internal
+		// error for a stream, and a cancellation is 1 here.
+		assert_eq!(StreamError::Cancel.to_code(), 0x1);
+		assert_eq!(StreamError::from_code(0x0), StreamError::Internal);
+		assert_eq!(SessionError::from_code(0x0), SessionError::Cancel);
+
+		// A session close flattens to SESSION_CLOSED: the specific reason travels on the
+		// session close, not on the stream.
+		assert_eq!(StreamError::Session(SessionError::Unauthorized).to_code(), 0x3);
+		assert_eq!(
+			StreamError::from_code(0x3),
+			StreamError::Session(SessionError::Internal)
+		);
+	}
+
+	// The registry a code is read with depends on what failed, and picking the wrong one
+	// silently mistranslates rather than erroring.
+	#[test]
+	fn from_transport_selects_the_matching_registry() {
+		#[derive(Debug, thiserror::Error)]
+		#[error("failed")]
+		struct Failed {
+			session: Option<u32>,
+			stream: Option<u32>,
+		}
+
+		impl web_transport_trait::Error for Failed {
+			fn session_error(&self) -> Option<(u32, String)> {
+				self.session.map(|code| (code, "closed".to_string()))
+			}
+			fn stream_error(&self) -> Option<u32> {
+				self.stream
+			}
+		}
+
+		let session = |code| {
+			Error::from_transport(Failed {
+				session: Some(code),
+				stream: None,
+			})
+		};
+		let stream = |code| {
+			Error::from_transport(Failed {
+				session: None,
+				stream: Some(code),
+			})
+		};
+
+		// A MoQ-layer auth rejection is now classifiable, because the code is specified.
+		assert!(matches!(session(0x2), Error::Unauthorized));
+		assert!(matches!(session(0x0), Error::Cancel));
+
+		// Same integer, different space: 0 ends a session cleanly but fails a stream.
+		assert!(matches!(stream(0x1), Error::Cancel));
+		assert!(matches!(stream(0x0), Error::Remote(0)));
+		assert!(matches!(stream(0x5), Error::Lagged));
+		assert!(matches!(stream(0x22), Error::Old));
+
+		// Neither: the transport itself failed.
+		assert!(matches!(
+			Error::from_transport(Failed {
+				session: None,
+				stream: None
+			}),
+			Error::Transport(_)
+		));
 	}
 }

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -2,10 +2,13 @@ use crate::coding;
 
 /// A code sent when terminating the session.
 ///
-/// One of the two wire registries specified by moq-lite, which mirror moq-transport's:
-/// 0-31 are moq-transport's codes with moq-transport's meaning, 32-63 are moq-lite's, and
-/// 64+ are the application's. The stream registry is [`StreamError`] and the two are
-/// disjoint, so the same integer means different things in each.
+/// One of the two wire registries specified by moq-lite, which reuse moq-transport's codes
+/// unchanged; 64+ are the application's. The stream registry is [`StreamError`] and the two
+/// are disjoint, so the same integer means different things in each.
+///
+/// Variants above the shared codes encode into the draft's reserved 32-63 range. Those are
+/// placeholders, not assignments: we send them because there has to be *some* code, but a
+/// receiver must not read one back (see [`from_code`](Self::from_code)).
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SessionError {
@@ -85,8 +88,12 @@ impl SessionError {
 
 	/// Decode a code received off the wire.
 	///
-	/// Unlike a raw peer code, these are specified, so decoding is a wire contract rather
-	/// than an assumption. Anything unregistered stays [`Self::Unknown`].
+	/// Unlike a raw peer code, the registered ones are specified, so decoding them is a
+	/// wire contract rather than an assumption. Anything unregistered stays
+	/// [`Self::Unknown`], including 32-63: we emit placeholders there for conditions the
+	/// shared codes don't cover, but the draft assigns it no meaning, so a received one is
+	/// not read back as our own placeholder. `to_code` is deliberately not injective as a
+	/// result.
 	pub fn from_code(code: u32) -> Self {
 		match code {
 			0x0 => Self::Cancel,
@@ -97,9 +104,6 @@ impl SessionError {
 			0x10 => Self::GoawayTimeout,
 			0x11 => Self::Timeout,
 			0x15 => Self::Version,
-			0x20 => Self::RequiredExtension,
-			0x21 => Self::InvalidRole,
-			0x22 => Self::UnexpectedStream,
 			code @ 64.. => match u16::try_from(code - 64) {
 				Ok(app) => Self::App(app),
 				Err(_) => Self::Unknown(code),
@@ -113,6 +117,10 @@ impl SessionError {
 ///
 /// The counterpart to [`SessionError`], and a disjoint space: a stream reset of 0 is
 /// [`Internal`](Self::Internal), not a cancellation ([`Cancel`](Self::Cancel) is 1).
+///
+/// Variants above the shared codes encode into the draft's reserved 32-63 range. Those are
+/// placeholders, not assignments: we send them because there has to be *some* code, but a
+/// receiver must not read one back (see [`from_code`](Self::from_code)).
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum StreamError {
@@ -213,6 +221,11 @@ impl StreamError {
 
 	/// Decode a code received off the wire.
 	///
+	/// Only the registered codes decode. 32-63 is the reserved range: we emit placeholders
+	/// there for conditions the shared codes don't cover, but the draft assigns it no
+	/// meaning, so a received one stays [`Unknown`](Self::Unknown) rather than being read
+	/// as our own placeholder. `to_code` is deliberately not injective as a result.
+	///
 	/// `SESSION_CLOSED` decodes to `Session(SessionError::Internal)`: the peer's actual
 	/// session code is not on this stream, so the specific reason is unknown here.
 	pub fn from_code(code: u32) -> Self {
@@ -224,13 +237,6 @@ impl StreamError {
 			0x4 => Self::GoingAway,
 			0x5 => Self::TooFarBehind,
 			0x12 => Self::MalformedTrack,
-			0x20 => Self::NotFound,
-			0x21 => Self::Unroutable,
-			0x22 => Self::Old,
-			0x23 => Self::Evicted,
-			0x24 => Self::WrongSize,
-			0x25 => Self::FrameTooLarge,
-			0x26 => Self::TimestampMismatch,
 			code @ 64.. => match u16::try_from(code - 64) {
 				Ok(app) => Self::App(app),
 				Err(_) => Self::Unknown(code),
@@ -602,7 +608,8 @@ mod tests {
 	// every code we send must decode back to what we meant.
 	#[test]
 	fn session_codes_round_trip() {
-		let variants = [
+		// Only the registered codes are a wire contract, so only they round trip.
+		let registered = [
 			SessionError::Cancel,
 			SessionError::Internal,
 			SessionError::Unauthorized,
@@ -611,13 +618,10 @@ mod tests {
 			SessionError::GoawayTimeout,
 			SessionError::Timeout,
 			SessionError::Version,
-			SessionError::RequiredExtension,
-			SessionError::InvalidRole,
-			SessionError::UnexpectedStream,
 			SessionError::App(0),
 			SessionError::App(404),
 		];
-		for err in variants {
+		for err in registered {
 			assert_eq!(
 				SessionError::from_code(err.to_code()),
 				err,
@@ -629,21 +633,44 @@ mod tests {
 		assert_eq!(SessionError::Unauthorized.to_code(), 0x2);
 		assert_eq!(SessionError::GoawayTimeout.to_code(), 0x10);
 		assert_eq!(SessionError::Version.to_code(), 0x15);
-		// Ours sit in the moq-lite range, clear of both.
-		assert!((0x20..0x40).contains(&SessionError::RequiredExtension.to_code()));
+
+		// The rest encode into 32-63, which the draft reserves rather than assigns. We
+		// send a placeholder because there has to be some code, but decoding one back
+		// would be reading a meaning the wire does not carry, so it stays Unknown. That
+		// makes to_code deliberately non-injective.
+		for err in [
+			SessionError::RequiredExtension,
+			SessionError::InvalidRole,
+			SessionError::UnexpectedStream,
+		] {
+			let code = err.to_code();
+			assert!((0x20..0x40).contains(&code), "{err:?} left the reserved range");
+			assert_eq!(SessionError::from_code(code), SessionError::Unknown(code));
+		}
+
 		// Unregistered codes keep their value instead of being given a meaning.
 		assert_eq!(SessionError::from_code(0x1f), SessionError::Unknown(0x1f));
 	}
 
 	#[test]
 	fn stream_codes_round_trip() {
-		let variants = [
+		// Only the registered codes are a wire contract, so only they round trip.
+		let registered = [
 			StreamError::Internal,
 			StreamError::Cancel,
 			StreamError::DeliveryTimeout,
 			StreamError::GoingAway,
 			StreamError::TooFarBehind,
 			StreamError::MalformedTrack,
+			StreamError::App(7),
+		];
+		for err in registered {
+			assert_eq!(StreamError::from_code(err.to_code()), err, "{err:?} did not round trip");
+		}
+
+		// The rest encode into the reserved 32-63 range and decode back as Unknown, for
+		// the same reason as the session codes above.
+		for err in [
 			StreamError::NotFound,
 			StreamError::Unroutable,
 			StreamError::Old,
@@ -651,10 +678,10 @@ mod tests {
 			StreamError::WrongSize,
 			StreamError::FrameTooLarge,
 			StreamError::TimestampMismatch,
-			StreamError::App(7),
-		];
-		for err in variants {
-			assert_eq!(StreamError::from_code(err.to_code()), err, "{err:?} did not round trip");
+		] {
+			let code = err.to_code();
+			assert!((0x20..0x40).contains(&code), "{err:?} left the reserved range");
+			assert_eq!(StreamError::from_code(code), StreamError::Unknown(code));
 		}
 
 		// The spaces are disjoint: 0 is a cancellation for a session but an internal
@@ -713,7 +740,11 @@ mod tests {
 		assert!(matches!(stream(0x1), Error::Cancel));
 		assert!(matches!(stream(0x0), Error::Remote(0)));
 		assert!(matches!(stream(0x5), Error::Lagged));
-		assert!(matches!(stream(0x22), Error::Old));
+
+		// 0x22 is what our own `Old` encodes to, but the draft reserves 32-63 rather than
+		// assigning it, so a peer's 0x22 stays opaque instead of being read as `Old`.
+		assert!(matches!(stream(0x22), Error::Remote(0x22)));
+		assert!(matches!(session(0x22), Error::Remote(0x22)));
 
 		// Neither: the transport itself failed.
 		assert!(matches!(

--- a/rs/moq-net/src/goaway.rs
+++ b/rs/moq-net/src/goaway.rs
@@ -21,7 +21,7 @@ use std::{
 	time::Duration,
 };
 
-use crate::{Error, Result};
+use crate::{Error, Result, SessionError};
 
 /// Maximum New Session URI length, in bytes. Both wires cap it here, and a
 /// receiver treats anything longer as a protocol violation.
@@ -291,7 +291,7 @@ pub(crate) async fn enforce<S: web_transport_trait::Session>(session: &S, timeou
 
 	if expired {
 		tracing::warn!(?timeout, "peer did not leave before the GOAWAY deadline; closing");
-		session.close(Error::GoawayTimeout.to_code(), &Error::GoawayTimeout.to_string());
+		session.close(SessionError::GoawayTimeout.to_code(), &Error::GoawayTimeout.to_string());
 	}
 }
 

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -369,7 +369,7 @@ pub fn start<S: web_transport_trait::Session>(
 		match &res {
 			Err(Error::Transport(_)) => {
 				tracing::info!("session terminated");
-				session.close(1, "");
+				session.close(SessionError::Internal.to_code(), "");
 			}
 			Err(err) => {
 				tracing::warn!(%err, "session error");
@@ -377,7 +377,7 @@ pub fn start<S: web_transport_trait::Session>(
 			}
 			_ => {
 				tracing::info!("session closed");
-				session.close(0, "");
+				session.close(SessionError::Cancel.to_code(), "");
 			}
 		}
 
@@ -833,7 +833,11 @@ mod tests {
 			.expect_err("a malformed NAMESPACE fails the session");
 
 		assert!(is_protocol_violation(&err), "not treated as the peer's fault: {err}");
-		assert_eq!(log.closes(), vec![(err.to_code(), err.to_string())]);
+		// A session close carries a session code, so the peer is told PROTOCOL_VIOLATION
+		// rather than the local table's value for whichever decode error we hit.
+		let (code, reason) = log.closes().first().cloned().expect("the session was closed");
+		assert_eq!(code, SessionError::ProtocolViolation.to_code());
+		assert_eq!(reason, err.to_string());
 	}
 
 	/// A subscriber issues one SUBSCRIBE_NAMESPACE per PERMITTED PREFIX, and asks for

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -1,6 +1,6 @@
 use crate::origin;
 use crate::{
-	Error, Origin,
+	Error, Origin, SessionError,
 	coding::{Decode, Encode, Reader, Stream, Writer},
 	ietf::{self, FetchHeader, RequestId},
 	setup,
@@ -110,7 +110,7 @@ pub fn start<S: web_transport_trait::Session>(
 			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
 				let Some(setup) = setup else {
 					let err = Error::ProtocolViolation;
-					session.close(err.to_code(), "setup stream required");
+					session.close(SessionError::from(&err).to_code(), "setup stream required");
 					return Err(err);
 				};
 				let control = Control::new(request_id_max, client);
@@ -373,7 +373,7 @@ pub fn start<S: web_transport_trait::Session>(
 			}
 			Err(err) => {
 				tracing::warn!(%err, "session error");
-				session.close(err.to_code(), err.to_string().as_ref());
+				session.close(SessionError::from(err).to_code(), err.to_string().as_ref());
 			}
 			_ => {
 				tracing::info!("session closed");
@@ -588,7 +588,7 @@ async fn run_unis<S: web_transport_trait::Session>(
 					Ok(msg) => msg,
 					Err(err) => {
 						tracing::warn!(%err, "setup decode error");
-						session.close(Error::ProtocolViolation.to_code(), "invalid setup");
+						session.close(SessionError::ProtocolViolation.to_code(), "invalid setup");
 						return;
 					}
 				};
@@ -598,7 +598,7 @@ async fn run_unis<S: web_transport_trait::Session>(
 						Ok(peer) => peer,
 						Err(err) => {
 							tracing::warn!(%err, "setup parameter decode error");
-							session.close(Error::ProtocolViolation.to_code(), "invalid setup parameters");
+							session.close(SessionError::ProtocolViolation.to_code(), "invalid setup parameters");
 							return;
 						}
 					};

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-	Error, Path, PathOwned, Timescale, broadcast,
+	Error, Path, PathOwned, SessionError, Timescale, broadcast,
 	coding::{Reader, Stream},
 	frame, group,
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
@@ -515,7 +515,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						// cluster draft requires closing the session on those; a stream
 						// the peer simply reset is not the peer's fault.
 						if is_protocol_violation(&err) {
-							this.session.close(err.to_code(), err.to_string().as_ref());
+							this.session
+								.close(SessionError::from(&err).to_code(), err.to_string().as_ref());
 						}
 						tracing::debug!(%err, "publish_namespace stream error");
 					}
@@ -1084,7 +1085,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				}
 
 				if let Err(err) = self.register_alias(request_id, alias) {
-					self.session.close(err.to_code(), err.to_string().as_ref());
+					self.session
+						.close(SessionError::from(&err).to_code(), err.to_string().as_ref());
 					self.remove_subscribe(request_id);
 					let _ = track.abort(err);
 					return;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1,4 +1,4 @@
-use crate::{announce, frame, group, origin, track};
+use crate::{SessionError, announce, frame, group, origin, track};
 use std::{sync::Arc, task::Poll, time::Duration};
 
 use bytes::Buf;
@@ -184,7 +184,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			// logs per-stream errors, so close the session here rather than letting a
 			// peer silently replace a redirect an observer may already be acting on.
 			tracing::warn!(%uri, "duplicate GOAWAY received; closing session");
-			self.session.close(err.to_code(), &err.to_string());
+			self.session.close(SessionError::from(&err).to_code(), &err.to_string());
 			return Err(err);
 		}
 		Ok(())
@@ -2641,7 +2641,7 @@ mod serve_group_test {
 		group.abort(Error::Old).unwrap();
 
 		assert!(matches!(serve.await, Err(Error::Old)));
-		assert_eq!(log.resets(), vec![Error::Old.to_code()]);
+		assert_eq!(log.resets(), vec![crate::StreamError::Old.to_code()]);
 	}
 }
 

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -248,7 +248,7 @@ pub fn start<S: web_transport_trait::Session>(
 		match &res {
 			Err(Error::Transport(_)) => {
 				tracing::info!("session terminated");
-				session.close(1, "");
+				session.close(SessionError::Internal.to_code(), "");
 			}
 			Err(err) => {
 				tracing::warn!(%err, "session error");
@@ -256,7 +256,7 @@ pub fn start<S: web_transport_trait::Session>(
 			}
 			_ => {
 				tracing::info!("session closed");
-				session.close(0, "");
+				session.close(SessionError::Cancel.to_code(), "");
 			}
 		}
 

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -1,6 +1,6 @@
 use crate::origin;
 use crate::{
-	Error, Origin, bandwidth,
+	Error, Origin, SessionError, bandwidth,
 	coding::{Reader, Stream, Writer},
 	lite::SessionInfo,
 	util::{MaybeBoxedExt, MaybeSendBox, TaskSet, err_only},
@@ -252,7 +252,7 @@ pub fn start<S: web_transport_trait::Session>(
 			}
 			Err(err) => {
 				tracing::warn!(%err, "session error");
-				session.close(err.to_code(), err.to_string().as_ref());
+				session.close(SessionError::from(err).to_code(), err.to_string().as_ref());
 			}
 			_ => {
 				tracing::info!("session closed");

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,7 +1,7 @@
 use crate::origin;
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
-	ALPN_LITE_06_WIP, Consume, Driver, Error, NEGOTIATED, Role, Session, Version, Versions,
+	ALPN_LITE_06_WIP, Consume, Driver, Error, NEGOTIATED, Role, Session, SessionError, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup, stats,
 };
@@ -537,7 +537,7 @@ impl<S: web_transport_trait::Session> RequestInner<S> {
 			Handshake::Legacy { session, .. } => session,
 			Handshake::LiteSetup { session, .. } => session,
 		};
-		session.close(err.to_code(), &err.to_string());
+		session.close(SessionError::from(&err).to_code(), &err.to_string());
 	}
 }
 

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -9,7 +9,7 @@ use std::{
 use web_transport_trait::Stats;
 
 use crate::{
-	Error, Version, bandwidth, goaway,
+	Error, SessionError, Version, bandwidth, goaway,
 	util::{MaybeBoxedExt, MaybeSendBox},
 };
 
@@ -104,12 +104,18 @@ impl Session {
 	/// Close the transport with an explicit error, instead of waiting for the last
 	/// clone to drop. Idempotent: the first close wins.
 	pub fn abort(&self, err: Error) {
-		self.shared.close(err.to_code(), err.to_string().as_ref());
+		self.shared
+			.close(SessionError::from(&err).to_code(), err.to_string().as_ref());
 	}
 
 	/// Block until the transport session is closed, returning the reason.
+	///
+	/// A close code the peer sent is decoded through the session registry (so an auth
+	/// rejection arrives as [`Error::Unauthorized`]); an unregistered code is kept
+	/// verbatim as [`Error::Remote`], and a close carrying no application code surfaces
+	/// as [`Error::Transport`]. See [`Error::from_transport`].
 	pub async fn closed(&self) -> Error {
-		Error::Transport(self.shared.inner.closed().await)
+		self.shared.inner.closed().await
 	}
 
 	/// Drain the peer gracefully: the handle for sending this session's single
@@ -254,7 +260,7 @@ impl SessionShared {
 
 impl Drop for SessionShared {
 	fn drop(&mut self) {
-		self.close(Error::Cancel.to_code(), "dropped");
+		self.close(SessionError::Cancel.to_code(), "dropped");
 	}
 }
 
@@ -400,7 +406,7 @@ impl<S: web_transport_trait::Session> SendBandwidth<S> {
 // allowing the !Send browser WebTransport on wasm.
 trait SessionInner: web_transport_trait::MaybeSend + web_transport_trait::MaybeSync {
 	fn close(&self, code: u32, reason: &str);
-	fn closed(&self) -> MaybeSendBox<'_, String>;
+	fn closed(&self) -> MaybeSendBox<'_, Error>;
 	fn stats(&self) -> ConnectionStats;
 }
 
@@ -409,19 +415,8 @@ impl<S: web_transport_trait::Session> SessionInner for S {
 		S::close(self, code, reason);
 	}
 
-	fn closed(&self) -> MaybeSendBox<'_, String> {
-		Box::pin(async move {
-			let err = S::closed(self).await;
-			// Surface the application close code and reason when the transport
-			// carries them: Display alone often drops both (e.g. quinn reports a
-			// bare "connection error: closed"), and the reason is how a peer
-			// distinguishes a GOAWAY-timeout force-close from a network failure.
-			match web_transport_trait::Error::session_error(&err) {
-				Some((code, reason)) if !reason.is_empty() => format!("code={code}: {reason}"),
-				Some((code, _)) => format!("code={code}: {err}"),
-				None => err.to_string(),
-			}
-		})
+	fn closed(&self) -> MaybeSendBox<'_, Error> {
+		Box::pin(async move { Error::from_transport(S::closed(self).await) })
 	}
 
 	fn stats(&self) -> ConnectionStats {

--- a/rs/moq-net/tests/goaway.rs
+++ b/rs/moq-net/tests/goaway.rs
@@ -147,7 +147,7 @@ async fn goaway_drains_without_a_wire_message_moq_lite_03() {
 		// The deadline still force-closes the session on schedule.
 		let err = pair.server.closed().await;
 		assert!(
-			err.to_string().contains("goaway timeout") || matches!(err, moq_net::Error::GoawayTimeout),
+			matches!(err, moq_net::Error::GoawayTimeout),
 			"expected a GoawayTimeout close, got {err}"
 		);
 	})
@@ -210,10 +210,11 @@ async fn goaway_timeout_force_close_moq_transport_17() {
 			.expect("session closed before GOAWAY");
 		assert_eq!(goaway.timeout, Some(Duration::from_millis(100)));
 
-		// The deadline fires and the driver force-closes with GoawayTimeout (33).
+		// The deadline fires and the driver force-closes with GOAWAY_TIMEOUT (0x10),
+		// which the peer decodes back through the session registry.
 		let reason = pair.client.closed().await;
 		assert!(
-			reason.to_string().contains("goaway timeout"),
+			matches!(reason, moq_net::Error::GoawayTimeout),
 			"peer should observe the GoawayTimeout close: {reason}"
 		);
 	})

--- a/rs/moq-wasm/src/transport.rs
+++ b/rs/moq-wasm/src/transport.rs
@@ -38,12 +38,21 @@ pub struct RecvStream(web_transport_wasm::RecvStream);
 pub struct Error(web_transport_wasm::Error);
 
 impl wtt::Error for Error {
+	// The browser reports one code either way, so the variant is the only thing saying
+	// which registry it belongs to. Answering both would have a stream reset decoded
+	// against the session table, since callers ask about the session first.
 	fn session_error(&self) -> Option<(u32, String)> {
-		self.0.code().map(|code| (code as u32, self.0.to_string()))
+		match self.0 {
+			web_transport_wasm::Error::Session(_) => self.0.code().map(|code| (code as u32, self.0.to_string())),
+			_ => None,
+		}
 	}
 
 	fn stream_error(&self) -> Option<u32> {
-		self.0.code().map(|c| c as u32)
+		match self.0 {
+			web_transport_wasm::Error::Stream(_) => self.0.code().map(|c| c as u32),
+			_ => None,
+		}
 	}
 }
 


### PR DESCRIPTION
Rebased off the #2618 / #2614 reconnect stack and onto `dev` directly, so this no longer waits on either. Started as "surface the peer's session close code" and turned into specifying the codes properly, since decoding one was the thing that wasn't sound.

## Root cause

A server that accepts the transport and then rejects at the MoQ layer (`Request::close` mapping 401/403) was unclassifiable at the client, in both implementations. The obvious fix, decoding the peer's close code, was itself unsound: moq-net's `to_code` table was implementation-specific and unspecified, so reading a peer's 26 as our `Lagged` assumed a shared meaning the wire never carried. The draft said only "an application-specific error code", with 0 the sole defined value.

Two real bugs fell out of the same gap:

- The IETF paths sent moq-lite codes on a moq-transport session (`ietf/session.rs`, `ietf/subscriber.rs`), so our `Unauthorized` arrived at a spec-compliant peer as `KEY_VALUE_FORMATTING_ERROR`.
- `from_transport` read a stream reset of 0 as a routine cancellation, where moq-transport defines 0 as `INTERNAL_ERROR` and puts `CANCELED` at 1.

Both trace to one `to_code` table serving two registries that moq-transport assigns independently.

## Fix

**Spec first** (`drafts/draft-lcurley-moq-lite.md`, new Error Codes section). Two spaces, mirroring moq-transport, each split into three ranges: 0-31 moq-transport's with moq-transport's meaning, 32-63 moq-lite's, 64+ the application's. Keeping the app base at 64 means the existing `App(n) => n + 64` offset needs no migration.

**Then the code.** `SessionError` and `StreamError` carry their own `to_code`/`from_code`. `StreamError::Session` flattens to `SESSION_CLOSED` on the wire, since the spaces are disjoint and the specific reason travels on the session close instead. `Error` stays the crate's local error type and maps into whichever registry the call site encodes for, so the ~2300 error *construction* sites are untouched: only the wire boundary (session closes, stream resets, `from_transport`) had to learn which space applies. `js/net` mirrors the tables as `SessionCode`/`StreamCode`.

Decoding is sound now that both registries are specified, so the reconnect loop stops on a session-level `UNAUTHORIZED` rather than retrying credentials that cannot work. That is the behavior the PR originally wanted, arrived at legitimately.

## What the rebase changed

The original branch sat on top of #2618, whose `Connection` handle (optimistic connect, one-shot mode, `with_reconnect`) does not exist on `dev`. Retargeted onto what `dev` actually has:

- The auth-terminal check moved from #2614's `Connection::run` into `dev`'s `Reconnect::run`, at the same point in the loop.
- The moq-ffi and py test edits are dropped: they only adjusted comments on tests that #2618 introduces, so there is nothing on `dev` to adjust. Both come back for free when #2618 rebases on this.
- The moq-native test pair is rewritten against `dev`'s API. `dev`'s `Client::connect` is a one-shot dial that completes the transport handshake before the MoQ-layer rejection arrives, so the dial succeeds and the rejection lands on the session's close. `session_close_surfaces_a_rejection_code` asserts that close decodes to `Error::Unauthorized`; `reconnect_stops_on_a_session_level_rejection` covers the loop via `Client::reconnect`. They sit next to `dev`'s existing WebSocket-401 pair, which makes the same claim for the transport-level rejection.

Also folded in three `session.close(Error::…to_code())` sites that landed on `dev` after this branch forked (two in `ietf/session.rs`'s SETUP decode, one in `ietf/subscriber.rs`'s PUBLISH_NAMESPACE handler). They are the same IETF-sends-lite-codes bug; leaving them would have defeated the fix.

## This is a wire break

Every code an existing implementation sends is renumbered. Sharpest edge: a stream reset of `0` changes from "cancelled" to "internal error". Old and new peers disagree about every code, which is why this targets `dev`.

## Tests

- `session_codes_round_trip` / `stream_codes_round_trip`: every variant survives encode/decode, the reused moq-transport values are pinned, ours are asserted inside 32-63, and the disjointness is pinned directly (`0` decodes differently per registry).
- `from_transport_selects_the_matching_registry`: same integer, both spaces, asserting they diverge.
- `session_close_surfaces_a_rejection_code` and `reconnect_stops_on_a_session_level_rejection`, per above. The latter proves the loop stops rather than burning the 5m backoff window.
- js: `the code tables match the spec` pins the TS tables against the same values, since they are a contract with the Rust side rather than a local convenience.

## Verification

Rust: 1243 tests across moq-net/moq-native/moq-relay/moq-ffi, all passing; `just rs check` clean (clippy `-D warnings`, fmt, rustdoc `-D warnings`, shear, sort).
JS: 355 tests in js/net, `tsc` and biome clean.
Drafts: `just drafts check` clean.

Not run on this rebase: the cross-language interop matrix (`just test smoke-full`). It passed on the pre-rebase branch, and the wire encoding is unchanged by the rebase, but the two implementations are validated against *each other* after renumbering, not against an older peer, which by design no longer interoperates.

Cross-package sync: `js/net` and `doc/lib/js/@moq/net.md` updated. No `moq-ffi` surface change, so no binding wrappers.

## Review round

A review pass found seven more instances of the same class of bug, all fixed here:

- `Reader::abort` still reset with `Error::to_code()`, so STOP_SENDING and RESET_STREAM carried values from different tables depending on which side refused.
- `moq-wasm`'s adapter answered both `session_error()` and `stream_error()` with the same code, and callers ask about the session first, so a browser stream reset decoded against the session table. The upstream error already distinguishes the two.
- A peer's `SESSION_CLOSED` (0x3) decoded through the *session* table into `Error::Remote(1)`, which re-encoded onto a stream as 0x1 = CANCELLED: a relay turned an upstream session teardown into a routine cancel. New `Error::SessionClosed` round-trips it.
- More generally `Error::Remote` carries no registry, so forwarding one into the other space could land on a value that *is* registered there (a session 0x4 becomes the stream's GOING_AWAY). It now sends the unspecified-error code instead of mistranslating, which is what the draft already requires of an unrecognized code. `MALFORMED_TRACK` gained a real `Error` variant so it keeps round-tripping rather than relying on `Remote`.
- `is_protocol_violation` names `WrongSize` and `Encode`, but neither reached `SessionError::ProtocolViolation`, so we closed with INTERNAL_ERROR right after deciding the peer broke the protocol.
- A `client.rs` assertion compared a close code against the local table, so it could no longer fail and had stopped guarding its regression.
- js/net sent no codes at all: every `abort`/`cancel` took a plain `Error`, which every transport puts on the wire as 0. Harmless while 0 meant "cancelled", not anymore, so a routine browser unsubscribe read as INTERNAL_ERROR at the publisher. `toTransport` builds the shape the transports read the code from, and a relayed reset keeps the peer's code. The `WebTransportError` test stub took its arguments in a different order than the real constructor, which is why nothing caught this; it now mirrors the DOM signature.

`Reload` also stops on an UNAUTHORIZED close, matching moq-native. The test that pinned the opposite argued the library had no basis to call an arbitrary code terminal, which was true before this code was specified.

Deliberately left as a follow-up: `Session::closed()` no longer surfaces the peer's close *reason* string, which the old `code=N: reason` formatting preserved. js/net keeps it, so the two disagree. For an application code the reason is the only place the meaning lives.

## Follow-ups, not in this PR

- moq-transport's session codes already reach 0x1B, leaving four free slots below the 32 boundary. Worth watching.
- `Reload.#retry` rejects `closed` on the retry timeout while leaving its effect and url/enabled subscriptions live, so a later url change dials again behind an already-rejected promise. Predates this branch.

`rs/moq-wasm` does not compile for wasm32 on `dev` either, for two reasons unrelated to this PR (`lib.rs:91` and `:177`); verified against a clean `origin/dev` worktree. Filed separately.

(Written by Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
