### PR TITLE
fix(moq-native): spawn the dial on the client's own runtime

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -201,6 +201,13 @@ pub struct Client {
 	pub(crate) reconnect: bool,
 	pub(crate) backoff: Backoff,
 	pub(crate) goaway: GoawayConfig,
+	/// The runtime to spawn each [`Connection`]'s dial loop on, when one was entered
+	/// at construction. [`Self::connect`] is synchronous, so a caller writing
+	/// `runtime.block_on(client.connect(url).established())` evaluates it outside the
+	/// runtime; without a handle of our own that dial would panic. `None` when the
+	/// client really was built outside a runtime (a tcp/websocket-only build can be),
+	/// which falls back to the caller's.
+	pub(crate) runtime: Option<tokio::runtime::Handle>,
 	/// The resolved Happy Eyeballs stagger, used by the `tcp://` dial here; the
 	/// QUIC backends capture their own copy from the config.
 	#[cfg(feature = "tcp")]
@@ -289,6 +296,7 @@ impl Client {
 			reconnect: config.reconnect.unwrap_or(true),
 			backoff: config.backoff,
 			goaway: config.goaway,
+			runtime: tokio::runtime::Handle::try_current().ok(),
 			#[cfg(feature = "tcp")]
 			failover_delay,
 			#[cfg(feature = "websocket")]
@@ -380,6 +388,9 @@ impl Client {
 	/// [`Addrs`] instead when the same peer has several candidate addresses and
 	/// only some of them route from here; each attempt walks them in order and
 	/// keeps the first that connects.
+	///
+	/// The dial runs on a tokio task, spawned on the runtime this [`Client`] was
+	/// built on, or the current one when it was built outside a runtime.
 	pub fn connect(&self, addrs: impl Into<Addrs>) -> Connection {
 		Connection::new(self.clone(), addrs.into())
 	}

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -522,7 +522,8 @@ impl Connection {
 		let closed: CloseGuard = Default::default();
 		let task_closed = closed.clone();
 
-		let task = tokio::spawn(async move {
+		let runtime = client.runtime.clone();
+		let dial_loop = async move {
 			let reconnect = client.reconnect;
 			let shared = Shared {
 				state: producer,
@@ -540,7 +541,15 @@ impl Connection {
 				shared.failed(err);
 			}
 			// Dropping the producers here closes the channels, signaling consumers.
-		});
+		};
+
+		// The client captured the runtime it was built on, which is what lets a
+		// synchronous `connect` be called from outside one. Falling back to the
+		// caller's runtime covers a client that was built outside one too.
+		let task = match &runtime {
+			Some(runtime) => runtime.spawn(dial_loop),
+			None => tokio::spawn(dial_loop),
+		};
 		Self {
 			task: std::sync::Arc::new(AbortOnDrop {
 				handle: task.abort_handle(),
@@ -1600,6 +1609,42 @@ mod tests {
 		assert!(logs_contain("connecting"), "the dial never logged at all");
 		assert!(!logs_contain(SECRET), "a log line leaked the credential");
 		assert!(!format!("{err}").contains(SECRET), "the error leaked it: {err}");
+	}
+
+	/// [`Client::connect`] is synchronous but spawns the dial, so a caller outside a
+	/// runtime must still get one: `runtime.block_on(client.connect(url).established())`
+	/// evaluates the `connect` before `block_on` enters the runtime.
+	///
+	/// Deliberately not a `#[tokio::test]`, since entering the runtime around the
+	/// call is exactly what this must not require.
+	#[cfg(feature = "tcp")]
+	#[test]
+	fn connect_dials_from_outside_the_runtime() {
+		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+		let runtime = tokio::runtime::Runtime::new().expect("runtime");
+
+		// The QUIC backend binds its socket through `quinn::default_runtime`, so a
+		// client is essentially always built inside a runtime; that is the handle the
+		// dial below borrows.
+		let client = runtime
+			.block_on(async {
+				let mut config = crate::ClientConfig::default();
+				config.tls.disable_verify = Some(true);
+				config.init()
+			})
+			.expect("build client")
+			// One-shot, so the refused address settles instead of retrying for the
+			// whole backoff window.
+			.with_reconnect(false);
+
+		let connection = client.connect(refused());
+
+		// The dial really ran, rather than a task that was never spawned sitting idle.
+		// `Connection` isn't `Debug`, so unwrap the failure by hand.
+		assert!(
+			runtime.block_on(connection.established()).is_err(),
+			"nothing is listening on the refused port"
+		);
 	}
 
 	/// A settled answer from one candidate ends the walk instead of being buried.

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -10,6 +10,14 @@
 //!
 //! See [`Client`] for connecting to relays and [`Server`] for accepting
 //! connections. [`mdns`] finds peers to connect to on the local network.
+//!
+//! ## Async
+//! Where [`moq_net`] spawns nothing behind your back, this crate does: it runs each
+//! session's protocol driver and each [`Connection`]'s dial loop on tokio tasks. The
+//! QUIC backends also bind their socket to the runtime that builds them, so
+//! [`ClientConfig::init`] and [`ServerConfig::init`] want a runtime entered.
+//! [`Client::connect`] is synchronous and reuses the runtime its client was built on,
+//! so dialing from outside one works.
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
## Summary

**Root cause.** `Client::connect` is synchronous but `Connection::new` calls `tokio::spawn`, so it panics with "there is no reactor running" when called outside an entered runtime. The natural migration from the old `async fn connect`,

```rust
runtime.block_on(client.connect(url).established())
```

evaluates `connect` *before* `block_on` enters the runtime, and panics. The async predecessor had no such trap and the requirement was documented nowhere.

`Client` now captures `tokio::runtime::Handle::try_current().ok()` at construction and `Connection::new` spawns through it, falling back to `tokio::spawn` when there was none. `try_current().ok()` rather than `current()` because a tcp/websocket-only client can legitimately be built outside a runtime; the `None` arm preserves today's behavior exactly, so this is strictly fewer panics with nothing that works today regressing. It fixes `publish`/`consume` for free, since both route through `connect`.

Capturing at construction works because the client is essentially always built inside a runtime: `QuinnClient::new` calls `quinn::default_runtime().ok_or(Error::NoRuntime)?`, and quinn is the default backend.

Rejected alternatives: deferring the spawn to first poll would break the documented publish path (`doc/lib/rs/env/native.md` shows `let _connection = client.with_publisher(...).connect(url);`, which never polls), silently never dialing. Documenting only leaves a runtime panic in a sync API whose async predecessor had none.

Residual, unfixed and unfixable: if the captured handle's runtime is shut down before `connect`, `Handle::spawn` still panics. That is tokio behavior.

## Public API changes

None. The new `runtime` field is `pub(crate)`. Doc additions only: a sentence on `Client::connect` and an `## Async` section in `lib.rs` mirroring the one in `moq-net`, since the contrast is the point (moq-net spawns nothing behind the caller; moq-native spawns the session driver and the dial loop).

## Test plan

- New `connection::tests::connect_dials_from_outside_the_runtime`, a plain `#[test]` rather than `#[tokio::test]` since not needing an entered runtime is the thing under test. Builds the client inside `block_on`, dials outside it, and asserts `established()` errors, which proves the task ran rather than sitting unspawned. Without the fix it panics at `connection.rs:549`.
- `cargo clippy -p moq-native --all-targets -- -D warnings`: clean
- `cargo nextest run -p moq-native`: 253/253

(Written by Opus 5)