### PR TITLE
feat(libmoq): add a client config handle, and advanced settings to the OBS plugin

### DIFF
--- a/cpp/obs/CMakeLists.txt
+++ b/cpp/obs/CMakeLists.txt
@@ -154,13 +154,20 @@ target_sources(
     src/moq-service.h
     src/moq-output.cpp
     src/moq-service.cpp
+    src/moq-settings.cpp
+    src/moq-settings.h
     src/moq-source.cpp
     src/moq-source.h
 )
 
 # The dock requires both the frontend API (to register it) and Qt (to build it).
+# The advanced settings dialog is Qt-only, so it ships with the dock that opens it;
+# without Qt the same settings are still reachable through the service properties.
 if(ENABLE_FRONTEND_API AND ENABLE_QT)
-  target_sources(obs-moq PRIVATE src/moq-dock.cpp src/moq-dock.h)
+  target_sources(
+    obs-moq
+    PRIVATE src/moq-dock.cpp src/moq-dock.h src/moq-advanced-dialog.cpp src/moq-advanced-dialog.h
+  )
   target_compile_definitions(obs-moq PRIVATE MOQ_FRONTEND_ENABLED MOQ_VERSION_STRING="${_moq_link_version}")
 endif()
 

--- a/cpp/obs/src/moq-advanced-dialog.cpp
+++ b/cpp/obs/src/moq-advanced-dialog.cpp
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "moq-advanced-dialog.h"
+#include "moq-settings.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+namespace {
+
+// A path row: an editable field plus a Browse button that opens the matching picker.
+// The QLineEdit is what gets registered as the field's widget, so Load/Save stay uniform.
+QWidget *PathRow(QLineEdit **out, const MoQSettings::Field &field, QWidget *parent)
+{
+	auto *row = new QWidget(parent);
+	auto *edit = new QLineEdit(row);
+	auto *browse = new QPushButton("Browse…", row);
+
+	const bool directory = field.kind == MoQSettings::Kind::Directory;
+	const QString label = QString::fromUtf8(field.label);
+	const QString filter = field.filter ? QString::fromUtf8(field.filter) : QString();
+
+	QObject::connect(browse, &QPushButton::clicked, edit, [edit, directory, label, filter]() {
+		const QString picked = directory ? QFileDialog::getExistingDirectory(edit, label, edit->text())
+						 : QFileDialog::getOpenFileName(edit, label, edit->text(), filter);
+		if (!picked.isEmpty())
+			edit->setText(picked);
+	});
+
+	auto *layout = new QHBoxLayout(row);
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->addWidget(edit, 1);
+	layout->addWidget(browse);
+
+	*out = edit;
+	return row;
+}
+
+} // namespace
+
+MoQAdvancedDialog::MoQAdvancedDialog(obs_data_t *settings, QWidget *parent)
+	: QDialog(parent),
+	  settings(settings),
+	  form(nullptr),
+	  enabled(nullptr)
+{
+	setWindowTitle("MoQ Advanced Settings");
+	setModal(true);
+
+	enabled = new QCheckBox("Use advanced settings", this);
+	enabled->setToolTip("With this off, MoQ connects with its defaults and everything below is ignored.");
+
+	form = new QWidget(this);
+	auto *layout = new QFormLayout(form);
+	layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+
+	for (const MoQSettings::Field &field : MoQSettings::Fields()) {
+		QWidget *widget = nullptr;
+		QWidget *row = nullptr;
+
+		switch (field.kind) {
+		case MoQSettings::Kind::Bool: {
+			auto *check = new QCheckBox(form);
+			widget = row = check;
+			break;
+		}
+		case MoQSettings::Kind::Int: {
+			auto *spin = new QSpinBox(form);
+			spin->setRange((int)field.min, (int)field.max);
+			spin->setSingleStep((int)field.step);
+			// Typing is faster than stepping through a 600000ms range.
+			spin->setKeyboardTracking(true);
+			widget = row = spin;
+			break;
+		}
+		case MoQSettings::Kind::Text: {
+			auto *edit = new QLineEdit(form);
+			widget = row = edit;
+			break;
+		}
+		case MoQSettings::Kind::File:
+		case MoQSettings::Kind::Directory: {
+			QLineEdit *edit = nullptr;
+			row = PathRow(&edit, field, form);
+			widget = edit;
+			break;
+		}
+		case MoQSettings::Kind::Choice: {
+			auto *combo = new QComboBox(form);
+			combo->setEditable(field.editable);
+			for (const MoQSettings::Option &option : field.options)
+				combo->addItem(QString::fromUtf8(option.label), QString::fromUtf8(option.value));
+			widget = row = combo;
+			break;
+		}
+		}
+
+		if (field.tooltip) {
+			const QString tooltip = QString::fromUtf8(field.tooltip);
+			widget->setToolTip(tooltip);
+			row->setToolTip(tooltip);
+		}
+
+		widgets[field.key] = widget;
+		layout->addRow(QString::fromUtf8(field.label), row);
+	}
+
+	// The form is long; scroll it rather than growing a window taller than the screen.
+	auto *scroll = new QScrollArea(this);
+	scroll->setWidget(form);
+	scroll->setWidgetResizable(true);
+
+	auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+	connect(buttons, &QDialogButtonBox::accepted, this, [this]() {
+		Save();
+		accept();
+	});
+	connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+	// Grey the form out when the settings are off, so it's obvious nothing below applies.
+	connect(enabled, &QCheckBox::toggled, form, &QWidget::setEnabled);
+
+	auto *outer = new QVBoxLayout(this);
+	outer->addWidget(enabled);
+	outer->addWidget(scroll, 1);
+	outer->addWidget(buttons);
+
+	resize(520, 600);
+
+	Load();
+}
+
+void MoQAdvancedDialog::Load()
+{
+	enabled->setChecked(obs_data_get_bool(settings, MoQSettings::ENABLED));
+	form->setEnabled(enabled->isChecked());
+
+	for (const MoQSettings::Field &field : MoQSettings::Fields()) {
+		QWidget *widget = widgets[field.key];
+
+		switch (field.kind) {
+		case MoQSettings::Kind::Bool:
+			static_cast<QCheckBox *>(widget)->setChecked(obs_data_get_bool(settings, field.key));
+			break;
+		case MoQSettings::Kind::Int:
+			static_cast<QSpinBox *>(widget)->setValue((int)obs_data_get_int(settings, field.key));
+			break;
+		case MoQSettings::Kind::Text:
+		case MoQSettings::Kind::File:
+		case MoQSettings::Kind::Directory:
+			static_cast<QLineEdit *>(widget)->setText(
+				QString::fromUtf8(obs_data_get_string(settings, field.key)));
+			break;
+		case MoQSettings::Kind::Choice: {
+			auto *combo = static_cast<QComboBox *>(widget);
+			const QString value = QString::fromUtf8(obs_data_get_string(settings, field.key));
+			const int index = combo->findData(value);
+			if (index >= 0)
+				combo->setCurrentIndex(index);
+			else if (combo->isEditable())
+				// A value the library accepts but doesn't advertise, e.g. a
+				// work-in-progress draft. Keep it rather than snapping to the default.
+				combo->setEditText(value);
+			break;
+		}
+		}
+	}
+}
+
+void MoQAdvancedDialog::Save()
+{
+	obs_data_set_bool(settings, MoQSettings::ENABLED, enabled->isChecked());
+
+	for (const MoQSettings::Field &field : MoQSettings::Fields()) {
+		QWidget *widget = widgets[field.key];
+
+		switch (field.kind) {
+		case MoQSettings::Kind::Bool:
+			obs_data_set_bool(settings, field.key, static_cast<QCheckBox *>(widget)->isChecked());
+			break;
+		case MoQSettings::Kind::Int:
+			obs_data_set_int(settings, field.key, static_cast<QSpinBox *>(widget)->value());
+			break;
+		case MoQSettings::Kind::Text:
+		case MoQSettings::Kind::File:
+		case MoQSettings::Kind::Directory:
+			obs_data_set_string(settings, field.key,
+					    static_cast<QLineEdit *>(widget)->text().toUtf8().constData());
+			break;
+		case MoQSettings::Kind::Choice: {
+			auto *combo = static_cast<QComboBox *>(widget);
+			// An editable combo's text is only a listed value when the user picked
+			// one; a typed value has no item data, so read the text in that case.
+			const int index = combo->findText(combo->currentText());
+			const QString value = index >= 0 ? combo->itemData(index).toString() : combo->currentText();
+			obs_data_set_string(settings, field.key, value.toUtf8().constData());
+			break;
+		}
+		}
+	}
+}

--- a/cpp/obs/src/moq-advanced-dialog.h
+++ b/cpp/obs/src/moq-advanced-dialog.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <obs.hpp>
+
+#include <QDialog>
+#include <QWidget>
+
+#include <map>
+#include <string>
+
+// A separate window for the advanced MoQ settings, so the dock stays small.
+//
+// The form is generated from MoQSettings::Fields(), the same list the service properties
+// page is built from, so a knob added there shows up in both without touching this file.
+class MoQAdvancedDialog : public QDialog {
+	Q_OBJECT
+
+public:
+	// Edits `settings` in place on accept. The caller keeps ownership and should
+	// persist it afterwards.
+	explicit MoQAdvancedDialog(obs_data_t *settings, QWidget *parent = nullptr);
+
+private:
+	// Fill the widgets from the settings data.
+	void Load();
+	// Write the widgets back into the settings data.
+	void Save();
+
+	obs_data_t *settings;
+	QWidget *form;
+	class QCheckBox *enabled;
+
+	// Widgets by setting key, so Load/Save can walk Fields() rather than naming each
+	// one twice more.
+	std::map<std::string, QWidget *> widgets;
+};

--- a/cpp/obs/src/moq-dock.cpp
+++ b/cpp/obs/src/moq-dock.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "moq-dock.h"
+#include "moq-advanced-dialog.h"
+#include "moq-settings.h"
 #include "logger.h"
 
 #include <obs-module.h>
@@ -112,6 +114,15 @@ MoQDock::MoQDock(QWidget *parent) : QWidget(parent)
 	button->setCursor(Qt::PointingHandCursor);
 	connect(button, &QPushButton::clicked, this, &MoQDock::ToggleStream);
 
+	// The advanced settings open in their own window; there are too many to fit in a
+	// dock that has to stay narrow.
+	advancedButton = new QPushButton("Advanced…", this);
+	advancedButton->setCursor(Qt::PointingHandCursor);
+	connect(advancedButton, &QPushButton::clicked, this, &MoQDock::OpenAdvanced);
+
+	advanced = OBSDataAutoRelease(obs_data_create());
+	MoQSettings::Defaults(advanced);
+
 	status = new QLabel(this);
 	status->setWordWrap(true);
 	QFont statusFont = status->font();
@@ -126,6 +137,7 @@ MoQDock::MoQDock(QWidget *parent) : QWidget(parent)
 	layout->setSpacing(10);
 	layout->addLayout(form);
 	layout->addWidget(button);
+	layout->addWidget(advancedButton);
 	layout->addWidget(status);
 	layout->addStretch();
 	layout->addWidget(versionLabel);
@@ -153,6 +165,13 @@ void MoQDock::ToggleStream()
 	} else {
 		StartStream();
 	}
+}
+
+void MoQDock::OpenAdvanced()
+{
+	MoQAdvancedDialog dialog(advanced, this);
+	if (dialog.exec() == QDialog::Accepted)
+		SaveSettings();
 }
 
 bool MoQDock::CreateConfiguredEncoders()
@@ -251,6 +270,9 @@ void MoQDock::StartStream()
 	// The MoQ output reads the server URL / path from its attached service, so
 	// build a throwaway service from the dock fields.
 	OBSDataAutoRelease serviceSettings = obs_data_create();
+	// The advanced settings ride along on the service, which is where the output reads
+	// them from regardless of whether the dock or Settings -> Stream configured it.
+	obs_data_apply(serviceSettings, advanced);
 	obs_data_set_string(serviceSettings, "server", url.c_str());
 	obs_data_set_string(serviceSettings, "key", path.c_str());
 	service =
@@ -322,6 +344,9 @@ void MoQDock::SetRunning(bool isRunning)
 
 	urlEdit->setEnabled(!isRunning);
 	pathEdit->setEnabled(!isRunning);
+	// The settings are read once at connect, so editing them mid-stream would look
+	// like it applied when it hadn't.
+	advancedButton->setEnabled(!isRunning);
 
 	if (!isRunning) {
 		status->setText("● Disconnected");
@@ -358,6 +383,12 @@ void MoQDock::LoadSettings()
 		urlEdit->setText(url);
 	if (obs_data_has_user_value(data, "path"))
 		pathEdit->setText(broadcast ? broadcast : "");
+
+	// Applied over the defaults set in the constructor, so a settings file written by
+	// an older build (missing keys that have since been added) still loads.
+	OBSDataAutoRelease saved = obs_data_get_obj(data, "advanced");
+	if (saved)
+		obs_data_apply(advanced, saved);
 }
 
 void MoQDock::SaveSettings()
@@ -371,6 +402,7 @@ void MoQDock::SaveSettings()
 	OBSDataAutoRelease data = obs_data_create();
 	obs_data_set_string(data, "url", urlEdit->text().toUtf8().constData());
 	obs_data_set_string(data, "path", pathEdit->text().toUtf8().constData());
+	obs_data_set_obj(data, "advanced", advanced);
 	obs_data_save_json(data, path.c_str());
 }
 

--- a/cpp/obs/src/moq-dock.h
+++ b/cpp/obs/src/moq-dock.h
@@ -23,6 +23,7 @@ public:
 private slots:
 	void ToggleStream();
 	void UpdateStatus();
+	void OpenAdvanced();
 
 private:
 	void StartStream();
@@ -40,7 +41,14 @@ private:
 	QLineEdit *urlEdit;
 	QLineEdit *pathEdit;
 	QPushButton *button;
+	QPushButton *advancedButton;
 	QLabel *status;
+
+	// Advanced connection settings, edited in their own window so the dock stays
+	// small. Persisted alongside the URL and path, and copied into the throwaway
+	// service at StartStream so the output reads them the same way it does for a
+	// service configured through Settings -> Stream.
+	OBSDataAutoRelease advanced;
 
 	QTimer *pollTimer;
 

--- a/cpp/obs/src/moq-output.cpp
+++ b/cpp/obs/src/moq-output.cpp
@@ -2,6 +2,7 @@
 #include <obs.hpp>
 
 #include "moq-output.h"
+#include "moq-settings.h"
 #include "util/util_uint64.h"
 
 extern "C" {
@@ -90,6 +91,19 @@ bool MoQOutput::Start()
 		return false;
 	}
 
+	// Advanced settings live on the service alongside the URL and path. A 0 handle
+	// means the group is switched off, which moq_client_connect reads as "defaults":
+	// the same dial moq_session_connect would have made.
+	OBSDataAutoRelease service_settings = obs_service_get_settings(service);
+	int client = MoQSettings::CreateClient(service_settings);
+	if (client < 0) {
+		// CreateClient logged which setting was rejected and why. Refusing to start
+		// beats connecting with a setting the user asked for quietly dropped.
+		obs_output_set_last_error(output, "Invalid advanced MoQ settings; see the log for details.");
+		SignalStop(OBS_OUTPUT_CONNECT_FAILED);
+		return false;
+	}
+
 	LOG_INFO("Connecting to MoQ server: %s", server_url.c_str());
 
 	// Held from the connect through obs_output_begin_data_capture. The status
@@ -117,8 +131,13 @@ bool MoQOutput::Start()
 
 	// Start establishing a session with the MoQ server
 	// NOTE: You could publish the same broadcasts to multiple sessions if you want (redundant ingest).
-	int handle =
-		moq_session_connect(server_url.data(), server_url.size(), origin, 0, MoQOutput::SessionStatus, ref);
+	int handle = moq_client_connect(server_url.data(), server_url.size(), (uint32_t)client, origin, 0,
+					MoQOutput::SessionStatus, ref);
+
+	// The connect copied the config, so the handle has done its job either way.
+	if (client > 0)
+		moq_client_close(client);
+
 	if (handle < 0) {
 		const char *reason = moq_error();
 		LOG_ERROR("Failed to initialize MoQ server: %d: %s", handle, reason ? reason : "unknown error");

--- a/cpp/obs/src/moq-service.cpp
+++ b/cpp/obs/src/moq-service.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "moq-service.h"
+#include "moq-settings.h"
 
 // TODO: Define supported codecs.
 const char *audio_codecs[] = {"aac", "opus", nullptr};
@@ -25,7 +26,14 @@ obs_properties_t *MoQService::Properties()
 	obs_properties_add_text(ppts, "server", "URL", OBS_TEXT_DEFAULT);
 	obs_properties_add_text(ppts, "key", "Path (optional)", OBS_TEXT_DEFAULT);
 
+	MoQSettings::AddProperties(ppts);
+
 	return ppts;
+}
+
+void MoQService::Defaults(obs_data_t *settings)
+{
+	MoQSettings::Defaults(settings);
 }
 
 void MoQService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
