### PR TITLE
fix(moq-net): handle namespace errors and directional link costs

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -310,9 +310,21 @@ impl Client {
 		self
 	}
 
-	/// Price the links this client dials; see [`moq_net::Client::with_cost`].
+	/// Price both directions of the links this client dials.
 	pub fn with_cost(mut self, cost: u64) -> Self {
 		self.moq = self.moq.with_cost(cost);
+		self
+	}
+
+	/// Price what peers pay to subscribe from this client.
+	pub fn with_egress_cost(mut self, cost: u64) -> Self {
+		self.moq = self.moq.with_egress_cost(cost);
+		self
+	}
+
+	/// Price what this client pays to subscribe from peers.
+	pub fn with_ingress_cost(mut self, cost: u64) -> Self {
+		self.moq = self.moq.with_ingress_cost(cost);
 		self
 	}
 

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -263,6 +263,24 @@ impl Server {
 		self
 	}
 
+	/// Price both directions of every accepted link.
+	pub fn with_cost(mut self, cost: u64) -> Self {
+		self.moq = self.moq.with_cost(cost);
+		self
+	}
+
+	/// Price what clients pay to subscribe from this server.
+	pub fn with_egress_cost(mut self, cost: u64) -> Self {
+		self.moq = self.moq.with_egress_cost(cost);
+		self
+	}
+
+	/// Price what this server pays to subscribe from clients.
+	pub fn with_ingress_cost(mut self, cost: u64) -> Self {
+		self.moq = self.moq.with_ingress_cost(cost);
+		self
+	}
+
 	/// Accept sessions until the listener stops, serving `origin` to each subscriber.
 	///
 	/// Spawns a task per session and logs (rather than propagates) per-session
@@ -946,6 +964,57 @@ impl Request {
 			kind,
 		} = self;
 		let kind = request_map!(kind, request => request.with_stats(stats));
