### PR TITLE
fix(moq-video): gate `worker` and `probe` to where their consumers compile

### DIFF
--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -21,7 +21,9 @@ use crate::{Error, Frame};
 
 mod openh264;
 
-#[cfg(test)]
+// Only the thread-confinement tests ask for this backend, and macOS is exempt
+// from those by design: the inline sink decodes on the calling thread.
+#[cfg(all(test, not(target_os = "macos")))]
 pub(crate) mod probe;
 
 #[cfg(target_os = "macos")]
@@ -110,14 +112,14 @@ const SOFTWARE: Candidate = Candidate {
 /// Test-only backends. Deliberately in neither list above, so `Auto` /
 /// `Hardware` / `Software` can never select one: they exist to be asked for by
 /// name.
-#[cfg(test)]
+#[cfg(all(test, not(target_os = "macos")))]
 const NAMED_ONLY: &[Candidate] = &[Candidate {
 	name: probe::NAME,
 	supports: |c| matches!(c, Codec::H264),
 	open: probe::Probe::open,
 }];
 
-#[cfg(not(test))]
+#[cfg(not(all(test, not(target_os = "macos"))))]
 const NAMED_ONLY: &[Candidate] = &[];
 
 /// Open the best decoder for `codec` and `config`, trying candidates in priority

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -23,7 +23,9 @@ use crate::{Error, Frame};
 
 mod openh264;
 
-#[cfg(test)]
+// Only the thread-confinement tests ask for this backend, and macOS is exempt
+// from those by design: the inline sink encodes on the calling thread.
+#[cfg(all(test, not(target_os = "macos")))]
 pub(crate) mod probe;
 
 #[cfg(target_os = "macos")]
@@ -125,14 +127,14 @@ const SOFTWARE: &[Candidate] = &[Candidate {
 /// Test-only backends. Deliberately in neither list above, so `Auto` /
 /// `Hardware` / `Software` can never select one: they exist to be asked for by
 /// name.
-#[cfg(test)]
+#[cfg(all(test, not(target_os = "macos")))]
 const NAMED_ONLY: &[Candidate] = &[Candidate {
 	name: probe::NAME,
 	codecs: &[Codec::H264],
 	open: probe::Probe::open,
 }];
 
-#[cfg(not(test))]
+#[cfg(not(all(test, not(target_os = "macos"))))]
 const NAMED_ONLY: &[Candidate] = &[];
 
 /// Open the best encoder for `config.codec` + `config.kind`, trying candidates

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -74,6 +74,9 @@ mod color;
 mod error;
 pub mod frame;
 mod size;
+// Only the threaded sinks use this, and macOS decodes and encodes inline on the
+// calling thread instead, so there is no worker there to build.
+#[cfg(not(target_os = "macos"))]
 mod worker;
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
Fixes 13 `-D dead-code` errors that break `just rs ci` on macOS.

## Summary

- **Root cause**: `mod worker` in `moq-video/src/lib.rs` was declared unconditionally, but its only consumers are the `mod threaded` blocks in `encode/sink.rs` and `decode/sink.rs`, both gated `#[cfg(not(target_os = "macos"))]`. On macOS the module compiled with nothing referencing it, so all six of its items read as dead.
- `mod probe` in both `encode/backend/mod.rs` and `decode/backend/mod.rs` has the same shape one layer over: it is `#[cfg(test)]`, but the only callers are the sinks' thread-confinement tests, gated `#[cfg(all(test, not(target_os = "macos")))]`. That stranded seven more items (`EXCLUSIVE`, `exclusive`, `take`, `hold`) in the lib test target. Gating only `worker` would have left `just rs ci` red, so both are fixed here.
- The fix is one line per site: give each module the cfg its consumers already carry, so it simply is not compiled where nothing uses it. `probe::Probe`/`NAME` stay live wherever the tests compile, and no macOS test asks for the probe backend.
- This was Linux-green because PR CI is Linux-only, where both gated blocks compile. It arrived with be8e61aac (#2608) and only blocked macOS developers running `just rs ci` locally.

## Not caught by `just rs macos`

Worth knowing for anyone chasing this class of bug: `just rs macos` runs plain `cargo check`, and `dead_code` is warn-by-default. The `-D dead-code` promotion comes from the `-D warnings` that `just rs ci` passes to clippy. Verified by stashing the fix: `just rs macos` emits 14 dead-code warnings on the original code but still exits 0. `just rs ci` is the real macOS gate here.

## Public API changes

None. `worker` and `probe` are private modules; every affected item is private or `pub(crate)`.

## Other platforms

Linux and Windows could not be compiled here (cross-compiling died on the nix toolchain lacking Linux std; Windows needs a Windows host), but the change is provably a no-op on both. Where `target_os != "macos"`, `not(target_os = "macos")` is `true`, so `all(test, true)` reduces to `test` and `not(all(test, true))` to `not(test)` -- the exact original attributes -- and `mod worker` is included as before. Windows matters most, since `worker.rs` exists for the Media Foundation COM-apartment constraint; it is unaffected because the gate added is the one its consumer `mod threaded` already had.

## Test plan

On macOS (aarch64-apple-darwin):

- `just rs ci` -- exit 0, 2576 tests passed, 12 skipped (was failing before)
- `cargo clippy -p moq-video --all-targets --all-features -- -D warnings` -- clean
- `just rs macos` -- clean
- `cargo fmt -p moq-video -- --check` -- clean
- `just rs test -p moq-video` -- 68/68 pass

No regression test: the failure is a compile-time lint on a platform with no automated gate (`rs/CLAUDE.md` documents that Mac runners are too expensive for a per-PR check), so there is nothing a test can encode. The guard stays "someone runs `just rs ci` on a Mac". Happy to add a macOS clippy job scoped to `rs/moq-video/**` in a follow-up if that gap is worth closing.

## Cross-Package Sync

No rows apply: no wire format, FFI surface, CLI interface, or public API changed.

(Written by Opus 5)