### PR TITLE
fix(native): make a build with one transport compile again

### DIFF
--- a/rs/justfile
+++ b/rs/justfile
@@ -209,36 +209,6 @@ wasm-fix *args:
     cargo clippy --fix --allow-staged --allow-dirty -p moq-wasm --target wasm32-unknown-unknown --all-targets {{ args }}
     cargo fmt -p moq-wasm
 
-# The default and `--all-features` passes only ever compile "everything" or "the
-# usual set", so a build that picks one transport goes unchecked. moq-native gates
-# most of its surface on which transports are compiled, and those `#[cfg]` lists
-# drifted apart until a websocket-only build stopped compiling entirely (#2773).
-#
-# One entry per transport, plus each crypto provider a QUIC backend can take,
-# because that's where the lists actually differ. `websocket,tcp,uds` is the
-# every-qmux-transport-and-no-QUIC-backend shape a relay-less client uses.
-#
-# The library only, not `--all-targets`: the integration tests under
-# `rs/moq-native/tests/` are written against the default feature set, so gating each
-# of them per transport would cost more than it catches. This answers "does the
-# crate build the way a consumer picked it", which is what broke.
-#
-# A build with no transport at all is not in the list and does not compile: the
-# `Request` machinery has no variants there, so its match arms have nothing to bind.
-# Such a build can neither dial nor accept, so it isn't worth the gating it would take.
-
-# Compile each supported transport feature combination on its own.
-features:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    for features in \
-    	websocket tcp uds iroh websocket,tcp,uds \
-    	quinn,aws-lc-rs quinn,ring noq,aws-lc-rs noq,ring quiche,aws-lc-rs
-    do
-    	echo "moq-native: $features"
-    	cargo clippy -p moq-native --no-default-features --features "$features" -- -D warnings
-    done
-
 # Full Rust CI: check + feature edge cases + tests + build. Takes a
 # newline-separated list of changed files; skips if FILES is non-empty
 # and none match the Rust scope. Run `just rs ci` (no FILES) to
@@ -276,9 +246,6 @@ ci $FILES="":
     # `--workspace` above still compiles moq-wasm for the host, where its crate
     # root cfgs away to nothing, so this wasm32 pass is what actually checks it.
     just rs wasm
-    # Neither pass above compiles moq-native with a single transport selected, which
-    # is the shape that silently broke in #2773.
-    just rs features
     # nextest compiles + runs the test binaries with real parallelism (faster than
     # `cargo test`'s serial harness). It does not build or run
     # doctests, so the `/// ```` examples are no longer compile-checked in CI -- an

--- a/rs/justfile
+++ b/rs/justfile
@@ -209,6 +209,36 @@ wasm-fix *args:
     cargo clippy --fix --allow-staged --allow-dirty -p moq-wasm --target wasm32-unknown-unknown --all-targets {{ args }}
     cargo fmt -p moq-wasm
 
+# The default and `--all-features` passes only ever compile "everything" or "the
+# usual set", so a build that picks one transport goes unchecked. moq-native gates
+# most of its surface on which transports are compiled, and those `#[cfg]` lists
+# drifted apart until a websocket-only build stopped compiling entirely (#2773).
+#
+# One entry per transport, plus each crypto provider a QUIC backend can take,
+# because that's where the lists actually differ. `websocket,tcp,uds` is the
+# every-qmux-transport-and-no-QUIC-backend shape a relay-less client uses.
+#
+# The library only, not `--all-targets`: the integration tests under
+# `rs/moq-native/tests/` are written against the default feature set, so gating each
+# of them per transport would cost more than it catches. This answers "does the
+# crate build the way a consumer picked it", which is what broke.
+#
+# A build with no transport at all is not in the list and does not compile: the
+# `Request` machinery has no variants there, so its match arms have nothing to bind.
+# Such a build can neither dial nor accept, so it isn't worth the gating it would take.
+
+# Compile each supported transport feature combination on its own.
+features:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for features in \
+    	websocket tcp uds iroh websocket,tcp,uds \
+    	quinn,aws-lc-rs quinn,ring noq,aws-lc-rs noq,ring quiche,aws-lc-rs
+    do
+    	echo "moq-native: $features"
+    	cargo clippy -p moq-native --no-default-features --features "$features" -- -D warnings
+    done
+
 # Full Rust CI: check + feature edge cases + tests + build. Takes a
 # newline-separated list of changed files; skips if FILES is non-empty
 # and none match the Rust scope. Run `just rs ci` (no FILES) to
@@ -246,6 +276,9 @@ ci $FILES="":
     # `--workspace` above still compiles moq-wasm for the host, where its crate
     # root cfgs away to nothing, so this wasm32 pass is what actually checks it.
     just rs wasm
+    # Neither pass above compiles moq-native with a single transport selected, which
+    # is the shape that silently broke in #2773.
+    just rs features
     # nextest compiles + runs the test binaries with real parallelism (faster than
     # `cargo test`'s serial harness). It does not build or run
     # doctests, so the `/// ```` examples are no longer compile-checked in CI -- an

--- a/rs/moq-native/src/bind.rs
+++ b/rs/moq-native/src/bind.rs
@@ -38,6 +38,7 @@ pub fn udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
 /// v6-only can't send to a mapped destination, and it looks identical from the
 /// outside: `local_addr` reads `[::]` either way. Always false for an IPv4
 /// socket, which reaches IPv4 natively rather than through mapping.
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 pub(crate) fn udp_is_dual_stack(socket: &UdpSocket) -> bool {
 	match socket.local_addr() {
 		Ok(addr) if addr.is_ipv6() => socket2::SockRef::from(socket).only_v6().is_ok_and(|only| !only),

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -251,10 +251,9 @@ impl Client {
 		config.quic.validate()?;
 		config.backoff.validate()?;
 
-		// Built even in a build that reads it nowhere (quiche keeps its own TLS stack,
-		// the plaintext qmux transports have none), so a bad `--client-tls-*` is
-		// rejected here rather than at the first dial.
-		#[allow(unused_variables)]
+		// Only the rustls-backed transports use this. Iroh, quiche, and the plaintext
+		// qmux transports must not require a rustls crypto provider.
+		#[cfg(any(feature = "noq", feature = "quinn", feature = "websocket"))]
 		let tls = config.tls.build()?;
 
 		#[cfg(feature = "noq")]
@@ -1085,6 +1084,17 @@ mod tests {
 		let config = ClientConfig::parse_from(["test"]);
 		assert_eq!(config.failover_delay, None);
 		assert_eq!(config.resolved_failover_delay(), std::time::Duration::from_millis(250));
+	}
+
+	/// Iroh carries no rustls state, so constructing its client must not require an
+	/// application-installed crypto provider.
+	#[cfg(all(
+		feature = "iroh",
+		not(any(feature = "noq", feature = "quinn", feature = "websocket"))
+	))]
+	#[test]
+	fn iroh_only_client_does_not_require_a_tls_provider() {
+		ClientConfig::default().init().expect("iroh-only client");
 	}
 
 	#[test]

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -1,10 +1,19 @@
 use crate::{Backoff, Error, QuicBackend, Reconnect};