+		Request {
+			transport,
+			url,
+			identity,
+			kind,
+		}
+	}
+
+	/// Price both directions of this accepted link.
+	pub fn with_cost(self, cost: u64) -> Self {
+		let Request {
+			transport,
+			url,
+			identity,
+			kind,
+		} = self;
+		let kind = request_map!(kind, request => request.with_cost(cost));
+		Request {
+			transport,
+			url,
+			identity,
+			kind,
+		}
+	}
+
+	/// Price what this client pays to subscribe from us.
+	pub fn with_egress_cost(self, cost: u64) -> Self {
+		let Request {
+			transport,
+			url,
+			identity,
+			kind,
+		} = self;
+		let kind = request_map!(kind, request => request.with_egress_cost(cost));
+		Request {
+			transport,
+			url,
+			identity,
+			kind,
+		}
+	}
+
+	/// Price what we pay to subscribe from this client.
+	pub fn with_ingress_cost(self, cost: u64) -> Self {
+		let Request {
+			transport,
+			url,
+			identity,
+			kind,
+		} = self;
+		let kind = request_map!(kind, request => request.with_ingress_cost(cost));
 		Request {
 			transport,
 			url,

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -14,7 +14,8 @@ pub struct Client {
 	stats: stats::Session,
 	versions: Versions,
 	setup_path: Option<String>,
-	cost: Option<u64>,
+	egress_cost: Option<u64>,
+	ingress_cost: Option<u64>,
 	peer_origin: Option<crate::Origin>,
 }
 
@@ -79,21 +80,34 @@ impl Client {
 		self
 	}
 
-	/// Price what subscribing from us costs, in the units the rest of the mesh uses
-	/// (moq-lite-06+, and `moqt-17`+ via the MoQ Cluster extension).
+	/// Price both directions of this link in the units the rest of the mesh uses.
 	///
-	/// Declared in our SETUP; the peer adds it to the route cost of every announcement
-	/// we forward it, so routing prefers cheap paths over short ones. Use `0` for a
-	/// direction that should look free (a sibling in the same datacenter), and
-	/// something large for one that should be a last resort (metered egress). When we
-	/// declare nothing the peer charges `1`, which makes the cost track the hop count
-	/// and so reproduces plain shortest-path routing.
+	/// Equivalent to setting both [`with_egress_cost`](Self::with_egress_cost) and
+	/// [`with_ingress_cost`](Self::with_ingress_cost). Use `0` for a free link and a
+	/// large value for a last resort. An unpriced direction costs `1`.
 	///
-	/// This prices one direction only. What *we* pay to pull from the peer is whatever
-	/// the peer declares, so an asymmetric link is described by each side setting its
-	/// own value, and a symmetric one by both setting the same.
+	/// Supported by moq-lite-06+ and `moqt-17`+ via the MoQ Cluster extension.
 	pub fn with_cost(mut self, cost: u64) -> Self {
-		self.cost = Some(cost);
+		self.egress_cost = Some(cost);
+		self.ingress_cost = Some(cost);
+		self
+	}
+
+	/// Price what the peer pays to subscribe from us.
+	///
+	/// Declared in our SETUP and added by the peer to announcements we forward. Use
+	/// this with [`with_ingress_cost`](Self::with_ingress_cost) for an asymmetric link.
+	pub fn with_egress_cost(mut self, cost: u64) -> Self {
+		self.egress_cost = Some(cost);
+		self
+	}
+
+	/// Price what we pay to subscribe from the peer.
+	///
+	/// This local routing policy overrides the peer's declared egress price. Use this
+	/// with [`with_egress_cost`](Self::with_egress_cost) for an asymmetric link.
+	pub fn with_ingress_cost(mut self, cost: u64) -> Self {
+		self.ingress_cost = Some(cost);
 		self
 	}
 
@@ -158,20 +172,23 @@ impl Client {
 					.ok_or(Error::Version)?;
 
 				// Draft-17+: SETUP is exchanged by the connection driver.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: None,
-					request_id_max: None,
-					client: true,
-					publish: publish.clone(),
-					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
-					cost: self.cost,
-					version: ietf::Version::Draft19,
-					path: self.setup_path.clone(),
-					peer_setup_stream: None,
-					peer_cluster: None,
-				})?;
+				let protocol = ietf::start_with_ingress_cost(
+					ietf::Config {
+						session: session.clone(),
+						setup: None,
+						request_id_max: None,
+						client: true,
+						publish: publish.clone(),
+						subscribe: subscribe.clone(),
+						peer_origin: self.peer_origin,
+						cost: self.egress_cost,
+						version: ietf::Version::Draft19,
+						path: self.setup_path.clone(),
+						peer_setup_stream: None,
+						peer_cluster: None,
+					},
+					self.ingress_cost,
+				)?;
 
 				tracing::debug!(version = ?v, "connected");
 				return Ok(Session::new(session, v, None, protocol));
@@ -184,20 +201,23 @@ impl Client {
 
 				// Draft-17+: SETUP is exchanged by the connection driver.
 				// We advertise the request path in our SETUP for URL-less transports.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: None,
-					request_id_max: None,
-					client: true,
-					publish: publish.clone(),
-					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
-					cost: self.cost,
-					version: ietf::Version::Draft18,
-					path: self.setup_path.clone(),
-					peer_setup_stream: None,
-					peer_cluster: None,
-				})?;
+				let protocol = ietf::start_with_ingress_cost(
+					ietf::Config {
+						session: session.clone(),
+						setup: None,
+						request_id_max: None,
+						client: true,
+						publish: publish.clone(),
+						subscribe: subscribe.clone(),
+						peer_origin: self.peer_origin,
+						cost: self.egress_cost,
+						version: ietf::Version::Draft18,
+						path: self.setup_path.clone(),
+						peer_setup_stream: None,
+						peer_cluster: None,
+					},
+					self.ingress_cost,
+				)?;
 
 				tracing::debug!(version = ?v, "connected");
 				return Ok(Session::new(session, v, None, protocol));
