### PR TITLE
fix(net): stop sending draft-16 NAMESPACE entries on ietf draft-14/15

### DIFF
--- a/js/net/src/ietf/adapter.ts
+++ b/js/net/src/ietf/adapter.ts
@@ -97,9 +97,6 @@ export class ControlStreamAdapter implements Session {
 	// requestId → namespace reverse lookup (for cleanup in #closeStream)
 	#namespacesByRequestId = new Map<bigint, string>();
 
-	// SubscribeNamespace requestIds — for routing 0x08/0x0E entries that lack requestId (v14/v15)
-	#subscribeNamespaces = new Set<bigint>();
-
 	// Incoming stream queue (for acceptBi)
 	#incomingQueue: Stream[] = [];
 	#incomingWaiters: ((stream: Stream | undefined) => void)[] = [];
@@ -360,7 +357,6 @@ export class ControlStreamAdapter implements Session {
 		if (!entry) return;
 		console.debug(`adapter: closing stream requestId=${requestId}`);
 		this.#streams.delete(requestId);
-		this.#subscribeNamespaces.delete(requestId);
 		const namespace = this.#namespacesByRequestId.get(requestId);
 		if (namespace !== undefined) {
 			this.#namespaces.delete(namespace);
@@ -432,11 +428,6 @@ export class ControlStreamAdapter implements Session {
 			}
 		}
 
-		// SubscribeNamespace (0x11): register for follow-up routing
-		if (typeId === 0x11) {
-			this.#subscribeNamespaces.add(requestId);
-		}
-
 		return { requestId };
 	}
 
@@ -504,13 +495,19 @@ export class ControlStreamAdapter implements Session {
 			return await r.u62();
 		};
 
-		const readNamespaceRequestId = async (): Promise<bigint> => {
+		// v14/v15 key PublishNamespaceDone/Cancel by namespace rather than request ID, so the
+		// stream they refer to has to be looked up. An unknown namespace means the stream is
+		// already gone (both peers can retract at once), which is not worth a session teardown.
+		const readNamespaceRoute = async (): Promise<{ route: Route; requestId: bigint }> => {
 			const r = new Reader(undefined, body, this.version);
 			const namespace = await Namespace.decode(r);
 			const requestId = this.#namespaces.get(namespace);
-			if (requestId === undefined) throw new Error(`unknown namespace: ${namespace}`);
+			if (requestId === undefined) {
+				console.warn(`adapter: no stream for namespace=${namespace} typeId=0x${typeId.toString(16)}`);
+				return { route: Route.Ignore, requestId: 0n };
+			}
 			this.#namespaces.delete(namespace);
-			return requestId;
+			return { route: Route.CloseStream, requestId };
 		};
 
 		switch (typeId) {
@@ -595,22 +592,16 @@ export class ControlStreamAdapter implements Session {
 				return { route: Route.ErrorResponse, requestId };
 			}
 			case 0x08: {
-				if (this.version === Version.DRAFT_14) {
-					// PublishNamespaceError
-					const requestId = await readRequestId();
-					return { route: Route.ErrorResponse, requestId };
-				}
-				// v15: Namespace entry (no requestId) — route to SubscribeNamespace stream
-				const subNs08 = this.#subscribeNamespaces.values().next().value;
-				if (subNs08 === undefined) throw new Error("unexpected message 0x08: no SubscribeNamespace stream");
-				return { route: Route.FollowUp, requestId: subNs08 };
+				// PublishNamespaceError (v14 only; folded into RequestError in v15+).
+				// NAMESPACE shares this ID from v16 on, but only on the SubscribeNamespace
+				// bidi stream, which never reaches the control stream.
+				if (this.version !== Version.DRAFT_14) throw new Error("unexpected PublishNamespaceError");
+				const requestId = await readRequestId();
+				return { route: Route.ErrorResponse, requestId };
 			}
-			case 0x0e: {
-				// v15: NamespaceDone entry (no requestId) — route to SubscribeNamespace stream
-				const subNs0e = this.#subscribeNamespaces.values().next().value;
-				if (subNs0e === undefined) throw new Error("unexpected message 0x0e: no SubscribeNamespace stream");
-				return { route: Route.FollowUp, requestId: subNs0e };
-			}
+			// 0x0e is v14's TRACK_STATUS_OK (RequestOk in v15+) and NAMESPACE_DONE on the v16+
+			// SubscribeNamespace bidi stream. Neither belongs on the control stream here: we
+			// never send TrackStatusRequest, so it falls through to the unknown-type error.
 			case 0x13: {
 				// SubscribeNamespaceError (v14 only)
 				if (this.version !== Version.DRAFT_14) throw new Error("unexpected SubscribeNamespaceError");
@@ -640,8 +631,7 @@ export class ControlStreamAdapter implements Session {
 					const requestId = await readRequestId();
 					return { route: Route.CloseStream, requestId };
 				}
-				const requestId = await readNamespaceRequestId();
-				return { route: Route.CloseStream, requestId };
+				return await readNamespaceRoute();
 			}
 			case 0x0c: {
 				// PublishNamespaceCancel: v16 uses requestId, v14/v15 uses namespace
@@ -649,8 +639,7 @@ export class ControlStreamAdapter implements Session {
 					const requestId = await readRequestId();
 					return { route: Route.CloseStream, requestId };
 				}
-				const requestId = await readNamespaceRequestId();
-				return { route: Route.CloseStream, requestId };
+				return await readNamespaceRoute();
 			}
 			case 0x14: {
 				// UnsubscribeNamespace (v14/v15 only)
@@ -706,7 +695,6 @@ export class ControlStreamAdapter implements Session {
 		// Clear namespace mappings
 		this.#namespaces.clear();
 		this.#namespacesByRequestId.clear();
-		this.#subscribeNamespaces.clear();
 
 		// Unblock maxRequestId waiters
 		for (const resolve of this.#maxRequestIdResolves) resolve();

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -252,7 +252,7 @@ export class Publisher {
 
 	/**
 	 * Handles an incoming SUBSCRIBE_NAMESPACE on a bidi stream.
-	 * Sends RequestOk, then streams Namespace/NamespaceDone entries.
+	 * Sends RequestOk, then streams Namespace/NamespaceDone entries (draft-16+).
 	 *
 	 * @internal
 	 */
@@ -272,6 +272,18 @@ export class Publisher {
 					requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
 				});
 				await ok.encode(stream.writer, version);
+			}
+
+			// Drafts 14 and 15 have no NAMESPACE/NAMESPACE_DONE messages: a subscriber learns
+			// about matching namespaces from PUBLISH_NAMESPACE/PUBLISH_NAMESPACE_DONE, which
+			// #runPublish already sends. Their IDs are taken by other messages there
+			// (0x08 is PUBLISH_NAMESPACE_ERROR, 0x0e is TRACK_STATUS_OK), so sending entries
+			// anyway corrupts the peer's control stream. Just hold the stream open until it
+			// unsubscribes.
+			if (version === Version.DRAFT_14 || version === Version.DRAFT_15) {
+				await stream.reader.closed;
+				stream.close();
+				return;
 			}
 
 			const announced = new announce.Producer(prefix);

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -1114,3 +1114,88 @@ test("integration: ietf blind handle picks up a publisher that arrives late", as
 	client.close();
 	server.close();
 });
+
+// Drafts 14 and 15 retract an announcement with PUBLISH_NAMESPACE_DONE, which is keyed by
+// namespace rather than by request ID. Getting that lookup wrong used to kill the session, so
+// assert the retraction lands AND that the session survives to announce the next publisher.
+for (const version of [Ietf.Version.DRAFT_14, Ietf.Version.DRAFT_15] as const) {
+	const draft = version === Ietf.Version.DRAFT_14 ? "draft-14" : "draft-15";
+
+	test(`integration: ietf ${draft} unpublish retracts the announcement`, async () => {
+		const pair = createMockTransportPair("");
+		const [client, server] = await Promise.all([
+			connect(url, { transport: pair.client }),
+			accept(pair.server, url, { version }),
+		]);
+
+		const announced = client.announced();
+
+		const first = new BroadcastProducer();
+		server.publish(Path.from("shared"), first);
+		expect(await announced.next()).toEqual({ path: "shared" as Path.Valid, active: true });
+
+		first.close();
+		expect(await announced.next()).toEqual({ path: "shared" as Path.Valid, active: false });
+
+		// The session is still usable, so the next publisher on the same path is announced too.
+		const second = new BroadcastProducer();
+		server.publish(Path.from("shared"), second);
+		expect(await announced.next()).toEqual({ path: "shared" as Path.Valid, active: true });
+
+		second.close();
+		announced.close();
+		client.close();
+		server.close();
+	});
+
+	test(`integration: ietf ${draft} republish is not served from the previous generation's cache`, async () => {
+		const pair = createMockTransportPair("");
+		const [client, server] = await Promise.all([
+			connect(url, { transport: pair.client }),
+			accept(pair.server, url, { version }),
+		]);
+
+		const serve = async (broadcast: BroadcastProducer, payload: string) => {
+			for (;;) {
+				const req = await broadcast.requested();
+				if (!req) break;
+				req.accept().writeString(payload);
+			}
+		};
+
+		const first = new BroadcastProducer();
+		const servingFirst = serve(first, "old");
+		server.publish(Path.from("shared"), first);
+
+		const watched = client.announcedBroadcast(Path.from("shared"));
+		const active = await waitFor(watched.active, (b) => b !== undefined);
+		if (!active) throw new Error("expected an active broadcast");
+		expect(await active.subscribe("video").readString()).toBe("old");
+
+		// A second holder of the same path, which is what makes the cache reachable: consumed
+		// broadcasts are reference-counted, so the handle closing its own copy below does not
+		// release the shared one.
+		const bystander = client.consume(Path.from("shared"));
+
+		first.close();
+		await servingFirst;
+		await waitFor(watched.active, (b) => b === undefined);
+
+		// The republish must subscribe fresh. Cloning the cached entry would resolve the previous
+		// generation's tracks, which the wire has already reset.
+		const second = new BroadcastProducer();
+		const servingSecond = serve(second, "new");
+		server.publish(Path.from("shared"), second);
+
+		const republished = await waitFor(watched.active, (b) => b !== undefined);
+		if (!republished) throw new Error("expected a republished broadcast");
+		expect(await republished.subscribe("video").readString()).toBe("new");
+
+		bystander.close();
+		watched.close();
+		second.close();
+		await servingSecond;
+		client.close();
+		server.close();
+	});
+}


### PR DESCRIPTION
Unpublishing a broadcast over IETF moq-transport draft-14 tore the whole session down instead of emitting a clean retraction. `announced()` returned `undefined` (stream ended) rather than `{path, active: false}`, with `adapter error ... unknown namespace: shared` on the way out.

```ts
const announced = client.announced();
const first = new BroadcastProducer();
server.publish(Path.from("shared"), first);
await announced.next();   // {path: "shared", active: true}
first.close();
await announced.next();   // was: undefined (session dead). now: {path: "shared", active: false}
```

## Root cause

`Publisher.runSubscribeNamespace` streamed NAMESPACE (0x08) and NAMESPACE_DONE (0x0e) entries for **every** negotiated version. Those messages only exist from draft-16 on, and only on the SUBSCRIBE_NAMESPACE bidi stream. Neither [draft-14](https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.txt) nor [draft-15](https://www.ietf.org/archive/id/draft-ietf-moq-transport-15.txt) has them in the control message registry, where those IDs mean PUBLISH_NAMESPACE_ERROR and TRACK_STATUS_OK.

So on draft-14 the adapter classified an incoming NAMESPACE entry as PUBLISH_NAMESPACE_ERROR and read a request ID off the front of the body. The body is actually a namespace tuple, whose first varint is the part count. For a single-part namespace like `shared` that decodes to `1`, which is exactly the request ID of the peer's PUBLISH_NAMESPACE virtual stream. Routing it as an error response closed that stream and dropped its `namespace -> requestId` mapping, so the PUBLISH_NAMESPACE_DONE that followed could not resolve `shared`, and `readNamespaceRequestId` threw out of the adapter read loop and closed the session.

A multi-part namespace decodes to a part count of 2+, which is usually unmapped, so it only logged `adapter: no stream for requestId=2` and the session survived. That is why this hid until now: it needs a single-segment path.

## The fix

Per draft-14 §6.1 and draft-15 §6.2, a SUBSCRIBE_NAMESPACE subscriber learns about matching namespaces from PUBLISH_NAMESPACE / PUBLISH_NAMESPACE_DONE, which `#runPublish` already sends independently. On those versions `runSubscribeNamespace` now just answers OK and holds the stream open until the peer unsubscribes.

`rs/moq-net` (`ietf/publisher.rs`) already does exactly this, down to the same reasoning in its comment. Only the JS side diverged, so this is a JS-only conformance fix. No wire format changed and no draft under `drafts/` is affected.

Adapter hardening, so a stray message cannot hijack an unrelated stream again:

- 0x08 is draft-14 only; other versions reject it (matches the Rust adapter).
- 0x0e is no longer routed at all and falls through to the unknown-type error (matches the Rust adapter, which has no 0x0e case).
- `#subscribeNamespaces` had no remaining reader and is gone.
- A PUBLISH_NAMESPACE_DONE/CANCEL naming an unknown namespace now warns and is ignored rather than throwing. This is a deliberate divergence from Rust, which returns `UnexpectedMessage`: the stream being already gone is the same condition `#pushMessage` already tolerates for an unroutable request ID, and it is not worth a session teardown. Happy to drop it if you would rather keep strict parity.

## Tests

Four new cases in `js/net/src/integration.test.ts`, parameterized over draft-14 and draft-15:

- the retraction itself, plus a republish afterwards to prove the session is still alive
- an IETF port of the lite-only "a republish is not served from the previous generation's cache" test, which is what @kixelated flagged as blocked on this

All four fail on `main` and pass with the fix. Full `js/net` suite: 330 pass.

## Out of scope

On draft-16 and up an announcement is delivered **twice** (once as a NAMESPACE entry on the SUBSCRIBE_NAMESPACE stream, once as PUBLISH_NAMESPACE from `#runPublish`), so a draft-16 subscriber sees a duplicate `{active: true}`. That reproduces on `main` independently of this change, and the two channels need to be reconciled rather than patched, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 5)