@@ -79,6 +87,9 @@ void register_moq_service()
 	};
 	info.get_properties = [](void *) -> obs_properties_t * {
 		return MoQService::Properties();
+	};
+	info.get_defaults = [](obs_data_t *settings) {
+		MoQService::Defaults(settings);
 	};
 	info.get_protocol = [](void *) -> const char * {
 		return "MoQ";

--- a/cpp/obs/src/moq-service.h
+++ b/cpp/obs/src/moq-service.h
@@ -12,6 +12,7 @@ struct MoQService {
 
 	void Update(obs_data_t *settings);
 	static obs_properties_t *Properties();
+	static void Defaults(obs_data_t *settings);
 	static void ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *audio_settings);
 	bool CanTryToConnect();
 	const char *GetConnectInfo(enum obs_service_connect_info type);

--- a/cpp/obs/src/moq-settings.cpp
+++ b/cpp/obs/src/moq-settings.cpp
@@ -1,0 +1,529 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "moq-settings.h"
+#include "logger.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include "moq.h"
+}
+
+namespace MoQSettings {
+
+namespace {
+
+// Keys. These are stable: they land in scene collections and in the dock's settings
+// file, so renaming one silently drops whatever the user had configured.
+constexpr const char *VERSION = "version";
+constexpr const char *BACKEND = "backend";
+constexpr const char *BIND = "bind";
+constexpr const char *CONNECT_TIMEOUT = "connect_timeout_ms";
+constexpr const char *FAILOVER_DELAY = "failover_delay_ms";
+
+constexpr const char *TLS_DISABLE_VERIFY = "tls_disable_verify";
+constexpr const char *TLS_FINGERPRINT = "tls_fingerprint";
+constexpr const char *TLS_ROOT = "tls_root";
+constexpr const char *TLS_HOST_NAME = "tls_host_name";
+
+constexpr const char *BACKOFF_INITIAL = "backoff_initial_ms";
+constexpr const char *BACKOFF_MAX = "backoff_max_ms";
+constexpr const char *BACKOFF_TIMEOUT = "backoff_timeout_ms";
+
+constexpr const char *QUIC_CONGESTION_CONTROL = "quic_congestion_control";
+constexpr const char *QUIC_MAX_STREAMS = "quic_max_streams";
+constexpr const char *QUIC_IDLE_TIMEOUT = "quic_idle_timeout_ms";
+constexpr const char *QUIC_KEEP_ALIVE = "quic_keep_alive_ms";
+constexpr const char *QUIC_GSO = "quic_gso";
+constexpr const char *QUIC_MTU_DISCOVERY = "quic_mtu_discovery";
+constexpr const char *QUIC_QLOG = "quic_qlog";
+
+constexpr const char *WEBSOCKET_ENABLED = "websocket_enabled";
+constexpr const char *WEBSOCKET_DELAY = "websocket_delay_ms";
+
+// Read a string setting, returning nullptr when it's unset or empty. libmoq's optional
+// string setters take exactly that: NULL means "leave at the default".
+const char *OptionalString(obs_data_t *settings, const char *key)
+{
+	const char *value = obs_data_get_string(settings, key);
+	return (value && *value) ? value : nullptr;
+}
+
+// Resolve a tri-state choice (AUTO / "on" / "off") into an override, if any.
+bool TriState(obs_data_t *settings, const char *key, bool *out)
+{
+	const char *value = OptionalString(settings, key);
+	if (!value)
+		return false;
+	*out = strcmp(value, "on") == 0;
+	return true;
+}
+
+// Report a failed libmoq call with the reason it recorded. moq_error() only describes
+// the most recent call on this thread, so read it before anything else runs.
+void LogFailure(const char *what, int code)
+{
+	const char *reason = moq_error();
+	LOG_ERROR("Advanced setting %s rejected (%d): %s", what, code, reason ? reason : "(no reason)");
+}
+
+// The protocol versions this build of libmoq offers, so the menu can't drift from what
+// moq_client_set_versions accepts.
+std::vector<Option> VersionOptions()
+{
+	std::vector<Option> options = {{"Automatic (offer all)", AUTO}};
+
+	int count = moq_versions(nullptr, 0);
+	if (count <= 0)
+		return options;
+
+	std::vector<moq_string> raw(static_cast<size_t>(count));
+	if (moq_versions(raw.data(), raw.size()) < 0)
+		return options;
+
+	// Option holds borrowed pointers, and the names libmoq hands back are not NUL
+	// terminated, so park NUL-terminated copies somewhere that outlives Fields().
+	// Filled exactly once, because Fields() builds its table once.
+	static std::vector<std::string> names;
+	names.reserve(raw.size());
+	for (const moq_string &name : raw)
+		names.emplace_back(name.data, name.len);
+
+	for (const std::string &name : names)
+		options.push_back({name.c_str(), name.c_str()});
+	return options;
+}
+
+// The QUIC backends this build of libmoq compiled in, so the menu can't offer one the
+// setter rejects. The backends are feature-gated, so listing the three names would put
+// dead options in front of the user on a release build.
+std::vector<Option> BackendOptions()
+{
+	std::vector<Option> options = {{"Automatic", AUTO}};
+
+	int count = moq_backends(nullptr, 0);
+	if (count <= 0)
+		return options;
+
+	std::vector<moq_string> raw(static_cast<size_t>(count));
+	if (moq_backends(raw.data(), raw.size()) < 0)
+		return options;
+
+	// Same borrowing rule as VersionOptions: Option holds pointers and the names are
+	// not NUL terminated, so park copies that outlive Fields().
+	static std::vector<std::string> names;
+	names.reserve(raw.size());
+	for (const moq_string &name : raw)
+		names.emplace_back(name.data, name.len);
+
+	for (const std::string &name : names)
+		options.push_back({name.c_str(), name.c_str()});
+	return options;
+}
+
+// Shorthands so the table below reads as data rather than aggregate initializers.
+Field Toggle(const char *key, const char *label, bool value, const char *tooltip = nullptr)
+{
+	return Field{key, label, tooltip, Kind::Bool, 0, 0, 0, value, 0, "", {}, false, nullptr};
+}
+
+Field Number(const char *key, const char *label, long long value, long long min, long long max, long long step,
+	     const char *tooltip = nullptr)
+{
+	return Field{key, label, tooltip, Kind::Int, min, max, step, false, value, "", {}, false, nullptr};
+}
+
+Field Text(const char *key, const char *label, const char *tooltip = nullptr)
+{
+	return Field{key, label, tooltip, Kind::Text, 0, 0, 0, false, 0, "", {}, false, nullptr};
+}
+
+Field Choose(const char *key, const char *label, std::vector<Option> options, bool editable = false,
+	     const char *tooltip = nullptr)
+{
+	return Field{key, label, tooltip, Kind::Choice, 0, 0, 0, false, 0, AUTO, std::move(options), editable, nullptr};
+}
+
+Field File(const char *key, const char *label, const char *filter, const char *tooltip = nullptr)
+{
+	return Field{key, label, tooltip, Kind::File, 0, 0, 0, false, 0, "", {}, false, filter};
+}
+
+Field Directory(const char *key, const char *label, const char *tooltip = nullptr)
+{
+	return Field{key, label, tooltip, Kind::Directory, 0, 0, 0, false, 0, "", {}, false, nullptr};
+}
+
+// The tri-state used wherever the library default depends on the backend.
+std::vector<Option> AutoOnOff()
+{
+	return {{"Automatic", AUTO}, {"Enabled", "on"}, {"Disabled", "off"}};
+}
+
+// libmoq's own defaults, so the table below doesn't repeat numbers that live in
+// moq-native and drift the moment one is retuned. Same reason Fields() reads the
+// version list from moq_versions instead of listing drafts.
+//
+// A knob nobody has set reads back as its default, so a throwaway handle is the
+// defaults. Local to the plugin rather than a libmoq type: the ABI is the getters.
+struct DefaultValues {
+	long long connect_timeout_ms = 0;
+	long long failover_delay_ms = 0;
+	long long backoff_initial_ms = 0;
+	long long backoff_max_ms = 0;
+	long long backoff_timeout_ms = 0;
+	long long quic_max_streams = 0;
+	long long quic_idle_timeout_ms = 0;
+	long long quic_keep_alive_ms = 0;
+	long long websocket_delay_ms = 0;
+	bool websocket_enabled = false;
+	bool loaded = false;
+};
+
+// Read a uint64 knob into the signed integer the UI edits, tracking whether every
+// getter in the batch succeeded.
+void Read(int (*get)(uint32_t, uint64_t *), uint32_t client, long long *out, bool *ok, const char *what)
+{
+	uint64_t value = 0;
+	int ret = get(client, &value);
+	if (ret < 0) {
+		const char *reason = moq_error();
+		LOG_ERROR("Failed to read the %s default (%d): %s", what, ret, reason ? reason : "(no reason)");
+		*ok = false;
+		return;
+	}
+	*out = (long long)value;
+}
+
+// The library's defaults, read once. A failure leaves `loaded` false, which
+// CreateClient refuses on rather than writing zeros into a scene collection.
+const DefaultValues &LibraryDefaults()
+{
+	static const DefaultValues defaults = [] {
+		DefaultValues d;
+		int client = moq_client_create();
+		if (client < 0) {
+			LOG_ERROR("Failed to create a libmoq client to read defaults from: %d", client);
+			return d;
+		}
+
+		bool ok = true;
+		uint32_t handle = (uint32_t)client;
+		Read(moq_client_get_connect_timeout, handle, &d.connect_timeout_ms, &ok, "connect timeout");
+		Read(moq_client_get_failover_delay, handle, &d.failover_delay_ms, &ok, "Happy Eyeballs delay");
+		Read(moq_client_get_backoff_initial, handle, &d.backoff_initial_ms, &ok, "reconnect delay");
+		Read(moq_client_get_backoff_max, handle, &d.backoff_max_ms, &ok, "reconnect delay cap");
+		Read(moq_client_get_backoff_timeout, handle, &d.backoff_timeout_ms, &ok, "reconnect timeout");
+		Read(moq_client_get_quic_max_streams, handle, &d.quic_max_streams, &ok, "max concurrent streams");
+		Read(moq_client_get_quic_idle_timeout, handle, &d.quic_idle_timeout_ms, &ok, "idle timeout");
+		Read(moq_client_get_quic_keep_alive, handle, &d.quic_keep_alive_ms, &ok, "keep-alive interval");
+		Read(moq_client_get_websocket_delay, handle, &d.websocket_delay_ms, &ok, "WebSocket fallback delay");
+
+		int ret = moq_client_get_websocket_enabled(handle, &d.websocket_enabled);
+		if (ret < 0) {
+			LOG_ERROR("Failed to read the WebSocket fallback default: %d", ret);
+			ok = false;
+		}
+
+		moq_client_close(client);
+		d.loaded = ok;
+		return d;
+	}();
+
+	return defaults;
+}
+
+} // namespace
+
+const std::vector<Field> &Fields()
+{
+	static const std::vector<Field> fields = [] {
+		const DefaultValues &d = LibraryDefaults();
+		std::vector<Field> f;
+
+		// Protocol. Editable so a work-in-progress draft, which is never offered by
+		// default and so never listed, can still be typed in.
+		f.push_back(Choose(VERSION, "Protocol version", VersionOptions(), true,
+				   "Pin the handshake to one draft instead of offering every supported version."));
+		f.push_back(Choose(BACKEND, "QUIC backend", BackendOptions()));
+		f.push_back(Text(BIND, "Bind address",
+				 "Local UDP address to send from, e.g. 192.0.2.7:0 to pin the outgoing "
+				 "interface. Leave empty for any."));
+		f.push_back(Number(CONNECT_TIMEOUT, "Connect timeout (ms)", d.connect_timeout_ms, 0, 600000, 1000,
+				   "How long one connection attempt may take, dial and handshake together. "
+				   "0 waits forever."));
+		f.push_back(Number(FAILOVER_DELAY, "Happy Eyeballs delay (ms)", d.failover_delay_ms, 0, 10000, 50,
+				   "How long to wait before also trying the next address DNS returned."));
+
+		// TLS.
+		f.push_back(Toggle(TLS_DISABLE_VERIFY, "Skip certificate verification", false,
+				   "Development only: accepts any certificate, so it cannot be combined "
+				   "with a fingerprint or a root below. To trust one known self-signed "
+				   "relay, turn this off and pin its fingerprint instead."));
+		f.push_back(Text(TLS_FINGERPRINT, "Certificate fingerprint (SHA-256 hex)",
+				 "Trust a self-signed certificate by pinning its fingerprint, without "
+				 "accepting every certificate the way the option above does. Leave that "
+				 "option off, or the stream refuses to start rather than quietly "
+				 "ignoring this pin."));
+		f.push_back(File(TLS_ROOT, "Root certificate (PEM)", "PEM (*.pem *.crt);;All Files (*)",
+				 "Trust this CA instead of the system roots."));
+		f.push_back(Text(TLS_HOST_NAME, "Server name override (SNI)",
+				 "Validate the certificate against this name instead of the host in the "
+				 "URL, so a relay can be reached by IP."));
+
+		// Reconnect.
+		f.push_back(Number(BACKOFF_INITIAL, "Reconnect delay (ms)", d.backoff_initial_ms, 0, 60000, 100,
+				   "Delay before the first reconnect attempt; it grows from here."));
+		f.push_back(Number(BACKOFF_MAX, "Reconnect delay cap (ms)", d.backoff_max_ms, 0, 600000, 1000,
+				   "Ceiling on the growing reconnect delay."));
+		f.push_back(Number(BACKOFF_TIMEOUT, "Give up after (ms)", d.backoff_timeout_ms, 0, 3600000, 1000,
+				   "Total time to keep retrying before the stream fails. Also how long the "
+				   "broadcast lingers for viewers across the gap. 0 retries forever."));
+
+		// QUIC transport.
+		f.push_back(Choose(
+			QUIC_CONGESTION_CONTROL, "Congestion control",
+			{{"Automatic", AUTO}, {"Delay-based (BBR)", "delay"}, {"Loss-based (CUBIC)", "loss"}}, false,
+			"Delay-based keeps queues short and the send rate steady enough for an "
+			"encoder to track. Loss-based chases throughput instead."));
+		f.push_back(Number(QUIC_MAX_STREAMS, "Max concurrent streams", d.quic_max_streams, 1, 65536, 1,
+				   "MoQ opens a stream per group, so a busy publisher wants this high."));
+		f.push_back(Number(QUIC_IDLE_TIMEOUT, "Idle timeout (ms)", d.quic_idle_timeout_ms, 0, 600000, 1000,
+				   "How long an idle connection survives before it is dropped."));
+		f.push_back(Number(QUIC_KEEP_ALIVE, "Keep-alive interval (ms)", d.quic_keep_alive_ms, 0, 60000, 100,
+				   "0 disables the keep-alive pings."));
+		f.push_back(Choose(QUIC_GSO, "UDP segmentation offload", AutoOnOff(), false,
+				   "Batches sends into one syscall. Turn it off if large sends vanish; some "
+				   "NICs and middleboxes mangle segmented packets."));
+		f.push_back(Choose(QUIC_MTU_DISCOVERY, "Path MTU discovery", AutoOnOff()));
+		// Only when this build can capture: setting a directory without support
+		// fails the dial, so offering it would be a control that only breaks things.
+		if (moq_qlog_supported()) {
+			f.push_back(Directory(QUIC_QLOG, "qlog directory",
+					      "Write QUIC connection traces here for diagnosing stalls. Leave "
+					      "empty to disable; the files get large."));
+		}
+
+		// WebSocket fallback.
+		f.push_back(Toggle(WEBSOCKET_ENABLED, "WebSocket fallback", d.websocket_enabled,
+				   "Race a WebSocket connection against QUIC so a network that blocks UDP "
+				   "still goes live. Turn it off to measure the QUIC path alone."));
+		f.push_back(Number(WEBSOCKET_DELAY, "WebSocket fallback delay (ms)", d.websocket_delay_ms, 0, 10000, 50,
+				   "How long QUIC gets a head start before the WebSocket attempt joins in."));
+
+		return f;
+	}();
+
+	return fields;
+}
+
+void Defaults(obs_data_t *settings)
+{
+	obs_data_set_default_bool(settings, ENABLED, false);
+
+	for (const Field &field : Fields()) {
+		switch (field.kind) {
+		case Kind::Bool:
+			obs_data_set_default_bool(settings, field.key, field.bool_default);
+			break;
+		case Kind::Int:
+			obs_data_set_default_int(settings, field.key, field.int_default);
+			break;
+		case Kind::Text:
+		case Kind::File:
+		case Kind::Directory:
+		case Kind::Choice:
+			obs_data_set_default_string(settings, field.key, field.text_default);
+			break;
+		}
+	}
+}
+
+void AddProperties(obs_properties_t *props)
+{
+	obs_properties_t *group = obs_properties_create();
+
+	for (const Field &field : Fields()) {
+		obs_property_t *p = nullptr;
+
+		switch (field.kind) {
+		case Kind::Bool:
+			p = obs_properties_add_bool(group, field.key, field.label);
+			break;
+		case Kind::Int:
+			p = obs_properties_add_int(group, field.key, field.label, (int)field.min, (int)field.max,
+						   (int)field.step);
+			break;
+		case Kind::Text:
+			p = obs_properties_add_text(group, field.key, field.label, OBS_TEXT_DEFAULT);
+			break;
+		case Kind::File:
+			p = obs_properties_add_path(group, field.key, field.label, OBS_PATH_FILE, field.filter,
+						    nullptr);
+			break;
+		case Kind::Directory:
+			p = obs_properties_add_path(group, field.key, field.label, OBS_PATH_DIRECTORY, nullptr,
+						    nullptr);
+			break;
+		case Kind::Choice:
+			p = obs_properties_add_list(group, field.key, field.label,
+						    field.editable ? OBS_COMBO_TYPE_EDITABLE : OBS_COMBO_TYPE_LIST,
+						    OBS_COMBO_FORMAT_STRING);
+			for (const Option &option : field.options)
+				obs_property_list_add_string(p, option.label, option.value);
+			break;
+		}
+
+		if (p && field.tooltip)
+			obs_property_set_long_description(p, field.tooltip);
+	}
+
+	obs_properties_add_group(props, ENABLED, "Advanced", OBS_GROUP_CHECKABLE, group);
+}
+
+int CreateClient(obs_data_t *settings)
+{
+	if (!settings || !obs_data_get_bool(settings, ENABLED))
+		return 0;
+
+	// Every numeric field defaulted to zero, so the settings on hand describe a config
+	// nobody chose. Refusing beats dialing with a 0ms idle timeout the user never asked
+	// for. LibraryDefaults() already logged which getter failed. Plain -1 because
+	// libmoq's error codes are Rust-side only; moq.h exports no names for them.
+	if (!LibraryDefaults().loaded) {
+		LOG_ERROR("Advanced settings unavailable: libmoq did not report its defaults");
+		return -1;
+	}
+
+	int client = moq_client_create();
+	if (client < 0) {
+		LogFailure("client", client);
+		return client;
+	}
+
+	// Any failure below aborts: the user opted into these settings explicitly, and a
+	// silently dropped version pin or fingerprint is the exact confusion the advanced
+	// settings exist to avoid.
+	int code = 0;
+	auto fail = [&](const char *what) {
+		LogFailure(what, code);
+		moq_client_close(client);
+		return code;
+	};
+
+	if (const char *version = OptionalString(settings, VERSION)) {
+		moq_string one = {version, strlen(version)};
+		code = moq_client_set_versions(client, &one, 1);
+		if (code < 0)
+			return fail("protocol version");
+	}
+
+	if (const char *backend = OptionalString(settings, BACKEND)) {
+		code = moq_client_set_backend(client, backend, strlen(backend));
+		if (code < 0)
+			return fail("QUIC backend");
+	}
+
+	if (const char *bind = OptionalString(settings, BIND)) {
+		code = moq_client_set_bind(client, bind, strlen(bind));
+		if (code < 0)
+			return fail("bind address");
+	}
+
+	code = moq_client_set_connect_timeout(client, (uint64_t)obs_data_get_int(settings, CONNECT_TIMEOUT));
+	if (code < 0)
+		return fail("connect timeout");
+
+	code = moq_client_set_failover_delay(client, (uint64_t)obs_data_get_int(settings, FAILOVER_DELAY));
+	if (code < 0)
+		return fail("Happy Eyeballs delay");
+
+	code = moq_client_set_tls_disable_verify(client, obs_data_get_bool(settings, TLS_DISABLE_VERIFY));
+	if (code < 0)
+		return fail("certificate verification");
+
+	if (const char *fingerprint = OptionalString(settings, TLS_FINGERPRINT)) {
+		moq_string one = {fingerprint, strlen(fingerprint)};
+		code = moq_client_set_tls_fingerprints(client, &one, 1);
+		if (code < 0)
+			return fail("certificate fingerprint");
+	}
+
+	if (const char *root = OptionalString(settings, TLS_ROOT)) {
+		moq_string one = {root, strlen(root)};
+		code = moq_client_set_tls_roots(client, &one, 1);
+		if (code < 0)
+			return fail("root certificate");
+	}
+
+	// NULL clears the override, so this one call covers both set and unset.
+	const char *host_name = OptionalString(settings, TLS_HOST_NAME);
+	code = moq_client_set_tls_host_name(client, host_name, host_name ? strlen(host_name) : 0);
+	if (code < 0)
+		return fail("server name override");
+
+	code = moq_client_set_backoff_initial(client, (uint64_t)obs_data_get_int(settings, BACKOFF_INITIAL));
+	if (code < 0)
+		return fail("reconnect delay");
+
+	code = moq_client_set_backoff_max(client, (uint64_t)obs_data_get_int(settings, BACKOFF_MAX));
+	if (code < 0)
+		return fail("reconnect delay cap");
+
+	code = moq_client_set_backoff_timeout(client, (uint64_t)obs_data_get_int(settings, BACKOFF_TIMEOUT));
+	if (code < 0)
+		return fail("reconnect give-up timeout");
+
+	code = moq_client_set_quic_max_streams(client, (uint64_t)obs_data_get_int(settings, QUIC_MAX_STREAMS));
+	if (code < 0)
+		return fail("max concurrent streams");
+
+	code = moq_client_set_quic_idle_timeout(client, (uint64_t)obs_data_get_int(settings, QUIC_IDLE_TIMEOUT));
+	if (code < 0)
+		return fail("idle timeout");
+
+	code = moq_client_set_quic_keep_alive(client, (uint64_t)obs_data_get_int(settings, QUIC_KEEP_ALIVE));
+	if (code < 0)
+		return fail("keep-alive interval");
+
+	// The tri-states stay untouched when the user left them on Automatic, which is what
+	// keeps the backend free to pick.
+	bool toggle = false;
+	if (TriState(settings, QUIC_GSO, &toggle)) {
+		code = moq_client_set_quic_gso(client, toggle);
+		if (code < 0)
+			return fail("UDP segmentation offload");
+	}
+
+	if (TriState(settings, QUIC_MTU_DISCOVERY, &toggle)) {
+		code = moq_client_set_quic_mtu_discovery(client, toggle);
+		if (code < 0)
+			return fail("path MTU discovery");
+	}
+
+	const char *congestion = OptionalString(settings, QUIC_CONGESTION_CONTROL);
+	code = moq_client_set_quic_congestion_control(client, congestion, congestion ? strlen(congestion) : 0);
+	if (code < 0)
+		return fail("congestion control");
+
+	// A scene collection written by a qlog-capable build keeps the key even where the
+	// field is hidden, and applying it there would fail the dial for a setting the user
+	// can no longer see, let alone clear.
+	const char *qlog = moq_qlog_supported() ? OptionalString(settings, QUIC_QLOG) : nullptr;
+	code = moq_client_set_quic_qlog(client, qlog, qlog ? strlen(qlog) : 0);
+	if (code < 0)
+		return fail("qlog directory");
+
+	code = moq_client_set_websocket_enabled(client, obs_data_get_bool(settings, WEBSOCKET_ENABLED));
+	if (code < 0)
+		return fail("WebSocket fallback");
+
+	code = moq_client_set_websocket_delay(client, (uint64_t)obs_data_get_int(settings, WEBSOCKET_DELAY));
+	if (code < 0)
+		return fail("WebSocket fallback delay");
+
+	return client;
+}
+
+} // namespace MoQSettings

--- a/cpp/obs/src/moq-settings.cpp
+++ b/cpp/obs/src/moq-settings.cpp
@@ -2,6 +2,7 @@
 #include "moq-settings.h"
 #include "logger.h"
 
+#include <algorithm>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -60,6 +61,20 @@ bool TriState(obs_data_t *settings, const char *key, bool *out)
 	return true;
 }
 
