### PR TITLE
feat(moq-mux)!: rename consumer latency methods

### DIFF
--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -79,7 +79,7 @@ async fn run_subscribe(consumer: moq_net::origin::Consumer) -> anyhow::Result<()
 		.subscribe(moq_net::track::Subscription::default().with_priority(1))
 		.await?;
 	let mut ordered = moq_mux::container::Consumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
-		.with_latency(Duration::from_millis(500));
+		.with_latency_max(Duration::from_millis(500));
 
 	// Read frames in latency-bounded presentation order.
 	while let Some(frame) = ordered.read().await? {

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -362,7 +362,7 @@ impl Consume {
 					.track(&name)?
 					.subscribe(moq_net::track::Subscription::default().with_priority(hang::catalog::PRIORITY.video))
 					.await?;
-				let track = moq_mux::container::Consumer::new(track, container).with_latency(latency);
+				let track = moq_mux::container::Consumer::new(track, container).with_latency_max(latency);
 				Self::run_track(on_frame, track, channel.1).await
 			}
 			.await;
@@ -411,7 +411,7 @@ impl Consume {
 					.track(&name)?
 					.subscribe(moq_net::track::Subscription::default().with_priority(hang::catalog::PRIORITY.audio))
 					.await?;
-				let track = moq_mux::container::Consumer::new(track, container).with_latency(latency);
+				let track = moq_mux::container::Consumer::new(track, container).with_latency_max(latency);
 				Self::run_track(on_frame, track, channel.1).await
 			}
 			.await;

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -54,7 +54,7 @@ impl Consumer {
 			.await?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = config.latency_max {
-			track = track.with_latency(latency);
+			track = track.with_latency_max(latency);
 		}
 
 		Ok(Self {

--- a/rs/moq-audio/src/decode/decoder.rs
+++ b/rs/moq-audio/src/decode/decoder.rs
@@ -35,7 +35,7 @@ pub struct Config {
 	pub channels: Option<u32>,
 	/// Upper bound on buffering before skipping a stalled group.
 	///
-	/// Forwarded to [`moq_mux::container::Consumer::with_latency`]: if a group is
+	/// Forwarded to [`moq_mux::container::Consumer::with_latency_max`]: if a group is
 	/// stuck and a newer group is more than this far ahead, the consumer skips.
 	/// `None` keeps the moq-mux default of zero, which skips aggressively. Set it
 	/// to the playout buffer you can tolerate (typically tens to a few hundred ms)

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -650,7 +650,7 @@ mod tests {
 	/// Read the first frame of a verbatim track back as raw bytes.
 	async fn read_frame(consumer: &moq_net::broadcast::Consumer, name: &str) -> Vec<u8> {
 		let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
-		let mut reader = Consumer::new(track, Container::Legacy).with_latency(Duration::ZERO);
+		let mut reader = Consumer::new(track, Container::Legacy).with_latency_max(Duration::ZERO);
 		let frame = tokio::time::timeout(Duration::from_secs(1), reader.read())
 			.await
 			.expect("verbatim read timed out")

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -268,7 +268,7 @@ impl MoqBroadcastConsumer {
 		let subscription = subscription.map(moq_net::track::Subscription::from).unwrap_or_default();
 		let latency = subscription.latency_max;
 		let track = self.inner.track(&name)?.subscribe(subscription).await?;
-		let consumer = moq_mux::container::Consumer::new(track, media).with_latency(latency);
+		let consumer = moq_mux::container::Consumer::new(track, media).with_latency_max(latency);
 		Ok(Arc::new(MoqMediaConsumer {
 			task: Task::new(Media { inner: consumer }),
 		}))

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -436,7 +436,8 @@ async fn reconcile(
 		.fetch_add(1, Ordering::Relaxed);
 
 		let track_subscriber = broadcast.track(&name)?.subscribe(None).await?;
-		let track = moq_mux::container::Consumer::new(track_subscriber, container).with_latency(Duration::from_secs(1));
+		let track =
+			moq_mux::container::Consumer::new(track_subscriber, container).with_latency_max(Duration::from_secs(1));
 
 		let descriptor = TrackDescriptor {
 			kind: d.kind,

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -29,8 +29,8 @@ use super::{Container, Frame};
 /// group's first timestamp has nothing left worth waiting for. Containers without a
 /// duration report zero, which disables this check and falls back to the latency budget.
 ///
-/// Set the latency with [`with_latency`](Self::with_latency) (builder) or
-/// [`set_latency`](Self::set_latency) (mid-stream).
+/// Set the latency ceiling with [`with_latency_max`](Self::with_latency_max) (builder) or
+/// [`set_latency_max`](Self::set_latency_max) (mid-stream).
 ///
 /// ## Timeline rewinds
 ///
@@ -55,7 +55,7 @@ pub struct Consumer<F: Container> {
 	startup: bool,
 
 	// The maximum buffer size before skipping a group.
-	latency: std::time::Duration,
+	latency_max: std::time::Duration,
 
 	// Timeline-rewind tracking: the live edge, the active boundary, and the discontinuity count.
 	rewind: Rewind,
@@ -128,7 +128,8 @@ impl Reset {
 impl<F: Container> Consumer<F> {
 	/// Create a Consumer wrapping the given moq-lite consumer, decoding `format`.
 	///
-	/// Skips aggressively by default; raise the tolerance with [`with_latency`](Self::with_latency).
+	/// Skips aggressively by default; raise the tolerance with
+	/// [`with_latency_max`](Self::with_latency_max).
 	pub fn new(track: moq_net::track::Subscriber, format: F) -> Self {
 		Self {
 			track,
@@ -136,7 +137,7 @@ impl<F: Container> Consumer<F> {
 			current: 0,
 			pending: VecDeque::new(),
 			startup: true,
-			latency: std::time::Duration::ZERO,
+			latency_max: std::time::Duration::ZERO,
 			rewind: Rewind::default(),
 		}
 	}
@@ -145,8 +146,8 @@ impl<F: Container> Consumer<F> {
 	///
 	/// Groups with timestamps older than the newest timestamp minus this value are skipped. Zero
 	/// (the default) skips aggressively: any group with a newer alternative is dropped.
-	pub fn with_latency(mut self, latency: std::time::Duration) -> Self {
-		self.latency = latency;
+	pub fn with_latency_max(mut self, latency_max: std::time::Duration) -> Self {
+		self.latency_max = latency_max;
 		self
 	}
 
@@ -299,7 +300,7 @@ impl<F: Container> Consumer<F> {
 					// the latency budget, or if the current group has already presented
 					// up to where the next group begins (duration coverage) so there's
 					// nothing left worth waiting for.
-					let over_latency = max_timestamp.saturating_sub(oldest) >= self.latency;
+					let over_latency = max_timestamp.saturating_sub(oldest) >= self.latency_max;
 					let covered = current_end.is_some_and(|end| end >= next_start);
 					over_latency || covered
 				} else {
@@ -476,8 +477,8 @@ impl<F: Container> Consumer<F> {
 	}
 
 	/// Set the maximum latency tolerance.
-	pub fn set_latency(&mut self, latency: std::time::Duration) {
-		self.latency = latency;
+	pub fn set_latency_max(&mut self, latency_max: std::time::Duration) {
+		self.latency_max = latency_max;
 	}
 }
 
@@ -764,7 +765,8 @@ mod tests {
 	async fn read_single_group() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
 		track.finish().unwrap();
@@ -782,7 +784,8 @@ mod tests {
 	async fn read_multiple_frames_single_group() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_000), ts(66_000)]);
 		track.finish().unwrap();
@@ -800,7 +803,8 @@ mod tests {
 	async fn read_multiple_groups_within_latency() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		// 5 groups, 20ms spacing. Total span = 80ms, well within 500ms latency.
 		for i in 0..5u64 {
@@ -819,7 +823,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
@@ -861,7 +866,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::ZERO);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::ZERO);
 
 		// Group 0 at ts 0 keeps timestamps monotonic with sequence (groups 1-9 follow at
 		// g*50 ms), so the test exercises latency skipping and not rewind detection.
@@ -900,7 +905,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
@@ -969,7 +975,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_secs(10));
 
 		// Old epoch, played forward until the live edge passes the rewind point.
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1008,7 +1014,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_secs(10));
 
 		// Old timeline, played to a live edge of 200 ms.
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1044,7 +1050,7 @@ mod tests {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		// Large latency so the slow-group skip never fires; isolate the rewind path.
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_secs(10));
 
 		// Publisher runs ahead: groups 0-4 at 0, 100, 200, 300, 400 ms.
 		for i in 0..5u64 {
@@ -1069,7 +1075,7 @@ mod tests {
 	async fn backwards_timestamp_always_resets() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
 		write_group(&mut track, 1, &[ts(500_000)]);
@@ -1104,7 +1110,8 @@ mod tests {
 	async fn empty_payload_is_skipped() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		let media = |timestamp| Frame {
@@ -1133,7 +1140,8 @@ mod tests {
 	async fn consecutive_markers_do_not_stall() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
@@ -1166,7 +1174,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
@@ -1202,7 +1211,8 @@ mod tests {
 	async fn adjacent_group_flushed_immediately() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
 		write_group(&mut track, 1, &[ts(30_000)]);
@@ -1220,7 +1230,8 @@ mod tests {
 	async fn bframes_within_group() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(66_000), ts(33_000)]);
 		track.finish().unwrap();
@@ -1239,7 +1250,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		track.finish().unwrap();
 
@@ -1257,7 +1269,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
 		track.abort(moq_net::Error::Cancel).unwrap();
@@ -1280,7 +1293,8 @@ mod tests {
 	async fn gap_in_group_sequence_recovery() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		write_group(&mut track, 0, &[ts(0), ts(20_000)]);
 		write_group(&mut track, 1, &[ts(40_000), ts(60_000)]);
@@ -1298,7 +1312,7 @@ mod tests {
 	async fn gap_at_start_of_sequence() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(80));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(80));
 
 		write_group(&mut track, 5, &[ts(0), ts(20_000)]);
 		write_group(&mut track, 7, &[ts(80_000), ts(100_000)]);
@@ -1321,7 +1335,8 @@ mod tests {
 	async fn evicted_group_with_gap_skips_to_live() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		// Group 0: a frame the consumer reads, positioning it there.
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
@@ -1364,7 +1379,8 @@ mod tests {
 	async fn missing_sequence_skips_on_live_track() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		// Group 0, then group 2 -- sequence 1 is missing (evicted) and never arrives.
 		// The track is NOT finished (live), the case that used to hang.
@@ -1463,7 +1479,8 @@ mod tests {
 	async fn frame_timestamp_and_index_decoding() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_333), ts(66_666)]);
 		track.finish().unwrap();
@@ -1483,7 +1500,8 @@ mod tests {
 	async fn frame_payload_preserved() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
 		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
@@ -1521,7 +1539,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_secs(10));
 
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
@@ -1567,7 +1585,7 @@ mod tests {
 	async fn large_timestamps() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(3700));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_secs(3700));
 
 		let one_hour = 3_600_000_000u64;
 		write_group(&mut track, 0, &[ts(one_hour)]);
@@ -1580,10 +1598,10 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn set_latency_changes_behavior() {
+	async fn set_latency_max_changes_behavior() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
 		track.finish().unwrap();
@@ -1591,7 +1609,7 @@ mod tests {
 		let frame = consumer.read().await.unwrap().unwrap();
 		assert_eq!(frame.timestamp, ts(0));
 
-		consumer.set_latency(Duration::from_millis(100));
+		consumer.set_latency_max(Duration::from_millis(100));
 
 		assert!(consumer.read().await.unwrap().is_none());
 	}
@@ -1603,7 +1621,8 @@ mod tests {
 		let consumer_track = track.subscribe(None);
 		// latency must exceed (group1_max - group0_min) = 100ms - 0ms = 100ms
 		// to avoid the latency skip and test B-frame timestamp tracking.
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(110));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(110));
 
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		for &timestamp in &[ts(0), ts(66_000), ts(33_000)] {
@@ -1653,7 +1672,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		write_group(&mut track, 3, &[ts(0)]);
 		write_group(&mut track, 5, &[ts(150_000)]);
@@ -1706,7 +1726,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		let _group5 = track.create_group(moq_net::group::Info { sequence: 5 }).unwrap();
 		write_group(&mut track, 7, &[ts(210_000)]);
@@ -1729,7 +1750,8 @@ mod tests {
 	async fn startup_single_group_mid_stream() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		write_group(&mut track, 100, &[ts(3_000_000)]);
 		track.finish().unwrap();
@@ -1743,7 +1765,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(50));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(50));
 
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
@@ -1779,7 +1801,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
@@ -1817,7 +1840,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		// Group 0: stalled at ts=0, NOT finished
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
@@ -1855,7 +1879,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(100));
 
 		// Group 0: finished normally
 		write_group(&mut track, 0, &[ts(0), ts(20_000)]);
@@ -1871,7 +1896,8 @@ mod tests {
 	async fn group_error_skips_to_next() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		let group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		group0.abort(moq_net::Error::Cancel).unwrap();
@@ -1888,7 +1914,8 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
 
@@ -1917,7 +1944,8 @@ mod tests {
 	async fn empty_group_advances() {
 		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		group0.finish().unwrap();
@@ -1937,7 +1965,8 @@ mod tests {
 
 		let mut track = track_producer("video", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency_max(Duration::from_millis(500));
 
 		// Write frames using Container::Legacy encoding
 		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
@@ -1980,7 +2009,7 @@ mod tests {
 		let mut track = track_producer("test", None);
 		let consumer_track = track.subscribe(None);
 		// Latency dwarfs the gap, so only duration coverage can trigger the skip.
-		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
+		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency_max(Duration::from_secs(10));
 
 		// Group 0: one frame at ts=0 lasting 33ms, never finished.
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
@@ -2020,7 +2049,7 @@ mod tests {
 		// DurationWire is untimed at the moq_net frame layer.
 		let mut track = track_producer("test", None);
 		let consumer_track = track.subscribe(None);
-		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
+		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency_max(Duration::from_secs(10));
 
 		// Group 0: frame at ts=0 lasting only 10ms, far short of group 1 at 33ms.
 		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -128,7 +128,7 @@ async fn import_emits_frames() {
 	// Decode the video track back through the Legacy container.
 	let track = consumer.track(&video_name).unwrap().subscribe(None).await.unwrap();
 	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
-		.with_latency(std::time::Duration::from_secs(1));
+		.with_latency_max(std::time::Duration::from_secs(1));
 	let frame = decoder.read().await.unwrap().expect("a video frame");
 	assert!(frame.keyframe);
 	// The payload is the length-prefixed NALU, carried through verbatim.
@@ -415,7 +415,7 @@ async fn import_enhanced_av1() {
 
 	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
-		.with_latency(std::time::Duration::from_secs(1));
+		.with_latency_max(std::time::Duration::from_secs(1));
 	let frame = decoder.read().await.unwrap().expect("an AV1 frame");
 	assert!(frame.keyframe);
 	assert_eq!(frame.payload.as_ref(), payload);
@@ -518,7 +518,7 @@ async fn import_reports_negative_pts_and_can_resume() {
 	let name = snap.video.renditions.keys().next().unwrap();
 	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
-		.with_latency(std::time::Duration::from_secs(1));
+		.with_latency_max(std::time::Duration::from_secs(1));
 	let frame = decoder.read().await.unwrap().expect("the good frame");
 	assert_eq!(frame.timestamp.as_millis(), 10);
 }
@@ -551,7 +551,7 @@ async fn import_enhanced_hvc1_applies_composition_time() {
 	let name = snap.video.renditions.keys().next().unwrap();
 	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
-		.with_latency(std::time::Duration::from_secs(1));
+		.with_latency_max(std::time::Duration::from_secs(1));
 	let frame = decoder.read().await.unwrap().expect("a video frame");
 	assert_eq!(frame.timestamp.as_millis(), 17);
 }

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -123,7 +123,7 @@ impl<S: Stream> Export<S> {
 
 	/// Set the maximum buffering latency for each per-track source.
 	///
-	/// See [`crate::container::Consumer::with_latency`] for the per-track skip behavior.
+	/// See [`crate::container::Consumer::with_latency_max`] for the per-track skip behavior.
 	/// Default is zero (skip aggressively).
 	pub fn with_latency(mut self, latency: Duration) -> Self {
 		self.latency = latency;

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -65,7 +65,7 @@ pub(crate) struct ExportSource {
 	state: SourceState,
 	/// Wire format, consumed when the subscription resolves into a consumer.
 	media: Option<HangContainer>,
-	latency: Duration,
+	latency_max: Duration,
 	transform: Option<VideoTransform>,
 	/// Resolved codec configuration record (avcC / hvcC / AudioSpecificConfig /
 	/// OpusHead). Some once the codec config is available — from the catalog
@@ -79,7 +79,7 @@ impl ExportSource {
 		source: &crate::Source,
 		name: &str,
 		config: &VideoConfig,
-		latency: Duration,
+		latency_max: Duration,
 	) -> Result<Self, crate::Error> {
 		let media: HangContainer = (&config.container).try_into()?;
 		let transform = build_video_transform(config);
@@ -88,7 +88,7 @@ impl ExportSource {
 		Ok(Self {
 			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
 			media: Some(media),
-			latency,
+			latency_max,
 			transform,
 			description,
 		})
@@ -102,7 +102,7 @@ impl ExportSource {
 		source: &crate::Source,
 		name: &str,
 		config: &VideoConfig,
-		latency: Duration,
+		latency_max: Duration,
 	) -> Result<Self, crate::Error> {
 		let media: HangContainer = (&config.container).try_into()?;
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
@@ -110,7 +110,7 @@ impl ExportSource {
 		Ok(Self {
 			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
 			media: Some(media),
-			latency,
+			latency_max,
 			transform: None,
 			description,
 		})
@@ -122,7 +122,7 @@ impl ExportSource {
 		source: &crate::Source,
 		name: &str,
 		config: &AudioConfig,
-		latency: Duration,
+		latency_max: Duration,
 	) -> Result<Self, crate::Error> {
 		let media: HangContainer = (&config.container).try_into()?;
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
@@ -130,7 +130,7 @@ impl ExportSource {
 		Ok(Self {
 			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
 			media: Some(media),
-			latency,
+			latency_max,
 			transform: None,
 			description,
 		})
@@ -139,11 +139,11 @@ impl ExportSource {
 	/// Subscribe to a verbatim `mpegts` stream rendition (SCTE-35, private PES, ...).
 	/// No codec-shape transform and no description: the frames are Legacy-framed
 	/// verbatim bytes the muxer writes back out as PES or private sections.
-	pub fn for_stream(source: &crate::Source, name: &str, latency: Duration) -> Result<Self, crate::Error> {
+	pub fn for_stream(source: &crate::Source, name: &str, latency_max: Duration) -> Result<Self, crate::Error> {
 		Ok(Self {
 			state: SourceState::Requesting(source.request(None), name.to_string()),
 			media: Some(HangContainer::Legacy),
-			latency,
+			latency_max,
 			transform: None,
 			description: None,
 		})
@@ -198,7 +198,7 @@ impl ExportSource {
 				.media
 				.take()
 				.expect("media present until the subscription resolves");
-			self.state = SourceState::Active(Box::new(Consumer::new(track, media).with_latency(self.latency)));
+			self.state = SourceState::Active(Box::new(Consumer::new(track, media).with_latency_max(self.latency_max)));
 		}
 
 		loop {

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -2041,7 +2041,7 @@ mod test {
 		let name = catalog.snapshot().mpegts.tracks.keys().next().unwrap().clone();
 		import.finish().unwrap();
 		let track = consumer.track(&name).unwrap().subscribe(None).await.unwrap();
-		let mut reader = Consumer::new(track, Container::Legacy).with_latency(std::time::Duration::ZERO);
+		let mut reader = Consumer::new(track, Container::Legacy).with_latency_max(std::time::Duration::ZERO);
 		let frame = tokio::time::timeout(std::time::Duration::from_secs(1), reader.read())
 			.await
 			.expect("cue read timed out")
@@ -2347,7 +2347,7 @@ mod test {
 
 		let name = catalog.snapshot().mpegts.tracks.keys().next().unwrap().clone();
 		let track = consumer.track(&name).unwrap().subscribe(None).await.unwrap();
-		let mut reader = Consumer::new(track, Container::Legacy).with_latency(std::time::Duration::ZERO);
+		let mut reader = Consumer::new(track, Container::Legacy).with_latency_max(std::time::Duration::ZERO);
 		let frame = tokio::time::timeout(std::time::Duration::from_secs(1), reader.read())
 			.await
 			.expect("cue read timed out")
@@ -2478,7 +2478,7 @@ mod test {
 		assert_eq!(track.pid, DATA_PID, "recorded the original PID");
 
 		let track = consumer.track(name.as_str()).unwrap().subscribe(None).await.unwrap();
-		let mut reader = Consumer::new(track, Container::Legacy).with_latency(std::time::Duration::ZERO);
+		let mut reader = Consumer::new(track, Container::Legacy).with_latency_max(std::time::Duration::ZERO);
 		let frame = tokio::time::timeout(std::time::Duration::from_secs(1), reader.read())
 			.await
 			.expect("verbatim read timed out")

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -44,7 +44,7 @@ impl Consumer {
 			.await?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = config.latency_max {
-			track = track.with_latency(latency);
+			track = track.with_latency_max(latency);
 		}
 
 		Ok(Self {

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -46,7 +46,7 @@ pub struct Config {
 	pub kind: Kind,
 	/// Upper bound on buffering before a stalled group is skipped. `None` uses
 	/// the moq-mux default (skip aggressively); set it to your playout buffer for
-	/// a softer skip. Forwarded to the container consumer's `with_latency`.
+	/// a softer skip. Forwarded to the container consumer's `with_latency_max`.
 	pub latency_max: Option<Duration>,
 	/// Ask the decoder to emit frames at this size (both dimensions even) instead
 	/// of the stream's native one. Best effort: a hardware decoder with a


### PR DESCRIPTION
## Summary

- Rename the moq-mux consumer latency controls to make clear that they configure a ceiling, not a fixed playout delay.
- Update direct Rust callers, examples, tests, and rustdoc references while leaving fixed SRT/RTMP latency and producer batching latency unchanged.

## Public API changes

- **Breaking:** `container::Consumer::with_latency` is now `with_latency_max`.
- **Breaking:** `container::Consumer::set_latency` is now `set_latency_max`.

This targets `dev` because both changes rename published Rust methods. There are no wire or container-format changes.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command cargo check --all-targets --package libmoq --package moq-ffi --package moq-gst`

(Written by GPT-5)