### PR TITLE
fix(moq-cli): follow the decode latency rename in play

### DIFF
--- a/rs/moq-cli/src/play.rs
+++ b/rs/moq-cli/src/play.rs
@@ -276,7 +276,7 @@ impl Media {
 								}
 							};
 							let mut decode = moq_video::decode::Config::new();
-							decode.latency_max = Some(self.args.latency_max);
+							decode.latency = moq_mux::Latency::max(self.args.latency_max);
 							match moq_video::decode::Consumer::new(&rendition, &config, &name, decode).await {
 								Ok(consumer) => {
 									tracing::info!(track = name, decoder = consumer.name(), "playing video rendition");
@@ -308,7 +308,7 @@ impl Media {
 								}
 							};
 							let mut decode = moq_audio::decode::Config::new();
-							decode.latency_max = Some(self.args.latency_max);
+							decode.latency = moq_mux::Latency::max(self.args.latency_max);
 							// The sink and the frame-duration math below both assume f32,
 							// so ask for it rather than inheriting the decoder default.
 							decode.format = moq_audio::Format::F32;


### PR DESCRIPTION
## Summary

`dev` does not compile with the `play` feature, so CI fails on every PR that targets it:

```
error[E0609]: no field `latency_max` on type `moq_video::decode::Config`
   --> rs/moq-cli/src/play.rs:279
error[E0609]: no field `latency_max` on type `moq_audio::decode::Config`
   --> rs/moq-cli/src/play.rs:311
```

Root cause: #2688 renamed both decode configs' `latency_max: Option<Duration>` to `latency: moq_mux::Latency` and updated the crates themselves, but missed these two call sites in `moq-cli`. They survived review and merge because `play` is an opt-in feature (it is what pulls `moq-video` and `moq-audio` into `moq-cli`), so no default-feature build and no local `just check` ever compiles them. CI's `just ci` builds `--all-features` and does.

`--latency-max` is documented as "maximum media buffering before skipping a stalled group", which is precisely what `Latency::max` expresses, so this is a rename to the new spelling with no behavior change. The old code always passed `Some(..)` and the arg has a default, so no path loses its value.

## Public API changes

None; two call sites in a binary.

## Test plan

- `cargo check -p moq-cli --features play` fails on `dev` with the two errors above and passes with this change.
- The rename touched only these two config types. Every other `.latency_max = ` in the workspace (`moq-rtmp`, `moq-srt`, `moq-rtc`, `track::Info`, the catalog producer) is a different type that still has the field, and those all build in default CI today.

Worth noting for follow-up: nothing gates the `play` feature outside `--all-features` CI, which is how a breaking rename landed without its consumer. Same class of hole as the manual `just rs windows` / `just rs macos` gates.

(written by Fable 5)