### PR TITLE
fix(just): format only tracked shell scripts

### DIFF
--- a/justfile
+++ b/justfile
@@ -229,7 +229,7 @@ fix-all:
 _fix-common:
     bun install
     bun remark . --quiet --output
-    @if command -v shfmt >/dev/null 2>&1; then shfmt --write $(shfmt -f . | grep -v '\.direnv/'); fi
+    @if command -v shfmt >/dev/null 2>&1; then files=$(git ls-files -z | xargs -0 shfmt -f); shfmt --write $files; fi
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); fi
     @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --justfile "$f"; done


### PR DESCRIPTION
## Summary

- scope the `_fix-common` shell format step to files tracked by Git
- use the same `git ls-files -z` and `shfmt -f` pipeline as `_check-common`

## Root cause

`_fix-common` discovered shell scripts by scanning the entire worktree with `shfmt -f .`. Populated dependency directories such as `cpp/obs/.deps` therefore supplied ignored vendored scripts to `shfmt --write`, and syntax unsupported by the repository's formatter caused `just fix` to fail before it reached tracked project files.

## Testing

- reproduced the old failure with an ignored invalid shell script under `cpp/obs/.deps`
- verified the tracked-file pipeline excludes the same script
- `nix develop --command just fix origin/main`
- `nix develop --command just check origin/main`

(Written by GPT-5)