### PR TITLE
fix(js/net): serialize subscription updates with group pops

### DIFF
--- a/js/net/src/internal.ts
+++ b/js/net/src/internal.ts
@@ -5,14 +5,26 @@
  *
  * @module
  */
-import type { Producer, Request } from "./track.ts";
+import type { Dispose } from "@moq/signals";
+import type { Consumer as GroupConsumer } from "./group.ts";
+import type { Producer, Request, Subscriber } from "./track.ts";
 
 /** Hooks assigned in static blocks by the owning class. */
 export const hooks: {
 	/** Mint a track {@link Request}; assigned by `track.ts`. */
 	makeRequest: (name: string, producer: Producer) => Request;
+	/** Pop one immediately readable group without waiting; assigned by `track.ts`. */
+	tryRecvGroup: (subscriber: Subscriber) => GroupConsumer | Error | null | undefined;
+	/** Wake once a subscriber's group cursor may read differently; assigned by `track.ts`. */
+	groupChanged: (subscriber: Subscriber, fn: () => void) => Dispose;
 } = {
 	makeRequest: () => {
+		throw new Error("track.ts not loaded");
+	},
+	tryRecvGroup: () => {
+		throw new Error("track.ts not loaded");
+	},
+	groupChanged: () => {
 		throw new Error("track.ts not loaded");
 	},
 };

--- a/js/net/src/internal.ts
+++ b/js/net/src/internal.ts
@@ -9,12 +9,33 @@ import type { Dispose } from "@moq/signals";
 import type { Consumer as GroupConsumer } from "./group.ts";
 import type { Producer, Request, Subscriber } from "./track.ts";
 
+/**
+ * What a non-blocking group read found, which is everything the caller needs to decide what
+ * to do next: no second look at the track's closed state, and no ordering rule to get wrong.
+ */
+export type Recv =
+	/** A group to serve. It has already left the buffer, so dropping this is dropping the group. */
+	| { kind: "group"; group: GroupConsumer }
+	/** Nothing readable, but the track is live and may produce more. */
+	| { kind: "idle" }
+	/** The producer finished, yet groups above the cap are still held: raising it releases them. */
+	| { kind: "boundary" }
+	/** The producer finished and the buffer is drained. Nothing can follow. */
+	| { kind: "done" }
+	/** The track aborted. */
+	| { kind: "error"; error: Error };
+
 /** Hooks assigned in static blocks by the owning class. */
 export const hooks: {
 	/** Mint a track {@link Request}; assigned by `track.ts`. */
 	makeRequest: (name: string, producer: Producer) => Request;
-	/** Pop one immediately readable group without waiting; assigned by `track.ts`. */
-	tryRecvGroup: (subscriber: Subscriber) => GroupConsumer | Error | null | undefined;
+	/**
+	 * Take the next group the subscriber's cursor allows, without waiting; assigned by `track.ts`.
+	 *
+	 * Synchronous so a caller can pop a group and act on it in the same turn. Park on
+	 * {@link groupChanged} when it reports `idle` or `boundary`.
+	 */
+	tryRecvGroup: (subscriber: Subscriber) => Recv;
 	/** Wake once a subscriber's group cursor may read differently; assigned by `track.ts`. */
 	groupChanged: (subscriber: Subscriber, fn: () => void) => Dispose;
 } = {

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -679,6 +679,46 @@ test("lite draft-06: a popped group keeps its frame bounds across a queued updat
 	}
 });
 
+// Control-first has to mean every buffered control, not just the first. Two updates that arrive
+// while the loop is parked both describe the subscription the peer wants now, so serving a group
+// under the older one puts frames on the wire that the newer one excluded.
+test("lite draft-06: a burst of updates all apply before the next group pop", async () => {
+	const sub = await servedSubscription({
+		version: Version.DRAFT_06,
+		startGroup: 0,
+		endGroup: 1,
+		endFrame: 2,
+		frames: ["a", "b", "c"],
+		gated: true,
+	});
+	try {
+		// Group 0 parks the loop inside its SUBSCRIBE_START write; group 1 buffers behind it.
+		sub.serve(0);
+		await sub.parked;
+		sub.serve(1);
+
+		// Two updates land back to back, the second superseding the first.
+		await new SubscribeUpdate({ priority: 0, endGroup: 1, endFrame: 1 }).encode(
+			sub.client.writer,
+			Version.DRAFT_06,
+		);
+		await new SubscribeUpdate({ priority: 0, endGroup: 1, endFrame: 0 }).encode(
+			sub.client.writer,
+			Version.DRAFT_06,
+		);
+		await flush();
+
+		sub.release();
+
+		// Group 0 was popped before either update and is not the end group either way.
+		expect(await sub.servedGroup()).toEqual({ sequence: 0, frameStart: 0, payloads: ["a", "b", "c"] });
+		// Group 1 is popped after both, so it honors the second: "b" stays off the wire.
+		expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 0, payloads: ["a"] });
+	} finally {
+		await sub.close();
+	}
+});
+
 // A peer FIN is the subscriber leaving, which the loop takes ahead of any ready group: it stops
 // there rather than draining what is buffered, since nobody is reading the rest. Matches the Rust
 // publisher's TrackEnd::PeerFin, which drops the in-flight group machines instead of draining.
@@ -699,11 +739,10 @@ test("lite draft-05: a peer FIN ends serving while the producer is still live", 
 	}
 });
 
