### PR TITLE
docs(moq-net): describe what with_cost actually prices

### DIFF
--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -79,19 +79,20 @@ impl Client {
 		self
 	}
 
-	/// Price what subscribing from us costs, in the units the rest of the mesh uses
-	/// (moq-lite-06+, and `moqt-17`+ via the MoQ Cluster extension).
+	/// Price this link, in the units the rest of the mesh uses (moq-lite-06+, and
+	/// `moqt-17`+ via the MoQ Cluster extension).
 	///
-	/// Declared in our SETUP; the peer adds it to the route cost of every announcement
-	/// we forward it, so routing prefers cheap paths over short ones. Use `0` for a
-	/// direction that should look free (a sibling in the same datacenter), and
-	/// something large for one that should be a last resort (metered egress). When we
-	/// declare nothing the peer charges `1`, which makes the cost track the hop count
-	/// and so reproduces plain shortest-path routing.
+	/// The dialer is the side that knows what a link costs, because it chose the peer:
+	/// use `0` for a sibling in the same datacenter and something large for another
+	/// region across a metered backbone. So this prices both directions. We add it to
+	/// the route cost of every announcement the peer sends us, and declare it in our
+	/// SETUP so the peer adds it to every announcement we send, which is what a server
+	/// accepting an anonymous connection needs: it cannot tell a sibling from a
+	/// stranger, so it has no price of its own to apply.
 	///
-	/// This prices one direction only. What *we* pay to pull from the peer is whatever
-	/// the peer declares, so an asymmetric link is described by each side setting its
-	/// own value, and a symmetric one by both setting the same.
+	/// A price the peer declares applies only where we set none. An unpriced link costs
+	/// `1`, which makes the cost track the hop count and so reproduces plain
+	/// shortest-path routing.
 	pub fn with_cost(mut self, cost: u64) -> Self {
 		self.cost = Some(cost);
 		self

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -35,10 +35,11 @@ pub struct Config<S: web_transport_trait::Session> {
 	/// declares its own, which wins.
 	pub peer_origin: Option<Origin>,
 
-	/// What subscribing from us costs, declared in our SETUP (see
-	/// [`cluster::RELAY_COST`]) for the peer to charge. Directional, so what we charge
-	/// in the other direction is whatever the peer declared. `None` leaves it unpriced,
-	/// which the peer reads as the default of 1.
+	/// What crossing this link costs. Declared in our SETUP (see
+	/// [`cluster::RELAY_COST`]) for the peer to charge, and charged locally on what the
+	/// peer sends us. `None` declares nothing and charges whatever the peer declared,
+	/// falling back to 1; that is what a server accepting a connection passes, since it
+	/// has no per-peer configuration of its own.
 	pub cost: Option<u64>,
 
 	pub version: Version,

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -40,6 +40,9 @@ pub struct Config<S: web_transport_trait::Session> {
 	/// peer sends us. `None` declares nothing and charges whatever the peer declared,
 	/// falling back to 1; that is what a server accepting a connection passes, since it
 	/// has no per-peer configuration of its own.
+	///
+	/// Only `moqt-17`+ negotiates the MoQ Cluster extension. Earlier drafts carry no
+	/// cost at all, so nothing is charged and their routes rank on hop count alone.
 	pub cost: Option<u64>,
 
 	pub version: Version,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -118,7 +118,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// policy. Otherwise we charge what the peer declared, which is how a server prices
 	/// a link at all: it cannot tell a sibling from a stranger, so the dialer that chose
 	/// the peer declares the price for both of them. Falls back to
-	/// [`super::DEFAULT_COST`] when neither priced it.
+	/// [`super::DEFAULT_COST`] when neither priced it, and to `0` on a version that
+	/// carries no cost at all, whose routes rank on hop count alone.
 	///
 	/// Our own price short-circuits the peer's, so a session that configured one never
 	/// blocks on a SETUP to start routing.

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -114,11 +114,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// What pulling content across this session's link costs, added to the route cost
 	/// of every announcement received over it.
 	///
-	/// The Cost Parameter is directional: each endpoint declares what subscribing from
-	/// it costs, so the peer's declaration prices this direction while ours prices the
-	/// other. A locally configured price overrides it, since what we charge our own
-	/// routing is local policy. Falls back to [`super::DEFAULT_COST`] when neither
-	/// priced it.
+	/// A locally configured price wins, since what we charge our own routing is local
+	/// policy. Otherwise we charge what the peer declared, which is how a server prices
+	/// a link at all: it cannot tell a sibling from a stranger, so the dialer that chose
+	/// the peer declares the price for both of them. Falls back to
+	/// [`super::DEFAULT_COST`] when neither priced it.
+	///
+	/// Our own price short-circuits the peer's, so a session that configured one never
+	/// blocks on a SETUP to start routing.
 	async fn resolve_cost(&self) -> u64 {
 		// Older versions carry no cost on the wire, so nothing is charged and their
 		// routes rank on hop count alone. Returning early also avoids blocking on a


### PR DESCRIPTION
## Summary

`Client::with_cost`'s doc claimed:

> This prices one direction only. What *we* pay to pull from the peer is whatever the peer declares, so an asymmetric link is described by each side setting its own value.

That is the opposite of what the code does. The same value is declared in our SETUP *and* charged locally on everything the peer sends us; a peer's declaration is consulted only where we set nothing (`local.or(peer).unwrap_or(1)`).

The behavior is the right one, so this fixes the docs rather than the code.

## Why one number, applied by both ends

The dialer is the only side that knows what a link costs, because it chose the peer. A relay in `ord02` knows whether it is dialing a sibling in `ord02` (cost 0) or a node in another pop (cost 1). A server accepting a connection cannot tell those apart, so it declares nothing and adopts whatever the client declared. Configuring the price once, on the side that has the information, and letting both ends apply it is what makes `?cost=N` on a peer URL work at all.

This is conformant: the drafts let an endpoint declare its egress price and let a receiver charge a locally configured value instead. The dialer does both, and the accepting side does neither.

## Changes

- `Client::with_cost`: describe the real model, including why the accepting side has no price of its own.
- `ietf::Config::cost`: same correction, plus what `None` means for a server.
- `lite::Subscriber::resolve_cost`: note that our own price short-circuits the peer's, so a session that configured one never blocks on a SETUP before it can route.

Docs only. No behavior, wire, or API change, so no cross-package sync row applies, and `doc/bin/relay/cluster.md` already described this correctly.

## History

This PR previously attempted to split the field into directional `with_egress_cost` / `with_ingress_cost` setters (later a `Cost` type). That was built on the premise that the conflation was a bug. It isn't: a blanket server-side price is the accepting relay asserting something it cannot know, and the local override would shadow the client's declaration for every peer regardless of pop. Reduced to the doc fix that was the only real defect.

(Written by Opus 5)