### PR TITLE
fix(rtc): publish VP8 and VP9 dimensions

### DIFF
--- a/rs/moq-rtc/src/codec/bitstream_test.rs
+++ b/rs/moq-rtc/src/codec/bitstream_test.rs
@@ -89,23 +89,19 @@ async fn opus_frame_publishes_catalog_entry() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn vp9_keyframe_flag_from_uncompressed_header() {
+async fn vp9_keyframe_publishes_dimensions_and_starts_group() {
 	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 
 	let mut bridge = codec::vp9::Bridge::new(producer, catalog.clone()).expect("bridge");
 
-	// VP9 uncompressed header: frame_type is bit 2. 0 = keyframe, 1 = inter.
-	// Byte with bit 2 cleared is a keyframe; with bit 2 set is an inter frame.
-	let keyframe_byte = 0b1000_0010; // frame_marker=10, profile bits, frame_type=0
-	let interframe_byte = 0b1000_0110; // same shape but frame_type=1
-
 	Bridge::push(
 		&mut bridge,
 		Frame {
 			timestamp_us: 0,
-			payload: Bytes::from(vec![keyframe_byte, 0, 0]),
+			// VP9 profile 0 keyframe header for 320x240.
+			payload: Bytes::from_static(&[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00]),
 		},
 	)
 	.expect("keyframe accepted");
@@ -117,12 +113,17 @@ async fn vp9_keyframe_flag_from_uncompressed_header() {
 		&mut bridge,
 		Frame {
 			timestamp_us: 33_000,
-			payload: Bytes::from(vec![interframe_byte, 0, 0]),
+			// frame_marker=10, profile=0, show_existing=0, frame_type=1.
+			payload: Bytes::from_static(&[0x84, 0x00, 0x00]),
 		},
 	)
 	.expect("interframe accepted");
 
-	assert_eq!(catalog.snapshot().video.renditions.len(), 1, "vp9 rendition announced");
+	let snapshot = catalog.snapshot();
+	assert_eq!(snapshot.video.renditions.len(), 1, "vp9 rendition announced");
+	let config = snapshot.video.renditions.values().next().unwrap();
+	assert_eq!(config.coded_width, Some(320));
+	assert_eq!(config.coded_height, Some(240));
 }
 
 // ── Egress (RTP-out) round-trip tests ─────────────────────────────────────

--- a/rs/moq-rtc/src/codec/bitstream_test.rs
+++ b/rs/moq-rtc/src/codec/bitstream_test.rs
@@ -89,6 +89,34 @@ async fn opus_frame_publishes_catalog_entry() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn idle_video_bridges_do_not_gate_audio_catalog() {
+	let broadcast = moq_net::broadcast::Info::new();
+	let mut producer = broadcast.produce();
+	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
+	let mut updates = catalog.consume().expect("catalog consumer");
+
+	let _vp8 = codec::vp8::Bridge::new(producer.clone(), catalog.clone()).expect("vp8 bridge");
+	let _vp9 = codec::vp9::Bridge::new(producer.clone(), catalog.clone()).expect("vp9 bridge");
+	let mut opus = codec::opus::Bridge::new(producer, catalog, 48_000, 2).expect("opus bridge");
+	Bridge::push(
+		&mut opus,
+		Frame {
+			timestamp_us: 0,
+			payload: Bytes::from_static(&[0xfc, 0xff, 0xfe]),
+		},
+	)
+	.expect("push opus");
+
+	let snapshot = tokio::time::timeout(std::time::Duration::from_millis(1), updates.next())
+		.await
+		.expect("idle video must not gate active audio")
+		.expect("catalog update")
+		.expect("catalog snapshot");
+	assert_eq!(snapshot.audio.renditions.len(), 1);
+	assert!(snapshot.video.renditions.is_empty());
+}
+
+#[tokio::test(start_paused = true)]
 async fn vp9_keyframe_publishes_dimensions_and_starts_group() {
 	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -99,6 +99,7 @@ struct PendingVideo {
 enum DeferredState<I> {
 	Pending(Box<PendingVideo>),
 	Active(Box<I>),
+	Failed(Box<moq_net::track::Producer>),
 	Poisoned,
 }
 
@@ -132,7 +133,14 @@ impl<I: DeferredImport> DeferredVideo<I> {
 			)));
 		};
 		let reserved = pending.catalog.reserve();
