### PR TITLE
feat(libmoq): declare the catalog container for manually authored renditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,6 +4257,7 @@ dependencies = [
  "hang",
  "moq-audio",
  "moq-json",
+ "moq-loc",
  "moq-mux",
  "moq-native",
  "moq-net",

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -38,3 +38,6 @@ url = "2"
 
 [build-dependencies]
 cbindgen = "0.29"
+
+[dev-dependencies]
+moq-loc = { workspace = true }

--- a/rs/libmoq/build.rs
+++ b/rs/libmoq/build.rs
@@ -6,6 +6,7 @@ const LIB_NAME: &str = "moq";
 
 /// Enums the header must declare even though no signature mentions them.
 const ENUMS: &[&str] = &[
+	"moq_container_kind",
 	"moq_audio_format",
 	"moq_video_pixel_format",
 	"moq_video_codec",

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -6,6 +6,101 @@ use std::str::FromStr;
 
 use tracing::Level;
 
+/// How a media track's frames are wrapped, independent of the codec.
+///
+/// The ABI carries this as a `uint32_t`, so an unknown discriminant from C is an
+/// error rather than UB.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug)]
+pub enum moq_container_kind {
+	/// A QUIC VarInt timestamp prefix followed by the raw codec payload.
+	/// Timestamps are in microseconds.
+	MOQ_CONTAINER_KIND_LEGACY = 0,
+	/// Fragmented MP4: each frame is a complete moof+mdat fragment, described by
+	/// the init segment in `moq_container::init`.
+	MOQ_CONTAINER_KIND_CMAF = 1,
+	/// Low Overhead Container (draft-ietf-moq-loc): a small property block
+	/// followed by the codec payload.
+	MOQ_CONTAINER_KIND_LOC = 2,
+	/// A container this build does not recognize, so the rendition must be
+	/// ignored. Only ever read out of a catalog: publishing it is an error.
+	MOQ_CONTAINER_KIND_UNKNOWN = 3,
+}
+
+/// The container of a video or audio rendition, plus whatever that container
+/// needs to describe itself.
+///
+/// Zeroing this struct means `MOQ_CONTAINER_KIND_LEGACY` with no init segment,
+/// which is what a rendition written by [moq_publish_media] carries.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
+pub struct moq_container {
+	/// `moq_container_kind` discriminant.
+	pub kind: u32,
+
+	/// The CMAF init segment (ftyp+moov), or NULL.
+	/// Read only when `kind` is `MOQ_CONTAINER_KIND_CMAF`, where it is required.
+	pub init: *const u8,
+	pub init_len: usize,
+}
+
+impl Default for moq_container {
+	fn default() -> Self {
+		Self {
+			kind: moq_container_kind::MOQ_CONTAINER_KIND_LEGACY as u32,
+			init: std::ptr::null(),
+			init_len: 0,
+		}
+	}
+}
+
+/// # Safety
+/// - `container->init` must point to `container->init_len` bytes when
+///   `container->kind` is `MOQ_CONTAINER_KIND_CMAF`.
+pub(crate) unsafe fn parse_container(container: &moq_container) -> Result<hang::catalog::Container, Error> {
+	use hang::catalog::Container;
+
+	Ok(match container.kind {
+		v if v == moq_container_kind::MOQ_CONTAINER_KIND_LEGACY as u32 => Container::Legacy,
+		v if v == moq_container_kind::MOQ_CONTAINER_KIND_CMAF as u32 => {
+			let init = unsafe { ffi::parse_slice(container.init, container.init_len)? };
+			// A CMAF rendition is undecodable without its init segment, so an empty one
+			// fails here rather than at every subscriber.
+			if init.is_empty() {
+				return Err(Error::InvalidPointer);
+			}
+
+			Container::Cmaf {
+				init: bytes::Bytes::copy_from_slice(init),
+			}
+		}
+		v if v == moq_container_kind::MOQ_CONTAINER_KIND_LOC as u32 => Container::Loc,
+		// UNKNOWN included: we kept none of the original JSON, so there is nothing to republish.
+		_ => return Err(Error::InvalidCode),
+	})
+}
+
+/// Describe a catalog container for C, borrowing the CMAF init segment rather
+/// than copying it, so the result lives only as long as the catalog snapshot.
+pub(crate) fn borrow_container(container: &hang::catalog::Container) -> moq_container {
+	use hang::catalog::Container;
+
+	let (kind, init) = match container {
+		Container::Legacy => (moq_container_kind::MOQ_CONTAINER_KIND_LEGACY, None),
+		Container::Cmaf { init } => (moq_container_kind::MOQ_CONTAINER_KIND_CMAF, Some(init)),
+		Container::Loc => (moq_container_kind::MOQ_CONTAINER_KIND_LOC, None),
+		Container::Unknown(_) => (moq_container_kind::MOQ_CONTAINER_KIND_UNKNOWN, None),
+	};
+
+	moq_container {
+		kind: kind as u32,
+		init: init.map_or(std::ptr::null(), |init| init.as_ptr()),
+		init_len: init.map_or(0, |init| init.len()),
+	}
+}
+
 /// Information about a video rendition in the catalog.
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -28,6 +123,9 @@ pub struct moq_video_config {
 	/// The encoded width/height of the media, or NULL if not available
 	pub coded_width: *const u32,
 	pub coded_height: *const u32,
+
+	/// How the track's frames are wrapped.
+	pub container: moq_container,
 }
 
 /// Catalog properties shared by every video rendition.
@@ -80,6 +178,9 @@ pub struct moq_audio_config {
 
 	/// The number of channels in the track
 	pub channel_count: u32,
+
+	/// How the track's frames are wrapped.
+	pub container: moq_container,
 }
 
 /// Options for a JSON snapshot track (lossy latest-value mode).
@@ -1673,28 +1774,6 @@ pub unsafe extern "C" fn moq_publish_video_properties(broadcast: u32, properties
 	})
 }
 