-#[cfg(feature = "websocket")]
+#[cfg(all(feature = "websocket", any(feature = "noq", feature = "quinn", feature = "quiche")))]
 use std::future::Future;
 use std::net;
 use url::Url;
 
 const DEFAULT_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// How long to wait before also dialing the next resolved address, unless
+/// overridden by `--client-failover-delay`. RFC 8305's recommended Connection
+/// Attempt Delay.
+///
+/// Lives here rather than in [`crate::failover`], which is compiled only for the
+/// transports that dial an address themselves: the resolved default is config, so
+/// [`ClientConfig::resolved_failover_delay`] has to answer in every build.
+pub(crate) const DEFAULT_FAILOVER_DELAY: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// Configuration for the MoQ client.
 #[derive(Clone, Debug, clap::Parser, serde::Serialize, serde::Deserialize)]
@@ -131,7 +140,7 @@ impl ClientConfig {
 	/// it resolves to, so `ClientConfig::default().resolved_failover_delay()` is the
 	/// default itself.
 	pub fn resolved_failover_delay(&self) -> std::time::Duration {
-		self.failover_delay.unwrap_or(crate::failover::DEFAULT_DELAY)
+		self.failover_delay.unwrap_or(DEFAULT_FAILOVER_DELAY)
 	}
 
 	/// The deadline one connection attempt will actually get, dial and handshake
@@ -168,7 +177,16 @@ pub struct Client {
 	/// The single resolved set of protocol versions, used to advertise moq ALPNs across
 	/// every transport (passed into the QUIC backends' `connect` and used directly for
 	/// raw TCP/UDS qmux and WebSocket). Resolved once in [`Client::new`] so the ALPN list
-	/// can't diverge between transports.
+	/// can't diverge between transports. iroh is the exception: it negotiates over the
+	/// full `moq_net::ALPNS` rather than the configured subset, so it reads nothing here.
+	#[cfg(any(
+		feature = "noq",
+		feature = "quinn",
+		feature = "quiche",
+		feature = "websocket",
+		feature = "tcp",
+		feature = "uds"
+	))]
 	versions: moq_net::Versions,
 	/// The URL from [`ClientConfig::connect`], dialed by [`Client::publish`] / [`Client::consume`].
 	connect: Option<Url>,
@@ -181,6 +199,9 @@ pub struct Client {
 	failover_delay: std::time::Duration,
 	#[cfg(feature = "websocket")]
 	websocket: crate::websocket::Client,
+	/// Only the rustls-based dials read this. quiche builds its own TLS stack, and the
+	/// plaintext qmux transports have none.
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "websocket"))]
 	tls: rustls::ClientConfig,
 	#[cfg(feature = "noq")]
 	noq: Option<crate::noq::NoqClient>,
@@ -202,13 +223,14 @@ impl Client {
 		feature = "noq",
 		feature = "quinn",
 		feature = "quiche",
+		feature = "iroh",
 		feature = "websocket",
 		feature = "tcp",
 		feature = "uds"
 	)))]
 	pub fn new(_config: ClientConfig) -> crate::Result<Self> {
 		Err(Error::NoBackend(
-			"no QUIC or WebSocket backend compiled; enable noq, quinn, quiche, websocket, tcp, or uds feature",
+			"no backend compiled; enable noq, quinn, quiche, iroh, websocket, tcp, or uds feature",
 		))
 	}
 
