### PR TITLE
docs(js): rewrite the @moq/signals page against the real API

### DIFF
--- a/doc/lib/js/@moq/signals.md
+++ b/doc/lib/js/@moq/signals.md
@@ -221,6 +221,30 @@ new Effect((effect) => {
 
 A stale task may still want to bail for its own reasons, since work outside the effect's scope (plain fields, backoff counters) is not unwound for it. `close()` is permanent; reruns are not.
 
+One boundary is worth knowing, because it is the case where the guarantee above stops holding. A rerun waits at most **5 seconds** for outstanding `spawn` tasks before giving up and starting the next run (with a dev warning). A task that resumes after that cutoff no longer sees a dead run: its `cleanup` lands on the run that has since started, and is torn down with *that* run instead of firing immediately. So a `connect()` that takes longer than 5 seconds hands its socket to an unrelated run rather than closing it promptly.
+
+After `close()` the immediate teardown always holds, since there is no next run to inherit it. For reruns, keep spawned work inside the window, or make cancellation explicit:
+
+```ts
+new Effect((effect) => {
+	// Capture the signal during the run. Reading `effect.abort` after the cutoff returns the
+	// *next* run's controller, which is not aborted, so the check would silently pass.
+	const abort = effect.abort;
+
+	effect.spawn(async () => {
+		const socket = await connect();
+
+		// Past the 5s cutoff, cleanup() would defer to the run that has already started.
+		if (abort.aborted) {
+			socket.close();
+			return;
+		}
+
+		effect.cleanup(() => socket.close());
+	});
+});
+```
+
 ### Scoped helpers
 
 Use these instead of raw timers and listeners so cleanup is automatic. Do **not** reach for `setTimeout`, `setInterval`, `requestAnimationFrame`, or `addEventListener` directly inside an effect.

--- a/doc/lib/js/@moq/signals.md
+++ b/doc/lib/js/@moq/signals.md
@@ -194,6 +194,8 @@ new Effect((effect) => {
 });
 ```
 
+It stops at the first falsy signal, so the ones after it are not tracked on that run. Above, setting `track` while `broadcast` is still `undefined` does not rerun the effect. That is short-circuit tracking, the same as an `effect.get` behind an `if`, and it costs nothing: the values are only used once every signal is truthy, and reaching that state means changing the falsy one, which reruns the effect and reads the rest. Setting `track` first and `broadcast` second still lands on both values.
+
 ### Cleanup
 
 `effect.cleanup(fn)` registers teardown. Everything registered during a run is torn down before the next run and again on `close()`.
@@ -476,7 +478,7 @@ console.log(ticker.out.count.peek()); // read-only to us
 ticker.interval.set(250); // knobs stay writable
 ```
 
-`getter()` throws on a readable this package did not create, since wrapping a foreign object would silently freeze it into a constant that never updates. Pass a `Signal`, `Computed`, or `Once`.
+`getter()` checks the brand, not the class, so a `Signal`, `Computed`, or `Once` from any copy of `@moq/signals` in the dependency tree passes straight through. What it rejects is an unbranded object that merely looks like one (`peek`, `subscribe`, and `changed` of your own), since wrapping that would silently freeze it into a constant that never updates. Anything else is treated as a plain value and wrapped in a fresh `Signal`.
 
 The `#signals` effect stays private and `close()` is the only handle. The two custom elements (`<moq-watch>` and `<moq-publish>`) are the exception: they expose `readonly signals` as the documented place for an app to hang its own reactivity.
 

--- a/doc/lib/js/@moq/signals.md
+++ b/doc/lib/js/@moq/signals.md
@@ -1,19 +1,29 @@
 ---
 title: "@moq/signals"
-description: Reactive signals library
+description: Reactive signals with explicit tracking and automatic cleanup
 ---
 
 # @moq/signals
 
-Reactive signals library used by `@moq/hang` for state management.
+[![npm](https://img.shields.io/npm/v/@moq/signals)](https://www.npmjs.com/package/@moq/signals)
+
+Reactive signals with explicit tracking. No magic or footguns.
+
+`@moq/signals` is the reactive core underneath every other JavaScript package we ship. [@moq/net](/lib/js/@moq/net), [@moq/hang](/lib/js/@moq/hang/), [@moq/watch](/lib/js/@moq/watch), and [@moq/publish](/lib/js/@moq/publish) all expose their state as signals, so learning this package is how you drive the rest.
 
 ## Overview
 
-`@moq/signals` provides:
+Three classes do the work:
 
-- Reactive primitives for state management
-- Framework adapters (React, Solid, Vue)
-- Used internally by `@moq/hang`
+| Class | What it is |
+|---|---|
+| `Signal<T>` | A mutable observable value. |
+| `Computed<T>` | A read-only value derived from other signals. |
+| `Effect` | A reactive scope that reruns when a tracked signal changes, and cleans up after itself. |
+
+Alongside them: `Once<T>` for terminal state that settles exactly once, and `Derived` for a lifecycle-free mapped view.
+
+The key difference from other signals libraries: **`effect.get(signal)` is what subscribes**. Nothing is tracked implicitly. If you want to read a value without subscribing to it, call `signal.peek()`.
 
 ## Installation
 
@@ -23,197 +33,569 @@ bun add @moq/signals
 npm add @moq/signals
 ```
 
-## Basic Usage
+## Signal
 
-### Creating Signals
+A `Signal` holds a reactive value. Construct it with `new`; there is no `signal()` factory.
 
-```typescript
-import { signal } from "@moq/signals";
+```ts
+import { Signal } from "@moq/signals";
 
-const count = signal(0);
+const count = new Signal(0);
 
-// Get current value
-console.log(count.get()); // 0
+count.peek(); // 0, without subscribing
+count.set(1); // notifies subscribers
+count.update((n) => n + 1); // transform the previous value
 
-// Set value
+const dispose = count.subscribe((n) => console.log("count is", n));
+dispose(); // unsubscribe
+```
+
+### Writes are coalesced
+
+Multiple writes in the same microtask collapse into one notification, and subscribers only fire when the value actually changed. A value that moves and moves back within a microtask notifies nobody:
+
+```ts
+const count = new Signal(0);
+count.subscribe((n) => console.log(n)); // never called below
+
 count.set(1);
-
-// Subscribe to changes
-const unsubscribe = count.subscribe((value) => {
-    console.log("Count changed:", value);
-});
-
-// Cleanup
-unsubscribe();
+count.set(0); // net change is zero, so no notification
 ```
 
-### Computed Signals
+Equality is deep for plain objects and arrays, but identity (`===`) for class instances. Two distinct `Broadcast` instances are never equal even if they look alike, which is what you want for handles.
 
-```typescript
-import { signal, computed } from "@moq/signals";
+Override the check when you need to:
 
-const firstName = signal("John");
-const lastName = signal("Doe");
-
-const fullName = computed(() => {
-    return `${firstName.get()} ${lastName.get()}`;
-});
-
-console.log(fullName.get()); // "John Doe"
-
-firstName.set("Jane");
-console.log(fullName.get()); // "Jane Doe"
+```ts
+count.set(0, true); // always notify
+count.set(0, false); // never notify
 ```
 
-### Effects
+`set` stores whatever you hand it, including a function. Use `update` to transform instead:
 
-```typescript
-import { signal, effect } from "@moq/signals";
-
-const count = signal(0);
-
-const cleanup = effect(() => {
-    console.log("Count is:", count.get());
-});
-
-count.set(1); // Logs: "Count is: 1"
-count.set(2); // Logs: "Count is: 2"
-
-cleanup();
+```ts
+const fn = new Signal<() => void>(() => {});
+fn.set(() => console.log("hi")); // stores the function as the value
+count.update((n) => n + 1); // calls the function with the previous value
 ```
 
-## Framework Adapters
+`mutate` edits the current value in place and returns whatever the callback returns, notifying afterwards. Reach for it when the value is a container you would rather not clone:
+
+```ts
+const peers = new Signal(new Set<string>());
+const added = peers.mutate((set) => {
+	const before = set.size;
+	set.add("alice");
+	return set.size !== before;
+});
+```
+
+### Reading over time
+
+Three ways to observe, depending on what you need:
+
+```ts
+// Every change, until you dispose.
+const dispose = count.subscribe((n) => console.log("changed to", n));
+
+// The next change only, as a promise.
+const next = await count.changed();
+
+// The current value now (on a microtask), and every change after.
+const stop = count.watch((n) => console.log("is now", n));
+```
+
+`Signal.from` wraps a plain value but passes an existing signal straight through, which is how components accept `T | Signal<T>` props:
+
+```ts
+const a = Signal.from(5); // new Signal(5)
+const b = Signal.from(count); // count itself
+```
+
+`Signal.race` resolves with the next value from whichever readable changes first:
+
+```ts
+const paused = new Signal(false);
+const volume = new Signal(1);
+
+const winner = await Signal.race(paused, volume); // boolean | number
+```
+
+Identity across package versions uses a `Symbol.for` brand rather than `instanceof`, so two copies of `@moq/signals` in one dependency tree still recognize each other's signals.
+
+## Computed
+
+A `Computed` is a read-only signal derived from others. Its function reads dependencies with `effect.get(...)`, exactly like an effect, and reruns whenever one changes.
+
+```ts
+import { Computed, Signal } from "@moq/signals";
+
+const first = new Signal("Ada");
+const last = new Signal("Lovelace");
+
+const full = new Computed((effect) => `${effect.get(first)} ${effect.get(last)}`);
+
+full.peek(); // undefined: the first run has not completed yet
+await full.changed();
+full.peek(); // "Ada Lovelace"
+```
+
+Two rules that catch people out:
+
+- **The value is `undefined` until the first run completes**, and again after `close()`. Recomputes propagate on a microtask, coalesced and equality-filtered like any other signal. Read a computed inside an effect and handle the `undefined` case.
+- **Keep the function pure.** It derives a value; it does not perform side effects. Use an `Effect` for those.
+
+A standalone `Computed` must be closed to stop recomputing and release its dependencies:
+
+```ts
+full.close();
+```
+
+More often you create one on a long-lived effect, which closes it for you:
+
+```ts
+const signals = new Effect();
+const initials = signals.computed((effect) => `${effect.get(first)[0]}${effect.get(last)[0]}`);
+
+signals.close(); // also closes `initials`
+```
+
+## Effect
+
+An `Effect` runs its function immediately (on a microtask) and reruns whenever a signal it read with `effect.get` changes.
+
+```ts
+import { Effect, Signal } from "@moq/signals";
+
+const name = new Signal("world");
+
+const effect = new Effect((effect) => {
+	const value = effect.get(name); // read AND track
+	console.log(`Hello, ${value}!`);
+});
+
+name.set("signals"); // reruns: "Hello, signals!"
+
+effect.close(); // permanent: runs all cleanup and unsubscribes
+```
+
+`effect.getAll` reads several signals at once and returns `undefined` if any of them is falsy, which collapses the usual pile of guards:
+
+```ts
+const broadcast = new Signal<string | undefined>(undefined);
+const track = new Signal<string | undefined>(undefined);
+
+new Effect((effect) => {
+	const values = effect.getAll([broadcast, track]);
+	if (!values) return;
+
+	const [b, t] = values; // both are strings here
+	console.log(`${b}/${t}`);
+});
+```
+
+### Cleanup
+
+`effect.cleanup(fn)` registers teardown. Everything registered during a run is torn down before the next run and again on `close()`.
+
+```ts
+const url = new Signal("wss://relay.example.com");
+
+new Effect((effect) => {
+	const socket = new WebSocket(effect.get(url));
+	effect.cleanup(() => socket.close());
+});
+```
+
+A run that is already over runs `fn` **immediately**. That is what an async task resuming after a rerun sees, so registering teardown is enough to own a resource: register it unconditionally rather than checking staleness first.
+
+```ts
+new Effect((effect) => {
+	effect.spawn(async () => {
+		const socket = await connect();
+		// The run may already be over here. cleanup() closes the socket right away if so.
+		effect.cleanup(() => socket.close());
+	});
+});
+```
+
+A stale task may still want to bail for its own reasons, since work outside the effect's scope (plain fields, backoff counters) is not unwound for it. `close()` is permanent; reruns are not.
+
+### Scoped helpers
+
+Use these instead of raw timers and listeners so cleanup is automatic. Do **not** reach for `setTimeout`, `setInterval`, `requestAnimationFrame`, or `addEventListener` directly inside an effect.
+
+| Helper | Does |
+|---|---|
+| `effect.timer(fn, ms)` | `setTimeout` that cancels on rerun or close. |
+| `effect.interval(fn, ms)` | `setInterval` that cancels on rerun or close. |
+| `effect.timeout(fn, ms)` | Runs `fn` as a nested effect, then closes that child after `ms`. |
+| `effect.animate(fn)` | `requestAnimationFrame` that cancels on rerun or close. |
+| `effect.event(target, type, fn)` | `addEventListener` removed via an `AbortSignal`. |
+| `effect.subscribe(sig, fn)` | Runs `fn` with the current value now and on every change. |
+| `effect.set(sig, value, cleanup)` | Sets a signal for this run, restoring `cleanup` afterwards. |
+| `effect.proxy(dst, src)` | Copies `src` into `dst` and keeps it in sync. |
+| `effect.computed(fn)` | A `Computed` closed with this effect. |
+| `effect.run(fn)` | A nested effect closed with this effect. |
+| `effect.spawn(fn)` | An async task that blocks the next rerun until it settles. |
+
+```ts
+const visible = new Signal(true);
+const button = document.createElement("button");
+
+new Effect((effect) => {
+	if (!effect.get(visible)) return;
+
+	effect.event(button, "click", () => console.log("clicked"));
+	effect.interval(() => console.log("tick"), 1000);
+	effect.timer(() => console.log("one second later"), 1000);
+});
+```
+
+`effect.set` restores the cleanup value when the run ends. The cleanup argument is only optional when the signal's type already includes `undefined`:
+
+```ts
+const active = new Signal(false);
+
+new Effect((effect) => {
+	if (!effect.get(visible)) return;
+	effect.set(active, true, false); // false again on rerun or close
+});
+```
+
+### Nesting
+
+`effect.run(fn)` creates a child scope that reruns independently and is closed with its parent. Prefer several small effects over one big one, so unrelated dependencies do not retrigger each other.
+
+```ts
+const broadcast = new Signal("demo");
+const volume = new Signal(1);
+
+new Effect((effect) => {
+	console.log("broadcast:", effect.get(broadcast));
+
+	// NOTE: use the nested effect's argument, not the parent's.
+	effect.run((nested) => {
+		console.log("volume:", nested.get(volume));
+	});
+});
+
+volume.set(0.5); // only the nested effect reruns
+```
+
+`run` returns a disposer that closes the child early and releases it from the parent, so a long-lived effect spawning a child per event does not accumulate dead scopes:
+
+```ts
+const signals = new Effect();
+
+const dispose = signals.run((effect) => {
+	console.log("volume:", effect.get(volume));
+});
+
+dispose(); // closed now, not when `signals` closes
+```
+
+### Async
+
+`effect.spawn` runs a task and blocks the next rerun until it settles (with a dev warning after 5 seconds). Three handles tell a task when its run is over:
+
+- `effect.cancel`: a promise that resolves when the current run is torn down.
+- `effect.abort`: an `AbortSignal` that fires at the same moment. Pass it to `fetch`, streams, anything that takes one.
+- `effect.closed`: a promise that resolves on `close()` only, not on a rerun.
+
+```ts
+const endpoint = new Signal("/api/data");
+
+new Effect((effect) => {
+	const url = effect.get(endpoint);
+
+	effect.spawn(async () => {
+		const res = await fetch(url, { signal: effect.abort });
+		console.log(await res.text());
+	});
+});
+```
+
+### Dev warnings
+
+In development builds the library shouts when a lifecycle rule is broken. Each of these means a real bug, not noise:
+
+- A signal passing roughly 100 subscribers throws `"signal has too many subscribers; may be leaking"`. Something is subscribing without disposing.
+- An effect that tracked nothing warns `"Effect did not subscribe to any signals; it will never rerun."` You probably used `peek()` where you meant `effect.get()`.
+- A `FinalizationRegistry` warns when an `Effect` is garbage collected without `close()`.
+
+## Once and GetPromise
+
+A `Once` settles exactly once and then never changes. It is both observable and awaitable, which makes it the shape for terminal state such as "closed": one handle serves the synchronous check, the reactive short-circuit, and the `await`.
+
+Expose it to callers as `GetPromise<T>` so they can observe and await it but not settle it.
+
+```ts
+import { type GetPromise, Once } from "@moq/signals";
+
+class Connection {
+	#closed = new Once<Error | null>();
+
+	/** Settles when the connection closes: `null` for a clean close, an `Error` for an abort. */
+	get closed(): GetPromise<Error | null> {
+		return this.#closed;
+	}
+
+	close(err?: Error): void {
+		// Once.set throws on a second settle, so every close path guards and stays idempotent.
+		if (this.#closed.peek() !== undefined) return;
+		this.#closed.set(err ?? null);
+	}
+}
+```
+
+There are three states, and they need testing explicitly:
+
+| `peek()` | Means |
+|---|---|
+| `undefined` | Still open. This is the pending sentinel, so `T` must not include `undefined`. |
+| `null` | Closed cleanly. |
+| `Error` | Aborted. |
+
+**`if (closed)` means "aborted", not "closed".** Use `closed.peek() !== undefined` for "is it closed".
+
+All three reads off the same handle:
+
+```ts
+import { Effect } from "@moq/signals";
+
+const conn = new Connection();
+
+// Synchronous check.
+if (conn.closed.peek() !== undefined) console.log("already closed");
+
+// Reactive: short-circuit an effect when it closes.
+new Effect((effect) => {
+	if (effect.get(conn.closed) !== undefined) return;
+	// ... still open ...
+});
+
+// Awaited, resolving immediately if it already settled.
+const err = await conn.closed;
+if (err) console.warn("aborted:", err);
+```
+
+`Once` is a thenable, not a `Promise`, so use `.then()` rather than `.finally()` or `.catch()`. It never rejects on its own; an abort arrives as the resolved `Error` value.
+
+## Components: `in`, `out`, and knobs
+
+Every reactive component in `@moq/watch` and `@moq/publish` follows one shape, and yours should too if you are wiring them together.
+
+- **`in`**: the wired dependencies, built in the constructor with `getter(...)` and exposed as `Readonlys<XxxInput>`.
+- **`out`**: derived state, written privately and exposed through `readonlys(...)`. Never hand out a writable `Signal`, since that lets a caller forge state behind the owner's back.
+- **Knobs**: live-editable settings the component does not derive. They stay public writable `Signal`s outside both groups.
+
+`Inputs<I>` derives the constructor argument from the `in` map: every entry becomes optional and accepts a raw value, a `Signal`, or another component's `out` getter.
+
+```ts
+import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
+
+/** The signals a Ticker reads. */
+export type TickerInput = {
+	/** Whether the ticker is running. */
+	enabled: Getter<boolean>;
+};
+
+type TickerOutput = {
+	/** Ticks since the ticker last started. */
+	count: Signal<number>;
+};
+
+/** Constructor options: the wired inputs plus the live-editable knobs. */
+export type TickerProps = Inputs<TickerInput> & {
+	/** Milliseconds between ticks. Also editable later via `ticker.interval`. */
+	interval?: number | Signal<number>;
+};
+
+export class Ticker {
+	readonly in: Readonlys<TickerInput>;
+
+	/** Live-editable tick interval in milliseconds. */
+	readonly interval: Signal<number>;
+
+	readonly #out: TickerOutput = { count: new Signal(0) };
+	readonly out = readonlys(this.#out);
+
+	#signals = new Effect();
+
+	constructor(props?: TickerProps) {
+		this.in = { enabled: getter(props?.enabled ?? true) };
+		this.interval = Signal.from(props?.interval ?? 1000);
+
+		this.#signals.run((effect) => {
+			if (!effect.get(this.in.enabled)) return;
+
+			effect.set(this.#out.count, 0, 0);
+			effect.interval(() => this.#out.count.update((n) => n + 1), effect.get(this.interval));
+		});
+	}
+
+	/** Stops the ticker permanently. */
+	close(): void {
+		this.#signals.close();
+	}
+}
+```
+
+Wiring one component's `out` into another's `in` is then just a field, because `getter()` passes our readables through untouched:
+
+```ts
+const running = new Signal(true);
+const ticker = new Ticker({ enabled: running, interval: 500 });
+
+console.log(ticker.out.count.peek()); // read-only to us
+ticker.interval.set(250); // knobs stay writable
+```
+
+`getter()` throws on a readable this package did not create, since wrapping a foreign object would silently freeze it into a constant that never updates. Pass a `Signal`, `Computed`, `Once`, or `Derived`.
+
+The `#signals` effect stays private and `close()` is the only handle. The two custom elements (`<moq-watch>` and `<moq-publish>`) are the exception: they expose `readonly signals` as the documented place for an app to hang its own reactivity.
+
+## Derived
+
+A `Derived` is a read-only view over other readables, recomputed on every read. It is the lifecycle-free counterpart to `Computed`:
+
+| | `Computed` | `Derived` |
+|---|---|---|
+| Dependencies | Tracked automatically via `effect.get` | Named up front |
+| First read | `undefined` until the first run completes | Correct immediately |
+| Value | Cached, refreshed on a microtask | Recomputed on every read |
+| Teardown | Needs `close()` | None |
+| Compute function | May be expensive | Must be cheap and pure |
+
+Reach for it when a class wants to publish a small mapped view of its own state as part of its public surface. A hand-written object with the same three methods would work until a consumer passed it to `getter()` or an `Inputs` field, which reject a readable this package did not create.
+
+```ts
+import { Derived, Signal } from "@moq/signals";
+
+class Room {
+	#peers = new Signal(new Set<string>());
+
+	/** True while at least one peer is connected. */
+	readonly online = new Derived([this.#peers], (peers) => peers.size > 0);
+
+	join(name: string): void {
+		this.#peers.mutate((peers) => peers.add(name));
+	}
+}
+
+const room = new Room();
+room.online.peek(); // false, no first-run gap
+room.join("alice");
+room.online.peek(); // true
+```
+
+It notifies only when the derived value actually changes, matching `Signal`. A source can move without moving the view: another peer joining an already-online room changes `#peers` but not `online`, so subscribers stay quiet.
+
+## Framework adapters
 
 ### React
 
-```typescript
-import { signal } from "@moq/signals";
-import { react } from "@moq/signals/react";
-import { useEffect, useState } from "react";
+```tsx
+import { Signal } from "@moq/signals";
+import { useSignal, useValue } from "@moq/signals/react";
 
-const count = signal(0);
+const count = new Signal(0);
 
 function Counter() {
-    const reactiveCount = react(count);
+	const value = useValue(count); // read-only
+	const [other, setOther] = useSignal(count); // read-write, like useState
 
-    return (
-        <div>
-            Count: {reactiveCount()}
-            <button onClick={() => count.set(count.get() + 1)}>
-                Increment
-            </button>
-        </div>
-    );
+	return (
+		<button type="button" onClick={() => setOther(other + 1)}>
+			Count: {value}
+		</button>
+	);
 }
 ```
+
+`useValue` is a `useSyncExternalStore` subscription, so it works with concurrent rendering. `useSignal` accepts a value or an updater function, like `useState`.
 
 ### SolidJS
 
-```typescript
-import { signal } from "@moq/signals";
-import { solid } from "@moq/signals/solid";
+```ts
+import { Signal } from "@moq/signals";
+import { createAccessor, createPair, createSetter } from "@moq/signals/solid";
 
-const count = signal(0);
+const count = new Signal(0);
 
-function Counter() {
-    const solidCount = solid(count);
-
-    return (
-        <div>
-            Count: {solidCount()}
-            <button onClick={() => count.set(count.get() + 1)}>
-                Increment
-            </button>
-        </div>
-    );
-}
+const value = createAccessor(count); // Accessor<number>, unsubscribes on cleanup
+const setValue = createSetter(count); // Setter<number>, writes through
+const [get, set] = createPair(count); // both at once
 ```
 
-### Vue
+### DOM
 
-```typescript
-import { signal } from "@moq/signals";
-import { vue } from "@moq/signals/vue";
+`@moq/signals/dom` builds elements and reactive content on top of an `Effect`, with cleanup handled for you. This is what the `@moq/watch` and `@moq/publish` UI components use.
 
-const count = signal(0);
+```ts
+import { Effect, Signal } from "@moq/signals";
+import { create, render, setClass } from "@moq/signals/dom";
 
-// In Vue component
-const vueCount = vue(count);
+const label = new Signal("hello");
+const highlight = new Signal(false);
+
+const container = create("div", { className: "row" });
+
+new Effect((effect) => {
+	// Removed again when the effect reruns or closes.
+	render(effect, container, effect.get(label));
+
+	if (effect.get(highlight)) {
+		setClass(effect, container, "highlight");
+	}
+});
 ```
 
 ## Usage with @moq/hang
 
-All `@moq/hang` properties are signals:
+Everything the media packages expose is a signal, so an app reads them the same way it reads its own state:
 
-```typescript
+```ts
 import "@moq/watch/element";
-import { react } from "@moq/signals/react";
 
-const watch = document.querySelector("moq-watch") as MoqWatch;
+const watch = document.querySelector("moq-watch");
+if (!watch) throw new Error("no <moq-watch> on the page");
 
-// Convert to React-compatible signal
-const volume = react(watch.volume);
-const paused = react(watch.paused);
+// The element exposes its Effect so an app can hang reactivity off it.
+watch.signals.run((effect) => {
+	console.log("volume:", effect.get(watch.controls.volume));
+	console.log("paused:", effect.get(watch.controls.paused));
+});
 
-function Controls() {
-    return (
-        <div>
-            <span>Volume: {volume()}</span>
-            <span>Paused: {paused() ? "Yes" : "No"}</span>
+watch.controls.volume.set(0.5);
+```
 
-            <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={volume()}
-                onChange={(e) => watch.volume.set(Number(e.target.value))}
-            />
-        </div>
-    );
+Combine that with an adapter and the same signals drive a React or Solid tree:
+
+```tsx
+import { useValue } from "@moq/signals/react";
+import type MoqWatch from "@moq/watch/element";
+
+function Controls({ watch }: { watch: MoqWatch }) {
+	const volume = useValue(watch.controls.volume);
+
+	return (
+		<input
+			type="range"
+			min="0"
+			max="1"
+			step="0.1"
+			value={volume}
+			onChange={(e) => watch.controls.volume.set(Number(e.target.value))}
+		/>
+	);
 }
 ```
 
-## API Reference
+## Related Packages
 
-### signal(initialValue)
-
-Create a new reactive signal.
-
-```typescript
-const s = signal<T>(initialValue: T): Signal<T>
-```
-
-### computed(fn)
-
-Create a computed signal that derives from other signals.
-
-```typescript
-const c = computed<T>(fn: () => T): ReadonlySignal<T>
-```
-
-### effect(fn)
-
-Run a side effect when signals change.
-
-```typescript
-const cleanup = effect(fn: () => void): () => void
-```
-
-### batch(fn)
-
-Batch multiple signal updates.
-
-```typescript
-batch(() => {
-    signal1.set(1);
-    signal2.set(2);
-    // Subscribers notified once at the end
-});
-```
-
-## Next Steps
-
-- Use with [@moq/hang](/lib/js/@moq/hang/)
-- View [code examples](https://github.com/moq-dev/moq/tree/main/js)
-- Learn about [Web Components](/lib/js/env/web)
+- **[@moq/net](/lib/js/@moq/net)**: pub/sub transport, with `closed` state as `GetPromise`
+- **[@moq/hang](/lib/js/@moq/hang/)**: media catalog and container
+- **[@moq/watch](/lib/js/@moq/watch)** and **[@moq/publish](/lib/js/@moq/publish)**: the `in`/`out`/knobs convention in practice
+- **[Web Components](/lib/js/env/web)**: the custom elements built on these signals

--- a/doc/lib/js/@moq/signals.md
+++ b/doc/lib/js/@moq/signals.md
@@ -21,7 +21,7 @@ Three classes do the work:
 | `Computed<T>` | A read-only value derived from other signals. |
 | `Effect` | A reactive scope that reruns when a tracked signal changes, and cleans up after itself. |
 
-Alongside them: `Once<T>` for terminal state that settles exactly once, and `Derived` for a lifecycle-free mapped view.
+Alongside them, `Once<T>` holds terminal state that settles exactly once.
 
 The key difference from other signals libraries: **`effect.get(signal)` is what subscribes**. Nothing is tracked implicitly. If you want to read a value without subscribing to it, call `signal.peek()`.
 
@@ -476,45 +476,9 @@ console.log(ticker.out.count.peek()); // read-only to us
 ticker.interval.set(250); // knobs stay writable
 ```
 
-`getter()` throws on a readable this package did not create, since wrapping a foreign object would silently freeze it into a constant that never updates. Pass a `Signal`, `Computed`, `Once`, or `Derived`.
+`getter()` throws on a readable this package did not create, since wrapping a foreign object would silently freeze it into a constant that never updates. Pass a `Signal`, `Computed`, or `Once`.
 
 The `#signals` effect stays private and `close()` is the only handle. The two custom elements (`<moq-watch>` and `<moq-publish>`) are the exception: they expose `readonly signals` as the documented place for an app to hang its own reactivity.
-
-## Derived
-
-A `Derived` is a read-only view over other readables, recomputed on every read. It is the lifecycle-free counterpart to `Computed`:
-
-| | `Computed` | `Derived` |
-|---|---|---|
-| Dependencies | Tracked automatically via `effect.get` | Named up front |
-| First read | `undefined` until the first run completes | Correct immediately |
-| Value | Cached, refreshed on a microtask | Recomputed on every read |
-| Teardown | Needs `close()` | None |
-| Compute function | May be expensive | Must be cheap and pure |
-
-Reach for it when a class wants to publish a small mapped view of its own state as part of its public surface. A hand-written object with the same three methods would work until a consumer passed it to `getter()` or an `Inputs` field, which reject a readable this package did not create.
-
-```ts
-import { Derived, Signal } from "@moq/signals";
-
-class Room {
-	#peers = new Signal(new Set<string>());
-
-	/** True while at least one peer is connected. */
-	readonly online = new Derived([this.#peers], (peers) => peers.size > 0);
-
-	join(name: string): void {
-		this.#peers.mutate((peers) => peers.add(name));
-	}
-}
-
-const room = new Room();
-room.online.peek(); // false, no first-run gap
-room.join("alice");
-room.online.peek(); // true
-```
-
-It notifies only when the derived value actually changes, matching `Signal`. A source can move without moving the view: another peer joining an already-online room changes `#peers` but not `online`, so subscribers stay quiet.
 
 ## Framework adapters
 


### PR DESCRIPTION
## Summary

- `doc/lib/js/@moq/signals.md` documented an API that has never existed. It showed `import { signal, computed, effect } from "@moq/signals"` with `signal(0)` / `computed(() => ...)` / `effect(() => ...)` / `count.get()`, plus a `batch()` helper and a `@moq/signals/vue` adapter. The package exports classes (`Signal`, `Computed`, `Effect`, `Once`), has no factory functions and no `batch()`, and ships only the `./react`, `./solid`, and `./dom` subpaths.
- The `@moq/hang` example was wrong in the same way: `watch.volume` is really `watch.controls.volume`, and `MoqWatch` is a default export whose `HTMLElementTagNameMap` augmentation makes the `as MoqWatch` cast unnecessary.
- Rewritten against `js/signals/src/index.ts`, and widened past the old page's three toy snippets to the parts that actually bite:
  - `Signal`: microtask coalescing, deep-vs-identity equality, the `notify` override, `set` vs `update` vs `mutate`, `subscribe`/`changed`/`watch`, `Signal.from`, `Signal.race`, the `Symbol.for` brand.
  - `Computed`: `undefined` until the first run completes, purity, standalone `close()` vs `effect.computed()`.
  - `Effect` lifecycle: `get`/`getAll`, `cleanup` and its boundary (below), a table of the scoped helpers with a "don't use raw `setTimeout`/`addEventListener`" warning, `run` and its early disposer, `spawn`/`cancel`/`abort`/`closed`, and the three DEV warnings.
  - `Once`/`GetPromise` as the terminal-state shape, with the three states (`undefined` pending / `null` clean close / `Error` abort), the `if (closed)` means "aborted" trap, and the thenable-not-Promise caveat.
  - The `in` / `out` / knobs component convention, with a complete worked component using `getter`, `readonlys`, `Inputs`, and `Readonlys`.

## The cleanup guarantee is bounded (2nd commit)

The first draft repeated, from the `Effect.cleanup` doc comment, that a run which is already over runs teardown **immediately**, so an async task can register cleanup unconditionally. That holds only inside the 5 second window a rerun waits for outstanding `spawn` tasks. Past the cutoff `#stale` has already been reset and the next run has opened, so `cleanup` lands on that unrelated run instead.

Measured, in a reproduction against the real class:

| task duration | cleanup registered | cleanup ran |
|---|---|---|
| 200ms | t+209ms | t+209ms, immediately, as documented |
| 6000ms | t+6009ms | t+7004ms, deferred to the newer run, only on `close()` |

The page now states the boundary and shows the guard. The guard has a trap of its own worth naming, also verified: `effect.abort` is a getter over the *current* run's controller, so a stale task reading it after the cutoff gets the next run's un-aborted signal and the check silently passes. The signal has to be captured during the run.

The same unconditional claim lives in the `Effect.cleanup` doc comment and in `js/CLAUDE.md`, which is where this page took it from. Those are left for a follow-up rather than pulling `js/` into a docs-only PR.

## Derived was split out (3rd commit)

`Derived` is not on `main` or `dev`; it exists only on the #2705 branch. Documenting it here would have described a class the published package does not export, which is the same failure mode this PR fixes. It now lives in **#2753**, stacked on this branch and blocked on #2705. This PR describes only what `main` ships today.

## Public API changes

None. Documentation only.

## Test plan

- Extracted all 30 fenced `ts`/`tsx` blocks into a scratch workspace package, resolved `@moq/signals` (and `/react`, `/solid`, `/dom`) and `@moq/watch/element` to the actual sources, and ran `tsc` under the repo's strict base config: zero errors, against a pristine `main` `js/signals/src/index.ts`. Confirmed the harness was not vacuously passing by injecting deliberate type errors and seeing both reported. It caught one real bug on the way (the `Once` reads sample used `Effect` with no import), now fixed. The scratch package is not part of this diff.
- Reproduced the 5s cleanup boundary and the `effect.abort` staleness trap directly against `Effect`, numbers above.
- `nix develop --command just check` passes, including the VitePress build (so the internal links resolve) and `bun remark . --quiet --frail`.

## Cross-Package Sync

No rows apply. This is a doc-only change with no code, wire, or CLI surface touched. `js/CLAUDE.md`'s "Signals + Effect" section was the source summary; it is accurate except for the cleanup sentence noted above, which is filed as a follow-up.

(Written by Opus 5)