### PR TITLE
docs(drafts): spec the timeline track and compressed catalog in moq-hang

### DIFF
--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -101,7 +101,7 @@ Each group contains a single frame with UTF-8 JSON.
 
 A publisher MUST NOT write multiple frames to a group until a future specification includes a delta-encoding mechanism (via JSON Patch most likely).
 
-A publisher SHOULD also serve the catalog as a `catalog.json.z` track: the identical JSON, compressed ({{compression}}).
+A publisher SHOULD also serve the catalog as a `catalog.json.z` track: the identical JSON under the same group and frame rules, differing only by compression ({{compression}}).
 A consumer reads whichever of the two tracks it prefers.
 
 ## Root
@@ -347,7 +347,7 @@ A publisher MUST omit this trailing marker from each frame and a consumer MUST a
 
 
 # Timeline {#timeline}
-A media track MAY have a companion timeline track: an ordered log mapping each of the media track's groups to its start timestamp.
+A media track MAY have a companion timeline track: an ordered log mapping the media track's groups to their start timestamps.
 On the wire a group carries only a sequence number; the timestamps live inside the media frames.
 The timeline republishes that mapping as metadata, so a consumer can determine which group covers a given time, and where the live edge is, without downloading the media itself.
 This is the primitive used to seek, or to serve HLS/DASH playlists.
@@ -362,16 +362,20 @@ type Timeline = {
 }
 ~~~
 
-The `track` field names the timeline track, published in the same broadcast as the catalog.
+The `track` field names the timeline track, published in the same broadcast as the media track it indexes: the rendition's `broadcast` field ({{field-broadcast}}), when present, relocates the timeline along with the media.
 The conventional name is the media track's name with a `.timeline.z` suffix, but a consumer MUST use the name from the catalog rather than deriving it.
 Renditions MAY share a timeline track when their group boundaries are aligned, for example a transcode ladder mirroring the source's groups.
 Audio and video groups have different durations, so each declares its own timeline.
 
-The `timescale` field is the number of timestamp units per second, defaulting to 1000 (milliseconds).
+The `timescale` field is the number of timestamp units per second, a positive integer defaulting to 1000 (milliseconds).
+A value of 0 is invalid; a consumer MUST reject a timeline that declares it.
 
 The `wall` field anchors the timeline to the wall clock, if known: the wall-clock time of timestamp 0, in `timescale` units since the moq epoch, 2020-01-01T00:00:00Z (1577836800 Unix seconds).
-Measuring from 2020 rather than 1970 keeps the value safely within a 53-bit JSON integer even at fine timescales.
+Measuring from 2020 rather than 1970 keeps the values small.
 A consumer derives the wall-clock time of any group as `wall + pts`.
