### PR TITLE
feat(rtmp,srt,rtc): honor `--latency-max` on the gateway ingest paths

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -427,10 +427,16 @@ non-latest group of the published media tracks fetchable. It is a retention
 budget, so raising it never makes a subscriber play further behind live: it caps
 how far back a fetch can still reach. The default is sized for a segmented
 egress (HLS/DASH), which may only advertise segments that are still fetchable;
-lower it when nothing reads history and the memory matters. It applies to the
-media tracks only, and to the sources whose catalog this binary builds (the
-stdin containers, `hls`, and `capture`) - the other gateways reject the flag
-rather than accepting it and publishing at the default.
+lower it when nothing reads history and the memory matters:
+
+```bash
+moq --client-connect https://relay.example.com --broadcast my-stream.hang import --latency-max 5s ts
+```
+
+It sits on `import` itself rather than the endpoint, so it applies to every
+source: the stdin containers, `hls`, `capture`, and the `rtmp` / `srt` / `rtc`
+gateways alike. Media tracks only, since the catalog and timeline are read at
+the live edge, which is retained unconditionally.
 
 Export formats:
 

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -265,23 +265,6 @@ impl ImportSource {
 			_ => return None,
 		})
 	}
-
-	/// Whether this source threads [`Import::latency_max`] into the catalog it publishes.
-	///
-	/// The stdin containers, HLS, and capture build their catalog in this crate, so they honor
-	/// it. The remaining gateways build theirs inside moq-rtmp / moq-srt / moq-rtc, which take
-	/// no retention yet -- so the flag is REFUSED there rather than silently ignored.
-	pub fn honors_latency_max(&self) -> bool {
-		if self.stdin_format().is_some() {
-			return true;
-		}
-		match self {
-			Self::Hls(_) => true,
-			#[cfg(feature = "capture")]
-			Self::Capture(_) => true,
-			_ => false,
-		}
-	}
 }
 
 // ------------------------------------------------------------------ export
@@ -387,30 +370,36 @@ mod tests {
 
 	#[test]
 	fn latency_max_is_unset_unless_asked_for() {
-		// Unset rather than defaulted to hang's constant, so a source that cannot apply the
-		// retention can tell "the user asked for one" from "nobody asked", and refuse only the
-		// former. A `default_value` here would make an explicit `--latency-max 30s` on such a
-		// source indistinguishable from the default, which is the silent no-op the guard exists
-		// to stop.
+		// Unset rather than defaulted to hang's constant, so the publisher's own default is
+		// what every source falls back to. A `default_value` here would put the number in the
+		// CLI as well, and the two would drift.
 		let cli = Cli::try_parse_from(["moq", "import", "ts"]).unwrap();
 		let Command::Import(import) = cli.command else {
 			panic!("expected import")
 		};
 		assert_eq!(import.latency_max, None);
-		assert!(import.source.honors_latency_max());
 
+		// It sits on the parent `import`, so it parses ahead of any source, gateway or not.
 		let cli = Cli::try_parse_from(["moq", "import", "--latency-max", "5s", "ts"]).unwrap();
 		let Command::Import(import) = cli.command else {
 			panic!("expected import")
 		};
 		assert_eq!(import.latency_max, Some(std::time::Duration::from_secs(5)));
 
-		// The gateways build their catalogs in their own crates, so they cannot apply it.
-		let cli = Cli::try_parse_from(["moq", "import", "rtmp", "--listen", "127.0.0.1:1935"]).unwrap();
+		let cli = Cli::try_parse_from([
+			"moq",
+			"import",
+			"--latency-max",
+			"5s",
+			"rtmp",
+			"--listen",
+			"127.0.0.1:1935",
+		])
+		.unwrap();
 		let Command::Import(import) = cli.command else {
 			panic!("expected import")
 		};
-		assert!(!import.source.honors_latency_max());
+		assert_eq!(import.latency_max, Some(std::time::Duration::from_secs(5)));
 	}
 
 	#[test]

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -212,14 +212,6 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		reject_listener_cors(&rtc.cors, "import rtc")?;
 	}
 
-	// Refuse a retention this source can't apply rather than accepting the flag and quietly
-	// publishing at the default: the gateways build their catalogs inside their own crates.
-	anyhow::ensure!(
-		import.latency_max.is_none() || import.source.honors_latency_max(),
-		"--latency-max is not supported for this source yet; it applies to the stdin container \
-		 formats, hls, and capture"
-	);
-
 	// The uplink's bandwidth estimate, for sources that can encode to fit it. Only
 	// an outbound client has one: a `--server-bind` publisher's sessions are
 	// inbound and never surfaced here, so it stays `None` and those sources encode
@@ -248,6 +240,15 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	moq::notify_ready();
 
 	// Foreign side: the single source.