+// Read an integer setting inside the range declared by its Field. Scene collections
+// are editable JSON, so the widget bounds alone do not protect the unsigned C API.
+uint64_t Amount(obs_data_t *settings, const char *key)
+{
+	const long long value = obs_data_get_int(settings, key);
+	for (const Field &field : Fields()) {
+		if (strcmp(field.key, key) == 0)
+			return static_cast<uint64_t>(std::clamp(value, field.min, field.max));
+	}
+
+	LOG_ERROR("Advanced integer setting has no Field: %s", key);
+	return 0;
+}
+
 // Report a failed libmoq call with the reason it recorded. moq_error() only describes
 // the most recent call on this thread, so read it before anything else runs.
 void LogFailure(const char *what, int code)
@@ -68,31 +83,39 @@ void LogFailure(const char *what, int code)
 	LOG_ERROR("Advanced setting %s rejected (%d): %s", what, code, reason ? reason : "(no reason)");
 }
 
-// The protocol versions this build of libmoq offers, so the menu can't drift from what
-// moq_client_set_versions accepts.
-std::vector<Option> VersionOptions()
+// Enumerate a libmoq capability into menu options. The names live beside the caller's
+// static field table because Option borrows their pointers.
+std::vector<Option> CapabilityOptions(int (*enumerate)(moq_string *, size_t), const char *automatic,
+				      std::vector<std::string> &names)
 {
-	std::vector<Option> options = {{"Automatic (offer all)", AUTO}};
+	std::vector<Option> options = {{automatic, AUTO}};
 
-	int count = moq_versions(nullptr, 0);
+	int count = enumerate(nullptr, 0);
 	if (count <= 0)
 		return options;
 
 	std::vector<moq_string> raw(static_cast<size_t>(count));
-	if (moq_versions(raw.data(), raw.size()) < 0)
+	const int reported = enumerate(raw.data(), raw.size());
+	if (reported < 0)
 		return options;
+	const size_t written = std::min(raw.size(), static_cast<size_t>(reported));
 
-	// Option holds borrowed pointers, and the names libmoq hands back are not NUL
-	// terminated, so park NUL-terminated copies somewhere that outlives Fields().
-	// Filled exactly once, because Fields() builds its table once.
-	static std::vector<std::string> names;
-	names.reserve(raw.size());
-	for (const moq_string &name : raw)
-		names.emplace_back(name.data, name.len);
+	names.clear();
+	names.reserve(written);
+	for (size_t i = 0; i < written; ++i)
+		names.emplace_back(raw[i].data, raw[i].len);
 
 	for (const std::string &name : names)
 		options.push_back({name.c_str(), name.c_str()});
 	return options;
+}
+
+// The protocol versions this build of libmoq offers, so the menu can't drift from what
+// moq_client_set_versions accepts.
+std::vector<Option> VersionOptions()
+{
+	static std::vector<std::string> names;
+	return CapabilityOptions(moq_versions, "Automatic (offer all)", names);
 }
 
 // The QUIC backends this build of libmoq compiled in, so the menu can't offer one the
@@ -100,26 +123,8 @@ std::vector<Option> VersionOptions()
 // dead options in front of the user on a release build.
 std::vector<Option> BackendOptions()
 {
-	std::vector<Option> options = {{"Automatic", AUTO}};
-
-	int count = moq_backends(nullptr, 0);
-	if (count <= 0)
-		return options;
-
-	std::vector<moq_string> raw(static_cast<size_t>(count));
-	if (moq_backends(raw.data(), raw.size()) < 0)
-		return options;
-
-	// Same borrowing rule as VersionOptions: Option holds pointers and the names are
-	// not NUL terminated, so park copies that outlive Fields().
 	static std::vector<std::string> names;
-	names.reserve(raw.size());
-	for (const moq_string &name : raw)
-		names.emplace_back(name.data, name.len);
-
-	for (const std::string &name : names)
-		options.push_back({name.c_str(), name.c_str()});
-	return options;
+	return CapabilityOptions(moq_backends, "Automatic", names);
 }
 
 // Shorthands so the table below reads as data rather than aggregate initializers.
@@ -273,9 +278,9 @@ const std::vector<Field> &Fields()
 				 "URL, so a relay can be reached by IP."));
 
 		// Reconnect.
