### PR TITLE
fix!: reject a catalog whose broadcast reference escapes the root

### DIFF
--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -94,12 +94,14 @@ The section is omitted entirely when a broadcast publishes no captions.
 A rendition may set an optional `broadcast` field: a path relative to the broadcast that served the catalog (e.g. `"../source"`), pointing at another broadcast that publishes the actual track.
 A consumer resolves the reference against the catalog broadcast's own path (`..` pops a segment, other segments append) and subscribes to the track on the resolved broadcast over the same connection.
 When the field is absent, the track lives in the same broadcast as the catalog.
+A reference that walks above the root (more `..` than the catalog path has segments) names no broadcast, so the whole catalog is rejected rather than pointed at whatever path the walk stops on.
+The root is the consumer's authorized subtree, so such a reference is an attempt to name content it cannot reach: a publisher emitting one has a bug, and quietly serving the remaining renditions would hide that.
 
 This lets a transcoder publish a sidecar catalog that adds new renditions while pointing unchanged ones at the original broadcast, instead of re-publishing those bytes through the transcoder.
 For example, a transcoder consuming `room/source` can publish `room/transcode` whose catalog contains a downscaled `480p` rendition plus the original `1080p` rendition marked `"broadcast": "../source"`.
 A viewer of `room/transcode` then pulls `480p` from the transcoder and `1080p` directly from the source, and the relay dedupes the source subscription with the transcoder's own.
 
-`@moq/watch` resolves the reference automatically. In Rust, the `moq-mux` exporters do the same: they take a `Source::new(origin, path)`, and both the catalog broadcast and any referenced broadcast resolve through the origin over the same connection.
+Rejection happens where the catalog is read, not where a track is subscribed: the rendition set drives track layouts, playlists, codec lists, and quality selectors, so a reference caught any later would already have been offered and chosen. In Rust the `moq-mux` catalog stream rejects it and every exporter reads through that stream; `@moq/watch` rejects the catalog it would otherwise publish.
 
 ### Extensions
 

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -334,7 +334,9 @@ The `broadcast` field overrides that, naming a different broadcast that publishe
 
 The value is a relative path, resolved against the path of the broadcast that served the catalog.
 It uses the `.` and `..` semantics of a relative URL reference ({{!RFC3986, Section 5.2.4}}), for example `../source`.
-A publisher MUST NOT use an absolute path, and a consumer MUST ignore a rendition whose `broadcast` escapes above the root.
+A publisher MUST NOT use an absolute path, nor a reference that escapes above the root.
+The root is the consumer's authorized subtree, so such a reference names content the consumer cannot reach.
+A consumer MUST reject a catalog containing one, rather than resolving the reference against a different broadcast or ignoring the rendition.
 
 This lets a publisher author a catalog that points at tracks it does not republish.
 For example, a transcoder produces a catalog listing its own downstream renditions alongside the untouched source rendition, referencing the latter in the source broadcast rather than copying the bytes through.
@@ -501,6 +503,9 @@ A publisher SHOULD carry the end of the last group's content into that value, si
 
 
 # Security Considerations
+A rendition's `broadcast` reference ({{field-broadcast}}) resolves against the consumer's root, which is the subtree it is authorized for.
+Clamping a reference that escapes above that root would silently redirect the subscription to an unrelated broadcast, so a consumer rejects the catalog instead.
+
 TODO Security
 
 

--- a/js/hang/src/catalog/path.ts
+++ b/js/hang/src/catalog/path.ts
@@ -5,7 +5,8 @@ import * as z from "zod/mini";
  * Zod schema for a relative broadcast reference stored in a catalog (a rendition's
  * `broadcast` field, e.g. "../source"). Normalizes the input the same way the Rust
  * `PathRelative` type does so JS and Rust agree byte-for-byte after deserialization.
- * Resolve it against the catalog broadcast's own path with `Path.resolve`.
+ * Resolve it against the catalog broadcast's own path with `Path.resolve`, which rejects a
+ * reference that walks above the root: hang requires rejecting such a catalog.
  */
 export const RelativeBroadcastSchema = z.pipe(z.string(), z.transform(Path.normalizeRelative));
 

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -190,33 +190,33 @@ test("from sanitizes multiple arguments with slashes", () => {
 	expect(Path.from("foo//", "//bar", "baz")).toBe("foo/bar/baz" as Path.Valid);
 });
 
