### PR TITLE
fix(rtmp,native): close two keep-alive gaps on the accept side

### DIFF
--- a/doc/bin/rtmp.md
+++ b/doc/bin/rtmp.md
@@ -126,7 +126,10 @@ be pulled back out over RTMP.
 - **RTMPS.** Embedders can terminate TLS themselves: set `Config::tls` (or
   `Server::with_tls`) with a `rustls::ServerConfig`, or accept the connection and
   finish the TLS handshake by hand and hand the stream to `moq_rtmp::accept_stream`
-  (which works over any `AsyncRead + AsyncWrite` transport).
+  (which works over any `AsyncRead + AsyncWrite` transport). An embedder that owns
+  the `TcpStream` should call `moq_rtmp::configure_socket` on it first, the way
+  `Server` does: its keepalive is what reaps a play session whose viewer
+  disappeared without closing.
 - **Codecs.** FLAC and MP3 enhanced-audio payloads are dropped (no MoQ catalog
   codec); everything else (H.264/HEVC/AV1/VP9 video, AAC/Opus/AC-3/E-AC-3 audio)
   is supported.

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -246,7 +246,16 @@ impl Listener {
 		// `qmux_versions_for` returns `&[]` (every QMux draft) for ALPNs the spec
 		// doesn't restrict; qmux by default also accepts legacy clients that
 		// only offer a bare wire-format ALPN (today's moq-net clients still do).
-		let server = qmux::Server::new().with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))));
+		//
+		// Keep-alive matches the dial side (5s ping / 30s deadline, parity with QUIC's
+		// idle timeout) and is on by default because the accept side is where its
+		// absence costs something: a peer whose host crashed sends no FIN, and a
+		// WebSocket has no idle timeout of its own, so the session -- and every
+		// broadcast announced through it -- would survive until the OS probes the
+		// socket hours later. `qmux::Server` defaults it OFF, so this must be explicit.
+		let server = qmux::Server::new()
+			.with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))))
+			.with_keep_alive(qmux::KeepAlive::default());
 		Ok(Self { listener, server })
 	}
 

--- a/rs/moq-rtmp/README.md
+++ b/rs/moq-rtmp/README.md
@@ -108,11 +108,18 @@ Two ways to serve `rtmps://`:
   which runs the RTMP handshake and yields the same `Request`:
 
   ```rust
+  moq_rtmp::configure_socket(&tcp, peer); // Nagle off, keepalive on
   let tls = acceptor.accept(tcp).await?; // your tokio_rustls TlsAcceptor
   if let Some(request) = moq_rtmp::accept_stream(tls, peer).await? {
       // authorize, then match on Request::Publish / Request::Play and accept it
   }
   ```
+
+  When the transport is a `TcpStream` you own, call `configure_socket` on it
+  first; `Server` does this for every socket it accepts. Its keepalive is the
+  only thing that reaps a **play** session whose viewer vanished without a FIN:
+  publishers are bounded by `PUBLISH_IDLE_TIMEOUT`, but a play session sitting on
+  a quiet broadcast neither reads nor writes, so nothing else would notice.
 
 ## CLI
 

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -53,7 +53,9 @@
 //!   handshake yourself (any [`Stream`]: a `tokio_rustls` stream, a custom
 //!   socket, a test pipe), then hand the established stream to [`accept_stream`].
 //!   Useful when an existing TLS terminator, proxy, or non-TCP transport already
-//!   owns the socket.
+//!   owns the socket. When that transport is a `TcpStream`, call
+//!   [`configure_socket`] on it first: [`Server`] does, and its keepalive is what
+//!   reaps a play session whose viewer vanished without closing.
 //!
 //! Pure Rust: the RTMP handshake, chunk codec, and session state machine live in
 //! the vendored `rml` module (a fork of `rml_rtmp`), with no librtmp or ffmpeg
@@ -84,7 +86,7 @@ pub const DEFAULT_LATENCY: Duration = Duration::from_secs(2);
 pub use dial::Client;
 pub use error::{Error, Result};
 pub use listen::{Config, run};
