### PR TITLE
fix(moq-video): unbreak the d3d11-resize-probe example on Windows

### DIFF
--- a/rs/moq-video/examples/d3d11-resize-probe.rs
+++ b/rs/moq-video/examples/d3d11-resize-probe.rs
@@ -888,7 +888,9 @@ mod probe {
 			SOURCE.height,
 			TARGET.width,
 			TARGET.height,
-			mae(got.y(), expected.y())
+			// `into_i420` hands back one packed buffer, so its luma is the leading
+			// `width * height` bytes rather than a plane accessor.
+			mae(got.y(), &expected[..TARGET.pixels() as usize])
 		);
 		Ok(())
 	}
@@ -1127,6 +1129,9 @@ mod probe {
 		eprintln!("[ladder] primed the decoder; starting live decode and the rungs");
 
 		let stop = &AtomicBool::new(false);
+		// Outside the scope alongside `stop`: a scoped thread's borrow has to
+		// outlive the scope, which a binding declared inside it does not.
+		let start = &Barrier::new(2);
 		let frames = &frames;
 		std::thread::scope(|scope| -> Result<()> {
 			let mut workers = Vec::with_capacity(RUNGS);
@@ -1157,7 +1162,6 @@ mod probe {
 				}));
 			}
 
-			let start = &Barrier::new(2);
 			let scale_device = device.clone();
 			let scale_source = source.clone();
 			let scale_worker = scope.spawn(move || -> Result<()> {


### PR DESCRIPTION
`just rs windows` has failed on `main` since #2601 landed. The recipe builds `--all-targets`, and `rs/moq-video/examples/d3d11-resize-probe.rs` does not compile.

Nothing catches this: PR CI is Linux-only, and the release-time backstop builds `libmoq` rather than moq-video's examples. So the only Windows gate the repo has has been red, and anyone running it has had to look past the failure to see their own.

Found while running the gate for #2626; unrelated to that work, so it goes on its own against `main`.

## The two breaks

**`expected.y()` is not a method.** `Surface::into_i420` hands back one packed buffer rather than an `I420`, so there is no plane accessor on it. The luma is the leading `width * height` bytes:

```rust
mae(got.y(), &expected[..TARGET.pixels() as usize])
```

`got` is still an `I420` (it comes from the probe's own `download_i420`), so only the right-hand side changes.

**`let start = &Barrier::new(2);` sat inside the `thread::scope` closure.** Temporary lifetime extension reaches the end of that closure's block, but `scope.spawn` needs the borrow to outlive the scope, so the temporary is dropped while still borrowed. Hoisted one scope out next to `stop`, which is already the same idiom:

```rust
let stop = &AtomicBool::new(false);
let start = &Barrier::new(2);
let frames = &frames;
std::thread::scope(|scope| -> Result<()> {
```

## Verification

Run on a Windows host: `just rs windows` is clean, the whole recipe, for the first time since #2601. The probe itself needs a GPU to run, which is unchanged by this; the point here is that it compiles again so the recipe covers everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Opus 5)