### PR TITLE
chore(demo): install deps before serving the web demo

### DIFF
--- a/demo/web/justfile
+++ b/demo/web/justfile
@@ -8,5 +8,9 @@ default:
 # The vite config opens the watch, publish, and stats demos in separate tabs;
 
 # set MOQ_NO_OPEN=1 to skip opening a browser.
-serve url='http://localhost:4443':
+serve url='http://localhost:4443': install
     VITE_RELAY_URL="{{ url }}" bun --bun vite
+
+# Install the workspace deps that vite and the demo's imports need.
+install:
+    bun install


### PR DESCRIPTION
`just web serve` ran `bun --bun vite` directly, assuming `node_modules` was already populated. In a fresh clone or worktree that fails, since nothing installs first.

`just dev` only worked by accident: `demo/justfile`'s default recipe runs `bun install` up front because `bun run concurrently` needs it, and `just web serve` inherits the result. Running the web demo on its own had no such luck.

Adds a `demo/web` `install` recipe and makes `serve` depend on it. The `bun install` in `demo/justfile` stays: `just dev` needs `node_modules` before `concurrently` starts, which is earlier than `just web serve`.

(written by Opus 5)