### PR TITLE
fix(net): let the accepting side pick the retention window when the wire carries none

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -471,6 +471,15 @@ headroom = "2GiB"
 # stays cached. The latest group of every track is always retained, as it is
 # the live edge. Unbounded (each track keeps its own window) when unset.
 duration = "30s"
+
+# Retention window for a track whose publisher advertises none ("30s"), which
+# is every moq-transport peer and moq-lite 01-04: those wire formats carry no
+# publisher retention property, so the relay picks the window instead. Raise it
+# when this relay fronts a segmented egress (HLS/DASH) that advertises a longer
+# playlist window, since serving an older segment is a cache hit that far back.
+# moq-lite 05+ publishers advertise their own window and keep it. Defaults to
+# 5s, and `duration` still caps it.
+latency_default = "30s"
 ```
 
 The `capacity` budget counts group payload bytes, not process RSS, so leave
@@ -486,9 +495,13 @@ until it resumes or the broadcast closes; under memory pressure the byte budget
 is repaid by the tracks that are still writing. A publisher that disconnects has
 its groups released once the broadcast closes (see `cluster.linger`).
 
-All three flags also accept CLI arguments (`--cache-capacity`,
-`--cache-headroom`, `--cache-duration`) and environment variables
-(`MOQ_CACHE_CAPACITY`, `MOQ_CACHE_HEADROOM`, `MOQ_CACHE_DURATION`).
+`duration` only ever lowers retention. `latency_default` is the one knob that
+raises it, and only for peers whose protocol never told us what to keep.
+
+All four flags also accept CLI arguments (`--cache-capacity`,
+`--cache-headroom`, `--cache-duration`, `--cache-latency-default`) and
+environment variables (`MOQ_CACHE_CAPACITY`, `MOQ_CACHE_HEADROOM`,
+`MOQ_CACHE_DURATION`, `MOQ_CACHE_LATENCY_DEFAULT`).
 
 ### \[iroh]
 

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1281,6 +1281,109 @@ async fn broadcast_negotiate_client_all_server_transport_19() {
 	broadcast_test("moqt", None, Some("moq-transport-19")).await;
 }
 
+// ── Retention window (track::Info::latency_max) ─────────────────────
+
+/// The window the publisher advertises, distinct from both the model default and
+/// the accepting side's [`LATENCY_DEFAULT`] so the assertions can tell them apart.
+const LATENCY_PUBLISHED: Duration = Duration::from_secs(2);
+
+/// The window the subscribing origin assigns to a track whose publisher advertises
+/// none. Deliberately longer than the publisher's, like a relay fronting a
+/// segmented egress that serves a playlist window's worth of history.
+const LATENCY_DEFAULT: Duration = Duration::from_secs(30);
+
+/// Publish a track advertising [`LATENCY_PUBLISHED`], subscribe to it through an
+/// origin configured with [`LATENCY_DEFAULT`], and return the window the subscriber
+/// ends up with.
+async fn latency_max_test(version: &str) -> Duration {
+	let version: moq_net::Version = version.parse().expect("invalid version");
+
+	// ── publisher (server) ──────────────────────────────────────────
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin
+		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
+		.expect("create broadcast");
+	let info = moq_net::track::Info::default().with_latency_max(LATENCY_PUBLISHED);
+	let track = broadcast.create_track("video", info).expect("create track");
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("[::]:0".to_string());
+	server_config.tls.generate = vec!["localhost".into()];
+	server_config.version = vec![version];
+	let mut server = server_config.init().expect("init server");
+	let addr = server.local_addr().expect("local addr");
+
+	let handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("accept");
+		let session = request.with_publisher(&pub_origin).ok().await?;
+		let _broadcast = broadcast;
+		let _track = track;
+		let _ = session.closed().await;
+		Ok::<_, anyhow::Error>(())
+	});
+
+	// ── subscriber (client) ─────────────────────────────────────────
+	// The origin the session writes remote broadcasts into decides the window for
+	// tracks whose protocol can't carry the publisher's.
+	let sub_origin = moq_net::origin::Info::new(Origin::random())
+		.with_latency_default(LATENCY_DEFAULT)
+		.produce();
+	let mut announcements = sub_origin.consume().announced();
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	client_config.version = vec![version];
+	let client = client_config.init().expect("init client");
+	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
+	let session = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url))
+		.await
+		.expect("connect timeout")
+		.expect("connect failed");
+
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
+	assert_eq!(path.as_str(), "test");
+	let broadcast = broadcast.expect("expected announce");
+
+	let sub = broadcast
+		.track("video")
+		.unwrap()
+		.subscribe(None)
+		.await
+		.expect("subscribe failed");
+	let latency_max = sub.info().latency_max;
+
+	drop(sub);
+	drop(session);
+	handle.await.expect("server panicked").expect("server failed");
+
+	latency_max
+}
+
+/// moq-lite-05 carries the publisher's window in TRACK_INFO, so it wins over the
+/// subscribing origin's default.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_latency_max_lite_05() {
+	assert_eq!(latency_max_test("moq-lite-05").await, LATENCY_PUBLISHED);
+}
+
+/// moq-lite-01 has no TRACK stream, so the publisher's window never reaches us and
+/// the subscribing origin's default applies.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_latency_max_lite_01() {
+	assert_eq!(latency_max_test("moq-lite-01").await, LATENCY_DEFAULT);
+}
+
+/// moq-transport carries no publisher retention property at all, so an IETF-relayed
+/// track used to fall back to the 5s model default no matter how the deployment was
+/// configured (issue #2645).
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_latency_max_transport_18() {
+	assert_eq!(latency_max_test("moq-transport-18").await, LATENCY_DEFAULT);
+}
+
 // ── WebTransport (https://) – same version on both sides ────────────
 
 #[tracing_test::traced_test]

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -606,7 +606,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Set the track timescale to microseconds: IETF object timestamps default to
 		// microseconds, and `create_frame` normalizes each frame into the track scale.
 		// Accepting at milliseconds (the default) would truncate microsecond precision.
-		let info = track::Info::default().with_timescale(crate::Timescale::MICRO);
+		//
+		// moq-transport carries no publisher retention property, so the window comes
+		// from the accepting side (see `origin::Info::latency_default`) rather than
+		// from the peer.
+		let info = track::Info::default()
+			.with_timescale(crate::Timescale::MICRO)
+			.with_latency_max(self.origin.latency_default());
 		let mut track = request.accept(info);
 
 		let request_id = match self.control.next_request_id().await {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1232,7 +1232,10 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				}
 			}
 		} else {
-			(track::Info::default(), None)
+			// No TRACK stream, so the publisher's retention window never reaches us: the
+			// accepting side picks it (see `origin::Info::latency_default`).
+			let info = track::Info::default().with_latency_max(self.subscriber.origin.latency_default());
+			(info, None)
 		};
 
 		// Accept with the resolved info. The origin splices this session's copy
@@ -1635,7 +1638,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// live subscription); otherwise the group inherits the accepted timescale.
 		// Relay-served FETCH is lite-05+, so `timescale` is `Some`; fall back to the
 		// default scale defensively rather than panicking.
-		let group_info = track::Info::default().with_timescale(timescale.unwrap_or_default());
+		let group_info = track::Info::default()
+			.with_timescale(timescale.unwrap_or_default())
+			.with_latency_max(subscriber.origin.latency_default());
 		let mut producer = match request.accept(group_info) {
 			Ok(producer) => producer,
 			Err(err) => {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -117,6 +117,17 @@ pub struct Info {
 	/// ceiling, leaving each track's own window in force.
 	pub cache_duration: Duration,
 
+	/// The retention window given to a track whose publisher advertises none.
+	///
+	/// moq-lite 05+ carries [`latency_max`](track::Info::latency_max) in TRACK_INFO, so a
+	/// track relayed over it keeps the window its publisher chose. Every moq-transport
+	/// draft and moq-lite 01-04 have no such wire property, so a track arriving over one
+	/// of them lands here instead. Raise it on a relay fronting a segmented egress
+	/// (HLS/DASH), which needs a playlist window's worth of history rather than the live
+	/// edge. Defaults to [`track::DEFAULT_LATENCY_MAX`], and [`Self::cache_duration`]
+	/// still caps it.
+	pub latency_default: Duration,
+
 	/// How long a broadcast under this origin outlives the *ungraceful* loss of its
 	/// last source before closing. Within the window the path stays announced and a
 	/// source re-attaching at it (a session reconnecting, a publisher re-announcing)
@@ -136,6 +147,7 @@ impl Default for Info {
 			id: Origin::UNKNOWN,
 			pool: cache::Pool::default(),
 			cache_duration: Duration::MAX,
+			latency_default: track::DEFAULT_LATENCY_MAX,
 			linger: Duration::ZERO,
 		}
 	}
@@ -157,6 +169,13 @@ impl Info {
 	/// under this origin, returning `self` for chaining.
 	pub fn with_cache_duration(mut self, cache_duration: Duration) -> Self {
 		self.cache_duration = cache_duration;
+		self
+	}
+
+	/// Set the retention window (see [`Self::latency_default`]) used for tracks whose
+	/// publisher advertises none, returning `self` for chaining.
+	pub fn with_latency_default(mut self, latency_default: Duration) -> Self {
+		self.latency_default = latency_default;
 		self
 	}
 
@@ -914,6 +933,10 @@ pub struct Producer {
 	// [`Info::cache_duration`]). `Duration::MAX` (no ceiling) by default.
 	cache_duration: Duration,
 
+	// Retention window for a track whose publisher advertises none (see
+	// [`Info::latency_default`]).
+	latency_default: Duration,
+
 	// How long a broadcast outlives ungracefully losing its last source (see
 	// [`Info::linger`]). Zero by default.
 	linger: Duration,
@@ -944,6 +967,7 @@ impl Producer {
 			dynamic: kio::Shared::default(),
 			pool: info.pool,
 			cache_duration: info.cache_duration,
+			latency_default: info.latency_default,
 			linger: info.linger,
 			stats: stats::Session::default(),
 		}
@@ -977,8 +1001,15 @@ impl Producer {
 			id: self.info,
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
+			latency_default: self.latency_default,
 			linger: self.linger,
 		}
+	}
+
+	// The retention window for a track whose publisher advertises none (see
+	// [`Info::latency_default`]). Cheaper than `info()`, which clones the pool.
+	pub(crate) fn latency_default(&self) -> Duration {
+		self.latency_default
 	}
 
 	/// A producer with *no* allowed prefixes: it can't publish anything and
@@ -993,6 +1024,7 @@ impl Producer {
 			dynamic: kio::Shared::default(),
 			pool: cache::Pool::default(),
 			cache_duration: Duration::MAX,
+			latency_default: track::DEFAULT_LATENCY_MAX,
 			linger: Duration::ZERO,
 			stats: stats::Session::default(),
 		}
@@ -1095,6 +1127,7 @@ impl Producer {
 			dynamic: self.dynamic.clone(),
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
+			latency_default: self.latency_default,
 			linger: self.linger,
 			stats: self.stats.clone(),
 		})
@@ -1151,6 +1184,7 @@ impl Producer {
 			dynamic: self.dynamic.clone(),
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
+			latency_default: self.latency_default,
 			linger: self.linger,
 			stats: self.stats.clone(),
 		})

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -63,6 +63,19 @@ pub struct CacheConfig {
 	#[arg(long = "cache-duration", env = "MOQ_CACHE_DURATION", value_parser = humantime::parse_duration)]
 	#[serde(default, with = "humantime_serde")]
 	pub duration: Option<Duration>,
+
+	/// Retention window for a track whose publisher advertises none, e.g. "30s".
+	/// Defaults to 5s.
+	///
+	/// moq-lite 05+ publishers advertise their own window and it is used verbatim.
+	/// Every moq-transport draft and moq-lite 01-04 have no such wire property, so a
+	/// track relayed over one of them retains for this long instead. Raise it when
+	/// this relay fronts a segmented egress (HLS/DASH) that advertises a longer
+	/// playlist window, since serving an older segment means a cache hit that far
+	/// back. `duration` still caps it.
+	#[arg(long = "cache-latency-default", env = "MOQ_CACHE_LATENCY_DEFAULT", value_parser = humantime::parse_duration)]
+	#[serde(default, with = "humantime_serde")]
+	pub latency_default: Option<Duration>,
 }
 
 /// The relay's resolved cache settings: the shared byte-budget pool plus the
@@ -75,6 +88,11 @@ pub struct Cache {
 	/// track is always kept). [`Duration::MAX`] imposes no ceiling, leaving each
 	/// track's own window in force.
 	pub duration: Duration,
+
+	/// Retention window for a track whose publisher advertises none, which is every
+	/// moq-transport peer and moq-lite 01-04. Defaults to
+	/// [`moq_net::track::DEFAULT_LATENCY_MAX`].
+	pub latency_default: Duration,
 }
 
 impl CacheConfig {
@@ -100,9 +118,14 @@ impl CacheConfig {
 			tracing::info!(?duration, "cache duration ceiling set");
 		}
 
+		if let Some(latency_default) = self.latency_default {
+			tracing::info!(?latency_default, "cache latency default set");
+		}
+
 		Ok(Cache {
 			pool,
 			duration: self.duration.unwrap_or(Duration::MAX),
+			latency_default: self.latency_default.unwrap_or(moq_net::track::DEFAULT_LATENCY_MAX),
 		})
 	}
 }

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -435,9 +435,10 @@ impl Cluster {
 		})
 	}
 
-	/// Attach the resolved [`Cache`](crate::Cache) (the shared group pool and the
-	/// per-track retention ceiling) so every session's broadcasts cache into one
-	/// memory budget bounded by both bytes and age. Call before deriving any origin
+	/// Attach the resolved [`Cache`](crate::Cache) (the shared group pool, the
+	/// per-track retention ceiling, and the window for tracks whose publisher
+	/// advertises none) so every session's broadcasts cache into one memory
+	/// budget bounded by both bytes and age. Call before deriving any origin
 	/// handles (e.g. [`with_stats`](Self::with_stats)) so they inherit the settings.
 	///
 	/// Rebuilds the origin with the cache: safe because the cluster's origin is
@@ -447,7 +448,8 @@ impl Cluster {
 			.info
 			.clone()
 			.with_pool(cache.pool)
-			.with_cache_duration(cache.duration);
+			.with_cache_duration(cache.duration)
+			.with_latency_default(cache.latency_default);
 		self.origin = self.info.clone().produce();
 		self.nodes = self.nodes.with_origin(self.origin.clone());
 		self

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -156,18 +156,24 @@ depth = 2
 		assert_eq!(config.stats.depth, Some(2));
 	}
 
-	/// Regression test for the clap+TOML clobber bug applied to `[cache]`. Both
-	/// fields are `Option<String>` so a TOML-configured cache size survives the
-	/// CLI re-parse when no `--cache-*` flag is passed.
+	/// Regression test for the clap+TOML clobber bug applied to `[cache]`. Every
+	/// field is an `Option` so a TOML-configured cache setting survives the CLI
+	/// re-parse when no `--cache-*` flag is passed.
 	#[test]
 	fn cli_does_not_clobber_toml_cache() {
-		let _env = EnvGuard::clear(&["MOQ_CACHE_CAPACITY", "MOQ_CACHE_HEADROOM", "MOQ_CACHE_DURATION"]);
+		let _env = EnvGuard::clear(&[
+			"MOQ_CACHE_CAPACITY",
+			"MOQ_CACHE_HEADROOM",
+			"MOQ_CACHE_DURATION",
+			"MOQ_CACHE_LATENCY_DEFAULT",
+		]);
 
 		let toml = r#"
 [cache]
 capacity = "8GiB"
 headroom = "10%"
 duration = "30s"
+latency_default = "20s"
 "#;
 		let dir = std::env::temp_dir().join("moq-relay-config-test");
 		std::fs::create_dir_all(&dir).unwrap();
@@ -188,22 +194,38 @@ duration = "30s"
 			Some(std::time::Duration::from_secs(30)),
 			"TOML's cache.duration must not be clobbered by the CLI re-parse"
 		);
+		assert_eq!(
+			config.cache.latency_default,
+			Some(std::time::Duration::from_secs(20)),
+			"TOML's cache.latency_default must not be clobbered by the CLI re-parse"
+		);
 	}
 
-	/// `cache.duration` is an `Option<Duration>` behind plain `humantime_serde`
-	/// (not `humantime_serde::option`), so pin both directions including the
-	/// `None` serialize path, which the merge test above never exercises.
+	/// `cache.duration` and `cache.latency_default` are `Option<Duration>` behind
+	/// plain `humantime_serde` (not `humantime_serde::option`), so pin both
+	/// directions including the `None` serialize path, which the merge test above
+	/// never exercises.
 	#[test]
 	fn cache_duration_serde_round_trip() {
-		let set: CacheConfig = toml::from_str(r#"duration = "30s""#).expect("deserialize Some");
+		let set: CacheConfig = toml::from_str(
+			"duration = \"30s\"
+latency_default = \"20s\"",
+		)
+		.expect("deserialize Some");
 		assert_eq!(set.duration, Some(std::time::Duration::from_secs(30)));
+		assert_eq!(set.latency_default, Some(std::time::Duration::from_secs(20)));
 
 		let unset: CacheConfig = toml::from_str("").expect("deserialize absent");
 		assert_eq!(unset.duration, None);
+		assert_eq!(unset.latency_default, None);
 
 		let encoded = toml::to_string(&set).expect("serialize Some");
 		let decoded: CacheConfig = toml::from_str(&encoded).expect("re-deserialize");
 		assert_eq!(decoded.duration, set.duration, "round trip must preserve the duration");
+		assert_eq!(
+			decoded.latency_default, set.latency_default,
+			"round trip must preserve the latency default"
+		);
 
 		toml::to_string(&unset).expect("serialize None");
 	}


### PR DESCRIPTION
Fixes #2645.

## Root cause

`track::Info::latency_max` is how long a publisher keeps a non-latest group, and it bounds how long a relay re-serving that track retains it. moq-lite 05+ carries it in TRACK_INFO, so a relayed track keeps the window its publisher chose. Every moq-transport draft and moq-lite 01-04 have no such wire property, and both subscribers accepted the track with a plain `track::Info::default()`:

- `ietf::Subscriber::run_subscribe` (`Info::default().with_timescale(MICRO)`)
- `lite::TrackServe::run`, on the no-TRACK-stream branch

so the window silently fell back to the 5s `DEFAULT_LATENCY_MAX`.

That is a real gap for a relay fed over moq-transport in front of a segmented egress: the exporter advertises a 30s playlist window, the relay evicts at 5s, and every FETCH for an older advertised segment misses. The relay's `cache.duration` ceiling only ever *lowers* retention, so no deployment-side knob raised it.

## Fix

Neither of the obvious fixes works (both are spelled out in the issue): there is nothing to propagate from the peer, and moq-net can't reach `hang`'s media constant, nor should it invent a media-shaped default that would apply to every IETF track. So this takes option 1 from the issue: let the accepting side choose.

`origin::Info::latency_default` is the retention window given to a track whose publisher advertises none. It defaults to `DEFAULT_LATENCY_MAX`, so nothing changes unless a deployment asks for it, and `cache_duration` still caps the result. Both subscribers read it when they accept the track, so the moq-lite 01-04 gap is closed by the same knob.

It goes on `origin::Info` rather than on `Client`/`Server` because that struct is already the bag of retention policy a relay configures once and every broadcast beneath the origin inherits (`pool`, `cache_duration`, `linger`), and both subscribers already hold the `origin::Producer` they write into.

moq-relay exposes it as `cache.latency_default` (`--cache-latency-default`, `MOQ_CACHE_LATENCY_DEFAULT`), the first knob in `[cache]` that raises retention rather than lowering it.

## Notes

- Nothing changes on the wire, so no draft update is needed. Carrying the value as an IETF parameter (option 2) still needs a spec extension; this unblocks deployments meanwhile.
- Cross-package sync: `doc/bin/relay/config.md` updated. `js/net` has no origin-level cache config, so nothing to mirror there.

## Testing

Three integration tests in `rs/moq-native/tests/broadcast.rs` publish a track advertising a 2s window and subscribe through an origin configured with a 30s default:

- `broadcast_latency_max_lite_05` -> 2s (the publisher's window rides TRACK_INFO and wins)
- `broadcast_latency_max_lite_01` -> 30s
- `broadcast_latency_max_transport_18` -> 30s (the regression)

The latter two fail on the unfixed code with `left: 5s, right: 30s`; lite-05 passes either way, which pins that the fix doesn't override a window the publisher did advertise. Relay config coverage extends the existing `cli_does_not_clobber_toml_cache` and `cache_duration_serde_round_trip` tests.

`cargo test -p moq-net` (629 passed) and the full `broadcast` suite (79 passed) are green. 17 pre-existing `moq-relay` `auth::tests` failures on this machine ("key not found") are unrelated and fail identically on a clean tree.

(Written by Opus 5)
