### PR TITLE
fix(moq-net): let the last owner out decide the detach

### DIFF
--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -553,8 +553,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 
 		// An endpoint updates an advertisement by re-sending it on the stream that
-		// already carries it, so keep reading until the stream closes (which is also how
-		// v14-16's PublishNamespaceDone arrives, via the adapter).
+		// already carries it, so keep reading until the stream ends: a close on
+		// draft-17+, or v14-16's PublishNamespaceDone (see `terminal_publish_namespace`).
 		//
 		// `attached` survives the call so a stream that detached mid-flight (a reflected
 		// update) is not released twice here.
@@ -564,11 +564,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			.await;
 
 		if attached {
-			// A clean close IS the retraction here, unlike a NAMESPACE stream: this stream
-			// carries exactly one advertisement, and PUBLISH_NAMESPACE_DONE reaches us as
-			// that close (see the adapter). Anything else ended the stream while it still
-			// held the advertisement, so the peer never withdrew it and the origin's linger
-			// window stays open for the reconnect.
+			// Ending cleanly IS the retraction here, unlike a NAMESPACE stream: this stream
+			// carries exactly one advertisement, and withdrawing it is what ends the stream.
+			// Any other ending left the advertisement standing, so the peer never withdrew
+			// it and the origin's linger window stays open for the reconnect.
 			let detach = match res.is_ok() {
 				true => Detach::Graceful,
 				false => Detach::Abrupt,
@@ -577,6 +576,23 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 
 		res
+	}
+
+	/// Whether `type_id` retracts a PUBLISH_NAMESPACE rather than updating it.
+	///
+	/// v14-16 carry the stream over the control stream, and the adapter delivers the
+	/// terminal message *before* it FINs (`Route::CloseStream`), so the withdrawal
+	/// arrives here as a message and only then as a close. Draft-17+ has a real stream,
+	/// where the close alone retracts and a terminal message on it is a violation.
+	///
+	/// Only PUBLISH_NAMESPACE_DONE: the publisher sends that one. PUBLISH_NAMESPACE_CANCEL
+	/// travels the other way, so receiving it on an advertisement *we* were offered is a
+	/// violation, not a withdrawal.
+	fn terminal_publish_namespace(&self, type_id: u64) -> bool {
+		match self.version {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 => type_id == ietf::PublishNamespaceDone::ID,
+			_ => false,
+		}
 	}
 
 	/// Read advertisement updates off a live PUBLISH_NAMESPACE stream until it closes.
@@ -593,13 +609,24 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				Some(id) => id,
 				None => return Ok(()),
 			};
