### PR TITLE
build(js): stop compiling tests into dist/

### DIFF
--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -86,7 +86,8 @@ Plain custom elements built directly on `@moq/signals`, no framework (except moq
 - ESM only (`"type": "module"`). Relative imports include the `.ts`/`.tsx` extension in the lower-level packages (`net`, `signals`, `hang`); `rewriteRelativeImportExtensions` in `tsconfig.json` rewrites them to `.js` on build. Some higher-level packages (watch/publish) still omit extensions, so match the file you are editing.
 - Document every exported symbol and add a top-of-file `@module` doc block to each entrypoint (root convention; the published JSR/`.d.ts` docs render these). Use `@public` on the load-bearing classes.
 - **Deprecation mechanics** (root Deprecation explains the why): mark a deprecated export `@internal` or drop it from the entrypoint re-exports so it falls off the published JSR/`.d.ts` docs. No "deprecated, use X" note in its doc comment.
-- Build is per-package: `tsc -b` (or `vite build` for the bundled UI/web-component packages) then `bun ../common/package.ts`, which rewrites `package.json` exports from `./src/*.ts` to built `./*.js`/`.d.ts` and runs `publint`. Release via `bun ../common/release.ts`.
+- Build is per-package: `tsc -b tsconfig.build.json` (or `vite build` plus `tsc -p tsconfig.build.json` for the bundled UI/web-component packages) then `bun ../common/package.ts`, which rewrites `package.json` exports from `./src/*.ts` to built `./*.js`/`.d.ts` and runs `publint`. Release via `bun ../common/release.ts`.
+- `tsconfig.build.json` exists only to drop `src/**/*.test.ts` from the emit; `tsconfig.json` is what `tsc --noEmit` (the `check` script) and your editor use, so tests are still type-checked. Keeping tests out of `dist/` matters twice over: `package.ts` globs all of `dist/` into the published tarball, and a compiled test in `dist/` is a second runnable copy that `bun test` discovers at the package root and runs against the wrong `import.meta.dir`.
 
 ## Tooling and testing
 

--- a/js/flate/package.json
+++ b/js/flate/package.json
@@ -10,7 +10,7 @@
 		".": "./src/index.ts"
 	},
 	"scripts": {
-		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
 		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"

--- a/js/flate/tsconfig.build.json
+++ b/js/flate/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/flate/tsconfig.build.json
+++ b/js/flate/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -13,7 +13,7 @@
 		"./util": "./src/util/index.ts"
 	},
 	"scripts": {
-		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
 		"release": "bun ../common/release.ts"
 	},

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -15,6 +15,7 @@
 	"scripts": {
 		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
+		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {

--- a/js/hang/tsconfig.build.json
+++ b/js/hang/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/hang/tsconfig.build.json
+++ b/js/hang/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -10,7 +10,7 @@
 		".": "./src/index.ts"
 	},
 	"scripts": {
-		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
 		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"

--- a/js/json/tsconfig.build.json
+++ b/js/json/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/json/tsconfig.build.json
+++ b/js/json/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/loc/package.json
+++ b/js/loc/package.json
@@ -10,7 +10,7 @@
 	},
 	"sideEffects": false,
 	"scripts": {
-		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit && bun test",
 		"release": "bun ../common/release.ts"
 	},

--- a/js/loc/tsconfig.build.json
+++ b/js/loc/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/loc/tsconfig.build.json
+++ b/js/loc/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -18,7 +18,7 @@
 		"./src/element.tsx"
 	],
 	"scripts": {
-		"build": "rimraf dist && vite build && tsc && bun ../common/package.ts",
+		"build": "rimraf dist && vite build && tsc -p tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
 		"release": "bun ../common/release.ts"
 	},

--- a/js/moq-boy/tsconfig.build.json
+++ b/js/moq-boy/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/moq-boy/tsconfig.build.json
+++ b/js/moq-boy/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -12,6 +12,7 @@
 	"scripts": {
 		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
+		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -10,7 +10,7 @@
 	},
 	"sideEffects": false,
 	"scripts": {
-		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
 		"release": "bun ../common/release.ts"
 	},

