### PR TITLE
ci: drop Intel macOS release targets

### DIFF
--- a/.github/homebrew/Formula/moq-cli.rb.tmpl
+++ b/.github/homebrew/Formula/moq-cli.rb.tmpl
@@ -9,10 +9,6 @@ class MoqCli < Formula
       url "https://github.com/moq-dev/moq/releases/download/moq-cli-v#{version}/moq-cli-#{version}-aarch64-apple-darwin.tar.gz"
       sha256 "__SHA256_AARCH64_APPLE_DARWIN__"
     end
-    on_intel do
-      url "https://github.com/moq-dev/moq/releases/download/moq-cli-v#{version}/moq-cli-#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "__SHA256_X86_64_APPLE_DARWIN__"
-    end
   end
 
   on_linux do

--- a/.github/homebrew/Formula/moq-gst.rb.tmpl
+++ b/.github/homebrew/Formula/moq-gst.rb.tmpl
@@ -11,10 +11,6 @@ class MoqGst < Formula
       url "https://github.com/moq-dev/moq/releases/download/moq-gst-v#{version}/moq-gst-#{version}-aarch64-apple-darwin.tar.gz"
       sha256 "__SHA256_AARCH64_APPLE_DARWIN__"
     end
-    on_intel do
-      url "https://github.com/moq-dev/moq/releases/download/moq-gst-v#{version}/moq-gst-#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "__SHA256_X86_64_APPLE_DARWIN__"
-    end
   end
 
   on_linux do

--- a/.github/homebrew/Formula/moq-relay.rb.tmpl
+++ b/.github/homebrew/Formula/moq-relay.rb.tmpl
@@ -9,10 +9,6 @@ class MoqRelay < Formula
       url "https://github.com/moq-dev/moq/releases/download/moq-relay-v#{version}/moq-relay-#{version}-aarch64-apple-darwin.tar.gz"
       sha256 "__SHA256_AARCH64_APPLE_DARWIN__"
     end
-    on_intel do
-      url "https://github.com/moq-dev/moq/releases/download/moq-relay-v#{version}/moq-relay-#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "__SHA256_X86_64_APPLE_DARWIN__"
-    end
   end
 
   on_linux do

--- a/.github/homebrew/Formula/moq-token-cli.rb.tmpl
+++ b/.github/homebrew/Formula/moq-token-cli.rb.tmpl
@@ -9,10 +9,6 @@ class MoqTokenCli < Formula
       url "https://github.com/moq-dev/moq/releases/download/moq-token-cli-v#{version}/moq-token-cli-#{version}-aarch64-apple-darwin.tar.gz"
       sha256 "__SHA256_AARCH64_APPLE_DARWIN__"
     end
-    on_intel do
-      url "https://github.com/moq-dev/moq/releases/download/moq-token-cli-v#{version}/moq-token-cli-#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "__SHA256_X86_64_APPLE_DARWIN__"
-    end
   end
 
   on_linux do

--- a/.github/scripts/render-formula.sh
+++ b/.github/scripts/render-formula.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Render a Homebrew formula template by substituting __VERSION__ and the
-# four __SHA256_<TARGET>__ placeholders.
+# three __SHA256_<TARGET>__ placeholders.
 #
 # Usage:
 #   render-formula.sh \
@@ -12,10 +12,9 @@ set -euo pipefail
 #     --crate <crate-name> \
 #     --output <path/to/crate.rb>
 #
-# The release dir must contain the four tarballs named like
+# The release dir must contain the three tarballs named like
 # <crate>-<version>-<target>.tar.gz for each of:
 #   aarch64-apple-darwin
-#   x86_64-apple-darwin
 #   aarch64-unknown-linux-gnu
 #   x86_64-unknown-linux-gnu
 
@@ -66,7 +65,6 @@ fi
 
 targets=(
     "aarch64-apple-darwin AARCH64_APPLE_DARWIN"
-    "x86_64-apple-darwin X86_64_APPLE_DARWIN"
     "aarch64-unknown-linux-gnu AARCH64_UNKNOWN_LINUX_GNU"
     "x86_64-unknown-linux-gnu X86_64_UNKNOWN_LINUX_GNU"
 )

--- a/.github/workflows/libmoq.yml
+++ b/.github/workflows/libmoq.yml
@@ -23,13 +23,6 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             use_nix: true
-          # Both Apple targets build on the Apple Silicon runner: the
-          # Determinate Nix installer dropped Intel macOS, so x86_64 is
-          # cross-compiled (Apple clang is multi-arch). libmoq.a needs no
-          # execution, so no Rosetta. See rs/libmoq/build.sh.
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            use_nix: true
           - target: aarch64-apple-darwin
             os: macos-latest
             use_nix: true

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -119,12 +119,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both Apple targets build on the Apple Silicon runner. The
-          # Determinate Nix installer dropped Intel macOS, so x86_64 is
-          # cross-compiled (Apple clang is multi-arch) and its smoke test
-          # runs under Rosetta. See rs/scripts/package-binary.sh.
-          - target: x86_64-apple-darwin
-            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -137,13 +131,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-
-      # The cross build links system libs only, but its dyld smoke test must
-      # actually run the x86_64 binary on this arm host. Idempotent no-op when
-      # Rosetta is already present.
-      - name: Install Rosetta (x86_64 smoke test)
-        if: matrix.target == 'x86_64-apple-darwin'
-        run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Parse version
         id: parse

--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -21,13 +21,6 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
-          # Both Apple targets build on the Apple Silicon runner. The
-          # Determinate Nix installer dropped Intel macOS, so x86_64 is
-          # cross-compiled against an x86_64 GStreamer (see nix/overlay.nix);
-          # its gst-inspect smoke test is skipped (an arm gst-inspect can't
-          # load an x86_64 plugin).
-          - target: x86_64-apple-darwin
-            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -62,11 +55,7 @@ jobs:
       # This is the customer-facing scenario: `nix build .#moq-gst` then
       # `gst-inspect-1.0 moq`. If dyld/ld.so can't resolve the plugin's deps
       # against the system GStreamer, this step fails.
-      # Skipped for the x86_64-darwin cross build: the arm runner's
-      # gst-inspect can't load an x86_64 plugin. Native builds (incl. the
-      # arm mac) still exercise the full load test.
       - name: Install system GStreamer
-        if: matrix.target != 'x86_64-apple-darwin'
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
@@ -80,7 +69,6 @@ jobs:
           fi
 
       - name: Smoke test (gst-inspect against system GStreamer)
