### PR TITLE
fix(js/net): honor frame floor for a held group

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -182,7 +182,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -573,8 +573,8 @@ test("lite draft-05: a group taken before the cap dropped is still served", asyn
 // by design, since the read cursor shifts and closes every buffered group below it, so a group
 // already in hand has to go the same way: serving it would re-deliver below a floor the
 // subscriber just moved, which on a route splice is duplicate media.
-test("lite draft-05: a group taken before the floor rose is dropped", async () => {
-	const sub = await servedSubscription({ startGroup: 0, gated: true });
+test("lite draft-06: a group taken before the floor rose past it is dropped", async () => {
+	const sub = await servedSubscription({ version: Version.DRAFT_06, startGroup: 0, gated: true });
 	try {
 		// Same window as the cap test: group 0 parks the loop, so the prefetch takes group 1.
 		sub.serve(0);
@@ -583,7 +583,7 @@ test("lite draft-05: a group taken before the floor rose is dropped", async () =
 		await flush();
 
 		// Skip ahead past group 1, which the loop is already holding.
-		await new SubscribeUpdate({ priority: 0, startGroup: 2 }).encode(sub.client.writer, Version.DRAFT_05);
+		await new SubscribeUpdate({ priority: 0, startGroup: 2 }).encode(sub.client.writer, Version.DRAFT_06);
 		while (sub.track.subscription.peek()?.startGroup !== 2) await sub.track.subscription.changed();
 
 		// Buffered while the loop is still parked, so it is taken under the raised floor.
@@ -593,6 +593,41 @@ test("lite draft-05: a group taken before the floor rose is dropped", async () =
 		// Group 0 was already decided and stays in flight; group 1 must not follow it.
 		expect(await sub.servedSequence()).toBe(0);
 		expect(await sub.servedSequence()).toBe(2);
+	} finally {
+		await sub.close();
+	}
+});
+
+// Raising the floor into a group already in hand is just as destructive as raising it past
+// the group. The group stays servable, but its snapshotted frame range must be lifted to the
+// new floor so frames the subscriber discarded do not reach the wire.
+test("lite draft-06: a group taken before the floor rose into it starts at the raised frame", async () => {
+	const sub = await servedSubscription({
+		version: Version.DRAFT_06,
+		startGroup: 0,
+		frames: ["a", "b", "c"],
+		gated: true,
+	});
+	try {
+		// Group 0 parks the loop, so the armed prefetch takes group 1 under the old floor.
+		sub.serve(0);
+		await sub.parked;
+		sub.serve(1);
+		await flush();
+
+		// Raise the floor into held group 1, excluding its first two frames.
+		await new SubscribeUpdate({ priority: 0, startGroup: 1, startFrame: 2 }).encode(
+			sub.client.writer,
+			Version.DRAFT_06,
+		);
+		while (sub.track.subscription.peek()?.startGroup !== 1) await sub.track.subscription.changed();
+
+		sub.release();
+
+		// Group 0 was already decided and stays in flight. Group 1 must honor the newer,
+		// destructive floor even though it was taken with a start frame of 0.
+		expect(await sub.servedGroup()).toEqual({ sequence: 0, frameStart: 0, payloads: ["a", "b", "c"] });
+		expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 2, payloads: ["c"] });
 	} finally {
 		await sub.close();
 	}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -571,19 +571,18 @@ export class Publisher {
 				next = take();
 
 				// The floor is judged against the bounds as they stand now, deliberately unlike
-				// the frame range above, which is the snapshot this group was taken under. The
-				// two ends of a subscription are not symmetric: raising the floor is destructive
-				// (the read cursor shifts and closes every buffered group below it), so dropping
-				// one already in hand discards nothing the subscriber has not discarded itself,
-				// while serving it would re-deliver below a floor they just moved. Lowering the
-				// cap only parks its groups, which is why the cap must not reject here.
-				//
-				// Whole groups only. A floor raised to a frame *within* a group already in hand
-				// still serves it from the snapshotted start frame, since the group clears this
-				// check and carries its own range.
+				// the rest of the frame range, which is the snapshot this group was taken under.
+				// Raising the floor is destructive: the read cursor shifts and closes every
+				// buffered group below it, so an in-hand group below the new floor must also go.
+				// When the new floor lands within this group, intersect it with the snapshotted
+				// start so neither a raised nor a subsequently lowered floor widens what is sent.
+				// Lowering the cap only parks its groups, which is why the cap does not reject here.
 				if (bounds.startGroup !== undefined && group.sequence < bounds.startGroup) {
 					group.close();
 					continue;
+				}
+				if (bounds.startGroup === group.sequence) {
+					range.start = Math.max(range.start, bounds.startFrame);
 				}
 
 				if (emitRange && !startSent) {


### PR DESCRIPTION
## Summary

- Intersect a prefetched group's snapshotted frame start with the current raised start floor when both name the same group.
- Preserve the existing destructive whole-group floor behavior while preventing frames below a newer intra-group floor from reaching the wire.
- Add deterministic draft-06 regressions for a floor raised past a held group and a floor raised into it.
- Bump `@moq/net` from `0.3.0` to `0.3.1` for the shipped behavioral fix.

Root cause: the serving loop snapshots a group's frame range when `recvGroup()` hands it over, then can remain parked while `SUBSCRIBE_UPDATE` raises the start floor. The later whole-group rejection only compared `group.sequence`, so a floor raised into the held group accepted the stale `start: 0` snapshot and served frames the subscriber had discarded. The fix intersects that snapshot with the current frame floor at the serving handoff. The end cap remains snapshot-based because lowering it is recoverable and must not discard a prefetched group.

Closes #2807.

## Public API changes

None. This changes internal lite publisher range enforcement only.

## Test plan

- `bun test js/net/src/lite/publisher.test.ts` (27 passed)
- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (including 465 `@moq/net` tests)

No cross-package or draft update is required because the public API and wire format are unchanged.

(Written by GPT-5)