### PR TITLE
feat: trim the media timeline as segments leave the publisher's cache

### DIFF
--- a/drafts/draft-lcurley-moq-flate.md
+++ b/drafts/draft-lcurley-moq-flate.md
@@ -1,0 +1,129 @@
+---
+title: "Media over QUIC - Group Compression"
+abbrev: "moq-flate"
+category: info
+
+docname: draft-lcurley-moq-flate-latest
+submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
+number:
+date:
+v: 3
+area: wit
+workgroup: moq
+
+author:
+ -
+    fullname: Luke Curley
+    email: kixelated@gmail.com
+
+normative:
+  moql: I-D.lcurley-moq-lite
+  moqt: I-D.ietf-moq-transport
+  DEFLATE: RFC1951
+
+informative:
+  PMDEFLATE: RFC7692
+  json:
+    title: "Media over QUIC - JSON Tracks"
+    target: https://datatracker.ietf.org/doc/draft-lcurley-moq-json/
+    author:
+      - fullname: Luke Curley
+    date: false
+
+--- abstract
+
+This document specifies a compression layer for Media over QUIC tracks: the frames of a group are compressed as a single DEFLATE stream, sync-flushed at each frame boundary.
+Every frame remains individually framed by the transport while later frames reuse the earlier ones as context, so a stream of similar payloads (a snapshot followed by deltas, repeated records, log lines) compresses far better than each frame alone.
+The group is the compression unit, so groups remain independently decodable and relays remain oblivious.
+The encoding is defined for both moq-lite and moq-transport.
+
+--- middle
+
+# Conventions and Definitions
+{::boilerplate bcp14-tagged}
+
+
+# Introduction
+Non-media tracks often carry small, repetitive frames: a catalog snapshot followed by deltas, a log of similar JSON records {{json}}, captions, telemetry.
+Compressing each frame alone wastes the redundancy between frames, which is where most of the savings are.
+
+This document compresses all the frames of a group through one shared DEFLATE {{DEFLATE}} context instead.
+The group is the natural unit: its frames are already delivered reliably and in order, and it is the boundary at which subscribers join and caches evict.
+Each group starts a fresh context, so any group is decodable on its own and dropping old groups loses nothing.
+
+The layer is invisible to the transport.
+Frame boundaries, timestamps, and group structure are unchanged; only the payload bytes differ.
+Relays forward compressed tracks like any other.
+
+
+# Terminology
+This document is written using moq-lite {{moql}} terminology and applies equally to moq-transport {{moqt}}:
+
+| moq-lite | moq-transport |
+|:---------|:--------------|
+| Track | Track |
+| Group | Group |
+| Frame | Object |
+
+Decoding depends on receiving every frame of a group, in order.
+Over moq-transport, a publisher MUST send all Objects of a group on a single Subgroup, with Object IDs assigned sequentially from 0 and no gaps.
+Datagrams MUST NOT be used.
+
+Whether a track is compressed is communicated out-of-band, typically by the application's catalog or a [naming convention](#track-naming).
+
+
+# Encoding
+A publisher maintains one raw DEFLATE compression context per group, created when the group starts.
+
+Each frame's payload is produced by:
+
+1. Compressing the uncompressed payload into the group's context.
+2. Flushing to a byte boundary with an empty stored block (zlib's `Z_SYNC_FLUSH`), which always ends in the 4 bytes `0x00 0x00 0xff 0xff`.
+3. Removing those trailing 4 bytes.
+
+The result is the frame's payload on the wire.
+The flush makes each frame self-delimited while retaining the sliding window, and the removed tail is constant so it carries no information; this is the technique of {{PMDEFLATE, Section 7.2.1}}, with the transport's frame boundaries taking the place of message framing.
+
+The stream is raw DEFLATE: no zlib or gzip wrapper, matching `deflate-raw` in web runtimes.
+The context MUST be reset at each new group and MUST NOT be shared across groups or tracks.
+
+The DEFLATE window is at most 32 KiB of decompressed history, so a frame only benefits from context within that distance; a publisher whose reference frame (e.g. a snapshot) is much larger should not expect cross-frame savings beyond it.
+
+
+# Decoding
+A subscriber maintains one DEFLATE decompression context per group and MUST process the group's frames in order, starting at the first frame.
+For each frame, the subscriber appends `0x00 0x00 0xff 0xff` to the payload and inflates the result through the group's context; the output is the uncompressed payload.
+
+A frame cannot be decoded without every prior frame of its group.
+A subscriber that joins a track mid-group, or loses a frame, MUST NOT attempt to decode subsequent frames of that group and SHOULD wait for the next group.
+
+A subscriber MUST enforce a limit on each frame's decompressed size and treat a frame exceeding it as malformed: a small compressed frame can inflate to a far larger output, and the transport's frame size says nothing about the decompressed size.
+
+
+# Track Naming
+This section is a convention, not a requirement; the application's catalog is authoritative.
+
+A compressed track appends `.z` to the name the track would otherwise have: `catalog.json.z`, `video.timeline.z`.
+A publisher MAY publish uncompressed and compressed siblings carrying the same content, letting each subscriber pick.
+
+
+# Security Considerations
+The considerations of the underlying transport ({{moql}} or {{moqt}}) apply.
+
+Compressed tracks are a decompression-bomb vector: a receiver MUST NOT size buffers from the compressed length and MUST enforce the decompressed-size limit of [Decoding](#decoding).
+
+Compression leaks information through size.
+If attacker-influenced data shares a compression context with confidential data, the compressed sizes can reveal the confidential data (as in the CRIME attack on TLS).
+An application SHOULD NOT mix secrets and attacker-controlled content in the same group, or SHOULD leave such tracks uncompressed.
+
+
+# IANA Considerations
+This document has no IANA actions.
+
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+This document was drafted with the assistance of Claude, an AI assistant by Anthropic.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -18,6 +18,18 @@ author:
 
 normative:
   moql: I-D.lcurley-moq-lite
+  json:
+    title: "Media over QUIC - JSON Tracks"
+    target: https://datatracker.ietf.org/doc/draft-lcurley-moq-json/
+    author:
+      - fullname: Luke Curley
+    date: false
+  flate:
+    title: "Media over QUIC - Group Compression"
+    target: https://datatracker.ietf.org/doc/draft-lcurley-moq-flate/
+    author:
+      - fullname: Luke Curley
+    date: false
   webcodecs:
     title: "WebCodecs"
     target: https://www.w3.org/TR/webcodecs/
@@ -438,15 +450,22 @@ A consumer derives the wall-clock time of any segment as `wall + pts`, and Unix 
 The epoch is 2020 rather than 1970 so the value stays small, safely within a 53-bit integer even at fine timescales.
 
 ## Track Framing {#timeline-framing}
-The timeline track is an append-log: a single group that is never rolled, with one record per frame, every record preserved in order.
+The timeline track is a JSON sliding window {{json}}: an ordered log that appends a record at the tail as each segment is indexed, and trims records from the head as their media stops being available.
 Each record is a UTF-8 JSON object.
 
-The frames are DEFLATE-compressed ({{!RFC1951}}) sharing a single compression window across the group, so each record compresses against all earlier ones.
-The publisher ends each frame's compressed data with an empty sync-flush block (the `0x00 0x00 0xff 0xff` trailer is removed, as in {{?RFC7692}}), so a consumer decompresses frames incrementally with one shared window.
-The `.z` suffix on the RECOMMENDED track name marks this compression, mirroring the catalog's `catalog.json.z` sibling.
+The window is what lets the timeline describe what is *available* rather than everything ever published.
+An append-log cannot: its whole history rides a single group that is never rolled, so a consumer must start at the first frame, and once the publisher's cache drops the earliest frames the track becomes unreadable for anyone joining later.
+A window's groups are each self-contained, so old ones are disposable and a late joiner reads only the newest.
 
-A consumer MUST start reading from the group's first frame; the shared window makes a mid-group join undecodable.
-The live group is therefore bounded history; deep history is served from a recording.
+A publisher SHOULD retract a record once the media it names is no longer retrievable, so that every segment the timeline lists can actually be fetched.
+The record's group ranges say exactly which groups that is: a record is retractable once any group in any of its ranges is gone, since a consumer fetches the whole segment and a missing group anywhere in it breaks the segment.
+A publisher MAY retract more aggressively (a bounded playlist length), and a consumer MUST NOT assume a listed segment is still fetchable: retraction is a publisher's best effort, not a guarantee, and the two race.
+
+Because a window has a single head, retracting a record whose predecessors are still available also retracts those predecessors.
+Publishers whose cache does not evict strictly oldest-first will therefore drop live records ahead of a dead one; this is preferable to listing media that cannot be fetched.
+
+The frames are DEFLATE-compressed ({{flate}}) sharing a single compression window across each group, so each record compresses against the earlier ones in its group.
+The `.z` suffix on the RECOMMENDED track name marks this compression, mirroring the catalog's `catalog.json.z` sibling.
 
 ## Records {#timeline-records}
 Each record describes one complete segment:

--- a/drafts/draft-lcurley-moq-json.md
+++ b/drafts/draft-lcurley-moq-json.md
@@ -1,0 +1,222 @@
+---
+title: "Media over QUIC - JSON Tracks"
+abbrev: "moq-json"
+category: info
+
+docname: draft-lcurley-moq-json-latest
+submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
+number:
+date:
+v: 3
+area: wit
+workgroup: moq
+
+author:
+ -
+    fullname: Luke Curley
+    email: kixelated@gmail.com
+
+normative:
+  moql: I-D.lcurley-moq-lite
+  moqt: I-D.ietf-moq-transport
+  JSON: RFC8259
+  MERGEPATCH: RFC7396
+
+informative:
+  flate:
+    title: "Media over QUIC - Group Compression"
+    target: https://datatracker.ietf.org/doc/draft-lcurley-moq-flate/
+    author:
+      - fullname: Luke Curley
+    date: false
+  HLS: RFC8216
+  msf: I-D.ietf-moq-msf
+
+--- abstract
+
+This document specifies three encodings for publishing JSON over a Media over QUIC track: **snapshot** (one value updated over time), **stream** (an append-only log), and **window** (a log that appends at the tail and removes from the head, like an HLS playlist).
+Each encoding maps JSON values onto the transport's group model so a subscriber can join mid-stream and old state can be evicted from caches.
+An optional layer compresses each group as one shared DEFLATE window, so repetitive values shrink sharply.
+The encodings are defined for both moq-lite and moq-transport.
+
+--- middle
+
+# Conventions and Definitions
+{::boilerplate bcp14-tagged}
+
+
+# Introduction
+Live applications publish more than media: a catalog of available tracks, a timeline mapping groups to timestamps, an event log, a set of participants.
+These are naturally JSON documents that change over time, and they change in three distinct ways:
+
+- A **snapshot** is one value where only the latest matters, such as a catalog. Intermediate updates may be collapsed or skipped.
+- A **stream** is an ordered log where every record matters, such as telemetry. Nothing is ever superseded.
+- A **window** is an ordered log with a moving head and tail, such as a media timeline over a bounded cache, or anything shaped like an HLS media playlist {{HLS}}. Records are appended at the tail and removed from the head as the content they describe becomes unavailable.
+
+This document specifies how each is encoded onto a track.
+The common design is that a group is self-contained: its first frame carries enough state to start from, and later frames in the group are incremental.
+A subscriber joins at the latest group and needs nothing older, so relays and publishers can drop older groups without breaking new subscribers.
+
+
+# Terminology
+This document is written using moq-lite {{moql}} terminology and applies equally to moq-transport {{moqt}}:
+
+| moq-lite | moq-transport |
+|:---------|:--------------|
+| Broadcast | Track Namespace |
+| Track | Track |
+| Group | Group |
+| Group Sequence | Group ID |
+| Frame | Object |
+| latest group | Largest Group ID |
+
+Every encoding in this document depends on in-order delivery of the frames within a group.
+Over moq-transport, a publisher MUST send all Objects of a group on a single Subgroup, with Object IDs assigned sequentially from 0 and no gaps.
+Datagrams MUST NOT be used.
+
+A subscriber joins at the latest group: the default in moq-lite, or a Largest Object/Group filter in moq-transport.
+
+
+# Common Rules
+Each frame decodes to exactly one JSON value {{JSON}} encoded as UTF-8.
+The frame boundary is the value boundary: there is no delimiter inside a frame and no value spans frames.
+
+A receiver MUST ignore unknown members of the JSON objects defined by this document, so that encodings remain extensible.
+
+A track uses exactly one of the three encodings below.
+Which encoding (and whether [Compression](#compression) applies) is communicated out-of-band, typically by the application's catalog or a [naming convention](#track-naming).
+
+
+# Snapshot Tracks
+A snapshot track carries a single JSON value updated over time.
+Only the most recent value matters; a subscriber that falls behind skips ahead.
+
+Each group is self-contained:
+
+- Frame 0 is the complete value.
+- Each subsequent frame is a JSON Merge Patch {{MERGEPATCH}}, applied to the result of the previous frame.
+
+A subscriber reads the latest group, decodes frame 0, and applies each following frame in order.
+When a newer group arrives, the subscriber switches to it and starts over from its frame 0; groups older than the newest carry no information the newest lacks.
+
+A publisher starts a new group when the update cannot be expressed as a merge patch: the root value is not an object, or a member's new value is a genuine `null` (which a merge patch cannot represent, since `null` means removal).
+A publisher SHOULD also start a new group once the patches written to the current group exceed the size of its snapshot frame, bounding the work a new subscriber replays, and MUST start one before exceeding any transport limit on frames per group.
+
+
+# Stream Tracks
+A stream track carries an ordered, append-only log.
+Every record is preserved and delivered in order.
+
+The entire log is a single group.
+Each frame is one record, appended to the group as it is produced.
+A publisher MUST NOT start a second group.
+
+Because a subscriber always starts at frame 0, the log's history is bounded by how long the publisher and relays retain the group's early frames.
+Once they are gone, new subscribers cannot join the track.
+A stream track is therefore best for short-lived or bounded logs; a log that must outlive the cache should use a [window track](#window-tracks) instead.
+
+
+# Window Tracks
+A window track carries an ordered log that grows at the tail and shrinks at the head, like an HLS media playlist {{HLS}}: records are appended as content is produced and removed as the content they describe expires.
+
+Every record occupies a stable **position**: the count of records ever appended before it.
+Positions start at 0 and never repeat, so a record is identified by its position across groups, group switches, and removals.
+This is the same role the media sequence number plays in HLS.
+
+Each group is self-contained.
+Frame 0 is a snapshot of the current window:
+
+~~~
+{
+  "offset": 1042,
+  "values": [ ... ]
+}
+~~~
+
+**offset**:
+The position of the first record in `values`: the total number of records removed from the head over the lifetime of the log.
+Required, 0 at the start of the log.
+It MUST be a non-negative integer, and a receiver MUST reject a snapshot whose offset is absent or not one: every position derives from it, so a bad offset silently corrupts them all rather than failing.
+It MUST NOT exceed 2^53-1, so a receiver using IEEE 754 doubles (a JSON parser's usual number type) counts exactly.
+
+**values**:
+Every record currently in the window, oldest first.
+Required, and may be empty.
+
+Each subsequent frame carries exactly one operation:
+
+~~~
+{ "append": <value> }
+~~~
+
+**append**:
+Adds one record at the tail of the window.
+
+~~~
+{ "trim": 3 }
+~~~
+
+**trim**:
+Removes the given number of records from the head of the window and advances the effective offset by the same amount.
+The count MUST be a non-negative integer, MUST be greater than 0, and MUST NOT exceed the number of records currently in the window.
+
+A publisher MUST NOT write both members in one frame.
+A receiver that sees both MUST treat the frame as malformed, since applying them would append and retract in an order this document does not define.
+
+A frame carrying *neither* member is not an error: that is how an operation introduced by a later revision appears to a receiver that predates it, and per [Common Rules](#common-rules) unknown members are ignored.
+A receiver MUST skip such a frame without changing the window.
+
+## Publishing
+A publisher appends a record the moment it becomes valid and trims the moment the head records become invalid, so the live window is always current.
+
+A publisher SHOULD start a new group once the records trimmed since the group's snapshot outnumber the records still in the window: the group is then mostly dead weight for a new subscriber, and a fresh snapshot costs no more than what has already been trimmed.
+This bounds the total bytes at roughly twice an append-only log.
+A publisher MUST start a new group before exceeding any transport limit on frames per group.
+
+The new group's snapshot reflects the window at that moment; the previous group SHOULD be finished (closed cleanly).
+Old groups carry no information the newest lacks, so publishers and relays MAY drop them at any time.
+
+## Consuming
+A subscriber reads the latest group, decodes the snapshot, and applies each operation in order.
+When a newer group arrives, the subscriber switches to it, even mid-group.
+
+Positions make the switch lossless: a subscriber that has processed records up to position `p` skips the new snapshot's records at positions at or below `p` and continues from there.
+If the new snapshot's `offset` is greater than `p + 1`, the intervening records were trimmed before the subscriber saw them; whether that matters is up to the application (for a timeline it is a gap; for a cache index it is nothing).
+
+
+# Compression
+Any of the encodings can be compressed with group compression {{flate}}, whose unit of compression is also the group: every frame of a group shares one DEFLATE window.
+The fit is deliberate.
+Frame 0 (a snapshot, or the first records of a log) seeds the window, and every later frame compresses against it, so repetitive values shrink sharply while each group stays independently decodable.
+
+
+# Track Naming
+This section is a convention, not a requirement; the application's catalog is authoritative.
+
+A plaintext JSON track SHOULD use a name ending in `.json`.
+A compressed track appends `.z` per the convention of {{flate}}: `catalog.json.z`, or `video.timeline.z` for a track whose plaintext suffix is implied by the application.
+A publisher MAY publish plaintext and compressed siblings carrying the same content, letting each subscriber pick.
+
+
+# Security Considerations
+The considerations of the underlying transport ({{moql}} or {{moqt}}) apply, as do those of {{flate}} when a track is compressed.
+
+JSON parsing is a well-known attack surface.
+Receivers SHOULD bound the size and nesting depth of the values they accept, and treat all content as untrusted application data.
+
+A malicious publisher of a window track can lie in either direction: advertising records for unavailable content, or trimming records for content that still exists.
+A subscriber MUST treat the window as a hint about availability, not a guarantee.
+
+
+# IANA Considerations
+This document has no IANA actions.
+
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+The snapshot-per-group structure follows the catalog and media timeline design of {{msf}}, extended here with explicit head removal.
+
+This document was drafted with the assistance of Claude, an AI assistant by Anthropic.

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -76,7 +76,7 @@ export class Producer {
 			this.#group?.close();
 			this.#group = this.#track.appendGroup();
 			// Report the group the moment it opens: its start is this keyframe's timestamp.
-			this.#timeline?.record(this.#group.sequence, timestamp, true);
+			this.#timeline?.record(this.#group, timestamp, true);
 		} else if (!this.#group) {
 			throw new Error("must start with a keyframe");
 		}

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -1,37 +1,89 @@
 import { expect, test } from "bun:test";
 import * as Json from "@moq/json";
-import type { Time } from "@moq/net";
-import { Track } from "@moq/net";
+import { Group, Time, Track } from "@moq/net";
 import { MOQ_EPOCH_UNIX_MILLIS, u53 } from "../catalog";
-import { Producer, type Record } from "./timeline.ts";
+import { Producer, type Record, type Recorder } from "./timeline.ts";
 
 const us = (ms: number): Time.Micro => (ms * 1000) as Time.Micro;
 
-/** A timeline whose published records are decoded back out of its MoQ track. */
+/**
+ * A media track feeding one timeline enrollment.
+ *
+ * The timeline watches the groups it is handed, so a test has to publish real ones: the backing
+ * track caches them, which is what keeps them available until a test evicts one on purpose.
+ */
+class Media {
+	#track: Track.Producer;
+	#recorder?: Recorder;
+	#groups = new Map<number, Group.Producer>();
+
+	constructor(timeline: Producer, name: string) {
+		this.#track = new Track.Producer(name);
+		this.#recorder = timeline.track(name);
+	}
+
+	/** Open group `sequence` at `pts` and report it. */
+	record(sequence: number, pts: Time.Micro, keyframe = true): void {
+		const group = new Group.Producer(sequence);
+		// An empty group is not cached, so it would read as gone the moment the timeline looked.
+		group.writeFrame({ payload: new Uint8Array([0]), timestamp: Time.Timestamp.fromMicros(pts) });
+		this.#track.writeGroup(group);
+		this.#recorder?.record(group, pts, keyframe);
+		this.#groups.set(sequence, group);
+	}
+
+	end(pts: Time.Micro): void {
+		this.#recorder?.end(pts);
+	}
+
+	/** End the timeline enrollment, leaving the media track and its cached groups alive. */
+	close(): void {
+		this.#recorder?.close();
+		this.#recorder = undefined;
+	}
+
+	/** Evict group `sequence` the way the cache does, so the timeline sees it go. */
+	evict(sequence: number): void {
+		const group = this.#groups.get(sequence);
+		if (!group) throw new Error(`group ${sequence} was not recorded`);
+		this.#groups.delete(sequence);
+		group.close(new Error("evicted"));
+	}
+
+	/** Finish group `sequence` cleanly, leaving it cached and fetchable. */
+	finishGroup(sequence: number): void {
+		this.#groups.get(sequence)?.close();
+	}
+}
+
+/** A timeline whose published updates are decoded back out of its MoQ track. */
 function capture(props?: ConstructorParameters<typeof Producer>[1]): {
 	timeline: Producer;
+	updates: () => Promise<Json.Window.Update<Record>[]>;
 	records: () => Promise<Record[]>;
 } {
 	const track = new Track.Producer("timeline.z");
-	const consumer = new Json.Stream.Consumer<Record>(track.subscribe(), { compression: true });
+	const consumer = new Json.Window.Consumer<Record>(track.subscribe(), { compression: true });
 	const timeline = new Producer(track, props);
 
-	const records = async () => {
-		const out: Record[] = [];
+	const updates = async () => {
+		const out: Json.Window.Update<Record>[] = [];
 		for (;;) {
-			const record = await consumer.next();
-			if (!record) return out;
-			out.push(record);
+			const update = await consumer.next();
+			if (!update) return out;
+			out.push(update);
 		}
 	};
-	return { timeline, records };
+	const records = async () => (await updates()).flatMap((update) => (update.type === "append" ? [update.value] : []));
+
+	return { timeline, updates, records };
 }
 
 // The coarsest track paces: video GOPs are longer than durationMin, so segments are GOPs.
 test("the coarsest track paces the segments", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = new Media(timeline, "video0");
+	const audio = new Media(timeline, "audio0");
 
 	// Video keyframes every 2s, audio groups every 500ms, minimum 1s.
 	video.record(0, us(0));
@@ -85,7 +137,7 @@ test("the coarsest track paces the segments", async () => {
 // a segment could start and stay decodable, so the segment is simply long.
 test("a GOP longer than the minimum is one segment", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = new Media(timeline, "video0");
 
 	video.record(0, us(0));
 	video.record(1, us(30_000));
@@ -102,7 +154,7 @@ test("a GOP longer than the minimum is one segment", async () => {
 // Groups shorter than the minimum pack into one segment rather than each becoming one.
 test("short groups pack up to the minimum", async () => {
 	const { timeline, records } = capture({ durationMin: 1500 });
-	const audio = timeline.track("audio0");
+	const audio = new Media(timeline, "audio0");
 
 	for (let seq = 0; seq < 8; seq++) {
 		audio.record(seq, us(seq * 500));
@@ -120,8 +172,8 @@ test("short groups pack up to the minimum", async () => {
 // a rendition that was about to contribute to it.
 test("a segment waits for every track", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = new Media(timeline, "video0");
+	const audio = new Media(timeline, "audio0");
 
 	video.record(0, us(0));
 	audio.record(0, us(0));
@@ -144,7 +196,7 @@ test("a segment waits for every track", async () => {
 // An application that knows its own boundaries overrides the pacing.
 test("explicit cuts override the pacing", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = new Media(timeline, "video0");
 
 	// Keyframes every second, cut every three: the segments follow the cuts, not the GOPs.
 	timeline.cut(us(3000));
@@ -164,7 +216,7 @@ test("explicit cuts override the pacing", async () => {
 // segment shorter than the minimum is dropped rather than producing a stray segment.
 test("a cut below the minimum is ignored", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = new Media(timeline, "video0");
 
 	video.record(0, us(0));
 	timeline.cut(us(2000));
@@ -188,7 +240,7 @@ test("a cut below the minimum is ignored", async () => {
 // the catalog.
 test("exceeding the declared maximum fails the timeline", async () => {
 	const { timeline, records } = capture({ durationMin: 1000, durationMax: 3000 });
-	const video = timeline.track("video0");
+	const video = new Media(timeline, "video0");
 
 	video.record(0, us(0));
 	video.record(1, us(2000));
@@ -214,7 +266,7 @@ test("an undeclared maximum is omitted from the catalog", () => {
 // final segment's duration collapses to zero (an HLS EXTINF:0).
 test("the final segment runs to the reported end", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = new Media(timeline, "video0");
 
 	video.record(0, us(0));
 	video.record(1, us(2000));
@@ -236,7 +288,7 @@ test("a reservation defers flushing until every track enrolls", async () => {
 	const release = timeline.reserve();
 
 	// The primary rendition runs a whole batch of segments through before its sibling exists.
-	const first = timeline.track("video0");
+	const first = new Media(timeline, "video0");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -245,7 +297,7 @@ test("a reservation defers flushing until every track enrolls", async () => {
 		first.record(seq, us(ms));
 	}
 
-	const second = timeline.track("video1");
+	const second = new Media(timeline, "video1");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -280,8 +332,8 @@ test("a reservation defers flushing until every track enrolls", async () => {
 // A track that races ahead of the others still lands in the segment its content falls in.
 test("groups before the first boundary join the first segment", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = new Media(timeline, "video0");
+	const audio = new Media(timeline, "audio0");
 
 	audio.record(0, us(0));
 	video.record(0, us(30));
@@ -311,8 +363,8 @@ test("groups before the first boundary join the first segment", async () => {
 
 test("sequence gaps split ranges", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = new Media(timeline, "video0");
+	const audio = new Media(timeline, "audio0");
 
 	// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
 	video.record(0, us(0));
@@ -345,8 +397,8 @@ test("sequence gaps split ranges", async () => {
 // has merely gone quiet still gets to say where the boundary is.
 test("a closed track leaves a whole segment gap", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = new Media(timeline, "video0");
+	const audio = new Media(timeline, "audio0");
 
 	video.record(0, us(0));
 	audio.record(0, us(0));
@@ -362,7 +414,7 @@ test("a closed track leaves a whole segment gap", async () => {
 
 test("a non-keyframe range start is flagged", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = new Media(timeline, "video0");
 
 	video.record(0, us(0));
 	// A mid-stream join: the group doesn't open on an IDR.
@@ -395,7 +447,7 @@ test("reservations nest", async () => {
 	const outer = timeline.reserve();
 	const inner = timeline.reserve();
 
-	const first = timeline.track("video0");
+	const first = new Media(timeline, "video0");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -407,7 +459,7 @@ test("reservations nest", async () => {
 	// If reservations didn't nest, releasing this one would publish segment 0 without video1.
 	inner();
 
-	const second = timeline.track("video1");
+	const second = new Media(timeline, "video1");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -441,7 +493,7 @@ test("reservations nest", async () => {
 // spent cut must not block the ones behind it, and durationMin pacing must not race ahead of them.
 test("a cut on the first group does not poison later cuts", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = new Media(timeline, "video0");
 
 	// Source segments every 3s, keyframes every 1s: 3s segments, not the 1s the durationMin
 	// pacing would produce on its own.
@@ -457,4 +509,98 @@ test("a cut on the first group does not poison later cuts", async () => {
 	const out = await records();
 	expect(out[0]).toEqual({ segment: 0, pts: 0, duration: 3000, tracks: { video0: [{ start: 0, end: 2 }] } });
 	expect(out[1]).toEqual({ segment: 1, pts: 3000, duration: 3000, tracks: { video0: [{ start: 3, end: 5 }] } });
+});
+
+/**
+ * A segment's record is retracted once its media leaves the cache. The whole point of the window:
+ * a timeline must never advertise a segment a consumer would fail to fetch.
+ */
+test("eviction retracts the segment", async () => {
+	const { timeline, updates } = capture();
+	const video = new Media(timeline, "video0");
+
+	for (let seq = 0; seq < 4; seq++) {
+		video.record(seq, us(seq * 2000));
+	}
+
+	// Segment 0 is carried by group 0. Losing it retracts the record naming it, which the next
+	// report sweeps.
+	video.evict(0);
+	video.record(4, us(8000));
+	video.close();
+	timeline.finish();
+
+	const trims = (await updates()).flatMap((u) => (u.type === "trim" ? [u.offset] : []));
+	expect(trims).toEqual([1]);
+});
+
+/**
+ * A segment spans every enrolled track, so losing a group on ANY of them breaks it: a consumer
+ * fetches the whole segment, and a hole in audio is as fatal as one in video.
+ */
+test("a segment goes when any track loses a group", async () => {
+	const { timeline, updates } = capture();
+	const video = new Media(timeline, "video0");
+	const audio = new Media(timeline, "audio0");
+
+	for (let seq = 0; seq < 3; seq++) {
+		video.record(seq, us(seq * 2000));
+		audio.record(seq, us(seq * 2000));
+	}
+
+	// Video's group 0 is untouched; only audio's is lost.
+	audio.evict(0);
+	video.record(3, us(6000));
+	audio.record(3, us(6000));
+	video.close();
+	audio.close();
+	timeline.finish();
+
+	const trims = (await updates()).flatMap((u) => (u.type === "trim" ? [u.offset] : []));
+	expect(trims).toEqual([1]);
+});
+
+/**
+ * A cleanly finished group is still cached and fetchable, so its segment stays listed.
+ *
+ * The trap this pins: `closed` in js/net means completion, so watching it rather than `isGone`
+ * would retract every segment the instant its groups finished, i.e. immediately and always.
+ */
+test("a finished group is not a retraction", async () => {
+	const { timeline, updates } = capture();
+	const video = new Media(timeline, "video0");
+
+	video.record(0, us(0));
+	video.record(1, us(2000));
+	video.finishGroup(0);
+	video.finishGroup(1);
+	video.record(2, us(4000));
+	video.close();
+	timeline.finish();
+
+	const all = await updates();
+	expect(all.filter((u) => u.type === "trim")).toEqual([]);
+	expect(all.some((u) => u.type === "append")).toBe(true);
+});
+
+/**
+ * Eviction is charged from the frame-write path, so a group can die after the last record.
+ * `finish` sweeps once more, or the track would close still listing unfetchable media and a reader
+ * would take that clean end as a complete playlist.
+ */
+test("finish sweeps media lost after the last record", async () => {
+	const { timeline, updates } = capture();
+	const video = new Media(timeline, "video0");
+
+	video.record(0, us(0));
+	video.record(1, us(2000));
+	video.record(2, us(4000));
+	video.close();
+
+	// Nothing will report again; only finish() can notice this.
+	video.evict(0);
+	timeline.finish();
+
+	const trims = (await updates()).flatMap((u) => (u.type === "trim" ? [u.offset] : []));
+	expect(trims).toEqual([1]);
 });

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -12,6 +12,15 @@
  * track has reported past its end (or closed), so records are self-contained and immediately
  * servable.
  *
+ * On the wire the track is a `@moq/json` {@link Json.Window}: a sliding log that appends as
+ * segments are indexed and trims as they stop being fetchable, so the timeline describes what is
+ * actually available rather than everything ever published.
+ *
+ * Trimming is driven by the media cache itself, not a timer. The timeline keeps a group handle for
+ * every group a segment covers, on every track, and retracts the record once any of them reports
+ * the group gone. Holding those handles does not keep the media alive, so the timeline tracks the
+ * cache without extending it.
+ *
  * @module
  */
 
@@ -109,7 +118,7 @@ export interface ProducerProps {
 /** One enrolled track's report state. */
 interface TrackState {
 	// Group opens reported and not yet flushed into a record.
-	pending: { sequence: number; pts: Time.Micro; keyframe: boolean }[];
+	pending: { sequence: number; pts: Time.Micro; keyframe: boolean; group: Moq.Group.Consumer }[];
 	// The newest reported timestamp: everything earlier is known. Advanced by a group open (the
 	// group starts there) and by Recorder.end (the content stops there).
 	frontier?: Time.Micro;
@@ -126,7 +135,10 @@ interface TrackState {
  * {@link cut}. Advertise it in the catalog's root `timeline` section via {@link section}.
  */
 export class Producer {
-	#stream: Json.Stream.Producer<Record>;
+	#window: Json.Window.Producer<Record>;
+	// One span of group handles per record in the window, oldest first. A record stands for the
+	// media across its whole segment, so it survives exactly as long as every group it covers.
+	#indexed: Moq.Group.Consumer[][] = [];
 	#trackName: string;
 	#durationMinUs: number;
 	#durationMaxUs?: number;
@@ -157,7 +169,7 @@ export class Producer {
 			const unixMillis = Math.max(props.wall.getTime(), MOQ_EPOCH_UNIX_MILLIS);
 			this.#wall = Math.floor(((unixMillis - MOQ_EPOCH_UNIX_MILLIS) * DEFAULT_TIMESCALE) / 1000);
 		}
-		this.#stream = new Json.Stream.Producer<Record>(track, { compression: true });
+		this.#window = new Json.Window.Producer<Record>(track, { compression: true });
 	}
 
 	/**
@@ -264,14 +276,19 @@ export class Producer {
 			}
 		}
 
-		this.#stream.finish();
+		// Eviction is charged from the frame-write path too, so a group can die after the last
+		// record. Without this final sweep the window would close still listing it, and a reader
+		// would take the clean end as a complete playlist over media it cannot fetch.
+		this.#sweep();
+
+		this.#window.finish();
 	}
 
 	/** @internal A group open reported by a {@link Recorder}. */
-	report(name: string, sequence: number, pts: Time.Micro, keyframe: boolean): void {
+	report(name: string, group: Moq.Group.Producer, pts: Time.Micro, keyframe: boolean): void {
 		const track = this.#tracks.get(name);
 		if (!track) return;
-		track.pending.push({ sequence, pts, keyframe });
+		track.pending.push({ sequence: group.sequence, pts, keyframe, group: group.consume() });
 		this.#advance(track, pts);
 	}
 
@@ -306,6 +323,12 @@ export class Producer {
 	// will report again, so one that never reached a boundary stops voting instead of holding
 	// the timeline open forever.
 	#pump(finished: boolean): void {
+		// Sweep first: a retraction and the record that triggers it ride the same window group, and
+		// sweeping before appending keeps the window from briefly listing content already gone.
+		// Unconditional, since media leaving the cache is worth reporting even while a reservation
+		// withholds new records.
+		this.#sweep();
+
 		if (this.#tracks.size === 0 || this.#reservers > 0 || this.#overrun) return;
 		while (this.#closeSegment(finished)) {
 			if (this.#overrun) break;
@@ -404,7 +427,7 @@ export class Producer {
 				);
 				// End the track rather than drop it: the records published before the promise
 				// broke are still true, and a consumer that has them should keep them.
-				this.#stream.finish();
+				this.#window.finish();
 				return;
 			}
 		}
@@ -414,6 +437,9 @@ export class Producer {
 
 		const tracks: { [track: string]: Range[] } = {};
 		let any = false;
+		// Every group this segment covers, across every track: the set whose availability the
+		// record's own availability is the AND of.
+		const covered: Moq.Group.Consumer[] = [];
 		for (const [name, track] of this.#tracks) {
 			const ranges: Range[] = [];
 			while (track.pending.length > 0) {
@@ -430,6 +456,7 @@ export class Producer {
 					if (!group.keyframe) range.keyframe = false;
 					ranges.push(range);
 				}
+				covered.push(group.group);
 			}
 			if (ranges.length > 0) {
 				tracks[name] = ranges;
@@ -438,7 +465,32 @@ export class Producer {
 		}
 		if (any) record.tracks = tracks;
 
-		this.#stream.append(record);
+		this.#window.append(record);
+		this.#indexed.push(covered);
+	}
+
+	/**
+	 * Retract every record up to and including the newest one that has lost any of its groups.
+	 *
+	 * A record goes when *any* group it covers is gone, on any track: a consumer fetches the whole
+	 * segment, so a hole in the middle breaks it just as thoroughly as a missing head.
+	 *
+	 * Eviction is not strictly oldest-first: a group refreshed by a fetch is protected while a
+	 * newer unread one is evicted in its place. That leaves a hole, and a window has only a head,
+	 * so the choice is to advertise the dead record or to drop the live ones in front of it.
+	 * Dropping them keeps the promise that everything listed is fetchable, which is the whole point
+	 * of the timeline; the cost is a shorter window, and eviction reaches those records shortly
+	 * anyway.
+	 */
+	#sweep(): void {
+		let gone = 0;
+		this.#indexed.forEach((covered, index) => {
+			if (covered.some((group) => group.isGone)) gone = index + 1;
+		});
+		if (gone === 0) return;
+
+		this.#indexed.splice(0, gone);
+		this.#window.trim(gone);
 	}
 }
 
@@ -459,12 +511,14 @@ export class Recorder {
 	}
 
 	/**
-	 * Report that group `sequence` opened at presentation time `pts` (microseconds),
-	 * `keyframe` stating whether its first frame is one. Reports must be in group order with
-	 * monotonic timestamps.
+	 * Report that `group` opened at presentation time `pts` (microseconds), `keyframe` stating
+	 * whether its first frame is one. Reports must be in group order with monotonic timestamps.
+	 *
+	 * The timeline keeps a read handle on `group` to watch when it leaves the cache, which is what
+	 * retracts the segment carrying it. That pins no frames, and the caller keeps ownership.
 	 */
-	record(sequence: number, pts: Time.Micro, keyframe = true): void {
-		this.#timeline.report(this.#name, sequence, pts, keyframe);
+	record(group: Moq.Group.Producer, pts: Time.Micro, keyframe = true): void {
+		this.#timeline.report(this.#name, group, pts, keyframe);
 	}
 
 	/**

--- a/js/json/src/index.ts
+++ b/js/json/src/index.ts
@@ -1,18 +1,24 @@
 /**
- * JSON publishing over MoQ tracks, in two modes:
+ * JSON publishing over MoQ tracks, in three modes:
  *
  * - {@link Snapshot}: **lossy**. One JSON value updated over time; a consumer only gets the most
  *   recent value. Intermediate updates are collapsed and older groups are dropped.
  * - {@link Stream}: **lossless**. An ordered append-log of self-contained records; every record
  *   is preserved and delivered in order, nothing is ever superseded.
+ * - {@link Window}: **sliding**. An ordered log that appends at the tail and removes from the
+ *   head, like an HLS playlist. Records carry stable positions and old groups are disposable.
  *
  * Pick {@link Snapshot} when consumers care about "what is the value now" (a catalog, a status
- * document) and {@link Stream} when they care about every record (an event log, a media timeline).
+ * document), {@link Stream} when they care about every record ever written (an event log), and
+ * {@link Window} when records expire (a media timeline over a bounded cache).
  *
- * Each mode comes in two layers. `Producer`/`Consumer` own a track and manage its groups.
- * `Encoder`/`Decoder` are the same logic without the track: values in, frame payloads out (and
- * back), with the encoder saying where the group boundaries fall. Reach for the codec layer when
- * something else already owns the track.
+ * {@link Snapshot} and {@link Stream} each come in two layers. `Producer`/`Consumer` own a track
+ * and manage its groups. `Encoder`/`Decoder` are the same logic without the track: values in,
+ * frame payloads out (and back), with the encoder saying where the group boundaries fall. Reach
+ * for the codec layer when something else already owns the track.
+ *
+ * {@link Window} is the one layer: where its groups roll follows from its own trim history, so it
+ * owns the track outright.
  *
  * @module
  */
@@ -20,3 +26,4 @@
 export { type Diff, deepEqual, diff, merge } from "./diff.ts";
 export * as Snapshot from "./snapshot/index.ts";
 export * as Stream from "./stream/index.ts";
+export * as Window from "./window.ts";

--- a/js/json/src/window.test.ts
+++ b/js/json/src/window.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, test } from "bun:test";
+import * as Moq from "@moq/net";
+import * as Window from "./window.ts";
+
+interface Rec {
+	n: number;
+}
+
+function pair(compression = false): [Window.Producer<Rec>, Window.Consumer<Rec>] {
+	const track = new Moq.Track.Producer("test");
+	const consumer = new Window.Consumer<Rec>(track.subscribe(), { compression });
+	return [new Window.Producer<Rec>(track, { compression }), consumer];
+}
+
+/** Drain every update the consumer can produce until the track ends. */
+async function drain(consumer: Window.Consumer<Rec>): Promise<Window.Update<Rec>[]> {
+	const out: Window.Update<Rec>[] = [];
+	for (;;) {
+		const update = await consumer.next();
+		if (!update) return out;
+		out.push(update);
+	}
+}
+
+/** The records a consumer holds after applying every update. */
+function replay(updates: Window.Update<Rec>[]): [number, Rec][] {
+	let held: [number, Rec][] = [];
+	for (const update of updates) {
+		if (update.type === "append") held.push([update.position, update.value]);
+		else held = held.filter(([position]) => position >= update.offset);
+	}
+	return held;
+}
+
+describe("window", () => {
+	test("appends carry positions", async () => {
+		const [producer, consumer] = pair();
+		for (let n = 0; n < 3; n++) expect(producer.append({ n })).toBe(n);
+		producer.finish();
+
+		expect(await drain(consumer)).toEqual([
+			{ type: "append", position: 0, value: { n: 0 } },
+			{ type: "append", position: 1, value: { n: 1 } },
+			{ type: "append", position: 2, value: { n: 2 } },
+		]);
+	});
+
+	test("a trim retracts from the head", async () => {
+		const [producer, consumer] = pair();
+		for (let n = 0; n < 4; n++) producer.append({ n });
+		producer.trim(2);
+		expect(producer.offset).toBe(2);
+		expect(producer.length).toBe(2);
+		producer.finish();
+
+		const updates = await drain(consumer);
+		expect(updates.at(-1)).toEqual({ type: "trim", offset: 2 });
+		expect(replay(updates)).toEqual([
+			[2, { n: 2 }],
+			[3, { n: 3 }],
+		]);
+	});
+
+	test("a trim past the window throws", () => {
+		const [producer] = pair();
+		producer.append({ n: 0 });
+		expect(() => producer.trim(2)).toThrow();
+		// The rejected trim left the window untouched, and zero is a no-op.
+		expect(producer.length).toBe(1);
+		producer.trim(0);
+	});
+
+	test("a non-integer trim count is rejected", () => {
+		// NaN fails every comparison, so a range check alone lets it through: it would splice
+		// nothing, poison the offset, and serialize as `null`. A fraction splices nothing either
+		// and emits a count both consumers reject.
+		const [producer] = pair();
+		for (let n = 0; n < 3; n++) producer.append({ n });
+
+		for (const bad of [0.5, Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+			expect(() => producer.trim(bad)).toThrow();
+		}
+		expect(producer.length).toBe(3);
+		expect(producer.offset).toBe(0);
+	});
+
+	test("heavy trimming rolls a group and still converges on the live window", async () => {
+		const track = new Moq.Track.Producer("test");
+		const producer = new Window.Producer<Rec>(track);
+
+		producer.append({ n: 0 });
+		producer.append({ n: 1 });
+		for (let n = 2; n < 12; n++) {
+			producer.append({ n });
+			producer.trim(1);
+		}
+		producer.finish();
+
+		// A late joiner skips to the newest buffered group rather than replaying every cached one.
+		// Parity with the Rust consumer.
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+		const updates = await drain(consumer);
+		const positions = updates.filter((u) => u.type === "append").map((u) => u.position);
+
+		// It starts inside the newest group's snapshot, not back at the beginning of the log. The
+		// exact position depends on where the last roll fell, so assert the property, not the value.
+		expect(positions[0]).toBeGreaterThan(0);
+		expect(positions).toEqual([...new Set(positions)]);
+		expect(replay(updates)).toEqual([
+			[10, { n: 10 }],
+			[11, { n: 11 }],
+		]);
+	});
+
+	test("mutating an appended record does not change what a later snapshot emits", async () => {
+		// The window keeps records by value, not by reference. Otherwise a caller mutating an object
+		// it already appended would make a later group's snapshot emit different JSON for the same
+		// position, so a consumer that saw the first group and one that joined later would disagree
+		// about a record they both name.
+		const track = new Moq.Track.Producer("test");
+		const producer = new Window.Producer<Rec>(track);
+
+		const record = { n: 0 };
+		producer.append(record);
+		record.n = 999; // after publishing, before any roll
+
+		// Roll via the per-group frame cap rather than by trimming, so position 0 is still in the
+		// window and gets re-serialized into the new group's snapshot.
+		for (let n = 1; n < 300; n++) producer.append({ n });
+		producer.finish();
+
+		const held = replay(await drain(new Window.Consumer<Rec>(track.subscribe())));
+		const first = held.find(([position]) => position === 0);
+		expect(first).toBeDefined();
+		expect(first?.[1]).toEqual({ n: 0 });
+	});
+
+	test("a failed publish leaves the window untouched", () => {
+		// `finish` only closes the track, so a later append is expressible. It must fail without
+		// moving the window: `offset`, `length`, and the next position all read from it.
+		const [producer] = pair();
+		producer.append({ n: 0 });
+		producer.append({ n: 1 });
+		producer.finish();
+
+		expect(() => producer.append({ n: 2 })).toThrow();
+		expect(producer.length).toBe(2);
+		expect(producer.offset).toBe(0);
+
+		expect(() => producer.trim(1)).toThrow();
+		expect(producer.length).toBe(2);
+		expect(producer.offset).toBe(0);
+	});
+
+	test("a snapshot spanning past the exact-integer limit is rejected", async () => {
+		// The offset alone is not enough: past 2^53-1 two positions round together, so the next
+		// append would repeat one the consumer already yielded.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		const snapshot = { offset: Number.MAX_SAFE_INTEGER - 1, values: [{ n: 0 }, { n: 1 }, { n: 2 }] };
+		group.writeFrame({
+			payload: new TextEncoder().encode(JSON.stringify(snapshot)),
+			timestamp: Moq.Time.Timestamp.now(),
+		});
+		group.close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("maximum position");
+	});
+
+	test("a group roll never repeats a record", async () => {
+		// Whatever group a consumer lands on, positions are what make the switch lossless: a record
+		// repeated by a later snapshot is skipped rather than yielded twice. (The strictly-live
+		// interleaving is covered on the Rust side, which has a synchronous poll API to drive it.)
+		const [producer, consumer] = pair();
+		for (let n = 0; n < 2; n++) producer.append({ n });
+		for (let n = 2; n < 12; n++) {
+			producer.append({ n });
+			producer.trim(1);
+		}
+		producer.finish();
+
+		const positions = (await drain(consumer)).filter((u) => u.type === "append").map((u) => u.position);
+		expect(positions).toEqual([...new Set(positions)]);
+		expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+	});
+
+	test("compressed roundtrip", async () => {
+		const [producer, consumer] = pair(true);
+		for (let n = 0; n < 20; n++) producer.append({ n });
+		producer.trim(15);
+		producer.finish();
+
+		const held = replay(await drain(consumer));
+		expect(held.length).toBe(5);
+		expect(held[0]).toEqual([15, { n: 15 }]);
+	});
+
+	test("a null record keeps its position", async () => {
+		// `null` is a valid JSON record. Treating it as an absent `append` would drop the record and
+		// stall the tail, shifting every later position. Parity with the Rust window.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec | null>(track.subscribe());
+		const producer = new Window.Producer<Rec | null>(track);
+
+		producer.append({ n: 0 });
+		producer.append(null);
+		producer.append({ n: 2 });
+		producer.finish();
+
+		const out: Window.Update<Rec | null>[] = [];
+		for (;;) {
+			const update = await consumer.next();
+			if (!update) break;
+			out.push(update);
+		}
+		expect(out).toEqual([
+			{ type: "append", position: 0, value: { n: 0 } },
+			{ type: "append", position: 1, value: null },
+			{ type: "append", position: 2, value: { n: 2 } },
+		]);
+	});
+
+	test("a malformed trim is rejected", async () => {
+		// A non-numeric trim would coerce to 0 and silently no-op, leaving the head desynced from
+		// the publisher's; Rust errors on it too.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [{ offset: 0, values: [{ n: 0 }] }, { trim: null }]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		// Buffered frames drain in one pass, so the malformed trim surfaces on the first read.
+		await expect(drain(consumer)).rejects.toThrow("invalid trim");
+	});
+
+	test("a frame carrying both operations is rejected", async () => {
+		// Applying both would append and retract in an order the format never defines. Parity with
+		// the Rust window; a frame carrying neither stays a no-op (see the next test).
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [
+			{ offset: 0, values: [{ n: 0 }] },
+			{ append: { n: 1 }, trim: 1 },
+		]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("both an append and a trim");
+	});
+
+	test("a snapshot with an unusable offset is rejected", async () => {
+		// Every position derives from the offset, and NaN comparisons are all false, so a bad offset
+		// would keep emitting appends whose positions no reader can use rather than failing.
+		for (const offset of [undefined, "4", Number.NaN, -1]) {
+			const track = new Moq.Track.Producer("test");
+			const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+			const group = track.appendGroup();
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify({ offset, values: [{ n: 0 }] })),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+			group.close();
+			track.close();
+
+			await expect(drain(consumer)).rejects.toThrow("invalid offset");
+		}
+	});
+
+	test("a snapshot missing values is rejected", async () => {
+		// `values` is required. Treating an absent one as an empty window would report a head jump
+		// and continue from fabricated state, where the Rust decoder fails outright.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		group.writeFrame({
+			payload: new TextEncoder().encode(JSON.stringify({ offset: 4 })),
+			timestamp: Moq.Time.Timestamp.now(),
+		});
+		group.close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("must be an array");
+	});
+
+	test("an append past the exact-integer limit is rejected", async () => {
+		// The snapshot bound alone is not enough: a snapshot can land the tail exactly at the limit
+		// and appends walk it past, where positions round together. Rust rejects the same frame.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [{ offset: Number.MAX_SAFE_INTEGER - 1, values: [{ n: 0 }] }, { append: { n: 1 } }]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("reaches the maximum");
+	});
+
+	test("an unknown operation is ignored", async () => {
+		// A frame carrying neither key is a forward-compatible extension, not an error. Written by
+		// hand, since the producer only emits the operations it knows.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [{ offset: 0, values: [{ n: 0 }] }, { rewind: 1 }, { append: { n: 1 } }]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		expect(await drain(consumer)).toEqual([
+			{ type: "append", position: 0, value: { n: 0 } },
+			{ type: "append", position: 1, value: { n: 1 } },
+		]);
+	});
+
+	test("a group with no snapshot is rejected", async () => {
+		// A group that ends cleanly having carried nothing is malformed: every group opens with a
+		// snapshot. Reporting it as a clean end of track would lose the window the publisher
+		// advertised. Rust rejects the same group.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		track.appendGroup().close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("no snapshot");
+	});
+
+	test("a hand-written trim is applied", async () => {
+		// The wire shape the Rust producer emits, decoded independently of our own producer.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [{ offset: 4, values: [{ n: 4 }, { n: 5 }] }, { append: { n: 6 } }, { trim: 2 }]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		const updates = await drain(consumer);
+		// Joining at offset 4 reports no trim for records it never held; the later trim is real.
+		expect(updates).toEqual([
+			{ type: "append", position: 4, value: { n: 4 } },
+			{ type: "append", position: 5, value: { n: 5 } },
+			{ type: "append", position: 6, value: { n: 6 } },
+			{ type: "trim", offset: 6 },
+		]);
+		expect(replay(updates)).toEqual([[6, { n: 6 }]]);
+	});
+});

--- a/js/json/src/window.ts
+++ b/js/json/src/window.ts
@@ -1,0 +1,474 @@
+/**
+ * Sliding-window JSON publishing over MoQ tracks: an ordered log that grows at the tail and
+ * shrinks at the head, like an HLS media playlist. {@link Producer.append} adds a record as
+ * content becomes available and {@link Producer.trim} drops records from the head as it stops
+ * being available. The counterpart to the `Stream` module, which only ever appends, and to
+ * `Snapshot`, which keeps no history at all.
+ *
+ * Every record has a stable **position**: the count of records ever appended before it. Positions
+ * never repeat, so a record is identified across group rolls and trims, exactly like an HLS media
+ * sequence number.
+ *
+ * On the wire each group is self-contained. Frame 0 is a snapshot of the live window
+ * (`{"offset":N,"values":[...]}`) and each later frame is one operation (`{"append":V}` or
+ * `{"trim":N}`). A new group rolls once the records trimmed since the snapshot outnumber those
+ * still in the window, so a late joiner reads the newest group and needs nothing older.
+ * Interoperable on the wire with the Rust `moq_json::window`.
+ *
+ * @module
+ */
+
+import { Decoder, Encoder } from "@moq/flate";
+import type * as Moq from "@moq/net";
+import { Time } from "@moq/net";
+
+/**
+ * Maximum frames (snapshot plus operations) in one group before a snapshot is forced.
+ *
+ * Kept well below moq-net's per-group frame cap so a late joiner can always read the snapshot at
+ * frame 0 before the group is evicted.
+ */
+const MAX_GROUP_FRAMES = 256;
+
+/**
+ * The largest position the wire format allows: 2^53-1.
+ *
+ * Past this a JSON number stops counting exactly, so two distinct positions round together and
+ * lossless group switching breaks: the next append would repeat a position the consumer already
+ * yielded. Matches `MAX_POSITION` in the Rust window.
+ */
+const MAX_POSITION = Number.MAX_SAFE_INTEGER;
+
+/** Compress (when an encoder is given) and write one already-serialized frame. */
+function writeFrame(group: Moq.Group.Producer, encoder: Encoder | undefined, payload: string): void {
+	const bytes = new TextEncoder().encode(payload);
+	group.writeFrame({ payload: encoder ? encoder.frame(bytes) : bytes, timestamp: Time.Timestamp.now() });
+}
+
+/** Options for a window {@link Producer}. */
+export interface ProducerConfig {
+	/**
+	 * Compress each group as one sync-flushed `deflate-raw` stream, so operations reuse the
+	 * snapshot as context and shrink sharply. A {@link Consumer} reading the track must set the
+	 * same flag. Defaults to `false`.
+	 */
+	compression?: boolean;
+}
+
+/** Options for a window {@link Consumer}. */
+export interface ConsumerConfig {
+	/** Whether the track's frames are `deflate-raw` compressed. Must match the producer. Defaults to `false`. */
+	compression?: boolean;
+}
+
+/** One change to the window, yielded by a {@link Consumer}. */
+export type Update<T> =
+	| {
+			type: "append";
+			/** The record's position: the count of records ever appended before it. */
+			position: number;
+			/** The record itself. */
+			value: T;
+	  }
+	| {
+			type: "trim";
+			/** The position of the oldest record still in the window; everything before it is gone. */
+			offset: number;
+	  };
+
+/** The snapshot at frame 0 of every group. */
+interface Snapshot<T> {
+	offset: number;
+	values: T[];
+}
+
+/** One operation frame. Unknown members are ignored, so a frame carrying neither key is a no-op. */
+interface Op<T> {
+	append?: T;
+	trim?: number;
+}
+
+/** Publishes a sliding window of JSON records to a track. */
+export class Producer<T> {
+	#track: Moq.Track.Producer;
+	#compress: boolean;
+
+	#group?: Moq.Group.Producer;
+	// The open group's DEFLATE encoder (one window per group), present while compressing.
+	#encoder?: Encoder;
+	// Every record currently in the window, oldest first, kept so a new group can snapshot it.
+	//
+	// Stored already serialized rather than by reference: a caller that mutates an object it
+	// appended would otherwise make a later snapshot emit different JSON for the same position, so
+	// a consumer that saw the first group and one that joined later would disagree about a record
+	// they both name. Serializing once at append pins the value, matching the Rust window's
+	// `Box<RawValue>`.
+	#window: string[] = [];
+	// The position of `#window[0]`: how many records have been trimmed for the log's lifetime.
+	#offset = 0;
+	// Records trimmed since the open group's snapshot, the roll trigger.
+	#trimmed = 0;
+	#frames = 0;
+
+	/** Wrap a track to publish a sliding record window into it. */
+	constructor(track: Moq.Track.Producer, config: ProducerConfig = {}) {
+		this.#track = track;
+		this.#compress = config.compression ?? false;
+	}
+
+	/** The position of the oldest record still in the window. */
+	get offset(): number {
+		return this.#offset;
+	}
+
+	/** The number of records currently in the window. */
+	get length(): number {
+		return this.#window.length;
+	}
+
+	/** Append one record to the tail of the window, returning the position it was assigned. */
+	append(value: T): number {
+		const raw = JSON.stringify(value);
+		if (raw === undefined) {
+			throw new Error("record is not JSON-serializable");
+		}
+
+		const position = this.#offset + this.#window.length;
+		// A consumer rejects an append *at* the maximum, so refuse to publish one: the window would
+		// be unreadable by the very consumers it targets.
+		if (position >= MAX_POSITION) {
+			throw new Error(`append at position ${position} reaches the maximum ${MAX_POSITION}`);
+		}
+		this.#window.push(raw);
+
+		try {
+			if (this.#needsSnapshot()) {
+				this.#snapshot();
+			} else {
+				this.#emit(`{"append":${raw}}`);
+			}
+		} catch (err) {
+			// A publish that failed (a finished or closed track) must leave the window as it was:
+			// `offset`, `length`, and the next position all read from it, so keeping a record nobody
+			// received would report a window that does not exist.
+			this.#window.pop();
+			throw err;
+		}
+		return position;
+	}
+
+	/**
+	 * Remove the oldest `count` records from the head of the window.
+	 *
+	 * A `count` of 0 does nothing. Throws if it exceeds the number of records in the window, since
+	 * trimming past the head would desync every consumer's positions.
+	 */
+	trim(count: number): void {
+		// Check integrality before the range test: `NaN` fails every comparison, so it would slip
+		// through, splice nothing, and poison `#offset` (and serialize as `null`). A fraction would
+		// splice nothing either, yet still emit a count both consumers reject.
+		if (!Number.isSafeInteger(count) || count < 0) {
+			throw new Error(`trim count must be a non-negative integer, got ${count}`);
+		}
+		if (count === 0) return;
+		if (count > this.#window.length) {
+			throw new Error(`trim of ${count} exceeds the ${this.#window.length} records in the window`);
+		}
+
+		const removed = this.#window.splice(0, count);
+		this.#offset += count;
+		this.#trimmed += count;
+
+		try {
+			if (this.#needsSnapshot()) {
+				this.#snapshot();
+			} else {
+				this.#emit(`{"trim":${count}}`);
+			}
+		} catch (err) {
+			// Same rollback as `append`: an unpublished trim must not move the head.
+			this.#offset -= count;
+			this.#trimmed -= count;
+			this.#window.unshift(...removed);
+			throw err;
+		}
+	}
+
+	/** Finish the track, closing any open group. */
+	finish(): void {
+		this.#group?.close();
+		this.#group = undefined;
+		this.#encoder = undefined;
+		this.#track.close();
+	}
+
+	/**
+	 * Whether the next operation should roll a fresh snapshot group instead.
+	 *
+	 * Rolls once the records trimmed since the snapshot outnumber those still in the window: the
+	 * group is then mostly dead weight for a new subscriber, and a fresh snapshot costs no more
+	 * than what has already been trimmed.
+	 */
+	#needsSnapshot(): boolean {
+		return !this.#group || this.#frames >= MAX_GROUP_FRAMES || this.#trimmed > this.#window.length;
+	}
+
+	/**
+	 * Start a new group whose frame 0 snapshots the whole window.
+	 *
+	 * State moves to the new group only once its snapshot frame lands. A half-rolled group (open,
+	 * but with no frame 0) would take the next append down the operation path and publish it as
+	 * frame 0, which every consumer rejects as a malformed snapshot, leaving the track unrecoverable.
+	 * Clearing the group instead forces the next publish to snapshot again.
+	 */
+	#snapshot(): void {
+		// Materialize before touching any group state, so a serialization failure changes nothing.
+		const payload = `{"offset":${this.#offset},"values":[${this.#window.join(",")}]}`;
+
+		// The previous group is complete; no more frames will be appended to it.
+		this.#group?.close();
+		this.#group = undefined;
+		this.#encoder = undefined;
+		this.#frames = 0;
+
+		const group = this.#track.appendGroup();
+		const encoder = this.#compress ? new Encoder() : undefined;
+		try {
+			writeFrame(group, encoder, payload);
+		} catch (err) {
+			group.close();
+			throw err;
+		}
+
+		this.#group = group;
+		this.#encoder = encoder;
+		this.#frames = 1;
+		// Only now is the roll real, so only now does the trim debt reset. Resetting earlier would
+		// let a failed roll drive `#trimmed` negative when the caller rolls back.
+		this.#trimmed = 0;
+	}
+
+	/** Write one already-serialized frame into the open group. */
+	#emit(payload: string): void {
+		// biome-ignore lint/style/noNonNullAssertion: #needsSnapshot guarantees an open group
+		writeFrame(this.#group!, this.#encoder, payload);
+		this.#frames += 1;
+	}
+}
+
+/**
+ * Reads a sliding window of JSON records from a track, yielding each change in order.
+ *
+ * Starts at the newest group's snapshot, so a late joiner sees an append per record currently in
+ * the window and then follows along live. Switching to a newer group is lossless: positions
+ * identify what has already been yielded, so records are never repeated.
+ *
+ * A trim only ever retracts records this consumer was told about, so joining a window that has
+ * already trimmed does not report the records it missed. Those show up instead as a jump in the
+ * first append's `position`.
+ */
+export class Consumer<T> {
+	#track: Moq.Track.Subscriber;
+	#decompress: boolean;
+
+	#group?: Moq.Group.Consumer;
+	// The open group's DEFLATE decoder (one window per group), built on its first frame.
+	#decoder?: Decoder;
+	// Frames read from the open group; frame 0 is its snapshot.
+	#frames = 0;
+	// The position of the next record this consumer has not yielded yet.
+	#next = 0;
+	// The head offset already reported through a trim, or undefined until the first snapshot
+	// establishes where this consumer joined.
+	#reported?: number;
+	// The head offset of the group being followed, advanced by its trims.
+	#head = 0;
+	// The position one past the last record the group being followed has appended.
+	#tail = 0;
+	// Updates decoded but not yet yielded; one frame can decode a whole snapshot.
+	#pending: Update<T>[] = [];
+
+	constructor(track: Moq.Track.Subscriber, config: ConsumerConfig = {}) {
+		this.#track = track;
+		this.#decompress = config.compression ?? false;
+	}
+
+	/** Get the next update, or `undefined` once the track ends. */
+	async next(): Promise<Update<T> | undefined> {
+		for (;;) {
+			const ready = this.#pending.shift();
+			if (ready) return ready;
+
+			if (!this.#group) {
+				// Advance to the next group with a higher sequence number (skipping late arrivals).
+				this.#group = await this.#track.nextGroup();
+				if (!this.#group) return undefined;
+
+				// Then skip to the newest group already buffered. Each group is self-contained, so
+				// an older one carries nothing the newest lacks; without this a late joiner replays
+				// every cached group, emitting appends and trims for records already gone.
+				//
+				// Close each group skipped past. A subscriber's group is its own mirror of the
+				// source (`Group.Producer.mirror` builds a fresh state per sink), so closing one
+				// releases only this reader's copy and drops its share of the producer's demand.
+				for (let newer = this.#track.tryNextGroup(); newer; newer = this.#track.tryNextGroup()) {
+					this.#group.close();
+					this.#group = newer;
+				}
+
+				this.#frames = 0;
+				this.#decoder = undefined;
+			}
+
+			// Drain everything already buffered before blocking, so a late joiner catches up in one step.
+			let advanced = false;
+			for (let frame = this.#group.tryReadFrame(); frame !== undefined; frame = this.#group.tryReadFrame()) {
+				this.#apply(frame.payload);
+				advanced = true;
+			}
+			if (advanced) continue;
+
+			let frame: Moq.Group.Frame | undefined;
+			try {
+				frame = await this.#group.readFrame();
+			} catch {
+				// The group was reset or we fell behind its eviction window. Resync from the next
+				// group, which begins with a fresh snapshot, so no partial state is presented.
+				this.#group = undefined;
+				continue;
+			}
+
+			if (frame === undefined) {
+				// Every group opens with a snapshot, so one that ends cleanly having delivered
+				// nothing is malformed. Accepting it would let it masquerade as a clean end of
+				// track and silently lose the window the publisher advertised. Rust rejects the
+				// same group. (A group that *errors* before frame 0 is a different case, handled
+				// above: that is a lost group, and it resyncs.)
+				if (this.#frames === 0) throw new Error("a group carried no snapshot");
+
+				// The group is exhausted; advance to the next one.
+				this.#group = undefined;
+				continue;
+			}
+
+			this.#apply(frame.payload);
+		}
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<Update<T>> {
+		for (;;) {
+			const update = await this.next();
+			if (update === undefined) return;
+			yield update;
+		}
+	}
+
+	/** Apply one frame: frame 0 of a group is a snapshot, the rest are operations. */
+	#apply(frame: Uint8Array): void {
+		let payload = frame;
+		if (this.#decompress) {
+			this.#decoder ??= new Decoder();
+			payload = this.#decoder.frame(frame);
+		}
+		const parsed = JSON.parse(new TextDecoder().decode(payload));
+
+		if (this.#frames === 0) {
+			this.#applySnapshot(parsed as Snapshot<T>);
+		} else {
+			this.#applyOp(parsed as Op<T>);
+		}
+		this.#frames += 1;
+	}
+
+	/** Adopt a group's snapshot, yielding only what this consumer hasn't seen. */
+	#applySnapshot(snapshot: Snapshot<T>): void {
+		// Every position derives from this offset. A missing or non-numeric one would make `#head`,
+		// `#tail`, and every position NaN, and NaN comparisons are all false, so the consumer would
+		// keep emitting appends whose positions no reader can use. Fail loudly instead.
+		if (!Number.isSafeInteger(snapshot.offset) || snapshot.offset < 0) {
+			throw new Error(`snapshot carries an invalid offset: ${JSON.stringify(snapshot.offset)}`);
+		}
+		// `values` is required, so an absent one is malformed rather than an empty window: accepting
+		// it would report a head jump and continue from fabricated state, where the Rust decoder
+		// fails. Both implementations must reject the same frames.
+		if (!Array.isArray(snapshot.values)) {
+			throw new Error("snapshot values must be an array");
+		}
+		const values = snapshot.values;
+		// The tail matters as much as the offset: past the exact-integer limit two positions round
+		// together, so the next append would repeat one the consumer already yielded.
+		if (snapshot.offset + values.length > MAX_POSITION) {
+			throw new Error(`snapshot spans past the maximum position ${MAX_POSITION}`);
+		}
+		this.#head = snapshot.offset;
+		this.#tail = snapshot.offset + values.length;
+		this.#reportTrim();
+
+		values.forEach((value, index) => {
+			const position = snapshot.offset + index;
+			// Already yielded from an older group: the position is what makes the switch lossless.
+			if (position < this.#next) return;
+			this.#pushAppend(position, value);
+		});
+	}
+
+	/** Apply one operation frame from the group being followed. */
+	#applyOp(op: Op<T>): void {
+		// A frame carries at most one operation. Applying both would append and retract in an order
+		// the format never defines, so reject it instead of guessing. A frame carrying *neither* is
+		// not an error: that is how an operation added by a later revision reads here.
+		if ("append" in op && op.trim !== undefined) {
+			throw new Error("a frame carries both an append and a trim");
+		}
+
+		// An explicit `null` is a valid record, so test for the member's presence rather than for a
+		// defined value: collapsing the two would drop the record and stall the tail, shifting every
+		// later position.
+		if ("append" in op) {
+			const position = this.#tail;
+			// The snapshot bound is not enough on its own: a snapshot can land the tail exactly at
+			// the limit, and appends walk it past. Rust rejects the same operation.
+			if (position >= MAX_POSITION) {
+				throw new Error(`append at position ${position} reaches the maximum ${MAX_POSITION}`);
+			}
+			this.#tail += 1;
+			if (position >= this.#next) this.#pushAppend(position, op.append as T);
+		}
+
+		if (op.trim !== undefined) {
+			// A non-numeric trim would coerce to 0 and silently no-op, desyncing the head from the
+			// publisher's; reject it instead.
+			if (typeof op.trim !== "number" || !Number.isInteger(op.trim) || op.trim < 0) {
+				throw new Error(`invalid trim ${JSON.stringify(op.trim)}`);
+			}
+			if (this.#head + op.trim > this.#tail) {
+				throw new Error(`trim of ${op.trim} exceeds the ${this.#tail - this.#head} records in the window`);
+			}
+			this.#head += op.trim;
+			this.#reportTrim();
+		}
+	}
+
+	/**
+	 * Emit a trim if the followed group's head has moved past what was last reported.
+	 *
+	 * A trim says "records you were told about are gone", so the first snapshot only adopts its
+	 * offset: a consumer joining a window that already trimmed never held those records.
+	 */
+	#reportTrim(): void {
+		if (this.#reported === undefined) {
+			this.#reported = this.#head;
+			return;
+		}
+		if (this.#head > this.#reported) {
+			this.#reported = this.#head;
+			this.#pending.push({ type: "trim", offset: this.#head });
+		}
+	}
+
+	/** Queue a record, advancing the yield cursor past it. */
+	#pushAppend(position: number, value: T): void {
+		this.#next = position + 1;
+		this.#pending.push({ type: "append", position, value });
+	}
+}

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -50,6 +50,10 @@ class GroupState {
 	readonly sequence: number;
 	frames = new Signal<Frame[]>([]);
 	closed = new Once<Error | null>();
+	// Availability, as opposed to `closed`'s completion: settled once the group has left the
+	// publisher's cache and can no longer be fetched. A cleanly finished group stays unsettled
+	// here while it is still cached.
+	gone = new Once<Error | null>();
 	total = new Signal<number>(0); // The total number of frames in the group thus far
 
 	// Frames evicted from the front by the cache cap. A reader that had not consumed
@@ -60,6 +64,29 @@ class GroupState {
 	constructor(sequence: number) {
 		this.sequence = sequence;
 	}
+}
+
+/** Settle a group's availability once, ignoring later causes. */
+function markGone(state: GroupState, reason: Error | null) {
+	if (state.gone.peek() === undefined) state.gone.set(reason);
+}
+
+/**
+ * Drop a gone group's buffered frames, so watching its availability costs nothing.
+ *
+ * Counted into `offset` rather than silently discarded: a reader that had not drained them has a
+ * gap, and reporting {@link Lagged} on its next read beats handing it a short group that looks
+ * cleanly finished.
+ */
+function releaseFrames(state: GroupState) {
+	const buffered = state.frames.peek().length;
+	if (buffered === 0) return;
+
+	state.offset += buffered;
+	state.cacheBytes = 0;
+	state.frames.mutate((frames) => {
+		frames.length = 0;
+	});
 }
 
 function appendFrame(state: GroupState, frame: Frame) {
@@ -127,6 +154,9 @@ export class Producer {
 		const dst = new GroupState(this.sequence);
 		for (const frame of this.#state.frames.peek()) appendFrame(dst, frame);
 		dst.offset = this.#state.offset;
+
+		const gone = this.#state.gone.peek();
+		if (gone !== undefined) markGone(dst, gone);
 
 		const closed = this.#state.closed.peek();
 		if (closed !== undefined) {
@@ -211,11 +241,34 @@ export class Producer {
 		if (this.#state.closed.peek() !== undefined) return;
 		this.#state.closed.set(abort ?? null);
 
+		// An abort takes the group's content with it, so it is gone as well as closed. A clean
+		// finish is not: the group stays fetchable until the cache drops it (see {@link evict}).
+		if (abort) markGone(this.#state, abort);
+
 		if (this.#mirrors) {
 			for (const mirror of this.#mirrors) {
+				if (abort) markGone(mirror, abort);
 				if (mirror.closed.peek() === undefined) mirror.closed.set(abort ?? null);
 			}
 			this.#mirrors.clear();
+		}
+	}
+
+	/**
+	 * Mark the group gone: it has left the publisher's cache, so nothing can fetch it any more.
+	 *
+	 * Separate from {@link close}, which ends the frame stream but leaves the group replayable.
+	 * Releases the buffered frames as well as settling the signal, so a handle held purely to watch
+	 * availability (an index track) does not pin the media it is no longer allowed to point at.
+	 *
+	 * @internal Track cache eviction only.
+	 */
+	evict(): void {
+		markGone(this.#state, null);
+		releaseFrames(this.#state);
+
+		if (this.#mirrors) {
+			for (const mirror of this.#mirrors) markGone(mirror, null);
 		}
 	}
 }
@@ -247,6 +300,24 @@ export class Consumer {
 	 */
 	get closed(): GetPromise<Error | null> {
 		return this.#state.closed;
+	}
+
+	/**
+	 * Settles once the group is gone: dropped from the publisher's cache, evicted, or aborted.
+	 * `null` when it simply aged out, or the abort {@link Error}.
+	 *
+	 * This is availability, not completion: a group that finished cleanly stays unsettled here
+	 * while it is still cached and fetchable, and settles once it is not. An index track (a
+	 * timeline, a playlist) watches this to learn which groups it can still point at. Holding a
+	 * {@link Consumer} does not keep the group's frames alive, so watching is free.
+	 */
+	get gone(): GetPromise<Error | null> {
+		return this.#state.gone;
+	}
+
+	/** True once the group is gone. Synchronous complement to the {@link gone} promise. */
+	get isGone(): boolean {
+		return this.#state.gone.peek() !== undefined;
 	}
 
 	static {

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -205,3 +205,58 @@ test("readFrame does not livelock when a sole group finishes before the next arr
 
 	expect(await track.readString()).toBe("hello");
 }, 2000);
+
+test("eviction marks a group gone, a clean finish does not", async () => {
+	// `closed` is completion and `gone` is availability: a finished group stays fetchable from the
+	// cache until it ages out. An index track (a timeline, a playlist) watches `gone` to learn what
+	// it can still point at.
+	const producer = new TrackProducer("test").accept({ latencyMax: 0 });
+
+	const first = producer.appendGroup();
+	const watching = first.consume();
+	first.writeFrame({ payload: enc.encode("hello"), timestamp: Timestamp.now() });
+	first.close();
+
+	// Finished, but nothing has pruned the cache yet, so it is still fetchable.
+	expect(watching.isClosed).toBe(true);
+	expect(watching.isGone).toBe(false);
+
+	// The cache is pruned as the next group is published. With a zero latency window the finished
+	// group is immediately past the cutoff.
+	producer.appendGroup();
+	expect(watching.isGone).toBe(true);
+	expect(await watching.gone).toBe(null);
+});
+
+test("an aborted group is gone as well as closed", async () => {
+	const producer = new TrackProducer("test").accept();
+
+	const group = producer.appendGroup();
+	const watching = group.consume();
+
+	const abort = new Error("boom");
+	group.close(abort);
+
+	expect(watching.isGone).toBe(true);
+	expect(await watching.gone).toBe(abort);
+});
+
+test("eviction releases the frames a watching handle would otherwise pin", async () => {
+	// An index track holds a consumer purely to watch `gone`. Eviction has to drop the payloads
+	// too, or watching an idle publisher's timeline keeps every evicted group's media alive.
+	const producer = new TrackProducer("test").accept({ latencyMax: 0 });
+
+	const first = producer.appendGroup();
+	const watching = first.consume();
+	first.writeFrame({ payload: enc.encode("payload"), timestamp: Timestamp.now() });
+	first.close();
+
+	// Pruning runs when a late subscriber attaches, not only when the publisher writes.
+	producer.subscribe();
+
+	expect(watching.isGone).toBe(true);
+	// The buffer is empty, and the unread frame is reported as a gap rather than a clean finish.
+	expect(watching.skipped).toBe(true);
+	expect(watching.tryReadFrame()).toBeUndefined();
+	expect(watching.readFrame()).rejects.toThrow("lagged");
+});

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -390,6 +390,11 @@ export class Producer {
 				continue;
 			}
 
+			// Mark the source and its mirrors gone before dropping them, so an index track holding
+			// a consumer learns the group stopped being fetchable. Done first: closing a mirror
+			// detaches it from the source, which would leave it unmarked.
+			entry.group.evict();
+
 			for (const [sink, mirror] of entry.mirrors) {
 				sink.groups.mutate((groups) => {
 					const i = groups.indexOf(mirror);
@@ -641,6 +646,28 @@ export class Subscriber {
 	async nextGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
 			const group = await this.recvGroup();
+			if (!group) return undefined;
+			if (group.sequence < this.#nextSequence) {
+				group.close();
+				continue;
+			}
+			this.#nextSequence = group.sequence + 1;
+			return group;
+		}
+	}
+
+	/**
+	 * Take the next group only if one is already buffered, otherwise `undefined`.
+	 *
+	 * The non-blocking counterpart to {@link nextGroup}, mirroring {@link GroupConsumer.tryReadFrame}.
+	 * A reader whose groups are each self-contained (a snapshot or window track) drains with this to
+	 * reach the newest buffered group, so a late joiner starts from current state instead of
+	 * replaying every cached group.
+	 */
+	tryNextGroup(): GroupConsumer | undefined {
+		for (;;) {
+			const groups = this.#state.groups.peek();
+			const group = groups.shift();
 			if (!group) return undefined;
 			if (group.sequence < this.#nextSequence) {
 				group.close();

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -318,8 +318,15 @@ async fn watch(
 	renditions: &renditions::Fanout,
 ) -> crate::Result<()> {
 	let mut timeline = moq_mux::timeline::Consumer::<()>::subscribe(broadcast, section).await?;
-	while let Some(entry) = timeline.next().await? {
-		renditions.push(entry);
+	while let Some(update) = timeline.next().await? {
+		match update {
+			moq_mux::timeline::Update::Append { entry } => renditions.push(entry),
+			// The publisher dropped this media from its cache, so it can no longer be fetched:
+			// drop it from the playlists rather than advertising segments that would 404.
+			moq_mux::timeline::Update::Trim { segment } => renditions.trim(segment),
+			// A change a later revision added; the window it describes is unaffected.
+			_ => {}
+		}
 	}
 	Ok(())
 }

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -149,6 +149,12 @@ impl Rendition {
 		self.live.push(row, window);
 	}
 
+	/// Drop every segment below `segment` from this rendition's window: the publisher's cache
+	/// no longer holds their media. See [`segments::Producer::trim`].
+	pub(crate) fn trim(&self, segment: u64) {
+		self.live.trim(segment);
+	}
+
 	/// Mark this rendition's window ended (the timeline finished cleanly).
 	pub(crate) fn end(&self) {
 		self.live.end();

--- a/rs/moq-hls/src/export/renditions.rs
+++ b/rs/moq-hls/src/export/renditions.rs
@@ -214,6 +214,31 @@ impl Fanout {
 		});
 	}
 
+	/// Drop every segment below `segment` from the replay history and from every living
+	/// rendition: the publisher's cache no longer has them.
+	///
+	/// Applied to the history as well as the live windows so a rendition that attaches later
+	/// replays the same window a live one holds, rather than being seeded with segments that are
+	/// already unfetchable.
+	pub fn trim(&self, segment: u64) {
+		let mut feed = self.feed.lock().unwrap();
+
+		while feed.history.front().is_some_and(|entry| entry.segment < segment) {
+			feed.history.pop_front();
+		}
+		if feed.history.is_empty() {
+			feed.anchor = None;
+		}
+
+		feed.targets.retain(|target| {
+			let Some(rendition) = target.upgrade() else {
+				return false;
+			};
+			rendition.trim(segment);
+			true
+		});
+	}
+
 	/// Mark every living rendition's window ended (the timeline finished cleanly).
 	pub fn end_windows(&self) {
 		let mut feed = self.feed.lock().unwrap();

--- a/rs/moq-hls/src/export/renditions.rs
+++ b/rs/moq-hls/src/export/renditions.rs
@@ -220,14 +220,18 @@ impl Fanout {
 	/// Applied to the history as well as the live windows so a rendition that attaches later
 	/// replays the same window a live one holds, rather than being seeded with segments that are
 	/// already unfetchable.
+	///
+	/// [`Feed::anchor`] survives, including a retraction that empties the history. It maps the pts
+	/// axis onto wall clock, and a retraction says nothing about that axis: only a timeline restart
+	/// invalidates it. Re-anchoring would re-estimate from a fresh `now()` and jump every client's
+	/// `EXT-X-PROGRAM-DATE-TIME` over unchanged content, worst of all here, since a retraction deep
+	/// enough to empty the history means the publisher is shedding media and its "this segment just
+	/// ended" assumption is at its least true.
 	pub fn trim(&self, segment: u64) {
 		let mut feed = self.feed.lock().unwrap();
 
 		while feed.history.front().is_some_and(|entry| entry.segment < segment) {
 			feed.history.pop_front();
-		}
-		if feed.history.is_empty() {
-			feed.anchor = None;
 		}
 
 		feed.targets.retain(|target| {
@@ -423,4 +427,60 @@ fn next_event(current: &BTreeMap<Key, Arc<Rendition>>, seen: &BTreeMap<Key, Arc<
 		}
 	}
 	Poll::Pending
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn entry(segment: u64, pts_ms: u64, duration_ms: u64) -> Entry {
+		Entry {
+			segment,
+			pts: moq_net::Timestamp::from_millis(pts_ms).unwrap(),
+			duration: Duration::from_millis(duration_ms),
+			tracks: BTreeMap::new(),
+			ext: (),
+		}
+	}
+
+	/// The wall-clock anchor maps the pts axis onto real time, and a retraction does not move that
+	/// axis. It must therefore survive a trim, including one deep enough to empty the history:
+	/// re-anchoring would re-estimate from a fresh `now()` and jump `EXT-X-PROGRAM-DATE-TIME` (and
+	/// DASH `availabilityStartTime`) for every client following unchanged content.
+	#[test]
+	fn a_trim_keeps_the_wall_clock_anchor() {
+		let producer = Producer::new(Duration::from_secs(30));
+		let fanout = producer.fanout();
+
+		fanout.push(entry(0, 0, 2_000));
+		fanout.push(entry(1, 2_000, 2_000));
+		let anchored = producer.anchor().expect("the first record anchors");
+
+		// A retraction that outruns everything listed: the history empties.
+		fanout.trim(9);
+		assert!(fanout.feed.lock().unwrap().history.is_empty());
+		assert_eq!(
+			producer.anchor(),
+			Some(anchored),
+			"a retraction is not a timeline restart"
+		);
+
+		// The next record lands on the same axis, so it must not re-anchor either.
+		fanout.push(entry(9, 18_000, 2_000));
+		assert_eq!(producer.anchor(), Some(anchored));
+	}
+
+	/// The contrast case, and the only thing that legitimately drops the anchor: a publisher that
+	/// restarts rewinds pts, so the old mapping genuinely no longer describes the new content.
+	#[test]
+	fn a_backwards_jump_still_reanchors() {
+		let producer = Producer::new(Duration::from_secs(30));
+		let fanout = producer.fanout();
+
+		fanout.push(entry(0, 600_000, 2_000));
+		let anchored = producer.anchor().expect("the first record anchors");
+
+		fanout.push(entry(0, 0, 2_000));
+		assert_ne!(producer.anchor(), Some(anchored), "a restart re-anchors");
+	}
 }

--- a/rs/moq-hls/src/export/segments.rs
+++ b/rs/moq-hls/src/export/segments.rs
@@ -157,6 +157,22 @@ impl Producer {
 		}
 	}
 
+	/// Drop every listed segment numbered below `segment`: the publisher no longer holds their
+	/// media, so a client following the playlist would fetch a 404.
+	///
+	/// This is the hard bound on the window, where the configured duration is only a preference:
+	/// the duration says how much history to *keep*, a retraction says what is *gone*, so
+	/// whichever removes more wins. `EXT-X-MEDIA-SEQUENCE` reads off the front of the window and
+	/// this only ever pops from the front, so it advances and never rewinds.
+	pub fn trim(&self, segment: u64) {
+		let Ok(mut state) = self.state.write() else {
+			return;
+		};
+		while state.rows.front().is_some_and(|row| row.segment < segment) {
+			state.rows.pop_front();
+		}
+	}
+
 	/// Mark the timeline ended (the broadcast finished cleanly): the playlist gets
 	/// `EXT-X-ENDLIST` and cursors end once drained.
 	pub fn end(&self) {
@@ -471,5 +487,77 @@ mod tests {
 
 		live.end();
 		assert!(matches!(live.state.read().next_after(Some(1)), Next::Ended));
+	}
+
+	/// A retraction drops segments the publisher can no longer serve, so the playlist stops
+	/// advertising fetches that would 404. This is the hard bound: the duration window would
+	/// have kept all three.
+	#[test]
+	fn a_trim_drops_unfetchable_segments() {
+		let live = Producer::new();
+		let window = Duration::from_secs(30);
+		live.push(row(0, 0, 0, 2_000), window);
+		live.push(row(1, 1, 2_000, 2_000), window);
+		live.push(row(2, 2, 4_000, 2_000), window);
+		assert_eq!(live.window().segments.len(), 3);
+
+		live.trim(2);
+
+		let snapshot = live.window();
+		assert_eq!(snapshot.segments.len(), 1, "only segment 2 is still fetchable");
+		assert_eq!(snapshot.segments[0].segment, 2);
+		assert_eq!(snapshot.sequence, 2, "EXT-X-MEDIA-SEQUENCE follows the head");
+	}
+
+	/// `EXT-X-MEDIA-SEQUENCE` must never go backwards: a client that saw sequence N and then
+	/// sees it again over different content reloads into the wrong place. A stale or repeated
+	/// retraction is therefore a no-op rather than a rewind.
+	#[test]
+	fn a_trim_never_rewinds_the_media_sequence() {
+		let live = Producer::new();
+		let window = Duration::from_secs(30);
+		live.push(row(0, 0, 0, 2_000), window);
+		live.push(row(1, 1, 2_000, 2_000), window);
+		live.push(row(2, 2, 4_000, 2_000), window);
+
+		live.trim(2);
+		assert_eq!(live.window().sequence, 2);
+
+		// An older retraction arriving late, and a repeat of the current one.
+		live.trim(1);
+		live.trim(2);
+		assert_eq!(live.window().sequence, 2, "the head stayed put");
+		assert_eq!(live.window().segments.len(), 1);
+	}
+
+	/// A retraction can outrun what this playlist ever listed (it joined late, or its own
+	/// duration window already evicted them). Everything goes, and the window is empty rather
+	/// than listing something unfetchable.
+	#[test]
+	fn a_trim_past_the_window_empties_it() {
+		let live = Producer::new();
+		let window = Duration::from_secs(30);
+		live.push(row(0, 0, 0, 2_000), window);
+		live.push(row(1, 1, 2_000, 2_000), window);
+
+		live.trim(9);
+
+		let snapshot = live.window();
+		assert!(snapshot.segments.is_empty());
+		assert_eq!(snapshot.sequence, 0, "an empty window has no head to report");
+	}
+
+	/// The duration window stays a preference on top: whichever of the two removes more wins.
+	#[test]
+	fn the_duration_window_still_evicts_after_a_trim() {
+		let live = Producer::new();
+		let window = Duration::from_secs(3);
+		live.push(row(0, 0, 0, 2_000), window);
+		live.push(row(1, 1, 2_000, 2_000), window);
+		live.push(row(2, 2, 4_000, 2_000), window);
+
+		// Nothing was retracted, so the duration bound is what trimmed the front.
+		live.trim(0);
+		assert_eq!(live.window().segments.first().unwrap().segment, 1);
 	}
 }

--- a/rs/moq-json/Cargo.toml
+++ b/rs/moq-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moq-json"
-description = "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, or append-log record streams."
+description = "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, append-log record streams, or sliding windows."
 authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ kio = { workspace = true }
 moq-flate = { workspace = true }
 moq-net = { workspace = true }
 serde = { workspace = true }
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 serde_path_to_error = "0.1"
 thiserror = "2"
 tracing = "0.1"

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -4,19 +4,26 @@
 //!   recent value. Intermediate updates are collapsed and older groups are dropped.
 //! - [`stream`]: **lossless**. An ordered append-log of self-contained records; every record is
 //!   preserved and delivered in order, nothing is ever superseded.
+//! - [`window`]: **sliding**. An ordered log that appends at the tail and removes from the head,
+//!   like an HLS playlist. Records carry stable positions and old groups are disposable.
 //!
 //! Pick [`snapshot`] when consumers care about "what is the value now" (a catalog, a status
-//! document) and [`stream`] when they care about every record (an event log, a media timeline).
+//! document), [`stream`] when they care about every record ever written (an event log), and
+//! [`window`] when records expire (a media timeline over a bounded cache).
 //!
-//! Each mode comes in two layers. `Producer`/`Consumer` own a [`moq_net`] track and manage its
-//! groups. `Encoder`/`Decoder` are the same logic without the track: values in, frame payloads out
-//! (and back), with the encoder saying where the group boundaries fall. Reach for the codec layer
-//! when something else already owns the track, such as a `moq_mux::container::Producer` also
-//! managing a timeline and a catalog estimate.
+//! [`snapshot`] and [`stream`] each come in two layers. `Producer`/`Consumer` own a [`moq_net`]
+//! track and manage its groups. `Encoder`/`Decoder` are the same logic without the track: values
+//! in, frame payloads out (and back), with the encoder saying where the group boundaries fall.
+//! Reach for the codec layer when something else already owns the track, such as a
+//! `moq_mux::container::Producer` also managing a timeline and a catalog estimate.
+//!
+//! [`window`] is the one layer: where its groups roll follows from its own trim history, so it
+//! owns the track outright.
 
 mod diff;
 pub mod snapshot;
 pub mod stream;
+pub mod window;
 
 pub use crate::diff::{Diff, diff};
 
@@ -37,6 +44,11 @@ pub enum Error {
 	/// A compressed frame could not be decoded (malformed, truncated, or oversized).
 	#[error(transparent)]
 	Flate(#[from] moq_flate::Error),
+
+	/// A [`window`] operation is inconsistent with the window it applies to, such as a trim
+	/// reaching past the oldest record.
+	#[error("invalid window update: {0}")]
+	Window(String),
 
 	/// A merge patch arrived with no snapshot to apply it to.
 	///

--- a/rs/moq-json/src/window.rs
+++ b/rs/moq-json/src/window.rs
@@ -1,0 +1,1323 @@
+//! Sliding-window JSON publishing over [`moq-net`](moq_net) tracks.
+//!
+//! An ordered log that grows at the tail and shrinks at the head, like an HLS media playlist:
+//! [`Producer::append`] adds a record as content becomes available and [`Producer::trim`] drops
+//! records from the head as it stops being available. The counterpart to [`stream`](crate::stream),
+//! which only ever appends, and to [`snapshot`](crate::snapshot), which keeps no history at all.
+//!
+//! Every record has a stable **position**: the count of records ever appended before it. Positions
+//! never repeat, so a record is identified across group rolls and trims, exactly like an HLS media
+//! sequence number.
+//!
+//! On the wire each group is self-contained. Frame 0 is a snapshot of the live window
+//! (`{"offset":N,"values":[...]}`) and each later frame is one operation (`{"append":V}` or
+//! `{"trim":N}`). A new group rolls once the records trimmed since the snapshot outnumber those
+//! still in the window, which bounds the total bytes at roughly twice an append-only log while
+//! keeping every group independently readable.
+//!
+//! That rolling is what a [`stream`](crate::stream) track cannot do: its whole log rides one group,
+//! so a consumer always starts at frame 0 and the track breaks (with
+//! [`moq_net::Error::Lagged`]) once the earliest frames age out. Here a late joiner reads the
+//! *newest* group and needs nothing older, so old groups can be dropped freely.
+
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
+use std::task::Poll;
+
+use bytes::Bytes;
+use moq_flate::{Decoder, Encoder};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+use crate::{Error, Result};
+
+/// Maximum frames (snapshot plus operations) in one group before a snapshot is forced.
+///
+/// Kept well below moq-net's per-group frame cap so a late joiner can always read the snapshot at
+/// frame 0 before the group is evicted.
+const MAX_GROUP_FRAMES: usize = 256;
+
+/// The largest position the wire format allows: 2^53-1.
+///
+/// The bound comes from the format, not from Rust: a receiver whose JSON numbers are IEEE 754
+/// doubles (the usual case, and what the JS implementation uses) counts exactly only up to here.
+/// Enforcing it also keeps the tail arithmetic well clear of a `u64` overflow, which would panic in
+/// debug and silently wrap every later position in release.
+const MAX_POSITION: u64 = (1 << 53) - 1;
+
+/// Configuration for a window [`Producer`].
+///
+/// Build from [`Default`] and override fields (the struct is `#[non_exhaustive]`, so new options
+/// stay additive), or chain the `with_*` setters.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ProducerConfig {
+	/// Compress each group as one sync-flushed DEFLATE stream, so operations reuse the snapshot as
+	/// context and shrink sharply.
+	///
+	/// `false` (the default) writes plaintext JSON frames. A [`Consumer`] reading the track must set
+	/// [`ConsumerConfig::compression`] to match.
+	pub compression: bool,
+}
+
+impl ProducerConfig {
+	/// Set [`compression`](Self::compression) (a builder, since the struct is `#[non_exhaustive]`).
+	pub fn with_compression(mut self, compression: bool) -> Self {
+		self.compression = compression;
+		self
+	}
+}
+
+/// Configuration for a window [`Consumer`].
+///
+/// Build from [`Default`] and override fields (the struct is `#[non_exhaustive]`, so new options
+/// stay additive), or chain the `with_*` setters.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ConsumerConfig {
+	/// Whether the track's frames are DEFLATE-compressed. Must match the producer's
+	/// [`ProducerConfig::compression`]. Defaults to `false`.
+	pub compression: bool,
+}
+
+impl ConsumerConfig {
+	/// Set [`compression`](Self::compression) (a builder, since the struct is `#[non_exhaustive]`).
+	pub fn with_compression(mut self, compression: bool) -> Self {
+		self.compression = compression;
+		self
+	}
+}
+
+/// The snapshot at frame 0 of every group, as written.
+#[derive(Serialize)]
+struct SnapshotOut<'a> {
+	offset: u64,
+	values: &'a VecDeque<Box<RawValue>>,
+}
+
+/// An append operation, as written.
+#[derive(Serialize)]
+struct AppendOut<'a> {
+	append: &'a RawValue,
+}
+
+/// A trim operation, as written.
+#[derive(Serialize)]
+struct TrimOut {
+	trim: usize,
+}
+
+/// The snapshot at frame 0 of every group, as read.
+///
+/// Values stay raw so only the records the consumer hasn't already seen are deserialized.
+#[derive(Deserialize)]
+struct SnapshotIn {
+	offset: u64,
+	values: Vec<Box<RawValue>>,
+}
+
+/// One operation frame, as read. Unknown members are ignored, so a frame carrying neither key is a
+/// no-op rather than an error (a forward-compatible extension).
+#[derive(Deserialize)]
+struct OpIn {
+	#[serde(default, deserialize_with = "present")]
+	append: Option<Box<RawValue>>,
+	#[serde(default, deserialize_with = "present")]
+	trim: Option<usize>,
+}
+
+/// Deserialize a *present* member into `Some`, even when its value is JSON `null`.
+///
+/// A plain `Option` collapses an explicit null into `None`, which would make an appended `null`
+/// record indistinguishable from an absent `append` member: the record would be dropped and, worse,
+/// the tail would not advance, shifting every later position in the group. A snapshot preserves a
+/// null record (its values decode as raw JSON), so without this the same record survives a group
+/// roll but vanishes as an append.
+fn present<'de, D, T>(deserializer: D) -> std::result::Result<Option<T>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+	T: Deserialize<'de>,
+{
+	T::deserialize(deserializer).map(Some)
+}
+
+/// Publishes a sliding window of JSON records over a track.
+///
+/// Cheaply clonable: clones share one underlying track and window state, so several owners append
+/// into a single ordered log.
+pub struct Producer<T> {
+	inner: Arc<Mutex<Inner>>,
+	_marker: PhantomData<fn(T)>,
+}
+
+impl<T> Clone for Producer<T> {
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<T> Producer<T> {
+	/// Create a subscriber for the underlying track.
+	pub fn consume(&self) -> moq_net::track::Subscriber {
+		self.inner.lock().unwrap().track.subscribe(None)
+	}
+
+	/// The position of the oldest record still in the window: the number of records trimmed over
+	/// the log's lifetime.
+	pub fn offset(&self) -> u64 {
+		self.inner.lock().unwrap().offset
+	}
+
+	/// The number of records currently in the window.
+	pub fn len(&self) -> usize {
+		self.inner.lock().unwrap().window.len()
+	}
+
+	/// Whether the window is empty.
+	pub fn is_empty(&self) -> bool {
+		self.len() == 0
+	}
+}
+
+impl<T: Serialize> Producer<T> {
+	/// Create a producer that publishes to the given track.
+	pub fn new(track: moq_net::track::Producer, config: ProducerConfig) -> Self {
+		Self {
+			inner: Arc::new(Mutex::new(Inner {
+				track,
+				group: None,
+				encoder: None,
+				window: VecDeque::new(),
+				offset: 0,
+				trimmed: 0,
+				frames: 0,
+				config,
+			})),
+			_marker: PhantomData,
+		}
+	}
+
+	/// Append one record to the tail of the window, returning the position it was assigned.
+	pub fn append(&mut self, value: &T) -> Result<u64> {
+		self.inner.lock().unwrap().append(value)
+	}
+
+	/// Remove the oldest `count` records from the head of the window.
+	///
+	/// A `count` of 0 does nothing. Errors if it exceeds the number of records in the window, since
+	/// trimming past the head would desync every consumer's positions.
+	pub fn trim(&mut self, count: usize) -> Result<()> {
+		self.inner.lock().unwrap().trim(count)
+	}
+
+	/// Finish the track, closing any open group.
+	pub fn finish(&mut self) -> Result<()> {
+		self.inner.lock().unwrap().finish()
+	}
+}
+
+/// Shared publishing state behind [`Producer`]'s `Arc<Mutex>`.
+struct Inner {
+	track: moq_net::track::Producer,
+	group: Option<moq_net::group::Producer>,
+	// The open group's DEFLATE encoder (one window per group), `Some` while compressing.
+	encoder: Option<Encoder>,
+	// Every record currently in the window, oldest first, kept so a new group can snapshot it.
+	window: VecDeque<Box<RawValue>>,
+	// The position of `window[0]`: how many records have been trimmed for the log's lifetime.
+	offset: u64,
+	// Records trimmed since the open group's snapshot, the roll trigger.
+	trimmed: usize,
+	frames: usize,
+	config: ProducerConfig,
+}
+
+impl Inner {
+	fn append<T: Serialize>(&mut self, value: &T) -> Result<u64> {
+		let raw = serde_json::value::to_raw_value(value)?;
+		let position = self.offset + self.window.len() as u64;
+		// Refuse to publish a position a consumer would reject: the window would be unreadable.
+		if position >= MAX_POSITION {
+			return Err(Error::Window(format!(
+				"append at position {position} reaches the maximum {MAX_POSITION}"
+			)));
+		}
+		self.window.push_back(raw);
+
+		let published = if self.needs_snapshot() {
+			self.snapshot()
+		} else {
+			// The record was just pushed, so the back is the one to advertise.
+			serde_json::to_vec(&AppendOut {
+				append: self.window.back().expect("just pushed"),
+			})
+			.map_err(Error::from)
+			.and_then(|payload| self.write(payload))
+		};
+
+		match published {
+			Ok(()) => Ok(position),
+			Err(err) => {
+				// A publish that failed (a finished or aborted track) must leave the window as it
+				// was: `offset`, `len`, and the next position all read from it, so keeping a record
+				// nobody received would report a window that does not exist.
+				self.window.pop_back();
+				Err(err)
+			}
+		}
+	}
+
+	fn trim(&mut self, count: usize) -> Result<()> {
+		if count == 0 {
+			return Ok(());
+		}
+		if count > self.window.len() {
+			return Err(Error::Window(format!(
+				"trim of {count} exceeds the {} records in the window",
+				self.window.len()
+			)));
+		}
+
+		let removed: Vec<Box<RawValue>> = self.window.drain(..count).collect();
+		self.offset += count as u64;
+		self.trimmed += count;
+
+		let published = if self.needs_snapshot() {
+			self.snapshot()
+		} else {
+			serde_json::to_vec(&TrimOut { trim: count })
+				.map_err(Error::from)
+				.and_then(|payload| self.write(payload))
+		};
+
+		if let Err(err) = published {
+			// Same rollback as `append`: an unpublished trim must not move the head.
+			self.offset -= count as u64;
+			self.trimmed -= count;
+			for raw in removed.into_iter().rev() {
+				self.window.push_front(raw);
+			}
+			return Err(err);
+		}
+		Ok(())
+	}
+
+	/// Whether the next operation should roll a fresh snapshot group instead.
+	///
+	/// Rolls once the records trimmed since the snapshot outnumber those still in the window: the
+	/// group is then mostly dead weight for a new subscriber, and a fresh snapshot costs no more
+	/// than what has already been trimmed. That bounds the total bytes at roughly twice an
+	/// append-only log.
+	fn needs_snapshot(&self) -> bool {
+		self.group.is_none() || self.frames >= MAX_GROUP_FRAMES || self.trimmed > self.window.len()
+	}
+
+	/// Start a new group whose frame 0 snapshots the whole window.
+	fn snapshot(&mut self) -> Result<()> {
+		let payload = serde_json::to_vec(&SnapshotOut {
+			offset: self.offset,
+			values: &self.window,
+		})?;
+
+		// The previous group is complete; no more frames will be appended to it.
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+
+		let mut group = self.track.append_group()?;
+		let (slice, encoder) = match self.config.compression {
+			true => {
+				let mut encoder = Encoder::new();
+				let slice = encoder.frame(&payload);
+				(slice, Some(encoder))
+			}
+			false => (Bytes::from(payload), None),
+		};
+		group.write_frame(moq_net::Timestamp::now(), slice)?;
+
+		self.group = Some(group);
+		self.encoder = encoder;
+		self.frames = 1;
+		self.trimmed = 0;
+		Ok(())
+	}
+
+	/// Write one operation frame into the open group.
+	fn write(&mut self, payload: Vec<u8>) -> Result<()> {
+		let slice = match self.encoder.as_mut() {
+			Some(encoder) => encoder.frame(&payload),
+			None => Bytes::from(payload),
+		};
+		self.group
+			.as_mut()
+			.expect("needs_snapshot guarantees an open group")
+			.write_frame(moq_net::Timestamp::now(), slice)?;
+		self.frames += 1;
+		Ok(())
+	}
+
+	fn finish(&mut self) -> Result<()> {
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+		self.track.finish()?;
+		Ok(())
+	}
+}
+
+/// One change to the window, yielded by a [`Consumer`].
+///
+/// `#[non_exhaustive]` because the wire format is explicitly extensible: a frame carrying an
+/// operation this revision does not know is ignored rather than rejected, so a later revision can
+/// add one. Match with a wildcard arm and skip what you don't recognize.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum Update<T> {
+	/// A record was appended at the tail.
+	Append {
+		/// The record's position: the count of records ever appended before it.
+		position: u64,
+		/// The record itself.
+		value: T,
+	},
+
+	/// Records were removed from the head; everything before `offset` is gone.
+	Trim {
+		/// The position of the oldest record still in the window.
+		offset: u64,
+	},
+}
+
+/// Reads a sliding window of JSON records from a track, yielding each change in order.
+///
+/// Starts at the newest group's snapshot, so a late joiner sees an [`Update::Append`] per record
+/// currently in the window and then follows along live. Switching to a newer group is lossless:
+/// positions identify what has already been yielded, so records are never repeated.
+///
+/// [`Update::Trim`] only ever retracts records this consumer was told about, so joining a window
+/// that has already trimmed does not report the records it missed. Those show up instead as a
+/// jump in the first [`Update::Append`]'s `position`; whether a gap matters is up to the
+/// application.
+pub struct Consumer<T> {
+	track: moq_net::track::Subscriber,
+	group: Option<moq_net::group::Consumer>,
+	compressed: bool,
+	// The open group's DEFLATE decoder (one window per group), built on its first frame.
+	decoder: Option<Decoder>,
+	// Frames read from the open group; frame 0 is its snapshot.
+	frames: usize,
+	// The position of the next record this consumer has not yielded yet.
+	next: u64,
+	// The head offset already reported through an `Update::Trim`, or `None` until the first
+	// snapshot establishes where this consumer joined.
+	reported: Option<u64>,
+	// The head offset of the group being followed, advanced by its trims.
+	head: u64,
+	// The position one past the last record the group being followed has appended.
+	tail: u64,
+	// Updates decoded but not yet yielded; one poll can decode a whole snapshot.
+	pending: VecDeque<Update<T>>,
+	_marker: PhantomData<fn() -> T>,
+}
+
+impl<T: DeserializeOwned> Consumer<T> {
+	/// Create a consumer reading from the given track subscriber.
+	///
+	/// Set [`ConsumerConfig::compression`] to read a track written by a producer with
+	/// [`ProducerConfig::compression`] on.
+	pub fn new(track: moq_net::track::Subscriber, config: ConsumerConfig) -> Self {
+		Self {
+			track,
+			group: None,
+			compressed: config.compression,
+			decoder: None,
+			frames: 0,
+			next: 0,
+			reported: None,
+			head: 0,
+			tail: 0,
+			pending: VecDeque::new(),
+			_marker: PhantomData,
+		}
+	}
+
+	/// Get the next update, or `None` once the track ends.
+	pub async fn next(&mut self) -> Result<Option<Update<T>>>
+	where
+		T: Unpin,
+	{
+		kio::wait(|waiter| self.poll_next(waiter)).await
+	}
+
+	/// Poll for the next update, without blocking.
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Update<T>>>> {
+		loop {
+			if let Some(update) = self.pending.pop_front() {
+				return Poll::Ready(Ok(Some(update)));
+			}
+
+			// Skip to the newest group; anything older carries nothing it lacks.
+			let track_finished = loop {
+				match self.track.poll_next_group(waiter)? {
+					Poll::Ready(Some(group)) => {
+						self.group = Some(group);
+						self.decoder = None;
+						self.frames = 0;
+					}
+					Poll::Ready(None) => break true,
+					Poll::Pending => break false,
+				}
+			};
+
+			// Decode frames until something is ready to yield, or the group blocks or ends.
+			let mut group_ended = false;
+			let mut group_pending = false;
+			while self.pending.is_empty() {
+				let Some(group) = &mut self.group else { break };
+				match group.poll_read_frame(waiter) {
+					Poll::Ready(Ok(Some(frame))) => self.apply(frame.payload)?,
+					Poll::Ready(Ok(None)) => {
+						// Every group opens with a snapshot, so one that ends cleanly having
+						// delivered nothing is malformed. Treating it as an ordinary end would let
+						// it masquerade as a clean end of track and silently lose the window the
+						// publisher advertised. (A group that *errors* before frame 0 is a different
+						// case: that is a lost group, handled below as a resync.)
+						if self.frames == 0 {
+							return Poll::Ready(Err(Error::Window("a group carried no snapshot".to_string())));
+						}
+						self.group = None;
+						group_ended = true;
+						break;
+					}
+					// The group died under us: evicted, aged out, or read past its cache. Groups
+					// here are self-contained and disposable, so this is a resync point rather than
+					// the end of the track. Failing instead would strand a slow consumer (the HLS
+					// timeline watcher among them) on a track that is still publishing.
+					Poll::Ready(Err(err)) => {
+						tracing::debug!(%err, "window group lost; resyncing from the next snapshot");
+						self.group = None;
+						self.decoder = None;
+						group_ended = true;
+						break;
+					}
+					Poll::Pending => {
+						group_pending = true;
+						break;
+					}
+				}
+			}
+
+			if !self.pending.is_empty() {
+				continue;
+			}
+			// The group ended without yielding anything: loop once more to pick up a newer one.
+			// That poll either finds one or reports Pending, so this can't spin.
+			if group_ended {
+				continue;
+			}
+			// An open group may still deliver frames after the track finishes (it was appended
+			// before), so wait on it rather than ending the stream.
+			if group_pending || !track_finished {
+				return Poll::Pending;
+			}
+			return Poll::Ready(Ok(None));
+		}
+	}
+
+	/// Decompress a frame slice, or pass it through when the track is uncompressed.
+	fn decode(&mut self, slice: Bytes) -> Result<Bytes> {
+		if !self.compressed {
+			return Ok(slice);
+		}
+		let decoder = self.decoder.get_or_insert_with(Decoder::new);
+		Ok(decoder.frame(&slice)?)
+	}
+
+	/// Apply one frame: frame 0 of a group is a snapshot, the rest are operations.
+	fn apply(&mut self, frame: Bytes) -> Result<()> {
+		let frame = self.decode(frame)?;
+		match self.frames {
+			0 => self.apply_snapshot(&frame)?,
+			_ => self.apply_op(&frame)?,
+		}
+		self.frames += 1;
+		Ok(())
+	}
+
+	/// Adopt a group's snapshot, yielding only what this consumer hasn't seen.
+	fn apply_snapshot(&mut self, frame: &[u8]) -> Result<()> {
+		let snapshot: SnapshotIn = serde_json::from_slice(frame)?;
+
+		// A peer picks both the offset and the record count, so bound the whole span, not just the
+		// offset: an in-range offset with enough records still lands the tail past MAX_POSITION and
+		// yields positions the wire format (and a JSON-number receiver) cannot represent. The
+		// checked add also keeps a hostile offset from overflowing u64, which panics in debug and
+		// silently wraps every later position to zero in release.
+		let tail = snapshot
+			.offset
+			.checked_add(snapshot.values.len() as u64)
+			.filter(|tail| *tail <= MAX_POSITION);
+		let Some(tail) = tail else {
+			return Err(Error::Window(format!(
+				"snapshot at offset {} with {} records runs past the maximum position {MAX_POSITION}",
+				snapshot.offset,
+				snapshot.values.len()
+			)));
+		};
+
+		self.head = snapshot.offset;
+		self.tail = tail;
+		self.report_trim();
+
+		for (index, raw) in snapshot.values.into_iter().enumerate() {
+			let position = snapshot.offset + index as u64;
+			// Already yielded from an older group: the position is what makes the switch lossless.
+			if position < self.next {
+				continue;
+			}
+			self.push_append(position, &raw)?;
+		}
+		Ok(())
+	}
+
+	/// Apply one operation frame from the group being followed.
+	fn apply_op(&mut self, frame: &[u8]) -> Result<()> {
+		let op: OpIn = serde_json::from_slice(frame)?;
+
+		// A frame carries at most one operation. Applying both would append and retract in an order
+		// the format never defines, so reject it instead of guessing. A frame carrying *neither* is
+		// not an error: that is how an operation added by a later revision reads here.
+		if op.append.is_some() && op.trim.is_some() {
+			return Err(Error::Window("a frame carries both an append and a trim".to_string()));
+		}
+
+		if let Some(raw) = op.append {
+			let position = self.tail;
+			if position >= MAX_POSITION {
+				return Err(Error::Window(format!(
+					"append at position {position} reaches the maximum {MAX_POSITION}"
+				)));
+			}
+			self.tail += 1;
+			if position >= self.next {
+				self.push_append(position, &raw)?;
+			}
+		}
+
+		if let Some(count) = op.trim {
+			// A peer picks this count, so add with a checked op: `head + count` would otherwise
+			// overflow before the range test could reject it.
+			let count = count as u64;
+			let head = self.head.checked_add(count).filter(|head| *head <= self.tail);
+			let Some(head) = head else {
+				return Err(Error::Window(format!(
+					"trim of {count} exceeds the {} records in the window",
+					self.tail - self.head
+				)));
+			};
+			self.head = head;
+			self.report_trim();
+		}
+
+		Ok(())
+	}
+
+	/// Emit a trim if the followed group's head has moved past what was last reported.
+	///
+	/// A trim says "records you were told about are gone", so the first snapshot only adopts its
+	/// offset: a consumer joining a window that already trimmed never held those records, and
+	/// reporting them would be noise. Later movement is guarded too, since a newer group's snapshot
+	/// repeats a head this consumer already reported.
+	fn report_trim(&mut self) {
+		match self.reported {
+			None => self.reported = Some(self.head),
+			Some(reported) if self.head > reported => {
+				self.reported = Some(self.head);
+				self.pending.push_back(Update::Trim { offset: self.head });
+			}
+			Some(_) => {}
+		}
+	}
+
+	/// Deserialize a record and queue it, advancing the yield cursor past it.
+	fn push_append(&mut self, position: u64, raw: &RawValue) -> Result<()> {
+		let value = serde_json::from_str(raw.get())?;
+		self.next = position + 1;
+		self.pending.push_back(Update::Append { position, value });
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use serde_json::{Value, json};
+
+	fn producer(config: ProducerConfig) -> (Producer<Value>, moq_net::track::Subscriber) {
+		let track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let consumer = track.subscribe(None);
+		(Producer::new(track, config), consumer)
+	}
+
+	fn compressed() -> ProducerConfig {
+		ProducerConfig { compression: true }
+	}
+
+	fn consumer(track: moq_net::track::Subscriber, compression: bool) -> Consumer<Value> {
+		Consumer::new(track, ConsumerConfig { compression })
+	}
+
+	/// Drain every update currently available without blocking.
+	fn drain(mut consumer: Consumer<Value>) -> Vec<Update<Value>> {
+		let waiter = kio::Waiter::noop();
+		let mut out = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			out.push(update);
+		}
+		out
+	}
+
+	/// The records a consumer would hold after applying every update, as (position, value).
+	fn replay(updates: &[Update<Value>]) -> Vec<(u64, Value)> {
+		let mut records: Vec<(u64, Value)> = Vec::new();
+		for update in updates {
+			match update {
+				Update::Append { position, value } => records.push((*position, value.clone())),
+				Update::Trim { offset } => records.retain(|(position, _)| position >= offset),
+			}
+		}
+		records
+	}
+
+	fn append(position: u64, n: i64) -> Update<Value> {
+		Update::Append {
+			position,
+			value: json!({ "n": n }),
+		}
+	}
+
+	#[test]
+	fn appends_carry_positions() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..3 {
+			assert_eq!(producer.append(&json!({ "n": n })).unwrap(), n as u64);
+		}
+		producer.finish().unwrap();
+
+		assert_eq!(
+			drain(consumer(track, false)),
+			vec![append(0, 0), append(1, 1), append(2, 2)]
+		);
+	}
+
+	#[test]
+	fn trim_removes_from_the_head() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..4 {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+		producer.trim(2).unwrap();
+		assert_eq!(producer.offset(), 2);
+		assert_eq!(producer.len(), 2);
+		producer.finish().unwrap();
+
+		// A live consumer sees every append, then the trim.
+		let updates = drain(consumer(track, false));
+		assert_eq!(updates.last().unwrap(), &Update::Trim { offset: 2 });
+		assert_eq!(replay(&updates), vec![(2, json!({ "n": 2 })), (3, json!({ "n": 3 }))]);
+	}
+
+	#[test]
+	fn late_joiner_reads_the_window_not_the_history() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..6 {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+		producer.trim(4).unwrap();
+		producer.finish().unwrap();
+
+		// Only the surviving records, at their original positions: no trace of 0..4.
+		let updates = drain(consumer(track, false));
+		assert_eq!(updates, vec![append(4, 4), append(5, 5)]);
+	}
+
+	#[test]
+	fn a_failed_publish_leaves_the_window_untouched() {
+		// `finish` only borrows, since a `Producer` is a shared handle, so a later append is
+		// expressible. It must fail without moving the window: `offset`, `len`, and the next
+		// position all read from it, so a phantom record would report a window nobody received.
+		let (mut producer, _track) = producer(ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		assert!(matches!(producer.append(&json!({ "n": 2 })), Err(Error::Net(_))));
+		assert_eq!(producer.len(), 2, "a rejected append must not grow the window");
+		assert_eq!(producer.offset(), 0);
+
+		assert!(matches!(producer.trim(1), Err(Error::Net(_))));
+		assert_eq!(producer.len(), 2, "a rejected trim must not shrink the window");
+		assert_eq!(producer.offset(), 0, "a rejected trim must not move the head");
+	}
+
+	#[test]
+	fn trim_past_the_window_is_rejected() {
+		let (mut producer, _track) = producer(ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+		assert!(matches!(producer.trim(2), Err(Error::Window(_))));
+		// A rejected trim leaves the window untouched.
+		assert_eq!(producer.len(), 1);
+		assert_eq!(producer.offset(), 0);
+		// A zero trim is a no-op, not an error.
+		producer.trim(0).unwrap();
+	}
+
+	#[test]
+	fn heavy_trimming_rolls_a_group() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		// A steady sliding window of two records: append, append, then one in/one out.
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		for n in 2..12 {
+			producer.append(&json!({ "n": n })).unwrap();
+			producer.trim(1).unwrap();
+		}
+		producer.finish().unwrap();
+
+		// Trims outgrew the window repeatedly, so the log rolled instead of growing forever.
+		assert!(track.latest().unwrap() > 0, "a trimming window should roll groups");
+
+		// And a late joiner still reads exactly the live window.
+		let updates = drain(consumer(track, false));
+		assert_eq!(
+			replay(&updates),
+			vec![(10, json!({ "n": 10 })), (11, json!({ "n": 11 }))]
+		);
+	}
+
+	#[test]
+	fn frame_cap_rolls_a_group() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..=(MAX_GROUP_FRAMES as i64) {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(1), "the frame cap forces exactly one roll");
+		assert_eq!(drain(consumer(track, false)).len(), MAX_GROUP_FRAMES + 1);
+	}
+
+	#[test]
+	fn a_slow_consumer_converges_after_draining_a_stale_snapshot() {
+		// A snapshot queues its whole window at once, so a consumer can be mid-drain when a newer
+		// group rolls with the head already trimmed. Draining the stale queue first is correct: the
+		// records were real when the snapshot was written, and the newer snapshot's head retracts
+		// them on arrival, so the consumer converges on the live window without losing a record.
+		//
+		// Dropping the queue on the switch instead would lose records outright: `push_append`
+		// advances `next` when it *queues* a record, so the newer snapshot would skip every queued
+		// position as already yielded.
+		let (mut producer, track) = producer(ProducerConfig::default());
+		let waiter = kio::Waiter::noop();
+
+		for n in 0..6 {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+
+		// Join late, so frame 0 is a snapshot that queues the whole window in one go.
+		let mut consumer = consumer(track, false);
+		let first = consumer.poll_next(&waiter);
+		assert!(matches!(
+			first,
+			Poll::Ready(Ok(Some(Update::Append { position: 0, .. })))
+		));
+
+		// Roll a new group behind its back, trimming the head it is still holding queued.
+		for n in 6..12 {
+			producer.append(&json!({ "n": n })).unwrap();
+			producer.trim(1).unwrap();
+		}
+		producer.finish().unwrap();
+
+		let mut seen = vec![Update::Append {
+			position: 0,
+			value: json!({ "n": 0 }),
+		}];
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			seen.push(update);
+		}
+
+		let positions: Vec<u64> = seen
+			.iter()
+			.filter_map(|u| match u {
+				Update::Append { position, .. } => Some(*position),
+				Update::Trim { .. } => None,
+			})
+			.collect();
+
+		let mut sorted = positions.clone();
+		sorted.sort_unstable();
+		sorted.dedup();
+		assert_eq!(positions, sorted, "a position was repeated or went backwards");
+		assert_eq!(positions.first(), Some(&0), "the stale queue must still be delivered");
+		assert_eq!(positions.last(), Some(&11), "the newest record must arrive");
+
+		// And the retractions land, so the consumer ends up holding exactly the live window.
+		let held: Vec<u64> = replay(&seen).into_iter().map(|(position, _)| position).collect();
+		assert_eq!(held, vec![6, 7, 8, 9, 10, 11]);
+	}
+
+	#[test]
+	fn group_roll_is_lossless_for_a_live_consumer() {
+		// A consumer following live must not see a record twice when the producer rolls a group
+		// and re-snapshots the window it already holds.
+		let (mut producer, track) = producer(ProducerConfig::default());
+		let mut consumer = consumer(track, false);
+		let waiter = kio::Waiter::noop();
+
+		let mut seen = Vec::new();
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			seen.push(update);
+		}
+
+		// Force rolls while the consumer keeps up.
+		for n in 2..12 {
+			producer.append(&json!({ "n": n })).unwrap();
+			producer.trim(1).unwrap();
+			while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+				seen.push(update);
+			}
+		}
+		producer.finish().unwrap();
+
+		let positions: Vec<u64> = seen
+			.iter()
+			.filter_map(|u| match u {
+				Update::Append { position, .. } => Some(*position),
+				Update::Trim { .. } => None,
+			})
+			.collect();
+		let mut sorted = positions.clone();
+		sorted.dedup();
+		assert_eq!(positions, sorted, "a roll must not repeat a record: {positions:?}");
+		assert_eq!(positions, (0..12).collect::<Vec<_>>());
+		assert_eq!(replay(&seen), vec![(10, json!({ "n": 10 })), (11, json!({ "n": 11 }))]);
+	}
+
+	#[test]
+	fn late_joiner_sees_a_gap_as_a_position_jump() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..4 {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+		producer.trim(3).unwrap();
+
+		// Joining now, the first record seen is at position 3: the jump is the gap signal.
+		let updates = drain(consumer(track, false));
+		match updates.first().unwrap() {
+			Update::Append { position, .. } => assert_eq!(*position, 3),
+			other => panic!("expected an append, got {other:?}"),
+		}
+		producer.finish().unwrap();
+	}
+
+	#[test]
+	fn compressed_roundtrip() {
+		let (mut producer, track) = producer(compressed());
+		for n in 0..20 {
+			producer.append(&json!({ "group": n, "pts": n * 2_000 })).unwrap();
+		}
+		producer.trim(15).unwrap();
+		producer.finish().unwrap();
+
+		let updates = drain(consumer(track, true));
+		assert_eq!(replay(&updates).len(), 5);
+		assert_eq!(replay(&updates)[0].0, 15);
+	}
+
+	#[test]
+	fn compressed_window_shrinks_records() {
+		// The shared per-group window is the point: a repetitive record compresses to a fraction of
+		// its raw size once the snapshot has seeded the window.
+		let (mut producer, mut track) = producer(compressed());
+		for n in 0..8 {
+			producer.append(&json!({ "group": n, "pts": n * 2_000 })).unwrap();
+		}
+		producer.finish().unwrap();
+
+		let waiter = kio::Waiter::noop();
+		let Poll::Ready(Ok(Some(mut group))) = track.poll_next_group(&waiter) else {
+			panic!("expected a group");
+		};
+		let mut sizes = Vec::new();
+		while let Poll::Ready(Ok(Some(frame))) = group.poll_read_frame(&waiter) {
+			sizes.push(frame.payload.len());
+		}
+		assert_eq!(sizes.len(), 8, "one snapshot plus seven appends");
+
+		let raw = serde_json::to_vec(&json!({ "append": { "group": 7, "pts": 14_000 } }))
+			.unwrap()
+			.len();
+		assert!(
+			*sizes.last().unwrap() < raw / 2,
+			"windowed record {} should be far below its raw size {raw}",
+			sizes.last().unwrap()
+		);
+	}
+
+	#[test]
+	fn a_null_record_keeps_its_position() {
+		// `null` is a valid JSON record. If it decodes as "no append", the record is lost AND the
+		// tail stalls, shifting every later position. The snapshot path preserves it either way, so
+		// getting this wrong makes a record appear or vanish depending on which frame carried it.
+		let (mut producer, track) = producer(ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&Value::Null).unwrap();
+		producer.append(&json!({ "n": 2 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(
+			drain(consumer(track, false)),
+			vec![
+				append(0, 0),
+				Update::Append {
+					position: 1,
+					value: Value::Null
+				},
+				append(2, 2),
+			]
+		);
+	}
+
+	#[test]
+	fn a_null_record_appended_after_a_roll_keeps_its_position() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		producer.append(&Value::Null).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		producer.trim(1).unwrap();
+		producer.append(&json!({ "n": 2 })).unwrap();
+		// Trims now outnumber the window, so this rolls: the survivors come from a fresh snapshot.
+		producer.trim(1).unwrap();
+		producer.append(&Value::Null).unwrap();
+		producer.finish().unwrap();
+
+		// A late joiner starts at the newest group's snapshot (offset 2), then reads the null as an
+		// append. A stalled tail here would have put the null at position 2, colliding with `n: 2`.
+		assert_eq!(
+			drain(consumer(track, false)),
+			vec![
+				append(2, 2),
+				Update::Append {
+					position: 3,
+					value: Value::Null
+				},
+			]
+		);
+	}
+
+	#[test]
+	fn a_null_record_inside_a_snapshot_decodes() {
+		// The other half of the round trip: a null carried by frame 0 rather than by an append.
+		// Written by hand so the decoder is checked against the byte shape, not just our producer.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		for frame in [r#"{"offset":4,"values":[{"n":4},null,{"n":6}]}"#, r#"{"append":null}"#] {
+			group
+				.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.as_bytes().to_vec()))
+				.unwrap();
+		}
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		assert_eq!(
+			drain(consumer(subscriber, false)),
+			vec![
+				append(4, 4),
+				Update::Append {
+					position: 5,
+					value: Value::Null
+				},
+				append(6, 6),
+				Update::Append {
+					position: 7,
+					value: Value::Null
+				},
+			]
+		);
+	}
+
+	#[test]
+	fn an_out_of_range_snapshot_offset_is_rejected() {
+		// A peer picks the offset. Past MAX_POSITION the tail addition overflows: a debug build
+		// panics and a release build wraps every later position to zero.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		let frame = format!(r#"{{"offset":{},"values":[null]}}"#, u64::MAX);
+		group
+			.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.into_bytes()))
+			.unwrap();
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		match consumer(subscriber, false).poll_next(&kio::Waiter::noop()) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("maximum position"), "{msg}"),
+			other => panic!("expected an out-of-range offset to be rejected, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn a_snapshot_spanning_past_the_limit_is_rejected() {
+		// An in-range offset with enough records still lands the tail past the limit, so the span
+		// has to be checked, not just the offset.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		let frame = format!(r#"{{"offset":{},"values":[{{"n":0}},{{"n":1}}]}}"#, MAX_POSITION);
+		group
+			.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.into_bytes()))
+			.unwrap();
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		match consumer(subscriber, false).poll_next(&kio::Waiter::noop()) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("maximum position"), "{msg}"),
+			other => panic!("expected an out-of-range span to be rejected, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn a_group_with_no_snapshot_is_rejected() {
+		// A group that ends cleanly having carried nothing is malformed: every group opens with a
+		// snapshot. Reporting it as a clean end would lose the window the publisher advertised.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		track.append_group().unwrap().finish().unwrap();
+		track.finish().unwrap();
+
+		match consumer(subscriber, false).poll_next(&kio::Waiter::noop()) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("no snapshot"), "{msg}"),
+			other => panic!("expected an empty group to be rejected, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn a_lost_group_resyncs_instead_of_ending_the_stream() {
+		// Groups here are self-contained and disposable, so one dying under a slow consumer is a
+		// resync point, not the end of the track. Failing would strand the HLS timeline watcher on
+		// a track that is still publishing.
+		let (mut producer, track) = producer(ProducerConfig::default());
+		let mut consumer = consumer(track, false);
+		let waiter = kio::Waiter::noop();
+
+		producer.append(&json!({ "n": 0 })).unwrap();
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(update))) => assert_eq!(update, append(0, 0)),
+			other => panic!("expected the first record, got {other:?}"),
+		}
+
+		// Kill the group the consumer is parked on, the way cache eviction does.
+		producer
+			.inner
+			.lock()
+			.unwrap()
+			.group
+			.take()
+			.expect("a group is open")
+			.abort(moq_net::Error::Evicted)
+			.unwrap();
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending), "not an error");
+
+		// The publisher rolls a fresh snapshot group and the consumer picks up from it.
+		producer.append(&json!({ "n": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		let mut seen = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			seen.push(update);
+		}
+		assert_eq!(seen, vec![append(1, 1)], "resynced from the next snapshot");
+	}
+
+	#[test]
+	fn an_overflowing_trim_is_rejected() {
+		// Same for the trim count: `head + count` must not wrap before the range test sees it.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		for frame in [
+			r#"{"offset":0,"values":[{"n":0}]}"#.to_string(),
+			format!(r#"{{"trim":{}}}"#, u64::MAX),
+		] {
+			group
+				.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.into_bytes()))
+				.unwrap();
+		}
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		let mut consumer = consumer(subscriber, false);
+		let waiter = kio::Waiter::noop();
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(update))) => assert_eq!(update, append(0, 0)),
+			other => panic!("expected the snapshot record, got {other:?}"),
+		}
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("exceeds"), "{msg}"),
+			other => panic!("expected an overflowing trim to be rejected, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn a_frame_carrying_both_operations_is_rejected() {
+		// Applying both would append and retract in an order the format never defines, so it is
+		// malformed rather than something to guess at. A frame carrying *neither* stays a no-op:
+		// that is how a future operation reads here.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		for frame in [r#"{"offset":0,"values":[{"n":0}]}"#, r#"{"append":{"n":1},"trim":1}"#] {
+			group
+				.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.as_bytes().to_vec()))
+				.unwrap();
+		}
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		let mut consumer = consumer(subscriber, false);
+		let waiter = kio::Waiter::noop();
+		// The snapshot record lands first, then the malformed frame surfaces.
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(update))) => assert_eq!(update, append(0, 0)),
+			other => panic!("expected the snapshot record, got {other:?}"),
+		}
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("both"), "{msg}"),
+			other => panic!("expected a malformed-frame error, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn unknown_operation_is_ignored() {
+		// A frame carrying neither key is a forward-compatible extension, not an error.
+		let track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut producer = Producer::<Value>::new(track, ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+
+		// Write a future operation directly into the open group.
+		producer
+			.inner
+			.lock()
+			.unwrap()
+			.write(serde_json::to_vec(&json!({ "rewind": 1 })).unwrap())
+			.unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(drain(consumer(subscriber, false)), vec![append(0, 0), append(1, 1)]);
+	}
+
+	#[test]
+	fn empty_window_snapshots_cleanly() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.trim(1).unwrap();
+		assert!(producer.is_empty());
+		// The offset is preserved across an empty window, so positions keep counting.
+		assert_eq!(producer.offset(), 1);
+		assert_eq!(producer.append(&json!({ "n": 1 })).unwrap(), 1);
+		producer.finish().unwrap();
+
+		assert_eq!(drain(consumer(track, false)), vec![append(1, 1)]);
+	}
+
+	#[test]
+	fn a_trim_retracts_what_was_yielded() {
+		// A consumer told about a record is told when it goes away. (The converse, that a consumer
+		// which never held the record gets no trim, is what `late_joiner_reads_the_window_not_the
+		// _history` asserts: after a roll the snapshot starts past those records.)
+		let (mut producer, track) = producer(ProducerConfig::default());
+		let mut live = consumer(track, false);
+		let waiter = kio::Waiter::noop();
+
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		let mut seen = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = live.poll_next(&waiter) {
+			seen.push(update);
+		}
+		assert_eq!(seen, vec![append(0, 0), append(1, 1)]);
+
+		producer.trim(1).unwrap();
+		producer.finish().unwrap();
+		while let Poll::Ready(Ok(Some(update))) = live.poll_next(&waiter) {
+			seen.push(update);
+		}
+		assert_eq!(seen.last().unwrap(), &Update::Trim { offset: 1 });
+		assert_eq!(replay(&seen), vec![(1, json!({ "n": 1 }))]);
+	}
+
+	#[test]
+	fn open_group_pends_after_track_finish() {
+		// A group appended before the track finishes may still deliver frames, so the consumer
+		// must keep waiting on it rather than ending the stream.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let mut group = track.append_group().unwrap();
+		let subscriber = track.subscribe(None);
+		track.finish().unwrap();
+
+		let mut consumer = consumer(subscriber, false);
+		let waiter = kio::Waiter::noop();
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
+
+		let snapshot = json!({ "offset": 0, "values": [{ "n": 7 }] });
+		group
+			.write_frame(
+				moq_net::Timestamp::ZERO,
+				Bytes::from(serde_json::to_vec(&snapshot).unwrap()),
+			)
+			.unwrap();
+		group.finish().unwrap();
+
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(update))) => assert_eq!(update, append(0, 7)),
+			other => panic!("expected the snapshot record, got {other:?}"),
+		}
+	}
+}

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -924,7 +924,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					},
 				};
 				if let Some(recorder) = track.recorder.as_mut() {
-					recorder.record(g.sequence, reported, contains_keyframe);
+					recorder.record(&g, reported, contains_keyframe);
 				}
 
 				// Close the previous group for the bitrate estimator (used only when the

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -332,6 +332,19 @@ async fn test_msf_catalog_roundtrip() {
 /// directly. This guards that the import advertises the broadcast's timeline at the catalog root
 /// and actually records both renditions' group opens into it, the index the VOD/playlist export
 /// reads. Regression for the missing-timeline break that skipped VOD renditions.
+/// The next segment the timeline indexes, skipping retractions.
+///
+/// Nothing here evicts, so a retraction would be a bug; these tests are about what gets indexed,
+/// and the retraction path has its own coverage in `timeline`.
+async fn next_entry(timeline: &mut crate::timeline::Consumer) -> Option<crate::timeline::Entry> {
+	while let Some(update) = timeline.next().await.unwrap() {
+		if let crate::timeline::Update::Append { entry } = update {
+			return Some(entry);
+		}
+	}
+	None
+}
+
 #[tokio::test]
 async fn import_populates_the_broadcast_timeline() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
@@ -363,10 +376,8 @@ async fn import_populates_the_broadcast_timeline() {
 	catalog.finish().unwrap();
 
 	// The first record indexes both renditions from their first group (sequence 0).
-	let first = timeline
-		.next()
+	let first = next_entry(&mut timeline)
 		.await
-		.unwrap()
 		.expect("a segment should be recorded in the timeline");
 	assert_eq!(first.segment, 0);
 	let video_ranges = first.tracks.get(&video_name).expect("video is indexed");
@@ -654,7 +665,7 @@ async fn segmented_source_indexes_one_group_range_per_track() {
 	catalog.finish().unwrap();
 
 	let mut records = Vec::new();
-	while let Some(record) = timeline.next().await.unwrap() {
+	while let Some(record) = next_entry(&mut timeline).await {
 		records.push(record);
 	}
 	assert_eq!(records.len(), 3, "one record per declared segment");
@@ -740,7 +751,7 @@ async fn segment_ranges_with_skew(
 	catalog.finish().unwrap();
 
 	let mut out = Vec::new();
-	while let Some(record) = timeline.next().await.unwrap() {
+	while let Some(record) = next_entry(&mut timeline).await {
 		out.push((
 			record.tracks.get(&video_name).cloned().unwrap_or_default(),
 			record.tracks.get(&audio_name).cloned().unwrap_or_default(),

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -164,7 +164,7 @@ impl<C: Container> Producer<C> {
 			// timeline absorbs publish failures itself (it is an optional sidecar),
 			// so reporting can't abort the media write.
 			if let Some(recorder) = self.recorder.as_mut() {
-				recorder.record(group.sequence, frame.timestamp, frame.keyframe);
+				recorder.record(&group, frame.timestamp, frame.keyframe);
 			}
 
 			self.group = Some(group);

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -38,9 +38,26 @@
 //!
 //! On the read side, [`Consumer::subscribe`] reads the timeline straight from the catalog's
 //! [`hang::catalog::Timeline`] section (so the track name and timescale can't be mismatched)
-//! and yields decoded [`Entry`]s. On the wire the track is a DEFLATE-compressed
-//! [`moq_json::stream`] (a single group, one record per frame; see [`hang::timeline`] for the
+//! and yields [`Update`]s: a decoded [`Entry`] per segment, and a retraction once a segment's
+//! media is gone. On the wire the track is a DEFLATE-compressed [`moq_json::window`]: a sliding
+//! log that appends at the tail and trims at the head, so the timeline describes what is
+//! actually available rather than everything ever published (see [`hang::timeline`] for the
 //! record schema).
+//!
+//! ## Retraction follows the cache
+//!
+//! Trimming is driven by the media cache itself, not a timer. A segment's record names the
+//! group ranges that carry it, and the timeline keeps a [`moq_net::group::Consumer`] for every
+//! one of those groups, on every track. The record is retracted once any of them reports the
+//! group gone (evicted under cache pressure, aged out of the publisher's latency window, or
+//! aborted), since a consumer fetches the whole segment and a hole anywhere in it breaks the
+//! segment just as thoroughly as a missing head.
+//!
+//! Holding those handles doesn't keep the media alive, so the timeline tracks the cache without
+//! extending it. The sweep runs as segments are recorded, which is also the only time the
+//! publisher's cache shrinks. The corollary is that the window is only accurate while media is
+//! flowing: a publisher that stalls keeps advertising segments that have since aged out, until
+//! it records again or calls [`Producer::finish`].
 
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
@@ -104,11 +121,24 @@ impl Default for Config {
 	}
 }
 
+/// One group open, as reported by a track and not yet flushed into a record.
+struct Report {
+	/// The group's sequence number, as used by FETCH/SUBSCRIBE on the media track.
+	sequence: u64,
+	/// Where the group starts.
+	pts: Timestamp,
+	/// Whether its first frame is a keyframe.
+	keyframe: bool,
+	/// A read handle on the group, held so the segment it lands in can watch it leave the
+	/// cache. Pins no frames, so this observes availability without extending it.
+	group: moq_net::group::Consumer,
+}
+
 /// One enrolled track's report state.
 #[derive(Default)]
 struct TrackState {
-	/// Group opens reported and not yet flushed into a record: (sequence, pts, keyframe).
-	pending: VecDeque<(u64, Timestamp, bool)>,
+	/// Group opens reported and not yet flushed into a record.
+	pending: VecDeque<Report>,
 	/// The newest reported timestamp: everything earlier is known, which is what lets a
 	/// segment ending at or before it flush. Advanced by a group open (the group starts there)
 	/// and by [`Recorder::end`] (the content stops there).
@@ -123,7 +153,7 @@ impl TrackState {
 	fn candidate(&self, threshold: u128) -> Option<Timestamp> {
 		self.pending
 			.iter()
-			.map(|&(_, pts, _)| pts)
+			.map(|report| report.pts)
 			.find(|pts| pts.as_micros() >= threshold)
 	}
 }
@@ -134,7 +164,11 @@ struct State {
 	/// Retained so the timeline track can be created when the first media track enrolls.
 	broadcast: moq_net::broadcast::Producer,
 	/// The timeline track, created by the first [`Producer::track`] call.
-	sink: Option<moq_json::stream::Producer<Record>>,
+	sink: Option<moq_json::window::Producer<Record>>,
+	/// One entry per record still in the window, oldest first, holding a handle for every group
+	/// the segment covers across every track. Kept in lockstep with the window, so its length is
+	/// what a trim count is measured against.
+	indexed: VecDeque<Vec<moq_net::group::Consumer>>,
 	/// Where the open (unflushed) segment starts; `None` until the first report.
 	start: Option<Timestamp>,
 	/// Explicit [`Producer::cut`] boundaries not yet reached, in order.
@@ -159,11 +193,16 @@ struct State {
 
 impl State {
 	/// A group open reported by `name`: record the fact and publish whatever became complete.
-	fn report(&mut self, name: &str, sequence: u64, pts: Timestamp, keyframe: bool) {
+	fn report(&mut self, name: &str, group: &moq_net::group::Producer, pts: Timestamp, keyframe: bool) {
 		let Some(track) = self.tracks.get_mut(name) else {
 			return;
 		};
-		track.pending.push_back((sequence, pts, keyframe));
+		track.pending.push_back(Report {
+			sequence: group.sequence,
+			pts,
+			keyframe,
+			group: group.consume(),
+		});
 		self.advance(name, pts);
 	}
 
@@ -205,6 +244,12 @@ impl State {
 	/// `finished` is the terminal pass: no track will report again, so a track that never
 	/// reached a boundary stops voting instead of holding the timeline open forever.
 	fn pump(&mut self, finished: bool) {
+		// Sweep first: a retraction and the record that triggers it ride the same window group,
+		// and sweeping before appending keeps the window from briefly listing content that is
+		// already gone. Unconditional, since media leaving the cache is worth reporting even
+		// while a reservation withholds new records.
+		self.sweep();
+
 		// With nothing enrolled there is nothing to describe. A record is immutable once
 		// published, so a caller that knows more tracks are still enrolling withholds it (see
 		// [`Producer::reserve`]), and an overrun has already broken the catalog's promise.
@@ -339,37 +384,42 @@ impl State {
 			if let Some(sink) = self.sink.as_mut() {
 				let _ = sink.finish();
 			}
-			self.sink = None;
+			self.drop_sink();
 			return;
 		}
 
 		let mut record = Record::new(self.next_segment, pts, duration);
 		self.next_segment += 1;
 
+		// Every group this segment covers, across every track: the set whose availability the
+		// record's own availability is the AND of.
+		let mut covered: Vec<moq_net::group::Consumer> = Vec::new();
+
 		for (name, track) in &mut self.tracks {
 			let mut ranges: Vec<Range> = Vec::new();
-			while let Some(&(sequence, group_pts, keyframe)) = track.pending.front() {
-				if end.is_some_and(|end| group_pts.as_micros() >= end.as_micros()) {
+			while let Some(report) = track.pending.front() {
+				if end.is_some_and(|end| report.pts.as_micros() >= end.as_micros()) {
 					break;
 				}
-				track.pending.pop_front();
+				let report = track.pending.pop_front().expect("peeked above");
 				match ranges.last_mut() {
 					// Contiguous sequences extend the run; a skip starts a new range (a gap:
 					// groups that never existed).
-					Some(last) if last.end + 1 == sequence => last.end = sequence,
+					Some(last) if last.end + 1 == report.sequence => last.end = report.sequence,
 					_ => {
-						let mut range = Range::new(sequence, sequence);
-						range.keyframe = keyframe;
+						let mut range = Range::new(report.sequence, report.sequence);
+						range.keyframe = report.keyframe;
 						ranges.push(range);
 					}
 				}
+				covered.push(report.group);
 			}
 			if !ranges.is_empty() {
 				record.tracks.insert(name.clone(), ranges);
 			}
 		}
 
-		self.emit(record);
+		self.emit(record, covered);
 	}
 
 	/// A duration in the wire timescale's units, rounded up so a bound never understates itself.
@@ -377,18 +427,57 @@ impl State {
 		(duration.as_micros() * self.timescale.as_u64() as u128).div_ceil(1_000_000) as u64
 	}
 
-	/// Publish a flushed record.
+	/// Publish a flushed record, remembering the groups it covers so it can be retracted once
+	/// they leave the cache.
 	///
 	/// The timeline is an optional sidecar, so a transport failure logs and stops publishing
 	/// rather than tearing down the media path.
-	fn emit(&mut self, record: Record) {
+	fn emit(&mut self, record: Record, covered: Vec<moq_net::group::Consumer>) {
 		let Some(sink) = self.sink.as_mut() else {
 			return;
 		};
 		if let Err(err) = sink.append(&record) {
 			tracing::warn!(%err, "timeline publish failed; dropping the timeline track");
-			self.sink = None;
+			self.drop_sink();
+			return;
 		}
+		self.indexed.push_back(covered);
+	}
+
+	/// Retract every record up to and including the newest one that has lost any of its groups.
+	///
+	/// A record goes when *any* group it covers is gone, on any track: a consumer fetches the
+	/// whole segment, so a hole in the middle breaks it just as thoroughly as a missing head.
+	///
+	/// Eviction is not strictly oldest-first: a group refreshed by a FETCH is protected while a
+	/// newer unread one is evicted in its place. That leaves a hole, and a window has only a
+	/// head, so the choice is to advertise the dead record or to drop the live ones in front of
+	/// it. Dropping them keeps the promise that everything listed is fetchable, which is the
+	/// whole point of the timeline; the cost is a shorter window, and eviction reaches those
+	/// records shortly anyway.
+	fn sweep(&mut self) {
+		let gone = |covered: &Vec<moq_net::group::Consumer>| covered.iter().any(moq_net::group::Consumer::is_closed);
+		let Some(last) = self.indexed.iter().rposition(gone) else {
+			return;
+		};
+		let count = last + 1;
+
+		let Some(sink) = self.sink.as_mut() else {
+			return;
+		};
+		if let Err(err) = sink.trim(count) {
+			tracing::warn!(%err, "timeline retraction failed; dropping the timeline track");
+			self.drop_sink();
+			return;
+		}
+		self.indexed.drain(..count);
+	}
+
+	/// Stop publishing. The handles go too: nothing can be retracted from a window nobody is
+	/// writing to, so keeping them would only pin memory for the life of the broadcast.
+	fn drop_sink(&mut self) {
+		self.sink = None;
+		self.indexed.clear();
 	}
 
 	/// The terminal flush: publish what the media finalized, then the open tail.
@@ -407,6 +496,11 @@ impl State {
 		{
 			self.flush_segment(start, None);
 		}
+
+		// Eviction is charged from the frame-write path too, so a group can die after the last
+		// record. Without this final sweep the window would close still listing it, and a reader
+		// would take the clean end as a complete playlist over media it cannot fetch.
+		self.sweep();
 	}
 
 	/// The error a segment overrunning [`Config::duration_max`] left behind, if any.
@@ -461,6 +555,7 @@ impl Producer {
 				config,
 				broadcast: broadcast.clone(),
 				sink: None,
+				indexed: VecDeque::new(),
 				start: None,
 				cuts: VecDeque::new(),
 				manual: false,
@@ -488,8 +583,8 @@ impl Producer {
 
 		if state.sink.is_none() && state.overrun.is_none() {
 			let net = state.broadcast.create_track(DEFAULT_NAME, None)?;
-			let config = moq_json::stream::ProducerConfig::default().with_compression(true);
-			state.sink = Some(moq_json::stream::Producer::new(net, config));
+			let config = moq_json::window::ProducerConfig::default().with_compression(true);
+			state.sink = Some(moq_json::window::Producer::new(net, config));
 		}
 
 		state.tracks.insert(name.to_string(), TrackState::default());
@@ -622,13 +717,18 @@ pub struct Recorder {
 }
 
 impl Recorder {
-	/// Report that group `sequence` opened at presentation time `pts`, `keyframe` stating
-	/// whether its first frame is one (i.e. whether a player could join here).
+	/// Report that `group` opened at presentation time `pts`, `keyframe` stating whether its
+	/// first frame is one (i.e. whether a player could join here).
 	///
 	/// Reports must be in group order with monotonic timestamps; this is the fact the timeline
 	/// builds ranges, boundaries and completeness from.
-	pub(crate) fn record(&mut self, sequence: u64, pts: Timestamp, keyframe: bool) {
-		self.state.lock().unwrap().report(&self.name, sequence, pts, keyframe);
+	///
+	/// The timeline keeps a read handle on `group` to watch when it leaves the cache, which is
+	/// what retracts the segment carrying it. That pins no frames, and the caller keeps
+	/// ownership. Taking the group rather than its sequence number is also what makes the two
+	/// impossible to mismatch.
+	pub(crate) fn record(&mut self, group: &moq_net::group::Producer, pts: Timestamp, keyframe: bool) {
+		self.state.lock().unwrap().report(&self.name, group, pts, keyframe);
 	}
 
 	/// Report that this track's content extends to `pts`, without a group opening there.
@@ -670,12 +770,52 @@ pub struct Entry<E: RecordExt = ()> {
 	pub ext: E,
 }
 
-/// Reads a broadcast's timeline, yielding decoded [`Entry`]s in segment order.
+/// One change to a broadcast's timeline.
 ///
-/// Generic over the record extension `E` (see [`RecordExt`]).
+/// Generic over the record extension `E` (see [`RecordExt`]). `#[non_exhaustive]` because the
+/// underlying window format is extensible, so a later revision can carry a change this one has
+/// no variant for; match with a wildcard arm and skip what you don't recognize.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum Update<E: RecordExt = ()> {
+	/// A segment was indexed. Its number is [`Entry::segment`].
+	Append {
+		/// The segment.
+		entry: Entry<E>,
+	},
+
+	/// Every segment before `segment` is gone: its media has left the publisher's cache and can
+	/// no longer be fetched.
+	Trim {
+		/// A lower bound on the oldest segment still available: everything below it is gone.
+		///
+		/// Normally this is exactly the oldest surviving segment, which is what a playlist's
+		/// `EXT-X-MEDIA-SEQUENCE` wants. It can understate after the consumer resynchronizes past
+		/// a lost group, where the retraction is known before the replacement's contents are, so
+		/// read the live edge off the entries themselves rather than off this number.
+		segment: u64,
+	},
+}
+
+/// Reads a broadcast's timeline, yielding an [`Update`] per change.
+///
+/// A consumer sees an [`Update::Append`] per segment in the live window when it joins, then
+/// follows along: an `Append` as each segment is indexed and an [`Update::Trim`] as old ones
+/// stop being fetchable. Generic over the record extension `E` (see [`RecordExt`]).
+///
+/// A `Trim` only ever retracts segments this consumer was told about, so joining a window that
+/// has already trimmed does not report the segments it missed. Those show up instead as a jump
+/// in the first entry's [`segment`](Entry::segment).
 pub struct Consumer<E: RecordExt = ()> {
-	inner: moq_json::stream::Consumer<Record<E>>,
+	inner: moq_json::window::Consumer<Record<E>>,
 	timescale: Timescale,
+	/// The segment number of each yielded entry, oldest first, so a trim expressed in window
+	/// positions can be reported as the segment number a playlist actually keys on. Holding the
+	/// pair rather than assuming `position == segment` keeps the two independent: the record
+	/// carries its own number, and nothing on the wire ties it to the window's coordinates.
+	held: VecDeque<(u64, u64)>,
+	/// The segment after the newest one retracted, for a trim that empties `held`.
+	trimmed: u64,
 }
 
 impl<E: RecordExt> Consumer<E> {
@@ -687,12 +827,14 @@ impl<E: RecordExt> Consumer<E> {
 	pub async fn subscribe(broadcast: &moq_net::broadcast::Consumer, section: &Timeline) -> crate::Result<Self> {
 		let track = broadcast.track(&section.track)?.subscribe(None).await?;
 
-		let config = moq_json::stream::ConsumerConfig::default().with_compression(true);
+		let config = moq_json::window::ConsumerConfig::default().with_compression(true);
 
 		Ok(Self {
-			inner: moq_json::stream::Consumer::new(track, config),
+			inner: moq_json::window::Consumer::new(track, config),
 			timescale: Timescale::new(section.timescale as u64)
 				.map_err(|_| crate::Error::InvalidTimescale(section.timescale))?,
+			held: VecDeque::new(),
+			trimmed: 0,
 		})
 	}
 
@@ -712,20 +854,57 @@ impl<E: RecordExt> Consumer<E> {
 		})
 	}
 
-	/// Get the next entry, or `None` once the track ends.
-	pub async fn next(&mut self) -> crate::Result<Option<Entry<E>>> {
-		match self.inner.next().await? {
-			Some(record) => Ok(Some(self.decode(record)?)),
-			None => Ok(None),
+	/// Translate one window change into a timeline change.
+	///
+	/// `None` for a window change this revision has no timeline meaning for, which a caller skips
+	/// rather than failing on: the window format is extensible by design.
+	fn convert(&mut self, update: moq_json::window::Update<Record<E>>) -> crate::Result<Option<Update<E>>> {
+		Ok(match update {
+			moq_json::window::Update::Append { position, value } => {
+				let entry = self.decode(value)?;
+				self.held.push_back((position, entry.segment));
+				Some(Update::Append { entry })
+			}
+			moq_json::window::Update::Trim { offset } => {
+				while self.held.front().is_some_and(|&(position, _)| position < offset) {
+					let (_, segment) = self.held.pop_front().expect("peeked above");
+					self.trimmed = segment + 1;
+				}
+				// The oldest entry still held names the new head; with nothing left it is one
+				// past the newest thing retracted.
+				let segment = self.held.front().map_or(self.trimmed, |&(_, segment)| segment);
+				Some(Update::Trim { segment })
+			}
+			_ => None,
+		})
+	}
+
+	/// Get the next update, or `None` once the track ends.
+	pub async fn next(&mut self) -> crate::Result<Option<Update<E>>> {
+		loop {
+			let Some(update) = self.inner.next().await? else {
+				return Ok(None);
+			};
+			if let Some(update) = self.convert(update)? {
+				return Ok(Some(update));
+			}
 		}
 	}
 
-	/// Poll for the next entry, without blocking.
-	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<crate::Result<Option<Entry<E>>>> {
-		match self.inner.poll_next(waiter)? {
-			Poll::Ready(Some(record)) => Poll::Ready(self.decode(record).map(Some)),
-			Poll::Ready(None) => Poll::Ready(Ok(None)),
-			Poll::Pending => Poll::Pending,
+	/// Poll for the next update, without blocking.
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<crate::Result<Option<Update<E>>>> {
+		loop {
+			match self.inner.poll_next(waiter)? {
+				// A change with no timeline meaning is skipped, so keep polling rather than
+				// reporting a spurious end of stream.
+				Poll::Ready(Some(update)) => match self.convert(update) {
+					Ok(Some(update)) => return Poll::Ready(Ok(Some(update))),
+					Ok(None) => continue,
+					Err(err) => return Poll::Ready(Err(err)),
+				},
+				Poll::Ready(None) => return Poll::Ready(Ok(None)),
+				Poll::Pending => return Poll::Pending,
+			}
 		}
 	}
 }
@@ -736,6 +915,66 @@ mod test {
 
 	fn ms(v: u64) -> Timestamp {
 		Timestamp::from_millis(v).unwrap()
+	}
+
+	/// A media track feeding one timeline enrollment.
+	///
+	/// The timeline watches the groups it is handed, so a test has to publish real ones: the
+	/// backing [`moq_net::track::Producer`] caches them, which is what keeps them available
+	/// until a test evicts one on purpose.
+	struct Media {
+		track: moq_net::track::Producer,
+		/// Dropped by [`Self::close`] to end the enrollment while the media stays cached, which
+		/// is what a real track finishing looks like to the timeline.
+		recorder: Option<Recorder>,
+		groups: BTreeMap<u64, moq_net::group::Producer>,
+	}
+
+	impl Media {
+		fn new(broadcast: &mut moq_net::broadcast::Producer, timeline: &Producer, name: &str) -> Self {
+			Self {
+				track: broadcast.create_track(name, None).unwrap(),
+				recorder: Some(timeline.track(name).unwrap()),
+				groups: BTreeMap::new(),
+			}
+		}
+
+		/// Open group `sequence` at `pts` and report it.
+		fn record(&mut self, sequence: u64, pts: Timestamp, keyframe: bool) {
+			let mut group = self.track.create_group(moq_net::group::Info { sequence }).unwrap();
+			// An empty group is not cached, so it would read as gone the moment the timeline
+			// looked at it.
+			group.write_frame(pts, b"x".as_slice()).unwrap();
+			self.recorder
+				.as_mut()
+				.expect("still enrolled")
+				.record(&group, pts, keyframe);
+			self.groups.insert(sequence, group);
+		}
+
+		fn end(&mut self, pts: Timestamp) {
+			self.recorder.as_mut().expect("still enrolled").end(pts);
+		}
+
+		/// End the timeline enrollment, leaving the media track and its cached groups alive.
+		fn close(&mut self) {
+			self.recorder = None;
+		}
+
+		/// Evict group `sequence` the way the cache does, so the timeline sees it go.
+		fn evict(&mut self, sequence: u64) {
+			let group = self.groups.remove(&sequence).expect("group was recorded");
+			group.abort(moq_net::Error::Evicted).unwrap();
+		}
+
+		/// Finish group `sequence` cleanly, leaving it cached and fetchable.
+		fn finish_group(&mut self, sequence: u64) {
+			self.groups
+				.get_mut(&sequence)
+				.expect("group was recorded")
+				.finish()
+				.unwrap();
+		}
 	}
 
 	/// Build an Entry the tests compare against.
@@ -757,17 +996,73 @@ mod test {
 		}
 	}
 
-	/// Drain a finished timeline track by subscribing to the producer's advertised section.
-	async fn drain(broadcast: &moq_net::broadcast::Producer, producer: &Producer) -> Vec<Entry> {
+	/// Drain every update a subscriber sees on the producer's advertised section.
+	async fn drain(broadcast: &moq_net::broadcast::Producer, producer: &Producer) -> Vec<Update> {
 		let mut consumer = Consumer::subscribe(&broadcast.consume(), &producer.section())
 			.await
 			.unwrap();
 		let waiter = kio::Waiter::noop();
 		let mut out = Vec::new();
-		while let Poll::Ready(Ok(Some(entry))) = consumer.poll_next(&waiter) {
-			out.push(entry);
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			out.push(update);
 		}
 		out
+	}
+
+	/// Subscribe before the action under test, so the consumer sees every update.
+	///
+	/// A consumer that joins afterwards is a late joiner: it adopts the trimmed head silently and
+	/// reports no retraction for records it never held (see [`Consumer`]). Whether a trim is even
+	/// still on the wire then depends on whether the window rolled, so a test that asserts on
+	/// retractions has to be watching when they happen.
+	async fn watch(broadcast: &moq_net::broadcast::Producer, producer: &Producer) -> Consumer {
+		Consumer::subscribe(&broadcast.consume(), &producer.section())
+			.await
+			.unwrap()
+	}
+
+	/// Everything a live consumer has been told so far.
+	fn collect(consumer: &mut Consumer) -> Vec<Update> {
+		let waiter = kio::Waiter::noop();
+		let mut out = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			out.push(update);
+		}
+		out
+	}
+
+	/// The segment numbers a run of updates retracted to, in order.
+	fn trims(updates: &[Update]) -> Vec<u64> {
+		updates
+			.iter()
+			.filter_map(|update| match update {
+				Update::Trim { segment } => Some(*segment),
+				_ => None,
+			})
+			.collect()
+	}
+
+	/// The segment numbers a run of updates indexed, in order.
+	fn appended(updates: &[Update]) -> Vec<u64> {
+		updates
+			.iter()
+			.filter_map(|update| match update {
+				Update::Append { entry } => Some(entry.segment),
+				_ => None,
+			})
+			.collect()
+	}
+
+	/// The entries a subscriber is told about, ignoring retractions.
+	async fn entries(broadcast: &moq_net::broadcast::Producer, producer: &Producer) -> Vec<Entry> {
+		drain(broadcast, producer)
+			.await
+			.into_iter()
+			.filter_map(|update| match update {
+				Update::Append { entry } => Some(entry),
+				_ => None,
+			})
+			.collect()
 	}
 
 	fn setup() -> (moq_net::broadcast::Producer, Producer) {
@@ -783,9 +1078,9 @@ mod test {
 	// The coarsest track paces: video GOPs are longer than duration_min, so segments are GOPs.
 	#[tokio::test]
 	async fn the_coarsest_track_paces_the_segments() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut audio = Media::new(&mut broadcast, &timeline, "audio0");
 
 		// Video keyframes every 2s, audio groups every 500ms, minimum 1s.
 		video.record(0, ms(0), true);
@@ -798,14 +1093,14 @@ mod test {
 		}
 		video.record(2, ms(4_000), true);
 		audio.record(8, ms(4_000), true);
-		drop(video);
-		drop(audio);
+		video.close();
+		audio.close();
 		timeline.finish().unwrap();
 
 		// Audio's own candidate (1s) loses to video's (2s), so no segment splits a GOP. Every
 		// record is self-contained: start AND end groups, explicit duration.
 		assert_eq!(
-			drain(&broadcast, &timeline).await,
+			entries(&broadcast, &timeline).await,
 			vec![
 				entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 3)])]),
 				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)]), ("audio0", &[(4, 7)])]),
@@ -818,17 +1113,17 @@ mod test {
 	// else a segment could start and stay decodable, so the segment is simply long.
 	#[tokio::test]
 	async fn a_gop_longer_than_the_minimum_is_one_segment() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(30_000), true);
 		video.end(ms(60_000));
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 
 		assert_eq!(
-			drain(&broadcast, &timeline).await,
+			entries(&broadcast, &timeline).await,
 			vec![
 				entry(0, 0, 30_000, &[("video0", &[(0, 0)])]),
 				entry(1, 30_000, 30_000, &[("video0", &[(1, 1)])]),
@@ -839,19 +1134,19 @@ mod test {
 	// Groups shorter than the minimum pack into one segment rather than each becoming one.
 	#[tokio::test]
 	async fn short_groups_pack_up_to_the_minimum() {
-		let (broadcast, mut timeline) = setup_with(Config {
+		let (mut broadcast, mut timeline) = setup_with(Config {
 			duration_min: Duration::from_millis(1_500),
 			..Default::default()
 		});
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut audio = Media::new(&mut broadcast, &timeline, "audio0");
 
 		for seq in 0..8u64 {
 			audio.record(seq, ms(seq * 500), true);
 		}
-		drop(audio);
+		audio.close();
 		timeline.finish().unwrap();
 
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		// The first group at or past 1500ms ends segment 0, so it holds groups 0..=2.
 		assert_eq!(entries[0], entry(0, 0, 1_500, &[("audio0", &[(0, 2)])]));
 		assert_eq!(entries[1], entry(1, 1_500, 1_500, &[("audio0", &[(3, 5)])]));
@@ -861,32 +1156,32 @@ mod test {
 	// omits a rendition that was about to contribute to it.
 	#[tokio::test]
 	async fn a_segment_waits_for_every_track() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut audio = Media::new(&mut broadcast, &timeline, "audio0");
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
 		video.record(1, ms(2_000), true);
 		// Video alone would close segment 0 here, but audio hasn't crossed 2s.
-		assert!(drain(&broadcast, &timeline).await.is_empty());
+		assert!(entries(&broadcast, &timeline).await.is_empty());
 
 		audio.record(1, ms(2_000), true);
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(
 			entries,
 			vec![entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])])]
 		);
-		drop(video);
-		drop(audio);
+		video.close();
+		audio.close();
 		timeline.finish().unwrap();
 	}
 
 	// An application that knows its own boundaries overrides the pacing.
 	#[tokio::test]
 	async fn explicit_cuts_override_the_pacing() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 
 		// Keyframes every second, cut every three: the segments follow the cuts, not the GOPs.
 		timeline.cut(ms(3_000)).unwrap();
@@ -894,10 +1189,10 @@ mod test {
 		for seq in 0..7u64 {
 			video.record(seq, ms(seq * 1_000), true);
 		}
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(entries[0], entry(0, 0, 3_000, &[("video0", &[(0, 2)])]));
 		assert_eq!(entries[1], entry(1, 3_000, 3_000, &[("video0", &[(3, 5)])]));
 	}
@@ -906,8 +1201,8 @@ mod test {
 	// segment shorter than the minimum is dropped rather than producing a stray segment.
 	#[tokio::test]
 	async fn a_cut_below_the_minimum_is_ignored() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 
 		video.record(0, ms(0), true);
 		timeline.cut(ms(2_000)).unwrap();
@@ -917,10 +1212,10 @@ mod test {
 		timeline.cut(ms(4_000)).unwrap();
 		video.record(1, ms(2_000), true);
 		video.record(2, ms(4_000), true);
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(entries.len(), 3, "the duplicate and the 500ms cut are both dropped");
 		assert_eq!(entries[0], entry(0, 0, 2_000, &[("video0", &[(0, 0)])]));
 		assert_eq!(entries[1], entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]));
@@ -931,12 +1226,12 @@ mod test {
 	// contradicts the catalog.
 	#[tokio::test]
 	async fn exceeding_the_declared_maximum_fails_the_timeline() {
-		let (broadcast, mut timeline) = setup_with(Config {
+		let (mut broadcast, mut timeline) = setup_with(Config {
 			duration_min: Duration::from_secs(1),
 			duration_max: Some(Duration::from_secs(3)),
 			..Default::default()
 		});
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 
 		let mut consumer = {
 			video.record(0, ms(0), true);
@@ -948,7 +1243,7 @@ mod test {
 
 		// A 4s GOP against a declared 3s maximum.
 		video.record(2, ms(6_000), true);
-		drop(video);
+		video.close();
 
 		let err = timeline.finish().unwrap_err();
 		assert!(
@@ -959,11 +1254,16 @@ mod test {
 		// The record that was still true published; the one that would have contradicted the
 		// catalog did not, and the track ended there.
 		let waiter = kio::Waiter::noop();
-		let mut entries = Vec::new();
-		while let Poll::Ready(Ok(Some(entry))) = consumer.poll_next(&waiter) {
-			entries.push(entry);
+		let mut updates = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			updates.push(update);
 		}
-		assert_eq!(entries, vec![entry(0, 0, 2_000, &[("video0", &[(0, 0)])])]);
+		assert_eq!(
+			updates,
+			vec![Update::Append {
+				entry: entry(0, 0, 2_000, &[("video0", &[(0, 0)])])
+			}]
+		);
 	}
 
 	#[tokio::test]
@@ -982,18 +1282,18 @@ mod test {
 	// final segment's duration collapses to zero (an HLS EXTINF:0).
 	#[tokio::test]
 	async fn the_final_segment_runs_to_the_reported_end() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(2_000), true);
 		// A finished `container::Producer` reports where its content stops.
 		video.end(ms(4_000));
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 
 		assert_eq!(
-			drain(&broadcast, &timeline).await,
+			entries(&broadcast, &timeline).await,
 			vec![
 				entry(0, 0, 2_000, &[("video0", &[(0, 0)])]),
 				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
@@ -1006,30 +1306,30 @@ mod test {
 	// renditions) holds flushing back until they are all in.
 	#[tokio::test]
 	async fn a_reservation_defers_flushing_until_every_track_enrolls() {
-		let (broadcast, mut timeline) = setup();
+		let (mut broadcast, mut timeline) = setup();
 		let reserved = timeline.reserve();
 
 		// The primary rendition runs a whole batch of segments through before its sibling has
 		// even loaded an init segment.
-		let mut first = timeline.track("video0").unwrap();
+		let mut first = Media::new(&mut broadcast, &timeline, "video0");
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			first.record(seq, ms(t), true);
 		}
 
-		let mut second = timeline.track("video1").unwrap();
+		let mut second = Media::new(&mut broadcast, &timeline, "video1");
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			second.record(seq, ms(t), true);
 		}
 
 		drop(reserved);
-		drop(first);
-		drop(second);
+		first.close();
+		second.close();
 		timeline.finish().unwrap();
 
 		// Both renditions are indexed from segment 0. Without the reservation, segments 0 and 1 would
 		// have flushed knowing only video0 (a permanent gap for video1), and video1's first two
 		// groups would have folded into segment 2.
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(
 			entries[0],
 			entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("video1", &[(0, 0)])])
@@ -1043,9 +1343,9 @@ mod test {
 	// A track that races ahead of the others still lands in the segment its content falls in.
 	#[tokio::test]
 	async fn groups_before_the_first_boundary_join_the_first_segment() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut audio = Media::new(&mut broadcast, &timeline, "audio0");
 
 		// Audio races ahead of video's first keyframe (the startup race): its early group
 		// belongs to segment 0, which starts where the earliest content does.
@@ -1056,11 +1356,11 @@ mod test {
 		}
 		video.record(1, ms(2_030), true);
 		audio.record(5, ms(2_500), true);
-		drop(video);
-		drop(audio);
+		video.close();
+		audio.close();
 		timeline.finish().unwrap();
 
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(
 			entries[0],
 			entry(0, 0, 2_030, &[("video0", &[(0, 0)]), ("audio0", &[(0, 4)])]),
@@ -1069,9 +1369,9 @@ mod test {
 
 	#[tokio::test]
 	async fn sequence_gaps_split_ranges() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut audio = Media::new(&mut broadcast, &timeline, "audio0");
 
 		// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
 		video.record(0, ms(0), true);
@@ -1080,11 +1380,11 @@ mod test {
 		audio.record(5, ms(1_500), true);
 		video.record(1, ms(2_000), true);
 		audio.record(6, ms(2_100), true);
-		drop(video);
-		drop(audio);
+		video.close();
+		audio.close();
 		timeline.finish().unwrap();
 
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(
 			entries[0],
 			entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 1), (5, 5)])]),
@@ -1096,35 +1396,35 @@ mod test {
 	// track that has merely gone quiet still gets to say where the boundary is.
 	#[tokio::test]
 	async fn a_closed_track_leaves_a_whole_segment_gap() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut audio = Media::new(&mut broadcast, &timeline, "audio0");
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
-		drop(audio);
+		audio.close();
 		video.record(1, ms(2_000), true);
 		video.record(2, ms(4_000), true);
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(entries[1], entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]));
 	}
 
 	#[tokio::test]
 	async fn a_non_keyframe_range_start_is_flagged() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 
 		video.record(0, ms(0), true);
 		// A mid-stream join: the group doesn't open on an IDR.
 		video.record(1, ms(2_000), false);
 		video.record(2, ms(4_000), true);
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		let range = entries[1].tracks["video0"][0];
 		assert!(!range.keyframe, "a range whose first group isn't an IDR says so");
 	}
@@ -1133,22 +1433,22 @@ mod test {
 	// says it will never report again.
 	#[tokio::test]
 	async fn a_closed_track_stops_gating() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut audio = Media::new(&mut broadcast, &timeline, "audio0");
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
 		video.record(1, ms(2_000), true);
-		assert!(drain(&broadcast, &timeline).await.is_empty(), "audio still gates");
+		assert!(entries(&broadcast, &timeline).await.is_empty(), "audio still gates");
 
-		drop(audio);
-		let entries = drain(&broadcast, &timeline).await;
+		audio.close();
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(
 			entries,
 			vec![entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])])]
 		);
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 	}
 
@@ -1199,8 +1499,8 @@ mod test {
 	// others are still filling in.
 	#[tokio::test]
 	async fn reservations_nest() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 
 		let outer = timeline.reserve();
 		let inner = outer.clone();
@@ -1211,36 +1511,36 @@ mod test {
 
 		drop(inner);
 		assert!(
-			drain(&broadcast, &timeline).await.is_empty(),
+			entries(&broadcast, &timeline).await.is_empty(),
 			"the other clone still gates"
 		);
 
 		drop(outer);
 		assert_eq!(
-			drain(&broadcast, &timeline).await.len(),
+			entries(&broadcast, &timeline).await.len(),
 			2,
 			"the last clone dropped flushes"
 		);
 
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 	}
 
 	// A reservation outstanding when the broadcast ends must not strand the terminal flush.
 	#[tokio::test]
 	async fn finish_overrides_an_outstanding_reservation() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 		let reserved = timeline.reserve();
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(2_000), true);
 		video.end(ms(4_000));
-		drop(video);
+		video.close();
 
 		timeline.finish().unwrap();
 		assert_eq!(
-			drain(&broadcast, &timeline).await,
+			entries(&broadcast, &timeline).await,
 			vec![
 				entry(0, 0, 2_000, &[("video0", &[(0, 0)])]),
 				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
@@ -1265,8 +1565,8 @@ mod test {
 	// fMP4 importer does: it cuts at the keyframe fragment's timestamp, then records that group).
 	#[tokio::test]
 	async fn a_cut_on_the_first_group_does_not_poison_later_cuts() {
-		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
 
 		// Source segments every 3s, keyframes every 1s: 3s segments, not the 1s the
 		// duration_min pacing would produce on its own.
@@ -1278,14 +1578,197 @@ mod test {
 			}
 			video.record(seq, ms(seq * 1_000), true);
 		}
-		drop(video);
+		video.close();
 		timeline.finish().unwrap();
 
-		let entries = drain(&broadcast, &timeline).await;
+		let entries = entries(&broadcast, &timeline).await;
 		assert_eq!(
 			entries[0],
 			entry(0, 0, 3_000, &[("video0", &[(0, 2)])]),
 			"the source's 3s boundaries should be reproduced, not duration_min pacing"
 		);
+	}
+
+	/// A segment's record is retracted once its media leaves the cache. The whole point of the
+	/// window: a timeline must never advertise a segment a consumer would fail to fetch.
+	#[tokio::test]
+	async fn eviction_retracts_the_segment() {
+		let (mut broadcast, timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut watcher = watch(&broadcast, &timeline).await;
+
+		for seq in 0..4u64 {
+			video.record(seq, ms(seq * 2_000), true);
+		}
+		assert_eq!(appended(&collect(&mut watcher)), vec![0, 1, 2]);
+
+		// Segment 0 is carried by group 0. Losing it retracts the record naming it, which the
+		// next report sweeps.
+		video.evict(0);
+		video.record(4, ms(8_000), true);
+
+		let updates = collect(&mut watcher);
+		assert_eq!(trims(&updates), vec![1], "segment 0 is gone, so the head moves to 1");
+		assert_eq!(appended(&updates), vec![3], "the newly complete segment still lands");
+	}
+
+	/// A segment spans every enrolled track, so losing a group on ANY of them breaks it: a
+	/// consumer fetches the whole segment, and a hole in audio is as fatal as one in video.
+	#[tokio::test]
+	async fn a_segment_goes_when_any_track_loses_a_group() {
+		let (mut broadcast, timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut audio = Media::new(&mut broadcast, &timeline, "audio0");
+		let mut watcher = watch(&broadcast, &timeline).await;
+
+		for seq in 0..3u64 {
+			video.record(seq, ms(seq * 2_000), true);
+			audio.record(seq, ms(seq * 2_000), true);
+		}
+		assert_eq!(appended(&collect(&mut watcher)), vec![0, 1]);
+
+		// Video's group 0 is untouched; only audio's is lost.
+		audio.evict(0);
+		video.record(3, ms(6_000), true);
+		audio.record(3, ms(6_000), true);
+
+		assert_eq!(
+			trims(&collect(&mut watcher)),
+			vec![1],
+			"the segment goes even though video still has its group"
+		);
+	}
+
+	/// A cleanly finished group is still cached and fetchable, so its segment stays listed.
+	///
+	/// The trap this pins: watching completion rather than availability would retract every
+	/// segment the instant its groups finished, i.e. immediately and always.
+	#[tokio::test]
+	async fn a_finished_group_is_not_a_retraction() {
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut watcher = watch(&broadcast, &timeline).await;
+
+		video.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		video.finish_group(0);
+		video.finish_group(1);
+		video.record(2, ms(4_000), true);
+		video.close();
+		timeline.finish().unwrap();
+
+		let updates = collect(&mut watcher);
+		assert!(
+			trims(&updates).is_empty(),
+			"a finished group is still available: {updates:?}"
+		);
+		assert!(!appended(&updates).is_empty(), "and its segment is still listed");
+	}
+
+	/// Eviction is not strictly oldest-first (a FETCH refreshes a group past a newer one), and a
+	/// window has only a head. Losing a middle segment therefore drops the live records in front
+	/// of it rather than advertising a dead one.
+	#[tokio::test]
+	async fn out_of_order_eviction_drops_the_records_in_front() {
+		let (mut broadcast, timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut watcher = watch(&broadcast, &timeline).await;
+
+		for seq in 0..4u64 {
+			video.record(seq, ms(seq * 2_000), true);
+		}
+		assert_eq!(appended(&collect(&mut watcher)), vec![0, 1, 2]);
+
+		// Segment 1 goes while segment 0 is still fetchable.
+		video.evict(1);
+		video.record(4, ms(8_000), true);
+
+		assert_eq!(
+			trims(&collect(&mut watcher)),
+			vec![2],
+			"segment 0 goes with 1, so the head lands past both"
+		);
+	}
+
+	/// Eviction is charged from the frame-write path, so a group can die after the last record.
+	/// `finish` sweeps once more, or the track would close still listing unfetchable media and a
+	/// reader would take that clean end as a complete playlist.
+	#[tokio::test]
+	async fn finish_sweeps_media_lost_after_the_last_record() {
+		let (mut broadcast, mut timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut watcher = watch(&broadcast, &timeline).await;
+
+		video.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		video.record(2, ms(4_000), true);
+		video.close();
+
+		// Nothing will report again; only `finish` can notice this.
+		video.evict(0);
+		timeline.finish().unwrap();
+
+		assert_eq!(
+			trims(&collect(&mut watcher)),
+			vec![1],
+			"the final sweep retracted the lost segment"
+		);
+	}
+
+	/// A retraction that empties the window still has to name a segment, and the only honest
+	/// answer is one past the newest thing retracted. The window counts in its own positions, so
+	/// this pins the translation at the point where there is no surviving record to read it off.
+	#[tokio::test]
+	async fn a_retraction_that_empties_the_window_names_the_next_segment() {
+		let (mut broadcast, timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut watcher = watch(&broadcast, &timeline).await;
+
+		for seq in 0..4u64 {
+			video.record(seq, ms(seq * 2_000), true);
+		}
+		assert_eq!(appended(&collect(&mut watcher)), vec![0, 1, 2]);
+
+		// The whole cache goes at once, so every indexed segment is retracted together.
+		for seq in 0..4u64 {
+			video.evict(seq);
+		}
+		video.record(4, ms(8_000), true);
+
+		assert_eq!(
+			trims(&collect(&mut watcher)),
+			vec![3],
+			"nothing survives, so the head is one past the newest retracted segment"
+		);
+	}
+
+	/// Folding every update a live consumer receives leaves exactly the segments that are still
+	/// fetchable: an append adds one, a retraction drops everything before it.
+	#[tokio::test]
+	async fn the_updates_converge_on_the_available_segments() {
+		let (mut broadcast, timeline) = setup();
+		let mut video = Media::new(&mut broadcast, &timeline, "video0");
+		let mut watcher = watch(&broadcast, &timeline).await;
+
+		for seq in 0..6u64 {
+			video.record(seq, ms(seq * 2_000), true);
+		}
+		video.evict(0);
+		video.evict(1);
+		video.record(6, ms(12_000), true);
+
+		let mut held: Vec<u64> = Vec::new();
+		for update in collect(&mut watcher) {
+			match update {
+				// No wildcard: `#[non_exhaustive]` doesn't apply inside the defining crate, so
+				// this stays exhaustive and a new variant fails the build here on purpose.
+				Update::Append { entry } => held.push(entry.segment),
+				Update::Trim { segment } => held.retain(|&s| s >= segment),
+			}
+		}
+
+		// Groups 0 and 1 carried segments 0 and 1; everything from 2 on is still cached. Segment
+		// 5 is in there because recording group 6 is what bounded it, and the sweep runs first.
+		assert_eq!(held, vec![2, 3, 4, 5]);
 	}
 }

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -47,9 +47,9 @@
 //! ## Retraction follows the cache
 //!
 //! Trimming is driven by the media cache itself, not a timer. A segment's record names the
-//! group ranges that carry it, and the timeline keeps a [`moq_net::group::Consumer`] for every
-//! one of those groups, on every track. The record is retracted once any of them reports the
-//! group gone (evicted under cache pressure, aged out of the publisher's latency window, or
+//! group ranges that carry it, and the timeline keeps a [`moq_net::group::Availability`] for
+//! every one of those groups, on every track. The record is retracted once any of them reports
+//! the group gone (evicted under cache pressure, aged out of the publisher's latency window, or
 //! aborted), since a consumer fetches the whole segment and a hole anywhere in it breaks the
 //! segment just as thoroughly as a missing head.
 //!
@@ -129,9 +129,9 @@ struct Report {
 	pts: Timestamp,
 	/// Whether its first frame is a keyframe.
 	keyframe: bool,
-	/// A read handle on the group, held so the segment it lands in can watch it leave the
-	/// cache. Pins no frames, so this observes availability without extending it.
-	group: moq_net::group::Consumer,
+	/// Watches the group leave the cache, so the segment it lands in can be retracted. Pins no
+	/// frames, so this observes availability without extending it.
+	availability: moq_net::group::Availability,
 }
 
 /// One enrolled track's report state.
@@ -168,7 +168,7 @@ struct State {
 	/// One entry per record still in the window, oldest first, holding a handle for every group
 	/// the segment covers across every track. Kept in lockstep with the window, so its length is
 	/// what a trim count is measured against.
-	indexed: VecDeque<Vec<moq_net::group::Consumer>>,
+	indexed: VecDeque<Vec<moq_net::group::Availability>>,
 	/// Where the open (unflushed) segment starts; `None` until the first report.
 	start: Option<Timestamp>,
 	/// Explicit [`Producer::cut`] boundaries not yet reached, in order.
@@ -201,7 +201,7 @@ impl State {
 			sequence: group.sequence,
 			pts,
 			keyframe,
-			group: group.consume(),
+			availability: group.availability(),
 		});
 		self.advance(name, pts);
 	}
@@ -393,7 +393,7 @@ impl State {
 
 		// Every group this segment covers, across every track: the set whose availability the
 		// record's own availability is the AND of.
-		let mut covered: Vec<moq_net::group::Consumer> = Vec::new();
+		let mut covered: Vec<moq_net::group::Availability> = Vec::new();
 
 		for (name, track) in &mut self.tracks {
 			let mut ranges: Vec<Range> = Vec::new();
@@ -412,7 +412,7 @@ impl State {
 						ranges.push(range);
 					}
 				}
-				covered.push(report.group);
+				covered.push(report.availability);
 			}
 			if !ranges.is_empty() {
 				record.tracks.insert(name.clone(), ranges);
@@ -432,7 +432,7 @@ impl State {
 	///
 	/// The timeline is an optional sidecar, so a transport failure logs and stops publishing
 	/// rather than tearing down the media path.
-	fn emit(&mut self, record: Record, covered: Vec<moq_net::group::Consumer>) {
+	fn emit(&mut self, record: Record, covered: Vec<moq_net::group::Availability>) {
 		let Some(sink) = self.sink.as_mut() else {
 			return;
 		};
@@ -456,7 +456,8 @@ impl State {
 	/// whole point of the timeline; the cost is a shorter window, and eviction reaches those
 	/// records shortly anyway.
 	fn sweep(&mut self) {
-		let gone = |covered: &Vec<moq_net::group::Consumer>| covered.iter().any(moq_net::group::Consumer::is_closed);
+		let gone =
+			|covered: &Vec<moq_net::group::Availability>| covered.iter().any(moq_net::group::Availability::is_gone);
 		let Some(last) = self.indexed.iter().rposition(gone) else {
 			return;
 		};
@@ -723,10 +724,11 @@ impl Recorder {
 	/// Reports must be in group order with monotonic timestamps; this is the fact the timeline
 	/// builds ranges, boundaries and completeness from.
 	///
-	/// The timeline keeps a read handle on `group` to watch when it leaves the cache, which is
-	/// what retracts the segment carrying it. That pins no frames, and the caller keeps
-	/// ownership. Taking the group rather than its sequence number is also what makes the two
-	/// impossible to mismatch.
+	/// The timeline mints a [`moq_net::group::Availability`] from `group` to watch when it leaves
+	/// the cache, which is what retracts the segment carrying it. That pins no frames, and the
+	/// caller keeps ownership. Taking the producer rather than a sequence number is what makes the
+	/// two impossible to mismatch, and it is the only handle that can answer the question: the
+	/// cache being asked about is this one.
 	pub(crate) fn record(&mut self, group: &moq_net::group::Producer, pts: Timestamp, keyframe: bool) {
 		self.state.lock().unwrap().report(&self.name, group, pts, keyframe);
 	}

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -47,7 +47,7 @@
 //! ## Retraction follows the cache
 //!
 //! Trimming is driven by the media cache itself, not a timer. A segment's record names the
-//! group ranges that carry it, and the timeline keeps a [`moq_net::group::Availability`] for
+//! group ranges that carry it, and the timeline keeps a [`moq_net::group::Demand`] for
 //! every one of those groups, on every track. The record is retracted once any of them reports
 //! the group gone (evicted under cache pressure, aged out of the publisher's latency window, or
 //! aborted), since a consumer fetches the whole segment and a hole anywhere in it breaks the
@@ -131,7 +131,7 @@ struct Report {
 	keyframe: bool,
 	/// Watches the group leave the cache, so the segment it lands in can be retracted. Pins no
 	/// frames, so this observes availability without extending it.
-	availability: moq_net::group::Availability,
+	demand: moq_net::group::Demand,
 }
 
 /// One enrolled track's report state.
@@ -168,7 +168,7 @@ struct State {
 	/// One entry per record still in the window, oldest first, holding a handle for every group
 	/// the segment covers across every track. Kept in lockstep with the window, so its length is
 	/// what a trim count is measured against.
-	indexed: VecDeque<Vec<moq_net::group::Availability>>,
+	indexed: VecDeque<Vec<moq_net::group::Demand>>,
 	/// Where the open (unflushed) segment starts; `None` until the first report.
 	start: Option<Timestamp>,
 	/// Explicit [`Producer::cut`] boundaries not yet reached, in order.
@@ -201,7 +201,7 @@ impl State {
 			sequence: group.sequence,
 			pts,
 			keyframe,
-			availability: group.availability(),
+			demand: group.demand(),
 		});
 		self.advance(name, pts);
 	}
@@ -393,7 +393,7 @@ impl State {
 
 		// Every group this segment covers, across every track: the set whose availability the
 		// record's own availability is the AND of.
-		let mut covered: Vec<moq_net::group::Availability> = Vec::new();
+		let mut covered: Vec<moq_net::group::Demand> = Vec::new();
 
 		for (name, track) in &mut self.tracks {
 			let mut ranges: Vec<Range> = Vec::new();
@@ -412,7 +412,7 @@ impl State {
 						ranges.push(range);
 					}
 				}
-				covered.push(report.availability);
+				covered.push(report.demand);
 			}
 			if !ranges.is_empty() {
 				record.tracks.insert(name.clone(), ranges);
@@ -432,7 +432,7 @@ impl State {
 	///
 	/// The timeline is an optional sidecar, so a transport failure logs and stops publishing
 	/// rather than tearing down the media path.
-	fn emit(&mut self, record: Record, covered: Vec<moq_net::group::Availability>) {
+	fn emit(&mut self, record: Record, covered: Vec<moq_net::group::Demand>) {
 		let Some(sink) = self.sink.as_mut() else {
 			return;
 		};
@@ -456,8 +456,7 @@ impl State {
 	/// whole point of the timeline; the cost is a shorter window, and eviction reaches those
 	/// records shortly anyway.
 	fn sweep(&mut self) {
-		let gone =
-			|covered: &Vec<moq_net::group::Availability>| covered.iter().any(moq_net::group::Availability::is_gone);
+		let gone = |covered: &Vec<moq_net::group::Demand>| covered.iter().any(moq_net::group::Demand::is_closed);
 		let Some(last) = self.indexed.iter().rposition(gone) else {
 			return;
 		};
@@ -724,7 +723,7 @@ impl Recorder {
 	/// Reports must be in group order with monotonic timestamps; this is the fact the timeline
 	/// builds ranges, boundaries and completeness from.
 	///
-	/// The timeline mints a [`moq_net::group::Availability`] from `group` to watch when it leaves
+	/// The timeline mints a [`moq_net::group::Demand`] from `group` to watch when it leaves
 	/// the cache, which is what retracts the segment carrying it. That pins no frames, and the
 	/// caller keeps ownership. Taking the producer rather than a sequence number is what makes the
 	/// two impossible to mismatch, and it is the only handle that can answer the question: the

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -600,6 +600,17 @@ impl Producer {
 		}
 	}
 
+	/// Mint a handle watching whether this group's frames are still in the cache.
+	///
+	/// Minted here rather than from a [`Consumer`] because only the side that owns the cache can
+	/// answer the question: a reader's handle may be assembled across routes, none of which it
+	/// caches for. A relay mints one too, since it creates a [`Producer`] per group it caches.
+	pub fn availability(&self) -> Availability {
+		Availability {
+			state: self.state.consume(),
+		}
+	}
+
 	/// Block until the group is closed or aborted.
 	pub async fn closed(&self) -> Error {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
@@ -920,39 +931,51 @@ impl Consumer {
 	pub async fn finished(&mut self) -> Result<u64> {
 		kio::wait(|waiter| self.poll_finished(waiter)).await
 	}
+}
 
-	/// Whether the group can still deliver content.
+/// Watches whether a group's frames are still in the cache, and so whether it can still be
+/// fetched.
+///
+/// This is availability, not completion: a group that finished cleanly stays available while its
+/// frames are still retrievable, and goes once they aren't (evicted under memory pressure, aged
+/// out of the publisher's latency window, or aborted). An index track (a timeline, a playlist)
+/// watches this to learn which groups it can still point at.
+///
+/// Minted from a [`Producer`] via [`Producer::availability`], never from a [`Consumer`]: the
+/// question is about a specific cache, and only the side that owns one can answer it. Holding this
+/// pins no frames, so watching is free, and it is far smaller than a [`Consumer`] (which carries a
+/// read cursor and a frame prefetch it has no use for).
+pub struct Availability {
+	state: kio::Consumer<GroupState>,
+}
+
+impl Availability {
+	/// Whether the group is gone: its frames have left the cache and can no longer be fetched.
 	///
-	/// This is availability, not completion: a group that [`finished`](Self::finished) cleanly
-	/// stays open while its frames are still retrievable, and closes once they aren't. An index
-	/// track (a timeline, a playlist) watches this to learn which groups it can still point at.
-	/// Holding a [`Consumer`] does not keep the group's frames alive, so watching is free.
-	///
-	/// What ends availability depends on where the group came from, but the question is the same
-	/// either way: a group served by one publisher closes when that publisher's cache drops it
-	/// (evicted, aged out, or aborted), and a group spliced across route changes closes when the
-	/// assembly does, i.e. when no route can serve it again.
-	pub fn is_closed(&self) -> bool {
-		match &self.inner {
-			ConsumerKind::Plain(plain) => plain.state.is_closed(),
-			ConsumerKind::Spliced(spliced) => spliced.is_closed(),
-		}
+	/// Monotone. Once this is true it stays true, so a retraction driven off it never has to be
+	/// taken back.
+	pub fn is_gone(&self) -> bool {
+		self.state.is_closed()
 	}
 
-	/// Poll until the group is gone; ready with the cause. See [`is_closed`](Self::is_closed).
-	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Error> {
-		match &self.inner {
-			ConsumerKind::Plain(plain) => plain
-				.state
-				.poll_closed(waiter)
-				.map(|()| plain.state.read().abort.clone().unwrap_or(Error::Dropped)),
-			ConsumerKind::Spliced(spliced) => spliced.poll_closed(waiter),
-		}
+	/// Poll until the group is gone; ready with the cause. See [`is_gone`](Self::is_gone).
+	pub fn poll_gone(&self, waiter: &kio::Waiter) -> Poll<Error> {
+		self.state
+			.poll_closed(waiter)
+			.map(|()| self.state.read().abort.clone().unwrap_or(Error::Dropped))
 	}
 
-	/// Block until the group is gone, returning the cause. See [`is_closed`](Self::is_closed).
-	pub async fn closed(&self) -> Error {
-		kio::wait(|waiter| self.poll_closed(waiter)).await
+	/// Block until the group is gone, returning the cause. See [`is_gone`](Self::is_gone).
+	pub async fn gone(&self) -> Error {
+		kio::wait(|waiter| self.poll_gone(waiter)).await
+	}
+}
+
+impl Clone for Availability {
+	fn clone(&self) -> Self {
+		Self {
+			state: self.state.clone(),
+		}
 	}
 }
 
@@ -1671,47 +1694,65 @@ mod test {
 		assert!(matches!(result, Err(Error::FrameTooLarge)));
 	}
 
-	/// `Consumer::is_closed` reports availability, not completion: a finished group stays open
-	/// while it is still cached, and an abort (how the cache evicts) closes it. An index track
-	/// keying off this must not see a clean finish as "gone".
+	/// `Availability` reports availability, not completion: a finished group stays available while
+	/// it is still cached, and an abort (how the cache evicts) ends it. An index track keying off
+	/// this must not see a clean finish as "gone".
 	#[test]
-	fn consumer_closed_tracks_availability() {
+	fn availability_tracks_the_cache_not_completion() {
 		let mut producer = Info { sequence: 0 }.produce();
 		producer
 			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hi"))
 			.unwrap();
-		let consumer = producer.consume();
-		assert!(!consumer.is_closed());
+		let watching = producer.availability();
+		assert!(!watching.is_gone());
 
 		// Finishing completes the group but leaves it cached and fetchable.
 		producer.finish().unwrap();
-		assert!(!consumer.is_closed(), "a finished group is still available");
+		assert!(!watching.is_gone(), "a finished group is still available");
 
 		// Eviction aborts it, even though it finished cleanly.
 		producer.abort(Error::Evicted).unwrap();
-		assert!(consumer.is_closed());
+		assert!(watching.is_gone());
 		assert!(matches!(
-			consumer.poll_closed(&kio::Waiter::noop()),
+			watching.poll_gone(&kio::Waiter::noop()),
 			Poll::Ready(Error::Evicted)
 		));
 	}
 
 	/// Dropping the last producer (the track releasing a cached group without an explicit
-	/// abort) also closes the consumer, reported as `Dropped`.
+	/// abort) also ends availability, reported as `Dropped`.
 	#[test]
-	fn consumer_closed_on_producer_drop() {
+	fn availability_ends_on_producer_drop() {
 		let mut producer = Info { sequence: 0 }.produce();
 		producer
 			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hi"))
 			.unwrap();
 		producer.finish().unwrap();
 
-		let consumer = producer.consume();
+		let watching = producer.availability();
 		drop(producer);
-		assert!(consumer.is_closed());
+		assert!(watching.is_gone());
 		assert!(matches!(
-			consumer.poll_closed(&kio::Waiter::noop()),
+			watching.poll_gone(&kio::Waiter::noop()),
 			Poll::Ready(Error::Dropped)
 		));
+	}
+
+	/// Watching availability must not keep the group's frames alive, or an index track would pin
+	/// exactly the media it exists to stop advertising.
+	#[test]
+	fn availability_pins_no_frames() {
+		let mut producer = Info { sequence: 0 }.produce();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"data"))
+			.unwrap();
+
+		let watching = producer.availability();
+		producer.clone().abort(Error::Evicted).unwrap();
+
+		assert!(watching.is_gone());
+		let state = producer.state.read();
+		assert!(state.frames.is_empty(), "a watcher must not pin the cached frames");
+		assert_eq!(state.cache, 0);
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -600,14 +600,15 @@ impl Producer {
 		}
 	}
 
-	/// Mint a handle watching whether this group's frames are still in the cache.
+	/// Mint a watch-only handle for whether this group's frames are still in the cache.
 	///
 	/// Minted here rather than from a [`Consumer`] because only the side that owns the cache can
 	/// answer the question: a reader's handle may be assembled across routes, none of which it
 	/// caches for. A relay mints one too, since it creates a [`Producer`] per group it caches.
+	/// The group-level analogue of [`track::Producer::demand`].
 	pub fn availability(&self) -> Availability {
 		Availability {
-			state: self.state.consume(),
+			state: self.state.weak(),
 		}
 	}
 
@@ -942,11 +943,16 @@ impl Consumer {
 /// watches this to learn which groups it can still point at.
 ///
 /// Minted from a [`Producer`] via [`Producer::availability`], never from a [`Consumer`]: the
-/// question is about a specific cache, and only the side that owns one can answer it. Holding this
-/// pins no frames, so watching is free, and it is far smaller than a [`Consumer`] (which carries a
-/// read cursor and a frame prefetch it has no use for).
+/// question is about a specific cache, and only the side that owns one can answer it.
+///
+/// The watch-only counterpart to [`track::Demand`], and weak for the same reason: it holds no ref
+/// count, so it neither keeps the group open nor pins its cached frames, and it does not count as
+/// a consumer (a watcher is not a reader, and must not hold [`Producer::unused`] open). It does
+/// keep the state allocated, which is what lets [`gone`](Self::gone) still report the cause after
+/// the channel closed.
+#[derive(Clone)]
 pub struct Availability {
-	state: kio::Consumer<GroupState>,
+	state: kio::ProducerWeak<GroupState>,
 }
 
 impl Availability {
@@ -960,22 +966,17 @@ impl Availability {
 
 	/// Poll until the group is gone; ready with the cause. See [`is_gone`](Self::is_gone).
 	pub fn poll_gone(&self, waiter: &kio::Waiter) -> Poll<Error> {
-		self.state
-			.poll_closed(waiter)
-			.map(|()| self.state.read().abort.clone().unwrap_or(Error::Dropped))
+		self.state.poll_closed(waiter).map(|()| self.abort_reason())
 	}
 
 	/// Block until the group is gone, returning the cause. See [`is_gone`](Self::is_gone).
 	pub async fn gone(&self) -> Error {
 		kio::wait(|waiter| self.poll_gone(waiter)).await
 	}
-}
 
-impl Clone for Availability {
-	fn clone(&self) -> Self {
-		Self {
-			state: self.state.clone(),
-		}
+	/// The recorded abort reason, or [`Error::Dropped`] if the group went without one.
+	fn abort_reason(&self) -> Error {
+		self.state.read().abort.clone().unwrap_or(Error::Dropped)
 	}
 }
 
@@ -1754,5 +1755,31 @@ mod test {
 		let state = producer.state.read();
 		assert!(state.frames.is_empty(), "a watcher must not pin the cached frames");
 		assert_eq!(state.cache, 0);
+	}
+
+	/// A watcher is not a reader: it must not register as a consumer, or an on-demand publisher
+	/// waiting on `unused` would stall forever behind an index track that only ever watches.
+	/// This is why `Availability` is weak, matching `track::Demand`.
+	#[test]
+	fn availability_is_not_a_consumer() {
+		let mut producer = Info { sequence: 0 }.produce();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hi"))
+			.unwrap();
+
+		let watching = producer.availability();
+		assert!(
+			producer.unused().now_or_never().is_some(),
+			"a watcher must leave the group unused"
+		);
+
+		// A real reader does hold it, and dropping that reader releases it again.
+		let reader = producer.consume();
+		assert!(producer.unused().now_or_never().is_none());
+		drop(reader);
+		assert!(producer.unused().now_or_never().is_some());
+
+		// Still watching throughout, and still weak: it never kept the group open.
+		assert!(!watching.is_gone());
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -920,6 +920,40 @@ impl Consumer {
 	pub async fn finished(&mut self) -> Result<u64> {
 		kio::wait(|waiter| self.poll_finished(waiter)).await
 	}
+
+	/// Whether the group can still deliver content.
+	///
+	/// This is availability, not completion: a group that [`finished`](Self::finished) cleanly
+	/// stays open while its frames are still retrievable, and closes once they aren't. An index
+	/// track (a timeline, a playlist) watches this to learn which groups it can still point at.
+	/// Holding a [`Consumer`] does not keep the group's frames alive, so watching is free.
+	///
+	/// What ends availability depends on where the group came from, but the question is the same
+	/// either way: a group served by one publisher closes when that publisher's cache drops it
+	/// (evicted, aged out, or aborted), and a group spliced across route changes closes when the
+	/// assembly does, i.e. when no route can serve it again.
+	pub fn is_closed(&self) -> bool {
+		match &self.inner {
+			ConsumerKind::Plain(plain) => plain.state.is_closed(),
+			ConsumerKind::Spliced(spliced) => spliced.is_closed(),
+		}
+	}
+
+	/// Poll until the group is gone; ready with the cause. See [`is_closed`](Self::is_closed).
+	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Error> {
+		match &self.inner {
+			ConsumerKind::Plain(plain) => plain
+				.state
+				.poll_closed(waiter)
+				.map(|()| plain.state.read().abort.clone().unwrap_or(Error::Dropped)),
+			ConsumerKind::Spliced(spliced) => spliced.poll_closed(waiter),
+		}
+	}
+
+	/// Block until the group is gone, returning the cause. See [`is_closed`](Self::is_closed).
+	pub async fn closed(&self) -> Error {
+		kio::wait(|waiter| self.poll_closed(waiter)).await
+	}
 }
 
 impl Plain {
@@ -1635,5 +1669,49 @@ mod test {
 			timestamp: Timestamp::ZERO,
 		});
 		assert!(matches!(result, Err(Error::FrameTooLarge)));
+	}
+
+	/// `Consumer::is_closed` reports availability, not completion: a finished group stays open
+	/// while it is still cached, and an abort (how the cache evicts) closes it. An index track
+	/// keying off this must not see a clean finish as "gone".
+	#[test]
+	fn consumer_closed_tracks_availability() {
+		let mut producer = Info { sequence: 0 }.produce();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hi"))
+			.unwrap();
+		let consumer = producer.consume();
+		assert!(!consumer.is_closed());
+
+		// Finishing completes the group but leaves it cached and fetchable.
+		producer.finish().unwrap();
+		assert!(!consumer.is_closed(), "a finished group is still available");
+
+		// Eviction aborts it, even though it finished cleanly.
+		producer.abort(Error::Evicted).unwrap();
+		assert!(consumer.is_closed());
+		assert!(matches!(
+			consumer.poll_closed(&kio::Waiter::noop()),
+			Poll::Ready(Error::Evicted)
+		));
+	}
+
+	/// Dropping the last producer (the track releasing a cached group without an explicit
+	/// abort) also closes the consumer, reported as `Dropped`.
+	#[test]
+	fn consumer_closed_on_producer_drop() {
+		let mut producer = Info { sequence: 0 }.produce();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hi"))
+			.unwrap();
+		producer.finish().unwrap();
+
+		let consumer = producer.consume();
+		drop(producer);
+		assert!(consumer.is_closed());
+		assert!(matches!(
+			consumer.poll_closed(&kio::Waiter::noop()),
+			Poll::Ready(Error::Dropped)
+		));
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -600,14 +600,9 @@ impl Producer {
 		}
 	}
 
-	/// Mint a watch-only handle for whether this group's frames are still in the cache.
-	///
-	/// Minted here rather than from a [`Consumer`] because only the side that owns the cache can
-	/// answer the question: a reader's handle may be assembled across routes, none of which it
-	/// caches for. A relay mints one too, since it creates a [`Producer`] per group it caches.
-	/// The group-level analogue of [`track::Producer::demand`].
-	pub fn availability(&self) -> Availability {
-		Availability {
+	/// A watch-only handle to the group's reader demand and lifetime. See [`Demand`].
+	pub fn demand(&self) -> Demand {
+		Demand {
 			state: self.state.weak(),
 		}
 	}
@@ -934,47 +929,86 @@ impl Consumer {
 	}
 }
 
-/// Watches whether a group's frames are still in the cache, and so whether it can still be
-/// fetched.
+/// A cloneable, watch-only handle to a group's reader demand and lifetime.
 ///
-/// This is availability, not completion: a group that finished cleanly stays available while its
-/// frames are still retrievable, and goes once they aren't (evicted under memory pressure, aged
-/// out of the publisher's latency window, or aborted). An index track (a timeline, a playlist)
-/// watches this to learn which groups it can still point at.
+/// Obtained from [`Producer::demand`]; the group-level sibling of
+/// [`broadcast::Demand`](crate::broadcast::Demand) and [`track::Demand`](crate::track::Demand).
+/// [`used`](Self::used) / [`unused`](Self::unused) track whether anyone is reading the group, and
+/// [`is_closed`](Self::is_closed) tracks whether it still exists at all.
 ///
-/// Minted from a [`Producer`] via [`Producer::availability`], never from a [`Consumer`]: the
-/// question is about a specific cache, and only the side that owns one can answer it.
+/// It's a weak handle: it neither keeps the group alive, nor pins its cached frames, nor counts as
+/// a reader itself. It does keep the state allocated, which is what lets [`closed`](Self::closed)
+/// still report the cause after the channel closed.
 ///
-/// The watch-only counterpart to [`track::Demand`], and weak for the same reason: it holds no ref
-/// count, so it neither keeps the group open nor pins its cached frames, and it does not count as
-/// a consumer (a watcher is not a reader, and must not hold [`Producer::unused`] open). It does
-/// keep the state allocated, which is what lets [`gone`](Self::gone) still report the cause after
-/// the channel closed.
+/// ## Closed means gone, not finished
+///
+/// For a group, closure is the *availability* signal an index track (a timeline, a playlist) needs:
+/// a group that [`finished`](Consumer::finished) cleanly stays open while its frames are still
+/// retrievable, and closes once they aren't (evicted under memory pressure, aged out of the
+/// publisher's latency window, or aborted). Keying an index off a clean finish instead would retract
+/// everything the moment it was published.
+///
+/// Minted from a [`Producer`] rather than a [`Consumer`] because the question is about one specific
+/// cache, and only the side that owns a cache can answer it. A relay mints one too, since it creates
+/// a producer per group it caches.
 #[derive(Clone)]
-pub struct Availability {
+pub struct Demand {
 	state: kio::ProducerWeak<GroupState>,
 }
 
-impl Availability {
-	/// Whether the group is gone: its frames have left the cache and can no longer be fetched.
+impl Demand {
+	/// Whether the group has a reader right now.
+	///
+	/// A point-in-time snapshot with no registration; use [`used`](Self::used) /
+	/// [`unused`](Self::unused) (or their `poll_*` forms) to wait for the edge.
+	pub fn is_used(&self) -> bool {
+		self.state.is_used()
+	}
+
+	/// Block until the group has a reader. Resolves immediately if it already does.
+	pub async fn used(&self) -> Result<()> {
+		self.state.used().await.map_err(|_| self.abort_reason())
+	}
+
+	/// Block until the group has no readers. Resolves immediately if it has none.
+	pub async fn unused(&self) -> Result<()> {
+		self.state.unused().await.map_err(|_| self.abort_reason())
+	}
+
+	/// Poll-based variant of [`used`](Self::used).
+	pub fn poll_used(&self, waiter: &kio::Waiter) -> Poll<Result<()>> {
+		self.state
+			.poll_used(waiter)
+			.map(|res| res.ok_or_else(|| self.abort_reason()))
+	}
+
+	/// Poll-based variant of [`unused`](Self::unused).
+	pub fn poll_unused(&self, waiter: &kio::Waiter) -> Poll<Result<()>> {
+		self.state
+			.poll_unused(waiter)
+			.map(|res| res.ok_or_else(|| self.abort_reason()))
+	}
+
+	/// Whether the group is gone: its frames have left the cache, so nothing can fetch it.
 	///
 	/// Monotone. Once this is true it stays true, so a retraction driven off it never has to be
-	/// taken back.
-	pub fn is_gone(&self) -> bool {
+	/// taken back. See [the note above](Self#closed-means-gone-not-finished) on why this is
+	/// availability rather than completion.
+	pub fn is_closed(&self) -> bool {
 		self.state.is_closed()
 	}
 
-	/// Poll until the group is gone; ready with the cause. See [`is_gone`](Self::is_gone).
-	pub fn poll_gone(&self, waiter: &kio::Waiter) -> Poll<Error> {
+	/// Poll until the group is closed; ready with the cause. See [`is_closed`](Self::is_closed).
+	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Error> {
 		self.state.poll_closed(waiter).map(|()| self.abort_reason())
 	}
 
-	/// Block until the group is gone, returning the cause. See [`is_gone`](Self::is_gone).
-	pub async fn gone(&self) -> Error {
-		kio::wait(|waiter| self.poll_gone(waiter)).await
+	/// Block until the group is closed, returning the cause. See [`is_closed`](Self::is_closed).
+	pub async fn closed(&self) -> Error {
+		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
 
-	/// The recorded abort reason, or [`Error::Dropped`] if the group went without one.
+	/// The recorded abort reason, or [`Error::Dropped`] if the group closed without one.
 	fn abort_reason(&self) -> Error {
 		self.state.read().abort.clone().unwrap_or(Error::Dropped)
 	}
@@ -1695,63 +1729,63 @@ mod test {
 		assert!(matches!(result, Err(Error::FrameTooLarge)));
 	}
 
-	/// `Availability` reports availability, not completion: a finished group stays available while
-	/// it is still cached, and an abort (how the cache evicts) ends it. An index track keying off
+	/// `Demand::is_closed` reports availability, not completion: a finished group stays open while
+	/// it is still cached, and an abort (how the cache evicts) closes it. An index track keying off
 	/// this must not see a clean finish as "gone".
 	#[test]
-	fn availability_tracks_the_cache_not_completion() {
+	fn demand_closes_on_eviction_not_completion() {
 		let mut producer = Info { sequence: 0 }.produce();
 		producer
 			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hi"))
 			.unwrap();
-		let watching = producer.availability();
-		assert!(!watching.is_gone());
+		let watching = producer.demand();
+		assert!(!watching.is_closed());
 
 		// Finishing completes the group but leaves it cached and fetchable.
 		producer.finish().unwrap();
-		assert!(!watching.is_gone(), "a finished group is still available");
+		assert!(!watching.is_closed(), "a finished group is still available");
 
 		// Eviction aborts it, even though it finished cleanly.
 		producer.abort(Error::Evicted).unwrap();
-		assert!(watching.is_gone());
+		assert!(watching.is_closed());
 		assert!(matches!(
-			watching.poll_gone(&kio::Waiter::noop()),
+			watching.poll_closed(&kio::Waiter::noop()),
 			Poll::Ready(Error::Evicted)
 		));
 	}
 
 	/// Dropping the last producer (the track releasing a cached group without an explicit
-	/// abort) also ends availability, reported as `Dropped`.
+	/// abort) also closes it, reported as `Dropped`.
 	#[test]
-	fn availability_ends_on_producer_drop() {
+	fn demand_closes_on_producer_drop() {
 		let mut producer = Info { sequence: 0 }.produce();
 		producer
 			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hi"))
 			.unwrap();
 		producer.finish().unwrap();
 
-		let watching = producer.availability();
+		let watching = producer.demand();
 		drop(producer);
-		assert!(watching.is_gone());
+		assert!(watching.is_closed());
 		assert!(matches!(
-			watching.poll_gone(&kio::Waiter::noop()),
+			watching.poll_closed(&kio::Waiter::noop()),
 			Poll::Ready(Error::Dropped)
 		));
 	}
 
-	/// Watching availability must not keep the group's frames alive, or an index track would pin
-	/// exactly the media it exists to stop advertising.
+	/// Watching must not keep the group's frames alive, or an index track would pin exactly the
+	/// media it exists to stop advertising.
 	#[test]
-	fn availability_pins_no_frames() {
+	fn demand_pins_no_frames() {
 		let mut producer = Info { sequence: 0 }.produce();
 		producer
 			.write_frame(Timestamp::ZERO, Bytes::from_static(b"data"))
 			.unwrap();
 
-		let watching = producer.availability();
+		let watching = producer.demand();
 		producer.clone().abort(Error::Evicted).unwrap();
 
-		assert!(watching.is_gone());
+		assert!(watching.is_closed());
 		let state = producer.state.read();
 		assert!(state.frames.is_empty(), "a watcher must not pin the cached frames");
 		assert_eq!(state.cache, 0);
@@ -1759,15 +1793,16 @@ mod test {
 
 	/// A watcher is not a reader: it must not register as a consumer, or an on-demand publisher
 	/// waiting on `unused` would stall forever behind an index track that only ever watches.
-	/// This is why `Availability` is weak, matching `track::Demand`.
+	/// This is why `Demand` is weak, like its broadcast and track siblings.
 	#[test]
-	fn availability_is_not_a_consumer() {
+	fn demand_is_not_a_reader() {
 		let mut producer = Info { sequence: 0 }.produce();
 		producer
 			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hi"))
 			.unwrap();
 
-		let watching = producer.availability();
+		let watching = producer.demand();
+		assert!(!watching.is_used(), "a watcher must leave the group unused");
 		assert!(
 			producer.unused().now_or_never().is_some(),
 			"a watcher must leave the group unused"
@@ -1775,11 +1810,13 @@ mod test {
 
 		// A real reader does hold it, and dropping that reader releases it again.
 		let reader = producer.consume();
+		assert!(watching.is_used());
 		assert!(producer.unused().now_or_never().is_none());
 		drop(reader);
+		assert!(!watching.is_used());
 		assert!(producer.unused().now_or_never().is_some());
 
 		// Still watching throughout, and still weak: it never kept the group open.
-		assert!(!watching.is_gone());
+		assert!(!watching.is_closed());
 	}
 }

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -969,32 +969,6 @@ impl Group {
 		}
 	}
 
-	/// Whether the assembly is closed: no route can serve this group again.
-	///
-	/// A spliced group has no single publisher, so this is how it answers the availability
-	/// question [`group::Consumer::is_closed`] asks. A route dying is not enough: another can
-	/// still take over, so only the assembly itself closing is terminal.
-	pub fn is_closed(&self) -> bool {
-		// An abort is recorded in the state rather than by closing the channel (it has to survive
-		// for late subscribers to read the cause), so the channel's own flag only covers the
-		// producer being dropped. A clean `finish` is deliberately not closed: it means no further
-		// switches, and the segments already in place keep serving.
-		self.state.is_closed() || self.state.read().abort.is_some()
-	}
-
-	/// Poll until the assembly closes; ready with the cause. See [`is_closed`](Self::is_closed).
-	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Error> {
-		match self.state.poll(waiter, |state| match &state.abort {
-			Some(err) => Poll::Ready(err.clone()),
-			None => Poll::Pending,
-		}) {
-			Poll::Ready(Ok(err)) => Poll::Ready(err),
-			// The channel closed with no abort recorded: the producer was dropped.
-			Poll::Ready(Err(_)) => Poll::Ready(Error::Dropped),
-			Poll::Pending => Poll::Pending,
-		}
-	}
-
 	/// The logical group's total frame count, which only the unbounded tail copy knows:
 	/// its own count already includes the frames it skipped.
 	pub fn poll_finished(&mut self, waiter: &kio::Waiter) -> Poll<Result<u64>> {
@@ -2083,40 +2057,6 @@ mod test {
 		assert_eq!(counter.0.load(Ordering::SeqCst), 2, "second update lost its wakeup");
 		assert!(fut.as_mut().poll(&mut cx).is_pending());
 		assert_eq!(track_a.subscription().unwrap().priority, 2);
-	}
-
-	/// A spliced group reports availability the same way a plain one does, but a dying *route* is
-	/// not the end of availability: another can take over, so only the assembly closing is
-	/// terminal. An index track watching `is_closed` must not retract on a mid-group takeover.
-	#[tokio::test]
-	async fn spliced_group_stays_available_across_a_takeover() {
-		let (mut track_a, consumer_a) = track_pair("a");
-		// Bound, not dropped: B has to stay alive to be a live replacement route.
-		let (_track_b, consumer_b) = track_pair("b");
-
-		let mut producer = Producer::new();
-		producer.takeover(&consumer_a).unwrap();
-		let mut sub = producer.consume().subscribe(None);
-
-		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
-		group.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
-
-		let reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
-		assert!(!reading.is_closed(), "a live spliced group is available");
-
-		// A's route dies, but B takes the group over: still available, since a replacement can
-		// serve it. This is the case that separates availability from a plain group's cache.
-		producer.takeover(&consumer_b).unwrap();
-		track_a.abort(Error::Dropped).unwrap();
-		assert!(!reading.is_closed(), "a dead route is not a dead group");
-
-		// The assembly itself closing is what ends it.
-		producer.abort(Error::Evicted).unwrap();
-		assert!(reading.is_closed());
-		assert!(matches!(
-			reading.poll_closed(&kio::Waiter::noop()),
-			Poll::Ready(Error::Evicted)
-		));
 	}
 
 	/// A route dying partway through a group is resumed at the frame it stopped on:

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -969,6 +969,32 @@ impl Group {
 		}
 	}
 
+	/// Whether the assembly is closed: no route can serve this group again.
+	///
+	/// A spliced group has no single publisher, so this is how it answers the availability
+	/// question [`group::Consumer::is_closed`] asks. A route dying is not enough: another can
+	/// still take over, so only the assembly itself closing is terminal.
+	pub fn is_closed(&self) -> bool {
+		// An abort is recorded in the state rather than by closing the channel (it has to survive
+		// for late subscribers to read the cause), so the channel's own flag only covers the
+		// producer being dropped. A clean `finish` is deliberately not closed: it means no further
+		// switches, and the segments already in place keep serving.
+		self.state.is_closed() || self.state.read().abort.is_some()
+	}
+
+	/// Poll until the assembly closes; ready with the cause. See [`is_closed`](Self::is_closed).
+	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Error> {
+		match self.state.poll(waiter, |state| match &state.abort {
+			Some(err) => Poll::Ready(err.clone()),
+			None => Poll::Pending,
+		}) {
+			Poll::Ready(Ok(err)) => Poll::Ready(err),
+			// The channel closed with no abort recorded: the producer was dropped.
+			Poll::Ready(Err(_)) => Poll::Ready(Error::Dropped),
+			Poll::Pending => Poll::Pending,
+		}
+	}
+
 	/// The logical group's total frame count, which only the unbounded tail copy knows:
 	/// its own count already includes the frames it skipped.
 	pub fn poll_finished(&mut self, waiter: &kio::Waiter) -> Poll<Result<u64>> {
@@ -2063,6 +2089,40 @@ mod test {
 	/// the reader keeps the same group handle, sees no duplicate frames, and never
 	/// learns a route changed. This is the whole point of frame-precise boundaries
 	/// (a JSON append log's group may never roll).
+	/// A spliced group reports availability the same way a plain one does, but a dying *route* is
+	/// not the end of availability: another can take over, so only the assembly closing is
+	/// terminal. An index track watching `is_closed` must not retract on a mid-group takeover.
+	#[tokio::test]
+	async fn spliced_group_stays_available_across_a_takeover() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		// Bound, not dropped: B has to stay alive to be a live replacement route.
+		let (_track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
+
+		let reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert!(!reading.is_closed(), "a live spliced group is available");
+
+		// A's route dies, but B takes the group over: still available, since a replacement can
+		// serve it. This is the case that separates availability from a plain group's cache.
+		producer.takeover(&consumer_b).unwrap();
+		track_a.abort(Error::Dropped).unwrap();
+		assert!(!reading.is_closed(), "a dead route is not a dead group");
+
+		// The assembly itself closing is what ends it.
+		producer.abort(Error::Evicted).unwrap();
+		assert!(reading.is_closed());
+		assert!(matches!(
+			reading.poll_closed(&kio::Waiter::noop()),
+			Poll::Ready(Error::Evicted)
+		));
+	}
+
 	#[tokio::test]
 	async fn takeover_splices_mid_group() {
 		let (mut track_a, consumer_a) = track_pair("a");

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -2085,10 +2085,6 @@ mod test {
 		assert_eq!(track_a.subscription().unwrap().priority, 2);
 	}
 
-	/// A route dying partway through a group is resumed at the frame it stopped on:
-	/// the reader keeps the same group handle, sees no duplicate frames, and never
-	/// learns a route changed. This is the whole point of frame-precise boundaries
-	/// (a JSON append log's group may never roll).
 	/// A spliced group reports availability the same way a plain one does, but a dying *route* is
 	/// not the end of availability: another can take over, so only the assembly closing is
 	/// terminal. An index track watching `is_closed` must not retract on a mid-group takeover.
@@ -2123,6 +2119,10 @@ mod test {
 		));
 	}
 
+	/// A route dying partway through a group is resumed at the frame it stopped on:
+	/// the reader keeps the same group handle, sees no duplicate frames, and never
+	/// learns a route changed. This is the whole point of frame-precise boundaries
+	/// (a JSON append log's group may never roll).
 	#[tokio::test]
 	async fn takeover_splices_mid_group() {
 		let (mut track_a, consumer_a) = track_pair("a");


### PR DESCRIPTION
## Summary

- The media timeline was an append-only `moq_json::stream`, so it listed every segment ever published, including long-evicted ones. An HLS playlist built from it advertised segments that could no longer be fetched, and moq-hls papered over the misses by emitting `EXT-X-DISCONTINUITY` after a failed fetch.
- **Root cause of why removal was impossible:** a stream's whole log rides one group that is never rolled, and a consumer always starts at frame 0. Once moq-net evicted the earliest frames the track was bricked for late joiners (`Error::Lagged`), and with compression the retained suffix is undecodable anyway since its DEFLATE window depends on the evicted prefix. There was no shape in which a record could be dropped.
- Adds `moq_json::window`: each group is self-contained (snapshot at frame 0, then `{"append":V}` / `{"trim":N}` operations) and rolls once the records trimmed since the snapshot outnumber those still in the window. That bounds total bytes at roughly 2x an append-only log and lets old groups be dropped freely, since a late joiner reads only the newest.
- Trims are driven by the cache itself, via the new `group::Consumer::closed()`. Both moq-net eviction paths abort the group (`Error::Evicted` under pool pressure, `Error::Old` by age) and abort closes the shared state. A consumer handle pins no frames, so the timeline observes availability without extending it, and no task, timer, or callback is involved. The sweep runs as segments are recorded, which is also the only time the publisher's cache shrinks.
- A segment spans group ranges on **every** enrolled track, so its record is retracted once any group it covers is gone: a consumer fetches the whole segment, and a hole anywhere in it breaks the segment just as thoroughly as a missing head.
- moq-hls treats a retraction as the hard bound on the playlist, with the configured duration window staying a soft preference; whichever removes more wins.

### Design notes for reviewers

Three behaviors that are easy to get backwards, all pinned by tests:

- `group::Demand::is_closed()` is **availability, not completion**. A cleanly finished group stays open while it is still cached and fetchable; only the abort closes it. An index track keying off a clean finish would retract everything immediately. This matches `broadcast::Consumer`, which already pairs `is_closed` with `is_finished`. JS spells the same concept `Group.Consumer.gone`/`isGone`, because `closed` there already means completion (it settles `null` on a clean finish).
- An `Update::Trim` only ever retracts records the consumer **was told about**. The first snapshot adopts its offset silently, so a consumer joining a window that already trimmed gets no trim for records it never held; a gap surfaces instead as a jump in the first append's position. Note the corollary, which cost me two wrong tests: a late joiner *does* legitimately see a trim when the window has not rolled, because its snapshot included the record being retracted.
- Out-of-order eviction retracts the **live records in front** of the dead one. Eviction is not strictly oldest-first (a FETCH refreshes a group while a newer unread one is evicted in its place), and a window has a single head, so the choice is to advertise a dead record or drop the live ones ahead of it. Dropping them keeps the promise that everything listed is fetchable.

## Branch targeting

Targets `dev`, for a signature change to an exported symbol: `@moq/hang`'s `Container.Timeline.Recorder.record` now takes the `Moq.Group.Producer` rather than its sequence number, since the timeline has to hold a handle on the group to watch it leave the cache. Taking the group also makes the sequence impossible to mismatch with the group being watched.

This PR was originally written against `main`, before #2547 reworked the timeline into a per-broadcast segment index. It has been rebased onto `dev` and the integration **rewritten** against that model rather than ported; the diff against the old `main`-based branch is not meaningful. Building it against dev's real timeline is what validated the primitive, and it changed three things (see below).

## Public API changes

**Added**

- `rs/moq-net`: `group::Demand` and `group::Producer::demand()` that mints it, completing the `broadcast::Demand` / `track::Demand` family. Exposes `is_used`/`used`/`unused` (plus `poll_` forms) for reader interest, and `is_closed`/`closed`/`poll_closed` for whether the group still exists.
- `rs/moq-json`: the `window` module (`Producer`, `Consumer`, `Update`, `ProducerConfig`, `ConsumerConfig`), plus an `Error::Window` variant (the enum is `#[non_exhaustive]`).
- `js/json`: the `Window` namespace, mirroring the above.
- `js/net`: `Group.Consumer.{gone, isGone}`, `Group.Producer.evict()` (`@internal`), `Track.Subscriber.tryNextGroup()`.
- `rs/moq-mux`: `timeline::Update`.

**Changed**

- `js/hang`: `Container.Timeline.Recorder.record` signature, as above. This is the `dev` trigger.
- `rs/moq-mux`: `timeline::Consumer::{next, poll_next}` now yield `Update<E>` rather than `Entry<E>`, since an entry alone cannot express a retraction. `Entry` is unchanged and rides inside `Update::Append`. `Recorder::record` also takes the group, but it is `pub(crate)`.

**Wire format (breaking).** The timeline track changes from an append-only stream to a window. Nothing negotiates this: a new consumer against an old publisher errors rather than mis-parsing. That is acceptable *here specifically* because the catalog's `timeline` field was never specified — this PR is what specifies it, so breaking it now costs nothing and breaking it later would cost a version.

## What rebasing onto `dev` changed

Worth reading, since these are the parts that differ from the `main` version by more than mechanics:

1. **The primitive had to be reworked to exist, and that reshaped where it lives.** dev's `group::Consumer` is a `Plain`/`Spliced` enum (from the route-splicing work). Only `Plain` has a publisher whose cache can drop it; a `Spliced` group is a reader-side reassembly across routes, with no single publisher. Putting the signal on `Consumer` therefore gave it two different meanings under one name, and the `Spliced` one was not group-scoped at all: it read the whole logical *track's* routing state, so it stayed false for as long as the track kept publishing. An index track built on a subscriber's group would simply never retract. The signal moved to `group::Demand`, minted only by `group::Producer::demand()`, because only the side that owns a cache can answer the question. That removes the case with no honest answer instead of answering it badly. It also completes an existing family rather than inventing a parallel one: `broadcast::Demand` and `track::Demand` are already cloneable, weak, producer-minted handles reporting demand *and* lifetime, and `track::Demand` already pairs `used`/`unused` with `closed`. Being weak (`kio::ProducerWeak`, the same handle `track::Demand` uses) matters twice over: the per-record cost drops to a pointer instead of a `group::Consumer` carrying a read cursor and an inline 8-slot frame prefetch, and a watcher no longer registers as a reader, which would have held `group::Producer::unused()` open for as long as an index track kept watching.
2. **`position` became redundant, so it is gone from the timeline's API.** dev's `Record.segment` already exists and already anchors `EXT-X-MEDIA-SEQUENCE`. `timeline::Update` therefore speaks only segment numbers and never leaks the window's coordinate system; the consumer translates positions to segments internally, holding the pair rather than assuming the two coincide.
3. **Retraction generalized.** A dev segment spans group ranges across every enrolled track, so "retract when any covered group is gone" now covers the multi-track case the old per-rendition model could not express.

## Cross-Package Sync

- `rs/hang` catalog/container -> `js/hang`, `drafts/`: done. `draft-lcurley-moq-hang`'s Timeline section now specifies the window framing and the retraction rules.
- Two new drafts specify the formats: `draft-lcurley-moq-json` (snapshot / stream / window) and `draft-lcurley-moq-flate` (group compression, factored out since it is not JSON-specific). Cross-references are manual reference entries rather than `I-D.` anchors, since neither is on the datatracker yet; those become plain anchors once submitted.
- `doc/`: no change. The timeline is not documented on the site, and no CLI surface moved.

## Cross-language shape

Rust and JS now agree on the word: `Availability::{is_gone, gone}` against `Group.Consumer.{isGone, gone}`. The earlier `is_closed` vs `gone` divergence is gone with it.

What still differs is where the handle is minted: Rust from the producer, JS from a consumer. That asymmetry is deliberate rather than an oversight. `js/net` has no spliced groups, so its consumer-side signal has exactly one meaning and answers about the local cache in both the publish and subscribe directions. Mirroring the Rust shape there would be churn with no correctness payoff in an already-large diff.

## Review follow-ups

Two defects found reviewing the branch, fixed in `6427611ca`:

- **`moq-hls` dropped the wall-clock anchor on a retraction.** `Fanout::trim` cleared `Feed::anchor` whenever a trim emptied the replay history. The anchor maps the pts axis onto wall clock, and a retraction says nothing about that axis; only a timeline restart invalidates it. The next record then re-estimated from a fresh `now()`, jumping `EXT-X-PROGRAM-DATE-TIME` and DASH `availabilityStartTime` over unchanged content. The correlation makes it worse than a random jump: a retraction deep enough to empty the history means the publisher is shedding media, which is exactly when the anchor's "this segment just ended" assumption is least true. Two tests cover it, and the positive one was mutation-checked (it fails without the fix).
- A misplaced doc comment left `takeover_splices_mid_group` undocumented and the new spliced test carrying two comments.

## Test plan

- `just check` passes. `just rs ci` passes, including `cargo doc` with `-D warnings`.
- `just js check` and `bun test` pass.
- `just drafts check` (kramdown-rfc) passes on all 10 drafts. (The `HT characters` warning on the hang draft is pre-existing on `dev`: 32 tab-containing lines in its schema blocks, none of them touched here.)
- New Rust coverage: `group::Consumer` closing on eviction vs. surviving a clean finish; window append/trim/roll, lossless group switching, gap-as-position-jump, compression, and an unknown forward-compatible operation; timeline retraction on eviction, a segment going when *any* track loses a group, a finished group not counting as a retraction, out-of-order eviction dropping the records in front, the final sweep in `finish`, a retraction that empties the window, and a fold showing the updates converge on exactly the available segments; moq-hls trims dropping unfetchable segments, never rewinding the media sequence, surviving a trim past the window, and leaving the duration bound in force.
- New JS coverage: 8 tests in `js/json/src/window.test.ts` (two decode hand-written wire frames, so the decoder is verified against the byte shape rather than only against its own producer), plus 4 timeline retraction tests mirroring the Rust ones.

(Written by Opus 5)