-		f.push_back(Number(BACKOFF_INITIAL, "Reconnect delay (ms)", d.backoff_initial_ms, 0, 60000, 100,
+		f.push_back(Number(BACKOFF_INITIAL, "Reconnect delay (ms)", d.backoff_initial_ms, 1, 60000, 100,
 				   "Delay before the first reconnect attempt; it grows from here."));
-		f.push_back(Number(BACKOFF_MAX, "Reconnect delay cap (ms)", d.backoff_max_ms, 0, 600000, 1000,
+		f.push_back(Number(BACKOFF_MAX, "Reconnect delay cap (ms)", d.backoff_max_ms, 1, 600000, 1000,
 				   "Ceiling on the growing reconnect delay."));
 		f.push_back(Number(BACKOFF_TIMEOUT, "Give up after (ms)", d.backoff_timeout_ms, 0, 3600000, 1000,
 				   "Total time to keep retrying before the stream fails. Also how long the "
@@ -431,11 +436,11 @@ int CreateClient(obs_data_t *settings)
 			return fail("bind address");
 	}
 
-	code = moq_client_set_connect_timeout(client, (uint64_t)obs_data_get_int(settings, CONNECT_TIMEOUT));
+	code = moq_client_set_connect_timeout(client, Amount(settings, CONNECT_TIMEOUT));
 	if (code < 0)
 		return fail("connect timeout");
 
-	code = moq_client_set_failover_delay(client, (uint64_t)obs_data_get_int(settings, FAILOVER_DELAY));
+	code = moq_client_set_failover_delay(client, Amount(settings, FAILOVER_DELAY));
 	if (code < 0)
 		return fail("Happy Eyeballs delay");
 
@@ -463,27 +468,27 @@ int CreateClient(obs_data_t *settings)
 	if (code < 0)
 		return fail("server name override");
 
-	code = moq_client_set_backoff_initial(client, (uint64_t)obs_data_get_int(settings, BACKOFF_INITIAL));
+	code = moq_client_set_backoff_initial(client, Amount(settings, BACKOFF_INITIAL));
 	if (code < 0)
 		return fail("reconnect delay");
 
-	code = moq_client_set_backoff_max(client, (uint64_t)obs_data_get_int(settings, BACKOFF_MAX));
+	code = moq_client_set_backoff_max(client, Amount(settings, BACKOFF_MAX));
 	if (code < 0)
 		return fail("reconnect delay cap");
 
-	code = moq_client_set_backoff_timeout(client, (uint64_t)obs_data_get_int(settings, BACKOFF_TIMEOUT));
+	code = moq_client_set_backoff_timeout(client, Amount(settings, BACKOFF_TIMEOUT));
 	if (code < 0)
 		return fail("reconnect give-up timeout");
 
-	code = moq_client_set_quic_max_streams(client, (uint64_t)obs_data_get_int(settings, QUIC_MAX_STREAMS));
+	code = moq_client_set_quic_max_streams(client, Amount(settings, QUIC_MAX_STREAMS));
 	if (code < 0)
 		return fail("max concurrent streams");
 
-	code = moq_client_set_quic_idle_timeout(client, (uint64_t)obs_data_get_int(settings, QUIC_IDLE_TIMEOUT));
+	code = moq_client_set_quic_idle_timeout(client, Amount(settings, QUIC_IDLE_TIMEOUT));
 	if (code < 0)
 		return fail("idle timeout");
 
-	code = moq_client_set_quic_keep_alive(client, (uint64_t)obs_data_get_int(settings, QUIC_KEEP_ALIVE));
+	code = moq_client_set_quic_keep_alive(client, Amount(settings, QUIC_KEEP_ALIVE));
 	if (code < 0)
 		return fail("keep-alive interval");
 
@@ -519,7 +524,7 @@ int CreateClient(obs_data_t *settings)
 	if (code < 0)
 		return fail("WebSocket fallback");
 
-	code = moq_client_set_websocket_delay(client, (uint64_t)obs_data_get_int(settings, WEBSOCKET_DELAY));
+	code = moq_client_set_websocket_delay(client, Amount(settings, WEBSOCKET_DELAY));
 	if (code < 0)
 		return fail("WebSocket fallback delay");
 

--- a/cpp/obs/src/moq-settings.h
+++ b/cpp/obs/src/moq-settings.h
@@ -13,8 +13,7 @@
 namespace MoQSettings {
 
 // Whether any of this applies. With it off the output dials with libmoq's defaults and
-// ignores every other key, so the default path stays exactly what it was before these
-// settings existed.
+// ignores every other key.
 inline constexpr const char *ENABLED = "advanced";
 
 // The value a Choice field carries when the user hasn't picked: leave the knob wherever

--- a/cpp/obs/src/moq-settings.h
+++ b/cpp/obs/src/moq-settings.h
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+#include <obs-module.h>
+
+#include <vector>
+
+// Advanced MoQ connection settings.
+//
+// One set of keys on an obs_data_t backs every surface that edits them: the service
+// properties page, the dock's advanced dialog, and the output that reads them at connect
+// time. The fields are described once in Fields() so both UIs are generated from the
+// same list; adding a knob means adding a Field entry and one call in CreateClient.
+namespace MoQSettings {
+
+// Whether any of this applies. With it off the output dials with libmoq's defaults and
+// ignores every other key, so the default path stays exactly what it was before these
+// settings existed.
+inline constexpr const char *ENABLED = "advanced";
+
+// The value a Choice field carries when the user hasn't picked: leave the knob wherever
+// the library puts it. An empty string, so it round-trips through obs_data as "no
+// choice" without a separate flag.
+inline constexpr const char *AUTO = "";
+
+// What kind of widget a field needs.
+enum class Kind {
+	Bool,
+	Int,
+	Text,
+	// A file path; Filter names what to accept.
+	File,
+	Directory,
+	// A fixed set of values, or a suggested set when Editable is set.
+	Choice,
+};
+
+// One entry in a Choice field's menu.
+struct Option {
+	const char *label;
+	const char *value;
+};
+
+// A single advanced setting, rendered by both UIs and read by CreateClient.
+struct Field {
+	const char *key;
+	const char *label;
+	// Longer explanation, shown as a tooltip. May be null.
+	const char *tooltip;
+	Kind kind;
+
+	// Int only.
+	long long min;
+	long long max;
+	long long step;
+
+	// Defaults. Only the one matching kind is meaningful.
+	bool bool_default;
+	long long int_default;
+	const char *text_default;
+
+	// Choice only. Editable lets the user type a value that isn't listed.
+	std::vector<Option> options;
+	bool editable;
+
+	// File only: an OBS path filter, e.g. "PEM (*.pem);;All (*)".
+	const char *filter;
+};
+
+// Every advanced setting, in display order.
+//
+// Built on first call because the protocol version menu is populated from libmoq, so it
+// can't drift from what the library actually accepts.
+const std::vector<Field> &Fields();
+
+// Register the defaults from Fields(). Call from the service's get_defaults.
+void Defaults(obs_data_t *settings);
+
+// Add the checkable "Advanced" group to a properties list.
+void AddProperties(obs_properties_t *props);
+
+// Build a libmoq client config handle from these settings.
+//
+// Returns 0 when the advanced group is off, meaning "dial with the defaults" (which is
+// what a 0 client handle means to moq_client_connect). Returns negative if a setting is
+// invalid, or if libmoq never reported the defaults the fields are built from; the
+// caller should refuse to start rather than connect with a setting the user asked for
+// silently dropped. The caller owns the handle and must release it with
+// moq_client_close.
+int CreateClient(obs_data_t *settings);
+
+} // namespace MoQSettings

--- a/cpp/obs/test/moq-output-test.cpp
+++ b/cpp/obs/test/moq-output-test.cpp
@@ -43,6 +43,7 @@ std::mutex g_signals_mutex;
 std::vector<RecordedSignal> g_signals;
 std::string g_last_error;
 std::atomic<int> g_begin_capture{0};
+std::atomic<int> g_client_result{0};
 // Lets a test run something inside obs_output_signal_stop, standing in for a
 // frontend that stops the output straight from the signal handler.
 std::function<void()> g_on_signal;
@@ -85,6 +86,13 @@ const char *obs_service_get_connect_info(const obs_service_t *, uint32_t type)
 {
 	return type == OBS_SERVICE_CONNECT_INFO_SERVER_URL ? "https://relay.example/anon" : "room";
 }
+
+obs_data_t *obs_service_get_settings(const obs_service_t *)
+{
+	return reinterpret_cast<obs_data_t *>(0x3);
+}
+
+void obs_data_release(obs_data_t *) {}
 
 obs_encoder_t *obs_output_get_video_encoder2(const obs_output_t *, size_t idx)
 {
@@ -132,6 +140,13 @@ const char *obs_encoder_get_codec(const obs_encoder_t *)
 }
 
 } // extern "C"
+
+namespace MoQSettings {
+int CreateClient(obs_data_t *)
+{
+	return g_client_result;
+}
+} // namespace MoQSettings
 
 // ------------------------------------------------------------- libmoq stubs
 
@@ -215,6 +230,17 @@ int32_t moq_session_connect(const char *, size_t, uint32_t, uint32_t, void (*on_
 	return handle;
 }
 
+int32_t moq_client_connect(const char *url, size_t url_len, uint32_t, uint32_t origin_publish, uint32_t origin_consume,
+			   void (*on_status)(void *, int32_t), void *user_data)
+{
+	return moq_session_connect(url, url_len, origin_publish, origin_consume, on_status, user_data);
+}
+
+int32_t moq_client_close(uint32_t)
+{
+	return 0;
+}
+
 int32_t moq_session_close(uint32_t session)
 {
 	g_closed_handle = static_cast<int>(session);
@@ -290,6 +316,7 @@ void reset()
 	g_on_status = nullptr;
 	g_closed_handle = 0;
 	g_begin_capture = 0;
+	g_client_result = 0;
 	g_start_gate = nullptr;
 	g_connect_fires_terminal = false;
 	g_connect_fires_terminal_threaded = false;
@@ -309,6 +336,19 @@ void reset()
 int main()
 {
 	auto out = reinterpret_cast<obs_output_t *>(0x9);
+
+	// Invalid advanced settings stop before a session or capture is created.
+	{
+		reset();
+		g_client_result = -40;
+		MoQOutput o(nullptr, out);
+		CHECK(!o.Start());
+		CHECK(g_on_status == nullptr);
+		CHECK(g_begin_capture == 0);
+		CHECK(signalCount() == 1);
+		CHECK(signalAt(0).code == OBS_OUTPUT_CONNECT_FAILED);
+	}
+	printf("invalid advanced settings: ok\n");
 
 	// Reconnection gave up after the session had been up: OBS must be told, with
 	// the libmoq reason attached, so it stops reporting a live stream.

--- a/doc/bin/obs.md
+++ b/doc/bin/obs.md
@@ -107,15 +107,15 @@ They live in two places, backed by the same values:
 - **The MoQ dock**, via the **Advanced…** button, which opens them in their own window so
   the dock stays small.
 
-Everything is ignored unless the group is switched on, so leaving it off connects exactly
-the way it did before these settings existed. If a value is rejected (an unknown version,
-an unparseable bind address), the stream refuses to start and the log says which setting
-and why, rather than connecting with your setting quietly dropped.
+Everything is ignored unless the group is switched on. With the group off, the plugin
+connects with the libmoq defaults. If a value is rejected (an unknown version, an
+unparseable bind address), the stream refuses to start and the log records which setting
+was rejected and why.
 
 | Setting | What it's for |
 | --- | --- |
 | Protocol version | Pin the handshake to one draft instead of offering all of them. The menu lists what this build offers; a work-in-progress draft can be typed in. |
-| QUIC backend | Pick quinn, quiche, or noq instead of the compiled-in default. |
+| QUIC backend | Pick one of the backends compiled into this libmoq build instead of its default. |
 | Bind address | Send from a specific local address, e.g. `192.0.2.7:0` to pin the outgoing interface. |
 | Connect timeout | Bound on one attempt, dial and handshake together. `0` waits forever. |
 | Happy Eyeballs delay | How long before also trying the next address DNS returned. |
@@ -128,6 +128,6 @@ and why, rather than connecting with your setting quietly dropped.
 | Max concurrent streams | MoQ opens a stream per group, so a busy publisher wants this high. |
 | Idle timeout / Keep-alive | Connection liveness. A keep-alive of `0` disables the pings. |
 | UDP segmentation offload | Batches sends into one syscall. Turn it off if large sends vanish; some NICs and middleboxes mangle segmented packets. |
-| Path MTU discovery | Off by default. |
-| qlog directory | Write QUIC connection traces here for diagnosing stalls. The files get large. |
+| Path MTU discovery | Leave it automatic for the library's choice, or explicitly enable or disable it. |
+| qlog directory | On builds with qlog support, write QUIC connection traces here for diagnosing stalls. The files get large. |
 | WebSocket fallback (+ delay) | Race a WebSocket connection against QUIC so a network that blocks UDP still goes live. Turn it off to measure the QUIC path alone. |

--- a/doc/bin/obs.md
+++ b/doc/bin/obs.md
@@ -93,3 +93,41 @@ The archives are **unsigned**, so macOS Gatekeeper and Windows SmartScreen will 
 2. Select "MoQ Source"
 3. Enter the relay URL and broadcast path
 4. The stream will appear in your scene
+
+### Advanced settings
+
+The defaults are what you want for streaming to a normal relay. The advanced settings
+exist for testing against a specific protocol draft, reaching a relay with a self-signed
+certificate, and diagnosing a connection that misbehaves.
+
+They live in two places, backed by the same values:
+
+- **Settings > Stream**, under the collapsible **Advanced** group. Saved with the rest of
+  the service, so they travel with the profile.
+- **The MoQ dock**, via the **Advanced…** button, which opens them in their own window so
+  the dock stays small.
+
+Everything is ignored unless the group is switched on, so leaving it off connects exactly
+the way it did before these settings existed. If a value is rejected (an unknown version,
+an unparseable bind address), the stream refuses to start and the log says which setting
+and why, rather than connecting with your setting quietly dropped.
+
+| Setting | What it's for |
+| --- | --- |
+| Protocol version | Pin the handshake to one draft instead of offering all of them. The menu lists what this build offers; a work-in-progress draft can be typed in. |
+| QUIC backend | Pick quinn, quiche, or noq instead of the compiled-in default. |
+| Bind address | Send from a specific local address, e.g. `192.0.2.7:0` to pin the outgoing interface. |
+| Connect timeout | Bound on one attempt, dial and handshake together. `0` waits forever. |
+| Happy Eyeballs delay | How long before also trying the next address DNS returned. |
+| Skip certificate verification | Development only: accepts any certificate. Prefer a fingerprint. |
+| Certificate fingerprint | Trust one self-signed certificate by its SHA-256 hex fingerprint, the native equivalent of the browser's `serverCertificateHashes`. |
+| Root certificate | Trust a PEM CA instead of the system roots. |
+| Server name override | Validate against this name instead of the URL host, so a relay can be reached by IP. |
+| Reconnect delay / cap / give up after | Retry pacing after a drop. "Give up after" is also how long the broadcast lingers for viewers across the gap; `0` retries forever. |
+| Congestion control | Delay-based (BBR) keeps queues short and the send rate steady enough for an encoder to track. Loss-based (CUBIC) chases throughput. |
+| Max concurrent streams | MoQ opens a stream per group, so a busy publisher wants this high. |
+| Idle timeout / Keep-alive | Connection liveness. A keep-alive of `0` disables the pings. |
+| UDP segmentation offload | Batches sends into one syscall. Turn it off if large sends vanish; some NICs and middleboxes mangle segmented packets. |
+| Path MTU discovery | Off by default. |
+| qlog directory | Write QUIC connection traces here for diagnosing stalls. The files get large. |
+| WebSocket fallback (+ delay) | Race a WebSocket connection against QUIC so a network that blocks UDP still goes live. Turn it off to measure the QUIC path alone. |

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -87,6 +87,62 @@ root `target/` (two levels up from `rs/libmoq/`): `../../target/release/libmoq.a
 (static) and `../../target/release/libmoq.{so,dylib,dll}` (dynamic), with the
 generated header at `../../target/release/moq.h`.
 
+## Client configuration
+
+`moq_session_connect` dials with the defaults. To pin a protocol version, adjust TLS trust, or tune the transport, build a client config and dial with `moq_client_connect` instead:
+
+```c
+int client = moq_client_create();
+
+// Pin the handshake to one draft instead of offering every supported version.
+struct moq_string version = { "moq-lite-05", 11 };
+moq_client_set_versions(client, &version, 1);
+
+// Trust one self-signed relay without accepting every certificate.
+struct moq_string fingerprint = { hex_sha256, strlen(hex_sha256) };
+moq_client_set_tls_fingerprints(client, &fingerprint, 1);
+
+moq_client_set_quic_congestion_control(client, "delay", 5);
+
+int session = moq_client_connect(url, url_len, client, origin, 0, on_status, user_data);
+
+// The config is copied into the session, so the handle can be released (or reused
+// for another dial, or edited in between) right away.
+moq_client_close(client);
+```
+
+A `client` of `0` means the defaults, so `moq_client_connect(url, len, 0, ...)` is exactly `moq_session_connect`.
+
+The setters fall into a few groups:
+
+- **Protocol**: `moq_client_set_versions` restricts what's offered during the handshake. Names are spelled the way the CLI spells them (`moq-lite-05`, `moq-transport-19`); `moq_versions` lists what this build offers so a menu can't drift from what the setter accepts. An empty list restores the default of offering everything.
+- **TLS**: `moq_client_set_tls_fingerprints` (pin a SHA-256 hex fingerprint, the native equivalent of the browser's `serverCertificateHashes`), `moq_client_set_tls_roots`, `moq_client_set_tls_system_roots`, `moq_client_set_tls_host_name` (SNI override), `moq_client_set_tls_cert` / `moq_client_set_tls_key` (mTLS), and `moq_client_set_tls_disable_verify` (development only: it accepts any certificate, so prefer a fingerprint).
+- **Transport**: `moq_client_set_backend`, `moq_client_set_bind`, `moq_client_set_connect_timeout`, `moq_client_set_failover_delay`, and `moq_client_set_websocket_enabled` / `moq_client_set_websocket_delay` for the fallback that gets you through a UDP-blocked network. The QUIC backends are compile-time optional, so use `moq_backends` for the names this build actually accepts rather than assuming all three.
+- **Tuning**: `moq_client_set_backoff_initial` / `_multiplier` / `_max` / `_timeout` for reconnect pacing, and `moq_client_set_quic_max_streams` / `_idle_timeout` / `_keep_alive` / `_gso` / `_mtu_discovery` / `_congestion_control` / `_qlog` for the transport. The QUIC ones are ignored by the WebSocket fallback.
+
+Every knob is its own setter, and a knob you never set stays at its default. That is deliberate rather than incidental: the C ABI is stable, so a new knob has to be a new function. Bundling several into one `struct` you pass by pointer would freeze their layout, and adding a field later would break every caller compiled against the old size. The optional strings (`congestion_control`, `qlog`, the TLS paths) are set-or-clear, where NULL or empty puts the knob back to automatic, so a setting can be undone without rebuilding the handle.
+
+Every setter has a matching `moq_client_get_*`, and a knob you never set reads back as its default:
+
+```c
+uint32_t client = moq_client_create();
+uint64_t idle;
+moq_client_get_quic_idle_timeout(client, &idle);   // 30000
+```
+
+So a fresh handle *is* the defaults, and a settings UI can read them instead of hardcoding numbers that go stale when a default is retuned. Same reason `moq_versions` exists for the version menu. The getters take an out-parameter and return zero or a negative code, since every value is a valid one and the return channel is for errors.
+
+The knobs whose default depends on the backend (GSO, path MTU discovery, congestion control, the TLS root store) have no getter: there is no single value to report, and they stay on the backend's choice until you set them.
+
+Two capabilities are compile-time optional, so ask before offering them:
+
+- `moq_backends` lists the QUIC backends this build has, the same way `moq_versions` lists the drafts. A name it doesn't report is rejected by `moq_client_set_backend`.
+- `moq_qlog_supported` reports whether traces can be captured. `moq_client_set_quic_qlog` stores a directory either way, but dialing fails without the support.
+
+Combinations that would quietly drop a setting are rejected at dial rather than resolved by precedence. `moq_client_set_tls_disable_verify` accepts every certificate, so pairing it with a fingerprint or a root fails instead of ignoring the trust material, and the reconnect knobs must leave a non-zero delay or retrying would spin.
+
+Setters validate what they can parse, so a typo'd version or an unparseable bind address fails at the setter with the reason in `moq_error()`, rather than being silently dropped at connect time. A value that parses but the transport can't express (an idle timeout past QUIC's millisecond varint, say) is caught when the connection is dialed instead. Either way `moq_error()` names it.
+
 ## Callback lifetime
 
 Any function that registers a callback (`moq_session_connect`, `moq_origin_announced`, `moq_origin_consume_announced`, `moq_origin_request`, `moq_consume_catalog`, `moq_consume_video`, `moq_consume_audio`, `moq_consume_track`, `moq_consume_datagrams`, `moq_consume_video_raw`, `moq_consume_audio_raw`, `moq_consume_json_snapshot`, `moq_consume_json_stream`) takes a `void *user_data` pointer that libmoq passes back to every callback invocation. The status code carries the lifecycle:

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -93,22 +93,40 @@ generated header at `../../target/release/moq.h`.
 
 ```c
 int client = moq_client_create();
+if (client < 0)
+    return client;
+
+int result;
 
 // Pin the handshake to one draft instead of offering every supported version.
 struct moq_string version = { "moq-lite-05", 11 };
-moq_client_set_versions(client, &version, 1);
+result = moq_client_set_versions(client, &version, 1);
+if (result < 0) {
+    moq_client_close(client);
+    return result;
+}
 
 // Trust one self-signed relay without accepting every certificate.
 struct moq_string fingerprint = { hex_sha256, strlen(hex_sha256) };
-moq_client_set_tls_fingerprints(client, &fingerprint, 1);
+result = moq_client_set_tls_fingerprints(client, &fingerprint, 1);
+if (result < 0) {
+    moq_client_close(client);
+    return result;
+}
 
-moq_client_set_quic_congestion_control(client, "delay", 5);
+result = moq_client_set_quic_congestion_control(client, "delay", 5);
+if (result < 0) {
+    moq_client_close(client);
+    return result;
+}
 
 int session = moq_client_connect(url, url_len, client, origin, 0, on_status, user_data);
 
 // The config is copied into the session, so the handle can be released (or reused
 // for another dial, or edited in between) right away.
 moq_client_close(client);
+if (session < 0)
+    return session;
 ```
 
 A `client` of `0` means the defaults, so `moq_client_connect(url, len, 0, ...)` is exactly `moq_session_connect`.
@@ -122,7 +140,7 @@ The setters fall into a few groups:
 
 Every knob is its own setter, and a knob you never set stays at its default. That is deliberate rather than incidental: the C ABI is stable, so a new knob has to be a new function. Bundling several into one `struct` you pass by pointer would freeze their layout, and adding a field later would break every caller compiled against the old size. The optional strings (`congestion_control`, `qlog`, the TLS paths) are set-or-clear, where NULL or empty puts the knob back to automatic, so a setting can be undone without rebuilding the handle.
 
-Every setter has a matching `moq_client_get_*`, and a knob you never set reads back as its default:
+Setters for reportable knobs have a matching `moq_client_get_*`, and a knob you never set reads back as its default:
 
 ```c
 uint32_t client = moq_client_create();
@@ -137,7 +155,7 @@ The knobs whose default depends on the backend (GSO, path MTU discovery, congest
 Two capabilities are compile-time optional, so ask before offering them:
 
 - `moq_backends` lists the QUIC backends this build has, the same way `moq_versions` lists the drafts. A name it doesn't report is rejected by `moq_client_set_backend`.
-- `moq_qlog_supported` reports whether traces can be captured. `moq_client_set_quic_qlog` stores a directory either way, but dialing fails without the support.
+- `moq_qlog_supported` reports whether traces can be captured. `moq_client_set_quic_qlog` stores a directory either way, but a non-empty directory is rejected while the client configuration is initialized, before a connection is created.
 
 Combinations that would quietly drop a setting are rejected at dial rather than resolved by precedence. `moq_client_set_tls_disable_verify` accepts every certificate, so pairing it with a fingerprint or a root fails instead of ignoring the trust material, and the reconnect knobs must leave a non-zero delay or retrying would spin.
 

--- a/justfile
+++ b/justfile
@@ -222,8 +222,8 @@ ci BASE="":
     # when the diff has no JS-scoped files.
     bun install --frozen-lockfile
     bun remark . --quiet --frail
-    shfmt --diff $(shfmt -f . | grep -v '\.direnv/')
-    shellcheck $(shfmt -f . | grep -v '\.direnv/')
+    shfmt --diff $(just _shell-files)
+    shellcheck $(just _shell-files)
     RUST_LOG=error taplo format --check
     nixfmt --check $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*')
     for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --check --justfile "$f"; done

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -992,7 +992,7 @@ pub unsafe extern "C" fn moq_client_get_connect_timeout(client: u32, out: *mut u
 	ffi::enter(move || {
 		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
 		let client = ffi::parse_id(client)?;
-		*out = millis(State::lock().client.get_mut(client)?.connect_timeout());
+		*out = millis(State::lock().client.get_mut(client)?.resolved_connect_timeout());
 		Ok(())
 	})
 }
@@ -1009,7 +1009,7 @@ pub unsafe extern "C" fn moq_client_get_failover_delay(client: u32, out: *mut u6
 	ffi::enter(move || {
 		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
 		let client = ffi::parse_id(client)?;
-		*out = millis(State::lock().client.get_mut(client)?.effective_failover_delay());
+		*out = millis(State::lock().client.get_mut(client)?.resolved_failover_delay());
 		Ok(())
 	})
 }

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -1,4 +1,4 @@
-use crate::{Error, State, ffi};
+use crate::{Connect, Error, State, ffi};
 
 use std::ffi::c_char;
 use std::ffi::c_void;
@@ -731,6 +731,9 @@ pub unsafe extern "C" fn moq_client_set_tls_fingerprints(
 ) -> i32 {
 	ffi::enter(move || {
 		let fingerprints = unsafe { ffi::parse_strings(fingerprints, count)? };
+		for fingerprint in &fingerprints {
+			moq_native::tls::parse_fingerprint(fingerprint).map_err(|err| Error::InvalidConfig(err.to_string()))?;
+		}
 		let client = ffi::parse_id(client)?;
 		State::lock().client.get_mut(client)?.tls.fingerprint = fingerprints;
 		Ok(())
@@ -826,7 +829,7 @@ pub extern "C" fn moq_client_set_backoff_multiplier(client: u32, multiplier: u32
 
 /// Set the ceiling on the growing reconnect delay, in milliseconds.
 ///
-/// Defaults to 30s.
+/// Defaults to 5s.
 ///
 /// Returns zero on success, or a negative code if the handle is unknown.
 #[unsafe(no_mangle)]
@@ -840,7 +843,7 @@ pub extern "C" fn moq_client_set_backoff_max(client: u32, delay_ms: u64) -> i32 
 
 /// Set how long to keep retrying before giving up, in milliseconds.
 ///
-/// Zero retries forever. Defaults to 5 minutes. This is also how long published
+/// Zero retries forever. Defaults to 10s. This is also how long published
 /// broadcasts linger across a drop, so a longer timeout papers over a longer relay
 /// outage.
 ///
@@ -1188,23 +1191,54 @@ pub unsafe extern "C" fn moq_client_connect(
 	on_status: Option<extern "C" fn(user_data: *mut c_void, code: i32)>,
 	user_data: *mut c_void,
 ) -> i32 {
-	ffi::enter(move || {
-		let url = ffi::parse_url(url, url_len)?;
-
-		let mut state = State::lock();
-		let config = state.client.config(ffi::parse_id_optional(client)?)?;
-		let publish = ffi::parse_id_optional(origin_publish)?
-			.map(|id| state.origin.get(id))
-			.transpose()?
-			.cloned();
-		let consume = ffi::parse_id_optional(origin_consume)?
-			.map(|id| state.origin.get(id))
-			.transpose()?
-			.cloned();
-
-		let on_status = unsafe { ffi::OnStatus::new(user_data, on_status) };
-		state.session.connect(config, url, publish, consume, on_status)
+	ffi::enter(move || unsafe {
+		connect_session(
+			url,
+			url_len,
+			client,
+			origin_publish,
+			origin_consume,
+			on_status,
+			user_data,
+		)
 	})
+}
+
+/// Resolve handles under the global lock, prepare the client without it, then insert
+/// the ready session under a short second lock.
+unsafe fn connect_session(
+	url: *const c_char,
+	url_len: usize,
+	client: u32,
+	origin_publish: u32,
+	origin_consume: u32,
+	on_status: Option<extern "C" fn(user_data: *mut c_void, code: i32)>,
+	user_data: *mut c_void,
+) -> Result<crate::Id, Error> {
+	let url = ffi::parse_url(url, url_len)?;
+	let client = ffi::parse_id_optional(client)?;
+	let origin_publish = ffi::parse_id_optional(origin_publish)?;
+	let origin_consume = ffi::parse_id_optional(origin_consume)?;
+
+	let (config, publish, consume) = {
+		let state = State::lock();
+		let config = state.client.config(client)?;
+		let publish = origin_publish.map(|id| state.origin.get(id)).transpose()?.cloned();
+		let consume = origin_consume.map(|id| state.origin.get(id)).transpose()?.cloned();
+		(config, publish, consume)
+	};
+
+	let callback = unsafe { ffi::OnStatus::new(user_data, on_status) };
+	let request = Connect {
+		config,
+		url,
+		publish,
+		consume,
+		callback,
+	}
+	.prepare()?;
+
+	State::lock().session.connect(request)
 }
 
 /// Start establishing a connection to a MoQ server.
@@ -1252,22 +1286,8 @@ pub unsafe extern "C" fn moq_session_connect(
 	on_status: Option<extern "C" fn(user_data: *mut c_void, code: i32)>,
 	user_data: *mut c_void,
 ) -> i32 {
-	ffi::enter(move || {
-		let url = ffi::parse_url(url, url_len)?;
-
-		let mut state = State::lock();
-		let publish = ffi::parse_id_optional(origin_publish)?
-			.map(|id| state.origin.get(id))
-			.transpose()?
-			.cloned();
-		let consume = ffi::parse_id_optional(origin_consume)?
-			.map(|id| state.origin.get(id))
-			.transpose()?
-			.cloned();
-
-		let on_status = unsafe { ffi::OnStatus::new(user_data, on_status) };
-		let config = moq_native::ClientConfig::default();
-		state.session.connect(config, url, publish, consume, on_status)
+	ffi::enter(move || unsafe {
+		connect_session(url, url_len, 0, origin_publish, origin_consume, on_status, user_data)
 	})
 }
 

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -240,11 +240,14 @@ impl From<&moq_subscription> for moq_net::track::Subscription {
 
 /// A borrowed UTF-8 string slice, NOT NULL terminated.
 ///
-/// Used to hand a C caller a JSON document that lives inside libmoq's storage.
-/// The pointer borrows that storage and is only valid until the owning resource
-/// is freed (see the function that fills it for the exact lifetime).
+/// Used in both directions. As an output (e.g. a JSON document libmoq hands back) the
+/// pointer borrows libmoq's own storage and is only valid until the owning resource is
+/// freed; see the function that fills it for the exact lifetime. As an input (e.g. a
+/// `moq_client_set_*` list) the pointer borrows the caller's storage and is only read
+/// during the call.
 #[repr(C)]
 #[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub struct moq_string {
 	/// Pointer to `len` bytes of UTF-8, NOT NULL terminated.
 	pub data: *const c_char,
@@ -406,6 +409,804 @@ pub extern "C" fn moq_error() -> *const c_char {
 	ffi::last_error_ptr()
 }
 
+/// The protocol version names this build offers by default, spelled the way
+/// [moq_client_set_versions] expects. Built once; the slices are valid for the life of
+/// the process.
+static VERSION_NAMES: std::sync::LazyLock<Vec<String>> =
+	std::sync::LazyLock::new(|| moq_net::Versions::all().iter().map(|v| v.to_string()).collect());
+
+/// List the protocol versions offered during the handshake by default.
+///
+/// Writes up to `count` names into `dst` and returns the total number available, which
+/// may be larger than `count`. Pass a NULL `dst` with a zero `count` to size the array
+/// first. Each name borrows a static string valid for the life of the process, so a
+/// caller building a menu can hold them indefinitely.
+///
+/// Work-in-progress versions are omitted, since they are not advertised unless pinned;
+/// [moq_client_set_versions] still accepts them by name.
+///
+/// Returns the total count on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that `dst` is either NULL with a zero `count`, or a valid
+///   pointer to `count` writable [moq_string] values.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_versions(dst: *mut moq_string, count: usize) -> i32 {
+	ffi::enter(move || {
+		if !dst.is_null() {
+			let dst = unsafe { std::slice::from_raw_parts_mut(dst, count) };
+			for (slot, name) in dst.iter_mut().zip(VERSION_NAMES.iter()) {
+				slot.data = name.as_ptr().cast::<c_char>();
+				slot.len = name.len();
+			}
+		} else if count != 0 {
+			return Err(Error::InvalidPointer);
+		}
+
+		Ok(VERSION_NAMES.len())
+	})
+}
+
+/// The QUIC backend names this build offers, spelled the way [moq_client_set_backend]
+/// expects. Built once; the slices are valid for the life of the process.
+static BACKEND_NAMES: std::sync::LazyLock<Vec<&'static str>> =
+	std::sync::LazyLock::new(|| moq_native::QuicBackend::compiled().iter().map(|b| b.as_str()).collect());
+
+/// List the QUIC backends this build was compiled with.
+///
+/// Writes up to `count` names into `dst` and returns the total number available, which
+/// may be larger than `count`. Pass a NULL `dst` with a zero `count` to size the array
+/// first. Each name borrows a static string valid for the life of the process.
+///
+/// The backends are compile-time optional, so a caller building a menu must read this
+/// rather than listing names: an option this build lacks is rejected by
+/// [moq_client_set_backend], which would leave a menu entry that can only fail.
+///
+/// Returns the total count on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that `dst` is either NULL with a zero `count`, or a valid
+///   pointer to `count` writable [moq_string] values.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_backends(dst: *mut moq_string, count: usize) -> i32 {
+	ffi::enter(move || {
+		if !dst.is_null() {
+			let dst = unsafe { std::slice::from_raw_parts_mut(dst, count) };
+			for (slot, name) in dst.iter_mut().zip(BACKEND_NAMES.iter()) {
+				slot.data = name.as_ptr().cast::<c_char>();
+				slot.len = name.len();
+			}
+		} else if count != 0 {
+			return Err(Error::InvalidPointer);
+		}
+
+		Ok(BACKEND_NAMES.len())
+	})
+}
+
+/// Whether this build can capture qlog traces.
+///
+/// Capture is compile-time optional. [moq_client_set_quic_qlog] accepts a directory
+/// either way, but dialing fails when the support is absent, so a caller offering the
+/// knob should hide it rather than surface an option that cannot work.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_qlog_supported() -> bool {
+	moq_native::qlog_supported()
+}
+
+/// A duration as the milliseconds the setters take, saturating rather than wrapping.
+fn millis(duration: std::time::Duration) -> u64 {
+	duration.as_millis().min(u64::MAX as u128) as u64
+}
+
+/// Create a client configuration for [moq_client_connect].
+///
+/// A fresh handle carries the same defaults [moq_session_connect] dials with; the
+/// `moq_client_set_*` functions override one knob at a time. Connecting clones the
+/// config, so one handle can open any number of sessions and stays editable in between.
+///
+/// Returns a non-zero handle on success, or a negative code on failure. Release it with
+/// [moq_client_close]; that does not disturb sessions already dialed from it.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_create() -> i32 {
+	ffi::enter(move || State::lock().client.create())
+}
+
+/// Release a client configuration created by [moq_client_create].
+///
+/// Sessions already dialed from it keep running: each connect took its own copy.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_close(client: u32) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.close(client)
+	})
+}
+
+/// Restrict the protocol versions offered during the handshake.
+///
+/// By default every supported version is offered and the server picks one. Pass a
+/// subset to pin the negotiation, in the same spelling the CLI uses: `moq-lite-01`
+/// through `moq-lite-06-wip`, or `moq-transport-14` through `moq-transport-19`. An
+/// empty list restores the default.
+///
+/// Returns zero on success, or a negative code if the handle is unknown or a version
+/// string is unrecognized.
+///
+/// # Safety
+/// - The caller must ensure that `versions` is either NULL with a zero `count`, or a
+///   valid pointer to `count` [moq_string] values, each valid for its own length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_versions(client: u32, versions: *const moq_string, count: usize) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		let versions = unsafe { ffi::parse_strings(versions, count)? }
+			.into_iter()
+			.map(|version| moq_net::Version::from_str(&version).map_err(Error::InvalidConfig))
+			.collect::<Result<Vec<_>, Error>>()?;
+
+		State::lock().client.get_mut(client)?.version = versions;
+		Ok(())
+	})
+}
+
+/// Choose the QUIC backend: `"quinn"`, `"quiche"`, or `"noq"`.
+///
+/// Defaults to whichever is compiled in, preferring quinn. A NULL or empty value
+/// restores that auto-detection.
+///
+/// Returns zero on success, or a negative code if the handle is unknown or the backend
+/// is unrecognized (which includes a backend this build was compiled without).
+///
+/// # Safety
+/// - The caller must ensure that `backend` is NULL or a valid pointer to `backend_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_backend(client: u32, backend: *const c_char, backend_len: usize) -> i32 {
+	ffi::enter(move || {
+		let backend = match unsafe { ffi::parse_str_optional(backend, backend_len)? } {
+			Some(backend) => Some(moq_native::QuicBackend::from_str(backend).map_err(Error::InvalidConfig)?),
+			None => None,
+		};
+
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.backend = backend;
+		Ok(())
+	})
+}
+
+/// Set the local UDP socket address to bind, e.g. `"[::]:0"` (the default) or
+/// `"192.0.2.7:0"` to pin the outgoing interface.
+///
+/// Returns zero on success, or a negative code if the handle is unknown or the address
+/// does not parse.
+///
+/// # Safety
+/// - The caller must ensure that `addr` is a valid pointer to `addr_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_bind(client: u32, addr: *const c_char, addr_len: usize) -> i32 {
+	ffi::enter(move || {
+		let addr = unsafe { ffi::parse_str(addr, addr_len)? };
+		let addr: std::net::SocketAddr = addr
+			.parse()
+			.map_err(|err| Error::InvalidConfig(format!("invalid bind address {addr:?}: {err}")))?;
+
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.bind = addr;
+		Ok(())
+	})
+}
+
+/// Bound one connection attempt, covering both the dial and the MoQ handshake, in
+/// milliseconds.
+///
+/// Defaults to 30s; zero waits forever. The reconnect loop only re-arms its backoff
+/// between attempts, so this is what stops a peer that accepts the connection and then
+/// never speaks from wedging the loop.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_connect_timeout(client: u32, timeout_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.timeout = Some(std::time::Duration::from_millis(timeout_ms));
+		Ok(())
+	})
+}
+
+/// Delay before also dialing the next resolved address (Happy Eyeballs), in milliseconds.
+///
+/// When DNS returns several addresses, attempts alternate between IPv6 and IPv4, each
+/// starting this long after the previous one, and the first to complete wins. Defaults
+/// to 250ms; zero dials every address at once.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_failover_delay(client: u32, delay_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.failover_delay = Some(std::time::Duration::from_millis(delay_ms));
+		Ok(())
+	})
+}
+
+/// Delay before racing a WebSocket fallback against the QUIC dial, in milliseconds.
+///
+/// Defaults to 200ms, and drops to zero for a server WebSocket already won against.
+/// This is what gets a publisher through a network that blocks UDP.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_websocket_delay(client: u32, delay_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.websocket.delay = Some(std::time::Duration::from_millis(delay_ms));
+		Ok(())
+	})
+}
+
+/// Enable or disable the WebSocket fallback entirely.
+///
+/// Enabled by default. Disabling it makes a UDP-blocked network fail outright rather
+/// than falling back, which is what you want when measuring the QUIC path.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_websocket_enabled(client: u32, enabled: bool) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.websocket.enabled = enabled;
+		Ok(())
+	})
+}
+
+/// Skip TLS certificate verification.
+///
+/// Development only: it accepts any certificate, so it defeats the point of TLS. Prefer
+/// [moq_client_set_tls_fingerprints] to trust one known self-signed certificate.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_tls_disable_verify(client: u32, disable: bool) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.tls.disable_verify = Some(disable);
+		Ok(())
+	})
+}
+
+/// Whether to also trust the platform's native root certificates.
+///
+/// By default the system roots are trusted only when no custom roots are configured.
+/// Set this to true to trust them alongside the roots from [moq_client_set_tls_roots],
+/// or false to trust only those.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_tls_system_roots(client: u32, enabled: bool) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.tls.system_roots = Some(enabled);
+		Ok(())
+	})
+}
+
+/// Trust these PEM root certificate files.
+///
+/// An empty list restores the default of using the platform's native root store.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+///
+/// # Safety
+/// - The caller must ensure that `paths` is either NULL with a zero `count`, or a valid
+///   pointer to `count` [moq_string] values, each valid for its own length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_tls_roots(client: u32, paths: *const moq_string, count: usize) -> i32 {
+	ffi::enter(move || {
+		let paths = unsafe { ffi::parse_strings(paths, count)? };
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.tls.root = paths.into_iter().map(Into::into).collect();
+		Ok(())
+	})
+}
+
+/// Pin the peer to a certificate with one of these SHA-256 fingerprints, hex encoded.
+///
+/// The native equivalent of the browser's WebTransport `serverCertificateHashes`, taking
+/// the same values a relay reports for its self-signed certificate. Use it instead of
+/// [moq_client_set_tls_disable_verify] to trust one known certificate without accepting
+/// every certificate. An empty list clears any pinned fingerprints.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+///
+/// # Safety
+/// - The caller must ensure that `fingerprints` is either NULL with a zero `count`, or a
+///   valid pointer to `count` [moq_string] values, each valid for its own length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_tls_fingerprints(
+	client: u32,
+	fingerprints: *const moq_string,
+	count: usize,
+) -> i32 {
+	ffi::enter(move || {
+		let fingerprints = unsafe { ffi::parse_strings(fingerprints, count)? };
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.tls.fingerprint = fingerprints;
+		Ok(())
+	})
+}
+
+/// Override the TLS server name (SNI) sent during the handshake.
+///
+/// Defaults to the host in the dial URL. Set this to reach a relay by IP while still
+/// validating its certificate against the name it was issued for. A NULL or empty value
+/// restores the default.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+///
+/// # Safety
+/// - The caller must ensure that `name` is NULL or a valid pointer to `name_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_tls_host_name(client: u32, name: *const c_char, name_len: usize) -> i32 {
+	ffi::enter(move || {
+		let name = unsafe { ffi::parse_str_optional(name, name_len)? }.map(str::to_string);
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.tls.host_name = name;
+		Ok(())
+	})
+}
+
+/// Present this PEM certificate chain when the relay requires mTLS.
+///
+/// Only certificates are read from the file; any private keys in it are ignored. Must be
+/// paired with [moq_client_set_tls_key] or the connect fails. A NULL or empty path clears it.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+///
+/// # Safety
+/// - The caller must ensure that `path` is NULL or a valid pointer to `path_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_tls_cert(client: u32, path: *const c_char, path_len: usize) -> i32 {
+	ffi::enter(move || {
+		let path = unsafe { ffi::parse_str_optional(path, path_len)? }.map(Into::into);
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.tls.cert = path;
+		Ok(())
+	})
+}
+
+/// Present this PEM private key when the relay requires mTLS.
+///
+/// Only the private key is read from the file; any certificates in it are ignored. Must
+/// be paired with [moq_client_set_tls_cert] or the connect fails. A NULL or empty path
+/// clears it.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+///
+/// # Safety
+/// - The caller must ensure that `path` is NULL or a valid pointer to `path_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_tls_key(client: u32, path: *const c_char, path_len: usize) -> i32 {
+	ffi::enter(move || {
+		let path = unsafe { ffi::parse_str_optional(path, path_len)? }.map(Into::into);
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.tls.key = path;
+		Ok(())
+	})
+}
+
+/// Set the delay before the first reconnect attempt, in milliseconds.
+///
+/// The delay grows from here by the multiplier after each failure. Defaults to 1s.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_backoff_initial(client: u32, delay_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.backoff.initial = std::time::Duration::from_millis(delay_ms);
+		Ok(())
+	})
+}
+
+/// Set the multiplier applied to the reconnect delay after each failed attempt.
+///
+/// Defaults to 2. A multiplier of 1 keeps the delay flat.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_backoff_multiplier(client: u32, multiplier: u32) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.backoff.multiplier = multiplier;
+		Ok(())
+	})
+}
+
+/// Set the ceiling on the growing reconnect delay, in milliseconds.
+///
+/// Defaults to 30s.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_backoff_max(client: u32, delay_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.backoff.max = std::time::Duration::from_millis(delay_ms);
+		Ok(())
+	})
+}
+
+/// Set how long to keep retrying before giving up, in milliseconds.
+///
+/// Zero retries forever. Defaults to 5 minutes. This is also how long published
+/// broadcasts linger across a drop, so a longer timeout papers over a longer relay
+/// outage.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_backoff_timeout(client: u32, timeout_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.backoff.timeout = std::time::Duration::from_millis(timeout_ms);
+		Ok(())
+	})
+}
+
+/// Set the maximum concurrent QUIC streams per connection, bidirectional and
+/// unidirectional alike.
+///
+/// Defaults to 1024. MoQ opens a stream per group, so a busy publisher wants this high.
+/// QUIC only; the WebSocket fallback ignores it.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_quic_max_streams(client: u32, max_streams: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.quic.max_streams = Some(max_streams);
+		Ok(())
+	})
+}
+
+/// Set the idle timeout before an inactive connection is dropped, in milliseconds.
+///
+/// Defaults to 30s. QUIC carries this as a millisecond varint, so a value of 2^62 or
+/// more is rejected when the connection is dialed. QUIC only.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_quic_idle_timeout(client: u32, timeout_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.quic.idle_timeout = Some(std::time::Duration::from_millis(timeout_ms));
+		Ok(())
+	})
+}
+
+/// Set the keep-alive ping interval, in milliseconds.
+///
+/// Defaults to 5s; zero disables the pings. QUIC only.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_quic_keep_alive(client: u32, interval_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.quic.keep_alive = Some(std::time::Duration::from_millis(interval_ms));
+		Ok(())
+	})
+}
+
+/// Enable or disable UDP generic segmentation offload.
+///
+/// GSO batches sends into one syscall for throughput, and defaults to on. Some NICs and
+/// middleboxes mangle segmented packets, so turn it off if large sends vanish. QUIC only.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_quic_gso(client: u32, enabled: bool) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.quic.gso = Some(enabled);
+		Ok(())
+	})
+}
+
+/// Enable or disable path MTU discovery.
+///
+/// Defaults to off. QUIC only.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_client_set_quic_mtu_discovery(client: u32, enabled: bool) -> i32 {
+	ffi::enter(move || {
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.quic.mtu_discovery = Some(enabled);
+		Ok(())
+	})
+}
+
+/// Set the congestion control family.
+///
+/// Either `"loss"` (CUBIC, throughput-oriented) or `"delay"` (BBR, which keeps queues
+/// short and the send rate steady enough for an encoder to track). A NULL or empty value
+/// puts it back to the backend's own default. QUIC only.
+///
+/// Returns zero on success, or a negative code if the handle is unknown or the family is
+/// unrecognized.
+///
+/// # Safety
+/// - The caller must ensure that `family` is either NULL or valid for `family_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_quic_congestion_control(
+	client: u32,
+	family: *const c_char,
+	family_len: usize,
+) -> i32 {
+	ffi::enter(move || {
+		// Parse before taking the lock, so a bad value leaves the config untouched.
+		let family = match unsafe { ffi::parse_str_optional(family, family_len)? } {
+			Some(value) => Some(moq_native::quic::CongestionControl::from_str(value).map_err(Error::InvalidConfig)?),
+			None => None,
+		};
+
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.quic.congestion_control = family;
+		Ok(())
+	})
+}
+
+/// Set the directory to write qlog traces into.
+///
+/// A NULL or empty value disables them. Dialing errors if this build has no qlog
+/// support. QUIC only.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+///
+/// # Safety
+/// - The caller must ensure that `dir` is either NULL or valid for `dir_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_set_quic_qlog(client: u32, dir: *const c_char, dir_len: usize) -> i32 {
+	ffi::enter(move || {
+		let dir = unsafe { ffi::parse_str_optional(dir, dir_len)? }.map(Into::into);
+		let client = ffi::parse_id(client)?;
+		State::lock().client.get_mut(client)?.quic.qlog = dir;
+		Ok(())
+	})
+}
+
+/// Read the connect timeout, in milliseconds. See [moq_client_set_connect_timeout].
+///
+/// A knob never set reads back as its default, so a fresh [moq_client_create] handle
+/// reports the defaults a dial would use. That is what a settings UI should show,
+/// rather than repeating numbers that go stale when a default is retuned.
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_connect_timeout(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = millis(State::lock().client.get_mut(client)?.connect_timeout());
+		Ok(())
+	})
+}
+
+/// Read the Happy Eyeballs stagger, in milliseconds. See [moq_client_set_failover_delay]
+/// and [moq_client_get_connect_timeout] for what an unset knob reports.
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_failover_delay(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = millis(State::lock().client.get_mut(client)?.effective_failover_delay());
+		Ok(())
+	})
+}
+
+/// Read the first reconnect delay, in milliseconds. See [moq_client_set_backoff_initial].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_backoff_initial(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = millis(State::lock().client.get_mut(client)?.backoff.initial);
+		Ok(())
+	})
+}
+
+/// Read the reconnect delay multiplier. See [moq_client_set_backoff_multiplier].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint32_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_backoff_multiplier(client: u32, out: *mut u32) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = State::lock().client.get_mut(client)?.backoff.multiplier;
+		Ok(())
+	})
+}
+
+/// Read the reconnect delay ceiling, in milliseconds. See [moq_client_set_backoff_max].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_backoff_max(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = millis(State::lock().client.get_mut(client)?.backoff.max);
+		Ok(())
+	})
+}
+
+/// Read how long reconnecting keeps trying, in milliseconds. Zero means forever. See
+/// [moq_client_set_backoff_timeout].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_backoff_timeout(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = millis(State::lock().client.get_mut(client)?.backoff.timeout);
+		Ok(())
+	})
+}
+
+/// Read the maximum concurrent QUIC streams. See [moq_client_set_quic_max_streams].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_quic_max_streams(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = State::lock().client.get_mut(client)?.quic.resolve().max_streams;
+		Ok(())
+	})
+}
+
+/// Read the QUIC idle timeout, in milliseconds. See [moq_client_set_quic_idle_timeout].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_quic_idle_timeout(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = millis(State::lock().client.get_mut(client)?.quic.resolve().idle_timeout);
+		Ok(())
+	})
+}
+
+/// Read the QUIC keep-alive interval, in milliseconds. Zero means the pings are
+/// disabled. See [moq_client_set_quic_keep_alive].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_quic_keep_alive(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		let keep_alive = State::lock().client.get_mut(client)?.quic.resolve().keep_alive;
+		*out = keep_alive.map(millis).unwrap_or(0);
+		Ok(())
+	})
+}
+
+/// Read whether the WebSocket fallback races the QUIC attempt. See
+/// [moq_client_set_websocket_enabled].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `bool`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_websocket_enabled(client: u32, out: *mut bool) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		*out = State::lock().client.get_mut(client)?.websocket.enabled;
+		Ok(())
+	})
+}
+
+/// Read the WebSocket fallback delay, in milliseconds. See
+/// [moq_client_set_websocket_delay].
+///
+/// Returns zero on success, or a negative code if the handle is unknown or `out` is NULL.
+///
+/// # Safety
+/// - The caller must ensure that `out` points to a writable `uint64_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_get_websocket_delay(client: u32, out: *mut u64) -> i32 {
+	ffi::enter(move || {
+		let out = unsafe { out.as_mut() }.ok_or(Error::InvalidPointer)?;
+		let client = ffi::parse_id(client)?;
+		let delay = State::lock().client.get_mut(client)?.websocket.delay;
+		*out = delay.map(millis).unwrap_or(0);
+		Ok(())
+	})
+}
+
+/// Start establishing a connection to a MoQ server using a client configuration.
+///
+/// Identical to [moq_session_connect] but dials with the settings on `client` (created
+/// by [moq_client_create]) instead of the defaults. The config is cloned, so the handle
+/// stays reusable and editable afterwards. A `client` of 0 means the defaults, which is
+/// exactly what [moq_session_connect] does.
+///
+/// Returns a non-zero session handle on success, or a negative code on (immediate)
+/// failure. Close it with [moq_session_close]. See [moq_session_connect] for the
+/// `on_status` contract, which is the same here.
+///
+/// # Safety
+/// - The caller must ensure that url is a valid pointer to url_len bytes of data.
+/// - The caller must keep `user_data` valid until the terminal (`<= 0`) `on_status` callback.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_client_connect(
+	url: *const c_char,
+	url_len: usize,
+	client: u32,
+	origin_publish: u32,
+	origin_consume: u32,
+	on_status: Option<extern "C" fn(user_data: *mut c_void, code: i32)>,
+	user_data: *mut c_void,
+) -> i32 {
+	ffi::enter(move || {
+		let url = ffi::parse_url(url, url_len)?;
+
+		let mut state = State::lock();
+		let config = state.client.config(ffi::parse_id_optional(client)?)?;
+		let publish = ffi::parse_id_optional(origin_publish)?
+			.map(|id| state.origin.get(id))
+			.transpose()?
+			.cloned();
+		let consume = ffi::parse_id_optional(origin_consume)?
+			.map(|id| state.origin.get(id))
+			.transpose()?
+			.cloned();
+
+		let on_status = unsafe { ffi::OnStatus::new(user_data, on_status) };
+		state.session.connect(config, url, publish, consume, on_status)
+	})
+}
+
 /// Start establishing a connection to a MoQ server.
 ///
 /// Takes origin handles, which are used for publishing and consuming broadcasts respectively.
