### PR TITLE
docs(js): document Derived on the @moq/signals page

### DIFF
--- a/doc/lib/js/@moq/signals.md
+++ b/doc/lib/js/@moq/signals.md
@@ -21,7 +21,7 @@ Three classes do the work:
 | `Computed<T>` | A read-only value derived from other signals. |
 | `Effect` | A reactive scope that reruns when a tracked signal changes, and cleans up after itself. |
 
-Alongside them, `Once<T>` holds terminal state that settles exactly once.
+Alongside them: `Once<T>` for terminal state that settles exactly once, and `Derived` for a lifecycle-free mapped view.
 
 The key difference from other signals libraries: **`effect.get(signal)` is what subscribes**. Nothing is tracked implicitly. If you want to read a value without subscribing to it, call `signal.peek()`.
 
@@ -478,9 +478,45 @@ console.log(ticker.out.count.peek()); // read-only to us
 ticker.interval.set(250); // knobs stay writable
 ```
 
-`getter()` checks the brand, not the class, so a `Signal`, `Computed`, or `Once` from any copy of `@moq/signals` in the dependency tree passes straight through. What it rejects is an unbranded object that merely looks like one (`peek`, `subscribe`, and `changed` of your own), since wrapping that would silently freeze it into a constant that never updates. Anything else is treated as a plain value and wrapped in a fresh `Signal`.
+`getter()` checks the brand, not the class, so a `Signal`, `Computed`, `Once`, or `Derived` from any copy of `@moq/signals` in the dependency tree passes straight through. What it rejects is an unbranded object that merely looks like one (`peek`, `subscribe`, and `changed` of your own), since wrapping that would silently freeze it into a constant that never updates. Anything else is treated as a plain value and wrapped in a fresh `Signal`.
 
 The `#signals` effect stays private and `close()` is the only handle. The two custom elements (`<moq-watch>` and `<moq-publish>`) are the exception: they expose `readonly signals` as the documented place for an app to hang its own reactivity.
+
+## Derived
+
+A `Derived` is a read-only view over other readables, recomputed on every read. It is the lifecycle-free counterpart to `Computed`:
+
+| | `Computed` | `Derived` |
+|---|---|---|
+| Dependencies | Tracked automatically via `effect.get` | Named up front |
+| First read | `undefined` until the first run completes | Correct immediately |
+| Value | Cached, refreshed on a microtask | Recomputed on every read |
+| Teardown | Needs `close()` | None |
+| Compute function | May be expensive | Must be cheap and pure |
+
+Reach for it when a class wants to publish a small mapped view of its own state as part of its public surface. A hand-written object with the same three methods would work until a consumer passed it to `getter()` or an `Inputs` field, which reject a readable this package did not create.
+
+```ts
+import { Derived, Signal } from "@moq/signals";
+
+class Room {
+	#peers = new Signal(new Set<string>());
+
+	/** True while at least one peer is connected. */
+	readonly online = new Derived([this.#peers], (peers) => peers.size > 0);
+
+	join(name: string): void {
+		this.#peers.mutate((peers) => peers.add(name));
+	}
+}
+
+const room = new Room();
+room.online.peek(); // false, no first-run gap
+room.join("alice");
+room.online.peek(); // true
+```
+
+It notifies only when the derived value actually changes, matching `Signal`. A source can move without moving the view: another peer joining an already-online room changes `#peers` but not `online`, so subscribers stay quiet.
 
 ## Framework adapters
 


### PR DESCRIPTION
## Summary

- Adds the `Derived` section to `doc/lib/js/@moq/signals.md`: what it buys over `Computed` (sources named up front instead of tracked, a correct first read rather than `undefined`, no `close()`), what it costs (`fn` runs on every read, so it must stay cheap and pure), and the notify-on-actual-change behavior that lets a source move without moving the view.
- Also restores the two supporting mentions: the `Overview` line and the list of readables `getter()` accepts.

## Why this was split from #2752

An adversarial review flagged the section in #2752: `Derived` does not exist on `main` or `dev`. It lives only in commit `3870cd1a` on `claude/js-origin-extract` (#2705). #2752 therefore shipped without it, describing only what `main` exports, and the section was parked here.

## Merging ahead of the implementation

This lands **before** #2705, which is the PR that actually adds the class, so the published page documents `Derived` ahead of the code. Until #2705 merges to `dev` and `dev` reaches `main`, a reader who copies the sample gets a failing import. Deliberate and self-correcting once #2705 propagates; flagged here so the gap is on the record rather than a surprise.

## Public API changes

None. Documentation only.

## Test plan

- Extracted all 31 fenced code blocks on the page and type-checked them under the repo's strict base config, with `js/signals/src/index.ts` taken from `3870cd1a` so `Derived` resolves: zero errors. This confirms the `new Derived([this.#peers], (peers) => peers.size > 0)` sample infers correctly through the `const S extends readonly Getter<unknown>[]` generic and that `peek()` returns `boolean`.
- `bun remark . --quiet --frail` passes.
- `just check` on this branch cannot exercise the sample, since `Derived` is not in the tree here. Worth re-running once #2705 lands.

(Written by Opus 5)