### PR TITLE
fix(moq-net): send IETF subscribe/fetch rejections without resetting the stream

### DIFF
--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -83,6 +83,24 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 		}
 	}
 
+	/// Finish the stream and wait for the peer to acknowledge everything written.
+	///
+	/// [`Self::finish`] alone is not enough to deliver a final message. A stream that has sent
+	/// its FIN is still retransmitting unacknowledged data, and a RESET_STREAM from that state
+	/// discards it, so the [`Drop`] fallback below can throw away bytes the peer never read.
+	/// Consuming the writer is what removes that fallback, and waiting for the acknowledgement
+	/// is what makes the bytes safe.
+	pub async fn close(mut self) -> Result<(), Error> {
+		let Some(mut stream) = self.stream.take() else {
+			return Ok(());
+		};
+
+		stream.finish().map_err(Error::from_transport)?;
+		stream.closed().await.map_err(Error::from_transport)?;
+
+		Ok(())
+	}
+
 	/// Wait for the stream to be closed, or the [Self::finish] to be acknowledged by the peer.
 	pub async fn closed(&mut self) -> Result<(), Error> {
 		self.stream

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -469,18 +469,18 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			})
 			.await;
 
-		stream.writer.finish().ok();
+		// PUBLISH_DONE is the last thing on this stream, so it needs the acknowledgement too.
+		let _ = stream.writer.close().await;
 
 		res
 	}
 
 	/// Reject a SUBSCRIBE, ending the request stream.
 	///
-	/// Takes the whole stream because the finish is the half that makes the error arrive:
-	/// [`Writer`] resets on drop, and a reset that races the write discards the bytes the peer
-	/// has not read yet, so the subscriber sees no response and waits forever. Finishing first
-	/// leaves that reset a no-op. The rejection is the whole exchange, so don't wait on the
-	/// peer's close.
+	/// Takes the whole stream because delivering the error is the other half of the job:
+	/// [`Writer`] resets on drop, and a reset discards data the peer has not acknowledged, so
+	/// returning here without [`Writer::close`] leaves the subscriber waiting on a request we
+	/// already refused.
 	async fn reject_subscribe(
 		&self,
 		mut stream: Stream<S, Version>,
@@ -490,7 +490,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	) -> Result<(), Error> {
 		self.write_subscribe_error(&mut stream.writer, request_id, error_code, reason)
 			.await?;
-		let _ = stream.writer.finish();
+
+		// The peer dropping the stream once it has the rejection is a normal end, not our failure.
+		let _ = stream.writer.close().await;
 		Ok(())
 	}
 
@@ -740,7 +742,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Reject a FETCH, ending the request stream. See [`Self::reject_subscribe`] for why the
-	/// finish is not optional.
+	/// close is not optional.
 	async fn reject_fetch(
 		&self,
 		mut stream: Stream<S, Version>,
@@ -750,7 +752,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	) -> Result<(), Error> {
 		self.write_fetch_error(&mut stream.writer, request_id, error_code, reason)
 			.await?;
-		let _ = stream.writer.finish();
+
+		let _ = stream.writer.close().await;
 		Ok(())
 	}
 

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1554,10 +1554,10 @@ mod tests {
 		(writes, h.log.resets())
 	}
 
-	/// A SUBSCRIBE for a path with no publisher must be answered, and the answer must survive
-	/// the trip. `Writer` resets the stream on drop, so returning straight after writing the
-	/// error threw the bytes away and left every interop client waiting on a request we had
-	/// already refused. Finishing first makes the drop-time reset a no-op.
+	/// A SUBSCRIBE for a path with no publisher is refused with REQUEST_ERROR, and the refusal
+	/// has to survive the trip. `Writer` resets the stream on drop, and a reset that races the
+	/// write discards the bytes the peer has not read yet, which leaves the subscriber waiting
+	/// on a request we already refused. Finishing first makes the drop-time reset a no-op.
 	#[tokio::test]
 	async fn missing_broadcast_is_refused_without_resetting_the_stream() {
 		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
@@ -1573,8 +1573,8 @@ mod tests {
 		}
 	}
 
