### PR TITLE
fix(just): lint only tracked shell scripts

### DIFF
--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -71,9 +71,9 @@ test:
     # success without running anything is worse than no gate, and nothing else
     # covers this code.
     cxx="${CXX:-c++}"
-    unsupported="'$cxx' cannot build with -fsanitize=thread. These tests need a clang or gcc style
-    driver with ThreadSanitizer: set CXX, or on Windows run them from WSL, since neither MSVC
-    nor clang on Windows implements ThreadSanitizer."
+    unsupported="'$cxx' cannot build with -fsanitize=thread. These tests need a Clang or GCC
+    compiler that supports ThreadSanitizer: set CXX, or on Windows run them from WSL, since
+    neither MSVC nor Clang on Windows implements ThreadSanitizer."
     if ! command -v "$cxx" >/dev/null; then
         echo "no C++ compiler at '$cxx'." >&2
         echo "$unsupported" >&2

--- a/doc/bin/obs.md
+++ b/doc/bin/obs.md
@@ -63,7 +63,7 @@ just obs build
 
 It needs the `libobs` headers plus a built `libmoq` (`target/include/moq.h`). On macOS and Windows the headers come from the obs-deps bundle `just obs setup` downloads; on Linux they come from the Nix dev shell via `pkg-config`. Set `OBS_INCLUDE_DIR` to point it somewhere else. Like `just rs macos` and `just rs windows`, it is a manual gate: PR CI never compiles this plugin.
 
-It also needs a clang or gcc style compiler with ThreadSanitizer, so it fails rather than skipping when one isn't available. Linux and macOS are covered by the toolchains the plugin already builds with; on Windows run it from WSL, since neither MSVC nor clang on Windows implements ThreadSanitizer.
+It also needs a Clang or GCC compiler that supports ThreadSanitizer, so it fails rather than skipping when one isn't available. Linux and macOS are covered by the toolchains the plugin already builds with; on Windows run it from WSL, since neither MSVC nor clang on Windows implements ThreadSanitizer.
 
 ```bash
 just obs test

--- a/doc/bin/obs.md
+++ b/doc/bin/obs.md
@@ -63,7 +63,7 @@ just obs build
 
 It needs the `libobs` headers plus a built `libmoq` (`target/include/moq.h`). On macOS and Windows the headers come from the obs-deps bundle `just obs setup` downloads; on Linux they come from the Nix dev shell via `pkg-config`. Set `OBS_INCLUDE_DIR` to point it somewhere else. Like `just rs macos` and `just rs windows`, it is a manual gate: PR CI never compiles this plugin.
 
-It also needs a Clang or GCC compiler that supports ThreadSanitizer, so it fails rather than skipping when one isn't available. Linux and macOS are covered by the toolchains the plugin already builds with; on Windows run it from WSL, since neither MSVC nor clang on Windows implements ThreadSanitizer.
+It also needs a Clang or GCC compiler that supports ThreadSanitizer, so it fails rather than skipping when one isn't available. Linux and macOS are covered by the toolchains the plugin already builds with; on Windows run it from WSL, since neither MSVC nor Clang on Windows implements ThreadSanitizer.
 
 ```bash
 just obs test

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ check-all *args:
 _check-common:
     bun install --frozen-lockfile
     bun remark . --quiet --frail
-    @if command -v shellcheck >/dev/null 2>&1 && command -v shfmt >/dev/null 2>&1; then shfmt --diff $(shfmt -f . | grep -v '\.direnv/') && shellcheck $(shfmt -f . | grep -v '\.direnv/'); fi
+    @if command -v shellcheck >/dev/null 2>&1 && command -v shfmt >/dev/null 2>&1; then files=$(git ls-files -z | xargs -0 shfmt -f); shfmt --diff $files && shellcheck $files; fi
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format --check; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt --check $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); fi
     @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --check --justfile "$f"; done


### PR DESCRIPTION
## Summary

Two small hygiene fixes, both fallout from #2681.

- **`just check` fails locally once you've built the OBS plugin.** `shfmt -f .` walks the working tree, so it picks up CMake-generated scripts under gitignored build directories. After `just obs setup && just obs build`, `cpp/obs/.deps/` and `cpp/obs/build_macos/` contribute 51 generated scripts that fail `shfmt`, and the repo-wide lint fails. CI never saw this because a fresh checkout has no build output.

  Fixed by selecting the files with `git ls-files`, which is what `just obs check` already does for clang-format. Ignored output is excluded by construction rather than by a hardcoded list of directory names that would need extending for every new build tree, and it drops the walk from 87 files to the 36 real ones.

- **Compiler wording** in the `just obs test` requirement: "a clang or gcc style compiler with ThreadSanitizer" -> "a Clang or GCC compiler that supports ThreadSanitizer", in both the recipe's error message and `doc/bin/obs.md`. Raised by CodeRabbit on #2681 after it had already merged.

## Public API changes

None. Tooling and docs only.

## Test plan

- Verified the tracked file set is **unchanged**: diffed the old scope against the new one and confirmed no file the old lint covered is missed, and the new scope adds nothing. The 51 dropped files are all under `cpp/obs/.deps/` and `cpp/obs/build_macos/`.
- `shfmt --diff` + `shellcheck` over the new set: clean.
- `just _check-common` (the recipe CI runs) **in a worktree with the build artifacts present**, which is the exact scenario that failed before: passes.
- `just --fmt --check` on both edited justfiles, and `remark` on the doc: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Opus 5)