### PR TITLE
fix(net): abort a refused track instantly instead of sweeping and retrying

### DIFF
--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2014,10 +2014,12 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 						// the pollable (which is `Sync`) is held across the await.
 						let query = track.info().into_inner();
 						let skip = |id: u64| dead.contains(&id);
+						// The route-change edge is checked BEFORE the query result:
+						// a rejection is only authoritative while the source is
+						// still the dispatched route, and the two can resolve in
+						// the same wake. Taking a stale rejection here would turn
+						// a seamless handover into a terminal abort.
 						let info = kio::wait(|waiter| {
-							if let Poll::Ready(result) = query.poll(waiter) {
-								return Poll::Ready(Some(result));
-							}
 							match state.poll(waiter, |s| {
 								if s.closed || s.serve_route(skip) != Some(id) {
 									Poll::Ready(())
@@ -2025,9 +2027,10 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 									Poll::Pending
 								}
 							}) {
-								Poll::Ready(_) => Poll::Ready(None),
-								Poll::Pending => Poll::Pending,
+								Poll::Ready(_) => return Poll::Ready(None),
+								Poll::Pending => {}
 							}
+							query.poll(waiter).map(Some)
 						})
 						.await;
 						match info {
@@ -3739,6 +3742,51 @@ mod tests {
 		// One refusal is the verdict; the source is never re-asked.
 		assert!(matches!(subscribing.await, Err(Error::NotFound)));
 		dynamic.assert_no_request();
+	}
+
+	/// A rejection is only authoritative while its source is still the
+	/// dispatched route. Here a better route takes over while the original
+	/// source's info request is pending, and the stale source rejects at the
+	/// same moment: the handover must win, not the stale rejection.
+	#[tokio::test]
+	async fn test_stale_rejection_does_not_abort_a_handover() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+
+		let publisher = Origin::new(1).unwrap();
+		let peer = Origin::new(5).unwrap();
+		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
+		let local = OriginList::try_from(vec![publisher]).unwrap();
+
+		// The only route: dispatch parks on its pending info request.
+		let source_remote = origin
+			.create_broadcast("test", announce().with_hops(via_peer).with_cost(2))
+			.unwrap();
+		let mut dynamic_remote = source_remote.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let request_remote = dynamic_remote.requested_track().await.unwrap();
+
+		// A better route attaches (taking dispatch) while the old source's
+		// request is still pending; the old source rejects in the same window.
+		let source_local = origin.create_broadcast("test", announce().with_hops(local)).unwrap();
+		let mut dynamic_local = source_local.dynamic();
+		request_remote.reject(Error::NotFound);
+		settle().await;
+
+		// The subscription rides the handover onto the new route.
+		let mut producer_local = accept_track(&mut dynamic_local, "video").await;
+		settle().await;
+		let mut sub = subscribing
+			.await
+			.expect("the handover must win over the stale rejection");
+		producer_local.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+		sub.assert_not_closed();
 	}
 
 	/// A better source attaching mid-subscription takes the track over at an

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1173,11 +1173,6 @@ impl Producer {
 	}
 }
 
-/// How many times every attached source may refuse a single track (rejecting it,
-/// or never resolving its info) before the track is aborted instead of retried.
-/// Bounds the retry loop against a table that keeps rejecting one track.
-const MAX_TRACK_RETRIES: u32 = 3;
-
 /// How long a spliced track stays warm after its last reader leaves.
 ///
 /// Within the window a returning viewer, or the next of a run of back-to-back
