### PR TITLE
docs(net): say who owns the broadcast behind Announce.Broadcast.active

### DIFF
--- a/js/net/src/announced.ts
+++ b/js/net/src/announced.ts
@@ -186,7 +186,14 @@ export class Broadcast {
 	/** The broadcast path this handle watches. */
 	readonly path: Path.Valid;
 
-	/** The live broadcast, or `undefined` while it is offline. */
+	/**
+	 * The live broadcast, or `undefined` while it is offline.
+	 *
+	 * Borrowed, not yours to close: this handle owns the consumer and swaps it when the path is
+	 * republished. Closing it leaves `active` pointing at a dead one, so reads fail until the
+	 * next announcement replaces it. Take a {@link broadcast.Consumer.clone} for a lifetime of
+	 * your own, or close this whole handle to release everything.
+	 */
 	readonly active: Getter<broadcast.Consumer | undefined>;
 
 	#active = new Signal<broadcast.Consumer | undefined>(undefined);

--- a/js/net/src/announced.ts
+++ b/js/net/src/announced.ts
@@ -190,9 +190,10 @@ export class Broadcast {
 	 * The live broadcast, or `undefined` while it is offline.
 	 *
 	 * Borrowed, not yours to close: this handle owns the consumer and swaps it when the path is
-	 * republished. Closing it leaves `active` pointing at a dead one, so reads fail until the
-	 * next announcement replaces it. Take a {@link broadcast.Consumer.clone} for a lifetime of
-	 * your own, or close this whole handle to release everything.
+	 * republished. `active` keeps pointing at whatever you closed, so once you drop the last
+	 * reference the shared broadcast is gone and reads fail until the next announcement replaces
+	 * it. Take a {@link broadcast.Consumer.clone} for a lifetime of your own, or close this whole
+	 * handle to release everything.
 	 */
 	readonly active: Getter<broadcast.Consumer | undefined>;
 


### PR DESCRIPTION
## Summary

Follow-up to [#2617](https://github.com/moq-dev/moq/pull/2617), from a review that landed after it merged.

`Announce.Broadcast.active` hands out the same `Broadcast.Consumer` type that `consume()` returns, so nothing stops a caller from closing it. If they do, the handle doesn't notice: `active` keeps pointing at the closed consumer and every later read fails, while the path is still announced and a fresh `conn.consume(path)` works.

```
2. active still points at it: true
3. that consumer is closed: true
4. subscribe after caller close FAILED: Error: broadcast is closed: null
5. fresh conn.consume works: hi
```

No in-tree caller does this (`js/watch` mirrors `active` and subscribes off it without closing), so this is an API-misuse hazard rather than a live bug.

## Why a doc change and not a type change

Two stronger options were suggested and both have a real downside:

- **Strip `close()` from the exposed type.** It is the same `Broadcast.Consumer` that `consume()` returns, and callers legitimately `clone()` it, so a narrowed view complicates the type for everyone to stop one misuse.
- **Observe the consumer and reacquire on close.** That races a caller who keeps closing: close, reacquire, close, reacquire.

The repo already has an idiom for the underlying question (refcounted handles, `clone()` when you want an independent lifetime, closing a borrowed handle is a holder bug). So this says which side of that idiom `active` is on, and points at `clone()`.

Happy to take the stronger version instead if the view-type cost is acceptable.

## Public API changes

None. Doc comment only.

## Test plan

`bun run --filter='@moq/net' check` and `just js fix` clean. No behavior change, so no test; a test here would only codify the misuse.

(written by Opus 5)