-test("resolve appends named segments", () => {
+test("resolve appends and pops", () => {
 	expect(Path.resolve(Path.from("a/b"), "c")).toBe(Path.from("a/b/c"));
 	expect(Path.resolve(Path.from("a/b"), "c/d")).toBe(Path.from("a/b/c/d"));
+	expect(Path.resolve(Path.from("a/b/c"), "../d")).toBe(Path.from("a/b/d"));
+	expect(Path.resolve(Path.from("a/b/c"), "..")).toBe(Path.from("a/b"));
+	expect(Path.resolve(Path.from("a/b/c"), "../../x")).toBe(Path.from("a/x"));
 });
 
 test("resolve with empty rel returns base", () => {
 	expect(Path.resolve(Path.from("a/b"), "")).toBe(Path.from("a/b"));
+	expect(Path.resolve(Path.empty(), "")).toBe(Path.empty());
 });
 
-test("resolve single dotdot pops one segment", () => {
-	expect(Path.resolve(Path.from("a/b/c"), "../d")).toBe(Path.from("a/b/d"));
-	expect(Path.resolve(Path.from("a/b/c"), "..")).toBe(Path.from("a/b"));
+test("resolve rejects a reference that escapes the root", () => {
+	expect(Path.resolve(Path.from("a/b/c"), "../../../../x")).toBeUndefined();
+	expect(Path.resolve(Path.from("a/b/c"), "../../../..")).toBeUndefined();
+	// A `..` that escapes mid-way is rejected even if later segments walk back down.
+	expect(Path.resolve(Path.from("a/b/c"), "../../../../a/b/c")).toBeUndefined();
+	expect(Path.resolve(Path.empty(), "../x")).toBeUndefined();
 });
 
-test("resolve multiple dotdot pops multiple segments", () => {
-	expect(Path.resolve(Path.from("a/b/c"), "../../x")).toBe(Path.from("a/x"));
-	expect(Path.resolve(Path.from("a/b/c"), "../../../x")).toBe(Path.from("x"));
-});
-
-test("resolve excess dotdot clamps at empty", () => {
-	expect(Path.resolve(Path.from("a"), "../../../foo")).toBe(Path.from("foo"));
-	expect(Path.resolve(Path.from("a"), "..")).toBe(Path.from(""));
-});
-
-test("resolve with empty base", () => {
+test("resolve allows a reference landing on the root", () => {
+	// Popping to exactly the root stops at it rather than walking above it.
+	expect(Path.resolve(Path.from("a"), "..")).toBe(Path.empty());
+	expect(Path.resolve(Path.from("a/b"), "../..")).toBe(Path.empty());
+	expect(Path.resolve(Path.from("a/b"), "../../x")).toBe(Path.from("x"));
 	expect(Path.resolve(Path.empty(), "foo")).toBe(Path.from("foo"));
-	expect(Path.resolve(Path.empty(), "..")).toBe(Path.from(""));
 });
 
 test("resolve treats dot as a no-op", () => {

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -194,22 +194,28 @@ export function normalizeRelative(rel: string): string {
  * Resolve a relative path reference against a base path.
  *
  * `..` segments pop the last segment of the base; other segments are appended.
- * `.` and empty segments are no-ops. Excess `..` once the base is empty is also a
- * no-op (subsequent named segments still append). An empty / normalized-empty `rel`
- * returns the base path unchanged.
+ * `.` and empty segments are no-ops. An empty / normalized-empty `rel` returns the
+ * base path unchanged.
  *
- * Mirrors the Rust `Path::resolve`, used by hang catalogs to express
- * cross-broadcast track references (a rendition's `broadcast` field).
+ * Returns `undefined` when a `..` has nothing left to pop, i.e. the reference walks
+ * above the root and names nothing. Popping to exactly the root is fine and yields the
+ * empty path, which still names a broadcast. The alternative, clamping, would silently
+ * land `../../../../x` on an unrelated `x`, so the caller decides what an out-of-range
+ * reference means (the hang catalog rejects such a catalog outright).
+ *
+ * Mirrors the Rust `Path::resolve`, used by hang catalogs to express cross-broadcast
+ * track references (a rendition's `broadcast` field).
  *
  * @example
  * ```typescript
  * Path.resolve(Path.from("a/b/c"), "../source"); // "a/b/source"
  * Path.resolve(Path.from("a/b"), "x/y");         // "a/b/x/y"
- * Path.resolve(Path.from("a"), "../../x");       // "x"
  * Path.resolve(Path.from("a/b"), "./c");         // "a/b/c"
+ * Path.resolve(Path.from("a"), "..");            // "" (the root)
+ * Path.resolve(Path.from("a"), "../../x");       // undefined
  * ```
  */
-export function resolve(base: Valid, rel: string): Valid {
+export function resolve(base: Valid, rel: string): Valid | undefined {
 	const segments = base === "" ? [] : base.split("/");
 
 	for (const seg of rel.split("/")) {
@@ -217,7 +223,8 @@ export function resolve(base: Valid, rel: string): Valid {
 			continue;
 		}
 		if (seg === "..") {
-			segments.pop();
+			// Nothing left to pop: the reference walks above the root.
+			if (segments.pop() === undefined) return undefined;
 		} else {
 			segments.push(seg);
 		}

--- a/js/watch/src/broadcast.test.ts
+++ b/js/watch/src/broadcast.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "bun:test";
+import type * as Catalog from "@moq/hang/catalog";
+import type * as Moq from "@moq/net";
+import { Path } from "@moq/net";
+import { Effect } from "@moq/signals";
+import { Broadcast } from "./broadcast";
+
+// A consumer stub that only remembers which path it was consumed from.
+type Consumed = { path: Moq.Path.Valid; close: () => void };
+
+// The connection is only asked to consume a path; `reload: false` skips the announcement
+// stream and `catalogFormat: "manual"` skips the catalog fetch.
+function connection(): Moq.Connection.Established {
+	return {
+		consume: (path: Moq.Path.Valid): Consumed => ({ path, close: () => {} }),
+	} as unknown as Moq.Connection.Established;
+}
+
+function broadcast(name: string): Broadcast {
+	return new Broadcast({
+		connection: connection(),
+		name: Path.from(name),
+		enabled: true,
+		reload: false,
+		catalogFormat: "manual",
+	});
+}
+
+function consumed(value: Moq.Broadcast.Consumer | undefined): string | undefined {
+	return (value as unknown as Consumed | undefined)?.path;
+}
+
+function withoutWarnings<T>(fn: () => T): T {
+	const warn = console.warn;
+	console.warn = () => {};
+	try {
+		return fn();
+	} finally {
+		console.warn = warn;
+	}
+}
+
+describe("relativeBroadcast", () => {
+	it("resolves a legal reference against the catalog broadcast", () => {
+		const source = broadcast("a/b");
+		const effect = new Effect();
+		try {
+			expect(consumed(source.relativeBroadcast(effect, "../source"))).toBe("a/source");
+			expect(consumed(source.relativeBroadcast(effect, "sub"))).toBe("a/b/sub");
+		} finally {
+			effect.close();
+			source.close();
+		}
+	});
+
+	it("ignores a reference that escapes above the root", () => {
+		const source = broadcast("a/b");
+		const effect = new Effect();
+		try {
+			// Clamping would subscribe to an unrelated `x` instead of dropping the rendition.
+			withoutWarnings(() => {
+				expect(source.relativeBroadcast(effect, "../../../x")).toBeUndefined();
+				expect(source.relativeBroadcast(effect, "../../../..")).toBeUndefined();
+			});
+			// Popping to exactly the root stops at it, and the root still names a broadcast.
+			expect(consumed(source.relativeBroadcast(effect, "../.."))).toBe(Path.empty());
+		} finally {
+			effect.close();
+			source.close();
+		}
+	});
+
+	const rendition = (broadcast?: string): Catalog.VideoConfig =>
+		({ codec: "avc1.42001f", container: { kind: "legacy" }, broadcast }) as Catalog.VideoConfig;
+
+	const manualCatalog = (catalog: Catalog.Root) =>
+		new Broadcast({
+			connection: connection(),
+			name: Path.from("a/b"),
+			enabled: true,
+			reload: false,
+			catalogFormat: "manual",
+			catalog,
+		});
+
+	const manual = (renditions: Record<string, Catalog.VideoConfig>) =>
+		manualCatalog({ video: { renditions } } as Catalog.Root);
+
+	it("rejects a catalog carrying an escaping rendition", async () => {
+		// The whole catalog goes, not just the offending rendition: the root is this
+		// consumer's authorized subtree, so the reference names content it cannot reach,
+		// and serving the rest would hide a publisher bug behind a track that never fills.
+		const source = manual({ good: rendition(), sibling: rendition("../source"), bad: rendition("../../../x") });
+
+		const error = console.error;
+		console.error = () => {};
+		try {
+			// The catalog is validated by an effect, which settles a microtask later.
+			await Promise.resolve();
+			expect(source.out.catalog.peek()).toBeUndefined();
+		} finally {
+			console.error = error;
+			source.close();
+		}
+	});
+
+	it("rejects a catalog whose text rendition escapes the root", async () => {
+		// The containment check covers every section carrying renditions: a text (caption)
+		// reference escaping the root rejects the catalog like a video or audio one.
+		const captions = {
+			format: "vtt",
+			role: "subtitle",
+			container: { kind: "legacy" },
+			broadcast: "../../../x",
+		} as Catalog.TextConfig;
+		const source = manualCatalog({
+			video: { renditions: { good: rendition() } },
+			text: { renditions: { captions } },
+		} as Catalog.Root);
+
+		const error = console.error;
+		console.error = () => {};
+		try {
+			await Promise.resolve();
+			expect(source.out.catalog.peek()).toBeUndefined();
+		} finally {
+			console.error = error;
+			source.close();
+		}
+	});
+
+	it("accepts a catalog whose references stay within the root", async () => {
+		const source = manual({ good: rendition(), sibling: rendition("../source"), root: rendition("../..") });
+
+		try {
+			await Promise.resolve();
+			const renditions = source.out.catalog.peek()?.video?.renditions ?? {};
+			expect(Object.keys(renditions).sort()).toEqual(["good", "root", "sibling"]);
+		} finally {
+			source.close();
+		}
+	});
+
+	it("uses the catalog's own broadcast when the reference is absent, empty, or self", async () => {
+		const source = broadcast("a/b");
+		const effect = new Effect();
+		try {
+			// The catalog broadcast is consumed by an effect, which settles a microtask later.
+			await Promise.resolve();
+			expect(consumed(source.relativeBroadcast(effect, undefined))).toBe("a/b");
+			expect(consumed(source.relativeBroadcast(effect, ""))).toBe("a/b");
+			expect(consumed(source.relativeBroadcast(effect, "../b"))).toBe("a/b");
+		} finally {
+			effect.close();
+			source.close();
+		}
+	});
+});

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -24,6 +24,39 @@ function skipDiscovery(conn: Moq.Connection.Established): boolean {
 	return true;
 }
 
+/**
+ * The name of the first rendition whose `broadcast` reference walks above the root, if any.
+ *
+ * The root is the consumer's authorized subtree, so such a reference names content this
+ * consumer cannot reach. It rejects the whole catalog rather than the one rendition: a
+ * publisher that emits one has a bug, and quietly serving the rest hides that while the
+ * missing rendition resurfaces later as a track that never fills.
+ */
+function findEscaping(base: Moq.Path.Valid, catalog: Catalog.Root): string | undefined {
+	// Every section carrying renditions must be listed here; one left out silently exempts
+	// its renditions from the containment check.
+	const renditions = [
+		...Object.entries(catalog.video?.renditions ?? {}),
+		...Object.entries(catalog.audio?.renditions ?? {}),
+		...Object.entries(catalog.text?.renditions ?? {}),
+	];
+
+	for (const [name, config] of renditions) {
+		if (config.broadcast && Path.resolve(base, config.broadcast) === undefined) return name;
+	}
+
+	return undefined;
+}
+
+/** Throw if any rendition's `broadcast` reference escapes the root. */
+function assertResolvable(base: Moq.Path.Valid, catalog: Catalog.Root): Catalog.Root {
+	const escaping = findEscaping(base, catalog);
+	if (escaping !== undefined) {
+		throw new Error(`rendition ${JSON.stringify(escaping)}: broadcast reference escapes the root ${base}`);
+	}
+	return catalog;
+}
+
 // Watch supports the on-the-wire catalog formats from @moq/hang, plus "hangz" (the
 // DEFLATE-compressed `catalog.json.z` track) and a "manual" mode where the user supplies the
 // catalog directly without fetching. "hangz" is opt-in only: it shares the `.hang` broadcast suffix
@@ -197,10 +230,18 @@ export class Broadcast {
 		const format: CatalogFormat = catalogFormat ?? Catalog.detectFormat(name) ?? Catalog.DEFAULT_FORMAT;
 
 		if (format === "manual") {
-			// Mirror the caller-supplied catalog into the effective output.
+			// Mirror the caller-supplied catalog into the effective output. A caller-supplied
+			// catalog is rejected the same way a fetched one is, minus the throw: this runs in
+			// the effect body, where an exception would surface as an unhandled error.
 			const catalog = effect.get(this.in.catalog);
-			effect.set(this.#out.catalog, catalog, undefined);
-			this.#out.status.set(catalog ? "live" : "loading");
+			const escaping = catalog && findEscaping(name, catalog);
+			if (escaping !== undefined) {
+				console.error("rejecting catalog: broadcast reference escapes the root", name, escaping);
+			}
+
+			const accepted = escaping === undefined ? catalog : undefined;
+			effect.set(this.#out.catalog, accepted, undefined);
+			this.#out.status.set(accepted ? "live" : "loading");
 			return;
 		}
 
@@ -237,11 +278,11 @@ export class Broadcast {
 
 					console.debug("received catalog", format, this.in.name.peek(), update);
 
-					this.#out.catalog.set(update);
+					this.#out.catalog.set(assertResolvable(name, update));
 					this.#out.status.set("live");
 				}
 			} catch (err) {
-				console.warn("error fetching catalog", this.in.name.peek(), err);
+				console.error("error fetching catalog", this.in.name.peek(), err);
 			} finally {
 				this.#out.catalog.set(undefined);
 				this.#out.status.set("offline");
@@ -256,6 +297,10 @@ export class Broadcast {
 	 * relative to this broadcast's name and consume the resolved broadcast on the same
 	 * connection. Otherwise return the catalog's own active broadcast.
 	 *
+	 * Returns `undefined` for a reference that walks above the root: hang requires such a
+	 * rendition to be ignored, since clamping at the root would point it at an unrelated
+	 * broadcast.
+	 *
 	 * The consumer is scoped to the caller's `effect` (closed on its next run), so a
 	 * reference resolves lazily and reacts to `enabled` / connection / announcement
 	 * changes exactly like the catalog broadcast.
@@ -265,11 +310,14 @@ export class Broadcast {
 
 		const base = effect.get(this.in.name);
 		const resolved = Path.resolve(base, rel);
+		if (resolved === undefined) {
+			console.warn("ignoring rendition: broadcast reference escapes the root", base, rel);
+			return undefined;
+		}
 
-		// A reference that walks back to the catalog's own broadcast (or resolves to
-		// the empty root, via excess `..`) is served by the catalog broadcast itself,
-		// avoiding a duplicate subscription on the same path.
-		if (resolved === base || resolved === Path.empty()) return effect.get(this.out.active);
+		// A reference that walks back to the catalog's own broadcast is served by the
+		// catalog broadcast itself, avoiding a duplicate subscription on the same path.
+		if (resolved === base) return effect.get(this.out.active);
 
 		if (!effect.get(this.in.enabled)) return undefined;
 

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -71,6 +71,9 @@ pub struct AudioConfig {
 	/// Optional reference to another broadcast that publishes this track, expressed
 	/// relative to the broadcast that served this catalog (e.g. `../source`). If unset,
 	/// the track lives in the same broadcast as the catalog.
+	///
+	/// Resolve it with [`Path::resolve`](moq_net::Path::resolve): a reference that walks
+	/// above the root names no broadcast, so the catalog is rejected.
 	#[serde(default)]
 	pub broadcast: Option<moq_net::PathRelativeOwned>,
 

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -147,6 +147,9 @@ pub struct VideoConfig {
 	///
 	/// This allows a transcoder to author a downstream catalog that points unchanged
 	/// renditions at the source broadcast without re-publishing the bytes.
+	///
+	/// Resolve it with [`Path::resolve`](moq_net::Path::resolve): a reference that walks
+	/// above the root names no broadcast, so the catalog is rejected.
 	#[serde(default)]
 	pub broadcast: Option<moq_net::PathRelativeOwned>,
 

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -196,8 +196,7 @@ impl Subscribe {
 	/// Build the catalog stream, narrowed by the rendition selection flags. The
 	/// catalog source honors the requested format (e.g. compressed `HangZ` or `Msf`).
 	async fn stream(&self) -> anyhow::Result<catalog::Select<catalog::Consumer>> {
-		let broadcast = self.source.broadcast().await?;
-		let consumer = catalog::Consumer::new(&broadcast, self.catalog).await?;
+		let consumer = self.source.catalog(self.catalog).await?;
 		Ok(consumer.select(self.args.selection()?))
 	}
 

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -249,6 +249,9 @@ async fn watch_catalog(
 	renditions: renditions::Producer,
 	timeline_watcher: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 ) {
+	// Built from the caller's `broadcast` handle rather than re-resolving through `source`, so
+	// the catalog, the timeline subscription, and the closed check below all refer to the same
+	// resolution. A same-name replacement between the two lookups would otherwise split them.
 	let mut consumer = loop {
 		match catalog::Consumer::<()>::new(&broadcast, CatalogFormat::Hang).await {
 			Ok(consumer) => break consumer,

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -1,5 +1,7 @@
 use std::task::{Poll, ready};
 
+use moq_net::PathOwned;
+
 use super::{Catalog, CatalogExt};
 use crate::Result;
 
@@ -10,14 +12,22 @@ use crate::Result;
 ///
 /// Generic over the application extension `E` (defaulting to `()`); yields a
 /// [`Catalog<E>`](super::Catalog).
+///
+/// A rendition's `broadcast` field is relative to the path of the broadcast serving the
+/// catalog, taken from the track's [`broadcast::Info::path`](moq_net::broadcast::Info::path).
+/// A catalog that misuses that reference is rejected outright (see [`Self::poll_next`]).
 pub struct Consumer<E: CatalogExt = ()> {
 	inner: moq_json::snapshot::Consumer<Catalog<E>>,
+	/// Path of the broadcast serving this catalog, which every rendition's `broadcast`
+	/// reference resolves against.
+	base: PathOwned,
 }
 
 impl<E: CatalogExt> Consumer<E> {
 	/// Create a new catalog consumer from a MoQ track subscriber (uncompressed `catalog.json`).
 	pub fn new(track: moq_net::track::Subscriber) -> Self {
 		Self {
+			base: track.broadcast().path.clone(),
 			inner: moq_json::snapshot::Consumer::new(track, moq_json::snapshot::ConsumerConfig::default()),
 		}
 	}
@@ -29,14 +39,26 @@ impl<E: CatalogExt> Consumer<E> {
 		let mut config = moq_json::snapshot::ConsumerConfig::default();
 		config.compression = true;
 		Self {
+			base: track.broadcast().path.clone(),
 			inner: moq_json::snapshot::Consumer::new(track, config),
 		}
 	}
 
 	/// Poll for the next catalog update.
+	///
+	/// Fails with [`Error::EscapingBroadcast`](crate::Error::EscapingBroadcast) if any rendition's
+	/// `broadcast` reference walks above the root. Such a reference names no broadcast, and the
+	/// root is the consumer's authorized subtree, so it is an attempt to reference content the
+	/// consumer cannot name. The whole catalog is rejected rather than the one rendition: a
+	/// publisher that emits one has a bug (or is hostile), and silently serving the rest hides
+	/// that from the operator while the missing rendition surfaces much later as a track that
+	/// never fills.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Catalog<E>>>> {
-		let result = ready!(self.inner.poll_next(waiter));
-		Poll::Ready(result.map_err(Into::into))
+		let catalog = ready!(self.inner.poll_next(waiter))?;
+		if let Some(catalog) = catalog.as_ref() {
+			check_resolvable(&self.base, catalog)?;
+		}
+		Poll::Ready(Ok(catalog))
 	}
 
 	/// Get the next catalog update.
@@ -47,7 +69,7 @@ impl<E: CatalogExt> Consumer<E> {
 	where
 		Catalog<E>: Unpin,
 	{
-		Ok(self.inner.next().await?)
+		kio::wait(|waiter| self.poll_next(waiter)).await
 	}
 }
 
@@ -55,6 +77,33 @@ impl<E: CatalogExt> From<moq_net::track::Subscriber> for Consumer<E> {
 	fn from(inner: moq_net::track::Subscriber) -> Self {
 		Self::new(inner)
 	}
+}
+
+/// Reject the catalog if any rendition's `broadcast` reference walks above the root.
+///
+/// Every section carrying renditions must be chained here; a section left out silently
+/// exempts its renditions from the containment check.
+fn check_resolvable<E: CatalogExt>(base: &PathOwned, catalog: &Catalog<E>) -> Result<()> {
+	let video = catalog.video.renditions.iter();
+	let audio = catalog.audio.renditions.iter();
+	let text = catalog.text.renditions.iter();
+
+	for (rendition, rel) in video
+		.map(|(name, config)| (name, config.broadcast.as_ref()))
+		.chain(audio.map(|(name, config)| (name, config.broadcast.as_ref())))
+		.chain(text.map(|(name, config)| (name, config.broadcast.as_ref())))
+	{
+		let Some(rel) = rel.filter(|rel| !rel.is_empty()) else {
+			continue;
+		};
+
+		if base.resolve(rel).is_none() {
+			tracing::error!(rendition, %rel, catalog = %base, "rejecting catalog: broadcast reference escapes the root");
+			return Err(crate::Error::EscapingBroadcast(rel.to_string()));
+		}
+	}
+
+	Ok(())
 }
 
 #[cfg(test)]
@@ -90,6 +139,110 @@ mod test {
 		match result {
 			Poll::Ready(Ok(Some(decoded))) => decoded,
 			other => panic!("expected catalog payload, got {other:?}"),
+		}
+	}
+
+	fn opus() -> hang::catalog::AudioConfig {
+		hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2)
+	}
+
+	fn referencing(rel: &str) -> hang::catalog::AudioConfig {
+		let mut config = opus();
+		config.broadcast = Some(moq_net::PathRelative::new(rel).into_owned());
+		config
+	}
+
+	/// Publish `catalog` as one snapshot on a broadcast at `a/pub` (two segments, so a
+	/// third `..` walks above the root) and return what the stream yields. The broadcast is
+	/// minted through an origin because that is what stamps
+	/// [`broadcast::Info::path`](moq_net::broadcast::Info::path), the base the consumer
+	/// resolves against.
+	fn publish_catalog(published: Catalog<()>) -> Result<Option<Catalog>> {
+		let origin = moq_net::Origin::random().produce();
+		let mut broadcast = origin
+			.create_broadcast("a/pub", moq_net::broadcast::Route::new())
+			.expect("broadcast should create");
+		let mut track = broadcast
+			.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())
+			.expect("catalog track should create");
+		let mut consumer = Consumer::new(track.subscribe(None));
+		let mut group = track.append_group().expect("catalog group should append");
+
+		let payload = serde_json::to_string(&published).expect("catalog should serialize");
+		group
+			.write_frame(moq_net::Timestamp::ZERO, payload)
+			.expect("catalog frame should write");
+		group.finish().expect("catalog group should finish");
+
+		match consumer.poll_next(&kio::Waiter::noop()) {
+			Poll::Ready(result) => result,
+			Poll::Pending => panic!("a finished catalog group should be ready"),
+		}
+	}
+
+	/// [`publish_catalog`] over audio renditions alone.
+	fn publish(renditions: Vec<(&str, hang::catalog::AudioConfig)>) -> Result<Option<Catalog>> {
+		let mut published = Catalog::<()>::default();
+		for (name, config) in renditions {
+			published.audio.renditions.insert(name.to_string(), config);
+		}
+		publish_catalog(published)
+	}
+
+	/// A reference that stops at or below the root names a broadcast, so the catalog stands.
+	#[tokio::test]
+	async fn accepts_references_within_the_root() {
+		let catalog = publish(vec![
+			("here", opus()),
+			("sibling", referencing("../source")),
+			("root", referencing("../..")),
+		])
+		.expect("catalog should be accepted")
+		.expect("catalog should decode");
+
+		let mut names: Vec<&str> = catalog.audio.renditions.keys().map(String::as_str).collect();
+		names.sort_unstable();
+		assert_eq!(names, ["here", "root", "sibling"]);
+	}
+
+	/// A rendition whose `broadcast` reference walks above the root names no broadcast, and
+	/// the root is the consumer's authorized subtree. The whole catalog is rejected rather
+	/// than the one rendition, so a publisher bug is loud instead of surfacing later as a
+	/// track that never fills.
+	#[tokio::test]
+	async fn rejects_a_catalog_whose_broadcast_escapes_the_root() {
+		for reference in ["../../../elsewhere", "../../..", "../../../.."] {
+			// The escaping rendition is published alongside perfectly good ones, which do
+			// not rescue the catalog.
+			let result = publish(vec![
+				("here", opus()),
+				("sibling", referencing("../source")),
+				("escaping", referencing(reference)),
+			]);
+
+			match result {
+				Err(crate::Error::EscapingBroadcast(reported)) => assert_eq!(reported, reference),
+				Err(err) => panic!("{reference} failed with the wrong error: {err:?}"),
+				Ok(_) => panic!("{reference} should reject the catalog"),
+			}
+		}
+	}
+
+	/// The containment check covers every section carrying renditions, not just audio and
+	/// video: an escaping text (caption) reference rejects the catalog the same way.
+	#[tokio::test]
+	async fn rejects_a_catalog_whose_text_broadcast_escapes_the_root() {
+		let mut published = Catalog::<()>::default();
+		published.audio.renditions.insert("here".to_string(), opus());
+
+		let mut text = hang::catalog::TextConfig::new(hang::catalog::TextFormat::Vtt);
+		text.broadcast = Some(moq_net::PathRelative::new("../../../elsewhere").into_owned());
+		published.text.renditions.insert("captions".to_string(), text);
+
+		match publish_catalog(published) {
+			Err(crate::Error::EscapingBroadcast(reported)) => assert_eq!(reported, "../../../elsewhere"),
+			Err(err) => panic!("wrong error: {err:?}"),
+			Ok(_) => panic!("an escaping text reference should reject the catalog"),
 		}
 	}
 

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -176,8 +176,7 @@ impl Export {
 		source: crate::Source,
 		catalog_format: CatalogFormat,
 	) -> Result<Self, crate::Error> {
-		let broadcast = source.broadcast().await?;
-		let catalog = crate::catalog::Consumer::new(&broadcast, catalog_format).await?;
+		let catalog = source.catalog(catalog_format).await?;
 		Ok(Self {
 			source,
 			catalog: Some(catalog),

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -318,7 +318,10 @@ impl<S: Stream> Export<S> {
 	}
 
 	fn update_catalog(&mut self, catalog: &Catalog) -> Result<()> {
-		// A rendition we can't parse is ignored rather than failing the whole export.
+		// A rendition we can't parse is ignored rather than failing the whole export. Drop it
+		// before the snapshot is cached, since the init segment expects a track for every
+		// rendition in it. (An escaping `broadcast` reference is already gone: the catalog
+		// stream drops those.)
 		let mut catalog = catalog.clone();
 		catalog
 			.video

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -75,6 +75,11 @@ pub(crate) struct ExportSource {
 
 impl ExportSource {
 	/// Subscribe to a video rendition and build an `ExportSource`.
+	///
+	/// Fails with [`Error::EscapingBroadcast`](crate::Error::EscapingBroadcast) if the catalog
+	/// `broadcast` reference escapes above the root, naming no broadcast to subscribe on. The
+	/// catalog stream rejects such a reference first, so this is a backstop for a caller that
+	/// built the config itself.
 	pub fn for_video(
 		source: &crate::Source,
 		name: &str,
@@ -85,8 +90,10 @@ impl ExportSource {
 		let transform = build_video_transform(config);
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
+		let request = source.request(config.broadcast.as_ref())?;
+
 		Ok(Self {
-			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
+			state: SourceState::Requesting(request, name.to_string()),
 			media: Some(media),
 			latency_max,
 			transform,
@@ -98,6 +105,8 @@ impl ExportSource {
 	/// transform. Payloads pass through untouched (Annex-B stays Annex-B,
 	/// avc1 length-prefixed stays length-prefixed). The Annex-B exporter
 	/// uses this to keep parameter sets in-band.
+	///
+	/// Rejects an escaping `broadcast` reference like [`Self::for_video`].
 	pub fn for_video_raw(
 		source: &crate::Source,
 		name: &str,
@@ -107,8 +116,10 @@ impl ExportSource {
 		let media: HangContainer = (&config.container).try_into()?;
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
+		let request = source.request(config.broadcast.as_ref())?;
+
 		Ok(Self {
-			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
+			state: SourceState::Requesting(request, name.to_string()),
 			media: Some(media),
 			latency_max,
 			transform: None,
@@ -118,6 +129,8 @@ impl ExportSource {
 
 	/// Subscribe to an audio rendition. Audio has no codec-shape transform;
 	/// `description` is taken straight from the catalog.
+	///
+	/// Rejects an escaping `broadcast` reference like [`Self::for_video`].
 	pub fn for_audio(
 		source: &crate::Source,
 		name: &str,
@@ -127,8 +140,10 @@ impl ExportSource {
 		let media: HangContainer = (&config.container).try_into()?;
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
+		let request = source.request(config.broadcast.as_ref())?;
+
 		Ok(Self {
-			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
+			state: SourceState::Requesting(request, name.to_string()),
 			media: Some(media),
 			latency_max,
 			transform: None,
@@ -139,9 +154,12 @@ impl ExportSource {
 	/// Subscribe to a verbatim `mpegts` stream rendition (SCTE-35, private PES, ...).
 	/// No codec-shape transform and no description: the frames are Legacy-framed
 	/// verbatim bytes the muxer writes back out as PES or private sections.
+	///
+	/// Such a rendition has no catalog `broadcast` field, so it always lives on the
+	/// catalog broadcast and can never carry an escaping reference.
 	pub fn for_stream(source: &crate::Source, name: &str, latency_max: Duration) -> Result<Self, crate::Error> {
 		Ok(Self {
-			state: SourceState::Requesting(source.request(None), name.to_string()),
+			state: SourceState::Requesting(source.request_catalog(), name.to_string()),
 			media: Some(HangContainer::Legacy),
 			latency_max,
 			transform: None,
@@ -261,5 +279,80 @@ pub(crate) fn build_video_transform(config: &VideoConfig) -> Option<VideoTransfo
 		VideoCodec::H264(_) => Some(VideoTransform::Avc1(Avc1::new())),
 		VideoCodec::H265(_) => Some(VideoTransform::Hvc1(Hvc1::new())),
 		_ => None,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use hang::catalog::{AudioCodec, Container, H264};
+	use moq_net::PathRelative;
+
+	use super::*;
+	use crate::container::test_util::Live;
+
+	fn video(broadcast: Option<&str>) -> VideoConfig {
+		let mut config = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		config.container = Container::Legacy;
+		config.broadcast = broadcast.map(|b| PathRelative::new(b).into_owned());
+		config
+	}
+
+	fn audio(broadcast: Option<&str>) -> AudioConfig {
+		let mut config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		config.container = Container::Legacy;
+		config.broadcast = broadcast.map(|b| PathRelative::new(b).into_owned());
+		config
+	}
+
+	/// A rendition whose `broadcast` escapes the root fails, rather than resolving against
+	/// whatever broadcast the clamped path lands on. The test origin serves every path it
+	/// is asked for, so a clamped request would happily resolve.
+	#[tokio::test]
+	async fn escaping_reference_fails_the_rendition() {
+		let live = Live::avc3();
+		let source = live.source();
+		let latency = Duration::ZERO;
+
+		let escaping = |result: Result<ExportSource, crate::Error>, what: &str| match result {
+			Err(crate::Error::EscapingBroadcast(_)) => {}
+			Err(err) => panic!("{what} failed with the wrong error: {err:?}"),
+			Ok(_) => panic!("{what} should not resolve"),
+		};
+
+		// The source is rooted at a single-segment path, so two `..` walk above the root.
+		// A single `..` stops at the root, which still names a broadcast.
+		for reference in ["../../elsewhere", "../../.."] {
+			let config = video(Some(reference));
+			escaping(ExportSource::for_video(&source, "video", &config, latency), reference);
+			escaping(
+				ExportSource::for_video_raw(&source, "video", &config, latency),
+				reference,
+			);
+			escaping(
+				ExportSource::for_audio(&source, "audio", &audio(Some(reference)), latency),
+				reference,
+			);
+		}
+	}
+
+	/// A legal reference still resolves, as does an absent or empty one (the catalog's own
+	/// broadcast).
+	#[tokio::test]
+	async fn legal_reference_keeps_the_rendition() {
+		let live = Live::avc3();
+		let source = live.source();
+		let latency = Duration::ZERO;
+
+		for reference in [None, Some(""), Some("../source"), Some("sub"), Some("..")] {
+			ExportSource::for_video(&source, "video", &video(reference), latency)
+				.unwrap_or_else(|err| panic!("{reference:?} should keep the rendition: {err:?}"));
+			ExportSource::for_audio(&source, "audio", &audio(reference), latency)
+				.unwrap_or_else(|err| panic!("{reference:?} should keep the rendition: {err:?}"));
+		}
 	}
 }

--- a/rs/moq-mux/src/container/test_util.rs
+++ b/rs/moq-mux/src/container/test_util.rs
@@ -61,7 +61,8 @@ impl Live {
 	}
 
 	pub(crate) async fn catalog_stream(&self) -> crate::catalog::Consumer {
-		crate::catalog::Consumer::<()>::new(&self.consumer, crate::catalog::CatalogFormat::Hang)
+		self.source()
+			.catalog::<()>(crate::catalog::CatalogFormat::Hang)
 			.await
 			.expect("catalog consumer")
 	}

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -194,8 +194,7 @@ impl<E: catalog::Catalog> Export<E> {
 	/// Shared constructor. The public entry points each live on a concrete
 	/// `Export<E>` impl that pins `E`, so the extension is chosen by which one you call.
 	async fn build(source: crate::Source, catalog_format: CatalogFormat) -> Result<Self, crate::Error> {
-		let broadcast = source.broadcast().await?;
-		let catalog = crate::catalog::Consumer::<E>::new(&broadcast, catalog_format).await?;
+		let catalog = source.catalog::<E>(catalog_format).await?;
 		Ok(Self {
 			source,
 			catalog: Some(catalog),
@@ -1187,8 +1186,9 @@ fn dts_reserve(config: &VideoConfig) -> u64 {
 mod tests {
 	use std::time::Duration;
 
-	use super::{DEFAULT_DTS_RESERVE, PSI_INTERVAL, author_dts, due, is_complete_section};
 	use moq_net::Timestamp;
+
+	use super::{DEFAULT_DTS_RESERVE, PSI_INTERVAL, author_dts, due, is_complete_section};
 
 	fn ms(value: u64) -> Timestamp {
 		Timestamp::from_millis(value).unwrap()

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -145,6 +145,16 @@ pub enum Error {
 	/// frames cannot be parsed. Such a rendition must be ignored, not guessed at.
 	#[error("unsupported container: {0}")]
 	UnsupportedContainer(String),
+
+	/// A rendition's `broadcast` reference walks above the root, so it names no broadcast.
+	///
+	/// The root is the consumer's authorized subtree, so such a reference is an attempt to
+	/// name content the consumer cannot reach. It rejects the whole catalog
+	/// ([`catalog::hang::Consumer`](crate::catalog::hang::Consumer)) rather than the one
+	/// rendition, and is also what a direct [`Source::resolve`](crate::Source::resolve) /
+	/// [`Source::subscribe_track`](crate::Source::subscribe_track) reports.
+	#[error("broadcast reference escapes the root: {0}")]
+	EscapingBroadcast(String),
 }
 
 impl Error {

--- a/rs/moq-mux/src/source.rs
+++ b/rs/moq-mux/src/source.rs
@@ -41,50 +41,83 @@ impl Source {
 
 	/// Resolve and subscribe to the catalog broadcast (the one at this source's path).
 	pub async fn broadcast(&self) -> crate::Result<moq_net::broadcast::Consumer> {
-		Ok(self.origin.request_broadcast(&self.path).await?)
+		Ok(self.request_catalog().await?)
 	}
 
-	/// Begin resolving the broadcast that serves rendition track `name`, honoring an
-	/// optional cross-broadcast reference.
+	/// Subscribe to this broadcast's catalog.
 	///
-	/// A missing/empty `rel`, or one that resolves back to the catalog's own path (or
-	/// walks past the origin root), targets the catalog broadcast; anything else targets
-	/// the resolved sibling broadcast. Either way the broadcast is fetched from the origin,
-	/// which deduplicates repeat requests for the same live path (announced or dynamically
-	/// served) so the catalog and every rendition share one upstream subscription.
-	pub(crate) fn request(&self, rel: Option<&moq_net::PathRelative<'_>>) -> kio::Pending<moq_net::origin::Requesting> {
-		let target = match rel.filter(|rel| !rel.is_empty()) {
-			// Excess `..` clamps to the (empty) origin root, which is not a broadcast; treat
-			// it as a self-reference and use the catalog broadcast instead.
-			Some(rel) => match self.path.resolve(rel) {
-				resolved if resolved.is_empty() => self.path.clone(),
-				resolved => resolved,
-			},
-			None => self.path.clone(),
+	/// The stream rejects a catalog carrying a `broadcast` reference that walks above the root
+	/// (see [`Error::EscapingBroadcast`](crate::Error::EscapingBroadcast)), so every snapshot a
+	/// consumer sees is one whose references all name a broadcast it may reach.
+	pub async fn catalog<E: crate::catalog::hang::CatalogExt>(
+		&self,
+		format: crate::catalog::CatalogFormat,
+	) -> crate::Result<crate::catalog::Consumer<E>> {
+		let broadcast = self.broadcast().await?;
+		crate::catalog::Consumer::new(&broadcast, format).await
+	}
+
+	/// Begin resolving the catalog broadcast (the one at this source's path).
+	pub(crate) fn request_catalog(&self) -> kio::Pending<moq_net::origin::Requesting> {
+		self.origin.request_broadcast(&self.path)
+	}
+
+	/// The path of the broadcast a rendition's `broadcast` reference names.
+	///
+	/// A missing or empty `rel` names the catalog broadcast; anything else names the
+	/// resolved broadcast, which may be the catalog's own path again (`../pub` from
+	/// `a/pub`).
+	fn target(&self, rel: Option<&moq_net::PathRelative<'_>>) -> crate::Result<moq_net::PathOwned> {
+		let Some(rel) = rel.filter(|rel| !rel.is_empty()) else {
+			return Ok(self.path.clone());
 		};
 
-		self.origin.request_broadcast(&target)
+		self.path.resolve(rel).ok_or_else(|| {
+			tracing::error!(%rel, catalog = %self.path, "broadcast reference escapes the root");
+			crate::Error::EscapingBroadcast(rel.to_string())
+		})
+	}
+
+	/// Begin resolving the broadcast that serves a rendition, honoring an optional
+	/// cross-broadcast reference.
+	///
+	/// The broadcast is fetched from the origin, which deduplicates repeat requests for the
+	/// same live path (announced or dynamically served) so the catalog and every rendition
+	/// share one upstream subscription.
+	///
+	/// Fails with [`Error::EscapingBroadcast`](crate::Error::EscapingBroadcast) if `rel` walks
+	/// above the origin root, naming no broadcast.
+	pub(crate) fn request(
+		&self,
+		rel: Option<&moq_net::PathRelative<'_>>,
+	) -> crate::Result<kio::Pending<moq_net::origin::Requesting>> {
+		Ok(self.origin.request_broadcast(&self.target(rel)?))
 	}
 
 	/// Resolve an optional cross-broadcast reference to its broadcast.
 	///
-	/// `rel` is a rendition's catalog `broadcast` field: `None` (or an empty / self
-	/// reference) resolves the catalog broadcast itself; anything else fetches the
-	/// referenced sibling broadcast from the origin. Use it when you need the broadcast
-	/// handle itself (e.g. to FETCH individual groups) rather than a subscription.
+	/// `rel` is a rendition's catalog `broadcast` field: `None` (or an empty reference)
+	/// resolves the catalog broadcast itself; anything else fetches the referenced
+	/// broadcast from the origin. Use it when you need the broadcast handle itself
+	/// (e.g. to FETCH individual groups) rather than a subscription.
+	///
+	/// A reference that escapes above the origin root is
+	/// [`Error::EscapingBroadcast`](crate::Error::EscapingBroadcast): the rendition names
+	/// no broadcast, so there is nothing to resolve.
 	pub async fn resolve(
 		&self,
 		rel: Option<&moq_net::PathRelative<'_>>,
 	) -> crate::Result<moq_net::broadcast::Consumer> {
-		Ok(self.request(rel).await?)
+		Ok(self.request(rel)?.await?)
 	}
 
 	/// Resolve an optional cross-broadcast reference and subscribe to track `name`,
 	/// awaiting SUBSCRIBE_OK.
 	///
-	/// `rel` is a rendition's catalog `broadcast` field: `None` (or an empty / self
-	/// reference) subscribes on the catalog broadcast; anything else fetches the
-	/// referenced broadcast from the origin first.
+	/// `rel` is a rendition's catalog `broadcast` field: `None` (or an empty reference)
+	/// subscribes on the catalog broadcast; anything else fetches the referenced broadcast
+	/// from the origin first. A reference that escapes above the origin root is
+	/// [`Error::EscapingBroadcast`](crate::Error::EscapingBroadcast).
 	///
 	/// This is the async counterpart to the poll-driven container exporters: consumers
 	/// that wrap a raw [`moq_net::track::Subscriber`] themselves (e.g. the WebRTC egress)
@@ -94,7 +127,7 @@ impl Source {
 		rel: Option<&moq_net::PathRelative<'_>>,
 		name: &str,
 	) -> crate::Result<moq_net::track::Subscriber> {
-		let broadcast = self.request(rel).await?;
+		let broadcast = self.request(rel)?.await?;
 		Ok(broadcast.track(name)?.subscribe(None).await?)
 	}
 }
@@ -142,10 +175,15 @@ mod tests {
 		let source = Source::new(origin.consume(), "a/pub");
 
 		// No reference and an empty reference both resolve to the catalog broadcast.
-		source.request(None).await.expect("catalog broadcast should resolve");
+		source
+			.request(None)
+			.expect("no reference is always resolvable")
+			.await
+			.expect("catalog broadcast should resolve");
 		let empty = PathRelative::empty();
 		source
 			.request(Some(&empty))
+			.expect("empty reference is always resolvable")
 			.await
 			.expect("empty reference should resolve to the catalog broadcast");
 	}
@@ -184,13 +222,45 @@ mod tests {
 			.subscribe_track(Some(&rel), "video")
 			.await
 			.expect("self-reference should resolve to the catalog broadcast");
+	}
 
-		// Excess `..` walks past the (empty) origin root, treated as a self-reference.
-		let rel = PathRelative::new("../../..");
-		source
-			.subscribe_track(Some(&rel), "video")
-			.await
-			.expect("excess `..` should resolve to the catalog broadcast");
+	#[tokio::test]
+	async fn escaping_reference_is_rejected() {
+		let origin = Origin::random().produce();
+
+		let mut catalog = origin
+			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
+			.unwrap();
+		let _catalog_video = catalog.create_track("video", None).unwrap();
+
+		// The broadcast an escaping reference would land on if it clamped at the root.
+		let mut clamped = origin
+			.create_broadcast("elsewhere", moq_net::broadcast::Route::new().with_announce(true))
+			.unwrap();
+		let _clamped_video = clamped.create_track("video", None).unwrap();
+		settle().await;
+
+		let source = Source::new(origin.consume(), "a/pub");
+
+		// `a/pub` has two segments, so a third `..` walks above the root. `../..` stops at
+		// the root, which still names a broadcast, so it is not in this set.
+		for reference in ["../../../elsewhere", "../../..", "../../../.."] {
+			let rel = PathRelative::new(reference);
+			assert!(source.request(Some(&rel)).is_err(), "{reference} should be rejected");
+
+			// Neither `elsewhere` nor the catalog broadcast answers it: the rendition names
+			// no broadcast at all.
+			match source.resolve(Some(&rel)).await {
+				Err(crate::Error::EscapingBroadcast(_)) => {}
+				Err(err) => panic!("{reference} failed with the wrong error: {err:?}"),
+				Ok(_) => panic!("{reference} should not resolve to any broadcast"),
+			}
+			match source.subscribe_track(Some(&rel), "video").await {
+				Err(crate::Error::EscapingBroadcast(_)) => {}
+				Err(err) => panic!("{reference} failed with the wrong error: {err:?}"),
+				Ok(_) => panic!("{reference} should not resolve to any broadcast"),
+			}
+		}
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -33,6 +33,15 @@ pub struct Info {
 	/// broadcast. Defaults to an unknown origin with an unbounded pool (a standalone
 	/// broadcast with no relay origin).
 	pub origin: super::origin::Info,
+
+	/// This broadcast's path, relative to the root of the origin it was created under
+	/// (stamped by [`origin::Producer::create_broadcast`](super::origin::Producer::create_broadcast),
+	/// including through a scoped producer). Relative references in a catalog served by this
+	/// broadcast (hang's `broadcast` field) resolve against it.
+	///
+	/// Empty (the default) for a standalone broadcast with no origin, which is then its own
+	/// root: any `..` reference escapes.
+	pub path: crate::PathOwned,
 }
 
 impl Info {
@@ -1068,7 +1077,11 @@ impl Consumer {
 				spliced.tracks.remove(name);
 			}
 			if let Some(producer) = spliced.tracks.get(name) {
-				return Ok(track::Consumer::spliced(name.into(), producer.consume()));
+				return Ok(track::Consumer::spliced(
+					name.into(),
+					self.info.clone(),
+					producer.consume(),
+				));
 			}
 			// A deliberately-ended broadcast serves nothing new; nothing drains the
 			// pending queue once the front is torn down.
@@ -1080,7 +1093,7 @@ impl Consumer {
 			let consumer = producer.consume();
 			spliced.tracks.insert(name.clone(), producer);
 			spliced.pending.push_back(name.clone());
-			return Ok(track::Consumer::spliced(name, consumer));
+			return Ok(track::Consumer::spliced(name, self.info.clone(), consumer));
 		}
 
 		// Reuse a live producer if one is already publishing the track. `get` drops a

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1071,9 +1071,12 @@ impl Producer {
 		// off route transitions.
 		let ingress = self.stats.ingress(&full);
 
-		let mut source = broadcast::Info { origin: self.info() }
-			.produce()
-			.with_stats(ingress.clone());
+		let mut source = broadcast::Info {
+			origin: self.info(),
+			path: full.clone(),
+		}
+		.produce()
+		.with_stats(ingress.clone());
 		source.set_route(route).expect("fresh producer");
 
 		web_async::spawn(run_source(self.info(), node, full, rest, source.consume(), ingress));
@@ -1706,6 +1709,7 @@ fn attach_source(
 	let announce = route.announce;
 	let broadcast = broadcast::Producer::new_spliced(broadcast::Info {
 		origin: ctx.origin.clone(),
+		path: ctx.full.clone(),
 	});
 	let _ = broadcast.clone().set_route(route.clone());
 	let state = kio::Producer::new(FrontState {

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1282,8 +1282,12 @@ impl Producer {
 		let subscription = kio::Producer::new(preferences);
 		register_subscription(self.state.read(), &subscription);
 
+		// Hoisted: an inline `read()` guard would live to the end of the struct literal,
+		// deadlocking against the `consume()` below.
+		let broadcast = self.state.read().broadcast.clone();
 		Subscriber {
 			name: self.name.clone(),
+			broadcast,
 			info,
 			inner: SubscriberKind::Plain(PlainSubscriber {
 				state: self.state.consume(),
@@ -1762,6 +1766,9 @@ impl Demand {
 #[derive(Clone)]
 pub struct Consumer {
 	name: Arc<str>,
+	// The broadcast this track belongs to, so a catalog track can name the path its
+	// relative references resolve against.
+	broadcast: Arc<broadcast::Info>,
 	inner: ConsumerKind,
 	// Egress stats scope, set by a tagged [`broadcast::Consumer`] via
 	// [`Self::with_stats`]. Empty (no-op) for an untagged track.
@@ -1776,17 +1783,20 @@ enum ConsumerKind {
 
 impl Consumer {
 	fn plain(name: Arc<str>, state: kio::Consumer<TrackState>) -> Self {
+		let broadcast = state.read().broadcast.clone();
 		Self {
 			name,
+			broadcast,
 			inner: ConsumerKind::Plain(state),
 			stats: stats::Scope::default(),
 		}
 	}
 
 	/// A consumer over a spliced logical track (a route-fed broadcast's track).
-	pub(crate) fn spliced(name: Arc<str>, resume: super::resume::Consumer) -> Self {
+	pub(crate) fn spliced(name: Arc<str>, broadcast: Arc<broadcast::Info>, resume: super::resume::Consumer) -> Self {
 		Self {
 			name,
+			broadcast,
 			inner: ConsumerKind::Spliced(resume),
 			stats: stats::Scope::default(),
 		}
@@ -1802,6 +1812,12 @@ impl Consumer {
 	/// The track name this handle is bound to.
 	pub fn name(&self) -> &str {
 		&self.name
+	}
+
+	/// The broadcast this track belongs to. Its [`path`](broadcast::Info::path) is what a
+	/// catalog's relative `broadcast` references resolve against.
+	pub fn broadcast(&self) -> &broadcast::Info {
+		&self.broadcast
 	}
 
 	/// Open a live subscription.
@@ -1825,6 +1841,7 @@ impl Consumer {
 
 		kio::Pending::new(Subscribing {
 			name: self.name.clone(),
+			broadcast: self.broadcast.clone(),
 			inner,
 			subscription,
 			stats: self.stats.clone(),
@@ -2068,6 +2085,7 @@ impl Consumer {
 /// [`kio::Pending`] wrapper, whose `DerefMut` exposes [`Self::update`].
 pub struct Subscribing {
 	name: Arc<str>,
+	broadcast: Arc<broadcast::Info>,
 	inner: SubscribingKind,
 	subscription: kio::Producer<Subscription>,
 	stats: stats::Scope,
@@ -2090,6 +2108,7 @@ impl Subscribing {
 
 				Poll::Ready(Ok(Subscriber {
 					name: self.name.clone(),
+					broadcast: self.broadcast.clone(),
 					info,
 					inner: SubscriberKind::Plain(PlainSubscriber {
 						state: state.clone(),
@@ -2111,6 +2130,7 @@ impl Subscribing {
 
 				Poll::Ready(Ok(Subscriber {
 					name: self.name.clone(),
+					broadcast: self.broadcast.clone(),
 					info,
 					inner: SubscriberKind::Spliced(Box::new(resume.subscribe_shared(self.subscription.clone()))),
 					stats: self.stats.clone(),
@@ -2380,6 +2400,8 @@ impl kio::Pollable for Fetching {
 /// for. Set both to skip them *and* avoid the transfer.
 pub struct Subscriber {
 	name: Arc<str>,
+	// The broadcast this track belongs to; see [`Self::broadcast`].
+	broadcast: Arc<broadcast::Info>,
 	info: Info,
 	inner: SubscriberKind,
 	// Egress stats scope, used to meter the groups this subscriber reads. Empty
@@ -2515,6 +2537,12 @@ impl Subscriber {
 	/// The track's name, unique within its broadcast.
 	pub fn name(&self) -> &str {
 		&self.name
+	}
+
+	/// The broadcast this track belongs to. Its [`path`](broadcast::Info::path) is what a
+	/// catalog's relative `broadcast` references resolve against.
+	pub fn broadcast(&self) -> &broadcast::Info {
+		&self.broadcast
 	}
 
 	/// Create a handle for updating this subscriber's delivery preferences.
@@ -3413,7 +3441,14 @@ mod test {
 	/// track's own window is clamped down to it on bind.
 	fn track_producer_capped(name: impl Into<Arc<str>>, info: Info, cap: Duration) -> Producer {
 		let origin = crate::origin::Info::default().with_cache_duration(cap);
-		Producer::new(Arc::new(broadcast::Info { origin }), name, info)
+		Producer::new(
+			Arc::new(broadcast::Info {
+				origin,
+				..Default::default()
+			}),
+			name,
+			info,
+		)
 	}
 
 	#[test]

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -325,8 +325,13 @@ impl<'a> Path<'a> {
 	/// Resolve a [`PathRelative`] against this path.
 	///
 	/// `..` segments in `rel` pop the last segment of the base; other segments are appended.
-	/// Excess `..` is a no-op once the base is empty (subsequent named segments still append).
 	/// An empty `rel` returns this path as an owned copy.
+	///
+	/// Returns `None` when a `..` has nothing left to pop, i.e. the reference walks above the
+	/// root and names nothing. Popping to exactly the root is fine and yields the empty path,
+	/// which still names a broadcast. The alternative, clamping, would silently land
+	/// `../../../../x` on an unrelated `x`, so the caller decides what an out-of-range
+	/// reference means (the hang catalog rejects such a catalog outright).
 	///
 	/// [`PathRelative::new`] strips `.` and empty segments, so they are not handled here.
 	///
@@ -335,20 +340,22 @@ impl<'a> Path<'a> {
 	/// use moq_net::{Path, PathRelative};
 	///
 	/// let base = Path::new("a/b/c");
-	/// assert_eq!(base.resolve(&PathRelative::new("../d")).as_str(), "a/b/d");
-	/// assert_eq!(base.resolve(&PathRelative::new("d")).as_str(), "a/b/c/d");
-	/// assert_eq!(base.resolve(&PathRelative::new("../../../../x")).as_str(), "x");
+	/// assert_eq!(base.resolve(&PathRelative::new("../d")).unwrap().as_str(), "a/b/d");
+	/// assert_eq!(base.resolve(&PathRelative::new("d")).unwrap().as_str(), "a/b/c/d");
+	/// assert_eq!(base.resolve(&PathRelative::new("../../..")).unwrap().as_str(), "");
+	/// assert_eq!(base.resolve(&PathRelative::new("../../../../x")), None);
 	/// ```
-	pub fn resolve(&self, rel: &PathRelative<'_>) -> PathOwned {
+	pub fn resolve(&self, rel: &PathRelative<'_>) -> Option<PathOwned> {
 		if rel.is_empty() {
-			return self.to_owned();
+			return Some(self.to_owned());
 		}
 
 		let mut segments: Vec<&str> = self.parts().collect();
 
 		for seg in rel.as_str().split('/') {
 			if seg == ".." {
-				segments.pop();
+				// Nothing left to pop: the reference walks above the root.
+				segments.pop()?;
 			} else {
 				segments.push(seg);
 			}
@@ -356,13 +363,13 @@ impl<'a> Path<'a> {
 
 		let path = segments.join("/");
 		if path.is_empty() {
-			Path::empty()
-		} else {
-			Path(Repr::Shared {
-				buf: path.into(),
-				start: 0,
-			})
+			return Some(Path::empty());
 		}
+
+		Some(Path(Repr::Shared {
+			buf: path.into(),
+			start: 0,
+		}))
 	}
 }
 
@@ -492,7 +499,10 @@ pub type PathRelativeOwned = PathRelative<'static>;
 /// use moq_net::{Path, PathRelative};
 ///
 /// let rel = PathRelative::new("../source");
-/// assert_eq!(Path::new("a/b").resolve(&rel).as_str(), "a/source");
+/// assert_eq!(Path::new("a/b").resolve(&rel).unwrap().as_str(), "a/source");
+///
+/// // A reference that walks above the root names nothing.
+/// assert_eq!(Path::new("a").resolve(&PathRelative::new("../../b")), None);
 ///
 /// // `.` segments are stripped on creation.
 /// assert_eq!(PathRelative::new("./a/./b").as_str(), "a/b");
@@ -1371,54 +1381,62 @@ mod tests {
 	}
 
 	#[test]
-	fn test_resolve_no_dotdot() {
-		let base = Path::new("a/b");
-		assert_eq!(base.resolve(&PathRelative::new("c")).as_str(), "a/b/c");
-		assert_eq!(base.resolve(&PathRelative::new("c/d")).as_str(), "a/b/c/d");
+	fn test_resolve_appends_and_pops() {
+		let base = Path::new("a/b/c");
+		assert_eq!(base.resolve(&PathRelative::new("d")).unwrap().as_str(), "a/b/c/d");
+		assert_eq!(base.resolve(&PathRelative::new("d/e")).unwrap().as_str(), "a/b/c/d/e");
+		assert_eq!(base.resolve(&PathRelative::new("../d")).unwrap().as_str(), "a/b/d");
+		assert_eq!(base.resolve(&PathRelative::new("..")).unwrap().as_str(), "a/b");
+		assert_eq!(base.resolve(&PathRelative::new("../../x/y")).unwrap().as_str(), "a/x/y");
 	}
 
 	#[test]
 	fn test_resolve_empty_rel_returns_base() {
 		let base = Path::new("a/b");
-		assert_eq!(base.resolve(&PathRelative::new("")).as_str(), "a/b");
+		assert_eq!(base.resolve(&PathRelative::empty()).unwrap().as_str(), "a/b");
+		assert_eq!(Path::empty().resolve(&PathRelative::empty()).unwrap(), Path::empty());
 	}
 
 	#[test]
-	fn test_resolve_single_dotdot() {
+	fn test_resolve_rejects_escape() {
 		let base = Path::new("a/b/c");
-		assert_eq!(base.resolve(&PathRelative::new("../d")).as_str(), "a/b/d");
-		assert_eq!(base.resolve(&PathRelative::new("..")).as_str(), "a/b");
+		// One more `..` than the base has segments. Clamping would land this on "x".
+		assert_eq!(base.resolve(&PathRelative::new("../../../../x")), None);
+		assert_eq!(base.resolve(&PathRelative::new("../../../..")), None);
+		// A `..` that escapes mid-way is rejected even if later segments walk back down.
+		assert_eq!(base.resolve(&PathRelative::new("../../../../a/b/c")), None);
+		assert_eq!(Path::empty().resolve(&PathRelative::new("../x")), None);
 	}
 
 	#[test]
-	fn test_resolve_multiple_dotdot() {
-		let base = Path::new("a/b/c");
-		assert_eq!(base.resolve(&PathRelative::new("../../x")).as_str(), "a/x");
-		assert_eq!(base.resolve(&PathRelative::new("../../../x")).as_str(), "x");
-	}
-
-	#[test]
-	fn test_resolve_dotdot_clamps_at_root() {
-		let base = Path::new("a");
-		// Excess `..` clamps at the root instead of escaping it.
-		assert_eq!(base.resolve(&PathRelative::new("../../../foo")).as_str(), "foo");
-		assert_eq!(base.resolve(&PathRelative::new("..")).as_str(), "");
-	}
-
-	#[test]
-	fn test_resolve_empty_base() {
-		let base = Path::empty();
-		assert_eq!(base.resolve(&PathRelative::new("foo")).as_str(), "foo");
-		assert_eq!(base.resolve(&PathRelative::new("..")).as_str(), "");
+	fn test_resolve_allows_root() {
+		// Popping to exactly the root stops at it rather than walking above it, and the
+		// root still names a broadcast.
+		assert_eq!(Path::new("a").resolve(&PathRelative::new("..")).unwrap(), Path::empty());
+		assert_eq!(
+			Path::new("a/b").resolve(&PathRelative::new("../..")).unwrap(),
+			Path::empty()
+		);
+		assert_eq!(
+			Path::new("a/b")
+				.resolve(&PathRelative::new("../../x"))
+				.unwrap()
+				.as_str(),
+			"x"
+		);
+		assert_eq!(
+			Path::empty().resolve(&PathRelative::new("foo")).unwrap().as_str(),
+			"foo"
+		);
 	}
 
 	#[test]
 	fn test_resolve_dot_is_noop() {
 		let base = Path::new("a/b");
 		// `.` is normalized away by PathRelative::new, so resolve ignores it.
-		assert_eq!(base.resolve(&PathRelative::new(".")).as_str(), "a/b");
-		assert_eq!(base.resolve(&PathRelative::new("./c")).as_str(), "a/b/c");
-		assert_eq!(base.resolve(&PathRelative::new("./../c")).as_str(), "a/c");
+		assert_eq!(base.resolve(&PathRelative::new(".")).unwrap().as_str(), "a/b");
+		assert_eq!(base.resolve(&PathRelative::new("./c")).unwrap().as_str(), "a/b/c");
+		assert_eq!(base.resolve(&PathRelative::new("./../c")).unwrap().as_str(), "a/c");
 	}
 
 	#[test]
@@ -1426,6 +1444,6 @@ mod tests {
 		// Walking `..` back to the same path yields the base unchanged, which lets the
 		// caller compare resolved == base to detect a self-reference.
 		let base = Path::new("a/b");
-		assert_eq!(base.resolve(&PathRelative::new("../b")).as_str(), "a/b");
+		assert_eq!(base.resolve(&PathRelative::new("../b")).unwrap().as_str(), "a/b");
 	}
 }

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use hang::catalog::{AudioCodec, VideoCodecKind};
+use moq_mux::catalog::Stream;
 use moq_mux::catalog::hang::Catalog;
 use str0m::format::Codec;
 use str0m::media::{Frequency, MediaTime, Mid, Pt};
@@ -105,13 +106,7 @@ impl EgressSource {
 	/// caller hands `EgressSource` to [`Session::egress`](crate::session::Session::egress)
 	/// which takes the receiver via [`Self::take_writes`].
 	pub async fn new(source: moq_mux::Source) -> Result<Self> {
-		let catalog_track = source
-			.broadcast()
-			.await?
-			.track(hang::Catalog::DEFAULT_NAME)?
-			.subscribe(hang::Catalog::default_subscription())
-			.await?;
-		let mut consumer = moq_mux::catalog::hang::Consumer::new(catalog_track);
+		let mut consumer = source.catalog::<()>(moq_mux::catalog::CatalogFormat::Hang).await?;
 		let catalog = consumer
 			.next()
 			.await

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -508,7 +508,13 @@ mod tests {
 			..Default::default()
 		};
 
-		let output = moq_net::broadcast::Info::default().produce();
+		// The passthrough reference (`..`) resolves against the output broadcast's path, so
+		// the output must be minted through an origin: a standalone producer has no path, and
+		// `..` from it would escape, failing the catalog read below.
+		let origin = moq_net::Origin::random().produce();
+		let output = origin
+			.create_broadcast("room/transcode", moq_net::broadcast::Route::new())
+			.unwrap();
 		let consumer = output.consume();
 		let transcoder = tokio::spawn(run(source.broadcast.consume(), output, config));
 


### PR DESCRIPTION
Targets `dev`: `Path::resolve` / `Path.resolve` change signature.

## Summary

- `draft-lcurley-moq-hang-02` had a consumer **ignore** a rendition whose `broadcast` field escapes above the root. Both stacks clamped instead, so `"broadcast": "../../../../x"` resolved to `x` and the consumer silently subscribed to an unrelated broadcast. Root cause: `resolve` treated an excess `..` as a no-op, turning an out-of-range reference into a valid-looking one.
- **`resolve` now returns `Option`/`undefined`** rather than clamping. A reference that stops *on* the root is fine (a broadcast can live there), so `None` means exactly one thing: a `..` with nothing left to pop.
- **An escaping reference now rejects the whole catalog**, and the draft changes to require that. The root is the consumer's authorized subtree, so the reference names content the consumer cannot reach. That is a malformed catalog, not a rendition to skip: quietly serving the rest hides a publisher bug while the missing rendition resurfaces much later as a track that never fills.
- **The broadcast knows its own path.** `create_broadcast` already computed the origin-root-relative path; it now stamps it on `broadcast::Info`, and track handles expose the `Arc<Info>` they already held (`track::{Consumer,Subscriber}::broadcast()`). A catalog track can therefore name its own base, so no reader has to be told it and no constructor grew a parameter.
- **The catalog stream owns the check, not each consumer.** Consumers key their bookkeeping off the catalog, not off what they managed to subscribe to, so a reference caught any later would already have reached a track layout, a playlist, an SDP codec list, or a quality selector. `catalog::hang::Consumer` validates every snapshot against its track's broadcast path.
- Publishers are unaffected: `moq-cli transcode` emits exactly one `..` per nesting level, so it cannot produce an escaping reference.

## Why the path lives on `broadcast::Info`

Origin-root-relative is the right coordinate system. Token-scoped cursors (`origin::Consumer::with_root`, applied per session by the relay's auth) mean the same broadcast is seen at different paths by different clients, so a *client-relative* path cannot live on shared state. But those scoped cursors exist only inside the relay, which is media-agnostic and never reads catalogs. Every catalog reader is an endpoint whose origin has exactly one coordinate system, which is also its authorized view: paths above its root do not exist on its wire.

A standalone producer (`Info::new().produce()`) has an empty path and is its own root, so any `..` reference escapes. That is the honest semantic: such refs are relative to an announce location that does not exist yet. The transcode `end_to_end` test tripped exactly this and now mints its output through an origin, as `moq-cli` does in production.

## Why reject rather than ignore

Because "escapes the root" and "crosses an authorization boundary" are the same condition. Clamping silently redirects the subscription; ignoring the rendition declines to follow it but still tells nobody. Rejecting the catalog puts the failure in front of the operator who can fix the publisher.

This changes `draft-lcurley-moq-hang` normatively (`MUST ignore` -> `MUST reject`), and adds the rationale to its Security Considerations section, which was a bare TODO. hang is published at `-02`; the draft has no changelog appendix, so per `drafts/CLAUDE.md` none was added.

**Operational consequence, stated plainly:** a gateway exporting a third-party broadcast (`moq-hls`, `moq-rtmp`, the container exporters) now aborts that export on an escaping reference, where before it clamped. Contained to the one broadcast, not the process, but live-stream-killing on malformed input. That is the intended reading of a hard error.

## Public API changes

Breaking (hence `dev`):

- **`moq-net`**: `Path::resolve` returns `Option<PathOwned>` (was `PathOwned`).
- **`js/net`**: `Path.resolve` returns `Valid | undefined` (was `Valid`).

Additive:

- **`moq-net`**: `broadcast::Info.path` (`Info` is `#[non_exhaustive]`), stamped by `create_broadcast`; `track::Consumer::broadcast()` and `track::Subscriber::broadcast()`.
- **`moq-mux`**: `Source::catalog(format)`, and `Error::EscapingBroadcast`, raised by the catalog stream as well as by `Source::{resolve,subscribe_track}`.

Behavior changes no signature states:

- `catalog::hang::Consumer` can now fail on a catalog it previously yielded (escaping reference).
- A reference landing exactly on the root now resolves to the root broadcast; `@moq/watch` previously treated `../..` from `a/b` as a self-reference.
- A catalog consumed from a **standalone** producer resolves references against the empty root, so any `..` rejects it. Mint the broadcast through `create_broadcast` when its catalog uses cross-broadcast references.

Internal: `Source::request` returns `Result`, `ExportSource::for_*` return `Result<Self>`. `libmoq`, `moq-ffi`, and `moq_transcode::run` are untouched relative to `dev` in their signatures; the catalog constructors (`catalog::hang::Consumer::{new,compressed}`, `catalog::Consumer::new`, `catalog::Producer::consume`) keep their pre-branch shapes.

## Cross-package sync

`rs/moq-net` -> `js/net` mirrored for `Path.resolve`; `Info.path` has no JS counterpart because the JS consumer model already carries the name where catalogs are read (`@moq/watch`'s `Broadcast.in.name`). `doc/concept/layer/hang.md` and the `broadcast` field docs in `rs/hang` + `js/hang` updated; `drafts/draft-lcurley-moq-hang.md` updated normatively (above). No wire-format change.

## Test plan

- `just check`, `just rs doctest`, `just drafts check`, and `RUSTDOCFLAGS="-D warnings" cargo doc` on the touched crates all pass.
- `moq-net`: `resolve` unit tests + doctests -- append/pop, empty rel, escape rejected (including a `..` that escapes mid-way then walks back down), root-landing allowed.
- `moq-mux` `catalog/hang/consumer.rs`: a catalog carrying a legal `../source` and a root-landing `../..` is accepted; one that also carries an escaping `../../../elsewhere` is rejected wholesale, including via a text (caption) rendition. The broadcast is minted through an origin, which is what stamps the path being resolved against. The check covers every section carrying renditions (video, audio, text); adversarial review caught the text omission.
- `moq-mux` `source.rs`: `escaping_reference_is_rejected` builds a real `elsewhere` broadcast at the exact path a clamp would land on, and asserts the reference resolves to neither it nor the catalog broadcast, via `request`, `resolve`, and `subscribe_track`.
- `moq-mux` `container/source.rs`: the rendition fails on a test origin whose dynamic handler would happily serve the clamped path, and is kept for absent / `""` / `..` / `../source` / `sub`.
- `moq-transcode` `end_to_end`: regression for the standalone-root semantics; fails if the output broadcast loses its path.
- `js/net/src/path.test.ts` and `js/watch/src/broadcast.test.ts`: the JS mirrors, plus a catalog with an escaping rendition being rejected and one within the root being accepted.
- Full workspace: 1245 Rust tests pass. Caught one real deadlock during development (a struct-literal-inline `state.read()` guard living across `state.consume()`), fixed with a hoist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Opus 5)
