### PR TITLE
refactor(moq-net): give lite::start a Config, like ietf::start

### DIFF
--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -269,16 +269,16 @@ impl Client {
 					origin: None,
 				};
 
-				let start = lite::start(
-					session.clone(),
-					None,
-					publish.clone(),
-					subscribe.clone(),
-					self.peer_origin,
+				let start = lite::start(lite::Config {
+					session: session.clone(),
+					setup_stream: None,
+					publish: publish.clone(),
+					subscribe: subscribe.clone(),
+					peer_origin: self.peer_origin,
 					version,
 					our_setup,
-					None,
-				)?;
+					peer_setup: None,
+				})?;
 
 				// Block until the initial announce set has landed (Lite05+ reports it
 				// via AnnounceOk + N), so a `request_broadcast()` for a live path resolves
@@ -293,16 +293,16 @@ impl Client {
 					.select(Version::Lite(lite::Version::Lite04))
 					.ok_or(Error::Version)?;
 
-				let start = lite::start(
-					session.clone(),
-					None,
-					publish.clone(),
-					subscribe.clone(),
-					self.peer_origin,
-					lite::Version::Lite04,
-					lite::Setup::default(),
-					None,
-				)?;
+				let start = lite::start(lite::Config {
+					session: session.clone(),
+					setup_stream: None,
+					publish: publish.clone(),
+					subscribe: subscribe.clone(),
+					peer_origin: self.peer_origin,
+					version: lite::Version::Lite04,
+					our_setup: lite::Setup::default(),
+					peer_setup: None,
+				})?;
 
 				// Lite04 has no initial-set boundary, so this resolves immediately.
 				let (session, mut driver) = Session::new(
@@ -321,16 +321,16 @@ impl Client {
 					.ok_or(Error::Version)?;
 
 				// Starting with draft-03, there's no more SETUP control stream.
-				let start = lite::start(
-					session.clone(),
-					None,
-					publish.clone(),
-					subscribe.clone(),
-					self.peer_origin,
-					lite::Version::Lite03,
-					lite::Setup::default(),
-					None,
-				)?;
+				let start = lite::start(lite::Config {
+					session: session.clone(),
+					setup_stream: None,
+					publish: publish.clone(),
+					subscribe: subscribe.clone(),
+					peer_origin: self.peer_origin,
+					version: lite::Version::Lite03,
+					our_setup: lite::Setup::default(),
+					peer_setup: None,
+				})?;
 
 				// Lite03 has no initial-set boundary, so this resolves immediately.
 				let (session, mut driver) = Session::new(
@@ -382,18 +382,18 @@ impl Client {
 		let (recv_bw, protocol, connecting) = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
-				let start = lite::start(
-					session.clone(),
-					Some(stream),
-					publish.clone(),
-					subscribe.clone(),
-					self.peer_origin,
-					v,
+				let start = lite::start(lite::Config {
+					session: session.clone(),
+					setup_stream: Some(stream),
+					publish: publish.clone(),
+					subscribe: subscribe.clone(),
+					peer_origin: self.peer_origin,
+					version: v,
 					// This path only handles versions negotiated via the bidi SETUP exchange
 					// (pre-lite-05), which have no Setup Stream.
-					lite::Setup::default(),
-					None,
-				)?;
+					our_setup: lite::Setup::default(),
+					peer_setup: None,
+				})?;
 
 				(start.recv_bandwidth, start.driver, Some(start.connecting))
 			}

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -44,40 +44,58 @@ pub async fn accept_setup<S: web_transport_trait::Session>(session: &S, version:
 	}
 }
 
+/// Everything one moq-lite session needs to start.
+pub struct Config<S: web_transport_trait::Session> {
+	pub session: S,
+
+	/// The stream used to set up the session, after exchanging setup messages.
+	/// NOTE: No longer used in draft-03.
+	pub setup_stream: Option<Stream<S, Version>>,
+
+	/// We will publish any local broadcasts from this origin, when set.
+	pub publish: Option<origin::Consumer>,
+
+	/// We will consume any remote broadcasts, inserting them into this origin, when
+	/// set. Traffic stats are attributed through these origin handles: tag them with
+	/// `origin::{Consumer, Producer}::with_stats` before calling [`start`].
+	pub subscribe: Option<origin::Producer>,
+
+	/// The origin (hop) id assigned to the peer, used whenever the peer doesn't
+	/// declare one itself. See `Client::with_peer_origin`.
+	pub peer_origin: Option<Origin>,
+
+	/// The version of the protocol to use.
+	pub version: Version,
+
+	/// The capabilities (and optional request path) we advertise in our SETUP message.
+	/// Only sent on versions with a Setup Stream (lite-05+); ignored otherwise.
+	/// Its `origin` is filled in here from the attached origin handles.
+	pub our_setup: Setup,
+
+	/// The peer's SETUP, when it was already read before [`start`] (e.g. a server that
+	/// gated on the client's path via [`accept_setup`]). Seeds the peer-setup slot so
+	/// the Setup Stream isn't expected again. `None` reads it from the wire as usual.
+	pub peer_setup: Option<Setup>,
+}
+
 /// Start a lite session.
 ///
 /// Returns the receive-bandwidth consumer (if any) and a [`Connecting`] handle that
 /// becomes ready once the initial announce set has been inserted into the subscribe
 /// origin, letting `connect()` block past the startup race. It is ready immediately
 /// when there is nothing to wait on (a version without an initial-set boundary).
-// Internal entry point wiring a session together; the knobs are all distinct and
-// positional clarity beats a one-off config struct here.
-#[allow(clippy::too_many_arguments)]
-pub fn start<S: web_transport_trait::Session>(
-	session: S,
-	// The stream used to set up the session, after exchanging setup messages.
-	// NOTE: No longer used in draft-03.
-	setup_stream: Option<Stream<S, Version>>,
-	// We will publish any local broadcasts from this origin, when set.
-	publish: Option<origin::Consumer>,
-	// We will consume any remote broadcasts, inserting them into this origin, when set.
-	// Traffic stats are attributed through these origin handles: tag them with
-	// `origin::{Consumer, Producer}::with_stats` before calling `start`.
-	subscribe: Option<origin::Producer>,
-	// The origin (hop) id assigned to the peer, used whenever the peer doesn't
-	// declare one itself. See `Client::with_peer_origin`.
-	peer_origin: Option<Origin>,
-	// The version of the protocol to use.
-	version: Version,
-	// The capabilities (and optional request path) we advertise in our SETUP message.
-	// Only sent on versions with a Setup Stream (lite-05+); ignored otherwise.
-	// Its `origin` is filled in here from the attached origin handles.
-	mut our_setup: Setup,
-	// The peer's SETUP, when it was already read before `start` (e.g. a server that
-	// gated on the client's path via [`accept_setup`]). Seeds the peer-setup slot so
-	// the Setup Stream isn't expected again. `None` reads it from the wire as usual.
-	peer_setup: Option<Setup>,
-) -> Result<SessionStart, Error> {
+pub fn start<S: web_transport_trait::Session>(config: Config<S>) -> Result<SessionStart, Error> {
+	let Config {
+		session,
+		setup_stream,
+		publish,
+		subscribe,
+		peer_origin,
+		version,
+		mut our_setup,
+		peer_setup,
+	} = config;
+
 	let recv_bw = bandwidth::Producer::new();
 
 	let recv_bw_consumer = match version {

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -46,6 +46,8 @@ pub async fn accept_setup<S: web_transport_trait::Session>(session: &S, version:
 
 /// Everything one moq-lite session needs to start.
 pub struct Config<S: web_transport_trait::Session> {
+	/// The transport carrying the session. Cloned into every loop that outlives
+	/// [`start`], so the connection closes when the last of them drops.
 	pub session: S,
 
 	/// The stream used to set up the session, after exchanging setup messages.

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -406,16 +406,16 @@ impl<S: web_transport_trait::Session> Request<S> {
 				return Ok(Session::new(session, version.into(), None, protocol));
 			}
 			Handshake::LiteBare { session, version } => {
-				let start = lite::start(
-					session.clone(),
-					None,
+				let start = lite::start(lite::Config {
+					session: session.clone(),
+					setup_stream: None,
 					publish,
 					subscribe,
-					None,
+					peer_origin: None,
 					version,
-					lite::Setup::default(),
-					None,
-				)?;
+					our_setup: lite::Setup::default(),
+					peer_setup: None,
+				})?;
 				return Ok(Session::new(
 					session,
 					version.into(),
@@ -438,16 +438,16 @@ impl<S: web_transport_trait::Session> Request<S> {
 					// Filled by `lite::start` from the attached origin handles.
 					origin: None,
 				};
-				let start = lite::start(
-					session.clone(),
-					None,
+				let start = lite::start(lite::Config {
+					session: session.clone(),
+					setup_stream: None,
 					publish,
 					subscribe,
-					None,
+					peer_origin: None,
 					version,
 					our_setup,
-					Some(client_setup),
-				)?;
+					peer_setup: Some(client_setup),
+				})?;
 				return Ok(Session::new(
 					session,
 					version.into(),
@@ -484,16 +484,16 @@ impl<S: web_transport_trait::Session> Request<S> {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
 				// Pre-lite-05: no Setup Stream, so nothing to advertise or seed.
-				let start = lite::start(
-					session.clone(),
-					Some(stream),
+				let start = lite::start(lite::Config {
+					session: session.clone(),
+					setup_stream: Some(stream),
 					publish,
 					subscribe,
-					None,
-					v,
-					lite::Setup::default(),
-					None,
-				)?;
+					peer_origin: None,
+					version: v,
+					our_setup: lite::Setup::default(),
+					peer_setup: None,
+				})?;
 				(start.recv_bandwidth, start.driver)
 			}
 			Version::Ietf(v) => {


### PR DESCRIPTION
## Summary

`lite::start` took eight positional arguments, three of them a bare `None`, and every call site passed at least two:

```rust
lite::start(session.clone(), None, publish, subscribe, None, version, lite::Setup::default(), None)?;
```

Nothing there says which `None` is the setup stream, which is the peer origin, and which is the peer's SETUP. On several arms, swapping two of them still compiles.

`ietf::start` already takes a `Config` for exactly this job, so this makes the two halves of the crate match:

```rust
lite::start(lite::Config {
    session: session.clone(),
    setup_stream: None,
    publish,
    subscribe,
    peer_origin: None,
    version,
    our_setup: lite::Setup::default(),
    peer_setup: None,
})?;
```

The per-argument comments become field docs, so they render for anyone reading the type rather than only for someone scrolling the signature.

This also drops the `#[allow(clippy::too_many_arguments)]` and the comment above it arguing that positional clarity beat a config struct here. That call was deliberate and I raised it before changing it; overriding it is @kixelated's call, and this is that override.

## Test plan

- Mechanical: seven call sites (four in `client.rs`, three in `server.rs`), no behavior change.
- `just check` (clippy clean without the `allow`), `cargo nextest run -p moq-net` (698 passed).

## Cross-package sync

`mod lite` is private in `lib.rs`, so `lite::start` and `lite::Config` are crate-internal and no published surface moves. No wire, FFI, or config change, so no row applies.

(Written by Opus 5)