### PR TITLE
feat(mux): carry EIT present/following through a TS round-trip

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -519,8 +519,13 @@ The service layer rides the same `mpegts` section. The program identity
 rebuild a matching PAT/PMT, while the standalone SI tables (SDT, NIT) are carried as
 opaque sections and re-emitted byte-for-byte on their original PIDs, each at its own
 repetition interval. So the service name, provider, type, and network survive the
-round-trip without being parsed. Regenerated tables (TDT/TOT) and EPG (EIT) are not
-captured: they are live or bulky rather than static identity.
+round-trip without being parsed. Present/following EPG (EIT p/f) rides along too, so
+"now" and "next" survive, but the full EIT schedule does not: the catalog is republished
+whole on every change, which suits a table that is small and revised rarely rather than
+an eight-day listing whose edges churn continuously. Regenerated tables (TDT/TOT) are
+left out for the opposite reason, that every section is new content rather than a
+repetition, and an exporter's own clock beats a time relayed from an upstream
+multiplexer of unknown delay.
 
 ### FLV
 

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -519,13 +519,14 @@ The service layer rides the same `mpegts` section. The program identity
 rebuild a matching PAT/PMT, while the standalone SI tables (SDT, NIT) are carried as
 opaque sections and re-emitted byte-for-byte on their original PIDs, each at its own
 repetition interval. So the service name, provider, type, and network survive the
-round-trip without being parsed. Present/following EPG (EIT p/f) rides along too, so
-"now" and "next" survive, but the full EIT schedule does not: the catalog is republished
-whole on every change, which suits a table that is small and revised rarely rather than
-an eight-day listing whose edges churn continuously. Regenerated tables (TDT/TOT) are
-left out for the opposite reason, that every section is new content rather than a
-repetition, and an exporter's own clock beats a time relayed from an upstream
-multiplexer of unknown delay.
+round-trip without being parsed. Present/following EPG for this transport stream (EIT
+p/f actual) rides along too, so "now" and "next" survive. The full EIT schedule does not:
+the catalog is republished whole on every change, which suits a table that is small and
+revised rarely rather than an eight-day listing whose edges churn continuously. Neither
+does EIT for other multiplexes, whose sections a verbatim carriage keyed on the section
+header cannot tell apart. Regenerated tables (TDT/TOT) are left out for a different
+reason, that every section is new content rather than a repetition, and an exporter's own
+clock beats a time relayed from an upstream multiplexer of unknown delay.
 
 ### FLV
 

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -19,18 +19,97 @@ use serde_with::{DisplayFromStr, DurationMilliSeconds, serde_as};
 
 use crate::catalog::hang::CatalogExt;
 
-/// A standalone SI PID we capture, and how often export must re-emit it.
+/// Which of a PID's tables we capture.
+///
+/// A PID is usually all-or-nothing: the SDT PID also carries the BAT, and a table we
+/// have never heard of is as worth preserving as one we have, so [`Self::All`] is the
+/// default posture. [`Self::Only`] exists for a PID that carries tables with genuinely
+/// different carriage requirements, which so far is just the EIT PID.
+///
+/// Selecting on `table_id` does not make the sections any less opaque. The `table_id`
+/// is the first byte of every section under generic section syntax (ISO 13818-1), the
+/// same byte [`section_key`] already reads to dedupe: this narrows what we carry
+/// without widening what we claim to understand.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Tables {
+	/// Every section on the PID, whatever its `table_id`.
+	All,
+	/// Only sections whose `table_id` falls in one of these inclusive ranges.
+	Only(&'static [(u8, u8)]),
+}
+
+/// A standalone SI PID we capture: which of its tables, and how often export must
+/// re-emit them.
 ///
 /// Intervals are the DVB maximum repetition intervals (ETSI TS 101 211); export
 /// treats them as an upper bound, not the source's observed cadence, which is a
