### PR TITLE
fix(moq-net): harden origin resume/route serving

### DIFF
--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1886,6 +1886,12 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 
 	// The source whose copy is currently spliced in, and that copy.
 	let mut serving: Option<(u64, track::Consumer)> = None;
+	// The delivered edge when that copy spliced in. A copy that dies without
+	// advancing it never delivered anything, which is what [`Step::Failed`]
+	// uses to tell a refusal from a mid-stream failover. Snapshotted per splice,
+	// not per wake: an unrelated wake between the copy's last group and its
+	// death must not launder its delivered progress away.
+	let mut spliced_edge: Option<u64> = None;
 	// Sources that refused this track, and the most recent refusal's error. A
 	// standby joining a live front wins dispatch the moment it attaches, which is
 	// before a real publisher has created every track, so its refusal must cost
@@ -1903,9 +1909,6 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 
 	loop {
 		let serving_id = serving.as_ref().map(|(id, _)| *id);
-		// The delivered edge as of this pass; what [`Step::Failed`] compares
-		// against to tell a mid-stream failover from a refusal.
-		let delivered = resume.latest();
 
 		// The table's verdict: once every attached source has refused, nothing
 		// will ever serve the track (refusals are never retried) and it aborts
@@ -2021,14 +2024,14 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 				return;
 			}
 			Step::Failed(err) => {
-				// The spliced copy died mid-serve. With delivered progress it's a
-				// normal failover: re-splice from the (possibly same) active
-				// source. A copy that died before producing anything is a refusal
-				// (a source whose track keeps dying right after acceptance must
-				// not re-splice forever), unless the source itself is closing:
-				// that corpse parks for its detach so a reconnect gets the
-				// seamless splice.
-				if resume.latest() == delivered
+				// The spliced copy died mid-serve. With delivered progress since
+				// its splice it's a normal failover: re-splice from the (possibly
+				// same) active source. A copy that died before producing anything
+				// is a refusal (a source whose track keeps dying right after
+				// acceptance must not re-splice forever), unless the source
+				// itself is closing: that corpse parks for its detach so a
+				// reconnect gets the seamless splice.
+				if resume.latest() == spliced_edge
 					&& let Some(id) = serving_id
 				{
 					let closing = state
@@ -2117,6 +2120,9 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 							return;
 						}
 						dead.clear();
+						// The new segment has produced nothing yet, so this is
+						// the edge the copy is asked to advance.
+						spliced_edge = resume.latest();
 						serving = Some((id, track));
 					}
 					// The source itself closed or deliberately ended: not a
