### PR TITLE
feat(net): solicited PUBLISH_NAMESPACE and rejected PUBLISH

### DIFF
--- a/doc/concept/standard/interop.md
+++ b/doc/concept/standard/interop.md
@@ -42,7 +42,12 @@ If it plays, you interop. That's the whole test.
 
 - **`SUBSCRIBE_NAMESPACE` is required.** The subscriber discovers broadcasts by
   sending `SUBSCRIBE_NAMESPACE` and waiting for a matching announce, so your
-  relay must support it. The publisher announces with `PUBLISH_NAMESPACE`.
+  relay must support it. The publisher announces with `PUBLISH_NAMESPACE`, and
+  only in response to a `SUBSCRIBE_NAMESPACE` covering the namespace.
+- **`PUBLISH` is declined.** Content is routed per namespace and tracks are
+  resolved on demand via `SUBSCRIBE`, so a single-track `PUBLISH` offer is
+  answered with a request error. Announce with `PUBLISH_NAMESPACE` and serve
+  the resulting `SUBSCRIBE`s instead.
 - **Self-signed or expired cert?** Add `--client-tls-disable-verify`.
 - **Subscriber sees nothing?** If your relay doesn't replay existing
   announcements, start the subscriber before the publisher.

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -122,6 +122,7 @@ export class Connection implements Established {
 
 		this.#closed = true;
 
+		this.#publisher.close();
 		this.#session.close();
 
 		try {

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -1,4 +1,4 @@
-import * as announce from "../announced.ts";
+import { type Dispose, Signal } from "@moq/signals";
 import type * as broadcast from "../broadcast.ts";
 import { error, reason } from "../error.ts";
 import type * as group from "../group.ts";
@@ -31,10 +31,8 @@ export class Publisher {
 	#session: Session;
 
 	// Our published broadcasts.
-	#broadcasts: Map<Path.Valid, broadcast.Producer> = new Map();
-
-	// Any consumers that want each new announcement.
-	#announcedConsumers = new Set<announce.Producer>();
+	// It's a signal so we can live update any subscribe_namespace streams.
+	#broadcasts = new Signal<Map<Path.Valid, broadcast.Producer> | undefined>(new Map());
 
 	/**
 	 * Creates a new Publisher instance.
@@ -50,71 +48,21 @@ export class Publisher {
 
 	/**
 	 * Publishes a broadcast with any associated tracks.
-	 * Opens a bidi stream to send PublishNamespace and waits for response.
+	 * The namespace is only advertised in response to a SUBSCRIBE_NAMESPACE
+	 * (see {@link runSubscribeNamespace}), mirroring the moq-lite publisher.
 	 */
 	publish(path: Path.Valid, broadcast: broadcast.Producer) {
-		this.#broadcasts.set(path, broadcast);
-		this.#notifyConsumers(path, true);
-		void this.#runPublish(path, broadcast);
-	}
+		this.#broadcasts.mutate((broadcasts) => {
+			if (!broadcasts) throw new Error("closed");
+			broadcasts.set(path, broadcast);
+		});
 
-	async #runPublish(path: Path.Valid, broadcast: broadcast.Producer) {
-		try {
-			const requestId = await this.#session.nextRequestId();
-			if (requestId === undefined) return;
-
-			const stream = await this.#session.openBi();
-
-			try {
-				// Write PublishNamespace
-				await stream.writer.u53(PublishNamespace.id);
-				const msg = new PublishNamespace({ requestId, trackNamespace: path });
-				await msg.encode(stream.writer, this.#session.version);
-
-				// Read response (RequestOk and PublishNamespaceOk share 0x07)
-				const respTypeId = await stream.reader.u53();
-				if (respTypeId === RequestOk.id) {
-					// Draft-14 sends PublishNamespaceOk (requestId only, no parameters)
-					if (this.#session.version === Version.DRAFT_14) {
-						await PublishNamespaceOk.decode(stream.reader, this.#session.version);
-					} else {
-						await RequestOk.decode(stream.reader, this.#session.version);
-					}
-				} else {
-					throw new Error(`PublishNamespace rejected: typeId=0x${respTypeId.toString(16)}`);
-				}
-
-				// Wait for broadcast to close or stream to close (peer cancelled)
-				await Promise.race([broadcast.closed, stream.reader.closed]);
-
-				// For v14-v16: send explicit PublishNamespaceDone (removed in v17+)
-				if (
-					this.#session.version === Version.DRAFT_14 ||
-					this.#session.version === Version.DRAFT_15 ||
-					this.#session.version === Version.DRAFT_16
-				) {
-					try {
-						await stream.writer.u53(PublishNamespaceDone.id);
-						const done = new PublishNamespaceDone({ trackNamespace: path, requestId });
-						await done.encode(stream.writer, this.#session.version);
-					} catch {
-						// Stream might already be closed
-					}
-				}
-
-				stream.close();
-			} catch (err) {
-				stream.abort(error(err));
-				throw err;
-			}
-		} catch (err: unknown) {
-			const e = error(err);
-			console.warn(`announce failed: broadcast=${path} error=${reason(e)}`);
-		} finally {
-			broadcast.close();
-			this.#broadcasts.delete(path);
-			this.#notifyConsumers(path, false);
-		}
+		// Remove the broadcast from the lookup when it's closed.
+		void broadcast.closed.then(() => {
+			this.#broadcasts.mutate((broadcasts) => {
+				broadcasts?.delete(path);
+			});
+		});
 	}
 
 	/**
@@ -126,7 +74,7 @@ export class Publisher {
 	async runSubscribe(msg: Subscribe, stream: Stream) {
 		const version = this.#session.version;
 		const name = msg.trackNamespace;
-		const broadcast = this.#broadcasts.get(name);
+		const broadcast = this.#broadcasts.peek()?.get(name);
 
 		if (!broadcast) {
 			// Write error response
@@ -252,13 +200,22 @@ export class Publisher {
 
 	/**
 	 * Handles an incoming SUBSCRIBE_NAMESPACE on a bidi stream.
-	 * Sends RequestOk, then streams Namespace/NamespaceDone entries.
+	 *
+	 * Namespaces are only advertised in response to one of these, and the state
+	 * is local to this stream's task, mirroring the moq-lite publisher. Draft-16+
+	 * streams Namespace/NamespaceDone entries inline; draft-14/15 predate those
+	 * messages, so each advertisement is a PUBLISH_NAMESPACE request of its own
+	 * over the control stream, closed out with PUBLISH_NAMESPACE_DONE.
 	 *
 	 * @internal
 	 */
 	async runSubscribeNamespace(msg: SubscribeNamespace, stream: Stream) {
 		const version = this.#session.version;
 		const prefix = msg.namespace;
+		const legacy = version === Version.DRAFT_14 || version === Version.DRAFT_15;
+
+		// Draft-14/15: the open PUBLISH_NAMESPACE request per advertised suffix.
+		const requests = new Map<Path.Valid, { path: Path.Valid; requestId: bigint; stream: Stream }>();
 
 		try {
 			// Send OK response
@@ -274,39 +231,62 @@ export class Publisher {
 				await ok.encode(stream.writer, version);
 			}
 
-			const announced = new announce.Producer(prefix);
-			for (const name of this.#broadcasts.keys()) {
+			const advertise = async (suffix: Path.Valid) => {
+				if (legacy) {
+					await this.#advertise(prefix, suffix, requests);
+				} else {
+					await stream.writer.u53(SubscribeNamespaceEntry.id);
+					await new SubscribeNamespaceEntry({ suffix }).encode(stream.writer, version);
+				}
+			};
+			const withdraw = async (suffix: Path.Valid) => {
+				if (legacy) {
+					await this.#withdraw(suffix, requests);
+				} else {
+					await stream.writer.u53(SubscribeNamespaceEntryDone.id);
+					await new SubscribeNamespaceEntryDone({ suffix }).encode(stream.writer, version);
+				}
+			};
+
+			// Advertise the currently published broadcasts under the prefix.
+			let active = new Set<Path.Valid>();
+			for (const name of this.#broadcasts.peek()?.keys() ?? []) {
 				const suffix = Path.stripPrefix(prefix, name);
 				if (suffix === null) continue;
-				announced.append({ path: suffix, active: true });
+				active.add(suffix);
 			}
-			this.#announcedConsumers.add(announced);
-			const consumer = announced.consume();
+			for (const suffix of active) {
+				await advertise(suffix);
+			}
 
-			// Close the consumer when the stream closes
-			stream.reader.closed.then(
-				() => announced.close(),
-				() => announced.close(),
-			);
+			// Wait for updates to the broadcasts.
+			for (;;) {
+				// TODO Make a better helper within Signals.
+				let dispose!: Dispose;
+				const changed = new Promise<Map<Path.Valid, broadcast.Producer> | undefined>((resolve) => {
+					dispose = this.#broadcasts.changed(resolve);
+				});
 
-			try {
-				for (;;) {
-					const entry = await consumer.next();
-					if (!entry) break;
+				// Wait until the map of broadcasts changes or the peer unsubscribes.
+				const broadcasts = await Promise.race([changed, stream.reader.closed]);
+				dispose();
+				if (!broadcasts) break;
 
-					if (entry.active) {
-						await stream.writer.u53(SubscribeNamespaceEntry.id);
-						const e = new SubscribeNamespaceEntry({ suffix: entry.path });
-						await e.encode(stream.writer, version);
-					} else {
-						await stream.writer.u53(SubscribeNamespaceEntryDone.id);
-						const e = new SubscribeNamespaceEntryDone({ suffix: entry.path });
-						await e.encode(stream.writer, version);
-					}
+				const newActive = new Set<Path.Valid>();
+				for (const name of broadcasts.keys()) {
+					const suffix = Path.stripPrefix(prefix, name);
+					if (suffix === null) continue;
+					newActive.add(suffix);
 				}
-			} finally {
-				announced.close();
-				this.#announcedConsumers.delete(announced);
+
+				for (const added of newActive.difference(active)) {
+					await advertise(added);
+				}
+				for (const removed of active.difference(newActive)) {
+					await withdraw(removed);
+				}
+
+				active = newActive;
 			}
 
 			stream.close();
@@ -314,7 +294,76 @@ export class Publisher {
 			const e = error(err);
 			console.debug(`subscribe_namespace stream error: ${reason(e)}`);
 			stream.abort(e);
+		} finally {
+			// This subscription's advertisements die with it: close out every open
+			// draft-14/15 PUBLISH_NAMESPACE request.
+			for (const suffix of [...requests.keys()]) {
+				await this.#withdraw(suffix, requests);
+			}
 		}
+	}
+
+	/**
+	 * Advertise one namespace on its own PUBLISH_NAMESPACE request (draft-14/15,
+	 * which have no NAMESPACE entry message). A declined request is logged and
+	 * skipped rather than failing the subscription.
+	 */
+	async #advertise(
+		prefix: Path.Valid,
+		suffix: Path.Valid,
+		requests: Map<Path.Valid, { path: Path.Valid; requestId: bigint; stream: Stream }>,
+	) {
+		const path = Path.join(prefix, suffix);
+
+		const requestId = await this.#session.nextRequestId();
+		if (requestId === undefined) return;
+
+		const request = await this.#session.openBi();
+		try {
+			await request.writer.u53(PublishNamespace.id);
+			const msg = new PublishNamespace({ requestId, trackNamespace: path });
+			await msg.encode(request.writer, this.#session.version);
+
+			// Read response (RequestOk and PublishNamespaceOk share 0x07)
+			const respTypeId = await request.reader.u53();
+			if (respTypeId !== RequestOk.id) {
+				throw new Error(`PublishNamespace rejected: typeId=0x${respTypeId.toString(16)}`);
+			}
+			// Draft-14 sends PublishNamespaceOk (requestId only, no parameters)
+			if (this.#session.version === Version.DRAFT_14) {
+				await PublishNamespaceOk.decode(request.reader, this.#session.version);
+			} else {
+				await RequestOk.decode(request.reader, this.#session.version);
+			}
+
+			requests.set(suffix, { path, requestId, stream: request });
+		} catch (err: unknown) {
+			const e = error(err);
+			console.warn(`announce failed: broadcast=${path} error=${reason(e)}`);
+			request.abort(e);
+		}
+	}
+
+	/**
+	 * Close out a namespace's PUBLISH_NAMESPACE request with PUBLISH_NAMESPACE_DONE
+	 * (draft-14/15).
+	 */
+	async #withdraw(
+		suffix: Path.Valid,
+		requests: Map<Path.Valid, { path: Path.Valid; requestId: bigint; stream: Stream }>,
+	) {
+		const request = requests.get(suffix);
+		if (!request) return;
+		requests.delete(suffix);
+
+		try {
+			await request.stream.writer.u53(PublishNamespaceDone.id);
+			const done = new PublishNamespaceDone({ trackNamespace: request.path, requestId: request.requestId });
+			await done.encode(request.stream.writer, this.#session.version);
+		} catch {
+			// Stream might already be closed
+		}
+		request.stream.close();
 	}
 
 	/**
@@ -347,15 +396,17 @@ export class Publisher {
 		stream.close();
 	}
 
-	#notifyConsumers(path: Path.Valid, active: boolean) {
-		for (const consumer of this.#announcedConsumers) {
-			const suffix = Path.stripPrefix(consumer.prefix, path);
-			if (suffix === null) continue;
-			try {
-				consumer.append({ path: suffix, active });
-			} catch {
-				// Consumer already closed, will be cleaned up
+	/**
+	 * Closes every published broadcast and stops accepting new ones.
+	 *
+	 * @internal
+	 */
+	close() {
+		this.#broadcasts.update((broadcasts) => {
+			for (const broadcast of broadcasts?.values() ?? []) {
+				broadcast.close();
 			}
-		}
+			return undefined;
+		});
 	}
 }

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -104,10 +104,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		Poll::Pending
 	}
 
-	pub async fn run(self) -> Result<(), Error> {
-		self.run_announce().await
-	}
-
 	/// Handle an incoming bidi stream dispatched by the session.
 	pub fn handle_stream(
 		&self,
@@ -580,155 +576,127 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		Ok(())
 	}
 
-	/// Outgoing PublishNamespace: announce each namespace via a bidi stream.
-	async fn run_announce(self) -> Result<(), Error> {
-		// Each accepted namespace holds a `publisher()` announce guard (bumps
-		// `announced` / `announced_closed`) alongside its stream, so dropping the
-		// tuple on unannounce or cleanup records the close.
-		let mut namespace_streams: HashMap<crate::PathOwned, (RequestId, Stream<S, Version>)> = HashMap::new();
-		let mut announced = self.origin.announced();
-		let mut watched: HashMap<crate::PathOwned, Watched> = HashMap::new();
-
-		loop {
-			// Wait for the next (un)announce or watched route change, bailing once
-			// the session dies.
-			let event = {
-				let mut closed = std::pin::pin!(self.session.closed());
-				kio::wait(|waiter| {
-					if waiter.poll_future(closed.as_mut()).is_ready() {
-						return Poll::Ready(NamespaceEvent::Closed(Ok(())));
-					}
-					if let Poll::Ready(update) = announced.poll_next(waiter) {
-						return Poll::Ready(NamespaceEvent::Update(update));
-					}
-					Self::poll_watched(&mut watched, waiter).map(NamespaceEvent::Routes)
-				})
-				.await
-			};
-
-			match event {
-				NamespaceEvent::Closed(res) => return res,
-				NamespaceEvent::Update(None) => break,
-				NamespaceEvent::Update(Some(crate::announce::Update { path, broadcast })) => {
-					let suffix = path.to_owned();
-					match broadcast {
-						Some(broadcast) => {
-							let advertisable = self.advertisable(&broadcast);
-							if self.peer_origin.is_some() {
-								watched.insert(suffix.clone(), Watched::new(broadcast));
-							}
-							// A broadcast with no route avoiding the peer would only echo
-							// its own content back; skip it. The watch re-decides when its
-							// route table changes.
-							if advertisable {
-								self.announce_namespace(suffix, &mut namespace_streams).await?;
-							}
-						}
-						None => {
-							watched.remove(&suffix);
-							// A no-op for a namespace that was never announced (no stream
-							// to tear down).
-							self.unannounce_namespace(&suffix, &mut namespace_streams).await;
-						}
-					}
-				}
-				NamespaceEvent::Routes(suffix) => {
-					let Some(watch) = watched.get(&suffix) else { continue };
-					let advertisable = self.advertisable(&watch.broadcast);
-					if advertisable && !namespace_streams.contains_key(&suffix) {
-						self.announce_namespace(suffix, &mut namespace_streams).await?;
-					} else if !advertisable && namespace_streams.contains_key(&suffix) {
-						self.unannounce_namespace(&suffix, &mut namespace_streams).await;
-					}
-				}
-			}
-		}
-
-		// Clean up remaining streams
-		let suffixes: Vec<crate::PathOwned> = namespace_streams.keys().cloned().collect();
-		for suffix in suffixes {
-			self.unannounce_namespace(&suffix, &mut namespace_streams).await;
-		}
-
-		Ok(())
-	}
-
-	/// Open a bidi stream and send a PublishNamespace, recording the stream for later teardown.
-	async fn announce_namespace(
+	/// Advertise one namespace to a subscribed peer.
+	///
+	/// Draft-16+ writes a NAMESPACE entry inline on the SUBSCRIBE_NAMESPACE stream.
+	/// Draft-14/15 predate that message, so the namespace goes out as a
+	/// PUBLISH_NAMESPACE request of its own over the control stream, recorded in
+	/// `requests` so a withdrawal can close it out. Returns whether the peer saw
+	/// the advertisement (it declined the PUBLISH_NAMESPACE otherwise).
+	async fn advertise_namespace(
 		&self,
+		stream: &mut Stream<S, Version>,
+		requests: &mut HashMap<crate::PathOwned, NamespaceRequest<S>>,
+		path: &crate::PathOwned,
 		suffix: crate::PathOwned,
-		namespace_streams: &mut HashMap<crate::PathOwned, (RequestId, Stream<S, Version>)>,
-	) -> Result<(), Error> {
-		let absolute = self.origin.absolute(&suffix).to_owned();
-		tracing::debug!(broadcast = %absolute, "announce");
+	) -> Result<bool, Error> {
+		match self.version {
+			Version::Draft14 | Version::Draft15 => {
+				let request_id = self.control.next_request_id().await?;
+				let mut request = Stream::open(&self.session, self.version).await?;
 
-		let request_id = self.control.next_request_id().await?;
-		let mut stream = Stream::open(&self.session, self.version).await?;
+				request.writer.encode(&ietf::PublishNamespace::ID).await?;
+				request
+					.writer
+					.encode(&ietf::PublishNamespace {
+						request_id,
+						track_namespace: path.as_path(),
+					})
+					.await?;
 
-		stream.writer.encode(&ietf::PublishNamespace::ID).await?;
-		stream
-			.writer
-			.encode(&ietf::PublishNamespace {
-				request_id,
-				track_namespace: suffix.as_path(),
-			})
-			.await?;
+				let type_id: u64 = request.reader.decode().await?;
+				let size: u16 = request.reader.decode().await?;
+				let mut data = request.reader.read_exact(size as usize).await?;
 
-		let type_id: u64 = stream.reader.decode().await?;
-		let size: u16 = stream.reader.decode().await?;
-		let mut data = stream.reader.read_exact(size as usize).await?;
+				match (self.version, type_id) {
+					(Version::Draft14, ietf::PublishNamespaceOk::ID) => {
+						let msg = ietf::PublishNamespaceOk::decode_msg(&mut data, self.version)?;
+						tracing::debug!(message = ?msg, "publish namespace ok");
+					}
+					(Version::Draft14, ietf::PublishNamespaceError::ID) => {
+						let msg = ietf::PublishNamespaceError::decode_msg(&mut data, self.version)?;
+						tracing::warn!(message = ?msg, "publish namespace error");
+						return Ok(false);
+					}
+					(_, ietf::RequestOk::ID) => {
+						let msg = ietf::RequestOk::decode_msg(&mut data, self.version)?;
+						tracing::debug!(message = ?msg, "publish namespace ok");
+					}
+					(_, ietf::RequestError::ID) => {
+						let msg = ietf::RequestError::decode_msg(&mut data, self.version)?;
+						tracing::warn!(message = ?msg, "publish namespace error");
+						return Ok(false);
+					}
+					_ => return Err(Error::UnexpectedMessage),
+				}
 
-		match (self.version, type_id) {
-			(Version::Draft14, ietf::PublishNamespaceOk::ID) => {
-				let msg = ietf::PublishNamespaceOk::decode_msg(&mut data, self.version)?;
-				tracing::debug!(message = ?msg, "publish namespace ok");
-				namespace_streams.insert(suffix, (request_id, stream));
+				requests.insert(
+					suffix,
+					NamespaceRequest {
+						path: path.clone(),
+						request_id,
+						stream: request,
+					},
+				);
 			}
-			(Version::Draft14, ietf::PublishNamespaceError::ID) => {
-				let msg = ietf::PublishNamespaceError::decode_msg(&mut data, self.version)?;
-				tracing::warn!(message = ?msg, "publish namespace error");
+			_ => {
+				stream.writer.encode(&ietf::Namespace::ID).await?;
+				stream.writer.encode(&ietf::Namespace { suffix }).await?;
 			}
-			(_, ietf::RequestOk::ID) => {
-				let msg = ietf::RequestOk::decode_msg(&mut data, self.version)?;
-				tracing::debug!(message = ?msg, "publish namespace ok");
-				namespace_streams.insert(suffix, (request_id, stream));
-			}
-			(_, ietf::RequestError::ID) => {
-				let msg = ietf::RequestError::decode_msg(&mut data, self.version)?;
-				tracing::warn!(message = ?msg, "publish namespace error");
-			}
-			_ => return Err(Error::UnexpectedMessage),
 		}
-
-		Ok(())
+		Ok(true)
 	}
 
-	/// Tear down the namespace stream for a suffix, sending PublishNamespaceDone where required.
-	async fn unannounce_namespace(
+	/// Withdraw an advertised namespace: NAMESPACE_DONE inline on draft-16+, or
+	/// PUBLISH_NAMESPACE_DONE closing its own request on draft-14/15.
+	async fn withdraw_namespace(
 		&self,
-		suffix: &crate::PathOwned,
-		namespace_streams: &mut HashMap<crate::PathOwned, (RequestId, Stream<S, Version>)>,
-	) {
-		tracing::debug!(broadcast = %self.origin.absolute(suffix), "unannounce");
-		if let Some((request_id, mut stream)) = namespace_streams.remove(suffix) {
-			// v14-16 sends PublishNamespaceDone; v17+ just closes the stream.
-			match self.version {
-				Version::Draft14 | Version::Draft15 | Version::Draft16 => {
-					let _ = stream
+		stream: &mut Stream<S, Version>,
+		requests: &mut HashMap<crate::PathOwned, NamespaceRequest<S>>,
+		suffix: crate::PathOwned,
+	) -> Result<(), Error> {
+		match self.version {
+			Version::Draft14 | Version::Draft15 => {
+				if let Some(mut request) = requests.remove(&suffix) {
+					// Best effort: the peer may already be gone.
+					let _ = request
+						.stream
 						.writer
 						.encode_message(&ietf::PublishNamespaceDone {
-							track_namespace: suffix.as_path(),
-							request_id,
+							track_namespace: request.path.as_path(),
+							request_id: request.request_id,
 						})
 						.await;
+					request.stream.writer.finish().ok();
 				}
-				_ => {}
 			}
-			stream.writer.finish().ok();
+			_ => {
+				stream.writer.encode(&ietf::NamespaceDone::ID).await?;
+				stream.writer.encode(&ietf::NamespaceDone { suffix }).await?;
+			}
+		}
+		Ok(())
+	}
+
+	/// Close out every open draft-14/15 PUBLISH_NAMESPACE request. A no-op on
+	/// later drafts, whose entries ride the SUBSCRIBE_NAMESPACE stream itself.
+	async fn withdraw_requests(
+		&self,
+		stream: &mut Stream<S, Version>,
+		requests: &mut HashMap<crate::PathOwned, NamespaceRequest<S>>,
+	) {
+		let suffixes: Vec<crate::PathOwned> = requests.keys().cloned().collect();
+		for suffix in suffixes {
+			let _ = self.withdraw_namespace(stream, requests, suffix).await;
 		}
 	}
 
 	/// Handle a SUBSCRIBE_NAMESPACE on its bidi stream.
+	///
+	/// Namespaces are only advertised in response to one of these, and all the
+	/// announce state is local to this task (mirroring `lite::Publisher`'s
+	/// announce handling): whatever this subscription advertised is withdrawn
+	/// when its stream ends.
 	async fn run_subscribe_namespace_stream(
 		self,
 		mut stream: Stream<S, Version>,
@@ -772,120 +740,113 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 		}
 
-		match self.version {
-			// v14/v15: Namespace/NamespaceDone don't exist. After OK, the publisher
-			// sends PUBLISH_NAMESPACE/PUBLISH_NAMESPACE_DONE as separate control
-			// stream messages (handled by run_announce). Just wait for stream close.
-			Version::Draft14 | Version::Draft15 => {
-				return stream.reader.closed().await;
-			}
-			// v16+: Send Namespace/NamespaceDone entries on this bidi stream.
-			_ => {
-				let mut announced = origin.announced();
+		let mut announced = origin.announced();
 
-				// Namespaces actually sent to the peer, so a filtered announce (no
-				// route avoiding the peer's assigned identity) never gets a dangling
-				// NamespaceDone.
-				let mut sent: std::collections::HashSet<crate::PathOwned> = std::collections::HashSet::new();
-				let mut watched: HashMap<crate::PathOwned, Watched> = HashMap::new();
+		// Namespaces actually sent to the peer, so a filtered announce (no
+		// route avoiding the peer's assigned identity) never gets a dangling
+		// withdrawal. Keyed by suffix like the maps below.
+		let mut sent: std::collections::HashSet<crate::PathOwned> = std::collections::HashSet::new();
+		let mut watched: HashMap<crate::PathOwned, Watched> = HashMap::new();
+		// Draft-14/15: the open PUBLISH_NAMESPACE request carrying each advertised
+		// namespace. Empty on later drafts, whose entries ride `stream` inline.
+		let mut requests: HashMap<crate::PathOwned, NamespaceRequest<S>> = HashMap::new();
 
-				// Send initial NAMESPACE messages for currently active namespaces.
-				while let Some(crate::announce::Update { path, broadcast }) = announced.try_next() {
-					if let Some(broadcast) = broadcast {
-						let suffix = path
-							.strip_prefix(&prefix)
-							.expect("origin returned invalid path")
-							.to_owned();
-						let advertisable = self.advertisable(&broadcast);
-						if self.peer_origin.is_some() {
-							watched.insert(suffix.clone(), Watched::new(broadcast));
-						}
-						if !advertisable {
-							continue;
-						}
-						tracing::debug!(broadcast = %origin.absolute(&path), "namespace");
-						sent.insert(suffix.clone());
-						stream.writer.encode(&ietf::Namespace::ID).await?;
-						stream.writer.encode(&ietf::Namespace { suffix }).await?;
+		// Stream updates (origin (un)announces plus watched route changes),
+		// bailing if the peer closes its side first.
+		let res = loop {
+			let event = {
+				let mut closed = std::pin::pin!(stream.reader.closed());
+				kio::wait(|waiter| {
+					if let Poll::Ready(res) = waiter.poll_future(closed.as_mut()) {
+						return Poll::Ready(NamespaceEvent::Closed(res));
 					}
+					if let Poll::Ready(update) = announced.poll_next(waiter) {
+						return Poll::Ready(NamespaceEvent::Update(update));
+					}
+					Self::poll_watched(&mut watched, waiter).map(NamespaceEvent::Routes)
+				})
+				.await
+			};
+
+			match event {
+				NamespaceEvent::Closed(res) => break res,
+				NamespaceEvent::Update(None) => {
+					// The origin is gone: withdraw everything, then finish the
+					// stream and wait for delivery.
+					self.withdraw_requests(&mut stream, &mut requests).await;
+					stream.writer.finish()?;
+					return stream.writer.closed().await;
 				}
+				NamespaceEvent::Update(Some(crate::announce::Update { path, broadcast })) => {
+					let suffix = path
+						.strip_prefix(&prefix)
+						.expect("origin returned invalid path")
+						.to_owned();
+					let absolute = origin.absolute(&path).to_owned();
+					let path = path.to_owned();
 
-				// Stream updates (origin (un)announces plus watched route changes),
-				// bailing if the peer closes its side first.
-				loop {
-					let event = {
-						let mut closed = std::pin::pin!(stream.reader.closed());
-						kio::wait(|waiter| {
-							if let Poll::Ready(res) = waiter.poll_future(closed.as_mut()) {
-								return Poll::Ready(NamespaceEvent::Closed(res));
+					match broadcast {
+						Some(broadcast) => {
+							let advertisable = self.advertisable(&broadcast);
+							if self.peer_origin.is_some() {
+								watched.insert(suffix.clone(), Watched::new(broadcast));
 							}
-							if let Poll::Ready(update) = announced.poll_next(waiter) {
-								return Poll::Ready(NamespaceEvent::Update(update));
+							// Filtered now, but the watch re-decides when the
+							// route table changes.
+							if !advertisable {
+								continue;
 							}
-							Self::poll_watched(&mut watched, waiter).map(NamespaceEvent::Routes)
-						})
-						.await
-					};
-
-					match event {
-						NamespaceEvent::Closed(res) => return res,
-						NamespaceEvent::Update(None) => {
-							stream.writer.finish()?;
-							return stream.writer.closed().await;
-						}
-						NamespaceEvent::Update(Some(crate::announce::Update { path, broadcast })) => {
-							let suffix = path
-								.strip_prefix(&prefix)
-								.expect("origin returned invalid path")
-								.to_owned();
-							let absolute = origin.absolute(&path).to_owned();
-
-							match broadcast {
-								Some(broadcast) => {
-									let advertisable = self.advertisable(&broadcast);
-									if self.peer_origin.is_some() {
-										watched.insert(suffix.clone(), Watched::new(broadcast));
-									}
-									// Filtered now, but the watch re-decides when the
-									// route table changes.
-									if !advertisable {
-										continue;
-									}
-									tracing::debug!(broadcast = %absolute, "namespace");
-									sent.insert(suffix.clone());
-									stream.writer.encode(&ietf::Namespace::ID).await?;
-									stream.writer.encode(&ietf::Namespace { suffix }).await?;
-								}
-								None => {
-									watched.remove(&suffix);
-									// Only close out namespaces the peer actually saw.
-									if sent.remove(&suffix) {
-										tracing::debug!(broadcast = %absolute, "namespace_done");
-										stream.writer.encode(&ietf::NamespaceDone::ID).await?;
-										stream.writer.encode(&ietf::NamespaceDone { suffix }).await?;
-									}
-								}
+							tracing::debug!(broadcast = %absolute, "namespace");
+							if self
+								.advertise_namespace(&mut stream, &mut requests, &path, suffix.clone())
+								.await?
+							{
+								sent.insert(suffix);
 							}
 						}
-						NamespaceEvent::Routes(suffix) => {
-							let Some(watch) = watched.get(&suffix) else { continue };
-							let advertisable = self.advertisable(&watch.broadcast);
-							if advertisable && !sent.contains(&suffix) {
-								tracing::debug!(broadcast = %suffix, "namespace");
-								sent.insert(suffix.clone());
-								stream.writer.encode(&ietf::Namespace::ID).await?;
-								stream.writer.encode(&ietf::Namespace { suffix }).await?;
-							} else if !advertisable && sent.remove(&suffix) {
-								tracing::debug!(broadcast = %suffix, "namespace_done");
-								stream.writer.encode(&ietf::NamespaceDone::ID).await?;
-								stream.writer.encode(&ietf::NamespaceDone { suffix }).await?;
+						None => {
+							watched.remove(&suffix);
+							// Only close out namespaces the peer actually saw.
+							if sent.remove(&suffix) {
+								tracing::debug!(broadcast = %absolute, "namespace_done");
+								self.withdraw_namespace(&mut stream, &mut requests, suffix).await?;
 							}
 						}
 					}
 				}
+				NamespaceEvent::Routes(suffix) => {
+					let Some(watch) = watched.get(&suffix) else { continue };
+					let advertisable = self.advertisable(&watch.broadcast);
+					if advertisable && !sent.contains(&suffix) {
+						tracing::debug!(broadcast = %suffix, "namespace");
+						let path = prefix.join(&suffix);
+						if self
+							.advertise_namespace(&mut stream, &mut requests, &path, suffix.clone())
+							.await?
+						{
+							sent.insert(suffix);
+						}
+					} else if !advertisable && sent.remove(&suffix) {
+						tracing::debug!(broadcast = %suffix, "namespace_done");
+						self.withdraw_namespace(&mut stream, &mut requests, suffix).await?;
+					}
+				}
 			}
-		}
+		};
+
+		// This subscription's advertisements die with it.
+		self.withdraw_requests(&mut stream, &mut requests).await;
+
+		res
 	}
+}
+
+/// One draft-14/15 advertisement: the PUBLISH_NAMESPACE request it rode on and
+/// what closes it out with PUBLISH_NAMESPACE_DONE.
+struct NamespaceRequest<S: web_transport_trait::Session> {
+	path: crate::PathOwned,
+	request_id: RequestId,
+	stream: Stream<S, Version>,
 }
 
 #[cfg(test)]
@@ -1026,5 +987,120 @@ mod tests {
 			2,
 			"NAMESPACE_DONE after the last clean route detaches"
 		);
+	}
+
+	/// The peer's OK to a PUBLISH_NAMESPACE, framed exactly as the announce path
+	/// reads it -- built with the crate's own writer so the framing can't drift
+	/// from the encoder under test.
+	async fn publish_namespace_ok(version: Version) -> Vec<u8> {
+		let log = crate::lite::test_transport::Log::default();
+		let mut writer = crate::coding::Writer::new(crate::lite::test_transport::SinkSend::new(log.clone()), version);
+
+		match version {
+			Version::Draft14 => {
+				writer.encode(&ietf::PublishNamespaceOk::ID).await.unwrap();
+				writer
+					.encode(&ietf::PublishNamespaceOk {
+						request_id: RequestId(1),
+					})
+					.await
+					.unwrap();
+			}
+			_ => {
+				writer.encode(&ietf::RequestOk::ID).await.unwrap();
+				writer
+					.encode(&ietf::RequestOk {
+						request_id: Some(RequestId(1)),
+					})
+					.await
+					.unwrap();
+			}
+		}
+
+		let writes = log.writes.lock().unwrap();
+		writes.clone()
+	}
+
+	/// Draft-14/15 predate the NAMESPACE message, so a SUBSCRIBE_NAMESPACE is
+	/// answered with one PUBLISH_NAMESPACE request per matching namespace over the
+	/// control stream, and PUBLISH_NAMESPACE_DONE withdraws it. The state is local
+	/// to the subscription's task, mirroring lite's announce handling.
+	#[tokio::test]
+	async fn v14_subscribe_namespace_is_answered_with_publish_namespace() {
+		const VERSION: Version = Version::Draft14;
+
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let consumer = origin.consume();
+
+		// Announced before the peer subscribes: it must only hit the wire after.
+		let early = origin
+			.create_broadcast("early-cam", crate::broadcast::Route::new().with_announce(true))
+			.unwrap();
+		settle().await;
+
+		// Stream 1 is the peer's SUBSCRIBE_NAMESPACE (the peer stays quiet after);
+		// streams 2 and 3 answer our two PUBLISH_NAMESPACE requests.
+		let ok = publish_namespace_ok(VERSION).await;
+		let session = crate::lite::test_transport::ScriptedSession::per_stream(vec![Vec::new(), ok.clone(), ok]);
+		let log = session.log.clone();
+
+		let publisher = Publisher::new(session.clone(), consumer, Control::new(None, false), None, VERSION);
+
+		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let msg = ietf::SubscribeNamespace {
+			request_id: RequestId(1),
+			namespace: crate::Path::new(""),
+		};
+		let mut run = std::pin::pin!(publisher.run_subscribe_namespace_stream(stream, msg));
+
+		// The subscription solicits the already-announced namespace.
+		for _ in 0..100 {
+			assert!(futures::poll!(run.as_mut()).is_pending());
+			if occurrences(&log, b"early-cam") >= 1 {
+				break;
+			}
+			settle().await;
+		}
+		assert_eq!(
+			occurrences(&log, b"early-cam"),
+			1,
+			"PUBLISH_NAMESPACE after subscribing"
+		);
+
+		// A later announce reaches the same subscription.
+		let _late = origin
+			.create_broadcast("late-cam", crate::broadcast::Route::new().with_announce(true))
+			.unwrap();
+		for _ in 0..100 {
+			assert!(futures::poll!(run.as_mut()).is_pending());
+			if occurrences(&log, b"late-cam") >= 1 {
+				break;
+			}
+			settle().await;
+		}
+		assert_eq!(
+			occurrences(&log, b"late-cam"),
+			1,
+			"PUBLISH_NAMESPACE for a live announce"
+		);
+
+		// An unannounce closes out its own request with PUBLISH_NAMESPACE_DONE.
+		drop(early);
+		for _ in 0..100 {
+			assert!(futures::poll!(run.as_mut()).is_pending());
+			if occurrences(&log, b"early-cam") >= 2 {
+				break;
+			}
+			settle().await;
+		}
+		assert_eq!(
+			occurrences(&log, b"early-cam"),
+			2,
+			"PUBLISH_NAMESPACE_DONE on unannounce"
+		);
+
+		// One stream for the subscription itself, one per PUBLISH_NAMESPACE: the
+		// withdrawal rode the announce's own request, not a new stream.
+		assert_eq!(log.bi_opens(), 3, "no extra stream for the withdrawal");
 	}
 }

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -68,7 +68,6 @@ pub fn start<S: web_transport_trait::Session>(
 					subscriber.clone(),
 					version
 				)));
-				let mut publisher_run = std::pin::pin!(err_only(publisher.run()));
 				// One SUBSCRIBE_NAMESPACE per permitted prefix, like `lite::Subscriber`:
 				// the scope is what we may ask for, and it is not the origin's root.
 				let mut sub_ns_run = std::pin::pin!(err_only(async {
@@ -108,9 +107,6 @@ pub fn start<S: web_transport_trait::Session>(
 						return Poll::Ready(Err(err));
 					}
 					if let Poll::Ready(err) = waiter.poll_future(dispatch.as_mut()) {
-						return Poll::Ready(Err(err));
-					}
-					if let Poll::Ready(err) = waiter.poll_future(publisher_run.as_mut()) {
 						return Poll::Ready(Err(err));
 					}
 					if task_set.poll(waiter).is_ready() {
@@ -163,7 +159,6 @@ pub fn start<S: web_transport_trait::Session>(
 					subscriber.clone(),
 					version
 				)));
-				let mut publisher_run = std::pin::pin!(err_only(publisher.run()));
 				let mut goaway = std::pin::pin!(err_only(goaway));
 				let mut setup = std::pin::pin!(setup);
 				// One SUBSCRIBE_NAMESPACE per permitted prefix; see the draft-16 arm.
@@ -192,9 +187,6 @@ pub fn start<S: web_transport_trait::Session>(
 						return Poll::Ready(Err::<(), Error>(err));
 					}
 					if let Poll::Ready(err) = waiter.poll_future(dispatch.as_mut()) {
-						return Poll::Ready(Err(err));
-					}
-					if let Poll::Ready(err) = waiter.poll_future(publisher_run.as_mut()) {
 						return Poll::Ready(Err(err));
 					}
 					if let Poll::Ready(err) = waiter.poll_future(goaway.as_mut()) {
@@ -493,5 +485,43 @@ mod tests {
 		assert_eq!(occurrences(&log, b"cam"), 1, "one SUBSCRIBE_NAMESPACE for cam");
 		assert_eq!(occurrences(&log, b"mic"), 1, "one SUBSCRIBE_NAMESPACE for mic");
 		assert_eq!(occurrences(&log, b"rootns"), 0, "asked the peer for our local root");
+	}
+
+	/// A namespace is only advertised in response to a SUBSCRIBE_NAMESPACE. A peer
+	/// that never subscribes hears nothing, no matter what we announce locally.
+	#[tokio::test]
+	async fn announces_wait_for_a_subscribe_namespace() {
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let _cam = origin
+			.create_broadcast("solo-cam", crate::broadcast::Route::new().with_announce(true))
+			.unwrap();
+
+		// An open gate: an unsolicited PUBLISH_NAMESPACE would reach the wire.
+		let gate = kio::Producer::new(true);
+		let session = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
+		let log = session.log.clone();
+
+		let driver = start(
+			session,
+			None,
+			None,
+			true,
+			Some(origin.consume()),
+			None,
+			None,
+			Version::Draft18,
+			None,
+			None,
+		)
+		.expect("start the session");
+		let _driver = tokio::spawn(driver);
+
+		// Give an unsolicited announce every chance to land before asserting silence.
+		tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+		assert_eq!(
+			occurrences(&log, b"solo-cam"),
+			0,
+			"PUBLISH_NAMESPACE must wait for a SUBSCRIBE_NAMESPACE"
+		);
 	}
 }

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -50,11 +50,8 @@ struct State {
 	// Track aliases chosen by the remote publisher.
 	aliases: TrackAliases,
 
-	// Each broadcast created by either a PUBLISH or PUBLISH_NAMESPACE message.
+	// Each broadcast created by a PUBLISH_NAMESPACE message.
 	broadcasts: HashMap<PathOwned, BroadcastState>,
-
-	// Each PUBLISH message that is implicitly causing a PUBLISH_NAMESPACE message.
-	publishes: HashMap<RequestId, PathOwned>,
 }
 
 struct TrackState {
@@ -73,7 +70,7 @@ struct BroadcastState {
 	// the origin unannounces once the last source detaches.
 	producer: crate::model::broadcast::SourceGuard,
 
-	// active number of PUBLISH or PUBLISH_NAMESPACE messages.
+	// active number of PUBLISH_NAMESPACE messages.
 	count: usize,
 }
 
@@ -341,50 +338,31 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	/// Handle an incoming PUBLISH on its bidi stream.
+	/// Reject an incoming PUBLISH.
+	///
+	/// PUBLISH offers a single track, so honoring it means routing per
+	/// (namespace, track). Our model routes per namespace: a source attaches at a
+	/// path and serves every track under it, resolved on demand via SUBSCRIBE.
+	/// Accepting a PUBLISH would mean inventing a namespace-level source out of a
+	/// track-level offer, and that fiction then contradicts any real
+	/// PUBLISH_NAMESPACE for the same path.
+	///
+	/// Declining the request rather than failing the session, since a peer using
+	/// a feature we don't implement is not a protocol violation.
 	async fn run_publish_stream(
 		&mut self,
 		mut stream: Stream<S, Version>,
 		msg: ietf::Publish<'_>,
 	) -> Result<(), Error> {
-		let request_id = msg.request_id;
+		tracing::debug!(broadcast = %msg.track_namespace, track = %msg.track_name, "rejecting publish");
 
-		if let Err(err) = self.start_publish(&msg) {
-			if matches!(err, Error::Duplicate) {
-				self.session.close(err.to_code(), err.to_string().as_ref());
-				return Err(err);
-			}
-			self.write_publish_error(&mut stream, request_id, 400, &err.to_string())
-				.await?;
-			return Ok(());
-		}
+		self.write_publish_error(&mut stream, msg.request_id, 400, "PUBLISH is not supported")
+			.await?;
+		// Finish rather than awaiting the peer's close: the rejection is the whole
+		// exchange, and dropping `stream` on return tears down the rest.
+		let _ = stream.writer.finish();
 
-		let res = self.write_publish_ok(&mut stream, &msg).await;
-
-		if res.is_ok() {
-			// PUBLISH is the peer feeding us a broadcast, so count this session as
-			// an active upstream feed for the lifetime of the publish. The guard
-			// drops (releasing `broadcasts_closed`) when the stream closes below.
-			// Wait for PublishDone or stream close
-			let _ = stream.reader.closed().await;
-		}
-
-		// Clean up (always runs after start_publish succeeds)
-		let mut state = self.state.lock();
-		if let Some(mut track) = state.subscribes.remove(&request_id) {
-			let _ = track.producer.finish();
-			if let Some(alias) = track.alias {
-				remove_track_alias(&state.aliases, alias, request_id);
-			}
-		}
-		if let Some(path) = state.publishes.remove(&request_id) {
-			drop(state);
-			// Count the unannounce only when the publish was OK'd and its stream then
-			// closed (a real end); a failed write_publish_ok is a local rollback.
-			let _ = self.stop_announce(path, res.is_ok());
-		}
-
-		res
+		Ok(())
 	}
 
 	/// Send OK on the bidi stream.
@@ -454,38 +432,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						retry_interval: 0,
 					})
 					.await?;
-			}
-		}
-		Ok(())
-	}
-
-	async fn write_publish_ok(&self, stream: &mut Stream<S, Version>, msg: &ietf::Publish<'_>) -> Result<(), Error> {
-		match self.version {
-			Version::Draft14 => {
-				stream.writer.encode(&ietf::PublishOk::ID).await?;
-				stream
-					.writer
-					.encode(&ietf::PublishOk {
-						request_id: Some(msg.request_id),
-						forward: true,
-						subscriber_priority: 0,
-						group_order: GroupOrder::Descending,
-						filter_type: FilterType::LargestObject,
-					})
-					.await?;
-			}
-			Version::Draft15 | Version::Draft16 => {
-				stream.writer.encode(&ietf::RequestOk::ID).await?;
-				stream
-					.writer
-					.encode(&ietf::RequestOk {
-						request_id: Some(msg.request_id),
-					})
-					.await?;
-			}
-			_ => {
-				stream.writer.encode(&ietf::RequestOk::ID).await?;
-				stream.writer.encode(&ietf::RequestOk { request_id: None }).await?;
 			}
 		}
 		Ok(())
@@ -605,49 +551,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 			Entry::Vacant(_) => return Err(Error::NotFound),
 		};
-
-		Ok(())
-	}
-
-	fn start_publish(&mut self, msg: &ietf::Publish<'_>) -> Result<(), Error> {
-		let request_id = msg.request_id;
-		let namespace = msg.track_namespace.to_owned();
-
-		// Announce the broadcast first so the track is born from it (inheriting the
-		// broadcast's Arc<broadcast::Info>). Undo the announce on any error path below.
-		let mut broadcast = self.start_announce(namespace.clone())?;
-		let track = match broadcast.create_track(msg.track_name.to_string(), None) {
-			Ok(track) => track,
-			Err(err) => {
-				let _ = self.stop_announce(namespace, false);
-				return Err(err);
-			}
-		};
-
-		let mut state = self.state.lock();
-		match state.subscribes.entry(request_id) {
-			Entry::Vacant(entry) => {
-				entry.insert(TrackState {
-					producer: track.clone(),
-					alias: Some(msg.track_alias),
-					timescale: msg.timescale,
-				});
-			}
-			Entry::Occupied(_) => {
-				drop(state);
-				let _ = self.stop_announce(namespace, false);
-				return Err(Error::Duplicate);
-			}
-		};
-
-		if let Err(err) = insert_track_alias(&state.aliases, msg.track_alias, request_id) {
-			state.subscribes.remove(&request_id);
-			drop(state);
-			let _ = self.stop_announce(namespace, false);
-			return Err(err);
-		}
-		state.publishes.insert(request_id, namespace);
-		drop(state);
 
 		Ok(())
 	}
@@ -1194,5 +1097,54 @@ mod tests {
 		let broadcast = consumer.get_broadcast("room/host").unwrap();
 		let hops: Vec<_> = broadcast.routes()[0].hops.iter().copied().collect();
 		assert_eq!(hops, vec![assigned]);
+	}
+
+	/// PUBLISH offers one track, but a source attaches per namespace and serves
+	/// every track under it, resolved on demand via SUBSCRIBE. Rather than invent
+	/// a namespace-level source from a track-level offer, decline the request and
+	/// leave the session running.
+	#[tokio::test]
+	async fn publish_is_rejected_without_announcing() {
+		// An open gate, so the rejection actually reaches the wire.
+		let gate = kio::Producer::new(true);
+		let session = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let consumer = origin.consume();
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+
+		let mut subscriber = Subscriber::new(
+			session.clone(),
+			origin,
+			Control::new(None, false),
+			None,
+			Version::Draft19,
+			tasks,
+		);
+
+		let stream = Stream::open(&session, Version::Draft19).await.unwrap();
+		let msg = ietf::Publish {
+			request_id: RequestId(1),
+			track_namespace: crate::Path::new("room/host"),
+			track_name: "video".into(),
+			track_alias: 7,
+			group_order: GroupOrder::Ascending,
+			largest_location: None,
+			forward: true,
+			timescale: None,
+		};
+
+		// Errors are surfaced to the peer on the stream, not raised as a session error.
+		subscriber.run_publish_stream(stream, msg).await.unwrap();
+		settle().await;
+
+		assert!(
+			consumer.get_broadcast("room/host").is_none(),
+			"a rejected PUBLISH must not announce a broadcast"
+		);
+		assert_eq!(
+			occurrences(&session.log, b"PUBLISH is not supported"),
+			1,
+			"the decline reaches the peer"
+		);
 	}
 }

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -241,11 +241,16 @@ impl web_transport_trait::RecvStream for ScriptedRecv {
 /// Records what we send while replaying a scripted peer response on every stream.
 ///
 /// The script is shared across streams, so a test that only opens one gets exactly
-/// what it wrote; drive one stream at a time.
+/// what it wrote; drive one stream at a time. [`Self::per_stream`] hands each
+/// opened stream its own script instead, for flows holding several requests open
+/// at once.
 #[derive(Clone)]
 pub struct ScriptedSession {
 	pub log: Log,
 	script: Arc<Mutex<Vec<u8>>>,
+	/// Per-stream scripts popped by `open_bi` in order; `None` shares `script`
+	/// across every stream.
+	queue: Option<Arc<Mutex<std::collections::VecDeque<Vec<u8>>>>>,
 }
 
 impl ScriptedSession {
@@ -253,6 +258,17 @@ impl ScriptedSession {
 		Self {
 			log: Log::default(),
 			script: Arc::new(Mutex::new(script)),
+			queue: None,
+		}
+	}
+
+	/// Each `open_bi` replays the next script in order. An exhausted queue (or an
+	/// empty entry) reads as a peer that never speaks.
+	pub fn per_stream(scripts: Vec<Vec<u8>>) -> Self {
+		Self {
+			log: Log::default(),
+			script: Arc::new(Mutex::new(Vec::new())),
+			queue: Some(Arc::new(Mutex::new(scripts.into_iter().collect()))),
 		}
 	}
 }
@@ -272,12 +288,11 @@ impl web_transport_trait::Session for ScriptedSession {
 
 	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
 		self.log.bi_opens.fetch_add(1, Ordering::Relaxed);
-		Ok((
-			SinkSend::new(self.log.clone()),
-			ScriptedRecv {
-				script: self.script.clone(),
-			},
-		))
+		let script = match &self.queue {
+			Some(queue) => Arc::new(Mutex::new(queue.lock().unwrap().pop_front().unwrap_or_default())),
+			None => self.script.clone(),
+		};
+		Ok((SinkSend::new(self.log.clone()), ScriptedRecv { script }))
 	}
 
 	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {


### PR DESCRIPTION
Forked out of #2629 per review: the PUBLISH / PUBLISH_NAMESPACE behavior changes land on their own, ahead of the MoQ Cluster extension work.

## PUBLISH_NAMESPACE is now solicited, and task-local

The IETF publisher used to advertise every announced namespace unsolicited, from a session-wide loop (`Publisher::run_announce`) holding a session-wide stream map. That had two concrete problems:

- On draft-16+ a subscribed peer heard about each namespace **twice**: once via the unsolicited PUBLISH_NAMESPACE and again via the NAMESPACE entry on its SUBSCRIBE_NAMESPACE stream. Two messages describing one source is the ordering trap #2629 tripped over: whichever arrives second replaces the source the first attached, tearing down tracks a subscriber was resolving through it.
- The announce state outlived any single peer request, which is the opposite of how moq-lite is shaped, where `recv_announce` owns its state and everything dies with the stream that asked.

Now nothing is advertised until a SUBSCRIBE_NAMESPACE arrives, and `run_subscribe_namespace_stream` owns all the announce state for that subscription, mirroring `lite::Publisher::run_announce`:

- **Draft-16+** replies inline with NAMESPACE / NAMESPACE_DONE entries on the SUBSCRIBE_NAMESPACE stream (this path already existed; it is now the only one).
- **Draft-14/15** predate the NAMESPACE message, so each advertisement goes out as a PUBLISH_NAMESPACE request of its own over the control stream, scoped to the subscribed prefix, and PUBLISH_NAMESPACE_DONE closes it out on unannounce. When the subscription ends, its open requests are withdrawn.

This costs nothing against ourselves: both the Rust and JS subscribers always send one SUBSCRIBE_NAMESPACE per permitted prefix at session start. It is also what makes the cluster restack sane: on draft-17+ (the only place the extension negotiates) every advertisement now rides exactly one stream, so an update has exactly one place to go.

## PUBLISH is now rejected

PUBLISH offers a single track, but we route by namespace: a source attaches at a path and serves every track under it, resolved on demand via SUBSCRIBE. Honoring a PUBLISH meant inventing a namespace-level source from a track-level offer, and that fiction contradicted any real PUBLISH_NAMESPACE for the same path (the second message replaced the source the first attached). Accepting it would also commit us to (namespace, track) routing we do not support.

The subscriber now declines with a request error (`PUBLISH_ERROR` on draft-14, `REQUEST_ERROR` after) and finishes the stream, keeping the session alive: a peer using a feature we don't implement is not a protocol violation. `start_publish`, the `publishes` map, and `write_publish_ok` go with it. The JS subscriber already declined PUBLISH, so only Rust changes here.

## Cross-Package Sync

- `js/net` mirrors both halves. The IETF publisher is reshaped onto the same Signal-of-broadcasts pattern as the lite publisher: `publish()` just records the broadcast, `runSubscribeNamespace` diffs the map task-locally and (on 14/15) opens per-namespace PUBLISH_NAMESPACE requests. This also fixes a real interop bug: the JS publisher used to answer a draft-14/15 SUBSCRIBE_NAMESPACE with inline NAMESPACE entries, a message that does not exist on those drafts. `Connection.close()` now closes published broadcasts via `Publisher.close()`, matching lite (previously the per-publish wire task did it).
- `doc/concept/standard/interop.md` states the solicited-announce behavior and the PUBLISH decline.
- `drafts/` untouched: no wire format changes, only which (existing, spec-compliant) messages we choose to send. moq-lite is unaffected.

## Test plan

- New: `ietf::session::announces_wait_for_a_subscribe_namespace` (a quiet peer hears nothing, whatever we announce), `ietf::publisher::v14_subscribe_namespace_is_answered_with_publish_namespace` (drives the draft-14 arm end to end through a scripted peer: solicited announce, live announce, DONE riding the announce's own request rather than a new stream), `ietf::subscriber::publish_is_rejected_without_announcing` (the decline reaches the peer, nothing is announced, the session stays up).
- `test_transport::ScriptedSession` grew a `per_stream` mode (one script per opened stream) to make the draft-14 test possible.
- `cargo nextest run -p moq-net`: 627/627.
- `bun test` (js/net): 652/652, including the ietf draft-14..19 integration flows, which exercise the new solicited path end to end JS-to-JS.
- `just fix` / `just check` clean.

(written by Fable 5)
