### PR TITLE
fix(release): repair native package releases

### DIFF
--- a/.github/homebrew/Formula/moq-token-cli.rb.tmpl
+++ b/.github/homebrew/Formula/moq-token-cli.rb.tmpl
@@ -23,10 +23,10 @@ class MoqTokenCli < Formula
   end
 
   def install
-    bin.install "bin/moq-token-cli"
+    bin.install "bin/moq-token"
   end
 
   test do
-    system bin/"moq-token-cli", "--help"
+    system bin/"moq-token", "--help"
   end
 end

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -61,7 +61,7 @@ jobs:
           target="${{ matrix.target }}"
           name="moq-token-cli-v${version}-${target}"
           mkdir -p dist
-          cp "target/${target}/release/moq-token-cli" "dist/${name}"
+          cp "target/${target}/release/moq-token" "dist/${name}"
 
       - name: Package tarball (Homebrew)
         shell: bash
@@ -71,7 +71,7 @@ jobs:
         run: |
           name="moq-token-cli-${VERSION}-${TARGET}"
           mkdir -p "dist/${name}/bin"
-          cp "target/${TARGET}/release/moq-token-cli" "dist/${name}/bin/moq-token-cli"
+          cp "target/${TARGET}/release/moq-token" "dist/${name}/bin/moq-token"
           cp LICENSE-MIT LICENSE-APACHE "dist/${name}/"
           if [[ -f rs/moq-token-cli/README.md ]]; then
             cp rs/moq-token-cli/README.md "dist/${name}/"
@@ -83,7 +83,7 @@ jobs:
         env:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.deb-arch }}
-          BINARY_PATH: target/${{ matrix.target }}/release/moq-token-cli
+          BINARY_PATH: target/${{ matrix.target }}/release/moq-token
         run: |
           # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
           envsubst '$VERSION $ARCH $BINARY_PATH' \
@@ -95,7 +95,7 @@ jobs:
         env:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.rpm-arch }}
-          BINARY_PATH: target/${{ matrix.target }}/release/moq-token-cli
+          BINARY_PATH: target/${{ matrix.target }}/release/moq-token
         run: |
           # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
           envsubst '$VERSION $ARCH $BINARY_PATH' \
@@ -139,6 +139,7 @@ jobs:
         run: |
           ./rs/scripts/package-binary.sh \
             --crate moq-token-cli \
+            --bin moq-token \
             --target ${{ matrix.target }} \
             --version ${{ steps.parse.outputs.version }} \
             --output dist
@@ -186,6 +187,7 @@ jobs:
         run: |
           ./rs/scripts/package-windows.sh \
             --crate moq-token-cli \
+            --bin moq-token \
             --target ${{ matrix.target }} \
             --version ${{ steps.parse.outputs.version }} \
             --output dist

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -129,14 +129,16 @@ Drop the defaults on Linux, as above: the default `pipewire` feature links
 libpipewire-0.3 at build time to give `import capture` a display source that
 playback never uses.
 
-A Linux build still needs three system packages, whichever features are picked.
-The speaker goes through cpal, which links ALSA, and `play` pulls in moq-video,
-whose V4L2 camera capture is not behind a feature and whose bindgen wants
-libclang. On Debian and Ubuntu:
+A Linux playback-only build needs ALSA because the speaker goes through cpal.
+It does not compile moq-video's capture feature, so it no longer needs V4L2
+headers or libclang. On Debian and Ubuntu:
 
 ```bash
-sudo apt install libasound2-dev libclang-dev libv4l-dev
+sudo apt install libasound2-dev
 ```
+
+A build with the `capture` feature additionally needs `libclang-dev` and
+`libv4l-dev` for V4L2 camera capture.
 
 macOS and Windows need nothing extra, so plain `--features play` is enough
 there.

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -52,10 +52,10 @@ slow path. AV1 is decode-only, via NVDEC.
 cargo add moq-video
 ```
 
-NVIDIA hardware codecs are on by default. VAAPI is not, since that backend has
-never been validated on real hardware, and neither are rendering and PipeWire
-screen capture, which pull in a graphics stack and a `libpipewire` build
-dependency respectively:
+Capture and NVIDIA hardware codecs are on by default. VAAPI is not, since that
+backend has never been validated on real hardware, and neither are rendering
+and PipeWire screen capture, which pull in a graphics stack and a `libpipewire`
+build dependency respectively:
 
 ```bash
 cargo add moq-video --features render,pipewire