-		let import = I::create(pending.track, reserved)?;
+		let abort = pending.track.clone();
+		let import = match I::create(pending.track, reserved) {
+			Ok(import) => import,
+			Err(err) => {
+				self.state = DeferredState::Failed(Box::new(abort));
+				return Err(err.into());
+			}
+		};
 		self.state = DeferredState::Active(Box::new(import));
 		let DeferredState::Active(import) = &mut self.state else {
 			unreachable!();
@@ -147,6 +155,9 @@ impl<I: DeferredImport> DeferredVideo<I> {
 				let _ = pending.track.abort(err);
 			}
 			DeferredState::Active(import) => import.abort(err),
+			DeferredState::Failed(track) => {
+				let _ = track.abort(err);
+			}
 			DeferredState::Poisoned => {}
 		}
 	}

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -51,6 +51,107 @@ pub trait Bridge: Send {
 	fn abort(self: Box<Self>, err: moq_net::Error);
 }
 
+/// A mux importer whose catalog configuration is resolved from its first frame.
+pub(crate) trait DeferredImport: Send + Sized {
+	/// Create the importer and its unresolved catalog rendition.
+	fn create(track: moq_net::track::Producer, reserved: moq_mux::catalog::Reserved) -> moq_mux::Result<Self>;
+
+	/// Decode one complete codec frame.
+	fn decode(&mut self, frame: Bytes, pts: moq_net::Timestamp) -> moq_mux::Result<()>;
+
+	/// Abort the active media track.
+	fn abort(self, err: moq_net::Error);
+}
+
+impl DeferredImport for moq_mux::codec::vp8::Import {
+	fn create(track: moq_net::track::Producer, reserved: moq_mux::catalog::Reserved) -> moq_mux::Result<Self> {
+		Self::new(track, reserved, Default::default())
+	}
+
+	fn decode(&mut self, frame: Bytes, pts: moq_net::Timestamp) -> moq_mux::Result<()> {
+		moq_mux::codec::vp8::Import::decode(self, frame, Some(pts))
+	}
+
+	fn abort(self, err: moq_net::Error) {
+		moq_mux::codec::vp8::Import::abort(self, err);
+	}
+}
+
+impl DeferredImport for moq_mux::codec::vp9::Import {
+	fn create(track: moq_net::track::Producer, reserved: moq_mux::catalog::Reserved) -> moq_mux::Result<Self> {
+		Self::new(track, reserved, Default::default())
+	}
+
+	fn decode(&mut self, frame: Bytes, pts: moq_net::Timestamp) -> moq_mux::Result<()> {
+		moq_mux::codec::vp9::Import::decode(self, frame, Some(pts))
+	}
+
+	fn abort(self, err: moq_net::Error) {
+		moq_mux::codec::vp9::Import::abort(self, err);
+	}
+}
+
+struct PendingVideo {
+	track: moq_net::track::Producer,
+	catalog: moq_mux::catalog::Producer,
+}
+
+enum DeferredState<I> {
+	Pending(Box<PendingVideo>),
+	Active(Box<I>),
+	Poisoned,
+}
+
+/// Defers a video importer's catalog reservation until its first frame.
+pub(crate) struct DeferredVideo<I> {
+	state: DeferredState<I>,
+}
+
+impl<I: DeferredImport> DeferredVideo<I> {
+	/// Create the media track without gating the initial catalog snapshot.
+	pub fn new(
+		mut broadcast: moq_net::broadcast::Producer,
+		catalog: moq_mux::catalog::Producer,
+		suffix: &str,
+	) -> Result<Self> {
+		let track = broadcast.unique_track(suffix, catalog.track_info())?;
+		Ok(Self {
+			state: DeferredState::Pending(Box::new(PendingVideo { track, catalog })),
+		})
+	}
+
+	/// Decode a frame, creating the importer on first use.
+	pub fn decode(&mut self, frame: Bytes, pts: moq_net::Timestamp) -> Result<()> {
+		if let DeferredState::Active(import) = &mut self.state {
+			return import.decode(frame, pts).map_err(Into::into);
+		}
+
+		let DeferredState::Pending(pending) = std::mem::replace(&mut self.state, DeferredState::Poisoned) else {
+			return Err(crate::Error::Other(anyhow::anyhow!(
+				"video bridge initialization already failed"
+			)));
+		};
+		let reserved = pending.catalog.reserve();
+		let import = I::create(pending.track, reserved)?;
+		self.state = DeferredState::Active(Box::new(import));
+		let DeferredState::Active(import) = &mut self.state else {
+			unreachable!();
+		};
+		import.decode(frame, pts).map_err(Into::into)
+	}
+
+	/// Abort the media track in either lifecycle state.
+	pub fn abort(self, err: moq_net::Error) {
+		match self.state {
+			DeferredState::Pending(pending) => {
+				let _ = pending.track.abort(err);
+			}
+			DeferredState::Active(import) => import.abort(err),
+			DeferredState::Poisoned => {}
+		}
+	}
+}
+
 /// One RTP-ready codec frame produced by an egress [`Track`].
 ///
 /// `timestamp_us` stays in microseconds; the session loop converts it to

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -51,21 +51,6 @@ pub trait Bridge: Send {
 	fn abort(self: Box<Self>, err: moq_net::Error);
 }
 
