### PR TITLE
fix(relay): honor server version over WebSocket

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -48,6 +48,11 @@ certificate, and Unix sockets add optional peer-credential gating.
 # is configured below.
 bind = "[::]:443"
 
+# MoQ versions accepted by QUIC, WebTransport, and WebSocket listeners.
+# TCP and Unix stream listeners also accept moq-lite-05 because it carries
+# their request path in SETUP. Omit to accept every supported version.
+version = ["moq-transport-16"]
+
 # Plaintext qmux over TCP (no TLS, carries no peer identity). Trusted networks
 # only; a non-loopback bind logs a warning. Requires the `tcp` build feature.
 [server.tcp]

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -82,6 +82,7 @@ impl Relay {
 		config.server.quic.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
 
 		let mtls_enabled = !config.server.tls.root.is_empty();
+		let server_versions = config.server.versions();
 
 		#[allow(unused_mut)]
 		let mut server = config.server.init()?;
@@ -130,7 +131,8 @@ impl Relay {
 		let cluster = cluster.with_stats(stats.clone());
 
 		// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
-		let web = Web::new(auth.clone(), cluster.clone(), server.certificates(), config.web);
+		let web =
+			Web::new(auth.clone(), cluster.clone(), server.certificates(), config.web).with_versions(server_versions);
 
 		// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
 		// /metrics + /health + /nodes, separate from the customer-facing web server. No-op

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -136,6 +136,7 @@ pub(crate) struct WebState {
 pub struct Web {
 	state: Arc<WebState>,
 	config: WebConfig,
+	versions: moq_net::Versions,
 	health: moq_native::accept::Health,
 }
 
@@ -153,8 +154,15 @@ impl Web {
 		Self {
 			state,
 			config,
+			versions: moq_net::Versions::all(),
 			health: moq_native::accept::Health::new("web"),
 		}
+	}
+
+	/// Restrict which MoQ versions WebSocket sessions accept, in preference order.
+	pub fn with_versions(mut self, versions: moq_net::Versions) -> Self {
+		self.versions = versions;
+		self
 	}
 
 	/// A live handle to the accept-loop health of the HTTP/HTTPS listeners, for an
@@ -215,7 +223,8 @@ impl Web {
 			app
 		};
 
-		app.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]))
+		app.layer(Extension(self.versions.clone()))
+			.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]))
 			.with_state(self.state.clone())
 	}
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -21,6 +21,7 @@ pub(crate) async fn serve_ws(
 	OriginalUri(uri): OriginalUri,
 	headers: HeaderMap,
 	mtls: Option<Extension<MtlsPeer>>,
+	Extension(versions): Extension<moq_net::Versions>,
 	State(state): State<Arc<WebState>>,
 ) -> axum::response::Result<Response> {
 	// If this isn't a WebSocket upgrade (e.g. a plain browser visit), serve
@@ -29,7 +30,8 @@ pub(crate) async fn serve_ws(
 		return Ok(landing_response());
 	};
 
-	let ws = negotiate_subprotocol(ws)?;
+	let alpns = versions.alpns();
+	let ws = negotiate_subprotocol(ws, &alpns)?;
 
 	let host = uri
 		.authority()
@@ -63,7 +65,15 @@ pub(crate) async fn serve_ws(
 		// Unfortunately, we need to convert from Axum to Tungstenite.
 		// Axum uses Tungstenite internally, but it's not exposed to avoid semvar issues.
 		let socket = WebSocketAdapter::new(socket);
-		let _ = handle_socket(id, socket, alpn, publish, subscribe, stats).await;
+		let session = SessionInputs {
+			id,
+			alpn,
+			versions,
+			publish,
+			subscribe,
+			stats,
+		};
+		let _ = handle_socket(socket, session).await;
 	}))
 }
 
@@ -74,15 +84,17 @@ fn request_auth_params(auth: &Auth, host: &str, uri: &Uri) -> Result<AuthParams,
 	Ok(auth.params_from_url(&url))
 }
 
