### PR TITLE
fix(moq-wasm): repair the consume path and gate wasm32 in CI

### DIFF
--- a/justfile
+++ b/justfile
@@ -100,10 +100,12 @@ check $BASE="":
 
     just _check-common
 
-# Check every JavaScript workspace and every default Rust member.
+# Check every JavaScript workspace, every default Rust member, and moq-wasm.
 check-all *args:
     just js check
     just rs check {{ args }}
+    # Not covered by the line above: moq-wasm only exists on the wasm32 target.
+    just rs wasm
     just obs check
     just _check-common
 

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -166,11 +166,12 @@ Then `Config::load()?` (initializes tracing), build clients/servers via `.init()
 
 - Config-merge regressions belong next to the config (`moq-relay/src/config.rs::tests`); they serialize env mutation with a lock since clap reads env.
 
-- **Local checks only compile the host's platform, and PR CI is Linux-only.** `#[cfg(target_os = "...")]` code for other platforms is invisible to them, and `cargo fmt` skips those modules too. Windows and Mac runners cost too much for a per-PR gate, so those platforms are manual:
+- **Local checks only compile the host's platform and target, and PR CI is Linux-only.** `#[cfg(target_os = "...")]` code for other platforms is invisible to them, and `cargo fmt` skips those modules too. Windows and Mac runners cost too much for a per-PR gate, so those platforms are manual:
 
   - Windows (moq-video's Media Foundation and D3D11 backends): `just rs windows`, which must run ON Windows. You can't reproduce it elsewhere, since cross-compiling dies in openh264-sys2's vendored C++.
   - macOS (moq-video's VideoToolbox and ScreenCaptureKit, moq-audio's system audio): `just rs macos`, which must run ON macOS. Scoped to moq-video + moq-audio, and needs `--all-features` because moq-audio's capture backend is off by default.
   - Linux: covered. `just rs ci` already runs `--all-features` in a dev shell carrying PipeWire and ALSA. VAAPI loads libva dynamically, so nvenc/nvdec/vaapi/pipewire all compile without libva installed.
+  - wasm32 (moq-wasm): `just rs wasm`. The crate root is `#![cfg(target_arch = "wasm32")]`, so a host-target `cargo check --workspace` compiles it down to nothing and sees no errors at all. This one needs no special host (the Nix shell carries the target), so `just rs ci` and `just check-all` both run it, and `just check` adds it when the diff touches `rs/moq-wasm/`. It's a compile gate, distinct from the root `just wasm`, which builds the shippable `@moq/wasm` package.
 
   What still compiles these automatically, and when:
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -105,6 +105,12 @@ check-changed $FILES:
     	*)     echo "rs: checking ${packages//--package /}"; just rs check $packages ;;
     esac
 
+    # moq-wasm is a non-default member, so `_select` never reaches it and the
+    # branch above would check nothing at all for a moq-wasm-only diff.
+    if grep -q '^rs/moq-wasm/' <<< "$FILES"; then
+    	just rs wasm
+    fi
+
 # Same as `fix`, but scoped the same way as `check-changed`.
 fix-changed $FILES:
     #!/usr/bin/env bash
@@ -115,6 +121,12 @@ fix-changed $FILES:
     	ALL)   just rs fix ;;
     	*)     echo "rs: fixing ${packages//--package /}"; just rs fix $packages ;;
     esac
+
+    # Mirrors `check-changed`: without this a moq-wasm-only diff is never
+    # formatted, and `ci`'s `cargo fmt --all --check` fails on it later.
+    if grep -q '^rs/moq-wasm/' <<< "$FILES"; then
+    	just rs wasm-fix
+    fi
 
 # Runs the `#[cfg(target_os = "windows")]` code past the compiler: moq-video's
 # Media Foundation capture/encode/decode and its D3D11 frames, which the Linux
@@ -157,6 +169,29 @@ windows *args:
 macos *args:
     cargo check -p moq-video -p moq-audio --all-targets --all-features {{ args }}
 
+# Same idea as `windows`/`macos`, for the browser: moq-wasm's whole crate root is
+# `#![cfg(target_arch = "wasm32")]`, so a host-target `cargo check --workspace`
+# compiles an empty crate and every error in it stays invisible. Only a wasm32
+# build sees the code.
+#
+# Unlike those two this needs no special host, so `ci` runs it on every Rust PR.
+# The wasm32 target and the `getrandom`/`web-sys` cfg flags come from the Nix dev
+# shell and `.cargo/config.toml`. Not to be confused with the root `just wasm`,
+# which builds the shippable `@moq/wasm` package (wasm-bindgen, release profile);
+# this is the compile gate.
+
+# Compile and lint the browser/WASM bindings, which the host-target check skips.
+wasm *args:
+    cargo clippy -p moq-wasm --target wasm32-unknown-unknown --all-targets {{ args }} -- -D warnings
+
+# The `fix` counterpart to `wasm`. `cargo fmt` is scoped rather than `--all`
+# because this runs alongside `fix`, which already formats everything else.
+
+# Auto-fix the browser/WASM bindings.
+wasm-fix *args:
+    cargo clippy --fix --allow-staged --allow-dirty -p moq-wasm --target wasm32-unknown-unknown --all-targets {{ args }}
+    cargo fmt -p moq-wasm
+
 # Full Rust CI: check + feature edge cases + tests + build. Takes a
 # newline-separated list of changed files; skips if FILES is non-empty
 # and none match the Rust scope. Run `just rs ci` (no FILES) to