-/// Container used by a manually authored media rendition.
-///
-/// The ABI accepts this as a `uint32_t`, so unknown values return
-/// `Error::InvalidCode` instead of constructing an invalid Rust enum.
-#[repr(C)]
-#[allow(non_camel_case_types)]
-#[derive(Clone, Copy, Debug)]
-pub enum moq_media_container {
-	/// A QUIC VarInt timestamp prefix followed by the codec payload.
-	MOQ_MEDIA_CONTAINER_LEGACY = 0,
-	/// Low Overhead Container (draft-ietf-moq-loc).
-	MOQ_MEDIA_CONTAINER_LOC = 1,
-}
-
-fn media_container_from_u32(value: u32) -> Result<hang::catalog::Container, Error> {
-	Ok(match value {
-		v if v == moq_media_container::MOQ_MEDIA_CONTAINER_LEGACY as u32 => hang::catalog::Container::Legacy,
-		v if v == moq_media_container::MOQ_MEDIA_CONTAINER_LOC as u32 => hang::catalog::Container::Loc,
-		_ => return Err(Error::InvalidCode),
-	})
-}
-
 /// Add or replace a video rendition in a broadcast's catalog.
 ///
 /// This is the producer counterpart to [moq_consume_video_config]: instead of
@@ -1707,6 +1786,10 @@ fn media_container_from_u32(value: u32) -> Result<hang::catalog::Container, Erro
 /// - `name` / `codec` are required (NOT NULL terminated) string slices.
 /// - `description` may be NULL to omit it.
 /// - `coded_width` / `coded_height` may be NULL to omit them.
+/// - `container` describes how the frames written to the track are wrapped. A
+///   zeroed one declares the legacy container, which is what [moq_publish_media]
+///   writes; declare CMAF or LOC for a [moq_publish_track] whose frames you
+///   already encode that way.
 ///
 /// Returns a zero on success, or a negative code on failure.
 ///
@@ -1715,26 +1798,6 @@ fn media_container_from_u32(value: u32) -> Result<hang::catalog::Container, Erro
 /// - The caller must ensure each non-NULL pointer inside `config` is valid for its length.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const moq_video_config) -> i32 {
