### PR TITLE
fix(moq-mux): make the synthesized fMP4 init playable on strict players

### DIFF
--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -508,6 +508,12 @@ pub(crate) fn extract_init(
 					// browser applying an empty-edit media_time would shift the track
 					// off the others (a black screen in Media Source Extensions).
 					trak.edts = None;
+					// tkhd.duration is in the *movie* timescale, and the merged moov
+					// picks its own (the first trak's media scale), so whatever the
+					// source stated is now read at a scale it wasn't written in. A
+					// merged multi-track moov can't hold one scale that suits every
+					// source anyway, so declare it unknown like the rest of the init.
+					trak.tkhd.duration = super::UNKNOWN_DURATION;
 					traks.push(trak);
 				}
 				if let Some(mvex) = moov.mvex {
@@ -921,5 +927,49 @@ mod tests {
 
 		assert_eq!(traks.len(), 1);
 		assert!(traks[0].edts.is_none(), "CMAF init must not carry an edit list");
+	}
+
+	// tkhd.duration is in the movie timescale, which the merged moov replaces with its own. A
+	// duration carried over from the source is then read at a scale it wasn't written in: a 30
+	// second track authored at a 1 kHz movie scale reads as 0.625s once the moov says 48 kHz.
+	#[test]
+	fn extract_init_clears_a_stale_track_duration() {
+		use mp4_atom::Encode;
+
+		let moov = mp4_atom::Moov {
+			mvhd: mp4_atom::Mvhd {
+				timescale: 1_000,
+				..Default::default()
+			},
+			trak: vec![mp4_atom::Trak {
+				tkhd: mp4_atom::Tkhd {
+					duration: 30_000, // 30s at the source's 1 kHz movie scale
+					..Default::default()
+				},
+				mdia: mp4_atom::Mdia {
+					mdhd: mp4_atom::Mdhd {
+						timescale: 48_000,
+						..Default::default()
+					},
+					..Default::default()
+				},
+				..Default::default()
+			}],
+			..Default::default()
+		};
+		let mut init = Vec::new();
+		moov.encode(&mut init).unwrap();
+
+		let mut traks = Vec::new();
+		let mut trexs = Vec::new();
+		let mut ftyp = None;
+		extract_init(&Bytes::from(init), 1, &mut ftyp, &mut traks, &mut trexs).unwrap();
+
+		assert_eq!(traks.len(), 1);
+		assert_eq!(
+			traks[0].tkhd.duration,
+			u64::MAX,
+			"a live fragmented init declares an unknown duration"
+		);
 	}
 }

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use hang::catalog::{AudioCodec, Catalog, Container, VideoConfig};
-use mp4_atom::{DecodeMaybe, Encode};
+use mp4_atom::DecodeMaybe;
 
 use crate::Result;
 use crate::catalog::Stream;
@@ -473,34 +473,7 @@ impl<S: Stream> Export<S> {
 			}
 		}
 
