### PR TITLE
feat(relay): assemble the relay in `Relay::load` instead of `main`

### DIFF
--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -391,6 +391,13 @@ pub struct Cluster {
 	/// returns) so traffic classes land in separate counter sets. Defaults
 	/// to a disabled (no-op) registry until [`with_stats`](Self::with_stats) is called.
 	pub stats: moq_net::stats::Registry,
+
+	/// Keeps the stats publish task running for as long as any handle on this
+	/// cluster lives. The task holds only a `Weak` to its producer, so it stops
+	/// when the last [`moq_stats::Producer`] clone drops; parking one here means
+	/// serving and publishing end together, instead of publishing ending early
+	/// because a caller dropped a producer it never asked for.
+	_stats_publisher: Option<moq_stats::Producer>,
 }
 
 impl Cluster {
@@ -424,6 +431,7 @@ impl Cluster {
 			info,
 			origin,
 			stats: moq_net::stats::Registry::disabled(),
+			_stats_publisher: None,
 		})
 	}
 
@@ -473,15 +481,16 @@ impl Cluster {
 		self.connection_ids.fetch_add(1, Ordering::Relaxed)
 	}
 
-	/// Attach a stats registry. Replaces the default disabled registry.
+	/// Attach a stats producer, replacing the default disabled registry with its
+	/// registry and taking over keeping its publish task alive.
 	///
