### PR TITLE
refactor(js/net)!: drop transport from ReloadProps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/src/connection/reload.test.ts
+++ b/js/net/src/connection/reload.test.ts
@@ -52,8 +52,16 @@ test("equivalent URL instances do not restart a pending connection", async () =>
 });
 
 test("ReloadProps excludes signal", () => {
+	const withSignal = { signal: new AbortController().signal };
 	// @ts-expect-error signal is not part of ReloadProps
-	const props: ReloadProps = { signal: new AbortController().signal };
+	const props: ReloadProps = withSignal;
+	expect(props.enabled).toBeUndefined();
+});
+
+test("ReloadProps excludes transport", () => {
+	const withTransport = { transport: {} as WebTransport };
+	// @ts-expect-error transport is not part of ReloadProps
+	const props: ReloadProps = withTransport;
 	expect(props.enabled).toBeUndefined();
 });
 

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -26,8 +26,20 @@ export type ReloadDelay = {
 	timeout?: DOMHighResTimeStamp;
 };
 
-/** Connection and retry options for {@link Reload}. */
-export type ReloadProps = Omit<ConnectProps, "signal"> & {
+/**
+ * Connection and retry options for {@link Reload}.
+ *
+ * {@link ConnectProps.transport} is excluded: a supplied session is good for exactly one
+ * connection, so the reconnect loop has nothing to reuse once that session drops. Call
+ * {@link connect} directly when you have a session to hand over.
+ */
+export type ReloadProps = Omit<ConnectProps, "signal" | "transport"> & {
+	/** A reload owns the abort signal for each connection attempt. */
+	signal?: never;
+
+	/** A one-shot transport cannot be reused by the reconnect loop. */
+	transport?: never;
+
 	/** Whether to reload the connection when it disconnects (default: true). */
 	enabled?: boolean | Signal<boolean>;
 


### PR DESCRIPTION
## Summary

- `Reload.#connect` has never forwarded `ConnectProps.transport` to `connect()`, so a caller who supplied a pre-existing `WebTransport` silently got a fresh dial instead.
- The option cannot work here by construction. A supplied session is good for exactly one connection, and the reconnect loop has nothing to reuse after the first drop. `connect()` remains the entry point for handing over a session.
- Narrow `ReloadProps` to omit `signal` and `transport`, then explicitly forbid both with optional `never` members. This rejects both inline object literals and preassembled config objects instead of silently ignoring either field.
- Bump `@moq/net` from 0.3.0 to 0.4.0 for the breaking published API change.

## Public API changes

- **Breaking**: `ReloadProps` no longer accepts `transport`.
- **Breaking type tightening**: the existing `signal` exclusion now also rejects preassembled option objects. Current `Reload` owns the abort signal for each connection attempt.
- `ConnectProps.transport`, `ConnectProps.signal`, and `connect()` are unchanged.
- Targets `dev` per [Branch Targeting](https://github.com/moq-dev/moq/blob/main/CONTRIBUTING.md#branch-targeting).

## Test plan

- Type-check and package build passed.
- Full `@moq/net` source suite: 354 pass, 0 fail.
- Pinned Bun 1.3.13 run after building: 708 pass, 0 fail across source and generated output.
- Required GitHub `Check` passed on `79cdceeaf` in 3m42s.

## Cross-package sync

- Updated `js/net/package.json` and `bun.lock` to 0.4.0.
- `doc/lib/js/@moq/net.md` never documented `transport` on `Reload`, so no docs change is needed.
- No wire format change.

## Interaction with #2655

[#2655](https://github.com/moq-dev/moq/pull/2655) targets `main` and deliberately makes `Reload` honor a caller-provided `signal`, while adding a runtime warning for `transport` as a non-breaking stopgap. When `main` and `dev` are reconciled, preserve #2655's signal support and this PR's transport prohibition. Remove #2655's transport warning and its warning-specific test.

(Written by GPT-5)