-	unsafe {
-		moq_publish_video_config_with_container(broadcast, config, moq_media_container::MOQ_MEDIA_CONTAINER_LEGACY as u32)
-	}
-}
-
-/// Add or replace a video rendition with an explicit frame container.
-///
-/// LOC is intended for tracks created with [moq_publish_track] whose frames
-/// have already been encoded according to draft-ietf-moq-loc.
-///
-/// Returns a zero on success, or a negative code on failure.
-///
-/// # Safety
-/// - Same contract as [moq_publish_video_config].
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_publish_video_config_with_container(
-	broadcast: u32,
-	config: *const moq_video_config,
-	container: u32,
-) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
@@ -1750,7 +1813,7 @@ pub unsafe extern "C" fn moq_publish_video_config_with_container(
 		}
 		video.coded_width = unsafe { config.coded_width.as_ref() }.copied();
 		video.coded_height = unsafe { config.coded_height.as_ref() }.copied();
-		video.container = media_container_from_u32(container)?;
+		video.container = unsafe { parse_container(&config.container)? };
 
 		State::lock().publish.video_config(broadcast, name, video)
 	})
@@ -1766,6 +1829,8 @@ pub unsafe extern "C" fn moq_publish_video_config_with_container(
 /// - `name` / `codec` are required (NOT NULL terminated) string slices.
 /// - `sample_rate` / `channel_count` are required.
 /// - `description` may be NULL to omit it.
+/// - `container` describes how the frames written to the track are wrapped, the
+///   same as for [moq_publish_video_config].
 ///
 /// Returns a zero on success, or a negative code on failure.
 ///
@@ -1774,23 +1839,6 @@ pub unsafe extern "C" fn moq_publish_video_config_with_container(
 /// - The caller must ensure each non-NULL pointer inside `config` is valid for its length.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_publish_audio_config(broadcast: u32, config: *const moq_audio_config) -> i32 {
-	unsafe {
-		moq_publish_audio_config_with_container(broadcast, config, moq_media_container::MOQ_MEDIA_CONTAINER_LEGACY as u32)
-	}
-}
-
-/// Add or replace an audio rendition with an explicit frame container.
-///
-/// Returns a zero on success, or a negative code on failure.
-///
-/// # Safety
-/// - Same contract as [moq_publish_audio_config].
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_publish_audio_config_with_container(
-	broadcast: u32,
-	config: *const moq_audio_config,
-	container: u32,
-) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
@@ -1800,7 +1848,7 @@ pub unsafe extern "C" fn moq_publish_audio_config_with_container(
 		let codec = hang::catalog::AudioCodec::from_str(codec).map_err(Error::Hang)?;
 
 		let mut audio = hang::catalog::AudioConfig::new(codec, config.sample_rate, config.channel_count);
-		audio.container = media_container_from_u32(container)?;
+		audio.container = unsafe { parse_container(&config.container)? };
 		if !config.description.is_null() {
 			let description = unsafe { ffi::parse_slice(config.description, config.description_len)? };
 			audio.description = Some(bytes::Bytes::copy_from_slice(description));
@@ -2256,7 +2304,9 @@ pub extern "C" fn moq_consume_catalog_free(catalog: u32) -> i32 {
 
 /// Query information about a video track in a catalog.
 ///
-/// The destination is filled with the video track information.
+/// The destination is filled with the video track information. `dst->container`
+/// says how the track's frames are wrapped; skip a rendition whose kind is
+/// `MOQ_CONTAINER_KIND_UNKNOWN`, since this build cannot parse it.
 ///
 /// Returns a zero on success, or a negative code on failure.
 ///
@@ -2293,7 +2343,9 @@ pub unsafe extern "C" fn moq_consume_video_properties(catalog: u32, dst: *mut mo
 
 /// Query information about an audio track in a catalog.
 ///
-/// The destination is filled with the audio track information.
+/// The destination is filled with the audio track information. `dst->container`
+/// says how the track's frames are wrapped; skip a rendition whose kind is
+/// `MOQ_CONTAINER_KIND_UNKNOWN`, since this build cannot parse it.
 ///
 /// Returns a zero on success, or a negative code on failure.
 ///

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -1673,6 +1673,28 @@ pub unsafe extern "C" fn moq_publish_video_properties(broadcast: u32, properties
 	})
 }
 
+/// Container used by a manually authored media rendition.
+///
+/// The ABI accepts this as a `uint32_t`, so unknown values return
+/// `Error::InvalidCode` instead of constructing an invalid Rust enum.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug)]
+pub enum moq_media_container {
+	/// A QUIC VarInt timestamp prefix followed by the codec payload.
+	MOQ_MEDIA_CONTAINER_LEGACY = 0,
+	/// Low Overhead Container (draft-ietf-moq-loc).
+	MOQ_MEDIA_CONTAINER_LOC = 1,
+}
+
+fn media_container_from_u32(value: u32) -> Result<hang::catalog::Container, Error> {
+	Ok(match value {
+		v if v == moq_media_container::MOQ_MEDIA_CONTAINER_LEGACY as u32 => hang::catalog::Container::Legacy,
+		v if v == moq_media_container::MOQ_MEDIA_CONTAINER_LOC as u32 => hang::catalog::Container::Loc,
+		_ => return Err(Error::InvalidCode),
+	})
+}
+
 /// Add or replace a video rendition in a broadcast's catalog.
 ///
 /// This is the producer counterpart to [moq_consume_video_config]: instead of
@@ -1693,6 +1715,26 @@ pub unsafe extern "C" fn moq_publish_video_properties(broadcast: u32, properties
 /// - The caller must ensure each non-NULL pointer inside `config` is valid for its length.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const moq_video_config) -> i32 {
+	unsafe {
+		moq_publish_video_config_with_container(broadcast, config, moq_media_container::MOQ_MEDIA_CONTAINER_LEGACY as u32)
+	}
+}
+
+/// Add or replace a video rendition with an explicit frame container.
+///
+/// LOC is intended for tracks created with [moq_publish_track] whose frames
+/// have already been encoded according to draft-ietf-moq-loc.
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - Same contract as [moq_publish_video_config].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_video_config_with_container(
+	broadcast: u32,
+	config: *const moq_video_config,
+	container: u32,
+) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
@@ -1708,6 +1750,7 @@ pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const
 		}
 		video.coded_width = unsafe { config.coded_width.as_ref() }.copied();
 		video.coded_height = unsafe { config.coded_height.as_ref() }.copied();
+		video.container = media_container_from_u32(container)?;
 
 		State::lock().publish.video_config(broadcast, name, video)
 	})
