### PR TITLE
chore: bump non-Rust package versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.9.8",
@@ -182,7 +182,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",
@@ -202,7 +202,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/net": "workspace:^",
@@ -220,7 +220,7 @@
     },
     "js/signals": {
       "name": "@moq/signals",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "devDependencies": {
         "@types/bun": "^1.3.11",
         "@types/react": "^19.2.18",
@@ -265,7 +265,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/msf": "workspace:^",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.4.3",
+	"version": "0.4.4",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/signals",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/py/moq-rs/pyproject.toml
+++ b/py/moq-rs/pyproject.toml
@@ -14,7 +14,7 @@ name = "moq-rs"
 # isn't already there (no tag needed; the registry is the gate).
 # Starts at 0.3.0 to open a new line above the old lockstep 0.2.x releases that
 # bundled the bindings.
-version = "0.4.3"
+version = "0.4.4"
 description = "Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization, with a Pythonic API. Import as `moq`."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ source = { editable = "py/moq-ffi" }
 
 [[package]]
 name = "moq-rs"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "py/moq-rs" }
 dependencies = [
     { name = "moq-ffi" },


### PR DESCRIPTION
## Summary

- Bump `@moq/hang` to 0.3.5, `@moq/net` to 0.2.8, `@moq/publish` to 0.4.4, `@moq/signals` to 0.2.2, and `@moq/watch` to 0.4.6 for their unreleased additive APIs and consumer-visible fixes.
- Bump `moq-rs` to 0.4.4 for the additive request path/query accessors and its `moq-ffi ~= 0.3.10` floor.
- Keep the JavaScript and Python workspace lockfiles aligned. Swift and Kotlin only had non-shipping changes; Go keeps its human-owned `MAJOR.MINOR` line because CI derives patch releases.

## Public API changes

This PR only changes release versions. The releases carry previously landed additive APIs, including hang media-track retention helpers, publish retention configuration, and Python request path/query accessors. There are no breaking API changes.

## Test plan

- `just fix`
- `just js check`
- `just test`
- `uv lock --check`
- `uv build --package moq-rs`
- Verified the built wheel reports `moq-rs 0.4.4` and `moq-ffi~=0.3.10`

The host `just check` package, type, build, Pyright, and Sphinx phases passed. Its final workflow-coverage script is deferred to CI because host Bun 1.2.23 misparses the existing `apt-repo.yml` `on:` mapping; the pinned Nix environment did not finish realizing locally.

(Written by GPT-5)