### PR TITLE
fix(net): serve subscriptions in arrival order so reordered groups aren't dropped

### DIFF
--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1143,6 +1143,37 @@ mod test {
 			_ => panic!("expected finished once the boundary is reached"),
 		}
 	}
+
+	/// A relay can ingest back-to-back groups micro-reordered (the upstream leg
+	/// sends newest-first). The older group is cached and in demand, so serving
+	/// must still deliver it; a sequence cursor would skip it permanently.
+	#[tokio::test]
+	async fn recv_next_serves_late_arrival_after_newer_group() {
+		let mut producer = track_producer("test");
+		let mut subscriber = producer.subscribe(None);
+
+		producer.create_group(group::Info { sequence: 2 }).unwrap();
+		match recv_next(&mut subscriber, false, false).await.unwrap() {
+			Recv::Group(group) => assert_eq!(group.sequence, 2),
+			_ => panic!("expected group 2"),
+		}
+
+		// Group 1 lands after group 2 was already served.
+		producer.create_group(group::Info { sequence: 1 }).unwrap();
+		match recv_next(&mut subscriber, false, false).now_or_never() {
+			Some(Ok(Recv::Group(group))) => assert_eq!(group.sequence, 1),
+			Some(_) => panic!("expected the late-arriving group"),
+			None => panic!("the late-arriving group was skipped"),
+		}
+
+		// Staleness is the latency window's job, not arrival order's: the track
+		// still finishes normally afterward.
+		producer.finish_at(3).unwrap();
+		match recv_next(&mut subscriber, false, false).await.unwrap() {
+			Recv::Finished => {}
+			_ => panic!("expected finished"),
+		}
+	}
 }
 
 /// The announce loop's demand/linger state machine: a drained broadcast keeps
@@ -1782,9 +1813,15 @@ enum Recv {
 	Finished,
 }
 
-/// Poll a single [`track::Subscriber`] for the next group (cap-aware) or datagram from one `&mut`
-/// borrow, so groups and datagrams share the same subscription. Groups are polled first so a
-/// datagram burst can't starve them; datagrams are polled only when the transport carries them.
+/// Poll a single [`track::Subscriber`] for the next group (cap-aware, in arrival order) or
+/// datagram from one `&mut` borrow, so groups and datagrams share the same subscription. Groups
+/// are polled first so a datagram burst can't starve them; datagrams are polled only when the
+/// transport carries them.
+///
+/// Groups are served in arrival order (`poll_recv_group`), not sequence order: on a relay, a
+/// burst can be ingested micro-reordered by the upstream leg, and a sequence cursor would then
+/// permanently skip the older group even though it is cached and in demand. Staleness is
+/// governed by the latency window (cache expiry), not arrival raciness.
 ///
 /// When `emit_boundary` is set, a declared-but-not-yet-reached final sequence surfaces as
 /// [`Recv::Boundary`] in an idle moment (after groups and datagrams), so the caller can send