@@ -1731,6 +1774,23 @@ pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const
 /// - The caller must ensure each non-NULL pointer inside `config` is valid for its length.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_publish_audio_config(broadcast: u32, config: *const moq_audio_config) -> i32 {
+	unsafe {
+		moq_publish_audio_config_with_container(broadcast, config, moq_media_container::MOQ_MEDIA_CONTAINER_LEGACY as u32)
+	}
+}
+
+/// Add or replace an audio rendition with an explicit frame container.
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - Same contract as [moq_publish_audio_config].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_audio_config_with_container(
+	broadcast: u32,
+	config: *const moq_audio_config,
+	container: u32,
+) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
@@ -1740,6 +1800,7 @@ pub unsafe extern "C" fn moq_publish_audio_config(broadcast: u32, config: *const
 		let codec = hang::catalog::AudioCodec::from_str(codec).map_err(Error::Hang)?;
 
 		let mut audio = hang::catalog::AudioConfig::new(codec, config.sample_rate, config.channel_count);
+		audio.container = media_container_from_u32(container)?;
 		if !config.description.is_null() {
 			let description = unsafe { ffi::parse_slice(config.description, config.description_len)? };
 			audio.description = Some(bytes::Bytes::copy_from_slice(description));

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -213,6 +213,7 @@ impl Consume {
 				.as_ref()
 				.map(|height| height as *const u32)
 				.unwrap_or(std::ptr::null()),
+			container: crate::api::borrow_container(&config.container),
 		};
 
 		Ok(())
@@ -261,6 +262,7 @@ impl Consume {
 			description_len: config.description.as_ref().map(|desc| desc.len()).unwrap_or(0),
 			sample_rate: config.sample_rate,
 			channel_count: config.channel_count,
+			container: crate::api::borrow_container(&config.container),
 		};
 
 		Ok(())

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -383,6 +383,79 @@ fn publish_catalog_roundtrip() {
 }
 
 #[test]
+fn raw_loc_video_uses_the_declared_catalog_container() {
+	let origin = id(moq_origin_create());
+	let path = b"raw-loc-video";
+	let broadcast = publish_broadcast(origin, path);
+
+	let name = b"video";
+	let track = id(unsafe { moq_publish_track(broadcast, name.as_ptr() as *const c_char, name.len(), std::ptr::null()) });
+
+	let codec = b"vp8";
+	let video = moq_video_config {
+		name: name.as_ptr() as *const c_char,
+		name_len: name.len(),
+		codec: codec.as_ptr() as *const c_char,
+		codec_len: codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		coded_width: std::ptr::null(),
+		coded_height: std::ptr::null(),
+	};
+	assert_eq!(
+		unsafe {
+			moq_publish_video_config_with_container(
+				broadcast,
+				&video,
+				moq_media_container::MOQ_MEDIA_CONTAINER_LOC as u32,
+			)
+		},
+		0
+	);
+
+	let consume = request_broadcast(origin, path);
+	let catalog_cb = Callback::new();
+	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
+	let catalog = id(catalog_cb.recv());
+
+	let frame_cb = Callback::new();
+	let consumer = id(unsafe { moq_consume_video(catalog, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
+
+	let timestamp_us = 42_000;
+	let payload = b"codec frame";
+	let loc = moq_loc::encode(timestamp_us, payload).unwrap();
+	let group = id(moq_publish_track_group(track));
+	assert_eq!(unsafe { moq_publish_group_frame(group, loc.as_ptr(), loc.len(), timestamp_us) }, 0);
+	assert_eq!(moq_publish_group_finish(group), 0);
+
+	let frame_id = id(frame_cb.recv());
+	let mut frame = moq_frame {
+		payload: std::ptr::null(),
+		payload_size: 0,
+		timestamp_us: 0,
+		keyframe: false,
+	};
+	assert_eq!(unsafe { moq_consume_frame(frame_id, &mut frame) }, 0);
+	assert_eq!(frame.timestamp_us, timestamp_us);
+	assert!(frame.keyframe);
+	assert_eq!(
+		unsafe { std::slice::from_raw_parts(frame.payload, frame.payload_size) },
+		payload
+	);
+
+	assert_eq!(moq_consume_frame_free(frame_id), 0);
+	assert_eq!(moq_consume_video_close(consumer), 0);
+	assert_eq!(frame_cb.recv_terminal(), 0);
+	assert_eq!(moq_consume_catalog_free(catalog), 0);
+	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
+	assert_eq!(catalog_cb.recv_terminal(), 0);
+	assert_eq!(moq_consume_close(consume), 0);
+	assert_eq!(moq_publish_track_finish(track), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+#[test]
 fn catalog_section_roundtrip() {
 	let origin = id(moq_origin_create());
 	let path = b"catalog-sections";

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -216,6 +216,7 @@ fn publish_catalog_config_invalid_broadcast() {
 		description_len: 0,
 		coded_width: std::ptr::null(),
 		coded_height: std::ptr::null(),
+		container: moq_container::default(),
 	};
 	assert!(unsafe { moq_publish_video_config(0, &video) } < 0);
 	assert!(unsafe { moq_publish_video_properties(0, &moq_video_properties::default()) } < 0);
@@ -230,6 +231,7 @@ fn publish_catalog_config_invalid_broadcast() {
 		description_len: 0,
 		sample_rate: 48000,
 		channel_count: 2,
+		container: moq_container::default(),
 	};
 	assert!(unsafe { moq_publish_audio_config(0, &audio) } < 0);
 
@@ -280,6 +282,7 @@ fn publish_catalog_roundtrip() {
 		description_len: description.len(),
 		coded_width: &width,
 		coded_height: &height,
+		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_publish_video_config(broadcast, &video) }, 0);
 	let properties = moq_video_properties {
@@ -304,6 +307,7 @@ fn publish_catalog_roundtrip() {
 		description_len: 0,
 		sample_rate: 48000,
 		channel_count: 2,
+		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_publish_audio_config(broadcast, &audio) }, 0);
 
@@ -323,6 +327,7 @@ fn publish_catalog_roundtrip() {
 		description_len: 0,
 		coded_width: std::ptr::null(),
 		coded_height: std::ptr::null(),
+		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_consume_video_config(catalog_id, 0, &mut video_cfg) }, 0);
 	let codec = unsafe {
@@ -356,6 +361,7 @@ fn publish_catalog_roundtrip() {
 		description_len: 0,
 		sample_rate: 0,
 		channel_count: 0,
+		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 0, &mut audio_cfg) }, 0);
 	assert_eq!(audio_cfg.sample_rate, 48000);
@@ -389,7 +395,8 @@ fn raw_loc_video_uses_the_declared_catalog_container() {
 	let broadcast = publish_broadcast(origin, path);
 
 	let name = b"video";
-	let track = id(unsafe { moq_publish_track(broadcast, name.as_ptr() as *const c_char, name.len(), std::ptr::null()) });
+	let track =
+		id(unsafe { moq_publish_track(broadcast, name.as_ptr() as *const c_char, name.len(), std::ptr::null()) });
 
 	let codec = b"vp8";
 	let video = moq_video_config {
@@ -401,22 +408,37 @@ fn raw_loc_video_uses_the_declared_catalog_container() {
 		description_len: 0,
 		coded_width: std::ptr::null(),
 		coded_height: std::ptr::null(),
-	};
-	assert_eq!(
-		unsafe {
-			moq_publish_video_config_with_container(
-				broadcast,
-				&video,
-				moq_media_container::MOQ_MEDIA_CONTAINER_LOC as u32,
-			)
+		container: moq_container {
+			kind: moq_container_kind::MOQ_CONTAINER_KIND_LOC as u32,
+			init: std::ptr::null(),
+			init_len: 0,
 		},
-		0
-	);
+	};
+	assert_eq!(unsafe { moq_publish_video_config(broadcast, &video) }, 0);
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
 	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
 	let catalog = id(catalog_cb.recv());
+
+	// The declaration survives the round trip, so a consumer knows to parse LOC.
+	let mut video_cfg = moq_video_config {
+		name: std::ptr::null(),
+		name_len: 0,
+		codec: std::ptr::null(),
+		codec_len: 0,
+		description: std::ptr::null(),
+		description_len: 0,
+		coded_width: std::ptr::null(),
+		coded_height: std::ptr::null(),
+		container: moq_container::default(),
+	};
+	assert_eq!(unsafe { moq_consume_video_config(catalog, 0, &mut video_cfg) }, 0);
+	assert_eq!(
+		video_cfg.container.kind,
+		moq_container_kind::MOQ_CONTAINER_KIND_LOC as u32
+	);
+	assert!(video_cfg.container.init.is_null());
 
 	let frame_cb = Callback::new();
 	let consumer = id(unsafe { moq_consume_video(catalog, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
@@ -425,7 +447,10 @@ fn raw_loc_video_uses_the_declared_catalog_container() {
 	let payload = b"codec frame";
 	let loc = moq_loc::encode(timestamp_us, payload).unwrap();
 	let group = id(moq_publish_track_group(track));
-	assert_eq!(unsafe { moq_publish_group_frame(group, loc.as_ptr(), loc.len(), timestamp_us) }, 0);
+	assert_eq!(
+		unsafe { moq_publish_group_frame(group, loc.as_ptr(), loc.len(), timestamp_us) },
+		0
+	);
 	assert_eq!(moq_publish_group_finish(group), 0);
 
 	let frame_id = id(frame_cb.recv());
@@ -451,6 +476,124 @@ fn raw_loc_video_uses_the_declared_catalog_container() {
 	assert_eq!(catalog_cb.recv_terminal(), 0);
 	assert_eq!(moq_consume_close(consume), 0);
 	assert_eq!(moq_publish_track_finish(track), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+#[test]
+fn cmaf_catalog_container_carries_its_init_segment() {
+	let origin = id(moq_origin_create());
+	let path = b"cmaf-container";
+	let broadcast = publish_broadcast(origin, path);
+
+	let name = "audio";
+	let codec = "opus";
+	let init: &[u8] = &[0x00, 0x01, 0x02, 0x03];
+	let audio = moq_audio_config {
+		name: name.as_ptr() as *const c_char,
+		name_len: name.len(),
+		codec: codec.as_ptr() as *const c_char,
+		codec_len: codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 48000,
+		channel_count: 2,
+		container: moq_container {
+			kind: moq_container_kind::MOQ_CONTAINER_KIND_CMAF as u32,
+			init: init.as_ptr(),
+			init_len: init.len(),
+		},
+	};
+	assert_eq!(unsafe { moq_publish_audio_config(broadcast, &audio) }, 0);
+
+	let consume = request_broadcast(origin, path);
+	let catalog_cb = Callback::new();
+	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
+	let catalog = id(catalog_cb.recv());
+
+	let mut audio_cfg = moq_audio_config {
+		name: std::ptr::null(),
+		name_len: 0,
+		codec: std::ptr::null(),
+		codec_len: 0,
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 0,
+		channel_count: 0,
+		container: moq_container::default(),
+	};
+	assert_eq!(unsafe { moq_consume_audio_config(catalog, 0, &mut audio_cfg) }, 0);
+	assert_eq!(
+		audio_cfg.container.kind,
+		moq_container_kind::MOQ_CONTAINER_KIND_CMAF as u32
+	);
+	assert_eq!(
+		unsafe { std::slice::from_raw_parts(audio_cfg.container.init, audio_cfg.container.init_len) },
+		init
+	);
+
+	assert_eq!(moq_consume_catalog_free(catalog), 0);
+	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
+	assert_eq!(catalog_cb.recv_terminal(), 0);
+	assert_eq!(moq_consume_close(consume), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+#[test]
+fn unpublishable_catalog_containers_are_rejected() {
+	let origin = id(moq_origin_create());
+	let broadcast = publish_broadcast(origin, b"container-reject");
+
+	let name = "video";
+	let codec = "vp8";
+	let config = |container| moq_video_config {
+		name: name.as_ptr() as *const c_char,
+		name_len: name.len(),
+		codec: codec.as_ptr() as *const c_char,
+		codec_len: codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		coded_width: std::ptr::null(),
+		coded_height: std::ptr::null(),
+		container,
+	};
+
+	// UNKNOWN only ever comes out of a catalog: we keep none of the original JSON, so
+	// there is nothing to write back.
+	let unknown = config(moq_container {
+		kind: moq_container_kind::MOQ_CONTAINER_KIND_UNKNOWN as u32,
+		init: std::ptr::null(),
+		init_len: 0,
+	});
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, &unknown) },
+		-15,
+		"unknown container should return InvalidCode (-15)"
+	);
+
+	let garbage = config(moq_container {
+		kind: 12345,
+		init: std::ptr::null(),
+		init_len: 0,
+	});
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, &garbage) },
+		-15,
+		"out of range container should return InvalidCode (-15)"
+	);
+
+	let cmaf = config(moq_container {
+		kind: moq_container_kind::MOQ_CONTAINER_KIND_CMAF as u32,
+		init: std::ptr::null(),
+		init_len: 0,
+	});
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, &cmaf) },
+		-6,
+		"cmaf without an init segment should return InvalidPointer (-6)"
+	);
+
 	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
@@ -1332,6 +1475,7 @@ fn local_publish_consume() {
 		description_len: 0,
 		sample_rate: 0,
 		channel_count: 0,
+		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 0, &mut audio_cfg) }, 0);
 	assert_eq!(audio_cfg.sample_rate, 48000);
@@ -1355,6 +1499,7 @@ fn local_publish_consume() {
 		description_len: 0,
 		coded_width: std::ptr::null(),
 		coded_height: std::ptr::null(),
+		container: moq_container::default(),
 	};
 	assert!(
 		unsafe { moq_consume_video_config(catalog_id, 0, &mut video_cfg) } < 0,
@@ -1446,6 +1591,7 @@ fn consume_announced_local() {
 		description_len: 0,
 		sample_rate: 0,
 		channel_count: 0,
+		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 0, &mut audio_cfg) }, 0);
 	assert_eq!(audio_cfg.sample_rate, 48000);
@@ -1517,6 +1663,7 @@ fn video_publish_consume() {
 		description_len: 0,
 		coded_width: std::ptr::null(),
 		coded_height: std::ptr::null(),
+		container: moq_container::default(),
 	};
 	assert_eq!(
 		unsafe { moq_consume_video_config(catalog_id, 0, &mut video_cfg) },
@@ -1552,6 +1699,7 @@ fn video_publish_consume() {
 		description_len: 0,
 		sample_rate: 0,
 		channel_count: 0,
+		container: moq_container::default(),
 	};
 	assert!(
 		unsafe { moq_consume_audio_config(catalog_id, 0, &mut audio_cfg) } < 0,
@@ -2220,6 +2368,7 @@ fn catalog_update_on_new_track() {
 		description_len: 0,
 		sample_rate: 0,
 		channel_count: 0,
+		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id1, 0, &mut audio_cfg) }, 0);
 	assert!(unsafe { moq_consume_audio_config(catalog_id1, 1, &mut audio_cfg) } < 0);

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -454,7 +454,7 @@ impl I420 {
 	/// Convert tightly-packed RGB (`width * height * 3` bytes) to I420 in
 	/// [`Color::infer`]'s color space for this size. Used for MJPEG capture
 	/// (Linux V4L2), which decodes to RGB.
-	#[cfg(target_os = "linux")]
+	#[cfg(all(target_os = "linux", feature = "capture"))]
 	pub(crate) fn from_rgb(rgb: &[u8], width: u32, height: u32) -> Result<Self, Error> {
 		use yuv::rgb_to_yuv420;
 
@@ -469,7 +469,7 @@ impl I420 {
 	/// Convert packed YUYV (YUV 4:2:2, `stride` bytes per row) to I420. A chroma
 	/// resample (4:2:2 -> 4:2:0), no color-space conversion. Used for the raw
 	/// V4L2 capture path (Linux).
-	#[cfg(target_os = "linux")]
+	#[cfg(all(target_os = "linux", feature = "capture"))]
 	pub(crate) fn from_yuyv(yuyv: &[u8], stride: u32, width: u32, height: u32) -> Result<Self, Error> {
 		use yuv::{YuvPackedImage, yuyv422_to_yuv420};
 
@@ -2081,7 +2081,7 @@ mod tests {
 	/// 4:2:0 chroma resample must not claim it is BT.601: a 720p camera is
 	/// usually BT.709, and mislabeling pins it to the wrong matrix instead of
 	/// letting the resolution heuristic get it right.
-	#[cfg(target_os = "linux")]
+	#[cfg(all(target_os = "linux", feature = "capture"))]
 	#[test]
 	fn yuyv_capture_keeps_its_color_space_open() {
 		let (width, height) = (1280, 720);


### PR DESCRIPTION
A C publisher can author frames on a raw track (`moq_publish_track`) already encoded per draft-ietf-moq-loc, or as CMAF fragments, but the catalog write path always declared the legacy container, so there was no way to tell subscribers what the track actually carries.

`moq_video_config` and `moq_audio_config` now carry a `moq_container`: a `moq_container_kind` discriminant plus the CMAF init segment. The kind covers every container hang knows (`LEGACY`, `CMAF`, `LOC`, `UNKNOWN`) and crosses the ABI as `uint32_t`, so an unrecognized value returns `InvalidCode` instead of constructing an invalid Rust enum. A zeroed struct means legacy, so a recompiled caller that ignores the field behaves exactly as before. CMAF needs its init segment, which is why the kind travels in a struct rather than as a bare parameter.

`UNKNOWN` is read-only. A catalog written by a future build round-trips into it so a consumer can skip the rendition, but publishing one is `InvalidCode`: none of the original JSON survives the trip through C, so there is nothing to write back.

Because both structs are shared with the consume path, `moq_consume_video_config` and `moq_consume_audio_config` now report the container too, borrowing the CMAF init segment from the catalog snapshot exactly like `description` already does. `moq_container_kind` goes in the cbindgen `ENUMS` list, since no signature reaches it and a C caller would otherwise have to hardcode the integers.

**C callers must recompile**: both config structs grew a field.

Out of scope: `moq_publish_media_*` still writes the legacy container; switching the moq-mux encoder outputs to LOC is a separate change.

### The red CI was not this PR

`just check` failed in `moq-video`, which nothing here touches. `I420::from_rgb` and `from_yuyv` are `#[cfg(target_os = "linux")]`, but their only callers live in `capture/v4l2.rs`, which the `capture` feature gates, and every workspace consumer of moq-video leaves that feature off. So on Linux the two functions compiled with no callers and `-D warnings` turned the resulting `dead_code` lint into a hard error, which fails any branch whose diff selects libmoq. The second commit matches the cfg to the callers, test included.

### Tests

- a LOC frame published on a raw track with a LOC declaration and consumed through `moq_consume_video`: the catalog reports LOC, and payload, timestamp and keyframe survive the round trip
- a CMAF audio rendition: the init segment comes back byte for byte through `moq_consume_audio_config`
- the rejected kinds: `UNKNOWN`, an out-of-range value, and CMAF with no init segment

(written by Opus 5)