-/// property of that multiplexer's bitrate shaping and means nothing downstream.
-/// Adding a table here is a one-line change: the sections themselves are opaque.
-pub(super) const SI_PIDS: &[(u16, Duration)] = &[
+/// property of that multiplexer's bitrate shaping and means nothing downstream. A PID
+/// gets one interval because [`Si`] holds one, so a PID carrying several tables takes
+/// the tightest of them.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SiPid {
+	/// The PID these sections ride on.
+	pub pid: u16,
+
+	/// Which of the PID's tables to capture.
+	pub tables: Tables,
+
+	/// Maximum re-emit interval, recorded in [`Si::interval`] for export.
+	pub interval: Duration,
+}
+
+impl SiPid {
+	/// The entry for `pid`, or `None` if we capture nothing on it.
+	pub fn get(pid: u16) -> Option<&'static Self> {
+		SI_PIDS.iter().find(|si| si.pid == pid)
+	}
+
+	/// Whether a completed section on this PID is one we carry.
+	pub fn captures(&self, section: &[u8]) -> bool {
+		match self.tables {
+			Tables::All => true,
+			Tables::Only(ranges) => {
+				let table_id = section.first().copied().unwrap_or(0);
+				ranges.iter().any(|(first, last)| (*first..=*last).contains(&table_id))
+			}
+		}
+	}
+}
+
+/// The standalone SI PIDs we capture.
+pub(super) const SI_PIDS: &[SiPid] = &[
 	// NIT (network description): 10s.
-	(0x0010, Duration::from_secs(10)),
+	SiPid {
+		pid: 0x0010,
+		tables: Tables::All,
+		interval: Duration::from_secs(10),
+	},
 	// SDT and BAT (service and bouquet description): 2s for SDT Actual, the tightest
 	// of the two, so one interval per PID stays conservative.
-	(0x0011, Duration::from_secs(2)),
+	SiPid {
+		pid: 0x0011,
+		tables: Tables::All,
+		interval: Duration::from_secs(2),
+	},
+	// EIT present/following (0x4E actual, 0x4F other): 2s for actual, the tightest.
+	//
+	// This PID also carries EIT schedule (0x50..=0x6F), which is deliberately left out.
+	// The catalog is whole-state and republished on every change, so it suits a table
+	// that is small and revised rarely. p/f is exactly that: two sections per service,
+	// replaced on event transition. A full schedule is thousands of sections whose
+	// window edges churn as it rolls forward, and every subscriber would pay all of it
+	// at join, ahead of media. If it is ever wanted it belongs on its own track, the way
+	// SCTE-35 sections already ride one (see `SectionStream` in the import path).
+	SiPid {
+		pid: 0x0012,
+		tables: Tables::Only(&[(0x4E, 0x4F)]),
+		interval: Duration::from_secs(2),
+	},
+	// TDT/TOT (0x0014) is left out for the opposite reason: every section is new content
+	// rather than a repetition, so each one would be a catalog modification and a
+	// republish. It also has the least to gain from being relayed, since it carries
+	// nothing but "now", and an exporter's own clock is a better source than a value
+	// forwarded from an upstream multiplexer of unknown delay.
 ];
 
 /// The `mpegts` catalog section.

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -237,6 +237,21 @@ impl Si {
 	}
 }
 
+/// Whether a section is the version that applies now.
+///
+/// Generic section syntax again (ISO 13818-1), so this parses no table: a long-form
+/// section carries `current_next_indicator` in the low bit of byte 5, and a source may
+/// transmit the *next* version of a sub-table ahead of a version change with the bit
+/// clear. Those cannot be carried alongside the current version, because [`section_key`]
+/// identifies a section by `(table_id, table_id_extension, section_number)` and both
+/// versions share all three: they would replace each other on every repetition,
+/// republishing the catalog each cycle and exporting whichever landed last. A short-form
+/// section (TDT and friends) has no version and is always current.
+pub(super) fn is_current(section: &[u8]) -> bool {
+	let long_form = section.get(1).is_some_and(|b| b & 0x80 != 0);
+	!long_form || section.get(5).is_some_and(|b| b & 0x01 != 0)
+}
+
 /// Identify a section within its PID: `(table_id, table_id_extension, section_number)`.
 ///
 /// Generic section syntax (ISO 13818-1 / EN 300 468), not table-specific: a long-form

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -91,18 +91,28 @@ pub(super) const SI_PIDS: &[SiPid] = &[
 		tables: Tables::All,
 		interval: Duration::from_secs(2),
 	},