-	/// Every FETCH we refuse takes the same path, through its own error encoder. A reset there
-	/// loses the rejection exactly like the SUBSCRIBE one did.
+	/// Every FETCH we refuse goes out through its own error encoder, so it needs the same
+	/// finish: a reset there loses the rejection the same way.
 	#[tokio::test]
 	async fn unsupported_fetch_is_refused_without_resetting_the_stream() {
 		let unsupported = || {

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1470,15 +1470,21 @@ mod tests {
 		assert_eq!(log.bi_opens(), 3, "no extra stream for the withdrawal");
 	}
 
-	/// Subscribe to a path nothing publishes, returning what the peer would read off the
-	/// request stream plus the reset codes the stream recorded.
-	async fn subscribe_missing(version: Version) -> (Vec<u8>, Vec<u32>) {
+	/// A publisher talking to a scripted peer that never answers, over one bidi stream.
+	struct Harness {
+		publisher: Publisher<crate::lite::test_transport::ScriptedSession>,
+		session: crate::lite::test_transport::ScriptedSession,
+		log: crate::lite::test_transport::Log,
+		/// Keeps the origin alive; the publisher only holds a consumer.
+		_origin: origin::Producer,
+	}
+
+	fn harness(version: Version) -> Harness {
 		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
-		// One bidi stream, with a peer that says nothing back.
 		let session = crate::lite::test_transport::ScriptedSession::per_stream(vec![Vec::new()]);
 		let log = session.log.clone();
 
-		// Serving a subscription blocks on the peer's SETUP, which no scripted peer sends here.
+		// Serving a request blocks on the peer's SETUP, which no scripted peer sends here.
 		let peer_setup = cluster::PeerSetup::default();
 		peer_setup.set(cluster::Peer::default());
 
@@ -1491,8 +1497,22 @@ mod tests {
 			version,
 		);
 
-		let stream = Stream::open(&session, version).await.unwrap();
-		publisher
+		Harness {
+			publisher,
+			session,
+			log,
+			_origin: origin,
+		}
+	}
+
+	/// Subscribe to a path nothing publishes, returning what the peer would read off the
+	/// request stream plus the reset codes the stream recorded.
+	async fn subscribe_missing(version: Version) -> (Vec<u8>, Vec<u32>) {
+		let h = harness(version);
+
+		let stream = Stream::open(&h.session, version).await.unwrap();
+		h.publisher
+			.clone()
 			.run_subscribe_stream(
 				stream,
 				ietf::Subscribe {
@@ -1507,8 +1527,31 @@ mod tests {
 			.await
 			.unwrap();
 
-		let writes = log.writes.lock().unwrap().clone();
-		(writes, log.resets())
+		let writes = h.log.writes.lock().unwrap().clone();
+		(writes, h.log.resets())
+	}
+
+	/// Send a FETCH we don't implement, returning the same pair.
+	async fn fetch_unsupported(version: Version, fetch_type: FetchType<'_>) -> (Vec<u8>, Vec<u32>) {
+		let h = harness(version);
+
+		let stream = Stream::open(&h.session, version).await.unwrap();
+		h.publisher
+			.clone()
+			.run_fetch_stream(
+				stream,
+				ietf::Fetch {
+					request_id: RequestId(1),
+					subscriber_priority: 128,
+					group_order: GroupOrder::Descending,
+					fetch_type,
+				},
+			)
+			.await
+			.unwrap();
+
+		let writes = h.log.writes.lock().unwrap().clone();
+		(writes, h.log.resets())
 	}
 
 	/// A SUBSCRIBE for a path with no publisher must be answered, and the answer must survive
@@ -1527,6 +1570,56 @@ mod tests {
 				"{version}: not a REQUEST_ERROR"
 			);
 			assert!(resets.is_empty(), "{version}: stream reset, discarding the error");
+		}
+	}
+
+	/// Every FETCH we refuse takes the same path, through its own error encoder. A reset there
+	/// loses the rejection exactly like the SUBSCRIBE one did.
+	#[tokio::test]
+	async fn unsupported_fetch_is_refused_without_resetting_the_stream() {
+		let unsupported = || {
+			[
+				(
+					"standalone",
+					FetchType::Standalone {
+						namespace: crate::Path::new("nothing/here"),
+						track: "video".into(),
+						start: Location { group: 0, object: 0 },
+						end: Location { group: 1, object: 0 },
+					},
+				),
+				(
+					"relative joining with an offset",
+					FetchType::RelativeJoining {
+						subscriber_request_id: RequestId(3),
+						group_offset: 1,
+					},
+				),
+				(
+					"absolute joining",
+					FetchType::AbsoluteJoining {
+						subscriber_request_id: RequestId(3),
+						group_id: 7,
+					},
+				),
+			]
+		};
+
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
+			for (label, fetch_type) in unsupported() {
+				let (writes, resets) = fetch_unsupported(version, fetch_type).await;
+
+				assert!(!writes.is_empty(), "{version} {label}: nothing was sent");
+				assert_eq!(
+					writes[0],
+					ietf::RequestError::ID as u8,
+					"{version} {label}: not a REQUEST_ERROR"
+				);
+				assert!(
+					resets.is_empty(),
+					"{version} {label}: stream reset, discarding the error"
+				);
+			}
 		}
 	}
 }

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -702,8 +702,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				request_id: msg.request_id,
 			})
 			.await?;
