### PR TITLE
chore(rs): clean up pedantic clippy warnings

### DIFF
--- a/rs/hang/src/catalog/audio/codec.rs
+++ b/rs/hang/src/catalog/audio/codec.rs
@@ -89,8 +89,7 @@ impl AudioCodec {
 			Self::Mp3 => AudioCodecKind::Mp3,
 			// Legacy TS-bridge codecs aren't WebCodecs-decodable, so they share the
 			// coarse Unknown family for tag-only matching.
-			Self::Mp2 | Self::Ac3 | Self::Ec3 => AudioCodecKind::Unknown,
-			Self::Unknown(_) => AudioCodecKind::Unknown,
+			Self::Mp2 | Self::Ac3 | Self::Ec3 | Self::Unknown(_) => AudioCodecKind::Unknown,
 		}
 	}
 }

--- a/rs/hang/src/catalog/video/av1.rs
+++ b/rs/hang/src/catalog/video/av1.rs
@@ -66,20 +66,20 @@ impl std::fmt::Display for AV1 {
 		write!(
 			f,
 			".{:01}.{}{}{}.{:02}.{:02}.{:02}.{:01}",
-			self.mono_chrome as u8,
-			self.chroma_subsampling_x as u8,
-			self.chroma_subsampling_y as u8,
+			u8::from(self.mono_chrome),
+			u8::from(self.chroma_subsampling_x),
+			u8::from(self.chroma_subsampling_y),
 			{ self.chroma_sample_position },
 			self.color_primaries,
 			self.transfer_characteristics,
 			self.matrix_coefficients,
-			self.full_range as u8,
+			u8::from(self.full_range),
 		)
 	}
 }
 
 lazy_static::lazy_static! {
-	static ref AV1_REGEX: regex::Regex = regex::Regex::new(&r#"
+	static ref AV1_REGEX: regex::Regex = regex::Regex::new(&r"
 		^av01
 		\.(?<profile>[01])
 		\.(?<level>\d{2})(?<tier>\w)
@@ -92,7 +92,7 @@ lazy_static::lazy_static! {
 			\.(?<matrix>\d{2})
 			\.(?<full>[01])
 		)?
-		$"#.replace(['\n', ' ', '\t'], "")
+		$".replace(['\n', ' ', '\t'], "")
 	).unwrap();
 }
 

--- a/rs/moq-bench/build.rs
+++ b/rs/moq-bench/build.rs
@@ -23,7 +23,7 @@ fn git_version(prefix: &str) -> Option<String> {
 	let version = desc.strip_prefix(prefix)?;
 	// "0.7.13-3-gabcdef" -> "0.7.13-abcdef" (drop count, strip 'g')
 	if let Some((base, hash)) = version.rsplit_once("-g") {
-		let base = base.rsplit_once('-').map(|(b, _)| b).unwrap_or(base);
+		let base = base.rsplit_once('-').map_or(base, |(b, _)| b);
 		Some(format!("{base}-{hash}"))
 	} else {
 		Some(version.to_string())

--- a/rs/moq-cli/build.rs
+++ b/rs/moq-cli/build.rs
@@ -23,7 +23,7 @@ fn git_version(prefix: &str) -> Option<String> {
 	let version = desc.strip_prefix(prefix)?;
 	// "0.7.13-3-gabcdef" → "0.7.13-abcdef" (drop count, strip 'g')
 	if let Some((base, hash)) = version.rsplit_once("-g") {
-		let base = base.rsplit_once('-').map(|(b, _)| b).unwrap_or(base);
+		let base = base.rsplit_once('-').map_or(base, |(b, _)| b);
 		Some(format!("{base}-{hash}"))
 	} else {
 		Some(version.to_string())

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -247,9 +247,9 @@ impl Rendition {
 	/// The wall-clock time of a media timestamp, when the timeline advertises an anchor.
 	pub(crate) fn wall_clock(&self, pts: moq_net::Timestamp) -> Option<SystemTime> {
 		let wall = self.section.wall?;
-		let timescale = moq_net::Timescale::new(self.section.timescale as u64).ok()?;
-		let units = wall as u128 + pts.as_scale(timescale);
-		let unix_ms = MOQ_EPOCH_UNIX_MILLIS as u128 + units * 1000 / timescale.as_u64() as u128;
+		let timescale = moq_net::Timescale::new(u64::from(self.section.timescale)).ok()?;
+		let units = u128::from(wall) + pts.as_scale(timescale);
+		let unix_ms = u128::from(MOQ_EPOCH_UNIX_MILLIS) + units * 1000 / u128::from(timescale.as_u64());
 		Some(SystemTime::UNIX_EPOCH + Duration::from_millis(u64::try_from(unix_ms).ok()?))
 	}
 

--- a/rs/moq-json/src/snapshot.rs
+++ b/rs/moq-json/src/snapshot.rs
@@ -318,7 +318,7 @@ impl Inner {
 	/// that tips the group past `ratio * snapshot` still lands: a group overshoots by at most one delta
 	/// before rolling.
 	fn delta_allowed(&self) -> bool {
-		let ratio = self.config.delta_ratio as u64;
+		let ratio = u64::from(self.config.delta_ratio);
 		ratio != 0
 			&& self.group.is_some()
 			&& self.group_frames < MAX_DELTA_FRAMES

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -82,7 +82,7 @@ impl Producer {
 		Ok(Self {
 			inner: moq_json::stream::Producer::new(net, config),
 			track,
-			timescale: Timescale::new(Timeline::default_timescale() as u64).expect("default timescale is nonzero"),
+			timescale: Timescale::new(u64::from(Timeline::default_timescale())).expect("default timescale is nonzero"),
 			granularity: DEFAULT_GRANULARITY,
 			wall: Arc::new(Mutex::new(None)),
 		})
@@ -116,9 +116,9 @@ impl Producer {
 			.duration_since(SystemTime::UNIX_EPOCH)
 			.unwrap_or_default()
 			.as_millis();
-		let scale = self.timescale.as_u64() as u128;
+		let scale = u128::from(self.timescale.as_u64());
 		let pts_units = pts.as_scale(self.timescale);
-		let moq_millis = unix_millis.saturating_sub(hang::catalog::MOQ_EPOCH_UNIX_MILLIS as u128);
+		let moq_millis = unix_millis.saturating_sub(u128::from(hang::catalog::MOQ_EPOCH_UNIX_MILLIS));
 		let moq_units = moq_millis * scale / 1000;
 		*self.wall.lock().unwrap() = Some(moq_units.saturating_sub(pts_units) as u64);
 	}
@@ -220,7 +220,7 @@ impl<E: RecordExt> Consumer<E> {
 
 		Ok(Self {
 			inner: moq_json::stream::Consumer::new(track, config),
-			timescale: Timescale::new(section.timescale as u64)
+			timescale: Timescale::new(u64::from(section.timescale))
 				.map_err(|_| crate::Error::InvalidTimescale(section.timescale))?,
 		})
 	}

--- a/rs/moq-relay/build.rs
+++ b/rs/moq-relay/build.rs
@@ -23,7 +23,7 @@ fn git_version(prefix: &str) -> Option<String> {
 	let version = desc.strip_prefix(prefix)?;
 	// "0.10.13-3-gabcdef" → "0.10.13-abcdef" (drop count, strip 'g')
 	if let Some((base, hash)) = version.rsplit_once("-g") {
-		let base = base.rsplit_once('-').map(|(b, _)| b).unwrap_or(base);
+		let base = base.rsplit_once('-').map_or(base, |(b, _)| b);
 		Some(format!("{base}-{hash}"))
 	} else {
 		Some(version.to_string())

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -69,19 +69,19 @@ impl Connection {
 		};
 		if !authorized {
 			let _ = self.request.close(http::StatusCode::FORBIDDEN.as_u16()).await;
-			let wanted = role.map(|role| role.as_str()).unwrap_or("any");
+			let wanted = role.map_or("any", moq_net::Role::as_str);
 			anyhow::bail!("token does not grant {wanted} access to {}", token.root);
 		}
 
 		match (&publish, &subscribe) {
 			(Some(publish), Some(subscribe)) => {
-				tracing::info!(%transport, ?role, tier = %token.tier, root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "session accepted");
+				tracing::info!(%transport, ?role, tier = %token.tier, root = %token.root, publish = %publish.allowed().map(moq_net::Path::as_str).collect::<Vec<_>>().join(","), subscribe = %subscribe.allowed().map(moq_net::Path::as_str).collect::<Vec<_>>().join(","), "session accepted");
 			}
 			(Some(publish), None) => {
-				tracing::info!(%transport, ?role, tier = %token.tier, root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "publisher accepted");
+				tracing::info!(%transport, ?role, tier = %token.tier, root = %token.root, publish = %publish.allowed().map(moq_net::Path::as_str).collect::<Vec<_>>().join(","), "publisher accepted");
 			}
 			(None, Some(subscribe)) => {
-				tracing::info!(%transport, ?role, tier = %token.tier, root = %token.root, subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "subscriber accepted")
+				tracing::info!(%transport, ?role, tier = %token.tier, root = %token.root, subscribe = %subscribe.allowed().map(moq_net::Path::as_str).collect::<Vec<_>>().join(","), "subscriber accepted");
 			}
 			_ => unreachable!("authorized above guarantees at least one origin"),
 		}

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -182,11 +182,11 @@ impl Web {
 		// through to the landing page, and the client's WS fallback is silently
 		// dead.
 		#[cfg(feature = "websocket")]
-		let app = match self.config.ws {
-			true => app
-				.route("/", axum::routing::any(crate::websocket::serve_ws))
-				.route("/{*path}", axum::routing::any(crate::websocket::serve_ws)),
-			false => app,
+		let app = if self.config.ws {
+			app.route("/", axum::routing::any(crate::websocket::serve_ws))
+				.route("/{*path}", axum::routing::any(crate::websocket::serve_ws))
+		} else {
+			app
 		};
 
 		app.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]))
@@ -506,7 +506,11 @@ async fn serve_announced(
 		}
 	}
 
-	Ok(broadcasts.iter().map(|p| p.to_string()).collect::<Vec<_>>().join("\n"))
+	Ok(broadcasts
+		.iter()
+		.map(ToString::to_string)
+		.collect::<Vec<_>>()
+		.join("\n"))
 }
 
 /// Serve the given group for a given track
@@ -517,7 +521,7 @@ async fn serve_fetch(
 	State(state): State<Arc<WebState>>,
 ) -> axum::response::Result<ServeGroup> {
 	// The path containts a broadcast/track
-	let mut path: Vec<&str> = path.split("/").collect();
+	let mut path: Vec<&str> = path.split('/').collect();
 	let track = path.pop().unwrap().to_string();
 
 	// We need at least a broadcast and a track.

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -37,7 +37,7 @@ pub(crate) async fn serve_ws(
 
 	let host = uri
 		.authority()
-		.map(|authority| authority.as_str())
+		.map(axum::http::uri::Authority::as_str)
 		.or_else(|| headers.get(HOST).and_then(|value| value.to_str().ok()))
 		.ok_or(StatusCode::BAD_REQUEST)?;
 	let mut params = request_auth_params(&state.auth, host, &uri)?;

--- a/rs/moq-stats/src/produce.rs
+++ b/rs/moq-stats/src/produce.rs
@@ -188,7 +188,7 @@ impl Task {
 	/// Publishes stats broadcasts and writes a frame per drain. Runs until
 	/// every [`Producer`] clone is dropped (`weak.upgrade()` returns `None`).
 	async fn run(self, weak: Weak<Keepalive>) {
-		let node = self.node.as_ref().map(|p| p.as_str());
+		let node = self.node.as_ref().map(moq_net::Path::as_str);
 		let mut groups: HashMap<PathOwned, GroupPublisher> = HashMap::new();
 
 		if self.depth == 0 {

--- a/rs/moq-token-cli/build.rs
+++ b/rs/moq-token-cli/build.rs
@@ -23,7 +23,7 @@ fn git_version(prefix: &str) -> Option<String> {
 	let version = desc.strip_prefix(prefix)?;
 	// "0.5.17-3-gabcdef" → "0.5.17-abcdef" (drop count, strip 'g')
 	if let Some((base, hash)) = version.rsplit_once("-g") {
-		let base = base.rsplit_once('-').map(|(b, _)| b).unwrap_or(base);
+		let base = base.rsplit_once('-').map_or(base, |(b, _)| b);
 		Some(format!("{base}-{hash}"))
 	} else {
 		Some(version.to_string())

--- a/rs/moq-token/src/fs.rs
+++ b/rs/moq-token/src/fs.rs
@@ -12,9 +12,10 @@ const PRIVATE_MODE: u32 = 0o600;
 /// A public key keeps the default permissions, since it's meant to be handed around and often
 /// gets read by a relay running as a different user.
 pub(crate) fn write(path: &Path, contents: &str, private: bool) -> io::Result<()> {
-	match private {
-		true => write_private(path, contents),
-		false => std::fs::write(path, contents),
+	if private {
+		write_private(path, contents)
+	} else {
+		std::fs::write(path, contents)
 	}
 }
 

--- a/rs/moq-token/src/generate.rs
+++ b/rs/moq-token/src/generate.rs
@@ -14,8 +14,12 @@ pub fn generate(algorithm: Algorithm, id: Option<crate::KeyId>) -> crate::Result
 		Algorithm::HS256 => generate_hmac_key::<32>(),
 		Algorithm::HS384 => generate_hmac_key::<48>(),
 		Algorithm::HS512 => generate_hmac_key::<64>(),
-		Algorithm::RS256 | Algorithm::RS384 | Algorithm::RS512 => generate_rsa_key(2048),
-		Algorithm::PS256 | Algorithm::PS384 | Algorithm::PS512 => generate_rsa_key(2048),
+		Algorithm::RS256
+		| Algorithm::RS384
+		| Algorithm::RS512
+		| Algorithm::PS256
+		| Algorithm::PS384
+		| Algorithm::PS512 => generate_rsa_key(2048),
 		Algorithm::ES256 => generate_ec_key::<p256::NistP256>(EllipticCurve::P256),
 		Algorithm::ES384 => generate_ec_key::<p384::NistP384>(EllipticCurve::P384),
 		Algorithm::EdDSA => generate_ed25519_key(),

--- a/rs/moq-token/src/key.rs
+++ b/rs/moq-token/src/key.rs
@@ -424,8 +424,7 @@ impl Key {
 	pub(crate) fn is_private(&self) -> bool {
 		match &self.material {
 			KeyMaterial::OCT { .. } => true,
-			KeyMaterial::EC { d, .. } => d.is_some(),
-			KeyMaterial::OKP { d, .. } => d.is_some(),
+			KeyMaterial::EC { d, .. } | KeyMaterial::OKP { d, .. } => d.is_some(),
 			KeyMaterial::RSA { private, .. } => private.is_some(),
 		}
 	}


### PR DESCRIPTION
## Summary

- Clean up straightforward `clippy::pedantic` findings across the Rust workspace.
- Prefer lossless conversions, direct method references, simpler option combinators, and consolidated match arms without changing behavior.
- No public API, wire format, or catalog format changes. Cross-package sync does not apply.

## Public API changes

None.

## Test plan

- `cargo clippy -- -W clippy::pedantic`
- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just rs test -p hang -p moq-json -p moq-mux -p moq-token -p moq-stats -p moq-hls -p moq-relay` (944 passed)

(Written by GPT-5)