+
+Timeline integers (`timescale`, `wall`, and each record's `pts`) MUST NOT exceed 2^53 - 1, so they survive JSON consumers that parse numbers as IEEE 754 doubles.
+A publisher chooses a `timescale` coarse enough to honor this bound.
 
 ## Timeline Track
 The timeline track is a single compressed ({{compression}}) group that is never rolled.
@@ -386,14 +390,16 @@ type Record = {
 ~~~
 
 The `group` field is the sequence number of the media track's group, as used by subscriptions and fetches.
-The `pts` field is the group's start, its first frame's presentation timestamp, in the timeline's `timescale`.
+The `pts` field is the group's start, its first frame's presentation timestamp, re-expressed in the timeline's `timescale` (rounding down when the media clock is finer).
 Additional fields MAY be added based on the application; a consumer MUST ignore fields it does not recognize.
 
-A record is appended when the media group opens, so the live edge of the timeline is the live edge of the media.
-A group's duration is implicit: the gap to the next record.
+A record is appended when its group opens, so the live edge of the timeline is the live edge of the media.
+A publisher MAY throttle records to a granularity, emitting at most one record per some amount of media time; video keyframes are usually at least that far apart, while short audio groups are thinned out.
 
-A publisher MAY throttle records to a granularity, emitting at most one record per some amount of media time.
-Group sequence numbers are contiguous, so a consumer that lands between two records can extrapolate the group number or inspect the media to fill the gap.
+A record therefore spans from its `pts` until the next record's `pts`: the named group plus any unrecorded groups that opened in between.
+The last record's span extends to the live edge, its duration unknown until the next record arrives.
+A consumer looks up a time by finding the record whose span covers it, which names the group to fetch first.
+To locate an individual unrecorded group within a span, a consumer MAY extrapolate from the surrounding records when the media track's group sequence numbers are contiguous, or inspect the fetched media itself.
 
 
 # Security Considerations

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -101,6 +101,9 @@ Each group contains a single frame with UTF-8 JSON.
 
 A publisher MUST NOT write multiple frames to a group until a future specification includes a delta-encoding mechanism (via JSON Patch most likely).
 
+A publisher SHOULD also serve the catalog as a `catalog.json.z` track: the identical JSON, compressed ({{compression}}).
+A consumer reads whichever of the two tracks it prefers.
+
 ## Root
 The root of the catalog is a JSON document with the following schema:
 
@@ -258,6 +261,7 @@ type CommonExtensions = {
   "broadcast": string | undefined,
   "container": Container,
   "jitter": number | undefined,
+  "timeline": Timeline | undefined,
 }
 ~~~
 
@@ -291,6 +295,9 @@ For example:
 
 An audio frame's duration is codec dependent.
 AAC often uses 1024 samples per frame, so at 44100Hz an immediately-flushed track's `jitter` is 23.
+
+### timeline {#field-timeline}
+The companion timeline track indexing this rendition's groups ({{timeline}}), if the publisher offers one.
 
 # Container {#container}
 Audio and video tracks use a container to encapsulate the media payload.
@@ -326,6 +333,67 @@ A consumer MUST feed `init` to the decoder before the first frame.
 
 ## loc
 Each frame is a Low Overhead Container frame {{!I-D.ietf-moq-loc}}: a property block, carrying the timestamp among other properties, followed by the codec payload.
+
+
+# Compression {#compression}
+Some metadata tracks are compressed, conventionally marked with a `.z` suffix on the track name.
+
+Each group is one raw DEFLATE stream ({{!RFC1951}}), sync-flushed at each frame boundary.
+Each frame is therefore a self-delimited, byte-aligned slice, while later frames compress against the earlier ones in the same group.
+A consumer MUST decompress a group's frames in order, starting from the first.
+
+A sync flush ends with the empty-block marker `0x00 0x00 0xff 0xff`.
+A publisher MUST omit this trailing marker from each frame and a consumer MUST append it before decompressing, the same trick as permessage-deflate ({{!RFC7692, Section 7.2.1}}).
+
+
+# Timeline {#timeline}
+A media track MAY have a companion timeline track: an ordered log mapping each of the media track's groups to its start timestamp.
+On the wire a group carries only a sequence number; the timestamps live inside the media frames.
+The timeline republishes that mapping as metadata, so a consumer can determine which group covers a given time, and where the live edge is, without downloading the media itself.
+This is the primitive used to seek, or to serve HLS/DASH playlists.
+
+A rendition advertises its timeline via the `timeline` field ({{common}}):
+
+~~~
+type Timeline = {
+  "track": string,
+  "timescale": number | undefined,
+  "wall": number | undefined,
+}
+~~~
+
+The `track` field names the timeline track, published in the same broadcast as the catalog.
+The conventional name is the media track's name with a `.timeline.z` suffix, but a consumer MUST use the name from the catalog rather than deriving it.
+Renditions MAY share a timeline track when their group boundaries are aligned, for example a transcode ladder mirroring the source's groups.
+Audio and video groups have different durations, so each declares its own timeline.
+
+The `timescale` field is the number of timestamp units per second, defaulting to 1000 (milliseconds).
+
+The `wall` field anchors the timeline to the wall clock, if known: the wall-clock time of timestamp 0, in `timescale` units since the moq epoch, 2020-01-01T00:00:00Z (1577836800 Unix seconds).
+Measuring from 2020 rather than 1970 keeps the value safely within a 53-bit JSON integer even at fine timescales.
+A consumer derives the wall-clock time of any group as `wall + pts`.
+
+## Timeline Track
+The timeline track is a single compressed ({{compression}}) group that is never rolled.
+Each frame is one UTF-8 JSON record:
+
+~~~
+type Record = {
+  "group": number,
+  "pts": number,
+  // ... any custom fields ...
+}
+~~~
+
+The `group` field is the sequence number of the media track's group, as used by subscriptions and fetches.
+The `pts` field is the group's start, its first frame's presentation timestamp, in the timeline's `timescale`.
+Additional fields MAY be added based on the application; a consumer MUST ignore fields it does not recognize.
+
+A record is appended when the media group opens, so the live edge of the timeline is the live edge of the media.
+A group's duration is implicit: the gap to the next record.
+
+A publisher MAY throttle records to a granularity, emitting at most one record per some amount of media time.
+Group sequence numbers are contiguous, so a consumer that lands between two records can extrapolate the group number or inspect the media to fill the gap.
 
 
 # Security Considerations


### PR DESCRIPTION
## Summary

The hang draft had drifted from the implementation. The catalog code (`rs/hang/src/catalog`, `js/hang/src/catalog`) carries a per-rendition `timeline` field pointing at a companion timeline track, and publishes a compressed `catalog.json.z` sibling, but `draft-lcurley-moq-hang` documented neither. This reconciles the draft with the implementation as the source of truth:

- **Timeline section**: the per-rendition `Timeline` catalog schema (`track`, `timescale` defaulting to 1000, `wall` anchored to the 2020-01-01 moq epoch) and the timeline track format (a single never-rolled compressed group of `{group, pts}` JSON records, appended at group open, duration implicit, optional granularity throttling). Matches `rs/hang/src/catalog/timeline.rs`, `rs/hang/src/timeline.rs`, and the `moq-mux` timeline producer/consumer.
- **Compression section**: the shared-window sync-flushed raw DEFLATE framing (RFC 1951 with the RFC 7692 trailing-marker trick) used by the `.z` tracks, matching `moq-flate`.
- **Common rendition fields**: add `timeline` alongside `broadcast`/`container`/`jitter`.
- **Catalog**: note the `catalog.json.z` sibling a publisher SHOULD also serve.

Notably *not* touched: the `text` root section, which was already cleanly reverted from both the draft and the implementation on main by #2571 (it lives on dev), so draft and code agree there.

Docs-only; no wire change (the draft catches up to what already ships). No changelog appendix exists in this draft, so none updated.

## Testing

- `nix develop --command just drafts check` (kramdown-rfc parses all drafts)
- `nix develop --command bun run --cwd doc check` (VitePress renders the generated /draft/ pages; drafts.test.ts passes, only existing kramdown constructs used)

(written by Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)