-		writer.finish()?;
-		writer.closed().await?;
+		writer.close().await?;
 
 		Ok(())
 	}
@@ -980,7 +979,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							request_id: request.request_id,
 						})
 						.await;
-					request.stream.writer.finish().ok();
+
+					// The withdrawal rides this request's own stream, which drops with it, so
+					// it needs the acknowledgement before the drop-time reset can discard it.
+					let _ = request.stream.writer.close().await;
 				}
 			}
 			_ => {

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -397,9 +397,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		{
 			Ok(broadcast) => broadcast,
 			Err(_) => {
-				self.write_subscribe_error(&mut stream.writer, request_id, 404, "Broadcast not found")
-					.await?;
-				return Ok(());
+				return self
+					.reject_subscribe(stream, request_id, 404, "Broadcast not found")
+					.await;
 			}
 		};
 
@@ -411,9 +411,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let track = match async { broadcast.track(&msg.track_name)?.subscribe(subscription).await }.await {
 			Ok(track) => track,
 			Err(err) => {
-				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())
-					.await?;
-				return Ok(());
+				return self.reject_subscribe(stream, request_id, 404, &err.to_string()).await;
 			}
 		};
 
@@ -474,6 +472,26 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		stream.writer.finish().ok();
 
 		res
+	}
+
+	/// Reject a SUBSCRIBE, ending the request stream.
+	///
+	/// Takes the whole stream because the finish is the half that makes the error arrive:
+	/// [`Writer`] resets on drop, and a reset that races the write discards the bytes the peer
+	/// has not read yet, so the subscriber sees no response and waits forever. Finishing first
+	/// leaves that reset a no-op. The rejection is the whole exchange, so don't wait on the
+	/// peer's close.
+	async fn reject_subscribe(
+		&self,
+		mut stream: Stream<S, Version>,
+		request_id: RequestId,
+		error_code: u64,
+		reason: &str,
+	) -> Result<(), Error> {
+		self.write_subscribe_error(&mut stream.writer, request_id, error_code, reason)
+			.await?;
+		let _ = stream.writer.finish();
+		Ok(())
 	}
 
 	/// Write a subscribe error on the bidi stream writer.
