### PR TITLE
fix(net): tolerate incoming streams that die before their first byte

### DIFF
--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -481,7 +481,18 @@ async fn run_unis<S: web_transport_trait::Session>(
 	loop {
 		let recv = tasks.drive(session.accept_uni()).await.map_err(Error::from_transport)?;
 		let mut reader: Reader<S::RecvStream, crate::Version> = Reader::new(recv, outer_version);
-		let kind: u64 = tasks.drive(reader.decode_peek()).await?;
+		// A stream that dies before its type varint is that stream's failure, not the
+		// session's. RESET_STREAM is how a peer drops a group, and QUIC does not order
+		// the reset behind the data, so one can beat the first byte even of a stream
+		// the peer wrote to. Failing the loop here would tear down the whole session
+		// over a single stream the peer had already given up on.
+		let kind: u64 = match tasks.drive(reader.decode_peek()).await {
+			Ok(kind) => kind,
+			Err(err) => {
+				tracing::debug!(%err, "dropping uni stream that died before its type");
+				continue;
+			}
+		};
 
 		// v17+: SETUP arrives on a uni stream, then becomes the GOAWAY channel.
 		// We accept it in the background without blocking; the one thing that does
@@ -589,7 +600,15 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 				Ok::<_, Error>((id, data))
 			})
 			.await;
