### PR TITLE
fix(net): decode largest object in subscribe ok

### DIFF
--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -515,36 +515,7 @@ macro_rules! decode_params {
 						continue;
 					}
 				)*
-
-				// A parameter this message doesn't handle. Through draft-16 the
-				// Key-Value-Pair shape is self-describing (even key = varint value,
-				// odd key = length-prefixed bytes), and parameters that appear in an
-				// unexpected message type MUST be ignored (moq-transport Section
-				// 9.2.2) — faulting them tears down interop with spec-compliant
-				// peers: Cloudflare's draft-16 relays send LARGEST_OBJECT (0x9) in
-				// SUBSCRIBE_OK, which used to kill every subscribe with content as
-				// `InvalidValue`. From draft-17 on this implementation encodes
-				// parameter values type-specifically (see `Param`), so an unknown
-				// value's length is unknowable and rejecting stays the only option.
-				match _version {
-					$crate::ietf::Version::Draft14 | $crate::ietf::Version::Draft15 | $crate::ietf::Version::Draft16 => {
-						if _key % 2 == 0 {
-							let _: u64 = <u64 as $crate::coding::Decode<$crate::ietf::Version>>::decode($r, _version)?;
-						} else {
-							let _len =
-								<u64 as $crate::coding::Decode<$crate::ietf::Version>>::decode($r, _version)? as usize;
-							// Mirrors MAX_KVP_VALUE_LEN; the const is private to the defining module.
-							if _len > (1 << 16) - 1 {
-								return Err($crate::coding::DecodeError::BoundsExceeded);
-							}
-							if ::bytes::Buf::remaining($r) < _len {
-								return Err($crate::coding::DecodeError::Short);
-							}
-							::bytes::Buf::advance($r, _len);
-						}
-					}
-					_ => return Err($crate::coding::DecodeError::InvalidValue),
-				}
+				return Err($crate::coding::DecodeError::InvalidValue);
 			}
 		}
 
