### PR TITLE
fix(libmoq): stop holding the global locks across a video encode

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -103,6 +103,12 @@ The matching `*_close` function only *requests* shutdown: it returns immediately
 
 Because the terminal callback runs on libmoq's thread, bindings that own thread-affine objects (e.g. a Qt `QObject`) should hop to the owning thread to perform the actual destruction; the `user_data` lifetime contract holds regardless of which thread tears the object down.
 
+## Threading
+
+Every function may be called from any thread, and a handle is not tied to the thread that created it.
+
+The raw publish functions (`moq_publish_video_raw_frame`, `moq_publish_audio_raw_frame`) block the caller until the codec has taken the frame, which is what paces a publisher against its encoder. Only other calls on that same producer wait behind it, served in arrival order: a second producer keeps encoding, and consume callbacks, frees, and shutdown are unaffected.
+
 ## Error handling
 
 Functions return a negative code on failure (`0` or a positive handle on success). The code identifies the kind of failure, but the human-readable reason is available separately via `moq_error()`:

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -107,7 +107,7 @@ Because the terminal callback runs on libmoq's thread, bindings that own thread-
 
 Every function may be called from any thread, and a handle is not tied to the thread that created it.
 
-The raw publish functions (`moq_publish_video_raw_frame`, `moq_publish_audio_raw_frame`) block the caller until the codec has taken the frame, which is what paces a publisher against its encoder. Only other calls on that same producer wait behind it, served in arrival order: a second producer keeps encoding, and consume callbacks, frees, and shutdown are unaffected.
+The raw publish functions (`moq_publish_video_raw_frame`, `moq_publish_audio_raw_frame`) block the caller until the codec has taken the frame, which is what paces a publisher against its encoder. Calls on the same producer are serialized, but concurrent calls have no defined order, so use one thread when frame, cut, or bitrate order matters. A second producer keeps encoding, and consume callbacks, frees, and shutdown are unaffected.
 
 ## Error handling
 

--- a/rs/libmoq/src/audio.rs
+++ b/rs/libmoq/src/audio.rs
@@ -18,7 +18,7 @@ use bytes::Bytes;
 use tokio::sync::oneshot;
 
 use crate::ffi::OnStatus;
-use crate::{Error, Id, NonZeroSlab, State, ffi};
+use crate::{Error, Id, NonZeroSlab, Shared, State, ffi};
 
 // ---- C-visible types ----
 
