### PR TITLE
feat(moq-native): classify, pace, and publish accept(2) failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,6 +4580,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "jni 0.22.4",
+ "libc",
  "moq-net",
  "noq-proto",
  "notify",

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -116,9 +116,9 @@ network.
 listen = "127.0.0.1:9101"
 ```
 
-It serves `/health`, Prometheus traffic counters at `/metrics`, and the local
-cluster topology view at `/nodes`. See [HTTP Endpoints](/bin/relay/http) for the
-response formats.
+It serves `/health`, Prometheus traffic and listener counters at `/metrics`, and
+the local cluster topology view at `/nodes`. See
+[HTTP Endpoints](/bin/relay/http) for the response formats.
 
 ### \[web.https]
 

--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -103,8 +103,40 @@ Bind it only to loopback or a trusted private network:
 listen = "127.0.0.1:9101"
 ```
 
-It mirrors `/health`, exposes Prometheus traffic counters at `/metrics`, and
-adds the cluster topology endpoint below.
+It mirrors `/health`, exposes Prometheus counters at `/metrics`, and adds the
+cluster topology endpoint below.
+
+### GET /metrics
+
+Prometheus text exposition of this node's own traffic counters (bytes, frames,
+groups, subscriptions, viewers, sessions), split by `tier` and `role`.
+
+Alongside them are the TCP listeners' accept-loop counters, which are how a node
+that has stopped accepting connections says so:
+
+```
+moq_relay_accept_failures_total{listener="web",class="connection"} 41
+moq_relay_accept_failures_total{listener="web",class="exhausted"} 0
+moq_relay_accept_failures_total{listener="web",class="unknown"} 0
+moq_relay_accept_stalled_seconds{listener="web"} 0
+```
+
+`connection` counts connections that died before the relay dequeued them (a peer
+reset, a firewall rule, a scanner): ordinary traffic on a public port, and never
+a fault. A non-zero `exhausted` is the one worth paging on, and means the process
+or the host ran out of a resource `accept` needs (file descriptors, kernel
+memory) while connections were queued; `moq_relay_accept_stalled_seconds` is how
+long that has been true, and only a successful accept clears it. `unknown` is an
+errno the relay does not classify: worth a look, not an alert.
+
+Alert on the `exhausted` counter rather than the gauge. A process out of
+descriptors often cannot serve this scrape either, so the gauge tends to read
+zero again by the time a scrape gets through, while the counter still shows the
+jump.
+
+Nothing here reports host CPU, memory, disk, or network; run a node exporter for
+those. The QUIC listener has no accept counters at all: it multiplexes every
+session over one UDP socket, so it never calls `accept` and cannot exhaust it.
 
 ### GET /nodes
 

--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -121,6 +121,13 @@ moq_relay_accept_failures_total{listener="web",class="unknown"} 0
 moq_relay_accept_stalled_seconds{listener="web"} 0
 ```
 
+One `listener` per socket that is actually configured: `web` for the HTTP/HTTPS
+pair, `internal` for this listener, and `tcp` / `unix` for the qmux stream
+listeners. A listener you have not configured is absent rather than zero, so a
+stream-only relay publishes no `web` series at all. That is deliberate: a
+permanent zero for a socket nobody opened reads as a watch that is passing, when
+there is nothing there to watch.
+
 `connection` counts connections that died before the relay dequeued them (a peer
 reset, a firewall rule, a scanner): ordinary traffic on a public port, and never
 a fault. A non-zero `exhausted` is the one worth paging on, and means the process

--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -114,7 +114,7 @@ groups, subscriptions, viewers, sessions), split by `tier` and `role`.
 Alongside them are the TCP listeners' accept-loop counters, which are how a node
 that has stopped accepting connections says so:
 
-```
+```text
 moq_relay_accept_failures_total{listener="web",class="connection"} 41
 moq_relay_accept_failures_total{listener="web",class="exhausted"} 0
 moq_relay_accept_failures_total{listener="web",class="unknown"} 0

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -82,6 +82,11 @@ web-transport-quinn = { workspace = true, optional = true }
 web-transport-trait = { workspace = true }
 x509-parser = "0.18"
 
+[target.'cfg(unix)'.dependencies]
+# Errno constants for classifying an `accept(2)` failure (`accept::Failure`).
+# Their numeric values differ across unix platforms, so they can't be spelled out.
+libc = "0.2"
+
 [target.'cfg(target_os = "android")'.dependencies]
 # Android's platform verifier needs a JNI handle to the app Context (see
 # `tls::init_android`); jni is the bridge. Until init runs, verification falls

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -82,11 +82,6 @@ web-transport-quinn = { workspace = true, optional = true }
 web-transport-trait = { workspace = true }
 x509-parser = "0.18"
 
-[target.'cfg(unix)'.dependencies]
-# Errno constants for classifying an `accept(2)` failure (`accept::Failure`).
-# Their numeric values differ across unix platforms, so they can't be spelled out.
-libc = "0.2"
-
 [target.'cfg(target_os = "android")'.dependencies]
 # Android's platform verifier needs a JNI handle to the app Context (see
 # `tls::init_android`); jni is the bridge. Until init runs, verification falls
@@ -94,6 +89,11 @@ libc = "0.2"
 jni = "0.22"
 tracing-android = { version = "0.2", optional = true }
 webpki-roots = "1"
+
+[target.'cfg(unix)'.dependencies]
+# Errno constants for classifying an `accept(2)` failure (`accept::Failure`).
+# Their numeric values differ across unix platforms, so they can't be spelled out.
+libc = "0.2"
 
 [dev-dependencies]
 anyhow = "1"

--- a/rs/moq-native/src/accept.rs
+++ b/rs/moq-native/src/accept.rs
@@ -50,8 +50,15 @@ pub enum Failure {
 	///
 	/// Ordinary traffic, and never a fault of the listener. The queue entry is
 	/// consumed, so the very next `accept` makes progress and delaying it would only
-	/// punish the connections queued behind the dead one. A peer able to open and
-	/// reset connections in bulk would otherwise hold the listener at the retry cap.
+	/// punish the connections queued behind the dead one, at whatever rate a remote
+	/// peer chooses to supply them.
+	///
+	/// How reachable that is depends on the platform. Linux surfaces a new socket's
+	/// already-pending network errors through `accept` (which BSD does not, and which
+	/// is why the list is as long as it is), but drops a connection reset before
+	/// `accept` from the queue silently rather than reporting `ECONNABORTED`. So the
+	/// simplest flood is louder on BSD than on Linux; the handling is the same either
+	/// way.
 	Connection,
 	/// A resource `accept` needs is exhausted process-wide or host-wide: the process
 	/// fd table (`EMFILE`), the system-wide one (`ENFILE`), or kernel memory for the

--- a/rs/moq-native/src/accept.rs
+++ b/rs/moq-native/src/accept.rs
@@ -76,7 +76,11 @@ pub enum Failure {
 impl Failure {
 	/// Every class, for a caller enumerating [`Health::failures`] into a metrics
 	/// endpoint.
-	pub const ALL: [Failure; 3] = [Failure::Connection, Failure::Exhausted, Failure::Unknown];
+	///
+	/// A slice rather than an array: the length of an array is part of the type, so
+	/// `[Failure; 3]` would make adding a class a breaking change for every caller
+	/// that named the type, defeating the `#[non_exhaustive]` above.
+	pub const ALL: &'static [Failure] = &[Failure::Connection, Failure::Exhausted, Failure::Unknown];
 
 	/// Classify a failed `accept(2)`.
 	///