@@ -1798,7 +1835,7 @@ fn poll_recv_next(
 ) -> Poll<Result<Recv, Error>> {
 	{
 		let mut groups_finished = false;
-		match track.poll_next_group(waiter) {
+		match track.poll_recv_group(waiter) {
 			Poll::Ready(Ok(Some(group))) => return Poll::Ready(Ok(Recv::Group(group))),
 			Poll::Ready(Ok(None)) => groups_finished = true,
 			Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
@@ -1907,10 +1944,10 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					if let Poll::Ready(upd) = waiter.poll_future(update.as_mut()) {
 						return Poll::Ready(Event::Update(upd));
 					}
-					// One cursor drives the whole subscription: poll the cap-aware next group and,
-					// when enabled, the next best-effort datagram. Groups are polled first so a
-					// datagram burst can't starve them; datagrams flow whenever no group is ready
-					// (including while groups are paused above the cap).
+					// One cursor drives the whole subscription: poll the cap-aware arrival-order
+					// group and, when enabled, the next best-effort datagram. Groups are polled
+					// first so a datagram burst can't starve them; datagrams flow whenever no
+					// group is ready (including while groups are parked above the cap).
 					if let Poll::Ready(res) = poll_recv_next(&mut track, datagrams, emit_boundary, waiter) {
 						return Poll::Ready(Event::Recv(res));
 					}
@@ -1924,6 +1961,11 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					Recv::Group(group) => {
 						if emit_range && !start_sent {
 							start_sent = true;
+							// SUBSCRIBE_OK promises nothing below this sequence will be
+							// delivered. Arrival-order serving could later surface a
+							// straggler below the first group, so pin the floor to what
+							// was announced.
+							track.start_at(group.sequence);
 							writer
 								.encode(&lite::SubscribeResponse::Start(lite::SubscribeStart {
 									group: group.sequence,

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -672,6 +672,12 @@ impl Consumer {
 		self
 	}
 
+	/// Whether the group has been aborted (including pool eviction); the abort
+	/// dropped the cached frames, so a held consumer has nothing left to read.
+	pub(crate) fn is_aborted(&self) -> bool {
+		self.state.read().abort.is_some()
+	}
+
 	/// The parent track's timescale.
 	pub fn timescale(&self) -> Timescale {
 		self.track.timescale

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -12,6 +12,7 @@
 //! its segment bounds, so a session serving a segment just sees an ordinary
 //! subscription that happens to start or end at a boundary.
 
+use std::collections::BTreeMap;
 use std::task::{Poll, ready};
 
 use crate::{Datagram, Error, Result, frame, group, track};
@@ -578,10 +579,12 @@ struct SegmentSub {
 	start: Option<u64>,
 	end: Option<u64>,
 	sub: SubState,
-	/// A received group held back by the subscriber's [`Subscriber::end_at`] cap,
+	/// Received groups held back by the subscriber's [`Subscriber::end_at`] cap,
 	/// re-offered once the cap rises (arrival-order reads consume the underlying
-	/// cursor, so the group is parked here instead of dropped).
-	parked: Option<group::Consumer>,
+	/// cursor, so they are parked here instead of dropped). Keyed by sequence so
+	/// the lowest is re-offered first; holding them here (rather than blocking on
+	/// the first) keeps in-range groups that arrive behind a capped one flowing.
+	parked: BTreeMap<u64, group::Consumer>,
 	/// The producer dropped this segment (pruned from the window, or replaced
 	/// before producing). See [`Self::retired`].
 	pruned: bool,
@@ -594,7 +597,7 @@ impl SegmentSub {
 	/// parked group is re-offered, so a slow reader still gets what the pruned
 	/// segment's track cached.
 	fn retired(&self) -> bool {
-		self.pruned && (self.end.is_none() || (matches!(self.sub, SubState::Done(_)) && self.parked.is_none()))
+		self.pruned && (self.end.is_none() || (matches!(self.sub, SubState::Done(_)) && self.parked.is_empty()))
 	}
 }
 
@@ -675,7 +678,7 @@ impl Subscriber {
 				}
 				if seg.pruned {
 					seg.sub = SubState::Done(None);
-					seg.parked = None;
+					seg.parked.clear();
 					cut -= 1;
 				}
 			}
@@ -763,8 +766,10 @@ impl Subscriber {
 					if existing.end != segment.end {
 						existing.end = segment.end;
 						if let SubState::Active(sub) = &mut existing.sub {
-							sub.end_at(min_some(segment.end, self.end_sequence));
-							// Also shrink the demand so the session can cap upstream.
+							// Shrink the demand so the session can cap upstream. The
+							// read bounds stay on this subscriber (see `poll_recv_group`):
+							// an inner `end_at` would park boundary-crossing groups in the
+							// inner cursor, hiding the segment's completion.
 							let _ = sub.update(slice(&self.last_prefs, segment.start, segment.end));
 						}
 						// A still-pending subscription picks the moved boundary up
@@ -780,7 +785,7 @@ impl Subscriber {
 						start: segment.start,
 						end: segment.end,
 						sub: SubState::Pending(sub),
-						parked: None,
+						parked: BTreeMap::new(),
 						pruned: false,
 					});
 				}
@@ -791,20 +796,16 @@ impl Subscriber {
 	/// Resolve a segment's pending subscription, if any. Ready once the segment is
 	/// `Active` or `Done`; a rejected or closed track becomes `Done` (stall, not
 	/// error). Never consumes groups, so terminal-state pollers can share it.
-	fn poll_activate(
-		seg: &mut SegmentSub,
-		prefs: &Subscription,
-		min_sequence: u64,
-		end_sequence: Option<u64>,
-		waiter: &kio::Waiter,
-	) -> Poll<()> {
+	fn poll_activate(seg: &mut SegmentSub, prefs: &Subscription, min_sequence: u64, waiter: &kio::Waiter) -> Poll<()> {
 		if let SubState::Pending(pending) = &mut seg.sub {
 			match pending.poll_ok(waiter) {
 				Poll::Ready(Ok(mut sub)) => {
-					// Enforce the bounds on the read cursor, and re-slice demand in
-					// case a boundary moved while the subscription was pending.
+					// Enforce the floor on the read cursor, and re-slice demand in
+					// case a boundary moved while the subscription was pending. The
+					// upper bounds (segment boundary and `end_at` cap) are enforced by
+					// this subscriber, never on the inner cursor: an inner cap would
+					// park groups there and hide the segment's completion.
 					sub.start_at(seg.start.unwrap_or(0).max(min_sequence));
-					sub.end_at(min_some(seg.end, end_sequence));
 					let _ = sub.update(slice(prefs, seg.start, seg.end));
 					seg.sub = SubState::Active(sub);
 				}
@@ -822,13 +823,12 @@ impl Subscriber {
 		seg: &mut SegmentSub,
 		prefs: &Subscription,
 		min_sequence: u64,
-		end_sequence: Option<u64>,
 		waiter: &kio::Waiter,
 	) -> Poll<Option<group::Consumer>> {
 		loop {
 			match &mut seg.sub {
 				SubState::Pending(_) => {
-					ready!(Self::poll_activate(seg, prefs, min_sequence, end_sequence, waiter));
+					ready!(Self::poll_activate(seg, prefs, min_sequence, waiter));
 				}
 				SubState::Active(sub) => match sub.poll_recv_group(waiter) {
 					Poll::Ready(Ok(Some(group))) => {
@@ -871,35 +871,34 @@ impl Subscriber {
 		self.poll_sync(waiter);
 
 		let end_sequence = self.end_sequence;
+		let min_sequence = self.min_sequence;
 		let beyond_cap = |sequence: u64| end_sequence.is_some_and(|end| sequence > end);
 
 		let mut all_done = true;
 		for seg in &mut self.segments {
-			// Re-offer a group parked at the cap once the cap rises.
-			if let Some(group) = seg.parked.take_if(|group| !beyond_cap(group.sequence))
-				&& group.sequence >= self.min_sequence
+			// A `start_at` overtook these parked groups; drop them and read on.
+			seg.parked.retain(|sequence, _| *sequence >= min_sequence);
+
+			// Re-offer the lowest parked group back inside the cap once it rises.
+			if let Some(&sequence) = seg.parked.keys().next()
+				&& !beyond_cap(sequence)
 			{
-				self.next_sequence = self.next_sequence.max(group.sequence.saturating_add(1));
+				let group = seg.parked.remove(&sequence).expect("parked key just observed");
+				self.next_sequence = self.next_sequence.max(sequence.saturating_add(1));
 				return Poll::Ready(Ok(Some(group)));
-			}
-			// A `start_at` overtook the parked group; drop it and read on.
-			if seg.parked.is_some() {
-				// Still capped: the segment isn't done, it's parked.
-				all_done = false;
-				continue;
 			}
 
 			loop {
-				match Self::poll_segment(seg, &self.last_prefs, self.min_sequence, end_sequence, waiter) {
+				match Self::poll_segment(seg, &self.last_prefs, min_sequence, waiter) {
 					Poll::Ready(Some(group)) => {
 						if beyond_cap(group.sequence) {
-							// `end_at` parks the subscriber; hold the group until
-							// the cap rises rather than dropping it.
-							seg.parked = Some(group);
-							all_done = false;
-							break;
+							// `end_at` holds the group until the cap rises rather than
+							// dropping it; keep draining so an in-range group that
+							// arrived behind it still flows.
+							seg.parked.insert(group.sequence, group);
+							continue;
 						}
-						if group.sequence < self.min_sequence {
+						if group.sequence < min_sequence {
 							// A `start_at` raced an already-delivered group; skip it
 							// and re-poll the same segment for what's behind it.
 							continue;
@@ -908,11 +907,14 @@ impl Subscriber {
 						return Poll::Ready(Ok(Some(group)));
 					}
 					Poll::Ready(None) => break,
-					Poll::Pending => {
-						all_done = false;
-						break;
-					}
+					Poll::Pending => break,
 				}
+			}
+
+			// Parked groups become deliverable if the cap rises, and a segment that
+			// hasn't completed can still produce; either way the track isn't over.
+			if !seg.parked.is_empty() || !matches!(seg.sub, SubState::Done(_)) {
+				all_done = false;
 			}
 		}
 
@@ -990,7 +992,7 @@ impl Subscriber {
 		// datagrams must still resolve the subscription (registering demand) and
 		// be woken when it activates.
 		if let Some(seg) = self.segments.last_mut()
-			&& Self::poll_activate(seg, &self.last_prefs, self.min_sequence, self.end_sequence, waiter).is_ready()
+			&& Self::poll_activate(seg, &self.last_prefs, self.min_sequence, waiter).is_ready()
 			&& let SubState::Active(sub) = &mut seg.sub
 		{
 			match sub.poll_recv_datagram(waiter) {
@@ -1035,13 +1037,7 @@ impl Subscriber {
 		let Some(seg) = self.segments.last_mut() else {
 			return Poll::Ready(Ok(0));
 		};
-		ready!(Self::poll_activate(
-			seg,
-			&self.last_prefs,
-			self.min_sequence,
-			self.end_sequence,
-			waiter
-		));
+		ready!(Self::poll_activate(seg, &self.last_prefs, self.min_sequence, waiter));
 		match &mut seg.sub {
 			SubState::Done(count) => Poll::Ready(Ok(count.unwrap_or(0))),
 			SubState::Active(sub) => match ready!(sub.poll_finished(waiter)) {
@@ -1075,13 +1071,12 @@ impl Subscriber {
 	}
 
 	/// Cap the subscriber at the specified sequence (inclusive), or remove the cap.
+	///
+	/// Enforced on this subscriber's reads (see [`Self::poll_recv_group`]), never
+	/// on the inner segment cursors, so a capped group parks here and a rising cap
+	/// re-offers it.
 	pub fn end_at(&mut self, sequence: impl Into<Option<u64>>) {
 		self.end_sequence = sequence.into();
-		for seg in &mut self.segments {
-			if let SubState::Active(sub) = &mut seg.sub {
-				sub.end_at(min_some(seg.end, self.end_sequence));
-			}
-		}
 	}
 
 	/// The shared preferences channel, so `track::SubscriberControl` can wrap it.
@@ -1461,6 +1456,33 @@ mod test {
 		// Raising the cap re-offers the parked group.
 		sub.end_at(1);
 		assert_eq!(recv(&mut sub), 1);
+	}
+
+	/// A parked beyond-cap group must not block in-range groups that arrive
+	/// behind it: a relay can ingest a burst micro-reordered (newest first).
+	#[tokio::test]
+	async fn end_at_reoffers_reordered_arrivals() {
+		let (mut track_a, consumer_a) = track_pair("a");
+
+		let mut producer = Producer::new();
+		producer.switch(&consumer_a, None).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		sub.end_at(1);
+
+		// Reordered burst: the beyond-cap group arrives first.
+		write_group(&mut track_a, 2, "a2");
+		write_group(&mut track_a, 0, "a0");
+		write_group(&mut track_a, 1, "a1");
+
+		// The capped group parks without blocking the in-range late arrivals.
+		assert_eq!(recv(&mut sub), 0);
+		assert_eq!(recv(&mut sub), 1);
+		recv_pending(&mut sub);
+
+		// Raising the cap re-offers the parked group.
+		sub.end_at(2);
+		assert_eq!(recv(&mut sub), 2);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -877,7 +877,11 @@ impl Subscriber {
 		let mut all_done = true;
 		for seg in &mut self.segments {
 			// A `start_at` overtook these parked groups; drop them and read on.
-			seg.parked.retain(|sequence, _| *sequence >= min_sequence);
+			// Eviction/expiry (which aborts a cached group) drops its entry too,
+			// bounding parking by the track's cache policy rather than retaining
+			// every group a long-capped subscription ever observed.
+			seg.parked
+				.retain(|sequence, group| *sequence >= min_sequence && !group.is_aborted());
 
 			// Re-offer the lowest parked group back inside the cap once it rises.
 			if let Some(&sequence) = seg.parked.keys().next()
@@ -1483,6 +1487,29 @@ mod test {
 		// Raising the cap re-offers the parked group.
 		sub.end_at(2);
 		assert_eq!(recv(&mut sub), 2);
+	}
+
+	/// A parked group the producer aborts (eviction/expiry) is dropped rather
+	/// than re-offered when the cap rises.
+	#[tokio::test]
+	async fn evicted_parked_groups_are_dropped() {
+		let (mut track_a, consumer_a) = track_pair("a");
+
+		let mut producer = Producer::new();
+		producer.switch(&consumer_a, None).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		sub.end_at(0);
+		write_group(&mut track_a, 0, "a0");
+		assert_eq!(recv(&mut sub), 0);
+
+		let straggler = track_a.create_group(group::Info { sequence: 1 }).unwrap();
+		recv_pending(&mut sub);
+		straggler.abort(Error::Old).unwrap();
+
+		sub.end_at(None);
+		write_group(&mut track_a, 2, "a2");
+		assert_eq!(recv(&mut sub), 2, "the evicted parked group is dropped, not re-offered");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -21,7 +21,7 @@ use super::{Datagram, Requests};
 pub use super::subscription::Subscription;
 
 use std::{
-	collections::{HashMap, VecDeque},
+	collections::{BTreeMap, HashMap, VecDeque},
 	sync::Arc,
 	sync::OnceLock,
 	sync::atomic::{AtomicBool, Ordering},
@@ -1196,6 +1196,7 @@ impl Producer {
 				min_sequence: 0,
 				next_sequence: 0,
 				end_sequence: None,
+				parked: BTreeMap::new(),
 			}),
 			// A producer-side (in-process) subscribe is not egress: stay untagged.
 			stats: stats::Scope::default(),
@@ -1901,6 +1902,7 @@ impl Subscribing {
 						min_sequence: 0,
 						next_sequence: 0,
 						end_sequence: None,
+						parked: BTreeMap::new(),
 					}),
 					stats: self.stats.clone(),
 					_stats_sub: self.stats.subscribe(),
@@ -2188,11 +2190,16 @@ struct PlainSubscriber {
 	/// One past the highest sequence returned by `next_group`.
 	/// Used only by that method to skip late arrivals; does not affect `recv_group`.
 	next_sequence: u64,
-	/// Inclusive upper sequence bound for `next_group`. `None` means no cap. Set by
-	/// `end_at`; can be raised, lowered, or unset at any time. Groups beyond the
-	/// cap stay in the producer's cache and become eligible again when the cap
-	/// rises (or is removed).
+	/// Inclusive upper sequence bound for `next_group` and `recv_group`. `None`
+	/// means no cap. Set by `end_at`; can be raised, lowered, or unset at any time.
+	/// Groups beyond the cap stay in the producer's cache and become eligible again
+	/// when the cap rises (or is removed).
 	end_sequence: Option<u64>,
+	/// Groups received beyond the [`Self::end_sequence`] cap, held for `recv_group`
+	/// until the cap rises (arrival-order reads consume the shared cursor, so they
+	/// are parked here instead of dropped). Keyed by sequence so the lowest is
+	/// re-offered first.
+	parked: BTreeMap<u64, group::Consumer>,
 }
 
 impl PlainSubscriber {
@@ -2209,14 +2216,37 @@ impl PlainSubscriber {
 	}
 
 	fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
-		let Some((consumer, found_index)) =
-			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, self.min_sequence))?)
-		else {
-			return Poll::Ready(Ok(None));
-		};
+		// A raised `start_at` drops parked groups it overtook.
+		self.parked.retain(|sequence, _| *sequence >= self.min_sequence);
 
-		self.index = found_index + 1;
-		Poll::Ready(Ok(Some(consumer)))
+		// Re-offer the lowest parked group back inside the cap once it rises.
+		if let Some(&sequence) = self.parked.keys().next()
+			&& self.end_sequence.is_none_or(|end| sequence <= end)
+		{
+			return Poll::Ready(Ok(self.parked.remove(&sequence)));
+		}
+
+		loop {
+			let Some((consumer, found_index)) =
+				ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, self.min_sequence))?)
+			else {
+				// Parked groups survive a finished track: they become deliverable
+				// again if the cap rises, so the stream isn't over while any are held.
+				if self.parked.is_empty() {
+					return Poll::Ready(Ok(None));
+				}
+				return Poll::Pending;
+			};
+			self.index = found_index + 1;
+
+			// Park a group beyond the cap instead of dropping it, and keep scanning
+			// so an in-range group that arrived behind it still flows.
+			if self.end_sequence.is_some_and(|end| consumer.sequence > end) {
+				self.parked.insert(consumer.sequence, consumer);
+				continue;
+			}
+			return Poll::Ready(Ok(Some(consumer)));
+		}
 	}
 
 	fn poll_recv_datagram(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Datagram>>> {
@@ -2311,6 +2341,10 @@ impl Subscriber {
 	/// out of sequence due to network reordering or loss. Use [`Self::poll_next_group`] if
 	/// you only want groups whose sequence number is higher than any previously returned.
 	///
+	/// Honors the floor set by [`Self::start_at`] and the cap set by [`Self::end_at`]:
+	/// a group beyond the cap is parked (not dropped) and re-offered once the cap rises,
+	/// without blocking in-range groups that arrive behind it.
+	///
 	/// Returns `Poll::Ready(Ok(Some(group)))` when a group is available,
 	/// `Poll::Ready(Ok(None))` when the track is finished,
 	/// `Poll::Ready(Err(e))` when the track has been aborted, or
@@ -2329,6 +2363,7 @@ impl Subscriber {
 	/// Every group is returned exactly once, in the order it landed on the wire, which may
 	/// be out of sequence due to network reordering or loss. Use [`Self::next_group`] if you
 	/// only want groups whose sequence number is higher than any previously returned.
+	/// See [`Self::poll_recv_group`] for how [`Self::start_at`] and [`Self::end_at`] apply.
 	pub async fn recv_group(&mut self) -> Result<Option<group::Consumer>> {
 		kio::wait(|waiter| self.poll_recv_group(waiter)).await
 	}
@@ -2469,9 +2504,9 @@ impl Subscriber {
 	/// A local filter, not a request; [`Subscription::group_end`] is the wire-level
 	/// counterpart. See [Local cursor vs wire preference](Self#local-cursor-vs-wire-preference).
 	///
-	/// Affects [`Self::next_group`] only: groups beyond the cap stay in the producer's
-	/// cache rather than being skipped past, so a later call to [`Self::end_at`] with a
-	/// higher value (or `None`) makes them available again. Lowering the cap below the
+	/// Affects [`Self::next_group`] and [`Self::recv_group`]: groups beyond the cap are
+	/// held rather than skipped past, so a later call to [`Self::end_at`] with a higher
+	/// value (or `None`) makes them available again. Lowering the cap below the
 	/// consumer's current cursor parks the consumer until the cap is raised.
 	pub fn end_at(&mut self, sequence: impl Into<Option<u64>>) {
 		match &mut self.inner {
@@ -3822,6 +3857,102 @@ mod test {
 		assert_eq!(
 			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
 			8
+		);
+	}
+
+	/// `recv_group` (arrival order) honors the `end_at` cap by parking, like
+	/// `next_group`: beyond-cap groups are held, not dropped, and a raised cap
+	/// re-offers them, even after the track finishes.
+	#[tokio::test]
+	async fn end_at_parks_recv_group() {
+		let mut producer = track_producer("test", None);
+		let mut consumer = producer.subscribe(None);
+
+		for s in 0..3 {
+			producer.create_group(group::Info { sequence: s }).unwrap();
+		}
+
+		consumer.end_at(1);
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			0
+		);
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			1
+		);
+		assert!(consumer.recv_group().now_or_never().is_none(), "capped at 1");
+
+		// A finished track keeps the parked group claimable: the cap may rise.
+		producer.finish().unwrap();
+		assert!(
+			consumer.recv_group().now_or_never().is_none(),
+			"still parked after finish"
+		);
+
+		consumer.end_at(None);
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			2
+		);
+		assert!(
+			matches!(consumer.recv_group().now_or_never(), Some(Ok(None))),
+			"finished once the parked group drains"
+		);
+	}
+
+	/// A group beyond the cap must not block in-range groups that arrive behind
+	/// it: a relay can ingest a burst micro-reordered (newest first).
+	#[tokio::test]
+	async fn recv_group_serves_arrivals_behind_the_cap() {
+		let mut producer = track_producer("test", None);
+		let mut consumer = producer.subscribe(None);
+
+		consumer.end_at(1);
+
+		// Reordered burst: the beyond-cap group arrives first.
+		producer.create_group(group::Info { sequence: 2 }).unwrap();
+		producer.create_group(group::Info { sequence: 0 }).unwrap();
+		producer.create_group(group::Info { sequence: 1 }).unwrap();
+
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			0
+		);
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			1
+		);
+		assert!(consumer.recv_group().now_or_never().is_none(), "capped at 1");
+
+		consumer.end_at(2);
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			2
+		);
+	}
+
+	/// A raised `start_at` drops parked groups it overtook instead of re-offering
+	/// them once the cap rises.
+	#[tokio::test]
+	async fn start_at_drops_parked_recv_groups() {
+		let mut producer = track_producer("test", None);
+		let mut consumer = producer.subscribe(None);
+
+		consumer.end_at(0);
+		producer.create_group(group::Info { sequence: 1 }).unwrap();
+		assert!(
+			consumer.recv_group().now_or_never().is_none(),
+			"group 1 parked at the cap"
+		);
+
+		consumer.start_at(2);
+		consumer.end_at(None);
+		producer.create_group(group::Info { sequence: 2 }).unwrap();
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			2,
+			"the overtaken parked group is dropped, not re-offered"
 		);
 	}
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -2216,8 +2216,12 @@ impl PlainSubscriber {
 	}
 
 	fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
-		// A raised `start_at` drops parked groups it overtook.
-		self.parked.retain(|sequence, _| *sequence >= self.min_sequence);
+		// A raised `start_at` drops parked groups it overtook, and eviction/expiry
+		// (which aborts a cached group) drops its parked entry. The latter is what
+		// bounds parking: a subscription capped indefinitely holds only what the
+		// track's cache policy still retains, not every group it ever observed.
+		self.parked
+			.retain(|sequence, group| *sequence >= self.min_sequence && !group.is_aborted());
 
 		// Re-offer the lowest parked group back inside the cap once it rises.
 		if let Some(&sequence) = self.parked.keys().next()
@@ -2342,8 +2346,10 @@ impl Subscriber {
 	/// you only want groups whose sequence number is higher than any previously returned.
 	///
 	/// Honors the floor set by [`Self::start_at`] and the cap set by [`Self::end_at`]:
-	/// a group beyond the cap is parked (not dropped) and re-offered once the cap rises,
-	/// without blocking in-range groups that arrive behind it.
+	/// a group beyond the cap is parked (not dropped) and re-offered once the cap rises
+	/// (lowest sequence first), without blocking in-range groups that arrive behind it.
+	/// A parked group that the producer evicts or expires in the meantime is dropped,
+	/// so parking never outlives the track's cache policy.
 	///
 	/// Returns `Poll::Ready(Ok(Some(group)))` when a group is available,
 	/// `Poll::Ready(Ok(None))` when the track is finished,
@@ -3953,6 +3959,38 @@ mod test {
 			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
 			2,
 			"the overtaken parked group is dropped, not re-offered"
+		);
+	}
+
+	/// A parked group the producer aborts (eviction/expiry) is dropped: it is
+	/// neither delivered once the cap rises nor allowed to hold the stream open
+	/// after the track finishes. This is what bounds parking by the cache policy.
+	#[tokio::test]
+	async fn evicted_parked_recv_groups_are_dropped() {
+		let mut producer = track_producer("test", None);
+		let mut consumer = producer.subscribe(None);
+
+		producer.create_group(group::Info { sequence: 0 }).unwrap();
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			0
+		);
+
+		consumer.end_at(0);
+		let straggler = producer.create_group(group::Info { sequence: 1 }).unwrap();
+		assert!(
+			consumer.recv_group().now_or_never().is_none(),
+			"group 1 parked at the cap"
+		);
+
+		// The cache evicts the parked group (abort-as-tombstone), then the track ends.
+		straggler.abort(Error::Old).unwrap();
+		producer.finish().unwrap();
+
+		consumer.end_at(None);
+		assert!(
+			matches!(consumer.recv_group().now_or_never(), Some(Ok(None))),
+			"a dead parked group must not be delivered or hold the stream open"
 		);
 	}
 


### PR DESCRIPTION
## Root cause

`lite::publisher::run_track` selected groups with `track.poll_next_group`, whose serving cursor skips any group with a sequence at or below the highest already returned. On a relay hop the upstream leg can deliver a back-to-back burst micro-reordered (newest-first send order ranks the newer group's stream ahead), so the relay ingests group N+1 a few microseconds before group N. If the serving loop polled between the two arrivals, the cursor advanced past N and the older group was permanently dropped for every downstream subscriber, even though it was cached, in demand, and only microseconds "late". The spliced variant (`resume::Subscriber::poll_next_group`, which relay-served tracks actually use) had the same skip in its floor check.

## Fix

Serve subscriptions in arrival order with exactly-once semantics (`poll_recv_group`) instead of the sequence cursor, so staleness is governed by the latency window (cache expiry), not arrival raciness. That required teaching `recv_group` the two bounds the serving path relies on:

- **`end_at` cap parking (#2758 semantics)**: `PlainSubscriber::poll_recv_group` previously ignored `end_at` entirely. It now parks beyond-cap groups (keyed by sequence) and re-offers them when the cap rises; parked groups survive a clean finish, so a capped subscription parks instead of ending, matching `next_group`. The parked set is a map rather than resume's old single slot, so a parked beyond-cap group no longer blocks in-range groups that arrive behind it (the cap x reorder composite: capped at 10, arrivals 11 then 10, group 10 must still flow).
- **`SUBSCRIBE_START` floor**: `min_sequence` was already honored by arrival-order reads. Since arrival order could later surface a straggler below the first served group, `run_track` now pins the floor to the announced start when it sends SUBSCRIBE_OK, keeping the draft's contract that nothing below the resolved start group is delivered ("MUST be greater than or equal to the requested start group; any groups in between are unavailable and implicitly dropped").

`resume::Subscriber` gets the same multi-slot parking, and it now owns the caps outright: the inner per-segment `end_at` calls are removed. They were no-ops before (plain arrival-order reads ignored the cap), but with cap-aware inner cursors they would have parked boundary-crossing groups inside a segment, hiding the segment's completion and holding groups the splice boundary is supposed to discard. The segment boundary (`seg.end`) discard and the subscriber cap (`end_at`) park stay separate, enforced in `resume::Subscriber::poll_recv_group`.

The IETF publisher already served via `poll_recv_group`, so this also aligns the two serving paths.

## Regression tests

All fail without the fix (verified by re-running them against the pre-fix sources):

- `lite::publisher::test::recv_next_serves_late_arrival_after_newer_group`: the serving selection ingests group 2, serves it, then ingests group 1; the late group must still be served and the track still finishes.
- `model::track::test::{end_at_parks_recv_group, recv_group_serves_arrivals_behind_the_cap, start_at_drops_parked_recv_groups}`: cap parking, cap x reorder, and floor-overtake semantics on the plain subscriber.
- `model::resume::test::end_at_reoffers_reordered_arrivals`: the same cap x reorder composite on the spliced subscriber (previously the single parked slot blocked the whole segment).

## Cross-package sync

- **drafts**: no wire change. No message, field, or framing changes; SUBSCRIBE_OK's resolved-start contract is preserved (and now actively enforced via the floor pin). Delivery was already specified as parallel out-of-order streams.
- **js/net**: the JS lite publisher (`#runTrack` via `nextGroup`) has the same skip; spun off as a follow-up task rather than mixing a JS model change into this PR.
- **doc/concept**: no pages document the serving-cursor behavior; nothing to update.

`just check`, full `moq-net` + dependent crate tests (`moq-relay`, `hang`, `moq-mux`, `moq-stats`), `cargo doc -D warnings`, and `just test smoke` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Fable 5)