-        if: matrix.target != 'x86_64-apple-darwin'
         shell: bash
         env:
           TARGET: ${{ matrix.target }}

--- a/.github/workflows/moq-relay.yml
+++ b/.github/workflows/moq-relay.yml
@@ -119,12 +119,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both Apple targets build on the Apple Silicon runner. The
-          # Determinate Nix installer dropped Intel macOS, so x86_64 is
-          # cross-compiled (Apple clang is multi-arch) and its smoke test
-          # runs under Rosetta. See rs/scripts/package-binary.sh.
-          - target: x86_64-apple-darwin
-            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -137,13 +131,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-
-      # The cross build links system libs only, but its dyld smoke test must
-      # actually run the x86_64 binary on this arm host. Idempotent no-op when
-      # Rosetta is already present.
-      - name: Install Rosetta (x86_64 smoke test)
-        if: matrix.target == 'x86_64-apple-darwin'
-        run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Parse version
         id: parse

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -116,12 +116,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both Apple targets build on the Apple Silicon runner. The
-          # Determinate Nix installer dropped Intel macOS, so x86_64 is
-          # cross-compiled (Apple clang is multi-arch) and its smoke test
-          # runs under Rosetta. See rs/scripts/package-binary.sh.
-          - target: x86_64-apple-darwin
-            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -134,13 +128,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-
-      # The cross build links system libs only, but its dyld smoke test must
-      # actually run the x86_64 binary on this arm host. Idempotent no-op when
-      # Rosetta is already present.
-      - name: Install Rosetta (x86_64 smoke test)
-        if: matrix.target == 'x86_64-apple-darwin'
-        run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Parse version
         id: parse

--- a/.github/workflows/release-brew.yml
+++ b/.github/workflows/release-brew.yml
@@ -81,7 +81,6 @@ jobs:
           mkdir -p release-assets
           for target in \
             aarch64-apple-darwin \
-            x86_64-apple-darwin \
             aarch64-unknown-linux-gnu \
             x86_64-unknown-linux-gnu
           do

