### PR TITLE
fix(moq-mux): anchor the TS table cadence to the media timeline

### DIFF
--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -986,18 +986,25 @@ const DEFAULT_DTS_RESERVE: u64 = 16;
 /// at the same points, which a redundant pair compares byte for byte. `None` (nothing
 /// emitted yet) is always due, so a fresh exporter leads with the tables and a receiver
 /// can tune in without waiting for the next slot.
+///
+/// A *later* slot, not merely a different one: video is emitted in decode order, so a
+/// reordered (B-frame) PTS steps backwards all the time, and re-emitting on every
+/// oscillation across a boundary buys nothing and costs a table each way.
 fn due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> bool {
+	// "Every frame", which the slot arithmetic can't express (and would divide by zero on).
+	if interval.is_zero() {
+		return true;
+	}
 	let Some(last) = last else {
 		return true;
 	};
-	slot(timestamp, interval) != slot(last, interval)
+	slot(timestamp, interval) > slot(last, interval)
 }
 
 /// Index of `timestamp`'s repetition slot: how many whole `interval`s fit under it.
-///
-/// A zero interval degenerates to one slot per microsecond, which makes every frame due.
+/// `interval` must be non-zero; [`due`] handles that case before it gets here.
 fn slot(timestamp: Timestamp, interval: Duration) -> u128 {
-	Duration::from(timestamp).as_micros() / interval.as_micros().max(1)
+	Duration::from(timestamp).as_micros() / interval.as_micros()
 }
 
 /// External byte size of an adaptation field (manual mirror of the crate's
