### PR TITLE
fix(moq-net): move the publisher group order out of message parameters

### DIFF
--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -938,6 +938,38 @@ test("SubscribeOk v18: group order is a track property, not a parameter", async 
 	]);
 });
 
+// Draft-16 has the block too, under the name Track Extensions. We don't write one there, but
+// a peer that does used to fail the whole message on trailing bytes.
+test("SubscribeOk v16: reads track extensions", async () => {
+	const body = [
+		7, // request id
+		42, // track alias
+		0x00, // zero message parameters
+		0x22, // DEFAULT_PUBLISHER_GROUP_ORDER
+		0x02, // descending
+	];
+	const bytes = new Uint8Array([0x00, body.length, ...body]);
+
+	const decoded = await decodeVersioned(bytes, Subscribe.SubscribeOk.decode, Version.DRAFT_16);
+	expect(decoded.trackAlias).toBe(42n);
+});
+
+// Only Ascending and Descending are defined, so 0x0 is a malformed message rather than the
+// "publisher decides" it means in the draft-14 fields.
+test("SubscribeOk v18: rejects a zero group order property", async () => {
+	const body = [
+		42, // track alias
+		0x00, // zero message parameters
+		0x22, // DEFAULT_PUBLISHER_GROUP_ORDER
+		0x00, // invalid
+	];
+	const bytes = new Uint8Array([0x00, body.length, ...body]);
+
+	await expect(decodeVersioned(bytes, Subscribe.SubscribeOk.decode, Version.DRAFT_18)).rejects.toThrow(
+		"unknown group order",
+	);
+});
+
 // Draft-15 is the one version that takes it as a message parameter, and has no track
 // properties to put it in.
 test("SubscribeOk v15: group order is a message parameter", async () => {

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -920,6 +920,41 @@ test("SubscribeOk v18: no requestId", async () => {
 	expect(decoded.trackAlias).toBe(42n);
 });
 
+// GROUP_ORDER (0x22) is only a legal SUBSCRIBE_OK *message parameter* through draft-15; a
+// draft-16+ peer closes the session with PROTOCOL_VIOLATION when it sees one. The publisher's
+// preference belongs in the DEFAULT_PUBLISHER_GROUP_ORDER track property, which shares the
+// number 0x22 in the separate property registry.
+test("SubscribeOk v18: group order is a track property, not a parameter", async () => {
+	const msg = new Subscribe.SubscribeOk({ trackAlias: 42n });
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	expect(Array.from(encoded)).toEqual([
+		0x00,
+		0x04, // u16 message length
+		42, // track alias
+		0x00, // zero message parameters
+		0x22, // DEFAULT_PUBLISHER_GROUP_ORDER, the first (and only) track property
+		0x02, // descending
+	]);
+});
+
+// Draft-15 is the one version that takes it as a message parameter, and has no track
+// properties to put it in.
+test("SubscribeOk v15: group order is a message parameter", async () => {
+	const msg = new Subscribe.SubscribeOk({ requestId: 7n, trackAlias: 42n });
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_15);
+	expect(Array.from(encoded)).toEqual([
+		0x00,
+		0x05, // u16 message length
+		7, // request id
+		42, // track alias
+		0x01, // one message parameter
+		0x22, // GROUP_ORDER
+		0x02, // descending
+	]);
+});
+
 test("SubscribeUpdate v18: 1 byte shorter than v17 (no required_request_id_delta)", async () => {
 	const msg = new Subscribe.SubscribeUpdate({ requestId: 10n });
 	const v17 = await encodeVersioned(msg, Version.DRAFT_17);

--- a/js/net/src/ietf/properties.ts
+++ b/js/net/src/ietf/properties.ts
@@ -7,39 +7,67 @@ import { type IetfVersion, Version } from "./version.ts";
 // presence is what opts the track into timestamps at all.
 const TIMESCALE = 0x08n;
 
-/// Write the track's Timescale as a Track Property block.
+// DEFAULT_PUBLISHER_GROUP_ORDER (0x22), the publisher's delivery preference for the track.
+// It shares its number with the GROUP_ORDER *message parameter*, which is a different
+// registry: that one is only legal in SUBSCRIBE, PUBLISH_OK, and FETCH, where the
+// subscriber states its own preference.
+const DEFAULT_PUBLISHER_GROUP_ORDER = 0x22n;
+
+/// The Track Properties block carried at the end of SUBSCRIBE_OK, PUBLISH, and FETCH_OK.
+export interface Properties {
+	/// The track's Timescale, which declares the units of every object Timestamp on it.
+	///
+	/// `undefined` declares no timeline, so the subscriber times objects by arrival.
+	timescale?: Timescale;
+
+	/// The publisher's preference for prioritizing groups within a subscription,
+	/// Ascending (0x1) or Descending (0x2).
+	///
+	/// `undefined` means the draft default, Ascending.
+	groupOrder?: number;
+}
+
+/// Write the block, which is the final field of the message: no count and no length, so
+/// the caller must not append anything after it.
 ///
-/// Track Properties are the final field of the message, so this writes the block with
-/// no count and no length; the caller must not append anything after it.
-export async function encode(w: Writer, timescale: Timescale, version: IetfVersion): Promise<void> {
-	// Track Properties only exist in draft-17+; older drafts have nowhere to put this.
+/// Properties are serialized in ascending order by type, delta-encoded.
+export async function encode(w: Writer, properties: Properties, version: IetfVersion): Promise<void> {
+	// Track Properties only exist in draft-17+; older drafts have nowhere to put these.
 	if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
 		return;
 	}
 
-	// First property in the block, so the delta-encoded type is the absolute id.
-	await w.u62(TIMESCALE);
-	await w.u62(BigInt(timescale));
+	let prevType = 0n;
+
+	if (properties.timescale !== undefined) {
+		await w.u62(TIMESCALE);
+		await w.u62(BigInt(properties.timescale));
+		prevType = TIMESCALE;
+	}
+
+	if (properties.groupOrder !== undefined) {
+		await w.u62(DEFAULT_PUBLISHER_GROUP_ORDER - prevType);
+		await w.u62(BigInt(properties.groupOrder));
+	}
 }
 
-/// Parse Track Properties from the remaining bytes of a message, returning the track's
-/// Timescale if it declared one.
+/// Parse Track Properties from the remaining bytes of a message.
 ///
 /// Track Properties are delta-encoded Key-Value-Pairs (same format as
 /// Message Parameters) but with NO count prefix — they extend to the
 /// end of the message payload.
 ///
-/// `undefined` means the track declared no timeline, which is not an error: the caller
-/// times its objects by arrival instead.
+/// Unlike an unknown message parameter, an unknown property is skipped rather than fatal,
+/// which is what lets a relay forward properties it does not implement.
 ///
 /// Only present in draft-17+; older drafts don't have Track Properties.
-export async function decode(r: Reader, version: IetfVersion): Promise<Timescale | undefined> {
+export async function decode(r: Reader, version: IetfVersion): Promise<Properties> {
 	// Track Properties only exist in draft-17+
 	if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
-		return undefined;
+		return {};
 	}
 
-	let timescale: Timescale | undefined;
+	const properties: Properties = {};
 	let prevType = 0n;
 	let i = 0;
 
@@ -55,7 +83,12 @@ export async function decode(r: Reader, version: IetfVersion): Promise<Timescale
 			if (abs === TIMESCALE && value > 0n) {
 				// A zero timescale is invalid; treat it as no declaration rather than
 				// failing the whole message over one property we could have ignored.
-				timescale = Timescale(Number(value));
+				properties.timescale = Timescale(Number(value));
+			} else if (abs === DEFAULT_PUBLISHER_GROUP_ORDER) {
+				if (value > 2n) {
+					throw new Error(`unknown group order: ${value}`);
+				}
+				properties.groupOrder = Number(value);
 			}
 		} else {
 			// Odd type: length-prefixed bytes
@@ -64,5 +97,5 @@ export async function decode(r: Reader, version: IetfVersion): Promise<Timescale
 		}
 	}
 
-	return timescale;
+	return properties;
 }

--- a/js/net/src/ietf/properties.ts
+++ b/js/net/src/ietf/properties.ts
@@ -32,7 +32,10 @@ export interface Properties {
 ///
 /// Properties are serialized in ascending order by type, delta-encoded.
 export async function encode(w: Writer, properties: Properties, version: IetfVersion): Promise<void> {
-	// Track Properties only exist in draft-17+; older drafts have nowhere to put these.
+	// Draft-16 carries the same block under the name Track Extensions, but we only write it
+	// from draft-17 on: a draft-16 peer running an older build rejects any trailing bytes it
+	// doesn't parse, and draft-16 never registered TIMESCALE (0x08). We still read the block
+	// on draft-16, so a peer that sends one is understood.
 	if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
 		return;
 	}
@@ -54,16 +57,17 @@ export async function encode(w: Writer, properties: Properties, version: IetfVer
 /// Parse Track Properties from the remaining bytes of a message.
 ///
 /// Track Properties are delta-encoded Key-Value-Pairs (same format as
-/// Message Parameters) but with NO count prefix — they extend to the
+/// Message Parameters) but with NO count prefix: they extend to the
 /// end of the message payload.
 ///
 /// Unlike an unknown message parameter, an unknown property is skipped rather than fatal,
 /// which is what lets a relay forward properties it does not implement.
 ///
-/// Only present in draft-17+; older drafts don't have Track Properties.
+/// Drafts before 16 have no such block, so this reads nothing and leaves the reader alone.
 export async function decode(r: Reader, version: IetfVersion): Promise<Properties> {
-	// Track Properties only exist in draft-17+
-	if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
+	// Draft-16 calls the block Track Extensions, draft-17+ Track Properties. Same encoding, so
+	// read either rather than faulting the message for trailing bytes.
+	if (version === Version.DRAFT_14 || version === Version.DRAFT_15) {
 		return {};
 	}
 
@@ -85,7 +89,9 @@ export async function decode(r: Reader, version: IetfVersion): Promise<Propertie
 				// failing the whole message over one property we could have ignored.
 				properties.timescale = Timescale(Number(value));
 			} else if (abs === DEFAULT_PUBLISHER_GROUP_ORDER) {
-				if (value > 2n) {
+				// Only Ascending (0x1) and Descending (0x2) are defined here. Unlike the draft-14
+				// fields, 0x0 has no "publisher decides" meaning to fall back on.
+				if (value < 1n || value > 2n) {
 					throw new Error(`unknown group order: ${value}`);
 				}
 				properties.groupOrder = Number(value);

--- a/js/net/src/ietf/publish.ts
+++ b/js/net/src/ietf/publish.ts
@@ -76,12 +76,20 @@ export class Publish {
 				throw new Error("contentExists and largest must both be true or false");
 			}
 			const params = new Parameters();
-			params.groupOrder = this.groupOrder;
+			// GROUP_ORDER is a legal PUBLISH parameter only through draft-15. Draft-16 moved the
+			// publisher's preference to the DEFAULT_PUBLISHER_GROUP_ORDER track property, so
+			// sending the parameter here is a PROTOCOL_VIOLATION.
+			if (version === Version.DRAFT_15) {
+				params.groupOrder = this.groupOrder;
+			}
 			params.forward = this.forward;
 			if (this.largest) {
 				params.largest = this.largest;
 			}
 			await params.encode(w, version);
+
+			// Track Properties are the final field, so nothing may follow.
+			await Properties.encode(w, { groupOrder: this.groupOrder }, version);
 		}
 	}
 
@@ -121,8 +129,10 @@ export class Publish {
 		}
 		// v15+: parameters followed by Track Properties (draft-17+)
 		const params = await Parameters.decode(r, version);
-		await Properties.decode(r, version);
-		const groupOrder = params.groupOrder ?? 0x02;
+		const properties = await Properties.decode(r, version);
+		// GROUP_ORDER is only legal here through draft-15, but keep accepting it so a peer that
+		// still sends it doesn't have its session torn down over a hint.
+		const groupOrder = properties.groupOrder ?? params.groupOrder ?? 0x02;
 		const forward = params.forward ?? true;
 		const largest = params.largest;
 		return new Publish({

--- a/js/net/src/ietf/publish.ts
+++ b/js/net/src/ietf/publish.ts
@@ -76,9 +76,10 @@ export class Publish {
 				throw new Error("contentExists and largest must both be true or false");
 			}
 			const params = new Parameters();
-			// GROUP_ORDER is a legal PUBLISH parameter only through draft-15. Draft-16 moved the
-			// publisher's preference to the DEFAULT_PUBLISHER_GROUP_ORDER track property, so
-			// sending the parameter here is a PROTOCOL_VIOLATION.
+			// GROUP_ORDER is a legal PUBLISH parameter only through draft-15; a later peer closes
+			// the session with PROTOCOL_VIOLATION when it sees one. The publisher's preference is
+			// a DEFAULT_PUBLISHER_GROUP_ORDER track property instead, which we write from
+			// draft-17 on. Draft-16 gets neither form; see Properties.encode.
 			if (version === Version.DRAFT_15) {
 				params.groupOrder = this.groupOrder;
 			}

--- a/js/net/src/ietf/subscribe.ts
+++ b/js/net/src/ietf/subscribe.ts
@@ -168,13 +168,16 @@ export class SubscribeOk {
 		} else {
 			// v15+: just parameters after track_alias
 			const params = new Parameters();
-			params.groupOrder = GROUP_ORDER;
+			// GROUP_ORDER is a legal SUBSCRIBE_OK parameter only through draft-15. Draft-16 moved
+			// the publisher's preference to the DEFAULT_PUBLISHER_GROUP_ORDER track property, so
+			// sending the parameter here is a PROTOCOL_VIOLATION.
+			if (version === Version.DRAFT_15) {
+				params.groupOrder = GROUP_ORDER;
+			}
 			await params.encode(w, version);
 
 			// Track Properties are the final field, so nothing may follow.
-			if (this.timescale !== undefined) {
-				await Properties.encode(w, this.timescale, version);
-			}
+			await Properties.encode(w, { timescale: this.timescale, groupOrder: GROUP_ORDER }, version);
 		}
 	}
 
@@ -213,7 +216,7 @@ export class SubscribeOk {
 		} else {
 			// v15+: parameters followed by Track Properties (draft-17+)
 			await Parameters.decode(r, version);
-			timescale = await Properties.decode(r, version);
+			timescale = (await Properties.decode(r, version)).timescale;
 		}
 
 		return new SubscribeOk({ requestId, trackAlias, timescale });

--- a/js/net/src/ietf/subscribe.ts
+++ b/js/net/src/ietf/subscribe.ts
@@ -168,9 +168,10 @@ export class SubscribeOk {
 		} else {
 			// v15+: just parameters after track_alias
 			const params = new Parameters();
-			// GROUP_ORDER is a legal SUBSCRIBE_OK parameter only through draft-15. Draft-16 moved
-			// the publisher's preference to the DEFAULT_PUBLISHER_GROUP_ORDER track property, so
-			// sending the parameter here is a PROTOCOL_VIOLATION.
+			// GROUP_ORDER is a legal SUBSCRIBE_OK parameter only through draft-15; a later peer
+			// closes the session with PROTOCOL_VIOLATION when it sees one. The publisher's
+			// preference is a DEFAULT_PUBLISHER_GROUP_ORDER track property instead, which we
+			// write from draft-17 on. Draft-16 gets neither form; see Properties.encode.
 			if (version === Version.DRAFT_15) {
 				params.groupOrder = GROUP_ORDER;
 			}

--- a/rs/moq-net/src/ietf/fetch.rs
+++ b/rs/moq-net/src/ietf/fetch.rs
@@ -207,11 +207,11 @@ impl Message for FetchOk {
 				0u8.encode(w, version)?; // no parameters
 			}
 			_ => {
+				// GROUP_ORDER is not a legal FETCH_OK parameter in any draft after 14; the order
+				// of the response is whatever the FETCH asked for.
 				self.end_of_track.encode(w, version)?;
 				self.end_location.encode(w, version)?;
-				encode_params!(w, version,
-					0x22 => self.group_order,
-				);
+				encode_params!(w, version,);
 			}
 		}
 		Ok(())
@@ -240,12 +240,14 @@ impl Message for FetchOk {
 			_ => {
 				let end_of_track = bool::decode(buf, version)?;
 				let end_location = Location::decode(buf, version)?;
+				// GROUP_ORDER isn't legal here, but keep accepting it so a peer that still sends
+				// it doesn't have its session torn down over a hint.
 				decode_params!(buf, version,
 					0x22 => group_order: Option<GroupOrder>,
 				);
 				// FETCH_OK may declare a timescale; we don't surface it yet, and a fetched
 				// object without an interpretable timestamp is stamped on arrival.
-				let _ = super::properties::decode(buf, version)?;
+				let _ = super::Properties::decode(buf, version)?;
 
 				let group_order = group_order.unwrap_or(GroupOrder::Descending);
 
@@ -534,5 +536,27 @@ mod tests {
 		assert_eq!(decoded.request_id, None);
 		assert!(!decoded.end_of_track);
 		assert_eq!(decoded.end_location, Location { group: 5, object: 3 });
+	}
+
+	/// GROUP_ORDER (0x22) has never been a legal FETCH_OK parameter outside draft-14, where
+	/// it was a plain field. A draft-15+ peer closes the session with PROTOCOL_VIOLATION when
+	/// it sees one, so the response carries no parameters at all.
+	#[test]
+	fn test_fetch_ok_v18_omits_group_order() {
+		let msg = FetchOk {
+			request_id: None,
+			group_order: GroupOrder::Descending,
+			end_of_track: false,
+			end_location: Location { group: 5, object: 3 },
+		};
+
+		#[rustfmt::skip]
+		let expected = vec![
+			0, // end of track
+			5, // end group
+			3, // end object
+			0, // zero message parameters
+		];
+		assert_eq!(encode_message(&msg, Version::Draft18), expected);
 	}
 }

--- a/rs/moq-net/src/ietf/mod.rs
+++ b/rs/moq-net/src/ietf/mod.rs
@@ -34,6 +34,7 @@ pub use group::*;
 pub use location::*;
 pub use message::Message;
 pub use parameters::*;
+pub use properties::Properties;
 pub use publish::*;
 pub use publish_namespace::*;
 use publisher::*;

--- a/rs/moq-net/src/ietf/properties.rs
+++ b/rs/moq-net/src/ietf/properties.rs
@@ -53,7 +53,10 @@ impl Properties {
 	///
 	/// Properties are serialized in ascending order by type, delta-encoded.
 	pub fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		// Track Properties only exist in draft-17+; older drafts have nowhere to put these.
+		// Draft-16 carries the same block under the name Track Extensions, but we only write it
+		// from draft-17 on: a draft-16 peer running an older build of this crate rejects any
+		// trailing bytes it doesn't parse, and draft-16 never registered TIMESCALE (0x08). We
+		// still read the block on draft-16, so a peer that sends one is understood.
 		match version {
 			Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(()),
 			_ => {}
@@ -84,13 +87,14 @@ impl Properties {
 	/// Unlike an unknown message parameter, an unknown property is skipped rather than
 	/// fatal, which is what lets a relay forward properties it does not implement.
 	///
-	/// Only call this for draft-17+; older drafts don't have Track Properties.
+	/// Drafts before 16 have no such block, so this reads nothing and leaves the buffer alone.
 	pub fn decode<R: Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let mut properties = Self::default();
 
-		// Track Properties only exist in draft-17+
+		// Draft-16 calls the block Track Extensions, draft-17+ Track Properties. Same encoding,
+		// so read either rather than faulting the message for trailing bytes.
 		match version {
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(properties),
+			Version::Draft14 | Version::Draft15 => return Ok(properties),
 			_ => {}
 		}
 
@@ -121,9 +125,13 @@ impl Properties {
 						properties.timescale = Timescale::new(value).ok();
 					}
 					DEFAULT_PUBLISHER_GROUP_ORDER => {
-						let value = u8::try_from(value).map_err(|_| DecodeError::InvalidValue)?;
-						let order = GroupOrder::try_from(value).map_err(|_| DecodeError::InvalidValue)?;
-						properties.group_order = Some(order.any_to_descending());
+						// Only Ascending and Descending are defined here. Unlike the draft-14
+						// fields, 0x0 has no "publisher decides" meaning to fall back on.
+						properties.group_order = match value {
+							1 => Some(GroupOrder::Ascending),
+							2 => Some(GroupOrder::Descending),
+							_ => return Err(DecodeError::InvalidValue),
+						};
 					}
 					_ => {}
 				}
@@ -213,6 +221,32 @@ mod tests {
 
 		let mut bytes = buf.freeze();
 		assert_eq!(Properties::decode(&mut bytes, Version::Draft18).unwrap(), properties);
+		assert!(!bytes.has_remaining());
+	}
+
+	/// Only Ascending and Descending are defined, so 0x0 is a malformed message rather than
+	/// the "publisher decides" it means in the draft-14 fields.
+	#[test]
+	fn test_rejects_zero_group_order() {
+		let mut buf = BytesMut::new();
+		0x22u64.encode(&mut buf, Version::Draft18).unwrap();
+		0u64.encode(&mut buf, Version::Draft18).unwrap();
+
+		let mut bytes = buf.freeze();
+		assert!(Properties::decode(&mut bytes, Version::Draft18).is_err());
+	}
+
+	/// Draft-16 carries the same block under the name Track Extensions. We don't write one
+	/// there, but a peer that does must be understood rather than faulted.
+	#[test]
+	fn test_decodes_draft16_track_extensions() {
+		let mut buf = BytesMut::new();
+		0x22u64.encode(&mut buf, Version::Draft16).unwrap();
+		2u64.encode(&mut buf, Version::Draft16).unwrap();
+
+		let mut bytes = buf.freeze();
+		let properties = Properties::decode(&mut bytes, Version::Draft16).unwrap();
+		assert_eq!(properties.group_order, Some(GroupOrder::Descending));
 		assert!(!bytes.has_remaining());
 	}
 

--- a/rs/moq-net/src/ietf/properties.rs
+++ b/rs/moq-net/src/ietf/properties.rs
@@ -7,13 +7,14 @@
 /// Unlike Message Parameters which have a count prefix, Track Properties
 /// have no count and are read until the end of the message payload.
 ///
-/// TIMESCALE is the one property we understand; the rest are parsed and discarded.
+/// TIMESCALE and DEFAULT_PUBLISHER_GROUP_ORDER are the ones we understand;
+/// the rest are parsed and discarded.
 use bytes::Buf;
 
 use crate::Timescale;
 use crate::coding::{Decode, DecodeError, Encode, EncodeError};
 
-use super::Version;
+use super::{GroupOrder, Version};
 
 const MAX_PROPERTIES: u64 = 64;
 /// Maximum byte value length per spec Section 1.4.3.
@@ -25,82 +26,122 @@ const MAX_KVP_VALUE_LEN: usize = (1 << 16) - 1;
 /// presence is what opts the track into timestamps at all.
 const TIMESCALE: u64 = 0x08;
 
-/// Write the track's Timescale as a Track Property block.
+/// DEFAULT_PUBLISHER_GROUP_ORDER (0x22), the publisher's delivery preference for the track.
 ///
-/// Track Properties are the final field of the message, so this writes the block with
-/// no count and no length; the caller must not append anything after it.
-pub fn encode<W: bytes::BufMut>(w: &mut W, timescale: Timescale, version: Version) -> Result<(), EncodeError> {
-	// Track Properties only exist in draft-17+; older drafts have nowhere to put this.
-	match version {
-		Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(()),
-		_ => {}
-	}
+/// It shares its number with the GROUP_ORDER *message parameter*, which is a different
+/// registry: that one is only legal in SUBSCRIBE, PUBLISH_OK, and FETCH, where the
+/// subscriber states its own preference.
+const DEFAULT_PUBLISHER_GROUP_ORDER: u64 = 0x22;
 
-	// First property in the block, so the delta-encoded type is the absolute id.
-	TIMESCALE.encode(w, version)?;
-	u64::from(timescale).encode(w, version)
+/// The Track Properties block carried at the end of SUBSCRIBE_OK, PUBLISH, and FETCH_OK.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Properties {
+	/// The track's Timescale, which declares the units of every object Timestamp on it.
+	///
+	/// `None` declares no timeline, so the subscriber times objects by arrival.
+	pub timescale: Option<Timescale>,
+
+	/// The publisher's preference for prioritizing groups within a subscription.
+	///
+	/// `None` means the draft default, Ascending.
+	pub group_order: Option<GroupOrder>,
 }
 
-/// Parse Track Properties from the remaining bytes of a message, returning the track's
-/// Timescale if it declared one.
-///
-/// Track Properties use the same Key-Value-Pair encoding as parameters:
-/// delta-encoded types, even = varint value, odd = length-prefixed bytes.
-/// They have no count prefix. Read until the buffer is empty.
-///
-/// `None` means the track declared no timeline, which is not an error: the caller
-/// interprets its objects by arrival time instead. A Timescale of 0 is invalid and
-/// decodes to `None` for the same reason.
-///
-/// Only call this for draft-17+; older drafts don't have Track Properties.
-pub fn decode<R: Buf>(r: &mut R, version: Version) -> Result<Option<Timescale>, DecodeError> {
-	// Track Properties only exist in draft-17+
-	match version {
-		Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(None),
-		_ => {}
-	}
-
-	let mut timescale = None;
-
-	let mut prev_type: u64 = 0;
-	let mut i: u64 = 0;
-
-	while r.has_remaining() {
-		if i >= MAX_PROPERTIES {
-			return Err(DecodeError::TooMany);
+impl Properties {
+	/// Write the block, which is the final field of the message: no count and no length,
+	/// so the caller must not append anything after it.
+	///
+	/// Properties are serialized in ascending order by type, delta-encoded.
+	pub fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		// Track Properties only exist in draft-17+; older drafts have nowhere to put these.
+		match version {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(()),
+			_ => {}
 		}
 
-		let delta = u64::decode(r, version)?;
-		let abs = if i == 0 {
-			delta
-		} else {
-			prev_type.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?
-		};
-		prev_type = abs;
-		i += 1;
+		let mut prev_type = 0;
 
-		if abs % 2 == 0 {
-			// Even type: single varint value
-			let value = u64::decode(r, version)?;
-			if abs == TIMESCALE {
-				// A zero timescale is invalid; treat it as no declaration rather than
-				// failing the whole message over one property we could have ignored.
-				timescale = Timescale::new(value).ok();
-			}
-		} else {
-			// Odd type: length-prefixed bytes
-			let len = u64::decode(r, version)? as usize;
-			if len > MAX_KVP_VALUE_LEN {
-				return Err(DecodeError::BoundsExceeded);
-			}
-			if r.remaining() < len {
-				return Err(DecodeError::Short);
-			}
-			r.advance(len);
+		if let Some(timescale) = self.timescale {
+			TIMESCALE.encode(w, version)?;
+			u64::from(timescale).encode(w, version)?;
+			prev_type = TIMESCALE;
 		}
+
+		if let Some(group_order) = self.group_order {
+			(DEFAULT_PUBLISHER_GROUP_ORDER - prev_type).encode(w, version)?;
+			u64::from(u8::from(group_order)).encode(w, version)?;
+		}
+
+		Ok(())
 	}
 
-	Ok(timescale)
+	/// Parse Track Properties from the remaining bytes of a message.
+	///
+	/// Track Properties use the same Key-Value-Pair encoding as parameters:
+	/// delta-encoded types, even = varint value, odd = length-prefixed bytes.
+	/// They have no count prefix. Read until the buffer is empty.
+	///
+	/// Unlike an unknown message parameter, an unknown property is skipped rather than
+	/// fatal, which is what lets a relay forward properties it does not implement.
+	///
+	/// Only call this for draft-17+; older drafts don't have Track Properties.
+	pub fn decode<R: Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let mut properties = Self::default();
+
+		// Track Properties only exist in draft-17+
+		match version {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(properties),
+			_ => {}
+		}
+
+		let mut prev_type: u64 = 0;
+		let mut i: u64 = 0;
+
+		while r.has_remaining() {
+			if i >= MAX_PROPERTIES {
+				return Err(DecodeError::TooMany);
+			}
+
+			let delta = u64::decode(r, version)?;
+			let abs = if i == 0 {
+				delta
+			} else {
+				prev_type.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?
+			};
+			prev_type = abs;
+			i += 1;
+
+			if abs % 2 == 0 {
+				// Even type: single varint value
+				let value = u64::decode(r, version)?;
+				match abs {
+					TIMESCALE => {
+						// A zero timescale is invalid; treat it as no declaration rather than
+						// failing the whole message over one property we could have ignored.
+						properties.timescale = Timescale::new(value).ok();
+					}
+					DEFAULT_PUBLISHER_GROUP_ORDER => {
+						let value = u8::try_from(value).map_err(|_| DecodeError::InvalidValue)?;
+						let order = GroupOrder::try_from(value).map_err(|_| DecodeError::InvalidValue)?;
+						properties.group_order = Some(order.any_to_descending());
+					}
+					_ => {}
+				}
+			} else {
+				// Odd type: length-prefixed bytes
+				let len = u64::decode(r, version)? as usize;
+				if len > MAX_KVP_VALUE_LEN {
+					return Err(DecodeError::BoundsExceeded);
+				}
+				if r.remaining() < len {
+					return Err(DecodeError::Short);
+				}
+				r.advance(len);
+			}
+		}
+
+		Ok(properties)
+	}
 }
 
 #[cfg(test)]
@@ -112,7 +153,10 @@ mod tests {
 	#[test]
 	fn test_skip_empty_properties() {
 		let mut buf = bytes::Bytes::new();
-		decode(&mut buf, Version::Draft17).unwrap();
+		assert_eq!(
+			Properties::decode(&mut buf, Version::Draft17).unwrap(),
+			Properties::default()
+		);
 	}
 
 	#[test]
@@ -122,7 +166,7 @@ mod tests {
 		0x02u64.encode(&mut buf, Version::Draft17).unwrap(); // delta type
 		5000u64.encode(&mut buf, Version::Draft17).unwrap(); // value
 		let mut bytes = buf.freeze();
-		decode(&mut bytes, Version::Draft17).unwrap();
+		Properties::decode(&mut bytes, Version::Draft17).unwrap();
 		assert!(!bytes.has_remaining());
 	}
 
@@ -134,7 +178,7 @@ mod tests {
 		3u64.encode(&mut buf, Version::Draft17).unwrap(); // length
 		buf.extend_from_slice(&[0x01, 0x02, 0x03]); // value bytes
 		let mut bytes = buf.freeze();
-		decode(&mut bytes, Version::Draft17).unwrap();
+		Properties::decode(&mut bytes, Version::Draft17).unwrap();
 		assert!(!bytes.has_remaining());
 	}
 
@@ -153,7 +197,39 @@ mod tests {
 		buf.extend_from_slice(&[0xAA, 0xBB]);
 
 		let mut bytes = buf.freeze();
-		decode(&mut bytes, Version::Draft17).unwrap();
+		Properties::decode(&mut bytes, Version::Draft17).unwrap();
+		assert!(!bytes.has_remaining());
+	}
+
+	#[test]
+	fn test_round_trip() {
+		let properties = Properties {
+			timescale: Some(Timescale::MICRO),
+			group_order: Some(GroupOrder::Descending),
+		};
+
+		let mut buf = BytesMut::new();
+		properties.encode(&mut buf, Version::Draft18).unwrap();
+
+		let mut bytes = buf.freeze();
+		assert_eq!(Properties::decode(&mut bytes, Version::Draft18).unwrap(), properties);
+		assert!(!bytes.has_remaining());
+	}
+
+	/// The group order property is delta-encoded against the timescale that precedes it,
+	/// so it has to survive the timescale being absent.
+	#[test]
+	fn test_round_trip_group_order_only() {
+		let properties = Properties {
+			timescale: None,
+			group_order: Some(GroupOrder::Descending),
+		};
+
+		let mut buf = BytesMut::new();
+		properties.encode(&mut buf, Version::Draft18).unwrap();
+
+		let mut bytes = buf.freeze();
+		assert_eq!(Properties::decode(&mut bytes, Version::Draft18).unwrap(), properties);
 		assert!(!bytes.has_remaining());
 	}
 }

--- a/rs/moq-net/src/ietf/publish.rs
+++ b/rs/moq-net/src/ietf/publish.rs
@@ -107,10 +107,10 @@ The namespace or track is not of interest to the endpoint.
 use std::borrow::Cow;
 
 use crate::{
-	Path, Timescale,
+	Path,
 	coding::{Decode, DecodeError, Encode, EncodeError},
 	ietf::{
-		FilterType, GroupOrder, Location, Parameters, RequestId,
+		FilterType, GroupOrder, Location, Parameters, Properties, RequestId,
 		namespace::{decode_namespace, encode_namespace},
 	},
 };
@@ -170,14 +170,11 @@ pub struct Publish<'a> {
 	pub track_namespace: Path<'a>,
 	pub track_name: Cow<'a, str>,
 	pub track_alias: u64,
-	pub group_order: GroupOrder,
 	pub largest_location: Option<Location>,
 	pub forward: bool,
 
-	/// The track's Timescale, sent as a Track Property (draft-17+).
-	///
-	/// `None` declares no timeline, so the subscriber times objects by arrival.
-	pub timescale: Option<Timescale>,
+	/// Metadata about the track, sent as Track Properties (draft-17+).
+	pub properties: Properties,
 	// pub parameters: Parameters,
 }
 
@@ -195,7 +192,10 @@ impl Message for Publish<'_> {
 
 		match version {
 			Version::Draft14 => {
-				self.group_order.encode(w, version)?;
+				self.properties
+					.group_order
+					.unwrap_or(GroupOrder::Ascending)
+					.encode(w, version)?;
 				if let Some(location) = &self.largest_location {
 					true.encode(w, version)?;
 					location.encode(w, version)?;
@@ -208,16 +208,22 @@ impl Message for Publish<'_> {
 				0u8.encode(w, version)?;
 			}
 			_ => {
+				// GROUP_ORDER is a legal PUBLISH parameter only through draft-15. Draft-16 moved
+				// the publisher's preference to the DEFAULT_PUBLISHER_GROUP_ORDER track property,
+				// so sending the parameter here is a PROTOCOL_VIOLATION.
+				let group_order = match version {
+					Version::Draft15 => self.properties.group_order,
+					_ => None,
+				};
+
 				encode_params!(w, version,
 					0x09 => self.largest_location,
 					0x10 => self.forward,
-					0x22 => self.group_order,
+					0x22 => group_order,
 				);
 
 				// Track Properties are the final field, so nothing may follow.
-				if let Some(timescale) = self.timescale {
-					super::properties::encode(w, timescale, version)?;
-				}
+				self.properties.encode(w, version)?;
 			}
 		}
 
@@ -235,7 +241,7 @@ impl Message for Publish<'_> {
 
 		match version {
 			Version::Draft14 => {
-				let group_order = GroupOrder::decode(r, version)?;
+				let group_order = GroupOrder::decode(r, version)?.any_to_descending();
 				let content_exists = bool::decode(r, version)?;
 				let largest_location = match content_exists {
 					true => Some(Location::decode(r, version)?),
@@ -250,21 +256,25 @@ impl Message for Publish<'_> {
 					track_namespace,
 					track_name,
 					track_alias,
-					group_order,
 					largest_location,
 					forward,
-					timescale: None,
+					properties: Properties {
+						group_order: Some(group_order),
+						..Default::default()
+					},
 				})
 			}
 			_ => {
+				// GROUP_ORDER is only legal here through draft-15, but keep accepting it so a
+				// peer that still sends it doesn't have its session torn down over a hint.
 				decode_params!(r, version,
 					0x09 => largest_location: Option<Location>,
 					0x10 => forward: Option<bool>,
 					0x22 => group_order: Option<GroupOrder>,
 				);
-				let timescale = super::properties::decode(r, version)?;
+				let mut properties = Properties::decode(r, version)?;
+				properties.group_order = properties.group_order.or(group_order);
 
-				let group_order = group_order.unwrap_or(GroupOrder::Descending);
 				let forward = forward.unwrap_or(true);
 
 				Ok(Self {
@@ -272,10 +282,9 @@ impl Message for Publish<'_> {
 					track_namespace,
 					track_name,
 					track_alias,
-					group_order,
 					largest_location,
 					forward,
-					timescale,
+					properties,
 				})
 			}
 		}
@@ -441,10 +450,12 @@ mod tests {
 			track_namespace: Path::new("test/ns"),
 			track_name: "video".into(),
 			track_alias: 42,
-			group_order: GroupOrder::Descending,
 			largest_location: Some(Location { group: 10, object: 5 }),
 			forward: true,
-			timescale: None,
+			properties: Properties {
+				group_order: Some(GroupOrder::Descending),
+				..Default::default()
+			},
 		};
 
 		let encoded = encode_message(&msg, Version::Draft14);
@@ -465,10 +476,12 @@ mod tests {
 			track_namespace: Path::new("test/ns"),
 			track_name: "video".into(),
 			track_alias: 42,
-			group_order: GroupOrder::Descending,
 			largest_location: Some(Location { group: 10, object: 5 }),
 			forward: true,
-			timescale: None,
+			properties: Properties {
+				group_order: Some(GroupOrder::Descending),
+				..Default::default()
+			},
 		};
 
 		let encoded = encode_message(&msg, Version::Draft15);
@@ -525,10 +538,12 @@ mod tests {
 			track_namespace: Path::new("test/ns"),
 			track_name: "video".into(),
 			track_alias: 42,
-			group_order: GroupOrder::Descending,
 			largest_location: Some(Location { group: 10, object: 5 }),
 			forward: true,
-			timescale: None,
+			properties: Properties {
+				group_order: Some(GroupOrder::Descending),
+				..Default::default()
+			},
 		};
 
 		let encoded = encode_message(&msg, Version::Draft17);
@@ -585,10 +600,12 @@ mod tests {
 			track_namespace: Path::new("test/ns"),
 			track_name: "video".into(),
 			track_alias: 42,
-			group_order: GroupOrder::Descending,
 			largest_location: Some(Location { group: 10, object: 5 }),
 			forward: true,
-			timescale: None,
+			properties: Properties {
+				group_order: Some(GroupOrder::Descending),
+				..Default::default()
+			},
 		};
 
 		let encoded = encode_message(&msg, Version::Draft18);
@@ -602,6 +619,76 @@ mod tests {
 		assert!(decoded.forward);
 	}
 
+	/// GROUP_ORDER (0x22) is only a legal PUBLISH *message parameter* through draft-15; a
+	/// draft-16+ peer closes the session with PROTOCOL_VIOLATION when it sees one. The
+	/// publisher's preference belongs in the DEFAULT_PUBLISHER_GROUP_ORDER track property,
+	/// which shares the number 0x22 in the separate property registry.
+	#[test]
+	fn test_publish_v18_group_order_is_a_property() {
+		let msg = Publish {
+			request_id: RequestId(1),
+			track_namespace: Path::new("ns"),
+			track_name: "video".into(),
+			track_alias: 42,
+			largest_location: None,
+			forward: true,
+			properties: Properties {
+				timescale: None,
+				group_order: Some(GroupOrder::Descending),
+			},
+		};
+
+		#[rustfmt::skip]
+		let expected = vec![
+			1,                            // request id
+			1,                            // namespace tuple count
+			2, b'n', b's',                // "ns"
+			5, b'v', b'i', b'd', b'e', b'o', // "video"
+			42,                           // track alias
+			1,                            // one message parameter
+			0x10, 0x01,                   // FORWARD = true
+			0x22, 0x02,                   // DEFAULT_PUBLISHER_GROUP_ORDER = descending
+		];
+		assert_eq!(encode_message(&msg, Version::Draft18), expected);
+
+		let decoded: Publish = decode_message(&expected, Version::Draft18).unwrap();
+		assert_eq!(decoded.properties.group_order, Some(GroupOrder::Descending));
+	}
+
+	/// Draft-15 is the last version that takes it as a message parameter, and has no track
+	/// properties to put it in.
+	#[test]
+	fn test_publish_v15_group_order_is_a_parameter() {
+		let msg = Publish {
+			request_id: RequestId(1),
+			track_namespace: Path::new("ns"),
+			track_name: "video".into(),
+			track_alias: 42,
+			largest_location: None,
+			forward: true,
+			properties: Properties {
+				timescale: None,
+				group_order: Some(GroupOrder::Descending),
+			},
+		};
+
+		#[rustfmt::skip]
+		let expected = vec![
+			1,                            // request id
+			1,                            // namespace tuple count
+			2, b'n', b's',                // "ns"
+			5, b'v', b'i', b'd', b'e', b'o', // "video"
+			42,                           // track alias
+			2,                            // two message parameters
+			0x10, 0x01,                   // FORWARD = true
+			0x22, 0x02,                   // GROUP_ORDER = descending
+		];
+		assert_eq!(encode_message(&msg, Version::Draft15), expected);
+
+		let decoded: Publish = decode_message(&expected, Version::Draft15).unwrap();
+		assert_eq!(decoded.properties.group_order, Some(GroupOrder::Descending));
+	}
+
 	/// Draft-18 drops the required_request_id_delta varint (#1615).
 	/// For Publish (#1D) the field is a single zero varint = 1 byte.
 	#[test]
@@ -611,10 +698,12 @@ mod tests {
 			track_namespace: Path::new("test/ns"),
 			track_name: "video".into(),
 			track_alias: 42,
-			group_order: GroupOrder::Descending,
 			largest_location: None,
 			forward: true,
-			timescale: None,
+			properties: Properties {
+				group_order: Some(GroupOrder::Descending),
+				..Default::default()
+			},
 		};
 
 		let v17 = encode_message(&msg, Version::Draft17);

--- a/rs/moq-net/src/ietf/publish.rs
+++ b/rs/moq-net/src/ietf/publish.rs
@@ -208,9 +208,10 @@ impl Message for Publish<'_> {
 				0u8.encode(w, version)?;
 			}
 			_ => {
-				// GROUP_ORDER is a legal PUBLISH parameter only through draft-15. Draft-16 moved
-				// the publisher's preference to the DEFAULT_PUBLISHER_GROUP_ORDER track property,
-				// so sending the parameter here is a PROTOCOL_VIOLATION.
+				// GROUP_ORDER is a legal PUBLISH parameter only through draft-15; a later peer
+				// closes the session with PROTOCOL_VIOLATION when it sees one. The publisher's
+				// preference is a DEFAULT_PUBLISHER_GROUP_ORDER track property instead, which we
+				// write from draft-17 on. Draft-16 gets neither form; see Properties::encode.
 				let group_order = match version {
 					Version::Draft15 => self.properties.group_order,
 					_ => None,

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -427,9 +427,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					_ => None,
 				},
 				track_alias: request_id.0,
-				// Declaring the timescale is what opts the track into timestamps; every
-				// object Timestamp below is in these units.
-				timescale: Some(track.info().timescale),
+				properties: ietf::Properties {
+					// Declaring the timescale is what opts the track into timestamps; every
+					// object Timestamp below is in these units.
+					timescale: Some(track.info().timescale),
+					// We serve the newest group first, matching moq-lite.
+					group_order: Some(GroupOrder::Descending),
+				},
 			})
 			.await?;
 

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -5,9 +5,9 @@ use std::borrow::Cow;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
-	Path, Timescale,
+	Path,
 	coding::*,
-	ietf::{GroupOrder, Location, Parameters, RequestId},
+	ietf::{GroupOrder, Location, Parameters, Properties, RequestId},
 };
 
 use super::Message;
@@ -164,10 +164,8 @@ pub struct SubscribeOk {
 	pub request_id: Option<RequestId>,
 	pub track_alias: u64,
 
-	/// The track's Timescale, sent as a Track Property (draft-17+).
-	///
-	/// `None` declares no timeline, so the subscriber times objects by arrival.
-	pub timescale: Option<Timescale>,
+	/// Metadata about the track, sent as Track Properties (draft-17+).
+	pub properties: Properties,
 }
 
 impl Message for SubscribeOk {
@@ -186,19 +184,28 @@ impl Message for SubscribeOk {
 		match version {
 			Version::Draft14 => {
 				0u64.encode(w, version)?; // expires = 0
-				GroupOrder::Descending.encode(w, version)?;
+				self.properties
+					.group_order
+					.unwrap_or(GroupOrder::Ascending)
+					.encode(w, version)?;
 				false.encode(w, version)?; // no content
 				0u8.encode(w, version)?; // no parameters
 			}
 			_ => {
+				// GROUP_ORDER is a legal SUBSCRIBE_OK parameter only through draft-15. Draft-16
+				// moved the publisher's preference to the DEFAULT_PUBLISHER_GROUP_ORDER track
+				// property, so sending the parameter here is a PROTOCOL_VIOLATION.
+				let group_order = match version {
+					Version::Draft15 => self.properties.group_order,
+					_ => None,
+				};
+
 				encode_params!(w, version,
-					0x22 => GroupOrder::Descending,
+					0x22 => group_order,
 				);
 
 				// Track Properties are the final field, so nothing may follow.
-				if let Some(timescale) = self.timescale {
-					super::properties::encode(w, timescale, version)?;
-				}
+				self.properties.encode(w, version)?;
 			}
 		}
 
@@ -212,7 +219,7 @@ impl Message for SubscribeOk {
 			None
 		};
 		let track_alias = u64::decode(r, version)?;
-		let mut timescale = None;
+		let mut properties = Properties::default();
 
 		match version {
 			Version::Draft14 => {
@@ -221,7 +228,7 @@ impl Message for SubscribeOk {
 					return Err(DecodeError::Unsupported);
 				}
 
-				let _group_order = u8::decode(r, version)?;
+				properties.group_order = Some(GroupOrder::decode(r, version)?.any_to_descending());
 
 				if bool::decode(r, version)? {
 					let _group = u64::decode(r, version)?;
@@ -231,17 +238,20 @@ impl Message for SubscribeOk {
 				let _params = Parameters::decode(r, version)?;
 			}
 			_ => {
+				// GROUP_ORDER is only legal here through draft-15, but keep accepting it so a
+				// peer that still sends it doesn't have its session torn down over a hint.
 				decode_params!(r, version,
-					0x22 => _group_order: Option<GroupOrder>,
+					0x22 => group_order: Option<GroupOrder>,
 				);
-				timescale = super::properties::decode(r, version)?;
+				properties = Properties::decode(r, version)?;
+				properties.group_order = properties.group_order.or(group_order);
 			}
 		}
 
 		Ok(Self {
 			request_id,
 			track_alias,
-			timescale,
+			properties,
 		})
 	}
 }
@@ -503,7 +513,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: Some(RequestId(42)),
 			track_alias: 42,
-			timescale: None,
+			properties: Properties::default(),
 		};
 
 		let encoded = encode_message(&msg, Version::Draft14);
@@ -517,7 +527,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: Some(RequestId(42)),
 			track_alias: 42,
-			timescale: None,
+			properties: Properties::default(),
 		};
 
 		let encoded = encode_message(&msg, Version::Draft15);
@@ -656,7 +666,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: None,
 			track_alias: 42,
-			timescale: None,
+			properties: Properties::default(),
 		};
 
 		let encoded = encode_message(&msg, Version::Draft17);
@@ -711,7 +721,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: None,
 			track_alias: 42,
-			timescale: None,
+			properties: Properties::default(),
 		};
 
 		let encoded = encode_message(&msg, Version::Draft18);
@@ -719,6 +729,78 @@ mod tests {
 
 		assert_eq!(decoded.request_id, None);
 		assert_eq!(decoded.track_alias, 42);
+	}
+
+	/// GROUP_ORDER (0x22) is only a legal SUBSCRIBE_OK *message parameter* through draft-15;
+	/// a draft-16+ peer closes the session with PROTOCOL_VIOLATION when it sees one. The
+	/// publisher's preference belongs in the DEFAULT_PUBLISHER_GROUP_ORDER track property,
+	/// which shares the number 0x22 in the separate property registry.
+	#[test]
+	fn test_subscribe_ok_v18_group_order_is_a_property() {
+		let msg = SubscribeOk {
+			request_id: None,
+			track_alias: 42,
+			properties: Properties {
+				timescale: None,
+				group_order: Some(GroupOrder::Descending),
+			},
+		};
+
+		#[rustfmt::skip]
+		let expected = vec![
+			42,   // track alias
+			0,    // zero message parameters
+			0x22, // DEFAULT_PUBLISHER_GROUP_ORDER, the first (and only) track property
+			0x02, // descending
+		];
+		assert_eq!(encode_message(&msg, Version::Draft18), expected);
+
+		let decoded: SubscribeOk = decode_message(&expected, Version::Draft18).unwrap();
+		assert_eq!(decoded.properties.group_order, Some(GroupOrder::Descending));
+	}
+
+	/// Draft-15 is the one version that takes it as a message parameter, and has no track
+	/// properties to put it in.
+	#[test]
+	fn test_subscribe_ok_v15_group_order_is_a_parameter() {
+		let msg = SubscribeOk {
+			request_id: Some(RequestId(7)),
+			track_alias: 42,
+			properties: Properties {
+				timescale: None,
+				group_order: Some(GroupOrder::Descending),
+			},
+		};
+
+		#[rustfmt::skip]
+		let expected = vec![
+			7,    // request id
+			42,   // track alias
+			1,    // one message parameter
+			0x22, // GROUP_ORDER
+			0x02, // descending
+		];
+		assert_eq!(encode_message(&msg, Version::Draft15), expected);
+
+		let decoded: SubscribeOk = decode_message(&expected, Version::Draft15).unwrap();
+		assert_eq!(decoded.properties.group_order, Some(GroupOrder::Descending));
+	}
+
+	/// We stopped sending the parameter, but a peer still sending it shouldn't lose its
+	/// session over a hint we ignore anyway.
+	#[test]
+	fn test_subscribe_ok_v18_accepts_group_order_parameter() {
+		#[rustfmt::skip]
+		let bytes = vec![
+			42,   // track alias
+			1,    // one message parameter
+			0x22, // GROUP_ORDER
+			0x02, // descending
+		];
+
+		let decoded: SubscribeOk = decode_message(&bytes, Version::Draft18).unwrap();
+		assert_eq!(decoded.track_alias, 42);
+		assert_eq!(decoded.properties.group_order, Some(GroupOrder::Descending));
 	}
 
 	/// Draft-18 removes the `required_request_id_delta` field (#1615), so the

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -192,9 +192,11 @@ impl Message for SubscribeOk {
 				0u8.encode(w, version)?; // no parameters
 			}
 			_ => {
-				// GROUP_ORDER is a legal SUBSCRIBE_OK parameter only through draft-15. Draft-16
-				// moved the publisher's preference to the DEFAULT_PUBLISHER_GROUP_ORDER track
-				// property, so sending the parameter here is a PROTOCOL_VIOLATION.
+				// GROUP_ORDER is a legal SUBSCRIBE_OK parameter only through draft-15; a later
+				// peer closes the session with PROTOCOL_VIOLATION when it sees one. The
+				// publisher's preference is a DEFAULT_PUBLISHER_GROUP_ORDER track property
+				// instead, which we write from draft-17 on. Draft-16 gets neither form; see
+				// Properties::encode.
 				let group_order = match version {
 					Version::Draft15 => self.properties.group_order,
 					_ => None,
@@ -783,6 +785,30 @@ mod tests {
 		assert_eq!(encode_message(&msg, Version::Draft15), expected);
 
 		let decoded: SubscribeOk = decode_message(&expected, Version::Draft15).unwrap();
+		assert_eq!(decoded.properties.group_order, Some(GroupOrder::Descending));
+	}
+
+	/// Draft-16 has the block too, under the name Track Extensions. We don't write one there,
+	/// but a peer that does used to fail the whole message as `Long`.
+	#[test]
+	fn test_subscribe_ok_v16_reads_track_extensions() {
+		#[rustfmt::skip]
+		let body = vec![
+			7,    // request id
+			42,   // track alias
+			0,    // zero message parameters
+			0x22, // DEFAULT_PUBLISHER_GROUP_ORDER
+			0x02, // descending
+		];
+
+		// Go through the size-prefixed path: that's what rejects unread trailing bytes.
+		let mut buf = BytesMut::new();
+		(body.len() as u16).encode(&mut buf, Version::Draft16).unwrap();
+		buf.extend_from_slice(&body);
+
+		let mut bytes = buf.freeze();
+		let decoded = SubscribeOk::decode(&mut bytes, Version::Draft16).unwrap();
+		assert_eq!(decoded.track_alias, 42);
 		assert_eq!(decoded.properties.group_order, Some(GroupOrder::Descending));
 	}
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1145,7 +1145,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			ietf::SubscribeOk::ID => {
 				let msg = ietf::SubscribeOk::decode_msg(&mut data, self.version)?;
 				tracing::debug!(message = ?msg, "received subscribe ok");
-				Ok(Some((msg.track_alias, msg.timescale)))
+				Ok(Some((msg.track_alias, msg.properties.timescale)))
 			}
 			ietf::SubscribeError::ID if self.version == Version::Draft14 => {
 				let msg = ietf::SubscribeError::decode_msg(&mut data, self.version)?;
@@ -2307,10 +2307,9 @@ mod tests {
 			track_namespace: crate::Path::new("room/host"),
 			track_name: "video".into(),
 			track_alias: 7,
-			group_order: ietf::GroupOrder::Ascending,
 			largest_location: None,
 			forward: true,
-			timescale: None,
+			properties: ietf::Properties::default(),
 		};
 
 		// Errors are surfaced to the peer on the stream, not raised as a session error.


### PR DESCRIPTION
## Summary

- The [moq-interop-runner](https://github.com/englishm/moq-interop-runner) caught moq5 closing our session with `PROTOCOL_VIOLATION` on SUBSCRIBE_OK. Root cause: we encoded `GROUP_ORDER` (0x22) in the SUBSCRIBE_OK message-parameter block, but draft-18 §10.2.8 scopes that parameter to SUBSCRIBE, PUBLISH_OK, and FETCH, and §10.2 makes an out-of-scope message parameter a MUST-close. It is fatal, not ignorable.
- Draft-16 moved the publisher's preference to the `DEFAULT_PUBLISHER_GROUP_ORDER` **track property**, which reuses the number 0x22 in a *separate* registry (unknown properties are skipped, not fatal). Descending is intentional here (we serve the newest group first, matching moq-lite), so it moves to the property rather than being dropped.
- Auditing the sibling encoders found the same bug twice more: PUBLISH also sent the parameter (illegal in draft-16+), and FETCH_OK sent it despite it never being legal there outside draft-14, where it is a fixed field. A fetch response is ordered by whatever the FETCH asked for.
- Per-version behavior now: draft-14 keeps its fixed field, draft-15 keeps the parameter (the last version where it is legal in SUBSCRIBE_OK/PUBLISH), draft-17+ sends the track property.
- Decoders still *accept* the parameter on purpose. Our own deployed peers send it, and tearing down a session over a hint we ignore anyway would be a worse regression than the leniency.
- `js/net` had the identical bug in `SubscribeOk` and `Publish`; mirrored per the cross-package sync table. Byte-exact tests on both sides pin the same wire output.
- Audited the remaining `encode_params!` call sites against the draft-18 parameter scopes: SUBSCRIBE, PUBLISH_OK, FETCH, and REQUEST_UPDATE only carry parameters the draft scopes to them.

### Review follow-ups (second commit)

- **Draft-16 reads the block now.** Draft-16 carries the same trailing block under the name Track Extensions, and we were failing any message that had one as `Long`, which is a fault on valid input. Writing it stays draft-17+: a draft-16 peer on an older build of this crate rejects trailing bytes it doesn't parse, and draft-16 never registered TIMESCALE (0x08) in its Extension Headers table.
- **An undefined group order is rejected.** The property defines only Ascending and Descending, so `0x0` is malformed rather than the "publisher decides" it means in the draft-14 fixed fields. Both decoders mapped it to Descending; in JS it was then re-emitted as a fixed field or parameter, which a strict peer answers with `PROTOCOL_VIOLATION`.

## Public API changes

None. `moq_net::ietf` is a private module, and `js/net`'s `ietf/` is not exported from the package entrypoint. `Properties` (Rust struct / TS interface) replaces the timescale-only `properties::{encode,decode}` helpers, and `SubscribeOk`/`Publish` now hold a `properties` field instead of separate `timescale`/`group_order` fields, all internal.

## Known gap

We still don't *write* the group-order property on draft-16, for the interop reason above, so a draft-16 peer sees no preference and defaults to Ascending. Reading it works, so this is one-directional and only on the version below the one that renamed the block.

## Test plan

- `just fix` + `just check` (Rust + JS) pass.
- `cargo nextest run -p moq-net`: 692 passed, including tests for the property round-trip, the draft-15 parameter form, the draft-18 property form, decode-side leniency, draft-16 Track Extensions, and the rejected zero.
- `bun test src/ietf` in `js/net`: 90 passed, with byte-exact assertions matching the Rust encoder. Both new JS tests were mutation-checked (they fail when the guard is reverted).
- Not run: the interop runner itself, which is where this needs its real confirmation.

(Written by Opus 5)