### PR TITLE
fix(js/net): resolve nextGroup as finished when the track closes above the cap

### DIFF
--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -378,12 +378,13 @@ type Served = { sequence: number; frameStart: number; payloads: string[] };
 
 /**
  * Serves `groups` (frame payloads per group, keyed by sequence) under `bounds`, and
- * reports every group stream that reached the wire plus the resolved SUBSCRIBE_START.
+ * reports every group stream that reached the wire plus the resolved
+ * SUBSCRIBE_START / SUBSCRIBE_END range.
  */
 async function serve(
 	groups: Record<number, string[]>,
 	bounds: { startGroup?: number; startFrame?: number; endGroup?: number; endFrame?: number },
-): Promise<{ start?: number; served: Served[] }> {
+): Promise<{ start?: number; end?: number; served: Served[] }> {
 	const pair = createMockTransportPair(ALPN_06_WIP);
 	const publisher = new Publisher(pair.server, Version.DRAFT_06, randomOrigin());
 
@@ -448,12 +449,16 @@ async function serve(
 		}
 
 		let start: number | undefined;
+		let end: number | undefined;
 		for (;;) {
 			const resp = await decodeSubscribeResponse(client.reader, Version.DRAFT_06);
 			if ("start" in resp) start = resp.start.group;
-			if ("end" in resp) break;
+			if ("end" in resp) {
+				end = resp.end.group;
+				break;
+			}
 		}
-		return { start, served };
+		return { start, end, served };
 	} finally {
 		// Settles the pending read as well as dropping the stream.
 		await reader.cancel();
@@ -511,6 +516,14 @@ test("lite draft-06: groups below the start group are not served", async () => {
 test("lite draft-06: groups past the end group are not served", async () => {
 	const { served } = await serve({ 0: ["w"], 1: ["x"], 2: ["y"], 3: ["z"] }, { startGroup: 1, endGroup: 2 });
 	expect(served.map((s) => s.sequence)).toEqual([1, 2]);
+});
+
+// SUBSCRIBE_END names the track's exclusive final boundary, not the capped delivered
+// range: a Rust peer feeds it into finish_at, so a truncated value would silently drop
+// the held-back groups across languages.
+test("lite draft-06: a capped subscription still reports the track's final boundary", async () => {
+	const { end } = await serve({ 0: ["w"], 1: ["x"], 2: ["y"], 3: ["z"] }, { startGroup: 1, endGroup: 2 });
+	expect(end).toBe(4);
 });
 
 // Group streams open with waitUntilAvailable, so a browser at its concurrent stream cap

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -489,14 +489,12 @@ export class Publisher {
 		let startSent = false;
 		let endSent = false;
 
-		// The track's exclusive final boundary: one past the highest sequence produced,
-		// 0 for a track that produced none. A Rust subscriber feeds SUBSCRIBE_END straight
-		// into finish_at, so it must name the track's boundary, not the delivered range
-		// (a subscription cap can hold produced groups back).
-		const boundary = () => {
-			const latest = track.latest();
-			return latest !== undefined ? latest + 1 : 0;
-		};
+		// The track's exclusive final boundary. A Rust subscriber feeds SUBSCRIBE_END
+		// straight into finish_at, so it must name the track's boundary (which counts
+		// datagram sequences too), not the delivered range: a subscription cap can hold
+		// produced groups back. The latest() fallback covers a subscription torn down
+		// before the producer declared it.
+		const boundary = () => track.final() ?? (track.latest() ?? -1) + 1;
 
 		// Settles once the producer closes cleanly, so SUBSCRIBE_END can go out while
 		// groups parked above the subscription's cap stay servable (a SUBSCRIBE_UPDATE
@@ -530,10 +528,12 @@ export class Publisher {
 			() => unsubscribe(),
 		);
 
+		// One read cursor across iterations: a boundary emission must not spawn a
+		// second concurrent nextGroup against the same subscriber. Declared outside the
+		// try so the finally can observe whatever was in flight when the loop exited
+		// (closing a late group, swallowing the rejection from our own teardown abort).
+		let next = track.nextGroup();
 		try {
-			// One read cursor across iterations: a boundary emission must not spawn a
-			// second concurrent nextGroup against the same subscriber.
-			let next = track.nextGroup();
 			for (;;) {
 				const result = await Promise.race(endSent ? [next, stream.closed] : [next, stream.closed, done]);
 				if (result === doneSentinel) {
@@ -547,10 +547,7 @@ export class Publisher {
 				}
 
 				const group = result;
-				if (!group) {
-					next.then((group) => group?.close()).catch(() => {});
-					break;
-				}
+				if (!group) break;
 				next = track.nextGroup();
 
 				const range = frameRange(bounds, group.sequence);
@@ -593,6 +590,7 @@ export class Publisher {
 			track.close(e);
 			stream.reset(e);
 		} finally {
+			next.then((group) => group?.close()).catch(() => {});
 			priority.close();
 		}
 	}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -487,11 +487,29 @@ export class Publisher {
 		// first group is known, SUBSCRIBE_END when the track finishes.
 		const emitRange = supportsTrackStream(this.version);
 		let startSent = false;
+		let endSent = false;
 
-		// The exclusive end of the delivered range. recvGroup is arrival-ordered rather than
-		// sequence-ordered, so this tracks the max and not the last group seen. 0 is already
-		// the encoding for a track that produced no groups.
-		let end = 0;
+		// The track's exclusive final boundary: one past the highest sequence produced,
+		// 0 for a track that produced none. A Rust subscriber feeds SUBSCRIBE_END straight
+		// into finish_at, so it must name the track's boundary, not the delivered range
+		// (a subscription cap can hold produced groups back).
+		const boundary = () => {
+			const latest = track.latest();
+			return latest !== undefined ? latest + 1 : 0;
+		};
+
+		// Settles once the producer closes cleanly, so SUBSCRIBE_END can go out while
+		// groups parked above the subscription's cap stay servable (a SUBSCRIBE_UPDATE
+		// can still raise it; see the Rust publisher's Recv::Boundary). Rejects on abort,
+		// which the catch below turns into a reset.
+		const doneSentinel = Symbol("done");
+		const done = (async (): Promise<typeof doneSentinel> => {
+			const closed = await track.closed;
+			if (closed instanceof Error) throw closed;
+			return doneSentinel;
+		})();
+		// The loop can exit on the peer's FIN before an abort settles this; keep it quiet.
+		void done.catch(() => {});
 
 		// One ranking for the whole subscription, shared by every group it serves.
 		const priority = new Priority(track);
@@ -513,13 +531,27 @@ export class Publisher {
 		);
 
 		try {
+			// One read cursor across iterations: a boundary emission must not spawn a
+			// second concurrent nextGroup against the same subscriber.
+			let next = track.nextGroup();
 			for (;;) {
-				const next = track.nextGroup();
-				const group = await Promise.race([next, stream.closed]);
+				const result = await Promise.race(endSent ? [next, stream.closed] : [next, stream.closed, done]);
+				if (result === doneSentinel) {
+					// The producer finished: declare the boundary now and keep serving
+					// whatever a later cap raise releases, until the peer FINs.
+					endSent = true;
+					if (emitRange) {
+						await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
+					}
+					continue;
+				}
+
+				const group = result;
 				if (!group) {
 					next.then((group) => group?.close()).catch(() => {});
 					break;
 				}
+				next = track.nextGroup();
 
 				const range = frameRange(bounds, group.sequence);
 				if (!range) {
@@ -534,7 +566,6 @@ export class Publisher {
 					startSent = true;
 					await encodeSubscribeResponse(stream, { start: new SubscribeStart(group.sequence) }, this.version);
 				}
-				end = Math.max(end, group.sequence + 1);
 
 				void this.#runGroup({
 					sub,
@@ -547,8 +578,8 @@ export class Publisher {
 				});
 			}
 
-			if (emitRange) {
-				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(end) }, this.version);
+			if (emitRange && !endSent) {
+				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
 			}
 
 			console.debug(`publish close: broadcast=${broadcast} track=${track.name}`);

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -545,7 +545,6 @@ export class Publisher {
 					start: range.start,
 					end: range.end,
 				});
-				if (bounds.endGroup !== undefined && group.sequence >= bounds.endGroup) break;
 			}
 
 			if (emitRange) {

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -275,6 +275,33 @@ test("a closed track still delivers a group parked above the cap once the cap is
 	expect(await track.nextGroup()).toBeUndefined();
 });
 
+// The final boundary counts datagrams: they share the group sequence namespace, and a
+// Rust peer feeds SUBSCRIBE_END into finish_at, so a boundary that ignored a trailing
+// datagram would finalize the track before it arrives.
+test("final reports one past the highest produced sequence, datagrams included", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+	expect(track.final()).toBeUndefined();
+
+	producer.writeGroup(new GroupProducer(0));
+	producer.appendDatagram(Timestamp.fromMillis(1), enc.encode("x"));
+	producer.close();
+	expect(track.final()).toBe(2);
+});
+
+// 0 is the only encoding for "nothing produced"; an abort declares no boundary at all.
+test("final is 0 for an empty track and undefined after an abort", async () => {
+	const empty = new TrackProducer("test");
+	const emptyTrack = empty.subscribe();
+	empty.close();
+	expect(emptyTrack.final()).toBe(0);
+
+	const aborted = new TrackProducer("test");
+	const abortedTrack = aborted.subscribe();
+	aborted.close(new Error("boom"));
+	expect(abortedTrack.final()).toBeUndefined();
+});
+
 test("readFrame does not livelock when a sole group finishes before the next arrives", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -241,26 +241,38 @@ test("nextGroup returns undefined when track closes", async () => {
 	expect(await track.nextGroup()).toBeUndefined();
 });
 
-// Close kills every buffered group, so a group parked above the cap can never be
-// delivered. nextGroup must report the track finished rather than wait forever
-// for a cap raise that has nothing left to release.
-test("nextGroup resolves undefined when the track closes with a group parked above the cap", async () => {
+// Close doesn't erase buffered frames: a group parked above the cap stays readable, so
+// nextGroup must keep waiting for a cap raise rather than fake an end-of-track and lose
+// the data (mirrors the Rust subscriber). Only a drained closed track reports finished.
+test("a closed track still delivers a group parked above the cap once the cap is raised", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();
 
-	for (let sequence = 0; sequence < 4; sequence++) producer.writeGroup(new GroupProducer(sequence));
+	for (let sequence = 0; sequence < 3; sequence++) {
+		const group = new GroupProducer(sequence);
+		group.writeString(`frame-${sequence}`);
+		group.close();
+		producer.writeGroup(group);
+	}
 
-	track.endAt(2);
+	track.endAt(1);
 	expect((await track.nextGroup())?.sequence).toBe(0);
 	expect((await track.nextGroup())?.sequence).toBe(1);
-	expect((await track.nextGroup())?.sequence).toBe(2);
 
-	// Group 3 is parked above the cap while the track is live.
+	// Group 2 parks above the cap; a clean close must not resolve it as finished.
 	const parked = track.nextGroup();
-	expect(await Promise.race([parked, Promise.resolve("pending")])).toBe("pending");
-
 	producer.close();
-	expect(await parked).toBeUndefined();
+	const timeout = new Promise((resolve) => setTimeout(() => resolve("pending"), 10));
+	expect(await Promise.race([parked, timeout])).toBe("pending");
+
+	// Raising the cap after close releases the buffered group, frames intact.
+	track.endAt(2);
+	const released = await parked;
+	expect(released?.sequence).toBe(2);
+	expect(await released?.readString()).toBe("frame-2");
+
+	// Drained and closed: now it's finished.
+	expect(await track.nextGroup()).toBeUndefined();
 });
 
 test("readFrame does not livelock when a sole group finishes before the next arrives", async () => {

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -241,6 +241,28 @@ test("nextGroup returns undefined when track closes", async () => {
 	expect(await track.nextGroup()).toBeUndefined();
 });
 
+// Close kills every buffered group, so a group parked above the cap can never be
+// delivered. nextGroup must report the track finished rather than wait forever
+// for a cap raise that has nothing left to release.
+test("nextGroup resolves undefined when the track closes with a group parked above the cap", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	for (let sequence = 0; sequence < 4; sequence++) producer.writeGroup(new GroupProducer(sequence));
+
+	track.endAt(2);
+	expect((await track.nextGroup())?.sequence).toBe(0);
+	expect((await track.nextGroup())?.sequence).toBe(1);
+	expect((await track.nextGroup())?.sequence).toBe(2);
+
+	// Group 3 is parked above the cap while the track is live.
+	const parked = track.nextGroup();
+	expect(await Promise.race([parked, Promise.resolve("pending")])).toBe("pending");
+
+	producer.close();
+	expect(await parked).toBeUndefined();
+});
+
 test("readFrame does not livelock when a sole group finishes before the next arrives", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -746,7 +746,10 @@ export class Subscriber {
 
 			const closed = this.#state.closed.peek();
 			if (closed instanceof Error) throw closed;
-			if (closed !== undefined && !group) return undefined;
+			// Reaching here with a group buffered means it's parked above the cap. Close
+			// already closed every buffered group, so a later cap raise has nothing left
+			// to deliver: the track is finished, not paused.
+			if (closed !== undefined) return undefined;
 
 			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -237,6 +237,12 @@ class TrackState {
 	/** Best-effort datagram channel, parallel to {@link groups}; an age-evicted send buffer per subscriber. */
 	datagrams = new Signal<BufferedDatagram[]>([]);
 	latest?: number;
+	/**
+	 * The exclusive final boundary, stamped when the producer closes cleanly: one past the
+	 * highest sequence produced. Groups and datagrams share the namespace, so this can
+	 * exceed `latest + 1` (which only tracks groups). Mirrors the Rust `final_sequence`.
+	 */
+	final?: number;
 	closed = new Once<Error | null>();
 	update: Signal<Subscription | undefined>;
 	/** Resolved once the producer commits the immutable properties. */
@@ -425,7 +431,10 @@ export class Producer {
 		this.#prune();
 		for (const entry of this.#cache) this.#mirror(entry, sink);
 
-		if (closed !== undefined) closeTrackState(sink, closed instanceof Error ? closed : undefined);
+		if (closed !== undefined) {
+			sink.final = this.#state.final;
+			closeTrackState(sink, closed instanceof Error ? closed : undefined);
+		}
 	}
 
 	// Recompute from every live sink because an update or close can narrow as well as widen
@@ -557,6 +566,11 @@ export class Producer {
 
 	/** Close the track and every subscriber, mirroring the abort to their groups. Idempotent. */
 	close(abort?: Error) {
+		// A clean close declares the final boundary; an abort ends without one.
+		if (abort === undefined && this.#state.closed.peek() === undefined) {
+			this.#state.final = this.#next ?? 0;
+			for (const sink of this.#sinks) sink.final = this.#state.final;
+		}
 		closeTrackState(this.#state, abort);
 		for (const { group } of this.#cache) group.close(abort);
 		for (const sink of this.#sinks) {
@@ -643,6 +657,16 @@ export class Subscriber {
 	/** Return the latest group sequence observed on this track, if any. */
 	latest(): number | undefined {
 		return this.#state.latest;
+	}
+
+	/**
+	 * The track's exclusive final boundary, known once the producer closes cleanly:
+	 * one past the highest sequence produced, or 0 for a track that produced none.
+	 * Groups and datagrams share the sequence namespace, so this can exceed
+	 * `latest() + 1`. Undefined while the track is live or after an abort.
+	 */
+	final(): number | undefined {
+		return this.#state.final;
 	}
 
 	/** Start this subscriber's local read cursor at `sequence`, without changing its wire request. */

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -746,10 +746,10 @@ export class Subscriber {
 
 			const closed = this.#state.closed.peek();
 			if (closed instanceof Error) throw closed;
-			// Reaching here with a group buffered means it's parked above the cap. Close
-			// already closed every buffered group, so a later cap raise has nothing left
-			// to deliver: the track is finished, not paused.
-			if (closed !== undefined) return undefined;
+			// A group parked above the cap stays deliverable even after a clean close
+			// (its frames remain buffered), so keep waiting for a cap raise. Only a
+			// drained track reports finished.
+			if (closed !== undefined && !group) return undefined;
 
 			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}


### PR DESCRIPTION
Fixes #2763. Unblocks CI on #2736.

## Root cause

`track.Subscriber.nextGroup()` parks above the `endAt` cap by design (#2758 semantics: a SUBSCRIBE_UPDATE can raise the cap later). But the lite publisher's serve loop had no way to observe the producer finishing while parked, so a capped subscription over a closed track hung forever and never emitted SUBSCRIBE_END. This hole predates the af7b5720f main->dev merge: on the pre-merge dev tip, `lite draft-06: groups past the end group are not served` (js/net/src/lite/publisher.test.ts) already hung for exactly this reason.

The conflict resolution in merge af7b5720f papered over that hang by hand-adding `if (bounds.endGroup !== undefined && group.sequence >= bounds.endGroup) break;` to the serve loop (the line is in neither parent). That break FINs the subscription the moment the cap is reached, which contradicts the serving-cap semantics and is what made `integration: lite applies initial and updated group bounds` fail deterministically: the racing FIN closed the consumer before the first group was read, and the updated bounds could never serve group 4.

## Fix

Mirror the Rust publisher's `Recv::Boundary` shape (rs/moq-net/src/lite/publisher.rs):

- `nextGroup()` keeps parking above the cap, even after a clean close. Close does not erase buffered frames, so a parked group stays deliverable when the cap is raised later; adversarial review caught an earlier revision of this PR that returned `undefined` there and silently dropped that data.
- The serve loop races a `finished` signal alongside `nextGroup()`. When the producer closes cleanly it sends SUBSCRIBE_END immediately and keeps serving whatever a later SUBSCRIBE_UPDATE releases until the peer FINs. The hand-written endGroup break is removed; uncapped flows drain and FIN as before.
- SUBSCRIBE_END names the track's exclusive final boundary, not the capped delivered range: a Rust peer feeds the value into `track::Producer::finish_at`, so a truncated boundary would silently drop the held-back groups across languages. A clean close now stamps the producer's sequence counter (which datagrams advance, mirroring Rust's `max_sequence`/`final_sequence`) on the track state, exposed as `Subscriber.final()`; review caught that deriving it from `latest()` missed trailing datagram sequences.
- The serve loop's prefetched `nextGroup()` is observed in a `finally`, so a failed SUBSCRIBE_START/END write no longer leaves it to surface the teardown abort as an unhandled rejection.

## Tests

- `a closed track still delivers a group parked above the cap once the cap is raised` (track.test.ts): pins the parking + post-close cap-raise delivery with frame contents intact.
- `final reports one past the highest produced sequence, datagrams included` and `final is 0 for an empty track and undefined after an abort` (track.test.ts).
- `lite draft-06: a capped subscription still reports the track's final boundary` (publisher.test.ts): groups 0-3 under cap 2 must report SUBSCRIBE_END 4, not 3; the serve harness now returns the decoded END value. Hangs on pre-merge dev, reports 3 on current dev.
- `integration: lite applies initial and updated group bounds` passes again.
- Full `js/net` suite: 394 pass, 0 fail. `just check` clean.

## Cross-package sync

No wire change (SUBSCRIBE_END already means the exclusive final boundary per the draft; this makes the JS publisher honor it), so no draft update. Rust is unaffected: this ports its existing boundary/park semantics to JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Fable 5)