### PR TITLE
feat(cli): run multiple import/export stages over one connection

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -225,6 +225,9 @@ Rules worth knowing:
   container from stdin, and at most one may write one to stdout.
 - The MoQ side belongs to the invocation, not a stage: `--client-connect` and
   friends go before the first stage and are rejected after a `--`.
+- `moq` reads every `--` as a stage separator, so it can't double as the usual
+  end-of-options marker. The one place that matters is a local playlist path
+  starting with `-`; write it as `./-playlist.m3u8`.
 - `play`, `transcode`, `token`, and `devices` own the process and can't be
   staged; run those on their own.
 

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -230,6 +230,12 @@ Rules worth knowing:
   starting with `-`; write it as `./-playlist.m3u8`.
 - `play`, `transcode`, `token`, and `devices` own the process and can't be
   staged; run those on their own.
+- `import capture` encodes to fit the connection's bandwidth estimate over
+  `--client-connect`, and rate control assumes it's the only publisher on that
+  connection, so it can't share a process with another `import`. Run those as
+  separate processes, or publish over `--server-bind`, which has no estimate.
+  (An audio-only `--no-video` capture never reads the estimate, so it doesn't
+  count.)
 
 ### Redundant Publishers (1+1)
 

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -5,7 +5,7 @@ description: Command-line tools for MoQ media
 
 # FFmpeg / moq-cli
 
-`moq-cli` is a media router: it wires one endpoint onto a shared MoQ Origin. It
+`moq-cli` is a media router: it wires endpoints onto a shared MoQ Origin. It
 moves media into MoQ from a source, out of MoQ to a sink, or plays a broadcast
 locally, bridging stdin/stdout (via FFmpeg), HLS, RTMP, SRT, and WebRTC.
 
@@ -74,6 +74,7 @@ Each signal writes a numbered `/tmp/moq.heap.*.heap` profile for analysis with
 
 ```
 moq <MoQ side>  <import|export>  <endpoint> [endpoint options]
+moq <MoQ side>  <stage>  [-- <stage>]...
 moq <MoQ side>  play [playback options]
 ```
 
