### PR TITLE
chore: update web-transport dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10031,9 +10031,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.6.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4029,6 +4029,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kio"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdaadab1a06c04819b8f7cabe4ead8c9f1e86016c4c2a9384829bbc555f477a7"
+dependencies = [
+ "loom",
+ "smallvec",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,7 +4523,7 @@ dependencies = [
  "bytes",
  "hang",
  "humantime",
- "kio",
+ "kio 0.5.4",
  "m3u8-rs",
  "moq-mux",
  "moq-net",
@@ -4534,7 +4544,7 @@ dependencies = [
  "bytes",
  "criterion",
  "json-patch",
- "kio",
+ "kio 0.5.4",
  "moq-flate",
  "moq-net",
  "serde",
@@ -4572,7 +4582,7 @@ dependencies = [
  "futures",
  "h264-parser",
  "hang",
- "kio",
+ "kio 0.5.4",
  "memchr",
  "moq-json",
  "moq-loc",
@@ -4658,7 +4668,7 @@ dependencies = [
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "kio",
+ "kio 0.5.4",
  "loom",
  "num_enum",
  "rand 0.10.2",
@@ -6678,9 +6688,9 @@ dependencies = [
 
 [[package]]
 name = "qmux"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a824572a7e027bd1d78ddd0df76447a810b881868dfee2cabdfe0e6301e24e5"
+checksum = "98b28b59b131430bbfcc6687e98f33e0edd7d908e325c76583d62a9c4c876e53"
 dependencies = [
  "bytes",
  "futures",
@@ -9678,13 +9688,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-iroh"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34a91cf241951b8fe02ff216fdf16fc0a52b910568053652d546ded52399f77"
+checksum = "14c292c05ff2f4df8e582244a6a5f2ba89f4c13b1170ec5f59a727f9a4624baf"
 dependencies = [
  "bytes",
  "http",
  "iroh",
+ "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-error",
  "n0-future",
  "tokio",
@@ -9696,13 +9707,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-noq"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0344a32000bbf11bd30e3c1244d223baac316c2a25e06eb638b5ca9322d589"
+checksum = "56dfe08820de549204c3ab02e901c4a316616ba7daae26df4478a86f4a2d48cd"
 dependencies = [
  "bytes",
  "futures",
  "http",
+ "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -9730,15 +9742,16 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quiche"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3599414f964f4f1132dc8bd8f6c497b7a7b97043e4d5de53abbc155527d48fdf"
+checksum = "153ece42b1d6e86015fcac192b6d4aae0ac8595045e844ac075169b22f1d37c6"
 dependencies = [
  "boring",
  "bytes",
  "flume",
  "futures",
  "http",
+ "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-pki-types",
  "thiserror 2.0.19",
  "tokio",
@@ -9751,13 +9764,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quinn"
-version = "0.11.12"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ada8c56f3dc126fa3c9e6b8f31f3bff5dfd24458f6664743d936ecad741d15"
+checksum = "0b494e7a90c7c576bac11d7506128cea266d63ed9a8b0be39269c7b9ea402a5e"
 dependencies = [
  "bytes",
  "futures",
  "http",
+ "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quinn",
  "rustls",
  "rustls-native-certs",
@@ -9771,9 +9785,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-trait"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6394e09415ddc1e7c88d605443a3d2f333bf278f74c17020a2b6c44e97507883"
+checksum = "2a916df726e858e8e6cc21e852129f59e6277d3a01bb2254c0506dcf829fdd5d"
 dependencies = [
  "bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,22 +114,22 @@ moq-transcode = { version = "0.0.8", path = "rs/moq-transcode", default-features
 moq-vaapi = "0.0.3"
 moq-video = { version = "0.0.14", path = "rs/moq-video", default-features = false }
 percent-encoding = "2"
-qmux = { version = "0.4.0", default-features = false }
+qmux = { version = "0.5.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
 subtle = "2.6"
 tempfile = "3"
 tokio = "1.48"
 web-async = { version = "0.1.5", features = ["tracing"] }
-web-transport-iroh = "0.6"
+web-transport-iroh = "0.7"
 # default-features off so the QUIC crypto provider is chosen by moq-native's
 # aws-lc-rs / ring features (mirroring how the quinn dependency is wired).
-# 0.2.1 for the `qlog` passthrough feature moq-native's `qlog` forwards to.
-web-transport-noq = { version = "0.2.1", default-features = false }
+# 0.3 for the `qlog` passthrough feature moq-native's `qlog` forwards to.
+web-transport-noq = { version = "0.3", default-features = false }
 web-transport-proto = "0.6"
-web-transport-quiche = "0.5"
-web-transport-quinn = "0.11"
-web-transport-trait = "0.3.4"
+web-transport-quiche = "0.6"
+web-transport-quinn = "0.12"
+web-transport-trait = "0.4"
 
 [profile.dev]
 panic = "abort"

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -368,19 +368,7 @@ impl NoqClient {
 			"https" => web_transport_noq::Session::connect(connection, request)
 				.await
 				.map_err(map_client_error)?,
-			"moqt" | "moql" => {
-				let handshake = connection
-					.handshake_data()
-					.ok_or(Error::MissingHandshake)?
-					.downcast::<noq::crypto::rustls::HandshakeData>()
-					.unwrap();
-
-				let alpn = handshake.protocol.ok_or(Error::MissingAlpn)?;
-				let alpn = String::from_utf8(alpn)?;
-
-				let response = web_transport_noq::proto::ConnectResponse::OK.with_protocol(alpn);
-				web_transport_noq::Session::raw(connection, request, response)
-			}
+			"moqt" | "moql" => web_transport_noq::Session::raw(connection),
 			_ => return Err(Error::UnsupportedScheme(url.scheme().to_string())),
 		};
 
@@ -650,22 +638,9 @@ pub(crate) async fn accept(
 		// this covers opt-in / work-in-progress versions (e.g. moq-lite-06-wip) that are
 		// deliberately absent from `moq_net::ALPNS`.
 		alpn if alpns.contains(&alpn) => {
-			// Raw QUIC carries no in-band request URL like WebTransport's CONNECT, so the TLS
-			// SNI is the only authority the client can offer, and it's optional. A client dialing
-			// a bare IP sends no SNI (RFC 6066 forbids IP literals), leaving `host` empty; the
-			// resulting hostless `moqt://` routes to the root path, exactly like a URL-less stream
-			// transport. `url()` returns `None` for the raw variant either way.
-			let host_str = if host.contains(':') {
-				format!("[{}]", host)
-			} else {
-				host.clone()
-			};
-			let url = format!("moqt://{}", host_str).parse::<Url>().map_err(Error::BuildUrl)?;
-			let request = web_transport_noq::proto::ConnectRequest::new(url);
-			let response = web_transport_noq::proto::ConnectResponse::OK.with_protocol(alpn);
 			let identity = crate::tls::PeerIdentity::from_any(conn.peer_identity());
 			// Raw QUIC carries no request URL; the path rides the SETUP.
-			let session = web_transport_noq::Session::raw(conn, request, response);
+			let session = web_transport_noq::Session::raw(conn);
 			Ok((session, None, identity))
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn)),

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -12,7 +12,6 @@ use std::net;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 use url::Url;
-use web_transport_quiche::proto::ConnectRequest;
 
 /// Re-exported because this module's public API exposes its types. A major
 /// `web-transport-quiche` bump is therefore a breaking change for this crate.
@@ -380,11 +379,7 @@ impl QuicheClient {
 			}
 			"moqt" | "moql" => {
 				// Raw QUIC mode
-				let alpn = conn.alpn().ok_or(Error::MissingAlpn)?;
-				let alpn = std::str::from_utf8(&alpn)?;
-
-				let response = web_transport_quiche::proto::ConnectResponse::OK.with_protocol(alpn);
-				Ok(web_transport_quiche::Connection::raw(conn, request, response))
+				Ok(web_transport_quiche::Connection::raw(conn))
 			}
 			_ => unreachable!("unsupported URL scheme: {}", url.scheme()),
 		}
@@ -738,10 +733,8 @@ pub(crate) async fn accept(
 		// not the global default set, so opt-in / work-in-progress versions (e.g.
 		// moq-lite-06-wip) that are deliberately absent from `moq_net::ALPNS` still work.
 		alpn if alpns.contains(&alpn) => {
-			let request = ConnectRequest::new("moqt://".to_string().parse::<Url>().unwrap());
-			let response = web_transport_quiche::proto::ConnectResponse::OK.with_protocol(alpn);
 			// Raw QUIC carries no request URL; the path rides the SETUP.
-			let session = web_transport_quiche::Connection::raw(conn, request, response);
+			let session = web_transport_quiche::Connection::raw(conn);
 			Ok((session, None, identity))
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn.to_string())),

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -381,19 +381,7 @@ impl QuinnClient {
 			"https" => web_transport_quinn::Session::connect(connection, request)
 				.await
 				.map_err(map_client_error)?,
-			"moqt" | "moql" => {
-				let handshake = connection
-					.handshake_data()
-					.ok_or(Error::MissingHandshake)?
-					.downcast::<quinn::crypto::rustls::HandshakeData>()
-					.unwrap();
-
-				let alpn = handshake.protocol.ok_or(Error::MissingAlpn)?;
-				let alpn = String::from_utf8(alpn)?;
-
-				let response = web_transport_quinn::proto::ConnectResponse::OK.with_protocol(alpn);
-				web_transport_quinn::Session::raw(connection, request, response)
-			}
+			"moqt" | "moql" => web_transport_quinn::Session::raw(connection),
 			_ => return Err(Error::UnsupportedScheme(url.scheme().to_string())),
 		};
 
@@ -662,22 +650,9 @@ pub(crate) async fn accept(
 		// this covers opt-in / work-in-progress versions (e.g. moq-lite-06-wip) that are
 		// deliberately absent from `moq_net::ALPNS`.
 		alpn if alpns.contains(&alpn) => {
-			// Raw QUIC carries no in-band request URL like WebTransport's CONNECT, so the TLS
-			// SNI is the only authority the client can offer, and it's optional. A client dialing
-			// a bare IP sends no SNI (RFC 6066 forbids IP literals), leaving `host` empty; the
-			// resulting hostless `moqt://` routes to the root path, exactly like a URL-less stream
-			// transport. `url()` returns `None` for the raw variant either way.
-			let host_str = if host.contains(':') {
-				format!("[{}]", host)
-			} else {
-				host.clone()
-			};
-			let url = format!("moqt://{}", host_str).parse::<Url>().map_err(Error::BuildUrl)?;
-			let request = web_transport_quinn::proto::ConnectRequest::new(url);
-			let response = web_transport_quinn::proto::ConnectResponse::OK.with_protocol(alpn);
 			let identity = crate::tls::PeerIdentity::from_any(conn.peer_identity());
 			// Raw QUIC carries no request URL; the path rides the SETUP.
-			let session = web_transport_quinn::Session::raw(conn, request, response);
+			let session = web_transport_quinn::Session::raw(conn);
 			Ok((session, None, identity))
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn)),

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -5,8 +5,8 @@
 //! a small head start ([`Client::delay`]), so WebSocket only wins when QUIC can't get
 //! through. Servers accept it on a separate TCP port via [`Listener`].
 
-use qmux::tokio_tungstenite;
-use qmux::tokio_tungstenite::tungstenite::{self, http};
+use qmux::ws::tokio_tungstenite;
+use qmux::ws::tokio_tungstenite::tungstenite::{self, http};
 use std::collections::HashSet;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::{net, time};
@@ -185,10 +185,10 @@ pub(crate) async fn connect(
 	// restricts. qmux also offers the bare ALPNs (`qmux-01`, `qmux-00`,
 	// `webtransport`) by default so we still interop with relays that only know a
 	// wire-format version.
-	let session = qmux::Client::new()
+	let session = qmux::ws::Client::new()
 		.with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))))
 		.with_connector(connector)
-		.with_keep_alive(qmux::KeepAlive::default()) // 5s ping / 30s deadline, parity with QUIC
+		.with_keep_alive(qmux::ws::KeepAlive::default()) // 5s ping / 30s deadline, parity with QUIC
 		.connect(url.as_str())
 		.await
 		.map_err(Error::Connect)?;
@@ -243,7 +243,7 @@ impl Error {
 /// alongside QUIC connections on a separate port.
 pub struct Listener {
 	listener: tokio::net::TcpListener,
-	server: qmux::Server,
+	server: qmux::ws::Server,
 	health: crate::accept::Health,
 }
 
@@ -259,7 +259,7 @@ impl Listener {
 		// `qmux_versions_for` returns `&[]` (every QMux draft) for ALPNs the spec
 		// doesn't restrict; qmux by default also accepts legacy clients that
 		// only offer a bare wire-format ALPN (today's moq-net clients still do).
-		let server = qmux::Server::new().with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))));
+		let server = qmux::ws::Server::new().with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))));
 		Ok(Self {
 			listener,
 			server,

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -1,5 +1,5 @@
 use futures::{Sink, Stream};
-use qmux::tungstenite;
+use qmux::ws::tungstenite;
 use std::{
 	pin::Pin,
 	sync::{Arc, atomic::Ordering},
@@ -101,7 +101,7 @@ where
 	// broadcast it published stays announced for that entire window and the
 	// announce propagates to the rest of the cluster. QUIC gets this from its
 	// idle timeout; WebSocket has no equivalent of its own.
-	let upgraded = qmux::ws::Upgraded::new(socket).with_keep_alive(qmux::KeepAlive::default());
+	let upgraded = qmux::ws::Upgraded::new(socket).with_keep_alive(qmux::ws::KeepAlive::default());
 	let upgraded = match alpn.as_deref() {
 		Some(alpn) => upgraded.with_alpn(alpn),
 		None => upgraded,
@@ -377,7 +377,7 @@ mod tests {
 	}
 
 	/// The newest moq ALPN both sides agree on. Derived from the same source
-	/// of truth that `supported_subprotocols` and `qmux::Client::with_protocols`
+	/// of truth that `supported_subprotocols` and `qmux::ws::Client::with_protocols`
 	/// consume, so adding a new ALPN doesn't break these tests independently
 	/// of the production logic.
 	fn newest_moq_alpn() -> &'static str {
@@ -611,7 +611,7 @@ mod tests {
 	async fn axum_ws_negotiates_newest_moq_alpn() {
 		let (addr, mut rx) = spawn_test_server().await;
 
-		let session = qmux::Client::new()
+		let session = qmux::ws::Client::new()
 			.with_protocols(moq_net::ALPNS.iter().map(|&a| (a, &[] as &[qmux::Version])))
 			.connect(&format!("ws://{addr}/"))
 			.await
@@ -650,7 +650,7 @@ mod tests {
 				continue;
 			};
 
-			let session = qmux::Client::new()
+			let session = qmux::ws::Client::new()
 				.with_protocol(app, &[version])
 				.connect(&url)
 				.await
@@ -672,7 +672,7 @@ mod tests {
 		// rather than failing: we always accept a bare web-transport connection, and
 		// there's no other qmux version worth negotiating for moqt-18. It just never
 		// lands on `moqt-18`.
-		let session = qmux::Client::new()
+		let session = qmux::ws::Client::new()
 			.with_protocol("moqt-18", &[qmux::Version::QMux00])
 			.connect(&url)
 			.await


### PR DESCRIPTION
## Summary

- Update QMux and the Iroh, Noq, Quiche, Quinn, and trait WebTransport dependencies to the releases from moq-dev/web-transport#338.
- Adapt raw QUIC sessions to the new connection-only constructors and move QMux WebSocket types under `qmux::ws`.
- Keep `web-transport-proto` at `0.6.0`: crates.io already contains an unrelated, yanked `0.6.1` from 2024, so the current upstream release was skipped and must use a new version such as `0.6.2`.
- Downgrade transitive `wide` from yanked `1.6.0` to `1.5.0`, fixing the cargo-deny failure inherited from `dev`.

## Public API changes

- Breaking: `moq-native` publicly re-exports new major versions of `web-transport-iroh`, `web-transport-noq`, `web-transport-quiche`, and `web-transport-quinn`. In particular, the raw session constructors now take only the underlying QUIC connection. This PR therefore targets `dev`.
- No MoQ-owned public function signatures change.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just rs test -p moq-native -p moq-relay`
- `nix develop --command just ci`

## Cross-package sync

- No wire format, `moq-ffi`, CLI, or documented configuration surface changed, so no paired package or documentation updates are required.

(Written by GPT-5)