-// The decoder holds one message at a time and parks until the loop takes it, so a subscription
-// that dies while holding one leaves the decoder parked on the slot rather than on a read that
-// resetting the stream would release. Teardown has to unpark it too, or runSubscribe never
-// returns and the subscription leaks.
-test("lite draft-05: teardown unwinds while the decoder holds an untaken update", async () => {
+// runSubscribe waits on the decoder before it returns, so a subscription that dies mid-write
+// with a control still queued has to end the decoder too, or it never returns and the
+// subscription leaks.
+test("lite draft-05: teardown unwinds with an undelivered update queued", async () => {
 	const sub = await servedSubscription({ startGroup: 0, gated: true });
 	try {
 		// Group 0 parks the loop inside its SUBSCRIBE_START write.

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -366,14 +366,17 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 // Wraps a writable so its writes park until `release()`, giving a test a window inside
 // whatever the publisher is writing while its other loops keep running. `parked` settles on
-// the first write attempt, held or not.
+// the first write attempt, held or not. Passing an error to `release` fails the held write
+// instead, which is how a test drives the publisher's error teardown from a known point.
 function gateWrites(target: WritableStream<Uint8Array>, hold: boolean) {
 	const writer = target.getWriter();
 
-	let release!: () => void;
-	const released = new Promise<void>((resolve) => {
-		release = resolve;
+	let release!: (err?: Error) => void;
+	const released = new Promise<void>((resolve, reject) => {
+		release = (err) => (err ? reject(err) : resolve());
 	});
+	// Nobody awaits this until a write parks on it, so a rejection would look unhandled.
+	released.catch(() => void 0);
 	if (!hold) release();
 
 	let parking!: () => void;
@@ -441,13 +444,17 @@ async function servedSubscription(
 		endGroup: options.endGroup,
 		endFrame: options.endFrame,
 	});
-	void publisher.runSubscribe(msg, server);
+	// Kept so a test can wait for the whole subscription to unwind, decoder included, rather
+	// than only for what reached the wire. It reports failures by tearing down, never by
+	// rejecting.
+	const serving = publisher.runSubscribe(msg, server);
 
 	const opened = pair.client.incomingUnidirectionalStreams.getReader();
 
 	return {
 		client,
 		track,
+		serving,
 		parked: gate.parked,
 		release: gate.release,
 		serve(sequence: number) {
@@ -667,6 +674,49 @@ test("lite draft-06: a popped group keeps its frame bounds across a queued updat
 
 		sub.release();
 		expect(await sub.servedGroup()).toEqual({ sequence: 0, frameStart: 0, payloads: ["a", "b"] });
+	} finally {
+		await sub.close();
+	}
+});
+
+// A peer FIN is the subscriber leaving, which the loop takes ahead of any ready group: it stops
+// there rather than draining what is buffered, since nobody is reading the rest. Matches the Rust
+// publisher's TrackEnd::PeerFin, which drops the in-flight group machines instead of draining.
+test("lite draft-05: a peer FIN ends serving while the producer is still live", async () => {
+	const sub = await servedSubscription({ startGroup: 0 });
+	try {
+		sub.serve(0);
+		expect(await sub.servedSequence()).toBe(0);
+
+		// The subscriber unsubscribes. The producer doesn't know and keeps going.
+		sub.client.writer.close();
+		await flush();
+		sub.serve(1);
+
+		expect(await sub.servedSequence()).toBeUndefined();
+	} finally {
+		await sub.close();
+	}
+});
+
+// The decoder holds one message at a time and parks until the loop takes it, so a subscription
+// that dies while holding one leaves the decoder parked on the slot rather than on a read that
+// resetting the stream would release. Teardown has to unpark it too, or runSubscribe never
+// returns and the subscription leaks.
+test("lite draft-05: teardown unwinds while the decoder holds an untaken update", async () => {
+	const sub = await servedSubscription({ startGroup: 0, gated: true });
+	try {
+		// Group 0 parks the loop inside its SUBSCRIBE_START write.
+		sub.serve(0);
+		await sub.parked;
+
+		// The update decodes into the slot behind the parked loop, which never takes it
+		// because the write it is parked on fails.
+		await new SubscribeUpdate({ priority: 0, endGroup: 5 }).encode(sub.client.writer, Version.DRAFT_05);
+		await flush();
+
+		sub.release(new Error("write failed"));
+		await sub.serving;
 	} finally {
 		await sub.close();
 	}

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -1,9 +1,10 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { Producer as GroupProducer } from "../group.ts";
 import { createMockTransportPair } from "../mock.ts";
 import { Producer as OriginProducer } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Reader, Stream } from "../stream.ts";
+import { Subscriber as TrackSubscriber } from "../track.ts";
 import { Fetch } from "./fetch.ts";
 import { Group as GroupMessage } from "./group.ts";
 import { randomOrigin } from "./origin.ts";
@@ -679,10 +680,9 @@ test("lite draft-06: a popped group keeps its frame bounds across a queued updat
 	}
 });
 
-// Control-first has to mean every buffered control, not just the first. Two updates that arrive
-// while the loop is parked both describe the subscription the peer wants now, so serving a group
-// under the older one puts frames on the wire that the newer one excluded.
-test("lite draft-06: a burst of updates all apply before the next group pop", async () => {
+// Updates are full-state, so a burst buffered while the serving loop is parked only needs its
+// newest member. Keeping one pending update bounds memory without serving under stale bounds.
+test("lite draft-06: a burst of updates coalesces before the next group pop", async () => {
 	const sub = await servedSubscription({
 		version: Version.DRAFT_06,
 		startGroup: 0,
@@ -696,24 +696,34 @@ test("lite draft-06: a burst of updates all apply before the next group pop", as
 		sub.serve(0);
 		await sub.parked;
 		sub.serve(1);
+		const updates = spyOn(TrackSubscriber.prototype, "update");
 
-		// Two updates land back to back, the second superseding the first.
-		await new SubscribeUpdate({ priority: 0, endGroup: 1, endFrame: 1 }).encode(
-			sub.client.writer,
-			Version.DRAFT_06,
-		);
-		await new SubscribeUpdate({ priority: 0, endGroup: 1, endFrame: 0 }).encode(
-			sub.client.writer,
-			Version.DRAFT_06,
-		);
-		await flush();
+		try {
+			// Two updates land back to back, the second superseding the first.
+			await new SubscribeUpdate({ priority: 0, endGroup: 1, endFrame: 1 }).encode(
+				sub.client.writer,
+				Version.DRAFT_06,
+			);
+			await new SubscribeUpdate({ priority: 0, endGroup: 1, endFrame: 0 }).encode(
+				sub.client.writer,
+				Version.DRAFT_06,
+			);
+			await flush();
 
-		sub.release();
+			sub.release();
 
-		// Group 0 was popped before either update and is not the end group either way.
-		expect(await sub.servedGroup()).toEqual({ sequence: 0, frameStart: 0, payloads: ["a", "b", "c"] });
-		// Group 1 is popped after both, so it honors the second: "b" stays off the wire.
-		expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 0, payloads: ["a"] });
+			// Group 0 was popped before either update and is not the end group either way.
+			expect(await sub.servedGroup()).toEqual({
+				sequence: 0,
+				frameStart: 0,
+				payloads: ["a", "b", "c"],
+			});
+			// Group 1 is popped under the latest state, with no application of the older one.
+			expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 0, payloads: ["a"] });
+			expect(updates).toHaveBeenCalledTimes(1);
+		} finally {
+			updates.mockRestore();
+		}
 	} finally {
 		await sub.close();
 	}

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -729,6 +729,48 @@ test("lite draft-06: a burst of updates coalesces before the next group pop", as
 	}
 });
 
+// Applying one update can itself race the decoder's next message. The serving loop yields a task
+// before another pop so the decoder can finish the already-delivered update and tighten the cap.
+test("lite draft-06: a newer update wins before a buffered group backlog drains", async () => {
+	const sub = await servedSubscription({
+		version: Version.DRAFT_06,
+		startGroup: 0,
+		gated: true,
+	});
+	let second!: Promise<void>;
+	const update = TrackSubscriber.prototype.update;
+	const updates = spyOn(TrackSubscriber.prototype, "update").mockImplementation(function (
+		this: TrackSubscriber,
+		options,
+	) {
+		second ??= new SubscribeUpdate({ priority: 0, endGroup: 1 }).encode(sub.client.writer, Version.DRAFT_06);
+		return update.call(this, options);
+	});
+
+	try {
+		// Group 0 parks the loop. Groups 1 and 2 are both readable when it wakes.
+		sub.serve(0);
+		await sub.parked;
+		sub.serve(1);
+		sub.serve(2);
+
+		// The first update wakes the serving loop. Applying it starts the second update,
+		// which caps the subscription before group 2.
+		await new SubscribeUpdate({ priority: 0, endGroup: 2 }).encode(sub.client.writer, Version.DRAFT_06);
+		await flush();
+		sub.release();
+
+		expect(await sub.servedSequence()).toBe(0);
+		expect(await sub.servedSequence()).toBe(1);
+		await second;
+		expect(await sub.servedSequence()).toBeUndefined();
+		expect(updates).toHaveBeenCalledTimes(2);
+	} finally {
+		updates.mockRestore();
+		await sub.close();
+	}
+});
+
 // A peer FIN is the subscriber leaving, which the loop takes ahead of any ready group: it stops
 // there rather than draining what is buffered, since nobody is reading the rest. Matches the Rust
 // publisher's TrackEnd::PeerFin, which drops the in-flight group machines instead of draining.

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -3,7 +3,7 @@ import { Producer as GroupProducer } from "../group.ts";
 import { createMockTransportPair } from "../mock.ts";
 import { Producer as OriginProducer } from "../origin.ts";
 import * as Path from "../path.ts";
-import { Reader, Stream } from "../stream.ts";
+import { Reader, Stream, Writer } from "../stream.ts";
 import { Subscriber as TrackSubscriber } from "../track.ts";
 import { Fetch } from "./fetch.ts";
 import { Group as GroupMessage } from "./group.ts";
@@ -843,6 +843,7 @@ test("lite draft-05: a peer FIN ends serving while the producer is still live", 
 // response write by itself, so serving must race the write against decoded termination.
 test("lite draft-05: a peer FIN interrupts a blocked SUBSCRIBE_START", async () => {
 	const sub = await servedSubscription({ startGroup: 0, gated: true });
+	const resets = spyOn(Writer.prototype, "reset");
 	try {
 		sub.serve(0);
 		await sub.parked;
@@ -853,7 +854,9 @@ test("lite draft-05: a peer FIN interrupts a blocked SUBSCRIBE_START", async () 
 			new Promise<false>((resolve) => setTimeout(() => resolve(false), IDLE_MS)),
 		]);
 		expect(stopped).toBe(true);
+		expect(resets).toHaveBeenCalledTimes(1);
 	} finally {
+		resets.mockRestore();
 		// Also unwinds the old behavior when this regression fails.
 		sub.release();
 		await sub.close();

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -537,71 +537,56 @@ test("lite draft-05: a straggler below the announced start group is not served",
 	}
 });
 
-// The serving loop prefetches the next group the moment it takes one, so a SUBSCRIBE_UPDATE
-// can lower the cap while a group is already in hand. Dropping it there would be permanent:
-// the group has left the buffer, so raising the cap again could never bring it back. The cap
-// gates what the read cursor hands out, and a group already handed out stays served.
-test("lite draft-05: a group taken before the cap dropped is still served", async () => {
-	const sub = await servedSubscription({ startGroup: 0, gated: true });
+// A group pop is the linearization point. Once the publisher reaches the SUBSCRIBE_START write,
+// the group and its range have already been decided, so an update queued during the write applies
+// to the next pop rather than reaching backward into this one.
+test("lite draft-05: a group popped before a cap update is still served", async () => {
+	const sub = await servedSubscription({ startGroup: 1, gated: true });
 	try {
-		// Group 0 parks the loop inside its SUBSCRIBE_START write, prefetch already armed.
-		sub.serve(0);
+		sub.serve(1);
 		await sub.parked;
 
-		// So group 1 leaves the buffer here; only the parked loop still holds it.
-		sub.serve(1);
-		await flush();
-
-		// Cap the subscription at group 0, behind the loop's back.
 		await new SubscribeUpdate({ priority: 0, endGroup: 0 }).encode(sub.client.writer, Version.DRAFT_05);
-		while (sub.track.subscription.peek()?.endGroup !== 0) await sub.track.subscription.changed();
+		await flush();
+		// The decoder queues controls, but the parked serving loop remains the sole state owner.
+		expect(sub.track.subscription.peek()?.endGroup).toBeUndefined();
 
 		sub.release();
-
-		// Both reach the wire under a cap of 0, because group 1 was taken while it was still
-		// in range. Nothing raises the cap to rescue it, so the assertion stays sensitive to
-		// the window under test: had the prefetch not taken group 1, the cap would hold it in
-		// the buffer and the second read would go idle instead.
-		expect(await sub.servedSequence()).toBe(0);
 		expect(await sub.servedSequence()).toBe(1);
+		while (sub.track.subscription.peek()?.endGroup !== 0) await sub.track.subscription.changed();
 	} finally {
 		await sub.close();
 	}
 });
 
-// The other end of the subscription is not symmetric. Raising the start floor is destructive
-// by design, since the read cursor shifts and closes every buffered group below it, so a group
-// already in hand has to go the same way: serving it would re-deliver below a floor the
-// subscriber just moved, which on a route splice is duplicate media.
-test("lite draft-06: a group taken before the floor rose past it is dropped", async () => {
+// No next read is armed while a subscription response is blocked. A buffered control therefore
+// applies before the next buffered group is popped, matching the Rust publisher's control-first
+// poll order.
+test("lite draft-06: a queued floor update applies before the next group pop", async () => {
 	const sub = await servedSubscription({ version: Version.DRAFT_06, startGroup: 0, gated: true });
 	try {
-		// Same window as the cap test: group 0 parks the loop, so the prefetch takes group 1.
 		sub.serve(0);
 		await sub.parked;
 		sub.serve(1);
-		await flush();
 
-		// Skip ahead past group 1, which the loop is already holding.
 		await new SubscribeUpdate({ priority: 0, startGroup: 2 }).encode(sub.client.writer, Version.DRAFT_06);
-		while (sub.track.subscription.peek()?.startGroup !== 2) await sub.track.subscription.changed();
-
-		// Buffered while the loop is still parked, so it is taken under the raised floor.
 		sub.serve(2);
+		await flush();
+		expect(sub.track.subscription.peek()?.startGroup).toBe(0);
+
 		sub.release();
 
-		// Group 0 was already decided and stays in flight; group 1 must not follow it.
 		expect(await sub.servedSequence()).toBe(0);
 		expect(await sub.servedSequence()).toBe(2);
+		while (sub.track.subscription.peek()?.startGroup !== 2) await sub.track.subscription.changed();
 	} finally {
 		await sub.close();
 	}
 });
 
-// Raising the floor into a group already in hand is just as destructive as raising it past
-// the group. The group stays servable, but its snapshotted frame range must be lifted to the
-// new floor so frames the subscriber discarded do not reach the wire.
-test("lite draft-06: a group taken before the floor rose into it starts at the raised frame", async () => {
+// The queued update raises the floor within the next buffered group. Control-first polling
+// applies the new frame start before popping the group, so excluded frames never reach the wire.
+test("lite draft-06: a queued frame floor applies before the next group pop", async () => {
 	const sub = await servedSubscription({
 		version: Version.DRAFT_06,
 		startGroup: 0,
@@ -609,35 +594,30 @@ test("lite draft-06: a group taken before the floor rose into it starts at the r
 		gated: true,
 	});
 	try {
-		// Group 0 parks the loop, so the armed prefetch takes group 1 under the old floor.
 		sub.serve(0);
 		await sub.parked;
 		sub.serve(1);
-		await flush();
 
-		// Raise the floor into held group 1, excluding its first two frames.
 		await new SubscribeUpdate({ priority: 0, startGroup: 1, startFrame: 2 }).encode(
 			sub.client.writer,
 			Version.DRAFT_06,
 		);
-		while (sub.track.subscription.peek()?.startGroup !== 1) await sub.track.subscription.changed();
+		await flush();
+		expect(sub.track.subscription.peek()?.startGroup).toBe(0);
 
 		sub.release();
 
-		// Group 0 was already decided and stays in flight. Group 1 must honor the newer,
-		// destructive floor even though it was taken with a start frame of 0.
 		expect(await sub.servedGroup()).toEqual({ sequence: 0, frameStart: 0, payloads: ["a", "b", "c"] });
 		expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 2, payloads: ["c"] });
+		while (sub.track.subscription.peek()?.startGroup !== 1) await sub.track.subscription.changed();
 	} finally {
 		await sub.close();
 	}
 });
 
-// Frame bounds have to travel with the group they were taken under. An update that moves the
-// cap off a group already in hand leaves it matching neither boundary, and mapping that to
-// the whole group would put frames the subscription excluded on the wire. Nothing downstream
-// trims them: a frame range is a wire request, not a receiver-side cursor.
-test("lite draft-06: a prefetched group keeps the frame bounds it was taken under", async () => {
+// The update and group are both ready when the write unblocks. Control is drained first, then
+// the group is popped and positioned synchronously under the new frame cap.
+test("lite draft-06: a queued frame update applies before the next group pop", async () => {
 	const sub = await servedSubscription({
 		version: Version.DRAFT_06,
 		startGroup: 0,
@@ -647,23 +627,46 @@ test("lite draft-06: a prefetched group keeps the frame bounds it was taken unde
 		gated: true,
 	});
 	try {
-		// Same window as above: group 0 parks the loop, so the armed prefetch takes group 1.
 		sub.serve(0);
 		await sub.parked;
 		sub.serve(1);
+		await new SubscribeUpdate({ priority: 0, endGroup: 1, endFrame: 0 }).encode(
+			sub.client.writer,
+			Version.DRAFT_06,
+		);
 		await flush();
-
-		// Move the cap off group 1, which the loop is already holding.
-		await new SubscribeUpdate({ priority: 0, endGroup: 0 }).encode(sub.client.writer, Version.DRAFT_06);
-		while (sub.track.subscription.peek()?.endGroup !== 0) await sub.track.subscription.changed();
 
 		sub.release();
 
-		// Group 0 was never the end group, so it goes whole either way.
 		expect(await sub.servedGroup()).toEqual({ sequence: 0, frameStart: 0, payloads: ["a", "b", "c"] });
-		// Group 1 was taken while it was the end group, capped at frame 1, so "c" stays off
-		// the wire even though the cap has since moved below it.
-		expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 0, payloads: ["a", "b"] });
+		expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 0, payloads: ["a"] });
+	} finally {
+		await sub.close();
+	}
+});
+
+// The inverse ordering is equally important. Once the group is popped, its range is fixed in
+// the same turn, so an update decoded while SUBSCRIBE_START is blocked only affects later groups.
+test("lite draft-06: a popped group keeps its frame bounds across a queued update", async () => {
+	const sub = await servedSubscription({
+		version: Version.DRAFT_06,
+		startGroup: 0,
+		endGroup: 0,
+		endFrame: 1,
+		frames: ["a", "b", "c"],
+		gated: true,
+	});
+	try {
+		sub.serve(0);
+		await sub.parked;
+		await new SubscribeUpdate({ priority: 0, endGroup: 0, endFrame: 2 }).encode(
+			sub.client.writer,
+			Version.DRAFT_06,
+		);
+		await flush();
+
+		sub.release();
+		expect(await sub.servedGroup()).toEqual({ sequence: 0, frameStart: 0, payloads: ["a", "b"] });
 	} finally {
 		await sub.close();
 	}

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -550,19 +550,23 @@ test("lite draft-05: a straggler below the announced start group is not served",
 // to the next pop rather than reaching backward into this one.
 test("lite draft-05: a group popped before a cap update is still served", async () => {
 	const sub = await servedSubscription({ startGroup: 1, gated: true });
+	const ranges = spyOn(TrackSubscriber.prototype, "endAt");
 	try {
 		sub.serve(1);
 		await sub.parked;
 
 		await new SubscribeUpdate({ priority: 0, endGroup: 0 }).encode(sub.client.writer, Version.DRAFT_05);
 		await flush();
-		// The decoder queues controls, but the parked serving loop remains the sole state owner.
-		expect(sub.track.subscription.peek()?.endGroup).toBeUndefined();
+		// The full update is visible, but the parked serving loop still owns its local cursor.
+		expect(ranges).not.toHaveBeenCalled();
 
 		sub.release();
 		expect(await sub.servedSequence()).toBe(1);
-		while (sub.track.subscription.peek()?.endGroup !== 0) await sub.track.subscription.changed();
+		while (ranges.mock.calls.length === 0) await flush();
+		expect(ranges).toHaveBeenLastCalledWith(0);
 	} finally {
+		ranges.mockRestore();
+		sub.release();
 		await sub.close();
 	}
 });
@@ -572,6 +576,7 @@ test("lite draft-05: a group popped before a cap update is still served", async 
 // poll order.
 test("lite draft-06: a queued floor update applies before the next group pop", async () => {
 	const sub = await servedSubscription({ version: Version.DRAFT_06, startGroup: 0, gated: true });
+	const ranges = spyOn(TrackSubscriber.prototype, "startAt");
 	try {
 		sub.serve(0);
 		await sub.parked;
@@ -580,14 +585,17 @@ test("lite draft-06: a queued floor update applies before the next group pop", a
 		await new SubscribeUpdate({ priority: 0, startGroup: 2 }).encode(sub.client.writer, Version.DRAFT_06);
 		sub.serve(2);
 		await flush();
-		expect(sub.track.subscription.peek()?.startGroup).toBe(0);
+		expect(ranges).toHaveBeenCalledTimes(1);
+		expect(ranges).toHaveBeenLastCalledWith(0);
 
 		sub.release();
 
 		expect(await sub.servedSequence()).toBe(0);
 		expect(await sub.servedSequence()).toBe(2);
-		while (sub.track.subscription.peek()?.startGroup !== 2) await sub.track.subscription.changed();
+		expect(ranges).toHaveBeenLastCalledWith(2);
 	} finally {
+		ranges.mockRestore();
+		sub.release();
 		await sub.close();
 	}
 });
@@ -601,6 +609,7 @@ test("lite draft-06: a queued frame floor applies before the next group pop", as
 		frames: ["a", "b", "c"],
 		gated: true,
 	});
+	const ranges = spyOn(TrackSubscriber.prototype, "startAt");
 	try {
 		sub.serve(0);
 		await sub.parked;
@@ -611,14 +620,17 @@ test("lite draft-06: a queued frame floor applies before the next group pop", as
 			Version.DRAFT_06,
 		);
 		await flush();
-		expect(sub.track.subscription.peek()?.startGroup).toBe(0);
+		expect(ranges).toHaveBeenCalledTimes(1);
+		expect(ranges).toHaveBeenLastCalledWith(0);
 
 		sub.release();
 
 		expect(await sub.servedGroup()).toEqual({ sequence: 0, frameStart: 0, payloads: ["a", "b", "c"] });
 		expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 2, payloads: ["c"] });
-		while (sub.track.subscription.peek()?.startGroup !== 1) await sub.track.subscription.changed();
+		expect(ranges).toHaveBeenLastCalledWith(1);
 	} finally {
+		ranges.mockRestore();
+		sub.release();
 		await sub.close();
 	}
 });
@@ -696,7 +708,7 @@ test("lite draft-06: a burst of updates coalesces before the next group pop", as
 		sub.serve(0);
 		await sub.parked;
 		sub.serve(1);
-		const updates = spyOn(TrackSubscriber.prototype, "update");
+		const ranges = spyOn(TrackSubscriber.prototype, "endAt");
 
 		try {
 			// Two updates land back to back, the second superseding the first.
@@ -720,9 +732,10 @@ test("lite draft-06: a burst of updates coalesces before the next group pop", as
 			});
 			// Group 1 is popped under the latest state, with no application of the older one.
 			expect(await sub.servedGroup()).toEqual({ sequence: 1, frameStart: 0, payloads: ["a"] });
-			expect(updates).toHaveBeenCalledTimes(1);
+			expect(ranges).toHaveBeenCalledTimes(1);
+			expect(ranges).toHaveBeenLastCalledWith(1);
 		} finally {
-			updates.mockRestore();
+			ranges.mockRestore();
 		}
 	} finally {
 		await sub.close();
@@ -738,13 +751,13 @@ test("lite draft-06: a newer update wins before a buffered group backlog drains"
 		gated: true,
 	});
 	let second!: Promise<void>;
-	const update = TrackSubscriber.prototype.update;
-	const updates = spyOn(TrackSubscriber.prototype, "update").mockImplementation(function (
+	const endAt = TrackSubscriber.prototype.endAt;
+	const ranges = spyOn(TrackSubscriber.prototype, "endAt").mockImplementation(function (
 		this: TrackSubscriber,
-		options,
+		endGroup,
 	) {
 		second ??= new SubscribeUpdate({ priority: 0, endGroup: 1 }).encode(sub.client.writer, Version.DRAFT_06);
-		return update.call(this, options);
+		return endAt.call(this, endGroup);
 	});
 
 	try {
@@ -764,9 +777,44 @@ test("lite draft-06: a newer update wins before a buffered group backlog drains"
 		expect(await sub.servedSequence()).toBe(1);
 		await second;
 		expect(await sub.servedSequence()).toBeUndefined();
-		expect(updates).toHaveBeenCalledTimes(2);
+		expect(ranges).toHaveBeenCalledTimes(2);
 	} finally {
-		updates.mockRestore();
+		ranges.mockRestore();
+		await sub.close();
+	}
+});
+
+// Scheduling affects streams already in flight, so it cannot wait behind a response write.
+// The full update remains atomic to observers, while the local range cursor stays serialized.
+test("lite draft-06: scheduling updates apply while SUBSCRIBE_START is blocked", async () => {
+	const sub = await servedSubscription({ version: Version.DRAFT_06, startGroup: 0, gated: true });
+	const ranges = spyOn(TrackSubscriber.prototype, "endAt");
+	try {
+		sub.serve(0);
+		await sub.parked;
+
+		await new SubscribeUpdate({ priority: 9, ordered: true, endGroup: 5 }).encode(
+			sub.client.writer,
+			Version.DRAFT_06,
+		);
+		await flush();
+
+		expect(sub.track.subscription.peek()).toEqual({
+			priority: 9,
+			ordered: true,
+			latencyMax: 0,
+			startGroup: undefined,
+			endGroup: 5,
+		});
+		expect(ranges).not.toHaveBeenCalled();
+
+		sub.release();
+		expect(await sub.servedSequence()).toBe(0);
+		while (ranges.mock.calls.length === 0) await flush();
+		expect(ranges).toHaveBeenLastCalledWith(5);
+	} finally {
+		ranges.mockRestore();
+		sub.release();
 		await sub.close();
 	}
 });
@@ -787,6 +835,27 @@ test("lite draft-05: a peer FIN ends serving while the producer is still live", 
 
 		expect(await sub.servedSequence()).toBeUndefined();
 	} finally {
+		await sub.close();
+	}
+});
+
+// The two halves of a bidirectional stream close independently. A peer FIN cannot unblock a
+// response write by itself, so serving must race the write against decoded termination.
+test("lite draft-05: a peer FIN interrupts a blocked SUBSCRIBE_START", async () => {
+	const sub = await servedSubscription({ startGroup: 0, gated: true });
+	try {
+		sub.serve(0);
+		await sub.parked;
+
+		sub.client.writer.close();
+		const stopped = await Promise.race([
+			sub.serving.then(() => true),
+			new Promise<false>((resolve) => setTimeout(() => resolve(false), IDLE_MS)),
+		]);
+		expect(stopped).toBe(true);
+	} finally {
+		// Also unwinds the old behavior when this regression fails.
+		sub.release();
 		await sub.close();
 	}
 });

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -202,6 +202,12 @@ class SubscriptionControls {
 	}
 }
 
+// A microtask is too short: decoding one framed update crosses several awaits, each of which
+// can requeue behind the serving continuation. A task boundary lets the decoder finish whatever
+// the transport already delivered before the next group pop. Updates are rare, so groups do not
+// pay this scheduling cost on the normal path.
+const yieldToControls = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 // Register both readiness sources in the same turn after the caller observed neither ready.
 // The winner disposes both registrations, so an idle subscription accumulates nothing no
 // matter how many times it wakes.
@@ -614,6 +620,7 @@ export class Publisher {
 							bounds.startFrame = update.startFrame;
 							bounds.endGroup = update.endGroup;
 							bounds.endFrame = update.endFrame;
+							await yieldToControls();
 							continue;
 						}
 					}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -134,12 +134,20 @@ type Control =
 	/** The stream failed; the subscription goes down with it. */
 	| { kind: "error"; error: Error };
 
+type SubscriptionControlOptions = {
+	reader: Reader;
+	writer: Writer;
+	version: Version;
+	apply: (update: SubscribeUpdate) => void;
+};
+
 /**
  * The subscribe stream's control half, decoded ahead of the serving loop.
  *
- * Decoding runs on its own, but only stores the latest full-state update: the serving loop owns
- * the track cursor and frame bounds, so nothing here may apply an update itself. That is what
- * keeps a group pop and its frame-range snapshot one indivisible step.
+ * Decoding runs on its own and publishes each full subscription update immediately, so a
+ * blocked response write cannot delay re-ranking streams already in flight. It separately
+ * stores only the latest range state for the serving loop, which owns the local track cursor
+ * and frame bounds. That keeps a group pop and its frame-range snapshot one indivisible step.
  *
  * Reading ahead makes control-first ordering hold for a burst. Coalescing bounds memory while
  * preserving the newest state decoded before the next group pop. The Rust publisher gets the
@@ -150,13 +158,18 @@ class SubscriptionControls {
 	#update?: SubscribeUpdate;
 	// Sticky, first one wins: null once the stream is over, an Error once it failed.
 	#end?: Error | null;
+	#ended: Promise<Error | null>;
+	#resolveEnd!: (end: Error | null) => void;
 	#changed = new Signal(0);
 
 	/** Settles once decoding stops, so teardown can wait for it rather than leaving it running. */
 	readonly decoding: Promise<void>;
 
-	constructor(reader: Reader, writer: Writer, version: Version) {
-		this.decoding = this.#decode(reader, version);
+	constructor({ reader, writer, version, apply }: SubscriptionControlOptions) {
+		this.#ended = new Promise((resolve) => {
+			this.#resolveEnd = resolve;
+		});
+		this.decoding = this.#decode(reader, version, apply);
 		// Our own half going away ends the loop too, and has to reach it the same way: the
 		// loop looks at nothing else.
 		void writer.closed.then(
@@ -180,17 +193,35 @@ class SubscriptionControls {
 		return this.#changed.changed(fn);
 	}
 
+	/** Returns false when peer departure supersedes a blocked response write. */
+	async response(pending: Promise<void>): Promise<boolean> {
+		const result = await Promise.race([
+			pending.then(
+				() => ({ kind: "sent" }) as const,
+				(err: unknown) => ({ kind: "error", error: error(err) }) as const,
+			),
+			this.#ended.then((end) => ({ kind: "ended", end }) as const),
+		]);
+
+		if (result.kind === "sent") return true;
+		if (result.kind === "error") throw result.error;
+		if (result.end) throw result.end;
+		return false;
+	}
+
 	#finish(end: Error | null) {
 		if (this.#end !== undefined) return;
 		this.#end = end;
+		this.#resolveEnd(end);
 		this.#changed.update((value) => value + 1);
 	}
 
-	async #decode(reader: Reader, version: Version) {
+	async #decode(reader: Reader, version: Version, apply: (update: SubscribeUpdate) => void) {
 		try {
 			while (this.#end === undefined) {
 				const update = await SubscribeUpdate.decodeMaybe(reader, version);
 				if (!update) break;
+				apply(update);
 				this.#update = update;
 				this.#changed.update((value) => value + 1);
 			}
@@ -467,7 +498,20 @@ export class Publisher {
 				datagrams = this.#runDatagrams(msg.id, track, timescale);
 			}
 
-			controls = new SubscriptionControls(stream.reader, stream.writer, this.version);
+			controls = new SubscriptionControls({
+				reader: stream.reader,
+				writer: stream.writer,
+				version: this.version,
+				apply: (update) => {
+					track.update({
+						priority: update.priority,
+						ordered: update.ordered,
+						latencyMax: update.latencyMax,
+						startGroup: update.startGroup,
+						endGroup: update.endGroup,
+					});
+				},
+			});
 			await this.#runTrack(track, stream.writer, controls, {
 				sub: msg.id,
 				broadcast: msg.broadcast,
@@ -571,11 +615,14 @@ export class Publisher {
 		// SUBSCRIBE_END names that boundary, which a cap can hold groups back from, so it goes
 		// out as soon as the producer finishes and the subscription keeps serving whatever a
 		// later cap raise releases (see the Rust publisher's Recv::Boundary).
-		const sendEnd = async () => {
+		const sendEnd = async (): Promise<boolean> => {
 			endSent = true;
 			if (emitRange) {
-				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
+				return controls.response(
+					encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version),
+				);
 			}
+			return true;
 		};
 
 		// One ranking for the whole subscription, shared by every group it serves.
@@ -607,13 +654,6 @@ export class Publisher {
 						case "update": {
 							const update = control.update;
 							console.debug(`subscribe update: broadcast=${broadcast} track=${track.name}`);
-							track.update({
-								priority: update.priority,
-								ordered: update.ordered,
-								latencyMax: update.latencyMax,
-								startGroup: update.startGroup,
-								endGroup: update.endGroup,
-							});
 							if (update.startGroup !== undefined) track.startAt(update.startGroup);
 							track.endAt(update.endGroup);
 							bounds.startGroup = update.startGroup;
@@ -639,14 +679,14 @@ export class Publisher {
 						// The producer finished but is still holding groups above the cap.
 						// Declare the boundary, then wait for an update to release them.
 						if (!endSent) {
-							await sendEnd();
+							if (!(await sendEnd())) return;
 							continue;
 						}
 						await waitForSubscription(controls, track);
 						continue;
 					case "done":
 						if (!endSent) {
-							await sendEnd();
+							if (!(await sendEnd())) return;
 							continue;
 						}
 						finished = true;
@@ -662,7 +702,16 @@ export class Publisher {
 					// Arrival-order serving could later surface a straggler below the first
 					// group, so pin the floor to what was announced.
 					track.startAt(group.sequence);
-					await encodeSubscribeResponse(stream, { start: new SubscribeStart(group.sequence) }, this.version);
+					if (
+						!(await controls.response(
+							encodeSubscribeResponse(
+								stream,
+								{ start: new SubscribeStart(group.sequence) },
+								this.version,
+							),
+						))
+					)
+						return;
 				}
 
 				void this.#runGroup({

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -135,20 +135,19 @@ type Control =
 	| { kind: "error"; error: Error };
 
 /**
- * The subscribe stream's control half, decoded ahead of the serving loop into a queue.
+ * The subscribe stream's control half, decoded ahead of the serving loop.
  *
- * Decoding runs on its own, but only ever queues: the serving loop owns the track cursor and
- * the frame bounds, so nothing here may apply an update itself. That is what keeps a group pop
- * and its frame-range snapshot one indivisible step.
+ * Decoding runs on its own, but only stores the latest full-state update: the serving loop owns
+ * the track cursor and frame bounds, so nothing here may apply an update itself. That is what
+ * keeps a group pop and its frame-range snapshot one indivisible step.
  *
- * Reading ahead is what makes control-first ordering hold for a burst. The loop drains this
- * queue synchronously, so it cannot yield to the decoder between two controls: anything not
- * already decoded when the loop resumes would land after the next pop instead of before it.
- * The Rust publisher gets the same property from `poll_decode_maybe`, which decodes straight
- * out of the reader's buffer; nothing here can decode synchronously, so it reads ahead instead.
+ * Reading ahead makes control-first ordering hold for a burst. Coalescing bounds memory while
+ * preserving the newest state decoded before the next group pop. The Rust publisher gets the
+ * same ordering from `poll_decode_maybe`, which decodes straight out of the reader's buffer;
+ * nothing here can decode synchronously, so it reads ahead instead.
  */
 class SubscriptionControls {
-	#updates: SubscribeUpdate[] = [];
+	#update?: SubscribeUpdate;
 	// Sticky, first one wins: null once the stream is over, an Error once it failed.
 	#end?: Error | null;
 	#changed = new Signal(0);
@@ -168,9 +167,9 @@ class SubscriptionControls {
 
 	/** The next control to apply, or undefined while the peer is quiet. */
 	take(): Control | undefined {
-		const update = this.#updates.shift();
-		// An update decoded before the stream ended still applies, so the queue drains first.
-		// `#end` is sticky, so it is still there once the queue is empty.
+		const update = this.#update;
+		this.#update = undefined;
+		// An update decoded before the stream ended still applies before the sticky end.
 		if (update) return { kind: "update", update };
 		if (this.#end === undefined) return undefined;
 		return this.#end === null ? { kind: "done" } : { kind: "error", error: this.#end };
@@ -192,7 +191,7 @@ class SubscriptionControls {
 			while (this.#end === undefined) {
 				const update = await SubscribeUpdate.decodeMaybe(reader, version);
 				if (!update) break;
-				this.#updates.push(update);
+				this.#update = update;
 				this.#changed.update((value) => value + 1);
 			}
 		} catch (err: unknown) {

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -1,6 +1,6 @@
 import { type Dispose, type Getter, Signal } from "@moq/signals";
 import type * as broadcast from "../broadcast.ts";
-import { error, reason } from "../error.ts";
+import { error, reason, StreamCode, toTransport } from "../error.ts";
 import type * as group from "../group.ts";
 import { hooks } from "../internal.ts";
 import type { Consumer as OriginConsumer } from "../origin.ts";
@@ -155,6 +155,7 @@ type SubscriptionControlOptions = {
  * nothing here can decode synchronously, so it reads ahead instead.
  */
 class SubscriptionControls {
+	#writer: Writer;
 	#update?: SubscribeUpdate;
 	// Sticky, first one wins: null once the stream is over, an Error once it failed.
 	#end?: Error | null;
@@ -166,6 +167,7 @@ class SubscriptionControls {
 	readonly decoding: Promise<void>;
 
 	constructor({ reader, writer, version, apply }: SubscriptionControlOptions) {
+		this.#writer = writer;
 		this.#ended = new Promise((resolve) => {
 			this.#resolveEnd = resolve;
 		});
@@ -205,6 +207,8 @@ class SubscriptionControls {
 
 		if (result.kind === "sent") return true;
 		if (result.kind === "error") throw result.error;
+		// Promise.race leaves the blocked encode running, so reset the writable half too.
+		this.#writer.reset(result.end ?? toTransport(StreamCode.Cancel, "cancel"));
 		if (result.end) throw result.end;
 		return false;
 	}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -2,9 +2,10 @@ import { type Dispose, type Getter, Signal } from "@moq/signals";
 import type * as broadcast from "../broadcast.ts";
 import { error, reason } from "../error.ts";
 import type * as group from "../group.ts";
+import { hooks } from "../internal.ts";
 import type { Consumer as OriginConsumer } from "../origin.ts";
 import * as Path from "../path.ts";
-import { type Stream, Writer } from "../stream.ts";
+import { type Reader, type Stream, Writer } from "../stream.ts";
 import { Timescale } from "../time.ts";
 import type * as track from "../track.ts";
 import { AnnounceInit, AnnounceOk, type AnnounceRequest, encodeAnnounceBroadcast } from "./announce.ts";
@@ -96,15 +97,11 @@ type FrameBounds = {
  *
  * The frame bounds qualify the start and end group only; every other group is served whole.
  * Which groups are served at all is the subscriber's read cursor (`startAt` / `endAt`),
- * applied when a group is popped rather than re-checked here: the serving loop prefetches,
- * so a group in hand has already left the buffer and rejecting it against a cap lowered in
- * the meantime would drop it for good, even if a later SUBSCRIBE_UPDATE raises the cap again.
+ * applied when a group is popped rather than re-checked here.
  *
- * Call this against the bounds the group was taken under, which is why the serving loop
- * snapshots it at the cursor handoff. Reading moved bounds here would map a group that now
- * matches neither boundary to the whole group and send frames the request excluded. Nothing
- * downstream trims those: a subscription's frame range is a wire request, deliberately
- * decoupled from the receiver's local read cursor (see `moq_net::Subscription::end`).
+ * The serving loop calls this synchronously after the pop, before any SUBSCRIBE_UPDATE can
+ * change `bounds`. Nothing downstream trims the frame range: it is a wire request,
+ * deliberately decoupled from the receiver's local read cursor.
  */
 function frameRange(bounds: FrameBounds, sequence: number): { start: number; end?: number } {
 	return {
@@ -127,6 +124,74 @@ type ServeGroup = {
 
 /** What serving fetched frames needs beyond the group and destination stream. */
 type ServeFetch = Omit<ServeGroup, "sub">;
+
+type SubscriptionControl =
+	| { kind: "update"; update: SubscribeUpdate }
+	| { kind: "fin" }
+	| { kind: "closed" }
+	| { kind: "error"; error: Error };
+
+// Decodes control messages independently, but only queues them. The serving loop is the sole
+// owner of the track cursor and frame bounds, so decoding can never mutate either between a
+// synchronous group pop and its frame-range snapshot.
+class SubscriptionControls {
+	#pending: SubscriptionControl[] = [];
+	#changed = new Signal(0);
+	readonly decoding: Promise<void>;
+
+	constructor(reader: Reader, writer: Writer, version: Version) {
+		this.decoding = this.#decode(reader, version);
+		void writer.closed.then(
+			() => this.#push({ kind: "closed" }),
+			(err: unknown) => this.#push({ kind: "error", error: error(err) }),
+		);
+	}
+
+	take(): SubscriptionControl | undefined {
+		return this.#pending.shift();
+	}
+
+	changed(fn: () => void): Dispose {
+		return this.#changed.changed(fn);
+	}
+
+	#push(control: SubscriptionControl) {
+		this.#pending.push(control);
+		this.#changed.update((value) => value + 1);
+	}
+
+	async #decode(reader: Reader, version: Version) {
+		try {
+			for (;;) {
+				const update = await SubscribeUpdate.decodeMaybe(reader, version);
+				if (!update) {
+					this.#push({ kind: "fin" });
+					return;
+				}
+				this.#push({ kind: "update", update });
+			}
+		} catch (err: unknown) {
+			this.#push({ kind: "error", error: error(err) });
+		}
+	}
+}
+
+// Register both readiness sources in the same turn after the caller observed neither ready.
+// The winner disposes both one-shot registrations, so an idle subscription keeps only two
+// listeners no matter how many times it wakes.
+function waitForSubscription(controls: SubscriptionControls, subscriber: track.Subscriber): Promise<void> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const dispose: Dispose[] = [];
+		const wake = () => {
+			if (settled) return;
+			settled = true;
+			for (const close of dispose) close();
+			resolve();
+		};
+		dispose.push(controls.changed(wake), hooks.groupChanged(subscriber, wake));
+	});
+}
 
 /**
  * Handles publishing broadcasts and managing their lifecycle.
@@ -329,19 +394,11 @@ export class Publisher {
 		if (startGroup !== undefined) track.startAt(startGroup);
 		track.endAt(msg.endGroup);
 
-		// Frame bounds qualify the start and end group only, and SUBSCRIBE_UPDATE can move
-		// them, so the serving loop reads them from here rather than closing over `msg`.
-		const bounds: FrameBounds = {
-			startGroup: msg.startGroup,
-			startFrame: msg.startFrame,
-			endGroup: msg.endGroup,
-			endFrame: msg.endFrame,
-		};
-
 		// The best-effort datagram loop, started once serving begins. It parks when the
 		// track finishes (recvDatagram returns undefined), so #runTrack alone ends the
 		// subscription; awaited during teardown so it doesn't outlive the subscription.
 		let datagrams = Promise.resolve();
+		let controls: SubscriptionControls | undefined;
 
 		try {
 			let timescale: Timescale = Timescale.MILLI;
@@ -372,54 +429,36 @@ export class Publisher {
 
 			console.debug(`publish ok: broadcast=${msg.broadcast} track=${track.name}`);
 
-			const serving = this.#runTrack(track, stream.writer, {
-				sub: msg.id,
-				broadcast: msg.broadcast,
-				timescale,
-				bounds,
-			});
-
 			// Serve datagrams concurrently with groups whenever the transport carries them
 			// (the writer exists iff so). No group fallback: otherwise they simply aren't sent.
 			if (this.#datagramWriter) {
 				datagrams = this.#runDatagrams(msg.id, track, timescale);
 			}
 
-			for (;;) {
-				const decode = SubscribeUpdate.decodeMaybe(stream.reader, this.version);
-
-				const result = await Promise.any([serving, decode]);
-				if (!result) break;
-
-				if (result instanceof SubscribeUpdate) {
-					console.debug(`subscribe update: broadcast=${msg.broadcast} track=${track.name}`);
-					track.update({
-						priority: result.priority,
-						ordered: result.ordered,
-						latencyMax: result.latencyMax,
-						startGroup: result.startGroup,
-						endGroup: result.endGroup,
-					});
-					if (result.startGroup !== undefined) track.startAt(result.startGroup);
-					track.endAt(result.endGroup);
-					bounds.startGroup = result.startGroup;
-					bounds.startFrame = result.startFrame;
-					bounds.endGroup = result.endGroup;
-					bounds.endFrame = result.endFrame;
-				}
-			}
+			controls = new SubscriptionControls(stream.reader, stream.writer, this.version);
+			await this.#runTrack(track, stream.writer, controls, {
+				sub: msg.id,
+				broadcast: msg.broadcast,
+				timescale,
+				bounds: {
+					startGroup: msg.startGroup,
+					startFrame: msg.startFrame,
+					endGroup: msg.endGroup,
+					endFrame: msg.endFrame,
+				},
+			});
 
 			console.debug(`publish done: broadcast=${msg.broadcast} track=${track.name}`);
 			stream.close();
 			track.close();
-			// track.close ends the datagram loop; wait so it doesn't leak past teardown.
-			await datagrams;
+			// Closing the stream ends the decoder and track.close ends the datagram loop.
+			await Promise.all([datagrams, controls.decoding]);
 		} catch (err: unknown) {
 			const e = error(err);
 			console.warn(`publish error: broadcast=${msg.broadcast} track=${track.name} error=${reason(e)}`);
 			track.close(e);
 			stream.abort(e);
-			await datagrams;
+			await Promise.all([datagrams, controls?.decoding]);
 		}
 	}
 
@@ -480,6 +519,7 @@ export class Publisher {
 	async #runTrack(
 		track: track.Subscriber,
 		stream: Writer,
+		controls: SubscriptionControls,
 		serving: { sub: bigint; broadcast: Path.Valid; timescale: Timescale; bounds: FrameBounds },
 	) {
 		const { sub, broadcast, timescale, bounds } = serving;
@@ -496,19 +536,6 @@ export class Publisher {
 		// before the producer declared it.
 		const boundary = () => track.final() ?? (track.latest() ?? -1) + 1;
 
-		// Settles once the producer closes cleanly, so SUBSCRIBE_END can go out while
-		// groups parked above the subscription's cap stay servable (a SUBSCRIBE_UPDATE
-		// can still raise it; see the Rust publisher's Recv::Boundary). Rejects on abort,
-		// which the catch below turns into a reset.
-		const doneSentinel = Symbol("done");
-		const done = (async (): Promise<typeof doneSentinel> => {
-			const closed = await track.closed;
-			if (closed instanceof Error) throw closed;
-			return doneSentinel;
-		})();
-		// The loop can exit on the peer's FIN before an abort settles this; keep it quiet.
-		void done.catch(() => {});
-
 		// One ranking for the whole subscription, shared by every group it serves.
 		const priority = new Priority(track);
 
@@ -520,70 +547,71 @@ export class Publisher {
 		const unsubscribed = new Promise<void>((resolve) => {
 			unsubscribe = resolve;
 		});
-		void stream.closed.then(
-			() => {
-				if (!finished) unsubscribe();
-			},
-			// A reset is always the peer.
-			() => unsubscribe(),
-		);
-
-		// Exactly-once serving, not the sequence cursor: on a relay, a burst can be
-		// ingested micro-reordered by the upstream leg, and a sequence cursor would
-		// permanently skip the older group even though it is cached and in demand.
-		// Staleness is the latency window's job (cache expiry), not arrival order's.
-		//
-		// One read cursor across iterations: a boundary emission must not spawn a
-		// second concurrent recvGroup against the same subscriber. Declared outside the
-		// try so the finally can observe whatever was in flight when the loop exited
-		// (closing a late group, swallowing the rejection from our own teardown abort).
-		//
-		// Snapshot the frame bounds as the cursor hands the group over, rather than reading
-		// them in the loop body, which can sit parked in a control-stream write long after the
-		// group left the buffer. Reading `bounds` there serves the group under a range it was
-		// never taken under.
-		//
-		// That narrows the window to the microtask between `recvGroup` removing the group and
-		// this callback, but does not close it: a SUBSCRIBE_UPDATE whose bytes are already
-		// buffered decodes without another transport read, so its continuation can still land
-		// in between. Closing it means handing the bounds back with the group, or the two
-		// loops not sharing mutable state at all.
-		const take = () =>
-			track
-				.recvGroup()
-				.then((group) => (group ? { group, range: frameRange(bounds, group.sequence) } : undefined));
-		let next = take();
 		try {
 			for (;;) {
-				const result = await Promise.race(endSent ? [next, stream.closed] : [next, stream.closed, done]);
-				if (result === doneSentinel) {
-					// The producer finished: declare the boundary now and keep serving
-					// whatever a later cap raise releases, until the peer FINs.
-					endSent = true;
-					if (emitRange) {
-						await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
+				// Drain every ready control before touching data. The decoder only queues, so
+				// applying the update and popping/positioning a group below cannot interleave.
+				const control = controls.take();
+				if (control) {
+					switch (control.kind) {
+						case "fin":
+						case "closed":
+							return;
+						case "error":
+							throw control.error;
+						case "update": {
+							const update = control.update;
+							console.debug(`subscribe update: broadcast=${broadcast} track=${track.name}`);
+							track.update({
+								priority: update.priority,
+								ordered: update.ordered,
+								latencyMax: update.latencyMax,
+								startGroup: update.startGroup,
+								endGroup: update.endGroup,
+							});
+							if (update.startGroup !== undefined) track.startAt(update.startGroup);
+							track.endAt(update.endGroup);
+							bounds.startGroup = update.startGroup;
+							bounds.startFrame = update.startFrame;
+							bounds.endGroup = update.endGroup;
+							bounds.endFrame = update.endFrame;
+							continue;
+						}
 					}
+				}
+
+				// Exactly-once arrival-order serving. This synchronous package-internal pop
+				// and frameRange call are the operation's linearization point.
+				const result = hooks.tryRecvGroup(track);
+				if (result instanceof Error) throw result;
+				if (result === null) {
+					if (!endSent) {
+						endSent = true;
+						if (emitRange) {
+							await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
+						}
+						continue;
+					}
+					finished = true;
+					return;
+				}
+
+				if (!result) {
+					// A cleanly finished producer can still hold groups above the cap. Declare
+					// its boundary now, then wait for an update to make those groups readable.
+					if (!endSent && track.closed.peek() === null) {
+						endSent = true;
+						if (emitRange) {
+							await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
+						}
+						continue;
+					}
+					await waitForSubscription(controls, track);
 					continue;
 				}
 
-				if (!result) break;
-				const { group, range } = result;
-				next = take();
-
-				// The floor is judged against the bounds as they stand now, deliberately unlike
-				// the rest of the frame range, which is the snapshot this group was taken under.
-				// Raising the floor is destructive: the read cursor shifts and closes every
-				// buffered group below it, so an in-hand group below the new floor must also go.
-				// When the new floor lands within this group, intersect it with the snapshotted
-				// start so neither a raised nor a subsequently lowered floor widens what is sent.
-				// Lowering the cap only parks its groups, which is why the cap does not reject here.
-				if (bounds.startGroup !== undefined && group.sequence < bounds.startGroup) {
-					group.close();
-					continue;
-				}
-				if (bounds.startGroup === group.sequence) {
-					range.start = Math.max(range.start, bounds.startFrame);
-				}
+				const group = result;
+				const range = frameRange(bounds, group.sequence);
 
 				if (emitRange && !startSent) {
 					startSent = true;
@@ -604,23 +632,8 @@ export class Publisher {
 					end: range.end,
 				});
 			}
-
-			if (emitRange && !endSent) {
-				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
-			}
-
-			console.debug(`publish close: broadcast=${broadcast} track=${track.name}`);
-			finished = true;
-			track.close();
-			stream.close();
-		} catch (err: unknown) {
-			const e = error(err);
-			console.warn(`publish error: broadcast=${broadcast} track=${track.name} error=${reason(e)}`);
-			unsubscribe();
-			track.close(e);
-			stream.reset(e);
 		} finally {
-			next.then((taken) => taken?.group.close()).catch(() => {});
+			if (!finished) unsubscribe();
 			priority.close();
 		}
 	}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -135,18 +135,20 @@ type Control =
 	| { kind: "error"; error: Error };
 
 /**
- * The subscribe stream's control half, decoded into a single-message slot.
+ * The subscribe stream's control half, decoded ahead of the serving loop into a queue.
  *
- * Decoding runs on its own, but only ever fills the slot: the serving loop owns the track
- * cursor and the frame bounds, so nothing here may apply an update itself. That is what keeps
- * a group pop and its frame-range snapshot one indivisible step.
+ * Decoding runs on its own, but only ever queues: the serving loop owns the track cursor and
+ * the frame bounds, so nothing here may apply an update itself. That is what keeps a group pop
+ * and its frame-range snapshot one indivisible step.
  *
- * One message in flight rather than a queue, so a peer that floods SUBSCRIBE_UPDATE while the
- * loop is parked in a write backs up in QUIC flow control instead of on our heap. It also
- * matches the Rust publisher, which decodes one message per poll.
+ * Reading ahead is what makes control-first ordering hold for a burst. The loop drains this
+ * queue synchronously, so it cannot yield to the decoder between two controls: anything not
+ * already decoded when the loop resumes would land after the next pop instead of before it.
+ * The Rust publisher gets the same property from `poll_decode_maybe`, which decodes straight
+ * out of the reader's buffer; nothing here can decode synchronously, so it reads ahead instead.
  */
 class SubscriptionControls {
-	#update?: SubscribeUpdate;
+	#updates: SubscribeUpdate[] = [];
 	// Sticky, first one wins: null once the stream is over, an Error once it failed.
 	#end?: Error | null;
 	#changed = new Signal(0);
@@ -157,8 +159,7 @@ class SubscriptionControls {
 	constructor(reader: Reader, writer: Writer, version: Version) {
 		this.decoding = this.#decode(reader, version);
 		// Our own half going away ends the loop too, and has to reach it the same way: the
-		// loop looks at nothing else. This is also what releases a decoder parked on a full
-		// slot during teardown, which closing the reader alone would leave stuck.
+		// loop looks at nothing else.
 		void writer.closed.then(
 			() => this.#finish(null),
 			(err: unknown) => this.#finish(error(err)),
@@ -167,14 +168,10 @@ class SubscriptionControls {
 
 	/** The next control to apply, or undefined while the peer is quiet. */
 	take(): Control | undefined {
-		const update = this.#update;
-		if (update) {
-			// An update decoded before the stream ended still applies. `#end` is sticky, so
-			// the next call reports it.
-			this.#update = undefined;
-			this.#wake();
-			return { kind: "update", update };
-		}
+		const update = this.#updates.shift();
+		// An update decoded before the stream ended still applies, so the queue drains first.
+		// `#end` is sticky, so it is still there once the queue is empty.
+		if (update) return { kind: "update", update };
 		if (this.#end === undefined) return undefined;
 		return this.#end === null ? { kind: "done" } : { kind: "error", error: this.#end };
 	}
@@ -187,26 +184,16 @@ class SubscriptionControls {
 	#finish(end: Error | null) {
 		if (this.#end !== undefined) return;
 		this.#end = end;
-		this.#wake();
-	}
-
-	#wake() {
 		this.#changed.update((value) => value + 1);
 	}
 
 	async #decode(reader: Reader, version: Version) {
 		try {
 			while (this.#end === undefined) {
-				// Hold the decoded update until the loop takes it, rather than reading ahead.
-				if (this.#update) {
-					await this.#changed.changed();
-					continue;
-				}
-
 				const update = await SubscribeUpdate.decodeMaybe(reader, version);
 				if (!update) break;
-				this.#update = update;
-				this.#wake();
+				this.#updates.push(update);
+				this.#changed.update((value) => value + 1);
 			}
 		} catch (err: unknown) {
 			this.#finish(error(err));
@@ -492,7 +479,6 @@ export class Publisher {
 			stream.close();
 			track.close();
 			// Closing the stream ends the decoder and track.close ends the datagram loop.
-			// Both halves settle, so a decoder parked on an untaken update unwinds too.
 			await Promise.all([datagrams, controls.decoding]);
 		} catch (err: unknown) {
 			const e = error(err);
@@ -600,10 +586,10 @@ export class Publisher {
 		});
 		try {
 			for (;;) {
-				// Control before data, matching the Rust publisher: an update decoded while the
-				// loop was parked applies to the next pop, never to one already made. The
-				// decoder only fills a slot, so nothing here can land between the pop below and
-				// its frame range.
+				// Control before data, matching the Rust publisher: every control decoded while
+				// the loop was parked applies to the next pop, never to one already made. This
+				// drain is synchronous, so nothing the decoder holds can land between the pop
+				// below and its frame range.
 				const control = controls.take();
 				if (control) {
 					switch (control.kind) {

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -125,60 +125,100 @@ type ServeGroup = {
 /** What serving fetched frames needs beyond the group and destination stream. */
 type ServeFetch = Omit<ServeGroup, "sub">;
 
-type SubscriptionControl =
+/** What the serving loop takes from the subscribe stream instead of serving a group. */
+type Control =
+	/** The peer re-stated the subscription: priority, ordering, latency, and both ranges. */
 	| { kind: "update"; update: SubscribeUpdate }
-	| { kind: "fin" }
-	| { kind: "closed" }
+	/** The peer FIN'd, or our own half went away. Either way there is nobody left to serve. */
+	| { kind: "done" }
+	/** The stream failed; the subscription goes down with it. */
 	| { kind: "error"; error: Error };
 
-// Decodes control messages independently, but only queues them. The serving loop is the sole
-// owner of the track cursor and frame bounds, so decoding can never mutate either between a
-// synchronous group pop and its frame-range snapshot.
+/**
+ * The subscribe stream's control half, decoded into a single-message slot.
+ *
+ * Decoding runs on its own, but only ever fills the slot: the serving loop owns the track
+ * cursor and the frame bounds, so nothing here may apply an update itself. That is what keeps
+ * a group pop and its frame-range snapshot one indivisible step.
+ *
+ * One message in flight rather than a queue, so a peer that floods SUBSCRIBE_UPDATE while the
+ * loop is parked in a write backs up in QUIC flow control instead of on our heap. It also
+ * matches the Rust publisher, which decodes one message per poll.
+ */
 class SubscriptionControls {
-	#pending: SubscriptionControl[] = [];
+	#update?: SubscribeUpdate;
+	// Sticky, first one wins: null once the stream is over, an Error once it failed.
+	#end?: Error | null;
 	#changed = new Signal(0);
+
+	/** Settles once decoding stops, so teardown can wait for it rather than leaving it running. */
 	readonly decoding: Promise<void>;
 
 	constructor(reader: Reader, writer: Writer, version: Version) {
 		this.decoding = this.#decode(reader, version);
+		// Our own half going away ends the loop too, and has to reach it the same way: the
+		// loop looks at nothing else. This is also what releases a decoder parked on a full
+		// slot during teardown, which closing the reader alone would leave stuck.
 		void writer.closed.then(
-			() => this.#push({ kind: "closed" }),
-			(err: unknown) => this.#push({ kind: "error", error: error(err) }),
+			() => this.#finish(null),
+			(err: unknown) => this.#finish(error(err)),
 		);
 	}
 
-	take(): SubscriptionControl | undefined {
-		return this.#pending.shift();
+	/** The next control to apply, or undefined while the peer is quiet. */
+	take(): Control | undefined {
+		const update = this.#update;
+		if (update) {
+			// An update decoded before the stream ended still applies. `#end` is sticky, so
+			// the next call reports it.
+			this.#update = undefined;
+			this.#wake();
+			return { kind: "update", update };
+		}
+		if (this.#end === undefined) return undefined;
+		return this.#end === null ? { kind: "done" } : { kind: "error", error: this.#end };
 	}
 
+	/** Calls `fn` once {@link take} may answer differently. */
 	changed(fn: () => void): Dispose {
 		return this.#changed.changed(fn);
 	}
 
-	#push(control: SubscriptionControl) {
-		this.#pending.push(control);
+	#finish(end: Error | null) {
+		if (this.#end !== undefined) return;
+		this.#end = end;
+		this.#wake();
+	}
+
+	#wake() {
 		this.#changed.update((value) => value + 1);
 	}
 
 	async #decode(reader: Reader, version: Version) {
 		try {
-			for (;;) {
-				const update = await SubscribeUpdate.decodeMaybe(reader, version);
-				if (!update) {
-					this.#push({ kind: "fin" });
-					return;
+			while (this.#end === undefined) {
+				// Hold the decoded update until the loop takes it, rather than reading ahead.
+				if (this.#update) {
+					await this.#changed.changed();
+					continue;
 				}
-				this.#push({ kind: "update", update });
+
+				const update = await SubscribeUpdate.decodeMaybe(reader, version);
+				if (!update) break;
+				this.#update = update;
+				this.#wake();
 			}
 		} catch (err: unknown) {
-			this.#push({ kind: "error", error: error(err) });
+			this.#finish(error(err));
+			return;
 		}
+		this.#finish(null);
 	}
 }
 
 // Register both readiness sources in the same turn after the caller observed neither ready.
-// The winner disposes both one-shot registrations, so an idle subscription keeps only two
-// listeners no matter how many times it wakes.
+// The winner disposes both registrations, so an idle subscription accumulates nothing no
+// matter how many times it wakes.
 function waitForSubscription(controls: SubscriptionControls, subscriber: track.Subscriber): Promise<void> {
 	return new Promise((resolve) => {
 		let settled = false;
@@ -452,6 +492,7 @@ export class Publisher {
 			stream.close();
 			track.close();
 			// Closing the stream ends the decoder and track.close ends the datagram loop.
+			// Both halves settle, so a decoder parked on an untaken update unwinds too.
 			await Promise.all([datagrams, controls.decoding]);
 		} catch (err: unknown) {
 			const e = error(err);
@@ -536,12 +577,22 @@ export class Publisher {
 		// before the producer declared it.
 		const boundary = () => track.final() ?? (track.latest() ?? -1) + 1;
 
+		// SUBSCRIBE_END names that boundary, which a cap can hold groups back from, so it goes
+		// out as soon as the producer finishes and the subscription keeps serving whatever a
+		// later cap raise releases (see the Rust publisher's Recv::Boundary).
+		const sendEnd = async () => {
+			endSent = true;
+			if (emitRange) {
+				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
+			}
+		};
+
 		// One ranking for the whole subscription, shared by every group it serves.
 		const priority = new Priority(track);
 
 		// Cancels groups still queued for a stream slot. Only the subscriber leaving counts:
-		// a track that ran out of groups still has to flush the ones already queued, and we
-		// FIN the subscribe stream ourselves below to say so.
+		// a track that ran out of groups still has to flush the ones already queued, and the
+		// caller FINs the subscribe stream to say so.
 		let finished = false;
 		let unsubscribe!: () => void;
 		const unsubscribed = new Promise<void>((resolve) => {
@@ -549,13 +600,16 @@ export class Publisher {
 		});
 		try {
 			for (;;) {
-				// Drain every ready control before touching data. The decoder only queues, so
-				// applying the update and popping/positioning a group below cannot interleave.
+				// Control before data, matching the Rust publisher: an update decoded while the
+				// loop was parked applies to the next pop, never to one already made. The
+				// decoder only fills a slot, so nothing here can land between the pop below and
+				// its frame range.
 				const control = controls.take();
 				if (control) {
 					switch (control.kind) {
-						case "fin":
-						case "closed":
+						case "done":
+							// The subscriber left. Its queued groups are pointless now, which
+							// the finally below acts on since `finished` stays false.
 							return;
 						case "error":
 							throw control.error;
@@ -582,35 +636,32 @@ export class Publisher {
 
 				// Exactly-once arrival-order serving. This synchronous package-internal pop
 				// and frameRange call are the operation's linearization point.
-				const result = hooks.tryRecvGroup(track);
-				if (result instanceof Error) throw result;
-				if (result === null) {
-					if (!endSent) {
-						endSent = true;
-						if (emitRange) {
-							await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
-						}
+				const recv = hooks.tryRecvGroup(track);
+				switch (recv.kind) {
+					case "error":
+						throw recv.error;
+					case "idle":
+						await waitForSubscription(controls, track);
 						continue;
-					}
-					finished = true;
-					return;
+					case "boundary":
+						// The producer finished but is still holding groups above the cap.
+						// Declare the boundary, then wait for an update to release them.
+						if (!endSent) {
+							await sendEnd();
+							continue;
+						}
+						await waitForSubscription(controls, track);
+						continue;
+					case "done":
+						if (!endSent) {
+							await sendEnd();
+							continue;
+						}
+						finished = true;
+						return;
 				}
 
-				if (!result) {
-					// A cleanly finished producer can still hold groups above the cap. Declare
-					// its boundary now, then wait for an update to make those groups readable.
-					if (!endSent && track.closed.peek() === null) {
-						endSent = true;
-						if (emitRange) {
-							await encodeSubscribeResponse(stream, { end: new SubscribeEnd(boundary()) }, this.version);
-						}
-						continue;
-					}
-					await waitForSubscription(controls, track);
-					continue;
-				}
-
-				const group = result;
+				const group = recv.group;
 				const range = frameRange(bounds, group.sequence);
 
 				if (emitRange && !startSent) {

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -3,7 +3,7 @@
  *
  * @module
  */
-import { type GetPromise, type Getter, Once, Signal } from "@moq/signals";
+import { type Dispose, type GetPromise, type Getter, Once, Signal } from "@moq/signals";
 import type { Datagram } from "./datagram.ts";
 import { type Frame, type Consumer as GroupConsumer, Producer as GroupProducer, Lagged } from "./group.ts";
 import { hooks } from "./internal.ts";
@@ -651,6 +651,8 @@ export class Subscriber {
 
 	static {
 		makeSubscriber = (name, state) => new Subscriber(name, state);
+		hooks.tryRecvGroup = (subscriber) => subscriber.#tryRecvGroup();
+		hooks.groupChanged = (subscriber, fn) => subscriber.#groupChanged(fn);
 	}
 
 	/**
@@ -730,26 +732,45 @@ export class Subscriber {
 	 */
 	async recvGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
-			const groups = this.#state.groups.peek();
-			const { start, end } = this.#cursor.peek();
-			while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
-
-			// The buffer is sequence-sorted, so an in-range group that arrives behind a
-			// beyond-cap one sorts in front of it and is never blocked by it.
-			const group = groups[0];
-			if (group && (end === undefined || group.sequence <= end)) {
-				groups.shift();
-				return group;
-			}
-
-			const closed = this.#state.closed.peek();
-			if (closed instanceof Error) throw closed;
-			// A group beyond the cap outlives a clean close: it becomes deliverable if
-			// the cap rises, so the track isn't over while any are held.
-			if (closed !== undefined && !group) return undefined;
+			const result = this.#tryRecvGroup();
+			if (result instanceof Error) throw result;
+			if (result === null) return undefined;
+			if (result) return result;
 
 			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}
+	}
+
+	// Package-internal synchronous half of recvGroup. The lite publisher uses this so applying
+	// control state, popping the group, and positioning its frames are one JavaScript turn.
+	#tryRecvGroup(): GroupConsumer | Error | null | undefined {
+		const groups = this.#state.groups.peek();
+		const { start, end } = this.#cursor.peek();
+		while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
+
+		// The buffer is sequence-sorted, so an in-range group that arrives behind a
+		// beyond-cap one sorts in front of it and is never blocked by it.
+		const group = groups[0];
+		if (group && (end === undefined || group.sequence <= end)) {
+			groups.shift();
+			return group;
+		}
+
+		const closed = this.#state.closed.peek();
+		if (closed instanceof Error) return closed;
+		// A group beyond the cap outlives a clean close: it becomes deliverable if
+		// the cap rises, so the track isn't over while any are held.
+		if (closed !== undefined && !group) return null;
+		return undefined;
+	}
+
+	// Package-internal readiness half of recvGroup. Each registration fires at most once, and
+	// the caller disposes the two losers after whichever source wakes it.
+	#groupChanged(fn: () => void): Dispose {
+		const dispose = [this.#state.groups.changed(fn), this.#cursor.changed(fn), this.#state.closed.changed(fn)];
+		return () => {
+			for (const close of dispose) close();
+		};
 	}
 
 	/**

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -6,7 +6,7 @@
 import { type Dispose, type GetPromise, type Getter, Once, Signal } from "@moq/signals";
 import type { Datagram } from "./datagram.ts";
 import { type Frame, type Consumer as GroupConsumer, Producer as GroupProducer, Lagged } from "./group.ts";
-import { hooks } from "./internal.ts";
+import { hooks, type Recv } from "./internal.ts";
 import { Timescale, type Timestamp } from "./time.ts";
 
 export type { Datagram } from "./datagram.ts";
@@ -732,18 +732,24 @@ export class Subscriber {
 	 */
 	async recvGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
-			const result = this.#tryRecvGroup();
-			if (result instanceof Error) throw result;
-			if (result === null) return undefined;
-			if (result) return result;
+			const recv = this.#tryRecvGroup();
+			switch (recv.kind) {
+				case "group":
+					return recv.group;
+				case "done":
+					return undefined;
+				case "error":
+					throw recv.error;
+			}
 
+			// Idle, or parked at the boundary waiting for the cap to rise.
 			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}
 	}
 
 	// Package-internal synchronous half of recvGroup. The lite publisher uses this so applying
 	// control state, popping the group, and positioning its frames are one JavaScript turn.
-	#tryRecvGroup(): GroupConsumer | Error | null | undefined {
+	#tryRecvGroup(): Recv {
 		const groups = this.#state.groups.peek();
 		const { start, end } = this.#cursor.peek();
 		while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
@@ -753,19 +759,19 @@ export class Subscriber {
 		const group = groups[0];
 		if (group && (end === undefined || group.sequence <= end)) {
 			groups.shift();
-			return group;
+			return { kind: "group", group };
 		}
 
 		const closed = this.#state.closed.peek();
-		if (closed instanceof Error) return closed;
+		if (closed instanceof Error) return { kind: "error", error: closed };
+		if (closed === undefined) return { kind: "idle" };
 		// A group beyond the cap outlives a clean close: it becomes deliverable if
 		// the cap rises, so the track isn't over while any are held.
-		if (closed !== undefined && !group) return null;
-		return undefined;
+		return group ? { kind: "boundary" } : { kind: "done" };
 	}
 
 	// Package-internal readiness half of recvGroup. Each registration fires at most once, and
-	// the caller disposes the two losers after whichever source wakes it.
+	// the caller disposes the losers after whichever source wakes it.
 	#groupChanged(fn: () => void): Dispose {
 		const dispose = [this.#state.groups.changed(fn), this.#cursor.changed(fn), this.#state.closed.changed(fn)];
 		return () => {


### PR DESCRIPTION
## Summary

- serialize `SUBSCRIBE_UPDATE` range handling and cap-aware group reads under one publisher state owner
- make the group pop and frame-range snapshot one synchronous operation, closing the residual microtask race from #2808
- coalesce decoded full-state range updates into one latest-wins slot so a blocked writer cannot grow publisher memory without bound
- publish each full subscription update immediately so priority, ordering, and latency changes re-rank in-flight streams under response backpressure
- race `SUBSCRIBE_START` and `SUBSCRIBE_END` writes against control termination so peer FIN detaches a blocked subscription
- reset the writable half when control termination wins so the losing blocked encode cannot retain transport resources
- yield one task after applying local range state so newer buffered controls or FIN are observed before another group pop

## Root cause

`recvGroup()` removed a buffered group synchronously, but the publisher snapshotted mutable frame bounds in a later promise job. A buffered `SUBSCRIBE_UPDATE` could run between those steps and serve the group under bounds it was never taken under.

The independent decoder also retained every decoded update while the serving loop was blocked on a write. Since each update restates the full subscription, retaining only the newest pending local range state preserves control-first serving while bounding memory.

Applying one local range update could still wake the serving loop and synchronously drain another buffered group before the decoder completed its next already-delivered framed message. A task boundary on the update path gives the decoder time to publish newer control state before the next pop without adding scheduling cost to normal group delivery.

Response backpressure exposed three further ownership issues. Delaying the whole update behind a blocked response prevented the priority listener from re-ranking group streams when congestion made it most important. Separating immediate full subscription publication from serialized local cursor and frame-bound mutation preserves both behaviors. A peer FIN also could not unblock the independent response half, so response writes now race the decoder's sticky terminal state and release the subscription as soon as the subscriber leaves. Because `Promise.race` does not cancel its losing promise, termination also resets the writable half so the blocked encode and transport stream cannot remain retained.

## Public API changes

None. The synchronous group receive, readiness hooks, and control coordination are package-internal.

## Test plan

- `nix develop --command just check`
- `nix develop --command just test`
- focused publisher and integration tests covering control-before-pop, pop-before-control, latest-wins range coalescing, a newer buffered update tightening the cap before a group backlog drains, scheduling updates during a blocked response, peer FIN interrupting blocked `SUBSCRIBE_START`, and reset of the abandoned response write

Closes #2808.

(Written by GPT-5)