### PR TITLE
build(nix): package the Go toolchain so `just go check` actually runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ To force a base, `just check origin/dev` and `just fix origin/dev` take it posit
 
 `MOQ_STRICT` is the one thing CI does differently. Every tool the checks use is guarded with `command -v` so an incomplete local toolchain checks less instead of failing; in CI that would be a green run that silently checked nothing, so the variable turns the required set into an up-front precondition (`_tools` in the root justfile). Required is per scope, mirroring what the diff actually dispatches, so a docs-only PR doesn't have to have gradle.
 
-Two tools stay unrequired: `swift` exists only on macOS (swift.yml is its gate), and **`go`/`uniffi-bindgen-go` are not in the dev shell**, so `just go check` skips itself in CI exactly as it always has. `uniffi-bindgen-go` isn't in nixpkgs (it installs from a NordSecurity git tag), so closing that hole means packaging it in the flake.
+One tool stays unrequired: `swift` exists only on macOS, so swift.yml is its gate rather than the PR path.
 
 Two gates live outside the PR path, in `.github/workflows/nightly.yml`: `just rs audit` (cargo-deny) because an advisory lands without this repo changing, and `just rs features` (the `--all-features` and `--no-default-features` compiles) because each is a full extra workspace compile that shares almost nothing with the default one. A break there lands on `main` rather than being caught in review, which is the accepted trade; anything that must block a merge belongs in `check`.
 

--- a/flake.nix
+++ b/flake.nix
@@ -274,6 +274,11 @@
 
           cargoHash = "sha256-ctDBz0oE8+mkn7SJn2KGSb6P4LF8S5UC3XcjVHWApg4=";
 
+          # The tag is a virtual workspace whose other members are uniffi test
+          # fixtures. Building from the root would compile all of them, and CI
+          # has no Nix binary cache, so it would pay for that on every run.
+          buildAndTestSubdir = "bindgen";
+
           # The upstream test suite generates fixtures and compiles them with a
           # Go toolchain, which is a lot of build for a binary we only invoke.
           doCheck = false;

--- a/flake.nix
+++ b/flake.nix
@@ -250,6 +250,43 @@
           gradle_8
         ];
 
+        # uniffi-bindgen-go renders rs/moq-ffi into the generated half of
+        # go/ffi. Not in nixpkgs, so build it from NordSecurity's fork; without
+        # it `just go check` skips itself, which reads as a pass in CI.
+        #
+        # The tag pairs the generator's own version with the uniffi release it
+        # targets (v0.7.1+v0.31.0 -> uniffi 0.31), and it only understands
+        # metadata emitted by that uniffi, so it moves with the `uniffi`
+        # dependency in rs/moq-ffi/Cargo.toml. Three other places name the same
+        # tag and must be bumped together: UNIFFI_BINDGEN_GO_TAG in
+        # release-go-ffi.yml, and the `cargo install` line in go/ffi/README.md
+        # and go/scripts/check.sh.
+        uniffi-bindgen-go = pkgs.rustPlatform.buildRustPackage rec {
+          pname = "uniffi-bindgen-go";
+          version = "0.7.1+v0.31.0";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "NordSecurity";
+            repo = "uniffi-bindgen-go";
+            rev = "v${version}";
+            hash = "sha256-ZoGxEWJKriGhe/nMpSbJF6pyyZQZLzdVervUrBzUM5k=";
+          };
+
+          cargoHash = "sha256-ctDBz0oE8+mkn7SJn2KGSb6P4LF8S5UC3XcjVHWApg4=";
+
+          # The upstream test suite generates fixtures and compiles them with a
+          # Go toolchain, which is a lot of build for a binary we only invoke.
+          doCheck = false;
+        };
+
+        # Go toolchain (go/) so `just go check` regenerates the bindings and
+        # runs `go test -race` on the wrapper instead of skipping. Cross-platform:
+        # the check builds moq-ffi for the host and runs on Linux and macOS.
+        goDeps = [
+          pkgs.go
+          uniffi-bindgen-go
+        ];
+
         # Dependencies for building the OBS plugin (`just obs build`).
         # Linux-only: nixpkgs marks obs-studio broken on Darwin, so macOS
         # and Windows fetch libobs/Qt6 via the OBS buildspec instead (see
@@ -323,6 +360,7 @@
             ++ lintDeps
             ++ obsDeps
             ++ ktDeps
+            ++ goDeps
             ++ devTools;
 
           # jemalloc's configure uses -O0 test builds, which conflict with