-	// EIT present/following (0x4E actual, 0x4F other): 2s for actual, the tightest.
+	// EIT present/following, actual transport stream only (0x4E): 2s.
 	//
-	// This PID also carries EIT schedule (0x50..=0x6F), which is deliberately left out.
-	// The catalog is whole-state and republished on every change, so it suits a table
-	// that is small and revised rarely. p/f is exactly that: two sections per service,
-	// replaced on event transition. A full schedule is thousands of sections whose
-	// window edges churn as it rolls forward, and every subscriber would pay all of it
-	// at join, ahead of media. If it is ever wanted it belongs on its own track, the way
-	// SCTE-35 sections already ride one (see `SectionStream` in the import path).
+	// Two other things ride this PID and are deliberately left out.
+	//
+	// EIT p/f *other* (0x4F) describes services in other multiplexes, and `section_key`
+	// cannot tell them apart. An EIT's `table_id_extension` is its `service_id`, which is
+	// only unique within a transport stream: the rest of the DVB triplet
+	// (`transport_stream_id`, `original_network_id`) sits at bytes 8..12, past the generic
+	// header. So two foreign services sharing a `service_id` would collide on one entry
+	// and overwrite each other every repetition. Telling them apart means parsing EIT
+	// specifically, which is a bigger break of section opacity than this is worth.
+	//
+	// EIT schedule (0x50..=0x6F) is a volume problem instead. The catalog is whole-state
+	// and republished on every change, so it suits a table that is small and revised
+	// rarely. p/f actual is exactly that: two sections per service, replaced on event
+	// transition. A full schedule is thousands of sections whose window edges churn as it
+	// rolls forward, and every subscriber would pay all of it at join, ahead of media. If
+	// it is ever wanted it belongs on its own track, the way SCTE-35 sections already ride
+	// one (see `SectionStream` in the import path).
 	SiPid {
 		pid: 0x0012,
-		tables: Tables::Only(&[(0x4E, 0x4F)]),
+		tables: Tables::Only(&[(0x4E, 0x4E)]),
 		interval: Duration::from_secs(2),
 	},
 	// TDT/TOT (0x0014) is left out for the opposite reason: every section is new content

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -196,6 +196,14 @@ pub struct Program {
 /// table we've never heard of all round-trip the same way. A PID carries a *set* of
 /// sections (a multi-service SDT is several, and the SDT PID also carries the BAT),
 /// so they are held together and replaced individually as each is re-signaled.
+///
+/// Only the version that applies now is carried. A section is identified by its
+/// `table_id`, `table_id_extension` and `section_number`, which is the generic header
+/// minus the version, so a pending version transmitted ahead of a change cannot be held
+/// alongside the current one and is dropped at import. Replacement being per-section also
+/// means a multi-section table changes version one section at a time, so a consumer can
+/// briefly observe a mix of the two. Both are consequences of the identity, not of the
+/// tables involved.
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1272,6 +1272,12 @@ fn make_section(table_id: u8, body: &[u8]) -> Vec<u8> {
 		(section_length & 0xff) as u8,
 	];
 	s.extend_from_slice(body);
+	// Byte 5 of a long-form section holds version_number + current_next_indicator. Set the
+	// indicator, so the section is the currently-applicable version a conformant
+	// multiplexer transmits; a test wanting the pending version clears it again.
+	if let Some(b) = s.get_mut(5) {
+		*b |= 0x01;
+	}
 	s.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
 	s
 }
@@ -1645,6 +1651,43 @@ fn tdt_is_not_captured() {
 		"control: the import gate ran"
 	);
 	assert!(!si.contains_key(&0x0014), "TDT is dropped at the import gate");
