### PR TITLE
feat: slide the media timeline over the publisher's cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4785,6 +4785,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "web-async",
  "webm-iterable",
 ]
 

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -454,15 +454,62 @@ A consumer derives the wall-clock time of any segment as `wall + pts`, and Unix 
 The epoch is 2020 rather than 1970 so the value stays small, safely within a 53-bit integer even at fine timescales.
 
 ## Track Framing {#timeline-framing}
-The timeline track is an append-log: a single group that is never rolled, with one record per frame, every record preserved in order.
-Each record is a UTF-8 JSON object.
+The timeline track is a sliding window: an ordered log that grows at the tail as segments become available and shrinks at the head as they stop being available, like an HLS media playlist.
 
-The frames are DEFLATE-compressed ({{!RFC1951}}) sharing a single compression window across the group, so each record compresses against all earlier ones.
+Every record has a **position**: the count of records ever appended before it.
+Positions never repeat, so a record is identified across group rolls and retractions, exactly like an HLS media sequence number.
+A position is carried on the wire only as the `offset` below; it is distinct from the record's own `segment` field, and a consumer MUST NOT assume the two coincide.
+
+Each group is self-contained.
+The first frame of every group is a snapshot of the window at that moment:
+
+~~~
+type TimelineSnapshot = {
+	"offset": number,
+	"values": [TimelineRecord],
+}
+~~~
+
+The `offset` field is the position of the first record in `values`, and `values` lists every record then in the window, oldest first.
+
+Each later frame in the group is exactly one operation:
+
+~~~
+type TimelineOperation =
+	{ "append": TimelineRecord } |
+	{ "trim": number }
+~~~
+
+An `append` adds one record at the tail, taking the next position.
+A `trim` removes `n` records from the head, where `n` is the value.
+A consumer MUST ignore an operation whose key it does not recognize, so later revisions can add operations without a version bump.
+A `trim` reaching past the oldest record in the window is a protocol error.
+
+A publisher SHOULD start a new group once the records trimmed since the group's snapshot outnumber those still in the window.
+That bounds the track's total bytes at roughly twice an append-only log while keeping every group independently readable.
+A publisher MUST NOT let a group grow without bound, since a consumer always reads a group from its first frame.
+
+A consumer SHOULD begin at the newest available group and MUST read that group from its first frame.
+Because each group opens with a full snapshot, a late joiner needs nothing older, and a publisher MAY drop earlier groups freely.
+Switching to a newer group mid-read is lossless: positions identify what the consumer already holds, so records are not repeated.
+
+The frames are DEFLATE-compressed ({{!RFC1951}}) sharing a single compression window across the group, so each frame compresses against the earlier ones.
 The publisher ends each frame's compressed data with an empty sync-flush block (the `0x00 0x00 0xff 0xff` trailer is removed, as in {{?RFC7692}}), so a consumer decompresses frames incrementally with one shared window.
 The `.z` suffix on the RECOMMENDED track name marks this compression, mirroring the catalog's `catalog.json.z` sibling.
 
