### PR TITLE
docs(cli): add a broadcast primary-distribution recipe

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -522,6 +522,9 @@ repetition interval. So the service name, provider, type, and network survive th
 round-trip without being parsed. Regenerated tables (TDT/TOT) and EPG (EIT) are not
 captured: they are live or bulky rather than static identity.
 
+For a redundant broadcast chain built on these two verbs, see
+[Broadcast primary distribution](#broadcast-primary-distribution).
+
 ### FLV
 
 ```bash
@@ -536,6 +539,103 @@ moq --client-connect https://relay.example.com --broadcast my-stream.hang export
 FLV is the classic RTMP container: H.264 video and AAC audio, each with an
 out-of-band header. The enhanced E-RTMP FourCC payloads (HEVC, AV1, Opus) and the
 older codecs (VP6, MP3) are not supported on the stdin/stdout container path.
+
+## Broadcast primary distribution
+
+`import ts` and `export ts` carry a broadcast primary-distribution mux end to
+end, and the relay fans it out to as many receiving sites as required.
+Redundancy is achieved by doubling the chain rather than by any one component: a
+redundant source, two publishers, two relays, two subscribers, and receivers
+that select between the two outputs.
+
+```mermaid
+flowchart LR
+    SA[Source leg A] --> PA["moq import ts"] --> RA[moq-relay A] --> XA["moq export ts + pacer"]
+    SB[Source leg B] --> PB["moq import ts"] --> RB[moq-relay B] --> XB["moq export ts + pacer"]
+    XA --> IRD1[IRD 1]
+    XB --> IRD1
+    XA --> IRD2[IRD 2]
+    XB --> IRD2
+```
+
+MPEG-TS null stuffing is not carried. Where a constant-rate output is required,
+it is regenerated at the handoff.
+
+Every hop is QUIC, so the media is encrypted in transit as shown; for
+production, replace the anonymous `/anon` path with a path-scoped JWT (see
+[Authentication](#authentication)) and authenticate relay peering with mTLS.
+
+### Multicast RTP in (1+1)
+
+`import ts` reads a transport stream from stdin, so the multicast join belongs
+to whatever reads the group. Use a pass-through reader such as TSDuck rather
+than FFmpeg, which re-muxes:
+
+```bash
+# leg A
+tsp -I ip 239.10.0.1:5000 --local-address 10.0.0.7 -O file - \
+    | moq --origin 42 --client-connect https://relay-a.example.com/anon \
+          --broadcast event.hang import ts --latency-max 1s
+
+# leg B: the same command on a second host, same --origin, against the second
+#        relay and the source's other leg if it has one
+```
+
+Where the source is an ST 2022-7 pair, give each publisher one leg; where it is
+a single group, both publishers join it independently and see the same bytes, so
+the feed does not have to be duplicated locally. Either way a publisher may join
+an already-running feed. See [Redundant Publishers](#redundant-publishers-11)
+for what `--origin` promises.
+
+### Relays (1+)
+
+One relay per leg, kept independent of the other so the legs share no failure.
+Add relays *within* a leg for regional fan-out, dialing peers with
+[`cluster.connect`](/bin/relay/cluster):
+
+```bash
+moq-relay relay.toml \
+    --server-quic-congestion-control delay \
+    --server-quic-mtu-discovery=true
+```
+
+### Handoff to a broadcast receiver
+
+MoQ delivers objects in bursts, so `export ts` output is not constant-rate.
+Where the receiver needs one (a hardware IRD locking to PCR does), restore the
+cadence downstream with a CBR pacer, which is also the UDP/RTP sink: it emits
+the paced stream straight to a unicast or multicast destination, so nothing else
+sits between the subscriber and the receiver. Several tools will do it;
+[`mpegts-pacer`](https://github.com/tdrapier-wbd/mpegts-pacer) is one:
+
+```bash
+moq --client-connect https://relay-a.example.com/anon --broadcast event.hang \
+    export ts | mpegts-pacer 239.20.0.1:5000 12000000 --rtp
+```
+
+Pick a target rate above the content rate.
+
+### Redundant handoff (1+1)
+
+Give each leg its own pacer, stream-clocked and sharing the pair's rate, SSRC
+and sequence seed, so the two legs emit identical datagrams under identical RTP
+sequence numbers for an ST 2022-7 receiver to merge:
+
+```bash
+# leg A
+moq --client-connect https://relay-a.example.com/anon --broadcast event.hang \
+    export ts \
+    | mpegts-pacer 239.20.0.1:5000 12000000 --rtp --ssrc 538968071 \
+        --stream-clock --sequence-seed 0 --stall-ms 1000 --on-stall mute
+
+# leg B
+moq --client-connect https://relay-b.example.com/anon --broadcast event.hang \
+    export ts \
+    | mpegts-pacer 239.20.0.2:5000 12000000 --rtp --ssrc 538968071 \
+        --stream-clock --sequence-seed 0 --stall-ms 1000 --on-stall mute
+```
+
+Start both legs together.
 
 ## HLS
 


### PR DESCRIPTION
## Summary

- `cli.md` documents every endpoint but not how to wire `import ts` / `export ts` into a broadcast primary-distribution chain, which is where most of the MPEG-TS questions land. Adds a `## Broadcast primary distribution` section: multicast RTP ingest, relays, handoff to a receiver, and a redundant (1+1) handoff, plus a pointer to it from `### MPEG-TS`.
- Recipes only, no rationale or measurements. Four things a reader would otherwise get wrong are stated as constraints: FFmpeg re-muxes a broadcast mux where a pass-through reader does not, null stuffing is not carried so a constant-rate egress regenerates it, `export ts` output is not constant-rate and needs a CBR pacer for a hardware IRD, and redundancy comes from doubling the chain rather than from any one component.
- Placed at `##` level after `## Container Formats` rather than nested inside `### MPEG-TS`: nothing in `doc/bin/` uses `####` or deeper, and the default outline only lists `##`, so a nested version would be invisible in the page nav. Happy to move it if you would rather it sat inside the MPEG-TS subsection.
- The `--server-quic-congestion-control delay` and `--server-quic-mtu-discovery=true` flags in the relay recipe are what a long-haul TS trunk wants; the reasoning stays in `/bin/relay/config`, which the surrounding text already links.

## Two things to decide

- **The diagram is a `mermaid` block, and `vitepress-plugin-mermaid` is not a dependency**, so today it renders as a syntax-highlighted code block rather than a diagram. The build passes either way. Happy to add the plugin in this PR, or to replace the block with a plain-text diagram, whichever you prefer.
- **Suggestion, not part of this patch:** `### SRT` sits three sections away under `## Network Gateways`. It is the other broadcast-contribution transport in this document, so moving it next to `### MPEG-TS` (or next to this new section) would put the broadcast paths together.

The pacer named in the handoff recipes is external and offered as one option rather than a recommendation, consistent with a generic egress sink being scoped out of core in #1839.

## Public API changes

None. Documentation only.

## Test plan

- `just fix` and `just check` clean, including `bun remark . --quiet --frail`.
- `cd doc && bun run check` (tsc, `.vitepress` tests, `vitepress build`) passes; checked the rendered `bin/cli.html` for the new section and for how the mermaid block comes out.
- The recipes are the ones used to carry a live 9.9 Mbps DVB mux over the public internet through `moq-relay` to an ST 2022-7 receiver; the measurements behind each choice are written up at https://github.com/tdrapier-wbd/moq-mpegts-paper.

(Written by Claude Opus 5)

Made with [Cursor](https://cursor.com)