### PR TITLE
fix(net): transmit groups in sequence order for ordered subscriptions

### DIFF
--- a/rs/moq-net/src/lite/priority.rs
+++ b/rs/moq-net/src/lite/priority.rs
@@ -35,9 +35,9 @@ pub struct Priority {
 	track: u8,
 	subscribe: u64,
 	group: u64,
-	/// The owning subscription's `Ordered` preference. Only ever read when
-	/// `subscribe` matches, so both sides of such a comparison agree on it; see
-	/// [`PriorityState::set_ordered`] for what keeps that true.
+	/// The owning subscription's `Ordered` preference, which decides which way
+	/// `group` is read. [`PriorityState::set_ordered`] moves a whole
+	/// subscription's groups at once so they agree on it.
 	ordered: bool,
 }
 
@@ -74,7 +74,15 @@ impl Ord for Priority {
 			// stable and independent of either one's direction. The older (lower id)
 			// subscription goes first.
 			.then(self.subscribe.cmp(&other.subscribe))
-			// Same subscription, so both sides carry its direction.
+			// Normally redundant, since one subscription's groups all carry its
+			// direction. It is here so the comparison below is reached only by two
+			// groups that agree on it, which makes this a total order for every
+			// value rather than only for well-formed ones: reversing the sense for
+			// one side alone is intransitive, and `sort` is documented to be free
+			// to panic on a comparator that does that. Nothing in the protocol
+			// stops a peer opening two SUBSCRIBEs with one id and disagreeing.
+			.then(self.ordered.cmp(&other.ordered))
+			// Both sides agree on the direction, so it can be read off either.
 			.then_with(|| match self.ordered {
 				true => self.group.cmp(&other.group),
 				false => other.group.cmp(&self.group),
@@ -561,6 +569,35 @@ mod tests {
 		assert_eq!(handles[0].current(), 0);
 		assert_eq!(handles[1].current(), 1);
 		assert_eq!(handles[total - 1].current(), u8::MAX);
+	}
+
+	/// `Ord` has to hold for every value, not just the ones a well-behaved peer
+	/// produces. Nothing stops a peer opening two SUBSCRIBEs with the same id and
+	/// opposite `Ordered`, which lands both directions under one subscribe id, and
+	/// a comparator that says `a < b` and `b < a` is free to panic `sort`.
+	#[test]
+	fn test_ord_is_total_across_mixed_directions() {
+		let mixed = [
+			Priority::ordered(100, 7, 1),
+			Priority::new(100, 7, 1),
+			Priority::ordered(100, 7, 2),
+			Priority::new(100, 7, 2),
+			Priority::new(100, 8, 1),
+			Priority::new(200, 7, 1),
+		];
+
+		for a in mixed {
+			for b in mixed {
+				// Antisymmetric, and agreeing with Eq on what equality means.
+				assert_eq!(a.cmp(&b), b.cmp(&a).reverse(), "{a:?} vs {b:?}");
+				assert_eq!(a.cmp(&b) == Ordering::Equal, a == b, "{a:?} vs {b:?}");
+				for c in mixed {
+					if a.cmp(&b) != Ordering::Greater && b.cmp(&c) != Ordering::Greater {
+						assert_ne!(a.cmp(&c), Ordering::Greater, "{a:?} <= {b:?} <= {c:?}");
+					}
+				}
+			}
+		}
 	}
 
 	/// A flip must not disturb a subscription that did not ask for one.

--- a/rs/moq-net/src/lite/priority.rs
+++ b/rs/moq-net/src/lite/priority.rs
@@ -14,33 +14,52 @@ use std::{
 // - On remove from Vec: pop highest priority item from overflow heap to backfill
 // - On remove from overflow: rebuild heap (rare case, acceptable O(n) cost)
 //
-// Priority ordering: higher track value = higher priority, then higher group rank = higher priority
+// Priority ordering: higher track value = higher priority, then subscription, then
+// group sequence in that subscription's own direction.
 
-/// A priority composed of a track-level priority and a group rank within the track.
-/// Higher `track` is always preferred; `group_rank` only breaks ties within the same
-/// track. The rank direction encodes the subscription's `Ordered` preference: a live
-/// subscription ranks newer groups first, an ordered one ranks older groups first.
+/// A group stream's rank: its subscription's track priority, the subscription it
+/// belongs to, and its group sequence.
+///
+/// Higher `track` always wins. `group` breaks ties only *within* one `subscribe`,
+/// in the direction that subscription asked for: a live subscription transmits the
+/// newest group first, an `Ordered` one the oldest.
+///
+/// Scoping the tie-break to a subscription is what keeps `Ordered` from deciding
+/// between tracks. The draft gives that job to `Priority` alone, so a session
+/// carrying an ordered track and a live one at equal priority must interleave them
+/// by priority, not by direction. Comparing the two directions in one space cannot
+/// do that: whichever encoding puts the oldest group on top also puts it above
+/// every group of the other subscription.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Priority {
 	track: u8,
-	group_rank: u64,
+	subscribe: u64,
+	group: u64,
+	/// The owning subscription's `Ordered` preference. Only ever read when
+	/// `subscribe` matches, so both sides of such a comparison agree on it; see
+	/// [`PriorityState::set_ordered`] for what keeps that true.
+	ordered: bool,
 }
 
 impl Priority {
 	/// Rank for a live (unordered) subscription: the newest group transmits first.
-	pub fn new(track: u8, group: u64) -> Self {
+	pub fn new(track: u8, subscribe: u64, group: u64) -> Self {
 		Self {
 			track,
-			group_rank: group,
+			subscribe,
+			group,
+			ordered: false,
 		}
 	}
 
 	/// Rank for an `Ordered` subscription: the oldest group transmits first, so
 	/// back-to-back groups leave the session in sequence order.
-	pub fn ordered(track: u8, group: u64) -> Self {
+	pub fn ordered(track: u8, subscribe: u64, group: u64) -> Self {
 		Self {
 			track,
-			group_rank: !group,
+			subscribe,
+			group,
+			ordered: true,
 		}
 	}
 }
@@ -51,7 +70,15 @@ impl Ord for Priority {
 		other
 			.track
 			.cmp(&self.track)
-			.then(other.group_rank.cmp(&self.group_rank))
+			// Which subscription wins a priority tie is arbitrary, but it has to be
+			// stable and independent of either one's direction. The older (lower id)
+			// subscription goes first.
+			.then(self.subscribe.cmp(&other.subscribe))
+			// Same subscription, so both sides carry its direction.
+			.then_with(|| match self.ordered {
+				true => self.group.cmp(&other.group),
+				false => other.group.cmp(&self.group),
+			})
 	}
 }
 
@@ -94,9 +121,14 @@ pub struct PriorityQueue {
 
 impl PriorityQueue {
 	// TODO Implement some sort of round robin between tracks with the same priority.
-	// The Group ID should only be used to break ties within the same track.
 	pub fn insert(&self, priority: Priority) -> PriorityHandle {
 		self.state.lock().unwrap().insert(priority, self.clone())
+	}
+
+	/// Apply a subscription's new `Ordered` preference to the groups it has already
+	/// queued, so a SUBSCRIBE_UPDATE reaches the backlog and not just what follows it.
+	pub fn set_ordered(&self, subscribe: u64, ordered: bool) {
+		self.state.lock().unwrap().set_ordered(subscribe, ordered);
 	}
 }
 
@@ -136,7 +168,7 @@ impl PriorityState {
 
 		PriorityHandle {
 			id,
-			priority,
+			track: priority.track,
 			rx,
 			seen: u8::MAX,
 			queue: myself,
@@ -178,7 +210,7 @@ impl PriorityState {
 			// Note: Ord is reversed (higher priority = "less than"), so `top < item`
 			// means `top` has higher priority. If an overflow item outranks the one
 			// we're placing, swap them so the higher-priority item lands in vec.
-			// This case only arises via `set_priority`: a fresh insert can't reach
+			// This case only arises via a re-rank: a fresh insert can't reach
 			// here with non-empty overflow because the invariant "every overflow
 			// item has lower priority than every vec item" is maintained on insert.
 			if let Some(Reverse(top)) = self.overflow.peek()
@@ -238,7 +270,7 @@ impl PriorityState {
 			Location::Overflow => {
 				// BinaryHeap has no O(log N) random removal, so drain and rebuild.
 				// Acceptable because overflow removal is rare (only when handle drops
-				// or a set_priority targets an item that has been demoted past index 254).
+				// or a re-rank targets an item that has been demoted past index 254).
 				let mut found = None;
 				let drained: Vec<_> = self.overflow.drain().collect();
 				for Reverse(entry) in drained {
@@ -253,10 +285,48 @@ impl PriorityState {
 		}
 	}
 
-	fn set_priority(&mut self, id: usize, new_priority: Priority) {
+	/// Change one item's track priority, leaving the rest of its rank alone.
+	///
+	/// Deliberately narrower than "write back a whole [`Priority`]": a handle's copy
+	/// of the direction goes stale the moment [`Self::set_ordered`] runs, and pushing
+	/// that copy back would resurrect the old direction for a single group.
+	fn set_track(&mut self, id: usize, track: u8) {
 		let mut item = self.extract(id);
-		item.priority = new_priority;
+		item.priority.track = track;
 		self.place(item);
+	}
+
+	/// Flip the group direction for every queued group of one subscription.
+	///
+	/// Done wholesale rather than per item because [`Priority`] is only a total order
+	/// while every group of a subscription agrees on its direction. Re-placing them
+	/// one at a time would leave the queue comparing an ordered rank against a live
+	/// one from the same subscription, which is intransitive and would corrupt the
+	/// sorted vec. The flip can also move entries across the vec/overflow boundary,
+	/// so both containers are rebuilt from one sorted snapshot.
+	fn set_ordered(&mut self, subscribe: u64, ordered: bool) {
+		let stale = |item: &PriorityItem| item.priority.subscribe == subscribe && item.priority.ordered != ordered;
+		if !self.vec.iter().any(stale) && !self.overflow.iter().any(|Reverse(item)| stale(item)) {
+			return;
+		}
+
+		let mut items = std::mem::take(&mut self.vec);
+		items.extend(self.overflow.drain().map(|Reverse(item)| item));
+		for item in &mut items {
+			if item.priority.subscribe == subscribe {
+				item.priority.ordered = ordered;
+			}
+		}
+		items.sort();
+
+		let overflow = items.split_off(items.len().min(MAX_VEC_SIZE));
+		self.vec = items;
+		self.update_indices_from(0);
+		for item in overflow {
+			let id = item.id;
+			self.overflow.push(Reverse(item));
+			Self::update_location(&mut self.indexes, id, Location::Overflow);
+		}
 	}
 
 	fn remove(&mut self, id: usize) {
@@ -277,7 +347,10 @@ impl PriorityState {
 
 pub struct PriorityHandle {
 	id: usize,
-	priority: Priority,
+	/// This item's track priority, the only part of its rank a handle owns. The
+	/// rest lives in the queue, which [`PriorityQueue::set_ordered`] can change
+	/// underneath us.
+	track: u8,
 	rx: kio::Consumer<u8>,
 	/// Last value observed via [`current`](Self::current)/[`next`](Self::next), so
 	/// `next` fires only on a real change.
@@ -334,11 +407,11 @@ impl PriorityHandle {
 	/// Change this item's track priority and re-sort the queue.
 	/// No-op if the track value hasn't changed.
 	pub fn set_track(&mut self, new_track: u8) {
-		if self.priority.track == new_track {
+		if self.track == new_track {
 			return;
 		}
-		self.priority.track = new_track;
-		self.queue.state.lock().unwrap().set_priority(self.id, self.priority);
+		self.track = new_track;
+		self.queue.state.lock().unwrap().set_track(self.id, new_track);
 	}
 }
 
@@ -346,10 +419,22 @@ impl PriorityHandle {
 mod tests {
 	use super::*;
 
+	/// A live subscription's group rank, on the one subscription these tests share.
+	/// Group order within a subscription is what most of them exercise, so scoping
+	/// them together is what keeps them testing it.
+	fn live(track: u8, group: u64) -> Priority {
+		Priority::new(track, 0, group)
+	}
+
+	/// The same, for a subscription that asked for `Ordered`.
+	fn older_first(track: u8, group: u64) -> Priority {
+		Priority::ordered(track, 0, group)
+	}
+
 	#[test]
 	fn test_single_item() {
 		let queue = PriorityQueue::default();
-		let mut handle = queue.insert(Priority::new(100, 5));
+		let mut handle = queue.insert(live(100, 5));
 		assert_eq!(handle.current(), 0); // First item is always index 0
 	}
 
@@ -359,8 +444,8 @@ mod tests {
 	#[test]
 	fn test_send_order_inverts_rank() {
 		let queue = PriorityQueue::default();
-		let mut top = queue.insert(Priority::new(200, 0));
-		let mut low = queue.insert(Priority::new(100, 0));
+		let mut top = queue.insert(live(200, 0));
+		let mut low = queue.insert(live(100, 0));
 
 		assert_eq!(top.current(), 0);
 		assert_eq!(top.send_order(), 255, "most urgent rank gets the highest send order");
@@ -373,9 +458,9 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Insert items with different track priorities
-		let mut low = queue.insert(Priority::new(50, 0));
-		let mut high = queue.insert(Priority::new(255, 0));
-		let mut mid = queue.insert(Priority::new(100, 0));
+		let mut low = queue.insert(live(50, 0));
+		let mut high = queue.insert(live(255, 0));
+		let mut mid = queue.insert(live(100, 0));
 
 		// With sorted vec, indices map exactly to priority order
 		assert_eq!(high.current(), 0); // Highest priority
@@ -388,9 +473,9 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Same track priority, different groups
-		let mut group10 = queue.insert(Priority::new(100, 10));
-		let mut group5 = queue.insert(Priority::new(100, 5));
-		let mut group1 = queue.insert(Priority::new(100, 1));
+		let mut group10 = queue.insert(live(100, 10));
+		let mut group5 = queue.insert(live(100, 5));
+		let mut group1 = queue.insert(live(100, 1));
 
 		// Exact index mapping for sorted vec
 		assert_eq!(group10.current(), 0);
@@ -403,13 +488,95 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Same track priority, ordered subscription: sequence order wins.
-		let mut group1 = queue.insert(Priority::ordered(100, 1));
-		let mut group5 = queue.insert(Priority::ordered(100, 5));
-		let mut group10 = queue.insert(Priority::ordered(100, 10));
+		let mut group1 = queue.insert(older_first(100, 1));
+		let mut group5 = queue.insert(older_first(100, 5));
+		let mut group10 = queue.insert(older_first(100, 10));
 
 		assert_eq!(group1.current(), 0);
 		assert_eq!(group5.current(), 1);
 		assert_eq!(group10.current(), 2);
+	}
+
+	/// `Ordered` chooses between a subscription's own groups, never between
+	/// subscriptions. One queue serves the whole session, so an ordered rank and a
+	/// live rank meet here constantly; if the direction were compared across them,
+	/// every ordered group would outrank every live one at the same priority and
+	/// starve a live track that shares the session.
+	#[test]
+	fn test_ordered_does_not_outrank_a_live_subscription() {
+		let queue = PriorityQueue::default();
+
+		// Same track priority: one live subscription, one that asked for Ordered.
+		let mut live_new = queue.insert(Priority::new(100, 0, 2));
+		let mut live_old = queue.insert(Priority::new(100, 0, 1));
+		let mut ordered_old = queue.insert(Priority::ordered(100, 1, 1));
+		let mut ordered_new = queue.insert(Priority::ordered(100, 1, 2));
+
+		// The subscriptions stay whole and in id order; neither one's direction
+		// promotes it past the other.
+		assert_eq!(live_new.current(), 0);
+		assert_eq!(live_old.current(), 1);
+		assert_eq!(ordered_old.current(), 2);
+		assert_eq!(ordered_new.current(), 3);
+	}
+
+	/// A subscription that flips to `Ordered` mid-stream means it about the groups
+	/// already queued for it, not just the ones that follow. Leaving the backlog on
+	/// the old direction would let every new group outrank exactly the groups the
+	/// subscriber just asked to receive first.
+	#[test]
+	fn test_set_ordered_reranks_the_backlog() {
+		let queue = PriorityQueue::default();
+
+		let mut group1 = queue.insert(live(100, 1));
+		let mut group2 = queue.insert(live(100, 2));
+		let mut group3 = queue.insert(live(100, 3));
+		assert_eq!((group3.current(), group2.current(), group1.current()), (0, 1, 2));
+
+		queue.set_ordered(0, true);
+		assert_eq!((group1.current(), group2.current(), group3.current()), (0, 1, 2));
+
+		// And back: the direction is not a one-way door.
+		queue.set_ordered(0, false);
+		assert_eq!((group3.current(), group2.current(), group1.current()), (0, 1, 2));
+	}
+
+	/// The flip can move an entry across the vec/overflow boundary, so both sides
+	/// are rebuilt: the oldest groups start out demoted past index 254 and have to
+	/// come back as the top of the queue.
+	#[test]
+	fn test_set_ordered_promotes_across_the_overflow_boundary() {
+		let queue = PriorityQueue::default();
+
+		let total = MAX_VEC_SIZE + 50;
+		let mut handles: Vec<_> = (0..total as u64).map(|group| queue.insert(live(100, group))).collect();
+
+		// Live ranks newest first, so the oldest groups sit in overflow.
+		assert_eq!(handles[total - 1].current(), 0);
+		assert_eq!(handles[0].current(), u8::MAX);
+
+		queue.set_ordered(0, true);
+
+		// Ordered inverts it: the oldest group leads and the newest is demoted.
+		assert_eq!(handles[0].current(), 0);
+		assert_eq!(handles[1].current(), 1);
+		assert_eq!(handles[total - 1].current(), u8::MAX);
+	}
+
+	/// A flip must not disturb a subscription that did not ask for one.
+	#[test]
+	fn test_set_ordered_leaves_other_subscriptions_alone() {
+		let queue = PriorityQueue::default();
+
+		let mut other_new = queue.insert(Priority::new(100, 7, 2));
+		let mut other_old = queue.insert(Priority::new(100, 7, 1));
+		let mut mine = queue.insert(Priority::new(100, 9, 1));
+
+		queue.set_ordered(9, true);
+
+		assert_eq!(other_new.current(), 0, "an untouched subscription keeps newest-first");
+		assert_eq!(other_old.current(), 1);
+		assert_eq!(mine.current(), 2);
 	}
 
 	#[test]
@@ -417,9 +584,9 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Lower track priority but higher group
-		let mut low_track_high_group = queue.insert(Priority::new(50, 1000));
+		let mut low_track_high_group = queue.insert(live(50, 1000));
 		// Higher track priority but lower group
-		let mut high_track_low_group = queue.insert(Priority::new(255, 1));
+		let mut high_track_low_group = queue.insert(live(255, 1));
 
 		// Track priority should take precedence
 		assert_eq!(high_track_low_group.current(), 0);
@@ -430,9 +597,9 @@ mod tests {
 	fn test_removal_on_drop() {
 		let queue = PriorityQueue::default();
 
-		let mut first = queue.insert(Priority::new(255, 0));
-		let mut second = queue.insert(Priority::new(100, 0));
-		let mut third = queue.insert(Priority::new(50, 0));
+		let mut first = queue.insert(live(255, 0));
+		let mut second = queue.insert(live(100, 0));
+		let mut third = queue.insert(live(50, 0));
 
 		assert_eq!(first.current(), 0);
 		assert_eq!(second.current(), 1);
@@ -450,8 +617,8 @@ mod tests {
 	fn test_removal_of_highest_priority() {
 		let queue = PriorityQueue::default();
 
-		let mut first = queue.insert(Priority::new(255, 0));
-		let mut second = queue.insert(Priority::new(100, 0));
+		let mut first = queue.insert(live(255, 0));
+		let mut second = queue.insert(live(100, 0));
 
 		assert_eq!(first.current(), 0);
 		assert_eq!(second.current(), 1);
@@ -467,8 +634,8 @@ mod tests {
 	fn test_removal_of_lowest_priority() {
 		let queue = PriorityQueue::default();
 
-		let mut first = queue.insert(Priority::new(255, 0));
-		let mut second = queue.insert(Priority::new(100, 0));
+		let mut first = queue.insert(live(255, 0));
+		let mut second = queue.insert(live(100, 0));
 
 		assert_eq!(first.current(), 0);
 		assert_eq!(second.current(), 1);
@@ -485,7 +652,7 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Insert items from high to low group to make them ordered in heap
-		let mut handles: Vec<_> = (0..10).rev().map(|i| queue.insert(Priority::new(100, i))).collect();
+		let mut handles: Vec<_> = (0..10).rev().map(|i| queue.insert(live(100, i))).collect();
 
 		// Highest group (9, at handles[0]) should be at heap index 0
 		assert_eq!(handles[0].current(), 0);
@@ -501,7 +668,7 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Insert more than 255 items (insert high to low so first item is highest priority)
-		let mut handles: Vec<_> = (0..300).rev().map(|i| queue.insert(Priority::new(100, i))).collect();
+		let mut handles: Vec<_> = (0..300).rev().map(|i| queue.insert(live(100, i))).collect();
 
 		// Highest priority item (group=299, handles[0]) should be at heap index 0
 		assert_eq!(handles[0].current(), 0);
@@ -522,11 +689,11 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Mix of different track priorities and groups
-		let mut high_track_high_group = queue.insert(Priority::new(255, 10));
-		let mut high_track_low_group = queue.insert(Priority::new(255, 1));
-		let mut mid_track_high_group = queue.insert(Priority::new(100, 5));
-		let mut mid_track_low_group = queue.insert(Priority::new(100, 1));
-		let mut low_track_high_group = queue.insert(Priority::new(50, 100));
+		let mut high_track_high_group = queue.insert(live(255, 10));
+		let mut high_track_low_group = queue.insert(live(255, 1));
+		let mut mid_track_high_group = queue.insert(live(100, 5));
+		let mut mid_track_low_group = queue.insert(live(100, 1));
+		let mut low_track_high_group = queue.insert(live(50, 100));
 
 		// Exact index mapping with sorted vec
 		assert_eq!(high_track_high_group.current(), 0); // track=255, group=10
@@ -541,13 +708,10 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Fill vec to capacity
-		let mut fillers: Vec<_> = (0..255)
-			.rev()
-			.map(|i| queue.insert(Priority::new(100, i + 100)))
-			.collect();
+		let mut fillers: Vec<_> = (0..255).rev().map(|i| queue.insert(live(100, i + 100))).collect();
 
 		// This goes to overflow
-		let mut overflow_item = queue.insert(Priority::new(100, 50));
+		let mut overflow_item = queue.insert(live(100, 50));
 		assert_eq!(overflow_item.current(), u8::MAX);
 
 		// Spawn task to wait for promotion from overflow
@@ -568,9 +732,9 @@ mod tests {
 	fn test_interleaved_insertions_and_removals() {
 		let queue = PriorityQueue::default();
 
-		let mut h1 = queue.insert(Priority::new(200, 0));
-		let h2 = queue.insert(Priority::new(150, 0));
-		let mut h3 = queue.insert(Priority::new(100, 0));
+		let mut h1 = queue.insert(live(200, 0));
+		let h2 = queue.insert(live(150, 0));
+		let mut h3 = queue.insert(live(100, 0));
 
 		// h1 has highest priority
 		assert_eq!(h1.current(), 0);
@@ -582,7 +746,7 @@ mod tests {
 		// h3 should have moved up
 		assert!(h3.current() < 2);
 
-		let mut h4 = queue.insert(Priority::new(250, 0));
+		let mut h4 = queue.insert(live(250, 0));
 
 		// h4 has highest priority now
 		assert_eq!(h4.current(), 0);
@@ -600,9 +764,9 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Items with identical track and group should still be ordered consistently
-		let mut h1 = queue.insert(Priority::new(100, 5));
-		let mut h2 = queue.insert(Priority::new(100, 5));
-		let mut h3 = queue.insert(Priority::new(100, 5));
+		let mut h1 = queue.insert(live(100, 5));
+		let mut h2 = queue.insert(live(100, 5));
+		let mut h3 = queue.insert(live(100, 5));
 
 		// All three should have valid indices
 		let indices = [h1.current(), h2.current(), h3.current()];
@@ -617,9 +781,9 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Create a heap with known structure
-		let mut root = queue.insert(Priority::new(255, 0));
-		let left = queue.insert(Priority::new(100, 0));
-		let mut right = queue.insert(Priority::new(100, 0));
+		let mut root = queue.insert(live(255, 0));
+		let left = queue.insert(live(100, 0));
+		let mut right = queue.insert(live(100, 0));
 
 		assert_eq!(root.current(), 0);
 
@@ -638,11 +802,11 @@ mod tests {
 
 		// Insert in random order
 		let mut handles = vec![
-			queue.insert(Priority::new(100, 5)),
-			queue.insert(Priority::new(200, 3)),
-			queue.insert(Priority::new(50, 10)),
-			queue.insert(Priority::new(200, 8)),
-			queue.insert(Priority::new(100, 1)),
+			queue.insert(live(100, 5)),
+			queue.insert(live(200, 3)),
+			queue.insert(live(50, 10)),
+			queue.insert(live(200, 8)),
+			queue.insert(live(100, 1)),
 		];
 
 		// Verify highest priority is at index 0
@@ -661,10 +825,10 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Fill vec to capacity - 1
-		let _fillers: Vec<_> = (0..254).map(|i| queue.insert(Priority::new(100, i + 100))).collect();
+		let _fillers: Vec<_> = (0..254).map(|i| queue.insert(live(100, i + 100))).collect();
 
 		// Insert one more that will be at the edge
-		let mut at_edge = queue.insert(Priority::new(100, 50));
+		let mut at_edge = queue.insert(live(100, 50));
 		assert_eq!(at_edge.current(), 254);
 
 		// Spawn task to wait for demotion notification
@@ -673,7 +837,7 @@ mod tests {
 		tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
 		// Insert very high priority item, kicking at_edge to overflow
-		let _high = queue.insert(Priority::new(255, 1000));
+		let _high = queue.insert(live(255, 1000));
 
 		let new_priority = task.await.unwrap();
 		assert_eq!(new_priority, u8::MAX, "Should be demoted to overflow");
@@ -683,16 +847,16 @@ mod tests {
 	fn test_empty_after_all_removed() {
 		let queue = PriorityQueue::default();
 
-		let h1 = queue.insert(Priority::new(100, 0));
-		let h2 = queue.insert(Priority::new(200, 0));
-		let h3 = queue.insert(Priority::new(50, 0));
+		let h1 = queue.insert(live(100, 0));
+		let h2 = queue.insert(live(200, 0));
+		let h3 = queue.insert(live(50, 0));
 
 		drop(h1);
 		drop(h2);
 		drop(h3);
 
 		// Queue should be empty, next insert should get index 0
-		let mut h4 = queue.insert(Priority::new(100, 0));
+		let mut h4 = queue.insert(live(100, 0));
 		assert_eq!(h4.current(), 0);
 	}
 
@@ -701,10 +865,10 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Subscription 1 (track=255), Subscription 2 (track=55)
-		let mut s1_g1 = queue.insert(Priority::new(255, 1));
-		let mut s1_g2 = queue.insert(Priority::new(255, 2));
-		let mut s2_g1 = queue.insert(Priority::new(55, 1));
-		let mut s2_g2 = queue.insert(Priority::new(55, 2));
+		let mut s1_g1 = queue.insert(live(255, 1));
+		let mut s1_g2 = queue.insert(live(255, 2));
+		let mut s2_g1 = queue.insert(live(55, 1));
+		let mut s2_g2 = queue.insert(live(55, 2));
 
 		assert_eq!(s1_g2.current(), 0); // s1 highest
 		assert_eq!(s1_g1.current(), 1);
@@ -728,8 +892,8 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// h_low at index 1, will be promoted to 0 when h_high is demoted.
-		let mut h_high = queue.insert(Priority::new(255, 1));
-		let mut h_low = queue.insert(Priority::new(50, 1));
+		let mut h_high = queue.insert(live(255, 1));
+		let mut h_low = queue.insert(live(50, 1));
 
 		assert_eq!(h_low.current(), 1);
 
@@ -748,9 +912,9 @@ mod tests {
 	fn test_set_track_self() {
 		let queue = PriorityQueue::default();
 
-		let mut h_high = queue.insert(Priority::new(255, 1));
-		let mut h_mid = queue.insert(Priority::new(100, 1));
-		let mut h_low = queue.insert(Priority::new(50, 1));
+		let mut h_high = queue.insert(live(255, 1));
+		let mut h_mid = queue.insert(live(100, 1));
+		let mut h_low = queue.insert(live(50, 1));
 
 		assert_eq!(h_high.current(), 0);
 		assert_eq!(h_mid.current(), 1);
@@ -770,10 +934,10 @@ mod tests {
 
 		// Fill vec with 255 items at track=100, groups 1..=255.
 		// f1 (group=1) is the vec tail (lowest priority of the fillers).
-		let mut fillers: Vec<_> = (1..=255u64).map(|g| queue.insert(Priority::new(100, g))).collect();
+		let mut fillers: Vec<_> = (1..=255u64).map(|g| queue.insert(live(100, g))).collect();
 
 		// Insert a higher-track item; this kicks f1 out of vec into overflow.
-		let mut top = queue.insert(Priority::new(200, 0));
+		let mut top = queue.insert(live(200, 0));
 		assert_eq!(top.current(), 0);
 		assert_eq!(fillers[0].current(), u8::MAX, "f1 was kicked into overflow");
 
@@ -791,9 +955,9 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Three items, all in vec; no overflow involvement.
-		let mut a = queue.insert(Priority::new(200, 0));
-		let mut b = queue.insert(Priority::new(100, 0));
-		let mut c = queue.insert(Priority::new(50, 0));
+		let mut a = queue.insert(live(200, 0));
+		let mut b = queue.insert(live(100, 0));
+		let mut c = queue.insert(live(50, 0));
 		assert_eq!(a.current(), 0);
 		assert_eq!(b.current(), 1);
 		assert_eq!(c.current(), 2);
@@ -810,12 +974,12 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Fill vec to capacity with track=200.
-		let fillers: Vec<_> = (100..355u64).map(|g| queue.insert(Priority::new(200, g))).collect();
+		let fillers: Vec<_> = (100..355u64).map(|g| queue.insert(live(200, g))).collect();
 
 		// Three overflow items with distinct priorities (same track, different groups).
-		let mut low = queue.insert(Priority::new(100, 1));
-		let mut mid = queue.insert(Priority::new(100, 2));
-		let mut high = queue.insert(Priority::new(100, 3));
+		let mut low = queue.insert(live(100, 1));
+		let mut mid = queue.insert(live(100, 2));
+		let mut high = queue.insert(live(100, 3));
 		assert_eq!(low.current(), u8::MAX);
 		assert_eq!(mid.current(), u8::MAX);
 		assert_eq!(high.current(), u8::MAX);
@@ -839,8 +1003,8 @@ mod tests {
 		let queue = PriorityQueue::default();
 
 		// Fill vec, then insert top, kicking f1 (filler at group=1) into overflow.
-		let mut fillers: Vec<_> = (1..=255u64).map(|g| queue.insert(Priority::new(100, g))).collect();
-		let mut top = queue.insert(Priority::new(200, 0));
+		let mut fillers: Vec<_> = (1..=255u64).map(|g| queue.insert(live(100, g))).collect();
+		let mut top = queue.insert(live(200, 0));
 		assert_eq!(top.current(), 0);
 
 		// Take ownership of f1 so we can await its promotion notification.

--- a/rs/moq-net/src/lite/priority.rs
+++ b/rs/moq-net/src/lite/priority.rs
@@ -14,26 +14,44 @@ use std::{
 // - On remove from Vec: pop highest priority item from overflow heap to backfill
 // - On remove from overflow: rebuild heap (rare case, acceptable O(n) cost)
 //
-// Priority ordering: higher track value = higher priority, then higher group value = higher priority
+// Priority ordering: higher track value = higher priority, then higher group rank = higher priority
 
-/// A priority composed of a track-level priority and a group sequence number.
-/// Higher `track` is always preferred; `group` only breaks ties within the same track.
+/// A priority composed of a track-level priority and a group rank within the track.
+/// Higher `track` is always preferred; `group_rank` only breaks ties within the same
+/// track. The rank direction encodes the subscription's `Ordered` preference: a live
+/// subscription ranks newer groups first, an ordered one ranks older groups first.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Priority {
-	pub track: u8,
-	pub group: u64,
+	track: u8,
+	group_rank: u64,
 }
 
 impl Priority {
+	/// Rank for a live (unordered) subscription: the newest group transmits first.
 	pub fn new(track: u8, group: u64) -> Self {
-		Self { track, group }
+		Self {
+			track,
+			group_rank: group,
+		}
+	}
+
+	/// Rank for an `Ordered` subscription: the oldest group transmits first, so
+	/// back-to-back groups leave the session in sequence order.
+	pub fn ordered(track: u8, group: u64) -> Self {
+		Self {
+			track,
+			group_rank: !group,
+		}
 	}
 }
 
 impl Ord for Priority {
 	fn cmp(&self, other: &Self) -> Ordering {
 		// Reverse ordering so highest priority sorts first (index 0)
-		other.track.cmp(&self.track).then(other.group.cmp(&self.group))
+		other
+			.track
+			.cmp(&self.track)
+			.then(other.group_rank.cmp(&self.group_rank))
 	}
 }
 
@@ -378,6 +396,20 @@ mod tests {
 		assert_eq!(group10.current(), 0);
 		assert_eq!(group5.current(), 1);
 		assert_eq!(group1.current(), 2);
+	}
+
+	#[test]
+	fn test_ordered_prefers_older_groups() {
+		let queue = PriorityQueue::default();
+
+		// Same track priority, ordered subscription: sequence order wins.
+		let mut group1 = queue.insert(Priority::ordered(100, 1));
+		let mut group5 = queue.insert(Priority::ordered(100, 5));
+		let mut group10 = queue.insert(Priority::ordered(100, 10));
+
+		assert_eq!(group1.current(), 0);
+		assert_eq!(group5.current(), 1);
+		assert_eq!(group10.current(), 2);
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -2258,9 +2258,15 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					if let Ok(mut value) = track_priority_tx.write() {
 						*value = upd.priority;
 					}
-					// Groups already queued keep their rank; only future groups adopt
-					// the new direction, matching how the wire treats mid-flight data.
-					self.ordered = upd.ordered;
+					// Re-rank the backlog too, not just the groups queued from here on.
+					// The preference is about which of the groups we are holding to send
+					// first, so leaving the queued ones on the old direction would let
+					// every new group outrank exactly the ones the subscriber just asked
+					// to receive first, starving them until they expire.
+					if self.ordered != upd.ordered {
+						self.ordered = upd.ordered;
+						self.priority.set_ordered(self.id, self.ordered);
+					}
 					// Feed the full update into the model subscriber so the producer's
 					// aggregate reflects it (and a relay re-forwards it upstream).
 					let bounds = Bounds::from(&upd);
@@ -2288,9 +2294,12 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 
 		// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
 		let current_priority = self.track_priority_current();
+		// The subscribe id scopes the group tie-break: one queue serves every
+		// subscription on the session, and only groups of the same one may be
+		// ranked against each other by sequence.
 		let priority = match self.ordered {
-			true => Priority::ordered(current_priority, sequence),
-			false => Priority::new(current_priority, sequence),
+			true => Priority::ordered(current_priority, self.id, sequence),
+			false => Priority::new(current_priority, self.id, sequence),
 		};
 		let handle = self.priority.insert(priority);
 		let fut = self.clone().serve_group(sequence, frame_start, handle, group);
@@ -2667,7 +2676,7 @@ mod serve_group_test {
 			.write_frame(Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
 			.unwrap();
 
-		let handle = subscription.priority.insert(Priority::new(0, 0));
+		let handle = subscription.priority.insert(Priority::new(0, 0, 0));
 		let mut serve = std::pin::pin!(subscription.serve_group(0, 0, handle, group.consume()));
 
 		// Drain the frame, leaving the task parked awaiting the next one.
@@ -2710,7 +2719,7 @@ mod serve_group_test {
 		let consumer = group.consume();
 		group.finish().unwrap();
 
-		let handle = subscription.priority.insert(Priority::new(0, 0));
+		let handle = subscription.priority.insert(Priority::new(0, 0, 0));
 		subscription.serve_group(0, 0, handle, consumer).await.unwrap();
 
 		assert_eq!(log.resets(), Vec::<u32>::new(), "clean completion must not reset");

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1016,6 +1016,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			priority,
 			track_priority: track_priority_tx.consume(),
 			track_priority_seen: subscribe.priority,
+			ordered: subscribe.ordered,
 			version,
 			timescale,
 		};
@@ -2117,6 +2118,10 @@ struct Subscription<S: web_transport_trait::Session> {
 	track_priority: kio::Consumer<u8>,
 	/// Last track priority observed by this clone, so a change only fires once.
 	track_priority_seen: u8,
+	/// The subscriber's `Ordered` preference: rank older groups first so they
+	/// transmit in sequence order, instead of the live default of newest first.
+	/// Applied to groups as they are queued; refreshed by SUBSCRIBE_UPDATE.
+	ordered: bool,
 	version: Version,
 	/// Negotiated timestamp scale for this track. `Some(_)` on lite-05+ after
 	/// TRACK_INFO; used to validate per-frame timestamps before encoding.
@@ -2253,6 +2258,9 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					if let Ok(mut value) = track_priority_tx.write() {
 						*value = upd.priority;
 					}
+					// Groups already queued keep their rank; only future groups adopt
+					// the new direction, matching how the wire treats mid-flight data.
+					self.ordered = upd.ordered;
 					// Feed the full update into the model subscriber so the producer's
 					// aggregate reflects it (and a relay re-forwards it upstream).
 					let bounds = Bounds::from(&upd);
@@ -2280,7 +2288,11 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 
 		// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
 		let current_priority = self.track_priority_current();
-		let handle = self.priority.insert(Priority::new(current_priority, sequence));
+		let priority = match self.ordered {
+			true => Priority::ordered(current_priority, sequence),
+			false => Priority::new(current_priority, sequence),
+		};
+		let handle = self.priority.insert(priority);
 		let fut = self.clone().serve_group(sequence, frame_start, handle, group);
 		tasks.push(fut.map(|_| ()).maybe_boxed());
 	}
@@ -2644,6 +2656,7 @@ mod serve_group_test {
 			priority: PriorityQueue::default(),
 			track_priority: track_priority.consume(),
 			track_priority_seen: 0,
+			ordered: false,
 			version: Version::Lite06Wip,
 			timescale: Some(crate::Timescale::default()),
 		};
@@ -2684,6 +2697,7 @@ mod serve_group_test {
 			priority: PriorityQueue::default(),
 			track_priority: track_priority.consume(),
 			track_priority_seen: 0,
+			ordered: false,
 			version: Version::Lite06Wip,
 			timescale: Some(crate::Timescale::default()),
 		};

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -447,9 +447,15 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 	)
 	.await
 	.expect("broadcast announced");
+	// Ordered, because the verification below asserts strict sequence order.
+	// A live (unordered) subscription transmits the newest group first, so a
+	// back-to-back burst legally arrives inverted; `ordered` is the protocol's
+	// way to ask every hop for sequence-order transmission instead.
 	let mut sub = within(
 		"subscribe to the video track",
-		bc.track("video").expect("track handle").subscribe(None),
+		bc.track("video")
+			.expect("track handle")
+			.subscribe(moq_net::track::Subscription::default().with_ordered(true)),
 	)
 	.await
 	.expect("subscribe");


### PR DESCRIPTION
## Summary

- `cluster_diamond_goaway_seamless_failover` fails deterministically on dev (`left: 22, right: 21` in the post-drain phase). Root cause: it is not a failover bug. The resume/takeover machinery is correct (boundary `{group: 21, frame: 0}`, every SUBSCRIBE and SUBSCRIBE_START in the chain carries 21, and every relay hop serves group 21 first). The inversion happens on the final relay-to-subscriber hop: the test publishes its post-drain groups back-to-back, the lite publisher ranked group streams **newest-first** within a track, and qmux 0.5's strict-priority write scheduler (#2717, which replaced arrival-order frame interleaving) transmits group 22's queued frames before 21's whenever both are buffered at once. The subscriber receives 22 before 21, which the test's strict in-order assertion reports as a failover defect.
- Newest-first is the draft's intended **live** behavior. The draft's `Ordered` field is how a subscriber asks for oldest-first instead, and moq-lite carried it on the wire and in the demand aggregate but never applied it to transmission. This PR implements it, and the diamond test now subscribes `with_ordered(true)` so its strict sequence-order verification asserts a property the protocol actually grants. The flag propagates end-to-end (subscriber -> BOTTOM -> MID-B -> TOP) through the demand aggregate and resume slices.

## How the rank is scoped

The draft scopes `Ordered` to groups *within a Track*, and `Priority` is what selects *between* tracks. That distinction is load-bearing here, because one `PriorityQueue` serves every subscription on a session:

- `Priority` now carries the subscribe id and compares it **before** the group, so a group tie-break only ever happens between groups of the same subscription. An ordered rank and a live rank are therefore never compared against each other. Without this, any direction encoding that puts a subscription's oldest group on top also puts it above every group of a live subscription at equal priority, starving that track until its groups expire.
- `PriorityQueue::set_ordered` re-ranks a subscription's **already-queued** groups when SUBSCRIBE_UPDATE flips the flag, so the backlog adopts the new direction instead of being outranked by every group that follows it. It rebuilds both the sorted vec and the overflow heap from one snapshot: the flip can move entries across the 255-item boundary, and `Priority` is only a total order while every group of a subscription agrees on its direction, so a per-item re-place would transiently compare two directions within one subscription.
- `PriorityHandle` now owns only its track priority. It previously wrote a whole cached `Priority` back on `set_track`, which after a `set_ordered` would have resurrected the stale direction for one group.

In-flight `serve_group` tasks pick the new send order up through the existing rank-change notification, the same path a SUBSCRIBE_UPDATE priority change already used.

## Public API changes

None. The whole `lite` module is crate-internal: `lite::priority::Priority` gains a `subscribe` field and its constructors take it, `PriorityQueue::set_ordered` is new, and `PriorityState::set_priority` narrowed to `set_track`. `track::Subscription.ordered` already existed and is unchanged.

## Test plan

- `cluster_diamond_goaway_seamless_failover`: failed deterministically before, passes repeatedly after.
- Four new tests in `lite/priority.rs`, each verified by mutation (the fix reverted, the test fails):
  - `test_ordered_does_not_outrank_a_live_subscription` — fails when the subscribe comparison is removed from `Ord`.
  - `test_set_ordered_reranks_the_backlog` and `test_set_ordered_promotes_across_the_overflow_boundary` — both fail when `set_ordered` is neutered to the old future-groups-only behavior.
  - `test_set_ordered_leaves_other_subscriptions_alone`.
- The pre-existing priority tests are unchanged in substance; they were rewritten onto shared `live`/`older_first` helpers that pin them to one subscription, which is the scope they were always exercising.
- `cargo nextest run -p moq-net -p moq-relay`, plus `just fix` / `just check`.

## Cross-package sync

- `drafts/`: no update needed. This implements the existing `Ordered` semantics in draft-lcurley-moq-lite's Prioritization section ("older (0x1) or newer (0x0) groups ... first within a Track") rather than changing them; no wire change.
- `js/net`: not updated here. The JS lite publisher sets no sendOrder on group streams at all and ignores `ordered`, so it needs the same treatment; tracked separately.

Debugging note: the original failure is a heisenbug. Any stderr logging in the serve path yields to the qmux writer task between two `queue_serve` calls, flushing the older group's stream before the newer one is queued, which hides the race; it was pinned down with an in-memory event buffer dumped from a panic hook.

(written by Fable 5)