-pub use server::{Conn, Play, Publish, Request, Server, Stream, accept_stream};
+pub use server::{Conn, PUBLISH_IDLE_TIMEOUT, Play, Publish, Request, Server, Stream, accept_stream, configure_socket};
 
 /// Re-export of the `rustls` version this crate builds [`Config::tls`] against,
 /// so consumers construct a matching [`rustls::ServerConfig`] (a major `rustls`

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -66,7 +66,10 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_PENDING_REQUESTS: usize = 128;
 
 /// Maximum gap between media packets from an accepted publisher.
-const PUBLISH_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+///
+/// Note this bounds the PUBLISH direction only; a play session has no equivalent,
+/// which is why [`configure_socket`]'s keepalive is not optional.
+pub const PUBLISH_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How long a play request may wait for its broadcast and initial FLV header
 /// before the server rejects it.
@@ -331,9 +334,16 @@ impl Server {
 /// Nagle off for latency, keepalive on so a dead peer is reaped rather than
 /// pinning a broadcast forever.
 ///
-/// Both are best-effort: a failure to set either is logged and ignored rather
+/// [`Server`] applies this to every socket it accepts. Call it yourself when you own
+/// the listener and hand the stream to [`accept_stream`]: the keepalive is the ONLY
+/// thing bounding a play session whose viewer vanished without a FIN while its
+/// broadcast was quiet. [`PUBLISH_IDLE_TIMEOUT`] covers the publish direction, but
+/// nothing reads or writes on a silent play socket, so it would otherwise live until
+/// the process restarted, holding its origin consumer open.
+///
+/// Both options are best-effort: a failure to set either is logged and ignored rather
 /// than dropping an otherwise healthy connection.
-pub(crate) fn configure_socket(stream: &TcpStream, peer: SocketAddr) {
+pub fn configure_socket(stream: &TcpStream, peer: SocketAddr) {
 	// Nagle off: RTMP is latency-sensitive and we write whole packets.
 	if let Err(err) = stream.set_nodelay(true) {
 		tracing::debug!(%peer, %err, "failed to set TCP_NODELAY");


### PR DESCRIPTION
## Summary

Two places where a peer that vanished **without a TCP FIN** is never noticed, so the session (and everything it announced) survives until the process restarts. Found while auditing timeouts/keep-alives across every transport in a downstream deployment.

- **`moq-rtmp`**: `configure_socket` was `pub(crate)`, so a bring-your-own-transport caller that owns its listener and hands the stream to `accept_stream` silently gets no TCP keepalive. Root cause of why that matters: `PUBLISH_IDLE_TIMEOUT` bounds the publish direction, but a **play** session whose broadcast is momentarily quiet neither reads nor writes, so nothing else ever reaps a viewer that disappeared and it holds its origin consumer open indefinitely. Made public, with the split spelled out in the docs and in the BYO-transport section of the crate docs.
- **`moq-native`**: `websocket::Listener` set keep-alive on the **dial** side but not the **accept** side, which is where its absence costs something. `qmux::Server` defaults it off, so this has to be explicit. `moq-relay`'s own axum path already passes it; this aligns the second construction site with the first.

No behavior change for existing `Server` users: it already called `configure_socket` on every socket it accepted.

## Public API changes

Additive only, so this targets `main`:

- `moq_rtmp::configure_socket` — `pub(crate)` → `pub` (re-exported from the crate root).
- `moq_rtmp::PUBLISH_IDLE_TIMEOUT` — private const → `pub` (re-exported; referenced by `configure_socket`'s docs).

Nothing renamed, removed, or signature-changed. `moq_native::websocket::Listener`'s signature is unchanged; only its behavior (it now pings and reaps silent peers, matching the client).

## Test plan

- `cargo test -p moq-rtmp -p moq-native` — green (393 tests).
- `cargo check -p moq-rtmp -p moq-native --all-targets`, `cargo fmt --all --check` — clean.
- Verified against the downstream consumer this came from: its RTMP listener re-implements the accept loop to sniff TLS on a shared port, copied only the `TCP_NODELAY` half, and now asserts both options on an accepted socket in a regression test that fails without the keepalive.

No behavior test for the `moq-native` half: a faithful one needs an in-memory transport that can be frozen mid-session, which `Listener` cannot accept since it owns a real `TcpListener`. The underlying qmux mechanism is already covered by `moq-relay`'s `keep_alive_reaps_a_silent_peer`, which exercises the same `KeepAlive::default()` against a freezable pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Opus 5)