@@ -89,14 +90,20 @@ moq <MoQ side>  play [playback options]
   Both may be given at once (dial a relay *and* accept incoming sessions).
   `--origin <id>` pins the process's origin id (default: fresh and random per
   run); see [Redundant Publishers](#redundant-publishers-11).
+
 - **`import`** routes media INTO MoQ (a source fills the Origin); **`export`**
   routes it OUT (a sink drains the Origin). The verb fixes the data direction.
+
 - **`play`** subscribes to a broadcast and plays its audio and video locally.
+
 - **endpoint** is one subcommand: a container format (`avc3`, `fmp4`, `ts`, `flv`
   read from stdin on import; `fmp4`, `mkv`, `ts`, `flv` written to stdout on
   export), or a gateway (`hls`, `rtmp`, `srt`, `rtc`). For the bidirectional
   gateways, `--connect` dials out and `--listen` binds a socket; the parent verb
   decides whether that pushes or pulls.
+
+- **`--`** starts another stage, where a stage is one `import` or `export` with
+  its endpoint. See [Multiple Stages](#multiple-stages).
 
 Run `moq import --help` / `moq export --help` to see the endpoints, and
 `moq import rtmp --help` for a specific one.
@@ -184,6 +191,42 @@ Remux a file to MPEG-TS and pipe it in (`-c copy` avoids re-encoding):
 ffmpeg -i video.mp4 -c copy -f mpegts - | \
     moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang import ts
 ```
+
+### Multiple Stages
+
+One `moq` process bridges one broadcast by default. Separate stages with `--` to
+bridge several over a single connection, each naming its own `--broadcast`:
+
+```bash
+moq --client-connect https://relay.example.com/anon \
+    import --broadcast cam1.hang rtmp --listen 0.0.0.0:1935 \
+    -- import --broadcast cam2.hang rtmp --listen 0.0.0.0:1936
+```
+
+Stages may run in opposite directions, so one process can ingest and re-publish
+without a second connection or a second copy of the media:
+
+```bash
+moq --client-connect https://relay.example.com/anon \
+    import --broadcast event.hang srt --listen 0.0.0.0:9000 \
+    -- export --broadcast event.hang hls --listen 0.0.0.0:8080
+```
+
+Every stage shares one connection, one origin id, and one Origin, and each keeps
+its own `--help` (`moq import rtmp --help`). A stage without `--broadcast` falls
+back to the process-wide one, so a single-stage command can keep naming the
+broadcast before the verb.
+
+Rules worth knowing:
+
+- The first stage to finish (stdin EOF, Ctrl-C, or an error) ends the process,
+  taking the others with it.
+- stdin and stdout are one resource each, so at most one stage may read a
+  container from stdin, and at most one may write one to stdout.
+- The MoQ side belongs to the invocation, not a stage: `--client-connect` and
+  friends go before the first stage and are rejected after a `--`.
+- `play`, `transcode`, `token`, and `devices` own the process and can't be
+  staged; run those on their own.
 
 ### Redundant Publishers (1+1)
 

--- a/rs/moq-cli/README.md
+++ b/rs/moq-cli/README.md
@@ -19,7 +19,15 @@ Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub
 
 ## Usage
 
-`moq-cli` routes one endpoint onto a shared MoQ Origin: `moq <MoQ side> <import|export> <endpoint>`. The MoQ side (before the verb) is either `--client-connect <url>` (dial a relay) or `--server-bind <addr>` (self-host). `import` moves media into MoQ, `export` moves it out. The endpoint is a container format (`fmp4`, `ts`, `flv`, ... read from stdin / written to stdout), or a gateway (`hls`, `rtmp`, `srt`, `rtc`). A build with the `play` feature can also render a broadcast locally with `moq <MoQ side> play`.
+`moq-cli` routes endpoints onto a shared MoQ Origin: `moq <MoQ side> <import|export> <endpoint>`. The MoQ side (before the verb) is either `--client-connect <url>` (dial a relay) or `--server-bind <addr>` (self-host). `import` moves media into MoQ, `export` moves it out. The endpoint is a container format (`fmp4`, `ts`, `flv`, ... read from stdin / written to stdout), or a gateway (`hls`, `rtmp`, `srt`, `rtc`). A build with the `play` feature can also render a broadcast locally with `moq <MoQ side> play`.
+
+Separate additional stages with `--` to bridge several broadcasts (or both directions) over one connection, each naming its own `--broadcast`:
+
+```bash
+moq --client-connect https://relay.example.com/anon \
+    import --broadcast cam1.hang rtmp --listen 0.0.0.0:1935 \
+    -- import --broadcast cam2.hang rtmp --listen 0.0.0.0:1936
+```
 
 ### Publish to a remote relay
 

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -350,6 +350,18 @@ impl ImportSource {
 		})
 	}
 
+	/// Whether this source encodes to fit the connection's bandwidth estimate.
+	///
+	/// Rate control is per-encoder while the estimate is per-connection, so each such
+	/// source assumes it's the only one on the uplink.
+	pub fn uses_bandwidth(&self) -> bool {
+		match self {
+			#[cfg(feature = "capture")]
+			Self::Capture(_) => true,
+			_ => false,
+		}
+	}
+
 	/// Whether this source threads [`Import::latency_max`] into the catalog it publishes.
 	///
 	/// The stdin containers, HLS, and capture build their catalog in this crate, so they honor

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -1,11 +1,12 @@
 //! The unified moq-cli argument surface.
 //!
-//! Grammar: `moq <MoQ side> <import|export> <endpoint> [endpoint opts]`, plus
-//! `moq <MoQ side> play` for native playback.
+//! Grammar: `moq <MoQ side> <stage> [-- <stage>]...`, where a stage is
+//! `<import|export> <endpoint> [endpoint opts]`, plus `moq <MoQ side> play` for
+//! native playback.
 //!
 //! - The MoQ side (`--client-connect` / `--server-bind`, both optional, at least
 //!   one) attaches the shared Origin to the MoQ network, and comes before the
-//!   verb. Both may be given: dial a relay *and* accept incoming sessions.
+//!   first stage. Both may be given: dial a relay *and* accept incoming sessions.
 //! - `import` routes media INTO MoQ from one source; `export` routes it OUT to
 //!   one sink. The verb fixes the data direction (and thus, for the
 //!   bidirectional gateways, whether `--connect`/`--listen` push or pull).
@@ -15,9 +16,15 @@
 //!   conditional on the subcommand.
 //! - The endpoint is one subcommand: a container format (`ts`, `fmp4`, ... read
 //!   from stdin on import, written to stdout on export) or a gateway (`hls`,
-//!   `rtmp`, `srt`, `rtc`). Exactly one per invocation, so "which endpoint" is
+//!   `rtmp`, `srt`, `rtc`). Exactly one per stage, so "which endpoint" is
 //!   unambiguous and there's no silently-ignored flag.
+//! - `--` starts another stage on the same Origin and the same MoQ attachment, so
+//!   one process can bridge several broadcasts (or both directions at once). clap
+//!   can't express a repeated subcommand, so [`Invocation`] splits argv on `--`
+//!   and runs each chunk through a real parser: every stage keeps full validation
+//!   and its own `--help`.
 
+use std::ffi::{OsStr, OsString};
 use std::time::Duration;
 
 use clap::{ArgGroup, Args, Parser, Subcommand};
@@ -26,9 +33,13 @@ use hang::moq_net;
 use crate::publish::PublishFormat;
 use crate::subscribe::{CatalogFormatArg, SubscribeFormat};
 
-/// moq-cli: a media router that wires one endpoint onto a shared MoQ Origin.
+/// moq-cli: a media router that wires endpoints onto a shared MoQ Origin.
+///
+/// The globals plus the first stage. Later stages are [`Stage`]s.
 #[derive(Parser, Clone)]
 #[command(name = "moq", version = env!("VERSION"))]
+#[command(after_help = "Separate additional import/export stages with `--`; they share one \
+                        connection and one Origin.")]
 pub struct Cli {
 	/// Logging configuration.
 	#[command(flatten)]
@@ -43,6 +54,86 @@ pub struct Cli {
 	pub command: Command,
 }
 
+/// A stage after the first: the verb and endpoint, without the globals.
+///
+/// `no_binary_name` because the chunk after a `--` starts at the verb, and the
+/// globals are deliberately absent: `--client-connect` past the first stage would
+/// read like it scopes that stage, when there is only ever one connection.
+#[derive(Parser, Clone)]
+#[command(name = "moq", no_binary_name = true)]
+pub struct Stage {
+	/// The verb and endpoint.
+	#[command(subcommand)]
+	pub command: Command,
+}
+
+/// The whole command line: the globals plus one or more `--`-separated stages.
+pub struct Invocation {
+	/// Logging configuration.
+	pub log: moq_native::Log,
+
+	/// The MoQ attachment, shared by every stage.
+	pub moq: MoqSide,
+
+	/// The stages, in the order given. Never empty.
+	pub stages: Vec<Command>,
+}
+
+impl Invocation {
+	/// Parse the process arguments, exiting with clap's own message on error.
+	pub fn parse() -> Self {
+		match Self::try_parse_from(std::env::args_os()) {
+			Ok(parsed) => parsed,
+			Err(err) => err.exit(),
+		}
+	}
+
+	/// Split `argv` on `--` and run each chunk through a real parser.
+	pub fn try_parse_from<I, T>(argv: I) -> Result<Self, clap::Error>
+	where
+		I: IntoIterator<Item = T>,
+		T: Into<OsString>,
+	{
+		let argv: Vec<OsString> = argv.into_iter().map(Into::into).collect();
+		let mut chunks = argv.split(|arg| arg == OsStr::new("--"));
+
+		// `split` always yields at least one chunk, even for an empty argv; clap then
+		// reports the missing subcommand as usual.
+		let cli = Cli::try_parse_from(chunks.next().unwrap_or_default())?;
+
+		let mut stages = vec![cli.command];
+		for chunk in chunks {
+			stages.push(Stage::try_parse_from(chunk)?.command);
+		}
+
+		Ok(Self {
+			log: cli.log,
+			moq: cli.moq,
+			stages,
+		})
+	}
+
+	/// Reject the verb combinations a single process can't run.
+	///
+	/// Only `import` and `export` share an Origin. The rest own the process: `play`
+	/// drives a window on the main thread, `transcode` builds its own Origin, and
+	/// `token` / `devices` never touch the network at all.
+	pub fn validate(&self) -> anyhow::Result<()> {
+		if self.stages.len() == 1 {
+			return Ok(());
+		}
+
+		if let Some(command) = self.stages.iter().find(|command| !command.is_stageable()) {
+			anyhow::bail!(
+				"`{}` must be the only verb; it can't share a process with another `--` stage",
+				command.name()
+			);
+		}
+
+		Ok(())
+	}
+}
+
 /// The MoQ attachment. At least one of `--client-connect` / `--server-bind`;
 /// both may be given at once.
 ///
@@ -52,10 +143,12 @@ pub struct Cli {
 #[derive(Args, Clone)]
 #[command(group = ArgGroup::new("moq").multiple(true).args(["client-connect", "server-bind"]))]
 pub struct MoqSide {
-	/// The broadcast name. Optional for the point endpoints (stdin/stdout, HLS
-	/// import, and the `--connect` dials), which default to the root broadcast at
-	/// the connection path; required by the `--listen` endpoints and `hls export`,
-	/// which bridge one named broadcast.
+	/// The default broadcast name for every stage that doesn't name its own.
+	///
+	/// Optional for the point endpoints (stdin/stdout, HLS import, and the
+	/// `--connect` dials), which default to the root broadcast at the connection
+	/// path; required by the `--listen` endpoints and `hls export`, which bridge one
+	/// named broadcast.
 	#[arg(long, alias = "name", help_heading = "MoQ")]
 	pub broadcast: Option<String>,
 
@@ -153,11 +246,55 @@ pub enum Command {
 	Devices,
 }
 
+impl Command {
+	/// The verb as typed, for error messages.
+	pub fn name(&self) -> &'static str {
+		match self {
+			Self::Import(_) => "import",
+			Self::Export(_) => "export",
+			#[cfg(feature = "play")]
+			Self::Play(_) => "play",
+			#[cfg(feature = "transcode")]
+			Self::Transcode(_) => "transcode",
+			Self::Token(_) => "token",
+			#[cfg(feature = "capture")]
+			Self::Devices => "devices",
+		}
+	}
+
+	/// Whether this verb can share a process (and an Origin) with other stages.
+	pub fn is_stageable(&self) -> bool {
+		matches!(self, Self::Import(_) | Self::Export(_))
+	}
+
+	/// The broadcast this stage names, falling back to the process-wide `--broadcast`.
+	///
+	/// Empty means the root broadcast: MoQ names each broadcast by the connection
+	/// path plus any explicit `--broadcast`, so an unset name is the connection path
+	/// itself.
+	pub fn broadcast(&self, moq: &MoqSide) -> String {
+		let stage = match self {
+			Self::Import(import) => import.broadcast.as_deref(),
+			Self::Export(export) => export.broadcast.as_deref(),
+			_ => None,
+		};
+
+		stage.or(moq.broadcast.as_deref()).unwrap_or_default().to_string()
+	}
+}
+
 // ------------------------------------------------------------------ import
 
 /// import = one source -> MoQ.
 #[derive(Args, Clone)]
 pub struct Import {
+	/// The broadcast this stage publishes, overriding the process-wide `--broadcast`.
+	///
+	/// Required when a process imports more than one broadcast; a single stage can
+	/// keep naming it before the verb.
+	#[arg(long, alias = "name")]
+	pub broadcast: Option<String>,
+
 	/// How long relays keep a non-latest group of the published media tracks fetchable,
 	/// e.g. "30s" or "5s". Defaults to hang's 30s.
 	///
@@ -236,6 +373,13 @@ impl ImportSource {
 /// export = MoQ -> one sink.
 #[derive(Args, Clone)]
 pub struct Export {
+	/// The broadcast this stage subscribes to, overriding the process-wide `--broadcast`.
+	///
+	/// Required when a process exports more than one broadcast; a single stage can
+	/// keep naming it before the verb.
+	#[arg(long, alias = "name")]
+	pub broadcast: Option<String>,
+
 	/// Catalog format to read for track discovery (default: detect from the broadcast suffix).
 	#[arg(long = "catalog-format")]
 	pub catalog_format: Option<CatalogFormatArg>,
@@ -327,6 +471,160 @@ mod tests {
 	#[test]
 	fn valid() {
 		Cli::command().debug_assert();
+	}
+
+	/// The `Stage` parser is a second entry point into the same command tree, so it
+	/// needs the same conflict check as [`Cli`].
+	#[test]
+	fn valid_stage() {
+		Stage::command().debug_assert();
+	}
+
+	#[test]
+	fn single_stage() {
+		let cli = Invocation::try_parse_from(["moq", "--client-connect", "http://relay", "import", "ts"]).unwrap();
+		assert_eq!(cli.stages.len(), 1);
+		assert_eq!(cli.stages[0].name(), "import");
+		assert!(cli.validate().is_ok());
+	}
+
+	/// The grammar clap can't express: one connection, several endpoints.
+	#[test]
+	fn multiple_stages() {
+		let cli = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://localhost:4444/event",
+			"import",
+			"--broadcast",
+			"cam1.hang",
+			"rtmp",
+			"--listen",
+			"0.0.0.0:1935",
+			"--",
+			"import",
+			"--broadcast",
+			"cam2.hang",
+			"rtmp",
+			"--listen",
+			"0.0.0.0:1936",
+			"--",
+			"export",
+			"--broadcast",
+			"cam1.hang",
+			"hls",
+			"--listen",
+			"0.0.0.0:8080",
+		])
+		.unwrap();
+
+		assert!(cli.validate().is_ok());
+		assert_eq!(cli.stages.len(), 3);
+
+		// The globals are read once, from the first chunk, and shared by every stage.
+		assert_eq!(
+			cli.moq.client.connect.as_ref().map(ToString::to_string).as_deref(),
+			Some("http://localhost:4444/event")
+		);
+
+		let names: Vec<String> = cli.stages.iter().map(|stage| stage.broadcast(&cli.moq)).collect();
+		assert_eq!(names, ["cam1.hang", "cam2.hang", "cam1.hang"]);
+		assert_eq!(cli.stages[2].name(), "export");
+	}
+
+	/// A stage without its own `--broadcast` falls back to the process-wide one, so
+	/// every single-stage invocation keeps naming the broadcast before the verb.
+	#[test]
+	fn broadcast_falls_back_to_the_global() {
+		let cli = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://relay",
+			"--broadcast",
+			"room.hang",
+			"import",
+			"ts",
+			"--",
+			"export",
+			"--broadcast",
+			"other.hang",
+			"fmp4",
+		])
+		.unwrap();
+
+		assert_eq!(cli.stages[0].broadcast(&cli.moq), "room.hang");
+		assert_eq!(cli.stages[1].broadcast(&cli.moq), "other.hang");
+	}
+
+	/// An unnamed broadcast is the root one at the connection path, not an error.
+	#[test]
+	fn broadcast_defaults_to_root() {
+		let cli = Invocation::try_parse_from(["moq", "--client-connect", "http://relay", "import", "ts"]).unwrap();
+		assert_eq!(cli.stages[0].broadcast(&cli.moq), "");
+	}
+
+	/// Only import/export share an Origin; the rest own the process.
+	#[test]
+	fn rejects_unstageable_verbs() {
+		let cli = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://relay",
+			"import",
+			"ts",
+			"--",
+			"token",
+			"generate",
+			"--algorithm",
+			"ES256",
+		])
+		.unwrap();
+
+		let err = cli.validate().unwrap_err().to_string();
+		assert!(err.contains("token"), "{err}");
+	}
+
+	/// Each stage is parsed by a real clap parser, so a typo past the first `--` is
+	/// still a parse error rather than something swallowed as a positional.
+	#[test]
+	fn stage_errors_are_parse_errors() {
+		let Err(err) = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://relay",
+			"import",
+			"ts",
+			"--",
+			"import",
+			"rtmp",
+			"--bogus",
+		]) else {
+			panic!("expected a parse error")
+		};
+
+		assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+	}
+
+	/// The globals belong to the invocation, not a stage: there is only ever one
+	/// connection, so accepting `--client-connect` again would be a lie.
+	#[test]
+	fn stages_reject_globals() {
+		let Err(err) = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://relay",
+			"import",
+			"ts",
+			"--",
+			"--client-connect",
+			"http://other",
+			"import",
+			"fmp4",
+		]) else {
+			panic!("expected a parse error")
+		};
+
+		assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
 	}
 
 	#[test]

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -22,7 +22,10 @@
 //!   one process can bridge several broadcasts (or both directions at once). clap
 //!   can't express a repeated subcommand, so [`Invocation`] splits argv on `--`
 //!   and runs each chunk through a real parser: every stage keeps full validation
-//!   and its own `--help`.
+//!   and its own `--help`. That claims `--` from clap, which would otherwise treat
+//!   it as the end-of-options marker. The only positional it could have escaped is
+//!   an `import hls` playlist path starting with `-`, which `./-name` covers, so
+//!   the separator stays unconditional rather than context-sensitive.
 
 use std::ffi::{OsStr, OsString};
 use std::time::Duration;
@@ -40,7 +43,8 @@ use crate::subscribe::{CatalogFormatArg, SubscribeFormat};
 #[derive(Parser, Clone)]
 #[command(name = "moq", version = env!("VERSION"))]
 #[command(after_help = "Separate additional import/export stages with `--`; they share one \
-                        connection and one Origin.")]
+                        connection and one Origin. Every `--` starts a stage, so it is not an \
+                        end-of-options marker: write a path starting with `-` as `./-name`.")]
 pub struct Cli {
 	/// Logging configuration.
 	#[command(flatten)]
@@ -625,6 +629,29 @@ mod tests {
 		};
 
 		assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+	}
+
+	/// Splitting on `--` claims it from clap, so it can't also escape a positional
+	/// starting with `-`. `./-name` is the documented way to write one.
+	#[test]
+	fn a_dash_prefixed_path_is_written_relative() {
+		let cli = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://relay",
+			"import",
+			"hls",
+			"./-odd.m3u8",
+		])
+		.unwrap();
+
+		let Command::Import(import) = &cli.stages[0] else {
+			panic!("expected import")
+		};
+		let ImportSource::Hls(hls) = &import.source else {
+			panic!("expected hls")
+		};
+		assert_eq!(hls.playlist, "./-odd.m3u8");
 	}
 
 	/// A `--` with nothing after it names no verb, so it's an error rather than an

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -127,22 +127,47 @@ impl Invocation {
 		})
 	}
 
-	/// Reject the verb combinations a single process can't run.
+	/// Reject the stage combinations a single process can't run.
 	///
-	/// Only `import` and `export` share an Origin. The rest own the process: `play`
-	/// drives a window on the main thread, `transcode` builds its own Origin, and
-	/// `token` / `devices` never touch the network at all.
+	/// Called before anything binds a port or dials out, so a refused invocation has
+	/// no side effects to unwind.
 	pub fn validate(&self) -> anyhow::Result<()> {
+		// One stage is what the CLI has always run, so nothing below can bite.
 		if self.stages.len() == 1 {
 			return Ok(());
 		}
 
+		// Only `import` and `export` share an Origin. The rest own the process: `play`
+		// drives a window on the main thread, `transcode` builds its own Origin, and
+		// `token` / `devices` never touch the network at all.
 		if let Some(command) = self.stages.iter().find(|command| !command.is_stageable()) {
 			anyhow::bail!(
 				"`{}` must be the only verb; it can't share a process with another `--` stage",
 				command.name()
 			);
 		}
+
+		// Rate control assumes it owns the uplink: the encoder targets a fraction of the
+		// connection's estimate, leaving room for its own audio and transport overhead but
+		// not for a second publisher. Anything else importing over the same connection
+		// spends what that encoder already claimed, so refuse rather than congest the link
+		// the estimate exists to protect. Exports only receive, so they don't count, and
+		// only an outbound client has an estimate at all.
+		let imports = self
+			.stages
+			.iter()
+			.filter(|stage| matches!(stage, Command::Import(_)))
+			.count();
+		let adaptive = self
+			.stages
+			.iter()
+			.any(|stage| matches!(stage, Command::Import(import) if import.source.uses_bandwidth()));
+		anyhow::ensure!(
+			self.moq.client.connect.is_none() || !adaptive || imports == 1,
+			"a stage that encodes to fit the connection's bandwidth estimate assumes it's the only \
+			 publisher on that connection, but this runs {imports} import stages; run them as separate \
+			 processes, or publish over --server-bind, which has no estimate"
+		);
 
 		Ok(())
 	}
@@ -701,6 +726,91 @@ mod tests {
 		};
 
 		assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+	}
+
+	/// Stages that never read the estimate can share a connection freely, so the guard
+	/// must not reject them.
+	#[test]
+	fn imports_without_rate_control_can_share_a_connection() {
+		let cli = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://relay",
+			"import",
+			"--broadcast",
+			"a.hang",
+			"rtmp",
+			"--listen",
+			"127.0.0.1:1935",
+			"--",
+			"import",
+			"--broadcast",
+			"b.hang",
+			"srt",
+			"--listen",
+			"127.0.0.1:9000",
+		])
+		.unwrap();
+
+		assert!(cli.validate().is_ok());
+	}
+
+	/// An encoder that follows the estimate targets most of it, so a second publisher
+	/// on the same connection spends what it already claimed. Exports only receive, and
+	/// a `--server-bind` publisher has no estimate to oversubscribe.
+	#[cfg(feature = "capture")]
+	#[test]
+	fn an_adaptive_capture_must_be_the_only_import() {
+		let client: &[&str] = &["--client-connect", "http://relay"];
+		let server: &[&str] = &["--server-bind", "[::]:4443"];
+
+		let cases: [(&[&str], &[&str], bool); 3] = [
+			// Two video captures follow the same estimate.
+			(client, &["import", "capture"], false),
+			// A fixed-rate import spends the same uplink from outside the budget.
+			(client, &["import", "rtmp", "--listen", "127.0.0.1:1935"], false),
+			// No outbound client, so there's no estimate to oversubscribe.
+			(server, &["import", "capture"], true),
+		];
+
+		for (side, second, ok) in cases {
+			let argv = [&["moq"][..], side, &["import", "capture", "--"], second].concat();
+			let cli = Invocation::try_parse_from(argv.clone()).unwrap();
+			assert_eq!(cli.validate().is_ok(), ok, "{argv:?}");
+		}
+
+		// An audio-only capture never reads the estimate, so it may share the connection.
+		let cli = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://relay",
+			"import",
+			"capture",
+			"--no-video",
+			"--",
+			"import",
+			"rtmp",
+			"--listen",
+			"127.0.0.1:1935",
+		])
+		.unwrap();
+		assert!(cli.validate().is_ok());
+
+		// Exports only receive, so they don't compete for the uplink.
+		let cli = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"http://relay",
+			"import",
+			"capture",
+			"--",
+			"export",
+			"--broadcast",
+			"other.hang",
+			"fmp4",
+		])
+		.unwrap();
+		assert!(cli.validate().is_ok());
 	}
 
 	/// Only the video encoder reads the connection's bandwidth estimate, so an

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -27,7 +27,7 @@
 use std::ffi::{OsStr, OsString};
 use std::time::Duration;
 
-use clap::{ArgGroup, Args, Parser, Subcommand};
+use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand};
 use hang::moq_net;
 
 use crate::publish::PublishFormat;
@@ -103,6 +103,15 @@ impl Invocation {
 
 		let mut stages = vec![cli.command];
 		for chunk in chunks {
+			// A trailing or doubled `--` leaves an empty chunk, which clap would report as a
+			// bare missing-subcommand usage dump. Name what's actually wrong instead.
+			if chunk.is_empty() {
+				return Err(Stage::command().error(
+					clap::error::ErrorKind::MissingSubcommand,
+					"`--` starts another stage, so it must be followed by `import` or `export`",
+				));
+			}
+
 			stages.push(Stage::try_parse_from(chunk)?.command);
 		}
 
@@ -474,7 +483,6 @@ pub struct Fragmented {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use clap::CommandFactory;
 
 	// Catches the conflicts clap only panics on at runtime: a duplicate long, a
 	// dangling `conflicts_with`, a flattened arg colliding with an existing one.
@@ -615,6 +623,33 @@ mod tests {
 		};
 
 		assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+	}
+
+	/// A `--` with nothing after it names no verb, so it's an error rather than an
+	/// empty stage. Same for a doubled `--`, which leaves an empty chunk between them.
+	#[test]
+	fn rejects_an_empty_stage() {
+		for argv in [
+			vec!["moq", "--client-connect", "http://relay", "import", "ts", "--"],
+			vec![
+				"moq",
+				"--client-connect",
+				"http://relay",
+				"import",
+				"ts",
+				"--",
+				"--",
+				"export",
+				"fmp4",
+			],
+		] {
+			let Err(err) = Invocation::try_parse_from(argv.clone()) else {
+				panic!("expected a parse error for {argv:?}")
+			};
+
+			assert_eq!(err.kind(), clap::error::ErrorKind::MissingSubcommand);
+			assert!(err.to_string().contains("must be followed by"), "{err}");
+		}
 	}
 
 	/// The globals belong to the invocation, not a stage: there is only ever one

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -33,9 +33,10 @@ use hang::moq_net;
 use crate::publish::PublishFormat;
 use crate::subscribe::{CatalogFormatArg, SubscribeFormat};
 
+// The globals plus the first stage; later stages are parsed as a [`Stage`]. Keep
+// the doc comment to one line: clap renders the rest as `--help` body text, where
+// rustdoc links read as noise.
 /// moq-cli: a media router that wires endpoints onto a shared MoQ Origin.
-///
-/// The globals plus the first stage. Later stages are [`Stage`]s.
 #[derive(Parser, Clone)]
 #[command(name = "moq", version = env!("VERSION"))]
 #[command(after_help = "Separate additional import/export stages with `--`; they share one \
@@ -54,11 +55,11 @@ pub struct Cli {
 	pub command: Command,
 }
 
+// `no_binary_name` because the chunk after a `--` starts at the verb, and the
+// globals are deliberately absent: `--client-connect` past the first stage would
+// read like it scopes that stage, when there is only ever one connection. As with
+// [`Cli`], the doc comment stays one line because clap shows it in `--help`.
 /// A stage after the first: the verb and endpoint, without the globals.
-///
-/// `no_binary_name` because the chunk after a `--` starts at the verb, and the
-/// globals are deliberately absent: `--client-connect` past the first stage would
-/// read like it scopes that stage, when there is only ever one connection.
 #[derive(Parser, Clone)]
 #[command(name = "moq", no_binary_name = true)]
 pub struct Stage {

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -362,11 +362,12 @@ impl ImportSource {
 	/// Whether this source encodes to fit the connection's bandwidth estimate.
 	///
 	/// Rate control is per-encoder while the estimate is per-connection, so each such
-	/// source assumes it's the only one on the uplink.
+	/// source assumes it's the only one on the uplink. Only the video encoder reads
+	/// the estimate, so an audio-only capture doesn't count.
 	pub fn uses_bandwidth(&self) -> bool {
 		match self {
 			#[cfg(feature = "capture")]
-			Self::Capture(_) => true,
+			Self::Capture(capture) => !capture.no_video,
 			_ => false,
 		}
 	}
@@ -672,6 +673,22 @@ mod tests {
 		};
 
 		assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+	}
+
+	/// Only the video encoder reads the connection's bandwidth estimate, so an
+	/// audio-only capture doesn't compete for it and isn't counted against the
+	/// one-adaptive-stage limit.
+	#[cfg(feature = "capture")]
+	#[test]
+	fn audio_only_capture_is_not_bandwidth_adaptive() {
+		for (args, adaptive) in [(vec!["capture"], true), (vec!["capture", "--no-video"], false)] {
+			let argv = [vec!["moq", "--client-connect", "http://relay", "import"], args].concat();
+			let cli = Invocation::try_parse_from(argv).unwrap();
+			let Command::Import(import) = &cli.stages[0] else {
+				panic!("expected import")
+			};
+			assert_eq!(import.source.uses_bandwidth(), adaptive);
+		}
 	}
 
 	#[test]

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -1,8 +1,8 @@
-//! moq-cli: a media router that wires one endpoint onto a shared MoQ Origin.
+//! moq-cli: a media router that wires endpoints onto a shared MoQ Origin.
 //!
 //! The binary is `moq`. See [`args`] for the `import`/`export`/`play` command
 //! grammar; this module orchestrates the shared Origin and spawns the MoQ side
-//! plus the selected endpoint.
+//! plus every stage's endpoint.
 
 mod args;
 #[cfg(feature = "capture")]
@@ -20,13 +20,12 @@ mod subscribe;
 mod transcode;
 mod web;
 
-use args::{Cli, Command, Export, ExportSink, Import, ImportSource, MoqSide};
+use args::{Command, Export, ExportSink, Import, ImportSource, Invocation, MoqSide};
 use hang::moq_net;
 use publish::Publish;
 use subscribe::{Subscribe, SubscribeArgs};
 
 use anyhow::Context;
-use clap::Parser;
 use tokio::task::JoinSet;
 
 #[cfg(feature = "jemalloc")]
@@ -71,23 +70,28 @@ async fn main() -> anyhow::Result<()> {
 		.install_default()
 		.expect("failed to install default crypto provider");
 
-	let cli = Cli::parse();
+	let cli = Invocation::parse();
 	cli.log.init()?;
+	cli.validate()?;
 
 	// The local verbs never touch the network, so answer them before binding any
-	// transport. Each arm returns, so the move out of `cli.command` can't reach the
-	// code below.
-	match cli.command {
-		Command::Token(token) => {
-			cli.moq.reject("token")?;
-			return token.run();
+	// transport. `validate` has already refused to pair them with another stage, so
+	// the single stage here is the whole invocation.
+	let mut stages = cli.stages;
+	if stages.len() == 1 {
+		match stages.remove(0) {
+			Command::Token(token) => {
+				cli.moq.reject("token")?;
+				return token.run();
+			}
+			#[cfg(feature = "capture")]
+			Command::Devices => {
+				cli.moq.reject("devices")?;
+				return devices::run().await;
+			}
+			// Put it back: it needs the transport bound below.
+			other => stages.push(other),
 		}
-		#[cfg(feature = "capture")]
-		Command::Devices => {
-			cli.moq.reject("devices")?;
-			return devices::run().await;
-		}
-		_ => {}
 	}
 
 	cli.moq.validate()?;
@@ -103,17 +107,19 @@ async fn main() -> anyhow::Result<()> {
 	let jemalloc = std::future::pending::<anyhow::Result<()>>();
 
 	let run = async move {
-		match cli.command {
-			Command::Import(import) => run_import(cli.moq, import, net).await,
-			Command::Export(export) => run_export(cli.moq, export, net).await,
-			#[cfg(feature = "play")]
-			Command::Play(args) => run_play(cli.moq, args, net).await,
-			#[cfg(feature = "transcode")]
-			Command::Transcode(args) => transcode::run(cli.moq, args, net).await,
-			Command::Token(_) => unreachable!("handled above, before the transport is bound"),
-			#[cfg(feature = "capture")]
-			Command::Devices => unreachable!("handled above, before the transport is bound"),
+		// The verbs that own the process were refused alongside another stage, so a
+		// lone one of those runs by itself; everything else is a list of stages.
+		if stages.len() == 1 && !stages[0].is_stageable() {
+			match stages.remove(0) {
+				#[cfg(feature = "play")]
+				Command::Play(args) => return run_play(cli.moq, args, net).await,
+				#[cfg(feature = "transcode")]
+				Command::Transcode(args) => return transcode::run(cli.moq, args, net).await,
+				_ => unreachable!("the local verbs returned before the transport was bound"),
+			}
 		}
+
+		run_stages(cli.moq, stages, net).await
 	};
 
 	tokio::select! {
@@ -122,29 +128,85 @@ async fn main() -> anyhow::Result<()> {
 	}
 }
 
-/// Attach the MoQ side so it fills the shared Origin: dial a relay, accept
-/// inbound sessions, or both. Shared by every verb that consumes.
-fn spawn_moq_consume(
+/// Which directions the stages need on the shared MoQ attachment.
+#[derive(Clone, Copy, Default)]
+struct Directions {
+	/// Any `import`: the Origin is published outward.
+	publish: bool,
+	/// Any `export` or `play`: the Origin is filled from the network.
+	consume: bool,
+}
+
+impl Directions {
+	/// The union of what the stages need, so one attachment serves them all.
+	fn of(stages: &[Command]) -> Self {
+		Self {
+			publish: stages.iter().any(|stage| matches!(stage, Command::Import(_))),
+			consume: stages.iter().any(|stage| matches!(stage, Command::Export(_))),
+		}
+	}
+}
+
+/// Attach the shared Origin to the MoQ network: dial a relay, accept inbound
+/// sessions, or both.
+///
+/// An invocation that both imports and exports attaches both directions to the
+/// same session rather than opening two, which is how a relay peers with another
+/// relay. Loops are the network's problem, not ours: an announcement carries the
+/// hops it crossed, and our own origin id is one of them, so a broadcast we
+/// publish is never announced back to us.
+///
+/// Returns the uplink's bandwidth estimate, for the sources that can encode to
+/// fit it. Only an outbound client has one: a `--server-bind` publisher's sessions
+/// are inbound and never surfaced here, so it stays `None` and those sources
+/// encode at their configured rate.
+fn spawn_moq(
 	moq: &MoqSide,
 	net: &Net,
 	origin: &moq_net::origin::Producer,
+	directions: Directions,
 	tasks: &mut JoinSet<anyhow::Result<()>>,
-) -> anyhow::Result<()> {
-	if moq.client.connect.is_some()
-		&& let Some(reconnect) = net.client(moq.client.clone())?.consume(origin.clone())
-	{
+) -> anyhow::Result<Option<moq_net::bandwidth::Consumer>> {
+	let mut bandwidth = None;
+
+	if let Some(url) = moq.client.connect.clone() {
+		let mut client = net.client(moq.client.clone())?;
+		if directions.publish {
+			client = client.with_publisher(origin.consume());
+		}
+		if directions.consume {
+			// Matching `Client::consume`: broadcasts fed by these sessions linger across a
+			// session drop for as long as the reconnect loop keeps retrying, so a relay
+			// restart is a bounded gap rather than a teardown.
+			let linger = origin.clone().with_linger(moq.client.backoff.linger());
+			client = client.with_subscriber(linger);
+		}
+
+		let reconnect = client.reconnect(url);
 		moq::notify_ready();
+		// Read before the handle moves into the task. This consumer is persistent: it
+		// survives reconnects, reading `None` while down, so it can be wired up before
+		// anything connects.
+		bandwidth = Some(reconnect.send_bandwidth());
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
+
 	if let Some(web_bind) = moq.server.bind.clone() {
-		let server = net.server(moq.server.clone())?;
+		let mut server = net.server(moq.server.clone())?;
+		if directions.publish {
+			server = server.with_publisher(origin.consume());
+		}
+		if directions.consume {
+			server = server.with_subscriber(origin.clone());
+		}
+
 		let certificates = server.certificates();
 		moq::notify_ready();
-		let origin = origin.clone();
-		tasks.spawn(async move { Ok(server.serve_consume(origin).await?) });
+		tasks.spawn(async move { Ok(server.serve().await?) });
 		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
 	}
-	Ok(())
+
+	Ok(bandwidth)
 }
 
 /// Fill the shared Origin from MoQ, then play one broadcast locally.
@@ -161,21 +223,115 @@ async fn run_play(moq: MoqSide, args: play::Args, net: Net) -> anyhow::Result<()
 	let name = moq.broadcast.clone().unwrap_or_default();
 	let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
-	spawn_moq_consume(&moq, &net, &origin, &mut tasks)?;
+	let directions = Directions {
+		consume: true,
+		..Default::default()
+	};
+	spawn_moq(&moq, &net, &origin, directions, &mut tasks)?;
 
 	play::run(origin.consume(), name, args, tasks)
 }
 
-/// Route one source INTO the shared Origin, exposing it to the MoQ network.
-async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()> {
+/// Run every stage over one Origin and one MoQ attachment.
+///
+/// Stages are independent: each names its own broadcast and owns its own endpoint,
+/// and the first to finish (stdin EOF, Ctrl-C, or an error) ends the process.
+async fn run_stages(moq: MoqSide, stages: Vec<Command>, net: Net) -> anyhow::Result<()> {
 	let origin = moq.origin()?;
-	// The broadcast defaults to "": MoQ names each broadcast by the connection
-	// path plus any explicit `--broadcast`, so an unset name is the root broadcast.
-	let name = moq.broadcast.clone().unwrap_or_default();
 	let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
-	// The stdin/capture pipeline runs on this task instead of the JoinSet: the
-	// platform capture stream is not Send, so its future cannot be spawned.
-	let mut local: Option<Publish> = None;
+	// The stdin/capture pipelines run on this thread instead of the JoinSet: the
+	// platform capture stream is not Send, so their futures cannot be spawned.
+	let mut locals: Vec<Publish> = Vec::new();
+
+	let bandwidth = spawn_moq(&moq, &net, &origin, Directions::of(&stages), &mut tasks)?;
+
+	// stdin and stdout are one resource each, so two stages can't share them.
+	let mut stdin = None;
+	let mut stdout = None;
+
+	for stage in stages {
+		let name = stage.broadcast(&moq);
+		match stage {
+			Command::Import(import) => {
+				if import.source.stdin_format().is_some() {
+					claim("stdin", &mut stdin, &name)?;
+				}
+				if let Some(publish) = spawn_import(&origin, import, name, bandwidth.clone(), &mut tasks)? {
+					locals.push(publish);
+				}
+			}
+			Command::Export(export) => {
+				if export.sink.stdout().is_some() {
+					claim("stdout", &mut stdout, &name)?;
+				}
+				spawn_export(&origin, export, name, &mut tasks)?;
+			}
+			other => unreachable!("`{}` is not a stage", other.name()),
+		}
+	}
+
+	if locals.is_empty() {
+		return drive(tasks).await;
+	}
+
+	// Report the first local pipeline to finish, so stdin EOF ends the process just
+	// like a spawned stage returning does.
+	let (done, mut first) = tokio::sync::mpsc::channel(1);
+	let local = tokio::task::LocalSet::new();
+	for publish in locals {
+		let done = done.clone();
+		local.spawn_local(async move {
+			let _ = done.send(publish.run().await).await;
+		});
+	}
+	drop(done);
+
+	local
+		.run_until(async move {
+			tokio::select! {
+				res = drive(tasks) => res,
+				// `None` means every local pipeline ended without reporting, which a
+				// completed one never does: the task panicked, and tokio caught it.
+				res = first.recv() => res.unwrap_or_else(|| Err(anyhow::anyhow!("pipeline panicked"))),
+			}
+		})
+		.await
+}
+
+/// Refuse a second stage on a stream there is only one of.
+fn claim(stream: &str, held: &mut Option<String>, name: &str) -> anyhow::Result<()> {
+	if let Some(first) = held {
+		anyhow::bail!(
+			"only one stage can use {stream}, but both `{}` and `{}` do",
+			display_name(first),
+			display_name(name),
+		);
+	}
+
+	*held = Some(name.to_string());
+	Ok(())
+}
+
+/// The broadcast name for an error message; the root broadcast has none.
+fn display_name(name: &str) -> &str {
+	if name.is_empty() { "<root>" } else { name }
+}
+
+/// Route one stage's source INTO the shared Origin, exposing it to the MoQ network.
+///
+/// Returns the pipeline that has to run on the caller's thread, for the sources
+/// that have one (the stdin containers and capture).
+fn spawn_import(
+	origin: &moq_net::origin::Producer,
+	import: Import,
+	name: String,
+	bandwidth: Option<moq_net::bandwidth::Consumer>,
+	tasks: &mut JoinSet<anyhow::Result<()>>,
+) -> anyhow::Result<Option<Publish>> {
+	// Capture is the only source that reads the bandwidth estimate, so without that
+	// feature nothing does.
+	#[cfg(not(feature = "capture"))]
+	let _ = bandwidth;
 
 	if let ImportSource::Rtc(rtc) = &import.source
 		&& rtc.connect.is_some()
@@ -191,38 +347,8 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		 formats, hls, and capture"
 	);
 
-	// The uplink's bandwidth estimate, for sources that can encode to fit it. Only
-	// an outbound client has one: a `--server-bind` publisher's sessions are
-	// inbound and never surfaced here, so it stays `None` and those sources encode
-	// at their configured rate. Capture is the only such source today, so without
-	// that feature nothing reads this.
-	#[cfg(feature = "capture")]
-	let mut send_bandwidth = None;
+	let mut local = None;
 
-	// MoQ side: publish the Origin outward.
-	if moq.client.connect.is_some()
-		&& let Some(reconnect) = net.client(moq.client.clone())?.publish(origin.consume())
-	{
-		moq::notify_ready();
-		// Read before the handle moves into the task. This consumer is
-		// persistent: it survives reconnects, reading `None` while down, so it
-		// can be wired up before anything connects.
-		#[cfg(feature = "capture")]
-		{
-			send_bandwidth = Some(reconnect.send_bandwidth());
-		}
-		tasks.spawn(async move { Ok(reconnect.closed().await?) });
-	}
-	if let Some(web_bind) = moq.server.bind.clone() {
-		let server = net.server(moq.server.clone())?;
-		let certificates = server.certificates();
-		moq::notify_ready();
-		let origin = origin.consume();
-		tasks.spawn(async move { Ok(server.serve_publish(origin).await?) });
-		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
-	}
-
-	// Foreign side: the single source.
 	if let Some(format) = import.source.stdin_format() {
 		warn_if_missing_format(&name);
 		let broadcast = origin
@@ -274,44 +400,28 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 				let broadcast = origin
 					.create_broadcast(&name, moq_net::broadcast::Route::new().with_announce(true))
 					.context("failed to create broadcast")?;
-				local = Some(Publish::capture(
-					broadcast,
-					&capture,
-					send_bandwidth,
-					import.latency_max,
-				)?);
+				local = Some(Publish::capture(broadcast, &capture, bandwidth, import.latency_max)?);
 			}
 			_ => unreachable!("container formats are handled by stdin_format above"),
 		}
 	}
 
-	match local {
-		Some(publish) => tokio::select! {
-			res = publish.run() => res,
-			res = drive(tasks) => res,
-		},
-		None => drive(tasks).await,
-	}
+	Ok(local)
 }
 
-/// Route the shared Origin OUT to one sink, filling it from the MoQ network.
-async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()> {
-	let origin = moq.origin()?;
-	// The broadcast defaults to "": MoQ names each broadcast by the connection
-	// path plus any explicit `--broadcast`, so an unset name is the root broadcast.
-	let name = moq.broadcast.clone().unwrap_or_default();
-	let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
-
+/// Route the shared Origin OUT to one stage's sink, filling it from the MoQ network.
+fn spawn_export(
+	origin: &moq_net::origin::Producer,
+	export: Export,
+	name: String,
+	tasks: &mut JoinSet<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
 	if let ExportSink::Rtc(rtc) = &export.sink
 		&& rtc.connect.is_some()
 	{
 		reject_listener_cors(&rtc.cors, "export rtc")?;
 	}
 
-	// MoQ side: fill the Origin.
-	spawn_moq_consume(&moq, &net, &origin, &mut tasks)?;
-
-	// Foreign side: the single sink.
 	if let Some((format, max_latency, fragment_duration)) = export.sink.stdout() {
 		let args = SubscribeArgs {
 			format,
@@ -363,7 +473,7 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 		}
 	}
 
-	drive(tasks).await
+	Ok(())
 }
 
 /// Subscribe to `name` from the Origin and write it to stdout.

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -192,17 +192,33 @@ fn spawn_moq(
 	}
 
 	if let Some(web_bind) = moq.server.bind.clone() {
-		let mut server = net.server(moq.server.clone())?;
-		if directions.publish {
-			server = server.with_publisher(origin.consume());
-		}
-		if directions.consume {
-			server = server.with_subscriber(origin.clone());
-		}
-
+		let server = net.server(moq.server.clone())?;
 		let certificates = server.certificates();
 		moq::notify_ready();
-		tasks.spawn(async move { Ok(server.serve().await?) });
+
+		let origin = origin.clone();
+		tasks.spawn(async move {
+			let _: () = match directions {
+				Directions {
+					publish: true,
+					consume: true,
+				} => server.serve_both(origin.consume(), origin).await?,
+				Directions {
+					publish: true,
+					consume: false,
+				} => server.serve_publish(origin.consume()).await?,
+				Directions {
+					publish: false,
+					consume: true,
+				} => server.serve_consume(origin).await?,
+				// Every caller attaches a direction: each stage is an import or an export.
+				Directions {
+					publish: false,
+					consume: false,
+				} => unreachable!("a stage always needs a direction"),
+			};
+			Ok(())
+		});
 		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
 	}
 
@@ -245,6 +261,19 @@ async fn run_stages(moq: MoqSide, stages: Vec<Command>, net: Net) -> anyhow::Res
 
 	let bandwidth = spawn_moq(&moq, &net, &origin, Directions::of(&stages), &mut tasks)?;
 
+	// Rate control is per-encoder but the estimate is per-connection, so each encoder
+	// would independently target most of the same uplink and together oversubscribe
+	// it. Refuse rather than congest the link the estimate exists to protect.
+	let adaptive = stages
+		.iter()
+		.filter(|stage| matches!(stage, Command::Import(import) if import.source.uses_bandwidth()))
+		.count();
+	anyhow::ensure!(
+		bandwidth.is_none() || adaptive <= 1,
+		"only one stage can encode to fit the connection's bandwidth estimate, but {adaptive} do; \
+		 run them as separate processes, or publish over --server-bind, which has no estimate"
+	);
+
 	// stdin and stdout are one resource each, so two stages can't share them.
 	let mut stdin = None;
 	let mut stdout = None;
@@ -274,28 +303,27 @@ async fn run_stages(moq: MoqSide, stages: Vec<Command>, net: Net) -> anyhow::Res
 		return drive(tasks).await;
 	}
 
-	// Report the first local pipeline to finish, so stdin EOF ends the process just
-	// like a spawned stage returning does.
-	let (done, mut first) = tokio::sync::mpsc::channel(1);
 	let local = tokio::task::LocalSet::new();
-	for publish in locals {
-		let done = done.clone();
-		local.spawn_local(async move {
-			let _ = done.send(publish.run().await).await;
-		});
-	}
-	drop(done);
+	supervise(&local, locals.into_iter().map(Publish::run), &mut tasks);
+	local.run_until(drive(tasks)).await
+}
 
-	local
-		.run_until(async move {
-			tokio::select! {
-				res = drive(tasks) => res,
-				// `None` means every local pipeline ended without reporting, which a
-				// completed one never does: the task panicked, and tokio caught it.
-				res = first.recv() => res.unwrap_or_else(|| Err(anyhow::anyhow!("pipeline panicked"))),
-			}
-		})
-		.await
+/// Run the non-Send pipelines on `local`, reporting each into `tasks`.
+///
+/// The report is what makes a local pipeline end the process on the same terms as a
+/// spawned stage: it returns on stdin EOF, and a panic surfaces as an error instead
+/// of leaving the other stages running without it.
+fn supervise<F>(
+	local: &tokio::task::LocalSet,
+	pipelines: impl IntoIterator<Item = F>,
+	tasks: &mut JoinSet<anyhow::Result<()>>,
+) where
+	F: std::future::Future<Output = anyhow::Result<()>> + 'static,
+{
+	for pipeline in pipelines {
+		let pipeline = local.spawn_local(pipeline);
+		tasks.spawn(async move { pipeline.await.context("pipeline panicked")? });
+	}
 }
 
 /// Refuse a second stage on a stream there is only one of.
@@ -538,4 +566,44 @@ fn reject_listener_cors(cors: &crate::web::Cors, endpoint: &str) -> anyhow::Resu
 		"`--cors-origin` only applies to `{endpoint} --listen`"
 	);
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::future::Future;
+	use std::pin::Pin;
+
+	type Pipeline = Pin<Box<dyn Future<Output = anyhow::Result<()>>>>;
+
+	/// A local pipeline that dies takes the process with it, even while another one is
+	/// still running. Reporting completion from inside the task instead would miss
+	/// this: a panic skips the report, leaving the survivor to keep the process alive
+	/// with one broadcast silently gone.
+	#[tokio::test]
+	async fn a_panicking_pipeline_ends_the_process() {
+		let local = tokio::task::LocalSet::new();
+		let mut tasks = JoinSet::new();
+
+		let pipelines: Vec<Pipeline> = vec![
+			Box::pin(async { panic!("pipeline died") }),
+			Box::pin(std::future::pending()),
+		];
+		supervise(&local, pipelines, &mut tasks);
+
+		let err = local.run_until(drive(tasks)).await.unwrap_err();
+		assert!(err.to_string().contains("pipeline panicked"), "{err}");
+	}
+
+	/// The first to finish ends the process, which is how stdin EOF stops a run.
+	#[tokio::test]
+	async fn a_finished_pipeline_ends_the_process() {
+		let local = tokio::task::LocalSet::new();
+		let mut tasks = JoinSet::new();
+
+		let pipelines: Vec<Pipeline> = vec![Box::pin(async { Ok(()) }), Box::pin(std::future::pending())];
+		supervise(&local, pipelines, &mut tasks);
+
+		local.run_until(drive(tasks)).await.unwrap();
+	}
 }

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -261,17 +261,23 @@ async fn run_stages(moq: MoqSide, stages: Vec<Command>, net: Net) -> anyhow::Res
 
 	let bandwidth = spawn_moq(&moq, &net, &origin, Directions::of(&stages), &mut tasks)?;
 
-	// Rate control is per-encoder but the estimate is per-connection, so each encoder
-	// would independently target most of the same uplink and together oversubscribe
-	// it. Refuse rather than congest the link the estimate exists to protect.
+	// Rate control assumes it owns the uplink: the encoder targets a fraction of the
+	// connection's estimate, leaving room for its own audio and transport overhead but
+	// not for a second publisher. Anything else importing over the same connection
+	// spends what that encoder already claimed, so refuse rather than congest the link
+	// the estimate exists to protect. Exports only receive, so they don't count.
+	let imports = stages
+		.iter()
+		.filter(|stage| matches!(stage, Command::Import(_)))
+		.count();
 	let adaptive = stages
 		.iter()
-		.filter(|stage| matches!(stage, Command::Import(import) if import.source.uses_bandwidth()))
-		.count();
+		.any(|stage| matches!(stage, Command::Import(import) if import.source.uses_bandwidth()));
 	anyhow::ensure!(
-		bandwidth.is_none() || adaptive <= 1,
-		"only one stage can encode to fit the connection's bandwidth estimate, but {adaptive} do; \
-		 run them as separate processes, or publish over --server-bind, which has no estimate"
+		bandwidth.is_none() || !adaptive || imports == 1,
+		"a stage that encodes to fit the connection's bandwidth estimate assumes it's the only \
+		 publisher on that connection, but this runs {imports} import stages; run them as separate \
+		 processes, or publish over --server-bind, which has no estimate"
 	);
 
 	// stdin and stdout are one resource each, so two stages can't share them.

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -259,26 +259,9 @@ async fn run_stages(moq: MoqSide, stages: Vec<Command>, net: Net) -> anyhow::Res
 	// platform capture stream is not Send, so their futures cannot be spawned.
 	let mut locals: Vec<Publish> = Vec::new();
 
+	// The stage combinations were refused up front by `Invocation::validate`, before
+	// anything bound a port or dialed out.
 	let bandwidth = spawn_moq(&moq, &net, &origin, Directions::of(&stages), &mut tasks)?;
-
-	// Rate control assumes it owns the uplink: the encoder targets a fraction of the
-	// connection's estimate, leaving room for its own audio and transport overhead but
-	// not for a second publisher. Anything else importing over the same connection
-	// spends what that encoder already claimed, so refuse rather than congest the link
-	// the estimate exists to protect. Exports only receive, so they don't count.
-	let imports = stages
-		.iter()
-		.filter(|stage| matches!(stage, Command::Import(_)))
-		.count();
-	let adaptive = stages
-		.iter()
-		.any(|stage| matches!(stage, Command::Import(import) if import.source.uses_bandwidth()));
-	anyhow::ensure!(
-		bandwidth.is_none() || !adaptive || imports == 1,
-		"a stage that encodes to fit the connection's bandwidth estimate assumes it's the only \
-		 publisher on that connection, but this runs {imports} import stages; run them as separate \
-		 processes, or publish over --server-bind, which has no estimate"
-	);
 
 	// stdin and stdout are one resource each, so two stages can't share them.
 	let mut stdin = None;

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -308,9 +308,14 @@ impl Server {
 		self.with_subscriber(origin).serve().await
 	}
 
-	/// Shared accept loop for [`serve_publish`](Self::serve_publish) /
-	/// [`serve_consume`](Self::serve_consume); the origin is already attached.
-	async fn serve(mut self) -> crate::Result<()> {
+	/// Accept sessions until the listener stops, serving whatever directions were
+	/// already attached by [`with_publisher`](Self::with_publisher) /
+	/// [`with_subscriber`](Self::with_subscriber).
+	///
+	/// [`serve_publish`](Self::serve_publish) and [`serve_consume`](Self::serve_consume)
+	/// are the one-direction shorthands; call this directly to serve both, so inbound
+	/// sessions can subscribe to the origin and publish into it over one connection.
+	pub async fn serve(mut self) -> crate::Result<()> {
 		if let Ok(addr) = self.local_addr() {
 			tracing::info!(%addr, "listening");
 		}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -308,14 +308,24 @@ impl Server {
 		self.with_subscriber(origin).serve().await
 	}
 
-	/// Accept sessions until the listener stops, serving whatever directions were
-	/// already attached by [`with_publisher`](Self::with_publisher) /
-	/// [`with_subscriber`](Self::with_subscriber).
+	/// Accept sessions until the listener stops, serving `publish` to each subscriber
+	/// and ingesting each publisher into `subscribe`.
 	///
-	/// [`serve_publish`](Self::serve_publish) and [`serve_consume`](Self::serve_consume)
-	/// are the one-direction shorthands; call this directly to serve both, so inbound
-	/// sessions can subscribe to the origin and publish into it over one connection.
-	pub async fn serve(mut self) -> crate::Result<()> {
+	/// The both-directions counterpart of [`serve_publish`](Self::serve_publish) and
+	/// [`serve_consume`](Self::serve_consume), so an inbound session can subscribe to
+	/// the origin and publish into it over one connection.
+	pub async fn serve_both(
+		self,
+		publish: moq_net::origin::Consumer,
+		subscribe: moq_net::origin::Producer,
+	) -> crate::Result<()> {
+		self.with_publisher(publish).with_subscriber(subscribe).serve().await
+	}
+
+	/// Shared accept loop for the `serve_*` entry points; the origin is already
+	/// attached. Private so a server can't be served with no direction at all, which
+	/// would accept and handshake sessions that carry nothing.
+	async fn serve(mut self) -> crate::Result<()> {
 		if let Ok(addr) = self.local_addr() {
 			tracing::info!(%addr, "listening");
 		}


### PR DESCRIPTION
## Summary

- `moq` bridged exactly one broadcast per process, so ingesting two cameras meant two processes and two connections to the relay. Stages separated by `--` now share one connection, one origin id, and one Origin:

  ```bash
  moq --client-connect https://relay.example.com/anon \
      import --broadcast cam1.hang rtmp --listen 0.0.0.0:1935 \
      -- import --broadcast cam2.hang rtmp --listen 0.0.0.0:1936
  ```

- clap can't express this grammar: it needs a repeated subcommand at one level *and* an `import` reachable under `rtmp`, which makes the command tree cyclic. The derive builds that tree eagerly, so it compiles and then overflows the stack. `Invocation` therefore splits argv on `--` before clap sees it, sending chunk 0 to `Cli` and later chunks to a `no_binary_name` `Stage` parser. Each stage keeps full validation, stage-scoped errors, and its own `--help`. Splitting on the literal word `import` instead would misfire on `--broadcast import`; `--` has no such ambiguity, and nothing in moq-cli or moq-native used `trailing_var_arg`/`last`, so it was free to claim.

- Stages may run in opposite directions (`import ... -- export ...`), so one process can ingest and re-publish without a second connection or a second copy of the media. That attaches a publisher and a subscriber to the same session, which is what `moq-relay`'s cluster peering already does; loop prevention stays the network's job, since an announcement carries this process's origin id as a hop.

- `--broadcast` is now also a per-stage flag on `import`/`export`, falling back to the process-wide one. Every existing invocation parses unchanged, so no existing doc example broke.

## What a stage can't do

Refused rather than silently mishandled:

- `play`, `transcode`, `token`, and `devices` own the process.
- stdin and stdout are one resource each, so one stage may read a container from stdin and one may write one to stdout.
- The MoQ side belongs to the invocation, so `--client-connect` after a `--` is an error, not a silently-ignored flag.
- A stage that encodes to fit the connection's bandwidth estimate (today: `import capture` with video) must be the only `import` on that connection. Rate control targets a fraction of the *connection* estimate with headroom for its own audio and transport overhead, not for a second publisher, so any other import spends what that encoder already claimed. Exports only receive, so they don't count, and an audio-only `--no-video` capture never reads the estimate. #2815 tracks dividing the estimate so this can be lifted.
- Claiming `--` takes it from clap as the end-of-options marker. The only positional it could have escaped is an `import hls` playlist path starting with `-`, so `./-playlist.m3u8` is documented in `--help` and the docs rather than making the separator context-sensitive.

## Public API changes

- **Added**: `moq_native::Server::serve_both(publish, subscribe)`, the both-directions counterpart of `serve_publish` / `serve_consume`. Additive, so this targets `main`.
- No renamed, removed, or signature-changed items. `Server::serve` stays private, so every public way to serve attaches at least one direction.
- moq-cli is a binary; its `Invocation` / `Stage` / `Command::{name, is_stageable, broadcast}` / `ImportSource::uses_bandwidth` additions are not a published API.

## Test plan

- `just check` and `just test` pass (1575 tests).
- Clippy clean under default features and under `play,capture` (the local-pipeline and bandwidth paths are feature-gated).
- 11 new `args` tests: stage splitting, per-stage vs process-wide `--broadcast`, root-broadcast default, refusing unstageable verbs, stage-scoped parse errors, globals rejected after `--`, empty stages from a trailing or doubled `--`, the `./-name` escape, audio-only capture not counting as adaptive, and a `debug_assert` on the new `Stage` tree.
- 2 new supervision tests: a panicking pipeline ends the process while another is still running (this hangs without the fix), and a finished one ends it normally.
- End-to-end against a local relay:
  - the two-stage import above bound both RTMP listeners and published over one connection;
  - `import ... rtmp --listen -- export --broadcast src.hang fmp4` produced 19.6s of h264 320x240 + aac that ffprobe decodes, confirming a single session carrying both directions;
  - a single-stage run produces byte-identical teardown warnings, so nothing regressed there.

## Review fixes

From the adversarial pass and the bots, each verified against the code first:

- **Local pipeline supervision.** Completion was reported by a channel send after `run()` returned, so a panicking pipeline never reported: its sender dropped, but a second pipeline still held one, leaving the receiver pending while the process ran on with a broadcast silently gone. Now supervised through their `JoinHandle` from the same `JoinSet` the spawned stages use.
- **Bandwidth oversubscription**, in two rounds: first refusing multiple adaptive stages, then widening it to the rule above once it was pointed out that fixed-rate imports spend the same uplink; and narrowing `uses_bandwidth()` to `!no_video`, since `Publish::capture` only passes the estimate to `video_encode`.
- **Server API.** `serve` reverted to private with `serve_both` added.
- **Empty stages and help text.** A trailing or doubled `--` now names the problem instead of dumping a bare missing-subcommand usage; and the stage parsers' doc comments were leaking rustdoc prose (`Later stages are [`Stage`]s.`) into `moq --help`.

Filed rather than fixed here: #2815 (connection-level rate allocation) and #2834 (moq-cli can't run a TCP/UDS-only server, pre-existing on `main`).

(Written by Opus 5)