### PR TITLE
test(ts): synthesise an EIT so the import path's SI routing is testable

### DIFF
--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -77,7 +77,7 @@ writes the full machine-readable report.
 
 `make-eit-fixture.sh` adds a synthetic DVB EPG to any transport stream, so the
 import path's EIT handling can be exercised without a broadcast capture that
-carries one — no capture in this repository does.
+carries one. No capture in this repository does.
 
 ```bash
 ./make-eit-fixture.sh in.ts out.ts             # EIT p/f + schedule on PID 0x0012
@@ -87,8 +87,8 @@ carries one — no capture in this repository does.
 Everything is derived from the input, so the EIT describes the service the
 stream actually carries: the triplet (`original_network_id`,
 `transport_stream_id`, `service_id`) comes from its PAT and SDT, and the EPG is
-anchored to the stream's own TDT where it has one. Without a TDT — the
-ffmpeg-generated clip has none — it falls back to a fixed date, so the output is
+anchored to the stream's own TDT where it has one. Without a TDT (the
+ffmpeg-generated clip has none), it falls back to a fixed date, so the output is
 byte-reproducible for a given input. The SDT's `EIT_present_following_flag` and
 `EIT_schedule_flag` are set to match, since a stream carrying an EIT while
 advertising none is internally inconsistent.
@@ -99,7 +99,7 @@ clip with none is padded to a constant bitrate first, and the script says so.
 
 `--with-eit` wires this into the round-trip and prints which SI PIDs came back:
 
-```
+```text
 ### SI round-trip (source -> capture)
   TABLE      PID           SOURCE      CAPTURE
   NIT        0x0010             7            5

--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -18,6 +18,7 @@ just test ts                    # generate a clip, round-trip, analyze
 just test ts --source cap.ts    # round-trip a real capture instead
 just test ts --analyze-only x.ts # skip the round-trip, analyze a file
 just test ts --strict           # also fail on broadcast-shape warnings
+just test ts --with-eit         # add a synthetic EPG first, report which SI survived
 ```
 
 `--analyze-only` needs only TSDuck + Python, so you can point it at any captured
@@ -71,6 +72,48 @@ Thresholds are CLI flags forwarded through `run.sh` (e.g.
 `--pcr-repetition-ms`, `--pcr-jitter-us`, `--bitrate-cov-max`, `--burstiness-max`,
 `--tb-size-bytes`, `--video-leak-bps`, `--audio-leak-bps`). `--report-json <path>`
 writes the full machine-readable report.
+
+## EIT fixture
+
+`make-eit-fixture.sh` adds a synthetic DVB EPG to any transport stream, so the
+import path's EIT handling can be exercised without a broadcast capture that
+carries one — no capture in this repository does.
+
+```bash
+./make-eit-fixture.sh in.ts out.ts             # EIT p/f + schedule on PID 0x0012
+./make-eit-fixture.sh --pf-only in.ts out.ts   # p/f only
+```
+
+Everything is derived from the input, so the EIT describes the service the
+stream actually carries: the triplet (`original_network_id`,
+`transport_stream_id`, `service_id`) comes from its PAT and SDT, and the EPG is
+anchored to the stream's own TDT where it has one. Without a TDT — the
+ffmpeg-generated clip has none — it falls back to a fixed date, so the output is
+byte-reproducible for a given input. The SDT's `EIT_present_following_flag` and
+`EIT_schedule_flag` are set to match, since a stream carrying an EIT while
+advertising none is internally inconsistent.
+
+`tsp` replaces packets rather than creating them, so the EIT has to come out of
+existing stuffing. A broadcast capture has plenty and keeps its exact mux rate; a
+clip with none is padded to a constant bitrate first, and the script says so.
+
+`--with-eit` wires this into the round-trip and prints which SI PIDs came back:
+
+```
+### SI round-trip (source -> capture)
+  TABLE      PID           SOURCE      CAPTURE
+  NIT        0x0010             7            5
+  SDT        0x0011            31           21
+  EIT        0x0012         1,007            0
+  TDT/TOT    0x0014            40            0
+```
+
+This is a report, not a gate. `SI_PIDS` in
+[`catalog.rs`](../../rs/moq-mux/src/container/ts/catalog.rs) is the allowlist of
+PIDs the import path routes, and a table outside it is dropped by design rather
+than by malfunction; the census makes that visible instead of leaving it to be
+inferred from the code. Counts differ for a table that *did* survive because the
+exporter re-emits SI on its own repetition cadence rather than the source's.
 
 ## CI
 