-		let ftyp = ftyp_data.unwrap_or(mp4_atom::Ftyp {
-			major_brand: b"isom".into(),
-			minor_version: 0x200,
-			compatible_brands: vec![b"isom".into(), b"iso6".into(), b"mp41".into()],
-		});
-		let timescale = traks.first().map(|t| t.mdia.mdhd.timescale).unwrap_or(1000);
-
-		let moov = mp4_atom::Moov {
-			mvhd: mp4_atom::Mvhd {
-				timescale,
-				..Default::default()
-			},
-			trak: traks,
-			mvex: if trexs.is_empty() {
-				None
-			} else {
-				Some(mp4_atom::Mvex {
-					trex: trexs,
-					..Default::default()
-				})
-			},
-			..Default::default()
-		};
-
-		let mut buf = Vec::new();
-		ftyp.encode(&mut buf)?;
-		moov.encode(&mut buf)?;
-		Ok(Bytes::from(buf))
+		Ok(crate::container::fmp4::encode_init(ftyp_data, traks, trexs)?)
 	}
 }
 

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -545,9 +545,12 @@ pub(crate) fn synthesize_audio_trak(track_id: u32, timescale: u64, config: &Audi
 			// zeros: they endOfStream("decode") on the *init* append, which leaves the
 			// ManagedMediaSource ended and every later audio and video append failing. The
 			// catalog bitrate is optional and real publishers omit it, so fall back to the
-			// AAC-LC values ffmpeg and the iTunes encoders write.
-			let (max_bitrate, avg_bitrate) = match config.bitrate {
-				Some(bitrate) => (bitrate as u32, bitrate as u32),
+			// AAC-LC values ffmpeg and the iTunes encoders write. A zero or wider-than-u32
+			// bitrate takes the fallback as well, since writing it back would rebuild the
+			// all-zero descriptor this exists to avoid.
+			let bitrate = config.bitrate.and_then(|b| u32::try_from(b).ok()).filter(|b| *b > 0);
+			let (max_bitrate, avg_bitrate) = match bitrate {
+				Some(bitrate) => (bitrate, bitrate),
 				None => (256_000, 128_000),
 			};
 			mp4_atom::Codec::from(mp4_atom::Mp4a {
@@ -624,6 +627,9 @@ fn build_video_trak(
 		tkhd: mp4_atom::Tkhd {
 			track_id,
 			enabled: true,
+			// track_in_movie. A player is entitled to skip a track the presentation doesn't
+			// claim, and the flags field is 0x000001 rather than 0x000003 without it.
+			in_movie: true,
 			duration: UNKNOWN_DURATION,
 			width: mp4_atom::FixedPoint::from(width),
 			height: mp4_atom::FixedPoint::from(height),
@@ -639,7 +645,11 @@ fn build_audio_trak(track_id: u32, timescale: u32, sample_entry: mp4_atom::Codec
 		tkhd: mp4_atom::Tkhd {
 			track_id,
 			enabled: true,
+			in_movie: true,
 			duration: UNKNOWN_DURATION,
+			// Full volume (8.8 fixed point). The default is 0, which is a muted track, and
+			// only an audio track carries a meaningful value.
+			volume: mp4_atom::FixedPoint::from(1),
 			..Default::default()
 		},
 		mdia: build_mdia(timescale, b"soun", false, sample_entry),
@@ -665,11 +675,18 @@ pub(crate) fn encode_init(
 		compatible_brands: vec![b"isom".into(), b"iso6".into(), b"mp41".into()],
 	});
 	let timescale = traks.first().map(|t| t.mdia.mdhd.timescale).unwrap_or(1000);
+	let next_track_id = traks.iter().map(|t| t.tkhd.track_id).max().unwrap_or(0) + 1;
 
 	let moov = mp4_atom::Moov {
 		mvhd: mp4_atom::Mvhd {
 			timescale,
 			duration: UNKNOWN_DURATION,
+			// Normal playback rate and full volume (16.16 and 8.8 fixed point). Both default
+			// to 0, which declares a stopped, muted presentation.
+			rate: mp4_atom::FixedPoint::from(1),
+			volume: mp4_atom::FixedPoint::from(1),
+			// The next id a track could take, so it must be past every one already present.
+			next_track_id,
 			..Default::default()
 		},
 		trak: traks,
@@ -729,6 +746,7 @@ fn build_mdia(timescale: u32, handler: &[u8; 4], is_video: bool, sample_entry: m
 /// Used by the fMP4 exporter when synthesizing an init segment for a
 /// Legacy or LOC source: prefer `framerate * 1000` (so each frame has an
 /// integer duration), falling back to 90 kHz (the MPEG-TS convention).
+///
 pub(crate) fn default_video_timescale(config: &VideoConfig) -> u64 {
 	if let Some(fps) = config.framerate {
 		(fps * 1000.0) as u64
@@ -753,6 +771,20 @@ mod tests {
 		config
 	}
 
+	/// The moov an encoded init segment carries, so a test asserts on what a player parses
+	/// rather than on the struct that went in.
+	fn moov(init: &Bytes) -> mp4_atom::Moov {
+		use mp4_atom::DecodeMaybe;
+
+		let mut cursor = std::io::Cursor::new(init.as_ref());
+		while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).unwrap() {
+			if let mp4_atom::Any::Moov(moov) = atom {
+				return moov;
+			}
+		}
+		panic!("no moov");
+	}
+
 	fn dec_config(trak: &mp4_atom::Trak) -> mp4_atom::esds::DecoderConfig {
 		match &trak.mdia.minf.stbl.stsd.codecs[0] {
 			mp4_atom::Codec::Mp4a(mp4a) => mp4a.esds.es_desc.dec_config,
@@ -773,27 +805,59 @@ mod tests {
 		let stated = dec_config(&synthesize_audio_trak(1, 44_100, &aac_config(Some(96_000))).unwrap());
 		assert_eq!(stated.max_bitrate, 96_000, "the catalog's bitrate wins");
 		assert_eq!(stated.avg_bitrate, 96_000);
+
+		// A stated bitrate the field can't carry rebuilds the same all-zero descriptor, so it
+		// takes the fallback rather than the catalog.
+		for unusable in [Some(0), Some(u64::from(u32::MAX) + 1)] {
+			let config = dec_config(&synthesize_audio_trak(1, 44_100, &aac_config(unusable)).unwrap());
+			assert_eq!(config.max_bitrate, inferred.max_bitrate, "{unusable:?}");
+			assert_eq!(config.avg_bitrate, inferred.avg_bitrate, "{unusable:?}");
+		}
 	}
 
 	// A live fragmented stream's duration isn't known up front. Zero reads as an empty file to a
 	// strict parser: VLC refuses to play one.
 	#[test]
 	fn synthesized_init_declares_unknown_duration() {
-		use mp4_atom::DecodeMaybe;
-
 		let trak = synthesize_audio_trak(1, 44_100, &aac_config(None)).unwrap();
 		assert_eq!(trak.tkhd.duration, u64::MAX);
 
 		let init = encode_init(None, vec![trak], Vec::new()).unwrap();
-		let mut cursor = std::io::Cursor::new(init.as_ref());
-		while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).unwrap() {
-			if let mp4_atom::Any::Moov(moov) = atom {
-				assert_eq!(moov.mvhd.duration, u64::MAX);
-				assert_eq!(moov.trak[0].tkhd.duration, u64::MAX);
-				return;
-			}
-		}
-		panic!("no moov");
+		let moov = moov(&init);
+		assert_eq!(moov.mvhd.duration, u64::MAX);
+		assert_eq!(moov.trak[0].tkhd.duration, u64::MAX);
+	}
+
+	// The header defaults are all the "off" value: a track the presentation doesn't claim, a
+	// stopped playback rate, a muted volume, and a next id that collides with the track already
+	// there. A strict player is entitled to act on any of them.
+	#[test]
+	fn synthesized_init_headers_describe_a_playable_presentation() {
+		let audio = synthesize_audio_trak(1, 44_100, &aac_config(None)).unwrap();
+		let init = encode_init(None, vec![audio], Vec::new()).unwrap();
+		let moov = moov(&init);
+
+		assert_eq!(moov.mvhd.rate.integer(), 1, "normal playback rate");
+		assert_eq!(moov.mvhd.volume.integer(), 1, "full volume");
+		assert_eq!(moov.mvhd.next_track_id, 2, "past the only track id");
+
+		let tkhd = &moov.trak[0].tkhd;
+		assert!(tkhd.enabled && tkhd.in_movie, "flags 0x000003");
+		assert_eq!(tkhd.volume.integer(), 1, "an audio track carries the volume");
+	}
+
+	// A video track's volume stays 0: the field only means something for audio.
+	#[test]
+	fn synthesized_video_init_sets_the_track_flags() {
+		let mut config = VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		config.framerate = Some(30.0);
+		let video = synthesize_video_trak(1, 30_000, &config, None).unwrap();
+		let init = encode_init(None, vec![video], Vec::new()).unwrap();
+		let moov = moov(&init);
+
+		let tkhd = &moov.trak[0].tkhd;
+		assert!(tkhd.enabled && tkhd.in_movie, "flags 0x000003");
+		assert_eq!(tkhd.volume.integer(), 0);
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -747,11 +747,20 @@ fn build_mdia(timescale: u32, handler: &[u8; 4], is_video: bool, sample_entry: m
 /// Legacy or LOC source: prefer `framerate * 1000` (so each frame has an
 /// integer duration), falling back to 90 kHz (the MPEG-TS convention).
 ///
+/// A framerate that scales to less than one tick takes the fallback too: zero and negative land
+/// on 0 through `as u64`, which is not a timescale anything accepts, and a non-finite one is
+/// filtered out before the cast, since infinity would saturate to `u64::MAX`, past the varint
+/// range a `Timescale` holds. A fractional tick count truncates rather than falling back, so
+/// 30.0005 fps gives 30000; the common broadcast rates (29.97, 59.94, 23.976) all land on a whole
+/// tick already.
 pub(crate) fn default_video_timescale(config: &VideoConfig) -> u64 {
-	if let Some(fps) = config.framerate {
-		(fps * 1000.0) as u64
-	} else {
-		90000
+	let ticks = config
+		.framerate
+		.filter(|fps| fps.is_finite())
+		.map(|fps| (fps * 1000.0) as u64);
+	match ticks {
+		Some(ticks) if ticks > 0 => ticks,
+		_ => 90000,
 	}
 }
 
@@ -813,6 +822,20 @@ mod tests {
 			assert_eq!(config.max_bitrate, inferred.max_bitrate, "{unusable:?}");
 			assert_eq!(config.avg_bitrate, inferred.avg_bitrate, "{unusable:?}");
 		}
+	}
+
+	// `framerate * 1000` is 0 for a zero, negative or non-finite catalog framerate, and 0 is not
+	// a timescale: Timescale::new rejects it, so Muxer::video would fail to build at all.
+	#[test]
+	fn default_video_timescale_ignores_an_unusable_framerate() {
+		let mut config = VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		for unusable in [0.0, -30.0, f64::NAN, f64::INFINITY, 0.0005] {
+			config.framerate = Some(unusable);
+			assert_eq!(default_video_timescale(&config), 90_000, "{unusable}");
+		}
+
+		config.framerate = Some(30.0);
+		assert_eq!(default_video_timescale(&config), 30_000);
 	}
 
 	// A live fragmented stream's duration isn't known up front. Zero reads as an empty file to a

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -139,6 +139,11 @@ pub enum Error {
 
 	#[error("multi-sample fragment has a non-final sample with no duration; DTS is unrecoverable")]
 	MissingSampleDuration,
+
+	/// `mdhd.timescale` is a 32-bit field, so a larger scale would reach the init segment
+	/// truncated while the fragments kept the full value, putting them on different timelines.
+	#[error("timescale {0} does not fit the 32-bit mdhd field")]
+	TimescaleTooLarge(u64),
 }
 
 impl From<mp4_atom::Error> for Error {
@@ -484,7 +489,13 @@ pub(crate) fn synthesize_video_trak(
 		other => return Err(Error::UnsupportedSynthesis(format!("video codec {:?}", other))),
 	};
 
-	Ok(build_video_trak(track_id, timescale, sample_entry, width, height))
+	Ok(build_video_trak(
+		track_id,
+		mdhd_timescale(timescale)?,
+		sample_entry,
+		width,
+		height,
+	))
 }
 
 /// Synthesize a CMAF `Trak` for an audio rendition that has no init segment.
@@ -594,7 +605,7 @@ pub(crate) fn synthesize_audio_trak(track_id: u32, timescale: u64, config: &Audi
 		other => return Err(Error::UnsupportedSynthesis(format!("audio codec {:?}", other))),
 	};
 
-	Ok(build_audio_trak(track_id, timescale, sample_entry))
+	Ok(build_audio_trak(track_id, mdhd_timescale(timescale)?, sample_entry))
 }
 
 /// All-ones: the ISO/IEC 14496-12 spelling of "duration not known up front", which is always
@@ -604,7 +615,7 @@ const UNKNOWN_DURATION: u64 = u64::MAX;
 
 fn build_video_trak(
 	track_id: u32,
-	timescale: u64,
+	timescale: u32,
 	sample_entry: mp4_atom::Codec,
 	width: u16,
 	height: u16,
@@ -623,7 +634,7 @@ fn build_video_trak(
 	}
 }
 
-fn build_audio_trak(track_id: u32, timescale: u64, sample_entry: mp4_atom::Codec) -> mp4_atom::Trak {
+fn build_audio_trak(track_id: u32, timescale: u32, sample_entry: mp4_atom::Codec) -> mp4_atom::Trak {
 	mp4_atom::Trak {
 		tkhd: mp4_atom::Tkhd {
 			track_id,
@@ -675,10 +686,19 @@ pub(crate) fn encode_init(
 	Ok(Bytes::from(buf))
 }
 
-fn build_mdia(timescale: u64, handler: &[u8; 4], is_video: bool, sample_entry: mp4_atom::Codec) -> mp4_atom::Mdia {
+/// Narrow a media timescale to the 32-bit `mdhd` field, rejecting what would truncate.
+///
+/// `moq_net::Timescale` permits the whole QUIC varint range, so a caller-supplied scale can be
+/// wider than the field. Truncating would put the init segment and the fragments on different
+/// timelines, silently, so refuse instead.
+fn mdhd_timescale(timescale: u64) -> Result<u32> {
+	u32::try_from(timescale).map_err(|_| Error::TimescaleTooLarge(timescale))
+}
+
+fn build_mdia(timescale: u32, handler: &[u8; 4], is_video: bool, sample_entry: mp4_atom::Codec) -> mp4_atom::Mdia {
 	mp4_atom::Mdia {
 		mdhd: mp4_atom::Mdhd {
-			timescale: timescale as u32,
+			timescale,
 			..Default::default()
 		},
 		hdlr: mp4_atom::Hdlr {

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -660,8 +660,9 @@ fn build_audio_trak(track_id: u32, timescale: u32, sample_entry: mp4_atom::Codec
 /// Assemble a fragmented init segment (ftyp + moov) around already-built traks.
 ///
 /// `ftyp` is the one a passed-through CMAF init carried, if any; otherwise a plain `isom` one
-/// is synthesized. A `Cmaf` rendition's `tkhd` is left exactly as its publisher wrote it, but
-/// the `mvhd` is ours either way, so it declares the unknown duration a fragmented stream has.
+/// is synthesized. The `mvhd` is ours either way, so it declares the unknown duration and the
+/// movie timescale of the assembled init rather than of whatever source a trak came from.
+/// [`extract_init`] normalizes a passed-through trak to match.
 pub(crate) fn encode_init(
 	ftyp: Option<mp4_atom::Ftyp>,
 	traks: Vec<mp4_atom::Trak>,

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -530,7 +530,15 @@ pub(crate) fn synthesize_audio_trak(track_id: u32, timescale: u64, config: &Audi
 			let mut cursor = std::io::Cursor::new(description.as_ref());
 			let dec_specific = mp4_atom::esds::DecoderSpecific::decode(&mut cursor)?;
 
-			let bitrate = config.bitrate.unwrap_or(0) as u32;
+			// Safari and AVFoundation reject an AAC track whose DecoderConfigDescriptor is all
+			// zeros: they endOfStream("decode") on the *init* append, which leaves the
+			// ManagedMediaSource ended and every later audio and video append failing. The
+			// catalog bitrate is optional and real publishers omit it, so fall back to the
+			// AAC-LC values ffmpeg and the iTunes encoders write.
+			let (max_bitrate, avg_bitrate) = match config.bitrate {
+				Some(bitrate) => (bitrate as u32, bitrate as u32),
+				None => (256_000, 128_000),
+			};
 			mp4_atom::Codec::from(mp4_atom::Mp4a {
 				audio,
 				esds: mp4_atom::Esds {
@@ -541,9 +549,10 @@ pub(crate) fn synthesize_audio_trak(track_id: u32, timescale: u64, config: &Audi
 							object_type_indication: 0x40, // MPEG-4 AAC
 							stream_type: 0x05,            // audio
 							up_stream: 0,
-							buffer_size_db: Default::default(),
-							max_bitrate: bitrate,
-							avg_bitrate: bitrate,
+							// 24 KiB, the decoder buffer those same encoders declare.
+							buffer_size_db: mp4_atom::u24::from([0x00, 0x60, 0x00]),
+							max_bitrate,
+							avg_bitrate,
 							dec_specific,
 						},
 						sl_config: Default::default(),
@@ -588,6 +597,11 @@ pub(crate) fn synthesize_audio_trak(track_id: u32, timescale: u64, config: &Audi
 	Ok(build_audio_trak(track_id, timescale, sample_entry))
 }
 
+/// All-ones: the ISO/IEC 14496-12 spelling of "duration not known up front", which is always
+/// the case for the live fragmented streams synthesized here. Zero reads as an empty file to a
+/// strict parser, and VLC refuses to play one.
+const UNKNOWN_DURATION: u64 = u64::MAX;
+
 fn build_video_trak(
 	track_id: u32,
 	timescale: u64,
@@ -599,6 +613,7 @@ fn build_video_trak(
 		tkhd: mp4_atom::Tkhd {
 			track_id,
 			enabled: true,
+			duration: UNKNOWN_DURATION,
 			width: mp4_atom::FixedPoint::from(width),
 			height: mp4_atom::FixedPoint::from(height),
 			..Default::default()
@@ -613,11 +628,51 @@ fn build_audio_trak(track_id: u32, timescale: u64, sample_entry: mp4_atom::Codec
 		tkhd: mp4_atom::Tkhd {
 			track_id,
 			enabled: true,
+			duration: UNKNOWN_DURATION,
 			..Default::default()
 		},
 		mdia: build_mdia(timescale, b"soun", false, sample_entry),
 		..Default::default()
 	}
+}
+
+/// Assemble a fragmented init segment (ftyp + moov) around already-built traks.
+///
+/// `ftyp` is the one a passed-through CMAF init carried, if any; otherwise a plain `isom` one
+/// is synthesized. A `Cmaf` rendition's `tkhd` is left exactly as its publisher wrote it, but
+/// the `mvhd` is ours either way, so it declares the unknown duration a fragmented stream has.
+pub(crate) fn encode_init(
+	ftyp: Option<mp4_atom::Ftyp>,
+	traks: Vec<mp4_atom::Trak>,
+	trexs: Vec<mp4_atom::Trex>,
+) -> Result<Bytes> {
+	use mp4_atom::Encode;
+
+	let ftyp = ftyp.unwrap_or(mp4_atom::Ftyp {
+		major_brand: b"isom".into(),
+		minor_version: 0x200,
+		compatible_brands: vec![b"isom".into(), b"iso6".into(), b"mp41".into()],
+	});
+	let timescale = traks.first().map(|t| t.mdia.mdhd.timescale).unwrap_or(1000);
+
+	let moov = mp4_atom::Moov {
+		mvhd: mp4_atom::Mvhd {
+			timescale,
+			duration: UNKNOWN_DURATION,
+			..Default::default()
+		},
+		trak: traks,
+		mvex: (!trexs.is_empty()).then(|| mp4_atom::Mvex {
+			trex: trexs,
+			..Default::default()
+		}),
+		..Default::default()
+	};
+
+	let mut buf = Vec::new();
+	ftyp.encode(&mut buf)?;
+	moov.encode(&mut buf)?;
+	Ok(Bytes::from(buf))
 }
 
 fn build_mdia(timescale: u64, handler: &[u8; 4], is_video: bool, sample_entry: mp4_atom::Codec) -> mp4_atom::Mdia {
@@ -668,6 +723,57 @@ mod tests {
 
 	fn ts(micros: u64) -> Timestamp {
 		Timestamp::from_micros(micros).unwrap()
+	}
+
+	// An AAC-LC / 44.1 kHz / stereo AudioSpecificConfig, the catalog `description` shape.
+	fn aac_config(bitrate: Option<u64>) -> AudioConfig {
+		let mut config = AudioConfig::new(AudioCodec::AAC(hang::catalog::AAC { profile: 2 }), 44_100, 2);
+		config.description = Some(Bytes::from_static(&[0x12, 0x10]));
+		config.bitrate = bitrate;
+		config
+	}
+
+	fn dec_config(trak: &mp4_atom::Trak) -> mp4_atom::esds::DecoderConfig {
+		match &trak.mdia.minf.stbl.stsd.codecs[0] {
+			mp4_atom::Codec::Mp4a(mp4a) => mp4a.esds.es_desc.dec_config,
+			other => panic!("expected mp4a, got {other:?}"),
+		}
+	}
+
+	// Safari and AVFoundation reject an all-zero DecoderConfigDescriptor on the *init* append,
+	// which ends the ManagedMediaSource and fails every append after it. The catalog bitrate is
+	// optional and real publishers omit it, so a synthesized esds must not lean on it.
+	#[test]
+	fn synthesized_aac_init_has_non_zero_bitrates() {
+		let inferred = dec_config(&synthesize_audio_trak(1, 44_100, &aac_config(None)).unwrap());
+		assert_ne!(u32::from(inferred.buffer_size_db), 0);
+		assert_ne!(inferred.max_bitrate, 0);
+		assert_ne!(inferred.avg_bitrate, 0);
+
+		let stated = dec_config(&synthesize_audio_trak(1, 44_100, &aac_config(Some(96_000))).unwrap());
+		assert_eq!(stated.max_bitrate, 96_000, "the catalog's bitrate wins");
+		assert_eq!(stated.avg_bitrate, 96_000);
+	}
+
+	// A live fragmented stream's duration isn't known up front. Zero reads as an empty file to a
+	// strict parser: VLC refuses to play one.
+	#[test]
+	fn synthesized_init_declares_unknown_duration() {
+		use mp4_atom::DecodeMaybe;
+
+		let trak = synthesize_audio_trak(1, 44_100, &aac_config(None)).unwrap();
+		assert_eq!(trak.tkhd.duration, u64::MAX);
+
+		let init = encode_init(None, vec![trak], Vec::new()).unwrap();
+		let mut cursor = std::io::Cursor::new(init.as_ref());
+		while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).unwrap() {
+			if let mp4_atom::Any::Moov(moov) = atom {
+				assert_eq!(moov.mvhd.duration, u64::MAX);
+				assert_eq!(moov.trak[0].tkhd.duration, u64::MAX);
+				return;
+			}
+		}
+		panic!("no moov");
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use hang::catalog::{AudioConfig, Container as CatalogContainer, VideoConfig};
-use mp4_atom::Encode;
 
 use crate::catalog::hang::Container as HangContainer;
 use crate::container::Frame;
@@ -171,34 +170,7 @@ impl Muxer {
 			CatalogContainer::Unknown(unknown) => return Err(crate::Error::unsupported_container(unknown)),
 		}
 
-		let ftyp = ftyp.unwrap_or(mp4_atom::Ftyp {
-			major_brand: b"isom".into(),
-			minor_version: 0x200,
-			compatible_brands: vec![b"isom".into(), b"iso6".into(), b"mp41".into()],
-		});
-		let timescale = traks.first().map(|t| t.mdia.mdhd.timescale).unwrap_or(1000);
-
-		let moov = mp4_atom::Moov {
-			mvhd: mp4_atom::Mvhd {
-				timescale,
-				..Default::default()
-			},
-			trak: traks,
-			mvex: if trexs.is_empty() {
-				None
-			} else {
-				Some(mp4_atom::Mvex {
-					trex: trexs,
-					..Default::default()
-				})
-			},
-			..Default::default()
-		};
-
-		let mut buf = Vec::new();
-		ftyp.encode(&mut buf).map_err(Error::from)?;
-		moov.encode(&mut buf).map_err(Error::from)?;
-		Ok(Some(Bytes::from(buf)))
+		Ok(Some(super::encode_init(ftyp, traks, trexs)?))
 	}
 
 	/// Encode frames as one moof+mdat fragment.

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -310,4 +310,18 @@ mod tests {
 		let first = decoded[0].duration.unwrap().as_micros();
 		assert_eq!(first, 20_000, "the pause is a discontinuity, not a 2405 second sample");
 	}
+
+	// mdhd.timescale is a 32-bit field, but the video timescale is `framerate * 1000`, so an
+	// absurd catalog framerate overflows it. Truncating would leave the init and the fragments
+	// on different timelines with no error.
+	#[test]
+	fn init_rejects_a_catalog_scale_too_large_for_mdhd() {
+		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.framerate = Some(5_000_000.0); // 5e9 ticks, past u32::MAX
+		let err = Muxer::video(&config).unwrap().init().unwrap_err();
+		assert!(
+			matches!(err, crate::Error::Cmaf(Error::TimescaleTooLarge(_))),
+			"got {err:?}"
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Five fixes to the CMAF init segment `moq-mux` synthesizes, split out of #2623 so they can land on their own. **Every commit here is authored by @zshenker**; this branch only cherry-picks them onto `main` and drops the parts that depend on that PR's new public API. The API half is #2680, stacked on this.

Each one is a case of a strict player rejecting an init that Chrome happens to tolerate, or of a catalog field we never validated reaching a fixed-width box.

## The fixes

**1. Unknown duration, and an AAC `esds` that isn't all zeros** (`17299e51d`)

- `mvhd.duration` and synthesized `tkhd.duration` were both `0`. These inits are always fragmented, whose duration isn't known up front, and ISO/IEC 14496-12 spells that as all-ones. A strict parser reads `0` as "empty file"; VLC refuses playback outright.
- A synthesized AAC `esds` took its bitrates from `AudioConfig::bitrate`, which is `Option` and which real publishers omit, leaving `buffer_size_db`, `max_bitrate` and `avg_bitrate` all zero. Safari and AVFoundation `endOfStream("decode")` on the **init** append for that, which puts `ManagedMediaSource` into `readyState: ended`, after which every subsequent audio *and* video append fails.

`Muxer::init` and `Export::build_init` assembled the same ftyp+moov by hand, so the shared part becomes `encode_init` and the fix lands once rather than twice.

**2. Reject a timescale that can't round-trip through `mdhd`** (`172c0dfa2`)

`mdhd.timescale` is 32-bit, but `moq_net::Timescale` spans the whole QUIC varint range and `build_mdia` narrowed with a silent `as u32`. A scale above `u32::MAX` reached the init truncated while the fragments kept the full value, putting them on different timelines with no error. Reachable today from the catalog alone: the video timescale is `framerate * 1000`, so a framerate of `5_000_000` overflows the field on its own.

The fix goes in at the truncation site: `build_mdia` and the two trak builders take a `u32` so the narrowing can't be expressed, and `synthesize_*_trak` do the checked conversion.

**3. Describe a playable presentation** (`a5d9e922f`)

The synthesized moov left every header field at its struct default, and each default is the "off" value:

- `tkhd` flags encoded as `0x000001`, without `track_in_movie`, so a player is entitled to skip a track the presentation never claims.
- The audio `tkhd` volume was 0, a muted track.
- `mvhd` rate was 0 ("stopped") and `mvhd` volume 0.
- `mvhd` `next_track_id` stayed at 1, colliding with the only trak's id.

Also takes the AAC bitrate fallback when the catalog states a bitrate the `esds` field cannot carry (zero, or past `u32::MAX` so it truncates to zero), which would otherwise rebuild the all-zero descriptor fix 1 exists to prevent.

**4. Fall back when a catalog framerate can't derive a timescale** (`21b6751ad`)

The video timescale is `framerate * 1000` cast through `as u64`. A zero or negative catalog framerate lands on 0, which `Timescale::new` rejects, so `Muxer::video` failed to build a muxer for a rendition that only misstates its framerate. Infinity is worse: it saturates to `u64::MAX`, past the varint range. Takes the 90 kHz fallback for any framerate that doesn't scale to a whole tick, matching what the constructor already does one line away.

**5. Clear a stale track duration on a CMAF passthrough** (`c7532e411`)

`tkhd.duration` is expressed in the *movie* timescale, and `encode_init` sets `mvhd.timescale` to the first trak's media scale, discarding whatever movie timescale the source authored against. A duration carried over from the source is then read at a scale it was never written in: 30 seconds stated at a 1 kHz movie scale reads as 0.625s once the merged moov says 48 kHz. The multi-track exporter makes this structural, since no single `mvhd.timescale` can suit durations authored against several sources.

## On `duration = u64::MAX` and browser liveness

Worth recording, because the obvious worry is that all-ones breaks the live signal browsers key on. It doesn't. Chromium's `MP4StreamParser::ParseMoov` resolves the duration in this order:

1. `mvex.mehd.fragment_duration`, if present.
2. Else `mvhd.duration`, **but only if it is non-zero and not all-ones** (`0xFFFFFFFF` for a v0 header, `0xFFFFFFFFFFFFFFFF` for v1).
3. Otherwise `kInfiniteDuration`, with `liveness = kLive`.

So `0` and all-ones are two spellings of the same "unknown", both landing on `kLive`. All-ones additionally satisfies VLC. We keep `mehd` absent, which is what 14496-12 asks for when the duration isn't known in advance, and which also keeps us out of branch 1 with a bogus value.

`mp4-atom` 0.14 encodes `mvhd` and `tkhd` as version 1 unconditionally, so `u64::MAX` is a genuine 64-bit all-ones here rather than a truncated write. If `mp4-atom` ever picks v0 when the fields fit, the correct value becomes `u32::MAX` instead, and this should be revisited then.

## What is deliberately not here

The new public API from #2623 (`Muxer::timescale`, `Muxer::with_timescale`, per-frame fragmenting) and the `pub(crate)` `FragmentInfo` refactor that rode along with fix 2. Those are in #2680, stacked on this branch. Consequences:

- `Error::TimescaleTooLarge` is the only new public item, additive on an already-`#[non_exhaustive]` enum. `Error::TimescaleOverride` belongs to `with_timescale` and is not included.
- `encode_fragment` keeps its existing signature, so this merges into `dev` without touching the eight additional call sites `dev` has in `import_test.rs`.

## Behavioural change

Not visible to `cargo semver-checks`, so calling it out: **the init bytes change**, for `Export` as well as `Muxer`. Specifically for (a) an AAC rendition whose catalog states no usable bitrate, (b) every synthesized init via `mvhd`/`tkhd` duration and the header fields in fix 3, and (c) a passed-through CMAF init via `tkhd.duration`. All move toward spec conformance and away from a known Safari, VLC, or skipped-track failure.

## Test plan

- `cargo nextest run -p moq-mux -p moq-hls` — 504 passed, 0 failed.
- `cargo clippy -p moq-mux -p moq-hls --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

Regression tests, one per root cause, all from the original commits:

- `synthesized_aac_init_has_non_zero_bitrates`, including the zero and overflow cases.
- `synthesized_init_declares_unknown_duration`.
- `init_rejects_a_catalog_scale_too_large_for_mdhd`, covering the catalog path rather than the (excluded) setter.
- `default_video_timescale_ignores_an_unusable_framerate`.
- `extract_init_clears_a_stale_track_duration`.

Not run: `just rs macos` / `just rs windows` (no platform-gated code touched) and `just test smoke-full` (no wire, `moq-ffi`, or gateway change).

Heads up that `just check` currently fails on macOS for any branch touching `moq-mux`, on pre-existing dead-code in `moq-video`'s `probe.rs` whose consumers are cfg-gated off. It reproduces on an untouched `main`. Linux CI doesn't see it.

## Cross-Package Sync

No rows apply. Not a wire-format change: it alters neither the moq-lite/moq-transport framing nor the hang catalog/container format, so no draft under `drafts/` needs updating. `moq-mux` has no row in the table, and no CLI surface changed.

(written by Opus 5)
