### PR TITLE
fix(mux): derive missing video geometry

### DIFF
--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -514,7 +514,9 @@ async fn fetch_media_group_rejects_invalid_container_before_fetching() {
 
 #[tokio::test]
 async fn fetch_media_group_decodes_multiple_cmaf_samples() {
-	let config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+	let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+	config.coded_width = Some(320);
+	config.coded_height = Some(240);
 	let muxer = moq_mux::container::fmp4::Muxer::video(&config).unwrap();
 	let init = muxer.init().unwrap().expect("VP8 init should be available");
 	let catalog_container = hang::catalog::Container::Cmaf { init: init.clone() };

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -239,6 +239,21 @@ mod tests {
 		}
 	}
 
+	fn vp8_frame(micros: u64, keyframe: bool) -> moq_mux::container::Frame {
+		let payload = if keyframe {
+			// Key frame tag, start code, and 320x240 geometry.
+			&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00][..]
+		} else {
+			&[0x31, 0x00, 0x00][..]
+		};
+		moq_mux::container::Frame {
+			timestamp: moq_net::Timestamp::from_micros(micros).unwrap(),
+			payload: bytes::Bytes::copy_from_slice(payload),
+			keyframe,
+			duration: None,
+		}
+	}
+
 	fn video_config(catalog: &moq_mux::catalog::Producer) -> hang::catalog::VideoConfig {
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.coded_width = Some(320);
@@ -292,7 +307,9 @@ mod tests {
 
 		let reserved = catalog.reserve();
 		let mut registration = reserved.video("video0");
-		let config = video_config(&catalog);
+		let mut config = video_config(&catalog);
+		config.coded_width = None;
+		config.coded_height = None;
 		registration.set(config);
 		drop(reserved);
 
@@ -301,11 +318,11 @@ mod tests {
 		let mut media = catalog
 			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
 			.unwrap();
-		media.write(frame(0, true)).unwrap();
-		media.write(frame(1_000_000, false)).unwrap();
-		media.write(frame(2_000_000, true)).unwrap();
-		media.write(frame(3_000_000, false)).unwrap();
-		media.write(frame(4_000_000, true)).unwrap();
+		media.write(vp8_frame(0, true)).unwrap();
+		media.write(vp8_frame(1_000_000, false)).unwrap();
+		media.write(vp8_frame(2_000_000, true)).unwrap();
+		media.write(vp8_frame(3_000_000, false)).unwrap();
+		media.write(vp8_frame(4_000_000, true)).unwrap();
 
 		let source = moq_mux::Source::new(origin.consume(), "live");
 		let broadcaster = Broadcaster::new(source, Config::default()).await.unwrap();

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -239,6 +239,15 @@ mod tests {
 		}
 	}
 
+	fn video_config(catalog: &moq_mux::catalog::Producer) -> hang::catalog::VideoConfig {
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
+		config.framerate = Some(30.0);
+		config.timeline = Some(catalog.timeline("video0").unwrap().section());
+		config
+	}
+
 	// Let the origin's spawned attach task run so a created broadcast is routable.
 	async fn settle() {
 		for _ in 0..10 {
@@ -283,9 +292,7 @@ mod tests {
 
 		let reserved = catalog.reserve();
 		let mut registration = reserved.video("video0");
-		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
-		config.framerate = Some(30.0);
-		config.timeline = Some(catalog.timeline("video0").unwrap().section());
+		let config = video_config(&catalog);
 		registration.set(config);
 		drop(reserved);
 
@@ -359,9 +366,7 @@ mod tests {
 
 		let reserved = catalog.reserve();
 		let mut registration = reserved.video("video0");
-		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
-		config.framerate = Some(30.0);
-		config.timeline = Some(catalog.timeline("video0").unwrap().section());
+		let config = video_config(&catalog);
 		registration.set(config);
 		drop(reserved);
 
@@ -430,9 +435,7 @@ mod tests {
 
 			let reserved = catalog.reserve();
 			let mut registration = reserved.video("video0");
-			let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
-			config.framerate = Some(30.0);
-			config.timeline = Some(catalog.timeline("video0").unwrap().section());
+			let config = video_config(&catalog);
 			registration.set(config.clone());
 			drop(reserved);
 
@@ -573,9 +576,7 @@ mod tests {
 
 		let reserved = catalog.reserve();
 		let mut registration = reserved.video("video0");
-		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
-		config.framerate = Some(30.0);
-		config.timeline = Some(catalog.timeline("video0").unwrap().section());
+		let config = video_config(&catalog);
 		registration.set(config);
 		drop(reserved);
 
@@ -632,9 +633,7 @@ mod tests {
 
 		let reserved = catalog.reserve();
 		let mut registration = reserved.video("video0");
-		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
-		config.framerate = Some(30.0);
-		config.timeline = Some(catalog.timeline("video0").unwrap().section());
+		let config = video_config(&catalog);
 		registration.set(config);
 		drop(reserved);
 

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -184,17 +184,13 @@ impl<E: CatalogExt> Import<E> {
 		}
 		self.last_seq = Some(seq_obu.clone());
 
-		let mut reader = &seq_obu[..];
-		let header = ObuHeader::parse(&mut reader)?;
-		let payload_offset = seq_obu.len() - reader.len();
-
-		match SequenceHeaderObu::parse(header, &mut &seq_obu[payload_offset..]) {
-			Ok(seq_header) => self.init(&seq_header),
-			Err(_) if !self.catalog.configured() => {
+		match parse_sequence_header(seq_obu)? {
+			Some(seq_header) => self.init(&seq_header),
+			None if !self.catalog.configured() => {
 				tracing::debug!("sequence header parse failed, using minimal config");
 				self.init_minimal();
 			}
-			Err(_) => {}
+			None => {}
 		}
 		Ok(())
 	}
@@ -273,6 +269,26 @@ fn is_sequence_header(obu: &[u8]) -> bool {
 	ObuHeader::parse(&mut reader)
 		.map(|h| h.obu_type == ObuType::SequenceHeader)
 		.unwrap_or(false)
+}
+
+fn parse_sequence_header(obu: &[u8]) -> Result<Option<SequenceHeaderObu>> {
+	let mut reader = obu;
+	let header = ObuHeader::parse(&mut reader)?;
+	Ok(SequenceHeaderObu::parse(header, &mut reader).ok())
+}
+
+/// Read encoded dimensions from the first parseable sequence header in a frame.
+pub(crate) fn dimensions(payload: &[u8]) -> Result<Option<(u32, u32)>> {
+	let Some(sequence) = find_sequence_header(payload) else {
+		return Ok(None);
+	};
+	let Some(sequence) = parse_sequence_header(&sequence)? else {
+		return Ok(None);
+	};
+	Ok(Some((
+		sequence.max_frame_width as u32,
+		sequence.max_frame_height as u32,
+	)))
 }
 
 /// Find the first sequence-header OBU in a payload, if any.

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -189,14 +189,23 @@ impl<S: Stream> Export<S> {
 		// is ready, so the source keeps polling for SPS/PPS-bearing frames
 		// instead of parking.
 		let waiting_for_init = !self.init_emitted;
-		for track in self.tracks.values_mut() {
+		for (name, track) in &mut self.tracks {
 			if track.pending.is_some() || track.finished {
 				continue;
 			}
 			loop {
 				match track.source.poll_read(waiter) {
 					Poll::Ready(Ok(Some(frame))) => {
-						if waiting_for_init && !track.source.header_ready() {
+						let geometry_ready = !track.is_video
+							|| self
+								.catalog_snapshot
+								.as_ref()
+								.and_then(|catalog| catalog.video.renditions.get(name))
+								.is_some_and(|config| {
+									matches!(config.container, Container::Cmaf { .. })
+										|| track.source.video_geometry_ready(config)
+								});
+						if waiting_for_init && (!track.source.header_ready() || !geometry_ready) {
 							continue;
 						}
 						track.pending = Some(frame);
@@ -409,7 +418,17 @@ impl<S: Stream> Export<S> {
 	/// True once every source has resolved its codec config so we can build
 	/// the merged init segment.
 	fn init_ready(&self) -> bool {
-		self.catalog_snapshot.is_some() && self.tracks.values().all(|t| t.source.header_ready())
+		let Some(catalog) = self.catalog_snapshot.as_ref() else {
+			return false;
+		};
+		self.tracks.values().all(|t| t.source.header_ready())
+			&& catalog.video.renditions.iter().all(|(name, config)| {
+				matches!(config.container, Container::Cmaf { .. })
+					|| self
+						.tracks
+						.get(name)
+						.is_some_and(|track| track.source.video_geometry_ready(config))
+			})
 	}
 
 	/// Build the merged ftyp + multi-track moov init segment from the cached
@@ -434,10 +453,11 @@ impl<S: Stream> Export<S> {
 				Container::Legacy | Container::Loc => {
 					// H.264/H.265 need a synthesized config record here; VP8 has none.
 					let description = track.source.description();
+					let config = track.source.video_config(config).unwrap_or_else(|| config.clone());
 					let trak = crate::container::fmp4::synthesize_video_trak(
 						track.track_id,
 						track.timescale,
-						config,
+						&config,
 						description.map(|d| d.as_ref()),
 					)?;
 					trexs.push(mp4_atom::Trex {

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -218,6 +218,32 @@ async fn dimensionless_video_waits_for_catalog_geometry() {
 	assert_eq!((vp08.visual.width, vp08.visual.height), (320, 240));
 }
 
+/// A fixed codec description cannot recover on a later frame, so malformed
+/// metadata must fail instead of leaving the exporter pending for geometry.
+#[tokio::test(start_paused = true)]
+async fn dimensionless_video_rejects_a_malformed_description() {
+	use hang::catalog::{Container, H264, VideoConfig};
+
+	let live = Live::new(".avc1", |catalog, name| {
+		let mut config = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0,
+			level: 0x1f,
+			inline: false,
+		});
+		config.description = Some(bytes::Bytes::from_static(&[1]));
+		config.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(name, config);
+	});
+
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	let error = exporter.next().await.expect_err("malformed fixed description");
+	assert!(matches!(
+		error,
+		crate::Error::H264(crate::codec::h264::Error::AvccTooShort)
+	));
+}
+
 /// VP9 source (catalog `Container::Legacy`, codec `vp09`, no `description`) →
 /// fMP4 export must synthesize a `vp09` sample entry whose `vpcC` round-trips
 /// the catalog's VP9 parameters.

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -120,22 +120,27 @@ async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
 	moov.encode(&mut buf).expect("encode synthesized moov");
 }
 
-/// VP8 source (catalog `Container::Legacy`, codec `vp8`, no `description`) →
-/// fMP4 export must synthesize a `vp08` sample entry. VP8 carries no out-of-band
-/// config, so this exercises the description-less synthesis path.
+/// VP8 source (catalog `Container::Legacy`, codec `vp8`, no dimensions or
+/// `description`) → fMP4 export derives geometry from the keyframe and
+/// synthesizes a `vp08` sample entry. VP8 carries no out-of-band config, so
+/// this exercises the dimensionless startup and description-less synthesis paths.
 #[tokio::test(start_paused = true)]
 async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
 	use hang::catalog::{Container, VideoCodec, VideoConfig};
 
 	let mut live = Live::new(".vp8", |catalog, name| {
 		let mut config = VideoConfig::new(VideoCodec::VP8);
-		config.coded_width = Some(320);
-		config.coded_height = Some(240);
 		config.container = Container::Legacy;
 		catalog.lock().video.renditions.insert(name, config);
 	});
+	// Geometry-less startup frames must not park the source before the keyframe.
+	live.track.write(raw_frame(0, &[0x31, 0x00, 0x00], true)).unwrap();
 	live.track
-		.write(raw_frame(0, &[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a], true))
+		.write(raw_frame(
+			33_000,
+			&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00],
+			true,
+		))
 		.unwrap();
 	live.track.finish().unwrap();
 
@@ -166,6 +171,51 @@ async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
 	// The synthesized init (vpcC included) must round-trip through encode.
 	let mut buf = Vec::new();
 	moov.encode(&mut buf).expect("encode synthesized moov");
+}
+
+/// If codec data cannot reveal geometry yet, the exporter waits for a later
+/// catalog snapshot instead of freezing zero dimensions into the init segment.
+#[tokio::test(start_paused = true)]
+async fn dimensionless_video_waits_for_catalog_geometry() {
+	use hang::catalog::{Container, VideoCodec, VideoConfig};
+
+	let mut live = Live::new(".vp8", |catalog, name| {
+		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(name, config);
+	});
+	let name = live.track.name().to_string();
+	// A VP8 interframe carries no geometry. Mark it as the group boundary only
+	// so the synthetic producer accepts it before the catalog update arrives.
+	live.track.write(raw_frame(0, &[0x31, 0x00, 0x00], true)).unwrap();
+
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	let pending = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next()).await;
+	assert!(
+		pending.is_err(),
+		"exporter emitted an init without geometry: {pending:?}"
+	);
+
+	{
+		let mut catalog = live.catalog.lock();
+		let config = catalog.video.renditions.get_mut(&name).unwrap();
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
+	}
+
+	let init = fragment_now(&mut exporter).await.data;
+	let mut cursor = Cursor::new(init.as_ref());
+	let mut moov = None;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).expect("decode init") {
+		if let mp4_atom::Any::Moov(value) = atom {
+			moov = Some(value);
+		}
+	}
+	let trak = &moov.expect("init segment missing moov").trak[0];
+	let mp4_atom::Codec::Vp08(vp08) = &trak.mdia.minf.stbl.stsd.codecs[0] else {
+		panic!("expected vp08 sample entry");
+	};
+	assert_eq!((vp08.visual.width, vp08.visual.height), (320, 240));
 }
 
 /// VP9 source (catalog `Container::Legacy`, codec `vp09`, no `description`) →
@@ -507,6 +557,8 @@ async fn unusable_framerate_uses_the_standard_fallback_rate() {
 
 	let mut live = Live::new(".vp8", |catalog, name| {
 		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
 		config.framerate = Some(0.0005);
 		config.container = Container::Legacy;
 		catalog.lock().video.renditions.insert(name, config);

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -120,6 +120,10 @@ pub enum Error {
 	#[error("video track {0} missing in catalog")]
 	MissingVideoTrack(String),
 
+	/// A synthesized video track has no usable encoded dimensions.
+	#[error("missing video dimensions for codec: {0}")]
+	MissingVideoDimensions(String),
+
 	#[error("audio track {0} missing in catalog")]
 	MissingAudioTrack(String),
 
@@ -529,8 +533,28 @@ pub(crate) fn synthesize_video_trak(
 	config: &VideoConfig,
 	description: Option<&[u8]>,
 ) -> Result<mp4_atom::Trak> {
-	let width = config.coded_width.unwrap_or(0) as u16;
-	let height = config.coded_height.unwrap_or(0) as u16;
+	if !matches!(
+		config.codec,
+		VideoCodec::H264(_) | VideoCodec::H265(_) | VideoCodec::AV1(_) | VideoCodec::VP8 | VideoCodec::VP9(_)
+	) {
+		return Err(Error::UnsupportedSynthesis(format!("video codec {:?}", config.codec)));
+	}
+
+	let width = u16::try_from(
+		config
+			.coded_width
+			.ok_or_else(|| Error::MissingVideoDimensions(config.codec.to_string()))?,
+	)
+	.map_err(|_| Error::MissingVideoDimensions(config.codec.to_string()))?;
+	let height = u16::try_from(
+		config
+			.coded_height
+			.ok_or_else(|| Error::MissingVideoDimensions(config.codec.to_string()))?,
+	)
+	.map_err(|_| Error::MissingVideoDimensions(config.codec.to_string()))?;
+	if width == 0 || height == 0 {
+		return Err(Error::MissingVideoDimensions(config.codec.to_string()));
+	}
 	let visual = mp4_atom::Visual {
 		data_reference_index: 1,
 		width,
@@ -584,7 +608,7 @@ pub(crate) fn synthesize_video_trak(
 			vpcc: crate::codec::vp9::vpcc(vp9),
 			..Default::default()
 		}),
-		other => return Err(Error::UnsupportedSynthesis(format!("video codec {:?}", other))),
+		other => unreachable!("unsupported codecs rejected before geometry synthesis: {other:?}"),
 	};
 
 	Ok(build_video_trak(
@@ -1115,6 +1139,8 @@ mod tests {
 	#[test]
 	fn synthesized_video_init_sets_the_track_flags() {
 		let mut config = VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
 		config.framerate = Some(30.0);
 		let video = synthesize_video_trak(1, 30_000, &config, None).unwrap();
 		let init = encode_init(None, vec![video], Vec::new()).unwrap();
@@ -1123,6 +1149,13 @@ mod tests {
 		let tkhd = &moov.trak[0].tkhd;
 		assert!(tkhd.enabled && tkhd.in_movie, "flags 0x000003");
 		assert_eq!(tkhd.volume.integer(), 0);
+	}
+
+	#[test]
+	fn synthesized_video_init_rejects_missing_dimensions() {
+		let config = VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		let error = synthesize_video_trak(1, 30_000, &config, None).unwrap_err();
+		assert!(matches!(error, Error::MissingVideoDimensions(_)));
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -321,6 +321,8 @@ mod tests {
 	// A 30 fps Legacy VP8 rendition: no description needed, so the muxer builds without media.
 	fn video_muxer() -> Muxer {
 		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
 		config.framerate = Some(30.0);
 		Muxer::video(&config).unwrap()
 	}
@@ -391,6 +393,8 @@ mod tests {
 	#[test]
 	fn low_framerate_fallback_fits_mp4_timing_fields() {
 		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
 		config.framerate = Some(0.0011);
 		let muxer = Muxer::video(&config).unwrap();
 		assert_eq!(muxer.timescale().as_u64(), 11);
@@ -487,6 +491,8 @@ mod tests {
 	#[test]
 	fn init_rejects_a_catalog_scale_too_large_for_mdhd() {
 		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
 		config.framerate = Some(5_000_000.0); // 5e9 ticks, past u32::MAX
 		let err = Muxer::video(&config).unwrap().init().unwrap_err();
 		assert!(

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -7,7 +7,7 @@ use hang::catalog::{AudioConfig, Container as CatalogContainer, VideoConfig};
 
 use crate::catalog::hang::Container as HangContainer;
 use crate::container::Frame;
-use crate::container::source::{VideoTransform, build_video_transform};
+use crate::container::source::{VideoTransform, build_video_transform, catalog_dimensions, codec_dimensions};
 
 use super::export::{
 	apply_codec_durations, catalog_timescale_audio, catalog_timescale_video, extract_init, infer_missing_durations,
@@ -42,8 +42,8 @@ enum Kind {
 ///    [`fragmenter`](Self::fragmenter) instead cuts a stream into one separately addressable
 ///    fragment per frame, for a consumer that stores media per encoded frame.
 ///
-/// For inline-parameter-set codecs (catalog `description` absent), [`init`](Self::init) returns
-/// `None` until a group has been [`read`](Self::read) to resolve the config from a keyframe.
+/// For video missing codec configuration or geometry, [`init`](Self::init) returns `None` until a
+/// group has been [`read`](Self::read) to resolve the missing fields from a keyframe.
 pub struct Muxer {
 	kind: Kind,
 	container: HangContainer,
@@ -64,14 +64,22 @@ impl Muxer {
 	pub fn video(config: &VideoConfig) -> crate::Result<Self> {
 		let container = (&config.container).try_into()?;
 		let framerate = super::usable_video_framerate(config).unwrap_or(30.0);
+		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
+		let mut config = config.clone();
+		if catalog_dimensions(&config).is_none()
+			&& let Some((width, height)) = codec_dimensions(&config.codec, description.as_deref(), &[])
+		{
+			config.coded_width = Some(width);
+			config.coded_height = Some(height);
+		}
 		Ok(Self {
 			container,
-			transform: build_video_transform(config),
-			description: config.description.as_ref().filter(|b| !b.is_empty()).cloned(),
-			timescale: moq_net::Timescale::new(catalog_timescale_video(config)?).map_err(Error::from)?,
+			transform: build_video_transform(&config),
+			description,
+			timescale: moq_net::Timescale::new(catalog_timescale_video(&config)?).map_err(Error::from)?,
 			default_frame: Duration::from_secs_f64(1.0 / framerate),
 			opus: false,
-			kind: Kind::Video(config.clone()),
+			kind: Kind::Video(config),
 		})
 	}
 
@@ -138,6 +146,7 @@ impl Muxer {
 		while let Some(frames) = self.container.read(group).await? {
 			for frame in frames {
 				let Some(transform) = self.transform.as_mut() else {
+					self.resolve_video_dimensions(&frame.payload);
 					out.push(frame);
 					continue;
 				};
@@ -149,6 +158,7 @@ impl Muxer {
 				{
 					self.description = Some(d.clone());
 				}
+				self.resolve_video_dimensions(&frame.payload);
 				if let Some(payload) = payload {
 					out.push(Frame { payload, ..frame });
 				}
@@ -160,17 +170,37 @@ impl Muxer {
 		Ok(out)
 	}
 
+	fn resolve_video_dimensions(&mut self, payload: &[u8]) {
+		let Kind::Video(config) = &mut self.kind else {
+			return;
+		};
+		if catalog_dimensions(config).is_some() {
+			return;
+		}
+		if let Some((width, height)) = codec_dimensions(&config.codec, self.description.as_deref(), payload) {
+			config.coded_width = Some(width);
+			config.coded_height = Some(height);
+		}
+	}
+
 	/// Build the rendition's CMAF init segment (ftyp+moov), or `None` if it isn't buildable yet.
 	///
 	/// A `Cmaf` rendition's catalog init passes through (with the track id normalized to match
 	/// [`fragment`](Self::fragment)); a `Legacy`/`Loc` rendition's is synthesized from the catalog
-	/// config. `None` means an inline-parameter-set video rendition whose codec config hasn't been
-	/// resolved yet: [`read`](Self::read) a group (its keyframe carries the parameter sets) and call
-	/// again.
+	/// config. `None` means a video rendition whose codec config or geometry hasn't been resolved
+	/// yet: [`read`](Self::read) a group (its keyframe carries those fields) and call again.
 	pub fn init(&self) -> crate::Result<Option<Bytes>> {
 		// An inline codec carries its config in-band, so the init can't be built until a keyframe
 		// group has been read.
 		if self.transform.is_some() && self.description.is_none() {
+			return Ok(None);
+		}
+		if matches!(
+			self.catalog_container(),
+			CatalogContainer::Legacy | CatalogContainer::Loc
+		) && let Kind::Video(config) = &self.kind
+			&& catalog_dimensions(config).is_none()
+		{
 			return Ok(None);
 		}
 
@@ -316,6 +346,40 @@ mod tests {
 		assert_eq!(decoded[0].timestamp.as_micros(), 10_000_000);
 		assert!(decoded[0].keyframe);
 		assert_eq!(decoded[1].timestamp.as_micros(), 10_033_000);
+	}
+
+	#[tokio::test]
+	async fn dimensionless_vp8_init_waits_for_keyframe_geometry() {
+		let track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("v", None)
+			.unwrap();
+		let mut subscriber = track.subscribe(None);
+		let mut producer = crate::container::Producer::new(track, HangContainer::Legacy);
+		producer
+			.write(Frame {
+				timestamp: Timestamp::ZERO,
+				// Key frame tag, start code, and 320x240 geometry.
+				payload: Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00]),
+				keyframe: true,
+				duration: None,
+			})
+			.unwrap();
+		producer.finish().unwrap();
+		let mut group = subscriber.next_group().await.unwrap().expect("a group");
+
+		let config = VideoConfig::new(VideoCodec::VP8);
+		let mut muxer = Muxer::video(&config).unwrap();
+		assert!(muxer.init().unwrap().is_none(), "geometry is unresolved before media");
+
+		let frames = muxer.read(&mut group).await.unwrap();
+		assert_eq!(frames.len(), 1);
+		let init = muxer.init().unwrap().expect("keyframe geometry makes init buildable");
+		let wire = super::super::Wire::from_init(&init).unwrap();
+		let mp4_atom::Codec::Vp08(vp08) = &wire.trak().mdia.minf.stbl.stsd.codecs[0] else {
+			panic!("expected VP8 sample entry");
+		};
+		assert_eq!((vp08.visual.width, vp08.visual.height), (320, 240));
 	}
 
 	// A 30 fps Legacy VP8 rendition: no description needed, so the muxer builds without media.

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -67,7 +67,7 @@ impl Muxer {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 		let mut config = config.clone();
 		if catalog_dimensions(&config).is_none()
-			&& let Some((width, height)) = codec_dimensions(&config.codec, description.as_deref(), &[])
+			&& let Some((width, height)) = codec_dimensions(&config.codec, description.as_deref(), &[])?
 		{
 			config.coded_width = Some(width);
 			config.coded_height = Some(height);
@@ -146,7 +146,7 @@ impl Muxer {
 		while let Some(frames) = self.container.read(group).await? {
 			for frame in frames {
 				let Some(transform) = self.transform.as_mut() else {
-					self.resolve_video_dimensions(&frame.payload);
+					self.resolve_video_dimensions(&frame.payload)?;
 					out.push(frame);
 					continue;
 				};
@@ -158,7 +158,7 @@ impl Muxer {
 				{
 					self.description = Some(d.clone());
 				}
-				self.resolve_video_dimensions(&frame.payload);
+				self.resolve_video_dimensions(&frame.payload)?;
 				if let Some(payload) = payload {
 					out.push(Frame { payload, ..frame });
 				}
@@ -170,17 +170,18 @@ impl Muxer {
 		Ok(out)
 	}
 
-	fn resolve_video_dimensions(&mut self, payload: &[u8]) {
+	fn resolve_video_dimensions(&mut self, payload: &[u8]) -> crate::Result<()> {
 		let Kind::Video(config) = &mut self.kind else {
-			return;
+			return Ok(());
 		};
 		if catalog_dimensions(config).is_some() {
-			return;
+			return Ok(());
 		}
-		if let Some((width, height)) = codec_dimensions(&config.codec, self.description.as_deref(), payload) {
+		if let Some((width, height)) = codec_dimensions(&config.codec, self.description.as_deref(), payload)? {
 			config.coded_width = Some(width);
 			config.coded_height = Some(height);
 		}
+		Ok(())
 	}
 
 	/// Build the rendition's CMAF init segment (ftyp+moov), or `None` if it isn't buildable yet.
@@ -380,6 +381,22 @@ mod tests {
 			panic!("expected VP8 sample entry");
 		};
 		assert_eq!((vp08.visual.width, vp08.visual.height), (320, 240));
+	}
+
+	#[test]
+	fn malformed_fixed_description_errors_instead_of_waiting_for_geometry() {
+		let mut config = VideoConfig::new(hang::catalog::H264 {
+			profile: 0x42,
+			constraints: 0,
+			level: 0x1f,
+			inline: false,
+		});
+		config.description = Some(Bytes::from_static(&[1]));
+
+		assert!(matches!(
+			Muxer::video(&config),
+			Err(crate::Error::H264(crate::codec::h264::Error::AvccTooShort))
+		));
 	}
 
 	// A 30 fps Legacy VP8 rendition: no description needed, so the muxer builds without media.

--- a/rs/moq-mux/src/container/group.rs
+++ b/rs/moq-mux/src/container/group.rs
@@ -109,7 +109,9 @@ mod tests {
 	/// One CMAF fragment decodes to several samples, which are handed back one at a time.
 	#[tokio::test]
 	async fn hands_back_a_cmaf_batch_one_frame_at_a_time() {
-		let config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
 		let muxer = crate::container::fmp4::Muxer::video(&config).unwrap();
 		let init = muxer.init().unwrap().expect("VP8 init should be available");
 		let cmaf = hang::catalog::Container::Cmaf { init };

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -219,15 +219,21 @@ impl<S: Stream> Export<S> {
 		// without the header anyway, and parking them would stop us from
 		// polling for the next SPS/PPS-bearing frame.
 		let waiting_for_header = !self.header_emitted;
-		for track in self.tracks.values_mut() {
+		for (name, track) in &mut self.tracks {
 			if track.pending.is_some() || track.finished {
 				continue;
 			}
 			loop {
 				match track.source.poll_read(waiter) {
 					Poll::Ready(Ok(Some(frame))) => {
-						if waiting_for_header && !track.source.header_ready() {
-							// Drop this slice and keep polling for SPS/PPS.
+						let geometry_ready = track.kind == TrackKind::Audio
+							|| self
+								.catalog_snapshot
+								.as_ref()
+								.and_then(|catalog| catalog.video.renditions.get(name))
+								.is_some_and(|config| track.source.video_geometry_ready(config));
+						if waiting_for_header && (!track.source.header_ready() || !geometry_ready) {
+							// Drop this slice and keep polling for codec configuration or geometry.
 							continue;
 						}
 						track.pending = Some(frame);
@@ -381,9 +387,16 @@ impl<S: Stream> Export<S> {
 	/// catalog arrives `tracks` is empty, and `all()` would otherwise be
 	/// vacuously true and send us into `build_header` with no snapshot.
 	fn header_ready(&self) -> bool {
-		self.catalog_snapshot.is_some()
-			&& !self.tracks.is_empty()
+		let Some(catalog) = self.catalog_snapshot.as_ref() else {
+			return false;
+		};
+		!self.tracks.is_empty()
 			&& self.tracks.values().all(|t| t.source.header_ready())
+			&& catalog.video.renditions.iter().all(|(name, config)| {
+				self.tracks
+					.get(name)
+					.is_some_and(|track| track.source.video_geometry_ready(config))
+			})
 	}
 
 	fn build_header(&self) -> Result<Bytes> {
@@ -408,9 +421,10 @@ impl<S: Stream> Export<S> {
 				.tracks
 				.get(name)
 				.ok_or_else(|| Error::MissingVideoTrack(name.clone()))?;
+			let config = track.source.video_config(config).unwrap_or_else(|| config.clone());
 			entries.push(build_video_track_entry(
 				track.track_number,
-				config,
+				&config,
 				track.source.description(),
 			)?);
 		}

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -305,6 +305,45 @@ async fn export_waits_for_catalog_before_header() {
 	drop(producer);
 }
 
+/// A catalog may publish a codec before its optional dimensions. The MKV
+/// header is immutable, so derive geometry from the first keyframe before
+/// writing `PixelWidth` and `PixelHeight`.
+#[tokio::test(start_paused = true)]
+async fn export_derives_video_geometry_before_header() {
+	use hang::catalog::{Container, VideoConfig};
+
+	let mut live = Live::new(".vp8", |catalog, name| {
+		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(name, config);
+	});
+	// Geometry-less startup frames must not park the source before the keyframe.
+	live.track.write(raw_frame(0, &[0x31, 0x00, 0x00], true)).unwrap();
+	live.track
+		.write(raw_frame(
+			33_000,
+			&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00],
+			true,
+		))
+		.unwrap();
+	live.track.finish().unwrap();
+
+	let mut exporter = crate::container::mkv::Export::new(live.source(), live.catalog_stream().await);
+	let header = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected header bytes");
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut importer = crate::container::mkv::Import::new(broadcast, catalog.reserve());
+	importer.decode(&bytes::BytesMut::from(header.as_ref())).unwrap();
+	let video = catalog.snapshot().video.renditions.values().next().unwrap().clone();
+	assert_eq!(video.coded_width, Some(320));
+	assert_eq!(video.coded_height, Some(240));
+}
+
 #[tokio::test(start_paused = true)]
 async fn export_emits_blocks_for_each_frame() {
 	// Import a WebM that contains 3 video frames + 2 audio frames, export it,

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -299,42 +299,40 @@ impl ExportSource {
 		let Some(codec) = self.video_codec.as_ref() else {
 			return;
 		};
-
-		let dimensions = match codec {
-			VideoCodec::H264(_) => self
-				.description
-				.as_deref()
-				.and_then(|description| crate::codec::h264::config(description).ok())
-				.as_ref()
-				.and_then(catalog_dimensions),
-			VideoCodec::H265(_) => self
-				.description
-				.as_deref()
-				.and_then(|description| crate::codec::h265::config(description).ok())
-				.as_ref()
-				.and_then(catalog_dimensions),
-			VideoCodec::VP8 if !payload.is_empty() => crate::codec::vp8::FrameHeader::parse(payload)
-				.ok()
-				.and_then(|header| header.dimensions)
-				.map(|(width, height)| (u32::from(width), u32::from(height))),
-			VideoCodec::VP9(_) if !payload.is_empty() => crate::codec::vp9::config_from_keyframe(payload)
-				.ok()
-				.flatten()
-				.as_ref()
-				.and_then(catalog_dimensions),
-			VideoCodec::AV1(_) if !payload.is_empty() => crate::codec::av1::dimensions(payload).ok().flatten(),
-			_ => None,
-		};
-
-		if dimensions.is_some_and(|(width, height)| width > 0 && height > 0) {
-			self.video_dimensions = dimensions;
-		}
+		self.video_dimensions = codec_dimensions(codec, self.description.as_deref(), payload);
 	}
 }
 
-fn catalog_dimensions(config: &VideoConfig) -> Option<(u32, u32)> {
+pub(crate) fn catalog_dimensions(config: &VideoConfig) -> Option<(u32, u32)> {
 	let dimensions = (config.coded_width?, config.coded_height?);
 	(dimensions.0 > 0 && dimensions.1 > 0).then_some(dimensions)
+}
+
+/// Resolve encoded dimensions from codec configuration or an in-band keyframe.
+pub(crate) fn codec_dimensions(codec: &VideoCodec, description: Option<&[u8]>, payload: &[u8]) -> Option<(u32, u32)> {
+	let dimensions = match codec {
+		VideoCodec::H264(_) => description
+			.and_then(|description| crate::codec::h264::config(description).ok())
+			.as_ref()
+			.and_then(catalog_dimensions),
+		VideoCodec::H265(_) => description
+			.and_then(|description| crate::codec::h265::config(description).ok())
+			.as_ref()
+			.and_then(catalog_dimensions),
+		VideoCodec::VP8 if !payload.is_empty() => crate::codec::vp8::FrameHeader::parse(payload)
+			.ok()
+			.and_then(|header| header.dimensions)
+			.map(|(width, height)| (u32::from(width), u32::from(height))),
+		VideoCodec::VP9(_) if !payload.is_empty() => crate::codec::vp9::config_from_keyframe(payload)
+			.ok()
+			.flatten()
+			.as_ref()
+			.and_then(catalog_dimensions),
+		VideoCodec::AV1(_) if !payload.is_empty() => crate::codec::av1::dimensions(payload).ok().flatten(),
+		_ => None,
+	};
+
+	dimensions.filter(|(width, height)| *width > 0 && *height > 0)
 }
 
 /// Build a video transform for an Annex-B source, or `None` if the catalog

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -71,6 +71,10 @@ pub(crate) struct ExportSource {
 	/// OpusHead). Some once the codec config is available — from the catalog
 	/// `description`, or synthesized by the transform.
 	description: Option<Bytes>,
+	/// Video codec used to derive geometry from its configuration or keyframes.
+	video_codec: Option<VideoCodec>,
+	/// Geometry resolved from the initial catalog or codec data received afterward.
+	video_dimensions: Option<(u32, u32)>,
 }
 
 impl ExportSource {
@@ -81,20 +85,7 @@ impl ExportSource {
 		config: &VideoConfig,
 		latency: Duration,
 	) -> Result<Option<Self>, crate::Error> {
-		let media: HangContainer = (&config.container).try_into()?;
-		let transform = build_video_transform(config);
-		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
-		let Some(request) = source.request(config.broadcast.as_ref()) else {
-			return Ok(None);
-		};
-
-		Ok(Some(Self {
-			state: SourceState::Requesting(request, name.to_string()),
-			media: Some(media),
-			latency,
-			transform,
-			description,
-		}))
+		Self::video(source, name, config, latency, build_video_transform(config))
 	}
 
 	/// Subscribe to a video rendition without attaching any codec-shape
@@ -107,19 +98,33 @@ impl ExportSource {
 		config: &VideoConfig,
 		latency: Duration,
 	) -> Result<Option<Self>, crate::Error> {
+		Self::video(source, name, config, latency, None)
+	}
+
+	fn video(
+		source: &crate::Source,
+		name: &str,
+		config: &VideoConfig,
+		latency: Duration,
+		transform: Option<VideoTransform>,
+	) -> Result<Option<Self>, crate::Error> {
 		let media: HangContainer = (&config.container).try_into()?;
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 		let Some(request) = source.request(config.broadcast.as_ref()) else {
 			return Ok(None);
 		};
 
-		Ok(Some(Self {
+		let mut source = Self {
 			state: SourceState::Requesting(request, name.to_string()),
 			media: Some(media),
 			latency,
-			transform: None,
+			transform,
 			description,
-		}))
+			video_codec: Some(config.codec.clone()),
+			video_dimensions: catalog_dimensions(config),
+		};
+		source.resolve_video_dimensions(&[]);
+		Ok(Some(source))
 	}
 
 	/// Subscribe to an audio rendition. Audio has no codec-shape transform;
@@ -142,6 +147,8 @@ impl ExportSource {
 			latency,
 			transform: None,
 			description,
+			video_codec: None,
+			video_dimensions: None,
 		}))
 	}
 
@@ -156,6 +163,8 @@ impl ExportSource {
 			latency,
 			transform: None,
 			description: None,
+			video_codec: None,
+			video_dimensions: None,
 		})
 	}
 
@@ -168,6 +177,27 @@ impl ExportSource {
 	/// no transform attached, or the transform has built its record).
 	pub fn header_ready(&self) -> bool {
 		self.transform.is_none() || self.description.is_some()
+	}
+
+	/// Combine the latest catalog config with geometry resolved from codec data.
+	pub fn video_config(&self, config: &VideoConfig) -> Option<VideoConfig> {
+		if catalog_dimensions(config).is_some() {
+			return Some(config.clone());
+		}
+
+		let (width, height) = self.video_dimensions?;
+		let mut config = config.clone();
+		config.coded_width = Some(width);
+		config.coded_height = Some(height);
+		Some(config)
+	}
+
+	/// True when this codec is unsupported or has enough geometry to build a video header.
+	pub fn video_geometry_ready(&self, config: &VideoConfig) -> bool {
+		!matches!(
+			config.codec,
+			VideoCodec::H264(_) | VideoCodec::H265(_) | VideoCodec::VP8 | VideoCodec::VP9(_) | VideoCodec::AV1(_)
+		) || self.video_config(config).is_some()
 	}
 
 	/// Pull the next normalized frame.
@@ -227,6 +257,7 @@ impl ExportSource {
 			};
 
 			let Some(transform) = self.transform.as_mut() else {
+				self.resolve_video_dimensions(&frame.payload);
 				return Poll::Ready(Ok(Some(frame)));
 			};
 
@@ -236,10 +267,12 @@ impl ExportSource {
 					// resolved description (it may have just become available)
 					// and pull the next frame.
 					self.refresh_description();
+					self.resolve_video_dimensions(&frame.payload);
 					continue;
 				}
 				Some(payload) => {
 					self.refresh_description();
+					self.resolve_video_dimensions(&payload);
 					return Poll::Ready(Ok(Some(Frame { payload, ..frame })));
 				}
 			}
@@ -258,6 +291,50 @@ impl ExportSource {
 			self.description = Some(d.clone());
 		}
 	}
+
+	fn resolve_video_dimensions(&mut self, payload: &[u8]) {
+		if self.video_dimensions.is_some() {
+			return;
+		}
+		let Some(codec) = self.video_codec.as_ref() else {
+			return;
+		};
+
+		let dimensions = match codec {
+			VideoCodec::H264(_) => self
+				.description
+				.as_deref()
+				.and_then(|description| crate::codec::h264::config(description).ok())
+				.as_ref()
+				.and_then(catalog_dimensions),
+			VideoCodec::H265(_) => self
+				.description
+				.as_deref()
+				.and_then(|description| crate::codec::h265::config(description).ok())
+				.as_ref()
+				.and_then(catalog_dimensions),
+			VideoCodec::VP8 if !payload.is_empty() => crate::codec::vp8::FrameHeader::parse(payload)
+				.ok()
+				.and_then(|header| header.dimensions)
+				.map(|(width, height)| (u32::from(width), u32::from(height))),
+			VideoCodec::VP9(_) if !payload.is_empty() => crate::codec::vp9::config_from_keyframe(payload)
+				.ok()
+				.flatten()
+				.as_ref()
+				.and_then(catalog_dimensions),
+			VideoCodec::AV1(_) if !payload.is_empty() => crate::codec::av1::dimensions(payload).ok().flatten(),
+			_ => None,
+		};
+
+		if dimensions.is_some_and(|(width, height)| width > 0 && height > 0) {
+			self.video_dimensions = dimensions;
+		}
+	}
+}
+
+fn catalog_dimensions(config: &VideoConfig) -> Option<(u32, u32)> {
+	let dimensions = (config.coded_width?, config.coded_height?);
+	(dimensions.0 > 0 && dimensions.1 > 0).then_some(dimensions)
 }
 
 /// Build a video transform for an Annex-B source, or `None` if the catalog

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -123,7 +123,7 @@ impl ExportSource {
 			video_codec: Some(config.codec.clone()),
 			video_dimensions: catalog_dimensions(config),
 		};
-		source.resolve_video_dimensions(&[]);
+		source.resolve_video_dimensions(&[])?;
 		Ok(Some(source))
 	}
 
@@ -257,7 +257,7 @@ impl ExportSource {
 			};
 
 			let Some(transform) = self.transform.as_mut() else {
-				self.resolve_video_dimensions(&frame.payload);
+				self.resolve_video_dimensions(&frame.payload)?;
 				return Poll::Ready(Ok(Some(frame)));
 			};
 
@@ -267,12 +267,12 @@ impl ExportSource {
 					// resolved description (it may have just become available)
 					// and pull the next frame.
 					self.refresh_description();
-					self.resolve_video_dimensions(&frame.payload);
+					self.resolve_video_dimensions(&frame.payload)?;
 					continue;
 				}
 				Some(payload) => {
 					self.refresh_description();
-					self.resolve_video_dimensions(&payload);
+					self.resolve_video_dimensions(&payload)?;
 					return Poll::Ready(Ok(Some(Frame { payload, ..frame })));
 				}
 			}
@@ -292,14 +292,15 @@ impl ExportSource {
 		}
 	}
 
-	fn resolve_video_dimensions(&mut self, payload: &[u8]) {
+	fn resolve_video_dimensions(&mut self, payload: &[u8]) -> crate::Result<()> {
 		if self.video_dimensions.is_some() {
-			return;
+			return Ok(());
 		}
 		let Some(codec) = self.video_codec.as_ref() else {
-			return;
+			return Ok(());
 		};
-		self.video_dimensions = codec_dimensions(codec, self.description.as_deref(), payload);
+		self.video_dimensions = codec_dimensions(codec, self.description.as_deref(), payload)?;
+		Ok(())
 	}
 }
 
@@ -309,30 +310,31 @@ pub(crate) fn catalog_dimensions(config: &VideoConfig) -> Option<(u32, u32)> {
 }
 
 /// Resolve encoded dimensions from codec configuration or an in-band keyframe.
-pub(crate) fn codec_dimensions(codec: &VideoCodec, description: Option<&[u8]>, payload: &[u8]) -> Option<(u32, u32)> {
+pub(crate) fn codec_dimensions(
+	codec: &VideoCodec,
+	description: Option<&[u8]>,
+	payload: &[u8],
+) -> crate::Result<Option<(u32, u32)>> {
 	let dimensions = match codec {
-		VideoCodec::H264(_) => description
-			.and_then(|description| crate::codec::h264::config(description).ok())
-			.as_ref()
-			.and_then(catalog_dimensions),
-		VideoCodec::H265(_) => description
-			.and_then(|description| crate::codec::h265::config(description).ok())
-			.as_ref()
-			.and_then(catalog_dimensions),
-		VideoCodec::VP8 if !payload.is_empty() => crate::codec::vp8::FrameHeader::parse(payload)
-			.ok()
-			.and_then(|header| header.dimensions)
+		VideoCodec::H264(_) => match description {
+			Some(description) => catalog_dimensions(&crate::codec::h264::config(description)?),
+			None => None,
+		},
+		VideoCodec::H265(_) => match description {
+			Some(description) => catalog_dimensions(&crate::codec::h265::config(description)?),
+			None => None,
+		},
+		VideoCodec::VP8 if !payload.is_empty() => crate::codec::vp8::FrameHeader::parse(payload)?
+			.dimensions
 			.map(|(width, height)| (u32::from(width), u32::from(height))),
-		VideoCodec::VP9(_) if !payload.is_empty() => crate::codec::vp9::config_from_keyframe(payload)
-			.ok()
-			.flatten()
+		VideoCodec::VP9(_) if !payload.is_empty() => crate::codec::vp9::config_from_keyframe(payload)?
 			.as_ref()
 			.and_then(catalog_dimensions),
-		VideoCodec::AV1(_) if !payload.is_empty() => crate::codec::av1::dimensions(payload).ok().flatten(),
+		VideoCodec::AV1(_) if !payload.is_empty() => crate::codec::av1::dimensions(payload)?,
 		_ => None,
 	};
 
-	dimensions.filter(|(width, height)| *width > 0 && *height > 0)
+	Ok(dimensions.filter(|(width, height)| *width > 0 && *height > 0))
 }
 
 /// Build a video transform for an Annex-B source, or `None` if the catalog


### PR DESCRIPTION
## Summary

- derive missing H.264, H.265, VP8, VP9, and AV1 geometry from codec configuration or keyframes before authoring immutable fMP4/MKV headers
- keep polling past provisional frames until both codec configuration and usable geometry are available, while allowing later catalog geometry to unblock export
- teach the one-shot fMP4 muxer used by fetch-on-demand HLS to wait for and derive the same missing geometry from fetched keyframes
- reject synthesized fMP4 video tracks with absent, zero, or unrepresentable dimensions instead of silently writing 0x0 metadata
- surface malformed fixed codec metadata as an export error instead of waiting indefinitely for geometry that can never arrive

The root cause was that catalog dimensions are optional and may arrive independently from media, but the exporters treated codec readiness as sufficient to freeze their headers. A codec-only catalog could therefore produce a permanent 0x0 fMP4 init segment or an MKV header without geometry. The one-shot fMP4 path instead failed before fetching media because it tried to synthesize its init segment immediately. Both cases occur with in-tree RTC VP8/VP9 publishers, which do not currently put dimensions in the catalog.

Fixes #2797.

## Public API changes

- None. Geometry derivation and readiness tracking are internal to `moq-mux`.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (1,192 Rust tests and 50 Python tests passed)

No wire format or public catalog API changed, so the cross-package wire/draft sync rows do not apply.

(Written by GPT-5)
