### PR TITLE
fix(py): require video-capable moq-ffi

### DIFF
--- a/py/moq-rs/pyproject.toml
+++ b/py/moq-rs/pyproject.toml
@@ -14,7 +14,7 @@ name = "moq-rs"
 # isn't already there (no tag needed; the registry is the gate).
 # Starts at 0.3.0 to open a new line above the old lockstep 0.2.x releases that
 # bundled the bindings.
-version = "0.4.2"
+version = "0.4.3"
 description = "Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization, with a Pythonic API. Import as `moq`."
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -30,9 +30,9 @@ classifiers = [
 ]
 # Compatible-release pin: floats to the latest 0.3.x moq-ffi patch without a
 # wrapper re-release. A moq-ffi minor bump (0.4) is the only thing that forces
-# bumping this constraint. Floor is 0.3.0, the release that renamed the FFI
-# publish -> announce and required accepting a TrackRequest before writing.
-dependencies = ["moq-ffi ~= 0.3.0"]
+# bumping this constraint. Version 0.3.7 provides the raw video producer that
+# the wrapper imports.
+dependencies = ["moq-ffi ~= 0.3.7"]
 
 [project.urls]
 Homepage = "https://github.com/moq-dev/moq"

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ source = { editable = "py/moq-ffi" }
 
 [[package]]
 name = "moq-rs"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "py/moq-rs" }
 dependencies = [
     { name = "moq-ffi" },


### PR DESCRIPTION
## Summary

- require `moq-ffi ~= 0.3.7` from the Python wrapper
- bump `moq-rs` from 0.4.2 to 0.4.3 so corrected metadata is published
- update the workspace lockfile

## Root cause

`moq-rs 0.4.2` imports `MoqVideoProducer`, which was introduced in `moq-ffi 0.3.7`, but its dependency metadata allowed every 0.3.x release starting at 0.3.0. Fresh installs resolved the latest published `moq-ffi 0.3.6` and failed during `import moq`.

The higher floor makes the actual API requirement explicit. Until a compatible `moq-ffi` wheel is published, installers will report an unsatisfied dependency instead of producing a broken runtime environment.

## Validation

- `nix develop --command just py package`
- verified wheel and sdist metadata contain `Requires-Dist: moq-ffi~=0.3.7`
- `uv lock --check --offline`
- `git diff --check origin/main...HEAD`

(Written by GPT-5)