### PR TITLE
fix(obs): track the matching libmoq version

### DIFF
--- a/.github/workflows/libmoq.yml
+++ b/.github/workflows/libmoq.yml
@@ -130,7 +130,8 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
+            # The plugin preset uses the Visual Studio 17 2022 generator.
+            os: windows-2022
 
     steps:
       # Shallow: this job only compiles, it never reads git history or tags.

--- a/cpp/obs/CMakeLists.txt
+++ b/cpp/obs/CMakeLists.txt
@@ -1,5 +1,27 @@
 cmake_minimum_required(VERSION 3.28)
 
+# Build the in-tree libmoq by default. Release-only builds clear MOQ_LOCAL and
+# must select the published archive explicitly, so this never silently drifts
+# to an old static version.
+set(MOQ_LOCAL "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "Path to the moq repo (builds rs/libmoq in-tree)")
+set(MOQ_VERSION "" CACHE STRING "Published libmoq version (required without MOQ_LOCAL)")
+
+if(MOQ_LOCAL AND EXISTS "${MOQ_LOCAL}/rs/libmoq/CMakeLists.txt")
+  set(_moq_manifest "${MOQ_LOCAL}/rs/libmoq/Cargo.toml")
+  file(STRINGS "${_moq_manifest}" _moq_version_lines REGEX "^version = \"[^\"]+\"$")
+  list(LENGTH _moq_version_lines _moq_version_count)
+  if(NOT _moq_version_count EQUAL 1)
+    message(FATAL_ERROR "Expected one package version in ${_moq_manifest}, found ${_moq_version_count}")
+  endif()
+  list(GET _moq_version_lines 0 _moq_version_line)
+  string(REGEX REPLACE "^version = \"([^\"]+)\"$" "\\1" _moq_link_version "${_moq_version_line}")
+else()
+  if(NOT MOQ_VERSION)
+    message(FATAL_ERROR "MOQ_VERSION is required when MOQ_LOCAL does not contain rs/libmoq")
+  endif()
+  set(_moq_link_version "${MOQ_VERSION}")
+endif()
+
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCOPE)
 
 project(${_name} VERSION ${_version})
@@ -37,11 +59,6 @@ endif()
 
 target_link_libraries(obs-moq PRIVATE OBS::libobs)
 
