### PR TITLE
fix(moq-net): stop a reflected announce from evicting the source we publish

### DIFF
--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -221,31 +221,31 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	/// The route for an advertisement that carries no path of its own.
 	///
-	/// Base moq-transport has no hops on the wire, so the chain is reconstructed here,
-	/// as the MoQ Cluster draft requires of an advertisement from an upstream that did
-	/// not negotiate the extension: a single `Origin::UNKNOWN` for that upstream. The
-	/// first entry is the original publisher and `UNKNOWN` is how the draft spells "we
-	/// cannot name it", which is the truth here: whoever produced this is somewhere
-	/// behind the peer and the wire never said who.
+	/// Base moq-transport has no hops on the wire, so the chain is a single entry
+	/// attributed to this session (`Origin::UNKNOWN` unless the peer or the caller
+	/// supplied an identity).
 	///
-	/// An identity the caller assigned the peer (`Client::with_peer_origin`) names the
-	/// *link* we received it over, not that publisher, so it follows as a second hop
-	/// exactly where a relay appends its own. Collapsing the two would let a peer
-	/// reflecting our own broadcast back at us look like a rival publisher claiming the
-	/// path, which evicts the source we are publishing from.
+	/// That entry doubles as the content identity, which is what makes an assigned
+	/// identity worth having: every session dialing the same relay produces the same
+	/// first hop, so a reconnect splices into the front its predecessor was serving
+	/// instead of replacing it. The cost is that we cannot tell the peer's own content
+	/// apart from our own coming back through it, since neither carries a chain. Loop
+	/// detection for that case is `FrontState::excluded`, not the chain.
 	///
 	/// The link is charged all the same. Such an advertisement carries no ROUTE_COST,
 	/// which reads as 0, but the draft charges every advertisement for the direction it
 	/// arrived over regardless. Skipping it would forward a paid upstream to
 	/// cluster-aware peers as free and pull subscriptions onto the wrong relay.
