### PR TITLE
fix(js/net): count advertisements per namespace instead of flagging them

### DIFF
--- a/js/net/src/ietf/subscriber.test.ts
+++ b/js/net/src/ietf/subscriber.test.ts
@@ -1,9 +1,12 @@
 import { expect, test } from "bun:test";
+import type * as announce from "../announced.ts";
 import { createMockTransportPair } from "../mock.ts";
 import * as Path from "../path.ts";
 import { Stream } from "../stream.ts";
 import { NativeSession } from "./adapter.ts";
 import { PublishNamespace } from "./publish_namespace.ts";
+import { RequestOk } from "./request.ts";
+import { SubscribeNamespace, SubscribeNamespaceEntry, SubscribeNamespaceEntryDone } from "./subscribe_namespace.ts";
 import { Subscriber } from "./subscriber.ts";
 import { ALPN, Version } from "./version.ts";
 
@@ -85,4 +88,137 @@ test("an unsolicited announcement lands", async () => {
 	peer?.close();
 	await handler;
 	expect(await announced.next()).toMatchObject({ path: Path.from("surprise"), active: false });
+});
+
+/**
+ * Answer the SUBSCRIBE_NAMESPACE the subscriber just opened, then hand back its stream so
+ * the test can feed inline NAMESPACE entries down it.
+ */
+async function acceptSubscribeNamespace(transport: WebTransport): Promise<Stream> {
+	const stream = await nextStream(transport);
+	if (!stream) throw new Error("no SUBSCRIBE_NAMESPACE was sent");
+
+	// Drain the request, then answer it.
+	await stream.reader.u53();
+	await SubscribeNamespace.decode(stream.reader, VERSION);
+	await stream.writer.u53(RequestOk.id);
+	await new RequestOk({ requestId: undefined }).encode(stream.writer, VERSION);
+
+	return stream;
+}
+
+/** Advertise `path` inline on a SUBSCRIBE_NAMESPACE stream. */
+async function inlineNamespace(stream: Stream, path: Path.Valid): Promise<void> {
+	await stream.writer.u53(SubscribeNamespaceEntry.id);
+	await new SubscribeNamespaceEntry({ suffix: path }).encode(stream.writer, VERSION);
+}
+
+/**
+ * Advertise a path nothing else uses and wait for it, which proves the entries written
+ * before it on the same stream have been read. Announcing an already-announced path is
+ * silent by design, so it cannot be waited on directly.
+ */
+async function syncInline(stream: Stream, announced: announce.Consumer): Promise<void> {
+	await inlineNamespace(stream, Path.from("sentinel"));
+	expect(await announced.next()).toMatchObject({ path: Path.from("sentinel"), active: true });
+}
+
+/**
+ * A peer may advertise one namespace both ways on a session: an unsolicited
+ * PUBLISH_NAMESPACE and an inline NAMESPACE answering our own SUBSCRIBE_NAMESPACE are two
+ * messages about one source, and the MoQ Solicit draft requires us to tolerate it.
+ *
+ * The unsolicited request ending must not retract what the subscription still holds, or a
+ * watcher drops a broadcast that is still being published.
+ */
+test("an announcement survives the first of its two sources ending", async () => {
+	const pair = createMockTransportPair(ALPN.DRAFT_19);
+	const session = new NativeSession(pair.server, VERSION, true);
+	const subscriber = new Subscriber(session);
+
+	const announced = subscriber.announced(Path.empty());
+	const subscription = await acceptSubscribeNamespace(pair.client);
+
+	// Unsolicited first, then the same path inline on the subscription.
+	const request = await Stream.open(pair.server, { version: VERSION });
+	const handler = subscriber.runPublishNamespace(
+		new PublishNamespace({ requestId: 0n, trackNamespace: Path.from("both") }),
+		request,
+	);
+	expect(await announced.next()).toMatchObject({ path: Path.from("both"), active: true });
+
+	await inlineNamespace(subscription, Path.from("both"));
+	await syncInline(subscription, announced);
+
+	// The unsolicited request goes away. The subscription still advertises the path, so
+	// nothing has been withdrawn and there is nothing for the consumer to hear.
+	const peer = await nextStream(pair.client);
+	peer?.close();
+	await handler;
+
+	const next = await Promise.race([
+		announced.next(),
+		new Promise<"nothing">((resolve) => setTimeout(() => resolve("nothing"), 250)),
+	]);
+	expect(next).toBe("nothing");
+});
+
+/**
+ * The mirror of the above, and the reason the count exists rather than a flag: once the
+ * last source goes, the path really is gone and consumers have to hear it.
+ */
+test("an announcement ends once its last source does", async () => {
+	const pair = createMockTransportPair(ALPN.DRAFT_19);
+	const session = new NativeSession(pair.server, VERSION, true);
+	const subscriber = new Subscriber(session);
+
+	const announced = subscriber.announced(Path.empty());
+	const subscription = await acceptSubscribeNamespace(pair.client);
+
+	const request = await Stream.open(pair.server, { version: VERSION });
+	const handler = subscriber.runPublishNamespace(
+		new PublishNamespace({ requestId: 0n, trackNamespace: Path.from("both") }),
+		request,
+	);
+	expect(await announced.next()).toMatchObject({ path: Path.from("both"), active: true });
+
+	await inlineNamespace(subscription, Path.from("both"));
+	await syncInline(subscription, announced);
+
+	const peer = await nextStream(pair.client);
+	peer?.close();
+	await handler;
+
+	// Now the subscription drops it too, which is the last reference.
+	await subscription.writer.u53(SubscribeNamespaceEntryDone.id);
+	await new SubscribeNamespaceEntryDone({ suffix: Path.from("both") }).encode(subscription.writer, VERSION);
+
+	expect(await announced.next()).toMatchObject({ path: Path.from("both"), active: false });
+});
+
+/**
+ * A stream owns every advertisement it carried, so losing it retracts them: closing a
+ * subscription withdraws nothing on the wire, since NAMESPACE_DONE is what does that.
+ * Whatever is still live outlived its channel, and a count left behind would pin the path
+ * for the rest of the session, for every other consumer too.
+ */
+test("a subscription that dies releases what it advertised", async () => {
+	const pair = createMockTransportPair(ALPN.DRAFT_19);
+	const session = new NativeSession(pair.server, VERSION, true);
+	const subscriber = new Subscriber(session);
+
+	// Two feeds, so one outlives the stream that carries the advertisement.
+	const doomed = subscriber.announced(Path.empty());
+	const streamA = await acceptSubscribeNamespace(pair.client);
+	const survivor = subscriber.announced(Path.empty());
+	await acceptSubscribeNamespace(pair.client);
+
+	await inlineNamespace(streamA, Path.from("orphan"));
+	expect(await doomed.next()).toMatchObject({ path: Path.from("orphan"), active: true });
+	expect(await survivor.next()).toMatchObject({ path: Path.from("orphan"), active: true });
+
+	// The stream that advertised it goes away without a NAMESPACE_DONE.
+	streamA.writer.close();
+
+	expect(await survivor.next()).toMatchObject({ path: Path.from("orphan"), active: false });
 });