-	/// Build a publishing `moq_stats::Producer` with
-	/// [`StatsConfig::build`](crate::StatsConfig::build) (passing
-	/// [`Self::origin`] so it publishes through the same origin cluster peers
-	/// read from) and pass its registry here; keep the producer alive for as
-	/// long as the cluster runs.
-	pub fn with_stats(mut self, stats: moq_net::stats::Registry) -> Self {
-		self.stats = stats;
+	/// Build one with [`StatsConfig::build`](crate::StatsConfig::build), passing
+	/// [`Self::origin`] so it publishes through the same origin cluster peers read
+	/// from. The cluster holds the producer from here on, so the caller may drop
+	/// its own handle: publishing lasts exactly as long as the cluster does.
+	pub fn with_stats(mut self, stats: moq_stats::Producer) -> Self {
+		self.stats = stats.registry().clone();
+		self._stats_publisher = Some(stats);
 		self
 	}
 
@@ -1107,6 +1116,57 @@ where
 mod tests {
 	use super::*;
 	use crate::Config;
+
+	/// The publish task holds only a `Weak` to its producer, so it stops when the
+	/// last `moq_stats::Producer` clone drops. Attaching one must therefore hand
+	/// its lifetime to the cluster: an embedder driving its own loop takes the
+	/// pieces it needs off a `Relay` and drops the rest, and a relay that keeps
+	/// serving while silently publishing nothing is exactly the class of failure
+	/// this API exists to rule out. Moving the ONLY handle in must keep it alive.
+	///
+	/// Asserts the broadcast is still live AFTER a few publish intervals, not
+	/// merely that one appeared: the task publishes once before it can notice its
+	/// producer is gone, so a first announcement races through either way and
+	/// proves nothing.
+	#[tokio::test]
+	async fn stats_publishing_outlives_the_producer_handle() {
+		let config = crate::StatsConfig {
+			enabled: Some(true),
+			node: Some("test".to_string()),
+			..Default::default()
+		};
+
+		let cluster = Cluster::new(ClusterConfig::default()).expect("cluster");
+		let stats = config.build(cluster.origin.clone());
+		let cluster = cluster.with_stats(stats);
+
+		let path = moq_net::Path::new(".stats").join("node").join("test");
+		let broadcast = tokio::time::timeout(
+			std::time::Duration::from_secs(5),
+			cluster.origin.consume().announced_broadcast(&path),
+		)
+		.await
+		.expect("stats broadcast announced within 5s")
+		.expect("stats broadcast present");
+
+		// Several publish intervals (1s each by default) after the handle went out
+		// of scope, the task is still running and its broadcast still open. The
+		// re-check is bounded: without the keepalive the broadcast is gone and
+		// `announced_broadcast` waits forever, which must read as a failure rather
+		// than a hung test.
+		tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+		let still_live = tokio::time::timeout(
+			std::time::Duration::from_secs(2),
+			cluster.origin.consume().announced_broadcast(&path),
+		)
+		.await;
+		assert!(
+			matches!(still_live, Ok(Some(_))),
+			"stats broadcast unannounced after the producer handle was dropped: \
+			 the publish task stopped while the cluster kept serving"
+		);
+		drop(broadcast);
+	}
 
 	/// `?cost=` is read and stripped (it rides SETUP, not the URL), other
 	/// query params survive, and a garbage value is an error rather than a

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -5,7 +5,10 @@
 //! or any other stream. Clustering, JWT authentication, WebSocket
 //! fallback, and an HTTP API are all included.
 //!
-//! See `main.rs` for a complete example of how these pieces fit together.
+//! [`Relay::load`] assembles every piece from a [`Config`]; [`Relay::run`] drives
+//! the stock loop, and embedders with their own workers or routes destructure a
+//! `Relay` instead of reproducing the sequence. `main.rs` is a thin wrapper over
+//! the two.
 
 mod auth;
 mod cache;
@@ -15,6 +18,7 @@ mod connection;
 mod http_client;
 mod internal;
 mod nodes;
+mod relay;
 mod stats;
 #[cfg(test)]
 mod test_env;
@@ -38,5 +42,6 @@ pub use cluster::*;
 pub use config::*;
 pub use connection::*;
 pub use internal::*;
+pub use relay::*;
 pub use stats::*;
 pub use web::*;

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -1,6 +1,4 @@
-use moq_relay::*;
-
-use anyhow::Context;
+use moq_relay::{Config, Relay};
 
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
@@ -14,105 +12,7 @@ async fn main() -> anyhow::Result<()> {
 		.install_default()
 		.expect("failed to install default crypto provider");
 
-	let mut config = Config::load()?;
-
-	config.client.quic.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
-	config.server.quic.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
-
-	let mtls_enabled = !config.server.tls.root.is_empty();
-
-	#[allow(unused_mut)]
-	let mut server = config.server.init()?;
-	let client = config.client.clone().init()?;
-
-	// `None` for a stream-only server (no QUIC); any other error is real.
-	let addr = match server.local_addr() {
-		Ok(addr) => Some(addr),
-		Err(moq_native::Error::NoBackend(_)) => None,
-		Err(err) => return Err(err).context("failed to resolve the QUIC bind address"),
-	};
-
-	#[cfg(feature = "iroh")]
-	let (server, client) = match config.iroh.bind(&config.client.quic).await? {
-		Some(iroh) => (server.with_iroh(iroh.clone()), client.with_iroh(iroh)),
-		None => (server, client),
-	};
-
-	// Reject configs where neither JWT nor mTLS can authenticate anyone.
-	if config.auth.is_empty() {
-		anyhow::ensure!(
-			mtls_enabled,
-			"no auth-key, auth-key-dir, public path, or server tls.root configured; \
-			 nobody can authenticate"
-		);
-		tracing::warn!("no JWT/public auth configured; only mTLS peers will be accepted");
-	}
-
-	let auth = if config.auth.is_empty() {
-		// mTLS-only: no JWT/public source, but `--auth-mtls-tier` still applies.
-		Auth::default().with_mtls_tier(config.auth.mtls_tier.clone())
-	} else {
-		config.auth.init(&config.client.tls).await?
-	};
-
-	let cache = config.cache.init()?;
-	let cluster = Cluster::new(config.cluster)?
-		.with_cache(cache)
-		.with_client(client)
-		.with_client_tls(config.client.tls.build()?);
-	// Keep the producer alive for the whole run: its publish task stops when
-	// the last clone drops. The cluster only needs the counter registry.
-	let stats = config.stats.build(cluster.origin.clone());
-	let cluster = cluster.with_stats(stats.registry().clone());
-
-	// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
-	// /metrics + /health + /nodes, separate from the customer-facing web server. No-op
-	// when unconfigured.
-	let internal = Internal::new(config.internal, cluster.stats.clone()).with_cluster(&cluster);
-
-	// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
-	let web = Web::new(auth.clone(), cluster.clone(), server.certificates(), config.web);
-
-	match addr {
-		Some(addr) => tracing::info!(%addr, "listening"),
-		None => tracing::info!("listening (stream transports only)"),
-	}
-
-	#[cfg(unix)]
-	// Notify systemd that we're ready after all initialization is complete
-	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
-
-	#[cfg(feature = "jemalloc")]
-	let jemalloc = moq_native::jemalloc::run();
-	#[cfg(not(feature = "jemalloc"))]
-	let jemalloc = std::future::pending::<anyhow::Result<()>>();
-
-	tokio::select! {
-		Err(err) = cluster.clone().run() => return Err(err).context("cluster failed"),
-		Err(err) = web.run() => return Err(err).context("web server failed"),
-		Err(err) = internal.run() => return Err(err).context("internal server failed"),
-		Err(err) = serve(server, cluster, auth) => return Err(err).context("server failed"),
-		Err(err) = jemalloc => return Err(err).context("jemalloc profiler failed"),
-		else => Ok(()),
-	}
-}
-
-async fn serve(mut server: moq_native::Server, cluster: Cluster, auth: Auth) -> anyhow::Result<()> {
-	while let Some(request) = server.accept().await {
-		let conn = Connection {
-			// Shared with outbound cluster dials so one id space covers every session.
-			id: cluster.next_connection_id(),
-			request,
-			cluster: cluster.clone(),
-			auth: auth.clone(),
-		};
-
-		tokio::spawn(async move {
-			if let Err(err) = conn.run().await {
-				tracing::warn!(%err, "connection closed");
-			}
-		});
-	}
-
-	anyhow::bail!("stopped accepting connections")
+	// The whole startup sequence lives in `Relay::load` rather than here, so an
+	// embedder gets it by calling one function instead of copying this file.
+	Relay::load(Config::load()?).await?.run().await
 }

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -6,25 +6,21 @@
 //!
 //! # Why this is a type and not just `main`
 //!
-//! An embedder that wants the relay PLUS its own workers - extra routes on the
-//! web server, an in-process recorder against [`Cluster::origin`], another
-//! listener in its own `select!` - used to have no choice but to copy `main`'s
-//! body, because the assembly lived there. That copy then rots: this crate is
-//! consumed as a git dependency, so a step added here arrives as a library
-//! update with no call site on the other end, and the embedder silently keeps
-//! the old behavior. Two such omissions ran on a production fleet for days
-//! (an unbounded group cache whose `--cache-capacity` parsed and was dropped,
-//! and a `/nodes` endpoint that answered `200` with an empty list), because
-//! the config still parses either way and nothing errors.
+//! An embedder wanting the relay PLUS its own workers - extra routes on the web
+//! server, an in-process recorder against [`Cluster::origin`], another listener
+//! in its own `select!` - takes the assembled pieces from [`Relay::load`] and
+//! drives them, instead of reproducing the sequence.
 //!
-//! So the assembly is a public type: embedders call [`Relay::load`] and
-//! destructure it, rather than reproducing the sequence. A step added to
-//! `load` reaches every consumer on their next update, which is the whole
-//! point.
+//! That distinction matters because this crate is consumed as a git dependency.
+//! A caller who copies the sequence gets a step added here as a library update
+//! with no call site on their end, and nothing says so: the config still parses,
+//! nothing errors, and the feature reports as configured while doing nothing.
+//! Calling `load` means a new step arrives with the update, and a reshaped API
+//! is a compile error.
 //!
-//! Ordering constraints live here too, where they can't be dropped in a copy.
-//! [`Cluster::with_cache`] rebuilds the origin, so it runs before anything
-//! derives a handle from it (the stats producer, and every session after).
+//! Ordering constraints live here for the same reason. [`Cluster::with_cache`]
+//! rebuilds the origin, so it runs before anything derives a handle from it (the
+//! stats producer, and every session after).
 
 use anyhow::Context;
 
@@ -36,6 +32,11 @@ use crate::{Auth, Cluster, Config, Connection, DEFAULT_MAX_STREAMS, Internal, We
 /// own event loop (mount extra routes on [`Self::web`], spawn workers against
 /// [`Cluster::origin`], add listeners to its own `select!`). Use [`Self::run`]
 /// when the stock behavior is what you want.
+///
+/// `#[non_exhaustive]`, so destructure with a trailing `..` (a pattern naming
+/// every field does not compile outside this crate) or move out the fields you
+/// need one at a time. Dropping any field you do not name is safe: the pieces
+/// that must outlive setup are owned by [`Self::cluster`].
 #[non_exhaustive]
 pub struct Relay {
 	/// The QUIC/WebTransport server, already bound. Feed it to [`serve`].
@@ -51,8 +52,9 @@ pub struct Relay {
 	/// The shared cluster: the origin every session and peer publishes into.
 	pub cluster: Cluster,
 
-	/// The stats producer. Keep it alive for as long as the relay runs: its
-	/// publish task stops when the last clone drops.
+	/// The stats producer, exposed for embedders that publish their own counters
+	/// through it. [`Self::cluster`] holds a clone, so the publish task lives as
+	/// long as the cluster whether or not this handle is kept.
 	pub stats: moq_stats::Producer,
 
 	/// The internal (ops) listener: `/metrics`, `/health`, `/nodes`. Inert
@@ -122,10 +124,10 @@ impl Relay {
 			.with_cache(cache)
 			.with_client(client.clone())
 			.with_client_tls(config.client.tls.build()?);
-		// Keep the producer alive for the whole run: its publish task stops when
-		// the last clone drops. The cluster only needs the counter registry.
 		let stats = config.stats.build(cluster.origin.clone());
-		let cluster = cluster.with_stats(stats.registry().clone());
+		// The cluster takes over keeping the publish task alive, so an embedder that
+		// drops the producer keeps publishing for as long as it serves.
+		let cluster = cluster.with_stats(stats.clone());
 
 		// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
 		// /metrics + /health + /nodes, separate from the customer-facing web server. No-op
@@ -162,14 +164,10 @@ impl Relay {
 			server,
 			auth,
 			cluster,
-			stats,
 			internal,
 			web,
 			..
 		} = self;
-
-		// Held so the stats publish task outlives the setup that built it.
-		let _stats = stats;
 
 		#[cfg(unix)]
 		// Notify systemd that we're ready after all initialization is complete

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -1,0 +1,218 @@
+//! The assembled relay: every startup step, in one place, in the right order.
+//!
+//! [`Relay::load`] turns a [`Config`] into the running pieces (server, client,
+//! auth, cluster, stats, internal + web listeners), and [`Relay::run`] drives
+//! them. `main.rs` is a thin wrapper over the two.
+//!
+//! # Why this is a type and not just `main`
+//!
+//! An embedder that wants the relay PLUS its own workers - extra routes on the
+//! web server, an in-process recorder against [`Cluster::origin`], another
+//! listener in its own `select!` - used to have no choice but to copy `main`'s
+//! body, because the assembly lived there. That copy then rots: this crate is
+//! consumed as a git dependency, so a step added here arrives as a library
+//! update with no call site on the other end, and the embedder silently keeps
+//! the old behavior. Two such omissions ran on a production fleet for days
+//! (an unbounded group cache whose `--cache-capacity` parsed and was dropped,
+//! and a `/nodes` endpoint that answered `200` with an empty list), because
+//! the config still parses either way and nothing errors.
+//!
+//! So the assembly is a public type: embedders call [`Relay::load`] and
+//! destructure it, rather than reproducing the sequence. A step added to
+//! `load` reaches every consumer on their next update, which is the whole
+//! point.
+//!
+//! Ordering constraints live here too, where they can't be dropped in a copy.
+//! [`Cluster::with_cache`] rebuilds the origin, so it runs before anything
+//! derives a handle from it (the stats producer, and every session after).
+
+use anyhow::Context;
+
+use crate::{Auth, Cluster, Config, Connection, DEFAULT_MAX_STREAMS, Internal, Web};
+
+/// A fully assembled relay: the listeners and the shared cluster behind them.
+///
+/// Fields are public so an embedder can take the pieces it needs and drive its
+/// own event loop (mount extra routes on [`Self::web`], spawn workers against
+/// [`Cluster::origin`], add listeners to its own `select!`). Use [`Self::run`]
+/// when the stock behavior is what you want.
+#[non_exhaustive]
+pub struct Relay {
+	/// The QUIC/WebTransport server, already bound. Feed it to [`serve`].
+	pub server: moq_native::Server,
+
+	/// The client used to dial cluster peers. Already handed to [`Self::cluster`];
+	/// clone it for your own outbound dials so they share the connection config.
+	pub client: moq_native::Client,
+
+	/// The resolved auth policy (JWT/public sources, or mTLS-only).
+	pub auth: Auth,
+
+	/// The shared cluster: the origin every session and peer publishes into.
+	pub cluster: Cluster,
+
+	/// The stats producer. Keep it alive for as long as the relay runs: its
+	/// publish task stops when the last clone drops.
+	pub stats: moq_stats::Producer,
+
+	/// The internal (ops) listener: `/metrics`, `/health`, `/nodes`. Inert
+	/// unless `internal.listen` is configured.
+	pub internal: Internal,
+
+	/// The customer-facing web server. [`Web::routes`] + [`Web::serve`] to mount
+	/// your own routes onto it; [`Web::run`] serves just the relay's own.
+	pub web: Web,
+
+	/// The QUIC bind address, or `None` for a stream-only server (no QUIC).
+	pub addr: Option<std::net::SocketAddr>,
+}
+
+impl Relay {
+	/// Assemble a relay from its configuration: bind the listeners, resolve
+	/// auth, and build the cluster with its cache and stats attached.
+	///
+	/// This performs the side effects of starting up (binding sockets, reading
+	/// key material, spawning the cache governor), so a returned `Relay` is
+	/// ready to serve; nothing accepts a connection until [`Self::run`] (or
+	/// [`serve`]) drives it.
+	pub async fn load(mut config: Config) -> anyhow::Result<Self> {
+		config.client.quic.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
+		config.server.quic.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
+
+		let mtls_enabled = !config.server.tls.root.is_empty();
+
+		#[allow(unused_mut)]
+		let mut server = config.server.init()?;
+		let client = config.client.clone().init()?;
+
+		// `None` for a stream-only server (no QUIC); any other error is real.
+		let addr = match server.local_addr() {
+			Ok(addr) => Some(addr),
+			Err(moq_native::Error::NoBackend(_)) => None,
+			Err(err) => return Err(err).context("failed to resolve the QUIC bind address"),
+		};
+
+		#[cfg(feature = "iroh")]
+		let (server, client) = match config.iroh.bind(&config.client.quic).await? {
+			Some(iroh) => (server.with_iroh(iroh.clone()), client.with_iroh(iroh)),
+			None => (server, client),
+		};
+
+		// Reject configs where neither JWT nor mTLS can authenticate anyone.
+		if config.auth.is_empty() {
+			anyhow::ensure!(
+				mtls_enabled,
+				"no auth-key, auth-key-dir, public path, or server tls.root configured; \
+				 nobody can authenticate"
+			);
+			tracing::warn!("no JWT/public auth configured; only mTLS peers will be accepted");
+		}
+
+		let auth = if config.auth.is_empty() {
+			// mTLS-only: no JWT/public source, but `--auth-mtls-tier` still applies.
+			Auth::default().with_mtls_tier(config.auth.mtls_tier.clone())
+		} else {
+			config.auth.init(&config.client.tls).await?
+		};
+
+		// Before any origin handle is derived: `with_cache` rebuilds the origin, so a
+		// handle taken earlier would keep charging groups into the unbounded pool.
+		let cache = config.cache.init()?;
+		let cluster = Cluster::new(config.cluster)?
+			.with_cache(cache)
+			.with_client(client.clone())
+			.with_client_tls(config.client.tls.build()?);
+		// Keep the producer alive for the whole run: its publish task stops when
+		// the last clone drops. The cluster only needs the counter registry.
+		let stats = config.stats.build(cluster.origin.clone());
+		let cluster = cluster.with_stats(stats.registry().clone());
+
+		// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
+		// /metrics + /health + /nodes, separate from the customer-facing web server. No-op
+		// when unconfigured.
+		let internal = Internal::new(config.internal, cluster.stats.clone()).with_cluster(&cluster);
+
+		// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
+		let web = Web::new(auth.clone(), cluster.clone(), server.certificates(), config.web);
+
+		match addr {
+			Some(addr) => tracing::info!(%addr, "listening"),
+			None => tracing::info!("listening (stream transports only)"),
+		}
+
+		Ok(Relay {
+			server,
+			client,
+			auth,
+			cluster,
+			stats,
+			internal,
+			web,
+			addr,
+		})
+	}
+
+	/// Serve until something fails: accept sessions, run the cluster, and serve
+	/// both HTTP surfaces. Notifies systemd once everything is up.
+	///
+	/// Drive the pieces yourself instead when you have your own workers or
+	/// routes to add; this is the stock loop.
+	pub async fn run(self) -> anyhow::Result<()> {
+		let Relay {
+			server,
+			auth,
+			cluster,
+			stats,
+			internal,
+			web,
+			..
+		} = self;
+
+		// Held so the stats publish task outlives the setup that built it.
+		let _stats = stats;
+
+		#[cfg(unix)]
+		// Notify systemd that we're ready after all initialization is complete
+		let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
+
+		#[cfg(feature = "jemalloc")]
+		let jemalloc = moq_native::jemalloc::run();
+		#[cfg(not(feature = "jemalloc"))]
+		let jemalloc = std::future::pending::<anyhow::Result<()>>();
+
+		tokio::select! {
+			Err(err) = cluster.clone().run() => Err(err).context("cluster failed"),
+			Err(err) = web.run() => Err(err).context("web server failed"),
+			Err(err) = internal.run() => Err(err).context("internal server failed"),
+			Err(err) = serve(server, cluster, auth) => Err(err).context("server failed"),
+			Err(err) = jemalloc => Err(err).context("jemalloc profiler failed"),
+			else => Ok(()),
+		}
+	}
+}
+
+/// Accept sessions off `server` until it stops, spawning a [`Connection`] task
+/// for each.
+///
+/// Public because an embedder running its own `select!` still needs the accept
+/// loop, and reimplementing it means re-deriving details like where a `conn` id
+/// comes from.
+pub async fn serve(mut server: moq_native::Server, cluster: Cluster, auth: Auth) -> anyhow::Result<()> {
+	while let Some(request) = server.accept().await {
+		let conn = Connection {
+			// Shared with outbound cluster dials so one id space covers every session.
+			id: cluster.next_connection_id(),
+			request,
+			cluster: cluster.clone(),
+			auth: auth.clone(),
+		};
+
+		tokio::spawn(async move {
+			if let Err(err) = conn.run().await {
+				tracing::warn!(%err, "connection closed");
+			}
+		});
+	}
+
+	anyhow::bail!("stopped accepting connections")
+}

--- a/rs/moq-relay/src/stats.rs
+++ b/rs/moq-relay/src/stats.rs
@@ -78,10 +78,10 @@ impl StatsConfig {
 	/// Build a [`moq_stats::Producer`] from this config, publishing on `origin`.
 	///
 	/// Returns a no-op producer when [`Self::enabled`] is false, so the relay can
-	/// attach the result unconditionally. Hand the producer's
-	/// [`registry`](moq_stats::Producer::registry) to the cluster and keep the
-	/// producer itself alive for as long as the relay runs (its publish task
-	/// stops when the last clone drops).
+	/// attach the result unconditionally. Hand it to
+	/// [`Cluster::with_stats`](crate::Cluster::with_stats), which takes over both
+	/// the registry and keeping the publish task alive (the task stops when the
+	/// last clone of the producer drops).
 	pub fn build(&self, origin: origin::Producer) -> moq_stats::Producer {
 		if !self.enabled.unwrap_or(false) {
 			return moq_stats::Producer::new(moq_stats::ProducerConfig::new());


### PR DESCRIPTION
## The problem

The relay's startup sequence lives in `main.rs`. An embedder that wants the relay **plus** its own workers - extra routes on the web server, a recorder consuming `Cluster::origin`, another listener in its own `select!` - has no way to reuse it, so it copies `main`'s body.

That copy rots, and it rots quietly. This crate is consumed as a git dependency, so a step added here arrives as a library update with **no call site** on the other end. The embedder keeps its old behavior, and nothing says so: the config still parses (embedders typically flatten `moq_relay::Config` wholesale), nothing errors, the feature just silently does nothing.

Not hypothetical - three omissions of exactly this shape ran on a production fleet built on this crate:

- `CacheConfig::init` + `Cluster::with_cache` were never called, so the group cache pool ran **unbounded** while `--cache-capacity` was set, parsed, and dropped.
- `Internal::with_cluster` was omitted, so `/nodes` answered `200` with an empty node list - a fleet that reads as quiet rather than broken.
- `Auth::with_mtls_tier` was dropped on the mTLS-only branch, which meters cert-verified peers on the default tier.

## The change

Make the assembly the public surface instead of something to copy:

- `Relay::load(config)` performs the whole sequence (stream limits, listeners, auth, the cache-bounded cluster, stats, both HTTP surfaces) and returns the assembled pieces as public fields.
- `Relay::run(self)` drives the stock loop.
- `main` is now a wrapper over the two - 18 lines.
- `serve` becomes public, because an embedder running its own `select!` still needs the accept loop, and reimplementing it means re-deriving details like drawing the `conn` id from the cluster's shared counter rather than a local one.

An embedder now destructures a `Relay` and drives its own loop. A step added to `load` reaches them on their next update, and reshaping the API is a **compile error** instead of a silent divergence. Ordering constraints move into `load` too, where a copy can't drop them: `Cluster::with_cache` rebuilds the origin, so it runs before anything derives a handle from it.

## Behavior

No change to the standalone binary; the sequence is identical, just relocated. The one difference is that the cluster gets a **clone** of the client so `Relay` can also expose it (that is how an embedder reuses the mesh's connection config for its own dials). `Client` is a handle struct with no `Drop` impl, so the extra clone is inert - and `Relay::run` dropping its copy leaves the cluster's alive.

`cargo clippy --all-targets` clean with and without `--features iroh`, `cargo fmt --check` clean, `cargo test -p moq-relay` green (13 passed).

(written by Opus 5)