@@ -210,20 +230,23 @@ impl Client {
 
 				// Draft-17+: SETUP is exchanged by the connection driver.
 				// We advertise the request path in our SETUP for URL-less transports.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: None,
-					request_id_max: None,
-					client: true,
-					publish: publish.clone(),
-					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
-					cost: self.cost,
-					version: ietf::Version::Draft17,
-					path: self.setup_path.clone(),
-					peer_setup_stream: None,
-					peer_cluster: None,
-				})?;
+				let protocol = ietf::start_with_ingress_cost(
+					ietf::Config {
+						session: session.clone(),
+						setup: None,
+						request_id_max: None,
+						client: true,
+						publish: publish.clone(),
+						subscribe: subscribe.clone(),
+						peer_origin: self.peer_origin,
+						cost: self.egress_cost,
+						version: ietf::Version::Draft17,
+						path: self.setup_path.clone(),
+						peer_setup_stream: None,
+						peer_cluster: None,
+					},
+					self.ingress_cost,
+				)?;
 
 				tracing::debug!(version = ?v, "connected");
 				return Ok(Session::new(session, v, None, protocol));
@@ -264,7 +287,7 @@ impl Client {
 					probe: lite::ProbeLevel::Report,
 					path: self.setup_path.clone(),
 					role: lite::Role::from_origins(self.publish.is_some(), self.subscribe.is_some()),
-					cost: self.cost,
+					cost: self.egress_cost,
 					// Filled by `lite::start` from the attached origin handles.
 					origin: None,
 				};