@@ -1200,7 +1207,7 @@ fn dts_reserve(config: &VideoConfig) -> u64 {
 mod tests {
 	use std::time::Duration;
 
-	use super::{DEFAULT_DTS_RESERVE, PSI_INTERVAL, author_dts, due, is_complete_section};
+	use super::{DEFAULT_DTS_RESERVE, PSI_INTERVAL, author_dts, due, is_complete_section, slot};
 	use moq_net::Timestamp;
 
 	fn ms(value: u64) -> Timestamp {
@@ -1334,15 +1341,56 @@ mod tests {
 		assert!(!due(ms(1_250), Some(ms(1_000)), PSI_INTERVAL));
 		assert!(due(ms(1_500), Some(ms(1_000)), PSI_INTERVAL));
 
-		// A backwards timestamp is a rewound timeline, not a slot that has yet to lapse;
-		// re-emit the tables rather than sit out until the old slot comes back around.
-		assert!(due(ms(750), Some(ms(1_000)), PSI_INTERVAL));
+		// A backwards timestamp is a slot already served, not a new one. Emitting there would
+		// fire on every B-frame that steps back across a boundary (see `due_ignores_reorder`).
+		assert!(!due(ms(750), Some(ms(1_000)), PSI_INTERVAL));
 
 		// A per-PID SI interval is honored independently of the PSI cadence: an SDT at
 		// 2s is not due when the 500ms PSI would be.
 		let sdt = Duration::from_millis(2_000);
 		assert!(!due(ms(1_500), Some(ms(1_000)), sdt));
 		assert!(due(ms(3_000), Some(ms(1_000)), sdt));
+	}
+
+	/// Drive a run of timestamps through the cadence exactly as `write_frame` does (the last
+	/// emission only moves when one actually fires), returning how many tables it emitted.
+	fn run_cadence(stamps: &[Timestamp], interval: Duration) -> usize {
+		let mut last = None;
+		let mut emissions = 0;
+		for &ts in stamps {
+			if due(ts, last, interval) {
+				emissions += 1;
+				last = Some(ts);
+			}
+		}
+		emissions
+	}
+
+	#[test]
+	fn due_ignores_reorder() {
+		// Video is emitted in decode order, so a B-frame stream steps its PTS backwards
+		// constantly (measured at 39% of frames on real contribution content). The cadence has
+		// to follow the slots the stream has *reached*, not fire on every crossing of one, or
+		// each oscillation across a boundary re-sends the tables both ways.
+		let ticks = decode_order(40, 3, 3_600, 10_000_000);
+		let stamps: Vec<Timestamp> = ticks
+			.iter()
+			.map(|&t| Timestamp::from_micros(t * 1_000_000 / 90_000).unwrap())
+			.collect();
+		assert!(stamps.windows(2).any(|w| w[1] < w[0]), "fixture must reorder its PTS");
+
+		// One table per slot the stream covers, however often the reorder revisits a boundary.
+		let first = slot(stamps[0], PSI_INTERVAL);
+		let last = slot(*stamps.iter().max().unwrap(), PSI_INTERVAL);
+		assert_eq!(run_cadence(&stamps, PSI_INTERVAL), (last - first + 1) as usize);
+	}
+
+	#[test]
+	fn due_zero_interval_emits_every_frame() {
+		// A catalog is free to ask for a table on every frame. Slot arithmetic can't express
+		// that (and would divide by zero), so it is handled before the division.
+		let stamps: Vec<Timestamp> = [0, 0, 40, 40, 80].iter().map(|&t| ms(t)).collect();
+		assert_eq!(run_cadence(&stamps, Duration::ZERO), stamps.len());
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -1002,9 +1002,12 @@ fn due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> boo
 }
 
 /// Index of `timestamp`'s repetition slot: how many whole `interval`s fit under it.
-/// `interval` must be non-zero; [`due`] handles that case before it gets here.
+///
+/// Nanoseconds, so the divisor is zero only for a genuinely zero `interval`, which [`due`]
+/// takes before it gets here. Coarser units would floor a sub-unit interval to zero and
+/// divide by it.
 fn slot(timestamp: Timestamp, interval: Duration) -> u128 {
-	Duration::from(timestamp).as_micros() / interval.as_micros()
+	Duration::from(timestamp).as_nanos() / interval.as_nanos()
 }
 
 /// External byte size of an adaptation field (manual mirror of the crate's
@@ -1352,8 +1355,10 @@ mod tests {
 		assert!(due(ms(3_000), Some(ms(1_000)), sdt));
 	}
 
-	/// Drive a run of timestamps through the cadence exactly as `write_frame` does (the last
-	/// emission only moves when one actually fires), returning how many tables it emitted.
+	/// Drive a run of timestamps through the interval cadence, advancing the stored emission
+	/// only when one fires, and return how many tables it emitted. That is the whole of the SI
+	/// path; PSI additionally emits (and re-anchors) at every video keyframe, which is what
+	/// keeps two exporters of a program *with* video in step even before this.
 	fn run_cadence(stamps: &[Timestamp], interval: Duration) -> usize {
 		let mut last = None;
 		let mut emissions = 0;
@@ -1388,9 +1393,24 @@ mod tests {
 	#[test]
 	fn due_zero_interval_emits_every_frame() {
 		// A catalog is free to ask for a table on every frame. Slot arithmetic can't express
-		// that (and would divide by zero), so it is handled before the division.
+		// that (and would divide by zero), so it is handled before the division. Repeated
+		// timestamps are the case a slot count gets wrong: two tracks can share one.
 		let stamps: Vec<Timestamp> = [0, 0, 40, 40, 80].iter().map(|&t| ms(t)).collect();
 		assert_eq!(run_cadence(&stamps, Duration::ZERO), stamps.len());
+	}
+
+	#[test]
+	fn due_survives_a_sub_microsecond_interval() {
+		// Only an exactly-zero interval short-circuits, so the slot divisor has to stay
+		// non-zero for every other duration. Nanoseconds do; anything coarser floors a
+		// sub-unit interval to zero and panics on the division.
+		let interval = Duration::from_nanos(500);
+		assert!(
+			!interval.is_zero() && interval.as_micros() == 0,
+			"fixture must be sub-microsecond"
+		);
+		assert!(due(ms(1), Some(ms(0)), interval));
+		assert!(!due(ms(0), Some(ms(0)), interval));
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -69,12 +69,12 @@ pub struct Export<E: catalog::Catalog = ()> {
 	/// Standalone SI sections captured on import, keyed by PID and re-emitted verbatim
 	/// on their own cadence. Opaque: export never parses a table it carries.
 	si: BTreeMap<u16, catalog::Si>,
-	/// When each SI PID was last emitted, so each honors its own interval.
+	/// When each SI PID was last emitted, so each honors its own interval ([`due`]).
 	last_si: HashMap<u16, Timestamp>,
 
 	/// Program tables, built once the track layout is known.
 	psi: Option<Psi>,
-	/// Media timestamp of the last PAT/PMT emission.
+	/// Media timestamp of the last PAT/PMT emission ([`due`]).
 	last_psi: Option<Timestamp>,
 	/// Tune-in point: the first video keyframe's timestamp, captured when the program
 	/// tables are built. Non-video frames before it are dropped so the keyframe leads
@@ -978,13 +978,26 @@ const PES_DTS_LEN: usize = 5;
 /// [`author_dts`] and [`Track::dts_reserve`].
 const DEFAULT_DTS_RESERVE: u64 = 16;
 
+/// Whether `timestamp` has crossed into a later repetition slot than `last`.
+///
+/// Slots are absolute on the media timeline (`floor(timestamp / interval)`) rather than
+/// measured forward from the previous emission, so a table lands on the same frames no
+/// matter when the exporter started. Two exporters of one broadcast then emit the tables
+/// at the same points, which a redundant pair compares byte for byte. `None` (nothing
+/// emitted yet) is always due, so a fresh exporter leads with the tables and a receiver
+/// can tune in without waiting for the next slot.
 fn due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> bool {
 	let Some(last) = last else {
 		return true;
 	};
-	Duration::from(timestamp)
-		.checked_sub(Duration::from(last))
-		.is_some_and(|elapsed| elapsed >= interval)
+	slot(timestamp, interval) != slot(last, interval)
+}
+
+/// Index of `timestamp`'s repetition slot: how many whole `interval`s fit under it.
+///
+/// A zero interval degenerates to one slot per microsecond, which makes every frame due.
+fn slot(timestamp: Timestamp, interval: Duration) -> u128 {
+	Duration::from(timestamp).as_micros() / interval.as_micros().max(1)
 }
 
 /// External byte size of an adaptation field (manual mirror of the crate's
@@ -1289,17 +1302,58 @@ mod tests {
 	}
 
 	#[test]
-	fn due_uses_elapsed_duration() {
+	fn author_dts_is_join_independent_at_a_peak() {
+		// An exporter that has been running and one that just joined author the same decode
+		// timeline from any frame whose PTS leads everything decoded before it. A keyframe is
+		// exactly that (export only ever tunes in on one), so the monotonic bump cannot fire
+		// there and the state carried across the join stops mattering.
+		for b in [1, 3, 5] {
+			let pts = decode_order(40, b, 3_600, 10_000_000);
+			let running = run_clock(&pts, DEFAULT_DTS_RESERVE);
+
+			let mut peaks = 0;
+			for k in 1..pts.len() {
+				if pts[..k].iter().any(|&p| p >= pts[k]) {
+					continue;
+				}
+				peaks += 1;
+				let fresh = run_clock(&pts[k..], DEFAULT_DTS_RESERVE);
+				assert_eq!(
+					&running[k..],
+					&fresh[..],
+					"b={b}: joining at {k} authored a different clock"
+				);
+			}
+			assert!(peaks > 10, "b={b}: fixture must have peaks to join at, got {peaks}");
+		}
+	}
+
+	#[test]
+	fn due_crosses_an_absolute_slot() {
 		assert!(due(ms(1_000), None, PSI_INTERVAL));
 		assert!(!due(ms(1_250), Some(ms(1_000)), PSI_INTERVAL));
 		assert!(due(ms(1_500), Some(ms(1_000)), PSI_INTERVAL));
-		assert!(!due(ms(750), Some(ms(1_000)), PSI_INTERVAL));
+
+		// A backwards timestamp is a rewound timeline, not a slot that has yet to lapse;
+		// re-emit the tables rather than sit out until the old slot comes back around.
+		assert!(due(ms(750), Some(ms(1_000)), PSI_INTERVAL));
 
 		// A per-PID SI interval is honored independently of the PSI cadence: an SDT at
 		// 2s is not due when the 500ms PSI would be.
 		let sdt = Duration::from_millis(2_000);
 		assert!(!due(ms(1_500), Some(ms(1_000)), sdt));
 		assert!(due(ms(3_000), Some(ms(1_000)), sdt));
+	}
+
+	#[test]
+	fn due_ignores_when_the_last_emission_landed_in_its_slot() {
+		// The whole point of the absolute grid: two exporters that emitted at different
+		// points *within* the same slot agree on every later frame, so the emission points
+		// belong to the broadcast rather than to whoever started when.
+		for last in [1_000, 1_100, 1_499] {
+			assert!(!due(ms(1_499), Some(ms(last)), PSI_INTERVAL), "last={last}");
+			assert!(due(ms(1_500), Some(ms(last)), PSI_INTERVAL), "last={last}");
+		}
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1731,3 +1731,186 @@ async fn opus_export_import_roundtrip() {
 		assert_eq!(got.as_slice(), orig.as_ref(), "Opus packet survived the round-trip");
 	}
 }
+
+// Two exporters of one broadcast, started at different times, must render the same packets
+// from the moment they overlap. That is what a redundant (SMPTE ST 2022-7) pair compares, and
+// it is what lets a leg be restarted without the merge at the far end seeing the two disagree.
+// See moq-dev/moq#2779.
+
+/// 25 fps video.
+const VIDEO_US: u64 = 40_000;
+/// 48 kHz AAC, 1024 samples per frame.
+const AUDIO_US: u64 = 21_333;
+/// Video frames per group. Deliberately not a whole number of PSI intervals, so a table
+/// cadence anchored anywhere but the media timeline drifts against the keyframes.
+const GOP: u64 = 15;
+/// Audio frames per group, roughly matching the video group duration.
+const AUDIO_GROUP: u64 = 28;
+/// Video-frame ticks to produce, and the tick the second exporter joins at.
+const TICKS: u64 = 150;
+const JOIN: u64 = 75;
+
+/// Produce one broadcast and export it twice, the second exporter joining partway in, and
+/// return what each rendered.
+///
+/// Both exporters are drained after every write, so neither skips a group and the two see the
+/// same arrival order. That isolates the question under test (does the *rendering* depend on
+/// when the process started) from the separate question of whether two legs received the same
+/// groups in the same order.
+async fn export_twice(with_video: bool) -> (Vec<Frame>, Vec<Frame>) {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	let mut video = with_video.then(|| {
+		let track = broadcast
+			.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+			.unwrap();
+		// Out-of-band parameter sets (avc1), so the export source takes the catalog
+		// description as-is instead of parsing them out of the bitstream.
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: false,
+		});
+		cfg.container = Container::Legacy;
+		cfg.description =
+			Some(crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap());
+		catalog.lock().video.renditions.insert(track.name().to_string(), cfg);
+		Producer::new(track, HangContainer::Legacy)
+	});
+
+	let mut audio = {
+		let track = broadcast
+			.create_track(broadcast.unique_name(".aac"), hang::container::track_info())
+			.unwrap();
+		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
+		cfg.container = Container::Legacy;
+		catalog.lock().audio.renditions.insert(track.name().to_string(), cfg);
+		Producer::new(track, HangContainer::Legacy)
+	};
+
+	let source = crate::source::announced(&consumer);
+	let mut a = Export::new(source.clone()).await.unwrap();
+	let mut b = None;
+	let (mut out_a, mut out_b) = (Vec::new(), Vec::new());
+
+	let mut audio_index = 0;
+	for tick in 0..TICKS {
+		if let Some(video) = video.as_mut() {
+			let keyframe = tick % GOP == 0;
+			let slice = if keyframe {
+				vec![0x65u8; 3_000]
+			} else {
+				vec![0x41u8; 400]
+			};
+			video
+				.write(Frame {
+					timestamp: Timestamp::from_micros(tick * VIDEO_US).unwrap(),
+					duration: None,
+					payload: length_prefixed(&[&slice]),
+					keyframe,
+				})
+				.unwrap();
+		}
+		// Every audio frame that starts before the next video tick.
+		while audio_index * AUDIO_US < (tick + 1) * VIDEO_US {
+			audio
+				.write(Frame {
+					timestamp: Timestamp::from_micros(audio_index * AUDIO_US).unwrap(),
+					duration: None,
+					payload: Bytes::from_iter((0..180u16).map(|i| (i ^ audio_index as u16) as u8)),
+					keyframe: audio_index % AUDIO_GROUP == 0,
+				})
+				.unwrap();
+			audio_index += 1;
+		}
+
+		out_a.extend(drain_frames(&mut a).await);
+		if let Some(b) = b.as_mut() {
+			out_b.extend(drain_frames(b).await);
+		}
+		if tick + 1 == JOIN {
+			b = Some(Export::new(source.clone()).await.unwrap());
+		}
+	}
+
+	(out_a, out_b)
+}
+
+/// Pull every frame an exporter can render right now, like `drain` but keeping the frames
+/// whole (this compares them one by one, not as one byte stream).
+async fn drain_frames<E: tscat::Catalog>(export: &mut Export<E>) -> Vec<Frame> {
+	let mut out = Vec::new();
+	while let Ok(res) = tokio::time::timeout(Duration::from_secs(1), export.next()).await {
+		match res.expect("exporter error") {
+			Some(frame) => out.push(frame),
+			None => break,
+		}
+	}
+	out
+}
+
+/// Compare the overlapping output of two exporters, starting at `from`, and assert the only
+/// bytes that disagree are continuity counters.
+///
+/// The counter is the known exception: it is numbered from process state, so two legs are
+/// offset by a constant. Fixing that needs the emitted packet count per group to be a function
+/// of the broadcast, which is a much larger change than this guards. Everything else has to
+/// match exactly, so this fails if any new field starts being minted per process.
+fn assert_only_continuity_differs(a: &[Frame], b: &[Frame], from: Timestamp) {
+	let a: Vec<&Frame> = a.iter().filter(|f| f.timestamp >= from).collect();
+	let b: Vec<&Frame> = b.iter().filter(|f| f.timestamp >= from).collect();
+	assert!(b.len() > 20, "not enough overlap to be worth comparing: {}", b.len());
+	assert_eq!(a.len(), b.len(), "exporters rendered a different number of frames");
+
+	for (a, b) in a.iter().zip(b.iter()) {
+		assert_eq!(a.timestamp, b.timestamp, "compared frames must be the same frame");
+		assert_eq!(
+			a.payload.len(),
+			b.payload.len(),
+			"same frame rendered to a different size"
+		);
+		assert_packet_aligned(&a.payload);
+
+		for (offset, (x, y)) in a.payload.iter().zip(b.payload.iter()).enumerate() {
+			if x == y {
+				continue;
+			}
+			// Byte 3 of a TS packet is `transport_scrambling_control | adaptation_field_control |
+			// continuity_counter`, and only the low nibble is the counter. A difference anywhere
+			// else is a value the exporter minted from its own state rather than from the broadcast.
+			assert_eq!(
+				(offset % 188, (x ^ y) & 0xf0),
+				(3, 0),
+				"frame at {:?} differs outside the continuity counter: offset {offset}, {x:#04x} vs {y:#04x}",
+				a.timestamp,
+			);
+		}
+	}
+}
+
+#[tokio::test(start_paused = true)]
+async fn late_join_matches_a_running_exporter() {
+	let (a, b) = export_twice(true).await;
+
+	// Skip to the joiner's second keyframe: its first group covers tune-in, where the two legs
+	// legitimately differ because only the joiner has to lead with the program tables.
+	let keyframes: Vec<Timestamp> = b.iter().filter(|f| f.keyframe).map(|f| f.timestamp).collect();
+	assert_only_continuity_differs(&a, &b, keyframes[1]);
+}
+
+/// The same property for a program with no video track. Worth its own case because the program
+/// tables are re-emitted at every video keyframe, a boundary both legs share, which hides a
+/// drifting cadence. Audio-only has no such boundary, so the cadence has to come from the media
+/// timeline on its own.
+#[tokio::test(start_paused = true)]
+async fn late_join_matches_a_running_exporter_without_video() {
+	let (a, b) = export_twice(false).await;
+
+	// The joiner leads with PAT/PMT on its very first frame so a receiver can tune in; the
+	// running exporter has no reason to repeat them there. From the next frame on the two are
+	// rendering the same stream.
+	assert_only_continuity_differs(&a, &b, b[1].timestamp);
+}


### PR DESCRIPTION
Two exporters of one broadcast should render the same packets. Today the MPEG-TS exporter decides when to re-emit a table by measuring forward from its own last emission, so the cadence is anchored to whenever that process started rather than to the media timeline. Start a second exporter of the same broadcast 20 seconds later and the two put PAT/PMT (and SDT/NIT) on different frames, forever.

That breaks the case in #2779: a SMPTE ST 2022-7 pair needs its two legs packet-identical so a receiver can merge them, and a leg restarted for maintenance has to come back rendering exactly what its partner is rendering.

## Root cause

`due()` asked "has `interval` elapsed since the last emission", which carries the phase of whenever the exporter first ran. It now asks "has the timestamp crossed into a later `floor(timestamp / interval)` slot", which is a property of the broadcast alone. Two exporters that last emitted at different points inside the same slot agree on every frame after that.

A program *with* video hid this for PAT/PMT, because the tables are also re-emitted at every video keyframe and that re-anchors both legs to a boundary they share. The two cases where it does not:

- an audio-only program, which has no keyframe to re-anchor on, so PAT/PMT drifts;
- the standalone SI PIDs (SDT 0x0011, NIT 0x0010) in any program, which are never re-anchored at keyframes, so they land on different frames rather than merely being renumbered.

A slot boundary also re-emits after a backwards timestamp jump (a rewound timeline), which the elapsed-time version sat out until the old interval came back around.

## What this does not fix

The continuity counter, which is the headline of #2779, is still numbered from process state. Making it a function of the broadcast requires each group's per-PID packet count to be a multiple of 16 (a counter that is both globally continuous and independent of the join point forces that), which means padding, which is a much larger and opt-in-shaped change. The details are in #2779; this is the part that is unambiguous and free.

## Tests

`late_join_matches_a_running_exporter{,_without_video}` produce one broadcast, export it twice with the second exporter joining halfway in, and assert the only bytes that disagree in the overlap are continuity counters. The audio-only case fails without this change (one leg renders 752 bytes where the other renders 376: two extra packets, PAT and PMT). The video case passes either way and is there to catch the next field someone mints per process; it is the topology in the report.

`author_dts_is_join_independent_at_a_peak` pins the one piece of carried state that is *not* a divergence: the monotonic decode-clock bump cannot fire on a frame whose PTS leads everything decoded before it, which every keyframe is, and export only ever tunes in on a keyframe.

## Cross-package sync

None. No wire format, no public API, no CLI surface, and the MPEG-TS exporter has no JS counterpart.

Fixes part of #2779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 5)