@@ -217,6 +239,7 @@ impl Client {
 		feature = "noq",
 		feature = "quinn",
 		feature = "quiche",
+		feature = "iroh",
 		feature = "websocket",
 		feature = "tcp",
 		feature = "uds"
@@ -228,6 +251,10 @@ impl Client {
 		config.quic.validate()?;
 		config.backoff.validate()?;
 
+		// Built even in a build that reads it nowhere (quiche keeps its own TLS stack,
+		// the plaintext qmux transports have none), so a bad `--client-tls-*` is
+		// rejected here rather than at the first dial.
+		#[allow(unused_variables)]
 		let tls = config.tls.build()?;
 
 		#[cfg(feature = "noq")]
@@ -245,6 +272,7 @@ impl Client {
 		};
 
 		#[cfg(feature = "quiche")]
+		#[allow(unreachable_patterns)]
 		let quiche = match backend {
 			QuicBackend::Quiche => Some(crate::quiche::QuicheClient::new(&config)?),
 			_ => None,
@@ -258,6 +286,14 @@ impl Client {
 
 		Ok(Self {
 			moq: moq_net::Client::new().with_versions(versions.clone()),
+			#[cfg(any(
+				feature = "noq",
+				feature = "quinn",
+				feature = "quiche",
+				feature = "websocket",
+				feature = "tcp",
+				feature = "uds"
+			))]
 			versions,
 			connect: config.connect,
 			timeout,
@@ -266,6 +302,7 @@ impl Client {
 			failover_delay,
 			#[cfg(feature = "websocket")]
 			websocket: config.websocket,
+			#[cfg(any(feature = "noq", feature = "quinn", feature = "websocket"))]
 			tls,
 			#[cfg(feature = "noq")]
 			noq,
@@ -449,7 +486,9 @@ impl Client {
 	async fn connect_inner(&self, url: Url) -> crate::Result<(moq_net::Session, moq_net::Driver)> {
 		// Transports with no request URI of their own advertise the request target in the
 		// SETUP instead; `setup_path` returns `None` for the ones that carry a URI, where
-		// sending it again is a protocol violation.
+		// sending it again is a protocol violation. An iroh-only build reads none of this:
+		// that dial waits for the negotiated binding and builds its own.
+		#[allow(unused_variables)]
 		let moq = self.moq_with_path(setup_path(&url));
 
 		// Plain TCP (qmux, no TLS). Explicit opt-in scheme; never raced against
@@ -555,7 +594,10 @@ impl Client {
 	/// `moq` is the QUIC-side builder, which carries the SETUP path for a raw QUIC dial.
 	/// The WebSocket fallback uses the plain builder: qmux over WebSocket carries the
 	/// path in its request URI, so repeating it in the SETUP is a protocol violation.
-	#[cfg(feature = "websocket")]
+	///
+	/// Only compiled when there is a QUIC dial to race: a WebSocket-only build connects
+	/// over the fallback directly.
+	#[cfg(all(feature = "websocket", any(feature = "noq", feature = "quinn", feature = "quiche")))]
 	async fn race_moq_connect<Q, S>(
 		&self,
 		moq: &moq_net::Client,
@@ -642,14 +684,14 @@ fn setup_path(url: &Url) -> Option<String> {
 	}
 }
 
-#[cfg(feature = "websocket")]
+#[cfg(all(feature = "websocket", any(feature = "noq", feature = "quinn", feature = "quiche")))]
 #[derive(Debug, PartialEq, Eq)]
 enum TransportRace<Q, W> {
 	Quic(Q),
 	WebSocket(W),
 }
 
-#[cfg(feature = "websocket")]
+#[cfg(all(feature = "websocket", any(feature = "noq", feature = "quinn", feature = "quiche")))]
 async fn race_transport_connect<Q, W, QT, WT>(quic: Q, websocket: W) -> crate::Result<TransportRace<QT, WT>>
 where
 	Q: Future<Output = crate::Result<QT>>,
@@ -996,7 +1038,7 @@ mod tests {
 		assert_eq!(config.versions().alpns().len(), moq_net::ALPNS.len());
 	}
 
-	#[cfg(feature = "websocket")]
+	#[cfg(all(feature = "websocket", any(feature = "noq", feature = "quinn", feature = "quiche")))]
 	#[tokio::test]
 	async fn race_transport_connect_stops_on_quic_auth_error() {
 		let quic = async { Err::<usize, _>(crate::ConnectError::Unauthorized.into()) };
@@ -1010,7 +1052,7 @@ mod tests {
 		assert_eq!(err.connect_error(), Some(crate::ConnectError::Unauthorized));
 	}
 
-	#[cfg(feature = "websocket")]
+	#[cfg(all(feature = "websocket", any(feature = "noq", feature = "quinn", feature = "quiche")))]
 	#[tokio::test]
 	async fn race_transport_connect_keeps_websocket_after_quic_non_auth_error() {
 		let quic = async { Err::<usize, _>(Error::ConnectFailed) };
@@ -1020,7 +1062,7 @@ mod tests {
 		assert_eq!(value, super::TransportRace::WebSocket(7));
 	}
 
-	#[cfg(feature = "websocket")]
+	#[cfg(all(feature = "websocket", any(feature = "noq", feature = "quinn", feature = "quiche")))]
 	#[tokio::test]
 	async fn race_transport_connect_returns_when_quic_transport_connects() {
 		let quic = async { Ok("quic") };
@@ -1034,6 +1076,15 @@ mod tests {
 		.expect("race waited for WebSocket after QUIC transport connected")
 		.unwrap();
 		assert_eq!(value, super::TransportRace::Quic("quic"));
+	}
+
+	/// The resolved default has to exist in every build, including ones that compile
+	/// no address-racing transport at all, which is what broke in #2773.
+	#[test]
+	fn failover_delay_defaults_to_the_rfc_8305_stagger() {
+		let config = ClientConfig::parse_from(["test"]);
+		assert_eq!(config.failover_delay, None);
+		assert_eq!(config.resolved_failover_delay(), std::time::Duration::from_millis(250));
 	}
 
 	#[test]

--- a/rs/moq-native/src/connect.rs
+++ b/rs/moq-native/src/connect.rs
@@ -14,6 +14,9 @@ pub enum ConnectError {
 }
 
 impl ConnectError {
+	/// Only the transports that carry an HTTP status (WebTransport, WebSocket) can
+	/// classify one; qmux over tcp/unix has no such response.
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche", feature = "websocket"))]
 	pub(crate) fn from_status_u16(status: u16) -> Option<Self> {
 		match status {
 			401 => Some(Self::Unauthorized),
@@ -29,7 +32,10 @@ impl ConnectError {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(
+	test,
+	any(feature = "noq", feature = "quinn", feature = "quiche", feature = "websocket")
+))]
 mod tests {
 	use super::*;
 

--- a/rs/moq-native/src/failover.rs
+++ b/rs/moq-native/src/failover.rs
@@ -10,18 +10,16 @@
 //! a consumer sees is [`Failure`], which the backend `Error` types carry when
 //! the race loses every attempt.
 
-use std::collections::HashSet;
 use std::fmt;
 use std::future::Future;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::time::Duration;
 
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 
-/// How long to wait before also dialing the next address, unless overridden by
-/// `--client-failover-delay`. RFC 8305's recommended Connection Attempt Delay.
-pub(crate) const DEFAULT_DELAY: Duration = Duration::from_millis(250);
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
+pub(crate) use local::match_local;
 
 /// One failed connection attempt, naming the address it dialed.
 ///
@@ -92,74 +90,173 @@ pub(crate) fn interleave(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<Soc
 	out
 }
 
-/// [`interleave`], then adapt each address to the family of the `local` socket.
+/// Adapting candidates to the family of an already-bound local socket.
 ///
-/// The QUIC backends send from one already-bound socket, so a candidate the
-/// socket can't reach is converted when the conversion is lossless (IPv4 to
-/// IPv4-mapped IPv6 for a dual-stack socket, and the reverse) and dropped when
-/// it isn't. `dual_stack` is [`crate::bind::udp_is_dual_stack`] for that socket.
-/// When every candidate would be dropped, the normalized candidates are kept so
-/// the dial surfaces the OS error instead of a confusing "no DNS entries". See
-/// <https://github.com/moq-dev/moq/issues/1375> for the Windows failure this
-/// family matching originally fixed.
-pub(crate) fn match_local(
-	addrs: impl IntoIterator<Item = SocketAddr>,
-	local: SocketAddr,
-	dual_stack: bool,
-) -> Vec<SocketAddr> {
-	// Duplicates cost a wasted dial and a repeated line in the error, and they
-	// don't have to arrive adjacent: interleaving separates two copies of the same
-	// address with the other family, and normalizing collapses `1.2.3.4` and
-	// `::ffff:1.2.3.4` into one value only after that. So dedup by value rather
-	// than with `Vec::dedup`, keeping the first occurrence's position.
-	let mut seen = HashSet::new();
-	let candidates: Vec<SocketAddr> = interleave(addrs)
-		.into_iter()
-		.map(|addr| normalize_family(addr, local))
-		.filter(|addr| seen.insert(*addr))
-		.collect();
+/// Only the QUIC backends need this: they send every attempt from one socket
+/// bound up front, so a candidate that socket can't reach has to be converted or
+/// dropped. The stream transports open a fresh socket per attempt and let the OS
+/// pick the source, so nothing here applies to them.
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
+mod local {
+	use std::collections::HashSet;
+	use std::net::{IpAddr, SocketAddr};
 
-	let usable: Vec<SocketAddr> = candidates
-		.iter()
-		.copied()
-		.filter(|addr| addressable(*addr, local, dual_stack))
-		.collect();
+	/// [`super::interleave`], then adapt each address to the family of the `local` socket.
+	///
+	/// A candidate the socket can't reach is converted when the conversion is
+	/// lossless (IPv4 to IPv4-mapped IPv6 for a dual-stack socket, and the reverse)
+	/// and dropped when it isn't. `dual_stack` is [`crate::bind::udp_is_dual_stack`]
+	/// for that socket. When every candidate would be dropped, the normalized
+	/// candidates are kept so the dial surfaces the OS error instead of a confusing
+	/// "no DNS entries". See <https://github.com/moq-dev/moq/issues/1375> for the
+	/// Windows failure this family matching originally fixed.
+	pub(crate) fn match_local(
+		addrs: impl IntoIterator<Item = SocketAddr>,
+		local: SocketAddr,
+		dual_stack: bool,
+	) -> Vec<SocketAddr> {
+		// Duplicates cost a wasted dial and a repeated line in the error, and they
+		// don't have to arrive adjacent: interleaving separates two copies of the same
+		// address with the other family, and normalizing collapses `1.2.3.4` and
+		// `::ffff:1.2.3.4` into one value only after that. So dedup by value rather
+		// than with `Vec::dedup`, keeping the first occurrence's position.
+		let mut seen = HashSet::new();
+		let candidates: Vec<SocketAddr> = super::interleave(addrs)
+			.into_iter()
+			.map(|addr| normalize_family(addr, local))
+			.filter(|addr| seen.insert(*addr))
+			.collect();
 
-	if usable.is_empty() { candidates } else { usable }
-}
+		let usable: Vec<SocketAddr> = candidates
+			.iter()
+			.copied()
+			.filter(|addr| addressable(*addr, local, dual_stack))
+			.collect();
 
-/// Whether a socket bound to `local` can send to `dest`.
-///
-/// Mostly this is the address family, but reaching IPv4 from an IPv6 socket has
-/// a wrinkle: it means sending to an IPv4-mapped destination, which the kernel
-/// turns back into a real IPv4 packet, and that needs an IPv4 source address. So
-/// it takes both a socket that is actually dual-stack (`IPV6_V6ONLY` cleared,
-/// which [`crate::bind::udp`] only attempts) and a bind that left an IPv4 source
-/// to use: `[::]` does, since the kernel picks the source, and an IPv4-mapped
-/// bind already is one, but a concrete IPv6 bind is not. The mirror holds too:
-/// an IPv4-mapped bind can't reach a real IPv6 destination.
-fn addressable(dest: SocketAddr, local: SocketAddr, dual_stack: bool) -> bool {
-	let (SocketAddr::V6(dest), SocketAddr::V6(local)) = (dest, local) else {
-		return dest.is_ipv4() == local.is_ipv4();
-	};
-
-	match (dest.ip().to_ipv4_mapped(), local.ip().to_ipv4_mapped()) {
-		(Some(_), None) => dual_stack && local.ip().is_unspecified(),
-		(None, Some(_)) => false,
-		_ => true,
+		if usable.is_empty() { candidates } else { usable }
 	}
-}
 
-/// Convert `addr` to match the family of `local` when the conversion is
-/// lossless: unwrap IPv4-mapped IPv6 to IPv4, or wrap IPv4 as IPv4-mapped IPv6.
-fn normalize_family(addr: SocketAddr, local: SocketAddr) -> SocketAddr {
-	match (addr, local.is_ipv4()) {
-		(SocketAddr::V6(v6), true) => match v6.ip().to_ipv4_mapped() {
-			Some(v4) => SocketAddr::new(IpAddr::V4(v4), v6.port()),
-			None => addr,
-		},
-		(SocketAddr::V4(v4), false) => SocketAddr::new(IpAddr::V6(v4.ip().to_ipv6_mapped()), v4.port()),
-		_ => addr,
+	/// Whether a socket bound to `local` can send to `dest`.
+	///
+	/// Mostly this is the address family, but reaching IPv4 from an IPv6 socket has
+	/// a wrinkle: it means sending to an IPv4-mapped destination, which the kernel
+	/// turns back into a real IPv4 packet, and that needs an IPv4 source address. So
+	/// it takes both a socket that is actually dual-stack (`IPV6_V6ONLY` cleared,
+	/// which [`crate::bind::udp`] only attempts) and a bind that left an IPv4 source
+	/// to use: `[::]` does, since the kernel picks the source, and an IPv4-mapped
+	/// bind already is one, but a concrete IPv6 bind is not. The mirror holds too:
+	/// an IPv4-mapped bind can't reach a real IPv6 destination.
+	fn addressable(dest: SocketAddr, local: SocketAddr, dual_stack: bool) -> bool {
+		let (SocketAddr::V6(dest), SocketAddr::V6(local)) = (dest, local) else {
+			return dest.is_ipv4() == local.is_ipv4();
+		};
+
+		match (dest.ip().to_ipv4_mapped(), local.ip().to_ipv4_mapped()) {
+			(Some(_), None) => dual_stack && local.ip().is_unspecified(),
+			(None, Some(_)) => false,
+			_ => true,
+		}
+	}
+
+	/// Convert `addr` to match the family of `local` when the conversion is
+	/// lossless: unwrap IPv4-mapped IPv6 to IPv4, or wrap IPv4 as IPv4-mapped IPv6.
+	fn normalize_family(addr: SocketAddr, local: SocketAddr) -> SocketAddr {
+		match (addr, local.is_ipv4()) {
+			(SocketAddr::V6(v6), true) => match v6.ip().to_ipv4_mapped() {
+				Some(v4) => SocketAddr::new(IpAddr::V4(v4), v6.port()),
+				None => addr,
+			},
+			(SocketAddr::V4(v4), false) => SocketAddr::new(IpAddr::V6(v4.ip().to_ipv6_mapped()), v4.port()),
+			_ => addr,
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+
+		fn v4(s: &str) -> SocketAddr {
+			s.parse().unwrap()
+		}
+
+		#[test]
+		fn match_local_prefers_matching_family() {
+			let a4 = v4("127.0.0.1:443");
+			let a6 = v4("[::1]:443");
+
+			// IPv6 listed first, but local socket is IPv4: only IPv4 is usable.
+			assert_eq!(match_local([a6, a4], v4("0.0.0.0:0"), false), vec![a4]);
+			// IPv4 wraps to IPv4-mapped for an IPv6 (dual-stack) socket.
+			assert_eq!(
+				match_local([a4, a6], v4("[::]:0"), true),
+				vec![v4("[::ffff:127.0.0.1]:443"), a6]
+			);
+		}
+
+		#[test]
+		fn match_local_skips_mapped_ipv4_on_a_v6_only_socket() {
+			let a4 = v4("192.0.2.1:443");
+			let a6 = v4("[2001:db8::1]:443");
+			assert_eq!(match_local([a4, a6], v4("[::]:0"), false), vec![a6]);
+		}
+
+		#[test]
+		fn match_local_skips_ipv4_for_a_concrete_v6_bind() {
+			let a4 = v4("192.0.2.1:443");
+			let a6 = v4("[2001:db8::1]:443");
+			assert_eq!(match_local([a4, a6], v4("[2001:db8::5]:0"), true), vec![a6]);
+		}
+
+		#[test]
+		fn match_local_keeps_normalized_fallback_when_none_are_usable() {
+			let a4 = v4("192.0.2.1:443");
+			assert_eq!(
+				match_local([a4], v4("[::]:0"), false),
+				vec![v4("[::ffff:192.0.2.1]:443")]
+			);
+		}
+
+		#[test]
+		fn match_local_unwraps_v4_mapped_for_v4_socket() {
+			let mapped = v4("[::ffff:127.0.0.1]:443");
+			assert_eq!(match_local([mapped], v4("0.0.0.0:0"), false), vec![v4("127.0.0.1:443")]);
+		}
+
+		#[test]
+		fn match_local_falls_back_for_unmappable_v6() {
+			// IPv4 socket with only a true IPv6 entry: no conversion possible, keep it
+			// so the OS surfaces a clear error.
+			let a6 = v4("[2001:db8::1]:443");
+			assert_eq!(match_local([a6], v4("0.0.0.0:0"), false), vec![a6]);
+		}
+
+		#[test]
+		fn match_local_empty() {
+			assert!(match_local(std::iter::empty(), v4("0.0.0.0:0"), false).is_empty());
+		}
+
+		#[test]
+		fn match_local_dedups_across_the_interleave() {
+			// Two copies of the same IPv4 entry land either side of the IPv6 one, so
+			// only a value-wise dedup catches them.
+			let a4 = v4("1.2.3.4:443");
+			let a6 = v4("[2001:db8::1]:443");
+			assert_eq!(match_local([a4, a4, a6], v4("0.0.0.0:0"), false), vec![a4]);
+			assert_eq!(
+				match_local([a4, a4, a6], v4("[::]:0"), true),
+				vec![v4("[::ffff:1.2.3.4]:443"), a6]
+			);
+		}
+
+		#[test]
+		fn match_local_dedups_normalized_forms() {
+			// The same address twice, once already IPv4-mapped: different families
+			// going in, one candidate coming out.
+			let a4 = v4("1.2.3.4:443");
+			let mapped = v4("[::ffff:1.2.3.4]:443");
+			assert_eq!(match_local([a4, mapped], v4("[::]:0"), true), vec![mapped]);
+			assert_eq!(match_local([mapped, a4], v4("0.0.0.0:0"), false), vec![a4]);
+		}
 	}
 }
 
@@ -264,6 +361,7 @@ fn collapse<E: Aggregate>(mut failures: Vec<Failure<E>>) -> E {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::client::DEFAULT_FAILOVER_DELAY;
 	use std::sync::Arc;
 	use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -333,93 +431,18 @@ mod tests {
 		assert_eq!(interleave(addrs), addrs.to_vec());
 	}
 
-	#[test]
-	fn match_local_prefers_matching_family() {
-		let a4 = v4("127.0.0.1:443");
-		let a6 = v4("[::1]:443");
-
-		// IPv6 listed first, but local socket is IPv4: only IPv4 is usable.
-		assert_eq!(match_local([a6, a4], v4("0.0.0.0:0"), false), vec![a4]);
-		// IPv4 wraps to IPv4-mapped for an IPv6 (dual-stack) socket.
-		assert_eq!(
-			match_local([a4, a6], v4("[::]:0"), true),
-			vec![v4("[::ffff:127.0.0.1]:443"), a6]
-		);
-	}
-
-	#[test]
-	fn match_local_skips_mapped_ipv4_on_a_v6_only_socket() {
-		let a4 = v4("192.0.2.1:443");
-		let a6 = v4("[2001:db8::1]:443");
-		assert_eq!(match_local([a4, a6], v4("[::]:0"), false), vec![a6]);
-	}
-
-	#[test]
-	fn match_local_skips_ipv4_for_a_concrete_v6_bind() {
-		let a4 = v4("192.0.2.1:443");
-		let a6 = v4("[2001:db8::1]:443");
-		assert_eq!(match_local([a4, a6], v4("[2001:db8::5]:0"), true), vec![a6]);
-	}
-
-	#[test]
-	fn match_local_keeps_normalized_fallback_when_none_are_usable() {
-		let a4 = v4("192.0.2.1:443");
-		assert_eq!(
-			match_local([a4], v4("[::]:0"), false),
-			vec![v4("[::ffff:192.0.2.1]:443")]
-		);
-	}
-
-	#[test]
-	fn match_local_unwraps_v4_mapped_for_v4_socket() {
-		let mapped = v4("[::ffff:127.0.0.1]:443");
-		assert_eq!(match_local([mapped], v4("0.0.0.0:0"), false), vec![v4("127.0.0.1:443")]);
-	}
-
-	#[test]
-	fn match_local_falls_back_for_unmappable_v6() {
-		// IPv4 socket with only a true IPv6 entry: no conversion possible, keep it
-		// so the OS surfaces a clear error.
-		let a6 = v4("[2001:db8::1]:443");
-		assert_eq!(match_local([a6], v4("0.0.0.0:0"), false), vec![a6]);
-	}
-
-	#[test]
-	fn match_local_empty() {
-		assert!(match_local(std::iter::empty(), v4("0.0.0.0:0"), false).is_empty());
-	}
-
-	#[test]
-	fn match_local_dedups_across_the_interleave() {
-		// Two copies of the same IPv4 entry land either side of the IPv6 one, so
-		// only a value-wise dedup catches them.
-		let a4 = v4("1.2.3.4:443");
-		let a6 = v4("[2001:db8::1]:443");
-		assert_eq!(match_local([a4, a4, a6], v4("0.0.0.0:0"), false), vec![a4]);
-		assert_eq!(
-			match_local([a4, a4, a6], v4("[::]:0"), true),
-			vec![v4("[::ffff:1.2.3.4]:443"), a6]
-		);
-	}
-
-	#[test]
-	fn match_local_dedups_normalized_forms() {
-		// The same address twice, once already IPv4-mapped: different families
-		// going in, one candidate coming out.
-		let a4 = v4("1.2.3.4:443");
-		let mapped = v4("[::ffff:1.2.3.4]:443");
-		assert_eq!(match_local([a4, mapped], v4("[::]:0"), true), vec![mapped]);
-		assert_eq!(match_local([mapped, a4], v4("0.0.0.0:0"), false), vec![a4]);
-	}
-
 	#[tokio::test(start_paused = true)]
 	async fn first_success_returns_immediately() {
 		let dials = Arc::new(AtomicUsize::new(0));
 		let counter = dials.clone();
-		let res: Result<&str, TestError> = race(vec![v4("1.1.1.1:1"), v4("2.2.2.2:2")], DEFAULT_DELAY, move |_| {
-			counter.fetch_add(1, Ordering::SeqCst);
-			async { Ok("winner") }
-		})
+		let res: Result<&str, TestError> = race(
+			vec![v4("1.1.1.1:1"), v4("2.2.2.2:2")],
+			DEFAULT_FAILOVER_DELAY,
+			move |_| {
+				counter.fetch_add(1, Ordering::SeqCst);
+				async { Ok("winner") }
+			},
+		)
 		.await;
 		assert_eq!(res, Ok("winner"));
 		assert_eq!(dials.load(Ordering::SeqCst), 1, "no second dial after a fast success");
@@ -430,7 +453,7 @@ mod tests {
 		let start = tokio::time::Instant::now();
 		let res: Result<&str, TestError> = race(
 			vec![v4("1.1.1.1:1"), v4("2.2.2.2:2")],
-			DEFAULT_DELAY,
+			DEFAULT_FAILOVER_DELAY,
 			|addr| async move {
 				if addr == v4("1.1.1.1:1") {
 					std::future::pending().await
@@ -441,7 +464,11 @@ mod tests {
 		)
 		.await;
 		assert_eq!(res, Ok("second"));
-		assert_eq!(start.elapsed(), DEFAULT_DELAY, "second dial waits out the stagger");
+		assert_eq!(
+			start.elapsed(),
+			DEFAULT_FAILOVER_DELAY,
+			"second dial waits out the stagger"
+		);
 	}
 
 	#[tokio::test(start_paused = true)]
@@ -449,7 +476,7 @@ mod tests {
 		let start = tokio::time::Instant::now();
 		let res: Result<&str, TestError> = race(
 			vec![v4("1.1.1.1:1"), v4("2.2.2.2:2")],
-			DEFAULT_DELAY,
+			DEFAULT_FAILOVER_DELAY,
 			|addr| async move {
 				if addr == v4("1.1.1.1:1") {
 					Err(TestError::Dial("boom"))
@@ -522,7 +549,7 @@ mod tests {
 	/// produced (variant, source chain and all) instead of an aggregate of one.
 	#[tokio::test(start_paused = true)]
 	async fn a_lone_failure_is_returned_unwrapped() {
-		let res: Result<&str, TestError> = race(vec![v4("1.1.1.1:1")], DEFAULT_DELAY, |_| async {
+		let res: Result<&str, TestError> = race(vec![v4("1.1.1.1:1")], DEFAULT_FAILOVER_DELAY, |_| async {
 			Err(TestError::Dial("invalid peer certificate"))
 		})
 		.await;

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -35,6 +35,9 @@ pub mod tcp;
 pub mod tls;
 #[cfg(all(feature = "uds", unix))]
 pub mod unix;
+// Resolving a `host:port` bind string is a QUIC-listener concern; the stream
+// listeners take a `SocketAddr`/path straight from their config.
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 mod util;
 #[cfg(feature = "watch")]
 pub mod watch;
@@ -159,6 +162,11 @@ pub fn qlog_supported() -> bool {
 	cfg!(feature = "qlog")
 }
 
+/// The backend a config without an explicit `--*-backend` gets.
+///
+/// Only compiled when there is one to pick: a build with no QUIC backend never
+/// reaches for a default, since `QuicBackend` has no variants there.
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 fn default_quic_backend() -> QuicBackend {
 	#[cfg(feature = "quinn")]
 	{
@@ -172,8 +180,6 @@ fn default_quic_backend() -> QuicBackend {
 	{
 		QuicBackend::Quiche
 	}
-	#[cfg(all(not(feature = "quiche"), not(feature = "quinn"), not(feature = "noq")))]
-	panic!("no QUIC backend compiled; enable noq, quinn, or quiche feature");
 }
 
 #[cfg(test)]

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -356,6 +356,7 @@ impl Server {
 	}
 
 	/// The per-connection knobs with defaults applied, ready to hand to a backend.
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	pub(crate) fn resolve(&self) -> Resolved {
 		Resolved::new(
 			self.max_streams,
@@ -478,6 +479,8 @@ mod tests {
 		assert!(!quic.gso_disabled());
 	}
 
+	// `Server::resolve` only exists where a backend consumes it.
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	#[test]
 	fn zero_keep_alive_disables_it() {
 		let disabled = Server {

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -8,6 +8,15 @@ use crate::{Error, QuicBackend};
 use moq_net::Session;
 use url::Url;
 
+// Only the transports that finish their handshake in a spawned future need `.boxed()`;
+// the stream listeners hand back an already-built `Request`.
+#[cfg(any(
+	feature = "noq",
+	feature = "quinn",
+	feature = "quiche",
+	feature = "iroh",
+	feature = "websocket"
+))]
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
@@ -110,6 +119,7 @@ impl ServerConfig {
 }
 
 /// Default bind address used when [`ServerConfig::bind`] is not set.
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 pub(crate) const DEFAULT_BIND: &str = "[::]:443";
 
 /// Server for accepting MoQ connections.
@@ -141,6 +151,9 @@ impl Server {
 	/// The stream (`tcp`/`unix`) listeners bind lazily on the first
 	/// [`accept`](Self::accept), since they need a runtime.
 	pub fn new(config: ServerConfig) -> crate::Result<Self> {
+		// `default_quic_backend` panics when no backend is compiled, so a WebSocket- or
+		// stream-only build must not ask it.
+		#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 		let backend = config.backend.clone().unwrap_or_else(crate::default_quic_backend);
 
 		let versions = config.versions();
@@ -153,6 +166,9 @@ impl Server {
 		let build_quic = config.bind.is_some() || !config.has_stream_listener();
 
 		if build_quic && !config.tls.root.is_empty() {
+			// Only a QUIC backend validates client certificates; the qmux listeners
+			// (tcp/unix/websocket) carry no TLS of their own.
+			#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 			let mtls_supported = match backend {
 				#[cfg(feature = "quinn")]
 				QuicBackend::Quinn => true,
@@ -163,6 +179,9 @@ impl Server {
 				#[allow(unreachable_patterns)]
 				_ => false,
 			};
+			#[cfg(not(any(feature = "noq", feature = "quinn", feature = "quiche")))]
+			let mtls_supported = false;
+
 			if !mtls_supported {
 				return Err(Error::MtlsUnsupported);
 			}
@@ -329,6 +348,7 @@ impl Server {
 		feature = "quinn",
 		feature = "quiche",
 		feature = "iroh",
+		feature = "websocket",
 		feature = "tcp",
 		all(feature = "uds", unix)
 	)))]
@@ -336,7 +356,7 @@ impl Server {
 	///
 	/// Panics: no transport feature is compiled in, so nothing can be accepted.
 	pub async fn accept(&mut self) -> Option<Request> {
-		unreachable!("no transport compiled; enable a QUIC backend, tcp, or uds feature");
+		unreachable!("no transport compiled; enable a QUIC backend, websocket, tcp, or uds feature");
 	}
 
 	/// The accept-loop health of every listener this server owns that performs a real
@@ -397,6 +417,7 @@ impl Server {
 		feature = "quinn",
 		feature = "quiche",
 		feature = "iroh",
+		feature = "websocket",
 		feature = "tcp",
 		all(feature = "uds", unix)
 	))]
@@ -621,8 +642,8 @@ impl Server {
 		{
 			let _ = self.websocket.take();
 		}
-		#[cfg(not(any(feature = "noq", feature = "quinn", feature = "quiche", feature = "iroh")))]
-		unreachable!("no QUIC backend compiled");
+		// The stream (tcp/unix) listeners have nothing to close here: their accept
+		// loops own the sockets and are aborted when this `Server` drops.
 	}
 }
 

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -164,6 +164,12 @@ impl Server {
 		config.quic.validate()?;
 
 		let build_quic = config.bind.is_some() || !config.has_stream_listener();
+		#[cfg(not(any(feature = "noq", feature = "quinn", feature = "quiche")))]
+		if config.bind.is_some() {
+			return Err(Error::NoBackend(
+				"--server-bind requires a noq, quinn, or quiche backend feature",
+			));
+		}
 
 		if build_quic && !config.tls.root.is_empty() {
 			// Only a QUIC backend validates client certificates; the qmux listeners
@@ -619,6 +625,8 @@ impl Server {
 	///
 	/// [`accept`](Self::accept) calls this for you on Ctrl-C.
 	pub async fn close(&mut self) {
+		#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
+		self.streams.close().await;
 		#[cfg(feature = "noq")]
 		if let Some(noq) = self.noq.as_mut() {
 			noq.close();
@@ -642,8 +650,6 @@ impl Server {
 		{
 			let _ = self.websocket.take();
 		}
-		// The stream (tcp/unix) listeners have nothing to close here: their accept
-		// loops own the sockets and are aborted when this `Server` drops.
 	}
 }
 
@@ -696,8 +702,8 @@ impl StreamBind {
 ///
 /// Bound lazily on the first [`Server::accept`] (they need a runtime), after
 /// which each runs an accept loop in its own task and feeds completed [`Request`]s
-/// back over a channel. The tasks own their listeners and are aborted when the
-/// `Server` (and thus this) is dropped, so bound sockets don't linger.
+/// back over a channel. The tasks own their listeners and are stopped when the
+/// server closes or drops, so bound sockets don't linger.
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 struct StreamListeners {
 	binds: Vec<StreamBind>,
@@ -813,6 +819,17 @@ impl StreamListeners {
 		match self.rx.as_mut() {
 			Some(rx) => rx.recv().await,
 			None => std::future::pending().await,
+		}
+	}
+
+	/// Stop every accept loop and wait until its listener has released the socket.
+	async fn close(&mut self) {
+		self.binds.clear();
+		self.rx = None;
+		let tasks = std::mem::take(&mut self.tasks);
+		for task in tasks {
+			task.abort();
+			let _ = task.await;
 		}
 	}
 }
@@ -1232,6 +1249,40 @@ mod tests {
 		// Same error the second time, rather than a success over a listener that the
 		// first call already tore down.
 		assert!(server.listen().await.is_err(), "a retry must not report success");
+	}
+
+	/// Closing a retained server must release its TCP socket before returning and
+	/// must not let a later `listen` restart the terminal listener.
+	#[cfg(feature = "tcp")]
+	#[tokio::test]
+	async fn close_releases_stream_listener_socket() {
+		let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = probe.local_addr().unwrap();
+		drop(probe);
+
+		let mut config = ServerConfig::default();
+		config.tcp.bind = Some(addr);
+		let mut server = Server::new(config).expect("stream-only server");
+		server.listen().await.expect("listen");
+		assert!(tokio::net::TcpListener::bind(addr).await.is_err(), "listener is bound");
+
+		server.close().await;
+		server.listen().await.expect("closed listener stays terminal");
+		let _rebound = tokio::net::TcpListener::bind(addr)
+			.await
+			.expect("close must release the listener socket");
+	}
+
+	/// An explicit QUIC bind cannot be honored without a QUIC backend.
+	#[cfg(not(any(feature = "noq", feature = "quinn", feature = "quiche")))]
+	#[test]
+	fn quic_bind_without_a_quic_backend_is_rejected() {
+		let config = ServerConfig {
+			bind: Some("127.0.0.1:0".to_string()),
+			..Default::default()
+		};
+
+		assert!(matches!(Server::new(config), Err(Error::NoBackend(_))));
 	}
 
 	/// A QUIC-only server reports nothing. It multiplexes over one UDP socket and

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -435,6 +435,7 @@ impl Client {
 	/// plaintext fetch, and there is nothing to bootstrap when verification is
 	/// disabled. With CA roots (the default), `http://` is the deliberate
 	/// per-connection way to pin a self-signed relay, so it is allowed.
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	pub(crate) fn allows_http_bootstrap(&self) -> bool {
 		self.effective_fingerprint().is_empty() && !self.effective_disable_verify().unwrap_or_default()
 	}
@@ -754,9 +755,11 @@ impl PeerIdentity {
 }
 
 /// The certificates a server is currently serving.
+///
+/// Only a QUIC backend serves TLS of its own, so nothing else populates this.
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 #[derive(Debug, Default)]
 pub(crate) struct Info {
-	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	pub(crate) certs: Vec<Arc<rustls::sign::CertifiedKey>>,
 	pub(crate) fingerprints: Vec<String>,
 }

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -102,6 +102,9 @@ impl Default for Client {
 	}
 }
 
+/// The fallback arm of the QUIC-vs-WebSocket race, so only compiled when there is a
+/// QUIC dial to race against. A WebSocket-only build calls [`connect`] directly.
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 pub(crate) async fn race_handle(
 	config: &Client,
 	tls: &rustls::ClientConfig,


### PR DESCRIPTION
## Root cause

`ClientConfig::resolved_failover_delay` is unconditional but read `crate::failover::DEFAULT_DELAY`, and `mod failover` is gated on `any(quinn, noq, quiche, tcp)`. `websocket = ["dep:qmux"]` enables none of them, so `cargo check -p moq-native --no-default-features --features websocket,aws-lc-rs` failed to compile the crate at all.

The constant is a *config* default, not dial machinery, so it moves next to `DEFAULT_CONNECT_TIMEOUT` in `client.rs` (the first option in the issue). The resolver then answers in every build, and #2749's `resolved_resolution_delay` can do the same thing with no extra plumbing.

## What else the same drift had broken

Once it compiled, a QUIC-less build still didn't work. Each of these is the same `#[cfg]` list having drifted apart, and none is reachable from the default or `--all-features` build, which is why they sat there:

- **`Server::new` panicked.** It called `default_quic_backend()` unconditionally; with no backend compiled, `QuicBackend` is uninhabited and the function's only surviving arm was `panic!("no QUIC backend compiled")`. `ServerConfig::init()` aborted the process.
- **A WebSocket-only server could never accept.** `Server::accept`'s cfg list is `any(noq, quinn, quiche, iroh, tcp, uds)` and omits `websocket`, so a build with only `with_websocket` got the `unreachable!()` stub.
- **A stream-only server panicked on Ctrl-C.** `Server::close` ended in `#[cfg(not(any(noq, quinn, quiche, iroh)))] unreachable!("no QUIC backend compiled")`, and `accept` calls `close` on Ctrl-C. Closing now aborts and joins stream-listener tasks so their sockets are released before it returns.
- **An iroh-only build could not construct a `Client`.** `Client::new`'s cfg lists omitted `iroh` even though `Client::connect` handles `iroh://`. It also built unused rustls state, which could panic without an installed crypto provider.
- **A non-QUIC build silently ignored `--server-bind`.** It returned a server without binding the requested UDP address. Explicit QUIC binds now return `NoBackend` when no QUIC backend is compiled.

The remainder of the diff gates the helpers that genuinely go dead when a transport isn't compiled (`bind::udp_is_dual_stack`, `util::resolve`, `server::DEFAULT_BIND`, `tls::{Info, allows_http_bootstrap}`, `quic::Server::resolve`, `ConnectError::from_status_u16`, the QUIC-vs-WebSocket race), so every combination is clean under `-D warnings` rather than merely compiling. `failover`'s local-socket adaptation (`match_local` and friends) moves into a cfg-gated `mod local` with its tests, since it only exists for the backends that dial from one pre-bound UDP socket.

## Known remaining gap

A build with **no** transport at all (plain `--no-default-features`) still does not compile and remains unsupported. `RequestKind` has no variants there, so `Request`'s three delegating macros expand to empty matches (`E0004`/`E0282`) and their arguments read as unused. Making it work means either an `Infallible` placeholder variant plus `allow(unused_variables)` on five methods, or gating the whole `Request`/`accept` surface away and dropping the `pub async fn accept` stub from that build. Such a build can neither dial nor accept, so I left it rather than making that call unprompted.

## Test plan

- `cargo check -p moq-native --no-default-features --features websocket,aws-lc-rs` (the issue's command) now passes.
- `just fix` and `cargo nextest run -p moq-native --lib` (116 tests) pass.
- `cargo check --workspace --no-default-features`, `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-native --all-features`, and `cargo check -p libmoq -p moq-ffi` (which `just check` never compiles) all pass.
- `cargo nextest run -p moq-native --lib --no-default-features --features iroh` (54 tests) passes.
- Regression tests cover the failover default, Iroh-only construction without rustls setup, unsupported QUIC binds, and stream-socket release from `Server::close`.

## Cross-package sync

No wire change, no `moq-ffi` change, no public API change in the default build (`libmoq`'s `moq_client_get_failover_delay` still reads the same resolved value), so no `drafts/`, `js/`, or `doc/` row applies. The only behavior change outside a QUIC-less build is that `Client::new` is now compiled for an iroh-only build.

Fixes #2773

(written by Opus 5)