@@ -63,14 +63,15 @@ cargo add moq-video --features render,pipewire
 
 | Feature | Default | Pulls in |
 | --- | --- | --- |
+| `capture` | yes | Native device capture (`v4l` and `zune-jpeg` on Linux) |
 | `nvenc` / `nvdec` | yes | NVIDIA encode/decode on Linux (`cudarc`, `moq-nvenc`) |
 | `vaapi` | no | Intel/AMD encode on Linux (`moq-vaapi`), unvalidated on hardware |
 | `render` | no | `wgpu` and the GPU renderer |
 | `pipewire` | no | Wayland/X11 screen capture via xdg-desktop-portal |
 
-The two default features are Linux-only in effect (their dependencies are), and
-`--no-default-features` gives a slim build that still captures V4L2 and encodes
-with openh264. A relay never needs any of them.
+`--no-default-features` gives a codec-only build that still encodes and decodes
+H.264 with openh264 but omits native capture and the Linux GPU dependencies. A
+relay or language binding that only handles supplied frames needs none of them.
 
 ## Publishing
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -18,8 +18,21 @@ check *args:
     cargo clippy --all-targets {{ args }} -- -D warnings
     cargo fmt --all --check
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps {{ args }}
+    just rs ffi-dependencies
     cargo shear
     cargo sort --workspace --check --no-format
+
+# moq-ffi exposes raw video encode/decode, not device capture. Keep the capture
+# dependency graph out of cross-compiled Python, Swift, Kotlin, and Go builds.
+ffi-dependencies:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tree=$(cargo tree --locked --package moq-ffi --target x86_64-unknown-linux-gnu)
+    if grep -qE '(^| )(v4l|v4l2-sys-mit|zune-jpeg) v' <<< "$tree"; then
+        echo "moq-ffi unexpectedly enables moq-video capture dependencies" >&2
+        grep -E '(^| )(v4l|v4l2-sys-mit|zune-jpeg) v' <<< "$tree" >&2
+        exit 1
+    fi
 
 # Auto-fix clippy/format/shear/sort.
 fix *args:
@@ -149,7 +162,7 @@ fix-changed $FILES:
 
 # Compile the whole workspace on a Windows host. Must run ON Windows.
 windows *args:
-    cargo check --workspace --exclude moq-gst --all-targets --features moq-cli/play {{ args }}
+    cargo check --workspace --exclude moq-gst --all-targets --features "moq-cli/play moq-cli/capture" {{ args }}
 
 # Runs the `#[cfg(target_os = "macos")]` code past the compiler: moq-video's
 # VideoToolbox encode/decode and its ScreenCaptureKit / AVFoundation capture,

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -35,7 +35,7 @@ websocket = ["moq-native/websocket"]
 # needs ALSA/libasound), plus binary size. macOS/Windows use OS frameworks, no
 # extra install. H.264 is vendored static (openh264), so no system ffmpeg/libav.
 # Enable with `cargo build -p moq-cli --features capture`.
-capture = ["dep:moq-video", "dep:moq-audio", "moq-audio/capture"]
+capture = ["dep:moq-video", "dep:moq-audio", "moq-video/capture", "moq-audio/capture"]
 # Just-in-time transcoding (`moq ... transcode`). Off by default because it pulls
 # in moq-video and its codec dependencies. Enable with
 # `cargo build -p moq-cli --features transcode`.