--- a/js/net/src/ietf/subscriber.test.ts
+++ b/js/net/src/ietf/subscriber.test.ts
@@ -85,7 +85,8 @@ test("an unsolicited announcement lands", async () => {
 	// The handler holds the request open until the peer drops it, and withdraws the
 	// namespace on the way out.
 	const peer = await nextStream(pair.client);
-	peer?.close();
+	if (!peer) throw new Error("no PUBLISH_NAMESPACE stream to close");
+	peer.close();
 	await handler;
 	expect(await announced.next()).toMatchObject({ path: Path.from("surprise"), active: false });
 });
@@ -153,7 +154,8 @@ test("an announcement survives the first of its two sources ending", async () =>
 	// The unsolicited request goes away. The subscription still advertises the path, so
 	// nothing has been withdrawn and there is nothing for the consumer to hear.
 	const peer = await nextStream(pair.client);
-	peer?.close();
+	if (!peer) throw new Error("no PUBLISH_NAMESPACE stream to close");
+	peer.close();
 	await handler;
 
 	const next = await Promise.race([
@@ -186,7 +188,8 @@ test("an announcement ends once its last source does", async () => {
 	await syncInline(subscription, announced);
 
 	const peer = await nextStream(pair.client);
-	peer?.close();
+	if (!peer) throw new Error("no PUBLISH_NAMESPACE stream to close");
+	peer.close();
 	await handler;
 
 	// Now the subscription drops it too, which is the last reference.
@@ -221,4 +224,73 @@ test("a subscription that dies releases what it advertised", async () => {
 	streamA.writer.close();
 
 	expect(await survivor.next()).toMatchObject({ path: Path.from("orphan"), active: false });
+});
+
+/**
+ * Draft-14/15 name their namespace-scoped messages instead of numbering them, so the
+ * adapter can hold one request per namespace. A second would overwrite the first and the
+ * withdrawals would go to the wrong stream, then to none at all, killing the session. The
+ * case that makes a second reference legitimate needs an inline NAMESPACE, which those
+ * drafts do not have.
+ */
+test("a duplicate legacy publish_namespace is still refused", async () => {
+	const pair = createMockTransportPair(ALPN.DRAFT_19);
+	const session = new NativeSession(pair.server, Version.DRAFT_15, true);
+	const subscriber = new Subscriber(session);
+
+	const announced = subscriber.announced(Path.empty());
+
+	const first = await Stream.open(pair.server, { version: Version.DRAFT_15 });
+	const handler = subscriber.runPublishNamespace(
+		new PublishNamespace({ requestId: 0n, trackNamespace: Path.from("twice") }),
+		first,
+	);
+	expect(await announced.next()).toMatchObject({ path: Path.from("twice"), active: true });
+
+	// The same namespace again, on its own request.
+	const second = await Stream.open(pair.server, { version: Version.DRAFT_15 });
+	await subscriber.runPublishNamespace(
+		new PublishNamespace({ requestId: 2n, trackNamespace: Path.from("twice") }),
+		second,
+	);
+
+	// Refused, so it took no reference: the first request ending still retracts the path.
+	const peer = await nextStream(pair.client);
+	if (!peer) throw new Error("no PUBLISH_NAMESPACE stream to close");
+	peer.close();
+	await handler;
+
+	expect(await announced.next()).toMatchObject({ path: Path.from("twice"), active: false });
+});
+
+/**
+ * The read loop is not awaited when the local consumer closes first, and closing the
+ * stream cancels the transport without discarding what the reader already buffered. An
+ * entry that decodes after the teardown must not take a reference, or the path is pinned
+ * for the session with nobody left to release it.
+ */
+test("an entry buffered past a consumer close does not pin the path", async () => {
+	const pair = createMockTransportPair(ALPN.DRAFT_19);
+	const session = new NativeSession(pair.server, VERSION, true);
+	const subscriber = new Subscriber(session);
+
+	const announced = subscriber.announced(Path.empty());
+	const subscription = await acceptSubscribeNamespace(pair.client);
+
+	// Both entries land in one chunk, so the second is buffered while the first is being
+	// delivered. Closing the consumer then races the loop that would attach it.
+	await inlineNamespace(subscription, Path.from("first"));
+	await inlineNamespace(subscription, Path.from("buffered"));
+
+	announced.close();
+
+	// Whatever the loop managed to attach, the stream gave back on its way out.
+	await new Promise((resolve) => setTimeout(resolve, 50));
+
+	const fresh = subscriber.announced(Path.empty());
+	const seeded = await Promise.race([
+		fresh.next(),
+		new Promise<"nothing">((resolve) => setTimeout(() => resolve("nothing"), 250)),
+	]);
+	expect(seeded).toBe("nothing");
 });

--- a/js/net/src/ietf/subscriber.test.ts
+++ b/js/net/src/ietf/subscriber.test.ts
@@ -294,3 +294,39 @@ test("an entry buffered past a consumer close does not pin the path", async () =
 	]);
 	expect(seeded).toBe("nothing");
 });
+
+/**
+ * The reservation has to be synchronous. The count is only taken once the OK is written,
+ * so two legacy requests dispatched together would both get past a check that looked only
+ * at what is announced, and both would take a reference for one namespace.
+ */
+test("concurrent legacy publish_namespace requests take one reference", async () => {
+	const pair = createMockTransportPair(ALPN.DRAFT_19);
+	const session = new NativeSession(pair.server, Version.DRAFT_15, true);
+	const subscriber = new Subscriber(session);
+
+	const announced = subscriber.announced(Path.empty());
+
+	// Dispatched together, as the connection would on two incoming streams.
+	const first = await Stream.open(pair.server, { version: Version.DRAFT_15 });
+	const second = await Stream.open(pair.server, { version: Version.DRAFT_15 });
+	const one = subscriber.runPublishNamespace(
+		new PublishNamespace({ requestId: 0n, trackNamespace: Path.from("raced") }),
+		first,
+	);
+	const two = subscriber.runPublishNamespace(
+		new PublishNamespace({ requestId: 2n, trackNamespace: Path.from("raced") }),
+		second,
+	);
+
+	expect(await announced.next()).toMatchObject({ path: Path.from("raced"), active: true });
+	await two;
+
+	// Only one reference was taken, so the surviving request ending retracts the path.
+	const peer = await nextStream(pair.client);
+	if (!peer) throw new Error("no PUBLISH_NAMESPACE stream to close");
+	peer.close();
+	await one;
+
+	expect(await announced.next()).toMatchObject({ path: Path.from("raced"), active: false });
+});

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -13,7 +13,7 @@ import { TrackAliases } from "./aliases.ts";
 import { Frame, type Group as GroupMessage } from "./object.ts";
 import { toWire } from "./priority.ts";
 import { type Publish, PublishError } from "./publish.ts";
-import { type PublishNamespace, PublishNamespaceError, PublishNamespaceOk } from "./publish_namespace.ts";
+import { type PublishNamespace, PublishNamespaceOk } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
 import { Subscribe, SubscribeError, SubscribeOk, Unsubscribe } from "./subscribe.ts";
 import {
@@ -60,8 +60,14 @@ export class Subscriber {
 	// Dedup consumed broadcasts per path: repeat consume() calls share one subscription.
 	#consumes = new BroadcastCache();
 
-	// Any currently active announcements.
-	#announced = new Set<Path.Valid>();
+	// Every announced path, counted by how many live advertisements reference it.
+	//
+	// A peer may advertise one namespace twice on a session: an unsolicited
+	// PUBLISH_NAMESPACE and an inline NAMESPACE answering our own SUBSCRIBE_NAMESPACE are
+	// two messages about one source, which the MoQ Solicit draft requires us to tolerate.
+	// Counting them is what keeps the second from duplicating the announce and the first
+	// to end from retracting what the other still holds.
+	#announced = new Map<Path.Valid, number>();
 
 	// Any consumers that want each new announcement.
 	#announcedConsumers = new Set<announce.Producer>();
@@ -85,7 +91,7 @@ export class Subscriber {
 	 */
 	announced(prefix = Path.empty()): announce.Consumer {
 		const announced = new announce.Producer(prefix);
-		for (const active of this.#announced) {
+		for (const active of this.#announced.keys()) {
 			const suffix = Path.stripPrefix(prefix, active);
 			if (suffix === null) continue;
 			announced.append({ path: suffix, active: true });
@@ -100,8 +106,58 @@ export class Subscriber {
 		return announced.consume();
 	}
 
+	/**
+	 * Record one more advertisement for a path, telling consumers only when it is the
+	 * first. A second one is the same namespace said twice, not news.
+	 */
+	#attachAnnounce(path: Path.Valid) {
+		const count = this.#announced.get(path) ?? 0;
+		this.#announced.set(path, count + 1);
+		if (count > 0) return;
+
+		console.debug(`announced: broadcast=${path} active=true`);
+		for (const consumer of this.#announcedConsumers) {
+			const suffix = Path.stripPrefix(consumer.prefix, path);
+			if (suffix === null) continue;
+			consumer.append({ path: suffix, active: true });
+		}
+	}
+
+	/**
+	 * Drop one advertisement for a path, retracting it only once the last one goes.
+	 */
+	#detachAnnounce(path: Path.Valid) {
+		const count = this.#announced.get(path);
+		if (count === undefined) return;
+		if (count > 1) {
+			this.#announced.set(path, count - 1);
+			return;
+		}
+
+		this.#announced.delete(path);
+
+		// The path is gone, so stop sharing its broadcast: a holder outliving the publisher
+		// would otherwise hand the dead generation to whoever consumes the path next.
+		this.#consumes.evict(path);
+		console.debug(`announced: broadcast=${path} active=false`);
+
+		for (const consumer of this.#announcedConsumers) {
+			const suffix = Path.stripPrefix(consumer.prefix, path);
+			if (suffix === null) continue;
+			try {
+				consumer.append({ path: suffix, active: false });
+			} catch {
+				// Consumer already closed, will be cleaned up
+			}
+		}
+	}
+
 	async #runAnnounced(announced: announce.Producer, prefix: Path.Valid) {
 		const version = this.#session.version;
+
+		// Suffixes live on this stream, so a repeat is recognized as an update to the
+		// advertisement rather than a second one, which would leak the count.
+		const live = new Set<Path.Valid>();
 
 		// v14/v15: SubscribeNamespace on control stream (via adapter virtual stream)
 		// v16+: SubscribeNamespace on its own real bidi stream
@@ -155,25 +211,18 @@ export class Subscriber {
 						if (msgType === SubscribeNamespaceEntry.id) {
 							const entry = await SubscribeNamespaceEntry.decode(stream.reader, version);
 							const path = Path.join(prefix, entry.suffix);
-							console.debug(`announced: broadcast=${path} active=true`);
 
-							this.#announced.add(path);
-							for (const consumer of this.#announcedConsumers) {
-								const suffix = Path.stripPrefix(consumer.prefix, path);
-								if (suffix === null) continue;
-								consumer.append({ path: suffix, active: true });
+							// A repeat updates the advertisement; only the first is news.
+							if (!live.has(path)) {
+								live.add(path);
+								this.#attachAnnounce(path);
 							}
 						} else if (msgType === SubscribeNamespaceEntryDone.id) {
 							const entry = await SubscribeNamespaceEntryDone.decode(stream.reader, version);
 							const path = Path.join(prefix, entry.suffix);
-							console.debug(`announced: broadcast=${path} active=false`);
 
-							this.#announced.delete(path);
-							this.#consumes.evict(path);
-							for (const consumer of this.#announcedConsumers) {
-								const suffix = Path.stripPrefix(consumer.prefix, path);
-								if (suffix === null) continue;
-								consumer.append({ path: suffix, active: false });
+							if (live.delete(path)) {
+								this.#detachAnnounce(path);
 							}
 						} else if (msgType === PublishBlocked.id && version === Version.DRAFT_17) {
 							const blocked = await PublishBlocked.decode(stream.reader, version);
@@ -214,6 +263,15 @@ export class Subscriber {
 			// it from "nothing is published under this prefix" waits forever on a broadcast
 			// that will never be announced. Matches the lite subscriber.
 			announced.close(e);
+		} finally {
+			// The stream owns every advertisement it carried, so release them however it
+			// ends: a clean close, a decode error, or the peer resetting it. Without this
+			// each namespace keeps its count and the source never detaches, which would
+			// pin the path for the session even after the other source withdrew.
+			for (const path of live) {
+				this.#detachAnnounce(path);
+			}
+			live.clear();
 		}
 	}
 
@@ -404,30 +462,10 @@ export class Subscriber {
 		const version = this.#session.version;
 		const path = msg.trackNamespace;
 
-		if (this.#announced.has(path)) {
-			console.warn("duplicate PublishNamespace");
-			if (version === Version.DRAFT_14) {
-				await stream.writer.u53(PublishNamespaceError.id);
-				const err = new PublishNamespaceError({
-					requestId: msg.requestId,
-					errorCode: 409,
-					reasonPhrase: "duplicate namespace",
-				});
-				await err.encode(stream.writer, version);
-			} else {
-				await stream.writer.u53(RequestError.id);
-				const err = new RequestError({
-					requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
-					errorCode: 409,
-					reasonPhrase: "duplicate namespace",
-				});
-				await err.encode(stream.writer, version);
-			}
-			stream.close();
-			return;
-		}
-
-		this.#announced.add(path);
+		// A path this session already knows is not refused: the same namespace can reach
+		// us twice, and the count is what tells the second apart from news. This request
+		// owns exactly one of those references and gives it back when the stream ends.
+		let attached = false;
 
 		try {
 			// Send OK first. This must complete before notifying consumers,
@@ -445,34 +483,20 @@ export class Subscriber {
 				await ok.encode(stream.writer, version);
 			}
 
-			console.debug(`announced: broadcast=${path} active=true`);
-
-			// Notify consumers after OK is written
-			for (const consumer of this.#announcedConsumers) {
-				const suffix = Path.stripPrefix(consumer.prefix, path);
-				if (suffix === null) continue;
-				consumer.append({ path: suffix, active: true });
-			}
+			// Only now is the advertisement ours to announce, for the reason above: a
+			// consumer reacting with a SUBSCRIBE must not interleave with that OK.
+			attached = true;
+			this.#attachAnnounce(path);
 
 			// Wait for stream close (= PublishNamespaceDone)
 			console.debug(`runPublishNamespace: awaiting stream.reader.closed for ${path}`);
 			await stream.reader.closed;
 			console.debug(`runPublishNamespace: stream.reader.closed resolved for ${path}`);
 		} finally {
-			this.#announced.delete(path);
-			// The path is gone, so stop sharing its broadcast: a holder outliving the publisher
-			// would otherwise hand the dead generation to whoever consumes the path next.
-			this.#consumes.evict(path);
-			console.debug(`announced: broadcast=${path} active=false`);
-
-			for (const consumer of this.#announcedConsumers) {
-				const suffix = Path.stripPrefix(consumer.prefix, path);
-				if (suffix === null) continue;
-				try {
-					consumer.append({ path: suffix, active: false });
-				} catch {
-					// Consumer already closed, will be cleaned up
-				}
+			// Give back exactly what was taken: a request that never got its OK out never
+			// referenced the path, and retracting there would drop someone else's count.
+			if (attached) {
+				this.#detachAnnounce(path);
 			}
 		}
 	}

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -60,6 +60,11 @@ export class Subscriber {
 	// Dedup consumed broadcasts per path: repeat consume() calls share one subscription.
 	#consumes = new BroadcastCache();
 
+	// Paths with a legacy PUBLISH_NAMESPACE request in flight, reserved synchronously.
+	// The count below is only taken once the OK is written, and two requests that both
+	// got past the duplicate check before either attached would both take one.
+	#legacyRequests = new Set<Path.Valid>();
+
 	// Every announced path, counted by how many live advertisements reference it.
 	//
 	// A peer may advertise one namespace twice on a session: an unsolicited
@@ -478,7 +483,8 @@ export class Subscriber {
 		// the other. Nothing is lost by refusing it, because the case that makes a second
 		// reference legitimate (an inline NAMESPACE for a path a PUBLISH_NAMESPACE already
 		// carried) needs a message those drafts do not have.
-		if ((version === Version.DRAFT_14 || version === Version.DRAFT_15) && this.#announced.has(path)) {
+		const legacy = version === Version.DRAFT_14 || version === Version.DRAFT_15;
+		if (legacy && (this.#announced.has(path) || this.#legacyRequests.has(path))) {
 			console.warn("duplicate PublishNamespace");
 			if (version === Version.DRAFT_14) {
 				await stream.writer.u53(PublishNamespaceError.id);
@@ -503,6 +509,7 @@ export class Subscriber {
 		// namespace can reach us twice, and the count is what tells the second apart from
 		// news. This request owns exactly one of those references and gives it back when
 		// the stream ends.
+		if (legacy) this.#legacyRequests.add(path);
 		let attached = false;
 
 		try {
@@ -531,6 +538,8 @@ export class Subscriber {
 			await stream.reader.closed;
 			console.debug(`runPublishNamespace: stream.reader.closed resolved for ${path}`);
 		} finally {
+			if (legacy) this.#legacyRequests.delete(path);
+
 			// Give back exactly what was taken: a request that never got its OK out never
 			// referenced the path, and retracting there would drop someone else's count.
 			if (attached) {

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -13,7 +13,7 @@ import { TrackAliases } from "./aliases.ts";
 import { Frame, type Group as GroupMessage } from "./object.ts";
 import { toWire } from "./priority.ts";
 import { type Publish, PublishError } from "./publish.ts";
-import { type PublishNamespace, PublishNamespaceOk } from "./publish_namespace.ts";
+import { type PublishNamespace, PublishNamespaceError, PublishNamespaceOk } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
 import { Subscribe, SubscribeError, SubscribeOk, Unsubscribe } from "./subscribe.ts";
 import {
@@ -159,6 +159,13 @@ export class Subscriber {
 		// advertisement rather than a second one, which would leak the count.
 		const live = new Set<Path.Valid>();
 
+		// Set once the teardown below has given back everything this stream held. The read
+		// loop is not awaited when the local consumer closes first, and closing the stream
+		// cancels the transport without discarding what the reader already buffered, so a
+		// fully buffered entry can still decode afterwards. Attaching one then would take a
+		// reference nobody is left to release, pinning the path for the session.
+		let released = false;
+
 		// v14/v15: SubscribeNamespace on control stream (via adapter virtual stream)
 		// v16+: SubscribeNamespace on its own real bidi stream
 
@@ -210,6 +217,7 @@ export class Subscriber {
 						const msgType = await stream.reader.u53();
 						if (msgType === SubscribeNamespaceEntry.id) {
 							const entry = await SubscribeNamespaceEntry.decode(stream.reader, version);
+							if (released) break;
 							const path = Path.join(prefix, entry.suffix);
 
 							// A repeat updates the advertisement; only the first is news.
@@ -219,6 +227,7 @@ export class Subscriber {
 							}
 						} else if (msgType === SubscribeNamespaceEntryDone.id) {
 							const entry = await SubscribeNamespaceEntryDone.decode(stream.reader, version);
+							if (released) break;
 							const path = Path.join(prefix, entry.suffix);
 
 							if (live.delete(path)) {
@@ -268,6 +277,7 @@ export class Subscriber {
 			// ends: a clean close, a decode error, or the peer resetting it. Without this
 			// each namespace keeps its count and the source never detaches, which would
 			// pin the path for the session even after the other source withdrew.
+			released = true;
 			for (const path of live) {
 				this.#detachAnnounce(path);
 			}
@@ -462,9 +472,37 @@ export class Subscriber {
 		const version = this.#session.version;
 		const path = msg.trackNamespace;
 
-		// A path this session already knows is not refused: the same namespace can reach
-		// us twice, and the count is what tells the second apart from news. This request
-		// owns exactly one of those references and gives it back when the stream ends.
+		// Draft-14/15 key their namespace-scoped messages by name, not request ID, so the
+		// adapter can hold only one request per namespace: a second would overwrite the
+		// first, and the withdrawals would then close the wrong stream and fail to find
+		// the other. Nothing is lost by refusing it, because the case that makes a second
+		// reference legitimate (an inline NAMESPACE for a path a PUBLISH_NAMESPACE already
+		// carried) needs a message those drafts do not have.
+		if ((version === Version.DRAFT_14 || version === Version.DRAFT_15) && this.#announced.has(path)) {
+			console.warn("duplicate PublishNamespace");
+			if (version === Version.DRAFT_14) {
+				await stream.writer.u53(PublishNamespaceError.id);
+				await new PublishNamespaceError({
+					requestId: msg.requestId,
+					errorCode: 409,
+					reasonPhrase: "duplicate namespace",
+				}).encode(stream.writer, version);
+			} else {
+				await stream.writer.u53(RequestError.id);
+				await new RequestError({
+					requestId: msg.requestId,
+					errorCode: 409,
+					reasonPhrase: "duplicate namespace",
+				}).encode(stream.writer, version);
+			}
+			stream.close();
+			return;
+		}
+
+		// Everywhere else a path this session already knows is not refused: the same
+		// namespace can reach us twice, and the count is what tells the second apart from
+		// news. This request owns exactly one of those references and gives it back when
+		// the stream ends.
 		let attached = false;
 
 		try {


### PR DESCRIPTION
Fixes #2776.

## The problem

A peer may advertise one namespace twice on a session: an unsolicited `PUBLISH_NAMESPACE` and an inline `NAMESPACE` answering our own `SUBSCRIBE_NAMESPACE` are two messages about one source. [MoQ Solicit](https://github.com/moq-dev/moq/blob/main/drafts/draft-lcurley-moq-solicit.md) requires a receiver to tolerate exactly this, and now that we always declare the option, the peers that ignore it are the ones that will produce it.

`js/net`'s IETF subscriber tracked announced paths in a bare `Set<Path.Valid>`, so the two sources overwrote each other:

- **`PUBLISH_NAMESPACE` first, then inline:** the inline entry re-delivered `active: true` as if it were news, and when the request stream later closed, its `finally` deleted the path, evicted the broadcast, and emitted `active: false` while the subscription was still advertising it. A watcher dropped a broadcast that was still being published.
- **Inline first, then `PUBLISH_NAMESPACE`:** the request was refused with 409, which is survivable but is the same asymmetry seen from the other side.

Rust has refcounted this since it grew the second discovery path (`count` in `rs/moq-net/src/ietf/subscriber.rs`, decremented in `stop_announce`, dropping the entry only at zero). Its comment names the case directly: a session's `PUBLISH_NAMESPACE` and `NAMESPACE` for one namespace "are two messages about a single source".

## The fix

The `Set` becomes a count, and one place owns the edges: consumers hear an announce on 0 to 1 and a withdrawal (plus the `#consumes.evict`) on 1 to 0, nothing in between.

Counting only works if each source takes exactly one reference and gives it back, so the two rules Rust already had come with it:

- **A repeat `NAMESPACE` entry on one stream is an update**, not a second reference. The cluster extension re-sends an entry to re-price a route, and counting that would leak.
- **A stream releases everything it carried, however it ends** — clean close, decode error, or reset. Closing retracts nothing on the wire (`NAMESPACE_DONE` is what does that), so a count left behind would pin the path for the rest of the session, for every other consumer too.

A duplicate `PUBLISH_NAMESPACE` is no longer refused with 409; it is simply another reference, matching Rust.

One ordering constraint is preserved: `runPublishNamespace` still writes its OK before announcing to consumers, since a consumer may react with a `SUBSCRIBE` that would otherwise interleave with that OK on the control stream. The attach moved after the write, and the `finally` gives back only what was taken.

## Tests

Three, each verified to fail with its fix reverted:

- `an announcement survives the first of its two sources ending` — the reported bug.
- `an announcement ends once its last source does` — the other edge, so the count can't just be a flag that never clears.
- `a subscription that dies releases what it advertised` — the teardown, observed through a second feed that outlives the stream.

Ordering between the two sources is made deterministic with a sentinel path on the same stream rather than a sleep: announcing an already-announced path is silent by design, so it can't be awaited directly.

`just check`, `bun test` (390), and the full `just test smoke-full` matrix all pass. No Rust changed.

(Written by Opus 5)