### PR TITLE
fix(moq-net): name a broadcast by where its reader found it

### DIFF
--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -92,7 +92,8 @@ The section is omitted entirely when a broadcast publishes no captions.
 ### Cross-broadcast renditions
 
 A rendition may set an optional `broadcast` field: a path relative to the broadcast that served the catalog (e.g. `"../source"`), pointing at another broadcast that publishes the actual track.
-A consumer resolves the reference against the catalog broadcast's own path (`..` pops a segment, other segments append) and subscribes to the track on the resolved broadcast over the same connection.
+A consumer resolves the reference against the path it reached the catalog broadcast at (`..` pops a segment, other segments append) and subscribes to the track on the resolved broadcast over the same connection.
+That is the path the consumer asked for, not one the publisher declares, so a reference can only ever name a broadcast the consumer could have named itself.
 When the field is absent, the track lives in the same broadcast as the catalog.
 A reference that walks above the root (more `..` than the catalog path has segments) names no broadcast, so the whole catalog is rejected rather than pointed at whatever path the walk stops on.
 The root is the consumer's authorized subtree, so such a reference is an attempt to name content it cannot reach: a publisher emitting one has a bug, and quietly serving the remaining renditions would hide that.

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -119,17 +119,19 @@ impl Announced {
 			}
 		}
 	}
+}
 
+/// Waits for one exact path, delegating to [`moq_net::origin::Consumer::announced_broadcast`].
+struct AnnouncedBroadcast {
+	origin: moq_net::origin::Consumer,
+	path: moq_net::PathOwned,
+}
+
+impl AnnouncedBroadcast {
 	async fn available(&mut self) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
-		loop {
-			match self.inner.next().await {
-				// Skip unannounce events; we're waiting for the broadcast to become available.
-				Some(moq_net::announce::Update { broadcast, .. }) => match broadcast {
-					Some(broadcast) => return Ok(Arc::new(MoqBroadcastConsumer::new(broadcast))),
-					None => continue,
-				},
-				None => return Err(MoqError::Closed),
-			}
+		match self.origin.announced_broadcast(&self.path).await {
+			Some(broadcast) => Ok(Arc::new(MoqBroadcastConsumer::new(broadcast))),
+			None => Err(MoqError::Closed),
 		}
 	}
 }