@@ -124,9 +124,13 @@ pub struct moq_audio_frame {
 
 // ---- State extensions (used internally by lib.rs) ----
 
+/// An audio producer, shared so the Opus encode in `write` runs with the global
+/// lock released. See [`Shared`].
+type AudioProducer = Shared<moq_audio::encode::Producer<moq_mux::catalog::hang::Extra>>;
+
 #[derive(Default)]
 pub struct Audio {
-	producers: NonZeroSlab<moq_audio::encode::Producer<moq_mux::catalog::hang::Extra>>,
+	producers: NonZeroSlab<AudioProducer>,
 	consumer_tasks: NonZeroSlab<Option<AudioTaskEntry>>,
 	frames: NonZeroSlab<moq_audio::Frame>,
 }
@@ -150,19 +154,22 @@ impl Audio {
 		options: moq_audio::encode::Options,
 	) -> Result<Id, Error> {
 		let producer = moq_audio::encode::Producer::new(broadcast, catalog, input, &options)?;
-		self.producers.insert(producer)
+		self.producers.insert(Shared::new(producer))
 	}
 
-	pub fn publish_frame(&mut self, id: Id, frame: moq_audio::Frame) -> Result<(), Error> {
-		let producer = self.producers.get_mut(id).ok_or(Error::MediaNotFound)?;
-		producer.write(&frame)?;
-		Ok(())
+	/// Resolve a producer handle, so the caller can encode with the global lock
+	/// released.
+	///
+	/// Bind the result before locking it: a temporary [`State`] guard lives to the
+	/// end of the statement that created it, so resolving and locking in one
+	/// expression would put the encode back under the global lock.
+	pub(crate) fn producer(&self, id: Id) -> Result<AudioProducer, Error> {
+		self.producers.get(id).cloned().ok_or(Error::MediaNotFound)
 	}
 
-	pub fn publish_finish(&mut self, id: Id) -> Result<(), Error> {
-		let producer = self.producers.remove(id).ok_or(Error::MediaNotFound)?;
-		producer.finish()?;
-		Ok(())
+	/// Resolve a producer and drop its id, so nothing can be published to it after.
+	pub(crate) fn remove(&mut self, id: Id) -> Result<AudioProducer, Error> {
+		self.producers.remove(id).ok_or(Error::MediaNotFound)
 	}
 
 	pub fn consume(
@@ -340,7 +347,9 @@ pub unsafe extern "C" fn moq_publish_audio_raw_frame(producer: u32, frame: *cons
 			data: Bytes::copy_from_slice(data),
 		};
 
-		State::lock().audio.publish_frame(producer, owned)
+		let producer = State::lock().audio.producer(producer)?;
+		producer.lock().as_mut().ok_or(Error::MediaNotFound)?.write(&owned)?;
+		Ok(())
 	})
 }
 
@@ -349,7 +358,11 @@ pub unsafe extern "C" fn moq_publish_audio_raw_frame(producer: u32, frame: *cons
 pub extern "C" fn moq_publish_audio_raw_finish(producer: u32) -> i32 {
 	ffi::enter(move || {
 		let producer = ffi::parse_id(producer)?;
-		State::lock().audio.publish_finish(producer)
+		// The id is dropped first, so nothing new queues behind the flush; whatever
+		// is mid-encode still finishes before this takes the producer.
+		let producer = State::lock().audio.remove(producer)?;
+		producer.take().ok_or(Error::MediaNotFound)?.finish()?;
+		Ok(())
 	})
 }
 

--- a/rs/libmoq/src/ffi.rs
+++ b/rs/libmoq/src/ffi.rs
@@ -1,14 +1,14 @@
 use std::{
 	cell::RefCell,
 	ffi::{CString, c_char, c_void},
-	sync::{LazyLock, Mutex},
+	sync::LazyLock,
 };
 
 use url::Url;
 
 use crate::{Error, Id};
 
-pub static RUNTIME: LazyLock<Mutex<tokio::runtime::Handle>> = LazyLock::new(|| {
+pub static RUNTIME: LazyLock<tokio::runtime::Handle> = LazyLock::new(|| {
 	let runtime = tokio::runtime::Builder::new_current_thread()
 		.enable_all()
 		.build()
@@ -22,19 +22,18 @@ pub static RUNTIME: LazyLock<Mutex<tokio::runtime::Handle>> = LazyLock::new(|| {
 		})
 		.expect("failed to spawn runtime thread");
 
-	Mutex::new(handle)
+	handle
 });
 
 /// Runs the provided function in the runtime context.
 /// Additionally, we convert the return code to a C-compatible return value.
 ///
-/// Uses a mutex to ensure Handle::enter() guards are dropped in LIFO order,
-/// as required by tokio to avoid panics in multi-threaded FFI contexts.
+/// Callers run concurrently: entering a handle only sets a thread-local, so
+/// nothing here is shared between threads. Tokio's requirement that the guards
+/// be dropped in LIFO order is per-thread too, and this one lives and dies in
+/// this frame, so a nested call nests rather than crosses.
 pub fn enter<C: ReturnCode, F: FnOnce() -> C>(f: F) -> i32 {
-	// NOTE: I think we need a mutex because Handle::enter() needs to be dropped in LIFO order.
-	// If this starts to become a bottleneck, we might have to rethink our runtime model.
-	let handle = RUNTIME.lock().unwrap();
-	let _guard = handle.enter();
+	let _guard = RUNTIME.enter();
 
 	match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
 		Ok(ret) => {

--- a/rs/libmoq/src/state.rs
+++ b/rs/libmoq/src/state.rs
@@ -1,4 +1,4 @@
-use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 
 use crate::{Consume, Origin, Publish, Session, audio::Audio, video::Video};
 
@@ -30,3 +30,50 @@ impl State {
 
 /// Global shared state instance.
 static STATE: LazyLock<Mutex<State>> = LazyLock::new(|| Mutex::new(State::new()));
+
+/// A resource a C call works on with the global [`State`] lock released.
+///
+/// Some calls block for a long time: encoding a frame is a round trip to the
+/// codec thread, and a wedged codec never comes back. Doing that under the
+/// process-wide `State` mutex parks every unrelated session, callback and
+/// shutdown behind it, so those entry points resolve the handle, drop the global
+/// guard, and work behind the resource's own lock instead. That lock is what
+/// keeps writes to one resource ordered, without ordering them against the rest
+/// of the process.
+///
+/// Locking order is `State` then this, never the reverse.
+pub struct Shared<T>(Arc<Mutex<Option<T>>>);
+
+impl<T> Shared<T> {
+	pub fn new(value: T) -> Self {
+		Self(Arc::new(Mutex::new(Some(value))))
+	}
+
+	/// The resource, locked for as long as the guard is held.
+	///
+	/// `None` once a terminal call has taken it. Its id is dropped from the slab
+	/// under the global lock at the same moment, so that is only what a call which
+	/// resolved the handle just before the end sees.
+	pub fn lock(&self) -> MutexGuard<'_, Option<T>> {
+		self.0.lock().unwrap()
+	}
+
+	/// Take the resource, for the call that ends it and needs to consume it.
+	pub fn take(&self) -> Option<T> {
+		self.lock().take()
+	}
+
+	/// How many callers hold this handle right now: the slab plus whoever has
+	/// resolved it. Lets a test tell that a blocking call has made it past the
+	/// global lock and is inside the resource's own.
+	#[cfg(test)]
+	pub fn holders(&self) -> usize {
+		Arc::strong_count(&self.0)
+	}
+}
+
+impl<T> Clone for Shared<T> {
+	fn clone(&self) -> Self {
+		Self(self.0.clone())
+	}
+}

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -1516,6 +1516,53 @@ fn video_publish_consume() {
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
+/// The raw audio publish path: PCM in, an Opus track out. The decode half has
+/// its own coverage in moq-audio; this pins the producer lifecycle the C surface
+/// owns, including that a finished handle is gone.
+#[test]
+fn audio_raw_publish() {
+	let origin = id(moq_origin_create());
+	let broadcast = publish_broadcast(origin, b"audio-raw-publish-test");
+
+	let name = b"audio";
+	let input = moq_audio_encoder_input {
+		format: moq_audio_format::MOQ_AUDIO_FORMAT_F32 as u32,
+		sample_rate: 48_000,
+		channels: 2,
+	};
+	let codec = b"opus";
+	let output = moq_audio_encoder_output {
+		codec: codec.as_ptr() as *const c_char,
+		codec_len: codec.len(),
+		sample_rate: 0,
+		channels: 0,
+		bitrate: 0,
+		frame_duration_ms: 20,
+	};
+	let producer =
+		id(unsafe { moq_publish_audio_raw(broadcast, name.as_ptr() as *const c_char, name.len(), &input, &output) });
+
+	// 20 ms of silence: interleaved stereo f32 at 48 kHz, one encoded frame's worth.
+	let samples = vec![0.0f32; 960 * 2];
+	let pcm = unsafe { std::slice::from_raw_parts(samples.as_ptr().cast::<u8>(), std::mem::size_of_val(&samples[..])) };
+	let frame = moq_audio_frame {
+		timestamp_us: 0,
+		data: pcm.as_ptr(),
+		data_size: pcm.len(),
+	};
+	assert_eq!(unsafe { moq_publish_audio_raw_frame(producer, &frame) }, 0);
+
+	assert_eq!(moq_publish_audio_raw_finish(producer), 0);
+	assert!(moq_publish_audio_raw_finish(producer) < 0, "double-finish should fail");
+	assert!(
+		unsafe { moq_publish_audio_raw_frame(producer, &frame) } < 0,
+		"a finished producer should take no more frames"
+	);
+
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
 /// A mid-gray RGBA frame, encodable without a camera.
 fn gray_rgba(width: u32, height: u32) -> Vec<u8> {
 	vec![0x80u8; width as usize * height as usize * 4]
@@ -1615,12 +1662,12 @@ fn video_raw_publish_consume() {
 }
 
 /// Regression: a producer handle is just an integer, so a C caller may drive it
-/// from any thread. `ffi::enter` serializes those calls but runs each on the
-/// calling thread, so holding a bare `Encoder` was unsound on Windows, where the
-/// codec's COM apartment is per-thread: it was opened on the publishing thread
-/// and closed on whichever thread called finish. The confinement itself is
-/// asserted in moq-video (`encode::sink`); this pins that the C surface supports
-/// the usage, including the drain on finish.
+/// from any thread, and each call runs on the thread that made it. Holding a bare
+/// `Encoder` was therefore unsound on Windows, where the codec's COM apartment is
+/// per-thread: it was opened on the publishing thread and closed on whichever
+/// thread called finish. The confinement itself is asserted in moq-video
+/// (`encode::sink`); this pins that the C surface supports the usage, including
+/// the drain on finish.
 #[test]
 fn video_raw_publish_from_many_threads() {
 	let origin = id(moq_origin_create());
@@ -1669,6 +1716,99 @@ fn video_raw_publish_from_many_threads() {
 		.join()
 		.unwrap();
 
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+/// Publish one mid-gray frame to a raw video producer, returning the status code.
+fn publish_gray(producer: u32, rgba: &[u8]) -> i32 {
+	let frame = moq_video_encoder_frame {
+		timestamp_us: 0,
+		data: rgba.as_ptr(),
+		data_size: rgba.len(),
+	};
+	unsafe { moq_publish_video_raw_frame(producer, &frame) }
+}
+
+/// Regression: an encode is a round trip to the codec thread, and a wedged codec
+/// never comes back from it. It used to run under both of libmoq's process-wide
+/// locks, the `State` mutex and one wrapping the runtime handle, so a single
+/// stalled producer parked every unrelated call in the process behind it: another
+/// broadcast's publish, a consumer's frame free, a session close.
+///
+/// Stalling the codec itself would take a test-only backend, so this holds the
+/// per-producer lock an in-flight encode holds instead. From every other caller's
+/// point of view that is the same wait.
+#[test]
+fn a_stalled_encode_does_not_block_unrelated_calls() {
+	let origin = id(moq_origin_create());
+	let broadcast = publish_broadcast(origin, b"video-raw-stall-test");
+
+	let input = moq_video_encoder_input {
+		format: moq_video_pixel_format::MOQ_VIDEO_PIXEL_FORMAT_RGBA as u32,
+		width: 320,
+		height: 240,
+		framerate: 30,
+	};
+	let output = moq_video_encoder_output {
+		codec: moq_video_codec::MOQ_VIDEO_CODEC_H264 as u32,
+		bitrate: 0,
+		gop: 0,
+		kind: moq_video_encoder_kind::MOQ_VIDEO_ENCODER_KIND_SOFTWARE as u32,
+		encoder: std::ptr::null(),
+		encoder_len: 0,
+	};
+	let stalled = id(unsafe { moq_publish_video_raw(broadcast, &input, &output) });
+	let other = id(unsafe { moq_publish_video_raw(broadcast, &input, &output) });
+
+	// Hold the lock a publish takes for the duration of its encode.
+	let handle = State::lock().video.producer(Id::try_from(stalled).unwrap()).unwrap();
+	let held = handle.lock();
+
+	let rgba = std::sync::Arc::new(gray_rgba(320, 240));
+	let stalling = {
+		let rgba = rgba.clone();
+		std::thread::spawn(move || publish_gray(stalled, &rgba))
+	};
+
+	// Wait until it has resolved the handle, so it is genuinely inside the stalled
+	// call rather than still on its way in: the slab holds one reference, this test
+	// a second, and the parked publish is the third.
+	let deadline = std::time::Instant::now() + TIMEOUT;
+	while handle.holders() < 3 {
+		assert!(
+			std::time::Instant::now() < deadline,
+			"the publish never reached the encoder"
+		);
+		std::thread::yield_now();
+	}
+
+	// Unrelated work must not be queued behind it. On its own thread so a
+	// regression fails this assertion rather than hanging the test.
+	let (tx, rx) = mpsc::channel();
+	let unrelated = {
+		let rgba = rgba.clone();
+		std::thread::spawn(move || {
+			let _ = tx.send((moq_origin_create(), publish_gray(other, &rgba)));
+		})
+	};
+	let (created, published) = rx
+		.recv_timeout(TIMEOUT)
+		.expect("an unrelated call was waiting on the stalled encode");
+	assert!(created > 0, "creating an origin failed while a producer was stalled");
+	assert_eq!(published, 0, "a second producer could not encode while the first stalled");
+	unrelated.join().unwrap();
+
+	// ...and the stalled publish was still in flight the whole time, so the calls
+	// above really did overlap it.
+	assert_eq!(handle.holders(), 3, "the stalled publish finished early");
+
+	drop(held);
+	assert_eq!(stalling.join().unwrap(), 0);
+
+	assert_eq!(moq_origin_close(id(created)), 0);
+	assert_eq!(moq_publish_video_raw_finish(stalled), 0);
+	assert_eq!(moq_publish_video_raw_finish(other), 0);
 	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -1796,7 +1796,10 @@ fn a_stalled_encode_does_not_block_unrelated_calls() {
 		.recv_timeout(TIMEOUT)
 		.expect("an unrelated call was waiting on the stalled encode");
 	assert!(created > 0, "creating an origin failed while a producer was stalled");
-	assert_eq!(published, 0, "a second producer could not encode while the first stalled");
+	assert_eq!(
+		published, 0,
+		"a second producer could not encode while the first stalled"
+	);
 	unrelated.join().unwrap();
 
 	// ...and the stalled publish was still in flight the whole time, so the calls

--- a/rs/libmoq/src/video.rs
+++ b/rs/libmoq/src/video.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use tokio::sync::oneshot;
 
 use crate::ffi::OnStatus;
-use crate::{Error, Id, NonZeroSlab, State, ffi};
+use crate::{Error, Id, NonZeroSlab, Shared, State, ffi};
 
 // ---- C-visible types ----
 
@@ -164,7 +164,7 @@ pub struct moq_video_frame {
 /// buffered decoded frames.
 #[derive(Default)]
 pub struct Video {
-	producers: NonZeroSlab<VideoEncoder>,
+	producers: NonZeroSlab<Shared<VideoEncoder>>,
 	consumer_tasks: NonZeroSlab<Option<VideoTaskEntry>>,
 	frames: NonZeroSlab<VideoFrame>,
 }
@@ -187,12 +187,11 @@ fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
 /// a timestamp).
 ///
 /// The encoder is a [`Sink`](moq_video::encode::Sink) rather than a bare
-/// `Encoder` because [`ffi::enter`] serializes calls without confining them:
-/// each one runs on whichever thread the C caller used, so a bare `Encoder`
-/// would be built on one thread and dropped on another, unbalancing the
-/// per-thread COM apartment the Windows backend opens. The sink owns the thread
-/// instead, so every caller is welcome.
-struct VideoEncoder {
+/// `Encoder` because a C caller drives a handle from whichever thread it likes,
+/// so a bare `Encoder` would be built on one thread and dropped on another,
+/// unbalancing the per-thread COM apartment the Windows backend opens. The sink
+/// owns the thread instead, so every caller is welcome.
+pub(crate) struct VideoEncoder {
 	encoder: moq_video::encode::Sink,
 	producer: moq_video::encode::Producer<moq_mux::catalog::hang::Extra>,
 	format: moq_video_pixel_format,
@@ -241,33 +240,12 @@ struct VideoTaskEntry {
 	callback: OnStatus,
 }
 
-impl Video {
-	pub fn publish(
-		&mut self,
-		broadcast: &moq_net::broadcast::Producer,
-		catalog: moq_mux::catalog::Producer<moq_mux::catalog::hang::Extra>,
-		format: moq_video_pixel_format,
-		config: moq_video::encode::Config,
-	) -> Result<Id, Error> {
-		// Open the encoder first: a config this machine can't encode should fail
-		// without leaving a track advertised that will never carry frames.
-		let encoder = block_on(moq_video::encode::Sink::open(&config))?;
-		let producer = moq_video::encode::Producer::new(broadcast.clone(), catalog, config.codec)?;
-		self.producers.insert(VideoEncoder {
-			encoder,
-			producer,
-			format,
-			size: config.size(),
-		})
-	}
-
-	pub fn publish_frame(&mut self, id: Id, timestamp_us: u64, data: &[u8]) -> Result<(), Error> {
-		let entry = self.producers.get_mut(id).ok_or(Error::MediaNotFound)?;
-
+impl VideoEncoder {
+	fn publish_frame(&mut self, timestamp_us: u64, data: &[u8]) -> Result<(), Error> {
 		// A buffer that isn't one picture at the configured size is rejected here,
 		// by the surface constructors, rather than reinterpreted.
-		let size = entry.size;
-		let surface = match entry.format {
+		let size = self.size;
+		let surface = match self.format {
 			moq_video_pixel_format::MOQ_VIDEO_PIXEL_FORMAT_I420 => {
 				moq_video::Surface::I420(moq_video::I420::new(size.width, size.height, data.to_vec())?)
 			}
@@ -277,34 +255,69 @@ impl Video {
 		let frame = moq_video::Frame::new(surface, moq_net::Timestamp::from_micros(timestamp_us)?);
 		// A backend that pipelines hands back an earlier frame's output, so this is
 		// zero or more access units rather than one per call.
-		let encoded = block_on(entry.encoder.encode(frame))?;
-		entry.producer.publish(&encoded)?;
+		let encoded = block_on(self.encoder.encode(frame))?;
+		self.producer.publish(&encoded)?;
 		Ok(())
 	}
 
-	pub fn publish_cut(&mut self, id: Id) -> Result<(), Error> {
-		let entry = self.producers.get_mut(id).ok_or(Error::MediaNotFound)?;
+	fn publish_cut(&mut self) {
 		// A keyframe is what a cut is on the wire: the importer closes the open
 		// group and starts a new one at it.
-		entry.encoder.keyframe();
+		self.encoder.keyframe();
+	}
+
+	fn publish_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		block_on(self.encoder.set_bitrate(bitrate))?;
 		Ok(())
 	}
 
-	pub fn publish_bitrate(&mut self, id: Id, bitrate: u64) -> Result<(), Error> {
-		let entry = self.producers.get_mut(id).ok_or(Error::MediaNotFound)?;
-		block_on(entry.encoder.set_bitrate(bitrate))?;
-		Ok(())
-	}
-
-	pub fn publish_finish(&mut self, id: Id) -> Result<(), Error> {
-		let entry = self.producers.remove(id).ok_or(Error::MediaNotFound)?;
+	fn publish_finish(self) -> Result<(), Error> {
 		let VideoEncoder {
 			encoder, mut producer, ..
-		} = entry;
+		} = self;
 		// Drain the codec into the track before ending it, so the last frames land
 		// in it rather than being dropped with the encoder.
 		let drained = block_on(encoder.finish()).and_then(|encoded| producer.publish(&encoded));
 		finalize(producer, drained)
+	}
+}
+
+impl Video {
+	/// Advertise a track for an already-opened encoder.
+	///
+	/// The encoder is opened by the caller, and before this, so a config this
+	/// machine can't encode fails without leaving a track advertised that will
+	/// never carry frames.
+	pub fn publish(
+		&mut self,
+		broadcast: &moq_net::broadcast::Producer,
+		catalog: moq_mux::catalog::Producer<moq_mux::catalog::hang::Extra>,
+		format: moq_video_pixel_format,
+		config: &moq_video::encode::Config,
+		encoder: moq_video::encode::Sink,
+	) -> Result<Id, Error> {
+		let producer = moq_video::encode::Producer::new(broadcast.clone(), catalog, config.codec)?;
+		self.producers.insert(Shared::new(VideoEncoder {
+			encoder,
+			producer,
+			format,
+			size: config.size(),
+		}))
+	}
+
+	/// Resolve a producer handle, so the caller can encode with the global lock
+	/// released.
+	///
+	/// Bind the result before locking it: a temporary [`State`] guard lives to the
+	/// end of the statement that created it, so resolving and locking in one
+	/// expression would put the encode back under the global lock.
+	pub(crate) fn producer(&self, id: Id) -> Result<Shared<VideoEncoder>, Error> {
+		self.producers.get(id).cloned().ok_or(Error::MediaNotFound)
+	}
+
+	/// Resolve a producer and drop its id, so nothing can be published to it after.
+	pub(crate) fn remove(&mut self, id: Id) -> Result<Shared<VideoEncoder>, Error> {
+		self.producers.remove(id).ok_or(Error::MediaNotFound)
 	}
 
 	pub fn consume(
@@ -483,11 +496,15 @@ pub unsafe extern "C" fn moq_publish_video_raw(
 			config.gop = raw_output.gop;
 		}
 
+		// Opened before the global lock is taken: bringing up a hardware encoder is
+		// slow enough that every other call would wait behind it.
+		let encoder = block_on(moq_video::encode::Sink::open(&config))?;
+
 		let mut state = State::lock();
 		let State { publish, video, .. } = &mut *state;
 		let (broadcast_producer, catalog) = publish.pair_mut(broadcast)?;
 
-		video.publish(broadcast_producer, catalog.clone(), format, config)
+		video.publish(broadcast_producer, catalog.clone(), format, &config, encoder)
 	})
 }
 
@@ -509,7 +526,12 @@ pub unsafe extern "C" fn moq_publish_video_raw_frame(producer: u32, frame: *cons
 		let frame = unsafe { frame.as_ref() }.ok_or(Error::InvalidPointer)?;
 		let data = unsafe { ffi::parse_slice(frame.data, frame.data_size)? };
 
-		State::lock().video.publish_frame(producer, frame.timestamp_us, data)
+		let producer = State::lock().video.producer(producer)?;
+		producer
+			.lock()
+			.as_mut()
+			.ok_or(Error::MediaNotFound)?
+			.publish_frame(frame.timestamp_us, data)
 	})
 }
 
@@ -528,7 +550,9 @@ pub unsafe extern "C" fn moq_publish_video_raw_frame(producer: u32, frame: *cons
 pub extern "C" fn moq_publish_video_raw_cut(producer: u32) -> i32 {
 	ffi::enter(move || {
 		let producer = ffi::parse_id(producer)?;
-		State::lock().video.publish_cut(producer)
+		let producer = State::lock().video.producer(producer)?;
+		producer.lock().as_mut().ok_or(Error::MediaNotFound)?.publish_cut();
+		Ok(())
 	})
 }
 
@@ -547,7 +571,12 @@ pub extern "C" fn moq_publish_video_raw_cut(producer: u32) -> i32 {
 pub extern "C" fn moq_publish_video_raw_bitrate(producer: u32, bitrate: u64) -> i32 {
 	ffi::enter(move || {
 		let producer = ffi::parse_id(producer)?;
-		State::lock().video.publish_bitrate(producer, bitrate)
+		let producer = State::lock().video.producer(producer)?;
+		producer
+			.lock()
+			.as_mut()
+			.ok_or(Error::MediaNotFound)?
+			.publish_bitrate(bitrate)
 	})
 }
 
@@ -558,7 +587,10 @@ pub extern "C" fn moq_publish_video_raw_bitrate(producer: u32, bitrate: u64) -> 
 pub extern "C" fn moq_publish_video_raw_finish(producer: u32) -> i32 {
 	ffi::enter(move || {
 		let producer = ffi::parse_id(producer)?;
-		State::lock().video.publish_finish(producer)
+		// The id is dropped first, so nothing new queues behind the drain; whatever
+		// is mid-encode still finishes before this takes the encoder.
+		let producer = State::lock().video.remove(producer)?;
+		producer.take().ok_or(Error::MediaNotFound)?.publish_finish()
 	})
 }
 


### PR DESCRIPTION
Fixes #2649.

## Summary

- **Root cause**: `Video::publish_frame` borrowed the producer out of the global `State` slab and encoded under that guard, and every C entry point runs inside `ffi::enter`, which took a process-wide mutex around the runtime handle for the duration. Both locks were held across `Sink::encode`, a round trip to the codec thread, so one slow or wedged codec parked every unrelated call in the process. `moq_publish_audio_raw_frame` had the identical shape around the Opus encode.
- Producers now live behind their own lock (`state::Shared`). Entry points resolve the handle under the global lock, drop that guard, and perform work behind the producer lock. Separate producers can encode concurrently.
- The runtime mutex is gone. `Handle::enter` only sets thread-local state, and its LIFO requirement is satisfied by the guard scoped to `enter` on each thread.
- The C threading documentation now promises serialization for one producer without claiming a FIFO order that `std::sync::Mutex` does not guarantee.

## Public API changes

None. `libmoq` is `crate-type = ["staticlib"]`, so its published surface is the unchanged C ABI.

## Test plan

- `nix develop --command just rs test -p libmoq`: 43 passed.
- `nix develop --command just ci`: JavaScript, docs, builds, Rust checks, rustdoc, and 2,616 Rust tests passed with 12 skipped. The final local flake evaluation cannot evaluate the configured `x86_64-darwin` cross-target because current Nixpkgs 26.11 has dropped support for that platform.
- GitHub Actions `Check` validates the pushed head on Linux.
- `just test smoke-full` was not run because there is no wire, moq-ffi, gateway, or C ABI change.

## Cross-package sync

No row applies: `moq.h` is unchanged, so `cpp/obs` and `doc/bin/obs.md` are unaffected, and `moq-ffi` never had this defect.

(Written by GPT-5)