-# Default to the in-tree moq checkout (this file lives at cpp/obs, so the repo
-# root is two levels up). A consumer building cpp/obs in isolation can point
-# MOQ_LOCAL elsewhere, or unset it to fall back to the published release.
-set(MOQ_LOCAL "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "Path to the moq repo (builds rs/libmoq in-tree)")
-
 if(MOQ_LOCAL AND EXISTS "${MOQ_LOCAL}/rs/libmoq/CMakeLists.txt")
   add_subdirectory("${MOQ_LOCAL}/rs/libmoq" moq)
   target_link_libraries(obs-moq PRIVATE moq)
@@ -50,7 +67,7 @@ else()
   FetchContent_Declare(
     moq
     URL
-      https://github.com/moq-dev/moq/releases/download/libmoq-v${MOQ_VERSION}/moq-${MOQ_VERSION}-${MOQ_TARGET}.${MOQ_ARCHIVE}
+      https://github.com/moq-dev/moq/releases/download/libmoq-v${_moq_link_version}/moq-${_moq_link_version}-${MOQ_TARGET}.${MOQ_ARCHIVE}
   )
   FetchContent_MakeAvailable(moq)
 
@@ -137,7 +154,7 @@ target_sources(
 # The dock requires both the frontend API (to register it) and Qt (to build it).
 if(ENABLE_FRONTEND_API AND ENABLE_QT)
   target_sources(obs-moq PRIVATE src/moq-dock.cpp src/moq-dock.h)
-  target_compile_definitions(obs-moq PRIVATE MOQ_FRONTEND_ENABLED MOQ_VERSION_STRING="${MOQ_VERSION}")
+  target_compile_definitions(obs-moq PRIVATE MOQ_FRONTEND_ENABLED MOQ_VERSION_STRING="${_moq_link_version}")
 endif()
 
 if(${BUILD_PLUGIN})

--- a/cpp/obs/CMakeLists.txt
+++ b/cpp/obs/CMakeLists.txt
@@ -6,7 +6,14 @@ cmake_minimum_required(VERSION 3.28)
 set(MOQ_LOCAL "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "Path to the moq repo (builds rs/libmoq in-tree)")
 set(MOQ_VERSION "" CACHE STRING "Published libmoq version (required without MOQ_LOCAL)")
 
+# One predicate for both the version derivation here and the link/fetch choice
+# below, so the two can't drift apart.
+set(_moq_local_build FALSE)
 if(MOQ_LOCAL AND EXISTS "${MOQ_LOCAL}/rs/libmoq/CMakeLists.txt")
+  set(_moq_local_build TRUE)
+endif()
+
+if(_moq_local_build)
   set(_moq_manifest "${MOQ_LOCAL}/rs/libmoq/Cargo.toml")
   file(STRINGS "${_moq_manifest}" _moq_version_lines REGEX "^version = \"[^\"]+\"$")
   list(LENGTH _moq_version_lines _moq_version_count)
@@ -59,7 +66,7 @@ endif()
 
 target_link_libraries(obs-moq PRIVATE OBS::libobs)
 
-if(MOQ_LOCAL AND EXISTS "${MOQ_LOCAL}/rs/libmoq/CMakeLists.txt")
+if(_moq_local_build)
   add_subdirectory("${MOQ_LOCAL}/rs/libmoq" moq)
   target_link_libraries(obs-moq PRIVATE moq)
 else()

--- a/cpp/obs/CMakePresets.json
+++ b/cpp/obs/CMakePresets.json
@@ -14,7 +14,6 @@
         "ENABLE_QT": true,
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "BUILD_PLUGIN": true,
-        "MOQ_VERSION": "0.3.6",
         "MOQ_ARCHIVE": "tar.gz"
       }
     },

--- a/cpp/obs/build.sh
+++ b/cpp/obs/build.sh
@@ -110,8 +110,8 @@ if [[ -n "$VERSION" ]]; then
 fi
 if [[ -n "$MOQ_RELEASE" ]]; then
     # Empty MOQ_LOCAL forces CMake's release-download branch; MOQ_VERSION and
-    # MOQ_TARGET steer it at this target's archive (the presets hard-code an
-    # x86_64/stale default). MOQ_ARCHIVE is correct per preset already.
+    # MOQ_TARGET steer it at this target's archive. MOQ_ARCHIVE is correct per
+    # preset already.
     echo "Linking libmoq release v$MOQ_RELEASE ($TARGET)"
     CONFIGURE_ARGS+=(-DMOQ_LOCAL= "-DMOQ_VERSION=$MOQ_RELEASE" "-DMOQ_TARGET=$TARGET")
 fi

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -62,6 +62,20 @@ run:
 check:
     #!/usr/bin/env bash
     set -euo pipefail
+    if grep -Fq '"MOQ_VERSION"' CMakePresets.json; then
+        echo "CMakePresets.json must not pin MOQ_VERSION" >&2
+        exit 1
+    fi
+    build_dir=$(mktemp -d)
+    trap 'rm -rf "$build_dir"' EXIT
+    if cmake -S . -B "$build_dir" -DMOQ_LOCAL= >"$build_dir/configure.log" 2>&1; then
+        echo "CMake accepted a release build without MOQ_VERSION" >&2
+        exit 1
+    fi
+    if ! grep -Fq "MOQ_VERSION is required when MOQ_LOCAL does not contain rs/libmoq" "$build_dir/configure.log"; then
+        cat "$build_dir/configure.log" >&2
+        exit 1
+    fi
     if command -v clang-format >/dev/null; then
         git ls-files 'src/*.cpp' 'src/*.h' | xargs clang-format --dry-run --Werror
     fi

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -66,15 +66,17 @@ check:
         echo "CMakePresets.json must not pin MOQ_VERSION" >&2
         exit 1
     fi
-    build_dir=$(mktemp -d)
-    trap 'rm -rf "$build_dir"' EXIT
-    if cmake -S . -B "$build_dir" -DMOQ_LOCAL= >"$build_dir/configure.log" 2>&1; then
-        echo "CMake accepted a release build without MOQ_VERSION" >&2
-        exit 1
-    fi
-    if ! grep -Fq "MOQ_VERSION is required when MOQ_LOCAL does not contain rs/libmoq" "$build_dir/configure.log"; then
-        cat "$build_dir/configure.log" >&2
-        exit 1
+    if command -v cmake >/dev/null; then
+        build_dir=$(mktemp -d)
+        trap 'rm -rf "$build_dir"' EXIT
+        if cmake -S . -B "$build_dir" -DMOQ_LOCAL= >"$build_dir/configure.log" 2>&1; then
+            echo "CMake accepted a release build without MOQ_VERSION" >&2
+            exit 1
+        fi
+        if ! grep -Fq "MOQ_VERSION is required when MOQ_LOCAL does not contain rs/libmoq" "$build_dir/configure.log"; then
+            cat "$build_dir/configure.log" >&2
+            exit 1
+        fi
     fi
     if command -v clang-format >/dev/null; then
         git ls-files 'src/*.cpp' 'src/*.h' | xargs clang-format --dry-run --Werror

--- a/justfile
+++ b/justfile
@@ -89,6 +89,11 @@ check $BASE="":
     if [[ -n "$files" ]]; then
     	just js check "$files"
     	just rs check-changed "$files"
+    	# The OBS plugin has no compile job in PR CI, so its lint + CMake
+    	# guards are the only automated coverage it gets.
+    	if echo "$files" | grep -q '^cpp/obs/'; then
+    		just obs check
+    	fi
     else
     	echo "check: nothing changed."
     fi
@@ -99,6 +104,7 @@ check $BASE="":
 check-all *args:
     just js check
     just rs check {{ args }}
+    just obs check
     just _check-common
 
 # Repository-wide non-compiling checks shared by `check` and `check-all`.
@@ -150,6 +156,15 @@ ci BASE="":
     	just go    ci "$files"
     fi
 
+    # The OBS plugin has no compile job in PR CI, so its lint + CMake guards
+    # are the only automated coverage it gets. Empty $files is a force-run,
+    # so run then.
+    if [[ -z "$files" ]] || echo "$files" | grep -q '^cpp/obs/'; then
+    	just obs check
+    else
+    	echo "ci: no cpp/obs changes; skipping obs check."
+    fi
+
     # Validate the flake (eval + dev shell build) via `nix flake check`. This no
     # longer compiles the workspace -- the heavy Rust CI (clippy/doc/test) moved
     # to `just rs ci` (plain cargo), leaving only lightweight Nix checks -- so
@@ -186,6 +201,9 @@ fix $BASE="":
     if [[ -n "$files" ]]; then
     	just js fix "$files"
     	just rs fix-changed "$files"
+    	if echo "$files" | grep -q '^cpp/obs/'; then
+    		just obs fix
+    	fi
     else
     	echo "fix: nothing changed."
     fi
@@ -198,6 +216,7 @@ fix-all:
     just js fix
     just rs fix
     just py fix
+    just obs fix
     just _fix-common
 
 # Optional tools skip if missing locally. `bun install` for the same reason as


### PR DESCRIPTION
## Summary

- Remove the stale libmoq 0.3.6 pin from the OBS CMake presets.
- Derive the linked version from the in-tree `rs/libmoq` manifest for local builds, while requiring release builds to select an explicit published version.
- Run the Windows OBS release build on Windows 2022 because its CMake preset requires the Visual Studio 2022 generator.
- Add regression checks that reject static preset pins and release configurations without `MOQ_VERSION`, and dispatch those checks from the root `check`, `fix`, and `ci` workflows.

The root cause was that the 0.3.6 fallback survived the OBS plugin's move into the monorepo even though tagged release builds already supplied the matching libmoq version. Newer plugin releases then failed to complete because `windows-latest` moved beyond the Visual Studio 2022 generator requested by the preset. The OBS-specific regression guards also needed root task-runner integration to execute in pull request CI.

## Public API changes

None.

## Test plan

- `nix develop --command just obs fix`
- `nix develop --command just obs check`
- `nix develop --command just check`
- `nix develop --command just ci`
- Native macOS OBS plugin build against in-tree libmoq 0.5.3
- GitHub Check workflow passed

(Written by GPT-5)