### PR TITLE
fix(publish): stop the bandwidth estimate from re-probing the video codec

### DIFF
--- a/js/publish/src/video/encoder.test.ts
+++ b/js/publish/src/video/encoder.test.ts
@@ -4,7 +4,17 @@ import { Signal } from "@moq/signals";
 import { Encoder } from "./encoder";
 
 class FakeVideoEncoder {
+	// How many times the hardware has been probed, so a test can assert it isn't re-probed.
+	static probes = 0;
+
 	state: CodecState = "unconfigured";
+
+	static async isConfigSupported(config: VideoEncoderConfig): Promise<{ supported: boolean }> {
+		FakeVideoEncoder.probes++;
+		// Pretend the GPU takes a while, like a real probe under load.
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		return { supported: config.codec.startsWith("avc1") };
+	}
 
 	configure(): void {
 		this.state = "configured";
@@ -69,3 +79,77 @@ test("encoding tracks encoder config in its child effect", async () => {
 		warn.mockRestore();
 	}
 });
+
+// A bandwidth sample used to rerun the whole resolve effect, which blanked the resolved config (and
+// with it the catalog entry) and re-probed the hardware for a codec. A subscriber returning during
+// that window got a VideoEncoder that was never configured, so every captured frame was dropped.
+// https://github.com/moq-dev/moq/issues/2635
+test("a bandwidth estimate updates the bitrate without blanking the config or re-probing", async () => {
+	using _videoEncoder = installFakeVideoEncoder();
+
+	const track = new Moq.Track.Producer("video").accept();
+	const rendition = {
+		config: new Signal(undefined),
+		track: new Signal<Moq.Track.Producer | undefined>(track),
+		close: () => track.close(),
+	};
+	const capture = {
+		in: {
+			source: new Signal({
+				getSettings: () => ({ frameRate: 30 }),
+				getConstraints: () => ({}),
+			} as never),
+		},
+		out: {
+			frame: new Signal<VideoFrame | undefined>({ codedWidth: 640, codedHeight: 480 } as never),
+		},
+	};
+	const bandwidth = new Signal<number | undefined>(10_000_000);
+
+	const encoder = new Encoder("video", {
+		enabled: true,
+		broadcast: { video: () => rendition } as never,
+		capture: capture as never,
+		bandwidth,
+	});
+
+	try {
+		await settle();
+
+		const resolved = encoder.out.resolved.peek();
+		expect(resolved).toBeDefined();
+		expect(encoder.out.catalog.peek()).toBeDefined();
+
+		const probes = FakeVideoEncoder.probes;
+		expect(probes).toBeGreaterThan(0);
+
+		// A poll lands with an estimate low enough to cap the bitrate.
+		bandwidth.set(200_000);
+		await settle();
+
+		// The cap applied, and nothing went blank on the way there.
+		expect(encoder.out.resolved.peek()?.bitrate).toBe(180_000);
+		expect(encoder.out.resolved.peek()?.codec).toBe(resolved?.codec);
+		expect(encoder.out.catalog.peek()).toBeDefined();
+
+		// The codec doesn't depend on bandwidth, so the hardware is not asked again.
+		expect(FakeVideoEncoder.probes).toBe(probes);
+
+		// Repeated samples, as the 100ms poll delivers. The config stays live throughout.
+		for (let i = 0; i < 20; i++) {
+			bandwidth.set(1_000_000 + i * 13_000);
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(encoder.out.resolved.peek()).toBeDefined();
+			expect(encoder.out.catalog.peek()).toBeDefined();
+		}
+
+		expect(FakeVideoEncoder.probes).toBe(probes);
+	} finally {
+		encoder.close();
+	}
+});
+
+async function settle(): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, 200));
+}

