### PR TITLE
fix(just): call the shell lint recipe that exists

### DIFF
--- a/justfile
+++ b/justfile
@@ -222,8 +222,7 @@ ci BASE="":
     # when the diff has no JS-scoped files.
     bun install --frozen-lockfile
     bun remark . --quiet --frail
-    shfmt --diff $(just _shell-files)
-    shellcheck $(just _shell-files)
+    just _shell check
     RUST_LOG=error taplo format --check
     nixfmt --check $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*')
     for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --check --justfile "$f"; done


### PR DESCRIPTION
## Summary

`just ci` currently fails on every PR. #2650 replaced the inline shfmt/shellcheck lines in the `ci` recipe with `just _shell-files`, but that recipe does not exist:

```
error: justfile does not contain recipe `_shell-files`
```

`git log -S"_shell-files:"` finds nothing, so it was never defined here or in the history. #2690 and #2707 landed the tracked-scripts change as `_shell <action>`, which is what `_check-common` and `_fix-common` already call. #2650 was carrying the earlier `_shell-files` naming and it never got reconciled on the way in.

This points `ci` at `_shell check`, matching `_check-common`.

## Why it matters

The step runs after `cargo deny`, the full clippy/doc/nextest pass, and the JS build, so every PR burns a complete CI run before failing on it. Six open PRs are affected (#2693, #2697, #2703, #2704, #2705, #2710).

`_shell` no-ops when shfmt or shellcheck is missing, where the old inline lines would have failed. Both are in the CI dev shell, so the coverage in CI is unchanged; locally this now matches what `just check` already did.

## Test plan

- `nix develop --command just _shell check` — resolves and passes
- `nix develop --command just --fmt --check --justfile justfile` — clean

## Public API changes

None; repository tooling only.

(Written by Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)