### PR TITLE
fix(net): wake a capped subscriber when its parked group is evicted

### DIFF
--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -2216,12 +2216,25 @@ impl PlainSubscriber {
 	}
 
 	fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
+		// An eviction aborts a parked group without touching any cursor this
+		// subscriber polls, so each entry needs a waiter or this poll would never
+		// rerun. `poll_closed` observes-or-registers under one lock: `Pending`
+		// parks the waiter while the group is open (an open group cannot be
+		// aborted), and `Ready` means closed, where only an abort invalidates the
+		// entry. Checking `is_aborted` separately from the registration would leave
+		// a window where an abort lands between the two and wakes nobody.
+		let watch = |group: &group::Consumer| match group.poll_closed(waiter) {
+			Poll::Pending => true,
+			Poll::Ready(()) => !group.is_aborted(),
+		};
+
 		// A raised `start_at` drops parked groups it overtook, and eviction/expiry
 		// (which aborts a cached group) drops its parked entry. The latter is what
 		// bounds parking: a subscription capped indefinitely holds only what the
 		// track's cache policy still retains, not every group it ever observed.
+		let min_sequence = self.min_sequence;
 		self.parked
-			.retain(|sequence, group| *sequence >= self.min_sequence && !group.is_aborted());
+			.retain(|sequence, group| *sequence >= min_sequence && watch(group));
 
 		// Re-offer the lowest parked group back inside the cap once it rises.
 		if let Some(&sequence) = self.parked.keys().next()
@@ -2246,7 +2259,12 @@ impl PlainSubscriber {
 			// Park a group beyond the cap instead of dropping it, and keep scanning
 			// so an in-range group that arrived behind it still flows.
 			if self.end_sequence.is_some_and(|end| consumer.sequence > end) {
-				self.parked.insert(consumer.sequence, consumer);
+				// Watch it from the moment it parks: the retain pass above already
+				// ran, so an entry admitted here would otherwise sit unwatched for
+				// the rest of this poll, and an abort could wake nobody.
+				if watch(&consumer) {
+					self.parked.insert(consumer.sequence, consumer);
+				}
 				continue;
 			}
 			return Poll::Ready(Ok(Some(consumer)));
@@ -3992,6 +4010,51 @@ mod test {
 			matches!(consumer.recv_group().now_or_never(), Some(Ok(None))),
 			"a dead parked group must not be delivered or hold the stream open"
 		);
+	}
+
+	/// Eviction aborts a parked group behind a sleeping subscriber's back. Nothing
+	/// else will poll it (the track already finished), so the entry has to carry a
+	/// waiter or the subscription sleeps forever holding its stream open.
+	#[tokio::test]
+	async fn evicted_parked_group_wakes_the_clean_end() {
+		use std::sync::atomic::{AtomicUsize, Ordering};
+		use std::task::{Context, Wake};
+
+		/// A waker that counts its wakes, for asserting a pending poll left a live
+		/// registration behind.
+		struct CountWaker(AtomicUsize);
+		impl Wake for CountWaker {
+			fn wake(self: std::sync::Arc<Self>) {
+				self.0.fetch_add(1, Ordering::SeqCst);
+			}
+		}
+
+		let mut producer = track_producer("test", None);
+		let mut consumer = producer.subscribe(None);
+
+		producer.create_group(group::Info { sequence: 0 }).unwrap();
+		assert_eq!(
+			consumer.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			0
+		);
+
+		consumer.end_at(0);
+		let straggler = producer.create_group(group::Info { sequence: 1 }).unwrap();
+		assert!(consumer.recv_group().now_or_never().is_none(), "parked at the cap");
+		producer.finish().unwrap();
+
+		let counter = std::sync::Arc::new(CountWaker(AtomicUsize::new(0)));
+		let waker = std::task::Waker::from(counter.clone());
+		let mut cx = Context::from_waker(&waker);
+		let mut fut = std::pin::pin!(consumer.recv_group());
+		assert!(
+			fut.as_mut().poll(&mut cx).is_pending(),
+			"the parked group holds it open"
+		);
+
+		straggler.abort(Error::Old).unwrap();
+		assert!(counter.0.load(Ordering::SeqCst) > 0, "the eviction wakeup was lost");
+		assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Ready(Ok(None))));
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Root cause

A group beyond a subscriber's `end_at` cap is parked rather than dropped, so it stays deliverable if the cap rises later. `PlainSubscriber::poll_recv_group` drops such an entry once the producer aborts it (eviction/expiry), which is what bounds parking by the cache policy instead of by every group the subscription ever observed.

It only ever noticed while being polled. The check was a bare `is_aborted()`, and the "track finished, parking remains" branch returns `Pending` *after* the state poll has already resolved to `Ready(None)`, so that poll leaves no registration behind at all. An eviction then wakes nobody and the subscriber sleeps forever, holding its subscribe stream open rather than observing the clean end and FINing.

`resume.rs` hit this exact bug and already fixed it: the spliced subscriber watches each parked entry with `group::Consumer::poll_closed`, which observes-or-registers under one lock. The plain subscriber never got the same treatment. This PR closes that asymmetry.

## The fix

Mirror the spliced pattern in `PlainSubscriber::poll_recv_group`:

- `retain` watches every parked entry via `poll_closed` instead of reading `is_aborted()`. Splitting the two would leave a window where an abort lands between the check and the registration and wakes nobody.
- A group is watched *from the moment it parks*, since the retain pass has already run by the time the loop admits a new entry, and it would otherwise sit unwatched for the rest of the poll.

## Testing

`evicted_parked_group_wakes_the_clean_end` is the counterpart of the resume.rs test of the same name, using a counting waker to assert the pending poll left a live registration. It fails on `main` with `the eviction wakeup was lost` and passes with the fix.

Full `moq-net` suite green (765 tests), clippy `-D warnings` clean.

## Reviewer notes

Found while adjudicating an adversarial review of the #2724 release. It was the one code finding of four that held up under verification; the other three (a `SUBSCRIBE_UPDATE` start-floor claim, a capture probe/reopen catalog claim, and an origin takeover race) did not, and are not touched here.

One related issue is worth a follow-up and is deliberately **not** in this PR: `lite::subscriber::send_update` echoes the original `start_group` on every `SUBSCRIBE_UPDATE` ("varying only `end_group`"), so an `end_group`-only update silently resets the floor that `run_track` pinned when it announced `SUBSCRIBE_START`. Impact is bounded, since lowering `min_sequence` does not rewind the arrival-order cursor, so only a genuinely late arrival below the floor can slip through. The fix is to re-apply the start only when the requested value actually changed, rather than clamping unconditionally, which would break the spec's explicit allowance that the start group may shrink.

(written by Opus 5)