### PR TITLE
fix(bindings): confine the video encoder to one thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,6 +4857,7 @@ dependencies = [
  "openh264",
  "openh264-sys2",
  "pipewire",
+ "pollster",
  "thiserror 2.0.19",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,6 +4838,7 @@ dependencies = [
  "cudarc",
  "dispatch2",
  "fast_image_resize",
+ "futures",
  "h264-reader",
  "hang",
  "libloading 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,6 +4099,7 @@ dependencies = [
  "moq-native",
  "moq-net",
  "moq-video",
+ "pollster",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -101,6 +101,16 @@ Keyframes are the encoder's business: it inserts them per `encode::Config::gop`,
 and `Encoder::keyframe` is there for the rarer case where you need one at a
 specific frame.
 
+`encode::Sink` is the same encoder with a thread of its own. Reach for it when the
+codec outlives a single thread's stack: an object shared between threads, a handle
+behind an FFI boundary, or a task that migrates between executor workers. Hardware
+codecs are not all thread-agnostic (a Media Foundation MFT's COM apartment is
+per-thread, so building it on one thread and dropping it on another corrupts COM
+state), and the sink confines the whole encoder lifetime to one thread so callers
+do not have to. Each call comes in an `async` flavor for a task and a `blocking_`
+one for a plain thread. A plain `Encoder` you build, drive, and drop inside one
+function needs none of this.
+
 ## Subscribing
 
 `decode::Consumer` is the mirror. It reads the rendition's catalog entry to pick a

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -101,14 +101,15 @@ Keyframes are the encoder's business: it inserts them per `encode::Config::gop`,
 and `Encoder::keyframe` is there for the rarer case where you need one at a
 specific frame.
 
-`encode::Sink` is the same encoder with a thread of its own. Reach for it when the
-codec outlives a single thread's stack: an object shared between threads, a handle
-behind an FFI boundary, or a task that migrates between executor workers. Hardware
-codecs are not all thread-agnostic (a Media Foundation MFT's COM apartment is
-per-thread, so building it on one thread and dropping it on another corrupts COM
-state), and the sink confines the whole encoder lifetime to one thread so callers
-do not have to. Each call comes in an `async` flavor for a task and a `blocking_`
-one for a plain thread. A plain `Encoder` you build, drive, and drop inside one
+`encode::Sink` is the same encoder with a thread of its own, and an `async` API on
+top. Reach for it when the codec outlives a single thread's stack: an object
+shared between threads, a handle behind an FFI boundary, or a task that migrates
+between executor workers. Hardware codecs are not all thread-agnostic (a Media
+Foundation MFT's COM apartment is per-thread, so building it on one thread and
+dropping it on another corrupts COM state), and the sink confines the whole
+encoder lifetime to one thread so callers do not have to. Awaiting rather than
+blocking is the point: the executor keeps its worker while a slow hardware encoder
+works through a frame. A plain `Encoder` you build, drive, and drop inside one
 function needs none of this.
 
 ## Subscribing

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -27,6 +27,9 @@ moq-native = { workspace = true, default-features = true }
 moq-net = { workspace = true }
 # Enable the NVENC / VAAPI / NVDEC hardware codecs (default-off at the workspace level).
 moq-video = { workspace = true, features = ["nvenc", "vaapi", "nvdec"] }
+# Blocking on `encode::Sink` from the synchronous C entry points; see
+# `video::block_on` for why not a tokio helper.
+pollster = "1.0"
 serde_json = "1"
 thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -1614,6 +1614,65 @@ fn video_raw_publish_consume() {
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
+/// Regression: a producer handle is just an integer, so a C caller may drive it
+/// from any thread. `ffi::enter` serializes those calls but runs each on the
+/// calling thread, so holding a bare `Encoder` was unsound on Windows, where the
+/// codec's COM apartment is per-thread: it was opened on the publishing thread
+/// and closed on whichever thread called finish. The confinement itself is
+/// asserted in moq-video (`encode::sink`); this pins that the C surface supports
+/// the usage, including the drain on finish.
+#[test]
+fn video_raw_publish_from_many_threads() {
+	let origin = id(moq_origin_create());
+	let broadcast = publish_broadcast(origin, b"video-raw-threads-test");
+
+	let input = moq_video_encoder_input {
+		format: moq_video_pixel_format::MOQ_VIDEO_PIXEL_FORMAT_RGBA as u32,
+		width: 320,
+		height: 240,
+		framerate: 30,
+	};
+	let output = moq_video_encoder_output {
+		codec: moq_video_codec::MOQ_VIDEO_CODEC_H264 as u32,
+		// An explicit ceiling so the retunes below stay under the rate the encoder
+		// opened at, which openh264 requires.
+		bitrate: 1_000_000,
+		gop: 0,
+		kind: moq_video_encoder_kind::MOQ_VIDEO_ENCODER_KIND_SOFTWARE as u32,
+		encoder: std::ptr::null(),
+		encoder_len: 0,
+	};
+	let producer = id(unsafe { moq_publish_video_raw(broadcast, &input, &output) });
+
+	// A fresh caller thread per frame, never the one that published.
+	let rgba = std::sync::Arc::new(gray_rgba(320, 240));
+	for i in 0..8u64 {
+		let rgba = rgba.clone();
+		std::thread::spawn(move || {
+			if i == 0 {
+				assert_eq!(moq_publish_video_raw_cut(producer), 0);
+			}
+			let frame = moq_video_encoder_frame {
+				timestamp_us: i * 33_333,
+				data: rgba.as_ptr(),
+				data_size: rgba.len(),
+			};
+			assert_eq!(unsafe { moq_publish_video_raw_frame(producer, &frame) }, 0);
+			assert_eq!(moq_publish_video_raw_bitrate(producer, 900_000 - i), 0);
+		})
+		.join()
+		.unwrap();
+	}
+
+	// ...and finished, so the encoder is drained and dropped, from yet another.
+	std::thread::spawn(move || assert_eq!(moq_publish_video_raw_finish(producer), 0))
+		.join()
+		.unwrap();
+
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
 /// A raw video producer rejects a buffer that isn't one picture at the
 /// configured resolution, rather than reinterpreting it.
 #[test]

--- a/rs/libmoq/src/video.rs
+++ b/rs/libmoq/src/video.rs
@@ -169,6 +169,19 @@ pub struct Video {
 	frames: NonZeroSlab<VideoFrame>,
 }
 
+/// Wait out an encode-thread round trip from a C entry point.
+///
+/// The C ABI hands back a status code, so there is no executor to yield to and
+/// this is where [`Sink`](moq_video::encode::Sink)'s futures stop. Blocking is
+/// also what paces the caller: a raw frame is megabytes, so a publish free to run
+/// ahead of the codec would queue pictures without bound.
+///
+/// `pollster` rather than a tokio helper because those panic when the calling
+/// thread is driving a runtime, which the one dispatching a callback is.
+fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+	pollster::block_on(future)
+}
+
 /// An encoder paired with the track publishing its output, plus the pixel format
 /// its caller feeds it (fixed at publish time, so a frame carries only pixels and
 /// a timestamp).
@@ -238,7 +251,7 @@ impl Video {
 	) -> Result<Id, Error> {
 		// Open the encoder first: a config this machine can't encode should fail
 		// without leaving a track advertised that will never carry frames.
-		let encoder = moq_video::encode::Sink::blocking_open(&config)?;
+		let encoder = block_on(moq_video::encode::Sink::open(&config))?;
 		let producer = moq_video::encode::Producer::new(broadcast.clone(), catalog, config.codec)?;
 		self.producers.insert(VideoEncoder {
 			encoder,
@@ -264,7 +277,7 @@ impl Video {
 		let frame = moq_video::Frame::new(surface, moq_net::Timestamp::from_micros(timestamp_us)?);
 		// A backend that pipelines hands back an earlier frame's output, so this is
 		// zero or more access units rather than one per call.
-		let encoded = entry.encoder.blocking_encode(frame)?;
+		let encoded = block_on(entry.encoder.encode(frame))?;
 		entry.producer.publish(&encoded)?;
 		Ok(())
 	}
@@ -279,7 +292,7 @@ impl Video {
 
 	pub fn publish_bitrate(&mut self, id: Id, bitrate: u64) -> Result<(), Error> {
 		let entry = self.producers.get_mut(id).ok_or(Error::MediaNotFound)?;
-		entry.encoder.blocking_set_bitrate(bitrate)?;
+		block_on(entry.encoder.set_bitrate(bitrate))?;
 		Ok(())
 	}
 
@@ -290,7 +303,7 @@ impl Video {
 		} = entry;
 		// Drain the codec into the track before ending it, so the last frames land
 		// in it rather than being dropped with the encoder.
-		let drained = encoder.blocking_finish().and_then(|encoded| producer.publish(&encoded));
+		let drained = block_on(encoder.finish()).and_then(|encoded| producer.publish(&encoded));
 		finalize(producer, drained)
 	}
 

--- a/rs/libmoq/src/video.rs
+++ b/rs/libmoq/src/video.rs
@@ -172,8 +172,15 @@ pub struct Video {
 /// An encoder paired with the track publishing its output, plus the pixel format
 /// its caller feeds it (fixed at publish time, so a frame carries only pixels and
 /// a timestamp).
+///
+/// The encoder is a [`Sink`](moq_video::encode::Sink) rather than a bare
+/// `Encoder` because [`ffi::enter`] serializes calls without confining them:
+/// each one runs on whichever thread the C caller used, so a bare `Encoder`
+/// would be built on one thread and dropped on another, unbalancing the
+/// per-thread COM apartment the Windows backend opens. The sink owns the thread
+/// instead, so every caller is welcome.
 struct VideoEncoder {
-	encoder: moq_video::encode::Encoder,
+	encoder: moq_video::encode::Sink,
 	producer: moq_video::encode::Producer<moq_mux::catalog::hang::Extra>,
 	format: moq_video_pixel_format,
 	/// The encoded resolution, from the publish config. Frames carry only pixels,
@@ -231,7 +238,7 @@ impl Video {
 	) -> Result<Id, Error> {
 		// Open the encoder first: a config this machine can't encode should fail
 		// without leaving a track advertised that will never carry frames.
-		let encoder = moq_video::encode::Encoder::new(&config)?;
+		let encoder = moq_video::encode::Sink::blocking_open(&config)?;
 		let producer = moq_video::encode::Producer::new(broadcast.clone(), catalog, config.codec)?;
 		self.producers.insert(VideoEncoder {
 			encoder,
@@ -257,7 +264,7 @@ impl Video {
 		let frame = moq_video::Frame::new(surface, moq_net::Timestamp::from_micros(timestamp_us)?);
 		// A backend that pipelines hands back an earlier frame's output, so this is
 		// zero or more access units rather than one per call.
-		let encoded = entry.encoder.encode(&frame)?;
+		let encoded = entry.encoder.blocking_encode(frame)?;
 		entry.producer.publish(&encoded)?;
 		Ok(())
 	}
@@ -272,7 +279,7 @@ impl Video {
 
 	pub fn publish_bitrate(&mut self, id: Id, bitrate: u64) -> Result<(), Error> {
 		let entry = self.producers.get_mut(id).ok_or(Error::MediaNotFound)?;
-		entry.encoder.set_bitrate(bitrate)?;
+		entry.encoder.blocking_set_bitrate(bitrate)?;
 		Ok(())
 	}
 
@@ -283,7 +290,7 @@ impl Video {
 		} = entry;
 		// Drain the codec into the track before ending it, so the last frames land
 		// in it rather than being dropped with the encoder.
-		let drained = encoder.finish().and_then(|encoded| producer.publish(&encoded));
+		let drained = encoder.blocking_finish().and_then(|encoded| producer.publish(&encoded));
 		finalize(producer, drained)
 	}
 

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -33,6 +33,9 @@ moq-net = { workspace = true }
 # Default features only: the Linux hardware codecs stay off so the wrappers'
 # cross-compiled targets (Android, iOS) don't pull a CUDA / libva graph.
 moq-video = { workspace = true }
+# Blocking on `encode::Sink` from the synchronous producer exports; see
+# `video::block_on` for why not a tokio helper.
+pollster = "1.0"
 serde_json = "1"
 thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }
@@ -44,4 +47,3 @@ url = "2"
 uniffi = { version = "0.31", features = ["build"] }
 
 [dev-dependencies]
-pollster = "1.0"

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -1006,6 +1006,85 @@ async fn video_raw_publish_consume() {
 	broadcast.finish().unwrap();
 }
 
+/// Regression: a `MoqVideoProducer` is shared, so its calls land on whichever
+/// thread the caller is on, and none of them need be the thread that published.
+/// Holding a bare `Encoder` made that unsound on Windows, where the codec's COM
+/// apartment is per-thread: it was opened on the publishing thread and closed on
+/// whichever thread dropped the object. The confinement itself is asserted in
+/// moq-video (`encode::sink`); this pins that the binding supports the usage
+/// end to end, including the drain on `finish`.
+#[tokio::test]
+async fn video_raw_publish_from_many_threads() {
+	use crate::video::*;
+
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let broadcast = origin.create_broadcast("video-raw-threads".into()).unwrap();
+
+	let video = broadcast
+		.publish_video(
+			MoqVideoEncoderInput {
+				format: MoqVideoPixelFormat::Rgba,
+				width: 320,
+				height: 240,
+				framerate: 30,
+			},
+			MoqVideoEncoderOutput {
+				codec: MoqVideoCodec::H264,
+				// An explicit ceiling so the retunes below stay under the rate the
+				// encoder opened at, which openh264 requires.
+				bitrate: Some(1_000_000),
+				gop: None,
+				kind: MoqVideoEncoderKind::Software,
+			},
+		)
+		.unwrap();
+
+	// A fresh caller thread per frame, never the one that published.
+	let rgba = std::sync::Arc::new(vec![0x80u8; 320 * 240 * 4]);
+	for i in 0..8u64 {
+		let video = video.clone();
+		let rgba = rgba.clone();
+		std::thread::spawn(move || {
+			if i == 0 {
+				video.cut().unwrap();
+			}
+			video
+				.write(MoqVideoFrame {
+					timestamp_us: i * 33_333,
+					data: rgba.as_ref().clone(),
+				})
+				.unwrap();
+			video.set_bitrate(900_000 - i).unwrap();
+		})
+		.join()
+		.unwrap();
+	}
+
+	// The rendition only exists once the importer parsed the codec config out of
+	// an encoded keyframe, so this is what says the frames really were encoded.
+	// Checked before finishing, which withdraws it again.
+	let consumer = origin.consume();
+	let announced = consumer.announced("".into()).unwrap();
+	let announcement = tokio::time::timeout(TIMEOUT, announced.next())
+		.await
+		.expect("timed out")
+		.unwrap()
+		.expect("expected announcement");
+	let catalog_consumer = announcement.broadcast().subscribe_catalog().await.unwrap();
+	let catalog = tokio::time::timeout(TIMEOUT, catalog_consumer.next())
+		.await
+		.expect("timed out")
+		.unwrap()
+		.expect("expected catalog");
+	assert_eq!(catalog.video.len(), 1);
+
+	// ...and finished, so the encoder is drained and dropped, from yet another.
+	let closer = video.clone();
+	std::thread::spawn(move || closer.finish()).join().unwrap().unwrap();
+
+	broadcast.finish().unwrap();
+}
+
 /// A raw video producer rejects a buffer that isn't one picture at the
 /// configured resolution, rather than reinterpreting it, and rejects any write
 /// after `finish`.

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -142,6 +142,20 @@ fn finalize(
 	}
 }
 
+/// Wait out an encode-thread round trip from a synchronous export.
+///
+/// The producer methods are sync, matching every other write path here
+/// ([`MoqAudioProducer::write`](crate::audio::MoqAudioProducer::write) and the
+/// json ones), so this is where [`Sink`](moq_video::encode::Sink)'s futures stop.
+/// Blocking is also what paces the caller: a raw frame is megabytes, so a `write`
+/// free to run ahead of the codec would queue pictures without bound.
+///
+/// `pollster` rather than a tokio helper because those panic when the calling
+/// thread is driving a runtime, which the one dispatching a uniffi callback is.
+fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+	pollster::block_on(future)
+}
+
 /// An encoder paired with the track publishing its output.
 ///
 /// The encoder is a [`Sink`](moq_video::encode::Sink) rather than a bare
@@ -172,7 +186,7 @@ impl VideoProducer {
 		let frame = moq_video::Frame::new(surface, moq_net::Timestamp::from_micros(frame.timestamp_us)?);
 		// A backend that pipelines hands back an earlier frame's output, so this is
 		// zero or more access units rather than one per call.
-		let encoded = self.encoder.blocking_encode(frame)?;
+		let encoded = block_on(self.encoder.encode(frame))?;
 		self.producer.publish(&encoded)?;
 		Ok(())
 	}
@@ -183,7 +197,7 @@ impl VideoProducer {
 		} = self;
 		// Drain the codec into the track before ending it, so the last frames land
 		// in it rather than being dropped with the encoder.
-		let drained = encoder.blocking_finish().and_then(|encoded| producer.publish(&encoded));
+		let drained = block_on(encoder.finish()).and_then(|encoded| producer.publish(&encoded));
 		finalize(producer, drained)
 	}
 }
@@ -248,7 +262,7 @@ impl MoqVideoProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.inner.lock().unwrap();
 		let producer = guard.as_mut().ok_or(MoqError::Closed)?;
-		Ok(producer.encoder.blocking_set_bitrate(bitrate)?)
+		Ok(block_on(producer.encoder.set_bitrate(bitrate))?)
 	}
 
 	/// Flush any frames the codec is still holding and finalize the track.
@@ -286,7 +300,7 @@ impl MoqBroadcastProducer {
 
 		// Open the encoder first: a config this machine can't encode should fail
 		// without leaving a track advertised that will never carry frames.
-		let encoder = moq_video::encode::Sink::blocking_open(&config)?;
+		let encoder = block_on(moq_video::encode::Sink::open(&config))?;
 		let producer = self.with_state(|state| {
 			Ok(moq_video::encode::Producer::new(
 				state.broadcast.clone(),

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -143,8 +143,14 @@ fn finalize(
 }
 
 /// An encoder paired with the track publishing its output.
+///
+/// The encoder is a [`Sink`](moq_video::encode::Sink) rather than a bare
+/// `Encoder` because this object is shared across threads: uniffi hands it to
+/// whichever thread the caller writes from, and an `Encoder` built on one thread
+/// and dropped on another unbalances the per-thread COM apartment the Windows
+/// backend opens. The sink owns the thread instead, so every caller is welcome.
 struct VideoProducer {
-	encoder: moq_video::encode::Encoder,
+	encoder: moq_video::encode::Sink,
 	producer: moq_video::encode::Producer<moq_mux::catalog::hang::Extra>,
 	format: MoqVideoPixelFormat,
 	/// The encoded resolution, from the publish config. Frames carry only pixels,
@@ -166,7 +172,7 @@ impl VideoProducer {
 		let frame = moq_video::Frame::new(surface, moq_net::Timestamp::from_micros(frame.timestamp_us)?);
 		// A backend that pipelines hands back an earlier frame's output, so this is
 		// zero or more access units rather than one per call.
-		let encoded = self.encoder.encode(&frame)?;
+		let encoded = self.encoder.blocking_encode(frame)?;
 		self.producer.publish(&encoded)?;
 		Ok(())
 	}
@@ -177,7 +183,7 @@ impl VideoProducer {
 		} = self;
 		// Drain the codec into the track before ending it, so the last frames land
 		// in it rather than being dropped with the encoder.
-		let drained = encoder.finish().and_then(|encoded| producer.publish(&encoded));
+		let drained = encoder.blocking_finish().and_then(|encoded| producer.publish(&encoded));
 		finalize(producer, drained)
 	}
 }
@@ -242,7 +248,7 @@ impl MoqVideoProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.inner.lock().unwrap();
 		let producer = guard.as_mut().ok_or(MoqError::Closed)?;
-		Ok(producer.encoder.set_bitrate(bitrate)?)
+		Ok(producer.encoder.blocking_set_bitrate(bitrate)?)
 	}
 
 	/// Flush any frames the codec is still holding and finalize the track.
@@ -280,7 +286,7 @@ impl MoqBroadcastProducer {
 
 		// Open the encoder first: a config this machine can't encode should fail
 		// without leaving a track advertised that will never carry frames.
-		let encoder = moq_video::encode::Encoder::new(&config)?;
+		let encoder = moq_video::encode::Sink::blocking_open(&config)?;
 		let producer = self.with_state(|state| {
 			Ok(moq_video::encode::Producer::new(
 				state.broadcast.clone(),

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -67,7 +67,14 @@ impl Rung {
 	/// decoded frame where the decoder knows. A rung below 576 lines fed by an HD
 	/// source carries the source's space, not the one its own size implies, so
 	/// leaving this to the encoder's size guess would label the rung wrongly.
-	fn encode(&self, color: Option<moq_video::Color>) -> Result<moq_video::encode::Encoder, Error> {
+	///
+	/// A [`Sink`](moq_video::encode::Sink) rather than a bare `Encoder`: both
+	/// callers hold it across `.await`, so on a multi-thread runtime the future
+	/// can migrate workers between opening the codec and dropping it. The Windows
+	/// backend's COM apartment is per-thread, so that would leak the opening
+	/// worker's initialization and uninitialize COM on one that never initialized
+	/// it. The sink owns a thread and stays on it.
+	async fn encode(&self, color: Option<moq_video::Color>) -> Result<moq_video::encode::Sink, Error> {
 		let mut config =
 			moq_video::encode::Config::new(self.info.size.width, self.info.size.height, self.info.framerate);
 		config.bitrate = Some(self.info.bitrate);
@@ -76,7 +83,7 @@ impl Rung {
 		// Keyframes are forced at every group boundary; the GOP is only a
 		// backstop against pathologically long source groups.
 		config.gop = self.info.framerate.saturating_mul(8).max(1);
-		Ok(moq_video::encode::Encoder::new(&config)?)
+		Ok(moq_video::encode::Sink::open(&config).await?)
 	}
 }
 
@@ -126,7 +133,7 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 		// Built from the first frame: the encoder writes that frame's color space
 		// into the bitstream, so it cannot open before one has arrived. A keyframe
 		// asked for at a group boundary waits here until it exists.
-		let mut encoder: Option<moq_video::encode::Encoder> = None;
+		let mut encoder: Option<moq_video::encode::Sink> = None;
 		let mut pending_keyframe = false;
 
 		// The output group currently being written, if the feed is mid-group.
@@ -151,7 +158,7 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 					// group's tail would otherwise emit it into the new group, ahead of
 					// the keyframe requested just below.
 					if let Some(encoder) = &mut encoder {
-						encoder.flush()?;
+						encoder.flush().await?;
 					}
 					if let Some(output) = current.take() {
 						// A group boundary without an end: treat as incomplete.
@@ -192,32 +199,28 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 					// CPU. The resize carries the source's color space across, which is
 					// why the encoder is opened from the scaled frame rather than from
 					// this rung's size.
-					let resized;
-					let frame: &moq_video::Frame = match frame.size() == rung.info.size {
-						true => &frame,
-						false => {
-							resized = frame.resize_with(rung.info.size, &rung.resize)?;
-							&resized
-						}
+					let frame: Arc<moq_video::Frame> = match frame.size() == rung.info.size {
+						true => frame,
+						false => Arc::new(frame.resize_with(rung.info.size, &rung.resize)?),
 					};
 					let encoder = match &mut encoder {
 						Some(encoder) => encoder,
 						None => {
-							let mut opened = rung.encode(frame.surface.color())?;
+							let mut opened = rung.encode(frame.surface.color()).await?;
 							if std::mem::take(&mut pending_keyframe) {
 								opened.keyframe();
 							}
 							encoder.insert(opened)
 						}
 					};
-					write(output, encoder.encode(frame)?)?;
+					write(output, encoder.encode(frame).await?)?;
 				}
 				Some(Item::End) => {
 					if let Some(mut output) = current.take() {
 						// The source group is complete, so this one has to be too: a
 						// hardware encoder is still holding its last frames.
 						if let Some(encoder) = &mut encoder {
-							write(&mut output, encoder.flush()?)?;
+							write(&mut output, encoder.flush().await?)?;
 						}
 						output.finish()?;
 					}
@@ -368,13 +371,13 @@ async fn transcode_group_inner(
 			let keyframe = frame.keyframe || first;
 			first = false;
 
-			write(output, pipeline.process(&frame.payload, timestamp, keyframe)?)?;
+			write(output, pipeline.process(&frame.payload, timestamp, keyframe).await?)?;
 		}
 	}
 
 	// One-shot group: drain whatever the encoder still buffers. Each packet keeps
 	// the timestamp of the frame it was encoded from, so the tail stays in step.
-	write(output, pipeline.finish()?)?;
+	write(output, pipeline.finish().await?)?;
 	Ok(())
 }
 
@@ -402,7 +405,7 @@ struct Pipeline {
 	/// Opened from the first decoded frame, whose color space it has to declare.
 	/// `None` until one arrives; a keyframe requested before then waits in
 	/// `pending_keyframe`.
-	encoder: Option<moq_video::encode::Encoder>,
+	encoder: Option<moq_video::encode::Sink>,
 	pending_keyframe: bool,
 	rung: Rung,
 	size: moq_video::Size,
@@ -426,7 +429,7 @@ impl Pipeline {
 
 	/// Transcode one container payload into zero or more encoded frames, each
 	/// carrying the presentation time of the picture it came from.
-	fn process(
+	async fn process(
 		&mut self,
 		payload: &Bytes,
 		timestamp: moq_net::Timestamp,
@@ -446,25 +449,19 @@ impl Pipeline {
 		for raw in self.decoder.decode(payload, timestamp, keyframe)? {
 			// Already at the rung size (the decoder scaled): feed the frame through
 			// as-is, keeping a GPU frame on the GPU.
-			let resized;
-			let raw: &moq_video::Frame = match raw.size() == self.size {
-				true => &raw,
-				false => {
-					resized = raw.resize_with(self.size, &self.rung.resize)?;
-					&resized
-				}
+			let raw = match raw.size() == self.size {
+				true => raw,
+				false => raw.resize_with(self.size, &self.rung.resize)?,
 			};
-			let encoder = match &mut self.encoder {
-				Some(encoder) => encoder,
-				None => {
-					let mut opened = self.rung.encode(raw.surface.color())?;
-					if std::mem::take(&mut self.pending_keyframe) {
-						opened.keyframe();
-					}
-					self.encoder.insert(opened)
+			if self.encoder.is_none() {
+				let mut opened = self.rung.encode(raw.surface.color()).await?;
+				if std::mem::take(&mut self.pending_keyframe) {
+					opened.keyframe();
 				}
-			};
-			encoded.extend(encoder.encode(raw)?);
+				self.encoder = Some(opened);
+			}
+			let encoder = self.encoder.as_mut().expect("just opened");
+			encoded.extend(encoder.encode(raw).await?);
 		}
 		Ok(encoded)
 	}
@@ -473,10 +470,10 @@ impl Pipeline {
 	///
 	/// Consumes the pipeline, since flushing the encoder consumes it: a one-shot
 	/// group's pipeline is done once drained.
-	fn finish(self) -> Result<Vec<moq_video::encode::Encoded>, Error> {
+	async fn finish(self) -> Result<Vec<moq_video::encode::Encoded>, Error> {
 		// No encoder means no frame ever decoded, so there is nothing buffered.
 		match self.encoder {
-			Some(encoder) => encoder.finish().map_err(Into::into),
+			Some(encoder) => encoder.finish().await.map_err(Into::into),
 			None => Ok(Vec::new()),
 		}
 	}

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -159,6 +159,8 @@ windows = { version = "0.62", features = [
 ] }
 
 [dev-dependencies]
+# `poll!`, to cancel an `encode::Sink` request exactly where a `select!` would.
+futures = "0.3"
 h264-reader = "0.8.0"
 # Driving `encode::Sink` from a plain test thread, the way an FFI caller does.
 pollster = "1.0"

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -76,11 +76,6 @@ openh264 = "0.9.3"
 # features it needs; cargo unifies this on the same version it depends on, so the
 # raw API types stay identical.
 openh264-sys2 = { version = "0.9.6", default-features = false }
-# The `encode::Sink` blocking calls, for a caller with no executor to yield to
-# (an FFI boundary). Parks the thread on the encode thread's reply; tokio's own
-# blocking helpers panic when the caller happens to be a runtime worker, which an
-# FFI callback can be.
-pollster = "1.0"
 thiserror = "2"
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing = "0.1"
@@ -165,3 +160,5 @@ windows = { version = "0.62", features = [
 
 [dev-dependencies]
 h264-reader = "0.8.0"
+# Driving `encode::Sink` from a plain test thread, the way an FFI caller does.
+pollster = "1.0"

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -76,6 +76,11 @@ openh264 = "0.9.3"
 # features it needs; cargo unifies this on the same version it depends on, so the
 # raw API types stay identical.
 openh264-sys2 = { version = "0.9.6", default-features = false }
+# The `encode::Sink` blocking calls, for a caller with no executor to yield to
+# (an FFI boundary). Parks the thread on the encode thread's reply; tokio's own
+# blocking helpers panic when the caller happens to be a runtime worker, which an
+# FFI callback can be.
+pollster = "1.0"
 thiserror = "2"
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing = "0.1"

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -23,6 +23,9 @@ use crate::{Error, Frame};
 
 mod openh264;
 
+#[cfg(test)]
+pub(crate) mod probe;
+
 #[cfg(target_os = "macos")]
 mod videotoolbox;
 
@@ -119,6 +122,19 @@ const SOFTWARE: &[Candidate] = &[Candidate {
 	open: openh264::Openh264::open,
 }];
 
+/// Test-only backends. Deliberately in neither list above, so `Auto` /
+/// `Hardware` / `Software` can never select one: they exist to be asked for by
+/// name.
+#[cfg(test)]
+const NAMED_ONLY: &[Candidate] = &[Candidate {
+	name: probe::NAME,
+	codecs: &[Codec::H264],
+	open: probe::Probe::open,
+}];
+
+#[cfg(not(test))]
+const NAMED_ONLY: &[Candidate] = &[];
+
 /// Open the best encoder for `config.codec` + `config.kind`, trying candidates
 /// in priority order and falling back until one succeeds.
 pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
@@ -134,6 +150,7 @@ pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
 		Kind::Named(name) => HARDWARE
 			.iter()
 			.chain(SOFTWARE.iter())
+			.chain(NAMED_ONLY.iter())
 			.filter(supports)
 			.filter(|c| c.name == name)
 			.collect(),

--- a/rs/moq-video/src/encode/backend/probe.rs
+++ b/rs/moq-video/src/encode/backend/probe.rs
@@ -1,0 +1,80 @@
+//! A backend that records the thread each codec call ran on, so a test can pin
+//! where the codec lives rather than take the platform's word for it.
+//!
+//! Reachable only through [`Kind::Named`](super::Kind), never through `Auto` /
+//! `Hardware` / `Software`, so it can't be picked by accident.
+//!
+//! It also holds each frame back by one, like the Media Foundation MFT, so a
+//! drain that loses the tail shows up as a missing frame rather than passing.
+
+use std::sync::Mutex;
+use std::thread::ThreadId;
+
+use super::super::{Config, Encoded};
+use super::Backend;
+use crate::{Error, Frame};
+
+pub(crate) const NAME: &str = "probe";
+
+/// What happened to the codec, and where. `open` and `drop` are the pair that
+/// matters: the Windows backend opens a COM apartment in one and closes it in
+/// the other, so they have to land on the same thread.
+pub(crate) type Event = (&'static str, ThreadId);
+
+static LOG: Mutex<Vec<Event>> = Mutex::new(Vec::new());
+
+fn record(what: &'static str) {
+	LOG.lock().unwrap().push((what, std::thread::current().id()));
+}
+
+/// Empty the log and hand back what was in it.
+pub(crate) fn take() -> Vec<Event> {
+	std::mem::take(&mut LOG.lock().unwrap())
+}
+
+pub(crate) struct Probe {
+	pending: Option<Encoded>,
+}
+
+impl Probe {
+	pub(crate) fn open(_config: &Config) -> Result<Box<dyn Backend>, Error> {
+		record("open");
+		Ok(Box::new(Self { pending: None }))
+	}
+}
+
+impl Backend for Probe {
+	fn encode(&mut self, frame: &Frame, _keyframe: bool) -> Result<Vec<Encoded>, Error> {
+		record("encode");
+		// The payload is the frame's timestamp, so a test can tell which frame a
+		// packet came from independently of what it's stamped with.
+		let payload = bytes::Bytes::from(frame.timestamp.as_micros().to_string());
+		let previous = self.pending.replace(Encoded::new(payload, frame.timestamp));
+		Ok(previous.into_iter().collect())
+	}
+
+	fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+		record("flush");
+		Ok(self.pending.take().into_iter().collect())
+	}
+
+	fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
+		record("finish");
+		Ok(self.pending.take().into_iter().collect())
+	}
+
+	fn set_bitrate(&mut self, _bitrate: u64) -> Result<(), Error> {
+		record("set_bitrate");
+		Ok(())
+	}
+
+	fn name(&self) -> &str {
+		NAME
+	}
+}
+
+impl Drop for Probe {
+	fn drop(&mut self) {
+		record("drop");
+	}
+}

--- a/rs/moq-video/src/encode/backend/probe.rs
+++ b/rs/moq-video/src/encode/backend/probe.rs
@@ -23,6 +23,29 @@ pub(crate) type Event = (&'static str, ThreadId);
 
 static LOG: Mutex<Vec<Event>> = Mutex::new(Vec::new());
 
+/// Serializes the tests that read [`LOG`], which is process-wide. nextest gives
+/// each test its own process, but `cargo test` does not, and a shared log that
+/// only holds up under one runner is a trap for whoever adds the next test.
+static EXCLUSIVE: Mutex<()> = Mutex::new(());
+
+/// Take the probe for one test, clearing whatever a previous one left behind.
+pub(crate) fn exclusive() -> std::sync::MutexGuard<'static, ()> {
+	let guard = EXCLUSIVE.lock().unwrap_or_else(|err| err.into_inner());
+	let _ = take();
+	guard
+}
+
+/// Held by [`hold`] to stall the codec inside [`Probe::encode`].
+static GATE: Mutex<()> = Mutex::new(());
+
+/// Stall the next encode until the returned guard drops.
+///
+/// Lets a test pin the codec mid-call, so a cancellation lands while the request
+/// is genuinely in flight rather than racing the encode thread for it.
+pub(crate) fn hold() -> std::sync::MutexGuard<'static, ()> {
+	GATE.lock().unwrap_or_else(|err| err.into_inner())
+}
+
 fn record(what: &'static str) {
 	LOG.lock().unwrap().push((what, std::thread::current().id()));
 }
@@ -45,6 +68,8 @@ impl Probe {
 
 impl Backend for Probe {
 	fn encode(&mut self, frame: &Frame, _keyframe: bool) -> Result<Vec<Encoded>, Error> {
+		// Uncontended unless a test is holding the codec here on purpose.
+		drop(GATE.lock().unwrap_or_else(|err| err.into_inner()));
 		record("encode");
 		// The payload is the frame's timestamp, so a test can tell which frame a
 		// packet came from independently of what it's stamped with.

--- a/rs/moq-video/src/encode/mod.rs
+++ b/rs/moq-video/src/encode/mod.rs
@@ -8,6 +8,9 @@
 //! - [`Encoder`] encodes raw [`Frame`](crate::Frame)s you supply into
 //!   [`Encoded`] access units, and [`Producer`] publishes those (bring your own
 //!   frames). Build both for the same [`Codec`].
+//! - [`Sink`] is an [`Encoder`] that owns the thread it runs on, for an encoder
+//!   outliving a single thread's stack (a shared object, an FFI handle, a task
+//!   that migrates between workers).
 //! - [`Producer`] alone publishes frames you already encoded.
 //!
 //! [`Options`] / [`Kind`] / [`Config`] configure them. The decode/consume
@@ -28,3 +31,4 @@ pub mod rate;
 pub use encoded::Encoded;
 pub use encoder::{Codec, Config, Encoder, Kind};
 pub use producer::{Options, Producer, publish_capture};
+pub use sink::Sink;

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -15,9 +15,9 @@ use crate::capture;
 use crate::{Error, Frame};
 
 use super::Encoded;
+use super::Sink;
 use super::encoder::{self, Codec};
 use super::rate::{Control, Policy};
-use super::sink::Sink;
 
 /// Last-resort framerate when neither the caller nor the camera reports one.
 const DEFAULT_FRAMERATE: u32 = 30;
@@ -407,8 +407,11 @@ async fn capture_loop<E: CatalogExt>(
 			// Stamp at capture, so a backend that buffers still publishes each
 			// access unit at the time the picture was grabbed.
 			let frame = Frame::new(surface, Timestamp::from_micros(clock.micros())?);
-			let encoded = encoder.encode(frame, force_keyframe).await?;
-			force_keyframe = false;
+			if force_keyframe {
+				encoder.keyframe();
+				force_keyframe = false;
+			}
+			let encoded = encoder.encode(frame).await?;
 			// Once the encoder emits a frame the importer has parsed the SPS and
 			// the catalog rendition exists, so demand gating can take over.
 			catalog_ready |= !encoded.is_empty();

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -1,5 +1,5 @@
-//! The encoder as [`publish_capture`](super::publish_capture)'s capture loop
-//! drives it, abstracting over where the encode actually runs.
+//! An [`Encoder`](super::Encoder) that owns the thread it runs on, so any
+//! thread (or task) can drive it.
 //!
 //! Off macOS the encoder runs on a dedicated OS thread (mirroring
 //! [`capture::pump`](crate::capture)): the Windows hardware encoder is a Media
@@ -7,19 +7,114 @@
 //! one thread (COM apartments are per-thread), and whose encode call blocks on
 //! MFT events. Driving it inline on a tokio worker would unbalance the
 //! per-thread COM refcount as the future migrates between workers and park a
-//! worker on a stalled MFT. Confining the whole encoder lifetime to one thread
-//! fixes both; frames are `Send` there (Windows D3D11 textures and CPU I420 both
-//! are) and packets come back over a channel.
+//! worker on a stalled MFT. A synchronous caller has the same problem for the
+//! same reason: an FFI object shared between threads opens the apartment on
+//! whichever thread built it and closes it on whichever thread drops it.
+//! Confining the whole encoder lifetime to one thread fixes both; frames are
+//! `Send` there (Windows D3D11 textures and CPU I420 both are) and packets come
+//! back over a channel.
 //!
 //! macOS keeps encoding inline: VideoToolbox has no COM apartment to balance and
 //! doesn't block on an event loop, so a thread would only add a hop, and its
 //! zero-copy `CVPixelBuffer` surface is `!Send` and couldn't cross to one anyway.
 
-#[cfg(not(target_os = "macos"))]
-pub(super) use threaded::Sink;
+use super::Encoded;
+use super::encoder::Config;
+use crate::{Error, Frame};
 
 #[cfg(target_os = "macos")]
-pub(super) use inline::Sink;
+use inline::Inner;
+#[cfg(not(target_os = "macos"))]
+use threaded::Inner;
+
+/// An [`Encoder`](super::Encoder) confined to one thread, driven from anywhere.
+///
+/// Same shape as [`Encoder`](super::Encoder), one method at a time, except that
+/// [`encode`](Self::encode) takes the frame by value (it may cross a thread) and
+/// each call comes in an `async` flavor and a `blocking_` one. Reach for this
+/// instead of an `Encoder` whenever the encoder outlives a single thread's
+/// stack: an object shared across threads, an FFI handle, a task that migrates
+/// between executor workers. An `Encoder` you build, drive, and drop inside one
+/// function needs none of it.
+///
+/// The two flavors differ only in how the caller waits for the encode thread.
+/// Use `async` from a task, so the executor keeps its worker while the codec
+/// runs, and `blocking_` from a plain thread (an FFI boundary that has to return
+/// a result synchronously). The `blocking_` calls park the calling thread and
+/// need no runtime.
+pub struct Sink(Inner);
+
+impl Sink {
+	/// Open an encoder for `config` on its own thread. Returns once the encoder
+	/// is built (or its construction fails), so a bad config or a missing backend
+	/// surfaces here rather than on the first frame.
+	pub async fn open(config: &Config) -> Result<Self, Error> {
+		Ok(Self(Inner::open(config).await?))
+	}
+
+	/// [`open`](Self::open) for a synchronous caller.
+	pub fn blocking_open(config: &Config) -> Result<Self, Error> {
+		pollster::block_on(Self::open(config))
+	}
+
+	/// The encoder name in use, e.g. `"mediafoundation"`.
+	pub fn name(&self) -> &str {
+		self.0.name()
+	}
+
+	/// Ask for the next frame to be encoded as a keyframe, like
+	/// [`Encoder::keyframe`](super::Encoder::keyframe).
+	///
+	/// Queued behind the frames already in flight rather than applied to
+	/// whichever one the codec happens to be on, so it keys the next frame you
+	/// pass to [`encode`](Self::encode). Never blocks, so there is no `async`
+	/// flavor.
+	pub fn keyframe(&mut self) {
+		self.0.keyframe();
+	}
+
+	/// Encode one frame, waiting for its access units.
+	///
+	/// Takes the frame by value because it may be moved to the encode thread.
+	/// Otherwise [`Encoder::encode`](super::Encoder::encode): zero or more access
+	/// units, each stamped with the frame it came from.
+	pub async fn encode(&mut self, frame: Frame) -> Result<Vec<Encoded>, Error> {
+		self.0.encode(frame).await
+	}
+
+	/// [`encode`](Self::encode) for a synchronous caller.
+	pub fn blocking_encode(&mut self, frame: Frame) -> Result<Vec<Encoded>, Error> {
+		pollster::block_on(self.encode(frame))
+	}
+
+	/// Retune the encoder, waiting for the backend's verdict. See
+	/// [`Encoder::set_bitrate`](super::Encoder::set_bitrate) for what a failure
+	/// means (not fatal: stop adapting, keep encoding).
+	pub async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		self.0.set_bitrate(bitrate).await
+	}
+
+	/// [`set_bitrate`](Self::set_bitrate) for a synchronous caller.
+	pub fn blocking_set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		pollster::block_on(self.set_bitrate(bitrate))
+	}
+
+	/// Drain the codec, returning every access unit it was still holding, and
+	/// shut the encoder down.
+	///
+	/// Consumes the sink, like [`Encoder::finish`](super::Encoder::finish).
+	/// Dropping a sink without this is fine and tears down just as cleanly, it
+	/// just discards the tail: publish the returned frames before ending a track,
+	/// or its last pictures never reach a subscriber.
+	pub async fn finish(self) -> Result<Vec<Encoded>, Error> {
+		self.0.finish().await
+	}
+
+	/// [`finish`](Self::finish) for a synchronous caller.
+	pub fn blocking_finish(self) -> Result<Vec<Encoded>, Error> {
+		pollster::block_on(self.finish())
+	}
+}
 
 #[cfg(not(target_os = "macos"))]
 mod threaded {
@@ -27,21 +122,23 @@ mod threaded {
 
 	use tokio::sync::{mpsc, oneshot};
 
-	use super::super::encoder::{self, Encoder};
-	use crate::encode::Encoded;
+	use super::super::Encoded;
+	use super::super::encoder::{Config, Encoder};
 	use crate::{Error, Frame};
 
-	/// Work for the encode thread. Both variants go down the same channel so a
-	/// bitrate change lands in order with the frames around it, rather than
-	/// racing them.
+	/// Work for the encode thread. Every variant goes down the same channel so a
+	/// keyframe request or a bitrate change lands in order with the frames around
+	/// it, rather than racing them.
 	enum Request {
-		/// A frame to encode and whether to force a keyframe, plus a oneshot to
-		/// return the resulting access units (or an error) in order.
+		/// A frame to encode, plus a oneshot to return the resulting access units
+		/// (or an error) in order.
 		Encode {
 			frame: Frame,
-			keyframe: bool,
 			resp: oneshot::Sender<Result<Vec<Encoded>, Error>>,
 		},
+		/// Key the next frame. No reply: the encoder only records the request, so
+		/// there is nothing to report and nothing to wait for.
+		Keyframe,
 		/// Retune to a new bitrate, reporting whether the backend took it so the
 		/// caller can stop adapting against an encoder that can't. The round trip
 		/// is affordable because the rate control policy only sends one of these
@@ -50,10 +147,16 @@ mod threaded {
 			bitrate: u64,
 			resp: oneshot::Sender<Result<(), Error>>,
 		},
+		/// Drain the codec and shut down, returning the tail. Last request the
+		/// thread serves: `Encoder::finish` consumes the encoder, so the loop has
+		/// to break out rather than come back round for another frame.
+		Finish {
+			resp: oneshot::Sender<Result<Vec<Encoded>, Error>>,
+		},
 	}
 
 	/// An [`Encoder`] running on its own thread. See the module docs.
-	pub(in crate::encode) struct Sink {
+	pub struct Inner {
 		/// `Option` so `Drop` can drop the sender (signalling the thread to exit)
 		/// before joining.
 		tx: Option<mpsc::UnboundedSender<Request>>,
@@ -61,45 +164,55 @@ mod threaded {
 		name: String,
 	}
 
-	impl Sink {
-		/// Open an encoder for `config` on a dedicated thread. Returns once the
-		/// encoder is built (or its construction fails), so a bad config or a
-		/// missing backend surfaces here rather than on the first frame.
-		pub(in crate::encode) async fn open(config: &encoder::Config) -> Result<Self, Error> {
+	impl Inner {
+		pub async fn open(config: &Config) -> Result<Self, Error> {
 			let (req_tx, mut req_rx) = mpsc::unbounded_channel::<Request>();
 			let (ready_tx, ready_rx) = oneshot::channel::<Result<String, Error>>();
 			let config = config.clone();
 
-			let handle = std::thread::spawn(move || {
-				let mut encoder = match Encoder::new(&config) {
-					Ok(encoder) => encoder,
-					Err(err) => {
-						let _ = ready_tx.send(Err(err));
+			let handle = std::thread::Builder::new()
+				.name("moq-video-encode".into())
+				.spawn(move || {
+					let mut encoder = match Encoder::new(&config) {
+						Ok(encoder) => encoder,
+						Err(err) => {
+							let _ = ready_tx.send(Err(err));
+							return;
+						}
+					};
+					// If the awaiting `open` was cancelled, give up before encoding.
+					if ready_tx.send(Ok(encoder.name().to_string())).is_err() {
 						return;
 					}
-				};
-				// If the awaiting `open` was cancelled, give up before encoding.
-				if ready_tx.send(Ok(encoder.name().to_string())).is_err() {
-					return;
-				}
 
-				// Serve each request in arrival order. The encoder and its COM /
-				// MFT handles are created, used, and dropped only on this thread.
-				while let Some(req) = req_rx.blocking_recv() {
-					match req {
-						Request::Encode { frame, keyframe, resp } => {
-							if keyframe {
-								encoder.keyframe();
+					// Serve each request in arrival order. The encoder and its COM /
+					// MFT handles are created, used, and dropped only on this thread.
+					// `finish` consumes the encoder, so it breaks out and drains below
+					// rather than serving another request.
+					let mut draining = None;
+					while let Some(req) = req_rx.blocking_recv() {
+						match req {
+							Request::Encode { frame, resp } => {
+								let _ = resp.send(encoder.encode(&frame));
 							}
-							let _ = resp.send(encoder.encode(&frame));
-						}
-						Request::SetBitrate { bitrate, resp } => {
-							let _ = resp.send(encoder.set_bitrate(bitrate));
+							Request::Keyframe => encoder.keyframe(),
+							Request::SetBitrate { bitrate, resp } => {
+								let _ = resp.send(encoder.set_bitrate(bitrate));
+							}
+							Request::Finish { resp } => {
+								draining = Some(resp);
+								break;
+							}
 						}
 					}
-				}
-				// `encoder` drops here, on this thread, balancing the COM apartment.
-			});
+					// The drain runs here, on this thread, and consumes the encoder;
+					// otherwise `encoder` drops here. Either way the COM apartment it
+					// opened closes on the thread that opened it.
+					if let Some(resp) = draining {
+						let _ = resp.send(encoder.finish());
+					}
+				})
+				.map_err(|err| Error::Codec(anyhow::anyhow!("failed to spawn the encode thread: {err}")))?;
 
 			match ready_rx.await {
 				Ok(Ok(name)) => Ok(Self {
@@ -115,20 +228,33 @@ mod threaded {
 			}
 		}
 
-		/// The encoder name in use, e.g. `"mediafoundation"`.
-		pub(in crate::encode) fn name(&self) -> &str {
+		pub fn name(&self) -> &str {
 			&self.name
 		}
 
-		/// Encode one frame, awaiting its packets. The frame is moved to the
-		/// encode thread; the result returns over a oneshot.
-		pub(in crate::encode) async fn encode(&mut self, frame: Frame, keyframe: bool) -> Result<Vec<Encoded>, Error> {
-			self.request(|resp| Request::Encode { frame, keyframe, resp }).await
+		pub fn keyframe(&mut self) {
+			// Nothing to report: a dead encode thread surfaces on the next encode,
+			// which is where the caller is already handling one.
+			let _ = self.send(Request::Keyframe);
 		}
 
-		/// Retune the encoder, awaiting the backend's verdict.
-		pub(in crate::encode) async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		pub async fn encode(&mut self, frame: Frame) -> Result<Vec<Encoded>, Error> {
+			self.request(|resp| Request::Encode { frame, resp }).await
+		}
+
+		pub async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
 			self.request(|resp| Request::SetBitrate { bitrate, resp }).await
+		}
+
+		pub async fn finish(self) -> Result<Vec<Encoded>, Error> {
+			// `self` drops on the way out, which drops the sender and joins the
+			// thread that just drained and released the encoder.
+			self.request(|resp| Request::Finish { resp }).await
+		}
+
+		/// Queue a request, mapping a dead encode thread onto an error.
+		fn send(&self, req: Request) -> Result<(), Error> {
+			self.tx.as_ref().ok_or_else(gone)?.send(req).map_err(|_| gone())
 		}
 
 		/// Send a request built around a fresh oneshot and await its reply,
@@ -138,16 +264,12 @@ mod threaded {
 			build: impl FnOnce(oneshot::Sender<Result<T, Error>>) -> Request,
 		) -> Result<T, Error> {
 			let (resp_tx, resp_rx) = oneshot::channel();
-			self.tx
-				.as_ref()
-				.ok_or_else(gone)?
-				.send(build(resp_tx))
-				.map_err(|_| gone())?;
+			self.send(build(resp_tx))?;
 			resp_rx.await.map_err(|_| gone())?
 		}
 	}
 
-	impl Drop for Sink {
+	impl Drop for Inner {
 		fn drop(&mut self) {
 			// Drop the sender so the thread's `blocking_recv` returns `None` and it
 			// exits, dropping the encoder on its own thread; then join so teardown
@@ -167,34 +289,130 @@ mod threaded {
 
 #[cfg(target_os = "macos")]
 mod inline {
-	use super::super::encoder::{self, Encoder};
-	use crate::encode::Encoded;
+	use super::super::Encoded;
+	use super::super::encoder::{Config, Encoder};
 	use crate::{Error, Frame};
 
-	/// An [`Encoder`] driven inline on the capture task (see the module docs).
-	pub(in crate::encode) struct Sink(Encoder);
+	/// An [`Encoder`] driven inline on the calling thread (see the module docs).
+	pub struct Inner(Encoder);
 
-	impl Sink {
-		pub(in crate::encode) async fn open(config: &encoder::Config) -> Result<Self, Error> {
+	impl Inner {
+		pub async fn open(config: &Config) -> Result<Self, Error> {
 			Ok(Self(Encoder::new(config)?))
 		}
 
-		/// The encoder name in use, e.g. `"videotoolbox"`.
-		pub(in crate::encode) fn name(&self) -> &str {
+		pub fn name(&self) -> &str {
 			self.0.name()
 		}
 
-		pub(in crate::encode) async fn encode(&mut self, frame: Frame, keyframe: bool) -> Result<Vec<Encoded>, Error> {
-			if keyframe {
-				self.0.keyframe();
-			}
+		pub fn keyframe(&mut self) {
+			self.0.keyframe();
+		}
+
+		/// Async only to match the threaded `Inner`; there's no thread to hand this
+		/// to, so it encodes inline. The same holds for the two below.
+		pub async fn encode(&mut self, frame: Frame) -> Result<Vec<Encoded>, Error> {
 			self.0.encode(&frame)
 		}
 
-		/// Retune the encoder. Async only to match the threaded `Sink`; there's
-		/// no thread to hand this to, so it applies inline.
-		pub(in crate::encode) async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		pub async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
 			self.0.set_bitrate(bitrate)
 		}
+
+		pub async fn finish(self) -> Result<Vec<Encoded>, Error> {
+			self.0.finish()
+		}
+	}
+}
+
+/// macOS is exempt by design: the inline sink encodes on the calling thread, so
+/// there is no confinement to assert (see the module docs).
+#[cfg(all(test, not(target_os = "macos")))]
+mod tests {
+	use std::collections::HashSet;
+	use std::sync::{Arc, Mutex};
+	use std::thread::ThreadId;
+
+	use super::super::backend::probe;
+	use super::super::{Codec, Kind};
+	use super::*;
+	use crate::{I420, Surface};
+
+	/// A mid-gray frame at the probe backend's resolution, stamped as the
+	/// `index`th frame of a 30fps stream.
+	fn gray(index: u64) -> Frame {
+		let i420 = I420::new(320, 240, vec![0x80u8; I420::len(320, 240)]).unwrap();
+		Frame::new(
+			Surface::I420(i420),
+			moq_net::Timestamp::from_micros(index * 33_333).unwrap(),
+		)
+	}
+
+	fn probe_config() -> Config {
+		let mut config = Config::new(320, 240, 30);
+		config.codec = Codec::H264;
+		config.kind = Kind::Named(probe::NAME.into());
+		config
+	}
+
+	/// Regression: the Windows backend opens a COM apartment on the thread that
+	/// builds the codec and closes it on the thread that drops it, so a codec
+	/// reachable from more than one thread has to own a thread of its own. Both
+	/// FFI bindings held a bare `Encoder` and drove it from whichever thread
+	/// called in, which leaked the opening thread's initialization and ran
+	/// `CoUninitialize` on a thread that never initialized COM.
+	///
+	/// Asserted on every platform rather than only Windows: the confinement is
+	/// what the bindings now rely on, so it should fail here rather than on a
+	/// machine none of CI has.
+	#[test]
+	fn the_codec_stays_on_one_thread_however_it_is_driven() {
+		let _ = probe::take();
+
+		let sink = Arc::new(Mutex::new(Some(Sink::blocking_open(&probe_config()).unwrap())));
+
+		// Drive it the way an FFI handle gets driven: a fresh caller thread every
+		// time, none of them the thread that opened it.
+		let mut callers = vec![std::thread::current().id()];
+		for index in 0..3u64 {
+			let sink = sink.clone();
+			let caller = std::thread::spawn(move || {
+				let mut guard = sink.lock().unwrap();
+				let sink = guard.as_mut().unwrap();
+				sink.keyframe();
+				sink.blocking_encode(gray(index)).unwrap();
+				sink.blocking_set_bitrate(500_000 + index).unwrap();
+				std::thread::current().id()
+			});
+			callers.push(caller.join().unwrap());
+		}
+
+		// ...and finished, so dropped, from yet another.
+		let closer = std::thread::spawn(move || {
+			let sink = sink.lock().unwrap().take().unwrap();
+			let tail = sink.blocking_finish().unwrap();
+			(std::thread::current().id(), tail)
+		});
+		let (closer, tail) = closer.join().unwrap();
+		callers.push(closer);
+
+		// The probe holds each frame back by one, so the drain has to hand back the
+		// last one. Dropping the sink without draining would lose it silently.
+		let tail: Vec<_> = tail.iter().map(|frame| frame.timestamp.as_micros()).collect();
+		assert_eq!(tail, vec![2 * 33_333], "the drain lost the codec's tail");
+
+		let log = probe::take();
+		for what in ["open", "encode", "set_bitrate", "finish", "drop"] {
+			assert!(log.iter().any(|(event, _)| *event == what), "no {what} in {log:?}");
+		}
+
+		let threads: HashSet<ThreadId> = log.iter().map(|(_, id)| *id).collect();
+		assert_eq!(threads.len(), 1, "the codec ran on more than one thread: {log:?}");
+
+		let codec = threads.into_iter().next().unwrap();
+		assert!(
+			!callers.contains(&codec),
+			"the codec ran on a caller's thread rather than its own: {log:?}"
+		);
 	}
 }

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -40,6 +40,19 @@ use threaded::Inner;
 /// so the executor keeps its worker while a slow hardware encoder works through
 /// a frame. A caller with no executor to yield to (an FFI boundary that must
 /// return a result synchronously) blocks on these futures itself.
+///
+/// # Cancellation
+///
+/// These futures are not cancel-safe, and the sink says so rather than letting
+/// it slide. The codec runs on its own thread, so a request that has been queued
+/// runs whether or not anyone is still waiting: dropping the future (racing it in
+/// a `select!`, giving it a timeout) leaves the codec a step ahead of the stream,
+/// holding output nobody received. Rather than let the next call carry on and
+/// publish a track quietly missing those frames, the sink refuses every call
+/// after a cancelled one. Drop it and open another.
+///
+/// Racing an encode against a shutdown signal is fine, since the sink is on its
+/// way out anyway. What does not work is cancelling one and carrying on.
 pub struct Sink(Inner);
 
 impl Sink {
@@ -158,6 +171,9 @@ mod threaded {
 		tx: Option<mpsc::UnboundedSender<Request>>,
 		handle: Option<JoinHandle<()>>,
 		name: String,
+		/// Set between queueing a request and taking its reply, so a cancelled
+		/// call is caught rather than silently skipped. See [`Inner::request`].
+		abandoned: bool,
 	}
 
 	impl Inner {
@@ -218,6 +234,7 @@ mod threaded {
 					tx: Some(req_tx),
 					handle: Some(handle),
 					name,
+					abandoned: false,
 				}),
 				Ok(Err(err)) => Err(err),
 				Err(_) => {
@@ -249,7 +266,7 @@ mod threaded {
 			self.request(|resp| Request::Flush { resp }).await
 		}
 
-		pub async fn finish(self) -> Result<Vec<Encoded>, Error> {
+		pub async fn finish(mut self) -> Result<Vec<Encoded>, Error> {
 			// `self` drops on the way out, which drops the sender and joins the
 			// thread that just drained and released the encoder.
 			self.request(|resp| Request::Finish { resp }).await
@@ -262,13 +279,29 @@ mod threaded {
 
 		/// Send a request built around a fresh oneshot and await its reply,
 		/// mapping a dead encode thread onto an error either way.
+		///
+		/// The flag is what makes a cancelled call safe. Dropping this future
+		/// after the send leaves the request queued: the thread still runs it and
+		/// still advances the codec, but its reply lands in a dropped receiver.
+		/// Letting the next call proceed would publish a stream quietly missing
+		/// whatever that request produced, so the sink refuses instead.
 		async fn request<T>(
-			&self,
+			&mut self,
 			build: impl FnOnce(oneshot::Sender<Result<T, Error>>) -> Request,
 		) -> Result<T, Error> {
+			if self.abandoned {
+				return Err(abandoned());
+			}
 			let (resp_tx, resp_rx) = oneshot::channel();
 			self.send(build(resp_tx))?;
-			resp_rx.await.map_err(|_| gone())?
+
+			self.abandoned = true;
+			let reply = resp_rx.await;
+			// Only reached if this future was polled to completion; a cancelled one
+			// never gets here and leaves the flag set.
+			self.abandoned = false;
+
+			reply.map_err(|_| gone())?
 		}
 	}
 
@@ -287,6 +320,12 @@ mod threaded {
 
 	fn gone() -> Error {
 		Error::Codec(anyhow::anyhow!("encode thread stopped unexpectedly"))
+	}
+
+	fn abandoned() -> Error {
+		Error::Codec(anyhow::anyhow!(
+			"a cancelled encode left the codec ahead of this stream; drop the sink"
+		))
 	}
 }
 
@@ -362,6 +401,45 @@ mod tests {
 		config
 	}
 
+	/// Regression: a queued request runs on the encode thread whether or not the
+	/// caller is still waiting, so a cancelled `encode` leaves the codec a step
+	/// ahead of the stream with output nobody received. Carrying on would publish
+	/// a track quietly missing those frames, which is worse than an error: only
+	/// the publisher could ever tell, and only by decoding its own output.
+	#[test]
+	fn a_cancelled_call_poisons_the_sink() {
+		let _probe = probe::exclusive();
+
+		let mut sink = pollster::block_on(Sink::open(&probe_config())).unwrap();
+
+		// Cancel an encode the moment it starts waiting, the shape a `select!` or a
+		// timeout produces. Holding the codec inside the call is what makes the
+		// cancel land mid-flight rather than race the encode thread for it.
+		let gate = probe::hold();
+		pollster::block_on(async {
+			let mut encode = Box::pin(sink.encode(gray(0)));
+			assert!(
+				futures::poll!(encode.as_mut()).is_pending(),
+				"the encode should still be waiting on the held codec"
+			);
+			// Dropped here, with the request queued and the reply still to come.
+		});
+		drop(gate);
+
+		// The codec really did run, so the stream is missing whatever came back.
+		let err = pollster::block_on(sink.encode(gray(1))).expect_err("the sink should refuse");
+		assert!(err.to_string().contains("cancelled"), "unexpected error: {err}");
+		// ...and it stays refused rather than recovering on the call after.
+		assert!(pollster::block_on(sink.flush()).is_err());
+
+		drop(sink);
+		let log = probe::take();
+		assert!(
+			log.iter().any(|(event, _)| *event == "encode"),
+			"the cancelled request should still have reached the codec: {log:?}"
+		);
+	}
+
 	/// Regression: the Windows backend opens a COM apartment on the thread that
 	/// builds the codec and closes it on the thread that drops it, so a codec
 	/// reachable from more than one thread has to own a thread of its own. Both
@@ -374,7 +452,7 @@ mod tests {
 	/// machine none of CI has.
 	#[test]
 	fn the_codec_stays_on_one_thread_however_it_is_driven() {
-		let _ = probe::take();
+		let _probe = probe::exclusive();
 
 		let sink = Arc::new(Mutex::new(Some(
 			pollster::block_on(Sink::open(&probe_config())).unwrap(),

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -18,6 +18,8 @@
 //! doesn't block on an event loop, so a thread would only add a hop, and its
 //! zero-copy `CVPixelBuffer` surface is `!Send` and couldn't cross to one anyway.
 
+use std::sync::Arc;
+
 use super::Encoded;
 use super::encoder::Config;
 use crate::{Error, Frame};
@@ -81,11 +83,16 @@ impl Sink {
 
 	/// Encode one frame, waiting for its access units.
 	///
-	/// Takes the frame by value because it may be moved to the encode thread.
 	/// Otherwise [`Encoder::encode`](super::Encoder::encode): zero or more access
 	/// units, each stamped with the frame it came from.
-	pub async fn encode(&mut self, frame: Frame) -> Result<Vec<Encoded>, Error> {
-		self.0.encode(frame).await
+	///
+	/// Takes ownership, since the frame may be moved to the encode thread, but
+	/// takes it as anything that can become an [`Arc`] so a caller fanning one
+	/// frame out to several encoders (a transcode ladder) hands over a clone of
+	/// the handle rather than a copy of the pixels. Pass a [`Frame`] and it is
+	/// wrapped for you.
+	pub async fn encode(&mut self, frame: impl Into<Arc<Frame>>) -> Result<Vec<Encoded>, Error> {
+		self.0.encode(frame.into()).await
 	}
 
 	/// Retune the encoder, waiting for the backend's verdict. See
@@ -121,6 +128,7 @@ impl Sink {
 
 #[cfg(not(target_os = "macos"))]
 mod threaded {
+	use std::sync::Arc;
 	use std::thread::JoinHandle;
 
 	use tokio::sync::{mpsc, oneshot};
@@ -136,7 +144,7 @@ mod threaded {
 		/// A frame to encode, plus a oneshot to return the resulting access units
 		/// (or an error) in order.
 		Encode {
-			frame: Frame,
+			frame: Arc<Frame>,
 			resp: oneshot::Sender<Result<Vec<Encoded>, Error>>,
 		},
 		/// Key the next frame. No reply: the encoder only records the request, so
@@ -254,7 +262,7 @@ mod threaded {
 			let _ = self.send(Request::Keyframe);
 		}
 
-		pub async fn encode(&mut self, frame: Frame) -> Result<Vec<Encoded>, Error> {
+		pub async fn encode(&mut self, frame: Arc<Frame>) -> Result<Vec<Encoded>, Error> {
 			self.request(|resp| Request::Encode { frame, resp }).await
 		}
 
@@ -331,6 +339,8 @@ mod threaded {
 
 #[cfg(target_os = "macos")]
 mod inline {
+	use std::sync::Arc;
+
 	use super::super::Encoded;
 	use super::super::encoder::{Config, Encoder};
 	use crate::{Error, Frame};
@@ -353,7 +363,7 @@ mod inline {
 
 		/// Async only to match the threaded `Inner`; there's no thread to hand this
 		/// to, so it encodes inline. The same holds for the two below.
-		pub async fn encode(&mut self, frame: Frame) -> Result<Vec<Encoded>, Error> {
+		pub async fn encode(&mut self, frame: Arc<Frame>) -> Result<Vec<Encoded>, Error> {
 			self.0.encode(&frame)
 		}
 

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -82,6 +82,18 @@ impl Sink {
 		self.0.set_bitrate(bitrate).await
 	}
 
+	/// Empty the codec at a boundary the output has to respect, leaving it ready
+	/// for the frames that follow. See [`Encoder::flush`](super::Encoder::flush).
+	///
+	/// A live track needs this at every group boundary: a backend that pipelines
+	/// is still holding the last frames of a group when it ends, and they would
+	/// otherwise surface in the next group ahead of its keyframe, where a
+	/// subscriber joining there cannot decode them. Publishing frame by frame
+	/// with no group structure needs none of it.
+	pub async fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+		self.0.flush().await
+	}
+
 	/// Drain the codec, returning every access unit it was still holding, and
 	/// shut the encoder down.
 	///
@@ -124,6 +136,12 @@ mod threaded {
 		SetBitrate {
 			bitrate: u64,
 			resp: oneshot::Sender<Result<(), Error>>,
+		},
+		/// Empty the codec at a group boundary, leaving it running. Unlike
+		/// `Finish` the encoder survives, so this is served like any other
+		/// request.
+		Flush {
+			resp: oneshot::Sender<Result<Vec<Encoded>, Error>>,
 		},
 		/// Drain the codec and shut down, returning the tail. Last request the
 		/// thread serves: `Encoder::finish` consumes the encoder, so the loop has
@@ -177,6 +195,9 @@ mod threaded {
 							Request::SetBitrate { bitrate, resp } => {
 								let _ = resp.send(encoder.set_bitrate(bitrate));
 							}
+							Request::Flush { resp } => {
+								let _ = resp.send(encoder.flush());
+							}
 							Request::Finish { resp } => {
 								draining = Some(resp);
 								break;
@@ -222,6 +243,10 @@ mod threaded {
 
 		pub async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
 			self.request(|resp| Request::SetBitrate { bitrate, resp }).await
+		}
+
+		pub async fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+			self.request(|resp| Request::Flush { resp }).await
 		}
 
 		pub async fn finish(self) -> Result<Vec<Encoded>, Error> {
@@ -297,6 +322,10 @@ mod inline {
 			self.0.set_bitrate(bitrate)
 		}
 
+		pub async fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+			self.0.flush()
+		}
+
 		pub async fn finish(self) -> Result<Vec<Encoded>, Error> {
 			self.0.finish()
 		}
@@ -354,6 +383,7 @@ mod tests {
 		// Drive it the way an FFI handle gets driven: a fresh caller thread every
 		// time, none of them the thread that opened it.
 		let mut callers = vec![std::thread::current().id()];
+		let mut flushed = Vec::new();
 		for index in 0..3u64 {
 			let sink = sink.clone();
 			let caller = std::thread::spawn(move || {
@@ -362,10 +392,24 @@ mod tests {
 				sink.keyframe();
 				pollster::block_on(sink.encode(gray(index))).unwrap();
 				pollster::block_on(sink.set_bitrate(500_000 + index)).unwrap();
-				std::thread::current().id()
+				// Only the first frame closes a group, so the two after it stay in
+				// the codec and leave the drain below something to find.
+				let flushed = match index {
+					0 => pollster::block_on(sink.flush()).unwrap(),
+					_ => Vec::new(),
+				};
+				(std::thread::current().id(), flushed)
 			});
-			callers.push(caller.join().unwrap());
+			let (caller, drained) = caller.join().unwrap();
+			callers.push(caller);
+			flushed.extend(drained);
 		}
+
+		// The probe holds each frame back by one, so a flush that reached the codec
+		// hands back the frame the group ended on. An inherited no-op would return
+		// nothing here and silently drop it into the next group.
+		let flushed: Vec<_> = flushed.iter().map(|frame| frame.timestamp.as_micros()).collect();
+		assert_eq!(flushed, vec![0], "the group boundary did not empty the codec");
 
 		// ...and finished, so dropped, from yet another.
 		let closer = std::thread::spawn(move || {
@@ -376,13 +420,13 @@ mod tests {
 		let (closer, tail) = closer.join().unwrap();
 		callers.push(closer);
 
-		// The probe holds each frame back by one, so the drain has to hand back the
-		// last one. Dropping the sink without draining would lose it silently.
+		// Frame 2 never came back from an encode call and no flush claimed it, so
+		// the drain has to. Dropping the sink instead would lose it silently.
 		let tail: Vec<_> = tail.iter().map(|frame| frame.timestamp.as_micros()).collect();
 		assert_eq!(tail, vec![2 * 33_333], "the drain lost the codec's tail");
 
 		let log = probe::take();
-		for what in ["open", "encode", "set_bitrate", "finish", "drop"] {
+		for what in ["open", "encode", "set_bitrate", "flush", "finish", "drop"] {
 			assert!(log.iter().any(|(event, _)| *event == what), "no {what} in {log:?}");
 		}
 

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -30,18 +30,16 @@ use threaded::Inner;
 /// An [`Encoder`](super::Encoder) confined to one thread, driven from anywhere.
 ///
 /// Same shape as [`Encoder`](super::Encoder), one method at a time, except that
-/// [`encode`](Self::encode) takes the frame by value (it may cross a thread) and
-/// each call comes in an `async` flavor and a `blocking_` one. Reach for this
-/// instead of an `Encoder` whenever the encoder outlives a single thread's
-/// stack: an object shared across threads, an FFI handle, a task that migrates
-/// between executor workers. An `Encoder` you build, drive, and drop inside one
-/// function needs none of it.
+/// the calls are `async` and [`encode`](Self::encode) takes the frame by value
+/// (it may cross a thread). Reach for this instead of an `Encoder` whenever the
+/// encoder outlives a single thread's stack: an object shared across threads, an
+/// FFI handle, a task that migrates between executor workers. An `Encoder` you
+/// build, drive, and drop inside one function needs none of it.
 ///
-/// The two flavors differ only in how the caller waits for the encode thread.
-/// Use `async` from a task, so the executor keeps its worker while the codec
-/// runs, and `blocking_` from a plain thread (an FFI boundary that has to return
-/// a result synchronously). The `blocking_` calls park the calling thread and
-/// need no runtime.
+/// Awaiting rather than blocking is the point: the codec runs on its own thread,
+/// so the executor keeps its worker while a slow hardware encoder works through
+/// a frame. A caller with no executor to yield to (an FFI boundary that must
+/// return a result synchronously) blocks on these futures itself.
 pub struct Sink(Inner);
 
 impl Sink {
@@ -50,11 +48,6 @@ impl Sink {
 	/// surfaces here rather than on the first frame.
 	pub async fn open(config: &Config) -> Result<Self, Error> {
 		Ok(Self(Inner::open(config).await?))
-	}
-
-	/// [`open`](Self::open) for a synchronous caller.
-	pub fn blocking_open(config: &Config) -> Result<Self, Error> {
-		pollster::block_on(Self::open(config))
 	}
 
 	/// The encoder name in use, e.g. `"mediafoundation"`.
@@ -67,8 +60,8 @@ impl Sink {
 	///
 	/// Queued behind the frames already in flight rather than applied to
 	/// whichever one the codec happens to be on, so it keys the next frame you
-	/// pass to [`encode`](Self::encode). Never blocks, so there is no `async`
-	/// flavor.
+	/// pass to [`encode`](Self::encode). Only queues the request, so unlike the
+	/// rest there is nothing to await.
 	pub fn keyframe(&mut self) {
 		self.0.keyframe();
 	}
@@ -82,21 +75,11 @@ impl Sink {
 		self.0.encode(frame).await
 	}
 
-	/// [`encode`](Self::encode) for a synchronous caller.
-	pub fn blocking_encode(&mut self, frame: Frame) -> Result<Vec<Encoded>, Error> {
-		pollster::block_on(self.encode(frame))
-	}
-
 	/// Retune the encoder, waiting for the backend's verdict. See
 	/// [`Encoder::set_bitrate`](super::Encoder::set_bitrate) for what a failure
 	/// means (not fatal: stop adapting, keep encoding).
 	pub async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
 		self.0.set_bitrate(bitrate).await
-	}
-
-	/// [`set_bitrate`](Self::set_bitrate) for a synchronous caller.
-	pub fn blocking_set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
-		pollster::block_on(self.set_bitrate(bitrate))
 	}
 
 	/// Drain the codec, returning every access unit it was still holding, and
@@ -108,11 +91,6 @@ impl Sink {
 	/// or its last pictures never reach a subscriber.
 	pub async fn finish(self) -> Result<Vec<Encoded>, Error> {
 		self.0.finish().await
-	}
-
-	/// [`finish`](Self::finish) for a synchronous caller.
-	pub fn blocking_finish(self) -> Result<Vec<Encoded>, Error> {
-		pollster::block_on(self.finish())
 	}
 }
 
@@ -369,7 +347,9 @@ mod tests {
 	fn the_codec_stays_on_one_thread_however_it_is_driven() {
 		let _ = probe::take();
 
-		let sink = Arc::new(Mutex::new(Some(Sink::blocking_open(&probe_config()).unwrap())));
+		let sink = Arc::new(Mutex::new(Some(
+			pollster::block_on(Sink::open(&probe_config())).unwrap(),
+		)));
 
 		// Drive it the way an FFI handle gets driven: a fresh caller thread every
 		// time, none of them the thread that opened it.
@@ -380,8 +360,8 @@ mod tests {
 				let mut guard = sink.lock().unwrap();
 				let sink = guard.as_mut().unwrap();
 				sink.keyframe();
-				sink.blocking_encode(gray(index)).unwrap();
-				sink.blocking_set_bitrate(500_000 + index).unwrap();
+				pollster::block_on(sink.encode(gray(index))).unwrap();
+				pollster::block_on(sink.set_bitrate(500_000 + index)).unwrap();
 				std::thread::current().id()
 			});
 			callers.push(caller.join().unwrap());
@@ -390,7 +370,7 @@ mod tests {
 		// ...and finished, so dropped, from yet another.
 		let closer = std::thread::spawn(move || {
 			let sink = sink.lock().unwrap().take().unwrap();
-			let tail = sink.blocking_finish().unwrap();
+			let tail = pollster::block_on(sink.finish()).unwrap();
 			(std::thread::current().id(), tail)
 		});
 		let (closer, tail) = closer.join().unwrap();


### PR DESCRIPTION
Fixes #2619. Stacked on #2608, which is where the affected code lives, so this targets that branch rather than `main`.

## Root cause

Every owner of a `moq_video::encode::Encoder` that outlives one thread's stack was unsound on Windows. The Media Foundation backend's COM apartment is per-thread: `ComGuard` calls `CoInitializeEx` + `MFStartup` on the thread that builds the encoder and `MFShutdown` + `CoUninitialize` on the thread that drops it, and `unsafe impl Send for MediaFoundation` is sound only while those are the same thread.

MTA keeps cross-thread *calls* into the MFT legal, so encoding from another thread is the mild part. The sharp edge is create-on-one-thread / drop-on-another: the creating thread leaks its initialization, and `CoUninitialize` runs on a thread that never called `CoInitializeEx`, which can corrupt COM state for anything else in the process.

Three owners violated it:

- `rs/moq-ffi/src/video.rs` held the encoder in a `Mutex` inside a uniffi object shared across threads, so `publish_video` built it on one thread while `write` / `set_bitrate` / `finish` ran on whichever thread called in.
- `rs/libmoq/src/video.rs` kept it in the global slab. `ffi::enter` serializes calls but runs each on the *calling* thread.
- `rs/moq-transcode/src/rung.rs` holds an encoder across `.await` in a plain `async fn`, in both `live` (per demand session, across `listener.recv()`) and `Pipeline` (the fetch path, across `Container::read`). On a multi-thread runtime that future migrates workers.

macOS and Linux are unaffected. `publish_capture` was already correct: it used the private encode thread this PR promotes.

## The fix

`encode::Sink` (the encode thread `publish_capture` already used) becomes public and gains what the other callers need:

- **A drain path.** `Encoder::finish` consumes the encoder, so the thread loop breaks out on a `Finish` request and drains after it. Without this a caller could only drop the sink, losing the codec's tail before ending a track.
- **`flush`**, so a caller mirroring upstream group boundaries does not have to choose between thread confinement and valid group starts. A pipelined backend still holding the previous group's tail would otherwise emit it into the next group ahead of the keyframe.
- **Cancel safety.** A queued request runs whether or not anyone is still waiting, so a dropped future left the codec a step ahead of the stream with output nobody received. The sink now refuses every call after a cancelled one rather than publishing a track quietly missing those frames.

`Sink` mirrors `Encoder` one method at a time, so `keyframe()` is its own request rather than a flag threaded through `encode`. It stays async-only: the impedance against the two synchronous FFI surfaces is handled at those boundaries, where blocking is also the backpressure that stops a caller running megabytes of raw frames ahead of the codec.

`Sink::encode` takes `impl Into<Arc<Frame>>`. The live transcode path is fed by the shared decode, which fans one `Arc<Frame>` out to every rung, and `Frame` is deliberately not `Clone`; demanding an owned `Frame` would force a pixel copy on the caller the type most needs to serve. Callers holding a plain `Frame` convert for free.

## Correction to the issue

The issue warned that `Handle::block_on` panics inside an entered runtime context, so libmoq's `ffi::enter` would need restructuring. It does not: tokio gates blocking on the `EnterRuntime` flag, set only when a thread is actually *driving* the runtime, while `Handle::enter()` only sets the current-handle slot (`try_enter_blocking_region`, `runtime/context/blocking.rs`). No restructuring was needed.

The bindings still use `pollster` rather than a tokio helper, for the neighbouring case those really do reject: an FFI callback dispatched from libmoq's own runtime thread *is* entered, and a reentrant publish from there would panic.

## Tests

A backend that records the thread of every codec call, reachable only by name so backend selection can never pick it. Driving a `Sink` from four different caller threads must leave open / encode / set_bitrate / flush / finish / drop on one thread that is none of theirs; against the old shape it reports five. It also holds each frame back by one, like the MFT, so the flush and the drain are both asserted to have really emptied the codec.

A second test cancels a request mid-flight (gating the probe inside `encode` so the cancel lands deterministically rather than racing the encode thread) and asserts the sink refuses afterwards. Both bindings gain an end-to-end cross-thread publish test.

The two probe tests take an exclusive lock: nextest gives each test its own process and would have hidden the shared state, but `cargo test` does not.

## Known gap: the decoders

This fixes every **encoder**. The **decoders** have the identical problem and are not fixed here: `decode/backend/mediafoundation.rs` has its own `ComGuard` and its own `unsafe impl Send`, whose stated invariant is "only ever touched from the one decode task" -- a task, which migrates between workers. `moq-transcode/src/feed.rs` builds a `Decoder` in a `tokio::spawn`ed loop, and `Pipeline::decoder` sits beside the encoder fixed here.

So `live` is now fully correct (its only codec is the encoder), while the fetch path has one fixed half and one broken half. Closing it needs a `decode::Sink` mirroring this one, which is a new public API plus tests and did not belong in this PR.

## Verification

Run on a Windows host, which the issue assumed nobody had: `just rs windows` (clean, once #2638 unbroke the example it builds), plus the moq-video, moq-transcode, moq-ffi and libmoq suites including the real Media Foundation round-trips. The COM imbalance itself is not observable from a test, which is why the confinement is asserted instead.

## Cross-package sync

No FFI surface changed (same uniffi methods, same C functions, same signatures), so the language wrappers and their docs need no update. No wire format changed, so no draft does either. `doc/lib/rs/crate/moq-video.md` gains a paragraph on `encode::Sink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Opus 5)