### PR TITLE
docs: reply to review comments as you address them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,8 @@ The marker never goes in the codebase itself: no code comments, doc comments, or
 
 CodeRabbit reviews PRs automatically, but it has an hourly quota and runs out of org credits. If a PR shows a "Review limit reached" / "out of usage credits" message instead of an actual review (or CodeRabbit otherwise fails to produce one), run the `/review` skill locally against the PR. Then act on the findings the same way you would CodeRabbit's: push the high-confidence, unambiguous fixes directly, and escalate anything ambiguous, architectural, or open to interpretation by asking first rather than guessing.
 
+Reply to review comments as you address them, saying what changed or why you disagree, so the reviewer doesn't have to diff the branch to find out. Replies are GitHub prose like any other, so they carry the [AI Attribution](#ai-attribution) marker.
+
 When reviewing a PR, always include the same public API changes list described above, and call out anything breaking per [Branch Targeting](#branch-targeting).
 
 ## Releases


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` never said whether to answer a reviewer, only how to act on the findings, so replying was left to each agent's own instructions.
- Adds one line to the Reviews section: reply as you address a comment, saying what changed or why you disagree, and carry the existing AI Attribution marker since a reply is GitHub prose like any other.

## Public API changes

None. Docs only.

## Test plan

- `bun remark CONTRIBUTING.md --quiet --frail` (clean).

(Written by Opus 5)