### PR TITLE
feat(libmoq)!: configure and label media renditions

### DIFF
--- a/cpp/obs/src/moq-output.cpp
+++ b/cpp/obs/src/moq-output.cpp
@@ -480,7 +480,7 @@ void MoQOutput::VideoInit(obs_encoder_t *encoder)
 	}
 
 	// Intialize the media import module with the codec and initialization data.
-	int handle = moq_publish_media(broadcast, moq_codec, strlen(moq_codec), extra_data, extra_size);
+	int handle = moq_publish_media(broadcast, moq_codec, strlen(moq_codec), extra_data, extra_size, NULL, 0);
 	video_tracks[encoder] = handle;
 	if (handle < 0) {
 		LOG_ERROR("Failed to initialize video track: %d", handle);
@@ -519,7 +519,7 @@ void MoQOutput::AudioInit(obs_encoder_t *encoder)
 
 	const char *codec = obs_encoder_get_codec(encoder);
 
-	int handle = moq_publish_media(broadcast, codec, strlen(codec), extra_data, extra_size);
+	int handle = moq_publish_media(broadcast, codec, strlen(codec), extra_data, extra_size, NULL, 0);
 	audio_tracks[encoder] = handle;
 	if (handle < 0) {
 		LOG_ERROR("Failed to initialize audio track: %d", handle);

--- a/cpp/obs/src/moq-output.cpp
+++ b/cpp/obs/src/moq-output.cpp
@@ -479,8 +479,13 @@ void MoQOutput::VideoInit(obs_encoder_t *encoder)
 		moq_codec = "hev1";
 	}
 
-	// Intialize the media import module with the codec and initialization data.
-	int handle = moq_publish_media(broadcast, moq_codec, strlen(moq_codec), extra_data, extra_size, NULL, 0);
+	// Initialize the media import module with the codec and initialization data.
+	moq_media_config config{};
+	config.format = moq_codec;
+	config.format_len = strlen(moq_codec);
+	config.init = extra_data;
+	config.init_len = extra_size;
+	int handle = moq_publish_media(broadcast, &config);
 	video_tracks[encoder] = handle;
 	if (handle < 0) {
 		LOG_ERROR("Failed to initialize video track: %d", handle);
@@ -519,7 +524,12 @@ void MoQOutput::AudioInit(obs_encoder_t *encoder)
 
 	const char *codec = obs_encoder_get_codec(encoder);
 
-	int handle = moq_publish_media(broadcast, codec, strlen(codec), extra_data, extra_size, NULL, 0);
+	moq_media_config config{};
+	config.format = codec;
+	config.format_len = strlen(codec);
+	config.init = extra_data;
+	config.init_len = extra_size;
+	int handle = moq_publish_media(broadcast, &config);
 	audio_tracks[encoder] = handle;
 	if (handle < 0) {
 		LOG_ERROR("Failed to initialize audio track: %d", handle);

--- a/cpp/obs/test/moq-output-test.cpp
+++ b/cpp/obs/test/moq-output-test.cpp
@@ -195,7 +195,7 @@ int32_t moq_publish_finish(uint32_t)
 	return 0;
 }
 
-int32_t moq_publish_media(uint32_t, const char *, size_t, const uint8_t *, size_t, const char *, size_t)
+int32_t moq_publish_media(uint32_t, const moq_media_config *)
 {
 	return 7;
 }
@@ -206,6 +206,11 @@ int32_t moq_publish_media_finish(uint32_t)
 }
 
 int32_t moq_publish_media_frame(uint32_t, const uint8_t *, uintptr_t, uint64_t)
+{
+	return 0;
+}
+
+int32_t moq_publish_media_cut(uint32_t)
 {
 	return 0;
 }

--- a/cpp/obs/test/moq-output-test.cpp
+++ b/cpp/obs/test/moq-output-test.cpp
@@ -195,7 +195,7 @@ int32_t moq_publish_finish(uint32_t)
 	return 0;
 }
 
-int32_t moq_publish_media(uint32_t, const char *, size_t, const uint8_t *, size_t)
+int32_t moq_publish_media(uint32_t, const char *, size_t, const uint8_t *, size_t, const char *, size_t)
 {
 	return 7;
 }

