### PR TITLE
chore: add a `cargo moq` alias for running moq-cli

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,10 @@
+# `cargo moq <args>` runs the moq-cli binary. Bare `cargo run` can't be pointed
+# at it: cargo has no workspace-level `default-run`, and an `[alias] run` is
+# ignored because it shadows a built-in. Narrowing `default-members` to moq-cli
+# would work, but that list is what scopes `just check` and `cargo semver-checks`.
+[alias]
+moq = ["run", "--bin", "moq", "--"]
+
 # Browser/WASM (moq-wasm). getrandom needs its wasm_js backend, and web-sys's
 # WebTransport bindings are behind the unstable cfg.
 [target.wasm32-unknown-unknown]


### PR DESCRIPTION
## Summary

- Adds `[alias] moq = ["run", "--bin", "moq", "--"]` to `.cargo/config.toml`, so `cargo moq publish ...` runs moq-cli with arguments passing straight through.

The ask was to make moq-cli the target of a bare `cargo run`. That isn't reachable, and each candidate was tested rather than assumed:

- Cargo has no workspace-level `default-run`. Setting it in a scratch workspace leaves `cargo run` erroring with the same ambiguity message; the key is ignored.
- `[alias] run = [...]` is rejected outright: `warning: user-defined alias 'run' is ignored, because it is shadowed by a built-in command`.
- Turning the virtual manifest into a root package with `default-run` doesn't help either. With an explicit `default-members`, cargo uses that list for target selection even from a root package, so all five workspace binaries stay in scope.

The only thing that resolves a bare `cargo run` is narrowing `default-members` to `rs/moq-cli`, and that list is load-bearing: `rs/justfile`'s `_select` reads `workspace_default_members` from `cargo metadata` to build the dependency graph behind the diff-aware `just check`, `just rs build` is a bare `cargo build`, and `cargo semver-checks` runs over default-members. Not worth trading three things for a shorter command, so the alias uses a name cargo will actually honor.

## Public API changes

None. Build tooling only.

## Test plan

- `cargo moq --version` builds and runs `target/debug/moq`, printing `moq 0.9.7-92be5e65c`.
- `taplo format --check` (via `nix develop`) clean.
- No Cross-Package Sync rows apply: no `rs/moq-cli` interface change, so `doc/bin/cli.md` and the sample invocations elsewhere are untouched.

(Written by Opus 5)