### PR TITLE
fix(js/net): serve subscription groups in arrival order

### DIFF
--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -3,8 +3,9 @@ import { Producer as BroadcastProducer } from "../broadcast.ts";
 import { Producer as GroupProducer } from "../group.ts";
 import { createMockTransportPair } from "../mock.ts";
 import * as Path from "../path.ts";
-import { Stream } from "../stream.ts";
+import { Reader, Stream } from "../stream.ts";
 import { Fetch } from "./fetch.ts";
+import { Group as GroupMessage } from "./group.ts";
 import { randomOrigin } from "./origin.ts";
 import { sendOrder } from "./priority.ts";
 import { Publisher } from "./publisher.ts";
@@ -351,6 +352,99 @@ test("lite draft-05: the fetch response ranks the publisher's own writes", async
 	} finally {
 		publisher.close();
 		client.close();
+	}
+});
+
+// Opens a served subscription and returns the machinery to write groups and observe
+// which of them the publisher put on the wire (each group gets its own uni stream).
+async function servedSubscription(options: { startGroup?: number } = {}) {
+	const pair = createMockTransportPair(ALPN_05);
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin());
+
+	const broadcast = new BroadcastProducer();
+	const track = broadcast.createTrack("video");
+	publisher.publish(Path.from("test"), broadcast);
+
+	const client = await Stream.open(pair.client);
+	const server = await Stream.accept(pair.server);
+	if (!server) throw new Error("publisher never accepted the subscribe stream");
+
+	const msg = new Subscribe({
+		id: 0n,
+		broadcast: Path.from("test"),
+		track: "video",
+		priority: 0,
+		startGroup: options.startGroup,
+	});
+	void publisher.runSubscribe(msg, server);
+
+	const opened = pair.client.incomingUnidirectionalStreams.getReader();
+
+	return {
+		client,
+		serve(sequence: number) {
+			const group = new GroupProducer(sequence);
+			group.writeString("hello");
+			group.close();
+			track.writeGroup(group);
+		},
+		// The sequence of the next group stream the publisher opened.
+		async servedSequence() {
+			const next = await opened.read();
+			if (next.done) throw new Error("publisher never opened the group stream");
+			const reader = new Reader(next.value);
+			await reader.u53(); // stream type
+			return (await GroupMessage.decode(reader)).sequence;
+		},
+		close() {
+			opened.releaseLock();
+			publisher.close();
+			client.close();
+		},
+	};
+}
+
+// A relay can ingest back-to-back groups micro-reordered (the upstream leg sends
+// newest-first). The older group is cached and in demand, so serving must still
+// deliver it; a sequence cursor would skip it permanently.
+test("lite draft-05: a late-arriving older group is still served", async () => {
+	const sub = await servedSubscription({ startGroup: 1 });
+	try {
+		// Serve one at a time so arrival order at the publisher is the order given.
+		sub.serve(1);
+		expect(await sub.servedSequence()).toBe(1);
+		sub.serve(3);
+		expect(await sub.servedSequence()).toBe(3);
+
+		// Group 2 lands after group 3 was already served.
+		sub.serve(2);
+		expect(await sub.servedSequence()).toBe(2);
+	} finally {
+		sub.close();
+	}
+});
+
+// SUBSCRIBE_START promises nothing below the announced sequence will be delivered, so
+// the floor is pinned there: a straggler below the first served group is dropped even
+// though arrival-order serving would otherwise surface it.
+test("lite draft-05: a straggler below the announced start group is not served", async () => {
+	const sub = await servedSubscription();
+	try {
+		sub.serve(2);
+		expect(await sub.servedSequence()).toBe(2);
+
+		// The publisher announced group 2 as the resolved start.
+		const resp = await decodeSubscribeResponse(sub.client.reader, Version.DRAFT_05);
+		if (!("start" in resp)) throw new Error("expected SUBSCRIBE_START");
+		expect(resp.start.group).toBe(2);
+
+		// A straggler below the announced start never reaches the wire: the next
+		// stream the publisher opens is group 3's.
+		sub.serve(1);
+		sub.serve(3);
+		expect(await sub.servedSequence()).toBe(3);
+	} finally {
+		sub.close();
 	}
 });
 

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -437,10 +437,10 @@ export class Publisher {
 
 		try {
 			for (;;) {
-				// Arrival order, not the sequence cursor: on a relay, a burst can be ingested
-				// micro-reordered by the upstream leg, and a sequence cursor would permanently
-				// skip the older group even though it is cached and in demand. Staleness is the
-				// latency window's job (cache expiry), not arrival order's.
+				// Exactly-once serving, not the sequence cursor: on a relay, a burst can be
+				// ingested micro-reordered by the upstream leg, and a sequence cursor would
+				// permanently skip the older group even though it is cached and in demand.
+				// Staleness is the latency window's job (cache expiry), not arrival order's.
 				const next = track.recvGroup();
 				const group = await Promise.race([next, stream.closed]);
 				if (!group) {

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -437,7 +437,11 @@ export class Publisher {
 
 		try {
 			for (;;) {
-				const next = track.nextGroup();
+				// Arrival order, not the sequence cursor: on a relay, a burst can be ingested
+				// micro-reordered by the upstream leg, and a sequence cursor would permanently
+				// skip the older group even though it is cached and in demand. Staleness is the
+				// latency window's job (cache expiry), not arrival order's.
+				const next = track.recvGroup();
 				const group = await Promise.race([next, stream.closed]);
 				if (!group) {
 					next.then((group) => group?.close()).catch(() => {});
@@ -446,6 +450,10 @@ export class Publisher {
 
 				if (emitRange && !startSent) {
 					startSent = true;
+					// SUBSCRIBE_START promises nothing below this sequence will be delivered.
+					// Arrival-order serving could later surface a straggler below the first
+					// group, so pin the floor to what was announced.
+					track.startAt(group.sequence);
 					await encodeSubscribeResponse(stream, { start: new SubscribeStart(group.sequence) }, this.version);
 				}
 				end = Math.max(end, group.sequence + 1);

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -306,6 +306,55 @@ test("startAt drops groups recvGroup parked at the cap", async () => {
 	expect((await pending)?.sequence).toBe(2);
 });
 
+// A live duplicate would fan out to every subscriber twice (recvGroup has no sequence
+// cursor to hide it), so writeGroup rejects it like Rust's claim_sequence. An aborted
+// incarnation is evicted so a fresh group can serve the sequence again.
+test("writeGroup rejects a duplicate live sequence", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	const first = new GroupProducer(7);
+	first.writeString("first");
+	first.close();
+	producer.writeGroup(first);
+
+	// A peer re-sending a live sequence is rejected, not fanned out again.
+	expect(() => producer.writeGroup(new GroupProducer(7))).toThrow("duplicate group");
+	expect((await track.recvGroup())?.sequence).toBe(7);
+
+	// An aborted incarnation is replaceable: the retry serves the sequence fresh.
+	const aborted = new GroupProducer(8);
+	producer.writeGroup(aborted);
+	aborted.close(new Error("upstream reset"));
+
+	const retry = new GroupProducer(8);
+	retry.writeString("retry");
+	retry.close();
+	producer.writeGroup(retry);
+
+	const got = await track.recvGroup();
+	expect(got?.sequence).toBe(8);
+	expect(await got?.readString()).toBe("retry");
+});
+
+// A group parked at the cap outlives a clean producer close on purpose, so the
+// subscriber leaving is what must release it: close() drops the parked group and
+// settles the pending read instead of leaving it hanging forever.
+test("closing the subscriber releases a recvGroup parked after a clean close", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	track.endAt(0);
+	producer.writeGroup(new GroupProducer(1));
+
+	const pending = track.recvGroup();
+	expect(await Promise.race([pending, Promise.resolve("pending")])).toBe("pending");
+
+	producer.close();
+	track.close();
+	expect(await pending).toBeUndefined();
+});
+
 test("recvGroup after nextGroup still returns late arrivals", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -355,6 +355,22 @@ test("closing the subscriber releases a recvGroup parked after a clean close", a
 	expect(await pending).toBeUndefined();
 });
 
+// Same, but with the producer still live: the first close() must also clear the
+// buffer, or the parked group re-parks on wake and the read hangs forever.
+test("closing the subscriber releases a recvGroup parked while the producer is live", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	track.endAt(0);
+	producer.writeGroup(new GroupProducer(1));
+
+	const pending = track.recvGroup();
+	expect(await Promise.race([pending, Promise.resolve("pending")])).toBe("pending");
+
+	track.close();
+	expect(await pending).toBeUndefined();
+});
+
 test("recvGroup after nextGroup still returns late arrivals", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -218,6 +218,94 @@ test("local cursor bounds can skip, pause, and release buffered groups", async (
 	expect((await pending)?.sequence).toBe(4);
 });
 
+// A relay can ingest back-to-back groups micro-reordered (the upstream leg sends
+// newest-first). The older group is cached and in demand, so serving must still
+// deliver it; a sequence cursor would skip it permanently.
+test("recvGroup serves a late arrival after a newer group", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	producer.writeGroup(new GroupProducer(2));
+	expect((await track.recvGroup())?.sequence).toBe(2);
+
+	// Group 1 lands after group 2 was already served.
+	producer.writeGroup(new GroupProducer(1));
+	expect((await track.recvGroup())?.sequence).toBe(1);
+
+	// Staleness is the latency window's job, not arrival order's: the track
+	// still finishes normally afterward.
+	producer.close();
+	expect(await track.recvGroup()).toBeUndefined();
+});
+
+// recvGroup honors the endAt cap by parking, like nextGroup: beyond-cap groups are
+// held, not dropped, and a raised cap re-offers them, even after a clean close.
+test("endAt parks recvGroup beyond the cap and a raised cap re-offers", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	for (let sequence = 0; sequence < 3; sequence++) producer.writeGroup(new GroupProducer(sequence));
+
+	track.endAt(1);
+	expect((await track.recvGroup())?.sequence).toBe(0);
+	expect((await track.recvGroup())?.sequence).toBe(1);
+
+	const pending = track.recvGroup();
+	expect(await Promise.race([pending, Promise.resolve("pending")])).toBe("pending");
+
+	// A clean close keeps the parked group claimable: the cap may still rise.
+	producer.close();
+	expect(await Promise.race([pending, new Promise((resolve) => setTimeout(() => resolve("parked"), 10))])).toBe(
+		"parked",
+	);
+
+	track.endAt();
+	expect((await pending)?.sequence).toBe(2);
+	expect(await track.recvGroup()).toBeUndefined();
+});
+
+// A group beyond the cap must not block in-range groups that arrive behind it:
+// a relay can ingest a burst micro-reordered (newest first).
+test("recvGroup serves in-range groups that arrive behind a capped one", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	track.endAt(1);
+
+	// Reordered burst: the beyond-cap group arrives first.
+	producer.writeGroup(new GroupProducer(2));
+	producer.writeGroup(new GroupProducer(0));
+	producer.writeGroup(new GroupProducer(1));
+
+	expect((await track.recvGroup())?.sequence).toBe(0);
+	expect((await track.recvGroup())?.sequence).toBe(1);
+
+	const pending = track.recvGroup();
+	expect(await Promise.race([pending, Promise.resolve("pending")])).toBe("pending");
+
+	track.endAt(2);
+	expect((await pending)?.sequence).toBe(2);
+});
+
+// A raised startAt drops parked groups it overtook instead of re-offering them
+// once the cap rises.
+test("startAt drops groups recvGroup parked at the cap", async () => {
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+
+	track.endAt(0);
+	producer.writeGroup(new GroupProducer(1));
+	const pending = track.recvGroup();
+	expect(await Promise.race([pending, Promise.resolve("pending")])).toBe("pending");
+
+	track.startAt(2);
+	track.endAt();
+	producer.writeGroup(new GroupProducer(2));
+
+	// The overtaken parked group is dropped, not re-offered.
+	expect((await pending)?.sequence).toBe(2);
+});
+
 test("recvGroup after nextGroup still returns late arrivals", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -651,9 +651,9 @@ export class Subscriber {
 	}
 
 	/**
-	 * Cap {@link nextGroup} at `sequence` inclusively, or omit it to remove the cap.
-	 * Groups above the cap remain buffered and become readable if the cap is raised.
-	 * This local cursor does not change the subscription's wire request.
+	 * Cap {@link nextGroup} and {@link recvGroup} at `sequence` inclusively, or omit it to
+	 * remove the cap. Groups above the cap remain buffered and become readable if the cap
+	 * is raised. This local cursor does not change the subscription's wire request.
 	 */
 	endAt(sequence?: number): void {
 		this.#cursor.update((cursor) => ({ ...cursor, end: sequence }));
@@ -668,23 +668,34 @@ export class Subscriber {
 	}
 
 	/**
-	 * Receive the next group available on this track, in arrival order.
+	 * Receive the next group available on this track, in arrival order, exactly once.
 	 *
 	 * Groups may arrive out of order or with gaps due to network conditions.
 	 * Use {@link nextGroup} for sequence order, skipping those that arrive too late.
+	 *
+	 * Honors the floor set by {@link startAt} and the cap set by {@link endAt}: a group
+	 * beyond the cap stays buffered (not dropped) and is offered once the cap rises, even
+	 * after a clean close, without blocking in-range groups that arrive behind it.
 	 */
 	async recvGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
 			const groups = this.#state.groups.peek();
-			const { start } = this.#cursor.peek();
+			const { start, end } = this.#cursor.peek();
 			while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
-			if (groups.length > 0) {
-				return groups.shift();
+
+			// The buffer is sequence-sorted, so an in-range group that arrives behind a
+			// beyond-cap one sorts in front of it and is never blocked by it.
+			const group = groups[0];
+			if (group && (end === undefined || group.sequence <= end)) {
+				groups.shift();
+				return group;
 			}
 
 			const closed = this.#state.closed.peek();
 			if (closed instanceof Error) throw closed;
-			if (closed !== undefined) return undefined;
+			// A group beyond the cap outlives a clean close: it becomes deliverable if
+			// the cap rises, so the track isn't over while any are held.
+			if (closed !== undefined && !group) return undefined;
 
 			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -681,19 +681,15 @@ export class Subscriber {
 
 	/** Close the track (optionally with an error), closing any pending groups. Idempotent. */
 	close(abort?: Error) {
-		if (!closeTrackState(this.#state, abort)) {
-			// The track already settled (e.g. the producer finished), but groups parked
-			// at the endAt cap can still be buffered, keeping a read pending. Leaving is
-			// what abandons them: drop them and wake the read so it observes the end.
-			this.#state.groups.mutate((groups) => {
-				for (const group of groups) group.close(abort);
-				groups.length = 0;
-			});
-			return;
-		}
-		for (const group of this.#state.groups.peek()) {
-			group.close(abort);
-		}
+		// Settle if we're first (the producer may already have); either way drop anything
+		// still buffered. Groups parked at the endAt cap deliberately outlive a clean
+		// producer close, so the subscriber leaving is what must release them: closing
+		// and clearing wakes a pending read to observe the end instead of hanging.
+		closeTrackState(this.#state, abort);
+		this.#state.groups.mutate((groups) => {
+			for (const group of groups) group.close(abort);
+			groups.length = 0;
+		});
 	}
 
 	/**

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -447,8 +447,19 @@ export class Producer {
 		});
 	}
 
-	// Evict cached groups that are closed and older than the cache window, dropping
-	// each evicted group's mirror from every sink so no consumer can pin it.
+	// Drop a cached group's mirror from every sink so no consumer can pin it.
+	#evict(entry: CachedGroup): void {
+		for (const [sink, mirror] of entry.mirrors) {
+			sink.groups.mutate((groups) => {
+				const i = groups.indexOf(mirror);
+				if (i >= 0) groups.splice(i, 1);
+			});
+			mirror.close();
+		}
+		entry.mirrors.clear();
+	}
+
+	// Evict cached groups that are closed and older than the cache window.
 	#prune(): void {
 		const latencyMaxMs = this.#state.info.peek()?.latencyMax ?? DEFAULT_LATENCY_MAX_MS;
 		const cutoff = Date.now() - latencyMaxMs;
@@ -459,15 +470,7 @@ export class Producer {
 				retained.push(entry);
 				continue;
 			}
-
-			for (const [sink, mirror] of entry.mirrors) {
-				sink.groups.mutate((groups) => {
-					const i = groups.indexOf(mirror);
-					if (i >= 0) groups.splice(i, 1);
-				});
-				mirror.close();
-			}
-			entry.mirrors.clear();
+			this.#evict(entry);
 		}
 		this.#cache = retained;
 	}
@@ -491,9 +494,26 @@ export class Producer {
 		return group;
 	}
 
-	/** Insert an existing group into the track. */
+	/**
+	 * Insert an existing group into the track.
+	 *
+	 * Throws on a sequence that is still cached: a live duplicate would fan out to every
+	 * subscriber twice. An aborted incarnation is evicted so a fresh group can serve the
+	 * sequence again. Best effort (mirrors Rust): nothing remembers a sequence whose cache
+	 * entry is already gone, so a long-evicted sequence is accepted as new.
+	 */
 	writeGroup(group: GroupProducer) {
 		if (this.#state.closed.peek() !== undefined) throw new Error("track is closed");
+
+		const existing = this.#cache.findIndex((entry) => entry.group.sequence === group.sequence);
+		if (existing >= 0) {
+			const entry = this.#cache[existing];
+			if (!(entry.group.closed.peek() instanceof Error)) {
+				throw new Error(`duplicate group: sequence=${group.sequence}`);
+			}
+			this.#evict(entry);
+			this.#cache.splice(existing, 1);
+		}
 
 		// Only advance #next upward (for appendGroup auto-increment).
 		if (group.sequence >= (this.#next ?? 0)) {
@@ -661,17 +681,28 @@ export class Subscriber {
 
 	/** Close the track (optionally with an error), closing any pending groups. Idempotent. */
 	close(abort?: Error) {
-		if (!closeTrackState(this.#state, abort)) return;
+		if (!closeTrackState(this.#state, abort)) {
+			// The track already settled (e.g. the producer finished), but groups parked
+			// at the endAt cap can still be buffered, keeping a read pending. Leaving is
+			// what abandons them: drop them and wake the read so it observes the end.
+			this.#state.groups.mutate((groups) => {
+				for (const group of groups) group.close(abort);
+				groups.length = 0;
+			});
+			return;
+		}
 		for (const group of this.#state.groups.peek()) {
 			group.close(abort);
 		}
 	}
 
 	/**
-	 * Receive the next group available on this track, in arrival order, exactly once.
+	 * Receive every group on this track exactly once, as it becomes available.
 	 *
-	 * Groups may arrive out of order or with gaps due to network conditions.
-	 * Use {@link nextGroup} for sequence order, skipping those that arrive too late.
+	 * Groups may arrive out of order or with gaps due to network conditions; unlike
+	 * {@link nextGroup}, one that arrives after a newer group was already returned is
+	 * still delivered. When several groups are buffered, the lowest sequence is
+	 * returned first.
 	 *
 	 * Honors the floor set by {@link startAt} and the cap set by {@link endAt}: a group
 	 * beyond the cap stays buffered (not dropped) and is offered once the cap rises, even


### PR DESCRIPTION
Mirrors rs PR #2771 in js/net.

## Root cause

The lite publisher's `#runTrack` served groups via `track.nextGroup()`, a sequence cursor that silently skips late arrivals. On a relay, the upstream leg sends a burst newest-first, so back-to-back groups can be ingested micro-reordered: the newer group gets served, and the older one, cached and in demand, is then permanently skipped. Staleness should be governed by the latency window (cache expiry), not arrival raciness.

## What changed

- `lite/publisher.ts` `#runTrack` serves via `recvGroup()` (arrival order, exactly-once). When it sends SUBSCRIBE_START it pins the subscriber floor with `startAt(group.sequence)`: SUBSCRIBE_START promises nothing below the announced sequence is delivered, and arrival-order serving could otherwise surface a straggler below the first served group.
- `track.ts` `Subscriber.recvGroup` now honors the `endAt` serving cap: a beyond-cap group stays buffered (not dropped) and is offered once the cap rises, surviving a clean close (same `closed !== undefined && !group` shape `nextGroup` got in #2766; a settled `Once` never re-fires `Signal.race`, so no spin). Where Rust needed a `BTreeMap` of parked groups, JS needs no separate structure: the subscriber's group buffer is sequence-sorted, so leaving a beyond-cap group buffered *is* the parking, and an in-range group arriving behind it sorts in front and is never blocked.

The existing `end = max(...)` SUBSCRIBE_END tracking in `#runTrack` already assumed arrival order (its comment even said `recvGroup`), so the boundary logic is untouched. The other `recvGroup` callers (IETF publisher, `broadcast.fetchGroup`, hang's container consumer) never set `endAt`, so the cap change only affects the lite serving path.

## Tests

Regression tests mirror the Rust ones:

- `track.test.ts`: a late arrival after a newer group is served (fails on the old cursor); `endAt` parks and a raised cap re-offers, across a clean close; an in-range group behind a capped one still flows (burst 2,0,1 with cap 1); a raised `startAt` drops parked groups it overtook.
- `lite/publisher.test.ts` (wire-level, mock transport): serving 1,3,2 opens a group stream for all three (previously group 2 never hit the wire); a straggler below the announced SUBSCRIBE_START group is not served.

No wire format change, so no draft update (same as the Rust PR). `just js test` and `just check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Fable 5)