@@ -654,25 +672,19 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	async fn run_fetch_stream(self, mut stream: Stream<S, Version>, msg: ietf::Fetch<'_>) -> Result<(), Error> {
 		let _subscribe_id = match msg.fetch_type {
 			FetchType::Standalone { .. } => {
-				self.write_fetch_error(&mut stream.writer, msg.request_id, 500, "not supported")
-					.await?;
-				return Ok(());
+				return self.reject_fetch(stream, msg.request_id, 500, "not supported").await;
 			}
 			FetchType::RelativeJoining {
 				subscriber_request_id,
 				group_offset,
 			} => {
 				if group_offset != 0 {
-					self.write_fetch_error(&mut stream.writer, msg.request_id, 500, "not supported")
-						.await?;
-					return Ok(());
+					return self.reject_fetch(stream, msg.request_id, 500, "not supported").await;
 				}
 				subscriber_request_id
 			}
 			FetchType::AbsoluteJoining { .. } => {
-				self.write_fetch_error(&mut stream.writer, msg.request_id, 500, "not supported")
-					.await?;
-				return Ok(());
+				return self.reject_fetch(stream, msg.request_id, 500, "not supported").await;
 			}
 		};
 
@@ -724,6 +736,21 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				writer.encode(&ietf::RequestOk { request_id: None }).await?;
 			}
 		}
+		Ok(())
+	}
+
+	/// Reject a FETCH, ending the request stream. See [`Self::reject_subscribe`] for why the
+	/// finish is not optional.
+	async fn reject_fetch(
+		&self,
+		mut stream: Stream<S, Version>,
+		request_id: RequestId,
+		error_code: u64,
+		reason: &str,
+	) -> Result<(), Error> {
+		self.write_fetch_error(&mut stream.writer, request_id, error_code, reason)
+			.await?;
+		let _ = stream.writer.finish();
 		Ok(())
 	}
 
