### PR TITLE
feat(net): expose JavaScript subscription options

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -68,6 +68,19 @@ test("a request exposes the aggregate subscription options", async () => {
 	expect(request?.priority).toBe(7);
 });
 
+test("requested selects the highest current priority", async () => {
+	const consumer = new TestConsumer();
+
+	const first = consumer.subscribe("first", { priority: 1 });
+	consumer.subscribe("second", { priority: 5 });
+	const updated = first.subscription.changed();
+	first.update({ priority: 9 });
+	await updated;
+
+	expect((await consumer.requested())?.name).toBe("first");
+	expect((await consumer.requested())?.name).toBe("second");
+});
+
 test("a consumer clone shares the broadcast until every handle closes", () => {
 	const consumer = new TestConsumer();
 	const clone = consumer.clone();

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -51,6 +51,23 @@ test("consumer dedupes repeat subscriptions onto one upstream request", async ()
 	expect((await pendingRequest(consumer))?.name).toBe("video");
 });
 
+test("a request exposes the aggregate subscription options", async () => {
+	const consumer = new TestConsumer();
+
+	consumer.subscribe("video", { priority: 3, ordered: true, latencyMax: 100, startGroup: 10, endGroup: 20 });
+	consumer.subscribe("video", { priority: 7, ordered: true, latencyMax: 250, startGroup: 0, endGroup: 30 });
+
+	const request = await pendingRequest(consumer);
+	expect(request?.subscription).toEqual({
+		priority: 7,
+		ordered: true,
+		latencyMax: 250,
+		startGroup: 0,
+		endGroup: 30,
+	});
+	expect(request?.priority).toBe(7);
+});
+
 test("a consumer clone shares the broadcast until every handle closes", () => {
 	const consumer = new TestConsumer();
 	const clone = consumer.clone();

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -18,6 +18,12 @@ class BroadcastState {
 	consumers = 0;
 }
 
+function dequeueRequest(state: BroadcastState): track.Request | undefined {
+	const requested = state.requested.peek();
+	requested.sort((a, b) => a.priority - b.priority);
+	return requested.pop();
+}
+
 // Close the broadcast and reject any requests still pending in the queue, so a
 // subscriber blocked on the track's info() or group reads is unblocked rather
 // than left waiting on a producer that will never be served.
@@ -70,7 +76,6 @@ function subscribe(
 
 	state.requested.mutate((requested) => {
 		requested.push(hooks.makeRequest(name, producer));
-		requested.sort((a, b) => a.priority - b.priority);
 	});
 
 	return subscriber;
@@ -89,7 +94,6 @@ async function resolveTrackInfo(state: BroadcastState, name: string): Promise<tr
 	const producer = new track.Producer(name);
 	state.requested.mutate((requested) => {
 		requested.push(hooks.makeRequest(name, producer));
-		requested.sort((a, b) => a.priority - b.priority);
 	});
 
 	try {
@@ -154,7 +158,7 @@ export class Producer implements track.Broadcast {
 	/** Return the next track requested by a peer. */
 	async requested(): Promise<track.Request | undefined> {
 		for (;;) {
-			const request = this.#state.requested.peek().pop();
+			const request = dequeueRequest(this.#state);
 			if (request) return request;
 
 			const closed = this.#state.closed.peek();
@@ -293,7 +297,7 @@ export class Consumer implements track.Broadcast {
 	/** Return the next track requested by the local consumer. Used by the subscribing wire layer. */
 	async requested(): Promise<track.Request | undefined> {
 		for (;;) {
-			const request = this.#state.requested.peek().pop();
+			const request = dequeueRequest(this.#state);
 			if (request) return request;
 
 			const closed = this.#state.closed.peek();

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -52,12 +52,12 @@ function subscribe(
 
 	const existing = state.tracks.get(name);
 	if (existing) {
-		if (existing.closed.peek() === undefined) return existing.subscribe();
+		if (existing.closed.peek() === undefined) return existing.subscribe(options);
 		state.tracks.delete(name);
 	}
 
 	const producer = new track.Producer(name);
-	const subscriber = producer.subscribe();
+	const subscriber = producer.subscribe(options);
 
 	if (register) {
 		state.tracks.set(name, producer);
@@ -69,7 +69,7 @@ function subscribe(
 	}
 
 	state.requested.mutate((requested) => {
-		requested.push(hooks.makeRequest(name, producer, options.priority ?? 0));
+		requested.push(hooks.makeRequest(name, producer));
 		requested.sort((a, b) => a.priority - b.priority);
 	});
 
@@ -88,7 +88,7 @@ async function resolveTrackInfo(state: BroadcastState, name: string): Promise<tr
 
 	const producer = new track.Producer(name);
 	state.requested.mutate((requested) => {
-		requested.push(hooks.makeRequest(name, producer, 0));
+		requested.push(hooks.makeRequest(name, producer));
 		requested.sort((a, b) => a.priority - b.priority);
 	});
 

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -9,6 +9,7 @@ import { createMockTransportPair } from "./mock.ts";
 import * as Path from "./path.ts";
 import { Timescale, Timestamp } from "./time.ts";
 import type { Producer as TrackProducer } from "./track.ts";
+import { withTimeout } from "./util/timeout.ts";
 
 const url = new URL("https://localhost:4443/test");
 
@@ -153,30 +154,46 @@ test("integration: lite subscription options and updates reach the publisher", a
 });
 
 test("integration: lite applies initial and updated group bounds", async () => {
+	const GROUP_COUNT = 6;
+	const INITIAL_START_GROUP = 1;
+	const INITIAL_END_GROUP = 2;
+	const UPDATED_GROUP = 4;
+	const PENDING_ASSERT_MS = 20;
+	const UPDATE_TIMEOUT_MS = 1000;
+
 	const pair = createMockTransportPair(Lite.ALPN_05);
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	const broadcast = new BroadcastProducer();
 	const producer = broadcast.createTrack("video");
-	for (let sequence = 0; sequence < 5; sequence++) producer.appendGroup().close();
+	for (let sequence = 0; sequence < GROUP_COUNT; sequence++) producer.appendGroup().close();
 	server.publish(Path.from("test"), broadcast);
 
 	const remote = client.consume(Path.from("test"));
-	const subscriber = remote.track("video").subscribe({ startGroup: 1, endGroup: 2 });
-	expect((await subscriber.nextGroup())?.sequence).toBe(1);
-	expect((await subscriber.nextGroup())?.sequence).toBe(2);
+	const subscriber = remote
+		.track("video")
+		.subscribe({ startGroup: INITIAL_START_GROUP, endGroup: INITIAL_END_GROUP });
+	try {
+		expect((await subscriber.nextGroup())?.sequence).toBe(INITIAL_START_GROUP);
+		expect((await subscriber.nextGroup())?.sequence).toBe(INITIAL_END_GROUP);
 
-	const pending = subscriber.nextGroup();
-	expect(await Promise.race([pending, sleep(20).then(() => "pending")])).toBe("pending");
+		const pending = subscriber.nextGroup();
+		expect(await Promise.race([pending, sleep(PENDING_ASSERT_MS).then(() => "pending")])).toBe("pending");
 
-	subscriber.update({ startGroup: 4, endGroup: 4 });
-	expect((await pending)?.sequence).toBe(4);
+		subscriber.update({ startGroup: UPDATED_GROUP, endGroup: UPDATED_GROUP });
+		expect((await withTimeout(pending, UPDATE_TIMEOUT_MS, "updated group bound timed out"))?.sequence).toBe(
+			UPDATED_GROUP,
+		);
 
-	subscriber.close();
-	remote.close();
-	broadcast.close();
-	client.close();
-	server.close();
+		const capped = subscriber.nextGroup();
+		expect(await Promise.race([capped, sleep(PENDING_ASSERT_MS).then(() => "pending")])).toBe("pending");
+	} finally {
+		subscriber.close();
+		remote.close();
+		broadcast.close();
+		client.close();
+		server.close();
+	}
 });
 
 test("integration: lite draft-06", async () => {

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -97,6 +97,61 @@ test("integration: lite draft-05", async () => {
 	await runPublishSubscribeFlow(Lite.ALPN_05);
 });
 
+test("integration: lite subscription options and updates reach the publisher", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_05);
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+
+	let resolveProducer: ((producer: TrackProducer) => void) | undefined;
+	const accepted = new Promise<TrackProducer>((resolve) => {
+		resolveProducer = resolve;
+	});
+	const serving = (async () => {
+		for (;;) {
+			const request = await broadcast.requested();
+			if (!request) return;
+			const producer = request.accept();
+			if (request.subscription.startGroup === 0) resolveProducer?.(producer);
+		}
+	})();
+
+	const remote = client.consume(Path.from("test"));
+	const subscriber = remote.track("video").subscribe({
+		priority: 3,
+		ordered: true,
+		latencyMax: 250,
+		startGroup: 0,
+		endGroup: 9,
+	});
+	const producer = await accepted;
+	expect(producer.subscription.peek()).toEqual({
+		priority: 3,
+		ordered: true,
+		latencyMax: 250,
+		startGroup: 0,
+		endGroup: 9,
+	});
+
+	const updated = producer.subscription.changed();
+	subscriber.update({ priority: 8, ordered: false, latencyMax: 500, startGroup: 2, endGroup: 12 });
+	expect(await updated).toEqual({
+		priority: 8,
+		ordered: false,
+		latencyMax: 500,
+		startGroup: 2,
+		endGroup: 12,
+	});
+
+	subscriber.close();
+	remote.close();
+	broadcast.close();
+	await serving;
+	client.close();
+	server.close();
+});
+
 test("integration: lite draft-06", async () => {
 	// Exercises announce ids: every active assigns an ordinal on the wire.
 	await runPublishSubscribeFlow(Lite.ALPN_06_WIP);

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -152,6 +152,33 @@ test("integration: lite subscription options and updates reach the publisher", a
 	server.close();
 });
 
+test("integration: lite applies initial and updated group bounds", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_05);
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	const producer = broadcast.createTrack("video");
+	for (let sequence = 0; sequence < 5; sequence++) producer.appendGroup().close();
+	server.publish(Path.from("test"), broadcast);
+
+	const remote = client.consume(Path.from("test"));
+	const subscriber = remote.track("video").subscribe({ startGroup: 1, endGroup: 2 });
+	expect((await subscriber.nextGroup())?.sequence).toBe(1);
+	expect((await subscriber.nextGroup())?.sequence).toBe(2);
+
+	const pending = subscriber.nextGroup();
+	expect(await Promise.race([pending, sleep(20).then(() => "pending")])).toBe("pending");
+
+	subscriber.update({ startGroup: 4, endGroup: 4 });
+	expect((await pending)?.sequence).toBe(4);
+
+	subscriber.close();
+	remote.close();
+	broadcast.close();
+	client.close();
+	server.close();
+});
+
 test("integration: lite draft-06", async () => {
 	// Exercises announce ids: every active assigns an ordinal on the wire.
 	await runPublishSubscribeFlow(Lite.ALPN_06_WIP);

--- a/js/net/src/internal.ts
+++ b/js/net/src/internal.ts
@@ -10,7 +10,7 @@ import type { Producer, Request } from "./track.ts";
 /** Hooks assigned in static blocks by the owning class. */
 export const hooks: {
 	/** Mint a track {@link Request}; assigned by `track.ts`. */
-	makeRequest: (name: string, producer: Producer, priority: number) => Request;
+	makeRequest: (name: string, producer: Producer) => Request;
 } = {
 	makeRequest: () => {
 		throw new Error("track.ts not loaded");

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -249,7 +249,13 @@ export class Publisher {
 			return;
 		}
 
-		const track = broadcast.subscribe(msg.track, { priority: msg.priority });
+		const track = broadcast.subscribe(msg.track, {
+			priority: msg.priority,
+			ordered: msg.ordered,
+			latencyMax: msg.maxLatency,
+			startGroup: msg.startGroup,
+			endGroup: msg.endGroup,
+		});
 
 		// The best-effort datagram loop, started once serving begins. It parks when the
 		// track finishes (recvDatagram returns undefined), so #runTrack alone ends the
@@ -273,7 +279,13 @@ export class Publisher {
 				timescale = info.timescale;
 			} else {
 				// Older drafts acknowledge with SUBSCRIBE_OK and stream frames verbatim.
-				const ok = new SubscribeOk({ priority: msg.priority });
+				const ok = new SubscribeOk({
+					priority: msg.priority,
+					ordered: msg.ordered,
+					maxLatency: msg.maxLatency,
+					startGroup: msg.startGroup,
+					endGroup: msg.endGroup,
+				});
 				await encodeSubscribeResponse(stream.writer, { ok }, this.version);
 			}
 
@@ -294,10 +306,14 @@ export class Publisher {
 				if (!result) break;
 
 				if (result instanceof SubscribeUpdate) {
-					console.debug(
-						`subscribe update: broadcast=${msg.broadcast} track=${track.name} priority=${result.priority}`,
-					);
-					track.update({ priority: result.priority });
+					console.debug(`subscribe update: broadcast=${msg.broadcast} track=${track.name}`);
+					track.update({
+						priority: result.priority,
+						ordered: result.ordered,
+						latencyMax: result.maxLatency,
+						startGroup: result.startGroup,
+						endGroup: result.endGroup,
+					});
 				}
 			}
 

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -256,6 +256,9 @@ export class Publisher {
 			startGroup: msg.startGroup,
 			endGroup: msg.endGroup,
 		});
+		const startGroup = msg.startGroup ?? track.latest();
+		if (startGroup !== undefined) track.startAt(startGroup);
+		track.endAt(msg.endGroup);
 
 		// The best-effort datagram loop, started once serving begins. It parks when the
 		// track finishes (recvDatagram returns undefined), so #runTrack alone ends the
@@ -314,6 +317,8 @@ export class Publisher {
 						startGroup: result.startGroup,
 						endGroup: result.endGroup,
 					});
+					if (result.startGroup !== undefined) track.startAt(result.startGroup);
+					track.endAt(result.endGroup);
 				}
 			}
 
@@ -390,7 +395,7 @@ export class Publisher {
 
 		try {
 			for (;;) {
-				const next = track.recvGroup();
+				const next = track.nextGroup();
 				const group = await Promise.race([next, stream.closed]);
 				if (!group) {
 					next.then((group) => group?.close()).catch(() => {});

--- a/js/net/src/lite/subscribe.test.ts
+++ b/js/net/src/lite/subscribe.test.ts
@@ -1,13 +1,16 @@
 import { expect, test } from "bun:test";
+import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
 import {
 	decodeSubscribeResponse,
 	encodeSubscribeResponse,
+	Subscribe,
 	SubscribeDrop,
 	SubscribeEnd,
 	SubscribeOk,
 	type SubscribeResponse,
 	SubscribeStart,
+	SubscribeUpdate,
 } from "./subscribe.ts";
 import { Version } from "./version.ts";
 
@@ -38,6 +41,20 @@ async function responseRoundtrip(version: Version, resp: SubscribeResponse): Pro
 	return decodeSubscribeResponse(reader, version);
 }
 
+async function encodeMessage(
+	version: Version,
+	message: { encode(writer: Writer, version: Version): Promise<void> },
+): Promise<Uint8Array> {
+	const written: Uint8Array[] = [];
+	const writer = new Writer(
+		new WritableStream<Uint8Array>({ write: (chunk) => void written.push(new Uint8Array(chunk)) }),
+	);
+	await message.encode(writer, version);
+	writer.close();
+	await writer.closed;
+	return concat(written);
+}
+
 test("SubscribeOk round-trips priority/ordered/groups on draft-04", async () => {
 	const got = await responseRoundtrip(Version.DRAFT_04, {
 		ok: new SubscribeOk({ priority: 7, ordered: true, maxLatency: 250, startGroup: 3 }),
@@ -47,6 +64,47 @@ test("SubscribeOk round-trips priority/ordered/groups on draft-04", async () => 
 	expect(got.ok.priority).toBe(7);
 	expect(got.ok.ordered).toBe(true);
 	expect(got.ok.startGroup).toBe(3);
+});
+
+test("Subscribe round-trips every option including startGroup 0", async () => {
+	const message = new Subscribe({
+		id: 4n,
+		broadcast: Path.from("test"),
+		track: "video",
+		priority: 7,
+		ordered: true,
+		maxLatency: 250,
+		startGroup: 0,
+		endGroup: 9,
+	});
+	const got = await Subscribe.decode(
+		new Reader(undefined, await encodeMessage(Version.DRAFT_05, message)),
+		Version.DRAFT_05,
+	);
+	expect(got.priority).toBe(7);
+	expect(got.ordered).toBe(true);
+	expect(got.maxLatency).toBe(250);
+	expect(got.startGroup).toBe(0);
+	expect(got.endGroup).toBe(9);
+});
+
+test("SubscribeUpdate round-trips every option including startGroup 0", async () => {
+	const message = new SubscribeUpdate({
+		priority: 8,
+		ordered: true,
+		maxLatency: 500,
+		startGroup: 0,
+		endGroup: 12,
+	});
+	const got = await SubscribeUpdate.decode(
+		new Reader(undefined, await encodeMessage(Version.DRAFT_05, message)),
+		Version.DRAFT_05,
+	);
+	expect(got.priority).toBe(8);
+	expect(got.ordered).toBe(true);
+	expect(got.maxLatency).toBe(500);
+	expect(got.startGroup).toBe(0);
+	expect(got.endGroup).toBe(12);
 });
 
 test("SubscribeStart round-trips on draft-05", async () => {

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -357,6 +357,7 @@ export class Subscriber {
 
 	async #runSubscribe(broadcast: Path.Valid, request: track.Request) {
 		const id = this.#subscribeNext++;
+		const subscription = request.subscription;
 
 		// `timescale` stays undefined until TRACK_INFO (or, on older drafts,
 		// implicit defaults) resolves it; runGroup blocks on it before decoding.
@@ -364,7 +365,16 @@ export class Subscriber {
 
 		console.debug(`subscribe start: id=${id} broadcast=${broadcast} track=${request.name}`);
 
-		const msg = new Subscribe({ id, broadcast, track: request.name, priority: request.priority });
+		const msg = new Subscribe({
+			id,
+			broadcast,
+			track: request.name,
+			priority: subscription.priority ?? 0,
+			ordered: subscription.ordered,
+			maxLatency: subscription.latencyMax,
+			startGroup: subscription.startGroup,
+			endGroup: subscription.endGroup,
+		});
 
 		// Open the stream under a timeout. The stream handle flows back via `state`
 		// so the timeout path can abort it if it finishes opening after the deadline.
@@ -396,7 +406,7 @@ export class Subscriber {
 
 		const { stream, producer } = opened;
 		try {
-			// Watch for priority changes and send SUBSCRIBE_UPDATE. Lite01/Lite02
+			// Watch for subscription changes and send SUBSCRIBE_UPDATE. Lite01/Lite02
 			// don't carry SUBSCRIBE_UPDATE on the wire, so skip the watcher there
 			// and just wait on the stream/track like before.
 			//
@@ -404,15 +414,15 @@ export class Subscriber {
 			// drain them (we don't drive delivery off the resolved range) so the FIN is
 			// observed. Older drafts just wait for the stream to close.
 			const closed = supportsTrackStream(this.version) ? this.#drainResponses(stream) : stream.reader.closed;
-			const priorityUpdates =
+			const subscriptionUpdates =
 				this.version === Version.DRAFT_01 || this.version === Version.DRAFT_02
 					? undefined
-					: this.#runPriorityUpdates(id, broadcast, producer, msg, stream);
+					: this.#runSubscriptionUpdates(id, broadcast, producer, msg, stream);
 
-			// Terminal conditions (stream end, track close, a failed priority update) settle at most
+			// Terminal conditions (stream end, track close, a failed subscription update) settle at most
 			// once; race them into one stable promise so the demand loop doesn't re-subscribe each pass.
 			const terminal: PromiseLike<unknown>[] = [closed, producer.closed];
-			if (priorityUpdates !== undefined) terminal.push(priorityUpdates);
+			if (subscriptionUpdates !== undefined) terminal.push(subscriptionUpdates);
 			const done = Promise.race(terminal);
 
 			// Serve until a terminal condition fires or the last local subscriber leaves. The unused
@@ -645,17 +655,17 @@ export class Subscriber {
 	}
 
 	/**
-	 * Send SUBSCRIBE_UPDATE messages whenever the track's priority signal changes.
+	 * Send SUBSCRIBE_UPDATE messages whenever the track's aggregate subscription changes.
 	 *
 	 * Resolves cleanly when the stream or track closes, so the caller can include
 	 * this in Promise.race without leaving a dangling pending write that would
-	 * become an unhandled rejection if the user calls updatePriority after close.
+	 * become an unhandled rejection if the user calls update after close.
 	 *
 	 * Peeks the signal at the top of every iteration so that updates which landed
 	 * before SubscribeOk arrived (or between iterations, before .next() registered
 	 * its listener) aren't lost.
 	 */
-	async #runPriorityUpdates(
+	async #runSubscriptionUpdates(
 		id: bigint,
 		broadcast: Path.Valid,
 		track: track.Producer,
@@ -663,30 +673,44 @@ export class Subscriber {
 		stream: Stream,
 	): Promise<void> {
 		const stopped: Promise<null> = Promise.race([track.closed, stream.reader.closed]).then(() => null);
-		let lastSent: number | undefined;
+		let lastSent: track.Subscription = {
+			priority: msg.priority,
+			ordered: msg.ordered,
+			latencyMax: msg.maxLatency,
+			startGroup: msg.startGroup,
+			endGroup: msg.endGroup,
+		};
 
 		for (;;) {
-			const current = track.subscription.peek()?.priority;
-			if (current === undefined || current === lastSent) {
+			const current = track.subscription.peek();
+			if (current === undefined || this.#sameSubscription(current, lastSent)) {
 				// Nothing new to send; wait for a change or termination.
 				const next = await Promise.race([track.subscription.changed(), stopped]);
 				if (next === null) return;
 				continue;
 			}
 
-			// Round-trip the other Subscribe parameters so the publisher doesn't
-			// interpret SUBSCRIBE_UPDATE as a reset of ordered/maxLatency/etc.
 			const update = new SubscribeUpdate({
-				priority: current,
-				ordered: msg.ordered,
-				maxLatency: msg.maxLatency,
-				startGroup: msg.startGroup,
-				endGroup: msg.endGroup,
+				priority: current.priority ?? 0,
+				ordered: current.ordered,
+				maxLatency: current.latencyMax,
+				startGroup: current.startGroup,
+				endGroup: current.endGroup,
 			});
 			await update.encode(stream.writer, this.version);
-			lastSent = current;
-			console.debug(`subscribe update: id=${id} broadcast=${broadcast} track=${track.name} priority=${current}`);
+			lastSent = { ...current };
+			console.debug(`subscribe update: id=${id} broadcast=${broadcast} track=${track.name}`);
 		}
+	}
+
+	#sameSubscription(a: track.Subscription, b: track.Subscription): boolean {
+		return (
+			(a.priority ?? 0) === (b.priority ?? 0) &&
+			(a.ordered ?? false) === (b.ordered ?? false) &&
+			(a.latencyMax ?? 0) === (b.latencyMax ?? 0) &&
+			a.startGroup === b.startGroup &&
+			a.endGroup === b.endGroup
+		);
 	}
 
 	/**

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -198,6 +198,26 @@ test("nextGroup returns buffered groups in sequence", async () => {
 	expect((await track.nextGroup())?.sequence).toBe(5);
 });
 
+test("local cursor bounds can skip, pause, and release buffered groups", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	for (let sequence = 0; sequence < 5; sequence++) producer.writeGroup(new GroupProducer(sequence));
+
+	expect(track.latest()).toBe(4);
+	track.startAt(1);
+	track.endAt(2);
+	expect((await track.nextGroup())?.sequence).toBe(1);
+	expect((await track.nextGroup())?.sequence).toBe(2);
+
+	const pending = track.nextGroup();
+	expect(await Promise.race([pending, Promise.resolve("pending")])).toBe("pending");
+
+	track.startAt(4);
+	track.endAt(4);
+	expect((await pending)?.sequence).toBe(4);
+});
+
 test("recvGroup after nextGroup still returns late arrivals", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -122,15 +122,51 @@ test("appendDatagram rejects a payload over the QUIC datagram frame ceiling", ()
 	expect(() => producer.appendDatagram(Timestamp.fromMillis(0), new Uint8Array(65536))).toThrow();
 });
 
-test("a subscriber update is forwarded to the producer's update signal", async () => {
+test("subscriber options and updates are forwarded to the producer's aggregate", async () => {
 	const producer = new TrackProducer("test");
-	const track = producer.subscribe();
+	const track = producer.subscribe({ startGroup: 0 });
+
+	// The initial options are available before the request is accepted or put on the wire.
+	expect(producer.subscription.peek()).toEqual({
+		priority: 0,
+		ordered: false,
+		latencyMax: 0,
+		startGroup: 0,
+		endGroup: undefined,
+	});
 
 	// The wire layer watches the producer's signal to emit SUBSCRIBE_UPDATE.
-	expect(producer.subscription.peek()).toBeUndefined();
 	const next = producer.subscription.changed();
-	track.update({ priority: 7 });
-	expect((await next)?.priority).toBe(7);
+	track.update({ priority: 7, ordered: true, latencyMax: 250, startGroup: 2, endGroup: 9 });
+	expect(await next).toEqual({ priority: 7, ordered: true, latencyMax: 250, startGroup: 2, endGroup: 9 });
+});
+
+test("multiple subscriber options aggregate like Rust", async () => {
+	const producer = new TrackProducer("test");
+	const bounded = producer.subscribe({ priority: 2, ordered: true, latencyMax: 100, startGroup: 10, endGroup: 20 });
+	const live = producer.subscribe({ priority: 7, ordered: false, latencyMax: 250, startGroup: 5 });
+
+	expect(producer.subscription.peek()).toEqual({
+		priority: 7,
+		ordered: false,
+		latencyMax: 250,
+		startGroup: 5,
+		endGroup: undefined,
+	});
+
+	const narrowed = producer.subscription.changed();
+	live.close();
+	expect(await narrowed).toEqual({
+		priority: 2,
+		ordered: true,
+		latencyMax: 100,
+		startGroup: 10,
+		endGroup: 20,
+	});
+
+	const none = producer.subscription.changed();
+	bounded.close();
+	expect(await none).toBeUndefined();
 });
 
 test("nextGroup skips late arrivals", async () => {

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -79,6 +79,57 @@ export function infoDefaults(info: Partial<Info> = {}): Info {
 export interface Subscription {
 	/** Delivery priority relative to this session's other subscriptions. Defaults to `0`. */
 	priority?: number;
+	/** Whether groups are prioritized in sequence order. Defaults to `false` (newest-first). */
+	ordered?: boolean;
+	/** Maximum age (milliseconds) of a non-latest group before it is skipped. Defaults to `0`. */
+	latencyMax?: number;
+	/** First group the publisher should deliver, or omit to start at the latest group. */
+	startGroup?: number;
+	/** Last group the publisher should deliver (inclusive), or omit for no end. */
+	endGroup?: number;
+}
+
+// Materialize the defaults at the model boundary so every layer observes a complete
+// subscription rather than interpreting an omitted field differently.
+function subscriptionDefaults(subscription: Subscription = {}): Subscription {
+	return {
+		priority: subscription.priority ?? 0,
+		ordered: subscription.ordered ?? false,
+		latencyMax: subscription.latencyMax ?? 0,
+		startGroup: subscription.startGroup,
+		endGroup: subscription.endGroup,
+	};
+}
+
+// Aggregate the preferences of every live subscriber, matching Rust's Subscription::poll_combined.
+function combineSubscriptions(states: Iterable<TrackState>): Subscription | undefined {
+	let combined: Subscription | undefined;
+	for (const state of states) {
+		const subscription = state.update.peek();
+		if (!subscription) continue;
+		if (!combined) {
+			combined = { ...subscription };
+			continue;
+		}
+
+		combined.priority = Math.max(combined.priority ?? 0, subscription.priority ?? 0);
+		combined.ordered = (combined.ordered ?? false) && (subscription.ordered ?? false);
+		combined.latencyMax = Math.max(combined.latencyMax ?? 0, subscription.latencyMax ?? 0);
+
+		if (subscription.startGroup !== undefined) {
+			combined.startGroup =
+				combined.startGroup === undefined
+					? subscription.startGroup
+					: Math.min(combined.startGroup, subscription.startGroup);
+		}
+
+		if (combined.endGroup === undefined || subscription.endGroup === undefined) {
+			combined.endGroup = undefined;
+		} else {
+			combined.endGroup = Math.max(combined.endGroup, subscription.endGroup);
+		}
+	}
+	return combined;
 }
 
 /**
@@ -92,19 +143,26 @@ export interface Subscription {
 export class Request {
 	/** The requested track name. */
 	readonly name: string;
-	/** The subscriber's priority for this track. */
-	readonly priority: number;
 
 	#producer: Producer;
 
-	private constructor(name: string, producer: Producer, priority: number) {
+	private constructor(name: string, producer: Producer) {
 		this.name = name;
 		this.#producer = producer;
-		this.priority = priority;
 	}
 
 	static {
-		hooks.makeRequest = (name, producer, priority) => new Request(name, producer, priority);
+		hooks.makeRequest = (name, producer) => new Request(name, producer);
+	}
+
+	/** The aggregate subscription requested for this track. */
+	get subscription(): Readonly<Subscription> {
+		return this.#producer.subscription.peek() ?? subscriptionDefaults();
+	}
+
+	/** The subscriber's priority for this track. */
+	get priority(): number {
+		return this.subscription.priority ?? 0;
 	}
 
 	/** Accept the request, committing the track's immutable {@link Info}. */
@@ -179,9 +237,13 @@ class TrackState {
 	/** Best-effort datagram channel, parallel to {@link groups}; an age-evicted send buffer per subscriber. */
 	datagrams = new Signal<BufferedDatagram[]>([]);
 	closed = new Once<Error | null>();
-	update = new Signal<Subscription | undefined>(undefined);
+	update: Signal<Subscription | undefined>;
 	/** Resolved once the producer commits the immutable properties. */
 	info = new Signal<Info | undefined>(undefined);
+
+	constructor(subscription?: Subscription) {
+		this.update = new Signal(subscription === undefined ? undefined : subscriptionDefaults(subscription));
+	}
 }
 
 // Settle a track state's closed Once. Idempotent: Once.set throws on a second settle, and a
@@ -275,8 +337,8 @@ export class Producer {
 	}
 
 	/**
-	 * The current subscription, or `undefined` until a subscriber first calls
-	 * {@link Subscriber.update}. The wire layer watches this to emit SUBSCRIBE_UPDATE.
+	 * The aggregate subscription across live subscribers, or `undefined` when there are none.
+	 * The wire layer watches this to emit SUBSCRIBE_UPDATE.
 	 */
 	get subscription(): Getter<Subscription | undefined> {
 		return this.#state.update;
@@ -292,8 +354,8 @@ export class Producer {
 	}
 
 	/** An independent {@link Subscriber} receiving a full copy of this track's groups. */
-	subscribe(): Subscriber {
-		const sink = new TrackState();
+	subscribe(options: Subscription = {}): Subscriber {
+		const sink = new TrackState(options);
 		this.#addSink(sink);
 		return makeSubscriber(this.name, sink);
 	}
@@ -330,9 +392,8 @@ export class Producer {
 
 			// Forward subscription updates from the sink's Subscriber to the producer's own
 			// state, which the wire layer (or the serving application) watches.
-			const forward = sink.update.subscribe((update) => {
-				if (update) this.#state.update.set(update, true);
-			});
+			const forward = sink.update.subscribe(() => this.#updateSubscription());
+			this.#updateSubscription();
 
 			// Drop the sink once its consumer goes away, closing its mirrors so source
 			// groups stop teeing into them, so a long-lived producer doesn't leak. This
@@ -343,6 +404,7 @@ export class Producer {
 				const abort = c instanceof Error ? c : undefined;
 				forward();
 				this.#sinks.delete(sink);
+				this.#updateSubscription();
 				for (const entry of this.#cache) {
 					const mirror = entry.mirrors.get(sink);
 					if (mirror) {
@@ -363,6 +425,12 @@ export class Producer {
 		for (const entry of this.#cache) this.#mirror(entry, sink);
 
 		if (closed !== undefined) closeTrackState(sink, closed instanceof Error ? closed : undefined);
+	}
+
+	// Recompute from every live sink because an update or close can narrow as well as widen
+	// the aggregate. The wire layer observes this signal and emits SUBSCRIBE_UPDATE.
+	#updateSubscription(): void {
+		this.#state.update.set(combineSubscriptions(this.#sinks));
 	}
 
 	// Mirror a cached source group into a sink. The mirror fills synchronously as the
@@ -564,7 +632,7 @@ export class Subscriber {
 		return this.#state.closed;
 	}
 
-	/** The last {@link update} requested on this subscriber, or `undefined` if none yet. */
+	/** This subscriber's current options, including defaults and the last {@link update}. */
 	get subscription(): Getter<Subscription | undefined> {
 		return this.#state.update;
 	}
@@ -758,6 +826,6 @@ export class Subscriber {
 	 * publisher. Mirrors the Rust `Subscriber::update`.
 	 */
 	update(options: Subscription) {
-		this.#state.update.set(options, true);
+		this.#state.update.set(subscriptionDefaults(options));
 	}
 }

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -650,7 +650,11 @@ export class Subscriber {
 		this.#cursor.update((cursor) => ({ ...cursor, start: sequence }));
 	}
 
-	/** Cap this subscriber's sequence-ordered cursor at `sequence` inclusively, or omit it to remove the cap. */
+	/**
+	 * Cap {@link nextGroup} at `sequence` inclusively, or omit it to remove the cap.
+	 * Groups above the cap remain buffered and become readable if the cap is raised.
+	 * This local cursor does not change the subscription's wire request.
+	 */
 	endAt(sequence?: number): void {
 		this.#cursor.update((cursor) => ({ ...cursor, end: sequence }));
 	}

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -236,6 +236,7 @@ class TrackState {
 	groups = new Signal<GroupConsumer[]>([]);
 	/** Best-effort datagram channel, parallel to {@link groups}; an age-evicted send buffer per subscriber. */
 	datagrams = new Signal<BufferedDatagram[]>([]);
+	latest?: number;
 	closed = new Once<Error | null>();
 	update: Signal<Subscription | undefined>;
 	/** Resolved once the producer commits the immutable properties. */
@@ -439,6 +440,7 @@ export class Producer {
 	#mirror(entry: CachedGroup, sink: TrackState): void {
 		const dst = entry.group.mirror();
 		entry.mirrors.set(sink, dst);
+		sink.latest = Math.max(sink.latest ?? 0, dst.sequence);
 		sink.groups.mutate((groups) => {
 			groups.push(dst);
 			groups.sort((a, b) => a.sequence - b.sequence);
@@ -606,6 +608,7 @@ export class Subscriber {
 
 	#state: TrackState;
 	#nextSequence = 0;
+	#cursor = new Signal<{ start: number; end?: number }>({ start: 0 });
 
 	private constructor(name: string, state: TrackState) {
 		this.name = name;
@@ -637,6 +640,21 @@ export class Subscriber {
 		return this.#state.update;
 	}
 
+	/** Return the latest group sequence observed on this track, if any. */
+	latest(): number | undefined {
+		return this.#state.latest;
+	}
+
+	/** Start this subscriber's local read cursor at `sequence`, without changing its wire request. */
+	startAt(sequence: number): void {
+		this.#cursor.update((cursor) => ({ ...cursor, start: sequence }));
+	}
+
+	/** Cap this subscriber's sequence-ordered cursor at `sequence` inclusively, or omit it to remove the cap. */
+	endAt(sequence?: number): void {
+		this.#cursor.update((cursor) => ({ ...cursor, end: sequence }));
+	}
+
 	/** Close the track (optionally with an error), closing any pending groups. Idempotent. */
 	close(abort?: Error) {
 		if (!closeTrackState(this.#state, abort)) return;
@@ -654,6 +672,8 @@ export class Subscriber {
 	async recvGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
 			const groups = this.#state.groups.peek();
+			const { start } = this.#cursor.peek();
+			while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
 			if (groups.length > 0) {
 				return groups.shift();
 			}
@@ -662,7 +682,7 @@ export class Subscriber {
 			if (closed instanceof Error) throw closed;
 			if (closed !== undefined) return undefined;
 
-			await Signal.race(this.#state.groups, this.#state.closed);
+			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}
 	}
 
@@ -708,14 +728,23 @@ export class Subscriber {
 	 */
 	async nextGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
-			const group = await this.recvGroup();
-			if (!group) return undefined;
-			if (group.sequence < this.#nextSequence) {
-				group.close();
-				continue;
+			const groups = this.#state.groups.peek();
+			const cursor = this.#cursor.peek();
+			const start = Math.max(cursor.start, this.#nextSequence);
+			while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
+
+			const group = groups[0];
+			if (group && (cursor.end === undefined || group.sequence <= cursor.end)) {
+				groups.shift();
+				this.#nextSequence = group.sequence + 1;
+				return group;
 			}
-			this.#nextSequence = group.sequence + 1;
-			return group;
+
+			const closed = this.#state.closed.peek();
+			if (closed instanceof Error) throw closed;
+			if (closed !== undefined && !group) return undefined;
+
+			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}
 	}
 
@@ -735,6 +764,8 @@ export class Subscriber {
 	async readFrameSequence(): Promise<({ group: number; frame: number } & Frame) | undefined> {
 		for (;;) {
 			const groups = this.#state.groups.peek();
+			const { start } = this.#cursor.peek();
+			while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
 
 			// Drain older groups first, dropping each once empty.
 			while (groups.length > 1) {
@@ -760,7 +791,7 @@ export class Subscriber {
 				const closed = this.#state.closed.peek();
 				if (closed instanceof Error) throw closed;
 				if (closed !== undefined) return undefined;
-				await Signal.race(this.#state.groups, this.#state.closed);
+				await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 				continue;
 			}
 
@@ -794,7 +825,7 @@ export class Subscriber {
 
 			// Lone open group with nothing buffered yet: wait for a frame on it, a new group, or
 			// the track closing.
-			await Promise.race([Signal.race(this.#state.groups, this.#state.closed), group.readable()]);
+			await Promise.race([Signal.race(this.#state.groups, this.#cursor, this.#state.closed), group.readable()]);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- expose `ordered`, `latencyMax`, `startGroup`, and `endGroup` on the JavaScript `Subscription` API
- carry the complete subscription through initial Lite SUBSCRIBE messages and later SUBSCRIBE_UPDATE messages
- aggregate deduplicated local subscribers using the same rules as Rust and expose the aggregate on track requests
- apply initial and updated Lite group bounds through a Rust-style local subscriber cursor
- re-rank pending track requests using their current aggregate priority
- bump `@moq/net` from 0.2.4 to 0.2.5

The Lite wire types already encoded these fields, but the public JavaScript model and request plumbing retained only `priority`. This made values such as `startGroup: 0` impossible to request from JavaScript. The publisher also stored group bounds without applying them to its serving cursor.

## Public API changes

- additive fields on `track.Subscription`: `ordered`, `latencyMax`, `startGroup`, and `endGroup`
- additive `Request.subscription` getter for the aggregate request
- additive optional `Subscription` argument on `track.Producer.subscribe`
- additive `Subscriber.latest()`, `Subscriber.startAt()`, and `Subscriber.endAt()` local cursor methods

The IETF adapter is unchanged. No draft update is needed because the Lite wire format itself did not change.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just js test`
- `nix develop --command bun run build` from `js/net`

(Written by GPT-5)