+}
+
+/// A multiplexer may transmit the *next* version of a sub-table alongside the current
+/// one, with `current_next_indicator` clear. The two differ only in byte 5, which
+/// `section_key` does not read, so carrying both would have them replace each other on
+/// every repetition: the catalog would republish each cycle and export would emit
+/// whichever landed last, which half the time is the version that does not apply yet.
+#[test]
+fn eit_pending_version_is_not_carried() {
+	// Same service_id (bytes 3..5) and section_number (byte 6); only the version differs.
+	let current = make_section(0x4E, &[0x00, 0x44, 0x0a, 0x00, 0x00, 0xaa, 0xaa, 0xaa]);
+	let mut pending = make_section(0x4E, &[0x00, 0x44, 0x0c, 0x00, 0x00, 0xbb, 0xbb, 0xbb]);
+	pending[5] &= !0x01;
+	assert_eq!(
+		section_key_of(&current),
+		section_key_of(&pending),
+		"the two versions must be indistinguishable to `section_key`, or this proves nothing"
+	);
+
+	// Two full cycles, so a collision shows up as the entry flipping between them.
+	let mut input = Vec::new();
+	for _ in 0..2 {
+		input.extend_from_slice(&si_packet(0x0012, &current));
+		input.extend_from_slice(&si_packet(0x0012, &pending));
+	}
+
+	assert_eq!(
+		import_si(&input).get(&0x0012).expect("an EIT entry").sections,
+		vec![Bytes::from(current)],
+		"only the currently-applicable version is carried"
+	);
+}
+
+/// `(table_id, table_id_extension, section_number)`, mirroring the private `section_key`
+/// so a test can assert two sections are indistinguishable to it.
+fn section_key_of(section: &[u8]) -> (u8, u16, u8) {
+	(section[0], ((section[3] as u16) << 8) | section[4] as u16, section[6])
 }
 
 /// The claim in full: real EIT p/f packets go in as TS and come back out as TS on the

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1568,20 +1568,31 @@ fn import_si(input: &[u8]) -> std::collections::BTreeMap<u16, tscat::Si> {
 	catalog.snapshot().mpegts.si.clone()
 }
 
-/// The EIT PID carries present/following and schedule interleaved, and only p/f is
-/// captured. This is the one PID whose `table_id`s are filtered rather than taken whole,
-/// so it is also the test that the filter runs after reassembly (a section boundary is
-/// only findable by following the whole PID).
+/// A captured SDT to sit alongside a PID under test, so a "not captured" assertion can
+/// prove the import gate actually ran rather than passing because nothing was decoded.
+/// A lone TS packet is never routed: sync needs the following packet's 0x47 to confirm
+/// the 188 stride, so a single-packet input leaves everything buffered.
+fn si_control() -> (Vec<u8>, Vec<u8>) {
+	let sdt = make_section(0x42, &[0xaa; 8]);
+	(si_packet(0x0011, &sdt), sdt)
+}
+
+/// The EIT PID carries p/f actual, p/f other and schedule, and only p/f actual survives.
+///
+/// The p/f section spans several TS packets, which is what pins the filter to *after*
+/// reassembly: a continuation packet has no `table_id` of its own, so judging packets
+/// individually would drop the section's tail and never rebuild it.
 #[test]