@@ -1441,5 +1468,65 @@ mod tests {
 		// One stream for the subscription itself, one per PUBLISH_NAMESPACE: the
 		// withdrawal rode the announce's own request, not a new stream.
 		assert_eq!(log.bi_opens(), 3, "no extra stream for the withdrawal");
+	}
+
+	/// Subscribe to a path nothing publishes, returning what the peer would read off the
+	/// request stream plus the reset codes the stream recorded.
+	async fn subscribe_missing(version: Version) -> (Vec<u8>, Vec<u32>) {
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		// One bidi stream, with a peer that says nothing back.
+		let session = crate::lite::test_transport::ScriptedSession::per_stream(vec![Vec::new()]);
+		let log = session.log.clone();
+
+		// Serving a subscription blocks on the peer's SETUP, which no scripted peer sends here.
+		let peer_setup = cluster::PeerSetup::default();
+		peer_setup.set(cluster::Peer::default());
+
+		let publisher = Publisher::new(
+			session.clone(),
+			origin.consume(),
+			Control::new(None, false),
+			None,
+			peer_setup,
+			version,
+		);
+
+		let stream = Stream::open(&session, version).await.unwrap();
+		publisher
+			.run_subscribe_stream(
+				stream,
+				ietf::Subscribe {
+					request_id: RequestId(1),
+					track_namespace: crate::Path::new("nothing/here"),
+					track_name: "video".into(),
+					subscriber_priority: 128,
+					group_order: GroupOrder::Descending,
+					filter_type: FilterType::LargestObject,
+				},
+			)
+			.await
+			.unwrap();
+
+		let writes = log.writes.lock().unwrap().clone();
+		(writes, log.resets())
+	}
+
+	/// A SUBSCRIBE for a path with no publisher must be answered, and the answer must survive
+	/// the trip. `Writer` resets the stream on drop, so returning straight after writing the
+	/// error threw the bytes away and left every interop client waiting on a request we had
+	/// already refused. Finishing first makes the drop-time reset a no-op.
+	#[tokio::test]
+	async fn missing_broadcast_is_refused_without_resetting_the_stream() {
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
+			let (writes, resets) = subscribe_missing(version).await;
+
+			assert!(!writes.is_empty(), "{version}: nothing was sent");
+			assert_eq!(
+				writes[0],
+				ietf::RequestError::ID as u8,
+				"{version}: not a REQUEST_ERROR"
+			);
+			assert!(resets.is_empty(), "{version}: stream reset, discarding the error");
+		}
 	}
 }

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -96,11 +96,24 @@ impl Message for Subscribe<'_> {
 			}
 			_ => {
 				decode_params!(r, version,
+					0x04 => rendezvous_timeout: Option<u64>,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
 					0x21 => filter_type: Option<FilterType>,
 					0x22 => group_order: Option<GroupOrder>,
 				);
+
+				// RENDEZVOUS_TIMEOUT arrived in draft-17; 0x04 means MAX_CACHE_DURATION in
+				// draft-15, which is a publisher parameter with no business in a SUBSCRIBE.
+				// An unknown message parameter is a protocol violation, so reject it there.
+				if rendezvous_timeout.is_some() && matches!(version, Version::Draft15 | Version::Draft16) {
+					return Err(DecodeError::InvalidValue);
+				}
+
+				// The value is deliberately dropped: we always answer a SUBSCRIBE with what is
+				// published right now, which is the shorter timeout the draft lets a relay pick.
+				// We still have to parse it, or the parameter alone would kill the session.
+				let _ = rendezvous_timeout;
 
 				if forward == Some(false) {
 					return Err(DecodeError::Unsupported);
@@ -479,6 +492,68 @@ mod tests {
 		assert_eq!(decoded.track_namespace.as_str(), "test");
 		assert_eq!(decoded.track_name, "video");
 		assert_eq!(decoded.subscriber_priority, 128);
+	}
+
+	/// Build a SUBSCRIBE body carrying a single RENDEZVOUS_TIMEOUT parameter.
+	fn subscribe_with_rendezvous(millis: u64, version: Version) -> Vec<u8> {
+		fn build(millis: u64, version: Version) -> Result<Vec<u8>, EncodeError> {
+			let mut buf = BytesMut::new();
+			RequestId(1).encode(&mut buf, version)?;
+			if version == Version::Draft17 {
+				0u64.encode(&mut buf, version)?; // required_request_id_delta
+			}
+			encode_namespace(&mut buf, &Path::new("test"), version)?;
+			Cow::Borrowed("video").encode(&mut buf, version)?;
+			encode_params!(&mut buf, version,
+				0x04 => millis,
+			);
+			Ok(buf.to_vec())
+		}
+
+		build(millis, version).unwrap()
+	}
+
+	/// A subscriber may send RENDEZVOUS_TIMEOUT (draft-17+). We do not honor the wait, but an
+	/// unknown message parameter is a session-killing protocol violation, so it still has to
+	/// parse: a client that sent one used to take the whole session down instead of getting an
+	/// answer to its SUBSCRIBE.
+	#[test]
+	fn rendezvous_timeout_is_accepted_and_ignored() {
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
+			for millis in [0, 5000] {
+				let encoded = subscribe_with_rendezvous(millis, version);
+				let msg: Subscribe = decode_message(&encoded, version)
+					.unwrap_or_else(|err| panic!("{version} rendezvous {millis}ms: {err}"));
+				assert_eq!(msg.track_name, "video");
+			}
+		}
+	}
+
+	/// 0x04 only means RENDEZVOUS_TIMEOUT from draft-17 on; in draft-15 it is
+	/// MAX_CACHE_DURATION, a publisher parameter that has no business in a SUBSCRIBE.
+	#[test]
+	fn rendezvous_timeout_is_rejected_before_draft17() {
+		for version in [Version::Draft15, Version::Draft16] {
+			let encoded = subscribe_with_rendezvous(0, version);
+			decode_message::<Subscribe>(&encoded, version).expect_err(&format!("{version} must reject parameter 0x04"));
+		}
+	}
+
+	/// We never ask a peer to hold a subscription open, so the parameter stays off our wire.
+	#[test]
+	fn rendezvous_timeout_is_never_sent() {
+		let msg = Subscribe {
+			request_id: RequestId(1),
+			track_namespace: Path::new("test"),
+			track_name: "video".into(),
+			subscriber_priority: 128,
+			group_order: GroupOrder::Descending,
+			filter_type: FilterType::LargestObject,
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let plain = subscribe_with_rendezvous(0, Version::Draft18);
+		assert_ne!(encoded, plain, "RENDEZVOUS_TIMEOUT must not be advertised");
 	}
 
 	#[test]

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -539,6 +539,28 @@ mod tests {
 		}
 	}
 
+	/// The first message parameter key on an encoded SUBSCRIBE, or `None` when it carries no
+	/// parameters.
+	///
+	/// Only the first key is needed, and only the first is readable. `encode_params!` enforces
+	/// ascending keys at compile time and RENDEZVOUS_TIMEOUT (0x04) sorts below every parameter
+	/// we do send, so it can only appear here. Walking further is not possible anyway: message
+	/// parameter values are typed per key with no generic skip rule, which is exactly why the
+	/// draft makes an unknown one a protocol violation.
+	fn first_param_key(encoded: &[u8], version: Version) -> Option<u64> {
+		let mut buf = bytes::Bytes::copy_from_slice(encoded);
+		RequestId::decode(&mut buf, version).unwrap();
+		if version == Version::Draft17 {
+			u64::decode(&mut buf, version).unwrap();
+		}
+		decode_namespace(&mut buf, version).unwrap();
+		Cow::<str>::decode(&mut buf, version).unwrap();
+
+		// draft-14/15 write absolute keys, draft-16+ deltas, but the first is absolute either way.
+		let count = u64::decode(&mut buf, version).unwrap();
+		(count > 0).then(|| u64::decode(&mut buf, version).unwrap())
+	}
+
 	/// We never ask a peer to hold a subscription open, so the parameter stays off our wire.
 	#[test]
 	fn rendezvous_timeout_is_never_sent() {
@@ -551,9 +573,20 @@ mod tests {
 			filter_type: FilterType::LargestObject,
 		};
 
-		let encoded = encode_message(&msg, Version::Draft18);
-		let plain = subscribe_with_rendezvous(0, Version::Draft18);
-		assert_ne!(encoded, plain, "RENDEZVOUS_TIMEOUT must not be advertised");
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
+			// The reader has to be able to see a 0x04, or its absence below proves nothing.
+			assert_eq!(
+				first_param_key(&subscribe_with_rendezvous(5000, version), version),
+				Some(0x04),
+				"{version}: reader missed a planted RENDEZVOUS_TIMEOUT"
+			);
+
+			assert_eq!(
+				first_param_key(&encode_message(&msg, version), version),
+				Some(0x10),
+				"{version}: RENDEZVOUS_TIMEOUT must not be advertised"
+			);
+		}
 	}
 
 	#[test]

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -515,8 +515,8 @@ mod tests {
 
 	/// A subscriber may send RENDEZVOUS_TIMEOUT (draft-17+). We do not honor the wait, but an
 	/// unknown message parameter is a session-killing protocol violation, so it still has to
-	/// parse: a client that sent one used to take the whole session down instead of getting an
-	/// answer to its SUBSCRIBE.
+	/// parse: failing to decode it takes the whole session down instead of answering the
+	/// SUBSCRIBE.
 	#[test]
 	fn rendezvous_timeout_is_accepted_and_ignored() {
 		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -531,8 +531,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			tracing::debug!(%path, "dropping reflected publish_namespace");
 			self.write_error(&mut stream, request_id, 400, "route loops through this relay")
 				.await?;
-			let _ = stream.writer.finish();
-			let _ = stream.writer.closed().await;
+			let _ = stream.writer.close().await;
 			return Ok(());
 		};
 
@@ -546,8 +545,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 			Err(err) => {
 				self.write_error(&mut stream, request_id, 400, &err.to_string()).await?;
-				let _ = stream.writer.finish();
-				let _ = stream.writer.closed().await;
+				let _ = stream.writer.close().await;
 				return Ok(());
 			}
 		}
