### PR TITLE
fix(moq-net): close the session on a malformed NAMESPACE

### DIFF
--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -7,7 +7,10 @@ use crate::{
 	util::{MaybeBoxedExt, MaybeSendBox, TaskSet, err_only},
 };
 
-use super::{Control, Message, Publisher, Subscriber, Version, adapter::ControlStreamAdapter, cluster};
+use super::{
+	Control, Message, Publisher, Subscriber, Version, adapter::ControlStreamAdapter, cluster,
+	subscriber::is_protocol_violation,
+};
 
 /// Everything one moq-transport session needs to start.
 pub struct Config<S: web_transport_trait::Session> {
@@ -167,6 +170,11 @@ pub fn start<S: web_transport_trait::Session>(
 								_ => Stream::open(&sub_ns_adapter, version).await?,
 							};
 							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix).await {
+								// The peer breaking the protocol is fatal, and the driver
+								// below turns this into the session close the draft wants.
+								if is_protocol_violation(&err) {
+									return Err(err);
+								}
 								tracing::warn!(%err, "subscribe_namespace failed, continuing without");
 							}
 							Ok::<(), Error>(())
@@ -273,6 +281,11 @@ pub fn start<S: web_transport_trait::Session>(
 						prefixes.push(async move {
 							let stream = Stream::open(&sub_ns_session, version).await?;
 							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix).await {
+								// The peer breaking the protocol is fatal, and the driver
+								// below turns this into the session close the draft wants.
+								if is_protocol_violation(&err) {
+									return Err(err);
+								}
 								tracing::warn!(%err, "subscribe_namespace failed, continuing without");
 							}
 							Ok::<(), Error>(())
@@ -625,6 +638,76 @@ mod tests {
 	fn occurrences(log: &crate::lite::test_transport::Log, needle: &[u8]) -> usize {
 		let writes = log.writes.lock().unwrap();
 		writes.windows(needle.len()).filter(|window| *window == needle).count()
+	}
+
+	/// The peer's REQUEST_OK followed by a NAMESPACE in the base form: no cluster
+	/// parameters, so no HOP_PATH. Built with the crate's own writer so the framing
+	/// can't drift from the encoder under test.
+	async fn namespace_without_hop_path(version: Version) -> Vec<u8> {
+		let log = crate::lite::test_transport::Log::default();
+		let mut writer = crate::coding::Writer::new(crate::lite::test_transport::SinkSend::new(log.clone()), version);
+
+		writer.encode(&ietf::RequestOk::ID).await.unwrap();
+		writer.encode(&ietf::RequestOk { request_id: None }).await.unwrap();
+		writer.encode(&ietf::Namespace::ID).await.unwrap();
+		writer
+			.encode(&ietf::Namespace {
+				suffix: crate::Path::new("cam"),
+				cluster: None,
+			})
+			.await
+			.unwrap();
+
+		let writes = log.writes.lock().unwrap();
+		writes.clone()
+	}
+
+	/// A session that negotiated the MoQ Cluster extension requires HOP_PATH on every
+	/// NAMESPACE, and the draft answers a missing one by closing the session.
+	///
+	/// Driven through `start` rather than `run_subscribe_namespace` directly: that
+	/// stream always surfaced the error, and the bug was this loop logging it and
+	/// carrying on, so a test below the loop would pass either way.
+	#[tokio::test]
+	async fn a_namespace_without_a_hop_path_closes_the_session() {
+		const VERSION: Version = Version::Draft19;
+
+		// A driver that swallows the violation parks forever instead of failing, so
+		// bound it: paused time makes the deadline fire the moment nothing else can run.
+		tokio::time::pause();
+
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let session = crate::lite::test_transport::ScriptedSession::new(namespace_without_hop_path(VERSION).await);
+		let log = session.log.clone();
+
+		let driver = start(Config {
+			session,
+			setup: None,
+			request_id_max: None,
+			client: true,
+			publish: None,
+			subscribe: Some(origin),
+			peer_origin: None,
+			cost: None,
+			version: VERSION,
+			path: None,
+			peer_setup_stream: None,
+			// A peer that declared its Hop ID negotiated the extension, which is what
+			// makes the cluster parameters mandatory in both directions.
+			peer_cluster: Some(cluster::Peer {
+				origin: Some(crate::Origin::new(2).unwrap()),
+				cost: None,
+			}),
+		})
+		.expect("start the session");
+
+		let err = tokio::time::timeout(std::time::Duration::from_secs(10), driver)
+			.await
+			.expect("the session ended rather than carrying on")
+			.expect_err("a malformed NAMESPACE fails the session");
+
+		assert!(is_protocol_violation(&err), "not treated as the peer's fault: {err}");
+		assert_eq!(log.closes(), vec![(err.to_code(), err.to_string())]);
 	}
 
 	/// A subscriber issues one SUBSCRIBE_NAMESPACE per PERMITTED PREFIX, and asks for

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -665,9 +665,9 @@ mod tests {
 	/// A session that negotiated the MoQ Cluster extension requires HOP_PATH on every
 	/// NAMESPACE, and the draft answers a missing one by closing the session.
 	///
-	/// Driven through `start` rather than `run_subscribe_namespace` directly: that
-	/// stream always surfaced the error, and the bug was this loop logging it and
-	/// carrying on, so a test below the loop would pass either way.
+	/// Driven through `start` rather than `run_subscribe_namespace` directly: the
+	/// stream surfaces the error either way, so only this loop's handling of it decides
+	/// between a close and a warning, and a test below the loop would pass regardless.
 	#[tokio::test]
 	async fn a_namespace_without_a_hop_path_closes_the_session() {
 		const VERSION: Version = Version::Draft19;

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -36,12 +36,12 @@ fn insert_track_alias(aliases: &TrackAliases, alias: u64, request_id: RequestId)
 /// Whether an error means the peer broke the protocol, as opposed to a stream or
 /// transport failing on its own.
 ///
-/// Only the former justifies taking the whole session down.
-fn is_protocol_violation(err: &Error) -> bool {
+/// Only the former justifies taking the whole session down. An encode error is ours,
+/// so it stays out: we cannot ask the peer to answer for a message we failed to write.
+pub(super) fn is_protocol_violation(err: &Error) -> bool {
 	matches!(
 		err,
 		Error::Decode(_)
-			| Error::Encode(_)
 			| Error::BoundsExceeded(_)
 			| Error::WrongSize
 			| Error::TooManyParameters
@@ -304,6 +304,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// Send SUBSCRIBE_NAMESPACE for one prefix on a bidi stream.
 	/// The caller is responsible for opening the appropriate stream type
 	/// (virtual for v14/v15, real bidi for v16+), one per prefix.
+	///
+	/// A failure here is per-prefix, so the caller decides what it means for the
+	/// session: [`is_protocol_violation`] separates the peer's fault (fatal) from a
+	/// stream of ours that simply died (survivable).
 	pub async fn run_subscribe_namespace<T: web_transport_trait::Session>(
 		&mut self,
 		mut stream: Stream<T, Version>,

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -37,7 +37,7 @@ fn insert_track_alias(aliases: &TrackAliases, alias: u64, request_id: RequestId)
 /// transport failing on its own.
 ///
 /// Only the former justifies taking the whole session down. An encode error is ours,
-/// so it stays out: we cannot ask the peer to answer for a message we failed to write.
+/// not the peer's: we cannot ask it to answer for a message we failed to write.
 pub(super) fn is_protocol_violation(err: &Error) -> bool {
 	matches!(
 		err,

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -32,12 +32,19 @@ impl web_transport_trait::Error for SinkError {
 pub struct Log {
 	pub writes: Arc<Mutex<Vec<u8>>>,
 	pub resets: Arc<Mutex<Vec<u32>>>,
+	closes: Arc<Mutex<Vec<(u32, String)>>>,
 	bi_opens: Arc<AtomicUsize>,
 }
 
 impl Log {
 	pub fn resets(&self) -> Vec<u32> {
 		self.resets.lock().unwrap().clone()
+	}
+
+	/// The session-level closes, as (code, reason). A list rather than a last-value so
+	/// a second close racing the first is visible.
+	pub fn closes(&self) -> Vec<(u32, String)> {
+		self.closes.lock().unwrap().clone()
 	}
 
 	/// How many bidi streams the session has opened, so a test can pin down how many
@@ -181,7 +188,9 @@ impl web_transport_trait::Session for SinkSession {
 		None
 	}
 
-	fn close(&self, _code: u32, _reason: &str) {}
+	fn close(&self, code: u32, reason: &str) {
+		self.log.closes.lock().unwrap().push((code, reason.to_owned()));
+	}
 
 	async fn closed(&self) -> Self::Error {
 		std::future::pending().await
@@ -334,7 +343,9 @@ impl web_transport_trait::Session for ScriptedSession {
 		None
 	}
 
-	fn close(&self, _code: u32, _reason: &str) {}
+	fn close(&self, code: u32, reason: &str) {
+		self.log.closes.lock().unwrap().push((code, reason.to_owned()));
+	}
 
 	async fn closed(&self) -> Self::Error {
 		std::future::pending().await


### PR DESCRIPTION
## Summary

A negotiated MoQ Cluster session requires HOP_PATH on every NAMESPACE, and [moq-cluster-00](https://github.com/moq-dev/moq/blob/main/drafts/draft-lcurley-moq-cluster.md) answers a missing one by closing the session. The decode error reached `run_subscribe_namespace`'s caller in `ietf::start`, which logged `subscribe_namespace failed, continuing without` and carried on, so a peer that broke the protocol kept the transport and every other stream on it.

## Root cause

`run_subscribe_namespace` has always returned the error; the bug is that both `ietf::start` arms swallowed it. Per-prefix failures are genuinely survivable (a stream the peer reset is not a reason to kill the session), so the classification, not the propagation, is what was missing.

Fixed at the call site: a protocol violation propagates out of the per-prefix fan-out, and the driver closes the session with `err.to_code()` exactly as it already does for every other fatal error. Anything else still degrades to a warning. This keeps one close path rather than adding a second one inside the subscriber, and surfaces the error on the `Driver`'s `Result` where callers can see it.

Also drops `Error::Encode` from `is_protocol_violation`: a message *we* failed to write is not the peer's fault, and it currently kills the session on the `publish_namespace` path.

## Test plan

- New regression test `a_namespace_without_a_hop_path_closes_the_session`, driven through `start` rather than `run_subscribe_namespace`: a test below the session loop passes with or without the fix, since the stream always surfaced the error. Reverting either propagation site fails it in ~0ms (the await is bounded under paused time, so a swallowed violation reports as a failed deadline rather than wedging the harness).
- `just check`
- `cargo nextest run -p moq-net` (671 passed)

`test_transport::Log` grows a `closes()` accessor so a test can assert the session close, matching the existing `resets()`.

## Cross-package sync

No wire format, FFI, or config surface changed, so no row applies. `moq-cluster-00` already specifies this behavior; nothing in `drafts/` needs updating.

(Written by Opus 5)