--- a/test/ts/make-eit-fixture.sh
+++ b/test/ts/make-eit-fixture.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Add a synthetic DVB EPG (EIT) to any transport stream.
+#
+# The MPEG-TS import path routes SI by PID, but no capture in this repository carries
+# EIT (PID 0x0012), so nothing exercises that route. This synthesises one from a clip
+# that has none — including the ffmpeg-generated clip run.sh makes — so the EIT path is
+# testable without needing a broadcast capture.
+#
+# Everything is derived from the input: the service triplet comes from its PAT and SDT, so
+# the generated EIT actually describes the service the stream carries rather than a
+# plausible-looking one a receiver would ignore. The EPG is anchored to a fixed UTC
+# reference by default, which makes the output byte-reproducible for a given input.
+#
+# Requires TSDuck (tsp, tstables) and python3.
+#
+# Usage: make-eit-fixture.sh [options] <input.ts> <output.ts>
+#
+#   --pf-only        EIT p/f actual only. The default also generates EIT schedule.
+#   --events N       events in the EPG (default 12)
+#   --time T         UTC reference, "YYYY/MM/DD:hh:mm:ss". Defaults to the input's own
+#                    TDT if it has one, else a fixed date.
+#   --service-id N   service to describe (default: the first service in the PAT)
+#   --quiet          suppress the post-generation summary
+
+set -euo pipefail
+
+PF_ONLY=""
+EVENTS=12
+TIME_REF=""
+SERVICE_ID=""
+QUIET=""
+ARGS=()
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--pf-only) PF_ONLY=1; shift ;;
+		--events) EVENTS="$2"; shift 2 ;;
+		--time) TIME_REF="$2"; shift 2 ;;
+		--service-id) SERVICE_ID="$2"; shift 2 ;;
+		--quiet) QUIET=1; shift ;;
+		-h|--help) sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+		*) ARGS+=("$1"); shift ;;
+	esac
+done
+
+[[ ${#ARGS[@]} -eq 2 ]] || { echo "usage: $(basename "$0") [options] <input.ts> <output.ts>" >&2; exit 2; }
+IN="${ARGS[0]}"
+OUT="${ARGS[1]}"
+[[ -r "$IN" ]] || { echo "error: no such input: $IN" >&2; exit 1; }
+
+for t in tsp tstables python3; do
+	command -v "$t" >/dev/null 2>&1 || { echo "error: missing required tool: $t" >&2; exit 1; }
+done
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Read the service triplet from the stream rather than assuming it. An EIT whose
+# (original_network_id, transport_stream_id, service_id) does not match the SDT describes
+# nothing, and a receiver is right to ignore it.
+tstables "$IN" --pid 0x0000 --pid 0x0011 --pid 0x0014 --max-tables 8 \
+	--json-output "$TMP/si.json" --no-pager >/dev/null 2>&1 || true
+
+read -r DERIVED_SID TSID ONID TDT <<<"$(python3 - "$TMP/si.json" <<'PY'
+import json, sys
+
+sid = tsid = onid = tdt = "-"
+try:
+    doc = json.load(open(sys.argv[1]))
+except Exception:
+    doc = {}
+for t in doc.get("#nodes", []) if isinstance(doc, dict) else doc:
+    name = t.get("#name", "")
+    if name == "PAT":
+        tsid = t.get("transport_stream_id", tsid)
+        for s in t.get("#nodes", []):
+            if s.get("#name") == "service" and sid == "-":
+                sid = s.get("service_id", sid)
+    elif name == "SDT":
+        tsid = t.get("transport_stream_id", tsid)
+        onid = t.get("original_network_id", onid)
+        for s in t.get("#nodes", []):
+            if s.get("#name") == "service" and sid == "-":
+                sid = s.get("service_id", sid)
+    elif name == "TDT" and tdt == "-":
+        raw = t.get("utc_time") or t.get("UTC_time") or ""
+        # "YYYY-MM-DD hh:mm:ss" -> the "YYYY/MM/DD:hh:mm:ss" eitinject --time wants.
+        if len(raw) == 19 and raw[4] == "-" and raw[10] == " ":
+            tdt = raw.replace("-", "/").replace(" ", ":")
+print(sid, tsid, onid, tdt)
+PY
+)"
+
+SERVICE_ID="${SERVICE_ID:-$DERIVED_SID}"
+[[ "$SERVICE_ID" == "-" || -z "$SERVICE_ID" ]] && SERVICE_ID=1
+[[ "$TSID" == "-" || -z "$TSID" ]] && TSID=1
+[[ "$ONID" == "-" || -z "$ONID" ]] && ONID=1
+
+# Anchor to the stream's own clock where it has one, so the "present" event is genuinely
+# present for a receiver decoding from the start. Otherwise a fixed date, which keeps the
+# output reproducible; eitinject needs a reference either way and would otherwise take the
+# wall clock, making every run differ.
+if [[ -z "$TIME_REF" ]]; then
+	if [[ "$TDT" != "-" && -n "$TDT" ]]; then
+		TIME_REF="$TDT"
+	else
+		TIME_REF="2026/01/01:12:00:00"
+	fi
+fi
+
+python3 - "$TMP/epg.xml" "$SERVICE_ID" "$TSID" "$ONID" "$TIME_REF" "$EVENTS" <<'PY'
+import sys, datetime
+
+path, sid, tsid, onid, ref, count = sys.argv[1:7]
+sid, tsid, onid, count = int(sid), int(tsid), int(onid), int(count)
+t0 = datetime.datetime.strptime(ref, "%Y/%m/%d:%H:%M:%S")
+
+# The first event has to straddle the reference, not merely precede it: an event ending
+# exactly at the reference is already obsolete and eitinject drops it, leaving p/f empty
+# for the whole clip.
+start = t0 - datetime.timedelta(minutes=15)
+titles = [
+    ("News", "International news, business and weather."),
+    ("Sport", "The day in sport."),
+    ("Documentary", "Long-form reporting."),
+    ("Talk", "Interviews with newsmakers."),
+    ("Markets", "Companies and the people who run them."),
+    ("Weather", "The outlook, region by region."),
+]
+
+rows = []
+for i in range(count):
+    s = start + datetime.timedelta(minutes=30 * i)
+    name, text = titles[i % len(titles)]
+    rows.append(
+        f'    <event event_id="{1000 + i}" start_time="{s:%Y-%m-%d %H:%M:%S}" '
+        f'duration="00:30:00" running_status="{"running" if i == 0 else "not-running"}" '
+        f'CA_mode="false">\n'
+        f'      <short_event_descriptor language_code="eng">\n'
+        f'        <event_name>{name} {i + 1}</event_name>\n'
+        f'        <text>{text}</text>\n'
+        f"      </short_event_descriptor>\n"
+        f"    </event>"
+    )
+
+# eitinject ignores this structure and re-derives p/f and schedule from the event list, so
+# one EIT carrying every event is the intended input shape.
+open(path, "w").write(
+    '<?xml version="1.0" encoding="UTF-8"?>\n<tsduck>\n'
+    f'  <EIT type="pf" actual="true" version="1" current="true"\n'
+    f'       service_id="{sid}" transport_stream_id="{tsid}" original_network_id="{onid}">\n'
+    + "\n".join(rows)
+    + "\n  </EIT>\n</tsduck>\n"
+)
+PY
+
+EIT_ARGS=(--actual)
+[[ -n "$PF_ONLY" ]] && EIT_ARGS=(--actual-pf)
+
+# tsp packet processors replace packets, they do not create them, so EIT can only go where
+# there is stuffing. A broadcast capture has plenty and keeps its mux rate; a clip muxed by
+# ffmpeg has none, so pad it to a constant rate first and say so, since that changes the
+# stream in a way the caller should know about.
+SRC="$IN"
+NULLS=$(tsp -I file "$IN" -P count --pid 0x1FFF --total -O drop 2>&1 |
+	sed -n 's/.*counted \([0-9,]*\) packets out of \([0-9,]*\).*/\1 \2/p' | head -1)
+HAVE=$(echo "$NULLS" | cut -d' ' -f1 | tr -d ,)
+TOTAL=$(echo "$NULLS" | cut -d' ' -f2 | tr -d ,)
+if [[ -z "$HAVE" || -z "$TOTAL" || "$TOTAL" -eq 0 || $((HAVE * 200)) -lt "$TOTAL" ]]; then
+	RATE=$(tsp -I file "$IN" -P analyze --normalized -O drop 2>/dev/null |
+		sed -n 's/^ts:.*:bitrate=\([0-9]*\):.*/\1/p' | head -1)
+	[[ -n "$RATE" && "$RATE" -gt 0 ]] || { echo "error: cannot determine input bitrate to pad to" >&2; exit 1; }
+	PADDED=$((RATE + 200000))
+	[[ -n "$QUIET" ]] || echo "### input carries no stuffing; padding to ${PADDED} b/s CBR to make room"
+	tsstuff --bitrate "$PADDED" "$IN" >"$TMP/padded.ts" 2>"$TMP/stuff.log" || {
+		sed 's/^/  tsstuff: /' "$TMP/stuff.log" >&2 || true
+		exit 1
+	}
+	SRC="$TMP/padded.ts"
+fi
+
+# --wait-first-batch: without it injection races the EPG load and the head of the output
+# carries no EIT, which a short capture would read as "the table was dropped".
+# The SDT flags: a stream that carries EIT while advertising none is internally
+# inconsistent, and a conformance analyser will say so.
+tsp -I file "$SRC" \
+	-P sdt --service-id "$SERVICE_ID" --eit-pf 1 --eit-schedule "$([[ -n "$PF_ONLY" ]] && echo 0 || echo 1)" \
+	-P eitinject --files "$TMP/epg.xml" --wait-first-batch --time "$TIME_REF" "${EIT_ARGS[@]}" \
+	-O file "$OUT" 2>"$TMP/tsp.log" || {
+	sed 's/^/  tsp: /' "$TMP/tsp.log" >&2 || true
+	exit 1
+}
+
+EIT_PKTS=$(tsp -I file "$OUT" -P count --pid 0x0012 --total -O drop 2>&1 |
+	sed -n 's/.*counted \([0-9,]*\) packets.*/\1/p' | head -1)
+if [[ -z "$EIT_PKTS" || "$EIT_PKTS" == "0" ]]; then
+	echo "error: no EIT in the output; the EPG or the time reference did not match the stream" >&2
+	sed 's/^/  tsp: /' "$TMP/tsp.log" >&2 || true
+	exit 1
+fi
+
+[[ -n "$QUIET" ]] || {
+	echo "### EIT fixture: service $SERVICE_ID (ts $TSID, onid $ONID), reference $TIME_REF"
+	echo "### $EVENTS events, $([[ -n "$PF_ONLY" ]] && echo "p/f only" || echo "p/f + schedule")"
+	echo "### $EIT_PKTS packets on PID 0x0012 -> $OUT"
+}

--- a/test/ts/make-eit-fixture.sh
+++ b/test/ts/make-eit-fixture.sh
@@ -32,24 +32,54 @@ QUIET=""
 ARGS=()
 
 while [[ $# -gt 0 ]]; do
-	case "$1" in
-		--pf-only) PF_ONLY=1; shift ;;
-		--events) EVENTS="$2"; shift 2 ;;
-		--time) TIME_REF="$2"; shift 2 ;;
-		--service-id) SERVICE_ID="$2"; shift 2 ;;
-		--quiet) QUIET=1; shift ;;
-		-h|--help) sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-		*) ARGS+=("$1"); shift ;;
-	esac
+    case "$1" in
+        --pf-only)
+            PF_ONLY=1
+            shift
+            ;;
+        --events)
+            EVENTS="$2"
+            shift 2
+            ;;
+        --time)
+            TIME_REF="$2"
+            shift 2
+            ;;
+        --service-id)
+            SERVICE_ID="$2"
+            shift 2
+            ;;
+        --quiet)
+            QUIET=1
+            shift
+            ;;
+        -h | --help)
+            sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
 done
 
