### PR TITLE
fix(wasm): advertise ALPN so the browser can negotiate a version

### DIFF
--- a/rs/moq-wasm/src/transport.rs
+++ b/rs/moq-wasm/src/transport.rs
@@ -14,9 +14,16 @@ use web_transport_trait as wtt;
 #[derive(Clone)]
 pub struct Session(web_transport_wasm::Session);
 
+/// Advertise every version `moq-net` supports, so the peer picks one via ALPN.
+/// Without this the browser negotiates no subprotocol and the session has no
+/// version to start from.
+fn builder() -> web_transport_wasm::ClientBuilder {
+	web_transport_wasm::ClientBuilder::new().with_protocols(moq_net::ALPNS.iter().copied())
+}
+
 /// Open a browser WebTransport connection to `url`.
 pub async fn connect(url: Url) -> Result<Session, Error> {
-	let client = web_transport_wasm::ClientBuilder::new().with_system_roots();
+	let client = builder().with_system_roots();
 	let session = client.connect(url).await.map_err(Error)?;
 	Ok(Session(session))
 }
@@ -24,7 +31,7 @@ pub async fn connect(url: Url) -> Result<Session, Error> {
 /// Connect, trusting only the given sha-256 certificate hashes (serverless dev,
 /// matching the browser's `serverCertificateHashes` option).
 pub async fn connect_with_hashes(url: Url, hashes: Vec<Vec<u8>>) -> Result<Session, Error> {
-	let client = web_transport_wasm::ClientBuilder::new().with_server_certificate_hashes(hashes);
+	let client = builder().with_server_certificate_hashes(hashes);
 	let session = client.connect(url).await.map_err(Error)?;
 	Ok(Session(session))
 }
@@ -90,7 +97,9 @@ impl wtt::Session for Session {
 	}
 
 	fn protocol(&self) -> Option<&str> {
-		self.0.protocol()
+		// The browser reports "" when no subprotocol was negotiated, which means the
+		// same thing as `None`: fall back to negotiating the version over SETUP.
+		self.0.protocol().filter(|p| !p.is_empty())
 	}
 
 	fn close(&self, code: u32, reason: &str) {


### PR DESCRIPTION
## Problem

`moq-wasm` cannot open a session at all. Every connect fails with:

```
Error: unknown ALPN:
```

`transport.rs` built its `web_transport_wasm::ClientBuilder` without ever calling `with_protocols`, so the browser negotiated no WebTransport subprotocol and reported `""` back. moq-net has no ALPN to start from in that case and rejects the session.

This is the same gap that #1726 fixed before it was closed unmerged, so the fix was lost with it.

## Fix

Advertise `moq_net::ALPNS` (the same list the native client offers) and let the peer pick.

Separately, map the browser's `""` to `None` in `Session::protocol`. An empty string means *no subprotocol was negotiated*, which is exactly what `None` already encodes; passing it through as `Some("")` is what turned "nothing negotiated" into "unknown ALPN". With it mapped, moq-net falls back to negotiating the version over SETUP instead of erroring on an ALPN nobody offered.

## Verification

Driven in a real browser against a local relay + `bbb.hang` fmp4 publisher, reading frames through the wasm consume API:

| relay | negotiated | drained | max event-loop gap |
|---|---|---|---|
| default | `moq-lite-05` | 4 groups / 209 frames / 1.9 MB | 15 ms |
| `--server-version moq-transport-19` | `moq-transport-19` | 8 groups / 412 frames / 4.5 MB | 11 ms |

Event-loop gaps measured with `MessageChannel` macrotasks (not `setTimeout`, which a background tab clamps to 1/sec and which made the first reading look like starvation when it wasn't). No sign of the main-thread starvation from #1726; the kio fixes in #1735 / #1739 hold up.

`just rs wasm` and `just fix` are clean.

## No regression test

`moq-wasm` is `#![cfg(target_arch = "wasm32")]` and the crate has no `wasm-bindgen-test` harness, so this path can only be exercised in a real browser. `just rs wasm` compiles the crate and nothing more. Standing up a headless-browser test runner is worth doing but is a much larger change than this fix.

(written by Opus 5)