@@ -1849,40 +1844,37 @@ async fn run_front(
 
 /// Serves one spliced logical track: splices in the best source's copy of the
 /// track, re-splicing on handover or failure, until the track completes or the
-/// front closes. A source that refuses the track (rejects it, or its info never
-/// resolves) is skipped for this track and the next-best route is tried; only a
-/// full sweep with every source refusing counts toward [`MAX_TRACK_RETRIES`],
-/// after which the track aborts as [`Error::Unroutable`]. Failures after a splice
-/// (a serving session dying mid-stream) are normal failover and re-splice from
-/// the next source at the first missing group.
+/// front closes. A source that refuses the track (rejects it, or hands over a
+/// copy that already ended in an error) aborts the logical track immediately:
+/// which tracks a broadcast carries is the publisher's contract (announce after
+/// the tracks exist), so the dispatched source's answer is authoritative and
+/// there is nothing to retry. Failures after a splice (a serving session dying
+/// mid-stream) are normal failover and re-splice from the next source at the
+/// first missing group; a source that errors while *closing* is likewise a
+/// corpse to fail over past (its watcher is about to detach it), not a verdict
+/// on the track.
 async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resume: super::resume::Producer) {
 	enum Step {
 		Closed,
 		Splice(u64, broadcast::Consumer),
 		Complete,
 		Failed,
-		/// The route we were serving from left the table and every source still in
-		/// it has refused this track: close out the sweep and try them again.
-		Resweep,
+		/// The route we were serving from left the table with nothing servable
+		/// to replace it (an empty table, or only corpses awaiting detach):
+		/// drop our handle and park for the table to move on.
+		NoRoute,
 		/// The linger expired with the track still unread: release the segment.
 		Idle,
 		/// A reader arrived or the last one left: recompute the demand gate.
 		Demand,
 	}
 
-	let mut fails = 0u32;
 	// The source whose copy is currently spliced in, and that copy.
 	let mut serving: Option<(u64, track::Consumer)> = None;
-	// Sources that refused this track. A standby joining a live front wins
-	// dispatch the moment it attaches, which is before a real publisher has
-	// created every track, so its refusal must cost the incumbent nothing: we
-	// keep serving from a route that has the track, and re-try the refuser on the
-	// next sweep.
-	let mut refused: HashSet<u64> = HashSet::new();
 	// Sources whose splice failed because they had already closed. Their watchers
 	// are about to detach them, so wait for the table to move on rather than
-	// burning the strike budget on a corpse (ids are never reused, so this cannot
-	// wedge).
+	// treating a corpse's error as the track's fate (ids are never reused, so
+	// this cannot wedge).
 	let mut dead: HashSet<u64> = HashSet::new();
 	// When the spliced segment stopped being read, starting the release countdown.
 	let mut idle_since: Option<web_async::time::Instant> = None;
@@ -1891,32 +1883,11 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 	loop {
 		let serving_id = serving.as_ref().map(|(id, _)| *id);
 
-		// Close out a sweep in which every attached source refused the track.
-		// Reached either by working through the table one refusal at a time, or by
-		// the route we were serving from leaving it, which is exactly the failover
-		// a refuser deserves to be re-tried on. Re-trying is what lets a publisher
-		// that had not created the track yet serve it once it has, so the sweep
-		// itself is the strike: a track no source will ever carry still ends after
-		// [`MAX_TRACK_RETRIES`] of them rather than looping forever.
+		// Drop corpses the table has detached, so a source that reattaches (under
+		// a fresh id) is dispatchable while a still-detaching one stays skipped.
 		{
 			let s = state.read();
-			refused.retain(|id| s.routes.iter().any(|r| r.id == *id));
 			dead.retain(|id| s.routes.iter().any(|r| r.id == *id));
-			let exhausted = !s.routes.is_empty()
-				&& s.serve_route(|id| refused.contains(&id) || dead.contains(&id))
-					.is_none();
-			// A sweep blocked only by a source we watched close is not the table's
-			// verdict: park for its detach instead of spending a strike.
-			if exhausted && dead.is_empty() {
-				drop(s);
-				fails += 1;
-				if fails >= MAX_TRACK_RETRIES {
-					tracing::debug!(name = %name, "aborting unservable track");
-					let _ = resume.abort(Error::Unroutable);
-					return;
-				}
-				refused.clear();
-			}
 		}
 
 		// Demand gates both directions: an unread track never splices a source in,
@@ -1938,12 +1909,11 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		deadline.set(idle_since.and_then(|at| at.checked_add(TRACK_IDLE_LINGER)));
 
 		let step = {
-			let skip = |id: u64| refused.contains(&id) || dead.contains(&id);
+			let skip = |id: u64| dead.contains(&id);
 			kio::wait(|waiter| {
 				// Watch the source table: the front closing, a better servable
-				// source than the one spliced in (skipping any we already know
-				// can't serve this track), or the served route leaving the table,
-				// which retires the refusals collected against it. Splicing waits
+				// source than the one spliced in (skipping corpses awaiting
+				// detach), or the served route leaving the table. Splicing waits
 				// for a reader.
 				match state.poll(waiter, |s| {
 					let gone = serving_id.is_some_and(|id| !s.routes.iter().any(|r| r.id == id));
@@ -1960,7 +1930,7 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 							return Poll::Ready(Step::Closed);
 						}
 						let Some(next) = guard.serve_route(skip) else {
-							return Poll::Ready(Step::Resweep);
+							return Poll::Ready(Step::NoRoute);
 						};
 						let source = guard
 							.routes
@@ -2011,21 +1981,18 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 				return;
 			}
 			Step::Failed => {
-				// The spliced copy died mid-serve: failover, not a strike.
-				// Re-splice from the (possibly same) active source.
+				// The spliced copy died mid-serve: failover. Re-splice from the
+				// (possibly same) active source.
 				serving = None;
 			}
 			// The outer loop recomputes `used` and the countdown on the next pass.
 			Step::Demand => {}
-			// The sweep is closed out at the top of the loop, which clears the
-			// refusals so the retry below picks a source.
-			//
 			// Forget which route we were serving from, or the `gone` edge that woke
 			// us keeps firing: the id stays absent from the table, the wait returns
 			// Ready at once, and the loop spins on a full core without ever parking.
 			// The segment itself stays spliced into `resume` (readers keep whatever
 			// it delivered) until a replacement is proven servable.
-			Step::Resweep => serving = None,
+			Step::NoRoute => serving = None,
 			Step::Idle => {
 				// Nobody has read the track for the linger: drop the source's copy so
 				// its session can release the track (and the cached `track::Info` that
@@ -2046,7 +2013,7 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 						// `into_inner` sheds the `Pending` future wrapper so only
 						// the pollable (which is `Sync`) is held across the await.
 						let query = track.info().into_inner();
-						let skip = |id: u64| refused.contains(&id) || dead.contains(&id);
+						let skip = |id: u64| dead.contains(&id);
 						let info = kio::wait(|waiter| {
 							if let Poll::Ready(result) = query.poll(waiter) {
 								return Poll::Ready(Some(result));
@@ -2064,12 +2031,10 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 						})
 						.await;
 						match info {
-							// The table changed under us; retry from the top
-							// without a strike.
+							// The table changed under us; re-pick from the top.
 							None => continue,
 							// A copy that is already aborted can't be spliced;
-							// count a strike, or a source pinning a dead track
-							// alive would spin this loop without ever yielding.
+							// its error is the source's answer for the track.
 							Some(Ok(_)) => match track.poll_complete(&kio::Waiter::noop()) {
 								Poll::Ready(Err(err)) => Err(err),
 								_ => Ok(track),
@@ -2087,28 +2052,25 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 							// aborted); nothing left to serve.
 							return;
 						}
-						// A successful splice proves the track servable: reset
-						// the strike budget. `refused` stays: re-trying the
-						// refusers now would only re-refuse and re-splice, and
-						// the loop would spin. A failover clears it instead.
-						fails = 0;
 						dead.clear();
 						serving = Some((id, track));
 					}
 					// The source itself closed or deliberately ended: not a
-					// rejection, so no strike. Park until its watcher detaches
+					// verdict on the track. Park until its watcher detaches
 					// it and the table promotes a replacement.
 					Err(_) if source.is_closing() => {
 						dead.insert(id);
 						serving = None;
 					}
-					// This source can't serve the track: rule it out of this track
-					// only and let the next-best route try. The strike is spent by
-					// the sweep, at the top of the loop.
+					// The dispatched source does not carry the track, and its
+					// answer is authoritative: a publisher announces a broadcast
+					// only once its tracks exist, so there is no later sweep that
+					// would find the track and nothing to retry. Fail now, loudly,
+					// with the source's own error.
 					Err(err) => {
-						tracing::debug!(name = %name, source = id, %err, "source refused track");
-						refused.insert(id);
-						serving = None;
+						tracing::debug!(name = %name, source = id, %err, "source refused track; aborting");
+						let _ = resume.abort(err);
+						return;
 					}
 				}
 			}
@@ -3752,10 +3714,11 @@ mod tests {
 		late.assert_closed();
 	}
 
-	/// A successful splice resets the retry budget: transient pre-splice failures
-	/// spread over a track's lifetime never accumulate into an abort.
+	/// A source rejecting a track ends the logical track immediately, with the
+	/// source's own error: which tracks a broadcast carries is the publisher's
+	/// contract, so there is no sweep of other routes and no retry budget.
 	#[tokio::test]
-	async fn test_serve_resets_retry_budget() {
+	async fn test_refused_track_aborts_instantly() {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
@@ -3768,26 +3731,14 @@ mod tests {
 		settle().await;
 		let broadcast = consumer.request_broadcast("test").await.unwrap();
 
-		// Queue the track; the subscription resolves once a serve finally sticks.
 		let subscribing = broadcast.track("video").unwrap().subscribe(None);
-
-		// Alternate a pre-splice failure with a successful splice, well past the
-		// retry cap; the resets keep the track alive.
-		for _ in 0..2 * MAX_TRACK_RETRIES {
-			let request = tokio::time::timeout(std::time::Duration::from_secs(1), dynamic.requested_track())
-				.await
-				.expect("timed out waiting for a retry")
-				.unwrap();
-			request.reject(Error::NotFound);
-			let producer = accept_track(&mut dynamic, "video").await;
-			settle().await;
-			drop(producer);
-		}
-
-		let _producer = accept_track(&mut dynamic, "video").await;
+		let request = dynamic.requested_track().await.unwrap();
+		request.reject(Error::NotFound);
 		settle().await;
-		let mut sub = subscribing.await.unwrap();
-		sub.assert_not_closed();
+
+		// One refusal is the verdict; the source is never re-asked.
+		assert!(matches!(subscribing.await, Err(Error::NotFound)));
+		dynamic.assert_no_request();
 	}
 
 	/// A better source attaching mid-subscription takes the track over at an
@@ -4201,12 +4152,11 @@ mod tests {
 	///
 	/// An ungraceful loss empties the route table while the front waits out its
 	/// linger, so the route a track is spliced from is gone with no replacement to
-	/// serve it: the resweep. The task has to park for the whole window on the
-	/// strength of dropping the departed route, because nothing else bounds it. The
-	/// strike budget is gated on `!routes.is_empty()`, so an empty table never spends
-	/// one, and a "route gone" edge that keeps firing yields a wait that is Ready on
-	/// every poll: a full core per subscribed track, and the runtime that has to
-	/// deliver the reconnect starved along with it.
+	/// serve it. The task has to park for the whole window on the strength of
+	/// dropping the departed route, because nothing else bounds it: a "route gone"
+	/// edge that keeps firing yields a wait that is Ready on every poll, a full
+	/// core per subscribed track, and the runtime that has to deliver the
+	/// reconnect starved along with it.
 	///
 	/// Under a paused clock that spin never yields, so a regression hangs here
 	/// rather than failing.
@@ -4818,14 +4768,13 @@ mod tests {
 		sub.assert_not_closed();
 	}
 
-	/// The standby wins dispatch the instant it attaches, which is before a real
-	/// publisher has created every track: a live `moq import` announces its
-	/// broadcast on connect and only creates each track once its demuxer reaches
-	/// it. Refusing one track must cost the incumbent nothing (#2473, e2e finding
-	/// 2 in the field): the subscription keeps flowing from the route that has the
-	/// track, and the standby is re-tried once it does.
+	/// A standby that wins dispatch without carrying the track ends the logical
+	/// track immediately, even over an incumbent that was serving it: which
+	/// tracks a broadcast carries is the publisher's contract (announce after
+	/// the tracks exist), so the newly-dispatched source's refusal is the
+	/// track's verdict rather than the start of a retry sweep.
 	#[tokio::test]
-	async fn test_standby_missing_track_keeps_incumbent() {
+	async fn test_standby_missing_track_aborts() {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
@@ -4851,42 +4800,22 @@ mod tests {
 		producer_remote.append_group().unwrap();
 		assert_eq!(sub.assert_group().sequence, 0);
 
-		// The standby joins and wins dispatch, but has not created "audio" yet.
-		// Refuse it more times than the strike budget: the old code aborted the
-		// logical track after three, killing a subscription the incumbent was
-		// happily serving.
+		// The standby joins and wins dispatch, but has not created "audio" yet:
+		// its refusal ends the logical track, incumbent notwithstanding.
 		let source_local = origin.create_broadcast("test", announce().with_hops(local)).unwrap();
 		let mut dynamic_local = source_local.dynamic();
 		settle().await;
-		for _ in 0..2 * MAX_TRACK_RETRIES {
-			if let Some(Ok(request)) = dynamic_local.requested_track().now_or_never() {
-				assert_eq!(request.name(), "audio");
-				request.reject(Error::NotFound);
-			}
-			settle().await;
-		}
-
-		// Still spliced to the incumbent, still delivering.
-		producer_remote.append_group().unwrap();
-		assert_eq!(sub.assert_group().sequence, 1);
-		sub.assert_not_closed();
-
-		// The incumbent going away re-tries the standby, which by now has the
-		// track: the subscription splices across instead of ending.
-		source_remote.abort(Error::Dropped).unwrap();
+		let request = dynamic_local.requested_track().await.unwrap();
+		assert_eq!(request.name(), "audio");
+		request.reject(Error::NotFound);
 		settle().await;
-		settle().await;
-		let mut producer_local = accept_track(&mut dynamic_local, "audio").await;
-		settle().await;
-		producer_local.create_group(group::Info { sequence: 2 }).unwrap();
-		assert_eq!(sub.assert_group().sequence, 2);
-		sub.assert_not_closed();
+		sub.assert_closed();
 	}
 
-	/// A track every source refuses still aborts, but the verdict is not cached:
-	/// it belongs to the sources attached at the time, so a later request re-asks
-	/// them. Otherwise one early request for a track the publisher had not created
-	/// yet leaves the name dead for the life of the front.
+	/// A refused track aborts, but the verdict is not cached: it belongs to the
+	/// request that received it, so a later request re-asks the source. Otherwise
+	/// one early request for a track the publisher had not created yet leaves the
+	/// name dead for the life of the front.
 	#[tokio::test]
 	async fn test_unservable_track_retried_by_a_later_request() {
 		tokio::time::pause();
@@ -4900,14 +4829,12 @@ mod tests {
 		settle().await;
 		let broadcast = consumer.request_broadcast("test").await.unwrap();
 
-		// Nothing serves it: the strike budget runs out and the track aborts.
+		// Nothing serves it: the refusal aborts the track with the source's error.
 		let subscribing = broadcast.track("audio").unwrap().subscribe(None);
-		for _ in 0..MAX_TRACK_RETRIES {
-			let request = dynamic.requested_track().await.unwrap();
-			request.reject(Error::NotFound);
-			settle().await;
-		}
-		assert!(matches!(subscribing.await, Err(Error::Unroutable)));
+		let request = dynamic.requested_track().await.unwrap();
+		request.reject(Error::NotFound);
+		settle().await;
+		assert!(matches!(subscribing.await, Err(Error::NotFound)));
 
 		// The publisher has the track now; a fresh request must reach it.
 		let retry = broadcast.track("audio").unwrap().subscribe(None);
@@ -4955,13 +4882,11 @@ mod tests {
 		settle().await;
 
 		// The peer is pinned to the clean source, so the fallback the front would
-		// take for everyone else is not reachable from their subscription.
-		for _ in 0..2 * MAX_TRACK_RETRIES {
-			if let Some(Ok(request)) = dynamic_clean.requested_track().now_or_never() {
-				request.reject(Error::NotFound);
-			}
-			settle().await;
-		}
+		// take for everyone else is not reachable from their subscription: the
+		// refusal aborts the track rather than asking the tainted route.
+		let request = dynamic_clean.requested_track().await.unwrap();
+		request.reject(Error::NotFound);
+		settle().await;
 		dynamic_tainted.assert_no_request();
 	}
 


### PR DESCRIPTION
## What

A source that rejects a track (or hands over a copy that already ended in an error) now aborts the logical track immediately, propagating the source's own error. `MAX_TRACK_RETRIES`, the `refused` set, the per-sweep strike budget, and the sweep-exhausted check are all deleted from `serve_track`.

What stays:
- A source that errors while **closing** is still parked as a corpse (`dead`) and failed over past once its watcher detaches it.
- Mid-stream death of a spliced copy is still failover, not a verdict.
- A refusal verdict is still not cached: a later request re-asks the source (test updated to pin this).

What flips:
- `test_standby_missing_track_keeps_incumbent` is now `test_standby_missing_track_aborts`: a standby that wins dispatch without carrying the track ends the logical track, incumbent notwithstanding. Which tracks a broadcast carries is the publisher's contract - announce after the tracks exist.
- The abort error is the source's own (e.g. `NotFound`) rather than `Unroutable` after three sweeps.

## Why

Production incident on moq.pro (2026-08-04): a 1-vCPU relay wedged for 35+ minutes with one `serve_track` task spinning at 100% CPU inside a single poll. perf showed the task's poll never returning: `route_order` + `prefer_untainted` + `RequestId` hashing dominated, `broadcast::Consumer::track` and `resume` takeover ran every iteration, and the starved runtime took `/health`, `/metrics`, and all logging down with it (single worker thread). The trigger was fleet-wide `.stats` track-subscribe churn: lazily-created tier tracks mean thousands of subscribe attempts per minute fleet-wide, each driving the refusal sweep.

The retry machinery is what gave the loop its unbounded states: several Ready paths spend no strike (`Resweep`, the inner-wait `None => continue`, corpse parking), so under continuous churn the sweep budget never fires. Removing the machinery removes those states outright, and with it the O(routes) `serve_route` sweep call that ran at the top of every loop iteration.

The retry loop was also pointless at the design level: whether a broadcast advertises a track is knowable at dispatch, so a refusal is a publisher contract violation to fail loudly on, not something to retry into existence.

## Testing

- `cargo test -p moq-net` (631) and `cargo test -p moq-relay` (177) pass; clippy and fmt clean.
- Rewrote the four tests that pinned the sweep semantics: instant abort with the source's error, standby refusal aborts over an incumbent, later requests still re-ask, and split-horizon exclusion still never asks a tainted route.

(written by Fable 5)