### PR TITLE
feat(ffi): expose generic CMAF muxing

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -264,6 +264,39 @@ Two knobs run the live encoder. `moq_publish_video_raw_bitrate` retunes it witho
 
 `moq_publish_audio_raw` is the same shape for PCM in and Opus out, and `moq_consume_video_raw` / `moq_consume_audio_raw` are the decode-side mirrors, delivering I420 frames and PCM through the usual callback contract.
 
+## CMAF muxing
+
+Create one muxer per encoded rendition. Use the same `origin_us` for audio and video so independently selected fragments share one zero-based presentation timeline:
+
+```c
+struct moq_cmaf_video_config config = {
+    .codec = "vp09.00.10.08",
+    .codec_len = strlen("vp09.00.10.08"),
+    .framerate = 30.0,
+    .container = 0,  // Legacy
+    .origin_us = interval_start_us,
+};
+int32_t muxer = moq_cmaf_video(&config);
+if (muxer < 0) {
+    fprintf(stderr, "muxer creation failed: %s\n", moq_error());
+}
+
+struct moq_cmaf_frame frame = {
+    .payload = payload,
+    .payload_size = payload_size,
+    .timestamp_us = timestamp_us,
+    .keyframe = true,
+    .duration_us = duration_us,
+    .has_duration = true,
+};
+struct moq_cmaf_output output = {0};
+if (moq_cmaf_mux(muxer, sequence, &frame, 1, &output) < 0) {
+    fprintf(stderr, "mux failed: %s\n", moq_error());
+}
+```
+
+`output.initialization` is NULL until inline H.264/H.265 parameter sets arrive. `output.fragment` is NULL when a batch produces no usable samples. Keep each batch within one codec configuration; if a rendition changes configuration, split and retry at the frame index reported by `moq_error`. Both buffers are borrowed and remain valid until the next call using that muxer or `moq_cmaf_close`.
+
 ## Raw Tracks
 
 Raw tracks carry arbitrary byte payloads without catalog or codec parsing. Use

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -175,6 +175,31 @@ err := broadcast.SetVideoProperties(moq.VideoProperties{
 })
 ```
 
+## Packaging fetched media as CMAF
+
+`CMAFMuxer` packages application-selected encoded frames. Give audio and video muxers the same origin so independently fetched fragments share one zero-based timeline:
+
+```go
+muxer, err := moq.NewVideoCMAFMuxer(catalog.Video[videoName], intervalStartUS)
+if err != nil {
+    log.Fatal(err)
+}
+defer muxer.Close()
+
+output, err := muxer.Mux(sequence, frames)
+if err != nil {
+    log.Fatal(err)
+}
+if output.Initialization != nil {
+    storeInit(output.Initialization)
+}
+if output.Fragment != nil {
+    storeFragment(output.Fragment)
+}
+```
+
+Inline H.264/H.265 metadata is resolved from the supplied frames, so `Initialization` is nil until parameter sets arrive. A batch with no usable samples can return no `Fragment`. Keep each batch within one codec configuration; split at the frame index reported by an error when a rendition is reconfigured. `MediaFrame.DurationUs` carries an exact sample duration when the source container provides one.
+
 ## Error handling
 
 A server can reject the connection on auth grounds: `ErrMoqErrorUnauthorized` (HTTP 401) or `ErrMoqErrorForbidden` (HTTP 403). These are terminal: retrying without new credentials won't help, so handle them separately from a transient transport failure. The `moq.IsAuthError` helper catches both:

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -160,6 +160,20 @@ video.finish()
 
 The track is named after the codec (`.avc3` / `.hev1`) and its catalog rendition appears once the first keyframe is encoded, so subscribers discover it through the catalog rather than a name you pick. `cut()` starts a new group at the next frame, which is optional: the encoder keyframes every `gop` frames on its own, and each of those cuts a group.
 
+### Packaging fetched media as CMAF
+
+`CmafMuxer` packages application-selected encoded frames. Give audio and video muxers the same origin so independently fetched fragments share one zero-based timeline:
+
+```kotlin
+CmafMuxer(catalog.video.getValue(videoName), originUs = intervalStartUs).use { muxer ->
+    val output = muxer.mux(sequence, frames)
+    output.initialization?.let(::storeInit)
+    output.fragment?.let(::storeFragment)
+}
+```
+
+Inline H.264/H.265 metadata is resolved from the supplied frames, so `initialization` is null until parameter sets arrive. A batch with no usable samples can return no `fragment`. Keep each batch within one codec configuration; split at the frame index reported by an error when a rendition is reconfigured. `MediaFrame.durationUs` carries an exact sample duration when the source container provides one.
+
 ## Serve
 
 `Server.listen(bind)` binds a listener, wires an internal origin for both directions, and returns an `AutoCloseable` `Server`. `serve()` accepts every session and holds it alive until it closes:

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -149,6 +149,22 @@ async for announcement in client.announced("prefix/"):
         ...
 ```
 
