### PR TITLE
fix(moq-hls): bind renditions to the broadcast their catalog came from

### DIFF
--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -19,6 +19,7 @@
 mod master;
 mod playlist;
 mod rendition;
+mod upstream;
 
 pub mod renditions;
 pub mod segments;
@@ -31,6 +32,7 @@ use rand::RngExt;
 
 pub(crate) use playlist::render_media;
 pub use rendition::{Kind, Rendition};
+pub(crate) use upstream::Upstream;
 
 /// Backoff bounds for the initial catalog subscription.
 ///
@@ -85,15 +87,19 @@ impl Broadcaster {
 	/// Resolve `source`'s catalog broadcast and start tracking its renditions.
 	pub async fn new(source: moq_mux::Source, config: Config) -> crate::Result<Arc<Self>> {
 		let broadcast = source.broadcast().await?;
+		let upstream = Upstream {
+			source,
+			broadcast: broadcast.clone(),
+		};
 		let renditions = renditions::Producer::new();
 		let broadcaster = Arc::new(Self {
-			broadcast: broadcast.clone(),
+			broadcast,
 			renditions: renditions.clone(),
 			watcher: Mutex::new(None),
 		});
 		// The watcher owns its own producer clone; the `Broadcaster`'s `Drop` aborts it so the
 		// standing catalog subscription stops when nobody's serving from this broadcaster.
-		let watcher = tokio::spawn(watch_catalog(source, broadcast, config, renditions));
+		let watcher = tokio::spawn(watch_catalog(upstream, config, renditions));
 		*broadcaster.watcher.lock().unwrap() = Some(watcher);
 		Ok(broadcaster)
 	}
@@ -179,16 +185,12 @@ impl Drop for Broadcaster {
 	}
 }
 