-A consumer MUST start reading from the group's first frame; the shared window makes a mid-group join undecodable.
-The live group is therefore bounded history; deep history is served from a recording.
+## Availability {#timeline-availability}
+The timeline indexes what the publisher can still serve, not everything it has ever published.
+A publisher MUST retract a record once the media it names is no longer fetchable, and a consumer MUST NOT fetch a segment the timeline has retracted.
+
+A segment is fetched whole, so a record stays true only while every group it names is still cached.
+A publisher therefore retracts a record at the earliest expiry among those groups, which for moq-lite is each group's arrival plus its track's `Publisher Max Latency` [moql].
+Tracks with different retention need no further rule: the shortest-lived group bounds the record.
+
+A retraction leads the eviction it describes, because `Publisher Max Latency` is a floor rather than a deadline [moql]: the groups stay fetchable for a round trip after the record naming them is gone, so a consumer acting on the last record it saw does not lose the race.
+
+A trim only ever retracts records a consumer was told about.
+A consumer joining a window that has already trimmed receives no retraction for records it never held; a gap surfaces instead as a jump in the first appended record's position.
+Whether such a gap matters is the application's decision.
 
 ## Records {#timeline-records}
 Each record describes one complete segment:

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -503,7 +503,12 @@ An application MUST support gaps and out-of-order delivery even when `ordered` i
 ## Expiration
 Expiration governs when an older group is dropped.
 The publisher SHOULD reset Group Streams for non-latest groups whose age relative to the latest group exceeds `Subscriber Max Latency` (see [SUBSCRIBE](#subscribe)); the subscriber MAY also locally drop such groups.
-Expiration only removes the group from live delivery; the publisher MAY still retain it for FETCH or new subscriptions until its age exceeds `Publisher Max Latency` (see [TRACK_INFO](#track-info)).
+Expiration only removes the group from live delivery; the publisher retains it for FETCH or new subscriptions for at least `Publisher Max Latency` (see [TRACK_INFO](#track-info)).
+
+`Publisher Max Latency` is a floor, not a deadline: the publisher MUST keep the group fetchable until its age exceeds that value, and SHOULD keep it a further interval covering the expected round trip, one second being a reasonable default.
+Without the extra interval a subscriber that acts on a group at the edge of the window always loses the race, because its FETCH arrives a round trip after it decided to send it.
+The same margin is what lets an index built from `Publisher Max Latency` (such as a media timeline) retract an entry while the content behind it is still fetchable.
+A publisher under memory pressure MAY drop a group earlier.
 
 It is not crucial to aggressively expire groups thanks to [prioritization](#prioritization), but a lower priority group still consumes RAM, bandwidth, and potentially flow control.
 It is RECOMMENDED that an application set conservative limits and only resort to expiration when data is absolutely no longer needed.
@@ -1310,6 +1315,7 @@ The `Message Length` describes the payload size on the wire.
 # Appendix A: Changelog
 
 ## moq-lite-06
+- Specified `Publisher Max Latency` as a floor rather than a deadline: a publisher MUST keep a group fetchable until its age exceeds the value and SHOULD keep it a round trip longer, so a FETCH issued at the edge of the window still lands.
 - Moved the Qmux-over-WebSocket binding details to draft-lcurley-qmux-websocket; the binding itself is unchanged.
 - Extended the SETUP `Path` parameter to carry the URI query: a client appends `?` and the query component after the path, matching moq-transport's PATH option. The credential a deployment puts in the query was previously unrepresentable on a binding with no request URI.
 - Allowed an empty SETUP `Path` parameter, equivalent to omitting it; both request the server's default path. Previously an empty value was a protocol violation, which made the two ways of asking for the default disagree.

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, setSystemTime, test } from "bun:test";
 import * as Json from "@moq/json";
 import type { Time } from "@moq/net";
 import { Track } from "@moq/net";
@@ -13,25 +13,38 @@ function capture(props?: ConstructorParameters<typeof Producer>[1]): {
 	records: () => Promise<Record[]>;
 } {
 	const track = new Track.Producer("timeline.z");
-	const consumer = new Json.Stream.Consumer<Record>(track.subscribe(), { compression: true });
+	const consumer = new Json.Window.Consumer<Record>(track.subscribe(), { compression: true });
 	const timeline = new Producer(track, props);
 
+	// The records a fresh reader ends up holding: appends minus whatever was retracted, which
+	// for a sliding window is what the publisher can still serve rather than everything it sent.
 	const records = async () => {
-		const out: Record[] = [];
+		const live: { position: number; value: Record }[] = [];
 		for (;;) {
-			const record = await consumer.next();
-			if (!record) return out;
-			out.push(record);
+			const update = await consumer.next();
+			if (!update) return live.map((entry) => entry.value);
+			if (update.type === "append") {
+				live.push({ position: update.position, value: update.value });
+			} else {
+				while (live.length > 0 && live[0].position < update.offset) live.shift();
+			}
 		}
 	};
 	return { timeline, records };
 }
 
+/** Enroll a media track by name, at the given retention (the `@moq/net` default when omitted). */
+function enroll(timeline: Producer, name: string, latencyMax?: number) {
+	const track = new Track.Producer(name);
+	track.accept(latencyMax === undefined ? {} : { latencyMax });
+	return timeline.track(track);
+}
+
 // The coarsest track paces: video GOPs are longer than durationMin, so segments are GOPs.
 test("the coarsest track paces the segments", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = enroll(timeline, "video0");
+	const audio = enroll(timeline, "audio0");
 
 	// Video keyframes every 2s, audio groups every 500ms, minimum 1s.
 	video.record(0, us(0));
@@ -85,7 +98,7 @@ test("the coarsest track paces the segments", async () => {
 // a segment could start and stay decodable, so the segment is simply long.
 test("a GOP longer than the minimum is one segment", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = enroll(timeline, "video0");
 
 	video.record(0, us(0));
 	video.record(1, us(30_000));
@@ -102,7 +115,7 @@ test("a GOP longer than the minimum is one segment", async () => {
 // Groups shorter than the minimum pack into one segment rather than each becoming one.
 test("short groups pack up to the minimum", async () => {
 	const { timeline, records } = capture({ durationMin: 1500 });
-	const audio = timeline.track("audio0");
+	const audio = enroll(timeline, "audio0");
 
 	for (let seq = 0; seq < 8; seq++) {
 		audio.record(seq, us(seq * 500));
@@ -120,8 +133,8 @@ test("short groups pack up to the minimum", async () => {
 // a rendition that was about to contribute to it.
 test("a segment waits for every track", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = enroll(timeline, "video0");
+	const audio = enroll(timeline, "audio0");
 
 	video.record(0, us(0));
 	audio.record(0, us(0));
@@ -144,7 +157,7 @@ test("a segment waits for every track", async () => {
 // An application that knows its own boundaries overrides the pacing.
 test("explicit cuts override the pacing", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = enroll(timeline, "video0");
 
 	// Keyframes every second, cut every three: the segments follow the cuts, not the GOPs.
 	timeline.cut(us(3000));
@@ -164,7 +177,7 @@ test("explicit cuts override the pacing", async () => {
 // segment shorter than the minimum is dropped rather than producing a stray segment.
 test("a cut below the minimum is ignored", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = enroll(timeline, "video0");
 
 	video.record(0, us(0));
 	timeline.cut(us(2000));
@@ -188,7 +201,7 @@ test("a cut below the minimum is ignored", async () => {
 // the catalog.
 test("exceeding the declared maximum fails the timeline", async () => {
 	const { timeline, records } = capture({ durationMin: 1000, durationMax: 3000 });
-	const video = timeline.track("video0");
+	const video = enroll(timeline, "video0");
 
 	video.record(0, us(0));
 	video.record(1, us(2000));
@@ -214,7 +227,7 @@ test("an undeclared maximum is omitted from the catalog", () => {
 // final segment's duration collapses to zero (an HLS EXTINF:0).
 test("the final segment runs to the reported end", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = enroll(timeline, "video0");
 
 	video.record(0, us(0));
 	video.record(1, us(2000));
@@ -236,7 +249,7 @@ test("a reservation defers flushing until every track enrolls", async () => {
 	const release = timeline.reserve();
 
 	// The primary rendition runs a whole batch of segments through before its sibling exists.
-	const first = timeline.track("video0");
+	const first = enroll(timeline, "video0");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -245,7 +258,7 @@ test("a reservation defers flushing until every track enrolls", async () => {
 		first.record(seq, us(ms));
 	}
 
-	const second = timeline.track("video1");
+	const second = enroll(timeline, "video1");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -280,8 +293,8 @@ test("a reservation defers flushing until every track enrolls", async () => {
 // A track that races ahead of the others still lands in the segment its content falls in.
 test("groups before the first boundary join the first segment", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = enroll(timeline, "video0");
+	const audio = enroll(timeline, "audio0");
 
 	audio.record(0, us(0));
 	video.record(0, us(30));
@@ -311,8 +324,8 @@ test("groups before the first boundary join the first segment", async () => {
 
 test("sequence gaps split ranges", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = enroll(timeline, "video0");
+	const audio = enroll(timeline, "audio0");
 
 	// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
 	video.record(0, us(0));
@@ -345,8 +358,8 @@ test("sequence gaps split ranges", async () => {
 // has merely gone quiet still gets to say where the boundary is.
 test("a closed track leaves a whole segment gap", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = enroll(timeline, "video0");
+	const audio = enroll(timeline, "audio0");
 
 	video.record(0, us(0));
 	audio.record(0, us(0));
@@ -362,7 +375,7 @@ test("a closed track leaves a whole segment gap", async () => {
 
 test("a non-keyframe range start is flagged", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = enroll(timeline, "video0");
 
 	video.record(0, us(0));
 	// A mid-stream join: the group doesn't open on an IDR.
@@ -395,7 +408,7 @@ test("reservations nest", async () => {
 	const outer = timeline.reserve();
 	const inner = timeline.reserve();
 
-	const first = timeline.track("video0");
+	const first = enroll(timeline, "video0");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -407,7 +420,7 @@ test("reservations nest", async () => {
 	// If reservations didn't nest, releasing this one would publish segment 0 without video1.
 	inner();
 
-	const second = timeline.track("video1");
+	const second = enroll(timeline, "video1");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -441,7 +454,7 @@ test("reservations nest", async () => {
 // spent cut must not block the ones behind it, and durationMin pacing must not race ahead of them.
 test("a cut on the first group does not poison later cuts", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = enroll(timeline, "video0");
 
 	// Source segments every 3s, keyframes every 1s: 3s segments, not the 1s the durationMin
 	// pacing would produce on its own.
@@ -457,4 +470,67 @@ test("a cut on the first group does not poison later cuts", async () => {
 	const out = await records();
 	expect(out[0]).toEqual({ segment: 0, pts: 0, duration: 3000, tracks: { video0: [{ start: 0, end: 2 }] } });
 	expect(out[1]).toEqual({ segment: 1, pts: 3000, duration: 3000, tracks: { video0: [{ start: 3, end: 5 }] } });
+});
+
+// The timeline lists what the publisher can still serve, so a record goes when the groups behind
+// it age out of the cache. A late joiner therefore gets the live window, not the whole broadcast.
+test("a record is retracted once its groups expire", async () => {
+	const start = Date.now();
+	setSystemTime(start);
+	try {
+		const { timeline, records } = capture();
+		const video = enroll(timeline, "video0", 10_000);
+
+		// Four 2s groups, published a group apart in wall-clock time too.
+		for (let seq = 0; seq < 4; seq++) {
+			video.record(seq, us(seq * 2000));
+			setSystemTime(start + (seq + 1) * 2000);
+		}
+
+		// Past the first two groups' windows but inside the third's. The next report is what
+		// sweeps, matching the track cache, which only prunes as groups are written.
+		setSystemTime(start + 13_000);
+		video.record(4, us(8000));
+		video.close();
+		timeline.finish();
+
+		// Segments 0 and 1 are gone; 4 is the tail `finish` flushes for the last open group.
+		const out = await records();
+		expect(out.map((record) => record.segment)).toEqual([2, 3, 4]);
+	} finally {
+		setSystemTime();
+	}
+});
+
+// A segment spans every track, so it is only fetchable while all of them still hold their groups:
+// the shortest window bounds the record, without the timeline needing a rule for it.
+test("the shortest retention bounds the record", async () => {
+	const start = Date.now();
+	setSystemTime(start);
+	try {
+		const { timeline, records } = capture();
+		const video = enroll(timeline, "video0", 60_000);
+		const audio = enroll(timeline, "audio0", 5000);
+
+		for (let seq = 0; seq < 3; seq++) {
+			video.record(seq, us(seq * 2000));
+			audio.record(seq, us(seq * 2000));
+			setSystemTime(start + (seq + 1) * 2000);
+		}
+
+		// Past audio's 5s window for the first two segments, but inside it for the third, and far
+		// inside video's 60s one throughout.
+		setSystemTime(start + 8000);
+		video.record(3, us(6000));
+		audio.record(3, us(6000));
+		video.close();
+		audio.close();
+		timeline.finish();
+
+		// The segments went with audio's groups even though video still holds its own.
+		const out = await records();
+		expect(out[0]?.segment).toBe(2);
+	} finally {
+		setSystemTime();
+	}
 });

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -12,12 +12,24 @@
  * track has reported past its end (or closed), so records are self-contained and immediately
  * servable.
  *
+ * The timeline *slides*: it indexes what the publisher can still serve, not everything it ever
+ * published. A record is retracted once the groups behind it reach their track's `latencyMax`,
+ * which is why {@link Producer.track} takes the track itself. Reading the window from the same
+ * place the track declares it leaves nothing for a caller to duplicate and get wrong. A segment
+ * covers every enrolled track, so the earliest deadline among the groups it names bounds it, and
+ * tracks with different retention need no special rule.
+ *
+ * The retraction *leads* the eviction it predicts: `@moq/net` keeps a group for `latencyMax` plus
+ * a grace period, so a consumer that acts on the last record it saw still finds the media when
+ * its fetch lands a round trip later. Both sweeps run as content is written, so a publisher that
+ * stalls stops trimming and stops evicting together, with no timer on either side.
+ *
  * @module
  */
 
 import * as Json from "@moq/json";
 import type * as Moq from "@moq/net";
-import type { Time } from "@moq/net";
+import { type Time, Track } from "@moq/net";
 import type * as Catalog from "../catalog";
 import { MOQ_EPOCH_UNIX_MILLIS, u53 } from "../catalog";
 
@@ -108,25 +120,32 @@ export interface ProducerProps {
 
 /** One enrolled track's report state. */
 interface TrackState {
-	// Group opens reported and not yet flushed into a record.
-	pending: { sequence: number; pts: Time.Micro; keyframe: boolean }[];
+	// Group opens reported and not yet flushed into a record. `reported` is when the report
+	// arrived, i.e. when the publisher created the group: the clock its cache lifetime runs on,
+	// and therefore the clock its record's does too.
+	pending: { sequence: number; pts: Time.Micro; keyframe: boolean; reported: number }[];
 	// The newest reported timestamp: everything earlier is known. Advanced by a group open (the
 	// group starts there) and by Recorder.end (the content stops there).
 	frontier?: Time.Micro;
 	closed: boolean;
+	// How long this track's publisher guarantees to keep a group cached, read at enrollment.
+	latencyMax: number;
 }
 
 /**
  * Publishes the broadcast's timeline track: one JSON record per complete segment,
- * DEFLATE-compressed (a `@moq/json` stream), plus the shared boundary list every media track's
- * groups map onto.
+ * DEFLATE-compressed (a `@moq/json` sliding window), plus the shared boundary list every media
+ * track's groups map onto.
  *
  * One per broadcast. Media tracks enroll with {@link track} and report group opens through the
  * returned {@link Recorder}; an application with its own boundaries overrides the pacing with
  * {@link cut}. Advertise it in the catalog's root `timeline` section via {@link section}.
  */
 export class Producer {
-	#stream: Json.Stream.Producer<Record>;
+	#window: Json.Window.Producer<Record>;
+	// When each record still in the window stops being fetchable, oldest first. One entry per
+	// record the window holds, so #sweep can trim the head without decoding anything.
+	#expiry: number[] = [];
 	#trackName: string;
 	#durationMinUs: number;
 	#durationMaxUs?: number;
@@ -157,21 +176,32 @@ export class Producer {
 			const unixMillis = Math.max(props.wall.getTime(), MOQ_EPOCH_UNIX_MILLIS);
 			this.#wall = Math.floor(((unixMillis - MOQ_EPOCH_UNIX_MILLIS) * DEFAULT_TIMESCALE) / 1000);
 		}
-		this.#stream = new Json.Stream.Producer<Record>(track, { compression: true });
+		this.#window = new Json.Window.Producer<Record>(track, { compression: true });
 	}
 
 	/**
-	 * Enroll the media track `name`, returning the {@link Recorder} it reports through.
+	 * Enroll `track`, returning the {@link Recorder} its group opens are reported through.
 	 *
-	 * The segment records key ranges by this name, and the track paces boundaries and gates
-	 * completeness until its recorder closes. Enroll a track when it is about to produce: an
-	 * enrolled but silent track holds every record back, by design, since a segment isn't
+	 * The segment records key ranges by the track's name, and the track paces boundaries and
+	 * gates completeness until its recorder closes. Enroll a track when it is about to produce:
+	 * an enrolled but silent track holds every record back, by design, since a segment isn't
 	 * complete until every track's content is known. One recorder per track: enrolling the same
 	 * name again resets its state.
+	 *
+	 * Takes the whole track rather than its name so the timeline reads its `latencyMax` from the
+	 * same place, which is how long a record about it stays true. Passing a name could name a
+	 * track whose window is something else entirely, and the timeline would advertise segments
+	 * nobody can fetch. Accept the track first: an unaccepted one has no declared window yet, so
+	 * it falls back to the default.
 	 */
-	track(name: string): Recorder {
-		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false });
-		return new Recorder(this, name);
+	track(track: Moq.Track.Producer): Recorder {
+		this.#tracks.set(track.name, {
+			pending: [],
+			frontier: undefined,
+			closed: false,
+			latencyMax: track.accepted?.latencyMax ?? Track.DEFAULT_LATENCY_MAX_MS,
+		});
+		return new Recorder(this, track.name);
 	}
 
 	/**
@@ -264,14 +294,14 @@ export class Producer {
 			}
 		}
 
-		this.#stream.finish();
+		this.#window.finish();
 	}
 
 	/** @internal A group open reported by a {@link Recorder}. */
 	report(name: string, sequence: number, pts: Time.Micro, keyframe: boolean): void {
 		const track = this.#tracks.get(name);
 		if (!track) return;
-		track.pending.push({ sequence, pts, keyframe });
+		track.pending.push({ sequence, pts, keyframe, reported: Date.now() });
 		this.#advance(track, pts);
 	}
 
@@ -306,6 +336,10 @@ export class Producer {
 	// will report again, so one that never reached a boundary stops voting instead of holding
 	// the timeline open forever.
 	#pump(finished: boolean): void {
+		// Retract before publishing: a reservation withholds records that don't exist yet, it
+		// doesn't resurrect ones whose content is gone.
+		this.#sweep();
+
 		if (this.#tracks.size === 0 || this.#reservers > 0 || this.#overrun) return;
 		while (this.#closeSegment(finished)) {
 			if (this.#overrun) break;
@@ -404,13 +438,19 @@ export class Producer {
 				);
 				// End the track rather than drop it: the records published before the promise
 				// broke are still true, and a consumer that has them should keep them.
-				this.#stream.finish();
+				this.#window.finish();
 				return;
 			}
 		}
 
 		const record: Record = { segment: this.#nextSegment, pts, duration };
 		this.#nextSegment += 1;
+
+		// When this record stops being true. A consumer fetches a segment whole, so the first
+		// group to leave its publisher's cache breaks the segment as thoroughly as any other: the
+		// deadline is the earliest across every group the record names, which is what makes tracks
+		// with different retention fall out rather than need a rule.
+		let expiry: number | undefined;
 
 		const tracks: { [track: string]: Range[] } = {};
 		let any = false;
@@ -420,6 +460,10 @@ export class Producer {
 				const group = track.pending[0];
 				if (end !== undefined && group.pts >= end) break;
 				track.pending.shift();
+
+				const deadline = group.reported + track.latencyMax;
+				expiry = expiry === undefined ? deadline : Math.min(expiry, deadline);
+
 				const last = ranges.at(-1);
 				// Contiguous sequences extend the run; a skip starts a new range (a gap: groups
 				// that never existed).
@@ -438,7 +482,32 @@ export class Producer {
 		}
 		if (any) record.tracks = tracks;
 
-		this.#stream.append(record);
+		// A record naming no groups describes a span with no content, so nothing can evict out
+		// from under it; keep it for as long as the shortest window any enrolled track declares,
+		// so a gap doesn't outlive the segments around it.
+		if (expiry === undefined) {
+			let shortest = Number.POSITIVE_INFINITY;
+			for (const track of this.#tracks.values()) shortest = Math.min(shortest, track.latencyMax);
+			expiry = Date.now() + (Number.isFinite(shortest) ? shortest : 0);
+		}
+
+		this.#window.append(record);
+		this.#expiry.push(expiry);
+	}
+
+	// Retract every record whose content has left the publisher's cache.
+	//
+	// Driven by the same reports that drive publishing, which is also what drives the track
+	// cache's own age eviction (it prunes as groups are written), so the two stay in phase
+	// without a timer: a publisher that stalls stops trimming and stops evicting together.
+	#sweep(): void {
+		const now = Date.now();
+		let expired = 0;
+		while (expired < this.#expiry.length && this.#expiry[expired] <= now) expired += 1;
+		if (expired === 0) return;
+
+		this.#expiry.splice(0, expired);
+		this.#window.trim(expired);
 	}
 }
 

--- a/js/json/src/index.ts
+++ b/js/json/src/index.ts
@@ -5,9 +5,12 @@
  *   recent value. Intermediate updates are collapsed and older groups are dropped.
  * - {@link Stream}: **lossless**. An ordered append-log of self-contained records; every record
  *   is preserved and delivered in order, nothing is ever superseded.
+ * - {@link Window}: **sliding**. An ordered log that appends at the tail and removes from the
+ *   head, like an HLS playlist. Records carry stable positions and old groups are disposable.
  *
  * Pick {@link Snapshot} when consumers care about "what is the value now" (a catalog, a status
- * document) and {@link Stream} when they care about every record (an event log, a media timeline).
+ * document), {@link Stream} when they care about every record ever written (an event log), and
+ * {@link Window} when records expire (a media timeline over a bounded cache).
  *
  * Each mode comes in two layers. `Producer`/`Consumer` own a track and manage its groups.
  * `Encoder`/`Decoder` are the same logic without the track: values in, frame payloads out (and
@@ -20,3 +23,4 @@
 export { type Diff, deepEqual, diff, merge } from "./diff.ts";
 export * as Snapshot from "./snapshot/index.ts";
 export * as Stream from "./stream/index.ts";
+export * as Window from "./window.ts";

--- a/js/json/src/window.test.ts
+++ b/js/json/src/window.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, test } from "bun:test";
+import * as Moq from "@moq/net";
+import * as Window from "./window.ts";
+
+interface Rec {
+	n: number;
+}
+
+function pair(compression = false): [Window.Producer<Rec>, Window.Consumer<Rec>] {
+	const track = new Moq.Track.Producer("test");
+	const consumer = new Window.Consumer<Rec>(track.subscribe(), { compression });
+	return [new Window.Producer<Rec>(track, { compression }), consumer];
+}
+
+/** Drain every update the consumer can produce until the track ends. */
+async function drain(consumer: Window.Consumer<Rec>): Promise<Window.Update<Rec>[]> {
+	const out: Window.Update<Rec>[] = [];
+	for (;;) {
+		const update = await consumer.next();
+		if (!update) return out;
+		out.push(update);
+	}
+}
+
+/** The records a consumer holds after applying every update. */
+function replay(updates: Window.Update<Rec>[]): [number, Rec][] {
+	let held: [number, Rec][] = [];
+	for (const update of updates) {
+		if (update.type === "append") held.push([update.position, update.value]);
+		else held = held.filter(([position]) => position >= update.offset);
+	}
+	return held;
+}
+
+describe("window", () => {
+	test("appends carry positions", async () => {
+		const [producer, consumer] = pair();
+		for (let n = 0; n < 3; n++) expect(producer.append({ n })).toBe(n);
+		producer.finish();
+
+		expect(await drain(consumer)).toEqual([
+			{ type: "append", position: 0, value: { n: 0 } },
+			{ type: "append", position: 1, value: { n: 1 } },
+			{ type: "append", position: 2, value: { n: 2 } },
+		]);
+	});
+
+	test("a trim retracts from the head", async () => {
+		const [producer, consumer] = pair();
+		for (let n = 0; n < 4; n++) producer.append({ n });
+		producer.trim(2);
+		expect(producer.offset).toBe(2);
+		expect(producer.length).toBe(2);
+		producer.finish();
+
+		const updates = await drain(consumer);
+		expect(updates.at(-1)).toEqual({ type: "trim", offset: 2 });
+		expect(replay(updates)).toEqual([
+			[2, { n: 2 }],
+			[3, { n: 3 }],
+		]);
+	});
+
+	test("a trim past the window throws", () => {
+		const [producer] = pair();
+		producer.append({ n: 0 });
+		expect(() => producer.trim(2)).toThrow();
+		// The rejected trim left the window untouched, and zero is a no-op.
+		expect(producer.length).toBe(1);
+		producer.trim(0);
+	});
+
+	test("a non-integer trim count is rejected", () => {
+		// NaN fails every comparison, so a range check alone lets it through: it would splice
+		// nothing, poison the offset, and serialize as `null`. A fraction splices nothing either
+		// and emits a count both consumers reject.
+		const [producer] = pair();
+		for (let n = 0; n < 3; n++) producer.append({ n });
+
+		for (const bad of [0.5, Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+			expect(() => producer.trim(bad)).toThrow();
+		}
+		expect(producer.length).toBe(3);
+		expect(producer.offset).toBe(0);
+	});
+
+	test("heavy trimming rolls a group and still converges on the live window", async () => {
+		const track = new Moq.Track.Producer("test");
+		const producer = new Window.Producer<Rec>(track);
+
+		producer.append({ n: 0 });
+		producer.append({ n: 1 });
+		for (let n = 2; n < 12; n++) {
+			producer.append({ n });
+			producer.trim(1);
+		}
+		producer.finish();
+
+		// A late joiner skips to the newest buffered group rather than replaying every cached one.
+		// Parity with the Rust consumer.
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+		const updates = await drain(consumer);
+		const positions = updates.filter((u) => u.type === "append").map((u) => u.position);
+
+		// It starts inside the newest group's snapshot, not back at the beginning of the log. The
+		// exact position depends on where the last roll fell, so assert the property, not the value.
+		expect(positions[0]).toBeGreaterThan(0);
+		expect(positions).toEqual([...new Set(positions)]);
+		expect(replay(updates)).toEqual([
+			[10, { n: 10 }],
+			[11, { n: 11 }],
+		]);
+	});
+
+	test("mutating an appended record does not change what a later snapshot emits", async () => {
+		// The window keeps records by value, not by reference. Otherwise a caller mutating an object
+		// it already appended would make a later group's snapshot emit different JSON for the same
+		// position, so a consumer that saw the first group and one that joined later would disagree
+		// about a record they both name.
+		const track = new Moq.Track.Producer("test");
+		const producer = new Window.Producer<Rec>(track);
+
+		const record = { n: 0 };
+		producer.append(record);
+		record.n = 999; // after publishing, before any roll
+
+		// Roll via the per-group frame cap rather than by trimming, so position 0 is still in the
+		// window and gets re-serialized into the new group's snapshot.
+		for (let n = 1; n < 300; n++) producer.append({ n });
+		producer.finish();
+
+		const held = replay(await drain(new Window.Consumer<Rec>(track.subscribe())));
+		const first = held.find(([position]) => position === 0);
+		expect(first).toBeDefined();
+		expect(first?.[1]).toEqual({ n: 0 });
+	});
+
+	test("a failed publish leaves the window untouched", () => {
+		// `finish` only closes the track, so a later append is expressible. It must fail without
+		// moving the window: `offset`, `length`, and the next position all read from it.
+		const [producer] = pair();
+		producer.append({ n: 0 });
+		producer.append({ n: 1 });
+		producer.finish();
+
+		expect(() => producer.append({ n: 2 })).toThrow();
+		expect(producer.length).toBe(2);
+		expect(producer.offset).toBe(0);
+
+		expect(() => producer.trim(1)).toThrow();
+		expect(producer.length).toBe(2);
+		expect(producer.offset).toBe(0);
+	});
+
+	test("a snapshot spanning past the exact-integer limit is rejected", async () => {
+		// The offset alone is not enough: past 2^53-1 two positions round together, so the next
+		// append would repeat one the consumer already yielded.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		const snapshot = { offset: Number.MAX_SAFE_INTEGER - 1, values: [{ n: 0 }, { n: 1 }, { n: 2 }] };
+		group.writeFrame({
+			payload: new TextEncoder().encode(JSON.stringify(snapshot)),
+			timestamp: Moq.Time.Timestamp.now(),
+		});
+		group.close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("maximum position");
+	});
+
+	test("a group roll never repeats a record", async () => {
+		// Whatever group a consumer lands on, positions are what make the switch lossless: a record
+		// repeated by a later snapshot is skipped rather than yielded twice. (The strictly-live
+		// interleaving is covered on the Rust side, which has a synchronous poll API to drive it.)
+		const [producer, consumer] = pair();
+		for (let n = 0; n < 2; n++) producer.append({ n });
+		for (let n = 2; n < 12; n++) {
+			producer.append({ n });
+			producer.trim(1);
+		}
+		producer.finish();
+
+		const positions = (await drain(consumer)).filter((u) => u.type === "append").map((u) => u.position);
+		expect(positions).toEqual([...new Set(positions)]);
+		expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+	});
+
+	test("compressed roundtrip", async () => {
+		const [producer, consumer] = pair(true);
+		for (let n = 0; n < 20; n++) producer.append({ n });
+		producer.trim(15);
+		producer.finish();
+
+		const held = replay(await drain(consumer));
+		expect(held.length).toBe(5);
+		expect(held[0]).toEqual([15, { n: 15 }]);
+	});
+
+	test("a null record keeps its position", async () => {
+		// `null` is a valid JSON record. Treating it as an absent `append` would drop the record and
+		// stall the tail, shifting every later position. Parity with the Rust window.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec | null>(track.subscribe());
+		const producer = new Window.Producer<Rec | null>(track);
+
+		producer.append({ n: 0 });
+		producer.append(null);
+		producer.append({ n: 2 });
+		producer.finish();
+
+		const out: Window.Update<Rec | null>[] = [];
+		for (;;) {
+			const update = await consumer.next();
+			if (!update) break;
+			out.push(update);
+		}
+		expect(out).toEqual([
+			{ type: "append", position: 0, value: { n: 0 } },
+			{ type: "append", position: 1, value: null },
+			{ type: "append", position: 2, value: { n: 2 } },
+		]);
+	});
+
+	test("a malformed trim is rejected", async () => {
+		// A non-numeric trim would coerce to 0 and silently no-op, leaving the head desynced from
+		// the publisher's; Rust errors on it too.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [{ offset: 0, values: [{ n: 0 }] }, { trim: null }]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		// Buffered frames drain in one pass, so the malformed trim surfaces on the first read.
+		await expect(drain(consumer)).rejects.toThrow("invalid trim");
+	});
+
+	test("a frame carrying both operations is rejected", async () => {
+		// Applying both would append and retract in an order the format never defines. Parity with
+		// the Rust window; a frame carrying neither stays a no-op (see the next test).
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [
+			{ offset: 0, values: [{ n: 0 }] },
+			{ append: { n: 1 }, trim: 1 },
+		]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("both an append and a trim");
+	});
+
+	test("a snapshot with an unusable offset is rejected", async () => {
+		// Every position derives from the offset, and NaN comparisons are all false, so a bad offset
+		// would keep emitting appends whose positions no reader can use rather than failing.
+		for (const offset of [undefined, "4", Number.NaN, -1]) {
+			const track = new Moq.Track.Producer("test");
+			const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+			const group = track.appendGroup();
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify({ offset, values: [{ n: 0 }] })),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+			group.close();
+			track.close();
+
+			await expect(drain(consumer)).rejects.toThrow("invalid offset");
+		}
+	});
+
+	test("a snapshot missing values is rejected", async () => {
+		// `values` is required. Treating an absent one as an empty window would report a head jump
+		// and continue from fabricated state, where the Rust decoder fails outright.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		group.writeFrame({
+			payload: new TextEncoder().encode(JSON.stringify({ offset: 4 })),
+			timestamp: Moq.Time.Timestamp.now(),
+		});
+		group.close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("must be an array");
+	});
+
+	test("an append past the exact-integer limit is rejected", async () => {
+		// The snapshot bound alone is not enough: a snapshot can land the tail exactly at the limit
+		// and appends walk it past, where positions round together. Rust rejects the same frame.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [{ offset: Number.MAX_SAFE_INTEGER - 1, values: [{ n: 0 }] }, { append: { n: 1 } }]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("reaches the maximum");
+	});
+
+	test("an unknown operation is ignored", async () => {
+		// A frame carrying neither key is a forward-compatible extension, not an error. Written by
+		// hand, since the producer only emits the operations it knows.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [{ offset: 0, values: [{ n: 0 }] }, { rewind: 1 }, { append: { n: 1 } }]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		expect(await drain(consumer)).toEqual([
+			{ type: "append", position: 0, value: { n: 0 } },
+			{ type: "append", position: 1, value: { n: 1 } },
+		]);
+	});
+
+	test("a group with no snapshot is rejected", async () => {
+		// A group that ends cleanly having carried nothing is malformed: every group opens with a
+		// snapshot. Reporting it as a clean end of track would lose the window the publisher
+		// advertised. Rust rejects the same group.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		track.appendGroup().close();
+		track.close();
+
+		await expect(drain(consumer)).rejects.toThrow("no snapshot");
+	});
+
+	test("a hand-written trim is applied", async () => {
+		// The wire shape the Rust producer emits, decoded independently of our own producer.
+		const track = new Moq.Track.Producer("test");
+		const consumer = new Window.Consumer<Rec>(track.subscribe());
+
+		const group = track.appendGroup();
+		for (const frame of [{ offset: 4, values: [{ n: 4 }, { n: 5 }] }, { append: { n: 6 } }, { trim: 2 }]) {
+			group.writeFrame({
+				payload: new TextEncoder().encode(JSON.stringify(frame)),
+				timestamp: Moq.Time.Timestamp.now(),
+			});
+		}
+		group.close();
+		track.close();
+
+		const updates = await drain(consumer);
+		// Joining at offset 4 reports no trim for records it never held; the later trim is real.
+		expect(updates).toEqual([
+			{ type: "append", position: 4, value: { n: 4 } },
+			{ type: "append", position: 5, value: { n: 5 } },
+			{ type: "append", position: 6, value: { n: 6 } },
+			{ type: "trim", offset: 6 },
+		]);
+		expect(replay(updates)).toEqual([[6, { n: 6 }]]);
+	});
+});

--- a/js/json/src/window.ts
+++ b/js/json/src/window.ts
@@ -1,0 +1,474 @@
+/**
+ * Sliding-window JSON publishing over MoQ tracks: an ordered log that grows at the tail and
+ * shrinks at the head, like an HLS media playlist. {@link Producer.append} adds a record as
+ * content becomes available and {@link Producer.trim} drops records from the head as it stops
+ * being available. The counterpart to the `Stream` module, which only ever appends, and to
+ * `Snapshot`, which keeps no history at all.
+ *
+ * Every record has a stable **position**: the count of records ever appended before it. Positions
+ * never repeat, so a record is identified across group rolls and trims, exactly like an HLS media
+ * sequence number.
+ *
+ * On the wire each group is self-contained. Frame 0 is a snapshot of the live window
+ * (`{"offset":N,"values":[...]}`) and each later frame is one operation (`{"append":V}` or
+ * `{"trim":N}`). A new group rolls once the records trimmed since the snapshot outnumber those
+ * still in the window, so a late joiner reads the newest group and needs nothing older.
+ * Interoperable on the wire with the Rust `moq_json::window`.
+ *
+ * @module
+ */
+
+import { Decoder, Encoder } from "@moq/flate";
+import type * as Moq from "@moq/net";
+import { Time } from "@moq/net";
+
+/**
+ * Maximum frames (snapshot plus operations) in one group before a snapshot is forced.
+ *
+ * Kept well below moq-net's per-group frame cap so a late joiner can always read the snapshot at
+ * frame 0 before the group is evicted.
+ */
+const MAX_GROUP_FRAMES = 256;
+
+/**
+ * The largest position the wire format allows: 2^53-1.
+ *
+ * Past this a JSON number stops counting exactly, so two distinct positions round together and
+ * lossless group switching breaks: the next append would repeat a position the consumer already
+ * yielded. Matches `MAX_POSITION` in the Rust window.
+ */
+const MAX_POSITION = Number.MAX_SAFE_INTEGER;
+
+/** Compress (when an encoder is given) and write one already-serialized frame. */
+function writeFrame(group: Moq.Group.Producer, encoder: Encoder | undefined, payload: string): void {
+	const bytes = new TextEncoder().encode(payload);
+	group.writeFrame({ payload: encoder ? encoder.frame(bytes) : bytes, timestamp: Time.Timestamp.now() });
+}
+
+/** Options for a window {@link Producer}. */
+export interface ProducerConfig {
+	/**
+	 * Compress each group as one sync-flushed `deflate-raw` stream, so operations reuse the
+	 * snapshot as context and shrink sharply. A {@link Consumer} reading the track must set the
+	 * same flag. Defaults to `false`.
+	 */
+	compression?: boolean;
+}
+
+/** Options for a window {@link Consumer}. */
+export interface ConsumerConfig {
+	/** Whether the track's frames are `deflate-raw` compressed. Must match the producer. Defaults to `false`. */
+	compression?: boolean;
+}
+
+/** One change to the window, yielded by a {@link Consumer}. */
+export type Update<T> =
+	| {
+			type: "append";
+			/** The record's position: the count of records ever appended before it. */
+			position: number;
+			/** The record itself. */
+			value: T;
+	  }
+	| {
+			type: "trim";
+			/** The position of the oldest record still in the window; everything before it is gone. */
+			offset: number;
+	  };
+
+/** The snapshot at frame 0 of every group. */
+interface Snapshot<T> {
+	offset: number;
+	values: T[];
+}
+
+/** One operation frame. Unknown members are ignored, so a frame carrying neither key is a no-op. */
+interface Op<T> {
+	append?: T;
+	trim?: number;
+}
+
+/** Publishes a sliding window of JSON records to a track. */
+export class Producer<T> {
+	#track: Moq.Track.Producer;
+	#compress: boolean;
+
+	#group?: Moq.Group.Producer;
+	// The open group's DEFLATE encoder (one window per group), present while compressing.
+	#encoder?: Encoder;
+	// Every record currently in the window, oldest first, kept so a new group can snapshot it.
+	//
+	// Stored already serialized rather than by reference: a caller that mutates an object it
+	// appended would otherwise make a later snapshot emit different JSON for the same position, so
+	// a consumer that saw the first group and one that joined later would disagree about a record
+	// they both name. Serializing once at append pins the value, matching the Rust window's
+	// `Box<RawValue>`.
+	#window: string[] = [];
+	// The position of `#window[0]`: how many records have been trimmed for the log's lifetime.
+	#offset = 0;
+	// Records trimmed since the open group's snapshot, the roll trigger.
+	#trimmed = 0;
+	#frames = 0;
+
+	/** Wrap a track to publish a sliding record window into it. */
+	constructor(track: Moq.Track.Producer, config: ProducerConfig = {}) {
+		this.#track = track;
+		this.#compress = config.compression ?? false;
+	}
+
+	/** The position of the oldest record still in the window. */
+	get offset(): number {
+		return this.#offset;
+	}
+
+	/** The number of records currently in the window. */
+	get length(): number {
+		return this.#window.length;
+	}
+
+	/** Append one record to the tail of the window, returning the position it was assigned. */
+	append(value: T): number {
+		const raw = JSON.stringify(value);
+		if (raw === undefined) {
+			throw new Error("record is not JSON-serializable");
+		}
+
+		const position = this.#offset + this.#window.length;
+		// A consumer rejects an append *at* the maximum, so refuse to publish one: the window would
+		// be unreadable by the very consumers it targets.
+		if (position >= MAX_POSITION) {
+			throw new Error(`append at position ${position} reaches the maximum ${MAX_POSITION}`);
+		}
+		this.#window.push(raw);
+
+		try {
+			if (this.#needsSnapshot()) {
+				this.#snapshot();
+			} else {
+				this.#emit(`{"append":${raw}}`);
+			}
+		} catch (err) {
+			// A publish that failed (a finished or closed track) must leave the window as it was:
+			// `offset`, `length`, and the next position all read from it, so keeping a record nobody
+			// received would report a window that does not exist.
+			this.#window.pop();
+			throw err;
+		}
+		return position;
+	}
+
+	/**
+	 * Remove the oldest `count` records from the head of the window.
+	 *
+	 * A `count` of 0 does nothing. Throws if it exceeds the number of records in the window, since
+	 * trimming past the head would desync every consumer's positions.
+	 */
+	trim(count: number): void {
+		// Check integrality before the range test: `NaN` fails every comparison, so it would slip
+		// through, splice nothing, and poison `#offset` (and serialize as `null`). A fraction would
+		// splice nothing either, yet still emit a count both consumers reject.
+		if (!Number.isSafeInteger(count) || count < 0) {
+			throw new Error(`trim count must be a non-negative integer, got ${count}`);
+		}
+		if (count === 0) return;
+		if (count > this.#window.length) {
+			throw new Error(`trim of ${count} exceeds the ${this.#window.length} records in the window`);
+		}
+
+		const removed = this.#window.splice(0, count);
+		this.#offset += count;
+		this.#trimmed += count;
+
+		try {
+			if (this.#needsSnapshot()) {
+				this.#snapshot();
+			} else {
+				this.#emit(`{"trim":${count}}`);
+			}
+		} catch (err) {
+			// Same rollback as `append`: an unpublished trim must not move the head.
+			this.#offset -= count;
+			this.#trimmed -= count;
+			this.#window.unshift(...removed);
+			throw err;
+		}
+	}
+
+	/** Finish the track, closing any open group. */
+	finish(): void {
+		this.#group?.close();
+		this.#group = undefined;
+		this.#encoder = undefined;
+		this.#track.close();
+	}
+
+	/**
+	 * Whether the next operation should roll a fresh snapshot group instead.
+	 *
+	 * Rolls once the records trimmed since the snapshot outnumber those still in the window: the
+	 * group is then mostly dead weight for a new subscriber, and a fresh snapshot costs no more
+	 * than what has already been trimmed.
+	 */
+	#needsSnapshot(): boolean {
+		return !this.#group || this.#frames >= MAX_GROUP_FRAMES || this.#trimmed > this.#window.length;
+	}
+
+	/**
+	 * Start a new group whose frame 0 snapshots the whole window.
+	 *
+	 * State moves to the new group only once its snapshot frame lands. A half-rolled group (open,
+	 * but with no frame 0) would take the next append down the operation path and publish it as
+	 * frame 0, which every consumer rejects as a malformed snapshot, leaving the track unrecoverable.
+	 * Clearing the group instead forces the next publish to snapshot again.
+	 */
+	#snapshot(): void {
+		// Materialize before touching any group state, so a serialization failure changes nothing.
+		const payload = `{"offset":${this.#offset},"values":[${this.#window.join(",")}]}`;
+
+		// The previous group is complete; no more frames will be appended to it.
+		this.#group?.close();
+		this.#group = undefined;
+		this.#encoder = undefined;
+		this.#frames = 0;
+
+		const group = this.#track.appendGroup();
+		const encoder = this.#compress ? new Encoder() : undefined;
+		try {
+			writeFrame(group, encoder, payload);
+		} catch (err) {
+			group.close();
+			throw err;
+		}
+
+		this.#group = group;
+		this.#encoder = encoder;
+		this.#frames = 1;
+		// Only now is the roll real, so only now does the trim debt reset. Resetting earlier would
+		// let a failed roll drive `#trimmed` negative when the caller rolls back.
+		this.#trimmed = 0;
+	}
+
+	/** Write one already-serialized frame into the open group. */
+	#emit(payload: string): void {
+		// biome-ignore lint/style/noNonNullAssertion: #needsSnapshot guarantees an open group
+		writeFrame(this.#group!, this.#encoder, payload);
+		this.#frames += 1;
+	}
+}
+
+/**
+ * Reads a sliding window of JSON records from a track, yielding each change in order.
+ *
+ * Starts at the newest group's snapshot, so a late joiner sees an append per record currently in
+ * the window and then follows along live. Switching to a newer group is lossless: positions
+ * identify what has already been yielded, so records are never repeated.
+ *
+ * A trim only ever retracts records this consumer was told about, so joining a window that has
+ * already trimmed does not report the records it missed. Those show up instead as a jump in the
+ * first append's `position`.
+ */
+export class Consumer<T> {
+	#track: Moq.Track.Subscriber;
+	#decompress: boolean;
+
+	#group?: Moq.Group.Consumer;
+	// The open group's DEFLATE decoder (one window per group), built on its first frame.
+	#decoder?: Decoder;
+	// Frames read from the open group; frame 0 is its snapshot.
+	#frames = 0;
+	// The position of the next record this consumer has not yielded yet.
+	#next = 0;
+	// The head offset already reported through a trim, or undefined until the first snapshot
+	// establishes where this consumer joined.
+	#reported?: number;
+	// The head offset of the group being followed, advanced by its trims.
+	#head = 0;
+	// The position one past the last record the group being followed has appended.
+	#tail = 0;
+	// Updates decoded but not yet yielded; one frame can decode a whole snapshot.
+	#pending: Update<T>[] = [];
+
+	constructor(track: Moq.Track.Subscriber, config: ConsumerConfig = {}) {
+		this.#track = track;
+		this.#decompress = config.compression ?? false;
+	}
+
+	/** Get the next update, or `undefined` once the track ends. */
+	async next(): Promise<Update<T> | undefined> {
+		for (;;) {
+			const ready = this.#pending.shift();
+			if (ready) return ready;
+
+			if (!this.#group) {
+				// Advance to the next group with a higher sequence number (skipping late arrivals).
+				this.#group = await this.#track.nextGroup();
+				if (!this.#group) return undefined;
+
+				// Then skip to the newest group already buffered. Each group is self-contained, so
+				// an older one carries nothing the newest lacks; without this a late joiner replays
+				// every cached group, emitting appends and trims for records already gone.
+				//
+				// Close each group skipped past. A subscriber's group is its own mirror of the
+				// source (`Group.Producer.mirror` builds a fresh state per sink), so closing one
+				// releases only this reader's copy and drops its share of the producer's demand.
+				for (let newer = this.#track.tryNextGroup(); newer; newer = this.#track.tryNextGroup()) {
+					this.#group.close();
+					this.#group = newer;
+				}
+
+				this.#frames = 0;
+				this.#decoder = undefined;
+			}
+
+			// Drain everything already buffered before blocking, so a late joiner catches up in one step.
+			let advanced = false;
+			for (let frame = this.#group.tryReadFrame(); frame !== undefined; frame = this.#group.tryReadFrame()) {
+				this.#apply(frame.payload);
+				advanced = true;
+			}
+			if (advanced) continue;
+
+			let frame: Moq.Group.Frame | undefined;
+			try {
+				frame = await this.#group.readFrame();
+			} catch {
+				// The group was reset or we fell behind its eviction window. Resync from the next
+				// group, which begins with a fresh snapshot, so no partial state is presented.
+				this.#group = undefined;
+				continue;
+			}
+
+			if (frame === undefined) {
+				// Every group opens with a snapshot, so one that ends cleanly having delivered
+				// nothing is malformed. Accepting it would let it masquerade as a clean end of
+				// track and silently lose the window the publisher advertised. Rust rejects the
+				// same group. (A group that *errors* before frame 0 is a different case, handled
+				// above: that is a lost group, and it resyncs.)
+				if (this.#frames === 0) throw new Error("a group carried no snapshot");
+
+				// The group is exhausted; advance to the next one.
+				this.#group = undefined;
+				continue;
+			}
+
+			this.#apply(frame.payload);
+		}
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<Update<T>> {
+		for (;;) {
+			const update = await this.next();
+			if (update === undefined) return;
+			yield update;
+		}
+	}
+
+	/** Apply one frame: frame 0 of a group is a snapshot, the rest are operations. */
+	#apply(frame: Uint8Array): void {
+		let payload = frame;
+		if (this.#decompress) {
+			this.#decoder ??= new Decoder();
+			payload = this.#decoder.frame(frame);
+		}
+		const parsed = JSON.parse(new TextDecoder().decode(payload));
+
+		if (this.#frames === 0) {
+			this.#applySnapshot(parsed as Snapshot<T>);
+		} else {
+			this.#applyOp(parsed as Op<T>);
+		}
+		this.#frames += 1;
+	}
+
+	/** Adopt a group's snapshot, yielding only what this consumer hasn't seen. */
+	#applySnapshot(snapshot: Snapshot<T>): void {
+		// Every position derives from this offset. A missing or non-numeric one would make `#head`,
+		// `#tail`, and every position NaN, and NaN comparisons are all false, so the consumer would
+		// keep emitting appends whose positions no reader can use. Fail loudly instead.
+		if (!Number.isSafeInteger(snapshot.offset) || snapshot.offset < 0) {
+			throw new Error(`snapshot carries an invalid offset: ${JSON.stringify(snapshot.offset)}`);
+		}
+		// `values` is required, so an absent one is malformed rather than an empty window: accepting
+		// it would report a head jump and continue from fabricated state, where the Rust decoder
+		// fails. Both implementations must reject the same frames.
+		if (!Array.isArray(snapshot.values)) {
+			throw new Error("snapshot values must be an array");
+		}
+		const values = snapshot.values;
+		// The tail matters as much as the offset: past the exact-integer limit two positions round
+		// together, so the next append would repeat one the consumer already yielded.
+		if (snapshot.offset + values.length > MAX_POSITION) {
+			throw new Error(`snapshot spans past the maximum position ${MAX_POSITION}`);
+		}
+		this.#head = snapshot.offset;
+		this.#tail = snapshot.offset + values.length;
+		this.#reportTrim();
+
+		values.forEach((value, index) => {
+			const position = snapshot.offset + index;
+			// Already yielded from an older group: the position is what makes the switch lossless.
+			if (position < this.#next) return;
+			this.#pushAppend(position, value);
+		});
+	}
+
+	/** Apply one operation frame from the group being followed. */
+	#applyOp(op: Op<T>): void {
+		// A frame carries at most one operation. Applying both would append and retract in an order
+		// the format never defines, so reject it instead of guessing. A frame carrying *neither* is
+		// not an error: that is how an operation added by a later revision reads here.
+		if ("append" in op && op.trim !== undefined) {
+			throw new Error("a frame carries both an append and a trim");
+		}
+
+		// An explicit `null` is a valid record, so test for the member's presence rather than for a
+		// defined value: collapsing the two would drop the record and stall the tail, shifting every
+		// later position.
+		if ("append" in op) {
+			const position = this.#tail;
+			// The snapshot bound is not enough on its own: a snapshot can land the tail exactly at
+			// the limit, and appends walk it past. Rust rejects the same operation.
+			if (position >= MAX_POSITION) {
+				throw new Error(`append at position ${position} reaches the maximum ${MAX_POSITION}`);
+			}
+			this.#tail += 1;
+			if (position >= this.#next) this.#pushAppend(position, op.append as T);
+		}
+
+		if (op.trim !== undefined) {
+			// A non-numeric trim would coerce to 0 and silently no-op, desyncing the head from the
+			// publisher's; reject it instead.
+			if (typeof op.trim !== "number" || !Number.isInteger(op.trim) || op.trim < 0) {
+				throw new Error(`invalid trim ${JSON.stringify(op.trim)}`);
+			}
+			if (this.#head + op.trim > this.#tail) {
+				throw new Error(`trim of ${op.trim} exceeds the ${this.#tail - this.#head} records in the window`);
+			}
+			this.#head += op.trim;
+			this.#reportTrim();
+		}
+	}
+
+	/**
+	 * Emit a trim if the followed group's head has moved past what was last reported.
+	 *
+	 * A trim says "records you were told about are gone", so the first snapshot only adopts its
+	 * offset: a consumer joining a window that already trimmed never held those records.
+	 */
+	#reportTrim(): void {
+		if (this.#reported === undefined) {
+			this.#reported = this.#head;
+			return;
+		}
+		if (this.#head > this.#reported) {
+			this.#reported = this.#head;
+			this.#pending.push({ type: "trim", offset: this.#head });
+		}
+	}
+
+	/** Queue a record, advancing the yield cursor past it. */
+	#pushAppend(position: number, value: T): void {
+		this.#next = position + 1;
+		this.#pending.push({ type: "append", position, value });
+	}
+}

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -15,6 +15,18 @@ export type { Datagram } from "./datagram.ts";
 export const DEFAULT_LATENCY_MAX_MS = 5000;
 
 /**
+ * How long a group is kept past {@link Info.latencyMax} before age eviction takes it, in
+ * milliseconds.
+ *
+ * The grace makes `latencyMax` a floor rather than a deadline. A reader deciding to fetch a group
+ * at the edge of the window needs it to still be there when the request lands, which is a round
+ * trip later, and an index built from `latencyMax` (a media timeline) drops a record while the
+ * content behind it is still fetchable rather than a moment after it is gone. Mirrors
+ * `EVICT_GRACE` in the Rust `moq-net`.
+ */
+const EVICT_GRACE_MS = 1000;
+
+/**
  * How long (milliseconds) a datagram stays in the per-subscriber buffer before it is dropped.
  *
  * Datagrams are a best-effort send buffer, not a replay cache (unlike groups): only the last few
@@ -351,6 +363,17 @@ export class Producer {
 		return this.#state.update;
 	}
 
+	/**
+	 * This track's committed publisher properties, or `undefined` before {@link accept}.
+	 *
+	 * The synchronous peek at {@link info}, for a caller that already knows the track was
+	 * accepted and needs the value inline. Anything sizing itself to the publisher's cache (a
+	 * media timeline deciding how far back to index) reads `latencyMax` from here.
+	 */
+	get accepted(): Info | undefined {
+		return this.#state.info.peek();
+	}
+
 	/** Commit the immutable publisher properties, resolving {@link info}. Returns `this`. */
 	accept(info: Partial<Info> = {}): this {
 		const resolved = infoDefaults(info);
@@ -460,7 +483,7 @@ export class Producer {
 	// each evicted group's mirror from every sink so no consumer can pin it.
 	#prune(): void {
 		const latencyMaxMs = this.#state.info.peek()?.latencyMax ?? DEFAULT_LATENCY_MAX_MS;
-		const cutoff = Date.now() - latencyMaxMs;
+		const cutoff = Date.now() - (latencyMaxMs + EVICT_GRACE_MS);
 
 		const retained: CachedGroup[] = [];
 		for (const entry of this.#cache) {
@@ -777,6 +800,28 @@ export class Subscriber {
 
 			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}
+	}
+
+	/**
+	 * Return the next group only if one is already buffered, otherwise `undefined`.
+	 *
+	 * The non-blocking counterpart to {@link nextGroup}. A reader whose groups are each
+	 * self-contained (a snapshot or a sliding window) drains with this to reach the newest
+	 * buffered group, so a late joiner starts from current state instead of replaying every
+	 * cached group.
+	 */
+	tryNextGroup(): GroupConsumer | undefined {
+		const groups = this.#state.groups.peek();
+		const cursor = this.#cursor.peek();
+		const start = Math.max(cursor.start, this.#nextSequence);
+		while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
+
+		const group = groups[0];
+		if (!group || (cursor.end !== undefined && group.sequence > cursor.end)) return undefined;
+
+		groups.shift();
+		this.#nextSequence = group.sequence + 1;
+		return group;
 	}
 
 	/**

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -336,8 +336,14 @@ async fn watch(
 	renditions: &renditions::Fanout,
 ) -> crate::Result<()> {
 	let mut timeline = moq_mux::timeline::Consumer::<()>::subscribe(broadcast, section).await?;
-	while let Some(entry) = timeline.next().await? {
-		renditions.push(entry);
+	while let Some(update) = timeline.next().await? {
+		match update {
+			moq_mux::timeline::Update::Append(entry) => renditions.push(entry),
+			moq_mux::timeline::Update::Trim { segment } => renditions.trim(segment),
+			// The timeline's updates are `#[non_exhaustive]`. Ignoring one this build doesn't
+			// know keeps the playlist stale rather than wrong, which is the safer of the two.
+			other => tracing::warn!(?other, "ignoring an unrecognized timeline update"),
+		}
 	}
 	Ok(())
 }

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -149,6 +149,12 @@ impl Rendition {
 		self.live.push(row, window);
 	}
 
+	/// Drop the segments below `segment` from this rendition's window: the publisher retracted
+	/// them, so their media is no longer fetchable.
+	pub(crate) fn trim(&self, segment: u64) {
+		self.live.trim(segment);
+	}
+
 	/// Mark this rendition's window ended (the timeline finished cleanly).
 	pub(crate) fn end(&self) {
 		self.live.end();

--- a/rs/moq-hls/src/export/renditions.rs
+++ b/rs/moq-hls/src/export/renditions.rs
@@ -214,6 +214,30 @@ impl Fanout {
 		});
 	}
 
+	/// Retract every segment below `segment`, from the replay history and every living rendition.
+	///
+	/// Deliberately leaves [`Feed::anchor`] alone, even when this empties the history. The anchor
+	/// maps the pts axis onto wall clock and a retraction says nothing about that axis; only a
+	/// timeline restart invalidates it. Re-estimating here would jump
+	/// `EXT-X-PROGRAM-DATE-TIME` (and DASH's `availabilityStartTime`) over content that never
+	/// moved, and worst of all exactly when the publisher is shedding media, which is when the
+	/// "this segment just ended" assumption behind a fresh estimate is least true.
+	pub fn trim(&self, segment: u64) {
+		let mut feed = self.feed.lock().unwrap();
+
+		while feed.history.front().is_some_and(|entry| entry.segment < segment) {
+			feed.history.pop_front();
+		}
+
+		feed.targets.retain(|target| {
+			let Some(rendition) = target.upgrade() else {
+				return false;
+			};
+			rendition.trim(segment);
+			true
+		});
+	}
+
 	/// Mark every living rendition's window ended (the timeline finished cleanly).
 	pub fn end_windows(&self) {
 		let mut feed = self.feed.lock().unwrap();

--- a/rs/moq-hls/src/export/segments.rs
+++ b/rs/moq-hls/src/export/segments.rs
@@ -157,6 +157,21 @@ impl Producer {
 		}
 	}
 
+	/// Drop every row numbered below `segment`: the publisher can no longer serve them.
+	///
+	/// The hard bound on the window, where [`push`](Self::push)'s duration is a soft preference:
+	/// a segment whose media has left the publisher's cache can't be listed however short the
+	/// configured window is, because a player following the playlist would 404 on it. Whichever
+	/// removes more wins.
+	pub fn trim(&self, segment: u64) {
+		let Ok(mut state) = self.state.write() else {
+			return;
+		};
+		while state.rows.front().is_some_and(|row| row.segment < segment) {
+			state.rows.pop_front();
+		}
+	}
+
 	/// Mark the timeline ended (the broadcast finished cleanly): the playlist gets
 	/// `EXT-X-ENDLIST` and cursors end once drained.
 	pub fn end(&self) {
@@ -396,6 +411,63 @@ mod tests {
 		let span: f64 = snapshot.segments.iter().map(|s| s.duration).sum();
 		assert!(span >= 4.0);
 		assert_eq!(snapshot.segments.first().unwrap().segment, snapshot.sequence);
+	}
+
+	/// A retraction is the hard bound: it drops segments the configured window would have kept,
+	/// because listing media the publisher can no longer serve 404s the player.
+	#[test]
+	fn a_trim_drops_segments_the_window_would_keep() {
+		let live = Producer::new();
+		// A window long enough that its own eviction never fires across these 6 segments.
+		let window = Duration::from_secs(600);
+		for i in 0..6u64 {
+			live.push(row(i, i, i * 2_000, 2_000), window);
+		}
+		assert_eq!(live.window().segments.len(), 6);
+
+		live.trim(4);
+
+		let snapshot = live.window();
+		assert_eq!(
+			snapshot.segments.iter().map(|s| s.segment).collect::<Vec<_>>(),
+			vec![4, 5]
+		);
+		assert_eq!(
+			snapshot.sequence, 4,
+			"EXT-X-MEDIA-SEQUENCE follows the oldest listed segment"
+		);
+	}
+
+	/// `EXT-X-MEDIA-SEQUENCE` may never go backwards, so a trim below the window (one the
+	/// duration bound already removed) has to be a no-op rather than resurrect anything.
+	#[test]
+	fn a_stale_trim_does_not_rewind_the_sequence() {
+		let live = Producer::new();
+		let window = Duration::from_secs(4);
+		for i in 0..6u64 {
+			live.push(row(i, i, i * 2_000, 2_000), window);
+		}
+		let before = live.window();
+		assert!(before.sequence > 0, "the duration bound already evicted the head");
+
+		live.trim(0);
+
+		let after = live.window();
+		assert_eq!(after.sequence, before.sequence);
+		assert_eq!(after.segments.len(), before.segments.len());
+	}
+
+	/// A trim past everything in the window empties it rather than leaving a stale tail.
+	#[test]
+	fn a_trim_past_the_window_empties_it() {
+		let live = Producer::new();
+		let window = Duration::from_secs(600);
+		for i in 0..3u64 {
+			live.push(row(i, i, i * 2_000, 2_000), window);
+		}
+
+		live.trim(99);
+		assert!(live.window().segments.is_empty());
 	}
 
 	#[test]

--- a/rs/moq-json/Cargo.toml
+++ b/rs/moq-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moq-json"
-description = "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, or append-log record streams."
+description = "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, append-log record streams, or sliding windows."
 authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ kio = { workspace = true }
 moq-flate = { workspace = true }
 moq-net = { workspace = true }
 serde = { workspace = true }
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 serde_path_to_error = "0.1"
 thiserror = "2"
 tracing = "0.1"

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -4,9 +4,12 @@
 //!   recent value. Intermediate updates are collapsed and older groups are dropped.
 //! - [`stream`]: **lossless**. An ordered append-log of self-contained records; every record is
 //!   preserved and delivered in order, nothing is ever superseded.
+//! - [`window`]: **sliding**. An ordered log that appends at the tail and removes from the head,
+//!   like an HLS playlist. Records carry stable positions and old groups are disposable.
 //!
 //! Pick [`snapshot`] when consumers care about "what is the value now" (a catalog, a status
-//! document) and [`stream`] when they care about every record (an event log, a media timeline).
+//! document), [`stream`] when they care about every record ever written (an event log), and
+//! [`window`] when records expire (a media timeline over a bounded cache).
 //!
 //! Each mode comes in two layers. `Producer`/`Consumer` own a [`moq_net`] track and manage its
 //! groups. `Encoder`/`Decoder` are the same logic without the track: values in, frame payloads out
@@ -17,6 +20,7 @@
 mod diff;
 pub mod snapshot;
 pub mod stream;
+pub mod window;
 
 pub use crate::diff::{Diff, diff};
 
@@ -37,6 +41,11 @@ pub enum Error {
 	/// A compressed frame could not be decoded (malformed, truncated, or oversized).
 	#[error(transparent)]
 	Flate(#[from] moq_flate::Error),
+
+	/// A [`window`] operation is inconsistent with the window it applies to, such as a trim
+	/// reaching past the oldest record.
+	#[error("invalid window update: {0}")]
+	Window(String),
 
 	/// A merge patch arrived with no snapshot to apply it to.
 	///

--- a/rs/moq-json/src/window.rs
+++ b/rs/moq-json/src/window.rs
@@ -1,0 +1,1323 @@
+//! Sliding-window JSON publishing over [`moq-net`](moq_net) tracks.
+//!
+//! An ordered log that grows at the tail and shrinks at the head, like an HLS media playlist:
+//! [`Producer::append`] adds a record as content becomes available and [`Producer::trim`] drops
+//! records from the head as it stops being available. The counterpart to [`stream`](crate::stream),
+//! which only ever appends, and to [`snapshot`](crate::snapshot), which keeps no history at all.
+//!
+//! Every record has a stable **position**: the count of records ever appended before it. Positions
+//! never repeat, so a record is identified across group rolls and trims, exactly like an HLS media
+//! sequence number.
+//!
+//! On the wire each group is self-contained. Frame 0 is a snapshot of the live window
+//! (`{"offset":N,"values":[...]}`) and each later frame is one operation (`{"append":V}` or
+//! `{"trim":N}`). A new group rolls once the records trimmed since the snapshot outnumber those
+//! still in the window, which bounds the total bytes at roughly twice an append-only log while
+//! keeping every group independently readable.
+//!
+//! That rolling is what a [`stream`](crate::stream) track cannot do: its whole log rides one group,
+//! so a consumer always starts at frame 0 and the track breaks (with
+//! [`moq_net::Error::Lagged`]) once the earliest frames age out. Here a late joiner reads the
+//! *newest* group and needs nothing older, so old groups can be dropped freely.
+
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
+use std::task::Poll;
+
+use bytes::Bytes;
+use moq_flate::{Decoder, Encoder};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+use crate::{Error, Result};
+
+/// Maximum frames (snapshot plus operations) in one group before a snapshot is forced.
+///
+/// Kept well below moq-net's per-group frame cap so a late joiner can always read the snapshot at
+/// frame 0 before the group is evicted.
+const MAX_GROUP_FRAMES: usize = 256;
+
+/// The largest position the wire format allows: 2^53-1.
+///
+/// The bound comes from the format, not from Rust: a receiver whose JSON numbers are IEEE 754
+/// doubles (the usual case, and what the JS implementation uses) counts exactly only up to here.
+/// Enforcing it also keeps the tail arithmetic well clear of a `u64` overflow, which would panic in
+/// debug and silently wrap every later position in release.
+const MAX_POSITION: u64 = (1 << 53) - 1;
+
+/// Configuration for a window [`Producer`].
+///
+/// Build from [`Default`] and override fields (the struct is `#[non_exhaustive]`, so new options
+/// stay additive), or chain the `with_*` setters.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ProducerConfig {
+	/// Compress each group as one sync-flushed DEFLATE stream, so operations reuse the snapshot as
+	/// context and shrink sharply.
+	///
+	/// `false` (the default) writes plaintext JSON frames. A [`Consumer`] reading the track must set
+	/// [`ConsumerConfig::compression`] to match.
+	pub compression: bool,
+}
+
+impl ProducerConfig {
+	/// Set [`compression`](Self::compression) (a builder, since the struct is `#[non_exhaustive]`).
+	pub fn with_compression(mut self, compression: bool) -> Self {
+		self.compression = compression;
+		self
+	}
+}
+
+/// Configuration for a window [`Consumer`].
+///
+/// Build from [`Default`] and override fields (the struct is `#[non_exhaustive]`, so new options
+/// stay additive), or chain the `with_*` setters.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ConsumerConfig {
+	/// Whether the track's frames are DEFLATE-compressed. Must match the producer's
+	/// [`ProducerConfig::compression`]. Defaults to `false`.
+	pub compression: bool,
+}
+
+impl ConsumerConfig {
+	/// Set [`compression`](Self::compression) (a builder, since the struct is `#[non_exhaustive]`).
+	pub fn with_compression(mut self, compression: bool) -> Self {
+		self.compression = compression;
+		self
+	}
+}
+
+/// The snapshot at frame 0 of every group, as written.
+#[derive(Serialize)]
+struct SnapshotOut<'a> {
+	offset: u64,
+	values: &'a VecDeque<Box<RawValue>>,
+}
+
+/// An append operation, as written.
+#[derive(Serialize)]
+struct AppendOut<'a> {
+	append: &'a RawValue,
+}
+
+/// A trim operation, as written.
+#[derive(Serialize)]
+struct TrimOut {
+	trim: usize,
+}
+
+/// The snapshot at frame 0 of every group, as read.
+///
+/// Values stay raw so only the records the consumer hasn't already seen are deserialized.
+#[derive(Deserialize)]
+struct SnapshotIn {
+	offset: u64,
+	values: Vec<Box<RawValue>>,
+}
+
+/// One operation frame, as read. Unknown members are ignored, so a frame carrying neither key is a
+/// no-op rather than an error (a forward-compatible extension).
+#[derive(Deserialize)]
+struct OpIn {
+	#[serde(default, deserialize_with = "present")]
+	append: Option<Box<RawValue>>,
+	#[serde(default, deserialize_with = "present")]
+	trim: Option<usize>,
+}
+
+/// Deserialize a *present* member into `Some`, even when its value is JSON `null`.
+///
+/// A plain `Option` collapses an explicit null into `None`, which would make an appended `null`
+/// record indistinguishable from an absent `append` member: the record would be dropped and, worse,
+/// the tail would not advance, shifting every later position in the group. A snapshot preserves a
+/// null record (its values decode as raw JSON), so without this the same record survives a group
+/// roll but vanishes as an append.
+fn present<'de, D, T>(deserializer: D) -> std::result::Result<Option<T>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+	T: Deserialize<'de>,
+{
+	T::deserialize(deserializer).map(Some)
+}
+
+/// Publishes a sliding window of JSON records over a track.
+///
+/// Cheaply clonable: clones share one underlying track and window state, so several owners append
+/// into a single ordered log.
+pub struct Producer<T> {
+	inner: Arc<Mutex<Inner>>,
+	_marker: PhantomData<fn(T)>,
+}
+
+impl<T> Clone for Producer<T> {
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<T> Producer<T> {
+	/// Create a subscriber for the underlying track.
+	pub fn consume(&self) -> moq_net::track::Subscriber {
+		self.inner.lock().unwrap().track.subscribe(None)
+	}
+
+	/// The position of the oldest record still in the window: the number of records trimmed over
+	/// the log's lifetime.
+	pub fn offset(&self) -> u64 {
+		self.inner.lock().unwrap().offset
+	}
+
+	/// The number of records currently in the window.
+	pub fn len(&self) -> usize {
+		self.inner.lock().unwrap().window.len()
+	}
+
+	/// Whether the window is empty.
+	pub fn is_empty(&self) -> bool {
+		self.len() == 0
+	}
+}
+
+impl<T: Serialize> Producer<T> {
+	/// Create a producer that publishes to the given track.
+	pub fn new(track: moq_net::track::Producer, config: ProducerConfig) -> Self {
+		Self {
+			inner: Arc::new(Mutex::new(Inner {
+				track,
+				group: None,
+				encoder: None,
+				window: VecDeque::new(),
+				offset: 0,
+				trimmed: 0,
+				frames: 0,
+				config,
+			})),
+			_marker: PhantomData,
+		}
+	}
+
+	/// Append one record to the tail of the window, returning the position it was assigned.
+	pub fn append(&mut self, value: &T) -> Result<u64> {
+		self.inner.lock().unwrap().append(value)
+	}
+
+	/// Remove the oldest `count` records from the head of the window.
+	///
+	/// A `count` of 0 does nothing. Errors if it exceeds the number of records in the window, since
+	/// trimming past the head would desync every consumer's positions.
+	pub fn trim(&mut self, count: usize) -> Result<()> {
+		self.inner.lock().unwrap().trim(count)
+	}
+
+	/// Finish the track, closing any open group.
+	pub fn finish(&mut self) -> Result<()> {
+		self.inner.lock().unwrap().finish()
+	}
+}
+
+/// Shared publishing state behind [`Producer`]'s `Arc<Mutex>`.
+struct Inner {
+	track: moq_net::track::Producer,
+	group: Option<moq_net::group::Producer>,
+	// The open group's DEFLATE encoder (one window per group), `Some` while compressing.
+	encoder: Option<Encoder>,
+	// Every record currently in the window, oldest first, kept so a new group can snapshot it.
+	window: VecDeque<Box<RawValue>>,
+	// The position of `window[0]`: how many records have been trimmed for the log's lifetime.
+	offset: u64,
+	// Records trimmed since the open group's snapshot, the roll trigger.
+	trimmed: usize,
+	frames: usize,
+	config: ProducerConfig,
+}
+
+impl Inner {
+	fn append<T: Serialize>(&mut self, value: &T) -> Result<u64> {
+		let raw = serde_json::value::to_raw_value(value)?;
+		let position = self.offset + self.window.len() as u64;
+		// Refuse to publish a position a consumer would reject: the window would be unreadable.
+		if position >= MAX_POSITION {
+			return Err(Error::Window(format!(
+				"append at position {position} reaches the maximum {MAX_POSITION}"
+			)));
+		}
+		self.window.push_back(raw);
+
+		let published = if self.needs_snapshot() {
+			self.snapshot()
+		} else {
+			// The record was just pushed, so the back is the one to advertise.
+			serde_json::to_vec(&AppendOut {
+				append: self.window.back().expect("just pushed"),
+			})
+			.map_err(Error::from)
+			.and_then(|payload| self.write(payload))
+		};
+
+		match published {
+			Ok(()) => Ok(position),
+			Err(err) => {
+				// A publish that failed (a finished or aborted track) must leave the window as it
+				// was: `offset`, `len`, and the next position all read from it, so keeping a record
+				// nobody received would report a window that does not exist.
+				self.window.pop_back();
+				Err(err)
+			}
+		}
+	}
+
+	fn trim(&mut self, count: usize) -> Result<()> {
+		if count == 0 {
+			return Ok(());
+		}
+		if count > self.window.len() {
+			return Err(Error::Window(format!(
+				"trim of {count} exceeds the {} records in the window",
+				self.window.len()
+			)));
+		}
+
+		let removed: Vec<Box<RawValue>> = self.window.drain(..count).collect();
+		self.offset += count as u64;
+		self.trimmed += count;
+
+		let published = if self.needs_snapshot() {
+			self.snapshot()
+		} else {
+			serde_json::to_vec(&TrimOut { trim: count })
+				.map_err(Error::from)
+				.and_then(|payload| self.write(payload))
+		};
+
+		if let Err(err) = published {
+			// Same rollback as `append`: an unpublished trim must not move the head.
+			self.offset -= count as u64;
+			self.trimmed -= count;
+			for raw in removed.into_iter().rev() {
+				self.window.push_front(raw);
+			}
+			return Err(err);
+		}
+		Ok(())
+	}
+
+	/// Whether the next operation should roll a fresh snapshot group instead.
+	///
+	/// Rolls once the records trimmed since the snapshot outnumber those still in the window: the
+	/// group is then mostly dead weight for a new subscriber, and a fresh snapshot costs no more
+	/// than what has already been trimmed. That bounds the total bytes at roughly twice an
+	/// append-only log.
+	fn needs_snapshot(&self) -> bool {
+		self.group.is_none() || self.frames >= MAX_GROUP_FRAMES || self.trimmed > self.window.len()
+	}
+
+	/// Start a new group whose frame 0 snapshots the whole window.
+	fn snapshot(&mut self) -> Result<()> {
+		let payload = serde_json::to_vec(&SnapshotOut {
+			offset: self.offset,
+			values: &self.window,
+		})?;
+
+		// The previous group is complete; no more frames will be appended to it.
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+
+		let mut group = self.track.append_group()?;
+		let (slice, encoder) = match self.config.compression {
+			true => {
+				let mut encoder = Encoder::new();
+				let slice = encoder.frame(&payload);
+				(slice, Some(encoder))
+			}
+			false => (Bytes::from(payload), None),
+		};
+		group.write_frame(moq_net::Timestamp::now(), slice)?;
+
+		self.group = Some(group);
+		self.encoder = encoder;
+		self.frames = 1;
+		self.trimmed = 0;
+		Ok(())
+	}
+
+	/// Write one operation frame into the open group.
+	fn write(&mut self, payload: Vec<u8>) -> Result<()> {
+		let slice = match self.encoder.as_mut() {
+			Some(encoder) => encoder.frame(&payload),
+			None => Bytes::from(payload),
+		};
+		self.group
+			.as_mut()
+			.expect("needs_snapshot guarantees an open group")
+			.write_frame(moq_net::Timestamp::now(), slice)?;
+		self.frames += 1;
+		Ok(())
+	}
+
+	fn finish(&mut self) -> Result<()> {
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+		self.track.finish()?;
+		Ok(())
+	}
+}
+
+/// One change to the window, yielded by a [`Consumer`].
+///
+/// `#[non_exhaustive]` because the wire format is explicitly extensible: a frame carrying an
+/// operation this revision does not know is ignored rather than rejected, so a later revision can
+/// add one. Match with a wildcard arm and skip what you don't recognize.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum Update<T> {
+	/// A record was appended at the tail.
+	Append {
+		/// The record's position: the count of records ever appended before it.
+		position: u64,
+		/// The record itself.
+		value: T,
+	},
+
+	/// Records were removed from the head; everything before `offset` is gone.
+	Trim {
+		/// The position of the oldest record still in the window.
+		offset: u64,
+	},
+}
+
+/// Reads a sliding window of JSON records from a track, yielding each change in order.
+///
+/// Starts at the newest group's snapshot, so a late joiner sees an [`Update::Append`] per record
+/// currently in the window and then follows along live. Switching to a newer group is lossless:
+/// positions identify what has already been yielded, so records are never repeated.
+///
+/// [`Update::Trim`] only ever retracts records this consumer was told about, so joining a window
+/// that has already trimmed does not report the records it missed. Those show up instead as a
+/// jump in the first [`Update::Append`]'s `position`; whether a gap matters is up to the
+/// application.
+pub struct Consumer<T> {
+	track: moq_net::track::Subscriber,
+	group: Option<moq_net::group::Consumer>,
+	compressed: bool,
+	// The open group's DEFLATE decoder (one window per group), built on its first frame.
+	decoder: Option<Decoder>,
+	// Frames read from the open group; frame 0 is its snapshot.
+	frames: usize,
+	// The position of the next record this consumer has not yielded yet.
+	next: u64,
+	// The head offset already reported through an `Update::Trim`, or `None` until the first
+	// snapshot establishes where this consumer joined.
+	reported: Option<u64>,
+	// The head offset of the group being followed, advanced by its trims.
+	head: u64,
+	// The position one past the last record the group being followed has appended.
+	tail: u64,
+	// Updates decoded but not yet yielded; one poll can decode a whole snapshot.
+	pending: VecDeque<Update<T>>,
+	_marker: PhantomData<fn() -> T>,
+}
+
+impl<T: DeserializeOwned> Consumer<T> {
+	/// Create a consumer reading from the given track subscriber.
+	///
+	/// Set [`ConsumerConfig::compression`] to read a track written by a producer with
+	/// [`ProducerConfig::compression`] on.
+	pub fn new(track: moq_net::track::Subscriber, config: ConsumerConfig) -> Self {
+		Self {
+			track,
+			group: None,
+			compressed: config.compression,
+			decoder: None,
+			frames: 0,
+			next: 0,
+			reported: None,
+			head: 0,
+			tail: 0,
+			pending: VecDeque::new(),
+			_marker: PhantomData,
+		}
+	}
+
+	/// Get the next update, or `None` once the track ends.
+	pub async fn next(&mut self) -> Result<Option<Update<T>>>
+	where
+		T: Unpin,
+	{
+		kio::wait(|waiter| self.poll_next(waiter)).await
+	}
+
+	/// Poll for the next update, without blocking.
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Update<T>>>> {
+		loop {
+			if let Some(update) = self.pending.pop_front() {
+				return Poll::Ready(Ok(Some(update)));
+			}
+
+			// Skip to the newest group; anything older carries nothing it lacks.
+			let track_finished = loop {
+				match self.track.poll_next_group(waiter)? {
+					Poll::Ready(Some(group)) => {
+						self.group = Some(group);
+						self.decoder = None;
+						self.frames = 0;
+					}
+					Poll::Ready(None) => break true,
+					Poll::Pending => break false,
+				}
+			};
+
+			// Decode frames until something is ready to yield, or the group blocks or ends.
+			let mut group_ended = false;
+			let mut group_pending = false;
+			while self.pending.is_empty() {
+				let Some(group) = &mut self.group else { break };
+				match group.poll_read_frame(waiter) {
+					Poll::Ready(Ok(Some(frame))) => self.apply(frame.payload)?,
+					Poll::Ready(Ok(None)) => {
+						// Every group opens with a snapshot, so one that ends cleanly having
+						// delivered nothing is malformed. Treating it as an ordinary end would let
+						// it masquerade as a clean end of track and silently lose the window the
+						// publisher advertised. (A group that *errors* before frame 0 is a different
+						// case: that is a lost group, handled below as a resync.)
+						if self.frames == 0 {
+							return Poll::Ready(Err(Error::Window("a group carried no snapshot".to_string())));
+						}
+						self.group = None;
+						group_ended = true;
+						break;
+					}
+					// The group died under us: evicted, aged out, or read past its cache. Groups
+					// here are self-contained and disposable, so this is a resync point rather than
+					// the end of the track. Failing instead would strand a slow consumer (the HLS
+					// timeline watcher among them) on a track that is still publishing.
+					Poll::Ready(Err(err)) => {
+						tracing::debug!(%err, "window group lost; resyncing from the next snapshot");
+						self.group = None;
+						self.decoder = None;
+						group_ended = true;
+						break;
+					}
+					Poll::Pending => {
+						group_pending = true;
+						break;
+					}
+				}
+			}
+
+			if !self.pending.is_empty() {
+				continue;
+			}
+			// The group ended without yielding anything: loop once more to pick up a newer one.
+			// That poll either finds one or reports Pending, so this can't spin.
+			if group_ended {
+				continue;
+			}
+			// An open group may still deliver frames after the track finishes (it was appended
+			// before), so wait on it rather than ending the stream.
+			if group_pending || !track_finished {
+				return Poll::Pending;
+			}
+			return Poll::Ready(Ok(None));
+		}
+	}
+
+	/// Decompress a frame slice, or pass it through when the track is uncompressed.
+	fn decode(&mut self, slice: Bytes) -> Result<Bytes> {
+		if !self.compressed {
+			return Ok(slice);
+		}
+		let decoder = self.decoder.get_or_insert_with(Decoder::new);
+		Ok(decoder.frame(&slice)?)
+	}
+
+	/// Apply one frame: frame 0 of a group is a snapshot, the rest are operations.
+	fn apply(&mut self, frame: Bytes) -> Result<()> {
+		let frame = self.decode(frame)?;
+		match self.frames {
+			0 => self.apply_snapshot(&frame)?,
+			_ => self.apply_op(&frame)?,
+		}
+		self.frames += 1;
+		Ok(())
+	}
+
+	/// Adopt a group's snapshot, yielding only what this consumer hasn't seen.
+	fn apply_snapshot(&mut self, frame: &[u8]) -> Result<()> {
+		let snapshot: SnapshotIn = serde_json::from_slice(frame)?;
+
+		// A peer picks both the offset and the record count, so bound the whole span, not just the
+		// offset: an in-range offset with enough records still lands the tail past MAX_POSITION and
+		// yields positions the wire format (and a JSON-number receiver) cannot represent. The
+		// checked add also keeps a hostile offset from overflowing u64, which panics in debug and
+		// silently wraps every later position to zero in release.
+		let tail = snapshot
+			.offset
+			.checked_add(snapshot.values.len() as u64)
+			.filter(|tail| *tail <= MAX_POSITION);
+		let Some(tail) = tail else {
+			return Err(Error::Window(format!(
+				"snapshot at offset {} with {} records runs past the maximum position {MAX_POSITION}",
+				snapshot.offset,
+				snapshot.values.len()
+			)));
+		};
+
+		self.head = snapshot.offset;
+		self.tail = tail;
+		self.report_trim();
+
+		for (index, raw) in snapshot.values.into_iter().enumerate() {
+			let position = snapshot.offset + index as u64;
+			// Already yielded from an older group: the position is what makes the switch lossless.
+			if position < self.next {
+				continue;
+			}
+			self.push_append(position, &raw)?;
+		}
+		Ok(())
+	}
+
+	/// Apply one operation frame from the group being followed.
+	fn apply_op(&mut self, frame: &[u8]) -> Result<()> {
+		let op: OpIn = serde_json::from_slice(frame)?;
+
+		// A frame carries at most one operation. Applying both would append and retract in an order
+		// the format never defines, so reject it instead of guessing. A frame carrying *neither* is
+		// not an error: that is how an operation added by a later revision reads here.
+		if op.append.is_some() && op.trim.is_some() {
+			return Err(Error::Window("a frame carries both an append and a trim".to_string()));
+		}
+
+		if let Some(raw) = op.append {
+			let position = self.tail;
+			if position >= MAX_POSITION {
+				return Err(Error::Window(format!(
+					"append at position {position} reaches the maximum {MAX_POSITION}"
+				)));
+			}
+			self.tail += 1;
+			if position >= self.next {
+				self.push_append(position, &raw)?;
+			}
+		}
+
+		if let Some(count) = op.trim {
+			// A peer picks this count, so add with a checked op: `head + count` would otherwise
+			// overflow before the range test could reject it.
+			let count = count as u64;
+			let head = self.head.checked_add(count).filter(|head| *head <= self.tail);
+			let Some(head) = head else {
+				return Err(Error::Window(format!(
+					"trim of {count} exceeds the {} records in the window",
+					self.tail - self.head
+				)));
+			};
+			self.head = head;
+			self.report_trim();
+		}
+
+		Ok(())
+	}
+
+	/// Emit a trim if the followed group's head has moved past what was last reported.
+	///
+	/// A trim says "records you were told about are gone", so the first snapshot only adopts its
+	/// offset: a consumer joining a window that already trimmed never held those records, and
+	/// reporting them would be noise. Later movement is guarded too, since a newer group's snapshot
+	/// repeats a head this consumer already reported.
+	fn report_trim(&mut self) {
+		match self.reported {
+			None => self.reported = Some(self.head),
+			Some(reported) if self.head > reported => {
+				self.reported = Some(self.head);
+				self.pending.push_back(Update::Trim { offset: self.head });
+			}
+			Some(_) => {}
+		}
+	}
+
+	/// Deserialize a record and queue it, advancing the yield cursor past it.
+	fn push_append(&mut self, position: u64, raw: &RawValue) -> Result<()> {
+		let value = serde_json::from_str(raw.get())?;
+		self.next = position + 1;
+		self.pending.push_back(Update::Append { position, value });
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use serde_json::{Value, json};
+
+	fn producer(config: ProducerConfig) -> (Producer<Value>, moq_net::track::Subscriber) {
+		let track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let consumer = track.subscribe(None);
+		(Producer::new(track, config), consumer)
+	}
+
+	fn compressed() -> ProducerConfig {
+		ProducerConfig { compression: true }
+	}
+
+	fn consumer(track: moq_net::track::Subscriber, compression: bool) -> Consumer<Value> {
+		Consumer::new(track, ConsumerConfig { compression })
+	}
+
+	/// Drain every update currently available without blocking.
+	fn drain(mut consumer: Consumer<Value>) -> Vec<Update<Value>> {
+		let waiter = kio::Waiter::noop();
+		let mut out = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			out.push(update);
+		}
+		out
+	}
+
+	/// The records a consumer would hold after applying every update, as (position, value).
+	fn replay(updates: &[Update<Value>]) -> Vec<(u64, Value)> {
+		let mut records: Vec<(u64, Value)> = Vec::new();
+		for update in updates {
+			match update {
+				Update::Append { position, value } => records.push((*position, value.clone())),
+				Update::Trim { offset } => records.retain(|(position, _)| position >= offset),
+			}
+		}
+		records
+	}
+
+	fn append(position: u64, n: i64) -> Update<Value> {
+		Update::Append {
+			position,
+			value: json!({ "n": n }),
+		}
+	}
+
+	#[test]
+	fn appends_carry_positions() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..3 {
+			assert_eq!(producer.append(&json!({ "n": n })).unwrap(), n as u64);
+		}
+		producer.finish().unwrap();
+
+		assert_eq!(
+			drain(consumer(track, false)),
+			vec![append(0, 0), append(1, 1), append(2, 2)]
+		);
+	}
+
+	#[test]
+	fn trim_removes_from_the_head() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..4 {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+		producer.trim(2).unwrap();
+		assert_eq!(producer.offset(), 2);
+		assert_eq!(producer.len(), 2);
+		producer.finish().unwrap();
+
+		// A live consumer sees every append, then the trim.
+		let updates = drain(consumer(track, false));
+		assert_eq!(updates.last().unwrap(), &Update::Trim { offset: 2 });
+		assert_eq!(replay(&updates), vec![(2, json!({ "n": 2 })), (3, json!({ "n": 3 }))]);
+	}
+
+	#[test]
+	fn late_joiner_reads_the_window_not_the_history() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..6 {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+		producer.trim(4).unwrap();
+		producer.finish().unwrap();
+
+		// Only the surviving records, at their original positions: no trace of 0..4.
+		let updates = drain(consumer(track, false));
+		assert_eq!(updates, vec![append(4, 4), append(5, 5)]);
+	}
+
+	#[test]
+	fn a_failed_publish_leaves_the_window_untouched() {
+		// `finish` only borrows, since a `Producer` is a shared handle, so a later append is
+		// expressible. It must fail without moving the window: `offset`, `len`, and the next
+		// position all read from it, so a phantom record would report a window nobody received.
+		let (mut producer, _track) = producer(ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		assert!(matches!(producer.append(&json!({ "n": 2 })), Err(Error::Net(_))));
+		assert_eq!(producer.len(), 2, "a rejected append must not grow the window");
+		assert_eq!(producer.offset(), 0);
+
+		assert!(matches!(producer.trim(1), Err(Error::Net(_))));
+		assert_eq!(producer.len(), 2, "a rejected trim must not shrink the window");
+		assert_eq!(producer.offset(), 0, "a rejected trim must not move the head");
+	}
+
+	#[test]
+	fn trim_past_the_window_is_rejected() {
+		let (mut producer, _track) = producer(ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+		assert!(matches!(producer.trim(2), Err(Error::Window(_))));
+		// A rejected trim leaves the window untouched.
+		assert_eq!(producer.len(), 1);
+		assert_eq!(producer.offset(), 0);
+		// A zero trim is a no-op, not an error.
+		producer.trim(0).unwrap();
+	}
+
+	#[test]
+	fn heavy_trimming_rolls_a_group() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		// A steady sliding window of two records: append, append, then one in/one out.
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		for n in 2..12 {
+			producer.append(&json!({ "n": n })).unwrap();
+			producer.trim(1).unwrap();
+		}
+		producer.finish().unwrap();
+
+		// Trims outgrew the window repeatedly, so the log rolled instead of growing forever.
+		assert!(track.latest().unwrap() > 0, "a trimming window should roll groups");
+
+		// And a late joiner still reads exactly the live window.
+		let updates = drain(consumer(track, false));
+		assert_eq!(
+			replay(&updates),
+			vec![(10, json!({ "n": 10 })), (11, json!({ "n": 11 }))]
+		);
+	}
+
+	#[test]
+	fn frame_cap_rolls_a_group() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..=(MAX_GROUP_FRAMES as i64) {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(1), "the frame cap forces exactly one roll");
+		assert_eq!(drain(consumer(track, false)).len(), MAX_GROUP_FRAMES + 1);
+	}
+
+	#[test]
+	fn a_slow_consumer_converges_after_draining_a_stale_snapshot() {
+		// A snapshot queues its whole window at once, so a consumer can be mid-drain when a newer
+		// group rolls with the head already trimmed. Draining the stale queue first is correct: the
+		// records were real when the snapshot was written, and the newer snapshot's head retracts
+		// them on arrival, so the consumer converges on the live window without losing a record.
+		//
+		// Dropping the queue on the switch instead would lose records outright: `push_append`
+		// advances `next` when it *queues* a record, so the newer snapshot would skip every queued
+		// position as already yielded.
+		let (mut producer, track) = producer(ProducerConfig::default());
+		let waiter = kio::Waiter::noop();
+
+		for n in 0..6 {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+
+		// Join late, so frame 0 is a snapshot that queues the whole window in one go.
+		let mut consumer = consumer(track, false);
+		let first = consumer.poll_next(&waiter);
+		assert!(matches!(
+			first,
+			Poll::Ready(Ok(Some(Update::Append { position: 0, .. })))
+		));
+
+		// Roll a new group behind its back, trimming the head it is still holding queued.
+		for n in 6..12 {
+			producer.append(&json!({ "n": n })).unwrap();
+			producer.trim(1).unwrap();
+		}
+		producer.finish().unwrap();
+
+		let mut seen = vec![Update::Append {
+			position: 0,
+			value: json!({ "n": 0 }),
+		}];
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			seen.push(update);
+		}
+
+		let positions: Vec<u64> = seen
+			.iter()
+			.filter_map(|u| match u {
+				Update::Append { position, .. } => Some(*position),
+				Update::Trim { .. } => None,
+			})
+			.collect();
+
+		let mut sorted = positions.clone();
+		sorted.sort_unstable();
+		sorted.dedup();
+		assert_eq!(positions, sorted, "a position was repeated or went backwards");
+		assert_eq!(positions.first(), Some(&0), "the stale queue must still be delivered");
+		assert_eq!(positions.last(), Some(&11), "the newest record must arrive");
+
+		// And the retractions land, so the consumer ends up holding exactly the live window.
+		let held: Vec<u64> = replay(&seen).into_iter().map(|(position, _)| position).collect();
+		assert_eq!(held, vec![6, 7, 8, 9, 10, 11]);
+	}
+
+	#[test]
+	fn group_roll_is_lossless_for_a_live_consumer() {
+		// A consumer following live must not see a record twice when the producer rolls a group
+		// and re-snapshots the window it already holds.
+		let (mut producer, track) = producer(ProducerConfig::default());
+		let mut consumer = consumer(track, false);
+		let waiter = kio::Waiter::noop();
+
+		let mut seen = Vec::new();
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			seen.push(update);
+		}
+
+		// Force rolls while the consumer keeps up.
+		for n in 2..12 {
+			producer.append(&json!({ "n": n })).unwrap();
+			producer.trim(1).unwrap();
+			while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+				seen.push(update);
+			}
+		}
+		producer.finish().unwrap();
+
+		let positions: Vec<u64> = seen
+			.iter()
+			.filter_map(|u| match u {
+				Update::Append { position, .. } => Some(*position),
+				Update::Trim { .. } => None,
+			})
+			.collect();
+		let mut sorted = positions.clone();
+		sorted.dedup();
+		assert_eq!(positions, sorted, "a roll must not repeat a record: {positions:?}");
+		assert_eq!(positions, (0..12).collect::<Vec<_>>());
+		assert_eq!(replay(&seen), vec![(10, json!({ "n": 10 })), (11, json!({ "n": 11 }))]);
+	}
+
+	#[test]
+	fn late_joiner_sees_a_gap_as_a_position_jump() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		for n in 0..4 {
+			producer.append(&json!({ "n": n })).unwrap();
+		}
+		producer.trim(3).unwrap();
+
+		// Joining now, the first record seen is at position 3: the jump is the gap signal.
+		let updates = drain(consumer(track, false));
+		match updates.first().unwrap() {
+			Update::Append { position, .. } => assert_eq!(*position, 3),
+			other => panic!("expected an append, got {other:?}"),
+		}
+		producer.finish().unwrap();
+	}
+
+	#[test]
+	fn compressed_roundtrip() {
+		let (mut producer, track) = producer(compressed());
+		for n in 0..20 {
+			producer.append(&json!({ "group": n, "pts": n * 2_000 })).unwrap();
+		}
+		producer.trim(15).unwrap();
+		producer.finish().unwrap();
+
+		let updates = drain(consumer(track, true));
+		assert_eq!(replay(&updates).len(), 5);
+		assert_eq!(replay(&updates)[0].0, 15);
+	}
+
+	#[test]
+	fn compressed_window_shrinks_records() {
+		// The shared per-group window is the point: a repetitive record compresses to a fraction of
+		// its raw size once the snapshot has seeded the window.
+		let (mut producer, mut track) = producer(compressed());
+		for n in 0..8 {
+			producer.append(&json!({ "group": n, "pts": n * 2_000 })).unwrap();
+		}
+		producer.finish().unwrap();
+
+		let waiter = kio::Waiter::noop();
+		let Poll::Ready(Ok(Some(mut group))) = track.poll_next_group(&waiter) else {
+			panic!("expected a group");
+		};
+		let mut sizes = Vec::new();
+		while let Poll::Ready(Ok(Some(frame))) = group.poll_read_frame(&waiter) {
+			sizes.push(frame.payload.len());
+		}
+		assert_eq!(sizes.len(), 8, "one snapshot plus seven appends");
+
+		let raw = serde_json::to_vec(&json!({ "append": { "group": 7, "pts": 14_000 } }))
+			.unwrap()
+			.len();
+		assert!(
+			*sizes.last().unwrap() < raw / 2,
+			"windowed record {} should be far below its raw size {raw}",
+			sizes.last().unwrap()
+		);
+	}
+
+	#[test]
+	fn a_null_record_keeps_its_position() {
+		// `null` is a valid JSON record. If it decodes as "no append", the record is lost AND the
+		// tail stalls, shifting every later position. The snapshot path preserves it either way, so
+		// getting this wrong makes a record appear or vanish depending on which frame carried it.
+		let (mut producer, track) = producer(ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&Value::Null).unwrap();
+		producer.append(&json!({ "n": 2 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(
+			drain(consumer(track, false)),
+			vec![
+				append(0, 0),
+				Update::Append {
+					position: 1,
+					value: Value::Null
+				},
+				append(2, 2),
+			]
+		);
+	}
+
+	#[test]
+	fn a_null_record_appended_after_a_roll_keeps_its_position() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		producer.append(&Value::Null).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		producer.trim(1).unwrap();
+		producer.append(&json!({ "n": 2 })).unwrap();
+		// Trims now outnumber the window, so this rolls: the survivors come from a fresh snapshot.
+		producer.trim(1).unwrap();
+		producer.append(&Value::Null).unwrap();
+		producer.finish().unwrap();
+
+		// A late joiner starts at the newest group's snapshot (offset 2), then reads the null as an
+		// append. A stalled tail here would have put the null at position 2, colliding with `n: 2`.
+		assert_eq!(
+			drain(consumer(track, false)),
+			vec![
+				append(2, 2),
+				Update::Append {
+					position: 3,
+					value: Value::Null
+				},
+			]
+		);
+	}
+
+	#[test]
+	fn a_null_record_inside_a_snapshot_decodes() {
+		// The other half of the round trip: a null carried by frame 0 rather than by an append.
+		// Written by hand so the decoder is checked against the byte shape, not just our producer.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		for frame in [r#"{"offset":4,"values":[{"n":4},null,{"n":6}]}"#, r#"{"append":null}"#] {
+			group
+				.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.as_bytes().to_vec()))
+				.unwrap();
+		}
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		assert_eq!(
+			drain(consumer(subscriber, false)),
+			vec![
+				append(4, 4),
+				Update::Append {
+					position: 5,
+					value: Value::Null
+				},
+				append(6, 6),
+				Update::Append {
+					position: 7,
+					value: Value::Null
+				},
+			]
+		);
+	}
+
+	#[test]
+	fn an_out_of_range_snapshot_offset_is_rejected() {
+		// A peer picks the offset. Past MAX_POSITION the tail addition overflows: a debug build
+		// panics and a release build wraps every later position to zero.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		let frame = format!(r#"{{"offset":{},"values":[null]}}"#, u64::MAX);
+		group
+			.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.into_bytes()))
+			.unwrap();
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		match consumer(subscriber, false).poll_next(&kio::Waiter::noop()) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("maximum position"), "{msg}"),
+			other => panic!("expected an out-of-range offset to be rejected, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn a_snapshot_spanning_past_the_limit_is_rejected() {
+		// An in-range offset with enough records still lands the tail past the limit, so the span
+		// has to be checked, not just the offset.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		let frame = format!(r#"{{"offset":{},"values":[{{"n":0}},{{"n":1}}]}}"#, MAX_POSITION);
+		group
+			.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.into_bytes()))
+			.unwrap();
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		match consumer(subscriber, false).poll_next(&kio::Waiter::noop()) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("maximum position"), "{msg}"),
+			other => panic!("expected an out-of-range span to be rejected, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn a_group_with_no_snapshot_is_rejected() {
+		// A group that ends cleanly having carried nothing is malformed: every group opens with a
+		// snapshot. Reporting it as a clean end would lose the window the publisher advertised.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		track.append_group().unwrap().finish().unwrap();
+		track.finish().unwrap();
+
+		match consumer(subscriber, false).poll_next(&kio::Waiter::noop()) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("no snapshot"), "{msg}"),
+			other => panic!("expected an empty group to be rejected, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn a_lost_group_resyncs_instead_of_ending_the_stream() {
+		// Groups here are self-contained and disposable, so one dying under a slow consumer is a
+		// resync point, not the end of the track. Failing would strand the HLS timeline watcher on
+		// a track that is still publishing.
+		let (mut producer, track) = producer(ProducerConfig::default());
+		let mut consumer = consumer(track, false);
+		let waiter = kio::Waiter::noop();
+
+		producer.append(&json!({ "n": 0 })).unwrap();
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(update))) => assert_eq!(update, append(0, 0)),
+			other => panic!("expected the first record, got {other:?}"),
+		}
+
+		// Kill the group the consumer is parked on, the way cache eviction does.
+		producer
+			.inner
+			.lock()
+			.unwrap()
+			.group
+			.take()
+			.expect("a group is open")
+			.abort(moq_net::Error::Evicted)
+			.unwrap();
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending), "not an error");
+
+		// The publisher rolls a fresh snapshot group and the consumer picks up from it.
+		producer.append(&json!({ "n": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		let mut seen = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			seen.push(update);
+		}
+		assert_eq!(seen, vec![append(1, 1)], "resynced from the next snapshot");
+	}
+
+	#[test]
+	fn an_overflowing_trim_is_rejected() {
+		// Same for the trim count: `head + count` must not wrap before the range test sees it.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		for frame in [
+			r#"{"offset":0,"values":[{"n":0}]}"#.to_string(),
+			format!(r#"{{"trim":{}}}"#, u64::MAX),
+		] {
+			group
+				.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.into_bytes()))
+				.unwrap();
+		}
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		let mut consumer = consumer(subscriber, false);
+		let waiter = kio::Waiter::noop();
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(update))) => assert_eq!(update, append(0, 0)),
+			other => panic!("expected the snapshot record, got {other:?}"),
+		}
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("exceeds"), "{msg}"),
+			other => panic!("expected an overflowing trim to be rejected, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn a_frame_carrying_both_operations_is_rejected() {
+		// Applying both would append and retract in an order the format never defines, so it is
+		// malformed rather than something to guess at. A frame carrying *neither* stays a no-op:
+		// that is how a future operation reads here.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut group = track.append_group().unwrap();
+		for frame in [r#"{"offset":0,"values":[{"n":0}]}"#, r#"{"append":{"n":1},"trim":1}"#] {
+			group
+				.write_frame(moq_net::Timestamp::ZERO, Bytes::from(frame.as_bytes().to_vec()))
+				.unwrap();
+		}
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		let mut consumer = consumer(subscriber, false);
+		let waiter = kio::Waiter::noop();
+		// The snapshot record lands first, then the malformed frame surfaces.
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(update))) => assert_eq!(update, append(0, 0)),
+			other => panic!("expected the snapshot record, got {other:?}"),
+		}
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Err(Error::Window(msg))) => assert!(msg.contains("both"), "{msg}"),
+			other => panic!("expected a malformed-frame error, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn unknown_operation_is_ignored() {
+		// A frame carrying neither key is a forward-compatible extension, not an error.
+		let track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut producer = Producer::<Value>::new(track, ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+
+		// Write a future operation directly into the open group.
+		producer
+			.inner
+			.lock()
+			.unwrap()
+			.write(serde_json::to_vec(&json!({ "rewind": 1 })).unwrap())
+			.unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(drain(consumer(subscriber, false)), vec![append(0, 0), append(1, 1)]);
+	}
+
+	#[test]
+	fn empty_window_snapshots_cleanly() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.trim(1).unwrap();
+		assert!(producer.is_empty());
+		// The offset is preserved across an empty window, so positions keep counting.
+		assert_eq!(producer.offset(), 1);
+		assert_eq!(producer.append(&json!({ "n": 1 })).unwrap(), 1);
+		producer.finish().unwrap();
+
+		assert_eq!(drain(consumer(track, false)), vec![append(1, 1)]);
+	}
+
+	#[test]
+	fn a_trim_retracts_what_was_yielded() {
+		// A consumer told about a record is told when it goes away. (The converse, that a consumer
+		// which never held the record gets no trim, is what `late_joiner_reads_the_window_not_the
+		// _history` asserts: after a roll the snapshot starts past those records.)
+		let (mut producer, track) = producer(ProducerConfig::default());
+		let mut live = consumer(track, false);
+		let waiter = kio::Waiter::noop();
+
+		producer.append(&json!({ "n": 0 })).unwrap();
+		producer.append(&json!({ "n": 1 })).unwrap();
+		let mut seen = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = live.poll_next(&waiter) {
+			seen.push(update);
+		}
+		assert_eq!(seen, vec![append(0, 0), append(1, 1)]);
+
+		producer.trim(1).unwrap();
+		producer.finish().unwrap();
+		while let Poll::Ready(Ok(Some(update))) = live.poll_next(&waiter) {
+			seen.push(update);
+		}
+		assert_eq!(seen.last().unwrap(), &Update::Trim { offset: 1 });
+		assert_eq!(replay(&seen), vec![(1, json!({ "n": 1 }))]);
+	}
+
+	#[test]
+	fn open_group_pends_after_track_finish() {
+		// A group appended before the track finishes may still deliver frames, so the consumer
+		// must keep waiting on it rather than ending the stream.
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let mut group = track.append_group().unwrap();
+		let subscriber = track.subscribe(None);
+		track.finish().unwrap();
+
+		let mut consumer = consumer(subscriber, false);
+		let waiter = kio::Waiter::noop();
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
+
+		let snapshot = json!({ "offset": 0, "values": [{ "n": 7 }] });
+		group
+			.write_frame(
+				moq_net::Timestamp::ZERO,
+				Bytes::from(serde_json::to_vec(&snapshot).unwrap()),
+			)
+			.unwrap();
+		group.finish().unwrap();
+
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(update))) => assert_eq!(update, append(0, 7)),
+			other => panic!("expected the snapshot record, got {other:?}"),
+		}
+	}
+}

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }
 tracing = "0.1"
 url = "2"
+web-async = { workspace = true }
 webm-iterable = "0.6"
 
 [dev-dependencies]

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -296,7 +296,7 @@ impl<E: CatalogExt> Producer<E> {
 		track: moq_net::track::Producer,
 		container: C,
 	) -> crate::Result<crate::container::Producer<C>> {
-		let recorder = self.enroll(track.name())?;
+		let recorder = self.enroll(&track)?;
 		Ok(crate::container::Producer::new(track, container).with_recorder(recorder))
 	}
 
@@ -306,7 +306,7 @@ impl<E: CatalogExt> Producer<E> {
 	/// [`media_producer`](Self::media_producer) calls this for you; call it directly for a track
 	/// that isn't built through a [`container::Producer`](crate::container::Producer) (an fMP4
 	/// passthrough writing groups by hand).
-	pub fn enroll(&mut self, track: &str) -> crate::Result<crate::timeline::Recorder> {
+	pub fn enroll(&mut self, track: &moq_net::track::Producer) -> crate::Result<crate::timeline::Recorder> {
 		let recorder = self.timeline.track(track)?;
 
 		let section = self.timeline.section();
@@ -674,7 +674,8 @@ mod test {
 
 		// Something else already took the name the timeline track wants.
 		let _taken = broadcast.create_track(hang::timeline::DEFAULT_NAME, None).unwrap();
-		assert!(catalog.enroll("video0").is_err());
+		let video = broadcast.create_track("video0", None).unwrap();
+		assert!(catalog.enroll(&video).is_err());
 	}
 
 	#[test]
@@ -685,7 +686,8 @@ mod test {
 		// A broadcast that never segments never advertises a timeline.
 		assert_eq!(catalog.snapshot().timeline, None);
 
-		let _recorder = catalog.enroll("video0").unwrap();
+		let video = broadcast.create_track("video0", None).unwrap();
+		let _recorder = catalog.enroll(&video).unwrap();
 		assert_eq!(
 			catalog.snapshot().timeline,
 			Some(catalog.timeline().section()),

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -564,7 +564,8 @@ mod tests {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut catalog = super::super::Producer::new(&mut broadcast).unwrap();
 
-		let _recorder = catalog.enroll("video0").unwrap();
+		let video = broadcast.create_track("video0", None).unwrap();
+		let _recorder = catalog.enroll(&video).unwrap();
 		let timeline = catalog.timeline();
 		assert_eq!(timeline.section().track, hang::timeline::DEFAULT_NAME);
 		assert_eq!(

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -305,7 +305,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			// (no `container::Producer`), so the recorder is fed directly at each group open.
 			// Enrolling on the timeline directly rather than through `catalog::Producer::enroll`,
 			// because the catalog is already locked here; the root section is advertised below.
-			let recorder = timeline.track(track.name())?;
+			let recorder = timeline.track(&track)?;
 
 			let detect_bitrate = match kind {
 				TrackKind::Video => {

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -363,11 +363,13 @@ async fn import_populates_the_broadcast_timeline() {
 	catalog.finish().unwrap();
 
 	// The first record indexes both renditions from their first group (sequence 0).
-	let first = timeline
-		.next()
-		.await
-		.unwrap()
-		.expect("a segment should be recorded in the timeline");
+	let first = appended(
+		timeline
+			.next()
+			.await
+			.unwrap()
+			.expect("a segment should be recorded in the timeline"),
+	);
 	assert_eq!(first.segment, 0);
 	let video_ranges = first.tracks.get(&video_name).expect("video is indexed");
 	assert_eq!(video_ranges[0].start, 0, "the first video group is sequence 0");
@@ -379,6 +381,17 @@ async fn import_populates_the_broadcast_timeline() {
 
 fn scale() -> moq_net::Timescale {
 	moq_net::Timescale::new(1_000_000).unwrap()
+}
+
+/// The segment an update appends, failing on a retraction.
+///
+/// These imports run in well under the tracks' retention window, so the timeline never trims;
+/// one appearing here would mean the window expired against the wall clock mid-test.
+fn appended(update: crate::timeline::Update) -> crate::timeline::Entry {
+	match update {
+		crate::timeline::Update::Append(entry) => entry,
+		other => panic!("expected an appended segment, got {other:?}"),
+	}
 }
 
 fn info(track_id: u32, timescale: moq_net::Timescale, sequence_number: u32) -> super::FragmentInfo {
@@ -658,8 +671,8 @@ async fn segmented_source_indexes_one_group_range_per_track() {
 	catalog.finish().unwrap();
 
 	let mut records = Vec::new();
-	while let Some(record) = timeline.next().await.unwrap() {
-		records.push(record);
+	while let Some(update) = timeline.next().await.unwrap() {
+		records.push(appended(update));
 	}
 	assert_eq!(records.len(), 3, "one record per declared segment");
 
@@ -740,7 +753,8 @@ async fn segment_ranges_with_skew(
 	catalog.finish().unwrap();
 
 	let mut out = Vec::new();
-	while let Some(record) = timeline.next().await.unwrap() {
+	while let Some(update) = timeline.next().await.unwrap() {
+		let record = appended(update);
 		out.push((
 			record.tracks.get(&video_name).cloned().unwrap_or_default(),
 			record.tracks.get(&audio_name).cloned().unwrap_or_default(),

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -36,16 +36,36 @@
 //! [`hang::catalog::Timeline`] section. A broadcast that never enrolls a track publishes no
 //! timeline at all: segmentation is opt-in per broadcast, never per track.
 //!
+//! ## The timeline slides
+//!
+//! It indexes what the publisher can still *serve*, not everything it ever published. A record
+//! is retracted once the groups behind it reach their track's
+//! [`latency_max`](moq_net::track::Info::latency_max), which is why [`Producer::track`] takes
+//! the track itself: reading the window from the same place the track declares it leaves nothing
+//! for a caller to duplicate and get wrong. A segment covers every enrolled track, so the
+//! earliest deadline among the groups it names bounds it, and tracks with different retention
+//! need no special rule.
+//!
+//! The retraction *leads* the eviction it predicts. moq-net keeps a group for `latency_max` plus
+//! a grace period, so a consumer that acts on the last record it saw still finds the media when
+//! its FETCH lands a round trip later. Both sweeps run as content is written, so a publisher
+//! that stalls stops trimming and stops evicting together, with no timer on either side.
+//!
 //! On the read side, [`Consumer::subscribe`] reads the timeline straight from the catalog's
 //! [`hang::catalog::Timeline`] section (so the track name and timescale can't be mismatched)
-//! and yields decoded [`Entry`]s. On the wire the track is a DEFLATE-compressed
-//! [`moq_json::stream`] (a single group, one record per frame; see [`hang::timeline`] for the
-//! record schema).
+//! and yields [`Update`]s: a decoded [`Entry`] per segment that becomes available, and a
+//! retraction as older ones expire. A late joiner sees the live window rather than the whole
+//! broadcast. On the wire the track is a DEFLATE-compressed [`moq_json::window`] (see
+//! [`hang::timeline`] for the record schema).
 
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
 use std::time::{Duration, SystemTime};
+
+// The same clock moq-net's own age eviction runs on, so the two agree (and a test that pauses
+// time moves both). `std::time::Instant` would drift from it under wasm and under a test clock.
+use web_async::time::Instant;
 
 use hang::catalog::Timeline;
 use hang::timeline::{DEFAULT_NAME, Range, Record, RecordExt};
@@ -104,17 +124,34 @@ impl Default for Config {
 	}
 }
 
+/// One group open reported by a track and not yet flushed into a record.
+struct Pending {
+	/// The group's sequence, as used by FETCH/SUBSCRIBE on the media track.
+	sequence: u64,
+	/// Where the group starts.
+	pts: Timestamp,
+	/// Whether its first frame is a keyframe.
+	keyframe: bool,
+	/// When the report arrived, which is when the publisher created the group. The clock the
+	/// group's cache lifetime runs on, and therefore the clock its record's does too.
+	reported: Instant,
+}
+
 /// One enrolled track's report state.
-#[derive(Default)]
 struct TrackState {
-	/// Group opens reported and not yet flushed into a record: (sequence, pts, keyframe).
-	pending: VecDeque<(u64, Timestamp, bool)>,
+	/// Group opens reported and not yet flushed into a record.
+	pending: VecDeque<Pending>,
 	/// The newest reported timestamp: everything earlier is known, which is what lets a
 	/// segment ending at or before it flush. Advanced by a group open (the group starts there)
 	/// and by [`Recorder::end`] (the content stops there).
 	frontier: Option<Timestamp>,
 	/// The recorder was dropped; this track no longer paces boundaries or gates completeness.
 	closed: bool,
+	/// How long this track's publisher guarantees to keep a group cached
+	/// ([`moq_net::track::Info::latency_max`]), read at enrollment. A segment's record is
+	/// retracted once the groups behind it pass this, so the timeline never lists content that
+	/// can't be fetched.
+	latency_max: Duration,
 }
 
 impl TrackState {
@@ -123,7 +160,7 @@ impl TrackState {
 	fn candidate(&self, threshold: u128) -> Option<Timestamp> {
 		self.pending
 			.iter()
-			.map(|&(_, pts, _)| pts)
+			.map(|p| p.pts)
 			.find(|pts| pts.as_micros() >= threshold)
 	}
 }
@@ -134,7 +171,10 @@ struct State {
 	/// Retained so the timeline track can be created when the first media track enrolls.
 	broadcast: moq_net::broadcast::Producer,
 	/// The timeline track, created by the first [`Producer::track`] call.
-	sink: Option<moq_json::stream::Producer<Record>>,
+	sink: Option<moq_json::window::Producer<Record>>,
+	/// When each record still in the window stops being fetchable, oldest first. One entry per
+	/// record the sink holds, so [`State::sweep`] can trim the head without decoding anything.
+	expiry: VecDeque<Instant>,
 	/// Where the open (unflushed) segment starts; `None` until the first report.
 	start: Option<Timestamp>,
 	/// Explicit [`Producer::cut`] boundaries not yet reached, in order.
@@ -163,7 +203,12 @@ impl State {
 		let Some(track) = self.tracks.get_mut(name) else {
 			return;
 		};
-		track.pending.push_back((sequence, pts, keyframe));
+		track.pending.push_back(Pending {
+			sequence,
+			pts,
+			keyframe,
+			reported: Instant::now(),
+		});
 		self.advance(name, pts);
 	}
 
@@ -205,6 +250,10 @@ impl State {
 	/// `finished` is the terminal pass: no track will report again, so a track that never
 	/// reached a boundary stops voting instead of holding the timeline open forever.
 	fn pump(&mut self, finished: bool) {
+		// Retract before publishing: a reservation withholds records that don't exist yet, it
+		// doesn't resurrect ones whose content is gone.
+		self.sweep();
+
 		// With nothing enrolled there is nothing to describe. A record is immutable once
 		// published, so a caller that knows more tracks are still enrolling withholds it (see
 		// [`Producer::reserve`]), and an overrun has already broken the catalog's promise.
@@ -346,20 +395,30 @@ impl State {
 		let mut record = Record::new(self.next_segment, pts, duration);
 		self.next_segment += 1;
 
+		// When this record stops being true. A consumer fetches a segment whole, so the first
+		// group to leave its publisher's cache breaks the segment as thoroughly as any other:
+		// the deadline is the earliest across every group the record names, which is what makes
+		// tracks with different retention fall out rather than need a rule.
+		let mut expiry: Option<Instant> = None;
+
 		for (name, track) in &mut self.tracks {
 			let mut ranges: Vec<Range> = Vec::new();
-			while let Some(&(sequence, group_pts, keyframe)) = track.pending.front() {
-				if end.is_some_and(|end| group_pts.as_micros() >= end.as_micros()) {
+			while let Some(pending) = track.pending.front() {
+				if end.is_some_and(|end| pending.pts.as_micros() >= end.as_micros()) {
 					break;
 				}
-				track.pending.pop_front();
+				let pending = track.pending.pop_front().expect("just peeked");
+
+				let deadline = pending.reported + track.latency_max;
+				expiry = Some(expiry.map_or(deadline, |e: Instant| e.min(deadline)));
+
 				match ranges.last_mut() {
 					// Contiguous sequences extend the run; a skip starts a new range (a gap:
 					// groups that never existed).
-					Some(last) if last.end + 1 == sequence => last.end = sequence,
+					Some(last) if last.end + 1 == pending.sequence => last.end = pending.sequence,
 					_ => {
-						let mut range = Range::new(sequence, sequence);
-						range.keyframe = keyframe;
+						let mut range = Range::new(pending.sequence, pending.sequence);
+						range.keyframe = pending.keyframe;
 						ranges.push(range);
 					}
 				}
@@ -369,7 +428,41 @@ impl State {
 			}
 		}
 
-		self.emit(record);
+		// A record naming no groups describes a span with no content, so nothing can evict out
+		// from under it; keep it for as long as the shortest window any enrolled track declares,
+		// so a gap doesn't outlive the segments around it.
+		let expiry = expiry.unwrap_or_else(|| {
+			let shortest = self.tracks.values().map(|t| t.latency_max).min().unwrap_or_default();
+			Instant::now() + shortest
+		});
+
+		self.emit(record, expiry);
+	}
+
+	/// Retract every record whose content has left the publisher's cache.
+	///
+	/// Driven by the same reports that drive publishing, which is also what drives moq-net's own
+	/// age eviction (it sweeps as groups are committed), so the two stay in phase without a timer:
+	/// a publisher that stalls stops trimming and stops evicting together.
+	///
+	/// The retraction leads the eviction it predicts, because moq-net keeps a group for
+	/// `latency_max` plus a grace period. A consumer that acts on the last record it saw for a
+	/// segment therefore still finds the groups when its FETCH lands.
+	fn sweep(&mut self) {
+		let now = Instant::now();
+		let expired = self.expiry.iter().take_while(|&&deadline| deadline <= now).count();
+		if expired == 0 {
+			return;
+		}
+		self.expiry.drain(..expired);
+
+		let Some(sink) = self.sink.as_mut() else {
+			return;
+		};
+		if let Err(err) = sink.trim(expired) {
+			tracing::warn!(%err, "timeline trim failed; dropping the timeline track");
+			self.sink = None;
+		}
 	}
 
 	/// A duration in the wire timescale's units, rounded up so a bound never understates itself.
@@ -381,14 +474,16 @@ impl State {
 	///
 	/// The timeline is an optional sidecar, so a transport failure logs and stops publishing
 	/// rather than tearing down the media path.
-	fn emit(&mut self, record: Record) {
+	fn emit(&mut self, record: Record, expiry: Instant) {
 		let Some(sink) = self.sink.as_mut() else {
 			return;
 		};
 		if let Err(err) = sink.append(&record) {
 			tracing::warn!(%err, "timeline publish failed; dropping the timeline track");
 			self.sink = None;
+			return;
 		}
+		self.expiry.push_back(expiry);
 	}
 
 	/// The terminal flush: publish what the media finalized, then the open tail.
@@ -461,6 +556,7 @@ impl Producer {
 				config,
 				broadcast: broadcast.clone(),
 				sink: None,
+				expiry: VecDeque::new(),
 				start: None,
 				cuts: VecDeque::new(),
 				manual: false,
@@ -473,30 +569,44 @@ impl Producer {
 		}
 	}
 
-	/// Enroll the media track `name`, returning the [`Recorder`] it reports through.
+	/// Enroll `track`, returning the [`Recorder`] its group opens are reported through.
 	///
-	/// The segment records key ranges by this name, and the track paces boundaries and gates
-	/// completeness until its recorder drops. Enroll a track when it is about to produce: an
-	/// enrolled but silent track holds every record back, by design, since a segment isn't
-	/// complete until every track's content is known. One recorder per track: enrolling the
-	/// same name again resets its state.
+	/// The segment records key ranges by the track's name, and the track paces boundaries and
+	/// gates completeness until its recorder drops. Enroll a track when it is about to produce:
+	/// an enrolled but silent track holds every record back, by design, since a segment isn't
+	/// complete until every track's content is known. One recorder per track: enrolling the same
+	/// name again resets its state.
+	///
+	/// Takes the whole track rather than its name so the timeline reads its
+	/// [`latency_max`](moq_net::track::Info::latency_max) from the same place, which is how long
+	/// a record about it stays true. Passing a name could name a track whose window is something
+	/// else entirely, and the timeline would advertise segments nobody can fetch.
 	///
 	/// Creates the timeline track on first use, which errors if the broadcast can't (something
 	/// else already took the name).
-	pub fn track(&self, name: &str) -> crate::Result<Recorder> {
+	pub fn track(&self, track: &moq_net::track::Producer) -> crate::Result<Recorder> {
 		let mut state = self.state.lock().unwrap();
 
 		if state.sink.is_none() && state.overrun.is_none() {
 			let net = state.broadcast.create_track(DEFAULT_NAME, None)?;
-			let config = moq_json::stream::ProducerConfig::default().with_compression(true);
-			state.sink = Some(moq_json::stream::Producer::new(net, config));
+			let config = moq_json::window::ProducerConfig::default().with_compression(true);
+			state.sink = Some(moq_json::window::Producer::new(net, config));
 		}
 
-		state.tracks.insert(name.to_string(), TrackState::default());
+		let name = track.name().to_string();
+		state.tracks.insert(
+			name.clone(),
+			TrackState {
+				pending: VecDeque::new(),
+				frontier: None,
+				closed: false,
+				latency_max: track.info().latency_max,
+			},
+		);
 
 		Ok(Recorder {
 			state: self.state.clone(),
-			name: name.to_string(),
+			name,
 		})
 	}
 
@@ -670,12 +780,43 @@ pub struct Entry<E: RecordExt = ()> {
 	pub ext: E,
 }
 
-/// Reads a broadcast's timeline, yielding decoded [`Entry`]s in segment order.
+/// One change to the timeline: a segment became available, or older ones stopped being.
 ///
-/// Generic over the record extension `E` (see [`RecordExt`]).
+/// The timeline is a sliding window over what the publisher can still serve, not a log of
+/// everything it ever published, so a reader has to be told about both ends. An exporter that
+/// only handles [`Append`](Self::Append) builds a playlist that grows forever and advertises
+/// segments whose media is long gone.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum Update<E: RecordExt = ()> {
+	/// A segment became available, in segment order.
+	Append(Entry<E>),
+
+	/// Every segment before `segment` has left the publisher's cache and can no longer be
+	/// fetched. Retracts only segments this consumer was told about.
+	Trim {
+		/// The oldest segment still available.
+		segment: u64,
+	},
+}
+
+/// Reads a broadcast's timeline, yielding each [`Update`] in order.
+///
+/// The timeline slides: a late joiner sees an [`Update::Append`] per segment currently available
+/// and then follows along live, with [`Update::Trim`] as the old ones expire. Generic over the
+/// record extension `E` (see [`RecordExt`]).
 pub struct Consumer<E: RecordExt = ()> {
-	inner: moq_json::stream::Consumer<Record<E>>,
+	inner: moq_json::window::Consumer<Record<E>>,
 	timescale: Timescale,
+	/// The `(position, segment)` of every record yielded and not yet retracted, oldest first.
+	///
+	/// The window counts in positions and the timeline speaks segment numbers. They advance
+	/// together but need not coincide: a consumer joining a window that already trimmed starts
+	/// at a nonzero position, and the publisher numbers segments from its own start.
+	live: VecDeque<(u64, u64)>,
+	/// One past the newest segment yielded: what a trim that empties the window reports, since
+	/// there is no oldest record left to name.
+	next_segment: u64,
 }
 
 impl<E: RecordExt> Consumer<E> {
@@ -687,43 +828,66 @@ impl<E: RecordExt> Consumer<E> {
 	pub async fn subscribe(broadcast: &moq_net::broadcast::Consumer, section: &Timeline) -> crate::Result<Self> {
 		let track = broadcast.track(&section.track)?.subscribe(None).await?;
 
-		let config = moq_json::stream::ConsumerConfig::default().with_compression(true);
+		let config = moq_json::window::ConsumerConfig::default().with_compression(true);
 
 		Ok(Self {
-			inner: moq_json::stream::Consumer::new(track, config),
+			inner: moq_json::window::Consumer::new(track, config),
 			timescale: Timescale::new(section.timescale as u64)
 				.map_err(|_| crate::Error::InvalidTimescale(section.timescale))?,
+			live: VecDeque::new(),
+			next_segment: 0,
 		})
 	}
 
-	/// Decode a record into an entry, converting its timing out of the wire timescale.
+	/// Translate a window update into a timeline one, converting timing out of the wire timescale.
 	///
 	/// A pts the timescale can't represent is an error rather than a substituted value: silently
 	/// moving a timestamp would misdirect seeking and live-edge logic.
-	fn decode(&self, record: Record<E>) -> crate::Result<Entry<E>> {
-		let scale = self.timescale.as_u64() as u128;
-		let nanos = (record.duration as u128) * 1_000_000_000 / scale;
-		Ok(Entry {
-			segment: record.segment,
-			pts: Timestamp::new(record.pts, self.timescale)?,
-			duration: Duration::from_nanos(nanos as u64),
-			tracks: record.tracks,
-			ext: record.ext,
-		})
+	fn decode(&mut self, update: moq_json::window::Update<Record<E>>) -> crate::Result<Update<E>> {
+		match update {
+			moq_json::window::Update::Append { position, value } => {
+				let scale = self.timescale.as_u64() as u128;
+				let nanos = (value.duration as u128) * 1_000_000_000 / scale;
+				let entry = Entry {
+					segment: value.segment,
+					pts: Timestamp::new(value.pts, self.timescale)?,
+					duration: Duration::from_nanos(nanos as u64),
+					tracks: value.tracks,
+					ext: value.ext,
+				};
+				self.live.push_back((position, entry.segment));
+				self.next_segment = entry.segment.saturating_add(1);
+				Ok(Update::Append(entry))
+			}
+			moq_json::window::Update::Trim { offset } => {
+				while self.live.front().is_some_and(|&(position, _)| position < offset) {
+					self.live.pop_front();
+				}
+				// The window retracts positions and callers think in segments. With the window
+				// emptied there is no oldest record to name, so the next segment the publisher
+				// appends is the bound: it is the next one this consumer will be told about.
+				let segment = self.live.front().map_or(self.next_segment, |&(_, segment)| segment);
+				Ok(Update::Trim { segment })
+			}
+			// The window's update kinds are `#[non_exhaustive]`. One this build doesn't know says
+			// something about availability that it can't translate into a segment fact, and
+			// guessing would leave the reader's view of the timeline quietly wrong.
+			_ => Err(moq_json::Error::Window("unsupported window update".to_string()).into()),
+		}
 	}
 
-	/// Get the next entry, or `None` once the track ends.
-	pub async fn next(&mut self) -> crate::Result<Option<Entry<E>>> {
+	/// Get the next update, or `None` once the track ends.
+	pub async fn next(&mut self) -> crate::Result<Option<Update<E>>> {
 		match self.inner.next().await? {
-			Some(record) => Ok(Some(self.decode(record)?)),
+			Some(update) => Ok(Some(self.decode(update)?)),
 			None => Ok(None),
 		}
 	}
 
-	/// Poll for the next entry, without blocking.
-	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<crate::Result<Option<Entry<E>>>> {
+	/// Poll for the next update, without blocking.
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<crate::Result<Option<Update<E>>>> {
 		match self.inner.poll_next(waiter)? {
-			Poll::Ready(Some(record)) => Poll::Ready(self.decode(record).map(Some)),
+			Poll::Ready(Some(update)) => Poll::Ready(self.decode(update).map(Some)),
 			Poll::Ready(None) => Poll::Ready(Ok(None)),
 			Poll::Pending => Poll::Pending,
 		}
@@ -757,21 +921,51 @@ mod test {
 		}
 	}
 
-	/// Drain a finished timeline track by subscribing to the producer's advertised section.
-	async fn drain(broadcast: &moq_net::broadcast::Producer, producer: &Producer) -> Vec<Entry> {
+	/// Drain every update a fresh subscriber sees on the producer's advertised section.
+	async fn drain_updates(broadcast: &moq_net::broadcast::Producer, producer: &Producer) -> Vec<Update> {
 		let mut consumer = Consumer::subscribe(&broadcast.consume(), &producer.section())
 			.await
 			.unwrap();
 		let waiter = kio::Waiter::noop();
 		let mut out = Vec::new();
-		while let Poll::Ready(Ok(Some(entry))) = consumer.poll_next(&waiter) {
-			out.push(entry);
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			out.push(update);
 		}
 		out
 	}
 
+	/// The segments a fresh subscriber can see, which for a window is what is still fetchable
+	/// rather than everything ever published.
+	async fn drain(broadcast: &moq_net::broadcast::Producer, producer: &Producer) -> Vec<Entry> {
+		drain_updates(broadcast, producer)
+			.await
+			.into_iter()
+			.filter_map(|update| match update {
+				Update::Append(entry) => Some(entry),
+				_ => None,
+			})
+			.collect()
+	}
+
 	fn setup() -> (moq_net::broadcast::Producer, Producer) {
 		setup_with(Config::default())
+	}
+
+	/// Mint a media track on the broadcast and enroll it, at moq-net's default retention.
+	fn enroll(broadcast: &moq_net::broadcast::Producer, timeline: &Producer, name: &str) -> Recorder {
+		enroll_with(broadcast, timeline, name, None)
+	}
+
+	/// Same, with explicit track info: the timeline reads its retention from the track, so this is
+	/// how a test gives one track a shorter (or longer) window than another.
+	fn enroll_with(
+		broadcast: &moq_net::broadcast::Producer,
+		timeline: &Producer,
+		name: &str,
+		info: impl Into<Option<moq_net::track::Info>>,
+	) -> Recorder {
+		let track = broadcast.clone().create_track(name, info).unwrap();
+		timeline.track(&track).unwrap()
 	}
 
 	fn setup_with(config: Config) -> (moq_net::broadcast::Producer, Producer) {
@@ -784,8 +978,8 @@ mod test {
 	#[tokio::test]
 	async fn the_coarsest_track_paces_the_segments() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
+		let mut audio = enroll(&broadcast, &timeline, "audio0");
 
 		// Video keyframes every 2s, audio groups every 500ms, minimum 1s.
 		video.record(0, ms(0), true);
@@ -819,7 +1013,7 @@ mod test {
 	#[tokio::test]
 	async fn a_gop_longer_than_the_minimum_is_one_segment() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(30_000), true);
@@ -843,7 +1037,7 @@ mod test {
 			duration_min: Duration::from_millis(1_500),
 			..Default::default()
 		});
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut audio = enroll(&broadcast, &timeline, "audio0");
 
 		for seq in 0..8u64 {
 			audio.record(seq, ms(seq * 500), true);
@@ -862,8 +1056,8 @@ mod test {
 	#[tokio::test]
 	async fn a_segment_waits_for_every_track() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
+		let mut audio = enroll(&broadcast, &timeline, "audio0");
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
@@ -886,7 +1080,7 @@ mod test {
 	#[tokio::test]
 	async fn explicit_cuts_override_the_pacing() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 
 		// Keyframes every second, cut every three: the segments follow the cuts, not the GOPs.
 		timeline.cut(ms(3_000)).unwrap();
@@ -907,7 +1101,7 @@ mod test {
 	#[tokio::test]
 	async fn a_cut_below_the_minimum_is_ignored() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 
 		video.record(0, ms(0), true);
 		timeline.cut(ms(2_000)).unwrap();
@@ -936,7 +1130,7 @@ mod test {
 			duration_max: Some(Duration::from_secs(3)),
 			..Default::default()
 		});
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 
 		let mut consumer = {
 			video.record(0, ms(0), true);
@@ -960,8 +1154,8 @@ mod test {
 		// catalog did not, and the track ended there.
 		let waiter = kio::Waiter::noop();
 		let mut entries = Vec::new();
-		while let Poll::Ready(Ok(Some(entry))) = consumer.poll_next(&waiter) {
-			entries.push(entry);
+		while let Poll::Ready(Ok(Some(Update::Append(appended)))) = consumer.poll_next(&waiter) {
+			entries.push(appended);
 		}
 		assert_eq!(entries, vec![entry(0, 0, 2_000, &[("video0", &[(0, 0)])])]);
 	}
@@ -983,7 +1177,7 @@ mod test {
 	#[tokio::test]
 	async fn the_final_segment_runs_to_the_reported_end() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(2_000), true);
@@ -1011,12 +1205,12 @@ mod test {
 
 		// The primary rendition runs a whole batch of segments through before its sibling has
 		// even loaded an init segment.
-		let mut first = timeline.track("video0").unwrap();
+		let mut first = enroll(&broadcast, &timeline, "video0");
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			first.record(seq, ms(t), true);
 		}
 
-		let mut second = timeline.track("video1").unwrap();
+		let mut second = enroll(&broadcast, &timeline, "video1");
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			second.record(seq, ms(t), true);
 		}
@@ -1044,8 +1238,8 @@ mod test {
 	#[tokio::test]
 	async fn groups_before_the_first_boundary_join_the_first_segment() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
+		let mut audio = enroll(&broadcast, &timeline, "audio0");
 
 		// Audio races ahead of video's first keyframe (the startup race): its early group
 		// belongs to segment 0, which starts where the earliest content does.
@@ -1070,8 +1264,8 @@ mod test {
 	#[tokio::test]
 	async fn sequence_gaps_split_ranges() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
+		let mut audio = enroll(&broadcast, &timeline, "audio0");
 
 		// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
 		video.record(0, ms(0), true);
@@ -1097,8 +1291,8 @@ mod test {
 	#[tokio::test]
 	async fn a_closed_track_leaves_a_whole_segment_gap() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
+		let mut audio = enroll(&broadcast, &timeline, "audio0");
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
@@ -1115,7 +1309,7 @@ mod test {
 	#[tokio::test]
 	async fn a_non_keyframe_range_start_is_flagged() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 
 		video.record(0, ms(0), true);
 		// A mid-stream join: the group doesn't open on an IDR.
@@ -1134,8 +1328,8 @@ mod test {
 	#[tokio::test]
 	async fn a_closed_track_stops_gating() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
+		let mut audio = enroll(&broadcast, &timeline, "audio0");
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
@@ -1152,6 +1346,175 @@ mod test {
 		timeline.finish().unwrap();
 	}
 
+	/// Track info with an explicit retention window.
+	fn retention(latency_max: Duration) -> moq_net::track::Info {
+		moq_net::track::Info::default().with_latency_max(latency_max)
+	}
+
+	/// The timeline lists what the publisher can still serve, so a record goes when the groups
+	/// behind it age out of the cache. A late joiner therefore gets the live window, not the
+	/// broadcast's whole history.
+	#[tokio::test]
+	async fn a_record_is_retracted_once_its_groups_expire() {
+		tokio::time::pause();
+
+		let (broadcast, mut timeline) = setup();
+		let mut video = enroll_with(&broadcast, &timeline, "video0", retention(Duration::from_secs(10)));
+
+		// Three segments, each a 2s group, published a group apart in wall-clock time too.
+		for seq in 0..4u64 {
+			video.record(seq, ms(seq * 2_000), true);
+			tokio::time::advance(Duration::from_secs(2)).await;
+		}
+
+		// Nothing has aged out yet at t=8s, so a fresh subscriber sees every segment.
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(entries.len(), 3, "3 complete segments, the 4th group is still open");
+
+		// Past the first group's window. The next report is what sweeps, matching moq-net, which
+		// only evicts as groups are committed.
+		tokio::time::advance(Duration::from_secs(5)).await;
+		video.record(4, ms(8_000), true);
+
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(
+			entries.iter().map(|e| e.segment).collect::<Vec<_>>(),
+			vec![2, 3],
+			"segments whose groups left the cache are no longer advertised"
+		);
+
+		drop(video);
+		timeline.finish().unwrap();
+	}
+
+	/// A consumer that was told about a segment is told when it goes, naming the oldest one still
+	/// available so an exporter can bound its playlist without diffing.
+	#[tokio::test]
+	async fn a_live_consumer_sees_the_retraction() {
+		tokio::time::pause();
+
+		let (broadcast, mut timeline) = setup();
+		let mut video = enroll_with(&broadcast, &timeline, "video0", retention(Duration::from_secs(10)));
+
+		let mut consumer = Consumer::<()>::subscribe(&broadcast.consume(), &timeline.section())
+			.await
+			.unwrap();
+		let waiter = kio::Waiter::noop();
+
+		for seq in 0..3u64 {
+			video.record(seq, ms(seq * 2_000), true);
+			tokio::time::advance(Duration::from_secs(2)).await;
+		}
+
+		let mut updates = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			updates.push(update);
+		}
+		assert_eq!(updates.len(), 2, "two complete segments appended, no retraction yet");
+
+		// Land past the first segment's deadline but inside the second's, then report to drive
+		// the sweep.
+		tokio::time::advance(Duration::from_secs(5)).await;
+		video.record(3, ms(6_000), true);
+
+		let mut updates = Vec::new();
+		while let Poll::Ready(Ok(Some(update))) = consumer.poll_next(&waiter) {
+			updates.push(update);
+		}
+		assert!(
+			updates.contains(&Update::Trim { segment: 1 }),
+			"expected segment 0 to be retracted, got {updates:?}"
+		);
+
+		drop(video);
+		timeline.finish().unwrap();
+	}
+
+	/// A segment spans every track, so it is only fetchable while all of them still hold their
+	/// groups: the shortest window bounds the record, without the timeline needing a rule for it.
+	#[tokio::test]
+	async fn the_shortest_retention_bounds_the_record() {
+		tokio::time::pause();
+
+		let (broadcast, mut timeline) = setup();
+		let mut video = enroll_with(&broadcast, &timeline, "video0", retention(Duration::from_secs(60)));
+		let mut audio = enroll_with(&broadcast, &timeline, "audio0", retention(Duration::from_secs(5)));
+
+		for seq in 0..3u64 {
+			video.record(seq, ms(seq * 2_000), true);
+			audio.record(seq, ms(seq * 2_000), true);
+			tokio::time::advance(Duration::from_secs(2)).await;
+		}
+		assert_eq!(drain(&broadcast, &timeline).await.len(), 2);
+
+		// Past audio's 5s window but far inside video's 60s one.
+		tokio::time::advance(Duration::from_secs(4)).await;
+		video.record(3, ms(6_000), true);
+		audio.record(3, ms(6_000), true);
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await.first().map(|e| e.segment),
+			Some(2),
+			"the segment went with audio's groups even though video still holds its own"
+		);
+
+		drop(video);
+		drop(audio);
+		timeline.finish().unwrap();
+	}
+
+	/// The retraction has to lead the eviction it predicts, or a consumer fetches on a record
+	/// whose groups are already gone by the time the request lands. moq-net keeps a group for a
+	/// grace period past `latency_max`, and the timeline trims at `latency_max` exactly.
+	#[tokio::test]
+	async fn the_retraction_leads_the_eviction() {
+		tokio::time::pause();
+
+		let latency_max = Duration::from_secs(4);
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let timeline = Producer::new(&broadcast, Config::default());
+
+		// A real media track, so the groups the record names are really cached and really evicted.
+		let mut track = broadcast.create_track("video0", retention(latency_max)).unwrap();
+		let mut video = timeline.track(&track).unwrap();
+
+		// t=0. Segment 0 ends up being exactly this group.
+		track.create_group(0u64.into()).unwrap().finish().unwrap();
+		video.record(0, ms(0), true);
+
+		// t=2: the next group closes segment 0 and publishes its record.
+		tokio::time::advance(Duration::from_secs(2)).await;
+		track.create_group(1u64.into()).unwrap().finish().unwrap();
+		video.record(1, ms(2_000), true);
+		assert!(
+			drain(&broadcast, &timeline).await.iter().any(|e| e.segment == 0),
+			"segment 0 should be published while its group is fresh"
+		);
+
+		// t=4.5: group 0 is past `latency_max`, so its record goes, but it is still inside the
+		// grace moq-net adds on top. Half a second is well clear of the cache's 100ms tick, so
+		// this lands strictly between the two deadlines rather than on the boundary.
+		tokio::time::advance(Duration::from_millis(2_500)).await;
+		track.create_group(2u64.into()).unwrap().finish().unwrap();
+		video.record(2, ms(4_000), true);
+
+		let entries = drain(&broadcast, &timeline).await;
+		assert!(
+			!entries.iter().any(|e| e.segment == 0),
+			"the record should be retracted at latency_max"
+		);
+		assert!(
+			broadcast
+				.consume()
+				.track("video0")
+				.unwrap()
+				.fetch_group(0, None)
+				.await
+				.is_ok(),
+			"the group must outlive its record, or a FETCH on it races eviction"
+		);
+	}
+
 	// The timeline track (and its catalog section) exist only once a media track enrolls.
 	#[tokio::test]
 	async fn the_track_is_created_on_first_enrollment() {
@@ -1164,7 +1527,7 @@ mod test {
 
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let timeline2 = Producer::new(&broadcast, Config::default());
-		let _recorder = timeline2.track("video0").unwrap();
+		let _recorder = enroll(&broadcast, &timeline2, "video0");
 		assert!(
 			broadcast.create_track(DEFAULT_NAME, None).is_err(),
 			"the timeline took the name once a track enrolled"
@@ -1200,7 +1563,7 @@ mod test {
 	#[tokio::test]
 	async fn reservations_nest() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 
 		let outer = timeline.reserve();
 		let inner = outer.clone();
@@ -1230,7 +1593,7 @@ mod test {
 	#[tokio::test]
 	async fn finish_overrides_an_outstanding_reservation() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 		let reserved = timeline.reserve();
 
 		video.record(0, ms(0), true);
@@ -1254,7 +1617,7 @@ mod test {
 	#[tokio::test]
 	async fn rejects_an_invalid_timescale() {
 		let (broadcast, timeline) = setup();
-		let _recorder = timeline.track("video0").unwrap();
+		let _recorder = enroll(&broadcast, &timeline, "video0");
 		let mut section = timeline.section();
 		section.timescale = 0;
 		let err = Consumer::<()>::subscribe(&broadcast.consume(), &section).await;
@@ -1266,7 +1629,7 @@ mod test {
 	#[tokio::test]
 	async fn a_cut_on_the_first_group_does_not_poison_later_cuts() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = enroll(&broadcast, &timeline, "video0");
 
 		// Source segments every 3s, keyframes every 1s: 3s segments, not the 1s the
 		// duration_min pacing would produce on its own.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -39,6 +39,19 @@ pub const DEFAULT_LATENCY_MAX: Duration = Duration::from_secs(5);
 /// replaying them. Sized like a typical send buffer for real-time audio/video.
 const MAX_DATAGRAM_AGE: Duration = Duration::from_millis(50);
 
+/// How long a group is kept past [`Info::latency_max`] before age eviction takes it.
+///
+/// The grace makes `latency_max` a floor rather than a deadline. A reader deciding to fetch a
+/// group at the edge of the window needs it to still be there when the request lands, which is a
+/// round trip later, and an index built from `latency_max` (a media timeline) drops a record while
+/// the content behind it is still fetchable rather than a moment after it is gone. Without the
+/// grace every reader reasoning about the window edge races the publisher's own cache.
+///
+/// It applies on top of [`origin::Info::cache_duration`](crate::origin::Info::cache_duration) too,
+/// so that ceiling is exceeded by up to this much; it is bounded and small enough not to matter
+/// against a retention budget measured in seconds.
+const EVICT_GRACE: Duration = Duration::from_secs(1);
+
 /// Slack before the eviction order is rebuilt, so a track holding just a few groups
 /// doesn't rebuild on every write.
 const EVICT_SLACK: usize = 64;
@@ -68,11 +81,15 @@ pub struct Info {
 	/// timestamps at this scale on the wire. Protocols whose wire can't carry it
 	/// (pre-Lite05 moq-lite, IETF moq-transport) fall back to local monotonic milliseconds.
 	pub timescale: Timescale,
-	/// The maximum age of a non-latest group before the publisher evicts it (the
-	/// newest group is always retained). A subscriber's
-	/// [`Subscription::latency`] window is clamped to this, since a group can't be
-	/// waited for longer than it's kept around. Reported in TRACK_INFO so
+	/// How long a non-latest group is guaranteed to stay cached (the newest group is always
+	/// retained). A subscriber's [`Subscription::latency`] window is clamped to this, since a
+	/// group can't be waited for longer than it's kept around. Reported in TRACK_INFO so
 	/// relays re-serve with the same window. Defaults to [`DEFAULT_LATENCY_MAX`].
+	///
+	/// A floor, not a deadline: age eviction fires a short grace period later, so a reader that
+	/// acts on a group at the edge of the window still finds it a round trip later. Don't rely
+	/// on the extra time (it is deliberately unspecified), only on the floor. Memory pressure is
+	/// the exception, and evicts on the byte budget regardless.
 	///
 	/// This is the `Publisher Max Latency` on the wire, the publisher-side half of
 	/// the same budget [`Subscription::latency`] sets for a subscriber.
@@ -515,7 +532,8 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	/// Expire groups whose last access is older than `max_age`, never the latest.
+	/// Expire groups whose last access is older than `max_age` plus [`EVICT_GRACE`], never
+	/// the latest.
 	///
 	/// One bounded, rotating scan over the eviction order, which holds every cached
 	/// group except the protected latest. The cursor persists across calls, so
@@ -525,7 +543,7 @@ impl TrackState {
 	/// byte budget reclaims the remainder under memory pressure.
 	fn evict_expired(&mut self, max_age: Duration) {
 		let now = self.cache.pool().now();
-		let max_ticks = cache::Pool::ticks(max_age);
+		let max_ticks = cache::Pool::ticks(max_age.saturating_add(EVICT_GRACE));
 
 		let len = self.evict.len();
 		if len > 0 {
@@ -985,6 +1003,22 @@ impl Producer {
 	/// The track's name, unique within its broadcast.
 	pub fn name(&self) -> &str {
 		&self.name
+	}
+
+	/// The track's metadata, as it actually applies.
+	///
+	/// Not necessarily what was passed to
+	/// [`create_track`](crate::broadcast::Producer::create_track):
+	/// [`latency_max`](Info::latency_max) is clamped to the origin's
+	/// [`cache_duration`](crate::origin::Info::cache_duration), so this reports the effective
+	/// retention rather than the requested one. Anything sizing itself to the publisher's cache
+	/// (a media timeline deciding how far back to index) wants the effective value.
+	pub fn info(&self) -> Info {
+		self.state
+			.read()
+			.info
+			.clone()
+			.expect("a track installs its info at construction")
 	}
 
 	/// The parent broadcast this track belongs to.
@@ -3310,7 +3344,7 @@ mod test {
 		}
 
 		// Advance time past the eviction threshold.
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 
 		// Append a new group to trigger eviction.
 		producer.append_group().unwrap(); // seq 3
@@ -3362,7 +3396,7 @@ mod test {
 		producer.append_group().unwrap(); // seq 0
 
 		// Advance time past threshold.
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 
 		// Append another group; seq 0 is expired and evicted.
 		producer.append_group().unwrap(); // seq 1
@@ -3400,7 +3434,7 @@ mod test {
 
 		let mut consumer = producer.subscribe(None);
 
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 		producer.append_group().unwrap(); // seq 1
 
 		// Group 0 was evicted. Consumer should get group 1.
@@ -3416,13 +3450,43 @@ mod test {
 		let mut producer = track_producer("test", Info::default().with_latency_max(Duration::from_secs(1)));
 		producer.append_group().unwrap(); // seq 0
 
-		// Past the custom budget but well within DEFAULT_LATENCY_MAX.
-		tokio::time::advance(Duration::from_secs(2)).await;
+		// Past the custom budget (and its grace) but well within DEFAULT_LATENCY_MAX.
+		tokio::time::advance(Duration::from_secs(1) + EVICT_GRACE + Duration::from_secs(1)).await;
 		producer.append_group().unwrap(); // seq 1
 
 		// Seq 0 is gone because the publisher only keeps groups for 1s.
 		let state = producer.state.read();
 		assert_eq!(live_groups(&state), 1);
+		assert_eq!(first_live_sequence(&state), 1);
+	}
+
+	/// `latency_max` is the age a group is *guaranteed* to survive, not the instant it dies.
+	/// A reader that acts on a group at the edge of the window (an index dropping its last
+	/// record for it, then a client fetching on that record) needs it to still be there a
+	/// round trip later, so eviction lags the declared window by [`EVICT_GRACE`].
+	#[tokio::test]
+	async fn latency_max_survives_its_own_deadline() {
+		tokio::time::pause();
+
+		let latency_max = Duration::from_secs(2);
+		let mut producer = track_producer("test", Info::default().with_latency_max(latency_max));
+		producer.append_group().unwrap(); // seq 0
+
+		// Exactly at the declared window: still fetchable, which is the whole promise.
+		tokio::time::advance(latency_max).await;
+		producer.append_group().unwrap(); // seq 1
+		assert_eq!(live_groups(&producer.state.read()), 2, "seq 0 died at its own deadline");
+
+		// Still inside the grace.
+		tokio::time::advance(EVICT_GRACE).await;
+		producer.append_group().unwrap(); // seq 2
+		assert_eq!(live_groups(&producer.state.read()), 3, "seq 0 died within the grace");
+
+		// Past it, and seq 0 goes. Seq 1 and 2 are younger than the window and stay.
+		tokio::time::advance(Duration::from_secs(1)).await;
+		producer.append_group().unwrap(); // seq 3
+		let state = producer.state.read();
+		assert_eq!(live_groups(&state), 3);
 		assert_eq!(first_live_sequence(&state), 1);
 	}
 
@@ -3495,8 +3559,8 @@ mod test {
 		);
 		producer.append_group().unwrap(); // seq 0
 
-		// Past the origin ceiling but far within the publisher's own 60s window.
-		tokio::time::advance(Duration::from_secs(2)).await;
+		// Past the origin ceiling (and its grace) but far within the publisher's own 60s window.
+		tokio::time::advance(Duration::from_secs(1) + EVICT_GRACE + Duration::from_secs(1)).await;
 		producer.append_group().unwrap(); // seq 1
 
 		// Seq 0 is evicted anyway: the origin ceiling wins over the larger publisher window.
@@ -3645,7 +3709,7 @@ mod test {
 		}
 
 		// Expire all three groups.
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 
 		// Append seq 6 (becomes new max_sequence).
 		producer.append_group().unwrap(); // seq 6
@@ -3672,7 +3736,7 @@ mod test {
 		// Arrive: seq 5, then seq 3.
 		producer.create_group(group::Info { sequence: 5 }).unwrap();
 
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 
 		// Seq 3 arrives late; max_sequence is still 5 (at front).
 		producer.create_group(group::Info { sequence: 3 }).unwrap();
@@ -3686,7 +3750,7 @@ mod test {
 		}
 
 		// Expire seq 3 as well.
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 
 		// Seq 2 arrives late, triggering eviction.
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
@@ -5101,7 +5165,7 @@ mod test {
 		producer.append_group().unwrap().finish().unwrap(); // seq 1 demotes seq 0
 
 		// Idle past the window, then the straggler receives a late frame.
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 		straggler
 			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 100]))
 			.unwrap();
@@ -5111,7 +5175,7 @@ mod test {
 		assert!(consumer.peek_group(0).is_some(), "the write restarted the clock");
 
 		// Once the writes stop, the group ages out normally.
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 		producer.append_group().unwrap().finish().unwrap(); // seq 3 runs expiry
 		assert!(consumer.peek_group(0).is_none(), "idle content still expires");
 	}
@@ -5144,7 +5208,7 @@ mod test {
 
 		// Age everything out, then refresh the first four backfills so they sit
 		// fresh at the front of the eviction order, hiding the expired fifth.
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 		for sequence in 1..=4u64 {
 			consumer.fetch_group(sequence, None).await.unwrap();
 		}
@@ -5497,7 +5561,7 @@ mod test {
 		let used = pool.used();
 
 		// Age past the track window; the next write reclaims the backfill.
-		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + EVICT_GRACE + Duration::from_secs(1)).await;
 		producer.create_group(6u64.into()).unwrap().finish().unwrap();
 
 		assert!(consumer.peek_group(2).is_none(), "expired backfill is reclaimed");


### PR DESCRIPTION
## Summary

The media timeline was an append-only `moq_json::stream`, so it listed every segment ever published, including long-evicted ones. An HLS playlist built from it advertised segments that could no longer be fetched, and moq-hls papered over the misses with `EXT-X-DISCONTINUITY`.

This makes the timeline a sliding window over what the publisher can still serve, retracting a record once the groups behind it reach their track's `latency_max`.

## Root cause

Two distinct bugs, and the second is the interesting one.

**The track could not shrink.** A `moq_json::stream`'s whole log rides one group that is never rolled, and a consumer always starts at frame 0. Once moq-net evicted the earliest frames the track was bricked for late joiners (`Error::Lagged`), and with compression the retained suffix is undecodable anyway since its DEFLATE window depends on the evicted prefix. There was no shape in which a record could be dropped, so `moq_json::window` is a new mode: each group is self-contained (snapshot at frame 0, then `{"append":V}` / `{"trim":N}` operations) and rolls once the records trimmed since the snapshot outnumber those still in the window. Total bytes stay at roughly 2x an append-only log, old groups become disposable, and a late joiner reads only the newest.

**`latency_max` was a knife edge.** `evict_expired` dropped a group the instant its age exceeded `latency_max`, which is the same instant anything reasoning about the window would conclude the group was gone. A consumer that decides to fetch at that edge has its FETCH arrive a round trip later, by which time the media is already evicted. This is not fixable by retracting *on* eviction: an observed eviction is by definition after the fact, so the retraction is emitted when the content is already gone and then takes another propagation delay to arrive. The timeline has to lead the cache, which only a predictive trigger can do.

So `latency_max` becomes a floor rather than a deadline: age eviction now fires at `latency_max + EVICT_GRACE` (1s), and the timeline trims at `latency_max` exactly. The user-facing knob keeps its meaning (30s configured is 30s of timeline and 30s guaranteed fetchable) and the grace is invisible slack. It fixes the race for every reader of the window edge, not just the timeline.

## Design notes for reviewers

- **`timeline::Producer::track` takes the `track::Producer`, not its name.** The retention is read from the same place the track declares it, so there is nothing for a caller to duplicate and get wrong. This is deliberate: an earlier attempt at a JS retention timer (`bafc419a4`, on the #2631 branch) was reverted precisely because it guessed `DEFAULT_LATENCY_MAX_MS` and silently mismatched any track published with a different `latencyMax`. That is an argument against a guessed constant, not against time-based trimming.
- **Heterogeneous retention needs no rule.** A record's deadline is the earliest `reported + latency_max` across the groups it names. A segment is fetched whole, so the first group to leave its cache breaks it as thoroughly as any other; a broadcast whose audio keeps 5s and video keeps 60s falls out of that without a special case.
- **No timer on either side.** The trim sweeps as segments are recorded, which is also when moq-net's `commit_group` runs `evict_expired`. The two stay in phase, and a publisher that stalls stops trimming and stops evicting together.
- **The clock is `web_async::time::Instant`**, which is what moq-net's cache pool already uses. `std::time::Instant` would drift from it under wasm and under a paused test clock. It is wall-clock rather than pts on purpose: eviction is wall-clock, so a file import racing pts ahead of real time must not trim content the cache is still holding in full.
- **`Fanout::trim` leaves the wall-clock anchor alone**, even when a retraction empties the replay history. The anchor maps the pts axis onto wall clock and a retraction says nothing about that axis; re-estimating would jump `EXT-X-PROGRAM-DATE-TIME` and DASH `availabilityStartTime` over content that never moved, and would do it exactly when the publisher is shedding media, which is when a fresh "this segment just ended" estimate is least true.

## Relationship to #2631

Same diagnosis of the append-only problem and the same `moq_json::window` format, which is lifted from that branch unchanged. The trigger is what differs: #2631 retracts by *observing* eviction, via a new `group::Demand` primitive in moq-net and `Group.Consumer.gone` / `Producer.evict` / `Track.Subscriber.tryNextGroup` in js/net. That is exact but structurally too late, as above. Predicting from the declared window is both smaller and correctly ordered, so this drops `group::Demand` and the `gone`/`evict` surface entirely. `tryNextGroup` stays, since the window primitive itself needs it to reach the newest buffered group.

The tradeoff taken knowingly: the prediction is optimistic where observation was exact. A group dropped early by the cache pool's byte budget is still listed until its declared window elapses. That is a bounded error on a cache hint, it self-corrects at the next group's snapshot, and moq-hls keeps the discontinuity path as the genuine-miss fallback.

## Public API changes

**Added**

- `rs/moq-net`: `track::Producer::info()`, the effective (post-clamp) track info.
- `rs/moq-json`: the `window` module (`Producer`, `Consumer`, `Update`, `ProducerConfig`, `ConsumerConfig`), plus an `Error::Window` variant (the enum is `#[non_exhaustive]`).
- `rs/moq-mux`: `timeline::Update`.
- `js/json`: the `Window` namespace, mirroring the above.
- `js/net`: `Track.Producer.accepted` (the synchronous peek at `info()`) and `Track.Subscriber.tryNextGroup()`.

**Changed**

- `rs/moq-mux`: `timeline::Consumer::{next, poll_next}` yield `Update<E>` rather than `Entry<E>`, since an entry alone cannot express a retraction. `Entry` is unchanged and rides inside `Update::Append`. `timeline::Producer::track` and `catalog::Producer::enroll` take `&moq_net::track::Producer` rather than `&str`.
- `js/hang`: `Container.Timeline.Producer.track` takes the `Moq.Track.Producer`, matching.

**Behavior**

- `moq_net::track::Info::latency_max` is now the age a group is *guaranteed* to survive; eviction fires a short unspecified grace later. Mirrored in `js/net`'s `Track.Producer` cache prune.

**Wire format (breaking).** The timeline track changes from an append-only stream to a sliding window. Nothing negotiates this: a new consumer against an old publisher errors rather than mis-parsing. That is acceptable here specifically because the catalog's `timeline` field is still being specified, so breaking it now costs nothing and breaking it later would cost a version.

## Cross-Package Sync

- `rs/hang` catalog/container -> `js/hang`, `drafts/`: done. `draft-lcurley-moq-hang`'s Timeline section specifies the window framing (snapshot, `append`/`trim`, group rolling) and a new Availability section covering retraction.
- `rs/moq-net` wire/API -> `js/net`, `drafts/`: done. `draft-lcurley-moq-lite`'s Expiration section now states `Publisher Max Latency` as a floor with the round-trip margin, with a changelog bullet under moq-lite-06. The hang draft cites it rather than restating.
- `doc/`: no change. The timeline is not documented on the site and no CLI surface moved.

## Test plan

- `just check` passes, including `cargo doc` with `-D warnings`.
- `just drafts check` (kramdown-rfc) passes on all 8 drafts. The `HT characters` warning on the hang draft is pre-existing: its schema blocks use tabs.
- New Rust coverage: a group surviving its own `latency_max` deadline and dying past the grace; a record retracted once its groups expire; a live consumer seeing the retraction with the oldest surviving segment named; the shortest retention bounding a multi-track record; and the load-bearing one, `the_retraction_leads_the_eviction`, which asserts the record is gone while a real FETCH on its group still succeeds. That test was mutation-checked by zeroing `EVICT_GRACE`, and fails without it. Plus moq-hls trims dropping segments the duration window would keep, never rewinding `EXT-X-MEDIA-SEQUENCE`, and emptying a window when trimmed past.
- New JS coverage: the 8 window tests from #2631 (two decode hand-written wire frames, so the decoder is checked against the byte shape rather than only against its own producer), plus retraction and shortest-retention tests mirroring the Rust ones.

## Branch targeting

Targets `dev`: `timeline::Consumer::next`, `timeline::Producer::track`, and `catalog::Producer::enroll` all change signature, as does `js/hang`'s `Timeline.Producer.track`.

(Written by Opus 5)