+### Packaging fetched media as CMAF
+
+`CmafMuxer` packages frames selected by the application, including frames read from fetched groups. Use one shared origin for audio and video so independently requested fragments stay synchronized:
+
+```python
+video_muxer = moq.CmafMuxer(catalog.video[video_name], origin_us=interval_start_us)
+output = video_muxer.mux(sequence, video_frames)
+
+if output.initialization is not None:
+    store_init(output.initialization)
+if output.fragment is not None:
+    store_fragment(output.fragment)
+```
+
+Inline H.264/H.265 metadata is resolved from the supplied frames, so `initialization` is `None` until the parameter sets arrive. A batch with no usable samples can return no `fragment`. Keep each batch within one codec configuration; split at the frame index reported by an error when a rendition is reconfigured. `MediaFrame.duration_us` carries an exact sample duration when the source container provides one.
+
 ### Catalog extensions
 
 Advertise application-specific metadata (for example a side-channel transcript track) as an untyped catalog section. The value is any JSON-serializable object; it rides alongside `video`/`audio` and reaches subscribers as `Catalog.sections`.

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -141,6 +141,24 @@ try broadcast.setVideoProperties(
 
 For sparse or replayed raw tracks, use `track.createGroup(sequence:)`. `track.finish(at:)` declares the exclusive end while still permitting lower groups, and `group.abort(errorCode:)` terminates a group with an application error.
 
+### Packaging fetched media as CMAF
+
+`CMAFMuxer` packages application-selected encoded frames. Give audio and video muxers the same origin so independently fetched fragments share one zero-based timeline:
+
+```swift
+let muxer = try CMAFMuxer(video: catalog.video[videoName]!, originTimestampUs: intervalStartUs)
+let output = try muxer.mux(sequence: sequence, frames: frames)
+
+if let initialization = output.initialization {
+    storeInit(initialization)
+}
+if let fragment = output.fragment {
+    storeFragment(fragment)
+}
+```
+
+Inline H.264/H.265 metadata is resolved from the supplied frames, so `initialization` is `nil` until parameter sets arrive. A batch with no usable samples can return no `fragment`. Keep each batch within one codec configuration; split at the frame index reported by an error when a rendition is reconfigured. `MediaFrame.durationUs` carries an exact sample duration when the source container provides one.
+
 ### Fetching raw groups
 
 Fetch retrieves one group by track name and group sequence without keeping a live subscription:

--- a/go/wrapper/moq/cmaf.go
+++ b/go/wrapper/moq/cmaf.go
@@ -1,0 +1,73 @@
+package moq
+
+import ffi "github.com/moq-dev/moq-go-ffi/moq"
+
+// CMAFOutput contains initialization and media data produced for one frame batch.
+type CMAFOutput struct {
+	// Initialization is the current init segment, or nil until codec metadata is available.
+	Initialization []byte
+	// Fragment is one media fragment, or nil when the batch produced no usable samples.
+	Fragment []byte
+}
+
+// CMAFMuxer packages one encoded audio or video rendition as CMAF.
+type CMAFMuxer struct {
+	inner *ffi.MoqCmafMuxer
+}
+
+// NewVideoCMAFMuxer creates a video muxer whose output timestamps are relative to originUS.
+func NewVideoCMAFMuxer(video Video, originUS uint64) (*CMAFMuxer, error) {
+	inner, err := ffi.NewMoqCmafMuxer(ffi.MoqCmafConfig{
+		Track:    ffi.MoqCmafTrackVideo{Config: video},
+		OriginUs: originUS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &CMAFMuxer{inner: inner}, nil
+}
+
+// NewAudioCMAFMuxer creates an audio muxer whose output timestamps are relative to originUS.
+func NewAudioCMAFMuxer(audio Audio, originUS uint64) (*CMAFMuxer, error) {
+	inner, err := ffi.NewMoqCmafMuxer(ffi.MoqCmafConfig{
+		Track:    ffi.MoqCmafTrackAudio{Config: audio},
+		OriginUs: originUS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &CMAFMuxer{inner: inner}, nil
+}
+
+// Initialization returns the current init segment, or nil until inline codec metadata arrives.
+func (m *CMAFMuxer) Initialization() ([]byte, error) {
+	initialization, err := m.inner.InitSegment()
+	if err != nil || initialization == nil {
+		return nil, err
+	}
+	return *initialization, nil
+}
+
+// Mux encodes one codec-configuration-consistent batch on the configured presentation timeline.
+func (m *CMAFMuxer) Mux(sequence uint32, frames []MediaFrame) (CMAFOutput, error) {
+	output, err := m.inner.Mux(sequence, frames)
+	if err != nil {
+		return CMAFOutput{}, err
+	}
+	return CMAFOutput{
+		Initialization: optionalBytes(output.Initialization),
+		Fragment:       optionalBytes(output.Fragment),
+	}, nil
+}
+
+// Close releases the native muxer.
+func (m *CMAFMuxer) Close() {
+	m.inner.Destroy()
+}
+
+func optionalBytes(value *[]byte) []byte {
+	if value == nil {
+		return nil
+	}
+	return *value
+}

--- a/go/wrapper/moq/moq_test.go
+++ b/go/wrapper/moq/moq_test.go
@@ -146,6 +146,38 @@ func TestVideoPropertiesUseDefaultedFields(t *testing.T) {
 	}
 }
 
+func TestCMAFMuxerConstructsAndRebasesFrames(t *testing.T) {
+	framerate := 30.0
+	video := moq.Video{
+		Codec:     "vp09.00.10.08",
+		Framerate: &framerate,
+		Container: moq.LegacyContainer(),
+	}
+	muxer, err := moq.NewVideoCMAFMuxer(video, 10_000_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer muxer.Close()
+
+	initialization, err := muxer.Initialization()
+	if err != nil || initialization == nil {
+		t.Fatalf("initialization=%v err=%v", initialization, err)
+	}
+	duration := uint64(17_000)
+	output, err := muxer.Mux(12, []moq.MediaFrame{{
+		Payload:     []byte("keyframe"),
+		TimestampUs: 10_000_000,
+		Keyframe:    true,
+		DurationUs:  &duration,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output.Initialization == nil || output.Fragment == nil {
+		t.Fatalf("output=%+v", output)
+	}
+}
+
 func TestFetchGroupAndServeDynamicMiss(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
@@ -208,7 +240,7 @@ func TestFetchGroupAndServeDynamicMiss(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := produced.WriteFrame(moq.Frame{Payload: []byte("archive"), TimestampUs: request.Sequence()*20_000}); err != nil {
+	if err := produced.WriteFrame(moq.Frame{Payload: []byte("archive"), TimestampUs: request.Sequence() * 20_000}); err != nil {
 		t.Fatal(err)
 	}
 	if err := produced.Finish(); err != nil {

--- a/go/wrapper/moq/types.go
+++ b/go/wrapper/moq/types.go
@@ -30,7 +30,7 @@ type (
 	Dimensions = ffi.MoqDimensions
 	// Frame is a raw track frame: a payload and its presentation timestamp in microseconds.
 	Frame = ffi.MoqFrame
-	// MediaFrame is a Frame plus the codec-derived keyframe flag carried on a media track.
+	// MediaFrame is an encoded sample with presentation time, keyframe status, and optional duration.
 	MediaFrame = ffi.MoqMediaFrame
 	// FetchGroupOptions configures a single FetchGroup call, currently just the delivery priority.
 	FetchGroupOptions = ffi.MoqFetchGroupOptions

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Cmaf.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Cmaf.kt
@@ -1,0 +1,39 @@
+package dev.moq
+
+import uniffi.moq.MoqCmafConfig
+import uniffi.moq.MoqCmafMuxer
+import uniffi.moq.MoqCmafTrack
+
+/** Initialization and media data produced for one frame batch. */
+data class CmafOutput(
+    /** The current initialization segment once codec metadata is available. */
+    val initialization: ByteArray?,
+    /** The media fragment, or null when the batch produced no usable samples. */
+    val fragment: ByteArray?,
+)
+
+/** Packages one encoded audio or video rendition as CMAF. */
+class CmafMuxer private constructor(private val ffi: MoqCmafMuxer) : AutoCloseable {
+    /** Creates a video muxer whose output timestamps are relative to [originUs]. */
+    constructor(video: Video, originUs: ULong = 0uL) : this(
+        MoqCmafMuxer(MoqCmafConfig(MoqCmafTrack.Video(video), originUs)),
+    )
+
+    /** Creates an audio muxer whose output timestamps are relative to [originUs]. */
+    constructor(audio: Audio, originUs: ULong = 0uL) : this(
+        MoqCmafMuxer(MoqCmafConfig(MoqCmafTrack.Audio(audio), originUs)),
+    )
+
+    /** The current initialization, or null until inline codec metadata arrives. */
+    val initialization: ByteArray?
+        get() = ffi.initSegment()
+
+    /** Encodes one codec-configuration-consistent batch on the configured presentation timeline. */
+    fun mux(sequence: UInt, frames: List<MediaFrame>): CmafOutput {
+        val output = ffi.mux(sequence, frames)
+        return CmafOutput(output.initialization, output.fragment)
+    }
+
+    /** Releases the native muxer. */
+    override fun close() = ffi.close()
+}

--- a/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
+++ b/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
@@ -88,6 +88,35 @@ class SmokeTest {
         }
     }
 
+    @Test
+    fun `cmaf muxer constructs and rebases frames`() {
+        val video = Video(
+            codec = "vp09.00.10.08",
+            description = null,
+            coded = null,
+            displayAspect = null,
+            bitrate = null,
+            framerate = 30.0,
+            container = uniffi.moq.MoqContainer.Legacy,
+        )
+        CmafMuxer(video, originUs = 10_000_000uL).use { muxer ->
+            assertTrue(muxer.initialization != null)
+            val output = muxer.mux(
+                12u,
+                listOf(
+                    MediaFrame(
+                        payload = "keyframe".encodeToByteArray(),
+                        timestampUs = 10_000_000uL,
+                        keyframe = true,
+                        durationUs = 17_000uL,
+                    ),
+                ),
+            )
+            assertTrue(output.initialization != null)
+            assertTrue(output.fragment != null)
+        }
+    }
+
     /** The typed JSON helpers round-trip a `@Serializable` value. */
     @Test
     fun `typed json snapshot round-trips a serializable value`() = runTest {

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -6,6 +6,7 @@ Real-time pub/sub with built-in caching, fan-out, and prioritization.
 from moq_ffi import MoqError as Error
 
 from .client import Client, connect
+from .cmaf import CmafMuxer, CmafOutput
 from .errors import is_auth, is_shutdown
 from .log import log_level
 from .origin import (
@@ -93,6 +94,8 @@ __all__ = [
     "BroadcastRequest",
     "Catalog",
     "CatalogConsumer",
+    "CmafMuxer",
+    "CmafOutput",
     "Client",
     "ConnectionStats",
     "Container",

--- a/py/moq-rs/moq/cmaf.py
+++ b/py/moq-rs/moq/cmaf.py
@@ -1,0 +1,51 @@
+"""CMAF packaging for application-selected encoded media frames."""
+
+from dataclasses import dataclass
+from typing import Sequence, cast
+
+from moq_ffi import (
+    MoqAudio,
+    MoqCmafConfig,
+    MoqCmafMuxer,
+    MoqCmafTrack,
+    MoqMediaFrame,
+    MoqVideo,
+)
+
+
+@dataclass(frozen=True)
+class CmafOutput:
+    """Initialization and media data produced for one frame batch."""
+
+    initialization: bytes | None
+    """The current initialization segment once codec metadata is available."""
+
+    fragment: bytes | None
+    """The media fragment, or ``None`` when the batch produced no usable samples."""
+
+
+class CmafMuxer:
+    """Package one encoded audio or video rendition as CMAF."""
+
+    def __init__(self, track: MoqVideo | MoqAudio, *, origin_us: int = 0) -> None:
+        """Create a muxer whose output timestamps are relative to ``origin_us``."""
+        if isinstance(track, MoqVideo):
+            ffi_track = MoqCmafTrack.VIDEO(config=track)
+        elif isinstance(track, MoqAudio):
+            ffi_track = MoqCmafTrack.AUDIO(config=track)
+        else:
+            raise TypeError("track must be a Video or Audio")
+        self._ffi = MoqCmafMuxer(MoqCmafConfig(track=cast(MoqCmafTrack, ffi_track), origin_us=origin_us))
+
+    @property
+    def initialization(self) -> bytes | None:
+        """Return the current initialization, or ``None`` until inline metadata arrives."""
+        return self._ffi.init_segment()
+
+    def mux(self, sequence: int, frames: Sequence[MoqMediaFrame]) -> CmafOutput:
+        """Encode one codec-configuration-consistent batch on the configured timeline."""
+        output = self._ffi.mux(sequence, list(frames))
+        return CmafOutput(
+            initialization=output.initialization,
+            fragment=output.fragment,
+        )

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -99,6 +99,34 @@ def test_unknown_format():
         broadcast.publish_media("nope", b"")
 
 
+def test_cmaf_muxer_constructs_and_rebases_frames():
+    video = moq.Video(
+        codec="vp09.00.10.08",
+        description=None,
+        coded=None,
+        display_aspect=None,
+        bitrate=None,
+        framerate=30.0,
+        container=cast(moq.Container, moq.Container.LEGACY()),
+    )
+    muxer = moq.CmafMuxer(video, origin_us=10_000_000)
+    assert muxer.initialization is not None
+
+    output = muxer.mux(
+        12,
+        [
+            moq.MediaFrame(
+                payload=b"keyframe",
+                timestamp_us=10_000_000,
+                keyframe=True,
+                duration_us=17_000,
+            )
+        ],
+    )
+    assert output.initialization is not None
+    assert output.fragment is not None
+
+
 async def test_local_publish_consume_audio():
     origin = moq.OriginProducer()
     broadcast = origin.create_broadcast("live")

--- a/rs/libmoq/src/cmaf.rs
+++ b/rs/libmoq/src/cmaf.rs
@@ -1,0 +1,306 @@
+//! Single-rendition CMAF muxing for application-selected encoded frames.
+
+use std::ffi::c_char;
+use std::str::FromStr;
+use std::time::Duration;
+
+use bytes::Bytes;
+
+use crate::{Error, Id, NonZeroSlab, State, ffi};
+
+const CONTAINER_LEGACY: u32 = 0;
+const CONTAINER_CMAF: u32 = 1;
+const CONTAINER_LOC: u32 = 2;
+
+/// Video rendition metadata used to create a CMAF muxer.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct moq_cmaf_video_config {
+	/// Codec string, such as `avc3.42c01f`, not NULL terminated.
+	pub codec: *const c_char,
+	/// Length of `codec` in bytes.
+	pub codec_len: usize,
+	/// Optional codec description bytes.
+	pub description: *const u8,
+	/// Length of `description` in bytes.
+	pub description_len: usize,
+	/// Encoded width in pixels, or zero when unknown.
+	pub coded_width: u32,
+	/// Encoded height in pixels, or zero when unknown.
+	pub coded_height: u32,
+	/// Frame rate, or zero when unknown.
+	pub framerate: f64,
+	/// Input container: 0 for Legacy, 1 for CMAF, or 2 for LOC.
+	pub container: u32,
+	/// Existing CMAF initialization bytes when `container` selects CMAF.
+	pub container_init: *const u8,
+	/// Length of `container_init` in bytes.
+	pub container_init_len: usize,
+	/// Timestamp subtracted from every output sample, in microseconds.
+	pub origin_us: u64,
+}
+
+/// Audio rendition metadata used to create a CMAF muxer.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct moq_cmaf_audio_config {
+	/// Codec string, such as `opus`, not NULL terminated.
+	pub codec: *const c_char,
+	/// Length of `codec` in bytes.
+	pub codec_len: usize,
+	/// Optional codec description bytes.
+	pub description: *const u8,
+	/// Length of `description` in bytes.
+	pub description_len: usize,
+	/// Audio sample rate in Hz.
+	pub sample_rate: u32,
+	/// Number of audio channels.
+	pub channel_count: u32,
+	/// Input container: 0 for Legacy, 1 for CMAF, or 2 for LOC.
+	pub container: u32,
+	/// Existing CMAF initialization bytes when `container` selects CMAF.
+	pub container_init: *const u8,
+	/// Length of `container_init` in bytes.
+	pub container_init_len: usize,
+	/// Timestamp subtracted from every output sample, in microseconds.
+	pub origin_us: u64,
+}
+
+/// One encoded sample supplied to a CMAF muxer.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct moq_cmaf_frame {
+	/// Encoded sample bytes borrowed for the duration of the mux call.
+	pub payload: *const u8,
+	/// Length of `payload` in bytes.
+	pub payload_size: usize,
+	/// Presentation timestamp in microseconds.
+	pub timestamp_us: u64,
+	/// Whether the sample can be decoded without an earlier sample.
+	pub keyframe: bool,
+	/// Exact sample duration in microseconds when `has_duration` is true.
+	pub duration_us: u64,
+	/// Whether `duration_us` is present.
+	pub has_duration: bool,
+}
+
+/// Borrowed CMAF initialization and media bytes produced by one mux call.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct moq_cmaf_output {
+	/// Current initialization bytes, or NULL while inline codec metadata is unresolved.
+	pub initialization: *const u8,
+	/// Length of `initialization` in bytes.
+	pub initialization_size: usize,
+	/// Media fragment bytes, or NULL when the batch produced no usable samples.
+	pub fragment: *const u8,
+	/// Length of `fragment` in bytes.
+	pub fragment_size: usize,
+}
+
+#[derive(Default)]
+pub(crate) struct Cmaf {
+	muxers: NonZeroSlab<Muxer>,
+}
+
+struct Muxer {
+	inner: moq_mux::container::fmp4::Muxer,
+	origin: Duration,
+	initialization: Option<Bytes>,
+	fragment: Option<Bytes>,
+}
+
+impl Cmaf {
+	fn insert(&mut self, inner: moq_mux::container::fmp4::Muxer, origin_us: u64) -> Result<Id, Error> {
+		self.muxers.insert(Muxer {
+			inner,
+			origin: Duration::from_micros(origin_us),
+			initialization: None,
+			fragment: None,
+		})
+	}
+
+	fn initialization(&mut self, id: Id, dst: &mut moq_cmaf_output) -> Result<(), Error> {
+		let muxer = self.muxers.get_mut(id).ok_or(Error::MediaNotFound)?;
+		muxer.initialization = muxer.inner.init()?;
+		muxer.fragment = None;
+		write_output(dst, muxer);
+		Ok(())
+	}
+
+	fn mux(
+		&mut self,
+		id: Id,
+		sequence: u32,
+		frames: Vec<moq_mux::container::Frame>,
+		dst: &mut moq_cmaf_output,
+	) -> Result<(), Error> {
+		let muxer = self.muxers.get_mut(id).ok_or(Error::MediaNotFound)?;
+		let output = muxer.inner.mux(sequence, muxer.origin, frames)?;
+		muxer.initialization = output.initialization;
+		muxer.fragment = output.fragment;
+		write_output(dst, muxer);
+		Ok(())
+	}
+
+	fn close(&mut self, id: Id) -> Result<(), Error> {
+		self.muxers.remove(id).ok_or(Error::MediaNotFound)?;
+		Ok(())
+	}
+}
+
+fn write_output(dst: &mut moq_cmaf_output, muxer: &Muxer) {
+	let (initialization, initialization_size) = borrowed_bytes(muxer.initialization.as_ref());
+	let (fragment, fragment_size) = borrowed_bytes(muxer.fragment.as_ref());
+	*dst = moq_cmaf_output {
+		initialization,
+		initialization_size,
+		fragment,
+		fragment_size,
+	};
+}
+
+fn borrowed_bytes(data: Option<&Bytes>) -> (*const u8, usize) {
+	match data {
+		Some(data) => (data.as_ptr(), data.len()),
+		None => (std::ptr::null(), 0),
+	}
+}
+
+unsafe fn description(data: *const u8, len: usize) -> Result<Option<Bytes>, Error> {
+	if data.is_null() {
+		return if len == 0 { Ok(None) } else { Err(Error::InvalidPointer) };
+	}
+	Ok(Some(Bytes::copy_from_slice(unsafe { ffi::parse_slice(data, len)? })))
+}
+
+unsafe fn container(kind: u32, init: *const u8, init_len: usize) -> Result<hang::catalog::Container, Error> {
+	Ok(match kind {
+		CONTAINER_LEGACY => hang::catalog::Container::Legacy,
+		CONTAINER_CMAF => {
+			let init = unsafe { ffi::parse_slice(init, init_len)? };
+			hang::catalog::Container::Cmaf {
+				init: Bytes::copy_from_slice(init),
+			}
+		}
+		CONTAINER_LOC => hang::catalog::Container::Loc,
+		_ => return Err(Error::InvalidCode),
+	})
+}
+
+/// Create a CMAF muxer for one video rendition.
+///
+/// Returns a non-zero muxer handle on success or a negative error code.
+///
+/// # Safety
+/// `config` and every non-NULL buffer it references must remain valid for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_cmaf_video(config: *const moq_cmaf_video_config) -> i32 {
+	ffi::enter(move || {
+		let raw = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
+		let codec = unsafe { ffi::parse_str(raw.codec, raw.codec_len)? };
+		let codec = hang::catalog::VideoCodec::from_str(codec).map_err(Error::Hang)?;
+		let mut config = hang::catalog::VideoConfig::new(codec);
+		config.description = unsafe { description(raw.description, raw.description_len)? };
+		if raw.coded_width != 0 && raw.coded_height != 0 {
+			config.coded_width = Some(raw.coded_width);
+			config.coded_height = Some(raw.coded_height);
+		}
+		config.framerate = (raw.framerate.is_finite() && raw.framerate > 0.0).then_some(raw.framerate);
+		config.container = unsafe { container(raw.container, raw.container_init, raw.container_init_len)? };
+		let muxer = moq_mux::container::fmp4::Muxer::video(&config)?;
+		State::lock().cmaf.insert(muxer, raw.origin_us)
+	})
+}
+
+/// Create a CMAF muxer for one audio rendition.
+///
+/// Returns a non-zero muxer handle on success or a negative error code.
+///
+/// # Safety
+/// `config` and every non-NULL buffer it references must remain valid for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_cmaf_audio(config: *const moq_cmaf_audio_config) -> i32 {
+	ffi::enter(move || {
+		let raw = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
+		let codec = unsafe { ffi::parse_str(raw.codec, raw.codec_len)? };
+		let codec = hang::catalog::AudioCodec::from_str(codec).map_err(Error::Hang)?;
+		let mut config = hang::catalog::AudioConfig::new(codec, raw.sample_rate, raw.channel_count);
+		config.description = unsafe { description(raw.description, raw.description_len)? };
+		config.container = unsafe { container(raw.container, raw.container_init, raw.container_init_len)? };
+		let muxer = moq_mux::container::fmp4::Muxer::audio(&config)?;
+		State::lock().cmaf.insert(muxer, raw.origin_us)
+	})
+}
+
+/// Read the muxer's current initialization segment.
+///
+/// Returned buffers remain valid until the next call using this muxer or until it is closed.
+///
+/// # Safety
+/// `dst` must point to writable `moq_cmaf_output` storage.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_cmaf_init(muxer: u32, dst: *mut moq_cmaf_output) -> i32 {
+	ffi::enter(move || {
+		let muxer = ffi::parse_id(muxer)?;
+		let dst = unsafe { dst.as_mut() }.ok_or(Error::InvalidPointer)?;
+		State::lock().cmaf.initialization(muxer, dst)
+	})
+}
+
+/// Normalize and encode one batch of frames on the muxer's presentation timeline.
+///
+/// A batch must not cross an inline codec configuration boundary. Split and retry at the
+/// input frame index reported by `moq_error` when a rendition is reconfigured.
+///
+/// Returned buffers remain valid until the next call using this muxer or until it is closed.
+///
+/// # Safety
+/// `frames` must point to `frame_count` valid frames, each payload must be readable for its
+/// declared size, and `dst` must point to writable `moq_cmaf_output` storage.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_cmaf_mux(
+	muxer: u32,
+	sequence: u32,
+	frames: *const moq_cmaf_frame,
+	frame_count: usize,
+	dst: *mut moq_cmaf_output,
+) -> i32 {
+	ffi::enter(move || {
+		let muxer = ffi::parse_id(muxer)?;
+		let frames = if frame_count == 0 {
+			&[][..]
+		} else {
+			if frames.is_null() {
+				return Err(Error::InvalidPointer);
+			}
+			unsafe { std::slice::from_raw_parts(frames, frame_count) }
+		};
+		let frames = frames
+			.iter()
+			.map(|frame| {
+				let payload = unsafe { ffi::parse_slice(frame.payload, frame.payload_size)? };
+				Ok(moq_mux::container::Frame {
+					payload: Bytes::copy_from_slice(payload),
+					timestamp: moq_net::Timestamp::from_micros(frame.timestamp_us)?,
+					keyframe: frame.keyframe,
+					duration: frame
+						.has_duration
+						.then(|| moq_net::Timestamp::from_micros(frame.duration_us))
+						.transpose()?,
+				})
+			})
+			.collect::<Result<Vec<_>, Error>>()?;
+		let dst = unsafe { dst.as_mut() }.ok_or(Error::InvalidPointer)?;
+		State::lock().cmaf.mux(muxer, sequence, frames, dst)
+	})
+}
+
+/// Release a CMAF muxer and invalidate its borrowed output buffers.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_cmaf_close(muxer: u32) -> i32 {
+	ffi::enter(move || {
+		let muxer = ffi::parse_id(muxer)?;
+		State::lock().cmaf.close(muxer)
+	})
+}

--- a/rs/libmoq/src/lib.rs
+++ b/rs/libmoq/src/lib.rs
@@ -19,6 +19,7 @@
 mod api;
 mod audio;
 mod client;
+mod cmaf;
 mod consume;
 mod error;
 mod ffi;
@@ -31,6 +32,7 @@ mod video;
 
 pub use api::*;
 pub use audio::*;
+pub use cmaf::*;
 pub use error::*;
 pub use id::*;
 pub use video::*;

--- a/rs/libmoq/src/state.rs
+++ b/rs/libmoq/src/state.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 
-use crate::{Client, Consume, Origin, Publish, Session, audio::Audio, video::Video};
+use crate::{Client, Consume, Origin, Publish, Session, audio::Audio, cmaf::Cmaf, video::Video};
 
 pub struct State {
 	pub session: Session,
@@ -9,6 +9,7 @@ pub struct State {
 	pub publish: Publish,
 	pub consume: Consume,
 	pub audio: Audio,
+	pub(crate) cmaf: Cmaf,
 	pub video: Video,
 }
 
@@ -21,6 +22,7 @@ impl State {
 			publish: Publish::default(),
 			consume: Consume::default(),
 			audio: Audio::default(),
+			cmaf: Cmaf::default(),
 			video: Video::default(),
 		}
 	}

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -124,6 +124,55 @@ fn opus_head() -> Vec<u8> {
 	head
 }
 
+#[test]
+fn cmaf_muxer_constructs_and_rebases_frames() {
+	let codec = b"vp09.00.10.08";
+	let config = moq_cmaf_video_config {
+		codec: codec.as_ptr().cast(),
+		codec_len: codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		coded_width: 0,
+		coded_height: 0,
+		framerate: 30.0,
+		container: 0,
+		container_init: std::ptr::null(),
+		container_init_len: 0,
+		origin_us: 10_000_000,
+	};
+	let muxer = unsafe { moq_cmaf_video(&config) };
+	assert!(
+		muxer > 0,
+		"{}",
+		unsafe { std::ffi::CStr::from_ptr(moq_error()) }.to_string_lossy()
+	);
+
+	let mut output = moq_cmaf_output {
+		initialization: std::ptr::null(),
+		initialization_size: 0,
+		fragment: std::ptr::null(),
+		fragment_size: 0,
+	};
+	assert_eq!(unsafe { moq_cmaf_init(muxer as u32, &mut output) }, 0);
+	assert!(!output.initialization.is_null());
+	assert!(output.initialization_size > 0);
+
+	let payload = b"keyframe";
+	let frame = moq_cmaf_frame {
+		payload: payload.as_ptr(),
+		payload_size: payload.len(),
+		timestamp_us: 10_000_000,
+		keyframe: true,
+		duration_us: 17_000,
+		has_duration: true,
+	};
+	assert_eq!(unsafe { moq_cmaf_mux(muxer as u32, 12, &frame, 1, &mut output) }, 0);
+	assert!(!output.initialization.is_null());
+	assert!(!output.fragment.is_null());
+	assert!(output.fragment_size > 0);
+	assert_eq!(moq_cmaf_close(muxer as u32), 0);
+}
+
 /// H.264 Annex B init with SPS + PPS extracted from Big Buck Bunny (1280x720, High profile, Level 3.1).
 fn h264_init() -> Vec<u8> {
 	let mut init = Vec::new();

--- a/rs/moq-ffi/src/cmaf.rs
+++ b/rs/moq-ffi/src/cmaf.rs
@@ -1,0 +1,121 @@
+//! Generic single-rendition CMAF muxing for application-selected media frames.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bytes::Bytes;
+
+use crate::error::MoqError;
+use crate::media::{MoqAudio, MoqMediaFrame, MoqVideo};
+
+/// The media configuration used by a single-rendition CMAF muxer.
+#[derive(uniffi::Enum)]
+pub enum MoqCmafTrack {
+	/// An encoded video rendition and its catalog metadata.
+	Video { config: MoqVideo },
+	/// An encoded audio rendition and its catalog metadata.
+	Audio { config: MoqAudio },
+}
+
+/// Options for constructing a single-rendition CMAF muxer.
+#[derive(uniffi::Record)]
+pub struct MoqCmafConfig {
+	/// The encoded rendition to package.
+	pub track: MoqCmafTrack,
+	/// Timestamp subtracted from every sample so independently fetched fragments share a timeline.
+	#[uniffi(default = 0)]
+	pub origin_us: u64,
+}
+
+/// CMAF data produced from one batch of encoded media frames.
+#[derive(uniffi::Record)]
+pub struct MoqCmafOutput {
+	/// The current `ftyp+moov`, once inline codec configuration has been resolved.
+	pub initialization: Option<Vec<u8>>,
+	/// One `moof+mdat`, or absent when the batch produced no usable samples.
+	pub fragment: Option<Vec<u8>>,
+}
+
+/// Muxes encoded media frames into CMAF initialization and media segments.
+#[derive(uniffi::Object)]
+pub struct MoqCmafMuxer {
+	inner: Mutex<moq_mux::container::fmp4::Muxer>,
+	origin: Duration,
+}
+
+#[uniffi::export]
+impl MoqCmafMuxer {
+	/// Create a single-rendition muxer.
+	#[uniffi::constructor]
+	pub fn new(config: MoqCmafConfig) -> Result<Arc<Self>, MoqError> {
+		let inner = match config.track {
+			MoqCmafTrack::Video { config } => moq_mux::container::fmp4::Muxer::video(&video_config(config)?)?,
+			MoqCmafTrack::Audio { config } => moq_mux::container::fmp4::Muxer::audio(&audio_config(config)?)?,
+		};
+		Ok(Arc::new(Self {
+			inner: Mutex::new(inner),
+			origin: Duration::from_micros(config.origin_us),
+		}))
+	}
+
+	/// Return the current initialization segment, or absent until inline codec metadata arrives.
+	pub fn init_segment(&self) -> Result<Option<Vec<u8>>, MoqError> {
+		let inner = self.inner.lock().map_err(|_| MoqError::Closed)?;
+		Ok(inner.init()?.map(|init| init.to_vec()))
+	}
+
+	/// Normalize and encode one batch of frames on the configured zero-based timeline.
+	///
+	/// A batch must not cross an inline codec configuration boundary. Split and retry at the
+	/// input frame index reported by the error when a rendition is reconfigured.
+	pub fn mux(&self, sequence: u32, frames: Vec<MoqMediaFrame>) -> Result<MoqCmafOutput, MoqError> {
+		let frames = media_frames(frames)?;
+		let mut inner = self.inner.lock().map_err(|_| MoqError::Closed)?;
+		let output = inner.mux(sequence, self.origin, frames)?;
+		Ok(MoqCmafOutput {
+			initialization: output.initialization.map(|init| init.to_vec()),
+			fragment: output.fragment.map(|fragment| fragment.to_vec()),
+		})
+	}
+}
+
+fn media_frames(frames: Vec<MoqMediaFrame>) -> Result<Vec<moq_mux::container::Frame>, MoqError> {
+	frames
+		.into_iter()
+		.map(|frame| {
+			Ok(moq_mux::container::Frame {
+				payload: Bytes::from(frame.payload),
+				timestamp: moq_net::Timestamp::from_micros(frame.timestamp_us)?,
+				keyframe: frame.keyframe,
+				duration: frame.duration_us.map(moq_net::Timestamp::from_micros).transpose()?,
+			})
+		})
+		.collect()
+}
+
+fn video_config(video: MoqVideo) -> Result<hang::catalog::VideoConfig, MoqError> {
+	let codec: hang::catalog::VideoCodec = video.codec.parse().map_err(|_| MoqError::Unsupported)?;
+	let mut config = hang::catalog::VideoConfig::new(codec);
+	config.description = video.description.map(Bytes::from);
+	if let Some(coded) = video.coded {
+		config.coded_width = Some(coded.width);
+		config.coded_height = Some(coded.height);
+	}
+	if let Some(display) = video.display_aspect {
+		config.display_aspect_width = Some(display.width);
+		config.display_aspect_height = Some(display.height);
+	}
+	config.bitrate = video.bitrate;
+	config.framerate = video.framerate;
+	config.container = video.container.into();
+	Ok(config)
+}
+
+fn audio_config(audio: MoqAudio) -> Result<hang::catalog::AudioConfig, MoqError> {
+	let codec: hang::catalog::AudioCodec = audio.codec.parse().map_err(|_| MoqError::Unsupported)?;
+	let mut config = hang::catalog::AudioConfig::new(codec, audio.sample_rate, audio.channel_count);
+	config.description = audio.description.map(Bytes::from);
+	config.bitrate = audio.bitrate;
+	config.container = audio.container.into();
+	Ok(config)
+}

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -168,15 +168,17 @@ impl Media {
 			return Ok(None);
 		};
 
-		let timestamp_us = timestamp_us(frame.timestamp)?;
+		let presentation_us = timestamp_us(frame.timestamp)?;
+		let duration_us = frame.duration.map(timestamp_us).transpose()?;
 
 		let mut buf = frame.payload;
 		let payload = buf.copy_to_bytes(buf.remaining()).to_vec();
 
 		Ok(Some(MoqMediaFrame {
 			payload,
-			timestamp_us,
+			timestamp_us: presentation_us,
 			keyframe: frame.keyframe,
+			duration_us,
 		}))
 	}
 }

--- a/rs/moq-ffi/src/lib.rs
+++ b/rs/moq-ffi/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(target_os = "android")]
 mod android;
 pub mod audio;
+pub mod cmaf;
 pub mod consumer;
 pub mod error;
 mod ffi;

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -112,7 +112,7 @@ pub struct MoqFrame {
 	pub timestamp_us: u64,
 }
 
-/// A [`MoqFrame`] plus the codec metadata a media track carries.
+/// An encoded media sample with keyframe and optional container-derived duration metadata.
 #[derive(Clone, uniffi::Record)]
 pub struct MoqMediaFrame {
 	/// The frame payload.
@@ -121,6 +121,9 @@ pub struct MoqMediaFrame {
 	pub timestamp_us: u64,
 	/// Whether this frame can be decoded without any earlier frame.
 	pub keyframe: bool,
+	/// Exact sample duration in microseconds, when carried by the media container or codec.
+	#[uniffi(default = None)]
+	pub duration_us: Option<u64>,
 }
 
 /// A best-effort raw track datagram, as received.

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -446,6 +446,71 @@ async fn fetches_cached_group_without_subscribing() {
 	assert!(fetched.read_frame().await.unwrap().is_none());
 }
 
+#[test]
+fn cmaf_muxer_emits_single_track_init_and_deterministic_zero_based_fragment() {
+	use moq_mux::mp4_atom::{self, DecodeMaybe};
+
+	let video = crate::media::MoqVideo {
+		codec: "vp09.00.10.08".into(),
+		description: None,
+		coded: None,
+		display_aspect: None,
+		bitrate: None,
+		framerate: Some(30.0),
+		container: crate::media::MoqContainer::Legacy,
+	};
+	let first_video = vec![
+		crate::media::MoqMediaFrame {
+			payload: b"keyframe".to_vec(),
+			timestamp_us: 10_000_000,
+			keyframe: true,
+			duration_us: Some(17_000),
+		},
+		crate::media::MoqMediaFrame {
+			payload: b"delta".to_vec(),
+			timestamp_us: 10_033_000,
+			keyframe: false,
+			duration_us: None,
+		},
+	];
+	let muxer = crate::cmaf::MoqCmafMuxer::new(crate::cmaf::MoqCmafConfig {
+		track: crate::cmaf::MoqCmafTrack::Video { config: video },
+		origin_us: 10_000_000,
+	})
+	.unwrap();
+
+	let init = muxer.init_segment().unwrap().unwrap();
+	let mut cursor = std::io::Cursor::new(init.as_slice());
+	let mut track_ids = Vec::new();
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).unwrap() {
+		if let mp4_atom::Any::Moov(moov) = atom {
+			track_ids = moov.trak.iter().map(|trak| trak.tkhd.track_id).collect();
+		}
+	}
+	assert_eq!(track_ids, [1]);
+
+	let video_fragment = muxer.mux(12, first_video).unwrap().fragment.unwrap();
+	let fragment_info = [video_fragment]
+		.into_iter()
+		.map(|fragment| {
+			let mut cursor = std::io::Cursor::new(fragment.as_slice());
+			while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).unwrap() {
+				if let mp4_atom::Any::Moof(moof) = atom {
+					let traf = &moof.traf[0];
+					return (
+						moof.mfhd.sequence_number,
+						traf.tfhd.track_id,
+						traf.tfdt.as_ref().unwrap().base_media_decode_time,
+						traf.trun[0].entries[0].duration,
+					);
+				}
+			}
+			panic!("fragment missing moof")
+		})
+		.collect::<Vec<_>>();
+	assert_eq!(fragment_info, [(12, 1, 0, Some(510))]);
+}
+
 #[tokio::test]
 async fn dynamic_track_serves_fetch_miss_and_priority() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();

--- a/rs/moq-mux/src/codec/h264/mod.rs
+++ b/rs/moq-mux/src/codec/h264/mod.rs
@@ -341,6 +341,7 @@ fn read_param_set_array(buf: &[u8], mut pos: usize, count: usize, params: &mut V
 /// The active set is scoped to the latest keyframe: a frame that carries
 /// parameter sets redefines them, so a mid-stream reconfiguration drops the
 /// superseded SPS/PPS instead of accumulating them forever.
+#[derive(Clone)]
 pub struct Avc1 {
 	avcc: Option<Bytes>,
 	/// The active SPS NALs (from the most recent keyframe that carried them).

--- a/rs/moq-mux/src/codec/h265/mod.rs
+++ b/rs/moq-mux/src/codec/h265/mod.rs
@@ -222,6 +222,7 @@ pub(crate) fn config_from_hvcc(hvcc: &[u8]) -> Result<hang::catalog::VideoConfig
 /// The active VPS/SPS/PPS set is scoped to the latest keyframe: a frame that
 /// carries parameter sets redefines them, so a mid-stream reconfiguration drops
 /// the superseded ones instead of accumulating them forever.
+#[derive(Clone)]
 pub struct Hvc1 {
 	hvcc: Option<Bytes>,
 	/// The active VPS NALs (from the most recent keyframe that carried them).

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -434,6 +434,7 @@ impl<S: Stream> Export<S> {
 						track.timescale,
 						config,
 						description.map(|d| d.as_ref()),
+						track.source.transforms_video(),
 					)?;
 					trexs.push(mp4_atom::Trex {
 						track_id: trak.tkhd.track_id,

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -173,6 +173,13 @@ pub enum Error {
 	/// Presentation timestamps do not reveal decode duration for reordered video.
 	#[error("duration-less video needs stated durations or presentation-ordered inference")]
 	MissingVideoDuration,
+
+	/// One batch crossed an inline codec configuration boundary.
+	#[error("codec configuration changed at input frame {index}; split the batch at that frame")]
+	CodecConfigChanged {
+		/// Zero-based input frame index where the new configuration appeared.
+		index: usize,
+	},
 }
 
 impl From<mp4_atom::Error> for Error {
@@ -528,6 +535,7 @@ pub(crate) fn synthesize_video_trak(
 	timescale: u64,
 	config: &VideoConfig,
 	description: Option<&[u8]>,
+	transformed: bool,
 ) -> Result<mp4_atom::Trak> {
 	let width = config.coded_width.unwrap_or(0) as u16;
 	let height = config.coded_height.unwrap_or(0) as u16;
@@ -554,8 +562,9 @@ pub(crate) fn synthesize_video_trak(
 		VideoCodec::H265(h265) => {
 			let mut cursor = std::io::Cursor::new(require_description()?);
 			let hvcc = mp4_atom::Hvcc::decode_body(&mut cursor).map_err(Error::from)?;
-			// `in_band` (catalog) ↔ hev1 sample entry; otherwise hvc1.
-			if h265.in_band {
+			// A normalized inline source has had VPS/SPS/PPS stripped from its samples,
+			// so it must advertise hvc1 even when the input catalog said hev1.
+			if h265.in_band && !transformed {
 				mp4_atom::Codec::from(mp4_atom::Hev1 {
 					visual,
 					hvcc,
@@ -1116,7 +1125,7 @@ mod tests {
 	fn synthesized_video_init_sets_the_track_flags() {
 		let mut config = VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
-		let video = synthesize_video_trak(1, 30_000, &config, None).unwrap();
+		let video = synthesize_video_trak(1, 30_000, &config, None, false).unwrap();
 		let init = encode_init(None, vec![video], Vec::new()).unwrap();
 		let moov = moov(&init);
 

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -1,4 +1,4 @@
-//! One-shot CMAF muxing for individually fetched groups.
+//! One-shot CMAF muxing for application-selected media frames.
 
 use std::time::Duration;
 
@@ -26,12 +26,21 @@ enum Kind {
 	Audio(AudioConfig),
 }
 
-/// Muxes one rendition's fetched groups into standalone CMAF, without a live subscription.
+/// CMAF data produced from one batch of encoded media frames.
+#[derive(Clone, Debug)]
+pub struct Output {
+	/// The current initialization segment, once codec configuration is available.
+	pub initialization: Option<Bytes>,
+	/// The media fragment, or `None` when the batch produced no usable samples.
+	pub fragment: Option<Bytes>,
+}
+
+/// Muxes one encoded rendition into standalone CMAF, without owning a subscription.
 ///
 /// The pull-based [`Export`](super::Export) subscribes to a whole broadcast and interleaves
-/// its tracks; `Muxer` is the building block for a fetch-on-demand consumer (an HLS/DASH
-/// origin) that retrieves one group at a time via
-/// [`track::Consumer::fetch_group`](moq_net::track::Consumer::fetch_group):
+/// its tracks. `Muxer` instead packages frames selected independently by an application.
+/// [`mux`](Self::mux) is the high-level transport-independent entry point: it normalizes a
+/// frame batch, rebases its timestamps, and returns matching initialization and fragment bytes.
 ///
 /// 1. [`read`](Self::read) decodes a fetched group into media [`Frame`]s, normalizing the
 ///    codec shape (Annex-B H.264/H.265 becomes length-prefixed, with the config record
@@ -136,27 +145,50 @@ impl Muxer {
 
 		let mut out: Vec<Frame> = Vec::new();
 		while let Some(frames) = self.container.read(group).await? {
-			for frame in frames {
-				let Some(transform) = self.transform.as_mut() else {
-					out.push(frame);
-					continue;
-				};
-				let payload = transform.transform(frame.payload.clone())?;
-				// Track the transform's record even after it is first set: a mid-stream
-				// reconfiguration rebuilds the avcC/hvcC with new parameter sets.
-				if let Some(d) = transform.codec_private()
-					&& self.description.as_ref() != Some(d)
-				{
-					self.description = Some(d.clone());
-				}
-				if let Some(payload) = payload {
-					out.push(Frame { payload, ..frame });
-				}
-			}
+			out.extend(self.normalize(frames)?);
 		}
 		if let Some(first) = out.first_mut() {
 			first.keyframe = true;
 		}
+		Ok(out)
+	}
+
+	fn normalize(&mut self, frames: Vec<Frame>) -> crate::Result<Vec<Frame>> {
+		let Some(mut transform) = self.transform.clone() else {
+			return Ok(frames);
+		};
+		let mut description = self.description.clone();
+		let mut out = Vec::with_capacity(frames.len());
+		for (index, frame) in frames.into_iter().enumerate() {
+			let Frame {
+				timestamp,
+				payload,
+				keyframe,
+				duration,
+			} = frame;
+			let payload = transform.transform(payload)?;
+			let next_description = transform.codec_private().cloned();
+			if description != next_description {
+				if !out.is_empty() {
+					return Err(Error::CodecConfigChanged { index }.into());
+				}
+				description = next_description;
+			}
+			// A length-prefixed sample without its config record is not independently usable.
+			// Match the streaming exporter and discard pre-config slices.
+			if let Some(payload) = payload
+				&& description.is_some()
+			{
+				out.push(Frame {
+					timestamp,
+					payload,
+					keyframe,
+					duration,
+				});
+			}
+		}
+		self.transform = Some(transform);
+		self.description = description;
 		Ok(out)
 	}
 
@@ -184,9 +216,13 @@ impl Muxer {
 			}
 			CatalogContainer::Legacy | CatalogContainer::Loc => {
 				let trak = match &self.kind {
-					Kind::Video(config) => {
-						synthesize_video_trak(TRACK_ID, self.timescale.as_u64(), config, self.description.as_deref())?
-					}
+					Kind::Video(config) => synthesize_video_trak(
+						TRACK_ID,
+						self.timescale.as_u64(),
+						config,
+						self.description.as_deref(),
+						self.transform.is_some(),
+					)?,
 					Kind::Audio(config) => synthesize_audio_trak(TRACK_ID, self.timescale.as_u64(), config)?,
 				};
 				trexs.push(mp4_atom::Trex {
@@ -217,8 +253,7 @@ impl Muxer {
 	/// To make each frame separately addressable instead, use
 	/// [`fragmenter`](Self::fragmenter).
 	pub fn fragment(&self, sequence: u32, frames: &[Frame]) -> crate::Result<Bytes> {
-		let frames = self.resolve_durations(frames)?;
-		Ok(super::encode_fragment(self.fragment_info(sequence), &frames)?)
+		self.fragment_owned(sequence, frames.to_vec())
 	}
 
 	/// A [`Fragmenter`] cutting this rendition into one fragment per frame.
@@ -256,6 +291,11 @@ impl Muxer {
 		Ok(frames)
 	}
 
+	fn fragment_owned(&self, sequence: u32, frames: Vec<Frame>) -> crate::Result<Bytes> {
+		let frames = self.resolve_durations(&frames)?;
+		Ok(super::encode_fragment(self.fragment_info(sequence), &frames)?)
+	}
+
 	/// Where a fragment sits: this muxer's single track, at its resolved timescale.
 	fn fragment_info(&self, sequence: u32) -> super::FragmentInfo {
 		super::FragmentInfo {
@@ -263,6 +303,44 @@ impl Muxer {
 			timescale: self.timescale,
 			sequence_number: sequence,
 		}
+	}
+
+	/// Encode a fragment after subtracting an application-selected presentation origin.
+	///
+	/// This is useful whenever independently requested fragments must share a zero-based timeline.
+	/// The origin must not be later than any supplied frame timestamp.
+	pub fn fragment_rebased(&self, sequence: u32, origin: Duration, frames: &[Frame]) -> crate::Result<Bytes> {
+		let mut rebased = Vec::with_capacity(frames.len());
+		for frame in frames {
+			let track_origin = moq_net::Timestamp::try_from(origin)?.convert(frame.timestamp.scale())?;
+			let timestamp = frame.timestamp.checked_sub(track_origin)?;
+			rebased.push(Frame {
+				timestamp,
+				..frame.clone()
+			});
+		}
+		self.fragment_owned(sequence, rebased)
+	}
+
+	/// Normalize encoded frames and package them with the matching CMAF initialization.
+	///
+	/// Inline H.264/H.265 parameter sets are absorbed and used to build the init segment before
+	/// the media fragment is encoded. Timestamps in the media fragment are relative to `origin`.
+	/// Pre-config samples are discarded. A batch that crosses a codec configuration boundary is
+	/// rejected so one init segment always describes every emitted sample. The origin must not be
+	/// later than any emitted frame timestamp.
+	pub fn mux(&mut self, sequence: u32, origin: Duration, frames: Vec<Frame>) -> crate::Result<Output> {
+		let frames = self.normalize(frames)?;
+		let initialization = self.init()?;
+		let fragment = if frames.is_empty() {
+			None
+		} else {
+			Some(self.fragment_rebased(sequence, origin, &frames)?)
+		};
+		Ok(Output {
+			initialization,
+			fragment,
+		})
 	}
 }
 
@@ -279,6 +357,211 @@ mod tests {
 			keyframe,
 			duration: None,
 		}
+	}
+
+	#[test]
+	fn muxer_rebases_fragment_to_explicit_origin() {
+		let mut video = VideoConfig::new(VideoCodec::VP8);
+		video.framerate = Some(30.0);
+		let muxer = Muxer::video(&video).unwrap();
+		let video_frames = vec![frame(10_000_000, true), frame(10_033_000, false)];
+		let video_fragment = muxer
+			.fragment_rebased(12, Duration::from_secs(10), &video_frames)
+			.unwrap();
+		let decoded_video = super::super::decode(video_fragment, moq_net::Timescale::new(30_000).unwrap()).unwrap();
+		assert!(decoded_video[0].timestamp.is_zero());
+		assert_eq!(decoded_video[1].timestamp.as_micros(), 33_000);
+	}
+
+	#[test]
+	fn muxer_resolves_inline_h264_before_emitting_cmaf() {
+		use hang::catalog::H264;
+
+		let mut video = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		video.coded_width = Some(320);
+		video.coded_height = Some(240);
+		video.framerate = Some(30.0);
+
+		let mut muxer = Muxer::video(&video).unwrap();
+		assert!(muxer.init().unwrap().is_none());
+
+		let output = muxer
+			.mux(
+				7,
+				Duration::from_secs(10),
+				vec![crate::container::test_util::video_frame(10_000_000, true)],
+			)
+			.unwrap();
+		assert_eq!(&output.initialization.unwrap()[4..8], b"ftyp");
+		assert_eq!(&output.fragment.unwrap()[4..8], b"moof");
+	}
+
+	#[test]
+	fn muxer_uses_cmaf_init_without_duplicate_codec_description() {
+		use hang::catalog::H264;
+
+		let mut video = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		video.coded_width = Some(320);
+		video.coded_height = Some(240);
+		video.framerate = Some(30.0);
+
+		let mut source = Muxer::video(&video).unwrap();
+		let output = source
+			.mux(
+				0,
+				Duration::ZERO,
+				vec![crate::container::test_util::video_frame(0, true)],
+			)
+			.unwrap();
+		video.container = CatalogContainer::Cmaf {
+			init: output.initialization.unwrap(),
+		};
+		video.description = None;
+
+		let remuxer = Muxer::video(&video).unwrap();
+		assert!(remuxer.init().unwrap().is_some());
+	}
+
+	#[test]
+	fn muxer_does_not_emit_inline_samples_before_configuration() {
+		use hang::catalog::H264;
+
+		let video = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		let mut muxer = Muxer::video(&video).unwrap();
+		let output = muxer
+			.mux(
+				0,
+				Duration::ZERO,
+				vec![crate::container::test_util::video_frame(0, false)],
+			)
+			.unwrap();
+		assert!(output.initialization.is_none());
+		assert!(output.fragment.is_none());
+	}
+
+	#[test]
+	fn muxer_rejects_a_codec_change_after_emitting_a_sample() {
+		use hang::catalog::H264;
+
+		let video = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		let first = crate::container::test_util::video_frame(0, true);
+		let mut changed_sps = crate::container::test_util::SPS.to_vec();
+		changed_sps[3] ^= 1;
+		let mut changed_payload = Vec::new();
+		for nal in [
+			changed_sps.as_slice(),
+			crate::container::test_util::PPS,
+			crate::container::test_util::IDR,
+		] {
+			changed_payload.extend_from_slice(&[0, 0, 0, 1]);
+			changed_payload.extend_from_slice(nal);
+		}
+		let changed = Frame {
+			timestamp: Timestamp::from_micros(33_000).unwrap(),
+			payload: Bytes::from(changed_payload),
+			keyframe: true,
+			duration: None,
+		};
+
+		let mut muxer = Muxer::video(&video).unwrap();
+		let error = muxer.mux(0, Duration::ZERO, vec![first.clone(), changed]).unwrap_err();
+		assert!(matches!(
+			error,
+			crate::Error::Cmaf(Error::CodecConfigChanged { index: 1 })
+		));
+		// Normalization is transactional, so the caller can split and retry the prefix.
+		assert!(muxer.mux(0, Duration::ZERO, vec![first]).is_ok());
+	}
+
+	#[test]
+	fn muxer_advertises_normalized_inline_h265_as_hvc1() {
+		use hang::catalog::{H265, VideoCodec};
+		use mp4_atom::DecodeMaybe;
+
+		let mut video = crate::codec::h265::config_from_hvcc(&crate::codec::h265::fixtures::hvcc()).unwrap();
+		let VideoCodec::H265(h265) = &video.codec else {
+			panic!("fixture must describe H.265");
+		};
+		video.codec = VideoCodec::H265(H265 {
+			in_band: true,
+			..h265.clone()
+		});
+		video.description = None;
+
+		let mut payload = Vec::new();
+		for nal in [
+			crate::codec::h265::fixtures::VPS,
+			crate::codec::h265::fixtures::SPS,
+			crate::codec::h265::fixtures::PPS,
+			&[0x26, 0x01, 0x80, 0xaa],
+		] {
+			payload.extend_from_slice(&[0, 0, 0, 1]);
+			payload.extend_from_slice(nal);
+		}
+
+		let mut muxer = Muxer::video(&video).unwrap();
+		let output = muxer
+			.mux(
+				0,
+				Duration::ZERO,
+				vec![Frame {
+					payload: Bytes::from(payload),
+					..frame(0, true)
+				}],
+			)
+			.unwrap();
+
+		let mut cursor = std::io::Cursor::new(output.initialization.unwrap());
+		while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).unwrap() {
+			if let mp4_atom::Any::Moov(moov) = atom {
+				assert!(matches!(
+					moov.trak[0].mdia.minf.stbl.stsd.codecs[0],
+					mp4_atom::Codec::Hvc1(_)
+				));
+				return;
+			}
+		}
+		panic!("initialization missing moov");
+	}
+
+	#[test]
+	fn muxer_preserves_explicit_sample_duration() {
+		let mut video = VideoConfig::new(VideoCodec::VP8);
+		video.framerate = Some(30.0);
+		let mut muxer = Muxer::video(&video).unwrap();
+		let exact = Timestamp::from_micros(17_000).unwrap();
+		let output = muxer
+			.mux(
+				0,
+				Duration::ZERO,
+				vec![Frame {
+					duration: Some(exact),
+					..frame(0, true)
+				}],
+			)
+			.unwrap();
+		let decoded = super::super::decode(output.fragment.unwrap(), moq_net::Timescale::new(30_000).unwrap()).unwrap();
+		assert_eq!(decoded[0].duration.unwrap().as_micros(), 17_000);
 	}
 
 	// A fetched Legacy group round-trips through the muxer into a self-contained fragment:
@@ -517,7 +800,7 @@ mod tests {
 		assert!(muxer.with_timescale(moq_net::Timescale::new(90_000).unwrap()).is_err());
 	}
 
-	// The HLS origin accumulates every group of a (multi-group) audio segment into ONE fragment,
+	// A consumer may accumulate every group of a multi-group audio interval into ONE fragment,
 	// and for audio those groups are often one packet each -- so every sample sits at a group
 	// boundary and none of them may borrow the next packet's timestamp (consecutive sequence
 	// numbers don't rule out a publisher pausing across the boundary). Opus stating its own

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -17,7 +17,7 @@ use std::task::Poll;
 use std::time::Duration;
 
 use bytes::Bytes;
-use hang::catalog::{AudioConfig, VideoCodec, VideoConfig};
+use hang::catalog::{AudioConfig, Container, VideoCodec, VideoConfig};
 
 use crate::catalog::hang::Container as HangContainer;
 use crate::codec::h264::Avc1;
@@ -25,6 +25,7 @@ use crate::codec::h265::Hvc1;
 use crate::container::{Consumer, Frame};
 
 /// Per-track video transform that bridges between codec shapes.
+#[derive(Clone)]
 pub(crate) enum VideoTransform {
 	Avc1(Avc1),
 	Hvc1(Hvc1),
@@ -160,6 +161,11 @@ impl ExportSource {
 		self.transform.is_none() || self.description.is_some()
 	}
 
+	/// True when inline parameter sets are converted to an out-of-band sample shape.
+	pub fn transforms_video(&self) -> bool {
+		self.transform.is_some()
+	}
+
 	/// Pull the next normalized frame.
 	///
 	/// Parameter-only frames (SPS/PPS-only inputs to the Avc3 transform) are
@@ -253,6 +259,11 @@ impl ExportSource {
 /// Build a video transform for an Annex-B source, or `None` if the catalog
 /// already provides an out-of-band description.
 pub(crate) fn build_video_transform(config: &VideoConfig) -> Option<VideoTransform> {
+	// CMAF samples already use the shape declared by their init segment. The catalog may omit a
+	// duplicate `description`, but that does not make the decoded samples Annex-B.
+	if matches!(config.container, Container::Cmaf { .. }) {
+		return None;
+	}
 	let needs_transform = config.description.as_ref().map(|d| d.is_empty()).unwrap_or(true);
 	if !needs_transform {
 		return None;

--- a/swift/Sources/Moq/CMAF.swift
+++ b/swift/Sources/Moq/CMAF.swift
@@ -1,0 +1,61 @@
+import Foundation
+import MoqFFI
+
+/// CMAF data produced from one batch of encoded media frames.
+public struct CMAFOutput: Sendable {
+    /// The current initialization segment, once inline codec metadata is available.
+    public let initialization: Data?
+    /// The media fragment, or `nil` when the batch produced no usable samples.
+    public let fragment: Data?
+}
+
+/// Muxes one encoded media rendition into CMAF initialization and media segments.
+public final class CMAFMuxer: Sendable {
+    private let ffi: MoqCmafMuxer
+
+    /// Creates a video muxer whose output timestamps are relative to `originTimestampUs`.
+    ///
+    /// Use the same origin for independently fetched audio and video so their fragments share
+    /// one zero-based presentation timeline.
+    public init(video: Video, originTimestampUs: UInt64 = 0) throws {
+        self.ffi = try MoqCmafMuxer(
+            config: MoqCmafConfig(
+                track: .video(config: video),
+                originUs: originTimestampUs
+            )
+        )
+    }
+
+    /// Creates an audio muxer whose output timestamps are relative to `originTimestampUs`.
+    ///
+    /// Use the same origin for independently fetched audio and video so their fragments share
+    /// one zero-based presentation timeline.
+    public init(audio: Audio, originTimestampUs: UInt64 = 0) throws {
+        self.ffi = try MoqCmafMuxer(
+            config: MoqCmafConfig(
+                track: .audio(config: audio),
+                originUs: originTimestampUs
+            )
+        )
+    }
+
+    /// Returns the current initialization segment, or `nil` until inline codec metadata arrives.
+    public var initialization: Data? {
+        get throws {
+            try ffi.initSegment()
+        }
+    }
+
+    /// Normalizes and encodes a frame batch on the configured presentation timeline.
+    ///
+    /// The returned initialization matches the returned fragment. Inline H.264/H.265 parameter
+    /// sets are absorbed before the fragment is encoded. Split batches at codec reconfiguration
+    /// boundaries; the thrown error reports the first frame using the new configuration.
+    public func mux(sequence: UInt32, frames: [MediaFrame]) throws -> CMAFOutput {
+        let output = try ffi.mux(sequence: sequence, frames: frames)
+        return CMAFOutput(
+            initialization: output.initialization,
+            fragment: output.fragment
+        )
+    }
+}

--- a/swift/Tests/MoqTests/SmokeTests.swift
+++ b/swift/Tests/MoqTests/SmokeTests.swift
@@ -170,4 +170,32 @@ final class SmokeTests: XCTestCase {
         try track.finish()
         try broadcast.finish()
     }
+
+    func testCMAFMuxerConstructsAndRebasesFrames() throws {
+        let video = Video(
+            codec: "vp09.00.10.08",
+            description: nil,
+            coded: nil,
+            displayAspect: nil,
+            bitrate: nil,
+            framerate: 30,
+            container: .legacy
+        )
+        let muxer = try CMAFMuxer(video: video, originTimestampUs: 10_000_000)
+        XCTAssertNotNil(try muxer.initialization)
+
+        let output = try muxer.mux(
+            sequence: 12,
+            frames: [
+                MediaFrame(
+                    payload: Data("keyframe".utf8),
+                    timestampUs: 10_000_000,
+                    keyframe: true,
+                    durationUs: 17_000
+                )
+            ]
+        )
+        XCTAssertNotNil(output.initialization)
+        XCTAssertNotNil(output.fragment)
+    }
 }


### PR DESCRIPTION
## Summary

- Let applications package selected encoded audio or video frames into standalone CMAF without owning a live subscription.
- Rebase independently selected fragments onto an explicit presentation origin, preserve exact sample durations, and return matching initialization and media data together.
- Resolve inline H.264 and H.265 configuration before emission, and reject batches that cross a codec reconfiguration boundary so one init segment always describes its fragment.
- Expose the same single-rendition muxer through Rust, UniFFI, C, Swift, Kotlin, Python, and Go.

## Public API changes

- Add `fmp4::Output`, `Muxer::fragment_rebased`, `Muxer::mux`, and `Error::CodecConfigChanged` to `moq-mux`.
- Add `MoqCmafTrack`, `MoqCmafConfig`, `MoqCmafOutput`, and `MoqCmafMuxer` to `moq-ffi`, plus optional `duration_us` metadata on `MoqMediaFrame`.
- Add the `moq_cmaf_*` configuration, frame, output, creation, muxing, initialization, and close surface to `libmoq`.
- Add idiomatic CMAF muxer wrappers for Swift, Kotlin, Python, and Go. These changes are additive and target `main`.

## Test plan

- `cargo fmt --all -- --check`
- `cargo check -p moq-mux -p moq-ffi -p libmoq`
- `cargo nextest run --all-targets -p moq-mux -p moq-ffi -p libmoq --no-fail-fast` (607 passed)

(Written by GPT-5)