+	///
+	/// It is charged only one hop, though the chain it stands for may be arbitrarily
+	/// long: a peer that carries no hop ids hides its depth, so this route understates
+	/// its true length and can out-rank a longer-looking but genuinely shorter one.
+	/// Price such a link with [`crate::Client::with_cost`] rather than trusting the
+	/// default.
 	fn session_route(&self, peer: &cluster::Peer) -> broadcast::Route {
 		let mut hops = crate::OriginList::new();
-		hops.push(crate::Origin::UNKNOWN)
+		hops.push(self.session_origin)
 			.expect("an empty hop chain has room for one entry");
-		if self.session_origin != crate::Origin::UNKNOWN {
-			hops.push(self.session_origin)
-				.expect("a one-entry hop chain has room for another");
-		}
 		broadcast::Route::new()
 			.with_hops(hops)
 			.with_cost(cluster::link_cost(self.cost, peer))
@@ -1488,8 +1488,8 @@ mod tests {
 	/// moq-transport carries no hop ids, so a peer's broadcasts are normally
 	/// attributed to a random per-connection origin. An identity assigned via
 	/// `Client::with_peer_origin` pins it, so sessions dialing the same relay
-	/// resolve to one recognizable route. It names the link, so it follows the
-	/// unnameable publisher rather than posing as it.
+	/// resolve to one recognizable route, and a reconnect splices rather than
+	/// replacing.
 	#[tokio::test]
 	async fn assigned_peer_origin_attributes_announces() {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
@@ -1520,7 +1520,7 @@ mod tests {
 
 		let broadcast = consumer.get_broadcast("room/host").unwrap();
 		let hops: Vec<_> = broadcast.routes()[0].hops.iter().copied().collect();
-		assert_eq!(hops, vec![crate::Origin::UNKNOWN, assigned]);
+		assert_eq!(hops, vec![assigned]);
 	}
 
 	/// Both directions of a sync target point at one relay, which has no way to tell
@@ -1539,6 +1539,11 @@ mod tests {
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
+		// The publish direction: an origin handle scoped to the peer, which is what
+		// `Client::with_peer_origin` hands the publisher. Holding its announce stream
+		// is what records that the peer has been offered these paths.
+		let mut publishing = consumer.clone().excluding(peer).announced();
+
 		// What we are publishing to the peer: a real upstream, announced.
 		let upstream = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
 		let _source = origin
@@ -1551,6 +1556,9 @@ mod tests {
 			.unwrap();
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 		announced.assert_next_some("room/host");
+		// Held for as long as the path is advertised, exactly as the publisher holds
+		// it in its `Watched` entry. The exclusion lives on this handle.
+		let _advertised = publishing.assert_next_some("room/host");
 
 		// The peer reflects it back over the subscribe direction, which carries no
 		// hop chain of its own.
@@ -1579,6 +1587,56 @@ mod tests {
 		let routes = broadcast.routes();
 		assert_eq!(routes.len(), 1, "the reflection must park, not attach");
 		assert_eq!(routes[0].hops, upstream);
+	}
+
+	/// The assigned identity is a content identity too, so a second session dialing
+	/// the same relay produces the same first hop and splices into the front its
+	/// predecessor is serving. That is what makes a reconnect immediate instead of
+	/// waiting for the transport to retire the dead session, and the reflection guard
+	/// must not cost us it.
+	#[tokio::test]
+	async fn reconnecting_peer_joins_the_front_it_replaces() {
+		let peer = crate::Origin::new(777).unwrap();
+		let self_origin = crate::Origin::new(1).unwrap();
+
+		let origin = crate::origin::Info::new(self_origin).produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let connect = || {
+			let (tasks, task_set) = crate::util::TaskSet::new();
+			std::mem::forget(task_set);
+			let mut subscriber = Subscriber::new(
+				crate::lite::test_transport::SinkSession::new(Default::default()),
+				origin.clone(),
+				Control::new(None, false),
+				Some(peer),
+				cluster::PeerSetup::default(),
+				self_origin,
+				None,
+				Version::Draft14,
+				tasks,
+			);
+			let advert = subscriber.route(None, &cluster::Peer::default()).expect("route");
+			let producer = subscriber
+				.start_announce(crate::Path::new("room/host").to_owned(), advert)
+				.unwrap();
+			(subscriber, producer)
+		};
+
+		let _first = connect();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		announced.assert_next_some("room/host");
+
+		// The peer reconnects before the old session is retired.
+		let _second = connect();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+		// It joined: no announce churn, and both routes are in the table so the front
+		// can fail over the moment the stale one dies.
+		announced.assert_next_wait();
+		let routes = consumer.get_broadcast("room/host").unwrap().routes();
+		assert_eq!(routes.len(), 2, "a reconnect must join, not park or replace");
 	}
 
 	fn cluster_subscriber(

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -139,11 +139,12 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	// Traffic stats are attributed through this tagged origin handle.
 	origin: origin::Producer,
 	control: Control,
-	// The origin stamped into the hop chain of every broadcast from this session,
-	// when the peer declares none of its own. Base moq-transport carries no hop ids,
-	// so a peer only has an identity if it negotiated the MoQ Cluster extension or
-	// the caller assigned it one (`Client::with_peer_origin`), which also makes the
-	// route recognizable across sessions dialing the same relay.
+	// The origin naming this link, appended to the hop chain of every broadcast from
+	// this session when the peer declares none of its own (see `session_route`). Base
+	// moq-transport carries no hop ids, so a peer only has an identity if it negotiated
+	// the MoQ Cluster extension or the caller assigned it one
+	// (`Client::with_peer_origin`), which also makes the route recognizable across
+	// sessions dialing the same relay.
 	//
 	// Otherwise this is `Origin::UNKNOWN` (0), the reserved "no identity" value.
 	// Inventing a random id here would look like a real identity without being
@@ -220,9 +221,18 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	/// The route for an advertisement that carries no path of its own.
 	///
-	/// Base moq-transport has no hops on the wire, so the chain is a single entry
-	/// attributed to this session (`Origin::UNKNOWN` unless the peer or the caller
-	/// supplied an identity).
+	/// Base moq-transport has no hops on the wire, so the chain is reconstructed here,
+	/// as the MoQ Cluster draft requires of an advertisement from an upstream that did
+	/// not negotiate the extension: a single `Origin::UNKNOWN` for that upstream. The
+	/// first entry is the original publisher and `UNKNOWN` is how the draft spells "we
+	/// cannot name it", which is the truth here: whoever produced this is somewhere
+	/// behind the peer and the wire never said who.
+	///
+	/// An identity the caller assigned the peer (`Client::with_peer_origin`) names the
+	/// *link* we received it over, not that publisher, so it follows as a second hop
+	/// exactly where a relay appends its own. Collapsing the two would let a peer
+	/// reflecting our own broadcast back at us look like a rival publisher claiming the
+	/// path, which evicts the source we are publishing from.
 	///
 	/// The link is charged all the same. Such an advertisement carries no ROUTE_COST,
 	/// which reads as 0, but the draft charges every advertisement for the direction it
@@ -230,8 +240,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// cluster-aware peers as free and pull subscriptions onto the wrong relay.
 	fn session_route(&self, peer: &cluster::Peer) -> broadcast::Route {
 		let mut hops = crate::OriginList::new();
-		hops.push(self.session_origin)
+		hops.push(crate::Origin::UNKNOWN)
 			.expect("an empty hop chain has room for one entry");
+		if self.session_origin != crate::Origin::UNKNOWN {
+			hops.push(self.session_origin)
+				.expect("a one-entry hop chain has room for another");
+		}
 		broadcast::Route::new()
 			.with_hops(hops)
 			.with_cost(cluster::link_cost(self.cost, peer))
@@ -1474,7 +1488,8 @@ mod tests {
 	/// moq-transport carries no hop ids, so a peer's broadcasts are normally
 	/// attributed to a random per-connection origin. An identity assigned via
 	/// `Client::with_peer_origin` pins it, so sessions dialing the same relay
-	/// resolve to one recognizable route.
+	/// resolve to one recognizable route. It names the link, so it follows the
+	/// unnameable publisher rather than posing as it.
 	#[tokio::test]
 	async fn assigned_peer_origin_attributes_announces() {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
@@ -1505,7 +1520,65 @@ mod tests {
 
 		let broadcast = consumer.get_broadcast("room/host").unwrap();
 		let hops: Vec<_> = broadcast.routes()[0].hops.iter().copied().collect();
-		assert_eq!(hops, vec![assigned]);
+		assert_eq!(hops, vec![crate::Origin::UNKNOWN, assigned]);
+	}
+
+	/// Both directions of a sync target point at one relay, which has no way to tell
+	/// our two connections apart on a wire with no hop ids and so offers our own
+	/// broadcast back to us. That reflection must not look like a rival publisher
+	/// claiming the path: taking it over would leave only a route we refuse to
+	/// advertise back to the peer, and the publish direction would withdraw the
+	/// announce it just made.
+	#[tokio::test]
+	async fn reflected_announce_does_not_evict_the_source_we_publish() {
+		let session = crate::lite::test_transport::SinkSession::new(Default::default());
+		let peer = crate::Origin::new(777).unwrap();
+		let self_origin = crate::Origin::new(1).unwrap();
+
+		let origin = crate::origin::Info::new(self_origin).produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		// What we are publishing to the peer: a real upstream, announced.
+		let upstream = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
+		let _source = origin
+			.create_broadcast(
+				"room/host",
+				crate::broadcast::Route::new()
+					.with_hops(upstream.clone())
+					.with_announce(true),
+			)
+			.unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		announced.assert_next_some("room/host");
+
+		// The peer reflects it back over the subscribe direction, which carries no
+		// hop chain of its own.
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+		let mut subscriber = Subscriber::new(
+			session,
+			origin,
+			Control::new(None, false),
+			Some(peer),
+			cluster::PeerSetup::default(),
+			self_origin,
+			None,
+			Version::Draft14,
+			tasks,
+		);
+		let advert = subscriber.route(None, &cluster::Peer::default()).expect("route");
+		let _reflected = subscriber
+			.start_announce(crate::Path::new("room/host").to_owned(), advert)
+			.unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+		// No announce churn, and the path still resolves to the upstream route, which
+		// is the one the publish direction can advertise back to the peer.
+		announced.assert_next_wait();
+		let broadcast = consumer.get_broadcast("room/host").unwrap();
+		let routes = broadcast.routes();
+		assert_eq!(routes.len(), 1, "the reflection must park, not attach");
+		assert_eq!(routes[0].hops, upstream);
 	}
 
 	fn cluster_subscriber(

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1551,9 +1551,9 @@ async fn run_source(
 		let (state, broadcast, id) = match attach_source(&ctx, &leaf, &source, route.clone()) {
 			Attach::Ready(state, broadcast, id) => (state, broadcast, id),
 			Attach::Parked(incumbent) => {
-				tracing::warn!(
+				tracing::debug!(
 					broadcast = %full,
-					"path already live with a different publisher; parking an offline source until it ends",
+					"path already live with a different publisher; parking this source until it ends",
 				);
 				// Wait for the incumbent front to close, or for our own route to
 				// change: announcing ourselves is what earns the takeover, and our
@@ -1639,9 +1639,10 @@ enum Attach {
 	/// source table, the spliced broadcast, and the source's table id.
 	Ready(kio::Producer<FrontState>, broadcast::Producer, u64),
 	/// The path's live front belongs to a different original publisher and this
-	/// source is offline, so it would rank below every route the front holds and
-	/// must not take the path from it. The caller parks on the returned table
-	/// until the front closes.
+	/// source may not take it: either the source is offline (so it would rank below
+	/// every route the front holds) or its chain does not prove it carries different
+	/// content (see [`proves_distinct_content`]). The caller parks on the returned
+	/// table until the front closes.
 	Parked(kio::Producer<FrontState>),
 }
 
@@ -1653,6 +1654,40 @@ struct AttachContext<'a> {
 	full: &'a PathOwned,
 	/// Path relative to `node`, for locating (and later pruning) the leaf.
 	rest: &'a PathOwned,
+}
+
+/// Whether two sources carry the same content and may therefore splice.
+///
+/// [`Origin::UNKNOWN`] identifies nothing: it is what a peer that declared no
+/// identity, or that does not speak the hops extension at all, contributes as a
+/// first hop. Two such sources are not interchangeable even though their first
+/// hops compare equal, so splicing them would cut one publisher's subscribers
+/// over to an unrelated publisher's content. Every other id compares normally,
+/// including `None` for a locally produced broadcast with no hops.
+fn same_publisher(a: Option<Origin>, b: Option<Origin>) -> bool {
+	if a == Some(Origin::UNKNOWN) || b == Some(Origin::UNKNOWN) {
+		return false;
+	}
+	a == b
+}
+
+/// Whether a source's chain proves it carries content distinct from the front it
+/// landed on, which is what taking the path over requires.
+///
+/// A real first hop names the original publisher, so it is proof by itself.
+/// [`Origin::UNKNOWN`] names nobody, and what that means depends on where it sits.
+/// A one-hop chain is the peer claiming to be the publisher: that is a publisher on
+/// a wire carrying no identity, and its reconnect must displace the session it
+/// replaced immediately instead of waiting for the transport to retire it. A longer
+/// chain is a forwarder relaying content it cannot name, which is indistinguishable
+/// from our own broadcast arriving back through a peer that does no loop detection
+/// of its own. Evicting a live front on that is how a publish direction cancels
+/// itself, so such a source waits for the front instead.
+fn proves_distinct_content(route: &broadcast::Route) -> bool {
+	match route.hops.iter().next() {
+		Some(first) if *first == Origin::UNKNOWN => route.hops.len() == 1,
+		_ => true,
+	}
 }
 
 /// Attach a source to the broadcast at `leaf`, creating (and publishing) the
@@ -1670,22 +1705,9 @@ struct AttachContext<'a> {
 /// Taking over requires announcing, which keeps the rule consistent with
 /// [`route_order`]: an offline source ranks below every announced route, so it
 /// waits ([`Attach::Parked`]) rather than unannouncing a live broadcast and
-/// cutting its subscribers for content nobody has advertised.
-/// Whether two sources carry the same content and may therefore splice.
-///
-/// [`Origin::UNKNOWN`] identifies nothing: it is what a peer that declared no
-/// identity, or that does not speak the hops extension at all, contributes as a
-/// first hop. Two such sources are not interchangeable even though their first
-/// hops compare equal, so splicing them would cut one publisher's subscribers
-/// over to an unrelated publisher's content. Every other id compares normally,
-/// including `None` for a locally produced broadcast with no hops.
-fn same_publisher(a: Option<Origin>, b: Option<Origin>) -> bool {
-	if a == Some(Origin::UNKNOWN) || b == Some(Origin::UNKNOWN) {
-		return false;
-	}
-	a == b
-}
-
+/// cutting its subscribers for content nobody has advertised. It also requires a
+/// chain that proves the content really is different (see
+/// [`proves_distinct_content`]); a source that cannot show that waits too.
 fn attach_source(
 	ctx: &AttachContext,
 	leaf: &Lock<OriginNode>,
@@ -1713,7 +1735,7 @@ fn attach_source(
 				});
 				s.reselect(carrying);
 				joined = Some(id);
-			} else if !route.announce {
+			} else if !route.announce || !proves_distinct_content(&route) {
 				return Attach::Parked(existing.state.clone());
 			} else {
 				// New content at a live path: the newest publisher wins it. Closing
@@ -3228,6 +3250,72 @@ mod tests {
 			Some(1),
 			"an unannounced incumbent must always be displaced"
 		);
+	}
+
+	/// A forwarder that cannot name the publisher it relays for (an `UNKNOWN` first
+	/// hop behind at least one link) never evicts a live front. That shape is what a
+	/// peer reflecting our own broadcast back at us produces on a wire with no hop
+	/// ids, and evicting on it leaves only a route we refuse to advertise to that
+	/// peer.
+	#[tokio::test]
+	async fn test_unnamed_forwarder_parks_instead_of_taking_over() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let upstream = OriginList::try_from(vec![Origin::new(7).unwrap()]).unwrap();
+		let peer = Origin::new(42).unwrap();
+		let reflected = OriginList::try_from(vec![Origin::UNKNOWN, peer]).unwrap();
+
+		let _source = origin
+			.create_broadcast("test", announce().with_hops(upstream.clone()))
+			.unwrap();
+		settle().await;
+		settle().await;
+		announced.assert_next_some("test");
+
+		let _reflection = origin
+			.create_broadcast("test", announce().with_hops(reflected))
+			.unwrap();
+		settle().await;
+		settle().await;
+
+		announced.assert_next_wait();
+		let broadcast = consumer.get_broadcast("test").unwrap();
+		let routes = broadcast.routes();
+		assert_eq!(routes.len(), 1, "the reflection must park, not attach");
+		assert_eq!(routes[0].hops, upstream);
+	}
+
+	/// A peer that claims to be the publisher itself (a one-hop chain) still takes
+	/// the path over even with no identity on the wire, so a publisher reconnecting
+	/// displaces the session it replaced instead of waiting for the transport.
+	#[tokio::test]
+	async fn test_unnamed_publisher_still_takes_over() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let direct = OriginList::try_from(vec![Origin::UNKNOWN]).unwrap();
+
+		let _first = origin
+			.create_broadcast("test", announce().with_hops(direct.clone()))
+			.unwrap();
+		settle().await;
+		settle().await;
+		announced.assert_next_some("test");
+
+		let _reconnect = origin.create_broadcast("test", announce().with_hops(direct)).unwrap();
+		settle().await;
+		settle().await;
+
+		// The takeover is an unannounce followed by a fresh announce.
+		announced.assert_next_none("test");
+		announced.assert_next_some("test");
 	}
 
 	/// Let the spawned origin tasks (source watchers, front dispatch) run. The

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -528,11 +528,26 @@ impl OriginConsumerState {
 struct AnnounceConsumerNotify {
 	root: PathOwned,
 	state: kio::Producer<OriginConsumerState>,
+	/// The peer this stream advertises to, when it is scoped to one (see
+	/// [`Consumer::excluding`]). Every broadcast handed out registers an
+	/// [`ExclusionGuard`] for it, which is what tells the front it is exposed to that
+	/// peer even before they subscribe.
+	exclude: Option<Origin>,
 }
 
 impl AnnounceConsumerNotify {
-	fn announce(&self, path: impl AsPath, broadcast: broadcast::Consumer) {
+	fn announce(&self, path: impl AsPath, broadcast: broadcast::Consumer, front: &kio::Producer<FrontState>) {
 		let path = path.as_path().strip_prefix(&self.root).unwrap().to_owned();
+
+		// Advertising a path to a peer exposes the front to them, so register the
+		// exclusion now rather than waiting for them to subscribe. A reflection can
+		// come back before any subscription does, and the front has to already know
+		// the route it arrives on leads to a peer we are feeding.
+		let broadcast = match self.exclude.and_then(|peer| ExclusionGuard::new(front, peer)) {
+			Some(guard) => broadcast.with_exclusion(guard),
+			None => broadcast,
+		};
+
 		self.state
 			.write()
 			.ok()
@@ -562,13 +577,16 @@ impl NotifyNode {
 		}
 	}
 
-	fn announce(&mut self, path: impl AsPath, broadcast: &broadcast::Consumer) {
+	/// `state` is the announced front's source table, so a consumer scoped to a peer
+	/// can register its [`ExclusionGuard`] against it (see
+	/// [`AnnounceConsumerNotify::announce`]).
+	fn announce(&mut self, path: impl AsPath, broadcast: &broadcast::Consumer, state: &kio::Producer<FrontState>) {
 		for consumer in self.consumers.values() {
-			consumer.announce(path.as_path(), broadcast.clone());
+			consumer.announce(path.as_path(), broadcast.clone(), state);
 		}
 
 		if let Some(parent) = &self.parent {
-			parent.lock().announce(path, broadcast);
+			parent.lock().announce(path, broadcast, state);
 		}
 	}
 
@@ -689,9 +707,10 @@ impl OriginNode {
 		existing.announced = announce;
 		let path = existing.path.clone();
 		let consumer = existing.broadcast.consume();
+		let state = existing.state.clone();
 		let mut notify = self.notify.lock();
 		if announce {
-			notify.announce(&path, &consumer);
+			notify.announce(&path, &consumer, &state);
 		} else {
 			notify.unannounce(&path);
 		}
@@ -708,7 +727,7 @@ impl OriginNode {
 		if let Some(broadcast) = &self.broadcast
 			&& broadcast.announced
 		{
-			notify.announce(&broadcast.path, broadcast.broadcast.consume());
+			notify.announce(&broadcast.path, broadcast.broadcast.consume(), &broadcast.state);
 		}
 
 		// Recursively subscribe to all nested nodes.
@@ -1249,12 +1268,18 @@ struct FrontState {
 	/// an exact tie toward the newest source.
 	next_route: u64,
 	routes: Vec<FrontRoute>,
-	/// Peers currently reading this front through the shared broadcast, refcounted
-	/// by live [`ExclusionGuard`]s. The resolve-time check only proves the table is
-	/// clean for a requester at that instant; the front picks per track and re-picks
-	/// on failover, so without this a route tainted for an attached peer could be
-	/// adopted underneath them and hand them back their own bytes. Routes through
-	/// these origins are avoided while any clean alternative exists.
+	/// Peers this front is exposed to, refcounted by live [`ExclusionGuard`]s: those
+	/// reading it through the shared broadcast, and those we merely advertise it to.
+	/// The resolve-time check only proves the table is clean for a requester at that
+	/// instant; the front picks per track and re-picks on failover, so without this a
+	/// route tainted for an attached peer could be adopted underneath them and hand
+	/// them back their own bytes. Routes through these origins are avoided while any
+	/// clean alternative exists.
+	///
+	/// Advertising registers a peer too, because a peer that cannot echo our identity
+	/// back (moq-transport carries no hop ids) may re-advertise the path to us before
+	/// it ever subscribes. That reflection is otherwise indistinguishable from a rival
+	/// publisher, and this is what tells [`attach_source`] apart.
 	excluded: HashMap<Origin, usize>,
 	/// The source tracks are dispatched to. Backups park until promoted.
 	active: Option<u64>,
@@ -1305,7 +1330,12 @@ impl FrontState {
 		self.pick(|r| exclude.is_none_or(|origin| !r.route.hops.contains(&origin)), false)
 	}
 
-	/// Whether serving from `route` would hand an attached peer its own bytes back.
+	/// Whether `route` flows back through a peer this front is exposed to, so serving
+	/// (or attaching) it would hand that peer its own bytes back.
+	///
+	/// Doubles as the reflection test in [`attach_source`]: a route arriving through a
+	/// peer we are already advertising this path to is our own broadcast coming home,
+	/// whatever its chain claims.
 	fn taints_a_reader(&self, route: &broadcast::Route) -> bool {
 		route.hops.iter().any(|hop| self.excluded.contains_key(hop))
 	}
@@ -1640,9 +1670,9 @@ enum Attach {
 	Ready(kio::Producer<FrontState>, broadcast::Producer, u64),
 	/// The path's live front belongs to a different original publisher and this
 	/// source may not take it: either the source is offline (so it would rank below
-	/// every route the front holds) or its chain does not prove it carries different
-	/// content (see [`proves_distinct_content`]). The caller parks on the returned
-	/// table until the front closes.
+	/// every route the front holds) or its chain leads back through a peer the front
+	/// is already exposed to, making it a reflection rather than rival content. The
+	/// caller parks on the returned table until the front closes.
 	Parked(kio::Producer<FrontState>),
 }
 
@@ -1671,25 +1701,6 @@ fn same_publisher(a: Option<Origin>, b: Option<Origin>) -> bool {
 	a == b
 }
 
-/// Whether a source's chain proves it carries content distinct from the front it
-/// landed on, which is what taking the path over requires.
-///
-/// A real first hop names the original publisher, so it is proof by itself.
-/// [`Origin::UNKNOWN`] names nobody, and what that means depends on where it sits.
-/// A one-hop chain is the peer claiming to be the publisher: that is a publisher on
-/// a wire carrying no identity, and its reconnect must displace the session it
-/// replaced immediately instead of waiting for the transport to retire it. A longer
-/// chain is a forwarder relaying content it cannot name, which is indistinguishable
-/// from our own broadcast arriving back through a peer that does no loop detection
-/// of its own. Evicting a live front on that is how a publish direction cancels
-/// itself, so such a source waits for the front instead.
-fn proves_distinct_content(route: &broadcast::Route) -> bool {
-	match route.hops.iter().next() {
-		Some(first) if *first == Origin::UNKNOWN => route.hops.len() == 1,
-		_ => true,
-	}
-}
-
 /// Attach a source to the broadcast at `leaf`, creating (and publishing) the
 /// broadcast if none is live. One lock acquisition covers the whole
 /// join-or-create decision, so concurrent attaches cannot race each other.
@@ -1706,8 +1717,10 @@ fn proves_distinct_content(route: &broadcast::Route) -> bool {
 /// [`route_order`]: an offline source ranks below every announced route, so it
 /// waits ([`Attach::Parked`]) rather than unannouncing a live broadcast and
 /// cutting its subscribers for content nobody has advertised. It also requires a
-/// chain that proves the content really is different (see
-/// [`proves_distinct_content`]); a source that cannot show that waits too.
+/// chain that does not lead back through a peer this front is already exposed to
+/// (see [`FrontState::taints_a_reader`]): such a source is our own broadcast
+/// reflected by a peer that cannot detect the loop itself, and letting it evict the
+/// front is how a publish direction ends up withdrawing its own announce.
 fn attach_source(
 	ctx: &AttachContext,
 	leaf: &Lock<OriginNode>,
@@ -1735,7 +1748,7 @@ fn attach_source(
 				});
 				s.reselect(carrying);
 				joined = Some(id);
-			} else if !route.announce || !proves_distinct_content(&route) {
+			} else if !route.announce || s.taints_a_reader(&route) {
 				return Attach::Parked(existing.state.clone());
 			} else {
 				// New content at a live path: the newest publisher wins it. Closing
@@ -1795,7 +1808,10 @@ fn attach_source(
 		announced: announce,
 	};
 	if entry.announced {
-		leaf_guard.notify.lock().announce(ctx.full, &broadcast.consume());
+		leaf_guard
+			.notify
+			.lock()
+			.announce(ctx.full, &broadcast.consume(), &state);
 	}
 	leaf_guard.broadcast = Some(entry);
 	drop(leaf_guard);
@@ -2653,7 +2669,7 @@ impl Consumer {
 	/// set as initial announcements. Drop the returned [`AnnounceConsumer`]
 	/// to unregister.
 	pub fn announced(&self) -> AnnounceConsumer {
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), self.stats.clone())
+		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), self.stats.clone(), self.exclude)
 	}
 
 	/// Returns a cheap duplicate of this read handle.
@@ -2867,7 +2883,7 @@ impl AnnounceProducer {
 	pub fn consume(&self) -> AnnounceConsumer {
 		// Untagged: `AnnounceProducer` is used for internal announce plumbing, not
 		// egress attribution (which flows through `origin::Consumer::announced`).
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), stats::Session::default())
+		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), stats::Session::default(), None)
 	}
 
 	/// Returns the prefix that is automatically stripped from announced paths.
@@ -2900,7 +2916,7 @@ pub struct AnnounceConsumer {
 }
 
 impl AnnounceConsumer {
-	fn new(root: PathOwned, nodes: OriginNodes, stats: stats::Session) -> Self {
+	fn new(root: PathOwned, nodes: OriginNodes, stats: stats::Session, exclude: Option<Origin>) -> Self {
 		let state = kio::Producer::<OriginConsumerState>::default();
 		let id = ConsumerId::new();
 
@@ -2908,6 +2924,7 @@ impl AnnounceConsumer {
 			let notify = AnnounceConsumerNotify {
 				root: root.clone(),
 				state: state.clone(),
+				exclude,
 			};
 			node.lock().consume(id, notify);
 		}
@@ -3252,70 +3269,81 @@ mod tests {
 		);
 	}
 
-	/// A forwarder that cannot name the publisher it relays for (an `UNKNOWN` first
-	/// hop behind at least one link) never evicts a live front. That shape is what a
-	/// peer reflecting our own broadcast back at us produces on a wire with no hop
-	/// ids, and evicting on it leaves only a route we refuse to advertise to that
-	/// peer.
-	#[tokio::test]
-	async fn test_unnamed_forwarder_parks_instead_of_taking_over() {
-		tokio::time::pause();
-
-		let origin = Origin::random().produce();
-		let consumer = origin.consume();
-		let mut announced = consumer.announced();
-
-		let upstream = OriginList::try_from(vec![Origin::new(7).unwrap()]).unwrap();
+	/// A route arriving through a peer the front is already exposed to is our own
+	/// broadcast reflected back, whatever its chain claims, so it must not evict the
+	/// front. This is the shape a relay with no hop ids produces when both directions
+	/// of a sync target point at it.
+	#[test]
+	fn test_reflection_through_an_exposed_peer_cannot_take_over() {
 		let peer = Origin::new(42).unwrap();
-		let reflected = OriginList::try_from(vec![Origin::UNKNOWN, peer]).unwrap();
+		let upstream = OriginList::try_from(vec![Origin::new(7).unwrap()]).unwrap();
+		let reflected = announce().with_hops(OriginList::try_from(vec![peer]).unwrap());
 
-		let _source = origin
-			.create_broadcast("test", announce().with_hops(upstream.clone()))
-			.unwrap();
-		settle().await;
-		settle().await;
-		announced.assert_next_some("test");
+		let mut state = front_state(Origin::new(1).unwrap(), vec![announce().with_hops(upstream)]);
 
-		let _reflection = origin
-			.create_broadcast("test", announce().with_hops(reflected))
-			.unwrap();
-		settle().await;
-		settle().await;
+		// Nobody is exposed yet: a different publisher is free to take the path.
+		assert!(!state.taints_a_reader(&reflected));
 
-		announced.assert_next_wait();
-		let broadcast = consumer.get_broadcast("test").unwrap();
-		let routes = broadcast.routes();
-		assert_eq!(routes.len(), 1, "the reflection must park, not attach");
-		assert_eq!(routes[0].hops, upstream);
+		// Advertising the path to `peer` registers them, and the same route is now
+		// recognizable as a reflection.
+		*state.excluded.entry(peer).or_default() += 1;
+		assert!(state.taints_a_reader(&reflected));
 	}
 
-	/// A peer that claims to be the publisher itself (a one-hop chain) still takes
-	/// the path over even with no identity on the wire, so a publisher reconnecting
-	/// displaces the session it replaced instead of waiting for the transport.
-	#[tokio::test]
-	async fn test_unnamed_publisher_still_takes_over() {
-		tokio::time::pause();
+	/// The exposure is what discriminates, not the shape of the chain: an unrelated
+	/// publisher reaching us through some *other* peer still takes the path over.
+	#[test]
+	fn test_rival_publisher_through_another_peer_still_takes_over() {
+		let peer = Origin::new(42).unwrap();
+		let elsewhere = Origin::new(43).unwrap();
+		let upstream = OriginList::try_from(vec![Origin::new(7).unwrap()]).unwrap();
+		let rival = announce().with_hops(OriginList::try_from(vec![Origin::UNKNOWN, elsewhere]).unwrap());
 
-		let origin = Origin::random().produce();
-		let consumer = origin.consume();
-		let mut announced = consumer.announced();
+		let mut state = front_state(Origin::new(1).unwrap(), vec![announce().with_hops(upstream)]);
+		*state.excluded.entry(peer).or_default() += 1;
 
-		let direct = OriginList::try_from(vec![Origin::UNKNOWN]).unwrap();
+		assert!(!state.taints_a_reader(&rival), "only the peer we feed is a reflection");
+	}
 
-		let _first = origin
-			.create_broadcast("test", announce().with_hops(direct.clone()))
-			.unwrap();
-		settle().await;
-		settle().await;
-		announced.assert_next_some("test");
+	/// A peer that carries no hop ids hides its depth: everything behind it collapses
+	/// into one entry, so its route understates its true length and wins the cost
+	/// comparison against a longer-looking but genuinely shorter path. Pricing the
+	/// opaque link (`Client::with_cost`) is what restores the intended order.
+	#[test]
+	fn test_opaque_peer_understates_its_depth() {
+		let us = Origin::new(1).unwrap();
 
-		let _reconnect = origin.create_broadcast("test", announce().with_hops(direct)).unwrap();
-		settle().await;
-		settle().await;
+		// Our own upstream, honestly described: two hops, charged per link.
+		let direct = || {
+			announce()
+				.with_hops(OriginList::try_from(vec![Origin::new(7).unwrap(), Origin::new(8).unwrap()]).unwrap())
+				.with_cost(2)
+		};
+		// The same content reached through an opaque relay, which is actually further
+		// away but advertises no chain at all, so it lands as one unpriced hop.
+		let opaque = |cost| {
+			announce()
+				.with_hops(OriginList::try_from(vec![Origin::new(42).unwrap()]).unwrap())
+				.with_cost(cost)
+		};
 
-		// The takeover is an unannounce followed by a fresh announce.
-		announced.assert_next_none("test");
-		announced.assert_next_some("test");
+		// Unpriced, the opaque route wins on cost even though it is the longer path.
+		let mut state = front_state(us, vec![direct(), opaque(1)]);
+		state.reselect(false);
+		assert_eq!(
+			state.active,
+			Some(1),
+			"an unpriced opaque link out-ranks a shorter real path"
+		);
+
+		// Priced to reflect what it hides, the real path wins again.
+		let mut state = front_state(us, vec![direct(), opaque(16)]);
+		state.reselect(false);
+		assert_eq!(
+			state.active,
+			Some(0),
+			"pricing the opaque link restores the intended order"
+		);
 	}
 
 	/// Let the spawned origin tasks (source watchers, front dispatch) run. The


### PR DESCRIPTION
Fixes the sync publish direction cancelling itself on the IETF wire, reported as
[moq.pro#954](https://github.com/moq-dev/moq.pro/issues/954).

## Symptom

A sync target whose PUBLISH and SUBSCRIBE directions point at the same relay with
overlapping prefixes (the shape the Cloudflare page produces by default) announces a
broadcast and then withdraws its own announce a couple of milliseconds later. Nothing
errors, so the target looks half-alive. Publish-only and subscribe-only targets against
the same relay both work; only the combination fails, and only on moq-transport.

## Root cause

Not the exclusion, which does exactly its job, and not cost or hop length, which are
never consulted. The withdrawal is the visible tail of an **eviction**.

A relay on the plain moq-transport wire cannot tell our two connections apart (separate
QUIC connections, no shared identity), so it reflects our own broadcast back over the
subscribe direction. That reflection reaches the origin as a source whose first hop
differs from the live front's, and `attach_source` reads a differing first hop as new
content and lets it **take the path over**: the front carrying our real upstream route
is closed and replaced by one holding only the route through the peer. The publish
direction then correctly refuses to advertise the only route it has left (it flows back
through the peer it would advertise to) and withdraws.

Demonstrated directly: with the real route given cost 0 and one hop, and the reflection
cost 99 and two hops, the reflection still wins, and the table goes from one entry to
one entry. It is not outranked, it is gone.

```
BEFORE: [ hops:[7],    cost: 0,  announce: true ]
AFTER:  [ hops:[0,42], cost: 99, announce: true ]
```

## Fix

The reflection is indistinguishable from rival content *by its chain*, so this detects
it by provenance instead.

Advertising a path to a peer now registers an `ExclusionGuard` on that front, so the
front knows it is **exposed** to that peer before they ever subscribe. `attach_source`
then refuses a takeover from a route flowing back through an exposed peer: that is our
own broadcast coming home, whatever its chain claims. It fires only for a genuine echo,
so an unrelated publisher reaching us through some other peer still takes the path over
as before.

This widens `FrontState::excluded` from "peers reading the front" to "peers the front is
offered to", which is the same split-horizon intent it already encoded. Mechanically it
needed the front's source table threaded through the announce fan-out so a peer-scoped
announce stream can register against it. No publisher change was required: `connect`
already hands the publisher an `excluding` origin when `with_peer_origin` is set, and the
ietf publisher retains the yielded consumer in its `Watched` entry, which is exactly the
lifetime the guard wants.

An earlier revision of this PR instead moved the assigned identity behind an `UNKNOWN`
publisher in the hop chain. That was wrong and has been reverted: the assigned identity
doubles as the *content* identity, so every session dialing the same relay produces the
same first hop and a reconnect splices into the front its predecessor is serving.
Displacing it made `same_publisher` reject those identical chains and cost us immediate
reconnect, which is the property `with_peer_origin` exists to provide. Caught by both
review bots; there is now a regression test for it.

## Opaque peers understate their depth

Documented on `session_route` while here, since it is the other consequence of a wire
with no hop ids and it is easy to trip over. Everything behind such a peer collapses into
a single chain entry, so its route understates its true length: a broadcast that is
really four hops away via Cloudflare advertises as one hop at cost 1 and out-ranks a
genuinely shorter two-hop path. Price such a link with `Client::with_cost` rather than
leaving it at the default.

Deliberately **not** changed: the default cost for peers that did not negotiate the
cluster extension. That bucket holds both opaque relays (should be expensive) and plain
publisher clients (are the origin, should be cheap), and we cannot tell them apart. A
blanket default would make our own directly-ingested content lose to a peer's copy of it.

## Tests

- `ietf::subscriber::tests::reflected_announce_does_not_evict_the_source_we_publish` —
  the reported bug end to end: no announce churn, path still resolves to the upstream route.
- `ietf::subscriber::tests::reconnecting_peer_joins_the_front_it_replaces` — a reconnect
  through the same assigned peer splices, leaving both routes in the table so failover
  still works.
- `model::origin_impl::tests::test_reflection_through_an_exposed_peer_cannot_take_over` —
  the discriminator is exposure: the same route is rival content until the path is
  advertised to that peer, and a reflection afterwards.
- `model::origin_impl::tests::test_rival_publisher_through_another_peer_still_takes_over` —
  an unrelated publisher through a different peer is unaffected.
- `model::origin_impl::tests::test_opaque_peer_understates_its_depth` — an unpriced opaque
  link out-ranks a shorter real path; pricing it restores the intended order.

Verified load-bearing by disabling the gate and confirming the reflection test fails while
the reconnect and rival-publisher tests still pass.

## Cross-package sync

- No wire change: `excluded` and the hop chain for a hop-less peer are local bookkeeping,
  and the moq-transport wire is untouched. No draft update.
- `js/net` needs no mirror: its IETF path does no hop-chain reconstruction and it has no
  origin/front splicing model (it is an endpoint client, not a relay).
- moq-lite is untouched. Its reflections are already dropped by the
  `hops.contains(self_origin)` check, which is why the bug was moq-transport only.

Once this lands and the dep bumps, moq.pro's `just dev smoke` can move its stand-in peer
onto moq-transport, which is what gives the suite real Cloudflare interop coverage.

(Written by Claude Fable 5)