@@ -415,6 +1216,9 @@ pub extern "C" fn moq_error() -> *const c_char {
 ///
 /// This may be called multiple times to connect to different servers.
 /// Origins can be shared across sessions, useful for fanout or relaying.
+///
+/// Dials with the default settings. Use [moq_client_connect] to pin a protocol version,
+/// adjust TLS trust, or tune the transport.
 ///
 /// Returns a non-zero handle to the session on success, or a negative code on (immediate) failure.
 /// You should call [moq_session_close], even on error, to free up resources.
@@ -462,7 +1266,8 @@ pub unsafe extern "C" fn moq_session_connect(
 			.cloned();
 
 		let on_status = unsafe { ffi::OnStatus::new(user_data, on_status) };
-		state.session.connect(url, publish, consume, on_status)
+		let config = moq_native::ClientConfig::default();
+		state.session.connect(config, url, publish, consume, on_status)
 	})
 }
 

--- a/rs/libmoq/src/client.rs
+++ b/rs/libmoq/src/client.rs
@@ -1,0 +1,36 @@
+use crate::{Error, Id, NonZeroSlab};
+
+/// Client configurations built up by the `moq_client_*` setters.
+///
+/// A handle is a plain [`moq_native::ClientConfig`] the caller mutates one knob at a
+/// time, then dials with. Dialing clones it, so one handle can open any number of
+/// sessions and stays editable in between.
+#[derive(Default)]
+pub struct Client {
+	configs: NonZeroSlab<moq_native::ClientConfig>,
+}
+
+impl Client {
+	pub fn create(&mut self) -> Result<Id, Error> {
+		self.configs.insert(moq_native::ClientConfig::default())
+	}
+
+	pub fn close(&mut self, id: Id) -> Result<(), Error> {
+		self.configs.remove(id).ok_or(Error::ClientNotFound)?;
+		Ok(())
+	}
+
+	/// The config a setter should mutate.
+	pub fn get_mut(&mut self, id: Id) -> Result<&mut moq_native::ClientConfig, Error> {
+		self.configs.get_mut(id).ok_or(Error::ClientNotFound)
+	}
+
+	/// The config to dial with. A missing handle means "no config given", which is the
+	/// defaults, so [`crate::moq_session_connect`] is just this with `None`.
+	pub fn config(&self, id: Option<Id>) -> Result<moq_native::ClientConfig, Error> {
+		match id {
+			Some(id) => self.configs.get(id).cloned().ok_or(Error::ClientNotFound),
+			None => Ok(moq_native::ClientConfig::default()),
+		}
+	}
+}

--- a/rs/libmoq/src/error.rs
+++ b/rs/libmoq/src/error.rs
@@ -159,7 +159,7 @@ pub enum Error {
 	#[error("client not found")]
 	ClientNotFound,
 
-	/// A client configuration value could not be parsed.
+	/// A client configuration value could not be parsed or initialized.
 	#[error("invalid config: {0}")]
 	InvalidConfig(String),
 }

--- a/rs/libmoq/src/error.rs
+++ b/rs/libmoq/src/error.rs
@@ -154,6 +154,14 @@ pub enum Error {
 	/// Error from the moq-json snapshot/stream layer.
 	#[error("json track error: {0}")]
 	JsonTrack(Arc<moq_json::Error>),
+
+	/// Client configuration handle not found.
+	#[error("client not found")]
+	ClientNotFound,
+
+	/// A client configuration value could not be parsed.
+	#[error("invalid config: {0}")]
+	InvalidConfig(String),
 }
 
 impl From<moq_json::Error> for Error {
@@ -231,6 +239,8 @@ impl ffi::ReturnCode for Error {
 			Error::Video(_) => -36,
 			Error::Json(_) => -37,
 			Error::JsonTrack(_) => -38,
+			Error::ClientNotFound => -39,
+			Error::InvalidConfig(_) => -40,
 		}
 	}
 }