-/// A bridge's video catalog entry, removed however the bridge ends.
-///
-/// A separate value rather than a `Drop` on the bridge itself, so a bridge's terminal
-/// [`Bridge::abort`] can consume its track producer.
-pub(crate) struct VideoRendition {
-	pub catalog: moq_mux::catalog::Producer,
-	pub name: String,
-}
-
-impl Drop for VideoRendition {
-	fn drop(&mut self) {
-		self.catalog.lock().video.renditions.remove(&self.name);
-	}
-}
-
 /// One RTP-ready codec frame produced by an egress [`Track`].
 ///
 /// `timestamp_us` stays in microseconds; the session loop converts it to

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -1,70 +1,63 @@
 //! VP8 bridge.
 //!
-//! VP8 carries no out-of-band config record. str0m hands us complete frames
-//! and we forward them to a `.vp8` track with the matching catalog entry.
-//! Keyframes are detected from the first byte (P-frame bit, RFC 6386 §9.1).
+//! str0m hands us complete VP8 frames, which is exactly the raw shape that
+//! [`moq_mux::codec::vp8::Import`] consumes. The shared importer parses keyframes
+//! so the catalog carries the encoded dimensions and stays in sync if they change.
 
 use crate::{Result, codec};
 
-/// Forwards str0m's VP8 frames to a `.vp8` track, detecting keyframes inline.
+/// Bridges str0m VP8 frames into a MoQ VP8 track.
 pub struct Bridge {
-	/// Owns the catalog rendition, retiring it when the bridge goes away.
-	rendition: codec::VideoRendition,
-	track: moq_mux::container::Producer<moq_mux::catalog::hang::Container>,
-	announced: bool,
+	import: moq_mux::codec::vp8::Import,
 }
 
 impl Bridge {
-	/// Publish a `.vp8` track on `broadcast`; the catalog rendition is added on the first frame.
+	/// Publish a `.vp8` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.create_track(broadcast.unique_name(".vp8"), catalog.track_info())?;
-		let name = track.name().to_string();
-		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy)?;
-		Ok(Self {
-			rendition: codec::VideoRendition { catalog, name },
-			track: producer,
-			announced: false,
-		})
-	}
-
-	fn announce(&mut self) -> Result<()> {
-		if self.announced {
-			return Ok(());
-		}
-		let name = self.rendition.name.clone();
-		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
-		config.container = hang::catalog::Container::Legacy;
-		config.timeline = Some(self.rendition.catalog.timeline(&name)?.section());
-		// Publish explicitly rather than through the guard's drop, which only warns:
-		// marking the rendition announced when the catalog never took it would leave the
-		// media track advertised nowhere, and `announced` latches so we'd never retry.
-		let mut guard = self.rendition.catalog.lock();
-		guard.video.renditions.insert(name, config);
-		guard.commit()?;
-		self.announced = true;
-		Ok(())
+		let track = broadcast.unique_track(".vp8", catalog.track_info())?;
+		let import = moq_mux::codec::vp8::Import::new(track, catalog.reserve(), Default::default())?;
+		Ok(Self { import })
 	}
 }
 
 impl codec::Bridge for Bridge {
 	fn push(&mut self, frame: codec::Frame) -> Result<()> {
-		self.announce()?;
 		let pts = moq_net::Timestamp::from_micros(frame.timestamp_us)
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("invalid timestamp: {err}")))?;
-		// VP8: first byte bit 0 == 0 means keyframe (RFC 6386 §9.1).
-		let keyframe = frame.payload.first().map(|b| b & 0x01 == 0).unwrap_or(false);
-		self.track
-			.write(moq_mux::container::Frame {
-				timestamp: pts,
-				payload: frame.payload,
-				keyframe,
-				duration: None,
-			})
-			.map_err(|err| crate::Error::Other(anyhow::anyhow!("vp8 track write failed: {err}")))?;
+		self.import.decode(frame.payload, Some(pts))?;
 		Ok(())
 	}
 
 	fn abort(self: Box<Self>, err: moq_net::Error) {
-		self.track.abort(err);
+		self.import.abort(err);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use bytes::Bytes;
+
+	use crate::codec::{self, Bridge as _};
+
+	#[test]
+	fn keyframe_publishes_catalog_dimensions() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut bridge = super::Bridge::new(broadcast, catalog.clone()).unwrap();
+
+		assert!(catalog.snapshot().video.renditions.is_empty());
+
+		// VP8 keyframe header for 320x240.
+		bridge
+			.push(codec::Frame {
+				timestamp_us: 0,
+				payload: Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00]),
+			})
+			.unwrap();
+
+		let snapshot = catalog.snapshot();
+		let config = snapshot.video.renditions.values().next().unwrap();
+		assert_eq!(config.coded_width, Some(320));
+		assert_eq!(config.coded_height, Some(240));
 	}
 }

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -58,4 +58,29 @@ mod tests {
 		assert_eq!(config.coded_width, Some(320));
 		assert_eq!(config.coded_height, Some(240));
 	}