@@ -687,9 +685,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		self.write_publish_error(&mut stream, msg.request_id, 400, "PUBLISH is not supported")
 			.await?;
-		// Finish rather than awaiting the peer's close: the rejection is the whole
-		// exchange, and dropping `stream` on return tears down the rest.
-		let _ = stream.writer.finish();
+		// The rejection is the whole exchange, but it still has to arrive: a finish alone
+		// leaves the drop-time reset free to discard it before the peer acknowledges it.
+		let _ = stream.writer.close().await;
 
 		Ok(())
 	}

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -52,11 +52,20 @@ pub struct SinkSend {
 	/// Writes park until this flips to true; `None` writes immediately. See
 	/// [`SinkSession::gated_bi`].
 	gate: Option<kio::Consumer<bool>>,
+	/// Set by [`finish`](web_transport_trait::SendStream::finish), so a later reset is
+	/// dropped the way quinn drops one on an already-finished stream (`ClosedStream`).
+	/// `Writer`'s drop fallback resets unconditionally, so without this every cleanly
+	/// finished stream would log a reset and `resets()` would say nothing.
+	finished: bool,
 }
 
 impl SinkSend {
 	pub fn new(log: Log) -> Self {
-		Self { log, gate: None }
+		Self {
+			log,
+			gate: None,
+			finished: false,
+		}
 	}
 }
 