-#[tracing::instrument("ws", err, skip_all, fields(id = _id))]
-async fn handle_socket<T>(
-	_id: u64,
-	socket: T,
+struct SessionInputs {
+	id: u64,
 	alpn: Option<String>,
+	versions: moq_net::Versions,
 	publish: Option<origin::Producer>,
 	subscribe: Option<origin::Producer>,
 	stats: Session,
-) -> anyhow::Result<()>
+}
+
+#[tracing::instrument("ws", err, skip_all, fields(id = session.id))]
+async fn handle_socket<T>(socket: T, session: SessionInputs) -> anyhow::Result<()>
 where
 	T: futures::Stream<Item = Result<tungstenite::Message, tungstenite::Error>>
 		+ futures::Sink<tungstenite::Message, Error = tungstenite::Error>
@@ -90,6 +102,15 @@ where
 		+ Unpin
 		+ 'static,
 {
+	let SessionInputs {
+		id: _,
+		alpn,
+		versions,
+		publish,
+		subscribe,
+		stats,
+	} = session;
+
 	// Wrap the WebSocket in a WebTransport compatibility layer. We have to
 	// forward the negotiated subprotocol explicitly; axum performed the
 	// upgrade, so qmux can't sniff it from the handshake.
@@ -109,7 +130,7 @@ where
 	// Only set the side the token actually grants. moq-net defaults the
 	// unset side to a fresh no-op origin, which is fine for a
 	// publish-only or subscribe-only token.
-	let mut server = moq_net::Server::new().with_stats(stats);
+	let mut server = moq_net::Server::new().with_versions(versions).with_stats(stats);
 	if let Some(subscribe) = subscribe {
 		server = server.with_publisher(&subscribe);
 	}
@@ -123,8 +144,8 @@ where
 
 /// Pick a subprotocol for the upgrade, or fail the handshake outright.
 ///
-/// We advertise the full qmux × moq-net subprotocol matrix, with bare qmux
-/// fallbacks last. axum picks the first entry that the client also offered, so
+/// We advertise the configured qmux × moq-net subprotocol matrix, with bare
+/// qmux fallbacks last. axum picks the first entry that the client also offered, so
 /// a modern client lands on `qmux-01.moq-lite-05`; old clients still match
 /// `webtransport` or `qmux-00.moql` and negotiate via SETUP.
 ///
@@ -136,8 +157,8 @@ where
 ///
 /// A client that offers no subprotocol at all is left alone: it upgrades and
 /// negotiates the moq version over moq-lite SETUP instead.
-fn negotiate_subprotocol(ws: WebSocketUpgrade) -> Result<WebSocketUpgrade, StatusCode> {
-	let supported = supported_subprotocols();
+fn negotiate_subprotocol(ws: WebSocketUpgrade, alpns: &[&str]) -> Result<WebSocketUpgrade, StatusCode> {
+	let supported = supported_subprotocols(alpns);
 
 	if !subprotocols_acceptable(ws.requested_protocols().map(HeaderValue::as_bytes), &supported) {
 		tracing::debug!("rejecting WebSocket upgrade: no supported subprotocol offered");
@@ -180,7 +201,7 @@ const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19"];
 
 /// Subprotocols to advertise on the WebSocket upgrade.
 ///
-/// Generates the cross product of [`QMUX_VERSIONS`] × `moq_net::ALPNS`, with
+/// Generates the cross product of `alpns` × [`QMUX_VERSIONS`], with
 /// the bare qmux fallbacks (`qmux-01`, `qmux-00`, `webtransport`) appended
 /// last so versioned subprotocols always win the exact-string match axum
 /// performs. Without the versioned entries, axum picks bare `webtransport`,
@@ -189,10 +210,10 @@ const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19"];
 ///
 /// `qmux-00.moqt-1{8,9}` is excluded: moq-transport-18 and -19 require qmux-01, so
 /// those pairs are illegal.
-fn supported_subprotocols() -> Vec<String> {
-	let mut out = Vec::with_capacity(QMUX_VERSIONS.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
-	for &version in QMUX_VERSIONS {
-		for &alpn in moq_net::ALPNS {
+fn supported_subprotocols(alpns: &[&str]) -> Vec<String> {
+	let mut out = Vec::with_capacity(QMUX_VERSIONS.len() * alpns.len() + qmux::ALPNS.len());
+	for &alpn in alpns {
+		for &version in QMUX_VERSIONS {
 			if version == qmux::Version::QMux00 && QMUX01_ONLY_ALPNS.contains(&alpn) {
 				continue;
 			}
@@ -384,7 +405,7 @@ mod tests {
 			vec![Some(0xff000012), Some(0xff000013)]
 		);
 
-		let list = supported_subprotocols();
+		let list = supported_subprotocols(moq_net::ALPNS);
 
 		// Newest moq ALPN under the preferred prefix must come first so axum
 		// picks it whenever the client offers it.
@@ -425,8 +446,36 @@ mod tests {
 	}
 
 	#[test]
+	fn supported_subprotocols_only_lists_configured_alpns() {
+		let list = supported_subprotocols(&["moqt-16"]);
+
+		assert!(list.contains(&"qmux-01.moqt-16".to_string()));
+		assert!(list.contains(&"qmux-00.moqt-16".to_string()));
+		assert!(list.iter().all(|entry| !entry.contains("moq-lite")));
+		assert!(list.iter().all(|entry| !entry.contains("moqt-19")));
+	}
+
+	#[test]
+	fn supported_subprotocols_preserves_moq_preference_across_qmux_versions() {
+		let list = supported_subprotocols(&["moqt-16", "moqt-18"]);
+		let preferred = list
+			.iter()
+			.position(|entry| entry == "qmux-00.moqt-16")
+			.expect("missing preferred moqt-16 pair");
+		let newer_qmux = list
+			.iter()
+			.position(|entry| entry == "qmux-01.moqt-18")
+			.expect("missing moqt-18 pair");
+
+		assert!(
+			preferred < newer_qmux,
+			"configured MoQ preference must outrank QMux version preference: {list:?}",
+		);
+	}
+
+	#[test]
 	fn subprotocols_acceptable_requires_a_match_when_any_are_offered() {
-		let supported = supported_subprotocols();
+		let supported = supported_subprotocols(moq_net::ALPNS);
 		let known = supported.first().expect("no supported subprotocols").clone();
 
 		// Offering nothing is the legacy route: upgrade and negotiate via SETUP.
@@ -504,7 +553,7 @@ mod tests {
 		);
 
 		// A supported identifier still upgrades.
-		let supported = supported_subprotocols();
+		let supported = supported_subprotocols(moq_net::ALPNS);
 		let known = supported.first().expect("no supported subprotocols");
 		let status = handshake_status(addr, Some(&format!("bogus-99, {known}"))).await;
 		assert!(
@@ -539,7 +588,7 @@ mod tests {
 		let route = any(move |ws: WebSocketUpgrade| {
 			let tx = tx.clone();
 			async move {
-				let ws = negotiate_subprotocol(ws)?;
+				let ws = negotiate_subprotocol(ws, moq_net::ALPNS)?;
 				Ok::<_, StatusCode>(ws.on_upgrade(move |socket| async move {
 					let wire = socket.protocol().and_then(|h| h.to_str().ok()).map(str::to_owned);
 					let socket = WebSocketAdapter::new(socket);
@@ -627,7 +676,7 @@ mod tests {
 		let (addr, mut rx) = spawn_test_server().await;
 		let url = format!("ws://{addr}/");
 
-		for entry in supported_subprotocols() {
+		for entry in supported_subprotocols(moq_net::ALPNS) {
 			// Bare fallbacks can't be offered in isolation via the qmux client API;
 			// they're covered by `axum_ws_negotiates_newest_moq_alpn`.
 			let Some((version, app)) = split_pair(&entry) else {
@@ -751,13 +800,17 @@ mod tests {
 		let (server_to_client, client_incoming) = mpsc::unbounded_channel();
 		let frozen = Arc::new(AtomicBool::new(false));
 
+		let session = SessionInputs {
+			id: 0,
+			alpn: Some(alpn.clone()),
+			versions: moq_net::Versions::all(),
+			publish: None,
+			subscribe: None,
+			stats: Session::default(),
+		};
 		let server = tokio::spawn(handle_socket(
-			0,
 			Pipe::new(server_incoming, server_to_client, frozen.clone()),
-			Some(alpn.clone()),
-			None,
-			None,
-			Session::default(),
+			session,
 		));
 
 		// A real qmux peer, so the transport handshake completes and its 10s

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -10,7 +10,7 @@
 use std::{net::TcpListener, time::Duration};
 
 use moq_native::moq_net::{self, Origin};
-use moq_relay::{AuthConfig, Cluster, ClusterConfig, Connection, PublicConfig, Web, WebConfig};
+use moq_relay::{AuthConfig, Cluster, ClusterConfig, Config, Connection, PublicConfig, Relay, Web, WebConfig};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -119,6 +119,31 @@ async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
 	(port, handle)
 }
 
+/// Stand up the assembled relay path with `--server-version` restricted.
+async fn spawn_versioned_relay(versions: Vec<moq_net::Version>) -> (u16, tokio::task::JoinHandle<()>) {
+	let port = free_tcp_port();
+	let mut config = Config::default();
+	config.server.bind = Some("127.0.0.1:0".to_string());
+	config.server.tls.generate = vec!["localhost".into()];
+	config.server.version = versions;
+	config.web.ws = true;
+	config.web.http.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
+
+	#[allow(deprecated)]
+	let public = PublicConfig::Simple(vec![String::new()]);
+	config.auth.public = Some(public);
+
+	let relay = Relay::load(config).await.expect("load relay");
+	let web = relay.web;
+	let (server_result_tx, mut server_result_rx) = tokio::sync::oneshot::channel();
+	let handle = tokio::spawn(async move {
+		let _ = server_result_tx.send(web.run().await);
+	});
+
+	wait_for_http(port, &mut server_result_rx).await;
+	(port, handle)
+}
+
 fn client() -> moq_native::Client {
 	client_version(None)
 }
@@ -212,6 +237,32 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 
 	drop(pub_session);
 	drop(sub_session);
+	web_handle.abort();
+}
+
+/// `--server-version` applies to the WebSocket fallback as well as QUIC.
+#[tokio::test]
+async fn relay_websocket_honors_server_version() {
+	let allowed: moq_net::Version = "moq-transport-16".parse().expect("parse allowed version");
+	let excluded = newest_lite_version();
+	let (port, web_handle) = spawn_versioned_relay(vec![allowed]).await;
+	let url: url::Url = format!("ws://127.0.0.1:{port}/smoke").parse().expect("parse url");
+
+	let excluded_result = tokio::time::timeout(TIMEOUT, client_version(Some(excluded)).connect(url.clone()))
+		.await
+		.expect("excluded client connect timeout");
+	assert!(
+		excluded_result.is_err(),
+		"WebSocket accepted excluded version {excluded} despite --server-version {allowed}"
+	);
+
+	let session = tokio::time::timeout(TIMEOUT, client_version(Some(allowed)).connect(url))
+		.await
+		.expect("allowed client connect timeout")
+		.expect("allowed client connect failed");
+	assert_eq!(session.version(), allowed);
+
+	drop(session);
 	web_handle.abort();
 }
 


### PR DESCRIPTION
## Summary

- honor `--server-version` when accepting relay sessions over the WebSocket fallback
- build the WebSocket subprotocol matrix from the configured MoQ versions while preserving their preference order
- apply the same version restriction to in-band negotiation through bare qmux fallbacks
- document the transport-specific behavior of `server.version`
- add unit and end-to-end regression coverage

The relay's Axum WebSocket path built its subprotocol list from every compiled-in ALPN and constructed a default `moq_net::Server`. As a result, both explicit WebSocket ALPN selection and bare qmux SETUP negotiation could accept versions excluded by the server configuration.

Closes #2810.

## Public API changes

- adds `Web::with_versions(moq_net::Versions)`, an additive builder for embedders that construct the relay web server directly

No wire format changed, so the protocol drafts and cross-language implementations do not need updates.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (192 passed, 1 skipped)

All gates were rerun after rebasing onto the latest `origin/main`.

(Written by GPT-5)