-		let (id, data) = header?;
+		// Same tolerance as `run_unis`: a request stream that dies before its header
+		// is the peer abandoning that request, not the session.
+		let (id, data) = match header {
+			Ok(header) => header,
+			Err(err) => {
+				tracing::debug!(%err, "dropping bidi stream that died before its header");
+				continue;
+			}
+		};
 
 		match id {
 			// Publisher handles: Subscribe, Fetch, SubscribeNamespace (0x50 modern /
@@ -820,5 +839,58 @@ mod tests {
 		// Neither half: nothing to route, so any id will do as long as it is ours.
 		let publish = crate::origin::Info::new(ours).produce();
 		assert_eq!(self_origin(Some(&publish.consume()), Some(&subscribe)), ours);
+	}
+
+	/// Drive `start` against a peer whose incoming streams die before their first
+	/// byte, and assert the session shrugs them off: the driver keeps running and
+	/// nothing closes the transport.
+	///
+	/// The dead stream is not exotic. RESET_STREAM is how a peer drops a group, and
+	/// QUIC does not order the reset behind the data, so it can beat the first byte
+	/// even when the peer wrote one. Erroring an accept loop on it tears down the
+	/// whole session over a single stream the peer had already given up on.
+	async fn a_dead_incoming_stream_is_not_fatal(session: crate::lite::test_transport::DeadStreamSession) {
+		const VERSION: Version = Version::Draft19;
+
+		// A driver that survives parks forever, so bound it: paused time makes the
+		// deadline fire the moment nothing else can run.
+		tokio::time::pause();
+
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let log = session.log.clone();
+
+		let driver = start(Config {
+			session,
+			setup: None,
+			request_id_max: None,
+			client: true,
+			publish: None,
+			subscribe: Some(origin),
+			peer_origin: None,
+			cost: None,
+			version: VERSION,
+			path: None,
+			peer_setup_stream: None,
+			// Pre-settled, so nothing waits on a SETUP the dead stream will never
+			// carry and the dispatch loop actually runs.
+			peer_cluster: Some(cluster::Peer::default()),
+		})
+		.expect("start the session");
+
+		tokio::time::timeout(std::time::Duration::from_secs(10), driver)
+			.await
+			.expect_err("the session ended over one dead stream");
+
+		assert_eq!(log.closes(), vec![], "nothing may close the transport");
+	}
+
+	#[tokio::test]
+	async fn a_uni_stream_dead_before_its_type_does_not_end_the_session() {
+		a_dead_incoming_stream_is_not_fatal(crate::lite::test_transport::DeadStreamSession::unis(1)).await;
+	}
+
+	#[tokio::test]
+	async fn a_bidi_stream_dead_before_its_header_does_not_end_the_session() {
+		a_dead_incoming_stream_is_not_fatal(crate::lite::test_transport::DeadStreamSession::bis(1)).await;
 	}
 }

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -1,7 +1,7 @@
 use crate::origin;
 use crate::{
 	Error, Origin,
-	coding::{Decode, Encode, Reader, Stream, Writer},
+	coding::{Decode, DecodeError, Encode, Reader, Stream, Writer},
 	ietf::{self, FetchHeader, RequestId},
 	setup,
 	util::{MaybeBoxedExt, MaybeSendBox, TaskSet, err_only},
@@ -458,6 +458,18 @@ async fn run_setup<S: web_transport_trait::Session>(
 	Ok(())
 }
 
+/// Whether reading a just-accepted stream failed because the stream died (a
+/// reset, or an end before the first message was complete) rather than
+/// delivering bytes that do not parse. Death is that stream's failure and the
+/// accept loops drop the one stream; garbage is the peer breaking the protocol
+/// and stays session-fatal, per [`is_protocol_violation`].
+fn stream_died(err: &Error) -> bool {
+	matches!(
+		err,
+		Error::Cancel | Error::Remote(_) | Error::Decode(DecodeError::Short)
+	)
+}
+
 /// Accept incoming uni streams and dispatch each to a handler.
 ///
 /// For v17, this also handles the SETUP stream (0x2F00) and GOAWAY.
@@ -485,13 +497,15 @@ async fn run_unis<S: web_transport_trait::Session>(
 		// session's. RESET_STREAM is how a peer drops a group, and QUIC does not order
 		// the reset behind the data, so one can beat the first byte even of a stream
 		// the peer wrote to. Failing the loop here would tear down the whole session
-		// over a single stream the peer had already given up on.
+		// over a single stream the peer had already given up on. Only death is
+		// tolerated: bytes that arrive and do not parse stay session-fatal.
 		let kind: u64 = match tasks.drive(reader.decode_peek()).await {
 			Ok(kind) => kind,
-			Err(err) => {
+			Err(err) if stream_died(&err) => {
 				tracing::debug!(%err, "dropping uni stream that died before its type");
 				continue;
 			}
+			Err(err) => return Err(err),
 		};
 
 		// v17+: SETUP arrives on a uni stream, then becomes the GOAWAY channel.
@@ -601,13 +615,15 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 			})
 			.await;
 		// Same tolerance as `run_unis`: a request stream that dies before its header
-		// is the peer abandoning that request, not the session.
+		// is the peer abandoning that request, not the session. Anything else, a
+		// header that does not parse included, still fails the session.
 		let (id, data) = match header {
 			Ok(header) => header,
-			Err(err) => {
+			Err(err) if stream_died(&err) => {
 				tracing::debug!(%err, "dropping bidi stream that died before its header");
 				continue;
 			}
+			Err(err) => return Err(err),
 		};
 
 		match id {

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -458,18 +458,6 @@ async fn run_setup<S: web_transport_trait::Session>(
 	Ok(())
 }
 
-/// Whether reading a just-accepted stream failed because the stream died (a
-/// reset, or an end before the first message was complete) rather than
-/// delivering bytes that do not parse. Death is that stream's failure and the
-/// accept loops drop the one stream; garbage is the peer breaking the protocol
-/// and stays session-fatal, per [`is_protocol_violation`].
-fn stream_died(err: &Error) -> bool {
-	matches!(
-		err,
-		Error::Cancel | Error::Remote(_) | Error::Decode(DecodeError::Short)
-	)
-}
-
 /// Accept incoming uni streams and dispatch each to a handler.
 ///
 /// For v17, this also handles the SETUP stream (0x2F00) and GOAWAY.
@@ -501,7 +489,7 @@ async fn run_unis<S: web_transport_trait::Session>(
 		// tolerated: bytes that arrive and do not parse stay session-fatal.
 		let kind: u64 = match tasks.drive(reader.decode_peek()).await {
 			Ok(kind) => kind,
-			Err(err) if stream_died(&err) => {
+			Err(err @ Error::Cancel) | Err(err @ Error::Remote(_)) | Err(err @ Error::Decode(DecodeError::Short)) => {
 				tracing::debug!(%err, "dropping uni stream that died before its type");
 				continue;
 			}
@@ -619,7 +607,7 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 		// header that does not parse included, still fails the session.
 		let (id, data) = match header {
 			Ok(header) => header,
-			Err(err) if stream_died(&err) => {
+			Err(err @ Error::Cancel) | Err(err @ Error::Remote(_)) | Err(err @ Error::Decode(DecodeError::Short)) => {
 				tracing::debug!(%err, "dropping bidi stream that died before its header");
 				continue;
 			}

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -131,23 +131,47 @@ impl web_transport_trait::RecvStream for PendingRecv {
 	}
 }
 
-/// A stream that died before delivering a single byte: every read fails, the
-/// wire equivalent of RESET_STREAM arriving ahead of any payload. QUIC does not
-/// order a reset behind the data, so this reaches an accept loop in normal
-/// operation, not just from a misbehaving peer.
+/// What a reset stream's reads report: RESET_STREAM with application code 0,
+/// the code a routine group drop carries. `Error::from_transport` decodes it
+/// back to `Error::Cancel`.
+#[derive(Debug, Clone, Default)]
+pub struct ResetError;
+
+impl std::fmt::Display for ResetError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "stream reset by peer (code 0)")
+	}
+}
+
+impl std::error::Error for ResetError {}
+
+impl web_transport_trait::Error for ResetError {
+	fn session_error(&self) -> Option<(u32, String)> {
+		None
+	}
+
+	fn stream_error(&self) -> Option<u32> {
+		Some(0)
+	}
+}
+
+/// A stream that died before delivering a single byte: every read reports a
+/// code-0 RESET_STREAM ([`ResetError`]), the wire shape of a reset arriving
+/// ahead of any payload. QUIC does not order a reset behind the data, so this
+/// reaches an accept loop in normal operation, not just from a misbehaving peer.
 pub struct DeadRecv;
 
 impl web_transport_trait::RecvStream for DeadRecv {
-	type Error = SinkError;
+	type Error = ResetError;
 
 	async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-		Err(SinkError)
+		Err(ResetError)
 	}
 
 	fn stop(&mut self, _code: u32) {}
 
 	async fn closed(&mut self) -> Result<(), Self::Error> {
-		Err(SinkError)
+		Err(ResetError)
 	}
 }
 
@@ -156,6 +180,7 @@ impl web_transport_trait::RecvStream for DeadRecv {
 /// peer with nothing more to say. Sends record to [`Log`] like [`SinkSession`].
 #[derive(Clone)]
 pub struct DeadStreamSession {
+	/// What the session's send streams recorded, for test assertions.
 	pub log: Log,
 	unis: Arc<Mutex<usize>>,
 	bis: Arc<Mutex<usize>>,

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -1,5 +1,6 @@
 //! Transport doubles shared by the lite tests: a session whose streams record
-//! everything written and every reset code, and peers that never speak.
+//! everything written and every reset code, peers that never speak, and peers
+//! whose incoming streams die before their first byte.
 
 use std::{
 	sync::{
@@ -127,6 +128,124 @@ impl web_transport_trait::RecvStream for PendingRecv {
 
 	async fn closed(&mut self) -> Result<(), Self::Error> {
 		std::future::pending().await
+	}
+}
+
+/// A stream that died before delivering a single byte: every read fails, the
+/// wire equivalent of RESET_STREAM arriving ahead of any payload. QUIC does not
+/// order a reset behind the data, so this reaches an accept loop in normal
+/// operation, not just from a misbehaving peer.
+pub struct DeadRecv;
+
+impl web_transport_trait::RecvStream for DeadRecv {
+	type Error = SinkError;
+
+	async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+		Err(SinkError)
+	}
+
+	fn stop(&mut self, _code: u32) {}
+
+	async fn closed(&mut self) -> Result<(), Self::Error> {
+		Err(SinkError)
+	}
+}
+
+/// Incoming streams that die before their first byte: `accept_uni` / `accept_bi`
+/// each yield the configured number of [`DeadRecv`] streams and then park like a
+/// peer with nothing more to say. Sends record to [`Log`] like [`SinkSession`].
+#[derive(Clone)]
+pub struct DeadStreamSession {
+	pub log: Log,
+	unis: Arc<Mutex<usize>>,
+	bis: Arc<Mutex<usize>>,
+}
+
+impl DeadStreamSession {
+	/// `count` uni streams that die before their first byte, then silence.
+	pub fn unis(count: usize) -> Self {
+		Self {
+			log: Log::default(),
+			unis: Arc::new(Mutex::new(count)),
+			bis: Arc::new(Mutex::new(0)),
+		}
+	}
+
+	/// `count` bidi streams that die before their first byte, then silence.
+	pub fn bis(count: usize) -> Self {
+		Self {
+			log: Log::default(),
+			unis: Arc::new(Mutex::new(0)),
+			bis: Arc::new(Mutex::new(count)),
+		}
+	}
+
+	fn take(counter: &Mutex<usize>) -> bool {
+		let mut remaining = counter.lock().unwrap();
+		match *remaining {
+			0 => false,
+			_ => {
+				*remaining -= 1;
+				true
+			}
+		}
+	}
+}
+
+impl web_transport_trait::Session for DeadStreamSession {
+	type SendStream = SinkSend;
+	type RecvStream = DeadRecv;
+	type Error = SinkError;
+
+	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
+		match Self::take(&self.unis) {
+			true => Ok(DeadRecv),
+			false => std::future::pending().await,
+		}
+	}
+
+	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+		match Self::take(&self.bis) {
+			true => Ok((SinkSend::new(self.log.clone()), DeadRecv)),
+			false => std::future::pending().await,
+		}
+	}
+
+	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+		self.log.bi_opens.fetch_add(1, Ordering::Relaxed);
+		Ok((SinkSend::new(self.log.clone()), DeadRecv))
+	}
+
+	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
+		Ok(SinkSend::new(self.log.clone()))
+	}
+
+	fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	async fn recv_datagram(&self) -> Result<bytes::Bytes, Self::Error> {
+		std::future::pending().await
+	}
+
+	fn max_datagram_size(&self) -> usize {
+		0
+	}
+
+	fn protocol(&self) -> Option<&str> {
+		None
+	}
+
+	fn close(&self, code: u32, reason: &str) {
+		self.log.closes.lock().unwrap().push((code, reason.to_owned()));
+	}
+
+	async fn closed(&self) -> Self::Error {
+		std::future::pending().await
+	}
+
+	fn stats(&self) -> impl web_transport_trait::Stats {
+		SinkStats
 	}
 }
 


### PR DESCRIPTION
## Summary

- The IETF accept loops (`run_unis` and `run_dispatch` in `rs/moq-net/src/ietf/session.rs`) read each accepted stream's type varint or request header at loop level with `?`. A stream error before the first byte therefore failed the whole loop, and dropping the loop's `TaskSet` tore down the peer's SETUP/GOAWAY stream and every in-flight request.
- RESET_STREAM with code 0 is how a peer drops a group, and QUIC does not order a reset behind stream data. A reset can therefore arrive before the first byte even when the peer wrote one, causing one routinely dropped group to disconnect a publisher.
- The accept loops now match stream termination inline. `Error::Cancel`, `Error::Remote(_)`, and `Error::Decode(DecodeError::Short)` drop only that stream. Every other error, including delivered but unparseable input, still fails the session.

## Public API changes

None. The changed functions are private, and the `ResetError`, `DeadRecv`, and `DeadStreamSession` doubles live in the crate-private test transport module.

## Test plan

- Regression tests drive `start()` against peers whose accepted uni and bidi streams report code-0 RESET_STREAM before their first byte. They assert that the driver keeps running and the transport remains open.
- `nix develop --command just ci`
- Live relay validation from the original report reproduced the disconnect before the fix and confirmed browser publishing, subscribing, and cross-relay continuity after it.

No Cross-Package Sync rows apply because this changes receive-side error handling without changing the wire format or a public API.

(Written by Claude Fable 5 and GPT-5)