@@ -714,52 +685,6 @@ mod tests {
 				|r, v| {
 					decode_params!(r, v, 0x09 => val: Option<Location>);
 					assert_eq!(val, Some(Location { group: 5, object: 3 }));
-					Ok(())
-				},
-			);
-		}
-	}
-
-	#[test]
-	fn test_unknown_params_are_skipped() {
-		// Parameters a message doesn't define MUST be ignored, not faulted
-		// (moq-transport Section 9.2.2). Skipping goes by Key-Value-Pair shape:
-		// odd keys are length-prefixed, even keys are a bare varint. Only
-		// through draft-16: from draft-17 on values are encoded
-		// type-specifically, so unknown ones cannot be skipped (see
-		// test_param_unknown_rejected_v17_plus).
-		let loc = Location { group: 5, object: 0 };
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16] {
-			// Unknown ODD key (0x09) before a known one.
-			round_trip_params(
-				version,
-				|w, v| {
-					encode_params!(w, v,
-						0x09 => loc.clone(),
-						0x20 => 200u8,
-					);
-					Ok(())
-				},
-				|r, v| {
-					decode_params!(r, v, 0x20 => val: Option<u8>);
-					assert_eq!(val, Some(200));
-					Ok(())
-				},
-			);
-
-			// Unknown EVEN key (0x20) before a known one.
-			round_trip_params(
-				version,
-				|w, v| {
-					encode_params!(w, v,
-						0x20 => 7u8,
-						0x22 => 9u8,
-					);
-					Ok(())
-				},
-				|r, v| {
-					decode_params!(r, v, 0x22 => val: Option<u8>);
-					assert_eq!(val, Some(9));
 					Ok(())
 				},
 			);
@@ -945,12 +870,15 @@ mod tests {
 	}
 
 	#[test]
-	fn test_param_unknown_rejected_v17_plus() {
-		// From draft-17 on, parameter values are encoded type-specifically
-		// (see `Param`), so an unknown parameter's length is unknowable and
-		// the message must be rejected. Draft-14/15/16 skip instead — see
-		// test_unknown_params_are_skipped.
-		for version in [Version::Draft17, Version::Draft18] {
+	fn test_param_unknown_rejected() {
+		// Manually encode one param at key 0x10, try to decode expecting key 0x20
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			let mut buf = BytesMut::new();
 			1usize.encode(&mut buf, version).unwrap();
 			0x10u64.encode(&mut buf, version).unwrap();

--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -515,7 +515,36 @@ macro_rules! decode_params {
 						continue;
 					}
 				)*
-				return Err($crate::coding::DecodeError::InvalidValue);
+
+				// A parameter this message doesn't handle. Through draft-16 the
+				// Key-Value-Pair shape is self-describing (even key = varint value,
+				// odd key = length-prefixed bytes), and parameters that appear in an
+				// unexpected message type MUST be ignored (moq-transport Section
+				// 9.2.2) — faulting them tears down interop with spec-compliant
+				// peers: Cloudflare's draft-16 relays send LARGEST_OBJECT (0x9) in
+				// SUBSCRIBE_OK, which used to kill every subscribe with content as
+				// `InvalidValue`. From draft-17 on this implementation encodes
+				// parameter values type-specifically (see `Param`), so an unknown
+				// value's length is unknowable and rejecting stays the only option.
+				match _version {
+					$crate::ietf::Version::Draft14 | $crate::ietf::Version::Draft15 | $crate::ietf::Version::Draft16 => {
+						if _key % 2 == 0 {
+							let _: u64 = <u64 as $crate::coding::Decode<$crate::ietf::Version>>::decode($r, _version)?;
+						} else {
+							let _len =
+								<u64 as $crate::coding::Decode<$crate::ietf::Version>>::decode($r, _version)? as usize;
+							// Mirrors MAX_KVP_VALUE_LEN; the const is private to the defining module.
+							if _len > (1 << 16) - 1 {
+								return Err($crate::coding::DecodeError::BoundsExceeded);
+							}
+							if ::bytes::Buf::remaining($r) < _len {
+								return Err($crate::coding::DecodeError::Short);
+							}
+							::bytes::Buf::advance($r, _len);
+						}
+					}
+					_ => return Err($crate::coding::DecodeError::InvalidValue),
+				}
 			}
 		}
 
@@ -685,6 +714,52 @@ mod tests {
 				|r, v| {
 					decode_params!(r, v, 0x09 => val: Option<Location>);
 					assert_eq!(val, Some(Location { group: 5, object: 3 }));
+					Ok(())
+				},
+			);
+		}
+	}
+
+	#[test]
+	fn test_unknown_params_are_skipped() {
+		// Parameters a message doesn't define MUST be ignored, not faulted
+		// (moq-transport Section 9.2.2). Skipping goes by Key-Value-Pair shape:
+		// odd keys are length-prefixed, even keys are a bare varint. Only
+		// through draft-16: from draft-17 on values are encoded
+		// type-specifically, so unknown ones cannot be skipped (see
+		// test_param_unknown_rejected_v17_plus).
+		let loc = Location { group: 5, object: 0 };
+		for version in [Version::Draft14, Version::Draft15, Version::Draft16] {
+			// Unknown ODD key (0x09) before a known one.
+			round_trip_params(
+				version,
+				|w, v| {
+					encode_params!(w, v,
+						0x09 => loc.clone(),
+						0x20 => 200u8,
+					);
+					Ok(())
+				},
+				|r, v| {
+					decode_params!(r, v, 0x20 => val: Option<u8>);
+					assert_eq!(val, Some(200));
+					Ok(())
+				},
+			);
+
+			// Unknown EVEN key (0x20) before a known one.
+			round_trip_params(
+				version,
+				|w, v| {
+					encode_params!(w, v,
+						0x20 => 7u8,
+						0x22 => 9u8,
+					);
+					Ok(())
+				},
+				|r, v| {
+					decode_params!(r, v, 0x22 => val: Option<u8>);
+					assert_eq!(val, Some(9));
 					Ok(())
 				},
 			);
@@ -870,15 +945,12 @@ mod tests {
 	}
 
 	#[test]
-	fn test_param_unknown_rejected() {
-		// Manually encode one param at key 0x10, try to decode expecting key 0x20
-		for version in [
-			Version::Draft14,
-			Version::Draft15,
-			Version::Draft16,
-			Version::Draft17,
-			Version::Draft18,
-		] {
+	fn test_param_unknown_rejected_v17_plus() {
+		// From draft-17 on, parameter values are encoded type-specifically
+		// (see `Param`), so an unknown parameter's length is unknowable and
+		// the message must be rejected. Draft-14/15/16 skip instead — see
+		// test_unknown_params_are_skipped.
+		for version in [Version::Draft17, Version::Draft18] {
 			let mut buf = BytesMut::new();
 			1usize.encode(&mut buf, version).unwrap();
 			0x10u64.encode(&mut buf, version).unwrap();

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -255,9 +255,23 @@ impl Message for SubscribeOk {
 			_ => {
 				// GROUP_ORDER is only legal here through draft-15, but keep accepting it so a
 				// peer that still sends it doesn't have its session torn down over a hint.
-				decode_params!(r, version,
-					0x22 => group_order: Option<GroupOrder>,
-				);
+				let group_order = match version {
+					Version::Draft15 | Version::Draft16 => {
+						// LARGEST_OBJECT is required here once the track has content, but
+						// the session model does not currently expose the location.
+						decode_params!(r, version,
+							0x09 => _largest_location: Option<Location>,
+							0x22 => group_order: Option<GroupOrder>,
+						);
+						group_order
+					}
+					_ => {
+						decode_params!(r, version,
+							0x22 => group_order: Option<GroupOrder>,
+						);
+						group_order
+					}
+				};
 				properties = Properties::decode(r, version)?;
 				properties.group_order = properties.group_order.or(group_order);
 			}
@@ -633,18 +647,15 @@ mod tests {
 	}
 
 	#[test]
-	fn test_subscribe_ok_ignores_unknown_parameter_v16() {
-		// The exact SUBSCRIBE_OK body Cloudflare's draft-16 relays send once a
-		// track has content: request_id=4, track_alias=4, one LARGEST_OBJECT
-		// (0x9) parameter carrying Location{group=5, object=0}. Parameters a
-		// message doesn't define MUST be ignored (moq-transport Section 9.2.2);
-		// this used to fail with InvalidValue, aborting every subscribe with
-		// content against those relays (#2832).
+	fn test_subscribe_ok_accepts_largest_object() {
+		// request_id=4, track_alias=4, one LARGEST_OBJECT parameter at {5, 0}.
 		let payload = [0x04, 0x04, 0x01, 0x09, 0x02, 0x05, 0x00];
-		let decoded: SubscribeOk = decode_message(&payload, Version::Draft16).unwrap();
+		for version in [Version::Draft15, Version::Draft16] {
+			let decoded: SubscribeOk = decode_message(&payload, version).unwrap();
 
-		assert_eq!(decoded.request_id, Some(RequestId(4)));
-		assert_eq!(decoded.track_alias, 4);
+			assert_eq!(decoded.request_id, Some(RequestId(4)));
+			assert_eq!(decoded.track_alias, 4);
+		}
 	}
 
 	#[test]

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -633,6 +633,21 @@ mod tests {
 	}
 
 	#[test]
+	fn test_subscribe_ok_ignores_unknown_parameter_v16() {
+		// The exact SUBSCRIBE_OK body Cloudflare's draft-16 relays send once a
+		// track has content: request_id=4, track_alias=4, one LARGEST_OBJECT
+		// (0x9) parameter carrying Location{group=5, object=0}. Parameters a
+		// message doesn't define MUST be ignored (moq-transport Section 9.2.2);
+		// this used to fail with InvalidValue, aborting every subscribe with
+		// content against those relays (#2832).
+		let payload = [0x04, 0x04, 0x01, 0x09, 0x02, 0x05, 0x00];
+		let decoded: SubscribeOk = decode_message(&payload, Version::Draft16).unwrap();
+
+		assert_eq!(decoded.request_id, Some(RequestId(4)));
+		assert_eq!(decoded.track_alias, 4);
+	}
+
+	#[test]
 	fn test_subscribe_ok_v15() {
 		let msg = SubscribeOk {
 			request_id: Some(RequestId(42)),


### PR DESCRIPTION
### Summary

- Closes #2832.
- Draft-15 and draft-16 define `LARGEST_OBJECT` (0x09) as a legal `SUBSCRIBE_OK` parameter and require it once the track has content.
- The `SubscribeOk` decoder now parses that typed parameter for draft-15/16 while leaving the public session model unchanged.
- Generic unknown message parameters remain rejected, including on draft-16.

### Root cause

The `SubscribeOk` decoder listed `GROUP_ORDER` but omitted `LARGEST_OBJECT`. Cloudflare's draft-16 relay sends `LARGEST_OBJECT` after content is available, so the otherwise valid response failed with `InvalidValue` and aborted the subscription.

### Public API changes

None. The decoded location is not currently exposed by the session model.

### Validation

- `cargo fmt --check --package moq-net`
- `cargo clippy --all-targets --package moq-net -- -D warnings`
- `cargo test --package moq-net` (764 tests)
- Regression test decodes the observed payload on both draft-15 and draft-16.

(Written by GPT-5)