-[[ ${#ARGS[@]} -eq 2 ]] || { echo "usage: $(basename "$0") [options] <input.ts> <output.ts>" >&2; exit 2; }
+[[ ${#ARGS[@]} -eq 2 ]] || {
+    echo "usage: $(basename "$0") [options] <input.ts> <output.ts>" >&2
+    exit 2
+}
 IN="${ARGS[0]}"
 OUT="${ARGS[1]}"
-[[ -r "$IN" ]] || { echo "error: no such input: $IN" >&2; exit 1; }
+[[ -r "$IN" ]] || {
+    echo "error: no such input: $IN" >&2
+    exit 1
+}
 
 for t in tsp tstables python3; do
-	command -v "$t" >/dev/null 2>&1 || { echo "error: missing required tool: $t" >&2; exit 1; }
+    command -v "$t" >/dev/null 2>&1 || {
+        echo "error: missing required tool: $t" >&2
+        exit 1
+    }
 done
 
 TMP="$(mktemp -d)"
@@ -59,9 +89,10 @@ trap 'rm -rf "$TMP"' EXIT
 # (original_network_id, transport_stream_id, service_id) does not match the SDT describes
 # nothing, and a receiver is right to ignore it.
 tstables "$IN" --pid 0x0000 --pid 0x0011 --pid 0x0014 --max-tables 8 \
-	--json-output "$TMP/si.json" --no-pager >/dev/null 2>&1 || true
+    --json-output "$TMP/si.json" --no-pager >/dev/null 2>&1 || true
 
-read -r DERIVED_SID TSID ONID TDT <<<"$(python3 - "$TMP/si.json" <<'PY'
+read -r DERIVED_SID TSID ONID TDT <<<"$(
+    python3 - "$TMP/si.json" <<'PY'
 import json, sys
 
 sid = tsid = onid = tdt = "-"
@@ -101,11 +132,11 @@ SERVICE_ID="${SERVICE_ID:-$DERIVED_SID}"
 # output reproducible; eitinject needs a reference either way and would otherwise take the
 # wall clock, making every run differ.
 if [[ -z "$TIME_REF" ]]; then
-	if [[ "$TDT" != "-" && -n "$TDT" ]]; then
-		TIME_REF="$TDT"
-	else
-		TIME_REF="2026/01/01:12:00:00"
-	fi
+    if [[ "$TDT" != "-" && -n "$TDT" ]]; then
+        TIME_REF="$TDT"
+    else
+        TIME_REF="2026/01/01:12:00:00"
+    fi
 fi
 
 python3 - "$TMP/epg.xml" "$SERVICE_ID" "$TSID" "$ONID" "$TIME_REF" "$EVENTS" <<'PY'
@@ -163,20 +194,23 @@ EIT_ARGS=(--actual)
 # stream in a way the caller should know about.
 SRC="$IN"
 NULLS=$(tsp -I file "$IN" -P count --pid 0x1FFF --total -O drop 2>&1 |
-	sed -n 's/.*counted \([0-9,]*\) packets out of \([0-9,]*\).*/\1 \2/p' | head -1)
+    sed -n 's/.*counted \([0-9,]*\) packets out of \([0-9,]*\).*/\1 \2/p' | head -1)
 HAVE=$(echo "$NULLS" | cut -d' ' -f1 | tr -d ,)
 TOTAL=$(echo "$NULLS" | cut -d' ' -f2 | tr -d ,)
 if [[ -z "$HAVE" || -z "$TOTAL" || "$TOTAL" -eq 0 || $((HAVE * 200)) -lt "$TOTAL" ]]; then
-	RATE=$(tsp -I file "$IN" -P analyze --normalized -O drop 2>/dev/null |
-		sed -n 's/^ts:.*:bitrate=\([0-9]*\):.*/\1/p' | head -1)
-	[[ -n "$RATE" && "$RATE" -gt 0 ]] || { echo "error: cannot determine input bitrate to pad to" >&2; exit 1; }
-	PADDED=$((RATE + 200000))
-	[[ -n "$QUIET" ]] || echo "### input carries no stuffing; padding to ${PADDED} b/s CBR to make room"
-	tsstuff --bitrate "$PADDED" "$IN" >"$TMP/padded.ts" 2>"$TMP/stuff.log" || {
-		sed 's/^/  tsstuff: /' "$TMP/stuff.log" >&2 || true
-		exit 1
-	}
-	SRC="$TMP/padded.ts"
+    RATE=$(tsp -I file "$IN" -P analyze --normalized -O drop 2>/dev/null |
+        sed -n 's/^ts:.*:bitrate=\([0-9]*\):.*/\1/p' | head -1)
+    [[ -n "$RATE" && "$RATE" -gt 0 ]] || {
+        echo "error: cannot determine input bitrate to pad to" >&2
+        exit 1
+    }
+    PADDED=$((RATE + 200000))
+    [[ -n "$QUIET" ]] || echo "### input carries no stuffing; padding to ${PADDED} b/s CBR to make room"
+    tsstuff --bitrate "$PADDED" "$IN" >"$TMP/padded.ts" 2>"$TMP/stuff.log" || {
+        sed 's/^/  tsstuff: /' "$TMP/stuff.log" >&2 || true
+        exit 1
+    }
+    SRC="$TMP/padded.ts"
 fi
 
 # --wait-first-batch: without it injection races the EPG load and the head of the output
@@ -184,23 +218,23 @@ fi
 # The SDT flags: a stream that carries EIT while advertising none is internally
 # inconsistent, and a conformance analyser will say so.
 tsp -I file "$SRC" \
-	-P sdt --service-id "$SERVICE_ID" --eit-pf 1 --eit-schedule "$([[ -n "$PF_ONLY" ]] && echo 0 || echo 1)" \
-	-P eitinject --files "$TMP/epg.xml" --wait-first-batch --time "$TIME_REF" "${EIT_ARGS[@]}" \
-	-O file "$OUT" 2>"$TMP/tsp.log" || {
-	sed 's/^/  tsp: /' "$TMP/tsp.log" >&2 || true
-	exit 1
+    -P sdt --service-id "$SERVICE_ID" --eit-pf 1 --eit-schedule "$([[ -n "$PF_ONLY" ]] && echo 0 || echo 1)" \
+    -P eitinject --files "$TMP/epg.xml" --wait-first-batch --time "$TIME_REF" "${EIT_ARGS[@]}" \
+    -O file "$OUT" 2>"$TMP/tsp.log" || {
+    sed 's/^/  tsp: /' "$TMP/tsp.log" >&2 || true
+    exit 1
 }
 
 EIT_PKTS=$(tsp -I file "$OUT" -P count --pid 0x0012 --total -O drop 2>&1 |
-	sed -n 's/.*counted \([0-9,]*\) packets.*/\1/p' | head -1)
+    sed -n 's/.*counted \([0-9,]*\) packets.*/\1/p' | head -1)
 if [[ -z "$EIT_PKTS" || "$EIT_PKTS" == "0" ]]; then
-	echo "error: no EIT in the output; the EPG or the time reference did not match the stream" >&2
-	sed 's/^/  tsp: /' "$TMP/tsp.log" >&2 || true
-	exit 1
+    echo "error: no EIT in the output; the EPG or the time reference did not match the stream" >&2
+    sed 's/^/  tsp: /' "$TMP/tsp.log" >&2 || true
+    exit 1
 fi
 
 [[ -n "$QUIET" ]] || {
-	echo "### EIT fixture: service $SERVICE_ID (ts $TSID, onid $ONID), reference $TIME_REF"
-	echo "### $EVENTS events, $([[ -n "$PF_ONLY" ]] && echo "p/f only" || echo "p/f + schedule")"
-	echo "### $EIT_PKTS packets on PID 0x0012 -> $OUT"
+    echo "### EIT fixture: service $SERVICE_ID (ts $TSID, onid $ONID), reference $TIME_REF"
+    echo "### $EVENTS events, $([[ -n "$PF_ONLY" ]] && echo "p/f only" || echo "p/f + schedule")"
+    echo "### $EIT_PKTS packets on PID 0x0012 -> $OUT"
 }

--- a/test/ts/make-eit-fixture.sh
+++ b/test/ts/make-eit-fixture.sh
@@ -3,7 +3,7 @@
 #
 # The MPEG-TS import path routes SI by PID, but no capture in this repository carries
 # EIT (PID 0x0012), so nothing exercises that route. This synthesises one from a clip
-# that has none — including the ffmpeg-generated clip run.sh makes — so the EIT path is
+# that has none, including the ffmpeg-generated clip run.sh makes. This makes the EIT path
 # testable without needing a broadcast capture.
 #
 # Everything is derived from the input: the service triplet comes from its PAT and SDT, so
@@ -89,43 +89,100 @@ trap 'rm -rf "$TMP"' EXIT
 # (original_network_id, transport_stream_id, service_id) does not match the SDT describes
 # nothing, and a receiver is right to ignore it.
 tstables "$IN" --pid 0x0000 --pid 0x0011 --pid 0x0014 --max-tables 8 \
-    --json-output "$TMP/si.json" --no-pager >/dev/null 2>&1 || true
+    --json-output "$TMP/si.json" --no-pager >/dev/null
 
-read -r DERIVED_SID TSID ONID TDT <<<"$(
-    python3 - "$TMP/si.json" <<'PY'
+METADATA=$(
+    python3 - "$TMP/si.json" "$SERVICE_ID" <<'PY'
 import json, sys
 
-sid = tsid = onid = tdt = "-"
+path, requested_sid = sys.argv[1:3]
+
+
+def fail(message):
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def integer(value, name):
+    if isinstance(value, bool):
+        fail(f"invalid {name} in SI metadata: {value!r}")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        fail(f"invalid {name} in SI metadata: {value!r}")
+
+
 try:
-    doc = json.load(open(sys.argv[1]))
-except Exception:
-    doc = {}
-for t in doc.get("#nodes", []) if isinstance(doc, dict) else doc:
-    name = t.get("#name", "")
-    if name == "PAT":
-        tsid = t.get("transport_stream_id", tsid)
-        for s in t.get("#nodes", []):
-            if s.get("#name") == "service" and sid == "-":
-                sid = s.get("service_id", sid)
-    elif name == "SDT":
-        tsid = t.get("transport_stream_id", tsid)
-        onid = t.get("original_network_id", onid)
-        for s in t.get("#nodes", []):
-            if s.get("#name") == "service" and sid == "-":
-                sid = s.get("service_id", sid)
-    elif name == "TDT" and tdt == "-":
+    with open(path) as stream:
+        doc = json.load(stream)
+except (OSError, json.JSONDecodeError) as error:
+    fail(f"cannot read complete PAT/SDT metadata: {error}")
+
+tables = doc.get("#nodes", []) if isinstance(doc, dict) else doc
+if not isinstance(tables, list):
+    fail("PAT/SDT metadata is not a table list")
+
+pats = [table for table in tables if table.get("#name") == "PAT"]
+sdts = [
+    table
+    for table in tables
+    if table.get("#name") == "SDT" and table.get("actual", True)
+]
+if not pats:
+    fail("input has no complete PAT")
+if not sdts:
+    fail("input has no complete actual SDT")
+
+pat_tsids = {integer(table.get("transport_stream_id"), "PAT transport_stream_id") for table in pats}
+sdt_tsids = {integer(table.get("transport_stream_id"), "SDT transport_stream_id") for table in sdts}
+if len(pat_tsids) != 1 or len(sdt_tsids) != 1 or pat_tsids != sdt_tsids:
+    fail(f"PAT/SDT transport_stream_id mismatch: PAT {sorted(pat_tsids)}, SDT {sorted(sdt_tsids)}")
+tsid = pat_tsids.pop()
+
+onids = {integer(table.get("original_network_id"), "original_network_id") for table in sdts}
+if len(onids) != 1:
+    fail(f"actual SDT tables disagree on original_network_id: {sorted(onids)}")
+onid = onids.pop()
+
+pat_services = [
+    integer(node.get("service_id"), "PAT service_id")
+    for table in pats
+    for node in table.get("#nodes", [])
+    if node.get("#name") == "service"
+]
+sdt_services = {
+    integer(node.get("service_id"), "SDT service_id")
+    for table in sdts
+    for node in table.get("#nodes", [])
+    if node.get("#name") == "service"
+}
+if requested_sid:
+    try:
+        sid = int(requested_sid, 0)
+    except ValueError:
+        fail(f"invalid --service-id: {requested_sid}")
+    if sid not in sdt_services:
+        fail(f"service {sid} is not present in the actual SDT")
+    if sid not in pat_services:
+        fail(f"service {sid} is not present in the PAT")
+else:
+    try:
+        sid = next(service for service in pat_services if service in sdt_services)
+    except StopIteration:
+        fail("PAT and actual SDT have no service in common")
+
+tdt = "-"
+for t in tables:
+    if t.get("#name") == "TDT" and tdt == "-":
         raw = t.get("utc_time") or t.get("UTC_time") or ""
         # "YYYY-MM-DD hh:mm:ss" -> the "YYYY/MM/DD:hh:mm:ss" eitinject --time wants.
         if len(raw) == 19 and raw[4] == "-" and raw[10] == " ":
             tdt = raw.replace("-", "/").replace(" ", ":")
 print(sid, tsid, onid, tdt)
 PY
-)"
+)
 
-SERVICE_ID="${SERVICE_ID:-$DERIVED_SID}"
-[[ "$SERVICE_ID" == "-" || -z "$SERVICE_ID" ]] && SERVICE_ID=1
-[[ "$TSID" == "-" || -z "$TSID" ]] && TSID=1
-[[ "$ONID" == "-" || -z "$ONID" ]] && ONID=1
+read -r SERVICE_ID TSID ONID TDT <<<"$METADATA"
 
 # Anchor to the stream's own clock where it has one, so the "present" event is genuinely
 # present for a receiver decoding from the start. Otherwise a fixed date, which keeps the
@@ -225,13 +282,39 @@ tsp -I file "$SRC" \
     exit 1
 }
 
+tstables "$OUT" --pid 0x0012 --json-output "$TMP/eit.json" --no-pager >/dev/null
+python3 - "$TMP/eit.json" "$SERVICE_ID" "$TSID" "$ONID" <<'PY'
+import json, sys
+
+path, sid, tsid, onid = sys.argv[1:5]
+expected = tuple(map(int, (sid, tsid, onid)))
+try:
+    with open(path) as stream:
+        doc = json.load(stream)
+except (OSError, json.JSONDecodeError) as error:
+    print(f"error: cannot read generated EIT metadata: {error}", file=sys.stderr)
+    sys.exit(1)
+
+tables = doc.get("#nodes", []) if isinstance(doc, dict) else doc
+observed = {
+    (
+        table.get("service_id"),
+        table.get("transport_stream_id"),
+        table.get("original_network_id"),
+    )
+    for table in tables
+    if table.get("#name") == "EIT"
+}
+if expected not in observed:
+    print(
+        f"error: no generated EIT for service triplet {expected}; observed {sorted(observed)}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+
 EIT_PKTS=$(tsp -I file "$OUT" -P count --pid 0x0012 --total -O drop 2>&1 |
     sed -n 's/.*counted \([0-9,]*\) packets.*/\1/p' | head -1)
-if [[ -z "$EIT_PKTS" || "$EIT_PKTS" == "0" ]]; then
-    echo "error: no EIT in the output; the EPG or the time reference did not match the stream" >&2
-    sed 's/^/  tsp: /' "$TMP/tsp.log" >&2 || true
-    exit 1
-fi
 
 [[ -n "$QUIET" ]] || {
     echo "### EIT fixture: service $SERVICE_ID (ts $TSID, onid $ONID), reference $TIME_REF"

--- a/test/ts/run.sh
+++ b/test/ts/run.sh
@@ -14,6 +14,7 @@
 #   ./run.sh --source cap.ts       # round-trip a real capture instead
 #   ./run.sh --analyze-only cap.ts # skip the round-trip, just analyze a file
 #   ./run.sh --strict              # fail on broadcast-shape warnings too
+#   ./run.sh --with-eit            # add a synthetic EPG first, report which SI survived
 set -euo pipefail
 
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -26,6 +27,7 @@ BITRATE="${TSC_BITRATE:-10000000}"
 PORT="${TSC_PORT:-4443}"
 PROFILE="${TSC_PROFILE:-debug}"
 STRICT=""
+WITH_EIT="" # add a synthetic EPG to the source and report which SI survived
 PASSTHRU=() # forwarded to compliance.py (thresholds, --report-json, ...)
 
 while [[ $# -gt 0 ]]; do
@@ -54,6 +56,10 @@ while [[ $# -gt 0 ]]; do
             STRICT="--strict"
             shift
             ;;
+        --with-eit)
+            WITH_EIT=1
+            shift
+            ;;
         *)
             PASSTHRU+=("$1")
             shift
@@ -74,6 +80,11 @@ require_tools() {
     # pgrep backs kill_tree; without it grandchild tsp/moq processes would leak.
     if [[ -z "$ANALYZE_ONLY" ]]; then
         for t in cargo ffmpeg curl timeout pgrep; do have "$t" || missing+=("$t"); done
+    fi
+    # The EIT fixture reads the service triplet out of the stream and may need to pad a
+    # stuffing-free clip to make room for the table.
+    if [[ -n "$WITH_EIT" ]]; then
+        for t in tstables tsstuff; do have "$t" || missing+=("$t"); done
     fi
     if [[ ${#missing[@]} -gt 0 ]]; then
         echo "error: missing required tools: ${missing[*]}" >&2
@@ -166,6 +177,13 @@ else
         -f mpegts -pes_payload_size 0 "$SRC_TS"
 fi
 
+# No capture in this repository carries EIT, so the import path's EIT handling is
+# otherwise untestable. Synthesise one, and report below which SI PIDs came back.
+if [[ -n "$WITH_EIT" ]]; then
+    "$DIR/make-eit-fixture.sh" "$SRC_TS" "$TMP/source-eit.ts"
+    mv "$TMP/source-eit.ts" "$SRC_TS"
+fi
+
 echo "### starting relay on 127.0.0.1:${PORT}"
 sed "s/4443/${PORT}/g" "$DIR/../smoke/smoke.toml" >"$TMP/relay.toml"
 "$RELAY" "$TMP/relay.toml" >"$TMP/relay.log" 2>&1 &
@@ -225,6 +243,24 @@ if [[ ! -s "$SUB_TS" ]]; then
 fi
 
 echo "### captured $(wc -c <"$SUB_TS" | tr -d ' ') bytes -> analyzing"
+
+# Which SI survived the round-trip. Informational: the exporter rebuilds SI from the
+# catalog, so a PID the import path does not route simply is not there, and that is a
+# statement about SI_PIDS rather than a malformed stream. compliance.py grades the stream
+# an IRD receives; this says what it was carrying on the way in.
+if [[ -n "$WITH_EIT" ]]; then
+    echo
+    echo "### SI round-trip (source -> capture)"
+    count_pid() {
+        tsp -I file "$1" -P count --pid "$2" --total -O drop 2>&1 |
+            sed -n 's/.*counted \([0-9,]*\) packets.*/\1/p' | head -1
+    }
+    printf '  %-10s %-8s %12s %12s\n' TABLE PID SOURCE CAPTURE
+    for spec in "NIT:0x0010" "SDT:0x0011" "EIT:0x0012" "TDT/TOT:0x0014"; do
+        printf '  %-10s %-8s %12s %12s\n' "${spec%%:*}" "${spec##*:}" \
+            "$(count_pid "$SRC_TS" "${spec##*:}")" "$(count_pid "$SUB_TS" "${spec##*:}")"
+    done
+fi
 echo
 # Pass the source so duration-fidelity can pin the exported stream's rate. A tiny
 # capture still parses, so the round-trip can fail here with a non-empty file;


### PR DESCRIPTION
Contributes the EIT fixture generator asked for in #2800.

## Summary

- No capture in this repository carries EIT, so PID 0x0012 — the one PID whose handling is under discussion — is also the one nothing exercises. `test/ts/make-eit-fixture.sh` synthesises one from any clip using TSDuck alone.
- Everything is derived from the input, so the fixture describes the service that is actually there: the triplet (`original_network_id`, `transport_stream_id`, `service_id`) comes from the stream's own PAT and SDT, and the EPG is anchored to its TDT where it has one. An EIT whose triplet does not match the SDT describes nothing, and a receiver is right to ignore it.
- `tsp` replaces packets rather than creating them, so the table has to come out of existing stuffing. A broadcast capture has plenty and keeps its exact mux rate (verified: 9,945,951 b/s before and after); the ffmpeg-generated clip has none, so it is padded to CBR first and the script says so.
- Without a TDT the time reference is a fixed date rather than the wall clock, so the output is byte-reproducible for a given input — checked by generating twice and comparing SHA-256.
- `run.sh --with-eit` injects it before the round-trip and prints which SI PIDs came back.

The census is a report, not a gate, since a table outside `SI_PIDS` is dropped by design rather than by malfunction. On `main` today, with the generated clip:

```
### SI round-trip (source -> capture)
  TABLE      PID            SOURCE      CAPTURE
  NIT        0x0010              0            0
  SDT        0x0011             20           14
  EIT        0x0012             16            0
  TDT/TOT    0x0014              0            0
```

That makes the behaviour something the harness prints rather than something a reader has to derive from `SI_PIDS`, and it gives whatever lands for #2800 a before/after that does not need a broadcast capture.

## Public API changes

None. Test tooling only — no Rust, no JS, no wire format, no CLI surface.

## Test plan

- `make-eit-fixture.sh` on the ffmpeg-generated clip (no stuffing, no TDT): pads to CBR, injects, EIT p/f + schedule present with the ffmpeg triplet (service 1, ts 1, onid 0xFF01).
- `make-eit-fixture.sh` on a real DVB capture (CNN International EMEA HD, 9.95 Mb/s CBR, H.264 + MP2 + AC-3 + teletext + SCTE-35): no padding, mux rate unchanged, reference taken from the clip's own TDT, 1,007 EIT packets.
- `--pf-only` produces p/f with no schedule.
- Byte-reproducibility: two runs over the same input give identical SHA-256.
- `run.sh --analyze-only` on a generated fixture: `ts: PASS`.
- `run.sh --with-eit` end to end at `--duration 10` and `--duration 15`: round-trip completes, `ts: PASS`, census as above.
- `shellcheck` clean on both `make-eit-fixture.sh` and `run.sh`.

Requires `tstables` and `tsstuff` alongside the `tsp`/`tsanalyze` the harness already uses; all four come from the same TSDuck install, so the nix shell and CI already have them. `require_tools` checks for them only when `--with-eit` is passed.

(Written by Opus 5)
