### PR TITLE
fix(net): invert stream priority to match transport send-order semantics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/src/ietf/priority.test.ts
+++ b/js/net/src/ietf/priority.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { fromWire, toWire } from "./priority.ts";
+
+test("IETF subscriber priority is lower first", () => {
+	expect(fromWire(0)).toBe(0xff);
+	expect(fromWire(0xff)).toBe(0);
+	expect(toWire(0xff)).toBe(0);
+	expect(toWire(0)).toBe(0xff);
+
+	for (let priority = 0; priority < 0xff; priority++) {
+		expect(fromWire(priority)).toBeGreaterThan(fromWire(priority + 1));
+	}
+});
+
+test("subscriber priority round trips", () => {
+	for (let priority = 0; priority <= 0xff; priority++) {
+		expect(fromWire(toWire(priority))).toBe(priority);
+	}
+});

--- a/js/net/src/ietf/priority.ts
+++ b/js/net/src/ietf/priority.ts
@@ -1,0 +1,9 @@
+/** Convert an IETF subscriber priority into the model's higher-first priority. */
+export function fromWire(priority: number): number {
+	return 0xff - priority;
+}
+
+/** Convert the model's higher-first priority into an IETF subscriber priority. */
+export function toWire(priority: number): number {
+	return 0xff - priority;
+}

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -7,6 +7,7 @@ import { type Stream, Writer } from "../stream.ts";
 import type { Timescale } from "../time.ts";
 import type { Session } from "./adapter.ts";
 import { Frame, Group as GroupMessage } from "./object.ts";
+import { fromWire } from "./priority.ts";
 import { PublishDone } from "./publish.ts";
 import { PublishNamespace, PublishNamespaceDone, PublishNamespaceOk } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
@@ -99,7 +100,7 @@ export class Publisher {
 			return;
 		}
 