@@ -191,6 +226,9 @@ ci $FILES="":
     cargo check --workspace --no-default-features
     cargo clippy --workspace --all-targets --all-features -- -D warnings
     RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+    # `--workspace` above still compiles moq-wasm for the host, where its crate
+    # root cfgs away to nothing, so this wasm32 pass is what actually checks it.
+    just rs wasm
     # nextest compiles + runs the test binaries with real parallelism (faster than
     # `cargo test`'s serial harness). It does not build or run
     # doctests, so the `/// ```` examples are no longer compile-checked in CI -- an

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -70,6 +70,10 @@
 //! run on any executor.
 
 #![warn(missing_docs)]
+// The browser transport is `!Send`, so on wasm the shared state behind these `Arc`s is
+// too and clippy suggests `Rc`. The same code is genuinely cross-thread on native, so
+// `Arc` stays and the lint is unactionable here.
+#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
 
 mod client;
 mod coding;

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -86,9 +86,11 @@ impl Session {
 		self.inner.version().to_string()
 	}
 
-	/// Resolve when the session closes (cleanly or with an error).
+	/// Reject when the session closes, with the reason it closed.
+	///
+	/// Every close carries a reason, including a clean one, so this never resolves.
 	pub async fn closed(&self) -> Result<(), JsValue> {
-		self.inner.closed().await.map_err(js_err)
+		Err(js_err(self.inner.closed().await))
 	}
 
 	/// Subscribe to a broadcast by path, waiting until it is announced.
@@ -174,6 +176,6 @@ impl Group {
 		*cell.borrow_mut() = Some(group);
 
 		let frame = result.map_err(js_err)?;
-		Ok(frame.map(|bytes| Uint8Array::from(bytes.as_ref())))
+		Ok(frame.map(|frame| Uint8Array::from(frame.payload.as_ref())))
 	}
 }


### PR DESCRIPTION
## Summary

- `rs/moq-wasm` has not compiled for a while. Two errors: `Session::closed` called `.map_err` on `moq_net::Session::closed()`, which returns `Error` directly rather than a `Result`, and `Group::read_frame` reached for `as_ref` on a `frame::Frame`, which carries its bytes in a `payload` field.
- **Root cause of the rot, not just the errors**: the crate root is `#![cfg(target_arch = "wasm32")]`, so `cargo check --workspace` on a Linux runner compiles it down to an empty crate and reports success. Only a wasm32 build ever sees the code, and the one thing that does that (`just wasm`) runs nowhere in the PR gate. Both errors were reachable on `main` and `dev`.
- Adds `just rs wasm` (a wasm32 clippy pass), wired into `just rs ci` unconditionally on any Rust diff, into `just check-all`, and into the diff-scoped `just check` / `just fix`. No new CI infra: the Nix dev shell already carries the `wasm32-unknown-unknown` target and `.cargo/config.toml` already sets the `getrandom` / `web-sys` cfg flags.
- moq-wasm is a **non-default** workspace member, so `_select` has no edges into it and a moq-wasm-only diff previously ran no Rust recipe at all, not even `cargo fmt`. `check-changed` and `fix-changed` now branch on `rs/moq-wasm/` explicitly; `wasm-fix` is the `fix` half.
- Clippy on wasm32 also flags `arc_with_non_send_sync` six times in moq-net, because the browser transport is `!Send` so the state behind those `Arc`s is too. `Rc` is not an option since the same code is genuinely cross-thread on native, so the lint is allowed at the moq-net crate root under a `target_arch = "wasm32"` cfg, where the reason sits next to it rather than as an invisible `-A` on the command line.

## Public API changes

None to any published crate. `moq-wasm` is `0.0.0`, unpublished, and not a default workspace member; its JS-facing `Session.closed()` now rejects with the close reason unconditionally, which is what `moq_net::Session::closed()` actually returns (every close carries a reason, a clean one included). The moq-net change is a crate-level lint attribute, not API surface.

## Test plan

- `nix develop --command cargo check -p moq-wasm --target wasm32-unknown-unknown` (the reported repro) passes.
- `nix develop --command just rs wasm` passes clean at `-D warnings`, before and after rebasing onto `main`.
- `just rs check-changed "rs/moq-wasm/src/lib.rs"` verified to run the new gate. It previously printed only `rs: no crates affected; skipping.`
- `cargo fmt --all --check`, `just --fmt --check` on both justfiles, and `remark` on `rs/CLAUDE.md` all pass.
- Not run: the full `just wasm` (wasm-bindgen + `--profile wasm-release`). That is a second full optimized compile whose only extra coverage is wasm-bindgen crate/CLI version drift against `flake.lock`, which seemed a poor cost-to-coverage trade for a per-PR gate. Easy to add if you disagree.

## Cross-package sync

No row applies: no wire format, catalog, FFI surface, or CLI flag changed. `js/wasm` consumes the generated `dist/` and needs no edit. `rs/CLAUDE.md` is updated with the new recipe and the visibility hole it plugs.

(Written by Opus 5)