### PR TITLE
fix(watch)!: move rendition jitter to decoder

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -149,7 +149,7 @@
     },
     "js/moq-boy": {
       "name": "@moq/boy",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@moq/json": "workspace:^",
         "@moq/net": "workspace:^",
@@ -265,7 +265,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/msf": "workspace:^",

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"jsr": false,
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -120,8 +120,6 @@ export class Game {
 		});
 		this.#signals.cleanup(() => this.broadcast.close());
 
-		// Sources produce the per-rendition jitter that Sync reads, so they're created
-		// before Sync to avoid a construction cycle.
 		this.videoSource = new Watch.Video.Source({
 			broadcast: this.broadcast,
 			target: this.#target,
@@ -135,10 +133,13 @@ export class Game {
 		});
 		this.#signals.cleanup(() => this.audioSource.close());
 
+		// The decoder owns rendition handoffs but also needs Sync. Bridge its jitter output through a
+		// local signal so Sync can be constructed first.
+		const videoJitter = new Moq.Signals.Signal<Moq.Time.Milli | undefined>(undefined);
 		this.sync = new Watch.Sync({
 			latency: this.latency,
 			connection: connection.established,
-			video: this.videoSource.out.jitter,
+			video: videoJitter,
 			audio: this.audioSource.out.jitter,
 		});
 		this.#signals.cleanup(() => this.sync.close());
@@ -147,6 +148,7 @@ export class Game {
 
 		const videoEnabled = new Moq.Signals.Signal(true);
 		this.videoDecoder = new Watch.Video.Decoder(this.videoSource, this.sync, { enabled: videoEnabled });
+		this.#signals.proxy(videoJitter, this.videoDecoder.out.jitter);
 		this.#signals.cleanup(() => this.videoDecoder.close());
 
 		// Renderer needs a canvas created by the UI layer, set via `canvas`.

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.4.4",
+	"version": "0.5.0",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -6,8 +6,9 @@ import { Time } from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
 import { base64ToBytes } from "../base64";
 
-import { type Bound, latencyBounds, type Sync } from "../sync";
+import type { Sync } from "../sync";
 import { type AudioBuffer, createAudioBuffer } from "./buffer";
+import { reanchorFloor } from "./latency";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
@@ -99,7 +100,7 @@ export class Decoder {
 
 	// The latency floor as of the last settled change, to detect a floor *increase* (needs a deeper
 	// cushion) versus a decrease or a real-time RTT wiggle. See #runLatencyReanchor.
-	#prevFloor?: Bound;
+	#prevFloor?: Time.Milli;
 
 	#signals = new Effect();
 
@@ -230,11 +231,15 @@ export class Decoder {
 	// longer), but the audio ring keeps draining at its old depth -- resize() (via setLatency) only
 	// re-stalls an *empty* ring, so a mid-playback ring never refills to the new floor and audio runs
 	// ahead of video (the "raise latency, only video re-buffers" desync). reset() re-stalls the ring
-	// so it refills to the new floor. Watch the latency *target* (not the derived buffer) so real-time
-	// RTT jitter never triggers this, and debounce so a slider drag coalesces into one re-anchor.
-	// Decreases are left to natural catch-up.
+	// so it refills to the new floor. Watch the latency target and media delay, excluding adaptive
+	// RTT jitter, and debounce so a slider drag coalesces into one re-anchor. Decreases are left to
+	// natural catch-up.
 	#runLatencyReanchor(effect: Effect): void {
-		const floor = latencyBounds(effect.get(this.sync.in.latency)).min;
+		const floor = reanchorFloor({
+			latency: effect.get(this.sync.in.latency),
+			audio: effect.get(this.sync.in.audio),
+			video: effect.get(this.sync.in.video),
+		});
 		if (this.#prevFloor === undefined) {
 			// Startup: the initial fill already builds the cushion; just record the baseline.
 			this.#prevFloor = floor;
@@ -244,8 +249,7 @@ export class Decoder {
 		// this effect (tearing down the timer), so compare it against the pre-change baseline directly.
 		const baseline = this.#prevFloor;
 		effect.timer(() => {
-			const toMs = (b: Bound): number => (b === "real-time" ? 0 : b);
-			if (toMs(floor) > toMs(baseline)) this.reset();
+			if (floor > baseline) this.reset();
 			this.#prevFloor = floor;
 		}, LATENCY_REANCHOR_DEBOUNCE_MS);
 	}

--- a/js/watch/src/audio/latency.test.ts
+++ b/js/watch/src/audio/latency.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import type { Time } from "@moq/net";
+import { reanchorFloor } from "./latency";
+
+const ms = (value: number) => value as Time.Milli;
+
+describe("reanchorFloor", () => {
+	it("includes fixed latency and the largest media delay", () => {
+		expect(reanchorFloor({ latency: ms(100), audio: ms(20), video: ms(80) })).toBe(ms(180));
+	});
+
+	it("tracks rendition delay without adaptive RTT jitter", () => {
+		expect(reanchorFloor({ latency: "real-time", audio: ms(20), video: ms(80) })).toBe(ms(80));
+		expect(reanchorFloor({ latency: "real-time", audio: ms(20), video: ms(200) })).toBe(ms(200));
+	});
+});

--- a/js/watch/src/audio/latency.ts
+++ b/js/watch/src/audio/latency.ts
@@ -1,0 +1,22 @@
+import { Time } from "@moq/net";
+import { type Latency, latencyBounds } from "../sync";
+
+/** The inputs that determine whether audio needs a deeper playback cushion. */
+export interface ReanchorFloor {
+	/** The configured latency target. */
+	latency: Latency;
+
+	/** Additional delay required by the selected audio rendition. */
+	audio?: Time.Milli;
+
+	/** Additional delay required by the active or pending video rendition. */
+	video?: Time.Milli;
+}
+
+/** The stable latency floor whose increase requires the audio ring to refill. */
+export function reanchorFloor(props: ReanchorFloor): Time.Milli {
+	const { min } = latencyBounds(props.latency);
+	const target = min === "real-time" ? Time.Milli.zero : min;
+	const media = Time.Milli.max(props.audio ?? Time.Milli.zero, props.video ?? Time.Milli.zero);
+	return Time.Milli.add(target, media);
+}

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -182,17 +182,19 @@ export default class MoqWatch extends HTMLElement {
 		});
 		this.signals.cleanup(() => this.text.close());
 
-		// Sources produce the per-rendition jitter that Sync reads, so they're created
-		// before Sync to avoid a construction cycle.
+		// The video decoder owns rendition handoffs but also needs Sync. Bridge its output through a
+		// parent-owned signal so Sync can be constructed first without exposing mutable wiring.
+		const videoJitter = new Signal<Time.Milli | undefined>(undefined);
 		this.sync = new Sync({
 			latency: this.controls.latency,
 			connection: this.connection.established,
-			video: videoSource.out.jitter,
+			video: videoJitter,
 			audio: audioSource.out.jitter,
 		});
 		this.signals.cleanup(() => this.sync.close());
 
 		this.video = new Video.Decoder(videoSource, this.sync, { enabled: this.#videoEnabled });
+		this.signals.proxy(videoJitter, this.video.out.jitter);
 		this.audio = new Audio.Decoder(audioSource, this.sync, { enabled: this.#audioEnabled });
 		this.signals.cleanup(() => {
 			this.video.close();

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -7,12 +7,12 @@ import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Si
 import { base64ToBytes } from "../base64";
 
 import type { Sync } from "../sync";
+import { caughtUp, renditionJitter, switchJitter } from "./playhead";
 import { rotateVideoDimensions } from "./presentation";
 import type { Source } from "./source";
 
 // The amount of time to wait before considering the video to be buffering.
 const BUFFERING = Time.Milli(500);
-const SWITCH = Time.Milli(100);
 
 export type DecoderInput = {
 	// Whether to download the video track. Wired from the renderer's output by the parent.
@@ -41,6 +41,9 @@ type DecoderOutput = {
 	stalled: Signal<boolean>;
 	stats: Signal<Stats | undefined>;
 
+	// The rendition delay Sync must cover while switching tracks.
+	jitter: Signal<Time.Milli | undefined>;
+
 	// Combined buffered ranges (network jitter + decode buffer)
 	buffered: Signal<Container.BufferedRanges>;
 };
@@ -62,12 +65,14 @@ export class Decoder {
 		display: new Signal<{ width: number; height: number } | undefined>(undefined),
 		stalled: new Signal<boolean>(false),
 		stats: new Signal<Stats | undefined>(undefined),
+		jitter: new Signal<Time.Milli | undefined>(undefined),
 		buffered: new Signal<Container.BufferedRanges>([]),
 	};
 	readonly out = readonlys(this.#out);
 
 	// The current track running, held so we can cancel it when the new track is ready.
 	#active = new Signal<DecoderTrack | undefined>(undefined);
+	#pendingJitter = new Signal<Time.Milli | undefined>(undefined);
 
 	#signals = new Effect();
 
@@ -87,10 +92,17 @@ export class Decoder {
 		this.source = source;
 		this.sync = sync;
 
+		this.#signals.run(this.#runJitter.bind(this));
 		this.#signals.run(this.#runPending.bind(this));
 		this.#signals.run(this.#runActive.bind(this));
 		this.#signals.run(this.#runDisplay.bind(this));
 		this.#signals.run(this.#runBuffering.bind(this));
+	}
+
+	#runJitter(effect: Effect): void {
+		const active = effect.get(this.#active)?.jitter;
+		const pending = effect.get(this.#pendingJitter);
+		effect.set(this.#out.jitter, switchJitter({ active, pending }));
 	}
 
 	#runPending(effect: Effect): void {
@@ -127,6 +139,7 @@ export class Decoder {
 			config,
 			stats: this.#out.stats,
 		});
+		effect.set(this.#pendingJitter, pending.jitter);
 
 		effect.cleanup(() => pending?.close());
 
@@ -135,17 +148,18 @@ export class Decoder {
 
 			const current = effect.get(this.#active);
 			if (current) {
+				// A zero timestamp is a rendered frame, not a missing one.
 				const pendingTimestamp = effect.get(pending.timestamp);
-				const activeTimestamp = effect.get(current.timestamp);
+				if (pendingTimestamp === undefined) return;
 
-				// Switch to the new track if it's ready and we've caught up enough.
-				if (!pendingTimestamp) return;
-				if (activeTimestamp && activeTimestamp > pendingTimestamp + SWITCH) return;
+				// Hold off until the new rendition has caught up to the picture it's replacing.
+				if (!caughtUp({ playhead: pendingTimestamp, active: effect.get(current.timestamp) })) return;
 			}
 
 			// Upgrade the pending track to active.
 			// #runActive will be in charge of it now.
 			this.#active.set(pending);
+			this.#pendingJitter.set(undefined);
 			pending = undefined;
 
 			// This effect is done; close it to avoid a useless re-run.
@@ -237,6 +251,7 @@ class DecoderTrack {
 	track: string;
 	config: RequiredDecoderConfig;
 	stats: Signal<Stats | undefined>;
+	jitter: Time.Milli | undefined;
 
 	timestamp = new Signal<Time.Milli | undefined>(undefined);
 	frame = new Signal<VideoFrame | undefined>(undefined);
@@ -262,6 +277,7 @@ class DecoderTrack {
 		this.track = props.track;
 		this.config = requiredConfig;
 		this.stats = props.stats;
+		this.jitter = renditionJitter(props.config);
 
 		this.#signals.run(this.#run.bind(this));
 	}

--- a/js/watch/src/video/playhead.test.ts
+++ b/js/watch/src/video/playhead.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import type * as Catalog from "@moq/hang/catalog";
+import type { Time } from "@moq/net";
+import { caughtUp, renditionJitter, switchJitter } from "./playhead";
+
+// `jitter` is a branded u53 in the catalog schema, so build the config through a cast.
+function config(props: { jitter?: number; framerate?: number }): Catalog.VideoConfig {
+	return { codec: "avc1.640028", container: { kind: "legacy" }, ...props } as Catalog.VideoConfig;
+}
+
+const ms = (value: number) => value as Time.Milli;
+
+describe("renditionJitter", () => {
+	it("prefers the catalog value", () => {
+		expect(renditionJitter(config({ jitter: 2000, framerate: 30 }))).toBe(ms(2000));
+	});
+
+	it("keeps a declared zero rather than falling back", () => {
+		expect(renditionJitter(config({ jitter: 0, framerate: 30 }))).toBe(ms(0));
+	});
+
+	it("falls back to a frame interval", () => {
+		expect(renditionJitter(config({ framerate: 30 }))).toBe(ms(34));
+	});
+
+	it("is undefined when the catalog declares neither", () => {
+		expect(renditionJitter(config({}))).toBeUndefined();
+	});
+});
+
+describe("caughtUp", () => {
+	it("promotes immediately when nothing is rendering", () => {
+		expect(caughtUp({ playhead: ms(1000) })).toBe(true);
+	});
+
+	it("holds off while the new rendition trails the picture it replaces", () => {
+		expect(caughtUp({ playhead: ms(8000), active: ms(10_000) })).toBe(false);
+		expect(caughtUp({ playhead: ms(9800), active: ms(10_000) })).toBe(false);
+	});
+
+	it("promotes once the new rendition is within slack of it", () => {
+		expect(caughtUp({ playhead: ms(9900), active: ms(10_000) })).toBe(true);
+		expect(caughtUp({ playhead: ms(10_500), active: ms(10_000) })).toBe(true);
+	});
+});
+
+describe("switchJitter", () => {
+	it("covers both renditions until promotion", () => {
+		expect(switchJitter({ active: ms(20), pending: ms(100) })).toBe(ms(100));
+		expect(switchJitter({ active: ms(100), pending: ms(20) })).toBe(ms(100));
+	});
+
+	it("settles to the remaining rendition", () => {
+		expect(switchJitter({ active: ms(20) })).toBe(ms(20));
+		expect(switchJitter({ pending: ms(100) })).toBe(ms(100));
+		expect(switchJitter({})).toBeUndefined();
+	});
+});

--- a/js/watch/src/video/playhead.ts
+++ b/js/watch/src/video/playhead.ts
@@ -1,0 +1,52 @@
+import type * as Catalog from "@moq/hang/catalog";
+import { Time } from "@moq/net";
+
+// How far the incoming rendition may still trail the picture it replaces when we promote it,
+// absorbing scheduling noise so the switch doesn't hinge on landing inside a single frame
+// interval. This is also the largest step backwards a switch can make visible.
+const SLACK = Time.Milli(100);
+
+/**
+ * How far behind live a rendition's playhead can sit while still being at its own live edge.
+ *
+ * Frames arrive one group at a time, so this is the rendition's group cadence: the sync buffer
+ * has to cover it or playback starves between groups. The catalog value wins. Otherwise assume
+ * the publisher flushes each frame as it's encoded, so a frame interval is the longest we wait.
+ * Undefined when the catalog declares neither.
+ */
+export function renditionJitter(config: Catalog.VideoConfig): Time.Milli | undefined {
+	if (config.jitter !== undefined) return Time.Milli(config.jitter);
+	if (config.framerate) return Time.Milli(Math.ceil(1000 / config.framerate));
+	return undefined;
+}
+
+/** The playheads involved in promoting a new rendition. */
+export interface CaughtUp {
+	/** The incoming rendition's playhead: the most recent timestamp it has rendered. */
+	playhead: Time.Milli;
+
+	/** The outgoing rendition's playhead, or undefined when it has rendered nothing. */
+	active?: Time.Milli;
+}
+
+/** Whether the incoming rendition has caught up enough to take over the picture. */
+export function caughtUp(props: CaughtUp): boolean {
+	if (props.active === undefined) return true;
+	return Time.Milli.add(props.playhead, SLACK) >= props.active;
+}
+
+/** The rendition delays that can be present during a track handoff. */
+export interface SwitchJitter {
+	/** The delay required by the rendition currently on screen. */
+	active?: Time.Milli;
+
+	/** The delay required by the rendition preparing to replace it. */
+	pending?: Time.Milli;
+}
+
+/** The delay Sync must cover while a rendition switch is in flight. */
+export function switchJitter(props: SwitchJitter): Time.Milli | undefined {
+	if (props.active === undefined) return props.pending;
+	if (props.pending === undefined) return props.active;
+	return Time.Milli.max(props.active, props.pending);
+}

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -1,6 +1,4 @@
 import type * as Catalog from "@moq/hang/catalog";
-import type * as Moq from "@moq/net";
-import { Time } from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
 import type { Broadcast } from "../broadcast";
 
@@ -50,9 +48,6 @@ type SourceOutput = {
 	// The name of the active rendition.
 	track: Signal<string | undefined>;
 	config: Signal<Catalog.VideoConfig | undefined>;
-
-	// The per-rendition jitter (ms) to add to the sync buffer. Wired into Sync by the parent.
-	jitter: Signal<Moq.Time.Milli | undefined>;
 };
 
 /**
@@ -220,7 +215,6 @@ export class Source {
 		error: new Signal<SourceError | undefined>(undefined),
 		track: new Signal<string | undefined>(undefined),
 		config: new Signal<Catalog.VideoConfig | undefined>(undefined),
-		jitter: new Signal<Moq.Time.Milli | undefined>(undefined),
 	};
 	readonly out = readonlys(this.#out);
 
@@ -296,7 +290,6 @@ export class Source {
 			const config = available[target.name];
 			effect.set(this.#out.track, target.name);
 			effect.set(this.#out.config, config);
-			effect.set(this.#out.jitter, config.jitter !== undefined ? Time.Milli(config.jitter) : undefined);
 			return;
 		}
 
@@ -320,10 +313,6 @@ export class Source {
 
 		effect.set(this.#out.track, selected);
 		effect.set(this.#out.config, config);
-
-		// Use catalog jitter if available, otherwise estimate from framerate.
-		const jitter = config.jitter ?? (config.framerate ? Math.ceil(1000 / config.framerate) : undefined);
-		effect.set(this.#out.jitter, jitter !== undefined ? Time.Milli(jitter) : undefined);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Move video rendition jitter ownership from selection-time `Source` state to the `Decoder` handoff, covering both active and pending renditions during a switch.
- Re-anchor the audio ring when the stable latency target or media delay grows, while continuing to ignore adaptive RTT jitter.
- Update MoQ Boy wiring and add regression coverage for rendition jitter, switch readiness, and re-anchor floor calculation.

Root cause: `Source.out.jitter` changed as soon as a rendition was selected, before that rendition rendered. `Sync` therefore moved the live edge while the outgoing rendition was still on screen, and audio did not re-anchor because it watched only the configured latency target.

## Public API changes

- Breaking: remove `Video.Source.out.jitter`.
- Add `Video.Decoder.out.jitter`, which reports the delay required by active and pending renditions.
- Bump `@moq/watch` from 0.4.4 to 0.5.0.
- Bump `@moq/boy` from 0.3.0 to 0.3.1 for the updated integration.

## Test plan

- `bun test js/watch/src` (133 passed)
- `nix develop --command just check`
- Local `just dev` browser smoke test: `bbb.hang` played 1280x720 video and audio with advancing traffic and no console errors.

Closes #2743

(Written by GPT-5)