--- a/go/ffi/README.md
+++ b/go/ffi/README.md
@@ -22,13 +22,15 @@ The published module ships prebuilt `libmoq_ffi.a` for `linux/amd64`, `linux/arm
 
 `go/scripts/check.sh` builds `moq-ffi` for the host, runs `uniffi-bindgen-go` to regenerate `moq.go`, stages this module plus the wrapper into `dist/`, and runs `go build`/`go vet`/`go test`. Run via `just go check`. Skips cleanly without `cargo`, `go`, or `uniffi-bindgen-go`.
 
-Install `uniffi-bindgen-go` once:
+The dev shell provides both `go` and `uniffi-bindgen-go`, so `nix develop --command just go check` needs no setup. Without Nix, install `uniffi-bindgen-go` once:
 
 ```bash
 cargo install uniffi-bindgen-go \
     --git https://github.com/NordSecurity/uniffi-bindgen-go \
     --tag v0.7.1+v0.31.0
 ```
+
+The tag pins the generator to the `uniffi` version `rs/moq-ffi` depends on; `flake.nix` pins the same one.
 
 ## Layout
 

--- a/go/scripts/check.sh
+++ b/go/scripts/check.sh
@@ -95,13 +95,18 @@ if [[ -d "$STAGE_BINDINGS/uniffi/moq" && ! -d "$STAGE_BINDINGS/moq" ]]; then
 fi
 
 echo "go check: assembling ffi module..."
+# --skip-size-check because the lib above is a plain `cargo build --release`,
+# which is ~3x the size of the one the mirror actually publishes:
+# rs/moq-ffi/build.sh scopes thin LTO to the release path to keep this check
+# fast. Enforcing the publish limit here would fail on a lib nobody publishes.
 bash "$GO_DIR/scripts/package-ffi.sh" \
     --version "0.0.0-dev" \
     --source-dir "$GO_DIR/ffi" \
     --lib-dir "$STAGE_PARENT/go-libs" \
     --bindings-dir "$STAGE_BINDINGS" \
     --output "$STAGE_FFI" \
-    --no-archive
+    --no-archive \
+    --skip-size-check
 FFI_PKG="$STAGE_FFI/moq-ffi-0.0.0-dev-go"
 
 echo "go check: staging wrapper module..."

--- a/go/scripts/package-ffi.sh
+++ b/go/scripts/package-ffi.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 #
 # Optional:
 #   --source-dir DIR   in-tree ffi module skeleton (default: go/ffi)
+#   --skip-size-check  don't enforce GitHub's 100 MiB per-file push limit, for
+#                      callers staging libs that are never pushed to the mirror
 #
 # Expected $LIB_DIR layout (per cargo target):
 #   $LIB_DIR/x86_64-unknown-linux-gnu/libmoq_ffi.a
@@ -31,6 +33,7 @@ BINDINGS_DIR=""
 OUTPUT_DIR=""
 SOURCE_DIR=""
 ARCHIVE=true
+SIZE_CHECK=true
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -56,6 +59,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-archive)
             ARCHIVE=false
+            shift
+            ;;
+        --skip-size-check)
+            SIZE_CHECK=false
             shift
             ;;
         -h | --help)
@@ -171,7 +178,7 @@ if [[ "$STAGED_ANY" != true ]]; then
     exit 1
 fi
 
-if [[ "${#OVERSIZED[@]}" -gt 0 ]]; then
+if [[ "$SIZE_CHECK" == true && "${#OVERSIZED[@]}" -gt 0 ]]; then
     echo "Error: staged libs exceed GitHub's 100 MiB push limit:" >&2
     printf '  %s\n' "${OVERSIZED[@]}" >&2
     echo "The mirror push would be rejected (GH001). Shrink the staticlib in rs/moq-ffi/build.sh (LTO)." >&2

--- a/justfile
+++ b/justfile
@@ -107,12 +107,19 @@ _tools $FILES="":
     scoped '^(rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo)
     scoped '^(py/|pyproject\.toml$|uv\.lock$|rs/moq-ffi/)'     && tools+=(uv)
     scoped '^(kt/|rs/moq-ffi/)'                                && tools+=(gradle java)
-    scoped '^(go/|rs/moq-ffi/)'                                && tools+=(go uniffi-bindgen-go)
+    # cargo because `go check` builds moq-ffi for the host, and skips on a
+    # missing cargo the same way it skips on a missing go.
+    scoped '^(go/|rs/moq-ffi/)'                                && tools+=(go uniffi-bindgen-go cargo)
     # The OBS lints ship only in the Linux dev shell; nixpkgs marks obs-studio
     # broken on Darwin.
     if [[ "$(uname -s)" == "Linux" ]] && scoped '^cpp/obs/'; then
     	tools+=(clang-format gersemi)
     fi
+
+    # Scopes overlap (rs/moq-ffi/ is in four of them), so the same tool can land
+    # in the list twice and be reported missing twice. Splitting on whitespace is
+    # safe: every entry is a bare command name.
+    tools=($(printf '%s\n' "${tools[@]}" | sort -u))
 
     missing=()
     for tool in "${tools[@]}"; do

--- a/justfile
+++ b/justfile
@@ -90,13 +90,8 @@ _changed $BASE:
 # to invoke it. Takes the same file list as the dispatch, or `ALL` to require
 # everything (`check-all`).
 #
-# Two deliberate absences:
-#   - swift exists only on macOS, and `swift check` skips off-macOS by design;
-#     swift.yml is its real gate.
-#   - go and uniffi-bindgen-go are NOT in the dev shell (uniffi-bindgen-go isn't
-#     in nixpkgs; it installs from a NordSecurity git tag). Requiring them would
-#     fail every Go-scoped PR, so `just go check` still skips itself in CI, as it
-#     always has. Packaging them is what would close that hole.
+# One deliberate absence: swift exists only on macOS, and `swift check` skips
+# off-macOS by design; swift.yml is its real gate.
 
 # Fail when a tool the diff's scopes need is missing. No-op unless MOQ_STRICT.
 [private]
@@ -112,6 +107,7 @@ _tools $FILES="":
     scoped '^(rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo)
     scoped '^(py/|pyproject\.toml$|uv\.lock$|rs/moq-ffi/)'     && tools+=(uv)
     scoped '^(kt/|rs/moq-ffi/)'                                && tools+=(gradle java)
+    scoped '^(go/|rs/moq-ffi/)'                                && tools+=(go uniffi-bindgen-go)
     # The OBS lints ship only in the Linux dev shell; nixpkgs marks obs-studio
     # broken on Darwin.
     if [[ "$(uname -s)" == "Linux" ]] && scoped '^cpp/obs/'; then


### PR DESCRIPTION
## Summary

`just go check` had never run in CI. `go/scripts/check.sh` skips cleanly without `go`, `cargo`, or `uniffi-bindgen-go`, and the dev shell provided none of the Go half, so the job printed `go check: no go on PATH, skipping` and stayed green. On a developer Mac both binaries resolve from outside Nix (Homebrew, `~/.cargo/bin`), which is why the hole was invisible locally.

- `flake.nix`: added `goDeps` (nixpkgs `go`) plus a `rustPlatform.buildRustPackage` derivation for `uniffi-bindgen-go`, which isn't in nixpkgs. Built from NordSecurity's fork at `v0.7.1+v0.31.0` with a vendored `cargoHash`. `buildAndTestSubdir = "bindgen"` because the tag is a virtual workspace whose other members are uniffi test fixtures, and CI has no Nix binary cache, so building from the root would compile all of them on every run. `doCheck = false` because upstream's tests generate fixtures and compile them with a Go toolchain.
- The tag pairs the generator with the uniffi release it targets, so it moves with the `uniffi` dependency in `rs/moq-ffi`. Three other places name the same tag (`UNIFFI_BINDGEN_GO_TAG` in `release-go-ffi.yml`, and the `cargo install` lines in `go/ffi/README.md` and `go/scripts/check.sh`); the flake comment lists them so a bump can't leave one behind.
- `justfile`: `_tools` now requires `go`, `uniffi-bindgen-go`, and `cargo` under `scoped '^(go/|rs/moq-ffi/)'`. `cargo` is in there because `check.sh` skips on a missing cargo exactly like it skips on a missing go, so the strict preflight could pass and the check still report a green skip. (`kt` has no such hole: `kt/scripts/generate.sh` exits 1.) Scopes overlap, so the list is deduped rather than reporting a tool missing twice.
- `go/scripts/package-ffi.sh`: new `--skip-size-check`, passed by `check.sh`. Turning the check on exposed this immediately: `check.sh` builds moq-ffi with a plain `cargo build --release`, but `rs/moq-ffi/build.sh` scopes thin LTO to the release path (~110 MB to ~35 MB) precisely so this check stays fast. The dev staticlib is 122 MiB on Linux, and `package-ffi.sh` was applying its 100 MiB GitHub push guard to it. That guard protects the mirror push, which the check never performs. The release path still enforces it: `release-go-ffi.yml` does not pass the flag, and Publish dry-run passes.

Follows #2769, which added the `MOQ_STRICT` preflight and documented this hole as the one it couldn't fill. `CLAUDE.md` and `go/ffi/README.md` updated to match.

## Public API changes

None.

## Test plan

- CI `Check` on Linux now runs it for real: `go check: generating bindings...` -> `go vet` -> `go build` -> `go test -race` -> `ok github.com/moq-dev/moq-go/moq 1.024s`, instead of skipping.
- `nix develop --command bash -c 'command -v go uniffi-bindgen-go'` -> both resolve into `/nix/store` (go 1.26.5, uniffi-bindgen 0.7.1+v0.31.0).
- `MOQ_STRICT=1 just _tools` passes for a `go/`-scoped diff, an `rs/moq-ffi/`-scoped diff, `ALL`, and a docs-only diff. With `cargo` stripped from `PATH` a `go/` diff fails with `missing: cargo`; with `uniffi-bindgen-go` stripped it fails with `missing: uniffi-bindgen-go`. A path matching four scopes reports the tool once.
- `buildAndTestSubdir` verified to compile only `uniffi-bindgen-go (source/bindgen)`, with `cargoHash` unchanged and the installed binary still passing `just go check` end to end.
- The derivation evaluates on `x86_64-linux` and `aarch64-linux` as well as the `aarch64-darwin` it was built on; nothing in it is platform-specific.
- `nixfmt --check`, `just --fmt --check`, `shellcheck`, `shfmt`, `bun remark --frail` clean.

Cross-Package Sync: no rows apply. This touches build tooling only, no wire format, FFI surface, or CLI interface.

(written by Opus 5)