### PR TITLE
fix(net): keep a live-edge subscriber at the live edge across a takeover

### DIFF
--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -709,6 +709,10 @@ async fn read_payloads(sub: &mut moq_net::track::Subscriber, count: usize) -> Ve
 /// preferred route (shorter hop chain) serves the track; when that session dies,
 /// the same `track::Subscriber` keeps receiving groups from the standby session.
 /// No unannounce is observed and nothing is resubscribed by the application.
+///
+/// The subscription is live-edge (`group_start: None`), and that means the same
+/// thing on the standby as it did on the first route: tune in at the latest
+/// group. The standby's older cached groups are not replayed.
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_route_migration() {
@@ -752,6 +756,8 @@ async fn broadcast_route_migration() {
 		)
 		.expect("create broadcast");
 	let mut track_b = broadcast_b.create_track("video", None).expect("create track");
+	// A clone to keep producing from the test body once the task owns the rest.
+	let mut standby_track = track_b.clone();
 	// B carries the continuation of the same content: groups 2 and 3.
 	for sequence in 2..4u64 {
 		let mut group = track_b
@@ -818,7 +824,8 @@ async fn broadcast_route_migration() {
 	assert_eq!(path.as_str(), "test");
 	let broadcast = broadcast.expect("expected announce");
 
-	// Subscribe once; a generous stale window so cached groups are served.
+	// Subscribe once, with a generous stale window: even that must not turn the
+	// live-edge default into a backfill when the route changes.
 	let subscription = moq_net::track::Subscription::default().with_latency_max(Duration::from_secs(10));
 	let mut sub = broadcast
 		.track("video")
@@ -832,9 +839,21 @@ async fn broadcast_route_migration() {
 	assert_eq!(read_payloads(&mut sub, 1).await, ["a1"]);
 
 	// Kill the serving session. The track migrates to B and the same subscriber
-	// keeps reading, resuming exactly at the first group A never delivered.
+	// keeps reading, tuning in at B's latest group. B's group 2 sits below the
+	// splice boundary and behind the live edge, so it is never replayed.
 	drop(session_a);
-	assert_eq!(read_payloads(&mut sub, 2).await, ["b2", "b3"]);
+	assert_eq!(read_payloads(&mut sub, 1).await, ["b3"]);
+
+	// The migrated subscription is live: what B produces from here on flows
+	// through the same subscriber handle.
+	{
+		let mut group = standby_track
+			.create_group(moq_net::group::Info { sequence: 4 })
+			.expect("create group");
+		group.write_frame(Timestamp::ZERO, b"b4".as_ref()).expect("write frame");
+		group.finish().expect("finish group");
+	}
+	assert_eq!(read_payloads(&mut sub, 1).await, ["b4"]);
 
 	// The application observed no unannounce or re-announce across the swap.
 	assert!(

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1556,10 +1556,11 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 
 	/// Open the upstream SUBSCRIBE and start routing groups into the producer.
 	///
-	/// The subscription's bounds come straight from the demand aggregate: when this
-	/// segment resumes a track after a route change, the origin's slice already
-	/// carries the boundary as `group_start`, so the upstream delivers exactly the
-	/// missing range.
+	/// The subscription's bounds come straight from the demand aggregate. After a
+	/// route change a takeover boundary caps the *previous* segment's `end_group`;
+	/// the segment resuming the track keeps whatever start the subscribers asked for,
+	/// so a live-edge subscriber gets the live edge upstream rather than a replay of
+	/// the outage.
 	async fn establish(
 		&self,
 		producer: &mut track::Producer,

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -3840,12 +3840,13 @@ mod tests {
 		settle().await;
 		announced.assert_next_wait();
 
-		// The new copy resumes one past the spliced groups: its demand starts at
-		// the boundary, and groups the old source already delivered are filtered.
+		// The new copy keeps the subscriber's live-edge demand; the splice
+		// boundary bounds the range, so groups the old source already delivered
+		// are filtered rather than re-demanded.
 		let mut producer = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer.subscription().unwrap().group_start, None);
 		producer.create_group(group::Info { sequence: 1 }).unwrap();
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 2, "groups below the boundary are filtered");
@@ -3930,15 +3931,17 @@ mod tests {
 			let producer = producers_b
 				.get_mut(*name)
 				.unwrap_or_else(|| panic!("{name} was never re-dispatched to the standby"));
-			let boundary = producer
-				.subscription()
-				.unwrap_or_else(|| panic!("{name} resumed without a subscription"))
-				.group_start
-				.unwrap_or_else(|| panic!("{name} resumed without a boundary"));
+			// The live-edge demand survives the failover; each track's own
+			// boundary lives in its segment range, checked through the filter.
 			assert_eq!(
-				boundary, *groups,
-				"{name} resumed at another track's boundary instead of its own"
+				producer
+					.subscription()
+					.unwrap_or_else(|| panic!("{name} resumed without a subscription"))
+					.group_start,
+				None,
+				"{name} must keep the subscriber's live-edge demand"
 			);
+			let boundary = *groups;
 
 			// A group below the boundary is filtered out; one at it is delivered.
 			producer.create_group(group::Info { sequence: boundary - 1 }).unwrap();
@@ -4036,10 +4039,10 @@ mod tests {
 
 		let mut producer_b = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
-		// Demand registers as the subscriber polls; the new segment starts at the
-		// splice boundary.
+		// Demand registers as the subscriber polls; the splice boundary bounds
+		// the range while a live-edge subscriber's demand stays unbounded.
 		sub.assert_no_group();
-		assert_eq!(producer_b.subscription().unwrap().group_start, Some(1));
+		assert_eq!(producer_b.subscription().unwrap().group_start, None);
 		producer_b.create_group(group::Info { sequence: 1 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 1);
 		sub.assert_not_closed();
@@ -4218,11 +4221,12 @@ mod tests {
 		let mut producer_b = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
 
-		// The old copy's demand is capped at the boundary; the new copy's starts
-		// there. Both propagate as the subscriber polls.
+		// The old copy's demand is capped at the boundary; the new copy keeps
+		// the subscriber's live-edge demand. Both propagate as the subscriber
+		// polls.
 		sub.assert_no_group();
 		assert_eq!(producer_a.subscription().unwrap().group_end, Some(1));
-		assert_eq!(producer_b.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer_b.subscription().unwrap().group_start, None);
 
 		// The old copy racing past its cap is filtered; the new copy serves on.
 		producer_a.create_group(group::Info { sequence: 2 }).unwrap();
@@ -4486,13 +4490,13 @@ mod tests {
 		let again = consumer.request_broadcast("test").await.unwrap();
 		assert!(again.is_clone(&broadcast), "the reconnect must splice, not replace");
 
-		// The pending track re-splices from the new source and resumes one past
-		// the groups the old source already delivered. Demand registers as the
-		// subscriber polls.
+		// The pending track re-splices from the new source; the boundary keeps
+		// already-delivered groups filtered while the subscriber's live-edge
+		// demand survives the splice. Demand registers as the subscriber polls.
 		let mut producer = accept_track(&mut dynamic, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer.subscription().unwrap().group_start, None);
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 2);
 		sub.assert_not_closed();
@@ -5348,14 +5352,15 @@ mod tests {
 		assert_eq!(sub.assert_group().sequence, 0);
 
 		// The local standby joins with the same first hop and a cheaper route:
-		// it wins dispatch and the live track re-splices at the boundary.
+		// it wins dispatch and the live track re-splices at the boundary,
+		// keeping the subscriber's live-edge demand.
 		let source_local = origin.create_broadcast("test", announce().with_hops(local)).unwrap();
 		let mut dynamic_local = source_local.dynamic();
 		settle().await;
 		let mut producer_local = accept_track(&mut dynamic_local, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer_local.subscription().unwrap().group_start, Some(1));
+		assert_eq!(producer_local.subscription().unwrap().group_start, None);
 		producer_local.create_group(group::Info { sequence: 1 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 1);
 		sub.assert_not_closed();
@@ -5421,9 +5426,10 @@ mod tests {
 		settle().await;
 		let mut producer_local = producer_local.expect("the standby was never asked for video");
 
-		// Video re-splices onto the standby at the boundary.
+		// Video re-splices onto the standby at the boundary, keeping the
+		// subscriber's live-edge demand.
 		sub_video.assert_no_group();
-		assert_eq!(producer_local.subscription().unwrap().group_start, Some(1));
+		assert_eq!(producer_local.subscription().unwrap().group_start, None);
 		producer_local.create_group(group::Info { sequence: 1 }).unwrap();
 		assert_eq!(
 			sub_video.assert_group().sequence,

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -59,7 +59,10 @@ fn slice(prefs: &Subscription, start: Option<u64>, end: Option<u64>) -> Subscrip
 	sub.group_start = match (prefs.group_start, start) {
 		(Some(a), Some(b)) => Some(a.max(b)),
 		(Some(a), None) => Some(a),
-		(None, bound) => bound,
+		// No explicit start means the live edge. A takeover boundary is range
+		// bookkeeping, not a request: turning it into demand would replay the
+		// whole outage to a subscriber that asked for the latest group.
+		(None, _) => None,
 	};
 	sub.group_end = min_some(prefs.group_end, end);
 	sub
@@ -1789,6 +1792,35 @@ mod test {
 
 		// The replacement must inherit live-edge demand, not a full backfill.
 		assert_eq!(track_b.subscription().unwrap().group_start, None);
+	}
+
+	#[tokio::test]
+	async fn takeover_after_produced_segment_keeps_live_edge() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+		recv_pending(&mut sub);
+		assert_eq!(track_a.subscription().unwrap().group_start, None);
+
+		// A produced groups before its route died; B takes over.
+		write_group(&mut track_a, 0, "a0");
+		write_group(&mut track_a, 1, "a1");
+		assert_eq!(recv(&mut sub), 0);
+		assert_eq!(recv(&mut sub), 1);
+		drop(track_a);
+		producer.takeover(&consumer_b).unwrap();
+		recv_pending(&mut sub);
+
+		// The takeover boundary bounds the segment range, not the demand: a
+		// live-edge subscriber must not be turned into a backfill of the outage.
+		assert_eq!(track_b.subscription().unwrap().group_start, None);
+
+		// Groups at the live edge still arrive past the boundary.
+		write_group(&mut track_b, 5, "b5");
+		assert_eq!(recv(&mut sub), 5);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -59,10 +59,15 @@ fn slice(prefs: &Subscription, start: Option<u64>, end: Option<u64>) -> Subscrip
 	sub.group_start = match (prefs.group_start, start) {
 		(Some(a), Some(b)) => Some(a.max(b)),
 		(Some(a), None) => Some(a),
-		// No explicit start means the live edge. A takeover boundary is range
-		// bookkeeping, not a request: turning it into demand would replay the
-		// whole outage to a subscriber that asked for the latest group.
-		(None, _) => None,
+		// No start plus a zero latency budget means the live edge: the boundary
+		// is range bookkeeping. A latency window is the opt-in to backfill.
+		(None, bound) => {
+			if prefs.latency_max.is_zero() {
+				None
+			} else {
+				bound
+			}
+		}
 	};
 	sub.group_end = min_some(prefs.group_end, end);
 	sub
@@ -1821,6 +1826,28 @@ mod test {
 		// Groups at the live edge still arrive past the boundary.
 		write_group(&mut track_b, 5, "b5");
 		assert_eq!(recv(&mut sub), 5);
+	}
+
+	#[tokio::test]
+	async fn takeover_backfills_a_subscriber_with_a_latency_window() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer
+			.consume()
+			.subscribe(Subscription::default().with_latency_max(std::time::Duration::from_secs(10)));
+		recv_pending(&mut sub);
+
+		write_group(&mut track_a, 0, "a0");
+		assert_eq!(recv(&mut sub), 0);
+		drop(track_a);
+		producer.takeover(&consumer_b).unwrap();
+		recv_pending(&mut sub);
+
+		// A latency window opts into history: the demand resumes at the boundary.
+		assert_eq!(track_b.subscription().unwrap().group_start, Some(1));
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -8,9 +8,11 @@
 //! segments as if they were one track: bounds are enforced on the read side (a
 //! route delivering outside its range is silently filtered), a segment dying
 //! stalls the subscriber instead of erroring (the next [`Producer::switch`]
-//! resumes it), and demand is forwarded to each underlying track intersected with
-//! its segment bounds, so a session serving a segment just sees an ordinary
-//! subscription that happens to start or end at a boundary.
+//! resumes it), and demand is forwarded to each underlying track capped at its
+//! segment end, so a session serving a segment just sees an ordinary subscription
+//! that happens to end at a boundary. A boundary never becomes a *start*: it says
+//! which groups this segment owns, not which ones anyone wants, so a subscriber
+//! asking for the live edge still asks for it after a switch.
 
 use std::collections::BTreeMap;
 use std::task::{Poll, ready};
@@ -53,21 +55,21 @@ impl Segment {
 }
 
 /// The demand to register on an underlying track: the subscriber's own
-/// preferences intersected with a segment's bounds.
+/// preferences, capped at the segment's end.
+///
+/// The segment's start only raises a start the subscriber already asked for. It
+/// bounds what the subscriber *reads* (`poll_activate` puts it on the read
+/// cursor), so it never has to become demand to keep an earlier segment's groups
+/// out.
 fn slice(prefs: &Subscription, start: Option<u64>, end: Option<u64>) -> Subscription {
 	let mut sub = prefs.clone();
 	sub.group_start = match (prefs.group_start, start) {
 		(Some(a), Some(b)) => Some(a.max(b)),
 		(Some(a), None) => Some(a),
-		// No start plus a zero latency budget means the live edge: the boundary
-		// is range bookkeeping. A latency window is the opt-in to backfill.
-		(None, bound) => {
-			if prefs.latency_max.is_zero() {
-				None
-			} else {
-				bound
-			}
-		}
+		// No explicit start means the live edge. A takeover boundary is range
+		// bookkeeping, not a request: turning it into demand would replay the
+		// whole outage to a subscriber that asked for the latest group.
+		(None, _) => None,
 	};
 	sub.group_end = min_some(prefs.group_end, end);
 	sub
@@ -257,10 +259,10 @@ impl Producer {
 		}
 		let start = match state.latest() {
 			Some(latest) => latest.checked_add(1),
-			// No segment produced a group (or none exists): replace them outright
-			// and start unbounded, exactly like a first splice. A `Some(0)` boundary
-			// here would turn the subscriber's live-edge demand into a full backfill
-			// from group 0.
+			// No segment produced a group (or none exists): there is nothing to
+			// splice around, so replace them outright and start unbounded, exactly
+			// like a first splice. `switch` rejects a `None` start once a segment
+			// exists, hence the clear.
 			None => {
 				state.segments.clear();
 				None
@@ -1823,13 +1825,18 @@ mod test {
 		// live-edge subscriber must not be turned into a backfill of the outage.
 		assert_eq!(track_b.subscription().unwrap().group_start, None);
 
+		// Unbounded demand means B may serve below the boundary; the segment range
+		// still filters those out, so nothing is delivered twice.
+		write_group(&mut track_b, 1, "b1");
+		recv_pending(&mut sub);
+
 		// Groups at the live edge still arrive past the boundary.
 		write_group(&mut track_b, 5, "b5");
 		assert_eq!(recv(&mut sub), 5);
 	}
 
 	#[tokio::test]
-	async fn takeover_backfills_a_subscriber_with_a_latency_window() {
+	async fn takeover_keeps_an_explicit_start() {
 		let (mut track_a, consumer_a) = track_pair("a");
 		let (track_b, consumer_b) = track_pair("b");
 
@@ -1837,17 +1844,21 @@ mod test {
 		producer.takeover(&consumer_a).unwrap();
 		let mut sub = producer
 			.consume()
-			.subscribe(Subscription::default().with_latency_max(std::time::Duration::from_secs(10)));
+			.subscribe(Subscription::default().with_group_start(0));
 		recv_pending(&mut sub);
+		assert_eq!(track_a.subscription().unwrap().group_start, Some(0));
 
 		write_group(&mut track_a, 0, "a0");
+		write_group(&mut track_a, 1, "a1");
 		assert_eq!(recv(&mut sub), 0);
+		assert_eq!(recv(&mut sub), 1);
 		drop(track_a);
 		producer.takeover(&consumer_b).unwrap();
 		recv_pending(&mut sub);
 
-		// A latency window opts into history: the demand resumes at the boundary.
-		assert_eq!(track_b.subscription().unwrap().group_start, Some(1));
+		// A subscriber that asked for history keeps its gapless backfill: the
+		// boundary raises the explicit start to the first missing group.
+		assert_eq!(track_b.subscription().unwrap().group_start, Some(2));
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

- **Root cause**: `slice()` in `rs/moq-net/src/model/resume.rs` mapped `(prefs.group_start = None, segment.start = Some(n))` to `group_start = Some(n)`. A takeover boundary is range bookkeeping (which groups the new segment owns), but it was entering the demand aggregate as a *request*, so a subscriber that asked for the live edge came back from a route change asking the upstream for every group it missed. Measured: a ~5 s relay outage replayed ~5 s of stale groups, and the ~30 s moq-mux cache makes the worst case ~30 s.
- **Fix**: a takeover boundary never becomes a start. `(None, _) => None`. The range is still enforced, on the read side, where it always was: `poll_activate` puts the segment start on the read cursor, so a replacement route serving below the boundary is filtered rather than re-demanded.
- Subscribers with an explicit `group_start` are unaffected: theirs is still raised to the first missing group, so gapless catch-up stays available as the explicit opt-in it already was. `fetch_group` also still reaches the missed range.
- A live-edge subscription now means the same thing on every segment. That is what it already meant on the *first* one, which `broadcast_route_migration` has always asserted ("a live-edge subscription tunes in at the latest group").

## Public API changes

None. `slice` is private; no signature or exported item changed.

## Test plan

- `just check` and `just test` green (2438 passed).
- New `resume::test::takeover_after_produced_segment_keeps_live_edge`: fails on `main` with `Some(2)` vs `None`; also asserts a below-boundary group from the replacement is filtered.
- New `resume::test::takeover_keeps_an_explicit_start`: the other half of the contract, `Some(0)` raised to `Some(2)` across the takeover.
- `moq-native::broadcast::broadcast_route_migration` rewritten as the end-to-end regression: over a real session, the standby's stale cached group is no longer the first thing delivered after the migration (`["b2"]` before the fix, `["b3"]` after), and a group produced post-migration keeps flowing through the same subscriber handle.
- Origin route/failover/standby/reconnect tests now assert the live-edge demand and keep checking each track's boundary through the delivery filter.

## Cross-package sync

No wire format change (this only changes which `Start Group` we choose to send), so no draft update. `js/net` has no splice/resume model to mirror.

Fixes #2784

(written by Opus 5)