--- a/rs/libmoq/src/ffi.rs
+++ b/rs/libmoq/src/ffi.rs
@@ -232,6 +232,45 @@ pub unsafe fn parse_str<'a>(cstr: *const c_char, cstr_len: usize) -> Result<&'a 
 	Ok(string)
 }
 
+/// Parse an optional C string, where a NULL or empty value means "unset".
+///
+/// Config setters use this so one function both sets and clears a knob, rather than
+/// needing a paired `moq_client_clear_*` for every optional field.
+///
+/// # Safety
+/// The caller must ensure that cstr is valid for 'a.
+pub unsafe fn parse_str_optional<'a>(cstr: *const c_char, cstr_len: usize) -> Result<Option<&'a str>, Error> {
+	if cstr.is_null() {
+		return Ok(None);
+	}
+
+	let string = unsafe { parse_str(cstr, cstr_len)? };
+	Ok((!string.is_empty()).then_some(string))
+}
+
+/// Parse a C array of [`crate::moq_string`] into owned strings.
+///
+/// A NULL array is only valid when `count` is zero, which yields an empty list.
+///
+/// # Safety
+/// The caller must ensure that items is valid for count elements, and that each
+/// element points to its own length in bytes.
+pub unsafe fn parse_strings(items: *const crate::moq_string, count: usize) -> Result<Vec<String>, Error> {
+	if items.is_null() {
+		if count == 0 {
+			return Ok(Vec::new());
+		}
+
+		return Err(Error::InvalidPointer);
+	}
+
+	let items = unsafe { std::slice::from_raw_parts(items, count) };
+	items
+		.iter()
+		.map(|item| Ok(unsafe { parse_str(item.data, item.len)? }.to_string()))
+		.collect()
+}
+
 /// Parse a raw pointer and size into a byte slice.
 ///
 /// Returns an empty slice if both pointer and size are zero.

--- a/rs/libmoq/src/lib.rs
+++ b/rs/libmoq/src/lib.rs
@@ -18,6 +18,7 @@
 
 mod api;
 mod audio;
+mod client;
 mod consume;
 mod error;
 mod ffi;
@@ -34,6 +35,7 @@ pub use error::*;
 pub use id::*;
 pub use video::*;
 