-async fn watch_catalog(
-	source: moq_mux::Source,
-	broadcast: moq_net::broadcast::Consumer,
-	config: Config,
-	renditions: renditions::Producer,
-) {
+async fn watch_catalog(upstream: Upstream, config: Config, renditions: renditions::Producer) {
+	let broadcast = &upstream.broadcast;
 	let mut delay = CATALOG_RETRY_MIN;
 
 	let mut consumer = loop {
-		match catalog::Consumer::<()>::new(&broadcast, CatalogFormat::Hang).await {
+		match catalog::Consumer::<()>::new(broadcast, CatalogFormat::Hang).await {
 			Ok(consumer) => break consumer,
 			Err(err) => {
 				tracing::warn!(%err, "failed to subscribe to broadcast catalog, retrying");
@@ -207,7 +209,7 @@ async fn watch_catalog(
 
 	loop {
 		match kio::wait(|waiter| consumer.poll_next(waiter)).await {
-			Ok(Some(catalog)) => renditions.sync(&source, &config, &catalog),
+			Ok(Some(catalog)) => renditions.sync(&upstream, &config, &catalog),
 			Ok(None) => break,
 			Err(err) => {
 				tracing::warn!(%err, "broadcast catalog stream ended with error");
@@ -225,9 +227,13 @@ mod tests {
 	use super::*;
 
 	fn frame(micros: u64, keyframe: bool) -> moq_mux::container::Frame {
+		payload_frame(micros, keyframe, &[0xDE, 0xAD, 0xBE, 0xEF])
+	}
+
+	fn payload_frame(micros: u64, keyframe: bool, payload: &'static [u8]) -> moq_mux::container::Frame {
 		moq_mux::container::Frame {
 			timestamp: moq_net::Timestamp::from_micros(micros).unwrap(),
-			payload: bytes::Bytes::from_static(&[0xDE, 0xAD, 0xBE, 0xEF]),
+			payload: bytes::Bytes::from_static(payload),
 			keyframe,
 			duration: None,
 		}
@@ -377,6 +383,116 @@ mod tests {
 		drop((catalog, media, registration, broadcast, rendition));
 	}
 
+	// A same-path republish takes the origin leaf over with a brand new broadcast (an ordinary
+	// publisher is `Origin::UNKNOWN`, which never counts as the same publisher, so even a plain
+	// reconnect qualifies). Renditions derived from the old broadcast's catalog must not serve the
+	// replacement's media: its group numbering restarts, so those bytes would be served under the
+	// replaced broadcast's segment number, duration, and PROGRAM-DATE-TIME.
+	#[tokio::test]
+	async fn a_replacement_publisher_is_not_served_under_the_replaced_catalog() {
+		const OLD: &[u8] = b"OLDOLDOLDOLDOLDO";
+		const NEW: &[u8] = b"NEWNEWNEWNEWNEWN";
+
+		// Publish broadcast "live": a `video0` rendition with a timeline, plus three keyframe
+		// groups whose frames carry `payload` so the two epochs' media differs byte for byte.
+		// The returned handle keeps the publisher alive until it is dropped.
+		fn publish(
+			origin: &moq_net::origin::Producer,
+			payload: &'static [u8],
+		) -> (Box<dyn std::any::Any>, hang::catalog::VideoConfig) {
+			let mut broadcast = origin
+				.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
+				.expect("publish allowed");
+			let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+			let reserved = catalog.reserve();
+			let mut registration = reserved.video("video0");
+			let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+			config.framerate = Some(30.0);
+			config.timeline = Some(catalog.timeline("video0").unwrap().section());
+			registration.set(config.clone());
+			drop(reserved);
+
+			let track = broadcast.create_track("video0", None).unwrap();
+			let mut media = catalog
+				.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
+				.unwrap();
+			media.write(payload_frame(0, true, payload)).unwrap();
+			media.write(payload_frame(2_000_000, true, payload)).unwrap();
+			media.write(payload_frame(4_000_000, true, payload)).unwrap();
+
+			(Box::new((broadcast, catalog, registration, media)), config)
+		}
+
+		fn contains(haystack: &bytes::Bytes, needle: &[u8]) -> bool {
+			haystack.windows(needle.len()).any(|window| window == needle)
+		}
+
+		let origin = moq_net::Origin::random().produce();
+		let (old, config) = publish(&origin, OLD);
+		settle().await;
+
+		// The export binds to the broadcast it reads the catalog from.
+		let source = moq_mux::Source::new(origin.consume(), "live");
+		let upstream = Upstream {
+			broadcast: source.broadcast().await.unwrap(),
+			source,
+		};
+		let mut catalog = moq_mux::catalog::hang::Catalog::default();
+		catalog.video.renditions.insert("video0".to_string(), config);
+
+		// The publisher reconnects before the catalog snapshot is reconciled. That gap is wide in
+		// practice: `watch_catalog` retries a not-yet-written catalog track with backoff, so
+		// seconds can pass between resolving the broadcast and syncing its first snapshot.
+		drop(old);
+		let (new, _) = publish(&origin, NEW);
+		settle().await;
+
+		// Reconcile by hand, which is what the catalog watcher does with each snapshot.
+		let renditions = renditions::Producer::new();
+		renditions.sync(&upstream, &Config::default(), &catalog);
+		let rendition = renditions.get(Kind::Video, "video0").expect("rendition synced");
+
+		let _ = tokio::time::timeout(Duration::from_secs(1), rendition.playable()).await;
+		let served = rendition.segment(0).await.unwrap();
+		if let Some(served) = &served {
+			assert!(
+				!contains(served, NEW),
+				"the replacement publisher's media was served under the replaced broadcast's catalog"
+			);
+		}
+		assert!(
+			served.is_none(),
+			"the replaced broadcast is closed, so it serves nothing"
+		);
+
+		// Control: an export started after the takeover does serve the new publisher's media, so
+		// the assertion above is about which epoch a rendition is bound to, not about a broadcast
+		// that happens to be unreadable.
+		let source = moq_mux::Source::new(origin.consume(), "live");
+		let fresh = Upstream {
+			broadcast: source.broadcast().await.unwrap(),
+			source,
+		};
+		let renditions = renditions::Producer::new();
+		renditions.sync(&fresh, &Config::default(), &catalog);
+		let rendition = renditions.get(Kind::Video, "video0").expect("rendition synced");
+		tokio::time::timeout(Duration::from_secs(5), rendition.playable())
+			.await
+			.expect("the new publisher's timeline arrives");
+		let served = rendition
+			.segment(0)
+			.await
+			.unwrap()
+			.expect("the new publisher is servable on its own catalog");
+		assert!(
+			contains(&served, NEW),
+			"the new export serves the new publisher's media"
+		);
+
+		drop(new);
+	}
+
 	// A rendition the catalog drops must end its segment cursors. The cursor holds an
 	// `Arc<Rendition>`, so without an explicit close the rendition (and its timeline
 	// subscription) would stay alive and the cursor would park at the live edge forever.
@@ -387,6 +503,11 @@ mod tests {
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
 		let source = moq_mux::Source::new(origin.consume(), "live");
+		settle().await;
+		let upstream = Upstream {
+			broadcast: source.broadcast().await.unwrap(),
+			source,
+		};
 
 		// Drive the producer directly so the catalog can be reconciled synchronously.
 		let renditions = renditions::Producer::new();
@@ -394,13 +515,17 @@ mod tests {
 		media.timeline = Some(hang::catalog::Timeline::new("video.timeline"));
 		let mut catalog = moq_mux::catalog::hang::Catalog::default();
 		catalog.video.renditions.insert("video".to_string(), media);
-		renditions.sync(&source, &Config::default(), &catalog);
+		renditions.sync(&upstream, &Config::default(), &catalog);
 
 		let rendition = renditions.get(Kind::Video, "video").expect("rendition synced");
 		let mut segments = rendition.segments();
 
 		// The catalog drops the rendition: its cursor must run dry rather than park.
-		renditions.sync(&source, &Config::default(), &moq_mux::catalog::hang::Catalog::default());
+		renditions.sync(
+			&upstream,
+			&Config::default(),
+			&moq_mux::catalog::hang::Catalog::default(),
+		);
 		let ended = tokio::time::timeout(Duration::from_secs(5), segments.next())
 			.await
 			.expect("a removed rendition's cursor ends instead of parking")

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -9,6 +9,7 @@ use moq_mux::container::fmp4::Muxer;
 
 use super::playlist::{Segment, Snapshot};
 use super::segments;
+use super::upstream::Upstream;
 use crate::Result;
 
 /// Fallback advertised bitrates when the catalog doesn't carry one.
@@ -102,16 +103,11 @@ impl Rendition {
 
 	/// Build a video rendition and spawn its timeline watcher. `None` if the catalog doesn't
 	/// advertise a timeline (fetch-on-demand needs one).
-	pub(crate) fn video(
-		name: String,
-		config: &VideoConfig,
-		source: &moq_mux::Source,
-		window: Duration,
-	) -> Option<Self> {
+	pub(crate) fn video(name: String, config: &VideoConfig, upstream: &Upstream, window: Duration) -> Option<Self> {
 		let section = config.timeline.clone()?;
-		let live = Arc::new(segments::Producer::new());
+		let live = Arc::new(segments::Producer::new(upstream.local(config.broadcast.as_ref())));
 		let watcher = spawn_watcher(
-			source.clone(),
+			upstream.clone(),
 			config.broadcast.clone(),
 			section.clone(),
 			live.clone(),
@@ -135,16 +131,11 @@ impl Rendition {
 
 	/// Build an audio rendition and spawn its timeline watcher. `None` if the catalog doesn't
 	/// advertise a timeline.
-	pub(crate) fn audio(
-		name: String,
-		config: &AudioConfig,
-		source: &moq_mux::Source,
-		window: Duration,
-	) -> Option<Self> {
+	pub(crate) fn audio(name: String, config: &AudioConfig, upstream: &Upstream, window: Duration) -> Option<Self> {
 		let section = config.timeline.clone()?;
-		let live = Arc::new(segments::Producer::new());
+		let live = Arc::new(segments::Producer::new(upstream.local(config.broadcast.as_ref())));
 		let watcher = spawn_watcher(
-			source.clone(),
+			upstream.clone(),
 			config.broadcast.clone(),
 			section.clone(),
 			live.clone(),
@@ -425,17 +416,17 @@ fn is_cache_miss_mux(err: &moq_mux::Error) -> bool {
 		.any(is_cache_miss)
 }
 
-/// Spawn the per-rendition watcher: resolve the (possibly sibling) broadcast, subscribe to
-/// the timeline track, and feed records into the shared window.
+/// Spawn the per-rendition watcher: settle which broadcast serves this rendition, subscribe to
+/// the timeline track on it, and feed records into the shared window.
 fn spawn_watcher(
-	source: moq_mux::Source,
+	upstream: Upstream,
 	broadcast: Option<moq_net::PathRelativeOwned>,
 	section: Timeline,
 	live: Arc<segments::Producer>,
 	window: Duration,
 ) -> tokio::task::JoinHandle<()> {
 	tokio::spawn(async move {
-		match watch(source, broadcast, &section, &live, window).await {
+		match watch(upstream, broadcast, &section, &live, window).await {
 			// The timeline finished cleanly: the publisher is done, so its media groups are
 			// finalized and the last record can become a servable (ENDLIST) segment.
 			Ok(()) => live.end(),
@@ -453,15 +444,25 @@ fn spawn_watcher(
 }
 
 async fn watch(
-	source: moq_mux::Source,
+	upstream: Upstream,
 	broadcast: Option<moq_net::PathRelativeOwned>,
 	section: &Timeline,
 	live: &segments::Producer,
 	window: Duration,
 ) -> Result<()> {
-	let broadcast = source.resolve(broadcast.as_ref()).await?;
-	// Publish the resolved broadcast so segment requests can FETCH from it.
-	let _ = live.broadcast.set(broadcast.clone());
+	// A self-referencing rendition already has its broadcast (the catalog's own), so take it
+	// rather than asking the origin again: the timeline and the media it describes must come from
+	// the same broadcast the catalog did, and a same-path takeover in between would hand back a
+	// different one. Only a named sibling still needs resolving, which cannot happen at
+	// construction because `renditions::Producer::sync` runs synchronously under a write lock.
+	let broadcast = match live.broadcast.get() {
+		Some(broadcast) => broadcast.clone(),
+		None => {
+			let resolved = upstream.source.resolve(broadcast.as_ref()).await?;
+			let _ = live.broadcast.set(resolved.clone());
+			resolved
+		}
+	};
 
 	let mut timeline = moq_mux::timeline::Consumer::<()>::subscribe(&broadcast, section).await?;
 	while let Some(entry) = timeline.next().await? {

--- a/rs/moq-hls/src/export/renditions.rs
+++ b/rs/moq-hls/src/export/renditions.rs
@@ -13,8 +13,8 @@ use std::task::Poll;
 
 use moq_mux::catalog::hang::Catalog;
 
-use super::Config;
 use super::rendition::{Kind, Rendition};
+use super::{Config, Upstream};
 
 /// The `(kind, name)` identity of a rendition. Video and audio are separate axes, so a video
 /// and an audio rendition may share a name without colliding.
@@ -125,7 +125,10 @@ impl Producer {
 	/// Reconcile the rendition set with a complete catalog snapshot. Removed or reconfigured
 	/// renditions are dropped before replacements become visible, which also aborts their
 	/// timeline watchers and releases their subscriptions.
-	pub fn sync(&self, source: &moq_mux::Source, config: &Config, catalog: &Catalog) {
+	///
+	/// `upstream` carries the broadcast the snapshot was read from, so each rendition serves media
+	/// from that same broadcast rather than whatever is at the path by the time it is asked.
+	pub fn sync(&self, upstream: &Upstream, config: &Config, catalog: &Catalog) {
 		let Ok(mut current) = self.state.write() else {
 			return;
 		};
@@ -160,7 +163,7 @@ impl Producer {
 			if current.contains_key(&key) {
 				continue;
 			}
-			match Rendition::video(name.clone(), video, source, config.window) {
+			match Rendition::video(name.clone(), video, upstream, config.window) {
 				Some(rendition) => {
 					current.insert(key, Arc::new(rendition));
 				}
@@ -172,7 +175,7 @@ impl Producer {
 			if current.contains_key(&key) {
 				continue;
 			}
-			match Rendition::audio(name.clone(), audio, source, config.window) {
+			match Rendition::audio(name.clone(), audio, upstream, config.window) {
 				Some(rendition) => {
 					current.insert(key, Arc::new(rendition));
 				}

--- a/rs/moq-hls/src/export/segments.rs
+++ b/rs/moq-hls/src/export/segments.rs
@@ -31,8 +31,9 @@ const DEFAULT_SEGMENT: Duration = Duration::from_secs(4);
 /// [`kio::Producer`] so a [`Consumer`] can await changes without a separate signal.
 pub(crate) struct Producer {
 	state: kio::Producer<State>,
-	/// The broadcast serving the media track, resolved once by the background task (it may be
-	/// a sibling broadcast when the catalog rendition carries a `broadcast` reference).
+	/// The broadcast serving the media track. Seeded at construction for a rendition served by
+	/// the catalog's own broadcast, and otherwise set by the background task once it has resolved
+	/// the sibling broadcast the catalog rendition's `broadcast` reference names.
 	pub broadcast: OnceLock<moq_net::broadcast::Consumer>,
 }
 
@@ -170,14 +171,17 @@ impl State {
 }
 
 impl Producer {
-	pub fn new() -> Self {
+	/// An empty window. `broadcast` is the media broadcast when it is already known, i.e. for a
+	/// rendition served by the catalog's own broadcast; a sibling reference passes `None` and the
+	/// watcher fills it in once resolved.
+	pub fn new(broadcast: Option<moq_net::broadcast::Consumer>) -> Self {
 		Self {
 			state: kio::Producer::new(State {
 				entries: VecDeque::new(),
 				dropped: 0,
 				ended: false,
 			}),
-			broadcast: OnceLock::new(),
+			broadcast: broadcast.map(OnceLock::from).unwrap_or_default(),
 		}
 	}
 
@@ -421,7 +425,7 @@ mod tests {
 
 	#[test]
 	fn last_record_is_the_live_edge_until_ended() {
-		let live = Producer::new();
+		let live = Producer::new(None);
 		live.push(entry(0, 0), Duration::from_secs(30));
 		live.push(entry(1, 2_000), Duration::from_secs(30));
 		live.push(entry(2, 4_000), Duration::from_secs(30));
@@ -443,7 +447,7 @@ mod tests {
 
 	#[test]
 	fn window_evicts_and_advances_sequence() {
-		let live = Producer::new();
+		let live = Producer::new(None);
 		let window = Duration::from_secs(4);
 		for i in 0..6u64 {
 			live.push(entry(i, i * 2_000), window);
@@ -459,7 +463,7 @@ mod tests {
 
 	#[test]
 	fn segment_groups_cover_record_gaps() {
-		let live = Producer::new();
+		let live = Producer::new(None);
 		let window = Duration::from_secs(30);
 		// An audio-style timeline: records skip groups (granularity throttling).
 		live.push(entry(0, 0), window);
@@ -478,7 +482,7 @@ mod tests {
 
 	#[test]
 	fn backwards_jump_resets_the_window() {
-		let live = Producer::new();
+		let live = Producer::new(None);
 		let window = Duration::from_secs(30);
 		live.push(entry(0, 10_000), window);
 		live.push(entry(1, 12_000), window);
@@ -491,7 +495,7 @@ mod tests {
 
 	#[test]
 	fn non_advancing_record_is_skipped() {
-		let live = Producer::new();
+		let live = Producer::new(None);
 		let window = Duration::from_secs(30);
 		live.push(entry(0, 0), window);
 		live.push(entry(1, 2_000), window);
@@ -518,7 +522,7 @@ mod tests {
 		let window = Duration::from_secs(30);
 
 		// The watcher's own order: end() then close() -- the live edge finalizes.
-		let clean = Producer::new();
+		let clean = Producer::new(None);
 		clean.push(entry(0, 0), window);
 		clean.push(entry(1, 2_000), window);
 		clean.end();
@@ -529,7 +533,7 @@ mod tests {
 		);
 
 		// Reversed: a close() that races ahead of end() strands it forever.
-		let raced = Producer::new();
+		let raced = Producer::new(None);
 		raced.push(entry(0, 0), window);
 		raced.push(entry(1, 2_000), window);
 		raced.close();
@@ -544,7 +548,7 @@ mod tests {
 	// estimated from the observed cadence, not a flat DEFAULT_SEGMENT.
 	#[test]
 	fn final_segment_duration_matches_the_serve_path() {
-		let live = Producer::new();
+		let live = Producer::new(None);
 		let window = Duration::from_secs(30);
 		// A 6s cadence, so the flat 4s DEFAULT_SEGMENT would be wrong for the last segment.
 		live.push(entry(0, 0), window);
@@ -570,7 +574,7 @@ mod tests {
 
 	#[test]
 	fn next_after_walks_finalized_segments() {
-		let live = Producer::new();
+		let live = Producer::new(None);
 		let window = Duration::from_secs(30);
 		live.push(entry(0, 0), window);
 		live.push(entry(1, 2_000), window);

--- a/rs/moq-hls/src/export/upstream.rs
+++ b/rs/moq-hls/src/export/upstream.rs
@@ -1,0 +1,30 @@
+//! The broadcast an export is bound to, held rather than looked up again by path.
+
+/// The one broadcast an export is bound to: the already-resolved catalog consumer, plus the
+/// [`moq_mux::Source`] it came from so a rendition can still follow a cross-broadcast reference.
+///
+/// The two travel together because resolving the catalog path by name is not idempotent. A
+/// same-path republish is a takeover (`Origin::UNKNOWN` never counts as the same publisher, so
+/// every ordinary publisher reconnect qualifies), and that installs a brand new broadcast at the
+/// leaf. A rendition that looked its media up by path would then serve the replacement's groups
+/// under the manifest, segment numbering, and `PROGRAM-DATE-TIME` of the broadcast it replaced.
+#[derive(Clone)]
+pub(crate) struct Upstream {
+	/// Origin plus catalog path, for resolving a rendition's sibling `broadcast` reference.
+	pub source: moq_mux::Source,
+	/// The catalog broadcast, resolved once when the export started.
+	pub broadcast: moq_net::broadcast::Consumer,
+}
+
+impl Upstream {
+	/// The broadcast serving a rendition whose catalog `broadcast` field is `rel`, when that can
+	/// be answered without a round trip.
+	///
+	/// An absent or empty reference means the catalog broadcast itself, which is already in hand.
+	/// A named sibling returns `None` and has to go through [`moq_mux::Source::resolve`].
+	pub fn local(&self, rel: Option<&moq_net::PathRelativeOwned>) -> Option<moq_net::broadcast::Consumer> {
+		rel.filter(|rel| !rel.is_empty())
+			.is_none()
+			.then(|| self.broadcast.clone())
+	}
+}


### PR DESCRIPTION
## Summary

**Root cause.** `Broadcaster::new` resolved the catalog broadcast once and held that consumer, but renditions kept only a path and resolved the media broadcast lazily through the origin. Resolving a path by name is not idempotent: `attach_source` treats a same-path republish as a takeover and installs a brand new broadcast at the leaf. Since `same_publisher` returns false whenever either publisher is `Origin::UNKNOWN`, and an ordinary non-relay client gets `Origin::UNKNOWN`, **every same-path republish from a normal publisher qualifies, including a plain publisher reconnect.**

The result was the replacement's groups served under the replaced broadcast's manifest, segment numbering, and PROGRAM-DATE-TIME. Because the replacement restarts group numbering, that is either a 404 or, when the numbers happen to overlap, silent cross-epoch corruption.

Note the split is wider than a catalog/media one: the timeline is per-rendition and resolved by the same lazy lookup as the media, so pre-fix it was catalog from A versus *timeline and media* from B.

New crate-private `Upstream { source, broadcast }` carries the already-resolved catalog consumer alongside the `Source` needed to follow a cross-broadcast reference, threaded through `watch_catalog` -> `renditions::sync` -> `Rendition::video`/`audio`. `Upstream::local(rel)` answers "which broadcast serves this rendition" without a round trip when the reference is absent or empty, seeding `segments::Producer`'s `OnceLock`. A named sibling still goes through `Source::resolve`, because `sync` runs synchronously under a `kio` write lock and cannot await.

Post-fix behavior is correct by construction: once the original closes, `broadcast::Consumer::track()` returns `Err(Error::Dropped)`, so `Rendition::track()` yields `None` and `segment()` yields `Ok(None)`, i.e. a 404 rather than the replacement's bytes.

**Residual, not fixed.** A rendition whose catalog `broadcast` field names a real sibling is still resolved lazily by path, so a takeover of *that* path between the catalog snapshot and the watcher's first resolve keeps the same exposure. Closing it needs eager async sibling resolution, which `sync` cannot do under that lock. Related and narrower: a self-reference spelled as a path walking back to the catalog's own path (`../pub`) also falls through to the lazy path, because the path math lives behind `moq_mux::Source`'s private fields.

## Public API changes

None. `Upstream`, `renditions::Producer`, `Rendition::video`/`audio`, and `segments::Producer` are all crate-private; `Broadcaster::new` is unchanged. `Broadcaster::broadcast` keeps its `#[cfg_attr(not(feature = "server"), allow(dead_code))]`, since the media path now flows through `Upstream` rather than that field (confirmed by a clean `--no-default-features` clippy run).

## Test plan

- New `export::tests::a_replacement_publisher_is_not_served_under_the_replaced_catalog`. Two publishers of "live" with distinguishable payloads; the `Upstream` binds to the first, the second takes the path over, then `sync` reconciles the first's catalog snapshot. Asserts the served segment carries none of the replacement's bytes, with a control that a fresh `Upstream` built after the takeover *does* serve them, so the primary assertion is not vacuous. Confirmed failing without the fix.
  - Worth noting: a first attempt that raced the takeover against the spawned watcher passed both with and without the fix, because `request_broadcast` handed back the closing incumbent before the replacement attached. The window that bites is the wider one between resolving the broadcast and reconciling the first catalog snapshot, where `watch_catalog` backs off up to 5s waiting for a catalog track. The committed test models that.
- `cargo clippy -p moq-hls --all-targets -- -D warnings`: clean, and again with `--no-default-features`
- `cargo nextest run -p moq-hls`: 61/61
- `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-hls --no-deps`: clean

(Written by Opus 5)