--- a/.github/workflows/release-go-ffi.yml
+++ b/.github/workflows/release-go-ffi.yml
@@ -66,10 +66,6 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            # macos-latest is arm64; the Intel target needs an Intel runner or
-            # the .a is mis-built for the wrong arch.
-            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/release-kt-ffi.yml
+++ b/.github/workflows/release-kt-ffi.yml
@@ -53,7 +53,7 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: universal-apple-darwin
+          - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -66,7 +66,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          targets: ${{ matrix.target == 'universal-apple-darwin' && 'x86_64-apple-darwin,aarch64-apple-darwin' || matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/release-py-ffi.yml
+++ b/.github/workflows/release-py-ffi.yml
@@ -67,12 +67,6 @@ jobs:
             manylinux: 2_28
             # The cross image sets TARGET_CC/CXX which leaks into host builds.
             before-script-linux: "unset TARGET_CC TARGET_CXX"
-          # Both Apple targets build on the Apple Silicon runner. maturin
-          # cross-compiles x86_64 natively via Apple's multi-arch clang (no
-          # external C libs in moq-ffi's tree), and uniffi 0.31 reads binding
-          # metadata from the cdylib statically, so no Rosetta is needed.
-          - target: x86_64-apple-darwin
-            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/release-swift-ffi.yml
+++ b/.github/workflows/release-swift-ffi.yml
@@ -45,11 +45,7 @@ jobs:
         target:
           - aarch64-apple-ios
           - aarch64-apple-ios-sim
-          # x86_64-apple-ios is the Intel iOS simulator slice (Apple never
-          # shipped Intel iOS devices), still needed for Xcode users on
-          # Intel Macs running the simulator.
-          - x86_64-apple-ios
-          - universal-apple-darwin
+          - aarch64-apple-darwin
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -59,7 +55,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          targets: ${{ matrix.target == 'universal-apple-darwin' && 'x86_64-apple-darwin,aarch64-apple-darwin' || matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10591,9 +10591,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.6.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/cpp/obs/CMakeLists.txt
+++ b/cpp/obs/CMakeLists.txt
@@ -164,10 +164,7 @@ target_sources(
 # The advanced settings dialog is Qt-only, so it ships with the dock that opens it;
 # without Qt the same settings are still reachable through the service properties.
 if(ENABLE_FRONTEND_API AND ENABLE_QT)
-  target_sources(
-    obs-moq
-    PRIVATE src/moq-dock.cpp src/moq-dock.h src/moq-advanced-dialog.cpp src/moq-advanced-dialog.h
-  )
+  target_sources(obs-moq PRIVATE src/moq-dock.cpp src/moq-dock.h src/moq-advanced-dialog.cpp src/moq-advanced-dialog.h)
   target_compile_definitions(obs-moq PRIVATE MOQ_FRONTEND_ENABLED MOQ_VERSION_STRING="${_moq_link_version}")
 endif()
 

--- a/cpp/obs/CMakePresets.json
+++ b/cpp/obs/CMakePresets.json
@@ -19,8 +19,8 @@
     },
     {
       "name": "macos",
-      "displayName": "macOS Universal",
-      "description": "Build for macOS 12.0+ (Universal binary)",
+      "displayName": "macOS Apple Silicon",
+      "description": "Build for macOS 12.0+ on Apple Silicon",
       "inherits": [
         "template"
       ],
@@ -48,8 +48,8 @@
       "inherits": [
         "macos"
       ],
-      "displayName": "macOS Universal CI build",
-      "description": "Build for macOS 12.0+ (Universal binary) for CI",
+      "displayName": "macOS Apple Silicon CI build",
+      "description": "Build for macOS 12.0+ on Apple Silicon for CI",
       "generator": "Xcode",
       "cacheVariables": {
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
@@ -133,15 +133,15 @@
     {
       "name": "macos",
       "configurePreset": "macos",
-      "displayName": "macOS Universal",
-      "description": "macOS build for Universal architectures",
+      "displayName": "macOS Apple Silicon",
+      "description": "macOS build for Apple Silicon",
       "configuration": "RelWithDebInfo"
     },
     {
       "name": "macos-ci",
       "configurePreset": "macos-ci",
-      "displayName": "macOS Universal CI",
-      "description": "macOS CI build for Universal architectures",
+      "displayName": "macOS Apple Silicon CI",
+      "description": "macOS CI build for Apple Silicon",
       "configuration": "RelWithDebInfo"
     },
     {

--- a/cpp/obs/cmake/common/buildspec_common.cmake
+++ b/cpp/obs/cmake/common/buildspec_common.cmake
@@ -58,7 +58,7 @@ function(_setup_obs_studio)
     set(_cmake_extra "-DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION} -DCMAKE_ENABLE_SCRIPTING=OFF")
   elseif(OS_MACOS)
     set(_cmake_generator "Xcode")
-    set(_cmake_arch "-DCMAKE_OSX_ARCHITECTURES:STRING='arm64;x86_64'")
+    set(_cmake_arch "-DCMAKE_OSX_ARCHITECTURES:STRING=arm64")
     set(_cmake_extra "-DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
   endif()
 

--- a/cpp/obs/cmake/macos/resources/distribution.in
+++ b/cpp/obs/cmake/macos/resources/distribution.in
@@ -2,7 +2,7 @@
 <installer-gui-script minSpecVersion="1.0">
     <options
         rootVolumeOnly="true"
-        hostArchitectures="arm64,x86_64"
+        hostArchitectures="arm64"
         customize="never"
         allow-external-scripts="no" />
     <domains enable_currentUserHome="true" enable_anywhere="false" enable_localSystem="false" />

--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -61,7 +61,7 @@ If you're using Nix, GStreamer is included in the dev shell automatically. Other
 
 ## Quick start with Nix
 
-If you have Nix installed, you don't need to build anything or set any environment variables. The `moq-gst` flake output bundles the plugin with wrappers around `gst-inspect-1.0` / `gst-launch-1.0` that preload moq alongside `gst-plugins-{base,good,bad}`, so the standard tools find `moqsink` / `moqsrc` automatically.
+On Linux or Apple Silicon macOS, Nix avoids a manual build and environment variables. The `moq-gst` flake output bundles the plugin with wrappers around `gst-inspect-1.0` / `gst-launch-1.0` that preload moq alongside `gst-plugins-{base,good,bad}`, so the standard tools find `moqsink` / `moqsrc` automatically.
 
 ### Inspect the plugin
 

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -33,7 +33,7 @@ Each [`libmoq-v*` release](https://github.com/moq-dev/moq/releases) ships a
 library, and the generated header. Supported targets:
 
 - `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`
-- `x86_64-apple-darwin`, `aarch64-apple-darwin`
+- `aarch64-apple-darwin`
 
 Download and extract a bundle (here `0.2.0` on Linux x86\_64):
 

--- a/doc/lib/go/index.md
+++ b/doc/lib/go/index.md
@@ -22,7 +22,7 @@ The raw UniFFI bindings (`MoqClient`, `MoqSession`, etc.) with blocking methods,
 **Supported platforms:**
 
 - `linux/amd64`, `linux/arm64`
-- `darwin/amd64`, `darwin/arm64` (macOS 12.3+)
+- `darwin/arm64` (macOS 12.3+)
 - `windows/amd64`
 
 [Learn more](/lib/go/moq-ffi)

--- a/doc/lib/go/moq-ffi.md
+++ b/doc/lib/go/moq-ffi.md
@@ -21,7 +21,7 @@ go get github.com/moq-dev/moq-go-ffi@latest
 import moqffi "github.com/moq-dev/moq-go-ffi/moq"
 ```
 
-The module bundles prebuilt `libmoq_ffi.a` for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`. The darwin archives need macOS 12.3+, since the video backend links ScreenCaptureKit. cgo selects the right archive at link time via build tags; `CGO_ENABLED=1` is required (the default on Unix).
+The module bundles prebuilt `libmoq_ffi.a` for `linux/amd64`, `linux/arm64`, `darwin/arm64`, and `windows/amd64`. The Darwin archive needs macOS 12.3+, since the video backend links ScreenCaptureKit. cgo selects the right archive at link time via build tags; `CGO_ENABLED=1` is required (the default on Unix).
 
 ## Local development
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -24,7 +24,7 @@ dependencies {
 The wrapper depends on `dev.moq:moq-ffi:[0.3,0.4)`, so Gradle resolves the latest bindings patch automatically. The bindings carry the native binaries:
 
 - Android: arm64-v8a, armeabi-v7a, x86\_64
-- JVM: Linux x86\_64 + aarch64, macOS x86\_64 + aarch64, Windows x86\_64
+- JVM: Linux x86\_64 + aarch64, macOS aarch64, Windows x86\_64
 
 Android uses JNI (`jniLibs/`), desktop JVM uses JNA (resource-classpath layout).
 

--- a/doc/lib/py/index.md
+++ b/doc/lib/py/index.md
@@ -38,10 +38,10 @@ uv pip install moq-rs # into the active environment
 This pulls in `moq-ffi`, for which prebuilt wheels are published for:
 
 - Linux x86\_64 / aarch64 (manylinux\_2\_28)
-- macOS x86\_64 / aarch64
+- macOS aarch64
 - Windows x86\_64
 
-For other platforms (Alpine, BSD, etc.) `pip` falls back to building `moq-ffi` from source via the published sdist. You'll need a Rust toolchain and a C compiler.
+For other platforms (Alpine, BSD, etc.) `pip` falls back to building `moq-ffi` from source via the published sdist. You'll need a Rust toolchain and a C compiler; source builds are not part of the supported release matrix.
 
 ## Quickstart
 

--- a/doc/lib/swift/index.md
+++ b/doc/lib/swift/index.md
@@ -20,8 +20,8 @@ The package you want. A Swift-native wrapper: de-prefixed types (`Client`, `Sess
 **Features:**
 
 - iOS 15+, iPadOS 15+, macOS 12.3+
-- Universal binary for Apple Silicon and Intel Macs
-- iOS device + iOS Simulator slices (arm64 and x86\_64)
+- Apple Silicon binary for macOS and the iOS Simulator
+- iOS device + iOS Simulator slices (arm64)
 - Cancellation through Swift `Task` propagates to native consumers
 - Versioned independently of the Rust crates; floats to the latest compatible `MoqFFI` patch
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -30,7 +30,7 @@ Add `Moq` to your target's dependencies:
 
 The raw `MoqFFI` bindings and the prebuilt XCFramework are pulled in transitively from [moq-dev/moq-swift-ffi](https://github.com/moq-dev/moq-swift-ffi); you only depend on `moq-swift`.
 
-Supported platforms: iOS 15+, iPadOS 15+, macOS 12.3+ (ScreenCaptureKit, which the video backend links, ships in 12.3). The XCFramework ships iOS device (arm64), iOS Simulator (arm64 + x86\_64), and macOS universal slices.
+Supported platforms: iOS 15+, iPadOS 15+, macOS 12.3+ (ScreenCaptureKit, which the video backend links, ships in 12.3). The XCFramework ships arm64 slices for iOS devices, the iOS Simulator, and macOS.
 
 ## Connect
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,13 @@
       rust-overlay,
       ...
     }:
+    let
+      eachSupportedSystem = flake-utils.lib.eachSystem [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+    in
     {
       nixosModules = {
         moq-relay = import ./nix/modules/moq-relay.nix;
@@ -42,7 +49,7 @@
 
       overlays.default = import ./nix/overlay.nix { inherit crane; };
     }
-    // flake-utils.lib.eachDefaultSystem (
+    // eachSupportedSystem (
       system:
       let
         pkgs = import nixpkgs {
@@ -64,7 +71,6 @@
             "wasm32-unknown-unknown"
           ]
           ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-            "x86_64-apple-darwin"
             "aarch64-apple-darwin"
           ];
         };
@@ -290,22 +296,7 @@
             name = "moq-packaging-tools";
             paths = packagingDeps ++ publishDeps;
           };
-        })
-        # x86_64-darwin release artifacts are cross-compiled from the
-        # aarch64-darwin runner (see nix/overlay.nix). The cross outputs only
-        # evaluate on an aarch64-darwin host, so gate them on the system to
-        # keep `nix flake check` working on Linux and Intel macs.
-        // pkgs.lib.optionalAttrs (system == "aarch64-darwin") {
-          inherit (overlayPkgs)
-            moq-relay-x86_64-apple-darwin
-            moq-cli-x86_64-apple-darwin
-            moq-bench-x86_64-apple-darwin
-            moq-token-x86_64-apple-darwin
-            moq-token-cli-x86_64-apple-darwin
-            libmoq-x86_64-apple-darwin
-            moq-gst-plugin-x86_64-apple-darwin
-            ;
-        };
+        });
 
         # Re-export gst_all_1 so users can pair the plugin with a matching
         # gstreamer in one nix invocation:

--- a/go/ffi/README.md
+++ b/go/ffi/README.md
@@ -16,7 +16,7 @@ go get github.com/moq-dev/moq-go-ffi@latest
 import moqffi "github.com/moq-dev/moq-go-ffi/moq"
 ```
 
-The published module ships prebuilt `libmoq_ffi.a` for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`. The darwin archives need macOS 12.3+, since the video backend links ScreenCaptureKit. cgo selects the right archive at link time via build tags; no `LD_LIBRARY_PATH` or extra setup needed. Building requires `CGO_ENABLED=1` (the default on Unix).
+The published module ships prebuilt `libmoq_ffi.a` for `linux/amd64`, `linux/arm64`, `darwin/arm64`, and `windows/amd64`. The Darwin archive needs macOS 12.3+, since the video backend links ScreenCaptureKit. cgo selects the right archive at link time via build tags; no `LD_LIBRARY_PATH` or extra setup needed. Building requires `CGO_ENABLED=1` (the default on Unix).
 
 ## Local development
 

--- a/go/ffi/moq/cgo.go
+++ b/go/ffi/moq/cgo.go
@@ -26,7 +26,6 @@ package moq
 /*
 #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/lib/linux_amd64 -lmoq_ffi -ldl -lm -lpthread -lstdc++
 #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/lib/linux_arm64 -lmoq_ffi -ldl -lm -lpthread -lstdc++
-#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/lib/darwin_amd64 -lmoq_ffi -framework Security -framework SystemConfiguration -framework CoreFoundation -framework CoreServices -framework Foundation -framework AVFoundation -framework CoreMedia -framework CoreVideo -framework VideoToolbox -framework ScreenCaptureKit -framework CoreGraphics -lc++
 #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/lib/darwin_arm64 -lmoq_ffi -framework Security -framework SystemConfiguration -framework CoreFoundation -framework CoreServices -framework Foundation -framework AVFoundation -framework CoreMedia -framework CoreVideo -framework VideoToolbox -framework ScreenCaptureKit -framework CoreGraphics -lc++
 #cgo windows,amd64 LDFLAGS: -L${SRCDIR}/lib/windows_amd64 -lmoq_ffi -lws2_32 -luserenv -lbcrypt -lntdll
 */

--- a/go/scripts/check.sh
+++ b/go/scripts/check.sh
@@ -66,7 +66,7 @@ esac
 # Reject unsupported hosts up front; package-ffi.sh derives the cgo
 # subdir name from the cargo target via its own mapping.
 case "$HOST_TARGET" in
-    x86_64-unknown-linux-gnu | aarch64-unknown-linux-gnu | x86_64-apple-darwin | aarch64-apple-darwin | x86_64-pc-windows-msvc) ;;
+    x86_64-unknown-linux-gnu | aarch64-unknown-linux-gnu | aarch64-apple-darwin | x86_64-pc-windows-msvc) ;;
     *)
         echo "go check: unsupported host target $HOST_TARGET" >&2
         exit 1

--- a/go/scripts/package-ffi.sh
+++ b/go/scripts/package-ffi.sh
@@ -18,7 +18,6 @@ set -euo pipefail
 # Expected $LIB_DIR layout (per cargo target):
 #   $LIB_DIR/x86_64-unknown-linux-gnu/libmoq_ffi.a
 #   $LIB_DIR/aarch64-unknown-linux-gnu/libmoq_ffi.a
-#   $LIB_DIR/x86_64-apple-darwin/libmoq_ffi.a
 #   $LIB_DIR/aarch64-apple-darwin/libmoq_ffi.a
 #   $LIB_DIR/x86_64-pc-windows-msvc/moq_ffi.lib
 
@@ -138,7 +137,6 @@ cp "$GENERATED_H" "$PKG_STAGE/moq/moq.h"
 GO_LIBS=(
     "x86_64-unknown-linux-gnu:linux_amd64:libmoq_ffi.a"
     "aarch64-unknown-linux-gnu:linux_arm64:libmoq_ffi.a"
-    "x86_64-apple-darwin:darwin_amd64:libmoq_ffi.a"
     "aarch64-apple-darwin:darwin_arm64:libmoq_ffi.a"
     "x86_64-pc-windows-msvc:windows_amd64:moq_ffi.lib"
 )
@@ -196,7 +194,7 @@ Source, issues, and pull requests live in [moq-dev/moq](https://github.com/moq-d
 go get github.com/moq-dev/moq-go-ffi@v${VERSION}
 \`\`\`
 
-The module bundles prebuilt native libraries for \`linux/amd64\`, \`linux/arm64\`, \`darwin/amd64\`, \`darwin/arm64\` (\`libmoq_ffi.a\`), and \`windows/amd64\` (\`moq_ffi.lib\`); cgo selects the right one automatically.
+The module bundles prebuilt native libraries for \`linux/amd64\`, \`linux/arm64\`, \`darwin/arm64\` (\`libmoq_ffi.a\`), and \`windows/amd64\` (\`moq_ffi.lib\`); cgo selects the right one automatically.
 
 See [moq-dev/moq/go/ffi/README.md](https://github.com/moq-dev/moq/blob/main/go/ffi/README.md) for usage and the release process.
 

--- a/kt/scripts/package.sh
+++ b/kt/scripts/package.sh
@@ -136,9 +136,7 @@ done
 JVM_LIBS=(
     "x86_64-unknown-linux-gnu:linux-x86-64:libmoq_ffi.so"
     "aarch64-unknown-linux-gnu:linux-aarch64:libmoq_ffi.so"
-    "universal-apple-darwin:darwin:libmoq_ffi.dylib"
     "aarch64-apple-darwin:darwin-aarch64:libmoq_ffi.dylib"
-    "x86_64-apple-darwin:darwin-x86-64:libmoq_ffi.dylib"
     "x86_64-pc-windows-msvc:win32-x86-64:moq_ffi.dll"
 )
 for entry in "${JVM_LIBS[@]}"; do

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -8,35 +8,11 @@ let
   # Without an explicit toolchain, crane falls back to `final.rustc`/
   # `final.cargo`, which nixpkgs resolves to its own default Rust.
   #
-  # Add both Apple targets so an aarch64-darwin host can cross-compile the
-  # x86_64-darwin release artifacts (Apple's clang is multi-arch, so no
-  # emulated x86_64 toolchain is needed). The default profile only ships
-  # std for the host triple, which is why the target list is explicit.
-  rustToolchain = final.rust-bin.stable."1.95.0".default.override {
-    targets = final.lib.optionals final.stdenv.isDarwin [
-      "x86_64-apple-darwin"
-      "aarch64-apple-darwin"
-    ];
-  };
+  rustToolchain = final.rust-bin.stable."1.95.0".default;
   craneLib = (crane.mkLib final).overrideToolchain rustToolchain;
 
   # Helper function to get crate info from Cargo.toml
   crateInfo = cargoTomlPath: craneLib.crateNameFromCargoToml { cargoToml = cargoTomlPath; };
-
-  # Cross-compile a crate's release artifact to x86_64-darwin from an
-  # aarch64-darwin host. The Determinate Nix installer dropped Intel macOS
-  # runners, but Apple's clang is multi-arch, so pointing cargo at the
-  # target produces a native (non-emulated) x86_64 build. doCheck is off
-  # because the x86_64 test binaries can't run in the aarch64 build sandbox.
-  # Only valid for pure-Rust artifacts with no cross buildInputs; moq-gst's
-  # GStreamer link would need pkgsCross instead.
-  crossX86Darwin =
-    args:
-    args
-    // {
-      CARGO_BUILD_TARGET = "x86_64-apple-darwin";
-      doCheck = false;
-    };
 
   moqRelayArgs = crateInfo ../rs/moq-relay/Cargo.toml // {
     src = craneLib.cleanCargoSource ../.;
@@ -85,7 +61,6 @@ let
     meta.mainProgram = "moq-token";
   };
   moqTokenPackage = craneLib.buildPackage moqTokenCliArgs;
-  moqTokenX86DarwinPackage = craneLib.buildPackage (crossX86Darwin moqTokenCliArgs);
 
   moqBenchArgs = crateInfo ../rs/moq-bench/Cargo.toml // {
     src = craneLib.cleanCargoSource ../.;
@@ -202,13 +177,6 @@ let
     '';
   };
 
-  # Native x86_64-darwin package set (matches cache.nixos.org's prebuilt
-  # binaries), used to link the cross moq-gst plugin against an x86_64
-  # GStreamer. pkgsCross would rebuild GStreamer from source under a cross
-  # stdenv; this fetches it. Lazy, so it's only instantiated when the cross
-  # plugin is actually built (aarch64-darwin only, see flake.nix).
-  pkgsX86Darwin = import final.path { system = "x86_64-darwin"; };
-
   moqGstPluginArgs = crateInfo ../rs/moq-gst/Cargo.toml // {
     src = craneLib.cleanCargoSource ../.;
     cargoExtraArgs = "-p moq-gst";
@@ -292,18 +260,13 @@ let
 in
 {
   moq-relay = craneLib.buildPackage moqRelayArgs;
-  moq-relay-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqRelayArgs);
 
   moq-cli = craneLib.buildPackage moqCliArgs;
-  moq-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqCliArgs);
 
   moq-bench = craneLib.buildPackage moqBenchArgs;
-  moq-bench-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqBenchArgs);
 
   moq-token = moqTokenPackage;
   moq-token-cli = moqTokenPackage;
-  moq-token-x86_64-apple-darwin = moqTokenX86DarwinPackage;
-  moq-token-cli-x86_64-apple-darwin = moqTokenX86DarwinPackage;
 
   moq-boy = craneLib.buildPackage (
     crateInfo ../rs/moq-boy/Cargo.toml
@@ -325,26 +288,8 @@ in
   );
 
   libmoq = craneLib.buildPackage libmoqArgs;
-  libmoq-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin libmoqArgs);
 
   moq-gst-plugin = craneLib.buildPackage moqGstPluginArgs;
-
-  # Cross plugin links the x86_64 GStreamer so the cdylib's LC_LOAD_DYLIB
-  # entries point at x86_64 libs. The release build (rs/moq-gst/build.sh)
-  # scrubs those nix paths to the user's system GStreamer and skips the
-  # gst-inspect smoke test, which can't load an x86_64 plugin under the
-  # arm runner's arm gst-inspect.
-  moq-gst-plugin-x86_64-apple-darwin = craneLib.buildPackage (
-    crossX86Darwin (
-      moqGstPluginArgs
-      // {
-        buildInputs = [
-          pkgsX86Darwin.gst_all_1.gstreamer
-          pkgsX86Darwin.gst_all_1.gst-plugins-base
-        ];
-      }
-    )
-  );
 
   # User-facing flake output. Bundles the plugin with wrapped gstreamer
   # tools so a single `nix shell .#moq-gst` gives you gst-inspect-1.0 /

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -176,7 +176,7 @@ Then `Config::load()?` (initializes tracing), build clients/servers via `.init()
 
   What still compiles these automatically, and when:
 
-  - moq-video's platform backends are gated on `target_os` alone, and libmoq depends on moq-video, so a `libmoq-v*` tag builds them on `windows-latest` and both Apple targets. That's a release-time backstop, not a PR one: a break lands on `main` and surfaces at the tag.
+  - moq-video's platform backends are gated on `target_os` alone, and libmoq depends on moq-video, so a `libmoq-v*` tag builds them on `windows-latest` and Apple Silicon. That's a release-time backstop, not a PR one: a break lands on `main` and surfaces at the tag.
   - **moq-audio's macOS capture has no automated backstop at all.** ScreenCaptureKit system audio and the TCC pre-check sit behind the off-by-default `capture` feature, and every consumer leaves it off (libmoq and moq-ffi don't enable it; moq-cli's own `capture` feature is off in release builds). `just rs macos` is the only thing that compiles it, ever.
   - `.github/workflows/swift.yml` still runs on a Mac for `swift/**` and `rs/moq-ffi/**` PRs, so moq-ffi and the Swift wrapper keep a PR-time gate.
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -157,7 +157,7 @@ windows *args:
 #
 # Nothing in CI runs this either; Mac runners cost too much for a per-PR gate.
 # The moq-video half has a release-time backstop, since libmoq's `libmoq-v*` tag
-# build compiles it on both Apple targets. The moq-audio half has none: its
+# build compiles it on Apple Silicon. The moq-audio half has none: its
 # capture backend is behind an off-by-default feature no release build enables,
 # so this recipe is the only thing that ever compiles it.
 #

--- a/rs/libmoq/build.sh
+++ b/rs/libmoq/build.sh
@@ -100,28 +100,19 @@ if [[ "$TARGET" == *"-windows-"* ]]; then
         -e "s|@MAJOR_VERSION@|${MAJOR_VERSION}|g" \
         "$SCRIPT_DIR/cmake/moq-config-version.cmake.in" >"$PACKAGE_DIR/lib/cmake/moq/moq-config-version.cmake"
 else
-    # Native builds use the bare flake output; the one supported cross is the
-    # Intel mac release built on an Apple Silicon runner (the Determinate Nix
-    # installer dropped Intel macOS). The flake exposes a per-target output for
-    # it; Apple's clang cross-compiles natively. libmoq.a needs no execution,
-    # so unlike the binary tarballs there's no Rosetta smoke test.
+    # Release builds must match the host. A mismatch would silently mislabel
+    # the archive, so reject it before building.
     HOST_TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
-    NIX_ATTR="libmoq"
     if [[ "$TARGET" != "$HOST_TARGET" ]]; then
-        if [[ "$HOST_TARGET" == "aarch64-apple-darwin" && "$TARGET" == "x86_64-apple-darwin" ]]; then
-            NIX_ATTR="libmoq-$TARGET"
-        else
-            echo "Error: unsupported cross ($HOST_TARGET -> $TARGET)." >&2
-            echo "Only aarch64-apple-darwin -> x86_64-apple-darwin is wired up." >&2
-            exit 1
-        fi
+        echo "Error: unsupported cross ($HOST_TARGET -> $TARGET); refusing to mislabel the archive." >&2
+        exit 1
     fi
 
-    echo "Building libmoq for $TARGET via nix (output: $NIX_ATTR)..."
+    echo "Building libmoq for $TARGET via nix..."
     BUILD_TMP="$(mktemp -d)"
     trap 'rm -rf "$BUILD_TMP"' EXIT
     RESULT_LINK="$BUILD_TMP/result"
-    nix build "$WORKSPACE_DIR#$NIX_ATTR" --out-link "$RESULT_LINK"
+    nix build "$WORKSPACE_DIR#libmoq" --out-link "$RESULT_LINK"
 
     # The derivation lays out everything under $out/{lib,include}; copy it
     # verbatim so the release tarball matches what nix produced.

--- a/rs/moq-ffi/build.sh
+++ b/rs/moq-ffi/build.sh
@@ -103,10 +103,6 @@ is_ios() {
 # Check if target can run on the host (for binding generation)
 can_run_on_host() {
     local target="$1"
-    # Universal darwin can run on host if we're on macOS
-    if [[ "$target" == "universal-apple-darwin" && "$(uname)" == "Darwin" ]]; then
-        return 0
-    fi
     [[ "$target" == "$HOST_TARGET" ]]
 }
 
@@ -206,22 +202,7 @@ fi
 
 # --- Full build mode ---
 
-if [[ "$TARGET" == "universal-apple-darwin" ]]; then
-    if [[ "$(uname)" != "Darwin" ]]; then
-        echo "Error: Universal builds are only supported on macOS" >&2
-        exit 1
-    fi
-
-    build_target "x86_64-apple-darwin"
-    build_target "aarch64-apple-darwin"
-
-    LIB_X86_STATIC="$TARGET_BASE_DIR/x86_64-apple-darwin/release/libmoq_ffi.a"
-    LIB_ARM64_STATIC="$TARGET_BASE_DIR/aarch64-apple-darwin/release/libmoq_ffi.a"
-    LIB_X86_DYLIB="$TARGET_BASE_DIR/x86_64-apple-darwin/release/libmoq_ffi.dylib"
-    LIB_ARM64_DYLIB="$TARGET_BASE_DIR/aarch64-apple-darwin/release/libmoq_ffi.dylib"
-else
-    build_target "$TARGET"
-fi
+build_target "$TARGET"
 
 # Package native libraries
 NAME="moq-ffi-${VERSION}-${TARGET}"
@@ -232,12 +213,7 @@ echo "Packaging $NAME..."
 rm -rf "$PACKAGE_DIR"
 mkdir -p "$PACKAGE_DIR/lib"
 
-if [[ "$TARGET" == "universal-apple-darwin" ]]; then
-    echo "Creating universal binaries..."
-    lipo -create "$LIB_X86_STATIC" "$LIB_ARM64_STATIC" -output "$PACKAGE_DIR/lib/libmoq_ffi.a"
-    lipo -create "$LIB_X86_DYLIB" "$LIB_ARM64_DYLIB" -output "$PACKAGE_DIR/lib/libmoq_ffi.dylib"
-
-elif [[ "$TARGET" == *"-windows-"* ]]; then
+if [[ "$TARGET" == *"-windows-"* ]]; then
     TARGET_DIR="$TARGET_BASE_DIR/$TARGET/release"
     cp "$TARGET_DIR/moq_ffi.dll" "$PACKAGE_DIR/lib/"
     cp "$TARGET_DIR/moq_ffi.dll.lib" "$PACKAGE_DIR/lib/" 2>/dev/null || true
@@ -294,20 +270,7 @@ fi
 # Generate bindings if we can run the library on this host
 cd "$WORKSPACE_DIR"
 if can_run_on_host "$TARGET"; then
-    # For universal builds, use the dylib matching the host arch
-    if [[ "$TARGET" == "universal-apple-darwin" ]]; then
-        host_arch=$(uname -m)
-        case "$host_arch" in
-            arm64 | aarch64) cdylib=$(find_cdylib "aarch64-apple-darwin") ;;
-            x86_64) cdylib=$(find_cdylib "x86_64-apple-darwin") ;;
-            *)
-                echo "Warning: unknown host arch $host_arch, skipping bindings"
-                cdylib=""
-                ;;
-        esac
-    else
-        cdylib=$(find_cdylib "$TARGET")
-    fi
+    cdylib=$(find_cdylib "$TARGET")
 
     if [[ -f "$cdylib" ]]; then
         generate_bindings "$cdylib"

--- a/rs/moq-gst/README.md
+++ b/rs/moq-gst/README.md
@@ -31,7 +31,7 @@ sudo dnf config-manager --add-repo https://rpm.moq.dev/moq.repo
 sudo dnf install gstreamer1-moq
 ```
 
-### Nix (any platform with Nix installed)
+### Nix (Linux or Apple Silicon macOS)
 
 The `moq-gst` flake output bundles the plugin with wrappers around `gst-inspect-1.0` / `gst-launch-1.0` that preload moq + the standard `gst-plugins-{base,good,bad}` set, so no `GST_PLUGIN_PATH` setup is needed.
 
@@ -80,7 +80,6 @@ Available targets:
 |---|---|
 | `x86_64-unknown-linux-gnu` | Linux (x86\_64) |
 | `aarch64-unknown-linux-gnu` | Linux (ARM64) |
-| `x86_64-apple-darwin` | macOS (Intel) |
 | `aarch64-apple-darwin` | macOS (Apple Silicon) |
 
 You need a matching GStreamer runtime installed:
@@ -89,7 +88,7 @@ You need a matching GStreamer runtime installed:
 - **macOS (Homebrew)**: `brew install gstreamer`
 - **macOS (official)**: the .pkg installer from [gstreamer.freedesktop.org](https://gstreamer.freedesktop.org/download/)
 
-The macOS dylib has rpaths pre-baked for the three common install locations (`/opt/homebrew/lib`, `/usr/local/lib`, `/Library/Frameworks/GStreamer.framework/Libraries`). If your GStreamer is somewhere else, set `DYLD_FALLBACK_LIBRARY_PATH` accordingly.
+The macOS dylib has rpaths pre-baked for Homebrew (`/opt/homebrew/lib`) and the official installer (`/Library/Frameworks/GStreamer.framework/Libraries`). If your GStreamer is somewhere else, set `DYLD_FALLBACK_LIBRARY_PATH` accordingly.
 
 ## Building from source
 

--- a/rs/moq-gst/build.sh
+++ b/rs/moq-gst/build.sh
@@ -52,32 +52,20 @@ if [[ -z "$TARGET" ]]; then
     echo "Detected target: $TARGET"
 fi
 
-# Native builds use the bare flake output. The one supported cross is the
-# Intel mac release built on an Apple Silicon runner (the Determinate Nix
-# installer dropped Intel macOS): a dedicated plugin output links the x86_64
-# GStreamer, and Apple's clang cross-compiles natively. The smoke test is
-# skipped for the cross plugin (an arm gst-inspect can't load an x86_64
-# plugin); scrub.sh and its no-/nix assertion still run.
+# Release builds must match the host. A mismatch would silently mislabel the
+# plugin archive, so reject it before building.
 HOST_TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
-NIX_ATTR="moq-gst"
-CROSS=false
 if [[ "$TARGET" != "$HOST_TARGET" ]]; then
-    if [[ "$HOST_TARGET" == "aarch64-apple-darwin" && "$TARGET" == "x86_64-apple-darwin" ]]; then
-        NIX_ATTR="moq-gst-plugin-$TARGET"
-        CROSS=true
-    else
-        echo "Error: unsupported cross ($HOST_TARGET -> $TARGET)." >&2
-        echo "Only aarch64-apple-darwin -> x86_64-apple-darwin is wired up." >&2
-        exit 1
-    fi
+    echo "Error: unsupported cross ($HOST_TARGET -> $TARGET); refusing to mislabel the archive." >&2
+    exit 1
 fi
 
-echo "Building moq-gst for $TARGET via nix (output: $NIX_ATTR)..."
+echo "Building moq-gst for $TARGET via nix..."
 
 BUILD_TMP="$(mktemp -d)"
 trap 'rm -rf "$BUILD_TMP"' EXIT
 RESULT_LINK="$BUILD_TMP/result"
-nix build "$WORKSPACE_DIR#$NIX_ATTR" --out-link "$RESULT_LINK"
+nix build "$WORKSPACE_DIR#moq-gst" --out-link "$RESULT_LINK"
 
 # Locate the produced shared library (extension differs by platform).
 # The flake places it in lib/gstreamer-1.0/ so gst_all_1.gstreamer's
@@ -114,11 +102,7 @@ cp "$WORKSPACE_DIR/LICENSE-MIT" "$PACKAGE_DIR/"
 cp "$WORKSPACE_DIR/LICENSE-APACHE" "$PACKAGE_DIR/"
 
 "$SCRIPT_DIR/scrub.sh" "$PACKAGE_DIR/lib/gstreamer-1.0/$LIB_FILE"
-if [[ "$CROSS" == true ]]; then
-    echo "Skipping smoke test for cross build ($TARGET): host gst-inspect can't load it."
-else
-    "$SCRIPT_DIR/smoke.sh" "$PACKAGE_DIR/lib/gstreamer-1.0"
-fi
+"$SCRIPT_DIR/smoke.sh" "$PACKAGE_DIR/lib/gstreamer-1.0"
 
 cd "$OUTPUT_DIR"
 ARCHIVE="$NAME.tar.gz"

--- a/rs/moq-gst/scrub.sh
+++ b/rs/moq-gst/scrub.sh
@@ -36,13 +36,12 @@ scrub_macos() {
 
     # The shared Mach-O scrub does the LC_LOAD_DYLIB rewrite, /nix LC_RPATH
     # strip, and the no-/nix assertion. We just pass the rpaths a GStreamer
-    # plugin needs: /opt/homebrew + /usr/local cover homebrew on ARM and
-    # Intel, the Framework path covers the official .pkg installer, and
-    # /usr/lib lets dyld resolve system libs (libiconv, libc++) via the
-    # dyld_shared_cache at @rpath substitution time.
+    # plugin needs: /opt/homebrew covers Homebrew on Apple Silicon, the
+    # Framework path covers the official .pkg installer, and /usr/lib lets
+    # dyld resolve system libs (libiconv, libc++) via the dyld_shared_cache at
+    # @rpath substitution time.
     "$SCRIPT_DIR/../scripts/scrub-macho.sh" "$dylib" \
         /opt/homebrew/lib \
-        /usr/local/lib \
         /Library/Frameworks/GStreamer.framework/Libraries \
         /usr/lib
 }

--- a/rs/scripts/package-binary.sh
+++ b/rs/scripts/package-binary.sh
@@ -73,30 +73,20 @@ if [[ -z "$TARGET" ]]; then
     echo "Detected target: $TARGET"
 fi
 
-# Native builds use the bare flake output. The one supported cross is the
-# Intel mac release built on an Apple Silicon runner (the Determinate Nix
-# installer dropped Intel macOS): the flake exposes a per-target output for
-# it (nix/overlay.nix) and Apple's clang cross-compiles natively, so the only
-# emulation is the Rosetta smoke test below. Any other host/target mismatch
-# would silently mislabel the archive, so it's rejected.
+# Release builds must match the host. A mismatch would silently mislabel the
+# archive, so reject it before building.
 HOST_TARGET=$(rustc -vV | awk '/^host:/ {print $2}')
-NIX_ATTR="$CRATE"
 if [[ "$TARGET" != "$HOST_TARGET" ]]; then
-    if [[ "$HOST_TARGET" == "aarch64-apple-darwin" && "$TARGET" == "x86_64-apple-darwin" ]]; then
-        NIX_ATTR="$CRATE-$TARGET"
-    else
-        echo "Error: unsupported cross ($HOST_TARGET -> $TARGET)." >&2
-        echo "Only aarch64-apple-darwin -> x86_64-apple-darwin is wired up; refusing to mislabel the archive." >&2
-        exit 1
-    fi
+    echo "Error: unsupported cross ($HOST_TARGET -> $TARGET); refusing to mislabel the archive." >&2
+    exit 1
 fi
 
-echo "Building $CRATE for $TARGET via nix (output: $NIX_ATTR)..."
+echo "Building $CRATE for $TARGET via nix (output: $CRATE)..."
 
 BUILD_TMP="$(mktemp -d)"
 trap 'rm -rf "$BUILD_TMP"' EXIT
 RESULT_LINK="$BUILD_TMP/result"
-nix build "$WORKSPACE_DIR#$NIX_ATTR" --out-link "$RESULT_LINK"
+nix build "$WORKSPACE_DIR#$CRATE" --out-link "$RESULT_LINK"
 
 # Locate the built binary. Crane installs to result/bin/<binary>. The binary
 # name is usually the crate name; the `moq-cli` crate ships as `moq`.

--- a/swift/scripts/package-ffi.sh
+++ b/swift/scripts/package-ffi.sh
@@ -146,19 +146,14 @@ ensure_lib() {
 
 IOS_DEVICE_LIB=$(ensure_lib "aarch64-apple-ios")
 IOS_SIM_ARM64=$(ensure_lib "aarch64-apple-ios-sim")
-IOS_SIM_X86_64=$(ensure_lib "x86_64-apple-ios")
-MAC_UNIVERSAL=$(ensure_lib "universal-apple-darwin")
-
-# Fat lib for iOS simulator (arm64 + x86_64).
-IOS_SIM_FAT="$STAGING/libmoq_ffi-iossim.a"
-lipo -create "$IOS_SIM_ARM64" "$IOS_SIM_X86_64" -output "$IOS_SIM_FAT"
+MAC_ARM64=$(ensure_lib "aarch64-apple-darwin")
 
 # --- Build XCFramework ---
 XCF="$STAGING/MoqFFI.xcframework"
 env ${xcode_sdk_env[@]+"${xcode_sdk_env[@]}"} xcodebuild -create-xcframework \
     -library "$IOS_DEVICE_LIB" -headers "$HEADERS_DIR" \
-    -library "$IOS_SIM_FAT" -headers "$HEADERS_DIR" \
-    -library "$MAC_UNIVERSAL" -headers "$HEADERS_DIR" \
+    -library "$IOS_SIM_ARM64" -headers "$HEADERS_DIR" \
+    -library "$MAC_ARM64" -headers "$HEADERS_DIR" \
     -output "$XCF"
 
 # --- Zip and checksum the XCFramework ---


### PR DESCRIPTION
## Summary

- remove x86_64 macOS targets from Nix and native release workflows after Nixpkgs 26.11 dropped the platform
- publish Apple Silicon-only macOS artifacts across Homebrew, C, Go, Python, Kotlin, Swift, GStreamer, and OBS
- build OBS's bundled libobs for arm64 only
- remove the obsolete cross-build paths and update supported-platform documentation
- replace the yanked `wide 1.6.0` lockfile entry with compatible `wide 1.5.0`

## Root cause

The `moq-gst-v0.3.4` release failed because the Intel macOS artifact evaluated against Nixpkgs 26.11, which no longer supports `x86_64-darwin`. Keeping that artifact would require pinning an older Nixpkgs branch with security support ending in 2026.

The first PR check was independently blocked by `wide 1.6.0` being yanked upstream. `openh264 0.9.7` accepts `wide 1.5.0`, so the lockfile now selects that non-yanked compatible release.

## Public API changes

None. This removes published Intel macOS artifacts and release support, but does not rename or change any public Rust or TypeScript API.

## Test plan

- clean JavaScript CI checks, tests, and builds
- `nix develop --command just rs ci` (2,799 tests passed, 12 skipped)
- `nix develop --command just py ci` (50 tests passed)
- `nix develop --command just kt ci`
- `nix develop --command just swift ci` (10 tests passed)
- `nix develop --command just go ci`
- `nix develop --command just obs check`
- `nix flake check`
- repository-wide Markdown, shell, formatting, actionlint, and workflow alert coverage checks

(Written by GPT-5)