### PR TITLE
fix(smoke): stop the C client returning from main while libmoq holds ctx

### DIFF
--- a/test/smoke/clients/c/subscribe.c
+++ b/test/smoke/clients/c/subscribe.c
@@ -11,6 +11,7 @@
 #include <moq.h>
 
 #include <pthread.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -27,8 +28,10 @@ typedef struct {
 } ctx_t;
 
 // Callbacks run on libmoq's runtime thread; main waits on the condvar. ctx
-// lives on main's stack and outlives the callbacks (main blocks until got/
-// timeout, then the process exits), so there's no use-after-free.
+// lives on main's stack, and libmoq keeps the pointer until each registration's
+// terminal (<= 0) callback fires, which this client never waits for. So once
+// anything is registered, main must not return: every path from there on ends in
+// _exit, which keeps the frame alive for as long as the callbacks can run.
 static void on_status(void *ud, int32_t code) {
     (void)ud;
     fprintf(stderr, "session status: %d\n", code);
@@ -86,6 +89,24 @@ static void on_catalog(void *ud, int32_t catalog) {
     moq_consume_catalog_free((uint32_t)catalog);
 }
 
+// Report a failure and exit 1, for the paths where libmoq still holds &c.
+//
+// _exit rather than a return, for two reasons. It leaves main's frame (and so
+// ctx) intact for the callbacks still pointing at it, and it skips the atexit
+// teardown: libmoq statically bundles moq-video (openh264/cuda), whose worker
+// threads use priority-protected mutexes, and tearing them down at normal exit
+// can trip a glibc pthread priority assertion and abort. An abort here would
+// replace the message we just printed with a SIGABRT, which is exactly the
+// wrong thing to do on the path that explains why the test failed.
+static _Noreturn void fail(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fflush(stderr);
+    _exit(1);
+}
+
 int main(int argc, char **argv) {
     const char *url = NULL, *broadcast = NULL;
     double timeout_s = 20.0;
@@ -116,6 +137,8 @@ int main(int argc, char **argv) {
     // origin_publish = 0 disables publishing; consume via our origin.
     int32_t session = moq_session_connect(url, strlen(url), 0, (uint32_t)origin, on_status, &c);
     if (session <= 0) {
+        // A registration that fails never invokes its callback, so &c isn't held
+        // yet and returning is still safe here.
         fprintf(stderr, "error: moq_session_connect failed: %d\n", session);
         return 1;
     }
@@ -129,8 +152,7 @@ int main(int argc, char **argv) {
     // available; we block on the condvar until then (or the deadline).
     int32_t wait = moq_origin_consume_announced((uint32_t)origin, broadcast, strlen(broadcast), on_broadcast, &c);
     if (wait <= 0) {
-        fprintf(stderr, "error: moq_origin_consume_announced failed: %d\n", wait);
-        return 1;
+        fail("error: moq_origin_consume_announced failed: %d\n", wait);
     }
 
     pthread_mutex_lock(&c.mu);
@@ -140,14 +162,12 @@ int main(int argc, char **argv) {
     int32_t bc = c.broadcast;
     pthread_mutex_unlock(&c.mu);
     if (bc <= 0) {
-        fprintf(stderr, "error: broadcast never announced\n");
-        return 1;
+        fail("error: broadcast never announced\n");
     }
 
     int32_t cat = moq_consume_catalog((uint32_t)bc, on_catalog, &c);
     if (cat <= 0) {
-        fprintf(stderr, "error: moq_consume_catalog failed: %d\n", cat);
-        return 1;
+        fail("error: moq_consume_catalog failed: %d\n", cat);
     }
 
     pthread_mutex_lock(&c.mu);
@@ -160,13 +180,10 @@ int main(int argc, char **argv) {
     if (got) {
         fprintf(stderr, "received a frame from %s\n", broadcast);
         // The data path succeeded, which is all this smoke client verifies.
-        // libmoq statically bundles moq-video (openh264/cuda), whose
-        // worker threads use priority-protected mutexes; tearing them down at
-        // normal exit can trip a glibc pthread priority assertion and abort.
-        // Skip that atexit teardown with _exit now that we have our result.
+        // _exit for the reasons on fail() above: the callbacks still point at
+        // ctx, and the atexit teardown can abort.
         fflush(stderr);
         _exit(0);
     }
-    fprintf(stderr, "error: timed out waiting for data\n");
-    return 1;
+    fail("error: timed out waiting for data\n");
 }


### PR DESCRIPTION
## Root cause

`test/smoke/clients/c/subscribe.c` registers `&c` (a `ctx_t` on `main`'s stack) with four libmoq callbacks: `on_status` via `moq_session_connect`, `on_broadcast` via `moq_origin_consume_announced`, `on_catalog` via `moq_consume_catalog`, and `on_frame` via `moq_consume_video`. Every one of those documents the same contract:

> The caller must keep `user_data` valid until the terminal (`<= 0`) callback.

The client never waits for any of those terminal callbacks. It waits on a condvar for a frame, and on failure did a plain `return 1` from `main`, which destroys the frame `&c` points into while libmoq's runtime thread is still free to call back into it. The stale comment at the top of the file asserted the opposite ("main blocks until got/timeout, then the process exits, so there's no use-after-free"), which was true only of the success path.

Four paths were affected: `moq_origin_consume_announced failed`, `broadcast never announced`, `moq_consume_catalog failed`, and `timed out waiting for data`.

## Fix

Route the post-connect failures through a `_Noreturn fail()` helper that prints the same message, flushes, and `_exit(1)`s. That keeps `main`'s frame alive for as long as the callbacks can run, and it makes the exit symmetric with the success path, which has used `_exit(0)` since 17bf0d950 to skip an abort in the atexit teardown. Those failure paths were still running that teardown, so the case where a legible message matters most (a timeout, i.e. the smoke test actually failing) was the case most likely to be replaced by a SIGABRT/134.

The paths *before* connect keep their plain `return 1`: a registration that fails never invokes its callback (libmoq drops the `OnStatus` wrapper without calling it), so nothing holds `&c` yet.

Also updates the stale comment to describe what the code does today, per CLAUDE.md.

## Notes

- No behavior change on the success path.
- `moq-dev/smoke`'s `clients/c/subscribe.c` is a copy of this file (differing only in the first comment line, which names the prebuilt libmoq instead of the workspace one). Updated to match; that repo's copy had also missed the `openh264/vaapi/cuda` -> `openh264/cuda` edit from #2669.
- The `_exit` workaround itself masks an unexplained abort inside libmoq (glibc's `__pthread_tpp_change_priority` priority-protected-mutex assertion) that has never been root-caused. Filed separately rather than papered over further here.

## Testing

`nix develop --command just check` passes. The C file compiles clean under `-Wall -Wextra` against the generated `moq.h`.

(written by Opus 5)