-fn eit_carries_present_following_not_schedule() {
-	let pf_actual = make_section(0x4E, &[0x01; 16]);
-	let pf_other = make_section(0x4F, &[0x02; 16]);
-	let mut input = Vec::new();
+fn eit_carries_present_following_actual_only() {
+	// 400 bytes forces the p/f section across three TS packets.
+	let body: Vec<u8> = (0..400u16).map(|i| i as u8).collect();
+	let pf_actual = make_section(0x4E, &body);
+	let mut input = si_packets_multi(0x0012, &pf_actual);
+	assert!(input.len() > 188, "the p/f section must span more than one TS packet");
 	for section in [
+		make_section(0x4F, &[0x02; 32]), // p/f other: collides in `section_key`, excluded
 		make_section(0x50, &[0x03; 32]), // schedule actual, first table_id
-		pf_actual.clone(),
 		make_section(0x5F, &[0x04; 32]), // schedule actual, last table_id
-		pf_other.clone(),
 		make_section(0x60, &[0x05; 32]), // schedule other, first table_id
 		make_section(0x6F, &[0x06; 32]), // schedule other, last table_id
 	] {
@@ -1592,13 +1603,13 @@ fn eit_carries_present_following_not_schedule() {
 	let eit = si.get(&0x0012).expect("an EIT entry");
 	assert_eq!(
 		eit.sections,
-		vec![Bytes::from(pf_actual), Bytes::from(pf_other)],
-		"only present/following (0x4E, 0x4F) survives; schedule (0x50..=0x6F) is dropped"
+		vec![Bytes::from(pf_actual)],
+		"only p/f actual (0x4E) survives, reassembled byte-for-byte; p/f other and schedule are dropped"
 	);
 	assert_eq!(
 		eit.interval,
 		Some(Duration::from_secs(2)),
-		"the EIT PID takes p/f actual's 2s maximum, the tightest of the tables it carries"
+		"EIT p/f actual's 2s maximum"
 	);
 }
 
@@ -1606,18 +1617,83 @@ fn eit_carries_present_following_not_schedule() {
 /// then have export re-emit a PID with nothing on it.
 #[test]
 fn eit_schedule_alone_creates_no_entry() {
-	let input = si_packet(0x0012, &make_section(0x50, &[0x07; 32]));
-	assert!(!import_si(&input).contains_key(&0x0012), "no EIT entry");
+	let (control, sdt) = si_control();
+	let mut input = si_packet(0x0012, &make_section(0x50, &[0x07; 32]));
+	input.extend_from_slice(&control);
+
+	let si = import_si(&input);
+	assert_eq!(
+		si.get(&0x0011).expect("the control SDT").sections,
+		vec![Bytes::from(sdt)],
+		"control: the import gate ran"
+	);
+	assert!(!si.contains_key(&0x0012), "no EIT entry");
 }
 
 /// TDT/TOT is never intercepted: every section is new content, so each would be a catalog
 /// modification, and an exporter's own clock beats a time relayed from upstream.
 #[test]
 fn tdt_is_not_captured() {
-	let input = si_packet(0x0014, &make_section(0x70, &[0x08; 5]));
-	assert!(
-		!import_si(&input).contains_key(&0x0014),
-		"TDT is dropped at the import gate"
+	let (control, sdt) = si_control();
+	let mut input = si_packet(0x0014, &make_section(0x70, &[0x08; 5]));
+	input.extend_from_slice(&control);
+
+	let si = import_si(&input);
+	assert_eq!(
+		si.get(&0x0011).expect("the control SDT").sections,
+		vec![Bytes::from(sdt)],
+		"control: the import gate ran"
+	);
+	assert!(!si.contains_key(&0x0014), "TDT is dropped at the import gate");
+}
+
+/// The claim in full: real EIT p/f packets go in as TS and come back out as TS on the
+/// same PID. The tests above cover the import gate alone, which is only half of what
+/// "survives a round-trip" means.
+#[tokio::test(start_paused = true)]
+async fn eit_survives_a_ts_round_trip() {
+	let pf = make_section(0x4E, &[0x5a; 24]);
+	// Appended to a real multiplex: the importer is already synced by then, and export
+	// needs the video timeline that bbb.ts carries to have anything to emit alongside.
+	let mut input = include_bytes!("test_data/bbb.ts").to_vec();
+	input.extend_from_slice(&si_packet(0x0012, &pf));
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	import.decode(&BytesMut::from(&input[..])).unwrap();
+	import.finish().unwrap();
+	assert_eq!(
+		catalog
+			.snapshot()
+			.mpegts
+			.si
+			.get(&0x0012)
+			.expect("EIT captured")
+			.sections,
+		vec![Bytes::from(pf.clone())],
+		"import captured the p/f section"
+	);
+
+	// `import` and `catalog` stay alive so the exporter can subscribe to the tracks.
+	let ts = drain_with(
+		Export::with_ts(crate::source::announced(&consumer), crate::catalog::CatalogFormat::Hang)
+			.await
+			.unwrap(),
+	)
+	.await;
+	assert_packet_aligned(&ts);
+
+	assert_eq!(
+		import_si(&ts)
+			.get(&0x0012)
+			.expect("EIT survived the round trip")
+			.sections,
+		vec![Bytes::from(pf)],
+		"the p/f section came back on 0x0012 byte-for-byte"
 	);
 }
 

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1547,20 +1547,77 @@ fn multi_packet_si_section_is_captured() {
 	let input = si_packets_multi(0x0011, &sdt);
 	assert!(input.len() > 188, "the SDT must span more than one TS packet");
 
+	assert_eq!(
+		import_si(&input).get(&0x0011).expect("an SDT entry").sections,
+		vec![Bytes::from(sdt)],
+		"the multi-packet SDT was reassembled and captured byte-for-byte"
+	);
+}
+
+/// Import raw TS bytes with the `mpegts` catalog extension enabled, returning the SI the
+/// import gate captured.
+fn import_si(input: &[u8]) -> std::collections::BTreeMap<u16, tscat::Si> {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let _consumer = broadcast.consume();
 	let catalog =
 		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
 			.unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
-	import.decode(&BytesMut::from(&input[..])).unwrap();
+	import.decode(&BytesMut::from(input)).unwrap();
 	import.finish().unwrap();
+	catalog.snapshot().mpegts.si.clone()
+}
 
-	let si = catalog.snapshot().mpegts.si.clone();
+/// The EIT PID carries present/following and schedule interleaved, and only p/f is
+/// captured. This is the one PID whose `table_id`s are filtered rather than taken whole,
+/// so it is also the test that the filter runs after reassembly (a section boundary is
+/// only findable by following the whole PID).
+#[test]
+fn eit_carries_present_following_not_schedule() {
+	let pf_actual = make_section(0x4E, &[0x01; 16]);
+	let pf_other = make_section(0x4F, &[0x02; 16]);
+	let mut input = Vec::new();
+	for section in [
+		make_section(0x50, &[0x03; 32]), // schedule actual, first table_id
+		pf_actual.clone(),
+		make_section(0x5F, &[0x04; 32]), // schedule actual, last table_id
+		pf_other.clone(),
+		make_section(0x60, &[0x05; 32]), // schedule other, first table_id
+		make_section(0x6F, &[0x06; 32]), // schedule other, last table_id
+	] {
+		input.extend_from_slice(&si_packet(0x0012, &section));
+	}
+
+	let si = import_si(&input);
+	let eit = si.get(&0x0012).expect("an EIT entry");
 	assert_eq!(
-		si.get(&0x0011).expect("an SDT entry").sections,
-		vec![Bytes::from(sdt)],
-		"the multi-packet SDT was reassembled and captured byte-for-byte"
+		eit.sections,
+		vec![Bytes::from(pf_actual), Bytes::from(pf_other)],
+		"only present/following (0x4E, 0x4F) survives; schedule (0x50..=0x6F) is dropped"
+	);
+	assert_eq!(
+		eit.interval,
+		Some(Duration::from_secs(2)),
+		"the EIT PID takes p/f actual's 2s maximum, the tightest of the tables it carries"
+	);
+}
+
+/// Schedule alone leaves no entry at all. An empty one would republish the catalog and
+/// then have export re-emit a PID with nothing on it.
+#[test]
+fn eit_schedule_alone_creates_no_entry() {
+	let input = si_packet(0x0012, &make_section(0x50, &[0x07; 32]));
+	assert!(!import_si(&input).contains_key(&0x0012), "no EIT entry");
+}
+
+/// TDT/TOT is never intercepted: every section is new content, so each would be a catalog
+/// modification, and an exporter's own clock beats a time relayed from upstream.
+#[test]
+fn tdt_is_not_captured() {
+	let input = si_packet(0x0014, &make_section(0x70, &[0x08; 5]));
+	assert!(
+		!import_si(&input).contains_key(&0x0014),
+		"TDT is dropped at the import gate"
 	);
 }
 

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -215,8 +215,10 @@ impl<E: catalog::Catalog> Import<E> {
 			// Intercept the standalone SI PIDs before the routing gate below drops them:
 			// they carry the service layer, not media, and are not fed to the reader
 			// (which only routes the PAT/PMT/ES PIDs it learns).
-			if self.supports_mpegts && catalog::SI_PIDS.iter().any(|(p, _)| *p == pid) {
-				self.si_section(pid, &pkt);
+			if self.supports_mpegts
+				&& let Some(si) = catalog::SiPid::get(pid)
+			{
+				self.si_section(si, &pkt);
 				continue;
 			}
 			// PIDs we don't decode and don't carry (`Stream::Ignored`: a base catalog's
@@ -611,17 +613,24 @@ impl<E: catalog::Catalog> Import<E> {
 	}
 
 	/// Feed one TS packet on a standalone SI PID to its reassembler, recording each
-	/// completed section verbatim into that PID's catalog entry.
+	/// completed section we carry verbatim into that PID's catalog entry.
 	///
-	/// Every section is captured, whatever its `table_id`: the SDT PID also carries
-	/// the BAT, an SDT can describe several services across several sections, and a
-	/// table we don't recognize is exactly as worth preserving as one we do. The
-	/// catalog holds a *set* per PID, so these coexist instead of overwriting each
-	/// other, and a plain repetition (SI repeats every couple of seconds) leaves the
-	/// set untouched rather than republishing the catalog.
-	fn si_section(&mut self, pid: u16, pkt: &[u8]) {
+	/// Which sections those are is the PID's own [`catalog::Tables`], and for all but
+	/// the EIT PID it is every one of them: the SDT PID also carries the BAT, an SDT can
+	/// describe several services across several sections, and a table we don't recognize
+	/// is exactly as worth preserving as one we do. The catalog holds a *set* per PID, so
+	/// these coexist instead of overwriting each other, and a plain repetition (SI repeats
+	/// every couple of seconds) leaves the set untouched rather than republishing the
+	/// catalog.
+	fn si_section(&mut self, si_pid: &'static catalog::SiPid, pkt: &[u8]) {
+		let pid = si_pid.pid;
 		let mut sections = Vec::new();
 		self.si_sections.entry(pid).or_default().push(pkt, &mut sections);
+
+		// Reassemble every section on the PID, then drop the tables we don't carry: the
+		// EIT PID interleaves p/f with schedule, so a section boundary is only findable
+		// by following the whole PID.
+		sections.retain(|section| si_pid.captures(section));
 		if sections.is_empty() {
 			return;
 		}
@@ -631,7 +640,7 @@ impl<E: catalog::Catalog> Import<E> {
 		// the other way round would republish the catalog on every SI cycle.
 		let updated = {
 			let si = self.si.entry(pid).or_insert_with(|| catalog::Si {
-				interval: catalog::SI_PIDS.iter().find(|(p, _)| *p == pid).map(|(_, i)| *i),
+				interval: Some(si_pid.interval),
 				..Default::default()
 			});
 			let mut changed = false;

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -627,10 +627,11 @@ impl<E: catalog::Catalog> Import<E> {
 		let mut sections = Vec::new();
 		self.si_sections.entry(pid).or_default().push(pkt, &mut sections);
 
-		// Reassemble every section on the PID, then drop the tables we don't carry: the
-		// EIT PID interleaves p/f with schedule, so a section boundary is only findable
-		// by following the whole PID.
-		sections.retain(|section| si_pid.captures(section));
+		// Reassemble every section on the PID, then drop what we don't carry: the tables
+		// this PID isn't captured for (the EIT PID interleaves p/f with schedule, so a
+		// section boundary is only findable by following the whole PID), and any version
+		// that doesn't apply yet.
+		sections.retain(|section| si_pid.captures(section) && catalog::is_current(section));
 		if sections.is_empty() {
 			return;
 		}


### PR DESCRIPTION
Closes #2800 (partially: p/f and TDT/TOT, not schedule).

`moq import ts` dropped EIT at the import gate, so the EPG could not survive a TS round-trip even though #2440 had already built the mechanism that would carry it. #2800 measured the cost on a synthesized EPG and found it far cheaper than we assumed: the `si` map dedupes by `(table_id, table_id_extension, section_number)` and compares before taking the catalog's write lock, so cost tracks the *revision* rate, not the transmission rate. Over ten minutes, EIT present/following was 4 distinct sections out of 592 transmitted.

## Root cause of the gap

`SI_PIDS` was keyed by PID alone, and `si_section` captured every completed section on an intercepted PID whatever its `table_id`. That is deliberate and correct for the PIDs it covered (the SDT PID also carries the BAT; an unrecognized table is as worth preserving as a known one), but it made EIT all-or-nothing: p/f (`0x4E`, `0x4F`) and schedule (`0x50`..=`0x6F`) share PID 0x0012.

`Si::interval` made that concrete rather than theoretical. It is one value per PID, but per ETSI TS 101 211 p/f actual is 2 s and schedule is 10-30 s. One PID, two cadences, one slot: there was no entry that was correct for both.

## The change

`SI_PIDS` becomes `&[SiPid]` (pid, tables, interval) with a `Tables::{All, Only}` filter, and 0x0012 joins it as `Only(&[(0x4E, 0x4F)])` at 2 s. `All` stays the default posture and is what 0x0010 and 0x0011 use, so nothing about their capture changes.

Filtering on `table_id` does not make the sections any less opaque: it is the first byte of every section under generic section syntax, the same byte `section_key` already reads to dedupe. This narrows what we carry without widening what we claim to parse.

The filter runs *after* reassembly, in `si_section`, because the EIT PID interleaves p/f with schedule and a section boundary is only findable by following the whole PID. When nothing survives the filter the entry is never created, so a schedule-only stream leaves no empty 0x0012 behind for export to emit.

Export needed no change: it already walks `mpegts.si` generically, honoring each PID's own interval.

## What is deliberately left out

**EIT schedule.** The catalog is whole-state and republished on every change, so cost per change is O(catalog), not O(delta), and every subscriber pays the full document at join, ahead of media. #2800's fixture yields 8 distinct schedule sections because it is one service with twelve events; a full multi-service eight-day EPG is thousands of sections whose window edges churn continuously as it rolls forward. That asymmetry does not depend on the magnitude, only on the catalog being whole-state. If schedule is ever wanted it belongs on its own track, the way SCTE-35 sections already ride one via `SectionStream`, and the reasoning is recorded next to the 0x0012 entry.

**TDT/TOT (0x0014)**, which is #2800's ask 3. Every section is new content rather than a repetition, so each would be a catalog modification and a republish, and it is the table with the least to gain from being relayed: an exporter's own clock is a better source than a time forwarded from an upstream multiplexer of unknown delay. The omission was previously silent and read as an oversight; it now has the rationale next to it.

## Tests

Three, in `export_test.rs` alongside the existing SI coverage:

- `eit_carries_present_following_not_schedule` feeds six sections interleaving p/f with schedule at both ends of both ranges, and asserts exactly the two p/f sections survive at a 2 s interval. This is also the regression test for the filter running post-reassembly.
- `eit_schedule_alone_creates_no_entry` covers the empty-entry case.
- `tdt_is_not_captured` pins the 0x0014 policy.

The existing `multi_packet_si_section_is_captured` is refactored onto the new `import_si` helper rather than duplicating the setup.

## Not done here

#2800 offers TSDuck fixture scripts (`make-eit-fixture.sh`, `eit-roundtrip.sh`) that synthesize an EPG onto any clip. Worth taking as a follow-up: no broadcast capture we hold carries EIT, which is why this gap survived #2440 with the mechanism in place and the table unrouted. The tests here are synthetic sections, not a real multiplex.

## Cross-package sync

`doc/bin/cli.md` described TDT/TOT and EIT together as "live or bulky rather than static identity" - two correct rationales covering three tables, and the same conflation this PR splits. Updated. No draft change: the `mpegts` catalog section is not specified in `drafts/`. No js mirror: `js/` has no MPEG-TS support.

(written by Opus 5)
