### PR TITLE
fix(net): stop treating the subscription end group as a terminator

### DIFF
--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -377,13 +377,13 @@ test("lite draft-05: subscribe end is 0 when no groups were produced", async () 
 type Served = { sequence: number; frameStart: number; payloads: string[] };
 
 /**
- * Serves `groups` (frame payloads per group, keyed by sequence) under `bounds`, and
- * reports every group stream that reached the wire plus the resolved SUBSCRIBE_START.
+ * Serves `groups` (frame payloads per group, keyed by sequence) under `bounds`, and reports
+ * every group stream that reached the wire plus the resolved SUBSCRIBE_START/SUBSCRIBE_END.
  */
 async function serve(
 	groups: Record<number, string[]>,
 	bounds: { startGroup?: number; startFrame?: number; endGroup?: number; endFrame?: number },
-): Promise<{ start?: number; served: Served[] }> {
+): Promise<{ start?: number; end: number; served: Served[] }> {
 	const pair = createMockTransportPair(ALPN_06_WIP);
 	const publisher = new Publisher(pair.server, Version.DRAFT_06, randomOrigin());
 
@@ -448,12 +448,16 @@ async function serve(
 		}
 
 		let start: number | undefined;
+		let end: number;
 		for (;;) {
 			const resp = await decodeSubscribeResponse(client.reader, Version.DRAFT_06);
 			if ("start" in resp) start = resp.start.group;
-			if ("end" in resp) break;
+			if ("end" in resp) {
+				end = resp.end.group;
+				break;
+			}
 		}
-		return { start, served };
+		return { start, end, served };
 	} finally {
 		// Settles the pending read as well as dropping the stream.
 		await reader.cancel();
@@ -511,6 +515,17 @@ test("lite draft-06: groups below the start group are not served", async () => {
 test("lite draft-06: groups past the end group are not served", async () => {
 	const { served } = await serve({ 0: ["w"], 1: ["x"], 2: ["y"], 3: ["z"] }, { startGroup: 1, endGroup: 2 });
 	expect(served.map((s) => s.sequence)).toEqual([1, 2]);
+});
+
+// The end group is a serving cap, not a subscription terminator: groups above it stay
+// buffered for a SUBSCRIBE_UPDATE that raises it. So the track ending has to reach the
+// subscriber on its own rather than riding the loop that drains those groups, and it
+// reports the track's live edge (group 3 is producible) instead of the range delivered
+// under the cap. Reporting 3 here would promise an ending a later update sends past.
+test("lite draft-06: subscribe end reports the track edge, not the capped range", async () => {
+	const { served, end } = await serve({ 0: ["w"], 1: ["x"], 2: ["y"], 3: ["z"] }, { startGroup: 1, endGroup: 2 });
+	expect(served.map((s) => s.sequence)).toEqual([1, 2]);
+	expect(end).toBe(4);
 });
 
 // Group streams open with waitUntilAvailable, so a browser at its concurrent stream cap

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -488,10 +488,13 @@ export class Publisher {
 		const emitRange = supportsTrackStream(this.version);
 		let startSent = false;
 
-		// The exclusive end of the delivered range. recvGroup is arrival-ordered rather than
-		// sequence-ordered, so this tracks the max and not the last group seen. 0 is already
-		// the encoding for a track that produced no groups.
-		let end = 0;
+		// The exclusive end of the range: "the first group that will never be delivered", so it
+		// is the track's live edge and not the delivered range. A group parked above
+		// `bounds.endGroup` is undelivered but very much producible, and a SUBSCRIBE_UPDATE
+		// raising the cap serves it, so bounding this by what we sent would promise an ending
+		// we then send groups past. `latest` is undefined until the first group, which is the
+		// 0 a track that produced none already encodes.
+		const boundary = () => (track.latest() ?? -1) + 1;
 
 		// One ranking for the whole subscription, shared by every group it serves.
 		const priority = new Priority(track);
@@ -512,10 +515,44 @@ export class Publisher {
 			() => unsubscribe(),
 		);
 
+		// The track ending and this loop ending are separate events, so SUBSCRIBE_END can't
+		// wait for the loop. `track.endAt(bounds.endGroup)` parks `nextGroup` with the groups
+		// above the cap still buffered, waiting for a SUBSCRIBE_UPDATE that raises it, so a
+		// capped subscription reaches its end group and then sits there indefinitely. Report
+		// the ending the moment the track closes and keep serving.
+		//
+		// Only a clean close is an ending, and it's attached once: an abort surfaces through
+		// `nextGroup` below (which resets the stream rather than claiming the track ended),
+		// and `closed` is a signal, so a `then` per iteration would pile up subscribers.
+		const ended = Symbol("ended");
+		const trackEnded = new Promise<symbol>((resolve) => {
+			void track.closed.then((err) => {
+				if (!err) resolve(ended);
+			});
+		});
+		let endSent = false;
+
 		try {
 			for (;;) {
+				// One `nextGroup` spans the SUBSCRIBE_END interleave below, so a group that
+				// lands while it goes out is still picked up rather than dropped with the race.
 				const next = track.nextGroup();
-				const group = await Promise.race([next, stream.closed]);
+
+				let group: Awaited<typeof next>;
+				for (;;) {
+					const racing: PromiseLike<unknown>[] = [next, stream.closed];
+					if (emitRange && !endSent) racing.push(trackEnded);
+
+					const result = await Promise.race(racing);
+					if (result !== ended) {
+						group = result as Awaited<typeof next>;
+						break;
+					}
+
+					endSent = true;
+					await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
+				}
+
 				if (!group) {
 					next.then((group) => group?.close()).catch(() => {});
 					break;
@@ -534,7 +571,6 @@ export class Publisher {
 					startSent = true;
 					await encodeSubscribeResponse(stream, { start: new SubscribeStart(group.sequence) }, this.version);
 				}
-				end = Math.max(end, group.sequence + 1);
 
 				void this.#runGroup({
 					sub,
@@ -545,11 +581,10 @@ export class Publisher {
 					start: range.start,
 					end: range.end,
 				});
-				if (bounds.endGroup !== undefined && group.sequence >= bounds.endGroup) break;
 			}
 
-			if (emitRange) {
-				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(end) }, this.version);
+			if (emitRange && !endSent) {
+				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
 			}
 
 			console.debug(`publish close: broadcast=${broadcast} track=${track.name}`);


### PR DESCRIPTION
## Summary

`dev` is red: `integration: lite applies initial and updated group bounds` fails on the first `nextGroup()`, and subscription bounds deliver nothing at all (verified for both pre-written and live-arriving groups).

**Root cause.** The merge in af7b5720f resolved a conflict in `js/net/src/lite/publisher.ts` with a line present in neither parent (it shows as `++` in `git show af7b5720f`):

```js
if (bounds.endGroup !== undefined && group.sequence >= bounds.endGroup) break;
```

The end group is a serving cap, not a subscription terminator. `rs/moq-net/src/lite/publisher.rs` says so verbatim, and moq-lite says SUBSCRIBE_END "bounds the range but does not by itself end the stream". That `break` FINs the subscribe stream immediately after queueing the last group's `#runGroup`, before those unidirectional streams have written a byte, so the subscriber reads the FIN as the end of the subscription, closes the local producer, and drops them. It also made the SUBSCRIBE_UPDATE bound-raise path unreachable.

**A second bug it was masking.** Removing the `break` makes `lite draft-06: groups past the end group are not served` hang. That test already failed on the pre-merge parent d7c58d75b (confirmed on a clean worktree), so the `break` had been papering over it. `Subscriber.nextGroup` parks when the track closes with groups buffered above the `endAt` cap, which is deliberate and mirrors Rust's `poll_next_in_range` ("Pending (not None) so the consumer is parked rather than told the stream is over"). The publisher was driving SUBSCRIBE_END off `nextGroup` draining rather than off the track ending, so a capped subscription never reported one. Rust keeps those two events separate (`Recv::Boundary` from `poll_finished` vs `Recv::Finished`), so `#runTrack` now does too. Fixing this in `track.ts` instead was considered and rejected: it would diverge a core primitive from its documented Rust counterpart to paper over a publisher-layer bug.

**Boundary value.** The above makes SUBSCRIBE_END observable under a cap, where it was wrong. It is specified as "the first group that will never be delivered", so it now reports the track's live edge rather than `max-delivered + 1`, which would promise an ending a later update sends groups past. The two coincide without a cap, so the three existing `subscribeEnd` tests are unchanged.

## Public API changes

None. No new, renamed, removed, or signature-changed exported item. `Publisher` is `@internal`; `nextGroup`/`startAt`/`endAt` are untouched. Targets `dev` only because both bugs are `dev`-only (`main` has no subscription bounds), not because anything breaks.

## Cross-package sync

No paired updates owed. No message encoding changed, only when SUBSCRIBE_END is sent and what value it carries, both of which now conform to draft text and Rust behavior that already exist. `js/net/src/ietf/publisher.ts` was checked and has no equivalent hole: `git show af7b5720f -- js/net/src/ietf/publisher.ts` is empty (git merged it cleanly, with no hand-editing), the IETF path carries no group bounds on the wire (`Subscribe.decode` keeps only requestId/namespace/name/priority and rejects any filter type but `0x1`/`0x2`), and it serves via `recvGroup()`, which ignores the `endAt` cap. An IETF bounds test would require first adding IETF bounds support, which is a feature rather than part of this fix.

## Test plan

- `bun test` in `js/net`: 391 pass, 0 fail.
- Each new assertion verified to fail without its fix, and the pre-merge hang reproduced on a clean `d7c58d75b` worktree so it was not misattributed to the merge.
- `nix develop --command just check`: clean.
- Codex adversarial review: approve, no material findings.

## Notes

The merge also left `ServeGroup` in `lite/publisher.ts` as a near-duplicate of the new `RunGroup`, surviving only to derive `ServeFetch` via `Omit`. Left alone as unrelated to the bug, but worth collapsing.

(Written by Opus 5)
