### PR TITLE
fix(just): format only tracked shell scripts

### DIFF
--- a/justfile
+++ b/justfile
@@ -115,12 +115,51 @@ check-all *args:
 # `bun install` because remark-cli lives in node_modules and `just js check` is
 # where it would otherwise be installed, which a Rust-only diff skips.
 
+# Run shell checks or formatting over tracked files that exist in the worktree.
+[private]
+_shell $ACTION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v shfmt >/dev/null 2>&1; then
+        exit 0
+    fi
+    if [[ "$ACTION" == "check" ]] && ! command -v shellcheck >/dev/null 2>&1; then
+        exit 0
+    fi
+
+    scripts_file=$(mktemp)
+    trap 'rm -f "$scripts_file"' EXIT
+    shfmt -f=0 . > "$scripts_file"
+
+    scripts=()
+    while IFS= read -r -d '' file; do
+        if git --literal-pathspecs ls-files --error-unmatch -- "$file" >/dev/null 2>&1; then
+            scripts+=("$file")
+        fi
+    done < "$scripts_file"
+    ((${#scripts[@]})) || exit 0
+
+    case "$ACTION" in
+        check)
+            shfmt --diff "${scripts[@]}"
+            shellcheck "${scripts[@]}"
+            ;;
+        fix)
+            shfmt --write "${scripts[@]}"
+            ;;
+        *)
+            echo "invalid shell action: $ACTION" >&2
+            exit 2
+            ;;
+    esac
+
 # Repository-wide lints, shared by `check` and `check-all`.
 [private]
 _check-common:
     bun install --frozen-lockfile
     bun remark . --quiet --frail
-    @if command -v shellcheck >/dev/null 2>&1 && command -v shfmt >/dev/null 2>&1; then files=$(git ls-files -z | xargs -0 shfmt -f); shfmt --diff $files && shellcheck $files; fi
+    just _shell check
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format --check; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt --check $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); fi
     @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --check --justfile "$f"; done
@@ -229,8 +268,7 @@ fix-all:
 _fix-common:
     bun install
     bun remark . --quiet --output
-    # Ignored dependency trees can contain shell syntax unsupported by our formatter.
-    @if command -v shfmt >/dev/null 2>&1; then files=$(git ls-files -z | xargs -0 shfmt -f); shfmt --write $files; fi
+    just _shell fix
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); fi
     @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --justfile "$f"; done

--- a/justfile
+++ b/justfile
@@ -229,6 +229,7 @@ fix-all:
 _fix-common:
     bun install
     bun remark . --quiet --output
+    # Ignored dependency trees can contain shell syntax unsupported by our formatter.
     @if command -v shfmt >/dev/null 2>&1; then files=$(git ls-files -z | xargs -0 shfmt -f); shfmt --write $files; fi
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); fi

--- a/justfile
+++ b/justfile
@@ -229,7 +229,7 @@ fix-all:
 _fix-common:
     bun install
     bun remark . --quiet --output
-    @if command -v shfmt >/dev/null 2>&1; then shfmt --write $(shfmt -f . | grep -v '\.direnv/'); fi
+    @if command -v shfmt >/dev/null 2>&1; then files=$(git ls-files -z | xargs -0 shfmt -f); shfmt --write $files; fi
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); fi
     @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --justfile "$f"; done


### PR DESCRIPTION
## Summary

- share tracked shell-file selection between `just check` and `just fix`
- preserve spaces, newlines, and glob characters with NUL-delimited discovery and Bash arrays
- exclude ignored scripts, unstaged deletions, and empty shell-file sets

## Root cause

`_fix-common` discovered shell scripts by scanning the entire worktree with `shfmt -f .`. Populated dependency directories such as `cpp/obs/.deps` therefore supplied ignored vendored scripts to `shfmt --write`, and syntax unsupported by the repository's formatter caused `just fix` to fail before it reached tracked project files.

The initial tracked-file pipeline also converted paths back to newline-delimited, unquoted shell words and included tracked files missing from the worktree. A shared private recipe now discovers shell files with NUL delimiters, retains only exact tracked paths that exist, and passes them to `shfmt` and `shellcheck` as arrays.

## Testing

- reproduced the old failure with an ignored invalid shell script under `cpp/obs/.deps`
- verified check and fix modes with isolated tracked paths containing spaces, a newline, and glob characters
- verified an ignored invalid script and an unstaged tracked deletion are excluded
- `nix develop --command just fix origin/main`
- `nix develop --command just check origin/main`
- `nix develop --command just ci`

(Written by GPT-5)
