### PR TITLE
feat(net): solicit announces lazily, on first announce interest

### DIFF
--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -349,6 +349,7 @@ When the stream is closed, the subscriber MUST assume that all broadcasts are no
 
 Path prefix matching and equality is done on a byte-by-byte basis.
 There MAY be multiple Announce Streams, potentially containing overlapping prefixes, that get their own ANNOUNCE_OK + announcements.
+A subscriber MAY open and close Announce Streams at any point during the session, e.g. opening one only once it has a consumer for the announcements and closing it when the last one leaves; closing the stream is how announce interest is withdrawn.
 
 #### Routing {#routing}
 Each advertisement carries an `Epoch` identifying the generation of content at the path, the path of Hop IDs it traversed, and an accumulated Route Cost (see [ANNOUNCE_START](#announce-start)), which relays use to build a loop-free mesh.
@@ -1320,6 +1321,7 @@ The `Message Length` describes the payload size on the wire.
 - Replaced the duplicate-`active` restart idiom with ANNOUNCE_UPDATE; a second ANNOUNCE_START for an already-available path is now a protocol violation.
 - Added an `Epoch` to ANNOUNCE_START and ANNOUNCE_UPDATE: a per-path content generation minted by the original publisher and forwarded unchanged, 0 meaning unspecified. The highest Epoch wins (non-zero outranks 0) and replacement is decided by value rather than arrival order; equal non-zero Epochs splice, and the first entry of the path remains the identity only when both are 0. That fallback identity requires a non-zero first entry: 0 identifies nothing, so it never proves continuity, and publishers SHOULD assign themselves a Hop ID (a random per-session value suffices).
 - Added an `Ended` flag to ANNOUNCE_START and ANNOUNCE_UPDATE, and as an opt-in filter on ANNOUNCE_REQUEST: ended broadcasts reject SUBSCRIBE, are read via FETCH, and are only announced to subscribers that asked for them.
+- Stated that a subscriber MAY open and close Announce Streams at any point in a session, and that closing one withdraws its announce interest.
 - Added an `Epoch` to SUBSCRIBE, FETCH, and TRACK (0 = current, mismatch = reset) and the resolved `Epoch` to TRACK_INFO, so metadata and groups always come from the same generation and requests cannot race a replacement.
 - Added a `Route Cost` field to ANNOUNCE_START and ANNOUNCE_UPDATE: the accumulated cost of the transfers a subscription via this advertisement would newly cause. Route selection prefers the lowest cost, with path length as the tie-break, and the most recently received advertisement below that.
 - Added a SETUP `Cost` parameter (0x4) declaring what subscribing from the sender costs, added by the receiver to every announcement that sender forwards. Both endpoints send their own, so the two directions are priced independently, and a receiver MAY charge a locally configured value instead. Unpriced directions default to 1, degrading to shortest-path routing.

--- a/rs/moq-net/src/connecting.rs
+++ b/rs/moq-net/src/connecting.rs
@@ -1,9 +1,14 @@
 //! Tracks a session's connection progress so `connect()` can block until it's done.
 //!
-//! Today "connecting" means every announce-prefix stream has received its initial
-//! set (AnnounceInit for Lite01/02, AnnounceOk + N for Lite05). It's deliberately
-//! generic so future work (e.g. extension negotiation) can register additional
-//! steps that must finish before a session is considered connected.
+//! Today "connecting" means every announce-prefix stream opened during connect has
+//! received its initial set (AnnounceInit for Lite01/02, AnnounceOk + N for Lite05).
+//! Announce streams are solicited lazily, so this only gates a session whose origin
+//! already has announce interest when it starts; one solicited later syncs through
+//! the interest ledger instead. The same drop-based countdown also reports a
+//! solicitor synced: moq-lite counts announce prefixes and moq-transport counts
+//! SUBSCRIBE_NAMESPACE responses. It's deliberately generic so future work (e.g.
+//! extension negotiation) can register additional steps that must finish before a
+//! session is considered connected.
 //!
 //! Backed by `kio`: each in-flight step holds a [`ConnectingProducer`], and the
 //! session is connected once they've all been dropped (which closes the channel).
@@ -22,7 +27,7 @@ use kio::{Consumer, Producer, Waiter};
 /// The inner producer exists purely for its `Clone` (adds a step) and `Drop` (closes
 /// the channel when the last one goes); it is never read, hence the allow.
 #[derive(Clone)]
-pub(super) struct ConnectingProducer(#[allow(dead_code)] Producer<()>);
+pub(crate) struct ConnectingProducer(#[allow(dead_code)] Producer<()>);
 
 /// Consumer side: returned by [`crate::lite::start`] and awaited by `connect()`.
 pub(crate) struct Connecting(Consumer<()>);
@@ -30,7 +35,7 @@ pub(crate) struct Connecting(Consumer<()>);
 impl Connecting {
 	/// Create a producer/consumer pair. The consumer reports "connected" once every
 	/// [`ConnectingProducer`] (the original plus any clones) has been dropped.
-	pub(super) fn new() -> (ConnectingProducer, Self) {
+	pub(crate) fn new() -> (ConnectingProducer, Self) {
 		let producer = Producer::new(());
 		let consumer = producer.consume();
 		(ConnectingProducer(producer), Self(consumer))

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -1,3 +1,5 @@
+use crate::connecting::Connecting;
+use crate::model::interest;
 use crate::origin;
 use crate::{
 	Error, Origin, SessionError,
@@ -85,20 +87,36 @@ pub fn start<S: crate::transport::poll::Session>(
 	// server to open connections (draft-19 sect 10.4).
 	let (goaway_handle, goaway) = crate::goaway::Handle::new(!client);
 
+	// Our own Hop ID, taken from whichever origin the caller actually supplied so
+	// every session out of this process stamps the same one and cross-session loop
+	// detection works. Read BEFORE the placeholders below: their ids are random and
+	// identify nothing, so declaring one would compare incoming paths against an
+	// identity no other session shares.
+	let self_origin = self_origin(publish.as_ref(), subscribe.as_ref());
+
+	// moq-transport threads concrete origins through the publisher/subscriber.
+	// An unset half gets an empty origin: an empty publish origin announces
+	// nothing, and an empty subscribe origin issues no SUBSCRIBE_NAMESPACE.
+	//
+	// The session's identity in the announce-interest ledger: interest the
+	// publisher half raises on behalf of this peer is tagged with it, so the
+	// subscriber half doesn't treat the peer's own solicitation as demand and
+	// reciprocate.
+	let session_id = interest::SessionId::new();
+	let publish = publish
+		.map(|p| p.on_behalf_of(session_id))
+		.unwrap_or_else(|| origin::Producer::empty(Origin::random()).consume());
+	let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Origin::random()));
+
+	// Lazy announce solicitation: SUBSCRIBE_NAMESPACE waits until the origin has
+	// announce interest to serve (see `lite::Subscriber::run_announce` for the
+	// full story). Attached here rather than inside the driver, like the lite
+	// subscriber does at construction: a request issued the instant `start`
+	// returns must see the solicitor and wait for its solicitation instead of
+	// settling on a cold table.
+	let solicitor = subscribe.solicitor(session_id);
+
 	let driver = async move {
-		// Our own Hop ID, taken from whichever origin the caller actually supplied so
-		// every session out of this process stamps the same one and cross-session loop
-		// detection works. Read BEFORE the placeholders below: their ids are random and
-		// identify nothing, so declaring one would compare incoming paths against an
-		// identity no other session shares.
-		let self_origin = self_origin(publish.as_ref(), subscribe.as_ref());
-
-		// moq-transport threads concrete origins through the publisher/subscriber.
-		// An unset half gets an empty origin: an empty publish origin announces
-		// nothing, and an empty subscribe origin issues no SUBSCRIBE_NAMESPACE.
-		let publish = publish.unwrap_or_else(|| origin::Producer::empty(Origin::random()).consume());
-		let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Origin::random()));
-
 		// The peer's cluster options. Seeded now when its SETUP was already read
 		// (a gated server accept), and filled by the uni loop otherwise. A version that
 		// cannot negotiate the extension is settled immediately so nothing blocks on it.
@@ -192,10 +210,22 @@ pub fn start<S: crate::transport::poll::Session>(
 				// One SUBSCRIBE_NAMESPACE per permitted prefix, like `lite::Subscriber`:
 				// the scope is what we may ask for, and it is not the origin's root.
 				let mut sub_ns_run = std::pin::pin!(err_only(async {
+					// Parked until something is interested in announcements; a session
+					// nobody reads announcements from never solicits any.
+					solicitor.needed().await;
+					// Reports the solicitor synced once every prefix has its response (or
+					// died trying). moq-transport marks no end to the initial set (there is
+					// no ANNOUNCE_OK counterpart with a count), so the peer acknowledging
+					// each SUBSCRIBE_NAMESPACE is the last boundary available: a cold
+					// `request_broadcast` still races the NAMESPACE messages behind the
+					// acknowledgment, but never settles before the peer has seen the
+					// solicitation.
+					let (sync_producer, synced) = Connecting::new();
 					let mut prefixes = futures::stream::FuturesUnordered::new();
 					for prefix in sub_ns.subscribe_prefixes() {
 						let mut sub_ns = sub_ns.clone();
 						let sub_ns_adapter = sub_ns_adapter.clone();
+						let connected = sync_producer.clone();
 						prefixes.push(async move {
 							let stream = match version {
 								Version::Draft16 => {
@@ -208,8 +238,8 @@ pub fn start<S: crate::transport::poll::Session>(
 								}
 								_ => Stream::open(&mut sub_ns_adapter.clone(), version).await?,
 							};
-							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix).await {
-								// The peer breaking the protocol is fatal, and the driver
+							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix, connected).await {
+								// The peer breaking the protocol is fatal, and the poll loop
 								// below turns this into the session close the draft wants.
 								if is_protocol_violation(&err) {
 									return Err(err);
@@ -219,10 +249,24 @@ pub fn start<S: crate::transport::poll::Session>(
 							Ok::<(), Error>(())
 						});
 					}
-					while let Some(result) = futures::StreamExt::next(&mut prefixes).await {
-						result?;
-					}
-					Ok(())
+					// Each prefix holds its own producer clone; drop ours so the channel
+					// closes once the last prefix reports in.
+					drop(sync_producer);
+					let mut drive = std::pin::pin!(async {
+						while let Some(result) = futures::StreamExt::next(&mut prefixes).await {
+							result?;
+						}
+						Ok::<(), Error>(())
+					});
+					let mut reported = false;
+					kio::wait(|waiter| {
+						if !reported && synced.poll_ready(waiter).is_ready() {
+							solicitor.synced();
+							reported = true;
+						}
+						waiter.poll_future(drive.as_mut())
+					})
+					.await
 				}));
 
 				kio::wait(|waiter| {
@@ -319,15 +363,21 @@ pub fn start<S: crate::transport::poll::Session>(
 				let mut setup = std::pin::pin!(setup);
 				// One SUBSCRIBE_NAMESPACE per permitted prefix; see the draft-16 arm.
 				let mut sub_ns_run = std::pin::pin!(err_only(async {
+					// Parked until something is interested in announcements; see the
+					// draft-16 arm.
+					solicitor.needed().await;
+					// Synced once every prefix has its response; see the draft-16 arm.
+					let (sync_producer, synced) = Connecting::new();
 					let mut prefixes = futures::stream::FuturesUnordered::new();
 					for prefix in sub_ns.subscribe_prefixes() {
 						let mut sub_ns = sub_ns.clone();
 						let sub_ns_session = sub_ns_session.clone();
+						let connected = sync_producer.clone();
 						prefixes.push(async move {
 							let mut sub_ns_session = sub_ns_session;
 							let stream = Stream::open(&mut sub_ns_session, version).await?;
-							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix).await {
-								// The peer breaking the protocol is fatal, and the driver
+							if let Err(err) = sub_ns.run_subscribe_namespace(stream, prefix, connected).await {
+								// The peer breaking the protocol is fatal, and the poll loop
 								// below turns this into the session close the draft wants.
 								if is_protocol_violation(&err) {
 									return Err(err);
@@ -337,10 +387,22 @@ pub fn start<S: crate::transport::poll::Session>(
 							Ok::<(), Error>(())
 						});
 					}
-					while let Some(result) = futures::StreamExt::next(&mut prefixes).await {
-						result?;
-					}
-					Ok(())
+					drop(sync_producer);
+					let mut drive = std::pin::pin!(async {
+						while let Some(result) = futures::StreamExt::next(&mut prefixes).await {
+							result?;
+						}
+						Ok::<(), Error>(())
+					});
+					let mut reported = false;
+					kio::wait(|waiter| {
+						if !reported && synced.poll_ready(waiter).is_ready() {
+							solicitor.synced();
+							reported = true;
+						}
+						waiter.poll_future(drive.as_mut())
+					})
+					.await
 				}));
 
 				kio::wait(|waiter| {
@@ -855,6 +917,9 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		// Announce interest is what makes the lazy subscriber open SUBSCRIBE_NAMESPACE
+		// at all; without it the scripted NAMESPACE below is never read.
+		let _interest = origin.consume().announced();
 		let session = crate::lite::test_transport::ScriptedSession::new(namespace_without_hop_path(VERSION).await);
 		let log = session.log.clone();
 
@@ -904,6 +969,8 @@ mod tests {
 			.with_root("rootns")
 			.and_then(|rooted| rooted.scope(&[crate::Path::new("cam"), crate::Path::new("mic")]))
 			.expect("scope the origin to two prefixes");
+		// Announce interest is what makes the lazy subscriber solicit at all.
+		let _interest = scoped.consume().announced();
 
 		let gate = kio::Producer::new(true);
 		let session = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
@@ -937,6 +1004,62 @@ mod tests {
 		assert_eq!(occurrences(&log, b"cam"), 1, "one SUBSCRIBE_NAMESPACE for cam");
 		assert_eq!(occurrences(&log, b"mic"), 1, "one SUBSCRIBE_NAMESPACE for mic");
 		assert_eq!(occurrences(&log, b"rootns"), 0, "asked the peer for our local root");
+	}
+
+	/// A cold `request_broadcast` must not settle before the peer acknowledges the
+	/// SUBSCRIBE_NAMESPACE it triggered: the acknowledgment is the only initial-set
+	/// boundary moq-transport offers. A peer that never responds keeps the request
+	/// pending rather than producing an instant `Unroutable` off a solicitation the
+	/// peer has not even received.
+	#[tokio::test]
+	async fn request_waits_for_the_acknowledgment() {
+		use futures::FutureExt;
+
+		// Scoped so the one SUBSCRIBE_NAMESPACE carries a grep-able prefix.
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap())
+			.produce()
+			.scope(&[crate::Path::new("cam")])
+			.expect("scope the origin");
+
+		// An open gate: the SUBSCRIBE_NAMESPACE reaches the wire, but no response
+		// ever comes back.
+		let gate = kio::Producer::new(true);
+		let session = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
+		let log = session.log.clone();
+
+		let (driver, _goaway) = start(Config {
+			session,
+			setup: None,
+			request_id_max: None,
+			client: true,
+			publish: None,
+			subscribe: Some(origin.clone()),
+			peer_origin: None,
+			cost: None,
+			version: Version::Draft19,
+			path: None,
+			peer_setup_stream: None,
+			peer_cluster: None,
+		})
+		.expect("start the session");
+		let _driver = tokio::spawn(driver);
+
+		// The request itself raises the interest that wakes the lazy solicitor: the
+		// solicitor is attached synchronously in `start`, so a request racing the
+		// spawned driver still counts.
+		let mut request = std::pin::pin!(origin.consume().request_broadcast("cam/live"));
+		for _ in 0..100 {
+			if occurrences(&log, b"cam") > 0 {
+				break;
+			}
+			tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+		}
+		assert_eq!(occurrences(&log, b"cam"), 1, "the request solicited the prefix");
+
+		assert!(
+			request.as_mut().now_or_never().is_none(),
+			"an unacknowledged solicitation must keep the request pending",
+		);
 	}
 
 	/// A namespace is only advertised in response to a SUBSCRIBE_NAMESPACE. A peer

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -323,6 +323,9 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	/// The caller is responsible for opening the appropriate stream type
 	/// (virtual for v14/v15, real bidi for v16+), one per prefix.
 	///
+	/// `connected` is released once the peer acknowledges the request (or the
+	/// request fails), which is what reports the session's solicitor synced.
+	///
 	/// A failure here is per-prefix, so the caller decides what it means for the
 	/// session: [`is_protocol_violation`] separates the peer's fault (fatal) from a
 	/// stream of ours that simply died (survivable).
@@ -330,6 +333,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		&mut self,
 		mut stream: Stream<T, Version>,
 		prefix: PathOwned,
+		connected: crate::connecting::ConnectingProducer,
 	) -> Result<(), Error> {
 		// A peer that sent GOAWAY told us to stop opening requests on this session,
 		// announce-interest included (draft-19 sect 10.4).
@@ -389,6 +393,11 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		}
 
 		tracing::debug!(%prefix, "subscribe_namespace ok");
+
+		// The acknowledgment is the closest thing moq-transport has to an
+		// initial-set boundary; report this prefix's solicitation delivered. An
+		// early error above reports it the same way via scope exit.
+		drop(connected);
 
 		// The extension changes the NAMESPACE encoding, so we can't parse one until
 		// the peer's SETUP says whether it negotiated.
@@ -1484,7 +1493,9 @@ mod tests {
 		);
 
 		let stream = Stream::open(&mut session.clone(), Version::Draft16).await.unwrap();
-		let mut run = std::pin::pin!(subscriber.run_subscribe_namespace(stream, crate::Path::new("cam").to_owned()));
+		let connected = crate::connecting::Connecting::new().0;
+		let mut run =
+			std::pin::pin!(subscriber.run_subscribe_namespace(stream, crate::Path::new("cam").to_owned(), connected));
 		// Parks awaiting the peer's response; the request is already on the wire.
 		assert!(futures::poll!(run.as_mut()).is_pending());
 
@@ -1553,7 +1564,8 @@ mod tests {
 		let prefix = subscriber.subscribe_prefixes().pop().expect("one prefix");
 		let stream = Stream::open(&mut session.clone(), VERSION).await.unwrap();
 		// Parks on the read after the scripted NAMESPACE is consumed.
-		let mut run = std::pin::pin!(subscriber.run_subscribe_namespace(stream, prefix));
+		let connected = crate::connecting::Connecting::new().0;
+		let mut run = std::pin::pin!(subscriber.run_subscribe_namespace(stream, prefix, connected));
 		for _ in 0..100 {
 			// The result is deliberately ignored: a regressed mount lands out of scope
 			// and errors here, which the assertions below name far better than a poll
@@ -1901,7 +1913,11 @@ mod tests {
 
 		let stream = Stream::open(&mut session.clone(), VERSION).await.unwrap();
 		subscriber
-			.run_subscribe_namespace(stream, crate::Path::new("").to_owned())
+			.run_subscribe_namespace(
+				stream,
+				crate::Path::new("").to_owned(),
+				crate::connecting::Connecting::new().0,
+			)
 			.await
 			.expect("a clean FIN is not an error");
 		settle().await;

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -77,6 +77,7 @@
 
 mod client;
 mod coding;
+mod connecting;
 mod error;
 pub mod goaway;
 mod ietf;

--- a/rs/moq-net/src/lite/mod.rs
+++ b/rs/moq-net/src/lite/mod.rs
@@ -5,7 +5,6 @@
 //! Specification: [<https://github.com/moq-dev/drafts>]
 
 mod announce;
-mod connecting;
 mod datagram;
 mod fetch;
 mod goaway;
@@ -27,7 +26,6 @@ mod track;
 mod version;
 
 pub use announce::*;
-pub(crate) use connecting::*;
 #[allow(unused_imports)]
 pub use datagram::*;
 #[allow(unused_imports)]

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -1,3 +1,4 @@
+use crate::model::interest;
 use crate::origin;
 use crate::{
 	Error, Origin, SessionError, bandwidth,
@@ -8,9 +9,10 @@ use crate::{
 
 use std::task::{Context, Poll, ready};
 
+use crate::connecting::Connecting;
+
 use super::{
-	Connecting, DataType, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber, SubscriberConfig, SubscriberDriver,
-	Version,
+	DataType, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber, SubscriberConfig, SubscriberDriver, Version,
 };
 
 pub(crate) struct SessionStart {
@@ -91,7 +93,9 @@ pub struct Config<S: crate::transport::poll::Session> {
 /// Returns the receive-bandwidth consumer (if any) and a [`Connecting`] handle that
 /// becomes ready once the initial announce set has been inserted into the subscribe
 /// origin, letting `connect()` block past the startup race. It is ready immediately
-/// when there is nothing to wait on (a version without an initial-set boundary).
+/// when there is nothing to wait on: a version without an initial-set boundary, or an
+/// origin with no announce interest yet, where nothing is solicited until interest
+/// appears (see `Subscriber::run_announce`).
 pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<SessionStart, Error> {
 	let Config {
 		mut session,
@@ -148,7 +152,14 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 	// (and answers the peer's announce-interest with an empty set), and an empty
 	// subscribe origin issues no ANNOUNCE_PLEASE (zero prefixes, so `run_announce`
 	// drops `connecting` at once and `connect()` still unblocks).
-	let publish = publish.unwrap_or_else(|| origin::Producer::empty(Origin::random()).consume());
+	//
+	// The session's identity in the announce-interest ledger: interest the publisher
+	// half raises on behalf of this peer is tagged with it, so the subscriber half
+	// doesn't treat the peer's own solicitation as demand and reciprocate.
+	let session_id = interest::SessionId::new();
+	let publish = publish
+		.map(|p| p.on_behalf_of(session_id))
+		.unwrap_or_else(|| origin::Producer::empty(Origin::random()).consume());
 	let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Origin::random()));
 
 	// Publisher and Subscriber each derive their identity from their own
@@ -194,6 +205,7 @@ pub fn start<S: crate::transport::poll::Session>(config: Config<S>) -> Result<Se
 		// for its own egress.
 		cost: our_cost,
 		going_away: goaway.going_away.clone(),
+		session_id,
 	});
 
 	let mut driver = Driver {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1,3 +1,4 @@
+use crate::model::interest;
 use crate::{frame, group, origin, track};
 use std::{
 	collections::HashMap,
@@ -15,7 +16,9 @@ use crate::{
 	track::{Position, Subscription},
 };
 
-use super::{ConnectingProducer, RouteCost, Version};
+use crate::connecting::{Connecting, ConnectingProducer};
+
+use super::{RouteCost, Version};
 
 use web_async::Lock;
 
@@ -41,6 +44,10 @@ pub(super) struct SubscriberConfig<S: crate::transport::poll::Session> {
 	/// Set once the peer sends a GOAWAY; new request streams are then rejected
 	/// with [`Error::GoingAway`] (the peer told us to stop asking).
 	pub going_away: crate::goaway::GoingAway,
+	/// This session's identity in the origin's announce-interest ledger: the egress
+	/// consumer is tagged with it, so interest raised on behalf of our own peer
+	/// doesn't make us solicit announces right back.
+	pub session_id: interest::SessionId,
 }
 
 #[derive(Clone)]
@@ -80,6 +87,29 @@ pub(super) struct Subscriber<S: crate::transport::poll::Session> {
 	/// [`SourceServe`] machines.
 	sources: kio::Queue<(PathOwned, crate::broadcast::Dynamic)>,
 	going_away: crate::goaway::GoingAway,
+	// This session's solicitor in the origin's announce-interest ledger. Attached
+	// here (at construction, inside `connect()`) rather than in `run_announce`, so a
+	// request issued the instant `connect()` returns already sees it and waits for
+	// its solicitation instead of settling on a cold table. Shared because the
+	// subscriber is cloned into several long-lived tasks; the last clone dropping
+	// (the session fully dead) is what detaches.
+	solicitor: Arc<interest::Solicitor>,
+}
+
+/// The initial-set producers one announce prefix holds: the session's external
+/// `connect()` gate, and the internal one reporting the solicitor synced.
+/// `take` (or scope exit, e.g. a failed stream) releases both: either way this prefix
+/// will deliver no more initial announcements.
+struct InitialSet {
+	external: Option<ConnectingProducer>,
+	internal: Option<ConnectingProducer>,
+}
+
+impl InitialSet {
+	fn take(&mut self) {
+		self.external.take();
+		self.internal.take();
+	}
 }
 
 #[derive(Clone)]
@@ -97,6 +127,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// every session sharing that origin, required for cross-session
 		// loop detection.
 		let self_origin = *config.origin;
+		let solicitor = Arc::new(config.origin.solicitor(config.session_id));
 		Self {
 			session: config.session,
 			origin: config.origin,
@@ -111,6 +142,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 			cost: config.cost,
 			sources: kio::Queue::new(),
 			going_away: config.going_away,
+			solicitor,
 		}
 	}
 
@@ -464,14 +496,21 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 /// error ends it.
 pub(super) struct SubscriberDriver<S: crate::transport::poll::Session> {
 	subscriber: Subscriber<S>,
-	/// Our own clone of the connection-progress producer, dropped on the first
-	/// poll. Holding it until then keeps `Connecting` pending so `connect()`
-	/// drives the driver at least once, exactly like the old announce task; the
-	/// per-prefix clones then own the boundary.
+	/// The session's `connect()` gate, held until the prefix machines are built
+	/// (each then owns a per-prefix clone). Dropped at construction when the
+	/// origin has no announce interest yet: the session connects immediately and
+	/// the streams open later, if interest ever appears.
 	connecting: Option<ConnectingProducer>,
-	/// One machine per permitted prefix. Only an error ends the session; a
-	/// prefix finishing cleanly (publisher FIN) just retires.
-	prefixes: Vec<AnnouncePrefix<S>>,
+	/// One machine per permitted prefix, built on the first poll after announce
+	/// interest exists (`None` until then; see [`Self::poll_solicit`]). Only an
+	/// error ends the session; a prefix finishing cleanly (publisher FIN) just
+	/// retires.
+	prefixes: Option<Vec<AnnouncePrefix<S>>>,
+	/// The internal initial-set countdown: ready once every prefix delivered its
+	/// initial set (or died trying), which is when the solicitor reports synced
+	/// and pending requests stop waiting on this session. `None` before the
+	/// prefixes are built and after reporting.
+	synced: Option<Connecting>,
 	uni: UniAccept<S>,
 	/// PROBE feedback; finishes quietly when unsupported or given up on.
 	bandwidth: Option<RecvBandwidth<S>>,
@@ -483,22 +522,16 @@ pub(super) struct SubscriberDriver<S: crate::transport::poll::Session> {
 
 impl<S: crate::transport::poll::Session> SubscriberDriver<S> {
 	/// `connecting` is the connection-progress producer for this session (None for
-	/// versions with no initial-set boundary). Each prefix holds its own clone and
-	/// drops it once its initial set is in; with no prefixes it drops here, so the
-	/// session is connected now.
+	/// versions with no initial-set boundary). Held until the first poll so
+	/// `connect()` drives the driver at least once, then either handed to the
+	/// prefix machines (interest already exists, so `connect()` gates on the real
+	/// initial set) or released (no interest yet: the session connects
+	/// immediately and the streams open later, if interest ever appears).
 	pub fn new(subscriber: Subscriber<S>, connecting: Option<ConnectingProducer>) -> Self {
-		let prefixes = subscriber
-			.origin
-			.allowed()
-			.map(|p| p.to_owned())
-			.collect::<Vec<PathOwned>>()
-			.into_iter()
-			.map(|prefix| AnnouncePrefix::new(subscriber.clone(), prefix, connecting.clone()))
-			.collect();
-
 		Self {
 			connecting,
-			prefixes,
+			prefixes: None,
+			synced: None,
 			uni: UniAccept::new(subscriber.clone()),
 			bandwidth: Some(RecvBandwidth::new(subscriber.clone())),
 			datagrams: Some(DatagramRecv::new(subscriber.clone())),
@@ -507,19 +540,82 @@ impl<S: crate::transport::poll::Session> SubscriberDriver<S> {
 		}
 	}
 
-	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
-		// Each prefix holds its own clone; with no prefixes, this drop is what
-		// marks the session connected.
-		self.connecting.take();
+	// Announces are solicited lazily: no machine is built (and no ANNOUNCE stream
+	// opens) until the origin has announce interest to serve (an `announced()`
+	// stream, an `announced_broadcast` wait, a pending `request_broadcast`, or
+	// another session's peer). Interest raised by our own peer doesn't count;
+	// reciprocating a solicitation would cost a publish-only endpoint the very
+	// traffic laziness avoids.
+	fn poll_solicit(&mut self, waiter: &kio::Waiter) {
+		let prefixes: Vec<PathOwned> = self.subscriber.origin.allowed().map(|p| p.to_owned()).collect();
+		if prefixes.is_empty() {
+			// Nothing we could ever solicit; requests must not wait on us, and
+			// the session is connected now.
+			self.subscriber.solicitor.synced();
+			self.connecting.take();
+			self.prefixes = Some(Vec::new());
+			return;
+		}
 
-		let mut i = 0;
-		while i < self.prefixes.len() {
-			match self.prefixes[i].poll(waiter) {
-				Poll::Ready(Ok(())) => {
-					self.prefixes.swap_remove(i);
+		// Parked until something is interested in announcements.
+		if self.subscriber.solicitor.poll_needed(waiter).is_pending() {
+			return;
+		}
+
+		// The peer told us to drain instead of opening new streams. Park rather
+		// than error (the session is still serving what it has); the interest is
+		// served by the next session after the reconnect.
+		if self.subscriber.going_away.is_set() {
+			self.subscriber.solicitor.synced();
+			self.connecting.take();
+			self.prefixes = Some(Vec::new());
+			return;
+		}
+
+		let (sync_producer, synced) = Connecting::new();
+		self.prefixes = Some(
+			prefixes
+				.into_iter()
+				.map(|prefix| {
+					let initial = InitialSet {
+						external: self.connecting.clone(),
+						internal: Some(sync_producer.clone()),
+					};
+					AnnouncePrefix::new(self.subscriber.clone(), prefix, initial)
+				})
+				.collect(),
+		);
+		// Each prefix holds its own producer clones; drop ours so the channels
+		// close once the last prefix finishes its initial set.
+		self.connecting.take();
+		self.synced = Some(synced);
+	}
+
+	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		if self.prefixes.is_none() {
+			self.poll_solicit(waiter);
+		}
+		// Our clone has done its job once the driver has been polled: the prefix
+		// machines (when built above) own the boundary, and a session parked on
+		// absent interest must not hang `connect()`.
+		self.connecting.take();
+		if let Some(synced) = &self.synced
+			&& synced.poll_ready(waiter).is_ready()
+		{
+			self.subscriber.solicitor.synced();
+			self.synced = None;
+		}
+
+		if let Some(prefixes) = &mut self.prefixes {
+			let mut i = 0;
+			while i < prefixes.len() {
+				match prefixes[i].poll(waiter) {
+					Poll::Ready(Ok(())) => {
+						prefixes.swap_remove(i);
+					}
+					Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+					Poll::Pending => i += 1,
 				}
-				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
-				Poll::Pending => i += 1,
 			}
 		}
 		if let Poll::Ready(res) = self.uni.poll(waiter) {
@@ -1079,9 +1175,9 @@ impl<S: crate::transport::poll::Session> ProbeStream<S> {
 struct AnnouncePrefix<S: crate::transport::poll::Session> {
 	subscriber: Subscriber<S>,
 	prefix: PathOwned,
-	// Dropped once this prefix's initial set is in (or on any exit), so a failed
-	// prefix can't hang connect().
-	connecting: Option<ConnectingProducer>,
+	// Released once this prefix's initial set is in (or on any exit), so a failed
+	// prefix can't hang connect() or a pending request.
+	connecting: InitialSet,
 	state: PrefixState<S>,
 }
 
@@ -1126,7 +1222,7 @@ struct PrefixRun {
 }
 
 impl<S: crate::transport::poll::Session> AnnouncePrefix<S> {
-	fn new(subscriber: Subscriber<S>, prefix: PathOwned, connecting: Option<ConnectingProducer>) -> Self {
+	fn new(subscriber: Subscriber<S>, prefix: PathOwned, connecting: InitialSet) -> Self {
 		Self {
 			subscriber,
 			prefix,
@@ -1383,6 +1479,7 @@ mod tests {
 			peer_origin: None,
 			cost: None,
 			going_away: Default::default(),
+			session_id: interest::SessionId::new(),
 		});
 		let subscribes = subscriber.subscribes.clone();
 		let serve = TrackServe {
@@ -1455,6 +1552,7 @@ mod tests {
 				peer_origin: None,
 				cost: None,
 				going_away: Default::default(),
+				session_id: interest::SessionId::new(),
 			});
 			let mut broadcast = crate::broadcast::Info::new().produce();
 			let producer = broadcast.create_track("catalog.json", None).unwrap();
@@ -1880,6 +1978,7 @@ mod tests {
 			peer_origin: Some(assigned),
 			cost: None,
 			going_away: Default::default(),
+			session_id: interest::SessionId::new(),
 		});
 
 		// An announce with an empty chain and no responder id: the versions that
@@ -1942,6 +2041,7 @@ mod tests {
 			cost: None,
 			peer_origin: None,
 			going_away: Default::default(),
+			session_id: interest::SessionId::new(),
 		});
 		(subscriber, consumer)
 	}
@@ -2048,6 +2148,7 @@ mod tests {
 			cost: None,
 			peer_origin: None,
 			going_away: Default::default(),
+			session_id: interest::SessionId::new(),
 		});
 
 		let path = Path::new("room/host").to_owned();
@@ -2081,6 +2182,68 @@ mod tests {
 			consumer.get_broadcast("room/host").is_none(),
 			"an explicit retraction must close the broadcast",
 		);
+	}
+
+	/// Announce solicitation is lazy: no ANNOUNCE stream opens until the origin has
+	/// announce interest, and the first interested consumer opens exactly one per
+	/// allowed prefix.
+	#[tokio::test]
+	async fn announce_solicited_lazily() {
+		tokio::time::pause();
+
+		// An open gate: an eager solicitation would reach the wire immediately.
+		let gate = kio::Producer::new(true);
+		let session = SinkSession::gated_bi(gate.consume());
+		let log = session.log.clone();
+
+		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let scoped = origin.scope(&[crate::Path::new("lazycam")]).expect("scope");
+		let subscriber = Subscriber::new(SubscriberConfig {
+			session: session.clone(),
+			origin: scoped,
+			recv_bandwidth: None,
+			// Lite04: no Setup Stream to wait on, and ANNOUNCE_PLEASE carries the
+			// prefix bytes this test greps for.
+			version: Version::Lite04,
+			peer_setup: Default::default(),
+			peer_origin: None,
+			cost: None,
+			going_away: Default::default(),
+			session_id: interest::SessionId::new(),
+		});
+		let mut driver = SubscriberDriver::new(subscriber, None);
+		let _driver = tokio::spawn(async move { kio::wait(|waiter| driver.poll(waiter)).await });
+
+		// Nothing is interested, so nothing may be solicited no matter how long the
+		// session sits there.
+		tokio::time::sleep(Duration::from_secs(1)).await;
+		assert_eq!(log.bi_opens(), 0, "no interest, no stream");
+
+		// The first consumer opens the announce stream for the allowed prefix.
+		let _interest = origin.consume().announced();
+		let mut solicited = false;
+		for _ in 0..100 {
+			tokio::time::sleep(Duration::from_millis(5)).await;
+			if log.bi_opens() > 0 {
+				solicited = true;
+				break;
+			}
+		}
+		assert!(solicited, "interest opens the announce stream");
+
+		// And it asked for the allowed prefix, exactly once.
+		for _ in 0..100 {
+			{
+				let writes = log.writes.lock().unwrap();
+				if writes.windows(b"lazycam".len()).any(|w| w == b"lazycam") {
+					break;
+				}
+			}
+			tokio::time::sleep(Duration::from_millis(5)).await;
+		}
+		let writes = log.writes.lock().unwrap();
+		let count = writes.windows(b"lazycam".len()).filter(|w| *w == b"lazycam").count();
+		assert_eq!(count, 1, "one ANNOUNCE_PLEASE for the allowed prefix");
 	}
 }
 

--- a/rs/moq-net/src/model/interest.rs
+++ b/rs/moq-net/src/model/interest.rs
@@ -1,0 +1,262 @@
+//! Lazy announce solicitation: tracking who wants announcements so sessions only
+//! ask their peer while someone is listening.
+//!
+//! One [`Ledger`] is shared by every handle derived from an origin. Two sides
+//! write to it:
+//!
+//! - **Demand.** Every `AnnounceConsumer` registers the prefixes it listens to (a
+//!   [`Guard`], refcounted, released on drop). That covers `announced()`,
+//!   `announced_broadcast`, the wait inside `request_broadcast`, and a session's
+//!   egress consumer serving its peer's solicitation. The last one is tagged with
+//!   the session's [`SessionId`]; everything else is the application's own
+//!   (`None`).
+//! - **Supply.** Each session's subscriber half attaches a [`Solicitor`]. It
+//!   parks until demand it should serve exists ([`Solicitor::needed`]), then
+//!   solicits announces from its peer for the rest of the session, reporting
+//!   [`Solicitor::synced`] once the initial announce set has landed (or provably
+//!   never will).
+//!
+//! The session tag is what breaks the feedback loop: a solicitor never counts
+//! demand raised on behalf of its own peer, so a peer soliciting our announces
+//! doesn't make us solicit theirs right back, and a publish-only endpoint keeps
+//! the traffic savings laziness exists for.
+//!
+//! A pending `request_broadcast` consumes the sync half: it waits until every
+//! solicitor that could announce its path is [`settled`](Ledger::settled) before
+//! falling back to the dynamic queue or `Unroutable`.
+
+use std::{
+	collections::{BTreeMap, HashMap},
+	sync::atomic::{AtomicU64, Ordering},
+	task::Poll,
+};
+
+use crate::{Path, PathOwned};
+
+static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(0);
+
+/// A session's identity in the announce-interest [`Ledger`].
+///
+/// Minted once per session and shared by both halves: the publisher half tags
+/// its egress consumer with it (interest that consumer raises is on behalf of
+/// the session's peer), and the subscriber half attaches its [`Solicitor`] with
+/// it, so the peer's own solicitation never reads as demand to reciprocate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SessionId(u64);
+
+impl SessionId {
+	/// A fresh identity for one session.
+	pub fn new() -> Self {
+		Self(NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed))
+	}
+}
+
+// The ledger's record of one attached solicitor: which session it belongs to,
+// the prefixes it may solicit, and whether its initial announce set has been
+// delivered (or definitively won't be, e.g. the stream failed or the peer is
+// draining).
+struct SolicitorEntry {
+	session: SessionId,
+	synced: bool,
+	// The solicitor's authorized scope, absolute. It can only ever announce paths
+	// under one of these, which is what keeps an unrelated session out of another's
+	// requests.
+	prefixes: Vec<PathOwned>,
+}
+
+impl SolicitorEntry {
+	// Whether this solicitor could announce `path`: some prefix it may solicit contains it.
+	fn covers(&self, path: &Path) -> bool {
+		self.prefixes.iter().any(|prefix| path.has_prefix(prefix))
+	}
+}
+
+// Whether two prefixes can name any path in common: one contains the other. Interest in
+// `a/b` is served by a solicitor scoped to `a`, and interest in `a` is (partly) served by
+// a solicitor scoped to `a/b`; interest in `b` is served by neither.
+fn overlaps(a: &Path, b: &Path) -> bool {
+	a.has_prefix(b) || b.has_prefix(a)
+}
+
+/// Announce demand across an origin, shared by every handle derived from it; see
+/// the module docs for the full story.
+#[derive(Default)]
+pub(crate) struct Ledger {
+	// Absolute prefix -> who raised the interest -> registration count. `None` is
+	// the application itself; `Some` is a session's egress consumer, acting on
+	// behalf of that session's peer.
+	prefixes: BTreeMap<PathOwned, BTreeMap<Option<SessionId>, usize>>,
+
+	// Attached solicitors, keyed by an id private to this map.
+	solicitors: HashMap<u64, SolicitorEntry>,
+	next_solicitor: u64,
+}
+
+impl Ledger {
+	fn register(&mut self, prefix: PathOwned, session: Option<SessionId>) {
+		*self.prefixes.entry(prefix).or_default().entry(session).or_default() += 1;
+	}
+
+	fn unregister(&mut self, prefix: &PathOwned, session: Option<SessionId>) {
+		let Some(parties) = self.prefixes.get_mut(prefix) else {
+			return;
+		};
+		let Some(count) = parties.get_mut(&session) else { return };
+		*count -= 1;
+		if *count == 0 {
+			parties.remove(&session);
+			if parties.is_empty() {
+				self.prefixes.remove(prefix);
+			}
+		}
+	}
+
+	/// Whether any interest exists that `solicitor` should serve: raised by the
+	/// application or on behalf of a different session, and under a prefix it may
+	/// actually solicit. A session never solicits announces just because its own
+	/// peer solicited ours, and interest in a path outside a solicitor's scope is
+	/// not that solicitor's to answer.
+	fn needs(&self, solicitor: &SolicitorEntry) -> bool {
+		self.prefixes.iter().any(|(prefix, parties)| {
+			parties.keys().any(|s| *s != Some(solicitor.session))
+				&& solicitor.prefixes.iter().any(|scope| overlaps(prefix, scope))
+		})
+	}
+
+	/// Whether the announce table is as warm as the attached sessions will make it
+	/// *for `path`*: every solicitor that could announce it has delivered its
+	/// initial set (or has no interest to serve, so it never will). Scoped per path
+	/// rather than globally, because a session scoped to somewhere else can neither
+	/// announce this path nor speak for it, so waiting on one would hang a request
+	/// it can never answer.
+	///
+	/// Vacuously true with no attached sessions, so a purely local origin resolves
+	/// requests immediately, exactly as before interest existed.
+	pub fn settled(&self, path: &Path) -> bool {
+		self.solicitors
+			.values()
+			.filter(|s| s.covers(path))
+			.all(|s| s.synced || !self.needs(s))
+	}
+
+	/// The registered prefixes, for tests asserting that registration is absolute.
+	#[cfg(test)]
+	pub fn prefixes(&self) -> Vec<PathOwned> {
+		self.prefixes.keys().cloned().collect()
+	}
+
+	/// Whether any attached solicitor might still warm `path`. Broader than
+	/// `!settled()`: a request consults this *before* registering its own interest,
+	/// so a parked solicitor that the interest is about to wake still counts.
+	pub fn warming(&self, path: &Path) -> bool {
+		self.solicitors.values().any(|s| !s.synced && s.covers(path))
+	}
+}
+
+/// Holds announce-interest registrations for one holder (an `AnnounceConsumer`,
+/// or the origin-wide `origin::Interest`); dropping it releases them.
+pub(crate) struct Guard {
+	state: kio::Producer<Ledger>,
+	// Absolute prefixes this consumer registered, one per scoped root.
+	prefixes: Vec<PathOwned>,
+	// Who the interest is on behalf of: `None` for the application itself.
+	session: Option<SessionId>,
+}
+
+impl Guard {
+	pub fn register(state: kio::Producer<Ledger>, prefixes: Vec<PathOwned>, session: Option<SessionId>) -> Self {
+		if let Ok(mut locked) = state.write() {
+			for prefix in &prefixes {
+				locked.register(prefix.clone(), session);
+			}
+		}
+		Self {
+			state,
+			prefixes,
+			session,
+		}
+	}
+}
+
+impl Drop for Guard {
+	fn drop(&mut self) {
+		if let Ok(mut locked) = self.state.write() {
+			for prefix in &self.prefixes {
+				locked.unregister(prefix, self.session);
+			}
+		}
+	}
+}
+
+/// A session subscriber half's attachment to the announce-interest [`Ledger`].
+///
+/// Obtained via `origin::Producer::solicitor`. The solicitor waits on
+/// [`poll_needed`](Self::poll_needed) before soliciting announces, then calls
+/// [`synced`](Self::synced) once the initial announce set has landed (or provably
+/// never will). Dropping it detaches, so a dead session can't hold requests
+/// hostage.
+pub(crate) struct Solicitor {
+	state: kio::Producer<Ledger>,
+	id: u64,
+}
+
+impl Solicitor {
+	pub fn attach(state: kio::Producer<Ledger>, session: SessionId, prefixes: Vec<PathOwned>) -> Self {
+		let id = {
+			let mut locked = state.write().ok().expect("interest never closes");
+			let id = locked.next_solicitor;
+			locked.next_solicitor += 1;
+			locked.solicitors.insert(
+				id,
+				SolicitorEntry {
+					session,
+					synced: false,
+					prefixes,
+				},
+			);
+			id
+		};
+		Self { state, id }
+	}
+
+	/// Whether interest this solicitor should serve already exists, without waiting.
+	#[cfg(test)]
+	pub fn is_needed(&self) -> bool {
+		let state = self.state.read();
+		state.solicitors.get(&self.id).is_some_and(|s| state.needs(s))
+	}
+
+	/// Poll until some interest this solicitor should serve exists.
+	pub fn poll_needed(&self, waiter: &kio::Waiter) -> Poll<()> {
+		self.state
+			.poll_ref(waiter, |state| match state.solicitors.get(&self.id) {
+				Some(solicitor) if state.needs(solicitor) => Poll::Ready(()),
+				_ => Poll::Pending,
+			})
+			.map(|_| ())
+	}
+
+	/// Block until some interest this solicitor should serve exists.
+	pub async fn needed(&self) {
+		kio::wait(|waiter| self.poll_needed(waiter)).await
+	}
+
+	/// Report that this solicitor's initial announce set has been delivered, or
+	/// never will be (a failed stream, a draining peer): pending requests stop
+	/// waiting on it.
+	pub fn synced(&self) {
+		if let Ok(mut locked) = self.state.write()
+			&& let Some(entry) = locked.solicitors.get_mut(&self.id)
+		{
+			entry.synced = true;
+		}
+	}
+}
+
+impl Drop for Solicitor {
+	fn drop(&mut self) {
+		if let Ok(mut locked) = self.state.write() {
+			locked.solicitors.remove(&self.id);
+		}
+	}
+}

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -11,6 +11,10 @@ pub mod track;
 #[path = "origin.rs"]
 mod origin_impl;
 
+// The announce-interest ledger behind lazy announce solicitation; sessions and
+// the origin implementation share it. See the module docs for the design.
+pub(crate) mod interest;
+
 mod bytes;
 mod datagram;
 mod requests;
@@ -33,7 +37,7 @@ pub use time::*;
 
 /// Publishing and consuming the set of broadcasts routed through an origin.
 pub mod origin {
-	pub use super::origin_impl::{Consumer, Dynamic, Info, Producer, Request, Requesting};
+	pub use super::origin_impl::{Consumer, Dynamic, Info, Interest, Producer, Request, Requesting};
 }
 
 /// Subscribing to broadcast (un)announcements from an origin.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -13,7 +13,7 @@ use std::{
 use rand::RngExt;
 use web_async::Lock;
 
-use super::{Requests, WeakCache};
+use super::{Requests, WeakCache, interest};
 use crate::{
 	AsPath, Error, Path, PathOwned, PathPrefixes,
 	coding::{BoundsExceeded, Decode, DecodeError, Encode, EncodeError},
@@ -357,6 +357,15 @@ impl ConsumerId {
 	fn new() -> Self {
 		Self(NEXT_CONSUMER_ID.fetch_add(1, Ordering::Relaxed))
 	}
+}
+
+/// Standing announce interest for an origin's whole scope; see [`Producer::solicit`].
+///
+/// Dropping it releases the interest: with no other consumer, sessions that
+/// solicit lazily stop counting this origin as a reason to open announce streams
+/// (already open streams stay open for the session's lifetime).
+pub struct Interest {
+	_guard: interest::Guard,
 }
 
 // The origin-owned broadcast at a leaf: the spliced broadcast consumers see,
@@ -871,6 +880,12 @@ impl OriginNodes {
 		}
 	}
 
+	// The absolute prefixes these roots cover: one per node, joined onto `root`.
+	// What an announce consumer registers in the interest ledger.
+	fn interest_prefixes(&self, root: &PathOwned) -> Vec<PathOwned> {
+		self.nodes.iter().map(|(key, _)| root.join(key).to_owned()).collect()
+	}
+
 	// Returns the root that has this prefix.
 	pub fn get(&self, path: impl AsPath) -> Option<(Lock<OriginNode>, PathOwned)> {
 		let path = path.as_path();
@@ -926,6 +941,10 @@ pub struct Producer {
 	// consumer's `request_broadcast` when no live announcement exists.
 	dynamic: kio::Shared<OriginDynamicState>,
 
+	// Announce demand, shared with every derived handle. Session subscriber halves
+	// watch it to solicit announces lazily: no interest, no announce streams.
+	interest: kio::Producer<interest::Ledger>,
+
 	// The cache pool inherited by broadcasts created under this origin (sessions
 	// mint their remote broadcasts with it). Unbounded by default.
 	pool: cache::Pool,
@@ -962,6 +981,7 @@ impl Producer {
 			nodes: OriginNodes::default(),
 			root: PathOwned::default(),
 			dynamic: kio::Shared::default(),
+			interest: kio::Producer::default(),
 			pool: info.pool,
 			cache_duration: info.cache_duration,
 			latency_default: info.latency_default,
@@ -1004,6 +1024,7 @@ impl Producer {
 			nodes: OriginNodes { nodes: Vec::new() },
 			root: PathOwned::default(),
 			dynamic: kio::Shared::default(),
+			interest: kio::Producer::default(),
 			pool: cache::Pool::default(),
 			cache_duration: Duration::MAX,
 			latency_default: track::DEFAULT_LATENCY_MAX,
@@ -1108,6 +1129,7 @@ impl Producer {
 			nodes: self.nodes.select(&prefixes)?,
 			root: self.root.clone(),
 			dynamic: self.dynamic.clone(),
+			interest: self.interest.clone(),
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
 			latency_default: self.latency_default,
@@ -1139,6 +1161,7 @@ impl Producer {
 			self.root.clone(),
 			self.nodes.clone(),
 			self.dynamic.clone(),
+			self.interest.clone(),
 			stats::Session::default(),
 		)
 	}
@@ -1149,7 +1172,30 @@ impl Producer {
 	/// [`AnnounceProducer::consume`] to get an [`AnnounceConsumer`] that
 	/// receives announce / unannounce events.
 	pub fn announces(&self) -> AnnounceProducer {
-		AnnounceProducer::new(self.root.clone(), self.nodes.clone())
+		AnnounceProducer::new(self.root.clone(), self.nodes.clone(), self.interest.clone())
+	}
+
+	/// Attach a session subscriber half to the interest ledger as a solicitor.
+	/// `session` is the session's identity there, so interest raised on behalf of
+	/// its own peer (via the egress consumer tagged with the same id) doesn't count
+	/// as demand for this solicitor.
+	pub(crate) fn solicitor(&self, session: interest::SessionId) -> interest::Solicitor {
+		interest::Solicitor::attach(self.interest.clone(), session, self.nodes.interest_prefixes(&self.root))
+	}
+
+	/// Keep announce solicitation warm: attached sessions solicit announces for this
+	/// handle's whole scope even while nothing consumes them, instead of waiting for
+	/// the first [`Consumer::announced`] or request.
+	///
+	/// A relay holds one so its mesh always carries every route (redundant-route
+	/// failover needs the alternatives before anything fails); leaf endpoints
+	/// normally rely on lazy solicitation instead. Drop the guard to release the
+	/// demand.
+	pub fn solicit(&self) -> Interest {
+		let prefixes = self.nodes.interest_prefixes(&self.root);
+		Interest {
+			_guard: interest::Guard::register(self.interest.clone(), prefixes, None),
+		}
 	}
 
 	/// Returns a new Producer that automatically strips out the provided prefix.
@@ -1164,6 +1210,7 @@ impl Producer {
 			root: self.root.join(&prefix).to_owned(),
 			nodes: self.nodes.root(&prefix)?,
 			dynamic: self.dynamic.clone(),
+			interest: self.interest.clone(),
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
 			latency_default: self.latency_default,
@@ -2396,6 +2443,85 @@ enum RequestState {
 	Failed(Error),
 	// Awaiting a handler: resolves when the request's result channel is written.
 	Pending(kio::Consumer<PendingBroadcast>),
+	// Awaiting an announcement: the table may just be cold because announces are
+	// solicited lazily. Locked because polling advances internal state while
+	// `poll_ok` takes `&self`.
+	Announce(Lock<AnnounceWait>),
+}
+
+// The announce-wait behind a `request_broadcast` on a cold table: interest has been
+// raised (via `announced`, which is what wakes a lazy session), and the request
+// resolves on the announcement or falls back to the dynamic queue once every attached
+// session has delivered its initial set.
+struct AnnounceWait {
+	// Scoped to the requested path; holding it is what holds the interest.
+	announced: AnnounceConsumer,
+	// The requested path relative to the cursor's root, matched exactly: the scope may
+	// be narrower than the request (an authorization deeper than the asked-for path),
+	// and a descendant's announcement is not the requested broadcast.
+	relative: PathOwned,
+	// Settled watch: once every attached solicitor has synced, no announcement is coming.
+	interest: kio::Producer<interest::Ledger>,
+	// What the dynamic fallback needs once settled.
+	dynamic: kio::Shared<OriginDynamicState>,
+	absolute: PathOwned,
+	// The post-settle state, computed at most once. `Announce` is unreachable here.
+	fallback: Option<RequestState>,
+}
+
+impl AnnounceWait {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<broadcast::Consumer, Error>> {
+		loop {
+			if let Some(fallback) = &self.fallback {
+				return match fallback {
+					RequestState::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone())),
+					RequestState::Failed(error) => Poll::Ready(Err(error.clone())),
+					RequestState::Pending(consumer) => {
+						match ready!(consumer.poll(waiter, |state| match &state.resolved {
+							Some(result) => Poll::Ready(result.clone()),
+							None => Poll::Pending,
+						})) {
+							Ok(result) => Poll::Ready(result),
+							// Every handler dropped without resolving: nobody could route it.
+							Err(_closed) => Poll::Ready(Err(Error::Unroutable)),
+						}
+					}
+					RequestState::Announce(_) => unreachable!("fallback is never an announce wait"),
+				};
+			}
+
+			// An announcement resolves first: knowledge beats the fallback.
+			match self.announced.poll_next(waiter) {
+				Poll::Ready(Some(OriginAnnounce {
+					path,
+					broadcast: Some(broadcast),
+				})) if path == self.relative => return Poll::Ready(Ok(broadcast)),
+				// An unannounce, or a descendant of the requested path; keep draining.
+				Poll::Ready(Some(_)) => continue,
+				// The origin is going away; settle now rather than waiting forever.
+				Poll::Ready(None) => {}
+				Poll::Pending => {
+					// No announcement yet: wait until the attached sessions have delivered
+					// everything they will (or the interest channel dies with the origin).
+					let absolute = self.absolute.as_path();
+					match self.interest.poll_ref(waiter, |state| {
+						if state.settled(&absolute) {
+							Poll::Ready(())
+						} else {
+							Poll::Pending
+						}
+					}) {
+						Poll::Ready(_) => {}
+						Poll::Pending => return Poll::Pending,
+					}
+				}
+			}
+
+			// Settled with no announcement: the path is genuinely unannounced. Fall back
+			// to the dynamic queue exactly like a request on a warm table.
+			self.fallback = Some(Consumer::dynamic_fallback(&self.dynamic, self.absolute.clone()));
+		}
+	}
 }
 
 impl Requesting {
@@ -2407,8 +2533,8 @@ impl Requesting {
 		Self::new(RequestState::Failed(error))
 	}
 
-	fn pending(consumer: kio::Consumer<PendingBroadcast>) -> Self {
-		Self::new(RequestState::Pending(consumer))
+	fn announce(wait: AnnounceWait) -> Self {
+		Self::new(RequestState::Announce(Lock::new(wait)))
 	}
 
 	fn new(inner: RequestState) -> Self {
@@ -2449,6 +2575,10 @@ impl Requesting {
 					Err(_closed) => Err(Error::Unroutable),
 				},
 			),
+			RequestState::Announce(wait) => {
+				let result = ready!(wait.lock().poll(waiter));
+				Poll::Ready(result.map(|broadcast| self.hand_out(broadcast)))
+			}
 		}
 	}
 }
@@ -2489,6 +2619,7 @@ impl Consume<Consumer> for Producer {
 			self.root.clone(),
 			self.nodes.clone(),
 			self.dynamic.clone(),
+			self.interest.clone(),
 			stats::Session::default(),
 		)
 	}
@@ -2552,6 +2683,14 @@ pub struct Consumer {
 	// served from a source whose hop chain excludes this origin (the requesting
 	// peer). `None` (the default) serves from the active source as usual.
 	exclude: Option<Origin>,
+
+	// Announce demand, shared with every handle derived from the same origin.
+	interest: kio::Producer<interest::Ledger>,
+
+	// Whose behalf interest raised through this handle is on: `None` for the
+	// application itself, or a session's identity for its egress consumer, so
+	// that session's own subscriber half doesn't count it as demand.
+	session: Option<interest::SessionId>,
 }
 
 impl std::ops::Deref for Consumer {
@@ -2568,6 +2707,7 @@ impl Consumer {
 		root: PathOwned,
 		nodes: OriginNodes,
 		dynamic: kio::Shared<OriginDynamicState>,
+		interest: kio::Producer<interest::Ledger>,
 		stats: stats::Session,
 	) -> Self {
 		Self {
@@ -2577,6 +2717,8 @@ impl Consumer {
 			dynamic,
 			stats,
 			exclude: None,
+			interest,
+			session: None,
 		}
 	}
 
@@ -2586,6 +2728,14 @@ impl Consumer {
 	/// origin id.
 	pub(crate) fn excluding(mut self, peer: Origin) -> Self {
 		self.exclude = Some(peer);
+		self
+	}
+
+	/// Attribute interest raised through this handle (and its derivatives) to a
+	/// session, so that session's subscriber half doesn't solicit announces on the
+	/// strength of its own peer's interest. Sessions tag their egress consumer.
+	pub(crate) fn on_behalf_of(mut self, session: interest::SessionId) -> Self {
+		self.session = Some(session);
 		self
 	}
 
@@ -2619,6 +2769,8 @@ impl Consumer {
 			dynamic: self.dynamic.clone(),
 			stats: self.stats.clone(),
 			exclude: self.exclude,
+			interest: self.interest.clone(),
+			session: self.session,
 		}
 	}
 
@@ -2629,7 +2781,17 @@ impl Consumer {
 	/// set as initial announcements. Drop the returned [`AnnounceConsumer`]
 	/// to unregister.
 	pub fn announced(&self) -> AnnounceConsumer {
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), self.stats.clone(), self.exclude)
+		AnnounceConsumer::new(
+			self.root.clone(),
+			self.nodes.clone(),
+			self.stats.clone(),
+			self.exclude,
+			interest::Guard::register(
+				self.interest.clone(),
+				self.nodes.interest_prefixes(&self.root),
+				self.session,
+			),
+		)
 	}
 
 	/// Returns a cheap duplicate of this read handle.
@@ -2669,11 +2831,11 @@ impl Consumer {
 	/// is closed before the broadcast is announced. The returned broadcast may itself be closed
 	/// later. Subscribers should watch [`broadcast::Consumer::closed`] to react to that.
 	///
-	/// Prefer this over [`Self::request_broadcast`] when you know the exact path you want but
-	/// cannot guarantee the announcement has already been received. With moq-lite-05 (and
-	/// the older Lite01/02) `connect()` already blocks until the initial announce set lands,
-	/// so [`Self::request_broadcast`] is race-free for broadcasts that were live at connect time;
-	/// this method is still needed to wait for a broadcast that comes online *after* connect.
+	/// Prefer this over [`Self::request_broadcast`] to wait for a broadcast that may not be
+	/// online yet: a request settles with [`Error::Unroutable`] once the attached sessions
+	/// have delivered their initial announce sets, while this method keeps waiting for the
+	/// announcement however late it comes. Both raise announce interest, so a session that
+	/// solicits announces lazily starts doing so on either call.
 	pub async fn announced_broadcast(&self, path: impl AsPath) -> Option<broadcast::Consumer> {
 		let path = path.as_path();
 
@@ -2720,6 +2882,8 @@ impl Consumer {
 			dynamic: self.dynamic.clone(),
 			stats: self.stats.clone(),
 			exclude: self.exclude,
+			interest: self.interest.clone(),
+			session: self.session,
 		})
 	}
 
@@ -2741,6 +2905,19 @@ impl Consumer {
 	/// dynamic handler exists. A request that is registered while a handler is live but then loses
 	/// every handler before being served also resolves to [`Error::Unroutable`]. Unlike an announced
 	/// broadcast, a dynamically served one is never visible to [`Self::announced`].
+	///
+	/// A request for a path that is not yet announced raises announce interest at that exact
+	/// path: an attached session that has not solicited announces yet does so now, and the
+	/// request waits for the resulting initial announce set before concluding the path is
+	/// unannounced. Only sessions whose scope covers the path are waited on, so a peer
+	/// authorized elsewhere can never hold the request up. With no such session (or once
+	/// every one of them has delivered its initial set) it concludes immediately, as above.
+	///
+	/// The wait is only as good as the protocol's initial-set boundary: moq-lite-01/02
+	/// (ANNOUNCE_INIT) and moq-lite-05+ (ANNOUNCE_OK) mark one, so the request is race-free
+	/// there. moq-lite-03/04 and moq-transport mark none, so on those the request can still
+	/// conclude before an announcement that was in flight, exactly as it did before
+	/// announces were solicited lazily.
 	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<Requesting> {
 		let path = path.as_path();
 
@@ -2768,14 +2945,45 @@ impl Consumer {
 			Resolved::Missing => {}
 		}
 
-		let mut state = self.dynamic.lock();
+		// Not announced yet, but a lazy session may simply not have solicited announces.
+		// Wait for the announcement (raising interest at exactly this path, which is what
+		// makes such a session solicit) unless the table is already as warm as the attached
+		// sessions will make it. `warming` rather than `settled`: the interest that could
+		// wake a parked solicitor is the one this wait is about to raise, and the wait
+		// itself settles precisely once it is registered. `scope` fails for a path outside
+		// this cursor's prefixes, where no announcement can ever land; fall through like
+		// the settled case.
+		if self.interest.read().warming(&absolute)
+			&& let Some(scoped) = self.scope(std::slice::from_ref(&path))
+		{
+			// Untagged like `announced_broadcast`: a lookup, not egress forwarding.
+			let wait = AnnounceWait {
+				announced: scoped.untagged().announced(),
+				relative: path.to_owned(),
+				interest: self.interest.clone(),
+				dynamic: self.dynamic.clone(),
+				absolute,
+				fallback: None,
+			};
+			let requesting = Requesting::announce(wait).with_path(requested).with_stats(scope);
+			return kio::Pending::new(requesting);
+		}
+
+		let state = Self::dynamic_fallback(&self.dynamic, absolute);
+		kio::Pending::new(Requesting::new(state).with_path(requested).with_stats(scope))
+	}
+
+	// The fallback once a path is known not to be announced: a still-live broadcast a
+	// handler already served, a (possibly coalesced) pending request when a handler is
+	// alive to serve it, or `Unroutable`.
+	fn dynamic_fallback(dynamic: &kio::Shared<OriginDynamicState>, absolute: PathOwned) -> RequestState {
+		let mut state = dynamic.lock();
 
 		// Reuse a still-live broadcast a handler already served for this path, so repeat
 		// requests share one upstream subscription. A closed entry is stale; `get` drops it
 		// and returns `None`, so we fall through and re-serve below.
 		if let Some(weak) = state.served.get(&absolute) {
-			let resolved = Requesting::ready(weak.consume()).with_path(requested).with_stats(scope);
-			return kio::Pending::new(resolved);
+			return RequestState::Ready(weak.consume());
 		}
 
 		// Coalesce onto a pending request for the same path; otherwise register a new
@@ -2786,12 +2994,12 @@ impl Consumer {
 			let producer = kio::Producer::<PendingBroadcast>::default();
 			let consumer = producer.consume();
 			if state.requests.insert(absolute, producer).is_err() {
-				return kio::Pending::new(Requesting::failed(Error::Unroutable));
+				return RequestState::Failed(Error::Unroutable);
 			}
 			consumer
 		};
 
-		kio::Pending::new(Requesting::pending(consumer).with_path(requested).with_stats(scope))
+		RequestState::Pending(consumer)
 	}
 
 	/// Returns a new Consumer that automatically strips out the provided prefix.
@@ -2808,6 +3016,8 @@ impl Consumer {
 			dynamic: self.dynamic.clone(),
 			stats: self.stats.clone(),
 			exclude: self.exclude,
+			interest: self.interest.clone(),
+			session: self.session,
 		})
 	}
 
@@ -2836,11 +3046,12 @@ impl Consumer {
 pub struct AnnounceProducer {
 	nodes: OriginNodes,
 	root: PathOwned,
+	interest: kio::Producer<interest::Ledger>,
 }
 
 impl AnnounceProducer {
-	fn new(root: PathOwned, nodes: OriginNodes) -> Self {
-		Self { nodes, root }
+	fn new(root: PathOwned, nodes: OriginNodes, interest: kio::Producer<interest::Ledger>) -> Self {
+		Self { nodes, root, interest }
 	}
 
 	/// Subscribe to announce / unannounce events for this subtree.
@@ -2851,7 +3062,14 @@ impl AnnounceProducer {
 	pub fn consume(&self) -> AnnounceConsumer {
 		// Untagged: `AnnounceProducer` is used for internal announce plumbing, not
 		// egress attribution (which flows through `origin::Consumer::announced`).
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), stats::Session::default(), None)
+		let prefixes = self.nodes.interest_prefixes(&self.root);
+		AnnounceConsumer::new(
+			self.root.clone(),
+			self.nodes.clone(),
+			stats::Session::default(),
+			None,
+			interest::Guard::register(self.interest.clone(), prefixes, None),
+		)
 	}
 
 	/// Returns the prefix that is automatically stripped from announced paths.
@@ -2881,10 +3099,21 @@ pub struct AnnounceConsumer {
 	// opens one (bumping `announced` + `announced_bytes`); the matching unannounce
 	// drops it (bumping `announced_closed` + `announced_bytes`).
 	guards: HashMap<PathOwned, stats::Announce>,
+
+	// Announce-interest registrations released when this cursor drops. What makes a
+	// lazy session solicit announces at all. Held, never read.
+	#[allow(dead_code)]
+	interest: interest::Guard,
 }
 
 impl AnnounceConsumer {
-	fn new(root: PathOwned, nodes: OriginNodes, stats: stats::Session, exclude: Option<Origin>) -> Self {
+	fn new(
+		root: PathOwned,
+		nodes: OriginNodes,
+		stats: stats::Session,
+		exclude: Option<Origin>,
+		interest: interest::Guard,
+	) -> Self {
 		let state = kio::Producer::<OriginConsumerState>::default();
 		let id = ConsumerId::new();
 
@@ -2904,6 +3133,7 @@ impl AnnounceConsumer {
 			state,
 			stats,
 			guards: HashMap::new(),
+			interest,
 		}
 	}
 
@@ -7284,5 +7514,201 @@ mod tests {
 			source.server.abort();
 		}
 		settle().await;
+	}
+	/// Announce interest: `announced()` handles register in the ledger, a solicitor
+	/// is only needed for interest from someone other than its own session, and
+	/// dropping the last handle releases the demand.
+	#[tokio::test]
+	async fn interest_attributed_by_session() {
+		let origin = Origin::random().produce();
+		let session = interest::SessionId::new();
+		let solicitor = origin.solicitor(session);
+		let noop = kio::Waiter::noop();
+
+		assert!(!solicitor.is_needed(), "no interest yet");
+
+		// Interest raised on behalf of the solicitor's own peer (the publisher
+		// half's tagged egress consumer) is not demand for this solicitor.
+		let own = origin.consume().on_behalf_of(session).announced();
+		assert!(!solicitor.is_needed(), "own peer's interest must not reciprocate");
+
+		// Local interest is demand, and derived handles keep their tag.
+		let local = origin.consume().announced();
+		assert!(solicitor.is_needed());
+		drop(local);
+		assert!(!solicitor.is_needed(), "released with the handle");
+
+		// Another session's interest is demand too.
+		let other = origin.consume().on_behalf_of(interest::SessionId::new()).announced();
+		assert!(solicitor.poll_needed(&noop).is_ready());
+		drop(other);
+		drop(own);
+		assert!(!solicitor.is_needed());
+	}
+
+	/// A request on a cold table waits for a lazy session: interest is raised at the
+	/// exact path, and the request resolves the moment the announcement lands.
+	#[tokio::test]
+	async fn request_waits_for_lazy_session() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let solicitor = origin.solicitor(interest::SessionId::new());
+
+		let consumer = origin.consume();
+		let mut request = std::pin::pin!(consumer.request_broadcast("cam"));
+		assert!(request.as_mut().now_or_never().is_none(), "cold table: not settled yet");
+
+		// The pending request is what wakes the solicitor.
+		assert!(solicitor.is_needed(), "the request raises interest");
+
+		// The "session" delivers the announcement; the request resolves without the
+		// solicitor even reporting synced.
+		let _broadcast = origin.create_broadcast("cam", announce()).unwrap();
+		settle().await;
+		let resolved = request.now_or_never().expect("announced").expect("found");
+		assert_eq!(resolved.info().path, PathOwned::from("cam"));
+	}
+
+	/// A request on a cold table fails once every attached session has delivered its
+	/// initial set without the path, exactly like a warm-table miss.
+	#[tokio::test]
+	async fn request_settles_unroutable() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let solicitor = origin.solicitor(interest::SessionId::new());
+
+		let consumer = origin.consume();
+		let mut request = std::pin::pin!(consumer.request_broadcast("cam"));
+		assert!(request.as_mut().now_or_never().is_none(), "waiting on the solicitor");
+
+		// The initial set landed and `cam` was not in it.
+		solicitor.synced();
+		settle().await;
+		let result = request.now_or_never().expect("settled");
+		assert!(matches!(result, Err(Error::Unroutable)), "nothing announced");
+	}
+
+	/// With no attached session there is nothing to wait for: a request misses
+	/// immediately, exactly as before lazy solicitation existed.
+	#[tokio::test]
+	async fn request_immediate_without_solicitors() {
+		let origin = Origin::random().produce();
+		let result = origin
+			.consume()
+			.request_broadcast("cam")
+			.now_or_never()
+			.expect("nothing to wait for");
+		assert!(matches!(result, Err(Error::Unroutable)), "nothing announced");
+	}
+
+	/// A solicitor parked on interest it cannot serve must not hold requests
+	/// hostage: settling only waits for solicitors the interest actually needs.
+	#[tokio::test]
+	async fn request_ignores_own_sessions_solicitor() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let session = interest::SessionId::new();
+		// The requesting session's own solicitor: our request is tagged with the
+		// same session, so this solicitor is never needed and never syncs.
+		let _own_solicitor = origin.solicitor(session);
+		// An upstream session that is needed and delivers nothing.
+		let upstream = origin.solicitor(interest::SessionId::new());
+
+		let consumer = origin.consume().on_behalf_of(session);
+		let mut request = std::pin::pin!(consumer.request_broadcast("cam"));
+		assert!(request.as_mut().now_or_never().is_none(), "waiting on upstream");
+
+		upstream.synced();
+		settle().await;
+		let result = request.now_or_never().expect("settled");
+		assert!(matches!(result, Err(Error::Unroutable)), "nothing announced");
+	}
+
+	/// A session dying mid-wait detaches its solicitor, settling the requests that
+	/// were waiting on it.
+	#[tokio::test]
+	async fn request_settles_when_solicitor_drops() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let solicitor = origin.solicitor(interest::SessionId::new());
+
+		let consumer = origin.consume();
+		let mut request = std::pin::pin!(consumer.request_broadcast("cam"));
+		assert!(request.as_mut().now_or_never().is_none(), "waiting on the solicitor");
+
+		drop(solicitor);
+		settle().await;
+		let result = request.now_or_never().expect("settled");
+		assert!(matches!(result, Err(Error::Unroutable)), "nothing announced");
+	}
+
+	/// A session scoped somewhere else can neither announce a path nor speak for it, so
+	/// it must not hold a request hostage. Before this was prefix-aware, a stalled peer
+	/// anywhere blocked every cold request, turning a fast `Unroutable` into a hang.
+	#[tokio::test]
+	async fn request_ignores_a_disjoint_scope() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		// A session authorized only for `b`, which never delivers its initial set.
+		let elsewhere = origin
+			.scope(&[crate::Path::new("b")])
+			.expect("scope")
+			.solicitor(interest::SessionId::new());
+
+		let result = origin
+			.consume()
+			.request_broadcast("a/cam")
+			.now_or_never()
+			.expect("a solicitor scoped to b cannot answer for a");
+		assert!(matches!(result, Err(Error::Unroutable)), "nothing announced");
+
+		// And it was never woken to solicit on someone else's behalf.
+		assert!(!elsewhere.is_needed(), "interest in `a` is not `b`'s to serve");
+
+		// The same request does wait for a solicitor whose scope covers it.
+		let covering = origin
+			.scope(&[crate::Path::new("a")])
+			.expect("scope")
+			.solicitor(interest::SessionId::new());
+		let mut request = std::pin::pin!(origin.consume().request_broadcast("a/cam"));
+		assert!(request.as_mut().now_or_never().is_none(), "waits for the `a` session");
+		assert!(covering.is_needed(), "the request is `a`'s to serve");
+
+		covering.synced();
+		settle().await;
+		let result = request.now_or_never().expect("settled");
+		assert!(matches!(result, Err(Error::Unroutable)), "nothing announced");
+	}
+
+	/// Scoped and rooted handles register interest at their absolute prefixes, so a
+	/// narrow consumer raises narrow demand.
+	#[tokio::test]
+	async fn interest_prefixes_are_absolute() {
+		let origin = Origin::random().produce();
+		let solicitor = origin.solicitor(interest::SessionId::new());
+
+		let scoped = origin
+			.consume()
+			.scope(&[crate::Path::new("a/b")])
+			.expect("scope")
+			.announced();
+		assert!(solicitor.is_needed());
+		{
+			let prefixes = origin.interest.read().prefixes();
+			assert_eq!(prefixes, vec![PathOwned::from("a/b")]);
+		}
+		drop(scoped);
+
+		let rooted = origin.with_root("a").expect("root").consume().announced();
+		{
+			let prefixes = origin.interest.read().prefixes();
+			assert_eq!(prefixes, vec![PathOwned::from("a")], "rooted interest is absolute");
+		}
+		drop(rooted);
 	}
 }

--- a/rs/moq-net/tests/lazy_announce.rs
+++ b/rs/moq-net/tests/lazy_announce.rs
@@ -1,0 +1,202 @@
+//! Lazy announce solicitation over the in-memory mock transport (#2708).
+//!
+//! A session solicits announces only once its origin has announce interest, a peer's
+//! own solicitation is never reciprocated, and a `request_broadcast` on a cold table
+//! waits for the solicitation it triggers instead of failing.
+//!
+//! Time is paused in the reciprocation test: the mock transport does no real I/O, so
+//! a sleep only fires once every in-flight task has quiesced, making "nothing else
+//! arrived" a deterministic observation rather than a race.
+
+mod support;
+
+use std::time::Duration;
+
+use moq_net::{AsPath, Error, Origin, Version};
+use support::harness::{MockConnectOptions, MockPair, connect_mock};
+
+/// Maximum time any single test may run before being treated as a deadlock.
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Both wire families: the lite ANNOUNCE_PLEASE stream and the IETF
+/// SUBSCRIBE_NAMESPACE request, before and after their respective initial-set
+/// boundaries (AnnounceOk landed in lite-05).
+const VERSIONS: &[&str] = &["moq-lite-04", "moq-lite-05", "moq-transport-19"];
+
+/// The versions that mark the end of the initial announce set (ANNOUNCE_INIT on
+/// moq-lite-01/02, ANNOUNCE_OK on moq-lite-05+), which is what lets a cold
+/// `request_broadcast` wait for an announcement instead of racing it.
+const BOUNDED_VERSIONS: &[&str] = &["moq-lite-02", "moq-lite-05"];
+
+fn announced() -> moq_net::broadcast::Route {
+	moq_net::broadcast::Route::new().with_announce(true)
+}
+
+/// A peer's solicitation is served but never reciprocated: a session whose origin has
+/// no announce interest of its own solicits nothing, no matter how interested the
+/// peer is. The first local consumer then solicits, and the peer's broadcasts arrive.
+#[tokio::test]
+async fn peer_interest_is_not_reciprocated() {
+	tokio::time::pause();
+	for version in VERSIONS {
+		tokio::time::timeout(TEST_TIMEOUT, async {
+			let version: Version = version.parse().unwrap();
+
+			// Client: one origin wired in both directions, the common `connect_origin`
+			// shape, publishing `hello`.
+			let client_origin = Origin::random().produce();
+			let _hello = client_origin
+				.create_broadcast("hello", announced())
+				.expect("publish hello");
+
+			// Server: publishes `secret`, and holds announce interest of its own so it
+			// solicits the client immediately.
+			let server_pub = Origin::random().produce();
+			let _secret = server_pub
+				.create_broadcast("secret", announced())
+				.expect("publish secret");
+			let server_sub = Origin::random().produce();
+			let mut server_interest = server_sub.consume().announced();
+
+			let mut opts = MockConnectOptions::new(version);
+			opts.client_publish = Some(client_origin.clone());
+			opts.client_subscribe = Some(client_origin.clone());
+			opts.server_publish = Some(server_pub.clone());
+			opts.server_subscribe = Some(server_sub.clone());
+			let MockPair { client, server } = connect_mock(opts).await;
+
+			// The server's interest pulls the client's `hello` across: solicitation
+			// works, and the client has served the peer's announce interest.
+			loop {
+				let announce = server_interest.next().await.expect("server session died");
+				if announce.path.as_path() == moq_net::Path::new("hello").as_path() && announce.broadcast.is_some() {
+					break;
+				}
+			}
+
+			// Quiesce: with paused time this sleep only fires once nothing is left
+			// in flight, so a reciprocal solicitation (the bug) would have landed
+			// `secret` in the client's table by now.
+			tokio::time::sleep(Duration::from_secs(1)).await;
+
+			// A fresh consumer's initial replay is synchronous: what the client's
+			// table held before this consumer's own interest could solicit anything.
+			let mut client_announced = client_origin.consume().announced();
+			let mut initial = Vec::new();
+			while let Some(announce) = client_announced.try_next() {
+				if announce.broadcast.is_some() {
+					initial.push(announce.path);
+				}
+			}
+			assert!(
+				initial
+					.iter()
+					.any(|p| p.as_path() == moq_net::Path::new("hello").as_path()),
+				"version {version}: local publish missing from the initial replay"
+			);
+			assert!(
+				initial
+					.iter()
+					.all(|p| p.as_path() != moq_net::Path::new("secret").as_path()),
+				"version {version}: the peer's solicitation was reciprocated"
+			);
+
+			// That consumer IS interest: the client now solicits, and `secret` arrives.
+			loop {
+				let announce = client_announced.next().await.expect("client session died");
+				if announce.path.as_path() == moq_net::Path::new("secret").as_path() && announce.broadcast.is_some() {
+					break;
+				}
+			}
+
+			drop(client);
+			drop(server);
+		})
+		.await
+		.expect("test timed out (likely a mock deadlock)");
+	}
+}
+
+/// A `request_broadcast` for a path the peer announced resolves on a cold table: the
+/// request raises interest, the session solicits, and the announcement satisfies it.
+/// The data path stays live afterwards, since the solicited stream is what carries
+/// the route.
+///
+/// Only the versions that mark the end of the initial announce set can promise this.
+/// moq-lite-03/04 and moq-transport mark none, so the request may conclude before the
+/// announcement arrives; asserting otherwise there would be asserting a scheduling race.
+#[tokio::test]
+async fn request_resolves_after_lazy_solicitation() {
+	for version in BOUNDED_VERSIONS {
+		tokio::time::timeout(TEST_TIMEOUT, async {
+			let version: Version = version.parse().unwrap();
+
+			// Server publishes a broadcast with a track holding one frame.
+			let pub_origin = Origin::random().produce();
+			let mut broadcast = pub_origin
+				.create_broadcast("cam", announced())
+				.expect("create broadcast");
+			let mut track = broadcast.create_track("video", None).expect("create track");
+			let mut group = track.append_group().expect("append group");
+			group
+				.write_frame(moq_net::Timestamp::ZERO, b"frame".as_ref())
+				.expect("write frame");
+			group.finish().expect("finish group");
+
+			let sub_origin = Origin::random().produce();
+			let mut opts = MockConnectOptions::new(version);
+			opts.server_publish = Some(pub_origin.clone());
+			opts.client_subscribe = Some(sub_origin.clone());
+			let MockPair { client, server } = connect_mock(opts).await;
+
+			// Nothing consumed announcements before this request; it must trigger the
+			// solicitation itself rather than failing on the cold table.
+			let bc = sub_origin
+				.consume()
+				.request_broadcast("cam")
+				.await
+				.expect("request resolves once the announcement arrives");
+
+			// The route the solicited stream carries serves data.
+			let mut sub = bc.track("video").unwrap().subscribe(None).await.expect("subscribe");
+			let mut group = sub.recv_group().await.expect("recv_group").expect("track closed");
+			let frame = group.read_frame().await.expect("read frame").expect("frame");
+			assert_eq!(&frame.payload[..], b"frame", "version {version}");
+
+			drop(client);
+			drop(server);
+		})
+		.await
+		.expect("test timed out (likely a mock deadlock)");
+	}
+}
+
+/// A `request_broadcast` for a path nobody announced still fails, but only after the
+/// solicited initial set arrives: `Unroutable`, not a hang.
+#[tokio::test]
+async fn request_settles_unroutable_across_the_wire() {
+	for version in VERSIONS {
+		tokio::time::timeout(TEST_TIMEOUT, async {
+			let version: Version = version.parse().unwrap();
+
+			// The server has a publish origin, but nothing at the requested path.
+			let pub_origin = Origin::random().produce();
+			let sub_origin = Origin::random().produce();
+			let mut opts = MockConnectOptions::new(version);
+			opts.server_publish = Some(pub_origin.clone());
+			opts.client_subscribe = Some(sub_origin.clone());
+			let MockPair { client, server } = connect_mock(opts).await;
+
+			let result = sub_origin.consume().request_broadcast("missing").await;
+			assert!(
+				matches!(result, Err(Error::Unroutable)),
+				"version {version}: expected Unroutable"
+			);
+
+			drop(client);
+			drop(server);
+		})
+		.await
+		.expect("test timed out (likely a mock deadlock)");
+	}
+}

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -523,6 +523,12 @@ pub struct Cluster {
 	/// serving and publishing end together, instead of publishing ending early
 	/// because a caller dropped a producer it never asked for.
 	_stats_publisher: Option<moq_stats::Producer>,
+
+	/// Standing announce interest on the origin, held for the cluster's lifetime.
+	/// Sessions solicit announces lazily, but a relay wants every route up front:
+	/// redundant-route failover needs the alternatives in the table before anything
+	/// fails, and a cold mesh warms hop by hop instead of on demand.
+	_interest: Arc<origin::Interest>,
 }
 
 impl Cluster {
@@ -551,6 +557,7 @@ impl Cluster {
 		}
 		let info = origin::Info::new(id);
 		let origin = info.clone().produce();
+		let interest = Arc::new(origin.solicit());
 		let nodes = crate::nodes::Nodes::new(origin.clone());
 		tracing::info!(origin_id = %origin.id(), configured = config.id.is_some(), "cluster initialized");
 		Ok(Cluster {
@@ -563,6 +570,7 @@ impl Cluster {
 			origin,
 			stats: moq_net::stats::Registry::disabled(),
 			_stats_publisher: None,
+			_interest: interest,
 		})
 	}
 
@@ -580,6 +588,7 @@ impl Cluster {
 			.with_pool(cache.pool)
 			.with_cache_duration(cache.duration);
 		self.origin = self.info.clone().produce();
+		self._interest = Arc::new(self.origin.solicit());
 		self.nodes = self.nodes.with_origin(self.origin.clone());
 		self
 	}


### PR DESCRIPTION
Implements the Rust half of #2708, PR 1 of the plan in [the design comment](https://github.com/moq-dev/moq/issues/2708#issuecomment-5262066044).

## Problem

A session wired to feed an origin opened announce-interest streams for every allowed prefix at attach time (lite: one ANNOUNCE_PLEASE per prefix; IETF: one SUBSCRIBE_NAMESPACE), whether or not anything ever read an announcement. A publish-only endpoint, or one that only consumes known paths, paid announce traffic and per-session announce state for every broadcast it could see.

## Design

An **announce-interest ledger**, its own module at `model/interest.rs`, the shared foundation for #2610's `requested_announce()` and #2756. Two sides write to it:

- **Demand**: every `AnnounceConsumer` registers its absolute prefixes (an `interest::Guard`, refcounted, released on drop). That covers `announced()`, `announced_broadcast`, the wait inside `request_broadcast`, and the publisher half serving a peer's announce interest, which is what will let interest cascade hop by hop.
- **Supply**: each session's subscriber half attaches an `interest::Solicitor` at construction (so a request racing `connect()`'s return still sees it), parks on `Solicitor::needed()` until demand it should serve exists, then solicits every allowed prefix for the rest of the session, reporting `Solicitor::synced()` once the initial announce set lands (or provably never will). A GOAWAY while parked parks for good instead of erroring; the reconnect's session serves the interest.

Demand is **attributed by session**: interest is tagged with an `interest::SessionId` (`None` = the application itself), and the publisher half tags its egress consumer via `Consumer::on_behalf_of(session_id)`, so a session's subscriber half never treats its own peer's solicitation as demand. Without this, a relay soliciting a publish-only client would make the client solicit right back, and the saving would evaporate.

**Sticky, not per-prefix**: announce streams feed routes, so closing one would yank routes from under handed-out broadcasts. Once opened, streams stay for the session's lifetime. Per-prefix scoping and close-on-last-consumer need route-lifetime accounting and are follow-ups.

**`request_broadcast` keeps its connect-warm behavior** without the warmth: on a cold table it raises exact-path interest (waking a parked solicitor), resolves the moment the announcement lands, and falls through to the dynamic queue / `Unroutable` only once every attached solicitor that could answer for the path has delivered its initial set (`Ledger::settled`, scoped per path so a session authorized elsewhere can't hold a request hostage). With no attached session it resolves immediately, exactly as before. Settling ignores solicitors whose only qualifying interest is the requester's own session.

**The initial-set boundary per protocol**: moq-lite 01/02 use ANNOUNCE_INIT and 05+ use ANNOUNCE_OK's count; lite 03/04 mark no end, so they sync once the request is on the wire and a cold request still races the announcements, exactly as those versions always have. moq-transport also marks no end, but each SUBSCRIBE_NAMESPACE is acknowledged, so the IETF session syncs once every prefix has its response (the same drop-based countdown `connect()` uses, `src/connecting.rs`, promoted from `lite/`): a cold request still races the NAMESPACE messages behind the acknowledgment, but can no longer settle before the peer has even received the solicitation.

**The relay opts out** via the new `origin::Producer::solicit()` guard (`origin::Interest`, standing demand, no event queue): a mesh needs every route up front, since redundant-route failover depends on alternatives being present before anything fails, and a cold mesh warms hop by hop, which per-request settling would race. This is what keeps the full relay test suite (diamond failover, republish, cross-version mesh) green. Making relays lazy end-to-end needs multi-hop warm-state propagation and is future work tracked on #2708/#2610.

**`connect()`** gates on the initial announce set only when interest already exists at session start (a reconnect, or an origin consumed before connecting); otherwise it completes immediately.

## Wire

No format change. moq-lite already allows multiple Announce Streams with overlapping prefixes, and closing the stream is the existing interest cancellation; old peers interoperate untouched. The draft gains one clarifying sentence that announce interest may start and stop mid-session, plus a changelog bullet (`drafts/draft-lcurley-moq-lite.md`).

## Tests

- Model (`model/origin.rs`): session-attributed demand (own-peer interest never reciprocates), request waits on a lazy solicitor and resolves on announce, settles `Unroutable` on a synced/dropped solicitor, resolves immediately with no solicitors, own-session solicitors don't block settling, scoped/rooted handles register absolute prefixes.
- Lite subscriber (`lite/subscriber.rs`): no stream opens while nothing is interested; the first consumer opens exactly one ANNOUNCE_PLEASE per allowed prefix.
- IETF session (`ietf/session.rs`): regression test `request_waits_for_the_acknowledgment`, which fails both without the synchronous solicitor attach in `start()` (the request settles on a cold table before the spawned driver runs) and without the acknowledgment sync boundary (the request settles `Unroutable` before the solicitation reaches the wire).
- End-to-end (`tests/lazy_announce.rs`, lite-04 / lite-05 / moqt-19): a peer's solicitation is served but never reciprocated (deterministic via paused-time quiescence + the synchronous initial replay of a fresh consumer); a cold `request_broadcast` triggers solicitation, resolves, and the data path works; a request for a missing path settles `Unroutable` instead of hanging.

## Cross-package sync

- `js/net`: not in this PR; the JS forwarder only exists on #2705, so the mirror stacks on that branch (#2775, PR 2 of the plan). The vocabulary here matches its `interest` / solicit naming.
- `moq-ffi`/wrappers: no surface change (`solicit()` is additive and not yet exposed); compile-checked.
- `doc/concept` already describes `announced()` as demand-driven; no change needed.
- Found while validating: #2761 (pre-existing `cluster_diamond_goaway_seamless_failover` flake, reproduces identically on base `dev`).

Targets `dev`: behaviorally this changes when `connect()` returns and when announce streams open, and it builds on the dev-state session code.

(written by Fable 5)