--- a/js/publish/src/video/encoder.test.ts
+++ b/js/publish/src/video/encoder.test.ts
@@ -7,13 +7,19 @@ class FakeVideoEncoder {
 	// How many times the hardware has been probed, so a test can assert it isn't re-probed.
 	static probes = 0;
 
+	// Every accepted probe, so a test can assert a published config was actually validated.
+	static accepted: string[] = [];
+
 	state: CodecState = "unconfigured";
 
 	static async isConfigSupported(config: VideoEncoderConfig): Promise<{ supported: boolean }> {
 		FakeVideoEncoder.probes++;
 		// Pretend the GPU takes a while, like a real probe under load.
 		await new Promise((resolve) => setTimeout(resolve, 5));
-		return { supported: config.codec.startsWith("avc1") };
+
+		const supported = config.codec.startsWith("avc1");
+		if (supported) FakeVideoEncoder.accepted.push(probeKey(config));
+		return { supported };
 	}
 
 	configure(): void {
@@ -152,4 +158,75 @@ test("a bandwidth estimate updates the bitrate without blanking the config or re
 
 async function settle(): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, 200));
+}
+
+// The codec probe only speaks for the dimensions and codec filter it ran against. Those live in
+// separate effects, which observe a change in whatever order they happen to be subscribed in, so
+// the resolved config must never pair a fresh dimension with a stale probe.
+// https://github.com/moq-dev/moq/issues/2635
+test("every published config was probed for its own codec and dimensions", async () => {
+	using _videoEncoder = installFakeVideoEncoder();
+	FakeVideoEncoder.accepted = [];
+
+	const track = new Moq.Track.Producer("video").accept();
+	const rendition = {
+		config: new Signal(undefined),
+		track: new Signal<Moq.Track.Producer | undefined>(track),
+		close: () => track.close(),
+	};
+	const capture = {
+		in: {
+			source: new Signal({
+				getSettings: () => ({ frameRate: 30 }),
+				getConstraints: () => ({}),
+			} as never),
+		},
+		out: {
+			frame: new Signal<VideoFrame | undefined>({ codedWidth: 1280, codedHeight: 720 } as never),
+		},
+	};
+	const bandwidth = new Signal<number | undefined>(10_000_000);
+
+	const encoder = new Encoder("video", {
+		enabled: true,
+		broadcast: { video: () => rendition } as never,
+		capture: capture as never,
+		bandwidth,
+	});
+
+	// Check at emission time, not afterwards: a probe that lands later would otherwise excuse a
+	// config that was already handed to a subscriber against a stale one.
+	const published: string[] = [];
+	const violations: string[] = [];
+	const unsubscribe = encoder.out.resolved.subscribe((config) => {
+		if (!config) return;
+
+		const key = probeKey(config);
+		published.push(key);
+		if (!FakeVideoEncoder.accepted.includes(key)) violations.push(key);
+	});
+
+	try {
+		encoder.config.set({ maxScale: 0.25 });
+		await settle();
+		expect(published.length).toBeGreaterThan(0);
+
+		// A resize landing in the same batch as a bandwidth sample, which is likely given the
+		// element polls the estimate every 100ms. The resize schedules the dimensions effect and
+		// the sample schedules the resolve effect, so the resolve effect runs with the new
+		// dimensions already written while the probe still holds the result for the old ones.
+		capture.out.frame.set({ codedWidth: 640, codedHeight: 480 } as never);
+		bandwidth.set(3_000_000);
+		await settle();
+
+		expect(published.length).toBeGreaterThan(1);
+		expect(violations).toEqual([]);
+	} finally {
+		unsubscribe();
+		encoder.close();
+	}
+});
+
+function probeKey(config: { codec: string; width: number; height: number }): string {
+	return `${config.codec}@${config.width}x${config.height}`;
 }

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -3,7 +3,16 @@ import * as Container from "@moq/hang/container";
 import * as Util from "@moq/hang/util";
 import type * as Moq from "@moq/net";
 import { Time } from "@moq/net";
-import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
+import {
+	type Computed,
+	Effect,
+	type Getter,
+	getter,
+	type Inputs,
+	type Readonlys,
+	readonlys,
+	Signal,
+} from "@moq/signals";
 import type { Broadcast } from "../broadcast";
 import type { Capture } from "./capture";
 import type { Source } from "./types";