@@ -144,7 +146,7 @@ pub struct MoqAnnouncement {
 /// Waits for a specific broadcast to be announced.
 #[derive(uniffi::Object)]
 pub struct MoqAnnouncedBroadcast {
-	task: Task<Announced>,
+	task: Task<AnnouncedBroadcast>,
 }
 
 impl MoqOriginProducer {
@@ -263,10 +265,20 @@ impl MoqOriginConsumer {
 	/// Wait for a specific broadcast to be announced by path.
 	pub fn announced_broadcast(&self, path: String) -> Result<Arc<MoqAnnouncedBroadcast>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let origin = self.inner.with_root(path).ok_or(MoqError::Unauthorized)?;
+		let path = moq_net::Path::new(&path).to_owned();
+
+		// Probe the permission eagerly so an unreachable path fails here, rather than
+		// surfacing later as a `Closed` the caller can't tell from the origin ending.
+		self.inner.with_root(&path).ok_or(MoqError::Unauthorized)?;
+
 		Ok(Arc::new(MoqAnnouncedBroadcast {
-			task: Task::new(Announced {
-				inner: origin.announced(),
+			task: Task::new(AnnouncedBroadcast {
+				// The wait runs on the *unrooted* cursor. `announced_broadcast` narrows with
+				// `scope`, which leaves the root alone, so the broadcast is handed out named by
+				// its full path. Rooting the cursor at `path` would name it "" instead, making
+				// it its own root, and a catalog's `../sibling` reference would read as escaping.
+				origin: self.inner.clone(),
+				path,
 			}),
 		}))
 	}

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -719,6 +719,33 @@ async fn create_broadcast_announces() {
 	_broadcast.finish().unwrap();
 }
 
+/// Waiting for an exact path must hand the broadcast back named by that path, the base a
+/// catalog's relative `broadcast` references resolve against. Implementing the wait by
+/// rooting the cursor *at* the path would name it "", making the broadcast its own root, so
+/// a legal `../sibling` reference would read as escaping for every binding built on this.
+#[tokio::test]
+async fn announced_broadcast_keeps_the_requested_path() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let consumer = origin.consume();
+	let broadcast = origin.create_broadcast("a/pub".into()).unwrap();
+
+	let announced = consumer.announced_broadcast("a/pub".into()).unwrap();
+	let waited = tokio::time::timeout(TIMEOUT, announced.available())
+		.await
+		.expect("timed out waiting for the announcement")
+		.unwrap();
+	assert_eq!(waited.inner().info().path.as_str(), "a/pub");
+
+	// The same broadcast reached by request names itself identically.
+	let requested = tokio::time::timeout(TIMEOUT, consumer.request_broadcast("a/pub".into()))
+		.await
+		.expect("timed out requesting the broadcast")
+		.unwrap();
+	assert_eq!(requested.inner().info().path.as_str(), "a/pub");
+
+	broadcast.finish().unwrap();
+}
+
 #[tokio::test]
 async fn set_announce_toggles_announcement() {
 	let origin = MoqOriginProducer::new(MoqOriginOptions::default());

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -189,6 +189,58 @@ mod test {
 		publish_catalog(published)
 	}
 
+	/// [`publish_catalog`] against a *standalone* broadcast (no origin, so its own path is
+	/// empty) that a dynamic handler serves at `a/pub`, read back through the requesting
+	/// origin cursor. That is the shape an FFI app takes when it answers an origin request
+	/// with a broadcast it built itself.
+	async fn publish_catalog_served(published: Catalog<()>) -> Result<Option<Catalog>> {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let mut track = broadcast
+			.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())
+			.expect("catalog track should create");
+
+		let origin = moq_net::Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let requesting = origin.consume().request_broadcast("a/pub");
+		let served = broadcast.consume();
+		tokio::spawn(async move {
+			dynamic
+				.requested_broadcast()
+				.await
+				.expect("handler should be asked for the path")
+				.accept(&served);
+		});
+
+		let subscriber = requesting
+			.await
+			.expect("the handler served it")
+			.track(hang::Catalog::DEFAULT_NAME)
+			.expect("catalog track should resolve")
+			.subscribe(None)
+			.await
+			.expect("catalog track should subscribe");
+		let mut consumer = Consumer::new(subscriber);
+
+		let mut group = track.append_group().expect("catalog group should append");
+		let payload = serde_json::to_string(&published).expect("catalog should serialize");
+		group
+			.write_frame(moq_net::Timestamp::ZERO, payload)
+			.expect("catalog frame should write");
+		group.finish().expect("catalog group should finish");
+
+		consumer.next().await
+	}
+
+	/// [`publish_catalog_served`] over one audio rendition carrying `reference`.
+	async fn publish_served(reference: &str) -> Result<Option<Catalog>> {
+		let mut published = Catalog::<()>::default();
+		published
+			.audio
+			.renditions
+			.insert("sibling".to_string(), referencing(reference));
+		publish_catalog_served(published).await
+	}
+
 	/// A reference that stops at or below the root names a broadcast, so the catalog stands.
 	#[tokio::test]
 	async fn accepts_references_within_the_root() {
@@ -225,6 +277,36 @@ mod test {
 				Err(err) => panic!("{reference} failed with the wrong error: {err:?}"),
 				Ok(_) => panic!("{reference} should reject the catalog"),
 			}
+		}
+	}
+
+	/// A broadcast is named by where its reader found it, not by where its producer created
+	/// it: a standalone broadcast served on demand at `a/pub` resolves `../source` against
+	/// `a/pub`. Naming it by the producer's own (empty) path would make its own root the
+	/// bound, rejecting a reference the requester can perfectly well reach.
+	#[tokio::test]
+	async fn accepts_references_within_the_served_path() {
+		let catalog = publish_served("../source")
+			.await
+			.expect("catalog should be accepted")
+			.expect("catalog should decode");
+
+		let rendition = catalog
+			.audio
+			.renditions
+			.get("sibling")
+			.expect("rendition should survive");
+		assert_eq!(rendition.broadcast.as_ref().unwrap().as_str(), "../source");
+	}
+
+	/// The bound moves with the served path rather than disappearing: a reference that
+	/// walks above `a/pub` still names nothing and still rejects the catalog.
+	#[tokio::test]
+	async fn rejects_references_escaping_the_served_path() {
+		match publish_served("../../../elsewhere").await {
+			Err(crate::Error::EscapingBroadcast(reported)) => assert_eq!(reported, "../../../elsewhere"),
+			Err(err) => panic!("wrong error: {err:?}"),
+			Ok(_) => panic!("an escaping reference should reject the catalog"),
 		}
 	}
 

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -34,10 +34,16 @@ pub struct Info {
 	/// broadcast with no relay origin).
 	pub origin: super::origin::Info,
 
-	/// This broadcast's path, relative to the root of the origin it was created under
-	/// (stamped by [`origin::Producer::create_broadcast`](super::origin::Producer::create_broadcast),
-	/// including through a scoped producer). Relative references in a catalog served by this
-	/// broadcast (hang's `broadcast` field) resolve against it.
+	/// The path this broadcast is named by, which relative references in a catalog it
+	/// serves (hang's `broadcast` field) resolve against.
+	///
+	/// [`origin::Producer::create_broadcast`](super::origin::Producer::create_broadcast) stamps
+	/// the path the broadcast was created at, relative to the origin root (including through a
+	/// scoped producer). Every [`Consumer`] an origin hands out is then re-stamped with the path
+	/// *that handle* was requested or announced at, relative to its cursor's root, since the
+	/// same broadcast can be reached under more than one name: a dynamic handler may serve a
+	/// standalone broadcast at any path, and a rooted cursor names a broadcast more tightly
+	/// than the origin does.
 	///
 	/// Empty (the default) for a standalone broadcast with no origin, which is then its own
 	/// root: any `..` reference escapes.
@@ -984,7 +990,23 @@ impl Consumer {
 		self
 	}
 
-	/// The broadcast's static metadata, fixed when it was created.
+	/// Stamp the path this handle was handed out at, overriding [`Info::path`].
+	///
+	/// The origin applies it to every broadcast it resolves, because the name belongs to
+	/// the (broadcast, cursor) pair rather than to the broadcast: what a catalog's relative
+	/// references resolve against is where the *reader* found the broadcast, not where its
+	/// producer happened to create it. Free when the two already agree, which is the case
+	/// for a broadcast created at the path an unrooted cursor asks for.
+	pub(crate) fn with_path(mut self, path: crate::PathOwned) -> Self {
+		if self.info.path != path {
+			let mut info = (*self.info).clone();
+			info.path = path;
+			self.info = Arc::new(info);
+		}
+		self
+	}
+
+	/// The broadcast's metadata, as reached through this handle.
 	pub fn info(&self) -> &Info {
 		&self.info
 	}
@@ -1051,9 +1073,12 @@ impl Consumer {
 
 	/// Get a handle to a track on this broadcast.
 	pub fn track(&self, name: &str) -> Result<track::Consumer, Error> {
-		// Tag the resolved track with this broadcast's egress scope so its
-		// subscriptions, fetches, and groups are attributed to the same broadcast.
-		self.track_inner(name).map(|track| track.with_stats(self.stats.clone()))
+		// Rebind the track to *this* handle's view of the broadcast, so a catalog track
+		// resolves its relative references against the path we were handed out at rather
+		// than the one the producer was created at, and tag it with this broadcast's egress
+		// scope so its subscriptions, fetches, and groups are attributed to the same broadcast.
+		self.track_inner(name)
+			.map(|track| track.with_broadcast(self.info.clone()).with_stats(self.stats.clone()))
 	}
 
 	fn track_inner(&self, name: &str) -> Result<track::Consumer, Error> {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2398,6 +2398,10 @@ impl Drop for Request {
 /// handler drops before serving it.
 pub struct Requesting {
 	inner: RequestState,
+	// The path the requester asked for, relative to its cursor's root. Stamped on the
+	// resolved broadcast (see [`broadcast::Info::path`]) because a handler is free to
+	// serve a broadcast created somewhere else entirely, or at no path at all.
+	path: PathOwned,
 	// Egress scope applied to the resolved broadcast, so its reads are attributed.
 	// Empty (no-op) for an untagged consumer.
 	stats: stats::Scope,
@@ -2415,24 +2419,28 @@ enum RequestState {
 
 impl Requesting {
 	fn ready(broadcast: broadcast::Consumer) -> Self {
-		Self {
-			inner: RequestState::Ready(broadcast),
-			stats: stats::Scope::default(),
-		}
+		Self::new(RequestState::Ready(broadcast))
 	}
 
 	fn failed(error: Error) -> Self {
+		Self::new(RequestState::Failed(error))
+	}
+
+	fn pending(consumer: kio::Consumer<PendingBroadcast>) -> Self {
+		Self::new(RequestState::Pending(consumer))
+	}
+
+	fn new(inner: RequestState) -> Self {
 		Self {
-			inner: RequestState::Failed(error),
+			inner,
+			path: PathOwned::default(),
 			stats: stats::Scope::default(),
 		}
 	}
 
-	fn pending(consumer: kio::Consumer<PendingBroadcast>) -> Self {
-		Self {
-			inner: RequestState::Pending(consumer),
-			stats: stats::Scope::default(),
-		}
+	fn with_path(mut self, path: PathOwned) -> Self {
+		self.path = path;
+		self
 	}
 
 	fn with_stats(mut self, scope: stats::Scope) -> Self {
@@ -2440,17 +2448,22 @@ impl Requesting {
 		self
 	}
 
+	/// Stamp a resolved broadcast with the path this cursor asked for and its egress scope.
+	fn hand_out(&self, broadcast: broadcast::Consumer) -> broadcast::Consumer {
+		broadcast.with_path(self.path.clone()).with_stats(self.stats.clone())
+	}
+
 	/// Poll for the requested broadcast without blocking.
 	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<broadcast::Consumer, Error>> {
 		match &self.inner {
-			RequestState::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone().with_stats(self.stats.clone()))),
+			RequestState::Ready(broadcast) => Poll::Ready(Ok(self.hand_out(broadcast.clone()))),
 			RequestState::Failed(error) => Poll::Ready(Err(error.clone())),
 			RequestState::Pending(consumer) => Poll::Ready(
 				match ready!(consumer.poll(waiter, |state| match &state.resolved {
 					Some(result) => Poll::Ready(result.clone()),
 					None => Poll::Pending,
 				})) {
-					Ok(result) => result.map(|broadcast| broadcast.with_stats(self.stats.clone())),
+					Ok(result) => result.map(|broadcast| self.hand_out(broadcast)),
 					// Every handler dropped without resolving: nobody could route it.
 					Err(_closed) => Err(Error::Unroutable),
 				},
@@ -2755,6 +2768,10 @@ impl Consumer {
 		// counters resolve against the same broadcast the ingress side wrote.
 		let absolute = self.root.join(&path).to_owned();
 		let scope = self.stats.egress(&absolute);
+		// The resolved handle is named by what *this* cursor asked for, not by the absolute
+		// path: a rooted cursor cannot name anything above its own root, so that is what a
+		// catalog it reads may reference.
+		let requested = path.to_owned();
 
 		// Prefer a live announcement when one is present; the dynamic queue is only a
 		// fallback for a path we hold nothing for. A broadcast we do hold but cannot
@@ -2762,7 +2779,10 @@ impl Consumer {
 		// with no route chain to check, so falling through would let it route around
 		// the split horizon and rebuild the loop.
 		match self.resolve(&path) {
-			Resolved::Found(broadcast) => return kio::Pending::new(Requesting::ready(broadcast).with_stats(scope)),
+			Resolved::Found(broadcast) => {
+				let resolved = Requesting::ready(broadcast).with_path(requested).with_stats(scope);
+				return kio::Pending::new(resolved);
+			}
 			Resolved::Excluded => return kio::Pending::new(Requesting::failed(Error::Unroutable)),
 			Resolved::Missing => {}
 		}
@@ -2773,7 +2793,8 @@ impl Consumer {
 		// requests share one upstream subscription. A closed entry is stale; `get` drops it
 		// and returns `None`, so we fall through and re-serve below.
 		if let Some(weak) = state.served.get(&absolute) {
-			return kio::Pending::new(Requesting::ready(weak.consume()).with_stats(scope));
+			let resolved = Requesting::ready(weak.consume()).with_path(requested).with_stats(scope);
+			return kio::Pending::new(resolved);
 		}
 
 		// Coalesce onto a pending request for the same path; otherwise register a new
@@ -2789,7 +2810,7 @@ impl Consumer {
 			consumer
 		};
 
-		kio::Pending::new(Requesting::pending(consumer).with_stats(scope))
+		kio::Pending::new(Requesting::pending(consumer).with_path(requested).with_stats(scope))
 	}
 
 	/// Returns a new Consumer that automatically strips out the provided prefix.
@@ -2904,21 +2925,24 @@ impl AnnounceConsumer {
 		}
 	}
 
-	/// Drive the egress announce guards and tag the broadcast for one update.
+	/// Stamp the broadcast for one update and drive the egress announce guards.
 	///
-	/// An announce opens a guard (keyed by absolute path) and tags the yielded
-	/// broadcast with the egress scope; an unannounce drops the guard. A no-op for
-	/// an untagged stream.
-	fn attribute(&mut self, update: OriginAnnounce) -> OriginAnnounce {
+	/// An announce stamps the yielded broadcast with the path it was announced at (see
+	/// [`broadcast::Info::path`]) plus the egress scope, and opens a guard keyed by the
+	/// absolute path; an unannounce drops the guard. The stamped path is the
+	/// cursor-relative one, so a catalog served by the broadcast resolves its relative
+	/// references against exactly the subtree this cursor may name.
+	fn hand_out(&mut self, update: OriginAnnounce) -> OriginAnnounce {
 		let OriginAnnounce { path, broadcast } = update;
 		let absolute = self.root.join(&path).to_owned();
 		match broadcast {
 			Some(broadcast) => {
 				let scope = self.stats.egress(&absolute);
 				self.guards.entry(absolute).or_insert_with(|| scope.announce());
+				let broadcast = broadcast.with_path(path.clone()).with_stats(scope);
 				OriginAnnounce {
 					path,
-					broadcast: Some(broadcast.with_stats(scope)),
+					broadcast: Some(broadcast),
 				}
 			}
 			None => {
@@ -2958,7 +2982,7 @@ impl AnnounceConsumer {
 			};
 			state.take().expect("predicate guaranteed an update")
 		};
-		Poll::Ready(Some(self.attribute(update)))
+		Poll::Ready(Some(self.hand_out(update)))
 	}
 
 	/// Returns the next (un)announced broadcast without blocking.
@@ -2967,7 +2991,7 @@ impl AnnounceConsumer {
 	/// Use [`Self::is_closed`] to check if the cursor is closed.
 	pub fn try_next(&mut self) -> Option<OriginAnnounce> {
 		let update = self.state.write().ok()?.take()?;
-		Some(self.attribute(update))
+		Some(self.hand_out(update))
 	}
 
 	/// Returns true if the cursor is closed (no more updates will arrive).
@@ -5294,6 +5318,74 @@ mod tests {
 			dynamic.requested_broadcast().now_or_never().is_some(),
 			"a genuinely missing path must still fall back"
 		);
+	}
+
+	/// A dynamic handler may serve a broadcast that was never created at the requested
+	/// path, so the requester's handle is named by what it asked for rather than by
+	/// whatever the producer was stamped with. A standalone broadcast (path `""`) served
+	/// at `a/pub` would otherwise be its own root, and a legal `../source` reference in
+	/// its catalog would read as escaping.
+	#[tokio::test]
+	async fn test_dynamic_broadcast_named_by_the_requested_path() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+
+		// A standalone broadcast, with no origin and no path of its own.
+		let mut standalone = broadcast::Info::new().produce();
+		let _track = standalone.create_track("catalog.json", None).unwrap();
+		assert_eq!(standalone.info().path.as_str(), "");
+
+		let requesting = origin.consume().request_broadcast("a/pub");
+		settle().await;
+		dynamic
+			.requested_broadcast()
+			.await
+			.expect("handler should be asked for the path")
+			.accept(&standalone);
+
+		let broadcast = requesting.await.expect("the handler served it");
+		assert_eq!(broadcast.info().path.as_str(), "a/pub");
+		// The stamp reaches the tracks, which is what a catalog reader resolves against.
+		let track = broadcast.track("catalog.json").unwrap();
+		assert_eq!(track.broadcast().path.as_str(), "a/pub");
+		assert_eq!(track.subscribe(None).await.unwrap().broadcast().path.as_str(), "a/pub");
+
+		// A repeat request shares the served broadcast and is named the same way.
+		let cached = origin.consume().request_broadcast("a/pub").await.unwrap();
+		assert_eq!(cached.info().path.as_str(), "a/pub");
+
+		// The handler's own handle keeps the broadcast's own (empty) name.
+		assert_eq!(standalone.consume().info().path.as_str(), "");
+	}
+
+	/// A rooted cursor names a broadcast relative to its own root, both when it requests
+	/// one by path and when it observes an announce. That is the only name it can
+	/// resolve against, so a catalog reference is bounds-checked against exactly the
+	/// subtree the cursor may reach rather than the origin's wider root.
+	#[tokio::test]
+	async fn test_rooted_cursor_names_broadcasts_relatively() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let _source = origin.create_broadcast("a/pub", announce()).unwrap();
+		settle().await;
+		settle().await;
+
+		// The origin stamps the absolute path at creation.
+		let absolute = origin.consume().request_broadcast("a/pub").await.unwrap();
+		assert_eq!(absolute.info().path.as_str(), "a/pub");
+
+		let rooted = origin.consume().with_root("a").unwrap();
+		assert_eq!(
+			rooted.request_broadcast("pub").await.unwrap().info().path.as_str(),
+			"pub"
+		);
+
+		let update = rooted.announced().next().await.unwrap();
+		assert_eq!(update.path.as_str(), "pub");
+		assert_eq!(update.broadcast.unwrap().info().path.as_str(), "pub");
 	}
 
 	/// When every route flows through the requester, the path is unroutable for

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1767,7 +1767,8 @@ impl Demand {
 pub struct Consumer {
 	name: Arc<str>,
 	// The broadcast this track belongs to, so a catalog track can name the path its
-	// relative references resolve against.
+	// relative references resolve against. Rebound by `broadcast::Consumer::track` to
+	// that handle's view, which may name the broadcast differently than its producer did.
 	broadcast: Arc<broadcast::Info>,
 	inner: ConsumerKind,
 	// Egress stats scope, set by a tagged [`broadcast::Consumer`] via
@@ -1809,13 +1810,22 @@ impl Consumer {
 		self
 	}
 
+	/// Rebind the track to the broadcast handle it was reached through, so
+	/// [`broadcast`](Self::broadcast) reports the path that handle was handed out at (see
+	/// [`broadcast::Info::path`]). Called by [`broadcast::Consumer::track`].
+	pub(crate) fn with_broadcast(mut self, broadcast: Arc<broadcast::Info>) -> Self {
+		self.broadcast = broadcast;
+		self
+	}
+
 	/// The track name this handle is bound to.
 	pub fn name(&self) -> &str {
 		&self.name
 	}
 
-	/// The broadcast this track belongs to. Its [`path`](broadcast::Info::path) is what a
-	/// catalog's relative `broadcast` references resolve against.
+	/// The broadcast this track belongs to, as reached through the handle it came from.
+	/// Its [`path`](broadcast::Info::path) is what a catalog's relative `broadcast`
+	/// references resolve against.
 	pub fn broadcast(&self) -> &broadcast::Info {
 		&self.broadcast
 	}
@@ -2539,8 +2549,9 @@ impl Subscriber {
 		&self.name
 	}
 
-	/// The broadcast this track belongs to. Its [`path`](broadcast::Info::path) is what a
-	/// catalog's relative `broadcast` references resolve against.
+	/// The broadcast this track belongs to, as reached through the handle it came from.
+	/// Its [`path`](broadcast::Info::path) is what a catalog's relative `broadcast`
+	/// references resolve against.
 	pub fn broadcast(&self) -> &broadcast::Info {
 		&self.broadcast
 	}


### PR DESCRIPTION
Closes #2685. Follow-up from #2630's review.

## Summary

**Root cause.** `broadcast::Info.path` was stamped once, by `create_broadcast`, so it named where the *producer* created the broadcast. That is right for every networked flow (a subscribing session re-mints the broadcast locally at the wire path), but a dynamic handler is free to serve a broadcast at a path it was never created at. Concretely: `MoqOriginRequest.accept()` (moq-ffi) can answer a request for `a/pub` with a standalone `MoqBroadcastProducer` stamped `""`. An in-process consumer then validated that catalog's `broadcast` references against the empty root, so a legal `../source` was rejected as `Error::EscapingBroadcast`.

**Fix.** Path is a property of the (broadcast, cursor) pair, not of the broadcast, so stamp it at origin hand-out:

- `broadcast::Consumer::with_path` re-stamps the path a handle was requested or announced at, rebuilding the `Arc<Info>` only when it actually differs.
- `broadcast::Consumer::track` rebinds the track to that view (`track::Consumer::with_broadcast`), which is what carries the stamp down to `track::Subscriber` and hence the hang catalog reader.
- `create_broadcast` still supplies the default, so an unrooted cursor asking for the path a broadcast was created at is unchanged.

Two calls worth reviewing:

- **Stamped at hand-out, not in `Request::accept`** (which the issue listed as a third site). One served broadcast can go to cursors with different roots, and each must see its own name; stamping at accept would freeze one cursor's view for everyone. The announced resolve, the `served` weak-cache hit, and the handler accept all funnel through `Requesting::poll_ok`, so one stamp covers all three.
- **Cursor-relative, not absolute.** That is already the base `moq_mux::Source` resolves against, so the catalog containment check and the subscribe path now agree by construction. This is the "exact validation" half of the issue: for a `with_root` consumer the check was previously against the wider origin root, and is now against the cursor's subtree. The visible consequence is that such a catalog is rejected at the catalog rather than later at subscribe.

## Public API changes

None. `broadcast::Consumer::with_path` and `track::Consumer::with_broadcast` are both `pub(crate)`; the private `AnnounceConsumer::attribute` is renamed to `hand_out`. `Requesting` gains a private field.

The observable change is the *value* `broadcast::Info::path` reports on a consumer handed out by an origin, which its doc comment now describes.

## Cross-package sync

- `js/net` / `js/hang`: nothing to mirror. `@moq/watch` resolves against `this.in.name`, the path the watcher asked for, so it never had this bug; the Rust side is adopting the JS model.
- `drafts/`: no wire change. The hang draft already says the reference "resolves against the consumer's root, which is the subtree it is authorized for", which is what this makes true in Rust.
- `doc/concept/layer/hang.md`: one sentence tightened to say the base is the path the consumer reached the broadcast at.

## Test plan

- `just check` (exit 0) over moq-net's dependents, plus the JS, markdown, and workflow checks.
- `cargo nextest run -p moq-net -p moq-mux`: 1265 passed.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-net --no-deps`: clean.
- Four new tests, three of which fail without the fix (the fourth is the complement guard, which must pass either way):
  - `moq-net`: a dynamic handler serving a standalone broadcast at `a/pub` (the issue's exact shape), asserting the stamp reaches `broadcast::Info`, `track::Consumer`, `track::Subscriber`, and a repeat request off the `served` cache.
  - `moq-net`: a rooted cursor naming a broadcast relatively, via both `request_broadcast` and `announced`.
  - `moq-mux`: end-to-end, a hang catalog with `../source` published on a standalone broadcast served at `a/pub` and read back through the requesting cursor.
  - `moq-mux`: the complement, that a reference escaping above the *served* path still rejects the catalog.

(Written by Opus 5)