--- a/rs/moq-native/src/accept.rs
+++ b/rs/moq-native/src/accept.rs
@@ -1,0 +1,397 @@
+//! Accept-loop health for the listeners that perform a real `accept(2)`.
+//!
+//! A listener loop cannot treat every `accept` failure the same way. The errnos
+//! `accept` returns mix two families that want opposite handling, and getting them
+//! backwards is not symmetric: pausing after a dead connection punishes the
+//! connections queued behind it, while retrying instantly after fd exhaustion is a
+//! hot loop burning the CPU the process needs in order to recover. [`Failure`] is
+//! that classification and [`Health`] applies it, so a listener's failure arm is
+//! one call rather than a policy each caller re-derives.
+//!
+//! [`Health`] is also the only thing that leaves the process when a listener goes
+//! dark. The loops here never give up (an accept loop is a process-lifetime
+//! supervisor with nobody to return an error to), so a node can be unable to accept
+//! a single TCP connection while every other signal looks healthy. The cumulative
+//! counters are the load-bearing half rather than [`stalled`](Health::stalled): a
+//! process with no descriptors left cannot serve a metrics scrape either, so the
+//! episode is often only visible once it is over, and a gauge read after recovery
+//! reads a healthy nothing while a counter still shows the jump.
+//!
+//! Only a listener that performs a real `accept(2)` has anything to report here.
+//! The QUIC backends multiplex every session over one UDP socket, so they never
+//! call `accept` and exhaustion cannot reach them; registering one would publish a
+//! permanently-zero counter, which reads as a watch that is passing when it is
+//! really a watch that can never fire.
+
+use std::{
+	io,
+	sync::{
+		Arc,
+		atomic::{AtomicU64, Ordering},
+	},
+	time::{Duration, Instant},
+};
+
+/// Delay after an accept failure that is not one connection's fault, escalating
+/// while they continue and reset by the next successful accept.
+///
+/// Capped in seconds rather than minutes: the loop is a supervisor that must stay
+/// responsive to a resource being returned, so it keeps asking at a rate that
+/// recovers promptly without spinning.
+const RETRY_MIN: Duration = Duration::from_millis(100);
+const RETRY_MAX: Duration = Duration::from_secs(5);
+
+/// What a failed `accept(2)` means for the listener that saw it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Failure {
+	/// One pending connection died on its way to us: the peer reset it before we
+	/// dequeued it, a firewall rule dropped it, its handshake timed out.
+	///
+	/// Ordinary traffic, and never a fault of the listener. The queue entry is
+	/// consumed, so the very next `accept` makes progress and delaying it would only
+	/// punish the connections queued behind the dead one. A peer able to open and
+	/// reset connections in bulk would otherwise hold the listener at the retry cap.
+	Connection,
+	/// A resource `accept` needs is exhausted process-wide or host-wide: the process
+	/// fd table (`EMFILE`), the system-wide one (`ENFILE`), or kernel memory for the
+	/// new socket (`ENOBUFS`/`ENOMEM`).
+	///
+	/// The connection stays queued, so the listener is instantly readable and
+	/// instantly failing until something outside this loop returns the resource.
+	Exhausted,
+	/// An errno we don't recognize. Worth backing off on, never worth claiming a
+	/// cause for: an unrecognized failure on ordinary traffic could be driven by a
+	/// remote peer, so escalating on it hands out a remote lever.
+	Unknown,
+}
+
+impl Failure {
+	/// Every class, for a caller enumerating [`Health::failures`] into a metrics
+	/// endpoint.
+	pub const ALL: [Failure; 3] = [Failure::Connection, Failure::Exhausted, Failure::Unknown];
+
+	/// Classify a failed `accept(2)`.
+	pub fn classify(err: &io::Error) -> Self {
+		match err.raw_os_error() {
+			Some(code) if EXHAUSTED.contains(&code) => Self::Exhausted,
+			Some(code) if PER_CONNECTION.contains(&code) => Self::Connection,
+			_ => Self::Unknown,
+		}
+	}
+
+	/// The stable lowercase name used in logs and metric labels.
+	pub const fn as_str(self) -> &'static str {
+		match self {
+			Self::Connection => "connection",
+			Self::Exhausted => "exhausted",
+			Self::Unknown => "unknown",
+		}
+	}
+}
+
+impl std::fmt::Display for Failure {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
+}
+
+/// Errnos meaning `accept` itself had nothing to work with. All of these persist
+/// until something outside the accept loop returns the resource.
+#[cfg(unix)]
+const EXHAUSTED: &[i32] = &[libc::EMFILE, libc::ENFILE, libc::ENOBUFS, libc::ENOMEM];
+
+/// Errnos belonging to the one connection being dequeued. The bulk of the list is
+/// the "already-pending network error on the new socket" set `accept(2)` documents
+/// on Linux; each reports the state of that connection, never of the listener.
+#[cfg(unix)]
+const PER_CONNECTION: &[i32] = &[
+	libc::ECONNABORTED,
+	libc::ECONNRESET,
+	libc::ETIMEDOUT,
+	// A netfilter/firewall rule rejected this connection.
+	libc::EPERM,
+	libc::EPROTO,
+	libc::ENOPROTOOPT,
+	libc::EOPNOTSUPP,
+	libc::EHOSTDOWN,
+	libc::EHOSTUNREACH,
+	libc::ENETDOWN,
+	libc::ENETUNREACH,
+	// Not a connection error at all: the syscall was interrupted by a signal.
+	// Grouped here because it wants the same handling (retry at once) and says
+	// nothing about the listener.
+	libc::EINTR,
+];
+
+/// Winsock reports the same two families under `WSAE*` codes rather than errnos.
+/// Spelled out because the constants live in `windows-sys`, which is a large
+/// dependency to take on for four integers; they are fixed by the Winsock ABI.
+#[cfg(windows)]
+const EXHAUSTED: &[i32] = &[
+	10024, // WSAEMFILE: too many open sockets
+	10055, // WSAENOBUFS: no buffer space available
+];
+
+#[cfg(windows)]
+const PER_CONNECTION: &[i32] = &[
+	10053, // WSAECONNABORTED
+	10054, // WSAECONNRESET
+	10060, // WSAETIMEDOUT
+	10064, // WSAEHOSTDOWN
+	10065, // WSAEHOSTUNREACH
+	10050, // WSAENETDOWN
+	10051, // WSAENETUNREACH
+];
+
+/// One listener's accept-loop health: how to react to a failure, and what a
+/// supervisor outside the process can read back.
+///
+/// Cheap to clone; every clone shares one listener's state. The listeners here
+/// build their own and hand out a clone through their `accept_health()` method (as
+/// does the relay's web server), while an embedder driving its own listener
+/// constructs one with [`new`](Self::new).
+///
+/// This owns the backoff rather than each loop inlining its own, which is the one
+/// place that indirection earns its keep: the classification above is the whole
+/// point of the pacing, and five listeners that each re-derive it will not agree
+/// for long.
+#[derive(Clone)]
+pub struct Health(Arc<Inner>);
+
+struct Inner {
+	listener: &'static str,
+	connection: AtomicU64,
+	exhausted: AtomicU64,
+	unknown: AtomicU64,
+	state: parking_lot::Mutex<State>,
+}
+
+struct State {
+	/// When the current run of exhaustion failures began, if one is in progress.
+	stall: Option<Instant>,
+	/// Consecutive failures since the last successful accept.
+	consecutive: u64,
+	/// The next un-jittered delay, escalating while accepts keep failing.
+	delay: Duration,
+}
+
+impl Health {
+	/// Track a listener reported under `listener` (the name used in logs and as a
+	/// metric label).
+	pub fn new(listener: &'static str) -> Self {
+		Self(Arc::new(Inner {
+			listener,
+			connection: AtomicU64::new(0),
+			exhausted: AtomicU64::new(0),
+			unknown: AtomicU64::new(0),
+			state: parking_lot::Mutex::new(State {
+				stall: None,
+				consecutive: 0,
+				delay: RETRY_MIN,
+			}),
+		}))
+	}
+
+	/// The name this listener is reported under.
+	pub fn listener(&self) -> &'static str {
+		self.0.listener
+	}
+
+	/// An accept succeeded: the listener is serving, so any stall is over and the
+	/// next failure starts from the shortest delay again.
+	pub fn accepted(&self) {
+		let mut state = self.0.state.lock();
+		if state.stall.take().is_some() {
+			tracing::info!(listener = self.0.listener, "listener is accepting again");
+		}
+		state.consecutive = 0;
+		state.delay = RETRY_MIN;
+	}
+
+	/// An accept failed: classify it, count it, log it, and return how long the loop
+	/// should wait before asking again.
+	///
+	/// `None` means retry at once, which is what a [`Failure::Connection`] wants:
+	/// the queue entry was consumed, so the listener has already made progress.
+	#[must_use = "an accept failure that is not one connection's fault must be paced, or the loop spins"]
+	pub fn failed(&self, err: &io::Error) -> Option<Duration> {
+		let failure = Failure::classify(err);
+		self.counter(failure).fetch_add(1, Ordering::Relaxed);
+
+		if failure == Failure::Connection {
+			// Ordinary traffic. Warning per occurrence would drown the log the moment
+			// a scanner shows up, and there is nothing for an operator to do.
+			tracing::debug!(listener = self.0.listener, %err, "dropped a connection before accepting it");
+			return None;
+		}
+
+		let mut state = self.0.state.lock();
+		state.consecutive += 1;
+		let delay = jitter(state.delay);
+		state.delay = (state.delay * 2).min(RETRY_MAX);
+
+		let stalled = match failure {
+			Failure::Exhausted => Some(state.stall.get_or_insert_with(Instant::now).elapsed()),
+			_ => None,
+		};
+
+		tracing::warn!(
+			listener = self.0.listener,
+			%err,
+			class = failure.as_str(),
+			consecutive = state.consecutive,
+			stalled_secs = stalled.map(|stalled| stalled.as_secs()),
+			retry_in_ms = delay.as_millis(),
+			"accept failed; the listener is not serving new connections"
+		);
+
+		Some(delay)
+	}
+
+	/// Failed accepts of this class since the process started.
+	///
+	/// Cumulative and never reset, so a scrape that lands after the episode still
+	/// sees it. Classes are counted apart rather than totalled because they are not
+	/// comparable: [`Failure::Connection`] tracks how much junk traffic the node is
+	/// fielding, while a non-zero [`Failure::Exhausted`] means the process ran out of
+	/// something it needs to serve anyone.
+	pub fn failures(&self, failure: Failure) -> u64 {
+		self.counter(failure).load(Ordering::Relaxed)
+	}
+
+	/// How long the listener has been unable to accept, when a
+	/// [`Failure::Exhausted`] stall is in progress.
+	///
+	/// Only a successful accept clears it, so a listener with no traffic holds its
+	/// last value rather than claiming a recovery it has no evidence for.
+	pub fn stalled(&self) -> Option<Duration> {
+		self.0.state.lock().stall.map(|since| since.elapsed())
+	}
+
+	fn counter(&self, failure: Failure) -> &AtomicU64 {
+		match failure {
+			Failure::Connection => &self.0.connection,
+			Failure::Exhausted => &self.0.exhausted,
+			Failure::Unknown => &self.0.unknown,
+		}
+	}
+}
+
+impl std::fmt::Debug for Health {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Health")
+			.field("listener", &self.0.listener)
+			.field("connection", &self.failures(Failure::Connection))
+			.field("exhausted", &self.failures(Failure::Exhausted))
+			.field("unknown", &self.failures(Failure::Unknown))
+			.field("stalled", &self.stalled())
+			.finish()
+	}
+}
+
+/// Equal jitter: half the delay is a firm floor, so a flapping listener always
+/// waits a meaningful amount, while the random half keeps a fleet that failed on
+/// the same tick from retrying in lockstep.
+fn jitter(delay: Duration) -> Duration {
+	use rand::RngExt as _;
+	delay.mul_f64(0.5 + rand::rng().random::<f64>() / 2.0)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn io(code: i32) -> io::Error {
+		io::Error::from_raw_os_error(code)
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn classifies_exhaustion_apart_from_dead_connections() {
+		// The whole point: a peer that reset before we accepted it is ordinary
+		// traffic, so it must never read as exhaustion. Counting it as one hands a
+		// remote peer a lever on whatever the exhaustion signal drives.
+		for code in [
+			libc::ECONNABORTED,
+			libc::ECONNRESET,
+			libc::EPERM,
+			libc::EPROTO,
+			libc::ETIMEDOUT,
+			libc::EHOSTUNREACH,
+			libc::ENETDOWN,
+			libc::EINTR,
+		] {
+			assert_eq!(Failure::classify(&io(code)), Failure::Connection, "errno {code}");
+		}
+
+		for code in [libc::EMFILE, libc::ENFILE, libc::ENOBUFS, libc::ENOMEM] {
+			assert_eq!(Failure::classify(&io(code)), Failure::Exhausted, "errno {code}");
+		}
+
+		// Unrecognized is Unknown, not Exhausted: a new failure mode earns a backoff
+		// and a warning, never a claim about the cause.
+		assert_eq!(Failure::classify(&io(libc::EINVAL)), Failure::Unknown);
+		assert_eq!(Failure::classify(&io::Error::other("never seen")), Failure::Unknown);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn a_dead_connection_never_pauses_the_listener() {
+		let health = Health::new("test");
+
+		// A pause here would let a peer opening and resetting connections in bulk
+		// hold the listener at the retry cap, starving legitimate ones.
+		assert_eq!(health.failed(&io(libc::ECONNABORTED)), None);
+		assert_eq!(health.failures(Failure::Connection), 1);
+		assert_eq!(health.stalled(), None, "a dead connection is not a stall");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn exhaustion_escalates_and_caps() {
+		let health = Health::new("test");
+
+		// Equal jitter, so each delay lands in [d/2, d] for the un-jittered d.
+		for expected in [RETRY_MIN, RETRY_MIN * 2, RETRY_MIN * 4] {
+			let delay = health.failed(&io(libc::EMFILE)).expect("exhaustion must pace");
+			assert!(
+				delay >= expected / 2 && delay <= expected,
+				"{delay:?} outside {expected:?}"
+			);
+		}
+
+		// Keep failing and it settles at the cap rather than climbing into minutes:
+		// the loop has to stay responsive to the resource coming back.
+		for _ in 0..20 {
+			let delay = health.failed(&io(libc::EMFILE)).expect("exhaustion must pace");
+			assert!(delay <= RETRY_MAX);
+		}
+
+		assert!(health.stalled().is_some(), "exhaustion is a sustained condition");
+		assert_eq!(health.failures(Failure::Exhausted), 23);
+		assert_eq!(health.failures(Failure::Connection), 0);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn a_successful_accept_ends_the_stall_and_the_backoff() {
+		let health = Health::new("test");
+		for _ in 0..5 {
+			let _ = health.failed(&io(libc::EMFILE));
+		}
+		assert!(health.stalled().is_some());
+
+		health.accepted();
+		assert_eq!(health.stalled(), None);
+
+		// Back to the shortest delay: the next episode is a new one, not a
+		// continuation of a schedule that already climbed to the cap.
+		let delay = health.failed(&io(libc::EMFILE)).expect("exhaustion must pace");
+		assert!(delay <= RETRY_MIN);
+
+		// The counters do NOT reset. They are what a scrape landing after the
+		// episode has to see, since the process could not answer one during it.
+		assert_eq!(health.failures(Failure::Exhausted), 6);
+	}
+}

--- a/rs/moq-native/src/accept.rs
+++ b/rs/moq-native/src/accept.rs
@@ -79,10 +79,14 @@ impl Failure {
 	pub const ALL: [Failure; 3] = [Failure::Connection, Failure::Exhausted, Failure::Unknown];
 
 	/// Classify a failed `accept(2)`.
+	///
+	/// Unrecognized is [`Unknown`](Self::Unknown), never [`Connection`](Self::Connection):
+	/// the default has to be the one that paces, because guessing "per connection" on a
+	/// listener-wide failure is the mistake that spins.
 	pub fn classify(err: &io::Error) -> Self {
 		match err.raw_os_error() {
-			Some(code) if EXHAUSTED.contains(&code) => Self::Exhausted,
-			Some(code) if PER_CONNECTION.contains(&code) => Self::Connection,
+			Some(code) if exhausted(code) => Self::Exhausted,
+			Some(code) if per_connection(code) => Self::Connection,
 			_ => Self::Unknown,
 		}
 	}
@@ -103,53 +107,88 @@ impl std::fmt::Display for Failure {
 	}
 }
 
-/// Errnos meaning `accept` itself had nothing to work with. All of these persist
-/// until something outside the accept loop returns the resource.
+/// Whether `accept` itself had nothing to work with, so the failure persists until
+/// something outside the accept loop returns the resource.
 #[cfg(unix)]
-const EXHAUSTED: &[i32] = &[libc::EMFILE, libc::ENFILE, libc::ENOBUFS, libc::ENOMEM];
+fn exhausted(code: i32) -> bool {
+	[libc::EMFILE, libc::ENFILE, libc::ENOBUFS, libc::ENOMEM].contains(&code)
+}
 
-/// Errnos belonging to the one connection being dequeued. The bulk of the list is
-/// the "already-pending network error on the new socket" set `accept(2)` documents
-/// on Linux; each reports the state of that connection, never of the listener.
+/// Whether the failure belongs to the one connection being dequeued rather than to
+/// the listener.
+///
+/// The bulk of the list is the "already-pending network error on the new socket" set
+/// `accept(2)` documents on Linux, which is a Linux behavior specifically (BSD holds
+/// the error until the socket is used). Each reports the state of that connection,
+/// never of the listener, so each is safe to retry at once.
 #[cfg(unix)]
-const PER_CONNECTION: &[i32] = &[
-	libc::ECONNABORTED,
-	libc::ECONNRESET,
-	libc::ETIMEDOUT,
-	// A netfilter/firewall rule rejected this connection.
-	libc::EPERM,
-	libc::EPROTO,
-	libc::ENOPROTOOPT,
-	libc::EOPNOTSUPP,
-	libc::EHOSTDOWN,
-	libc::EHOSTUNREACH,
-	libc::ENETDOWN,
-	libc::ENETUNREACH,
-	// Not a connection error at all: the syscall was interrupted by a signal.
-	// Grouped here because it wants the same handling (retry at once) and says
-	// nothing about the listener.
-	libc::EINTR,
-];
+fn per_connection(code: i32) -> bool {
+	let common = [
+		libc::ECONNABORTED,
+		libc::ECONNRESET,
+		libc::ETIMEDOUT,
+		// A netfilter/firewall rule rejected this connection.
+		libc::EPERM,
+		libc::EPROTO,
+		libc::ENOPROTOOPT,
+		libc::EOPNOTSUPP,
+		libc::EHOSTDOWN,
+		libc::EHOSTUNREACH,
+		libc::ENETDOWN,
+		libc::ENETUNREACH,
+		// Not a connection error at all: the syscall was interrupted by a signal.
+		// Grouped here because it wants the same handling (retry at once) and says
+		// nothing about the listener.
+		libc::EINTR,
+	]
+	.contains(&code);
 
-/// Winsock reports the same two families under `WSAE*` codes rather than errnos.
-/// Spelled out because the constants live in `windows-sys`, which is a large
-/// dependency to take on for four integers; they are fixed by the Winsock ABI.
+	// `ENONET` rounds out the pending-error set above, and exists only where that set
+	// does: it is absent from the BSD/Apple headers entirely.
+	#[cfg(any(target_os = "linux", target_os = "android"))]
+	let common = common || code == libc::ENONET;
+
+	common
+}
+
+/// Winsock reports these under `WSAE*` codes rather than errnos. Spelled out because
+/// the constants live in `windows-sys`, a large dependency to take on for four
+/// integers; they are fixed by the Winsock ABI.
+///
+/// Deliberately narrower than the unix set. `accept` on Windows documents far fewer
+/// per-connection failures, and the ones that look analogous are not: `WSAENETDOWN`
+/// is "the network subsystem has failed", which is listener-wide and would spin if
+/// retried at once. Anything not listed here lands in [`Failure::Unknown`], which
+/// paces, so the narrow list fails safe.
 #[cfg(windows)]
-const EXHAUSTED: &[i32] = &[
-	10024, // WSAEMFILE: too many open sockets
-	10055, // WSAENOBUFS: no buffer space available
-];
+fn exhausted(code: i32) -> bool {
+	[
+		10024, // WSAEMFILE: no more socket descriptors available
+		10055, // WSAENOBUFS: no buffer space available
+	]
+	.contains(&code)
+}
 
 #[cfg(windows)]
-const PER_CONNECTION: &[i32] = &[
-	10053, // WSAECONNABORTED
-	10054, // WSAECONNRESET
-	10060, // WSAETIMEDOUT
-	10064, // WSAEHOSTDOWN
-	10065, // WSAEHOSTUNREACH
-	10050, // WSAENETDOWN
-	10051, // WSAENETUNREACH
-];
+fn per_connection(code: i32) -> bool {
+	[
+		10053, // WSAECONNABORTED: software caused connection abort
+		10054, // WSAECONNRESET: the peer terminated the indicated connection
+	]
+	.contains(&code)
+}
+
+/// No error table for a platform we have never run a listener on. Everything is
+/// [`Failure::Unknown`], which paces and warns rather than claiming a cause.
+#[cfg(not(any(unix, windows)))]
+fn exhausted(_code: i32) -> bool {
+	false
+}
+
+#[cfg(not(any(unix, windows)))]
+fn per_connection(_code: i32) -> bool {
+	false
+}
 
 /// One listener's accept-loop health: how to react to a failure, and what a
 /// supervisor outside the process can read back.
@@ -340,6 +379,28 @@ mod tests {
 		// and a warning, never a claim about the cause.
 		assert_eq!(Failure::classify(&io(libc::EINVAL)), Failure::Unknown);
 		assert_eq!(Failure::classify(&io::Error::other("never seen")), Failure::Unknown);
+	}
+
+	/// `ENONET` belongs to the pending-error set the `classifies_*` test covers, and
+	/// exists only on Linux, so it needs its own gate. Without it the errno lands in
+	/// `Unknown` and a firewalled connection costs the listener a backoff.
+	#[cfg(any(target_os = "linux", target_os = "android"))]
+	#[test]
+	fn linux_pending_network_errors_are_per_connection() {
+		assert_eq!(Failure::classify(&io(libc::ENONET)), Failure::Connection);
+	}
+
+	/// Not compiled on a unix host; the Windows gates in `just rs windows` are the
+	/// only thing that builds this.
+	#[cfg(windows)]
+	#[test]
+	fn windows_subsystem_failure_is_not_per_connection() {
+		// WSAENETDOWN is "the network subsystem has failed", which is listener-wide.
+		// Retrying it at once is the spin this module exists to prevent, so it must
+		// fall through to Unknown (which paces) rather than read as one dead peer.
+		assert_eq!(Failure::classify(&io(10050)), Failure::Unknown);
+		assert_eq!(Failure::classify(&io(10054)), Failure::Connection);
+		assert_eq!(Failure::classify(&io(10024)), Failure::Exhausted);
 	}
 
 	#[cfg(unix)]

--- a/rs/moq-native/src/bind.rs
+++ b/rs/moq-native/src/bind.rs
@@ -47,8 +47,8 @@ pub(crate) fn udp_is_dual_stack(socket: &UdpSocket) -> bool {
 
 /// Bind a TCP listener, making an IPv6 socket dual-stack so it also serves IPv4.
 ///
-/// The returned listener is non-blocking, ready for
-/// [`axum_server::from_tcp`](https://docs.rs/axum-server).
+/// The returned listener is non-blocking, ready to be adopted by an async runtime
+/// (`tokio::net::TcpListener::from_std`, `axum_server::from_tcp`).
 pub fn tcp(addr: SocketAddr) -> std::io::Result<TcpListener> {
 	let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
 	let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
@@ -59,9 +59,9 @@ pub fn tcp(addr: SocketAddr) -> std::io::Result<TcpListener> {
 	socket.set_reuse_address(true)?;
 	// Enable keepalive on the listening socket so every accepted connection
 	// inherits it (accept() carries socket options across on Linux, macOS, and
-	// Windows). axum_server owns the accept loop, so this is the one hook we have
-	// to reach the HTTP/HTTPS/WebSocket connections it serves. Best-effort: a
-	// platform that rejects the option keeps the connection rather than failing.
+	// Windows). Setting it once here reaches every HTTP/HTTPS/WebSocket connection
+	// without the serve loop touching each one. Best-effort: a platform that rejects
+	// the option keeps the connection rather than failing.
 	let keepalive = TcpKeepalive::new()
 		.with_time(KEEPALIVE_IDLE)
 		.with_interval(KEEPALIVE_INTERVAL);

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -12,6 +12,7 @@
 
 #![warn(missing_docs)]
 
+pub mod accept;
 pub mod bind;
 mod client;
 mod connect;

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -336,6 +336,27 @@ impl Server {
 		unreachable!("no transport compiled; enable a QUIC backend, tcp, or uds feature");
 	}
 
+	/// The accept-loop health of every listener this server owns that performs a real
+	/// `accept(2)`: the `tcp`/`unix` stream listeners and, if one was set,
+	/// [`with_websocket`](Self::with_websocket).
+	///
+	/// Empty on a QUIC-only server, which is the honest answer rather than a
+	/// convenient one: a QUIC backend multiplexes every session over one UDP socket,
+	/// so it never calls `accept` and has nothing that could fail this way. Publishing
+	/// a zero for it would read as a watch that is passing when it can never fire.
+	///
+	/// Available before [`listen`](Self::listen), so an owner can register these with
+	/// a metrics endpoint at startup even though the sockets bind later.
+	pub fn accept_health(&self) -> Vec<crate::accept::Health> {
+		#[allow(unused_mut)]
+		let mut health = Vec::new();
+		#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
+		health.extend(self.streams.health.iter().cloned());
+		#[cfg(feature = "websocket")]
+		health.extend(self.websocket.as_ref().map(|ws| ws.accept_health()));
+		health
+	}
+
 	/// Bind the listeners that bind lazily, so a bind failure surfaces here.
 	///
 	/// The QUIC socket is bound by [`ServerConfig::init`], but the stream
@@ -627,6 +648,19 @@ enum StreamBind {
 	Unix(PathBuf),
 }
 
+#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
+impl StreamBind {
+	/// The name this listener reports its accept health under.
+	fn name(&self) -> &'static str {
+		match self {
+			#[cfg(feature = "tcp")]
+			Self::Tcp(_) => "tcp",
+			#[cfg(all(feature = "uds", unix))]
+			Self::Unix(_) => "unix",
+		}
+	}
+}
+
 /// The stream (`tcp`/`unix`) listeners owned by a [`Server`].
 ///
 /// Bound lazily on the first [`Server::accept`] (they need a runtime), after
@@ -636,6 +670,10 @@ enum StreamBind {
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 struct StreamListeners {
 	binds: Vec<StreamBind>,
+	/// One per entry in `binds`, in the same order, and created up front rather than
+	/// with the listener: an owner registering these with a metrics endpoint does so
+	/// at startup, long before the first `accept` binds anything.
+	health: Vec<crate::accept::Health>,
 	versions: moq_net::Versions,
 	#[cfg(all(feature = "uds", unix))]
 	unix_allow: Option<crate::unix::Allow>,
@@ -650,8 +688,13 @@ impl StreamListeners {
 		versions: moq_net::Versions,
 		#[cfg(all(feature = "uds", unix))] unix_allow: Option<crate::unix::Allow>,
 	) -> Self {
+		let health = binds
+			.iter()
+			.map(|bind| crate::accept::Health::new(bind.name()))
+			.collect();
 		Self {
 			binds,
+			health,
 			versions,
 			#[cfg(all(feature = "uds", unix))]
 			unix_allow,
@@ -667,7 +710,8 @@ impl StreamListeners {
 		}
 
 		let (tx, rx) = tokio::sync::mpsc::channel(16);
-		for bind in self.binds.drain(..) {
+		let health = self.health.clone();
+		for (bind, health) in self.binds.drain(..).zip(health) {
 			let versions = self.versions.clone();
 			match bind {
 				#[cfg(feature = "tcp")]
@@ -675,7 +719,10 @@ impl StreamListeners {
 					if !addr.ip().is_loopback() {
 						tracing::warn!(%addr, "tcp listener bound to a non-loopback address; qmux is UNENCRYPTED, ensure the network is trusted");
 					}
-					let listener = crate::tcp::Listener::bind(addr).await?.with_protocols(versions.alpns());
+					let listener = crate::tcp::Listener::bind(addr)
+						.await?
+						.with_protocols(versions.alpns())
+						.with_accept_health(health);
 					tracing::info!(%addr, "listening (tcp)");
 					self.tasks.push(spawn_tcp_loop(listener, versions, tx.clone()));
 				}
@@ -683,7 +730,8 @@ impl StreamListeners {
 				StreamBind::Unix(path) => {
 					let listener = crate::unix::Listener::bind(&path)
 						.await?
-						.with_protocols(versions.alpns());
+						.with_protocols(versions.alpns())
+						.with_accept_health(health);
 					// Loose file perms: the uid/gid/pid allow list is the real gate,
 					// and the worker usually runs as a different user than the server.
 					listener.set_mode(0o666)?;
@@ -1057,6 +1105,33 @@ impl Request {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// The handles have to exist before anything binds, and cover the stream
+	/// listeners rather than just the ones an owner happens to construct itself.
+	///
+	/// `tcp`/`unix` bind lazily on the first `accept`, so a naive implementation
+	/// hands out nothing at startup, which is exactly when a metrics endpoint is
+	/// assembled. A stream-only node would then publish no accept counters for the
+	/// only sockets on it that can fail.
+	#[cfg(feature = "tcp")]
+	#[test]
+	fn accept_health_covers_stream_listeners_before_they_bind() {
+		let mut config = ServerConfig::default();
+		config.tcp.bind = Some("127.0.0.1:0".parse().unwrap());
+		let server = Server::new(config).expect("stream-only server");
+
+		let names: Vec<_> = server.accept_health().iter().map(|h| h.listener()).collect();
+		assert_eq!(names, vec!["tcp"], "the tcp listener must report before it binds");
+	}
+
+	/// A QUIC-only server reports nothing. It multiplexes over one UDP socket and
+	/// never calls `accept`, so a zero counter would be a watch that cannot fire.
+	#[cfg(all(feature = "quinn", not(feature = "tcp")))]
+	#[test]
+	fn accept_health_is_empty_without_a_stream_listener() {
+		let server = ServerConfig::default().init().expect("quic server");
+		assert!(server.accept_health().is_empty());
+	}
 
 	#[test]
 	fn transport_names_are_stable() {

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -366,8 +366,10 @@ impl Server {
 	/// Call this first and the two are distinct: the error is yours to handle, and a
 	/// later `None` means the server stopped.
 	///
-	/// Idempotent, and optional: `accept` still binds them itself (logging the
-	/// failure) for a caller that doesn't.
+	/// Idempotent: a call that fails binds nothing at all (any listener it did bind
+	/// is torn down again), so a retry starts from the same place. Optional, too:
+	/// `accept` still binds them itself, logging the failure, for a caller that
+	/// doesn't call this.
 	pub async fn listen(&mut self) -> crate::Result<()> {
 		#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 		self.streams.ensure_started().await?;
@@ -641,6 +643,7 @@ fn stream_versions(base: &moq_net::Versions) -> moq_net::Versions {
 
 /// A configured stream listener (`--server-tcp-bind` / `--server-unix-bind`).
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
+#[derive(Clone)]
 enum StreamBind {
 	#[cfg(feature = "tcp")]
 	Tcp(net::SocketAddr),
@@ -710,8 +713,29 @@ impl StreamListeners {
 		}
 
 		let (tx, rx) = tokio::sync::mpsc::channel(16);
+		if let Err(err) = self.start(&tx).await {
+			// All or nothing. A half-bound set would leave the loops we did spawn
+			// feeding the channel this call is about to drop, so a retry would find
+			// listeners that can never deliver a request while `binds` looked done.
+			// Abort them instead and leave the binds untouched, so a retry starts over
+			// and a second `listen` cannot report success over a dead listener.
+			for task in self.tasks.drain(..) {
+				task.abort();
+			}
+			return Err(err);
+		}
+
+		self.rx = Some(rx);
+		Ok(())
+	}
+
+	/// Bind and spawn every configured listener, or return the first failure.
+	async fn start(&mut self, tx: &tokio::sync::mpsc::Sender<Request>) -> crate::Result<()> {
+		// Cloned so the loop can push into `self.tasks` while iterating; there are at
+		// most two entries, each an address or a path.
+		let binds = self.binds.clone();
 		let health = self.health.clone();
-		for (bind, health) in self.binds.drain(..).zip(health) {
+		for (bind, health) in binds.into_iter().zip(health) {
 			let versions = self.versions.clone();
 			match bind {
 				#[cfg(feature = "tcp")]
@@ -742,7 +766,6 @@ impl StreamListeners {
 			}
 		}
 
-		self.rx = Some(rx);
 		Ok(())
 	}
 
@@ -1122,6 +1145,31 @@ mod tests {
 
 		let names: Vec<_> = server.accept_health().iter().map(|h| h.listener()).collect();
 		assert_eq!(names, vec!["tcp"], "the tcp listener must report before it binds");
+	}
+
+	/// A failed `listen` must leave nothing bound, so a retry starts over.
+	///
+	/// The trap is `binds.drain(..)`: consume the list up front and a partial failure
+	/// leaves it empty, so the *second* `listen` sees nothing left to do and reports
+	/// success while no stream listener exists and `accept` parks forever.
+	#[cfg(all(feature = "tcp", feature = "uds", unix))]
+	#[tokio::test]
+	async fn a_failed_listen_binds_nothing_and_can_be_retried() {
+		// A path that cannot be a socket, so the unix bind fails after the tcp one
+		// has already succeeded.
+		let dir = tempfile::TempDir::new().unwrap();
+		let occupied = dir.path().join("not-a-socket");
+		std::fs::write(&occupied, b"in the way").unwrap();
+
+		let mut config = ServerConfig::default();
+		config.tcp.bind = Some("127.0.0.1:0".parse().unwrap());
+		config.unix.bind = Some(occupied);
+		let mut server = Server::new(config).expect("stream-only server");
+
+		assert!(server.listen().await.is_err(), "the unix bind must fail");
+		// Same error the second time, rather than a success over a listener that the
+		// first call already tore down.
+		assert!(server.listen().await.is_err(), "a retry must not report success");
 	}
 
 	/// A QUIC-only server reports nothing. It multiplexes over one UDP socket and

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -336,12 +336,33 @@ impl Server {
 		unreachable!("no transport compiled; enable a QUIC backend, tcp, or uds feature");
 	}
 
+	/// Bind the listeners that bind lazily, so a bind failure surfaces here.
+	///
+	/// The QUIC socket is bound by [`ServerConfig::init`], but the stream
+	/// (`tcp`/`unix`) listeners need a runtime, so they wait for the first
+	/// [`accept`](Self::accept) instead. That makes a bind failure arrive as a `None`
+	/// from `accept`, which a caller cannot tell apart from an ordinary shutdown.
+	/// Call this first and the two are distinct: the error is yours to handle, and a
+	/// later `None` means the server stopped.
+	///
+	/// Idempotent, and optional: `accept` still binds them itself (logging the
+	/// failure) for a caller that doesn't.
+	pub async fn listen(&mut self) -> crate::Result<()> {
+		#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
+		self.streams.ensure_started().await?;
+		Ok(())
+	}
+
 	/// Returns the next partially established session, across every configured
 	/// transport (QUIC, WebSocket, and plaintext qmux over TCP/Unix).
 	///
 	/// This returns a [Request] instead of a session so the connection can be
 	/// rejected early on an invalid path or missing auth. Call [Request::ok] or
 	/// [Request::close] to complete the handshake.
+	///
+	/// `None` means the server stopped: it was interrupted (Ctrl-C), or a lazy
+	/// listener failed to bind. Call [`listen`](Self::listen) up front to tell those
+	/// two apart.
 	#[cfg(any(
 		feature = "noq",
 		feature = "quinn",
@@ -487,7 +508,10 @@ impl Server {
 								Ok(Request { transport: Transport::WebSocket, url: None, identity: None, kind: RequestKind::Qmux(Box::new(request)) })
 							}.boxed());
 						}
-						Err(err) => tracing::debug!(%err, "failed to accept WebSocket session"),
+						// One connection's upgrade, not the listener's: a failed
+						// `accept(2)` never reaches here, having been classified,
+						// counted, and warned about by the listener itself.
+						Err(err) => tracing::debug!(%err, "WebSocket upgrade failed"),
 					}
 				}
 				Some(res) = self.accept.next() => {
@@ -703,7 +727,9 @@ fn spawn_tcp_loop(
 		loop {
 			match listener.accept().await {
 				Some(Ok(session)) => spawn_stream_request(session, Transport::Tcp, versions.clone(), tx.clone()),
-				Some(Err(err)) => tracing::warn!(%err, "tcp listener accept failed"),
+				// Per-connection: a failed `accept(2)` is the listener's own to
+				// classify and pace, and never surfaces here.
+				Some(Err(err)) => tracing::warn!(%err, "tcp qmux handshake failed"),
 				None => break,
 			}
 		}
@@ -730,7 +756,8 @@ fn spawn_unix_loop(
 					}
 					spawn_stream_request(session, Transport::Unix, versions.clone(), tx.clone());
 				}
-				Some(Err(err)) => tracing::warn!(%err, "unix listener accept failed"),
+				// Per-connection, as in `spawn_tcp_loop`.
+				Some(Err(err)) => tracing::warn!(%err, "unix qmux handshake failed"),
 				None => break,
 			}
 		}

--- a/rs/moq-native/src/tcp.rs
+++ b/rs/moq-native/src/tcp.rs
@@ -178,8 +178,11 @@ impl Listener {
 	/// A failed `accept(2)` is handled here rather than yielded: it is classified,
 	/// counted, logged, and paced by [`accept_health`](Self::accept_health), then
 	/// retried, because the caller has no better answer than to ask again. A
-	/// per-connection *handshake* failure is still yielded as `Some(Err(..))`, and
-	/// `None` only if the listener itself is gone.
+	/// per-connection *handshake* failure is still yielded as `Some(Err(..))`.
+	///
+	/// The `Option` no longer has a `None` case to report: nothing ends the accept
+	/// loop, so this always yields. It stays because dropping it is a breaking change
+	/// to a published signature.
 	pub async fn accept(&self) -> Option<Result<qmux::Session>> {
 		let (stream, addr) = self.accept_socket().await;
 		tracing::debug!(%addr, "accepted TCP connection");

--- a/rs/moq-native/src/tcp.rs
+++ b/rs/moq-native/src/tcp.rs
@@ -147,6 +147,16 @@ impl Listener {
 		self.health.clone()
 	}
 
+	/// Report into `health` instead of the one this listener made for itself.
+	///
+	/// For an owner that has to hand the handle out *before* the listener exists:
+	/// [`crate::Server`] binds these lazily (they need a runtime), but an embedder
+	/// registering them with a metrics endpoint does so at startup.
+	pub fn with_accept_health(mut self, health: crate::accept::Health) -> Self {
+		self.health = health;
+		self
+	}
+
 	/// Advertise these application protocols (moq ALPNs) for in-band negotiation,
 	/// in preference order. The first server entry the client also offers wins.
 	pub fn with_protocols<I, S>(mut self, protocols: I) -> Self

--- a/rs/moq-native/src/tcp.rs
+++ b/rs/moq-native/src/tcp.rs
@@ -37,7 +37,8 @@ pub struct Config {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
-	/// The TCP socket failed to bind, accept, or connect.
+	/// The TCP socket failed to bind or connect. Not accept: a failed `accept(2)` is
+	/// the listener's own to classify and retry (see [`crate::accept`]).
 	#[error(transparent)]
 	Io(#[from] std::io::Error),
 
@@ -126,6 +127,7 @@ async fn connect_addrs(
 pub struct Listener {
 	listener: tokio::net::TcpListener,
 	protocols: Vec<String>,
+	health: crate::accept::Health,
 }
 
 impl Listener {
@@ -135,7 +137,14 @@ impl Listener {
 		Ok(Self {
 			listener,
 			protocols: Vec::new(),
+			health: crate::accept::Health::new("tcp"),
 		})
+	}
+
+	/// A live handle to this listener's accept-loop health, for an embedder that
+	/// publishes it (see [`crate::accept`]).
+	pub fn accept_health(&self) -> crate::accept::Health {
+		self.health.clone()
 	}
 
 	/// Advertise these application protocols (moq ALPNs) for in-band negotiation,
@@ -156,20 +165,36 @@ impl Listener {
 
 	/// Accept the next connection, performing the qmux handshake over plain TCP.
 	///
-	/// Returns `None` only if the listener itself is gone; a per-connection
-	/// failure is yielded as `Some(Err(..))` so the accept loop keeps running.
+	/// A failed `accept(2)` is handled here rather than yielded: it is classified,
+	/// counted, logged, and paced by [`accept_health`](Self::accept_health), then
+	/// retried, because the caller has no better answer than to ask again. A
+	/// per-connection *handshake* failure is still yielded as `Some(Err(..))`, and
+	/// `None` only if the listener itself is gone.
 	pub async fn accept(&self) -> Option<Result<qmux::Session>> {
-		match self.listener.accept().await {
-			Ok((stream, addr)) => {
-				tracing::debug!(%addr, "accepted TCP connection");
-				let session = qmux::tcp::Config::new(WIRE_VERSION)
-					.protocols(self.protocols.iter().map(String::as_str))
-					.accept(stream)
-					.await
-					.map_err(Error::Accept);
-				Some(session)
+		let (stream, addr) = self.accept_socket().await;
+		tracing::debug!(%addr, "accepted TCP connection");
+		let session = qmux::tcp::Config::new(WIRE_VERSION)
+			.protocols(self.protocols.iter().map(String::as_str))
+			.accept(stream)
+			.await
+			.map_err(Error::Accept);
+		Some(session)
+	}
+
+	/// The `accept(2)` half: keep asking until a connection comes back.
+	async fn accept_socket(&self) -> (tokio::net::TcpStream, net::SocketAddr) {
+		loop {
+			match self.listener.accept().await {
+				Ok(accepted) => {
+					self.health.accepted();
+					return accepted;
+				}
+				Err(err) => {
+					if let Some(delay) = self.health.failed(&err) {
+						tokio::time::sleep(delay).await;
+					}
+				}
 			}
-			Err(e) => Some(Err(e.into())),
 		}
 	}
 }

--- a/rs/moq-native/src/unix.rs
+++ b/rs/moq-native/src/unix.rs
@@ -242,8 +242,9 @@ impl Listener {
 	/// A failed `accept(2)` is handled here rather than yielded: it is classified,
 	/// counted, logged, and paced by [`accept_health`](Self::accept_health), then
 	/// retried, because the caller has no better answer than to ask again. A
-	/// per-connection failure is still yielded as `Some(Err(..))`, and `None` only
-	/// if the listener itself is gone.
+	/// per-connection failure is still yielded as `Some(Err(..))`.
+	///
+	/// As in [`crate::tcp`], the `Option` has no `None` case left to report.
 	pub async fn accept(&self) -> Option<Result<(qmux::Session, PeerCred)>> {
 		let stream = self.accept_socket().await;
 		let cred = match stream.peer_cred() {

--- a/rs/moq-native/src/unix.rs
+++ b/rs/moq-native/src/unix.rs
@@ -168,6 +168,7 @@ pub struct Listener {
 	listener: tokio::net::UnixListener,
 	path: PathBuf,
 	protocols: Vec<String>,
+	health: crate::accept::Health,
 }
 
 impl Listener {
@@ -194,7 +195,14 @@ impl Listener {
 			listener,
 			path,
 			protocols: Vec::new(),
+			health: crate::accept::Health::new("unix"),
 		})
+	}
+
+	/// A live handle to this listener's accept-loop health, for an embedder that
+	/// publishes it (see [`crate::accept`]).
+	pub fn accept_health(&self) -> crate::accept::Health {
+		self.health.clone()
 	}
 
 	/// Advertise these application protocols (moq ALPNs) for in-band negotiation,
@@ -221,27 +229,43 @@ impl Listener {
 
 	/// Accept the next connection, returning the session and the peer's credentials.
 	///
-	/// Returns `None` only if the listener itself is gone; a per-connection
-	/// failure is yielded as `Some(Err(..))` so the accept loop keeps running.
+	/// A failed `accept(2)` is handled here rather than yielded: it is classified,
+	/// counted, logged, and paced by [`accept_health`](Self::accept_health), then
+	/// retried, because the caller has no better answer than to ask again. A
+	/// per-connection failure is still yielded as `Some(Err(..))`, and `None` only
+	/// if the listener itself is gone.
 	pub async fn accept(&self) -> Option<Result<(qmux::Session, PeerCred)>> {
-		match self.listener.accept().await {
-			Ok((stream, _addr)) => {
-				let cred = match stream.peer_cred() {
-					Ok(cred) => PeerCred {
-						uid: cred.uid(),
-						gid: cred.gid(),
-						pid: cred.pid(),
-					},
-					Err(err) => return Some(Err(err.into())),
-				};
-				let session = qmux::uds::Config::new(WIRE_VERSION)
-					.protocols(self.protocols.iter().map(String::as_str))
-					.accept(stream)
-					.await
-					.map_err(Error::Accept);
-				Some(session.map(|session| (session, cred)))
+		let stream = self.accept_socket().await;
+		let cred = match stream.peer_cred() {
+			Ok(cred) => PeerCred {
+				uid: cred.uid(),
+				gid: cred.gid(),
+				pid: cred.pid(),
+			},
+			Err(err) => return Some(Err(err.into())),
+		};
+		let session = qmux::uds::Config::new(WIRE_VERSION)
+			.protocols(self.protocols.iter().map(String::as_str))
+			.accept(stream)
+			.await
+			.map_err(Error::Accept);
+		Some(session.map(|session| (session, cred)))
+	}
+
+	/// The `accept(2)` half: keep asking until a connection comes back.
+	async fn accept_socket(&self) -> tokio::net::UnixStream {
+		loop {
+			match self.listener.accept().await {
+				Ok((stream, _addr)) => {
+					self.health.accepted();
+					return stream;
+				}
+				Err(err) => {
+					if let Some(delay) = self.health.failed(&err) {
+						tokio::time::sleep(delay).await;
+					}
+				}
 			}
-			Err(err) => Some(Err(err.into())),
 		}
 	}
 }

--- a/rs/moq-native/src/unix.rs
+++ b/rs/moq-native/src/unix.rs
@@ -205,6 +205,16 @@ impl Listener {
 		self.health.clone()
 	}
 
+	/// Report into `health` instead of the one this listener made for itself.
+	///
+	/// For an owner that has to hand the handle out *before* the listener exists:
+	/// [`crate::Server`] binds these lazily (they need a runtime), but an embedder
+	/// registering them with a metrics endpoint does so at startup.
+	pub fn with_accept_health(mut self, health: crate::accept::Health) -> Self {
+		self.health = health;
+		self
+	}
+
 	/// Advertise these application protocols (moq ALPNs) for in-band negotiation,
 	/// in preference order. The first server entry the client also offers wins.
 	pub fn with_protocols<I, S>(mut self, protocols: I) -> Self

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -283,8 +283,9 @@ impl Listener {
 	/// A failed `accept(2)` is handled here rather than yielded: it is classified,
 	/// counted, logged, and paced by [`accept_health`](Self::accept_health), then
 	/// retried, because the caller has no better answer than to ask again. A
-	/// per-connection upgrade failure is still yielded as `Some(Err(..))`, and `None`
-	/// only if the listener itself is gone.
+	/// per-connection upgrade failure is still yielded as `Some(Err(..))`.
+	///
+	/// As in [`crate::tcp`], the `Option` has no `None` case left to report.
 	pub async fn accept(&self) -> Option<Result<qmux::Session>> {
 		let (stream, addr) = self.accept_socket().await;
 		tracing::debug!(%addr, "accepted WebSocket TCP connection");

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -16,7 +16,8 @@ use url::Url;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
-	/// The TCP socket failed to bind, accept, or connect.
+	/// The TCP socket failed to bind or connect. Not accept: a failed `accept(2)` is
+	/// the listener's own to classify and retry (see [`crate::accept`]).
 	#[error(transparent)]
 	Io(#[from] std::io::Error),
 
@@ -243,6 +244,7 @@ impl Error {
 pub struct Listener {
 	listener: tokio::net::TcpListener,
 	server: qmux::Server,
+	health: crate::accept::Health,
 }
 
 impl Listener {
@@ -258,7 +260,11 @@ impl Listener {
 		// doesn't restrict; qmux by default also accepts legacy clients that
 		// only offer a bare wire-format ALPN (today's moq-net clients still do).
 		let server = qmux::Server::new().with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))));
-		Ok(Self { listener, server })
+		Ok(Self {
+			listener,
+			server,
+			health: crate::accept::Health::new("websocket"),
+		})
 	}
 
 	/// The local address the listener is bound to.
@@ -266,18 +272,40 @@ impl Listener {
 		Ok(self.listener.local_addr()?)
 	}
 
+	/// A live handle to this listener's accept-loop health, for an embedder that
+	/// publishes it (see [`crate::accept`]).
+	pub fn accept_health(&self) -> crate::accept::Health {
+		self.health.clone()
+	}
+
 	/// Accept the next connection, performing the WebSocket upgrade and qmux handshake.
 	///
-	/// Returns `None` only if the listener itself is gone; a per-connection failure is
-	/// yielded as `Some(Err(..))` so the accept loop keeps running.
+	/// A failed `accept(2)` is handled here rather than yielded: it is classified,
+	/// counted, logged, and paced by [`accept_health`](Self::accept_health), then
+	/// retried, because the caller has no better answer than to ask again. A
+	/// per-connection upgrade failure is still yielded as `Some(Err(..))`, and `None`
+	/// only if the listener itself is gone.
 	pub async fn accept(&self) -> Option<Result<qmux::Session>> {
-		match self.listener.accept().await {
-			Ok((stream, addr)) => {
-				tracing::debug!(%addr, "accepted WebSocket TCP connection");
-				let server = self.server.clone();
-				Some(server.accept(stream).await.map_err(Error::Accept))
+		let (stream, addr) = self.accept_socket().await;
+		tracing::debug!(%addr, "accepted WebSocket TCP connection");
+		let server = self.server.clone();
+		Some(server.accept(stream).await.map_err(Error::Accept))
+	}
+
+	/// The `accept(2)` half: keep asking until a connection comes back.
+	async fn accept_socket(&self) -> (tokio::net::TcpStream, net::SocketAddr) {
+		loop {
+			match self.listener.accept().await {
+				Ok(accepted) => {
+					self.health.accepted();
+					return accepted;
+				}
+				Err(err) => {
+					if let Some(delay) = self.health.failed(&err) {
+						tokio::time::sleep(delay).await;
+					}
+				}
 			}
-			Err(e) => Some(Err(e.into())),
 		}
 	}
 }

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -107,7 +107,22 @@ impl Internal {
 	/// [`moq_native::accept`] for that argument, and for why no QUIC backend has
 	/// anything to register.
 	pub fn with_listeners(mut self, health: impl IntoIterator<Item = moq_native::accept::Health>) -> Self {
-		self.listeners.extend(health);
+		for health in health {
+			// Two handles under one name would emit the same `listener` label twice,
+			// which is a malformed exposition: a scraper is entitled to reject the whole
+			// payload, taking the node's traffic counters down with it. Drop the
+			// duplicate loudly instead, so one mis-registered listener cannot blind the
+			// rest of the endpoint.
+			if self.listeners.iter().any(|seen| seen.listener() == health.listener()) {
+				tracing::warn!(
+					listener = health.listener(),
+					"ignoring a second listener registered under a name already in use; \
+					 its accept failures will not be reported"
+				);
+				continue;
+			}
+			self.listeners.push(health);
+		}
 		self
 	}
 
@@ -327,7 +342,7 @@ fn render_accepts(out: &mut String, listeners: &[moq_native::accept::Health]) {
 	);
 	let _ = writeln!(out, "# TYPE moq_relay_accept_failures_total counter");
 	for health in listeners {
-		for failure in Failure::ALL {
+		for &failure in Failure::ALL {
 			let _ = writeln!(
 				out,
 				"moq_relay_accept_failures_total{{listener=\"{}\",class=\"{}\"}} {}",

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -8,7 +8,7 @@
 //! Today it serves:
 //! - `/metrics` - this node's own traffic counters as Prometheus text
 //!   exposition, plus the accept-loop health of its TCP listeners
-//!   ([`with_listener`](Internal::with_listener)). A distinct plane from both the
+//!   ([`with_listeners`](Internal::with_listeners)). A distinct plane from both the
 //!   customer `web` surface and the MoQ `.stats` broadcast: the same atomics, but
 //!   a different transport and audience (an ops scraper, not a customer or the
 //!   dashboard/billing aggregators).
@@ -76,26 +76,38 @@ impl Internal {
 	pub fn new(config: InternalConfig, stats: moq_net::stats::Registry) -> Self {
 		// This listener registers itself: it is the one rendering the counters, and
 		// its own are evidence about the node (the resources it can run out of are
-		// process-wide) rather than about this socket.
+		// process-wide) rather than about this socket. Only when it will actually run,
+		// though: `routes()` is public, so an embedder can merge this surface onto its
+		// own listener while `serve` stays disabled, and a zero series for a socket
+		// nobody opened is a watch that can never fire.
 		let health = moq_native::accept::Health::new("internal");
+		let listeners = match config.listen {
+			Some(_) => vec![health.clone()],
+			None => Vec::new(),
+		};
 		Self {
 			config,
 			stats,
 			nodes: None,
-			health: health.clone(),
-			listeners: vec![health],
+			health,
+			listeners,
 		}
 	}
 
-	/// Report another listener's accept health at `/metrics`.
+	/// Report other listeners' accept health at `/metrics`.
 	///
-	/// The relay's own listeners register themselves; pass
-	/// [`Web::accept_health`](crate::Web::accept_health), and anything an embedder
-	/// listens on itself, so one scrape covers every socket on the node. See
-	/// [`moq_native::accept`] for what the classes mean and why a UDP-multiplexed
-	/// listener (every QUIC backend) has nothing to register.
-	pub fn with_listener(mut self, health: moq_native::accept::Health) -> Self {
-		self.listeners.push(health);
+	/// Takes an iterator so the accessors feed it directly, however many listeners
+	/// they turn out to describe: [`Web::accept_health`](crate::Web::accept_health)
+	/// yields an `Option`, [`moq_native::Server::accept_health`] a `Vec`, and an
+	/// embedder can pass its own. Register every socket on the node, so a scrape
+	/// covers the one that actually went quiet.
+	///
+	/// Register nothing for a listener that isn't running. A permanently-zero series
+	/// is worse than an absent one: it reads as a watch that is passing. See
+	/// [`moq_native::accept`] for that argument, and for why no QUIC backend has
+	/// anything to register.
+	pub fn with_listeners(mut self, health: impl IntoIterator<Item = moq_native::accept::Health>) -> Self {
+		self.listeners.extend(health);
 		self
 	}
 
@@ -345,6 +357,44 @@ fn render_accepts(out: &mut String, listeners: &[moq_native::accept::Health]) {
 mod tests {
 	use super::*;
 
+	/// An `InternalConfig` whose listener is enabled, so `Internal` registers its own.
+	fn listening() -> InternalConfig {
+		InternalConfig {
+			listen: Some("127.0.0.1:0".parse().unwrap()),
+		}
+	}
+
+	/// A listener that isn't running must not appear at all, and one that is must
+	/// appear even though nothing else registered it.
+	///
+	/// The failure this guards is a stream-only node: it has no web listener, so a
+	/// `web` series there would be a permanent zero standing in for a socket that was
+	/// never opened, while the `tcp` listener that can actually fail goes unreported.
+	/// Both halves are silent in exactly the way that reads as healthy.
+	#[test]
+	fn absent_listeners_are_not_reported_as_healthy() {
+		let disabled = Internal::new(InternalConfig::default(), moq_net::stats::Registry::disabled());
+		let body = render_metrics(&moq_net::stats::Registry::disabled().snapshot(), &disabled.listeners);
+		assert!(
+			!body.contains("listener=\"internal\""),
+			"a disabled internal listener must not publish counters:\n{body}"
+		);
+
+		// What a stream-only relay looks like: no web, one tcp.
+		let stream_only = Internal::new(listening(), moq_net::stats::Registry::disabled())
+			.with_listeners(None)
+			.with_listeners([moq_native::accept::Health::new("tcp")]);
+		let body = render_metrics(&moq_net::stats::Registry::disabled().snapshot(), &stream_only.listeners);
+		assert!(
+			body.contains("moq_relay_accept_failures_total{listener=\"tcp\",class=\"exhausted\"} 0"),
+			"the tcp listener must be reported:\n{body}"
+		);
+		assert!(
+			!body.contains("listener=\"web\""),
+			"a relay with no web listener must not publish a web series:\n{body}"
+		);
+	}
+
 	/// Every registered listener has to appear in the exposition, at zero, before it
 	/// has ever failed.
 	///
@@ -356,8 +406,7 @@ mod tests {
 	#[test]
 	fn accept_metrics_list_every_listener_from_zero() {
 		let web = moq_native::accept::Health::new("web");
-		let internal =
-			Internal::new(InternalConfig::default(), moq_net::stats::Registry::disabled()).with_listener(web.clone());
+		let internal = Internal::new(listening(), moq_net::stats::Registry::disabled()).with_listeners([web.clone()]);
 
 		let body = render_metrics(&moq_net::stats::Registry::disabled().snapshot(), &internal.listeners);
 

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -7,10 +7,11 @@
 //!
 //! Today it serves:
 //! - `/metrics` - this node's own traffic counters as Prometheus text
-//!   exposition. A distinct plane from both the customer `web` surface and the
-//!   MoQ `.stats` broadcast: the same atomics, but a different transport and
-//!   audience (an ops scraper, not a customer or the dashboard/billing
-//!   aggregators).
+//!   exposition, plus the accept-loop health of its TCP listeners
+//!   ([`with_listener`](Internal::with_listener)). A distinct plane from both the
+//!   customer `web` surface and the MoQ `.stats` broadcast: the same atomics, but
+//!   a different transport and audience (an ops scraper, not a customer or the
+//!   dashboard/billing aggregators).
 //! - `/health` - a liveness mirror of the public probe, for internal checks
 //!   that don't want to hit the customer port.
 //! - `/nodes` - the cluster nodes visible through gossip plus established
@@ -59,22 +60,43 @@ pub struct Internal {
 	config: InternalConfig,
 	stats: moq_net::stats::Registry,
 	nodes: Option<crate::nodes::Nodes>,
+	health: moq_native::accept::Health,
+	listeners: Vec<moq_native::accept::Health>,
 }
 
 #[derive(Clone)]
 struct InternalState {
 	stats: moq_net::stats::Registry,
 	nodes: Option<crate::nodes::Nodes>,
+	listeners: Vec<moq_native::accept::Health>,
 }
 
 impl Internal {
 	/// Create the service from its config and the node's stats registry.
 	pub fn new(config: InternalConfig, stats: moq_net::stats::Registry) -> Self {
+		// This listener registers itself: it is the one rendering the counters, and
+		// its own are evidence about the node (the resources it can run out of are
+		// process-wide) rather than about this socket.
+		let health = moq_native::accept::Health::new("internal");
 		Self {
 			config,
 			stats,
 			nodes: None,
+			health: health.clone(),
+			listeners: vec![health],
 		}
+	}
+
+	/// Report another listener's accept health at `/metrics`.
+	///
+	/// The relay's own listeners register themselves; pass
+	/// [`Web::accept_health`](crate::Web::accept_health), and anything an embedder
+	/// listens on itself, so one scrape covers every socket on the node. See
+	/// [`moq_native::accept`] for what the classes mean and why a UDP-multiplexed
+	/// listener (every QUIC backend) has nothing to register.
+	pub fn with_listener(mut self, health: moq_native::accept::Health) -> Self {
+		self.listeners.push(health);
+		self
 	}
 
 	/// Attach the relay cluster used to serve the `/nodes` topology snapshot.
@@ -97,6 +119,7 @@ impl Internal {
 			.with_state(InternalState {
 				stats: self.stats.clone(),
 				nodes: self.nodes.clone(),
+				listeners: self.listeners.clone(),
 			})
 	}
 
@@ -120,7 +143,9 @@ impl Internal {
 		let listener = moq_native::bind::tcp(listen).context("failed to bind internal listener")?;
 		// No blanket "…server failed" context here: the caller (main.rs) adds
 		// that single top-level layer, matching `Web::serve` / `Cluster::run`.
-		axum_server::from_tcp(listener)?.serve(app.into_make_service()).await?;
+		crate::listener::server(listener, self.health)?
+			.serve(app.into_make_service())
+			.await?;
 		Ok(())
 	}
 
@@ -152,7 +177,7 @@ async fn serve_health() -> Response {
 /// current cumulative snapshot; a downstream scraper derives rates and live
 /// counts (`open - closed`).
 async fn serve_metrics(State(state): State<InternalState>) -> Response {
-	let body = render_metrics(&state.stats.snapshot());
+	let body = render_metrics(&state.stats.snapshot(), &state.listeners);
 	([(http::header::CONTENT_TYPE, "text/plain; version=0.0.4")], body).into_response()
 }
 
@@ -171,7 +196,7 @@ async fn serve_nodes(State(state): State<InternalState>) -> Json<crate::nodes::S
 /// already are the registry, and a snapshot is a fixed handful of labeled
 /// counters, so a registry would only add a second source of truth to keep in
 /// sync.
-fn render_metrics(snap: &moq_net::stats::Snapshot) -> String {
+fn render_metrics(snap: &moq_net::stats::Snapshot, listeners: &[moq_native::accept::Health]) -> String {
 	use std::fmt::Write as _;
 
 	let traffic = snap.traffic();
@@ -267,12 +292,108 @@ fn render_metrics(snap: &moq_net::stats::Snapshot) -> String {
 		);
 	}
 
+	render_accepts(&mut out, listeners);
+
 	out
+}
+
+/// The accept-loop health of every listener on the node.
+///
+/// The counters are the load-bearing half: a process out of descriptors cannot
+/// answer this scrape either, so an episode is often only readable once it is over,
+/// and the gauge below has gone back to zero by then. Only `exhausted` is worth
+/// paging on; `connection` is junk traffic the node is fielding, and `unknown` is an
+/// errno the classifier has never seen (worth a dashboard, never an escalation, since
+/// a remote peer could drive it).
+fn render_accepts(out: &mut String, listeners: &[moq_native::accept::Health]) {
+	use moq_native::accept::Failure;
+	use std::fmt::Write as _;
+
+	let _ = writeln!(
+		out,
+		"# HELP moq_relay_accept_failures_total Failed accept() calls on a listener, by class."
+	);
+	let _ = writeln!(out, "# TYPE moq_relay_accept_failures_total counter");
+	for health in listeners {
+		for failure in Failure::ALL {
+			let _ = writeln!(
+				out,
+				"moq_relay_accept_failures_total{{listener=\"{}\",class=\"{}\"}} {}",
+				health.listener(),
+				failure.as_str(),
+				health.failures(failure)
+			);
+		}
+	}
+
+	let _ = writeln!(
+		out,
+		"# HELP moq_relay_accept_stalled_seconds How long a listener has been unable to accept a connection; 0 when it is serving."
+	);
+	let _ = writeln!(out, "# TYPE moq_relay_accept_stalled_seconds gauge");
+	for health in listeners {
+		let _ = writeln!(
+			out,
+			"moq_relay_accept_stalled_seconds{{listener=\"{}\"}} {}",
+			health.listener(),
+			health.stalled().unwrap_or_default().as_secs_f64()
+		);
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// Every registered listener has to appear in the exposition, at zero, before it
+	/// has ever failed.
+	///
+	/// A counter that only springs into existence on the first failure is the shape
+	/// that makes an alert unwritable: `rate(...)` over a series that does not exist
+	/// yet is empty, not zero, so the dashboard is blank on a healthy node and there
+	/// is nothing to notice going missing.
+	#[cfg(unix)]
+	#[test]
+	fn accept_metrics_list_every_listener_from_zero() {
+		let web = moq_native::accept::Health::new("web");
+		let internal =
+			Internal::new(InternalConfig::default(), moq_net::stats::Registry::disabled()).with_listener(web.clone());
+
+		let body = render_metrics(&moq_net::stats::Registry::disabled().snapshot(), &internal.listeners);
+
+		for listener in ["internal", "web"] {
+			for class in ["connection", "exhausted", "unknown"] {
+				let line = format!("moq_relay_accept_failures_total{{listener=\"{listener}\",class=\"{class}\"}} 0");
+				assert!(body.contains(&line), "missing {line} in:\n{body}");
+			}
+			assert!(body.contains(&format!(
+				"moq_relay_accept_stalled_seconds{{listener=\"{listener}\"}} 0"
+			)));
+		}
+
+		// An exhaustion stall is what an operator pages on, so it has to be readable
+		// as a growing count and a non-zero gauge, not just a log line the node may
+		// not have had the descriptors to ship.
+		let emfile = std::io::Error::from_raw_os_error(24);
+		// Asserted rather than assumed: 24 is EMFILE on Linux and macOS, and the
+		// classification is what makes the rest of this meaningful.
+		assert_eq!(
+			moq_native::accept::Failure::classify(&emfile),
+			moq_native::accept::Failure::Exhausted
+		);
+		let _ = web.failed(&emfile);
+		let body = render_metrics(&moq_net::stats::Registry::disabled().snapshot(), &internal.listeners);
+		assert!(body.contains("moq_relay_accept_failures_total{listener=\"web\",class=\"exhausted\"} 1"));
+
+		let prefix = "moq_relay_accept_stalled_seconds{listener=\"web\"} ";
+		let stalled: f64 = body
+			.lines()
+			.find_map(|line| line.strip_prefix(prefix))
+			.expect("stall gauge for the web listener")
+			.parse()
+			.expect("stall gauge is a number");
+		assert!(stalled > 0.0, "a stalled listener must not report zero seconds");
+	}
 
 	/// `serve` hosts the router it is HANDED, so an embedder's extra ops routes
 	/// answer on the same internal listener as the built-in ones. That is what
@@ -340,6 +461,7 @@ mod tests {
 		let state = InternalState {
 			stats: moq_net::stats::Registry::disabled(),
 			nodes: None,
+			listeners: Vec::new(),
 		};
 
 		let Json(snapshot) = serve_nodes(State(state)).await;
@@ -354,6 +476,7 @@ mod tests {
 		let state = InternalState {
 			stats: moq_net::stats::Registry::disabled(),
 			nodes: Some(nodes),
+			listeners: Vec::new(),
 		};
 
 		let Json(snapshot) = serve_nodes(State(state)).await;
@@ -411,7 +534,7 @@ mod tests {
 			group.finish().unwrap();
 		}
 
-		let body = render_metrics(&stats.snapshot());
+		let body = render_metrics(&stats.snapshot(), &[]);
 
 		assert!(
 			body.contains("# TYPE moq_relay_bytes_total counter"),

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -17,6 +17,7 @@ mod config;
 mod connection;
 mod http_client;
 mod internal;
+mod listener;
 mod nodes;
 mod relay;
 mod stats;

--- a/rs/moq-relay/src/listener.rs
+++ b/rs/moq-relay/src/listener.rs
@@ -118,7 +118,7 @@ mod tests {
 		let client = connect.await.unwrap();
 
 		assert_eq!(peer.0, client.local_addr().unwrap());
-		for failure in Failure::ALL {
+		for &failure in Failure::ALL {
 			assert_eq!(health.failures(failure), 0, "{failure} on a healthy accept");
 		}
 		assert_eq!(health.stalled(), None);

--- a/rs/moq-relay/src/listener.rs
+++ b/rs/moq-relay/src/listener.rs
@@ -1,0 +1,126 @@
+//! The TCP listener under [`Web`](crate::Web) and [`Internal`](crate::Internal).
+//!
+//! `axum_server` owns the serve loop (TLS, HTTP version negotiation, WebSocket
+//! upgrades, graceful shutdown), and its loop reacts to a failed `accept(2)` by
+//! sleeping a flat 50ms and discarding the error, so nothing outside the process
+//! ever learns that the relay stopped accepting TCP connections. That is not a side
+//! channel here: `:443` carries WebSocket MoQ, WHIP/WHEP signalling, and the whole
+//! live HLS origin.
+//!
+//! `axum_server`'s listener abstraction is the seam. Wrapping the socket in
+//! [`Listener`] puts the `accept(2)` call back under our own policy
+//! ([`moq_native::accept`]): a dead connection retries at once, an exhausted process
+//! backs off and warns, and either way it is counted where an embedder can read it
+//! back. Because the wrapper never yields an error upward, `axum_server`'s flat
+//! sleep is unreachable.
+
+use std::io;
+use std::net::SocketAddr;
+
+use axum_server::{AddrListener, Address};
+use moq_native::accept::Health;
+use tokio::net::{TcpListener, TcpStream};
+
+/// The peer address of an accepted connection.
+///
+/// A newtype only because [`Address`] is already implemented for `SocketAddr` with
+/// tokio's `TcpListener` nailed on as its listener type; this is what lets
+/// [`Listener`] take that slot instead.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Peer(pub(crate) SocketAddr);
+
+impl Address for Peer {
+	type Stream = TcpStream;
+	type Listener = Listener;
+}
+
+/// A TCP listener that classifies, counts, paces, and logs its own `accept(2)`
+/// failures instead of leaving them to `axum_server`.
+pub(crate) struct Listener {
+	inner: TcpListener,
+	health: Health,
+}
+
+impl Listener {
+	/// Adopt an already-bound listener (from [`moq_native::bind::tcp`], which sets
+	/// the dual-stack and keepalive options), reporting into `health`.
+	pub(crate) fn new(listener: std::net::TcpListener, health: Health) -> io::Result<Self> {
+		Ok(Self {
+			inner: TcpListener::from_std(listener)?,
+			health,
+		})
+	}
+}
+
+/// An `axum_server` bound to [`Listener`], ready for `.acceptor(..)`/`.serve(..)`.
+///
+/// The address type is spelled here rather than at each call site: `A::Listener`
+/// doesn't pin `A` down, so inference cannot get there from the listener alone.
+pub(crate) fn server(listener: std::net::TcpListener, health: Health) -> io::Result<axum_server::Server<Peer>> {
+	Ok(axum_server::Server::from_listener(Listener::new(listener, health)?))
+}
+
+impl AddrListener<TcpStream, Peer> for Listener {
+	/// Only reachable through `axum_server::Server::bind`, which nothing here uses:
+	/// both listeners come pre-bound so their socket options are ours to set.
+	async fn bind_to(addr: Peer) -> io::Result<Self> {
+		Ok(Self {
+			inner: TcpListener::bind(addr.0).await?,
+			health: Health::new("tcp"),
+		})
+	}
+
+	/// Keep asking until a connection comes back.
+	///
+	/// Never returns an error: there is nothing above this worth telling, since
+	/// `axum_server` would only sleep and drop it. The failure leaves through
+	/// [`Health`] instead, which survives the episode that a log line during it may
+	/// not.
+	async fn accept_stream(&self) -> io::Result<(TcpStream, Peer)> {
+		loop {
+			match self.inner.accept().await {
+				Ok((stream, peer)) => {
+					self.health.accepted();
+					return Ok((stream, Peer(peer)));
+				}
+				Err(err) => {
+					if let Some(delay) = self.health.failed(&err) {
+						tokio::time::sleep(delay).await;
+					}
+				}
+			}
+		}
+	}
+
+	fn get_local_addr(&self) -> io::Result<Peer> {
+		self.inner.local_addr().map(Peer)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use moq_native::accept::Failure;
+
+	/// The wrapper has to survive a real accept, since everything above it is
+	/// generic over `Address` and a mismatch only shows up at the serve call.
+	#[tokio::test]
+	async fn accepts_a_connection_and_reports_health() {
+		let bound = moq_native::bind::tcp("127.0.0.1:0".parse().unwrap()).unwrap();
+		let addr = bound.local_addr().unwrap();
+		let health = Health::new("test");
+		let listener = Listener::new(bound, health.clone()).unwrap();
+
+		assert_eq!(listener.get_local_addr().unwrap().0, addr);
+
+		let connect = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+		let (_stream, peer) = listener.accept_stream().await.unwrap();
+		let client = connect.await.unwrap();
+
+		assert_eq!(peer.0, client.local_addr().unwrap());
+		for failure in Failure::ALL {
+			assert_eq!(health.failures(failure), 0, "{failure} on a healthy accept");
+		}
+		assert_eq!(health.stalled(), None);
+	}
+}

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -129,13 +129,16 @@ impl Relay {
 		// drops the producer keeps publishing for as long as it serves.
 		let cluster = cluster.with_stats(stats.clone());
 
-		// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
-		// /metrics + /health + /nodes, separate from the customer-facing web server. No-op
-		// when unconfigured.
-		let internal = Internal::new(config.internal, cluster.stats.clone()).with_cluster(&cluster);
-
 		// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
 		let web = Web::new(auth.clone(), cluster.clone(), server.certificates(), config.web);
+
+		// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
+		// /metrics + /health + /nodes, separate from the customer-facing web server. No-op
+		// when unconfigured. The web server's accept health rides this listener, since
+		// the public one is exactly what goes quiet when the node runs out of sockets.
+		let internal = Internal::new(config.internal, cluster.stats.clone())
+			.with_cluster(&cluster)
+			.with_listener(web.accept_health());
 
 		match addr {
 			Some(addr) => tracing::info!(%addr, "listening"),

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -134,11 +134,13 @@ impl Relay {
 
 		// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
 		// /metrics + /health + /nodes, separate from the customer-facing web server. No-op
-		// when unconfigured. The web server's accept health rides this listener, since
-		// the public one is exactly what goes quiet when the node runs out of sockets.
+		// when unconfigured. Every listener that performs a real accept(2) reports here,
+		// web and stream alike: a stream-only relay has no web listener at all, and the
+		// point is that whichever socket goes quiet is the one a scrape can see.
 		let internal = Internal::new(config.internal, cluster.stats.clone())
 			.with_cluster(&cluster)
-			.with_listener(web.accept_health());
+			.with_listeners(web.accept_health())
+			.with_listeners(server.accept_health());
 
 		match addr {
 			Some(addr) => tracing::info!(%addr, "listening"),

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -165,12 +165,17 @@ impl Web {
 	/// a WebSocket session, a WHIP offer, or an HLS request while every other metric
 	/// looks healthy. Take it before `serve` consumes the server.
 	///
-	/// Both listeners report into this one handle. The failures worth escalating on
-	/// are process- or host-wide (out of descriptors, out of kernel memory), so an
+	/// `None` when neither listener is configured, so a QUIC-only relay publishes no
+	/// counters for a socket it never opens. A permanently-zero series for an absent
+	/// listener reads as a watch that is passing when there is nothing there to watch.
+	///
+	/// When both are configured they share one handle. The failures worth escalating
+	/// on are process- or host-wide (out of descriptors, out of kernel memory), so an
 	/// HTTP accept that succeeds is real evidence that the HTTPS one is not stalled
 	/// either.
-	pub fn accept_health(&self) -> moq_native::accept::Health {
-		self.health.clone()
+	pub fn accept_health(&self) -> Option<moq_native::accept::Health> {
+		let configured = self.config.http.listen.is_some() || self.config.https.listen.is_some();
+		configured.then(|| self.health.clone())
 	}
 
 	/// Build the default web router with `state` applied, returning a

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -136,6 +136,7 @@ pub(crate) struct WebState {
 pub struct Web {
 	state: Arc<WebState>,
 	config: WebConfig,
+	health: moq_native::accept::Health,
 }
 
 impl Web {
@@ -149,7 +150,27 @@ impl Web {
 			certificates,
 			conn_id: AtomicU64::new(0),
 		});
-		Self { state, config }
+		Self {
+			state,
+			config,
+			health: moq_native::accept::Health::new("web"),
+		}
+	}
+
+	/// A live handle to the accept-loop health of the HTTP/HTTPS listeners, for an
+	/// embedder that publishes it (see [`moq_native::accept`]).
+	///
+	/// This is the one signal that leaves the process when the public listener goes
+	/// dark: [`serve`](Self::serve) never gives up, so a node can be unable to accept
+	/// a WebSocket session, a WHIP offer, or an HLS request while every other metric
+	/// looks healthy. Take it before `serve` consumes the server.
+	///
+	/// Both listeners report into this one handle. The failures worth escalating on
+	/// are process- or host-wide (out of descriptors, out of kernel memory), so an
+	/// HTTP accept that succeeds is real evidence that the HTTPS one is not stalled
+	/// either.
+	pub fn accept_health(&self) -> moq_native::accept::Health {
+		self.health.clone()
 	}
 
 	/// Build the default web router with `state` applied, returning a
@@ -208,7 +229,7 @@ impl Web {
 			// Dual-stack so the cert endpoint + WebSocket fallback answer over IPv4
 			// too, even on Windows where `[::]` is IPv6-only by default.
 			let listener = moq_native::bind::tcp(listen).context("failed to bind HTTP listener")?;
-			let server = axum_server::from_tcp(listener)?;
+			let server = crate::listener::server(listener, self.health.clone())?;
 			Some(server.serve(app.clone()))
 		} else {
 			None
@@ -232,7 +253,7 @@ impl Web {
 				inner: RustlsAcceptor::new(rustls_config),
 			};
 			let listener = moq_native::bind::tcp(listen).context("failed to bind HTTPS listener")?;
-			let server = axum_server::from_tcp(listener)?.acceptor(acceptor);
+			let server = crate::listener::server(listener, self.health.clone())?.acceptor(acceptor);
 			Some(server.serve(app))
 		} else {
 			None

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -269,8 +269,9 @@ async fn relay_https_terminates_tls() {
 	let web = build_web_with(config).await;
 
 	// Held past `serve`, which consumes the server: this is the whole point of
-	// taking the handle up front.
-	let health = web.accept_health();
+	// taking the handle up front. `Some` because a listener is configured; a relay
+	// with neither HTTP nor HTTPS reports nothing rather than a permanent zero.
+	let health = web.accept_health().expect("an HTTPS listener is configured");
 
 	let (server_result_tx, mut server_result_rx) = tokio::sync::oneshot::channel();
 	let handle = tokio::spawn(async move {

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -30,6 +30,14 @@ fn newest_lite_version() -> moq_net::Version {
 }
 
 async fn build_web(port: u16, ws: bool) -> Web {
+	let mut config = WebConfig::default();
+	config.ws = ws;
+	config.http.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
+	build_web_with(config).await
+}
+
+/// [`build_web`] for a test that configures the listeners itself (e.g. HTTPS).
+async fn build_web_with(web_config: WebConfig) -> Web {
 	// Crypto provider is process-global; reinstalls after the first one are
 	// no-ops, but the test binary may run before any other moq code does.
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
@@ -55,10 +63,6 @@ async fn build_web(port: u16, ws: bool) -> Web {
 	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 	let server = server_config.init().expect("server init");
-
-	let mut web_config = WebConfig::default();
-	web_config.ws = ws;
-	web_config.http.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
 
 	Web::new(auth, cluster, server.certificates(), web_config)
 }
@@ -234,6 +238,61 @@ async fn relay_web_serves_merged_routes() {
 		.await
 		.expect("read embedded response");
 	assert_eq!(body, "embedded\n");
+
+	handle.abort();
+}
+
+/// The HTTPS listener has to terminate TLS and answer a real request.
+///
+/// The plain-HTTP tests above go through `axum_server`'s default acceptor, so they
+/// say nothing about the TLS stack: `MtlsAcceptor` wraps `RustlsAcceptor`, hot
+/// reload swaps the config underneath it, and the listener the relay hands
+/// `axum_server` is its own. A compile is not evidence any of that still handshakes.
+#[tokio::test]
+async fn relay_https_terminates_tls() {
+	let port = free_tcp_port();
+	let dir = tempfile::TempDir::new().expect("tempdir");
+
+	let key = rcgen::KeyPair::generate().expect("keypair");
+	let params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).expect("cert params");
+	let cert = params.self_signed(&key).expect("self-signed cert");
+	let cert_path = dir.path().join("cert.pem");
+	let key_path = dir.path().join("key.pem");
+	std::fs::write(&cert_path, cert.pem()).expect("write cert");
+	std::fs::write(&key_path, key.serialize_pem()).expect("write key");
+
+	let mut config = WebConfig::default();
+	config.ws = false;
+	config.https.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
+	config.https.cert = vec![cert_path];
+	config.https.key = vec![key_path];
+	let web = build_web_with(config).await;
+
+	// Held past `serve`, which consumes the server: this is the whole point of
+	// taking the handle up front.
+	let health = web.accept_health();
+
+	let (server_result_tx, mut server_result_rx) = tokio::sync::oneshot::channel();
+	let handle = tokio::spawn(async move {
+		let _ = server_result_tx.send(web.run().await);
+	});
+
+	wait_for_http(port, &mut server_result_rx).await;
+
+	let client = reqwest::Client::builder()
+		.add_root_certificate(reqwest::Certificate::from_pem(cert.pem().as_bytes()).expect("parse root"))
+		.build()
+		.expect("build https client");
+	let resp = tokio::time::timeout(TIMEOUT, client.get(format!("https://localhost:{port}/health")).send())
+		.await
+		.expect("https request timed out")
+		.expect("https request failed");
+	assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+	// A listener that just served a request is not stalled, and the connections it
+	// fielded were not junk.
+	assert_eq!(health.stalled(), None);
+	assert_eq!(health.failures(moq_native::accept::Failure::Exhausted), 0);
 
 	handle.abort();
 }


### PR DESCRIPTION
Upstream half of [moq.pro#962](https://github.com/moq-dev/moq.pro/issues/962): the relay's `:443` TCP listener is the only one in this stack that performs a real `accept(2)`, it carries WebSocket MoQ / WHIP-WHEP signalling / the live HLS origin, and nothing was watching it.

## Root cause

Two separate swallows, both reachable today:

- **`Web`/`Internal`.** `axum_server`'s serve loop is `Err(_) => sleep(50ms)` ([server.rs](https://docs.rs/axum-server/0.8.0/src/axum_server/server.rs.html)). The error is not logged at any level, not counted, and never reaches the embedder. A flat 50ms is also wrong in both directions: too long for a per-connection error (ordinary traffic on a public port, paid for by whatever is queued behind it), too short for `EMFILE`. Note `axum`'s own `serve` gets the *shape* right for comparison: retry-at-once for a connection error, `error!` plus a 1s sleep otherwise.
- **`moq_native::{tcp,unix,websocket}::Listener`.** Each flattened the accept errno into the same `Error::Io` variant used for bind and connect, and each caller looped immediately. Under `EMFILE` the connection stays queued, so the listener is instantly readable and instantly failing: a hot loop burning the core the process needs in order to recover, narrated at `debug!` (WebSocket) or as a misleading `warn!` (tcp/unix). `Server::accept` also returned `None` on a lazy bind failure, indistinguishable from a shutdown.

An accept loop is a process-lifetime supervisor with nobody to return an error to, so it has to own the policy and publish what it is doing. Neither did.

## What this adds

**`moq_native::accept`.** `Failure::classify` splits the errno into the two families that want opposite handling; `Health` counts, logs, and paces:

- `Connection` (`ECONNABORTED`, `ECONNRESET`, `EPERM`, `EINTR`, ...) retries at once. The queue entry was consumed, so the listener already made progress and delaying only punishes the connections queued behind the dead one.
- `Exhausted` (`EMFILE`/`ENFILE`/`ENOBUFS`/`ENOMEM`) backs off with equal jitter toward a 5s cap and warns per attempt, per the Retries policy in `CLAUDE.md` (supervisors retry forever, cap in seconds, loudly broken rather than silently parked).
- `Unknown` backs off but claims nothing. Escalating on an unrecognized errno hands a remote peer a lever, which is what [moq.pro#927](https://github.com/moq-dev/moq.pro/issues/927) was reverted for.

One shared object rather than an inlined backoff per listener, deliberately: the classification *is* the pacing policy here, getting it backwards is not symmetric, and five listeners that each re-derive it will not agree for long.

**The relay takes the accept syscall back from `axum_server`** through its own listener abstraction (`AddrListener`/`Address`, `rs/moq-relay/src/listener.rs`), so the wrapper never yields an error upward and the flat sleep is unreachable. `axum_server` keeps everything past the accept: TLS, HTTP version negotiation, WebSocket upgrades, graceful shutdown.

**The counters ride the existing ops endpoint**, so a plain relay operator gets this without writing any code:

```
moq_relay_accept_failures_total{listener="web",class="connection"} 41
moq_relay_accept_failures_total{listener="web",class="exhausted"} 0
moq_relay_accept_failures_total{listener="web",class="unknown"} 0
moq_relay_accept_stalled_seconds{listener="web"} 0
```

Alert on the counter, not the gauge: a process with no descriptors left cannot serve the scrape either, so the episode is usually only readable once it is over, by which point the gauge reads a healthy zero. `Web::accept_health()` hands the same handle to an embedder with its own metrics surface, and `Internal::with_listener` registers anything the embedder listens on itself.

No QUIC listener registers one. They multiplex every session over a single UDP socket, never call `accept`, and a permanently-zero exhaustion counter reads as a watch that is passing when it can never fire ([moq.pro#942](https://github.com/moq-dev/moq.pro/issues/942)).

**`Server::listen`** (additive) binds the lazy `tcp`/`unix` listeners up front, so a bind failure is an error the caller handles and a later `None` from `accept` unambiguously means shutdown.

## Tests

- `accept::tests` cover the classification (including that a reset connection never reads as exhaustion, and that an unrecognized errno is `Unknown`), that a dead connection never pauses the listener, that exhaustion escalates and caps, and that a successful accept clears the stall while leaving the counters intact.
- `internal::tests::accept_metrics_list_every_listener_from_zero` pins that every registered listener appears at zero before it has ever failed. A counter that springs into existence on first failure makes the alert unwritable: `rate()` over a missing series is empty, not zero.
- `smoke::relay_https_terminates_tls` is new end-to-end coverage of the HTTPS listener. `Web`'s TLS path had none, and it is the part this PR routes differently, so a compile was not evidence that `MtlsAcceptor` still handshakes over the swapped listener.
- 395 tests pass; `clippy -D warnings` and `RUSTDOCFLAGS=-D warnings cargo doc` clean on both crates; workspace `--all-targets` compiles.

Only checked on macOS/aarch64. The Windows `WSAE*` classification arm compiles nowhere locally and has no test host.

## Not in scope

- **The measurement the issue asks for first.** I could not reach fleet data from here, so whether a node has ever actually hit `EMFILE` is still open. But the plumbing is justified independently: the current failure mode is not "dark and quiet", it is a CPU-burning spin that impedes the recovery, and the loops were out of compliance with the retry policy either way.
- `moq_rtmp::Server`'s accept loop backs off on *every* error including per-connection ones (`rs/moq-rtmp/src/server.rs`), the exact lever described above. It cannot use this without moq-rtmp depending on moq-native, which is the wrong layering for a gateway crate. Left alone.
- `moq-cli`'s `web.rs` still uses `axum_server::from_tcp`; it is a dev/cert-serving convenience, not a production listener.
- moq.pro's `common::retry::Accept` and `Ops::listener` now duplicate this upstream classification and can be collapsed onto it in a follow-up there. Note also that `Internal::serve(router)` already exists, so [moq.pro#944](https://github.com/moq-dev/moq.pro/issues/944)'s `serve_internal` carve-out is collapsible now.

Refs: moq-dev/moq.pro#962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 5)
