### PR TITLE
chore(js/net): defer version bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.4.0",
+      "version": "0.3.0",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.4.0",
+	"version": "0.3.0",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
## Summary

- Restore `@moq/net` from 0.4.0 to 0.3.0 in the package manifest and workspace lockfile.
- Keep the breaking `ReloadProps` API correction from #2665 unchanged.
- Defer choosing the next package release version until the later release work.

## Public API changes

None. This only reverts premature release metadata.

## Release safety

- `release-js.yml` runs only on pushes to `main`, not `dev`.
- Both `main` and npm currently have `@moq/net` 0.2.3.
- Version 0.4.0 existed only on `dev` between #2665 and this correction, so it cannot publish before this change.
- When `dev` is eventually promoted, the final tree moves monotonically from published 0.2.3 to 0.3.0.

## Test plan

- `bun install --frozen-lockfile`
- `bun run --cwd js/net check`
- `just js fix`
- `git diff --check`
- Required GitHub `Check` passed in 3m34s.

(Written by GPT-5)