### PR TITLE
fix(native): bound Client::connect so a silent peer can't wedge reconnect

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -196,6 +196,10 @@ Client settings used when connecting to other relays (clustering).
 
 ```toml
 [client]
+# Maximum time for one outbound dial and MoQ handshake. Defaults to 30s.
+# Set to "0" to wait forever.
+timeout = "30s"
+
 # Disable TLS verification (development only!)
 tls.disable_verify = true
 
@@ -208,6 +212,9 @@ tls.disable_verify = true
 # Defaults to true only when no custom root is set.
 # tls.system_roots = true
 ```
+
+The connect timeout is also available as `--client-connect-timeout` or
+`MOQ_CLIENT_CONNECT_TIMEOUT`.
 
 ### \[server.quic] and \[client.quic]
 

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -96,5 +96,6 @@ bytes = "1"
 chrono = "0.4"
 rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs"] }
 tempfile = "3"
+tokio = { workspace = true, features = ["test-util"] }
 toml = "1.1"
 tracing-test = "0.2"

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -4,6 +4,8 @@ use std::future::Future;
 use std::net;
 use url::Url;
 
+const DEFAULT_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Configuration for the MoQ client.
 #[derive(Clone, Debug, clap::Parser, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields, default)]
@@ -35,7 +37,7 @@ pub struct ClientConfig {
 	pub backend: Option<QuicBackend>,
 
 	/// Maximum time for one [`Client::connect`], covering the dial and the MoQ
-	/// handshake. Set to 0 to wait forever.
+	/// handshake. Defaults to 30 seconds; set to 0 to wait forever.
 	///
 	/// This has to live above the transports rather than inside one: QUIC bounds its
 	/// own dial, but the WebSocket fallback and the handshake that follows either
@@ -46,12 +48,11 @@ pub struct ClientConfig {
 	#[arg(
 		id = "client-connect-timeout",
 		long = "client-connect-timeout",
-		default_value = "30s",
 		env = "MOQ_CLIENT_CONNECT_TIMEOUT",
 		value_parser = humantime::parse_duration,
 	)]
-	#[serde(with = "humantime_serde")]
-	pub timeout: std::time::Duration,
+	#[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde::option")]
+	pub timeout: Option<std::time::Duration>,
 
 	/// QUIC transport tuning (`--client-quic-*`): stream limits, GSO, timeouts.
 	#[command(flatten)]
@@ -101,6 +102,10 @@ impl ClientConfig {
 			moq_net::Versions::from(self.version.clone())
 		}
 	}