+
+	#[tokio::test]
+	async fn importer_creation_failure_preserves_abort_error() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let _collision = broadcast.create_track("0.vp8.timeline.z", None).unwrap();
+		let consumer = broadcast.consume();
+		let mut bridge = super::Bridge::new(broadcast, catalog).unwrap();
+		let mut track = consumer.track("0.vp8").unwrap().subscribe(None).await.unwrap();
+
+		let result = bridge.push(codec::Frame {
+			timestamp_us: 0,
+			payload: Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00]),
+		});
+		assert!(result.is_err(), "timeline collision must fail importer creation");
+
+		Box::new(bridge).abort(moq_net::Error::Transport("session failed".into()));
+		let Err(error) = track.recv_group().await else {
+			panic!("aborted track must fail");
+		};
+		assert!(matches!(
+			error,
+			moq_net::Error::Transport(message) if message == "session failed"
+		));
+	}
 }

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -8,14 +8,13 @@ use crate::{Result, codec};
 
 /// Bridges str0m VP8 frames into a MoQ VP8 track.
 pub struct Bridge {
-	import: moq_mux::codec::vp8::Import,
+	import: codec::DeferredVideo<moq_mux::codec::vp8::Import>,
 }
 
 impl Bridge {
 	/// Publish a `.vp8` track on `broadcast`, adding the catalog rendition once config is known.
-	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.unique_track(".vp8", catalog.track_info())?;
-		let import = moq_mux::codec::vp8::Import::new(track, catalog.reserve(), Default::default())?;
+	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+		let import = codec::DeferredVideo::new(broadcast, catalog, ".vp8")?;
 		Ok(Self { import })
 	}
 }
@@ -24,8 +23,7 @@ impl codec::Bridge for Bridge {
 	fn push(&mut self, frame: codec::Frame) -> Result<()> {
 		let pts = moq_net::Timestamp::from_micros(frame.timestamp_us)
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("invalid timestamp: {err}")))?;
-		self.import.decode(frame.payload, Some(pts))?;
-		Ok(())
+		self.import.decode(frame.payload, pts)
 	}
 
 	fn abort(self: Box<Self>, err: moq_net::Error) {

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -8,14 +8,13 @@ use crate::{Result, codec};
 
 /// Bridges str0m VP9 frames into a MoQ VP9 track.
 pub struct Bridge {
-	import: moq_mux::codec::vp9::Import,
+	import: codec::DeferredVideo<moq_mux::codec::vp9::Import>,
 }
 
 impl Bridge {
 	/// Publish a `.vp9` track on `broadcast`, adding the catalog rendition once config is known.
-	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.unique_track(".vp9", catalog.track_info())?;
-		let import = moq_mux::codec::vp9::Import::new(track, catalog.reserve(), Default::default())?;
+	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+		let import = codec::DeferredVideo::new(broadcast, catalog, ".vp9")?;
 		Ok(Self { import })
 	}
 }
