### PR TITLE
refactor(net)!: require the poll-based transport interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,6 +5105,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
+ "futures",
  "getrandom 0.4.3",
  "js-sys",
  "moq-net",

--- a/doc/lib/rs/env/index.md
+++ b/doc/lib/rs/env/index.md
@@ -7,7 +7,8 @@ description: Where Rust MoQ clients run, native and WebAssembly
 
 The same Rust crates ([`moq-net`](/lib/rs/crate/moq-net), [`hang`](/lib/rs/crate/hang))
 target two very different environments. `moq-net` is transport-agnostic: it runs
-over anything that implements [`web_transport_trait::Session`](https://docs.rs/web-transport-trait),
+over anything that implements the poll interface
+([`web_transport_trait::poll::Session`](https://docs.rs/web-transport-trait)),
 so the only thing that changes between environments is which transport you hand it.
 
 ## [Native](/lib/rs/env/native) <Badge type="tip" text="server, desktop, mobile" />

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -13,7 +13,7 @@ This guide covers connecting to a relay, discovering broadcasts, subscribing to 
 The key crates:
 
 - [moq-native](https://crates.io/crates/moq-native): Configures QUIC (via [quinn](https://crates.io/crates/quinn) by default, with [noq](https://crates.io/crates/noq) available through the `noq` feature) and TLS (via [rustls](https://crates.io/crates/rustls)) for you.
-- [moq-net](https://crates.io/crates/moq-net) — The core networking layer. Can be used directly with any `web_transport_trait::Session` implementation if you need full control over the QUIC endpoint.
+- [moq-net](https://crates.io/crates/moq-net) — The core networking layer. Can be used directly with any `web_transport_trait::poll::Session` implementation if you need full control over the QUIC endpoint.
 - [hang](https://crates.io/crates/hang) — Media-specific catalog and container format on top of `moq-net`.
 
 ## Connecting

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -13,7 +13,7 @@ This guide covers connecting to a relay, discovering broadcasts, subscribing to 
 The key crates:
 
 - [moq-native](https://crates.io/crates/moq-native): Configures QUIC (via [quinn](https://crates.io/crates/quinn) by default, with [noq](https://crates.io/crates/noq) available through the `noq` feature) and TLS (via [rustls](https://crates.io/crates/rustls)) for you.
-- [moq-net](https://crates.io/crates/moq-net) — The core networking layer. Can be used directly with any `web_transport_trait::poll::Session` implementation if you need full control over the QUIC endpoint.
+- [moq-net](https://crates.io/crates/moq-net): The core networking layer. Can be used directly with any `web_transport_trait::poll::Session` implementation if you need full control over the QUIC endpoint.
 - [hang](https://crates.io/crates/hang) — Media-specific catalog and container format on top of `moq-net`.
 
 ## Connecting

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -18,18 +18,20 @@ browser implementation.
 ## How it fits together
 
 `moq-net` talks to anything that implements
-[`web_transport_trait::poll::Session`](https://docs.rs/web-transport-trait);
-`moq-wasm` adapts the browser's promise-based transport to that interface
-internally.
-The [`web-transport`](https://crates.io/crates/web-transport) meta-crate picks
-the backend by target automatically:
+[`web_transport_trait::poll::Session`](https://docs.rs/web-transport-trait), the
+poll-based transport interface.
 
-- **native** → [`web-transport-quinn`](https://crates.io/crates/web-transport-quinn) (a real QUIC stack)
-- **wasm** → [`web-transport-wasm`](https://crates.io/crates/web-transport-wasm) (a thin wrapper over the browser's `WebTransport`)
+- **native**: [`web-transport-quinn`](https://crates.io/crates/web-transport-quinn)
+  (a real QUIC stack) implements the poll interface directly.
+- **wasm**: [`web-transport-wasm`](https://crates.io/crates/web-transport-wasm)
+  (a thin wrapper over the browser's `WebTransport`) exposes only the
+  promise-based interface today, so it needs an adapter to satisfy `moq-net`'s
+  bound. This repo carries one in `rs/moq-wasm/src/transport.rs` (the adapter
+  behind the `@moq/wasm` package); copy it or use `moq-wasm` until
+  `web-transport-wasm` implements the poll interface natively.
 
-So the same `moq-net` code works in both places. On wasm you skip
-[`moq-native`](/lib/rs/crate/moq-native) entirely (it's quinn-only) and get the
-`Session` from `web-transport` instead.
+On wasm you skip [`moq-native`](/lib/rs/crate/moq-native) entirely (it's
+quinn-only).
 
 ::: warning No `Send` on wasm
 Browser wasm is single-threaded and its `WebTransport` handles aren't `Send`,
@@ -61,18 +63,16 @@ trunk serve
 
 ## Connecting
 
-Build a transport `Session` with `web-transport`, then hand it to
+Build a poll-interface transport `Session` (see above), then hand it to
 [`moq_net::Client`](https://docs.rs/moq-net/latest/moq_net/struct.Client.html).
 From there the pub/sub API is identical to [native](/lib/rs/env/native):
 
 ```rust
 let url = url::Url::parse("https://cdn.moq.dev/anon")?;
 
-// On wasm this wraps the browser's native WebTransport.
-let transport = web_transport::ClientBuilder::new()
-    .with_system_roots()
-    .connect(url)
-    .await?;
+// The poll-interface adapter over the browser's native WebTransport
+// (rs/moq-wasm/src/transport.rs; see "How it fits together" above).
+let transport = transport::connect(url).await?;
 
 // Hand the transport to moq-net and run the MoQ handshake.
 let origin = moq_net::Origin::random().produce();

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -26,8 +26,8 @@ poll-based transport interface.
 - **wasm**: [`web-transport-wasm`](https://crates.io/crates/web-transport-wasm)
   (a thin wrapper over the browser's `WebTransport`) exposes only the
   promise-based interface today, so it needs an adapter to satisfy `moq-net`'s
-  bound. This repo carries one in `rs/moq-wasm/src/transport.rs` (the adapter
-  behind the `@moq/wasm` package); copy it or use `moq-wasm` until
+  bound. This repo carries one as `moq_wasm::transport` (the adapter behind the
+  `@moq/wasm` package); depend on `moq-wasm` from git until
   `web-transport-wasm` implements the poll interface natively.
 
 On wasm you skip [`moq-native`](/lib/rs/crate/moq-native) entirely (it's
@@ -46,7 +46,8 @@ executor like a default `tokio` runtime.
 # Cargo.toml
 [dependencies]
 moq-net = "0.1"
-web-transport = "0.10"
+# The WebTransport poll adapter; unpublished, so pull it from git.
+moq-wasm = { git = "https://github.com/moq-dev/moq" }
 url = "2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
@@ -71,8 +72,8 @@ From there the pub/sub API is identical to [native](/lib/rs/env/native):
 let url = url::Url::parse("https://cdn.moq.dev/anon")?;
 
 // The poll-interface adapter over the browser's native WebTransport
-// (rs/moq-wasm/src/transport.rs; see "How it fits together" above).
-let transport = transport::connect(url).await?;
+// (see "How it fits together" above).
+let transport = moq_wasm::transport::connect(url).await?;
 
 // Hand the transport to moq-net and run the MoQ handshake.
 let origin = moq_net::Origin::random().produce();

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -17,7 +17,10 @@ browser implementation.
 
 ## How it fits together
 
-`moq-net` talks to anything that implements [`web_transport_trait::Session`](https://docs.rs/web-transport-trait).
+`moq-net` talks to anything that implements
+[`web_transport_trait::poll::Session`](https://docs.rs/web-transport-trait);
+`moq-wasm` adapts the browser's promise-based transport to that interface
+internally.
 The [`web-transport`](https://crates.io/crates/web-transport) meta-crate picks
 the backend by target automatically:
 

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -73,7 +73,7 @@ let url = url::Url::parse("https://cdn.moq.dev/anon")?;
 
 // The poll-interface adapter over the browser's native WebTransport
 // (see "How it fits together" above).
-let transport = moq_wasm::transport::connect(url).await?;
+let transport = moq_wasm::transport::connect(url, Default::default()).await?;
 
 // Hand the transport to moq-net and run the MoQ handshake.
 let origin = moq_net::Origin::random().produce();

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -42,6 +42,7 @@ ring = ["rustls/ring", "rcgen?/ring", "quinn?/rustls-ring", "web-transport-noq?/
 android-logcat = ["dep:tracing-android"]
 
 [dependencies]
+bytes = "1"
 clap = { version = "4", features = ["derive", "env"] }
 futures = "0.3"
 hex = "0.4"

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -535,7 +535,7 @@ impl Client {
 		#[cfg(feature = "tcp")]
 		if url.scheme() == "tcp" {
 			let session = crate::tcp::connect(url, &self.versions.alpns(), self.failover_delay).await?;
-			return Ok(moq.connect(session).await?);
+			return Ok(moq.connect(crate::transport::Async::new(session)).await?);
 		}
 
 		// Unix domain socket (qmux, no TLS). Same-host only; the server can
@@ -543,7 +543,7 @@ impl Client {
 		#[cfg(all(feature = "uds", unix))]
 		if url.scheme() == "unix" {
 			let session = crate::unix::connect(url, &self.versions.alpns()).await?;
-			return Ok(moq.connect(session).await?);
+			return Ok(moq.connect(crate::transport::Async::new(session)).await?);
 		}
 
 		// iroh offers the moq ALPNs ahead of H3, so two moq endpoints normally land on raw
@@ -561,14 +561,19 @@ impl Client {
 				crate::iroh::Binding::H3 => self.moq.clone(),
 			};
 
-			return Ok(moq.connect(session).await?);
+			return Ok(moq.connect(crate::transport::Async::new(session)).await?);
 		}
 
 		#[cfg(feature = "noq")]
 		if let Some(noq) = self.noq.as_ref() {
 			let tls = self.tls.clone();
 			let quic_url = url.clone();
-			let quic_handle = async { noq.connect(&tls, quic_url, &self.versions).await.map_err(Error::from) };
+			let quic_handle = async {
+				noq.connect(&tls, quic_url, &self.versions)
+					.await
+					.map(crate::transport::Async::new)
+					.map_err(Error::from)
+			};
 
 			#[cfg(feature = "websocket")]
 			{
@@ -621,7 +626,7 @@ impl Client {
 		{
 			let alpns = self.versions.alpns();
 			let session = crate::websocket::connect(&self.websocket, &self.tls, url, &alpns).await?;
-			return Ok(moq.connect(session).await?);
+			return Ok(moq.connect(crate::transport::Async::new(session)).await?);
 		}
 
 		#[cfg(not(feature = "websocket"))]
@@ -645,7 +650,7 @@ impl Client {
 	) -> crate::Result<(moq_net::Session, moq_net::Driver)>
 	where
 		Q: Future<Output = crate::Result<S>>,
-		S: web_transport_trait::Session,
+		S: moq_net::transport::poll::Session,
 	{
 		let alpns = self.versions.alpns();
 		let ws_config = self.websocket.clone();
@@ -658,7 +663,9 @@ impl Client {
 
 		match race_transport_connect(quic, websocket).await? {
 			TransportRace::Quic(quic) => Ok(moq.connect(quic).await?),
-			TransportRace::WebSocket(websocket) => Ok(self.moq.connect(websocket).await?),
+			TransportRace::WebSocket(websocket) => {
+				Ok(self.moq.connect(crate::transport::Async::new(websocket)).await?)
+			}
 		}
 	}
 }

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -34,6 +34,7 @@ mod server;
 #[cfg(feature = "tcp")]
 pub mod tcp;
 pub mod tls;
+pub mod transport;
 #[cfg(all(feature = "uds", unix))]
 pub mod unix;
 // Resolving a `host:port` bind string is a QUIC-listener concern; the stream

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -506,7 +506,7 @@ impl Server {
 							// MoQ SETUP up front, so path/role are known before the caller authorizes
 							// (like the stream bindings).
 							let (session, url, identity) = super::noq::accept(_conn, alpns).await?;
-							let request = server.accept_request(session).await?;
+							let request = server.accept_request(crate::transport::Async::new(session)).await?;
 							Ok(Request { transport: Transport::Quic, url, identity, kind: RequestKind::Noq(Box::new(request)) })
 						}.boxed());
 					}
@@ -537,7 +537,7 @@ impl Server {
 					#[cfg(feature = "iroh")]
 					self.accept.push(async move {
 						let (session, url, identity) = super::iroh::accept(_conn).await?;
-						let request = server.accept_request(session).await?;
+						let request = server.accept_request(crate::transport::Async::new(session)).await?;
 						Ok(Request { transport: Transport::Iroh, url, identity, kind: RequestKind::Iroh(Box::new(request)) })
 					}.boxed());
 				}
@@ -548,7 +548,7 @@ impl Server {
 							// Read the SETUP off the qmux session before handing it over, so a
 							// slow peer doesn't stall the accept loop (spawned like the others).
 							self.accept.push(async move {
-								let request = server.accept_request(session).await?;
+								let request = server.accept_request(crate::transport::Async::new(session)).await?;
 								Ok(Request { transport: Transport::WebSocket, url: Some(url), identity: None, kind: RequestKind::Qmux(Box::new(request)) })
 							}.boxed());
 						}
@@ -948,7 +948,7 @@ fn spawn_stream_request(
 	tx: tokio::sync::mpsc::Sender<Request>,
 ) {
 	tokio::spawn(async move {
-		match server.accept_request(session).await {
+		match server.accept_request(crate::transport::Async::new(session)).await {
 			Ok(request) => {
 				let request = Request {
 					transport,
@@ -971,15 +971,15 @@ fn spawn_stream_request(
 /// underlying session type; all of them delegate identically.
 pub(crate) enum RequestKind {
 	#[cfg(feature = "noq")]
-	Noq(Box<moq_net::Request<web_transport_noq::Session>>),
+	Noq(Box<moq_net::Request<crate::transport::Async<web_transport_noq::Session>>>),
 	#[cfg(feature = "quinn")]
 	Quinn(Box<moq_net::Request<web_transport_quinn::Session>>),
 	#[cfg(feature = "quiche")]
 	Quiche(Box<moq_net::Request<web_transport_quiche::Connection>>),
 	#[cfg(feature = "iroh")]
-	Iroh(Box<moq_net::Request<web_transport_iroh::Session>>),
+	Iroh(Box<moq_net::Request<crate::transport::Async<web_transport_iroh::Session>>>),
 	#[cfg(any(feature = "tcp", all(feature = "uds", unix), feature = "websocket"))]
-	Qmux(Box<moq_net::Request<qmux::Session>>),
+	Qmux(Box<moq_net::Request<crate::transport::Async<qmux::Session>>>),
 }
 
 /// The network transport carrying an incoming MoQ session.

--- a/rs/moq-native/src/transport.rs
+++ b/rs/moq-native/src/transport.rs
@@ -46,7 +46,11 @@ type OpBox<T> = futures::future::BoxFuture<'static, T>;
 ///   `closed(&mut self)` cannot be stored as a `'static` watch without taking
 ///   the stream with it). A receive stream reports closed through its reads
 ///   (FIN drained, or a read error), buffering bounded read-ahead so a FIN
-///   behind undelivered payload still resolves the watch. A send stream only
+///   behind undelivered payload still resolves the watch; past the cap the
+///   watch parks until the caller's reads drain the backlog, deliberately
+///   trading watch liveness on an undrained flooding stream for a memory
+///   bound (every driver in this crate drains its reads alongside the watch).
+///   A send stream only
 ///   starts the real watch once `finish` or `reset` makes it terminal; before
 ///   that a closure surfaces as an error on the next write instead of waking an
 ///   idle watch. The send-side gap this leaves: a peer that resets a stream
@@ -213,20 +217,28 @@ pub struct AsyncSend<S: web_transport_trait::SendStream + 'static> {
 	/// Whether `finish` or `reset` has been observed, so no further writes can
 	/// come and the closed() watch may safely take ownership of the stream.
 	terminal: bool,
-	/// A write driven to completion by [`poll_closed`](wt_poll::SendStream::poll_closed)
-	/// rather than [`poll_write`](wt_poll::SendStream::poll_write). The caller was told
-	/// `Pending` and is contractually retrying the same bytes, so the next `poll_write`
-	/// reports this write instead of putting the bytes on the wire a second time.
-	completed: Option<Bytes>,
+	/// Bytes already transmitted but not yet reported to the caller: a write the
+	/// stored future finished (possibly inside
+	/// [`poll_closed`](wt_poll::SendStream::poll_closed)) while the caller held a
+	/// `Pending`. Later `poll_write` calls reconcile against the buffer actually
+	/// presented (the poll contract allows a shorter retry), reporting and
+	/// consuming a prefix per call, never writing these bytes a second time.
+	completed: Bytes,
+	/// Cancels the in-flight write so a reset applies immediately instead of
+	/// waiting behind blocked I/O (whose partial progress a reset discards
+	/// anyway). Fired by [`reset`](wt_poll::SendStream::reset) and by [`Drop`].
+	interrupt: Option<futures::channel::oneshot::Sender<()>>,
 }
 
 enum SendState<S: web_transport_trait::SendStream + 'static> {
 	Idle(S),
 	/// A write in flight; `chunk` is the copied bytes, kept (refcounted, no
 	/// extra copy) so a completion absorbed by `poll_closed` can verify the
-	/// retrying caller supplied the same bytes.
+	/// retrying caller supplied the same bytes. A `None` result means the write
+	/// was interrupted by a reset (see [`AsyncSend::interrupt`]).
 	Writing {
-		fut: OpBox<(S, Result<(), S::Error>)>,
+		#[allow(clippy::type_complexity)]
+		fut: OpBox<(S, Option<Result<(), S::Error>>)>,
 		chunk: Bytes,
 	},
 	Closing(OpBox<(S, Result<(), S::Error>)>),
@@ -241,7 +253,8 @@ impl<S: web_transport_trait::SendStream + 'static> AsyncSend<S> {
 			finish: false,
 			reset: None,
 			terminal: false,
-			completed: None,
+			completed: Bytes::new(),
+			interrupt: None,
 		}
 	}
 
@@ -266,18 +279,21 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 	type Error = S::Error;
 
 	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
-		// A previous write completed inside poll_closed; report it instead of
-		// writing the same bytes a second time. The retry contract says the
-		// caller re-supplies the bytes it was told Pending for.
-		if let Some(chunk) = self.completed.take() {
-			debug_assert_eq!(
-				buf.get(..chunk.len()),
-				Some(&chunk[..]),
-				"poll_write must retry the same bytes it was told Pending for"
-			);
-			return Poll::Ready(Ok(chunk.len()));
-		}
 		loop {
+			// Transmitted-but-unreported bytes from a completed write are
+			// reconciled against the buffer presented NOW: the poll contract
+			// allows a retry with a shorter buffer, so report (and consume) at
+			// most its length and keep the rest for the next call.
+			if !self.completed.is_empty() && !buf.is_empty() {
+				let n = buf.len().min(self.completed.len());
+				let reported = self.completed.split_to(n);
+				debug_assert_eq!(
+					&buf[..n],
+					&reported[..],
+					"poll_write retries must present the bytes already accepted"
+				);
+				return Poll::Ready(Ok(n));
+			}
 			match self.state.get_mut().unwrap().take().expect("in-flight") {
 				SendState::Idle(mut stream) => {
 					if buf.is_empty() {
@@ -289,8 +305,25 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 					// until this resolves (see [`Async`]).
 					let chunk = Bytes::copy_from_slice(buf);
 					let retained = chunk.clone();
+					let (tx, rx) = futures::channel::oneshot::channel::<()>();
+					self.interrupt = Some(tx);
 					let fut = async move {
-						let res = stream.write_chunk(chunk).await;
+						let res = {
+							let mut op = std::pin::pin!(stream.write_chunk(chunk).fuse());
+							let mut rx = rx.fuse();
+							loop {
+								futures::select_biased! {
+									res = op => break Some(res),
+									cancel = rx => match cancel {
+										Ok(()) => break None,
+										// A dropped (unfired) sender must not interrupt;
+										// only an explicit reset does. The fused arm goes
+										// quiet and the write keeps driving.
+										Err(_) => continue,
+									},
+								}
+							}
+						};
 						(stream, res)
 					}
 					.boxed();
@@ -302,10 +335,18 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
+						self.interrupt = None;
 						self.settle(&mut stream);
 						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
-						res?;
-						return Poll::Ready(Ok(chunk.len()));
+						// An interrupted write was abandoned for a reset, which
+						// settle just applied; the next iteration's write reports
+						// the stream state.
+						if let Some(res) = res {
+							res?;
+							// Reported through the reconciliation at the top of the
+							// loop, which caps it at the presented buffer's length.
+							self.completed = chunk;
+						}
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -344,7 +385,14 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 		self.terminal = true;
 		match self.state.get_mut().unwrap().as_mut() {
 			Some(SendState::Idle(stream)) => stream.reset(code),
-			_ => self.reset = Some(code),
+			_ => {
+				self.reset = Some(code);
+				// A reset discards the in-flight write's progress anyway, so
+				// cancel it rather than letting blocked I/O delay the code.
+				if let Some(tx) = self.interrupt.take() {
+					let _ = tx.send(());
+				}
+			}
 		}
 	}
 
@@ -374,16 +422,20 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
+						self.interrupt = None;
 						self.settle(&mut stream);
 						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
-						// A failed write is a closed stream; report it here.
-						if let Err(err) = res {
-							return Poll::Ready(Err(err));
+						match res {
+							// A failed write is a closed stream; report it here.
+							Some(Err(err)) => return Poll::Ready(Err(err)),
+							// The caller of poll_write was told Pending and will
+							// retry; poll_write's reconciliation reports these bytes
+							// instead of writing them a second time.
+							Some(Ok(())) => self.completed = chunk,
+							// Interrupted for a reset, applied by settle above; the
+							// next iteration starts the real closed watch.
+							None => {}
 						}
-						// The caller of poll_write was told Pending and will retry the
-						// same bytes; record the completion so the retry reports it
-						// instead of writing the bytes a second time.
-						self.completed = Some(chunk);
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -416,8 +468,11 @@ impl<S: web_transport_trait::SendStream + 'static> Drop for AsyncSend<S> {
 			// and lose the deferred reset code or FIN the caller asked for. The
 			// peer uses that code to classify the abort (Old vs Cancel vs
 			// Evicted), so finish the operation on the runtime and apply the
-			// terminal action then. Without a runtime the default drop stands.
-			Some(SendState::Writing { fut, .. }) | Some(SendState::Closing(fut)) => {
+			// terminal action then. A deferred reset fired the interrupt when it
+			// was recorded, so the salvage task never waits on blocked I/O; a
+			// deferred finish lets the write complete first (the FIN follows the
+			// data). Without a runtime the default drop stands.
+			Some(SendState::Writing { fut, .. }) => {
 				let reset = self.reset.take();
 				let finish = std::mem::take(&mut self.finish);
 				if (reset.is_some() || finish)
@@ -430,6 +485,19 @@ impl<S: web_transport_trait::SendStream + 'static> Drop for AsyncSend<S> {
 							None => {
 								let _ = stream.finish();
 							}
+						}
+					});
+				}
+			}
+			Some(SendState::Closing(fut)) => {
+				let reset = self.reset.take();
+				if reset.is_some()
+					&& let Ok(handle) = tokio::runtime::Handle::try_current()
+				{
+					handle.spawn(async move {
+						let (mut stream, _) = fut.await;
+						if let Some(code) = reset {
+							stream.reset(code);
 						}
 					});
 				}
@@ -457,6 +525,10 @@ pub struct AsyncRecv<S: web_transport_trait::RecvStream + 'static> {
 	fin: bool,
 	/// A deferred STOP_SENDING, applied when the in-flight operation settles.
 	stop: Option<u32>,
+	/// Cancels the in-flight read so a stop applies immediately instead of
+	/// waiting behind blocked I/O. Fired by [`stop`](wt_poll::RecvStream::stop)
+	/// and by [`Drop`].
+	interrupt: Option<futures::channel::oneshot::Sender<()>>,
 }
 
 /// How much the closed-watch may read ahead of the caller before it parks and
@@ -466,7 +538,9 @@ const READ_AHEAD_CAP: usize = 64 * 1024;
 
 enum RecvState<S: web_transport_trait::RecvStream + 'static> {
 	Idle(S),
-	Reading(#[allow(clippy::type_complexity)] OpBox<(S, Result<Option<Bytes>, S::Error>)>),
+	/// A read in flight; a `None` result means it was interrupted by a stop
+	/// (see [`AsyncRecv::interrupt`]).
+	Reading(#[allow(clippy::type_complexity)] OpBox<(S, Option<Result<Option<Bytes>, S::Error>>)>),
 }
 
 impl<S: web_transport_trait::RecvStream + 'static> AsyncRecv<S> {
@@ -479,6 +553,7 @@ impl<S: web_transport_trait::RecvStream + 'static> AsyncRecv<S> {
 			queued_len: 0,
 			fin: false,
 			stop: None,
+			interrupt: None,
 		}
 	}
 
@@ -500,8 +575,25 @@ impl<S: web_transport_trait::RecvStream + 'static> AsyncRecv<S> {
 					if let Some(code) = self.stop.take() {
 						stream.stop(code);
 					}
+					let (tx, rx) = futures::channel::oneshot::channel::<()>();
+					self.interrupt = Some(tx);
 					let fut = async move {
-						let res = stream.read_chunk(max).await;
+						let res = {
+							let mut op = std::pin::pin!(stream.read_chunk(max).fuse());
+							let mut rx = rx.fuse();
+							loop {
+								futures::select_biased! {
+									res = op => break Some(res),
+									cancel = rx => match cancel {
+										Ok(()) => break None,
+										// A dropped (unfired) sender must not interrupt;
+										// only an explicit stop does. The fused arm goes
+										// quiet and the read keeps driving.
+										Err(_) => continue,
+									},
+								}
+							}
+						};
 						(stream, res)
 					}
 					.boxed();
@@ -513,6 +605,7 @@ impl<S: web_transport_trait::RecvStream + 'static> AsyncRecv<S> {
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
+						self.interrupt = None;
 						// Apply a stop requested while the read was in flight now, not on
 						// the next read: a caller that stops and never reads again must
 						// still send STOP_SENDING.
@@ -520,6 +613,9 @@ impl<S: web_transport_trait::RecvStream + 'static> AsyncRecv<S> {
 							stream.stop(code);
 						}
 						*self.state.get_mut().unwrap() = Some(RecvState::Idle(stream));
+						// An interrupted read was abandoned for the stop applied
+						// above; the next iteration's read reports the stream state.
+						let Some(res) = res else { continue };
 						if let Ok(None) = &res {
 							self.fin = true;
 						}
@@ -578,7 +674,14 @@ impl<S: web_transport_trait::RecvStream + 'static> wt_poll::RecvStream for Async
 	fn stop(&mut self, code: u32) {
 		match self.state.get_mut().unwrap().as_mut() {
 			Some(RecvState::Idle(stream)) => stream.stop(code),
-			_ => self.stop = Some(code),
+			_ => {
+				self.stop = Some(code);
+				// The caller is discarding the stream, so cancel the in-flight
+				// read rather than letting blocked I/O delay the stop.
+				if let Some(tx) = self.interrupt.take() {
+					let _ = tx.send(());
+				}
+			}
 		}
 	}
 
@@ -623,8 +726,9 @@ impl<S: web_transport_trait::RecvStream + 'static> Drop for AsyncRecv<S> {
 			// The stream lives inside the in-flight read; dropping it here would
 			// fire the backend's default drop behavior (a code-0 stop) and lose
 			// the deferred code the peer classifies the abort by. Finish the
-			// read on the runtime and stop with the real code then. Without a
-			// runtime the default drop stands.
+			// read on the runtime and stop with the real code then; a deferred
+			// stop fired the interrupt when it was recorded, so the task never
+			// waits on blocked I/O. Without a runtime the default drop stands.
 			Some(RecvState::Reading(fut)) => {
 				if let Some(code) = self.stop.take()
 					&& let Ok(handle) = tokio::runtime::Handle::try_current()
@@ -834,6 +938,34 @@ mod tests {
 		);
 	}
 
+	// The poll contract allows retrying a pending write with a SHORTER buffer;
+	// transmitted-but-unreported bytes reconcile against the buffer presented,
+	// never reporting more than its length and never re-transmitting.
+	#[test]
+	fn a_completed_write_reconciles_against_a_shorter_retry() {
+		let fake = FakeSend::default();
+		fake.blocked.store(true, Ordering::SeqCst);
+		let mut send = AsyncSend::new(fake.clone());
+		let mut cx = cx();
+
+		assert!(send.poll_write(&mut cx, b"header").is_pending());
+		fake.blocked.store(false, Ordering::SeqCst);
+		assert!(send.poll_closed(&mut cx).is_pending());
+
+		// The caller shrank its buffer: only that much is reported per call.
+		assert_eq!(send.poll_write(&mut cx, b"hea"), Poll::Ready(Ok(3)));
+		assert_eq!(send.poll_write(&mut cx, b"der"), Poll::Ready(Ok(3)));
+		assert_eq!(
+			fake.writes.lock().unwrap().as_slice(),
+			b"header",
+			"the bytes must reach the stream exactly once"
+		);
+
+		// Fully reconciled: the next write is a fresh operation.
+		assert_eq!(send.poll_write(&mut cx, b"!"), Poll::Ready(Ok(1)));
+		assert_eq!(fake.writes.lock().unwrap().as_slice(), b"header!");
+	}
+
 	// A larger chunk than the destination is buffered and served across reads.
 	#[test]
 	fn recv_buffers_the_excess() {
@@ -914,7 +1046,7 @@ mod tests {
 		send.reset(9);
 		drop(send);
 
-		fake.blocked.store(false, Ordering::SeqCst);
+		// The write stays blocked forever: the reset must not wait behind it.
 		tokio::time::timeout(std::time::Duration::from_secs(1), async {
 			while fake.resets.lock().unwrap().is_empty() {
 				tokio::task::yield_now().await;
@@ -944,7 +1076,7 @@ mod tests {
 		wt_poll::RecvStream::stop(&mut recv, 11);
 		drop(recv);
 
-		blocked.store(false, Ordering::SeqCst);
+		// The read stays blocked forever: the stop must not wait behind it.
 		tokio::time::timeout(std::time::Duration::from_secs(1), async {
 			while stops.lock().unwrap().is_empty() {
 				tokio::task::yield_now().await;

--- a/rs/moq-native/src/transport.rs
+++ b/rs/moq-native/src/transport.rs
@@ -241,7 +241,9 @@ enum SendState<S: web_transport_trait::SendStream + 'static> {
 		fut: OpBox<(S, Option<Result<(), S::Error>>)>,
 		chunk: Bytes,
 	},
-	Closing(OpBox<(S, Result<(), S::Error>)>),
+	/// The closed() acknowledgement watch; a `None` result means it was
+	/// interrupted by a late reset (see [`AsyncSend::interrupt`]).
+	Closing(#[allow(clippy::type_complexity)] OpBox<(S, Option<Result<(), S::Error>>)>),
 }
 
 impl<S: web_transport_trait::SendStream + 'static> AsyncSend<S> {
@@ -287,10 +289,14 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 			if !self.completed.is_empty() && !buf.is_empty() {
 				let n = buf.len().min(self.completed.len());
 				let reported = self.completed.split_to(n);
-				debug_assert_eq!(
+				// A hard assert, not a debug one: these bytes are already on the
+				// wire and the bridge cannot un-send them, so a caller continuing
+				// with different data would silently corrupt the stream. Failing
+				// loudly is the only honest option left.
+				assert_eq!(
 					&buf[..n],
 					&reported[..],
-					"poll_write retries must present the bytes already accepted"
+					"poll_write must continue with the bytes the write bridge already transmitted"
 				);
 				return Poll::Ready(Ok(n));
 			}
@@ -355,6 +361,7 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, _res)) => {
+						self.interrupt = None;
 						self.settle(&mut stream);
 						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
 					}
@@ -409,8 +416,25 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
 						return Poll::Pending;
 					}
+					// Interruptible like a write: a late reset (the group machines
+					// cancel a finished stream this way) must not wait for a FIN
+					// acknowledgement that may never come.
+					let (tx, rx) = futures::channel::oneshot::channel::<()>();
+					self.interrupt = Some(tx);
 					let fut = async move {
-						let res = stream.closed().await;
+						let res = {
+							let mut op = std::pin::pin!(stream.closed().fuse());
+							let mut rx = rx.fuse();
+							loop {
+								futures::select_biased! {
+									res = op => break Some(res),
+									cancel = rx => match cancel {
+										Ok(()) => break None,
+										Err(_) => continue,
+									},
+								}
+							}
+						};
 						(stream, res)
 					}
 					.boxed();
@@ -444,9 +468,15 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
+						self.interrupt = None;
 						self.settle(&mut stream);
 						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
-						return Poll::Ready(res);
+						// An interrupted watch was abandoned for a late reset,
+						// which settle just applied; the next iteration watches
+						// the now-reset stream, which resolves promptly.
+						if let Some(res) = res {
+							return Poll::Ready(res);
+						}
 					}
 				},
 			}
@@ -780,6 +810,8 @@ mod tests {
 		priorities: Arc<Mutex<Vec<u8>>>,
 		finished: Arc<AtomicBool>,
 		resets: Arc<Mutex<Vec<u32>>>,
+		/// The peer never acknowledges the FIN: closed() stays pending forever.
+		never_ack: Arc<AtomicBool>,
 	}
 
 	impl web_transport_trait::SendStream for FakeSend {
@@ -812,7 +844,7 @@ mod tests {
 		}
 
 		async fn closed(&mut self) -> Result<(), Self::Error> {
-			match self.finished.load(Ordering::SeqCst) {
+			match self.finished.load(Ordering::SeqCst) && !self.never_ack.load(Ordering::SeqCst) {
 				true => Ok(()),
 				false => std::future::pending().await,
 			}
@@ -936,6 +968,31 @@ mod tests {
 			b"header",
 			"the bytes must reach the stream exactly once"
 		);
+	}
+
+	// A late reset must not wait behind a FIN acknowledgement that never comes:
+	// the group machines finish a stream and keep watching precisely so a late
+	// cancel can still reset it.
+	#[test]
+	fn a_late_reset_interrupts_the_ack_watch() {
+		let fake = FakeSend::default();
+		fake.never_ack.store(true, Ordering::SeqCst);
+		let mut send = AsyncSend::new(fake.clone());
+		let mut cx = cx();
+
+		assert_eq!(send.poll_write(&mut cx, b"bye"), Poll::Ready(Ok(3)));
+		send.finish().unwrap();
+		// The ack never arrives; the watch parks.
+		assert!(send.poll_closed(&mut cx).is_pending());
+
+		// The late cancel: the reset applies without waiting for the ack, and
+		// the watch then resolves against the reset stream.
+		send.reset(9);
+		let closed = send.poll_closed(&mut cx);
+		assert_eq!(fake.resets.lock().unwrap().as_slice(), &[9]);
+		// The re-armed watch on the reset stream is allowed to stay pending in
+		// this fake (it never acks); what matters is the reset went out.
+		let _ = closed;
 	}
 
 	// The poll contract allows retrying a pending write with a SHORTER buffer;

--- a/rs/moq-native/src/transport.rs
+++ b/rs/moq-native/src/transport.rs
@@ -40,11 +40,20 @@ type OpBox<T> = futures::future::BoxFuture<'static, T>;
 ///   and the specific code is lost.
 /// - Stream `poll_closed` watches are emulated rather than delegated: the
 ///   underlying async `closed()` future would own the stream for its whole
-///   lifetime, deadlocking any later read or write. A receive stream reports
-///   closed through its reads (FIN drained, or a read error). A send stream
-///   only starts the real watch once `finish` or `reset` makes it terminal;
-///   before that a closure surfaces as an error on the next write instead of
-///   waking an idle watch.
+///   lifetime, deadlocking any later read or write (the async trait's
+///   `closed(&mut self)` cannot be stored as a `'static` watch without taking
+///   the stream with it). A receive stream reports closed through its reads
+///   (FIN drained, or a read error), buffering bounded read-ahead so a FIN
+///   behind undelivered payload still resolves the watch. A send stream only
+///   starts the real watch once `finish` or `reset` makes it terminal; before
+///   that a closure surfaces as an error on the next write instead of waking an
+///   idle watch. The send-side gap this leaves: a peer that resets a stream
+///   sitting idle (no pending write, not finished) does not wake a parked
+///   `poll_closed`, so a driver waiting on "next frame or peer close" learns of
+///   the closure only when the next write fails. The drivers' other arms keep
+///   the session making progress; the stream itself lingers until then. A
+///   native poll implementation observes closure without owning the stream,
+///   which is the real fix and the reason this adapter is transitional.
 pub struct Async<S: web_transport_trait::Session> {
 	session: S,
 	accept_uni: OpSlot<Result<S::RecvStream, S::Error>>,
@@ -202,6 +211,11 @@ pub struct AsyncSend<S: web_transport_trait::SendStream + 'static> {
 	/// Whether `finish` or `reset` has been observed, so no further writes can
 	/// come and the closed() watch may safely take ownership of the stream.
 	terminal: bool,
+	/// A write driven to completion by [`poll_closed`](wt_poll::SendStream::poll_closed)
+	/// rather than [`poll_write`](wt_poll::SendStream::poll_write). The caller was told
+	/// `Pending` and is contractually retrying the same bytes, so the next `poll_write`
+	/// reports this length instead of writing the bytes a second time.
+	completed: Option<usize>,
 }
 
 enum SendState<S: web_transport_trait::SendStream + 'static> {
@@ -223,6 +237,7 @@ impl<S: web_transport_trait::SendStream + 'static> AsyncSend<S> {
 			finish: false,
 			reset: None,
 			terminal: false,
+			completed: None,
 		}
 	}
 
@@ -247,6 +262,11 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 	type Error = S::Error;
 
 	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+		// A previous write completed inside poll_closed; report it instead of
+		// writing the same bytes a second time.
+		if let Some(len) = self.completed.take() {
+			return Poll::Ready(Ok(len));
+		}
 		loop {
 			match self.state.get_mut().unwrap().take().expect("in-flight") {
 				SendState::Idle(mut stream) => {
@@ -350,6 +370,10 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 						if let Err(err) = res {
 							return Poll::Ready(Err(err));
 						}
+						// The caller of poll_write was told Pending and will retry the
+						// same bytes; record the completion so the retry reports it
+						// instead of writing the bytes a second time.
+						self.completed = Some(len);
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -387,11 +411,23 @@ pub struct AsyncRecv<S: web_transport_trait::RecvStream + 'static> {
 	state: std::sync::Mutex<Option<RecvState<S>>>,
 	/// Bytes already read from the transport but not yet handed to the caller.
 	buffer: Bytes,
+	/// Read-ahead pulled in by the closed-watch while payload sat undelivered, so
+	/// a FIN right behind buffered data still resolves the watch. Drained by the
+	/// read methods before the transport is polled again; bounded by
+	/// [`READ_AHEAD_CAP`].
+	queued: std::collections::VecDeque<Bytes>,
+	/// Total bytes across `queued`, so the cap check is O(1).
+	queued_len: usize,
 	/// The peer finished the stream.
 	fin: bool,
 	/// A deferred STOP_SENDING, applied when the in-flight operation settles.
 	stop: Option<u32>,
 }
+
+/// How much the closed-watch may read ahead of the caller before it parks and
+/// waits for the caller to drain. Bounds memory against a peer that floods a
+/// stream nobody is reading.
+const READ_AHEAD_CAP: usize = 64 * 1024;
 
 enum RecvState<S: web_transport_trait::RecvStream + 'static> {
 	Idle(S),
@@ -404,13 +440,25 @@ impl<S: web_transport_trait::RecvStream + 'static> AsyncRecv<S> {
 		Self {
 			state: std::sync::Mutex::new(Some(RecvState::Idle(stream))),
 			buffer: Bytes::new(),
+			queued: std::collections::VecDeque::new(),
+			queued_len: 0,
 			fin: false,
 			stop: None,
 		}
 	}
 
-	/// Fill `self.buffer` (or set `self.fin`) with the next chunk of data.
-	fn poll_fill(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<(), S::Error>> {
+	/// Pop read-ahead into `self.buffer` if the head is empty.
+	fn unqueue(&mut self) {
+		if self.buffer.is_empty()
+			&& let Some(next) = self.queued.pop_front()
+		{
+			self.queued_len -= next.len();
+			self.buffer = next;
+		}
+	}
+
+	/// Read the next chunk from the transport, setting `self.fin` on the FIN.
+	fn poll_fill(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<Option<Bytes>, S::Error>> {
 		loop {
 			match self.state.get_mut().unwrap().take().expect("in-flight") {
 				RecvState::Idle(mut stream) => {
@@ -429,14 +477,18 @@ impl<S: web_transport_trait::RecvStream + 'static> AsyncRecv<S> {
 						*self.state.get_mut().unwrap() = Some(RecvState::Reading(fut));
 						return Poll::Pending;
 					}
-					Poll::Ready((stream, res)) => {
-						*self.state.get_mut().unwrap() = Some(RecvState::Idle(stream));
-						match res {
-							Ok(Some(bytes)) => self.buffer = bytes,
-							Ok(None) => self.fin = true,
-							Err(err) => return Poll::Ready(Err(err)),
+					Poll::Ready((mut stream, res)) => {
+						// Apply a stop requested while the read was in flight now, not on
+						// the next read: a caller that stops and never reads again must
+						// still send STOP_SENDING.
+						if let Some(code) = self.stop.take() {
+							stream.stop(code);
 						}
-						return Poll::Ready(Ok(()));
+						*self.state.get_mut().unwrap() = Some(RecvState::Idle(stream));
+						if let Ok(None) = &res {
+							self.fin = true;
+						}
+						return Poll::Ready(res);
 					}
 				},
 			}
@@ -453,6 +505,7 @@ impl<S: web_transport_trait::RecvStream + 'static> wt_poll::RecvStream for Async
 		}
 
 		loop {
+			self.unqueue();
 			if !self.buffer.is_empty() {
 				let n = dst.len().min(self.buffer.len());
 				dst[..n].copy_from_slice(&self.buffer.split_to(n));
@@ -461,7 +514,9 @@ impl<S: web_transport_trait::RecvStream + 'static> wt_poll::RecvStream for Async
 			if self.fin {
 				return Poll::Ready(Ok(None));
 			}
-			ready!(self.poll_fill(cx, dst.len()))?;
+			if let Some(bytes) = ready!(self.poll_fill(cx, dst.len()))? {
+				self.buffer = bytes;
+			}
 		}
 	}
 
@@ -471,6 +526,7 @@ impl<S: web_transport_trait::RecvStream + 'static> wt_poll::RecvStream for Async
 		}
 
 		loop {
+			self.unqueue();
 			if !self.buffer.is_empty() {
 				let n = max.min(self.buffer.len());
 				return Poll::Ready(Ok(Some(self.buffer.split_to(n))));
@@ -478,7 +534,9 @@ impl<S: web_transport_trait::RecvStream + 'static> wt_poll::RecvStream for Async
 			if self.fin {
 				return Poll::Ready(Ok(None));
 			}
-			ready!(self.poll_fill(cx, max))?;
+			if let Some(bytes) = ready!(self.poll_fill(cx, max))? {
+				self.buffer = bytes;
+			}
 		}
 	}
 
@@ -493,19 +551,24 @@ impl<S: web_transport_trait::RecvStream + 'static> wt_poll::RecvStream for Async
 		// Emulated with reads rather than the underlying closed(): that future
 		// would own the stream, deadlocking any later read (the caller reclaims a
 		// dropped watch by simply reading again, which the bridge must preserve).
-		// A FIN or reset therefore surfaces through poll_fill, and undelivered
-		// data parks the watch until the caller drains it.
+		// A FIN or reset therefore surfaces through reads; payload arriving before
+		// it is queued as read-ahead (up to READ_AHEAD_CAP) so a FIN right behind
+		// undelivered data still resolves the watch without an external read.
 		loop {
 			if self.fin {
 				return Poll::Ready(Ok(()));
 			}
-			if !self.buffer.is_empty() {
-				// Not drained yet. The caller's own reads are what drain it, and
-				// their re-poll of this watch is what resumes it.
+			if self.buffer.len() + self.queued_len >= READ_AHEAD_CAP {
+				// The caller's own reads are what drain the backlog, and their
+				// re-poll of this watch is what resumes it.
 				return Poll::Pending;
 			}
 			match ready!(self.poll_fill(cx, 8 * 1024)) {
-				Ok(()) => {}
+				Ok(Some(bytes)) => {
+					self.queued_len += bytes.len();
+					self.queued.push_back(bytes);
+				}
+				Ok(None) => {}
 				// A read error is also a closed stream.
 				Err(err) => return Poll::Ready(Err(err)),
 			}
@@ -601,12 +664,22 @@ mod tests {
 	struct FakeRecv {
 		chunks: std::collections::VecDeque<Bytes>,
 		stops: Arc<Mutex<Vec<u32>>>,
+		/// Reads park while set, so a test can hold one in flight in the adapter.
+		blocked: Arc<AtomicBool>,
 	}
 
 	impl web_transport_trait::RecvStream for FakeRecv {
 		type Error = FakeError;
 
 		async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+			std::future::poll_fn(|cx| {
+				if self.blocked.load(Ordering::SeqCst) {
+					cx.waker().wake_by_ref();
+					return Poll::Pending;
+				}
+				Poll::Ready(())
+			})
+			.await;
 			let Some(chunk) = self.chunks.front_mut() else {
 				return Ok(None);
 			};
@@ -678,6 +751,34 @@ mod tests {
 		assert_eq!(fake.priorities.lock().unwrap().as_slice(), &[7]);
 	}
 
+	// The cluster-failover corruption: a write held Pending by backpressure is
+	// driven to completion by the peer-close check (poll_closed). Its result must
+	// reach the retrying poll_write; discarding it made the retry put the same
+	// bytes on the wire twice, which a peer decodes as a phantom frame.
+	#[test]
+	fn a_write_completed_by_poll_closed_is_not_duplicated() {
+		let fake = FakeSend::default();
+		fake.blocked.store(true, Ordering::SeqCst);
+		let mut send = AsyncSend::new(fake.clone());
+		let mut cx = cx();
+
+		// Backpressure: the write parks inside the adapter.
+		assert!(send.poll_write(&mut cx, b"header").is_pending());
+
+		// The pressure lifts; the driver's next pass checks for a peer close
+		// first, which drives the stored write to completion.
+		fake.blocked.store(false, Ordering::SeqCst);
+		assert!(send.poll_closed(&mut cx).is_pending(), "not terminal yet");
+
+		// The retry reports the completed write instead of writing again.
+		assert_eq!(send.poll_write(&mut cx, b"header"), Poll::Ready(Ok(6)));
+		assert_eq!(
+			fake.writes.lock().unwrap().as_slice(),
+			b"header",
+			"the bytes must reach the stream exactly once"
+		);
+	}
+
 	// A larger chunk than the destination is buffered and served across reads.
 	#[test]
 	fn recv_buffers_the_excess() {
@@ -685,6 +786,7 @@ mod tests {
 		let fake = FakeRecv {
 			chunks: [Bytes::from_static(b"abcdef")].into_iter().collect(),
 			stops: stops.clone(),
+			blocked: Default::default(),
 		};
 		let mut recv = AsyncRecv::new(fake);
 		let mut cx = cx();
@@ -710,10 +812,59 @@ mod tests {
 		let fake = FakeRecv {
 			chunks: Default::default(),
 			stops: stops.clone(),
+			blocked: Default::default(),
 		};
 		let mut recv = AsyncRecv::new(fake);
 
 		recv.stop(42);
 		assert_eq!(stops.lock().unwrap().as_slice(), &[42]);
+	}
+
+	// A stop issued while a read is in flight goes out when that read settles,
+	// not on a later read that may never come.
+	#[test]
+	fn recv_stop_applies_when_the_read_settles() {
+		let stops = Arc::new(Mutex::new(Vec::new()));
+		let blocked = Arc::new(AtomicBool::new(true));
+		let fake = FakeRecv {
+			chunks: [Bytes::from_static(b"data")].into_iter().collect(),
+			stops: stops.clone(),
+			blocked: blocked.clone(),
+		};
+		let mut recv = AsyncRecv::new(fake);
+		let mut cx = cx();
+
+		let mut dst = [0u8; 4];
+		assert!(recv.poll_read(&mut cx, &mut dst).is_pending());
+		recv.stop(7);
+		assert!(stops.lock().unwrap().is_empty(), "deferred while in flight");
+
+		// The read settles (here via a retry); the stop goes out with it.
+		blocked.store(false, Ordering::SeqCst);
+		assert_eq!(recv.poll_read(&mut cx, &mut dst), Poll::Ready(Ok(Some(4))));
+		assert_eq!(stops.lock().unwrap().as_slice(), &[7]);
+	}
+
+	// A FIN sitting behind undelivered payload resolves the closed watch without
+	// an external read; the payload is still delivered afterward, in order.
+	#[test]
+	fn recv_closed_resolves_behind_buffered_data() {
+		let stops = Arc::new(Mutex::new(Vec::new()));
+		let fake = FakeRecv {
+			chunks: [Bytes::from_static(b"tail")].into_iter().collect(),
+			stops: stops.clone(),
+			blocked: Default::default(),
+		};
+		let mut recv = AsyncRecv::new(fake);
+		let mut cx = cx();
+
+		// The watch reads through the payload to the FIN.
+		assert_eq!(recv.poll_closed(&mut cx), Poll::Ready(Ok(())));
+
+		// Nothing was lost: the read-ahead serves the payload, then EOF.
+		let mut dst = [0u8; 4];
+		assert_eq!(recv.poll_read(&mut cx, &mut dst), Poll::Ready(Ok(Some(4))));
+		assert_eq!(&dst, b"tail");
+		assert_eq!(recv.poll_read(&mut cx, &mut dst), Poll::Ready(Ok(None)));
 	}
 }

--- a/rs/moq-native/src/transport.rs
+++ b/rs/moq-native/src/transport.rs
@@ -36,8 +36,10 @@ type OpBox<T> = futures::future::BoxFuture<'static, T>;
 ///   retries with the same buffer.
 /// - `stop`, `reset`, and `finish` during an in-flight operation are deferred
 ///   until that operation settles. If the stream is dropped before then, the
-///   underlying transport's drop behavior applies (a reset or stop with code 0)
-///   and the specific code is lost.
+///   pending operation is finished on the tokio runtime and the deferred code
+///   applied after it, so the peer still sees the real reason; only without a
+///   runtime does the underlying transport's drop behavior (a reset or stop
+///   with code 0) stand in.
 /// - Stream `poll_closed` watches are emulated rather than delegated: the
 ///   underlying async `closed()` future would own the stream for its whole
 ///   lifetime, deadlocking any later read or write (the async trait's
@@ -214,16 +216,18 @@ pub struct AsyncSend<S: web_transport_trait::SendStream + 'static> {
 	/// A write driven to completion by [`poll_closed`](wt_poll::SendStream::poll_closed)
 	/// rather than [`poll_write`](wt_poll::SendStream::poll_write). The caller was told
 	/// `Pending` and is contractually retrying the same bytes, so the next `poll_write`
-	/// reports this length instead of writing the bytes a second time.
-	completed: Option<usize>,
+	/// reports this write instead of putting the bytes on the wire a second time.
+	completed: Option<Bytes>,
 }
 
 enum SendState<S: web_transport_trait::SendStream + 'static> {
 	Idle(S),
-	/// A write in flight; `len` is what to report when it resolves.
+	/// A write in flight; `chunk` is the copied bytes, kept (refcounted, no
+	/// extra copy) so a completion absorbed by `poll_closed` can verify the
+	/// retrying caller supplied the same bytes.
 	Writing {
 		fut: OpBox<(S, Result<(), S::Error>)>,
-		len: usize,
+		chunk: Bytes,
 	},
 	Closing(OpBox<(S, Result<(), S::Error>)>),
 }
@@ -263,9 +267,15 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 
 	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
 		// A previous write completed inside poll_closed; report it instead of
-		// writing the same bytes a second time.
-		if let Some(len) = self.completed.take() {
-			return Poll::Ready(Ok(len));
+		// writing the same bytes a second time. The retry contract says the
+		// caller re-supplies the bytes it was told Pending for.
+		if let Some(chunk) = self.completed.take() {
+			debug_assert_eq!(
+				buf.get(..chunk.len()),
+				Some(&chunk[..]),
+				"poll_write must retry the same bytes it was told Pending for"
+			);
+			return Poll::Ready(Ok(chunk.len()));
 		}
 		loop {
 			match self.state.get_mut().unwrap().take().expect("in-flight") {
@@ -278,24 +288,24 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 					// count is exact. The caller retries with the same bytes
 					// until this resolves (see [`Async`]).
 					let chunk = Bytes::copy_from_slice(buf);
-					let len = chunk.len();
+					let retained = chunk.clone();
 					let fut = async move {
 						let res = stream.write_chunk(chunk).await;
 						(stream, res)
 					}
 					.boxed();
-					*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, len });
+					*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, chunk: retained });
 				}
-				SendState::Writing { mut fut, len } => match fut.as_mut().poll(cx) {
+				SendState::Writing { mut fut, chunk } => match fut.as_mut().poll(cx) {
 					Poll::Pending => {
-						*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, len });
+						*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, chunk });
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
 						self.settle(&mut stream);
 						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
 						res?;
-						return Poll::Ready(Ok(len));
+						return Poll::Ready(Ok(chunk.len()));
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -358,9 +368,9 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 					.boxed();
 					*self.state.get_mut().unwrap() = Some(SendState::Closing(fut));
 				}
-				SendState::Writing { mut fut, len } => match fut.as_mut().poll(cx) {
+				SendState::Writing { mut fut, chunk } => match fut.as_mut().poll(cx) {
 					Poll::Pending => {
-						*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, len });
+						*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, chunk });
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
@@ -373,7 +383,7 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 						// The caller of poll_write was told Pending and will retry the
 						// same bytes; record the completion so the retry reports it
 						// instead of writing the bytes a second time.
-						self.completed = Some(len);
+						self.completed = Some(chunk);
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -394,12 +404,37 @@ impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for Async
 
 impl<S: web_transport_trait::SendStream + 'static> Drop for AsyncSend<S> {
 	fn drop(&mut self) {
-		// Apply a deferred reset if the stream is idle; otherwise the underlying
-		// stream's own drop behavior applies.
-		if let Some(SendState::Idle(mut stream)) = self.state.get_mut().unwrap().take()
-			&& let Some(code) = self.reset.take()
-		{
-			stream.reset(code);
+		match self.state.get_mut().unwrap().take() {
+			// Apply a deferred reset if the stream is idle.
+			Some(SendState::Idle(mut stream)) => {
+				if let Some(code) = self.reset.take() {
+					stream.reset(code);
+				}
+			}
+			// The stream lives inside the in-flight future; dropping it here
+			// would fire the backend's default drop behavior (a code-0 reset)
+			// and lose the deferred reset code or FIN the caller asked for. The
+			// peer uses that code to classify the abort (Old vs Cancel vs
+			// Evicted), so finish the operation on the runtime and apply the
+			// terminal action then. Without a runtime the default drop stands.
+			Some(SendState::Writing { fut, .. }) | Some(SendState::Closing(fut)) => {
+				let reset = self.reset.take();
+				let finish = std::mem::take(&mut self.finish);
+				if (reset.is_some() || finish)
+					&& let Ok(handle) = tokio::runtime::Handle::try_current()
+				{
+					handle.spawn(async move {
+						let (mut stream, _) = fut.await;
+						match reset {
+							Some(code) => stream.reset(code),
+							None => {
+								let _ = stream.finish();
+							}
+						}
+					});
+				}
+			}
+			None => {}
 		}
 	}
 }
@@ -578,12 +613,29 @@ impl<S: web_transport_trait::RecvStream + 'static> wt_poll::RecvStream for Async
 
 impl<S: web_transport_trait::RecvStream + 'static> Drop for AsyncRecv<S> {
 	fn drop(&mut self) {
-		// Apply a deferred stop if the stream is idle; otherwise the underlying
-		// stream's own drop behavior applies.
-		if let Some(RecvState::Idle(mut stream)) = self.state.get_mut().unwrap().take()
-			&& let Some(code) = self.stop.take()
-		{
-			stream.stop(code);
+		match self.state.get_mut().unwrap().take() {
+			// Apply a deferred stop if the stream is idle.
+			Some(RecvState::Idle(mut stream)) => {
+				if let Some(code) = self.stop.take() {
+					stream.stop(code);
+				}
+			}
+			// The stream lives inside the in-flight read; dropping it here would
+			// fire the backend's default drop behavior (a code-0 stop) and lose
+			// the deferred code the peer classifies the abort by. Finish the
+			// read on the runtime and stop with the real code then. Without a
+			// runtime the default drop stands.
+			Some(RecvState::Reading(fut)) => {
+				if let Some(code) = self.stop.take()
+					&& let Ok(handle) = tokio::runtime::Handle::try_current()
+				{
+					handle.spawn(async move {
+						let (mut stream, _) = fut.await;
+						stream.stop(code);
+					});
+				}
+			}
+			None => {}
 		}
 	}
 }
@@ -623,6 +675,7 @@ mod tests {
 		blocked: Arc<AtomicBool>,
 		priorities: Arc<Mutex<Vec<u8>>>,
 		finished: Arc<AtomicBool>,
+		resets: Arc<Mutex<Vec<u32>>>,
 	}
 
 	impl web_transport_trait::SendStream for FakeSend {
@@ -650,7 +703,9 @@ mod tests {
 			Ok(())
 		}
 
-		fn reset(&mut self, _code: u32) {}
+		fn reset(&mut self, code: u32) {
+			self.resets.lock().unwrap().push(code);
+		}
 
 		async fn closed(&mut self) -> Result<(), Self::Error> {
 			match self.finished.load(Ordering::SeqCst) {
@@ -843,6 +898,61 @@ mod tests {
 		blocked.store(false, Ordering::SeqCst);
 		assert_eq!(recv.poll_read(&mut cx, &mut dst), Poll::Ready(Ok(Some(4))));
 		assert_eq!(stops.lock().unwrap().as_slice(), &[7]);
+	}
+
+	// A writer dropped while its write is still in flight must not lose the
+	// deferred reset code: the peer classifies the abort by it (Old vs Cancel),
+	// so the salvage task finishes the write and applies the real code.
+	#[tokio::test]
+	async fn a_deferred_reset_code_survives_a_drop_mid_write() {
+		let fake = FakeSend::default();
+		fake.blocked.store(true, Ordering::SeqCst);
+		let mut send = AsyncSend::new(fake.clone());
+		let mut cx = cx();
+
+		assert!(send.poll_write(&mut cx, b"payload").is_pending());
+		send.reset(9);
+		drop(send);
+
+		fake.blocked.store(false, Ordering::SeqCst);
+		tokio::time::timeout(std::time::Duration::from_secs(1), async {
+			while fake.resets.lock().unwrap().is_empty() {
+				tokio::task::yield_now().await;
+			}
+		})
+		.await
+		.expect("the salvage task never applied the reset");
+		assert_eq!(fake.resets.lock().unwrap().as_slice(), &[9]);
+	}
+
+	// The receive-side twin: a reader dropped mid-read still sends the deferred
+	// STOP_SENDING with the real code.
+	#[tokio::test]
+	async fn a_deferred_stop_code_survives_a_drop_mid_read() {
+		let stops = Arc::new(Mutex::new(Vec::new()));
+		let blocked = Arc::new(AtomicBool::new(true));
+		let fake = FakeRecv {
+			chunks: [Bytes::from_static(b"data")].into_iter().collect(),
+			stops: stops.clone(),
+			blocked: blocked.clone(),
+		};
+		let mut recv = AsyncRecv::new(fake);
+		let mut cx = cx();
+
+		let mut dst = [0u8; 4];
+		assert!(recv.poll_read(&mut cx, &mut dst).is_pending());
+		wt_poll::RecvStream::stop(&mut recv, 11);
+		drop(recv);
+
+		blocked.store(false, Ordering::SeqCst);
+		tokio::time::timeout(std::time::Duration::from_secs(1), async {
+			while stops.lock().unwrap().is_empty() {
+				tokio::task::yield_now().await;
+			}
+		})
+		.await
+		.expect("the salvage task never applied the stop");
+		assert_eq!(stops.lock().unwrap().as_slice(), &[11]);
 	}
 
 	// A FIN sitting behind undelivered payload resolves the closed watch without

--- a/rs/moq-native/src/transport.rs
+++ b/rs/moq-native/src/transport.rs
@@ -1,0 +1,719 @@
+//! Transitional adapter from the async transport interface to the poll one.
+//!
+//! moq-net only accepts the poll interface (`web_transport_trait::poll`).
+//! Backends that predate it (qmux, iroh, noq) are wrapped in [`Async`] here,
+//! at the edge where async already lives, until they implement the poll
+//! interface natively upstream. Delete this module backend by backend as that
+//! lands: the wrapping costs one allocation per operation and one copy per
+//! write, and its closed-watch emulation is weaker than a native
+//! implementation (see [`Async`]).
+
+use std::task::{Context, Poll, ready};
+
+use bytes::Bytes;
+use futures::FutureExt;
+use web_transport_trait::poll as wt_poll;
+
+/// A stored in-flight operation future. Native transports are Send, so the
+/// plain boxed flavor suffices.
+type OpBox<T> = futures::future::BoxFuture<'static, T>;
+
+/// Adapts a transport that only implements the async interface
+/// ([`web_transport_trait::Session`]) to the poll interface this crate requires.
+///
+/// Each pending session operation is stored as a boxed future built from a clone
+/// of the underlying session; stream operations temporarily move the stream into
+/// the future and take it back when the operation settles. Two costs follow: one
+/// allocation per operation, and one copy per write (a poll write borrows its
+/// buffer, an async write future cannot). Prefer a transport's native poll
+/// implementation when it has one.
+///
+/// A few contract loosenings, all inherent to wrapping futures:
+///
+/// - A write must be retried with the same bytes until it resolves. The adapter
+///   copies the buffer it was first given; a caller that swaps buffers while the
+///   write is pending would corrupt the stream. Every caller in this crate
+///   retries with the same buffer.
+/// - `stop`, `reset`, and `finish` during an in-flight operation are deferred
+///   until that operation settles. If the stream is dropped before then, the
+///   underlying transport's drop behavior applies (a reset or stop with code 0)
+///   and the specific code is lost.
+/// - Stream `poll_closed` watches are emulated rather than delegated: the
+///   underlying async `closed()` future would own the stream for its whole
+///   lifetime, deadlocking any later read or write. A receive stream reports
+///   closed through its reads (FIN drained, or a read error). A send stream
+///   only starts the real watch once `finish` or `reset` makes it terminal;
+///   before that a closure surfaces as an error on the next write instead of
+///   waking an idle watch.
+pub struct Async<S: web_transport_trait::Session> {
+	session: S,
+	accept_uni: OpSlot<Result<S::RecvStream, S::Error>>,
+	accept_bi: OpSlot<BiResult<S>>,
+	open_uni: OpSlot<Result<S::SendStream, S::Error>>,
+	open_bi: OpSlot<BiResult<S>>,
+	recv_datagram: OpSlot<Result<Bytes, S::Error>>,
+	closed: OpSlot<S::Error>,
+}
+
+/// The stream pair an async-interface accept or open resolves to.
+type BiResult<S> = Result<
+	(
+		<S as web_transport_trait::Session>::SendStream,
+		<S as web_transport_trait::Session>::RecvStream,
+	),
+	<S as web_transport_trait::Session>::Error,
+>;
+
+/// A stored in-flight operation: `None` when idle.
+///
+/// The Mutex is never locked: every access goes through `get_mut`, which is free
+/// on an exclusive borrow. It exists only to make the slot `Sync`, since a boxed
+/// future is not, and sessions are shared behind `&` between the driver's tasks.
+type OpSlot<T> = std::sync::Mutex<Option<OpBox<T>>>;
+
+/// Lazily start and poll the operation in `slot`, clearing it when it resolves.
+fn poll_op<T>(slot: &mut OpSlot<T>, cx: &mut Context<'_>, start: impl FnOnce() -> OpBox<T>) -> Poll<T> {
+	let slot = slot.get_mut().unwrap();
+	let fut = slot.get_or_insert_with(start);
+	let output = ready!(fut.as_mut().poll(cx));
+	*slot = None;
+	Poll::Ready(output)
+}
+
+impl<S: web_transport_trait::Session> Async<S> {
+	/// Wrap an async-interface transport session.
+	pub fn new(session: S) -> Self {
+		Self {
+			session,
+			accept_uni: OpSlot::default(),
+			accept_bi: OpSlot::default(),
+			open_uni: OpSlot::default(),
+			open_bi: OpSlot::default(),
+			recv_datagram: OpSlot::default(),
+			closed: OpSlot::default(),
+		}
+	}
+}
+
+// Manual impl: a clone starts with no in-flight operations, since each handle
+// owns its own progress under the poll contract.
+impl<S: web_transport_trait::Session> Clone for Async<S> {
+	fn clone(&self) -> Self {
+		Self::new(self.session.clone())
+	}
+}
+
+impl<S> wt_poll::Session for Async<S>
+where
+	S: web_transport_trait::Session,
+	S::SendStream: 'static,
+	S::RecvStream: 'static,
+{
+	type SendStream = AsyncSend<S::SendStream>;
+	type RecvStream = AsyncRecv<S::RecvStream>;
+	type Error = S::Error;
+
+	fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>> {
+		let session = &self.session;
+		poll_op(&mut self.accept_uni, cx, || {
+			let session = session.clone();
+			async move { session.accept_uni().await }.boxed()
+		})
+		.map(|res| res.map(AsyncRecv::new))
+	}
+
+	fn poll_accept_bi(&mut self, cx: &mut Context<'_>) -> Poll<Result<wt_poll::BiStreams<Self>, Self::Error>> {
+		let session = &self.session;
+		poll_op(&mut self.accept_bi, cx, || {
+			let session = session.clone();
+			async move { session.accept_bi().await }.boxed()
+		})
+		.map(|res| res.map(|(send, recv)| (AsyncSend::new(send), AsyncRecv::new(recv))))
+	}
+
+	fn poll_open_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::SendStream, Self::Error>> {
+		let session = &self.session;
+		poll_op(&mut self.open_uni, cx, || {
+			let session = session.clone();
+			async move { session.open_uni().await }.boxed()
+		})
+		.map(|res| res.map(AsyncSend::new))
+	}
+
+	fn poll_open_bi(&mut self, cx: &mut Context<'_>) -> Poll<Result<wt_poll::BiStreams<Self>, Self::Error>> {
+		let session = &self.session;
+		poll_op(&mut self.open_bi, cx, || {
+			let session = session.clone();
+			async move { session.open_bi().await }.boxed()
+		})
+		.map(|res| res.map(|(send, recv)| (AsyncSend::new(send), AsyncRecv::new(recv))))
+	}
+
+	fn poll_send_datagram(&mut self, _cx: &mut Context<'_>, payload: &[u8]) -> Poll<Result<(), Self::Error>> {
+		// The async interface's send is non-blocking (the transport queues or
+		// drops), so there is never a reason to return Pending.
+		Poll::Ready(self.session.send_datagram(Bytes::copy_from_slice(payload)))
+	}
+
+	fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>> {
+		let session = &self.session;
+		poll_op(&mut self.recv_datagram, cx, || {
+			let session = session.clone();
+			async move { session.recv_datagram().await }.boxed()
+		})
+	}
+
+	fn max_datagram_size(&self) -> usize {
+		self.session.max_datagram_size()
+	}
+
+	fn protocol(&self) -> Option<&str> {
+		self.session.protocol()
+	}
+
+	fn close(&mut self, code: u32, reason: &str) {
+		self.session.close(code, reason);
+	}
+
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Self::Error> {
+		let session = &self.session;
+		poll_op(&mut self.closed, cx, || {
+			let session = session.clone();
+			async move { session.closed().await }.boxed()
+		})
+	}
+
+	fn stats(&self) -> impl web_transport_trait::Stats {
+		self.session.stats()
+	}
+}
+
+/// The send half produced by [`Async`]: an async-interface stream adapted to the
+/// poll interface. See [`Async`] for the deferred `finish`/`reset` behavior.
+pub struct AsyncSend<S: web_transport_trait::SendStream + 'static> {
+	// Same never-locked Mutex as [`Async`]'s slots: `get_mut` is free on an
+	// exclusive borrow, and the wrapper keeps the boxed future from stripping
+	// `Sync` off the containing session types.
+	state: std::sync::Mutex<Option<SendState<S>>>,
+	// Deferred actions, applied when the in-flight operation settles.
+	priority: Option<u8>,
+	finish: bool,
+	reset: Option<u32>,
+	/// Whether `finish` or `reset` has been observed, so no further writes can
+	/// come and the closed() watch may safely take ownership of the stream.
+	terminal: bool,
+}
+
+enum SendState<S: web_transport_trait::SendStream + 'static> {
+	Idle(S),
+	/// A write in flight; `len` is what to report when it resolves.
+	Writing {
+		fut: OpBox<(S, Result<(), S::Error>)>,
+		len: usize,
+	},
+	Closing(OpBox<(S, Result<(), S::Error>)>),
+}
+
+impl<S: web_transport_trait::SendStream + 'static> AsyncSend<S> {
+	/// Wrap an async-interface send stream.
+	pub fn new(stream: S) -> Self {
+		Self {
+			state: std::sync::Mutex::new(Some(SendState::Idle(stream))),
+			priority: None,
+			finish: false,
+			reset: None,
+			terminal: false,
+		}
+	}
+
+	/// Apply actions deferred while an operation was in flight.
+	fn settle(&mut self, stream: &mut S) {
+		if let Some(order) = self.priority.take() {
+			stream.set_priority(order);
+		}
+		if let Some(code) = self.reset.take() {
+			self.finish = false;
+			stream.reset(code);
+		}
+		if std::mem::take(&mut self.finish) {
+			// A deferred finish has nowhere to report to; its failure surfaces
+			// through closed() like any other terminal state.
+			let _ = stream.finish();
+		}
+	}
+}
+
+impl<S: web_transport_trait::SendStream + 'static> wt_poll::SendStream for AsyncSend<S> {
+	type Error = S::Error;
+
+	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+		loop {
+			match self.state.get_mut().unwrap().take().expect("in-flight") {
+				SendState::Idle(mut stream) => {
+					if buf.is_empty() {
+						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
+						return Poll::Ready(Ok(0));
+					}
+					// write_chunk delivers the whole chunk, so the reported
+					// count is exact. The caller retries with the same bytes
+					// until this resolves (see [`Async`]).
+					let chunk = Bytes::copy_from_slice(buf);
+					let len = chunk.len();
+					let fut = async move {
+						let res = stream.write_chunk(chunk).await;
+						(stream, res)
+					}
+					.boxed();
+					*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, len });
+				}
+				SendState::Writing { mut fut, len } => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, len });
+						return Poll::Pending;
+					}
+					Poll::Ready((mut stream, res)) => {
+						self.settle(&mut stream);
+						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
+						res?;
+						return Poll::Ready(Ok(len));
+					}
+				},
+				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						*self.state.get_mut().unwrap() = Some(SendState::Closing(fut));
+						return Poll::Pending;
+					}
+					Poll::Ready((mut stream, _res)) => {
+						self.settle(&mut stream);
+						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
+					}
+				},
+			}
+		}
+	}
+
+	fn set_priority(&mut self, order: u8) {
+		match self.state.get_mut().unwrap().as_mut() {
+			Some(SendState::Idle(stream)) => stream.set_priority(order),
+			_ => self.priority = Some(order),
+		}
+	}
+
+	fn finish(&mut self) -> Result<(), Self::Error> {
+		self.terminal = true;
+		match self.state.get_mut().unwrap().as_mut() {
+			Some(SendState::Idle(stream)) => stream.finish(),
+			_ => {
+				self.finish = true;
+				Ok(())
+			}
+		}
+	}
+
+	fn reset(&mut self, code: u32) {
+		self.terminal = true;
+		match self.state.get_mut().unwrap().as_mut() {
+			Some(SendState::Idle(stream)) => stream.reset(code),
+			_ => self.reset = Some(code),
+		}
+	}
+
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		loop {
+			match self.state.get_mut().unwrap().take().expect("in-flight") {
+				SendState::Idle(mut stream) => {
+					self.settle(&mut stream);
+					// Only a finished (or reset) stream starts the real closed()
+					// watch: that future owns the stream, and a stream the caller
+					// may still write to must stay reclaimable. Before that,
+					// closure surfaces as an error on the next operation instead.
+					if !self.terminal {
+						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
+						return Poll::Pending;
+					}
+					let fut = async move {
+						let res = stream.closed().await;
+						(stream, res)
+					}
+					.boxed();
+					*self.state.get_mut().unwrap() = Some(SendState::Closing(fut));
+				}
+				SendState::Writing { mut fut, len } => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						*self.state.get_mut().unwrap() = Some(SendState::Writing { fut, len });
+						return Poll::Pending;
+					}
+					Poll::Ready((mut stream, res)) => {
+						self.settle(&mut stream);
+						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
+						// A failed write is a closed stream; report it here.
+						if let Err(err) = res {
+							return Poll::Ready(Err(err));
+						}
+					}
+				},
+				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						*self.state.get_mut().unwrap() = Some(SendState::Closing(fut));
+						return Poll::Pending;
+					}
+					Poll::Ready((mut stream, res)) => {
+						self.settle(&mut stream);
+						*self.state.get_mut().unwrap() = Some(SendState::Idle(stream));
+						return Poll::Ready(res);
+					}
+				},
+			}
+		}
+	}
+}
+
+impl<S: web_transport_trait::SendStream + 'static> Drop for AsyncSend<S> {
+	fn drop(&mut self) {
+		// Apply a deferred reset if the stream is idle; otherwise the underlying
+		// stream's own drop behavior applies.
+		if let Some(SendState::Idle(mut stream)) = self.state.get_mut().unwrap().take()
+			&& let Some(code) = self.reset.take()
+		{
+			stream.reset(code);
+		}
+	}
+}
+
+/// The receive half produced by [`Async`]: an async-interface stream adapted to
+/// the poll interface. See [`Async`] for the deferred `stop` behavior.
+pub struct AsyncRecv<S: web_transport_trait::RecvStream + 'static> {
+	// See [`AsyncSend::state`] for why this Mutex exists; it is never locked.
+	state: std::sync::Mutex<Option<RecvState<S>>>,
+	/// Bytes already read from the transport but not yet handed to the caller.
+	buffer: Bytes,
+	/// The peer finished the stream.
+	fin: bool,
+	/// A deferred STOP_SENDING, applied when the in-flight operation settles.
+	stop: Option<u32>,
+}
+
+enum RecvState<S: web_transport_trait::RecvStream + 'static> {
+	Idle(S),
+	Reading(#[allow(clippy::type_complexity)] OpBox<(S, Result<Option<Bytes>, S::Error>)>),
+}
+
+impl<S: web_transport_trait::RecvStream + 'static> AsyncRecv<S> {
+	/// Wrap an async-interface receive stream.
+	pub fn new(stream: S) -> Self {
+		Self {
+			state: std::sync::Mutex::new(Some(RecvState::Idle(stream))),
+			buffer: Bytes::new(),
+			fin: false,
+			stop: None,
+		}
+	}
+
+	/// Fill `self.buffer` (or set `self.fin`) with the next chunk of data.
+	fn poll_fill(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<(), S::Error>> {
+		loop {
+			match self.state.get_mut().unwrap().take().expect("in-flight") {
+				RecvState::Idle(mut stream) => {
+					if let Some(code) = self.stop.take() {
+						stream.stop(code);
+					}
+					let fut = async move {
+						let res = stream.read_chunk(max).await;
+						(stream, res)
+					}
+					.boxed();
+					*self.state.get_mut().unwrap() = Some(RecvState::Reading(fut));
+				}
+				RecvState::Reading(mut fut) => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						*self.state.get_mut().unwrap() = Some(RecvState::Reading(fut));
+						return Poll::Pending;
+					}
+					Poll::Ready((stream, res)) => {
+						*self.state.get_mut().unwrap() = Some(RecvState::Idle(stream));
+						match res {
+							Ok(Some(bytes)) => self.buffer = bytes,
+							Ok(None) => self.fin = true,
+							Err(err) => return Poll::Ready(Err(err)),
+						}
+						return Poll::Ready(Ok(()));
+					}
+				},
+			}
+		}
+	}
+}
+
+impl<S: web_transport_trait::RecvStream + 'static> wt_poll::RecvStream for AsyncRecv<S> {
+	type Error = S::Error;
+
+	fn poll_read(&mut self, cx: &mut Context<'_>, dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
+		if dst.is_empty() {
+			return Poll::Ready(Ok(Some(0)));
+		}
+
+		loop {
+			if !self.buffer.is_empty() {
+				let n = dst.len().min(self.buffer.len());
+				dst[..n].copy_from_slice(&self.buffer.split_to(n));
+				return Poll::Ready(Ok(Some(n)));
+			}
+			if self.fin {
+				return Poll::Ready(Ok(None));
+			}
+			ready!(self.poll_fill(cx, dst.len()))?;
+		}
+	}
+
+	fn poll_read_chunk(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<Option<Bytes>, Self::Error>> {
+		if max == 0 {
+			return Poll::Ready(Ok(Some(Bytes::new())));
+		}
+
+		loop {
+			if !self.buffer.is_empty() {
+				let n = max.min(self.buffer.len());
+				return Poll::Ready(Ok(Some(self.buffer.split_to(n))));
+			}
+			if self.fin {
+				return Poll::Ready(Ok(None));
+			}
+			ready!(self.poll_fill(cx, max))?;
+		}
+	}
+
+	fn stop(&mut self, code: u32) {
+		match self.state.get_mut().unwrap().as_mut() {
+			Some(RecvState::Idle(stream)) => stream.stop(code),
+			_ => self.stop = Some(code),
+		}
+	}
+
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		// Emulated with reads rather than the underlying closed(): that future
+		// would own the stream, deadlocking any later read (the caller reclaims a
+		// dropped watch by simply reading again, which the bridge must preserve).
+		// A FIN or reset therefore surfaces through poll_fill, and undelivered
+		// data parks the watch until the caller drains it.
+		loop {
+			if self.fin {
+				return Poll::Ready(Ok(()));
+			}
+			if !self.buffer.is_empty() {
+				// Not drained yet. The caller's own reads are what drain it, and
+				// their re-poll of this watch is what resumes it.
+				return Poll::Pending;
+			}
+			match ready!(self.poll_fill(cx, 8 * 1024)) {
+				Ok(()) => {}
+				// A read error is also a closed stream.
+				Err(err) => return Poll::Ready(Err(err)),
+			}
+		}
+	}
+}
+
+impl<S: web_transport_trait::RecvStream + 'static> Drop for AsyncRecv<S> {
+	fn drop(&mut self) {
+		// Apply a deferred stop if the stream is idle; otherwise the underlying
+		// stream's own drop behavior applies.
+		if let Some(RecvState::Idle(mut stream)) = self.state.get_mut().unwrap().take()
+			&& let Some(code) = self.stop.take()
+		{
+			stream.stop(code);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::{
+		Arc, Mutex,
+		atomic::{AtomicBool, Ordering},
+	};
+
+	use super::*;
+	use web_transport_trait::poll::{RecvStream as _, SendStream as _};
+
+	#[derive(Debug, Clone, Default, PartialEq)]
+	struct FakeError;
+
+	impl std::fmt::Display for FakeError {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			write!(f, "fake error")
+		}
+	}
+
+	impl std::error::Error for FakeError {}
+
+	impl web_transport_trait::Error for FakeError {
+		fn session_error(&self) -> Option<(u32, String)> {
+			None
+		}
+	}
+
+	/// An async-interface send stream whose writes can be blocked, so a test can
+	/// hold an operation in flight inside the adapter.
+	#[derive(Clone, Default)]
+	struct FakeSend {
+		writes: Arc<Mutex<Vec<u8>>>,
+		blocked: Arc<AtomicBool>,
+		priorities: Arc<Mutex<Vec<u8>>>,
+		finished: Arc<AtomicBool>,
+	}
+
+	impl web_transport_trait::SendStream for FakeSend {
+		type Error = FakeError;
+
+		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+			std::future::poll_fn(|cx| {
+				if self.blocked.load(Ordering::SeqCst) {
+					cx.waker().wake_by_ref();
+					return Poll::Pending;
+				}
+				Poll::Ready(())
+			})
+			.await;
+			self.writes.lock().unwrap().extend_from_slice(buf);
+			Ok(buf.len())
+		}
+
+		fn set_priority(&mut self, order: u8) {
+			self.priorities.lock().unwrap().push(order);
+		}
+
+		fn finish(&mut self) -> Result<(), Self::Error> {
+			self.finished.store(true, Ordering::SeqCst);
+			Ok(())
+		}
+
+		fn reset(&mut self, _code: u32) {}
+
+		async fn closed(&mut self) -> Result<(), Self::Error> {
+			match self.finished.load(Ordering::SeqCst) {
+				true => Ok(()),
+				false => std::future::pending().await,
+			}
+		}
+	}
+
+	/// An async-interface receive stream replaying canned chunks, then EOF.
+	struct FakeRecv {
+		chunks: std::collections::VecDeque<Bytes>,
+		stops: Arc<Mutex<Vec<u32>>>,
+	}
+
+	impl web_transport_trait::RecvStream for FakeRecv {
+		type Error = FakeError;
+
+		async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+			let Some(chunk) = self.chunks.front_mut() else {
+				return Ok(None);
+			};
+			let n = dst.len().min(chunk.len());
+			dst[..n].copy_from_slice(&chunk.split_to(n));
+			if chunk.is_empty() {
+				self.chunks.pop_front();
+			}
+			Ok(Some(n))
+		}
+
+		fn stop(&mut self, code: u32) {
+			self.stops.lock().unwrap().push(code);
+		}
+
+		async fn closed(&mut self) -> Result<(), Self::Error> {
+			Ok(())
+		}
+	}
+
+	fn cx() -> Context<'static> {
+		Context::from_waker(std::task::Waker::noop())
+	}
+
+	// The regression behind goaway_gates_new_subscribes_moq_lite_04: a dropped
+	// closed() watch must not hold the stream hostage, so a later write still
+	// goes through.
+	#[test]
+	fn send_closed_watch_does_not_block_writes() {
+		let fake = FakeSend::default();
+		let mut send = AsyncSend::new(fake.clone());
+		let mut cx = cx();
+
+		// A pre-terminal closed watch stays pending without consuming the stream.
+		assert!(send.poll_closed(&mut cx).is_pending());
+
+		// The write proceeds; the old ownership-transfer watch deadlocked here.
+		assert_eq!(send.poll_write(&mut cx, b"hello"), Poll::Ready(Ok(5)));
+		assert_eq!(fake.writes.lock().unwrap().as_slice(), b"hello");
+	}
+
+	// After finish() the real closed() watch runs and resolves.
+	#[test]
+	fn send_closed_resolves_after_finish() {
+		let fake = FakeSend::default();
+		let mut send = AsyncSend::new(fake.clone());
+		let mut cx = cx();
+
+		assert_eq!(send.poll_write(&mut cx, b"bye"), Poll::Ready(Ok(3)));
+		send.finish().unwrap();
+		assert_eq!(send.poll_closed(&mut cx), Poll::Ready(Ok(())));
+	}
+
+	// Actions issued while a write is in flight apply when it settles, and the
+	// settled write reports its original length.
+	#[test]
+	fn send_defers_actions_across_an_inflight_write() {
+		let fake = FakeSend::default();
+		fake.blocked.store(true, Ordering::SeqCst);
+		let mut send = AsyncSend::new(fake.clone());
+		let mut cx = cx();
+
+		assert!(send.poll_write(&mut cx, b"queued").is_pending());
+		send.set_priority(7);
+		assert!(fake.priorities.lock().unwrap().is_empty(), "deferred while in flight");
+
+		fake.blocked.store(false, Ordering::SeqCst);
+		assert_eq!(send.poll_write(&mut cx, b"queued"), Poll::Ready(Ok(6)));
+		assert_eq!(fake.priorities.lock().unwrap().as_slice(), &[7]);
+	}
+
+	// A larger chunk than the destination is buffered and served across reads.
+	#[test]
+	fn recv_buffers_the_excess() {
+		let stops = Arc::new(Mutex::new(Vec::new()));
+		let fake = FakeRecv {
+			chunks: [Bytes::from_static(b"abcdef")].into_iter().collect(),
+			stops: stops.clone(),
+		};
+		let mut recv = AsyncRecv::new(fake);
+		let mut cx = cx();
+
+		let mut dst = [0u8; 4];
+		assert_eq!(recv.poll_read(&mut cx, &mut dst), Poll::Ready(Ok(Some(4))));
+		assert_eq!(&dst, b"abcd");
+
+		// The retry may shrink; the buffered tail serves it.
+		let mut dst = [0u8; 2];
+		assert_eq!(recv.poll_read(&mut cx, &mut dst), Poll::Ready(Ok(Some(2))));
+		assert_eq!(&dst, b"ef");
+
+		// EOF, and the closed watch resolves once drained.
+		assert_eq!(recv.poll_read(&mut cx, &mut dst), Poll::Ready(Ok(None)));
+		assert_eq!(recv.poll_closed(&mut cx), Poll::Ready(Ok(())));
+	}
+
+	// stop() while idle applies immediately.
+	#[test]
+	fn recv_stop_applies_when_idle() {
+		let stops = Arc::new(Mutex::new(Vec::new()));
+		let fake = FakeRecv {
+			chunks: Default::default(),
+			stops: stops.clone(),
+		};
+		let mut recv = AsyncRecv::new(fake);
+
+		recv.stop(42);
+		assert_eq!(stops.lock().unwrap().as_slice(), &[42]);
+	}
+}

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -125,7 +125,10 @@ impl Client {
 	/// Perform the MoQ handshake, returning the [`Session`] and the [`Driver`] that
 	/// runs its protocol work. The driver must be polled (spawned or awaited) for
 	/// the session to make progress.
-	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<(Session, Driver), Error> {
+	pub async fn connect<S: crate::transport::poll::Session>(
+		&self,
+		mut session: S,
+	) -> Result<(Session, Driver), Error> {
 		if self.publish.is_none() && self.subscribe.is_none() {
 			tracing::warn!("not publishing or consuming anything");
 		}
@@ -359,7 +362,7 @@ impl Client {
 			Some(p) => return Err(Error::UnknownAlpn(p.to_string())),
 		};
 
-		let mut stream = Stream::open(&session, encoding).await?;
+		let mut stream = Stream::open(&mut session, encoding).await?;
 
 		// The encoding is always an IETF version for SETUP negotiation.
 		let ietf_encoding = ietf::Version::try_from(encoding).map_err(|_| Error::Version)?;
@@ -452,6 +455,8 @@ mod tests {
 		sync::{Arc, Mutex},
 	};
 
+	use std::task::{Context, Poll};
+
 	use crate::SessionError;
 	use crate::coding::{Decode, Encode};
 	use bytes::{BufMut, Bytes};
@@ -476,6 +481,8 @@ mod tests {
 	#[derive(Clone, Default)]
 	struct FakeSession {
 		state: Arc<FakeSessionState>,
+		// Per-clone, so each pending poll_closed keeps its own registration live.
+		park: kio::Park,
 	}
 
 	#[derive(Default)]
@@ -483,7 +490,7 @@ mod tests {
 		protocol: Option<&'static str>,
 		control_stream: Mutex<Option<(FakeSendStream, FakeRecvStream)>>,
 		close_events: Mutex<Vec<(u32, String)>>,
-		close_notify: tokio::sync::Notify,
+		closed: kio::Fan,
 		control_writes: Arc<Mutex<Vec<u8>>>,
 		send_rate: Mutex<Option<u64>>,
 	}
@@ -499,11 +506,14 @@ mod tests {
 				protocol,
 				control_stream: Mutex::new(Some((send, recv))),
 				close_events: Mutex::new(Vec::new()),
-				close_notify: tokio::sync::Notify::new(),
+				closed: kio::Fan::default(),
 				control_writes: writes,
 				send_rate: Mutex::new(None),
 			};
-			Self { state: Arc::new(state) }
+			Self {
+				state: Arc::new(state),
+				park: kio::Park::default(),
+			}
 		}
 
 		fn set_send_rate(&self, rate: Option<u64>) {
@@ -515,43 +525,50 @@ mod tests {
 		}
 
 		async fn wait_for_first_close(&self) -> (u32, String) {
-			loop {
-				let notified = self.state.close_notify.notified();
-				if let Some(close) = self.state.close_events.lock().unwrap().first().cloned() {
-					return close;
+			kio::wait(|waiter| {
+				self.state.closed.register(waiter);
+				match self.state.close_events.lock().unwrap().first().cloned() {
+					Some(close) => std::task::Poll::Ready(close),
+					None => std::task::Poll::Pending,
 				}
-				notified.await;
-			}
+			})
+			.await
 		}
 	}
 
-	impl web_transport_trait::Session for FakeSession {
+	impl web_transport_trait::poll::Session for FakeSession {
 		type SendStream = FakeSendStream;
 		type RecvStream = FakeRecvStream;
 		type Error = FakeError;
 
-		async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-			std::future::pending().await
+		fn poll_accept_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>> {
+			Poll::Pending
 		}
 
-		async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			std::future::pending().await
+		fn poll_accept_bi(
+			&mut self,
+			_cx: &mut Context<'_>,
+		) -> Poll<Result<(Self::SendStream, Self::RecvStream), Self::Error>> {
+			Poll::Pending
 		}
 
-		async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			self.state.control_stream.lock().unwrap().take().ok_or(FakeError)
+		fn poll_open_bi(
+			&mut self,
+			_cx: &mut Context<'_>,
+		) -> Poll<Result<(Self::SendStream, Self::RecvStream), Self::Error>> {
+			Poll::Ready(self.state.control_stream.lock().unwrap().take().ok_or(FakeError))
 		}
 
-		async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-			std::future::pending().await
+		fn poll_open_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::SendStream, Self::Error>> {
+			Poll::Pending
 		}
 
-		fn send_datagram(&self, _payload: Bytes) -> Result<(), Self::Error> {
-			Ok(())
+		fn poll_send_datagram(&mut self, _cx: &mut Context<'_>, _payload: &[u8]) -> Poll<Result<(), Self::Error>> {
+			Poll::Ready(Ok(()))
 		}
 
-		async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
-			std::future::pending().await
+		fn poll_recv_datagram(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>> {
+			Poll::Pending
 		}
 
 		fn max_datagram_size(&self) -> usize {
@@ -562,18 +579,17 @@ mod tests {
 			self.state.protocol
 		}
 
-		fn close(&self, code: u32, reason: &str) {
+		fn close(&mut self, code: u32, reason: &str) {
 			self.state.close_events.lock().unwrap().push((code, reason.to_string()));
-			self.state.close_notify.notify_waiters();
+			self.state.closed.wake();
 		}
 
-		async fn closed(&self) -> Self::Error {
-			loop {
-				let notified = self.state.close_notify.notified();
-				if !self.state.close_events.lock().unwrap().is_empty() {
-					return FakeError;
-				}
-				notified.await;
+		fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Self::Error> {
+			// Register before checking so a close racing this poll still wakes it.
+			self.state.closed.register(self.park.hold(cx));
+			match self.state.close_events.lock().unwrap().is_empty() {
+				false => Poll::Ready(FakeError),
+				true => Poll::Pending,
 			}
 		}
 
@@ -599,12 +615,12 @@ mod tests {
 		writes: Arc<Mutex<Vec<u8>>>,
 	}
 
-	impl web_transport_trait::SendStream for FakeSendStream {
+	impl web_transport_trait::poll::SendStream for FakeSendStream {
 		type Error = FakeError;
 
-		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+		fn poll_write(&mut self, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
 			self.writes.lock().unwrap().put_slice(buf);
-			Ok(buf.len())
+			Poll::Ready(Ok(buf.len()))
 		}
 
 		fn set_priority(&mut self, _order: u8) {}
@@ -615,8 +631,8 @@ mod tests {
 
 		fn reset(&mut self, _code: u32) {}
 
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			Ok(())
+		fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+			Poll::Ready(Ok(()))
 		}
 	}
 
@@ -624,25 +640,25 @@ mod tests {
 		data: VecDeque<u8>,
 	}
 
-	impl web_transport_trait::RecvStream for FakeRecvStream {
+	impl web_transport_trait::poll::RecvStream for FakeRecvStream {
 		type Error = FakeError;
 
-		async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+		fn poll_read(&mut self, _cx: &mut Context<'_>, dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
 			if self.data.is_empty() {
-				return Ok(None);
+				return Poll::Ready(Ok(None));
 			}
 
 			let size = dst.len().min(self.data.len());
 			for slot in dst.iter_mut().take(size) {
 				*slot = self.data.pop_front().unwrap();
 			}
-			Ok(Some(size))
+			Poll::Ready(Ok(Some(size)))
 		}
 
 		fn stop(&mut self, _code: u32) {}
 
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			Ok(())
+		fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+			Poll::Ready(Ok(()))
 		}
 	}
 

--- a/rs/moq-net/src/coding/reader.rs
+++ b/rs/moq-net/src/coding/reader.rs
@@ -5,13 +5,13 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crate::{Error, StreamError, coding::*};
 
 /// A reader for decoding messages from a stream.
-pub struct Reader<S: web_transport_trait::RecvStream, V> {
+pub struct Reader<S: crate::transport::poll::RecvStream, V> {
 	stream: S,
 	buffer: BytesMut,
 	version: V,
 }
 
-impl<S: web_transport_trait::RecvStream, V> Reader<S, V> {
+impl<S: crate::transport::poll::RecvStream, V> Reader<S, V> {
 	pub fn new(stream: S, version: V) -> Self {
 		Self {
 			stream,
@@ -175,19 +175,23 @@ mod tests {
 		stops: Vec<u32>,
 	}
 
-	impl web_transport_trait::RecvStream for StopLog {
+	impl web_transport_trait::poll::RecvStream for StopLog {
 		type Error = crate::lite::test_transport::SinkError;
 
-		async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-			Ok(None)
+		fn poll_read(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+			_dst: &mut [u8],
+		) -> std::task::Poll<Result<Option<usize>, Self::Error>> {
+			std::task::Poll::Ready(Ok(None))
 		}
 
 		fn stop(&mut self, code: u32) {
 			self.stops.push(code);
 		}
 
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			Ok(())
+		fn poll_closed(&mut self, _cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+			std::task::Poll::Ready(Ok(()))
 		}
 	}
 

--- a/rs/moq-net/src/coding/reader.rs
+++ b/rs/moq-net/src/coding/reader.rs
@@ -1,10 +1,20 @@
-use std::{cmp, fmt::Debug, io};
+use std::{
+	cmp,
+	fmt::Debug,
+	io,
+	task::{Context, Poll, ready},
+};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 
 use crate::{Error, StreamError, coding::*};
 
 /// A reader for decoding messages from a stream.
+///
+/// The `poll_*` methods are the implementation; the `async` methods are thin
+/// wrappers, so the reader can be driven from another poll function without
+/// pinning a future. Partial bytes accumulate in the internal buffer, so a
+/// `Pending` (or a cancelled wrapper) never desynchronizes the stream.
 pub struct Reader<S: crate::transport::poll::RecvStream, V> {
 	stream: S,
 	buffer: BytesMut,
@@ -20,8 +30,8 @@ impl<S: crate::transport::poll::RecvStream, V> Reader<S, V> {
 		}
 	}
 
-	/// Decode the next message from the stream.
-	pub async fn decode<T: Decode<V> + Debug>(&mut self) -> Result<T, Error>
+	/// Poll for the next message on the stream.
+	pub fn poll_decode<T: Decode<V> + Debug>(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, Error>>
 	where
 		V: Clone,
 	{
@@ -30,39 +40,62 @@ impl<S: crate::transport::poll::RecvStream, V> Reader<S, V> {
 			match T::decode(&mut cursor, self.version.clone()) {
 				Ok(msg) => {
 					self.buffer.advance(cursor.position() as usize);
-					return Ok(msg);
+					return Poll::Ready(Ok(msg));
 				}
-				Err(DecodeError::Short) => {
-					// Try to read more data
-					if !self.read_more().await? {
-						// Stream closed while we still need more data
-						return Err(DecodeError::Short.into());
-					}
+				// Stream closed while we still need more data.
+				Err(DecodeError::Short) if !ready!(self.poll_read_more(cx))? => {
+					return Poll::Ready(Err(DecodeError::Short.into()));
 				}
-				Err(e) => return Err(e.into()),
+				Err(DecodeError::Short) => {}
+				Err(e) => return Poll::Ready(Err(e.into())),
 			}
 		}
 	}
 
+	/// Decode the next message from the stream.
+	pub async fn decode<T: Decode<V> + Debug>(&mut self) -> Result<T, Error>
+	where
+		V: Clone,
+	{
+		std::future::poll_fn(|cx| self.poll_decode(cx)).await
+	}
+
+	/// Poll for the next message unless the stream is closed cleanly first.
+	pub fn poll_decode_maybe<T: Decode<V> + Debug>(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<T>, Error>>
+	where
+		V: Clone,
+	{
+		if !ready!(self.poll_has_more(cx))? {
+			return Poll::Ready(Ok(None));
+		}
+
+		self.poll_decode(cx).map_ok(Some)
+	}
+
 	/// Decode the next message unless the stream is closed.
-	///
-	/// Cancel-safe with the transports we ship (`web_transport_quinn`, `qmux`).
-	/// The only `.await` points are reads from the underlying transport; partial
-	/// bytes accumulate in `self.buffer` and a re-entry resumes decoding from
-	/// the same position, so dropping the future mid-message never desynchronizes
-	/// the stream. This requires the transport's `read_buf` to be cancel-safe
-	/// (Quinn's `RecvStream::read` is documented as such, and qmux's
-	/// `RecvStream::read_chunk` is a `tokio::sync::mpsc::Receiver::recv`).
-	/// New transport impls must preserve this property.
 	pub async fn decode_maybe<T: Decode<V> + Debug>(&mut self) -> Result<Option<T>, Error>
 	where
 		V: Clone,
 	{
-		if !self.has_more().await? {
-			return Ok(None);
-		}
+		std::future::poll_fn(|cx| self.poll_decode_maybe(cx)).await
+	}
 
-		Ok(Some(self.decode().await?))
+	/// Poll for the next message without consuming it.
+	pub fn poll_decode_peek<T: Decode<V> + Debug>(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, Error>>
+	where
+		V: Clone,
+	{
+		loop {
+			let mut cursor = io::Cursor::new(&self.buffer);
+			match T::decode(&mut cursor, self.version.clone()) {
+				Ok(msg) => return Poll::Ready(Ok(msg)),
+				Err(DecodeError::Short) if !ready!(self.poll_read_more(cx))? => {
+					return Poll::Ready(Err(DecodeError::Short.into()));
+				}
+				Err(DecodeError::Short) => {}
+				Err(e) => return Poll::Ready(Err(e.into())),
+			}
+		}
 	}
 
 	/// Decode the next message from the stream without consuming it.
@@ -70,80 +103,63 @@ impl<S: crate::transport::poll::RecvStream, V> Reader<S, V> {
 	where
 		V: Clone,
 	{
-		loop {
-			let mut cursor = io::Cursor::new(&self.buffer);
-			match T::decode(&mut cursor, self.version.clone()) {
-				Ok(msg) => return Ok(msg),
-				Err(DecodeError::Short) => {
-					// Try to read more data
-					if !self.read_more().await? {
-						// Stream closed while we still need more data
-						return Err(DecodeError::Short.into());
-					}
-				}
-				Err(e) => return Err(e.into()),
-			}
+		std::future::poll_fn(|cx| self.poll_decode_peek(cx)).await
+	}
+
+	/// Poll for the next chunk, draining the reader's internal buffer first.
+	pub fn poll_read_chunk(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<Option<Bytes>, Error>> {
+		if !self.buffer.is_empty() {
+			let n = cmp::min(self.buffer.len(), max);
+			return Poll::Ready(Ok(Some(self.buffer.split_to(n).freeze())));
 		}
+		self.stream.poll_read_chunk(cx, max).map_err(Error::from_transport)
 	}
 
 	/// Read the next chunk, draining the reader's internal buffer first.
 	pub async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
-		if !self.buffer.is_empty() {
-			let n = cmp::min(self.buffer.len(), max);
-			return Ok(Some(self.buffer.split_to(n).freeze()));
+		std::future::poll_fn(|cx| self.poll_read_chunk(cx, max)).await
+	}
+
+	/// Poll for exactly `size` bytes, accumulating partial reads in the buffer.
+	pub fn poll_read_exact(&mut self, cx: &mut Context<'_>, size: usize) -> Poll<Result<Bytes, Error>> {
+		while self.buffer.len() < size {
+			if !ready!(self.poll_read_more(cx))? {
+				return Poll::Ready(Err(DecodeError::Short.into()));
+			}
 		}
-		self.stream.read_chunk(max).await.map_err(Error::from_transport)
+		Poll::Ready(Ok(self.buffer.split_to(size).freeze()))
 	}
 
 	/// Read exactly the given number of bytes from the stream.
 	pub async fn read_exact(&mut self, size: usize) -> Result<Bytes, Error> {
-		// An optimization to avoid a copy if we have enough data in the buffer
-		if self.buffer.len() >= size {
-			return Ok(self.buffer.split_to(size).freeze());
-		}
-
-		let data = BytesMut::with_capacity(size.min(u16::MAX as usize));
-		let mut buf = data.limit(size);
-
-		let size = cmp::min(buf.remaining_mut(), self.buffer.len());
-		let data = self.buffer.split_to(size);
-		buf.put(data);
-
-		while buf.has_remaining_mut() {
-			match self.stream.read_buf(&mut buf).await {
-				Ok(Some(_)) => {}
-				Ok(None) => return Err(DecodeError::Short.into()),
-				Err(e) => return Err(Error::from_transport(e)),
-			}
-		}
-
-		Ok(buf.into_inner().freeze())
+		std::future::poll_fn(|cx| self.poll_read_exact(cx, size)).await
 	}
 
-	/// Wait until the stream is closed, erroring if there are any additional bytes.
-	pub async fn closed(&mut self) -> Result<(), Error> {
-		if self.has_more().await? {
-			return Err(DecodeError::Short.into());
+	/// Poll until the stream is closed, erroring if there are any additional bytes.
+	pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+		if ready!(self.poll_has_more(cx))? {
+			return Poll::Ready(Err(DecodeError::Short.into()));
 		}
 
-		Ok(())
+		Poll::Ready(Ok(()))
 	}
 
-	/// Returns true if there is more data available in the buffer or stream.
-	async fn has_more(&mut self) -> Result<bool, Error> {
+	/// Poll for whether data is available in the buffer or stream.
+	fn poll_has_more(&mut self, cx: &mut Context<'_>) -> Poll<Result<bool, Error>> {
 		if !self.buffer.is_empty() {
-			return Ok(true);
+			return Poll::Ready(Ok(true));
 		}
 
-		self.read_more().await
+		self.poll_read_more(cx)
 	}
 
-	/// Try to read more data from the stream. Returns true if data was read, false if stream closed.
-	async fn read_more(&mut self) -> Result<bool, Error> {
-		match self.stream.read_buf(&mut self.buffer).await {
-			Ok(Some(_)) => Ok(true),
-			Ok(None) => Ok(false),
-			Err(e) => Err(Error::from_transport(e)),
+	/// Poll for more data from the stream. `true` if data was read, `false` if the
+	/// stream finished.
+	fn poll_read_more(&mut self, cx: &mut Context<'_>) -> Poll<Result<bool, Error>> {
+		match ready!(self.stream.poll_read_buf(cx, &mut self.buffer)) {
+			Ok(Some(_)) => Poll::Ready(Ok(true)),
+			Ok(None) => Poll::Ready(Ok(false)),
+			Err(e) => Poll::Ready(Err(Error::from_transport(e))),
 		}
 	}
 

--- a/rs/moq-net/src/coding/reader.rs
+++ b/rs/moq-net/src/coding/reader.rs
@@ -115,11 +115,6 @@ impl<S: crate::transport::poll::RecvStream, V> Reader<S, V> {
 		self.stream.poll_read_chunk(cx, max).map_err(Error::from_transport)
 	}
 
-	/// Read the next chunk, draining the reader's internal buffer first.
-	pub async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
-		std::future::poll_fn(|cx| self.poll_read_chunk(cx, max)).await
-	}
-
 	/// Poll for exactly `size` bytes, accumulating partial reads in the buffer.
 	pub fn poll_read_exact(&mut self, cx: &mut Context<'_>, size: usize) -> Poll<Result<Bytes, Error>> {
 		while self.buffer.len() < size {

--- a/rs/moq-net/src/coding/stream.rs
+++ b/rs/moq-net/src/coding/stream.rs
@@ -2,14 +2,14 @@ use crate::Error;
 use crate::coding::{Reader, Writer};
 
 /// A [Writer] and [Reader] pair for a single stream.
-pub struct Stream<S: web_transport_trait::Session, V> {
+pub struct Stream<S: crate::transport::poll::Session, V> {
 	pub writer: Writer<S::SendStream, V>,
 	pub reader: Reader<S::RecvStream, V>,
 }
 
-impl<S: web_transport_trait::Session, V> Stream<S, V> {
+impl<S: crate::transport::poll::Session, V> Stream<S, V> {
 	/// Open a new stream with the given version.
-	pub async fn open(session: &S, version: V) -> Result<Self, Error>
+	pub async fn open(session: &mut S, version: V) -> Result<Self, Error>
 	where
 		V: Clone,
 	{
@@ -22,7 +22,7 @@ impl<S: web_transport_trait::Session, V> Stream<S, V> {
 	}
 
 	/// Accept a new stream with the given version.
-	pub async fn accept(session: &S, version: V) -> Result<Self, Error>
+	pub async fn accept(session: &mut S, version: V) -> Result<Self, Error>
 	where
 		V: Clone,
 	{

--- a/rs/moq-net/src/coding/stream.rs
+++ b/rs/moq-net/src/coding/stream.rs
@@ -1,3 +1,5 @@
+use std::task::{Context, Poll, ready};
+
 use crate::Error;
 use crate::coding::{Reader, Writer};
 
@@ -8,17 +10,31 @@ pub struct Stream<S: crate::transport::poll::Session, V> {
 }
 
 impl<S: crate::transport::poll::Session, V> Stream<S, V> {
+	/// Poll opening a new stream with the given version.
+	pub fn poll_open(session: &mut S, version: V, cx: &mut Context<'_>) -> Poll<Result<Self, Error>>
+	where
+		V: Clone,
+	{
+		let (send, recv) = ready!(session.poll_open_bi(cx)).map_err(Error::from_transport)?;
+		Poll::Ready(Ok(Self::build(send, recv, version)))
+	}
+
 	/// Open a new stream with the given version.
 	pub async fn open(session: &mut S, version: V) -> Result<Self, Error>
 	where
 		V: Clone,
 	{
 		let (send, recv) = session.open_bi().await.map_err(Error::from_transport)?;
+		Ok(Self::build(send, recv, version))
+	}
 
-		let writer = Writer::new(send, version.clone());
-		let reader = Reader::new(recv, version);
-
-		Ok(Stream { writer, reader })
+	/// Poll accepting a new stream with the given version.
+	pub fn poll_accept(session: &mut S, version: V, cx: &mut Context<'_>) -> Poll<Result<Self, Error>>
+	where
+		V: Clone,
+	{
+		let (send, recv) = ready!(session.poll_accept_bi(cx)).map_err(Error::from_transport)?;
+		Poll::Ready(Ok(Self::build(send, recv, version)))
 	}
 
 	/// Accept a new stream with the given version.
@@ -27,11 +43,17 @@ impl<S: crate::transport::poll::Session, V> Stream<S, V> {
 		V: Clone,
 	{
 		let (send, recv) = session.accept_bi().await.map_err(Error::from_transport)?;
+		Ok(Self::build(send, recv, version))
+	}
 
-		let writer = Writer::new(send, version.clone());
-		let reader = Reader::new(recv, version);
-
-		Ok(Stream { writer, reader })
+	fn build(send: S::SendStream, recv: S::RecvStream, version: V) -> Self
+	where
+		V: Clone,
+	{
+		Self {
+			writer: Writer::new(send, version.clone()),
+			reader: Reader::new(recv, version),
+		}
 	}
 
 	/// Cast the stream to a different version, used during version negotiation.

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -2,14 +2,14 @@ use std::fmt::Debug;
 
 use crate::{Error, StreamError, coding::*, ietf};
 
-/// A wrapper around a [web_transport_trait::SendStream] that will reset on Drop.
-pub struct Writer<S: web_transport_trait::SendStream, V> {
+/// A wrapper around a [crate::transport::poll::SendStream] that will reset on Drop.
+pub struct Writer<S: crate::transport::poll::SendStream, V> {
 	stream: Option<S>,
 	buffer: bytes::BytesMut,
 	version: V,
 }
 
-impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
+impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 	/// Create a new writer for the given stream and version.
 	pub fn new(stream: S, version: V) -> Self {
 		Self {
@@ -133,7 +133,7 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 	}
 }
 
-impl<S: web_transport_trait::SendStream> Writer<S, ietf::Version> {
+impl<S: crate::transport::poll::SendStream> Writer<S, ietf::Version> {
 	/// Encode an IETF `Message` to the stream, writing `[type_id][size][body]`.
 	pub async fn encode_message<T: ietf::Message>(&mut self, msg: &T) -> Result<(), Error> {
 		self.encode(&T::ID).await?;
@@ -141,7 +141,7 @@ impl<S: web_transport_trait::SendStream> Writer<S, ietf::Version> {
 	}
 }
 
-impl<S: web_transport_trait::SendStream, V> Drop for Writer<S, V> {
+impl<S: crate::transport::poll::SendStream, V> Drop for Writer<S, V> {
 	fn drop(&mut self) {
 		if let Some(mut stream) = self.stream.take() {
 			// Unlike the Quinn default, we abort the stream on drop.

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -1,8 +1,17 @@
-use std::fmt::Debug;
+use std::{
+	fmt::Debug,
+	task::{Context, Poll, ready},
+};
 
 use crate::{Error, StreamError, coding::*, ietf};
 
 /// A wrapper around a [crate::transport::poll::SendStream] that will reset on Drop.
+///
+/// The `poll_*` methods are the implementation; the `async` methods are thin
+/// wrappers, so the writer can be driven from another poll function without
+/// pinning a future. Messages are encoded into an internal buffer with
+/// [`Self::buffer`] and drained by [`Self::poll_flush`], so a `Pending` (or a
+/// cancelled wrapper) resumes mid-message instead of desynchronizing the stream.
 pub struct Writer<S: crate::transport::poll::SendStream, V> {
 	stream: Option<S>,
 	buffer: bytes::BytesMut,
@@ -19,57 +28,82 @@ impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 		}
 	}
 
+	/// Encode the given message into the write buffer, to be sent by
+	/// [`Self::poll_flush`]. An encode error leaves the buffer untouched.
+	pub fn buffer<T: Encode<V> + Debug>(&mut self, msg: &T) -> Result<(), Error>
+	where
+		V: Clone,
+	{
+		let start = self.buffer.len();
+		if let Err(err) = msg.encode(&mut self.buffer, self.version.clone()) {
+			// Drop the partial encode: flushing it would corrupt the stream.
+			self.buffer.truncate(start);
+			return Err(err.into());
+		}
+		Ok(())
+	}
+
+	/// Poll until the write buffer has fully hit the stream.
+	pub fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+		while !self.buffer.is_empty() {
+			ready!(self.stream.as_mut().unwrap().poll_write_buf(cx, &mut self.buffer))
+				.map_err(Error::from_transport)?;
+		}
+		Poll::Ready(Ok(()))
+	}
+
 	/// Encode the given message to the stream.
 	pub async fn encode<T: Encode<V> + Debug>(&mut self, msg: &T) -> Result<(), Error>
 	where
 		V: Clone,
 	{
-		self.buffer.clear();
-		msg.encode(&mut self.buffer, self.version.clone())?;
-
-		while !self.buffer.is_empty() {
-			self.stream
-				.as_mut()
-				.unwrap()
-				.write_buf(&mut self.buffer)
-				.await
-				.map_err(Error::from_transport)?;
-		}
-
-		Ok(())
+		self.buffer(msg)?;
+		std::future::poll_fn(|cx| self.poll_flush(cx)).await
 	}
 
-	pub(crate) async fn write<Buf: bytes::Buf + Send>(&mut self, buf: &mut Buf) -> Result<usize, Error> {
+	/// Poll a write of `buf`, flushing any buffered message bytes first so the
+	/// stream never reorders around the buffer.
+	pub fn poll_write<Buf: bytes::Buf>(&mut self, cx: &mut Context<'_>, buf: &mut Buf) -> Poll<Result<usize, Error>> {
+		ready!(self.poll_flush(cx))?;
 		self.stream
 			.as_mut()
 			.unwrap()
-			.write_buf(buf)
-			.await
+			.poll_write_buf(cx, buf)
 			.map_err(Error::from_transport)
+	}
+
+	pub(crate) async fn write<Buf: bytes::Buf + Send>(&mut self, buf: &mut Buf) -> Result<usize, Error> {
+		std::future::poll_fn(|cx| self.poll_write(cx, buf)).await
+	}
+
+	/// Poll until the entire `Buf` has been written to the stream.
+	///
+	/// NOTE: This can avoid performing a copy when using `Bytes`.
+	pub fn poll_write_all<Buf: bytes::Buf>(&mut self, cx: &mut Context<'_>, buf: &mut Buf) -> Poll<Result<(), Error>> {
+		while buf.has_remaining() {
+			ready!(self.poll_write(cx, buf))?;
+		}
+		Poll::Ready(Ok(()))
 	}
 
 	/// Write the entire `Buf` to the stream.
 	///
 	/// NOTE: This can avoid performing a copy when using `Bytes`.
 	pub async fn write_all<Buf: bytes::Buf + Send>(&mut self, buf: &mut Buf) -> Result<(), Error> {
-		while buf.has_remaining() {
-			self.write(buf).await?;
-		}
-		Ok(())
+		std::future::poll_fn(|cx| self.poll_write_all(cx, buf)).await
 	}
 
 	/// Write the entire [`bytes::Bytes`] chunk to the stream.
-	pub async fn write_chunk(&mut self, chunk: bytes::Bytes) -> Result<(), Error> {
-		self.stream
-			.as_mut()
-			.unwrap()
-			.write_chunk(chunk)
-			.await
-			.map_err(Error::from_transport)
+	pub async fn write_chunk(&mut self, mut chunk: bytes::Bytes) -> Result<(), Error> {
+		self.write_all(&mut chunk).await
 	}
 
 	/// Mark the stream as finished.
+	///
+	/// Only valid once the buffer has flushed; the callers that finish
+	/// immediately after an `encode` are safe because `encode` flushes fully.
 	pub fn finish(&mut self) -> Result<(), Error> {
+		debug_assert!(self.buffer.is_empty(), "finish with unflushed bytes");
 		self.stream.as_mut().unwrap().finish().map_err(Error::from_transport)
 	}
 
@@ -96,20 +130,21 @@ impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 		};
 
 		stream.finish().map_err(Error::from_transport)?;
-		stream.closed().await.map_err(Error::from_transport)?;
+		std::future::poll_fn(|cx| stream.poll_closed(cx).map_err(Error::from_transport)).await
+	}
 
-		Ok(())
+	/// Poll until the stream is closed, or the [Self::finish] is acknowledged by the peer.
+	pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+		self.stream
+			.as_mut()
+			.unwrap()
+			.poll_closed(cx)
+			.map_err(Error::from_transport)
 	}
 
 	/// Wait for the stream to be closed, or the [Self::finish] to be acknowledged by the peer.
 	pub async fn closed(&mut self) -> Result<(), Error> {
-		self.stream
-			.as_mut()
-			.unwrap()
-			.closed()
-			.await
-			.map_err(Error::from_transport)?;
-		Ok(())
+		std::future::poll_fn(|cx| self.poll_closed(cx)).await
 	}
 
 	/// Set the stream's send order: streams with HIGHER values are transmitted first.
@@ -136,7 +171,7 @@ impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 impl<S: crate::transport::poll::SendStream> Writer<S, ietf::Version> {
 	/// Encode an IETF `Message` to the stream, writing `[type_id][size][body]`.
 	pub async fn encode_message<T: ietf::Message>(&mut self, msg: &T) -> Result<(), Error> {
-		self.encode(&T::ID).await?;
+		self.buffer(&T::ID)?;
 		self.encode(msg).await
 	}
 }
@@ -149,11 +184,11 @@ impl<S: crate::transport::poll::SendStream, V> Drop for Writer<S, V> {
 		}
 	}
 }
-
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::lite::test_transport::{Log, SinkSend};
+	use std::task::Waker;
 
 	#[test]
 	fn set_priority_forwards_send_order() {
@@ -165,5 +200,60 @@ mod tests {
 		}
 
 		assert_eq!(log.priorities(), (0u8..=255).collect::<Vec<_>>());
+	}
+
+	/// Writes some bytes, then errors: the shape of a partial encode.
+	#[derive(Debug)]
+	struct Poison;
+
+	impl Encode<()> for Poison {
+		fn encode<W: bytes::BufMut>(&self, w: &mut W, _: ()) -> Result<(), EncodeError> {
+			w.put_slice(b"junk");
+			Err(EncodeError::BoundsExceeded)
+		}
+	}
+
+	/// A failed encode must leave the buffer exactly as it was: flushing its
+	/// partial bytes would desynchronize the stream for every later message.
+	#[test]
+	fn a_failed_encode_leaves_no_partial_bytes() {
+		let mut writer = Writer::new(SinkSend::new(Log::default()), ());
+
+		writer.buffer(&5u8).unwrap();
+		writer.buffer(&Poison).unwrap_err();
+		writer.buffer(&7u8).unwrap();
+
+		let log = writer.stream.as_ref().unwrap().log.clone();
+		let mut cx = std::task::Context::from_waker(Waker::noop());
+		assert!(writer.poll_flush(&mut cx).is_ready());
+		assert_eq!(*log.writes.lock().unwrap(), vec![5, 7], "the partial encode leaked");
+	}
+
+	/// A flush interrupted mid-message resumes where it left off, so an
+	/// abandoned wrapper future never desynchronizes the stream.
+	#[test]
+	fn flush_resumes_after_pending() {
+		let gate = kio::Producer::new(false);
+		let mut writer = Writer::new(SinkSend::gated(Log::default(), gate.consume()), ());
+		let log = writer.stream.as_ref().unwrap().log.clone();
+
+		writer.buffer(&5u8).unwrap();
+		let mut cx = std::task::Context::from_waker(Waker::noop());
+		assert!(writer.poll_flush(&mut cx).is_pending());
+		assert!(log.writes.lock().unwrap().is_empty());
+
+		// The bytes survive the Pending (and a second message queued behind them).
+		writer.buffer(&7u8).unwrap();
+		let Ok(mut open) = gate.write() else {
+			panic!("gate closed")
+		};
+		*open = true;
+		drop(open);
+		assert!(writer.poll_flush(&mut cx).is_ready());
+		assert_eq!(
+			*log.writes.lock().unwrap(),
+			vec![5, 7],
+			"the flush lost or reordered bytes"
+		);
 	}
 }

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -43,6 +43,12 @@ impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 		Ok(())
 	}
 
+	/// Append raw pre-encoded bytes to the write buffer, to be sent by
+	/// [`Self::poll_flush`].
+	pub fn buffer_raw(&mut self, bytes: &[u8]) {
+		self.buffer.extend_from_slice(bytes);
+	}
+
 	/// Poll until the write buffer has fully hit the stream.
 	pub fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
 		while !self.buffer.is_empty() {
@@ -87,11 +93,6 @@ impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 	/// NOTE: This can avoid performing a copy when using `Bytes`.
 	pub async fn write_all<Buf: bytes::Buf + Send>(&mut self, buf: &mut Buf) -> Result<(), Error> {
 		std::future::poll_fn(|cx| self.poll_write_all(cx, buf)).await
-	}
-
-	/// Write the entire [`bytes::Bytes`] chunk to the stream.
-	pub async fn write_chunk(&mut self, mut chunk: bytes::Bytes) -> Result<(), Error> {
-		self.write_all(&mut chunk).await
 	}
 
 	/// Mark the stream as finished.

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -72,10 +72,6 @@ impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 			.map_err(Error::from_transport)
 	}
 
-	pub(crate) async fn write<Buf: bytes::Buf + Send>(&mut self, buf: &mut Buf) -> Result<usize, Error> {
-		std::future::poll_fn(|cx| self.poll_write(cx, buf)).await
-	}
-
 	/// Poll until the entire `Buf` has been written to the stream.
 	///
 	/// NOTE: This can avoid performing a copy when using `Bytes`.

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -59,6 +59,12 @@ impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 	}
 
 	/// Encode the given message to the stream.
+	///
+	/// Cancelling this future never desynchronizes the stream: the message is
+	/// already buffered and a later flush completes it. That also means a
+	/// cancelled `encode` must not be retried with the same message, or two
+	/// copies go on the wire; resume with [`Self::poll_flush`] (or any later
+	/// write) instead.
 	pub async fn encode<T: Encode<V> + Debug>(&mut self, msg: &T) -> Result<(), Error>
 	where
 		V: Clone,
@@ -137,6 +143,15 @@ impl<S: crate::transport::poll::SendStream, V> Writer<S, V> {
 			.unwrap()
 			.poll_closed(cx)
 			.map_err(Error::from_transport)
+	}
+
+	/// Poll-friendly [`Self::close`] for a finished writer: once the peer acknowledges
+	/// (or the stream dies), the stream is released so the [`Drop`] fallback cannot
+	/// reset an acknowledged stream with a spurious Cancel.
+	pub fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+		let res = ready!(self.poll_closed(cx));
+		self.stream = None;
+		Poll::Ready(res)
 	}
 
 	/// Wait for the stream to be closed, or the [Self::finish] to be acknowledged by the peer.

--- a/rs/moq-net/src/goaway.rs
+++ b/rs/moq-net/src/goaway.rs
@@ -273,16 +273,16 @@ impl Protocol {
 /// The draft makes the deadline the sender's promise, not the peer's, so the
 /// driver arms this after the message hits the wire rather than making the
 /// caller hold a handle and await it.
-pub(crate) async fn enforce<S: web_transport_trait::Session>(session: &S, timeout: Option<Duration>) {
+pub(crate) async fn enforce<S: crate::transport::poll::Session>(session: &mut S, timeout: Option<Duration>) {
 	let Some(timeout) = timeout else {
 		return;
 	};
 
-	let mut closed = std::pin::pin!(session.closed());
 	let mut deadline = std::pin::pin!(web_async::time::sleep(timeout));
 
 	let expired = kio::wait(|waiter| {
-		if waiter.poll_future(closed.as_mut()).is_ready() {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		if session.poll_closed(&mut cx).is_ready() {
 			return Poll::Ready(false);
 		}
 		waiter.poll_future(deadline.as_mut()).map(|_| true)

--- a/rs/moq-net/src/goaway.rs
+++ b/rs/moq-net/src/goaway.rs
@@ -249,50 +249,67 @@ impl Protocol {
 		Ok(())
 	}
 
-	/// Wait for the send trigger to fire, returning the GOAWAY to encode.
+	/// Poll for the send trigger firing, returning the GOAWAY to encode.
 	///
-	/// Returns `None` if the trigger was dropped without firing (the session is
-	/// closing without a drain), so nothing should be sent.
-	pub async fn triggered(&self) -> Option<Goaway> {
-		kio::wait(|waiter| {
-			match self.trigger.poll(waiter, |state| match &**state {
-				Some(goaway) => Poll::Ready(goaway.clone()),
-				None => Poll::Pending,
-			}) {
-				Poll::Ready(Ok(goaway)) => Poll::Ready(Some(goaway)),
-				Poll::Ready(Err(_)) => Poll::Ready(None),
-				Poll::Pending => Poll::Pending,
-			}
-		})
-		.await
+	/// `None` if the trigger was dropped without firing (the session is closing
+	/// without a drain), so nothing should be sent.
+	pub fn poll_triggered(&self, waiter: &kio::Waiter) -> Poll<Option<Goaway>> {
+		match self.trigger.poll(waiter, |state| match &**state {
+			Some(goaway) => Poll::Ready(goaway.clone()),
+			None => Poll::Pending,
+		}) {
+			Poll::Ready(Ok(goaway)) => Poll::Ready(Some(goaway)),
+			Poll::Ready(Err(_)) => Poll::Ready(None),
+			Poll::Pending => Poll::Pending,
+		}
+	}
+}
+
+/// Enforces a sent GOAWAY's deadline: closes the session once it passes.
+///
+/// The draft makes the deadline the sender's promise, not the peer's, so the
+/// driver arms this after the message hits the wire rather than making the
+/// caller hold a handle and await it.
+pub(crate) struct Enforce<S: crate::transport::poll::Session> {
+	session: S,
+	/// The armed deadline, or `None` when the GOAWAY carried no timeout (ready
+	/// immediately: there is nothing to enforce).
+	deadline: Option<(crate::util::MaybeSendBox<'static, ()>, Duration)>,
+}
+
+impl<S: crate::transport::poll::Session> Enforce<S> {
+	pub fn new(session: S, timeout: Option<Duration>) -> Self {
+		use crate::util::MaybeBoxedExt;
+		Self {
+			session,
+			deadline: timeout.map(|timeout| (web_async::time::sleep(timeout).maybe_boxed(), timeout)),
+		}
+	}
+
+	/// Ready once the session closes on its own or the deadline passes (closing it).
+	pub fn poll(&mut self, cx: &mut std::task::Context<'_>) -> Poll<()> {
+		let Some((deadline, timeout)) = &mut self.deadline else {
+			return Poll::Ready(());
+		};
+
+		if self.session.poll_closed(cx).is_ready() {
+			return Poll::Ready(());
+		}
+		std::task::ready!(deadline.as_mut().poll(cx));
+
+		tracing::warn!(?timeout, "peer did not leave before the GOAWAY deadline; closing");
+		self.session
+			.close(SessionError::GoawayTimeout.to_code(), &Error::GoawayTimeout.to_string());
+		Poll::Ready(())
 	}
 }
 
 /// Enforce a sent GOAWAY's deadline: close the session once it passes.
 ///
-/// The draft makes the deadline the sender's promise, not the peer's, so the
-/// driver arms this after the message hits the wire rather than making the
-/// caller hold a handle and await it.
+/// The async form of [`Enforce`], for drivers that are still `async` themselves.
 pub(crate) async fn enforce<S: crate::transport::poll::Session>(session: &mut S, timeout: Option<Duration>) {
-	let Some(timeout) = timeout else {
-		return;
-	};
-
-	let mut deadline = std::pin::pin!(web_async::time::sleep(timeout));
-
-	let expired = kio::wait(|waiter| {
-		let mut cx = std::task::Context::from_waker(waiter.waker());
-		if session.poll_closed(&mut cx).is_ready() {
-			return Poll::Ready(false);
-		}
-		waiter.poll_future(deadline.as_mut()).map(|_| true)
-	})
-	.await;
-
-	if expired {
-		tracing::warn!(?timeout, "peer did not leave before the GOAWAY deadline; closing");
-		session.close(SessionError::GoawayTimeout.to_code(), &Error::GoawayTimeout.to_string());
-	}
+	let mut enforce = Enforce::new(session.clone(), timeout);
+	std::future::poll_fn(|cx| enforce.poll(cx)).await
 }
 
 /// The halves held by the public [`crate::Session`].

--- a/rs/moq-net/src/ietf/adapter.rs
+++ b/rs/moq-net/src/ietf/adapter.rs
@@ -1,7 +1,7 @@
 use std::{
 	collections::{HashMap, VecDeque},
 	sync::{Arc, Mutex},
-	task::Poll,
+	task::{Context, Poll},
 };
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -115,6 +115,7 @@ pub struct VirtualRecvStream {
 	buffer: Bytes,
 	rx: Queue<Bytes>,
 	closed: bool,
+	park: kio::Park,
 }
 
 impl VirtualRecvStream {
@@ -123,81 +124,104 @@ impl VirtualRecvStream {
 			buffer: initial,
 			rx,
 			closed: false,
+			park: kio::Park::default(),
 		}
 	}
 
-	/// Fill the buffer from the queue if empty. Returns false if the stream is closed.
-	async fn fill(&mut self) -> bool {
-		if !self.buffer.is_empty() {
-			return true;
+	/// Fill the buffer from the queue if empty; `self.closed` marks the FIN.
+	fn poll_fill(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+		if !self.buffer.is_empty() || self.closed {
+			return Poll::Ready(());
 		}
 
-		if self.closed {
-			return false;
-		}
-
-		match self.rx.pop().await {
-			Some(data) => {
+		let waiter = self.park.hold(cx);
+		match self.rx.poll_pop(waiter) {
+			Poll::Ready(Some(data)) => {
 				self.buffer = data;
-				true
+				Poll::Ready(())
 			}
-			None => {
+			Poll::Ready(None) => {
 				self.closed = true;
-				false
+				Poll::Ready(())
 			}
+			Poll::Pending => Poll::Pending,
 		}
 	}
 }
 
-impl web_transport_trait::RecvStream for VirtualRecvStream {
+impl web_transport_trait::poll::RecvStream for VirtualRecvStream {
 	type Error = crate::Error;
 
-	async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-		if !self.fill().await {
-			return Ok(None);
+	fn poll_read(&mut self, cx: &mut Context<'_>, dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
+		if dst.is_empty() {
+			return Poll::Ready(Ok(Some(0)));
+		}
+
+		std::task::ready!(self.poll_fill(cx));
+		if self.buffer.is_empty() {
+			return Poll::Ready(Ok(None));
 		}
 
 		let n = dst.len().min(self.buffer.len());
 		dst[..n].copy_from_slice(&self.buffer[..n]);
 		self.buffer.advance(n);
-		Ok(Some(n))
+		Poll::Ready(Ok(Some(n)))
 	}
 
-	async fn read_buf<B: BufMut + web_transport_trait::MaybeSend>(
+	fn poll_read_buf<B: BufMut>(
 		&mut self,
+		cx: &mut Context<'_>,
 		buf: &mut B,
-	) -> Result<Option<usize>, Self::Error> {
-		if !self.fill().await {
-			return Ok(None);
+	) -> Poll<Result<Option<usize>, Self::Error>> {
+		if !buf.has_remaining_mut() {
+			return Poll::Ready(Ok(Some(0)));
+		}
+
+		std::task::ready!(self.poll_fill(cx));
+		if self.buffer.is_empty() {
+			return Poll::Ready(Ok(None));
 		}
 
 		let n = buf.remaining_mut().min(self.buffer.len());
 		buf.put(self.buffer.split_to(n));
-		Ok(Some(n))
+		Poll::Ready(Ok(Some(n)))
 	}
 
-	async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Self::Error> {
-		if !self.fill().await {
-			return Ok(None);
+	fn poll_read_chunk(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<Option<Bytes>, Self::Error>> {
+		if max == 0 {
+			return Poll::Ready(Ok(Some(Bytes::new())));
+		}
+
+		std::task::ready!(self.poll_fill(cx));
+		if self.buffer.is_empty() {
+			return Poll::Ready(Ok(None));
 		}
 
 		let n = max.min(self.buffer.len());
-		Ok(Some(self.buffer.split_to(n)))
+		Poll::Ready(Ok(Some(self.buffer.split_to(n))))
 	}
 
 	fn stop(&mut self, _code: u32) {
 		self.rx.close();
 	}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
-		// Wait until the queue is closed
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		if self.closed {
-			return Ok(());
+			return Poll::Ready(Ok(()));
 		}
-		// Drain remaining messages
-		while self.rx.pop().await.is_some() {}
-		self.closed = true;
-		Ok(())
+
+		// Drain (and discard) remaining messages until the queue closes.
+		let waiter = self.park.hold(cx);
+		loop {
+			match self.rx.poll_pop(waiter) {
+				Poll::Ready(Some(_)) => {}
+				Poll::Ready(None) => {
+					self.closed = true;
+					return Poll::Ready(Ok(()));
+				}
+				Poll::Pending => return Poll::Pending,
+			}
+		}
 	}
 }
 
@@ -286,31 +310,11 @@ impl VirtualSendStream {
 	}
 }
 
-impl web_transport_trait::SendStream for VirtualSendStream {
-	type Error = crate::Error;
-
-	async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-		let len = buf.len();
-
-		if let Some(pending) = &mut self.pending {
-			pending.buf.extend_from_slice(buf);
-
-			if let Some(request_id) = pending.try_parse()? {
-				let mut pending = self.pending.take().unwrap();
-				let buf = std::mem::take(&mut pending.buf).freeze();
-				pending.register(request_id);
-				if !self.control_tx.push(buf) {
-					return Err(crate::Error::Closed);
-				}
-			}
-		} else if !self.control_tx.push(Bytes::copy_from_slice(buf)) {
-			return Err(crate::Error::Closed);
-		}
-
-		Ok(len)
-	}
-
-	async fn write_chunk(&mut self, chunk: Bytes) -> Result<(), Self::Error> {
+impl VirtualSendStream {
+	/// Route a chunk: accumulate while the request_id is still unknown, then
+	/// register and flush; forward directly afterwards. Never blocks, since the
+	/// control queue is unbounded.
+	fn push(&mut self, chunk: Bytes) -> Result<(), crate::Error> {
 		if let Some(pending) = &mut self.pending {
 			pending.buf.extend_from_slice(&chunk);
 
@@ -328,6 +332,23 @@ impl web_transport_trait::SendStream for VirtualSendStream {
 
 		Ok(())
 	}
+}
+
+impl web_transport_trait::poll::SendStream for VirtualSendStream {
+	type Error = crate::Error;
+
+	fn poll_write(&mut self, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+		let len = buf.len();
+		Poll::Ready(self.push(Bytes::copy_from_slice(buf)).map(|()| len))
+	}
+
+	fn poll_write_buf<B: Buf>(&mut self, _cx: &mut Context<'_>, buf: &mut B) -> Poll<Result<usize, Self::Error>> {
+		// Taking the whole buffer is safe because this never returns Pending; a
+		// `Bytes` source hands its chunk over without a copy.
+		let len = buf.remaining();
+		let chunk = buf.copy_to_bytes(len);
+		Poll::Ready(self.push(chunk).map(|()| len))
+	}
 
 	fn set_priority(&mut self, _order: u8) {}
 
@@ -343,39 +364,32 @@ impl web_transport_trait::SendStream for VirtualSendStream {
 
 	fn reset(&mut self, _code: u32) {}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
-		Ok(())
+	fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
 	}
 }
 
 // === Adapter Send/Recv Enums ===
 
-pub enum AdapterSend<S: web_transport_trait::Session> {
+pub enum AdapterSend<S: crate::transport::poll::Session> {
 	Real(S::SendStream),
 	Virtual(VirtualSendStream),
 }
 
-impl<S: web_transport_trait::Session> web_transport_trait::SendStream for AdapterSend<S> {
+impl<S: crate::transport::poll::Session> web_transport_trait::poll::SendStream for AdapterSend<S> {
 	type Error = crate::Error;
 
-	async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
 		match self {
-			Self::Real(s) => s.write(buf).await.map_err(|_| crate::Error::Closed),
-			Self::Virtual(s) => s.write(buf).await,
+			Self::Real(s) => s.poll_write(cx, buf).map(|r| r.map_err(|_| crate::Error::Closed)),
+			Self::Virtual(s) => s.poll_write(cx, buf),
 		}
 	}
 
-	async fn write_buf<B: Buf + web_transport_trait::MaybeSend>(&mut self, buf: &mut B) -> Result<usize, Self::Error> {
+	fn poll_write_buf<B: Buf>(&mut self, cx: &mut Context<'_>, buf: &mut B) -> Poll<Result<usize, Self::Error>> {
 		match self {
-			Self::Real(s) => s.write_buf(buf).await.map_err(|_| crate::Error::Closed),
-			Self::Virtual(s) => s.write_buf(buf).await,
-		}
-	}
-
-	async fn write_chunk(&mut self, chunk: Bytes) -> Result<(), Self::Error> {
-		match self {
-			Self::Real(s) => s.write_chunk(chunk).await.map_err(|_| crate::Error::Closed),
-			Self::Virtual(s) => s.write_chunk(chunk).await,
+			Self::Real(s) => s.poll_write_buf(cx, buf).map(|r| r.map_err(|_| crate::Error::Closed)),
+			Self::Virtual(s) => s.poll_write_buf(cx, buf),
 		}
 	}
 
@@ -400,43 +414,44 @@ impl<S: web_transport_trait::Session> web_transport_trait::SendStream for Adapte
 		}
 	}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		match self {
-			Self::Real(s) => s.closed().await.map_err(|_| crate::Error::Closed),
-			Self::Virtual(s) => s.closed().await,
+			Self::Real(s) => s.poll_closed(cx).map(|r| r.map_err(|_| crate::Error::Closed)),
+			Self::Virtual(s) => s.poll_closed(cx),
 		}
 	}
 }
 
-pub enum AdapterRecv<S: web_transport_trait::Session> {
+pub enum AdapterRecv<S: crate::transport::poll::Session> {
 	Real(S::RecvStream),
 	Virtual(VirtualRecvStream),
 }
 
-impl<S: web_transport_trait::Session> web_transport_trait::RecvStream for AdapterRecv<S> {
+impl<S: crate::transport::poll::Session> web_transport_trait::poll::RecvStream for AdapterRecv<S> {
 	type Error = crate::Error;
 
-	async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+	fn poll_read(&mut self, cx: &mut Context<'_>, dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
 		match self {
-			Self::Real(s) => s.read(dst).await.map_err(|_| crate::Error::Closed),
-			Self::Virtual(s) => s.read(dst).await,
+			Self::Real(s) => s.poll_read(cx, dst).map(|r| r.map_err(|_| crate::Error::Closed)),
+			Self::Virtual(s) => s.poll_read(cx, dst),
 		}
 	}
 
-	async fn read_buf<B: BufMut + web_transport_trait::MaybeSend>(
+	fn poll_read_buf<B: BufMut>(
 		&mut self,
+		cx: &mut Context<'_>,
 		buf: &mut B,
-	) -> Result<Option<usize>, Self::Error> {
+	) -> Poll<Result<Option<usize>, Self::Error>> {
 		match self {
-			Self::Real(s) => s.read_buf(buf).await.map_err(|_| crate::Error::Closed),
-			Self::Virtual(s) => s.read_buf(buf).await,
+			Self::Real(s) => s.poll_read_buf(cx, buf).map(|r| r.map_err(|_| crate::Error::Closed)),
+			Self::Virtual(s) => s.poll_read_buf(cx, buf),
 		}
 	}
 
-	async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Self::Error> {
+	fn poll_read_chunk(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<Option<Bytes>, Self::Error>> {
 		match self {
-			Self::Real(s) => s.read_chunk(max).await.map_err(|_| crate::Error::Closed),
-			Self::Virtual(s) => s.read_chunk(max).await,
+			Self::Real(s) => s.poll_read_chunk(cx, max).map(|r| r.map_err(|_| crate::Error::Closed)),
+			Self::Virtual(s) => s.poll_read_chunk(cx, max),
 		}
 	}
 
@@ -447,10 +462,10 @@ impl<S: web_transport_trait::Session> web_transport_trait::RecvStream for Adapte
 		}
 	}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		match self {
-			Self::Real(s) => s.closed().await.map_err(|_| crate::Error::Closed),
-			Self::Virtual(s) => s.closed().await,
+			Self::Real(s) => s.poll_closed(cx).map(|r| r.map_err(|_| crate::Error::Closed)),
+			Self::Virtual(s) => s.poll_closed(cx),
 		}
 	}
 }
@@ -559,26 +574,29 @@ impl Shared {
 }
 
 #[derive(Clone)]
-pub struct ControlStreamAdapter<S: web_transport_trait::Session> {
+pub struct ControlStreamAdapter<S: crate::transport::poll::Session> {
 	inner: S,
 	shared: Arc<Shared>,
 	control: Control,
 	version: Version,
+	// Bridges Context-based polls onto the kio queues; empty on clone.
+	park: kio::Park,
 }
 
-impl<S: web_transport_trait::Session> ControlStreamAdapter<S> {
+impl<S: crate::transport::poll::Session> ControlStreamAdapter<S> {
 	pub fn new(inner: S, control: Control, version: Version) -> Self {
 		Self {
 			inner,
 			shared: Arc::new(Shared::default()),
 			control,
 			version,
+			park: kio::Park::default(),
 		}
 	}
 
 	/// Open a real (non-virtual) bidi stream, bypassing control stream multiplexing.
 	/// Used for v16 SubscribeNamespace which moved to its own bidi stream.
-	pub async fn open_native_bi(&self) -> Result<(AdapterSend<S>, AdapterRecv<S>), crate::Error> {
+	pub async fn open_native_bi(&mut self) -> Result<(AdapterSend<S>, AdapterRecv<S>), crate::Error> {
 		let (send, recv) = self.inner.open_bi().await.map_err(|_| crate::Error::Closed)?;
 		Ok((AdapterSend::Real(send), AdapterRecv::Real(recv)))
 	}
@@ -911,65 +929,66 @@ fn lookup_namespace_request_id(
 	namespaces.get(direction, &ns).ok_or(Error::NotFound)
 }
 
-impl<S: web_transport_trait::Session> web_transport_trait::Session for ControlStreamAdapter<S> {
+impl<S: crate::transport::poll::Session> web_transport_trait::poll::Session for ControlStreamAdapter<S> {
 	type SendStream = AdapterSend<S>;
 	type RecvStream = AdapterRecv<S>;
 	type Error = crate::Error;
 
-	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-		match self.version {
-			// v16: SubscribeNamespace uses real bidi streams, so race both sources.
-			Version::Draft16 => {
-				// Native first: real bidi streams are rare and transport-paced, so
-				// they can't starve the queue, while a control-message flood could
-				// starve a native SubscribeNamespace under queue-first order.
-				let mut accept = std::pin::pin!(self.inner.accept_bi());
-				kio::wait(|waiter| {
-					if let Poll::Ready(result) = waiter.poll_future(accept.as_mut()) {
-						return Poll::Ready(match result {
-							Ok((send, recv)) => Ok((AdapterSend::Real(send), AdapterRecv::Real(recv))),
-							Err(_) => Err(crate::Error::Closed),
-						});
-					}
-					if let Poll::Ready(result) = self.shared.incoming.poll_pop(waiter) {
-						return Poll::Ready(match result {
-							Some((send, recv)) => Ok((AdapterSend::Virtual(send), AdapterRecv::Virtual(recv))),
-							None => Err(crate::Error::Closed),
-						});
-					}
-					Poll::Pending
-				})
-				.await
+	fn poll_accept_bi(
+		&mut self,
+		cx: &mut Context<'_>,
+	) -> Poll<Result<(Self::SendStream, Self::RecvStream), Self::Error>> {
+		// v16: SubscribeNamespace uses real bidi streams, so poll both sources.
+		// Native first: real bidi streams are rare and transport-paced, so they
+		// can't starve the queue, while a control-message flood could starve a
+		// native SubscribeNamespace under queue-first order.
+		if self.version == Version::Draft16 {
+			match self.inner.poll_accept_bi(cx) {
+				Poll::Ready(Ok((send, recv))) => {
+					return Poll::Ready(Ok((AdapterSend::Real(send), AdapterRecv::Real(recv))));
+				}
+				Poll::Ready(Err(_)) => return Poll::Ready(Err(crate::Error::Closed)),
+				Poll::Pending => {}
 			}
-			// v14/v15: Only virtual streams from control stream.
-			_ => match self.shared.incoming.pop().await {
-				Some((send, recv)) => Ok((AdapterSend::Virtual(send), AdapterRecv::Virtual(recv))),
-				None => Err(crate::Error::Closed),
-			},
+		}
+
+		let waiter = self.park.hold(cx);
+		match std::task::ready!(self.shared.incoming.poll_pop(waiter)) {
+			Some((send, recv)) => Poll::Ready(Ok((AdapterSend::Virtual(send), AdapterRecv::Virtual(recv)))),
+			None => Poll::Ready(Err(crate::Error::Closed)),
 		}
 	}
 
-	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+	fn poll_open_bi(
+		&mut self,
+		_cx: &mut Context<'_>,
+	) -> Poll<Result<(Self::SendStream, Self::RecvStream), Self::Error>> {
 		let (send, recv) = self.shared.open_outgoing(self.version);
-		Ok((AdapterSend::Virtual(send), AdapterRecv::Virtual(recv)))
+		Poll::Ready(Ok((AdapterSend::Virtual(send), AdapterRecv::Virtual(recv))))
 	}
 
-	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-		let s = self.inner.open_uni().await.map_err(|_| crate::Error::Closed)?;
-		Ok(AdapterSend::Real(s))
+	fn poll_open_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::SendStream, Self::Error>> {
+		self.inner
+			.poll_open_uni(cx)
+			.map(|r| r.map(AdapterSend::Real).map_err(|_| crate::Error::Closed))
 	}
 
-	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-		let s = self.inner.accept_uni().await.map_err(|_| crate::Error::Closed)?;
-		Ok(AdapterRecv::Real(s))
+	fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>> {
+		self.inner
+			.poll_accept_uni(cx)
+			.map(|r| r.map(AdapterRecv::Real).map_err(|_| crate::Error::Closed))
 	}
 
-	fn send_datagram(&self, payload: Bytes) -> Result<(), Self::Error> {
-		self.inner.send_datagram(payload).map_err(|_| crate::Error::Closed)
+	fn poll_send_datagram(&mut self, cx: &mut Context<'_>, payload: &[u8]) -> Poll<Result<(), Self::Error>> {
+		self.inner
+			.poll_send_datagram(cx, payload)
+			.map(|r| r.map_err(|_| crate::Error::Closed))
 	}
 
-	async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
-		self.inner.recv_datagram().await.map_err(|_| crate::Error::Closed)
+	fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>> {
+		self.inner
+			.poll_recv_datagram(cx)
+			.map(|r| r.map_err(|_| crate::Error::Closed))
 	}
 
 	fn max_datagram_size(&self) -> usize {
@@ -980,13 +999,16 @@ impl<S: web_transport_trait::Session> web_transport_trait::Session for ControlSt
 		self.inner.protocol()
 	}
 
-	fn close(&self, code: u32, reason: &str) {
+	fn close(&mut self, code: u32, reason: &str) {
 		self.inner.close(code, reason)
 	}
 
-	async fn closed(&self) -> Self::Error {
-		let _ = self.inner.closed().await;
-		crate::Error::Closed
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Self::Error> {
+		self.inner.poll_closed(cx).map(|_| crate::Error::Closed)
+	}
+
+	fn stats(&self) -> impl web_transport_trait::Stats {
+		self.inner.stats()
 	}
 }
 
@@ -1040,9 +1062,9 @@ fn decode_publish_namespace_body(body: &Bytes, version: Version) -> Result<PathO
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::transport::poll::{RecvStream as _, SendStream as _};
 	use bytes::BytesMut;
 	use futures::FutureExt as _;
-	use web_transport_trait::{RecvStream as _, SendStream as _};
 
 	fn make_body_with_request_id(id: u64, version: Version) -> Bytes {
 		let mut buf = BytesMut::new();

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -439,15 +439,12 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 		let res = {
 			let mut closed_session = self.session.clone();
 			let mut serve = std::pin::pin!(self.run_track(track, request_id));
-			let mut reader_closed = std::pin::pin!(stream.reader.closed());
 			kio::wait(|waiter| {
 				if let Poll::Ready(res) = waiter.poll_future(serve.as_mut()) {
 					return Poll::Ready(res);
 				}
 				let mut cx = std::task::Context::from_waker(waiter.waker());
-				if waiter.poll_future(reader_closed.as_mut()).is_ready()
-					|| closed_session.poll_closed(&mut cx).is_ready()
-				{
+				if stream.reader.poll_closed(&mut cx).is_ready() || closed_session.poll_closed(&mut cx).is_ready() {
 					return Poll::Ready(Ok(()));
 				}
 				Poll::Pending
@@ -608,16 +605,14 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 
 		loop {
 			// Wait for the next frame, bailing if the peer closes the stream first.
-			let frame = {
-				let mut closed = std::pin::pin!(stream.closed());
-				kio::wait(|waiter| {
-					if waiter.poll_future(closed.as_mut()).is_ready() {
-						return Poll::Ready(Err(Error::Cancel));
-					}
-					group.poll_next_frame(waiter)
-				})
-				.await
-			};
+			let frame = kio::wait(|waiter| {
+				let mut cx = std::task::Context::from_waker(waiter.waker());
+				if stream.poll_closed(&mut cx).is_ready() {
+					return Poll::Ready(Err(Error::Cancel));
+				}
+				group.poll_next_frame(waiter)
+			})
+			.await;
 
 			let mut frame = match frame? {
 				Some(frame) => frame,
@@ -644,16 +639,14 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 			} else {
 				// Stream each chunk of the frame.
 				loop {
-					let chunk = {
-						let mut closed = std::pin::pin!(stream.closed());
-						kio::wait(|waiter| {
-							if waiter.poll_future(closed.as_mut()).is_ready() {
-								return Poll::Ready(Err(Error::Cancel));
-							}
-							frame.poll_read_chunk(waiter)
-						})
-						.await
-					};
+					let chunk = kio::wait(|waiter| {
+						let mut cx = std::task::Context::from_waker(waiter.waker());
+						if stream.poll_closed(&mut cx).is_ready() {
+							return Poll::Ready(Err(Error::Cancel));
+						}
+						frame.poll_read_chunk(waiter)
+					})
+					.await;
 
 					match chunk? {
 						Some(chunk) => {
@@ -1089,9 +1082,9 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 			linger.set(Self::linger_deadline(&watched));
 
 			let event = {
-				let mut closed = std::pin::pin!(stream.reader.closed());
 				kio::wait(|waiter| {
-					if let Poll::Ready(res) = waiter.poll_future(closed.as_mut()) {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if let Poll::Ready(res) = stream.reader.poll_closed(&mut cx) {
 						return Poll::Ready(NamespaceEvent::Closed(res));
 					}
 					if let Poll::Ready(update) = announced.poll_next(waiter) {

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -2,6 +2,7 @@ use crate::{group, origin, track};
 use std::{collections::HashMap, task::Poll};
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
+use web_transport_trait::poll::SendStream as _;
 
 use crate::{
 	AsPath, Error, Timescale,
@@ -115,7 +116,7 @@ enum NamespaceEvent {
 }
 
 #[derive(Clone)]
-pub(super) struct Publisher<S: web_transport_trait::Session> {
+pub(super) struct Publisher<S: crate::transport::poll::Session> {
 	session: S,
 	// Traffic stats are attributed through this tagged origin handle.
 	origin: origin::Consumer,
@@ -133,7 +134,7 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 	version: Version,
 }
 
-impl<S: web_transport_trait::Session> Publisher<S> {
+impl<S: crate::transport::poll::Session> Publisher<S> {
 	pub fn new(
 		session: S,
 		origin: origin::Consumer,
@@ -436,15 +437,16 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Run the track, cancelling on reader close (Unsubscribe or stream close)
 		let res = {
+			let mut closed_session = self.session.clone();
 			let mut serve = std::pin::pin!(self.run_track(track, request_id));
 			let mut reader_closed = std::pin::pin!(stream.reader.closed());
-			let mut session_closed = std::pin::pin!(self.session.closed());
 			kio::wait(|waiter| {
 				if let Poll::Ready(res) = waiter.poll_future(serve.as_mut()) {
 					return Poll::Ready(res);
 				}
+				let mut cx = std::task::Context::from_waker(waiter.waker());
 				if waiter.poll_future(reader_closed.as_mut()).is_ready()
-					|| waiter.poll_future(session_closed.as_mut()).is_ready()
+					|| closed_session.poll_closed(&mut cx).is_ready()
 				{
 					return Poll::Ready(Ok(()));
 				}
@@ -590,7 +592,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	async fn run_group(
-		session: S,
+		mut session: S,
 		msg: ietf::GroupHeader,
 		priority: u8,
 		mut group: group::Consumer,
@@ -674,7 +676,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Handle a FETCH on its bidi stream.
-	async fn run_fetch_stream(self, mut stream: Stream<S, Version>, msg: ietf::Fetch<'_>) -> Result<(), Error> {
+	async fn run_fetch_stream(mut self, mut stream: Stream<S, Version>, msg: ietf::Fetch<'_>) -> Result<(), Error> {
 		let _subscribe_id = match msg.fetch_type {
 			FetchType::Standalone { .. } => {
 				return self.reject_fetch(stream, msg.request_id, 500, "not supported").await;
@@ -913,7 +915,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		cluster: Option<cluster::Advert>,
 	) -> Result<(), Error> {
 		let request_id = self.control.next_request_id().await?;
-		let mut request = Stream::open(&self.session, self.version).await?;
+		let mut request = Stream::open(&mut self.session.clone(), self.version).await?;
 
 		request.writer.encode(&ietf::PublishNamespace::ID).await?;
 		request
@@ -1166,7 +1168,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 /// One draft-14/15 advertisement: the PUBLISH_NAMESPACE request it rode on and
 /// what closes it out with PUBLISH_NAMESPACE_DONE.
-struct NamespaceRequest<S: web_transport_trait::Session> {
+struct NamespaceRequest<S: crate::transport::poll::Session> {
 	path: crate::PathOwned,
 	request_id: RequestId,
 	stream: Stream<S, Version>,
@@ -1364,7 +1366,7 @@ mod tests {
 			.unwrap();
 		settle().await;
 
-		let stream = Stream::open(&session, Version::Draft16).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), Version::Draft16).await.unwrap();
 		let msg = ietf::SubscribeNamespace {
 			request_id: RequestId(1),
 			namespace: crate::Path::new(""),
@@ -1469,7 +1471,7 @@ mod tests {
 			VERSION,
 		);
 
-		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), VERSION).await.unwrap();
 		let msg = ietf::SubscribeNamespace {
 			request_id: RequestId(1),
 			namespace: crate::Path::new(""),
@@ -1567,7 +1569,7 @@ mod tests {
 	async fn subscribe_missing(version: Version) -> (Vec<u8>, Vec<u32>) {
 		let h = harness(version);
 
-		let stream = Stream::open(&h.session, version).await.unwrap();
+		let stream = Stream::open(&mut h.session.clone(), version).await.unwrap();
 		h.publisher
 			.clone()
 			.run_subscribe_stream(
@@ -1592,7 +1594,7 @@ mod tests {
 	async fn fetch_unsupported(version: Version, fetch_type: FetchType<'_>) -> (Vec<u8>, Vec<u32>) {
 		let h = harness(version);
 
-		let stream = Stream::open(&h.session, version).await.unwrap();
+		let stream = Stream::open(&mut h.session.clone(), version).await.unwrap();
 		h.publisher
 			.clone()
 			.run_fetch_stream(

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -407,7 +407,7 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 		};
 
 		let subscription = Subscription {
-			priority: msg.subscriber_priority,
+			priority: super::priority::from_wire(msg.subscriber_priority),
 			..Default::default()
 		};
 
@@ -936,15 +936,22 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 			}
 		}
 
+		// The extension changes what an advertisement carries, so nothing can be
+		// sent until the peer's SETUP says whether it speaks it.
+		let peer = self.peer().await;
+		// Register the split-horizon peer on the announce cursor too. The origin
+		// model uses this exposure to park a reflected copy before it can replace
+		// the source we are currently advertising to that peer.
+		let origin = match self.exclude(&peer) {
+			crate::Origin::UNKNOWN => origin,
+			exclude => origin.excluding(exclude),
+		};
 		let mut announced = origin.announced();
 		let mut watched: HashMap<crate::PathOwned, Watched> = HashMap::new();
 		// Draft-14/15: the open PUBLISH_NAMESPACE request carrying each advertised
 		// namespace. Empty on later drafts, whose entries ride `stream` inline.
 		let mut requests: HashMap<crate::PathOwned, NamespaceRequest<S>> = HashMap::new();
 
-		// The extension changes what an advertisement carries, so nothing can be
-		// sent until the peer's SETUP says whether it speaks it.
-		let peer = self.peer().await;
 		let mut linger = kio::time::Deadline::new();
 
 		// Stream updates (origin (un)announces plus watched route and demand
@@ -1237,8 +1244,9 @@ impl<S: crate::transport::poll::Session> GroupServe<S> {
 				}
 				GroupState::Closed { writer } => {
 					// Wait until everything is acknowledged by the peer so we can still
-					// cancel the stream.
-					let res = ready!(writer.poll_closed(&mut cx));
+					// cancel the stream. poll_close releases the stream on completion so
+					// the Drop fallback cannot reset the acknowledged stream.
+					let res = ready!(writer.poll_close(&mut cx));
 					let sequence = self.msg.group_id;
 					self.state = GroupState::Done;
 					return Poll::Ready(res.map(|()| {
@@ -1282,6 +1290,55 @@ struct NamespaceRequest<S: crate::transport::poll::Session> {
 	path: crate::PathOwned,
 	request_id: RequestId,
 	stream: Stream<S, Version>,
+}
+
+#[cfg(test)]
+mod group_priority_test {
+	use super::*;
+	use crate::lite::test_transport::SinkSession;
+
+	/// The model's `Subscription::priority` is higher-first ("higher values preempt
+	/// lower ones"), matching the transport trait's send order, so a group stream must
+	/// receive the model value unchanged. An inversion here would transmit the
+	/// LOWEST-priority track first under contention.
+	#[tokio::test]
+	async fn group_stream_preserves_model_priority() {
+		let log = crate::lite::test_transport::Log::default();
+		let session = SinkSession::new(log.clone());
+
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
+		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+		group
+			.write_frame(crate::Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
+			.unwrap();
+		let consumer = group.consume();
+		group.finish().unwrap();
+
+		let msg = ietf::GroupHeader {
+			track_alias: 0,
+			group_id: 0,
+			sub_group_id: 0,
+			publisher_priority: 0,
+			flags: Default::default(),
+		};
+
+		let mut serve = GroupServe {
+			session,
+			msg,
+			priority: 200,
+			group: consumer,
+			timescale: Timescale::default(),
+			version: Version::Draft14,
+			state: GroupState::Open,
+		};
+		kio::wait(|waiter| serve.poll_serve(waiter)).await.unwrap();
+
+		assert_eq!(
+			log.priorities(),
+			vec![200],
+			"model priority must pass through unchanged"
+		);
+	}
 }
 
 #[cfg(test)]

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1,13 +1,16 @@
-use crate::{group, origin, track};
-use std::{collections::HashMap, task::Poll};
+use crate::{frame, group, origin, track};
+use std::{
+	collections::HashMap,
+	task::{Poll, ready},
+};
 
-use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use web_transport_trait::poll::SendStream as _;
 
 use crate::{
 	AsPath, Error, Timescale,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
+	poll_set::{Machine, PollSet},
 	track::Subscription,
 	util::{MaybeBoxedExt, MaybeSendBox},
 };
@@ -404,7 +407,7 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 		};
 
 		let subscription = Subscription {
-			priority: super::priority::from_wire(msg.subscriber_priority),
+			priority: msg.subscriber_priority,
 			..Default::default()
 		};
 
@@ -438,9 +441,9 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 		// Run the track, cancelling on reader close (Unsubscribe or stream close)
 		let res = {
 			let mut closed_session = self.session.clone();
-			let mut serve = std::pin::pin!(self.run_track(track, request_id));
+			let mut serve = TrackServe::new(self.session.clone(), track, request_id, self.version);
 			kio::wait(|waiter| {
-				if let Poll::Ready(res) = waiter.poll_future(serve.as_mut()) {
+				if let Poll::Ready(res) = serve.poll(waiter) {
 					return Poll::Ready(res);
 				}
 				let mut cx = std::task::Context::from_waker(waiter.waker());
@@ -540,131 +543,6 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 					.await?;
 			}
 		}
-		Ok(())
-	}
-
-	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
-	async fn run_track(&self, mut track: track::Subscriber, request_id: RequestId) -> Result<(), Error> {
-		let mut tasks = FuturesUnordered::new();
-
-		loop {
-			// Await the next group while driving the in-flight group futures.
-			let group = {
-				kio::wait(|waiter| {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					while let std::task::Poll::Ready(Some(())) = tasks.poll_next_unpin(&mut cx) {}
-					track.poll_recv_group(waiter)
-				})
-				.await
-			};
-
-			let Some(group) = group? else {
-				// Track finished: drain the in-flight group futures, then FIN.
-				while tasks.next().await.is_some() {}
-				return Ok(());
-			};
-
-			let sequence = group.sequence;
-			tracing::debug!(subscribe = %request_id, track = %track.name(), sequence, "serving group");
-
-			let msg = ietf::GroupHeader {
-				track_alias: request_id.0,
-				group_id: sequence,
-				sub_group_id: 0,
-				publisher_priority: 0,
-				// Carry per-object timestamps as extension headers (the Timestamp Object
-				// Property) so moq-transport peers get the real PTS. The units are the
-				// track's, declared once in SUBSCRIBE_OK.
-				flags: ietf::GroupFlags {
-					has_extensions: true,
-					..Default::default()
-				},
-			};
-
-			let priority = track.subscription().priority;
-			let timescale = track.info().timescale;
-			tasks
-				.push(Self::run_group(self.session.clone(), msg, priority, group, timescale, self.version).map(|_| ()));
-		}
-	}
-
-	async fn run_group(
-		mut session: S,
-		msg: ietf::GroupHeader,
-		priority: u8,
-		mut group: group::Consumer,
-		timescale: Timescale,
-		version: Version,
-	) -> Result<(), Error> {
-		let stream = session.open_uni().await.map_err(Error::from_transport)?;
-
-		let mut stream = Writer::new(stream, version);
-		stream.set_priority(priority);
-
-		stream.encode(&msg).await?;
-
-		loop {
-			// Wait for the next frame, bailing if the peer closes the stream first.
-			let frame = kio::wait(|waiter| {
-				let mut cx = std::task::Context::from_waker(waiter.waker());
-				if stream.poll_closed(&mut cx).is_ready() {
-					return Poll::Ready(Err(Error::Cancel));
-				}
-				group.poll_next_frame(waiter)
-			})
-			.await;
-
-			let mut frame = match frame? {
-				Some(frame) => frame,
-				None => break,
-			};
-
-			// object id delta is always 0.
-			stream.encode(&0u64).await?;
-
-			// Per-object extension headers carry the frame's presentation timestamp.
-			if msg.flags.has_extensions {
-				let mut ext = bytes::BytesMut::new();
-				ietf::encode_object_time(&mut ext, frame.timestamp, timescale, version)?;
-				stream.encode(&(ext.len() as u64)).await?;
-				stream.write_chunk(ext.freeze()).await?;
-			}
-
-			// Write the size of the frame.
-			stream.encode(&frame.size).await?;
-
-			if frame.size == 0 {
-				// Have to write the object status too.
-				stream.encode(&0u8).await?;
-			} else {
-				// Stream each chunk of the frame.
-				loop {
-					let chunk = kio::wait(|waiter| {
-						let mut cx = std::task::Context::from_waker(waiter.waker());
-						if stream.poll_closed(&mut cx).is_ready() {
-							return Poll::Ready(Err(Error::Cancel));
-						}
-						frame.poll_read_chunk(waiter)
-					})
-					.await;
-
-					match chunk? {
-						Some(chunk) => {
-							stream.write_chunk(chunk).await?;
-						}
-						None => break,
-					}
-				}
-			}
-		}
-
-		// Consume the writer: close() waits for the peer to acknowledge everything,
-		// and taking ownership disarms the Drop fallback that would otherwise reset
-		// the finished stream with a spurious Cancel.
-		stream.close().await?;
-
-		tracing::debug!(sequence = %msg.group_id, "finished group");
-
 		Ok(())
 	}
 
@@ -1058,22 +936,15 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 			}
 		}
 
-		// The extension changes what an advertisement carries, so nothing can be
-		// sent until the peer's SETUP says whether it speaks it.
-		let peer = self.peer().await;
-		// Register the split-horizon peer on the announce cursor too. The origin
-		// model uses this exposure to park a reflected copy before it can replace
-		// the source we are currently advertising to that peer.
-		let origin = match self.exclude(&peer) {
-			crate::Origin::UNKNOWN => origin,
-			exclude => origin.excluding(exclude),
-		};
 		let mut announced = origin.announced();
 		let mut watched: HashMap<crate::PathOwned, Watched> = HashMap::new();
 		// Draft-14/15: the open PUBLISH_NAMESPACE request carrying each advertised
 		// namespace. Empty on later drafts, whose entries ride `stream` inline.
 		let mut requests: HashMap<crate::PathOwned, NamespaceRequest<S>> = HashMap::new();
 
+		// The extension changes what an advertisement carries, so nothing can be
+		// sent until the peer's SETUP says whether it speaks it.
+		let peer = self.peer().await;
 		let mut linger = kio::time::Deadline::new();
 
 		// Stream updates (origin (un)announces plus watched route and demand
@@ -1159,54 +1030,258 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 	}
 }
 
+/// Serves a track's groups, one machine per group, with unlimited concurrency.
+struct TrackServe<S: crate::transport::poll::Session> {
+	session: S,
+	track: track::Subscriber,
+	request_id: RequestId,
+	version: Version,
+	children: PollSet<GroupServe<S>>,
+	/// The track finished: the in-flight group machines drain, then FIN.
+	draining: bool,
+}
+
+impl<S: crate::transport::poll::Session> TrackServe<S> {
+	fn new(session: S, track: track::Subscriber, request_id: RequestId, version: Version) -> Self {
+		Self {
+			session,
+			track,
+			request_id,
+			version,
+			children: PollSet::new(),
+			draining: false,
+		}
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		if self.draining {
+			return self.children.poll(waiter).map(Ok);
+		}
+
+		let _ = self.children.poll(waiter);
+		loop {
+			match self.track.poll_recv_group(waiter) {
+				Poll::Ready(Ok(Some(group))) => {
+					let sequence = group.sequence;
+					tracing::debug!(subscribe = %self.request_id, track = %self.track.name(), sequence, "serving group");
+
+					let msg = ietf::GroupHeader {
+						track_alias: self.request_id.0,
+						group_id: sequence,
+						sub_group_id: 0,
+						publisher_priority: 0,
+						// Carry per-object timestamps as extension headers (the Timestamp
+						// Object Property) so moq-transport peers get the real PTS. The
+						// units are the track's, declared once in SUBSCRIBE_OK.
+						flags: ietf::GroupFlags {
+							has_extensions: true,
+							..Default::default()
+						},
+					};
+
+					self.children.push(GroupServe {
+						session: self.session.clone(),
+						msg,
+						priority: self.track.subscription().priority,
+						group,
+						timescale: self.track.info().timescale,
+						version: self.version,
+						state: GroupState::Open,
+					});
+				}
+				Poll::Ready(Ok(None)) => {
+					self.draining = true;
+					return self.children.poll(waiter).map(Ok);
+				}
+				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+				Poll::Pending => break,
+			}
+		}
+		// Newly created group machines start now rather than on the next wake.
+		let _ = self.children.poll(waiter);
+		Poll::Pending
+	}
+}
+
+/// Serves one group on its own unidirectional stream in the moq-transport
+/// subgroup format.
+struct GroupServe<S: crate::transport::poll::Session> {
+	session: S,
+	msg: ietf::GroupHeader,
+	priority: u8,
+	group: group::Consumer,
+	timescale: Timescale,
+	version: Version,
+	state: GroupState<S>,
+}
+
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
+enum GroupState<S: crate::transport::poll::Session> {
+	/// Waiting for stream credit on this machine's own session handle.
+	Open,
+	/// Streaming objects: the write buffer drains first, then the pending chunk,
+	/// then the pending frame, then the next frame.
+	Serve {
+		writer: Writer<S::SendStream, Version>,
+		frame: Option<frame::Consumer>,
+		chunk: Option<bytes::Bytes>,
+	},
+	/// Every frame is written and the FIN sent: wait for the acknowledgement so a
+	/// late cancel can still reset the stream.
+	Closed {
+		writer: Writer<S::SendStream, Version>,
+	},
+	Done,
+}
+
+impl<S: crate::transport::poll::Session> Machine for GroupServe<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		// Errors just drop the writer, whose Drop resets the stream, exactly like
+		// the old future being discarded.
+		ready!(self.poll_serve(waiter)).map(|()| ()).unwrap_or(());
+		Poll::Ready(())
+	}
+}
+
+impl<S: crate::transport::poll::Session> GroupServe<S> {
+	fn poll_serve(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.state {
+				GroupState::Open => {
+					let stream = match ready!(self.session.poll_open_uni(&mut cx)) {
+						Ok(stream) => stream,
+						Err(err) => {
+							self.state = GroupState::Done;
+							return Poll::Ready(Err(Error::from_transport(err)));
+						}
+					};
+					let mut stream = stream;
+					stream.set_priority(self.priority);
+
+					let mut writer = Writer::new(stream, self.version);
+					if let Err(err) = writer.buffer(&self.msg) {
+						self.state = GroupState::Done;
+						return Poll::Ready(Err(err));
+					}
+					self.state = GroupState::Serve {
+						writer,
+						frame: None,
+						chunk: None,
+					};
+				}
+				GroupState::Serve { writer, frame, chunk } => {
+					// The peer closing first cancels the group.
+					if writer.poll_closed(&mut cx).is_ready() {
+						self.state = GroupState::Done;
+						return Poll::Ready(Err(Error::Cancel));
+					}
+					let res = 'serve: {
+						loop {
+							match writer.poll_flush(&mut cx) {
+								Poll::Ready(Ok(())) => {}
+								Poll::Ready(Err(err)) => break 'serve Err(err),
+								Poll::Pending => return Poll::Pending,
+							}
+							if let Some(pending) = chunk {
+								match writer.poll_write(&mut cx, pending) {
+									Poll::Ready(Ok(_)) => {
+										if !bytes::Buf::has_remaining(pending) {
+											*chunk = None;
+										}
+									}
+									Poll::Ready(Err(err)) => break 'serve Err(err),
+									Poll::Pending => return Poll::Pending,
+								}
+							} else if let Some(pending) = frame {
+								match pending.poll_read_chunk(waiter) {
+									Poll::Ready(Ok(Some(next))) => *chunk = Some(next),
+									Poll::Ready(Ok(None)) => *frame = None,
+									Poll::Ready(Err(err)) => break 'serve Err(err),
+									Poll::Pending => return Poll::Pending,
+								}
+							} else {
+								match self.group.poll_next_frame(waiter) {
+									Poll::Ready(Ok(Some(next))) => {
+										if let Err(err) = buffer_object(writer, &next, self.timescale, self.version) {
+											break 'serve Err(err);
+										}
+										// An empty object has no payload to stream.
+										if next.size > 0 {
+											*frame = Some(next);
+										}
+									}
+									Poll::Ready(Ok(None)) => break 'serve Ok(()),
+									Poll::Ready(Err(err)) => break 'serve Err(err),
+									Poll::Pending => return Poll::Pending,
+								}
+							}
+						}
+					};
+
+					let GroupState::Serve { writer, .. } = std::mem::replace(&mut self.state, GroupState::Done) else {
+						unreachable!()
+					};
+					match res {
+						Ok(()) => {
+							let mut writer = writer;
+							match writer.finish() {
+								Ok(()) => self.state = GroupState::Closed { writer },
+								Err(err) => return Poll::Ready(Err(err)),
+							}
+						}
+						Err(err) => return Poll::Ready(Err(err)),
+					}
+				}
+				GroupState::Closed { writer } => {
+					// Wait until everything is acknowledged by the peer so we can still
+					// cancel the stream.
+					let res = ready!(writer.poll_closed(&mut cx));
+					let sequence = self.msg.group_id;
+					self.state = GroupState::Done;
+					return Poll::Ready(res.map(|()| {
+						tracing::debug!(sequence, "finished group");
+					}));
+				}
+				GroupState::Done => return Poll::Ready(Ok(())),
+			}
+		}
+	}
+}
+
+/// Buffer one object's header and prefix: the id delta, the extension headers
+/// carrying the timestamp, the size, and (for an empty object) the status.
+fn buffer_object<W: crate::transport::poll::SendStream>(
+	writer: &mut Writer<W, Version>,
+	frame: &frame::Consumer,
+	timescale: Timescale,
+	version: Version,
+) -> Result<(), Error> {
+	// object id delta is always 0.
+	writer.buffer(&0u64)?;
+
+	// Per-object extension headers carry the frame's presentation timestamp.
+	let mut ext = bytes::BytesMut::new();
+	ietf::encode_object_time(&mut ext, frame.timestamp, timescale, version)?;
+	writer.buffer(&(ext.len() as u64))?;
+	writer.buffer_raw(&ext);
+
+	writer.buffer(&frame.size)?;
+	if frame.size == 0 {
+		// Have to write the object status too.
+		writer.buffer(&0u8)?;
+	}
+	Ok(())
+}
+
 /// One draft-14/15 advertisement: the PUBLISH_NAMESPACE request it rode on and
 /// what closes it out with PUBLISH_NAMESPACE_DONE.
 struct NamespaceRequest<S: crate::transport::poll::Session> {
 	path: crate::PathOwned,
 	request_id: RequestId,
 	stream: Stream<S, Version>,
-}
-
-#[cfg(test)]
-mod group_priority_test {
-	use super::*;
-	use crate::lite::test_transport::SinkSession;
-
-	/// The model's `Subscription::priority` is higher-first ("higher values preempt
-	/// lower ones"), matching the transport trait's send order, so a group stream must
-	/// receive the model value unchanged. An inversion here would transmit the
-	/// LOWEST-priority track first under contention.
-	#[tokio::test]
-	async fn group_stream_preserves_model_priority() {
-		let log = crate::lite::test_transport::Log::default();
-		let session = SinkSession::new(log.clone());
-
-		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
-		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
-		group
-			.write_frame(crate::Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
-			.unwrap();
-		let consumer = group.consume();
-		group.finish().unwrap();
-
-		let msg = ietf::GroupHeader {
-			track_alias: 0,
-			group_id: 0,
-			sub_group_id: 0,
-			publisher_priority: 0,
-			flags: Default::default(),
-		};
-
-		Publisher::<SinkSession>::run_group(session, msg, 200, consumer, Timescale::default(), Version::Draft14)
-			.await
-			.unwrap();
-
-		assert_eq!(
-			log.priorities(),
-			vec![200],
-			"model priority must pass through unchanged"
-		);
-	}
 }
 
 #[cfg(test)]

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -13,7 +13,7 @@ use super::{
 };
 
 /// Everything one moq-transport session needs to start.
-pub struct Config<S: web_transport_trait::Session> {
+pub struct Config<S: crate::transport::poll::Session> {
 	pub session: S,
 
 	/// The bidi SETUP stream (draft-14 through draft-16 only). Draft-17+ passes `None`
@@ -61,11 +61,11 @@ pub struct Config<S: web_transport_trait::Session> {
 	pub peer_cluster: Option<cluster::Peer>,
 }
 
-pub fn start<S: web_transport_trait::Session>(
+pub fn start<S: crate::transport::poll::Session>(
 	config: Config<S>,
 ) -> Result<(MaybeSendBox<'static, Result<(), Error>>, crate::goaway::Handle), Error> {
 	let Config {
-		session,
+		mut session,
 		setup,
 		request_id_max,
 		client,
@@ -146,15 +146,15 @@ pub fn start<S: web_transport_trait::Session>(
 				// stream. Parked on the drain trigger; races the transport close so
 				// a parked trigger never blocks the task set draining.
 				{
-					let session = session.clone();
+					let mut session = session.clone();
 					let adapter = adapter.clone();
 					let goaway = goaway.clone();
 					tasks.push(async move {
 						let payload = {
-							let mut closed = std::pin::pin!(async { session.closed().await });
 							let mut triggered = std::pin::pin!(goaway.triggered());
 							kio::wait(|waiter| {
-								if waiter.poll_future(closed.as_mut()).is_ready() {
+								let mut cx = std::task::Context::from_waker(waiter.waker());
+								if session.poll_closed(&mut cx).is_ready() {
 									return std::task::Poll::Ready(None);
 								}
 								waiter.poll_future(triggered.as_mut())
@@ -166,7 +166,7 @@ pub fn start<S: web_transport_trait::Session>(
 						};
 						let timeout_ms = payload.timeout.map(|d| d.as_millis() as u64).unwrap_or(0);
 						adapter.send_goaway(&payload.uri, timeout_ms, version);
-						crate::goaway::enforce(&session, payload.timeout).await;
+						crate::goaway::enforce(&mut session, payload.timeout).await;
 					});
 				}
 				drop(tasks);
@@ -202,13 +202,14 @@ pub fn start<S: web_transport_trait::Session>(
 						prefixes.push(async move {
 							let stream = match version {
 								Version::Draft16 => {
+									let mut sub_ns_adapter = sub_ns_adapter;
 									let (send, recv) = sub_ns_adapter.open_native_bi().await?;
 									Stream {
 										writer: crate::coding::Writer::new(send, version),
 										reader: crate::coding::Reader::new(recv, version),
 									}
 								}
-								_ => Stream::open(&sub_ns_adapter, version).await?,
+								_ => Stream::open(&mut sub_ns_adapter.clone(), version).await?,
 							};
 							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix).await {
 								// The peer breaking the protocol is fatal, and the driver
@@ -326,7 +327,8 @@ pub fn start<S: web_transport_trait::Session>(
 						let mut sub_ns = sub_ns.clone();
 						let sub_ns_session = sub_ns_session.clone();
 						prefixes.push(async move {
-							let stream = Stream::open(&sub_ns_session, version).await?;
+							let mut sub_ns_session = sub_ns_session;
+							let stream = Stream::open(&mut sub_ns_session, version).await?;
 							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix).await {
 								// The peer breaking the protocol is fatal, and the driver
 								// below turns this into the session close the draft wants.
@@ -393,7 +395,7 @@ pub fn start<S: web_transport_trait::Session>(
 }
 
 /// What a peer's SETUP told us, beyond the stream it arrived on.
-pub struct PeerSetup<S: web_transport_trait::Session> {
+pub struct PeerSetup<S: crate::transport::poll::Session> {
 	/// The SETUP stream, which becomes the GOAWAY channel.
 	pub stream: Reader<S::RecvStream, crate::Version>,
 
@@ -423,8 +425,8 @@ fn self_origin(publish: Option<&origin::Consumer>, subscribe: Option<&origin::Pr
 /// `STOP_SENDING`-ed and skipped (group data needs a prior subscribe, so nothing
 /// legitimate precedes the SETUP at connect). Pass the returned reader to [`start`]
 /// as its `peer_setup_stream` so GOAWAY monitoring continues without re-reading it.
-pub async fn accept_setup<S: web_transport_trait::Session>(
-	session: &S,
+pub async fn accept_setup<S: crate::transport::poll::Session>(
+	session: &mut S,
 	version: Version,
 ) -> Result<PeerSetup<S>, Error> {
 	let outer_version = crate::Version::Ietf(version);
@@ -473,8 +475,8 @@ fn decode_peer_cluster(parameters: bytes::Bytes, version: Version) -> Result<clu
 /// `path` is the request path we advertise (clients on URL-less transports); a
 /// server passes `None`. `self_origin` and `cost` are the MoQ Cluster options, which
 /// declare our identity and (client-only) what this link costs to cross.
-async fn run_setup<S: web_transport_trait::Session>(
-	session: S,
+async fn run_setup<S: crate::transport::poll::Session>(
+	mut session: S,
 	version: Version,
 	path: Option<String>,
 	self_origin: Origin,
@@ -533,7 +535,7 @@ async fn run_setup<S: web_transport_trait::Session>(
 		writer.encode(&size).await?;
 		writer.write_all(&mut std::io::Cursor::new(body)).await?;
 
-		crate::goaway::enforce(&session, payload.timeout).await;
+		crate::goaway::enforce(&mut session, payload.timeout).await;
 		session.closed().await;
 		writer.finish().ok();
 	} else {
@@ -547,8 +549,8 @@ async fn run_setup<S: web_transport_trait::Session>(
 ///
 /// For v17, this also handles the SETUP stream (0x2F00) and GOAWAY.
 /// For v14-16, all uni streams are group data.
-async fn run_unis<S: web_transport_trait::Session>(
-	session: S,
+async fn run_unis<S: crate::transport::poll::Session>(
+	mut session: S,
 	subscriber: Subscriber<S>,
 	// Where to record the peer's MoQ Cluster options once its SETUP arrives. `None`
 	// for draft-14..16, whose SETUP rides the control stream instead.
@@ -595,7 +597,7 @@ async fn run_unis<S: web_transport_trait::Session>(
 			}
 
 			let peer_setup = peer_setup.clone();
-			let session = session.clone();
+			let mut session = session.clone();
 			let goaway = goaway.clone();
 			tasks.push(async move {
 				// The negotiation gates the announce and dispatch loops, so a SETUP we
@@ -643,7 +645,7 @@ async fn run_unis<S: web_transport_trait::Session>(
 	}
 }
 
-async fn run_uni_group<S: web_transport_trait::Session>(
+async fn run_uni_group<S: crate::transport::poll::Session>(
 	subscriber: &mut Subscriber<S>,
 	stream: &mut Reader<S::RecvStream, Version>,
 ) -> Result<(), Error> {
@@ -665,7 +667,7 @@ async fn run_uni_group<S: web_transport_trait::Session>(
 }
 
 /// Accept incoming bidi streams and dispatch to the correct handler based on message type.
-async fn run_dispatch<S: web_transport_trait::Session>(
+async fn run_dispatch<S: crate::transport::poll::Session>(
 	session: S,
 	publisher: Publisher<S>,
 	mut subscriber: Subscriber<S>,
@@ -678,8 +680,9 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 	let peer = subscriber.peer().await;
 
 	let mut tasks = TaskSet::owned();
+	let mut accept = session.clone();
 	loop {
-		let mut stream = tasks.drive(Stream::accept(&session, version)).await?;
+		let mut stream = tasks.drive(Stream::accept(&mut accept, version)).await?;
 
 		let header = tasks
 			.drive(async {
@@ -725,7 +728,7 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 
 /// Monitor the peer's SETUP stream for a GOAWAY, surfacing it through
 /// [`crate::Session::goaway`], then hold the stream until it FINs.
-async fn run_goaway<R: web_transport_trait::RecvStream>(
+async fn run_goaway<R: crate::transport::poll::RecvStream>(
 	mut reader: Reader<R, Version>,
 	version: Version,
 	goaway: crate::goaway::Protocol,

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -150,17 +150,14 @@ pub fn start<S: crate::transport::poll::Session>(
 					let adapter = adapter.clone();
 					let goaway = goaway.clone();
 					tasks.push(async move {
-						let payload = {
-							let mut triggered = std::pin::pin!(goaway.triggered());
-							kio::wait(|waiter| {
-								let mut cx = std::task::Context::from_waker(waiter.waker());
-								if session.poll_closed(&mut cx).is_ready() {
-									return std::task::Poll::Ready(None);
-								}
-								waiter.poll_future(triggered.as_mut())
-							})
-							.await
-						};
+						let payload = kio::wait(|waiter| {
+							let mut cx = std::task::Context::from_waker(waiter.waker());
+							if session.poll_closed(&mut cx).is_ready() {
+								return std::task::Poll::Ready(None);
+							}
+							goaway.poll_triggered(waiter)
+						})
+						.await;
 						let Some(payload) = payload else {
 							return;
 						};
@@ -502,17 +499,14 @@ async fn run_setup<S: crate::transport::poll::Session>(
 	// drain trigger fires meanwhile. The trigger resolves `None` when the session
 	// drops without draining; keep holding either way (closing this stream
 	// mid-session is a protocol violation on strict peers).
-	let payload = {
-		let mut closed = std::pin::pin!(session.closed());
-		let mut triggered = std::pin::pin!(goaway.triggered());
-		kio::wait(|waiter| {
-			if waiter.poll_future(closed.as_mut()).is_ready() {
-				return std::task::Poll::Ready(None);
-			}
-			waiter.poll_future(triggered.as_mut())
-		})
-		.await
-	};
+	let payload = kio::wait(|waiter| {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		if session.poll_closed(&mut cx).is_ready() {
+			return std::task::Poll::Ready(None);
+		}
+		goaway.poll_triggered(waiter)
+	})
+	.await;
 
 	if let Some(payload) = payload {
 		let timeout_ms = payload.timeout.map(|d| d.as_millis() as u64).unwrap_or(0);
@@ -567,7 +561,13 @@ async fn run_unis<S: crate::transport::poll::Session>(
 	let mut seen_setup = setup_read;
 
 	loop {
-		let recv = tasks.drive(session.accept_uni()).await.map_err(Error::from_transport)?;
+		let recv = tasks
+			.drive(|waiter| {
+				let mut cx = std::task::Context::from_waker(waiter.waker());
+				session.poll_accept_uni(&mut cx)
+			})
+			.await
+			.map_err(Error::from_transport)?;
 		let mut reader: Reader<S::RecvStream, crate::Version> = Reader::new(recv, outer_version);
 		// A stream that dies before its type varint is that stream's failure, not the
 		// session's. RESET_STREAM is how a peer drops a group, and QUIC does not order
@@ -575,7 +575,13 @@ async fn run_unis<S: crate::transport::poll::Session>(
 		// the peer wrote to. Failing the loop here would tear down the whole session
 		// over a single stream the peer had already given up on. Only death is
 		// tolerated: bytes that arrive and do not parse stay session-fatal.
-		let kind: u64 = match tasks.drive(reader.decode_peek()).await {
+		let kind: u64 = match tasks
+			.drive(|waiter| {
+				let mut cx = std::task::Context::from_waker(waiter.waker());
+				reader.poll_decode_peek(&mut cx)
+			})
+			.await
+		{
 			Ok(kind) => kind,
 			Err(err @ Error::Cancel) | Err(err @ Error::Remote(_)) | Err(err @ Error::Decode(DecodeError::Short)) => {
 				tracing::debug!(%err, "dropping uni stream that died before its type");
@@ -682,14 +688,30 @@ async fn run_dispatch<S: crate::transport::poll::Session>(
 	let mut tasks = TaskSet::owned();
 	let mut accept = session.clone();
 	loop {
-		let mut stream = tasks.drive(Stream::accept(&mut accept, version)).await?;
+		let mut stream = tasks
+			.drive(|waiter| {
+				let mut cx = std::task::Context::from_waker(waiter.waker());
+				Stream::poll_accept(&mut accept, version, &mut cx)
+			})
+			.await?;
 
+		// The intermediate results live outside the poll closure, so a Pending
+		// mid-header resumes where it left off.
+		let mut hdr_id: Option<u64> = None;
+		let mut hdr_size: Option<u16> = None;
 		let header = tasks
-			.drive(async {
-				let id: u64 = stream.reader.decode().await?;
-				let size: u16 = stream.reader.decode().await?;
-				let data = stream.reader.read_exact(size as usize).await?;
-				Ok::<_, Error>((id, data))
+			.drive(|waiter| {
+				let mut cx = std::task::Context::from_waker(waiter.waker());
+				let id = match hdr_id {
+					Some(id) => id,
+					None => *hdr_id.insert(std::task::ready!(stream.reader.poll_decode(&mut cx))?),
+				};
+				let size = match hdr_size {
+					Some(size) => size,
+					None => *hdr_size.insert(std::task::ready!(stream.reader.poll_decode(&mut cx))?),
+				};
+				let data = std::task::ready!(stream.reader.poll_read_exact(&mut cx, size as usize))?;
+				std::task::Poll::Ready(Ok::<_, Error>((id, data)))
 			})
 			.await;
 		// Same tolerance as `run_unis`: a request stream that dies before its header

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -976,22 +976,19 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		let mut closed_session = self.session.clone();
 		loop {
 			let next = subscribes
-				.drive(async {
-					kio::wait(|waiter| {
-						let mut cx = std::task::Context::from_waker(waiter.waker());
-						if closed_session.poll_closed(&mut cx).is_ready() {
-							return Poll::Ready(None);
-						}
-						// A draining peer usually stops publishing namespaces, so react to
-						// the signal itself; waiting for another message would leave the
-						// route primary until the session finally closed. Idempotent, since
-						// the signal stays set and this task wakes for other reasons too.
-						if self.going_away.poll(waiter).is_ready() {
-							broadcast.drain();
-						}
-						broadcast.poll_requested_track(waiter).map(Some)
-					})
-					.await
+				.drive(|waiter| {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if closed_session.poll_closed(&mut cx).is_ready() {
+						return Poll::Ready(None);
+					}
+					// A draining peer usually stops publishing namespaces, so react to
+					// the signal itself; waiting for another message would leave the
+					// route primary until the session finally closed. Idempotent, since
+					// the signal stays set and this task wakes for other reasons too.
+					if self.going_away.poll(waiter).is_ready() {
+						broadcast.drain();
+					}
+					broadcast.poll_requested_track(waiter).map(Some)
 				})
 				.await;
 
@@ -1123,19 +1120,17 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 			StreamClosed(Result<(), Error>),
 		}
 
-		let end = {
-			let mut closed = std::pin::pin!(stream.reader.closed());
-			kio::wait(|waiter| {
-				if track.poll_unused(waiter).is_ready() {
-					return Poll::Ready(End::Unused);
-				}
-				if let Poll::Ready(err) = broadcast.poll_closed(waiter) {
-					return Poll::Ready(End::BroadcastClosed(err));
-				}
-				waiter.poll_future(closed.as_mut()).map(End::StreamClosed)
-			})
-			.await
-		};
+		let end = kio::wait(|waiter| {
+			if track.poll_unused(waiter).is_ready() {
+				return Poll::Ready(End::Unused);
+			}
+			if let Poll::Ready(err) = broadcast.poll_closed(waiter) {
+				return Poll::Ready(End::BroadcastClosed(err));
+			}
+			let mut cx = std::task::Context::from_waker(waiter.waker());
+			stream.reader.poll_closed(&mut cx).map(End::StreamClosed)
+		})
+		.await;
 
 		match end {
 			End::Unused => {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1,6 +1,6 @@
 use std::{
 	collections::{HashMap, hash_map::Entry},
-	task::Poll,
+	task::{Poll, ready},
 	time::Duration,
 };
 
@@ -1239,7 +1239,8 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		};
 
 		let res = {
-			let mut serve = std::pin::pin!(self.run_group(group, stream, producer.clone(), timescale));
+			let mut ingest = GroupIngest::new(&group, timescale, self.version);
+			let mut writing = producer.clone();
 			kio::wait(|waiter| {
 				if let Poll::Ready(err) = track.poll_closed(waiter) {
 					return Poll::Ready(Err(err));
@@ -1247,7 +1248,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 				if let Poll::Ready(err) = producer.poll_closed(waiter) {
 					return Poll::Ready(Err(err));
 				}
-				waiter.poll_future(serve.as_mut())
+				ingest.poll(stream, &mut writing, waiter)
 			})
 			.await
 		};
@@ -1267,82 +1268,147 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 
 		Ok(())
 	}
+}
 
-	async fn run_group(
-		&mut self,
-		group: ietf::GroupHeader,
-		stream: &mut Reader<S::RecvStream, Version>,
-		mut producer: group::Producer,
-		timescale: Option<Timescale>,
-	) -> Result<(), Error> {
-		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
-			if id_delta != 0 {
-				tracing::warn!(id_delta = %id_delta, "object ID delta is not supported, dropping stream");
-				return Err(Error::Unsupported);
-			}
+/// Pumps moq-transport subgroup objects from a reader into a group producer:
+/// the id delta, the extension headers (carrying the timestamp), the size, the
+/// status for empty objects, and the streamed payload.
+struct GroupIngest {
+	has_extensions: bool,
+	has_end: bool,
+	timescale: Option<Timescale>,
+	version: Version,
+	phase: IngestPhase,
+}
 
-			// Per-object extension headers may carry the frame's presentation timestamp
-			// (the Timestamp Object Property), in the units the track declared. A track
-			// that declared no timescale opted out, so its objects are stamped on arrival
-			// even if one carries a Timestamp we could not interpret.
-			let timestamp = match (group.flags.has_extensions, timescale) {
-				(true, Some(timescale)) => {
-					let size: usize = stream.decode().await?;
-					let mut ext = stream.read_exact(size).await?;
-					ietf::decode_object_time(&mut ext, timescale, self.version)?
-				}
-				(true, None) => {
-					let size: usize = stream.decode().await?;
-					stream.read_exact(size).await?;
-					None
-				}
-				(false, _) => None,
-			};
+enum IngestPhase {
+	/// Reading the object id delta. Stream end here ends the group.
+	Delta,
+	/// Reading the extension block's size.
+	ExtSize,
+	/// Reading (and decoding or discarding) the extension block.
+	ExtBytes { size: usize },
+	/// Reading the object size.
+	Size { timestamp: Option<crate::Timestamp> },
+	/// Reading the status of an empty object.
+	Status { timestamp: Option<crate::Timestamp> },
+	/// Streaming the object payload.
+	Payload { frame: frame::ProducerOwned },
+	/// An explicit end-of-group status arrived.
+	Finished,
+}
 
-			let size: u64 = stream.decode().await?;
-			if size == 0 {
-				let status: u64 = stream.decode().await?;
-				if status == 0 {
-					let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
-					let frame = producer.create_frame(frame::Info { size: 0, timestamp })?;
-					frame.finish()?;
-				} else if status == 3 && !group.flags.has_end {
-					break;
-				} else {
-					return Err(Error::Unsupported);
-				}
-			} else {
-				// `create_frame` is the allocation chokepoint and rejects an oversized
-				// `size` before allocating, so no pre-check is needed.
-				let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
-				let mut frame = producer.create_frame(frame::Info { size, timestamp })?;
-
-				if let Err(err) = self.run_frame(stream, &mut frame).await {
-					let _ = frame.abort(err.clone());
-					return Err(err);
-				}
-
-				frame.finish()?;
-			}
+impl GroupIngest {
+	fn new(group: &ietf::GroupHeader, timescale: Option<Timescale>, version: Version) -> Self {
+		Self {
+			has_extensions: group.flags.has_extensions,
+			has_end: group.flags.has_end,
+			timescale,
+			version,
+			phase: IngestPhase::Delta,
 		}
-
-		Ok(())
 	}
 
-	async fn run_frame(
+	/// `Ready(Ok(()))` once the stream FINs on an object boundary (or an explicit
+	/// end-of-group status arrives). The caller finishes or aborts the group; an
+	/// object cut short mid-payload was already aborted here with the reason.
+	fn poll<R: crate::transport::poll::RecvStream>(
 		&mut self,
-		stream: &mut Reader<S::RecvStream, Version>,
-		frame: &mut frame::Producer<'_>,
-	) -> Result<(), Error> {
-		while frame.remaining() > 0 {
-			match stream.read_chunk(frame.remaining()).await? {
-				Some(chunk) if !chunk.is_empty() => {
-					frame.write(chunk)?;
+		reader: &mut Reader<R, Version>,
+		group: &mut group::Producer,
+		waiter: &kio::Waiter,
+	) -> Poll<Result<(), Error>> {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.phase {
+				IngestPhase::Delta => {
+					let Some(id_delta) = ready!(reader.poll_decode_maybe::<u64>(&mut cx))? else {
+						return Poll::Ready(Ok(()));
+					};
+					if id_delta != 0 {
+						tracing::warn!(id_delta = %id_delta, "object ID delta is not supported, dropping stream");
+						return Poll::Ready(Err(Error::Unsupported));
+					}
+					self.phase = match self.has_extensions {
+						true => IngestPhase::ExtSize,
+						false => IngestPhase::Size { timestamp: None },
+					};
 				}
-				_ => return Err(Error::WrongSize),
+				IngestPhase::ExtSize => {
+					let size: usize = ready!(reader.poll_decode(&mut cx))?;
+					self.phase = IngestPhase::ExtBytes { size };
+				}
+				IngestPhase::ExtBytes { size } => {
+					// Per-object extension headers may carry the frame's presentation
+					// timestamp (the Timestamp Object Property), in the units the track
+					// declared. A track that declared no timescale opted out, so its
+					// objects are stamped on arrival even if one carries a Timestamp we
+					// could not interpret.
+					let mut ext = ready!(reader.poll_read_exact(&mut cx, *size))?;
+					let timestamp = match self.timescale {
+						Some(timescale) => ietf::decode_object_time(&mut ext, timescale, self.version)?,
+						None => None,
+					};
+					self.phase = IngestPhase::Size { timestamp };
+				}
+				IngestPhase::Size { timestamp } => {
+					let size: u64 = ready!(reader.poll_decode(&mut cx))?;
+					if size == 0 {
+						self.phase = IngestPhase::Status { timestamp: *timestamp };
+						continue;
+					}
+					// `create_frame_owned` is the allocation chokepoint and rejects an
+					// oversized `size` before allocating, so no pre-check is needed.
+					let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
+					let frame = group.create_frame_owned(frame::Info { size, timestamp })?;
+					self.phase = IngestPhase::Payload { frame };
+				}
+				IngestPhase::Status { timestamp } => {
+					let status: u64 = ready!(reader.poll_decode(&mut cx))?;
+					if status == 0 {
+						let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
+						let frame = group.create_frame_owned(frame::Info { size: 0, timestamp })?;
+						frame.finish()?;
+						self.phase = IngestPhase::Delta;
+					} else if status == 3 && !self.has_end {
+						self.phase = IngestPhase::Finished;
+					} else {
+						return Poll::Ready(Err(Error::Unsupported));
+					}
+				}
+				IngestPhase::Payload { frame } => {
+					let failed = loop {
+						if frame.remaining() == 0 {
+							break None;
+						}
+						match reader.poll_read_chunk(&mut cx, frame.remaining()) {
+							Poll::Pending => return Poll::Pending,
+							Poll::Ready(Ok(Some(chunk))) if !chunk.is_empty() => {
+								if let Err(err) = frame.write(chunk) {
+									break Some(err);
+								}
+							}
+							Poll::Ready(Ok(_)) => break Some(Error::WrongSize),
+							Poll::Ready(Err(err)) => break Some(err),
+						}
+					};
+
+					let IngestPhase::Payload { frame } = std::mem::replace(&mut self.phase, IngestPhase::Delta) else {
+						unreachable!()
+					};
+					match failed {
+						None => frame.finish()?,
+						Some(err) => {
+							// Fail the group with the reason, not the Drop fallback's
+							// generic `Dropped`.
+							let _ = frame.abort(err.clone());
+							return Poll::Ready(Err(err));
+						}
+					}
+				}
+				IngestPhase::Finished => return Poll::Ready(Ok(())),
 			}
 		}
-		Ok(())
 	}
 }
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -133,7 +133,7 @@ struct Advertised {
 }
 
 #[derive(Clone)]
-pub(super) struct Subscriber<S: web_transport_trait::Session> {
+pub(super) struct Subscriber<S: crate::transport::poll::Session> {
 	session: S,
 	// Traffic stats are attributed through this tagged origin handle.
 	origin: origin::Producer,
@@ -185,7 +185,7 @@ async fn resolve_track_alias(aliases: kio::Consumer<HashMap<u64, RequestId>>, al
 	.await
 }
 
-impl<S: web_transport_trait::Session> Subscriber<S> {
+impl<S: crate::transport::poll::Session> Subscriber<S> {
 	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		session: S,
@@ -326,7 +326,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// A failure here is per-prefix, so the caller decides what it means for the
 	/// session: [`is_protocol_violation`] separates the peer's fault (fatal) from a
 	/// stream of ours that simply died (survivable).
-	pub async fn run_subscribe_namespace<T: web_transport_trait::Session>(
+	pub async fn run_subscribe_namespace<T: crate::transport::poll::Session>(
 		&mut self,
 		mut stream: Stream<T, Version>,
 		prefix: PathOwned,
@@ -419,7 +419,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// `live` tracks the suffixes this stream has advertised, so a repeat is recognized
 	/// as an update rather than a second advertisement, and the caller can release
 	/// whatever is still held when the stream ends.
-	async fn run_namespace_entries<T: web_transport_trait::Session>(
+	async fn run_namespace_entries<T: crate::transport::poll::Session>(
 		&mut self,
 		stream: &mut Stream<T, Version>,
 		prefix: &PathOwned,
@@ -973,12 +973,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	async fn run_broadcast(&self, path: Path<'_>, mut broadcast: broadcast::Dynamic) -> Result<(), Error> {
 		let mut subscribes = TaskSet::owned();
+		let mut closed_session = self.session.clone();
 		loop {
 			let next = subscribes
 				.drive(async {
-					let mut closed = std::pin::pin!(self.session.closed());
 					kio::wait(|waiter| {
-						if waiter.poll_future(closed.as_mut()).is_ready() {
+						let mut cx = std::task::Context::from_waker(waiter.waker());
+						if closed_session.poll_closed(&mut cx).is_ready() {
 							return Poll::Ready(None);
 						}
 						// A draining peer usually stops publishing namespaces, so react to
@@ -1052,7 +1053,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		};
 
-		let mut stream = match Stream::open(&self.session, self.version).await {
+		let mut stream = match Stream::open(&mut self.session.clone(), self.version).await {
 			Ok(s) => s,
 			Err(err) => {
 				tracing::debug!(%err, "failed to open subscribe stream");
@@ -1421,7 +1422,7 @@ mod tests {
 			"one SUBSCRIBE_NAMESPACE per permitted prefix, relative to the root",
 		);
 
-		let stream = Stream::open(&session, Version::Draft16).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), Version::Draft16).await.unwrap();
 		let mut run = std::pin::pin!(subscriber.run_subscribe_namespace(stream, crate::Path::new("cam").to_owned()));
 		// Parks awaiting the peer's response; the request is already on the wire.
 		assert!(futures::poll!(run.as_mut()).is_pending());
@@ -1489,7 +1490,7 @@ mod tests {
 		);
 
 		let prefix = subscriber.subscribe_prefixes().pop().expect("one prefix");
-		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), VERSION).await.unwrap();
 		// Parks on the read after the scripted NAMESPACE is consumed.
 		let mut run = std::pin::pin!(subscriber.run_subscribe_namespace(stream, prefix));
 		for _ in 0..100 {
@@ -1837,7 +1838,7 @@ mod tests {
 			Default::default(),
 		);
 
-		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), VERSION).await.unwrap();
 		subscriber
 			.run_subscribe_namespace(stream, crate::Path::new("").to_owned())
 			.await
@@ -1907,7 +1908,7 @@ mod tests {
 			Default::default(),
 		);
 
-		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), VERSION).await.unwrap();
 		let msg = ietf::PublishNamespace {
 			request_id: RequestId(0),
 			track_namespace: path.borrow(),
@@ -1962,7 +1963,7 @@ mod tests {
 		);
 
 		let path = crate::Path::new("room/host").to_owned();
-		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), VERSION).await.unwrap();
 		let msg = ietf::PublishNamespace {
 			request_id: RequestId(0),
 			track_namespace: path.borrow(),
@@ -2276,7 +2277,7 @@ mod tests {
 		settle().await;
 		assert!(consumer.get_broadcast("room/host").is_some(), "attached to start with");
 
-		let stream = Stream::open(&session, VERSION).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), VERSION).await.unwrap();
 		(subscriber, consumer, stream)
 	}
 
@@ -2449,7 +2450,7 @@ mod tests {
 			Default::default(),
 		);
 
-		let stream = Stream::open(&session, Version::Draft19).await.unwrap();
+		let stream = Stream::open(&mut session.clone(), Version::Draft19).await.unwrap();
 		let msg = ietf::Publish {
 			request_id: RequestId(1),
 			track_namespace: crate::Path::new("room/host"),

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -91,6 +91,7 @@ mod util;
 mod version;
 
 pub mod stats;
+pub mod transport;
 
 pub use client::*;
 pub use coding::{BoundsExceeded, DecodeError, EncodeError, VarInt};

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -84,6 +84,7 @@ mod latency;
 mod lite;
 mod model;
 mod path;
+mod poll_set;
 mod server;
 mod session;
 mod setup;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1349,6 +1349,7 @@ impl<S: crate::transport::poll::Session> SubscribeServe<S> {
 						priority: self.shared.priority.clone(),
 						track_priority: track_priority_tx.consume(),
 						track_priority_seen: msg.priority,
+						ordered: msg.ordered,
 						version: self.shared.version,
 						timescale,
 					};
@@ -1711,6 +1712,8 @@ mod test {
 	/// must still deliver it; a sequence cursor would skip it permanently.
 	#[tokio::test]
 	async fn recv_next_serves_late_arrival_after_newer_group() {
+		use futures::FutureExt;
+
 		let mut producer = track_producer("test");
 		let mut subscriber = producer.subscribe(None);
 
@@ -2746,6 +2749,15 @@ impl<S: crate::transport::poll::Session> TrackRun<S> {
 				if let Ok(mut value) = self.track_priority_tx.write() {
 					*value = upd.priority;
 				}
+				// Re-rank the backlog too, not just the groups queued from here on.
+				// The preference is about which of the groups we are holding to send
+				// first, so leaving the queued ones on the old direction would let
+				// every new group outrank exactly the ones the subscriber just asked
+				// to receive first, starving them until they expire.
+				if self.ctx.ordered != upd.ordered {
+					self.ctx.ordered = upd.ordered;
+					self.ctx.priority.set_ordered(self.ctx.id, self.ctx.ordered);
+				}
 				// Feed the full update into the model subscriber so the producer's
 				// aggregate reflects it (and a relay re-forwards it upstream).
 				let bounds = Bounds::from(&upd);
@@ -2764,10 +2776,10 @@ impl<S: crate::transport::poll::Session> TrackRun<S> {
 				continue;
 			}
 
-			// One cursor drives the whole subscription: poll the cap-aware next group and,
-			// when enabled, the next best-effort datagram. Groups are polled first so a
-			// datagram burst can't starve them; datagrams flow whenever no group is ready
-			// (including while groups are paused above the cap).
+			// One cursor drives the whole subscription: poll the cap-aware arrival-order
+			// group and, when enabled, the next best-effort datagram. Groups are polled
+			// first so a datagram burst can't starve them; datagrams flow whenever no
+			// group is ready (including while groups are parked above the cap).
 			let emit_boundary = self.emit_range && !self.end_sent;
 			if let Poll::Ready(res) = poll_recv_next(&mut self.track, self.datagrams, emit_boundary, waiter) {
 				match res? {
@@ -2802,7 +2814,14 @@ impl<S: crate::transport::poll::Session> TrackRun<S> {
 
 						// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
 						let current_priority = self.ctx.track_priority_current();
-						let handle = self.ctx.priority.insert(Priority::new(current_priority, sequence));
+						// The subscribe id scopes the group tie-break: one queue serves every
+						// subscription on the session, and only groups of the same one may be
+						// ranked against each other by sequence.
+						let priority = match self.ctx.ordered {
+							true => Priority::ordered(current_priority, self.ctx.id, sequence),
+							false => Priority::new(current_priority, self.ctx.id, sequence),
+						};
+						let handle = self.ctx.priority.insert(priority);
 						self.children
 							.push(GroupServe::new(self.ctx.clone(), sequence, frame_start, handle, group));
 					}
@@ -3202,6 +3221,7 @@ mod serve_group_test {
 			priority: PriorityQueue::default(),
 			track_priority: track_priority.consume(),
 			track_priority_seen: 0,
+			ordered: false,
 			version: Version::Lite06Wip,
 			timescale: Some(crate::Timescale::default()),
 		};
@@ -3214,7 +3234,7 @@ mod serve_group_test {
 		let consumer = group.consume();
 		group.finish().unwrap();
 
-		let handle = subscription.priority.insert(Priority::new(0, 0));
+		let handle = subscription.priority.insert(Priority::new(0, 0, 0));
 		subscription.serve_group(0, 0, handle, consumer).await.unwrap();
 
 		assert_eq!(log.resets(), Vec::<u32>::new(), "clean completion must not reset");

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -194,6 +194,9 @@ struct Control<S: crate::transport::poll::Session> {
 	state: ControlState<S>,
 }
 
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum ControlState<S: crate::transport::poll::Session> {
 	/// Reading the stream's type.
 	Start {
@@ -367,6 +370,9 @@ struct AnnounceServe<S: crate::transport::poll::Session> {
 	state: AnnounceState,
 }
 
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum AnnounceState {
 	/// Reading the ANNOUNCE_REQUEST.
 	Decode,
@@ -1380,6 +1386,9 @@ struct FetchServe<S: crate::transport::poll::Session> {
 	group: u64,
 }
 
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum FetchState {
 	Decode,
 	/// Resolving the split-horizon origin (waits on the peer's SETUP).

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -139,7 +139,12 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 		// shared `this` stays behind the Arc for the per-stream children.
 		let mut accept = this.session.clone();
 		loop {
-			let stream = tasks.drive(Stream::accept(&mut accept, this.version)).await?;
+			let stream = tasks
+				.drive(|waiter| {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					Stream::poll_accept(&mut accept, this.version, &mut cx)
+				})
+				.await?;
 
 			let this = this.clone();
 			tasks.push(async move {
@@ -217,17 +222,14 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 
 		loop {
 			// Tick the probe interval, bailing as soon as the peer closes its side.
-			let closed = {
-				let mut closed = std::pin::pin!(stream.reader.closed());
-				kio::wait(|waiter| {
-					if let Poll::Ready(res) = waiter.poll_future(closed.as_mut()) {
-						return Poll::Ready(Some(res));
-					}
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					interval.poll_tick(&mut cx).map(|_| None)
-				})
-				.await
-			};
+			let closed = kio::wait(|waiter| {
+				let mut cx = std::task::Context::from_waker(waiter.waker());
+				if let Poll::Ready(res) = stream.reader.poll_closed(&mut cx) {
+					return Poll::Ready(Some(res));
+				}
+				interval.poll_tick(&mut cx).map(|_| None)
+			})
+			.await;
 			if let Some(res) = closed {
 				return res;
 			}
@@ -516,9 +518,9 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 					.map(|at| at + COST_LINGER),
 			);
 			let op = {
-				let mut closed = std::pin::pin!(stream.reader.closed());
 				kio::wait(|waiter| {
-					if let Poll::Ready(res) = waiter.poll_future(closed.as_mut()) {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if let Poll::Ready(res) = stream.reader.poll_closed(&mut cx) {
 						return Poll::Ready(Err(res));
 					}
 					if let Poll::Ready(next) = announced.poll_next(waiter) {
@@ -2216,10 +2218,6 @@ impl<S: crate::transport::poll::Session> Subscription<S> {
 		loop {
 			let event = {
 				let emit_boundary = emit_range && !end_sent;
-				// SUBSCRIBE_UPDATE messages share this hot loop; safe because
-				// decode_maybe is cancel-safe given quinn/qmux's cancel-safe
-				// read primitives (see Reader::decode_maybe doc).
-				let mut update = std::pin::pin!(reader.decode_maybe::<lite::SubscribeUpdate>());
 				kio::wait(|waiter| {
 					// Drive in-flight group futures; completions just drop.
 					let mut cx = std::task::Context::from_waker(waiter.waker());
@@ -2227,8 +2225,9 @@ impl<S: crate::transport::poll::Session> Subscription<S> {
 
 					// Control first: SUBSCRIBE_UPDATE/FIN messages are rare, so they can't
 					// starve the data path, while a deep group backlog polled first could
-					// defer an unsubscribe or priority change indefinitely.
-					if let Poll::Ready(upd) = waiter.poll_future(update.as_mut()) {
+					// defer an unsubscribe or priority change indefinitely. Partial
+					// message bytes persist in the reader's buffer across turns.
+					if let Poll::Ready(upd) = reader.poll_decode_maybe::<lite::SubscribeUpdate>(&mut cx) {
 						return Poll::Ready(Event::Update(upd));
 					}
 					// One cursor drives the whole subscription: poll the cap-aware arrival-order
@@ -2511,10 +2510,10 @@ impl<S: crate::transport::poll::Session> Subscription<S> {
 
 		loop {
 			let event = {
-				let mut closed = std::pin::pin!(stream.closed());
 				let seen = *track_priority_seen;
 				kio::wait(|waiter| {
-					if waiter.poll_future(closed.as_mut()).is_ready() {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if stream.poll_closed(&mut cx).is_ready() {
 						return Poll::Ready(Event::Closed);
 					}
 					if let Poll::Ready(res) = work(waiter) {

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -49,7 +49,7 @@ struct SentRoute {
 	serving: bool,
 }
 
-pub(super) struct PublisherConfig<S: web_transport_trait::Session> {
+pub(super) struct PublisherConfig<S: crate::transport::poll::Session> {
 	pub session: S,
 	/// The origin we read local broadcasts from. Traffic stats are attributed
 	/// through this handle: tag it with [`origin::Consumer::with_stats`] first.
@@ -65,7 +65,7 @@ pub(super) struct PublisherConfig<S: web_transport_trait::Session> {
 	pub peer_origin: Option<Origin>,
 }
 
-pub(super) struct Publisher<S: web_transport_trait::Session> {
+pub(super) struct Publisher<S: crate::transport::poll::Session> {
 	session: S,
 	origin: origin::Consumer,
 	self_origin: Origin,
@@ -86,7 +86,7 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 	goaway: crate::goaway::Protocol,
 }
 
-impl<S: web_transport_trait::Session> Publisher<S> {
+impl<S: crate::transport::poll::Session> Publisher<S> {
 	pub fn new(config: PublisherConfig<S>) -> Self {
 		// Identity stamped onto outbound announce hops. Derived from the
 		// origin we're consuming so it matches the local relay identity
@@ -135,8 +135,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let this = Arc::new(self);
 		let mut tasks = TaskSet::owned();
 
+		// A dedicated accept handle: the poll interface takes `&mut self`, and the
+		// shared `this` stays behind the Arc for the per-stream children.
+		let mut accept = this.session.clone();
 		loop {
-			let stream = tasks.drive(Stream::accept(&this.session, this.version)).await?;
+			let stream = tasks.drive(Stream::accept(&mut accept, this.version)).await?;
 
 			let this = this.clone();
 			tasks.push(async move {
@@ -184,7 +187,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			// logs per-stream errors, so close the session here rather than letting a
 			// peer silently replace a redirect an observer may already be acting on.
 			tracing::warn!(%uri, "duplicate GOAWAY received; closing session");
-			self.session.close(SessionError::from(&err).to_code(), &err.to_string());
+			self.session
+				.clone()
+				.close(SessionError::from(&err).to_code(), &err.to_string());
 			return Err(err);
 		}
 		Ok(())
@@ -1920,7 +1925,7 @@ mod announce_test {
 /// model layer (`group::Producer::create_frame`) already converted the timestamp
 /// into the track timescale, so its raw value goes straight onto the wire. Mirrors
 /// the decode in the subscriber's `run_group`.
-async fn encode_frame_timing<W: web_transport_trait::SendStream>(
+async fn encode_frame_timing<W: crate::transport::poll::SendStream>(
 	writer: &mut Writer<W, Version>,
 	frame: &frame::Consumer,
 	timescale: Option<crate::Timescale>,
@@ -1938,7 +1943,7 @@ async fn encode_frame_timing<W: web_transport_trait::SendStream>(
 
 /// Encode `curr` as a zigzag-mapped varint delta against `*prev`, then advance
 /// `*prev` to `curr`.
-async fn encode_zigzag_delta<W: web_transport_trait::SendStream>(
+async fn encode_zigzag_delta<W: crate::transport::poll::SendStream>(
 	writer: &mut Writer<W, Version>,
 	curr: u64,
 	prev: &mut u64,
@@ -1957,7 +1962,7 @@ async fn encode_zigzag_delta<W: web_transport_trait::SendStream>(
 /// per-frame encoding in [`Subscription::serve_frame`] without the priority
 /// machinery, since a one-shot fetch carries a single static priority set on the
 /// stream up front.
-async fn write_fetch_frame<W: web_transport_trait::SendStream>(
+async fn write_fetch_frame<W: crate::transport::poll::SendStream>(
 	writer: &mut Writer<W, Version>,
 	frame: &mut frame::Consumer,
 	timescale: Option<crate::Timescale>,
@@ -2147,7 +2152,7 @@ impl From<&lite::SubscribeUpdate> for Bounds {
 /// so each in-flight group reads the latest SUBSCRIBE_UPDATE priority via its own
 /// consumer cursor.
 #[derive(Clone)]
-struct Subscription<S: web_transport_trait::Session> {
+struct Subscription<S: crate::transport::poll::Session> {
 	session: S,
 	id: u64,
 	track_name: Arc<str>,
@@ -2165,7 +2170,7 @@ struct Subscription<S: web_transport_trait::Session> {
 	timescale: Option<crate::Timescale>,
 }
 
-impl<S: web_transport_trait::Session> Subscription<S> {
+impl<S: crate::transport::poll::Session> Subscription<S> {
 	async fn run_track(
 		mut self,
 		mut track: track::Subscriber,
@@ -2404,7 +2409,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 	///
 	/// The datagram is dropped (there is no group fallback) if the encoded body doesn't fit the
 	/// transport's datagram limit or the send fails (congestion / no capacity right now).
-	fn serve_datagram(&self, datagram: crate::Datagram) {
+	fn serve_datagram(&mut self, datagram: crate::Datagram) {
 		let body = lite::Datagram {
 			subscribe: self.id,
 			sequence: datagram.sequence,
@@ -2428,7 +2433,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 			return;
 		}
 
-		let _ = self.session.send_datagram(body);
+		let _ = self.session.send_datagram(&body);
 	}
 
 	/// Send one frame: the size, then the payload streamed chunk-by-chunk so we
@@ -2814,7 +2819,7 @@ mod tests {
 		let gate = kio::Producer::new(true);
 		let session = SinkSession::gated_bi(gate.consume());
 		let log = session.log.clone();
-		let mut stream = Stream::open(&session, Version::Lite01).await.unwrap();
+		let mut stream = Stream::open(&mut session.clone(), Version::Lite01).await.unwrap();
 
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1,8 +1,11 @@
 use crate::{SessionError, announce, frame, group, origin, track};
-use std::{sync::Arc, task::Poll, time::Duration};
+use std::{
+	collections::HashMap,
+	sync::Arc,
+	task::{Context, Poll, ready},
+	time::Duration,
+};
 
-use bytes::Buf;
-use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use web_transport_trait::Stats;
 
 use crate::{
@@ -12,7 +15,7 @@ use crate::{
 		self,
 		priority::{Priority, PriorityHandle, PriorityQueue},
 	},
-	util::{MaybeBoxedExt, MaybeSendBox, TaskSet},
+	poll_set::{Machine, PollSet},
 };
 
 use super::Version;
@@ -65,7 +68,8 @@ pub(super) struct PublisherConfig<S: crate::transport::poll::Session> {
 	pub peer_origin: Option<Origin>,
 }
 
-pub(super) struct Publisher<S: crate::transport::poll::Session> {
+/// Context shared by every control-stream child.
+struct Shared<S: crate::transport::poll::Session> {
 	session: S,
 	origin: origin::Consumer,
 	self_origin: Origin,
@@ -86,286 +90,445 @@ pub(super) struct Publisher<S: crate::transport::poll::Session> {
 	goaway: crate::goaway::Protocol,
 }
 
-impl<S: crate::transport::poll::Session> Publisher<S> {
-	pub fn new(config: PublisherConfig<S>) -> Self {
-		// Identity stamped onto outbound announce hops. Derived from the
-		// origin we're consuming so it matches the local relay identity
-		// across every session, required for cross-session loop detection.
-		let self_origin = *config.origin;
-		Self {
-			session: config.session,
-			origin: config.origin,
-			self_origin,
-			peer_setup: config.peer_setup,
-			peer_origin: config.peer_origin,
-			serving: std::sync::OnceLock::new(),
-			priority: Default::default(),
-			version: config.version,
-			goaway: config.goaway,
-		}
-	}
-
+impl<S: crate::transport::poll::Session> Shared<S> {
 	/// The origin to resolve a peer-requested broadcast from: excludes routes
 	/// through the peer when its SETUP declared an origin id, so a subscription
 	/// is never served data that flowed through the subscriber. The first call
 	/// waits for the peer's SETUP (sent at startup on every lite-05+ session,
 	/// well before it could learn of anything to subscribe to); the result is
 	/// cached, since the peer sends exactly one SETUP per session.
-	async fn serving_origin(&self) -> origin::Consumer {
+	fn poll_serving_origin(&self, waiter: &kio::Waiter) -> Poll<origin::Consumer> {
 		if let Some(origin) = self.serving.get() {
-			return origin.clone();
+			return Poll::Ready(origin.clone());
 		}
 		// Pre-SETUP versions never declare an id; there is nothing to exclude.
 		let origin = if !self.version.has_setup_stream() {
 			self.origin.clone()
 		} else {
-			match self.peer_setup.origin().await {
+			match ready!(self.peer_setup.poll_origin(waiter)) {
 				Some(peer) => self.origin.clone().excluding(peer),
 				None => self.origin.clone(),
 			}
 		};
-		// A concurrent first call may have won the race; either value is
+		// A concurrent first resolution may have won the race; either value is
 		// identical, so keep whichever landed.
-		self.serving.get_or_init(|| origin).clone()
+		Poll::Ready(self.serving.get_or_init(|| origin).clone())
+	}
+}
+
+/// The publisher half: accepts control streams and drives each as a child state
+/// machine. Resolves only on a transport error; children never end the session.
+pub(super) struct Publisher<S: crate::transport::poll::Session> {
+	shared: Arc<Shared<S>>,
+	// A dedicated accept handle: the poll interface takes `&mut self`, and the
+	// shared context stays behind the Arc for the per-stream children.
+	accept: S,
+	children: PollSet<Control<S>>,
+}
+
+impl<S: crate::transport::poll::Session> Publisher<S> {
+	pub fn new(config: PublisherConfig<S>) -> Self {
+		// Identity stamped onto outbound announce hops. Derived from the
+		// origin we're consuming so it matches the local relay identity
+		// across every session, required for cross-session loop detection.
+		let self_origin = *config.origin;
+		let accept = config.session.clone();
+		Self {
+			shared: Arc::new(Shared {
+				session: config.session,
+				origin: config.origin,
+				self_origin,
+				peer_setup: config.peer_setup,
+				peer_origin: config.peer_origin,
+				serving: std::sync::OnceLock::new(),
+				priority: Default::default(),
+				version: config.version,
+				goaway: config.goaway,
+			}),
+			accept,
+			children: PollSet::new(),
+		}
 	}
 
-	pub async fn run(self) -> Result<(), Error> {
-		// `origin::Consumer` and friends are cheap to clone (shared handles), so each control
-		// stream gets its own child future and they all make progress independently.
-		let this = Arc::new(self);
-		let mut tasks = TaskSet::owned();
+	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		let _ = self.children.poll(waiter);
 
-		// A dedicated accept handle: the poll interface takes `&mut self`, and the
-		// shared `this` stays behind the Arc for the per-stream children.
-		let mut accept = this.session.clone();
+		let mut cx = Context::from_waker(waiter.waker());
 		loop {
-			let stream = tasks
-				.drive(|waiter| {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					Stream::poll_accept(&mut accept, this.version, &mut cx)
-				})
-				.await?;
-
-			let this = this.clone();
-			tasks.push(async move {
-				if let Err(err) = this.handle(stream).await {
-					tracing::warn!(%err, "control stream error");
-				}
-			});
-		}
-	}
-
-	async fn handle(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
-		let kind = stream.reader.decode().await?;
-
-		match kind {
-			lite::ControlType::Announce => self.recv_announce(stream).await,
-			lite::ControlType::Subscribe => self.recv_subscribe(stream).await,
-			lite::ControlType::Fetch => self.recv_fetch(stream).await,
-			lite::ControlType::Track => self.recv_track(stream).await,
-			lite::ControlType::Probe => {
-				self.recv_probe(stream).await;
-				Ok(())
-			}
-			lite::ControlType::Goaway => self.recv_goaway(stream).await,
-			lite::ControlType::Session => Err(Error::UnexpectedStream),
-		}
-	}
-
-	/// Decode the peer's GOAWAY and surface it through [`crate::Session::recv_goaway`].
-	///
-	/// A decode error propagates to the caller, which logs and continues: a
-	/// malformed GOAWAY must not tear down the session it is trying to drain.
-	async fn recv_goaway(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
-		let msg: lite::Goaway = stream.reader.decode().await?;
-		tracing::info!(uri = %msg.uri, "received goaway");
-
-		let uri = msg.uri.into_owned();
-		let goaway = crate::goaway::Goaway {
-			uri: uri.clone(),
-			// moq-lite has no timeout field on the wire.
-			timeout: None,
-		};
-
-		if let Err(err) = self.goaway.record(goaway) {
-			// A second Goaway stream is a protocol violation. The control loop only
-			// logs per-stream errors, so close the session here rather than letting a
-			// peer silently replace a redirect an observer may already be acting on.
-			tracing::warn!(%uri, "duplicate GOAWAY received; closing session");
-			self.session
-				.clone()
-				.close(SessionError::from(&err).to_code(), &err.to_string());
-			return Err(err);
-		}
-		Ok(())
-	}
-
-	async fn recv_probe(&self, mut stream: Stream<S, Version>) {
-		match Self::run_probe(&self.session, &mut stream, self.version).await {
-			Ok(()) => {
-				tracing::debug!("probe stream closed");
-			}
-			Err(err) => {
-				tracing::warn!(%err, "probe stream error");
-				stream.writer.abort(&err);
+			match Stream::poll_accept(&mut self.accept, self.shared.version, &mut cx) {
+				Poll::Ready(Ok(stream)) => self.children.push(Control {
+					shared: self.shared.clone(),
+					state: ControlState::Start { stream },
+				}),
+				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+				Poll::Pending => break,
 			}
 		}
+
+		// Newly accepted children start now rather than on the next wake.
+		let _ = self.children.poll(waiter);
+		Poll::Pending
 	}
+}
 
-	async fn run_probe(session: &S, stream: &mut Stream<S, Version>, _version: Version) -> Result<(), Error> {
-		const PROBE_INTERVAL: Duration = Duration::from_millis(100);
-		const PROBE_MAX_AGE: Duration = Duration::from_secs(10);
-		const PROBE_MAX_DELTA: f64 = 0.25;
-
-		let mut last_sent: Option<(u64, web_async::time::Instant)> = None;
-		let mut interval = web_async::time::interval(PROBE_INTERVAL);
-
-		loop {
-			// Tick the probe interval, bailing as soon as the peer closes its side.
-			let closed = kio::wait(|waiter| {
-				let mut cx = std::task::Context::from_waker(waiter.waker());
-				if let Poll::Ready(res) = stream.reader.poll_closed(&mut cx) {
-					return Poll::Ready(Some(res));
-				}
-				interval.poll_tick(&mut cx).map(|_| None)
-			})
-			.await;
-			if let Some(res) = closed {
-				return res;
-			}
-
-			let Some(bitrate) = session.stats().estimated_send_rate() else {
-				continue;
-			};
-
-			let should_send = match last_sent {
-				None => true,
-				Some((0, _)) => bitrate > 0,
-				Some((prev, at)) => {
-					let elapsed = at.elapsed().as_secs_f64();
-					let t = elapsed.clamp(PROBE_INTERVAL.as_secs_f64(), PROBE_MAX_AGE.as_secs_f64());
-					let range = PROBE_MAX_AGE.as_secs_f64() - PROBE_INTERVAL.as_secs_f64();
-					let threshold = PROBE_MAX_DELTA * (PROBE_MAX_AGE.as_secs_f64() - t) / range;
-					let change = (bitrate as f64 - prev as f64).abs() / prev as f64;
-					change >= threshold
-				}
-			};
-
-			if should_send {
-				let rtt = session.stats().rtt().map(|d| d.as_millis() as u64);
-				stream.writer.encode(&lite::Probe { bitrate, rtt }).await?;
-				last_sent = Some((bitrate, web_async::time::Instant::now()));
-			}
-		}
-	}
-
-	pub async fn recv_announce(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
-		let interest = stream.reader.decode::<lite::AnnounceRequest>().await?;
-		let prefix = interest.prefix.to_owned();
-
-		// The identity whose routes we filter out. Lite-04/05 carry it per
-		// announce stream; lite-06+ reads the session-wide SETUP Origin
-		// parameter, the same identity the subscribe path excludes. A peer that
-		// declares nothing falls back to the identity the caller assigned it
-		// (`with_peer_origin`), if any.
-		let assigned = self.peer_origin.map(|origin| origin.id()).unwrap_or(0);
-		let exclude_hop = if self.version.has_exclude_hop() {
-			match interest.exclude_hop {
-				0 => assigned,
-				id => id,
-			}
-		} else if self.version.has_setup_stream() {
-			self.peer_setup
-				.origin()
-				.await
-				.map(|origin| origin.id())
-				.unwrap_or(assigned)
-		} else {
-			assigned
-		};
-
-		// If the requested prefix is outside our scope (an empty origin, or a token
-		// that doesn't grant it), we simply have nothing to announce. Respond with an
-		// empty set and keep the stream open (the subscriber treats a FIN here as a
-		// fatal stream close), rather than erroring, which would reset the stream.
-		let origin = self
-			.origin
-			.scope(&[prefix.as_path()])
-			.unwrap_or_else(|| self.origin.empty());
-		// Register the split-horizon peer on the announce cursor too. The origin
-		// model uses this exposure to park a reflected copy before it can replace
-		// the source we are currently advertising to that peer.
-		let origin = match Origin::new(exclude_hop) {
-			Ok(peer) => origin.excluding(peer),
-			Err(_) => origin,
-		};
-		let mut announced = origin.announced();
-
-		if let Err(err) = Self::run_announce(
-			&mut stream,
-			&origin,
-			&mut announced,
-			&prefix,
-			self.self_origin,
-			exclude_hop,
-			self.version,
-		)
-		.await
-		{
-			match &err {
-				Error::Cancel | Error::Transport(_) => {
-					tracing::debug!(prefix = %origin.absolute(prefix), "announcing cancelled");
-				}
-				err => {
-					tracing::warn!(%err, prefix = %origin.absolute(prefix), "announcing error");
-				}
-			}
-
-			stream.writer.abort(&err);
-		}
-
-		Ok(())
-	}
-
-	#[allow(clippy::too_many_arguments)]
+#[cfg(test)]
+impl<S: crate::transport::poll::Session> Publisher<S> {
+	/// Test shim: drive one announce-interest stream like the old `run_announce`.
 	async fn run_announce(
 		stream: &mut Stream<S, Version>,
 		origin: &origin::Consumer,
 		announced: &mut announce::Consumer,
 		prefix: impl AsPath,
 		self_origin: Origin,
-		// Peer's session-level origin id, sent in ANNOUNCE_REQUEST on lite-04/05.
-		// We skip forwarding announces whose hop chain already contains this id, so
-		// reflected announces (cluster loops) never hit the wire. Zero means the peer
-		// didn't send one (every other version), in which case we forward and the peer
-		// drops the reflection on receipt.
 		exclude_hop: u64,
 		version: Version,
 	) -> Result<(), Error> {
-		let prefix = prefix.as_path();
+		let mut run = AnnounceRun::new(prefix.as_path().to_owned(), exclude_hop, self_origin, version);
+		kio::wait(|waiter| run.poll(stream, origin, announced, waiter)).await
+	}
+}
 
-		// Lite06+: announce ids. Every `active` we send implicitly assigns the next
-		// per-stream ordinal, and `ended` references the id instead of repeating the
-		// path. Keyed by suffix; only announces that actually hit the wire get an id
-		// (filtered ones were never seen by the peer).
-		let mut next_announce_id: u64 = 0;
-		let mut announce_ids: std::collections::HashMap<crate::PathOwned, u64> = std::collections::HashMap::new();
+/// One accepted control stream, dispatched on its first varint.
+struct Control<S: crate::transport::poll::Session> {
+	shared: Arc<Shared<S>>,
+	state: ControlState<S>,
+}
 
-		// Lite05+: watch every announced broadcast's route and forward changes as a
-		// restart, so an upstream failover re-advertises downstream instead of the
-		// peer keeping a stale hop chain. Keyed by suffix; filtered announces are
-		// watched too, since an update can cross the forwarding filter either way.
-		let mut watched: std::collections::HashMap<crate::PathOwned, WatchedRoute> = std::collections::HashMap::new();
-		// Pre-restart versions (Lite01-04) never populate `watched`, but the
-		// broadcast consumer handed out by an excluding cursor carries the
-		// ExclusionGuard that keeps the front marked as exposed to this peer. Hold
-		// it for as long as the peer holds the advertisement, or the guard releases
-		// right after the Active is written and a reflected UNKNOWN route can
-		// replace the incumbent after all.
-		let mut held: std::collections::HashMap<crate::PathOwned, crate::broadcast::Consumer> =
-			std::collections::HashMap::new();
+enum ControlState<S: crate::transport::poll::Session> {
+	/// Reading the stream's type.
+	Start {
+		stream: Stream<S, Version>,
+	},
+	Announce(AnnounceServe<S>),
+	Subscribe(SubscribeServe<S>),
+	Fetch(FetchServe<S>),
+	TrackInfo(TrackInfoServe<S>),
+	Probe(ProbeServe<S>),
+	/// Decoding the peer's GOAWAY, surfaced through [`crate::Session::draining`].
+	Goaway {
+		stream: Stream<S, Version>,
+	},
+	Done,
+}
 
-		match version {
+impl<S: crate::transport::poll::Session> Machine for Control<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		if let Err(err) = ready!(self.poll_serve(waiter)) {
+			tracing::warn!(%err, "control stream error");
+		}
+		Poll::Ready(())
+	}
+}
+
+impl<S: crate::transport::poll::Session> Control<S> {
+	fn poll_serve(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				ControlState::Start { stream } => {
+					let mut cx = Context::from_waker(waiter.waker());
+					let kind = ready!(stream.reader.poll_decode::<lite::ControlType>(&mut cx))?;
+
+					let ControlState::Start { stream } = std::mem::replace(&mut self.state, ControlState::Done) else {
+						unreachable!()
+					};
+					self.state = match kind {
+						lite::ControlType::Announce => {
+							ControlState::Announce(AnnounceServe::new(self.shared.clone(), stream))
+						}
+						lite::ControlType::Subscribe => {
+							ControlState::Subscribe(SubscribeServe::new(self.shared.clone(), stream))
+						}
+						lite::ControlType::Fetch => ControlState::Fetch(FetchServe::new(self.shared.clone(), stream)?),
+						lite::ControlType::Track => {
+							ControlState::TrackInfo(TrackInfoServe::new(self.shared.clone(), stream)?)
+						}
+						lite::ControlType::Probe => ControlState::Probe(ProbeServe::new(self.shared.clone(), stream)),
+						lite::ControlType::Goaway => ControlState::Goaway { stream },
+						lite::ControlType::Session => return Poll::Ready(Err(Error::UnexpectedStream)),
+					};
+				}
+				ControlState::Announce(serve) => return serve.poll(waiter),
+				ControlState::Subscribe(serve) => return serve.poll(waiter),
+				ControlState::Fetch(serve) => return serve.poll(waiter),
+				ControlState::TrackInfo(serve) => return serve.poll(waiter),
+				ControlState::Probe(serve) => return serve.poll(waiter),
+				ControlState::Goaway { stream } => {
+					// A decode error propagates to the caller, which logs and continues: a
+					// malformed GOAWAY must not tear down the session it is trying to drain.
+					let mut cx = Context::from_waker(waiter.waker());
+					let msg = ready!(stream.reader.poll_decode::<lite::Goaway>(&mut cx))?;
+					tracing::info!(uri = %msg.uri, "received goaway");
+
+					let uri = msg.uri.into_owned();
+					let goaway = crate::goaway::Goaway {
+						uri: uri.clone(),
+						// moq-lite has no timeout field on the wire.
+						timeout: None,
+					};
+
+					if let Err(err) = self.shared.goaway.record(goaway) {
+						// A second Goaway stream is a protocol violation. The control loop only
+						// logs per-stream errors, so close the session here rather than letting a
+						// peer silently replace a redirect an observer may already be acting on.
+						tracing::warn!(%uri, "duplicate GOAWAY received; closing session");
+						self.shared
+							.session
+							.clone()
+							.close(SessionError::from(&err).to_code(), &err.to_string());
+						return Poll::Ready(Err(err));
+					}
+					return Poll::Ready(Ok(()));
+				}
+				ControlState::Done => return Poll::Ready(Ok(())),
+			}
+		}
+	}
+}
+
+/// Serves one PROBE stream: periodic bandwidth estimates until the peer closes
+/// its side.
+struct ProbeServe<S: crate::transport::poll::Session> {
+	shared: Arc<Shared<S>>,
+	stream: Option<Stream<S, Version>>,
+	last_sent: Option<(u64, web_async::time::Instant)>,
+	interval: web_async::time::Interval,
+}
+
+impl<S: crate::transport::poll::Session> ProbeServe<S> {
+	const PROBE_INTERVAL: Duration = Duration::from_millis(100);
+	const PROBE_MAX_AGE: Duration = Duration::from_secs(10);
+	const PROBE_MAX_DELTA: f64 = 0.25;
+
+	fn new(shared: Arc<Shared<S>>, stream: Stream<S, Version>) -> Self {
+		Self {
+			shared,
+			stream: Some(stream),
+			last_sent: None,
+			interval: web_async::time::interval(Self::PROBE_INTERVAL),
+		}
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		match ready!(self.poll_probe(waiter)) {
+			Ok(()) => tracing::debug!("probe stream closed"),
+			Err(err) => {
+				tracing::warn!(%err, "probe stream error");
+				self.stream.take().expect("stream present").writer.abort(&err);
+			}
+		}
+		Poll::Ready(Ok(()))
+	}
+
+	fn poll_probe(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		let stream = self.stream.as_mut().expect("stream present");
+		let mut cx = Context::from_waker(waiter.waker());
+
+		loop {
+			// Deliver the previous estimate before ticking out the next one.
+			ready!(stream.writer.poll_flush(&mut cx))?;
+
+			// Tick the probe interval, bailing as soon as the peer closes its side.
+			if let Poll::Ready(res) = stream.reader.poll_closed(&mut cx) {
+				return Poll::Ready(res);
+			}
+			ready!(self.interval.poll_tick(&mut cx));
+
+			let Some(bitrate) = self.shared.session.stats().estimated_send_rate() else {
+				continue;
+			};
+
+			let should_send = match self.last_sent {
+				None => true,
+				Some((0, _)) => bitrate > 0,
+				Some((prev, at)) => {
+					let elapsed = at.elapsed().as_secs_f64();
+					let t = elapsed.clamp(Self::PROBE_INTERVAL.as_secs_f64(), Self::PROBE_MAX_AGE.as_secs_f64());
+					let range = Self::PROBE_MAX_AGE.as_secs_f64() - Self::PROBE_INTERVAL.as_secs_f64();
+					let threshold = Self::PROBE_MAX_DELTA * (Self::PROBE_MAX_AGE.as_secs_f64() - t) / range;
+					let change = (bitrate as f64 - prev as f64).abs() / prev as f64;
+					change >= threshold
+				}
+			};
+
+			if should_send {
+				let rtt = self.shared.session.stats().rtt().map(|d| d.as_millis() as u64);
+				stream.writer.buffer(&lite::Probe { bitrate, rtt })?;
+				self.last_sent = Some((bitrate, web_async::time::Instant::now()));
+			}
+		}
+	}
+}
+
+/// Serves one announce-interest stream: the initial set, then updates as routes,
+/// demand, and the origin change.
+struct AnnounceServe<S: crate::transport::poll::Session> {
+	shared: Arc<Shared<S>>,
+	stream: Option<Stream<S, Version>>,
+	state: AnnounceState,
+}
+
+enum AnnounceState {
+	/// Reading the ANNOUNCE_REQUEST.
+	Decode,
+	/// Waiting on the peer's SETUP for the session-wide excluded origin
+	/// (lite-05, whose wire carries no per-stream exclude_hop).
+	ExcludeHop { prefix: crate::PathOwned },
+	/// Streaming announce updates.
+	Run {
+		origin: origin::Consumer,
+		announced: announce::Consumer,
+		run: AnnounceRun,
+	},
+}
+
+impl<S: crate::transport::poll::Session> AnnounceServe<S> {
+	fn new(shared: Arc<Shared<S>>, stream: Stream<S, Version>) -> Self {
+		Self {
+			shared,
+			stream: Some(stream),
+			state: AnnounceState::Decode,
+		}
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				AnnounceState::Decode => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let mut cx = Context::from_waker(waiter.waker());
+					let interest = ready!(stream.reader.poll_decode::<lite::AnnounceRequest>(&mut cx))?;
+					let prefix = interest.prefix.to_owned();
+
+					// The identity whose routes we filter out. Lite-04/05 carry it per
+					// announce stream; lite-06+ reads the session-wide SETUP Origin
+					// parameter, the same identity the subscribe path excludes. A peer that
+					// declares nothing falls back to the identity the caller assigned it
+					// (`with_peer_origin`), if any.
+					let assigned = self.shared.peer_origin.map(|origin| origin.id()).unwrap_or(0);
+					if self.shared.version.has_exclude_hop() {
+						let exclude_hop = match interest.exclude_hop {
+							0 => assigned,
+							id => id,
+						};
+						self.start(prefix, exclude_hop);
+					} else if self.shared.version.has_setup_stream() {
+						self.state = AnnounceState::ExcludeHop { prefix };
+					} else {
+						self.start(prefix, assigned);
+					}
+				}
+				AnnounceState::ExcludeHop { prefix } => {
+					let assigned = self.shared.peer_origin.map(|origin| origin.id()).unwrap_or(0);
+					let exclude_hop = ready!(self.shared.peer_setup.poll_origin(waiter))
+						.map(|origin| origin.id())
+						.unwrap_or(assigned);
+					let prefix = prefix.clone();
+					self.start(prefix, exclude_hop);
+				}
+				AnnounceState::Run { origin, announced, run } => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let res = ready!(run.poll(stream, origin, announced, waiter));
+					if let Err(err) = res {
+						match &err {
+							Error::Cancel | Error::Transport(_) => {
+								tracing::debug!(prefix = %origin.absolute(&run.prefix), "announcing cancelled");
+							}
+							err => {
+								tracing::warn!(%err, prefix = %origin.absolute(&run.prefix), "announcing error");
+							}
+						}
+						self.stream.take().expect("stream present").writer.abort(&err);
+					}
+					return Poll::Ready(Ok(()));
+				}
+			}
+		}
+	}
+
+	fn start(&mut self, prefix: crate::PathOwned, exclude_hop: u64) {
+		// If the requested prefix is outside our scope (an empty origin, or a token
+		// that doesn't grant it), we simply have nothing to announce. Respond with an
+		// empty set and keep the stream open (the subscriber treats a FIN here as a
+		// fatal stream close), rather than erroring, which would reset the stream.
+		let origin = self
+			.shared
+			.origin
+			.scope(&[prefix.as_path()])
+			.unwrap_or_else(|| self.shared.origin.empty());
+		let announced = origin.announced();
+		let run = AnnounceRun::new(prefix, exclude_hop, self.shared.self_origin, self.shared.version);
+		self.state = AnnounceState::Run { origin, announced, run };
+	}
+}
+
+/// One announce-loop turn: either an (un)announce from the origin, a route
+/// change on an already-announced broadcast, or a demand edge re-pricing
+/// one. A route turn re-reads the broadcast's route table and re-runs the
+/// per-peer selection; `Err` means the broadcast is gone.
+enum Op {
+	Announce(Option<crate::announce::Update>),
+	Route(crate::PathOwned, Result<(), Error>),
+	Idle(crate::PathOwned),
+	/// The linger sleep fired without an expired entry (it was canceled,
+	/// or a later deadline remains): restart the turn so the next
+	/// deadline arms a fresh sleep.
+	Linger,
+}
+
+/// The announce loop's state, minus the handles it borrows per poll so the test
+/// shim can supply its own.
+struct AnnounceRun {
+	prefix: crate::PathOwned,
+	exclude_hop: u64,
+	self_origin: Origin,
+	version: Version,
+	// Lite06+: announce ids. Every `active` we send implicitly assigns the next
+	// per-stream ordinal, and `ended` references the id instead of repeating the
+	// path. Keyed by suffix; only announces that actually hit the wire get an id
+	// (filtered ones were never seen by the peer).
+	next_announce_id: u64,
+	announce_ids: HashMap<crate::PathOwned, u64>,
+	// Lite05+: watch every announced broadcast's route and forward changes as a
+	// restart, so an upstream failover re-advertises downstream instead of the
+	// peer keeping a stale hop chain. Keyed by suffix; filtered announces are
+	// watched too, since an update can cross the forwarding filter either way.
+	watched: HashMap<crate::PathOwned, WatchedRoute>,
+	linger: kio::time::Deadline,
+	phase: AnnouncePhase,
+}
+
+enum AnnouncePhase {
+	/// The version-specific initial burst has not been sent yet.
+	Init,
+	Running,
+	/// The origin ended: FIN sent, waiting for the acknowledgement.
+	Closing,
+}
+
+impl AnnounceRun {
+	fn new(prefix: crate::PathOwned, exclude_hop: u64, self_origin: Origin, version: Version) -> Self {
+		Self {
+			prefix,
+			exclude_hop,
+			self_origin,
+			version,
+			next_announce_id: 0,
+			announce_ids: HashMap::new(),
+			watched: HashMap::new(),
+			linger: kio::time::Deadline::new(),
+			phase: AnnouncePhase::Init,
+		}
+	}
+
+	/// Buffer the version-specific initial burst: ANNOUNCE_INIT (Lite01/02) or
+	/// ANNOUNCE_OK plus the initial actives (lite-05+).
+	fn init<S: crate::transport::poll::Session>(
+		&mut self,
+		stream: &mut Stream<S, Version>,
+		origin: &origin::Consumer,
+		announced: &mut announce::Consumer,
+	) -> Result<(), Error> {
+		match self.version {
 			Version::Lite01 | Version::Lite02 => {
 				let mut init = Vec::new();
 
@@ -373,7 +536,7 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 				// We use `try_next()` to synchronously get the initial updates.
 				while let Some(crate::announce::Update { path, broadcast }) = announced.try_next() {
 					let suffix = path
-						.strip_prefix(&prefix)
+						.strip_prefix(&self.prefix)
 						.expect("origin returned invalid path")
 						.to_owned();
 					let absolute = origin.absolute(&path).to_owned();
@@ -382,12 +545,12 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 						// The same per-peer selection as the live loop: an initial path
 						// with no advertisable route (a reflection, or every hop through
 						// the peer's assigned identity) is filtered like a live announce.
-						let selected = Self::select_route(
+						let selected = select_route(
 							&broadcast.routes(),
 							&broadcast.demand(),
-							self_origin,
-							exclude_hop,
-							version,
+							self.self_origin,
+							self.exclude_hop,
+							self.version,
 							&absolute,
 						);
 						if selected.is_none() {
@@ -405,9 +568,9 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 				}
 
 				let announce_init = lite::AnnounceInit { suffixes: init };
-				stream.writer.encode(&announce_init).await?;
+				stream.writer.buffer(&announce_init)?;
 			}
-			_ if version.has_announce_ok() => {
+			_ if self.version.has_announce_ok() => {
 				// Drain the current active set synchronously (like the Lite01/02 path),
 				// stashing suffix+hops so we can both COUNT them for AnnounceOk and re-send
 				// them afterward. The receiver stamps our origin onto each hop chain, so we
@@ -415,7 +578,7 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 				let mut initial: Vec<(crate::PathOwned, SentRoute)> = Vec::new();
 				while let Some(crate::announce::Update { path, broadcast }) = announced.try_next() {
 					let suffix = path
-						.strip_prefix(&prefix)
+						.strip_prefix(&self.prefix)
 						.expect("origin returned invalid path")
 						.to_owned();
 					let absolute = origin.absolute(&path).to_owned();
@@ -426,7 +589,7 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 							let demand = broadcast.demand();
 							// Watch even the announces we filter below: a later route update
 							// can cross the forwarding filter in either direction.
-							watched.insert(
+							self.watched.insert(
 								suffix.clone(),
 								WatchedRoute {
 									consumer: broadcast.clone(),
@@ -438,9 +601,14 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 							);
 							// The same per-peer selection as the live loop, so the count
 							// matches exactly what we send.
-							let Some(route) =
-								Self::select_route(&routes, &demand, self_origin, exclude_hop, version, &absolute)
-							else {
+							let Some(route) = select_route(
+								&routes,
+								&demand,
+								self.self_origin,
+								self.exclude_hop,
+								self.version,
+								&absolute,
+							) else {
 								continue;
 							};
 							tracing::debug!(broadcast = %absolute, "announce");
@@ -450,7 +618,7 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 						None => {
 							// A potential race: a just-announced path already unannounced.
 							tracing::debug!(broadcast = %absolute, "unannounce");
-							watched.remove(&suffix);
+							self.watched.remove(&suffix);
 							initial.retain(|(s, _)| s != &suffix);
 						}
 					}
@@ -459,142 +627,140 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 				// Report our origin id (stamped onto hops by the receiver, not us)
 				// and the count of initial announces that follow immediately.
 				let ok = lite::AnnounceOk {
-					origin: self_origin,
+					origin: self.self_origin,
 					active: initial.len() as u64,
 				};
-				let mut buf = bytes::BytesMut::new();
-				ok.encode(&mut buf, version)?;
+				stream.writer.buffer(&ok)?;
 				for (suffix, route) in &initial {
-					if version.has_announce_id() {
-						announce_ids.insert(suffix.clone(), next_announce_id);
-						next_announce_id += 1;
+					if self.version.has_announce_id() {
+						self.announce_ids.insert(suffix.clone(), self.next_announce_id);
+						self.next_announce_id += 1;
 					}
-					if let Some(entry) = watched.get_mut(suffix) {
+					if let Some(entry) = self.watched.get_mut(suffix) {
 						entry.sent = Some(route.clone());
 					}
-					lite::AnnounceBroadcast::Active {
+					stream.writer.buffer(&lite::AnnounceBroadcast::Active {
 						suffix: suffix.as_path(),
 						hops: route.hops.clone(),
 						cost: route.cost,
-					}
-					.encode(&mut buf, version)?;
+					})?;
 				}
-				let mut buf = buf.freeze();
-				stream.writer.write_all(&mut buf).await?;
 			}
 			_ => {
 				// Lite03/Lite04: no announce init, no AnnounceOk.
 			}
 		}
 
-		// One announce-loop turn: either an (un)announce from the origin, a route
-		// change on an already-announced broadcast, or a demand edge re-pricing
-		// one. Resolved outside the select so the handlers below can freely
-		// mutate the maps its futures borrow. A route turn re-reads the
-		// broadcast's route table and re-runs the per-peer selection; `Err`
-		// means the broadcast is gone.
-		enum Op {
-			Announce(Option<crate::announce::Update>),
-			Route(crate::PathOwned, Result<(), Error>),
-			Idle(crate::PathOwned),
-			/// The linger sleep fired without an expired entry (it was canceled,
-			/// or a later deadline remains): restart the turn so the next
-			/// deadline arms a fresh sleep.
-			Linger,
-		}
+		Ok(())
+	}
 
+	/// Stream updates as they arrive. Closure wins the race so a dead peer can't
+	/// stall on a busy announce feed.
+	fn poll<S: crate::transport::poll::Session>(
+		&mut self,
+		stream: &mut Stream<S, Version>,
+		origin: &origin::Consumer,
+		announced: &mut announce::Consumer,
+		waiter: &kio::Waiter,
+	) -> Poll<Result<(), Error>> {
 		use crate::broadcast::COST_LINGER;
 
-		// Send updates as they arrive. Closure wins the race so a dead peer can't
-		// stall on a busy announce feed.
-		let mut linger = kio::time::Deadline::new();
+		let mut cx = Context::from_waker(waiter.waker());
+
+		if matches!(self.phase, AnnouncePhase::Init) {
+			self.init(stream, origin, announced)?;
+			self.phase = AnnouncePhase::Running;
+		}
+
 		loop {
+			// Deliver the buffered updates before selecting more work.
+			ready!(stream.writer.poll_flush(&mut cx))?;
+
+			if matches!(self.phase, AnnouncePhase::Closing) {
+				return stream.writer.poll_closed(&mut cx);
+			}
+
 			// The earliest deferred cost-restore, if any entry's linger is running.
-			linger.set(
-				watched
+			self.linger.set(
+				self.watched
 					.values()
 					.filter_map(|entry| entry.idle_at)
 					.min()
 					.map(|at| at + COST_LINGER),
 			);
-			let op = {
-				kio::wait(|waiter| {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					if let Poll::Ready(res) = stream.reader.poll_closed(&mut cx) {
-						return Poll::Ready(Err(res));
+
+			let op = 'turn: {
+				if let Poll::Ready(res) = stream.reader.poll_closed(&mut cx) {
+					return Poll::Ready(res);
+				}
+				if let Poll::Ready(next) = announced.poll_next(waiter) {
+					break 'turn Op::Announce(next);
+				}
+				// Stamped per turn rather than kept: the turn always ends in an op
+				// below once it fires, so it never has to survive.
+				let fired = self.linger.poll(waiter).is_ready().then(web_async::time::Instant::now);
+				// Poll every watched broadcast for a route-table change; each
+				// wake rescans the map, which announce-control rates make fine.
+				for (suffix, entry) in self.watched.iter_mut() {
+					if let Poll::Ready(res) = entry.consumer.poll_routes_changed(waiter) {
+						break 'turn Op::Route(suffix.clone(), res);
 					}
-					if let Poll::Ready(next) = announced.poll_next(waiter) {
-						return Poll::Ready(Ok(Op::Announce(next)));
+					// Demand edges re-price the route without a route change:
+					// watch the direction opposite the advertised cost. Closure
+					// is ignored here; the route watch above surfaces it.
+					if !self.version.has_route_cost() {
+						continue;
 					}
-					// Stamped per poll rather than kept: the turn always ends in a
-					// `Ready` below once it fires, so it never has to survive.
-					let fired = linger.poll(waiter).is_ready().then(web_async::time::Instant::now);
-					// Poll every watched broadcast for a route-table change; each
-					// wake rescans the map, which announce-control rates make fine.
-					for (suffix, entry) in watched.iter_mut() {
-						if let Poll::Ready(res) = entry.consumer.poll_routes_changed(waiter) {
-							return Poll::Ready(Ok(Op::Route(suffix.clone(), res)));
+					let Some(sent) = &entry.sent else { continue };
+					// The demand discount only applies to the serving route:
+					// a standby advertised to an excluded peer keeps its own
+					// cost, so demand edges can never re-price it.
+					if !sent.serving {
+						continue;
+					}
+					if sent.cost != lite::RouteCost(0) {
+						if let Poll::Ready(Ok(())) = entry.demand.poll_used(waiter) {
+							break 'turn Op::Route(suffix.clone(), Ok(()));
 						}
-						// Demand edges re-price the route without a route change:
-						// watch the direction opposite the advertised cost. Closure
-						// is ignored here; the route watch above surfaces it.
-						if !version.has_route_cost() {
+						continue;
+					}
+					match entry.idle_at {
+						// Demand coming back within the linger cancels the
+						// restore; fall through to re-arm the unused watch.
+						Some(_) if entry.demand.is_used() => entry.idle_at = None,
+						// The linger expired: re-price via the route path.
+						Some(at) if fired.is_some_and(|now| now >= at + COST_LINGER) => {
+							entry.idle_at = None;
+							break 'turn Op::Route(suffix.clone(), Ok(()));
+						}
+						// Still lingering: the sleep owns the wakeup, and
+						// `poll_used` re-arms the cancel check above.
+						Some(_) => {
+							let _ = entry.demand.poll_used(waiter);
 							continue;
 						}
-						let Some(sent) = &entry.sent else { continue };
-						// The demand discount only applies to the serving route:
-						// a standby advertised to an excluded peer keeps its own
-						// cost, so demand edges can never re-price it.
-						if !sent.serving {
-							continue;
-						}
-						if sent.cost != lite::RouteCost(0) {
-							if let Poll::Ready(Ok(())) = entry.demand.poll_used(waiter) {
-								return Poll::Ready(Ok(Op::Route(suffix.clone(), Ok(()))));
-							}
-							continue;
-						}
-						match entry.idle_at {
-							// Demand coming back within the linger cancels the
-							// restore; fall through to re-arm the unused watch.
-							Some(_) if entry.demand.is_used() => entry.idle_at = None,
-							// The linger expired: re-price via the route path.
-							Some(at) if fired.is_some_and(|now| now >= at + COST_LINGER) => {
-								entry.idle_at = None;
-								return Poll::Ready(Ok(Op::Route(suffix.clone(), Ok(()))));
-							}
-							// Still lingering: the sleep owns the wakeup, and
-							// `poll_used` re-arms the cancel check above.
-							Some(_) => {
-								let _ = entry.demand.poll_used(waiter);
-								continue;
-							}
-							None => {}
-						}
-						if let Poll::Ready(Ok(())) = entry.demand.poll_unused(waiter) {
-							return Poll::Ready(Ok(Op::Idle(suffix.clone())));
-						}
+						None => {}
 					}
-					match fired {
-						Some(_) => Poll::Ready(Ok(Op::Linger)),
-						None => Poll::Pending,
+					if let Poll::Ready(Ok(())) = entry.demand.poll_unused(waiter) {
+						break 'turn Op::Idle(suffix.clone());
 					}
-				})
-				.await
-			};
-			let op = match op {
-				Ok(op) => op,
-				Err(res) => return res,
+				}
+				match fired {
+					Some(_) => Op::Linger,
+					None => return Poll::Pending,
+				}
 			};
 
 			match op {
 				Op::Announce(None) => {
+					// The buffer is empty (flushed at the loop top), so FIN now and
+					// wait for the acknowledgement.
 					stream.writer.finish()?;
-					return stream.writer.closed().await;
+					self.phase = AnnouncePhase::Closing;
 				}
 				Op::Announce(Some(crate::announce::Update { path, broadcast })) => {
 					let suffix = path
-						.strip_prefix(&prefix)
+						.strip_prefix(&self.prefix)
 						.expect("origin returned invalid path")
 						.to_owned();
 					let absolute = origin.absolute(&path).to_owned();
@@ -603,10 +769,10 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 						Some(active) => {
 							let routes = active.routes();
 							let demand = active.demand();
-							if lite::restart_supported(version) {
+							if lite::restart_supported(self.version) {
 								// Watch even if filtered below: a route update can cross
 								// the forwarding filter in either direction.
-								watched.insert(
+								self.watched.insert(
 									suffix.clone(),
 									WatchedRoute {
 										consumer: active.clone(),
@@ -617,31 +783,30 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 									},
 								);
 							}
-							let Some(route) =
-								Self::select_route(&routes, &demand, self_origin, exclude_hop, version, &absolute)
-							else {
+							let Some(route) = select_route(
+								&routes,
+								&demand,
+								self.self_origin,
+								self.exclude_hop,
+								self.version,
+								&absolute,
+							) else {
 								continue;
 							};
 							tracing::debug!(broadcast = %absolute, "announce");
-							if version.has_announce_id() {
-								let prev = announce_ids.insert(suffix.clone(), next_announce_id);
+							if self.version.has_announce_id() {
+								let prev = self.announce_ids.insert(suffix.clone(), self.next_announce_id);
 								debug_assert!(prev.is_none(), "announce id still assigned for a new announce");
-								next_announce_id += 1;
+								self.next_announce_id += 1;
 							}
-							if let Some(entry) = watched.get_mut(&suffix) {
+							if let Some(entry) = self.watched.get_mut(&suffix) {
 								entry.sent = Some(route.clone());
 							}
-							if !lite::restart_supported(version) {
-								held.insert(suffix.clone(), active.clone());
-							}
-							stream
-								.writer
-								.encode(&lite::AnnounceBroadcast::Active {
-									suffix,
-									hops: route.hops,
-									cost: route.cost,
-								})
-								.await?;
+							stream.writer.buffer(&lite::AnnounceBroadcast::Active {
+								suffix,
+								hops: route.hops,
+								cost: route.cost,
+							})?;
 						}
 						None => {
 							tracing::debug!(broadcast = %absolute, "unannounce");
@@ -650,23 +815,19 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 							// repeating the Ended would be a spurious wire message. Pre-watch
 							// versions never populate `watched`, so they keep sending the
 							// Ended even for announces filtered above.
-							let retracted = watched.remove(&suffix).is_some_and(|entry| entry.sent.is_none());
-							held.remove(&suffix);
-							if version.has_announce_id() {
+							let retracted = self.watched.remove(&suffix).is_some_and(|entry| entry.sent.is_none());
+							if self.version.has_announce_id() {
 								// Retract by id; nothing to send if the announce was filtered and
 								// the peer never saw it (an unknown id is a protocol violation).
-								if let Some(id) = announce_ids.remove(&suffix) {
-									stream.writer.encode(&lite::AnnounceBroadcast::EndedId { id }).await?;
+								if let Some(id) = self.announce_ids.remove(&suffix) {
+									stream.writer.buffer(&lite::AnnounceBroadcast::EndedId { id })?;
 								}
 							} else if !retracted {
 								// An ended announce doesn't need hops; the receiver matches on path only.
-								stream
-									.writer
-									.encode(&lite::AnnounceBroadcast::Ended {
-										suffix,
-										hops: OriginList::new(),
-									})
-									.await?;
+								stream.writer.buffer(&lite::AnnounceBroadcast::Ended {
+									suffix,
+									hops: OriginList::new(),
+								})?;
 							}
 						}
 					}
@@ -674,10 +835,10 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 				Op::Route(suffix, res) => {
 					if res.is_err() {
 						// The broadcast is gone; the origin delivers the Ended itself.
-						watched.remove(&suffix);
+						self.watched.remove(&suffix);
 						continue;
 					}
-					let Some(entry) = watched.get_mut(&suffix) else {
+					let Some(entry) = self.watched.get_mut(&suffix) else {
 						continue;
 					};
 					// Any re-price supersedes a pending cost-restore; a stale
@@ -685,7 +846,14 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 					entry.idle_at = None;
 					let absolute = origin.absolute(&entry.path).to_owned();
 					let routes = entry.consumer.routes();
-					let hops = Self::select_route(&routes, &entry.demand, self_origin, exclude_hop, version, &absolute);
+					let hops = select_route(
+						&routes,
+						&entry.demand,
+						self.self_origin,
+						self.exclude_hop,
+						self.version,
+						&absolute,
+					);
 					let sent = entry.sent.clone();
 					match (hops, sent) {
 						// Neither the forwarded chain nor the cost moved: nothing to
@@ -700,71 +868,59 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 						// route in place instead of re-resolving.
 						(Some(route), Some(_)) => {
 							tracing::debug!(broadcast = %absolute, "reannounce");
-							if version.has_announce_id() {
+							if self.version.has_announce_id() {
 								// The id exists for every live advertisement; a panic here would
 								// silently kill the announce loop (the peer keeps stale routes),
 								// so a bookkeeping bug degrades to a skipped restart instead.
-								let Some(id) = announce_ids.get(&suffix).copied() else {
+								let Some(id) = self.announce_ids.get(&suffix).copied() else {
 									debug_assert!(false, "announced path without an announce id");
 									tracing::warn!(broadcast = %absolute, "restart without an announce id; skipping");
 									continue;
 								};
 								entry.sent = Some(route.clone());
-								stream
-									.writer
-									.encode(&lite::AnnounceBroadcast::Restart {
-										id,
-										hops: route.hops,
-										cost: route.cost,
-									})
-									.await?;
+								stream.writer.buffer(&lite::AnnounceBroadcast::Restart {
+									id,
+									hops: route.hops,
+									cost: route.cost,
+								})?;
 							} else {
 								// Lite05: a duplicate ANNOUNCE for a live path is the restart.
 								entry.sent = Some(route.clone());
-								stream
-									.writer
-									.encode(&lite::AnnounceBroadcast::Active {
-										suffix,
-										hops: route.hops,
-										cost: route.cost,
-									})
-									.await?;
+								stream.writer.buffer(&lite::AnnounceBroadcast::Active {
+									suffix,
+									hops: route.hops,
+									cost: route.cost,
+								})?;
 							}
 						}
 						// Previously filtered, now forwardable: a fresh announce.
 						(Some(route), None) => {
 							tracing::debug!(broadcast = %absolute, "announce");
-							if version.has_announce_id() {
-								announce_ids.insert(suffix.clone(), next_announce_id);
-								next_announce_id += 1;
+							if self.version.has_announce_id() {
+								self.announce_ids.insert(suffix.clone(), self.next_announce_id);
+								self.next_announce_id += 1;
 							}
 							entry.sent = Some(route.clone());
-							stream
-								.writer
-								.encode(&lite::AnnounceBroadcast::Active {
-									suffix,
-									hops: route.hops,
-									cost: route.cost,
-								})
-								.await?;
+							stream.writer.buffer(&lite::AnnounceBroadcast::Active {
+								suffix,
+								hops: route.hops,
+								cost: route.cost,
+							})?;
 						}
 						// The new chain must not be forwarded (it now loops through the
 						// peer, or the peer excluded it): retract.
 						(None, Some(_)) => {
 							tracing::debug!(broadcast = %absolute, "unannounce (filtered route)");
 							entry.sent = None;
-							if version.has_announce_id() {
-								if let Some(id) = announce_ids.remove(&suffix) {
-									stream.writer.encode(&lite::AnnounceBroadcast::EndedId { id }).await?;
+							if self.version.has_announce_id() {
+								if let Some(id) = self.announce_ids.remove(&suffix) {
+									stream.writer.buffer(&lite::AnnounceBroadcast::EndedId { id })?;
 								}
 							} else {
-								stream
-									.writer
-									.encode(&lite::AnnounceBroadcast::Ended {
-										suffix,
-										hops: OriginList::new(),
-									})
-									.await?;
+								stream.writer.buffer(&lite::AnnounceBroadcast::Ended {
+									suffix,
+									hops: OriginList::new(),
+								})?;
 							}
 						}
 						// Still filtered: keep watching.
@@ -774,7 +930,7 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 				// Demand drained while advertising zero: start the linger. The
 				// restore rides the deadline unless demand returns first.
 				Op::Idle(suffix) => {
-					if let Some(entry) = watched.get_mut(&suffix) {
+					if let Some(entry) = self.watched.get_mut(&suffix) {
 						entry.idle_at = Some(web_async::time::Instant::now());
 					}
 				}
@@ -784,352 +940,638 @@ impl<S: crate::transport::poll::Session> Publisher<S> {
 			}
 		}
 	}
+}
 
-	/// Pick the route to advertise to this peer: the most preferred announced
-	/// route whose hop chain avoids both the peer (`exclude_hop`) and ourselves
-	/// (a reflection), with the outgoing chain and cost ready for the wire.
-	///
-	/// `routes` is the broadcast's table in preference order with the serving
-	/// (active) route first, so the peer usually receives exactly what we serve
-	/// everyone; a peer that the active chain flows through receives the best
-	/// standby instead of nothing. The subscribe path picks its source by the
-	/// same exclusion (see `origin::Consumer::excluding`), which is what keeps
-	/// the advertised chain truthful and the mesh loop-free.
-	///
-	/// Returns `None` when no route qualifies: every chain loops through the
-	/// peer or us, or none is announced.
-	fn select_route(
-		routes: &[crate::broadcast::Route],
-		demand: &crate::broadcast::Demand,
-		self_origin: Origin,
-		exclude_hop: u64,
-		version: Version,
-		absolute: &crate::Path,
-	) -> Option<SentRoute> {
-		let exclude = match exclude_hop {
-			0 => Origin::UNKNOWN,
-			id => Origin::new(id).unwrap_or(Origin::UNKNOWN),
-		};
+/// Pick the route to advertise to this peer: the most preferred announced
+/// route whose hop chain avoids both the peer (`exclude_hop`) and ourselves
+/// (a reflection), with the outgoing chain and cost ready for the wire.
+///
+/// `routes` is the broadcast's table in preference order with the serving
+/// (active) route first, so the peer usually receives exactly what we serve
+/// everyone; a peer that the active chain flows through receives the best
+/// standby instead of nothing. The subscribe path picks its source by the
+/// same exclusion (see `origin::Consumer::excluding`), which is what keeps
+/// the advertised chain truthful and the mesh loop-free.
+///
+/// Returns `None` when no route qualifies: every chain loops through the
+/// peer or us, or none is announced.
+fn select_route(
+	routes: &[crate::broadcast::Route],
+	demand: &crate::broadcast::Demand,
+	self_origin: Origin,
+	exclude_hop: u64,
+	version: Version,
+	absolute: &crate::Path,
+) -> Option<SentRoute> {
+	let exclude = match exclude_hop {
+		0 => Origin::UNKNOWN,
+		id => Origin::new(id).unwrap_or(Origin::UNKNOWN),
+	};
 
-		for (route, serving) in crate::broadcast::advertisable_routes(routes, self_origin, exclude) {
-			let mut hops = route.hops.clone();
-			// Lite05+ moves the self-stamp to the receiver, which appends our id (reported
-			// once via AnnounceOk) on receipt. Older versions stamp it here, dropping if the
-			// chain is full.
-			if !version.has_announce_ok() && hops.push(self_origin).is_err() {
-				tracing::warn!(broadcast = %absolute, "dropping announce; hop chain at MAX_HOPS (possible loop)");
-				continue;
-			}
-			let cost = Self::outgoing_cost(version, demand, route, serving);
-			return Some(SentRoute { hops, cost, serving });
+	for (route, serving) in crate::broadcast::advertisable_routes(routes, self_origin, exclude) {
+		let mut hops = route.hops.clone();
+		// Lite05+ moves the self-stamp to the receiver, which appends our id (reported
+		// once via AnnounceOk) on receipt. Older versions stamp it here, dropping if the
+		// chain is full.
+		if !version.has_announce_ok() && hops.push(self_origin).is_err() {
+			tracing::warn!(broadcast = %absolute, "dropping announce; hop chain at MAX_HOPS (possible loop)");
+			continue;
 		}
-		tracing::debug!(broadcast = %absolute, %exclude_hop, "no advertisable route for this peer");
-		None
+		let cost = outgoing_cost(version, demand, route, serving);
+		return Some(SentRoute { hops, cost, serving });
+	}
+	tracing::debug!(broadcast = %absolute, %exclude_hop, "no advertisable route for this peer");
+	None
+}
+
+/// The cost to advertise for a route, alongside its outgoing hop chain.
+///
+/// While the broadcast has demand, the *serving* (active) route costs zero:
+/// our ingress is already paid for (or, for a local standby publisher, the
+/// work is already running), so one more subscriber only pays the link to
+/// reach us. A standby advertised to a peer the active chain flows through
+/// keeps its own accumulated cost: serving that peer means opening a fresh
+/// ingest, which is not already paid for. Otherwise we forward the
+/// accumulated route cost unchanged, which for a standby publisher is its
+/// production cost and for a pure forwarder is the price of the fetch a
+/// subscription would trigger.
+///
+/// A ceiling-cost route pierces the carrying discount. For a drain (the
+/// ceiling's primary producer) the paid-for ingress is going away, so
+/// advertising zero would keep pulling subscribers onto a path about to
+/// vanish when a peer with any other edge should move now, while the seam is
+/// seamless. The rule keys on the value, not the reason: the reason does not
+/// travel on the wire, and a cost that saturated through charges marks a
+/// path of last resort all the same.
+///
+/// The receiving side adds its own link price on top, so we never account for
+/// the link we are sending over. Pre-lite-06 peers get nothing (the field isn't
+/// on their wire), leaving hop count as the metric exactly as before.
+fn outgoing_cost(
+	version: Version,
+	demand: &crate::broadcast::Demand,
+	route: &crate::broadcast::Route,
+	serving: bool,
+) -> lite::RouteCost {
+	if !version.has_route_cost() {
+		return lite::RouteCost::default();
 	}
 
-	/// The cost to advertise for a route, alongside its outgoing hop chain.
-	///
-	/// While the broadcast has demand, the *serving* (active) route costs zero:
-	/// our ingress is already paid for (or, for a local standby publisher, the
-	/// work is already running), so one more subscriber only pays the link to
-	/// reach us. A standby advertised to a peer the active chain flows through
-	/// keeps its own accumulated cost: serving that peer means opening a fresh
-	/// ingest, which is not already paid for. Otherwise we forward the
-	/// accumulated route cost unchanged, which for a standby publisher is its
-	/// production cost and for a pure forwarder is the price of the fetch a
-	/// subscription would trigger.
-	///
-	/// A ceiling-cost route pierces the carrying discount. For a drain (the
-	/// ceiling's primary producer) the paid-for ingress is going away, so
-	/// advertising zero would keep pulling subscribers onto a path about to
-	/// vanish when a peer with any other edge should move now, while the seam is
-	/// seamless. The rule keys on the value, not the reason: the reason does not
-	/// travel on the wire, and a cost that saturated through charges marks a
-	/// path of last resort all the same.
-	///
-	/// The receiving side adds its own link price on top, so we never account for
-	/// the link we are sending over. Pre-lite-06 peers get nothing (the field isn't
-	/// on their wire), leaving hop count as the metric exactly as before.
-	fn outgoing_cost(
-		version: Version,
-		demand: &crate::broadcast::Demand,
-		route: &crate::broadcast::Route,
-		serving: bool,
-	) -> lite::RouteCost {
-		if !version.has_route_cost() {
-			return lite::RouteCost::default();
-		}
+	lite::RouteCost(crate::broadcast::outgoing_cost(demand, route, serving))
+}
 
-		lite::RouteCost(crate::broadcast::outgoing_cost(demand, route, serving))
-	}
+/// Serves one TRACK stream: resolve the track, answer with its TRACK_INFO, FIN.
+struct TrackInfoServe<S: crate::transport::poll::Session> {
+	shared: Arc<Shared<S>>,
+	stream: Option<Stream<S, Version>>,
+	state: TrackInfoState,
+	// Log context, filled in after the decode.
+	absolute: crate::PathOwned,
+	track: String,
+}
 
-	pub async fn recv_track(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
+enum TrackInfoState {
+	Decode,
+	/// Resolving the split-horizon origin (waits on the peer's SETUP).
+	Origin {
+		msg: lite::Track<'static>,
+	},
+	/// Resolving the broadcast (may wait on a dynamic handler).
+	Request {
+		msg: lite::Track<'static>,
+		requesting: origin::Requesting,
+	},
+	/// Waiting for the track's info.
+	Query {
+		querying: track::Querying,
+	},
+	/// TRACK_INFO buffered: flush, FIN, and wait for the acknowledgement.
+	Finish {
+		finished: bool,
+	},
+}
+
+impl<S: crate::transport::poll::Session> TrackInfoServe<S> {
+	fn new(shared: Arc<Shared<S>>, stream: Stream<S, Version>) -> Result<Self, Error> {
 		// The Track Stream is lite-05+ only.
-		if !self.version.has_track_stream() {
+		if !shared.version.has_track_stream() {
 			return Err(Error::UnexpectedStream);
 		}
+		Ok(Self {
+			shared,
+			stream: Some(stream),
+			state: TrackInfoState::Decode,
+			absolute: Default::default(),
+			track: Default::default(),
+		})
+	}
 
-		let request = stream.reader.decode::<lite::Track>().await?;
-		let track = request.track.clone();
-		let absolute = self.origin.absolute(&request.broadcast).to_owned();
-
-		tracing::debug!(broadcast = %absolute, %track, "track info requested");
-
-		if let Err(err) = self.run_track_info(&mut stream, &request).await {
-			match &err {
-				Error::Cancel | Error::Transport(_) => {
-					tracing::debug!(broadcast = %absolute, %track, "track info cancelled")
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		match ready!(self.poll_serve(waiter)) {
+			Ok(()) => Poll::Ready(Ok(())),
+			// A decode error propagates so the control loop logs it; anything past
+			// the decode is answered on the stream instead.
+			Err(err) if matches!(self.state, TrackInfoState::Decode) => Poll::Ready(Err(err)),
+			Err(err) => {
+				match &err {
+					Error::Cancel | Error::Transport(_) => {
+						tracing::debug!(broadcast = %self.absolute, track = %self.track, "track info cancelled")
+					}
+					err => {
+						tracing::warn!(broadcast = %self.absolute, track = %self.track, %err, "track info error")
+					}
 				}
-				err => tracing::warn!(broadcast = %absolute, %track, %err, "track info error"),
+				self.stream.take().expect("stream present").writer.abort(&err);
+				Poll::Ready(Ok(()))
 			}
-			stream.writer.abort(&err);
 		}
-
-		Ok(())
 	}
 
-	async fn run_track_info(&self, stream: &mut Stream<S, Version>, request: &lite::Track<'_>) -> Result<(), Error> {
-		// The peer requested this exact path, so it has already seen an announcement for it.
-		// `request_broadcast` resolves it immediately, or falls back to an `origin::Dynamic`
-		// handler (as in recv_subscribe).
-		let broadcast = self
-			.serving_origin()
-			.await
-			.request_broadcast(&request.broadcast)
-			.await?;
-		let info = broadcast.track(&request.track)?.info().await?;
-
-		// TRACK_INFO only flows on Lite05+ (the encode errors otherwise), where every
-		// track is timed, so the model's timescale and retention bound go on the wire
-		// verbatim.
-		stream
-			.writer
-			.encode(&lite::TrackInfo {
-				priority: info.priority,
-				ordered: info.ordered,
-				latency_max: info.latency_max,
-				timescale: info.timescale,
-			})
-			.await?;
-
-		stream.writer.finish()?;
-		stream.writer.closed().await
-	}
-
-	pub async fn recv_subscribe(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
-		let subscribe = stream.reader.decode::<lite::Subscribe>().await?;
-
-		let id = subscribe.id;
-		let track = subscribe.track.clone();
-		let absolute = self.origin.absolute(&subscribe.broadcast).to_owned();
-
-		tracing::info!(%id, broadcast = %absolute, %track, "subscribed started");
-
-		// We just received a subscribe for this exact path, so by definition the peer has
-		// already seen an announcement for it. `request_broadcast` resolves an announced
-		// broadcast immediately; if it isn't announced it falls back to an `origin::Dynamic`
-		// handler (or resolves to an error when there is none).
-		let broadcast = self.serving_origin().await.request_broadcast(&subscribe.broadcast);
-
-		// Stats (subscriptions, viewer refcount, groups/frames/bytes) are counted in
-		// the model, through the tagged `origin::Consumer` this broadcast is resolved
-		// from; the wire loop carries no counters.
-		if let Err(err) = Self::run_subscribe(
-			self.session.clone(),
-			&mut stream,
-			&subscribe,
-			broadcast,
-			self.priority.clone(),
-			self.version,
-		)
-		.await
-		{
-			match &err {
-				// TODO better classify WebTransport errors.
-				Error::Cancel | Error::Transport(_) => {
-					tracing::info!(%id, broadcast = %absolute, %track, "subscribed cancelled")
+	fn poll_serve(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				TrackInfoState::Decode => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let mut cx = Context::from_waker(waiter.waker());
+					let msg = ready!(stream.reader.poll_decode::<lite::Track>(&mut cx))?;
+					self.absolute = self.shared.origin.absolute(&msg.broadcast).to_owned();
+					self.track = msg.track.to_string();
+					tracing::debug!(broadcast = %self.absolute, track = %self.track, "track info requested");
+					self.state = TrackInfoState::Origin { msg };
 				}
-				err => {
-					tracing::warn!(%id, broadcast = %absolute, %track, %err, "subscribed error")
+				TrackInfoState::Origin { .. } => {
+					// The peer requested this exact path, so it has already seen an
+					// announcement for it. `request_broadcast` resolves it immediately, or
+					// falls back to an `origin::Dynamic` handler (as in SubscribeServe).
+					let origin = ready!(self.shared.poll_serving_origin(waiter));
+					let TrackInfoState::Origin { msg } = std::mem::replace(&mut self.state, TrackInfoState::Decode)
+					else {
+						unreachable!()
+					};
+					let requesting = origin.request_broadcast(&msg.broadcast).into_inner();
+					self.state = TrackInfoState::Request { msg, requesting };
+				}
+				TrackInfoState::Request { msg, requesting } => {
+					let broadcast = ready!(requesting.poll_ok(waiter))?;
+					let querying = broadcast.track(&msg.track)?.info().into_inner();
+					self.state = TrackInfoState::Query { querying };
+				}
+				TrackInfoState::Query { querying } => {
+					let info = ready!(querying.poll_ok(waiter))?;
+
+					// TRACK_INFO only flows on Lite05+ (the encode errors otherwise), where every
+					// track is timed, so the model's timescale and retention bound go on the wire
+					// verbatim.
+					let stream = self.stream.as_mut().expect("stream present");
+					stream.writer.buffer(&lite::TrackInfo {
+						priority: info.priority,
+						ordered: info.ordered,
+						latency_max: info.latency_max,
+						timescale: info.timescale,
+					})?;
+					self.state = TrackInfoState::Finish { finished: false };
+				}
+				TrackInfoState::Finish { finished } => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let mut cx = Context::from_waker(waiter.waker());
+					if !*finished {
+						ready!(stream.writer.poll_flush(&mut cx))?;
+						stream.writer.finish()?;
+						*finished = true;
+					}
+					return stream.writer.poll_closed(&mut cx);
 				}
 			}
-			stream.writer.abort(&err);
-		} else {
-			tracing::info!(%id, broadcast = %absolute, %track, "subscribed complete")
 		}
+	}
+}
 
-		Ok(())
+/// Serves one SUBSCRIBE stream: resolve the track, then stream its groups (and
+/// best-effort datagrams) until the peer FINs or the track ends.
+struct SubscribeServe<S: crate::transport::poll::Session> {
+	shared: Arc<Shared<S>>,
+	stream: Option<Stream<S, Version>>,
+	state: SubscribeState<S>,
+	// Log context, filled in after the decode.
+	id: u64,
+	absolute: crate::PathOwned,
+	track: String,
+}
+
+enum SubscribeState<S: crate::transport::poll::Session> {
+	Decode,
+	/// Resolving the split-horizon origin (waits on the peer's SETUP).
+	Origin {
+		msg: lite::Subscribe<'static>,
+	},
+	/// Resolving the broadcast (may wait on a dynamic handler).
+	Request {
+		msg: lite::Subscribe<'static>,
+		requesting: origin::Requesting,
+	},
+	/// Waiting for the model subscription to be confirmed.
+	Confirm {
+		msg: lite::Subscribe<'static>,
+		subscribing: track::Subscribing,
+	},
+	/// Streaming groups and datagrams.
+	Run(TrackRun<S>),
+	/// The track finished: draining the in-flight group streams before the FIN.
+	Drain {
+		children: PollSet<GroupServe<S>>,
+	},
+	/// FIN and wait for the acknowledgement.
+	Finish {
+		finished: bool,
+	},
+}
+
+impl<S: crate::transport::poll::Session> SubscribeServe<S> {
+	fn new(shared: Arc<Shared<S>>, stream: Stream<S, Version>) -> Self {
+		Self {
+			shared,
+			stream: Some(stream),
+			state: SubscribeState::Decode,
+			id: 0,
+			absolute: Default::default(),
+			track: Default::default(),
+		}
 	}
 
-	async fn run_subscribe(
-		session: S,
-		stream: &mut Stream<S, Version>,
-		subscribe: &lite::Subscribe<'_>,
-		broadcast: kio::Pending<origin::Requesting>,
-		priority: PriorityQueue,
-		version: Version,
-	) -> Result<(), Error> {
-		let subscription = crate::track::Subscription {
-			priority: subscribe.priority,
-			ordered: subscribe.ordered,
-			latency: crate::Latency::max(subscribe.latency_max),
-			..Bounds::from(subscribe).positions()
-		};
-
-		// Awaits the dynamic fallback if the broadcast wasn't announced; resolves
-		// immediately otherwise (including an unroutable/dropped error).
-		let broadcast = broadcast.await?;
-		let track_consumer = broadcast.track(&subscribe.track)?;
-		// One subscriber for the whole subscription: `run_track` polls its groups and its
-		// best-effort datagrams from this single cursor, so a group-only or datagram-only
-		// track opens exactly one subscription (no duplicate demand).
-		let track = track_consumer.subscribe(subscription).await?;
-
-		// Per-frame timestamps require a wire format that carries them. Lite05+ prefixes
-		// every frame with a zigzag-delta timestamp at the track's timescale; older
-		// drafts have no wire field, so `None` here means "don't emit the prefix" (the
-		// frames still carry timestamps in the model, just not on this wire).
-		let timescale = if version.has_track_stream() {
-			Some(track.info().timescale)
-		} else {
-			None
-		};
-
-		// Lite05+ accepts implicitly: no SUBSCRIBE_OK, the immutable properties live
-		// in TRACK_INFO, and the resolved range arrives as SUBSCRIBE_START/END emitted
-		// from run_track. Older drafts still acknowledge with SUBSCRIBE_OK here.
-		if !version.has_track_stream() {
-			let info = lite::SubscribeOk {
-				priority: subscribe.priority,
-				ordered: false,
-				latency_max: std::time::Duration::ZERO,
-				start_group: None,
-				end_group: None,
-			};
-			stream.writer.encode(&lite::SubscribeResponse::Ok(info)).await?;
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		match ready!(self.poll_serve(waiter)) {
+			Ok(()) => {
+				tracing::info!(id = self.id, broadcast = %self.absolute, track = %self.track, "subscribed complete");
+				Poll::Ready(Ok(()))
+			}
+			// A decode error propagates so the control loop logs it.
+			Err(err) if matches!(self.state, SubscribeState::Decode) => Poll::Ready(Err(err)),
+			Err(err) => {
+				match &err {
+					// TODO better classify WebTransport errors.
+					Error::Cancel | Error::Transport(_) => {
+						tracing::info!(id = self.id, broadcast = %self.absolute, track = %self.track, "subscribed cancelled")
+					}
+					err => {
+						tracing::warn!(id = self.id, broadcast = %self.absolute, track = %self.track, %err, "subscribed error")
+					}
+				}
+				self.stream.take().expect("stream present").writer.abort(&err);
+				Poll::Ready(Ok(()))
+			}
 		}
-
-		// Track-level subscriber priority. SUBSCRIBE_UPDATE messages broadcast new values
-		// to both run_track (so future groups inherit the new priority) and serve_group
-		// tasks (so in-flight groups update via PriorityHandle::set_track). The producer
-		// stays in run_subscribe and gets handed to run_track so the same loop that
-		// parses SUBSCRIBE_UPDATEs also fans the new priority out.
-		let track_priority_tx = kio::Producer::new(subscribe.priority);
-
-		let sub = Subscription {
-			session,
-			id: subscribe.id,
-			track_name: Arc::from(track.name()),
-			priority,
-			track_priority: track_priority_tx.consume(),
-			track_priority_seen: subscribe.priority,
-			ordered: subscribe.ordered,
-			version,
-			timescale,
-		};
-
-		// `end_group` is a serving cap, not a subscription terminator: groups with
-		// sequence > cap are held in the producer's cache until the subscriber raises
-		// the cap (or unsets it) via SUBSCRIBE_UPDATE, then served in order. Only a
-		// peer FIN actually ends the subscription. This is what lets relays pause an
-		// upstream subscription across consumer churn without tearing it down.
-		//
-		// run_track serves groups and best-effort datagrams off the one subscriber.
-		sub.run_track(
-			track,
-			Bounds::from(subscribe),
-			&mut stream.reader,
-			&mut stream.writer,
-			&track_priority_tx,
-		)
-		.await?;
-
-		stream.writer.finish()?;
-		stream.writer.closed().await
 	}
 
-	pub async fn recv_fetch(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
+	fn poll_serve(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				SubscribeState::Decode => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let mut cx = Context::from_waker(waiter.waker());
+					let msg = ready!(stream.reader.poll_decode::<lite::Subscribe>(&mut cx))?;
+
+					self.id = msg.id;
+					self.absolute = self.shared.origin.absolute(&msg.broadcast).to_owned();
+					self.track = msg.track.to_string();
+					tracing::info!(id = self.id, broadcast = %self.absolute, track = %self.track, "subscribed started");
+
+					self.state = SubscribeState::Origin { msg };
+				}
+				SubscribeState::Origin { .. } => {
+					// We just received a subscribe for this exact path, so by definition the
+					// peer has already seen an announcement for it. `request_broadcast`
+					// resolves an announced broadcast immediately; if it isn't announced it
+					// falls back to an `origin::Dynamic` handler (or resolves to an error
+					// when there is none).
+					let origin = ready!(self.shared.poll_serving_origin(waiter));
+					let SubscribeState::Origin { msg } = std::mem::replace(&mut self.state, SubscribeState::Decode)
+					else {
+						unreachable!()
+					};
+					let requesting = origin.request_broadcast(&msg.broadcast).into_inner();
+					self.state = SubscribeState::Request { msg, requesting };
+				}
+				SubscribeState::Request { requesting, .. } => {
+					// Waits for the dynamic fallback if the broadcast wasn't announced;
+					// resolves immediately otherwise (including an unroutable/dropped error).
+					let broadcast = ready!(requesting.poll_ok(waiter))?;
+					let SubscribeState::Request { msg, .. } =
+						std::mem::replace(&mut self.state, SubscribeState::Decode)
+					else {
+						unreachable!()
+					};
+
+					let subscription = crate::track::Subscription {
+						priority: msg.priority,
+						ordered: msg.ordered,
+						latency: crate::Latency::max(msg.latency_max),
+						..Bounds::from(&msg).positions()
+					};
+
+					// One subscriber for the whole subscription: the run loop polls its
+					// groups and its best-effort datagrams from this single cursor, so a
+					// group-only or datagram-only track opens exactly one subscription (no
+					// duplicate demand).
+					let track_consumer = broadcast.track(&msg.track)?;
+					let subscribing = track_consumer.subscribe(subscription).into_inner();
+					self.state = SubscribeState::Confirm { msg, subscribing };
+				}
+				SubscribeState::Confirm { subscribing, .. } => {
+					let track = ready!(subscribing.poll_ok(waiter))?;
+					let SubscribeState::Confirm { msg, .. } =
+						std::mem::replace(&mut self.state, SubscribeState::Decode)
+					else {
+						unreachable!()
+					};
+					let stream = self.stream.as_mut().expect("stream present");
+
+					// Per-frame timestamps require a wire format that carries them. Lite05+
+					// prefixes every frame with a zigzag-delta timestamp at the track's
+					// timescale; older drafts have no wire field, so `None` here means
+					// "don't emit the prefix" (the frames still carry timestamps in the
+					// model, just not on this wire).
+					let timescale = if self.shared.version.has_track_stream() {
+						Some(track.info().timescale)
+					} else {
+						None
+					};
+
+					// Lite05+ accepts implicitly: no SUBSCRIBE_OK, the immutable properties
+					// live in TRACK_INFO, and the resolved range arrives as
+					// SUBSCRIBE_START/END from the run loop. Older drafts still acknowledge
+					// with SUBSCRIBE_OK here.
+					if !self.shared.version.has_track_stream() {
+						let info = lite::SubscribeOk {
+							priority: msg.priority,
+							ordered: false,
+							latency_max: std::time::Duration::ZERO,
+							start_group: None,
+							end_group: None,
+						};
+						stream.writer.buffer(&lite::SubscribeResponse::Ok(info))?;
+					}
+
+					// Track-level subscriber priority. SUBSCRIBE_UPDATE messages broadcast
+					// new values to the run loop (so future groups inherit the new priority)
+					// and the in-flight group machines (so they update via
+					// PriorityHandle::set_track).
+					let track_priority_tx = kio::Producer::new(msg.priority);
+
+					let sub = Subscription {
+						session: self.shared.session.clone(),
+						id: msg.id,
+						track_name: Arc::from(track.name()),
+						priority: self.shared.priority.clone(),
+						track_priority: track_priority_tx.consume(),
+						track_priority_seen: msg.priority,
+						version: self.shared.version,
+						timescale,
+					};
+
+					let run = TrackRun::new(sub, track, Bounds::from(&msg), track_priority_tx);
+					self.state = SubscribeState::Run(run);
+				}
+				SubscribeState::Run(run) => {
+					let stream = self.stream.as_mut().expect("stream present");
+					match ready!(run.poll(stream, waiter))? {
+						// Peer FIN'd: they're done with this subscription. Drop any
+						// in-flight group machines (don't drain) so half-sent groups get
+						// cancelled rather than completed pointlessly.
+						TrackEnd::PeerFin => self.state = SubscribeState::Finish { finished: false },
+						// The live edge reached the boundary; SUBSCRIBE_END was already
+						// sent (or the version predates the track stream). Drain in-flight
+						// group machines, then FIN.
+						TrackEnd::Finished => {
+							let SubscribeState::Run(run) = std::mem::replace(&mut self.state, SubscribeState::Decode)
+							else {
+								unreachable!()
+							};
+							self.state = SubscribeState::Drain { children: run.children };
+						}
+					}
+				}
+				SubscribeState::Drain { children } => {
+					ready!(children.poll(waiter));
+					self.state = SubscribeState::Finish { finished: false };
+				}
+				SubscribeState::Finish { finished } => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let mut cx = Context::from_waker(waiter.waker());
+					if !*finished {
+						ready!(stream.writer.poll_flush(&mut cx))?;
+						stream.writer.finish()?;
+						*finished = true;
+					}
+					return stream.writer.poll_closed(&mut cx);
+				}
+			}
+		}
+	}
+}
+
+/// Serves one FETCH stream: a single cached group, streamed in order, then FIN.
+struct FetchServe<S: crate::transport::poll::Session> {
+	shared: Arc<Shared<S>>,
+	stream: Option<Stream<S, Version>>,
+	state: FetchState,
+	// Log context, filled in after the decode.
+	absolute: crate::PathOwned,
+	track: String,
+	group: u64,
+}
+
+enum FetchState {
+	Decode,
+	/// Resolving the split-horizon origin (waits on the peer's SETUP).
+	Origin {
+		msg: lite::Fetch<'static>,
+	},
+	/// Resolving the broadcast (may wait on a dynamic handler).
+	Request {
+		msg: lite::Fetch<'static>,
+		requesting: origin::Requesting,
+	},
+	/// Waiting for the fetched group.
+	Fetch {
+		msg: lite::Fetch<'static>,
+		fetching: track::Fetching,
+	},
+	/// Streaming the group's frames in order. The delta-timestamp baseline
+	/// resets to 0, so the first served frame's delta is its absolute timestamp
+	/// (the subscriber decodes against the same baseline).
+	Serve {
+		group: group::Consumer,
+		timescale: Option<crate::Timescale>,
+		prev_ts: u64,
+		frame: Option<frame::Consumer>,
+		chunk: Option<bytes::Bytes>,
+	},
+	/// FIN and wait for the acknowledgement.
+	Finish {
+		finished: bool,
+	},
+}
+
+impl<S: crate::transport::poll::Session> FetchServe<S> {
+	fn new(shared: Arc<Shared<S>>, stream: Stream<S, Version>) -> Result<Self, Error> {
 		// FETCH is lite-05+ only; older drafts have no dedicated FETCH stream.
-		if !self.version.has_track_stream() {
+		if !shared.version.has_track_stream() {
 			return Err(Error::UnexpectedStream);
 		}
-
-		let fetch = stream.reader.decode::<lite::Fetch>().await?;
-
-		let track = fetch.track.clone();
-		let group = fetch.group;
-		let absolute = self.origin.absolute(&fetch.broadcast).to_owned();
-
-		tracing::info!(broadcast = %absolute, %track, %group, "fetch started");
-
-		// The peer fetched this exact path, so it has already seen an announcement for it.
-		// `request_broadcast` resolves it immediately, or falls back to an `origin::Dynamic`
-		// handler (as in recv_subscribe).
-		let broadcast = self.serving_origin().await.request_broadcast(&fetch.broadcast);
-
-		if let Err(err) = Self::run_fetch(&mut stream, &fetch, broadcast, self.version).await {
-			match &err {
-				Error::Cancel | Error::Transport(_) => {
-					tracing::info!(broadcast = %absolute, %track, %group, "fetch cancelled")
-				}
-				err => tracing::warn!(broadcast = %absolute, %track, %group, %err, "fetch error"),
-			}
-			stream.writer.abort(&err);
-		} else {
-			tracing::info!(broadcast = %absolute, %track, %group, "fetch complete");
-		}
-
-		Ok(())
+		Ok(Self {
+			shared,
+			stream: Some(stream),
+			state: FetchState::Decode,
+			absolute: Default::default(),
+			track: Default::default(),
+			group: 0,
+		})
 	}
 
-	async fn run_fetch(
-		stream: &mut Stream<S, Version>,
-		fetch: &lite::Fetch<'_>,
-		broadcast: kio::Pending<origin::Requesting>,
-		version: Version,
-	) -> Result<(), Error> {
-		let broadcast = broadcast.await?;
-		let track = broadcast.track(&fetch.track)?;
-
-		let mut group = track
-			.fetch_group(
-				fetch.group,
-				group::Fetch {
-					priority: fetch.priority,
-					frame_start: fetch.start_frame,
-					..Default::default()
-				},
-			)
-			.await?;
-
-		// The response carries no header, so a short run is indistinguishable from one
-		// that started elsewhere: only serve a range we can cover exactly. `fetch_group`
-		// already positions the consumer, so this is a belt-and-braces check on a
-		// promise the wire can't restate.
-		if group.index() != fetch.start_frame {
-			return Err(Error::Lagged);
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		match ready!(self.poll_serve(waiter)) {
+			Ok(()) => {
+				tracing::info!(broadcast = %self.absolute, track = %self.track, group = %self.group, "fetch complete");
+				Poll::Ready(Ok(()))
+			}
+			// A decode error propagates so the control loop logs it.
+			Err(err) if matches!(self.state, FetchState::Decode) => Poll::Ready(Err(err)),
+			Err(err) => {
+				match &err {
+					Error::Cancel | Error::Transport(_) => {
+						tracing::info!(broadcast = %self.absolute, track = %self.track, group = %self.group, "fetch cancelled")
+					}
+					err => {
+						tracing::warn!(broadcast = %self.absolute, track = %self.track, group = %self.group, %err, "fetch error")
+					}
+				}
+				self.stream.take().expect("stream present").writer.abort(&err);
+				Poll::Ready(Ok(()))
+			}
 		}
-		// The end is a serving cap only: the cached group runs to the end of the group
-		// so it stays usable for anyone else (see `group::Fetch::frame_start`).
-		group.end_at(fetch.end_frame);
+	}
 
-		// FETCH is gated to lite-05+, which learned the track timescale via TRACK_INFO.
-		let timescale = if version.has_track_stream() {
-			Some(group.timescale())
-		} else {
-			None
-		};
+	fn poll_serve(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				FetchState::Decode => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let mut cx = Context::from_waker(waiter.waker());
+					let msg = ready!(stream.reader.poll_decode::<lite::Fetch>(&mut cx))?;
 
-		// Stream every frame in order. The delta-timestamp baseline resets to 0, so the
-		// first served frame's delta is its absolute timestamp (the subscriber decodes
-		// against the same baseline).
-		let mut prev_ts: u64 = 0;
-		while let Some(mut frame) = group.next_frame().await? {
-			write_fetch_frame(&mut stream.writer, &mut frame, timescale, &mut prev_ts).await?;
+					self.absolute = self.shared.origin.absolute(&msg.broadcast).to_owned();
+					self.track = msg.track.to_string();
+					self.group = msg.group;
+					tracing::info!(broadcast = %self.absolute, track = %self.track, group = %self.group, "fetch started");
+
+					self.state = FetchState::Origin { msg };
+				}
+				FetchState::Origin { .. } => {
+					// The peer fetched this exact path, so it has already seen an
+					// announcement for it. `request_broadcast` resolves it immediately, or
+					// falls back to an `origin::Dynamic` handler (as in SubscribeServe).
+					let origin = ready!(self.shared.poll_serving_origin(waiter));
+					let FetchState::Origin { msg } = std::mem::replace(&mut self.state, FetchState::Decode) else {
+						unreachable!()
+					};
+					let requesting = origin.request_broadcast(&msg.broadcast).into_inner();
+					self.state = FetchState::Request { msg, requesting };
+				}
+				FetchState::Request { requesting, .. } => {
+					let broadcast = ready!(requesting.poll_ok(waiter))?;
+					let FetchState::Request { msg, .. } = std::mem::replace(&mut self.state, FetchState::Decode) else {
+						unreachable!()
+					};
+					let track = broadcast.track(&msg.track)?;
+					let fetching = track
+						.fetch_group(
+							msg.group,
+							group::Fetch {
+								priority: msg.priority,
+								frame_start: msg.start_frame,
+								..Default::default()
+							},
+						)
+						.into_inner();
+					self.state = FetchState::Fetch { msg, fetching };
+				}
+				FetchState::Fetch { msg, fetching } => {
+					let mut group = ready!(kio::Pollable::poll(fetching, waiter))?;
+
+					// The response carries no header, so a short run is indistinguishable
+					// from one that started elsewhere: only serve a range we can cover
+					// exactly. `fetch_group` already positions the consumer, so this is a
+					// belt-and-braces check on a promise the wire can't restate.
+					if group.index() != msg.start_frame {
+						return Poll::Ready(Err(Error::Lagged));
+					}
+					// The end is a serving cap only: the cached group runs to the end of
+					// the group so it stays usable for anyone else (see
+					// `group::Fetch::frame_start`).
+					group.end_at(msg.end_frame);
+
+					// FETCH is gated to lite-05+, which learned the track timescale via
+					// TRACK_INFO.
+					let timescale = if self.shared.version.has_track_stream() {
+						Some(group.timescale())
+					} else {
+						None
+					};
+
+					self.state = FetchState::Serve {
+						group,
+						timescale,
+						prev_ts: 0,
+						frame: None,
+						chunk: None,
+					};
+				}
+				FetchState::Serve {
+					group,
+					timescale,
+					prev_ts,
+					frame,
+					chunk,
+				} => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let mut cx = Context::from_waker(waiter.waker());
+					loop {
+						ready!(stream.writer.poll_flush(&mut cx))?;
+						if let Some(pending) = chunk {
+							ready!(stream.writer.poll_write(&mut cx, pending))?;
+							if !bytes::Buf::has_remaining(pending) {
+								*chunk = None;
+							}
+						} else if let Some(pending) = frame {
+							match ready!(pending.poll_read_chunk(waiter))? {
+								Some(next) => *chunk = Some(next),
+								None => *frame = None,
+							}
+						} else {
+							match ready!(group.poll_next_frame(waiter))? {
+								Some(next) => {
+									buffer_frame_timing(&mut stream.writer, &next, *timescale, prev_ts)?;
+									stream.writer.buffer(&next.size)?;
+									*frame = Some(next);
+								}
+								None => break,
+							}
+						}
+					}
+					self.state = FetchState::Finish { finished: false };
+				}
+				FetchState::Finish { finished } => {
+					let stream = self.stream.as_mut().expect("stream present");
+					let mut cx = Context::from_waker(waiter.waker());
+					if !*finished {
+						ready!(stream.writer.poll_flush(&mut cx))?;
+						stream.writer.finish()?;
+						*finished = true;
+					}
+					return stream.writer.poll_closed(&mut cx);
+				}
+			}
 		}
-
-		stream.writer.finish()?;
-		stream.writer.closed().await
 	}
 }
 
@@ -1844,12 +2286,7 @@ mod announce_test {
 		let route = consumer.route();
 		let demand = consumer.demand();
 
-		let cost = Publisher::<crate::lite::test_transport::SinkSession>::outgoing_cost(
-			Version::Lite06Wip,
-			&demand,
-			&route,
-			false,
-		);
+		let cost = outgoing_cost(Version::Lite06Wip, &demand, &route, false);
 		assert_eq!(cost, lite::RouteCost(broadcast::MAX_COST));
 
 		let mut buf = Vec::new();
@@ -1880,12 +2317,7 @@ mod announce_test {
 		let _reader = track.consume();
 		assert!(demand.is_used(), "the consumed track should register demand");
 
-		let cost = Publisher::<crate::lite::test_transport::SinkSession>::outgoing_cost(
-			Version::Lite06Wip,
-			&demand,
-			&route,
-			true,
-		);
+		let cost = outgoing_cost(Version::Lite06Wip, &demand, &route, true);
 		assert_eq!(cost, lite::RouteCost(broadcast::DRAIN_COST));
 
 		// A drain that arrived over the wire propagates through a carrying relay:
@@ -1897,28 +2329,18 @@ mod announce_test {
 			.set_route(broadcast::Route::announced().with_cost(forwarded))
 			.unwrap();
 		let route = consumer.route();
-		let cost = Publisher::<crate::lite::test_transport::SinkSession>::outgoing_cost(
-			Version::Lite06Wip,
-			&demand,
-			&route,
-			true,
-		);
+		let cost = outgoing_cost(Version::Lite06Wip, &demand, &route, true);
 		assert_eq!(cost, lite::RouteCost(broadcast::DRAIN_COST));
 
 		// A healthy serving route with demand still gets the carrying discount.
 		producer.set_route(broadcast::Route::announced().with_cost(7)).unwrap();
 		let route = consumer.route();
-		let cost = Publisher::<crate::lite::test_transport::SinkSession>::outgoing_cost(
-			Version::Lite06Wip,
-			&demand,
-			&route,
-			true,
-		);
+		let cost = outgoing_cost(Version::Lite06Wip, &demand, &route, true);
 		assert_eq!(cost, lite::RouteCost(0));
 	}
 }
 
-/// Encode the per-frame timing prefix when the track advertises a timescale:
+/// Buffer the per-frame timing prefix when the track advertises a timescale:
 /// `[zigzag-delta timestamp]` (the lite-05 FRAME format). With `None` the field is
 /// omitted entirely, saving the bytes on tracks where timing isn't meaningful
 /// (catalogs, control channels, IETF transport).
@@ -1927,7 +2349,7 @@ mod announce_test {
 /// model layer (`group::Producer::create_frame`) already converted the timestamp
 /// into the track timescale, so its raw value goes straight onto the wire. Mirrors
 /// the decode in the subscriber's `run_group`.
-async fn encode_frame_timing<W: crate::transport::poll::SendStream>(
+fn buffer_frame_timing<W: crate::transport::poll::SendStream>(
 	writer: &mut Writer<W, Version>,
 	frame: &frame::Consumer,
 	timescale: Option<crate::Timescale>,
@@ -1938,14 +2360,14 @@ async fn encode_frame_timing<W: crate::transport::poll::SendStream>(
 	}
 
 	let ts = frame.timestamp.value();
-	encode_zigzag_delta(writer, ts, prev_ts).await?;
+	buffer_zigzag_delta(writer, ts, prev_ts)?;
 
 	Ok(())
 }
 
-/// Encode `curr` as a zigzag-mapped varint delta against `*prev`, then advance
+/// Buffer `curr` as a zigzag-mapped varint delta against `*prev`, then advance
 /// `*prev` to `curr`.
-async fn encode_zigzag_delta<W: crate::transport::poll::SendStream>(
+fn buffer_zigzag_delta<W: crate::transport::poll::SendStream>(
 	writer: &mut Writer<W, Version>,
 	curr: u64,
 	prev: &mut u64,
@@ -1954,29 +2376,8 @@ async fn encode_zigzag_delta<W: crate::transport::poll::SendStream>(
 		.try_into()
 		.map_err(|_| Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
 	let zz = crate::coding::VarInt::from_zigzag(delta).map_err(crate::coding::EncodeError::from)?;
-	writer.encode(&zz).await?;
+	writer.buffer(&zz)?;
 	*prev = curr;
-	Ok(())
-}
-
-/// Write one frame to a fetch stream in the lite wire format: the optional timing
-/// prefix (see [`encode_frame_timing`]), the size, then the payload. Mirrors the
-/// per-frame encoding in [`Subscription::serve_frame`] without the priority
-/// machinery, since a one-shot fetch carries a single static priority set on the
-/// stream up front.
-async fn write_fetch_frame<W: crate::transport::poll::SendStream>(
-	writer: &mut Writer<W, Version>,
-	frame: &mut frame::Consumer,
-	timescale: Option<crate::Timescale>,
-	prev_ts: &mut u64,
-) -> Result<(), Error> {
-	encode_frame_timing(writer, frame, timescale, prev_ts).await?;
-
-	writer.encode(&frame.size).await?;
-	while let Some(chunk) = frame.read_chunk().await? {
-		writer.write_chunk(chunk).await?;
-	}
-
 	Ok(())
 }
 
@@ -2173,237 +2574,6 @@ struct Subscription<S: crate::transport::poll::Session> {
 }
 
 impl<S: crate::transport::poll::Session> Subscription<S> {
-	async fn run_track(
-		mut self,
-		mut track: track::Subscriber,
-		bounds: Bounds,
-		reader: &mut crate::coding::Reader<S::RecvStream, Version>,
-		writer: &mut Writer<S::SendStream, Version>,
-		track_priority_tx: &kio::Producer<u8>,
-	) -> Result<(), Error> {
-		let mut tasks: FuturesUnordered<MaybeSendBox<'static, ()>> = FuturesUnordered::new();
-
-		// Start the consumer at the specified sequence, otherwise start at the latest group.
-		if let Some(start_group) = bounds.start_group.or_else(|| track.latest()) {
-			track.start_at(start_group);
-		}
-
-		// Apply the initial cap from the original Subscribe. Subsequent updates
-		// flow through the SubscribeUpdate select arm below.
-		track.end_at(bounds.end_group);
-
-		// Frame bounds qualify the start and end group only; everything in between is
-		// served whole. Each is `(group, frame)`, or `None` for no offset at all.
-		let mut start_frame = bounds.start_frame();
-		let mut end_frame = bounds.end_frame();
-
-		// Lite05+ resolves the range on the Subscribe Stream itself: SUBSCRIBE_START
-		// once the first group is known, SUBSCRIBE_END as soon as the track declares its
-		// exclusive final sequence (which may be ahead of the live edge).
-		let emit_range = self.version.has_track_stream();
-		let mut start_sent = false;
-		let mut end_sent = false;
-
-		// Serve datagrams off this same subscriber, but only on lite-05 over a datagram-capable
-		// transport (qmux/WebSocket/TCP/UDS report size 0). No group fallback: otherwise off.
-		let datagrams = self.version.has_datagrams() && self.session.max_datagram_size() > 0;
-
-		// Transient one-at-a-time value; the padding is never held in bulk (see `Recv`).
-		#[allow(clippy::large_enum_variant)]
-		enum Event {
-			Recv(Result<Recv, Error>),
-			Update(Result<Option<lite::SubscribeUpdate>, Error>),
-		}
-
-		loop {
-			let event = {
-				let emit_boundary = emit_range && !end_sent;
-				kio::wait(|waiter| {
-					// Drive in-flight group futures; completions just drop.
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					while let Poll::Ready(Some(())) = tasks.poll_next_unpin(&mut cx) {}
-
-					// Control first: SUBSCRIBE_UPDATE/FIN messages are rare, so they can't
-					// starve the data path, while a deep group backlog polled first could
-					// defer an unsubscribe or priority change indefinitely. Partial
-					// message bytes persist in the reader's buffer across turns.
-					if let Poll::Ready(upd) = reader.poll_decode_maybe::<lite::SubscribeUpdate>(&mut cx) {
-						return Poll::Ready(Event::Update(upd));
-					}
-					// One cursor drives the whole subscription: poll the cap-aware arrival-order
-					// group and, when enabled, the next best-effort datagram. Groups are polled
-					// first so a datagram burst can't starve them; datagrams flow whenever no
-					// group is ready (including while groups are parked above the cap).
-					if let Poll::Ready(res) = poll_recv_next(&mut track, datagrams, emit_boundary, waiter) {
-						return Poll::Ready(Event::Recv(res));
-					}
-					Poll::Pending
-				})
-				.await
-			};
-
-			match event {
-				Event::Recv(res) => match res? {
-					Recv::Group(mut group) => {
-						let sequence = group.sequence;
-						if !position_group(&mut group, start_frame, end_frame) {
-							// Its head is gone, and this subscriber didn't ask for a
-							// partial group. Skip it rather than open a stream that can
-							// only be reset; the next servable group resolves the start.
-							tracing::debug!(subscribe = self.id, track = %self.track_name, sequence, "skipping group with a missing head");
-							continue;
-						}
-						if emit_range && !start_sent {
-							start_sent = true;
-							// Only the group: the subscriber derives the start frame from
-							// its own request (see `lite::SubscribeStart`).
-							writer
-								.encode(&lite::SubscribeResponse::Start(lite::SubscribeStart {
-									group: sequence,
-								}))
-								.await?;
-							// SUBSCRIBE_OK is an implicit drop of everything below the
-							// resolved start (the subscriber records it as a permanent
-							// miss), so a lower group arriving late must not be served
-							// after all. A widening SUBSCRIBE_UPDATE re-lowers the floor,
-							// renegotiating the resolved start along with the demand.
-							track.start_at(sequence);
-						}
-						self.queue_serve(group, &mut tasks);
-					}
-					Recv::Datagram(datagram) => self.serve_datagram(datagram),
-					Recv::Boundary(group) => {
-						// The track declared its exclusive final sequence. Forward it now,
-						// even if trailing groups (below `group`) are still in flight, then
-						// keep serving them until the live edge reaches the boundary.
-						end_sent = true;
-						writer
-							.encode(&lite::SubscribeResponse::End(lite::SubscribeEnd { group }))
-							.await?;
-					}
-					Recv::Finished => {
-						// The live edge reached the boundary; SUBSCRIBE_END was already sent
-						// (or the version predates the track stream). Drain in-flight group
-						// tasks and FIN by returning.
-						while tasks.next().await.is_some() {}
-						return Ok(());
-					}
-				},
-				Event::Update(upd) => {
-					let Some(upd) = upd? else {
-						// Peer FIN'd. They're done with this subscription. Drop any
-						// in-flight serve_group tasks (don't drain) so half-sent
-						// groups get cancelled rather than completed pointlessly.
-						return Ok(());
-					};
-					if let Ok(mut value) = track_priority_tx.write() {
-						*value = upd.priority;
-					}
-					// Re-rank the backlog too, not just the groups queued from here on.
-					// The preference is about which of the groups we are holding to send
-					// first, so leaving the queued ones on the old direction would let
-					// every new group outrank exactly the ones the subscriber just asked
-					// to receive first, starving them until they expire.
-					if self.ordered != upd.ordered {
-						self.ordered = upd.ordered;
-						self.priority.set_ordered(self.id, self.ordered);
-					}
-					// Feed the full update into the model subscriber so the producer's
-					// aggregate reflects it (and a relay re-forwards it upstream).
-					let bounds = Bounds::from(&upd);
-					let _ = track.update(crate::track::Subscription {
-						priority: upd.priority,
-						ordered: upd.ordered,
-						latency: crate::Latency::max(upd.latency_max),
-						..bounds.positions()
-					});
-					if let Some(start_group) = upd.start_group {
-						track.start_at(start_group);
-					}
-					track.end_at(upd.end_group);
-					start_frame = bounds.start_frame();
-					end_frame = bounds.end_frame();
-				}
-			}
-		}
-	}
-
-	fn queue_serve(&mut self, group: group::Consumer, tasks: &mut FuturesUnordered<MaybeSendBox<'static, ()>>) {
-		let sequence = group.sequence;
-		let frame_start = group.index();
-		tracing::debug!(subscribe = self.id, track = %self.track_name, sequence, "serving group");
-
-		// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
-		let current_priority = self.track_priority_current();
-		// The subscribe id scopes the group tie-break: one queue serves every
-		// subscription on the session, and only groups of the same one may be
-		// ranked against each other by sequence.
-		let priority = match self.ordered {
-			true => Priority::ordered(current_priority, self.id, sequence),
-			false => Priority::new(current_priority, self.id, sequence),
-		};
-		let handle = self.priority.insert(priority);
-		let fut = self.clone().serve_group(sequence, frame_start, handle, group);
-		tasks.push(fut.map(|_| ()).maybe_boxed());
-	}
-
-	async fn serve_group(
-		mut self,
-		sequence: u64,
-		frame_start: u64,
-		mut priority: PriorityHandle,
-		mut group: group::Consumer,
-	) -> Result<(), Error> {
-		let msg = lite::Group {
-			subscribe: self.id,
-			sequence,
-			frame_start,
-		};
-		let stream = self.session.open_uni().await.map_err(Error::from_transport)?;
-		let mut stream = Writer::new(stream, self.version);
-
-		if let Err(err) = self.write_group(&mut stream, &msg, &mut priority, &mut group).await {
-			// Reset with the real reason (Old, Lagged, Evicted, ...) so the subscriber can
-			// tell a truncated group from a routine cancel. Without this the Writer's Drop
-			// fallback reports every failure as Cancel.
-			stream.abort(&err);
-			return Err(err);
-		}
-
-		// Consume the writer: close() waits for the peer to acknowledge everything,
-		// and taking ownership disarms the Drop fallback that would otherwise reset
-		// the finished stream with a spurious Cancel.
-		stream.close().await?;
-
-		tracing::debug!(sequence, "finished group");
-
-		Ok(())
-	}
-
-	/// Write the group header and every frame, leaving the stream open for the caller to
-	/// finish or abort.
-	async fn write_group(
-		&mut self,
-		stream: &mut Writer<S::SendStream, Version>,
-		msg: &lite::Group,
-		priority: &mut PriorityHandle,
-		group: &mut group::Consumer,
-	) -> Result<(), Error> {
-		stream.set_priority(priority.send_order());
-		stream.encode(&lite::DataType::Group).await?;
-		stream.encode(msg).await?;
-
-		// Lite05+ delta-encodes per-frame timestamps within the group. The first
-		// frame's delta is absolute (against an implicit prev value of 0), every
-		// subsequent delta is signed against the previous frame.
-		let mut prev_ts: u64 = 0;
-		while let Some(frame) = self.next_frame(stream, priority, group).await? {
-			self.serve_frame(stream, priority, frame, &mut prev_ts).await?;
-		}
-
-		Ok(())
-	}
-
 	/// Send one datagram best-effort over a QUIC datagram (lite-05 §6.4).
 	///
 	/// The datagram is dropped (there is no group fallback) if the encoded body doesn't fit the
@@ -2435,155 +2605,408 @@ impl<S: crate::transport::poll::Session> Subscription<S> {
 		let _ = self.session.send_datagram(&body);
 	}
 
-	/// Send one frame: the size, then the payload streamed chunk-by-chunk so we
-	/// never buffer the whole thing.
-	async fn serve_frame(
-		&mut self,
-		stream: &mut Writer<S::SendStream, Version>,
-		priority: &mut PriorityHandle,
-		mut frame: frame::Consumer,
-		prev_ts: &mut u64,
-	) -> Result<(), Error> {
-		encode_frame_timing(stream, &frame, self.timescale, prev_ts).await?;
-
-		stream.encode(&frame.size).await?;
-
-		while let Some(chunk) = self.read_chunk(stream, priority, &mut frame).await? {
-			self.write_chunk(stream, priority, chunk).await?;
-		}
-
-		Ok(())
-	}
-
-	/// Await the next frame in the group, applying any priority changes that
-	/// arrive meanwhile. Errors with [`Error::Cancel`] if the peer closes first.
-	async fn next_frame(
-		&mut self,
-		stream: &mut Writer<S::SendStream, Version>,
-		priority: &mut PriorityHandle,
-		group: &mut group::Consumer,
-	) -> Result<Option<frame::Consumer>, Error> {
-		Self::serve_step(
-			stream,
-			priority,
-			&self.track_priority,
-			&mut self.track_priority_seen,
-			|waiter| group.poll_next_frame(waiter),
-		)
-		.await
-	}
-
-	/// Await the next chunk of `frame`, applying priority changes meanwhile.
-	async fn read_chunk(
-		&mut self,
-		stream: &mut Writer<S::SendStream, Version>,
-		priority: &mut PriorityHandle,
-		frame: &mut frame::Consumer,
-	) -> Result<Option<bytes::Bytes>, Error> {
-		Self::serve_step(
-			stream,
-			priority,
-			&self.track_priority,
-			&mut self.track_priority_seen,
-			|waiter| frame.poll_read_chunk(waiter),
-		)
-		.await
-	}
-
-	/// Poll `work` to completion while applying queue and SUBSCRIBE_UPDATE priority
-	/// changes to the stream. Errors with [`Error::Cancel`] if the peer closes first.
-	async fn serve_step<T>(
-		stream: &mut Writer<S::SendStream, Version>,
-		priority: &mut PriorityHandle,
-		track_priority: &kio::Consumer<u8>,
-		track_priority_seen: &mut u8,
-		mut work: impl FnMut(&kio::Waiter) -> Poll<Result<T, Error>>,
-	) -> Result<T, Error> {
-		enum Event<T> {
-			Closed,
-			Work(Result<T, Error>),
-			/// The handle's rank changed; the new value is re-read via
-			/// [`PriorityHandle::send_order`] when handled.
-			Priority,
-			TrackPriority(u8),
-		}
-
-		loop {
-			let event = {
-				let seen = *track_priority_seen;
-				kio::wait(|waiter| {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					if stream.poll_closed(&mut cx).is_ready() {
-						return Poll::Ready(Event::Closed);
-					}
-					if let Poll::Ready(res) = work(waiter) {
-						return Poll::Ready(Event::Work(res));
-					}
-					if priority.poll_next(waiter).is_ready() {
-						return Poll::Ready(Event::Priority);
-					}
-					// A dropped producer just disables this arm, like the queue arm above.
-					match track_priority.poll(waiter, |value| {
-						if **value != seen {
-							Poll::Ready(**value)
-						} else {
-							Poll::Pending
-						}
-					}) {
-						Poll::Ready(Ok(value)) => Poll::Ready(Event::TrackPriority(value)),
-						Poll::Ready(Err(_)) | Poll::Pending => Poll::Pending,
-					}
-				})
-				.await
-			};
-
-			match event {
-				Event::Closed => return Err(Error::Cancel),
-				Event::Work(res) => return res,
-				Event::Priority => stream.set_priority(priority.send_order()),
-				Event::TrackPriority(new_track) => {
-					*track_priority_seen = new_track;
-					priority.set_track(new_track);
-				}
-			}
-		}
-	}
-
 	/// Read the latest SUBSCRIBE_UPDATE track priority, marking it seen.
 	fn track_priority_current(&mut self) -> u8 {
 		self.track_priority_seen = *self.track_priority.read();
 		self.track_priority_seen
 	}
 
-	/// Write a whole chunk, applying priority changes between partial writes.
-	async fn write_chunk(
-		&mut self,
-		stream: &mut Writer<S::SendStream, Version>,
-		priority: &mut PriorityHandle,
-		mut chunk: bytes::Bytes,
+	/// Test shim: drive one group stream like the old `serve_group`, surfacing the
+	/// error the machine otherwise swallows after aborting the stream.
+	#[cfg(test)]
+	async fn serve_group(
+		self,
+		sequence: u64,
+		frame_start: u64,
+		priority: PriorityHandle,
+		group: group::Consumer,
 	) -> Result<(), Error> {
-		while chunk.has_remaining() {
-			self.apply_priority(stream, priority);
-			stream.write(&mut chunk).await?;
+		let mut serve = Box::new(GroupServe::new(self, sequence, frame_start, priority, group));
+		kio::wait(move |waiter| serve.poll_serve(waiter)).await
+	}
+}
+
+/// What ended a subscription's run loop.
+enum TrackEnd {
+	/// The peer FIN'd the subscribe stream: drop the in-flight group machines so
+	/// half-sent groups get cancelled rather than completed pointlessly.
+	PeerFin,
+	/// The live edge reached the track's boundary: drain the in-flight group
+	/// machines, then FIN.
+	Finished,
+}
+
+/// A subscription's run loop: one subscriber cursor serving groups, datagrams,
+/// and SUBSCRIBE_UPDATE messages, with an in-flight group machine per group.
+struct TrackRun<S: crate::transport::poll::Session> {
+	ctx: Subscription<S>,
+	track: track::Subscriber,
+	/// Broadcasts SUBSCRIBE_UPDATE priorities to the in-flight group machines.
+	track_priority_tx: kio::Producer<u8>,
+	// Frame bounds qualify the start and end group only; everything in between is
+	// served whole. Each is `(group, frame)`, or `None` for no offset at all.
+	start_frame: Option<(u64, u64)>,
+	end_frame: Option<(u64, u64)>,
+	// Lite05+ resolves the range on the Subscribe Stream itself: SUBSCRIBE_START
+	// once the first group is known, SUBSCRIBE_END as soon as the track declares its
+	// exclusive final sequence (which may be ahead of the live edge).
+	emit_range: bool,
+	start_sent: bool,
+	end_sent: bool,
+	// Serve datagrams off this same subscriber, but only on lite-05 over a
+	// datagram-capable transport (qmux/WebSocket/TCP/UDS report size 0). No group
+	// fallback: otherwise off.
+	datagrams: bool,
+	children: PollSet<GroupServe<S>>,
+}
+
+impl<S: crate::transport::poll::Session> TrackRun<S> {
+	fn new(
+		ctx: Subscription<S>,
+		mut track: track::Subscriber,
+		bounds: Bounds,
+		track_priority_tx: kio::Producer<u8>,
+	) -> Self {
+		// Start the consumer at the specified sequence, otherwise start at the latest group.
+		if let Some(start_group) = bounds.start_group.or_else(|| track.latest()) {
+			track.start_at(start_group);
 		}
-		Ok(())
+
+		// Apply the initial cap from the original Subscribe. Subsequent updates
+		// flow through the SUBSCRIBE_UPDATE arm below.
+		track.end_at(bounds.end_group);
+
+		let emit_range = ctx.version.has_track_stream();
+		let datagrams = ctx.version.has_datagrams() && ctx.session.max_datagram_size() > 0;
+
+		Self {
+			start_frame: bounds.start_frame(),
+			end_frame: bounds.end_frame(),
+			ctx,
+			track,
+			track_priority_tx,
+			emit_range,
+			start_sent: false,
+			end_sent: false,
+			datagrams,
+			children: PollSet::new(),
+		}
 	}
 
-	fn apply_priority(&mut self, stream: &mut Writer<S::SendStream, Version>, priority: &mut PriorityHandle) {
-		let track_priority = self.track_priority_current();
-		priority.set_track(track_priority);
-		stream.set_priority(priority.send_order());
+	/// `end_group` is a serving cap, not a subscription terminator: groups with
+	/// sequence > cap are held in the producer's cache until the subscriber raises
+	/// the cap (or unsets it) via SUBSCRIBE_UPDATE, then served in order. Only a
+	/// peer FIN actually ends the subscription. This is what lets relays pause an
+	/// upstream subscription across consumer churn without tearing it down.
+	fn poll(&mut self, stream: &mut Stream<S, Version>, waiter: &kio::Waiter) -> Poll<Result<TrackEnd, Error>> {
+		let mut cx = Context::from_waker(waiter.waker());
+		loop {
+			// Deliver the buffered range messages before selecting more work.
+			ready!(stream.writer.poll_flush(&mut cx))?;
+
+			// Drive the in-flight group machines; completions just retire.
+			let _ = self.children.poll(waiter);
+
+			// Control first: SUBSCRIBE_UPDATE/FIN messages are rare, so they can't
+			// starve the data path, while a deep group backlog polled first could
+			// defer an unsubscribe or priority change indefinitely. Partial message
+			// bytes persist in the reader's buffer across turns.
+			if let Poll::Ready(upd) = stream.reader.poll_decode_maybe::<lite::SubscribeUpdate>(&mut cx) {
+				let Some(upd) = upd? else {
+					return Poll::Ready(Ok(TrackEnd::PeerFin));
+				};
+				if let Ok(mut value) = self.track_priority_tx.write() {
+					*value = upd.priority;
+				}
+				// Feed the full update into the model subscriber so the producer's
+				// aggregate reflects it (and a relay re-forwards it upstream).
+				let bounds = Bounds::from(&upd);
+				let _ = self.track.update(crate::track::Subscription {
+					priority: upd.priority,
+					ordered: upd.ordered,
+					latency: crate::Latency::max(upd.latency_max),
+					..bounds.positions()
+				});
+				if let Some(start_group) = upd.start_group {
+					self.track.start_at(start_group);
+				}
+				self.track.end_at(upd.end_group);
+				self.start_frame = bounds.start_frame();
+				self.end_frame = bounds.end_frame();
+				continue;
+			}
+
+			// One cursor drives the whole subscription: poll the cap-aware next group and,
+			// when enabled, the next best-effort datagram. Groups are polled first so a
+			// datagram burst can't starve them; datagrams flow whenever no group is ready
+			// (including while groups are paused above the cap).
+			let emit_boundary = self.emit_range && !self.end_sent;
+			if let Poll::Ready(res) = poll_recv_next(&mut self.track, self.datagrams, emit_boundary, waiter) {
+				match res? {
+					Recv::Group(mut group) => {
+						let sequence = group.sequence;
+						if !position_group(&mut group, self.start_frame, self.end_frame) {
+							// Its head is gone, and this subscriber didn't ask for a
+							// partial group. Skip it rather than open a stream that can
+							// only be reset; the next servable group resolves the start.
+							tracing::debug!(subscribe = self.ctx.id, track = %self.ctx.track_name, sequence, "skipping group with a missing head");
+							continue;
+						}
+						if self.emit_range && !self.start_sent {
+							self.start_sent = true;
+							// Only the group: the subscriber derives the start frame from
+							// its own request (see `lite::SubscribeStart`).
+							stream
+								.writer
+								.buffer(&lite::SubscribeResponse::Start(lite::SubscribeStart {
+									group: sequence,
+								}))?;
+							// SUBSCRIBE_OK is an implicit drop of everything below the
+							// resolved start (the subscriber records it as a permanent
+							// miss), so a lower group arriving late must not be served
+							// after all. A widening SUBSCRIBE_UPDATE re-lowers the floor,
+							// renegotiating the resolved start along with the demand.
+							self.track.start_at(sequence);
+						}
+
+						let frame_start = group.index();
+						tracing::debug!(subscribe = self.ctx.id, track = %self.ctx.track_name, sequence, "serving group");
+
+						// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
+						let current_priority = self.ctx.track_priority_current();
+						let handle = self.ctx.priority.insert(Priority::new(current_priority, sequence));
+						self.children
+							.push(GroupServe::new(self.ctx.clone(), sequence, frame_start, handle, group));
+					}
+					Recv::Datagram(datagram) => self.ctx.serve_datagram(datagram),
+					Recv::Boundary(group) => {
+						// The track declared its exclusive final sequence. Forward it now,
+						// even if trailing groups (below `group`) are still in flight, then
+						// keep serving them until the live edge reaches the boundary.
+						self.end_sent = true;
+						stream
+							.writer
+							.buffer(&lite::SubscribeResponse::End(lite::SubscribeEnd { group }))?;
+					}
+					Recv::Finished => return Poll::Ready(Ok(TrackEnd::Finished)),
+				}
+				continue;
+			}
+
+			return Poll::Pending;
+		}
+	}
+}
+
+/// Serves one group on its own unidirectional stream: the header, then every
+/// frame, applying queue and SUBSCRIBE_UPDATE priority changes as they land.
+struct GroupServe<S: crate::transport::poll::Session> {
+	ctx: Subscription<S>,
+	priority: PriorityHandle,
+	group: group::Consumer,
+	sequence: u64,
+	frame_start: u64,
+	// Lite05+ delta-encodes per-frame timestamps within the group. The first
+	// frame's delta is absolute (against an implicit prev value of 0), every
+	// subsequent delta is signed against the previous frame.
+	prev_ts: u64,
+	state: GroupState<S>,
+}
+
+enum GroupState<S: crate::transport::poll::Session> {
+	/// Waiting for stream credit on this machine's own session handle.
+	Open,
+	/// Streaming frames: the write buffer drains first, then the pending chunk,
+	/// then the pending frame, then the next frame.
+	Serve {
+		writer: Writer<S::SendStream, Version>,
+		frame: Option<frame::Consumer>,
+		chunk: Option<bytes::Bytes>,
+	},
+	/// Every frame is written and the FIN sent: wait for the acknowledgement so a
+	/// late cancel can still reset the stream.
+	Closed {
+		writer: Writer<S::SendStream, Version>,
+	},
+	Done,
+}
+
+impl<S: crate::transport::poll::Session> GroupServe<S> {
+	fn new(
+		ctx: Subscription<S>,
+		sequence: u64,
+		frame_start: u64,
+		priority: PriorityHandle,
+		group: group::Consumer,
+	) -> Self {
+		Self {
+			ctx,
+			priority,
+			group,
+			sequence,
+			frame_start,
+			prev_ts: 0,
+			state: GroupState::Open,
+		}
+	}
+
+	/// Serve the group, aborting the stream with the real reason (Old, Lagged,
+	/// Evicted, ...) on failure so the subscriber can tell a truncated group from
+	/// a routine cancel. Without this the Writer's Drop fallback would report
+	/// every failure as Cancel.
+	fn poll_serve(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				GroupState::Open => {
+					let mut cx = Context::from_waker(waiter.waker());
+					let stream = match ready!(self.ctx.session.poll_open_uni(&mut cx)) {
+						Ok(stream) => stream,
+						Err(err) => {
+							self.state = GroupState::Done;
+							return Poll::Ready(Err(Error::from_transport(err)));
+						}
+					};
+					let mut writer = Writer::new(stream, self.ctx.version);
+					writer.set_priority(self.priority.current());
+
+					let msg = lite::Group {
+						subscribe: self.ctx.id,
+						sequence: self.sequence,
+						frame_start: self.frame_start,
+					};
+					if let Err(err) = writer.buffer(&lite::DataType::Group).and_then(|()| writer.buffer(&msg)) {
+						self.state = GroupState::Done;
+						writer.abort(&err);
+						return Poll::Ready(Err(err));
+					}
+					self.state = GroupState::Serve {
+						writer,
+						frame: None,
+						chunk: None,
+					};
+				}
+				GroupState::Serve { writer, frame, chunk } => {
+					let mut cx = Context::from_waker(waiter.waker());
+
+					// Queue and SUBSCRIBE_UPDATE priority changes apply on every pass,
+					// whatever the write pipeline is blocked on.
+					while let Poll::Ready(new_pri) = self.priority.poll_next(waiter) {
+						writer.set_priority(new_pri);
+					}
+					let seen = self.ctx.track_priority_seen;
+					// A dropped producer just disables this arm, like the queue arm above.
+					if let Poll::Ready(Ok(value)) = self.ctx.track_priority.poll(waiter, |value| {
+						if **value != seen {
+							Poll::Ready(**value)
+						} else {
+							Poll::Pending
+						}
+					}) {
+						self.ctx.track_priority_seen = value;
+						self.priority.set_track(value);
+						writer.set_priority(self.priority.current());
+					}
+
+					let outcome = 'serve: {
+						// The peer closing first cancels the group.
+						if writer.poll_closed(&mut cx).is_ready() {
+							break 'serve Err(Error::Cancel);
+						}
+						loop {
+							match writer.poll_flush(&mut cx) {
+								Poll::Ready(Ok(())) => {}
+								Poll::Ready(Err(err)) => break 'serve Err(err),
+								Poll::Pending => return Poll::Pending,
+							}
+							if let Some(pending) = chunk {
+								match writer.poll_write(&mut cx, pending) {
+									Poll::Ready(Ok(_)) => {
+										if !bytes::Buf::has_remaining(pending) {
+											*chunk = None;
+										}
+									}
+									Poll::Ready(Err(err)) => break 'serve Err(err),
+									Poll::Pending => return Poll::Pending,
+								}
+							} else if let Some(pending) = frame {
+								match pending.poll_read_chunk(waiter) {
+									Poll::Ready(Ok(Some(next))) => *chunk = Some(next),
+									Poll::Ready(Ok(None)) => *frame = None,
+									Poll::Ready(Err(err)) => break 'serve Err(err),
+									Poll::Pending => return Poll::Pending,
+								}
+							} else {
+								match self.group.poll_next_frame(waiter) {
+									Poll::Ready(Ok(Some(next))) => {
+										let buffered =
+											buffer_frame_timing(writer, &next, self.ctx.timescale, &mut self.prev_ts)
+												.and_then(|()| writer.buffer(&next.size));
+										if let Err(err) = buffered {
+											break 'serve Err(err);
+										}
+										*frame = Some(next);
+									}
+									Poll::Ready(Ok(None)) => break 'serve Ok(()),
+									Poll::Ready(Err(err)) => break 'serve Err(err),
+									Poll::Pending => return Poll::Pending,
+								}
+							}
+						}
+					};
+
+					let GroupState::Serve { writer, .. } = std::mem::replace(&mut self.state, GroupState::Done) else {
+						unreachable!()
+					};
+					match outcome {
+						Ok(()) => {
+							let mut writer = writer;
+							// The buffer drained before the final frame resolved, so the
+							// FIN follows the last byte.
+							match writer.finish() {
+								Ok(()) => self.state = GroupState::Closed { writer },
+								// The writer drops here: the Drop reset stands in for the
+								// abort, exactly like the old `finish()?`.
+								Err(err) => return Poll::Ready(Err(err)),
+							}
+						}
+						Err(err) => {
+							writer.abort(&err);
+							return Poll::Ready(Err(err));
+						}
+					}
+				}
+				GroupState::Closed { writer } => {
+					let mut cx = Context::from_waker(waiter.waker());
+					let res = ready!(writer.poll_closed(&mut cx));
+					self.state = GroupState::Done;
+					return Poll::Ready(res.map(|()| {
+						tracing::debug!(sequence = self.sequence, "finished group");
+					}));
+				}
+				GroupState::Done => return Poll::Ready(Ok(())),
+			}
+		}
+	}
+}
+
+impl<S: crate::transport::poll::Session> Machine for GroupServe<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		// The machine owns its outcome: the stream was aborted with the reason (or
+		// reset by the writer's Drop), which is all the subscriber sees.
+		ready!(self.poll_serve(waiter)).map(|()| ()).unwrap_or(());
+		Poll::Ready(())
 	}
 }
 
 /// A group that fails mid-stream must reset with its own error code. The subscriber uses
 /// that code to tell a truncated group (Old, Lagged, Evicted) from a routine cancel, so a
 /// blanket [`Error::Cancel`] from the writer's drop fallback loses the reason.
-#[cfg(all(test, not(loom)))]
+#[cfg(test)]
 mod serve_group_test {
 	use super::*;
 	use crate::lite::test_transport::*;
 	use crate::{Timestamp, broadcast};
+	use futures::FutureExt;
 
 	/// The wire's inclusive pair maps to the model's exclusive end.
 	///
@@ -2728,51 +3151,6 @@ mod serve_group_test {
 
 		assert!(matches!(serve.await, Err(Error::Old)));
 		assert_eq!(log.resets(), vec![crate::StreamError::Old.to_code()]);
-	}
-
-	/// A group that completes cleanly must not reset at all. The completion path
-	/// consumes the writer via `close()`; leaving the writer to drop after `finish()`
-	/// would fire the Drop fallback and tack a spurious Cancel reset onto a stream
-	/// the peer already acknowledged.
-	#[tokio::test]
-	async fn completed_group_does_not_reset() {
-		let log = Log::default();
-		let session = SinkSession::new(log.clone());
-
-		let track_priority = kio::Producer::new(0u8);
-		let subscription = Subscription {
-			session,
-			id: 0,
-			track_name: "test".into(),
-			priority: PriorityQueue::default(),
-			track_priority: track_priority.consume(),
-			track_priority_seen: 0,
-			ordered: false,
-			version: Version::Lite06Wip,
-			timescale: Some(crate::Timescale::default()),
-		};
-
-		let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
-		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
-		group
-			.write_frame(Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
-			.unwrap();
-		let consumer = group.consume();
-		group.finish().unwrap();
-
-		let handle = subscription.priority.insert(Priority::new(0, 0, 0));
-		subscription.serve_group(0, 0, handle, consumer).await.unwrap();
-
-		assert_eq!(log.resets(), Vec::<u32>::new(), "clean completion must not reset");
-
-		// The group held rank 0 (most urgent); the transport sends higher values
-		// first, so every send order set on the stream must be the maximum.
-		let priorities = log.priorities();
-		assert!(!priorities.is_empty(), "the group stream must set a priority");
-		assert!(
-			priorities.iter().all(|&p| p == 255),
-			"rank 0 must reach the transport as send order 255: {priorities:?}",
-		);
 	}
 }
 

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -461,6 +461,13 @@ impl<S: crate::transport::poll::Session> AnnounceServe<S> {
 			.origin
 			.scope(&[prefix.as_path()])
 			.unwrap_or_else(|| self.shared.origin.empty());
+		// Register the split-horizon peer on the announce cursor too. The origin
+		// model uses this exposure to park a reflected copy before it can replace
+		// the source we are currently advertising to that peer.
+		let origin = match Origin::new(exclude_hop) {
+			Ok(peer) => origin.excluding(peer),
+			Err(_) => origin,
+		};
 		let announced = origin.announced();
 		let run = AnnounceRun::new(prefix, exclude_hop, self.shared.self_origin, self.shared.version);
 		self.state = AnnounceState::Run { origin, announced, run };
@@ -499,6 +506,13 @@ struct AnnounceRun {
 	// peer keeping a stale hop chain. Keyed by suffix; filtered announces are
 	// watched too, since an update can cross the forwarding filter either way.
 	watched: HashMap<crate::PathOwned, WatchedRoute>,
+	// Pre-restart versions (Lite01-04) never populate `watched`, but the
+	// broadcast consumer handed out by an excluding cursor carries the
+	// ExclusionGuard that keeps the front marked as exposed to this peer. Hold
+	// it for as long as the peer holds the advertisement, or the guard releases
+	// right after the Active is written and a reflected UNKNOWN route can
+	// replace the incumbent after all.
+	held: HashMap<crate::PathOwned, crate::broadcast::Consumer>,
 	linger: kio::time::Deadline,
 	phase: AnnouncePhase,
 }
@@ -521,6 +535,7 @@ impl AnnounceRun {
 			next_announce_id: 0,
 			announce_ids: HashMap::new(),
 			watched: HashMap::new(),
+			held: HashMap::new(),
 			linger: kio::time::Deadline::new(),
 			phase: AnnouncePhase::Init,
 		}
@@ -808,6 +823,9 @@ impl AnnounceRun {
 							if let Some(entry) = self.watched.get_mut(&suffix) {
 								entry.sent = Some(route.clone());
 							}
+							if !lite::restart_supported(self.version) {
+								self.held.insert(suffix.clone(), active.clone());
+							}
 							stream.writer.buffer(&lite::AnnounceBroadcast::Active {
 								suffix,
 								hops: route.hops,
@@ -822,6 +840,7 @@ impl AnnounceRun {
 							// versions never populate `watched`, so they keep sending the
 							// Ended even for announces filtered above.
 							let retracted = self.watched.remove(&suffix).is_some_and(|entry| entry.sent.is_none());
+							self.held.remove(&suffix);
 							if self.version.has_announce_id() {
 								// Retract by id; nothing to send if the announce was filtered and
 								// the peer never saw it (an unknown id is a protocol violation).
@@ -2876,7 +2895,7 @@ impl<S: crate::transport::poll::Session> GroupServe<S> {
 						}
 					};
 					let mut writer = Writer::new(stream, self.ctx.version);
-					writer.set_priority(self.priority.current());
+					writer.set_priority(self.priority.send_order());
 
 					let msg = lite::Group {
 						subscribe: self.ctx.id,
@@ -2898,9 +2917,10 @@ impl<S: crate::transport::poll::Session> GroupServe<S> {
 					let mut cx = Context::from_waker(waiter.waker());
 
 					// Queue and SUBSCRIBE_UPDATE priority changes apply on every pass,
-					// whatever the write pipeline is blocked on.
-					while let Poll::Ready(new_pri) = self.priority.poll_next(waiter) {
-						writer.set_priority(new_pri);
+					// whatever the write pipeline is blocked on. The rank is re-read as
+					// a send order when handled, since the two conventions are inverted.
+					while self.priority.poll_next(waiter).is_ready() {
+						writer.set_priority(self.priority.send_order());
 					}
 					let seen = self.ctx.track_priority_seen;
 					// A dropped producer just disables this arm, like the queue arm above.
@@ -2913,7 +2933,7 @@ impl<S: crate::transport::poll::Session> GroupServe<S> {
 					}) {
 						self.ctx.track_priority_seen = value;
 						self.priority.set_track(value);
-						writer.set_priority(self.priority.current());
+						writer.set_priority(self.priority.send_order());
 					}
 
 					let outcome = 'serve: {
@@ -2986,7 +3006,10 @@ impl<S: crate::transport::poll::Session> GroupServe<S> {
 				}
 				GroupState::Closed { writer } => {
 					let mut cx = Context::from_waker(waiter.waker());
-					let res = ready!(writer.poll_closed(&mut cx));
+					// poll_close releases the stream on completion: the peer acknowledged
+					// everything, so the Drop fallback must not reset the stream and
+					// discard bytes still retransmitting.
+					let res = ready!(writer.poll_close(&mut cx));
 					self.state = GroupState::Done;
 					return Poll::Ready(res.map(|()| {
 						tracing::debug!(sequence = self.sequence, "finished group");
@@ -3010,7 +3033,7 @@ impl<S: crate::transport::poll::Session> Machine for GroupServe<S> {
 /// A group that fails mid-stream must reset with its own error code. The subscriber uses
 /// that code to tell a truncated group (Old, Lagged, Evicted) from a routine cancel, so a
 /// blanket [`Error::Cancel`] from the writer's drop fallback loses the reason.
-#[cfg(test)]
+#[cfg(all(test, not(loom)))]
 mod serve_group_test {
 	use super::*;
 	use crate::lite::test_transport::*;
@@ -3160,6 +3183,50 @@ mod serve_group_test {
 
 		assert!(matches!(serve.await, Err(Error::Old)));
 		assert_eq!(log.resets(), vec![crate::StreamError::Old.to_code()]);
+	}
+
+	/// A group that completes cleanly must not reset at all. The completion path
+	/// releases the stream via `poll_close`; leaving the writer to drop after
+	/// `finish()` would fire the Drop fallback and tack a spurious Cancel reset
+	/// onto a stream the peer already acknowledged.
+	#[tokio::test]
+	async fn completed_group_does_not_reset() {
+		let log = Log::default();
+		let session = SinkSession::new(log.clone());
+
+		let track_priority = kio::Producer::new(0u8);
+		let subscription = Subscription {
+			session,
+			id: 0,
+			track_name: "test".into(),
+			priority: PriorityQueue::default(),
+			track_priority: track_priority.consume(),
+			track_priority_seen: 0,
+			version: Version::Lite06Wip,
+			timescale: Some(crate::Timescale::default()),
+		};
+
+		let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
+		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+		group
+			.write_frame(Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
+			.unwrap();
+		let consumer = group.consume();
+		group.finish().unwrap();
+
+		let handle = subscription.priority.insert(Priority::new(0, 0));
+		subscription.serve_group(0, 0, handle, consumer).await.unwrap();
+
+		assert_eq!(log.resets(), Vec::<u32>::new(), "clean completion must not reset");
+
+		// The group held rank 0 (most urgent); the transport sends higher values
+		// first, so every send order set on the stream must be the maximum.
+		let priorities = log.priorities();
+		assert!(!priorities.is_empty(), "the group stream must set a priority");
+		assert!(
+			priorities.iter().all(|&p| p == 255),
+			"rank 0 must reach the transport as send order 255: {priorities:?}",
+		);
 	}
 }
 

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -3,7 +3,7 @@ use crate::{
 	Error, Origin, SessionError, bandwidth,
 	coding::{Reader, Stream, Writer},
 	lite::SessionInfo,
-	util::{MaybeBoxedExt, MaybeSendBox, TaskSet},
+	util::{MaybeBoxedExt, MaybeSendBox},
 };
 
 use std::task::{Context, Poll, ready};
@@ -165,7 +165,6 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 		peer_setup_slot.set(setup);
 	}
 	let peer_setup = peer_setup_slot;
-	let (tasks, task_set) = TaskSet::new();
 
 	// GOAWAY wiring: the public Session holds one half (send trigger, received
 	// signal), the protocol tasks below hold the other. moq-lite lets either side
@@ -194,7 +193,6 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 		// configured a price; otherwise the subscriber charges what the peer declared
 		// for its own egress.
 		cost: our_cost,
-		tasks,
 		going_away: goaway.going_away.clone(),
 	});
 
@@ -205,7 +203,7 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 		goaway: Some(SendGoaway::new(session.clone(), goaway, version)),
 		session_stream: setup_stream,
 		publisher,
-		subscriber: SubscriberDriver::new(subscriber, sub_connecting, task_set),
+		subscriber: SubscriberDriver::new(subscriber, sub_connecting),
 	};
 
 	// The async block only owns the state; all the logic is in `Driver::poll`.

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -32,7 +32,10 @@ pub(crate) struct SessionStart {
 ///
 /// Pass the returned [`Setup`] to [`start`] as its `peer_setup` so PROBE gating still
 /// resolves without re-reading the (consumed) stream.
-pub async fn accept_setup<S: web_transport_trait::Session>(session: &S, version: Version) -> Result<Setup, Error> {
+pub async fn accept_setup<S: crate::transport::poll::Session>(
+	session: &mut S,
+	version: Version,
+) -> Result<Setup, Error> {
 	loop {
 		let stream = session.accept_uni().await.map_err(Error::from_transport)?;
 		let mut reader = Reader::new(stream, version);
@@ -47,7 +50,7 @@ pub async fn accept_setup<S: web_transport_trait::Session>(session: &S, version:
 }
 
 /// Everything one moq-lite session needs to start.
-pub struct Config<S: web_transport_trait::Session> {
+pub struct Config<S: crate::transport::poll::Session> {
 	/// The transport carrying the session. Cloned into every loop that outlives
 	/// [`start`], so the connection closes when the last of them drops.
 	pub session: S,
@@ -88,9 +91,9 @@ pub struct Config<S: web_transport_trait::Session> {
 /// becomes ready once the initial announce set has been inserted into the subscribe
 /// origin, letting `connect()` block past the startup race. It is ready immediately
 /// when there is nothing to wait on (a version without an initial-set boundary).
-pub fn start<S: web_transport_trait::Session>(config: Config<S>) -> Result<SessionStart, Error> {
+pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<SessionStart, Error> {
 	let Config {
-		session,
+		mut session,
 		setup_stream,
 		publish,
 		subscribe,
@@ -174,9 +177,9 @@ pub fn start<S: web_transport_trait::Session>(config: Config<S>) -> Result<Sessi
 	// Advertise our own capabilities on a uni Setup Stream, then FIN. Best-effort:
 	// a failure here just means the peer falls back to "no capabilities" for us.
 	if version.has_setup_stream() {
-		let session = session.clone();
+		let mut session = session.clone();
 		tasks.push(async move {
-			if let Err(err) = send_setup(&session, our_setup, version).await {
+			if let Err(err) = send_setup(&mut session, our_setup, version).await {
 				tracing::debug!(%err, "failed to send setup");
 			}
 		});
@@ -190,14 +193,14 @@ pub fn start<S: web_transport_trait::Session>(config: Config<S>) -> Result<Sessi
 	// deadline is the sender's own timer, so a caller draining a lite-03 peer still
 	// gets the session closed on schedule; the peer just never learns why.
 	{
-		let session = session.clone();
+		let mut session = session.clone();
 		let goaway = goaway.clone();
 		tasks.push(async move {
 			let payload = {
-				let mut closed = std::pin::pin!(session.closed());
 				let mut triggered = std::pin::pin!(goaway.triggered());
 				kio::wait(|waiter| {
-					if waiter.poll_future(closed.as_mut()).is_ready() {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if session.poll_closed(&mut cx).is_ready() {
 						return std::task::Poll::Ready(None);
 					}
 					waiter.poll_future(triggered.as_mut())
@@ -210,13 +213,13 @@ pub fn start<S: web_transport_trait::Session>(config: Config<S>) -> Result<Sessi
 			// moq-lite has no timeout field on the wire; only the URI is sent. The
 			// deadline is still ours to honor, enforced locally below.
 			if version.has_goaway()
-				&& let Err(err) = send_goaway(&session, &payload.uri, version).await
+				&& let Err(err) = send_goaway(&mut session, &payload.uri, version).await
 			{
 				// Still enforce the deadline: the drain was requested, and failing to
 				// explain it to the peer is no reason to hold the session open.
 				tracing::warn!(%err, "failed to send goaway");
 			}
-			crate::goaway::enforce(&session, payload.timeout).await;
+			crate::goaway::enforce(&mut session, payload.timeout).await;
 		});
 	}
 
@@ -293,7 +296,11 @@ pub fn start<S: web_transport_trait::Session>(config: Config<S>) -> Result<Sessi
 }
 
 /// Open a unidirectional Setup Stream, send our single SETUP message, and FIN.
-async fn send_setup<S: web_transport_trait::Session>(session: &S, setup: Setup, version: Version) -> Result<(), Error> {
+async fn send_setup<S: crate::transport::poll::Session>(
+	session: &mut S,
+	setup: Setup,
+	version: Version,
+) -> Result<(), Error> {
 	let stream = session.open_uni().await.map_err(Error::from_transport)?;
 	let mut writer = Writer::new(stream, version);
 	writer.encode(&super::DataType::Setup).await?;
@@ -304,7 +311,11 @@ async fn send_setup<S: web_transport_trait::Session>(session: &S, setup: Setup, 
 
 /// Open a Goaway control stream (0x5), send the single GOAWAY message, and FIN.
 /// Lite04+ only; the version gate is the caller's.
-async fn send_goaway<S: web_transport_trait::Session>(session: &S, uri: &str, version: Version) -> Result<(), Error> {
+async fn send_goaway<S: crate::transport::poll::Session>(
+	session: &mut S,
+	uri: &str,
+	version: Version,
+) -> Result<(), Error> {
 	let mut stream = Stream::open(session, version).await?;
 	stream.writer.encode(&super::ControlType::Goaway).await?;
 	stream
@@ -321,7 +332,7 @@ async fn send_goaway<S: web_transport_trait::Session>(session: &S, uri: &str, ve
 }
 
 // TODO do something useful with this
-async fn run_session<S: web_transport_trait::Session>(stream: Option<Stream<S, Version>>) -> Result<(), Error> {
+async fn run_session<S: crate::transport::poll::Session>(stream: Option<Stream<S, Version>>) -> Result<(), Error> {
 	if let Some(mut stream) = stream {
 		while let Some(_info) = stream.reader.decode_maybe::<SessionInfo>().await? {}
 		return Err(Error::Cancel);

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -203,7 +203,7 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 			.then(|| SendSetup::new(session.clone(), our_setup, version)),
 		goaway: Some(SendGoaway::new(session.clone(), goaway, version)),
 		session_stream: setup_stream,
-		publisher: publisher.run().maybe_boxed(),
+		publisher,
 		subscriber: subscriber.run(sub_connecting, task_set).maybe_boxed(),
 	};
 
@@ -250,7 +250,7 @@ struct Driver<S: crate::transport::poll::Session> {
 	/// The legacy session stream (pre-lite-03). Only its *error* ends the race, so
 	/// the publisher and subscriber keep running while it sits idle.
 	session_stream: Option<Stream<S, Version>>,
-	publisher: MaybeSendBox<'static, Result<(), Error>>,
+	publisher: Publisher<S>,
 	subscriber: MaybeSendBox<'static, Result<(), Error>>,
 }
 
@@ -275,7 +275,7 @@ impl<S: crate::transport::poll::Session> Driver<S> {
 		{
 			return Poll::Ready(Err(err));
 		}
-		if let Poll::Ready(res) = waiter.poll_future(self.publisher.as_mut()) {
+		if let Poll::Ready(res) = self.publisher.poll(waiter) {
 			return Poll::Ready(res);
 		}
 		if let Poll::Ready(res) = waiter.poll_future(self.subscriber.as_mut()) {

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -3,10 +3,10 @@ use crate::{
 	Error, Origin, SessionError, bandwidth,
 	coding::{Reader, Stream, Writer},
 	lite::SessionInfo,
-	util::{MaybeBoxedExt, MaybeSendBox, TaskSet, err_only},
+	util::{MaybeBoxedExt, MaybeSendBox, TaskSet},
 };
 
-use std::task::Poll;
+use std::task::{Context, Poll, ready};
 
 use super::{
 	Connecting, DataType, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber, SubscriberConfig, Version,
@@ -171,57 +171,8 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 	// name a redirect URI, unlike moq-transport.
 	let (goaway_handle, goaway) = crate::goaway::Handle::new(true);
 
-	// Read out before the setup task takes ownership below.
+	// Read out before the setup machine takes ownership below.
 	let our_cost = our_setup.cost;
-
-	// Advertise our own capabilities on a uni Setup Stream, then FIN. Best-effort:
-	// a failure here just means the peer falls back to "no capabilities" for us.
-	if version.has_setup_stream() {
-		let mut session = session.clone();
-		tasks.push(async move {
-			if let Err(err) = send_setup(&mut session, our_setup, version).await {
-				tracing::debug!(%err, "failed to send setup");
-			}
-		});
-	}
-
-	// GOAWAY send task: parked on the send trigger; fires at most once (the trigger
-	// only accepts one payload). Races the transport close so a parked trigger
-	// never blocks the task set draining.
-	//
-	// Spawned on every version, including those with no GOAWAY message. The
-	// deadline is the sender's own timer, so a caller draining a lite-03 peer still
-	// gets the session closed on schedule; the peer just never learns why.
-	{
-		let mut session = session.clone();
-		let goaway = goaway.clone();
-		tasks.push(async move {
-			let payload = {
-				let mut triggered = std::pin::pin!(goaway.triggered());
-				kio::wait(|waiter| {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					if session.poll_closed(&mut cx).is_ready() {
-						return std::task::Poll::Ready(None);
-					}
-					waiter.poll_future(triggered.as_mut())
-				})
-				.await
-			};
-			let Some(payload) = payload else {
-				return;
-			};
-			// moq-lite has no timeout field on the wire; only the URI is sent. The
-			// deadline is still ours to honor, enforced locally below.
-			if version.has_goaway()
-				&& let Err(err) = send_goaway(&mut session, &payload.uri, version).await
-			{
-				// Still enforce the deadline: the drain was requested, and failing to
-				// explain it to the peer is no reason to hold the session open.
-				tracing::warn!(%err, "failed to send goaway");
-			}
-			crate::goaway::enforce(&mut session, payload.timeout).await;
-		});
-	}
 
 	let publisher = Publisher::new(PublisherConfig {
 		session: session.clone(),
@@ -243,30 +194,23 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 		// for its own egress.
 		cost: our_cost,
 		tasks,
-		going_away: goaway.going_away,
+		going_away: goaway.going_away.clone(),
 	});
 
+	let mut driver = Driver {
+		setup: version
+			.has_setup_stream()
+			.then(|| SendSetup::new(session.clone(), our_setup, version)),
+		goaway: Some(SendGoaway::new(session.clone(), goaway, version)),
+		session_stream: setup_stream,
+		publisher: publisher.run().maybe_boxed(),
+		subscriber: subscriber.run(sub_connecting, task_set).maybe_boxed(),
+	};
+
+	// The async block only owns the state; all the logic is in `Driver::poll`.
+	// (The closure borrows `driver` so it stays `Unpin` for any transport.)
 	let driver = async move {
-		let res = {
-			// Only a session-stream error ends the race; its clean completion (no
-			// stream) parks so the publisher and subscriber keep running.
-			let mut session = std::pin::pin!(err_only(run_session(setup_stream)));
-			let mut publisher = std::pin::pin!(publisher.run());
-			let mut subscriber = std::pin::pin!(subscriber.run(sub_connecting, task_set));
-			kio::wait(|waiter| {
-				if let Poll::Ready(err) = waiter.poll_future(session.as_mut()) {
-					return Poll::Ready(Err(err));
-				}
-				if let Poll::Ready(res) = waiter.poll_future(publisher.as_mut()) {
-					return Poll::Ready(res);
-				}
-				if let Poll::Ready(res) = waiter.poll_future(subscriber.as_mut()) {
-					return Poll::Ready(res);
-				}
-				Poll::Pending
-			})
-			.await
-		};
+		let res = kio::wait(|waiter| driver.poll(waiter)).await;
 
 		match &res {
 			Err(Error::Transport(_)) => {
@@ -295,48 +239,269 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 	})
 }
 
-/// Open a unidirectional Setup Stream, send our single SETUP message, and FIN.
-async fn send_setup<S: crate::transport::poll::Session>(
-	session: &mut S,
-	setup: Setup,
-	version: Version,
-) -> Result<(), Error> {
-	let stream = session.open_uni().await.map_err(Error::from_transport)?;
-	let mut writer = Writer::new(stream, version);
-	writer.encode(&super::DataType::Setup).await?;
-	writer.encode(&setup).await?;
-	writer.finish()?;
-	writer.closed().await
+/// The lite session driver: one poll function racing every protocol arm, in
+/// place of a task set of boxed futures.
+struct Driver<S: crate::transport::poll::Session> {
+	/// Advertising our capabilities, or `None` once sent (or on a version with no
+	/// Setup Stream).
+	setup: Option<SendSetup<S>>,
+	/// Sending our single GOAWAY if the drain trigger fires, or `None` once done.
+	goaway: Option<SendGoaway<S>>,
+	/// The legacy session stream (pre-lite-03). Only its *error* ends the race, so
+	/// the publisher and subscriber keep running while it sits idle.
+	session_stream: Option<Stream<S, Version>>,
+	publisher: MaybeSendBox<'static, Result<(), Error>>,
+	subscriber: MaybeSendBox<'static, Result<(), Error>>,
 }
 
-/// Open a Goaway control stream (0x5), send the single GOAWAY message, and FIN.
-/// Lite04+ only; the version gate is the caller's.
-async fn send_goaway<S: crate::transport::poll::Session>(
-	session: &mut S,
-	uri: &str,
-	version: Version,
-) -> Result<(), Error> {
-	let mut stream = Stream::open(session, version).await?;
-	stream.writer.encode(&super::ControlType::Goaway).await?;
-	stream
-		.writer
-		.encode(&super::Goaway {
-			uri: std::borrow::Cow::Borrowed(uri),
-		})
-		.await?;
-	stream.writer.finish()?;
-	// Wait for the FIN to be acknowledged before dropping: Writer's Drop resets
-	// the stream, and on real QUIC a reset racing the FIN discards the unacked
-	// GOAWAY frame (the same dance as send_setup).
-	stream.writer.closed().await
+impl<S: crate::transport::poll::Session> Driver<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		let mut cx = Context::from_waker(waiter.waker());
+
+		// The send-side machines never end the session; completion just retires them.
+		if let Some(setup) = &mut self.setup
+			&& setup.poll(&mut cx).is_ready()
+		{
+			self.setup = None;
+		}
+		if let Some(goaway) = &mut self.goaway
+			&& goaway.poll(waiter).is_ready()
+		{
+			self.goaway = None;
+		}
+
+		if let Some(stream) = &mut self.session_stream
+			&& let Poll::Ready(err) = poll_session_stream(stream, &mut cx)
+		{
+			return Poll::Ready(Err(err));
+		}
+		if let Poll::Ready(res) = waiter.poll_future(self.publisher.as_mut()) {
+			return Poll::Ready(res);
+		}
+		if let Poll::Ready(res) = waiter.poll_future(self.subscriber.as_mut()) {
+			return Poll::Ready(res);
+		}
+		Poll::Pending
+	}
 }
 
-// TODO do something useful with this
-async fn run_session<S: crate::transport::poll::Session>(stream: Option<Stream<S, Version>>) -> Result<(), Error> {
-	if let Some(mut stream) = stream {
-		while let Some(_info) = stream.reader.decode_maybe::<SessionInfo>().await? {}
-		return Err(Error::Cancel);
+/// Drain SessionInfo updates off the legacy session stream, resolving only when
+/// the stream dies (a FIN counts: the peer abandoned the session).
+// TODO do something useful with the updates
+fn poll_session_stream<S: crate::transport::poll::Session>(
+	stream: &mut Stream<S, Version>,
+	cx: &mut Context<'_>,
+) -> Poll<Error> {
+	loop {
+		match ready!(stream.reader.poll_decode_maybe::<SessionInfo>(cx)) {
+			Ok(Some(_info)) => {}
+			Ok(None) => return Poll::Ready(Error::Cancel),
+			Err(err) => return Poll::Ready(err),
+		}
+	}
+}
+
+/// Advertise our capabilities on a uni Setup Stream, then FIN. Best-effort: an
+/// error is logged and the machine finishes; the peer falls back to "no
+/// capabilities" for us.
+struct SendSetup<S: crate::transport::poll::Session> {
+	version: Version,
+	state: SendSetupState<S>,
+}
+
+enum SendSetupState<S: crate::transport::poll::Session> {
+	/// Waiting for stream credit on our own session handle.
+	Open {
+		session: S,
+		setup: Box<Setup>,
+	},
+	/// Flushing the buffered SETUP, then FIN and wait for the acknowledgement (a
+	/// reset racing the FIN would discard the unacked message).
+	Send {
+		writer: Writer<S::SendStream, Version>,
+		finished: bool,
+	},
+	Done,
+}
+
+impl<S: crate::transport::poll::Session> SendSetup<S> {
+	fn new(session: S, setup: Setup, version: Version) -> Self {
+		Self {
+			version,
+			state: SendSetupState::Open {
+				session,
+				setup: Box::new(setup),
+			},
+		}
 	}
 
-	Ok(())
+	fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+		match ready!(self.poll_send(cx)) {
+			Ok(()) => {}
+			Err(err) => tracing::debug!(%err, "failed to send setup"),
+		}
+		self.state = SendSetupState::Done;
+		Poll::Ready(())
+	}
+
+	fn poll_send(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				SendSetupState::Open { session, setup } => {
+					let stream = ready!(session.poll_open_uni(cx)).map_err(Error::from_transport)?;
+					let mut writer = Writer::new(stream, self.version);
+					writer.buffer(&super::DataType::Setup)?;
+					writer.buffer(&**setup)?;
+					self.state = SendSetupState::Send {
+						writer,
+						finished: false,
+					};
+				}
+				SendSetupState::Send { writer, finished } => {
+					if !*finished {
+						ready!(writer.poll_flush(cx))?;
+						writer.finish()?;
+						*finished = true;
+					}
+					return writer.poll_closed(cx);
+				}
+				SendSetupState::Done => return Poll::Ready(Ok(())),
+			}
+		}
+	}
+}
+
+/// Send our single GOAWAY when the drain trigger fires, then enforce its local
+/// deadline.
+///
+/// Runs on every version, including those with no GOAWAY message: the deadline is
+/// the sender's own timer, so a caller draining a lite-03 peer still gets the
+/// session closed on schedule; the peer just never learns why.
+struct SendGoaway<S: crate::transport::poll::Session> {
+	version: Version,
+	goaway: crate::goaway::Protocol,
+	/// A dedicated handle for the trigger-phase close watch, since `session` opens
+	/// the Goaway stream and each pending operation needs its own handle.
+	closed: S,
+	session: S,
+	state: SendGoawayState<S>,
+}
+
+enum SendGoawayState<S: crate::transport::poll::Session> {
+	/// Parked on the send trigger, racing the transport close so a parked trigger
+	/// never blocks the driver. The trigger fires at most once.
+	Waiting,
+	/// Opening the Goaway control stream (0x5). Lite04+ only; earlier versions
+	/// jump straight to enforcement.
+	Open { payload: crate::goaway::Goaway },
+	/// Flushing the single GOAWAY message, then FIN and wait for the
+	/// acknowledgement before dropping: Writer's Drop resets the stream, and on
+	/// real QUIC a reset racing the FIN discards the unacked GOAWAY frame.
+	Send {
+		stream: Stream<S, Version>,
+		timeout: Option<std::time::Duration>,
+		finished: bool,
+	},
+	/// The message is on the wire (or failed); enforce the local deadline.
+	Enforce(crate::goaway::Enforce<S>),
+}
+
+impl<S: crate::transport::poll::Session> SendGoaway<S> {
+	fn new(session: S, goaway: crate::goaway::Protocol, version: Version) -> Self {
+		Self {
+			version,
+			goaway,
+			closed: session.clone(),
+			session,
+			state: SendGoawayState::Waiting,
+		}
+	}
+
+	/// Move to enforcement, logging why the message never (fully) hit the wire.
+	///
+	/// Still enforce the deadline: the drain was requested, and failing to explain
+	/// it to the peer is no reason to hold the session open.
+	fn enforce_after(&mut self, err: Error, timeout: Option<std::time::Duration>) {
+		tracing::warn!(%err, "failed to send goaway");
+		self.state = SendGoawayState::Enforce(crate::goaway::Enforce::new(self.session.clone(), timeout));
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		let mut cx = Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.state {
+				SendGoawayState::Waiting => {
+					if self.closed.poll_closed(&mut cx).is_ready() {
+						return Poll::Ready(());
+					}
+					let Some(payload) = ready!(self.goaway.poll_triggered(waiter)) else {
+						return Poll::Ready(());
+					};
+					// moq-lite has no timeout field on the wire; only the URI is sent.
+					// The deadline is still ours to honor, enforced locally below.
+					self.state = if self.version.has_goaway() {
+						SendGoawayState::Open { payload }
+					} else {
+						SendGoawayState::Enforce(crate::goaway::Enforce::new(self.session.clone(), payload.timeout))
+					};
+				}
+				SendGoawayState::Open { payload } => {
+					let timeout = payload.timeout;
+					let mut stream = match ready!(Stream::poll_open(&mut self.session, self.version, &mut cx)) {
+						Ok(stream) => stream,
+						Err(err) => {
+							self.enforce_after(err, timeout);
+							continue;
+						}
+					};
+					let msg = super::Goaway {
+						uri: std::borrow::Cow::Borrowed(payload.uri.as_str()),
+					};
+					if let Err(err) = stream
+						.writer
+						.buffer(&super::ControlType::Goaway)
+						.and_then(|()| stream.writer.buffer(&msg))
+					{
+						self.enforce_after(err, timeout);
+						continue;
+					}
+					self.state = SendGoawayState::Send {
+						stream,
+						timeout,
+						finished: false,
+					};
+				}
+				SendGoawayState::Send {
+					stream,
+					timeout,
+					finished,
+				} => {
+					let timeout = *timeout;
+					let res = if !*finished {
+						match ready!(stream.writer.poll_flush(&mut cx)) {
+							Ok(()) => {
+								*finished = true;
+								stream.writer.finish()
+							}
+							Err(err) => Err(err),
+						}
+					} else {
+						Ok(())
+					};
+					let res = match res {
+						Ok(()) => ready!(stream.writer.poll_closed(&mut cx)),
+						Err(err) => Err(err),
+					};
+					match res {
+						Ok(()) => {
+							self.state =
+								SendGoawayState::Enforce(crate::goaway::Enforce::new(self.session.clone(), timeout));
+						}
+						Err(err) => self.enforce_after(err, timeout),
+					}
+				}
+				SendGoawayState::Enforce(enforce) => return enforce.poll(&mut cx),
+			}
+		}
+	}
 }

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -9,7 +9,8 @@ use crate::{
 use std::task::{Context, Poll, ready};
 
 use super::{
-	Connecting, DataType, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber, SubscriberConfig, Version,
+	Connecting, DataType, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber, SubscriberConfig, SubscriberDriver,
+	Version,
 };
 
 pub(crate) struct SessionStart {
@@ -204,7 +205,7 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 		goaway: Some(SendGoaway::new(session.clone(), goaway, version)),
 		session_stream: setup_stream,
 		publisher,
-		subscriber: subscriber.run(sub_connecting, task_set).maybe_boxed(),
+		subscriber: SubscriberDriver::new(subscriber, sub_connecting, task_set),
 	};
 
 	// The async block only owns the state; all the logic is in `Driver::poll`.
@@ -251,7 +252,7 @@ struct Driver<S: crate::transport::poll::Session> {
 	/// the publisher and subscriber keep running while it sits idle.
 	session_stream: Option<Stream<S, Version>>,
 	publisher: Publisher<S>,
-	subscriber: MaybeSendBox<'static, Result<(), Error>>,
+	subscriber: SubscriberDriver<S>,
 }
 
 impl<S: crate::transport::poll::Session> Driver<S> {
@@ -278,7 +279,7 @@ impl<S: crate::transport::poll::Session> Driver<S> {
 		if let Poll::Ready(res) = self.publisher.poll(waiter) {
 			return Poll::Ready(res);
 		}
-		if let Poll::Ready(res) = waiter.poll_future(self.subscriber.as_mut()) {
+		if let Poll::Ready(res) = self.subscriber.poll(waiter) {
 			return Poll::Ready(res);
 		}
 		Poll::Pending

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -241,9 +241,9 @@ impl PeerSetup {
 		*self.0.lock() = Some(setup);
 	}
 
-	/// Await the peer's advertised probe level, blocking until its SETUP arrives.
-	pub async fn probe_level(&self) -> ProbeLevel {
-		kio::wait(|waiter| self.poll_get(waiter, |setup| setup.probe)).await
+	/// Poll for the peer's advertised probe level, waiting until its SETUP arrives.
+	pub fn poll_probe_level(&self, waiter: &kio::Waiter) -> std::task::Poll<ProbeLevel> {
+		self.poll_get(waiter, |setup| setup.probe)
 	}
 
 	/// Await the link cost the peer (the dialing side) declared in its SETUP.

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -243,38 +243,35 @@ impl PeerSetup {
 
 	/// Await the peer's advertised probe level, blocking until its SETUP arrives.
 	pub async fn probe_level(&self) -> ProbeLevel {
-		self.wait(|setup| setup.probe).await
+		kio::wait(|waiter| self.poll_get(waiter, |setup| setup.probe)).await
 	}
 
 	/// Await the link cost the peer (the dialing side) declared in its SETUP.
 	/// `None` when it declared none, meaning the default cost of 1.
 	pub async fn cost(&self) -> Option<u64> {
-		self.wait(|setup| setup.cost).await
+		kio::wait(|waiter| self.poll_get(waiter, |setup| setup.cost)).await
 	}
 
-	/// Await the origin (hop) id the peer declared in its SETUP. `None` when it
+	/// Poll for the origin (hop) id the peer declared in its SETUP. `None` when it
 	/// declared none: a leaf with no identity worth excluding.
-	pub async fn origin(&self) -> Option<crate::Origin> {
-		self.wait(|setup| setup.origin).await
+	pub fn poll_origin(&self, waiter: &kio::Waiter) -> std::task::Poll<Option<crate::Origin>> {
+		self.poll_get(waiter, |setup| setup.origin)
 	}
 
-	/// Await the peer's SETUP and read a field out of it.
+	/// Poll for a field of the peer's SETUP.
 	///
 	/// The peer MUST send exactly one SETUP, so this resolves once that stream is read.
-	/// Waits forever if it never does; the caller is a session task, cancelled when the
-	/// driver drops.
-	async fn wait<T>(&self, f: impl FnOnce(&Setup) -> T) -> T {
-		let slot = self
-			.0
-			.wait(|setup| {
-				if setup.is_some() {
-					std::task::Poll::Ready(())
-				} else {
-					std::task::Poll::Pending
-				}
-			})
-			.await;
-		f(slot.as_ref().expect("waited for Some"))
+	/// Pends forever if it never does; the caller is session state, dropped with the
+	/// driver.
+	fn poll_get<T>(&self, waiter: &kio::Waiter, f: impl FnOnce(&Setup) -> T) -> std::task::Poll<T> {
+		let slot = std::task::ready!(self.0.poll(waiter, |setup| {
+			if setup.is_some() {
+				std::task::Poll::Ready(())
+			} else {
+				std::task::Poll::Pending
+			}
+		}));
+		std::task::Poll::Ready(f(slot.as_ref().expect("waited for Some")))
 	}
 }
 

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -246,10 +246,10 @@ impl PeerSetup {
 		self.poll_get(waiter, |setup| setup.probe)
 	}
 
-	/// Await the link cost the peer (the dialing side) declared in its SETUP.
+	/// Poll for the link cost the peer (the dialing side) declared in its SETUP.
 	/// `None` when it declared none, meaning the default cost of 1.
-	pub async fn cost(&self) -> Option<u64> {
-		kio::wait(|waiter| self.poll_get(waiter, |setup| setup.cost)).await
+	pub fn poll_cost(&self, waiter: &kio::Waiter) -> std::task::Poll<Option<u64>> {
+		self.poll_get(waiter, |setup| setup.cost)
 	}
 
 	/// Poll for the origin (hop) id the peer declared in its SETUP. `None` when it

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -185,11 +185,15 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		.await
 	}
 
-	async fn run_uni(mut self) -> Result<(), Error> {
+	async fn run_uni(self) -> Result<(), Error> {
 		let mut tasks = TaskSet::owned();
+		let mut accept = self.session.clone();
 		loop {
 			let stream = tasks
-				.drive(self.session.accept_uni())
+				.drive(|waiter| {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					accept.poll_accept_uni(&mut cx)
+				})
 				.await
 				.map_err(Error::from_transport)?;
 
@@ -695,22 +699,19 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		let mut closed_session = self.session.clone();
 		loop {
 			let next = tracks
-				.drive(async {
-					kio::wait(|waiter| {
-						let mut cx = std::task::Context::from_waker(waiter.waker());
-						if closed_session.poll_closed(&mut cx).is_ready() {
-							return Poll::Ready(None);
-						}
-						// A draining peer usually stops announcing, so react to the signal
-						// itself; waiting for another message would leave the route primary
-						// until the session finally closed. Idempotent, since the signal
-						// stays set and this task wakes for other reasons too.
-						if self.going_away.poll(waiter).is_ready() {
-							dynamic.drain();
-						}
-						dynamic.poll_requested_track(waiter).map(Some)
-					})
-					.await
+				.drive(|waiter| {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if closed_session.poll_closed(&mut cx).is_ready() {
+						return Poll::Ready(None);
+					}
+					// A draining peer usually stops announcing, so react to the signal
+					// itself; waiting for another message would leave the route primary
+					// until the session finally closed. Idempotent, since the signal
+					// stays set and this task wakes for other reasons too.
+					if self.going_away.poll(waiter).is_ready() {
+						dynamic.drain();
+					}
+					dynamic.poll_requested_track(waiter).map(Some)
 				})
 				.await;
 
@@ -1844,13 +1845,6 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 
 		let teardown = loop {
 			let event = {
-				// The upstream subscribe stream closed, or carried a START/END/DROP.
-				let mut sub_msg = std::pin::pin!(async {
-					match &mut sub {
-						Sub::Active(active) => active.stream.reader.decode_maybe::<lite::SubscribeResponse>().await,
-						Sub::None => std::future::pending().await,
-					}
-				});
 				let mut closed_session = self.subscriber.session.clone();
 				// Biased: demand first, then completions, then closures.
 				kio::wait(|waiter| {
@@ -1889,7 +1883,14 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 					}
 
 					// (4) The upstream subscribe stream closed, or carried a START/END/DROP.
-					if let Poll::Ready(res) = waiter.poll_future(sub_msg.as_mut()) {
+					// Partial message bytes persist in the reader's buffer across turns.
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if let Sub::Active(active) = &mut sub
+						&& let Poll::Ready(res) = active
+							.stream
+							.reader
+							.poll_decode_maybe::<lite::SubscribeResponse>(&mut cx)
+					{
 						return Poll::Ready(match res {
 							Ok(Some(msg)) => Event::SubResponse(msg),
 							Ok(None) => Event::SubClosed(Ok(())),
@@ -1898,7 +1899,6 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 					}
 
 					// (5) The session died: hand the track back for another route.
-					let mut cx = std::task::Context::from_waker(waiter.waker());
 					if closed_session.poll_closed(&mut cx).is_ready() {
 						return Poll::Ready(Event::SessionClosed);
 					}
@@ -2023,17 +2023,14 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 			})
 			.await?;
 
-		let info = {
-			let mut decode = std::pin::pin!(stream.reader.decode::<lite::TrackInfo>());
-			kio::wait(|waiter| {
-				let mut cx = std::task::Context::from_waker(waiter.waker());
-				if session.poll_closed(&mut cx).is_ready() {
-					return Poll::Ready(Err(Error::Dropped));
-				}
-				waiter.poll_future(decode.as_mut())
-			})
-			.await?
-		};
+		let info = kio::wait(|waiter| {
+			let mut cx = std::task::Context::from_waker(waiter.waker());
+			if session.poll_closed(&mut cx).is_ready() {
+				return Poll::Ready(Err(Error::Dropped));
+			}
+			stream.reader.poll_decode::<lite::TrackInfo>(&mut cx)
+		})
+		.await?;
 		// The publisher FINs after TRACK_INFO; FIN our side too and let the stream drop.
 		let _ = stream.writer.finish();
 
@@ -2232,13 +2229,12 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 			// serve loop's teardown instead.
 			let resp = {
 				let mut session = self.subscriber.session.clone();
-				let mut decode = std::pin::pin!(stream.reader.decode::<lite::SubscribeResponse>());
 				kio::wait(|waiter| {
 					let mut cx = std::task::Context::from_waker(waiter.waker());
 					if session.poll_closed(&mut cx).is_ready() {
 						return Poll::Ready(Err(Error::Dropped));
 					}
-					waiter.poll_future(decode.as_mut())
+					stream.reader.poll_decode::<lite::SubscribeResponse>(&mut cx)
 				})
 				.await
 			};

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -2,13 +2,14 @@ use crate::{frame, group, origin, track};
 use std::{
 	collections::HashMap,
 	sync::{Arc, atomic},
-	task::Poll,
+	task::{Poll, ready},
 	time::Duration,
 };
 
 use futures::{StreamExt, stream::FuturesUnordered};
 
-use crate::util::{MaybeBoxedExt, MaybeSendBox, TaskSet, Tasks, err_only};
+use crate::poll_set::{Machine, PollSet};
+use crate::util::{MaybeBoxedExt, MaybeSendBox, TaskSet, Tasks};
 
 use crate::{
 	AsPath, Error, Path, PathOwned, Timescale, Timestamp, bandwidth,
@@ -148,91 +149,6 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 			Some(cost) => cost,
 			None => self.peer_setup.cost().await.unwrap_or(super::DEFAULT_COST),
 		}
-	}
-
-	/// `connecting` is the connection-progress producer for this session (None for
-	/// versions with no initial-set boundary). It is threaded through the announce path
-	/// rather than stored on `Subscriber`: the struct is cloned for several long-lived
-	/// tasks (`bw`, `run_uni`), and any clone retaining a producer would keep the channel
-	/// open and hang `connect()`.
-	pub async fn run(self, connecting: Option<ConnectingProducer>, mut tasks: TaskSet) -> Result<(), Error> {
-		let bw = self.clone();
-		let dg = self.clone();
-		// The watchdog halves (announce/bandwidth/datagrams) only end the session on
-		// error; their clean completion parks and the other futures keep running.
-		let mut announce = std::pin::pin!(err_only(self.clone().run_announce(connecting)));
-		let mut uni = std::pin::pin!(self.run_uni());
-		let mut bandwidth = std::pin::pin!(err_only(bw.run_recv_bandwidth()));
-		let mut datagrams = std::pin::pin!(err_only(dg.run_datagrams()));
-		kio::wait(|waiter| {
-			if let Poll::Ready(err) = waiter.poll_future(announce.as_mut()) {
-				return Poll::Ready(Err(err));
-			}
-			if let Poll::Ready(res) = waiter.poll_future(uni.as_mut()) {
-				return Poll::Ready(res);
-			}
-			if let Poll::Ready(err) = waiter.poll_future(bandwidth.as_mut()) {
-				return Poll::Ready(Err(err));
-			}
-			if let Poll::Ready(err) = waiter.poll_future(datagrams.as_mut()) {
-				return Poll::Ready(Err(err));
-			}
-			if tasks.poll(waiter).is_ready() {
-				return Poll::Ready(Ok(()));
-			}
-			Poll::Pending
-		})
-		.await
-	}
-
-	async fn run_uni(self) -> Result<(), Error> {
-		let mut tasks = TaskSet::owned();
-		let mut accept = self.session.clone();
-		loop {
-			let stream = tasks
-				.drive(|waiter| {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					accept.poll_accept_uni(&mut cx)
-				})
-				.await
-				.map_err(Error::from_transport)?;
-
-			let stream = Reader::new(stream, self.version);
-			let this = self.clone();
-
-			tasks.push(async move {
-				if let Err(err) = this.run_uni_stream(stream).await {
-					tracing::debug!(%err, "error running uni stream");
-				}
-			});
-		}
-	}
-
-	async fn run_uni_stream(mut self, mut stream: Reader<S::RecvStream, Version>) -> Result<(), Error> {
-		let kind = stream.decode().await?;
-
-		let res = match kind {
-			lite::DataType::Group => self.recv_group(&mut stream).await,
-			lite::DataType::Setup => self.recv_setup(&mut stream).await,
-		};
-
-		if let Err(err) = res {
-			stream.abort(&err);
-		}
-
-		Ok(())
-	}
-
-	/// Read the peer's single SETUP message off its Setup Stream and record it, so
-	/// capability-gated streams (PROBE) can consult it. lite-05+ only.
-	async fn recv_setup(&self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
-		if !self.version.has_setup_stream() {
-			return Err(Error::UnexpectedStream);
-		}
-		let setup = stream.decode::<lite::Setup>().await?;
-		tracing::debug!(?setup, "received peer setup");
-		self.peer_setup.set(setup);
-		Ok(())
 	}
 
 	async fn run_announce(self, connecting: Option<ConnectingProducer>) -> Result<(), Error> {
@@ -437,75 +353,6 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// down only the announce stream is correct since no further progress can be made,
 		// but we must not propagate an error that would kill the whole connection.
 		stream.writer.finish().ok();
-		Ok(())
-	}
-
-	/// Opens a PROBE stream on demand while a consumer is interested.
-	///
-	/// Loops forever: wait for a consumer, race the probe stream against
-	/// the consumer leaving, then loop back. Probe is best-effort, so stream
-	/// errors are logged but never tear down the session.
-	async fn run_recv_bandwidth(self) -> Result<(), Error> {
-		let Some(bandwidth) = &self.recv_bandwidth else {
-			return Ok(());
-		};
-
-		// lite-05+ negotiates probing: only open a PROBE stream if the peer advertised it
-		// (Report or higher) in its SETUP. Older versions have no SETUP, so probe is always
-		// available there.
-		if self.version.has_setup_stream() && self.peer_setup.probe_level().await < lite::ProbeLevel::Report {
-			tracing::debug!("peer does not support probing; skipping probe stream");
-			return Ok(());
-		}
-
-		loop {
-			// Wait until at least one consumer is interested in the estimate.
-			if bandwidth.used().await.is_err() {
-				return Ok(());
-			}
-
-			// Race the last consumer leaving against the probe stream ending.
-			let unused = {
-				let mut probe = std::pin::pin!(self.run_probe_stream(bandwidth));
-				kio::wait(|waiter| {
-					if let Poll::Ready(res) = bandwidth.poll_unused(waiter) {
-						return Poll::Ready(Some(res));
-					}
-					if let Poll::Ready(res) = waiter.poll_future(probe.as_mut()) {
-						match res {
-							Ok(()) => tracing::debug!("probe stream closed"),
-							Err(err) => tracing::warn!(%err, "probe stream error"),
-						}
-						return Poll::Ready(None);
-					}
-					Poll::Pending
-				})
-				.await
-			};
-			match unused {
-				// Loop back: a new consumer may arrive later.
-				Some(Ok(())) => {}
-				// The channel closed, or the stream ended (peer FIN'd or errored).
-				// Don't hammer an uncooperative peer; give up for the rest of the session.
-				Some(Err(_)) | None => return Ok(()),
-			}
-		}
-	}
-
-	async fn run_probe_stream(&self, bandwidth: &bandwidth::Producer) -> Result<(), Error> {
-		// After a GOAWAY the peer must not see new streams. Probe is best-effort;
-		// skip it rather than erroring.
-		if self.going_away.is_set() {
-			return Ok(());
-		}
-		let mut session = self.session.clone();
-		let mut stream = Stream::open(&mut session, self.version).await?;
-		stream.writer.encode(&lite::ControlType::Probe).await?;
-
-		while let Some(probe) = stream.reader.decode_maybe::<lite::Probe>().await? {
-			bandwidth.set(Some(probe.bitrate))?;
-		}
-
 		Ok(())
 	}
 
@@ -740,25 +587,6 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		}
 	}
 
-	/// Receive QUIC datagrams and route each to its subscription's track producer (lite-05 §6.4).
-	///
-	/// Returns `Ok(())` on a non-datagram transport or pre-lite-05 version, so the caller's
-	/// `select!` matches only on the error case and lets the other arms drive the session. A
-	/// decode error or an unknown subscribe id drops that datagram without tearing down the
-	/// session (best-effort); only a transport-level failure ends the loop.
-	async fn run_datagrams(mut self) -> Result<(), Error> {
-		if !self.version.has_datagrams() || self.session.max_datagram_size() == 0 {
-			return Ok(());
-		}
-
-		loop {
-			let payload = self.session.recv_datagram().await.map_err(Error::from_transport)?;
-			if let Err(err) = self.route_datagram(payload) {
-				tracing::debug!(%err, "dropping datagram");
-			}
-		}
-	}
-
 	/// Decode one datagram body and hand it to the matching subscription's producer.
 	fn route_datagram(&self, payload: bytes::Bytes) -> Result<(), Error> {
 		let mut buf = payload;
@@ -783,123 +611,6 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
-		let hdr: lite::Group = stream.decode().await?;
-
-		let (mut group, track, timescale) = {
-			let mut subs = self.subscribes.lock();
-			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
-
-			let group_info = group::Info { sequence: hdr.sequence };
-			// Stats (groups/frames/bytes) are counted in the model as the group is
-			// written, through the tagged `track::Producer`.
-			let mut group = entry.producer.create_group(group_info)?;
-			// The stream may carry only the tail of the group; number the frames from
-			// where the publisher said they start so a reader splicing across routes
-			// lines them up.
-			group.start_at(hdr.frame_start)?;
-			(group, entry.producer.clone(), entry.timescale)
-		};
-
-		// The timescale came from TRACK_INFO (read before this subscription was even
-		// registered), so frames decode immediately. No SUBSCRIBE_OK to wait on.
-
-		let res = {
-			let mut serve = std::pin::pin!(self.run_group(stream, group.clone(), timescale));
-			kio::wait(|waiter| {
-				if let Poll::Ready(err) = track.poll_closed(waiter) {
-					return Poll::Ready(Err(err));
-				}
-				if let Poll::Ready(err) = group.poll_closed(waiter) {
-					return Poll::Ready(Err(err));
-				}
-				waiter.poll_future(serve.as_mut())
-			})
-			.await
-		};
-
-		match res {
-			Err(Error::Cancel) => {
-				let _ = group.abort(Error::Cancel);
-			}
-			Err(err) => {
-				tracing::debug!(%err, group = %group.sequence, "group error");
-				let _ = group.abort(err);
-			}
-			_ => {
-				let _ = group.finish();
-			}
-		}
-
-		Ok(())
-	}
-
-	async fn run_group(
-		&mut self,
-		stream: &mut Reader<S::RecvStream, Version>,
-		mut group: group::Producer,
-		timescale: Option<Timescale>,
-	) -> Result<(), Error> {
-		// Previous frame's raw timestamp value (in `timescale` units), for the
-		// zigzag-delta decode when timestamps are negotiated. The first frame's
-		// delta is absolute (prev = 0 implicitly).
-		let mut prev_ts: u64 = 0;
-
-		loop {
-			let timestamp = if let Some(scale) = timescale {
-				// Publisher advertised a timescale, so every frame on this stream is
-				// prefixed with a zigzag-delta timestamp. The timestamp delta doubles
-				// as the per-frame sentinel: stream end here means the group has no
-				// more frames.
-				let Some(zz) = stream.decode_maybe::<crate::coding::VarInt>().await? else {
-					break;
-				};
-				let next: u64 = (prev_ts as i128 + zz.to_zigzag() as i128)
-					.try_into()
-					.map_err(|_| Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
-				prev_ts = next;
-				Some(Timestamp::new(next, scale).map_err(|_| Error::BoundsExceeded(crate::coding::BoundsExceeded))?)
-			} else {
-				None
-			};
-
-			let Some(size) = stream.decode_maybe::<u64>().await? else {
-				break;
-			};
-
-			// `create_frame` is the allocation chokepoint and rejects an oversized
-			// `size` before allocating, so no pre-check is needed. No wire timestamp
-			// (pre-lite-05) means local receive time.
-			let timestamp = timestamp.unwrap_or_else(Timestamp::now);
-			let mut frame = group.create_frame(frame::Info { size, timestamp })?;
-
-			if let Err(err) = self.run_frame(stream, &mut frame).await {
-				let _ = frame.abort(err.clone());
-				return Err(err);
-			}
-
-			frame.finish()?;
-		}
-
-		Ok(())
-	}
-
-	async fn run_frame(
-		&mut self,
-		stream: &mut Reader<S::RecvStream, Version>,
-		frame: &mut frame::Producer<'_>,
-	) -> Result<(), Error> {
-		while frame.remaining() > 0 {
-			match stream.read_chunk(frame.remaining()).await? {
-				Some(chunk) if !chunk.is_empty() => {
-					frame.write(chunk)?;
-				}
-				_ => return Err(Error::WrongSize),
-			}
-		}
-		Ok(())
-	}
-
 	fn log_path(&self, path: impl AsPath) -> Path<'_> {
 		self.origin.root().join(path)
 	}
@@ -908,6 +619,582 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	/// received chain is empty (Lite01/02) or anonymous placeholders (Lite03).
 	fn version_lacks_hops(&self) -> bool {
 		matches!(self.version, Version::Lite01 | Version::Lite02 | Version::Lite03)
+	}
+}
+
+/// The subscriber half's driver: the uni-stream accept loop, the announce
+/// half, PROBE feedback, datagrams, and the per-source serve tasks, raced the
+/// way the old `select!` did. Only an error (or the task set draining) ends it.
+pub(super) struct SubscriberDriver<S: crate::transport::poll::Session> {
+	/// The announce half, still async. Its clean completion parks (a publish-only
+	/// peer has nothing to announce); only its error ends the session.
+	announce: Option<MaybeSendBox<'static, Result<(), Error>>>,
+	uni: UniAccept<S>,
+	/// PROBE feedback; finishes quietly when unsupported or given up on.
+	bandwidth: Option<RecvBandwidth<S>>,
+	/// Datagram receive; inert on a version or transport without datagrams.
+	datagrams: Option<DatagramRecv<S>>,
+	/// Driver-owned scope for broadcast and track handlers.
+	tasks: TaskSet,
+}
+
+impl<S: crate::transport::poll::Session> SubscriberDriver<S> {
+	/// `connecting` is the connection-progress producer for this session (None for
+	/// versions with no initial-set boundary). It is threaded through the announce path
+	/// rather than stored on `Subscriber`: the struct is cloned for several long-lived
+	/// tasks, and any clone retaining a producer would keep the channel open and hang
+	/// `connect()`.
+	pub fn new(subscriber: Subscriber<S>, connecting: Option<ConnectingProducer>, tasks: TaskSet) -> Self {
+		Self {
+			announce: Some(subscriber.clone().run_announce(connecting).maybe_boxed()),
+			uni: UniAccept::new(subscriber.clone()),
+			bandwidth: Some(RecvBandwidth::new(subscriber.clone())),
+			datagrams: Some(DatagramRecv::new(subscriber)),
+			tasks,
+		}
+	}
+
+	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		if let Some(announce) = &mut self.announce {
+			match waiter.poll_future(announce.as_mut()) {
+				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+				Poll::Ready(Ok(())) => self.announce = None,
+				Poll::Pending => {}
+			}
+		}
+		if let Poll::Ready(res) = self.uni.poll(waiter) {
+			return Poll::Ready(res);
+		}
+		if let Some(bandwidth) = &mut self.bandwidth {
+			match bandwidth.poll(waiter) {
+				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+				Poll::Ready(Ok(())) => self.bandwidth = None,
+				Poll::Pending => {}
+			}
+		}
+		if let Some(datagrams) = &mut self.datagrams {
+			match datagrams.poll(waiter) {
+				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+				Poll::Ready(Ok(())) => self.datagrams = None,
+				Poll::Pending => {}
+			}
+		}
+		if self.tasks.poll(waiter).is_ready() {
+			return Poll::Ready(Ok(()));
+		}
+		Poll::Pending
+	}
+}
+
+/// Accepts incoming uni streams (GROUP data plus the peer's SETUP) and drives
+/// each as a child machine. Resolves only on a transport error.
+struct UniAccept<S: crate::transport::poll::Session> {
+	subscriber: Subscriber<S>,
+	// A dedicated accept handle: the poll interface takes `&mut self`.
+	accept: S,
+	children: PollSet<UniServe<S>>,
+}
+
+impl<S: crate::transport::poll::Session> UniAccept<S> {
+	fn new(subscriber: Subscriber<S>) -> Self {
+		let accept = subscriber.session.clone();
+		Self {
+			subscriber,
+			accept,
+			children: PollSet::new(),
+		}
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		let _ = self.children.poll(waiter);
+
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match self.accept.poll_accept_uni(&mut cx) {
+				Poll::Ready(Ok(stream)) => self.children.push(UniServe {
+					subscriber: self.subscriber.clone(),
+					state: UniState::Start {
+						reader: Reader::new(stream, self.subscriber.version),
+					},
+				}),
+				Poll::Ready(Err(err)) => return Poll::Ready(Err(Error::from_transport(err))),
+				Poll::Pending => break,
+			}
+		}
+
+		// Newly accepted children start now rather than on the next wake.
+		let _ = self.children.poll(waiter);
+		Poll::Pending
+	}
+}
+
+/// One accepted uni stream, dispatched on its first varint.
+struct UniServe<S: crate::transport::poll::Session> {
+	subscriber: Subscriber<S>,
+	state: UniState<S>,
+}
+
+enum UniState<S: crate::transport::poll::Session> {
+	/// Reading the stream's type.
+	Start {
+		reader: Reader<S::RecvStream, Version>,
+	},
+	/// Reading the peer's single SETUP message, recorded so capability-gated
+	/// streams (PROBE) can consult it. lite-05+ only.
+	Setup {
+		reader: Reader<S::RecvStream, Version>,
+	},
+	Group(GroupRecv<S>),
+	Done,
+}
+
+impl<S: crate::transport::poll::Session> Machine for UniServe<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		if let Err(err) = ready!(self.poll_serve(waiter)) {
+			tracing::debug!(%err, "error running uni stream");
+		}
+		Poll::Ready(())
+	}
+}
+
+impl<S: crate::transport::poll::Session> UniServe<S> {
+	/// Abort the stream with the given error, wherever the reader currently lives.
+	fn abort(&mut self, err: &Error) {
+		match &mut self.state {
+			UniState::Start { reader } | UniState::Setup { reader } => reader.abort(err),
+			UniState::Group(recv) => recv.reader.abort(err),
+			UniState::Done => {}
+		}
+	}
+
+	fn poll_serve(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				UniState::Start { reader } => {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					// A decode error here is only logged; the peer hung up or spoke garbage
+					// before the stream had a type.
+					let kind = ready!(reader.poll_decode::<lite::DataType>(&mut cx))?;
+					let UniState::Start { reader } = std::mem::replace(&mut self.state, UniState::Done) else {
+						unreachable!()
+					};
+					self.state = match kind {
+						lite::DataType::Group => UniState::Group(GroupRecv::new(self.subscriber.clone(), reader)),
+						lite::DataType::Setup => UniState::Setup { reader },
+					};
+				}
+				UniState::Setup { reader } => {
+					if !self.subscriber.version.has_setup_stream() {
+						let err = Error::UnexpectedStream;
+						self.abort(&err);
+						return Poll::Ready(Ok(()));
+					}
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					let res = ready!(reader.poll_decode::<lite::Setup>(&mut cx));
+					match res {
+						Ok(setup) => {
+							tracing::debug!(?setup, "received peer setup");
+							self.subscriber.peer_setup.set(setup);
+							return Poll::Ready(Ok(()));
+						}
+						Err(err) => {
+							self.abort(&err);
+							return Poll::Ready(Ok(()));
+						}
+					}
+				}
+				UniState::Group(recv) => {
+					let res = ready!(recv.poll_serve(waiter));
+					if let Err(err) = res {
+						self.abort(&err);
+					}
+					return Poll::Ready(Ok(()));
+				}
+				UniState::Done => return Poll::Ready(Ok(())),
+			}
+		}
+	}
+}
+
+/// Receives one GROUP stream into its subscription's track producer.
+struct GroupRecv<S: crate::transport::poll::Session> {
+	subscriber: Subscriber<S>,
+	reader: Reader<S::RecvStream, Version>,
+	state: GroupRecvState,
+}
+
+enum GroupRecvState {
+	/// Reading the GROUP header.
+	Header,
+	/// Filling the group, bailing if the track or group dies first.
+	Serve {
+		group: group::Producer,
+		track: track::Producer,
+		ingest: FrameIngest,
+	},
+	Done,
+}
+
+impl<S: crate::transport::poll::Session> GroupRecv<S> {
+	fn new(subscriber: Subscriber<S>, reader: Reader<S::RecvStream, Version>) -> Self {
+		Self {
+			subscriber,
+			reader,
+			state: GroupRecvState::Header,
+		}
+	}
+
+	fn poll_serve(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				GroupRecvState::Header => {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					let hdr = ready!(self.reader.poll_decode::<lite::Group>(&mut cx))?;
+
+					let (group, track, timescale) = {
+						let mut subs = self.subscriber.subscribes.lock();
+						let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
+
+						let group_info = group::Info { sequence: hdr.sequence };
+						// Stats (groups/frames/bytes) are counted in the model as the group
+						// is written, through the tagged `track::Producer`.
+						let mut group = entry.producer.create_group(group_info)?;
+						// The stream may carry only the tail of the group; number the frames
+						// from where the publisher said they start so a reader splicing
+						// across routes lines them up.
+						group.start_at(hdr.frame_start)?;
+						(group, entry.producer.clone(), entry.timescale)
+					};
+
+					// The timescale came from TRACK_INFO (read before this subscription was
+					// even registered), so frames decode immediately. No SUBSCRIBE_OK to
+					// wait on.
+					self.state = GroupRecvState::Serve {
+						group,
+						track,
+						ingest: FrameIngest::new(timescale),
+					};
+				}
+				GroupRecvState::Serve { group, track, ingest } => {
+					// The track or group dying cancels the stream; the peer's own close
+					// arrives through the ingest's reads.
+					let res = 'serve: {
+						if let Poll::Ready(err) = track.poll_closed(waiter) {
+							break 'serve Err(err);
+						}
+						if let Poll::Ready(err) = group.poll_closed(waiter) {
+							break 'serve Err(err);
+						}
+						match ingest.poll(&mut self.reader, group, waiter) {
+							Poll::Ready(res) => break 'serve res,
+							Poll::Pending => return Poll::Pending,
+						}
+					};
+
+					let GroupRecvState::Serve { group, .. } = std::mem::replace(&mut self.state, GroupRecvState::Done)
+					else {
+						unreachable!()
+					};
+					match res {
+						Ok(()) => {
+							let mut group = group;
+							let _ = group.finish();
+						}
+						Err(Error::Cancel) => {
+							let _ = group.abort(Error::Cancel);
+						}
+						Err(err) => {
+							tracing::debug!(%err, group = %group.sequence, "group error");
+							let _ = group.abort(err.clone());
+							return Poll::Ready(Err(err));
+						}
+					}
+					return Poll::Ready(Ok(()));
+				}
+				GroupRecvState::Done => return Poll::Ready(Ok(())),
+			}
+		}
+	}
+}
+
+/// Pumps bare FRAME messages from a reader into a group producer: the wire
+/// format shared by GROUP streams and FETCH responses.
+struct FrameIngest {
+	/// `Some` decodes the lite-05 zigzag-delta timestamp prefix; `None` stamps
+	/// local receive time (pre-lite-05).
+	timescale: Option<Timescale>,
+	/// Previous frame's raw timestamp value (in `timescale` units), for the
+	/// zigzag-delta decode. The first frame's delta is absolute (prev = 0).
+	prev_ts: u64,
+	phase: IngestPhase,
+}
+
+enum IngestPhase {
+	/// Reading the timestamp delta (skipped without a timescale). Stream end here
+	/// means the group has no more frames.
+	Timing,
+	/// Reading the frame size. Stream end here also ends the group (pre-lite-05,
+	/// where there is no timing prefix to act as the sentinel).
+	Size { timestamp: Option<Timestamp> },
+	/// Streaming the frame payload.
+	Payload { frame: frame::ProducerOwned },
+}
+
+impl FrameIngest {
+	fn new(timescale: Option<Timescale>) -> Self {
+		Self {
+			timescale,
+			prev_ts: 0,
+			phase: IngestPhase::Timing,
+		}
+	}
+
+	/// `Ready(Ok(()))` once the stream FINs on a frame boundary. The caller
+	/// finishes or aborts the group; a frame cut short mid-payload was already
+	/// aborted here with the reason.
+	fn poll<R: crate::transport::poll::RecvStream>(
+		&mut self,
+		reader: &mut Reader<R, Version>,
+		group: &mut group::Producer,
+		waiter: &kio::Waiter,
+	) -> Poll<Result<(), Error>> {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.phase {
+				IngestPhase::Timing => {
+					let Some(scale) = self.timescale else {
+						self.phase = IngestPhase::Size { timestamp: None };
+						continue;
+					};
+					// The timestamp delta doubles as the per-frame sentinel.
+					let Some(zz) = ready!(reader.poll_decode_maybe::<crate::coding::VarInt>(&mut cx))? else {
+						return Poll::Ready(Ok(()));
+					};
+					let next: u64 = (self.prev_ts as i128 + zz.to_zigzag() as i128)
+						.try_into()
+						.map_err(|_| Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
+					self.prev_ts = next;
+					let timestamp = Timestamp::new(next, scale)
+						.map_err(|_| Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
+					self.phase = IngestPhase::Size {
+						timestamp: Some(timestamp),
+					};
+				}
+				IngestPhase::Size { timestamp } => {
+					let Some(size) = ready!(reader.poll_decode_maybe::<u64>(&mut cx))? else {
+						return Poll::Ready(Ok(()));
+					};
+					// `create_frame_owned` is the allocation chokepoint and rejects an
+					// oversized `size` before allocating, so no pre-check is needed. No
+					// wire timestamp (pre-lite-05) means local receive time.
+					let timestamp = timestamp.unwrap_or_else(Timestamp::now);
+					let frame = group.create_frame_owned(frame::Info { size, timestamp })?;
+					self.phase = IngestPhase::Payload { frame };
+				}
+				IngestPhase::Payload { frame } => {
+					let failed = loop {
+						if frame.remaining() == 0 {
+							break None;
+						}
+						match reader.poll_read_chunk(&mut cx, frame.remaining()) {
+							Poll::Pending => return Poll::Pending,
+							Poll::Ready(Ok(Some(chunk))) if !chunk.is_empty() => {
+								if let Err(err) = frame.write(chunk) {
+									break Some(err);
+								}
+							}
+							Poll::Ready(Ok(_)) => break Some(Error::WrongSize),
+							Poll::Ready(Err(err)) => break Some(err),
+						}
+					};
+
+					let IngestPhase::Payload { frame } = std::mem::replace(&mut self.phase, IngestPhase::Timing) else {
+						unreachable!()
+					};
+					match failed {
+						None => frame.finish()?,
+						Some(err) => {
+							// Fail the group with the reason, not the Drop fallback's
+							// generic `Dropped`.
+							let _ = frame.abort(err.clone());
+							return Poll::Ready(Err(err));
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+/// Receives QUIC datagrams and routes each to its subscription's track producer
+/// (lite-05 §6.4).
+///
+/// A decode error or an unknown subscribe id drops that datagram without tearing
+/// down the session (best-effort); only a transport-level failure ends the loop.
+struct DatagramRecv<S: crate::transport::poll::Session> {
+	subscriber: Subscriber<S>,
+	// A dedicated receive handle: the poll interface takes `&mut self`.
+	recv: S,
+	enabled: bool,
+}
+
+impl<S: crate::transport::poll::Session> DatagramRecv<S> {
+	fn new(subscriber: Subscriber<S>) -> Self {
+		let recv = subscriber.session.clone();
+		let enabled = subscriber.version.has_datagrams() && recv.max_datagram_size() > 0;
+		Self {
+			subscriber,
+			recv,
+			enabled,
+		}
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		if !self.enabled {
+			return Poll::Ready(Ok(()));
+		}
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			let payload = ready!(self.recv.poll_recv_datagram(&mut cx)).map_err(Error::from_transport)?;
+			if let Err(err) = self.subscriber.route_datagram(payload) {
+				tracing::debug!(%err, "dropping datagram");
+			}
+		}
+	}
+}
+
+/// Opens a PROBE stream on demand while a consumer is interested.
+///
+/// Loops forever: wait for a consumer, race the probe stream against the
+/// consumer leaving, then loop back. Probe is best-effort, so stream errors are
+/// logged but never tear down the session.
+struct RecvBandwidth<S: crate::transport::poll::Session> {
+	subscriber: Subscriber<S>,
+	state: BandwidthState<S>,
+}
+
+enum BandwidthState<S: crate::transport::poll::Session> {
+	/// lite-05+ negotiates probing: only open a PROBE stream if the peer
+	/// advertised it (Report or higher) in its SETUP. Older versions have no
+	/// SETUP, so probe is always available there.
+	Gate,
+	/// Wait until at least one consumer is interested in the estimate.
+	WaitUsed,
+	/// Race the last consumer leaving against the probe stream ending.
+	Probing(ProbeStream<S>),
+}
+
+impl<S: crate::transport::poll::Session> RecvBandwidth<S> {
+	fn new(subscriber: Subscriber<S>) -> Self {
+		Self {
+			subscriber,
+			state: BandwidthState::Gate,
+		}
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		loop {
+			match &mut self.state {
+				BandwidthState::Gate => {
+					if self.subscriber.recv_bandwidth.is_none() {
+						return Poll::Ready(Ok(()));
+					}
+					if self.subscriber.version.has_setup_stream()
+						&& ready!(self.subscriber.peer_setup.poll_probe_level(waiter)) < lite::ProbeLevel::Report
+					{
+						tracing::debug!("peer does not support probing; skipping probe stream");
+						return Poll::Ready(Ok(()));
+					}
+					self.state = BandwidthState::WaitUsed;
+				}
+				BandwidthState::WaitUsed => {
+					let bandwidth = self.subscriber.recv_bandwidth.as_ref().expect("gated above");
+					match ready!(bandwidth.poll_used(waiter)) {
+						Ok(()) => self.state = BandwidthState::Probing(ProbeStream::new(&self.subscriber)),
+						Err(_) => return Poll::Ready(Ok(())),
+					}
+				}
+				BandwidthState::Probing(probe) => {
+					let bandwidth = self.subscriber.recv_bandwidth.as_ref().expect("gated above");
+					match bandwidth.poll_unused(waiter) {
+						// Loop back: a new consumer may arrive later. Dropping the probe
+						// machine resets its stream.
+						Poll::Ready(Ok(())) => {
+							self.state = BandwidthState::WaitUsed;
+							continue;
+						}
+						// The channel closed: give up for the rest of the session.
+						Poll::Ready(Err(_)) => return Poll::Ready(Ok(())),
+						Poll::Pending => {}
+					}
+					match ready!(probe.poll(waiter)) {
+						Ok(()) => tracing::debug!("probe stream closed"),
+						Err(err) => tracing::warn!(%err, "probe stream error"),
+					}
+					// The stream ended (peer FIN'd or errored). Don't hammer an
+					// uncooperative peer; give up for the rest of the session.
+					return Poll::Ready(Ok(()));
+				}
+			}
+		}
+	}
+}
+
+/// One PROBE stream: send the type, then feed the peer's estimates into the
+/// bandwidth producer until it FINs.
+struct ProbeStream<S: crate::transport::poll::Session> {
+	subscriber: Subscriber<S>,
+	session: S,
+	state: ProbeState<S>,
+}
+
+enum ProbeState<S: crate::transport::poll::Session> {
+	Open,
+	Send { stream: Stream<S, Version> },
+	Read { stream: Stream<S, Version> },
+}
+
+impl<S: crate::transport::poll::Session> ProbeStream<S> {
+	fn new(subscriber: &Subscriber<S>) -> Self {
+		Self {
+			subscriber: subscriber.clone(),
+			session: subscriber.session.clone(),
+			state: ProbeState::Open,
+		}
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.state {
+				ProbeState::Open => {
+					// After a GOAWAY the peer must not see new streams. Probe is
+					// best-effort; skip it rather than erroring.
+					if self.subscriber.going_away.is_set() {
+						return Poll::Ready(Ok(()));
+					}
+					let mut stream = ready!(Stream::poll_open(&mut self.session, self.subscriber.version, &mut cx))?;
+					stream.writer.buffer(&lite::ControlType::Probe)?;
+					self.state = ProbeState::Send { stream };
+				}
+				ProbeState::Send { stream } => {
+					ready!(stream.writer.poll_flush(&mut cx))?;
+					let ProbeState::Send { stream } = std::mem::replace(&mut self.state, ProbeState::Open) else {
+						unreachable!()
+					};
+					self.state = ProbeState::Read { stream };
+				}
+				ProbeState::Read { stream } => {
+					let bandwidth = self.subscriber.recv_bandwidth.as_ref().expect("gated by RecvBandwidth");
+					loop {
+						let Some(probe) = ready!(stream.reader.poll_decode_maybe::<lite::Probe>(&mut cx))? else {
+							return Poll::Ready(Ok(()));
+						};
+						bandwidth.set(Some(probe.bitrate))?;
+					}
+				}
+			}
+		}
 	}
 }
 
@@ -2368,9 +2655,9 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 			return;
 		}
 
-		let res = subscriber
-			.run_group(&mut stream.reader, producer.clone(), timescale)
-			.await;
+		let mut ingest = FrameIngest::new(timescale);
+		let mut group = producer.clone();
+		let res = kio::wait(|waiter| ingest.poll(&mut stream.reader, &mut group, waiter)).await;
 		match res {
 			Ok(()) => {
 				let _ = producer.finish();

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -600,6 +600,9 @@ struct UniServe<S: crate::transport::poll::Session> {
 	state: UniState<S>,
 }
 
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum UniState<S: crate::transport::poll::Session> {
 	/// Reading the stream's type.
 	Start {
@@ -689,6 +692,9 @@ struct GroupRecv<S: crate::transport::poll::Session> {
 	state: GroupRecvState,
 }
 
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum GroupRecvState {
 	/// Reading the GROUP header.
 	Header,
@@ -939,6 +945,9 @@ struct RecvBandwidth<S: crate::transport::poll::Session> {
 	state: BandwidthState<S>,
 }
 
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum BandwidthState<S: crate::transport::poll::Session> {
 	/// lite-05+ negotiates probing: only open a PROBE stream if the peer
 	/// advertised it (Report or higher) in its SETUP. Older versions have no
@@ -2398,6 +2407,9 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 }
 
 /// What a demand change asks the serve loop to do next.
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum Begin<S: crate::transport::poll::Session> {
 	/// Nothing further: the update (if any) sits in the active stream's write
 	/// buffer, flushed by the loop.
@@ -2531,6 +2543,9 @@ struct TrackServeRun<S: crate::transport::poll::Session> {
 	state: TrackRunState<S>,
 }
 
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum TrackRunState<S: crate::transport::poll::Session> {
 	/// Lite05+ learns the track's immutable properties once, up front, via a
 	/// TRACK stream. The timescale then flows into every SUBSCRIBE and FETCH
@@ -2720,6 +2735,9 @@ struct ServeLoop<S: crate::transport::poll::Session> {
 	mode: ServeMode<S>,
 }
 
+// A state machine's enum is its storage: one transient instance per stream, so the
+// big variant is the working state, not padding held in bulk.
+#[allow(clippy::large_enum_variant)]
 enum ServeMode<S: crate::transport::poll::Session> {
 	/// Selecting the next event.
 	Select,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -6,10 +6,7 @@ use std::{
 	time::Duration,
 };
 
-use futures::{StreamExt, stream::FuturesUnordered};
-
 use crate::poll_set::{Machine, PollSet};
-use crate::util::{MaybeBoxedExt, MaybeSendBox, TaskSet, Tasks};
 
 use crate::{
 	AsPath, Error, Path, PathOwned, Timescale, Timestamp, bandwidth,
@@ -41,8 +38,6 @@ pub(super) struct SubscriberConfig<S: crate::transport::poll::Session> {
 	/// Local policy for what pulling from this peer costs, overriding whatever it
 	/// declared in its SETUP. `None` charges the peer's declared price.
 	pub cost: Option<u64>,
-	/// Driver-owned scope for broadcast and track handlers.
-	pub tasks: Tasks,
 	/// Set once the peer sends a GOAWAY; new request streams are then rejected
 	/// with [`Error::GoingAway`] (the peer told us to stop asking).
 	pub going_away: crate::goaway::GoingAway,
@@ -79,9 +74,11 @@ pub(super) struct Subscriber<S: crate::transport::poll::Session> {
 	version: Version,
 	/// The peer's advertised SETUP (lite-05+), set when its Setup stream is read.
 	peer_setup: super::PeerSetup,
-	/// Local policy overriding the peer's declared egress price. See `resolve_cost`.
+	/// Local policy overriding the peer's declared egress price. See `poll_link_cost`.
 	cost: Option<u64>,
-	tasks: Tasks,
+	/// Sources created by the announce half, drained by the driver into
+	/// [`SourceServe`] machines.
+	sources: kio::Queue<(PathOwned, crate::broadcast::Dynamic)>,
 	going_away: crate::goaway::GoingAway,
 }
 
@@ -112,7 +109,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 			version: config.version,
 			peer_setup: config.peer_setup,
 			cost: config.cost,
-			tasks: config.tasks,
+			sources: kio::Queue::new(),
 			going_away: config.going_away,
 		}
 	}
@@ -138,221 +135,109 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	///
 	/// Our own price short-circuits the peer's, so a session that configured one never
 	/// blocks on a SETUP to start routing.
-	async fn resolve_cost(&self) -> u64 {
+	fn poll_link_cost(&self, waiter: &kio::Waiter) -> Poll<u64> {
 		// Older versions carry no cost on the wire, so nothing is charged and their
 		// routes rank on hop count alone. Returning early also avoids blocking on a
 		// SETUP that versions without a Setup Stream never send.
 		if !self.version.has_route_cost() {
-			return 0;
+			return Poll::Ready(0);
 		}
 		match self.cost {
-			Some(cost) => cost,
-			None => self.peer_setup.cost().await.unwrap_or(super::DEFAULT_COST),
+			Some(cost) => Poll::Ready(cost),
+			None => self
+				.peer_setup
+				.poll_cost(waiter)
+				.map(|cost| cost.unwrap_or(super::DEFAULT_COST)),
 		}
 	}
 
-	async fn run_announce(self, connecting: Option<ConnectingProducer>) -> Result<(), Error> {
-		let prefixes: Vec<PathOwned> = self.origin.allowed().map(|p| p.to_owned()).collect();
-
-		let mut tasks = FuturesUnordered::new();
-		for prefix in prefixes {
-			tasks.push(self.clone().run_announce_prefix(prefix, connecting.clone()));
-		}
-
-		// Each prefix holds its own producer clone; drop ours so the channel closes (and
-		// connect() unblocks) once the last prefix finishes its initial set. With no
-		// prefixes, this is the only producer, so the session is connected now.
-		drop(connecting);
-
-		while let Some(result) = tasks.next().await {
-			result?;
-		}
-
-		Ok(())
-	}
-
-	async fn run_announce_prefix(
-		mut self,
-		prefix: PathOwned,
-		mut connecting: Option<ConnectingProducer>,
+	/// Apply one received announce message to the origin and the per-stream
+	/// bookkeeping in `run`.
+	fn handle_announce(
+		&mut self,
+		prefix: &PathOwned,
+		announce: lite::AnnounceBroadcast<'_>,
+		run: &mut PrefixRun,
 	) -> Result<(), Error> {
-		// A peer that sent GOAWAY told us to stop opening streams on this session.
-		self.check_going_away()?;
-		let mut stream = Stream::open(&mut self.session, self.version).await?;
-		stream.writer.encode(&lite::ControlType::Announce).await?;
-
-		// Lite04/05: ask the peer to filter out announces that already passed through
-		// us, so the reflected ones never hit the wire. Encoding drops this on every
-		// other version, where start_announce below is the only filter.
-		let msg = lite::AnnounceRequest {
-			prefix: prefix.as_path(),
-			exclude_hop: self.self_origin.id(),
-		};
-		stream.writer.encode(&msg).await?;
-
-		// Lite05+: the publisher reports its own origin id (which we stamp onto every
-		// received Announce's hop chain, since it no longer does so itself) plus the
-		// count of initial active announces that follow immediately.
-		let (responder_origin, initial_count) = if self.version.has_announce_ok() {
-			let ok: lite::AnnounceOk = stream.reader.decode().await?;
-			// A peer may legally report id 0 (no identity). When the caller assigned
-			// it one, stand that in so the route isn't loop-blind.
-			let origin = match ok.origin.id() {
-				0 => self.peer_origin.unwrap_or(ok.origin),
-				_ => ok.origin,
-			};
-			(Some(origin), ok.active)
-		} else {
-			(None, 0)
-		};
-
-		// What we charge every announcement arriving on this stream. Resolved once:
-		// it comes from the connect config or the peer's SETUP, neither of which
-		// changes for the life of the session.
-		let link_cost = self.resolve_cost().await;
-
-		let mut routes = HashMap::new();
-
-		// Lite06+: announce ids. Each received `active` implicitly assigns the next
-		// per-stream ordinal; `ended`/`restart` reference it instead of repeating the
-		// path. Tracked even for announces we drop locally (reflected loops), since
-		// the sender doesn't know we dropped them. We never send a restart ourselves,
-		// but a peer may.
-		let mut next_announce_id: u64 = 0;
-		let mut announced_by_id: HashMap<u64, PathOwned> = HashMap::new();
-
-		// `connecting` is a local (a param), not a `self` field, so the `self.clone()` that
-		// start_announce uses for long-lived broadcast tasks doesn't carry the producer
-		// (which would keep the channel open for the broadcast's lifetime). Dropping it marks
-		// this prefix connected; on an early error it drops via scope exit, so a failed prefix
-		// can't hang connect().
-
-		match self.version {
-			Version::Lite01 | Version::Lite02 => {
-				let msg: lite::AnnounceInit = stream.reader.decode().await?;
-				for suffix in msg.suffixes {
-					let path = prefix.join(&suffix);
-					// Lite01/02 don't carry hop information; the broadcast starts with
-					// an empty chain and an unpriced link. Stats are attributed in the
-					// model when this enters the origin via `create_broadcast`.
+		match announce {
+			lite::AnnounceBroadcast::Active { suffix, hops, cost } => {
+				let path = prefix.join(&suffix);
+				if self.version.has_announce_id() {
+					// Every `active` assigns the next ordinal, even ones we drop locally.
+					run.announced_by_id.insert(run.next_announce_id, path.clone());
+					run.next_announce_id += 1;
+				}
+				if lite::restart_supported(self.version)
+					&& !self.version.has_announce_id()
+					&& run.routes.contains_key(&path)
+				{
+					// lite-05 only: a duplicate ANNOUNCE for an already-announced path is a RESTART;
+					// atomically replace the broadcast. Lite06+ restarts by announce id, and older
+					// versions never defined restarts, so both fall through to start_announce, which
+					// rejects the duplicate (Error::Duplicate).
+					self.restart_announce(
+						path.clone(),
+						hops,
+						cost,
+						run.link_cost,
+						run.responder_origin,
+						&mut run.routes,
+					)?;
+				} else {
 					self.start_announce(
 						path.clone(),
-						crate::OriginList::new(),
-						RouteCost::default(),
-						0,
-						responder_origin,
-						&mut routes,
+						hops,
+						cost,
+						run.link_cost,
+						run.responder_origin,
+						&mut run.routes,
 					)?;
 				}
+				// The first `initial_count` Active messages are the initial set; once
+				// they're all in, the caller drops its producer to mark this prefix
+				// connected.
+				run.initial_remaining = run.initial_remaining.saturating_sub(1);
 			}
-			_ => {
-				// Lite03+: no AnnounceInit, initial state comes via Announce messages.
-			}
-		}
+			lite::AnnounceBroadcast::Ended { suffix, .. } => {
+				let path = prefix.join(&suffix);
+				tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
 
-		// Release the producer once this prefix's initial set is in. Lite01/02 delivered it
-		// via AnnounceInit (consumed just above); Lite05 delivers `initial_count`
-		// Announce::Active counted in the loop below; Lite03/04 have no boundary (already None).
-		let mut initial_remaining = match self.version {
-			Version::Lite01 | Version::Lite02 => {
-				connecting.take();
-				0
+				// The matching Active may have been silently dropped by
+				// start_announce as a reflected loop, in which case
+				// `routes` has no entry; that's expected, not an error.
+				// A deliberate unannounce, so finish() rather than drop; the origin
+				// unannounces if this was the broadcast's last route.
+				if let Some(entry) = run.routes.remove(&path) {
+					entry.finish();
+				}
 			}
-			_ if self.version.has_announce_ok() => {
-				if initial_count == 0 {
-					connecting.take();
+			lite::AnnounceBroadcast::EndedId { id } => {
+				// Resolve and retire the id; an unknown or already-retired id is a
+				// protocol violation.
+				let Some(path) = run.announced_by_id.remove(&id) else {
+					return Err(Error::ProtocolViolation);
+				};
+				tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
+
+				if let Some(entry) = run.routes.remove(&path) {
+					entry.finish();
 				}
-				initial_count
 			}
-			_ => {
-				connecting.take();
-				0
-			}
-		};
-
-		while let Some(announce) = stream.reader.decode_maybe::<lite::AnnounceBroadcast>().await? {
-			match announce {
-				lite::AnnounceBroadcast::Active { suffix, hops, cost } => {
-					let path = prefix.join(&suffix);
-					if self.version.has_announce_id() {
-						// Every `active` assigns the next ordinal, even ones we drop locally.
-						announced_by_id.insert(next_announce_id, path.clone());
-						next_announce_id += 1;
-					}
-					if lite::restart_supported(self.version)
-						&& !self.version.has_announce_id()
-						&& routes.contains_key(&path)
-					{
-						// lite-05 only: a duplicate ANNOUNCE for an already-announced path is a RESTART;
-						// atomically replace the broadcast. Lite06+ restarts by announce id, and older
-						// versions never defined restarts, so both fall through to start_announce, which
-						// rejects the duplicate (Error::Duplicate).
-						self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
-					} else {
-						self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
-					}
-					// The first `initial_count` Active messages are the initial set; once
-					// they're all in, drop our producer to mark this prefix connected.
-					if initial_remaining > 0 {
-						initial_remaining -= 1;
-						if initial_remaining == 0 {
-							connecting.take();
-						}
-					}
-				}
-				lite::AnnounceBroadcast::Ended { suffix, .. } => {
-					let path = prefix.join(&suffix);
-					tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
-
-					// The matching Active may have been silently dropped by
-					// start_announce as a reflected loop, in which case
-					// `routes` has no entry; that's expected, not an error.
-					// A deliberate unannounce, so finish() rather than drop; the origin
-					// unannounces if this was the broadcast's last route.
-					if let Some(entry) = routes.remove(&path) {
-						entry.finish();
-					}
-				}
-				lite::AnnounceBroadcast::EndedId { id } => {
-					// Resolve and retire the id; an unknown or already-retired id is a
-					// protocol violation.
-					let Some(path) = announced_by_id.remove(&id) else {
-						return Err(Error::ProtocolViolation);
-					};
-					tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
-
-					// The matching Active may have been silently dropped by
-					// start_announce as a reflected loop, in which case
-					// `routes` has no entry; that's expected, not an error.
-					// A deliberate unannounce, so finish() rather than drop; the origin
-					// unannounces if this was the broadcast's last route.
-					if let Some(entry) = routes.remove(&path) {
-						entry.finish();
-					}
-				}
-				lite::AnnounceBroadcast::Restart { id, hops, cost } => {
-					// Resolve the id; it stays live (the replacement reuses it). An unknown
-					// or retired id is a protocol violation.
-					let Some(path) = announced_by_id.get(&id).cloned() else {
-						return Err(Error::ProtocolViolation);
-					};
-					if routes.contains_key(&path) {
-						self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
-					} else {
-						// The original announce was dropped locally (e.g. a reflected loop);
-						// the replacement may be routable, so treat it as a fresh start.
-						self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
-					}
+			lite::AnnounceBroadcast::Restart { id, hops, cost } => {
+				// Resolve the id; it stays live (the replacement reuses it). An unknown
+				// or retired id is a protocol violation.
+				let Some(path) = run.announced_by_id.get(&id).cloned() else {
+					return Err(Error::ProtocolViolation);
+				};
+				if run.routes.contains_key(&path) {
+					self.restart_announce(path, hops, cost, run.link_cost, run.responder_origin, &mut run.routes)?;
+				} else {
+					// The original announce was dropped locally (e.g. a reflected loop);
+					// the replacement may be routable, so treat it as a fresh start.
+					self.start_announce(path, hops, cost, run.link_cost, run.responder_origin, &mut run.routes)?;
 				}
 			}
 		}
-
-		// The read loop ended because the publisher FINed: it has nothing (more) to announce
-		// for this prefix (e.g. a publish-only peer). That's a clean completion of this
-		// announce stream, not a session error, so finish our side and return Ok. Tearing
-		// down only the announce stream is correct since no further progress can be made,
-		// but we must not propagate an error that would kill the whole connection.
-		stream.writer.finish().ok();
 		Ok(())
 	}
 
@@ -441,7 +326,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 
 		// Serve the origin's track requests for this source in the background; the
 		// announce loop keeps the producer so an unannounce can finish it.
-		self.tasks.push(self.clone().run_source(path.clone(), source.dynamic()));
+		let _ = self.sources.try_push((path.clone(), source.dynamic()));
 		routes.insert(path, AnnouncedRoute::new(source, publisher));
 
 		Ok(true)
@@ -533,58 +418,10 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		let Ok(source) = self.origin.create_broadcast(&path, metadata) else {
 			return Ok(false);
 		};
-		self.tasks.push(self.clone().run_source(path.clone(), source.dynamic()));
+		let _ = self.sources.try_push((path.clone(), source.dynamic()));
 		routes.insert(path, AnnouncedRoute::new(source, publisher));
 
 		Ok(true)
-	}
-
-	/// Serve the origin's track requests for one announced source until the peer
-	/// unannounces (the source is finished) or the session dies.
-	async fn run_source(self, path: PathOwned, mut dynamic: crate::broadcast::Dynamic) {
-		let mut tracks = TaskSet::owned();
-		let mut closed_session = self.session.clone();
-		loop {
-			let next = tracks
-				.drive(|waiter| {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					if closed_session.poll_closed(&mut cx).is_ready() {
-						return Poll::Ready(None);
-					}
-					// A draining peer usually stops announcing, so react to the signal
-					// itself; waiting for another message would leave the route primary
-					// until the session finally closed. Idempotent, since the signal
-					// stays set and this task wakes for other reasons too.
-					if self.going_away.poll(waiter).is_ready() {
-						dynamic.drain();
-					}
-					dynamic.poll_requested_track(waiter).map(Some)
-				})
-				.await;
-
-			let request = match next {
-				Some(Ok(request)) => request,
-				// The source was finished (unannounced) or aborted.
-				Some(Err(err)) => {
-					tracing::debug!(%err, "source closed");
-					break;
-				}
-				// Session gone.
-				None => break,
-			};
-
-			let name = request.name().to_string();
-
-			let serve = TrackServe {
-				subscriber: self.clone(),
-				path: path.clone(),
-				name,
-			};
-
-			// One task per track serves its lone subscription and any number of
-			// fetches concurrently.
-			tracks.push(serve.run(request));
-		}
 	}
 
 	/// Decode one datagram body and hand it to the matching subscription's producer.
@@ -622,44 +459,67 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	}
 }
 
-/// The subscriber half's driver: the uni-stream accept loop, the announce
-/// half, PROBE feedback, datagrams, and the per-source serve tasks, raced the
-/// way the old `select!` did. Only an error (or the task set draining) ends it.
+/// The subscriber half's driver: the announce prefixes, the uni-stream accept
+/// loop, PROBE feedback, datagrams, and the per-source serve machines. Only an
+/// error ends it.
 pub(super) struct SubscriberDriver<S: crate::transport::poll::Session> {
-	/// The announce half, still async. Its clean completion parks (a publish-only
-	/// peer has nothing to announce); only its error ends the session.
-	announce: Option<MaybeSendBox<'static, Result<(), Error>>>,
+	subscriber: Subscriber<S>,
+	/// Our own clone of the connection-progress producer, dropped on the first
+	/// poll. Holding it until then keeps `Connecting` pending so `connect()`
+	/// drives the driver at least once, exactly like the old announce task; the
+	/// per-prefix clones then own the boundary.
+	connecting: Option<ConnectingProducer>,
+	/// One machine per permitted prefix. Only an error ends the session; a
+	/// prefix finishing cleanly (publisher FIN) just retires.
+	prefixes: Vec<AnnouncePrefix<S>>,
 	uni: UniAccept<S>,
 	/// PROBE feedback; finishes quietly when unsupported or given up on.
 	bandwidth: Option<RecvBandwidth<S>>,
 	/// Datagram receive; inert on a version or transport without datagrams.
 	datagrams: Option<DatagramRecv<S>>,
-	/// Driver-owned scope for broadcast and track handlers.
-	tasks: TaskSet,
+	/// One machine per announced source, serving the origin's track requests.
+	sources: PollSet<SourceServe<S>>,
 }
 
 impl<S: crate::transport::poll::Session> SubscriberDriver<S> {
 	/// `connecting` is the connection-progress producer for this session (None for
-	/// versions with no initial-set boundary). It is threaded through the announce path
-	/// rather than stored on `Subscriber`: the struct is cloned for several long-lived
-	/// tasks, and any clone retaining a producer would keep the channel open and hang
-	/// `connect()`.
-	pub fn new(subscriber: Subscriber<S>, connecting: Option<ConnectingProducer>, tasks: TaskSet) -> Self {
+	/// versions with no initial-set boundary). Each prefix holds its own clone and
+	/// drops it once its initial set is in; with no prefixes it drops here, so the
+	/// session is connected now.
+	pub fn new(subscriber: Subscriber<S>, connecting: Option<ConnectingProducer>) -> Self {
+		let prefixes = subscriber
+			.origin
+			.allowed()
+			.map(|p| p.to_owned())
+			.collect::<Vec<PathOwned>>()
+			.into_iter()
+			.map(|prefix| AnnouncePrefix::new(subscriber.clone(), prefix, connecting.clone()))
+			.collect();
+
 		Self {
-			announce: Some(subscriber.clone().run_announce(connecting).maybe_boxed()),
+			connecting,
+			prefixes,
 			uni: UniAccept::new(subscriber.clone()),
 			bandwidth: Some(RecvBandwidth::new(subscriber.clone())),
-			datagrams: Some(DatagramRecv::new(subscriber)),
-			tasks,
+			datagrams: Some(DatagramRecv::new(subscriber.clone())),
+			sources: PollSet::new(),
+			subscriber,
 		}
 	}
 
 	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
-		if let Some(announce) = &mut self.announce {
-			match waiter.poll_future(announce.as_mut()) {
+		// Each prefix holds its own clone; with no prefixes, this drop is what
+		// marks the session connected.
+		self.connecting.take();
+
+		let mut i = 0;
+		while i < self.prefixes.len() {
+			match self.prefixes[i].poll(waiter) {
+				Poll::Ready(Ok(())) => {
+					self.prefixes.swap_remove(i);
+				}
 				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
-				Poll::Ready(Ok(())) => self.announce = None,
-				Poll::Pending => {}
+				Poll::Pending => i += 1,
 			}
 		}
 		if let Poll::Ready(res) = self.uni.poll(waiter) {
@@ -679,9 +539,15 @@ impl<S: crate::transport::poll::Session> SubscriberDriver<S> {
 				Poll::Pending => {}
 			}
 		}
-		if self.tasks.poll(waiter).is_ready() {
-			return Poll::Ready(Ok(()));
+
+		// Sources created by the announce half; their completion never ends the
+		// session (the origin delivers the unannounce itself).
+		while let Poll::Ready(Ok((path, dynamic))) = self.subscriber.sources.poll_pop(waiter) {
+			self.sources
+				.push(SourceServe::new(self.subscriber.clone(), path, dynamic));
 		}
+		let _ = self.sources.poll(waiter);
+
 		Poll::Pending
 	}
 }
@@ -1198,12 +1064,289 @@ impl<S: crate::transport::poll::Session> ProbeStream<S> {
 	}
 }
 
+/// One announce-interest stream: sends the ANNOUNCE_REQUEST for a prefix, then
+/// feeds every received announce into the origin. Only its *error* ends the
+/// session; a publisher FIN is a clean end for the prefix alone.
+struct AnnouncePrefix<S: crate::transport::poll::Session> {
+	subscriber: Subscriber<S>,
+	prefix: PathOwned,
+	// Dropped once this prefix's initial set is in (or on any exit), so a failed
+	// prefix can't hang connect().
+	connecting: Option<ConnectingProducer>,
+	state: PrefixState<S>,
+}
+
+enum PrefixState<S: crate::transport::poll::Session> {
+	/// Opening the control stream (after the GOAWAY gate).
+	Open,
+	/// Flushing the buffered request.
+	Send { stream: Stream<S, Version> },
+	/// Lite05+: reading the publisher's ANNOUNCE_OK.
+	ReadOk { stream: Stream<S, Version> },
+	/// Waiting for the link cost (may block on the peer's SETUP).
+	Cost {
+		stream: Stream<S, Version>,
+		responder_origin: Option<crate::Origin>,
+		initial_count: u64,
+	},
+	/// Lite01/02: reading the ANNOUNCE_INIT set.
+	ReadInit { stream: Stream<S, Version>, run: PrefixRun },
+	/// Streaming announce updates.
+	Run { stream: Stream<S, Version>, run: PrefixRun },
+}
+
+/// The announce-decode loop's state, split out so the states above can share it.
+struct PrefixRun {
+	responder_origin: Option<crate::Origin>,
+	/// What we charge every announcement arriving on this stream. Resolved once:
+	/// it comes from the connect config or the peer's SETUP, neither of which
+	/// changes for the life of the session.
+	link_cost: u64,
+	/// The first `initial_count` Active messages are the initial set; once
+	/// they're all in, the connecting producer drops to mark this prefix
+	/// connected.
+	initial_remaining: u64,
+	routes: HashMap<PathOwned, AnnouncedRoute>,
+	// Lite06+: announce ids. Each received `active` implicitly assigns the next
+	// per-stream ordinal; `ended`/`restart` reference it instead of repeating the
+	// path. Tracked even for announces we drop locally (reflected loops), since
+	// the sender doesn't know we dropped them. We never send a restart ourselves,
+	// but a peer may.
+	next_announce_id: u64,
+	announced_by_id: HashMap<u64, PathOwned>,
+}
+
+impl<S: crate::transport::poll::Session> AnnouncePrefix<S> {
+	fn new(subscriber: Subscriber<S>, prefix: PathOwned, connecting: Option<ConnectingProducer>) -> Self {
+		Self {
+			subscriber,
+			prefix,
+			connecting,
+			state: PrefixState::Open,
+		}
+	}
+
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.state {
+				PrefixState::Open => {
+					// A peer that sent GOAWAY told us to stop opening streams on this session.
+					self.subscriber.check_going_away()?;
+					let mut stream = ready!(Stream::poll_open(
+						&mut self.subscriber.session,
+						self.subscriber.version,
+						&mut cx
+					))?;
+
+					stream.writer.buffer(&lite::ControlType::Announce)?;
+					// Lite04/05: ask the peer to filter out announces that already passed
+					// through us, so the reflected ones never hit the wire. Encoding drops
+					// this on every other version, where start_announce below is the only
+					// filter.
+					stream.writer.buffer(&lite::AnnounceRequest {
+						prefix: self.prefix.as_path(),
+						exclude_hop: self.subscriber.self_origin.id(),
+					})?;
+					self.state = PrefixState::Send { stream };
+				}
+				PrefixState::Send { stream } => {
+					ready!(stream.writer.poll_flush(&mut cx))?;
+					let PrefixState::Send { stream } = std::mem::replace(&mut self.state, PrefixState::Open) else {
+						unreachable!()
+					};
+					self.state = match self.subscriber.version.has_announce_ok() {
+						true => PrefixState::ReadOk { stream },
+						false => PrefixState::Cost {
+							stream,
+							responder_origin: None,
+							initial_count: 0,
+						},
+					};
+				}
+				PrefixState::ReadOk { stream } => {
+					// Lite05+: the publisher reports its own origin id (which we stamp onto
+					// every received Announce's hop chain, since it no longer does so
+					// itself) plus the count of initial active announces that follow
+					// immediately.
+					let ok = ready!(stream.reader.poll_decode::<lite::AnnounceOk>(&mut cx))?;
+					// A peer may legally report id 0 (no identity). When the caller assigned
+					// it one, stand that in so the route isn't loop-blind.
+					let origin = match ok.origin.id() {
+						0 => self.subscriber.peer_origin.unwrap_or(ok.origin),
+						_ => ok.origin,
+					};
+					let PrefixState::ReadOk { stream } = std::mem::replace(&mut self.state, PrefixState::Open) else {
+						unreachable!()
+					};
+					self.state = PrefixState::Cost {
+						stream,
+						responder_origin: Some(origin),
+						initial_count: ok.active,
+					};
+				}
+				PrefixState::Cost { .. } => {
+					let link_cost = ready!(self.subscriber.poll_link_cost(waiter));
+					let PrefixState::Cost {
+						stream,
+						responder_origin,
+						initial_count,
+					} = std::mem::replace(&mut self.state, PrefixState::Open)
+					else {
+						unreachable!()
+					};
+
+					let mut run = PrefixRun {
+						responder_origin,
+						link_cost,
+						initial_remaining: 0,
+						routes: HashMap::new(),
+						next_announce_id: 0,
+						announced_by_id: HashMap::new(),
+					};
+
+					// Release the producer once this prefix's initial set is in. Lite01/02
+					// deliver it via ANNOUNCE_INIT (the ReadInit state); Lite05 delivers
+					// `initial_count` Announce::Active counted in the run loop; Lite03/04
+					// have no boundary.
+					match self.subscriber.version {
+						Version::Lite01 | Version::Lite02 => {
+							self.state = PrefixState::ReadInit { stream, run };
+						}
+						_ if self.subscriber.version.has_announce_ok() => {
+							if initial_count == 0 {
+								self.connecting.take();
+							}
+							run.initial_remaining = initial_count;
+							self.state = PrefixState::Run { stream, run };
+						}
+						_ => {
+							self.connecting.take();
+							self.state = PrefixState::Run { stream, run };
+						}
+					}
+				}
+				PrefixState::ReadInit { stream, run } => {
+					let msg = ready!(stream.reader.poll_decode::<lite::AnnounceInit>(&mut cx))?;
+					for suffix in msg.suffixes {
+						let path = self.prefix.join(&suffix);
+						// Lite01/02 don't carry hop information; the broadcast starts with
+						// an empty chain and an unpriced link. Stats are attributed in the
+						// model when this enters the origin via `create_broadcast`.
+						self.subscriber.start_announce(
+							path.clone(),
+							crate::OriginList::new(),
+							RouteCost::default(),
+							0,
+							run.responder_origin,
+							&mut run.routes,
+						)?;
+					}
+					self.connecting.take();
+					let PrefixState::ReadInit { stream, run } = std::mem::replace(&mut self.state, PrefixState::Open)
+					else {
+						unreachable!()
+					};
+					self.state = PrefixState::Run { stream, run };
+				}
+				PrefixState::Run { stream, run } => {
+					loop {
+						let Some(announce) =
+							ready!(stream.reader.poll_decode_maybe::<lite::AnnounceBroadcast>(&mut cx))?
+						else {
+							// The publisher FINed: it has nothing (more) to announce for this
+							// prefix (e.g. a publish-only peer). That's a clean completion of
+							// this announce stream, not a session error, so finish our side
+							// and return Ok. Tearing down only the announce stream is correct
+							// since no further progress can be made, but we must not
+							// propagate an error that would kill the whole connection.
+							stream.writer.finish().ok();
+							return Poll::Ready(Ok(()));
+						};
+						self.subscriber.handle_announce(&self.prefix, announce, run)?;
+						if run.initial_remaining == 0 {
+							self.connecting.take();
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+/// Serves the origin's track requests for one announced source until the peer
+/// unannounces (the source is finished) or the session dies. Dropping it drops
+/// the in-flight track machines with it.
+struct SourceServe<S: crate::transport::poll::Session> {
+	subscriber: Subscriber<S>,
+	path: PathOwned,
+	dynamic: crate::broadcast::Dynamic,
+	// A dedicated close-watch handle, since each pending operation needs its own.
+	closed: S,
+	tracks: PollSet<TrackServeRun<S>>,
+}
+
+impl<S: crate::transport::poll::Session> SourceServe<S> {
+	fn new(subscriber: Subscriber<S>, path: PathOwned, dynamic: crate::broadcast::Dynamic) -> Self {
+		let closed = subscriber.session.clone();
+		Self {
+			subscriber,
+			path,
+			dynamic,
+			closed,
+			tracks: PollSet::new(),
+		}
+	}
+}
+
+impl<S: crate::transport::poll::Session> Machine for SourceServe<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		let _ = self.tracks.poll(waiter);
+
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			if self.closed.poll_closed(&mut cx).is_ready() {
+				// Session gone.
+				return Poll::Ready(());
+			}
+			// A draining peer usually stops announcing, so react to the signal
+			// itself; waiting for another message would leave the route primary
+			// until the session finally closed. Idempotent, since the signal
+			// stays set and this task wakes for other reasons too.
+			if self.subscriber.going_away.poll(waiter).is_ready() {
+				self.dynamic.drain();
+			}
+			match self.dynamic.poll_requested_track(waiter) {
+				Poll::Ready(Ok(request)) => {
+					let serve = TrackServe {
+						subscriber: self.subscriber.clone(),
+						path: self.path.clone(),
+						name: request.name().to_string(),
+					};
+					// One machine per track serves its lone subscription and any number
+					// of fetches concurrently.
+					self.tracks.push(TrackServeRun::new(serve, request));
+				}
+				// The source was finished (unannounced) or aborted.
+				Poll::Ready(Err(err)) => {
+					tracing::debug!(%err, "source closed");
+					return Poll::Ready(());
+				}
+				Poll::Pending => break,
+			}
+		}
+
+		// Newly requested tracks start now rather than on the next wake.
+		let _ = self.tracks.poll(waiter);
+		Poll::Pending
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::coding::Decode;
 	use crate::lite::test_transport::SinkSession;
-	use crate::util::TaskSet;
 
 	const VERSION: Version = Version::Lite05;
 
@@ -1222,7 +1365,6 @@ mod tests {
 		let session = SinkSession::gated_bi(gate.consume());
 
 		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
-		let (tasks, _task_set) = TaskSet::new();
 		let subscriber = Subscriber::new(SubscriberConfig {
 			session: session.clone(),
 			origin,
@@ -1231,7 +1373,6 @@ mod tests {
 			peer_setup: Default::default(),
 			peer_origin: None,
 			cost: None,
-			tasks,
 			going_away: Default::default(),
 		});
 		let subscribes = subscriber.subscribes.clone();
@@ -1286,7 +1427,6 @@ mod tests {
 		producer: track::Producer,
 		_broadcast: crate::broadcast::Producer,
 		_gate: kio::Producer<bool>,
-		_tasks: TaskSet,
 	}
 
 	impl Harness {
@@ -1297,7 +1437,6 @@ mod tests {
 			let gate = kio::Producer::new(true);
 			let session = SinkSession::gated_bi(gate.consume());
 			let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
-			let (tasks, _tasks) = TaskSet::new();
 			let subscriber = Subscriber::new(SubscriberConfig {
 				session: session.clone(),
 				origin,
@@ -1306,7 +1445,6 @@ mod tests {
 				peer_setup: Default::default(),
 				peer_origin: None,
 				cost: None,
-				tasks,
 				going_away: Default::default(),
 			});
 			let mut broadcast = crate::broadcast::Info::new().produce();
@@ -1322,7 +1460,6 @@ mod tests {
 				producer,
 				_broadcast: broadcast,
 				_gate: gate,
-				_tasks,
 			}
 		}
 
@@ -1725,7 +1862,6 @@ mod tests {
 
 		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let consumer = origin.consume();
-		let (tasks, _task_set) = TaskSet::new();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session,
 			origin,
@@ -1734,7 +1870,6 @@ mod tests {
 			peer_setup: Default::default(),
 			peer_origin: Some(assigned),
 			cost: None,
-			tasks,
 			going_away: Default::default(),
 		});
 
@@ -1789,9 +1924,6 @@ mod tests {
 	fn restart_subscriber(session: SinkSession) -> (Subscriber<SinkSession>, crate::origin::Consumer) {
 		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let consumer = origin.consume();
-		let (tasks, task_set) = TaskSet::new();
-		// The task set must outlive the test; leak it so spawned run_source tasks stay alive.
-		std::mem::forget(task_set);
 		let subscriber = Subscriber::new(SubscriberConfig {
 			session,
 			origin,
@@ -1800,7 +1932,6 @@ mod tests {
 			peer_setup: Default::default(),
 			cost: None,
 			peer_origin: None,
-			tasks,
 			going_away: Default::default(),
 		});
 		(subscriber, consumer)
@@ -1899,8 +2030,6 @@ mod tests {
 	async fn a_lost_announce_stream_closes_the_broadcast() {
 		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let consumer = origin.consume();
-		let (tasks, task_set) = TaskSet::new();
-		std::mem::forget(task_set);
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session: SinkSession::new(Default::default()),
 			origin,
@@ -1909,7 +2038,6 @@ mod tests {
 			peer_setup: Default::default(),
 			cost: None,
 			peer_origin: None,
-			tasks,
 			going_away: Default::default(),
 		});
 
@@ -2054,25 +2182,6 @@ enum Teardown {
 	Released,
 }
 
-/// One step for the [`TrackServe`] loop, produced by racing track demand, the
-/// upstream stream, and the session.
-enum Event {
-	/// A consumer fetched a past group.
-	Fetch(track::GroupRequest),
-	/// The downstream aggregate subscription changed (`None` once the last subscriber leaves).
-	Subscription(Option<Subscription>),
-	/// An in-flight fetch finished.
-	FetchDone,
-	/// The upstream subscribe stream carried a START/END/DROP response.
-	SubResponse(lite::SubscribeResponse),
-	/// The upstream subscribe stream closed: `Ok` is a clean FIN, `Err` a transport error.
-	SubClosed(Result<(), Error>),
-	/// Every reader of this copy went away (the origin released it).
-	Unused,
-	/// The whole session died.
-	SessionClosed,
-}
-
 /// Serves one requested track for a relay: owns this session's copy of the
 /// track (spliced into the origin's logical track), driving the single upstream
 /// subscription (opened lazily on the first downstream subscriber, canceled when
@@ -2085,266 +2194,6 @@ struct TrackServe<S: crate::transport::poll::Session> {
 }
 
 impl<S: crate::transport::poll::Session> TrackServe<S> {
-	async fn run(self, request: track::Request) {
-		// SUBSCRIBE_UPDATE only exists on Lite03+, so older peers can't carry a
-		// preference change to an established subscription.
-		let supports_update = !matches!(self.subscriber.version, Version::Lite01 | Version::Lite02);
-		let supports_fetch = self.subscriber.version.has_track_stream();
-
-		// Lite05+ learns the track's immutable properties once, up front, via a TRACK
-		// stream. The timescale then flows into every SUBSCRIBE and FETCH without a
-		// per-response header. Older drafts have no TRACK stream, so the wire carries
-		// no properties at all and the defaults apply.
-		let (info, timescale) = if self.subscriber.version.has_track_stream() {
-			match self.track_info().await {
-				Ok(info) => {
-					// Lite05 carries per-frame timestamps on the wire at this scale; `Some`
-					// tells `run_group` to decode them instead of stamping local receive time.
-					let timescale = Some(info.timescale);
-					(info, timescale)
-				}
-				Err(err) => {
-					tracing::warn!(broadcast = %self.subscriber.log_path(&self.path), track = %self.name, %err, "track info failed");
-					// Rejecting the request lets the origin retry (bounded) on another
-					// source; waiting subscribers stall rather than error meanwhile.
-					request.reject(err);
-					return;
-				}
-			}
-		} else {
-			// No TRACK stream, so the publisher's retention window never reaches us: the
-			// accepting side picks it (see `origin::Info::latency_default`).
-			let info = track::Info::default().with_latency_max(self.subscriber.origin.latency_default());
-			(info, None)
-		};
-
-		// Accept with the resolved info. The origin splices this session's copy
-		// into the logical track; demand from the logical subscribers arrives
-		// through the producer's aggregate, sliced to this segment's bounds
-		// (including the resume floor after a source change).
-		let mut serving = request.accept(info);
-
-		// Serve on-demand fetches of uncached groups from this session.
-		let dynamic = serving.dynamic();
-
-		let mut sub = Sub::None;
-		let mut fetches: FuturesUnordered<MaybeSendBox<'static, ()>> = FuturesUnordered::new();
-
-		let teardown = loop {
-			let event = {
-				let mut closed_session = self.subscriber.session.clone();
-				// Biased: demand first, then completions, then closures.
-				kio::wait(|waiter| {
-					// (1) Track demand: a fetch, a subscription change, or the origin
-					// handing the track to another route. Polled under one waiter so
-					// the borrows of `dynamic` and `serving` are held together.
-
-					// A fetch is cheap and one-shot, so serve it ahead of subscription churn.
-					match dynamic.poll_requested_group(waiter) {
-						Poll::Ready(Ok(req)) => return Poll::Ready(Event::Fetch(req)),
-						// Our own producer is alive (we hold it); treat as terminal anyway.
-						Poll::Ready(Err(_)) => return Poll::Ready(Event::SessionClosed),
-						Poll::Pending => {}
-					}
-					match serving.poll_subscription_changed(waiter) {
-						Poll::Ready(Ok(pref)) => return Poll::Ready(Event::Subscription(pref)),
-						Poll::Ready(Err(_)) => return Poll::Ready(Event::SessionClosed),
-						Poll::Pending => {}
-					}
-
-					// (2) An in-flight fetch completed. An empty set is skipped (it reports
-					// terminated without registering a waker); this loop is what refills it.
-					if !fetches.is_empty() {
-						let mut cx = std::task::Context::from_waker(waiter.waker());
-						if let Poll::Ready(Some(())) = fetches.poll_next_unpin(&mut cx) {
-							return Poll::Ready(Event::FetchDone);
-						}
-					}
-
-					// (3) Nobody reads this copy anymore: the origin released it after its
-					// idle linger, so drop it instead of holding the track state (and its
-					// TRACK_INFO) for a reader that may never return. In-flight fetches
-					// keep it alive: work already accepted still gets finished.
-					if fetches.is_empty() && serving.poll_unused(waiter).is_ready() {
-						return Poll::Ready(Event::Unused);
-					}
-
-					// (4) The upstream subscribe stream closed, or carried a START/END/DROP.
-					// Partial message bytes persist in the reader's buffer across turns.
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					if let Sub::Active(active) = &mut sub
-						&& let Poll::Ready(res) = active
-							.stream
-							.reader
-							.poll_decode_maybe::<lite::SubscribeResponse>(&mut cx)
-					{
-						return Poll::Ready(match res {
-							Ok(Some(msg)) => Event::SubResponse(msg),
-							Ok(None) => Event::SubClosed(Ok(())),
-							Err(err) => Event::SubClosed(Err(err)),
-						});
-					}
-
-					// (5) The session died: hand the track back for another route.
-					if closed_session.poll_closed(&mut cx).is_ready() {
-						return Poll::Ready(Event::SessionClosed);
-					}
-
-					Poll::Pending
-				})
-				.await
-			};
-
-			match event {
-				Event::Fetch(req) => {
-					if supports_fetch {
-						fetches.push(self.clone().serve_fetch(req, timescale).maybe_boxed());
-					} else {
-						req.reject(Error::Version);
-					}
-				}
-				Event::Subscription(pref) => {
-					if let Err(err) = self
-						.handle_subscription(&mut serving, &mut sub, pref, supports_update, timescale)
-						.await
-					{
-						// Opening or updating the upstream failed (usually the session
-						// dying): hand the track back for another route to resume.
-						break Teardown::GiveBack(err);
-					}
-				}
-				Event::FetchDone => {}
-				Event::SubResponse(msg) => match &msg {
-					// SUBSCRIBE_END declares the track's exclusive final sequence, which may
-					// arrive while trailing groups are still in flight. Record it on this
-					// segment's producer so consumers learn the boundary early; the later
-					// stream FIN then finds the track already finished.
-					lite::SubscribeResponse::End(end) => {
-						// finish_at rejects a boundary at or below the live edge, which is what a
-						// peer sending an inclusive bound looks like once the final group has
-						// already arrived. Don't abort: the stream FIN still finishes the track,
-						// so this only costs the early boundary. Warn anyway, since it's our only
-						// signal that a peer disagrees about the encoding.
-						if let Err(err) = serving.finish_at(end.group) {
-							tracing::warn!(track = %self.name, group = end.group, %err, "invalid subscribe end");
-						}
-					}
-					// SUBSCRIBE_START names the first group this feed serves: the publisher
-					// skipped everything below it (e.g. it could not serve the requested
-					// frame). Record it as a drop signal, so a spliced reader waiting on a
-					// skipped group fails over instead of stalling on a live route.
-					lite::SubscribeResponse::Start(start) => {
-						// A START describes the demand the SUBSCRIBE carried. It applies
-						// only while the current start still matches that demand (updates
-						// get no fresh START, so an update that moved the start makes it
-						// stale, and one that moved back restores it); elsewhere the
-						// request-tracked floor stands rather than a guess.
-						if let Sub::Active(active) = &sub
-							&& active.start == active.requested
-						{
-							let _ = serving.start_at(start.group);
-						}
-					}
-					// OK/DROP just resolve the range (the producer already orders groups).
-					_ => tracing::debug!(track = %self.name, ?msg, "subscribe response"),
-				},
-				Event::SubClosed(Ok(())) => {
-					tracing::info!(broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "subscribe complete");
-					// Upstream FIN'd the subscription: the publisher only FINs once the
-					// track's final sequence is known and delivered, so the logical
-					// track is over for good (bounded downstream demand alone never
-					// FINs; the publisher parks, since a cap can be raised).
-					break Teardown::Finished;
-				}
-				Event::SubClosed(Err(err)) => {
-					tracing::warn!(broadcast = %self.subscriber.log_path(&self.path), track = %self.name, %err, "subscribe error");
-					break Teardown::GiveBack(err);
-				}
-				Event::Unused => {
-					tracing::debug!(broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "track released (idle)");
-					break Teardown::Released;
-				}
-				Event::SessionClosed => {
-					break Teardown::GiveBack(Error::Dropped);
-				}
-			}
-		};
-
-		if let Sub::Active(active) = &mut sub {
-			self.subscriber.subscribes.lock().remove(&active.id);
-			let _ = active.stream.writer.finish();
-		}
-
-		match teardown {
-			// The upstream ended the track for good; the origin observes the
-			// completed copy and finishes the logical track.
-			Teardown::Finished => {
-				let _ = serving.finish();
-			}
-			Teardown::GiveBack(err) => {
-				// Mark this copy dead: subscribers stall while the origin
-				// re-splices the track from the next source.
-				let _ = serving.abort(err);
-			}
-			Teardown::Released => {
-				// A deliberate end with no reader to observe it, which also drops the
-				// cached groups. The origin re-requests the track from this session if
-				// one comes back.
-				let _ = serving.abort(Error::Cancel);
-			}
-		}
-	}
-
-	/// Open a TRACK stream, read the single TRACK_INFO, and map it to the model's
-	/// [`track::Info`]. Lite05+ only. Bails if the broadcast dies meanwhile.
-	async fn track_info(&self) -> Result<track::Info, Error> {
-		self.subscriber.check_going_away()?;
-		let mut session = self.subscriber.session.clone();
-		let mut stream = Stream::open(&mut session, self.subscriber.version).await?;
-		stream.writer.encode(&lite::ControlType::Track).await?;
-		stream
-			.writer
-			.encode(&lite::Track {
-				broadcast: self.path.as_path(),
-				track: self.name.as_str().into(),
-			})
-			.await?;
-
-		let info = kio::wait(|waiter| {
-			let mut cx = std::task::Context::from_waker(waiter.waker());
-			if session.poll_closed(&mut cx).is_ready() {
-				return Poll::Ready(Err(Error::Dropped));
-			}
-			stream.reader.poll_decode::<lite::TrackInfo>(&mut cx)
-		})
-		.await?;
-		// The publisher FINs after TRACK_INFO; FIN our side too and let the stream drop.
-		let _ = stream.writer.finish();
-
-		// Publisher Max Latency rides on the wire, so the local retention window
-		// matches what the upstream advertises (relays re-serve with the same bound).
-		// `broadcast` is left at its default here; `track::Request::accept` stamps
-		// the track's real broadcast.
-		let model = track::Info::default()
-			.with_timescale(info.timescale)
-			.with_latency_max(info.latency_max)
-			.with_priority(info.priority)
-			.with_ordered(info.ordered);
-		Ok(model)
-	}
-
-	/// Widen a frame-precise request to whole groups when the peer predates lite-06.
-	///
-	/// The codec refuses to encode a frame bound an older peer cannot carry, since
-	/// widening at the message layer would hand the *caller* frames it excluded. Here we
-	/// are the caller, and we want the wider range: every group is positioned and capped
-	/// again on the read side ([`group::Consumer::start_at`] / `end_at`, driven by
-	/// [`crate::model::resume`]), so the extra frames are filtered locally and never
-	/// reach a subscriber. The only cost is transferring frames we already hold.
-	///
-	/// Passing the request through unchanged instead would fail the SUBSCRIBE, hand the
-	/// track back, and leave the origin re-splicing the same route indefinitely: the
-	/// splice itself keeps succeeding, so the retry budget never trips.
 	fn widen_frame_bounds(&self, subscription: &mut Subscription) {
 		if self.subscriber.version.has_frame_bounds() {
 			return;
@@ -2372,16 +2221,17 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 		subscription.end = end;
 	}
 
-	/// Apply a subscription-demand change: open the upstream SUBSCRIBE on the first
-	/// subscriber, update it while live, or cancel it when the last one leaves.
-	async fn handle_subscription(
+	/// Apply a subscription-demand change: hand back an [`Establish`] to open the
+	/// upstream SUBSCRIBE on the first subscriber, buffer a SUBSCRIBE_UPDATE while
+	/// live (the caller flushes), or cancel outright when the last one leaves.
+	fn begin_subscription(
 		&self,
 		producer: &mut track::Producer,
 		sub: &mut Sub<S>,
 		pref: Option<Subscription>,
 		supports_update: bool,
 		timescale: Option<Timescale>,
-	) -> Result<(), Error> {
+	) -> Result<Begin<S>, Error> {
 		// An empty half-open range asks for nothing, and the wire cannot say that: its
 		// bounds are inclusive, so the nearest encoding either hands back the position
 		// the caller excluded or inverts the range outright once the two bounds meet. No
@@ -2398,7 +2248,11 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 				match sub {
 					Sub::None => {
 						// Open an upstream SUBSCRIBE for the first subscriber.
-						self.establish(producer, sub, subscription, timescale).await?;
+						Ok(Begin::Establish(self.prepare_establish(
+							producer,
+							subscription,
+							timescale,
+						)))
 					}
 					Sub::Active(active) => {
 						// Downstream preferences changed: forward them upstream as a
@@ -2420,8 +2274,9 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 							if start_moved {
 								let _ = producer.start_at(active.start.map(|start| start.group));
 							}
-							self.send_update(active, subscription.end).await?;
+							buffer_update(active, subscription.end)?;
 						}
+						Ok(Begin::None)
 					}
 				}
 			}
@@ -2436,34 +2291,25 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 					tracing::info!(track = %self.name, "subscribe canceled (idle)");
 					*sub = Sub::None;
 				}
+				Ok(Begin::None)
 			}
 		}
-		Ok(())
 	}
 
-	/// Open the SUBSCRIBE control stream and send the request.
-	async fn open_subscribe(&self, msg: &lite::Subscribe<'_>) -> Result<Stream<S, Version>, Error> {
-		self.subscriber.check_going_away()?;
-		let mut session = self.subscriber.session.clone();
-		let mut stream = Stream::open(&mut session, self.subscriber.version).await?;
-		stream.writer.encode(&lite::ControlType::Subscribe).await?;
-		stream.writer.encode(msg).await?;
-		Ok(stream)
-	}
-
-	/// Open the upstream SUBSCRIBE and start routing groups into the producer.
+	/// Allocate the id, set the demand floor, and register the subscription, so the
+	/// returned [`Establish`] can put the SUBSCRIBE on the wire.
 	///
-	/// The subscription's bounds come straight from the demand aggregate: when this
-	/// segment resumes a track after a route change, the origin's slice already
-	/// carries the boundary as `group_start`, so the upstream delivers exactly the
-	/// missing range.
-	async fn establish(
+	/// Registration happens here, before any of it reaches the transport: `id` is
+	/// live the moment the peer reads it, and a publisher may serve its first group
+	/// immediately, so a late insert races the group stream (a group whose id isn't
+	/// in the map yet is dropped, stalling the track forever). The caller
+	/// deregisters `id` if the establish fails.
+	fn prepare_establish(
 		&self,
 		producer: &mut track::Producer,
-		sub: &mut Sub<S>,
 		subscription: Subscription,
 		timescale: Option<Timescale>,
-	) -> Result<(), Error> {
+	) -> Establish<S> {
 		let id = self.subscriber.next_id.fetch_add(1, atomic::Ordering::Relaxed);
 
 		// Both halves of each bound come from the same position, so a frame can never
@@ -2474,26 +2320,8 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 		// live-edge demand (None) starts with no floor at all.
 		let _ = producer.start_at(subscription.start.map(|start| start.group));
 
-		let bounds = WireBounds::new(subscription.start, subscription.end);
-		let msg = lite::Subscribe {
-			id,
-			broadcast: self.path.as_path(),
-			track: self.name.as_str().into(),
-			priority: subscription.priority,
-			ordered: subscription.ordered,
-			latency_max: subscription.latency.max,
-			start_group: bounds.start_group,
-			end_group: bounds.end_group,
-			start_frame: bounds.start_frame,
-			end_frame: bounds.end_frame,
-		};
-
 		tracing::info!(id, broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "subscribe started");
 
-		// Register before the SUBSCRIBE hits the wire. `id` is live the moment the peer
-		// reads it, and a publisher may serve its first group immediately, so a late
-		// insert races the group stream: `recv_group` would find no entry and drop it,
-		// stalling the track forever.
 		self.subscriber.subscribes.lock().insert(
 			id,
 			TrackEntry {
@@ -2502,168 +2330,777 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 			},
 		);
 
-		let mut stream = match self.open_subscribe(&msg).await {
-			Ok(stream) => stream,
+		let session = self.subscriber.session.clone();
+		Establish {
+			serve: self.clone(),
+			closed: session.clone(),
+			session,
+			id,
+			subscription,
+			state: EstablishState::Open,
+		}
+	}
+
+	/// Test shim: drive the upstream SUBSCRIBE open like the old `establish`.
+	#[cfg(test)]
+	async fn establish(
+		&self,
+		producer: &mut track::Producer,
+		sub: &mut Sub<S>,
+		subscription: Subscription,
+		timescale: Option<Timescale>,
+	) -> Result<(), Error> {
+		let mut est = Box::new(self.prepare_establish(producer, subscription, timescale));
+		let id = est.id;
+		match kio::wait(move |waiter| est.poll(waiter)).await {
+			Ok(active) => {
+				*sub = Sub::Active(active);
+				Ok(())
+			}
 			Err(err) => {
 				self.subscriber.subscribes.lock().remove(&id);
-				return Err(err);
-			}
-		};
-
-		if !self.subscriber.version.has_track_stream() {
-			// Older drafts: the first SUBSCRIBE_OK confirms it. Bail if the session
-			// dies meanwhile; a dying route hands the assignment back through the
-			// serve loop's teardown instead.
-			let resp = {
-				let mut session = self.subscriber.session.clone();
-				kio::wait(|waiter| {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					if session.poll_closed(&mut cx).is_ready() {
-						return Poll::Ready(Err(Error::Dropped));
-					}
-					stream.reader.poll_decode::<lite::SubscribeResponse>(&mut cx)
-				})
-				.await
-			};
-
-			let ok = match resp {
-				Ok(resp) => matches!(resp, lite::SubscribeResponse::Ok(_)),
-				Err(err) => {
-					self.subscriber.subscribes.lock().remove(&id);
-					return Err(err);
-				}
-			};
-
-			if !ok {
-				self.subscriber.subscribes.lock().remove(&id);
-				return Err(Error::ProtocolViolation);
+				Err(err)
 			}
 		}
+	}
 
-		*sub = Sub::Active(SubStream {
-			stream,
-			id,
-			ordered: subscription.ordered,
-			latency_max: subscription.latency.max,
-			start: subscription.start,
-			priority: subscription.priority,
-			requested: subscription.start,
-		});
-
+	/// Test shim: apply one demand change like the old `handle_subscription`,
+	/// driving the establish (or the update flush) to completion inline.
+	#[cfg(test)]
+	async fn handle_subscription(
+		&self,
+		producer: &mut track::Producer,
+		sub: &mut Sub<S>,
+		pref: Option<Subscription>,
+		supports_update: bool,
+		timescale: Option<Timescale>,
+	) -> Result<(), Error> {
+		match self.begin_subscription(producer, sub, pref, supports_update, timescale)? {
+			Begin::Establish(est) => {
+				let mut est = Box::new(est);
+				let id = est.id;
+				match kio::wait(move |waiter| est.poll(waiter)).await {
+					Ok(active) => *sub = Sub::Active(active),
+					Err(err) => {
+						self.subscriber.subscribes.lock().remove(&id);
+						return Err(err);
+					}
+				}
+			}
+			Begin::None => {
+				if let Sub::Active(active) = sub {
+					std::future::poll_fn(|cx| active.stream.writer.poll_flush(cx)).await?;
+				}
+			}
+		}
 		Ok(())
 	}
+}
 
-	/// Echo the current params upstream as a SUBSCRIBE_UPDATE, varying only the end bound.
-	async fn send_update(&self, active: &mut SubStream<S>, end: Option<Position>) -> Result<(), Error> {
-		let bounds = WireBounds::new(active.start, end);
-		let update = lite::SubscribeUpdate {
-			priority: active.priority,
-			ordered: active.ordered,
-			latency_max: active.latency_max,
-			start_group: bounds.start_group,
-			end_group: bounds.end_group,
-			start_frame: bounds.start_frame,
-			end_frame: bounds.end_frame,
-		};
-		active.stream.writer.encode(&update).await
+/// What a demand change asks the serve loop to do next.
+enum Begin<S: crate::transport::poll::Session> {
+	/// Nothing further: the update (if any) sits in the active stream's write
+	/// buffer, flushed by the loop.
+	None,
+	/// Open an upstream SUBSCRIBE for the first subscriber.
+	Establish(Establish<S>),
+}
+
+/// Buffer a SUBSCRIBE_UPDATE echoing the current params, varying only the end
+/// bound. The caller flushes.
+fn buffer_update<S: crate::transport::poll::Session>(
+	active: &mut SubStream<S>,
+	end: Option<Position>,
+) -> Result<(), Error> {
+	let bounds = WireBounds::new(active.start, end);
+	active.stream.writer.buffer(&lite::SubscribeUpdate {
+		priority: active.priority,
+		ordered: active.ordered,
+		latency_max: active.latency_max,
+		start_group: bounds.start_group,
+		end_group: bounds.end_group,
+		start_frame: bounds.start_frame,
+		end_frame: bounds.end_frame,
+	})
+}
+
+/// Opens the upstream SUBSCRIBE control stream: send the request, then (pre
+/// lite-05) wait for the SUBSCRIBE_OK. Resolves with the live [`SubStream`];
+/// the caller deregisters the id on failure.
+struct Establish<S: crate::transport::poll::Session> {
+	serve: TrackServe<S>,
+	session: S,
+	// A dedicated close-watch handle for the SUBSCRIBE_OK wait.
+	closed: S,
+	id: u64,
+	subscription: Subscription,
+	state: EstablishState<S>,
+}
+
+enum EstablishState<S: crate::transport::poll::Session> {
+	Open,
+	Send {
+		stream: Stream<S, Version>,
+	},
+	/// Older drafts: the first SUBSCRIBE_OK confirms it. Bail if the session
+	/// dies meanwhile; a dying route hands the assignment back through the
+	/// serve loop's teardown instead.
+	WaitOk {
+		stream: Stream<S, Version>,
+	},
+}
+
+impl<S: crate::transport::poll::Session> Establish<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<SubStream<S>, Error>> {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.state {
+				EstablishState::Open => {
+					// A peer that sent GOAWAY told us to stop opening streams.
+					self.serve.subscriber.check_going_away()?;
+					let mut stream = ready!(Stream::poll_open(
+						&mut self.session,
+						self.serve.subscriber.version,
+						&mut cx
+					))?;
+
+					let bounds = WireBounds::new(self.subscription.start, self.subscription.end);
+					let msg = lite::Subscribe {
+						id: self.id,
+						broadcast: self.serve.path.as_path(),
+						track: self.serve.name.as_str().into(),
+						priority: self.subscription.priority,
+						ordered: self.subscription.ordered,
+						latency_max: self.subscription.latency.max,
+						start_group: bounds.start_group,
+						end_group: bounds.end_group,
+						start_frame: bounds.start_frame,
+						end_frame: bounds.end_frame,
+					};
+					stream.writer.buffer(&lite::ControlType::Subscribe)?;
+					stream.writer.buffer(&msg)?;
+					self.state = EstablishState::Send { stream };
+				}
+				EstablishState::Send { stream } => {
+					ready!(stream.writer.poll_flush(&mut cx))?;
+					let EstablishState::Send { stream } = std::mem::replace(&mut self.state, EstablishState::Open)
+					else {
+						unreachable!()
+					};
+					if !self.serve.subscriber.version.has_track_stream() {
+						self.state = EstablishState::WaitOk { stream };
+						continue;
+					}
+					return Poll::Ready(Ok(self.activate(stream)));
+				}
+				EstablishState::WaitOk { stream } => {
+					if self.closed.poll_closed(&mut cx).is_ready() {
+						return Poll::Ready(Err(Error::Dropped));
+					}
+					let resp = ready!(stream.reader.poll_decode::<lite::SubscribeResponse>(&mut cx))?;
+					if !matches!(resp, lite::SubscribeResponse::Ok(_)) {
+						return Poll::Ready(Err(Error::ProtocolViolation));
+					}
+					let EstablishState::WaitOk { stream } = std::mem::replace(&mut self.state, EstablishState::Open)
+					else {
+						unreachable!()
+					};
+					return Poll::Ready(Ok(self.activate(stream)));
+				}
+			}
+		}
 	}
 
-	/// Serve one downstream fetch end-to-end on its own bidi stream: send FETCH, then
-	/// fill the group from the bare FRAME messages that follow. The timescale comes
-	/// from this track's TRACK_INFO (already known), and the group sequence is
-	/// implicit from the request. Runs to completion as an independent future in the
-	/// serve loop's `FuturesUnordered`.
-	async fn serve_fetch(self, request: track::GroupRequest, timescale: Option<Timescale>) {
-		let TrackServe {
-			mut subscriber,
-			path,
-			name,
-		} = self;
+	fn activate(&self, stream: Stream<S, Version>) -> SubStream<S> {
+		SubStream {
+			stream,
+			id: self.id,
+			ordered: self.subscription.ordered,
+			latency_max: self.subscription.latency.max,
+			start: self.subscription.start,
+			priority: self.subscription.priority,
+			requested: self.subscription.start,
+		}
+	}
+}
+
+/// Drives one [`TrackServe`]: the TRACK_INFO fetch, then the serve loop, then
+/// the teardown that decides how the origin sees this copy end.
+struct TrackServeRun<S: crate::transport::poll::Session> {
+	serve: TrackServe<S>,
+	state: TrackRunState<S>,
+}
+
+enum TrackRunState<S: crate::transport::poll::Session> {
+	/// Lite05+ learns the track's immutable properties once, up front, via a
+	/// TRACK stream. The timescale then flows into every SUBSCRIBE and FETCH
+	/// without a per-response header.
+	Info {
+		request: Option<track::Request>,
+		info: TrackInfoFetch<S>,
+	},
+	Serve(ServeLoop<S>),
+	Done,
+}
+
+impl<S: crate::transport::poll::Session> TrackServeRun<S> {
+	fn new(serve: TrackServe<S>, request: track::Request) -> Self {
+		let state = if serve.subscriber.version.has_track_stream() {
+			TrackRunState::Info {
+				request: Some(request),
+				info: TrackInfoFetch::new(&serve),
+			}
+		} else {
+			// No TRACK stream, so the publisher's retention window never reaches us:
+			// the accepting side picks it (see `origin::Info::latency_default`).
+			let info = track::Info::default().with_latency_max(serve.subscriber.origin.latency_default());
+			TrackRunState::Serve(ServeLoop::new(&serve, request, info, None))
+		};
+		Self { serve, state }
+	}
+}
+
+impl<S: crate::transport::poll::Session> Machine for TrackServeRun<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		loop {
+			match &mut self.state {
+				TrackRunState::Info { request, info } => {
+					let res = ready!(info.poll_fetch(&self.serve, waiter));
+					let request = request.take().expect("request pending");
+					match res {
+						Ok(info) => {
+							// Lite05 carries per-frame timestamps on the wire at this scale;
+							// `Some` tells the ingest to decode them instead of stamping
+							// local receive time.
+							let timescale = Some(info.timescale);
+							self.state = TrackRunState::Serve(ServeLoop::new(&self.serve, request, info, timescale));
+						}
+						Err(err) => {
+							tracing::warn!(broadcast = %self.serve.subscriber.log_path(&self.serve.path), track = %self.serve.name, %err, "track info failed");
+							// Rejecting the request lets the origin retry (bounded) on
+							// another source; waiting subscribers stall rather than error
+							// meanwhile.
+							request.reject(err);
+							self.state = TrackRunState::Done;
+							return Poll::Ready(());
+						}
+					}
+				}
+				TrackRunState::Serve(serve_loop) => {
+					let teardown = ready!(serve_loop.poll(&self.serve, waiter));
+					let TrackRunState::Serve(mut serve_loop) = std::mem::replace(&mut self.state, TrackRunState::Done)
+					else {
+						unreachable!()
+					};
+
+					if let Sub::Active(active) = &mut serve_loop.sub {
+						self.serve.subscriber.subscribes.lock().remove(&active.id);
+						let _ = active.stream.writer.finish();
+					}
+
+					match teardown {
+						// The upstream ended the track for good; the origin observes the
+						// completed copy and finishes the logical track.
+						Teardown::Finished => {
+							let _ = serve_loop.serving.finish();
+						}
+						Teardown::GiveBack(err) => {
+							// Mark this copy dead: subscribers stall while the origin
+							// re-splices the track from the next source.
+							let _ = serve_loop.serving.abort(err);
+						}
+						Teardown::Released => {
+							// A deliberate end with no reader to observe it, which also
+							// drops the cached groups. The origin re-requests the track from
+							// this session if one comes back.
+							let _ = serve_loop.serving.abort(Error::Cancel);
+						}
+					}
+					return Poll::Ready(());
+				}
+				TrackRunState::Done => return Poll::Ready(()),
+			}
+		}
+	}
+}
+
+/// Opens a TRACK stream, reads the single TRACK_INFO, and maps it to the
+/// model's [`track::Info`]. Lite05+ only. Bails if the session dies meanwhile.
+struct TrackInfoFetch<S: crate::transport::poll::Session> {
+	session: S,
+	// A dedicated close-watch handle for the read.
+	closed: S,
+	state: TrackInfoState<S>,
+}
+
+enum TrackInfoState<S: crate::transport::poll::Session> {
+	Open,
+	Send { stream: Stream<S, Version> },
+	Read { stream: Stream<S, Version> },
+}
+
+impl<S: crate::transport::poll::Session> TrackInfoFetch<S> {
+	fn new(serve: &TrackServe<S>) -> Self {
+		let session = serve.subscriber.session.clone();
+		Self {
+			closed: session.clone(),
+			session,
+			state: TrackInfoState::Open,
+		}
+	}
+
+	fn poll_fetch(&mut self, serve: &TrackServe<S>, waiter: &kio::Waiter) -> Poll<Result<track::Info, Error>> {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.state {
+				TrackInfoState::Open => {
+					serve.subscriber.check_going_away()?;
+					let mut stream = ready!(Stream::poll_open(&mut self.session, serve.subscriber.version, &mut cx))?;
+					stream.writer.buffer(&lite::ControlType::Track)?;
+					stream.writer.buffer(&lite::Track {
+						broadcast: serve.path.as_path(),
+						track: serve.name.as_str().into(),
+					})?;
+					self.state = TrackInfoState::Send { stream };
+				}
+				TrackInfoState::Send { stream } => {
+					ready!(stream.writer.poll_flush(&mut cx))?;
+					let TrackInfoState::Send { stream } = std::mem::replace(&mut self.state, TrackInfoState::Open)
+					else {
+						unreachable!()
+					};
+					self.state = TrackInfoState::Read { stream };
+				}
+				TrackInfoState::Read { stream } => {
+					if self.closed.poll_closed(&mut cx).is_ready() {
+						return Poll::Ready(Err(Error::Dropped));
+					}
+					let info = ready!(stream.reader.poll_decode::<lite::TrackInfo>(&mut cx))?;
+					// The publisher FINs after TRACK_INFO; FIN our side too and let the
+					// stream drop.
+					let _ = stream.writer.finish();
+
+					// Publisher Max Latency rides on the wire, so the local retention
+					// window matches what the upstream advertises (relays re-serve with
+					// the same bound). `broadcast` is left at its default here;
+					// `track::Request::accept` stamps the track's real broadcast.
+					let model = track::Info::default()
+						.with_timescale(info.timescale)
+						.with_latency_max(info.latency_max)
+						.with_priority(info.priority)
+						.with_ordered(info.ordered);
+					return Poll::Ready(Ok(model));
+				}
+			}
+		}
+	}
+}
+
+/// The serve loop proper: owns this session's copy of the track (spliced into
+/// the origin's logical track), driving the single upstream subscription
+/// (opened lazily on the first downstream subscriber, canceled when the last
+/// one leaves) concurrently with any number of one-shot fetches.
+struct ServeLoop<S: crate::transport::poll::Session> {
+	/// This session's copy, accepted with the resolved info. The origin splices
+	/// it into the logical track; demand from the logical subscribers arrives
+	/// through the producer's aggregate, sliced to this segment's bounds
+	/// (including the resume floor after a source change).
+	serving: track::Producer,
+	/// Serve on-demand fetches of uncached groups from this session.
+	dynamic: track::Dynamic,
+	sub: Sub<S>,
+	fetches: PollSet<FetchServeRun<S>>,
+	// A dedicated close-watch handle for the session-died arm.
+	closed: S,
+	// SUBSCRIBE_UPDATE only exists on Lite03+, so older peers can't carry a
+	// preference change to an established subscription.
+	supports_update: bool,
+	supports_fetch: bool,
+	timescale: Option<Timescale>,
+	mode: ServeMode<S>,
+}
+
+enum ServeMode<S: crate::transport::poll::Session> {
+	/// Selecting the next event.
+	Select,
+	/// Driving an upstream SUBSCRIBE open. The demand arms wait meanwhile,
+	/// exactly like the old inline await.
+	Establish(Establish<S>),
+}
+
+impl<S: crate::transport::poll::Session> ServeLoop<S> {
+	fn new(serve: &TrackServe<S>, request: track::Request, info: track::Info, timescale: Option<Timescale>) -> Self {
+		let serving = request.accept(info);
+		let dynamic = serving.dynamic();
+		Self {
+			serving,
+			dynamic,
+			sub: Sub::None,
+			fetches: PollSet::new(),
+			closed: serve.subscriber.session.clone(),
+			supports_update: !matches!(serve.subscriber.version, Version::Lite01 | Version::Lite02),
+			supports_fetch: serve.subscriber.version.has_track_stream(),
+			timescale,
+			mode: ServeMode::Select,
+		}
+	}
+
+	fn poll(&mut self, serve: &TrackServe<S>, waiter: &kio::Waiter) -> Poll<Teardown> {
+		loop {
+			match &mut self.mode {
+				ServeMode::Establish(est) => {
+					let res = ready!(est.poll(waiter));
+					let id = est.id;
+					self.mode = ServeMode::Select;
+					match res {
+						Ok(active) => self.sub = Sub::Active(active),
+						Err(err) => {
+							// Opening the upstream failed (usually the session dying): hand
+							// the track back for another route to resume.
+							serve.subscriber.subscribes.lock().remove(&id);
+							return Poll::Ready(Teardown::GiveBack(err));
+						}
+					}
+				}
+				ServeMode::Select => {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+
+					// Deliver any buffered SUBSCRIBE_UPDATE before selecting, so the
+					// demand that produced it is on the wire.
+					if let Sub::Active(active) = &mut self.sub {
+						match active.stream.writer.poll_flush(&mut cx) {
+							Poll::Ready(Ok(())) => {}
+							Poll::Ready(Err(err)) => {
+								// The stream is broken; drop it (the writer resets) and
+								// hand the track back.
+								serve.subscriber.subscribes.lock().remove(&active.id);
+								self.sub = Sub::None;
+								return Poll::Ready(Teardown::GiveBack(err));
+							}
+							Poll::Pending => return Poll::Pending,
+						}
+					}
+
+					// Biased: demand first, then completions, then closures.
+
+					// (1) Track demand: a fetch, a subscription change, or the origin
+					// handing the track to another route.
+
+					// A fetch is cheap and one-shot, so serve it ahead of subscription churn.
+					match self.dynamic.poll_requested_group(waiter) {
+						Poll::Ready(Ok(req)) => {
+							if self.supports_fetch {
+								self.fetches
+									.push(FetchServeRun::new(serve.clone(), req, self.timescale));
+							} else {
+								req.reject(Error::Version);
+							}
+							continue;
+						}
+						// Our own producer is alive (we hold it); treat as terminal anyway.
+						Poll::Ready(Err(_)) => return Poll::Ready(Teardown::GiveBack(Error::Dropped)),
+						Poll::Pending => {}
+					}
+					match self.serving.poll_subscription_changed(waiter) {
+						Poll::Ready(Ok(pref)) => {
+							match serve.begin_subscription(
+								&mut self.serving,
+								&mut self.sub,
+								pref,
+								self.supports_update,
+								self.timescale,
+							) {
+								Ok(Begin::Establish(est)) => self.mode = ServeMode::Establish(est),
+								Ok(Begin::None) => {}
+								// Updating the upstream failed: hand the track back for
+								// another route to resume.
+								Err(err) => return Poll::Ready(Teardown::GiveBack(err)),
+							}
+							continue;
+						}
+						Poll::Ready(Err(_)) => return Poll::Ready(Teardown::GiveBack(Error::Dropped)),
+						Poll::Pending => {}
+					}
+
+					// (2) In-flight fetches; completions just retire.
+					let _ = self.fetches.poll(waiter);
+
+					// (3) Nobody reads this copy anymore: the origin released it after its
+					// idle linger, so drop it instead of holding the track state (and its
+					// TRACK_INFO) for a reader that may never return. In-flight fetches
+					// keep it alive: work already accepted still gets finished.
+					if self.fetches.is_empty() && self.serving.poll_unused(waiter).is_ready() {
+						tracing::debug!(broadcast = %serve.subscriber.log_path(&serve.path), track = %serve.name, "track released (idle)");
+						return Poll::Ready(Teardown::Released);
+					}
+
+					// (4) The upstream subscribe stream closed, or carried a START/END/DROP.
+					// Partial message bytes persist in the reader's buffer across turns.
+					if let Sub::Active(active) = &mut self.sub
+						&& let Poll::Ready(res) = active
+							.stream
+							.reader
+							.poll_decode_maybe::<lite::SubscribeResponse>(&mut cx)
+					{
+						match res {
+							Ok(Some(msg)) => {
+								match &msg {
+									// SUBSCRIBE_END declares the track's exclusive final
+									// sequence, which may arrive while trailing groups are
+									// still in flight. Record it on this segment's producer so
+									// consumers learn the boundary early; the later stream FIN
+									// then finds the track already finished.
+									lite::SubscribeResponse::End(end) => {
+										// finish_at rejects a boundary at or below the live
+										// edge, which is what a peer sending an inclusive bound
+										// looks like once the final group has already arrived.
+										// Don't abort: the stream FIN still finishes the track,
+										// so this only costs the early boundary. Warn anyway,
+										// since it's our only signal that a peer disagrees
+										// about the encoding.
+										if let Err(err) = self.serving.finish_at(end.group) {
+											tracing::warn!(track = %serve.name, group = end.group, %err, "invalid subscribe end");
+										}
+									}
+									// SUBSCRIBE_START names the first group this feed serves:
+									// the publisher skipped everything below it (e.g. it could
+									// not serve the requested frame). Record it as a drop
+									// signal, so a spliced reader waiting on a skipped group
+									// fails over instead of stalling on a live route.
+									lite::SubscribeResponse::Start(start) => {
+										// A START describes the demand the SUBSCRIBE carried.
+										// It applies only while the current start still matches
+										// that demand (updates get no fresh START, so an update
+										// that moved the start makes it stale, and one that
+										// moved back restores it); elsewhere the
+										// request-tracked floor stands rather than a guess.
+										if active.start == active.requested {
+											let _ = self.serving.start_at(start.group);
+										}
+									}
+									// OK/DROP just resolve the range (the producer already
+									// orders groups).
+									_ => tracing::debug!(track = %serve.name, ?msg, "subscribe response"),
+								}
+								continue;
+							}
+							Ok(None) => {
+								tracing::info!(broadcast = %serve.subscriber.log_path(&serve.path), track = %serve.name, "subscribe complete");
+								// Upstream FIN'd the subscription: the publisher only FINs
+								// once the track's final sequence is known and delivered, so
+								// the logical track is over for good (bounded downstream
+								// demand alone never FINs; the publisher parks, since a cap
+								// can be raised).
+								return Poll::Ready(Teardown::Finished);
+							}
+							Err(err) => {
+								tracing::warn!(broadcast = %serve.subscriber.log_path(&serve.path), track = %serve.name, %err, "subscribe error");
+								return Poll::Ready(Teardown::GiveBack(err));
+							}
+						}
+					}
+
+					// (5) The session died: hand the track back for another route.
+					if self.closed.poll_closed(&mut cx).is_ready() {
+						return Poll::Ready(Teardown::GiveBack(Error::Dropped));
+					}
+
+					return Poll::Pending;
+				}
+			}
+		}
+	}
+}
+
+/// Serves one downstream fetch end-to-end on its own bidi stream: send FETCH,
+/// then fill the group from the bare FRAME messages that follow. The timescale
+/// comes from this track's TRACK_INFO (already known), and the group sequence
+/// is implicit from the request.
+struct FetchServeRun<S: crate::transport::poll::Session> {
+	serve: TrackServe<S>,
+	session: S,
+	timescale: Option<Timescale>,
+	group: u64,
+	state: FetchRunState<S>,
+}
+
+enum FetchRunState<S: crate::transport::poll::Session> {
+	Open {
+		request: Option<track::GroupRequest>,
+	},
+	Send {
+		request: Option<track::GroupRequest>,
+		stream: Stream<S, Version>,
+		frame_start: u64,
+	},
+	Ingest {
+		stream: Stream<S, Version>,
+		producer: group::Producer,
+		ingest: FrameIngest,
+	},
+	Done,
+}
+
+impl<S: crate::transport::poll::Session> FetchServeRun<S> {
+	fn new(serve: TrackServe<S>, request: track::GroupRequest, timescale: Option<Timescale>) -> Self {
+		let session = serve.subscriber.session.clone();
 		let group = request.sequence();
-
-		tracing::info!(broadcast = %subscriber.log_path(&path), track = %name, group, "fetch started");
-
-		// A peer that sent GOAWAY told us to stop opening streams on this session.
-		if subscriber.going_away.is_set() {
-			request.reject(Error::GoingAway);
-			return;
+		Self {
+			serve,
+			session,
+			timescale,
+			group,
+			state: FetchRunState::Open { request: Some(request) },
 		}
+	}
+}
 
-		let mut stream = match Stream::open(&mut subscriber.session, subscriber.version).await {
-			Ok(stream) => stream,
-			Err(err) => {
-				tracing::warn!(track = %name, %err, "fetch stream open failed");
-				request.reject(err);
-				return;
-			}
-		};
+impl<S: crate::transport::poll::Session> Machine for FetchServeRun<S> {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		loop {
+			match &mut self.state {
+				FetchRunState::Open { request } => {
+					tracing::info!(broadcast = %self.serve.subscriber.log_path(&self.serve.path), track = %self.serve.name, group = self.group, "fetch started");
 
-		// A peer that predates lite-06 addresses whole groups only, so ask for the whole
-		// group and number the response from 0. The wider group still covers what the
-		// caller asked for (`fetch_group` positions their own consumer), and is more
-		// reusable in the cache than the tail would have been. Asking for the offset
-		// anyway would fail to encode and reject a fetch we can serve.
-		let frame_start = match subscriber.version.has_frame_bounds() {
-			true => request.frame_start(),
-			false => 0,
-		};
+					// A peer that sent GOAWAY told us to stop opening streams on this session.
+					if self.serve.subscriber.going_away.is_set() {
+						request.take().expect("request pending").reject(Error::GoingAway);
+						self.state = FetchRunState::Done;
+						return Poll::Ready(());
+					}
 
-		let send = async {
-			let msg = lite::Fetch {
-				broadcast: path.as_path(),
-				track: name.as_str().into(),
-				priority: request.priority(),
-				group,
-				start_frame: frame_start,
-				// Always through the end of the group: a fetch that stopped short would
-				// cache a group indistinguishable from a complete one. A downstream cap
-				// is applied when serving, not when fetching.
-				end_frame: None,
-			};
-			stream.writer.encode(&lite::ControlType::Fetch).await?;
-			stream.writer.encode(&msg).await
-		};
-		if let Err(err) = send.await {
-			stream.writer.abort(&err);
-			request.reject(err);
-			return;
-		}
+					let mut stream = match ready!(Stream::poll_open(
+						&mut self.session,
+						self.serve.subscriber.version,
+						&mut cx
+					)) {
+						Ok(stream) => stream,
+						Err(err) => {
+							tracing::warn!(track = %self.serve.name, %err, "fetch stream open failed");
+							request.take().expect("request pending").reject(err);
+							self.state = FetchRunState::Done;
+							return Poll::Ready(());
+						}
+					};
 
-		// Make the group available (resolving the downstream fetch) and fill it. The
-		// track::Info only takes effect if the track isn't accepted yet (a fetch with no
-		// live subscription); otherwise the group inherits the accepted timescale.
-		// Relay-served FETCH is lite-05+, so `timescale` is `Some`; fall back to the
-		// default scale defensively rather than panicking.
-		let group_info = track::Info::default()
-			.with_timescale(timescale.unwrap_or_default())
-			.with_latency_max(subscriber.origin.latency_default());
-		let mut producer = match request.accept(group_info) {
-			Ok(producer) => producer,
-			Err(err) => {
-				// Already served (a concurrent fetch) or the track closed.
-				tracing::debug!(track = %name, group, %err, "fetch not served");
-				stream.writer.abort(&err);
-				return;
-			}
-		};
+					let request = request.take().expect("request pending");
 
-		// The response starts at the frame we asked for, so number it from there rather
-		// than restarting the group at 0.
-		if let Err(err) = producer.start_at(frame_start) {
-			stream.writer.abort(&err);
-			let _ = producer.abort(err);
-			return;
-		}
+					// A peer that predates lite-06 addresses whole groups only, so ask for
+					// the whole group and number the response from 0. The wider group still
+					// covers what the caller asked for (`fetch_group` positions their own
+					// consumer), and is more reusable in the cache than the tail would have
+					// been. Asking for the offset anyway would fail to encode and reject a
+					// fetch we can serve.
+					let frame_start = match self.serve.subscriber.version.has_frame_bounds() {
+						true => request.frame_start(),
+						false => 0,
+					};
 
-		let mut ingest = FrameIngest::new(timescale);
-		let mut group = producer.clone();
-		let res = kio::wait(|waiter| ingest.poll(&mut stream.reader, &mut group, waiter)).await;
-		match res {
-			Ok(()) => {
-				let _ = producer.finish();
-			}
-			Err(err) => {
-				let _ = producer.abort(err);
+					let msg = lite::Fetch {
+						broadcast: self.serve.path.as_path(),
+						track: self.serve.name.as_str().into(),
+						priority: request.priority(),
+						group: self.group,
+						start_frame: frame_start,
+						// Always through the end of the group: a fetch that stopped short
+						// would cache a group indistinguishable from a complete one. A
+						// downstream cap is applied when serving, not when fetching.
+						end_frame: None,
+					};
+					let buffered = stream
+						.writer
+						.buffer(&lite::ControlType::Fetch)
+						.and_then(|()| stream.writer.buffer(&msg));
+					if let Err(err) = buffered {
+						stream.writer.abort(&err);
+						request.reject(err);
+						self.state = FetchRunState::Done;
+						return Poll::Ready(());
+					}
+					self.state = FetchRunState::Send {
+						request: Some(request),
+						stream,
+						frame_start,
+					};
+				}
+				FetchRunState::Send { stream, .. } => {
+					if let Err(err) = ready!(stream.writer.poll_flush(&mut cx)) {
+						let FetchRunState::Send { request, stream, .. } =
+							std::mem::replace(&mut self.state, FetchRunState::Done)
+						else {
+							unreachable!()
+						};
+						stream.writer.abort(&err);
+						request.expect("request pending").reject(err);
+						return Poll::Ready(());
+					}
+					let FetchRunState::Send {
+						request,
+						stream,
+						frame_start,
+					} = std::mem::replace(&mut self.state, FetchRunState::Done)
+					else {
+						unreachable!()
+					};
+					let request = request.expect("request pending");
+
+					// Make the group available (resolving the downstream fetch) and fill
+					// it. The track::Info only takes effect if the track isn't accepted yet
+					// (a fetch with no live subscription); otherwise the group inherits the
+					// accepted timescale. Relay-served FETCH is lite-05+, so `timescale` is
+					// `Some`; fall back to the default scale defensively rather than
+					// panicking.
+					let group_info = track::Info::default()
+						.with_timescale(self.timescale.unwrap_or_default())
+						.with_latency_max(self.serve.subscriber.origin.latency_default());
+					let mut producer = match request.accept(group_info) {
+						Ok(producer) => producer,
+						Err(err) => {
+							// Already served (a concurrent fetch) or the track closed.
+							tracing::debug!(track = %self.serve.name, group = self.group, %err, "fetch not served");
+							stream.writer.abort(&err);
+							return Poll::Ready(());
+						}
+					};
+
+					// The response starts at the frame we asked for, so number it from
+					// there rather than restarting the group at 0.
+					if let Err(err) = producer.start_at(frame_start) {
+						stream.writer.abort(&err);
+						let _ = producer.abort(err);
+						return Poll::Ready(());
+					}
+
+					self.state = FetchRunState::Ingest {
+						stream,
+						producer,
+						ingest: FrameIngest::new(self.timescale),
+					};
+				}
+				FetchRunState::Ingest {
+					stream,
+					producer,
+					ingest,
+				} => {
+					let res = ready!(ingest.poll(&mut stream.reader, producer, waiter));
+					let FetchRunState::Ingest { producer, .. } =
+						std::mem::replace(&mut self.state, FetchRunState::Done)
+					else {
+						unreachable!()
+					};
+					match res {
+						Ok(()) => {
+							let mut producer = producer;
+							let _ = producer.finish();
+						}
+						Err(err) => {
+							let _ = producer.abort(err);
+						}
+					}
+					return Poll::Ready(());
+				}
+				FetchRunState::Done => return Poll::Ready(()),
 			}
 		}
 	}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -21,7 +21,7 @@ use super::{ConnectingProducer, RouteCost, Version};
 
 use web_async::Lock;
 
-pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
+pub(super) struct SubscriberConfig<S: crate::transport::poll::Session> {
 	pub session: S,
 	/// The origin into which remote broadcasts are inserted. Traffic stats are
 	/// attributed through this handle: tag it with [`origin::Producer::with_stats`]
@@ -48,7 +48,7 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 }
 
 #[derive(Clone)]
-pub(super) struct Subscriber<S: web_transport_trait::Session> {
+pub(super) struct Subscriber<S: crate::transport::poll::Session> {
 	session: S,
 
 	origin: origin::Producer,
@@ -92,7 +92,7 @@ struct TrackEntry {
 	timescale: Option<Timescale>,
 }
 
-impl<S: web_transport_trait::Session> Subscriber<S> {
+impl<S: crate::transport::poll::Session> Subscriber<S> {
 	pub fn new(config: SubscriberConfig<S>) -> Self {
 		// Identity for incoming-hop loop detection. Derived from the local
 		// origin we publish into so it matches the relay identity across
@@ -185,7 +185,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		.await
 	}
 
-	async fn run_uni(self) -> Result<(), Error> {
+	async fn run_uni(mut self) -> Result<(), Error> {
 		let mut tasks = TaskSet::owned();
 		loop {
 			let stream = tasks
@@ -258,7 +258,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	) -> Result<(), Error> {
 		// A peer that sent GOAWAY told us to stop opening streams on this session.
 		self.check_going_away()?;
-		let mut stream = Stream::open(&self.session, self.version).await?;
+		let mut stream = Stream::open(&mut self.session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Announce).await?;
 
 		// Lite04/05: ask the peer to filter out announces that already passed through
@@ -494,7 +494,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		if self.going_away.is_set() {
 			return Ok(());
 		}
-		let mut stream = Stream::open(&self.session, self.version).await?;
+		let mut session = self.session.clone();
+		let mut stream = Stream::open(&mut session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Probe).await?;
 
 		while let Some(probe) = stream.reader.decode_maybe::<lite::Probe>().await? {
@@ -691,12 +692,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// unannounces (the source is finished) or the session dies.
 	async fn run_source(self, path: PathOwned, mut dynamic: crate::broadcast::Dynamic) {
 		let mut tracks = TaskSet::owned();
+		let mut closed_session = self.session.clone();
 		loop {
 			let next = tracks
 				.drive(async {
-					let mut closed = std::pin::pin!(self.session.closed());
 					kio::wait(|waiter| {
-						if waiter.poll_future(closed.as_mut()).is_ready() {
+						let mut cx = std::task::Context::from_waker(waiter.waker());
+						if closed_session.poll_closed(&mut cx).is_ready() {
 							return Poll::Ready(None);
 						}
 						// A draining peer usually stops announcing, so react to the signal
@@ -743,7 +745,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// `select!` matches only on the error case and lets the other arms drive the session. A
 	/// decode error or an unknown subscribe id drops that datagram without tearing down the
 	/// session (best-effort); only a transport-level failure ends the loop.
-	async fn run_datagrams(self) -> Result<(), Error> {
+	async fn run_datagrams(mut self) -> Result<(), Error> {
 		if !self.version.has_datagrams() || self.session.max_datagram_size() == 0 {
 			return Ok(());
 		}
@@ -1700,7 +1702,7 @@ impl WireBounds {
 
 /// The at-most-one live upstream subscription: its control stream plus the params
 /// echoed in every SUBSCRIBE_UPDATE.
-struct SubStream<S: web_transport_trait::Session> {
+struct SubStream<S: crate::transport::poll::Session> {
 	stream: Stream<S, Version>,
 	id: u64,
 	/// Original SUBSCRIBE params, echoed in every SUBSCRIBE_UPDATE; refreshed as the
@@ -1717,7 +1719,7 @@ struct SubStream<S: web_transport_trait::Session> {
 	requested: Option<Position>,
 }
 
-enum Sub<S: web_transport_trait::Session> {
+enum Sub<S: crate::transport::poll::Session> {
 	None,
 	Active(SubStream<S>),
 }
@@ -1788,13 +1790,13 @@ enum Event {
 /// subscription (opened lazily on the first downstream subscriber, canceled when
 /// the last one leaves) concurrently with any number of one-shot fetches.
 #[derive(Clone)]
-struct TrackServe<S: web_transport_trait::Session> {
+struct TrackServe<S: crate::transport::poll::Session> {
 	subscriber: Subscriber<S>,
 	path: PathOwned,
 	name: String,
 }
 
-impl<S: web_transport_trait::Session> TrackServe<S> {
+impl<S: crate::transport::poll::Session> TrackServe<S> {
 	async fn run(self, request: track::Request) {
 		// SUBSCRIBE_UPDATE only exists on Lite03+, so older peers can't carry a
 		// preference change to an established subscription.
@@ -1849,7 +1851,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 						Sub::None => std::future::pending().await,
 					}
 				});
-				let mut session_closed = std::pin::pin!(self.subscriber.session.closed());
+				let mut closed_session = self.subscriber.session.clone();
 				// Biased: demand first, then completions, then closures.
 				kio::wait(|waiter| {
 					// (1) Track demand: a fetch, a subscription change, or the origin
@@ -1896,7 +1898,8 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					}
 
 					// (5) The session died: hand the track back for another route.
-					if waiter.poll_future(session_closed.as_mut()).is_ready() {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if closed_session.poll_closed(&mut cx).is_ready() {
 						return Poll::Ready(Event::SessionClosed);
 					}
 
@@ -2009,7 +2012,8 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 	/// [`track::Info`]. Lite05+ only. Bails if the broadcast dies meanwhile.
 	async fn track_info(&self) -> Result<track::Info, Error> {
 		self.subscriber.check_going_away()?;
-		let mut stream = Stream::open(&self.subscriber.session, self.subscriber.version).await?;
+		let mut session = self.subscriber.session.clone();
+		let mut stream = Stream::open(&mut session, self.subscriber.version).await?;
 		stream.writer.encode(&lite::ControlType::Track).await?;
 		stream
 			.writer
@@ -2020,10 +2024,10 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			.await?;
 
 		let info = {
-			let mut closed = std::pin::pin!(self.subscriber.session.closed());
 			let mut decode = std::pin::pin!(stream.reader.decode::<lite::TrackInfo>());
 			kio::wait(|waiter| {
-				if waiter.poll_future(closed.as_mut()).is_ready() {
+				let mut cx = std::task::Context::from_waker(waiter.waker());
+				if session.poll_closed(&mut cx).is_ready() {
 					return Poll::Ready(Err(Error::Dropped));
 				}
 				waiter.poll_future(decode.as_mut())
@@ -2156,7 +2160,8 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 	/// Open the SUBSCRIBE control stream and send the request.
 	async fn open_subscribe(&self, msg: &lite::Subscribe<'_>) -> Result<Stream<S, Version>, Error> {
 		self.subscriber.check_going_away()?;
-		let mut stream = Stream::open(&self.subscriber.session, self.subscriber.version).await?;
+		let mut session = self.subscriber.session.clone();
+		let mut stream = Stream::open(&mut session, self.subscriber.version).await?;
 		stream.writer.encode(&lite::ControlType::Subscribe).await?;
 		stream.writer.encode(msg).await?;
 		Ok(stream)
@@ -2226,10 +2231,11 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			// dies meanwhile; a dying route hands the assignment back through the
 			// serve loop's teardown instead.
 			let resp = {
-				let mut closed = std::pin::pin!(self.subscriber.session.closed());
+				let mut session = self.subscriber.session.clone();
 				let mut decode = std::pin::pin!(stream.reader.decode::<lite::SubscribeResponse>());
 				kio::wait(|waiter| {
-					if waiter.poll_future(closed.as_mut()).is_ready() {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if session.poll_closed(&mut cx).is_ready() {
 						return Poll::Ready(Err(Error::Dropped));
 					}
 					waiter.poll_future(decode.as_mut())
@@ -2300,7 +2306,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			return;
 		}
 
-		let mut stream = match Stream::open(&subscriber.session, subscriber.version).await {
+		let mut stream = match Stream::open(&mut subscriber.session, subscriber.version).await {
 			Ok(stream) => stream,
 			Err(err) => {
 				tracing::warn!(track = %name, %err, "fetch stream open failed");

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -1,14 +1,21 @@
 //! Transport doubles shared by the lite tests: a session whose streams record
 //! everything written and every reset code, peers that never speak, and peers
 //! whose incoming streams die before their first byte.
+//!
+//! These implement the poll traits directly, since that is what the crate's
+//! transport bound requires. A pending fake simply returns `Poll::Pending`
+//! without registering a waker: it models a peer that never answers, so nothing
+//! should ever wake it.
 
 use std::{
 	sync::{
 		Arc, Mutex,
 		atomic::{AtomicUsize, Ordering},
 	},
-	task::Poll,
+	task::{Context, Poll},
 };
+
+use web_transport_trait::poll;
 
 #[derive(Debug, Clone, Default)]
 pub struct SinkError;
@@ -68,8 +75,10 @@ pub struct SinkSend {
 	/// Writes park until this flips to true; `None` writes immediately. See
 	/// [`SinkSession::gated_bi`].
 	gate: Option<kio::Consumer<bool>>,
-	/// Set by [`finish`](web_transport_trait::SendStream::finish). A finished stream is what
-	/// [`closed`](web_transport_trait::SendStream::closed) waits on, mirroring a peer that
+	/// Bridges the gate's kio wakeups onto the caller's `Context`.
+	park: kio::Park,
+	/// Set by [`finish`](poll::SendStream::finish). A finished stream is what
+	/// [`poll_closed`](poll::SendStream::poll_closed) waits on, mirroring a peer that
 	/// acknowledges the FIN; an unfinished one parks like a peer that never answers.
 	finished: bool,
 }
@@ -79,24 +88,27 @@ impl SinkSend {
 		Self {
 			log,
 			gate: None,
+			park: kio::Park::default(),
 			finished: false,
 		}
 	}
 }
 
-impl web_transport_trait::SendStream for SinkSend {
+impl poll::SendStream for SinkSend {
 	type Error = SinkError;
 
-	async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
 		if let Some(gate) = &self.gate {
 			// A closed gate parks forever, which surfaces as a hung test rather than a
 			// write that silently skipped the gate.
-			let _ = gate
-				.wait(|open| if **open { Poll::Ready(()) } else { Poll::Pending })
-				.await;
+			let waiter = self.park.hold(cx);
+			match gate.poll(waiter, |open| if **open { Poll::Ready(()) } else { Poll::Pending }) {
+				Poll::Ready(Ok(())) => {}
+				Poll::Ready(Err(_)) | Poll::Pending => return Poll::Pending,
+			}
 		}
 		self.log.writes.lock().unwrap().extend_from_slice(buf);
-		Ok(buf.len())
+		Poll::Ready(Ok(buf.len()))
 	}
 
 	fn set_priority(&mut self, order: u8) {
@@ -114,11 +126,11 @@ impl web_transport_trait::SendStream for SinkSend {
 		self.log.resets.lock().unwrap().push(code);
 	}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
+	fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		match self.finished {
-			true => Ok(()),
+			true => Poll::Ready(Ok(())),
 			// Nothing to acknowledge yet, so park like a peer that never answers.
-			false => std::future::pending().await,
+			false => Poll::Pending,
 		}
 	}
 }
@@ -127,17 +139,17 @@ impl web_transport_trait::SendStream for SinkSend {
 /// model-side events.
 pub struct PendingRecv;
 
-impl web_transport_trait::RecvStream for PendingRecv {
+impl poll::RecvStream for PendingRecv {
 	type Error = SinkError;
 
-	async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-		std::future::pending().await
+	fn poll_read(&mut self, _cx: &mut Context<'_>, _dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
+		Poll::Pending
 	}
 
 	fn stop(&mut self, _code: u32) {}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
-		std::future::pending().await
+	fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Pending
 	}
 }
 
@@ -311,43 +323,44 @@ impl SinkSession {
 	}
 }
 
-impl web_transport_trait::Session for SinkSession {
+impl poll::Session for SinkSession {
 	type SendStream = SinkSend;
 	type RecvStream = PendingRecv;
 	type Error = SinkError;
 
-	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-		std::future::pending().await
+	fn poll_accept_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>> {
+		Poll::Pending
 	}
 
-	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-		std::future::pending().await
+	fn poll_accept_bi(&mut self, _cx: &mut Context<'_>) -> Poll<Result<poll::BiStreams<Self>, Self::Error>> {
+		Poll::Pending
 	}
 
-	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+	fn poll_open_bi(&mut self, _cx: &mut Context<'_>) -> Poll<Result<poll::BiStreams<Self>, Self::Error>> {
 		let Some(gate) = self.bi_gate.clone() else {
-			return std::future::pending().await;
+			return Poll::Pending;
 		};
 		self.log.bi_opens.fetch_add(1, Ordering::Relaxed);
 
 		let send = SinkSend {
 			log: self.log.clone(),
 			gate: Some(gate),
+			park: kio::Park::default(),
 			finished: false,
 		};
-		Ok((send, PendingRecv))
+		Poll::Ready(Ok((send, PendingRecv)))
 	}
 
-	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-		Ok(SinkSend::new(self.log.clone()))
+	fn poll_open_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::SendStream, Self::Error>> {
+		Poll::Ready(Ok(SinkSend::new(self.log.clone())))
 	}
 
-	fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
-		Ok(())
+	fn poll_send_datagram(&mut self, _cx: &mut Context<'_>, _payload: &[u8]) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
 	}
 
-	async fn recv_datagram(&self) -> Result<bytes::Bytes, Self::Error> {
-		std::future::pending().await
+	fn poll_recv_datagram(&mut self, _cx: &mut Context<'_>) -> Poll<Result<bytes::Bytes, Self::Error>> {
+		Poll::Pending
 	}
 
 	fn max_datagram_size(&self) -> usize {
@@ -358,12 +371,12 @@ impl web_transport_trait::Session for SinkSession {
 		None
 	}
 
-	fn close(&self, code: u32, reason: &str) {
+	fn close(&mut self, code: u32, reason: &str) {
 		self.log.closes.lock().unwrap().push((code, reason.to_owned()));
 	}
 
-	async fn closed(&self) -> Self::Error {
-		std::future::pending().await
+	fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Self::Error> {
+		Poll::Pending
 	}
 
 	fn stats(&self) -> impl web_transport_trait::Stats {
@@ -391,10 +404,10 @@ pub struct ScriptedRecv {
 	eof: bool,
 }
 
-impl web_transport_trait::RecvStream for ScriptedRecv {
+impl poll::RecvStream for ScriptedRecv {
 	type Error = SinkError;
 
-	async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+	fn poll_read(&mut self, _cx: &mut Context<'_>, dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
 		let take = {
 			let mut script = self.script.lock().unwrap();
 			if script.is_empty() {
@@ -408,16 +421,16 @@ impl web_transport_trait::RecvStream for ScriptedRecv {
 		};
 
 		match take {
-			0 if self.eof => Ok(None),
-			0 => std::future::pending().await,
-			take => Ok(Some(take)),
+			0 if self.eof => Poll::Ready(Ok(None)),
+			0 => Poll::Pending,
+			take => Poll::Ready(Ok(Some(take))),
 		}
 	}
 
 	fn stop(&mut self, _code: u32) {}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
-		std::future::pending().await
+	fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Pending
 	}
 }
 
@@ -471,38 +484,41 @@ impl ScriptedSession {
 	}
 }
 
-impl web_transport_trait::Session for ScriptedSession {
+impl poll::Session for ScriptedSession {
 	type SendStream = SinkSend;
 	type RecvStream = ScriptedRecv;
 	type Error = SinkError;
 
-	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-		std::future::pending().await
+	fn poll_accept_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>> {
+		Poll::Pending
 	}
 
-	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-		std::future::pending().await
+	fn poll_accept_bi(&mut self, _cx: &mut Context<'_>) -> Poll<Result<poll::BiStreams<Self>, Self::Error>> {
+		Poll::Pending
 	}
 
-	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+	fn poll_open_bi(&mut self, _cx: &mut Context<'_>) -> Poll<Result<poll::BiStreams<Self>, Self::Error>> {
 		self.log.bi_opens.fetch_add(1, Ordering::Relaxed);
 		let script = match &self.queue {
 			Some(queue) => Arc::new(Mutex::new(queue.lock().unwrap().pop_front().unwrap_or_default())),
 			None => self.script.clone(),
 		};
-		Ok((SinkSend::new(self.log.clone()), ScriptedRecv { script, eof: self.eof }))
+		Poll::Ready(Ok((
+			SinkSend::new(self.log.clone()),
+			ScriptedRecv { script, eof: self.eof },
+		)))
 	}
 
-	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-		Ok(SinkSend::new(self.log.clone()))
+	fn poll_open_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::SendStream, Self::Error>> {
+		Poll::Ready(Ok(SinkSend::new(self.log.clone())))
 	}
 
-	fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
-		Ok(())
+	fn poll_send_datagram(&mut self, _cx: &mut Context<'_>, _payload: &[u8]) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
 	}
 
-	async fn recv_datagram(&self) -> Result<bytes::Bytes, Self::Error> {
-		std::future::pending().await
+	fn poll_recv_datagram(&mut self, _cx: &mut Context<'_>) -> Poll<Result<bytes::Bytes, Self::Error>> {
+		Poll::Pending
 	}
 
 	fn max_datagram_size(&self) -> usize {
@@ -513,12 +529,12 @@ impl web_transport_trait::Session for ScriptedSession {
 		None
 	}
 
-	fn close(&self, code: u32, reason: &str) {
+	fn close(&mut self, code: u32, reason: &str) {
 		self.log.closes.lock().unwrap().push((code, reason.to_owned()));
 	}
 
-	async fn closed(&self) -> Self::Error {
-		std::future::pending().await
+	fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Self::Error> {
+		Poll::Pending
 	}
 
 	fn stats(&self) -> impl web_transport_trait::Stats {

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -193,17 +193,17 @@ impl web_transport_trait::Error for ResetError {
 /// reaches an accept loop in normal operation, not just from a misbehaving peer.
 pub struct DeadRecv;
 
-impl web_transport_trait::RecvStream for DeadRecv {
+impl poll::RecvStream for DeadRecv {
 	type Error = ResetError;
 
-	async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-		Err(ResetError)
+	fn poll_read(&mut self, _cx: &mut Context<'_>, _dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
+		Poll::Ready(Err(ResetError))
 	}
 
 	fn stop(&mut self, _code: u32) {}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
-		Err(ResetError)
+	fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Err(ResetError))
 	}
 }
 
@@ -249,40 +249,40 @@ impl DeadStreamSession {
 	}
 }
 
-impl web_transport_trait::Session for DeadStreamSession {
+impl poll::Session for DeadStreamSession {
 	type SendStream = SinkSend;
 	type RecvStream = DeadRecv;
 	type Error = SinkError;
 
-	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
+	fn poll_accept_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>> {
 		match Self::take(&self.unis) {
-			true => Ok(DeadRecv),
-			false => std::future::pending().await,
+			true => Poll::Ready(Ok(DeadRecv)),
+			false => Poll::Pending,
 		}
 	}
 
-	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+	fn poll_accept_bi(&mut self, _cx: &mut Context<'_>) -> Poll<Result<poll::BiStreams<Self>, Self::Error>> {
 		match Self::take(&self.bis) {
-			true => Ok((SinkSend::new(self.log.clone()), DeadRecv)),
-			false => std::future::pending().await,
+			true => Poll::Ready(Ok((SinkSend::new(self.log.clone()), DeadRecv))),
+			false => Poll::Pending,
 		}
 	}
 
-	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+	fn poll_open_bi(&mut self, _cx: &mut Context<'_>) -> Poll<Result<poll::BiStreams<Self>, Self::Error>> {
 		self.log.bi_opens.fetch_add(1, Ordering::Relaxed);
-		Ok((SinkSend::new(self.log.clone()), DeadRecv))
+		Poll::Ready(Ok((SinkSend::new(self.log.clone()), DeadRecv)))
 	}
 
-	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-		Ok(SinkSend::new(self.log.clone()))
+	fn poll_open_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::SendStream, Self::Error>> {
+		Poll::Ready(Ok(SinkSend::new(self.log.clone())))
 	}
 
-	fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
-		Ok(())
+	fn poll_send_datagram(&mut self, _cx: &mut Context<'_>, _payload: &[u8]) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
 	}
 
-	async fn recv_datagram(&self) -> Result<bytes::Bytes, Self::Error> {
-		std::future::pending().await
+	fn poll_recv_datagram(&mut self, _cx: &mut Context<'_>) -> Poll<Result<bytes::Bytes, Self::Error>> {
+		Poll::Pending
 	}
 
 	fn max_datagram_size(&self) -> usize {
@@ -293,12 +293,12 @@ impl web_transport_trait::Session for DeadStreamSession {
 		None
 	}
 
-	fn close(&self, code: u32, reason: &str) {
+	fn close(&mut self, code: u32, reason: &str) {
 		self.log.closes.lock().unwrap().push((code, reason.to_owned()));
 	}
 
-	async fn closed(&self) -> Self::Error {
-		std::future::pending().await
+	fn poll_closed(&mut self, _cx: &mut Context<'_>) -> Poll<Self::Error> {
+		Poll::Pending
 	}
 
 	fn stats(&self) -> impl web_transport_trait::Stats {

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -92,6 +92,16 @@ impl SinkSend {
 			finished: false,
 		}
 	}
+
+	/// A send stream whose writes park until `gate` flips to true.
+	pub fn gated(log: Log, gate: kio::Consumer<bool>) -> Self {
+		Self {
+			log,
+			gate: Some(gate),
+			park: kio::Park::default(),
+			finished: false,
+		}
+	}
 }
 
 impl poll::SendStream for SinkSend {

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -208,18 +208,10 @@ impl AsRef<[u8]> for FrameBuf {
 	}
 }
 
-/// Writes the payload of the single in-flight frame in one or more chunks.
-///
-/// Borrows the parent [`group::Producer`] exclusively, so no other frame can be
-/// opened while this one is live. The total bytes written must exactly match
-/// [`Info::size`]; call [`Self::finish`] to commit the frame (or [`Self::abort`] to
-/// fail it). Dropping without either aborts the group, since an unfinished frame
-/// leaves the group's stream broken.
-///
-/// A single whole-frame [`write`](Self::write) keeps the caller's allocation
-/// (zero-copy); chunked writes copy into one buffer sized to the declared frame.
-pub struct Producer<'a> {
-	group: &'a mut group::Producer,
+/// The writer behind [`Producer`] and [`ProducerOwned`], generic over how it
+/// reaches the parent group (an exclusive borrow, or an owned clone).
+struct Raw<G: std::borrow::BorrowMut<group::Producer>> {
+	group: G,
 	buf: FrameBuf,
 	info: Info,
 	// Set once the frame is committed (finished) or aborted, so Drop is a no-op.
@@ -229,45 +221,12 @@ pub struct Producer<'a> {
 	stats: stats::Meter,
 }
 
-impl std::ops::Deref for Producer<'_> {
-	type Target = Info;
-
-	fn deref(&self) -> &Self::Target {
-		&self.info
-	}
-}
-
-impl<'a> Producer<'a> {
-	pub(crate) fn new(group: &'a mut group::Producer, buf: FrameBuf, info: Info) -> Self {
-		Self {
-			group,
-			buf,
-			info,
-			done: false,
-			stats: stats::Meter::default(),
-		}
-	}
-
-	/// Attach the parent group's ingress meter, so written chunks bump `bytes`.
-	pub(crate) fn with_meter(mut self, meter: stats::Meter) -> Self {
-		self.stats = meter;
-		self
-	}
-
-	/// The parent group this frame belongs to.
-	pub fn group(&self) -> group::Info {
-		self.group.info()
-	}
-
-	/// Bytes still needed to complete the frame.
-	pub fn remaining(&self) -> usize {
+impl<G: std::borrow::BorrowMut<group::Producer>> Raw<G> {
+	fn remaining(&self) -> usize {
 		self.buf.capacity() - self.buf.written(Ordering::Acquire)
 	}
 
-	/// Write a chunk of data to the frame.
-	///
-	/// Returns [`Error::WrongSize`] if the chunk would exceed the remaining bytes.
-	pub fn write<B: IntoBytes>(&mut self, chunk: B) -> Result<()> {
+	fn write<B: IntoBytes>(&mut self, chunk: B) -> Result<()> {
 		let len = chunk.as_ref().len();
 		if len > self.remaining() {
 			return Err(Error::WrongSize);
@@ -288,19 +247,16 @@ impl<'a> Producer<'a> {
 		} else {
 			self.buf.append(chunk.as_ref());
 		}
-		self.group.frame_notify();
+		self.group.borrow_mut().frame_notify();
 		Ok(())
 	}
 
-	/// Commit the frame, verifying that all bytes were written.
-	///
-	/// Returns [`Error::WrongSize`] if the bytes written don't match [`Info::size`].
-	pub fn finish(mut self) -> Result<()> {
+	fn finish(&mut self) -> Result<()> {
 		if self.buf.written(Ordering::Acquire) != self.buf.capacity() {
 			return Err(Error::WrongSize);
 		}
 		let payload = self.buf.freeze(self.buf.capacity());
-		self.group.frame_commit(Frame {
+		self.group.borrow_mut().frame_commit(Frame {
 			timestamp: self.info.timestamp,
 			payload,
 		})?;
@@ -308,25 +264,145 @@ impl<'a> Producer<'a> {
 		Ok(())
 	}
 
-	/// Abort the frame (and its group) with the given error.
-	pub fn abort(mut self, err: Error) -> Result<()> {
-		self.group.frame_abort(err);
+	fn abort(&mut self, err: Error) -> Result<()> {
+		self.group.borrow_mut().frame_abort(err);
 		self.done = true;
 		Ok(())
 	}
 }
 
-impl Drop for Producer<'_> {
+impl<G: std::borrow::BorrowMut<group::Producer>> Drop for Raw<G> {
 	fn drop(&mut self) {
 		if !self.done {
 			// An unfinished frame leaves the group stream broken; fail the group so
 			// consumers surface an error instead of hanging on the partial forever.
 			tracing::warn!(
-				group = self.group.info().sequence,
+				group = self.group.borrow_mut().info().sequence,
 				"frame::Producer dropped before writing all bytes"
 			);
-			self.group.frame_abort(Error::Dropped);
+			self.group.borrow_mut().frame_abort(Error::Dropped);
 		}
+	}
+}
+
+/// Writes the payload of the single in-flight frame in one or more chunks.
+///
+/// Borrows the parent [`group::Producer`] exclusively, so no other frame can be
+/// opened while this one is live. The total bytes written must exactly match
+/// [`Info::size`]; call [`Self::finish`] to commit the frame (or [`Self::abort`] to
+/// fail it). Dropping without either aborts the group, since an unfinished frame
+/// leaves the group's stream broken.
+///
+/// A single whole-frame [`write`](Self::write) keeps the caller's allocation
+/// (zero-copy); chunked writes copy into one buffer sized to the declared frame.
+pub struct Producer<'a>(Raw<&'a mut group::Producer>);
+
+impl std::ops::Deref for Producer<'_> {
+	type Target = Info;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0.info
+	}
+}
+
+impl<'a> Producer<'a> {
+	pub(crate) fn new(group: &'a mut group::Producer, buf: FrameBuf, info: Info) -> Self {
+		Self(Raw {
+			group,
+			buf,
+			info,
+			done: false,
+			stats: stats::Meter::default(),
+		})
+	}
+
+	/// Attach the parent group's ingress meter, so written chunks bump `bytes`.
+	pub(crate) fn with_meter(mut self, meter: stats::Meter) -> Self {
+		self.0.stats = meter;
+		self
+	}
+
+	/// The parent group this frame belongs to.
+	pub fn group(&self) -> group::Info {
+		self.0.group.info()
+	}
+
+	/// Bytes still needed to complete the frame.
+	pub fn remaining(&self) -> usize {
+		self.0.remaining()
+	}
+
+	/// Write a chunk of data to the frame.
+	///
+	/// Returns [`Error::WrongSize`] if the chunk would exceed the remaining bytes.
+	pub fn write<B: IntoBytes>(&mut self, chunk: B) -> Result<()> {
+		self.0.write(chunk)
+	}
+
+	/// Commit the frame, verifying that all bytes were written.
+	///
+	/// Returns [`Error::WrongSize`] if the bytes written don't match [`Info::size`].
+	pub fn finish(mut self) -> Result<()> {
+		self.0.finish()
+	}
+
+	/// Abort the frame (and its group) with the given error.
+	pub fn abort(mut self, err: Error) -> Result<()> {
+		self.0.abort(err)
+	}
+}
+
+/// The owned counterpart of [`Producer`], for the wire drivers that stream a
+/// frame across polls and cannot hold the group borrowed inside their state.
+///
+/// Crate-private on purpose: the exclusivity the public borrow enforces (one
+/// live frame per group) becomes the holder's promise here. Do not open another
+/// frame on the group until this one is finished or aborted.
+pub(crate) struct ProducerOwned(Raw<group::Producer>);
+
+impl std::ops::Deref for ProducerOwned {
+	type Target = Info;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0.info
+	}
+}
+
+impl ProducerOwned {
+	pub(crate) fn new(group: group::Producer, buf: FrameBuf, info: Info) -> Self {
+		Self(Raw {
+			group,
+			buf,
+			info,
+			done: false,
+			stats: stats::Meter::default(),
+		})
+	}
+
+	/// Attach the parent group's ingress meter, so written chunks bump `bytes`.
+	pub(crate) fn with_meter(mut self, meter: stats::Meter) -> Self {
+		self.0.stats = meter;
+		self
+	}
+
+	/// Bytes still needed to complete the frame.
+	pub fn remaining(&self) -> usize {
+		self.0.remaining()
+	}
+
+	/// Write a chunk of data to the frame.
+	pub fn write<B: IntoBytes>(&mut self, chunk: B) -> Result<()> {
+		self.0.write(chunk)
+	}
+
+	/// Commit the frame, verifying that all bytes were written.
+	pub fn finish(mut self) -> Result<()> {
+		self.0.finish()
+	}
+
+	/// Abort the frame (and its group) with the given error.
+	pub fn abort(mut self, err: Error) -> Result<()> {
+		self.0.abort(err)
 	}
 }
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -471,6 +471,55 @@ impl Producer {
 		Ok(frame::Producer::new(self, buf, info).with_meter(meter))
 	}
 
+	/// The owned counterpart of [`Self::create_frame`], for the wire drivers that
+	/// stream a frame across polls and cannot hold the group borrowed inside their
+	/// state. The one-live-frame rule the borrow normally enforces becomes the
+	/// caller's promise; see [`frame::ProducerOwned`].
+	pub(crate) fn create_frame_owned(&mut self, frame: frame::Info) -> Result<frame::ProducerOwned> {
+		let timestamp = frame
+			.timestamp
+			.convert(self.track.timescale)
+			.map_err(|_| Error::TimestampMismatch)?;
+		if frame.size > MAX_GROUP_CACHE {
+			return Err(Error::FrameTooLarge);
+		}
+		let buf = FrameBuf::new(frame.size as usize);
+
+		let mut state = modify(&self.state)?;
+		if state.fin.is_some() {
+			return Err(Error::Closed);
+		}
+		let next_index = state
+			.next_index
+			.checked_add(1)
+			.ok_or(Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
+		debug_assert!(state.partial.is_none(), "a frame is already open");
+		state.cache += frame.size;
+		state.charge.add(frame.size);
+		state.partial = Some(Partial {
+			timestamp,
+			buf: buf.clone(),
+		});
+		state.next_index = next_index;
+		state.evict();
+		drop(state);
+
+		// With the group lock released (lock order is track then group), settle
+		// eviction debt if enough has been written since the track last paid.
+		self.cache.settle();
+
+		// Ingress payload: one frame opened; its bytes are counted per chunk as the
+		// producer writes them.
+		self.stats.frames(1);
+		let meter = self.stats.clone();
+
+		let info = frame::Info {
+			size: frame.size,
+			timestamp,
+		};
+		Ok(frame::ProducerOwned::new(self.clone(), buf, info).with_meter(meter))
+	}
+
 	/// Wake consumers parked on the group channel (called after a partial write).
 	pub(crate) fn frame_notify(&self) {
 		// Taking the write lock and dropping it triggers kio's notify.

--- a/rs/moq-net/src/poll_set.rs
+++ b/rs/moq-net/src/poll_set.rs
@@ -143,27 +143,27 @@ impl<T: Machine> PollSet<T> {
 			}
 		}
 
-		loop {
-			let ready = std::mem::take(&mut *self.shared.ready.lock().unwrap());
-			if ready.is_empty() {
-				break;
-			}
-			for index in ready {
-				// A stale index (the child finished, maybe its slot was reused) is
-				// skipped or costs one spurious poll; both are harmless.
-				let Some(child) = self.children.get_mut(index).and_then(Option::as_mut) else {
-					continue;
-				};
-				// Cleared before polling: a wake landing mid-poll re-queues the child
-				// rather than being lost.
-				child.flag.dirty.store(false, Ordering::Release);
-				let cx = Context::from_waker(&child.waker);
-				let child_waiter = child.park.hold(&cx);
-				if child.machine.poll(child_waiter).is_ready() {
-					self.children[index] = None;
-					self.free.push(index);
-					self.len -= 1;
-				}
+		// One snapshot per parent poll: a child woken during the pass (including a
+		// self-wake before returning Pending) re-queues itself and has already
+		// woken the parent through its ChildWaker, so the executor re-polls this
+		// set. Looping here instead would let a self-waking child spin without
+		// ever yielding, starving the caller's other arms.
+		let ready = std::mem::take(&mut *self.shared.ready.lock().unwrap());
+		for index in ready {
+			// A stale index (the child finished, maybe its slot was reused) is
+			// skipped or costs one spurious poll; both are harmless.
+			let Some(child) = self.children.get_mut(index).and_then(Option::as_mut) else {
+				continue;
+			};
+			// Cleared before polling: a wake landing mid-poll re-queues the child
+			// rather than being lost.
+			child.flag.dirty.store(false, Ordering::Release);
+			let cx = Context::from_waker(&child.waker);
+			let child_waiter = child.park.hold(&cx);
+			if child.machine.poll(child_waiter).is_ready() {
+				self.children[index] = None;
+				self.free.push(index);
+				self.len -= 1;
 			}
 		}
 
@@ -302,5 +302,51 @@ mod tests {
 
 		let _ = gated(&mut set);
 		assert!(flag.0.load(Ordering::SeqCst), "the push missed the parent");
+	}
+
+	/// A transport is allowed to self-wake before returning Pending. Such a child
+	/// must be polled once per parent poll, not spun on inside it, or it starves
+	/// the caller's other arms; the re-queue instead wakes the parent for the
+	/// next round.
+	#[test]
+	fn a_self_waking_child_yields_to_the_parent() {
+		struct Flag(AtomicBool);
+		impl Wake for Flag {
+			fn wake(self: Arc<Self>) {
+				self.0.store(true, Ordering::SeqCst);
+			}
+		}
+
+		struct SelfWaking {
+			polls: Arc<AtomicUsize>,
+		}
+		impl Machine for SelfWaking {
+			fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+				self.polls.fetch_add(1, Ordering::SeqCst);
+				waiter.waker().wake_by_ref();
+				Poll::Pending
+			}
+		}
+
+		let mut set = PollSet::new();
+		let polls = Arc::new(AtomicUsize::new(0));
+		set.push(SelfWaking { polls: polls.clone() });
+
+		let flag = Arc::new(Flag(AtomicBool::new(false)));
+		let waiter = kio::Waiter::new(Waker::from(flag.clone()));
+
+		assert!(set.poll(&waiter).is_pending());
+		assert_eq!(polls.load(Ordering::SeqCst), 1, "one poll per parent poll");
+		assert!(
+			flag.0.swap(false, Ordering::SeqCst),
+			"the re-queue must wake the parent"
+		);
+
+		assert!(set.poll(&waiter).is_pending());
+		assert_eq!(
+			polls.load(Ordering::SeqCst),
+			2,
+			"the next parent poll runs the child again"
+		);
 	}
 }

--- a/rs/moq-net/src/poll_set.rs
+++ b/rs/moq-net/src/poll_set.rs
@@ -94,6 +94,7 @@ impl<T: Machine> PollSet<T> {
 	}
 
 	/// The number of live children.
+	#[cfg(test)]
 	pub fn len(&self) -> usize {
 		self.len
 	}

--- a/rs/moq-net/src/poll_set.rs
+++ b/rs/moq-net/src/poll_set.rs
@@ -1,0 +1,305 @@
+//! A dynamic set of poll-driven children with per-child wakeups.
+//!
+//! The poll-native counterpart of `FuturesUnordered`: each child owns a
+//! [`Waker`] that marks it ready and wakes the parent, so a wakeup re-polls only
+//! the child it was aimed at. A session serving hundreds of subscriptions polls
+//! one machine per event, not all of them.
+
+use std::{
+	sync::{
+		Arc, Mutex,
+		atomic::{AtomicBool, Ordering},
+	},
+	task::{Context, Poll, Wake, Waker},
+};
+
+/// A child state machine drivable by a [`PollSet`].
+pub(crate) trait Machine {
+	/// Drive this child one step; `Ready` retires it from the set.
+	///
+	/// The machine owns its outcome: log or record errors before returning
+	/// `Ready`, the set only removes the entry.
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()>;
+}
+
+/// A set of [`Machine`]s polled with per-child granularity.
+pub(crate) struct PollSet<T> {
+	/// Slab of children; `None` slots are free and listed in `free`.
+	children: Vec<Option<Child<T>>>,
+	free: Vec<usize>,
+	len: usize,
+	shared: Arc<Shared>,
+}
+
+struct Child<T> {
+	machine: T,
+	/// This child's waker, marking it ready and waking the parent.
+	waker: Waker,
+	flag: Arc<ChildWaker>,
+	/// Retains the child's kio registrations between polls.
+	park: kio::Park,
+}
+
+/// State shared with every child waker.
+struct Shared {
+	/// Indices needing a poll. A child appears at most once (see [`ChildWaker::dirty`]).
+	ready: Mutex<Vec<usize>>,
+	/// The waker of whoever polls the set, re-registered on every poll.
+	parent: Mutex<Option<Waker>>,
+}
+
+impl Shared {
+	fn wake_parent(&self) {
+		let parent = self.parent.lock().unwrap().clone();
+		if let Some(waker) = parent {
+			waker.wake();
+		}
+	}
+}
+
+/// The per-child waker: queues the child's index and wakes the parent.
+struct ChildWaker {
+	index: usize,
+	/// Set while the child is queued, so a burst of wakes queues it once. Cleared
+	/// just before the child is polled, so a wake racing the poll re-queues it.
+	dirty: AtomicBool,
+	shared: Arc<Shared>,
+}
+
+impl Wake for ChildWaker {
+	fn wake(self: Arc<Self>) {
+		self.wake_by_ref();
+	}
+
+	fn wake_by_ref(self: &Arc<Self>) {
+		if self.dirty.swap(true, Ordering::AcqRel) {
+			return;
+		}
+		self.shared.ready.lock().unwrap().push(self.index);
+		self.shared.wake_parent();
+	}
+}
+
+impl<T: Machine> PollSet<T> {
+	pub fn new() -> Self {
+		Self {
+			children: Vec::new(),
+			free: Vec::new(),
+			len: 0,
+			shared: Arc::new(Shared {
+				ready: Mutex::new(Vec::new()),
+				parent: Mutex::new(None),
+			}),
+		}
+	}
+
+	/// The number of live children.
+	pub fn len(&self) -> usize {
+		self.len
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.len == 0
+	}
+
+	/// Add a child, queued for its first poll. Wakes the parent so a push from
+	/// outside its poll still gets the child started.
+	pub fn push(&mut self, machine: T) {
+		let index = match self.free.pop() {
+			Some(index) => index,
+			None => {
+				self.children.push(None);
+				self.children.len() - 1
+			}
+		};
+		let flag = Arc::new(ChildWaker {
+			index,
+			dirty: AtomicBool::new(true),
+			shared: self.shared.clone(),
+		});
+		self.children[index] = Some(Child {
+			machine,
+			waker: Waker::from(flag.clone()),
+			flag,
+			park: kio::Park::default(),
+		});
+		self.len += 1;
+		self.shared.ready.lock().unwrap().push(index);
+		self.shared.wake_parent();
+	}
+
+	/// Poll every child that has been woken since the last call, retiring the
+	/// finished ones. `Ready` when the set is empty.
+	///
+	/// `waiter` is registered for the next child wake (and for pushes); the
+	/// children themselves park on their own wakers.
+	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		{
+			let mut parent = self.shared.parent.lock().unwrap();
+			let waker = waiter.waker();
+			if !parent.as_ref().is_some_and(|w| w.will_wake(waker)) {
+				*parent = Some(waker.clone());
+			}
+		}
+
+		loop {
+			let ready = std::mem::take(&mut *self.shared.ready.lock().unwrap());
+			if ready.is_empty() {
+				break;
+			}
+			for index in ready {
+				// A stale index (the child finished, maybe its slot was reused) is
+				// skipped or costs one spurious poll; both are harmless.
+				let Some(child) = self.children.get_mut(index).and_then(Option::as_mut) else {
+					continue;
+				};
+				// Cleared before polling: a wake landing mid-poll re-queues the child
+				// rather than being lost.
+				child.flag.dirty.store(false, Ordering::Release);
+				let cx = Context::from_waker(&child.waker);
+				let child_waiter = child.park.hold(&cx);
+				if child.machine.poll(child_waiter).is_ready() {
+					self.children[index] = None;
+					self.free.push(index);
+					self.len -= 1;
+				}
+			}
+		}
+
+		match self.len {
+			0 => Poll::Ready(()),
+			_ => Poll::Pending,
+		}
+	}
+}
+
+impl<T: Machine> Default for PollSet<T> {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::sync::atomic::AtomicUsize;
+
+	/// Counts its polls; finishes when its gate opens.
+	struct Gated {
+		gate: kio::Consumer<bool>,
+		polls: Arc<AtomicUsize>,
+	}
+
+	impl Machine for Gated {
+		fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+			self.polls.fetch_add(1, Ordering::SeqCst);
+			match self.gate.poll(waiter, |open| match **open {
+				true => Poll::Ready(()),
+				false => Poll::Pending,
+			}) {
+				Poll::Ready(_) => Poll::Ready(()),
+				Poll::Pending => Poll::Pending,
+			}
+		}
+	}
+
+	fn gated(set: &mut PollSet<Gated>) -> (kio::Producer<bool>, Arc<AtomicUsize>) {
+		let gate = kio::Producer::new(false);
+		let polls = Arc::new(AtomicUsize::new(0));
+		set.push(Gated {
+			gate: gate.consume(),
+			polls: polls.clone(),
+		});
+		(gate, polls)
+	}
+
+	fn open(gate: &kio::Producer<bool>) {
+		let Ok(mut state) = gate.write() else {
+			panic!("gate closed")
+		};
+		*state = true;
+	}
+
+	/// A wake aimed at one child polls only that child.
+	#[test]
+	fn a_wake_polls_only_its_child() {
+		let mut set = PollSet::new();
+		let (a_gate, a_polls) = gated(&mut set);
+		let (_b_gate, b_polls) = gated(&mut set);
+
+		let waiter = kio::Waiter::noop();
+		assert!(set.poll(&waiter).is_pending());
+		assert_eq!((a_polls.load(Ordering::SeqCst), b_polls.load(Ordering::SeqCst)), (1, 1));
+
+		// Waking a's gate must re-poll a alone.
+		open(&a_gate);
+		assert!(set.poll(&waiter).is_pending(), "b is still live");
+		assert_eq!(a_polls.load(Ordering::SeqCst), 2, "a was woken");
+		assert_eq!(b_polls.load(Ordering::SeqCst), 1, "b was not");
+	}
+
+	/// Finished children retire, their slots are reused, and an empty set is Ready.
+	#[test]
+	fn finished_children_retire_and_slots_recycle() {
+		let mut set = PollSet::new();
+		let (a_gate, _) = gated(&mut set);
+		let (b_gate, _) = gated(&mut set);
+		assert_eq!(set.len(), 2);
+
+		let waiter = kio::Waiter::noop();
+		open(&a_gate);
+		assert!(set.poll(&waiter).is_pending());
+		assert_eq!(set.len(), 1);
+
+		// The freed slot is reused without growing the slab.
+		let (c_gate, _) = gated(&mut set);
+		assert_eq!(set.children.len(), 2);
+
+		open(&b_gate);
+		open(&c_gate);
+		assert!(set.poll(&waiter).is_ready(), "an empty set is Ready");
+		assert!(set.is_empty());
+	}
+
+	/// A wake for a child that already finished is skipped, even after its slot
+	/// has been handed to a newcomer.
+	#[test]
+	fn a_stale_wake_is_harmless() {
+		let mut set = PollSet::new();
+		let (gate, _) = gated(&mut set);
+		let stale = set.children[0].as_ref().unwrap().flag.clone();
+
+		let waiter = kio::Waiter::noop();
+		open(&gate);
+		assert!(set.poll(&waiter).is_ready());
+
+		// The dead child's waker fires (its slot is empty): nothing to poll.
+		Waker::from(stale).wake();
+		assert!(set.poll(&waiter).is_ready());
+	}
+
+	/// The parent is woken by a child wake and by a push, so neither is lost when
+	/// it happens between polls.
+	#[test]
+	fn child_wakes_and_pushes_reach_the_parent() {
+		struct Flag(AtomicBool);
+		impl Wake for Flag {
+			fn wake(self: Arc<Self>) {
+				self.0.store(true, Ordering::SeqCst);
+			}
+		}
+
+		let mut set = PollSet::new();
+		let (gate, _) = gated(&mut set);
+
+		let flag = Arc::new(Flag(AtomicBool::new(false)));
+		let waiter = kio::Waiter::new(Waker::from(flag.clone()));
+		assert!(set.poll(&waiter).is_pending());
+
+		open(&gate);
+		assert!(flag.0.swap(false, Ordering::SeqCst), "the child wake missed the parent");
+
+		let _ = gated(&mut set);
+		assert!(flag.0.load(Ordering::SeqCst), "the push missed the parent");
+	}
+}

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -64,7 +64,7 @@ impl Server {
 	/// Convenience wrapper over [`accept_request`](Self::accept_request) that
 	/// completes the handshake immediately. Use `accept_request` when you need to
 	/// inspect the client's advertised path before deciding what to serve.
-	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<(Session, Driver), Error> {
+	pub async fn accept<S: crate::transport::poll::Session>(&self, session: S) -> Result<(Session, Driver), Error> {
 		self.accept_request(session).await?.ok().await
 	}
 
@@ -78,7 +78,10 @@ impl Server {
 	///
 	/// The path is surfaced for moq-lite-05 and every moq-transport draft we speak;
 	/// it's empty on versions with no in-band request path (e.g. lite 01-04).
-	pub async fn accept_request<S: web_transport_trait::Session>(&self, session: S) -> Result<Request<S>, Error> {
+	pub async fn accept_request<S: crate::transport::poll::Session>(
+		&self,
+		mut session: S,
+	) -> Result<Request<S>, Error> {
 		// Regimes without a path to read defer to `ok()` without surfacing one, and
 		// carry no role or origin hint, so authorization is unchanged for them.
 		let deferred = |handshake| Request {
@@ -141,7 +144,7 @@ impl Server {
 				// Gate on the client's SETUP: read it before serving so the caller can
 				// scope by the advertised path. Seeded back into `start` on `ok()` so
 				// PROBE gating resolves without re-reading the (consumed) Setup Stream.
-				let client_setup = lite::accept_setup(&session, version).await?;
+				let client_setup = lite::accept_setup(&mut session, version).await?;
 				return Ok(Request {
 					path: client_setup.path.clone(),
 					role: client_setup.role,
@@ -183,7 +186,7 @@ impl Server {
 
 		// Legacy bidi SETUP exchange (IETF 14-16, lite 01/02). Read the client's
 		// SETUP to choose the version; `ok()` sends the server SETUP and starts.
-		let mut stream = Stream::accept(&session, encoding).await?;
+		let mut stream = Stream::accept(&mut session, encoding).await?;
 		let mut client: setup::Client = stream.reader.decode().await?;
 
 		let version = client
@@ -233,12 +236,12 @@ impl Server {
 
 	/// Read a draft-17/18 client's SETUP (with its request path) off its uni stream,
 	/// then pause. `ok()` starts the session and hands the stream back for GOAWAY.
-	async fn accept_ietf_modern<S: web_transport_trait::Session>(
+	async fn accept_ietf_modern<S: crate::transport::poll::Session>(
 		&self,
-		session: S,
+		mut session: S,
 		version: ietf::Version,
 	) -> Result<Request<S>, Error> {
-		let peer_setup = ietf::accept_setup(&session, version).await?;
+		let peer_setup = ietf::accept_setup(&mut session, version).await?;
 		Ok(Request {
 			path: peer_setup.path.clone(),
 			role: None,
@@ -264,7 +267,7 @@ impl Server {
 /// the origins to serve, then call [`ok`](Self::ok) to complete the handshake, or
 /// [`close`](Self::close) to reject it. Modeled on the WebTransport `Request` in
 /// moq-native.
-pub struct Request<S: web_transport_trait::Session> {
+pub struct Request<S: crate::transport::poll::Session> {
 	path: Option<String>,
 	role: Option<Role>,
 	origin: Option<crate::Origin>,
@@ -273,14 +276,14 @@ pub struct Request<S: web_transport_trait::Session> {
 }
 
 /// The parts of a [`Request`] consumed by [`Request::ok`] / [`Request::close`].
-struct RequestInner<S: web_transport_trait::Session> {
+struct RequestInner<S: crate::transport::poll::Session> {
 	server: Server,
 	handshake: Handshake<S>,
 }
 
 /// The handshake state captured at the pause point. Every variant defers its
 /// session start to [`Request::ok`] so origins set on the Request still apply.
-enum Handshake<S: web_transport_trait::Session> {
+enum Handshake<S: crate::transport::poll::Session> {
 	/// Modern IETF (17/18): the client's SETUP (with its request path) has been read
 	/// off its uni stream; `ok()` starts the session, handing that stream back for
 	/// GOAWAY monitoring.
@@ -309,7 +312,7 @@ enum Handshake<S: web_transport_trait::Session> {
 	},
 }
 
-impl<S: web_transport_trait::Session> Request<S> {
+impl<S: crate::transport::poll::Session> Request<S> {
 	/// The request path the client advertised in its SETUP.
 	///
 	/// Empty when the client advertised none: either it sent an empty path, or the
@@ -529,9 +532,9 @@ impl<S: web_transport_trait::Session> Request<S> {
 	}
 }
 
-impl<S: web_transport_trait::Session> RequestInner<S> {
+impl<S: crate::transport::poll::Session> RequestInner<S> {
 	fn close(self, err: Error) {
-		let session = match self.handshake {
+		let mut session = match self.handshake {
 			Handshake::IetfModern { session, .. } => session,
 			Handshake::LiteBare { session, .. } => session,
 			Handshake::Legacy { session, .. } => session,
@@ -541,7 +544,7 @@ impl<S: web_transport_trait::Session> RequestInner<S> {
 	}
 }
 
-impl<S: web_transport_trait::Session> Drop for Request<S> {
+impl<S: crate::transport::poll::Session> Drop for Request<S> {
 	// A dropped request would otherwise leave the client hanging until its idle
 	// timeout: it already sent SETUP and is waiting on a response. Reject loudly.
 	fn drop(&mut self) {
@@ -595,33 +598,50 @@ mod tests {
 		}
 	}
 
-	impl web_transport_trait::Session for FakeSession {
+	impl web_transport_trait::poll::Session for FakeSession {
 		type SendStream = FakeSend;
 		type RecvStream = FakeRecv;
 		type Error = FakeError;
 
-		async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-			// Drop the guard before any await so the future stays Send.
-			let data = self.uni.lock().unwrap().pop_front();
-			match data {
-				Some(data) => Ok(FakeRecv { data: data.into() }),
-				None => std::future::pending().await,
+		fn poll_accept_uni(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+		) -> std::task::Poll<Result<Self::RecvStream, Self::Error>> {
+			match self.uni.lock().unwrap().pop_front() {
+				Some(data) => std::task::Poll::Ready(Ok(FakeRecv { data: data.into() })),
+				None => std::task::Poll::Pending,
 			}
 		}
-		async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			std::future::pending().await
+		fn poll_accept_bi(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+		) -> std::task::Poll<Result<(Self::SendStream, Self::RecvStream), Self::Error>> {
+			std::task::Poll::Pending
 		}
-		async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			std::future::pending().await
+		fn poll_open_bi(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+		) -> std::task::Poll<Result<(Self::SendStream, Self::RecvStream), Self::Error>> {
+			std::task::Poll::Pending
 		}
-		async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-			std::future::pending().await
+		fn poll_open_uni(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+		) -> std::task::Poll<Result<Self::SendStream, Self::Error>> {
+			std::task::Poll::Pending
 		}
-		fn send_datagram(&self, _payload: Bytes) -> Result<(), Self::Error> {
-			Ok(())
+		fn poll_send_datagram(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+			_payload: &[u8],
+		) -> std::task::Poll<Result<(), Self::Error>> {
+			std::task::Poll::Ready(Ok(()))
 		}
-		async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
-			std::future::pending().await
+		fn poll_recv_datagram(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+		) -> std::task::Poll<Result<Bytes, Self::Error>> {
+			std::task::Poll::Pending
 		}
 		fn max_datagram_size(&self) -> usize {
 			1200
@@ -629,47 +649,58 @@ mod tests {
 		fn protocol(&self) -> Option<&str> {
 			self.protocol
 		}
-		fn close(&self, _code: u32, _reason: &str) {}
-		async fn closed(&self) -> Self::Error {
-			std::future::pending().await
+		fn close(&mut self, _code: u32, _reason: &str) {}
+		fn poll_closed(&mut self, _cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Error> {
+			std::task::Poll::Pending
+		}
+		fn stats(&self) -> impl web_transport_trait::Stats {
+			web_transport_trait::StatsUnavailable
 		}
 	}
 
 	#[derive(Clone, Default)]
 	struct FakeSend;
-	impl web_transport_trait::SendStream for FakeSend {
+	impl web_transport_trait::poll::SendStream for FakeSend {
 		type Error = FakeError;
-		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-			Ok(buf.len())
+		fn poll_write(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+			buf: &[u8],
+		) -> std::task::Poll<Result<usize, Self::Error>> {
+			std::task::Poll::Ready(Ok(buf.len()))
 		}
 		fn set_priority(&mut self, _order: u8) {}
 		fn finish(&mut self) -> Result<(), Self::Error> {
 			Ok(())
 		}
 		fn reset(&mut self, _code: u32) {}
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			Ok(())
+		fn poll_closed(&mut self, _cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+			std::task::Poll::Ready(Ok(()))
 		}
 	}
 
 	struct FakeRecv {
 		data: VecDeque<u8>,
 	}
-	impl web_transport_trait::RecvStream for FakeRecv {
+	impl web_transport_trait::poll::RecvStream for FakeRecv {
 		type Error = FakeError;
-		async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+		fn poll_read(
+			&mut self,
+			_cx: &mut std::task::Context<'_>,
+			dst: &mut [u8],
+		) -> std::task::Poll<Result<Option<usize>, Self::Error>> {
 			if self.data.is_empty() {
-				return Ok(None);
+				return std::task::Poll::Ready(Ok(None));
 			}
 			let size = dst.len().min(self.data.len());
 			for slot in dst.iter_mut().take(size) {
 				*slot = self.data.pop_front().unwrap();
 			}
-			Ok(Some(size))
+			std::task::Poll::Ready(Ok(Some(size)))
 		}
 		fn stop(&mut self, _code: u32) {}
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			Ok(())
+		fn poll_closed(&mut self, _cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+			std::task::Poll::Ready(Ok(()))
 		}
 	}
 

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -265,7 +265,7 @@ impl Drop for SessionShared {
 }
 
 impl Session {
-	pub(super) fn new<S: web_transport_trait::Session>(
+	pub(super) fn new<S: crate::transport::poll::Session>(
 		session: S,
 		version: Version,
 		recv_bandwidth: Option<bandwidth::Consumer>,
@@ -287,7 +287,7 @@ impl Session {
 
 		let session = Self {
 			shared: Arc::new(SessionShared {
-				inner: Box::new(session),
+				inner: Box::new(SessionInnerImpl(std::sync::Mutex::new(session))),
 				closed: std::sync::atomic::AtomicBool::new(false),
 			}),
 			version,
@@ -316,8 +316,9 @@ impl Session {
 struct SendBandwidth<S> {
 	session: S,
 	producer: bandwidth::Producer,
-	// The transport close, boxed once so it can be re-polled each step.
-	closed: MaybeSendBox<'static, ()>,
+	// A dedicated clone for the close watch, since each pending poll operation
+	// needs its own handle.
+	closed: S,
 	mode: SendBandwidthMode,
 }
 
@@ -328,18 +329,11 @@ enum SendBandwidthMode {
 	Polling { sleep: MaybeSendBox<'static, ()> },
 }
 
-impl<S: web_transport_trait::Session> SendBandwidth<S> {
+impl<S: crate::transport::poll::Session> SendBandwidth<S> {
 	const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 	fn new(session: S, producer: bandwidth::Producer) -> Self {
-		let closed = {
-			let session = session.clone();
-			async move {
-				session.closed().await;
-			}
-		}
-		.maybe_boxed();
-
+		let closed = session.clone();
 		Self {
 			session,
 			producer,
@@ -360,7 +354,8 @@ impl<S: web_transport_trait::Session> SendBandwidth<S> {
 	}
 
 	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
-		if waiter.poll_future(self.closed.as_mut()).is_ready() {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		if self.closed.poll_closed(&mut cx).is_ready() {
 			return Poll::Ready(());
 		}
 
@@ -406,23 +401,31 @@ impl<S: web_transport_trait::Session> SendBandwidth<S> {
 // allowing the !Send browser WebTransport on wasm.
 trait SessionInner: web_transport_trait::MaybeSend + web_transport_trait::MaybeSync {
 	fn close(&self, code: u32, reason: &str);
-	fn closed(&self) -> MaybeSendBox<'_, Error>;
+	fn closed(&self) -> MaybeSendBox<'static, Error>;
 	fn stats(&self) -> ConnectionStats;
 }
 
-impl<S: web_transport_trait::Session> SessionInner for S {
+// The poll interface takes `&mut self`, but the shared close-once state is
+// reached through `&self` from every clone, so the canonical handle lives
+// behind a Mutex. The lock is held only for the synchronous calls; `closed`
+// clones a handle out and polls that instead.
+struct SessionInnerImpl<S>(std::sync::Mutex<S>);
+
+impl<S: crate::transport::poll::Session> SessionInner for SessionInnerImpl<S> {
 	fn close(&self, code: u32, reason: &str) {
-		S::close(self, code, reason);
+		self.0.lock().unwrap().close(code, reason);
 	}
 
-	fn closed(&self) -> MaybeSendBox<'_, Error> {
-		Box::pin(async move { Error::from_transport(S::closed(self).await) })
+	fn closed(&self) -> MaybeSendBox<'static, Error> {
+		let mut session = self.0.lock().unwrap().clone();
+		Box::pin(async move { Error::from_transport(session.closed().await) })
 	}
 
 	fn stats(&self) -> ConnectionStats {
 		// estimated_recv_rate is filled in at the Session level (it comes from MoQ PROBE,
 		// not the transport), so leave it at the Default `None` here.
-		let stats = S::stats(self);
+		let session = self.0.lock().unwrap();
+		let stats = session.stats();
 		ConnectionStats {
 			rtt: stats.rtt(),
 			estimated_send_rate: stats.estimated_send_rate(),

--- a/rs/moq-net/src/transport.rs
+++ b/rs/moq-net/src/transport.rs
@@ -1,0 +1,148 @@
+//! The transport interface a MoQ session runs over.
+//!
+//! This crate is poll-only: every entry point ([`crate::Client::connect`],
+//! [`crate::Server::accept`]) is generic over the *poll* half of
+//! `web_transport_trait` ([`web_transport_trait::poll`]), never its async half.
+//! The [`poll::Session`], [`poll::SendStream`], and [`poll::RecvStream`] traits
+//! here bundle those poll traits with the bounds the session machinery needs
+//! (cloning, thread affinity) and provide async helper methods on top, the same
+//! layering the rest of the crate uses (`async fn` wraps `poll_*`).
+//!
+//! A transport that only implements the async half cannot be used directly:
+//! implement the poll interface for it (typically inside the transport itself,
+//! where its wakers live) rather than wrapping futures around it here.
+
+/// The poll-based transport traits this crate requires.
+///
+/// These mirror [`web_transport_trait::poll`], adding the bounds the session
+/// machinery needs and async helper methods; they are implemented automatically
+/// for any type implementing the upstream poll traits with those bounds.
+pub mod poll {
+	use std::task::{Context, Poll, ready};
+
+	use bytes::{Buf, BufMut, Bytes};
+	use web_transport_trait::{MaybeSend, MaybeSync, poll};
+
+	/// The transport session a MoQ session runs over.
+	///
+	/// This is [`web_transport_trait::poll::Session`] plus the bounds the protocol
+	/// drivers need: `Clone` so each concurrently pending operation gets its own
+	/// handle (each clone carries its own in-progress state, per the poll contract),
+	/// and `MaybeSend + 'static` so drivers can be boxed and sent to an executor.
+	/// It is implemented automatically.
+	///
+	/// The async methods are helpers over the required `poll_*` methods, so callers
+	/// can `.await` operations without giving up the ability to poll them.
+	pub trait Session:
+		poll::Session<SendStream: SendStream, RecvStream: RecvStream> + Clone + MaybeSend + MaybeSync + 'static
+	{
+		/// Accept the next unidirectional stream opened by the peer.
+		fn accept_uni(&mut self) -> impl Future<Output = Result<Self::RecvStream, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_accept_uni(cx))
+		}
+
+		/// Accept the next bidirectional stream opened by the peer.
+		fn accept_bi(&mut self) -> impl Future<Output = Result<poll::BiStreams<Self>, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_accept_bi(cx))
+		}
+
+		/// Open a unidirectional stream, waiting for stream credit if necessary.
+		fn open_uni(&mut self) -> impl Future<Output = Result<Self::SendStream, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_open_uni(cx))
+		}
+
+		/// Open a bidirectional stream, waiting for stream credit if necessary.
+		fn open_bi(&mut self) -> impl Future<Output = Result<poll::BiStreams<Self>, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_open_bi(cx))
+		}
+
+		/// Receive the next datagram from the peer.
+		fn recv_datagram(&mut self) -> impl Future<Output = Result<Bytes, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_recv_datagram(cx))
+		}
+
+		/// Send a datagram, best-effort: if the transport has no room for it right
+		/// now, the datagram is dropped, exactly as the network is allowed to do.
+		fn send_datagram(&mut self, payload: &[u8]) -> Result<(), Self::Error> {
+			let mut cx = Context::from_waker(std::task::Waker::noop());
+			match self.poll_send_datagram(&mut cx, payload) {
+				Poll::Ready(res) => res,
+				Poll::Pending => Ok(()),
+			}
+		}
+
+		/// Wait until the session is closed by either side, returning the reason.
+		fn closed(&mut self) -> impl Future<Output = Self::Error> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_closed(cx))
+		}
+	}
+
+	impl<S> Session for S where
+		S: poll::Session<SendStream: SendStream, RecvStream: RecvStream> + Clone + MaybeSend + MaybeSync + 'static
+	{
+	}
+
+	/// An outgoing transport stream: [`web_transport_trait::poll::SendStream`] plus
+	/// the bounds needed to move it into a boxed driver, with async helpers.
+	pub trait SendStream: poll::SendStream + MaybeSend + 'static {
+		/// Write some of the buffer, returning how many bytes were accepted.
+		fn write(&mut self, buf: &[u8]) -> impl Future<Output = Result<usize, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_write(cx, buf))
+		}
+
+		/// Write some of the buffer, advancing it by the bytes accepted.
+		fn write_buf<B: Buf + MaybeSend>(
+			&mut self,
+			buf: &mut B,
+		) -> impl Future<Output = Result<usize, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_write_buf(cx, buf))
+		}
+
+		/// Write the entire chunk to the stream.
+		fn write_chunk(&mut self, chunk: Bytes) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+			let mut chunk = chunk;
+			std::future::poll_fn(move |cx| {
+				while !chunk.is_empty() {
+					ready!(self.poll_write_buf(cx, &mut chunk))?;
+				}
+				Poll::Ready(Ok(()))
+			})
+		}
+
+		/// Wait until the stream is closed by either side.
+		fn closed(&mut self) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_closed(cx))
+		}
+	}
+
+	impl<S> SendStream for S where S: poll::SendStream + MaybeSend + 'static {}
+
+	/// An incoming transport stream: [`web_transport_trait::poll::RecvStream`] plus
+	/// the bounds needed to move it into a boxed driver, with async helpers.
+	pub trait RecvStream: poll::RecvStream + MaybeSend + 'static {
+		/// Read some bytes into the slice, or `None` once the stream is finished.
+		fn read(&mut self, dst: &mut [u8]) -> impl Future<Output = Result<Option<usize>, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_read(cx, dst))
+		}
+
+		/// Read some bytes into the buffer, advancing it, or `None` once finished.
+		fn read_buf<B: BufMut + MaybeSend>(
+			&mut self,
+			buf: &mut B,
+		) -> impl Future<Output = Result<Option<usize>, Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_read_buf(cx, buf))
+		}
+
+		/// Read the next chunk of data, up to `max` bytes, or `None` once finished.
+		fn read_chunk(&mut self, max: usize) -> impl Future<Output = Result<Option<Bytes>, Self::Error>> + MaybeSend {
+			std::future::poll_fn(move |cx| self.poll_read_chunk(cx, max))
+		}
+
+		/// Wait until the stream is closed by either side.
+		fn closed(&mut self) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+			std::future::poll_fn(|cx| self.poll_closed(cx))
+		}
+	}
+
+	impl<S> RecvStream for S where S: poll::RecvStream + MaybeSend + 'static {}
+}

--- a/rs/moq-net/src/util.rs
+++ b/rs/moq-net/src/util.rs
@@ -124,15 +124,14 @@ impl TaskSet {
 		}
 	}
 
-	/// Poll every child while awaiting `future`, returning its output.
+	/// Poll every child while polling `f`, returning its output.
 	///
-	/// `future` is polled in place rather than cancelled and rebuilt each time a
-	/// child finishes, so an accept loop can serve its children without assuming the
-	/// transport's `accept_*` is cancel-safe (`web_transport_trait` promises nothing).
-	pub async fn drive<F: Future>(&mut self, future: F) -> F::Output {
-		let mut future = std::pin::pin!(future);
+	/// `f` is a poll function rather than a future, so an accept loop polls the
+	/// transport directly and there is no accept future to cancel or rebuild when
+	/// a child finishes.
+	pub async fn drive<T>(&mut self, mut f: impl FnMut(&kio::Waiter) -> Poll<T> + Unpin) -> T {
 		kio::wait(|waiter| {
-			if let Poll::Ready(output) = waiter.poll_future(future.as_mut()) {
+			if let Poll::Ready(output) = f(waiter) {
 				return Poll::Ready(output);
 			}
 			// The children never end the drive; a `Ready` here just means they're
@@ -192,17 +191,17 @@ mod tests {
 			child_completed.fetch_add(1, Ordering::SeqCst);
 		});
 
-		// The driven future only resolves after the child ran, proving drive()
+		// The driven poll only resolves after the child ran, proving drive()
 		// interleaves both without an executor.
 		let gate = completed.clone();
-		let output = futures::executor::block_on(set.drive(std::future::poll_fn(move |cx| {
+		let output = futures::executor::block_on(set.drive(move |waiter| {
 			if gate.load(Ordering::SeqCst) == 1 {
 				std::task::Poll::Ready(42)
 			} else {
-				cx.waker().wake_by_ref();
+				waiter.waker().wake_by_ref();
 				std::task::Poll::Pending
 			}
-		})));
+		}));
 
 		assert_eq!(output, 42);
 	}

--- a/rs/moq-net/tests/goaway.rs
+++ b/rs/moq-net/tests/goaway.rs
@@ -236,8 +236,9 @@ async fn duplicate_goaway_keeps_first_payload_moq_lite_04() {
 	/// Varints under 64 encode as a single byte, so the frame is hand-rolled.
 	/// Returns the recv half so the caller can wait for the peer to fully
 	/// process (and drop) the stream.
-	async fn send_goaway_raw<S: web_transport_trait::Session>(session: &S, uri: &str) -> S::RecvStream {
-		use web_transport_trait::SendStream as _;
+	async fn send_goaway_raw<S: moq_net::transport::poll::Session>(session: &mut S, uri: &str) -> S::RecvStream {
+		use moq_net::transport::poll::SendStream as _;
+		use moq_net::web_transport_trait::poll::SendStream as _;
 		assert!(uri.len() < 63, "helper only encodes single-byte varints");
 		// Message body = [uri length varint][uri bytes]; the size prefix covers it.
 		let mut frame = vec![0x05u8, uri.len() as u8 + 1, uri.len() as u8];
@@ -252,7 +253,7 @@ async fn duplicate_goaway_keeps_first_payload_moq_lite_04() {
 
 	/// Block until the peer closes its half of the stream, i.e. it finished
 	/// processing the control message and dropped the stream.
-	async fn wait_processed<R: web_transport_trait::RecvStream>(mut recv: R) {
+	async fn wait_processed<R: moq_net::transport::poll::RecvStream>(mut recv: R) {
 		let mut buf = [0u8; 16];
 		while let Ok(Some(_)) = recv.read(&mut buf).await {}
 	}
@@ -274,7 +275,8 @@ async fn duplicate_goaway_keeps_first_payload_moq_lite_04() {
 
 		// First GOAWAY: observed with its URI. Waiting for the peer to close the
 		// stream guarantees the control message was fully processed.
-		let recv_a = send_goaway_raw(&server_raw, "a").await;
+		let mut server_raw = server_raw;
+		let recv_a = send_goaway_raw(&mut server_raw, "a").await;
 		wait_processed(recv_a).await;
 		let goaway = client_session
 			.draining()
@@ -286,7 +288,7 @@ async fn duplicate_goaway_keeps_first_payload_moq_lite_04() {
 
 		// Second GOAWAY: once the client has fully processed the stream, the
 		// observed payload must still carry the FIRST URI.
-		let recv_b = send_goaway_raw(&server_raw, "bb").await;
+		let recv_b = send_goaway_raw(&mut server_raw, "bb").await;
 		wait_processed(recv_b).await;
 
 		let goaway = client_session

--- a/rs/moq-net/tests/support/mock.rs
+++ b/rs/moq-net/tests/support/mock.rs
@@ -1,17 +1,22 @@
 //! In-memory mock WebTransport session for deterministic testing.
 //!
 //! Two `MockSession` instances form a bidirectional pair: streams opened on one
-//! side appear as accepted streams on the other. Backed by tokio channels so
-//! delivery is ordered per-stream and deterministic (no real network jitter).
+//! side appear as accepted streams on the other. Backed by kio queues so
+//! delivery is ordered per-stream and deterministic (no real network jitter),
+//! and so the mock implements the poll interface directly, which is what
+//! moq-net requires.
 //!
 //! The mock guarantees that data written and FIN'd on a stream before `close()`
 //! is readable by the peer, eliminating the Quinn CONNECTION_CLOSE race that
 //! plagues real-transport tests.
 
-use std::sync::{Arc, Mutex};
+use std::{
+	sync::{Arc, Mutex},
+	task::{Context, Poll},
+};
 
 use bytes::Bytes;
-use tokio::sync::mpsc;
+use web_transport_trait::poll;
 
 // ── Error ───────────────────────────────────────────────────────────
 
@@ -68,76 +73,112 @@ enum StreamChunk {
 /// Shared closed-signal state between a paired SendStream and RecvStream.
 ///
 /// Models QUIC STOP_SENDING: the recv side (or its Drop) flips the flag and
-/// notifies; the send side's `closed()` polls this without consuming state.
+/// wakes; the send side's `poll_closed` reads this without consuming state.
+#[derive(Default)]
 struct ClosedSignal {
 	/// Set once the peer signals stop or drops.
 	result: Mutex<Option<Result<(), MockError>>>,
-	/// Wakes pending `closed()` futures.
-	notify: tokio::sync::Notify,
+	/// Wakes pending `poll_closed` watches.
+	waiters: kio::Fan,
 }
 
-/// A mock send stream backed by an mpsc channel to the peer's reader.
+impl ClosedSignal {
+	fn set(&self, result: Result<(), MockError>) {
+		let mut slot = self.result.lock().unwrap();
+		if slot.is_none() {
+			*slot = Some(result);
+			self.waiters.wake();
+		}
+	}
+}
+
+/// A mock send stream backed by a queue to the peer's reader.
 pub struct MockSendStream {
-	tx: Option<mpsc::UnboundedSender<StreamChunk>>,
+	tx: Option<kio::Queue<StreamChunk>>,
 	closed: Arc<ClosedSignal>,
+	park: kio::Park,
 }
 
-impl web_transport_trait::SendStream for MockSendStream {
+impl poll::SendStream for MockSendStream {
 	type Error = MockError;
 
-	async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-		let tx = self.tx.as_ref().ok_or_else(MockError::closed)?;
-		tx.send(StreamChunk::Data(Bytes::copy_from_slice(buf)))
-			.map_err(|_| MockError::closed())?;
-		Ok(buf.len())
+	fn poll_write(&mut self, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+		let Some(tx) = self.tx.as_ref() else {
+			return Poll::Ready(Err(MockError::closed()));
+		};
+		match tx.try_push(StreamChunk::Data(Bytes::copy_from_slice(buf))) {
+			Ok(()) => Poll::Ready(Ok(buf.len())),
+			Err(_) => Poll::Ready(Err(MockError::closed())),
+		}
 	}
 
 	fn set_priority(&mut self, _order: u8) {}
 
 	fn finish(&mut self) -> Result<(), Self::Error> {
 		if let Some(tx) = self.tx.take() {
-			let _ = tx.send(StreamChunk::Fin);
+			let _ = tx.try_push(StreamChunk::Fin);
 		}
 		Ok(())
 	}
 
 	fn reset(&mut self, code: u32) {
 		if let Some(tx) = self.tx.take() {
-			let _ = tx.send(StreamChunk::Reset(code));
+			let _ = tx.try_push(StreamChunk::Reset(code));
 		}
 	}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
-		loop {
-			// Check if already signaled (idempotent: never consumes state).
-			let notified = self.closed.notify.notified();
-			if let Some(result) = self.closed.result.lock().unwrap().clone() {
-				return result;
-			}
-			notified.await;
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		// Register before checking so a signal racing this poll still wakes it.
+		self.closed.waiters.register(self.park.hold(cx));
+		match self.closed.result.lock().unwrap().clone() {
+			Some(result) => Poll::Ready(result),
+			None => Poll::Pending,
+		}
+	}
+}
+
+impl Drop for MockSendStream {
+	fn drop(&mut self) {
+		// Dropped without an explicit FIN: deliver an implicit one, matching a
+		// sender that went away cleanly.
+		if let Some(tx) = self.tx.take() {
+			let _ = tx.try_push(StreamChunk::Fin);
 		}
 	}
 }
 
 // ── RecvStream ──────────────────────────────────────────────────────
 
-/// A mock receive stream backed by an mpsc channel from the peer's writer.
+/// A mock receive stream backed by a queue from the peer's writer.
 pub struct MockRecvStream {
-	rx: mpsc::UnboundedReceiver<StreamChunk>,
+	rx: kio::Queue<StreamChunk>,
 	/// Buffered bytes from a chunk that was partially consumed.
 	buf: Bytes,
 	/// Whether we hit FIN or reset.
 	done: bool,
-	/// Shared signal to notify the peer's SendStream::closed().
+	/// Shared signal to notify the peer's send-side `poll_closed`.
 	closed: Arc<ClosedSignal>,
+	park: kio::Park,
 }
 
-impl web_transport_trait::RecvStream for MockRecvStream {
+impl MockRecvStream {
+	/// Pop the next chunk, mapping queue closure to an implicit FIN.
+	fn poll_chunk(&mut self, cx: &mut Context<'_>) -> Poll<Option<StreamChunk>> {
+		let waiter = self.park.hold(cx);
+		match self.rx.poll_pop(waiter) {
+			Poll::Ready(Ok(chunk)) => Poll::Ready(Some(chunk)),
+			Poll::Ready(Err(_)) => Poll::Ready(None),
+			Poll::Pending => Poll::Pending,
+		}
+	}
+}
+
+impl poll::RecvStream for MockRecvStream {
 	type Error = MockError;
 
-	async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+	fn poll_read(&mut self, cx: &mut Context<'_>, dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
 		if self.done {
-			return Ok(None);
+			return Poll::Ready(Ok(None));
 		}
 
 		// Drain buffered bytes first.
@@ -145,59 +186,49 @@ impl web_transport_trait::RecvStream for MockRecvStream {
 			let n = dst.len().min(self.buf.len());
 			dst[..n].copy_from_slice(&self.buf[..n]);
 			self.buf = self.buf.slice(n..);
-			return Ok(Some(n));
+			return Poll::Ready(Ok(Some(n)));
 		}
 
-		// Wait for next chunk from peer.
-		match self.rx.recv().await {
+		match std::task::ready!(self.poll_chunk(cx)) {
 			Some(StreamChunk::Data(data)) => {
 				let n = dst.len().min(data.len());
 				dst[..n].copy_from_slice(&data[..n]);
 				if n < data.len() {
 					self.buf = data.slice(n..);
 				}
-				Ok(Some(n))
+				Poll::Ready(Ok(Some(n)))
 			}
-			Some(StreamChunk::Fin) => {
+			Some(StreamChunk::Fin) | None => {
 				self.done = true;
-				Ok(None)
+				Poll::Ready(Ok(None))
 			}
 			Some(StreamChunk::Reset(code)) => {
 				self.done = true;
-				Err(MockError::stream_reset(code))
-			}
-			None => {
-				// Sender dropped without explicit FIN: treat as implicit FIN.
-				self.done = true;
-				Ok(None)
+				Poll::Ready(Err(MockError::stream_reset(code)))
 			}
 		}
 	}
 
 	fn stop(&mut self, _code: u32) {
-		let mut result = self.closed.result.lock().unwrap();
-		if result.is_none() {
-			*result = Some(Ok(()));
-			self.closed.notify.notify_waiters();
-		}
+		self.closed.set(Ok(()));
 		self.done = true;
 	}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		if self.done {
-			return Ok(());
+			return Poll::Ready(Ok(()));
 		}
 		// Drain until done.
 		loop {
-			match self.rx.recv().await {
-				Some(StreamChunk::Data(_)) => continue,
+			match std::task::ready!(self.poll_chunk(cx)) {
+				Some(StreamChunk::Data(_)) => {}
 				Some(StreamChunk::Fin) | None => {
 					self.done = true;
-					return Ok(());
+					return Poll::Ready(Ok(()));
 				}
 				Some(StreamChunk::Reset(code)) => {
 					self.done = true;
-					return Err(MockError::stream_reset(code));
+					return Poll::Ready(Err(MockError::stream_reset(code)));
 				}
 			}
 		}
@@ -206,12 +237,10 @@ impl web_transport_trait::RecvStream for MockRecvStream {
 
 impl Drop for MockRecvStream {
 	fn drop(&mut self) {
-		// Signal the paired SendStream that the receiver is gone (implicit STOP).
-		let mut result = self.closed.result.lock().unwrap();
-		if result.is_none() {
-			*result = Some(Ok(()));
-			self.closed.notify.notify_waiters();
-		}
+		// Signal the paired SendStream that the receiver is gone (implicit STOP),
+		// and fail its future writes.
+		self.closed.set(Ok(()));
+		self.rx.close();
 	}
 }
 
@@ -219,22 +248,20 @@ impl Drop for MockRecvStream {
 
 /// Create a linked (send, recv) stream pair.
 fn new_stream_pair() -> (MockSendStream, MockRecvStream) {
-	let (data_tx, data_rx) = mpsc::unbounded_channel();
-
-	let closed = Arc::new(ClosedSignal {
-		result: Mutex::new(None),
-		notify: tokio::sync::Notify::new(),
-	});
+	let queue = kio::Queue::new();
+	let closed = Arc::new(ClosedSignal::default());
 
 	let send = MockSendStream {
-		tx: Some(data_tx),
+		tx: Some(queue.clone()),
 		closed: closed.clone(),
+		park: kio::Park::default(),
 	};
 	let recv = MockRecvStream {
-		rx: data_rx,
+		rx: queue,
 		buf: Bytes::new(),
 		done: false,
 		closed,
+		park: kio::Park::default(),
 	};
 	(send, recv)
 }
@@ -245,23 +272,24 @@ fn new_stream_pair() -> (MockSendStream, MockRecvStream) {
 ///
 /// A real QUIC CONNECTION_CLOSE tears down the entire connection for both peers.
 /// This struct models that: a close on either side is visible to both.
+#[derive(Default)]
 struct ConnectionState {
 	/// Set once by whichever side closes first.
 	close_state: Mutex<Option<(u32, String)>>,
 	/// Wakes both sides when close_state is populated.
-	close_notify: tokio::sync::Notify,
+	waiters: kio::Fan,
 }
 
-/// Per-side state: stream channels and a reference to the shared connection.
+/// Per-side state: stream queues and a reference to the shared connection.
 struct SessionSide {
-	/// Bidi streams opened by the peer, available via accept_bi.
-	bidi_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<(MockSendStream, MockRecvStream)>>,
-	/// Uni streams opened by the peer, available via accept_uni.
-	uni_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<MockRecvStream>>,
-	/// Channel to send bidi streams TO the peer (peer's accept_bi picks them up).
-	peer_bidi_tx: mpsc::UnboundedSender<(MockSendStream, MockRecvStream)>,
-	/// Channel to send uni streams TO the peer (peer's accept_uni picks them up).
-	peer_uni_tx: mpsc::UnboundedSender<MockRecvStream>,
+	/// Bidi streams opened by the peer, popped by accept_bi.
+	bidi: kio::Queue<(MockSendStream, MockRecvStream)>,
+	/// Uni streams opened by the peer, popped by accept_uni.
+	uni: kio::Queue<MockRecvStream>,
+	/// Queue to deliver bidi streams TO the peer (its accept_bi pops them).
+	peer_bidi: kio::Queue<(MockSendStream, MockRecvStream)>,
+	/// Queue to deliver uni streams TO the peer (its accept_uni pops them).
+	peer_uni: kio::Queue<MockRecvStream>,
 	/// The ALPN protocol string for this side.
 	protocol: Option<&'static str>,
 	/// Connection-level close state shared with the peer.
@@ -270,73 +298,92 @@ struct SessionSide {
 
 /// An in-memory mock WebTransport session.
 ///
-/// Implements [`web_transport_trait::Session`]. Created in pairs via
+/// Implements [`web_transport_trait::poll::Session`]. Created in pairs via
 /// [`create_mock_session_pair`]. Streams opened on one side are delivered to
-/// the peer's accept methods deterministically via unbounded channels.
+/// the peer's accept methods deterministically via unbounded queues.
 #[derive(Clone)]
 pub struct MockSession {
 	side: Arc<SessionSide>,
+	// One park per pending-operation class: a park holds a single waiter, and a
+	// clone polling two classes at once must not clobber its own registration.
+	accept_uni: kio::Park,
+	accept_bi: kio::Park,
+	closed: kio::Park,
 }
 
-impl web_transport_trait::Session for MockSession {
+impl poll::Session for MockSession {
 	type SendStream = MockSendStream;
 	type RecvStream = MockRecvStream;
 	type Error = MockError;
 
-	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-		let mut rx = self.side.uni_rx.lock().await;
-		match rx.recv().await {
-			Some(stream) => Ok(stream),
-			None => {
-				// Channel closed: session is shutting down. Wait for the close signal.
-				self.await_close().await;
-				Err(self.close_error())
-			}
+	fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>> {
+		// Register on the close signal too, so a close with no incoming streams
+		// still fails the accept instead of parking it forever.
+		let waiter = self.accept_uni.hold(cx);
+		self.side.conn.waiters.register(waiter);
+		if let Poll::Ready(res) = self.side.uni.poll_pop(waiter) {
+			return Poll::Ready(res.map_err(|_| self.close_error()));
+		}
+		// Bind the flag: a guard living through the match would deadlock against
+		// close_error taking the same lock.
+		let closed = self.side.conn.close_state.lock().unwrap().is_some();
+		match closed {
+			true => Poll::Ready(Err(self.close_error())),
+			false => Poll::Pending,
 		}
 	}
 
-	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-		let mut rx = self.side.bidi_rx.lock().await;
-		match rx.recv().await {
-			Some(pair) => Ok(pair),
-			None => {
-				self.await_close().await;
-				Err(self.close_error())
-			}
+	fn poll_accept_bi(
+		&mut self,
+		cx: &mut Context<'_>,
+	) -> Poll<Result<(Self::SendStream, Self::RecvStream), Self::Error>> {
+		let waiter = self.accept_bi.hold(cx);
+		self.side.conn.waiters.register(waiter);
+		if let Poll::Ready(res) = self.side.bidi.poll_pop(waiter) {
+			return Poll::Ready(res.map_err(|_| self.close_error()));
+		}
+		// Bind the flag: a guard living through the match would deadlock against
+		// close_error taking the same lock.
+		let closed = self.side.conn.close_state.lock().unwrap().is_some();
+		match closed {
+			true => Poll::Ready(Err(self.close_error())),
+			false => Poll::Pending,
 		}
 	}
 
-	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+	fn poll_open_bi(
+		&mut self,
+		_cx: &mut Context<'_>,
+	) -> Poll<Result<(Self::SendStream, Self::RecvStream), Self::Error>> {
 		// Create two stream pairs: one for each direction.
 		let (our_send, peer_recv) = new_stream_pair();
 		let (peer_send, our_recv) = new_stream_pair();
 
 		// Deliver (peer_send, peer_recv) to the peer's accept_bi.
-		self.side
-			.peer_bidi_tx
-			.send((peer_send, peer_recv))
-			.map_err(|_| self.close_error())?;
-
-		Ok((our_send, our_recv))
+		match self.side.peer_bidi.try_push((peer_send, peer_recv)) {
+			Ok(()) => Poll::Ready(Ok((our_send, our_recv))),
+			Err(_) => Poll::Ready(Err(self.close_error())),
+		}
 	}
 
-	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
+	fn poll_open_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::SendStream, Self::Error>> {
 		let (our_send, peer_recv) = new_stream_pair();
 
 		// Deliver peer_recv to the peer's accept_uni.
-		self.side.peer_uni_tx.send(peer_recv).map_err(|_| self.close_error())?;
-
-		Ok(our_send)
+		match self.side.peer_uni.try_push(peer_recv) {
+			Ok(()) => Poll::Ready(Ok(our_send)),
+			Err(_) => Poll::Ready(Err(self.close_error())),
+		}
 	}
 
-	fn send_datagram(&self, _payload: Bytes) -> Result<(), Self::Error> {
+	fn poll_send_datagram(&mut self, _cx: &mut Context<'_>, _payload: &[u8]) -> Poll<Result<(), Self::Error>> {
 		// Datagrams are best-effort; silently succeed in mock.
-		Ok(())
+		Poll::Ready(Ok(()))
 	}
 
-	async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
+	fn poll_recv_datagram(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>> {
 		// No datagram support in mock; pend forever.
-		std::future::pending().await
+		Poll::Pending
 	}
 
 	fn max_datagram_size(&self) -> usize {
@@ -347,47 +394,38 @@ impl web_transport_trait::Session for MockSession {
 		self.side.protocol
 	}
 
-	fn close(&self, code: u32, reason: &str) {
+	fn close(&mut self, code: u32, reason: &str) {
 		// Set-once: a real QUIC CONNECTION_CLOSE keeps the first reason, and the
 		// GOAWAY-timeout tests rely on the server's force-close reason surviving
 		// a later local teardown close from the peer's own driver.
 		let mut state = self.side.conn.close_state.lock().unwrap();
 		if state.is_none() {
 			*state = Some((code, reason.to_string()));
-			self.side.conn.close_notify.notify_waiters();
+			// Wake outside the lock: a woken task may poll straight back into it.
+			drop(state);
+			self.side.conn.waiters.wake();
 		}
 	}
 
-	async fn closed(&self) -> Self::Error {
-		loop {
-			let notified = self.side.conn.close_notify.notified();
-			if let Some((code, reason)) = self.side.conn.close_state.lock().unwrap().clone() {
-				return MockError {
-					code: Some(code),
-					reason,
-				};
-			}
-			notified.await;
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Self::Error> {
+		// Register before checking so a close racing this poll still wakes it.
+		self.side.conn.waiters.register(self.closed.hold(cx));
+		let state = self.side.conn.close_state.lock().unwrap().clone();
+		match state {
+			Some((code, reason)) => Poll::Ready(MockError {
+				code: Some(code),
+				reason,
+			}),
+			None => Poll::Pending,
 		}
+	}
+
+	fn stats(&self) -> impl web_transport_trait::Stats {
+		web_transport_trait::StatsUnavailable
 	}
 }
 
 impl MockSession {
-	/// Wait until the connection is closed.
-	///
-	/// `notify_waiters` stores no permit, so registering after the close already
-	/// fired would park forever. Register before checking the state, the same
-	/// dance as `closed()`.
-	async fn await_close(&self) {
-		loop {
-			let notified = self.side.conn.close_notify.notified();
-			if self.side.conn.close_state.lock().unwrap().is_some() {
-				return;
-			}
-			notified.await;
-		}
-	}
-
 	fn close_error(&self) -> MockError {
 		self.side
 			.conn
@@ -408,42 +446,42 @@ impl MockSession {
 /// Create a pair of connected mock sessions.
 ///
 /// Streams opened on `client` appear in `server.accept_*()` and vice versa.
-/// Both sides report the given `protocol` from [`web_transport_trait::Session::protocol`],
-/// matching ALPN negotiation behavior.
+/// Both sides report the given `protocol` from
+/// [`web_transport_trait::poll::Session::protocol`], matching ALPN negotiation
+/// behavior.
 pub fn create_mock_session_pair(protocol: Option<&'static str>) -> (MockSession, MockSession) {
-	let conn = Arc::new(ConnectionState {
-		close_state: Mutex::new(None),
-		close_notify: tokio::sync::Notify::new(),
-	});
+	let conn = Arc::new(ConnectionState::default());
 
-	// Channels for client -> server stream delivery.
-	let (c2s_bidi_tx, c2s_bidi_rx) = mpsc::unbounded_channel();
-	let (c2s_uni_tx, c2s_uni_rx) = mpsc::unbounded_channel();
-
-	// Channels for server -> client stream delivery.
-	let (s2c_bidi_tx, s2c_bidi_rx) = mpsc::unbounded_channel();
-	let (s2c_uni_tx, s2c_uni_rx) = mpsc::unbounded_channel();
+	// Queues for client -> server and server -> client stream delivery.
+	let c2s_bidi = kio::Queue::new();
+	let c2s_uni = kio::Queue::new();
+	let s2c_bidi = kio::Queue::new();
+	let s2c_uni = kio::Queue::new();
 
 	let client_side = Arc::new(SessionSide {
-		bidi_rx: tokio::sync::Mutex::new(s2c_bidi_rx),
-		uni_rx: tokio::sync::Mutex::new(s2c_uni_rx),
-		peer_bidi_tx: c2s_bidi_tx,
-		peer_uni_tx: c2s_uni_tx,
+		bidi: s2c_bidi.clone(),
+		uni: s2c_uni.clone(),
+		peer_bidi: c2s_bidi.clone(),
+		peer_uni: c2s_uni.clone(),
 		protocol,
 		conn: conn.clone(),
 	});
 
 	let server_side = Arc::new(SessionSide {
-		bidi_rx: tokio::sync::Mutex::new(c2s_bidi_rx),
-		uni_rx: tokio::sync::Mutex::new(c2s_uni_rx),
-		peer_bidi_tx: s2c_bidi_tx,
-		peer_uni_tx: s2c_uni_tx,
+		bidi: c2s_bidi,
+		uni: c2s_uni,
+		peer_bidi: s2c_bidi,
+		peer_uni: s2c_uni,
 		protocol,
 		conn,
 	});
 
-	let client = MockSession { side: client_side };
-	let server = MockSession { side: server_side };
+	let new = |side| MockSession {
+		side,
+		accept_uni: kio::Park::default(),
+		accept_bi: kio::Park::default(),
+		closed: kio::Park::default(),
+	};
 
-	(client, server)
+	(new(client_side), new(server_side))
 }

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -118,7 +118,7 @@ where
 		server = server.with_subscriber(publish);
 	}
 	// Hold the session so it doesn't close early; the driver serves it in place.
-	let (session, mut driver) = server.accept(ws).await?;
+	let (session, mut driver) = server.accept(moq_native::transport::Async::new(ws)).await?;
 
 	tokio::select! {
 		res = &mut driver => res.map_err(Into::into),

--- a/rs/moq-wasm/Cargo.toml
+++ b/rs/moq-wasm/Cargo.toml
@@ -27,6 +27,7 @@ crate-type = ["cdylib", "rlib"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bytes = "1"
 console_error_panic_hook = "0.1"
+futures = "0.3"
 getrandom = { version = "0.4", features = ["wasm_js"] } # wasm_js backend for rand-via-moq-net; cfg flag in .cargo/config.toml
 js-sys = "0.3"
 moq-net = { workspace = true }

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -23,7 +23,7 @@ use std::rc::Rc;
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
-mod transport;
+pub mod transport;
 
 /// Map any displayable error into a JS exception.
 fn js_err(e: impl std::fmt::Display) -> JsValue {

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -52,7 +52,7 @@ impl Session {
 	/// Connect to a relay over the browser's WebTransport, using the system roots.
 	pub async fn connect(url: String) -> Result<Session, JsValue> {
 		let url = url::Url::parse(&url).map_err(js_err)?;
-		let transport = transport::connect(url).await.map_err(js_err)?;
+		let transport = transport::connect(url, Default::default()).await.map_err(js_err)?;
 		Self::handshake(transport).await
 	}
 
@@ -61,7 +61,11 @@ impl Session {
 	pub async fn connect_with_hashes(url: String, hashes: Vec<Uint8Array>) -> Result<Session, JsValue> {
 		let url = url::Url::parse(&url).map_err(js_err)?;
 		let hashes = hashes.iter().map(|h| h.to_vec()).collect();
-		let transport = transport::connect_with_hashes(url, hashes).await.map_err(js_err)?;
+		let options = transport::Options {
+			server_certificate_hashes: hashes,
+			..Default::default()
+		};
+		let transport = transport::connect(url, options).await.map_err(js_err)?;
 		Self::handshake(transport).await
 	}
 

--- a/rs/moq-wasm/src/transport.rs
+++ b/rs/moq-wasm/src/transport.rs
@@ -206,11 +206,12 @@ pub struct SendStream {
 	/// Whether `finish` or `reset` has been observed, so no further writes can
 	/// come and the closed() watch may safely take ownership of the stream.
 	terminal: bool,
-	/// A write driven to completion by `poll_closed` rather than `poll_write`. The
-	/// caller was told `Pending` and is contractually retrying the same bytes, so the
-	/// next `poll_write` reports this write instead of putting the bytes on the wire
-	/// a second time.
-	completed: Option<Bytes>,
+	/// Bytes already transmitted but not yet reported to the caller: a write the
+	/// stored future finished (possibly inside `poll_closed`) while the caller
+	/// held a `Pending`. Later `poll_write` calls reconcile against the buffer
+	/// actually presented (the poll contract allows a shorter retry), reporting
+	/// and consuming a prefix per call, never writing these bytes a second time.
+	completed: Bytes,
 }
 
 enum SendState {
@@ -233,7 +234,7 @@ impl SendStream {
 			finish: false,
 			reset: None,
 			terminal: false,
-			completed: None,
+			completed: Bytes::new(),
 		}
 	}
 
@@ -258,18 +259,21 @@ impl wtt::poll::SendStream for SendStream {
 	type Error = Error;
 
 	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
-		// A previous write completed inside poll_closed; report it instead of
-		// writing the same bytes a second time. The retry contract says the
-		// caller re-supplies the bytes it was told Pending for.
-		if let Some(chunk) = self.completed.take() {
-			debug_assert_eq!(
-				buf.get(..chunk.len()),
-				Some(&chunk[..]),
-				"poll_write must retry the same bytes it was told Pending for"
-			);
-			return Poll::Ready(Ok(chunk.len()));
-		}
 		loop {
+			// Transmitted-but-unreported bytes from a completed write are
+			// reconciled against the buffer presented NOW: the poll contract
+			// allows a retry with a shorter buffer, so report (and consume) at
+			// most its length and keep the rest for the next call.
+			if !self.completed.is_empty() && !buf.is_empty() {
+				let n = buf.len().min(self.completed.len());
+				let reported = self.completed.split_to(n);
+				debug_assert_eq!(
+					&buf[..n],
+					&reported[..],
+					"poll_write retries must present the bytes already accepted"
+				);
+				return Poll::Ready(Ok(n));
+			}
 			match self.state.take().expect("in-flight") {
 				SendState::Idle(mut stream) => {
 					if buf.is_empty() {
@@ -297,7 +301,9 @@ impl wtt::poll::SendStream for SendStream {
 						self.settle(&mut stream);
 						self.state = Some(SendState::Idle(stream));
 						res?;
-						return Poll::Ready(Ok(chunk.len()));
+						// Reported through the reconciliation at the top of the
+						// loop, which caps it at the presented buffer's length.
+						self.completed = chunk;
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -372,10 +378,10 @@ impl wtt::poll::SendStream for SendStream {
 						if let Err(err) = res {
 							return Poll::Ready(Err(err));
 						}
-						// The caller of poll_write was told Pending and will retry the
-						// same bytes; record the completion so the retry reports it
-						// instead of writing the bytes a second time.
-						self.completed = Some(chunk);
+						// The caller of poll_write was told Pending and will retry;
+						// poll_write's reconciliation reports these bytes instead of
+						// writing them a second time.
+						self.completed = chunk;
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {

--- a/rs/moq-wasm/src/transport.rs
+++ b/rs/moq-wasm/src/transport.rs
@@ -208,16 +208,19 @@ pub struct SendStream {
 	terminal: bool,
 	/// A write driven to completion by `poll_closed` rather than `poll_write`. The
 	/// caller was told `Pending` and is contractually retrying the same bytes, so the
-	/// next `poll_write` reports this length instead of writing them a second time.
-	completed: Option<usize>,
+	/// next `poll_write` reports this write instead of putting the bytes on the wire
+	/// a second time.
+	completed: Option<Bytes>,
 }
 
 enum SendState {
 	Idle(web_transport_wasm::SendStream),
-	/// A write in flight; `len` is what to report when it resolves.
+	/// A write in flight; `chunk` is the copied bytes, kept (refcounted, no
+	/// extra copy) so a completion absorbed by `poll_closed` can verify the
+	/// retrying caller supplied the same bytes.
 	Writing {
 		fut: LocalBoxFuture<'static, (web_transport_wasm::SendStream, Result<(), Error>)>,
-		len: usize,
+		chunk: Bytes,
 	},
 	Closing(LocalBoxFuture<'static, (web_transport_wasm::SendStream, Result<(), Error>)>),
 }
@@ -256,9 +259,15 @@ impl wtt::poll::SendStream for SendStream {
 
 	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
 		// A previous write completed inside poll_closed; report it instead of
-		// writing the same bytes a second time.
-		if let Some(len) = self.completed.take() {
-			return Poll::Ready(Ok(len));
+		// writing the same bytes a second time. The retry contract says the
+		// caller re-supplies the bytes it was told Pending for.
+		if let Some(chunk) = self.completed.take() {
+			debug_assert_eq!(
+				buf.get(..chunk.len()),
+				Some(&chunk[..]),
+				"poll_write must retry the same bytes it was told Pending for"
+			);
+			return Poll::Ready(Ok(chunk.len()));
 		}
 		loop {
 			match self.state.take().expect("in-flight") {
@@ -270,25 +279,25 @@ impl wtt::poll::SendStream for SendStream {
 					// The wasm writer writes the whole slice or errors, so the
 					// reported count is exact. The caller retries with the same
 					// bytes until this resolves.
-					let chunk = buf.to_vec();
-					let len = chunk.len();
+					let chunk = Bytes::copy_from_slice(buf);
+					let retained = chunk.clone();
 					let fut = async move {
 						let res = stream.write(&chunk).await.map_err(Error);
 						(stream, res)
 					}
 					.boxed_local();
-					self.state = Some(SendState::Writing { fut, len });
+					self.state = Some(SendState::Writing { fut, chunk: retained });
 				}
-				SendState::Writing { mut fut, len } => match fut.as_mut().poll(cx) {
+				SendState::Writing { mut fut, chunk } => match fut.as_mut().poll(cx) {
 					Poll::Pending => {
-						self.state = Some(SendState::Writing { fut, len });
+						self.state = Some(SendState::Writing { fut, chunk });
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
 						self.settle(&mut stream);
 						self.state = Some(SendState::Idle(stream));
 						res?;
-						return Poll::Ready(Ok(len));
+						return Poll::Ready(Ok(chunk.len()));
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -351,9 +360,9 @@ impl wtt::poll::SendStream for SendStream {
 					.boxed_local();
 					self.state = Some(SendState::Closing(fut));
 				}
-				SendState::Writing { mut fut, len } => match fut.as_mut().poll(cx) {
+				SendState::Writing { mut fut, chunk } => match fut.as_mut().poll(cx) {
 					Poll::Pending => {
-						self.state = Some(SendState::Writing { fut, len });
+						self.state = Some(SendState::Writing { fut, chunk });
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
@@ -366,7 +375,7 @@ impl wtt::poll::SendStream for SendStream {
 						// The caller of poll_write was told Pending and will retry the
 						// same bytes; record the completion so the retry reports it
 						// instead of writing the bytes a second time.
-						self.completed = Some(len);
+						self.completed = Some(chunk);
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {

--- a/rs/moq-wasm/src/transport.rs
+++ b/rs/moq-wasm/src/transport.rs
@@ -67,17 +67,25 @@ impl Clone for Session {
 	}
 }
 
-/// Open a browser WebTransport connection to `url`.
-pub async fn connect(url: Url) -> Result<Session, Error> {
-	let client = web_transport_wasm::ClientBuilder::new().with_system_roots();
-	let session = client.connect(url).await.map_err(Error)?;
-	Ok(Session::new(session))
+/// Options for a browser WebTransport connection.
+///
+/// Build via [`Default`] and set fields; new knobs are added here rather than
+/// as new `connect` parameters.
+#[derive(Default)]
+#[non_exhaustive]
+pub struct Options {
+	/// Trust only these sha-256 certificate hashes instead of the system roots
+	/// (serverless dev, matching the browser's `serverCertificateHashes`).
+	pub server_certificate_hashes: Vec<Vec<u8>>,
 }
 
-/// Connect, trusting only the given sha-256 certificate hashes (serverless dev,
-/// matching the browser's `serverCertificateHashes` option).
-pub async fn connect_with_hashes(url: Url, hashes: Vec<Vec<u8>>) -> Result<Session, Error> {
-	let client = web_transport_wasm::ClientBuilder::new().with_server_certificate_hashes(hashes);
+/// Open a browser WebTransport connection to `url`.
+pub async fn connect(url: Url, options: Options) -> Result<Session, Error> {
+	let client = web_transport_wasm::ClientBuilder::new();
+	let client = match options.server_certificate_hashes.is_empty() {
+		true => client.with_system_roots(),
+		false => client.with_server_certificate_hashes(options.server_certificate_hashes),
+	};
 	let session = client.connect(url).await.map_err(Error)?;
 	Ok(Session::new(session))
 }
@@ -212,18 +220,29 @@ pub struct SendStream {
 	/// actually presented (the poll contract allows a shorter retry), reporting
 	/// and consuming a prefix per call, never writing these bytes a second time.
 	completed: Bytes,
+	/// Cancels the in-flight write so a reset applies immediately instead of
+	/// waiting behind blocked I/O (whose partial progress a reset discards
+	/// anyway). Fired by `reset` and by `Drop`.
+	interrupt: Option<futures::channel::oneshot::Sender<()>>,
 }
 
 enum SendState {
 	Idle(web_transport_wasm::SendStream),
 	/// A write in flight; `chunk` is the copied bytes, kept (refcounted, no
 	/// extra copy) so a completion absorbed by `poll_closed` can verify the
-	/// retrying caller supplied the same bytes.
+	/// retrying caller supplied the same bytes. A `None` result means the write
+	/// was interrupted by a reset (see `SendStream::interrupt`).
 	Writing {
-		fut: LocalBoxFuture<'static, (web_transport_wasm::SendStream, Result<(), Error>)>,
+		#[allow(clippy::type_complexity)]
+		fut: LocalBoxFuture<'static, (web_transport_wasm::SendStream, Option<Result<(), Error>>)>,
 		chunk: Bytes,
 	},
-	Closing(LocalBoxFuture<'static, (web_transport_wasm::SendStream, Result<(), Error>)>),
+	/// The closed() acknowledgement watch; a `None` result means it was
+	/// interrupted by a late reset (see `SendStream::interrupt`).
+	Closing(
+		#[allow(clippy::type_complexity)]
+		LocalBoxFuture<'static, (web_transport_wasm::SendStream, Option<Result<(), Error>>)>,
+	),
 }
 
 impl SendStream {
@@ -235,6 +254,7 @@ impl SendStream {
 			reset: None,
 			terminal: false,
 			completed: Bytes::new(),
+			interrupt: None,
 		}
 	}
 
@@ -267,10 +287,14 @@ impl wtt::poll::SendStream for SendStream {
 			if !self.completed.is_empty() && !buf.is_empty() {
 				let n = buf.len().min(self.completed.len());
 				let reported = self.completed.split_to(n);
-				debug_assert_eq!(
+				// A hard assert, not a debug one: these bytes are already on the
+				// wire and the bridge cannot un-send them, so a caller continuing
+				// with different data would silently corrupt the stream. Failing
+				// loudly is the only honest option left.
+				assert_eq!(
 					&buf[..n],
 					&reported[..],
-					"poll_write retries must present the bytes already accepted"
+					"poll_write must continue with the bytes the write bridge already transmitted"
 				);
 				return Poll::Ready(Ok(n));
 			}
@@ -285,8 +309,25 @@ impl wtt::poll::SendStream for SendStream {
 					// bytes until this resolves.
 					let chunk = Bytes::copy_from_slice(buf);
 					let retained = chunk.clone();
+					let (tx, rx) = futures::channel::oneshot::channel::<()>();
+					self.interrupt = Some(tx);
 					let fut = async move {
-						let res = stream.write(&chunk).await.map_err(Error);
+						let res = {
+							let mut op = std::pin::pin!(async { stream.write(&chunk).await.map_err(Error) }.fuse());
+							let mut rx = rx.fuse();
+							loop {
+								futures::select_biased! {
+									res = op => break Some(res),
+									cancel = rx => match cancel {
+										Ok(()) => break None,
+										// A dropped (unfired) sender must not interrupt;
+										// only an explicit reset does. The fused arm goes
+										// quiet and the write keeps driving.
+										Err(_) => continue,
+									},
+								}
+							}
+						};
 						(stream, res)
 					}
 					.boxed_local();
@@ -298,12 +339,18 @@ impl wtt::poll::SendStream for SendStream {
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
+						self.interrupt = None;
 						self.settle(&mut stream);
 						self.state = Some(SendState::Idle(stream));
-						res?;
-						// Reported through the reconciliation at the top of the
-						// loop, which caps it at the presented buffer's length.
-						self.completed = chunk;
+						// An interrupted write was abandoned for a reset, which
+						// settle just applied; the next iteration's write reports
+						// the stream state.
+						if let Some(res) = res {
+							res?;
+							// Reported through the reconciliation at the top of the
+							// loop, which caps it at the presented buffer's length.
+							self.completed = chunk;
+						}
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -312,6 +359,7 @@ impl wtt::poll::SendStream for SendStream {
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, _res)) => {
+						self.interrupt = None;
 						self.settle(&mut stream);
 						self.state = Some(SendState::Idle(stream));
 					}
@@ -342,7 +390,14 @@ impl wtt::poll::SendStream for SendStream {
 		self.terminal = true;
 		match self.state.as_mut() {
 			Some(SendState::Idle(stream)) => stream.reset(&code.to_string()),
-			_ => self.reset = Some(code),
+			_ => {
+				self.reset = Some(code);
+				// A reset discards the in-flight write's progress anyway, so
+				// cancel it rather than letting blocked I/O delay the code.
+				if let Some(tx) = self.interrupt.take() {
+					let _ = tx.send(());
+				}
+			}
 		}
 	}
 
@@ -359,8 +414,26 @@ impl wtt::poll::SendStream for SendStream {
 						self.state = Some(SendState::Idle(stream));
 						return Poll::Pending;
 					}
+					// Interruptible like a write: a late reset (the group machines
+					// cancel a finished stream this way) must not wait for a FIN
+					// acknowledgement that may never come.
+					let (tx, rx) = futures::channel::oneshot::channel::<()>();
+					self.interrupt = Some(tx);
 					let fut = async move {
-						let res = stream.closed().await.map(|_| ()).map_err(Error);
+						let res = {
+							let mut op =
+								std::pin::pin!(async { stream.closed().await.map(|_| ()).map_err(Error) }.fuse());
+							let mut rx = rx.fuse();
+							loop {
+								futures::select_biased! {
+									res = op => break Some(res),
+									cancel = rx => match cancel {
+										Ok(()) => break None,
+										Err(_) => continue,
+									},
+								}
+							}
+						};
 						(stream, res)
 					}
 					.boxed_local();
@@ -372,16 +445,20 @@ impl wtt::poll::SendStream for SendStream {
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
+						self.interrupt = None;
 						self.settle(&mut stream);
 						self.state = Some(SendState::Idle(stream));
-						// A failed write is a closed stream; report it here.
-						if let Err(err) = res {
-							return Poll::Ready(Err(err));
+						match res {
+							// A failed write is a closed stream; report it here.
+							Some(Err(err)) => return Poll::Ready(Err(err)),
+							// The caller of poll_write was told Pending and will
+							// retry; poll_write's reconciliation reports these bytes
+							// instead of writing them a second time.
+							Some(Ok(())) => self.completed = chunk,
+							// Interrupted for a reset, applied by settle above; the
+							// next iteration starts the real closed watch.
+							None => {}
 						}
-						// The caller of poll_write was told Pending and will retry;
-						// poll_write's reconciliation reports these bytes instead of
-						// writing them a second time.
-						self.completed = chunk;
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -390,12 +467,60 @@ impl wtt::poll::SendStream for SendStream {
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
+						self.interrupt = None;
 						self.settle(&mut stream);
 						self.state = Some(SendState::Idle(stream));
-						return Poll::Ready(res);
+						// An interrupted watch was abandoned for a late reset,
+						// which settle just applied; the next iteration watches
+						// the now-reset stream, which resolves promptly.
+						if let Some(res) = res {
+							return Poll::Ready(res);
+						}
 					}
 				},
 			}
+		}
+	}
+}
+
+impl Drop for SendStream {
+	fn drop(&mut self) {
+		match self.state.take() {
+			// Apply a deferred reset if the stream is idle.
+			Some(SendState::Idle(mut stream)) => {
+				if let Some(code) = self.reset.take() {
+					stream.reset(&code.to_string());
+				}
+			}
+			// The stream lives inside the in-flight future; dropping it here
+			// would lose the deferred reset code or FIN. The reset already fired
+			// the interrupt, so the future resolves promptly; finish it on a
+			// local task and apply the terminal action then.
+			Some(SendState::Writing { fut, .. }) => {
+				let reset = self.reset.take();
+				let finish = std::mem::take(&mut self.finish);
+				if reset.is_some() || finish {
+					web_async::spawn(async move {
+						let (mut stream, _) = fut.await;
+						match reset {
+							Some(code) => stream.reset(&code.to_string()),
+							None => {
+								let _ = stream.finish();
+							}
+						}
+					});
+				}
+			}
+			Some(SendState::Closing(fut)) => {
+				let reset = self.reset.take();
+				if let Some(code) = reset {
+					web_async::spawn(async move {
+						let (mut stream, _) = fut.await;
+						stream.reset(&code.to_string());
+					});
+				}
+			}
+			None => {}
 		}
 	}
 }
@@ -416,6 +541,9 @@ pub struct RecvStream {
 	fin: bool,
 	/// A deferred STOP_SENDING, applied when the in-flight operation settles.
 	stop: Option<u32>,
+	/// Cancels the in-flight read so a stop applies immediately instead of
+	/// waiting behind blocked I/O. Fired by `stop` and by `Drop`.
+	interrupt: Option<futures::channel::oneshot::Sender<()>>,
 }
 
 /// How much the closed-watch may read ahead of the caller before it parks and
@@ -425,7 +553,12 @@ const READ_AHEAD_CAP: usize = 64 * 1024;
 
 enum RecvState {
 	Idle(web_transport_wasm::RecvStream),
-	Reading(LocalBoxFuture<'static, (web_transport_wasm::RecvStream, Result<Option<Bytes>, Error>)>),
+	/// A read in flight; a `None` result means it was interrupted by a stop
+	/// (see `RecvStream::interrupt`).
+	Reading(
+		#[allow(clippy::type_complexity)]
+		LocalBoxFuture<'static, (web_transport_wasm::RecvStream, Option<Result<Option<Bytes>, Error>>)>,
+	),
 }
 
 impl RecvStream {
@@ -437,6 +570,7 @@ impl RecvStream {
 			queued_len: 0,
 			fin: false,
 			stop: None,
+			interrupt: None,
 		}
 	}
 
@@ -458,8 +592,25 @@ impl RecvStream {
 					if let Some(code) = self.stop.take() {
 						stream.stop(&code.to_string());
 					}
+					let (tx, rx) = futures::channel::oneshot::channel::<()>();
+					self.interrupt = Some(tx);
 					let fut = async move {
-						let res = stream.read(max).await.map_err(Error);
+						let res = {
+							let mut op = std::pin::pin!(async { stream.read(max).await.map_err(Error) }.fuse());
+							let mut rx = rx.fuse();
+							loop {
+								futures::select_biased! {
+									res = op => break Some(res),
+									cancel = rx => match cancel {
+										Ok(()) => break None,
+										// A dropped (unfired) sender must not interrupt;
+										// only an explicit stop does. The fused arm goes
+										// quiet and the read keeps driving.
+										Err(_) => continue,
+									},
+								}
+							}
+						};
 						(stream, res)
 					}
 					.boxed_local();
@@ -471,6 +622,7 @@ impl RecvStream {
 						return Poll::Pending;
 					}
 					Poll::Ready((mut stream, res)) => {
+						self.interrupt = None;
 						// Apply a stop requested while the read was in flight now, not on
 						// the next read: a caller that stops and never reads again must
 						// still send STOP_SENDING.
@@ -478,6 +630,9 @@ impl RecvStream {
 							stream.stop(&code.to_string());
 						}
 						self.state = Some(RecvState::Idle(stream));
+						// An interrupted read was abandoned for the stop applied
+						// above; the next iteration's read reports the stream state.
+						let Some(res) = res else { continue };
 						if let Ok(None) = &res {
 							self.fin = true;
 						}
@@ -536,7 +691,14 @@ impl wtt::poll::RecvStream for RecvStream {
 	fn stop(&mut self, code: u32) {
 		match self.state.as_mut() {
 			Some(RecvState::Idle(stream)) => stream.stop(&code.to_string()),
-			_ => self.stop = Some(code),
+			_ => {
+				self.stop = Some(code);
+				// The caller is discarding the stream, so cancel the in-flight
+				// read rather than letting blocked I/O delay the stop.
+				if let Some(tx) = self.interrupt.take() {
+					let _ = tx.send(());
+				}
+			}
 		}
 	}
 
@@ -563,6 +725,31 @@ impl wtt::poll::RecvStream for RecvStream {
 				// A read error is also a closed stream.
 				Err(err) => return Poll::Ready(Err(err)),
 			}
+		}
+	}
+}
+
+impl Drop for RecvStream {
+	fn drop(&mut self) {
+		match self.state.take() {
+			// Apply a deferred stop if the stream is idle.
+			Some(RecvState::Idle(mut stream)) => {
+				if let Some(code) = self.stop.take() {
+					stream.stop(&code.to_string());
+				}
+			}
+			// The stream lives inside the in-flight read; the stop already fired
+			// the interrupt, so the future resolves promptly. Finish it on a
+			// local task and apply the real code then.
+			Some(RecvState::Reading(fut)) => {
+				if let Some(code) = self.stop.take() {
+					web_async::spawn(async move {
+						let (mut stream, _) = fut.await;
+						stream.stop(&code.to_string());
+					});
+				}
+			}
+			None => {}
 		}
 	}
 }

--- a/rs/moq-wasm/src/transport.rs
+++ b/rs/moq-wasm/src/transport.rs
@@ -11,7 +11,11 @@
 //! poll implementation inside `web-transport-wasm` would do better; migrate
 //! there once it grows one.
 
-use std::task::{Context, Poll, ready};
+use std::{
+	cell::Cell,
+	rc::Rc,
+	task::{Context, Poll, ready},
+};
 
 use bytes::Bytes;
 use futures::{FutureExt, future::LocalBoxFuture};
@@ -34,6 +38,12 @@ fn poll_op<T>(
 	Poll::Ready(output)
 }
 
+/// How many browser datagram sends may be outstanding before further ones are
+/// dropped. The browser API is promise-based with no readiness signal, so this
+/// is what keeps a backpressured connection from accumulating tasks and payload
+/// copies: at the 1200 byte limit below, the ceiling is under 10 KiB in flight.
+const MAX_PENDING_DATAGRAMS: usize = 8;
+
 /// A connected browser WebTransport session, usable by `moq-net`.
 pub struct Session {
 	inner: web_transport_wasm::Session,
@@ -43,6 +53,9 @@ pub struct Session {
 	open_bi: OpSlot<Result<(SendStream, RecvStream), Error>>,
 	recv_datagram: OpSlot<Result<Bytes, Error>>,
 	closed: OpSlot<Error>,
+	/// Datagram sends spawned but not yet settled. Shared by every clone, since
+	/// the connection they contend for is the shared resource.
+	datagrams_pending: Rc<Cell<usize>>,
 }
 
 impl Session {
@@ -55,15 +68,20 @@ impl Session {
 			open_bi: None,
 			recv_datagram: None,
 			closed: None,
+			datagrams_pending: Rc::new(Cell::new(0)),
 		}
 	}
 }
 
 // Manual impl: a clone starts with no in-flight operations, since each handle
-// owns its own progress under the poll contract.
+// owns its own progress under the poll contract. The datagram budget is the
+// exception, being a property of the connection rather than of one handle.
 impl Clone for Session {
 	fn clone(&self) -> Self {
-		Self::new(self.inner.clone())
+		Self {
+			datagrams_pending: self.datagrams_pending.clone(),
+			..Self::new(self.inner.clone())
+		}
 	}
 }
 
@@ -160,12 +178,24 @@ impl wtt::poll::Session for Session {
 	}
 
 	fn poll_send_datagram(&mut self, _cx: &mut Context<'_>, payload: &[u8]) -> Poll<Result<(), Self::Error>> {
-		// The browser datagram API is async. moq drives all control/media over
-		// streams, so fire-and-forget is acceptable here.
+		// The browser datagram API is async, so the send runs on its own task and
+		// the caller is told the datagram was accepted either way: datagrams are
+		// best-effort, and the publisher has no fallback to offer if we said no.
+		// What it must not do is let a producer outrunning the network queue those
+		// tasks without bound, so past the budget the datagram is dropped here,
+		// which is the congestion behavior the caller already expects.
+		let pending = self.datagrams_pending.get();
+		if pending >= MAX_PENDING_DATAGRAMS {
+			return Poll::Ready(Ok(()));
+		}
+		self.datagrams_pending.set(pending + 1);
+
 		let session = self.inner.clone();
 		let payload = Bytes::copy_from_slice(payload);
+		let budget = self.datagrams_pending.clone();
 		web_async::spawn(async move {
 			let _ = session.send_datagram(payload).await;
+			budget.set(budget.get() - 1);
 		});
 		Poll::Ready(Ok(()))
 	}

--- a/rs/moq-wasm/src/transport.rs
+++ b/rs/moq-wasm/src/transport.rs
@@ -1,24 +1,77 @@
-//! Adapt `web-transport-wasm` (the browser WebTransport API) to the
-//! `web-transport-trait` abstraction that `moq-net` is generic over.
+//! Adapt `web-transport-wasm` (the browser WebTransport API) to the poll
+//! interface (`web_transport_trait::poll`) that `moq-net` requires.
 //!
-//! Both the trait and the wasm types are foreign, so the orphan rule forces
-//! newtype wrappers. The shapes line up closely; the only real impedance
-//! mismatches are documented inline (sync-vs-async datagrams, byte-count vs
-//! write-all, string-vs-code stream resets).
+//! The browser API is promise-based, so each pending operation is stored as a
+//! boxed local future: session operations clone the underlying handle, stream
+//! operations move the stream into the future and take it back when the
+//! operation settles. Stream closed-watches are emulated (reads report the FIN
+//! for receive streams; send streams only start the real watch after
+//! `finish`/`reset`), since the underlying `closed()` future would own the
+//! stream and deadlock any later read or write. This mirrors what a native
+//! poll implementation inside `web-transport-wasm` would do better; migrate
+//! there once it grows one.
+
+use std::task::{Context, Poll, ready};
 
 use bytes::Bytes;
+use futures::{FutureExt, future::LocalBoxFuture};
 use url::Url;
 use web_transport_trait as wtt;
 
+/// A stored in-flight operation: `None` when idle. The browser is single
+/// threaded, so the plain local flavor suffices.
+type OpSlot<T> = Option<LocalBoxFuture<'static, T>>;
+
+/// Lazily start and poll the operation in `slot`, clearing it when it resolves.
+fn poll_op<T>(
+	slot: &mut OpSlot<T>,
+	cx: &mut Context<'_>,
+	start: impl FnOnce() -> LocalBoxFuture<'static, T>,
+) -> Poll<T> {
+	let fut = slot.get_or_insert_with(start);
+	let output = ready!(fut.as_mut().poll(cx));
+	*slot = None;
+	Poll::Ready(output)
+}
+
 /// A connected browser WebTransport session, usable by `moq-net`.
-#[derive(Clone)]
-pub struct Session(web_transport_wasm::Session);
+pub struct Session {
+	inner: web_transport_wasm::Session,
+	accept_uni: OpSlot<Result<RecvStream, Error>>,
+	accept_bi: OpSlot<Result<(SendStream, RecvStream), Error>>,
+	open_uni: OpSlot<Result<SendStream, Error>>,
+	open_bi: OpSlot<Result<(SendStream, RecvStream), Error>>,
+	recv_datagram: OpSlot<Result<Bytes, Error>>,
+	closed: OpSlot<Error>,
+}
+
+impl Session {
+	fn new(inner: web_transport_wasm::Session) -> Self {
+		Self {
+			inner,
+			accept_uni: None,
+			accept_bi: None,
+			open_uni: None,
+			open_bi: None,
+			recv_datagram: None,
+			closed: None,
+		}
+	}
+}
+
+// Manual impl: a clone starts with no in-flight operations, since each handle
+// owns its own progress under the poll contract.
+impl Clone for Session {
+	fn clone(&self) -> Self {
+		Self::new(self.inner.clone())
+	}
+}
 
 /// Open a browser WebTransport connection to `url`.
 pub async fn connect(url: Url) -> Result<Session, Error> {
 	let client = web_transport_wasm::ClientBuilder::new().with_system_roots();
 	let session = client.connect(url).await.map_err(Error)?;
-	Ok(Session(session))
+	Ok(Session::new(session))
 }
 
 /// Connect, trusting only the given sha-256 certificate hashes (serverless dev,
@@ -26,11 +79,8 @@ pub async fn connect(url: Url) -> Result<Session, Error> {
 pub async fn connect_with_hashes(url: Url, hashes: Vec<Vec<u8>>) -> Result<Session, Error> {
 	let client = web_transport_wasm::ClientBuilder::new().with_server_certificate_hashes(hashes);
 	let session = client.connect(url).await.map_err(Error)?;
-	Ok(Session(session))
+	Ok(Session::new(session))
 }
-
-pub struct SendStream(web_transport_wasm::SendStream);
-pub struct RecvStream(web_transport_wasm::RecvStream);
 
 /// Wraps `web_transport_wasm::Error` so we can implement the foreign error trait.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -56,41 +106,68 @@ impl wtt::Error for Error {
 	}
 }
 
-impl wtt::Session for Session {
+impl wtt::poll::Session for Session {
 	type SendStream = SendStream;
 	type RecvStream = RecvStream;
 	type Error = Error;
 
-	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-		Ok(RecvStream(self.0.accept_uni().await.map_err(Error)?))
+	fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>> {
+		let inner = &self.inner;
+		poll_op(&mut self.accept_uni, cx, || {
+			let session = inner.clone();
+			async move { Ok(RecvStream::new(session.accept_uni().await.map_err(Error)?)) }.boxed_local()
+		})
 	}
 
-	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-		let (s, r) = self.0.accept_bi().await.map_err(Error)?;
-		Ok((SendStream(s), RecvStream(r)))
+	fn poll_accept_bi(&mut self, cx: &mut Context<'_>) -> Poll<Result<(SendStream, RecvStream), Self::Error>> {
+		let inner = &self.inner;
+		poll_op(&mut self.accept_bi, cx, || {
+			let session = inner.clone();
+			async move {
+				let (s, r) = session.accept_bi().await.map_err(Error)?;
+				Ok((SendStream::new(s), RecvStream::new(r)))
+			}
+			.boxed_local()
+		})
 	}
 
-	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-		let (s, r) = self.0.open_bi().await.map_err(Error)?;
-		Ok((SendStream(s), RecvStream(r)))
+	fn poll_open_bi(&mut self, cx: &mut Context<'_>) -> Poll<Result<(SendStream, RecvStream), Self::Error>> {
+		let inner = &self.inner;
+		poll_op(&mut self.open_bi, cx, || {
+			let session = inner.clone();
+			async move {
+				let (s, r) = session.open_bi().await.map_err(Error)?;
+				Ok((SendStream::new(s), RecvStream::new(r)))
+			}
+			.boxed_local()
+		})
 	}
 
-	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-		Ok(SendStream(self.0.open_uni().await.map_err(Error)?))
+	fn poll_open_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::SendStream, Self::Error>> {
+		let inner = &self.inner;
+		poll_op(&mut self.open_uni, cx, || {
+			let session = inner.clone();
+			async move { Ok(SendStream::new(session.open_uni().await.map_err(Error)?)) }.boxed_local()
+		})
 	}
 
-	fn send_datagram(&self, payload: Bytes) -> Result<(), Self::Error> {
-		// The browser datagram API is async; the trait is sync. moq drives all
-		// control/media over streams, so fire-and-forget is acceptable here.
-		let session = self.0.clone();
+	fn poll_send_datagram(&mut self, _cx: &mut Context<'_>, payload: &[u8]) -> Poll<Result<(), Self::Error>> {
+		// The browser datagram API is async. moq drives all control/media over
+		// streams, so fire-and-forget is acceptable here.
+		let session = self.inner.clone();
+		let payload = Bytes::copy_from_slice(payload);
 		web_async::spawn(async move {
 			let _ = session.send_datagram(payload).await;
 		});
-		Ok(())
+		Poll::Ready(Ok(()))
 	}
 
-	async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
-		self.0.recv_datagram().await.map_err(Error)
+	fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>> {
+		let inner = &self.inner;
+		poll_op(&mut self.recv_datagram, cx, || {
+			let session = inner.clone();
+			async move { session.recv_datagram().await.map_err(Error) }.boxed_local()
+		})
 	}
 
 	fn max_datagram_size(&self) -> usize {
@@ -99,63 +176,322 @@ impl wtt::Session for Session {
 	}
 
 	fn protocol(&self) -> Option<&str> {
-		self.0.protocol()
+		self.inner.protocol()
 	}
 
-	fn close(&self, code: u32, reason: &str) {
-		self.0.close(code, reason);
+	fn close(&mut self, code: u32, reason: &str) {
+		self.inner.close(code, reason);
 	}
 
-	async fn closed(&self) -> Self::Error {
-		Error(self.0.closed().await)
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Self::Error> {
+		let inner = &self.inner;
+		poll_op(&mut self.closed, cx, || {
+			let session = inner.clone();
+			async move { Error(session.closed().await) }.boxed_local()
+		})
+	}
+
+	fn stats(&self) -> impl wtt::Stats {
+		wtt::StatsUnavailable
 	}
 }
 
-impl wtt::SendStream for SendStream {
+/// The send half of a browser stream, adapted to the poll interface.
+pub struct SendStream {
+	state: Option<SendState>,
+	// Deferred actions, applied when the in-flight operation settles.
+	priority: Option<i32>,
+	finish: bool,
+	reset: Option<u32>,
+	/// Whether `finish` or `reset` has been observed, so no further writes can
+	/// come and the closed() watch may safely take ownership of the stream.
+	terminal: bool,
+}
+
+enum SendState {
+	Idle(web_transport_wasm::SendStream),
+	/// A write in flight; `len` is what to report when it resolves.
+	Writing {
+		fut: LocalBoxFuture<'static, (web_transport_wasm::SendStream, Result<(), Error>)>,
+		len: usize,
+	},
+	Closing(LocalBoxFuture<'static, (web_transport_wasm::SendStream, Result<(), Error>)>),
+}
+
+impl SendStream {
+	fn new(stream: web_transport_wasm::SendStream) -> Self {
+		Self {
+			state: Some(SendState::Idle(stream)),
+			priority: None,
+			finish: false,
+			reset: None,
+			terminal: false,
+		}
+	}
+
+	/// Apply actions deferred while an operation was in flight.
+	fn settle(&mut self, stream: &mut web_transport_wasm::SendStream) {
+		if let Some(order) = self.priority.take() {
+			stream.set_priority(order);
+		}
+		if let Some(code) = self.reset.take() {
+			self.finish = false;
+			stream.reset(&code.to_string());
+		}
+		if std::mem::take(&mut self.finish) {
+			// A deferred finish has nowhere to report to; its failure surfaces
+			// through closed() like any other terminal state.
+			let _ = stream.finish();
+		}
+	}
+}
+
+impl wtt::poll::SendStream for SendStream {
 	type Error = Error;
 
-	async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-		// The wasm writer writes the whole slice or errors.
-		self.0.write(buf).await.map_err(Error)?;
-		Ok(buf.len())
+	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+		loop {
+			match self.state.take().expect("in-flight") {
+				SendState::Idle(mut stream) => {
+					if buf.is_empty() {
+						self.state = Some(SendState::Idle(stream));
+						return Poll::Ready(Ok(0));
+					}
+					// The wasm writer writes the whole slice or errors, so the
+					// reported count is exact. The caller retries with the same
+					// bytes until this resolves.
+					let chunk = buf.to_vec();
+					let len = chunk.len();
+					let fut = async move {
+						let res = stream.write(&chunk).await.map_err(Error);
+						(stream, res)
+					}
+					.boxed_local();
+					self.state = Some(SendState::Writing { fut, len });
+				}
+				SendState::Writing { mut fut, len } => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						self.state = Some(SendState::Writing { fut, len });
+						return Poll::Pending;
+					}
+					Poll::Ready((mut stream, res)) => {
+						self.settle(&mut stream);
+						self.state = Some(SendState::Idle(stream));
+						res?;
+						return Poll::Ready(Ok(len));
+					}
+				},
+				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						self.state = Some(SendState::Closing(fut));
+						return Poll::Pending;
+					}
+					Poll::Ready((mut stream, _res)) => {
+						self.settle(&mut stream);
+						self.state = Some(SendState::Idle(stream));
+					}
+				},
+			}
+		}
 	}
 
 	fn set_priority(&mut self, order: u8) {
-		self.0.set_priority(order as i32);
+		match self.state.as_mut() {
+			Some(SendState::Idle(stream)) => stream.set_priority(order as i32),
+			_ => self.priority = Some(order as i32),
+		}
 	}
 
 	fn finish(&mut self) -> Result<(), Self::Error> {
-		self.0.finish().map_err(Error)
+		self.terminal = true;
+		match self.state.as_mut() {
+			Some(SendState::Idle(stream)) => stream.finish().map_err(Error),
+			_ => {
+				self.finish = true;
+				Ok(())
+			}
+		}
 	}
 
 	fn reset(&mut self, code: u32) {
-		self.0.reset(&code.to_string());
+		self.terminal = true;
+		match self.state.as_mut() {
+			Some(SendState::Idle(stream)) => stream.reset(&code.to_string()),
+			_ => self.reset = Some(code),
+		}
 	}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
-		self.0.closed().await.map(|_| ()).map_err(Error)
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		loop {
+			match self.state.take().expect("in-flight") {
+				SendState::Idle(mut stream) => {
+					self.settle(&mut stream);
+					// Only a finished (or reset) stream starts the real closed()
+					// watch: that future owns the stream, and a stream the caller
+					// may still write to must stay reclaimable. Before that,
+					// closure surfaces as an error on the next operation instead.
+					if !self.terminal {
+						self.state = Some(SendState::Idle(stream));
+						return Poll::Pending;
+					}
+					let fut = async move {
+						let res = stream.closed().await.map(|_| ()).map_err(Error);
+						(stream, res)
+					}
+					.boxed_local();
+					self.state = Some(SendState::Closing(fut));
+				}
+				SendState::Writing { mut fut, len } => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						self.state = Some(SendState::Writing { fut, len });
+						return Poll::Pending;
+					}
+					Poll::Ready((mut stream, res)) => {
+						self.settle(&mut stream);
+						self.state = Some(SendState::Idle(stream));
+						// A failed write is a closed stream; report it here.
+						if let Err(err) = res {
+							return Poll::Ready(Err(err));
+						}
+					}
+				},
+				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						self.state = Some(SendState::Closing(fut));
+						return Poll::Pending;
+					}
+					Poll::Ready((mut stream, res)) => {
+						self.settle(&mut stream);
+						self.state = Some(SendState::Idle(stream));
+						return Poll::Ready(res);
+					}
+				},
+			}
+		}
 	}
 }
 
-impl wtt::RecvStream for RecvStream {
+/// The receive half of a browser stream, adapted to the poll interface.
+pub struct RecvStream {
+	state: Option<RecvState>,
+	/// Bytes already read from the transport but not yet handed to the caller.
+	buffer: Bytes,
+	/// The peer finished the stream.
+	fin: bool,
+	/// A deferred STOP_SENDING, applied when the in-flight operation settles.
+	stop: Option<u32>,
+}
+
+enum RecvState {
+	Idle(web_transport_wasm::RecvStream),
+	Reading(LocalBoxFuture<'static, (web_transport_wasm::RecvStream, Result<Option<Bytes>, Error>)>),
+}
+
+impl RecvStream {
+	fn new(stream: web_transport_wasm::RecvStream) -> Self {
+		Self {
+			state: Some(RecvState::Idle(stream)),
+			buffer: Bytes::new(),
+			fin: false,
+			stop: None,
+		}
+	}
+
+	/// Fill `self.buffer` (or set `self.fin`) with the next chunk of data.
+	fn poll_fill(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<(), Error>> {
+		loop {
+			match self.state.take().expect("in-flight") {
+				RecvState::Idle(mut stream) => {
+					if let Some(code) = self.stop.take() {
+						stream.stop(&code.to_string());
+					}
+					let fut = async move {
+						let res = stream.read(max).await.map_err(Error);
+						(stream, res)
+					}
+					.boxed_local();
+					self.state = Some(RecvState::Reading(fut));
+				}
+				RecvState::Reading(mut fut) => match fut.as_mut().poll(cx) {
+					Poll::Pending => {
+						self.state = Some(RecvState::Reading(fut));
+						return Poll::Pending;
+					}
+					Poll::Ready((stream, res)) => {
+						self.state = Some(RecvState::Idle(stream));
+						match res {
+							Ok(Some(bytes)) => self.buffer = bytes,
+							Ok(None) => self.fin = true,
+							Err(err) => return Poll::Ready(Err(err)),
+						}
+						return Poll::Ready(Ok(()));
+					}
+				},
+			}
+		}
+	}
+}
+
+impl wtt::poll::RecvStream for RecvStream {
 	type Error = Error;
 
-	async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-		match self.0.read(dst.len()).await.map_err(Error)? {
-			Some(chunk) => {
-				let n = chunk.len();
-				dst[..n].copy_from_slice(&chunk);
-				Ok(Some(n))
+	fn poll_read(&mut self, cx: &mut Context<'_>, dst: &mut [u8]) -> Poll<Result<Option<usize>, Self::Error>> {
+		if dst.is_empty() {
+			return Poll::Ready(Ok(Some(0)));
+		}
+
+		loop {
+			if !self.buffer.is_empty() {
+				let n = dst.len().min(self.buffer.len());
+				dst[..n].copy_from_slice(&self.buffer.split_to(n));
+				return Poll::Ready(Ok(Some(n)));
 			}
-			None => Ok(None),
+			if self.fin {
+				return Poll::Ready(Ok(None));
+			}
+			ready!(self.poll_fill(cx, dst.len()))?;
+		}
+	}
+
+	fn poll_read_chunk(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<Option<Bytes>, Self::Error>> {
+		if max == 0 {
+			return Poll::Ready(Ok(Some(Bytes::new())));
+		}
+
+		loop {
+			if !self.buffer.is_empty() {
+				let n = max.min(self.buffer.len());
+				return Poll::Ready(Ok(Some(self.buffer.split_to(n))));
+			}
+			if self.fin {
+				return Poll::Ready(Ok(None));
+			}
+			ready!(self.poll_fill(cx, max))?;
 		}
 	}
 
 	fn stop(&mut self, code: u32) {
-		self.0.stop(&code.to_string());
+		match self.state.as_mut() {
+			Some(RecvState::Idle(stream)) => stream.stop(&code.to_string()),
+			_ => self.stop = Some(code),
+		}
 	}
 
-	async fn closed(&mut self) -> Result<(), Self::Error> {
-		self.0.closed().await.map(|_| ()).map_err(Error)
+	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		// Emulated with reads: a FIN or reset surfaces through poll_fill, and
+		// undelivered data parks the watch until the caller drains it.
+		loop {
+			if self.fin {
+				return Poll::Ready(Ok(()));
+			}
+			if !self.buffer.is_empty() {
+				return Poll::Pending;
+			}
+			match ready!(self.poll_fill(cx, 8 * 1024)) {
+				Ok(()) => {}
+				// A read error is also a closed stream.
+				Err(err) => return Poll::Ready(Err(err)),
+			}
+		}
 	}
 }

--- a/rs/moq-wasm/src/transport.rs
+++ b/rs/moq-wasm/src/transport.rs
@@ -206,6 +206,10 @@ pub struct SendStream {
 	/// Whether `finish` or `reset` has been observed, so no further writes can
 	/// come and the closed() watch may safely take ownership of the stream.
 	terminal: bool,
+	/// A write driven to completion by `poll_closed` rather than `poll_write`. The
+	/// caller was told `Pending` and is contractually retrying the same bytes, so the
+	/// next `poll_write` reports this length instead of writing them a second time.
+	completed: Option<usize>,
 }
 
 enum SendState {
@@ -226,6 +230,7 @@ impl SendStream {
 			finish: false,
 			reset: None,
 			terminal: false,
+			completed: None,
 		}
 	}
 
@@ -250,6 +255,11 @@ impl wtt::poll::SendStream for SendStream {
 	type Error = Error;
 
 	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+		// A previous write completed inside poll_closed; report it instead of
+		// writing the same bytes a second time.
+		if let Some(len) = self.completed.take() {
+			return Poll::Ready(Ok(len));
+		}
 		loop {
 			match self.state.take().expect("in-flight") {
 				SendState::Idle(mut stream) => {
@@ -353,6 +363,10 @@ impl wtt::poll::SendStream for SendStream {
 						if let Err(err) = res {
 							return Poll::Ready(Err(err));
 						}
+						// The caller of poll_write was told Pending and will retry the
+						// same bytes; record the completion so the retry reports it
+						// instead of writing the bytes a second time.
+						self.completed = Some(len);
 					}
 				},
 				SendState::Closing(mut fut) => match fut.as_mut().poll(cx) {
@@ -376,11 +390,23 @@ pub struct RecvStream {
 	state: Option<RecvState>,
 	/// Bytes already read from the transport but not yet handed to the caller.
 	buffer: Bytes,
+	/// Read-ahead pulled in by the closed-watch while payload sat undelivered, so
+	/// a FIN right behind buffered data still resolves the watch. Drained by the
+	/// read methods before the transport is polled again; bounded by
+	/// [`READ_AHEAD_CAP`].
+	queued: std::collections::VecDeque<Bytes>,
+	/// Total bytes across `queued`, so the cap check is O(1).
+	queued_len: usize,
 	/// The peer finished the stream.
 	fin: bool,
 	/// A deferred STOP_SENDING, applied when the in-flight operation settles.
 	stop: Option<u32>,
 }
+
+/// How much the closed-watch may read ahead of the caller before it parks and
+/// waits for the caller to drain. Bounds memory against a peer that floods a
+/// stream nobody is reading.
+const READ_AHEAD_CAP: usize = 64 * 1024;
 
 enum RecvState {
 	Idle(web_transport_wasm::RecvStream),
@@ -392,13 +418,25 @@ impl RecvStream {
 		Self {
 			state: Some(RecvState::Idle(stream)),
 			buffer: Bytes::new(),
+			queued: std::collections::VecDeque::new(),
+			queued_len: 0,
 			fin: false,
 			stop: None,
 		}
 	}
 
-	/// Fill `self.buffer` (or set `self.fin`) with the next chunk of data.
-	fn poll_fill(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<(), Error>> {
+	/// Pop read-ahead into `self.buffer` if the head is empty.
+	fn unqueue(&mut self) {
+		if self.buffer.is_empty()
+			&& let Some(next) = self.queued.pop_front()
+		{
+			self.queued_len -= next.len();
+			self.buffer = next;
+		}
+	}
+
+	/// Read the next chunk from the transport, setting `self.fin` on the FIN.
+	fn poll_fill(&mut self, cx: &mut Context<'_>, max: usize) -> Poll<Result<Option<Bytes>, Error>> {
 		loop {
 			match self.state.take().expect("in-flight") {
 				RecvState::Idle(mut stream) => {
@@ -417,14 +455,18 @@ impl RecvStream {
 						self.state = Some(RecvState::Reading(fut));
 						return Poll::Pending;
 					}
-					Poll::Ready((stream, res)) => {
-						self.state = Some(RecvState::Idle(stream));
-						match res {
-							Ok(Some(bytes)) => self.buffer = bytes,
-							Ok(None) => self.fin = true,
-							Err(err) => return Poll::Ready(Err(err)),
+					Poll::Ready((mut stream, res)) => {
+						// Apply a stop requested while the read was in flight now, not on
+						// the next read: a caller that stops and never reads again must
+						// still send STOP_SENDING.
+						if let Some(code) = self.stop.take() {
+							stream.stop(&code.to_string());
 						}
-						return Poll::Ready(Ok(()));
+						self.state = Some(RecvState::Idle(stream));
+						if let Ok(None) = &res {
+							self.fin = true;
+						}
+						return Poll::Ready(res);
 					}
 				},
 			}
@@ -441,6 +483,7 @@ impl wtt::poll::RecvStream for RecvStream {
 		}
 
 		loop {
+			self.unqueue();
 			if !self.buffer.is_empty() {
 				let n = dst.len().min(self.buffer.len());
 				dst[..n].copy_from_slice(&self.buffer.split_to(n));
@@ -449,7 +492,9 @@ impl wtt::poll::RecvStream for RecvStream {
 			if self.fin {
 				return Poll::Ready(Ok(None));
 			}
-			ready!(self.poll_fill(cx, dst.len()))?;
+			if let Some(bytes) = ready!(self.poll_fill(cx, dst.len()))? {
+				self.buffer = bytes;
+			}
 		}
 	}
 
@@ -459,6 +504,7 @@ impl wtt::poll::RecvStream for RecvStream {
 		}
 
 		loop {
+			self.unqueue();
 			if !self.buffer.is_empty() {
 				let n = max.min(self.buffer.len());
 				return Poll::Ready(Ok(Some(self.buffer.split_to(n))));
@@ -466,7 +512,9 @@ impl wtt::poll::RecvStream for RecvStream {
 			if self.fin {
 				return Poll::Ready(Ok(None));
 			}
-			ready!(self.poll_fill(cx, max))?;
+			if let Some(bytes) = ready!(self.poll_fill(cx, max))? {
+				self.buffer = bytes;
+			}
 		}
 	}
 
@@ -478,17 +526,25 @@ impl wtt::poll::RecvStream for RecvStream {
 	}
 
 	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-		// Emulated with reads: a FIN or reset surfaces through poll_fill, and
-		// undelivered data parks the watch until the caller drains it.
+		// Emulated with reads: a FIN or reset surfaces through reads; payload
+		// arriving before it is queued as read-ahead (up to READ_AHEAD_CAP) so a
+		// FIN right behind undelivered data still resolves the watch without an
+		// external read.
 		loop {
 			if self.fin {
 				return Poll::Ready(Ok(()));
 			}
-			if !self.buffer.is_empty() {
+			if self.buffer.len() + self.queued_len >= READ_AHEAD_CAP {
+				// The caller's own reads are what drain the backlog, and their
+				// re-poll of this watch is what resumes it.
 				return Poll::Pending;
 			}
 			match ready!(self.poll_fill(cx, 8 * 1024)) {
-				Ok(()) => {}
+				Ok(Some(bytes)) => {
+					self.queued_len += bytes.len();
+					self.queued.push_back(bytes);
+				}
+				Ok(None) => {}
 				// A read error is also a closed stream.
 				Err(err) => return Poll::Ready(Err(err)),
 			}


### PR DESCRIPTION
## Why

web-transport-trait 0.4 shipped a sans-I/O poll surface (`web_transport_trait::poll`), implemented natively by quinn and quiche. This PR makes moq-net **poll-only**: every entry point requires the poll interface, and nothing in moq-net wraps futures to fake it. The second commit is the payoff: with every transport operation directly pollable, the internal drivers shed their stored/pinned futures and become plain poll logic.

## What

**`moq_net::transport::poll` (new module)**
- `transport::poll::{Session, SendStream, RecvStream}` (mirroring `web_transport_trait::poll`): the poll traits plus the bounds the session machinery needs (`Clone + MaybeSend + MaybeSync + 'static`), blanket-implemented. Every entry point (`Client::connect`, `Server::accept`, `Request<S>`) bounds on these.
- Async helper methods (`accept_uni`, `open_bi`, `read_chunk`, `write_buf`, `closed`, ...) are provided on the traits as `poll_fn` wrappers with the same names the async trait used, which kept the internal churn to receiver mutability (`&self` + `Clone` became `&mut self`, so each concurrently pending operation gets its own session clone, per the poll contract).
- **moq-net contains no async-to-poll adapter.** A transport that only implements the async half cannot be handed to moq-net; it has to implement the poll interface.

**Backends**
- quinn and quiche pass through natively (zero bridging).
- qmux (WebSocket/TCP/Unix), iroh, and noq are wrapped by `moq_native::transport::Async`, a *transitional* adapter living in moq-native (where async already lives), to be deleted backend by backend as native poll implementations land upstream. moq-relay's WebSocket fallback uses it too.
- moq-wasm adapts the browser's promise-based transport to the poll interface inside its own `transport::Session` newtype, which is the shape a native `web-transport-wasm` poll implementation will eventually replace.

**Poll-native internals (second commit): async logic replaced with poll logic**

This is what the breaking bound buys. Before, the drivers were async-first: transport waits were pinned futures (`std::pin::pin!(stream.closed())`, `pin!(reader.decode_maybe())`) polled via `waiter.poll_future` inside every `kio::wait` race, and one-shot protocol work was boxed into task sets. Now:

- `coding::{Reader, Writer, Stream}` are **sans-I/O**: `poll_decode`, `poll_decode_maybe`, `poll_decode_peek`, `poll_read_chunk`, `poll_read_exact`, `poll_closed` on the reader; a buffered encode (`buffer` + `poll_flush`) plus `poll_write`, `poll_write_all`, `poll_closed` on the writer; `poll_open`/`poll_accept` on the pair. The async methods are thin `poll_fn` wrappers, so all existing tests exercise the poll paths. Buffered writes make a flush resumable mid-message (the old `encode` discarded partial progress); new writer unit tests cover both properties.
- **Every select-style race polls the transport directly.** The lite and ietf publishers/subscribers, the announce and namespace loops, GOAWAY, and the probe loops no longer pin a single transport future anywhere. This retires the stored-future pattern behind the closed-watch ownership deadlock (see Bugs below) across the whole crate, not just in the adapters.
- **`TaskSet::drive` takes a poll closure instead of a future**, so accept loops poll `poll_accept_uni`/`poll_accept_bi` in place; there is no accept future whose cancel-safety needs auditing when a child completes.
- **The lite session driver is a state machine** (`lite::session::Driver`): `SendSetup` and `SendGoaway` replace the boxed setup/GOAWAY tasks, the legacy session stream is an inert poll arm, and GOAWAY deadline enforcement is a reusable `goaway::Enforce` machine (the ietf driver consumes it through the async wrapper for now). One `kio::wait` at the driver boundary is all that remains; everything inside is `Poll`.

**Poll-native drivers (commits 3-7): the run loops are state machines**

The `kio::wait` races and `FuturesUnordered` task sets are gone from the hot paths; the drivers are hand-written state machines with one `kio::wait` bridge at the session boundary.

- **`poll_set::PollSet`**: the poll-native counterpart of `FuturesUnordered`. Each child machine owns a waker that marks it ready and wakes the parent, so a wakeup re-polls only the child it was aimed at: a session serving hundreds of subscriptions polls one machine per frame, not all of them.
- **moq-lite is 100% machines.** The publisher accepts control streams into a `Control` dispatch machine (announce, subscribe, fetch, track-info, probe, goaway), serves each group through a per-group machine that applies priority updates on every pass, and runs the announce loop as a buffered-writer event machine. The subscriber's announce prefixes, per-source track serving, the upstream SUBSCRIBE lifecycle (TRACK_INFO, establish, updates, fetches), GROUP ingest, datagrams, and PROBE feedback are all machines; the lite half contains no `async fn` outside test shims, and `err_only`/`TaskSet` left it entirely.
- **The moq-transport group data plane is machines too**: the publisher's per-track/per-group serving and the subscriber's subgroup ingest, so no group stream on either protocol boxes or pins a future.
- Streaming a received frame across polls needed the frame producer inside machine state, which the borrowed `frame::Producer<'_>` cannot do. The model grew a crate-private owned variant (`frame::ProducerOwned` via `group::Producer::create_frame_owned`): same shared state through a group clone, with the public borrowed API and its one-live-frame guarantee unchanged.
- One subtlety preserved deliberately: `connect()` must drive the session at least once before its readiness resolves, so the subscriber driver holds a clone of the connection-progress producer until its first poll (the old announce task's `drop(connecting)` did this implicitly).

**Internals that became poll-native in the first commit**
- The ietf `ControlStreamAdapter` and its virtual streams implement the poll traits directly over their kio queues (no more pinned futures inside `accept_bi`).
- `SendBandwidth` polls the transport close directly instead of boxing a `closed()` future.
- Every test double is poll-native: the lite fakes, the client/server unit fakes, and the integration `MockSession` pair (rebuilt on kio queues, no tokio channels).

## Bugs the conversion caught

- **Closed-watch ownership deadlock**: an adapter that moves a stream into the underlying async `closed()` future deadlocks any later read or write; the old code relied on drop-to-cancel of scoped `closed()` watches. The transitional adapters therefore emulate stream closed-watches (reads report the FIN for receive streams; send streams only start the real watch once `finish`/`reset` makes them terminal). Caught by `goaway_gates_new_subscribes_moq_lite_04`; regression-covered by adapter unit tests in moq-native. The second commit removes the pattern from moq-net itself: no driver stores a transport future at all anymore.
- **Guard-through-match self-deadlock** in the rebuilt mock: `match state.lock().unwrap().is_some() { ... }` holds the guard through the arms, and an arm took the same lock. It wedged the whole current-thread runtime (even timers), which is why four goaway tests hit the harness timeout instead of their own.

## Cross-package sync

- No wire change, so no draft updates; `js/net` unaffected.
- `doc/lib/rs/env/{index,native,wasm}.md` updated for the poll-only requirement.
- moq-ffi/libmoq compile unchanged (verified explicitly; they are not default-members).
- The second commit touches only crate-private moq-net internals: no public API or doc changes.

## Verification

- `just check` (fmt, clippy `-D warnings`, nextest over changed crates + dependents): green; 790 moq-net + 253 moq-native tests pass, including new tests for the buffered writer and the PollSet wake granularity.
- `just test smoke`: green (relay + CLI end-to-end over real QUIC).
- `cargo check -p moq-wasm --target wasm32-unknown-unknown`: green.
- moq-ffi/libmoq `cargo check`: green (not default-members, checked explicitly).

## Follow-ups (separate PRs)

- Native poll implementations for qmux, iroh, and noq in the web-transport repo, then delete `moq_native::transport`; same for `web-transport-wasm`, then slim `moq-wasm/src/transport.rs` to a plain newtype.
- Convert the remaining ietf *control plane* (the session assembly races, `run_unis`/`run_dispatch` accept loops, the namespace loops, the fetch stream, and the `ControlStreamAdapter` read/write halves) to machines the same way, then delete `TaskSet`/`Tasks`/`err_only` from `util.rs`. The lite half and both group data planes are already fully converted.

Targets `dev`: the public bounds on `Client::connect` / `Server::accept` / `Request<S>` changed, a semver break.

## Rebase onto dev + review fixes (second pass)

The stack is rebased onto current `dev` and three commits landed on top:

**`fix(net): carry the dev regression fixes across the rebase`**. The machine conversion conflicted with three fixes that landed on dev while this PR was open; the rebase kept the machines and re-ported the dev semantics onto them: the split-horizon announce exclusion + held consumers (#2740, both lite and ietf), the send-order priority inversion (#2720, `PriorityHandle::send_order` / `priority::from_wire`), and close-consumes-writer (a new `Writer::poll_close` releases the stream once the FIN is acknowledged so the Drop fallback cannot reset it). Dev's regression tests are ported onto the machines.

**`fix(native): report adapter writes completed by the closure watch`**. This is the root cause of the `cluster_diamond_goaway_seamless_failover` CI failure (and confirms the review's duplicate-write finding). The cluster suite runs over `tcp://`, i.e. qmux through the transitional adapter. The group machines poll the peer-close watch before flushing on every pass; under the failover burst's backpressure, `AsyncSend::poll_closed` drove the pending group-header write to completion, discarded its result, and the machine's retry wrote the header a second time. The receiver parsed the duplicate as a phantom `ts=0 size=2` frame carrying the header's own subscribe/sequence bytes, which is exactly the corrupt `[0, 22]` frame the test caught. The completed write's length is now recorded and reported to the retrying `poll_write`. The same commit addresses the rest of the adapter review findings: deferred STOP applies when the in-flight read settles, the receive closed-watch reads through undelivered payload into a bounded (64 KiB) read-ahead queue, the send-side preterminal-closure limitation is documented, and `doc/lib/rs/env/wasm.md` stops advertising a wasm path that no longer compiles. All mirrored in moq-wasm; regression tests for each.

**`fix(net): poll one PollSet snapshot per parent poll`**. A self-waking child could spin the session driver inside a single parent poll and starve its other arms; one snapshot is processed per poll and the re-queue wakes the parent instead.

Verification after the rebase: full moq-net + moq-native suites (1065 tests), the full moq-relay suite (199 tests, including the previously failing `cluster_diamond_goaway_seamless_failover` and `unknown_publisher_does_not_flap_across_an_ietf_cluster_triangle`), `cargo check -p moq-wasm --target wasm32-unknown-unknown`, `just check`, and `just test smoke`, all green.

## Rebase onto dev (third pass)

Rebased again onto current `dev`, which had moved 20 commits. Two commits landed on top.

**`fix(net): carry ordered transmission onto the publisher machines`**. #2767 added the Ordered transmission preference to the *async* publisher this PR deletes, and git auto-merged it only partway: dev's 3-argument `Priority::new` signature and the `Subscription.ordered` field came across, while the conflicting async blocks resolved toward the machines, leaving the machine's group insert still calling the 2-argument form. The tree did not compile. Dev's semantics are now applied to the machines: `ordered` is carried from SUBSCRIBE, new groups rank through `Priority::ordered(priority, id, sequence)` (subscribe-id scoped), and a SUBSCRIBE_UPDATE that flips the preference re-ranks the backlog through `set_ordered`. A `GroupServe` clone's stale `ordered` copy is harmless: ranking reads `TrackRun`'s copy, and queued groups move through the clone-shared `PriorityQueue`.

**`fix(wasm): bound in-flight browser datagram sends`**. The last open review finding. `poll_send_datagram` spawned a task per datagram and reported it accepted, so a best-effort datagram track calling it once per frame could outrun a backpressured browser without bound. At most 8 sends are now outstanding per connection (under 10 KiB at the 1200 byte limit); past that the datagram drops, which is the congestion behavior the caller expects.

Carried across without incident: #2771's arrival-order serving (`poll_recv_group`) and its regression test, #2791's empty-range handling in the lite subscriber (its filter merged against this PR's changed return type; its other two hunks and both new tests auto-merged), and #2738's request URL in the WebSocket accept arm.

Verification on the final tree: `just check` green, `just test` green (3025 tests). Spot-checked as passing: `cluster_diamond_goaway_seamless_failover` and all three `unknown_publisher_does_not_flap_*` variants (the two that broke on the previous rebase), dev's `recv_next_serves_late_arrival_after_newer_group`, `test_set_ordered_*` and `a_nonzero_empty_range_*`, and this PR's `a_self_waking_child_yields_to_the_parent`, `recv_closed_resolves_behind_buffered_data`, `recv_stop_applies_*`, and `goaway_gates_new_subscribes_moq_lite_04`.

(written by Opus 5)

(Written by Fable 5)