--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -13,6 +13,11 @@ A simple, WebCodecs-based media format utilizing MoQ. See the [specification](ht
 This is how the viewer decides what it can decode and wants to receive.
 The catalog track is live updated as media tracks are added, removed, or changed.
 
+Each audio, video, or text rendition may carry a human-readable `label` for a
+track picker. The rendition map key remains the transport track name used to
+subscribe, so labels do not need to be unique and changing one does not rename
+the track.
+
 Each media track is described using the [WebCodecs specification](https://www.w3.org/TR/webcodecs/) and we plan to support every codec in the [WebCodecs registry](https://w3c.github.io/webcodecs/codec_registry.html).
 
 ### Example
@@ -24,6 +29,7 @@ Here is Big Buck Bunny's `catalog.json` as of 2026-02-02:
   "video": {
     "renditions": {
       "video0": {
+        "label": "HD",
         "codec": "avc1.64001f",
         "description": "0164001fffe100196764001fac2484014016ec0440000003004000000c23c60c9201000568ee32c8b0",
         "codedWidth": 1280,
@@ -35,6 +41,7 @@ Here is Big Buck Bunny's `catalog.json` as of 2026-02-02:
   "audio": {
     "renditions": {
       "audio1": {
+        "label": "English",
         "codec": "mp4a.40.2",
         "sampleRate": 44100,
         "numberOfChannels": 2,

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -267,9 +267,11 @@ int32_t media = moq_publish_media(broadcast, &config);
 
 The transport track name is generated from the codec format. `label` is an
 optional human-readable rendition name stored in the audio or video catalog
-configuration, and leaving it zero omits it. The same optional pair is
-available on `moq_video_config` and `moq_audio_config`; pointers returned by the
-consume APIs borrow the catalog snapshot just like `name` and `codec`.
+configuration, and leaving it zero omits it. It names one rendition, so a
+container format (`fmp4`, `mkv`, `ts`, `flv`) returns an error rather than
+ignoring it: those publish and describe their own tracks. The same optional pair
+is available on `moq_video_config` and `moq_audio_config`; pointers returned by
+the consume APIs borrow the catalog snapshot just like `name` and `codec`.
 
 `moq_publish_video_raw` opens an encoder and a video track together. Resolution, framerate, and pixel layout are fixed there, so each `moq_video_encoder_frame` carries only pixels and a timestamp:
 

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -249,12 +249,27 @@ if (moq_consume_video_stalled(catalog, index, &stalled) < 0) {
 
 The `moq_publish_media_*` and `moq_consume_video` / `moq_consume_audio` calls carry already-encoded frames, for a caller that brings its own codec. The `_raw` calls carry uncompressed media instead and run the codec inside libmoq, so a C application can publish pixels and PCM without linking one.
 
-`moq_publish_media` generates the transport track name from the codec format.
-Its final `label` / `label_len` pair is an optional human-readable rendition
-name stored in the audio or video catalog configuration. Pass `NULL, 0` to omit
-it. The same optional pair is available on `moq_video_config` and
-`moq_audio_config`; pointers returned by the consume APIs borrow the catalog
-snapshot just like `name` and `codec`.
+`moq_publish_media` takes a `moq_media_config` so publishing options can grow
+without adding positional arguments. Zero the struct, then set its required
+`format` / `format_len` pair and any optional fields:
+
+```c
+moq_media_config config = {0};
+config.format = "opus";
+config.format_len = 4;
+config.init = opus_head;
+config.init_len = opus_head_len;
+config.label = "English";
+config.label_len = 7;
+
+int32_t media = moq_publish_media(broadcast, &config);
+```
+
+The transport track name is generated from the codec format. `label` is an
+optional human-readable rendition name stored in the audio or video catalog
+configuration, and leaving it zero omits it. The same optional pair is
+available on `moq_video_config` and `moq_audio_config`; pointers returned by the
+consume APIs borrow the catalog snapshot just like `name` and `codec`.
 
 `moq_publish_video_raw` opens an encoder and a video track together. Resolution, framerate, and pixel layout are fixed there, so each `moq_video_encoder_frame` carries only pixels and a timestamp:
 

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -249,6 +249,13 @@ if (moq_consume_video_stalled(catalog, index, &stalled) < 0) {
 
 The `moq_publish_media_*` and `moq_consume_video` / `moq_consume_audio` calls carry already-encoded frames, for a caller that brings its own codec. The `_raw` calls carry uncompressed media instead and run the codec inside libmoq, so a C application can publish pixels and PCM without linking one.
 
+`moq_publish_media` generates the transport track name from the codec format.
+Its final `label` / `label_len` pair is an optional human-readable rendition
+name stored in the audio or video catalog configuration. Pass `NULL, 0` to omit
+it. The same optional pair is available on `moq_video_config` and
+`moq_audio_config`; pointers returned by the consume APIs borrow the catalog
+snapshot just like `name` and `codec`.
+
 `moq_publish_video_raw` opens an encoder and a video track together. Resolution, framerate, and pixel layout are fixed there, so each `moq_video_encoder_frame` carries only pixels and a timestamp:
 
 ```c

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -204,8 +204,8 @@ media, err := broadcast.PublishMedia("avc3", nil, moq.WithVideoHint(moq.VideoHin
 `WithLabel` stores a human-readable rendition name in the catalog without
 changing the generated transport track name. Labels do not need to be unique.
 It names one rendition, so a container format (`fmp4`, `mkv`, `ts`, `flv`) returns
-an error rather than ignoring it: those describe their own tracks. The same goes
-for `WithVideoHint`.
+an error rather than ignoring it: those describe their own tracks. `WithVideoHint`
+is likewise an error on a container or an audio format.
 
 Each catalog `Video` has a `Stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
 

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -203,6 +203,9 @@ media, err := broadcast.PublishMedia("avc3", nil, moq.WithVideoHint(moq.VideoHin
 
 `WithLabel` stores a human-readable rendition name in the catalog without
 changing the generated transport track name. Labels do not need to be unique.
+It names one rendition, so a container format (`fmp4`, `mkv`, `ts`, `flv`) returns
+an error rather than ignoring it: those describe their own tracks. The same goes
+for `WithVideoHint`.
 
 Each catalog `Video` has a `Stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
 

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -198,8 +198,11 @@ with `WithVideoHint`:
 ```go
 media, err := broadcast.PublishMedia("avc3", nil, moq.WithVideoHint(moq.VideoHint{
     Coded: &moq.Dimensions{Width: 1920, Height: 1080},
-}))
+}), moq.WithLabel("Main camera"))
 ```
+
+`WithLabel` stores a human-readable rendition name in the catalog without
+changing the generated transport track name. Labels do not need to be unique.
 
 Each catalog `Video` has a `Stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -138,7 +138,9 @@ Moq.connect("https://relay.example.com").use { moq ->
 ```
 
 `label` is presentation metadata for a track picker and does not change the
-generated transport track name. Labels do not need to be unique.
+generated transport track name. Labels do not need to be unique. It names one
+rendition, so a container format (`fmp4`, `mkv`, `ts`, `flv`) throws rather than
+ignoring it: those describe their own tracks.
 
 Each catalog `Video` has a `stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -122,7 +122,9 @@ import dev.moq.*
 
 Moq.connect("https://relay.example.com").use { moq ->
     val broadcast = moq.createBroadcast("my-stream")
-    val audio = broadcast.publishMedia(Init(format = "opus", data = opusInitBytes, video = null))
+    val audio = broadcast.publishMedia(
+        Init(format = "opus", data = opusInitBytes, label = "English", video = null)
+    )
 
     // Audio has no keyframes, so `cut` is what gives it group boundaries. Once
     // per frame is the lowest latency; a segment cadence suits HLS/DASH.
@@ -134,6 +136,9 @@ Moq.connect("https://relay.example.com").use { moq ->
     broadcast.finish()
 }
 ```
+
+`label` is presentation metadata for a track picker and does not change the
+generated transport track name. Labels do not need to be unique.
 
 Each catalog `Video` has a `stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -140,7 +140,8 @@ Moq.connect("https://relay.example.com").use { moq ->
 `label` is presentation metadata for a track picker and does not change the
 generated transport track name. Labels do not need to be unique. It names one
 rendition, so a container format (`fmp4`, `mkv`, `ts`, `flv`) throws rather than
-ignoring it: those describe their own tracks.
+ignoring it: those describe their own tracks. `video` throws on a container or an
+audio format for the same reason.
 
 Each catalog `Video` has a `stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -101,7 +101,8 @@ Supported codec formats include `opus`, `avc3`, `hev1`, `av01`, `vp09`, and othe
 The optional `label` is presentation metadata for a track picker. The transport
 track name remains generated from the format and labels do not need to be unique.
 It names one rendition, so a container format (`fmp4`, `mkv`, `ts`, `flv`) raises
-rather than ignoring it: those describe their own tracks.
+rather than ignoring it: those describe their own tracks. `video` raises on a
+container or an audio format for the same reason.
 
 ### Publishing raw media
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -87,7 +87,7 @@ except moq.Error as err:
 
 ```python
 broadcast = client.create_broadcast("my-stream")
-audio = broadcast.publish_media("opus", opus_init_bytes)
+audio = broadcast.publish_media("opus", opus_init_bytes, label="English")
 
 # Audio has no keyframes, so `cut` is what gives it group boundaries. Once per
 # frame is the lowest latency; a segment cadence suits HLS/DASH.
@@ -98,6 +98,8 @@ broadcast.finish()
 ```
 
 Supported codec formats include `opus`, `avc3`, `hev1`, `av01`, `vp09`, and others. See [`hang`](/lib/rs/crate/hang) for the full list.
+The optional `label` is presentation metadata for a track picker. The transport
+track name remains generated from the format and labels do not need to be unique.
 
 ### Publishing raw media
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -100,6 +100,8 @@ broadcast.finish()
 Supported codec formats include `opus`, `avc3`, `hev1`, `av01`, `vp09`, and others. See [`hang`](/lib/rs/crate/hang) for the full list.
 The optional `label` is presentation metadata for a track picker. The transport
 track name remains generated from the format and labels do not need to be unique.
+It names one rendition, so a container format (`fmp4`, `mkv`, `ts`, `flv`) raises
+rather than ignoring it: those describe their own tracks.
 
 ### Publishing raw media
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -145,7 +145,9 @@ try broadcast.finish()
 ```
 
 The optional `label` is presentation metadata for a track picker and does not
-change the generated transport track name. Video publishers can pass
+change the generated transport track name. It names one rendition, so a container
+format (`fmp4`, `mkv`, `ts`, `flv`) throws rather than ignoring it: those describe
+their own tracks. Video publishers can pass
 `video: VideoHint(...)` to seed catalog fields before the stream reveals them.
 Use `publishMedia(on:format:initData:label:video:)` to accept a media track
 obtained from `BroadcastDynamic`.

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -147,7 +147,8 @@ try broadcast.finish()
 The optional `label` is presentation metadata for a track picker and does not
 change the generated transport track name. It names one rendition, so a container
 format (`fmp4`, `mkv`, `ts`, `flv`) throws rather than ignoring it: those describe
-their own tracks. Video publishers can pass
+their own tracks, and `video:` throws on a container or an audio format for the same
+reason. Video publishers can pass
 `video: VideoHint(...)` to seed catalog fields before the stream reveals them.
 Use `publishMedia(on:format:initData:label:video:)` to accept a media track
 obtained from `BroadcastDynamic`.

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -132,7 +132,7 @@ track.update(subscription: Subscription(priority: 20, ordered: false))
 
 ```swift
 let broadcast = try session.publisher.createBroadcast(path: "my-stream")
-let audio = try broadcast.publishMedia(format: "opus", initData: opusInitBytes)
+let audio = try broadcast.publishMedia(format: "opus", initData: opusInitBytes, label: "English")
 
 // Audio has no keyframes, so `cut` is what gives it group boundaries. Once per
 // frame is the lowest latency; a segment cadence suits HLS/DASH.
@@ -144,7 +144,11 @@ try audio.finish()
 try broadcast.finish()
 ```
 
-Video publishers can pass `video: VideoHint(...)` to seed catalog fields before the stream reveals them. Use `publishMedia(on:format:initData:video:)` to accept a media track obtained from `BroadcastDynamic`.
+The optional `label` is presentation metadata for a track picker and does not
+change the generated transport track name. Video publishers can pass
+`video: VideoHint(...)` to seed catalog fields before the stream reveals them.
+Use `publishMedia(on:format:initData:label:video:)` to accept a media track
+obtained from `BroadcastDynamic`.
 
 Each catalog `Video` has a `stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
 

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -148,7 +148,7 @@ Any field carrying raw bytes, notably `description`, is a hex string ({{binary}}
 The `display` field is the size to render the video at, in pixels.
 It is separate from a rendition's `displayAspectWidth`/`displayAspectHeight` because changing it does not require reinitializing the decoder.
 
-In addition to the WebCodecs fields, each rendition MAY carry the fields common to audio and video ({{common}}) plus:
+In addition to the WebCodecs fields, each rendition MAY carry the common rendition fields ({{common}}) plus:
 
 ~~~
 type VideoDecoderConfigExtensions = {
@@ -216,7 +216,7 @@ The `renditions` field contains a map of track names to audio decoder configurat
 See the [WebCodecs specification](https://www.w3.org/TR/webcodecs/#audio-decoder-config) for specifics and registered codecs.
 Any field carrying raw bytes, notably `description`, is a hex string ({{binary}}).
 
-In addition to the WebCodecs fields, each rendition MAY carry the fields common to audio and video ({{common}}).
+In addition to the WebCodecs fields, each rendition MAY carry the common rendition fields ({{common}}).
 
 ### PCM {#audio-pcm}
 
@@ -294,6 +294,7 @@ It SHOULD keep such a rendition selectable and treat the role as `subtitle`, and
 Unlike `format`, an unrecognized `role` never prevents rendering: it describes intent, not the wire.
 
 The `lang` field is the BCP-47 {{!RFC5646}} language tag of the track, for example `en` or `es-419`.
+Two renditions sharing a `lang` are told apart by `label` ({{field-label}}), one of the common rendition fields ({{common}}).
 
 Regardless of `format`, each frame's timestamp ({{container}}) is the authoritative cue start time on the media clock, so a relay and a consumer can order and schedule cues without parsing the payload.
 A text track has no delta frames: every frame is a self-contained cue, so a group MAY consist of multiple frames, following the same rule as a codec that lacks delta frames ({{container}}).

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -173,6 +173,7 @@ For example:
 {
   "renditions": {
     "720p": {
+      "label": "HD",
       "codec": "avc1.64001f",
       "container": { "kind": "legacy" },
       "codedWidth": 1280,
@@ -236,6 +237,7 @@ For example:
 {
   "renditions": {
     "stereo": {
+      "label": "English stereo",
       "codec": "opus",
       "container": { "kind": "legacy" },
       "sampleRate": 48000,
@@ -268,7 +270,6 @@ type TextConfig = {
 	"format": "vtt" | "ttml" | "utf8" | string,
 	"role": "subtitle" | "caption" | string | undefined,
 	"lang": string | undefined,
-	"label": string | undefined,
 	// plus the common rendition fields
 }
 ~~~
@@ -293,7 +294,6 @@ It SHOULD keep such a rendition selectable and treat the role as `subtitle`, and
 Unlike `format`, an unrecognized `role` never prevents rendering: it describes intent, not the wire.
 
 The `lang` field is the BCP-47 {{!RFC5646}} language tag of the track, for example `en` or `es-419`.
-The `label` field is a human-readable name for a track picker, useful when `lang` alone is ambiguous (for example distinguishing subtitles from same-language captions).
 
 Regardless of `format`, each frame's timestamp ({{container}}) is the authoritative cue start time on the media clock, so a relay and a consumer can order and schedule cues without parsing the payload.
 A text track has no delta frames: every frame is a self-contained cue, so a group MAY consist of multiple frames, following the same rule as a codec that lacks delta frames ({{container}}).
@@ -333,6 +333,7 @@ Audio, video, and text renditions share the following fields, extending the WebC
 ~~~
 type CommonExtensions = {
   "broadcast": string | undefined,
+  "label": string | undefined,
   "container": Container,
   "jitter": number | undefined,
 }
@@ -354,6 +355,11 @@ This lets a publisher author a catalog that points at tracks it does not republi
 For example, a transcoder produces a catalog listing its own downstream renditions alongside the untouched source rendition, referencing the latter in the source broadcast rather than copying the bytes through.
 
 A consumer subscribes to such a rendition in the referenced broadcast, using the rendition's track name unchanged.
+
+### label {#field-label}
+The `label` field is a human-readable rendition name for a track picker.
+It is presentation metadata, not the track name used to subscribe.
+Multiple renditions MAY use the same label.
 
 ### container {#field-container}
 The container used to frame this rendition's media, as described in {{container}}.

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -12,10 +12,18 @@ import (
 type MediaOption func(*mediaConfig)
 
 type mediaConfig struct {
+	label *string
 	video *VideoHint
 }
 
 var errNilTrackRequest = errors.New("moq: nil track request")
+
+// WithLabel sets the human-readable rendition name stored in the catalog.
+func WithLabel(label string) MediaOption {
+	return func(c *mediaConfig) {
+		c.label = &label
+	}
+}
 
 // WithVideoHint seeds catalog fields that a video stream cannot reveal itself.
 func WithVideoHint(hint VideoHint) MediaOption {
@@ -30,7 +38,7 @@ func mediaInit(format string, init []byte, opts []MediaOption) ffi.MoqInit {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return ffi.MoqInit{Format: format, Data: init, Video: cfg.video}
+	return ffi.MoqInit{Format: format, Data: init, Label: cfg.label, Video: cfg.video}
 }
 
 // BroadcastProducer publishes a collection of tracks. Create one at a path with

--- a/js/hang/src/catalog/audio.test.ts
+++ b/js/hang/src/catalog/audio.test.ts
@@ -12,3 +12,15 @@ test("pcm codec is accepted", () => {
 
 	expect(config.codec).toBe("pcm");
 });
+
+test("audio config accepts a human-readable label", () => {
+	const config = AudioConfigSchema.parse({
+		label: "English",
+		codec: "opus",
+		container: { kind: "legacy" },
+		sampleRate: 48_000,
+		numberOfChannels: 2,
+	});
+
+	expect(config.label).toBe("English");
+});

--- a/js/hang/src/catalog/audio.ts
+++ b/js/hang/src/catalog/audio.ts
@@ -19,6 +19,9 @@ export const AudioConfigSchema = z.object({
 	// If unset, the track lives in the same broadcast as the catalog.
 	broadcast: z.optional(RelativeBroadcastSchema),
 
+	// Human-readable rendition name for track pickers.
+	label: z.optional(z.string()),
+
 	// Registered WebCodecs codec string, or Hang's "pcm" extension for
 	// interleaved little-endian IEEE-754 binary32 samples.
 	codec: z.string(),

--- a/js/hang/src/catalog/video.test.ts
+++ b/js/hang/src/catalog/video.test.ts
@@ -26,6 +26,16 @@ test("video config accepts optional stalled state", () => {
 	expect(stalled.stalled).toBe(true);
 });
 
+test("video config accepts a human-readable label", () => {
+	const config = VideoConfigSchema.parse({
+		label: "Main camera",
+		codec: "vp8",
+		container: { kind: "legacy" },
+	});
+
+	expect(config.label).toBe("Main camera");
+});
+
 test("legacy video arrays derive display size from display aspect fields", () => {
 	const parsed = VideoSchema.parse([
 		{

--- a/js/hang/src/catalog/video.ts
+++ b/js/hang/src/catalog/video.ts
@@ -16,6 +16,9 @@ export const VideoConfigSchema = z.object({
 	// If unset, the track lives in the same broadcast as the catalog.
 	broadcast: z.optional(RelativeBroadcastSchema),
 
+	// Human-readable rendition name for track pickers.
+	label: z.optional(z.string()),
+
 	// See: https://w3c.github.io/webcodecs/codec_registry.html
 	codec: z.string(),
 

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
     from .subscribe import BroadcastConsumer, GroupConsumer, TrackConsumer
 
 
-def _media_init(format: str, init: bytes, video: VideoHint | None) -> MoqInit:
-    return MoqInit(format=format, data=init, video=video)
+def _media_init(format: str, init: bytes, video: VideoHint | None, label: str | None) -> MoqInit:
+    return MoqInit(format=format, data=init, label=label, video=video)
 
 
 class MediaProducer:
@@ -473,12 +473,13 @@ class BroadcastProducer:
         format: str,
         init: bytes = b"",
         video: VideoHint | None = None,
+        label: str | None = None,
     ) -> MediaProducer:
         """Publish a single media track. `format` selects the codec (e.g. "opus", "avc3"); `init` is
-        its codec init bytes (required for audio formats). `video` seeds catalog fields the stream
-        can't reveal (bitrate) or publishes the catalog before the first keyframe. See
-        :class:`VideoHint`."""
-        return MediaProducer(self._inner.publish_media(_media_init(format, init, video)))
+        its codec init bytes (required for audio formats). `label` is the human-readable rendition
+        name stored in the catalog. `video` seeds fields the stream can't reveal (bitrate) or
+        publishes the catalog before the first keyframe. See :class:`VideoHint`."""
+        return MediaProducer(self._inner.publish_media(_media_init(format, init, video, label)))
 
     def publish_media_on_track(
         self,
@@ -486,19 +487,23 @@ class BroadcastProducer:
         format: str,
         init: bytes = b"",
         video: VideoHint | None = None,
+        label: str | None = None,
     ) -> MediaProducer:
         """Publish media onto a requested track. See :meth:`publish_media` for the arguments."""
-        return MediaProducer(self._inner.publish_media_on_track(request._inner, _media_init(format, init, video)))
+        return MediaProducer(
+            self._inner.publish_media_on_track(request._inner, _media_init(format, init, video, label))
+        )
 
     def publish_media_stream(
         self,
         format: str,
         video: VideoHint | None = None,
+        label: str | None = None,
     ) -> MediaStreamProducer:
         """Publish a media track fed by a raw byte stream (unknown frame
         boundaries). `format` is a stream format (avc3, hev1, av01, fmp4, mkv).
-        `video` seeds catalog fields as in :meth:`publish_media`."""
-        return MediaStreamProducer(self._inner.publish_media_stream(_media_init(format, b"", video)))
+        `label` and `video` seed catalog fields as in :meth:`publish_media`."""
+        return MediaStreamProducer(self._inner.publish_media_stream(_media_init(format, b"", video, label)))
 
     def publish_audio(
         self,

--- a/rs/hang/CHANGELOG.md
+++ b/rs/hang/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Human-readable labels for audio and video renditions.
+
 ## [0.20.5](https://github.com/moq-dev/moq/compare/hang-v0.20.4...hang-v0.20.5) - 2026-08-14
 
 ### Fixed

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -77,6 +77,10 @@ pub struct AudioConfig {
 	#[serde(default)]
 	pub broadcast: Option<moq_net::PathRelativeOwned>,
 
+	/// Human-readable rendition name for track pickers.
+	#[serde(default)]
+	pub label: Option<String>,
+
 	// The codec, see the registry for details:
 	// https://w3c.github.io/webcodecs/codec_registry.html
 	#[serde_as(as = "DisplayFromStr")]
@@ -127,6 +131,7 @@ impl AudioConfig {
 	pub fn new(codec: impl Into<AudioCodec>, sample_rate: u32, channel_count: u32) -> Self {
 		Self {
 			broadcast: None,
+			label: None,
 			codec: codec.into(),
 			sample_rate,
 			channel_count,
@@ -135,5 +140,21 @@ impl AudioConfig {
 			container: Container::default(),
 			jitter: None,
 		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn label_round_trips() {
+		let mut config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		config.label = Some("English".to_string());
+
+		let encoded = serde_json::to_value(&config).expect("failed to encode");
+		assert_eq!(encoded["label"], "English");
+		let decoded: AudioConfig = serde_json::from_value(encoded).expect("failed to decode");
+		assert_eq!(decoded.label.as_deref(), Some("English"));
 	}
 }

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -223,6 +223,7 @@ mod test {
 			"video".to_string(),
 			VideoConfig {
 				broadcast: None,
+				label: None,
 				codec: H264 {
 					profile: 0x64,
 					constraints: 0x00,
@@ -249,6 +250,7 @@ mod test {
 			"audio".to_string(),
 			AudioConfig {
 				broadcast: None,
+				label: None,
 				codec: Opus,
 				sample_rate: 48_000,
 				channel_count: 2,

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -153,6 +153,10 @@ pub struct VideoConfig {
 	#[serde(default)]
 	pub broadcast: Option<moq_net::PathRelativeOwned>,
 
+	/// Human-readable rendition name for track pickers.
+	#[serde(default)]
+	pub label: Option<String>,
+
 	/// The codec, see the registry for details:
 	/// <https://w3c.github.io/webcodecs/codec_registry.html>
 	#[serde_as(as = "DisplayFromStr")]
@@ -237,6 +241,7 @@ impl VideoConfig {
 	pub fn new(codec: impl Into<VideoCodec>) -> Self {
 		Self {
 			broadcast: None,
+			label: None,
 			codec: codec.into(),
 			description: None,
 			coded_width: None,
@@ -258,6 +263,17 @@ mod test {
 	use crate::catalog::{Container, H264};
 
 	use super::*;
+
+	#[test]
+	fn label_round_trips() {
+		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.label = Some("Main camera".to_string());
+
+		let encoded = serde_json::to_value(&config).expect("failed to encode");
+		assert_eq!(encoded["label"], "Main camera");
+		let decoded: VideoConfig = serde_json::from_value(encoded).expect("failed to decode");
+		assert_eq!(decoded.label.as_deref(), Some("Main camera"));
+	}
 
 	#[test]
 	fn display_aspect_uses_canonical_json_names() {

--- a/rs/libmoq/CHANGELOG.md
+++ b/rs/libmoq/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Publish and consume human-readable audio and video rendition labels.
 
+### Changed
+
+- `moq_publish_media` now takes an extensible `moq_media_config` instead of positional arguments.
+
 ## [0.5.8](https://github.com/moq-dev/moq/compare/libmoq-v0.5.7...libmoq-v0.5.8) - 2026-08-14
 
 ### Added

--- a/rs/libmoq/CHANGELOG.md
+++ b/rs/libmoq/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `moq_publish_media` now takes an extensible `moq_media_config` instead of positional arguments.
+- `moq_video_config` and `moq_audio_config` gained trailing `label` / `label_len` fields. Both structs
+  are caller-allocated and the consume calls write into them, so this is a recompile, not a
+  drop-in replacement for an existing header.
+- `moq_publish_media` rejects a label on a container format (fmp4, mkv, ts, flv) instead of
+  silently dropping it.
 
 ## [0.5.8](https://github.com/moq-dev/moq/compare/libmoq-v0.5.7...libmoq-v0.5.8) - 2026-08-14
 

--- a/rs/libmoq/CHANGELOG.md
+++ b/rs/libmoq/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Publish and consume human-readable audio and video rendition labels.
+
 ## [0.5.8](https://github.com/moq-dev/moq/compare/libmoq-v0.5.7...libmoq-v0.5.8) - 2026-08-14
 
 ### Added

--- a/rs/libmoq/README.md
+++ b/rs/libmoq/README.md
@@ -45,7 +45,7 @@ int32_t moq_origin_announced_close(uint32_t announced);
 // Publishing
 int32_t moq_publish_set_announce(uint32_t broadcast, bool announce);
 int32_t moq_publish_finish(uint32_t broadcast);
-int32_t moq_publish_media(uint32_t broadcast, const char *format, uintptr_t format_len, const uint8_t *init, uintptr_t init_size, const char *label, uintptr_t label_len);
+int32_t moq_publish_media(uint32_t broadcast, const moq_media_config *config);
 int32_t moq_publish_media_finish(uint32_t media);
 int32_t moq_publish_media_frame(uint32_t media, const uint8_t *payload, uintptr_t payload_size, uint64_t timestamp_us);
 int32_t moq_publish_track(uint32_t broadcast, const char *name, uintptr_t name_len);

--- a/rs/libmoq/README.md
+++ b/rs/libmoq/README.md
@@ -45,7 +45,7 @@ int32_t moq_origin_announced_close(uint32_t announced);
 // Publishing
 int32_t moq_publish_set_announce(uint32_t broadcast, bool announce);
 int32_t moq_publish_finish(uint32_t broadcast);
-int32_t moq_publish_media(uint32_t broadcast, const char *format, uintptr_t format_len, const uint8_t *init, uintptr_t init_size);
+int32_t moq_publish_media(uint32_t broadcast, const char *format, uintptr_t format_len, const uint8_t *init, uintptr_t init_size, const char *name, uintptr_t name_len);
 int32_t moq_publish_media_finish(uint32_t media);
 int32_t moq_publish_media_frame(uint32_t media, const uint8_t *payload, uintptr_t payload_size, uint64_t timestamp_us);
 int32_t moq_publish_track(uint32_t broadcast, const char *name, uintptr_t name_len);

--- a/rs/libmoq/README.md
+++ b/rs/libmoq/README.md
@@ -45,7 +45,7 @@ int32_t moq_origin_announced_close(uint32_t announced);
 // Publishing
 int32_t moq_publish_set_announce(uint32_t broadcast, bool announce);
 int32_t moq_publish_finish(uint32_t broadcast);
-int32_t moq_publish_media(uint32_t broadcast, const char *format, uintptr_t format_len, const uint8_t *init, uintptr_t init_size, const char *name, uintptr_t name_len);
+int32_t moq_publish_media(uint32_t broadcast, const char *format, uintptr_t format_len, const uint8_t *init, uintptr_t init_size, const char *label, uintptr_t label_len);
 int32_t moq_publish_media_finish(uint32_t media);
 int32_t moq_publish_media_frame(uint32_t media, const uint8_t *payload, uintptr_t payload_size, uint64_t timestamp_us);
 int32_t moq_publish_track(uint32_t broadcast, const char *name, uintptr_t name_len);

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -1225,8 +1225,9 @@ pub extern "C" fn moq_publish_finish(broadcast: u32) -> i32 {
 ///
 /// [moq_media_config::label] is an optional human-readable name stored in the
 /// audio or video catalog configuration. The track name is generated from the
-/// format and remains an internal identifier. Labels apply only to single-codec
-/// formats; container formats describe their tracks independently.
+/// format and remains an internal identifier. It names one rendition, so a
+/// container format (fmp4, mkv, ts, flv), which publishes and describes its own
+/// tracks, rejects a label rather than ignoring it.
 ///
 /// Returns a non-zero handle to the track on success, or a negative code on failure.
 ///

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -101,6 +101,30 @@ pub(crate) fn borrow_container(container: &hang::catalog::Container) -> moq_cont
 	}
 }
 
+/// Configuration for [moq_publish_media].
+///
+/// `format` is required. Zero the struct and set only the fields the selected
+/// codec or container needs. New optional fields are appended so existing
+/// initializers keep their meaning.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct moq_media_config {
+	/// Codec or container format, NOT NULL terminated.
+	pub format: *const c_char,
+	/// Length of `format` in bytes.
+	pub format_len: usize,
+
+	/// Codec or container initialization bytes, or NULL when none are needed.
+	pub init: *const u8,
+	/// Length of `init` in bytes.
+	pub init_len: usize,
+
+	/// Human-readable rendition name for track pickers, or NULL if not used.
+	pub label: *const c_char,
+	/// Length of `label` in bytes.
+	pub label_len: usize,
+}
+
 /// Information about a video rendition in the catalog.
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -108,11 +132,6 @@ pub struct moq_video_config {
 	/// The name of the track, NOT NULL terminated.
 	pub name: *const c_char,
 	pub name_len: usize,
-
-	/// Human-readable rendition name for track pickers, or NULL if not used.
-	pub label: *const c_char,
-	/// Length of `label` in bytes.
-	pub label_len: usize,
 
 	/// The codec of the track, NOT NULL terminated
 	pub codec: *const c_char,
@@ -133,6 +152,11 @@ pub struct moq_video_config {
 
 	/// How the track's frames are wrapped.
 	pub container: moq_container,
+
+	/// Human-readable rendition name for track pickers, or NULL if not used.
+	pub label: *const c_char,
+	/// Length of `label` in bytes.
+	pub label_len: usize,
 }
 
 /// Catalog properties shared by every video rendition.
@@ -172,11 +196,6 @@ pub struct moq_audio_config {
 	pub name: *const c_char,
 	pub name_len: usize,
 
-	/// Human-readable rendition name for track pickers, or NULL if not used.
-	pub label: *const c_char,
-	/// Length of `label` in bytes.
-	pub label_len: usize,
-
 	/// The codec of the track, NOT NULL terminated
 	pub codec: *const c_char,
 	pub codec_len: usize,
@@ -193,6 +212,11 @@ pub struct moq_audio_config {
 
 	/// How the track's frames are wrapped.
 	pub container: moq_container,
+
+	/// Human-readable rendition name for track pickers, or NULL if not used.
+	pub label: *const c_char,
+	/// Length of `label` in bytes.
+	pub label_len: usize,
 }
 
 /// Options for a JSON snapshot track (lossy latest-value mode).
@@ -1196,34 +1220,29 @@ pub extern "C" fn moq_publish_finish(broadcast: u32) -> i32 {
 /// Create a new media track for a broadcast
 ///
 /// All frames in [moq_publish_media_frame] must be written in decode order.
-/// The `format` controls the encoding, both of `init` and frame payloads.
+/// [moq_media_config::format] controls the encoding, both of
+/// [moq_media_config::init] and frame payloads.
 ///
-/// The `label` is an optional human-readable name stored in the audio or video
-/// catalog configuration. The track name is generated from `format` and remains
-/// an internal identifier. Labels apply only to single-codec formats; container
-/// formats describe their tracks independently.
+/// [moq_media_config::label] is an optional human-readable name stored in the
+/// audio or video catalog configuration. The track name is generated from the
+/// format and remains an internal identifier. Labels apply only to single-codec
+/// formats; container formats describe their tracks independently.
 ///
 /// Returns a non-zero handle to the track on success, or a negative code on failure.
 ///
 /// # Safety
-/// - The caller must ensure that format is a valid pointer to format_len bytes of data.
-/// - The caller must ensure that init is a valid pointer to init_size bytes of data.
-/// - If label is non-null, the caller must ensure it points to label_len valid bytes.
+/// - `config` must be NULL, or point to an aligned, readable
+///   [moq_media_config]. Every non-NULL pointer inside it must be valid for its
+///   paired length, and all of them must stay alive for the duration of this
+///   call. A NULL config is rejected with an ordinary error.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_publish_media(
-	broadcast: u32,
-	format: *const c_char,
-	format_len: usize,
-	init: *const u8,
-	init_size: usize,
-	label: *const c_char,
-	label_len: usize,
-) -> i32 {
+pub unsafe extern "C" fn moq_publish_media(broadcast: u32, config: *const moq_media_config) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
-		let format = unsafe { ffi::parse_str(format, format_len)? };
-		let init = unsafe { ffi::parse_slice(init, init_size)? };
-		let label = unsafe { ffi::parse_str_optional(label, label_len)? };
+		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
+		let format = unsafe { ffi::parse_str(config.format, config.format_len)? };
+		let init = unsafe { ffi::parse_slice(config.init, config.init_len)? };
+		let label = unsafe { ffi::parse_str_optional(config.label, config.label_len)? };
 
 		State::lock().publish.media(broadcast, format, init, label)
 	})

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -109,6 +109,11 @@ pub struct moq_video_config {
 	pub name: *const c_char,
 	pub name_len: usize,
 
+	/// Human-readable rendition name for track pickers, or NULL if not used.
+	pub label: *const c_char,
+	/// Length of `label` in bytes.
+	pub label_len: usize,
+
 	/// The codec of the track, NOT NULL terminated
 	pub codec: *const c_char,
 	pub codec_len: usize,
@@ -166,6 +171,11 @@ pub struct moq_audio_config {
 	/// The name of the track, NOT NULL terminated
 	pub name: *const c_char,
 	pub name_len: usize,
+
+	/// Human-readable rendition name for track pickers, or NULL if not used.
+	pub label: *const c_char,
+	/// Length of `label` in bytes.
+	pub label_len: usize,
 
 	/// The codec of the track, NOT NULL terminated
 	pub codec: *const c_char,
@@ -1188,16 +1198,17 @@ pub extern "C" fn moq_publish_finish(broadcast: u32) -> i32 {
 /// All frames in [moq_publish_media_frame] must be written in decode order.
 /// The `format` controls the encoding, both of `init` and frame payloads.
 ///
-/// The `name` is an optional track name, made unique within the broadcast by an
-/// incrementing index prefix (`0.opus`, `1.opus`, ...). When NULL, it's derived
-/// from the format instead.
+/// The `label` is an optional human-readable name stored in the audio or video
+/// catalog configuration. The track name is generated from `format` and remains
+/// an internal identifier. Labels apply only to single-codec formats; container
+/// formats describe their tracks independently.
 ///
 /// Returns a non-zero handle to the track on success, or a negative code on failure.
 ///
 /// # Safety
 /// - The caller must ensure that format is a valid pointer to format_len bytes of data.
 /// - The caller must ensure that init is a valid pointer to init_size bytes of data.
-/// - If name is non-null, the caller must ensure it points to name_len valid bytes.
+/// - If label is non-null, the caller must ensure it points to label_len valid bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_publish_media(
 	broadcast: u32,
@@ -1205,16 +1216,16 @@ pub unsafe extern "C" fn moq_publish_media(
 	format_len: usize,
 	init: *const u8,
 	init_size: usize,
-	name: *const c_char,
-	name_len: usize,
+	label: *const c_char,
+	label_len: usize,
 ) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let format = unsafe { ffi::parse_str(format, format_len)? };
 		let init = unsafe { ffi::parse_slice(init, init_size)? };
-		let name = unsafe { ffi::parse_str_optional(name, name_len)? };
+		let label = unsafe { ffi::parse_str_optional(label, label_len)? };
 
-		State::lock().publish.media(broadcast, format, init, name)
+		State::lock().publish.media(broadcast, format, init, label)
 	})
 }
 
@@ -1327,6 +1338,7 @@ pub unsafe extern "C" fn moq_publish_video_properties(broadcast: u32, properties
 ///
 /// The struct fields are read as inputs:
 /// - `name` / `codec` are required (NOT NULL terminated) string slices.
+/// - `label` may be NULL to omit the human-readable rendition name.
 /// - `description` may be NULL to omit it.
 /// - `coded_width` / `coded_height` may be zero to omit them.
 /// - `container` describes how the frames written to the track are wrapped. A
@@ -1346,10 +1358,12 @@ pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const
 		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
 
 		let name = unsafe { ffi::parse_str(config.name, config.name_len)? };
+		let label = unsafe { ffi::parse_str_optional(config.label, config.label_len)? };
 		let codec = unsafe { ffi::parse_str(config.codec, config.codec_len)? };
 		let codec = hang::catalog::VideoCodec::from_str(codec).map_err(Error::Hang)?;
 
 		let mut video = hang::catalog::VideoConfig::new(codec);
+		video.label = label.map(str::to_string);
 		if !config.description.is_null() {
 			let description = unsafe { ffi::parse_slice(config.description, config.description_len)? };
 			video.description = Some(bytes::Bytes::copy_from_slice(description));
@@ -1372,6 +1386,7 @@ pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const
 ///
 /// The struct fields are read as inputs:
 /// - `name` / `codec` are required (NOT NULL terminated) string slices.
+/// - `label` may be NULL to omit the human-readable rendition name.
 /// - `sample_rate` / `channel_count` are required.
 /// - `description` may be NULL to omit it.
 /// - `container` describes how the frames written to the track are wrapped, the
@@ -1389,10 +1404,12 @@ pub unsafe extern "C" fn moq_publish_audio_config(broadcast: u32, config: *const
 		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
 
 		let name = unsafe { ffi::parse_str(config.name, config.name_len)? };
+		let label = unsafe { ffi::parse_str_optional(config.label, config.label_len)? };
 		let codec = unsafe { ffi::parse_str(config.codec, config.codec_len)? };
 		let codec = hang::catalog::AudioCodec::from_str(codec).map_err(Error::Hang)?;
 
 		let mut audio = hang::catalog::AudioConfig::new(codec, config.sample_rate, config.channel_count);
+		audio.label = label.map(str::to_string);
 		audio.container = unsafe { parse_container(&config.container)? };
 		if !config.description.is_null() {
 			let description = unsafe { ffi::parse_slice(config.description, config.description_len)? };

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -1188,11 +1188,16 @@ pub extern "C" fn moq_publish_finish(broadcast: u32) -> i32 {
 /// All frames in [moq_publish_media_frame] must be written in decode order.
 /// The `format` controls the encoding, both of `init` and frame payloads.
 ///
+/// The `name` is an optional track name, made unique within the broadcast by an
+/// incrementing index prefix (`0.opus`, `1.opus`, ...). When NULL, it's derived
+/// from the format instead.
+///
 /// Returns a non-zero handle to the track on success, or a negative code on failure.
 ///
 /// # Safety
 /// - The caller must ensure that format is a valid pointer to format_len bytes of data.
 /// - The caller must ensure that init is a valid pointer to init_size bytes of data.
+/// - If name is non-null, the caller must ensure it points to name_len valid bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_publish_media(
 	broadcast: u32,
@@ -1200,13 +1205,16 @@ pub unsafe extern "C" fn moq_publish_media(
 	format_len: usize,
 	init: *const u8,
 	init_size: usize,
+	name: *const c_char,
+	name_len: usize,
 ) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let format = unsafe { ffi::parse_str(format, format_len)? };
 		let init = unsafe { ffi::parse_slice(init, init_size)? };
+		let name = unsafe { ffi::parse_str_optional(name, name_len)? };
 
-		State::lock().publish.media(broadcast, format, init)
+		State::lock().publish.media(broadcast, format, init, name)
 	})
 }
 

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -195,6 +195,12 @@ impl Consume {
 		*dst = moq_video_config {
 			name: rendition.as_str().as_ptr() as *const c_char,
 			name_len: rendition.len(),
+			label: config
+				.label
+				.as_ref()
+				.map(|label| label.as_ptr() as *const c_char)
+				.unwrap_or(std::ptr::null()),
+			label_len: config.label.as_ref().map_or(0, String::len),
 			codec: codec.as_str().as_ptr() as *const c_char,
 			codec_len: codec.len(),
 			description: config
@@ -257,6 +263,12 @@ impl Consume {
 		*dst = moq_audio_config {
 			name: rendition.as_str().as_ptr() as *const c_char,
 			name_len: rendition.len(),
+			label: config
+				.label
+				.as_ref()
+				.map(|label| label.as_ptr() as *const c_char)
+				.unwrap_or(std::ptr::null()),
+			label_len: config.label.as_ref().map_or(0, String::len),
 			codec: codec.as_str().as_ptr() as *const c_char,
 			codec_len: codec.len(),
 			description: config

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -195,12 +195,6 @@ impl Consume {
 		*dst = moq_video_config {
 			name: rendition.as_str().as_ptr() as *const c_char,
 			name_len: rendition.len(),
-			label: config
-				.label
-				.as_ref()
-				.map(|label| label.as_ptr() as *const c_char)
-				.unwrap_or(std::ptr::null()),
-			label_len: config.label.as_ref().map_or(0, String::len),
 			codec: codec.as_str().as_ptr() as *const c_char,
 			codec_len: codec.len(),
 			description: config
@@ -212,6 +206,12 @@ impl Consume {
 			coded_width: config.coded_width.unwrap_or(0),
 			coded_height: config.coded_height.unwrap_or(0),
 			container: crate::api::borrow_container(&config.container),
+			label: config
+				.label
+				.as_ref()
+				.map(|label| label.as_ptr() as *const c_char)
+				.unwrap_or(std::ptr::null()),
+			label_len: config.label.as_ref().map_or(0, String::len),
 		};
 
 		Ok(())
@@ -263,12 +263,6 @@ impl Consume {
 		*dst = moq_audio_config {
 			name: rendition.as_str().as_ptr() as *const c_char,
 			name_len: rendition.len(),
-			label: config
-				.label
-				.as_ref()
-				.map(|label| label.as_ptr() as *const c_char)
-				.unwrap_or(std::ptr::null()),
-			label_len: config.label.as_ref().map_or(0, String::len),
 			codec: codec.as_str().as_ptr() as *const c_char,
 			codec_len: codec.len(),
 			description: config
@@ -280,6 +274,12 @@ impl Consume {
 			sample_rate: config.sample_rate,
 			channel_count: config.channel_count,
 			container: crate::api::borrow_container(&config.container),
+			label: config
+				.label
+				.as_ref()
+				.map(|label| label.as_ptr() as *const c_char)
+				.unwrap_or(std::ptr::null()),
+			label_len: config.label.as_ref().map_or(0, String::len),
 		};
 
 		Ok(())

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -81,7 +81,7 @@ impl Publish {
 		Ok(())
 	}
 
-	pub fn media(&mut self, broadcast: Id, format: &str, init: &[u8], name: Option<&str>) -> Result<Id, Error> {
+	pub fn media(&mut self, broadcast: Id, format: &str, init: &[u8], label: Option<&str>) -> Result<Id, Error> {
 		let (broadcast, catalog) = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
 
 		// A container may publish several tracks; a single codec fills one reserved
@@ -91,9 +91,11 @@ impl Publish {
 			Ok(container) => Media::Container(container),
 			Err(moq_mux::Error::UnknownFormat(_)) => {
 				let mut broadcast = broadcast.clone();
-				let name = broadcast.unique_name(&format!(".{}", name.unwrap_or(format)));
+				let name = broadcast.unique_name(&format!(".{format}"));
 				let request = broadcast.reserve_track(name)?;
-				match import::Track::new(request, catalog.reserve(), import::Init::new(format, init.to_vec())) {
+				let mut media_init = import::Init::new(format, init.to_vec());
+				media_init.label = label.map(str::to_string);
+				match import::Track::new(request, catalog.reserve(), media_init) {
 					Ok(track) => Media::Track(Box::new(track)),
 					Err(moq_mux::Error::UnknownFormat(_)) => return Err(Error::UnknownFormat(format.to_string())),
 					Err(err) => return Err(err.into()),

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -81,7 +81,7 @@ impl Publish {
 		Ok(())
 	}
 
-	pub fn media(&mut self, broadcast: Id, format: &str, init: &[u8]) -> Result<Id, Error> {
+	pub fn media(&mut self, broadcast: Id, format: &str, init: &[u8], name: Option<&str>) -> Result<Id, Error> {
 		let (broadcast, catalog) = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
 
 		// A container may publish several tracks; a single codec fills one reserved
@@ -91,7 +91,7 @@ impl Publish {
 			Ok(container) => Media::Container(container),
 			Err(moq_mux::Error::UnknownFormat(_)) => {
 				let mut broadcast = broadcast.clone();
-				let name = broadcast.unique_name(&format!(".{format}"));
+				let name = broadcast.unique_name(&format!(".{}", name.unwrap_or(format)));
 				let request = broadcast.reserve_track(name)?;
 				match import::Track::new(request, catalog.reserve(), import::Init::new(format, init.to_vec())) {
 					Ok(track) => Media::Track(Box::new(track)),

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -84,17 +84,18 @@ impl Publish {
 	pub fn media(&mut self, broadcast: Id, format: &str, init: &[u8], label: Option<&str>) -> Result<Id, Error> {
 		let (broadcast, catalog) = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
 
+		let mut media_init = import::Init::new(format, init.to_vec());
+		media_init.label = label.map(str::to_string);
+
 		// A container may publish several tracks; a single codec fills one reserved
 		// track. Try the container first so a codec format doesn't reserve a stray
 		// track on the way to being recognized.
-		let media = match import::Container::new(broadcast.clone(), catalog.reserve(), format, init) {
+		let media = match import::Container::new(broadcast.clone(), catalog.reserve(), &media_init) {
 			Ok(container) => Media::Container(container),
 			Err(moq_mux::Error::UnknownFormat(_)) => {
 				let mut broadcast = broadcast.clone();
 				let name = broadcast.unique_name(&format!(".{format}"));
 				let request = broadcast.reserve_track(name)?;
-				let mut media_init = import::Init::new(format, init.to_vec());
-				media_init.label = label.map(str::to_string);
 				match import::Track::new(request, catalog.reserve(), media_init) {
 					Ok(track) => Media::Track(Box::new(track)),
 					Err(moq_mux::Error::UnknownFormat(_)) => return Err(Error::UnknownFormat(format.to_string())),

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -192,6 +192,8 @@ fn publish_media_lifecycle() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -201,6 +203,150 @@ fn publish_media_lifecycle() {
 
 	assert_eq!(moq_publish_media_finish(media), 0);
 	assert_eq!(moq_publish_finish(broadcast), 0);
+}
+
+/// Read the rendition name back out of a consumed audio config.
+fn cfg_name(cfg: &moq_audio_config) -> &str {
+	unsafe { std::str::from_utf8(std::slice::from_raw_parts(cfg.name.cast::<u8>(), cfg.name_len)) }.unwrap()
+}
+
+/// The name passed to `moq_publish_media` becomes the track name in the catalog,
+/// made unique the same way the format-derived name is. Two tracks sharing a name
+/// get distinct indices rather than colliding.
+#[test]
+fn publish_media_named_track() {
+	let origin = id(moq_origin_create());
+	let path = b"named-track";
+	let broadcast = publish_broadcast(origin, path);
+
+	let init = opus_head();
+	let format = b"opus";
+	let name = b"audio";
+
+	// The first track named "audio" becomes "0.audio".
+	let media1 = id(unsafe {
+		moq_publish_media(
+			broadcast,
+			format.as_ptr() as *const c_char,
+			format.len(),
+			init.as_ptr(),
+			init.len(),
+			name.as_ptr() as *const c_char,
+			name.len(),
+		)
+	});
+
+	let consume = request_broadcast(origin, path);
+	let catalog_cb = Callback::new();
+	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
+	let catalog_id1 = id(catalog_cb.recv());
+
+	let mut audio_cfg = moq_audio_config {
+		name: std::ptr::null(),
+		name_len: 0,
+		codec: std::ptr::null(),
+		codec_len: 0,
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 0,
+		channel_count: 0,
+	};
+	assert_eq!(unsafe { moq_consume_audio_config(catalog_id1, 0, &mut audio_cfg) }, 0);
+	assert_eq!(cfg_name(&audio_cfg), "0.audio");
+
+	// A second track with the same name gets the next index, and the refreshed
+	// catalog carries both.
+	let media2 = id(unsafe {
+		moq_publish_media(
+			broadcast,
+			format.as_ptr() as *const c_char,
+			format.len(),
+			init.as_ptr(),
+			init.len(),
+			name.as_ptr() as *const c_char,
+			name.len(),
+		)
+	});
+
+	let catalog_id2 = id(catalog_cb.recv());
+	assert_eq!(unsafe { moq_consume_audio_config(catalog_id2, 0, &mut audio_cfg) }, 0);
+	assert_eq!(cfg_name(&audio_cfg), "0.audio");
+	assert_eq!(unsafe { moq_consume_audio_config(catalog_id2, 1, &mut audio_cfg) }, 0);
+	assert_eq!(cfg_name(&audio_cfg), "1.audio");
+
+	assert_eq!(moq_consume_catalog_free(catalog_id1), 0);
+	assert_eq!(moq_consume_catalog_free(catalog_id2), 0);
+	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
+	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
+	assert_eq!(moq_consume_close(consume), 0);
+	assert_eq!(moq_publish_media_finish(media1), 0);
+	assert_eq!(moq_publish_media_finish(media2), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+/// An unnamed track still gets a unique name from its format, and shares the
+/// broadcast with a named one without colliding.
+#[test]
+fn publish_media_unnamed_uses_format_name() {
+	let origin = id(moq_origin_create());
+	let path = b"named-and-unnamed";
+	let broadcast = publish_broadcast(origin, path);
+
+	let init = opus_head();
+	let format = b"opus";
+
+	let media1 = id(unsafe {
+		moq_publish_media(
+			broadcast,
+			format.as_ptr() as *const c_char,
+			format.len(),
+			init.as_ptr(),
+			init.len(),
+			b"audio".as_ptr() as *const c_char,
+			5,
+		)
+	});
+	let media2 = id(unsafe {
+		moq_publish_media(
+			broadcast,
+			format.as_ptr() as *const c_char,
+			format.len(),
+			init.as_ptr(),
+			init.len(),
+			std::ptr::null(),
+			0,
+		)
+	});
+
+	let consume = request_broadcast(origin, path);
+	let catalog_cb = Callback::new();
+	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
+	let catalog_id = id(catalog_cb.recv());
+
+	let mut audio_cfg = moq_audio_config {
+		name: std::ptr::null(),
+		name_len: 0,
+		codec: std::ptr::null(),
+		codec_len: 0,
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 0,
+		channel_count: 0,
+	};
+	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 0, &mut audio_cfg) }, 0);
+	assert_eq!(cfg_name(&audio_cfg), "0.audio");
+	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 1, &mut audio_cfg) }, 0);
+	assert_eq!(cfg_name(&audio_cfg), "0.opus");
+
+	assert_eq!(moq_consume_catalog_free(catalog_id), 0);
+	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
+	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
+	assert_eq!(moq_consume_close(consume), 0);
+	assert_eq!(moq_publish_media_finish(media1), 0);
+	assert_eq!(moq_publish_media_finish(media2), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
 }
 
 #[test]
@@ -1430,6 +1576,8 @@ fn double_close_all_resource_types() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -1448,6 +1596,8 @@ fn double_close_all_resource_types() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -1503,6 +1653,8 @@ fn media_cut_bounds_audio_groups() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -1545,6 +1697,8 @@ fn unknown_format() {
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
+			std::ptr::null(),
+			0,
 			std::ptr::null(),
 			0,
 		)
@@ -1629,6 +1783,8 @@ fn local_publish_consume() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -1742,6 +1898,8 @@ fn consume_announced_local() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -1817,6 +1975,8 @@ fn video_publish_consume() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -2369,6 +2529,8 @@ fn video_raw_decode() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -2451,6 +2613,8 @@ fn multiple_frames_ordering() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -2519,6 +2683,8 @@ fn catalog_update_on_new_track() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 
@@ -2548,6 +2714,8 @@ fn catalog_update_on_new_track() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
+			std::ptr::null(),
+			0,
 		)
 	});
 

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -226,6 +226,22 @@ fn publish_media_rejects_a_null_config() {
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
+/// A container publishes and describes its own tracks, so there is no single rendition for a label
+/// to name. Report that rather than accepting the call and dropping the label.
+#[test]
+fn publish_media_rejects_a_label_on_a_container_format() {
+	let origin = id(moq_origin_create());
+	let broadcast = publish_broadcast(origin, b"publish-media-container-label");
+
+	assert!(publish_media(broadcast, b"fmp4", &[], Some(b"English")) < 0);
+	// The same container format is fine without one.
+	let media = id(publish_media(broadcast, b"fmp4", &[], None));
+
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
 fn borrowed_string(ptr: *const c_char, len: usize) -> Option<String> {
 	if ptr.is_null() {
 		return None;

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -137,6 +137,26 @@ fn h264_init() -> Vec<u8> {
 	init
 }
 
+fn publish_media(broadcast: u32, format: &[u8], init: &[u8], label: Option<&[u8]>) -> i32 {
+	let (label, label_len) = label
+		.map(|label| (label.as_ptr() as *const c_char, label.len()))
+		.unwrap_or((std::ptr::null(), 0));
+	let config = moq_media_config {
+		format: format.as_ptr() as *const c_char,
+		format_len: format.len(),
+		init: if !init.is_empty() {
+			init.as_ptr()
+		} else {
+			std::ptr::null()
+		},
+		init_len: init.len(),
+		label,
+		label_len,
+	};
+
+	unsafe { moq_publish_media(broadcast, &config) }
+}
+
 #[test]
 fn origin_lifecycle() {
 	let origin = id(moq_origin_create());
@@ -185,17 +205,7 @@ fn publish_media_lifecycle() {
 
 	let init = opus_head();
 	let format = b"opus";
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	let payload = b"opus frame";
 	let ret = unsafe { moq_publish_media_frame(media, payload.as_ptr(), payload.len(), 1000) };
@@ -203,6 +213,17 @@ fn publish_media_lifecycle() {
 
 	assert_eq!(moq_publish_media_finish(media), 0);
 	assert_eq!(moq_publish_finish(broadcast), 0);
+}
+
+#[test]
+fn publish_media_rejects_a_null_config() {
+	let origin = id(moq_origin_create());
+	let broadcast = publish_broadcast(origin, b"publish-media-null-config");
+
+	assert!(unsafe { moq_publish_media(broadcast, std::ptr::null()) } < 0);
+
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
 }
 
 fn borrowed_string(ptr: *const c_char, len: usize) -> Option<String> {
@@ -229,17 +250,7 @@ fn publish_media_labels_config_without_naming_track() {
 	let format = b"opus";
 	let label = b"English";
 
-	let media1 = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			label.as_ptr() as *const c_char,
-			label.len(),
-		)
-	});
+	let media1 = id(publish_media(broadcast, format, &init, Some(label)));
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -269,17 +280,7 @@ fn publish_media_labels_config_without_naming_track() {
 		Some("English")
 	);
 
-	let media2 = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			label.as_ptr() as *const c_char,
-			label.len(),
-		)
-	});
+	let media2 = id(publish_media(broadcast, format, &init, Some(label)));
 
 	let catalog_id2 = id(catalog_cb.recv());
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id2, 0, &mut audio_cfg) }, 0);
@@ -1570,17 +1571,7 @@ fn double_close_all_resource_types() {
 	let broadcast = publish_broadcast(origin, b"double-close-all-resource-types");
 	let init = opus_head();
 	let format = b"opus";
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	assert_eq!(moq_publish_media_finish(media), 0);
 	assert!(moq_publish_media_finish(media) < 0);
@@ -1590,17 +1581,7 @@ fn double_close_all_resource_types() {
 	let path = b"double-close-test";
 	let broadcast = publish_broadcast(origin, path);
 	let init = opus_head();
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -1647,17 +1628,7 @@ fn media_cut_bounds_audio_groups() {
 	let broadcast = publish_broadcast(origin, b"media-cut");
 	let init = opus_head();
 	let format = b"opus";
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	let payload = b"test";
 	for i in 0..3u64 {
@@ -1693,17 +1664,7 @@ fn unknown_format() {
 	}));
 
 	let format = b"nope";
-	let ret = unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			std::ptr::null(),
-			0,
-			std::ptr::null(),
-			0,
-		)
-	};
+	let ret = publish_media(broadcast, format, &[], None);
 	assert!(ret < 0, "unknown format should fail");
 }
 
@@ -1777,17 +1738,7 @@ fn local_publish_consume() {
 
 	let init = opus_head();
 	let format = b"opus";
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -1896,17 +1847,7 @@ fn consume_announced_local() {
 	let broadcast = publish_broadcast(origin, path);
 	let init = opus_head();
 	let format = b"opus";
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	// First the broadcast handle, then a terminal 0 once the wait finishes.
 	let consume = id(cb.recv());
@@ -1975,17 +1916,7 @@ fn video_publish_consume() {
 
 	let init = h264_init();
 	let format = b"avc3";
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -2533,17 +2464,7 @@ fn video_raw_decode() {
 	// inline parameter sets, so the decoder reads the true 320x240 from the wire.
 	let init = h264_init();
 	let format = b"avc3";
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -2617,17 +2538,7 @@ fn multiple_frames_ordering() {
 
 	let init = opus_head();
 	let format = b"opus";
-	let media = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media = id(publish_media(broadcast, format, &init, None));
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -2687,17 +2598,7 @@ fn catalog_update_on_new_track() {
 
 	let init = opus_head();
 	let format = b"opus";
-	let media1 = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media1 = id(publish_media(broadcast, format, &init, None));
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -2720,17 +2621,7 @@ fn catalog_update_on_new_track() {
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id1, 0, &mut audio_cfg) }, 0);
 	assert!(unsafe { moq_consume_audio_config(catalog_id1, 1, &mut audio_cfg) } < 0);
 
-	let media2 = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
+	let media2 = id(publish_media(broadcast, format, &init, None));
 
 	let catalog_id2 = id(catalog_cb.recv());
 

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -205,25 +205,30 @@ fn publish_media_lifecycle() {
 	assert_eq!(moq_publish_finish(broadcast), 0);
 }
 
-/// Read the rendition name back out of a consumed audio config.
-fn cfg_name(cfg: &moq_audio_config) -> &str {
-	unsafe { std::str::from_utf8(std::slice::from_raw_parts(cfg.name.cast::<u8>(), cfg.name_len)) }.unwrap()
+fn borrowed_string(ptr: *const c_char, len: usize) -> Option<String> {
+	if ptr.is_null() {
+		return None;
+	}
+
+	Some(
+		unsafe { std::str::from_utf8(std::slice::from_raw_parts(ptr.cast::<u8>(), len)) }
+			.unwrap()
+			.to_string(),
+	)
 }
 
-/// The name passed to `moq_publish_media` becomes the track name in the catalog,
-/// made unique the same way the format-derived name is. Two tracks sharing a name
-/// get distinct indices rather than colliding.
+/// A label describes the rendition without changing its generated track name.
+/// Duplicate labels remain valid because the transport identifiers stay unique.
 #[test]
-fn publish_media_named_track() {
+fn publish_media_labels_config_without_naming_track() {
 	let origin = id(moq_origin_create());
-	let path = b"named-track";
+	let path = b"labeled-track";
 	let broadcast = publish_broadcast(origin, path);
 
 	let init = opus_head();
 	let format = b"opus";
-	let name = b"audio";
+	let label = b"English";
 
-	// The first track named "audio" becomes "0.audio".
 	let media1 = id(unsafe {
 		moq_publish_media(
 			broadcast,
@@ -231,8 +236,8 @@ fn publish_media_named_track() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
-			name.as_ptr() as *const c_char,
-			name.len(),
+			label.as_ptr() as *const c_char,
+			label.len(),
 		)
 	});
 
@@ -244,18 +249,26 @@ fn publish_media_named_track() {
 	let mut audio_cfg = moq_audio_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
 		description_len: 0,
 		sample_rate: 0,
 		channel_count: 0,
+		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id1, 0, &mut audio_cfg) }, 0);
-	assert_eq!(cfg_name(&audio_cfg), "0.audio");
+	assert_eq!(
+		borrowed_string(audio_cfg.name, audio_cfg.name_len).as_deref(),
+		Some("0.opus")
+	);
+	assert_eq!(
+		borrowed_string(audio_cfg.label, audio_cfg.label_len).as_deref(),
+		Some("English")
+	);
 
-	// A second track with the same name gets the next index, and the refreshed
-	// catalog carries both.
 	let media2 = id(unsafe {
 		moq_publish_media(
 			broadcast,
@@ -263,83 +276,33 @@ fn publish_media_named_track() {
 			format.len(),
 			init.as_ptr(),
 			init.len(),
-			name.as_ptr() as *const c_char,
-			name.len(),
+			label.as_ptr() as *const c_char,
+			label.len(),
 		)
 	});
 
 	let catalog_id2 = id(catalog_cb.recv());
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id2, 0, &mut audio_cfg) }, 0);
-	assert_eq!(cfg_name(&audio_cfg), "0.audio");
+	assert_eq!(
+		borrowed_string(audio_cfg.name, audio_cfg.name_len).as_deref(),
+		Some("0.opus")
+	);
+	assert_eq!(
+		borrowed_string(audio_cfg.label, audio_cfg.label_len).as_deref(),
+		Some("English")
+	);
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id2, 1, &mut audio_cfg) }, 0);
-	assert_eq!(cfg_name(&audio_cfg), "1.audio");
+	assert_eq!(
+		borrowed_string(audio_cfg.name, audio_cfg.name_len).as_deref(),
+		Some("1.opus")
+	);
+	assert_eq!(
+		borrowed_string(audio_cfg.label, audio_cfg.label_len).as_deref(),
+		Some("English")
+	);
 
 	assert_eq!(moq_consume_catalog_free(catalog_id1), 0);
 	assert_eq!(moq_consume_catalog_free(catalog_id2), 0);
-	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
-	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
-	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_media_finish(media1), 0);
-	assert_eq!(moq_publish_media_finish(media2), 0);
-	assert_eq!(moq_publish_finish(broadcast), 0);
-	assert_eq!(moq_origin_close(origin), 0);
-}
-
-/// An unnamed track still gets a unique name from its format, and shares the
-/// broadcast with a named one without colliding.
-#[test]
-fn publish_media_unnamed_uses_format_name() {
-	let origin = id(moq_origin_create());
-	let path = b"named-and-unnamed";
-	let broadcast = publish_broadcast(origin, path);
-
-	let init = opus_head();
-	let format = b"opus";
-
-	let media1 = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			b"audio".as_ptr() as *const c_char,
-			5,
-		)
-	});
-	let media2 = id(unsafe {
-		moq_publish_media(
-			broadcast,
-			format.as_ptr() as *const c_char,
-			format.len(),
-			init.as_ptr(),
-			init.len(),
-			std::ptr::null(),
-			0,
-		)
-	});
-
-	let consume = request_broadcast(origin, path);
-	let catalog_cb = Callback::new();
-	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
-	let catalog_id = id(catalog_cb.recv());
-
-	let mut audio_cfg = moq_audio_config {
-		name: std::ptr::null(),
-		name_len: 0,
-		codec: std::ptr::null(),
-		codec_len: 0,
-		description: std::ptr::null(),
-		description_len: 0,
-		sample_rate: 0,
-		channel_count: 0,
-	};
-	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 0, &mut audio_cfg) }, 0);
-	assert_eq!(cfg_name(&audio_cfg), "0.audio");
-	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 1, &mut audio_cfg) }, 0);
-	assert_eq!(cfg_name(&audio_cfg), "0.opus");
-
-	assert_eq!(moq_consume_catalog_free(catalog_id), 0);
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
 	assert_eq!(moq_consume_close(consume), 0);
@@ -356,6 +319,8 @@ fn publish_catalog_config_invalid_broadcast() {
 	let video = moq_video_config {
 		name: name.as_ptr() as *const c_char,
 		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: codec.as_ptr() as *const c_char,
 		codec_len: codec.len(),
 		description: std::ptr::null(),
@@ -371,6 +336,8 @@ fn publish_catalog_config_invalid_broadcast() {
 	let audio = moq_audio_config {
 		name: name.as_ptr() as *const c_char,
 		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: audio_codec.as_ptr() as *const c_char,
 		codec_len: audio_codec.len(),
 		description: std::ptr::null(),
@@ -415,6 +382,7 @@ fn publish_catalog_roundtrip() {
 
 	// Author the catalog directly instead of via moq_publish_media.
 	let video_name = "video";
+	let video_label = "Main camera";
 	let video_codec = "vp8";
 	let width: u32 = 1920;
 	let height: u32 = 1080;
@@ -422,6 +390,8 @@ fn publish_catalog_roundtrip() {
 	let video = moq_video_config {
 		name: video_name.as_ptr() as *const c_char,
 		name_len: video_name.len(),
+		label: video_label.as_ptr() as *const c_char,
+		label_len: video_label.len(),
 		codec: video_codec.as_ptr() as *const c_char,
 		codec_len: video_codec.len(),
 		description: description.as_ptr(),
@@ -435,6 +405,8 @@ fn publish_catalog_roundtrip() {
 	let stalled_video = moq_video_config {
 		name: stalled_video_name.as_ptr() as *const c_char,
 		name_len: stalled_video_name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: video_codec.as_ptr() as *const c_char,
 		codec_len: video_codec.len(),
 		description: description.as_ptr(),
@@ -467,10 +439,13 @@ fn publish_catalog_roundtrip() {
 	assert_eq!(unsafe { moq_publish_video_properties(broadcast, &properties) }, 0);
 
 	let audio_name = "audio";
+	let audio_label = "English";
 	let audio_codec = "opus";
 	let audio = moq_audio_config {
 		name: audio_name.as_ptr() as *const c_char,
 		name_len: audio_name.len(),
+		label: audio_label.as_ptr() as *const c_char,
+		label_len: audio_label.len(),
 		codec: audio_codec.as_ptr() as *const c_char,
 		codec_len: audio_codec.len(),
 		description: std::ptr::null(),
@@ -491,6 +466,8 @@ fn publish_catalog_roundtrip() {
 	let mut video_cfg = moq_video_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -508,6 +485,10 @@ fn publish_catalog_roundtrip() {
 	}
 	.unwrap();
 	assert_eq!(codec, "vp8");
+	assert_eq!(
+		borrowed_string(video_cfg.label, video_cfg.label_len).as_deref(),
+		Some("Main camera")
+	);
 	assert_eq!(video_cfg.coded_width, 1920);
 	assert_eq!(video_cfg.coded_height, 1080);
 	let mut stalled = std::mem::MaybeUninit::<bool>::uninit();
@@ -554,6 +535,8 @@ fn publish_catalog_roundtrip() {
 	let mut audio_cfg = moq_audio_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -563,6 +546,10 @@ fn publish_catalog_roundtrip() {
 		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 0, &mut audio_cfg) }, 0);
+	assert_eq!(
+		borrowed_string(audio_cfg.label, audio_cfg.label_len).as_deref(),
+		Some("English")
+	);
 	assert_eq!(audio_cfg.sample_rate, 48000);
 	assert_eq!(audio_cfg.channel_count, 2);
 
@@ -602,6 +589,8 @@ fn a_half_specified_coded_size_round_trips() {
 	let mut video = moq_video_config {
 		name: name.as_ptr() as *const c_char,
 		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: codec.as_ptr() as *const c_char,
 		codec_len: codec.len(),
 		description: std::ptr::null(),
@@ -620,6 +609,8 @@ fn a_half_specified_coded_size_round_trips() {
 	let mut read = moq_video_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -676,6 +667,8 @@ fn raw_loc_video_uses_the_declared_catalog_container() {
 	let video = moq_video_config {
 		name: name.as_ptr() as *const c_char,
 		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: codec.as_ptr() as *const c_char,
 		codec_len: codec.len(),
 		description: std::ptr::null(),
@@ -699,6 +692,8 @@ fn raw_loc_video_uses_the_declared_catalog_container() {
 	let mut video_cfg = moq_video_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -766,6 +761,8 @@ fn cmaf_catalog_container_carries_its_init_segment() {
 	let audio = moq_audio_config {
 		name: name.as_ptr() as *const c_char,
 		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: codec.as_ptr() as *const c_char,
 		codec_len: codec.len(),
 		description: std::ptr::null(),
@@ -788,6 +785,8 @@ fn cmaf_catalog_container_carries_its_init_segment() {
 	let mut audio_cfg = moq_audio_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -824,6 +823,8 @@ fn unpublishable_catalog_containers_are_rejected() {
 	let config = |container| moq_video_config {
 		name: name.as_ptr() as *const c_char,
 		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: codec.as_ptr() as *const c_char,
 		codec_len: codec.len(),
 		description: std::ptr::null(),
@@ -1797,6 +1798,8 @@ fn local_publish_consume() {
 	let mut audio_cfg = moq_audio_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -1821,6 +1824,8 @@ fn local_publish_consume() {
 	let mut video_cfg = moq_video_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -1915,6 +1920,8 @@ fn consume_announced_local() {
 	let mut audio_cfg = moq_audio_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -1989,6 +1996,8 @@ fn video_publish_consume() {
 	let mut video_cfg = moq_video_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -2021,6 +2030,8 @@ fn video_publish_consume() {
 	let mut audio_cfg = moq_audio_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),
@@ -2696,6 +2707,8 @@ fn catalog_update_on_new_track() {
 	let mut audio_cfg = moq_audio_config {
 		name: std::ptr::null(),
 		name_len: 0,
+		label: std::ptr::null(),
+		label_len: 0,
 		codec: std::ptr::null(),
 		codec_len: 0,
 		description: std::ptr::null(),

--- a/rs/moq-ffi/CHANGELOG.md
+++ b/rs/moq-ffi/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `publish_media` and `publish_media_stream` reject a `MoqInit` label or video hint on a container
-  format instead of silently dropping it.
+  format, and an audio format rejects a video hint, instead of silently dropping either.
 
 ## [0.3.11](https://github.com/moq-dev/moq/compare/moq-ffi-v0.3.10...moq-ffi-v0.3.11) - 2026-08-14
 

--- a/rs/moq-ffi/CHANGELOG.md
+++ b/rs/moq-ffi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Publish and consume human-readable audio and video rendition labels.
+
 ## [0.3.11](https://github.com/moq-dev/moq/compare/moq-ffi-v0.3.10...moq-ffi-v0.3.11) - 2026-08-14
 
 ### Added

--- a/rs/moq-ffi/CHANGELOG.md
+++ b/rs/moq-ffi/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Publish and consume human-readable audio and video rendition labels.
 
+### Changed
+
+- `publish_media` and `publish_media_stream` reject a `MoqInit` label or video hint on a container
+  format instead of silently dropping it.
+
 ## [0.3.11](https://github.com/moq-dev/moq/compare/moq-ffi-v0.3.10...moq-ffi-v0.3.11) - 2026-08-14
 
 ### Added

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -242,6 +242,7 @@ fn audio_config(catalog_audio: crate::media::MoqAudio) -> Result<hang::catalog::
 	}
 
 	let mut config = hang::catalog::AudioConfig::new(codec, catalog_audio.sample_rate, catalog_audio.channel_count);
+	config.label = catalog_audio.label;
 	config.bitrate = catalog_audio.bitrate;
 	config.description = catalog_audio.description.map(Into::into);
 	config.container = catalog_audio.container.into();
@@ -286,6 +287,7 @@ mod tests {
 
 	fn catalog_audio(codec: &str) -> MoqAudio {
 		MoqAudio {
+			label: None,
 			codec: codec.to_string(),
 			description: None,
 			sample_rate: 48_000,

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -79,6 +79,9 @@ pub struct MoqCatalog {
 
 #[derive(Clone, uniffi::Record)]
 pub struct MoqVideo {
+	/// Human-readable rendition name for track pickers.
+	#[uniffi(default = None)]
+	pub label: Option<String>,
 	pub codec: String,
 	pub description: Option<Vec<u8>>,
 	pub coded: Option<MoqDimensions>,
@@ -93,6 +96,9 @@ pub struct MoqVideo {
 
 #[derive(Clone, uniffi::Record)]
 pub struct MoqAudio {
+	/// Human-readable rendition name for track pickers.
+	#[uniffi(default = None)]
+	pub label: Option<String>,
 	pub codec: String,
 	pub description: Option<Vec<u8>>,
 	pub sample_rate: u32,
@@ -161,7 +167,8 @@ pub struct MoqVideoHint {
 	pub optimize_for_latency: Option<bool>,
 }
 
-/// What a single-track media publish needs: a format, its init bytes, and optional video fields.
+/// What a single-track media publish needs: a format, its init bytes, an optional label, and
+/// optional video fields.
 ///
 /// `format` selects the codec (e.g. `"opus"`, `"avc3"`); `data` carries the codec init bytes (an
 /// OpusHead, an avcC, an AudioSpecificConfig, ...). Audio formats need those bytes up front; video
@@ -174,6 +181,9 @@ pub struct MoqInit {
 	pub format: String,
 	/// Codec init bytes. Required for audio; may be empty for a video format that resolves in band.
 	pub data: Vec<u8>,
+	/// Human-readable rendition name for a single-codec track picker entry.
+	#[uniffi(default = None)]
+	pub label: Option<String>,
 	/// Caller-provided fields for a video track.
 	pub video: Option<MoqVideoHint>,
 }
@@ -195,6 +205,7 @@ impl From<MoqVideoHint> for moq_mux::catalog::VideoHint {
 impl From<MoqInit> for moq_mux::import::Init {
 	fn from(init: MoqInit) -> Self {
 		let mut out = moq_mux::import::Init::new(init.format, init.data);
+		out.label = init.label;
 		out.video = init.video.map(Into::into);
 		out
 	}
@@ -209,6 +220,7 @@ pub(crate) fn convert_catalog(catalog: &moq_mux::catalog::hang::Catalog<moq_mux:
 			Some((
 				name.clone(),
 				MoqVideo {
+					label: config.label.clone(),
 					codec: config.codec.to_string(),
 					description: config.description.as_ref().map(|d| d.to_vec()),
 					coded: match (config.coded_width, config.coded_height) {
@@ -236,6 +248,7 @@ pub(crate) fn convert_catalog(catalog: &moq_mux::catalog::hang::Catalog<moq_mux:
 			Some((
 				name.clone(),
 				MoqAudio {
+					label: config.label.clone(),
 					codec: config.codec.to_string(),
 					description: config.description.as_ref().map(|d| d.to_vec()),
 					sample_rate: config.sample_rate,
@@ -283,5 +296,21 @@ mod test {
 		let converted = convert_catalog(&catalog);
 		assert!(!converted.video["active"].stalled);
 		assert!(converted.video["video"].stalled);
+	}
+
+	#[test]
+	fn catalog_exposes_rendition_labels() {
+		let mut catalog = moq_mux::catalog::hang::Catalog::default();
+		let mut video = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		video.label = Some("Main camera".to_string());
+		catalog.video.renditions.insert("video".to_string(), video);
+
+		let mut audio = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
+		audio.label = Some("English".to_string());
+		catalog.audio.renditions.insert("audio".to_string(), audio);
+
+		let converted = convert_catalog(&catalog);
+		assert_eq!(converted.video["video"].label.as_deref(), Some("Main camera"));
+		assert_eq!(converted.audio["audio"].label.as_deref(), Some("English"));
 	}
 }

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -357,42 +357,40 @@ impl MoqBroadcastProducer {
 	/// Create a new media track for this broadcast.
 	///
 	/// The [`MoqInit`] format selects the codec (or container) for the init bytes and frame payloads;
-	/// its hints seed the catalog. Hints apply to single-codec formats; container formats auto-detect
-	/// every track.
+	/// its label and hints seed the catalog. Those describe one rendition, so a container format
+	/// (which detects and describes its own tracks) rejects them rather than dropping them.
 	pub fn publish_media(&self, init: MoqInit) -> Result<Arc<MoqMediaProducer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 
+		let init: moq_mux::import::Init = init.into();
+
 		// A container may publish several tracks; a single codec fills one reserved
 		// track. Try the container first so a codec format doesn't reserve a stray
 		// track on the way to being recognized.
-		let (decoder, demand) = match moq_mux::import::Container::new(
-			state.broadcast.clone(),
-			state.catalog.reserve(),
-			&init.format,
-			&init.data,
-		) {
-			Ok(container) => (MediaDecoder::Container(container), None),
-			Err(moq_mux::Error::UnknownFormat(_)) => {
-				let mut broadcast = state.broadcast.clone();
-				let name = broadcast.unique_name(&format!(".{}", init.format));
-				let request = broadcast
-					.reserve_track(name)
-					.map_err(|err| MoqError::Codec(format!("init failed: {err}")))?;
-				match moq_mux::import::Track::new(request, state.catalog.reserve(), init.into()) {
-					Ok(import) => {
-						let demand = import.demand();
-						(MediaDecoder::Track(Box::new(import)), Some(demand))
+		let (decoder, demand) =
+			match moq_mux::import::Container::new(state.broadcast.clone(), state.catalog.reserve(), &init) {
+				Ok(container) => (MediaDecoder::Container(container), None),
+				Err(moq_mux::Error::UnknownFormat(_)) => {
+					let mut broadcast = state.broadcast.clone();
+					let name = broadcast.unique_name(&format!(".{}", init.format));
+					let request = broadcast
+						.reserve_track(name)
+						.map_err(|err| MoqError::Codec(format!("init failed: {err}")))?;
+					match moq_mux::import::Track::new(request, state.catalog.reserve(), init) {
+						Ok(import) => {
+							let demand = import.demand();
+							(MediaDecoder::Track(Box::new(import)), Some(demand))
+						}
+						Err(moq_mux::Error::UnknownFormat(format)) => {
+							return Err(MoqError::Codec(format!("unknown format: {format}")));
+						}
+						Err(err) => return Err(MoqError::Codec(format!("init failed: {err}"))),
 					}
-					Err(moq_mux::Error::UnknownFormat(format)) => {
-						return Err(MoqError::Codec(format!("unknown format: {format}")));
-					}
-					Err(err) => return Err(MoqError::Codec(format!("init failed: {err}"))),
 				}
-			}
-			Err(err) => return Err(MoqError::Codec(format!("init failed: {err}"))),
-		};
+				Err(err) => return Err(MoqError::Codec(format!("init failed: {err}"))),
+			};
 
 		Ok(Arc::new(MoqMediaProducer {
 			inner: std::sync::Mutex::new(Some(MediaProducer { decoder, demand })),
@@ -436,18 +434,20 @@ impl MoqBroadcastProducer {
 	/// Unlike [`Self::publish_media`], the importer infers frame boundaries, so the caller just pushes
 	/// bytes via [`MoqMediaStreamProducer::write`]. Only self-describing stream formats are supported
 	/// (avc3, hev1, av01, fmp4, mkv). [`MoqInit`] carries the format, any
-	/// seed bytes, and catalog hints.
+	/// seed bytes, and catalog hints. As in [`Self::publish_media`], a container format rejects a
+	/// label or video hint.
 	pub fn publish_media_stream(&self, init: MoqInit) -> Result<Arc<MoqMediaStreamProducer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 
+		let init: moq_mux::import::Init = init.into();
+
 		// A container may publish several tracks; a single codec fills one reserved
 		// track. Try the container first so a codec format doesn't reserve a stray
 		// track before being recognized.
 		let decoder =
-			match moq_mux::import::ContainerStream::new(state.broadcast.clone(), state.catalog.reserve(), &init.format)
-			{
+			match moq_mux::import::ContainerStream::new(state.broadcast.clone(), state.catalog.reserve(), &init) {
 				Ok(container) => StreamDecoder::Container(container),
 				Err(moq_mux::Error::UnknownFormat(_)) => {
 					let mut broadcast = state.broadcast.clone();
@@ -455,7 +455,7 @@ impl MoqBroadcastProducer {
 					let request = broadcast
 						.reserve_track(name)
 						.map_err(|err| MoqError::Codec(format!("init failed: {err}")))?;
-					match moq_mux::import::TrackStream::new(request, state.catalog.reserve(), init.into()) {
+					match moq_mux::import::TrackStream::new(request, state.catalog.reserve(), init) {
 						Ok(import) => StreamDecoder::Track(Box::new(import)),
 						Err(moq_mux::Error::UnknownFormat(format)) => {
 							return Err(MoqError::Codec(format!("unknown stream format: {format}")));

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -20,6 +20,7 @@ fn media_init(format: &str, data: Vec<u8>) -> MoqInit {
 	MoqInit {
 		format: format.to_string(),
 		data,
+		label: None,
 		video: None,
 	}
 }
@@ -1368,7 +1369,9 @@ async fn catalog_update_on_new_track() {
 	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let broadcast = origin.create_broadcast("catalog-update".into()).unwrap();
 	let init = opus_head();
-	let _media1 = broadcast.publish_media(media_init("opus", init.clone())).unwrap();
+	let mut first = media_init("opus", init.clone());
+	first.label = Some("English".to_string());
+	let _media1 = broadcast.publish_media(first).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -1387,6 +1390,7 @@ async fn catalog_update_on_new_track() {
 		.unwrap()
 		.unwrap();
 	assert_eq!(catalog1.audio.len(), 1);
+	assert_eq!(catalog1.audio["0.opus"].label.as_deref(), Some("English"));
 
 	let _media2 = broadcast.publish_media(media_init("opus", init)).unwrap();
 
@@ -1396,6 +1400,8 @@ async fn catalog_update_on_new_track() {
 		.unwrap()
 		.unwrap();
 	assert_eq!(catalog2.audio.len(), 2);
+	assert_eq!(catalog2.audio["0.opus"].label.as_deref(), Some("English"));
+	assert_eq!(catalog2.audio["1.opus"].label, None);
 
 	broadcast.finish().unwrap();
 }

--- a/rs/moq-mux/CHANGELOG.md
+++ b/rs/moq-mux/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Propagate rendition labels through single-track media imports.
+- `From<hang::catalog::VideoConfig> for catalog::VideoHint`, a total conversion for a caller that
+  already has a whole rendition. Replaces the per-field copy in `moq-video`, which dropped the label.
 
 ### Changed
 

--- a/rs/moq-mux/CHANGELOG.md
+++ b/rs/moq-mux/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `import::Container::new` and `import::ContainerStream::new` take an `import::Init` instead of a
   format and buffer, and reject the single-rendition `label` and `video` fields rather than
   dropping them.
+- An audio format rejects an `import::Init` video hint instead of dropping it.
+- `catalog::VideoHint::label` is no longer public. `import::Init::label` is the single source of a
+  rendition label, matching the hang draft, which classifies it as a common rendition field.
 
 ## [0.9.7](https://github.com/moq-dev/moq/compare/moq-mux-v0.9.6...moq-mux-v0.9.7) - 2026-08-14
 

--- a/rs/moq-mux/CHANGELOG.md
+++ b/rs/moq-mux/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Propagate rendition labels through single-track media imports.
 
+### Changed
+
+- `import::Container::new` and `import::ContainerStream::new` take an `import::Init` instead of a
+  format and buffer, and reject the single-rendition `label` and `video` fields rather than
+  dropping them.
+
 ## [0.9.7](https://github.com/moq-dev/moq/compare/moq-mux-v0.9.6...moq-mux-v0.9.7) - 2026-08-14
 
 ### Added

--- a/rs/moq-mux/CHANGELOG.md
+++ b/rs/moq-mux/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Propagate rendition labels through single-track media imports.
+
 ## [0.9.7](https://github.com/moq-dev/moq/compare/moq-mux-v0.9.6...moq-mux-v0.9.7) - 2026-08-14
 
 ### Added

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -96,6 +96,8 @@ pub trait RenditionConfig<E: CatalogExt>: Sized + 'static {
 #[derive(Clone, Default, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct VideoHint {
+	/// Human-readable rendition name for track pickers.
+	pub label: Option<String>,
 	/// The video codec.
 	pub codec: Option<hang::catalog::VideoCodec>,
 	/// The encoded width in pixels.
@@ -132,6 +134,7 @@ impl VideoHint {
 	/// calls this on every config it publishes, before handing it to [`Rendition::set`], so a hinted
 	/// field counts as supplied and is never overwritten by detection.
 	pub fn apply(&self, config: &mut hang::catalog::VideoConfig) {
+		fill(&mut config.label, self.label.clone());
 		fill(&mut config.coded_width, self.coded_width);
 		fill(&mut config.coded_height, self.coded_height);
 		fill(&mut config.display_aspect_width, self.display_aspect_width);
@@ -506,6 +509,7 @@ mod tests {
 		let (_broadcast, catalog, mut rendition) = video_track();
 
 		let hint = VideoHint {
+			label: Some("Main camera".to_string()),
 			bitrate: Some(456),
 			..Default::default()
 		};
@@ -517,6 +521,7 @@ mod tests {
 
 		let snapshot = catalog.snapshot();
 		let config = snapshot.video.renditions.get("v").unwrap();
+		assert_eq!(config.label.as_deref(), Some("Main camera"));
 		assert_eq!(config.bitrate, Some(456), "a hinted bitrate must not be overwritten");
 		assert!(config.jitter.is_some(), "the unhinted jitter should still be detected");
 	}

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -129,6 +129,29 @@ fn fill<T>(slot: &mut Option<T>, value: Option<T>) {
 	}
 }
 
+impl From<hang::catalog::VideoConfig> for VideoHint {
+	/// Carry a whole rendition across as hints, for a caller that already knows what its encoder
+	/// emits (moq-video probes its encoder for exactly this).
+	///
+	/// Total by construction: every field the hint can hold is taken from the config, so there is no
+	/// per-field copy for a caller to forget. Fields with no hint slot (`broadcast`, `description`,
+	/// `container`, `stalled`) are set through the catalog directly.
+	fn from(config: hang::catalog::VideoConfig) -> Self {
+		Self {
+			label: config.label,
+			codec: Some(config.codec),
+			coded_width: config.coded_width,
+			coded_height: config.coded_height,
+			display_aspect_width: config.display_aspect_width,
+			display_aspect_height: config.display_aspect_height,
+			bitrate: config.bitrate,
+			framerate: config.framerate,
+			optimize_for_latency: config.optimize_for_latency,
+			jitter: config.jitter,
+		}
+	}
+}
+
 impl VideoHint {
 	/// Fill a detected video config's absent optional fields from these hints.
 	///
@@ -503,6 +526,47 @@ mod tests {
 			Some(Duration::from_millis(50)),
 			"a provided jitter must not be overwritten"
 		);
+	}
+
+	/// A caller hands moq-video a whole `VideoConfig`, so the conversion into hints must be total.
+	/// Hand-copying it field by field is what dropped the label on that path.
+	#[test]
+	fn a_config_converts_into_hints_without_losing_the_label() {
+		let (_broadcast, catalog, mut rendition) = video_track();
+
+		let mut source = config(Some(456), None);
+		source.label = Some("Main camera".to_string());
+		source.coded_width = Some(1920);
+		source.coded_height = Some(1080);
+		let hint = VideoHint::from(source);
+
+		// The importer applies the hint to each config it publishes, so check the label survives
+		// both the up-front publish and a later one the stream resolved.
+		let mut first = config(None, None);
+		hint.apply(&mut first);
+		rendition.set(first);
+		feed(&mut rendition);
+		assert_eq!(
+			catalog.snapshot().video.renditions.get("v").unwrap().label.as_deref(),
+			Some("Main camera"),
+			"the label must survive the config the importer publishes up front"
+		);
+
+		let mut resolved = config(None, None);
+		resolved.coded_width = Some(1280);
+		resolved.coded_height = Some(720);
+		hint.apply(&mut resolved);
+		rendition.set(resolved);
+		feed(&mut rendition);
+
+		let snapshot = catalog.snapshot();
+		let published = snapshot.video.renditions.get("v").unwrap();
+		assert_eq!(
+			published.label.as_deref(),
+			Some("Main camera"),
+			"the label must survive a config the stream resolved later"
+		);
+		assert_eq!(published.bitrate, Some(456), "the rest of the config converts too");
 	}
 
 	/// A hint is applied by the importer before `set`, so a hinted field is indistinguishable from

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -96,8 +96,11 @@ pub trait RenditionConfig<E: CatalogExt>: Sized + 'static {
 #[derive(Clone, Default, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct VideoHint {
-	/// Human-readable rendition name for track pickers.
-	pub label: Option<String>,
+	/// Human-readable rendition name, plumbed through from [`Init::label`](crate::import::Init::label).
+	///
+	/// Not a hint: every other field here seeds something the stream may also reveal, while a label
+	/// can only ever come from the caller. It rides along so one `apply` writes the whole config.
+	pub(crate) label: Option<String>,
 	/// The video codec.
 	pub codec: Option<hang::catalog::VideoCodec>,
 	/// The encoded width in pixels.
@@ -509,7 +512,6 @@ mod tests {
 		let (_broadcast, catalog, mut rendition) = video_track();
 
 		let hint = VideoHint {
-			label: Some("Main camera".to_string()),
 			bitrate: Some(456),
 			..Default::default()
 		};
@@ -521,7 +523,6 @@ mod tests {
 
 		let snapshot = catalog.snapshot();
 		let config = snapshot.video.renditions.get("v").unwrap();
-		assert_eq!(config.label.as_deref(), Some("Main camera"));
 		assert_eq!(config.bitrate, Some(456), "a hinted bitrate must not be overwritten");
 		assert!(config.jitter.is_some(), "the unhinted jitter should still be detected");
 	}

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -99,6 +99,13 @@ pub enum Error {
 	#[error("unknown format: {0}")]
 	UnknownFormat(String),
 
+	/// A single-rendition [`Init`](crate::import::Init) field was set on a container format.
+	///
+	/// A container publishes its own tracks and describes each one from the container's metadata, so
+	/// there is no single rendition for the field to apply to.
+	#[error("container format does not support {0}")]
+	UnsupportedByContainer(&'static str),
+
 	/// A non-keyframe frame was received before any keyframe opened a group.
 	/// A track joining mid-stream should skip frames until the first keyframe.
 	#[error("{0}")]

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -99,12 +99,18 @@ pub enum Error {
 	#[error("unknown format: {0}")]
 	UnknownFormat(String),
 
-	/// A single-rendition [`Init`](crate::import::Init) field was set on a container format.
+	/// A caller-supplied [`Init`](crate::import::Init) field does not apply to the chosen format.
 	///
-	/// A container publishes its own tracks and describes each one from the container's metadata, so
-	/// there is no single rendition for the field to apply to.
-	#[error("container format does not support {0}")]
-	UnsupportedByContainer(&'static str),
+	/// A container publishes and describes its own tracks, so no single rendition is there to
+	/// configure. An audio importer reads its whole config out of the init bytes, so there is nothing
+	/// for a video hint to seed. Either way the field would be ignored, which is worse than an error.
+	#[error("a {kind} format does not support the {field}")]
+	UnsupportedField {
+		/// The field that was set.
+		field: &'static str,
+		/// The kind of format that cannot honor it.
+		kind: &'static str,
+	},
 
 	/// A non-keyframe frame was received before any keyframe opened a group.
 	/// A track joining mid-stream should skip frames until the first keyframe.

--- a/rs/moq-mux/src/import/container.rs
+++ b/rs/moq-mux/src/import/container.rs
@@ -5,7 +5,7 @@
 //! track, so neither exposes a single-track demand/name handle. Today every
 //! container supports both; both wrap the same [`ContainerImpl`] dispatch.
 
-use super::Init;
+use super::{Init, init::Kind};
 use crate::Result;
 
 /// The concrete container importers, shared by [`Container`] and
@@ -107,7 +107,7 @@ impl<E: crate::container::ts::Catalog> Container<E> {
 			"flv" => ContainerImpl::flv(broadcast, reserved),
 			_ => return Err(crate::Error::UnknownFormat(init.format.clone())),
 		};
-		init.reject_container_fields()?;
+		init.reject_unsupported(Kind::Container)?;
 		inner.decode(&init.data)?;
 		Ok(Self { inner })
 	}
@@ -170,7 +170,7 @@ impl<E: crate::container::ts::Catalog> ContainerStream<E> {
 			"flv" => ContainerImpl::flv(broadcast, reserved),
 			_ => return Err(crate::Error::UnknownFormat(init.format.clone())),
 		};
-		init.reject_container_fields()?;
+		init.reject_unsupported(Kind::Container)?;
 		Ok(Self { inner })
 	}
 
@@ -236,14 +236,14 @@ mod tests {
 			let (broadcast, catalog) = new_broadcast();
 			let err = Container::<()>::new(broadcast, catalog.reserve(), &init).err();
 			assert!(
-				matches!(err, Some(crate::Error::UnsupportedByContainer(field)) if field == expected),
+				matches!(err, Some(crate::Error::UnsupportedField { field, kind: "container" }) if field == expected),
 				"expected {expected} to be rejected, got {err:?}"
 			);
 
 			let (broadcast, catalog) = new_broadcast();
 			let err = ContainerStream::<()>::new(broadcast, catalog.reserve(), &init).err();
 			assert!(
-				matches!(err, Some(crate::Error::UnsupportedByContainer(field)) if field == expected),
+				matches!(err, Some(crate::Error::UnsupportedField { field, kind: "container" }) if field == expected),
 				"expected {expected} to be rejected on a stream, got {err:?}"
 			);
 		}

--- a/rs/moq-mux/src/import/container.rs
+++ b/rs/moq-mux/src/import/container.rs
@@ -5,6 +5,7 @@
 //! track, so neither exposes a single-track demand/name handle. Today every
 //! container supports both; both wrap the same [`ContainerImpl`] dispatch.
 
+use super::Init;
 use crate::Result;
 
 /// The concrete container importers, shared by [`Container`] and
@@ -89,21 +90,25 @@ pub struct Container<E: crate::container::ts::Catalog = ()> {
 }
 
 impl<E: crate::container::ts::Catalog> Container<E> {
-	/// Create a new container importer, decoding the initial chunk.
+	/// Create a new container importer, decoding [`Init::data`] as the initial chunk.
+	///
+	/// The format is matched before anything else, so a codec format still reports
+	/// [`UnknownFormat`](crate::Error::UnknownFormat) and a caller can fall back to
+	/// [`Track::new`](super::Track::new).
 	pub fn new(
 		broadcast: moq_net::broadcast::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		format: &str,
-		init: &[u8],
+		init: &Init,
 	) -> Result<Self> {
-		let mut inner = match format {
+		let mut inner = match init.format.as_str() {
 			"fmp4" | "cmaf" => ContainerImpl::fmp4(broadcast, reserved),
 			"mkv" | "webm" | "matroska" => ContainerImpl::mkv(broadcast, reserved),
 			"ts" | "mpegts" | "mpeg2ts" | "m2ts" => ContainerImpl::ts(broadcast, reserved),
 			"flv" => ContainerImpl::flv(broadcast, reserved),
-			_ => return Err(crate::Error::UnknownFormat(format.to_string())),
+			_ => return Err(crate::Error::UnknownFormat(init.format.clone())),
 		};
-		inner.decode(init)?;
+		init.reject_container_fields()?;
+		inner.decode(&init.data)?;
 		Ok(Self { inner })
 	}
 
@@ -147,23 +152,25 @@ pub struct ContainerStream<E: crate::container::ts::Catalog = ()> {
 }
 
 impl<E: crate::container::ts::Catalog> ContainerStream<E> {
-	/// Create a new container stream importer.
+	/// Create a new container stream importer. [`Init::data`] is unused: the stream carries its own
+	/// framing.
 	pub fn new(
 		broadcast: moq_net::broadcast::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		format: &str,
+		init: &Init,
 	) -> Result<Self> {
 		// A separate list from [`Container::new`]: only containers that can be
 		// recovered from a raw byte stream belong here. Today that's all of them,
 		// but a non-streamable container (e.g. RTP) would be added to `Container`
 		// alone.
-		let inner = match format {
+		let inner = match init.format.as_str() {
 			"fmp4" | "cmaf" => ContainerImpl::fmp4(broadcast, reserved),
 			"mkv" | "webm" | "matroska" => ContainerImpl::mkv(broadcast, reserved),
 			"ts" | "mpegts" | "mpeg2ts" | "m2ts" => ContainerImpl::ts(broadcast, reserved),
 			"flv" => ContainerImpl::flv(broadcast, reserved),
-			_ => return Err(crate::Error::UnknownFormat(format.to_string())),
+			_ => return Err(crate::Error::UnknownFormat(init.format.clone())),
 		};
+		init.reject_container_fields()?;
 		Ok(Self { inner })
 	}
 
@@ -195,5 +202,64 @@ impl<E: crate::container::ts::Catalog> ContainerStream<E> {
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.inner.seek(sequence)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::catalog::VideoHint;
+
+	fn new_broadcast() -> (moq_net::broadcast::Producer, crate::catalog::Producer) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+		(broadcast, catalog)
+	}
+
+	/// A container describes each of its own tracks, so a caller-supplied rendition field has nowhere
+	/// to go. Reject it instead of accepting the call and dropping the field.
+	#[tokio::test(start_paused = true)]
+	async fn a_container_rejects_single_rendition_fields() {
+		for (init, expected) in [
+			(
+				Init {
+					label: Some("English".to_string()),
+					..Init::new("fmp4", Vec::new())
+				},
+				"label",
+			),
+			(
+				Init::new("fmp4", Vec::new()).with_video(VideoHint::default()),
+				"video hint",
+			),
+		] {
+			let (broadcast, catalog) = new_broadcast();
+			let err = Container::<()>::new(broadcast, catalog.reserve(), &init).err();
+			assert!(
+				matches!(err, Some(crate::Error::UnsupportedByContainer(field)) if field == expected),
+				"expected {expected} to be rejected, got {err:?}"
+			);
+
+			let (broadcast, catalog) = new_broadcast();
+			let err = ContainerStream::<()>::new(broadcast, catalog.reserve(), &init).err();
+			assert!(
+				matches!(err, Some(crate::Error::UnsupportedByContainer(field)) if field == expected),
+				"expected {expected} to be rejected on a stream, got {err:?}"
+			);
+		}
+	}
+
+	/// The format is matched first, so a labelled codec format still falls through to `Track::new`
+	/// rather than reporting the label as the problem.
+	#[tokio::test(start_paused = true)]
+	async fn a_codec_format_still_reports_an_unknown_format() {
+		let init = Init {
+			label: Some("English".to_string()),
+			..Init::new("opus", Vec::new())
+		};
+
+		let (broadcast, catalog) = new_broadcast();
+		let err = Container::<()>::new(broadcast, catalog.reserve(), &init).err();
+		assert!(matches!(err, Some(crate::Error::UnknownFormat(_))), "got {err:?}");
 	}
 }

--- a/rs/moq-mux/src/import/init.rs
+++ b/rs/moq-mux/src/import/init.rs
@@ -2,22 +2,30 @@ use bytes::Bytes;
 
 use crate::catalog::VideoHint;
 
-/// What a single-track importer needs to start: a format, its init bytes, an optional label, and
-/// optional video fields.
+/// What a media importer needs to start: a format, its init bytes, an optional label, and optional
+/// video fields.
 ///
-/// `format` selects the codec parser (e.g. `"avc3"`, `"opus"`). `data` carries the codec init bytes
-/// (an avcC record, an OpusHead, an AudioSpecificConfig, ...). Audio formats need those bytes up
+/// `format` selects either a codec parser (e.g. `"avc3"`, `"opus"`) or a container
+/// (e.g. `"fmp4"`, `"ts"`). `data` carries the codec init bytes (an avcC record, an OpusHead, an
+/// AudioSpecificConfig, ...) or the container's leading chunk. Audio formats need those bytes up
 /// front (an audio importer can't resolve its config from frames); video formats may resolve lazily
 /// from the stream, and a [`video`](Self::video) hint can pin fields the stream can't reveal
 /// (bitrate) or publish the catalog before the first keyframe. See [`VideoHint`].
+///
+/// [`label`](Self::label) and [`video`](Self::video) describe one rendition, so they apply only to a
+/// codec format. A container publishes its own tracks and describes each from its own metadata:
+/// [`Container::new`](crate::import::Container::new) rejects either field rather than dropping it.
 #[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct Init {
-	/// The media format, e.g. `"avc3"`, `"opus"`, or `"aac"`.
+	/// The media format, e.g. `"avc3"`, `"opus"`, `"aac"`, or a container like `"fmp4"`.
 	pub format: String,
 	/// Codec init bytes. Required for audio; may be empty for a video format that resolves in band.
 	pub data: Bytes,
-	/// Human-readable rendition name for a single-codec track picker entry.
+	/// Human-readable rendition name for a track picker.
+	///
+	/// For a video format this is the default for [`VideoHint::label`]: an explicit hint label wins,
+	/// so set one or the other rather than both.
 	pub label: Option<String>,
 	/// Caller-provided fields for a video track.
 	pub video: Option<VideoHint>,
@@ -34,15 +42,20 @@ impl Init {
 		}
 	}
 
-	/// Attach a human-readable rendition name.
-	pub fn with_label(mut self, label: impl Into<String>) -> Self {
-		self.label = Some(label.into());
-		self
-	}
-
 	/// Attach caller-provided video catalog fields.
 	pub fn with_video(mut self, hint: VideoHint) -> Self {
 		self.video = Some(hint);
 		self
+	}
+
+	/// Error if a field describing a single rendition was set, for a container that has many.
+	pub(crate) fn reject_container_fields(&self) -> crate::Result<()> {
+		if self.label.is_some() {
+			return Err(crate::Error::UnsupportedByContainer("label"));
+		}
+		if self.video.is_some() {
+			return Err(crate::Error::UnsupportedByContainer("video hint"));
+		}
+		Ok(())
 	}
 }

--- a/rs/moq-mux/src/import/init.rs
+++ b/rs/moq-mux/src/import/init.rs
@@ -12,9 +12,10 @@ use crate::catalog::VideoHint;
 /// from the stream, and a [`video`](Self::video) hint can pin fields the stream can't reveal
 /// (bitrate) or publish the catalog before the first keyframe. See [`VideoHint`].
 ///
-/// [`label`](Self::label) and [`video`](Self::video) describe one rendition, so they apply only to a
-/// codec format. A container publishes its own tracks and describes each from its own metadata:
-/// [`Container::new`](crate::import::Container::new) rejects either field rather than dropping it.
+/// Each optional field applies to a subset of formats, and a format that cannot honor one rejects it
+/// rather than dropping it. [`label`](Self::label) describes one rendition, so a container, which
+/// publishes and describes its own tracks, refuses it. [`video`](Self::video) seeds a video config,
+/// so an audio format, which reads its whole config from [`data`](Self::data), refuses that too.
 #[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct Init {
@@ -22,10 +23,8 @@ pub struct Init {
 	pub format: String,
 	/// Codec init bytes. Required for audio; may be empty for a video format that resolves in band.
 	pub data: Bytes,
-	/// Human-readable rendition name for a track picker.
-	///
-	/// For a video format this is the default for [`VideoHint::label`]: an explicit hint label wins,
-	/// so set one or the other rather than both.
+	/// Human-readable rendition name for a track picker. The single source: a label can never be
+	/// detected from the stream, so nothing else sets one.
 	pub label: Option<String>,
 	/// Caller-provided fields for a video track.
 	pub video: Option<VideoHint>,
@@ -48,14 +47,54 @@ impl Init {
 		self
 	}
 
-	/// Error if a field describing a single rendition was set, for a container that has many.
-	pub(crate) fn reject_container_fields(&self) -> crate::Result<()> {
-		if self.label.is_some() {
-			return Err(crate::Error::UnsupportedByContainer("label"));
+	/// Error if a field was set that this kind of format cannot honor.
+	pub(crate) fn reject_unsupported(&self, kind: Kind) -> crate::Result<()> {
+		let unsupported = |field| {
+			Err(crate::Error::UnsupportedField {
+				field,
+				kind: kind.name(),
+			})
+		};
+
+		match kind {
+			// A container names and describes each track it publishes, so neither field has a single
+			// rendition to land on.
+			Kind::Container => {
+				if self.label.is_some() {
+					return unsupported("label");
+				}
+				if self.video.is_some() {
+					return unsupported("video hint");
+				}
+			}
+			// An audio importer builds its whole config from the init bytes; only the label rides along.
+			Kind::Audio => {
+				if self.video.is_some() {
+					return unsupported("video hint");
+				}
+			}
+			// Video honors everything.
+			Kind::Video => {}
 		}
-		if self.video.is_some() {
-			return Err(crate::Error::UnsupportedByContainer("video hint"));
-		}
+
 		Ok(())
+	}
+}
+
+/// What an [`Init`] format resolves to, which decides the fields it can honor.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum Kind {
+	Audio,
+	Video,
+	Container,
+}
+
+impl Kind {
+	fn name(self) -> &'static str {
+		match self {
+			Kind::Audio => "audio",
+			Kind::Video => "video",
+			Kind::Container => "container",
+		}
 	}
 }

--- a/rs/moq-mux/src/import/init.rs
+++ b/rs/moq-mux/src/import/init.rs
@@ -2,7 +2,8 @@ use bytes::Bytes;
 
 use crate::catalog::VideoHint;
 
-/// What a single-track importer needs to start: a format, its init bytes, and optional video fields.
+/// What a single-track importer needs to start: a format, its init bytes, an optional label, and
+/// optional video fields.
 ///
 /// `format` selects the codec parser (e.g. `"avc3"`, `"opus"`). `data` carries the codec init bytes
 /// (an avcC record, an OpusHead, an AudioSpecificConfig, ...). Audio formats need those bytes up
@@ -16,6 +17,8 @@ pub struct Init {
 	pub format: String,
 	/// Codec init bytes. Required for audio; may be empty for a video format that resolves in band.
 	pub data: Bytes,
+	/// Human-readable rendition name for a single-codec track picker entry.
+	pub label: Option<String>,
 	/// Caller-provided fields for a video track.
 	pub video: Option<VideoHint>,
 }
@@ -26,8 +29,15 @@ impl Init {
 		Self {
 			format: format.into(),
 			data: data.into(),
+			label: None,
 			video: None,
 		}
+	}
+
+	/// Attach a human-readable rendition name.
+	pub fn with_label(mut self, label: impl Into<String>) -> Self {
+		self.label = Some(label.into());
+		self
 	}
 
 	/// Attach caller-provided video catalog fields.

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -13,6 +13,9 @@ pub use super::Init;
 
 /// The caller-provided video fields for `init`, defaulting the codec from the format when the codec
 /// carries no extra parameters (VP8), so a hint with a codec can publish before the first frame.
+///
+/// [`Init::label`] is the label for callers that never build a hint, so an explicit
+/// [`VideoHint::label`] wins over it.
 fn video_hint(init: &Init, default_codec: Option<hang::catalog::VideoCodec>) -> VideoHint {
 	let mut hint = init.video.clone().unwrap_or_default();
 	if hint.label.is_none() {
@@ -24,11 +27,12 @@ fn video_hint(init: &Init, default_codec: Option<hang::catalog::VideoCodec>) -> 
 	hint
 }
 
-/// Apply the import's common catalog fields to a parsed audio config.
+/// Apply the import's caller-provided catalog fields to a parsed audio config.
+///
+/// Audio has no hint type: the codec parser fills everything else from the init bytes, so the label
+/// is the only field the caller supplies.
 fn audio_config(init: &Init, mut config: hang::catalog::AudioConfig) -> hang::catalog::AudioConfig {
-	if config.label.is_none() {
-		config.label = init.label.clone();
-	}
+	config.label = init.label.clone();
 	config
 }
 
@@ -795,7 +799,10 @@ mod tests {
 		let import = Track::new(
 			request,
 			catalog.reserve(),
-			Init::new("aac", init.clone()).with_label("English"),
+			Init {
+				label: Some("English".to_string()),
+				..Init::new("aac", init.clone())
+			},
 		)
 		.unwrap();
 
@@ -1039,12 +1046,37 @@ mod tests {
 		let _import = Track::new(
 			request,
 			catalog.reserve(),
-			Init::new("vp8", Vec::new()).with_label("Main camera"),
+			Init {
+				label: Some("Main camera".to_string()),
+				..Init::new("vp8", Vec::new())
+			},
 		)
 		.unwrap();
 
 		let video = catalog.snapshot().video.renditions.get("video").cloned().unwrap();
 		assert_eq!(video.codec.to_string(), "vp8");
+		assert_eq!(video.label.as_deref(), Some("Main camera"));
+	}
+
+	/// A caller that builds a hint has two places to put a label, so pin which one wins.
+	#[tokio::test(start_paused = true)]
+	async fn an_explicit_hint_label_beats_the_init_label() {
+		let (mut broadcast, catalog) = new_broadcast();
+		let request = broadcast.reserve_track("video").unwrap();
+		let _import = Track::new(
+			request,
+			catalog.reserve(),
+			Init {
+				label: Some("ignored".to_string()),
+				..Init::new("vp8", Vec::new()).with_video(VideoHint {
+					label: Some("Main camera".to_string()),
+					..Default::default()
+				})
+			},
+		)
+		.unwrap();
+
+		let video = catalog.snapshot().video.renditions.get("video").cloned().unwrap();
 		assert_eq!(video.label.as_deref(), Some("Main camera"));
 	}
 

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -15,10 +15,21 @@ pub use super::Init;
 /// carries no extra parameters (VP8), so a hint with a codec can publish before the first frame.
 fn video_hint(init: &Init, default_codec: Option<hang::catalog::VideoCodec>) -> VideoHint {
 	let mut hint = init.video.clone().unwrap_or_default();
+	if hint.label.is_none() {
+		hint.label = init.label.clone();
+	}
 	if hint.codec.is_none() {
 		hint.codec = default_codec;
 	}
 	hint
+}
+
+/// Apply the import's common catalog fields to a parsed audio config.
+fn audio_config(init: &Init, mut config: hang::catalog::AudioConfig) -> hang::catalog::AudioConfig {
+	if config.label.is_none() {
+		config.label = init.label.clone();
+	}
+	config
 }
 
 /// Build an H.264 avc3 split + import pair.
@@ -226,20 +237,20 @@ impl<E: CatalogExt> Track<E> {
 			// Audio can't resolve its config from frames, so it needs the init bytes up front (an
 			// OpusHead, AudioSpecificConfig, ...); `codec::config` errors when they're missing or bad.
 			"aac" => {
-				let config = crate::codec::aac::config(data)?;
+				let config = audio_config(&init, crate::codec::aac::config(data)?);
 				TrackKind::Aac(crate::codec::aac::Import::new(track, reserved, config)?)
 			}
 			"opus" => {
-				let config = crate::codec::opus::config(data)?;
+				let config = audio_config(&init, crate::codec::opus::config(data)?);
 				TrackKind::Opus(crate::codec::opus::Import::new(track, reserved, config)?)
 			}
 			"flac" => {
 				// `data` is a FLAC header: the `fLaC` marker plus the STREAMINFO block.
-				let config = crate::codec::flac::config(data)?;
+				let config = audio_config(&init, crate::codec::flac::config(data)?);
 				TrackKind::Flac(crate::codec::flac::Import::new(track, reserved, config)?)
 			}
 			"mp3" => {
-				let config = crate::codec::mp3::config(data)?;
+				let config = audio_config(&init, crate::codec::mp3::config(data)?);
 				TrackKind::Mp3(crate::codec::mp3::Import::new(track, reserved, config)?)
 			}
 			_ => return Err(crate::Error::UnknownFormat(init.format)),
@@ -781,7 +792,12 @@ mod tests {
 		let init = config.encode();
 		let request = broadcast.reserve_track("audio").unwrap();
 
-		let import = Track::new(request, catalog.reserve(), Init::new("aac", init.clone())).unwrap();
+		let import = Track::new(
+			request,
+			catalog.reserve(),
+			Init::new("aac", init.clone()).with_label("English"),
+		)
+		.unwrap();
 
 		assert_eq!(import.name(), "audio");
 		let snapshot = catalog.snapshot();
@@ -790,6 +806,7 @@ mod tests {
 		assert_eq!(audio.sample_rate, config.sample_rate);
 		assert_eq!(audio.channel_count, config.channel_count);
 		assert_eq!(audio.description.as_deref(), Some(init.as_ref()));
+		assert_eq!(audio.label.as_deref(), Some("English"));
 	}
 
 	#[tokio::test(start_paused = true)]
@@ -1019,10 +1036,16 @@ mod tests {
 	async fn video_publishes_before_first_frame() {
 		let (mut broadcast, catalog) = new_broadcast();
 		let request = broadcast.reserve_track("video").unwrap();
-		let _import = Track::new(request, catalog.reserve(), Init::new("vp8", Vec::new())).unwrap();
+		let _import = Track::new(
+			request,
+			catalog.reserve(),
+			Init::new("vp8", Vec::new()).with_label("Main camera"),
+		)
+		.unwrap();
 
 		let video = catalog.snapshot().video.renditions.get("video").cloned().unwrap();
 		assert_eq!(video.codec.to_string(), "vp8");
+		assert_eq!(video.label.as_deref(), Some("Main camera"));
 	}
 
 	/// hvc1 publishes the catalog up front from the out-of-band hvcC: dimensions

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -10,30 +10,34 @@ use crate::catalog::VideoHint;
 use crate::catalog::hang::CatalogExt;
 
 pub use super::Init;
+use super::init::Kind;
 
 /// The caller-provided video fields for `init`, defaulting the codec from the format when the codec
 /// carries no extra parameters (VP8), so a hint with a codec can publish before the first frame.
 ///
-/// [`Init::label`] is the label for callers that never build a hint, so an explicit
-/// [`VideoHint::label`] wins over it.
-fn video_hint(init: &Init, default_codec: Option<hang::catalog::VideoCodec>) -> VideoHint {
+/// The label is plumbed in rather than merged: [`Init::label`] is its only source.
+///
+/// Fallible for the same reason [`audio_config`] is: every arm of [`Track::new`] runs the field
+/// check, so a format added later cannot quietly skip it. Video honors every field today.
+fn video_hint(init: &Init, default_codec: Option<hang::catalog::VideoCodec>) -> Result<VideoHint> {
+	init.reject_unsupported(Kind::Video)?;
+
 	let mut hint = init.video.clone().unwrap_or_default();
-	if hint.label.is_none() {
-		hint.label = init.label.clone();
-	}
+	hint.label = init.label.clone();
 	if hint.codec.is_none() {
 		hint.codec = default_codec;
 	}
-	hint
+	Ok(hint)
 }
 
 /// Apply the import's caller-provided catalog fields to a parsed audio config.
 ///
 /// Audio has no hint type: the codec parser fills everything else from the init bytes, so the label
-/// is the only field the caller supplies.
-fn audio_config(init: &Init, mut config: hang::catalog::AudioConfig) -> hang::catalog::AudioConfig {
+/// is the only field the caller supplies. A video hint is rejected here rather than ignored.
+fn audio_config(init: &Init, mut config: hang::catalog::AudioConfig) -> Result<hang::catalog::AudioConfig> {
+	init.reject_unsupported(Kind::Audio)?;
 	config.label = init.label.clone();
-	config
+	Ok(config)
 }
 
 /// Build an H.264 avc3 split + import pair.
@@ -208,53 +212,53 @@ impl<E: CatalogExt> Track<E> {
 		let data = init.data.as_ref();
 		let kind = match init.format.as_str() {
 			"avc1" | "avcc" => {
-				let (length_size, import) = build_h264_avc1(track, reserved, data, video_hint(&init, None))?;
+				let (length_size, import) = build_h264_avc1(track, reserved, data, video_hint(&init, None)?)?;
 				TrackKind::Avc1 { length_size, import }
 			}
 			"avc3" | "h264" => {
-				let (split, import) = build_h264_avc3(track, reserved, data, video_hint(&init, None))?;
+				let (split, import) = build_h264_avc3(track, reserved, data, video_hint(&init, None)?)?;
 				TrackKind::Avc3 { split, import }
 			}
 			"hvc1" | "hvcc" => {
-				let (length_size, import) = build_h265_hvc1(track, reserved, data, video_hint(&init, None))?;
+				let (length_size, import) = build_h265_hvc1(track, reserved, data, video_hint(&init, None)?)?;
 				TrackKind::Hvc1 { length_size, import }
 			}
 			"hev1" => {
-				let (split, import) = build_h265(track, reserved, data, video_hint(&init, None))?;
+				let (split, import) = build_h265(track, reserved, data, video_hint(&init, None)?)?;
 				TrackKind::Hev1 { split, import }
 			}
 			"av01" | "av1" | "av1c" | "av1C" => {
-				let (split, import) = build_av1(track, reserved, data, video_hint(&init, None))?;
+				let (split, import) = build_av1(track, reserved, data, video_hint(&init, None)?)?;
 				TrackKind::Av01 { split, import }
 			}
 			"vp8" | "vp08" => {
 				let mut import =
-					crate::codec::vp8::Import::new(track, reserved, video_hint(&init, Some(VideoCodec::VP8)))?;
+					crate::codec::vp8::Import::new(track, reserved, video_hint(&init, Some(VideoCodec::VP8))?)?;
 				import.initialize(data)?;
 				TrackKind::Vp8(import)
 			}
 			"vp9" | "vp09" => {
-				let mut import = crate::codec::vp9::Import::new(track, reserved, video_hint(&init, None))?;
+				let mut import = crate::codec::vp9::Import::new(track, reserved, video_hint(&init, None)?)?;
 				import.initialize(data)?;
 				TrackKind::Vp9(import)
 			}
 			// Audio can't resolve its config from frames, so it needs the init bytes up front (an
 			// OpusHead, AudioSpecificConfig, ...); `codec::config` errors when they're missing or bad.
 			"aac" => {
-				let config = audio_config(&init, crate::codec::aac::config(data)?);
+				let config = audio_config(&init, crate::codec::aac::config(data)?)?;
 				TrackKind::Aac(crate::codec::aac::Import::new(track, reserved, config)?)
 			}
 			"opus" => {
-				let config = audio_config(&init, crate::codec::opus::config(data)?);
+				let config = audio_config(&init, crate::codec::opus::config(data)?)?;
 				TrackKind::Opus(crate::codec::opus::Import::new(track, reserved, config)?)
 			}
 			"flac" => {
 				// `data` is a FLAC header: the `fLaC` marker plus the STREAMINFO block.
-				let config = audio_config(&init, crate::codec::flac::config(data)?);
+				let config = audio_config(&init, crate::codec::flac::config(data)?)?;
 				TrackKind::Flac(crate::codec::flac::Import::new(track, reserved, config)?)
 			}
 			"mp3" => {
-				let config = audio_config(&init, crate::codec::mp3::config(data)?);
+				let config = audio_config(&init, crate::codec::mp3::config(data)?)?;
 				TrackKind::Mp3(crate::codec::mp3::Import::new(track, reserved, config)?)
 			}
 			_ => return Err(crate::Error::UnknownFormat(init.format)),
@@ -546,7 +550,7 @@ impl<E: CatalogExt> TrackStream<E> {
 	/// first frame; any [`Init::data`] seeds the stream (as a call to [`initialize`](Self::initialize)).
 	pub fn new(request: moq_net::track::Request, reserved: crate::catalog::Reserved<E>, init: Init) -> Result<Self> {
 		let track = request.accept(reserved.track_info());
-		let hint = video_hint(&init, None);
+		let hint = video_hint(&init, None)?;
 		// Only the self-delimiting codecs can be recovered from a raw byte stream.
 		let kind = match init.format.as_str() {
 			"avc3" | "h264" => TrackStreamKind::Avc3 {
@@ -1058,26 +1062,27 @@ mod tests {
 		assert_eq!(video.label.as_deref(), Some("Main camera"));
 	}
 
-	/// A caller that builds a hint has two places to put a label, so pin which one wins.
+	/// A video hint has nothing to seed on an audio track, so report it rather than ignore it.
 	#[tokio::test(start_paused = true)]
-	async fn an_explicit_hint_label_beats_the_init_label() {
+	async fn audio_rejects_a_video_hint() {
 		let (mut broadcast, catalog) = new_broadcast();
-		let request = broadcast.reserve_track("video").unwrap();
-		let _import = Track::new(
-			request,
-			catalog.reserve(),
-			Init {
-				label: Some("ignored".to_string()),
-				..Init::new("vp8", Vec::new()).with_video(VideoHint {
-					label: Some("Main camera".to_string()),
-					..Default::default()
-				})
-			},
-		)
-		.unwrap();
+		let request = broadcast.reserve_track("audio").unwrap();
+		let init = Init::new("opus", opus_head()).with_video(VideoHint {
+			bitrate: Some(128_000),
+			..Default::default()
+		});
 
-		let video = catalog.snapshot().video.renditions.get("video").cloned().unwrap();
-		assert_eq!(video.label.as_deref(), Some("Main camera"));
+		let err = Track::new(request, catalog.reserve(), init).err();
+		assert!(
+			matches!(
+				err,
+				Some(crate::Error::UnsupportedField {
+					field: "video hint",
+					kind: "audio"
+				})
+			),
+			"got {err:?}"
+		);
 	}
 
 	/// hvc1 publishes the catalog up front from the out-of-band hvcC: dimensions

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `encode::Producer` carries a rendition's `label` into the catalog. It copied the config into hints
+  field by field and had no case for the new field.
+
 ## [0.0.17](https://github.com/moq-dev/moq/compare/moq-video-v0.0.16...moq-video-v0.0.17) - 2026-08-14
 
 ### Added

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -35,26 +35,6 @@ use super::rate::{Control, Policy};
 #[cfg(feature = "capture")]
 const DEFAULT_FRAMERATE: u32 = 30;
 
-/// The rendition as the importer wants it: what to publish now, and what to keep filling in on
-/// every config it later resolves from the bitstream.
-///
-/// A probed rendition is what the first keyframe carries, so the importer's own config matches it
-/// field for field and the catalog is published once rather than corrected. The fields the
-/// bitstream can't reveal (bitrate always, framerate outside an optional VUI) are the ones this
-/// overlay keeps supplying.
-fn rendition_hint(rendition: hang::catalog::VideoConfig) -> moq_mux::catalog::VideoHint {
-	let mut hint = moq_mux::catalog::VideoHint::default();
-	hint.codec = Some(rendition.codec);
-	hint.coded_width = rendition.coded_width;
-	hint.coded_height = rendition.coded_height;
-	hint.display_aspect_width = rendition.display_aspect_width;
-	hint.display_aspect_height = rendition.display_aspect_height;
-	hint.framerate = rendition.framerate;
-	hint.bitrate = rendition.bitrate;
-	hint.optimize_for_latency = rendition.optimize_for_latency;
-	hint
-}
-
 /// Per-codec splitter + importer pair. Each codec frames its packets and resolves
 /// its catalog rendition differently, so the producer holds one of these.
 enum Codecs<E: CatalogExt> {
@@ -104,14 +84,14 @@ impl<E: CatalogExt> Producer<E> {
 				let track = broadcast.unique_track(".avc3", catalog.track_info())?;
 				Codecs::H264 {
 					split: moq_mux::codec::h264::Split::new(),
-					import: moq_mux::codec::h264::Import::new(track, catalog.reserve(), rendition_hint(rendition))?,
+					import: moq_mux::codec::h264::Import::new(track, catalog.reserve(), rendition.into())?,
 				}
 			}
 			hang::catalog::VideoCodec::H265(_) => {
 				let track = broadcast.unique_track(".hev1", catalog.track_info())?;
 				Codecs::H265 {
 					split: moq_mux::codec::h265::Split::new(),
-					import: moq_mux::codec::h265::Import::new(track, catalog.reserve(), rendition_hint(rendition))?,
+					import: moq_mux::codec::h265::Import::new(track, catalog.reserve(), rendition.into())?,
 				}
 			}
 			// Unreachable via `Config::probe`, which only encodes what `Codec` covers.

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -44,6 +44,7 @@ const DEFAULT_FRAMERATE: u32 = 30;
 /// overlay keeps supplying.
 fn rendition_hint(rendition: hang::catalog::VideoConfig) -> moq_mux::catalog::VideoHint {
 	let mut hint = moq_mux::catalog::VideoHint::default();
+	hint.label = rendition.label;
 	hint.codec = Some(rendition.codec);
 	hint.coded_width = rendition.coded_width;
 	hint.coded_height = rendition.coded_height;

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -44,7 +44,6 @@ const DEFAULT_FRAMERATE: u32 = 30;
 /// overlay keeps supplying.
 fn rendition_hint(rendition: hang::catalog::VideoConfig) -> moq_mux::catalog::VideoHint {
 	let mut hint = moq_mux::catalog::VideoHint::default();
-	hint.label = rendition.label;
 	hint.codec = Some(rendition.codec);
 	hint.coded_width = rendition.coded_width;
 	hint.coded_height = rendition.coded_height;

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -194,9 +194,10 @@ public final class BroadcastProducer: Sendable {
     public func publishMedia(
         format: String,
         initData: Data = Data(),
+        label: String? = nil,
         video: VideoHint? = nil
     ) throws -> MediaProducer {
-        MediaProducer(try ffi.publishMedia(init: MoqInit(format: format, data: initData, video: video)))
+        MediaProducer(try ffi.publishMedia(init: MoqInit(format: format, data: initData, label: label, video: video)))
     }
 
     /// Publish a single media track requested through `BroadcastDynamic`.
@@ -204,20 +205,26 @@ public final class BroadcastProducer: Sendable {
         on request: TrackRequest,
         format: String,
         initData: Data = Data(),
+        label: String? = nil,
         video: VideoHint? = nil
     ) throws -> MediaProducer {
         MediaProducer(
             try ffi.publishMediaOnTrack(
                 request: request.ffi,
-                init: MoqInit(format: format, data: initData, video: video)
+                init: MoqInit(format: format, data: initData, label: label, video: video)
             )
         )
     }
 
     /// Open a media track fed by a raw byte stream with inferred frame boundaries
     /// (e.g. piped Annex-B H.264). Only self-describing formats are supported.
-    public func publishMediaStream(format: String, video: VideoHint? = nil) throws -> MediaStreamProducer {
-        MediaStreamProducer(try ffi.publishMediaStream(init: MoqInit(format: format, data: Data(), video: video)))
+    public func publishMediaStream(
+        format: String,
+        label: String? = nil,
+        video: VideoHint? = nil
+    ) throws -> MediaStreamProducer {
+        MediaStreamProducer(
+            try ffi.publishMediaStream(init: MoqInit(format: format, data: Data(), label: label, video: video)))
     }
 
     /// Open a track for arbitrary byte payloads, with no codec or container.


### PR DESCRIPTION
## Summary

- Add optional human-readable labels to audio and video rendition catalog entries while keeping generated transport track names as internal identifiers.
- Propagate labels through Hang, the muxer, libmoq, moq-ffi, and the Python, Swift, Go, Kotlin, and C documentation surfaces.
- Replace libmoq's positional `moq_publish_media` arguments with an extensible `moq_media_config`, following the C configuration pattern established by #2880.
- Update the Hang draft and the OBS consumer to match the new API.

## Public API changes

Breaking:

- C `moq_publish_media` now takes `(uint32_t broadcast, const moq_media_config *config)` instead of positional format, init, and label arguments.

Additive:

- New C `moq_media_config` with required format plus optional init bytes and label. Optional fields use zero defaults, and future fields can be appended.
- Hang Rust and TypeScript audio/video catalog configs gain an optional `label`.
- C `moq_video_config` and `moq_audio_config` append `label` and `label_len`.
- `MoqInit` gains an optional label through moq-ffi and generated bindings.
- Python and Swift media publishing gain optional label arguments, and Go gains `WithLabel`.

The C signature break keeps this PR targeted at `dev`.

## Test plan

- [x] `just rs check -p libmoq`
- [x] `just rs test -p libmoq` (66 passed)
- [x] Generated `moq.h` signature and append-only struct field order inspected
- [x] `just obs check`
- [x] `just obs test`
- [x] `just obs build`
- [x] `just test smoke-full` (all Rust, Python, JS, C, and GStreamer combinations passed)
- [x] GitHub Actions `just check` and `just test`

## Cross-package sync

- Updated the Hang draft and concept documentation for the catalog field.
- Updated libmoq's OBS consumer, C documentation, tests, and changelog.
- Updated moq-ffi wrappers and documentation across Python, Swift, Kotlin, and Go.

(Written by GPT-5)