### PR TITLE
fix(libmoq): fix the generated CMake package config for Windows and installs

### DIFF
--- a/rs/libmoq/CMakeLists.txt
+++ b/rs/libmoq/CMakeLists.txt
@@ -119,6 +119,11 @@ if(PROJECT_IS_TOP_LEVEL)
     # Generate and install CMake package config files
     include(CMakePackageConfigHelpers)
 
+    # The remaining placeholders in cmake/moq-config.cmake.in. rs/libmoq/build.sh
+    # and nix/overlay.nix fill the same two in for the release artifacts.
+    get_filename_component(LIB_FILE "${RUST_LIB}" NAME)
+    set(VERSION "${PROJECT_VERSION}")
+
     configure_package_config_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/moq-config.cmake.in
         ${CMAKE_CURRENT_BINARY_DIR}/moq-config.cmake

--- a/rs/libmoq/CMakeLists.txt
+++ b/rs/libmoq/CMakeLists.txt
@@ -1,5 +1,20 @@
 cmake_minimum_required(VERSION 3.21)
-project(moq VERSION 0.6.1 LANGUAGES C)
+
+# release-plz owns the version and only ever bumps Cargo.toml, so read it from
+# there. A copy here goes stale the next release and stamps a wrong version into
+# the installed find_package(moq) config, where it silently breaks version
+# constraints rather than failing the build.
+file(READ "${CMAKE_CURRENT_LIST_DIR}/Cargo.toml" _cargo_toml)
+string(REGEX MATCH "\nversion[ \t]*=[ \t]*\"([^\"]+)\"" _match "${_cargo_toml}")
+set(_version "${CMAKE_MATCH_1}")
+unset(_cargo_toml)
+unset(_match)
+
+if(NOT _version MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+$")
+    message(FATAL_ERROR "Unsupported version '${_version}' in rs/libmoq/Cargo.toml (project() takes a numeric x.y.z)")
+endif()
+
+project(moq VERSION ${_version} LANGUAGES C)
 
 option(BUILD_RUST_LIB "Build the Rust library using cargo" ON)
 

--- a/rs/libmoq/build.sh
+++ b/rs/libmoq/build.sh
@@ -99,14 +99,6 @@ if [[ "$TARGET" == *"-windows-"* ]]; then
     sed -e "s|@VERSION@|${VERSION}|g" \
         -e "s|@MAJOR_VERSION@|${MAJOR_VERSION}|g" \
         "$SCRIPT_DIR/cmake/moq-config-version.cmake.in" >"$PACKAGE_DIR/lib/cmake/moq/moq-config-version.cmake"
-
-    # A placeholder added to a template but not to the seds above ships a zip
-    # whose find_package(moq) hands the linker a literal `@FOO@`, and the only
-    # thing that notices is a downstream build. Fail here instead.
-    if grep -nE '@[A-Z_]+@' "$PACKAGE_DIR/lib/cmake/moq"/*.cmake; then
-        echo "Error: unsubstituted placeholder in the generated CMake config (see above)" >&2
-        exit 1
-    fi
 else
     # Native builds use the bare flake output; the one supported cross is the
     # Intel mac release built on an Apple Silicon runner (the Determinate Nix
@@ -137,6 +129,22 @@ else
     cp -RL "$RESULT_LINK/include/." "$PACKAGE_DIR/include/"
     chmod -R u+w "$PACKAGE_DIR"
 fi
+
+# A placeholder added to cmake/*.cmake.in but not to every substituter (the seds
+# above, nix/overlay.nix) ships a config whose find_package(moq) hands the linker
+# a literal `@FOO@`, and the only thing that notices is a downstream build. Both
+# paths land the config here, so check them both.
+for cmake_file in moq-config.cmake moq-config-version.cmake; do
+    CMAKE_CONFIG="$PACKAGE_DIR/lib/cmake/moq/$cmake_file"
+    if [[ ! -f "$CMAKE_CONFIG" ]]; then
+        echo "Error: $CMAKE_CONFIG missing from the package" >&2
+        exit 1
+    fi
+    if grep -nE '@[A-Z_]+@' "$CMAKE_CONFIG"; then
+        echo "Error: unsubstituted placeholder in $CMAKE_CONFIG (see above)" >&2
+        exit 1
+    fi
+done
 
 # Create archive
 cd "$OUTPUT_DIR"

--- a/rs/libmoq/build.sh
+++ b/rs/libmoq/build.sh
@@ -85,12 +85,28 @@ if [[ "$TARGET" == *"-windows-"* ]]; then
     # Generate CMake config files from templates (no pkg-config on Windows).
     mkdir -p "$PACKAGE_DIR/lib/cmake/moq"
     MAJOR_VERSION="${VERSION%%.*}"
+
+    # The native libraries an external linker must pass alongside moq.lib,
+    # quoted the way rs/libmoq/CMakeLists.txt and nix/overlay.nix format them.
+    # Windows entries are all plain library names; `framework:` is Apple-only.
+    NATIVE_LIBS_QUOTED=$(awk 'NF && $1 !~ /^#/ { printf "%s\"%s\"", sep, $1; sep = " " }' \
+        "$SCRIPT_DIR/native-libs/windows.txt")
+
     sed -e "s|@LIB_FILE@|${LIB_FILE}|g" \
         -e "s|@VERSION@|${VERSION}|g" \
+        -e "s|@MOQ_NATIVE_LIBS_QUOTED@|${NATIVE_LIBS_QUOTED}|g" \
         "$SCRIPT_DIR/cmake/moq-config.cmake.in" >"$PACKAGE_DIR/lib/cmake/moq/moq-config.cmake"
     sed -e "s|@VERSION@|${VERSION}|g" \
         -e "s|@MAJOR_VERSION@|${MAJOR_VERSION}|g" \
         "$SCRIPT_DIR/cmake/moq-config-version.cmake.in" >"$PACKAGE_DIR/lib/cmake/moq/moq-config-version.cmake"
+
+    # A placeholder added to a template but not to the seds above ships a zip
+    # whose find_package(moq) hands the linker a literal `@FOO@`, and the only
+    # thing that notices is a downstream build. Fail here instead.
+    if grep -nE '@[A-Z_]+@' "$PACKAGE_DIR/lib/cmake/moq"/*.cmake; then
+        echo "Error: unsubstituted placeholder in the generated CMake config (see above)" >&2
+        exit 1
+    fi
 else
     # Native builds use the bare flake output; the one supported cross is the
     # Intel mac release built on an Apple Silicon runner (the Determinate Nix


### PR DESCRIPTION
## Summary

Two bugs in the `moq-config.cmake` that C/C++ consumers get from `find_package(moq)`.

**1. Unsubstituted placeholder breaks the Windows link.** The `OBS plugin (x86_64-pc-windows-msvc)` job on the `libmoq-v0.5.4` tag ([run 30979016057](https://github.com/moq-dev/moq/actions/runs/30979016057)) failed with `LINK : fatal error LNK1181: cannot open input file '@MOQ_NATIVE_LIBS_QUOTED@.lib'`.

Root cause: #2306 moved the native system-lib list into `rs/libmoq/native-libs/*.txt` and added a `@MOQ_NATIVE_LIBS_QUOTED@` placeholder to `cmake/moq-config.cmake.in`, but updated only two of the three things that fill that template in (`rs/libmoq/CMakeLists.txt` and `nix/overlay.nix`). The Windows branch of `rs/libmoq/build.sh` hand-`sed`s the template (no Nix on the Windows runner) and still substituted `@LIB_FILE@` and `@VERSION@` only. Every Windows zip since has shipped a config with a literal `@MOQ_NATIVE_LIBS_QUOTED@` in `INTERFACE_LINK_LIBRARIES`, which `find_package(moq)` hands to link.exe, which appends `.lib`. Confirmed in the published v0.5.4 asset. Only Windows is affected; the macOS OBS job links against the Nix-built tarball, which substitutes correctly.

Fix: build the quoted list from `native-libs/windows.txt`, formatted the same way `CMakeLists.txt` and `nix/overlay.nix` format it, and fail the package step if any `@PLACEHOLDER@` survives, so the next placeholder added to a template can't ship silently instead of surfacing in a downstream build.

**2. The installed config carried an empty library name and a wrong version.** Nothing defined `LIB_FILE` or `VERSION` before `configure_package_config_file`, so an in-tree `cmake --install` produced `set(_moq_lib_name "")` (`IMPORTED_LOCATION` pointing at a directory) and an empty `moq_VERSION`. Sourcing the version then surfaced a second, pre-existing drift: `project(moq VERSION 0.6.1)` was a hand-maintained copy, and release-plz only bumps `Cargo.toml`, so the real version is 0.5.4. `find_package(moq 0.5.4 EXACT)` rejected the matching library while constraints above the real version were accepted. Both generated files now take the version from `Cargo.toml`, matching what `cpp/obs` already does to pick the libmoq release it downloads, with a hard configure-time failure if it isn't a numeric `x.y.z` that `project()` accepts.

## Public API changes

None. No Rust/TS surface is touched; this is release packaging and CMake package-config generation. `cpp/obs` calls `find_package(moq REQUIRED)` with no version constraint, so the corrected version does not change what it resolves.

## Test plan

- New awk + sed substitution against `cmake/moq-config.cmake.in` emits `INTERFACE_LINK_LIBRARIES "ntdll" "userenv" "ws2_32" "bcrypt" "dbghelp" "advapi32" "legacy_stdio_definitions"`, no leftover placeholders in either generated file.
- Real `cmake --install` (with `-DBUILD_RUST_LIB=OFF` against a stub lib): `_moq_lib_name "libmoq.a"`, `moq_VERSION "0.5.4"`, `PACKAGE_VERSION "0.5.4"`. Before this PR: `""`, `""`, and `0.6.1`.
- Consumer project against that install: `find_package(moq 0.5.4 EXACT REQUIRED)` succeeds (it was rejected before), `find_package(moq 0.6.1 REQUIRED)` correctly fails as incompatible.
- Version guard: a `Cargo.toml` patched to `0.5.4-beta.1` fails configure with a named error rather than mis-stamping.
- `shfmt --diff` and `shellcheck` pass on `rs/libmoq/build.sh`.
- Not verified: an actual MSVC link, which needs a Windows runner. That happens on the next `libmoq-v*` tag.

## Cross-Package Sync

No rows apply: no wire format, `moq-ffi`, C ABI, or CLI surface changed. `cpp/obs` consumes the generated config unchanged.

## Re-releasing v0.5.4

Re-running the OBS job alone won't help; it downloads the already-published broken zip. Once this lands, the `libmoq` workflow needs to rerun on the tag so the Windows artifact is rebuilt and the release asset replaced.

(Written by Opus 5)