--- a/js/msf/tsconfig.build.json
+++ b/js/msf/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/msf/tsconfig.build.json
+++ b/js/msf/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -11,7 +11,7 @@
 		"./zod": "./src/zod.ts"
 	},
 	"scripts": {
-		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit && tsc -b examples/tsconfig.json",
 		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"

--- a/js/net/tsconfig.build.json
+++ b/js/net/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/net/tsconfig.build.json
+++ b/js/net/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -19,7 +19,7 @@
 		"./src/support/element.ts"
 	],
 	"scripts": {
-		"build": "rimraf dist && vite build && tsc && bun ../common/package.ts",
+		"build": "rimraf dist && vite build && tsc -p tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
 		"test": "bun test --pass-with-no-tests",
 		"release": "bun ../common/release.ts"

--- a/js/publish/tsconfig.build.json
+++ b/js/publish/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/publish/tsconfig.build.json
+++ b/js/publish/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -13,7 +13,7 @@
 		"./dom": "./src/dom.ts"
 	},
 	"scripts": {
-		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
 		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"

--- a/js/signals/tsconfig.build.json
+++ b/js/signals/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/signals/tsconfig.build.json
+++ b/js/signals/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -13,7 +13,7 @@
 		"moq-token": "./src/cli.ts"
 	},
 	"scripts": {
-		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"build": "rimraf dist && tsc -b tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit && tsc -b examples/tsconfig.json",
 		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"

--- a/js/token/tsconfig.build.json
+++ b/js/token/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/token/tsconfig.build.json
+++ b/js/token/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -19,7 +19,7 @@
 		"./src/support/element.ts"
 	],
 	"scripts": {
-		"build": "rimraf dist && vite build && tsc && bun ../common/package.ts",
+		"build": "rimraf dist && vite build && tsc -p tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
 		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"

--- a/js/watch/tsconfig.build.json
+++ b/js/watch/tsconfig.build.json
@@ -3,5 +3,5 @@
 	// are neither published nor discovered by `bun test` at the package root.
 	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
 	"extends": "./tsconfig.json",
-	"exclude": ["src/**/*.test.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/js/watch/tsconfig.build.json
+++ b/js/watch/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	// Build-only variant of tsconfig.json that keeps tests out of dist/, so they
+	// are neither published nor discovered by `bun test` at the package root.
+	// `tsc --noEmit` still uses tsconfig.json, so tests stay type-checked.
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Every `js/*` package's `tsconfig.json` has `"include": ["src"]` and emits to `dist/`, so `tsc -b` compiled `*.test.ts` alongside the sources. The base `js/tsconfig.json` excludes only `**/node_modules`, `**/dist`, `**/target`, so nothing filtered them out. Two consequences:

- `js/common/package.ts` globs all of `dist/` into the published package, so npm and JSR consumers received **262 test artifacts** (`.js`, `.d.ts`, and both source maps) they can't use.
- The compiled copies are runnable, so `bun test` at a package root discovered and ran them. They fail whenever a test resolves paths from `import.meta.dir`: `js/token/src/cli.test.ts` joins it with `cli.ts`, which only exists under `src/`.

The fix is a build-only `tsconfig.build.json` per package that extends `tsconfig.json` and excludes `src/**/*.test.ts` and `src/**/*.test.tsx`, with the `build` script pointed at it (`tsc -b tsconfig.build.json`, or `tsc -p tsconfig.build.json` for the three vite packages whose `tsc` pass is `emitDeclarationOnly`). `tsc --noEmit` (the `check` script) and editors still use `tsconfig.json`, so **tests remain type-checked** — they just never reach `dist/`.

All eleven `tsconfig.build.json` files are byte-identical so a new package can copy any of them.

Also adds `test` scripts to `hang` and `msf`. Both have test files (10 and 1) but no `test` script, so `bun run --filter='*' test` skipped them and their `check` was only `tsc --noEmit` — those suites had never run in CI. Both pass as-is: 72 tests for hang, 9 for msf.

`js/CLAUDE.md` documents the `tsconfig.json` / `tsconfig.build.json` split and why the emit matters.

## Public API changes

None. No `pub`/exported item added, renamed, removed, or changed. The published surface only *shrinks*, by dropping test files that were never part of any package's `exports` map.

## Cross-Package Sync

No rows apply: this is JS build configuration and test wiring, with no wire format, `moq-ffi`, or CLI surface touched.

## Test plan

- `just js build && ls js/*/dist/*.test.js` → no matches. A repo-wide `find` for `*.test.*` under any `dist/` returns 0 (was 262).
- Verified the `.tsx` half empirically rather than by inspection: a scratch `js/moq-boy/src/leakcheck.test.tsx` emitted `dist/leakcheck.test.d.ts` under a `.ts`-only exclude, and nothing under the pattern as committed. `moq-boy` is the one `.tsx` package, and `bun test` discovers `.test.tsx`, so it carried both halves of the problem.
- `just js test` passes, now including hang (72) and msf (9). Per-package file counts match `src` exactly, confirming the duplicate `dist/` copies are gone: net 365 tests/29 files, watch 105/8, token 94/6, json 83/7, publish 44/9, signals 44/2, flate 9/1, loc 7/1.
- `just check` (full) and `just fix` (no changes) are green.

## Review

CodeRabbit was rate-limited on this PR, so per [CONTRIBUTING.md](CONTRIBUTING.md#reviews) the review ran locally instead, plus a Codex adversarial pass. Findings:

- **Fixed**: `src/**/*.test.ts` alone did not match `.test.tsx`, leaving `moq-boy` (the one `.tsx` package) exposed to the very leak this PR prevents. Fixed in `df598a0`.
- Codex verdict: approve, no material findings. It independently confirmed every current test file is excluded, production output carries no test references, all published export targets exist, replacing the base `exclude` is harmless given the `include` roots, and no stale build invocation remains.

(Written by Opus 5)