@@ -275,6 +298,7 @@ impl Client {
 					publish.clone(),
 					subscribe.clone(),
 					self.peer_origin,
+					self.ingress_cost,
 					version,
 					our_setup,
 					None,
@@ -299,6 +323,7 @@ impl Client {
 					publish.clone(),
 					subscribe.clone(),
 					self.peer_origin,
+					self.ingress_cost,
 					lite::Version::Lite04,
 					lite::Setup::default(),
 					None,
@@ -327,6 +352,7 @@ impl Client {
 					publish.clone(),
 					subscribe.clone(),
 					self.peer_origin,
+					self.ingress_cost,
 					lite::Version::Lite03,
 					lite::Setup::default(),
 					None,
@@ -388,6 +414,7 @@ impl Client {
 					publish.clone(),
 					subscribe.clone(),
 					self.peer_origin,
+					self.ingress_cost,
 					v,
 					// This path only handles versions negotiated via the bidi SETUP exchange
 					// (pre-lite-05), which have no Setup Stream.
@@ -406,20 +433,23 @@ impl Client {
 
 				let stream = stream.with_version(v);
 				// Draft 14-16: the path rode in the bidi SETUP above, not the uni one.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: Some(stream),
-					request_id_max,
-					client: true,
-					publish: publish.clone(),
-					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
-					cost: self.cost,
-					version: v,
-					path: None,
-					peer_setup_stream: None,
-					peer_cluster: None,
-				})?;
+				let protocol = ietf::start_with_ingress_cost(
+					ietf::Config {
+						session: session.clone(),
+						setup: Some(stream),
+						request_id_max,
+						client: true,
+						publish: publish.clone(),
+						subscribe: subscribe.clone(),
+						peer_origin: self.peer_origin,
+						cost: self.egress_cost,
+						version: v,
+						path: None,
+						peer_setup_stream: None,
+						peer_cluster: None,
+					},
+					self.ingress_cost,
+				)?;
 				(None, protocol, None)
 			}
 		};
@@ -445,6 +475,17 @@ mod tests {
 
 	use crate::coding::{Decode, Encode};
 	use bytes::{BufMut, Bytes};
+
+	#[test]
+	fn link_costs_can_be_symmetric_or_directional() {
+		let symmetric = Client::new().with_cost(7);
+		assert_eq!(symmetric.egress_cost, Some(7));
+		assert_eq!(symmetric.ingress_cost, Some(7));
+
+		let asymmetric = Client::new().with_egress_cost(3).with_ingress_cost(11);
+		assert_eq!(asymmetric.egress_cost, Some(3));
+		assert_eq!(asymmetric.ingress_cost, Some(11));
+	}
 
 	#[derive(Debug, Clone, Default)]
 	struct FakeError;

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -32,10 +32,9 @@ pub struct Config<S: web_transport_trait::Session> {
 	/// declares its own, which wins.
 	pub peer_origin: Option<Origin>,
 
-	/// What subscribing from us costs, declared in our SETUP (see
-	/// [`cluster::RELAY_COST`]) for the peer to charge. Directional, so what we charge
-	/// in the other direction is whatever the peer declared. `None` leaves it unpriced,
-	/// which the peer reads as the default of 1.
+	/// Price both directions of the link. Declared in our SETUP (see
+	/// [`cluster::RELAY_COST`]) and used as local policy for subscriptions from the
+	/// peer. `None` advertises no price and accepts the peer's declared price.
 	pub cost: Option<u64>,
 
 	pub version: Version,
@@ -57,6 +56,24 @@ pub struct Config<S: web_transport_trait::Session> {
 pub fn start<S: web_transport_trait::Session>(
 	config: Config<S>,
 ) -> Result<MaybeSendBox<'static, Result<(), Error>>, Error> {
+	let ingress_cost = config.cost;
+	start_inner(config, ingress_cost)
+}
+
+pub(crate) fn start_with_ingress_cost<S: web_transport_trait::Session>(
+	config: Config<S>,
+	ingress_cost: Option<u64>,
+) -> Result<MaybeSendBox<'static, Result<(), Error>>, Error> {
+	if ingress_cost == config.cost {
+		return start(config);
+	}
+	start_inner(config, ingress_cost)
+}
+
+fn start_inner<S: web_transport_trait::Session>(
+	config: Config<S>,
+	ingress_cost: Option<u64>,
+) -> Result<MaybeSendBox<'static, Result<(), Error>>, Error> {
 	let Config {
 		session,
 		setup,
@@ -65,7 +82,7 @@ pub fn start<S: web_transport_trait::Session>(
 		publish,
 		subscribe,
 		peer_origin,
-		cost,
+		cost: egress_cost,
 		version,
 		path,
 		peer_setup_stream,
@@ -123,7 +140,7 @@ pub fn start<S: web_transport_trait::Session>(
 					peer_origin,
 					peer_setup.clone(),
 					self_origin,
-					cost,
+					ingress_cost,
 					version,
 					tasks,
 				);
@@ -204,7 +221,7 @@ pub fn start<S: web_transport_trait::Session>(
 				let setup = {
 					let session = session.clone();
 					async move {
-						if let Err(err) = run_setup(session, version, path, self_origin, cost).await {
+						if let Err(err) = run_setup(session, version, path, self_origin, egress_cost).await {
 							tracing::warn!(%err, "setup send error");
 						}
 						std::future::pending::<()>().await;
@@ -228,7 +245,7 @@ pub fn start<S: web_transport_trait::Session>(
 					peer_origin,
 					peer_setup.clone(),
 					self_origin,
-					cost,
+					ingress_cost,
 					version,
 					tasks,
 				);
@@ -410,14 +427,14 @@ fn decode_peer_cluster(parameters: bytes::Bytes, version: Version) -> Result<clu
 /// Send our SETUP on a uni stream and keep it alive for potential GOAWAY.
 ///
 /// `path` is the request path we advertise (clients on URL-less transports); a
-/// server passes `None`. `self_origin` and `cost` are the MoQ Cluster options, which
-/// declare our identity and (client-only) what this link costs to cross.
+/// server passes `None`. `self_origin` and `egress_cost` are the MoQ Cluster options,
+/// which declare our identity and what subscribing from us costs.
 async fn run_setup<S: web_transport_trait::Session>(
 	session: S,
 	version: Version,
 	path: Option<String>,
 	self_origin: Origin,
-	cost: Option<u64>,
+	egress_cost: Option<u64>,
 ) -> Result<(), Error> {
 	let outer_version = crate::Version::Ietf(version);
 
@@ -429,7 +446,7 @@ async fn run_setup<S: web_transport_trait::Session>(
 	if let Some(path) = path {
 		parameters.set_bytes(ietf::ParameterBytes::Path, path.into_bytes());
 	}
-	cluster::peer_into_setup(&mut parameters, self_origin, cost, version);
+	cluster::peer_into_setup(&mut parameters, self_origin, egress_cost, version);
 	let parameters = parameters.encode_bytes(version)?;
 
 	writer.encode(&setup::Setup { parameters }).await?;

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -41,7 +41,6 @@ fn is_protocol_violation(err: &Error) -> bool {
 	matches!(
 		err,
 		Error::Decode(_)
-			| Error::Encode(_)
 			| Error::BoundsExceeded(_)
 			| Error::WrongSize
 			| Error::TooManyParameters
@@ -304,6 +303,22 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// (virtual for v14/v15, real bidi for v16+), one per prefix.
 	pub async fn run_subscribe_namespace<T: web_transport_trait::Session>(
 		&mut self,
+		stream: Stream<T, Version>,
+		prefix: PathOwned,
+	) -> Result<(), Error> {
+		let res = self.run_subscribe_namespace_inner(stream, prefix).await;
+		if let Err(err) = &res
+			&& is_protocol_violation(err)
+		{
+			self.session
+				.close(Error::ProtocolViolation.to_code(), err.to_string().as_ref());
+		}
+		res
+	}
+
+	/// Run one namespace subscription, leaving session-level error policy to the wrapper.
+	async fn run_subscribe_namespace_inner<T: web_transport_trait::Session>(
+		&mut self,
 		mut stream: Stream<T, Version>,
 		prefix: PathOwned,
 	) -> Result<(), Error> {
@@ -498,7 +513,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						// cluster draft requires closing the session on those; a stream
 						// the peer simply reset is not the peer's fault.
 						if is_protocol_violation(&err) {
-							this.session.close(err.to_code(), err.to_string().as_ref());
+							this.session
+								.close(Error::ProtocolViolation.to_code(), err.to_string().as_ref());
 						}
 						tracing::debug!(%err, "publish_namespace stream error");
 					}
@@ -1422,6 +1438,49 @@ mod tests {
 		assert!(
 			consumer.get_broadcast("rootns/rootns/cam/x.hang").is_none(),
 			"the root was applied twice",
+		);
+	}
+
+	/// A negotiated cluster session requires HOP_PATH on every NAMESPACE. The error is
+	/// session-wide because the stream can no longer be decoded unambiguously.
+	#[tokio::test]
+	async fn a_malformed_cluster_namespace_closes_the_session() {
+		const VERSION: Version = Version::Draft19;
+
+		let session = crate::lite::test_transport::ScriptedSession::new(namespace_response(VERSION, "bad").await);
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let peer_setup = cluster::PeerSetup::default();
+		peer_setup.set(cluster::Peer {
+			origin: Some(crate::Origin::new(2).unwrap()),
+			cost: None,
+		});
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+		let mut subscriber = Subscriber::new(
+			session.clone(),
+			origin,
+			Control::new(None, false),
+			None,
+			peer_setup,
+			crate::Origin::new(1).unwrap(),
+			None,
+			VERSION,
+			tasks,
+		);
+
+		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let mut run = std::pin::pin!(subscriber.run_subscribe_namespace(stream, crate::Path::new("").to_owned()));
+		for _ in 0..20 {
+			let _ = futures::poll!(run.as_mut());
+			if !session.log.closes().is_empty() {
+				break;
+			}
+			settle().await;
+		}
+
+		assert_eq!(
+			session.log.closes().first().map(|(code, _)| *code),
+			Some(Error::ProtocolViolation.to_code()),
+			"a missing HOP_PATH must close the session",
 		);
 	}
 

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -67,6 +67,9 @@ pub fn start<S: web_transport_trait::Session>(
 	// The origin (hop) id assigned to the peer, used whenever the peer doesn't
 	// declare one itself. See `Client::with_peer_origin`.
 	peer_origin: Option<Origin>,
+	// Local policy for what subscribing from the peer costs. Distinct from
+	// `our_setup.cost`, which declares what subscribing from us costs.
+	ingress_cost: Option<u64>,
 	// The version of the protocol to use.
 	version: Version,
 	// The capabilities (and optional request path) we advertise in our SETUP message.
@@ -141,9 +144,6 @@ pub fn start<S: web_transport_trait::Session>(
 	let peer_setup = peer_setup_slot;
 	let (tasks, task_set) = TaskSet::new();
 
-	// Read out before the setup task takes ownership below.
-	let our_cost = our_setup.cost;
-
 	// Advertise our own capabilities on a uni Setup Stream, then FIN. Best-effort:
 	// a failure here just means the peer falls back to "no capabilities" for us.
 	if version.has_setup_stream() {
@@ -169,10 +169,9 @@ pub fn start<S: web_transport_trait::Session>(
 		version,
 		peer_setup,
 		peer_origin,
-		// Local policy for what pulling from this peer costs. Set only when we
-		// configured a price; otherwise the subscriber charges what the peer declared
-		// for its own egress.
-		cost: our_cost,
+		// Local policy for what pulling from this peer costs. Otherwise the subscriber
+		// charges what the peer declared for its own egress.
+		cost: ingress_cost,
 		tasks,
 	});
 

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -32,12 +32,18 @@ impl web_transport_trait::Error for SinkError {
 pub struct Log {
 	pub writes: Arc<Mutex<Vec<u8>>>,
 	pub resets: Arc<Mutex<Vec<u32>>>,
+	pub closes: Arc<Mutex<Vec<(u32, String)>>>,
 	bi_opens: Arc<AtomicUsize>,
 }
 
 impl Log {
 	pub fn resets(&self) -> Vec<u32> {
 		self.resets.lock().unwrap().clone()
+	}
+
+	/// Session close calls, including the application error code and reason.
+	pub fn closes(&self) -> Vec<(u32, String)> {
+		self.closes.lock().unwrap().clone()
 	}
 
 	/// How many bidi streams the session has opened, so a test can pin down how many
@@ -181,7 +187,9 @@ impl web_transport_trait::Session for SinkSession {
 		None
 	}
 
-	fn close(&self, _code: u32, _reason: &str) {}
+	fn close(&self, code: u32, reason: &str) {
+		self.log.closes.lock().unwrap().push((code, reason.to_owned()));
+	}
 
 	async fn closed(&self) -> Self::Error {
 		std::future::pending().await
@@ -334,7 +342,9 @@ impl web_transport_trait::Session for ScriptedSession {
 		None
 	}
 
-	fn close(&self, _code: u32, _reason: &str) {}
+	fn close(&self, code: u32, reason: &str) {
+		self.log.closes.lock().unwrap().push((code, reason.to_owned()));
+	}
 
 	async fn closed(&self) -> Self::Error {
 		std::future::pending().await

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -13,6 +13,8 @@ pub struct Server {
 	subscribe: Option<origin::Producer>,
 	stats: stats::Session,
 	versions: Versions,
+	egress_cost: Option<u64>,
+	ingress_cost: Option<u64>,
 }
 
 impl Server {
@@ -55,6 +57,30 @@ impl Server {
 	/// Defaults to every version this crate supports.
 	pub fn with_versions(mut self, versions: Versions) -> Self {
 		self.versions = versions;
+		self
+	}
+
+	/// Price both directions of every accepted link.
+	///
+	/// Equivalent to setting both [`with_egress_cost`](Self::with_egress_cost) and
+	/// [`with_ingress_cost`](Self::with_ingress_cost). An unpriced direction costs `1`.
+	pub fn with_cost(mut self, cost: u64) -> Self {
+		self.egress_cost = Some(cost);
+		self.ingress_cost = Some(cost);
+		self
+	}
+
+	/// Price what connected clients pay to subscribe from this server.
+	pub fn with_egress_cost(mut self, cost: u64) -> Self {
+		self.egress_cost = Some(cost);
+		self
+	}
+
+	/// Price what this server pays to subscribe from connected clients.
+	///
+	/// This local routing policy overrides each client's declared egress price.
+	pub fn with_ingress_cost(mut self, cost: u64) -> Self {
+		self.ingress_cost = Some(cost);
 		self
 	}
 
@@ -364,6 +390,25 @@ impl<S: web_transport_trait::Session> Request<S> {
 		self
 	}
 
+	/// Price both directions of this accepted link, overriding the server default.
+	pub fn with_cost(mut self, cost: u64) -> Self {
+		self.inner_mut().server.egress_cost = Some(cost);
+		self.inner_mut().server.ingress_cost = Some(cost);
+		self
+	}
+
+	/// Price what this client pays to subscribe from us, overriding the server default.
+	pub fn with_egress_cost(mut self, cost: u64) -> Self {
+		self.inner_mut().server.egress_cost = Some(cost);
+		self
+	}
+
+	/// Price what we pay to subscribe from this client, overriding the server default.
+	pub fn with_ingress_cost(mut self, cost: u64) -> Self {
+		self.inner_mut().server.ingress_cost = Some(cost);
+		self
+	}
+
 	fn inner_mut(&mut self) -> &mut RequestInner<S> {
 		self.inner.as_mut().expect("request already responded")
 	}
@@ -387,21 +432,23 @@ impl<S: web_transport_trait::Session> Request<S> {
 			} => {
 				// The client's SETUP was read in `accept_request`; hand the stream back
 				// for GOAWAY. A server never advertises a path, hence `None`.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: None,
-					request_id_max: None,
-					client: false,
-					publish,
-					subscribe,
-					peer_origin: None,
-					// Only the dialing side prices a link.
-					cost: None,
-					version,
-					path: None,
-					peer_setup_stream: Some(peer_setup.stream),
-					peer_cluster: Some(peer_setup.cluster),
-				})?;
+				let protocol = ietf::start_with_ingress_cost(
+					ietf::Config {
+						session: session.clone(),
+						setup: None,
+						request_id_max: None,
+						client: false,
+						publish,
+						subscribe,
+						peer_origin: None,
+						cost: server.egress_cost,
+						version,
+						path: None,
+						peer_setup_stream: Some(peer_setup.stream),
+						peer_cluster: Some(peer_setup.cluster),
+					},
+					server.ingress_cost,
+				)?;
 				tracing::debug!(?version, "connected");
 				return Ok(Session::new(session, version.into(), None, protocol));
 			}
@@ -412,6 +459,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					publish,
 					subscribe,
 					None,
+					server.ingress_cost,
 					version,
 					lite::Setup::default(),
 					None,
@@ -433,8 +481,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					probe: lite::ProbeLevel::Report,
 					path: None,
 					role: None,
-					// The dialing side prices the link; we charge what its SETUP declared.
-					cost: None,
+					cost: server.egress_cost,
 					// Filled by `lite::start` from the attached origin handles.
 					origin: None,
 				};
@@ -444,6 +491,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					publish,
 					subscribe,
 					None,
+					server.ingress_cost,
 					version,
 					our_setup,
 					Some(client_setup),
@@ -490,6 +538,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					publish,
 					subscribe,
 					None,
+					server.ingress_cost,
 					v,
 					lite::Setup::default(),
 					None,
@@ -499,20 +548,23 @@ impl<S: web_transport_trait::Session> Request<S> {
 			Version::Ietf(v) => {
 				let stream = stream.with_version(v);
 				// Draft 14-16: path came in the bidi SETUP, no uni SETUP to hand back.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: Some(stream),
-					request_id_max,
-					client: false,
-					publish,
-					subscribe,
-					peer_origin: None,
-					cost: None,
-					version: v,
-					path: None,
-					peer_setup_stream: None,
-					peer_cluster: None,
-				})?;
+				let protocol = ietf::start_with_ingress_cost(
+					ietf::Config {
+						session: session.clone(),
+						setup: Some(stream),
+						request_id_max,
+						client: false,
+						publish,
+						subscribe,
+						peer_origin: None,
+						cost: server.egress_cost,
+						version: v,
+						path: None,
+						peer_setup_stream: None,
+						peer_cluster: None,
+					},
+					server.ingress_cost,
+				)?;
 				(None, protocol)
 			}
 		};


### PR DESCRIPTION
## Summary

- Close IETF sessions with `PROTOCOL_VIOLATION` when a negotiated namespace stream contains malformed protocol data, including a missing Cluster `HOP_PATH`.
- Split link pricing into explicit ingress and egress policy across clients, servers, and accepted requests while keeping `with_cost` symmetric for compatibility.
- Preserve the existing public low-level IETF config shape and behavior.

The namespace error was returned to a wrapper that only logged it and continued, so a session-level protocol violation never closed the transport. Link pricing used one client field for both the advertised SETUP cost and the local subscriber override even though its documentation described only one direction.

## Public API changes

- Add `with_egress_cost` and `with_ingress_cost` to `moq_net::Client`, `moq_net::Server`, `moq_net::Request`, and their `moq_native` wrappers.
- Add symmetric `with_cost` configuration to server and request types.
- Existing `with_cost` and `ietf::Config` callers remain source-compatible and retain their symmetric behavior.

No wire format or FFI surface changed, so no cross-package synchronization row applies.

## Test plan

- `nix develop --command just check`
- `nix develop --command just rs test -p moq-net` (677 passed)

(Written by GPT-5)