-		const track = broadcast.subscribe(msg.trackName, { priority: msg.subscriberPriority });
+		const track = broadcast.subscribe(msg.trackName, { priority: fromWire(msg.subscriberPriority) });
 
 		try {
 			// Declaring the timescale is what opts the track into timestamps; every object

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -11,6 +11,7 @@ import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
 import { TrackAliases } from "./aliases.ts";
 import { Frame, type Group as GroupMessage } from "./object.ts";
+import { toWire } from "./priority.ts";
 import { type Publish, PublishError } from "./publish.ts";
 import { type PublishNamespace, PublishNamespaceError, PublishNamespaceOk } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
@@ -353,7 +354,7 @@ export class Subscriber {
 			requestId,
 			trackNamespace: broadcast,
 			trackName: request.name,
-			subscriberPriority: request.priority,
+			subscriberPriority: toWire(request.priority),
 		});
 		await msg.encode(state.stream.writer, version);
 		console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.name}`);

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -149,3 +149,21 @@ impl<S: web_transport_trait::SendStream, V> Drop for Writer<S, V> {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::lite::test_transport::{Log, SinkSend};
+
+	#[test]
+	fn set_priority_forwards_send_order() {
+		let log = Log::default();
+		let mut writer = Writer::new(SinkSend::new(log.clone()), crate::lite::Version::Lite05);
+
+		for send_order in 0u8..=255 {
+			writer.set_priority(send_order);
+		}
+
+		assert_eq!(log.priorities(), (0u8..=255).collect::<Vec<_>>());
+	}
+}

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -112,9 +112,14 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 		Ok(())
 	}
 
-	/// Set the priority of the stream.
-	pub fn set_priority(&mut self, priority: u8) {
-		self.stream.as_mut().unwrap().set_priority(priority);
+	/// Set the transmission urgency of the stream: 0 is the most urgent, 255 the least.
+	///
+	/// This is the convention of the lite priority queue rank and the IETF subscriber
+	/// priority. The transport trait uses the opposite one (higher values are sent first,
+	/// matching W3C `sendOrder` and quinn), so the urgency is inverted here, at the one
+	/// point where every group stream's priority crosses into the transport.
+	pub fn set_priority(&mut self, urgency: u8) {
+		self.stream.as_mut().unwrap().set_priority(u8::MAX - urgency);
 	}
 
 	/// Cast the writer to a different version, used during version negotiation.
@@ -142,5 +147,35 @@ impl<S: web_transport_trait::SendStream, V> Drop for Writer<S, V> {
 			// Unlike the Quinn default, we abort the stream on drop.
 			stream.reset(Error::Cancel.to_code());
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::lite::test_transport::{Log, SinkSend};
+
+	/// The urgency-to-send-order conversion. Callers pass urgency (0 = most urgent,
+	/// the convention of the lite priority queue and IETF subscriber priority), but
+	/// the transport trait sends HIGHER values first (W3C sendOrder / quinn). The
+	/// most urgent stream must therefore receive the largest send order, strictly
+	/// decreasing as urgency drops. Without the conversion the transport drains the
+	/// stalest stream first.
+	#[test]
+	fn set_priority_inverts_urgency_to_send_order() {
+		let log = Log::default();
+		let mut writer = Writer::new(SinkSend::new(log.clone()), crate::lite::Version::Lite05);
+
+		for urgency in 0u8..=255 {
+			writer.set_priority(urgency);
+		}
+
+		let sent = log.priorities();
+		assert_eq!(sent.first(), Some(&255), "urgency 0 must map to the highest send order");
+		assert_eq!(sent.last(), Some(&0), "urgency 255 must map to the lowest send order");
+		assert!(
+			sent.windows(2).all(|w| w[0] > w[1]),
+			"send order must strictly decrease as urgency drops: {sent:?}",
+		);
 	}
 }

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -112,14 +112,14 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 		Ok(())
 	}
 
-	/// Set the transmission urgency of the stream: 0 is the most urgent, 255 the least.
+	/// Set the stream's send order: streams with HIGHER values are transmitted first.
 	///
-	/// This is the convention of the lite priority queue rank and the IETF subscriber
-	/// priority. The transport trait uses the opposite one (higher values are sent first,
-	/// matching W3C `sendOrder` and quinn), so the urgency is inverted here, at the one
-	/// point where every group stream's priority crosses into the transport.
-	pub fn set_priority(&mut self, urgency: u8) {
-		self.stream.as_mut().unwrap().set_priority(u8::MAX - urgency);
+	/// This is the transport trait's convention (matching W3C `sendOrder` and quinn's
+	/// scheduler) and the model's [`Subscription::priority`](crate::track::Subscription),
+	/// where higher values preempt lower ones. The lite priority queue's rank is the
+	/// opposite (0 = most urgent); rank holders convert via `PriorityHandle::send_order`.
+	pub fn set_priority(&mut self, send_order: u8) {
+		self.stream.as_mut().unwrap().set_priority(send_order);
 	}
 
 	/// Cast the writer to a different version, used during version negotiation.
@@ -147,35 +147,5 @@ impl<S: web_transport_trait::SendStream, V> Drop for Writer<S, V> {
 			// Unlike the Quinn default, we abort the stream on drop.
 			stream.reset(Error::Cancel.to_code());
 		}
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use crate::lite::test_transport::{Log, SinkSend};
-
-	/// The urgency-to-send-order conversion. Callers pass urgency (0 = most urgent,
-	/// the convention of the lite priority queue and IETF subscriber priority), but
-	/// the transport trait sends HIGHER values first (W3C sendOrder / quinn). The
-	/// most urgent stream must therefore receive the largest send order, strictly
-	/// decreasing as urgency increases. Without the conversion the transport drains
-	/// the stalest stream first.
-	#[test]
-	fn set_priority_inverts_urgency_to_send_order() {
-		let log = Log::default();
-		let mut writer = Writer::new(SinkSend::new(log.clone()), crate::lite::Version::Lite05);
-
-		for urgency in 0u8..=255 {
-			writer.set_priority(urgency);
-		}
-
-		let sent = log.priorities();
-		assert_eq!(sent.first(), Some(&255), "urgency 0 must map to the highest send order");
-		assert_eq!(sent.last(), Some(&0), "urgency 255 must map to the lowest send order");
-		assert!(
-			sent.windows(2).all(|w| w[0] > w[1]),
-			"send order must strictly decrease as urgency increases: {sent:?}",
-		);
 	}
 }

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -159,8 +159,8 @@ mod tests {
 	/// the convention of the lite priority queue and IETF subscriber priority), but
 	/// the transport trait sends HIGHER values first (W3C sendOrder / quinn). The
 	/// most urgent stream must therefore receive the largest send order, strictly
-	/// decreasing as urgency drops. Without the conversion the transport drains the
-	/// stalest stream first.
+	/// decreasing as urgency increases. Without the conversion the transport drains
+	/// the stalest stream first.
 	#[test]
 	fn set_priority_inverts_urgency_to_send_order() {
 		let log = Log::default();
@@ -175,7 +175,7 @@ mod tests {
 		assert_eq!(sent.last(), Some(&0), "urgency 255 must map to the lowest send order");
 		assert!(
 			sent.windows(2).all(|w| w[0] > w[1]),
-			"send order must strictly decrease as urgency drops: {sent:?}",
+			"send order must strictly decrease as urgency increases: {sent:?}",
 		);
 	}
 }

--- a/rs/moq-net/src/ietf/mod.rs
+++ b/rs/moq-net/src/ietf/mod.rs
@@ -15,6 +15,7 @@ mod group;
 mod location;
 pub mod message;
 mod namespace;
+mod priority;
 mod properties;
 mod publish;
 mod publish_namespace;

--- a/rs/moq-net/src/ietf/priority.rs
+++ b/rs/moq-net/src/ietf/priority.rs
@@ -1,0 +1,30 @@
+//! Priority conversion between the IETF wire and the MoQ model.
+
+/// Convert an IETF subscriber priority into the model's higher-first priority.
+pub(super) const fn from_wire(priority: u8) -> u8 {
+	u8::MAX - priority
+}
+
+/// Convert the model's higher-first priority into an IETF subscriber priority.
+pub(super) const fn to_wire(priority: u8) -> u8 {
+	u8::MAX - priority
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn ietf_priority_is_lower_first() {
+		assert_eq!(from_wire(0), u8::MAX);
+		assert_eq!(from_wire(u8::MAX), 0);
+		assert_eq!(to_wire(u8::MAX), 0);
+		assert_eq!(to_wire(0), u8::MAX);
+		assert!((0u8..u8::MAX).all(|priority| from_wire(priority) > from_wire(priority + 1)));
+	}
+
+	#[test]
+	fn priority_round_trips() {
+		assert!((0u8..=u8::MAX).all(|priority| from_wire(to_wire(priority)) == priority));
+	}
+}

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -403,7 +403,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		};
 
 		let subscription = Subscription {
-			priority: msg.subscriber_priority,
+			priority: super::priority::from_wire(msg.subscriber_priority),
 			..Default::default()
 		};
 
@@ -600,8 +600,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let stream = session.open_uni().await.map_err(Error::from_transport)?;
 
 		let mut stream = Writer::new(stream, version);
-		// Set through the Writer so the IETF subscriber priority (lower = more urgent)
-		// is converted to the transport's send order (higher = sent first).
 		stream.set_priority(priority);
 
 		stream.encode(&msg).await?;

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -665,10 +665,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 		}
 
-		stream.finish()?;
-
-		// Wait until everything is acknowledged by the peer so we can still cancel the stream.
-		stream.closed().await?;
+		// Consume the writer: close() waits for the peer to acknowledge everything,
+		// and taking ownership disarms the Drop fallback that would otherwise reset
+		// the finished stream with a spurious Cancel.
+		stream.close().await?;
 
 		tracing::debug!(sequence = %msg.group_id, "finished group");
 

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1168,6 +1168,48 @@ struct NamespaceRequest<S: web_transport_trait::Session> {
 }
 
 #[cfg(test)]
+mod group_priority_test {
+	use super::*;
+	use crate::lite::test_transport::SinkSession;
+
+	/// The model's `Subscription::priority` is higher-first ("higher values preempt
+	/// lower ones"), matching the transport trait's send order, so a group stream must
+	/// receive the model value unchanged. An inversion here would transmit the
+	/// LOWEST-priority track first under contention.
+	#[tokio::test]
+	async fn group_stream_preserves_model_priority() {
+		let log = crate::lite::test_transport::Log::default();
+		let session = SinkSession::new(log.clone());
+
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
+		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+		group
+			.write_frame(crate::Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
+			.unwrap();
+		let consumer = group.consume();
+		group.finish().unwrap();
+
+		let msg = ietf::GroupHeader {
+			track_alias: 0,
+			group_id: 0,
+			sub_group_id: 0,
+			publisher_priority: 0,
+			flags: Default::default(),
+		};
+
+		Publisher::<SinkSession>::run_group(session, msg, 200, consumer, Timescale::default(), Version::Draft14)
+			.await
+			.unwrap();
+
+		assert_eq!(
+			log.priorities(),
+			vec![200],
+			"model priority must pass through unchanged"
+		);
+	}
+}
+
+#[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::lite::test_transport::SinkSession;

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -2,7 +2,6 @@ use crate::{group, origin, track};
 use std::{collections::HashMap, task::Poll};
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
-use web_transport_trait::SendStream;
 
 use crate::{
 	AsPath, Error, Timescale,
@@ -598,10 +597,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		timescale: Timescale,
 		version: Version,
 	) -> Result<(), Error> {
-		let mut stream = session.open_uni().await.map_err(Error::from_transport)?;
-		stream.set_priority(priority);
+		let stream = session.open_uni().await.map_err(Error::from_transport)?;
 
 		let mut stream = Writer::new(stream, version);
+		// Set through the Writer so the IETF subscriber priority (lower = more urgent)
+		// is converted to the transport's send order (higher = sent first).
+		stream.set_priority(priority);
 
 		stream.encode(&msg).await?;
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1146,7 +1146,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				request_id,
 				track_namespace: broadcast.to_owned(),
 				track_name: track.name().into(),
-				subscriber_priority: track.subscription().map(|s| s.priority).unwrap_or(0),
+				subscriber_priority: super::priority::to_wire(track.subscription().map(|s| s.priority).unwrap_or(0)),
 				group_order: GroupOrder::Descending,
 				filter_type: FilterType::LargestObject,
 			})

--- a/rs/moq-net/src/lite/priority.rs
+++ b/rs/moq-net/src/lite/priority.rs
@@ -279,6 +279,14 @@ impl PriorityHandle {
 		self.seen
 	}
 
+	/// The current rank as a transport send order, where HIGHER values are
+	/// transmitted first (the W3C `sendOrder` / quinn convention, and the model's
+	/// `Subscription::priority` semantics). The queue rank is the opposite
+	/// (0 = most urgent), so this is where the two conventions meet.
+	pub fn send_order(&mut self) -> u8 {
+		u8::MAX - self.current()
+	}
+
 	/// Poll for a priority change since the last observed value.
 	///
 	/// The queue holds the producer while this handle is registered, so closure is
@@ -325,6 +333,21 @@ mod tests {
 		let queue = PriorityQueue::default();
 		let mut handle = queue.insert(Priority::new(100, 5));
 		assert_eq!(handle.current(), 0); // First item is always index 0
+	}
+
+	/// The transport sends HIGHER values first, so the most urgent rank (0) must map
+	/// to the highest send order and overflow (u8::MAX) to the lowest. Emitting the
+	/// raw rank would transmit the stalest stream first.
+	#[test]
+	fn test_send_order_inverts_rank() {
+		let queue = PriorityQueue::default();
+		let mut top = queue.insert(Priority::new(200, 0));
+		let mut low = queue.insert(Priority::new(100, 0));
+
+		assert_eq!(top.current(), 0);
+		assert_eq!(top.send_order(), 255, "most urgent rank gets the highest send order");
+		assert_eq!(low.current(), 1);
+		assert_eq!(low.send_order(), 254);
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -2201,7 +2201,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 /// A group that fails mid-stream must reset with its own error code. The subscriber uses
 /// that code to tell a truncated group (Old, Lagged, Evicted) from a routine cancel, so a
 /// blanket [`Error::Cancel`] from the writer's drop fallback loses the reason.
-#[cfg(test)]
+#[cfg(all(test, not(loom)))]
 mod serve_group_test {
 	use super::*;
 	use crate::lite::test_transport::*;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -2011,7 +2011,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		priority: &mut PriorityHandle,
 		group: &mut group::Consumer,
 	) -> Result<(), Error> {
-		stream.set_priority(priority.current());
+		stream.set_priority(priority.send_order());
 		stream.encode(&lite::DataType::Group).await?;
 		stream.encode(msg).await?;
 
@@ -2124,7 +2124,9 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		enum Event<T> {
 			Closed,
 			Work(Result<T, Error>),
-			Priority(u8),
+			/// The handle's rank changed; the new value is re-read via
+			/// [`PriorityHandle::send_order`] when handled.
+			Priority,
 			TrackPriority(u8),
 		}
 
@@ -2139,8 +2141,8 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					if let Poll::Ready(res) = work(waiter) {
 						return Poll::Ready(Event::Work(res));
 					}
-					if let Poll::Ready(new_pri) = priority.poll_next(waiter) {
-						return Poll::Ready(Event::Priority(new_pri));
+					if priority.poll_next(waiter).is_ready() {
+						return Poll::Ready(Event::Priority);
 					}
 					// A dropped producer just disables this arm, like the queue arm above.
 					match track_priority.poll(waiter, |value| {
@@ -2160,7 +2162,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 			match event {
 				Event::Closed => return Err(Error::Cancel),
 				Event::Work(res) => return res,
-				Event::Priority(new_pri) => stream.set_priority(new_pri),
+				Event::Priority => stream.set_priority(priority.send_order()),
 				Event::TrackPriority(new_track) => {
 					*track_priority_seen = new_track;
 					priority.set_track(new_track);
@@ -2192,7 +2194,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 	fn apply_priority(&mut self, stream: &mut Writer<S::SendStream, Version>, priority: &mut PriorityHandle) {
 		let track_priority = self.track_priority_current();
 		priority.set_track(track_priority);
-		stream.set_priority(priority.current());
+		stream.set_priority(priority.send_order());
 	}
 }
 
@@ -2274,6 +2276,15 @@ mod serve_group_test {
 		subscription.serve_group(0, handle, consumer).await.unwrap();
 
 		assert_eq!(log.resets(), Vec::<u32>::new(), "clean completion must not reset");
+
+		// The group held rank 0 (most urgent); the transport sends higher values
+		// first, so every send order set on the stream must be the maximum.
+		let priorities = log.priorities();
+		assert!(!priorities.is_empty(), "the group stream must set a priority");
+		assert!(
+			priorities.iter().all(|&p| p == 255),
+			"rank 0 must reach the transport as send order 255: {priorities:?}",
+		);
 	}
 }
 

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1992,8 +1992,10 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 			return Err(err);
 		}
 
-		stream.finish()?;
-		stream.closed().await?;
+		// Consume the writer: close() waits for the peer to acknowledge everything,
+		// and taking ownership disarms the Drop fallback that would otherwise reset
+		// the finished stream with a spurious Cancel.
+		stream.close().await?;
 
 		tracing::debug!(sequence, "finished group");
 
@@ -2237,6 +2239,41 @@ mod serve_group_test {
 
 		assert!(matches!(serve.await, Err(Error::Old)));
 		assert_eq!(log.resets(), vec![Error::Old.to_code()]);
+	}
+
+	/// A group that completes cleanly must not reset at all. The completion path
+	/// consumes the writer via `close()`; leaving the writer to drop after `finish()`
+	/// would fire the Drop fallback and tack a spurious Cancel reset onto a stream
+	/// the peer already acknowledged.
+	#[tokio::test]
+	async fn completed_group_does_not_reset() {
+		let log = Log::default();
+		let session = SinkSession::new(log.clone());
+
+		let track_priority = kio::Producer::new(0u8);
+		let subscription = Subscription {
+			session,
+			id: 0,
+			track_name: "test".into(),
+			priority: PriorityQueue::default(),
+			track_priority: track_priority.consume(),
+			track_priority_seen: 0,
+			version: Version::Lite06Wip,
+			timescale: Some(crate::Timescale::default()),
+		};
+
+		let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
+		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+		group
+			.write_frame(Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
+			.unwrap();
+		let consumer = group.consume();
+		group.finish().unwrap();
+
+		let handle = subscription.priority.insert(Priority::new(0, 0));
+		subscription.serve_group(0, handle, consumer).await.unwrap();
+
+		assert_eq!(log.resets(), Vec::<u32>::new(), "clean completion must not reset");
 	}
 }
 

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -44,7 +44,7 @@ impl Log {
 
 	/// Every value handed to the transport's `set_priority`, in call order. These are
 	/// trait-contract send orders (higher = transmitted first), recorded so tests can
-	/// verify the urgency-to-send-order conversion.
+	/// verify priority conversions at their protocol boundaries.
 	pub fn priorities(&self) -> Vec<u8> {
 		self.priorities.lock().unwrap().clone()
 	}

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -34,11 +34,19 @@ pub struct Log {
 	pub resets: Arc<Mutex<Vec<u32>>>,
 	closes: Arc<Mutex<Vec<(u32, String)>>>,
 	bi_opens: Arc<AtomicUsize>,
+	priorities: Arc<Mutex<Vec<u8>>>,
 }
 
 impl Log {
 	pub fn resets(&self) -> Vec<u32> {
 		self.resets.lock().unwrap().clone()
+	}
+
+	/// Every value handed to the transport's `set_priority`, in call order. These are
+	/// trait-contract send orders (higher = transmitted first), recorded so tests can
+	/// verify the urgency-to-send-order conversion.
+	pub fn priorities(&self) -> Vec<u8> {
+		self.priorities.lock().unwrap().clone()
 	}
 
 	/// The session-level closes, as (code, reason). A list rather than a last-value so
@@ -90,7 +98,9 @@ impl web_transport_trait::SendStream for SinkSend {
 		Ok(buf.len())
 	}
 
-	fn set_priority(&mut self, _order: u8) {}
+	fn set_priority(&mut self, order: u8) {
+		self.log.priorities.lock().unwrap().push(order);
+	}
 
 	fn finish(&mut self) -> Result<(), Self::Error> {
 		self.finished = true;


### PR DESCRIPTION
## Summary

Lite group streams were transmitted in exactly inverted priority order under
contention: after a bandwidth drop, the relay drained its stalest backlog before
any fresh media. Separately, the IETF subscriber priority was passed between the
wire and the model unconverted, so priorities interoperated backwards with
spec-compliant peers.

**Root cause:** the codebase has exactly one lower-is-more-urgent value, the lite
priority queue's *rank* (0 = newest group of the highest-priority track, 255 =
overflow). Everything else is higher-first: `Subscription::priority` ("higher
values preempt lower ones"), the lite wire, `web_transport_trait::SendStream::set_priority`
(0.3.6+), W3C `sendOrder`, and quinn's scheduler. The lite publisher handed the
raw rank straight to the transport, which reads it as a send order, so the least
urgent group won the scheduler. The emitter was written against the pre-0.3.6
trait doc ("lower values sent first") and never updated when the contract
flipped.

The IETF wire is the other exception: `subscriber_priority` is lower-first
(draft-ietf-moq-transport section 7.1), but both the subscriber (encode) and the
publisher (decode) moved it to and from `Subscription::priority` unchanged.

**Fix:** convert at each boundary, and only there.

- `PriorityHandle::send_order()` returns `u8::MAX - rank`, so the conversion
  lives where the rank is produced. `Writer::set_priority` stays a documented
  passthrough of the transport's send order.
- `ietf::priority::{from_wire, to_wire}` normalize `subscriber_priority` in the
  IETF subscriber and publisher, so the model keeps its higher-first semantics
  everywhere inside moq-net. `js/net` gets the matching `ietf/priority.ts` at the
  same two call sites.

Also folded in: both group completion paths (lite `serve_group`, ietf
`run_group`) ended with `finish()` + `closed().await` and then dropped a
still-owned `Writer`, whose `Drop` fallback reset the stream with a spurious
`Cancel` on a group the peer had already acknowledged. They now consume the
writer via `close()`.

## Tested

- `PriorityHandle::send_order` unit test: rank 0 maps to send order 255.
- Lite group harness: a served group at rank 0 reaches the transport as 255, and
  a cleanly completed group records no resets.
- IETF group harness: model priority 200 reaches the transport unchanged (fails
  at 55 against a `Writer`-level inversion).
- `ietf::priority` and `js/net` `ietf/priority.ts` round-trip and direction tests.
- `cargo test -p moq-net`: 711 passed. `bun test` in `js/net`: 340 passed.
  `just check`: clean.

## Cross-package sync

- `js/net`: converted at the same two IETF call sites. Lite bidi Fetch streams
  already pass the higher-first priority into `sendOrder` correctly; lite group
  unidirectional streams still set no `sendOrder` at all, a pre-existing gap left
  out of scope.
- `drafts/`: no update. `subscriber_priority` is defined by
  draft-ietf-moq-transport, which is not carried in-tree, and this change makes
  us conform to it rather than altering it. `draft-lcurley-moq-lite` is
  unaffected: the lite wire was and remains higher-first.

## Note

The model's default priority is 0, which is the *lowest* higher-first value, so a
subscription that never sets a priority now sends IETF `subscriber_priority` 255
(least urgent) instead of 0 (most urgent). Relative ordering among our own tracks
is unchanged; only a third-party IETF relay arbitrating between us and other
subscribers sees a difference.

(written by Opus 5)