@@ -24,8 +23,7 @@ impl codec::Bridge for Bridge {
 	fn push(&mut self, frame: codec::Frame) -> Result<()> {
 		let pts = moq_net::Timestamp::from_micros(frame.timestamp_us)
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("invalid timestamp: {err}")))?;
-		self.import.decode(frame.payload, Some(pts))?;
-		Ok(())
+		self.import.decode(frame.payload, pts)
 	}
 
 	fn abort(self: Box<Self>, err: moq_net::Error) {

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -1,124 +1,63 @@
 //! VP9 bridge.
 //!
-//! Keyframes are detected from the frame_type bit (RFC 8741 §3 / VP9 spec §6.2:
-//! the second bit of the uncompressed header).
+//! str0m hands us complete VP9 frames, which is exactly the raw shape that
+//! [`moq_mux::codec::vp9::Import`] consumes. The shared importer parses keyframes
+//! so the catalog carries the encoded dimensions and stays in sync if they change.
 
 use crate::{Result, codec};
 
-/// Forwards str0m's VP9 frames to a `.vp9` track, detecting keyframes inline.
+/// Bridges str0m VP9 frames into a MoQ VP9 track.
 pub struct Bridge {
-	/// Owns the catalog rendition, retiring it when the bridge goes away.
-	rendition: codec::VideoRendition,
-	track: moq_mux::container::Producer<moq_mux::catalog::hang::Container>,
-	announced: bool,
+	import: moq_mux::codec::vp9::Import,
 }
 
 impl Bridge {
-	/// Publish a `.vp9` track on `broadcast`; the catalog rendition is added on the first frame.
+	/// Publish a `.vp9` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.create_track(broadcast.unique_name(".vp9"), catalog.track_info())?;
-		let name = track.name().to_string();
-		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy)?;
-		Ok(Self {
-			rendition: codec::VideoRendition { catalog, name },
-			track: producer,
-			announced: false,
-		})
-	}
-
-	fn announce(&mut self) -> Result<()> {
-		if self.announced {
-			return Ok(());
-		}
-		let name = self.rendition.name.clone();
-		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VP9::default());
-		config.container = hang::catalog::Container::Legacy;
-		config.timeline = Some(self.rendition.catalog.timeline(&name)?.section());
-		// Publish explicitly rather than through the guard's drop, which only warns:
-		// marking the rendition announced when the catalog never took it would leave the
-		// media track advertised nowhere, and `announced` latches so we'd never retry.
-		let mut guard = self.rendition.catalog.lock();
-		guard.video.renditions.insert(name, config);
-		guard.commit()?;
-		self.announced = true;
-		Ok(())
+		let track = broadcast.unique_track(".vp9", catalog.track_info())?;
+		let import = moq_mux::codec::vp9::Import::new(track, catalog.reserve(), Default::default())?;
+		Ok(Self { import })
 	}
 }
 
 impl codec::Bridge for Bridge {
 	fn push(&mut self, frame: codec::Frame) -> Result<()> {
-		self.announce()?;
 		let pts = moq_net::Timestamp::from_micros(frame.timestamp_us)
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("invalid timestamp: {err}")))?;
-		let keyframe = is_keyframe(&frame.payload);
-		self.track
-			.write(moq_mux::container::Frame {
-				timestamp: pts,
-				payload: frame.payload,
-				keyframe,
-				duration: None,
-			})
-			.map_err(|err| crate::Error::Other(anyhow::anyhow!("vp9 track write failed: {err}")))?;
+		self.import.decode(frame.payload, Some(pts))?;
 		Ok(())
 	}
 
 	fn abort(self: Box<Self>, err: moq_net::Error) {
-		self.track.abort(err);
+		self.import.abort(err);
 	}