@@ -5014,6 +5020,50 @@ mod tests {
 		let mut sub = retry.await.expect("a fresh request must reach the source");
 		producer.append_group().unwrap();
 		assert_eq!(sub.assert_group().sequence, 0);
+	}
+
+	/// A copy that delivered and later died is a failover even when unrelated
+	/// wakes happened between its last group and its death: progress is tracked
+	/// per splice, so a demand edge must not launder it into a zero-progress
+	/// refusal that aborts the only route.
+	#[tokio::test]
+	async fn test_delivered_copy_death_survives_unrelated_wakes() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+		producer.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+
+		// Unrelated demand-edge wakes after the copy's last group: the reader
+		// leaves and a new one arrives.
+		drop(sub);
+		settle().await;
+		let resubscribing = broadcast.track("video").unwrap().subscribe(None);
+		settle().await;
+		let mut sub = resubscribing.await.unwrap();
+		assert_eq!(sub.assert_group().sequence, 0, "cached group re-served");
+
+		// The copy then dies having delivered: failover, so the source is
+		// re-asked and the subscription resumes.
+		drop(producer);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		producer.create_group(group::Info { sequence: 1 }).unwrap();
+		assert_eq!(sub.assert_group().sequence, 1);
+		sub.assert_not_closed();
 	}
 
 	/// The front picks a source per track and re-picks on failover, so a route

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1235,17 +1235,30 @@ struct FrontState {
 }
 
 impl FrontState {
-	/// The source new track requests should dispatch to: live first, then lowest
-	/// cost, then shortest hop chain with a deterministic hash tie-break and the
-	/// newest source last, skipping routes that flow through a peer currently
-	/// reading the front while any other route remains (see
-	/// [`Self::prefer_untainted`]).
-	fn best_route(&self) -> Option<u64> {
-		let candidates: Vec<&FrontRoute> = self.routes.iter().collect();
-		self.prefer_untainted(&candidates)
+	/// The one selection primitive every picker goes through: the best route by
+	/// [`route_order`] among those surviving `keep`. With `untainted`, the pick
+	/// also steers away from routes that flow through a peer currently reading
+	/// the shared front, unless that leaves nothing (see
+	/// [`Self::prefer_untainted`]); it is off for [`Self::dispatch`], which pins
+	/// one requester to one source rather than serving the shared front.
+	fn pick(&self, keep: impl Fn(&FrontRoute) -> bool, untainted: bool) -> Option<u64> {
+		let candidates: Vec<&FrontRoute> = self.routes.iter().filter(|r| keep(r)).collect();
+		let candidates = match untainted {
+			true => self.prefer_untainted(&candidates),
+			false => candidates,
+		};
+		candidates
 			.into_iter()
 			.min_by_key(|r| route_order(&self.path.as_path(), r))
 			.map(|r| r.id)
+	}
+
+	/// The source new track requests should dispatch to: live first, then lowest
+	/// cost, then shortest hop chain with a deterministic hash tie-break and the
+	/// newest source last, skipping routes that flow through a peer currently
+	/// reading the front while any other route remains.
+	fn best_route(&self) -> Option<u64> {
+		self.pick(|_| true, true)
 	}
 
 	/// The source a subscription from `exclude` should dispatch to: the best
@@ -1255,11 +1268,7 @@ impl FrontState {
 	/// truthful, so any would-be cycle surfaces the requester's own origin in
 	/// the candidate chain and is filtered here, at any cycle length.
 	fn dispatch(&self, exclude: Option<Origin>) -> Option<u64> {
-		self.routes
-			.iter()
-			.filter(|r| exclude.is_none_or(|origin| !r.route.hops.contains(&origin)))
-			.min_by_key(|r| route_order(&self.path.as_path(), r))
-			.map(|r| r.id)
+		self.pick(|r| exclude.is_none_or(|origin| !r.route.hops.contains(&origin)), false)
 	}
 
 	/// Whether serving from `route` would hand an attached peer its own bytes back.
@@ -1307,11 +1316,7 @@ impl FrontState {
 		{
 			return Some(active);
 		}
-		let candidates: Vec<&FrontRoute> = self.routes.iter().filter(|r| !skip(r.id)).collect();
-		self.prefer_untainted(&candidates)
-			.into_iter()
-			.min_by_key(|r| route_order(&self.path.as_path(), r))
-			.map(|r| r.id)
+		self.pick(|r| !skip(r.id), true)
 	}
 
 	/// Re-pick the active source after the table changed. Serve tasks watch
@@ -1425,6 +1430,9 @@ fn detach_source(
 	graceful: bool,
 ) {
 	let close = {
+		// Snapshotted before the state lock (lock order: broadcast, then front).
+		// A demand flip in between only stales this reselect's handover gate,
+		// which self-corrects on the next table change.
 		let carrying = broadcast.demand().is_used();
 		let Ok(mut s) = state.write() else { return };
 		let Some(pos) = s.routes.iter().position(|r| r.id == id) else {
@@ -1445,6 +1453,16 @@ fn detach_source(
 		broadcast.abort_spliced(Error::Dropped);
 	}
 	sync_front(state, broadcast, leaf);
+}
+
+/// Match the ingress announce guard to a route's announce flag: opening bumps
+/// the announced counters, dropping bumps the closed ones. See [`run_source`].
+fn sync_announce(guard: &mut Option<stats::Announce>, announced: bool, ingress: &stats::Scope) {
+	match (announced, guard.is_some()) {
+		(true, false) => *guard = Some(ingress.announce()),
+		(false, true) => *guard = None,
+		_ => {}
+	}
 }
 
 /// Owns one source's lifecycle: attaches it to the front at its path on the first
@@ -1521,11 +1539,7 @@ async fn run_source(
 				match update {
 					// Our route moved; recompute the guard and retry with it.
 					Some(Ok(update)) => {
-						match (update.announce, announce.is_some()) {
-							(true, false) => announce = Some(ingress.announce()),
-							(false, true) => announce = None,
-							_ => {}
-						}
+						sync_announce(&mut announce, update.announce, &ingress);
 						route = update;
 					}
 					// The source closed while parked; it was never visible.
@@ -1545,13 +1559,16 @@ async fn run_source(
 					// A different first hop is new content: this source can no
 					// longer feed the front it attached to. Detach deliberately
 					// (a linger would only stall the replacement) and re-attach.
+					//
+					// Plain equality, not `same_publisher`: within one source
+					// handle the session layer already guarantees continuity (it
+					// replaces the handle when identity breaks, UNKNOWN restarts
+					// included), so this only catches a caller moving a live
+					// handle to a new publisher. An UNKNOWN-to-UNKNOWN metadata
+					// update (a legacy peer repricing) must not detach.
 					if update.hops.iter().next().copied() != publisher {
 						detach_source(&state, &broadcast, &leaf, id, true);
-						match (announced, announce.is_some()) {
-							(true, false) => announce = Some(ingress.announce()),
-							(false, true) => announce = None,
-							_ => {}
-						}
+						sync_announce(&mut announce, announced, &ingress);
 						route = update;
 						continue 'attach;
 					}
@@ -1568,11 +1585,7 @@ async fn run_source(
 						s.reselect(carrying);
 					}
 					// Toggle the ingress announce guard on a live/offline transition.
-					match (announced, announce.is_some()) {
-						(true, false) => announce = Some(ingress.announce()),
-						(false, true) => announce = None,
-						_ => {}
-					}
+					sync_announce(&mut announce, announced, &ingress);
 					sync_front(&state, &broadcast, &leaf);
 				}
 				Err(_) => {
@@ -1844,24 +1857,26 @@ async fn run_front(
 
 /// Serves one spliced logical track: splices in the best source's copy of the
 /// track, re-splicing on handover or failure, until the track completes or the
-/// front closes. A source that refuses the track (rejects it, or hands over a
-/// copy that already ended in an error) aborts the logical track immediately:
-/// which tracks a broadcast carries is the publisher's contract (announce after
-/// the tracks exist), so the dispatched source's answer is authoritative and
-/// there is nothing to retry. Failures after a splice (a serving session dying
-/// mid-stream) are normal failover and re-splice from the next source at the
-/// first missing group; a source that errors while *closing* is likewise a
-/// corpse to fail over past (its watcher is about to detach it), not a verdict
-/// on the track.
+/// front closes. A refusal (a source rejecting the track, or its copy dying
+/// before delivering anything) is authoritative and never retried: the refuser
+/// is skipped for this track so a joining standby cannot kill a subscription
+/// the incumbent is serving, and once every attached source has refused, the
+/// track aborts with the last refusal's error. The verdict belongs to this
+/// request; a later consumer request asks afresh (see `track_inner`). Failures
+/// after delivered progress (a serving session dying mid-stream) are normal
+/// failover and re-splice from the next source at the first missing group; a
+/// source that fails while *closing* is a corpse to fail over past (its watcher
+/// is about to detach it), not a verdict on the track.
 async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resume: super::resume::Producer) {
 	enum Step {
 		Closed,
 		Splice(u64, broadcast::Consumer),
 		Complete,
-		Failed,
-		/// The route we were serving from left the table with nothing servable
-		/// to replace it (an empty table, or only corpses awaiting detach):
-		/// drop our handle and park for the table to move on.
+		Failed(Error),
+		/// The route we were serving from left the table with nothing servable to
+		/// replace it: drop our handle; the verdict block at the top of the loop
+		/// decides between aborting (all refused) and parking (corpses detaching,
+		/// or an empty table awaiting a reconnect).
 		NoRoute,
 		/// The linger expired with the track still unread: release the segment.
 		Idle,
@@ -1871,10 +1886,16 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 
 	// The source whose copy is currently spliced in, and that copy.
 	let mut serving: Option<(u64, track::Consumer)> = None;
+	// Sources that refused this track, and the most recent refusal's error. A
+	// standby joining a live front wins dispatch the moment it attaches, which is
+	// before a real publisher has created every track, so its refusal must cost
+	// the incumbent nothing: we keep serving from a route that has the track.
+	let mut refused: HashSet<u64> = HashSet::new();
+	let mut refusal: Option<Error> = None;
 	// Sources whose splice failed because they had already closed. Their watchers
 	// are about to detach them, so wait for the table to move on rather than
-	// treating a corpse's error as the track's fate (ids are never reused, so
-	// this cannot wedge).
+	// treating a corpse's error as a refusal (ids are never reused, so this
+	// cannot wedge).
 	let mut dead: HashSet<u64> = HashSet::new();
 	// When the spliced segment stopped being read, starting the release countdown.
 	let mut idle_since: Option<web_async::time::Instant> = None;
@@ -1882,12 +1903,30 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 
 	loop {
 		let serving_id = serving.as_ref().map(|(id, _)| *id);
+		// The delivered edge as of this pass; what [`Step::Failed`] compares
+		// against to tell a mid-stream failover from a refusal.
+		let delivered = resume.latest();
 
-		// Drop corpses the table has detached, so a source that reattaches (under
-		// a fresh id) is dispatchable while a still-detaching one stays skipped.
+		// The table's verdict: once every attached source has refused, nothing
+		// will ever serve the track (refusals are never retried) and it aborts
+		// with the last refusal's error. A detached refuser leaves the set, so a
+		// source that reattaches (under a fresh id) is asked anew; a table blocked
+		// only by corpses awaiting detach parks instead, since their replacement
+		// (a reconnect) deserves the seamless splice.
 		{
 			let s = state.read();
+			refused.retain(|id| s.routes.iter().any(|r| r.id == *id));
 			dead.retain(|id| s.routes.iter().any(|r| r.id == *id));
+			let exhausted = !s.routes.is_empty()
+				&& s.serve_route(|id| refused.contains(&id) || dead.contains(&id))
+					.is_none();
+			if exhausted && dead.is_empty() {
+				drop(s);
+				let err = refusal.take().unwrap_or(Error::NotFound);
+				tracing::debug!(name = %name, %err, "every source refused track; aborting");
+				let _ = resume.abort(err);
+				return;
+			}
 		}
 
 		// Demand gates both directions: an unread track never splices a source in,
@@ -1909,11 +1948,12 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		deadline.set(idle_since.and_then(|at| at.checked_add(TRACK_IDLE_LINGER)));
 
 		let step = {
-			let skip = |id: u64| dead.contains(&id);
+			let skip = |id: u64| refused.contains(&id) || dead.contains(&id);
 			kio::wait(|waiter| {
 				// Watch the source table: the front closing, a better servable
-				// source than the one spliced in (skipping corpses awaiting
-				// detach), or the served route leaving the table. Splicing waits
+				// source than the one spliced in (skipping any we already know
+				// can't serve this track), or the served route leaving the table,
+				// which retires the refusals collected against it. Splicing waits
 				// for a reader.
 				match state.poll(waiter, |s| {
 					let gone = serving_id.is_some_and(|id| !s.routes.iter().any(|r| r.id == id));
@@ -1958,13 +1998,13 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 				}
 
 				// Watch the spliced copy for its end: complete means the logical
-				// track is over; anything else means the serving source died.
+				// track is over; anything else means the serving copy died.
 				if let Some((_, track)) = &serving
 					&& let Poll::Ready(result) = track.poll_complete(waiter)
 				{
 					return Poll::Ready(match result {
 						Ok(()) => Step::Complete,
-						Err(_) => Step::Failed,
+						Err(err) => Step::Failed(err),
 					});
 				}
 
@@ -1980,9 +2020,30 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 				let _ = resume.finish();
 				return;
 			}
-			Step::Failed => {
-				// The spliced copy died mid-serve: failover. Re-splice from the
-				// (possibly same) active source.
+			Step::Failed(err) => {
+				// The spliced copy died mid-serve. With delivered progress it's a
+				// normal failover: re-splice from the (possibly same) active
+				// source. A copy that died before producing anything is a refusal
+				// (a source whose track keeps dying right after acceptance must
+				// not re-splice forever), unless the source itself is closing:
+				// that corpse parks for its detach so a reconnect gets the
+				// seamless splice.
+				if resume.latest() == delivered
+					&& let Some(id) = serving_id
+				{
+					let closing = state
+						.read()
+						.routes
+						.iter()
+						.find(|r| r.id == id)
+						.is_some_and(|r| r.source.is_closing());
+					if closing {
+						dead.insert(id);
+					} else {
+						refused.insert(id);
+						refusal = Some(err);
+					}
+				}
 				serving = None;
 			}
 			// The outer loop recomputes `used` and the countdown on the next pass.
@@ -2013,13 +2074,11 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 						// `into_inner` sheds the `Pending` future wrapper so only
 						// the pollable (which is `Sync`) is held across the await.
 						let query = track.info().into_inner();
-						let skip = |id: u64| dead.contains(&id);
-						// The route-change edge is checked BEFORE the query result:
-						// a rejection is only authoritative while the source is
-						// still the dispatched route, and the two can resolve in
-						// the same wake. Taking a stale rejection here would turn
-						// a seamless handover into a terminal abort.
+						let skip = |id: u64| refused.contains(&id) || dead.contains(&id);
 						let info = kio::wait(|waiter| {
+							if let Poll::Ready(result) = query.poll(waiter) {
+								return Poll::Ready(Some(result));
+							}
 							match state.poll(waiter, |s| {
 								if s.closed || s.serve_route(skip) != Some(id) {
 									Poll::Ready(())
@@ -2027,10 +2086,9 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 									Poll::Pending
 								}
 							}) {
-								Poll::Ready(_) => return Poll::Ready(None),
-								Poll::Pending => {}
+								Poll::Ready(_) => Poll::Ready(None),
+								Poll::Pending => Poll::Pending,
 							}
-							query.poll(waiter).map(Some)
 						})
 						.await;
 						match info {
@@ -2050,9 +2108,12 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 
 				match attempt {
 					Ok(track) => {
-						if resume.takeover(&track).is_err() {
-							// The logical track already ended (finished or
-							// aborted); nothing left to serve.
+						if let Err(err) = resume.takeover(&track) {
+							// Closed means the logical track already ended
+							// (finished or aborted). Anything else is a boundary
+							// bug; abort rather than strand subscribers on a
+							// track no task serves (a no-op after a clean end).
+							let _ = resume.abort(err);
 							return;
 						}
 						dead.clear();
@@ -2065,15 +2126,16 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 						dead.insert(id);
 						serving = None;
 					}
-					// The dispatched source does not carry the track, and its
-					// answer is authoritative: a publisher announces a broadcast
-					// only once its tracks exist, so there is no later sweep that
-					// would find the track and nothing to retry. Fail now, loudly,
-					// with the source's own error.
+					// The dispatched source does not carry the track: a publisher
+					// announces a broadcast only once its tracks exist, so the
+					// answer is authoritative and never re-asked. Skip the source
+					// for this track; the verdict block aborts once every source
+					// has refused.
 					Err(err) => {
-						tracing::debug!(name = %name, source = id, %err, "source refused track; aborting");
-						let _ = resume.abort(err);
-						return;
+						tracing::debug!(name = %name, source = id, %err, "source refused track");
+						refused.insert(id);
+						refusal = Some(err);
+						serving = None;
 					}
 				}
 			}
@@ -3744,10 +3806,10 @@ mod tests {
 		dynamic.assert_no_request();
 	}
 
-	/// A rejection is only authoritative while its source is still the
-	/// dispatched route. Here a better route takes over while the original
-	/// source's info request is pending, and the stale source rejects at the
-	/// same moment: the handover must win, not the stale rejection.
+	/// A rejection only rules its source out of the track, so a better route
+	/// taking over while the original source's info request is pending (and the
+	/// stale source rejecting at the same moment) rides the handover instead of
+	/// aborting the subscription.
 	#[tokio::test]
 	async fn test_stale_rejection_does_not_abort_a_handover() {
 		tokio::time::pause();
@@ -4816,13 +4878,14 @@ mod tests {
 		sub.assert_not_closed();
 	}
 
-	/// A standby that wins dispatch without carrying the track ends the logical
-	/// track immediately, even over an incumbent that was serving it: which
-	/// tracks a broadcast carries is the publisher's contract (announce after
-	/// the tracks exist), so the newly-dispatched source's refusal is the
-	/// track's verdict rather than the start of a retry sweep.
+	/// A standby that wins dispatch before creating a track must not kill a
+	/// subscription the incumbent is serving: its refusal only rules it out of
+	/// this track, and the incumbent keeps delivering. The refusal is still
+	/// never retried: once the incumbent goes away every remaining source has
+	/// refused, so the subscription aborts and the consumer's next request asks
+	/// afresh.
 	#[tokio::test]
-	async fn test_standby_missing_track_aborts() {
+	async fn test_standby_missing_track_keeps_incumbent() {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
@@ -4848,8 +4911,8 @@ mod tests {
 		producer_remote.append_group().unwrap();
 		assert_eq!(sub.assert_group().sequence, 0);
 
-		// The standby joins and wins dispatch, but has not created "audio" yet:
-		// its refusal ends the logical track, incumbent notwithstanding.
+		// The standby joins and wins dispatch, but has not created "audio" yet.
+		// Its refusal must cost the incumbent nothing.
 		let source_local = origin.create_broadcast("test", announce().with_hops(local)).unwrap();
 		let mut dynamic_local = source_local.dynamic();
 		settle().await;
@@ -4857,7 +4920,27 @@ mod tests {
 		assert_eq!(request.name(), "audio");
 		request.reject(Error::NotFound);
 		settle().await;
+
+		// Still spliced to the incumbent, still delivering.
+		producer_remote.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 1);
+		sub.assert_not_closed();
+
+		// The incumbent leaving exhausts the table (the standby's refusal is
+		// never retried): the subscription aborts.
+		source_remote.abort(Error::Dropped).unwrap();
+		settle().await;
+		settle().await;
 		sub.assert_closed();
+		dynamic_local.assert_no_request();
+
+		// A fresh consumer request asks the standby anew, which has the track now.
+		let retry = broadcast.track("audio").unwrap().subscribe(None);
+		let mut producer_local = accept_track(&mut dynamic_local, "audio").await;
+		settle().await;
+		let mut sub = retry.await.expect("a fresh request must reach the standby");
+		producer_local.create_group(group::Info { sequence: 2 }).unwrap();
+		assert_eq!(sub.assert_group().sequence, 2);
 	}
 
 	/// A refused track aborts, but the verdict is not cached: it belongs to the
@@ -4887,6 +4970,46 @@ mod tests {
 		// The publisher has the track now; a fresh request must reach it.
 		let retry = broadcast.track("audio").unwrap().subscribe(None);
 		let mut producer = accept_track(&mut dynamic, "audio").await;
+		settle().await;
+		let mut sub = retry.await.expect("a fresh request must reach the source");
+		producer.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+	}
+
+	/// A copy that dies before delivering anything is a refusal, not a failover:
+	/// a source whose track keeps dying right after acceptance must not
+	/// re-splice forever. With every attached source refused, the track aborts
+	/// with the copy's error, and the verdict belongs to that request: a fresh
+	/// consumer request asks again.
+	#[tokio::test]
+	async fn test_track_dying_without_progress_aborts() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+
+		// The copy dies without delivering a single group, from a source that is
+		// alive and well: that's its answer for the track, not a failover.
+		drop(producer);
+		settle().await;
+		sub.assert_closed();
+		dynamic.assert_no_request();
+
+		// A fresh request asks the (still attached) source anew.
+		let retry = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
 		settle().await;
 		let mut sub = retry.await.expect("a fresh request must reach the source");
 		producer.append_group().unwrap();

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -1693,7 +1693,10 @@ mod test {
 		let handler = track_a.dynamic();
 		let fetch = consumer.fetch_group(0, None);
 		let mut fetch = std::pin::pin!(fetch);
-		assert!(futures::poll!(fetch.as_mut()).is_pending(), "unanswered fetch should park");
+		assert!(
+			futures::poll!(fetch.as_mut()).is_pending(),
+			"unanswered fetch should park"
+		);
 
 		// The front aborting must end the in-flight fetch, not strand it on the
 		// copy that will never answer.

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -519,7 +519,20 @@ impl kio::Pollable for Fetching {
 			let (latched, track, fetch) = inner.as_ref().expect("latched above");
 			let err = match kio::Pollable::poll(&**fetch, waiter) {
 				Poll::Ready(Err(err)) => err,
-				other => return other,
+				Poll::Ready(Ok(group)) => return Poll::Ready(Ok(group)),
+				// Park on the resume state too: the front aborting must end an
+				// in-flight fetch even when the latched copy never answers it.
+				Poll::Pending => {
+					return match self.state.poll(waiter, |s| match &s.abort {
+						Some(err) => Poll::Ready(err.clone()),
+						None => Poll::Pending,
+					}) {
+						Poll::Ready(Ok(err)) => Poll::Ready(Err(err)),
+						// The producer froze without aborting; only the copy can
+						// answer now.
+						_ => Poll::Pending,
+					};
+				}
 			};
 
 			// The latched copy failed the fetch. Fail over to a segment spliced in
@@ -1666,6 +1679,27 @@ mod test {
 		// The logical track aborting ends the wait with its error.
 		producer.abort(Error::Cancel).unwrap();
 		assert!(matches!(fetch.await, Err(Error::Cancel)));
+	}
+
+	#[tokio::test]
+	async fn fetch_pending_ends_when_the_track_aborts() {
+		let (track_a, consumer_a) = track_pair("a");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let consumer = producer.consume();
+
+		// A fetch handler exists but never answers: the latched fetch parks.
+		let handler = track_a.dynamic();
+		let fetch = consumer.fetch_group(0, None);
+		let mut fetch = std::pin::pin!(fetch);
+		assert!(futures::poll!(fetch.as_mut()).is_pending(), "unanswered fetch should park");
+
+		// The front aborting must end the in-flight fetch, not strand it on the
+		// copy that will never answer.
+		producer.abort(Error::Cancel).unwrap();
+		assert!(matches!(fetch.await, Err(Error::Cancel)));
+		drop(handler);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -1678,7 +1678,11 @@ mod test {
 
 		// The copy is alive and will never carry group 0 (no fetch handler):
 		// its answer surfaces instead of parking for a takeover.
-		assert!(matches!(consumer.fetch_group(0, None).await, Err(Error::NotFound)));
+		let result = consumer
+			.fetch_group(0, None)
+			.now_or_never()
+			.expect("a live copy's answer must resolve immediately");
+		assert!(matches!(result, Err(Error::NotFound)));
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -64,9 +64,20 @@ fn slice(prefs: &Subscription, start: Option<u64>, end: Option<u64>) -> Subscrip
 	sub
 }
 
+/// How many segments a logical track keeps before pruning terminal ones from the
+/// front: the live segment plus a couple of predecessors still draining to slow
+/// readers. Without a bound, every failover leaves one dead segment (pinning a
+/// dead session's [`track::Consumer`] and cache) behind for the life of the track.
+const MAX_SEGMENTS: usize = 3;
+
 struct ResumeState {
 	/// Segments in switch order; ranges are disjoint and ascending.
 	segments: Vec<Segment>,
+	/// The last group covered by segments that have since been pruned: no future
+	/// segment can serve at or below it (boundaries only move forward), so it
+	/// participates in the takeover boundary. `None` until the first prune; reset
+	/// by [`Producer::release`] along with the segments.
+	pruned: Option<u64>,
 	/// Bumped on every mutation so subscribers know to reconcile.
 	epoch: u64,
 	/// No more switches will happen; the logical track ends with its last segment.
@@ -79,6 +90,7 @@ impl Default for ResumeState {
 	fn default() -> Self {
 		Self {
 			segments: Vec::new(),
+			pruned: None,
 			epoch: 1,
 			finished: false,
 			abort: None,
@@ -88,8 +100,16 @@ impl Default for ResumeState {
 
 impl ResumeState {
 	/// The latest group sequence across the segments, clamped to their bounds.
+	///
+	/// The pruned floor participates: a pruned segment produced exactly through its
+	/// cap, so dropping it must not let the boundary collapse below what it served
+	/// (a takeover would re-splice under the delivered edge).
 	fn latest(&self) -> Option<u64> {
-		self.segments.iter().filter_map(Segment::produced).max()
+		self.segments
+			.iter()
+			.filter_map(Segment::produced)
+			.chain(self.pruned)
+			.max()
 	}
 
 	/// Append a segment serving groups from `start` onward, capping (or replacing)
@@ -129,7 +149,33 @@ impl ResumeState {
 			track,
 		});
 		self.epoch += 1;
+		self.prune();
 		Ok(())
+	}
+
+	/// Drop retired segments from the front once the list outgrows
+	/// [`MAX_SEGMENTS`], recording the last group they covered in [`Self::pruned`].
+	///
+	/// A front segment is retired when it owes nothing more: it produced through
+	/// its cap (a takeover boundary is one past the delivered edge, so this is
+	/// every takeover-capped segment, alive or not) or its track is terminal. What
+	/// it holds is a cache for slow readers, and a reader mid-drain keeps its own
+	/// cursor until it drains (see [`SegmentSub::retired`]). Only a manually
+	/// spliced boundary can sit above the produced edge; that segment is still
+	/// expected to backfill, so it blocks the sweep (and the segments behind it)
+	/// until it does or dies.
+	fn prune(&mut self) {
+		while self.segments.len() > MAX_SEGMENTS {
+			let front = &self.segments[0];
+			let Some(end) = front.end else { break };
+			let owes_more =
+				front.produced() < Some(end) && front.track.poll_complete(&kio::Waiter::noop()).is_pending();
+			if owes_more {
+				break;
+			}
+			self.pruned = self.pruned.max(Some(end));
+			self.segments.remove(0);
+		}
 	}
 }
 
@@ -200,13 +246,15 @@ impl Producer {
 		if state.finished || state.abort.is_some() {
 			return Err(Error::Closed);
 		}
-		let start = if state.segments.is_empty() {
-			None
-		} else {
-			match state.latest() {
-				Some(latest) => latest.checked_add(1),
-				// Segments exist but never produced a group: replace them.
-				None => Some(0),
+		let start = match state.latest() {
+			Some(latest) => latest.checked_add(1),
+			// No segment produced a group (or none exists): replace them outright
+			// and start unbounded, exactly like a first splice. A `Some(0)` boundary
+			// here would turn the subscriber's live-edge demand into a full backfill
+			// from group 0.
+			None => {
+				state.segments.clear();
+				None
 			}
 		};
 		state.switch(track, start)
@@ -229,6 +277,9 @@ impl Producer {
 			return Ok(());
 		}
 		state.segments.clear();
+		// The next takeover starts unbounded and may restart the numbering, so a
+		// floor from the old numbering must not cut into it.
+		state.pruned = None;
 		state.epoch += 1;
 		Ok(())
 	}
@@ -275,6 +326,12 @@ impl Producer {
 	/// servable or cleanly [`finish`](Self::finish)ed.
 	pub(crate) fn is_aborted(&self) -> bool {
 		self.state.read().abort.is_some()
+	}
+
+	/// The latest group sequence across the segments, clamped to their bounds.
+	/// The origin's serve task reads this as its delivered-progress signal.
+	pub(crate) fn latest(&self) -> Option<u64> {
+		self.state.read().latest()
 	}
 
 	/// Create a read handle for the logical track.
@@ -407,15 +464,21 @@ impl Consumer {
 /// [`kio::Pending`] wrapper.
 ///
 /// Waits for a segment to exist (no route may have served the track yet), then
-/// issues the fetch against the newest segment's track and resolves with it.
+/// issues the fetch against the newest segment's track and resolves with it. A
+/// fetch whose copy dies fails over: it re-latches onto a newer segment if one
+/// already spliced in, or parks for the next takeover like a live subscription
+/// (the front aborting the track ends the wait). An error from a copy that is
+/// still live (e.g. the group is gone upstream) is authoritative and surfaces.
 pub struct Fetching {
 	state: kio::Consumer<ResumeState>,
 	sequence: u64,
 	options: group::Fetch,
-	// The underlying fetch, latched once a segment exists. Behind a shared lock
-	// both to allow `&self` polling and to break the type recursion with
-	// `track::Fetching` (which can wrap a resume [`Fetching`]).
-	inner: web_async::Lock<Option<kio::Pending<track::Fetching>>>,
+	// The latched segment (id, its track, the in-flight fetch), set once a
+	// segment exists. Behind a shared lock both to allow `&self` polling and to
+	// break the type recursion with `track::Fetching` (which can wrap a resume
+	// [`Fetching`]).
+	#[allow(clippy::type_complexity)]
+	inner: web_async::Lock<Option<(u64, track::Consumer, kio::Pending<track::Fetching>)>>,
 }
 
 impl kio::Pollable for Fetching {
@@ -424,31 +487,75 @@ impl kio::Pollable for Fetching {
 	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
 		let mut inner = self.inner.lock();
 
-		if inner.is_none() {
-			// Wait for the first segment; the newest wins if several arrived.
-			let track = match self.state.poll(waiter, |s| {
-				if s.abort.is_some() || !s.segments.is_empty() {
+		loop {
+			if inner.is_none() {
+				// Wait for the first segment; the newest wins if several arrived.
+				let (id, track) = match self.state.poll(waiter, |s| {
+					if s.abort.is_some() || !s.segments.is_empty() {
+						Poll::Ready(match &s.abort {
+							Some(err) => Err(err.clone()),
+							None => {
+								let segment = s.segments.last().expect("nonempty");
+								Ok((segment.id, segment.track.clone()))
+							}
+						})
+					} else {
+						Poll::Pending
+					}
+				}) {
+					Poll::Ready(Ok(res)) => res?,
+					// The producer is gone; use whatever segment it froze with.
+					Poll::Ready(Err(state)) => match (&state.abort, state.segments.last()) {
+						(Some(err), _) => return Poll::Ready(Err(err.clone())),
+						(None, Some(segment)) => (segment.id, segment.track.clone()),
+						(None, None) => return Poll::Ready(Err(Error::NotFound)),
+					},
+					Poll::Pending => return Poll::Pending,
+				};
+				let fetch = track.fetch_group(self.sequence, self.options.clone());
+				*inner = Some((id, track, fetch));
+			}
+
+			let (latched, track, fetch) = inner.as_ref().expect("latched above");
+			let err = match kio::Pollable::poll(&**fetch, waiter) {
+				Poll::Ready(Err(err)) => err,
+				other => return other,
+			};
+
+			// The latched copy failed the fetch. Fail over to a segment spliced in
+			// above it, if any; ids are monotonic, so "newer" is a plain compare.
+			let latched = *latched;
+			let next = match self.state.poll(waiter, |s| {
+				if s.abort.is_some() || s.segments.last().is_some_and(|segment| segment.id > latched) {
 					Poll::Ready(match &s.abort {
 						Some(err) => Err(err.clone()),
-						None => Ok(s.segments.last().expect("nonempty").track.clone()),
+						None => {
+							let segment = s.segments.last().expect("checked newer");
+							Ok((segment.id, segment.track.clone()))
+						}
 					})
 				} else {
 					Poll::Pending
 				}
 			}) {
 				Poll::Ready(Ok(res)) => res?,
-				// The producer is gone; use whatever segment it froze with.
-				Poll::Ready(Err(state)) => match (&state.abort, state.segments.last()) {
-					(Some(err), _) => return Poll::Ready(Err(err.clone())),
-					(None, Some(segment)) => segment.track.clone(),
-					(None, None) => return Poll::Ready(Err(Error::NotFound)),
+				// The producer froze; no replacement can arrive.
+				Poll::Ready(Err(_)) => return Poll::Ready(Err(err)),
+				// No replacement yet, and the waiter is registered for the next
+				// switch. A dead copy's failure is the route's, not the group's:
+				// park for the takeover, exactly like a live subscription stalls.
+				// A live copy's answer stands.
+				Poll::Pending => match track.poll_complete(&kio::Waiter::noop()) {
+					Poll::Ready(Err(_)) => return Poll::Pending,
+					_ => return Poll::Ready(Err(err)),
 				},
-				Poll::Pending => return Poll::Pending,
 			};
-			*inner = Some(track.fetch_group(self.sequence, self.options.clone()));
-		}
 
-		kio::Pollable::poll(&**inner.as_ref().expect("latched above"), waiter)
+			let (id, track) = next;
+			let fetch = track.fetch_group(self.sequence, self.options.clone());
+			*inner = Some((id, track, fetch));
+			// Loop: poll the replacement fetch in this same pass.
+		}
 	}
 }
 
@@ -462,6 +569,20 @@ struct SegmentSub {
 	/// re-offered once the cap rises (arrival-order reads consume the underlying
 	/// cursor, so the group is parked here instead of dropped).
 	parked: Option<group::Consumer>,
+	/// The producer dropped this segment (pruned from the window, or replaced
+	/// before producing). See [`Self::retired`].
+	pruned: bool,
+}
+
+impl SegmentSub {
+	/// Whether a pruned segment owes this reader nothing more, so its cursor can
+	/// be dropped: an uncapped one was replaced before producing (its cursor holds
+	/// nothing), and a capped one is kept until it drains through its cap and any
+	/// parked group is re-offered, so a slow reader still gets what the pruned
+	/// segment's track cached.
+	fn retired(&self) -> bool {
+		self.pruned && (self.end.is_none() || (matches!(self.sub, SubState::Done(_)) && self.parked.is_none()))
+	}
 }
 
 enum SubState {
@@ -513,6 +634,43 @@ impl Subscriber {
 	/// Sync with the producer and preferences: pick up new segments, apply moved
 	/// boundaries, re-slice demand, and register the waiter for the next change.
 	fn poll_sync(&mut self, waiter: &kio::Waiter) {
+		self.sync(waiter);
+		self.reap();
+	}
+
+	/// Reap retired cursors, then bound the live stragglers: a pruned segment's
+	/// cursor keeps draining (groups below its cap may still arrive out of
+	/// order, and its demand keeps the upstream serving them), but only the
+	/// newest few. Beyond the bound the oldest are cut, mirroring the
+	/// producer-side policy: a reader that far behind loses the range.
+	///
+	/// Runs from [`Self::poll_sync`] so every polling entry point enforces the
+	/// bound; a subscriber driven only through datagrams or `poll_finished`
+	/// accumulates cursors all the same.
+	fn reap(&mut self) {
+		self.segments.retain(|s| !s.retired());
+		let mut cut = self
+			.segments
+			.iter()
+			.filter(|s| s.pruned)
+			.count()
+			.saturating_sub(MAX_SEGMENTS);
+		if cut > 0 {
+			for seg in &mut self.segments {
+				if cut == 0 {
+					break;
+				}
+				if seg.pruned {
+					seg.sub = SubState::Done(None);
+					seg.parked = None;
+					cut -= 1;
+				}
+			}
+			self.segments.retain(|s| !s.retired());
+		}
+	}
+
+	fn sync(&mut self, waiter: &kio::Waiter) {
 		// Preference changes re-derive every segment's demand. Loop: a poll that
 		// consumes a change leaves no waiter registered, so re-poll until Pending
 		// (mirroring the state loop below), or the next update is silently lost.
@@ -577,8 +735,14 @@ impl Subscriber {
 		self.finished = finished;
 		self.abort = abort;
 
-		// Segments removed by the producer (replaced before producing anything).
-		self.segments.retain(|s| segments.iter().any(|n| n.id == s.id));
+		// Segments the producer dropped: replaced before producing (uncapped) or
+		// pruned from the front of the window (capped). A capped one may still owe
+		// its cache to this reader, so it is only dropped once drained rather than
+		// outright (see [`SegmentSub::retired`]).
+		for s in &mut self.segments {
+			s.pruned = !segments.iter().any(|n| n.id == s.id);
+		}
+		self.segments.retain(|s| !s.retired());
 
 		for segment in segments {
 			match self.segments.iter_mut().find(|s| s.id == segment.id) {
@@ -604,6 +768,7 @@ impl Subscriber {
 						end: segment.end,
 						sub: SubState::Pending(sub),
 						parked: None,
+						pruned: false,
 					});
 				}
 			}
@@ -1353,6 +1518,160 @@ mod test {
 		assert_eq!(counter.0.load(Ordering::SeqCst), 2, "second update lost its wakeup");
 		assert!(fut.as_mut().poll(&mut cx).is_pending());
 		assert_eq!(track_a.subscription().unwrap().priority, 2);
+	}
+
+	#[tokio::test]
+	async fn prune_bounds_segments_and_keeps_the_boundary() {
+		let mut producer = Producer::new();
+		let mut sub = producer.consume().subscribe(None);
+
+		// Each failover leaves a capped segment behind; the producer keeps only
+		// the newest few, recording the boundary the pruned ones covered.
+		let count = 2 * MAX_SEGMENTS as u64;
+		let mut tracks = Vec::new();
+		for sequence in 0..count {
+			let (mut track, consumer) = track_pair("t");
+			producer.takeover(&consumer).unwrap();
+			write_group(&mut track, sequence, "g");
+			assert_eq!(recv(&mut sub), sequence);
+			tracks.push(track);
+		}
+		assert!(producer.state.read().segments.len() <= MAX_SEGMENTS);
+		assert_eq!(producer.latest(), Some(count - 1));
+
+		// The next takeover resumes above the pruned floor.
+		let (mut track, consumer) = track_pair("next");
+		producer.takeover(&consumer).unwrap();
+		write_group(&mut track, count, "g");
+		assert_eq!(recv(&mut sub), count);
+	}
+
+	#[tokio::test]
+	async fn reader_drains_a_pruned_segments_copy() {
+		let mut producer = Producer::new();
+		let mut sub = producer.consume().subscribe(None);
+
+		// Register a cursor on every segment as it splices (the datagram poll
+		// syncs without consuming groups), while the producer prunes the front.
+		let count = 2 * MAX_SEGMENTS as u64;
+		let mut tracks = Vec::new();
+		for sequence in 0..count {
+			let (mut track, consumer) = track_pair("t");
+			producer.takeover(&consumer).unwrap();
+			assert!(
+				kio::wait(|waiter| sub.poll_recv_datagram(waiter))
+					.now_or_never()
+					.is_none(),
+				"no datagram expected"
+			);
+			write_group(&mut track, sequence, "g");
+			tracks.push(track);
+		}
+		assert!(producer.state.read().segments.len() <= MAX_SEGMENTS);
+
+		// The slow reader still drains every group: a pruned segment's cursor is
+		// kept until it empties.
+		for sequence in 0..count {
+			assert_eq!(recv(&mut sub), sequence);
+		}
+	}
+
+	#[tokio::test]
+	async fn datagram_poller_bounds_pruned_cursors() {
+		let mut producer = Producer::new();
+		let mut sub = producer.consume().subscribe(None);
+
+		for sequence in 0..(3 * MAX_SEGMENTS as u64) {
+			let (mut track, consumer) = track_pair("t");
+			producer.takeover(&consumer).unwrap();
+			write_group(&mut track, sequence, "payload");
+			assert!(
+				kio::wait(|waiter| sub.poll_recv_datagram(waiter))
+					.now_or_never()
+					.is_none(),
+				"no datagram expected"
+			);
+		}
+
+		assert_eq!(
+			sub.segments.len(),
+			2 * MAX_SEGMENTS,
+			"the reap must run on the datagram path too"
+		);
+	}
+
+	#[tokio::test]
+	async fn fetch_fails_over_to_a_newer_segment() {
+		let (track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let consumer = producer.consume();
+
+		// The latched copy is dead: the fetch parks for a takeover instead of
+		// surfacing the route's failure as the group's.
+		track_a.abort(Error::Dropped).unwrap();
+		let fetch = consumer.fetch_group(0, None);
+		let mut fetch = std::pin::pin!(fetch);
+		assert!(futures::poll!(fetch.as_mut()).is_pending(), "a dead copy should park");
+
+		// The replacement has the group cached; the fetch fails over to it.
+		write_group(&mut track_b, 0, "b0");
+		producer.takeover(&consumer_b).unwrap();
+		let group = fetch.await.expect("fetch should fail over");
+		assert_eq!(group.sequence, 0);
+	}
+
+	#[tokio::test]
+	async fn fetch_aborts_with_the_track() {
+		let (track_a, consumer_a) = track_pair("a");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let consumer = producer.consume();
+
+		track_a.abort(Error::Dropped).unwrap();
+		let fetch = consumer.fetch_group(0, None);
+		let mut fetch = std::pin::pin!(fetch);
+		assert!(futures::poll!(fetch.as_mut()).is_pending(), "a dead copy should park");
+
+		// The logical track aborting ends the wait with its error.
+		producer.abort(Error::Cancel).unwrap();
+		assert!(matches!(fetch.await, Err(Error::Cancel)));
+	}
+
+	#[tokio::test]
+	async fn fetch_error_from_a_live_copy_is_authoritative() {
+		let (_track_a, consumer_a) = track_pair("a");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let consumer = producer.consume();
+
+		// The copy is alive and will never carry group 0 (no fetch handler):
+		// its answer surfaces instead of parking for a takeover.
+		assert!(matches!(consumer.fetch_group(0, None).await, Err(Error::NotFound)));
+	}
+
+	#[tokio::test]
+	async fn takeover_after_empty_segment_keeps_live_edge() {
+		let (track_a, consumer_a) = track_pair("a");
+		let (track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+		recv_pending(&mut sub);
+		assert_eq!(track_a.subscription().unwrap().group_start, None);
+
+		// A dies before producing anything; B takes over.
+		drop(track_a);
+		producer.takeover(&consumer_b).unwrap();
+		recv_pending(&mut sub);
+
+		// The replacement must inherit live-edge demand, not a full backfill.
+		assert_eq!(track_b.subscription().unwrap().group_start, None);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -1576,6 +1576,33 @@ mod test {
 		}
 	}
 
+	/// A reader that misses more than [`MAX_SEGMENTS`] failovers loses the pruned
+	/// ranges: the segments are gone from its next snapshot, so it resumes at the
+	/// retained ones, exactly like any other live loss (the groups stay fetchable
+	/// upstream). Deliberate: the alternative pins every dead session's cache
+	/// until the slowest reader drains it.
+	#[tokio::test]
+	async fn unpolled_reader_skips_pruned_ranges() {
+		let mut producer = Producer::new();
+		let mut sub = producer.consume().subscribe(None);
+		recv_pending(&mut sub);
+
+		let count = 2 * MAX_SEGMENTS as u64;
+		let mut tracks = Vec::new();
+		for sequence in 0..count {
+			let (mut track, consumer) = track_pair("t");
+			producer.takeover(&consumer).unwrap();
+			write_group(&mut track, sequence, "g");
+			tracks.push(track);
+		}
+
+		// Never polled during the churn: only the retained segments deliver.
+		for sequence in count - MAX_SEGMENTS as u64..count {
+			assert_eq!(recv(&mut sub), sequence);
+		}
+		recv_pending(&mut sub);
+	}
+
 	#[tokio::test]
 	async fn datagram_poller_bounds_pruned_cursors() {
 		let mut producer = Producer::new();


### PR DESCRIPTION
Fixes from an extensive review of the origin resume/route logic, plus the model-layer improvements from dev ported to main (deliberately without the GOAWAY API).

## Root causes and fixes

- **Live-edge demand became a full backfill after an empty-segment failover.** `resume::Producer::takeover` computed the boundary as `Some(0)` when segments existed but had never produced a group, so `slice()` turned a live-edge subscription (`group_start: None`) into a demand for the entire history. Reachable whenever a route dies between subscribe and its first delivered group. The replacement segment now starts unbounded, exactly like a first splice. Regression test: `takeover_after_empty_segment_keeps_live_edge`. (The same bug exists on dev as `resume_position().unwrap_or_default()` and needs the equivalent fix there.)
- **Unbounded segment accumulation.** Every failover left a capped segment (pinning the dead session's `track::Consumer` and cached groups) in the logical track for its whole life, and every new subscriber registered a cursor on all of them. Ported dev's pruning, adapted to group-granular boundaries: the producer keeps `MAX_SEGMENTS` and records a pruned floor that participates in the takeover boundary; readers retire pruned cursors once drained (dev's `reap`, ported verbatim), so a slow reader still drains a pruned segment's cache.
- **Refusals are authoritative and never retried.** Sharing a first hop is a promise that sources produce interchangeable tracks; a same-origin route that rejects a subscription has broken that promise and there is nothing to retry against. But a refusal no longer nukes the incumbent either: the refuser is ruled out of that one track, and the logical track aborts with the last refusal only once every attached source has refused. This fixes two failure modes: a standby joining a live front (before its publisher created every track) could kill a subscription the incumbent was serving, and a source whose copy died right after acceptance (zero delivered groups) could re-splice in an unbounded loop. Recovery stays consumer-driven: a fresh request asks afresh (`track_inner` re-mints aborted logical tracks). Tests: `test_standby_missing_track_keeps_incumbent`, `test_track_dying_without_progress_aborts`.
- **A stranded logical track on takeover failure.** `serve_track` returned silently when `resume.takeover` failed, assuming the track had ended; on any other error subscribers hung forever on a track no task served. It now aborts the resume track defensively (a no-op after a clean end).
- **Fetch had no failover.** A fetch latched one segment and rode it down; a route dying mid-fetch surfaced the route's failure as the group's. It now re-latches onto a newer segment, or parks for the next takeover like a live subscription (the front aborting ends the wait). An error from a live copy still surfaces immediately.
- **Cleanups:** the three route-selection functions now share one `pick(keep, untainted)` primitive; `run_source`'s ingress announce guard toggle is one helper instead of three copies; comments document why `run_source`'s first-hop check uses plain equality and why the `carrying` snapshot race is benign.

## Deliberate tradeoffs (flagged by adversarial review)

- A standby's refusal is permanent for its attachment: if the incumbent later leaves, the track aborts rather than re-asking the refuser. Intended: retrying a source that claims the same origin but refused the subscription just polls a liar; the consumer's re-request is the retry, and it reaches a re-attached or newly-capable source under a fresh verdict.
- A reader that misses more than `MAX_SEGMENTS` consecutive failovers loses the pruned ranges, like any other live loss (still fetchable upstream). Encoded in `unpolled_reader_skips_pruned_ranges`; the alternative pins every dead session's cache on the slowest reader.

## Cross-package sync

No wire change (drafts untouched), no public API change (everything touched is `pub(crate)` or private), so no bindings or docs rows apply. `just check`, `cargo doc -D warnings`, and the moq-net + moq-relay nextest suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Fable 5)