### PR TITLE
refactor(moq-mux)!: scope mp4-atom re-export to fmp4

### DIFF
--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -17,6 +17,10 @@ pub use fragmenter::*;
 pub use import::*;
 pub use muxer::*;
 
+/// Re-export of the [`mp4_atom`] crate, whose types appear in this module's public API.
+/// A major version bump of `mp4_atom` is a breaking change for moq-mux.
+pub use mp4_atom;
+
 #[cfg(test)]
 mod export_test;
 #[cfg(test)]

--- a/rs/moq-mux/src/lib.rs
+++ b/rs/moq-mux/src/lib.rs
@@ -36,8 +36,3 @@ pub use error::*;
 /// Re-export of [`moq_net::Latency`], the drift budget every consumer-side knob here takes.
 pub use moq_net::Latency;
 pub use source::Source;
-
-/// Re-export of the [`mp4_atom`] crate, whose types appear in the public CMAF
-/// surface ([`container::fmp4`]). A major version bump of `mp4_atom` is a
-/// breaking change for moq-mux.
-pub use mp4_atom;


### PR DESCRIPTION
## Summary

- Move the `mp4_atom` dependency re-export from the `moq-mux` crate root to the fMP4/CMAF module where its types appear in the public API.
- Keep the third-party dependency and its compatibility boundary scoped to `moq_mux::container::fmp4`.

## Public API changes

- **Breaking:** remove `moq_mux::mp4_atom`.
- Add the replacement path `moq_mux::container::fmp4::mp4_atom`.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command cargo nextest run -p moq-mux` (515 passed)
- Generated rustdoc confirms the re-export appears under `container::fmp4` and not at the crate root.

(Written by GPT-5)