### PR TITLE
fix(net): remove linger; a broadcast closes with its last source

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -189,13 +189,6 @@ connect_api = "https://api.example.com/cluster/connect"
 # whose URL has no inline ?jwt=. Required to authenticate gossip / connect_api
 # discovered peers; for static `connect` peers, prefer an inline ?jwt=.
 token = "cluster.jwt"
-
-# Optional. How long a broadcast stays alive and announced after abruptly
-# losing its last publisher (a session dying without unannouncing). A publisher
-# reconnecting within the window resumes the same broadcast and subscribers
-# never notice. A clean unannounce always takes effect immediately. "0"
-# unannounces abrupt losses immediately too. Default: 5s.
-linger = "5s"
 ```
 
 See [Clustering](/bin/relay/cluster) for topology choices and the trade-off between hand-listed peers and gossip.
@@ -514,7 +507,7 @@ All eviction happens as tracks write (there is no background reaper), so both
 up. A publisher that stops writing but stays connected keeps what it had cached
 until it resumes or the broadcast closes; under memory pressure the byte budget
 is repaid by the tracks that are still writing. A publisher that disconnects has
-its groups released once the broadcast closes (see `cluster.linger`).
+its groups released as soon as the broadcast closes with it.
 
 `duration` only ever lowers retention. `latency_default` is the one knob that
 raises it, and only for peers whose protocol never told us what to keep.

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -41,8 +41,8 @@ func (o *OriginProducer) Dynamic() *OriginDynamic {
 // The broadcast starts live: the origin announces the path so subscribers can
 // discover it, becoming visible shortly after this returns. Toggle
 // discoverability with [BroadcastProducer.SetAnnounce]; Finish unpublishes
-// immediately, while dropping the producer without finishing lingers briefly so
-// a replacement publisher can take over.
+// immediately, while dropping the producer without finishing also unpublishes
+// but reads to subscribers as a failure rather than a deliberate end.
 func (o *OriginProducer) CreateBroadcast(path string) (*BroadcastProducer, error) {
 	inner, err := o.inner.CreateBroadcast(path)
 	if err != nil {

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -205,6 +205,7 @@ class OriginProducer:
         discover it, becoming visible shortly after this returns. Toggle
         discoverability with :meth:`BroadcastProducer.set_announce`; ``finish()``
         unpublishes immediately, while dropping the producer without finishing
-        lingers briefly so a replacement publisher can take over.
+        also unpublishes but reads to subscribers as a failure rather than a
+        deliberate end.
         """
         return BroadcastProducer._from_inner(self._inner.create_broadcast(path))

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -85,13 +85,10 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		.clone()
 		.context("`transcode` requires a relay: pass --client-connect <url>")?;
 	let publish = moq_net::Origin::random().produce();
-	// The source has to outlive a session drop for the reconnect to be worth
-	// anything: without the linger it closes on the first drop and `run` exits
-	// while the redial is still in flight. This is what `Client::consume` applies
-	// for the same reason; the origin is wired by hand here, so it applies it too.
-	let remote = moq_net::Origin::random()
-		.produce()
-		.with_linger(moq.client.backoff.linger());
+	// A session drop closes the source broadcast and ends the run: the outage is
+	// surfaced rather than transcoded over. The reconnect loop covers the dial;
+	// restarting after a mid-run drop is the caller's call.
+	let remote = moq_net::Origin::random().produce();
 	let mut session = net
 		.client(moq.client.clone())?
 		.with_publisher(&publish)

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -237,8 +237,8 @@ impl MoqOriginProducer {
 	/// path for subscribes and fetches without being announced.
 	///
 	/// [`MoqBroadcastProducer::finish`] unpublishes immediately. Dropping the producer
-	/// without finishing is treated as a failure: the path lingers briefly so a
-	/// replacement publisher can take over without subscribers noticing.
+	/// without finishing also unpublishes, but subscribers observe the end as a
+	/// failure rather than a deliberate one.
 	pub fn create_broadcast(&self, path: String) -> Result<Arc<MoqBroadcastProducer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		// Surfaces Error::Unauthorized (out of scope) via the MoqError::Protocol conversion.

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -14,24 +14,16 @@ struct Client {
 
 impl Client {
 	async fn connect(&self, url: Url) -> Result<Arc<MoqSession>, MoqError> {
-		let reconnect = self.config.reconnect.unwrap_or(true);
-		let linger = self.config.backoff.linger();
 		let client = self.config.clone().init().map_err(map_connect_error)?;
 
 		// Materialize both origin sides so the session can publish/subscribe and the FFI can
 		// always hand back a publisher/consumer.
 		let (publish, subscribe) = crate::origin::resolve_pair(self.publish.as_ref(), self.consume.as_ref());
 
-		// Mirror moq_native::Client::consume: broadcasts fed by a reconnecting session
-		// linger across a drop for as long as the loop keeps retrying, so consumers ride
-		// out a relay restart instead of tearing down. The linger rides the clone handed
-		// to the session; the caller-facing handle keeps the origin's own window.
-		let ingest = match reconnect {
-			true => subscribe.clone().with_linger(linger),
-			false => subscribe.clone(),
-		};
-
-		let connection = client.with_publisher(&publish).with_subscriber(ingest).connect(url);
+		let connection = client
+			.with_publisher(&publish)
+			.with_subscriber(subscribe.clone())
+			.connect(url);
 
 		// Wait for the first session so auth errors surface here; later drops are the
 		// connection's to ride out. `MoqClient::cancel` unblocks a dial stuck retrying.

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -1296,8 +1296,8 @@ async fn announced_broadcast() {
 
 	assert_eq!(announcement.path(), "test/broadcast");
 	let _catalog = announcement.broadcast().subscribe_catalog().await.unwrap();
-	// Finish so the origin tears the broadcast down immediately (the canonical
-	// end for a publisher; dropping without finish is the failure-linger path).
+	// Finish so consumers observe a deliberate end (the canonical end for a
+	// publisher; dropping without finish reads as a failure).
 	_broadcast.finish().unwrap();
 }
 

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -926,7 +926,7 @@ mod tests {
 		// Tear down the publisher mid-group. The track ends abruptly (the cursor drains the
 		// segments it already saw and ends; the still-open live-edge group is NOT finalized,
 		// since a reset can't vouch that its media is complete), while finishing the broadcast
-		// ends it promptly instead of lingering for a reconnect. (Clean-end finalization of the
+		// ends it cleanly rather than as a failure. (Clean-end finalization of the
 		// live edge is covered by segments::tests::next_after_walks_finalized_segments.)
 		drop((catalog, media, registration));
 		broadcast.finish();

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -384,20 +384,13 @@ impl Client {
 	/// Connect to the configured [`ClientConfig::connect`] URL, consuming its
 	/// broadcasts into `origin`.
 	///
-	/// Broadcasts fed by these sessions linger across a session drop for as long
-	/// as the reconnect loop keeps retrying ([`Backoff::linger`]): a relay restart
-	/// is a bounded gap the reconnect splices over, not a teardown. When the loop
-	/// gives up, its error surfaces (via [`Connection::closed`]) just before the
-	/// broadcasts abort. With reconnecting disabled there is no gap to splice, so
-	/// the broadcasts don't linger.
+	/// A session drop closes and unannounces the broadcasts it fed; the reconnect
+	/// loop re-announces them once a replacement session attaches. Applications
+	/// observe the outage rather than reading from a stale route.
 	///
 	/// Returns `None` when no `--client-connect` URL was configured.
 	pub fn consume(self, origin: moq_net::origin::Producer) -> Option<Connection> {
 		let url = self.connect.clone()?;
-		let origin = match self.reconnect {
-			true => origin.with_linger(self.backoff.linger()),
-			false => origin,
-		};
 		Some(self.with_subscriber(origin).connect(url))
 	}
 

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -86,19 +86,6 @@ impl Backoff {
 	pub fn timeout(&self) -> Duration {
 		self.timeout.unwrap_or(DEFAULT_TIMEOUT)
 	}
-
-	/// How long broadcasts fed by a reconnecting session should outlive a session
-	/// drop (see [`moq_net::origin::Info::linger`]): slightly past the give-up
-	/// [`timeout`](Self::timeout), so when the loop does give up its error surfaces
-	/// before the broadcasts tear down. A zero timeout retries forever, so the
-	/// broadcasts linger forever too.
-	pub fn linger(&self) -> Duration {
-		let timeout = self.timeout();
-		match timeout.is_zero() {
-			true => Duration::MAX,
-			false => timeout.saturating_add(Duration::from_secs(1)),
-		}
-	}
 }
 
 /// A connection lifecycle transition reported by [`Connection::status`].
@@ -1323,20 +1310,6 @@ mod tests {
 		assert_eq!(backoff.multiplier(), 2);
 		assert_eq!(backoff.max(), Duration::from_secs(5));
 		assert_eq!(backoff.timeout(), Duration::from_secs(10));
-	}
-
-	/// The linger outlives the give-up timeout (so the reconnect error surfaces
-	/// first), and an unlimited-retry timeout lingers forever.
-	#[test]
-	fn test_backoff_linger() {
-		let backoff = Backoff::default();
-		assert_eq!(backoff.linger(), backoff.timeout() + Duration::from_secs(1));
-
-		let unlimited = Backoff {
-			timeout: Some(Duration::ZERO),
-			..Backoff::default()
-		};
-		assert_eq!(unlimited.linger(), Duration::MAX);
 	}
 
 	#[test]

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -638,7 +638,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	assert!(broadcast.is_some(), "expected live announce");
 
 	// Unannounce: retracted by announce id on the wire. A deliberate finish
-	// unannounces immediately (a bare drop would linger for a reconnect).
+	// unannounces cleanly (a bare drop would read as a failure and log a warning).
 	second.finish();
 	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "second");
@@ -2349,6 +2349,70 @@ async fn one_shot_connect_surfaces_the_session_close() {
 		1,
 		"one-shot mode must dial exactly once"
 	);
+
+	drop(connection);
+	server_handle.abort();
+}
+
+/// The #2695 regression: a dead session unannounces the broadcasts it fed
+/// immediately, even while the reconnect loop keeps retrying (`timeout = 0`
+/// retries forever, which used to keep them announced forever). The reconnect
+/// exists to restore service, not to hide the outage: the application observes
+/// the loss, and a successful redial re-announces.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn a_dead_session_unannounces_while_the_reconnect_retries() {
+	let (mut server, addr) = test_server();
+	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
+
+	let pub_origin = Origin::random().produce();
+	let _broadcast = pub_origin
+		.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
+		.expect("create broadcast");
+
+	// Accept the first session and hand it back so the test can kill it. Later
+	// redials are left hanging (the server stops accepting), so the subscriber is
+	// observed mid-outage with the retry loop still running.
+	let server_pub = pub_origin.clone();
+	let (session_tx, session_rx) = tokio::sync::oneshot::channel();
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("accept");
+		let session = request.with_publisher(&server_pub).ok().await?;
+		let _ = session_tx.send(session);
+		std::future::pending::<()>().await;
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume().announced();
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	// Retry forever with a fast cadence: the worst case for a stale announce.
+	client_config.backoff.initial = Some(Duration::from_millis(10));
+	client_config.backoff.timeout = Some(Duration::ZERO);
+	let client = client_config.init().expect("failed to init client");
+
+	let connection = tokio::time::timeout(TIMEOUT, client.with_subscriber(sub_origin).connect(url).established())
+		.await
+		.expect("connect timed out")
+		.expect("connect failed");
+
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
+	assert_eq!(path.as_str(), "live");
+	assert!(broadcast.is_some(), "expected the initial announce");
+
+	// The server kills the session; the loop starts redialing into the void.
+	let session = tokio::time::timeout(TIMEOUT, session_rx)
+		.await
+		.expect("server session timed out")
+		.expect("server task gone");
+	session.abort(moq_net::Error::Cancel);
+
+	// The unannounce lands promptly, while the connection is still retrying.
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
+	assert_eq!(path.as_str(), "live");
+	assert!(broadcast.is_none(), "a dead session must unannounce, not linger");
 
 	drop(connection);
 	server_handle.abort();

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -2380,7 +2380,7 @@ async fn one_shot_connect_surfaces_the_session_close() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn a_dead_session_unannounces_while_the_reconnect_retries() {
-	let (mut server, addr) = test_server();
+	let (mut server, addr) = test_server().await;
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
 	let pub_origin = Origin::random().produce();

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -95,9 +95,8 @@ enum Detach {
 	/// The peer retracted the path, or we are rolling back an announce we just made.
 	/// Nothing is coming back, so close it now.
 	Graceful,
-	/// The stream carrying the path went away without retracting it. Leave the
-	/// origin's linger window open so a source reconnecting into it resumes the
-	/// broadcast instead of viewers seeing it end here.
+	/// The stream carrying the path went away without retracting it. Abort the
+	/// source so viewers observe the loss as an error rather than a clean end.
 	Abrupt,
 }
 
@@ -595,7 +594,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			// Ending cleanly IS the retraction here, unlike a NAMESPACE stream: this stream
 			// carries exactly one advertisement, and withdrawing it is what ends the stream.
 			// Any other ending left the advertisement standing, so the peer never withdrew
-			// it and the origin's linger window stays open for the reconnect.
+			// it and the loss reads as abrupt (an error, not a clean end).
 			let detach = match res.is_ok() {
 				true => Detach::Graceful,
 				false => Detach::Abrupt,
@@ -960,8 +959,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					let producer = entry.remove().producer;
 					match detach {
 						Detach::Graceful => producer.finish(),
-						// Dropping the guard aborts the source, which is what leaves the
-						// origin's linger window open for a replacement.
+						// Dropping the guard aborts the source, so the loss reads as an
+						// error rather than a clean end.
 						Detach::Abrupt => drop(producer),
 					}
 				}
@@ -1686,18 +1685,8 @@ mod tests {
 		Subscriber<crate::lite::test_transport::SinkSession>,
 		crate::origin::Producer,
 	) {
-		cluster_subscriber_with_linger(self_origin, std::time::Duration::ZERO)
-	}
-
-	fn cluster_subscriber_with_linger(
-		self_origin: crate::Origin,
-		linger: std::time::Duration,
-	) -> (
-		Subscriber<crate::lite::test_transport::SinkSession>,
-		crate::origin::Producer,
-	) {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
-		let origin = crate::origin::Info::new(self_origin).with_linger(linger).produce();
+		let origin = crate::origin::Info::new(self_origin).produce();
 		let (tasks, task_set) = crate::util::TaskSet::new();
 		// The set only drains announce-serving tasks; the tests here drive the model
 		// directly, so leaking it keeps the handles alive without a spawner.
@@ -1811,26 +1800,19 @@ mod tests {
 		assert_eq!(subscriber.route(Some(&advert), &free).unwrap().route.cost, 2);
 	}
 
-	/// A namespace stream that ends with advertisements still live must detach them
-	/// ABRUPTLY, leaving the origin's linger window open so a source reconnecting into
-	/// it resumes the broadcast. Finishing instead closes it synchronously, which
-	/// viewers see as an end and which promises that a later create at the path is new
-	/// content rather than a resumption: the wrong promise for a transient blip.
-	///
-	/// True even of a clean FIN, since closing the stream retracts nothing: the protocol
-	/// has NAMESPACE_DONE for that. moq-lite already behaves this way (its route map is
-	/// a local whose guards drop), which `lite::subscriber` pins separately.
+	/// A namespace stream that ends with advertisements still live detaches them, so
+	/// the broadcast closes rather than staying announced over a dead stream. True
+	/// even of a clean FIN, since closing the stream retracts nothing: the protocol
+	/// has NAMESPACE_DONE for that. moq-lite already behaves this way (its route map
+	/// is a local whose guards drop), which `lite::subscriber` pins separately.
 	///
 	/// Driven through the real exit path rather than by calling `stop_announce`: a test
 	/// that picked the detach itself would still pass if the stream stopped using it.
-	/// A zero-linger origin cannot tell the two detaches apart, which is why this sets one.
 	#[tokio::test(start_paused = true)]
-	async fn a_lost_namespace_stream_leaves_the_linger_window_open() {
+	async fn a_lost_namespace_stream_closes_the_broadcast() {
 		const VERSION: Version = Version::Draft18;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap())
-			.with_linger(std::time::Duration::from_secs(30))
-			.produce();
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 
 		// The peer answers, advertises one namespace, then the stream ends without ever
@@ -1863,18 +1845,16 @@ mod tests {
 		settle().await;
 
 		assert!(
-			consumer.get_broadcast("x.hang").is_some(),
-			"an ended stream closed the broadcast instead of lingering for a reconnect",
+			consumer.get_broadcast("x.hang").is_none(),
+			"an ended stream must close the broadcast, not leave a stale route",
 		);
 	}
 
-	/// The peer explicitly retracting a namespace still ends the broadcast NOW, linger
-	/// or not: it said the namespace is gone, so holding the front open would stall a
-	/// replacement and promise a resumption that is not coming.
+	/// The peer explicitly retracting a namespace ends the broadcast immediately: it
+	/// said the namespace is gone, so a later create at the path is new content.
 	#[tokio::test(start_paused = true)]
-	async fn an_explicit_namespace_done_closes_despite_the_linger_window() {
-		let (mut subscriber, origin) =
-			cluster_subscriber_with_linger(crate::Origin::new(1).unwrap(), std::time::Duration::from_secs(30));
+	async fn an_explicit_namespace_done_closes_the_broadcast() {
+		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
 		let consumer = origin.consume();
 
 		let path = crate::Path::new("room/host").to_owned();
@@ -1886,14 +1866,13 @@ mod tests {
 		settle().await;
 		assert!(
 			consumer.get_broadcast("room/host").is_none(),
-			"an explicit NAMESPACE_DONE lingered instead of closing",
+			"an explicit NAMESPACE_DONE must close the broadcast",
 		);
 	}
 
 	/// v14-16 withdraw a PUBLISH_NAMESPACE with PUBLISH_NAMESPACE_DONE, which the adapter
 	/// delivers as a message before it FINs the virtual stream. Reading it as a stray
-	/// message closes the whole session over a routine unannounce, and strands the
-	/// broadcast for the linger window on the way out.
+	/// message closes the whole session over a routine unannounce.
 	#[tokio::test(start_paused = true)]
 	async fn a_publish_namespace_done_retracts_without_faulting_the_session() {
 		const VERSION: Version = Version::Draft14;
@@ -1910,9 +1889,7 @@ mod tests {
 			.unwrap();
 		let script = log.writes.lock().unwrap().clone();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap())
-			.with_linger(std::time::Duration::from_secs(30))
-			.produce();
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let session = crate::lite::test_transport::ScriptedSession::eof(script);
 		let (tasks, task_set) = crate::util::TaskSet::new();
@@ -1944,24 +1921,21 @@ mod tests {
 
 		assert!(
 			consumer.get_broadcast("room/host").is_none(),
-			"an explicit withdrawal lingered instead of closing",
+			"an explicit withdrawal must close the broadcast",
 		);
 	}
 
-	/// A PUBLISH_NAMESPACE stream that dies mid-advertisement detaches ABRUPTLY. Only a
-	/// clean close retracts here, since that is how PUBLISH_NAMESPACE_DONE reaches us
-	/// (the adapter turns it into one); a stream that ended any other way still held the
-	/// advertisement, so the origin keeps the linger window open for the reconnect.
+	/// A PUBLISH_NAMESPACE stream that dies mid-advertisement detaches it, closing the
+	/// broadcast: the advertisement was never withdrawn, but the stream carrying it is
+	/// gone, and a route into a dead stream must not stay announced.
 	///
 	/// Driven through the real exit path rather than by calling `stop_announce`: a test
 	/// that picked the detach itself would still pass if the stream stopped using it.
 	#[tokio::test(start_paused = true)]
-	async fn a_broken_publish_namespace_stream_leaves_the_linger_window_open() {
+	async fn a_broken_publish_namespace_stream_closes_the_broadcast() {
 		const VERSION: Version = Version::Draft19;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap())
-			.with_linger(std::time::Duration::from_secs(30))
-			.produce();
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 
 		// The peer sends something that does not belong on this stream, ending it with an
@@ -2001,14 +1975,14 @@ mod tests {
 		settle().await;
 
 		assert!(
-			consumer.get_broadcast("room/host").is_some(),
-			"a broken stream closed the broadcast instead of lingering for a reconnect",
+			consumer.get_broadcast("room/host").is_none(),
+			"a broken stream must close the broadcast, not leave a stale route",
 		);
 	}
 
 	/// Several advertisements share one refcounted source, so the detach that empties it
-	/// is the one that counts: an earlier owner lost abruptly does not outvote the last
-	/// one's explicit retraction, and does not stall a replacement behind a linger.
+	/// is the one that counts: the broadcast survives the first stop and closes on the
+	/// last, whatever kind each detach is.
 	///
 	/// That is the model's own rule for several sources at one path (`detach_source`),
 	/// which is what these advertisements would be had they arrived on two sessions. The
@@ -2016,8 +1990,7 @@ mod tests {
 	/// what the origin sees.
 	#[tokio::test(start_paused = true)]
 	async fn the_last_owner_out_decides_the_detach() {
-		let (mut subscriber, origin) =
-			cluster_subscriber_with_linger(crate::Origin::new(1).unwrap(), std::time::Duration::from_secs(30));
+		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer::default();
@@ -2028,27 +2001,20 @@ mod tests {
 		}
 		settle().await;
 
-		// One advertisement's stream dies, the other is retracted explicitly.
+		// One advertisement's stream dies: the other still holds the source.
 		subscriber.stop_announce(path.clone(), Detach::Abrupt).unwrap();
-		subscriber.stop_announce(path.clone(), Detach::Graceful).unwrap();
-		settle().await;
-		assert!(
-			consumer.get_broadcast("room/host").is_none(),
-			"an explicit retraction lingered because an earlier owner was lost abruptly",
-		);
-
-		// The reverse order still lingers: the path was never withdrawn on the way out.
-		for _ in 0..2 {
-			let advert = subscriber.route(None, &peer).expect("route");
-			subscriber.start_announce(path.clone(), advert).unwrap();
-		}
-		settle().await;
-		subscriber.stop_announce(path.clone(), Detach::Graceful).unwrap();
-		subscriber.stop_announce(path, Detach::Abrupt).unwrap();
 		settle().await;
 		assert!(
 			consumer.get_broadcast("room/host").is_some(),
-			"an abrupt last detach closed the broadcast instead of lingering for a reconnect",
+			"the broadcast must survive while an owner remains",
+		);
+
+		// The last owner retracts: the broadcast closes with it.
+		subscriber.stop_announce(path, Detach::Graceful).unwrap();
+		settle().await;
+		assert!(
+			consumer.get_broadcast("room/host").is_none(),
+			"the last owner out must close the broadcast",
 		);
 	}
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1517,20 +1517,16 @@ mod tests {
 		);
 	}
 
-	/// An announce stream that dies without an explicit `ended` must detach ABRUPTLY,
-	/// leaving the origin's linger window open so a source reconnecting into it resumes
-	/// the broadcast rather than viewers seeing it end here.
+	/// An announce stream that dies without an explicit `ended` closes the broadcast
+	/// as promptly as an explicit retraction: a route into a dead session must not
+	/// stay announced, so viewers observe the loss instead of a stale route.
 	///
-	/// This already falls out of `routes` being a local whose `AnnouncedRoute` guards
-	/// drop, which is exactly what makes it worth pinning: a refactor that finished them
-	/// on the way out, or hoisted the map to the session, would be a silent behavior
-	/// change. `ietf::Subscriber` names the same distinction explicitly as `Detach`.
-	/// A zero-linger origin cannot tell the two apart, so this sets one.
+	/// This falls out of `routes` being a local whose `AnnouncedRoute` guards drop,
+	/// which is exactly what makes it worth pinning: a refactor that hoisted the map
+	/// to the session (outliving the stream) would leak the announcement instead.
 	#[tokio::test(start_paused = true)]
-	async fn a_lost_announce_stream_leaves_the_linger_window_open() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap())
-			.with_linger(Duration::from_secs(30))
-			.produce();
+	async fn a_lost_announce_stream_closes_the_broadcast() {
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let (tasks, task_set) = TaskSet::new();
 		std::mem::forget(task_set);
@@ -1555,15 +1551,16 @@ mod tests {
 		tokio::time::sleep(Duration::from_millis(1)).await;
 		assert!(consumer.get_broadcast("room/host").is_some());
 
-		// The stream ends without retracting anything: the map dies with it.
+		// The stream ends without retracting anything: the map dies with it and the
+		// broadcast closes.
 		drop(routes);
 		tokio::time::sleep(Duration::from_millis(1)).await;
 		assert!(
-			consumer.get_broadcast("room/host").is_some(),
-			"an abnormal stream loss closed the broadcast instead of lingering for a reconnect",
+			consumer.get_broadcast("room/host").is_none(),
+			"an abnormal stream loss must close the broadcast",
 		);
 
-		// An explicit retraction still closes it now, linger or not.
+		// An explicit retraction closes it the same way.
 		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
 		let mut routes = HashMap::new();
 		subscriber
@@ -1574,7 +1571,7 @@ mod tests {
 		tokio::time::sleep(Duration::from_millis(1)).await;
 		assert!(
 			consumer.get_broadcast("room/host").is_none(),
-			"an explicit retraction lingered instead of closing",
+			"an explicit retraction must close the broadcast",
 		);
 	}
 }

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -289,8 +289,7 @@ struct BroadcastState {
 	closing: bool,
 
 	// Set only by `Producer::finish()`: the broadcast ended deliberately, as
-	// opposed to aborting or losing its producer. The origin reads this to decide
-	// whether a detached source may linger for a replacement.
+	// opposed to aborting or losing its producer.
 	finished: bool,
 
 	// The error passed to `Producer::abort()`, reported by `Consumer::closed`.
@@ -642,9 +641,8 @@ impl Producer {
 	/// producer clones are still alive, and existing tracks stay readable so
 	/// consumers can drain what they already have (an abort does not cascade into
 	/// the tracks). Unlike a finish, consumers observe `err` from
-	/// [`Consumer::closed`], and an origin treats the source as ungracefully lost,
-	/// so the path may linger for a replacement (see
-	/// [`origin::Info::linger`](crate::origin::Info::linger)).
+	/// [`Consumer::closed`], so the end reads as a failure rather than a
+	/// deliberate one.
 	///
 	/// Consumes the producer: an abort is terminal. Errors if the broadcast was
 	/// already finished or aborted.
@@ -714,8 +712,8 @@ impl Producer {
 /// A session-owned handle to a source broadcast created via
 /// [`crate::origin::Producer::create_broadcast`]: [`Self::finish`] ends it
 /// deliberately, while dropping the guard aborts it as [`Error::Dropped`] (a dead
-/// session), letting the origin linger the path for a reconnect. Shared by the
-/// lite and IETF subscribers so the drop-vs-finish contract lives in one place.
+/// session), so consumers observe the loss as an error. Shared by the lite and
+/// IETF subscribers so the drop-vs-finish contract lives in one place.
 pub(crate) struct SourceGuard {
 	// `Option` so `finish` can consume the producer while `Drop` aborts it.
 	producer: Option<Producer>,
@@ -1187,9 +1185,7 @@ impl Consumer {
 	}
 
 	/// Whether the broadcast ended via a deliberate [`Producer::finish`], as opposed
-	/// to aborting or losing its producer. `false` while the broadcast is still live;
-	/// an origin uses this to close a front immediately on a deliberate end instead
-	/// of lingering for a replacement.
+	/// to aborting or losing its producer. `false` while the broadcast is still live.
 	pub fn is_finished(&self) -> bool {
 		self.state.read().finished
 	}

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -127,16 +127,6 @@ pub struct Info {
 	/// edge. Defaults to [`track::DEFAULT_LATENCY_MAX`], and [`Self::cache_duration`]
 	/// still caps it.
 	pub latency_default: Duration,
-
-	/// How long a broadcast under this origin outlives the *ungraceful* loss of its
-	/// last source before closing. Within the window the path stays announced and a
-	/// source re-attaching at it (a session reconnecting, a publisher re-announcing)
-	/// splices in seamlessly, so consumers never observe the gap. A source that ends
-	/// deliberately ([`broadcast::Producer::finish`], a clean unannounce from a peer)
-	/// closes the broadcast immediately regardless. Zero (the default) closes
-	/// immediately either way; a duration too large to represent as a deadline
-	/// (e.g. [`Duration::MAX`]) lingers indefinitely.
-	pub linger: Duration,
 }
 
 impl Default for Info {
@@ -148,7 +138,6 @@ impl Default for Info {
 			pool: cache::Pool::default(),
 			cache_duration: Duration::MAX,
 			latency_default: track::DEFAULT_LATENCY_MAX,
-			linger: Duration::ZERO,
 		}
 	}
 }
@@ -176,13 +165,6 @@ impl Info {
 	/// publisher advertises none, returning `self` for chaining.
 	pub fn with_latency_default(mut self, latency_default: Duration) -> Self {
 		self.latency_default = latency_default;
-		self
-	}
-
-	/// Set how long a broadcast survives ungracefully losing its last source (see
-	/// [`Self::linger`]), returning `self` for chaining.
-	pub fn with_linger(mut self, linger: Duration) -> Self {
-		self.linger = linger;
 		self
 	}
 
@@ -956,10 +938,6 @@ pub struct Producer {
 	// [`Info::latency_default`]).
 	latency_default: Duration,
 
-	// How long a broadcast outlives ungracefully losing its last source (see
-	// [`Info::linger`]). Zero by default.
-	linger: Duration,
-
 	// Ingress stats context. Broadcasts created through this producer are attributed
 	// to it (writes counted on the subscriber/ingress side). Empty (no-op) unless a
 	// session tagged this handle via [`Self::with_stats`].
@@ -987,7 +965,6 @@ impl Producer {
 			pool: info.pool,
 			cache_duration: info.cache_duration,
 			latency_default: info.latency_default,
-			linger: info.linger,
 			stats: stats::Session::default(),
 		}
 	}
@@ -1000,19 +977,6 @@ impl Producer {
 		self
 	}
 
-	/// Set the linger (see [`Info::linger`]) for broadcasts created through this
-	/// handle and any handle derived from it.
-	///
-	/// A broadcast adopts the window of the handle whose source *created* it (the
-	/// first source at the path), so set this before handing the producer to
-	/// whatever attaches sources through it (e.g. a session). Lets one supplier
-	/// declare its own recovery promise, like a reconnecting client lingering for
-	/// as long as its retry loop keeps trying, without reconfiguring the origin.
-	pub fn with_linger(mut self, linger: Duration) -> Self {
-		self.linger = linger;
-		self
-	}
-
 	/// This origin's [`Info`] (identity + cache pool), the parent handle a broadcast
 	/// created under this origin carries (see [`broadcast::Info::origin`]).
 	pub fn info(&self) -> Info {
@@ -1021,7 +985,6 @@ impl Producer {
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
 			latency_default: self.latency_default,
-			linger: self.linger,
 		}
 	}
 
@@ -1044,7 +1007,6 @@ impl Producer {
 			pool: cache::Pool::default(),
 			cache_duration: Duration::MAX,
 			latency_default: track::DEFAULT_LATENCY_MAX,
-			linger: Duration::ZERO,
 			stats: stats::Session::default(),
 		}
 	}
@@ -1085,11 +1047,10 @@ impl Producer {
 	/// consumer finds them.
 	///
 	/// End the broadcast with [`broadcast::Producer::finish`]; dropping it
-	/// without finishing also works, but logs a warning. A finish closes and
-	/// unannounces the path immediately once it was the last source. An unfinished
-	/// drop is treated as an outage: the path survives for the origin's
-	/// [`Info::linger`] (zero by default), so a replacement source attaching within
-	/// that window splices in without consumers noticing.
+	/// without finishing also works, but logs a warning. Either way the path
+	/// closes and unannounces immediately once it was the last source; an
+	/// unfinished drop additionally aborts the spliced tracks with an error, so
+	/// consumers observe a failure rather than a clean end.
 	///
 	/// Fails with [`Error::Unauthorized`] if `path` is outside the prefixes this
 	/// producer may publish under (after [`scope`](Self::scope) /
@@ -1150,7 +1111,6 @@ impl Producer {
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
 			latency_default: self.latency_default,
-			linger: self.linger,
 			stats: self.stats.clone(),
 		})
 	}
@@ -1207,7 +1167,6 @@ impl Producer {
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
 			latency_default: self.latency_default,
-			linger: self.linger,
 			stats: self.stats.clone(),
 		})
 	}
@@ -1286,13 +1245,9 @@ struct FrontState {
 	excluded: HashMap<Origin, usize>,
 	/// The source tracks are dispatched to. Backups park until promoted.
 	active: Option<u64>,
-	/// How long the front outlives ungracefully losing its last source (see
-	/// [`Info::linger`]). [`run_front`] arms the countdown when the table empties.
-	linger: Duration,
 	/// Terminal: no more sources may attach and every poller stops. Set
 	/// synchronously by the detach that empties the table or by an
-	/// [`attach_source`] takeover, and by [`run_front`] when the linger window
-	/// expires without a replacement.
+	/// [`attach_source`] takeover.
 	closed: bool,
 }
 
@@ -1480,22 +1435,12 @@ fn sync_front(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer
 /// Detach source `id`, promoting the next-best source; the tracks it was serving
 /// re-splice on their own. Idempotent.
 ///
-/// `graceful` says how the source ended: a deliberate finish (a publisher done
-/// publishing, a peer's clean unannounce) or an abrupt loss (a session dying).
-/// Detaching the last source *gracefully* closes the broadcast synchronously,
-/// which guarantees a following create at the path is a *new* broadcast rather
-/// than splicing new content into this one. An abrupt last detach instead leaves
-/// the front open for the configured linger ([`Info::linger`]), so a source
-/// re-attaching within the window (a reconnect) splices in seamlessly;
-/// [`run_front`] closes it if the window expires empty. A zero linger closes
-/// abrupt detaches synchronously too.
-fn detach_source(
-	state: &kio::Producer<FrontState>,
-	broadcast: &broadcast::Producer,
-	leaf: &Lock<OriginNode>,
-	id: u64,
-	graceful: bool,
-) {
+/// Detaching the last source closes the broadcast synchronously, however the
+/// source ended, which guarantees a following create at the path is a *new*
+/// broadcast rather than splicing new content into this one. Failover is a
+/// property of sources that overlap in the table (a GOAWAY migration, a
+/// redundant publisher), never of a source that might come back later.
+fn detach_source(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer, leaf: &Lock<OriginNode>, id: u64) {
 	let close = {
 		// Snapshotted before the state lock (lock order: broadcast, then front).
 		// A demand flip in between only stales this reselect's handover gate,
@@ -1507,7 +1452,7 @@ fn detach_source(
 		};
 		s.routes.remove(pos);
 		s.reselect(carrying);
-		if s.routes.is_empty() && !s.closed && (graceful || s.linger.is_zero()) {
+		if s.routes.is_empty() && !s.closed {
 			// Last one out: close now. The front task observes `closed` and
 			// finishes the teardown (unpublish).
 			s.closed = true;
@@ -1624,8 +1569,7 @@ async fn run_source(
 				Ok(update) => {
 					let announced = update.announce;
 					// A different first hop is new content: this source can no
-					// longer feed the front it attached to. Detach deliberately
-					// (a linger would only stall the replacement) and re-attach.
+					// longer feed the front it attached to. Detach and re-attach.
 					//
 					// Plain equality, not `same_publisher`: within one source
 					// handle the session layer already guarantees continuity (it
@@ -1634,7 +1578,7 @@ async fn run_source(
 					// handle to a new publisher. An UNKNOWN-to-UNKNOWN metadata
 					// update (a legacy peer repricing) must not detach.
 					if update.hops.iter().next().copied() != publisher {
-						detach_source(&state, &broadcast, &leaf, id, true);
+						detach_source(&state, &broadcast, &leaf, id);
 						sync_announce(&mut announce, announced, &ingress);
 						route = update;
 						continue 'attach;
@@ -1656,9 +1600,9 @@ async fn run_source(
 					sync_front(&state, &broadcast, &leaf);
 				}
 				Err(_) => {
-					// A deliberate finish closes the front immediately; an abrupt loss
-					// (dropped producer, dead session) may linger for a replacement.
-					detach_source(&state, &broadcast, &leaf, id, source.is_finished());
+					// The source ended, deliberately or not: detach it. If it was the
+					// last one the front closes with it.
+					detach_source(&state, &broadcast, &leaf, id);
 					return;
 				}
 			}
@@ -1793,7 +1737,6 @@ fn attach_source(
 			source: source.clone(),
 		}],
 		active: Some(0),
-		linger: ctx.origin.linger,
 		closed: false,
 	});
 
@@ -1840,54 +1783,21 @@ async fn run_front(
 ) {
 	enum Step {
 		Serve(Arc<str>, super::resume::Producer),
-		/// The source table emptied or refilled: re-arm the linger countdown.
-		Changed,
-		/// The linger window expired: close if the table is still empty.
-		Expired,
 		Closed,
 	}
 
-	let linger = state.read().linger;
-	// Armed while the table is ungracefully empty: the instant the front gives up
-	// waiting for a replacement source. A graceful close never gets here (the
-	// detach sets `closed` synchronously), so a running countdown always means a
-	// reconnect is welcome.
-	let mut deadline = kio::time::Deadline::new();
-
 	loop {
-		let empty = {
-			let s = state.read();
-			!s.closed && s.routes.is_empty()
-		};
-		deadline.set(match (empty, deadline.deadline()) {
-			// An unrepresentable deadline (e.g. `Duration::MAX`) lingers forever:
-			// no timer, only a re-attach or teardown moves the front on.
-			(true, None) => web_async::time::Instant::now().checked_add(linger),
-			(true, at) => at,
-			(false, _) => None,
-		});
-
 		let step = {
 			kio::wait(|waiter| {
 				if let Poll::Ready((name, resume)) = broadcast.poll_spliced_assigned(waiter) {
 					return Poll::Ready(Step::Serve(name, resume));
 				}
-				// Watch for the close, and for the table changing shape so the
-				// countdown re-arms (a detach emptying it, a reconnect refilling it).
-				match state.poll(waiter, |s| {
-					if s.closed || s.routes.is_empty() != empty {
-						Poll::Ready(())
-					} else {
-						Poll::Pending
-					}
-				}) {
-					Poll::Ready(Ok(guard)) => {
-						return Poll::Ready(if guard.closed { Step::Closed } else { Step::Changed });
-					}
-					Poll::Ready(Err(_)) => return Poll::Ready(Step::Closed),
-					Poll::Pending => {}
+				// The close is set synchronously by the detach that empties the
+				// table or by a takeover; this task only finishes the teardown.
+				match state.poll(waiter, |s| if s.closed { Poll::Ready(()) } else { Poll::Pending }) {
+					Poll::Ready(_) => Poll::Ready(Step::Closed),
+					Poll::Pending => Poll::Pending,
 				}
-				deadline.poll(waiter).map(|_| Step::Expired)
 			})
 			.await
 		};
@@ -1897,24 +1807,6 @@ async fn run_front(
 				// Serve tasks self-terminate when the track completes or the
 				// front closes.
 				web_async::spawn(serve_track(state.clone(), name, resume));
-			}
-			Step::Changed => {}
-			Step::Expired => {
-				// Close only if the table is still empty: a source that re-attached
-				// as the window expired wins the write-lock race and keeps the
-				// broadcast alive.
-				let close = {
-					let Ok(mut s) = state.write() else { break };
-					if !s.closed && s.routes.is_empty() {
-						s.closed = true;
-						true
-					} else {
-						false
-					}
-				};
-				if close {
-					break;
-				}
 			}
 			Step::Closed => break,
 		}
@@ -1951,8 +1843,7 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		Failed(Error),
 		/// The route we were serving from left the table with nothing servable to
 		/// replace it: drop our handle; the verdict block at the top of the loop
-		/// decides between aborting (all refused) and parking (corpses detaching,
-		/// or an empty table awaiting a reconnect).
+		/// decides between aborting (all refused) and parking (corpses detaching).
 		NoRoute,
 		/// The linger expired with the track still unread: release the segment.
 		Idle,
@@ -1975,9 +1866,9 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 	let mut refused: HashSet<u64> = HashSet::new();
 	let mut refusal: Option<Error> = None;
 	// Sources whose splice failed because they had already closed. Their watchers
-	// are about to detach them, so wait for the table to move on rather than
-	// treating a corpse's error as a refusal (ids are never reused, so this
-	// cannot wedge).
+	// are about to detach them (closing the front if nothing else remains), so
+	// wait for the table to move on rather than treating a corpse's error as a
+	// refusal (ids are never reused, so this cannot wedge).
 	let mut dead: HashSet<u64> = HashSet::new();
 	// When the spliced segment stopped being read, starting the release countdown.
 	let mut idle_since: Option<web_async::time::Instant> = None;
@@ -2009,16 +1900,15 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		}
 
 		// Demand gates both directions: an unread track never splices a source in,
-		// and a spliced one is released once the linger expires. Both sides use the
-		// same signal, so a release can't immediately re-splice and spin.
+		// and a spliced one is released once the idle window expires. Both sides use
+		// the same signal, so a release can't immediately re-splice and spin.
 		//
 		// The countdown keys off the segment, not our handle on the route that
 		// produced it: a route that leaves (or a copy that dies) drops the handle
 		// while the segment stays spliced, and that segment is exactly what the
 		// release exists to reclaim. Keying off the handle strands it until the front
-		// closes, which pins the departed source's cached groups for a linger that
-		// may never expire and leaves a dead segment's edge behind for the next
-		// takeover to splice above.
+		// closes, pinning the departed source's cached groups and leaving a dead
+		// segment's edge behind for the next takeover to splice above.
 		let used = resume.is_used();
 		idle_since = match (resume.is_spliced(), used) {
 			(true, false) => idle_since.or_else(|| Some(web_async::time::Instant::now())),
@@ -3167,7 +3057,6 @@ mod tests {
 				})
 				.collect(),
 			active: Some(0),
-			linger: Duration::ZERO,
 			closed: false,
 		}
 	}
@@ -4098,8 +3987,8 @@ mod tests {
 		sub.assert_not_closed();
 	}
 
-	/// A graceful detach (deliberate unannounce) closes immediately: no linger, so
-	/// the unannounce propagates promptly and a re-create is a fresh broadcast.
+	/// A graceful detach (deliberate unannounce) closes immediately: the
+	/// unannounce propagates promptly and a re-create is a fresh broadcast.
 	#[tokio::test(start_paused = true)]
 	async fn test_route_unannounce_immediate() {
 		let origin = Origin::random().produce();
@@ -4131,10 +4020,11 @@ mod tests {
 		);
 	}
 
-	/// With the default zero linger, a dying source (a session drop, not a
-	/// deliberate unannounce) closes the broadcast just as promptly as a graceful
-	/// one: no reconnect window, the tracks abort, and a re-create is a fresh
-	/// broadcast rather than a splice.
+	/// A dying source (a session drop, not a deliberate unannounce) closes the
+	/// broadcast just as promptly as a graceful one: no reconnect window, the
+	/// tracks abort, and a re-create is a fresh broadcast rather than a splice.
+	/// The application decides how to react to the loss; the origin never hides
+	/// it behind a stale route.
 	#[tokio::test(start_paused = true)]
 	async fn test_route_detach_immediate() {
 		let origin = Origin::random().produce();
@@ -4291,318 +4181,6 @@ mod tests {
 		producer.append_group().unwrap().finish().unwrap();
 		settle().await;
 		fetching.await.expect("fetch after the linger");
-	}
-
-	/// With a linger configured, an ungraceful source loss keeps the broadcast
-	/// alive and announced; a source re-attaching within the window splices in and
-	/// consumers resume at the group boundary, never observing the outage.
-	#[tokio::test(start_paused = true)]
-	async fn test_linger_reconnect_splices() {
-		let origin = Info::new(Origin::random())
-			.with_linger(Duration::from_secs(5))
-			.produce();
-		let consumer = origin.consume();
-		let mut announced = consumer.announced();
-
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let source = origin
-			.create_broadcast("test", announce().with_hops(hops.clone()))
-			.unwrap();
-		let mut dynamic = source.dynamic();
-		settle().await;
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-		announced.assert_next_some("test");
-
-		let subscribing = broadcast.track("video").unwrap().subscribe(None);
-		let mut producer = accept_track(&mut dynamic, "video").await;
-		settle().await;
-		let mut sub = subscribing.await.unwrap();
-
-		producer.append_group().unwrap();
-		producer.append_group().unwrap();
-		assert_eq!(sub.assert_group().sequence, 0);
-		assert_eq!(sub.assert_group().sequence, 1);
-
-		// The session dies without unannouncing: the broadcast enters the linger
-		// window instead of closing.
-		drop(producer);
-		source.abort(Error::Dropped).unwrap();
-		drop(dynamic);
-		settle().await;
-
-		// No unannounce, no track error: the outage is invisible so far.
-		announced.assert_next_wait();
-		sub.assert_no_group();
-		sub.assert_not_closed();
-
-		// A consumer arriving mid-outage still resolves the lingering broadcast.
-		let during = consumer.request_broadcast("test").await.unwrap();
-		assert!(during.is_clone(&broadcast), "the lingering broadcast still resolves");
-
-		// The session reconnects within the window: the new source splices into
-		// the same broadcast.
-		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		let mut dynamic = source.dynamic();
-		settle().await;
-		settle().await;
-		announced.assert_next_wait();
-		let again = consumer.request_broadcast("test").await.unwrap();
-		assert!(again.is_clone(&broadcast), "the reconnect must splice, not replace");
-
-		// The pending track re-splices from the new source and resumes one past
-		// the groups the old source already delivered. Demand registers as the
-		// subscriber polls.
-		let mut producer = accept_track(&mut dynamic, "video").await;
-		settle().await;
-		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().start, Some(Position::group(2)));
-		producer.create_group(group::Info { sequence: 2 }).unwrap();
-		assert_eq!(sub.assert_group().sequence, 2);
-		sub.assert_not_closed();
-	}
-
-	/// The linger window expiring without a replacement closes the broadcast: the
-	/// path unannounces, tracks abort, and a later re-create is a fresh broadcast.
-	#[tokio::test(start_paused = true)]
-	async fn test_linger_expiry_closes() {
-		let origin = Info::new(Origin::random())
-			.with_linger(Duration::from_secs(5))
-			.produce();
-		let consumer = origin.consume();
-		let mut announced = consumer.announced();
-
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let source = origin
-			.create_broadcast("test", announce().with_hops(hops.clone()))
-			.unwrap();
-		let mut dynamic = source.dynamic();
-		settle().await;
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-		announced.assert_next_some("test");
-
-		let subscribing = broadcast.track("video").unwrap().subscribe(None);
-		let producer = accept_track(&mut dynamic, "video").await;
-		settle().await;
-		let mut sub = subscribing.await.unwrap();
-
-		drop(producer);
-		source.abort(Error::Dropped).unwrap();
-		drop(dynamic);
-		settle().await;
-		announced.assert_next_wait();
-
-		// Nobody comes back: the window expires and the broadcast closes.
-		tokio::time::sleep(std::time::Duration::from_secs(6)).await;
-		settle().await;
-		announced.assert_next_none("test");
-		sub.assert_error();
-
-		// A session reconnecting after the window gets a brand-new broadcast.
-		let _source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		settle().await;
-		settle().await;
-		let fresh = consumer.request_broadcast("test").await.unwrap();
-		announced.assert_next_some("test");
-		assert!(
-			!fresh.is_clone(&broadcast),
-			"a late re-create must not splice the expired broadcast"
-		);
-	}
-
-	/// A linger too large to represent as a deadline never expires: the broadcast
-	/// outlives an arbitrarily long outage (a reconnect loop with no give-up
-	/// timeout promises to retry forever).
-	#[tokio::test(start_paused = true)]
-	async fn test_linger_forever() {
-		let origin = Info::new(Origin::random()).with_linger(Duration::MAX).produce();
-		let consumer = origin.consume();
-		let mut announced = consumer.announced();
-
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let source = origin
-			.create_broadcast("test", announce().with_hops(hops.clone()))
-			.unwrap();
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-		announced.assert_next_some("test");
-
-		source.abort(Error::Dropped).unwrap();
-		settle().await;
-
-		// Days later the broadcast is still announced and still splices a reconnect.
-		tokio::time::sleep(std::time::Duration::from_secs(60 * 60 * 24 * 3)).await;
-		announced.assert_next_wait();
-		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		settle().await;
-		settle().await;
-		let again = consumer.request_broadcast("test").await.unwrap();
-		assert!(again.is_clone(&broadcast), "the reconnect must splice, not replace");
-		drop(source);
-	}
-
-	/// A lingering broadcast with a live subscription parks, then resumes on the
-	/// reconnect.
-	///
-	/// An ungraceful loss empties the route table while the front waits out its
-	/// linger, so the route a track is spliced from is gone with no replacement to
-	/// serve it. The task has to park for the whole window on the strength of
-	/// dropping the departed route, because nothing else bounds it: a "route gone"
-	/// edge that keeps firing yields a wait that is Ready on every poll, a full
-	/// core per subscribed track, and the runtime that has to deliver the
-	/// reconnect starved along with it.
-	///
-	/// Under a paused clock that spin never yields, so a regression hangs here
-	/// rather than failing.
-	#[tokio::test(start_paused = true)]
-	async fn test_linger_parks_a_live_subscription() {
-		let origin = Info::new(Origin::random())
-			.with_linger(Duration::from_secs(5))
-			.produce();
-		let consumer = origin.consume();
-
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let source = origin
-			.create_broadcast("test", announce().with_hops(hops.clone()))
-			.unwrap();
-		let mut dynamic = source.dynamic();
-		settle().await;
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-
-		// A viewer reading a track that is written once and then stays quiet, like a
-		// catalog.
-		let subscribing = broadcast.track("catalog.json").unwrap().subscribe(None);
-		let mut producer = accept_track(&mut dynamic, "catalog.json").await;
-		settle().await;
-		let mut sub = subscribing.await.unwrap();
-		producer.append_group().unwrap();
-		assert_eq!(sub.assert_group().sequence, 0);
-
-		// The publisher's session dies abruptly: the table empties and the front
-		// lingers, holding the subscription open for a reconnect. The track copy
-		// outlives the broadcast (closes don't cascade), so nothing reports the
-		// spliced segment as ended: the departed route is the only edge left.
-		source.abort(Error::Dropped).unwrap();
-		settle().await;
-		settle().await;
-		sub.assert_not_closed();
-
-		// Most of the window with no source at all: the subscription stays parked
-		// rather than being cut, which is what the linger promises a reconnect.
-		tokio::time::sleep(Duration::from_secs(4)).await;
-		settle().await;
-		sub.assert_not_closed();
-
-		// The reconnect inside the window resumes the same subscription.
-		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		let mut dynamic = source.dynamic();
-		settle().await;
-		let mut producer = accept_track(&mut dynamic, "catalog.json").await;
-		settle().await;
-		producer.create_group(group::Info { sequence: 1 }).unwrap();
-		assert_eq!(sub.assert_group().sequence, 1);
-		sub.assert_not_closed();
-	}
-
-	/// An idle segment is released even once the route that produced it is gone.
-	///
-	/// A departed route drops the loop's handle on it, so the idle countdown has to
-	/// key off the segment itself. Otherwise the segment is stranded for the life of
-	/// the front, pinning the dead source's cached groups.
-	///
-	/// Asserted through the boundary a stranded segment would leave behind, since
-	/// `resume` is private and delivery is what a viewer actually feels: a released
-	/// segment set splices the next source unbounded, so its first group arrives,
-	/// while a retained one caps it below that edge.
-	#[tokio::test(start_paused = true)]
-	async fn test_idle_release_survives_the_route_leaving() {
-		let origin = Info::new(Origin::random())
-			.with_linger(Duration::from_secs(600))
-			.produce();
-		let consumer = origin.consume();
-
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let source = origin
-			.create_broadcast("test", announce().with_hops(hops.clone()))
-			.unwrap();
-		let mut dynamic = source.dynamic();
-		settle().await;
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-
-		let subscribing = broadcast.track("catalog.json").unwrap().subscribe(None);
-		let mut producer = accept_track(&mut dynamic, "catalog.json").await;
-		settle().await;
-		let mut sub = subscribing.await.unwrap();
-		producer.append_group().unwrap();
-		assert_eq!(sub.assert_group().sequence, 0);
-
-		// The publisher's session dies, then the viewer gives up: nothing holds the
-		// segment, and nothing is left to serve the track.
-		source.abort(Error::Dropped).unwrap();
-		settle().await;
-		settle().await;
-		drop(sub);
-		drop(producer);
-		drop(dynamic);
-		settle().await;
-		tokio::time::sleep(TRACK_IDLE_LINGER + Duration::from_secs(1)).await;
-		settle().await;
-
-		// The publisher reconnects under the same identity, so it joins the front as
-		// a route rather than replacing it, and restarts its group numbering.
-		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		let mut dynamic = source.dynamic();
-		settle().await;
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-		let subscribing = broadcast.track("catalog.json").unwrap().subscribe(None);
-		let mut producer = accept_track(&mut dynamic, "catalog.json").await;
-		settle().await;
-		let mut sub = subscribing.await.unwrap();
-		producer.append_group().unwrap();
-		assert_eq!(
-			sub.assert_group().sequence,
-			0,
-			"the reconnect's first group must not be filtered by a stale boundary"
-		);
-	}
-
-	/// A deliberate finish never lingers, even with a linger configured: a clean
-	/// unannounce from a peer must propagate immediately.
-	#[tokio::test(start_paused = true)]
-	async fn test_linger_skipped_on_finish() {
-		let origin = Info::new(Origin::random())
-			.with_linger(Duration::from_secs(5))
-			.produce();
-		let consumer = origin.consume();
-		let mut announced = consumer.announced();
-
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let mut source = origin
-			.create_broadcast("test", announce().with_hops(hops.clone()))
-			.unwrap();
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-		announced.assert_next_some("test");
-
-		// A clean unannounce: the broadcast is gone as soon as the teardown task
-		// observes the close, with no reconnect window.
-		source.finish();
-		settle().await;
-		announced.assert_next_none("test");
-
-		// A re-create at the same path is a brand-new broadcast.
-		let _source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		settle().await;
-		let fresh = consumer.request_broadcast("test").await.unwrap();
-		announced.assert_next_some("test");
-		assert!(
-			!fresh.is_clone(&broadcast),
-			"a finish must not leave a lingering broadcast to splice into"
-		);
 	}
 
 	/// A non-live broadcast is reachable by exact path but never announced;

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -21,12 +21,6 @@ use crate::{AuthToken, nodes::MESH_PREFIX};
 /// How often the discovery loop scans for stale entries.
 const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
-/// Default for [`ClusterConfig::linger`]: how long a broadcast survives abruptly
-/// losing its last publisher before unannouncing. Long enough for a publisher
-/// restart or a brief network blip to resume seamlessly, short enough that a
-/// genuinely-gone broadcast unannounces promptly.
-const DEFAULT_LINGER: Duration = Duration::from_secs(5);
-
 /// How long a peer must stay unannounced before we abort the dial. Must clear the
 /// "prefer shorter hop" re-announce flap (which arrives as
 /// unannounce-then-announce within sub-milliseconds) plus reasonable churn from
@@ -333,17 +327,15 @@ pub struct ClusterConfig {
 	/// stats under. Defaults to the unprefixed tier.
 	#[arg(id = "cluster-tier", long = "cluster-tier", env = "MOQ_CLUSTER_TIER")]
 	pub tier: Option<String>,
-	/// How long a broadcast stays alive and announced after abruptly losing its
-	/// last publisher (a session dying without unannouncing), e.g. "5s" or "500ms".
-	/// A publisher reconnecting within the window resumes the same broadcast and
-	/// subscribers never notice; the window expiring unannounces it. A clean
-	/// unannounce always takes effect immediately. Set "0" to unannounce abrupt
-	/// losses immediately too. Defaults to 5s.
+	// Accepted so existing configs keep parsing (`deny_unknown_fields`), but
+	// ignored: a broadcast now closes as soon as its last publisher is lost.
+	#[doc(hidden)]
 	#[arg(
 		id = "cluster-linger",
 		long = "cluster-linger",
 		env = "MOQ_CLUSTER_LINGER",
 		value_parser = humantime::parse_duration,
+		hide = true,
 	)]
 	#[serde(default, with = "humantime_serde")]
 	pub linger: Option<Duration>,
@@ -370,8 +362,8 @@ pub struct Cluster {
 	/// view always points at the same session in the logs.
 	connection_ids: Arc<AtomicU64>,
 
-	/// The origin's construction config (identity, cache pool, linger). Kept so
-	/// the `with_*` builders can rebuild the origin without losing each other's
+	/// The origin's construction config (identity, cache pool). Kept so the
+	/// `with_*` builders can rebuild the origin without losing each other's
 	/// settings.
 	info: origin::Info,
 
@@ -417,7 +409,12 @@ impl Cluster {
 			Some(id) => Origin::new(id).expect("cluster id already validated"),
 			None => Origin::random(),
 		};
-		let info = origin::Info::new(id).with_linger(config.linger.unwrap_or(DEFAULT_LINGER));
+		if config.linger.is_some() {
+			tracing::warn!(
+				"cluster linger is deprecated and ignored; a broadcast closes as soon as its last publisher is lost"
+			);
+		}
+		let info = origin::Info::new(id);
 		let origin = info.clone().produce();
 		let nodes = crate::nodes::Nodes::new(origin.clone());
 		tracing::info!(origin_id = %origin.id(), configured = config.id.is_some(), "cluster initialized");

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -330,6 +330,7 @@ pub struct ClusterConfig {
 	// Accepted so existing configs keep parsing (`deny_unknown_fields`), but
 	// ignored: a broadcast now closes as soon as its last publisher is lost.
 	#[doc(hidden)]
+	#[deprecated(note = "ignored; a broadcast closes as soon as its last publisher is lost")]
 	#[arg(
 		id = "cluster-linger",
 		long = "cluster-linger",
@@ -409,6 +410,7 @@ impl Cluster {
 			Some(id) => Origin::new(id).expect("cluster id already validated"),
 			None => Origin::random(),
 		};
+		#[allow(deprecated)]
 		if config.linger.is_some() {
 			tracing::warn!(
 				"cluster linger is deprecated and ignored; a broadcast closes as soon as its last publisher is lost"

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -248,8 +248,10 @@ latency_default = \"20s\"",
 
 	/// Regression test for the clap+TOML clobber bug applied to `cluster.linger`.
 	/// The field is `Option<Duration>` so a TOML-configured window survives the
-	/// CLI re-parse when no `--cluster-linger` flag is passed.
+	/// CLI re-parse when no `--cluster-linger` flag is passed (deprecated and
+	/// ignored, but it must keep parsing so existing configs boot).
 	#[test]
+	#[allow(deprecated)]
 	fn cli_does_not_clobber_toml_linger() {
 		let _env = EnvGuard::clear(&["MOQ_CLUSTER_LINGER"]);
 

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -62,7 +62,7 @@ struct AcceptedSession {
 	cancel: Option<oneshot::Receiver<()>>,
 	role: &'static str,
 	// WHIP only: a clone of the ingest broadcast, so a deliberate DELETE can
-	// finish() it (prompt unannounce) instead of lingering for a reconnect.
+	// finish() it: a clean end instead of an abort error.
 	broadcast: Option<moq_net::broadcast::Producer>,
 }
 

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -30,8 +30,8 @@ public final class OriginProducer: Sendable {
     /// The broadcast starts live: the origin announces the path so subscribers can
     /// discover it, becoming visible shortly after this returns. Toggle
     /// discoverability with `BroadcastProducer.setAnnounce(_:)`; `finish()` unpublishes
-    /// immediately, while releasing the producer without finishing lingers briefly
-    /// so a replacement publisher can take over.
+    /// immediately, while releasing the producer without finishing also unpublishes
+    /// but reads to subscribers as a failure rather than a deliberate end.
     public func createBroadcast(path: String) throws -> BroadcastProducer {
         BroadcastProducer(try ffi.createBroadcast(path: path))
     }


### PR DESCRIPTION
Fixes #2695.

## Root cause

The linger (#2469) kept a broadcast announced after the *ungraceful* loss of its last source, on the theory that a reconnect would splice in before anyone noticed. But the window was a fixed origin timer modeling hope, not evidence: nothing tied it to whether a redial loop even existed, which is exactly how #2695 happened (a permanent local stop left broadcasts announced for the whole backoff window, and *forever* with `timeout = 0`). More fundamentally, a QUIC connection dies for a reason (keep-alive timeout, CONNECTION_CLOSE), and hiding that from the application means it reads a stale route instead of reacting to a real outage.

Rather than tying the timer to the reconnect loop's lifetime, this removes the linger entirely. Failover is now strictly a property of sources that overlap in the route table: a GOAWAY migration (old session keeps serving while the replacement dials), redundant publishers, CDN + P2P, cluster siblings. Those paths are untouched (`cluster_diamond_goaway_seamless_failover` still passes). A source that is gone closes its broadcast immediately, however it ended; the reconnect loop re-announces when a replacement session actually attaches.

Not touched, despite the shared name: the route-cost demand linger in `lite/publisher.rs` / `ietf/publisher.rs`, and `TRACK_IDLE_LINGER` (idle segment release) in `serve_track`.

## Public API changes (breaking, hence `dev`)

- `moq-net`: removed `origin::Info::linger` (pub field), `origin::Info::with_linger`, and `origin::Producer::with_linger`.
- `moq-native`: removed `Backoff::linger()`.
- `moq-relay`: `--cluster-linger` / `cluster.linger` / `MOQ_CLUSTER_LINGER` is now hidden and ignored (kept parse-compatible because `ClusterConfig` is `deny_unknown_fields`; setting it logs a deprecation warning).
- The `finish()` vs `abort()`/drop distinction on `broadcast::Producer` is unchanged and still meaningful: consumers observe a clean end vs an error. Only the origin's response to an abrupt loss changed.

## Behavior notes

- `moq-cli transcode` previously used the linger so a mid-run session drop didn't end the run; it now surfaces the drop and exits, matching the fail-fast retry policy (a supervisor restarts it).
- `moq-ffi` inherits the new behavior through `moq-native`; no FFI surface change, so the language wrappers only needed doc updates (py/swift/go; kt docs are generated).

## Cross-package sync

- `drafts/` untouched: the linger was local policy, never on the wire.
- `js/net` untouched: it never had a linger.
- `doc/bin/relay/config.md` updated (linger block removed).

## Test plan

- New regression test `a_dead_session_unannounces_while_the_reconnect_retries` (moq-native): a killed session must unannounce while the retry loop is still running with `timeout = 0`. On the old code this hangs waiting for an unannounce that never comes (infinite linger).
- Reworked the origin/lite/ietf tests that asserted linger behavior into immediate-close assertions; deleted the six origin tests whose scenario (an open front with an empty route table) is now unrepresentable.
- Merged the current `origin/dev` and adapted the regression to its async `test_server()` helper.
- `nix develop --command just fix origin/dev` and `nix develop --command just ci origin/dev` pass on `a9fd4a690`, including 2,953 Rust tests, Python, Kotlin, Swift, Go, rustdoc with `-D warnings`, wasm, Nix flake checks, and workflow lint.

(Written by GPT-5)