+
+	fn connect_timeout(&self) -> std::time::Duration {
+		self.timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT)
+	}
 }
 
 impl Default for ClientConfig {
@@ -109,7 +114,7 @@ impl Default for ClientConfig {
 			connect: None,
 			bind: "[::]:0".parse().unwrap(),
 			backend: None,
-			timeout: std::time::Duration::from_secs(30),
+			timeout: None,
 			quic: crate::quic::Client::default(),
 			version: Vec::new(),
 			tls: crate::tls::Client::default(),
@@ -207,11 +212,12 @@ impl Client {
 		};
 
 		let versions = config.versions();
+		let timeout = config.connect_timeout();
 		Ok(Self {
 			moq: moq_net::Client::new().with_versions(versions.clone()),
 			versions,
 			connect: config.connect,
-			timeout: config.timeout,
+			timeout,
 			backoff: config.backoff,
 			#[cfg(feature = "websocket")]
 			websocket: config.websocket,
@@ -960,7 +966,8 @@ mod tests {
 	#[test]
 	fn connect_timeout_defaults_to_thirty_seconds() {
 		let config = ClientConfig::parse_from(["test"]);
-		assert_eq!(config.timeout, std::time::Duration::from_secs(30));
+		assert_eq!(config.timeout, None);
+		assert_eq!(config.connect_timeout(), DEFAULT_CONNECT_TIMEOUT);
 	}
 
 	/// A peer that completes the TCP handshake and then never speaks: the QUIC arm
@@ -976,38 +983,37 @@ mod tests {
 		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
 		let addr = listener.local_addr().unwrap();
 
-		// Accept, then hold the connections open without ever writing a byte. Dropping
-		// them would surface as a clean EOF and let the fallback fail on its own.
-		tokio::spawn(async move {
-			let mut held = Vec::new();
-			while let Ok((stream, _)) = listener.accept().await {
-				held.push(stream);
-			}
-		});
-
-		let timeout = std::time::Duration::from_secs(1);
-		let client = ClientConfig {
-			timeout,
+		let timeout = DEFAULT_CONNECT_TIMEOUT;
+		let mut config = ClientConfig {
+			timeout: Some(timeout),
 			..Default::default()
-		}
-		.init()
-		.unwrap();
+		};
+		config.websocket.delay = Some(std::time::Duration::ZERO);
+		let client = config.init().unwrap();
 
 		// Nothing is listening on UDP, so the QUIC arm fails and leaves the WebSocket
 		// arm alone against the silent peer.
 		let url: Url = format!("https://127.0.0.1:{}/", addr.port()).parse().unwrap();
 
-		let started = std::time::Instant::now();
-		let err = match client.connect(url).await {
+		let mut attempt = Box::pin(client.connect(url));
+		let _silent = tokio::select! {
+			res = &mut attempt => match res {
+				Err(err) => panic!("connect failed before the silent peer accepted it: {err}"),
+				Ok(_) => panic!("connected to a peer that never spoke"),
+			},
+			res = listener.accept() => res.unwrap().0,
+		};
+
+		// Freeze only after TCP connected, then advance directly to the deadline. The
+		// accepted socket stays in scope and silent until the attempt returns.
+		tokio::time::pause();
+		tokio::time::advance(timeout).await;
+
+		let err = match attempt.await {
 			Err(err) => err,
 			Ok(_) => panic!("connected to a peer that never spoke"),
 		};
 
 		assert!(matches!(err, Error::ConnectTimeout(_)), "unexpected error: {err}");
-		assert!(
-			started.elapsed() < std::time::Duration::from_secs(15),
-			"connect outlived its own deadline by too much: {:?}",
-			started.elapsed()
-		);
 	}
 }

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -34,6 +34,25 @@ pub struct ClientConfig {
 	#[arg(id = "client-backend", long = "client-backend", env = "MOQ_CLIENT_BACKEND")]
 	pub backend: Option<QuicBackend>,
 
+	/// Maximum time for one [`Client::connect`], covering the dial and the MoQ
+	/// handshake. Set to 0 to wait forever.
+	///
+	/// This has to live above the transports rather than inside one: QUIC bounds its
+	/// own dial, but the WebSocket fallback and the handshake that follows either
+	/// transport have no deadline of their own, so a peer that accepts TCP and then
+	/// never speaks would hang the whole connect. [`Client::reconnect`] only re-arms
+	/// its backoff between attempts, so an attempt that never returns stalls the
+	/// retry loop indefinitely.
+	#[arg(
+		id = "client-connect-timeout",
+		long = "client-connect-timeout",
+		default_value = "30s",
+		env = "MOQ_CLIENT_CONNECT_TIMEOUT",
+		value_parser = humantime::parse_duration,
+	)]
+	#[serde(with = "humantime_serde")]
+	pub timeout: std::time::Duration,
+
 	/// QUIC transport tuning (`--client-quic-*`): stream limits, GSO, timeouts.
 	#[command(flatten)]
 	#[serde(default)]
@@ -90,6 +109,7 @@ impl Default for ClientConfig {
 			connect: None,
 			bind: "[::]:0".parse().unwrap(),
 			backend: None,
+			timeout: std::time::Duration::from_secs(30),
 			quic: crate::quic::Client::default(),
 			version: Vec::new(),
 			tls: crate::tls::Client::default(),
@@ -113,6 +133,8 @@ pub struct Client {
 	versions: moq_net::Versions,
 	/// The URL from [`ClientConfig::connect`], dialed by [`Client::publish`] / [`Client::consume`].
 	connect: Option<Url>,
+	/// Deadline for one [`Client::connect`], from [`ClientConfig::timeout`]. Zero waits forever.
+	timeout: std::time::Duration,
 	backoff: Backoff,
 	#[cfg(feature = "websocket")]
 	websocket: crate::websocket::Client,
@@ -189,6 +211,7 @@ impl Client {
 			moq: moq_net::Client::new().with_versions(versions.clone()),
 			versions,
 			connect: config.connect,
+			timeout: config.timeout,
 			backoff: config.backoff,
 			#[cfg(feature = "websocket")]
 			websocket: config.websocket,
@@ -329,7 +352,19 @@ impl Client {
 	pub async fn connect(&self, url: Url) -> crate::Result<moq_net::Session> {
 		// Each compiled backend adds state to this dispatch future. Keep it off the
 		// caller's stack so all-feature builds remain safe on standard 2 MiB threads.
-		let pair = Box::pin(self.connect_inner(url)).await?;
+		let attempt = Box::pin(self.connect_inner(url));
+
+		// The deadline covers the dial AND the handshake, for every transport: it is the
+		// only bound some of them have. Dropping `attempt` on expiry cancels whichever
+		// arm was still pending.
+		let pair = match self.timeout.is_zero() {
+			true => attempt.await?,
+			false => match tokio::time::timeout(self.timeout, attempt).await {
+				Ok(res) => res?,
+				Err(_) => return Err(Error::ConnectTimeout(self.timeout)),
+			},
+		};
+
 		tracing::info!(version = %pair.0.version(), "connected");
 		Ok(crate::spawn_session(pair))
 	}
@@ -920,5 +955,59 @@ mod tests {
 		.expect("race waited for WebSocket after QUIC transport connected")
 		.unwrap();
 		assert_eq!(value, super::TransportRace::Quic("quic"));
+	}
+
+	#[test]
+	fn connect_timeout_defaults_to_thirty_seconds() {
+		let config = ClientConfig::parse_from(["test"]);
+		assert_eq!(config.timeout, std::time::Duration::from_secs(30));
+	}
+
+	/// A peer that completes the TCP handshake and then never speaks: the QUIC arm
+	/// gives up on its own, but the WebSocket arm has no deadline of its own, so the
+	/// race stays pending forever. Without the connect timeout this test hangs.
+	///
+	/// That is what wedged a publisher against a livelocked relay: `Reconnect` only
+	/// re-arms its backoff (and checks its give-up timeout) *between* attempts, so an
+	/// attempt that never returns stalls the retry loop for good.
+	#[cfg(feature = "websocket")]
+	#[tokio::test]
+	async fn connect_times_out_against_a_peer_that_never_speaks() {
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = listener.local_addr().unwrap();
+
+		// Accept, then hold the connections open without ever writing a byte. Dropping
+		// them would surface as a clean EOF and let the fallback fail on its own.
+		tokio::spawn(async move {
+			let mut held = Vec::new();
+			while let Ok((stream, _)) = listener.accept().await {
+				held.push(stream);
+			}
+		});
+
+		let timeout = std::time::Duration::from_secs(1);
+		let client = ClientConfig {
+			timeout,
+			..Default::default()
+		}
+		.init()
+		.unwrap();
+
+		// Nothing is listening on UDP, so the QUIC arm fails and leaves the WebSocket
+		// arm alone against the silent peer.
+		let url: Url = format!("https://127.0.0.1:{}/", addr.port()).parse().unwrap();
+
+		let started = std::time::Instant::now();
+		let err = match client.connect(url).await {
+			Err(err) => err,
+			Ok(_) => panic!("connected to a peer that never spoke"),
+		};
+
+		assert!(matches!(err, Error::ConnectTimeout(_)), "unexpected error: {err}");
+		assert!(
+			started.elapsed() < std::time::Duration::from_secs(15),
+			"connect outlived its own deadline by too much: {:?}",
+			started.elapsed()
+		);
 	}
 }

--- a/rs/moq-native/src/error.rs
+++ b/rs/moq-native/src/error.rs
@@ -40,6 +40,16 @@ pub enum Error {
 	#[error("failed to connect to server")]
 	ConnectFailed,
 
+	/// The dial and handshake together outlived the connect timeout.
+	///
+	/// Not every transport bounds its own dial: QUIC gives up on its own, but a peer
+	/// that completes the TCP handshake and then never speaks leaves the WebSocket
+	/// fallback (and the MoQ handshake that follows either transport) pending with
+	/// nothing to time it out. This deadline turns that into an error the caller can
+	/// retry instead of a wait that never ends.
+	#[error("connect timed out after {0:?}")]
+	ConnectTimeout(std::time::Duration),
+
 	/// The server rejected the connection with an auth status. See [`crate::ConnectError`].
 	#[error(transparent)]
 	Connect(#[from] crate::ConnectError),

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -334,6 +334,27 @@ congestion_control = "loss"
 		);
 	}
 
+	/// The client connect timeout is optional at the clap layer so an absent CLI
+	/// flag does not replace the TOML value with the resolved 30-second default.
+	#[test]
+	fn cli_does_not_clobber_toml_client_connect_timeout() {
+		let _env = EnvGuard::clear(&["MOQ_CLIENT_CONNECT_TIMEOUT"]);
+
+		let toml = r#"
+[client]
+timeout = "2m"
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("client-connect-timeout-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(config.client.timeout, Some(std::time::Duration::from_secs(120)));
+	}
+
 	#[test]
 	fn cli_does_not_clobber_toml_web_https_cert_arrays() {
 		let _env = EnvGuard::clear(&["MOQ_WEB_HTTPS_CERT", "MOQ_WEB_HTTPS_KEY"]);


### PR DESCRIPTION
## Summary

- `Client::connect` had no overall deadline. QUIC bounds its own dial, but the WebSocket fallback does not, and neither does the MoQ handshake that follows either transport.
- **Root cause**: against a peer whose kernel completes the TCP handshake while its process never speaks, the QUIC arm fails on its own timeout and `race_transport_connect` then waits on the WebSocket arm forever. That prevents `Reconnect::run` from sleeping its backoff or evaluating `backoff.timeout`, because both happen between attempts.
- The deadline lives above the transports so it also covers the post-dial MoQ handshake. It defaults to 30 seconds, matching the QUIC dial timeout. A configured zero waits forever.
- The clap-facing timeout is optional so an absent CLI or environment value cannot overwrite the relay's TOML configuration during `update_from`.

## Public API changes

Both changes are additive, so this targets `main`:

- `ClientConfig::timeout: Option<Duration>` is a new `pub` field (`--client-connect-timeout`, `MOQ_CLIENT_CONNECT_TIMEOUT`). `None` resolves to 30 seconds when the client is built, and `Some(Duration::ZERO)` waits forever. `ClientConfig` is `#[non_exhaustive]`, so no external struct literal breaks.
- `Error::ConnectTimeout(Duration)` is a new variant. `Error` is `#[non_exhaustive]`, so no external match breaks.

No changes to `rs/moq-net`, the wire format, or any published binding.

## Test plan

- `connect_times_out_against_a_peer_that_never_speaks` accepts and holds a real TCP connection, then advances paused Tokio time directly to the deadline.
- `connect_timeout_defaults_to_thirty_seconds` guards the resolved default while leaving the clap field unset.
- `cli_does_not_clobber_toml_client_connect_timeout` verifies `[client] timeout = "2m"` survives the relay's CLI merge.
- `just rs test -p moq-native`: 183 passed, 0 failed.
- `just rs test -p moq-relay cli_does_not_clobber_toml_client_connect_timeout`: passed.
- `cargo clippy -p moq-native -p moq-relay --all-targets -- -D warnings`: clean.
- `cd doc && bun run check`: 24 tests passed and the VitePress site built.
- `just check` passed JS, Rust check/clippy/docs, formatting, dependency, and Markdown checks. The final local GitHub workflow audit could not parse the unchanged `.github/workflows/apt-repo.yml` `on:` value.

## Cross-Package Sync

The relay config and behavior row applies. `doc/bin/relay/config.md` now documents the TOML, CLI, and environment forms, the 30-second default, and zero-as-unbounded behavior. No other sync row applies.

(Written by Claude Opus 5 and GPT-5.6 Sol)