-			if type_id != ietf::PublishNamespace::ID {
+			let terminal = self.terminal_publish_namespace(type_id);
+			if type_id != ietf::PublishNamespace::ID && !terminal {
 				tracing::warn!(type_id, "unexpected message on publish_namespace stream");
 				return Err(Error::UnexpectedMessage);
 			}
 
 			let size: u16 = stream.reader.decode().await?;
 			let mut data = stream.reader.read_exact(size as usize).await?;
+
+			if terminal {
+				ietf::PublishNamespaceDone::decode_msg(&mut data, self.version)?;
+				if !data.is_empty() {
+					return Err(Error::WrongSize);
+				}
+				tracing::debug!(%path, "publish_namespace_done");
+				return Ok(());
+			}
+
 			let msg = ietf::PublishNamespace::decode_body(&mut data, self.version, peer.negotiated())?;
 			// Junk inside the declared size would otherwise be applied silently, which
 			// is the one decode path that skipped the check the others make.
@@ -1682,6 +1709,63 @@ mod tests {
 		assert!(
 			consumer.get_broadcast("room/host").is_none(),
 			"an explicit NAMESPACE_DONE lingered instead of closing",
+		);
+	}
+
+	/// v14-16 withdraw a PUBLISH_NAMESPACE with PUBLISH_NAMESPACE_DONE, which the adapter
+	/// delivers as a message before it FINs the virtual stream. Reading it as a stray
+	/// message closes the whole session over a routine unannounce, and strands the
+	/// broadcast for the linger window on the way out.
+	#[tokio::test(start_paused = true)]
+	async fn a_publish_namespace_done_retracts_without_faulting_the_session() {
+		const VERSION: Version = Version::Draft14;
+
+		let path = crate::Path::new("room/host").to_owned();
+		let log = crate::lite::test_transport::Log::default();
+		let mut writer = crate::coding::Writer::new(crate::lite::test_transport::SinkSend::new(log.clone()), VERSION);
+		writer
+			.encode_message(&ietf::PublishNamespaceDone {
+				track_namespace: path.borrow(),
+				request_id: RequestId(0),
+			})
+			.await
+			.unwrap();
+		let script = log.writes.lock().unwrap().clone();
+
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap())
+			.with_linger(std::time::Duration::from_secs(30))
+			.produce();
+		let consumer = origin.consume();
+		let session = crate::lite::test_transport::ScriptedSession::eof(script);
+		let (tasks, task_set) = crate::util::TaskSet::new();
+		std::mem::forget(task_set);
+		let mut subscriber = Subscriber::new(
+			session.clone(),
+			origin,
+			Control::new(None, false),
+			None,
+			cluster::PeerSetup::default(),
+			crate::Origin::new(1).unwrap(),
+			None,
+			VERSION,
+			tasks,
+		);
+
+		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let msg = ietf::PublishNamespace {
+			request_id: RequestId(0),
+			track_namespace: path.borrow(),
+			cluster: None,
+		};
+		subscriber
+			.run_publish_namespace_stream(stream, msg, cluster::Peer::default())
+			.await
+			.expect("a withdrawal is not a protocol violation");
+		settle().await;
+
+		assert!(
+			consumer.get_broadcast("room/host").is_none(),
+			"an explicit withdrawal lingered instead of closing",
 		);
 	}
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -84,6 +84,12 @@ struct TrackState {
 
 /// How the last source for a path detaches, which decides whether the origin closes
 /// the broadcast now or holds it open for a replacement.
+///
+/// Only the detach that drops the refcount to zero decides, matching the model's rule
+/// for several sources at one path (`detach_source`): an earlier owner that vanished
+/// does not outvote the last one still on the path. That keeps two advertisements on
+/// one session behaving like the same two on separate sessions, where the model sees
+/// two independent sources and the last one out decides.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Detach {
 	/// The peer retracted the path, or we are rolling back an announce we just made.
@@ -103,10 +109,6 @@ struct BroadcastState {
 
 	// active number of PUBLISH_NAMESPACE messages.
 	count: usize,
-
-	// Abrupt dominates once any owner disappears without retracting its advert. The
-	// source must still linger when a different owner releases the final ref cleanly.
-	detach: Detach,
 
 	// The first entry of the advertised path: the original publisher. `None` on an
 	// advertisement that carried no path at all, which is every one on a session
@@ -562,7 +564,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			.await;
 
 		if attached {
-			self.stop_announce(path, Detach::Graceful)?;
+			// A clean close IS the retraction here, unlike a NAMESPACE stream: this stream
+			// carries exactly one advertisement, and PUBLISH_NAMESPACE_DONE reaches us as
+			// that close (see the adapter). Anything else ended the stream while it still
+			// held the advertisement, so the peer never withdrew it and the origin's linger
+			// window stays open for the reconnect.
+			let detach = match res.is_ok() {
+				true => Detach::Graceful,
+				false => Detach::Abrupt,
+			};
+			self.stop_announce(path, detach)?;
 		}
 
 		res
@@ -856,7 +867,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				entry.insert(BroadcastState {
 					producer: crate::model::broadcast::SourceGuard::new(broadcast.clone()),
 					count: carried.unwrap_or(1),
-					detach: Detach::Graceful,
 					publisher,
 				});
 
@@ -883,19 +893,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		match state.broadcasts.entry(path.clone()) {
 			Entry::Occupied(mut entry) => {
-				let broadcast = entry.get_mut();
-				broadcast.count -= 1;
-				if detach == Detach::Abrupt {
-					broadcast.detach = Detach::Abrupt;
-				}
-				if broadcast.count == 0 {
-					let broadcast = entry.remove();
-					tracing::debug!(broadcast = %self.origin.absolute(&path), detach = ?broadcast.detach, "unannounced");
-					match broadcast.detach {
-						Detach::Graceful => broadcast.producer.finish(),
+				entry.get_mut().count -= 1;
+				if entry.get().count == 0 {
+					tracing::debug!(broadcast = %self.origin.absolute(&path), ?detach, "unannounced");
+					let producer = entry.remove().producer;
+					match detach {
+						Detach::Graceful => producer.finish(),
 						// Dropping the guard aborts the source, which is what leaves the
 						// origin's linger window open for a replacement.
-						Detach::Abrupt => drop(broadcast.producer),
+						Detach::Abrupt => drop(producer),
 					}
 				}
 			}
@@ -1679,11 +1685,73 @@ mod tests {
 		);
 	}
 
-	/// An abrupt owner remains significant while another advert keeps the source alive.
-	/// When that final owner retracts cleanly, the lost owner still requires the source
-	/// to linger for a replacement rather than close immediately.
+	/// A PUBLISH_NAMESPACE stream that dies mid-advertisement detaches ABRUPTLY. Only a
+	/// clean close retracts here, since that is how PUBLISH_NAMESPACE_DONE reaches us
+	/// (the adapter turns it into one); a stream that ended any other way still held the
+	/// advertisement, so the origin keeps the linger window open for the reconnect.
+	///
+	/// Driven through the real exit path rather than by calling `stop_announce`: a test
+	/// that picked the detach itself would still pass if the stream stopped using it.
 	#[tokio::test(start_paused = true)]
-	async fn an_abrupt_detach_survives_another_owner() {
+	async fn a_broken_publish_namespace_stream_leaves_the_linger_window_open() {
+		const VERSION: Version = Version::Draft19;
+
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap())
+			.with_linger(std::time::Duration::from_secs(30))
+			.produce();
+		let consumer = origin.consume();
+
+		// The peer sends something that does not belong on this stream, ending it with an
+		// error while the advertisement is still live.
+		let log = crate::lite::test_transport::Log::default();
+		let mut writer = crate::coding::Writer::new(crate::lite::test_transport::SinkSend::new(log.clone()), VERSION);
+		writer.encode(&ietf::NamespaceDone::ID).await.unwrap();
+		let script = log.writes.lock().unwrap().clone();
+
+		let session = crate::lite::test_transport::ScriptedSession::eof(script);
+		let (tasks, task_set) = crate::util::TaskSet::new();
+		std::mem::forget(task_set);
+		let mut subscriber = Subscriber::new(
+			session.clone(),
+			origin,
+			Control::new(None, false),
+			None,
+			cluster::PeerSetup::default(),
+			crate::Origin::new(1).unwrap(),
+			None,
+			VERSION,
+			tasks,
+		);
+
+		let path = crate::Path::new("room/host").to_owned();
+		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let msg = ietf::PublishNamespace {
+			request_id: RequestId(0),
+			track_namespace: path.borrow(),
+			cluster: None,
+		};
+		subscriber
+			.run_publish_namespace_stream(stream, msg, cluster::Peer::default())
+			.await
+			.expect_err("an unexpected message ends the stream");
+		settle().await;
+
+		assert!(
+			consumer.get_broadcast("room/host").is_some(),
+			"a broken stream closed the broadcast instead of lingering for a reconnect",
+		);
+	}
+
+	/// Several advertisements share one refcounted source, so the detach that empties it
+	/// is the one that counts: an earlier owner lost abruptly does not outvote the last
+	/// one's explicit retraction, and does not stall a replacement behind a linger.
+	///
+	/// That is the model's own rule for several sources at one path (`detach_source`),
+	/// which is what these advertisements would be had they arrived on two sessions. The
+	/// refcount is a detail of sharing one `SourceGuard` per session; it must not change
+	/// what the origin sees.
+	#[tokio::test(start_paused = true)]
+	async fn the_last_owner_out_decides_the_detach() {
 		let (mut subscriber, origin) =
 			cluster_subscriber_with_linger(crate::Origin::new(1).unwrap(), std::time::Duration::from_secs(30));
 		let consumer = origin.consume();
@@ -1696,13 +1764,27 @@ mod tests {
 		}
 		settle().await;
 
+		// One advertisement's stream dies, the other is retracted explicitly.
 		subscriber.stop_announce(path.clone(), Detach::Abrupt).unwrap();
-		subscriber.stop_announce(path, Detach::Graceful).unwrap();
+		subscriber.stop_announce(path.clone(), Detach::Graceful).unwrap();
 		settle().await;
+		assert!(
+			consumer.get_broadcast("room/host").is_none(),
+			"an explicit retraction lingered because an earlier owner was lost abruptly",
+		);
 
+		// The reverse order still lingers: the path was never withdrawn on the way out.
+		for _ in 0..2 {
+			let advert = subscriber.route(None, &peer).expect("route");
+			subscriber.start_announce(path.clone(), advert).unwrap();
+		}
+		settle().await;
+		subscriber.stop_announce(path.clone(), Detach::Graceful).unwrap();
+		subscriber.stop_announce(path, Detach::Abrupt).unwrap();
+		settle().await;
 		assert!(
 			consumer.get_broadcast("room/host").is_some(),
-			"the final clean retraction forgot that another owner was lost abruptly",
+			"an abrupt last detach closed the broadcast instead of lingering for a reconnect",
 		);
 	}
 


### PR DESCRIPTION
Follow-up to #2654, which I reviewed after it merged. Two commits: one reverts its production change, one fixes the bug it was reaching for.

## Why #2654's change is wrong

It made an abrupt detach sticky on the ietf subscriber's refcounted broadcast state, so a final owner's explicit retraction still aborted the source and left the origin lingering.

That contradicts the model's own rule. In `detach_source` only the detach that empties the source table decides, so the same two advertisements arriving on **two sessions** close immediately when the last one retracts cleanly. Collapsing N advertisements onto one `SourceGuard` is a detail of how one session shares state; it must not change what the origin sees. Verified against the model directly: two sources at one path with a 30s linger, one aborted and one finished last, closes now.

The sticky bit also never reset. One lost stream turned every later clean NAMESPACE_DONE on that path into a 30s linger, for as long as the entry lived:

```
advert A + advert B         -> count 2
A lost abruptly             -> count 1, sticky Abrupt
peer reopens, re-advertises -> count 2, still Abrupt
NAMESPACE_DONE on both      -> count 0 -> lingers, stalling any replacement
```

## Root cause

The case #2654 was reaching for is real, but it lives one layer down: `run_publish_namespace_stream` detached gracefully however the stream ended, so a stream that died holding its advertisement closed the broadcast instead of lingering. That is the same hole #2616 fixed for NAMESPACE streams. Classifying by the stream's result fixes it where it happens.

Fixing that exposed a second, worse bug. v14-16 multiplex a PUBLISH_NAMESPACE onto the control stream, and the adapter delivers the terminal message **before** it FINs (`Route::CloseStream`). The update loop only accepted another PUBLISH_NAMESPACE, so a routine PUBLISH_NAMESPACE_DONE decoded as `UnexpectedMessage`, which `run_bi` treats as a protocol violation and answers by **closing the whole session**. Live on `main` today, and the parent commit would have made it strand the broadcast for the linger window on the way out.

PUBLISH_NAMESPACE_CANCEL stays a violation: it travels subscriber to publisher, and this loop is the subscriber's.

## Tests

Kept #2654's scaffolding (the `cluster_subscriber_with_linger` helper and the paused-clock conversions). Three tests, each mutation-checked to fail without its fix:

- `the_last_owner_out_decides_the_detach` covers both orders, so neither half is vacuous.
- `a_broken_publish_namespace_stream_leaves_the_linger_window_open` drives the real exit path.
- `a_publish_namespace_done_retracts_without_faulting_the_session` scripts a real v14 withdrawal.

`nix develop --command just check` and the full `moq-net` suite (668 tests) pass.

## Left out

The adapter's v14/v15 `namespaces` map is direction-blind: both the outgoing and incoming PUBLISH_NAMESPACE paths insert keyed only by namespace, so two relays advertising the same path to each other can route a terminal message to the wrong virtual stream. Pre-existing and separate from this change; filed for its own PR with adapter-level coverage.

(Written by Opus 5)