--- a/rs/moq-ffi/build.sh
+++ b/rs/moq-ffi/build.sh
@@ -111,22 +111,19 @@ build_target() {
     local target="$1"
     echo "Building moq-ffi for $target..."
 
+    # Ensure the target's std is installed for the pinned toolchain Cargo
+    # resolves here. Release workflows may add it to floating stable instead,
+    # which leaves this toolchain without std and fails with E0463. No-op once
+    # present, and skipped when rustup is not the toolchain manager.
+    if command -v rustup >/dev/null 2>&1; then
+        rustup target add "$target"
+    fi
+
     if is_android "$target"; then
         # Android targets use cargo-ndk
         cargo ndk --target "$target" --platform 24 -- \
             build --release --package moq-ffi --manifest-path "$WORKSPACE_DIR/Cargo.toml"
     else
-        # Ensure the target's std is installed for the toolchain cargo actually
-        # resolves here. The release workflow's rust-toolchain action adds the
-        # target to `stable`, but the repo's channel-less rust-toolchain.toml
-        # makes cargo pick a different toolchain for this build, which then lacks
-        # the cross target's std -- cross builds die with E0463 "can't find crate
-        # for `std`" (e.g. building serde_core for aarch64). No-op once present,
-        # and for a host target; skipped when rustup isn't the toolchain manager.
-        if command -v rustup >/dev/null 2>&1; then
-            rustup target add "$target"
-        fi
-
         # Set up cross-compilation for Linux ARM64
         if [[ "$target" == "aarch64-unknown-linux-gnu" ]]; then
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -15,9 +15,13 @@ categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 [features]
 # NVIDIA hardware codecs are enabled by default. Disable them (e.g.
 # `--no-default-features`) for a slimmer self-compiled Linux build that drops the
-# CUDA dependencies. Openh264 stays as the always-compiled software fallback and
-# V4L2 capture is unaffected. The default features are no-ops off Linux.
-default = ["nvenc", "nvdec"]
+# CUDA dependencies. Openh264 stays as the always-compiled software fallback;
+# disable only `capture` to omit the device stack while retaining codecs.
+default = ["capture", "nvenc", "nvdec"]
+# Native camera and screen capture. Enabled by default for direct consumers,
+# but workspace consumers opt in so codec-only bindings avoid device build
+# dependencies such as V4L2 and libclang.
+capture = ["dep:v4l", "dep:zune-jpeg"]
 # NVIDIA NVENC hardware encoder (Linux). dlopen'd at runtime (cudarc + moq-nvenc,
 # which loads libnvidia-encode), with a libloading probe for the driver libs, so
 # an nvenc build still links GPU-less and starts driverless, falling back to the
@@ -51,7 +55,7 @@ render = [
 # Off by default because the `pipewire` crate links libpipewire-0.3 via pkg-config
 # at build time (and its bindgen needs libclang), so it only belongs in builds
 # that actually capture displays. Camera capture (V4L2) needs nothing extra.
-pipewire = ["dep:pipewire", "dep:ashpd"]
+pipewire = ["capture", "dep:pipewire", "dep:ashpd"]
 
 [dependencies]
 anyhow = "1"
@@ -118,8 +122,8 @@ moq-vaapi = { workspace = true, optional = true }
 pipewire = { version = "0.10", optional = true }
 # Native V4L2 webcam capture (replaces nokhwa). `v4l` streams MMAP buffers;
 # MJPEG cameras are decoded with the pure-Rust `zune-jpeg` (no libjpeg/IJG).
-v4l = "0.14"
-zune-jpeg = "0.5"
+v4l = { version = "0.14", optional = true }
+zune-jpeg = { version = "0.5", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 block2 = "0.6.2"

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -12,6 +12,10 @@ swapping or bumping a backend crate is not a breaking change.
 
 ## Capture
 
+The default-on `capture` feature exposes the device APIs and their per-platform
+backends. Disable it for a codec-only build that accepts frames supplied by the
+caller without pulling Linux V4L2 and libclang build dependencies.
+
 Per-platform, picked at compile time:
 
 - **macOS**: AVFoundation (camera) and ScreenCaptureKit (display), yielding

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -712,7 +712,7 @@ mod tests {
 	/// Full zero-copy path: real camera -> D3D11 NV12 texture -> hardware encoder
 	/// via the DXGI device manager, no CPU round-trip. Ignored: needs a camera and
 	/// a GPU. Run with `--ignored`.
-	#[cfg(target_os = "windows")]
+	#[cfg(all(target_os = "windows", feature = "capture"))]
 	#[tokio::test]
 	#[ignore]
 	async fn mediafoundation_camera_texture() {

--- a/rs/moq-video/src/encode/mod.rs
+++ b/rs/moq-video/src/encode/mod.rs
@@ -4,7 +4,8 @@
 //! for which backends cover each on this platform.
 //!
 //! Entry points, high to low level:
-//! - [`publish_capture`] captures and publishes a webcam (turnkey).
+//! - `publish_capture` captures and publishes a webcam (turnkey). Requires the
+//!   `capture` feature.
 //! - [`Encoder`] encodes raw [`Frame`](crate::Frame)s you supply into
 //!   [`Encoded`] access units, and [`Producer`] publishes those (bring your own
 //!   frames). Build both for the same [`Codec`].
@@ -18,7 +19,7 @@
 //! [`decode`](crate::decode) module.
 //!
 //! [`rate`] holds the policy mapping a congestion-control bandwidth estimate
-//! onto the encoder's bitrate, which [`publish_capture`] drives for you.
+//! onto the encoder's bitrate, which `publish_capture` drives for you.
 
 mod backend;
 mod encoded;
@@ -30,5 +31,7 @@ pub mod rate;
 
 pub use encoded::Encoded;
 pub use encoder::{Codec, Config, Encoder, Kind};
-pub use producer::{Options, Producer, publish_capture};
+pub use producer::Producer;
+#[cfg(feature = "capture")]
+pub use producer::{Options, publish_capture};
 pub use sink::Sink;

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -1,4 +1,4 @@
-//! Encode decoded video frames and publish them as a moq video track.
+//! Publish encoded video frames as a moq video track, with optional capture.
 //!
 //! Encoding is strictly on demand: the track and catalog entry are advertised
 //! immediately, but the camera stays closed (LED off, no CPU) until a subscriber
@@ -6,20 +6,30 @@
 //! mirrors `moq-boy`, which pauses its emulator on `track::Producer::used()` /
 //! `unused()`.
 
+#[cfg(feature = "capture")]
 use std::time::Instant;
 
 use moq_mux::catalog::hang::CatalogExt;
+#[cfg(any(feature = "capture", test))]
 use moq_net::Timestamp;
 
+use crate::Error;
+#[cfg(any(feature = "capture", test))]
+use crate::Frame;
+#[cfg(feature = "capture")]
 use crate::capture;
-use crate::{Error, Frame};
 
 use super::Encoded;
+#[cfg(feature = "capture")]
 use super::Sink;
-use super::encoder::{self, Codec};
+#[cfg(any(feature = "capture", test))]
+use super::encoder;
+use super::encoder::Codec;
+#[cfg(feature = "capture")]
 use super::rate::{Control, Policy};
 
 /// Last-resort framerate when neither the caller nor the camera reports one.
+#[cfg(feature = "capture")]
 const DEFAULT_FRAMERATE: u32 = 30;
 
 /// Per-codec splitter + importer pair. Each codec frames its packets and resolves
@@ -157,6 +167,7 @@ impl<E: CatalogExt> Producer<E> {
 /// new knobs can be added without breaking callers.
 #[derive(Clone, Default)]
 #[non_exhaustive]
+#[cfg(feature = "capture")]
 pub struct Options {
 	/// Target bitrate in bits per second; `None` derives from resolution.
 	///
@@ -183,6 +194,7 @@ pub struct Options {
 
 // Hand-written: `bandwidth::Consumer` isn't `Debug`, but its presence is the
 // only part worth printing anyway.
+#[cfg(feature = "capture")]
 impl std::fmt::Debug for Options {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("Options")
@@ -201,6 +213,7 @@ impl std::fmt::Debug for Options {
 /// subscriber is watching; frames are stamped from `clock`, so passing the
 /// same [`Clock`](moq_mux::Clock) to a concurrent audio publish keeps the two
 /// tracks aligned.
+#[cfg(feature = "capture")]
 pub async fn publish_capture<E: CatalogExt>(
 	broadcast: moq_net::broadcast::Producer,
 	catalog: moq_mux::catalog::Producer<E>,
@@ -240,7 +253,7 @@ pub async fn publish_capture<E: CatalogExt>(
 /// is `Send` there. This is never called; it exists only to fail compilation if
 /// the future ever regains a `!Send` component. macOS is exempt (the objc
 /// capture session is `!Send`).
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "capture", not(target_os = "macos")))]
 #[allow(dead_code)]
 fn assert_publish_capture_send(
 	broadcast: moq_net::broadcast::Producer,
@@ -256,12 +269,14 @@ fn assert_publish_capture_send(
 /// The live rate control state: the estimate source paired with the policy
 /// tracking it. `None` once there's nothing left to track, which is what stops
 /// the `select!` arm from spinning on a channel that is permanently ready.
+#[cfg(feature = "capture")]
 type Rate = Option<(moq_net::bandwidth::Consumer, Control)>;
 
 /// Wait for the next bandwidth estimate, or forever when rate control is off or
 /// finished. Cancel-safe: [`Consumer::changed`](moq_net::bandwidth::Consumer::changed)
 /// only reads shared state, so losing this race to a frame drops no estimate,
 /// it just re-reads the latest one next time round.
+#[cfg(feature = "capture")]
 async fn next_estimate(rate: &mut Rate) -> Option<Option<u64>> {
 	match rate {
 		Some((bandwidth, _)) => bandwidth.changed().await.ok(),
@@ -275,6 +290,7 @@ async fn next_estimate(rate: &mut Rate) -> Option<Option<u64>> {
 /// `None` means the producer is gone (the session ended for good), so rate
 /// control retires; a `Some(None)` estimate means the value is merely
 /// unavailable right now, which the policy holds through.
+#[cfg(feature = "capture")]
 async fn apply_estimate(encoder: &mut Sink, rate: &mut Rate, estimate: Option<Option<u64>>) {
 	let Some((_, control)) = rate.as_mut() else { return };
 
@@ -307,6 +323,7 @@ async fn apply_estimate(encoder: &mut Sink, rate: &mut Rate, estimate: Option<Op
 /// A dropped or closed track is the normal end of a publish; any other cause is
 /// a real abort (e.g. a transport reset) worth surfacing rather than treating as
 /// a clean exit.
+#[cfg(feature = "capture")]
 fn log_track_ended(err: moq_net::Error) {
 	if matches!(err, moq_net::Error::Dropped | moq_net::Error::Closed) {
 		tracing::debug!("video track no longer announced; stopping capture");
@@ -326,6 +343,7 @@ fn log_track_ended(err: moq_net::Error) {
 /// encode thread. Both the capture and encode threads sit idle between frames,
 /// so their joins return promptly unless the underlying device or encoder is
 /// itself wedged.
+#[cfg(feature = "capture")]
 async fn capture_loop<E: CatalogExt>(
 	producer: &mut Producer<E>,
 	demand: &moq_net::track::Demand,

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -1,8 +1,8 @@
 //! An [`Encoder`](super::Encoder) that owns the thread it runs on, so any
 //! thread (or task) can drive it.
 //!
-//! Off macOS the encoder runs on a dedicated OS thread (mirroring
-//! [`capture::pump`](crate::capture)): the Windows hardware encoder is a Media
+//! Off macOS the encoder runs on a dedicated OS thread (mirroring the capture
+//! pump): the Windows hardware encoder is a Media
 //! Foundation MFT whose COM handles must be created, driven, and dropped all on
 //! one thread (COM apartments are per-thread), and whose encode call blocks on
 //! MFT events. Driving it inline on a tokio worker would unbalance the

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -31,7 +31,7 @@ use crate::{Color, Error, Size};
 
 /// One raw (uncompressed) video frame: the pixels plus when they are shown.
 ///
-/// The currency of the crate's raw side: [`capture`](crate::capture) and
+/// The currency of the crate's raw side: capture sources and
 /// [`decode`](crate::decode) produce these, and
 /// [`encode::Encoder::encode`](crate::encode::Encoder::encode) consumes them,
 /// handing back the compressed [`encode::Encoded`](crate::encode::Encoded).

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -13,22 +13,19 @@
 //! [`encode::Config::gop`], and [`encode::Encoder::keyframe`] is there for the
 //! rarer case where a caller needs one at a specific frame.
 //!
-//! - [`capture`] describes a frame source ([`capture::Config`]) and grabs
-//!   frames per platform: AVFoundation/ScreenCaptureKit on macOS, native V4L2
-//!   on Linux, native Media Foundation (camera) and DXGI Desktop Duplication
-//!   (screen) on Windows. [`capture::Source`] picks a camera, a display, or
-//!   (macOS only) a single window or every window of an application;
-//!   [`capture::cameras`], [`capture::displays`], [`capture::windows`], and
-//!   [`capture::apps`] list what's available and hand back the ids it takes.
+//! - `capture` describes a frame source and grabs frames per platform:
+//!   AVFoundation/ScreenCaptureKit on macOS, native V4L2 on Linux, native Media
+//!   Foundation (camera) and DXGI Desktop Duplication (screen) on Windows. It
+//!   requires the default-on `capture` feature.
 //! - [`encode`] encodes frames with a native backend and publishes them through
 //!   the matching `moq_mux::codec` importer, which handles catalog registration
 //!   and framing. The codec is chosen via [`encode::Codec`]: H.264 (openh264 /
 //!   VideoToolbox / Media Foundation / NVENC / VAAPI) or H.265 (VideoToolbox /
 //!   Media Foundation / NVENC). Two entry points:
-//!   - [`encode::publish_capture`] captures a webcam and publishes it (turnkey).
+//!   - `encode::publish_capture` captures a webcam and publishes it (turnkey).
 //!     It encodes strictly on demand: the track and catalog are advertised up
 //!     front, but the camera opens only while a subscriber is watching and is
-//!     released when the last one leaves.
+//!     released when the last one leaves. It requires the `capture` feature.
 //!   - [`encode::Encoder`] encodes [`Frame`]s you supply (from capture, a
 //!     decoder, or your own pixels via [`Surface::rgba`]) and
 //!     [`encode::Producer`] publishes the results.
@@ -63,6 +60,7 @@
 //! fallback in [`Surface::into_i420`], so matching on it stays portable: take the
 //! fast path you recognize and let the `_` arm handle the rest.
 
+#[cfg(feature = "capture")]
 pub mod capture;
 pub mod decode;
 pub mod encode;

--- a/rs/moq-video/src/render/mod.rs
+++ b/rs/moq-video/src/render/mod.rs
@@ -1,7 +1,7 @@
 //! Draw decoded frames on the GPU, handing back a texture you present.
 //!
 //! The egress half of the zero-copy story, and the fourth role module alongside
-//! [`capture`](crate::capture), [`encode`](crate::encode) and
+//! capture, [`encode`](crate::encode) and
 //! [`decode`](crate::decode). [`decode`](crate::decode) keeps a hardware-decoded
 //! frame on the GPU; this draws it there too, converting YUV to RGB in a shader
 //! instead of downloading pixels to convert them on the CPU.


### PR DESCRIPTION
## Summary

Repair the native release paths that failed after the v0.5.43 / v0.3.9 release.

- Package the `moq-token` executable consistently across Linux, macOS, Windows, Homebrew, and native packages.
- Keep V4L2 and JPEG camera-capture dependencies out of `moq-ffi` builds while retaining capture for direct `moq-video` consumers and `moq-cli --features capture`.
- Install Android Rust targets into the repository-pinned toolchain before invoking `cargo-ndk`.
- Document the new capture feature boundary.

## Root cause

The token crate's binary is named `moq-token`, but release workflows and Homebrew expected `moq-token-cli`. Python FFI wheels inherited Linux camera-capture dependencies even though the FFI only exposes raw encode/decode. Kotlin release targets were installed into floating stable while the build selected the pinned Rust toolchain, leaving Android builds without `std`.

## Validation

- `nix develop --command just check`
- `nix develop --command cargo nextest run --locked --package moq-video --package moq-ffi` (123 passed)
- codec-only `moq-video` and `moq-ffi` compilation
- `moq-cli` capture-feature compilation
- native macOS token artifact packaging

The OpenH264 simulator repair is intentionally outside this PR.

(Written by GPT-5)