@@ -114,6 +123,13 @@ export class Encoder {
 	// The output dimensions of the video in pixels.
 	#dimensions = new Signal<{ width: number; height: number } | undefined>(undefined);
 
+	// The codec the browser will actually encode with, probed against the hardware.
+	#codec = new Signal<{ codec: string; hardwareAcceleration: HardwareAcceleration } | undefined>(undefined);
+
+	// Only the codec prefix the user asked for, narrowed out of `config` so tuning any other knob
+	// doesn't re-probe the hardware.
+	#codecFilter: Computed<string>;
+
 	#signals = new Effect();
 
 	constructor(name: string, props?: EncoderProps) {
@@ -125,8 +141,10 @@ export class Encoder {
 			bandwidth: getter(props?.bandwidth),
 		};
 		this.config = Signal.from(props?.config);
+		this.#codecFilter = this.#signals.computed((effect) => effect.get(this.config)?.codec ?? "");
 
 		this.#signals.run(this.#runCatalog.bind(this));
+		this.#signals.run(this.#runCodec.bind(this));
 		this.#signals.run(this.#runResolved.bind(this));
 		this.#signals.run(this.#runDimensions.bind(this));
 		this.#signals.run(this.#runRegister.bind(this));
@@ -252,6 +270,27 @@ export class Encoder {
 		effect.set(this.#out.catalog, catalog);
 	}
 
+	// Probe the hardware for the best codec. Deliberately depends on as little as possible: every
+	// rerun blanks the codec (and with it the resolved config and the catalog entry) for however long
+	// the probe takes, which on a busy GPU process is a long time.
+	#runCodec(effect: Effect): void {
+		if (!effect.get(this.in.enabled)) return;
+
+		const dimensions = effect.get(this.#dimensions);
+		if (!dimensions) return;
+
+		const required = effect.get(this.#codecFilter) ?? "";
+
+		effect.spawn(async () => {
+			const detected = await this.#bestCodec(required, dimensions);
+			if (!detected) return;
+
+			effect.set(this.#codec, detected);
+		});
+	}
+
+	// Size the bitrate for the detected codec. Synchronous, so a new bandwidth estimate updates the
+	// config within the same microtask instead of leaving it blank while something re-derives it.
 	#runResolved(effect: Effect): void {
 		// NOTE: dimensions already factors in user provided maxPixels.
 		// It's a separate effect in order to deduplicate.
@@ -266,6 +305,11 @@ export class Encoder {
 		const dimensions = effect.get(this.#dimensions);
 		if (!dimensions) return;
 
+		const detected = effect.get(this.#codec);
+		if (!detected) return;
+
+		const { codec, hardwareAcceleration } = detected;
+
 		const settings = source.getSettings();
 
 		// Get the user provided config.
@@ -277,78 +321,54 @@ export class Encoder {
 		const maxPixels = user.maxPixels ?? dimensions.width * dimensions.height;
 		const bitrateScale = user.bitrateScale ?? 0.07;
 
-		effect.spawn(async () => {
-			const detectedCodec = await this.#bestCodec(effect);
-			if (!detectedCodec) return;
+		// TARGET BITRATE CALCULATION (h264)
+		// 480p@30 = 1.0mbps
+		// 480p@60 = 1.5mbps
+		// 720p@30 = 2.5mbps
+		// 720p@60 = 3.5mpbs
+		// 1080p@30 = 4.5mbps
+		// 1080p@60 = 6.0mbps
 
-			const { codec, hardwareAcceleration } = detectedCodec;
+		// 30fps is the baseline, applying a multiplier for higher framerates.
+		// Framerate does not cause a multiplicative increase in bitrate because of delta encoding.
+		// TODO Make this better.
+		const framerateFactor = 30.0 + (framerate - 30) / 2;
 
-			// TARGET BITRATE CALCULATION (h264)
-			// 480p@30 = 1.0mbps
-			// 480p@60 = 1.5mbps
-			// 720p@30 = 2.5mbps
-			// 720p@60 = 3.5mpbs
-			// 1080p@30 = 4.5mbps
-			// 1080p@60 = 6.0mbps
+		// ACTUAL BITRATE CALCULATION
+		// 480p@30 = 409920 * 30 * 0.07 = 0.9 Mb/s
+		// 480p@60 = 409920 * 45 * 0.07 = 1.3 Mb/s
+		// 720p@30 = 921600 * 30 * 0.07 = 1.9 Mb/s
+		// 720p@60 = 921600 * 45 * 0.07 = 2.9 Mb/s
+		// 1080p@30 = 2073600 * 30 * 0.07 = 4.4 Mb/s
+		// 1080p@60 = 2073600 * 45 * 0.07 = 6.5 Mb/s
+		let bitrate = Math.round(maxPixels * bitrateScale * framerateFactor * codecBitrateScale(codec));
 
-			// 30fps is the baseline, applying a multiplier for higher framerates.
-			// Framerate does not cause a multiplicative increase in bitrate because of delta encoding.
-			// TODO Make this better.
-			const framerateFactor = 30.0 + (framerate - 30) / 2;
-			let bitrate = Math.round(maxPixels * bitrateScale * framerateFactor);
+		bitrate = Math.round(Math.min(bitrate, user.maxBitrate || bitrate));
 
-			// ACTUAL BITRATE CALCULATION
-			// 480p@30 = 409920 * 30 * 0.07 = 0.9 Mb/s
-			// 480p@60 = 409920 * 45 * 0.07 = 1.3 Mb/s
-			// 720p@30 = 921600 * 30 * 0.07 = 1.9 Mb/s
-			// 720p@60 = 921600 * 45 * 0.07 = 2.9 Mb/s
-			// 1080p@30 = 2073600 * 30 * 0.07 = 4.4 Mb/s
-			// 1080p@60 = 2073600 * 45 * 0.07 = 6.5 Mb/s
-
-			// We scale the bitrate for more efficient codecs.
-			// TODO This shouldn't be linear, as the efficiency is very similar at low bitrates.
-			if (codec.startsWith("avc1")) {
-				bitrate *= 1.0; // noop
-			} else if (codec.startsWith("hev1")) {
-				bitrate *= 0.7;
-			} else if (codec.startsWith("vp09")) {
-				bitrate *= 0.8;
-			} else if (codec.startsWith("av01")) {
-				bitrate *= 0.6;
-			} else if (codec === "vp8") {
-				// Worse than H.264 but it's a backup plan.
-				bitrate *= 1.1;
-			} else {
-				throw new Error(`unknown codec: ${codec}`);
+		// If no explicit maxBitrate, cap to the estimated send bandwidth (with 90% safety margin).
+		if (!user.maxBitrate) {
+			const estimate = effect.get(this.in.bandwidth);
+			if (estimate != null) {
+				// Reserve ~10% for audio and protocol overhead.
+				const cap = Math.round(estimate * 0.9);
+				bitrate = Math.min(bitrate, cap);
 			}
+		}
 
-			bitrate = Math.round(Math.min(bitrate, user.maxBitrate || bitrate));
+		const config: VideoEncoderConfig = {
+			codec,
+			width: dimensions.width,
+			height: dimensions.height,
+			framerate,
+			bitrate,
+			avc: codec.startsWith("avc1") ? { format: "annexb" } : undefined,
+			// @ts-expect-error Typescript needs to be updated.
+			hevc: codec.startsWith("hev1") ? { format: "annexb" } : undefined,
+			latencyMode: "realtime",
+			hardwareAcceleration,
+		};
 
-			// If no explicit maxBitrate, cap to the estimated send bandwidth (with 90% safety margin).
-			if (!user.maxBitrate) {
-				const estimate = effect.get(this.in.bandwidth);
-				if (estimate != null) {
-					// Reserve ~10% for audio and protocol overhead.
-					const cap = Math.round(estimate * 0.9);
-					bitrate = Math.min(bitrate, cap);
-				}
-			}
-
-			const config: VideoEncoderConfig = {
-				codec,
-				width: dimensions.width,
-				height: dimensions.height,
-				framerate,
-				bitrate,
-				avc: codec.startsWith("avc1") ? { format: "annexb" } : undefined,
-				// @ts-expect-error Typescript needs to be updated.
-				hevc: codec.startsWith("hev1") ? { format: "annexb" } : undefined,
-				latencyMode: "realtime",
-				hardwareAcceleration,
-			};
-
-			effect.set(this.#out.resolved, config);
-		});
+		effect.set(this.#out.resolved, config);
 	}
 
 	#runDimensions(effect: Effect): void {
@@ -385,19 +405,16 @@ export class Encoder {
 	}
 
 	// Try to determine the best config for the given settings.
-	async #bestCodec(effect: Effect): Promise<
+	async #bestCodec(
+		required: string,
+		dimensions: { width: number; height: number },
+	): Promise<
 		| {
 				codec: string;
 				hardwareAcceleration: HardwareAcceleration;
 		  }
 		| undefined
 	> {
-		const config = effect.get(this.config);
-		const required = config?.codec ?? "";
-
-		const dimensions = effect.get(this.#dimensions);
-		if (!dimensions) return;
-
 		// A list of codecs to try, in order of preference.
 		const HARDWARE_CODECS = [
 			// VP9
@@ -510,6 +527,19 @@ export class Encoder {
 	close() {
 		this.#signals.close();
 	}
+}
+
+// Scale the bitrate for more efficient codecs, relative to H.264.
+// TODO This shouldn't be linear, as the efficiency is very similar at low bitrates.
+function codecBitrateScale(codec: string): number {
+	if (codec.startsWith("avc1")) return 1.0;
+	if (codec.startsWith("hev1")) return 0.7;
+	if (codec.startsWith("vp09")) return 0.8;
+	if (codec.startsWith("av01")) return 0.6;
+	// Worse than H.264 but it's a backup plan.
+	if (codec === "vp8") return 1.1;
+
+	throw new Error(`unknown codec: ${codec}`);
 }
 
 function sourceConstraintPixels(source: Source): number | undefined {

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -123,8 +123,8 @@ export class Encoder {
 	// The output dimensions of the video in pixels.
 	#dimensions = new Signal<{ width: number; height: number } | undefined>(undefined);
 
-	// The codec the browser will actually encode with, probed against the hardware.
-	#codec = new Signal<{ codec: string; hardwareAcceleration: HardwareAcceleration } | undefined>(undefined);
+	// The codec the browser will actually encode with, tagged with the inputs it was probed against.
+	#codec = new Signal<Detected | undefined>(undefined);
 
 	// Only the codec prefix the user asked for, narrowed out of `config` so tuning any other knob
 	// doesn't re-probe the hardware.
@@ -285,7 +285,7 @@ export class Encoder {
 			const detected = await this.#bestCodec(required, dimensions);
 			if (!detected) return;
 
-			effect.set(this.#codec, detected);
+			effect.set(this.#codec, { ...detected, required, ...dimensions });
 		});
 	}
 
@@ -307,6 +307,15 @@ export class Encoder {
 
 		const detected = effect.get(this.#codec);
 		if (!detected) return;
+
+		// A probe only speaks for the inputs it ran against. Changing them reruns the probe, which
+		// clears the stale result, but a bandwidth sample landing in the same batch schedules this
+		// effect independently: it then runs against dimensions that are already written while the
+		// probe hasn't been torn down yet. Wait for a probe that matches rather than publishing a
+		// pairing the hardware never accepted.
+		const required = effect.get(this.#codecFilter) ?? "";
+		if (detected.required !== required) return;
+		if (detected.width !== dimensions.width || detected.height !== dimensions.height) return;
 
 		const { codec, hardwareAcceleration } = detected;
 
@@ -528,6 +537,17 @@ export class Encoder {
 		this.#signals.close();
 	}
 }
+
+// A hardware probe result, carrying the inputs it ran against so a consumer can tell whether it
+// still applies.
+type Detected = {
+	codec: string;
+	hardwareAcceleration: HardwareAcceleration;
+	// The codec prefix the user required at probe time.
+	required: string;
+	width: number;
+	height: number;
+};
 
 // Scale the bitrate for more efficient codecs, relative to H.264.
 // TODO This shouldn't be linear, as the efficiency is very similar at low bitrates.


### PR DESCRIPTION
## Summary

Investigation of #2635. The report's mechanism (a resubscribe rebuilds the encode pipeline) is real but doesn't explain a 44s blackout on its own, because a rebuilt `VideoEncoder` reconfigures a microtask later. The missing half is the root cause fixed here.

**Root cause.** `Encoder.#runResolved` read `in.bandwidth`, and `<moq-publish>` repolls `estimatedSendRate` every 100ms (`BANDWIDTH_POLL`). That estimate jitters on every sample, so the resolve effect reran ~10x/second, and each rerun:

1. blanked `out.resolved` to `undefined` (the `effect.set` cleanup restores the default), then
2. restarted `#bestCodec` from scratch: up to 13 sequential `VideoEncoder.isConfigSupported()` GPU round-trips.

Measured against the real `Encoder` with a 30ms-per-probe fake: `out.resolved` is `undefined` **77% of wall-clock** in steady state, with nobody churning anything.

In steady state that stays invisible, because the existing `VideoEncoder` is already configured and nothing reconfigures it. Subscriber churn removes that cover: it destroys the configured encoder, and the fresh one is only configured by the effect reading `out.resolved`. While that's blank the new encoder stays `unconfigured` and `if (encoder.state !== "configured")` silently drops every captured frame. That accounts for the parts of #2635 the reported mechanism doesn't: `out.active` stays `true`, capture stays live, no backlog floods on recovery (frames dropped, not queued), and recovery lands at a random time 15-52s later, whenever one detection pass finally completes without a poll landing on it.

**Second symptom, no churn required.** `#runCatalog` gates on `out.resolved`, so the same blanking dropped the video rendition out of the published catalog ~10x/second. Every catalog change is a new group pushed to every subscriber.

**Fix.** Split the one async resolve effect in two:

- `#runCodec` probes the hardware. Depends only on `enabled`, `#dimensions`, and a new `#codecFilter` computed that narrows `config.codec` out of the config object, so tuning `frameRate` or `maxBitrate` doesn't re-probe either.
- `#runResolved` is now fully synchronous: read the probe, size the bitrate. A bandwidth sample reruns only this, and the blank-then-set happens in one microtask, so it coalesces and subscribers never observe a gap.

`#bestCodec` takes `(required, dimensions)` instead of an `Effect`, which is what lets it move off the resolve path. The codec bitrate multiplier came out as a `codecBitrateScale` helper (same values, same throw on an unknown codec) since the if/else chain no longer read well inline.

**Second commit: don't publish a codec the hardware wasn't probed for.** Splitting the effects put the probe result and the output dimensions in separate signals, so the resolve effect could pair one with the other. Changing an input reruns the probe and clears the stale result, but a bandwidth sample landing in the same batch as a resize schedules the resolve effect *independently* of the probe effect: it then runs against dimensions that are already written (`Signal.set` writes the value synchronously and defers only notification) while the stale probe hasn't been torn down yet. The published config then pairs new dimensions with the previous probe, and `configure()` can be handed a combination the hardware never accepted. With the estimate polled every 100ms, a source resize (screen share, camera switch) hits that window readily. Fixed by tagging the probe with the dimensions and codec filter it ran against and publishing nothing until they match.

Not fixed here: a resubscribe still rebuilds the `VideoEncoder`. With this change that costs a keyframe and a reconfigure rather than a blackout, so it's a cost question rather than a correctness one. Left for a separate PR.

Both branches are affected identically. `#runResolved`, `#runCatalog`, `in.bandwidth` and `BANDWIDTH_POLL` are byte-identical between `main` and `dev` (the `encoder.ts` diff between them is only the frame-delivery path), which answers the open question in the issue thread about whether `main` reproduces.

## Public API changes

None. `#codec`, `#codecFilter` and the `Detected` type are private, `#bestCodec`'s signature is private, and `out.resolved` / `out.catalog` are unchanged. Nothing in the Cross-Package Sync table applies.

## Test plan

Two regression tests in `js/publish/src/video/encoder.test.ts`, both verified to fail against the unfixed encoder and pass with the fix:

- A bandwidth change updates `bitrate` while `out.resolved` and `out.catalog` stay defined, and `isConfigSupported` is not called again. Fails unfixed with 3 probes becoming 6.
- Every config published to `out.resolved` was probed for its own codec and dimensions, asserted **at emission time** via a subscription rather than by peeking after everything settles (a probe landing later would otherwise excuse a config already handed to a subscriber). Fails unfixed with `avc1.640028@320x240` published unprobed.

Other verification:

- `bun test js/publish/src/video/` — 8 pass.
- `tsc --noEmit` clean for `@moq/publish`; biome clean.
- `just js check`: one failure in `moq-doc check`, a YAML parse error in `doc/.vitepress/drafts.ts`. Pre-existing, confirmed identical on a clean tree.
- Not verified in a real browser: the blackout needs `isConfigSupported` latency to degrade under GPU pressure, which the unit fake can't model. The mechanism itself is measured above.

Closes #2635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)