+pub(crate) use client::*;
 pub(crate) use consume::*;
 pub(crate) use origin::*;
 pub(crate) use publish::*;

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -27,12 +27,13 @@ pub struct Session {
 impl Session {
 	pub fn connect(
 		&mut self,
+		config: moq_native::ClientConfig,
 		url: Url,
 		publish: Option<moq_net::origin::Producer>,
 		consume: Option<moq_net::origin::Producer>,
 		callback: ffi::OnStatus,
 	) -> Result<Id, Error> {
-		let mut client = moq_native::ClientConfig::default().init()?;
+		let mut client = config.init()?;
 		if let Some(publish) = &publish {
 			client = client.with_publisher(publish);
 		}

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -18,6 +18,48 @@ struct TaskEntry {
 	stats: moq_native::ConnectionStatsReader,
 }
 
+/// Everything needed to prepare a session without holding the global state lock.
+pub(crate) struct Connect {
+	pub config: moq_native::ClientConfig,
+	pub url: Url,
+	pub publish: Option<moq_net::origin::Producer>,
+	pub consume: Option<moq_net::origin::Producer>,
+	pub callback: ffi::OnStatus,
+}
+
+impl Connect {
+	/// Resolve files and backend configuration before the session is inserted.
+	pub fn prepare(self) -> Result<PreparedConnect, Error> {
+		let mut client = self
+			.config
+			.init()
+			.map_err(|err| Error::InvalidConfig(err.to_string()))?;
+		if let Some(publish) = &self.publish {
+			client = client.with_publisher(publish);
+		}
+		if let Some(consume) = &self.consume {
+			client = client.with_subscriber(consume.clone());
+		}
+
+		Ok(PreparedConnect {
+			client,
+			url: self.url,
+			publish: self.publish,
+			consume: self.consume,
+			callback: self.callback,
+		})
+	}
+}
+
+/// A validated session request ready for insertion into global state.
+pub(crate) struct PreparedConnect {
+	client: moq_native::Client,
+	url: Url,
+	publish: Option<moq_net::origin::Producer>,
+	consume: Option<moq_net::origin::Producer>,
+	callback: ffi::OnStatus,
+}
+
 #[derive(Default)]
 pub struct Session {
 	/// Session tasks. Close signals shutdown; the task delivers a final callback, then removes itself.
@@ -25,21 +67,14 @@ pub struct Session {
 }
 
 impl Session {
-	pub fn connect(
-		&mut self,
-		config: moq_native::ClientConfig,
-		url: Url,
-		publish: Option<moq_net::origin::Producer>,
-		consume: Option<moq_net::origin::Producer>,
-		callback: ffi::OnStatus,
-	) -> Result<Id, Error> {
-		let mut client = config.init()?;
-		if let Some(publish) = &publish {
-			client = client.with_publisher(publish);
-		}
-		if let Some(consume) = &consume {
-			client = client.with_subscriber(consume.clone());
-		}
+	pub fn connect(&mut self, request: PreparedConnect) -> Result<Id, Error> {
+		let PreparedConnect {
+			client,
+			url,
+			publish,
+			consume,
+			callback,
+		} = request;
 
 		// Build the reconnect loop up front so we can grab a stats reader for it
 		// before moving it into the spawned task.

--- a/rs/libmoq/src/state.rs
+++ b/rs/libmoq/src/state.rs
@@ -1,9 +1,10 @@
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 
-use crate::{Consume, Origin, Publish, Session, audio::Audio, video::Video};
+use crate::{Client, Consume, Origin, Publish, Session, audio::Audio, video::Video};
 
 pub struct State {
 	pub session: Session,
+	pub client: Client,
 	pub origin: Origin,
 	pub publish: Publish,
 	pub consume: Consume,
@@ -15,6 +16,7 @@ impl State {
 	pub fn new() -> Self {
 		Self {
 			session: Session::default(),
+			client: Client::default(),
 			origin: Origin::default(),
 			publish: Publish::default(),
 			consume: Consume::default(),

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -2417,10 +2417,10 @@ fn a_fresh_handle_reads_back_the_defaults() {
 
 	let mut value = 0u64;
 	assert_eq!(unsafe { moq_client_get_connect_timeout(client, &mut value) }, 0);
-	assert_eq!(value, config.connect_timeout().as_millis() as u64);
+	assert_eq!(value, config.resolved_connect_timeout().as_millis() as u64);
 
 	assert_eq!(unsafe { moq_client_get_failover_delay(client, &mut value) }, 0);
-	assert_eq!(value, config.effective_failover_delay().as_millis() as u64);
+	assert_eq!(value, config.resolved_failover_delay().as_millis() as u64);
 
 	assert_eq!(unsafe { moq_client_get_backoff_initial(client, &mut value) }, 0);
 	assert_eq!(value, config.backoff.initial.as_millis() as u64);

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::ffi::ReturnCode;
 use std::ffi::{c_char, c_void};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -2236,4 +2237,449 @@ fn session_connect_and_close() {
 	// user_data is safe to free.
 	assert_eq!(moq_session_close(session), 0);
 	assert!(cb.recv() <= 0, "session close delivers a terminal code");
+}
+
+/// A handle that parses but was never handed out: IDs come from a counter starting at 1,
+/// so the top of the range stays free. Distinct from 0, which is not a handle at all.
+const UNUSED_ID: u32 = i32::MAX as u32;
+
+/// Borrow a `&str` as the `moq_string` the list setters take.
+fn moq_str(s: &str) -> moq_string {
+	moq_string {
+		data: s.as_ptr() as *const c_char,
+		len: s.len(),
+	}
+}
+
+#[test]
+fn client_create_and_close() {
+	let client = id(moq_client_create());
+	assert_eq!(moq_client_close(client), 0);
+	assert!(
+		moq_client_close(client) < 0,
+		"closing a released client handle should fail"
+	);
+}
+
+#[test]
+fn client_setters_reject_unknown_handle() {
+	// Every setter funnels through the same lookup, so one is enough to pin the code.
+	// Zero is not a handle at all, so it fails the range check before the lookup;
+	// UNUSED_ID is in range and simply was never handed out.
+	assert_eq!(moq_client_set_tls_disable_verify(0, true), Error::InvalidId.code());
+	assert_eq!(
+		moq_client_set_connect_timeout(UNUSED_ID, 1000),
+		Error::ClientNotFound.code()
+	);
+}
+
+#[test]
+fn client_set_versions_round_trips() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	let versions = [moq_str("moq-lite-05"), moq_str("moq-transport-19")];
+	assert_eq!(
+		unsafe { moq_client_set_versions(client, versions.as_ptr(), versions.len()) },
+		0
+	);
+
+	// An empty list clears the pin, restoring the default of offering everything.
+	assert_eq!(unsafe { moq_client_set_versions(client, std::ptr::null(), 0) }, 0);
+}
+
+#[test]
+fn client_set_versions_rejects_unknown_name() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	let versions = [moq_str("moq-lite-05"), moq_str("moq-carrier-pigeon-01")];
+	let ret = unsafe { moq_client_set_versions(client, versions.as_ptr(), versions.len()) };
+	assert_eq!(ret, Error::InvalidConfig(String::new()).code());
+}
+
+#[test]
+fn client_set_bind_rejects_a_bad_address() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	let good = b"127.0.0.1:0";
+	assert_eq!(
+		unsafe { moq_client_set_bind(client, good.as_ptr() as *const c_char, good.len()) },
+		0
+	);
+
+	let bad = b"not-an-address";
+	let ret = unsafe { moq_client_set_bind(client, bad.as_ptr() as *const c_char, bad.len()) };
+	assert_eq!(ret, Error::InvalidConfig(String::new()).code());
+}
+
+#[test]
+fn client_optional_strings_clear_on_null() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	let name = b"relay.example.com";
+	assert_eq!(
+		unsafe { moq_client_set_tls_host_name(client, name.as_ptr() as *const c_char, name.len()) },
+		0
+	);
+	// NULL and empty both mean "unset", so one setter both sets and clears.
+	assert_eq!(unsafe { moq_client_set_tls_host_name(client, std::ptr::null(), 0) }, 0);
+	assert_eq!(
+		unsafe { moq_client_set_tls_host_name(client, b"".as_ptr() as *const c_char, 0) },
+		0
+	);
+}
+
+#[test]
+fn client_set_quic_rejects_unknown_congestion_control() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	let bogus = "sideways";
+	let ret = unsafe { moq_client_set_quic_congestion_control(client, bogus.as_ptr() as *const c_char, bogus.len()) };
+	assert_eq!(ret, Error::InvalidConfig(String::new()).code());
+
+	let delay = "delay";
+	assert_eq!(
+		unsafe { moq_client_set_quic_congestion_control(client, delay.as_ptr() as *const c_char, delay.len()) },
+		0
+	);
+
+	// NULL puts it back to the backend default, so the knob can return to automatic.
+	assert_eq!(
+		unsafe { moq_client_set_quic_congestion_control(client, std::ptr::null(), 0) },
+		0
+	);
+}
+
+/// Every QUIC and backoff knob is its own setter, so adding one stays additive. Nothing
+/// here is a struct field, which is what keeps a new knob off the ABI.
+#[test]
+fn client_quic_and_backoff_setters_apply() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	assert_eq!(moq_client_set_backoff_initial(client, 500), 0);
+	assert_eq!(moq_client_set_backoff_multiplier(client, 3), 0);
+	assert_eq!(moq_client_set_backoff_max(client, 10_000), 0);
+	assert_eq!(moq_client_set_backoff_timeout(client, 0), 0);
+
+	assert_eq!(moq_client_set_quic_max_streams(client, 4096), 0);
+	assert_eq!(moq_client_set_quic_idle_timeout(client, 15_000), 0);
+	assert_eq!(moq_client_set_quic_keep_alive(client, 0), 0);
+	assert_eq!(moq_client_set_quic_gso(client, false), 0);
+	assert_eq!(moq_client_set_quic_mtu_discovery(client, true), 0);
+
+	let dir = "/tmp/qlog";
+	assert_eq!(
+		unsafe { moq_client_set_quic_qlog(client, dir.as_ptr() as *const c_char, dir.len()) },
+		0
+	);
+	assert_eq!(unsafe { moq_client_set_quic_qlog(client, std::ptr::null(), 0) }, 0);
+
+	// Every one of them rejects an unknown handle rather than silently doing nothing.
+	assert_eq!(
+		moq_client_set_quic_max_streams(UNUSED_ID, 1),
+		Error::ClientNotFound.code()
+	);
+	assert_eq!(
+		moq_client_set_backoff_initial(UNUSED_ID, 1),
+		Error::ClientNotFound.code()
+	);
+}
+
+/// A knob never set reads back as its default, which is what lets a UI show the real
+/// ones. Pinned against the config each comes from rather than a literal copied here, so
+/// retuning a default without following through to C fails right here.
+#[test]
+fn a_fresh_handle_reads_back_the_defaults() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	let config = moq_native::ClientConfig::default();
+	let quic = moq_native::quic::Resolved::default();
+
+	let mut value = 0u64;
+	assert_eq!(unsafe { moq_client_get_connect_timeout(client, &mut value) }, 0);
+	assert_eq!(value, config.connect_timeout().as_millis() as u64);
+
+	assert_eq!(unsafe { moq_client_get_failover_delay(client, &mut value) }, 0);
+	assert_eq!(value, config.effective_failover_delay().as_millis() as u64);
+
+	assert_eq!(unsafe { moq_client_get_backoff_initial(client, &mut value) }, 0);
+	assert_eq!(value, config.backoff.initial.as_millis() as u64);
+
+	assert_eq!(unsafe { moq_client_get_backoff_max(client, &mut value) }, 0);
+	assert_eq!(value, config.backoff.max.as_millis() as u64);
+
+	assert_eq!(unsafe { moq_client_get_backoff_timeout(client, &mut value) }, 0);
+	assert_eq!(value, config.backoff.timeout.as_millis() as u64);
+
+	assert_eq!(unsafe { moq_client_get_quic_max_streams(client, &mut value) }, 0);
+	assert_eq!(value, quic.max_streams);
+
+	assert_eq!(unsafe { moq_client_get_quic_idle_timeout(client, &mut value) }, 0);
+	assert_eq!(value, quic.idle_timeout.as_millis() as u64);
+
+	assert_eq!(unsafe { moq_client_get_quic_keep_alive(client, &mut value) }, 0);
+	assert_eq!(value, quic.keep_alive.map(|d| d.as_millis() as u64).unwrap_or(0));
+
+	assert_eq!(unsafe { moq_client_get_websocket_delay(client, &mut value) }, 0);
+	assert_eq!(value, config.websocket.delay.map(|d| d.as_millis() as u64).unwrap_or(0));
+
+	let mut multiplier = 0u32;
+	assert_eq!(unsafe { moq_client_get_backoff_multiplier(client, &mut multiplier) }, 0);
+	assert_eq!(multiplier, config.backoff.multiplier);
+
+	let mut enabled = false;
+	assert_eq!(unsafe { moq_client_get_websocket_enabled(client, &mut enabled) }, 0);
+	assert_eq!(enabled, config.websocket.enabled);
+}
+
+/// A getter reports what the matching setter wrote, so the pair can't drift.
+#[test]
+fn getters_read_back_what_the_setters_wrote() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	assert_eq!(moq_client_set_quic_idle_timeout(client, 15_000), 0);
+	assert_eq!(moq_client_set_backoff_timeout(client, 0), 0);
+	assert_eq!(moq_client_set_quic_keep_alive(client, 0), 0);
+
+	let mut value = 0u64;
+	assert_eq!(unsafe { moq_client_get_quic_idle_timeout(client, &mut value) }, 0);
+	assert_eq!(value, 15_000);
+
+	// Zero is a real setting for both of these, not "unset": retry forever, and no
+	// keep-alive pings. So they must read back as zero rather than as their defaults.
+	assert_eq!(unsafe { moq_client_get_backoff_timeout(client, &mut value) }, 0);
+	assert_eq!(value, 0);
+	assert_eq!(unsafe { moq_client_get_quic_keep_alive(client, &mut value) }, 0);
+	assert_eq!(value, 0);
+
+	assert_eq!(
+		unsafe { moq_client_get_quic_idle_timeout(client, std::ptr::null_mut()) },
+		Error::InvalidPointer.code()
+	);
+	assert_eq!(
+		unsafe { moq_client_get_quic_idle_timeout(UNUSED_ID, &mut value) },
+		Error::ClientNotFound.code()
+	);
+}
+
+/// An idle timeout past QUIC's millisecond varint used to panic inside the backend while
+/// the global state lock was held, which poisoned it for every later call in the process.
+/// It has to come back as an ordinary error instead.
+#[test]
+fn client_connect_rejects_an_unrepresentable_idle_timeout() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	assert_eq!(moq_client_set_quic_idle_timeout(client, u64::MAX), 0);
+
+	let url = b"moqt://localhost:1";
+	let ret = unsafe {
+		moq_client_connect(
+			url.as_ptr() as *const c_char,
+			url.len(),
+			client,
+			0,
+			0,
+			None,
+			std::ptr::null_mut(),
+		)
+	};
+	assert!(ret < 0, "connect must fail, got {ret}");
+
+	// The real damage was to everything after: a poisoned lock takes the whole process
+	// down with it, so prove the next call still works.
+	let next = id(moq_client_create());
+	moq_client_close(next);
+}
+
+/// The backend variants are feature-gated, so a hardcoded menu offers options this
+/// build rejects. Every name reported must be one the setter takes, same contract as
+/// `moq_versions`.
+#[test]
+fn backends_lists_only_what_the_setter_accepts() {
+	let count = unsafe { moq_backends(std::ptr::null_mut(), 0) };
+	assert!(count > 0, "expected at least one compiled backend, got {count}");
+
+	let mut names = vec![
+		moq_string {
+			data: std::ptr::null(),
+			len: 0
+		};
+		count as usize
+	];
+	assert_eq!(unsafe { moq_backends(names.as_mut_ptr(), names.len()) }, count);
+
+	for name in &names {
+		let name = unsafe { ffi::parse_str(name.data, name.len) }.expect("backend name is UTF-8");
+		let client = id(moq_client_create());
+		assert_eq!(
+			unsafe { moq_client_set_backend(client, name.as_ptr() as *const c_char, name.len()) },
+			0,
+			"listed backend {name} must be settable"
+		);
+		moq_client_close(client);
+	}
+
+	// And the converse: a backend this build lacks is not listed, so the menu can't
+	// offer a dead option.
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+	for candidate in ["quinn", "quiche", "noq"] {
+		let listed = names.iter().any(|n| {
+			unsafe { ffi::parse_str(n.data, n.len) }
+				.map(|s| s == candidate)
+				.unwrap_or(false)
+		});
+		let accepted =
+			unsafe { moq_client_set_backend(client, candidate.as_ptr() as *const c_char, candidate.len()) } == 0;
+		assert_eq!(listed, accepted, "{candidate}: listed and accepted must agree");
+	}
+}
+
+/// Whether a qlog directory works at all is a compile-time feature, so the capability
+/// has to agree with what a dial does. Both branches matter: `just check` runs without
+/// `--all-features` and only ever sees the unsupported one, while CI runs with them and
+/// only sees the supported one.
+#[test]
+fn qlog_support_matches_what_a_dial_accepts() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	// A real directory: with capture compiled in, the dial creates a trace file inside
+	// it, so a path that doesn't exist would fail for that reason instead of the one
+	// under test. The pid keeps concurrent test binaries out of each other's way.
+	let dir = std::env::temp_dir().join(format!("moq-qlog-test-{}", std::process::id()));
+	std::fs::create_dir_all(&dir).expect("create the qlog directory");
+	let path = dir.to_str().expect("temp dir is UTF-8").to_string();
+
+	assert_eq!(
+		unsafe { moq_client_set_quic_qlog(client, path.as_ptr() as *const c_char, path.len()) },
+		0,
+		"the setter stores the path either way; the dial is what rejects it"
+	);
+
+	let url = b"moqt://localhost:1";
+	let ret = unsafe {
+		moq_client_connect(
+			url.as_ptr() as *const c_char,
+			url.len(),
+			client,
+			0,
+			0,
+			None,
+			std::ptr::null_mut(),
+		)
+	};
+
+	match moq_qlog_supported() {
+		true => {
+			assert!(ret > 0, "qlog is supported, so the dial must start: {ret}");
+			moq_session_close(id(ret));
+		}
+		false => assert!(ret < 0, "qlog is unsupported, so the dial must be refused"),
+	}
+
+	std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn versions_lists_the_offered_set() {
+	let count = unsafe { moq_versions(std::ptr::null_mut(), 0) };
+	assert!(count > 0, "expected at least one offered version, got {count}");
+
+	let mut names = vec![
+		moq_string {
+			data: std::ptr::null(),
+			len: 0
+		};
+		count as usize
+	];
+	assert_eq!(unsafe { moq_versions(names.as_mut_ptr(), names.len()) }, count);
+
+	for name in &names {
+		let name = unsafe { ffi::parse_str(name.data, name.len) }.expect("version name is UTF-8");
+		// Every listed name must be one the setter accepts, or the menu it builds is a lie.
+		let one = [moq_str(name)];
+		let client = id(moq_client_create());
+		assert_eq!(unsafe { moq_client_set_versions(client, one.as_ptr(), one.len()) }, 0);
+		moq_client_close(client);
+	}
+}
+
+#[test]
+fn client_connect_applies_the_config() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	let versions = [moq_str("moq-lite-05")];
+	assert_eq!(
+		unsafe { moq_client_set_versions(client, versions.as_ptr(), versions.len()) },
+		0
+	);
+	assert_eq!(moq_client_set_connect_timeout(client, 100), 0);
+
+	let cb = Callback::new();
+	let url = b"moqt://localhost:1";
+	let session = id(unsafe {
+		moq_client_connect(
+			url.as_ptr() as *const c_char,
+			url.len(),
+			client,
+			0,
+			0,
+			Some(channel_callback),
+			cb.ptr,
+		)
+	});
+
+	assert_eq!(moq_session_close(session), 0);
+	assert!(cb.recv() <= 0, "session close delivers a terminal code");
+}
+
+#[test]
+fn client_connect_rejects_unknown_client() {
+	let url = b"moqt://localhost:1";
+	let ret = unsafe {
+		moq_client_connect(
+			url.as_ptr() as *const c_char,
+			url.len(),
+			UNUSED_ID,
+			0,
+			0,
+			None,
+			std::ptr::null_mut(),
+		)
+	};
+	assert_eq!(ret, Error::ClientNotFound.code());
 }

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -2341,6 +2341,37 @@ fn client_optional_strings_clear_on_null() {
 }
 
 #[test]
+fn client_set_tls_fingerprints_rejects_malformed_values_before_mutating() {
+	let client = id(moq_client_create());
+	let _guard = Guard(Some(|| {
+		moq_client_close(client);
+	}));
+
+	for invalid in ["not-hex", "abcd"] {
+		let fingerprints = [moq_str(invalid)];
+		let ret = unsafe { moq_client_set_tls_fingerprints(client, fingerprints.as_ptr(), fingerprints.len()) };
+		assert_eq!(ret, Error::InvalidConfig(String::new()).code());
+		let client_id = ffi::parse_id(client).unwrap();
+		assert!(
+			State::lock()
+				.client
+				.get_mut(client_id)
+				.unwrap()
+				.tls
+				.fingerprint
+				.is_empty()
+		);
+	}
+
+	let valid_value = "ab".repeat(32);
+	let valid = [moq_str(&valid_value)];
+	assert_eq!(
+		unsafe { moq_client_set_tls_fingerprints(client, valid.as_ptr(), valid.len()) },
+		0
+	);
+}
+
+#[test]
 fn client_set_quic_rejects_unknown_congestion_control() {
 	let client = id(moq_client_create());
 	let _guard = Guard(Some(|| {
@@ -2485,9 +2516,8 @@ fn getters_read_back_what_the_setters_wrote() {
 	);
 }
 
-/// An idle timeout past QUIC's millisecond varint used to panic inside the backend while
-/// the global state lock was held, which poisoned it for every later call in the process.
-/// It has to come back as an ordinary error instead.
+/// An idle timeout outside QUIC's millisecond varint returns an ordinary configuration
+/// error, and later client API calls remain usable.
 #[test]
 fn client_connect_rejects_an_unrepresentable_idle_timeout() {
 	let client = id(moq_client_create());
@@ -2509,10 +2539,9 @@ fn client_connect_rejects_an_unrepresentable_idle_timeout() {
 			std::ptr::null_mut(),
 		)
 	};
-	assert!(ret < 0, "connect must fail, got {ret}");
+	assert_eq!(ret, Error::InvalidConfig(String::new()).code());
 
-	// The real damage was to everything after: a poisoned lock takes the whole process
-	// down with it, so prove the next call still works.
+	// A rejected dial leaves the global client state usable.
 	let next = id(moq_client_create());
 	moq_client_close(next);
 }

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -125,15 +125,15 @@ impl ClientConfig {
 	///
 	/// Every backend reads it from here so the four dial paths can't drift apart. The
 	/// [`failover_delay`](Self::failover_delay) field is the override; this is the value
-	/// it resolves to, so `ClientConfig::default().effective_failover_delay()` is the
+	/// it resolves to, so `ClientConfig::default().resolved_failover_delay()` is the
 	/// default itself.
-	pub fn effective_failover_delay(&self) -> std::time::Duration {
+	pub fn resolved_failover_delay(&self) -> std::time::Duration {
 		self.failover_delay.unwrap_or(crate::failover::DEFAULT_DELAY)
 	}
 
 	/// The deadline one connection attempt will actually get, dial and handshake
 	/// together, resolving the default from the [`timeout`](Self::timeout) override.
-	pub fn connect_timeout(&self) -> std::time::Duration {
+	pub fn resolved_connect_timeout(&self) -> std::time::Duration {
 		self.timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT)
 	}
 }
@@ -250,8 +250,8 @@ impl Client {
 		let versions = config.versions();
 		// Read before the struct literal below moves fields out of `config`.
 		#[cfg(feature = "tcp")]
-		let failover_delay = config.effective_failover_delay();
-		let timeout = config.connect_timeout();
+		let failover_delay = config.resolved_failover_delay();
+		let timeout = config.resolved_connect_timeout();
 
 		Ok(Self {
 			moq: moq_net::Client::new().with_versions(versions.clone()),
@@ -1029,7 +1029,7 @@ mod tests {
 	fn connect_timeout_defaults_to_thirty_seconds() {
 		let config = ClientConfig::parse_from(["test"]);
 		assert_eq!(config.timeout, None);
-		assert_eq!(config.connect_timeout(), DEFAULT_CONNECT_TIMEOUT);
+		assert_eq!(config.resolved_connect_timeout(), DEFAULT_CONNECT_TIMEOUT);
 	}
 
 	/// A peer that completes the TCP handshake and then never speaks: the QUIC arm

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -121,14 +121,19 @@ impl ClientConfig {
 		}
 	}
 
-	/// The Happy Eyeballs stagger to use, resolving the default. Every backend
-	/// reads it from here so the four dial paths can't drift apart.
-	#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche", feature = "tcp"))]
-	pub(crate) fn effective_failover_delay(&self) -> std::time::Duration {
+	/// The Happy Eyeballs stagger a dial will actually use, resolving the default.
+	///
+	/// Every backend reads it from here so the four dial paths can't drift apart. The
+	/// [`failover_delay`](Self::failover_delay) field is the override; this is the value
+	/// it resolves to, so `ClientConfig::default().effective_failover_delay()` is the
+	/// default itself.
+	pub fn effective_failover_delay(&self) -> std::time::Duration {
 		self.failover_delay.unwrap_or(crate::failover::DEFAULT_DELAY)
 	}
 
-	fn connect_timeout(&self) -> std::time::Duration {
+	/// The deadline one connection attempt will actually get, dial and handshake
+	/// together, resolving the default from the [`timeout`](Self::timeout) override.
+	pub fn connect_timeout(&self) -> std::time::Duration {
 		self.timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT)
 	}
 }
@@ -218,6 +223,7 @@ impl Client {
 		let backend = config.backend.clone().unwrap_or_else(crate::default_quic_backend);
 
 		config.quic.validate()?;
+		config.backoff.validate()?;
 
 		let tls = config.tls.build()?;
 

--- a/rs/moq-native/src/error.rs
+++ b/rs/moq-native/src/error.rs
@@ -45,6 +45,14 @@ pub enum Error {
 	#[error("qlog capture requires the 'qlog' feature")]
 	QlogUnsupported,
 
+	/// The idle timeout is longer than QUIC's millisecond varint can carry.
+	#[error("idle timeout must be under 2^62 milliseconds")]
+	IdleTimeoutRange,
+
+	/// The backoff would retry with no delay at all, spinning instead of pacing.
+	#[error("backoff initial, multiplier, and max must all be non-zero, or reconnecting spins")]
+	BackoffUnpaced,
+
 	/// Every backend we tried gave up without reporting why.
 	#[error("failed to connect to server")]
 	ConnectFailed,

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -133,7 +133,7 @@ impl QuicBackend {
 	///
 	/// [`FromStr`]: std::str::FromStr
 	pub fn as_str(&self) -> &'static str {
-		match self {
+		match *self {
 			#[cfg(feature = "quinn")]
 			Self::Quinn => "quinn",
 			#[cfg(feature = "quiche")]

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -99,6 +99,59 @@ pub enum QuicBackend {
 	Noq,
 }
 
+/// Parses the same spellings the CLI and TOML accept (`quinn`, `quiche`, `noq`),
+/// case-insensitively. A backend this build was compiled without is an error, since
+/// its variant doesn't exist.
+impl std::str::FromStr for QuicBackend {
+	type Err = String;
+
+	fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+		<Self as clap::ValueEnum>::from_str(s, true)
+	}
+}
+
+impl QuicBackend {
+	/// Every backend this build was compiled with, spelled the way [`FromStr`] accepts.
+	///
+	/// The variants are feature-gated, so this is the only honest answer to "what can I
+	/// pass here". A caller building a menu should read it rather than listing the three
+	/// names, which would offer options that cannot parse.
+	///
+	/// [`FromStr`]: std::str::FromStr
+	pub fn compiled() -> &'static [Self] {
+		&[
+			#[cfg(feature = "quinn")]
+			Self::Quinn,
+			#[cfg(feature = "quiche")]
+			Self::Quiche,
+			#[cfg(feature = "noq")]
+			Self::Noq,
+		]
+	}
+
+	/// The name [`FromStr`] accepts for this backend.
+	///
+	/// [`FromStr`]: std::str::FromStr
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			#[cfg(feature = "quinn")]
+			Self::Quinn => "quinn",
+			#[cfg(feature = "quiche")]
+			Self::Quiche => "quiche",
+			#[cfg(feature = "noq")]
+			Self::Noq => "noq",
+		}
+	}
+}
+
+/// Whether this build can capture qlog traces, which the `qlog` feature gates.
+///
+/// Setting a qlog directory without it is an error at dial time, so a caller offering
+/// the knob should check here rather than surfacing an option that cannot work.
+pub fn qlog_supported() -> bool {
+	cfg!(feature = "qlog")
+}
+
 fn default_quic_backend() -> QuicBackend {
 	#[cfg(feature = "quinn")]
 	{

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -267,7 +267,7 @@ impl NoqClient {
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
 			host_name: config.tls.host_name.clone(),
-			failover_delay: config.effective_failover_delay(),
+			failover_delay: config.resolved_failover_delay(),
 			dual_stack,
 		})
 	}

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -60,6 +60,15 @@ pub enum CongestionControl {
 	Delay,
 }
 
+/// Parses the same spellings the CLI and TOML accept (`loss`, `delay`), case-insensitively.
+impl std::str::FromStr for CongestionControl {
+	type Err = String;
+
+	fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+		<Self as clap::ValueEnum>::from_str(s, true)
+	}
+}
+
 /// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
 pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;
 
@@ -166,14 +175,30 @@ fn validate_qlog(qlog: Option<&PathBuf>) -> crate::Result<()> {
 	}
 }
 
+/// QUIC carries `max_idle_timeout` as a varint of milliseconds, so anything past this
+/// can't go on the wire.
+const MAX_IDLE_TIMEOUT: Duration = Duration::from_millis((1 << 62) - 1);
+
+/// Reject an idle timeout no QUIC connection can express.
+///
+/// Checked here rather than in each backend because the conversion the backends do is
+/// infallible-by-panic, and this config reaches them from a TOML file or a C caller.
+fn validate_idle_timeout(idle_timeout: Option<Duration>) -> crate::Result<()> {
+	match idle_timeout {
+		Some(timeout) if timeout > MAX_IDLE_TIMEOUT => Err(crate::Error::IdleTimeoutRange),
+		_ => Ok(()),
+	}
+}
+
 impl Client {
 	/// Reject knobs this build can't honor. Called when the client is built.
 	pub(crate) fn validate(&self) -> crate::Result<()> {
-		validate_qlog(self.qlog.as_ref())
+		validate_qlog(self.qlog.as_ref())?;
+		validate_idle_timeout(self.idle_timeout)
 	}
 
 	/// The per-connection knobs with defaults applied, ready to hand to a backend.
-	pub(crate) fn resolve(&self) -> Resolved {
+	pub fn resolve(&self) -> Resolved {
 		Resolved::new(
 			self.max_streams,
 			self.gso,
@@ -183,6 +208,13 @@ impl Client {
 			self.congestion_control,
 			self.qlog.clone(),
 		)
+	}
+}
+
+/// Every knob at its default, which is what an untouched [`Client`] resolves to.
+impl Default for Resolved {
+	fn default() -> Self {
+		Client::default().resolve()
 	}
 }
 
@@ -319,7 +351,8 @@ pub struct Server {
 impl Server {
 	/// Reject knobs this build can't honor. Called when the server is built.
 	pub(crate) fn validate(&self) -> crate::Result<()> {
-		validate_qlog(self.qlog.as_ref())
+		validate_qlog(self.qlog.as_ref())?;
+		validate_idle_timeout(self.idle_timeout)
 	}
 
 	/// The per-connection knobs with defaults applied, ready to hand to a backend.
@@ -339,10 +372,15 @@ impl Server {
 /// A resolved view of the per-connection knobs (defaults filled in), shared by
 /// [`Client`] and [`Server`] so backends apply them the same way regardless of role.
 ///
-/// Internal: the backends consume it and [`crate::iroh::EndpointConfig::bind`]
-/// resolves it from a [`Client`], so it never appears in the public surface.
+/// The backends consume it, and [`Client::resolve`] produces it. [`Resolved::default`]
+/// is therefore the canonical statement of what every QUIC knob defaults to, which is
+/// what a UI should show rather than repeating the numbers.
+///
+/// Non-exhaustive because it gains a field for every knob [`Client`] gains, so build it
+/// from [`Client::resolve`] or [`Resolved::default`] rather than a struct literal.
 #[derive(Clone, Debug)]
-pub(crate) struct Resolved {
+#[non_exhaustive]
+pub struct Resolved {
 	/// Max concurrent streams (bidi and uni).
 	pub max_streams: u64,
 	/// GSO override, or `None` to leave the backend default (on).
@@ -522,6 +560,29 @@ mod tests {
 		} else {
 			assert!(matches!(set.validate(), Err(crate::Error::QlogUnsupported)));
 		}
+	}
+
+	/// The backends convert this duration with an infallible-by-panic `expect`, and the
+	/// value arrives from a TOML file or a C caller, so validation has to catch it here.
+	#[test]
+	fn idle_timeout_beyond_the_varint_is_rejected() {
+		let over = Client {
+			idle_timeout: Some(MAX_IDLE_TIMEOUT + Duration::from_millis(1)),
+			..Default::default()
+		};
+		assert!(matches!(over.validate(), Err(crate::Error::IdleTimeoutRange)));
+
+		let server = Server {
+			idle_timeout: Some(Duration::from_millis(u64::MAX)),
+			..Default::default()
+		};
+		assert!(matches!(server.validate(), Err(crate::Error::IdleTimeoutRange)));
+
+		let at_limit = Client {
+			idle_timeout: Some(MAX_IDLE_TIMEOUT),
+			..Default::default()
+		};
+		assert!(at_limit.validate().is_ok());
 	}
 
 	#[test]

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -244,7 +244,7 @@ impl QuicheClient {
 			http_bootstrap: config.tls.allows_http_bootstrap(),
 			quic,
 			host_name: config.tls.host_name.clone(),
-			failover_delay: config.effective_failover_delay(),
+			failover_delay: config.resolved_failover_delay(),
 			identity,
 		})
 	}

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -280,7 +280,7 @@ impl QuinnClient {
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
 			host_name: config.tls.host_name.clone(),
-			failover_delay: config.effective_failover_delay(),
+			failover_delay: config.resolved_failover_delay(),
 			dual_stack,
 		})
 	}

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -76,6 +76,23 @@ impl Default for Backoff {
 }
 
 impl Backoff {
+	/// Reject a backoff that would retry without pacing.
+	///
+	/// The loop sleeps `delay`, then `delay = min(delay * multiplier, max)`. A zero in
+	/// any of the three collapses that to zero forever, so a relay that is simply down
+	/// becomes a hot loop of dials and DNS lookups, unbounded when
+	/// [`timeout`](Self::timeout) is also zero. A zero `timeout` on its own is fine and
+	/// documented: it means retry forever, which is only a problem unpaced.
+	///
+	/// A `multiplier` of 1 is allowed: the delay stays at `initial`, which is a
+	/// constant-delay retry rather than an unpaced one.
+	pub(crate) fn validate(&self) -> crate::Result<()> {
+		match self.initial.is_zero() || self.multiplier == 0 || self.max.is_zero() {
+			true => Err(crate::Error::BackoffUnpaced),
+			false => Ok(()),
+		}
+	}
+
 	/// How long broadcasts fed by a reconnecting session should outlive a session
 	/// drop (see [`moq_net::origin::Info::linger`]): slightly past the give-up
 	/// [`timeout`](Self::timeout), so when the loop does give up its error surfaces
@@ -453,6 +470,43 @@ fn terminal(state: &State) -> Error {
 
 #[cfg(test)]
 mod tests {
+	/// The retry loop is `delay = min(delay * multiplier, max)`, so a zero anywhere
+	/// pins the delay at zero and turns an unreachable relay into a hot dial loop,
+	/// unbounded when the give-up timeout is also zero.
+	#[test]
+	fn backoff_rejects_an_unpaced_retry() {
+		assert!(Backoff::default().validate().is_ok());
+
+		for bad in [
+			Backoff {
+				initial: Duration::ZERO,
+				..Default::default()
+			},
+			Backoff {
+				multiplier: 0,
+				..Default::default()
+			},
+			Backoff {
+				max: Duration::ZERO,
+				..Default::default()
+			},
+		] {
+			assert!(
+				matches!(bad.validate(), Err(crate::Error::BackoffUnpaced)),
+				"{bad:?} should be rejected"
+			);
+		}
+
+		// A zero timeout is documented as retry-forever, which is only a hazard
+		// unpaced, and a multiplier of 1 is a constant delay rather than no delay.
+		let forever = Backoff {
+			timeout: Duration::ZERO,
+			multiplier: 1,
+			..Default::default()
+		};
+		assert!(forever.validate().is_ok());
+	}
+
 	use super::*;
 
 	#[test]

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -93,6 +93,11 @@ impl Backoff {
 		}
 	}
 
+	/// Grow the retry delay without overflowing before applying the configured cap.
+	fn next_delay(&self, delay: Duration) -> Duration {
+		delay.saturating_mul(self.multiplier.max(1)).min(self.max)
+	}
+
 	/// How long broadcasts fed by a reconnecting session should outlive a session
 	/// drop (see [`moq_net::origin::Info::linger`]): slightly past the give-up
 	/// [`timeout`](Self::timeout), so when the loop does give up its error surfaces
@@ -307,7 +312,7 @@ impl Reconnect {
 			if let Some(deadline) = deadline {
 				wait = wait.min(deadline - now);
 			}
-			delay = (delay * backoff.multiplier.max(1)).min(backoff.max);
+			delay = backoff.next_delay(delay);
 
 			tracing::warn!(%url, ?wait, "reconnecting after backoff");
 			tokio::time::sleep(wait).await;
@@ -505,6 +510,15 @@ mod tests {
 			..Default::default()
 		};
 		assert!(forever.validate().is_ok());
+	}
+
+	#[test]
+	fn backoff_growth_saturates_before_applying_the_cap() {
+		let backoff = Backoff {
+			multiplier: u32::MAX,
+			..Default::default()
+		};
+		assert_eq!(backoff.next_delay(Duration::MAX), backoff.max);
 	}
 
 	use super::*;

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -140,6 +140,12 @@ pub enum Error {
 /// Convenience alias for results produced by this module.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Parse a hex-encoded SHA-256 certificate fingerprint.
+pub fn parse_fingerprint(value: &str) -> Result<[u8; 32]> {
+	let bytes = hex::decode(value.trim()).map_err(Error::Fingerprint)?;
+	bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))
+}
+
 /// Read a PEM file into its list of certificates.
 pub(crate) fn read_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>> {
 	let file = fs::File::open(path).map_err(Error::Open)?;
@@ -437,10 +443,7 @@ impl Client {
 	fn fingerprints(&self) -> Result<Vec<[u8; 32]>> {
 		self.effective_fingerprint()
 			.iter()
-			.map(|fp| {
-				let bytes = hex::decode(fp.trim()).map_err(Error::Fingerprint)?;
-				bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))
-			})
+			.map(|fp| parse_fingerprint(fp))
 			.collect()
 	}
 
@@ -898,10 +901,8 @@ impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
 #[cfg(test)]
 #[cfg(all(any(feature = "quinn", feature = "noq", feature = "quiche"), feature = "aws-lc-rs"))]
 mod tests {
-	/// Disabling verification alongside a fingerprint or root used to keep the
-	/// insecure path and drop the trust material without a word, which is the worst
-	/// way to be wrong: someone hardening a dev setup by adding a pin would still
-	/// accept every certificate.
+	/// Disabling verification cannot be combined with trust material that it would
+	/// otherwise ignore.
 	#[test]
 	fn disable_verify_rejects_trust_material() {
 		let insecure = Client {
@@ -935,6 +936,16 @@ mod tests {
 		assert!(matches!(
 			with_system_roots.verification(),
 			Err(Error::DisableVerifyWithTrust)
+		));
+
+		let without_system_roots = Client {
+			disable_verify: Some(true),
+			system_roots: Some(false),
+			..Default::default()
+		};
+		assert!(matches!(
+			without_system_roots.verification(),
+			Ok(Verification::Disabled)
 		));
 	}
 

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -75,6 +75,12 @@ pub enum Error {
 	)]
 	FingerprintWithRoots,
 
+	/// Trust material was configured alongside the flag that ignores all of it.
+	#[error(
+		"--client-tls-disable-verify cannot be combined with --client-tls-fingerprint, --client-tls-root or --client-tls-system-roots: it accepts every certificate, so the trust material would be ignored"
+	)]
+	DisableVerifyWithTrust,
+
 	/// A root certificate parsed as PEM but rustls rejected it as a trust anchor.
 	#[error("failed to add root certificate")]
 	AddRoot(#[source] rustls::Error),
@@ -357,35 +363,46 @@ impl Client {
 	/// Resolve the verification policy from the configured flags.
 	///
 	/// Precedence and rules (shared by all backends):
-	/// - `--client-tls-disable-verify` wins and disables verification.
+	/// - `--client-tls-disable-verify` disables verification, and combining it with any
+	///   trust material is rejected rather than silently ignoring that material.
 	/// - `--client-tls-fingerprint` pins the leaf and bypasses the CA chain; combining
 	///   it with `--client-tls-root` or `--client-tls-system-roots` is rejected rather than
 	///   silently ignoring one of them.
 	/// - Otherwise, verify against the system roots (default) plus any custom
 	///   roots. The system roots are dropped once a custom root is given unless
 	///   `--client-tls-system-roots` re-enables them.
+	///
+	/// Every combination that would quietly drop one setting is an error. Silently
+	/// weakening trust is the worst outcome here: someone moving off
+	/// `disable_verify` by adding a fingerprint would otherwise still accept every
+	/// certificate, with the UI showing the pin as configured.
 	pub(crate) fn verification(&self) -> Result<Verification> {
 		self.warn_deprecated();
 
+		let fingerprints = self.fingerprints()?;
+		let roots = self.effective_root();
+		let system_roots = self.effective_system_roots();
+
 		if self.effective_disable_verify().unwrap_or_default() {
+			if !fingerprints.is_empty() || !roots.is_empty() || system_roots == Some(true) {
+				return Err(Error::DisableVerifyWithTrust);
+			}
 			return Ok(Verification::Disabled);
 		}
 
-		let fingerprints = self.fingerprints()?;
 		if !fingerprints.is_empty() {
-			if !self.effective_root().is_empty() || self.effective_system_roots() == Some(true) {
+			if !roots.is_empty() || system_roots == Some(true) {
 				return Err(Error::FingerprintWithRoots);
 			}
 			return Ok(Verification::Fingerprints(fingerprints));
 		}
 
-		let root = self.effective_root();
 		// Default to system roots only when no custom root is given, so passing a
 		// root replaces them unless the system roots are explicitly re-enabled.
-		let system = self.effective_system_roots().unwrap_or(root.is_empty());
+		let system = system_roots.unwrap_or(roots.is_empty());
 
 		let mut custom = Vec::new();
-		for root in &root {
+		for root in &roots {
 			let certs = read_certs(root)?;
 			if certs.is_empty() {
 				return Err(Error::EmptyRoots(root.clone()));
@@ -881,6 +898,46 @@ impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
 #[cfg(test)]
 #[cfg(all(any(feature = "quinn", feature = "noq", feature = "quiche"), feature = "aws-lc-rs"))]
 mod tests {
+	/// Disabling verification alongside a fingerprint or root used to keep the
+	/// insecure path and drop the trust material without a word, which is the worst
+	/// way to be wrong: someone hardening a dev setup by adding a pin would still
+	/// accept every certificate.
+	#[test]
+	fn disable_verify_rejects_trust_material() {
+		let insecure = Client {
+			disable_verify: Some(true),
+			..Default::default()
+		};
+		assert!(matches!(insecure.verification(), Ok(Verification::Disabled)));
+
+		let with_fingerprint = Client {
+			disable_verify: Some(true),
+			fingerprint: vec!["ab".repeat(32)],
+			..Default::default()
+		};
+		assert!(matches!(
+			with_fingerprint.verification(),
+			Err(Error::DisableVerifyWithTrust)
+		));
+
+		let with_root = Client {
+			disable_verify: Some(true),
+			root: vec!["/tmp/root.pem".into()],
+			..Default::default()
+		};
+		assert!(matches!(with_root.verification(), Err(Error::DisableVerifyWithTrust)));
+
+		let with_system_roots = Client {
+			disable_verify: Some(true),
+			system_roots: Some(true),
+			..Default::default()
+		};
+		assert!(matches!(
+			with_system_roots.verification(),
+			Err(Error::DisableVerifyWithTrust)
+		));
+	}
+
 	use super::*;
 	use rustls::client::danger::ServerCertVerifier;
 	use rustls::pki_types::ServerName;


### PR DESCRIPTION
## Summary

- `moq_session_connect` built a default `moq_native::ClientConfig` and ignored everything else, so no C consumer could pin a protocol version, adjust TLS trust, or tune the transport. This exposes that config and surfaces it in the OBS plugin.
- **Shape**: a `moq_client_create()` handle plus one `moq_client_set_*` per knob, dialed with `moq_client_connect`. Deliberately a handle-with-setters rather than a `#[repr(C)]` config struct: the C ABI is stable and this config will keep growing, so a new setter stays additive where a new struct field would break every caller compiled against the old layout. That principle applies all the way down, so the QUIC and backoff knobs are individual setters too rather than two structs passed by pointer. One convention for the whole surface, no `*_valid` flags, and every future knob is purely additive. It also mirrors the `MoqClient` setter pattern `moq-ffi` already uses. A `client` of `0` means the defaults, so `moq_session_connect` is the shorthand for the same dial and is untouched.
- `moq_versions` enumerates the offered drafts, so a caller building a menu can't drift from what `moq_client_set_versions` accepts. The scalar knobs get the same treatment through a `moq_client_get_*` per setter: a knob nobody set reads back as its default, so a fresh handle *is* the defaults and a UI reads them instead of hardcoding numbers that go stale when one is retuned. Deliberately no separate defaults type, which would have been a second representation of the same config to keep in sync by hand.
- **OBS**: every knob is described once as a `Field` table in `cpp/obs/src/moq-settings.cpp`, and both UIs are generated from it: the checkable **Advanced** group in the service properties, and a separate `MoQAdvancedDialog` window off the dock so the dock stays small. Both write the same keys on the service, which is where the output reads them. With the group off no client handle is built at all, so the default dial is byte-identical to before.
- A rejected setting refuses to start the stream, naming the setting and the reason in the log. A silently dropped version pin is exactly the confusion an advanced dialog exists to avoid. Values that parse are checked at the setter; values that parse but the transport can't express are caught at dial.

## Rejected rather than silently dropped, found by review

The premise of this PR is that a setting the layer below can't honor refuses the stream rather than disappearing. Two adversarial review passes found four places where that wasn't true. All are fixed in the layer that owns the rule, so the CLI and TOML callers get them too.

**TLS trust was silently discarded.** `tls::Client::verification` returned `Verification::Disabled` on its first branch, before it looked at fingerprints or roots. So someone hardening a development setup by adding a pin, while `disable_verify` was still on, kept accepting every certificate with the pin quietly ignored. The OBS tooltip made it worse by pointing users at exactly that combination. Now `Error::DisableVerifyWithTrust`, matching the `FingerprintWithRoots` rule eight lines below it, and the tooltips say the two are exclusive.

**The backend menu offered options this build can't parse.** `QuicBackend`'s variants are `#[cfg(feature)]`-gated and libmoq compiles quinn only (`cargo tree -p libmoq -e features -i moq-native`), so the hardcoded `{quinn, quiche, noq}` menu had two entries that guarantee "invalid settings, stream won't start". Same for the qlog directory, which fails the dial without the `qlog` feature. `moq_backends` and `moq_qlog_supported` now report what the build has, the way `moq_versions` already does for drafts, and both menus are generated from them. The qlog *apply* is guarded too: a scene collection written by a qlog-capable build keeps the key even where the field is hidden.

**Zero backoff values spun.** The retry loop is `delay = min(delay * multiplier, max)`, so a zero in any of the three pins the delay at zero, turning an unreachable relay into a hot dial-and-DNS loop, unbounded when the give-up timeout is also zero. The OBS form allowed zero for two of them. `Backoff::validate` rejects it. A zero timeout stays legal (retry forever, only a hazard unpaced), as does a multiplier of 1 (constant delay, still paced).

## Panic fix, found by review

Exposing the QUIC knobs to C made an existing landmine reachable. `moq-native`'s backends convert the idle timeout with `.try_into().expect("idle timeout out of range")` (`quinn.rs`, `noq.rs`, `iroh.rs`), but QUIC carries `max_idle_timeout` as a **millisecond varint**, so anything at or past 2^62 ms fails that conversion. Nothing rejected such a value on the way in.

Via libmoq that panic is much worse than a crash: `moq_client_connect` runs inside `State::lock()`, and `ffi::enter` catches the unwind, so the panic **poisons the global state mutex**. Every later `State::lock().unwrap()` then panics too, and libmoq is dead for the rest of the process. `moq_client_set_quic(idle_timeout_ms = u64::MAX)` was enough to do it.

Fixed in the layer that owns the constraint: `quic::Client::validate` / `Server::validate` now reject an out-of-range idle timeout, which covers every backend and every caller (TOML, CLI, FFI), not just the one that panicked first. The regression test reproduces the original failure exactly: without the fix it panics in `quinn.rs`, then again on the poisoned lock.

## Public API changes

Every signature is additive, hence `main` rather than `dev`: no item is renamed, removed, or changed. But see [Behavior changes](#behavior-changes) below, which semver tooling cannot see and which matters more than the signature delta.

**`rs/libmoq`** (new C ABI):

- `moq_client_create`, `moq_client_close`, `moq_client_connect`
- `moq_client_set_versions`, `_backend`, `_bind`, `_connect_timeout`, `_failover_delay`
- `moq_client_set_tls_disable_verify`, `_tls_system_roots`, `_tls_roots`, `_tls_fingerprints`, `_tls_host_name`, `_tls_cert`, `_tls_key`
- `moq_client_set_backoff_initial`, `_backoff_multiplier`, `_backoff_max`, `_backoff_timeout`
- `moq_client_set_quic_max_streams`, `_quic_idle_timeout`, `_quic_keep_alive`, `_quic_gso`, `_quic_mtu_discovery`, `_quic_congestion_control`, `_quic_qlog`
- `moq_client_set_websocket_enabled`, `moq_client_set_websocket_delay`
- `moq_client_get_connect_timeout`, `_failover_delay`, `_backoff_initial`, `_backoff_multiplier`, `_backoff_max`, `_backoff_timeout`, `_quic_max_streams`, `_quic_idle_timeout`, `_quic_keep_alive`, `_websocket_enabled`, `_websocket_delay`. Out-parameter plus a zero/negative return, since every value is valid and the return channel is for errors.
- `moq_versions`, `moq_backends`, `moq_qlog_supported`
- 25 setters, 11 getters, 40 `moq_client_*` functions in total, and **no new types at all**. The knobs whose default resolves per backend (GSO, path MTU discovery, congestion control, the TLS root store) deliberately have no getter: there is no single value to report.
- `Error` gains `ClientNotFound` (-39) and `InvalidConfig` (-40). The enum is `#[non_exhaustive]`, and both codes are appended, so existing codes are unchanged.
- `moq_string` gains `Clone`/`Copy` and its doc now covers input use as well as output. Layout unchanged.

**`rs/moq-native`**:

- `impl FromStr` for `QuicBackend` and `CongestionControl`, delegating to their existing `clap::ValueEnum`. This is what lets libmoq parse the same spellings the CLI and TOML accept without pulling clap in or hardcoding a feature-gated variant list.
- `Error::IdleTimeoutRange`, for the panic fix above. The enum is `#[non_exhaustive]` and the variant is appended.
- `quic::Resolved` and `quic::Client::resolve` are now `pub`, with a `Default` impl and `#[non_exhaustive]`. The attribute earns its keep here: `Resolved` has all-`pub` fields and gains one per QUIC knob, so without it every future knob would be a breaking change for anyone who struct-literaled it. Build it from `resolve()` or `default()`. `Resolved` was already the concept libmoq needs, "the config with defaults filled in" as the backends consume it, just `pub(crate)`. So `quic::Resolved::default()` states every QUIC default, and it is the same value a dial uses rather than a constant that happens to match.
- `ClientConfig::connect_timeout` and `effective_failover_delay` are now `pub` (the latter also loses its feature `#[cfg]`). `effective_failover_delay` is an awkward public name sitting next to the `failover_delay` field it resolves; worth renaming before this ships if the overlap reads badly. These resolve the two scalars that live above the QUIC section; the fields stay the override, the methods are what a dial gets.
- `QuicBackend::compiled` and `QuicBackend::as_str`, plus a crate-root `qlog_supported()`. The backend variants are feature-gated, so this is the only honest answer to "what can I pass here", and it keeps libmoq from needing clap to enumerate them.
- `tls::Error::DisableVerifyWithTrust` and `Error::BackoffUnpaced`, both appended to `#[non_exhaustive]` enums.
- No new constants. `quic::Client` and the two `ClientConfig` scalars are `Option<T>` for the TOML/CLI merge, so their `Default` means "nothing overridden" rather than the real values, which is why the resolution has to be what's exposed. `Backoff` and `websocket::Client` already had real `Default` impls and needed nothing.

Internal only: `libmoq::Session::connect` takes the config as a parameter, but `Session` is `pub(crate)`.

## Behavior changes

Three configurations that `Client::new` used to accept now fail, in `moq-relay` and `moq-cli` and any TOML config, not just through the C bindings. No signature changed, so `cargo semver-checks` sees nothing, but a working deployment can stop starting:

| Config | Was | Now |
|---|---|---|
| `disable_verify` + fingerprint / root / explicit `system_roots` | verification off, trust material silently ignored | `tls::Error::DisableVerifyWithTrust` |
| Backoff `initial`, `multiplier`, or `max` of zero | hot retry loop, unbounded with a zero `timeout` | `Error::BackoffUnpaced` |
| Idle timeout at or past 2^62 ms | panic, poisoning libmoq's global lock | `Error::IdleTimeoutRange` |

The first two turn a running deployment into a startup failure. Both were already broken in a way the operator could not see (verification silently off; retries spinning), so surfacing them is the point, but it is a real behavior break rather than a pure addition. A zero backoff `timeout` stays legal, since retry-forever is only a hazard unpaced.

## Also here

`shfmt -f .` walks into everything `just obs setup` and `just obs build` leave under `cpp/obs/`: the downloaded obs-studio and Qt sources, and the CMake-generated Xcode script phases. Neither lints clean, neither is ours to reformat, so the repo's own gate failed on generated code after building this plugin. #2690 landed the same fix for `just check` while this was in review; `just ci` and `just fix` still had the old expression, so the three call sites are now one `_shell-files` recipe using #2690's `git ls-files` mechanism. One approach in the tree rather than two.

## Test plan

- `just check` green on the rebased tree (macOS): fmt, sort, shear, deny, clippy `-D warnings`, remark, the shell/TOML/Nix/justfile lints, and the full nextest run.
- `RUSTDOCFLAGS=-D warnings cargo doc` clean for `moq-native` and `libmoq`, since `just check` doesn't cover it and CI does.
- 18 new `libmoq` tests covering handle lifecycle, unknown-handle rejection, version round-trip and rejection, bind-address rejection, NULL-clears-optional-string, every QUIC and backoff setter applying and rejecting an unknown handle, congestion-control rejection leaving the config untouched and NULL restoring automatic, `moq_versions` round-tripping every listed name back through the setter, connect with and without a config, the idle-timeout panic above, a fresh handle reading back `ClientConfig::default()` and `quic::Resolved::default()` field by field, and setter/getter round-trip including that a zero backoff timeout and keep-alive read back as zero rather than falling through to a default. Plus the capability contract in both directions: every listed backend is settable, and for all three candidate names "listed" and "accepted" agree, so the menu can't drift from the build either way.
- `moq-native` tests for each validation: the idle-timeout range on both the client and server sections, every conflicting TLS pairing plus the still-valid solo case, and each zero backoff field plus the retry-forever and constant-delay cases that stay legal.
- The panic regression test was verified to fail without the fix, not just to pass with it: it aborts in `quinn.rs:53` and then on `PoisonError` from `state.rs:29`.
- `rs/libmoq` is not a `default-member`, so `just check` skips it locally. `just rs ci` runs `--workspace`, so CI does cover it, but the local gate doesn't: ran it by hand here with `cargo nextest run -p libmoq` (54 passed), `cargo clippy --all-targets -p libmoq -- -D warnings` clean, and `cargo doc -D warnings` clean.
- `cargo nextest --all-features` as well as the default set. The `qlog` capability test forks on `cfg!(feature = "qlog")`, and `just check` only ever compiles one side of that fork; the first CI run caught it doing the wrong thing on the other.
- The generated `moq.h` was syntax-checked standalone as both C and C++. That caught a real defect: naming the struct and the function both `moq_client_defaults` compiles in Rust but emits a header C can't parse, since cbindgen writes `typedef struct X {...} X;` and C shares one namespace between typedefs and functions. Hence `moq_defaults`.
- OBS plugin built on macOS (`just obs setup && just obs build`) against real libobs and Qt6, with `-Werror`. `just obs check` (clang-format, gersemi) clean. CI never compiles `cpp/obs`, so this is the only gate it gets.
- Not exercised at runtime: I have no relay set up here, so the settings are verified as far as "libmoq accepts them and the plugin builds and wires them through", not as observed on-the-wire behavior.

## Rebased onto #2681

The terminal-failure gap this PR originally flagged as out of scope is now fixed on `main` by #2681, which rewrote the session callback machinery: the inline lambda became a static `MoQOutput::SessionStatus` with a heap `SessionRef`, plus an attempt counter and a `signal_mutex` held across the connect. This branch is rebased on top of it, and the `moq-output.cpp` diff is now about 20 lines.

Resolving it needed two adjustments rather than a replay: the invalid-settings path now goes through #2681's `SignalStop()` helper (which takes `signal_mutex` first) instead of calling `obs_output_signal_stop` directly, and the `CreateClient` block moved out of the new `signal_lock` scope up to the other pre-flight validation, since it is config parsing and touches nothing that lock guards.

## Cross-package sync

The `rs/libmoq` C ABI row is covered: `cpp/obs/src` and `doc/bin/obs.md`, plus `doc/lib/c`. No other row applies, since `rs/moq-ffi` and the wire format are untouched.

Worth noting for later, not done here: `moq-ffi`'s `MoqClient` already has the TLS and bind setters but not versions, backoff, or QUIC tuning, so it now exposes less than libmoq does.

## Not included

- **CMAF vs hang is not a switch to flip.** Publishing CMAF goes through `moq-mux`'s fMP4 importer, which needs fMP4 bytes in, and OBS hands over raw encoder packets. The catalog isn't a choice either: `moq_mux::catalog::Producer` already publishes both `catalog.json` (hang) and `catalog` (MSF) on every broadcast. Making this a setting is new mux work, not a flag.
- **Per-track latency and priority**: `track::Info` has them, but media tracks go through `broadcast.reserve_track(name)`, which takes no info. Needs plumbing through moq-mux's import layer first.
- **The MoQ source (consume side) has no advanced settings.** It snapshots url/broadcast into its context under a mutex and reconnects from a worker, so wiring config in means holding an `obs_data_t` on that context plus change detection across ~20 fields, inside a refcounted and generation-checked path. Left for its own change rather than done half-carefully.

(Written by Opus 5)