@@ -78,10 +87,14 @@ impl web_transport_trait::SendStream for SinkSend {
 	fn set_priority(&mut self, _order: u8) {}
 
 	fn finish(&mut self) -> Result<(), Self::Error> {
+		self.finished = true;
 		Ok(())
 	}
 
 	fn reset(&mut self, code: u32) {
+		if self.finished {
+			return;
+		}
 		self.log.resets.lock().unwrap().push(code);
 	}
 
@@ -157,6 +170,7 @@ impl web_transport_trait::Session for SinkSession {
 		let send = SinkSend {
 			log: self.log.clone(),
 			gate: Some(gate),
+			finished: false,
 		};
 		Ok((send, PendingRecv))
 	}

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -52,10 +52,9 @@ pub struct SinkSend {
 	/// Writes park until this flips to true; `None` writes immediately. See
 	/// [`SinkSession::gated_bi`].
 	gate: Option<kio::Consumer<bool>>,
-	/// Set by [`finish`](web_transport_trait::SendStream::finish), so a later reset is
-	/// dropped the way quinn drops one on an already-finished stream (`ClosedStream`).
-	/// `Writer`'s drop fallback resets unconditionally, so without this every cleanly
-	/// finished stream would log a reset and `resets()` would say nothing.
+	/// Set by [`finish`](web_transport_trait::SendStream::finish). A finished stream is what
+	/// [`closed`](web_transport_trait::SendStream::closed) waits on, mirroring a peer that
+	/// acknowledges the FIN; an unfinished one parks like a peer that never answers.
 	finished: bool,
 }
 
@@ -91,15 +90,18 @@ impl web_transport_trait::SendStream for SinkSend {
 		Ok(())
 	}
 
+	/// Always recorded, even after a finish: quinn resets a stream that has sent its FIN but
+	/// still has unacknowledged data, which is exactly the case that loses a final message.
 	fn reset(&mut self, code: u32) {
-		if self.finished {
-			return;
-		}
 		self.log.resets.lock().unwrap().push(code);
 	}
 
 	async fn closed(&mut self) -> Result<(), Self::Error> {
-		std::future::pending().await
+		match self.finished {
+			true => Ok(()),
+			// Nothing to acknowledge yet, so park like a peer that never answers.
+			false => std::future::pending().await,
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Three independent interop clients (moqtopus, xquic, imquic) each passed 5/6, failing only because a SUBSCRIBE for a nonexistent track stayed pending instead of getting a REQUEST_ERROR.

**Root cause:** `Writer` resets its stream on drop (`coding/writer.rs`). The IETF SUBSCRIBE and FETCH rejection paths wrote REQUEST_ERROR and then `return Ok(())`, dropping the stream immediately. The RESET_STREAM discarded the bytes, and the subscriber waited forever on a request we had already refused.

**`finish()` alone does not fix this.** A stream in quinn's `DataSent` state has sent its FIN but is still retransmitting unacknowledged data, and `reset()` from that state transitions straight to `ResetSent` and drops it — see `SendStream::reset` in quinn-proto, where `ClosedStream` is returned only for a redundant reset or an unknown stream id. So finishing and returning still races the drop-time reset against the acknowledgement.

The fix is `Writer::close`: finish, wait for the peer to acknowledge, and take the stream so the drop fallback cannot fire at all. Rejections go through `reject_subscribe` / `reject_fetch`, which take the `Stream` **by value** and call it, so no call site can write an error and forget. PUBLISH_DONE gets the same treatment — it is the last thing on its stream and was previously only finished.

Also parses RENDEZVOUS_TIMEOUT (parameter `0x04`, added in **draft-17**) instead of rejecting it. An unknown message parameter is a `PROTOCOL_VIOLATION` per spec, so a client that sent one explicitly took the whole session down rather than getting an answer. The value is discarded: we answer with what is published right now, which is the shorter timeout [draft-18 §10.2.6](https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.txt) explicitly lets a relay pick. We never send it ourselves, and it stays rejected on draft-15/16 where `0x04` means MAX_CACHE_DURATION.

**Not in scope:** the REQUEST_ERROR codes. The rejection still carries `404`, which is wrong, but moq-net's error codes are a separate registry from the IETF one and that translation is being handled in its own PR. It was never the cause of the hang: draft-18 §14 requires a receiver to treat an unknown error code as INTERNAL_ERROR and forbids closing the session over it, so a client that actually received the 404 would have failed the subscribe promptly rather than waiting.

Two things the original diagnosis got wrong, for the record:

- **`request_broadcast` was not blocking.** It only parks when an origin-level `origin::Dynamic` handler is live, and the only registrant is `rs/moq-ffi/src/origin.rs`. `moq-relay` registers none, so it hits the zero-handler check and resolves to `Unroutable` synchronously. The relay answered immediately; the answer was destroyed on the way out. It is left awaiting as before, so `dynamic()` handlers keep working.
- **moq-lite is unaffected.** It signals rejections by aborting the stream with a meaningful error code rather than sending a message, which is by design.

## Public API changes

`Writer::close` is new, but `mod ietf` and `mod lite` are private in `moq-net` and `coding` is not re-exported, so nothing here reaches the published surface. Targets `main` per Branch Targeting.

## Test plan

- `missing_broadcast_is_refused_without_resetting_the_stream` and `unsupported_fetch_is_refused_without_resetting_the_stream` cover the SUBSCRIBE and all three unsupported FETCH branches across draft-17/18/19. Both verified to fail against a plain `finish()`-then-drop, which is the shape that looks correct but still loses the message.
- `SinkSend` now records every reset (previously it suppressed one after a finish, which hid this bug) and resolves `closed()` once finished, so those assertions mean what they say.
- Three RENDEZVOUS_TIMEOUT tests: accepted-and-ignored on draft-17/18/19 for both 0 and 5000 ms, rejected on draft-15/16, and never emitted by our encoder (asserted by reading the first parameter key off the wire, with a planted `0x04` first so the check cannot pass vacuously).
- Full `moq-net` suite: 686 passed. `just fix` and `just check` clean.

## Cross-package sync

No rows apply. RENDEZVOUS_TIMEOUT is an IETF moq-transport parameter, not one of our drafts, and no moq-lite wire behavior changed, so `drafts/` needs no update. `js/net` needs no counterpart: it already closes the request stream after writing the error, and its `Parameters.decode` stores unknown message parameters generically rather than throwing, so neither bug exists there.

Not verified against the interop clients themselves: the causal link to their reports is inferred from the code plus the regression tests, not reproduced against their implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 5)