-}
-
-/// Detect a VP9 keyframe from the uncompressed header's first byte (VP9 spec
-/// §6.2), reading bits MSB-first: `frame_marker(2)`, `profile_low(1)`,
-/// `profile_high(1)`, a `reserved(1)` bit only when profile == 3,
-/// `show_existing_frame(1)`, then `frame_type(1)` (0 == KEY_FRAME). A
-/// show-existing frame carries no frame_type and is never a keyframe.
-fn is_keyframe(payload: &[u8]) -> bool {
-	let Some(&b) = payload.first() else {
-		return false;
-	};
-	let profile = (((b >> 4) & 1) << 1) | ((b >> 5) & 1); // (high << 1) | low
-	// Bits consumed from the MSB: 2 (marker) + 2 (profile), plus profile 3's reserved bit.
-	let mut pos = 4;
-	if profile == 3 {
-		pos += 1;
-	}
-	let show_existing_frame = (b >> (7 - pos)) & 1;
-	if show_existing_frame == 1 {
-		return false;
-	}
-	pos += 1;
-	let frame_type = (b >> (7 - pos)) & 1;
-	frame_type == 0
 }
 
 #[cfg(test)]
 mod tests {
-	use super::is_keyframe;
+	use bytes::Bytes;
 
-	// frame_marker = 0b10 in the top two bits for every well-formed header.
-	#[test]
-	fn profile0_keyframe_and_interframe() {
-		// profile 0, show_existing_frame = 0, frame_type = 0 (key) / 1 (inter).
-		assert!(is_keyframe(&[0b1000_0010]));
-		assert!(!is_keyframe(&[0b1000_0110]));
-	}
+	use crate::codec::{self, Bridge as _};
 
 	#[test]
-	fn profile0_show_existing_frame_is_not_keyframe() {
-		// profile 0, show_existing_frame = 1: no frame_type follows.
-		assert!(!is_keyframe(&[0b1000_1000]));
-	}
+	fn keyframe_publishes_catalog_dimensions() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut bridge = super::Bridge::new(broadcast, catalog.clone()).unwrap();
 
-	#[test]
-	fn profile3_keyframe_and_interframe() {
-		// profile 3 (both profile bits set) inserts a reserved bit before
-		// show_existing_frame, shifting frame_type one position right.
-		assert!(is_keyframe(&[0b1011_0000])); // reserved=0, show=0, frame_type=0
-		assert!(!is_keyframe(&[0b1011_0010])); // frame_type=1
-	}
+		assert!(catalog.snapshot().video.renditions.is_empty());
 
-	#[test]
-	fn empty_payload_is_not_keyframe() {
-		assert!(!is_keyframe(&[]));
+		// VP9 profile 0 keyframe header for 320x240.
+		bridge
+			.push(codec::Frame {
+				timestamp_us: 0,
+				payload: Bytes::from_static(&[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00]),
+			})
+			.unwrap();
+
+		let snapshot = catalog.snapshot();
+		let config = snapshot.video.renditions.values().next().unwrap();
+		assert_eq!(config.coded_width, Some(320));
+		assert_eq!(config.coded_height, Some(240));
 	}
 }


### PR DESCRIPTION
## Summary

- Route WebRTC VP8 and VP9 ingest through the shared `moq-mux` importers.
- Publish authoritative coded width and height from the first parseable keyframe.
- Defer the catalog reservation until the first frame so an idle negotiated video track cannot withhold active audio or other renditions.
- Preserve an abort-capable track handle if deferred importer construction fails, so subscribers receive the session failure instead of `Error::Dropped`.
- Keep the video rendition absent until its codec configuration is known, matching the H.264, H.265, and AV1 ingest paths.

The RTC bridges previously announced VP8 and VP9 with hand-built catalog entries that omitted dimensions. They also duplicated keyframe parsing and catalog lifecycle logic already owned by `moq-mux`.

Creating the shared importer during SDP negotiation initially introduced a catalog bootstrap regression: its unresolved rendition held the initial catalog gate even when the peer never sent video. The final implementation creates the media track at negotiation time but activates the importer and reservation only when the first frame arrives.

The deferred activation state also retains a producer when importer construction fails. The session can then abort that track with its real transport error instead of dropping the last producer and losing the failure cause.

## Public API changes

None.

## Test plan

- `nix develop --command just check`
- `nix develop --command just test` (68 passed)
- Regression test: idle VP8 and VP9 bridges do not gate an active Opus catalog entry
- Regression test: importer construction failure preserves the later session abort error

Cross-package sync is not applicable: this changes WebRTC ingest catalog population without changing the catalog format, wire protocol, or public API.

(Written by GPT-5.6)