+	let latency_max = import.latency_max;
+	// The MoQ side every gateway publishes into, minted per source since each takes it
+	// by value onto its own task.
+	let target = |name: String| crate::moq::ImportTarget {
+		origin: origin.clone(),
+		name,
+		latency_max,
+	};
+
 	if let Some(format) = import.source.stdin_format() {
 		warn_if_missing_format(&name);
 		let broadcast = origin
@@ -265,32 +266,33 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 			ImportSource::Rtmp(rtmp) => {
 				if let Some(addr) = rtmp.listen {
 					let name = require_broadcast(name, "import rtmp --listen")?;
-					tasks.spawn(rtmp::listen_import(origin.clone(), addr, name));
+					tasks.spawn(rtmp::listen_import(target(name), addr));
 				} else if let Some(url) = rtmp.connect {
-					tasks.spawn(rtmp::connect_import(origin.clone(), url, name));
+					tasks.spawn(rtmp::connect_import(target(name), url));
 				}
 			}
 			ImportSource::Srt(srt) => {
 				if let Some(addr) = srt.listen {
 					let name = require_broadcast(name, "import srt --listen")?;
-					tasks.spawn(srt::listen_import(origin.clone(), addr, name, srt.latency));
+					tasks.spawn(srt::listen_import(target(name), addr, srt.latency));
 				} else if let Some(url) = srt.connect {
-					tasks.spawn(srt::connect_import(origin.clone(), url, name, srt.latency));
+					tasks.spawn(srt::connect_import(target(name), url, srt.latency));
 				}
 			}
 			ImportSource::Rtc(rtc) => {
 				if let Some(addr) = rtc.listen {
 					let name = require_broadcast(name, "import rtc --listen")?;
 					tasks.spawn(rtc::listen_import(
-						origin.clone(),
-						addr,
-						rtc.udp_bind,
-						rtc.public_addr,
-						rtc.cors,
-						name,
+						target(name),
+						rtc::Listen {
+							addr,
+							udp_bind: rtc.udp_bind,
+							public_addr: rtc.public_addr,
+							cors: rtc.cors,
+						},
 					));
 				} else if let Some(url) = rtc.connect {
-					tasks.spawn(rtc::connect_import(origin.clone(), url, name));
+					tasks.spawn(rtc::connect_import(target(name), url));
 				}
 			}
 			#[cfg(feature = "capture")]
@@ -384,11 +386,13 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 					let name = require_broadcast(name, "export rtc --listen")?;
 					tasks.spawn(rtc::listen_export(
 						origin.consume(),
-						addr,
-						rtc.udp_bind,
-						rtc.public_addr,
-						rtc.cors,
 						name,
+						rtc::Listen {
+							addr,
+							udp_bind: rtc.udp_bind,
+							public_addr: rtc.public_addr,
+							cors: rtc.cors,
+						},
 					));
 				} else if let Some(url) = rtc.connect {
 					tasks.spawn(rtc::connect_export(origin.consume(), url, name));

--- a/rs/moq-cli/src/moq.rs
+++ b/rs/moq-cli/src/moq.rs
@@ -1,8 +1,28 @@
 //! Small MoQ-side helpers shared across endpoints.
 //!
 //! The dial and accept loops live in `moq-native` (`Client::publish`/`consume`
-//! and `Server::serve_publish`/`serve_consume`); this module just carries the
-//! systemd readiness notification used by every endpoint.
+//! and `Server::serve_publish`/`serve_consume`); this module carries the systemd
+//! readiness notification used by every endpoint plus the MoQ side of an import.
+
+use hang::moq_net;
+
+/// The MoQ side of an import: where a gateway publishes, under what name, and the
+/// retention it declares on the media tracks it mints.
+///
+/// Every gateway needs all three regardless of protocol, so they travel together
+/// rather than as three positional arguments per entry point.
+#[derive(Clone)]
+pub struct ImportTarget {
+	/// The Origin the gateway publishes into.
+	pub origin: moq_net::origin::Producer,
+
+	/// The broadcast name to publish under.
+	pub name: String,
+
+	/// How long relays keep a non-latest group of the published media tracks fetchable
+	/// (`--latency-max`), or `None` for the publisher's own default.
+	pub latency_max: Option<std::time::Duration>,
+}
 
 /// Notify systemd (if any) that the endpoint is up.
 pub fn notify_ready() {

--- a/rs/moq-cli/src/rtc.rs
+++ b/rs/moq-cli/src/rtc.rs
@@ -10,7 +10,7 @@ use hang::moq_net;
 use hang::moq_net::AsPath;
 use url::Url;
 
-use crate::moq::notify_ready;
+use crate::moq::{ImportTarget, notify_ready};
 
 /// WebRTC endpoint args: exactly one of `--connect` (WHIP/WHEP client) /
 /// `--listen` (WHIP/WHEP server). The parent direction picks WHIP vs WHEP.
@@ -39,37 +39,40 @@ pub struct Args {
 	pub cors: crate::web::Cors,
 }
 
-/// WHIP server: accept incoming WebRTC publishes into the Origin as `name` (import).
-pub async fn listen_import(
-	origin: moq_net::origin::Producer,
-	listen: SocketAddr,
-	udp_bind: SocketAddr,
-	public_addr: Vec<SocketAddr>,
-	cors: crate::web::Cors,
-	name: String,
-) -> anyhow::Result<()> {
-	let publisher = scope_producer(&origin, &name)?;
-	let server = server(publisher, origin.consume(), udp_bind, public_addr);
-	serve(server.publish_router(), listen, "WHIP", cors).await
+/// HTTP and ICE settings shared by the WHIP and WHEP listeners.
+pub struct Listen {
+	/// HTTP address to bind.
+	pub addr: SocketAddr,
+
+	/// Shared UDP socket for ICE and media.
+	pub udp_bind: SocketAddr,
+
+	/// Public UDP addresses advertised as ICE host candidates.
+	pub public_addr: Vec<SocketAddr>,
+
+	/// Browser CORS policy for the HTTP listener.
+	pub cors: crate::web::Cors,
+}
+
+/// WHIP server: accept incoming WebRTC publishes into the Origin as `target.name` (import).
+pub async fn listen_import(target: ImportTarget, listen: Listen) -> anyhow::Result<()> {
+	let publisher = scope_producer(&target.origin, &target.name)?;
+	let mut config = server_config(&listen);
+	config.latency_max = target.latency_max;
+	let server = moq_rtc::Server::new(config, publisher, target.origin.consume());
+	serve(server.publish_router(), "WHIP", listen).await
 }
 
 /// WHEP server: serve WebRTC plays of `name` from the Origin (export).
-pub async fn listen_export(
-	origin: moq_net::origin::Consumer,
-	listen: SocketAddr,
-	udp_bind: SocketAddr,
-	public_addr: Vec<SocketAddr>,
-	cors: crate::web::Cors,
-	name: String,
-) -> anyhow::Result<()> {
+pub async fn listen_export(origin: moq_net::origin::Consumer, name: String, listen: Listen) -> anyhow::Result<()> {
 	let subscriber = origin
 		.scope(&[name.as_path()])
 		.with_context(|| format!("failed to scope origin to broadcast `{name}`"))?;
 	// A WHEP server only reads; it still needs a publisher handle for the shared
 	// glue, so hand it an unused, empty Origin producer.
 	let publisher = moq_net::Origin::random().produce();
-	let server = server(publisher, subscriber, udp_bind, public_addr);
-	serve(server.subscribe_router(), listen, "WHEP", cors).await
+	let server = moq_rtc::Server::new(server_config(&listen), publisher, subscriber);
+	serve(server.subscribe_router(), "WHEP", listen).await
 }
 
 /// Restrict a producer to the single broadcast `name` so a WHIP peer can only publish it.
@@ -79,16 +82,20 @@ fn scope_producer(origin: &moq_net::origin::Producer, name: &str) -> anyhow::Res
 		.with_context(|| format!("failed to scope origin to broadcast `{name}`"))
 }
 
-/// WHEP client: pull a remote broadcast into the Origin under `name` (import).
-pub async fn connect_import(origin: moq_net::origin::Producer, url: Url, name: String) -> anyhow::Result<()> {
-	let producer = origin
-		.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
+/// WHEP client: pull a remote broadcast into the Origin under `target.name` (import).
+pub async fn connect_import(target: ImportTarget, url: Url) -> anyhow::Result<()> {
+	let name = &target.name;
+	let producer = target
+		.origin
+		.create_broadcast(name, moq_net::broadcast::Route::new().with_announce(true))
 		.context("failed to create broadcast")?;
 
 	tracing::info!(%url, %name, "WHEP client pulling");
 	notify_ready();
 
-	let client = moq_rtc::Client::new(moq_rtc::client::Config::default());
+	let mut config = moq_rtc::client::Config::default();
+	config.latency_max = target.latency_max;
+	let client = moq_rtc::Client::new(config);
 	Ok(client.subscribe(url, producer).await?)
 }
 
@@ -108,24 +115,21 @@ pub async fn connect_export(origin: moq_net::origin::Consumer, url: Url, name: S
 	Ok(client.publish(url, origin, &name).await?)
 }
 
-fn server(
-	publisher: moq_net::origin::Producer,
-	subscriber: moq_net::origin::Consumer,
-	udp_bind: SocketAddr,
-	public_addr: Vec<SocketAddr>,
-) -> moq_rtc::Server {
+fn server_config(listen: &Listen) -> moq_rtc::server::Config {
 	let mut config = moq_rtc::server::Config::default();
-	config.udp_bind = udp_bind;
-	config.ice_candidates = public_addr;
-	moq_rtc::Server::new(config, publisher, subscriber)
+	config.udp_bind = listen.udp_bind;
+	config.ice_candidates.clone_from(&listen.public_addr);
+	config
 }
 
-async fn serve(router: axum::Router, listen: SocketAddr, role: &str, cors: crate::web::Cors) -> anyhow::Result<()> {
-	let cors = cors.layer([Method::POST, Method::PATCH, Method::DELETE, Method::OPTIONS])?;
+async fn serve(router: axum::Router, role: &str, listen: Listen) -> anyhow::Result<()> {
+	let cors = listen
+		.cors
+		.layer([Method::POST, Method::PATCH, Method::DELETE, Method::OPTIONS])?;
 	let app = router.layer(cors);
-	let listener = moq_native::bind::tcp(listen)?;
+	let listener = moq_native::bind::tcp(listen.addr)?;
 
-	tracing::info!(%listen, role, "serving WebRTC");
+	tracing::info!(listen = %listen.addr, role, "serving WebRTC");
 	notify_ready();
 
 	crate::web::serve(listener, app, None).await

--- a/rs/moq-cli/src/rtmp.rs
+++ b/rs/moq-cli/src/rtmp.rs
@@ -10,7 +10,7 @@ use hang::moq_net;
 use moq_rtmp::{Client, Request, Server};
 use url::Url;
 
-use crate::moq::notify_ready;
+use crate::moq::{ImportTarget, notify_ready};
 
 /// RTMP endpoint args: exactly one of `--connect` (dial) / `--listen` (bind).
 /// The parent direction fixes whether that dial/bind pushes or pulls. Import uses
@@ -48,8 +48,13 @@ impl ExportArgs {
 	}
 }
 
-/// Accept incoming RTMP publishes into the Origin as `name`; reject plays (import).
-pub async fn listen_import(origin: moq_net::origin::Producer, addr: SocketAddr, name: String) -> anyhow::Result<()> {
+/// Accept incoming RTMP publishes into the Origin as `target.name`; reject plays (import).
+pub async fn listen_import(target: ImportTarget, addr: SocketAddr) -> anyhow::Result<()> {
+	let ImportTarget {
+		origin,
+		name,
+		latency_max,
+	} = target;
 	let mut server = Server::bind(addr).await?;
 	tracing::info!(%addr, %name, "RTMP listening (import)");
 	notify_ready();
@@ -60,7 +65,7 @@ pub async fn listen_import(origin: moq_net::origin::Producer, addr: SocketAddr, 
 				let origin = origin.clone();
 				let name = name.clone();
 				tokio::spawn(async move {
-					if let Err(err) = publish.accept(&origin, &name).await {
+					if let Err(err) = publish.with_latency_max(latency_max).accept(&origin, &name).await {
 						tracing::warn!(%name, %err, "RTMP ingest ended with error");
 					}
 				});
@@ -113,14 +118,15 @@ pub async fn listen_export(
 	Ok(())
 }
 
-/// Dial a remote RTMP server and pull its play into the Origin under `name` (import).
-pub async fn connect_import(origin: moq_net::origin::Producer, url: Url, name: String) -> anyhow::Result<()> {
+/// Dial a remote RTMP server and pull its play into the Origin under `target.name` (import).
+pub async fn connect_import(target: ImportTarget, url: Url) -> anyhow::Result<()> {
 	let (addr, app, key) = parse_url(&url).await?;
+	let name = &target.name;
 	tracing::info!(%url, %name, "RTMP client pulling");
 	notify_ready();
 
-	let client = Client::connect(addr, &app).await?;
-	Ok(client.pull(&key, &origin, &name).await?)
+	let client = Client::connect(addr, &app).await?.with_latency_max(target.latency_max);
+	Ok(client.pull(&key, &target.origin, name).await?)
 }
 
 /// Push a broadcast from the Origin to a remote RTMP server (export).

--- a/rs/moq-cli/src/srt.rs
+++ b/rs/moq-cli/src/srt.rs
@@ -9,7 +9,7 @@ use hang::moq_net;
 use moq_srt::{Request, Server};
 use url::Url;
 
-use crate::moq::notify_ready;
+use crate::moq::{ImportTarget, notify_ready};
 
 /// SRT endpoint args: exactly one of `--connect` (dial) / `--listen` (bind).
 #[derive(clap::Args, Clone)]
@@ -29,13 +29,13 @@ pub struct Args {
 	pub latency: Duration,
 }
 
-/// Accept incoming SRT publishes into the Origin as `name`; reject requests (import).
-pub async fn listen_import(
-	origin: moq_net::origin::Producer,
-	addr: SocketAddr,
-	name: String,
-	latency: Duration,
-) -> anyhow::Result<()> {
+/// Accept incoming SRT publishes into the Origin as `target.name`; reject requests (import).
+pub async fn listen_import(target: ImportTarget, addr: SocketAddr, latency: Duration) -> anyhow::Result<()> {
+	let ImportTarget {
+		origin,
+		name,
+		latency_max,
+	} = target;
 	let mut server = Server::bind(addr, latency).await?;
 	tracing::info!(%addr, %name, "SRT listening (import)");
 	notify_ready();
@@ -46,7 +46,7 @@ pub async fn listen_import(
 				let origin = origin.clone();
 				let name = name.clone();
 				tokio::spawn(async move {
-					if let Err(err) = publish.accept(&origin, &name).await {
+					if let Err(err) = publish.with_latency_max(latency_max).accept(&origin, &name).await {
 						tracing::warn!(%name, %err, "SRT ingest ended with error");
 					}
 				});
@@ -97,18 +97,17 @@ pub async fn listen_export(
 	Ok(())
 }
 
-/// Dial a remote SRT server and pull its stream into the Origin under `name` (import).
-pub async fn connect_import(
-	origin: moq_net::origin::Producer,
-	url: Url,
-	name: String,
-	latency: Duration,
-) -> anyhow::Result<()> {
+/// Dial a remote SRT server and pull its stream into the Origin under `target.name` (import).
+pub async fn connect_import(target: ImportTarget, url: Url, latency: Duration) -> anyhow::Result<()> {
 	let (addr, resource) = parse_url(&url).await?;
+	let name = &target.name;
 	tracing::info!(%url, %name, "SRT client pulling");
 	notify_ready();
 
-	Ok(moq_srt::dial::pull(addr, &resource, latency, &origin, &name).await?)
+	let mut config = moq_srt::dial::Config::new(addr, resource);
+	config.latency = latency;
+	config.latency_max = target.latency_max;
+	Ok(moq_srt::dial::pull(&config, &target.origin, name).await?)
 }
 
 /// Push a broadcast from the Origin to a remote SRT server (export).
@@ -122,7 +121,9 @@ pub async fn connect_export(
 	tracing::info!(%url, %name, "SRT client pushing");
 	notify_ready();
 
-	Ok(moq_srt::dial::publish(addr, &resource, latency, &origin, &name).await?)
+	let mut config = moq_srt::dial::Config::new(addr, resource);
+	config.latency = latency;
+	Ok(moq_srt::dial::publish(&config, &origin, &name).await?)
 }
 
 /// Parse `srt://host:port?streamid=<resource>` into a resolved address and resource.

--- a/rs/moq-rtc/src/client/mod.rs
+++ b/rs/moq-rtc/src/client/mod.rs
@@ -9,6 +9,7 @@ mod whep;
 mod whip;
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use url::Url;
 
@@ -19,6 +20,14 @@ pub struct Config {
 	/// Public UDP socket addresses to advertise as ICE host candidates in
 	/// our outbound offer. Same semantics as [`crate::server::Config::ice_candidates`].
 	pub ice_candidates: Vec<SocketAddr>,
+
+	/// How long relays keep a non-latest group of an ingested media track fetchable.
+	/// Same semantics as [`crate::server::Config::latency_max`].
+	///
+	/// Ingest only ([`subscribe`](Client::subscribe) / WHEP): a WHIP
+	/// [`publish`](Client::publish) reads a broadcast someone else declared, so it
+	/// ignores this.
+	pub latency_max: Option<Duration>,
 }
 
 /// Outbound WHIP/WHEP dialer.

--- a/rs/moq-rtc/src/client/whep.rs
+++ b/rs/moq-rtc/src/client/whep.rs
@@ -18,7 +18,7 @@ use url::Url;
 use crate::{Error, Result, client::Client, ingest::IngestSink, session};
 
 pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::broadcast::Producer) -> Result<()> {
-	let sink = Box::new(IngestSink::new(broadcast)?);
+	let sink = Box::new(IngestSink::new(broadcast, client.config().latency_max)?);
 
 	let (socket, candidates) = session::bind_udp(&client.config().ice_candidates).await?;
 	let mut rtc = Rtc::new(Instant::now());

--- a/rs/moq-rtc/src/ingest.rs
+++ b/rs/moq-rtc/src/ingest.rs
@@ -15,8 +15,9 @@ pub struct IngestSink {
 }
 
 impl IngestSink {
-	pub fn new(mut broadcast: moq_net::broadcast::Producer) -> Result<Self> {
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, latency_max: Option<std::time::Duration>) -> Result<Self> {
+		let config = moq_mux::catalog::Config::default().with_latency_max(latency_max);
+		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 		Ok(Self {
 			broadcast,
 			catalog,
@@ -70,5 +71,32 @@ impl session::MediaSink for IngestSink {
 
 	fn abort(&mut self, err: moq_net::Error) {
 		self.bridges.abort(err);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	use super::*;
+	use crate::session::MediaSink;
+
+	/// The retention the caller configured has to land on the media tracks the codec
+	/// bridges mint, not just on the catalog producer it was set on.
+	#[tokio::test]
+	async fn tracks_inherit_the_configured_retention() {
+		let broadcast = moq_net::broadcast::Info::new().produce();
+		let mut sink = IngestSink::new(broadcast.clone(), Some(Duration::from_secs(3))).unwrap();
+
+		sink.on_track(
+			"0".into(),
+			str0m::media::MediaKind::Video,
+			str0m::format::Codec::H264,
+			None,
+		)
+		.unwrap();
+
+		let info = broadcast.consume().track("0.avc3").unwrap().info().await.unwrap();
+		assert_eq!(info.latency_max, Duration::from_secs(3));
 	}
 }

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -14,6 +14,7 @@ mod mux;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use axum::Router;
 use axum::extract::{Path, State};
@@ -145,6 +146,18 @@ pub struct Config {
 	/// exactly one media port in its firewall. `0.0.0.0:0` (the default) lets
 	/// the OS pick a port, which is fine for dev/loopback; production pins it.
 	pub udp_bind: SocketAddr,
+
+	/// How long relays keep a non-latest group of an ingested media track fetchable.
+	///
+	/// A retention budget, not a delivery one: it never makes a subscriber play further
+	/// behind live, it caps how far back a FETCH can still reach. `None` keeps hang's own
+	/// default, which suits a segmented egress (HLS/DASH) reading the broadcast downstream:
+	/// it may only advertise segments that are still fetchable. Lower it when nothing reads
+	/// history and the memory matters.
+	///
+	/// Ingest only (`server publish` / WHIP): WHEP egress reads a broadcast someone else
+	/// declared, so it ignores this.
+	pub latency_max: Option<Duration>,
 }
 
 impl Default for Config {
@@ -152,6 +165,7 @@ impl Default for Config {
 		Self {
 			ice_candidates: Vec::new(),
 			udp_bind: SocketAddr::from(([0, 0, 0, 0], 0)),
+			latency_max: None,
 		}
 	}
 }
@@ -223,6 +237,10 @@ impl Server {
 	/// call [`whep::accept`] directly from your own handler.
 	pub fn subscribe_router(&self) -> Router {
 		whep::router(self.clone())
+	}
+
+	pub(crate) fn config(&self) -> &Config {
+		&self.inner.config
 	}
 
 	pub(crate) fn publisher(&self) -> &moq_net::origin::Producer {

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -103,7 +103,7 @@ pub async fn accept(
 		.map_err(|err| Error::Other(anyhow::anyhow!("failed to create broadcast: {err}")))?;
 
 	let handle = producer.clone();
-	let sink = Box::new(IngestSink::new(producer)?);
+	let sink = Box::new(IngestSink::new(producer, server.config().latency_max)?);
 
 	// Register a session on the shared media mux: known ICE credentials (so the
 	// demux routes this peer's STUN by ufrag), an inbox to read datagrams from,

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -26,6 +26,7 @@
 
 use std::collections::VecDeque;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use crate::rml::handshake::{Handshake, HandshakeProcessResult, PeerType};
 use crate::rml::sessions::{
@@ -67,6 +68,9 @@ pub struct Client<S = TcpStream> {
 	/// How long [`publish`](Self::publish)'s FLV muxer waits for a stalled group
 	/// before skipping. Defaults to [`DEFAULT_LATENCY`](crate::DEFAULT_LATENCY).
 	latency: moq_mux::Latency,
+	/// Retention declared on the media tracks [`pull`](Self::pull) publishes, or `None`
+	/// for hang's own default.
+	latency_max: Option<Duration>,
 }
 
 impl Client<TcpStream> {
@@ -145,6 +149,7 @@ impl<S: Stream> Client<S> {
 			session,
 			work,
 			latency: crate::DEFAULT_LATENCY,
+			latency_max: None,
 		})
 	}
 
@@ -154,6 +159,22 @@ impl<S: Stream> Client<S> {
 	/// [`Latency::REAL_TIME`](moq_mux::Latency::REAL_TIME) to drop stale groups aggressively.
 	pub fn with_latency(mut self, latency: moq_mux::Latency) -> Self {
 		self.latency = latency;
+		self
+	}
+
+	/// Set how long relays keep a non-latest group of the media tracks
+	/// [`pull`](Self::pull) publishes fetchable. `None` keeps hang's own default.
+	///
+	/// A retention budget, not a delivery one: it never makes a subscriber play further
+	/// behind live, it caps how far back a FETCH can still reach. The default suits a
+	/// segmented egress (HLS/DASH) reading the broadcast downstream, which may only
+	/// advertise segments that are still fetchable. Lower it when nothing reads history
+	/// and the memory matters.
+	///
+	/// The pull (ingest) direction only; [`publish`](Self::publish) reads a broadcast
+	/// someone else declared, and takes [`with_latency`](Self::with_latency) instead.
+	pub fn with_latency_max(mut self, latency_max: impl Into<Option<Duration>>) -> Self {
+		self.latency_max = latency_max.into();
 		self
 	}
 
@@ -249,7 +270,7 @@ impl<S: Stream> Client<S> {
 
 		tracing::info!(%stream_key, %path, "rtmp play accepted by remote");
 
-		let mut publisher = Publisher::new(origin, path.as_str())?;
+		let mut publisher = Publisher::new(origin, path.as_str(), self.latency_max)?;
 
 		let result = self.pull_media(&mut publisher).await;
 		match &result {
@@ -446,11 +467,12 @@ struct Publisher {
 }
 
 impl Publisher {
-	fn new(origin: &origin::Producer, path: &str) -> anyhow::Result<Self> {
+	fn new(origin: &origin::Producer, path: &str, latency_max: Option<Duration>) -> anyhow::Result<Self> {
 		let mut broadcast = origin
 			.create_broadcast(path, broadcast::Route::new().with_announce(true))
 			.map_err(|err| anyhow::anyhow!("broadcast '{path}' could not be published: {err}"))?;
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		let config = moq_mux::catalog::Config::default().with_latency_max(latency_max);
+		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 		let handle = broadcast.clone();
 		let mut importer = FlvImport::new(broadcast, catalog.reserve());
 

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -21,6 +21,7 @@
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use moq_net::origin;
 
@@ -50,6 +51,16 @@ pub struct Config {
 	/// to drop stale groups aggressively. Only affects egress (plays); ingest ignores it.
 	pub latency: moq_mux::Latency,
 
+	/// How long relays keep a non-latest group of an ingested media track fetchable, or
+	/// `None` for hang's own default.
+	///
+	/// A retention budget, not a delivery one: it never makes a subscriber play further
+	/// behind live, it caps how far back a FETCH can still reach. The default suits a
+	/// segmented egress (HLS/DASH) reading the broadcast downstream, which may only
+	/// advertise segments that are still fetchable. Lower it when nothing reads history
+	/// and the memory matters. Only affects ingest (publishes); egress ignores it.
+	pub latency_max: Option<Duration>,
+
 	/// TLS configuration for RTMPS (RTMP over TLS). When set, the
 	/// [`listen`](Self::listen) address speaks RTMPS instead of plaintext RTMP,
 	/// so clients connect with `rtmps://`. Build it with
@@ -70,6 +81,7 @@ impl Default for Config {
 			listen: None,
 			prefix: String::new(),
 			latency: crate::DEFAULT_LATENCY,
+			latency_max: None,
 			#[cfg(feature = "tls")]
 			tls: None,
 			active: ActivePaths::default(),
@@ -120,6 +132,7 @@ pub async fn run(origin: origin::Producer, config: Config) -> Result<()> {
 	let active = config.active.clone();
 	let prefix = Arc::new(config.prefix);
 	let latency = config.latency;
+	let latency_max = config.latency_max;
 	// Players are served out of the same origin the publishers write into.
 	let consumer = origin.consume();
 
@@ -146,7 +159,7 @@ pub async fn run(origin: origin::Producer, config: Config) -> Result<()> {
 						let _ = publish.reject("path already being published").await;
 						return;
 					};
-					if let Err(err) = publish.accept(&origin, &path).await {
+					if let Err(err) = publish.with_latency_max(latency_max).accept(&origin, &path).await {
 						tracing::warn!(%peer, %path, %err, "RTMP ingest ended with error");
 					}
 				});

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -483,6 +483,9 @@ pub struct Publish<S = Conn> {
 	app: String,
 	stream_key: String,
 	peer: SocketAddr,
+	/// Retention declared on the media tracks this publish mints, or `None` for hang's
+	/// own default. Override with [`with_latency_max`](Self::with_latency_max).
+	latency_max: Option<Duration>,
 }
 
 impl<S: Stream> Publish<S> {
@@ -504,6 +507,19 @@ impl<S: Stream> Publish<S> {
 		self.peer
 	}
 
+	/// Set how long relays keep a non-latest group of this publish's media tracks
+	/// fetchable. `None` keeps hang's own default.
+	///
+	/// A retention budget, not a delivery one: it never makes a subscriber play further
+	/// behind live, it caps how far back a FETCH can still reach. The default suits a
+	/// segmented egress (HLS/DASH) reading the broadcast downstream, which may only
+	/// advertise segments that are still fetchable. Lower it when nothing reads history
+	/// and the memory matters.
+	pub fn with_latency_max(mut self, latency_max: impl Into<Option<Duration>>) -> Self {
+		self.latency_max = latency_max.into();
+		self
+	}
+
 	/// Accept the publish: announce a broadcast at `path` in `origin` and pump the
 	/// RTMP media into it until the client disconnects.
 	///
@@ -516,7 +532,7 @@ impl<S: Stream> Publish<S> {
 		// Reserve the broadcast path before telling the client the publish succeeded:
 		// if the origin refuses `path`, reject cleanly instead of accepting and then
 		// dropping the connection a moment later.
-		let mut publisher = match Publisher::new(origin, path.as_str()) {
+		let mut publisher = match Publisher::new(origin, path.as_str(), self.latency_max) {
 			Ok(publisher) => publisher,
 			Err(err) => {
 				tracing::warn!(peer = %self.peer, %path, %err, "rejecting RTMP publish: broadcast unavailable");
@@ -924,6 +940,7 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 							app: app_name,
 							stream_key,
 							peer,
+							latency_max: None,
 						})));
 					}
 					// The client wants to play: hand control back to the caller.
@@ -1232,9 +1249,10 @@ struct Publisher {
 impl Publisher {
 	/// Open a broadcast at `path` and prime the importer with the FLV file
 	/// header, so subsequent tags decode against an initialized demuxer.
-	fn new(origin: &origin::Producer, path: &str) -> anyhow::Result<Self> {
+	fn new(origin: &origin::Producer, path: &str, latency_max: Option<Duration>) -> anyhow::Result<Self> {
 		let mut broadcast = origin.create_broadcast(path, broadcast::Route::new().with_announce(true))?;
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		let config = moq_mux::catalog::Config::default().with_latency_max(latency_max);
+		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 		let handle = broadcast.clone();
 		let mut importer = FlvImport::new(broadcast, catalog.reserve());
 
@@ -1560,9 +1578,26 @@ mod tests {
 		}
 	}
 
-	/// End-to-end play: publish a real broadcast into an origin (via the FLV
-	/// importer, so it carries a catalog + frames), then drive an RTMP play client
-	/// and assert it receives the muxed AVC sequence header and keyframe back.
+	/// The retention a publish declares has to reach the media tracks the FLV importer
+	/// mints, not stop at the catalog producer it was set on.
+	#[tokio::test]
+	async fn publisher_declares_the_configured_retention() {
+		let mut vseq = vec![0x17, 0x00, 0x00, 0x00, 0x00];
+		vseq.extend_from_slice(&[0x01, 0x42, 0xc0, 0x1f, 0xff, 0xe1, 0x00, 0x04, 0x67, 0x42, 0xc0, 0x1f]);
+		vseq.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]);
+
+		let origin = moq_net::Origin::random().produce();
+		let mut publisher = Publisher::new(&origin, "live/cam0", Some(Duration::from_secs(3))).unwrap();
+		publisher.push(flv::TAG_VIDEO, 0, &vseq).unwrap();
+
+		let broadcast = origin.consume().announced_broadcast("live/cam0").await.unwrap();
+		let info = broadcast.track("0.flv-v").unwrap().info().await.unwrap();
+		assert_eq!(info.latency_max, Duration::from_secs(3));
+	}
+
+	/// End-to-end play: publish a real broadcast into an origin (via the FLV importer, so it
+	/// carries a catalog + frames), then drive an RTMP play client and assert it receives the
+	/// muxed AVC sequence header and keyframe back.
 	#[tokio::test]
 	async fn play_streams_broadcast_to_client() {
 		// An AVC sequence-header tag body: keyframe + AVC CodecID, AVCPacketType 0,

--- a/rs/moq-srt/src/dial.rs
+++ b/rs/moq-srt/src/dial.rs
@@ -26,63 +26,91 @@ use srt_tokio::SrtSocket;
 use crate::Result;
 use crate::server::{DEFAULT_LATENCY, configure_buffers, serve_publish, serve_subscribe};
 
-/// Dial `addr` and push a MoQ broadcast out to the remote: connect as an SRT caller
-/// requesting the remote receive on `resource` (`m=publish`), re-mux `path` from
-/// `origin` to MPEG-TS, and send it until the broadcast ends.
+/// Where to dial and how, shared by [`publish`] and [`pull`].
 ///
-/// `latency` is the SRT receive latency negotiated at handshake time; pass `None`
-/// for the default (500ms). This future resolves when the broadcast ends, so
-/// callers usually run it on its own task.
-pub async fn publish(
-	addr: SocketAddr,
-	resource: &str,
-	latency: impl Into<Option<Duration>>,
-	origin: &origin::Consumer,
-	path: impl moq_net::AsPath,
-) -> Result<()> {
-	let path = path.as_path();
-	let latency = latency.into().unwrap_or(DEFAULT_LATENCY);
-	let socket = call(addr, resource, Mode::Publish, latency).await?;
-	serve_subscribe(origin, path.as_str(), socket, latency).await
+/// Construct via [`Config::new`] and set the fields you need, so new options stay
+/// additive.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct Config {
+	/// The remote SRT listener to call.
+	pub addr: SocketAddr,
+
+	/// The resource to request, sent as the stream id's `r=` value. Must not contain
+	/// `,` or `=`, which delimit the stream id.
+	pub resource: String,
+
+	/// SRT receive latency, negotiated at handshake time: the buffer that trades delay
+	/// for loss recovery. It doubles as [`publish`]'s egress skip threshold.
+	pub latency: Duration,
+
+	/// How long relays keep a non-latest group of an ingested media track fetchable, or
+	/// `None` for hang's own default.
+	///
+	/// A retention budget, not a delivery one: it never makes a subscriber play further
+	/// behind live, it caps how far back a FETCH can still reach. The default suits a
+	/// segmented egress (HLS/DASH) reading the broadcast downstream, which may only
+	/// advertise segments that are still fetchable. Lower it when nothing reads history
+	/// and the memory matters. [`pull`] only; [`publish`] reads a broadcast someone else
+	/// declared.
+	pub latency_max: Option<Duration>,
 }
 
-/// Dial `addr` and pull a remote stream into `origin`: connect as an SRT caller
-/// requesting the remote send on `resource` (`m=request`), demux its MPEG-TS, and
-/// publish the result at `path` until the remote ends.
-///
-/// `latency` is the SRT receive latency negotiated at handshake time; pass `None`
-/// for the default (500ms). This future resolves when the remote stream ends, so
-/// callers usually run it on its own task.
-pub async fn pull(
-	addr: SocketAddr,
-	resource: &str,
-	latency: impl Into<Option<Duration>>,
-	origin: &origin::Producer,
-	path: impl moq_net::AsPath,
-) -> Result<()> {
-	let path = path.as_path();
-	let socket = call(addr, resource, Mode::Request, latency).await?;
-	serve_publish(origin, path.as_str(), socket).await
+impl Config {
+	/// Dial `addr` for `resource`, with the default SRT latency (500ms) and the
+	/// publisher's own media retention.
+	pub fn new(addr: SocketAddr, resource: impl Into<String>) -> Self {
+		Self {
+			addr,
+			resource: resource.into(),
+			latency: DEFAULT_LATENCY,
+			latency_max: None,
+		}
+	}
 }
 
-/// Dial `addr` as an SRT caller for `resource`, sending the standard
-/// `#!::r=<resource>,m=<mode>` stream id and returning the connected socket.
+/// Push a MoQ broadcast out to the remote: connect as an SRT caller requesting the
+/// remote receive on [`Config::resource`] (`m=publish`), re-mux `path` from `origin`
+/// to MPEG-TS, and send it until the broadcast ends.
+///
+/// This future resolves when the broadcast ends, so callers usually run it on its own
+/// task.
+pub async fn publish(config: &Config, origin: &origin::Consumer, path: impl moq_net::AsPath) -> Result<()> {
+	let path = path.as_path();
+	let socket = call(config, Mode::Publish).await?;
+	serve_subscribe(origin, path.as_str(), socket, config.latency).await
+}
+
+/// Pull a remote stream into `origin`: connect as an SRT caller requesting the remote
+/// send on [`Config::resource`] (`m=request`), demux its MPEG-TS, and publish the
+/// result at `path` until the remote ends.
+///
+/// This future resolves when the remote stream ends, so callers usually run it on its
+/// own task.
+pub async fn pull(config: &Config, origin: &origin::Producer, path: impl moq_net::AsPath) -> Result<()> {
+	let path = path.as_path();
+	let socket = call(config, Mode::Request).await?;
+	serve_publish(origin, path.as_str(), socket, config.latency_max).await
+}
+
+/// Dial as an SRT caller, sending the standard `#!::r=<resource>,m=<mode>` stream id
+/// and returning the connected socket.
 ///
 /// `mode` is the *remote's* role, the inverse of the local direction (the remote
 /// receives on `m=publish`, sends on `m=request`).
-async fn call(addr: SocketAddr, resource: &str, mode: Mode, latency: impl Into<Option<Duration>>) -> Result<SrtSocket> {
+async fn call(config: &Config, mode: Mode) -> Result<SrtSocket> {
+	let Config { addr, resource, .. } = config;
 	// `,` and `=` delimit the `#!::r=<resource>,m=<mode>` stream id, so a resource
 	// carrying either would corrupt it and misroute at the listener. Reject rather
 	// than silently produce a broken id (MoQ paths never contain these).
 	if resource.contains([',', '=']) {
 		return Err(anyhow::anyhow!("srt resource must not contain ',' or '=': {resource:?}").into());
 	}
-	let latency = latency.into().unwrap_or(DEFAULT_LATENCY);
 	let stream_id = format!("#!::r={resource},m={}", mode.as_str());
 	let socket = SrtSocket::builder()
-		.latency(latency)
+		.latency(config.latency)
 		.set(configure_buffers)
-		.call(addr, Some(&stream_id))
+		.call(*addr, Some(&stream_id))
 		.await?;
 	tracing::info!(%addr, %resource, mode = mode.as_str(), "SRT caller connected");
 	Ok(socket)
@@ -148,7 +176,7 @@ mod tests {
 		});
 
 		// Caller: dial with m=publish, then drop (we only assert connect + routing).
-		let caller = tokio::spawn(async move { call(addr, "cam0", Mode::Publish, None).await });
+		let caller = tokio::spawn(async move { call(&Config::new(addr, "cam0"), Mode::Publish).await });
 
 		let socket = tokio::time::timeout(Duration::from_secs(10), caller)
 			.await
@@ -187,7 +215,7 @@ mod tests {
 			(resource, is_subscribe)
 		});
 
-		let caller = tokio::spawn(async move { call(addr, "cam0", Mode::Request, None).await });
+		let caller = tokio::spawn(async move { call(&Config::new(addr, "cam0"), Mode::Request).await });
 
 		let socket = tokio::time::timeout(Duration::from_secs(10), caller)
 			.await

--- a/rs/moq-srt/src/lib.rs
+++ b/rs/moq-srt/src/lib.rs
@@ -24,8 +24,8 @@
 //!   JWT and scoping the origin per token) plugs its policy in. It mirrors
 //!   `moq-native`'s `Server` / `Request`.
 //!
-//! Beyond the listener, the [`dial`] module is the *dial-out* (client) role:
-//! connect to a remote SRT listener as a caller and either [`dial::publish`] a MoQ
+//! Beyond the listener, the [`dial`] module is the *dial-out* (client) role: build a
+//! [`dial::Config`] naming a remote SRT listener and either [`dial::publish`] a MoQ
 //! broadcast to it (restream MoQ out to a remote SRT ingest) or [`dial::pull`] a
 //! remote stream into an origin (ingest a remote SRT source). It reuses the same
 //! MPEG-TS <-> moq bridge; only the SRT caller transport is new.

--- a/rs/moq-srt/src/listen.rs
+++ b/rs/moq-srt/src/listen.rs
@@ -54,6 +54,16 @@ pub struct Config {
 	/// SRT receive latency: the negotiated buffer that trades delay for loss
 	/// recovery.
 	pub latency: Duration,
+
+	/// How long relays keep a non-latest group of an ingested media track fetchable, or
+	/// `None` for hang's own default.
+	///
+	/// A retention budget, not a delivery one: it never makes a subscriber play further
+	/// behind live, it caps how far back a FETCH can still reach. The default suits a
+	/// segmented egress (HLS/DASH) reading the broadcast downstream, which may only
+	/// advertise segments that are still fetchable. Lower it when nothing reads history
+	/// and the memory matters. Only affects ingest (`m=publish`); egress ignores it.
+	pub latency_max: Option<Duration>,
 }
 
 impl Default for Config {
@@ -62,6 +72,7 @@ impl Default for Config {
 			listen: None,
 			prefix: String::new(),
 			latency: crate::server::DEFAULT_LATENCY,
+			latency_max: None,
 		}
 	}
 }
@@ -98,6 +109,7 @@ pub async fn run(origin: origin::Producer, config: Config) -> Result<()> {
 	// take over the path when the first publisher drops.
 	let active = ActivePaths::default();
 	let prefix = Arc::new(config.prefix);
+	let latency_max = config.latency_max;
 
 	while let Some(request) = server.accept().await {
 		let prefix = prefix.clone();
@@ -118,7 +130,7 @@ pub async fn run(origin: origin::Producer, config: Config) -> Result<()> {
 						let _ = publish.reject().await;
 						return;
 					};
-					if let Err(err) = publish.accept(&origin, &path).await {
+					if let Err(err) = publish.with_latency_max(latency_max).accept(&origin, &path).await {
 						tracing::warn!(%peer, %path, %err, "SRT ingest ended with error");
 					} else {
 						tracing::info!(%peer, %path, "SRT ingest ended");

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -107,6 +107,7 @@ impl Server {
 				stream_id,
 				peer,
 				latency: self.latency,
+				latency_max: None,
 			};
 
 			// `m=request` reads a broadcast out; everything else publishes one in.
@@ -133,6 +134,9 @@ struct Pending {
 	peer: SocketAddr,
 	/// The SRT receive latency, reused as the egress skip threshold on a subscribe.
 	latency: Duration,
+	/// Retention declared on the media tracks an ingest mints, or `None` for hang's own
+	/// default. Override with [`Publish::with_latency_max`].
+	latency_max: Option<Duration>,
 }
 
 /// What an accepted SRT connection wants: to contribute media ([`Publish`]) or to
@@ -205,6 +209,22 @@ impl Publish {
 		self.0.peer
 	}
 
+	/// Set how long relays keep a non-latest group of this publish's media tracks
+	/// fetchable. `None` keeps hang's own default.
+	///
+	/// A retention budget, not a delivery one: it never makes a subscriber play further
+	/// behind live, it caps how far back a FETCH can still reach. The default suits a
+	/// segmented egress (HLS/DASH) reading the broadcast downstream, which may only
+	/// advertise segments that are still fetchable. Lower it when nothing reads history
+	/// and the memory matters.
+	///
+	/// Unrelated to the SRT receive latency [`Server::bind`] negotiates, which is a
+	/// transport buffer on this hop.
+	pub fn with_latency_max(mut self, latency_max: impl Into<Option<Duration>>) -> Self {
+		self.0.latency_max = latency_max.into();
+		self
+	}
+
 	/// Accept the publish: announce a broadcast at `path` in `origin` and pump the
 	/// connection's MPEG-TS into it until the client disconnects.
 	///
@@ -216,7 +236,7 @@ impl Publish {
 		let path = path.as_path();
 		let socket = self.0.request.accept(None).await?;
 		tracing::info!(peer = %self.0.peer, %path, "SRT publish accepted");
-		serve_publish(origin, path.as_str(), socket).await
+		serve_publish(origin, path.as_str(), socket, self.0.latency_max).await
 	}
 
 	/// Reject the publish, sending the client a `Forbidden` rejection.
@@ -289,10 +309,15 @@ async fn reject_log(request: ConnectionRequest, reason: ServerRejectReason, peer
 }
 
 /// Pump one accepted SRT socket's MPEG-TS payload into the origin (`m=publish`).
-pub(crate) async fn serve_publish(origin: &origin::Producer, path: &str, mut socket: SrtSocket) -> Result<()> {
+pub(crate) async fn serve_publish(
+	origin: &origin::Producer,
+	path: &str,
+	mut socket: SrtSocket,
+	latency_max: Option<Duration>,
+) -> Result<()> {
 	use futures::TryStreamExt;
 
-	let mut publisher = crate::ts::Publisher::new(origin, path)?;
+	let mut publisher = crate::ts::Publisher::new(origin, path, latency_max)?;
 
 	// Run the read/feed loop so an error surfaces here instead of unwinding past
 	// the publisher, which would drop it (and its tracks) with a bare Error::Dropped.

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -32,9 +32,13 @@ pub struct Publisher {
 impl Publisher {
 	/// Create the broadcast on `origin` at `path` and wire up the TS importer +
 	/// catalog.
-	pub fn new(origin: &origin::Producer, path: &str) -> Result<Self> {
+	///
+	/// `latency_max` is the retention declared on the media tracks the importer mints: how
+	/// long relays keep a non-latest group fetchable, or `None` for hang's own default.
+	pub fn new(origin: &origin::Producer, path: &str, latency_max: Option<Duration>) -> Result<Self> {
 		let mut broadcast = origin.create_broadcast(path, broadcast::Route::new().with_announce(true))?;
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		let config = moq_mux::catalog::Config::default().with_latency_max(latency_max);
+		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 		let handle = broadcast.clone();
 		let importer = ts::Import::new(broadcast, catalog.reserve());
 		tracing::info!(%path, "publishing ingest broadcast");
@@ -113,5 +117,70 @@ impl Subscriber {
 	/// broadcast ends.
 	pub async fn next(&mut self) -> Result<Option<Frame>> {
 		Ok(self.export.next().await?)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// One payload-only TS packet carrying a complete PSI section (PUSI + pointer_field
+	/// 0), padded to 188 with stuffing.
+	fn psi_packet(pid: u16, section: &[u8]) -> Vec<u8> {
+		let mut p = vec![0x47, 0x40 | (pid >> 8) as u8, pid as u8, 0x10, 0x00];
+		p.extend_from_slice(section);
+		p.resize(188, 0xff);
+		p
+	}
+
+	/// Append the CRC-32/MPEG-2 the PSI parser checks (poly 0x04c11db7, init all-ones,
+	/// unreflected, no final xor) over everything written so far.
+	fn seal(mut section: Vec<u8>) -> Vec<u8> {
+		let mut crc = 0xffff_ffffu32;
+		for byte in &section {
+			crc ^= u32::from(*byte) << 24;
+			for _ in 0..8 {
+				crc = if crc & 0x8000_0000 != 0 {
+					(crc << 1) ^ 0x04c1_1db7
+				} else {
+					crc << 1
+				};
+			}
+		}
+		section.extend_from_slice(&crc.to_be_bytes());
+		section
+	}
+
+	/// A PAT with one program (number 1) whose PMT lives on `pmt_pid`.
+	fn pat(pmt_pid: u16) -> Vec<u8> {
+		let mut s = vec![0x00, 0xb0, 0x0d, 0x00, 0x01, 0xc1, 0x00, 0x00];
+		s.extend_from_slice(&[0x00, 0x01]);
+		s.extend_from_slice(&[0xe0 | (pmt_pid >> 8) as u8, pmt_pid as u8]);
+		seal(s)
+	}
+
+	/// A PMT for program 1 declaring a single H.264 elementary stream on `es_pid`.
+	fn pmt(es_pid: u16) -> Vec<u8> {
+		let mut s = vec![0x02, 0xb0, 0x12, 0x00, 0x01, 0xc1, 0x00, 0x00];
+		s.extend_from_slice(&[0xe0 | (es_pid >> 8) as u8, es_pid as u8]);
+		s.extend_from_slice(&[0xf0, 0x00]);
+		s.extend_from_slice(&[0x1b, 0xe0 | (es_pid >> 8) as u8, es_pid as u8, 0xf0, 0x00]);
+		seal(s)
+	}
+
+	/// The retention the caller configured has to reach the media tracks the TS importer
+	/// mints off the PMT, not stop at the catalog producer it was set on.
+	#[tokio::test]
+	async fn publisher_declares_the_configured_retention() {
+		let origin = moq_net::Origin::random().produce();
+		let mut publisher = Publisher::new(&origin, "live/cam0", Some(Duration::from_secs(3))).unwrap();
+
+		let mut ts = psi_packet(0x0000, &pat(0x0100));
+		ts.extend_from_slice(&psi_packet(0x0100, &pmt(0x0101)));
+		publisher.feed(Bytes::from(ts)).unwrap();
+
+		let broadcast = origin.consume().announced_broadcast("live/cam0").await.unwrap();
+		let info = broadcast.track("0.avc3").unwrap().info().await.unwrap();
+		assert_eq!(info.latency_max, Duration::from_secs(3));
 	}
 }


### PR DESCRIPTION
Closes #2646. Follows #2615, which added `moq import --latency-max`; that has merged, so this stands alone.

**Targets `dev`**, not `main`: `moq_srt::dial::{publish,pull}` change signature, which is a semver break in a published crate. Everything else here is additive.

## Summary

- `--latency-max` reached the stdin containers, `hls`, and `capture` because those build their `catalog::Producer` inside `moq-cli`. `rtmp` / `srt` / `rtc` build theirs inside `moq-rtmp` / `moq-srt` / `moq-rtc`, which took no retention, so `run_import` **refused** the flag there rather than publishing at the default behind the operator's back.
- Each gateway now takes the retention and passes it to `catalog::Config` at its ingest catalog. The guard and `ImportSource::honors_latency_max` are gone, so the flag applies to every import source.
- The retention is `Option<Duration>` the whole way down, matching the CLI flag and `catalog::Config`: `None` means "the publisher's own default", so no gateway restates hang's number. That is also why `moq-srt` needs no new dependency.
- `moq-cli`'s six gateway import entry points were each taking `origin` + `name` positionally and would have taken a third shared value; they now take one `ImportTarget` (origin, name, retention). `rtc::listen_import` drops from 6 args to 4.
- `moq_srt::dial::{publish,pull}` were already at 5 positional args and needed a 6th, so they take a `dial::Config` (addr, resource, latency, latency_max) instead.

Docs: `doc/bin/cli.md` already documented `import --latency-max` from #2615, with a sentence saying the gateways refuse it. That sentence is now wrong, so the paragraph says the flag applies to every source and carries the example.

## Public API changes

**moq-rtc** (additive)
- `server::Config::latency_max`, `client::Config::latency_max`, both `Option<Duration>` on `#[non_exhaustive]` configs. `client::Config` keeps its derived `Default` (`None` is the default).

**moq-rtmp** (additive)
- `Publish::with_latency_max`, `Client::with_latency_max` (both `impl Into<Option<Duration>>`), `listen::Config::latency_max`, `dial` retention on `Client`.

**moq-srt**
- `Publish::with_latency_max`, `listen::Config::latency_max` (additive).
- **Signature change**: `dial::publish` / `dial::pull` now take `(&dial::Config, origin, path)` instead of `(addr, resource, latency, origin, path)`. New: `dial::Config`. Both were already at five positional arguments and needed a sixth, so the options bag replaces them rather than growing them. This is the break that puts the PR on `dev`: an existing 0.2.x caller must rewrite its call even if it never touches `latency_max`.

**moq-cli** (a binary, so no semver surface): `moq::ImportTarget` added; `ImportSource::honors_latency_max` removed; the six gateway `*_import` signatures changed.

`IngestSink::new`, `ts::Publisher::new`, and both `Publisher::new`s are crate-private.

## Test plan

Three regression tests, one per gateway, each asserting a non-default retention reaches the *media track* the importer mints rather than stopping at the catalog producer:

- `moq_rtc::ingest::tests::tracks_inherit_the_configured_retention` (H.264 bridge via `on_track`)
- `moq_rtmp::server::tests::publisher_declares_the_configured_retention` (synthetic FLV AVC sequence header)
- `moq_srt::ts::tests::publisher_declares_the_configured_retention` (hand-built PAT + PMT)

`just fix` / `just check` clean; `cargo check --workspace --all-targets` clean; `RUSTDOCFLAGS=-D warnings cargo doc` clean on moq-mux, moq-cli, and the three gateways; tests pass across moq-mux / moq-cli / moq-rtc / moq-rtmp / moq-srt.

## Cross-Package Sync

`rs/moq-cli` -> `doc/bin/cli.md` done. No wire format, catalog, container, or `moq-ffi` surface changed, so no draft or binding updates; `moq-relay` does not embed the RTMP/SRT gateways.

(written by Opus 5)


