### PR TITLE
feat(wasm): bind moq-net's full model, not just the consume path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ Top-level layout only. Per-crate and per-package detail lives in the nested guid
 
 `rs/moq-ffi` is the single UniFFI core that every non-Rust binding is generated from. The wrappers under `/py`, `/swift`, `/kt`, and `/go` are thin layers over it, and `rs/libmoq` exposes the same core as a C staticlib. So one `moq-ffi` change ripples out to all of them (and their docs) per the [Cross-Package Sync](#cross-package-sync) table. CI mirrors the Swift and Go source packages to their external repos; Kotlin publishes `dev.moq:*` artifacts to Maven Central. For Python, most callers want the ergonomic `moq-rs` wrapper rather than the generated `moq-ffi` bindings directly.
 
+`rs/moq-wasm` is the browser binding and belongs to the same set even though it does not go through `moq-ffi`: UniFFI is C-ABI only, so the browser gets its own wasm-bindgen surface over `moq-net`. **Treat it as one more binding to keep in sync, not as an experiment that can lag.** Nothing compiles it against `moq-net`'s current API except `just rs wasm`, and no test exercises it at all, so a `moq-net` method the browser needs is simply missing until someone notices. When you add or change a `moq-net` API a browser caller would use, mirror it in `rs/moq-wasm` in the same PR, the same way a `moq-ffi` change ripples into `libmoq` and the language wrappers.
+
 ## Per-Directory Guides
 
 Language-specific conventions, crate/package maps, and patterns live in nested `CLAUDE.md` files that load automatically when you work under that directory. Before writing code in one of these areas, read its guide (your editor loads it for you, but check it explicitly if you are reasoning about the area without opening a file in it):
@@ -172,7 +174,7 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 | Change in | Also update |
 |---|---|
 | `rs/moq-ffi` | `rs/libmoq`, `{py,swift,kt}/`, `go/wrapper/moq/*.go` (the `go/ffi` bindings regenerate automatically, but a new method needs a hand-written wrapper too, like `py/moq-rs`), `doc/lib/{py,swift,kt,go,c}` |
-| `rs/moq-net` wire/API | `js/net`, `doc/concept`, `drafts/draft-lcurley-moq-lite.md` (if the wire spec changes) |
+| `rs/moq-net` wire/API | `js/net`, `rs/moq-wasm` (the browser binding; nothing but `just rs wasm` compiles it, and that only catches a break, never a gap), `doc/concept`, `drafts/draft-lcurley-moq-lite.md` (if the wire spec changes) |
 | `rs/hang` catalog/container | `js/hang`, `doc/concept`, `drafts/draft-lcurley-moq-hang.md` (if the format spec changes) |
 | `rs/moq-token` | `js/token` |
 | `rs/moq-stats` wire (track names, frame shapes) | `doc/bin/relay/config.md` (stats section) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,8 +5165,11 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "moq-net",
+ "serde",
+ "serde-wasm-bindgen",
  "thiserror 2.0.20",
  "tracing-wasm",
+ "tsify",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -8111,6 +8114,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8138,6 +8152,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9711,6 +9736,30 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tsify"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
+dependencies = [
+ "serde",
+ "serde-wasm-bindgen",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "ttf-parser"

--- a/js/wasm/README.md
+++ b/js/wasm/README.md
@@ -3,7 +3,8 @@
 Browser bindings for [`moq-net`](../../rs/moq-net), compiled to WebAssembly with
 `wasm-bindgen`. This is the JS-facing half of the `rs/moq-wasm` crate: it
 packages the generated bindings so a JS app can `import` the real Rust moq-lite
-implementation instead of the hand-written TypeScript one in `@moq/net`.
+and moq-transport implementation instead of the hand-written TypeScript one in
+`@moq/net`.
 
 ```ts
 import init, * as Moq from "@moq/wasm";
@@ -12,17 +13,42 @@ await init(); // load the wasm module (wasm-bindgen's default loader)
 Moq.setup(); // install panic/tracing hooks for readable errors
 
 const session = await Moq.Session.connect("https://relay.example.com/anon");
-const broadcast = await session.consume("room/alice");
-const track = await broadcast?.subscribe("video");
-for (let group = await track?.recvGroup(); group; group = await track?.recvGroup()) {
+
+// Consume.
+const broadcast = await session.announcedBroadcast("room/alice");
+const track = await broadcast.subscribe("video");
+for (let group = await track.recvGroup(); group; group = await track.recvGroup()) {
 	for (let frame = await group.readFrame(); frame; frame = await group.readFrame()) {
 		// frame: Uint8Array
 	}
 }
+
+// Publish.
+const room = session.publish("room/bob");
+const video = room.createTrack("video");
+const group = video.appendGroup();
+group.writeFrame(timestampMicros, payload);
+group.close();
 ```
 
-The classes (`Moq.Session`, `Moq.Broadcast`, `Moq.Track`, `Moq.Group`) drop the
-`Moq` prefix since they're already namespaced under the import.
+## Surface
+
+The classes mirror `moq-net`'s role modules: `Session`, `BroadcastProducer` /
+`BroadcastConsumer`, `TrackProducer` / `TrackConsumer` / `TrackSubscriber` /
+`TrackRequest`, `GroupProducer` / `GroupConsumer`, `AnnounceConsumer`, plus the
+option bags `Subscription`, `TrackInfo`, and `Frame`. See
+[`rs/moq-wasm/README.md`](../../rs/moq-wasm/README.md) for the mapping and for
+what is deliberately left out.
+
+Conventions worth knowing before wiring this into app code:
+
+- Durations are milliseconds and timestamps are microseconds, matching `@moq/net`.
+- Sequence numbers are `bigint`, since they are `u64` on the wire.
+- `close()` is a clean finish; `abort(code)` takes an application close code.
+- `closed()` **rejects** rather than resolving, because every close carries a
+  reason (a clean one included).
+- One in-flight async call per handle. A second concurrent `recvGroup()` on the
+  same subscriber throws rather than interleaving; clone the handle instead.
 
 ## Building
 
@@ -32,14 +58,26 @@ The classes (`Moq.Session`, `Moq.Broadcast`, `Moq.Track`, `Moq.Group`) drop the
 just wasm
 ```
 
-That compiles `rs/moq-wasm` for `wasm32-unknown-unknown`, runs `wasm-bindgen`
+That compiles `rs/moq-wasm` for `wasm32-unknown-unknown` and runs `wasm-bindgen`
 (web target) into `dist/`. The required toolchain (wasm target and
 `wasm-bindgen-cli`) is provided by the Nix dev shell.
 
 ## Status
 
-Compiles and produces a typed, importable package. The consume path is
-runtime-portable: `moq-net`'s timers and `Instant` go through `web_async::time`
-(wasmtimer on wasm), so they no longer panic. Not yet exercised end-to-end in a
-browser against a relay, and media muxing (`moq-mux`) is still out. See
-[`rs/moq-wasm/README.md`](../../rs/moq-wasm/README.md) for details.
+Not a drop-in replacement for `@moq/net` yet. The wire layer works: publish,
+consume, discovery, and on-demand serving have all been driven in a browser
+against a relay on both `moq-lite-05` and `moq-transport-19`. What is missing is
+everything around it.
+
+- **No TS wrapper.** `@moq/net` exposes a reactive, signals-based surface that
+  `@moq/watch` and `@moq/publish` build on; these bindings expose Promises. A
+  hand-written shim would have to bridge the two.
+- **No WebSocket fallback.** `@moq/net` falls back to WebSocket via `@moq/qmux`;
+  the Rust `qmux` crate is tokio-based, so there is no wasm path today. Handing
+  a JS transport into wasm is the likely fix, since `@moq/qmux` already
+  implements the `WebTransport` interface structurally.
+- **Bigger.** Roughly 340 KB brotli against about 39 KB for a bundled `@moq/net`.
+- **Single-threaded.** Everything runs on the thread that instantiated the
+  module. Drain a high-bitrate track in a Worker so decode and render are not
+  sharing it.
+- **No media muxing.** `moq-mux` is not wasm-ready.

--- a/js/wasm/README.md
+++ b/js/wasm/README.md
@@ -26,7 +26,7 @@ for (let group = await track.recvGroup(); group; group = await track.recvGroup()
 
 // Publish.
 const room = session.publish("room/bob");
-const video = room.createTrack("video");
+const video = room.createTrack("video", { timescale: 1_000_000 });
 const group = video.appendGroup();
 group.writeFrame(timestampMicros, payload);
 group.close();
@@ -45,17 +45,21 @@ Conventions worth knowing before wiring this into app code:
 
 - Durations are milliseconds and timestamps are microseconds, matching `@moq/net`.
 - Sequence numbers are `bigint`, since they are `u64` on the wire.
+- Options are plain objects (`{ priority: 3 }`), not classes, so one can be built
+  once and reused across calls. Omitted fields take `moq-net`'s defaults; a wrong
+  type or an out-of-range value is an error, while a misspelled field is caught by
+  the TypeScript interface rather than at runtime.
 - `close()` is a clean finish; `abort(code)` takes an application close code and
   consumes the handle, so every later call on it fails. `Session.close(code)` is
   the exception: it takes an optional code and tears the whole session down.
 - `closed()` **rejects** rather than resolving, because every close carries a
   reason (a clean one included). It is safe to await while still using the
   handle, and so is `TrackProducer`'s `used()` / `unused()`.
-- One in-flight async call per handle otherwise. A second concurrent
-  `recvGroup()` on the same subscriber throws rather than interleaving; clone
-  the handle instead. Subscription changes are exempt: `update()` and
-  `subscription` go through a separate control handle, so they work while a read
-  is pending.
+- One in-flight async call per handle otherwise: a second concurrent
+  `recvGroup()` on the same subscriber throws rather than interleaving. Subscribe
+  again for a second independent reader. Subscription changes are exempt, since
+  `update()` and `subscription` go through a separate control handle and work
+  while a read is pending.
 
 ## Building
 

--- a/js/wasm/README.md
+++ b/js/wasm/README.md
@@ -14,8 +14,9 @@ Moq.setup(); // install panic/tracing hooks for readable errors
 
 const session = await Moq.Session.connect("https://relay.example.com/anon");
 
-// Consume.
+// Consume. `announcedBroadcast` resolves null if the session closes first.
 const broadcast = await session.announcedBroadcast("room/alice");
+if (!broadcast) throw new Error("session closed before the broadcast appeared");
 const track = await broadcast.subscribe("video");
 for (let group = await track.recvGroup(); group; group = await track.recvGroup()) {
 	for (let frame = await group.readFrame(); frame; frame = await group.readFrame()) {
@@ -44,11 +45,17 @@ Conventions worth knowing before wiring this into app code:
 
 - Durations are milliseconds and timestamps are microseconds, matching `@moq/net`.
 - Sequence numbers are `bigint`, since they are `u64` on the wire.
-- `close()` is a clean finish; `abort(code)` takes an application close code.
+- `close()` is a clean finish; `abort(code)` takes an application close code and
+  consumes the handle, so every later call on it fails. `Session.close(code)` is
+  the exception: it takes an optional code and tears the whole session down.
 - `closed()` **rejects** rather than resolving, because every close carries a
-  reason (a clean one included).
-- One in-flight async call per handle. A second concurrent `recvGroup()` on the
-  same subscriber throws rather than interleaving; clone the handle instead.
+  reason (a clean one included). It is safe to await while still using the
+  handle, and so is `TrackProducer`'s `used()` / `unused()`.
+- One in-flight async call per handle otherwise. A second concurrent
+  `recvGroup()` on the same subscriber throws rather than interleaving; clone
+  the handle instead. Subscription changes are exempt: `update()` and
+  `subscription` go through a separate control handle, so they work while a read
+  is pending.
 
 ## Building
 

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -48,9 +48,11 @@ Layered roughly transport -> container/format -> media -> apps/bindings.
 - `moq-ffi` (cdylib+staticlib): UniFFI bindings (Python/Swift/Kotlin/Go). Proc-macro based (`uniffi::setup_scaffolding!("moq")`, `#[uniffi::Object]`/`#[uniffi::export]`), no `.udl`. Exposes `Moq*Producer`/`Moq*Consumer`, `MoqError` (`#[uniffi(flat_error)]`).
 - `libmoq` (staticlib): C bindings. `cbindgen` `build.rs` emits `moq.h` + pkg-config. `extern "C"` over opaque handles; dedicated tokio runtime thread (`LazyLock`).
 - `moq-gst` (cdylib): GStreamer plugin. `gst::plugin_define!`, `moqsrc`/`moqsink` elements bridging to a background tokio task.
-- `moq-wasm` (cdylib+rlib): browser/WASM bindings, `wasm-bindgen` over `moq-net`. Consumed by `js/wasm` (`@moq/wasm`); build via `just wasm`.
+- `moq-wasm` (cdylib+rlib): browser/WASM bindings, `wasm-bindgen` over `moq-net`. Consumed by `js/wasm` (`@moq/wasm`); build via `just wasm`. Private modules mirroring moq-net's role modules (`broadcast`, `track`, `group`, `announce`, `session`), re-exported flat. Types carry the role as a prefix (`TrackProducer`, not `track::Producer`) against the usual naming rule, because wasm-bindgen resolves a type in a signature by its Rust ident alone: it ignores the module path *and* `js_name`, so two modules each exporting a `Consumer` silently emit typings where one stands in for the other.
 
 When you change `moq-ffi`'s surface, mirror it in `libmoq` and the language wrappers (see the Cross-Package Sync table in root).
+
+**`moq-wasm` is a binding too, and the easiest one to let rot.** It doesn't go through `moq-ffi` (UniFFI is C-ABI only, so the browser needs its own wasm-bindgen surface), which is exactly why it falls off the radar: it isn't in the `moq-ffi` sync row, `cargo check --workspace` compiles it to nothing on a host target, and no test in the repo exercises it. `just rs wasm` is a *compile* gate, so it catches a `moq-net` change that breaks an existing binding but says nothing about one the binding never grew. So when you add or change a `moq-net` API a browser caller would want (a new `track::Subscriber` control, a group option, a session capability), add the matching method to `rs/moq-wasm` in the same PR. The modules are named after their moq-net counterparts specifically so the two can be read side by side to spot the gap.
 
 ## Producer / Consumer Model (moq-net)
 

--- a/rs/moq-wasm/Cargo.toml
+++ b/rs/moq-wasm/Cargo.toml
@@ -10,8 +10,9 @@ publish = false
 
 [package.metadata.cargo-shear]
 # Required indirectly (getrandom: feature enabler; wasm-bindgen-futures: async
-# codegen) with no `use`, so cargo-shear can't see them.
-ignored = ["getrandom", "wasm-bindgen-futures"]
+# codegen; serde-wasm-bindgen: what tsify's derive expands into) with no `use`,
+# so cargo-shear can't see them.
+ignored = ["getrandom", "serde-wasm-bindgen", "wasm-bindgen-futures"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -30,8 +31,14 @@ console_error_panic_hook = "0.1"
 getrandom = { version = "0.4", features = ["wasm_js"] } # wasm_js backend for rand-via-moq-net; cfg flag in .cargo/config.toml
 js-sys = "0.3"
 moq-net = { workspace = true }
+serde = { workspace = true }
+# The option bags cross as plain JS objects rather than exported classes, so a
+# caller can reuse one. serde-wasm-bindgen does the conversion; tsify derives the
+# matching TypeScript interface so the .d.ts stays typed.
+serde-wasm-bindgen = "0.6"
 thiserror = "2"
 tracing-wasm = "0.2"
+tsify = { version = "0.5", default-features = false, features = ["js"] }
 url = "2"
 # Pinned to the wasm-bindgen-cli version in the Nix dev shell: the bindgen
 # schema must match exactly between crate and CLI. Bump both together.

--- a/rs/moq-wasm/README.md
+++ b/rs/moq-wasm/README.md
@@ -25,7 +25,7 @@ methods of its counterpart:
 | `track` | `TrackProducer`, `TrackConsumer`, `TrackSubscriber`, `TrackRequest` | `moq_net::track` |
 | `group` | `GroupProducer`, `GroupConsumer` | `moq_net::group` |
 | `announce` | `AnnounceConsumer`, `Announce` | `moq_net::announce` |
-| `options` | `Subscription`, `TrackInfo`, `Frame` | the plain-data types |
+| `options` | `Subscription`, `TrackInfo`, `Fetch`, `Frame` | the plain-data types |
 
 That mirroring is the point: the binding is the surface most likely to drift
 from the crate it wraps, so the two are meant to be read side by side. When
@@ -42,6 +42,13 @@ re-export flat, so nothing reads `broadcast::BroadcastProducer`.
 
 ### Conventions at the boundary
 
+- The input option bags (`Subscription`, `TrackInfo`, `Fetch`) cross as plain JS
+  objects via serde, not as exported classes, and `tsify` derives their
+  TypeScript interfaces. wasm-bindgen passes an exported class *by value*: it
+  zeroes the JS object's pointer and encodes a null pointer as `None`, so a
+  caller who reused one bag silently got defaults on the second call. A plain
+  object has no ownership to lose. `Frame` stays a class because it is only ever
+  returned and carries a `Uint8Array`.
 - Durations are milliseconds and timestamps are microseconds, matching `@moq/net`.
 - Sequence numbers stay `u64`, which wasm-bindgen maps to a JS `bigint`.
 - Closing takes an application close code (`moq_net::Error::App`); a JS `Error`

--- a/rs/moq-wasm/README.md
+++ b/rs/moq-wasm/README.md
@@ -57,9 +57,20 @@ Relay-side concerns are deliberately absent: routes, hops, cost, origin scoping,
 and cluster identity have no browser caller. So are the `poll_*` variants, since
 JS has no equivalent of a `kio::Waiter`.
 
+Datagrams are the one part of the track model still unbound:
+`track::Producer::append_datagram` / `write_datagram` and
+`track::Subscriber::recv_datagram` have no counterpart here, so a browser
+publisher can't emit them and a subscriber can't observe them. They only flow on
+moq-lite-05 over a transport that carries datagrams at all, which the browser
+does. Tracked separately.
+
 Media muxing is still out (see below), and there is no WebSocket fallback: the
 Rust `qmux` crate is tokio-based, so a browser session is WebTransport-only
 where `@moq/net` can fall back.
+
+`GroupProducer` has no `closed()`, unlike `TrackProducer`. See the note in
+`src/group.rs`: there is no second handle to wait on, so awaiting it would have
+to hold the producer and fail every `writeFrame` until it resolved.
 
 ### Three moq-net changes this requires
 

--- a/rs/moq-wasm/README.md
+++ b/rs/moq-wasm/README.md
@@ -57,12 +57,17 @@ Relay-side concerns are deliberately absent: routes, hops, cost, origin scoping,
 and cluster identity have no browser caller. So are the `poll_*` variants, since
 JS has no equivalent of a `kio::Waiter`.
 
-Datagrams are the one part of the track model still unbound:
-`track::Producer::append_datagram` / `write_datagram` and
-`track::Subscriber::recv_datagram` have no counterpart here, so a browser
-publisher can't emit them and a subscriber can't observe them. They only flow on
-moq-lite-05 over a transport that carries datagrams at all, which the browser
-does. Tracked separately.
+Two parts of the track model are still unbound, both tracked separately:
+
+- **Datagrams.** `track::Producer::append_datagram` / `write_datagram` and
+  `track::Subscriber::recv_datagram` have no counterpart here, so a browser
+  publisher can't emit them and a subscriber can't observe them. They only flow
+  on moq-lite-05 over a transport that carries datagrams at all, which the
+  browser does.
+- **Serving a cache-miss fetch.** `fetchGroup` binds the requesting side, but
+  `track::Dynamic` / `requested_group` is absent, so a publisher can only answer
+  a fetch for a group it still has cached. Note the asymmetry: the
+  broadcast-level equivalent *is* bound, as `BroadcastProducer.requestedTrack`.
 
 Media muxing is still out (see below), and there is no WebSocket fallback: the
 Rust `qmux` crate is tokio-based, so a browser session is WebTransport-only

--- a/rs/moq-wasm/README.md
+++ b/rs/moq-wasm/README.md
@@ -13,23 +13,53 @@ Go). Browsers need `wasm-bindgen`, so this is a separate sibling crate. (For
 *React Native* JS, `uniffi-bindgen-react-native` can reuse `moq-ffi` directly;
 that path is unrelated to this crate.)
 
-## Status: compiles and ships a typed JS package
+## Surface
 
-What works today:
+The modules mirror `moq-net`'s role modules one-for-one, and each type binds the
+methods of its counterpart:
 
-- **The architecture is right.** `moq-net` is generic over
-  `web_transport_trait::Session` and spawns via `web_async::spawn` (not
-  `tokio::spawn`), so it is not tied to native QUIC.
-- **The WebTransport adapter is complete** (`src/transport.rs`): a newtype
-  bridge from `web-transport-wasm` (browser WebTransport) to the
-  `web-transport-trait` abstraction `moq-net` consumes. The orphan rule forces
-  the newtypes; the shapes line up almost 1:1.
-- **It compiles to `wasm32-unknown-unknown` and produces `@moq/wasm`**: `just
-  wasm` emits a typed, importable package (`Session` / `Broadcast` / `Track` /
-  `Group`, used as `Moq.Session` etc. via `import * as Moq`, `Promise`-returning
-  methods, `.d.ts`).
-- Scope is the consume path (connect -> broadcast -> track -> group -> frame),
-  the `@moq/watch` use case. The publish path follows the same shape.
+| module | JS classes | mirrors |
+|---|---|---|
+| `session` | `Session` | `moq_net::Session` + `origin::{Producer, Consumer}` |
+| `broadcast` | `BroadcastProducer`, `BroadcastConsumer` | `moq_net::broadcast` |
+| `track` | `TrackProducer`, `TrackConsumer`, `TrackSubscriber`, `TrackRequest` | `moq_net::track` |
+| `group` | `GroupProducer`, `GroupConsumer` | `moq_net::group` |
+| `announce` | `AnnounceConsumer`, `Announce` | `moq_net::announce` |
+| `options` | `Subscription`, `TrackInfo`, `Frame` | the plain-data types |
+
+That mirroring is the point: the binding is the surface most likely to drift
+from the crate it wraps, so the two are meant to be read side by side. When
+`moq-net` grows an API a browser caller needs, add it to the matching module
+here rather than starting a new flat entry point. See the note in `rs/CLAUDE.md`
+about `moq-wasm` being a binding that nothing but a compile gate covers.
+
+Types carry the role as a prefix (`TrackProducer`, not `track::Producer`),
+against the usual convention of letting the module supply it. wasm-bindgen
+resolves a type in a signature by its Rust ident alone, ignoring both the module
+path and `js_name`, so two modules each exporting a `Consumer` silently generate
+typings where one stands in for the other. The modules stay private and
+re-export flat, so nothing reads `broadcast::BroadcastProducer`.
+
+### Conventions at the boundary
+
+- Durations are milliseconds and timestamps are microseconds, matching `@moq/net`.
+- Sequence numbers stay `u64`, which wasm-bindgen maps to a JS `bigint`.
+- Closing takes an application close code (`moq_net::Error::App`); a JS `Error`
+  has nothing to map onto the wire.
+- `closed()` rejects rather than resolving: every close carries a reason.
+- Async methods take `&self` and must produce `'static` futures, so a handle
+  with an in-flight call moves its value out for the duration (`util::Exclusive`).
+  A re-entrant call errors instead of aliasing: one at a time per handle.
+
+### Not covered
+
+Relay-side concerns are deliberately absent: routes, hops, cost, origin scoping,
+and cluster identity have no browser caller. So are the `poll_*` variants, since
+JS has no equivalent of a `kio::Waiter`.
+
+Media muxing is still out (see below), and there is no WebSocket fallback: the
+Rust `qmux` crate is tokio-based, so a browser session is WebTransport-only
+where `@moq/net` can fall back.
 
 ### Three moq-net changes this requires
 

--- a/rs/moq-wasm/src/announce.rs
+++ b/rs/moq-wasm/src/announce.rs
@@ -1,0 +1,70 @@
+//! Broadcast announcements, mirroring `moq_net::announce`.
+
+use wasm_bindgen::prelude::*;
+
+use crate::broadcast::BroadcastConsumer;
+use crate::util::Exclusive;
+
+/// A path, and the broadcast now available there.
+#[wasm_bindgen]
+pub struct Announce {
+	path: String,
+	broadcast: Option<BroadcastConsumer>,
+}
+
+#[wasm_bindgen]
+impl Announce {
+	/// The broadcast's path, relative to the prefix that was announced.
+	#[wasm_bindgen(getter)]
+	pub fn path(&self) -> String {
+		self.path.clone()
+	}
+
+	/// The broadcast now available at that path, or `null` if it went away.
+	///
+	/// A replacement arrives as a `null` followed by a new handle, never as a swap in
+	/// place, so a consumer can tear down the old one before wiring up the new.
+	#[wasm_bindgen(getter)]
+	pub fn broadcast(&self) -> Option<BroadcastConsumer> {
+		self.broadcast.as_ref().map(BroadcastConsumer::cloned)
+	}
+}
+
+impl From<moq_net::announce::Update> for Announce {
+	fn from(value: moq_net::announce::Update) -> Self {
+		Self {
+			path: value.path.to_string(),
+			broadcast: value.broadcast.map(BroadcastConsumer::new),
+		}
+	}
+}
+
+/// A stream of broadcast announcements under a path prefix.
+#[wasm_bindgen]
+pub struct AnnounceConsumer {
+	inner: Exclusive<moq_net::announce::Consumer>,
+}
+
+impl AnnounceConsumer {
+	pub fn new(inner: moq_net::announce::Consumer) -> Self {
+		Self {
+			inner: Exclusive::new(inner),
+		}
+	}
+}
+
+#[wasm_bindgen]
+impl AnnounceConsumer {
+	/// Wait for the next announcement, or `null` once the stream ends.
+	pub async fn next(&self) -> Result<Option<Announce>, JsValue> {
+		let result = self
+			.inner
+			.with("next", async |mut announced| {
+				let result = announced.next().await;
+				(announced, result)
+			})
+			.await?;
+
+		Ok(result.map(Announce::from))
+	}
+}

--- a/rs/moq-wasm/src/broadcast.rs
+++ b/rs/moq-wasm/src/broadcast.rs
@@ -1,0 +1,158 @@
+//! Broadcast producer and consumer, mirroring `moq_net::broadcast`.
+
+use std::cell::RefCell;
+
+use wasm_bindgen::prelude::*;
+
+use crate::options::{Subscription, TrackInfo};
+use crate::track::{TrackConsumer, TrackProducer, TrackRequest, TrackSubscriber};
+use crate::util::{Exclusive, js_err};
+
+/// Publishes tracks under a single broadcast.
+#[wasm_bindgen]
+pub struct BroadcastProducer {
+	inner: Exclusive<moq_net::broadcast::Producer>,
+
+	// Created on the first `requestedTrack` call, not up front: minting a `Dynamic`
+	// registers an on-demand handler, which is what makes a request for an unknown
+	// track queue instead of failing. A caller that never serves on demand should not
+	// silently get that behavior.
+	dynamic: RefCell<Option<Exclusive<moq_net::broadcast::Dynamic>>>,
+}
+
+impl BroadcastProducer {
+	pub fn new(inner: moq_net::broadcast::Producer) -> Self {
+		Self {
+			inner: Exclusive::new(inner),
+			dynamic: RefCell::new(None),
+		}
+	}
+
+	fn dynamic(&self) -> Result<Exclusive<moq_net::broadcast::Dynamic>, JsValue> {
+		let mut slot = self.dynamic.borrow_mut();
+		if let Some(dynamic) = slot.as_ref() {
+			return Ok(dynamic.clone());
+		}
+
+		let dynamic = Exclusive::new(self.inner.peek("requestedTrack", |b| b.dynamic())?);
+		*slot = Some(dynamic.clone());
+		Ok(dynamic)
+	}
+}
+
+#[wasm_bindgen]
+impl BroadcastProducer {
+	/// A broadcast nobody is publishing yet, ready to have tracks added.
+	#[wasm_bindgen(constructor)]
+	pub fn new_js() -> Self {
+		Self::new(moq_net::broadcast::Info::new().produce())
+	}
+
+	/// Create a track, optionally declaring its properties.
+	#[wasm_bindgen(js_name = createTrack)]
+	pub fn create_track(&self, name: String, info: Option<TrackInfo>) -> Result<TrackProducer, JsValue> {
+		let info = info.map(TryInto::try_into).transpose()?;
+		let inner = self
+			.inner
+			.peek("createTrack", |b| b.create_track(name, info))?
+			.map_err(js_err)?;
+		Ok(TrackProducer::new(inner))
+	}
+
+	/// Reserve a track by name, deciding its properties later.
+	///
+	/// Consumers can discover the name immediately; call `accept` on the returned
+	/// request once the properties are known (e.g. after inspecting the media).
+	#[wasm_bindgen(js_name = reserveTrack)]
+	pub fn reserve_track(&self, name: String) -> Result<TrackRequest, JsValue> {
+		let inner = self
+			.inner
+			.peek("reserveTrack", |b| b.reserve_track(name))?
+			.map_err(js_err)?;
+		Ok(TrackRequest::new(inner))
+	}
+
+	/// Remove a track by name.
+	#[wasm_bindgen(js_name = removeTrack)]
+	pub fn remove_track(&self, name: String) -> Result<(), JsValue> {
+		self.inner
+			.peek("removeTrack", |b| b.remove_track(&name))?
+			.map_err(js_err)
+	}
+
+	/// Wait for the next track a consumer asked for but nobody serves yet.
+	///
+	/// Answer it with `accept` or `reject`. Rejects once the broadcast closes.
+	#[wasm_bindgen(js_name = requestedTrack)]
+	pub async fn requested_track(&self) -> Result<TrackRequest, JsValue> {
+		let dynamic = self.dynamic()?;
+		let result = dynamic
+			.with("requestedTrack", async |mut d| {
+				let result = d.requested_track().await;
+				(d, result)
+			})
+			.await?;
+
+		Ok(TrackRequest::new(result.map_err(js_err)?))
+	}
+
+	/// Read this broadcast's tracks directly, without going over the wire.
+	pub fn consume(&self) -> Result<BroadcastConsumer, JsValue> {
+		let inner = self.inner.peek("consume", |b| b.consume())?;
+		Ok(BroadcastConsumer::new(inner))
+	}
+
+	/// Finish the broadcast cleanly, marking it complete.
+	pub fn close(&self) -> Result<(), JsValue> {
+		self.inner.peek("close", |b| b.finish())
+	}
+
+	/// Abort the broadcast with an application close code.
+	pub fn abort(&self, code: u16) -> Result<(), JsValue> {
+		let broadcast = self.inner.take("abort")?;
+		broadcast.abort(moq_net::Error::App(code)).map_err(js_err)
+	}
+}
+
+/// A handle to a broadcast, used to reach its tracks.
+#[wasm_bindgen]
+pub struct BroadcastConsumer {
+	inner: moq_net::broadcast::Consumer,
+}
+
+impl BroadcastConsumer {
+	pub fn new(inner: moq_net::broadcast::Consumer) -> Self {
+		Self { inner }
+	}
+}
+
+#[wasm_bindgen]
+impl BroadcastConsumer {
+	/// A handle to a track by name, without subscribing yet.
+	pub fn track(&self, name: String) -> Result<TrackConsumer, JsValue> {
+		let inner = self.inner.track(&name).map_err(js_err)?;
+		Ok(TrackConsumer::new(inner))
+	}
+
+	/// Subscribe to a track by name, resolving once the publisher accepts.
+	pub async fn subscribe(
+		&self,
+		name: String,
+		subscription: Option<Subscription>,
+	) -> Result<TrackSubscriber, JsValue> {
+		self.track(name)?.subscribe(subscription).await
+	}
+
+	/// Another handle to the same broadcast.
+	#[wasm_bindgen(js_name = clone)]
+	pub fn cloned(&self) -> BroadcastConsumer {
+		BroadcastConsumer::new(self.inner.clone())
+	}
+
+	/// Reject once the broadcast closes, with the reason it closed.
+	///
+	/// Every close carries a reason, including a clean one, so this never resolves.
+	pub async fn closed(&self) -> Result<(), JsValue> {
+		Err(js_err(self.inner.closed().await))
+	}
+}

--- a/rs/moq-wasm/src/group.rs
+++ b/rs/moq-wasm/src/group.rs
@@ -62,21 +62,15 @@ impl GroupProducer {
 		let group = self.inner.take("abort")?;
 		group.abort(moq_net::Error::App(code)).map_err(js_err)
 	}
-
-	/// Reject once the group closes, with the reason it closed.
-	///
-	/// Every close carries a reason, including a clean one, so this never resolves.
-	pub async fn closed(&self) -> Result<(), JsValue> {
-		let err = self
-			.inner
-			.with("closed", async |g| {
-				let e = g.closed().await;
-				(g, e)
-			})
-			.await?;
-		Err(js_err(err))
-	}
 }
+
+// No `closed()` on a group producer, unlike `TrackProducer`. Awaiting it would have to
+// hold the producer for the wait, and every `writeFrame` in the meantime would fail; the
+// two things a caller most wants to do at once are exactly write and watch for a drop.
+// `moq_net::group::Producer` is not `Clone`, so there is no second handle to wait on, and
+// keeping a `group::Consumer` around instead would leave the group permanently "used" and
+// distort the demand signal the track evicts against. Watch `TrackProducer.closed()`
+// instead: a group dies with its track, and the caller owns the group's own lifetime.
 
 /// Reads frames from a single group.
 #[wasm_bindgen]

--- a/rs/moq-wasm/src/group.rs
+++ b/rs/moq-wasm/src/group.rs
@@ -1,0 +1,153 @@
+//! Group producer and consumer, mirroring `moq_net::group`.
+
+use js_sys::Uint8Array;
+use wasm_bindgen::prelude::*;
+
+use crate::options::{self, Frame};
+use crate::util::{Exclusive, js_err};
+
+/// Writes frames into a single group.
+#[wasm_bindgen]
+pub struct GroupProducer {
+	sequence: u64,
+	inner: Exclusive<moq_net::group::Producer>,
+}
+
+impl GroupProducer {
+	pub fn new(inner: moq_net::group::Producer) -> Self {
+		Self {
+			sequence: inner.sequence,
+			inner: Exclusive::new(inner),
+		}
+	}
+}
+
+#[wasm_bindgen]
+impl GroupProducer {
+	/// This group's sequence number within its track.
+	#[wasm_bindgen(getter)]
+	pub fn sequence(&self) -> u64 {
+		self.sequence
+	}
+
+	/// Append a frame, timestamped in microseconds.
+	#[wasm_bindgen(js_name = writeFrame)]
+	pub fn write_frame(&self, timestamp: f64, payload: Uint8Array) -> Result<(), JsValue> {
+		let timestamp = options::timestamp(timestamp)?;
+		let payload = payload.to_vec();
+		self.inner
+			.peek("writeFrame", |group| group.write_frame(timestamp, payload))?
+			.map_err(js_err)
+	}
+
+	/// How many frames have been written so far.
+	#[wasm_bindgen(js_name = frameCount)]
+	pub fn frame_count(&self) -> Result<usize, JsValue> {
+		self.inner.peek("frameCount", |group| group.frame_count())
+	}
+
+	/// Read the frames written to this group.
+	pub fn consume(&self) -> Result<GroupConsumer, JsValue> {
+		let inner = self.inner.peek("consume", |group| group.consume())?;
+		Ok(GroupConsumer::new(inner))
+	}
+
+	/// Finish the group cleanly, marking it complete.
+	pub fn close(&self) -> Result<(), JsValue> {
+		self.inner.peek("close", |group| group.finish())?.map_err(js_err)
+	}
+
+	/// Abort the group with an application close code, discarding it.
+	pub fn abort(&self, code: u16) -> Result<(), JsValue> {
+		let group = self.inner.take("abort")?;
+		group.abort(moq_net::Error::App(code)).map_err(js_err)
+	}
+
+	/// Reject once the group closes, with the reason it closed.
+	///
+	/// Every close carries a reason, including a clean one, so this never resolves.
+	pub async fn closed(&self) -> Result<(), JsValue> {
+		let err = self
+			.inner
+			.with("closed", async |g| {
+				let e = g.closed().await;
+				(g, e)
+			})
+			.await?;
+		Err(js_err(err))
+	}
+}
+
+/// Reads frames from a single group.
+#[wasm_bindgen]
+pub struct GroupConsumer {
+	sequence: u64,
+	inner: Exclusive<moq_net::group::Consumer>,
+}
+
+impl GroupConsumer {
+	pub fn new(inner: moq_net::group::Consumer) -> Self {
+		Self {
+			sequence: inner.sequence,
+			inner: Exclusive::new(inner),
+		}
+	}
+}
+
+#[wasm_bindgen]
+impl GroupConsumer {
+	/// This group's sequence number within its track.
+	#[wasm_bindgen(getter)]
+	pub fn sequence(&self) -> u64 {
+		self.sequence
+	}
+
+	/// Units per second for this group's frame timestamps.
+	#[wasm_bindgen(getter)]
+	pub fn timescale(&self) -> Result<u64, JsValue> {
+		self.inner.peek("timescale", |group| group.timescale().as_u64())
+	}
+
+	/// Read the next frame's payload, or `null` at the end of the group.
+	///
+	/// Use `readFrameTimed` when the presentation timestamp matters.
+	#[wasm_bindgen(js_name = readFrame)]
+	pub async fn read_frame(&self) -> Result<Option<Uint8Array>, JsValue> {
+		let frame = self.read_frame_timed().await?;
+		Ok(frame.map(|frame| frame.payload()))
+	}
+
+	/// Read the next frame with its timestamp, or `null` at the end of the group.
+	#[wasm_bindgen(js_name = readFrameTimed)]
+	pub async fn read_frame_timed(&self) -> Result<Option<Frame>, JsValue> {
+		let result = self
+			.inner
+			.with("readFrame", async |mut group| {
+				let result = group.read_frame().await;
+				(group, result)
+			})
+			.await?;
+
+		Ok(result.map_err(js_err)?.map(Frame::from))
+	}
+
+	/// Resolve with the number of frames in the group once it is complete.
+	pub async fn finished(&self) -> Result<u64, JsValue> {
+		let result = self
+			.inner
+			.with("finished", async |mut group| {
+				let result = group.finished().await;
+				(group, result)
+			})
+			.await?;
+
+		result.map_err(js_err)
+	}
+
+	/// Another reader over the same group, starting from this one's position.
+	#[wasm_bindgen(js_name = clone)]
+	pub fn cloned(&self) -> Result<GroupConsumer, JsValue> {
+		let inner = self.inner.peek("clone", |group| group.clone())?;
+		Ok(GroupConsumer::new(inner))
+	}
+}

--- a/rs/moq-wasm/src/group.rs
+++ b/rs/moq-wasm/src/group.rs
@@ -67,10 +67,12 @@ impl GroupProducer {
 // No `closed()` on a group producer, unlike `TrackProducer`. Awaiting it would have to
 // hold the producer for the wait, and every `writeFrame` in the meantime would fail; the
 // two things a caller most wants to do at once are exactly write and watch for a drop.
-// `moq_net::group::Producer` is not `Clone`, so there is no second handle to wait on, and
-// keeping a `group::Consumer` around instead would leave the group permanently "used" and
-// distort the demand signal the track evicts against. Watch `TrackProducer.closed()`
-// instead: a group dies with its track, and the caller owns the group's own lifetime.
+//
+// `TrackProducer` avoids that with `track::Demand`, a weak observer. Groups have no
+// equivalent: `group::Producer` is `Clone`, but every clone shares the `Alive` guard, so a
+// clone parked in a pending `closed()` would keep the group and its cached frames alive
+// and defeat close-on-last-drop. Rather than ship that, leave the method out until
+// `moq-net` grows a weak group observer.
 
 /// Reads frames from a single group.
 #[wasm_bindgen]

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -1,34 +1,61 @@
 //! Browser/WASM bindings for `moq-net`, exposed to JavaScript via wasm-bindgen.
 //!
-//! This is an experiment: rather than reimplementing the moq-lite wire protocol
-//! in TypeScript (as `@moq/net` does today), compile the real `moq-net` Rust
-//! implementation to WebAssembly and drive the browser's WebTransport from
-//! inside it. See `transport.rs` for the WebTransport adapter.
+//! Rather than reimplementing the wire protocols in TypeScript (as `@moq/net` does),
+//! compile the real `moq-net` implementation to WebAssembly and drive the browser's
+//! WebTransport from inside it. See `transport.rs` for the WebTransport adapter.
 //!
-//! Scope: the consume path (connect -> broadcast -> track -> group -> frame),
-//! which is the highest-value target (the `@moq/watch` use case). The publish
-//! path follows the same shape and is left as the obvious next step.
+//! # Layout
 //!
-//! moq-net's timers and `Instant` go through `web_async::time` (tokio on native,
-//! wasmtimer on wasm), so the consume path runs in the browser. (`model/time.rs`
-//! has an unused wall-clock helper that isn't wasm-portable, but nothing calls
-//! it, so it never runs. See README.md.)
+//! The modules mirror `moq-net`'s role modules one-for-one (`broadcast`, `track`,
+//! `group`, `announce`, `session`), and each type binds the methods of its counterpart.
+//! That is deliberate: the binding is the surface most likely to drift, so keeping it
+//! shaped like the crate it wraps makes a gap visible when reading the two side by side.
+//! When `moq-net` grows a method a browser caller needs, add it to the matching module
+//! here rather than starting a new flat entry point.
+//!
+//! Unlike `moq-net`, the types carry the role as a prefix (`TrackProducer`, not
+//! `track::Producer`), against the usual convention of letting the module supply it.
+//! wasm-bindgen resolves a type in a signature by its Rust ident alone and ignores both
+//! the module path and `js_name`, so two modules each exporting a `Consumer` silently
+//! generate typings where one stands in for the other. Unique idents are what keep the
+//! generated `.d.ts` honest. The modules stay private and re-export flat, so nothing
+//! reads `broadcast::BroadcastProducer`; a TS wrapper is free to re-namespace them back
+//! into `Broadcast.Producer`.
+//!
+//! # Conventions at the boundary
+//!
+//! - Durations are milliseconds and timestamps are microseconds, matching `@moq/net`.
+//! - Sequence numbers stay `u64`, which wasm-bindgen maps to a JS `bigint`.
+//! - Closing takes an application close code (`moq_net::Error::App`), since a JS error
+//!   has nothing to map onto the wire.
+//! - `closed()` rejects rather than resolving: every close carries a reason.
+//!
+//! # Threading
+//!
+//! Everything runs on whichever thread instantiated the module, usually the main one. A
+//! caller that drains a high-bitrate track should do it in a Worker so decode and render
+//! are not sharing that thread.
 
 // Browser-only crate. Empty on native so `cargo check --workspace` stays green.
 #![cfg(target_arch = "wasm32")]
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
-use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
+mod announce;
+mod broadcast;
+mod group;
+mod options;
+mod session;
+mod track;
 mod transport;
+mod util;
 
-/// Map any displayable error into a JS exception.
-fn js_err(e: impl std::fmt::Display) -> JsValue {
-	JsError::new(&e.to_string()).into()
-}
+pub use announce::{Announce, AnnounceConsumer};
+pub use broadcast::{BroadcastConsumer, BroadcastProducer};
+pub use group::{GroupConsumer, GroupProducer};
+pub use options::{Frame, Subscription, TrackInfo};
+pub use session::Session;
+pub use track::{TrackConsumer, TrackProducer, TrackRequest, TrackSubscriber};
 
 /// Install panic + tracing hooks for readable errors. Call once after the wasm
 /// module's default `init()` loader resolves. (Named `setup` to avoid colliding
@@ -37,145 +64,4 @@ fn js_err(e: impl std::fmt::Display) -> JsValue {
 pub fn setup() {
 	console_error_panic_hook::set_once();
 	let _ = tracing_wasm::try_set_as_global_default();
-}
-
-/// A connected MoQ session.
-#[wasm_bindgen]
-pub struct Session {
-	inner: moq_net::Session,
-	// The origin remote broadcasts are announced into; read via `consume`.
-	consumer: moq_net::origin::Consumer,
-}
-
-#[wasm_bindgen]
-impl Session {
-	/// Connect to a relay over the browser's WebTransport, using the system roots.
-	pub async fn connect(url: String) -> Result<Session, JsValue> {
-		let url = url::Url::parse(&url).map_err(js_err)?;
-		let transport = transport::connect(url).await.map_err(js_err)?;
-		Self::handshake(transport).await
-	}
-
-	/// Connect trusting only the given sha-256 certificate hashes (serverless dev).
-	#[wasm_bindgen(js_name = connectWithHashes)]
-	pub async fn connect_with_hashes(url: String, hashes: Vec<Uint8Array>) -> Result<Session, JsValue> {
-		let url = url::Url::parse(&url).map_err(js_err)?;
-		let hashes = hashes.iter().map(|h| h.to_vec()).collect();
-		let transport = transport::connect_with_hashes(url, hashes).await.map_err(js_err)?;
-		Self::handshake(transport).await
-	}
-
-	async fn handshake(transport: transport::Session) -> Result<Session, JsValue> {
-		// Wire a subscribe origin so the session has somewhere to insert the
-		// broadcasts the remote announces; keep a consumer to read them.
-		let origin = moq_net::Origin::random().produce();
-		let consumer = origin.consume();
-		let client = moq_net::Client::new().with_subscriber(origin);
-		let (inner, driver) = client.connect(transport).await.map_err(js_err)?;
-		// The session only makes progress while its driver runs. The driver holds no
-		// session clone, so dropping this `Session` still closes the transport, which
-		// in turn ends the spawned task.
-		web_async::spawn(async move {
-			let _ = driver.await;
-		});
-		Ok(Session { inner, consumer })
-	}
-
-	/// The negotiated protocol version (e.g. "lite-05" or an IETF draft).
-	pub fn version(&self) -> String {
-		self.inner.version().to_string()
-	}
-
-	/// Reject when the session closes, with the reason it closed.
-	///
-	/// Every close carries a reason, including a clean one, so this never resolves.
-	pub async fn closed(&self) -> Result<(), JsValue> {
-		Err(js_err(self.inner.closed().await))
-	}
-
-	/// Subscribe to a broadcast by path, waiting until it is announced.
-	pub async fn consume(&self, path: String) -> Result<Option<Broadcast>, JsValue> {
-		let broadcast = self.consumer.announced_broadcast(path.as_str()).await;
-		Ok(broadcast.map(|inner| Broadcast { inner }))
-	}
-}
-
-/// A consumer handle for a single broadcast.
-#[wasm_bindgen]
-pub struct Broadcast {
-	inner: moq_net::broadcast::Consumer,
-}
-
-#[wasm_bindgen]
-impl Broadcast {
-	/// Subscribe to a track by name, resolving once the publisher accepts.
-	pub async fn subscribe(&self, name: String) -> Result<Track, JsValue> {
-		let track = self.inner.track(&name).map_err(js_err)?;
-		let subscriber = track.subscribe(None).await.map_err(js_err)?;
-		Ok(Track {
-			inner: Rc::new(RefCell::new(Some(subscriber))),
-		})
-	}
-}
-
-/// A subscriber to a single track, yielding groups.
-#[wasm_bindgen]
-pub struct Track {
-	// Rc<RefCell<Option<..>>> for interior mutability: wasm-bindgen async methods
-	// take `&self` and must produce 'static futures, so we move the value out of
-	// the cell for the duration of the await rather than holding a borrow across
-	// it (which would make the future self-referential). One in-flight call at a
-	// time; a re-entrant call while one is pending errors instead of aliasing.
-	inner: Rc<RefCell<Option<moq_net::track::Subscriber>>>,
-}
-
-#[wasm_bindgen]
-impl Track {
-	/// Receive the next group in arrival order, or `null` when the track ends.
-	#[wasm_bindgen(js_name = recvGroup)]
-	pub async fn recv_group(&self) -> Result<Option<Group>, JsValue> {
-		let cell = self.inner.clone();
-		let mut sub = cell
-			.borrow_mut()
-			.take()
-			.ok_or_else(|| js_err("recvGroup already in progress"))?;
-		let result = sub.recv_group().await;
-		*cell.borrow_mut() = Some(sub);
-
-		let group = result.map_err(js_err)?;
-		Ok(group.map(|g| Group {
-			sequence: g.sequence,
-			inner: Rc::new(RefCell::new(Some(g))),
-		}))
-	}
-}
-
-/// A consumer for a single group, yielding frames.
-#[wasm_bindgen]
-pub struct Group {
-	sequence: u64,
-	inner: Rc<RefCell<Option<moq_net::group::Consumer>>>,
-}
-
-#[wasm_bindgen]
-impl Group {
-	#[wasm_bindgen(getter)]
-	pub fn sequence(&self) -> u64 {
-		self.sequence
-	}
-
-	/// Read the next frame in the group, or `null` at the end of the group.
-	#[wasm_bindgen(js_name = readFrame)]
-	pub async fn read_frame(&self) -> Result<Option<Uint8Array>, JsValue> {
-		let cell = self.inner.clone();
-		let mut group = cell
-			.borrow_mut()
-			.take()
-			.ok_or_else(|| js_err("readFrame already in progress"))?;
-		let result = group.read_frame().await;
-		*cell.borrow_mut() = Some(group);
-
-		let frame = result.map_err(js_err)?;
-		Ok(frame.map(|frame| Uint8Array::from(frame.payload.as_ref())))
-	}
 }

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -53,7 +53,7 @@ mod util;
 pub use announce::{Announce, AnnounceConsumer};
 pub use broadcast::{BroadcastConsumer, BroadcastProducer};
 pub use group::{GroupConsumer, GroupProducer};
-pub use options::{Frame, Subscription, TrackInfo};
+pub use options::{Fetch, Frame, Subscription, TrackInfo};
 pub use session::Session;
 pub use track::{TrackConsumer, TrackProducer, TrackRequest, TrackSubscriber};
 

--- a/rs/moq-wasm/src/options.rs
+++ b/rs/moq-wasm/src/options.rs
@@ -16,15 +16,27 @@ use wasm_bindgen::prelude::*;
 
 use crate::util::js_err;
 
-/// Convert a JS millisecond duration into a `Duration`, saturating rather than panicking.
+/// The longest duration that still fits the wire, since these all get encoded as a
+/// millisecond QUIC varint. About 146 million years, so it reads as "no limit" to any
+/// caller while staying encodable.
 ///
-/// `Duration::from_secs_f64` panics on a non-finite or out-of-range value, and `Infinity` is
-/// how a JS caller naturally spells "no limit". A panic here would abort the whole wasm
-/// module over one bad option, so clamp instead: at or below zero is `ZERO`, anything past
-/// `Duration`'s range (including `Infinity`) is `MAX`. NaN lands on `ZERO` via the `max`.
+/// `Duration::MAX` would not: its `as_millis()` is ~1.8e22, four orders of magnitude past
+/// `VarInt::MAX`, so encoding a track's properties would fail well after the bad value was
+/// accepted.
+const MAX_ENCODABLE: Duration = Duration::from_millis(moq_net::VarInt::MAX.into_inner());
+
+/// Convert a JS millisecond duration into a `Duration`, clamping rather than panicking.
+///
+/// `Duration::from_secs_f64` panics on a non-finite or out-of-range value, and `Infinity`
+/// is how a JS caller naturally spells "no limit"; a panic would surface as an opaque wasm
+/// trap instead of the error this API declares. So clamp: at or below zero (and NaN, via
+/// the `max`) is `ZERO`, anything above is [`MAX_ENCODABLE`].
 fn duration_from_millis(millis: f64) -> Duration {
-	let secs = millis.max(0.0) / 1000.0;
-	Duration::try_from_secs_f64(secs).unwrap_or(Duration::MAX)
+	let millis = millis.max(0.0);
+	match Duration::try_from_secs_f64(millis / 1000.0) {
+		Ok(d) if d <= MAX_ENCODABLE => d,
+		_ => MAX_ENCODABLE,
+	}
 }
 
 /// Per-subscription options, requested when a subscription opens and adjustable later

--- a/rs/moq-wasm/src/options.rs
+++ b/rs/moq-wasm/src/options.rs
@@ -16,6 +16,17 @@ use wasm_bindgen::prelude::*;
 
 use crate::util::js_err;
 
+/// Convert a JS millisecond duration into a `Duration`, saturating rather than panicking.
+///
+/// `Duration::from_secs_f64` panics on a non-finite or out-of-range value, and `Infinity` is
+/// how a JS caller naturally spells "no limit". A panic here would abort the whole wasm
+/// module over one bad option, so clamp instead: at or below zero is `ZERO`, anything past
+/// `Duration`'s range (including `Infinity`) is `MAX`. NaN lands on `ZERO` via the `max`.
+fn duration_from_millis(millis: f64) -> Duration {
+	let secs = millis.max(0.0) / 1000.0;
+	Duration::try_from_secs_f64(secs).unwrap_or(Duration::MAX)
+}
+
 /// Per-subscription options, requested when a subscription opens and adjustable later
 /// via `TrackSubscriber.update`.
 #[wasm_bindgen]
@@ -53,7 +64,7 @@ impl From<Subscription> for moq_net::track::Subscription {
 		let mut out = Self::default();
 		out.priority = value.priority;
 		out.ordered = value.ordered;
-		out.latency_max = Duration::from_secs_f64(value.latency_max.max(0.0) / 1000.0);
+		out.latency_max = duration_from_millis(value.latency_max);
 		out.group_start = value.start_group;
 		out.group_end = value.end_group;
 		out
@@ -69,6 +80,32 @@ impl From<moq_net::track::Subscription> for Subscription {
 			start_group: value.group_start,
 			end_group: value.group_end,
 		}
+	}
+}
+
+/// Options for fetching a single past group.
+#[wasm_bindgen]
+#[derive(Clone, Default)]
+pub struct Fetch {
+	/// Delivery priority for the fetched group's stream. Higher wins.
+	pub priority: u8,
+}
+
+#[wasm_bindgen]
+impl Fetch {
+	/// Fetch options at their defaults: priority 0.
+	#[wasm_bindgen(constructor)]
+	pub fn new() -> Self {
+		Self::default()
+	}
+}
+
+impl From<Fetch> for moq_net::group::Fetch {
+	fn from(value: Fetch) -> Self {
+		// See the note in `Subscription`: `#[non_exhaustive]`, so fill in field by field.
+		let mut out = Self::default();
+		out.priority = value.priority;
+		out
 	}
 }
 
@@ -109,7 +146,7 @@ impl TryFrom<TrackInfo> for moq_net::track::Info {
 		// See the note in `Subscription`: `#[non_exhaustive]`, so fill in field by field.
 		let mut out = Self::default();
 		out.timescale = Timescale::new(value.timescale).map_err(js_err)?;
-		out.latency_max = Duration::from_secs_f64(value.latency_max.max(0.0) / 1000.0);
+		out.latency_max = duration_from_millis(value.latency_max);
 		out.priority = value.priority;
 		out.ordered = value.ordered;
 		Ok(out)

--- a/rs/moq-wasm/src/options.rs
+++ b/rs/moq-wasm/src/options.rs
@@ -1,17 +1,29 @@
 //! Option bags and value types crossing the JS boundary.
 //!
 //! These mirror the plain-data types in `moq-net` (`track::Subscription`, `track::Info`,
-//! `frame::Frame`). They are classes rather than positional arguments so a new knob is an
+//! `frame::Frame`). They are bags rather than positional parameters so a new knob is an
 //! added field instead of a changed signature.
 //!
+//! The three input bags cross as **plain JS objects** (serde), not exported classes.
+//! wasm-bindgen passes an exported class by value, which zeroes the JS object's pointer,
+//! and it encodes a null pointer as `None`. So a caller who built one bag and reused it
+//! across two calls silently got defaults on the second: measured, a `TrackInfo` reused
+//! across two `createTrack` calls gave the second track a millisecond timescale instead of
+//! the microsecond one it asked for, with no error anywhere. A plain object has no
+//! ownership to lose, and it matches how `@moq/net` already takes options.
+//!
+//! `Frame` stays a class: it is only ever returned, so it can't hit that, and its payload
+//! rides as a `Uint8Array` rather than a serialized number array.
+//!
 //! Units are the ones `@moq/net` uses, since that is what a JS caller expects: durations
-//! in milliseconds, timestamps in microseconds. Sequences stay `u64`, which wasm-bindgen
-//! maps to a JS `bigint`.
+//! in milliseconds, timestamps in microseconds. Sequence numbers stay `u64`.
 
 use std::time::Duration;
 
 use js_sys::Uint8Array;
 use moq_net::{Timescale, Timestamp};
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use crate::util::js_err;
@@ -41,31 +53,27 @@ fn duration_from_millis(millis: f64) -> Duration {
 
 /// Per-subscription options, requested when a subscription opens and adjustable later
 /// via `TrackSubscriber.update`.
-#[wasm_bindgen]
-#[derive(Clone, Default)]
+///
+/// Field types and ranges are enforced on the way in (a string priority, or one past
+/// `u8`, is an error), but a misspelled field is not: this deserializer never sees the
+/// keys it wasn't asked for, so `deny_unknown_fields` would be a no-op. The generated
+/// TypeScript interface is what catches a typo, the same as `@moq/net`.
+#[derive(Tsify, Serialize, Deserialize, Clone, Default)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase", default)]
 pub struct Subscription {
 	/// Delivery priority relative to this session's other subscriptions. Higher wins.
 	pub priority: u8,
 	/// Whether groups are prioritized in sequence order, rather than newest-first.
 	pub ordered: bool,
 	/// Maximum age in milliseconds of a non-latest group before it is skipped.
-	#[wasm_bindgen(js_name = latencyMax)]
 	pub latency_max: f64,
 	/// First group the publisher should deliver, or unset to start at the latest group.
-	#[wasm_bindgen(js_name = startGroup)]
+	#[tsify(optional)]
 	pub start_group: Option<u64>,
 	/// Last group the publisher should deliver (inclusive), or unset for no end.
-	#[wasm_bindgen(js_name = endGroup)]
+	#[tsify(optional)]
 	pub end_group: Option<u64>,
-}
-
-#[wasm_bindgen]
-impl Subscription {
-	/// A subscription with every field at its default: live edge, unordered, priority 0.
-	#[wasm_bindgen(constructor)]
-	pub fn new() -> Self {
-		Self::default()
-	}
 }
 
 impl From<Subscription> for moq_net::track::Subscription {
@@ -96,20 +104,12 @@ impl From<moq_net::track::Subscription> for Subscription {
 }
 
 /// Options for fetching a single past group.
-#[wasm_bindgen]
-#[derive(Clone, Default)]
+#[derive(Tsify, Serialize, Deserialize, Clone, Default)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase", default)]
 pub struct Fetch {
 	/// Delivery priority for the fetched group's stream. Higher wins.
 	pub priority: u8,
-}
-
-#[wasm_bindgen]
-impl Fetch {
-	/// Fetch options at their defaults: priority 0.
-	#[wasm_bindgen(constructor)]
-	pub fn new() -> Self {
-		Self::default()
-	}
 }
 
 impl From<Fetch> for moq_net::group::Fetch {
@@ -122,13 +122,13 @@ impl From<Fetch> for moq_net::group::Fetch {
 }
 
 /// Immutable per-track properties, set by the publisher and reported over the wire.
-#[wasm_bindgen]
-#[derive(Clone)]
+#[derive(Tsify, Serialize, Deserialize, Clone)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase", default)]
 pub struct TrackInfo {
 	/// Units per second for this track's frame timestamps. Defaults to 1000 (milliseconds).
 	pub timescale: u64,
 	/// Maximum age in milliseconds of a non-latest group before the publisher evicts it.
-	#[wasm_bindgen(js_name = latencyMax)]
 	pub latency_max: f64,
 	/// Tie-break priority between subscriptions of equal subscriber priority.
 	pub priority: u8,
@@ -136,18 +136,11 @@ pub struct TrackInfo {
 	pub ordered: bool,
 }
 
-#[wasm_bindgen]
-impl TrackInfo {
-	/// Track properties at their defaults: millisecond timescale, unordered, priority 0.
-	#[wasm_bindgen(constructor)]
-	pub fn new() -> Self {
-		moq_net::track::Info::default().into()
-	}
-}
-
 impl Default for TrackInfo {
+	/// Millisecond timescale, unordered, priority 0: `moq-net`'s own defaults, so an
+	/// omitted field means the same thing here as it does on the wire.
 	fn default() -> Self {
-		Self::new()
+		moq_net::track::Info::default().into()
 	}
 }
 

--- a/rs/moq-wasm/src/options.rs
+++ b/rs/moq-wasm/src/options.rs
@@ -1,0 +1,169 @@
+//! Option bags and value types crossing the JS boundary.
+//!
+//! These mirror the plain-data types in `moq-net` (`track::Subscription`, `track::Info`,
+//! `frame::Frame`). They are classes rather than positional arguments so a new knob is an
+//! added field instead of a changed signature.
+//!
+//! Units are the ones `@moq/net` uses, since that is what a JS caller expects: durations
+//! in milliseconds, timestamps in microseconds. Sequences stay `u64`, which wasm-bindgen
+//! maps to a JS `bigint`.
+
+use std::time::Duration;
+
+use js_sys::Uint8Array;
+use moq_net::{Timescale, Timestamp};
+use wasm_bindgen::prelude::*;
+
+use crate::util::js_err;
+
+/// Per-subscription options, requested when a subscription opens and adjustable later
+/// via `TrackSubscriber.update`.
+#[wasm_bindgen]
+#[derive(Clone, Default)]
+pub struct Subscription {
+	/// Delivery priority relative to this session's other subscriptions. Higher wins.
+	pub priority: u8,
+	/// Whether groups are prioritized in sequence order, rather than newest-first.
+	pub ordered: bool,
+	/// Maximum age in milliseconds of a non-latest group before it is skipped.
+	#[wasm_bindgen(js_name = latencyMax)]
+	pub latency_max: f64,
+	/// First group the publisher should deliver, or unset to start at the latest group.
+	#[wasm_bindgen(js_name = startGroup)]
+	pub start_group: Option<u64>,
+	/// Last group the publisher should deliver (inclusive), or unset for no end.
+	#[wasm_bindgen(js_name = endGroup)]
+	pub end_group: Option<u64>,
+}
+
+#[wasm_bindgen]
+impl Subscription {
+	/// A subscription with every field at its default: live edge, unordered, priority 0.
+	#[wasm_bindgen(constructor)]
+	pub fn new() -> Self {
+		Self::default()
+	}
+}
+
+impl From<Subscription> for moq_net::track::Subscription {
+	fn from(value: Subscription) -> Self {
+		// Field-by-field rather than a struct literal: the wire types are
+		// `#[non_exhaustive]`, so a new knob shows up here as a default rather than a
+		// compile error. Mirror it above when a caller should be able to set it.
+		let mut out = Self::default();
+		out.priority = value.priority;
+		out.ordered = value.ordered;
+		out.latency_max = Duration::from_secs_f64(value.latency_max.max(0.0) / 1000.0);
+		out.group_start = value.start_group;
+		out.group_end = value.end_group;
+		out
+	}
+}
+
+impl From<moq_net::track::Subscription> for Subscription {
+	fn from(value: moq_net::track::Subscription) -> Self {
+		Self {
+			priority: value.priority,
+			ordered: value.ordered,
+			latency_max: value.latency_max.as_secs_f64() * 1000.0,
+			start_group: value.group_start,
+			end_group: value.group_end,
+		}
+	}
+}
+
+/// Immutable per-track properties, set by the publisher and reported over the wire.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct TrackInfo {
+	/// Units per second for this track's frame timestamps. Defaults to 1000 (milliseconds).
+	pub timescale: u64,
+	/// Maximum age in milliseconds of a non-latest group before the publisher evicts it.
+	#[wasm_bindgen(js_name = latencyMax)]
+	pub latency_max: f64,
+	/// Tie-break priority between subscriptions of equal subscriber priority.
+	pub priority: u8,
+	/// Whether groups are prioritized in sequence order, rather than newest-first.
+	pub ordered: bool,
+}
+
+#[wasm_bindgen]
+impl TrackInfo {
+	/// Track properties at their defaults: millisecond timescale, unordered, priority 0.
+	#[wasm_bindgen(constructor)]
+	pub fn new() -> Self {
+		moq_net::track::Info::default().into()
+	}
+}
+
+impl Default for TrackInfo {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl TryFrom<TrackInfo> for moq_net::track::Info {
+	type Error = JsValue;
+
+	fn try_from(value: TrackInfo) -> Result<Self, Self::Error> {
+		// See the note in `Subscription`: `#[non_exhaustive]`, so fill in field by field.
+		let mut out = Self::default();
+		out.timescale = Timescale::new(value.timescale).map_err(js_err)?;
+		out.latency_max = Duration::from_secs_f64(value.latency_max.max(0.0) / 1000.0);
+		out.priority = value.priority;
+		out.ordered = value.ordered;
+		Ok(out)
+	}
+}
+
+impl From<moq_net::track::Info> for TrackInfo {
+	fn from(value: moq_net::track::Info) -> Self {
+		Self {
+			timescale: value.timescale.as_u64(),
+			latency_max: value.latency_max.as_secs_f64() * 1000.0,
+			priority: value.priority,
+			ordered: value.ordered,
+		}
+	}
+}
+
+/// A single frame: its presentation timestamp and payload.
+#[wasm_bindgen]
+pub struct Frame {
+	/// Presentation timestamp in microseconds.
+	pub timestamp: f64,
+
+	payload: Uint8Array,
+}
+
+#[wasm_bindgen]
+impl Frame {
+	/// Build a frame from a timestamp in microseconds and its payload.
+	#[wasm_bindgen(constructor)]
+	pub fn new(timestamp: f64, payload: Uint8Array) -> Self {
+		Self { timestamp, payload }
+	}
+
+	/// The frame payload.
+	#[wasm_bindgen(getter)]
+	pub fn payload(&self) -> Uint8Array {
+		self.payload.clone()
+	}
+}
+
+impl From<moq_net::frame::Frame> for Frame {
+	fn from(value: moq_net::frame::Frame) -> Self {
+		Self {
+			timestamp: value.timestamp.as_micros() as f64,
+			payload: Uint8Array::from(value.payload.as_ref()),
+		}
+	}
+}
+
+/// Convert a JS microsecond timestamp into the wire type.
+pub fn timestamp(micros: f64) -> Result<Timestamp, JsValue> {
+	if !micros.is_finite() || micros < 0.0 {
+		return Err(js_err("timestamp must be a non-negative finite number"));
+	}
+	Timestamp::from_micros(micros as u64).map_err(js_err)
+}

--- a/rs/moq-wasm/src/session.rs
+++ b/rs/moq-wasm/src/session.rs
@@ -1,0 +1,134 @@
+//! Session setup and the publish/subscribe entry points, mirroring `moq_net::Session`.
+
+use js_sys::Uint8Array;
+use wasm_bindgen::prelude::*;
+
+use crate::announce::AnnounceConsumer;
+use crate::broadcast::{BroadcastConsumer, BroadcastProducer};
+use crate::transport;
+use crate::util::js_err;
+
+/// A connected MoQ session.
+#[wasm_bindgen]
+pub struct Session {
+	inner: moq_net::Session,
+	url: String,
+
+	// Broadcasts the remote announces land here; read via `consume` / `announced`.
+	subscribe: moq_net::origin::Consumer,
+
+	// Broadcasts we publish to the remote are created here.
+	publish: moq_net::origin::Producer,
+}
+
+#[wasm_bindgen]
+impl Session {
+	/// Connect to a relay over the browser's WebTransport, using the system roots.
+	pub async fn connect(url: String) -> Result<Session, JsValue> {
+		let parsed = url::Url::parse(&url).map_err(js_err)?;
+		let transport = transport::connect(parsed).await.map_err(js_err)?;
+		Self::handshake(transport, url).await
+	}
+
+	/// Connect trusting only the given sha-256 certificate hashes (serverless dev).
+	#[wasm_bindgen(js_name = connectWithHashes)]
+	pub async fn connect_with_hashes(url: String, hashes: Vec<Uint8Array>) -> Result<Session, JsValue> {
+		let parsed = url::Url::parse(&url).map_err(js_err)?;
+		let hashes = hashes.iter().map(|h| h.to_vec()).collect();
+		let transport = transport::connect_with_hashes(parsed, hashes).await.map_err(js_err)?;
+		Self::handshake(transport, url).await
+	}
+
+	async fn handshake(transport: transport::Session, url: String) -> Result<Session, JsValue> {
+		// Separate origins for the two directions: a shared one would echo our own
+		// published broadcasts back into the tree we subscribe from.
+		let subscribe = moq_net::Origin::random().produce();
+		let publish = moq_net::Origin::random().produce();
+
+		let client = moq_net::Client::new()
+			.with_subscriber(subscribe.clone())
+			.with_publisher(&publish);
+
+		let (inner, driver) = client.connect(transport).await.map_err(js_err)?;
+
+		// The session only makes progress while its driver runs. The driver holds no
+		// session clone, so dropping this `Session` still closes the transport, which
+		// in turn ends the spawned task.
+		web_async::spawn(async move {
+			let _ = driver.await;
+		});
+
+		Ok(Session {
+			inner,
+			url,
+			subscribe: subscribe.consume(),
+			publish,
+		})
+	}
+
+	/// The URL this session connected to.
+	#[wasm_bindgen(getter)]
+	pub fn url(&self) -> String {
+		self.url.clone()
+	}
+
+	/// The negotiated protocol version, e.g. "moq-lite-05" or "moq-transport-19".
+	#[wasm_bindgen(getter)]
+	pub fn version(&self) -> String {
+		self.inner.version().to_string()
+	}
+
+	/// Consume the broadcast at the given path, resolving once it is routable.
+	///
+	/// Rejects if the path is neither announced nor served by a dynamic router. Use
+	/// `announcedBroadcast` to wait indefinitely for one that may not be online yet.
+	pub async fn consume(&self, path: String) -> Result<BroadcastConsumer, JsValue> {
+		let consumer = self.subscribe.request_broadcast(path.as_str()).await.map_err(js_err)?;
+		Ok(BroadcastConsumer::new(consumer))
+	}
+
+	/// Wait until the broadcast at the given path is announced, then consume it.
+	///
+	/// Resolves `null` if the session closes first.
+	#[wasm_bindgen(js_name = announcedBroadcast)]
+	pub async fn announced_broadcast(&self, path: String) -> Option<BroadcastConsumer> {
+		let broadcast = self.subscribe.announced_broadcast(path.as_str()).await;
+		broadcast.map(BroadcastConsumer::new)
+	}
+
+	/// Subscribe to announcements under a path prefix.
+	///
+	/// Yielded paths are relative to the prefix. Pass nothing for every broadcast.
+	pub fn announced(&self, prefix: Option<String>) -> Result<AnnounceConsumer, JsValue> {
+		let origin = match prefix {
+			Some(prefix) => self
+				.subscribe
+				.with_root(prefix.as_str())
+				.ok_or_else(|| js_err("prefix outside the session's allowed paths"))?,
+			None => self.subscribe.consume(),
+		};
+		Ok(AnnounceConsumer::new(origin.announced()))
+	}
+
+	/// Publish a broadcast at the given path, announcing it to the remote.
+	///
+	/// Returns the producer to write tracks into; keep it alive for as long as the
+	/// broadcast should stay available.
+	pub fn publish(&self, path: String) -> Result<BroadcastProducer, JsValue> {
+		let route = moq_net::broadcast::Route::new().with_announce(true);
+		let inner = self.publish.create_broadcast(path.as_str(), route).map_err(js_err)?;
+		Ok(BroadcastProducer::new(inner))
+	}
+
+	/// Close the session with an application close code.
+	pub fn close(&self, code: Option<u16>) {
+		self.inner.abort(moq_net::Error::App(code.unwrap_or(0)));
+	}
+
+	/// Reject when the session closes, with the reason it closed.
+	///
+	/// Every close carries a reason, including a clean one, so this never resolves.
+	pub async fn closed(&self) -> Result<(), JsValue> {
+		Err(js_err(self.inner.closed().await))
+	}
+}

--- a/rs/moq-wasm/src/track.rs
+++ b/rs/moq-wasm/src/track.rs
@@ -106,10 +106,21 @@ impl TrackProducer {
 		Err(js_err(waiter.closed().await))
 	}
 
+	/// Resolve once somebody is subscribed, so the producer can start working.
+	///
+	/// The counterpart to `unused`, and what a publisher waits on before opening a camera
+	/// or spinning up an encoder for a track nobody is watching yet. Safe to await while
+	/// publishing.
+	pub async fn used(&self) -> Result<(), JsValue> {
+		let waiter = self.waiter.clone();
+		waiter.used().await.map_err(js_err)
+	}
+
 	/// Resolve once nobody is subscribed, so the producer can stop working.
 	///
-	/// Safe to await while publishing, which is the point: this is the demand signal a
-	/// publisher races against its own writes.
+	/// Resolves immediately when nobody has ever subscribed, so use `used` to wait for the
+	/// first viewer rather than expecting this to hold. Safe to await while publishing,
+	/// which is the point: this is the demand signal a publisher races against its writes.
 	pub async fn unused(&self) -> Result<(), JsValue> {
 		let waiter = self.waiter.clone();
 		waiter.unused().await.map_err(js_err)

--- a/rs/moq-wasm/src/track.rs
+++ b/rs/moq-wasm/src/track.rs
@@ -12,11 +12,16 @@ use crate::util::{Exclusive, js_err};
 pub struct TrackProducer {
 	name: String,
 
-	// A second handle for the waiting methods. `unused` and `closed` take `&self` and are
-	// meant to be awaited *while* publishing, so routing them through `inner` would check
-	// the producer out for the whole wait and reject every write until they resolved. The
-	// clone shares the same track (see the refcount lifecycle in moq-net).
-	waiter: moq_net::track::Producer,
+	// The observers (`used`, `unused`, `closed`) run off this rather than `inner`. They
+	// take `&self` and are meant to be awaited *while* publishing, so routing them through
+	// `inner` would check the producer out for the whole wait and reject every write until
+	// they resolved.
+	//
+	// It has to be `Demand` and not a `Producer` clone: `Demand` is a weak handle, so it
+	// neither keeps the track alive nor pins its cached groups. A strong clone held across
+	// a pending `closed()` would defeat close-on-last-drop, and the promise would keep the
+	// very track it is waiting on alive.
+	demand: moq_net::track::Demand,
 
 	inner: Exclusive<moq_net::track::Producer>,
 }
@@ -25,7 +30,7 @@ impl TrackProducer {
 	pub fn new(inner: moq_net::track::Producer) -> Self {
 		Self {
 			name: inner.name().to_string(),
-			waiter: inner.clone(),
+			demand: inner.demand(),
 			inner: Exclusive::new(inner),
 		}
 	}
@@ -102,8 +107,8 @@ impl TrackProducer {
 	/// Every close carries a reason, including a clean one, so this never resolves.
 	/// Safe to await while publishing.
 	pub async fn closed(&self) -> Result<(), JsValue> {
-		let waiter = self.waiter.clone();
-		Err(js_err(waiter.closed().await))
+		let demand = self.demand.clone();
+		Err(js_err(demand.closed().await))
 	}
 
 	/// Resolve once somebody is subscribed, so the producer can start working.
@@ -112,8 +117,8 @@ impl TrackProducer {
 	/// or spinning up an encoder for a track nobody is watching yet. Safe to await while
 	/// publishing.
 	pub async fn used(&self) -> Result<(), JsValue> {
-		let waiter = self.waiter.clone();
-		waiter.used().await.map_err(js_err)
+		let demand = self.demand.clone();
+		demand.used().await.map_err(js_err)
 	}
 
 	/// Resolve once nobody is subscribed, so the producer can stop working.
@@ -122,8 +127,8 @@ impl TrackProducer {
 	/// first viewer rather than expecting this to hold. Safe to await while publishing,
 	/// which is the point: this is the demand signal a publisher races against its writes.
 	pub async fn unused(&self) -> Result<(), JsValue> {
-		let waiter = self.waiter.clone();
-		waiter.unused().await.map_err(js_err)
+		let demand = self.demand.clone();
+		demand.unused().await.map_err(js_err)
 	}
 
 	/// The subscription currently aggregated across every live subscriber, or `null`

--- a/rs/moq-wasm/src/track.rs
+++ b/rs/moq-wasm/src/track.rs
@@ -4,13 +4,20 @@ use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
 use crate::group::{GroupConsumer, GroupProducer};
-use crate::options::{self, Frame, Subscription, TrackInfo};
+use crate::options::{self, Fetch, Frame, Subscription, TrackInfo};
 use crate::util::{Exclusive, js_err};
 
 /// Publishes groups and frames for a single track.
 #[wasm_bindgen]
 pub struct TrackProducer {
 	name: String,
+
+	// A second handle for the waiting methods. `unused` and `closed` take `&self` and are
+	// meant to be awaited *while* publishing, so routing them through `inner` would check
+	// the producer out for the whole wait and reject every write until they resolved. The
+	// clone shares the same track (see the refcount lifecycle in moq-net).
+	waiter: moq_net::track::Producer,
+
 	inner: Exclusive<moq_net::track::Producer>,
 }
 
@@ -18,6 +25,7 @@ impl TrackProducer {
 	pub fn new(inner: moq_net::track::Producer) -> Self {
 		Self {
 			name: inner.name().to_string(),
+			waiter: inner.clone(),
 			inner: Exclusive::new(inner),
 		}
 	}
@@ -92,27 +100,19 @@ impl TrackProducer {
 	/// Reject once the track closes, with the reason it closed.
 	///
 	/// Every close carries a reason, including a clean one, so this never resolves.
+	/// Safe to await while publishing.
 	pub async fn closed(&self) -> Result<(), JsValue> {
-		let err = self
-			.inner
-			.with("closed", async |t| {
-				let e = t.closed().await;
-				(t, e)
-			})
-			.await?;
-		Err(js_err(err))
+		let waiter = self.waiter.clone();
+		Err(js_err(waiter.closed().await))
 	}
 
 	/// Resolve once nobody is subscribed, so the producer can stop working.
+	///
+	/// Safe to await while publishing, which is the point: this is the demand signal a
+	/// publisher races against its own writes.
 	pub async fn unused(&self) -> Result<(), JsValue> {
-		let result = self
-			.inner
-			.with("unused", async |t| {
-				let r = t.unused().await;
-				(t, r)
-			})
-			.await?;
-		result.map_err(js_err)
+		let waiter = self.waiter.clone();
+		waiter.unused().await.map_err(js_err)
 	}
 
 	/// The subscription currently aggregated across every live subscriber, or `null`
@@ -159,8 +159,8 @@ impl TrackConsumer {
 
 	/// Fetch a single past group by sequence.
 	#[wasm_bindgen(js_name = fetchGroup)]
-	pub async fn fetch_group(&self, sequence: u64, priority: Option<u8>) -> Result<GroupConsumer, JsValue> {
-		let options = priority.map(|priority| moq_net::group::Fetch::default().with_priority(priority));
+	pub async fn fetch_group(&self, sequence: u64, options: Option<Fetch>) -> Result<GroupConsumer, JsValue> {
+		let options = options.map(Into::into);
 		let inner = self.inner.fetch_group(sequence, options).await.map_err(js_err)?;
 		Ok(GroupConsumer::new(inner))
 	}
@@ -183,6 +183,13 @@ impl TrackConsumer {
 pub struct TrackSubscriber {
 	name: String,
 	info: TrackInfo,
+
+	// Preferences live on their own handle rather than behind `inner`. A read is pending
+	// most of the time on a live track, and `inner` is checked out for its whole duration,
+	// so routing `update` through it would mean priority and latency could only be changed
+	// in the gaps between arrivals. This is what `moq_net::track::SubscriberControl` is for.
+	control: moq_net::track::SubscriberControl,
+
 	inner: Exclusive<moq_net::track::Subscriber>,
 }
 
@@ -191,6 +198,7 @@ impl TrackSubscriber {
 		Self {
 			name: inner.name().to_string(),
 			info: inner.info().clone().into(),
+			control: inner.control(),
 			inner: Exclusive::new(inner),
 		}
 	}
@@ -289,16 +297,19 @@ impl TrackSubscriber {
 	}
 
 	/// The subscription this reader requested.
+	///
+	/// Readable while a read is in flight, unlike the cursor methods.
 	#[wasm_bindgen(getter)]
-	pub fn subscription(&self) -> Result<Subscription, JsValue> {
-		Ok(self.inner.peek("subscription", |sub| sub.subscription())?.into())
+	pub fn subscription(&self) -> Subscription {
+		self.control.subscription().into()
 	}
 
 	/// Change the subscription, e.g. to raise priority or widen the latency window.
+	///
+	/// Safe to call while a read is in flight, which is the point: a player retunes
+	/// priority or latency mid-stream, not in the gaps between groups.
 	pub fn update(&self, subscription: Subscription) -> Result<(), JsValue> {
-		self.inner
-			.peek("update", |sub| sub.update(subscription.into()))?
-			.map_err(js_err)
+		self.control.update(subscription.into()).map_err(js_err)
 	}
 
 	/// The latest group sequence seen, or `null` if none has arrived.

--- a/rs/moq-wasm/src/track.rs
+++ b/rs/moq-wasm/src/track.rs
@@ -1,0 +1,357 @@
+//! Track producer, consumer, subscriber, and request, mirroring `moq_net::track`.
+
+use js_sys::Uint8Array;
+use wasm_bindgen::prelude::*;
+
+use crate::group::{GroupConsumer, GroupProducer};
+use crate::options::{self, Frame, Subscription, TrackInfo};
+use crate::util::{Exclusive, js_err};
+
+/// Publishes groups and frames for a single track.
+#[wasm_bindgen]
+pub struct TrackProducer {
+	name: String,
+	inner: Exclusive<moq_net::track::Producer>,
+}
+
+impl TrackProducer {
+	pub fn new(inner: moq_net::track::Producer) -> Self {
+		Self {
+			name: inner.name().to_string(),
+			inner: Exclusive::new(inner),
+		}
+	}
+}
+
+#[wasm_bindgen]
+impl TrackProducer {
+	/// This track's name within its broadcast.
+	#[wasm_bindgen(getter)]
+	pub fn name(&self) -> String {
+		self.name.clone()
+	}
+
+	/// Start the next group, one sequence past the latest.
+	#[wasm_bindgen(js_name = appendGroup)]
+	pub fn append_group(&self) -> Result<GroupProducer, JsValue> {
+		let inner = self
+			.inner
+			.peek("appendGroup", |track| track.append_group())?
+			.map_err(js_err)?;
+		Ok(GroupProducer::new(inner))
+	}
+
+	/// Append a single-frame group, timestamped in microseconds.
+	#[wasm_bindgen(js_name = writeFrame)]
+	pub fn write_frame(&self, timestamp: f64, payload: Uint8Array) -> Result<(), JsValue> {
+		let timestamp = options::timestamp(timestamp)?;
+		let payload = payload.to_vec();
+		self.inner
+			.peek("writeFrame", |track| track.write_frame(timestamp, payload))?
+			.map_err(js_err)
+	}
+
+	/// The latest group sequence written, or `null` if nothing has been written.
+	#[wasm_bindgen(getter)]
+	pub fn latest(&self) -> Result<Option<u64>, JsValue> {
+		self.inner.peek("latest", |track| track.latest())
+	}
+
+	/// Read this track's groups directly, without going over the wire.
+	pub fn consume(&self) -> Result<TrackConsumer, JsValue> {
+		let inner = self.inner.peek("consume", |track| track.consume())?;
+		Ok(TrackConsumer::new(inner))
+	}
+
+	/// Subscribe to this track directly, without going over the wire.
+	pub fn subscribe(&self, subscription: Option<Subscription>) -> Result<TrackSubscriber, JsValue> {
+		let subscription = subscription.map(Into::into);
+		let inner = self.inner.peek("subscribe", |track| track.subscribe(subscription))?;
+		Ok(TrackSubscriber::new(inner))
+	}
+
+	/// Finish the track cleanly, marking it complete.
+	pub fn close(&self) -> Result<(), JsValue> {
+		self.inner.peek("close", |track| track.finish())?.map_err(js_err)
+	}
+
+	/// Finish the track once the given group sequence is reached (exclusive).
+	#[wasm_bindgen(js_name = closeAt)]
+	pub fn close_at(&self, sequence: u64) -> Result<(), JsValue> {
+		self.inner
+			.peek("closeAt", |track| track.finish_at(sequence))?
+			.map_err(js_err)
+	}
+
+	/// Abort the track with an application close code.
+	pub fn abort(&self, code: u16) -> Result<(), JsValue> {
+		let track = self.inner.take("abort")?;
+		track.abort(moq_net::Error::App(code)).map_err(js_err)
+	}
+
+	/// Reject once the track closes, with the reason it closed.
+	///
+	/// Every close carries a reason, including a clean one, so this never resolves.
+	pub async fn closed(&self) -> Result<(), JsValue> {
+		let err = self
+			.inner
+			.with("closed", async |t| {
+				let e = t.closed().await;
+				(t, e)
+			})
+			.await?;
+		Err(js_err(err))
+	}
+
+	/// Resolve once nobody is subscribed, so the producer can stop working.
+	pub async fn unused(&self) -> Result<(), JsValue> {
+		let result = self
+			.inner
+			.with("unused", async |t| {
+				let r = t.unused().await;
+				(t, r)
+			})
+			.await?;
+		result.map_err(js_err)
+	}
+
+	/// The subscription currently aggregated across every live subscriber, or `null`
+	/// when nobody is subscribed.
+	#[wasm_bindgen(getter)]
+	pub fn subscription(&self) -> Result<Option<Subscription>, JsValue> {
+		Ok(self
+			.inner
+			.peek("subscription", |track| track.subscription())?
+			.map(Into::into))
+	}
+}
+
+/// A handle to a track, used to subscribe or fetch.
+#[wasm_bindgen]
+pub struct TrackConsumer {
+	name: String,
+	inner: moq_net::track::Consumer,
+}
+
+impl TrackConsumer {
+	pub fn new(inner: moq_net::track::Consumer) -> Self {
+		Self {
+			name: inner.name().to_string(),
+			inner,
+		}
+	}
+}
+
+#[wasm_bindgen]
+impl TrackConsumer {
+	/// This track's name within its broadcast.
+	#[wasm_bindgen(getter)]
+	pub fn name(&self) -> String {
+		self.name.clone()
+	}
+
+	/// Subscribe, resolving once the publisher accepts.
+	pub async fn subscribe(&self, subscription: Option<Subscription>) -> Result<TrackSubscriber, JsValue> {
+		let subscription = subscription.map(Into::into);
+		let inner = self.inner.subscribe(subscription).await.map_err(js_err)?;
+		Ok(TrackSubscriber::new(inner))
+	}
+
+	/// Fetch a single past group by sequence.
+	#[wasm_bindgen(js_name = fetchGroup)]
+	pub async fn fetch_group(&self, sequence: u64, priority: Option<u8>) -> Result<GroupConsumer, JsValue> {
+		let options = priority.map(|priority| moq_net::group::Fetch::default().with_priority(priority));
+		let inner = self.inner.fetch_group(sequence, options).await.map_err(js_err)?;
+		Ok(GroupConsumer::new(inner))
+	}
+
+	/// Look up the track's properties, resolving once the publisher reports them.
+	pub async fn info(&self) -> Result<TrackInfo, JsValue> {
+		let info = self.inner.info().await.map_err(js_err)?;
+		Ok(info.into())
+	}
+
+	/// The latest group sequence seen, or `null` if none has arrived.
+	#[wasm_bindgen(getter)]
+	pub fn latest(&self) -> Option<u64> {
+		self.inner.latest()
+	}
+}
+
+/// An open subscription, yielding groups as they arrive.
+#[wasm_bindgen]
+pub struct TrackSubscriber {
+	name: String,
+	info: TrackInfo,
+	inner: Exclusive<moq_net::track::Subscriber>,
+}
+
+impl TrackSubscriber {
+	pub fn new(inner: moq_net::track::Subscriber) -> Self {
+		Self {
+			name: inner.name().to_string(),
+			info: inner.info().clone().into(),
+			inner: Exclusive::new(inner),
+		}
+	}
+}
+
+#[wasm_bindgen]
+impl TrackSubscriber {
+	/// This track's name within its broadcast.
+	#[wasm_bindgen(getter)]
+	pub fn name(&self) -> String {
+		self.name.clone()
+	}
+
+	/// The track's properties, as reported by the publisher when the subscription opened.
+	#[wasm_bindgen(getter)]
+	pub fn info(&self) -> TrackInfo {
+		self.info.clone()
+	}
+
+	/// Receive the next group in arrival order, or `null` when the track ends.
+	///
+	/// Arrival order means a newer group preempts an older one still in flight, which is
+	/// what a live player wants. Use `nextGroup` to read in sequence order instead.
+	#[wasm_bindgen(js_name = recvGroup)]
+	pub async fn recv_group(&self) -> Result<Option<GroupConsumer>, JsValue> {
+		let result = self
+			.inner
+			.with("recvGroup", async |mut sub| {
+				let result = sub.recv_group().await;
+				(sub, result)
+			})
+			.await?;
+
+		Ok(result.map_err(js_err)?.map(GroupConsumer::new))
+	}
+
+	/// Receive the next group in sequence order, or `null` when the track ends.
+	#[wasm_bindgen(js_name = nextGroup)]
+	pub async fn next_group(&self) -> Result<Option<GroupConsumer>, JsValue> {
+		let result = self
+			.inner
+			.with("nextGroup", async |mut sub| {
+				let result = sub.next_group().await;
+				(sub, result)
+			})
+			.await?;
+
+		Ok(result.map_err(js_err)?.map(GroupConsumer::new))
+	}
+
+	/// Read the next frame across group boundaries, or `null` when the track ends.
+	///
+	/// A convenience for tracks whose groups each hold one frame (a catalog, control
+	/// state); it hides the group structure.
+	#[wasm_bindgen(js_name = readFrame)]
+	pub async fn read_frame(&self) -> Result<Option<Frame>, JsValue> {
+		let result = self
+			.inner
+			.with("readFrame", async |mut sub| {
+				let result = sub.read_frame().await;
+				(sub, result)
+			})
+			.await?;
+
+		Ok(result.map_err(js_err)?.map(Frame::from))
+	}
+
+	/// Resolve with the final group sequence once the track is complete.
+	pub async fn finished(&self) -> Result<u64, JsValue> {
+		let result = self
+			.inner
+			.with("finished", async |mut sub| {
+				let result = sub.finished().await;
+				(sub, result)
+			})
+			.await?;
+
+		result.map_err(js_err)
+	}
+
+	/// Move this reader's cursor to the given group, skipping anything earlier.
+	///
+	/// A local cursor only: it does not change what the publisher sends. Use `update`
+	/// with a `startGroup` for that.
+	#[wasm_bindgen(js_name = startAt)]
+	pub fn start_at(&self, sequence: u64) -> Result<(), JsValue> {
+		self.inner.peek("startAt", |sub| sub.start_at(sequence))
+	}
+
+	/// Stop this reader after the given group, or pass nothing to remove the cap.
+	///
+	/// A local cursor only, like `startAt`.
+	#[wasm_bindgen(js_name = endAt)]
+	pub fn end_at(&self, sequence: Option<u64>) -> Result<(), JsValue> {
+		self.inner.peek("endAt", |sub| sub.end_at(sequence))
+	}
+
+	/// The subscription this reader requested.
+	#[wasm_bindgen(getter)]
+	pub fn subscription(&self) -> Result<Subscription, JsValue> {
+		Ok(self.inner.peek("subscription", |sub| sub.subscription())?.into())
+	}
+
+	/// Change the subscription, e.g. to raise priority or widen the latency window.
+	pub fn update(&self, subscription: Subscription) -> Result<(), JsValue> {
+		self.inner
+			.peek("update", |sub| sub.update(subscription.into()))?
+			.map_err(js_err)
+	}
+
+	/// The latest group sequence seen, or `null` if none has arrived.
+	#[wasm_bindgen(getter)]
+	pub fn latest(&self) -> Result<Option<u64>, JsValue> {
+		self.inner.peek("latest", |sub| sub.latest())
+	}
+}
+
+/// A track the peer subscribed to, waiting to be served.
+#[wasm_bindgen]
+pub struct TrackRequest {
+	name: String,
+	inner: Exclusive<moq_net::track::Request>,
+}
+
+impl TrackRequest {
+	pub fn new(inner: moq_net::track::Request) -> Self {
+		Self {
+			name: inner.name().to_string(),
+			inner: Exclusive::new(inner),
+		}
+	}
+}
+
+#[wasm_bindgen]
+impl TrackRequest {
+	/// The requested track's name.
+	#[wasm_bindgen(getter)]
+	pub fn name(&self) -> String {
+		self.name.clone()
+	}
+
+	/// What the subscriber asked for, or `null` if it only wants the track's properties.
+	#[wasm_bindgen(getter)]
+	pub fn subscription(&self) -> Result<Option<Subscription>, JsValue> {
+		Ok(self
+			.inner
+			.peek("subscription", |req| req.subscription())?
+			.map(Into::into))
+	}
+
+	/// Serve the track, optionally declaring its properties.
+	pub fn accept(&self, info: Option<TrackInfo>) -> Result<TrackProducer, JsValue> {
+		let info = info.map(TryInto::try_into).transpose()?;
+		let request = self.inner.take("accept")?;
+		Ok(TrackProducer::new(request.accept(info)))
+	}
+
+	/// Refuse to serve the track, with an application close code.
+	pub fn reject(&self, code: u16) -> Result<(), JsValue> {
+		let request = self.inner.take("reject")?;
+		request.reject(moq_net::Error::App(code));
+		Ok(())
+	}
+}

--- a/rs/moq-wasm/src/util.rs
+++ b/rs/moq-wasm/src/util.rs
@@ -1,0 +1,80 @@
+//! Small helpers shared by the binding modules.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+
+/// Map any displayable error into a JS exception.
+pub fn js_err(e: impl std::fmt::Display) -> JsValue {
+	JsError::new(&e.to_string()).into()
+}
+
+/// Holds a value that `&mut self` async methods need exclusive access to.
+///
+/// wasm-bindgen async methods take `&self` and must produce `'static` futures, so a
+/// `RefCell` borrow can't be held across the await. Instead the value is moved out for
+/// the duration of the call and moved back after, which also makes a re-entrant call an
+/// error rather than an aliasing bug: one in-flight call per handle.
+pub struct Exclusive<T> {
+	inner: Rc<RefCell<Option<T>>>,
+}
+
+impl<T> Exclusive<T> {
+	pub fn new(value: T) -> Self {
+		Self {
+			inner: Rc::new(RefCell::new(Some(value))),
+		}
+	}
+
+	/// Run `f` with the value moved out, restoring it when the future completes.
+	///
+	/// `what` names the operation so a re-entrant call reports which one is already
+	/// running.
+	pub async fn with<F, Fut, R>(&self, what: &str, f: F) -> Result<R, JsValue>
+	where
+		F: FnOnce(T) -> Fut,
+		Fut: Future<Output = (T, R)>,
+	{
+		let cell = self.inner.clone();
+		let value = cell
+			.borrow_mut()
+			.take()
+			.ok_or_else(|| js_err(format!("{what} already in progress")))?;
+
+		let (value, result) = f(value).await;
+		*cell.borrow_mut() = Some(value);
+		Ok(result)
+	}
+
+	/// Run `f` against the value without awaiting.
+	pub fn peek<F, R>(&self, what: &str, f: F) -> Result<R, JsValue>
+	where
+		F: FnOnce(&mut T) -> R,
+	{
+		let mut guard = self.inner.borrow_mut();
+		let value = guard
+			.as_mut()
+			.ok_or_else(|| js_err(format!("{what} already in progress")))?;
+		Ok(f(value))
+	}
+
+	/// Move the value out for good, for a terminal operation that consumes it.
+	///
+	/// Every later call reports the handle as unusable, which is the closest a
+	/// wasm-bindgen handle gets to moq-net's `fn abort(self)`.
+	pub fn take(&self, what: &str) -> Result<T, JsValue> {
+		self.inner
+			.borrow_mut()
+			.take()
+			.ok_or_else(|| js_err(format!("{what} already in progress")))
+	}
+}
+
+impl<T> Clone for Exclusive<T> {
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+		}
+	}
+}

--- a/rs/moq-wasm/src/util.rs
+++ b/rs/moq-wasm/src/util.rs
@@ -1,6 +1,6 @@
 //! Small helpers shared by the binding modules.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use wasm_bindgen::prelude::*;
@@ -18,12 +18,26 @@ pub fn js_err(e: impl std::fmt::Display) -> JsValue {
 /// error rather than an aliasing bug: one in-flight call per handle.
 pub struct Exclusive<T> {
 	inner: Rc<RefCell<Option<T>>>,
+
+	// Both "busy" and "consumed" read as an empty cell, so the reason is tracked here.
+	// Otherwise a call after `abort()` reports "already in progress", pointing a JS
+	// developer at concurrency when the real mistake was use-after-consume.
+	consumed: Rc<Cell<bool>>,
 }
 
 impl<T> Exclusive<T> {
 	pub fn new(value: T) -> Self {
 		Self {
 			inner: Rc::new(RefCell::new(Some(value))),
+			consumed: Rc::new(Cell::new(false)),
+		}
+	}
+
+	fn unavailable(&self, what: &str) -> JsValue {
+		if self.consumed.get() {
+			js_err(format!("{what}: handle was already consumed"))
+		} else {
+			js_err(format!("{what} already in progress"))
 		}
 	}
 
@@ -37,10 +51,7 @@ impl<T> Exclusive<T> {
 		Fut: Future<Output = (T, R)>,
 	{
 		let cell = self.inner.clone();
-		let value = cell
-			.borrow_mut()
-			.take()
-			.ok_or_else(|| js_err(format!("{what} already in progress")))?;
+		let value = cell.borrow_mut().take().ok_or_else(|| self.unavailable(what))?;
 
 		let (value, result) = f(value).await;
 		*cell.borrow_mut() = Some(value);
@@ -53,9 +64,7 @@ impl<T> Exclusive<T> {
 		F: FnOnce(&mut T) -> R,
 	{
 		let mut guard = self.inner.borrow_mut();
-		let value = guard
-			.as_mut()
-			.ok_or_else(|| js_err(format!("{what} already in progress")))?;
+		let value = guard.as_mut().ok_or_else(|| self.unavailable(what))?;
 		Ok(f(value))
 	}
 
@@ -64,10 +73,9 @@ impl<T> Exclusive<T> {
 	/// Every later call reports the handle as unusable, which is the closest a
 	/// wasm-bindgen handle gets to moq-net's `fn abort(self)`.
 	pub fn take(&self, what: &str) -> Result<T, JsValue> {
-		self.inner
-			.borrow_mut()
-			.take()
-			.ok_or_else(|| js_err(format!("{what} already in progress")))
+		let value = self.inner.borrow_mut().take().ok_or_else(|| self.unavailable(what))?;
+		self.consumed.set(true);
+		Ok(value)
 	}
 }
 
@@ -75,6 +83,7 @@ impl<T> Clone for Exclusive<T> {
 	fn clone(&self) -> Self {
 		Self {
 			inner: self.inner.clone(),
+			consumed: self.consumed.clone(),
 		}
 	}
 }


### PR DESCRIPTION
Stacked on #2811 (the ALPN fix), which is what makes any of this reachable in a browser. Review that one first; this PR retargets to `main` once it lands.

## Why

`moq-wasm` bound 4 classes and 8 methods: connect, consume a broadcast, subscribe, read groups and frames. No publish, no discovery, no subscription options, no track properties. Anything a browser wanted beyond "read the live edge of one track" had to fall back to the hand-written TypeScript in `@moq/net`, which is the thing this crate exists to replace.

It drifted because nothing notices. The crate is `#![cfg(target_arch = "wasm32")]`, so `cargo check --workspace` compiles it to nothing on a host target; `just rs wasm` is a *compile* gate, which catches a `moq-net` change that breaks an existing binding but says nothing about one the binding never grew; and no test in the repo exercises it. It isn't in the `moq-ffi` sync row either, so it falls off the radar exactly when `moq-net` gains something.

## What

Bind the rest of the model, in modules mirroring moq-net's role modules one-for-one:

| module | JS classes | mirrors |
|---|---|---|
| `session` | `Session` | `moq_net::Session` + `origin::{Producer, Consumer}` |
| `broadcast` | `BroadcastProducer`, `BroadcastConsumer` | `moq_net::broadcast` |
| `track` | `TrackProducer`, `TrackConsumer`, `TrackSubscriber`, `TrackRequest` | `moq_net::track` |
| `group` | `GroupProducer`, `GroupConsumer` | `moq_net::group` |
| `announce` | `AnnounceConsumer`, `Announce` | `moq_net::announce` |
| `options` | `Subscription`, `TrackInfo`, `Frame` | the plain-data types |

New capability: publishing (`session.publish` → producer → tracks → groups → frames), discovery (`announced(prefix)`, `announcedBroadcast`), on-demand serving (`requestedTrack` / `accept` / `reject`), `fetchGroup`, subscription options (priority, ordered, latency, group start/end) with live `update`, track properties, subscriber cursors (`startAt` / `endAt`), and frame timestamps.

Deliberately absent: relay-side concerns (routes, hops, cost, origin scoping, cluster identity) have no browser caller, and the `poll_*` variants have no JS equivalent of a `kio::Waiter`.

## Anti-drift

The mirroring is the point, and it needs a rule to go with it. `rs/CLAUDE.md` and the root Cross-Package Sync table now name `moq-wasm` as a binding to update alongside `moq-net`, the way a `moq-ffi` change ripples into `libmoq` and the language wrappers. The module-per-role layout is what makes "read the two side by side and spot the gap" a workable review step, since no automated gate can do it.

## The wasm-bindgen trap this surfaced

Types carry the role as a prefix (`TrackProducer`, not `track::Producer`), against the naming rule in `rs/CLAUDE.md`. **wasm-bindgen resolves a type in a signature by its Rust ident alone: it ignores the module path and `js_name` both.** With role modules each exporting a `Consumer`, the first cut generated typings that were quietly wrong:

```ts
consume(path: string): Promise<GroupConsumer>;      // actually a BroadcastConsumer
readonly broadcast: GroupConsumer | undefined;      // actually a BroadcastConsumer
track(name: string): GroupConsumer;                 // actually a TrackConsumer
```

It compiled and ran; only the `.d.ts` lied. Unique idents are the fix. The modules stay private and re-export flat, so nothing reads `broadcast::BroadcastProducer`. Documented in the crate docs and `rs/CLAUDE.md` so the next person doesn't rediscover it.

## Boundary conventions

Chosen to match what a JS caller already expects from `@moq/net`:

- Durations in milliseconds, timestamps in microseconds.
- Sequences as `bigint` (they are `u64` on the wire).
- Option bags as classes, so a new knob is an added field rather than a changed signature.
- Closing takes an application close code (`Error::App`); a JS `Error` has nothing to map onto the wire.
- `closed()` rejects rather than resolves, because every close carries a reason.
- One in-flight async call per handle. wasm-bindgen async methods take `&self` and must produce `'static` futures, so a handle moves its value out for the call's duration (`util::Exclusive`); a re-entrant call errors instead of aliasing.

## Verification

Driven in a real browser against a relay, twice over. Same script, once against a default relay (`moq-lite-05`) and once against one pinned with `--server-version moq-transport-19`; both completed every step with no errors:

1. Two sessions connect.
2. Publisher `session.publish("test/room")`, `createTrack("video")` with a microsecond timescale, priority 3, ordered.
3. Subscriber's `announced("test")` yields `path: "room"` with a live broadcast.
4. `subscribe` with priority 5 / latencyMax 2000; reported track info comes back with the publisher's timescale, priority, and ordered flag intact.
5. Write a 3-frame group, read it back: payloads and timestamps (1000/2000/3000µs) survive the round trip.
6. `requestedTrack` fires for an unsubscribed name; `accept` serves it and the frame arrives.
7. `fetchGroup(0n)` returns the past group.
8. `broadcast.close()` shows up as an announce with a null broadcast.

`just check`, `just test`, and `just fix` are clean.

## Still no test harness

The crate is wasm32-only and nothing in the repo runs a browser, so `just rs wasm` compiling it remains the entire automated gate. Everything above was verified by hand. A headless-browser runner (`wasm-bindgen-test` + a relay fixture) is the obvious follow-up and would turn this PR's manual script into a regression test; it is a bigger change than this one and I did not attempt it here.

## Cross-Package Sync

No `moq-net` wire or API change, so no `js/net`, `doc/`, or draft updates. The `@moq/wasm` and `rs/moq-wasm` READMEs are updated for the new surface.

(written by Opus 5)