### PR TITLE
feat(net)!: divide one connection's bandwidth estimate among its tracks

### DIFF
--- a/js/hang/src/container/track.ts
+++ b/js/hang/src/container/track.ts
@@ -26,12 +26,26 @@ const MAX_AGE_MS = 30_000;
  *
  * Options override that retention; see {@link TrackInfoOptions.maxAge}.
  */
-export function trackInfo(options?: TrackInfoOptions): Partial<Track.Info> {
-	return { timescale: Time.Timescale.MICRO, maxAge: options?.maxAge ?? MAX_AGE_MS };
+export function trackInfo(options: TrackInfoOptions): Partial<Track.Info> {
+	return {
+		timescale: Time.Timescale.MICRO,
+		maxAge: options.maxAge ?? MAX_AGE_MS,
+		priority: options.priority,
+	};
 }
 
-/** Overrides for {@link trackInfo}. */
+/** Options for {@link trackInfo}. */
 export type TrackInfoOptions = {
+	/**
+	 * The publisher's tie-break priority, which should come from `PRIORITY` in `@moq/hang/catalog`
+	 * for the kind of media the track carries (`PRIORITY.video` for a video track, and so on).
+	 *
+	 * Required rather than defaulted, matching `hang::container::track_info`: there is no correct
+	 * value for "some media track", and leaving it at zero is what puts audio and video in one
+	 * undifferentiated tier for every relay deciding what to forward first.
+	 */
+	priority: number;
+
 	/**
 	 * How long a relay keeps a non-latest group fetchable, in milliseconds, replacing the
 	 * retention {@link trackInfo} declares by default.

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -12,7 +12,7 @@ import * as Varint from "../varint.ts";
 import type { Session } from "./adapter.ts";
 import * as Cluster from "./cluster.ts";
 import { Frame, Group as GroupMessage } from "./object.ts";
-import { fromWire } from "./priority.ts";
+import { fromWire, toWire } from "./priority.ts";
 import { PublishDone } from "./publish.ts";
 import { PublishNamespace, PublishNamespaceDone, PublishNamespaceOk } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
@@ -64,6 +64,9 @@ interface RunGroup {
 
 	/** The track's advertised timescale, applied to every frame timestamp. */
 	timescale: Timescale;
+
+	/** The publisher's tie-break priority, already converted to the IETF wire convention. */
+	publisherPriority: number;
 
 	/** Settles when the subscriber leaves, dropping a group still queued for a stream slot. */
 	unsubscribed: Promise<void>;
@@ -168,7 +171,13 @@ export class Publisher {
 		try {
 			// Declaring the timescale is what opts the track into timestamps; every object
 			// Timestamp below is in these units.
-			const timescale = (await track.info()).timescale;
+			const info = await track.info();
+			const timescale = info.timescale;
+			// The model ranks higher-first, the IETF wire lower-first. Every group this
+			// subscription serves carries the same publisher priority, which is what lets a
+			// relay prefer catalog and audio over video when it has no subscriber preference
+			// to go on.
+			const publisherPriority = toWire(info.priority);
 
 			// Send SUBSCRIBE_OK
 			await stream.writer.u53(SubscribeOk.id);
@@ -204,7 +213,13 @@ export class Publisher {
 				for (;;) {
 					const group = await track.recvGroup();
 					if (!group) return;
-					void this.#runGroup({ requestId: msg.requestId, group, timescale, unsubscribed });
+					void this.#runGroup({
+						requestId: msg.requestId,
+						group,
+						timescale,
+						publisherPriority,
+						unsubscribed,
+					});
 				}
 			})();
 
@@ -245,7 +260,7 @@ export class Publisher {
 	 * Runs a group and sends its frames using ObjectStream (Subgroup delivery mode).
 	 */
 	async #runGroup(options: RunGroup) {
-		const { requestId, group, timescale, unsubscribed } = options;
+		const { requestId, group, timescale, publisherPriority, unsubscribed } = options;
 		try {
 			// One stream per group is faster than a peer at its limit can retire them, so this
 			// is the one path that doesn't wait for a slot: the transport would serve the opens
@@ -265,7 +280,7 @@ export class Publisher {
 				trackAlias: requestId,
 				groupId: group.sequence,
 				subGroupId: 0,
-				publisherPriority: 0,
+				publisherPriority,
 				flags: {
 					hasExtensions: true,
 					hasSubgroup: false,

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -237,7 +237,10 @@ export class Broadcast {
 
 			if (request.name === Broadcast.CATALOG_TRACK || request.name === Broadcast.CATALOG_TRACK_COMPRESSED) {
 				const compression = request.name === Broadcast.CATALOG_TRACK_COMPRESSED;
-				const track = request.accept();
+				// The catalog keeps the bare retention defaults (it is read at the live edge, which
+				// is always retained) but still declares its priority, so a relay forwards it ahead
+				// of the media it describes. Matches `hang::Catalog::default_track_info`.
+				const track = request.accept({ priority: Catalog.PRIORITY.catalog });
 
 				// Serve from a per-subscription child scope. Releasing it when this subscriber leaves keeps
 				// serving state from piling up on the connection-lifetime effect as viewers come and go.
@@ -257,9 +260,17 @@ export class Broadcast {
 			}
 
 			// Media, so declare the retention a FETCH-based consumer needs (the catalog above
-			// keeps the bare defaults: it is read at the live edge, which is always retained).
-			// Matches what a Rust publisher declares via `hang::container::track_info`.
-			const track = request.accept(Container.trackInfo({ maxAge: this.in.maxAge.peek() }));
+			// keeps the bare defaults: it is read at the live edge, which is always retained),
+			// plus the priority for what this rendition carries. Matches what a Rust publisher
+			// declares via `hang::container::track_info`; `Kind` and `PRIORITY` share their names,
+			// so a new kind can't be added on one side without the other noticing.
+			const kind = this.#renditions.peek()[request.name]?.kind;
+			const track = request.accept(
+				Container.trackInfo({
+					maxAge: this.in.maxAge.peek(),
+					priority: kind ? Catalog.PRIORITY[kind] : Catalog.PRIORITY.video,
+				}),
+			);
 
 			// A second subscription for the same name supersedes the first: close the old producer.
 			signal.peek()?.close();

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -71,8 +71,9 @@ fn create_track(broadcast: &mut moq_net::broadcast::Producer) -> anyhow::Result<
 	group.finish()?;
 
 	// Actually create the media track now.
-	// track_info() pins the microsecond timescale that the legacy container encodes with.
-	let track = broadcast.create_track(video_track, hang::container::track_info())?;
+	// track_info() pins the microsecond timescale that the legacy container encodes with, and
+	// declares the publisher priority so a subscriber orders this against a broadcast's audio.
+	let track = broadcast.create_track(video_track, hang::container::track_info(hang::catalog::PRIORITY.video))?;
 
 	Ok(track)
 }

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -105,8 +105,11 @@ impl Catalog {
 	/// Track properties for creating the catalog track via
 	/// [`create_track`](moq_net::broadcast::Producer::create_track) at
 	/// [`DEFAULT_NAME`](Self::DEFAULT_NAME).
+	///
+	/// Keeps the bare `moq_net` retention rather than the media one: the catalog is
+	/// snapshot mode, so the useful value is the live edge, which is always kept.
 	pub fn default_track_info() -> moq_net::track::Info {
-		moq_net::track::Info::default()
+		moq_net::track::Info::default().with_priority(PRIORITY.catalog)
 	}
 
 	/// The subscription preferences used for the catalog track (high priority so

--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -42,10 +42,19 @@ const MAX_AGE: std::time::Duration = std::time::Duration::from_secs(30);
 /// anyone play further behind live: a subscriber's own
 /// [`Subscription::max_age`](moq_net::track::Subscription::max_age) defaults to
 /// [`std::time::Duration::ZERO`](std::time::Duration::ZERO) (skip the moment a newer group arrives).
-pub fn track_info() -> moq_net::track::Info {
+///
+/// `priority` is the publisher's tie-break priority, and should come from
+/// [`PRIORITY`](crate::catalog::PRIORITY) so every publisher orders its kinds the
+/// same way (`PRIORITY.video` for a video track, and so on). It's a parameter
+/// rather than a default because there is no correct value for "some media
+/// track": leaving it at zero is what puts audio and video in one undifferentiated
+/// tier, both on the wire and in
+/// [`bandwidth::Allocator`](moq_net::bandwidth::Allocator).
+pub fn track_info(priority: u8) -> moq_net::track::Info {
 	moq_net::track::Info::default()
 		.with_timescale(TIMESCALE)
 		.with_max_age(MAX_AGE)
+		.with_priority(priority)
 }
 
 /// A media frame with a timestamp and codec-specific payload.
@@ -165,21 +174,32 @@ mod test {
 		assert_eq!(decoded.timestamp, Timestamp::from_micros(1_234_567).expect("timestamp"));
 	}
 
+	/// Publishers stamp the kind's priority, which is what keeps audio ahead of video
+	/// both on the wire and in `bandwidth::Allocator`. It is a parameter precisely so
+	/// this can't silently fall back to the undifferentiated default.
+	#[test]
+	fn track_info_carries_the_publisher_priority() {
+		use crate::catalog::PRIORITY;
+
+		assert_eq!(track_info(PRIORITY.video).priority, PRIORITY.video);
+		assert_eq!(track_info(PRIORITY.audio).priority, PRIORITY.audio);
+	}
+
 	#[test]
 	fn track_info_uses_container_timescale() {
-		assert_eq!(track_info().timescale, TIMESCALE);
+		assert_eq!(track_info(crate::catalog::PRIORITY.video).timescale, TIMESCALE);
 	}
 
 	#[test]
 	fn media_tracks_declare_their_retention() {
 		// A media track is read as history (a segmented egress FETCHes segments a playlist
 		// advertised), so it declares a retention rather than inheriting the live-edge default.
-		assert_eq!(track_info().max_age, MAX_AGE);
+		assert_eq!(track_info(crate::catalog::PRIORITY.video).max_age, MAX_AGE);
 		assert!(MAX_AGE > moq_net::track::DEFAULT_MAX_AGE);
 
 		// Retimescaling for a container that carries the source's own scale keeps it, since that
 		// is the shape that would otherwise reach for `Info::default()` and lose the retention.
-		let at = track_info().with_timescale(Timescale::MILLI);
+		let at = track_info(crate::catalog::PRIORITY.video).with_timescale(Timescale::MILLI);
 		assert_eq!(at.timescale, Timescale::MILLI);
 		assert_eq!(at.max_age, MAX_AGE);
 	}

--- a/rs/libmoq/src/audio.rs
+++ b/rs/libmoq/src/audio.rs
@@ -317,7 +317,7 @@ pub unsafe extern "C" fn moq_encode_audio(
 			.map_err(|_| Error::UnknownFormat(codec_str.to_string()))?;
 		options.sample_rate = zeroable(raw_output.sample_rate);
 		options.channels = zeroable(raw_output.channels);
-		options.bitrate = zeroable(raw_output.bitrate);
+		options.bitrate = zeroable(raw_output.bitrate).map(|bps| moq_net::bandwidth::Rate::from_bps(bps.into()));
 		options.frame_duration = Duration::from_millis(raw_output.frame_duration_ms.into());
 
 		let mut state = State::lock();

--- a/rs/libmoq/src/video.rs
+++ b/rs/libmoq/src/video.rs
@@ -266,7 +266,7 @@ impl VideoEncoder {
 	}
 
 	fn publish_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
-		block_on(self.encoder.set_bitrate(bitrate))?;
+		block_on(self.encoder.set_bitrate(moq_net::bandwidth::Rate::from_bps(bitrate)))?;
 		Ok(())
 	}
 
@@ -492,7 +492,7 @@ pub unsafe extern "C" fn moq_encode_video(
 		config.kind = unsafe { encoder_kind(raw_output)? };
 		// The C ABI spells an unset knob as 0, which neither field accepts as a real
 		// value: a zero bitrate or GOP is the default, not a request.
-		config.bitrate = (raw_output.bitrate != 0).then_some(raw_output.bitrate);
+		config.bitrate = (raw_output.bitrate != 0).then(|| moq_net::bandwidth::Rate::from_bps(raw_output.bitrate));
 		if raw_output.gop != 0 {
 			config.gop = raw_output.gop;
 		}

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -344,7 +344,9 @@ mod tests {
 	#[tokio::test]
 	async fn resampled_timestamps_follow_the_samples() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("audio", hang::container::track_info(hang::catalog::PRIORITY.audio))
+			.unwrap();
 		let subscriber = broadcast.consume();
 
 		let catalog = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Pcm, 44_100, 1);
@@ -398,7 +400,9 @@ mod tests {
 	#[tokio::test]
 	async fn resampled_tail_survives_the_end_of_the_track() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("audio", hang::container::track_info(hang::catalog::PRIORITY.audio))
+			.unwrap();
 		let subscriber = broadcast.consume();
 
 		let catalog = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Pcm, 44_100, 1);
@@ -456,7 +460,9 @@ mod tests {
 	#[tokio::test]
 	async fn reads_the_container_the_catalog_declares() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("audio", hang::container::track_info(hang::catalog::PRIORITY.audio))
+			.unwrap();
 		let observed = track.clone();
 		let subscriber = broadcast.consume();
 
@@ -522,7 +528,9 @@ mod tests {
 
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let subscriber = broadcast.consume();
-		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("audio", hang::container::track_info(hang::catalog::PRIORITY.audio))
+			.unwrap();
 		let container = moq_mux::catalog::hang::Container::try_from(&catalog.container).unwrap();
 		let mut producer = moq_mux::container::Producer::new(track, container);
 

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -40,13 +40,12 @@ pub async fn publish_capture(
 	let track = producer.track().clone();
 
 	// Reserve what audio actually costs, so a video encoder on the same connection
-	// sizes itself against what's left. The share is deliberately dropped: audio
-	// doesn't follow it yet, and the reservation lives with the track rather than
-	// with this handle. The encoder is open by now, so this is its real rate even
-	// when the caller left `Options::bitrate` unset for Opus to pick.
-	if let Some(allocator) = &encode.bandwidth {
-		allocator.register(&track.demand(), producer.bitrate());
-	}
+	// sizes itself against what's left. Held for the whole capture: dropping it would
+	// hand the room straight back and put video back to targeting the entire uplink.
+	// Audio doesn't read its share (it doesn't follow one yet), but it has to claim
+	// one. The encoder is open by now, so this is its real rate even when the caller
+	// left `Options::bitrate` unset for Opus to pick.
+	let _reservation = encode.bandwidth.reserve(&track.demand(), producer.bitrate());
 
 	let result = capture_loop(&mut producer, &track, &capture, &clock).await;
 

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -39,6 +39,15 @@ pub async fn publish_capture(
 	let mut producer = Producer::new(&mut broadcast, catalog, input, &encode)?;
 	let track = producer.track().clone();
 
+	// Reserve what audio actually costs, so a video encoder on the same connection
+	// sizes itself against what's left. The share is deliberately dropped: audio
+	// doesn't follow it yet, and the reservation lives with the track rather than
+	// with this handle. The encoder is open by now, so this is its real rate even
+	// when the caller left `Options::bitrate` unset for Opus to pick.
+	if let Some(allocator) = &encode.bandwidth {
+		allocator.register(&track.demand(), producer.bitrate());
+	}
+
 	let result = capture_loop(&mut producer, &track, &capture, &clock).await;
 
 	// Best-effort clean close: flush the trailing sub-frame and finalize the

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -111,7 +111,7 @@ pub struct Config {
 	pub channels: Option<u32>,
 	/// Bitrate in bits per second. `None` lets Opus pick. PCM requires `None`
 	/// because its bitrate is fixed by the sample rate and channel count.
-	pub bitrate: Option<u32>,
+	pub bitrate: Option<moq_net::bandwidth::Rate>,
 	/// Enable Opus in-band forward error correction.
 	pub fec: bool,
 	/// Enable Opus discontinuous transmission during silence.
@@ -305,7 +305,8 @@ impl Encoder {
 		codec_channels: u32,
 	) -> Result<(u64, usize, u16), Error> {
 		if let Some(bitrate) = config.bitrate {
-			Self::set_opus_bitrate(inner, codec_channels, bitrate as u64)?;
+			// libopus takes a plain integer, so the unit is unwrapped at this seam.
+			Self::set_opus_bitrate(inner, codec_channels, bitrate.as_bps())?;
 		}
 		Self::set_opus_ctl(
 			inner,
@@ -388,20 +389,21 @@ impl Encoder {
 		self.frame_size
 	}
 
-	/// Current target bitrate in bits per second.
-	pub fn bitrate(&self) -> u64 {
-		self.bitrate
+	/// Current target bitrate.
+	pub fn bitrate(&self) -> moq_net::bandwidth::Rate {
+		moq_net::bandwidth::Rate::from_bps(self.bitrate)
 	}
 
-	/// Retune the live Opus encoder to `bitrate` bits per second.
-	pub fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+	/// Retune the live Opus encoder to `bitrate`.
+	pub fn set_bitrate(&mut self, bitrate: moq_net::bandwidth::Rate) -> Result<(), Error> {
 		let Backend::Opus(opus) = &mut self.backend else {
 			return Err(Error::Unsupported("pcm bitrate is fixed".into()));
 		};
-		if bitrate != self.bitrate {
-			Self::set_opus_bitrate(opus.inner, self.codec_channels, bitrate)?;
-			self.bitrate = bitrate;
-			self.config.bitrate = Some(bitrate as u32);
+		if bitrate.as_bps() != self.bitrate {
+			// libopus wants a plain integer, so the unit is unwrapped at this seam.
+			Self::set_opus_bitrate(opus.inner, self.codec_channels, bitrate.as_bps())?;
+			self.bitrate = bitrate.as_bps();
+			self.config.bitrate = Some(bitrate);
 		}
 		Ok(())
 	}
@@ -541,7 +543,7 @@ impl Encoder {
 					self.codec_rate,
 					self.codec_channels,
 				);
-				config.bitrate = self.config.bitrate.map(u64::from);
+				config.bitrate = self.config.bitrate.map(moq_net::bandwidth::Rate::as_bps);
 				config.description = Some(head);
 				config.container = hang::catalog::Container::Legacy;
 				config
@@ -605,7 +607,7 @@ mod tests {
 	#[test]
 	fn opus_encode_then_decode_keeps_signal_close() {
 		let mut enc = Encoder::new(&Config {
-			bitrate: Some(96_000),
+			bitrate: Some(moq_net::bandwidth::Rate::from_bps(96_000)),
 			..Config::new(stereo_48k())
 		})
 		.unwrap();
@@ -650,7 +652,7 @@ mod tests {
 	#[test]
 	fn opus_catalog_includes_opushead() {
 		let enc = Encoder::new(&Config {
-			bitrate: Some(64_000),
+			bitrate: Some(moq_net::bandwidth::Rate::from_bps(64_000)),
 			..Config::new(stereo_48k())
 		})
 		.unwrap();
@@ -743,14 +745,14 @@ mod tests {
 	#[test]
 	fn opus_runtime_bitrate_updates_encoder_state() {
 		let mut enc = Encoder::new(&Config {
-			bitrate: Some(64_000),
+			bitrate: Some(moq_net::bandwidth::Rate::from_bps(64_000)),
 			..Config::new(stereo_48k())
 		})
 		.unwrap();
 
-		enc.set_bitrate(32_000).unwrap();
-		assert_eq!(enc.bitrate(), 32_000);
-		assert_eq!(enc.config().bitrate, Some(32_000));
+		enc.set_bitrate(moq_net::bandwidth::Rate::from_bps(32_000)).unwrap();
+		assert_eq!(enc.bitrate(), moq_net::bandwidth::Rate::from_bps(32_000));
+		assert_eq!(enc.config().bitrate, Some(moq_net::bandwidth::Rate::from_bps(32_000)));
 		assert_eq!(
 			Encoder::get_opus_ctl(
 				opus_inner(&enc),
@@ -766,8 +768,8 @@ mod tests {
 	fn opus_runtime_bitrate_rejects_values_libopus_would_clamp() {
 		let mut enc = Encoder::new(&Config::new(stereo_48k())).unwrap();
 		let original = enc.bitrate();
-		assert!(enc.set_bitrate(1).is_err());
-		assert!(enc.set_bitrate(600_001).is_err());
+		assert!(enc.set_bitrate(moq_net::bandwidth::Rate::from_bps(1)).is_err());
+		assert!(enc.set_bitrate(moq_net::bandwidth::Rate::from_bps(600_001)).is_err());
 		assert_eq!(enc.bitrate(), original);
 	}
 

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -157,10 +157,13 @@ impl<E: CatalogExt> Producer<E> {
 			// The catalog's info carries the microsecond timescale audio hang frames stamp, so
 			// Lite05 subscribers know what scale to expect and the model layer accepts
 			// Frame::timestamp on append, plus whatever retention the broadcast declared.
-			Some(name) => broadcast.create_track(name.clone(), catalog.track_info())?,
+			Some(name) => broadcast.create_track(name.clone(), catalog.track_info(hang::catalog::PRIORITY.audio))?,
 			// Mirrors the video side, which derives a unique name from the codec
 			// rather than making every caller invent one.
-			None => broadcast.unique_track(&format!(".{}", options.codec), catalog.track_info())?,
+			None => broadcast.unique_track(
+				&format!(".{}", options.codec),
+				catalog.track_info(hang::catalog::PRIORITY.audio),
+			)?,
 		};
 		let name = track.name().to_string();
 		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -37,7 +37,7 @@ pub struct Options {
 	pub channels: Option<u32>,
 	/// Bitrate in bits per second. `None` lets Opus pick. PCM requires `None`
 	/// because its bitrate is fixed by the sample rate and channel count.
-	pub bitrate: Option<u32>,
+	pub bitrate: Option<moq_net::bandwidth::Rate>,
 	/// Enable Opus in-band forward error correction.
 	pub fec: bool,
 	/// Enable Opus discontinuous transmission during silence.
@@ -48,14 +48,17 @@ pub struct Options {
 	/// The connection's bandwidth, as an allocator over
 	/// [`Session::send_bandwidth`](moq_net::Session::send_bandwidth).
 	///
-	/// Set it and the audio track reserves its bitrate, so the video encoder
-	/// sharing the connection sizes itself against what's actually left rather
-	/// than against the whole uplink. Pass the same allocator to both.
+	/// The audio track reserves its bitrate against it, so the video encoder sharing
+	/// the connection sizes itself against what's actually left rather than against
+	/// the whole uplink. Pass the same allocator to both.
+	///
+	/// Defaults to [`Allocator::unlimited`](moq_net::bandwidth::Allocator::unlimited),
+	/// which reserves nothing and leaves every sender at its configured rate.
 	///
 	/// Audio reserves but does not follow its share: Opus can retune live and PCM
 	/// can't at all, and at `hang`'s priorities audio outranks video, so it is only
 	/// ever squeezed on a link that can't carry audio alone.
-	pub bandwidth: Option<moq_net::bandwidth::Allocator>,
+	pub bandwidth: moq_net::bandwidth::Allocator,
 }
 
 impl Default for Options {
@@ -69,7 +72,7 @@ impl Default for Options {
 			fec: false,
 			dtx: false,
 			frame_duration: Duration::from_millis(20),
-			bandwidth: None,
+			bandwidth: moq_net::bandwidth::Allocator::unlimited(),
 		}
 	}
 }
@@ -197,13 +200,13 @@ impl<E: CatalogExt> Producer<E> {
 		self.track.track()
 	}
 
-	/// Current encoder target bitrate in bits per second.
-	pub fn bitrate(&self) -> u64 {
+	/// Current encoder target bitrate.
+	pub fn bitrate(&self) -> moq_net::bandwidth::Rate {
 		self.encoder.bitrate()
 	}
 
-	/// Retune the live encoder to `bitrate` bits per second.
-	pub fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+	/// Retune the live encoder to `bitrate`.
+	pub fn set_bitrate(&mut self, bitrate: moq_net::bandwidth::Rate) -> Result<(), Error> {
 		self.encoder.set_bitrate(bitrate)
 	}
 
@@ -427,7 +430,7 @@ mod tests {
 			};
 			let options = Options {
 				track: Some("audio".to_string()),
-				bitrate: Some(128_000),
+				bitrate: Some(moq_net::bandwidth::Rate::from_bps(128_000)),
 				..Options::default()
 			};
 			let decoder_config = Encoder::new(&options.config(input.clone())).unwrap().catalog();

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -45,6 +45,17 @@ pub struct Options {
 	/// Encoded frame duration. Opus accepts 2.5 / 5 / 10 / 20 / 40 / 60 ms.
 	/// PCM accepts any duration containing a whole number of samples.
 	pub frame_duration: Duration,
+	/// The connection's bandwidth, as an allocator over
+	/// [`Session::send_bandwidth`](moq_net::Session::send_bandwidth).
+	///
+	/// Set it and the audio track reserves its bitrate, so the video encoder
+	/// sharing the connection sizes itself against what's actually left rather
+	/// than against the whole uplink. Pass the same allocator to both.
+	///
+	/// Audio reserves but does not follow its share: Opus can retune live and PCM
+	/// can't at all, and at `hang`'s priorities audio outranks video, so it is only
+	/// ever squeezed on a link that can't carry audio alone.
+	pub bandwidth: Option<moq_net::bandwidth::Allocator>,
 }
 
 impl Default for Options {
@@ -58,6 +69,7 @@ impl Default for Options {
 			fec: false,
 			dtx: false,
 			frame_duration: Duration::from_millis(20),
+			bandwidth: None,
 		}
 	}
 }

--- a/rs/moq-audio/tests/roundtrip.rs
+++ b/rs/moq-audio/tests/roundtrip.rs
@@ -46,7 +46,7 @@ async fn opus_round_trip_48k_stereo() {
 	let mut options = encode::Options::default();
 	options.track = Some("audio".to_string());
 	options.codec = encode::Codec::Opus;
-	options.bitrate = Some(96_000);
+	options.bitrate = Some(moq_net::bandwidth::Rate::from_bps(96_000));
 
 	let mut producer = encode::Producer::new(&mut broadcast, catalog.clone(), input, &options).unwrap();
 
@@ -119,7 +119,7 @@ async fn opus_round_trip_44100_s16_resampled() {
 	let mut options = encode::Options::default();
 	options.track = Some("audio".to_string());
 	options.codec = encode::Codec::Opus;
-	options.bitrate = Some(64_000);
+	options.bitrate = Some(moq_net::bandwidth::Rate::from_bps(64_000));
 
 	let mut producer = encode::Producer::new(&mut broadcast, catalog.clone(), input, &options).unwrap();
 

--- a/rs/moq-boy/src/audio.rs
+++ b/rs/moq-boy/src/audio.rs
@@ -14,7 +14,7 @@ use bytes::Bytes;
 /// The Game Boy APU outputs stereo audio.
 const CHANNELS: u32 = 2;
 /// 64 kbps is reasonable for stereo Game Boy audio (simple waveforms).
-const OPUS_BITRATE: u32 = 64_000;
+const OPUS_BITRATE: moq_net::bandwidth::Rate = moq_net::bandwidth::Rate::from_kbps(64);
 
 pub struct AudioEncoder {
 	producer: moq_audio::encode::Producer,

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -269,8 +269,9 @@ impl Directions {
 ///
 /// Returns an allocator over the uplink's bandwidth estimate, for the sources that
 /// can encode to fit it. Only an outbound client has one: a `--server-bind`
-/// publisher's sessions are inbound and never surfaced here, so it stays `None` and
-/// those sources encode at their configured rate.
+/// publisher's sessions are inbound and never surfaced here, so it gets an
+/// [`unlimited`](moq_net::bandwidth::Allocator::unlimited) allocator and those
+/// sources encode at their configured rate.
 ///
 /// One allocator per connection, minted here rather than per stage, since dividing
 /// the estimate is only meaningful across everything sharing it. A stage that built
@@ -282,8 +283,8 @@ async fn spawn_moq(
 	origin: &moq_net::origin::Producer,
 	directions: Directions,
 	tasks: &mut JoinSet<anyhow::Result<()>>,
-) -> anyhow::Result<Option<moq_net::bandwidth::Allocator>> {
-	let mut bandwidth = None;
+) -> anyhow::Result<moq_net::bandwidth::Allocator> {
+	let mut bandwidth = moq_net::bandwidth::Allocator::unlimited();
 
 	if let Some(url) = moq.client.url.clone() {
 		let mut client = net.client(moq.client.clone())?;
@@ -301,7 +302,7 @@ async fn spawn_moq(
 		// Read before the handle moves into the task. This consumer is persistent: it
 		// survives reconnects, reading `None` while down, so it can be wired up before
 		// anything connects.
-		bandwidth = Some(moq_net::bandwidth::Allocator::new(reconnect.send_bandwidth()));
+		bandwidth = moq_net::bandwidth::Allocator::new(reconnect.send_bandwidth());
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
 	notify_when_initialized(spawn_server(tasks, moq, origin, net, directions), moq::notify_ready).await?;
@@ -436,10 +437,10 @@ fn spawn_import(
 	origin: &moq_net::origin::Producer,
 	import: Import,
 	name: String,
-	bandwidth: Option<moq_net::bandwidth::Allocator>,
+	bandwidth: moq_net::bandwidth::Allocator,
 	tasks: &mut JoinSet<anyhow::Result<()>>,
 ) -> anyhow::Result<Option<Publish>> {
-	// Capture is the only source that reads the bandwidth estimate, so without that
+	// Capture is the only source that reserves against the estimate, so without that
 	// feature nothing does.
 	#[cfg(not(feature = "capture"))]
 	let _ = bandwidth;

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -267,17 +267,22 @@ impl Directions {
 /// hops it crossed, and our own origin id is one of them, so a broadcast we
 /// publish is never announced back to us.
 ///
-/// Returns the uplink's bandwidth estimate, for the sources that can encode to
-/// fit it. Only an outbound client has one: a `--server-bind` publisher's sessions
-/// are inbound and never surfaced here, so it stays `None` and those sources
-/// encode at their configured rate.
+/// Returns an allocator over the uplink's bandwidth estimate, for the sources that
+/// can encode to fit it. Only an outbound client has one: a `--server-bind`
+/// publisher's sessions are inbound and never surfaced here, so it stays `None` and
+/// those sources encode at their configured rate.
+///
+/// One allocator per connection, minted here rather than per stage, since dividing
+/// the estimate is only meaningful across everything sharing it. A stage that built
+/// its own would split its own tracks correctly and still oversubscribe every other
+/// stage on the same connection, which is the whole problem.
 async fn spawn_moq(
 	moq: &MoqSide,
 	net: &Net,
 	origin: &moq_net::origin::Producer,
 	directions: Directions,
 	tasks: &mut JoinSet<anyhow::Result<()>>,
-) -> anyhow::Result<Option<moq_net::bandwidth::Consumer>> {
+) -> anyhow::Result<Option<moq_net::bandwidth::Allocator>> {
 	let mut bandwidth = None;
 
 	if let Some(url) = moq.client.url.clone() {
@@ -296,7 +301,7 @@ async fn spawn_moq(
 		// Read before the handle moves into the task. This consumer is persistent: it
 		// survives reconnects, reading `None` while down, so it can be wired up before
 		// anything connects.
-		bandwidth = Some(reconnect.send_bandwidth());
+		bandwidth = Some(moq_net::bandwidth::Allocator::new(reconnect.send_bandwidth()));
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
 	notify_when_initialized(spawn_server(tasks, moq, origin, net, directions), moq::notify_ready).await?;
@@ -431,7 +436,7 @@ fn spawn_import(
 	origin: &moq_net::origin::Producer,
 	import: Import,
 	name: String,
-	bandwidth: Option<moq_net::bandwidth::Consumer>,
+	bandwidth: Option<moq_net::bandwidth::Allocator>,
 	tasks: &mut JoinSet<anyhow::Result<()>>,
 ) -> anyhow::Result<Option<Publish>> {
 	// Capture is the only source that reads the bandwidth estimate, so without that

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -266,9 +266,12 @@ impl Publish {
 	/// Build a publisher capturing local devices (camera/screen and microphone).
 	///
 	/// `bandwidth` is the uplink's send estimate, when there is one: the video
-	/// encoder follows it down while the link is congested rather than
+	/// encoder follows its share down while the link is congested rather than
 	/// overshooting a pipe that can't carry it. Pass `None` to encode at the
 	/// configured bitrate regardless.
+	///
+	/// Audio and video share one allocator, so the video encoder targets what's
+	/// left after audio's reservation rather than the whole uplink.
 	#[cfg(feature = "capture")]
 	pub fn capture(
 		mut broadcast: moq_net::broadcast::Producer,
@@ -279,8 +282,9 @@ impl Publish {
 		let config = moq_mux::catalog::Config::default().with_max_age(max_age);
 		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 
-		let video = (!args.no_video).then(|| (args.video_config(), args.video_encode(bandwidth)));
-		let audio = (!args.no_audio).then(|| (args.audio_config(), args.audio_encode()));
+		let bandwidth = bandwidth.map(moq_net::bandwidth::Allocator::new);
+		let video = (!args.no_video).then(|| (args.video_config(), args.video_encode(bandwidth.clone())));
+		let audio = (!args.no_audio).then(|| (args.audio_config(), args.audio_encode(bandwidth)));
 		anyhow::ensure!(video.is_some() || audio.is_some(), "nothing to capture");
 
 		Ok(Self {
@@ -392,7 +396,7 @@ impl CaptureArgs {
 		config
 	}
 
-	fn video_encode(&self, bandwidth: Option<moq_net::bandwidth::Consumer>) -> moq_video::encode::Options {
+	fn video_encode(&self, bandwidth: Option<moq_net::bandwidth::Allocator>) -> moq_video::encode::Options {
 		let mut options = moq_video::encode::Options::default();
 		options.bitrate = self.bitrate;
 		options.codec = self.codec.into();
@@ -428,9 +432,10 @@ impl CaptureArgs {
 	/// The audio counterpart to [`video_encode`](Self::video_encode). `track` is
 	/// left unset so the name derives from the codec, the way the video side
 	/// names its track; consumers find it through the catalog either way.
-	fn audio_encode(&self) -> moq_audio::encode::Options {
+	fn audio_encode(&self, bandwidth: Option<moq_net::bandwidth::Allocator>) -> moq_audio::encode::Options {
 		let mut options = moq_audio::encode::Options::default();
 		options.bitrate = self.audio_bitrate;
+		options.bandwidth = bandwidth;
 		options
 	}
 }

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -241,7 +241,7 @@ impl Publish {
 		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 		let source = match format {
 			PublishFormat::Avc3 => {
-				let track = broadcast.unique_track(".avc3", catalog.track_info())?;
+				let track = broadcast.unique_track(".avc3", catalog.track_info(hang::catalog::PRIORITY.video))?;
 				let import = moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?;
 				let split = Box::new(moq_mux::codec::h264::Split::new());
 				Source::Stream(PublishDecoder::Avc3 {
@@ -510,7 +510,7 @@ mod tests {
 
 		// Section-framed verbatim stream (SCTE-35, stream_type 0x86).
 		let section = broadcast
-			.unique_track(".scte35", hang::container::track_info())
+			.unique_track(".scte35", hang::container::track_info(hang::catalog::PRIORITY.text))
 			.unwrap();
 		let mut section_track = tscat::Track::new(SECTION_PID);
 		section_track.verbatim = Some(tscat::Verbatim::new(0x86, tscat::Framing::Section));
@@ -536,7 +536,9 @@ mod tests {
 
 		// PES-framed verbatim stream (undecoded private data, stream_type 0x06), with
 		// an explicit PES stream_id to round-trip.
-		let pes = broadcast.unique_track(".data", hang::container::track_info()).unwrap();
+		let pes = broadcast
+			.unique_track(".data", hang::container::track_info(hang::catalog::PRIORITY.text))
+			.unwrap();
 		let mut verbatim = tscat::Verbatim::new(0x06, tscat::Framing::Pes);
 		verbatim.stream_id = Some(VERBATIM_PES_STREAM_ID);
 		let mut pes_track = tscat::Track::new(VERBATIM_PES_PID);

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -276,7 +276,7 @@ impl Publish {
 	pub fn capture(
 		mut broadcast: moq_net::broadcast::Producer,
 		args: &CaptureArgs,
-		bandwidth: Option<moq_net::bandwidth::Allocator>,
+		bandwidth: moq_net::bandwidth::Allocator,
 		max_age: Option<std::time::Duration>,
 	) -> anyhow::Result<Self> {
 		let config = moq_mux::catalog::Config::default().with_max_age(max_age);
@@ -395,9 +395,9 @@ impl CaptureArgs {
 		config
 	}
 
-	fn video_encode(&self, bandwidth: Option<moq_net::bandwidth::Allocator>) -> moq_video::encode::Options {
+	fn video_encode(&self, bandwidth: moq_net::bandwidth::Allocator) -> moq_video::encode::Options {
 		let mut options = moq_video::encode::Options::default();
-		options.bitrate = self.bitrate;
+		options.bitrate = self.bitrate.map(moq_net::bandwidth::Rate::from_bps);
 		options.codec = self.codec.into();
 		options.kind = if self.software {
 			moq_video::encode::Kind::Software
@@ -431,9 +431,11 @@ impl CaptureArgs {
 	/// The audio counterpart to [`video_encode`](Self::video_encode). `track` is
 	/// left unset so the name derives from the codec, the way the video side
 	/// names its track; consumers find it through the catalog either way.
-	fn audio_encode(&self, bandwidth: Option<moq_net::bandwidth::Allocator>) -> moq_audio::encode::Options {
+	fn audio_encode(&self, bandwidth: moq_net::bandwidth::Allocator) -> moq_audio::encode::Options {
 		let mut options = moq_audio::encode::Options::default();
-		options.bitrate = self.audio_bitrate;
+		options.bitrate = self
+			.audio_bitrate
+			.map(|bps| moq_net::bandwidth::Rate::from_bps(bps.into()));
 		options.bandwidth = bandwidth;
 		options
 	}

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -276,13 +276,12 @@ impl Publish {
 	pub fn capture(
 		mut broadcast: moq_net::broadcast::Producer,
 		args: &CaptureArgs,
-		bandwidth: Option<moq_net::bandwidth::Consumer>,
+		bandwidth: Option<moq_net::bandwidth::Allocator>,
 		max_age: Option<std::time::Duration>,
 	) -> anyhow::Result<Self> {
 		let config = moq_mux::catalog::Config::default().with_max_age(max_age);
 		let catalog = moq_mux::catalog::Producer::with_config(&mut broadcast, config)?;
 
-		let bandwidth = bandwidth.map(moq_net::bandwidth::Allocator::new);
 		let video = (!args.no_video).then(|| (args.video_config(), args.video_encode(bandwidth.clone())));
 		let audio = (!args.no_audio).then(|| (args.audio_config(), args.audio_encode(bandwidth)));
 		anyhow::ensure!(video.is_some() || audio.is_some(), "nothing to capture");

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -51,7 +51,10 @@ fn parse_rung(arg: &str) -> Result<moq_transcode::Rung, String> {
 	let bitrate: u64 = bitrate
 		.parse()
 		.map_err(|e| format!("invalid bitrate `{bitrate}`: {e}"))?;
-	Ok(moq_transcode::Rung::new(height, bitrate))
+	Ok(moq_transcode::Rung::new(
+		height,
+		moq_net::bandwidth::Rate::from_bps(bitrate),
+	))
 }
 
 /// Parse a frame resize acceleration preference.

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -232,7 +232,7 @@ impl MoqBroadcastProducer {
 		options.codec = output.codec.into();
 		options.sample_rate = output.sample_rate;
 		options.channels = output.channels;
-		options.bitrate = output.bitrate;
+		options.bitrate = output.bitrate.map(|bps| moq_net::bandwidth::Rate::from_bps(bps.into()));
 		options.frame_duration = Duration::from_millis(output.frame_duration_ms.into());
 
 		let producer = self.with_state(|state| {

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -335,7 +335,9 @@ impl MoqBroadcastProducer {
 		let encoder = block_on(moq_video::encode::Sink::open(&config))?;
 		let producer = self.with_state(|state| match output.track {
 			Some(name) => {
-				let track = state.broadcast.create_track(name, state.catalog.track_info())?;
+				let track = state
+					.broadcast
+					.create_track(name, state.catalog.track_info(hang::catalog::PRIORITY.video))?;
 				Ok(moq_video::encode::Producer::with_track(
 					track,
 					state.catalog.clone(),

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -292,7 +292,11 @@ impl MoqVideoProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.inner.lock().unwrap();
 		let producer = guard.as_mut().ok_or(MoqError::Closed)?;
-		Ok(block_on(producer.encoder.set_bitrate(bitrate))?)
+		Ok(block_on(
+			producer
+				.encoder
+				.set_bitrate(moq_net::bandwidth::Rate::from_bps(bitrate)),
+		)?)
 	}
 
 	/// Flush any frames the codec is still holding and finalize the track.
@@ -323,7 +327,7 @@ impl MoqBroadcastProducer {
 		let mut config = moq_video::encode::Config::new(input.width, input.height, input.framerate);
 		config.codec = output.codec.into();
 		config.kind = output.kind.into();
-		config.bitrate = output.bitrate;
+		config.bitrate = output.bitrate.map(moq_net::bandwidth::Rate::from_bps);
 		if let Some(gop) = output.gop {
 			config.gop = gop;
 		}

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -332,7 +332,7 @@ impl Pad {
 				// directly and lifts it into a `Track` via `.into()`.
 				let name = Self::track_name(&broadcast, requested, ".mp3");
 				let request = broadcast.reserve_track(name.clone())?;
-				let producer = request.accept(hang::container::track_info());
+				let producer = request.accept(hang::container::track_info(hang::catalog::PRIORITY.audio));
 				(
 					moq_mux::codec::mp3::Import::new(
 						producer,
@@ -377,7 +377,7 @@ impl Pad {
 				// importer directly and lifts it into a `Track` via `.into()`.
 				let name = Self::track_name(&broadcast, requested, ".opus");
 				let request = broadcast.reserve_track(name.clone())?;
-				let producer = request.accept(hang::container::track_info());
+				let producer = request.accept(hang::container::track_info(hang::catalog::PRIORITY.audio));
 				(
 					moq_mux::codec::opus::Import::new(
 						producer,
@@ -416,7 +416,7 @@ impl Pad {
 		structure: &gst::StructureRef,
 	) -> Result<Text> {
 		let request = broadcast.reserve_track(name.clone())?;
-		let producer = request.accept(hang::container::track_info());
+		let producer = request.accept(hang::container::track_info(hang::catalog::PRIORITY.text));
 
 		let mut config = hang::catalog::TextConfig::new(hang::catalog::TextFormat::Vtt);
 		// A demuxed text track is a subtitle track unless something says otherwise. Claiming

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -194,12 +194,12 @@ impl Session {
 
 	/// The congestion controller's send estimate in bits per second, 0 when disconnected or unavailable.
 	pub fn send_bitrate(&self) -> u64 {
-		self.send_bandwidth.peek().unwrap_or(0)
+		self.send_bandwidth.peek().map_or(0, moq_net::bandwidth::Rate::as_bps)
 	}
 
 	/// The estimated receive bitrate in bits per second, 0 when disconnected or unavailable.
 	pub fn recv_bitrate(&self) -> u64 {
-		self.recv_bandwidth.peek().unwrap_or(0)
+		self.recv_bandwidth.peek().map_or(0, moq_net::bandwidth::Rate::as_bps)
 	}
 
 	/// Whether the transport has hit a fatal error (the pad streaming threads stop feeding it on this).

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -290,10 +290,11 @@ impl<E: CatalogExt> Producer<E> {
 	/// Track properties for a media track under this catalog: hang's media defaults, plus any
 	/// [`Config::with_max_age`] override.
 	///
-	/// Chain [`with_timescale`](moq_net::track::Info::with_timescale) for a container that
-	/// carries the source's own scale (CMAF and Matroska both do).
-	pub fn track_info(&self) -> moq_net::track::Info {
-		let info = hang::container::track_info();
+	/// `priority` should come from [`PRIORITY`](hang::catalog::PRIORITY) for the kind of media
+	/// the track carries. Chain [`with_timescale`](moq_net::track::Info::with_timescale) for a
+	/// container that carries the source's own scale (CMAF and Matroska both do).
+	pub fn track_info(&self, priority: u8) -> moq_net::track::Info {
+		let info = hang::container::track_info(priority);
 		match self.max_age {
 			Some(max_age) => info.with_max_age(max_age),
 			None => info,
@@ -704,8 +705,8 @@ mod test {
 		// Unset, a catalog mints hang's media defaults, sized so a segmented egress can serve a
 		// full playlist window rather than moq-net's live-edge default.
 		let catalog = Producer::new(&mut broadcast).unwrap();
-		assert_eq!(catalog.track_info().max_age, hang::container::track_info().max_age);
-		assert!(catalog.track_info().max_age > moq_net::track::DEFAULT_MAX_AGE);
+		assert_eq!(catalog.track_info(hang::catalog::PRIORITY.video).max_age, hang::container::track_info(hang::catalog::PRIORITY.video).max_age);
+		assert!(catalog.track_info(hang::catalog::PRIORITY.video).max_age > moq_net::track::DEFAULT_MAX_AGE);
 
 		// An override reaches every media track this catalog mints, and does NOT disturb the
 		// timescale hang pins (or survive a retimescale for a source-scale container).
@@ -713,7 +714,7 @@ mod test {
 		let config = Config::default().with_max_age(std::time::Duration::from_secs(3));
 		let catalog = Producer::with_config(&mut broadcast, config).unwrap();
 
-		let info = catalog.track_info();
+		let info = catalog.track_info(hang::catalog::PRIORITY.video);
 		assert_eq!(info.max_age, std::time::Duration::from_secs(3));
 		assert_eq!(info.timescale, hang::container::TIMESCALE);
 
@@ -724,10 +725,10 @@ mod test {
 		// Every handle mints under the same policy, whatever order it was taken in: the codec
 		// paths hold a reservation and the container paths hold a clone.
 		assert_eq!(
-			catalog.reserve().track_info().max_age,
+			catalog.reserve().track_info(hang::catalog::PRIORITY.video).max_age,
 			std::time::Duration::from_secs(3)
 		);
-		assert_eq!(catalog.clone().track_info().max_age, std::time::Duration::from_secs(3));
+		assert_eq!(catalog.clone().track_info(hang::catalog::PRIORITY.video).max_age, std::time::Duration::from_secs(3));
 	}
 
 	#[test]

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -245,7 +245,11 @@ impl<E: CatalogExt> Producer<E> {
 		let hang_track = broadcast.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())?;
 		let hangz_track =
 			broadcast.create_track(hang::Catalog::COMPRESSED_NAME, hang::Catalog::default_track_info())?;
-		let msf_track = broadcast.create_track(moq_msf::DEFAULT_NAME, None)?;
+		// The MSF track is the same catalog in another encoding, so it takes the same
+		// priority. Leaving it at the default would rank a subscriber reading MSF
+		// below every media track on a relay's upstream leg.
+		let msf_info = moq_net::track::Info::default().with_priority(hang::catalog::PRIORITY.catalog);
+		let msf_track = broadcast.create_track(moq_msf::DEFAULT_NAME, msf_info)?;
 
 		// Disable deltas for now to stay byte-compatible with consumers that only read snapshots.
 		let mut json_config = moq_json::snapshot::ProducerConfig::default();
@@ -698,6 +702,33 @@ mod test {
 
 	use super::*;
 
+	/// The catalog, its MSF twin, and the timeline all rank above media. They're the
+	/// index a player reads before any media is useful, and they're small enough that
+	/// sitting above media can't starve it. Regression: the MSF and timeline tracks
+	/// were minted with no `Info` at all, so one broadcast advertised its hang catalog
+	/// at 100 and the same catalog in MSF at 0.
+	#[tokio::test]
+	async fn non_media_tracks_rank_above_media() {
+		use hang::catalog::PRIORITY;
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = Producer::new(&mut broadcast).unwrap();
+		// Pacing enrollment is what mints the timeline track; a passive one publishes none.
+		catalog.timeline().pacing_track("video").unwrap();
+
+		let consumer = broadcast.consume();
+		for name in [
+			hang::Catalog::DEFAULT_NAME,
+			hang::Catalog::COMPRESSED_NAME,
+			moq_msf::DEFAULT_NAME,
+			hang::timeline::DEFAULT_NAME,
+		] {
+			let track = consumer.track(name).expect("track");
+			let info = track.info().await.expect("info");
+			assert_eq!(info.priority, PRIORITY.catalog, "{name} should rank with the catalog");
+		}
+	}
+
 	#[test]
 	fn media_tracks_inherit_the_catalogs_declared_retention() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
@@ -705,7 +736,10 @@ mod test {
 		// Unset, a catalog mints hang's media defaults, sized so a segmented egress can serve a
 		// full playlist window rather than moq-net's live-edge default.
 		let catalog = Producer::new(&mut broadcast).unwrap();
-		assert_eq!(catalog.track_info(hang::catalog::PRIORITY.video).max_age, hang::container::track_info(hang::catalog::PRIORITY.video).max_age);
+		assert_eq!(
+			catalog.track_info(hang::catalog::PRIORITY.video).max_age,
+			hang::container::track_info(hang::catalog::PRIORITY.video).max_age
+		);
 		assert!(catalog.track_info(hang::catalog::PRIORITY.video).max_age > moq_net::track::DEFAULT_MAX_AGE);
 
 		// An override reaches every media track this catalog mints, and does NOT disturb the
@@ -728,7 +762,10 @@ mod test {
 			catalog.reserve().track_info(hang::catalog::PRIORITY.video).max_age,
 			std::time::Duration::from_secs(3)
 		);
-		assert_eq!(catalog.clone().track_info(hang::catalog::PRIORITY.video).max_age, std::time::Duration::from_secs(3));
+		assert_eq!(
+			catalog.clone().track_info(hang::catalog::PRIORITY.video).max_age,
+			std::time::Duration::from_secs(3)
+		);
 	}
 
 	#[test]

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -268,8 +268,8 @@ impl<E: CatalogExt> Reserved<E> {
 
 	/// Track properties for a media track under this catalog, carrying any retention it declares.
 	/// See [`Producer::track_info`](super::Producer::track_info).
-	pub fn track_info(&self) -> moq_net::track::Info {
-		self.catalog.track_info()
+	pub fn track_info(&self, priority: u8) -> moq_net::track::Info {
+		self.catalog.track_info(priority)
 	}
 
 	/// Reserve a rendition of config type `C` under `name`, returning the handle that owns it.

--- a/rs/moq-mux/src/codec/h264/export.rs
+++ b/rs/moq-mux/src/codec/h264/export.rs
@@ -275,7 +275,7 @@ mod tests {
 		// Producer side: publish the broadcast with one length-prefixed video track.
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut track = broadcast
-			.create_track("video.m4s", hang::container::track_info())
+			.create_track("video.m4s", hang::container::track_info(hang::catalog::PRIORITY.video))
 			.unwrap();
 
 		// Group 0 (keyframe-starting group): one IDR frame.

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -303,7 +303,9 @@ mod tests {
 	fn setup(name: &str) -> (moq_net::track::Producer, crate::catalog::Producer) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast.create_track(name, hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track(name, hang::container::track_info(hang::catalog::PRIORITY.video))
+			.unwrap();
 		(track, catalog)
 	}
 

--- a/rs/moq-mux/src/codec/h265/export.rs
+++ b/rs/moq-mux/src/codec/h265/export.rs
@@ -266,7 +266,7 @@ mod tests {
 		let catalog = hvc1_catalog("video.hvc1", hvcc(vps, sps, pps));
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut track = broadcast
-			.create_track("video.hvc1", hang::container::track_info())
+			.create_track("video.hvc1", hang::container::track_info(hang::catalog::PRIORITY.video))
 			.unwrap();
 
 		let mut g0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -351,7 +351,9 @@ mod tests {
 	fn setup(name: &str) -> (moq_net::track::Producer, crate::catalog::Producer) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast.create_track(name, hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track(name, hang::container::track_info(hang::catalog::PRIORITY.video))
+			.unwrap();
 		(track, catalog)
 	}
 

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -150,7 +150,9 @@ mod tests {
 	async fn a_loc_reservation_reaches_the_wire_and_the_catalog() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("audio", hang::container::track_info(hang::catalog::PRIORITY.audio))
+			.unwrap();
 		let subscriber = track.subscribe(None);
 		let reserved = catalog.reserve();
 		let config = crate::codec::opus::Config::new(48_000, 2);

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -148,7 +148,9 @@ mod tests {
 	fn setup() -> (moq_net::track::Producer, crate::catalog::Producer) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast.create_track("0.vp8", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("0.vp8", hang::container::track_info(hang::catalog::PRIORITY.video))
+			.unwrap();
 		(track, catalog)
 	}
 

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -151,7 +151,9 @@ mod tests {
 	fn setup() -> (moq_net::track::Producer, crate::catalog::Producer) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast.create_track("0.vp9", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("0.vp9", hang::container::track_info(hang::catalog::PRIORITY.video))
+			.unwrap();
 		(track, catalog)
 	}
 

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -851,7 +851,7 @@ mod tests {
 
 	#[test]
 	fn new_inherits_the_initial_subscription_latency() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let max_age = Duration::from_millis(250);
 		let subscriber = track.subscribe(moq_net::track::Subscription::default().with_max_age(max_age));
 
@@ -863,7 +863,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_single_group() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -882,7 +882,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn empty_group_declares_a_discontinuity() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(2)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -904,7 +904,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn latency_skip_preserves_empty_group_discontinuity() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(2)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -931,7 +931,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -950,7 +950,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -970,7 +970,7 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(100)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1013,7 +1013,7 @@ mod tests {
 	#[tokio::test]
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track = track.subscribe(None);
 		let mut consumer = container_max_age_only(consumer_track, Duration::ZERO);
 
@@ -1052,7 +1052,7 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track = track.subscribe(None);
 		let mut consumer = container_max_age_only(consumer_track, Duration::from_millis(100));
 
@@ -1121,7 +1121,7 @@ mod tests {
 	#[tokio::test]
 	async fn reset_keeps_out_of_order_new_group() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(10)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1161,7 +1161,7 @@ mod tests {
 	#[tokio::test]
 	async fn reset_detected_behind_forward_newest_group() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(10)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1197,7 +1197,7 @@ mod tests {
 	#[tokio::test]
 	async fn backwards_timestamp_resets_buffer() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(10)));
 		// Large max age so the slow-group skip never fires; isolate the rewind path.
@@ -1224,7 +1224,7 @@ mod tests {
 	/// configuration. Here group 2 rewinds the timeline and bumps the discontinuity counter.
 	#[tokio::test]
 	async fn backwards_timestamp_always_resets() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(10)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1260,7 +1260,7 @@ mod tests {
 	/// last (a group's end) -- and a publisher emitting them must not break us.
 	#[tokio::test]
 	async fn empty_payload_is_skipped() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1288,7 +1288,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn leading_marker_preserves_the_first_media_keyframe() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1319,7 +1319,7 @@ mod tests {
 	/// read, so a stall or an infinite loop fails this rather than hanging forever.
 	#[tokio::test]
 	async fn consecutive_markers_do_not_stall() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1353,7 +1353,7 @@ mod tests {
 	#[tokio::test]
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1390,7 +1390,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1409,7 +1409,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn bframes_within_group() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1429,7 +1429,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1448,7 +1448,7 @@ mod tests {
 	#[tokio::test]
 	async fn track_closed_with_error() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1472,7 +1472,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(100)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1491,7 +1491,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(80)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1515,7 +1515,7 @@ mod tests {
 	/// group + the sequences after it evict, then it resumes).
 	#[tokio::test]
 	async fn evicted_group_with_gap_skips_to_live() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(100)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1559,7 +1559,7 @@ mod tests {
 	/// higher group is buffered, and the track never finishes.
 	#[tokio::test]
 	async fn missing_sequence_skips_on_live_track() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(100)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1659,7 +1659,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1680,7 +1680,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn frame_payload_preserved() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1719,7 +1719,7 @@ mod tests {
 	#[tokio::test]
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(10)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1766,7 +1766,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn large_timestamps() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(3700)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1783,7 +1783,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn set_max_age_changes_behavior() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(10)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1802,7 +1802,7 @@ mod tests {
 	#[tokio::test]
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(110)));
 		// max age must exceed (group1_max - group0_min) = 100ms - 0ms = 100ms
@@ -1855,7 +1855,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(100)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1909,7 +1909,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1933,7 +1933,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1948,7 +1948,7 @@ mod tests {
 	#[tokio::test]
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(50)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -1985,7 +1985,7 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(100)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -2024,7 +2024,7 @@ mod tests {
 	#[tokio::test]
 	async fn single_newer_group_triggers_skip() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track = track.subscribe(None);
 		let mut consumer = container_max_age_only(consumer_track, Duration::from_millis(100));
 
@@ -2062,7 +2062,7 @@ mod tests {
 	#[tokio::test]
 	async fn single_missing_sequence_near_eof_skips() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track = track.subscribe(None);
 		let mut consumer = container_max_age_only(consumer_track, Duration::from_millis(100));
 
@@ -2078,7 +2078,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -2096,7 +2096,7 @@ mod tests {
 	#[tokio::test]
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -2126,7 +2126,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn empty_group_advances() {
-		let mut track = track_producer("test", hang::container::track_info());
+		let mut track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);
@@ -2147,7 +2147,7 @@ mod tests {
 	async fn video_container_legacy() {
 		tokio::time::pause();
 
-		let mut track = track_producer("video", hang::container::track_info());
+		let mut track = track_producer("video", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer_track =
 			track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_millis(500)));
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy);

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -549,7 +549,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			old.track.finish()?;
 			self.catalog.lock().video.renditions.remove(old.track.name());
 		}
-		Ok(self.broadcast.unique_track(".flv-v", self.catalog.track_info())?)
+		Ok(self
+			.broadcast
+			.unique_track(".flv-v", self.catalog.track_info(hang::catalog::PRIORITY.video))?)
 	}
 
 	/// Drop any existing audio track `track_id` (finishing it and clearing its
@@ -559,7 +561,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			old.track.finish()?;
 			self.catalog.lock().audio.renditions.remove(old.track.name());
 		}
-		Ok(self.broadcast.unique_track(".flv-a", self.catalog.track_info())?)
+		Ok(self
+			.broadcast
+			.unique_track(".flv-a", self.catalog.track_info(hang::catalog::PRIORITY.audio))?)
 	}
 
 	/// Close the current group on every track and reopen at `sequence`.

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -97,6 +97,17 @@ enum TrackKind {
 	Audio,
 }
 
+impl TrackKind {
+	/// The publisher priority for this kind of media, so audio isn't stuck behind a
+	/// video backlog on a busy connection.
+	fn priority(&self) -> u8 {
+		match self {
+			Self::Video => hang::catalog::PRIORITY.video,
+			Self::Audio => hang::catalog::PRIORITY.audio,
+		}
+	}
+}
+
 struct Fmp4Track {
 	kind: TrackKind,
 
@@ -298,7 +309,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 			let track = self.broadcast.create_track(
 				self.broadcast.unique_name(suffix),
-				self.catalog.track_info().with_timescale(timescale),
+				self.catalog.track_info(kind.priority()).with_timescale(timescale),
 			)?;
 
 			// Enroll every track in the broadcast's timeline: passthrough writes groups by hand

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -67,6 +67,17 @@ enum TrackKind {
 	Audio,
 }
 
+impl TrackKind {
+	/// The publisher priority for this kind of media, so audio isn't stuck behind a
+	/// video backlog on a busy connection.
+	fn priority(&self) -> u8 {
+		match self {
+			Self::Video => hang::catalog::PRIORITY.video,
+			Self::Audio => hang::catalog::PRIORITY.audio,
+		}
+	}
+}
+
 struct MkvTrack {
 	kind: TrackKind,
 	track: crate::container::Producer<crate::catalog::hang::Container>,
@@ -282,9 +293,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			}
 		};
 
-		let track = self
-			.broadcast
-			.create_track(self.broadcast.unique_name(suffix), self.catalog.track_info())?;
+		let track = self.broadcast.create_track(
+			self.broadcast.unique_name(suffix),
+			self.catalog.track_info(kind.priority()),
+		)?;
 		let name = track.name().to_string();
 
 		// Build the media producer before publishing the rendition. It is fallible (its

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -431,7 +431,7 @@ mod tests {
 	/// by hand, it just hands `estimate()` to its rendition.
 	#[tokio::test]
 	async fn writes_measure_the_catalog_estimate() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		// 25ms frames of 5 kB, a keyframe every 10, over more than the bitrate window.
@@ -450,7 +450,7 @@ mod tests {
 	/// Dropping it there instead would leave an audio track's bitrate permanently undetectable.
 	#[tokio::test]
 	async fn per_frame_groups_still_measure_bitrate() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		// 40ms packets of 5 kB: 1 Mbps.
@@ -467,7 +467,7 @@ mod tests {
 	/// reset a paused publisher would advertise the whole gap as the buffer a player must hold.
 	#[tokio::test]
 	async fn discontinuity_is_not_measured_across() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		producer.write(sized_frame(0, true, 5_000)).unwrap();
@@ -509,7 +509,7 @@ mod tests {
 	/// inflated bitrate on the catalog permanently.
 	#[tokio::test]
 	async fn a_rejected_frame_is_not_measured() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let mut producer = Producer::new(track, RejectAt(40_000));
 
 		// 40ms frames of 5 kB (1 Mbps), except one 500 kB frame the container turns away.
@@ -525,7 +525,7 @@ mod tests {
 	/// Reorder delay is the one input the writes can't reveal, since frames carry no decode time.
 	#[tokio::test]
 	async fn reorder_raises_the_measured_jitter() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		producer.write(frame(0, true)).unwrap();
@@ -560,7 +560,7 @@ mod tests {
 		// The resumed clock jumps forty minutes, so both the retention window and the
 		// drift budget have to cover it or the pre-discontinuity group reads as ancient.
 		let discontinuity_max_age = std::time::Duration::from_secs(41 * 60);
-		let info = hang::container::track_info().with_max_age(discontinuity_max_age);
+		let info = hang::container::track_info(hang::catalog::PRIORITY.video).with_max_age(discontinuity_max_age);
 		let track = track_producer("test", info);
 		let consumer = track.subscribe(moq_net::track::Subscription::default().with_max_age(discontinuity_max_age));
 		let mut producer = Producer::new(track, Container::Legacy);
@@ -581,7 +581,7 @@ mod tests {
 	/// 40-minute-stale frame reached a VOD recording in moq-dev/moq.pro#814.
 	#[tokio::test]
 	async fn discontinuity_moves_the_live_edge_off_stale_content() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		producer.write(frame(0, true)).unwrap();
@@ -597,7 +597,7 @@ mod tests {
 	/// Explicit keyframe closes the current group and starts a new one.
 	#[tokio::test]
 	async fn keyframe_closes_group_immediately() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer = track.subscribe(replay());
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -616,7 +616,7 @@ mod tests {
 	/// per audio packet" storm.
 	#[tokio::test]
 	async fn needs_keyframe_drives_audio_grouping() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer = track.subscribe(replay());
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -640,7 +640,7 @@ mod tests {
 	/// `cut()` flushes the current group immediately; the next write must be a keyframe.
 	#[tokio::test]
 	async fn cut_closes_immediately() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer = track.subscribe(replay());
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -658,7 +658,7 @@ mod tests {
 	#[tokio::test]
 	#[allow(deprecated)]
 	async fn deprecated_finish_group_still_closes() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer = track.subscribe(replay());
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -674,7 +674,7 @@ mod tests {
 	/// Writing a non-keyframe with no open group returns MissingKeyframe.
 	#[test]
 	fn first_frame_must_be_keyframe() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		let err = producer.write(frame(0, false)).unwrap_err();
@@ -693,7 +693,7 @@ mod tests {
 	/// `seek(n)` opens the next group at sequence `n`.
 	#[tokio::test]
 	async fn seek_uses_explicit_sequence() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer = track.subscribe(replay());
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -708,7 +708,7 @@ mod tests {
 	/// `seek` is consumed on the next group creation; subsequent groups auto-increment from there.
 	#[tokio::test]
 	async fn seek_clears_pending_after_use() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let consumer = track.subscribe(replay());
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -746,7 +746,7 @@ mod tests {
 	/// group's last frame, without buffering an extra frame.
 	#[tokio::test]
 	async fn keyframe_backfills_batched_durations() {
-		let track = track_producer("test", hang::container::track_info());
+		let track = track_producer("test", hang::container::track_info(hang::catalog::PRIORITY.video));
 		let recording = Recording::default();
 		let mut producer = Producer::new(track, recording.clone()).with_buffer(std::time::Duration::from_secs(10));
 

--- a/rs/moq-mux/src/container/test_util.rs
+++ b/rs/moq-mux/src/container/test_util.rs
@@ -20,7 +20,10 @@ impl Live {
 		let consumer = broadcast.consume();
 		let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let track = broadcast
-			.create_track(broadcast.unique_name(name), hang::container::track_info())
+			.create_track(
+				broadcast.unique_name(name),
+				hang::container::track_info(hang::catalog::PRIORITY.video),
+			)
 			.unwrap();
 		insert(&mut catalog, track.name().to_string());
 		Self {

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -108,7 +108,10 @@ async fn export_aac_roundtrip() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(broadcast.unique_name(".aac"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".aac"),
+			hang::container::track_info(hang::catalog::PRIORITY.audio),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -221,7 +224,10 @@ async fn export_lead_audio() -> BytesMut {
 
 	// In-band avc3 video (SPS/PPS inline on keyframes; no out-of-band description).
 	let vtrack = broadcast
-		.create_track(broadcast.unique_name(".avc3"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc3"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	{
 		let mut cfg = VideoConfig::new(H264 {
@@ -236,7 +242,10 @@ async fn export_lead_audio() -> BytesMut {
 	let mut video = Producer::new(vtrack, HangContainer::Legacy);
 
 	let atrack = broadcast
-		.create_track(broadcast.unique_name(".aac"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".aac"),
+			hang::container::track_info(hang::catalog::PRIORITY.audio),
+		)
 		.unwrap();
 	{
 		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
@@ -355,7 +364,10 @@ async fn export_avc3_in_band_reassembles() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc3"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc3"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -403,7 +415,10 @@ async fn export_avc3_preserves_multiple_pps() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc3"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc3"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -453,7 +468,10 @@ async fn export_avc1_out_of_band_reassembles() {
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc1"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -632,7 +650,10 @@ async fn export_pcr_wraps_below_the_reserve_at_start() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(broadcast.unique_name(".aac"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".aac"),
+			hang::container::track_info(hang::catalog::PRIORITY.audio),
+		)
 		.unwrap();
 	{
 		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
@@ -711,7 +732,9 @@ async fn export_pcr_respects_every_renditions_reserve() {
 
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 	let mut make = |name: &str, jitter: Option<Duration>| {
-		let track = broadcast.create_track(name, hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track(name, hang::container::track_info(hang::catalog::PRIORITY.video))
+			.unwrap();
 		let mut cfg = VideoConfig::new(H264 {
 			profile: 0x42,
 			constraints: 0xc0,
@@ -782,7 +805,10 @@ async fn export_pcr_backfills_a_coarse_cadence() {
 
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc1"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	{
 		let mut cfg = VideoConfig::new(H264 {
@@ -850,7 +876,7 @@ async fn export_scte35_roundtrip() {
 	// `Import` (which consumes it); the producer stays alive so the exporter can
 	// subscribe to the retained track.
 	let scte = broadcast
-		.unique_track(".scte35", hang::container::track_info())
+		.unique_track(".scte35", hang::container::track_info(hang::catalog::PRIORITY.video))
 		.unwrap();
 	let scte_name = scte.name().to_string();
 	{
@@ -967,7 +993,9 @@ async fn export_pes_verbatim_roundtrip() {
 
 	// Build the verbatim PES track BEFORE moving `broadcast` into `Import`; the
 	// producer stays alive so the exporter can subscribe to the retained track.
-	let data_track = broadcast.unique_track(".data", hang::container::track_info()).unwrap();
+	let data_track = broadcast
+		.unique_track(".data", hang::container::track_info(hang::catalog::PRIORITY.video))
+		.unwrap();
 	let data_name = data_track.name().to_string();
 	{
 		let mut verbatim = tscat::Verbatim::new(0x06, tscat::Framing::Pes);
@@ -1058,7 +1086,7 @@ async fn scte35_without_video_export_is_rejected() {
 
 	// A SCTE-35 cue track and nothing else.
 	let scte = broadcast
-		.unique_track(".scte35", hang::container::track_info())
+		.unique_track(".scte35", hang::container::track_info(hang::catalog::PRIORITY.video))
 		.unwrap();
 	let scte_name = scte.name().to_string();
 	{
@@ -1859,7 +1887,10 @@ async fn si_pids_are_re_emitted_on_their_own_interval() {
 
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc1"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 
@@ -2247,7 +2278,10 @@ async fn stale_si_entry_does_not_block_output() {
 
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc1"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -2348,7 +2382,10 @@ async fn export_opus_roundtrip() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(broadcast.unique_name(".opus"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".opus"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -2425,7 +2462,10 @@ async fn opus_export_import_roundtrip() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(broadcast.unique_name(".opus"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".opus"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -2718,7 +2758,10 @@ async fn repointed_si_entry_resubscribes() {
 
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc1"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -2827,7 +2870,10 @@ async fn si_revision_after_final_media_frame_is_flushed() {
 
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc1"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -2927,7 +2973,10 @@ async fn si_cadence_rig(pid: u16, table_id: u8, interval: Duration) -> SiCadence
 
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 	let track = broadcast
-		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.create_track(
+			broadcast.unique_name(".avc1"),
+			hang::container::track_info(hang::catalog::PRIORITY.video),
+		)
 		.unwrap();
 	let name = track.name().to_string();
 	{

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -2546,7 +2546,10 @@ async fn export_twice(with_video: bool) -> (Vec<Frame>, Vec<Frame>) {
 
 	let mut video = with_video.then(|| {
 		let track = broadcast
-			.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+			.create_track(
+				broadcast.unique_name(".avc1"),
+				hang::container::track_info(hang::catalog::PRIORITY.video),
+			)
 			.unwrap();
 		// Out-of-band parameter sets (avc1), so the export source takes the catalog
 		// description as-is instead of parsing them out of the bitstream.
@@ -2565,7 +2568,10 @@ async fn export_twice(with_video: bool) -> (Vec<Frame>, Vec<Frame>) {
 
 	let mut audio = {
 		let track = broadcast
-			.create_track(broadcast.unique_name(".aac"), hang::container::track_info())
+			.create_track(
+				broadcast.unique_name(".aac"),
+				hang::container::track_info(hang::catalog::PRIORITY.audio),
+			)
 			.unwrap();
 		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
 		cfg.container = Container::Legacy;

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -405,7 +405,9 @@ impl<E: catalog::Catalog> Import<E> {
 
 		let stream = match stream_type {
 			StreamType::H264 => {
-				let track = self.broadcast.unique_track(".avc3", self.catalog.track_info())?;
+				let track = self
+					.broadcast
+					.unique_track(".avc3", self.catalog.track_info(hang::catalog::PRIORITY.video))?;
 				Stream::H264 {
 					split: h264::Split::new(),
 					import: Box::new(h264::Import::new(track, self.reserve(), self.video_hint())?),
@@ -413,7 +415,9 @@ impl<E: catalog::Catalog> Import<E> {
 				}
 			}
 			StreamType::H265 => {
-				let track = self.broadcast.unique_track(".hev1", self.catalog.track_info())?;
+				let track = self
+					.broadcast
+					.unique_track(".hev1", self.catalog.track_info(hang::catalog::PRIORITY.video))?;
 				Stream::H265 {
 					split: h265::Split::new(),
 					import: Box::new(h265::Import::new(track, self.reserve(), self.video_hint())?),
@@ -444,7 +448,9 @@ impl<E: catalog::Catalog> Import<E> {
 			// come from the descriptors, so the importer is built up front.
 			StreamType::Mpeg2PacketizedData if registration_format(descriptors) == Some(*b"Opus") => {
 				let channel_count = opus_channel_count(descriptors).unwrap_or(2);
-				let track = self.broadcast.unique_track(".opus", self.catalog.track_info())?;
+				let track = self
+					.broadcast
+					.unique_track(".opus", self.catalog.track_info(hang::catalog::PRIORITY.audio))?;
 				let config = opus::Config::new(48_000, channel_count);
 				let mut config: hang::catalog::AudioConfig = config.into();
 				config.container = self.container.clone();
@@ -803,7 +809,12 @@ fn register_verbatim<E: catalog::Catalog>(
 	// Verbatim payloads ride the legacy container, which normalizes the per-frame
 	// timestamp to microseconds on the wire (see `hang::container::Frame::encode`),
 	// so the track declares that timescale to match.
-	let track = broadcast.unique_track(".ts", catalog.track_info())?;
+	//
+	// Priority follows text rather than the media tiers: an undecoded elementary
+	// stream (SCTE-35 cues, teletext, DVB subtitles) is tiny and timing-critical, so
+	// it should never queue behind a media backlog, and it's too small to starve
+	// anything by sitting above one.
+	let track = broadcast.unique_track(".ts", catalog.track_info(hang::catalog::PRIORITY.text))?;
 	let name = track.name().to_string();
 
 	// Build the media producer before advertising the track. It is fallible (its
@@ -1736,7 +1747,9 @@ impl<E: CatalogExt> AacStream<E> {
 					// The importer synthesizes the AudioSpecificConfig `description` from the config so
 					// out-of-band consumers (fMP4/MKV export, WebCodecs) can configure the decoder.
 					let reserved = self.reserved.take().expect("aac reservation already consumed");
-					let track = self.broadcast.unique_track(".aac", reserved.track_info())?;
+					let track = self
+						.broadcast
+						.unique_track(".aac", reserved.track_info(hang::catalog::PRIORITY.audio))?;
 					let mut config: hang::catalog::AudioConfig = config.into();
 					config.container = self.container.clone();
 					let aac = aac::Import::new(track, reserved, config)?;
@@ -2159,9 +2172,10 @@ impl<E: CatalogExt> LegacyStream<E> {
 					// Consume the reservation held since the PMT: this resolves the gated rendition,
 					// and carries the catalog's declared media retention onto the track.
 					let reserved = self.reserved.take().expect("legacy reservation already consumed");
-					let track = self
-						.broadcast
-						.unique_track(self.descriptor.track_suffix, reserved.track_info())?;
+					let track = self.broadcast.unique_track(
+						self.descriptor.track_suffix,
+						reserved.track_info(hang::catalog::PRIORITY.audio),
+					)?;
 					let legacy = legacy::Import::new(self.descriptor, track, reserved, config)?;
 					self.import.insert(legacy)
 				}

--- a/rs/moq-mux/src/import/mod.rs
+++ b/rs/moq-mux/src/import/mod.rs
@@ -37,5 +37,5 @@ pub fn unique_track(
 	broadcast: &mut moq_net::broadcast::Producer,
 	suffix: &str,
 ) -> crate::Result<moq_net::track::Producer> {
-	Ok(broadcast.unique_track(suffix, hang::container::track_info())?)
+	Ok(broadcast.unique_track(suffix, hang::container::track_info(0))?)
 }

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -199,7 +199,7 @@ impl<E: CatalogExt> Track<E> {
 	) -> Result<Self> {
 		// Accept at the legacy microsecond timescale, matching the frame timestamps the container
 		// stamps. A codec-specific timescale (e.g. the opus sample rate) would be chosen here.
-		let track = request.accept(reserved.track_info());
+		let track = request.accept(reserved.track_info(hang::catalog::PRIORITY.audio));
 		let data = init.data.as_ref();
 		let kind = match init.format {
 			AudioFormat::Aac => {
@@ -236,7 +236,7 @@ impl<E: CatalogExt> Track<E> {
 	) -> Result<Self> {
 		use hang::catalog::VideoCodec;
 
-		let track = request.accept(reserved.track_info());
+		let track = request.accept(reserved.track_info(hang::catalog::PRIORITY.video));
 		let data = init.data.as_ref();
 		let kind = match init.format {
 			VideoFormat::Avc1 => {
@@ -561,7 +561,7 @@ impl<E: CatalogExt> TrackStream<E> {
 		reserved: crate::catalog::Reserved<E>,
 		init: VideoInit,
 	) -> Result<Self> {
-		let track = request.accept(reserved.track_info());
+		let track = request.accept(reserved.track_info(hang::catalog::PRIORITY.video));
 		let hint = video_hint(&init, None);
 		// Only the self-delimiting codecs can be recovered from a raw byte stream.
 		let kind = match init.format {
@@ -891,7 +891,9 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn opus_import_delivers_frames() {
 		let (mut broadcast, catalog) = new_broadcast();
-		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("audio", hang::container::track_info(hang::catalog::PRIORITY.audio))
+			.unwrap();
 		let subscriber = track.subscribe(None);
 
 		let config = crate::codec::opus::Config::new(48_000, 2);
@@ -933,7 +935,9 @@ mod tests {
 		broadcast: &mut moq_net::broadcast::Producer,
 		catalog: &crate::catalog::Producer,
 	) -> (crate::codec::opus::Import, moq_net::track::Subscriber) {
-		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
+		let track = broadcast
+			.create_track("audio", hang::container::track_info(hang::catalog::PRIORITY.audio))
+			.unwrap();
 		// Every group is written before anything reads, which the default
 		// REAL_TIME budget would collapse to the live edge.
 		let subscriber = track.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(30)));

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -1095,6 +1095,33 @@ mod tests {
 		assert_eq!(audio.channel_count, 2);
 	}
 
+	/// Each constructor stamps its own kind's priority, so an audio track never goes
+	/// out at the video priority and queues behind a video backlog.
+	#[tokio::test(start_paused = true)]
+	async fn each_kind_ranks_as_itself() {
+		use hang::catalog::PRIORITY;
+
+		let (mut broadcast, catalog) = new_broadcast();
+		let consumer = broadcast.consume();
+
+		let request = broadcast.reserve_track("audio").unwrap();
+		let _audio = Track::audio(
+			request,
+			catalog.reserve(),
+			AudioInit::new(AudioFormat::Opus, opus_head()),
+		)
+		.unwrap();
+
+		let request = broadcast.reserve_track("video").unwrap();
+		let _video = Track::video(request, catalog.reserve(), VideoInit::new(VideoFormat::Vp8, Vec::new())).unwrap();
+
+		let audio = consumer.track("audio").unwrap().info().await.unwrap();
+		assert_eq!(audio.priority, PRIORITY.audio);
+
+		let video = consumer.track("video").unwrap().info().await.unwrap();
+		assert_eq!(video.priority, PRIORITY.video);
+	}
+
 	/// An audio format with no init bytes errors up front (audio can't resolve its config from frames),
 	/// rather than registering a track that never publishes.
 	#[tokio::test(start_paused = true)]

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -546,7 +546,11 @@ impl Producer {
 	/// Create the timeline track when the first pacing track enrolls.
 	fn prepare_pacing(&self, state: &mut State) -> crate::Result<()> {
 		if state.sink.is_none() && state.overrun.is_none() {
-			let net = state.broadcast.create_track(DEFAULT_NAME, None)?;
+			// Catalog priority, like the catalog tracks: the timeline is the index a
+			// player reads before any media is useful to it, and it is far too small
+			// to starve the media it indexes by sitting above it.
+			let info = moq_net::track::Info::default().with_priority(hang::catalog::PRIORITY.catalog);
+			let net = state.broadcast.create_track(DEFAULT_NAME, info)?;
 			let config = moq_json::stream::ProducerConfig::default().with_compression(true);
 			state.sink = Some(moq_json::stream::Producer::new(net, config));
 		}

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1162,10 +1162,16 @@ mod tests {
 			.unwrap();
 
 		let mut bandwidth = session.send_bandwidth().expect("backend reports an estimate");
-		assert_eq!(bandwidth.changed().await.unwrap(), Some(1_000_000));
+		assert_eq!(
+			bandwidth.changed().await.unwrap(),
+			Some(crate::bandwidth::Rate::from_bps(1_000_000))
+		);
 
 		// A later change is picked up by the next interval tick.
 		fake.set_send_rate(Some(2_000_000));
-		assert_eq!(bandwidth.changed().await.unwrap(), Some(2_000_000));
+		assert_eq!(
+			bandwidth.changed().await.unwrap(),
+			Some(crate::bandwidth::Rate::from_bps(2_000_000))
+		);
 	}
 }

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1457,7 +1457,10 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 						track_alias: self.request_id.0,
 						group_id: sequence,
 						sub_group_id: 0,
-						publisher_priority: 0,
+						// The publisher's own ranking of its tracks, which is what a relay
+						// prefers when it can't pick between its subscribers' priorities. The
+						// model ranks higher-first and this wire field lower-first.
+						publisher_priority: super::priority::to_wire(self.track.info().priority),
 						// Carry per-object timestamps as extension headers (the Timestamp
 						// Object Property) so moq-transport peers get the real PTS. The
 						// units are the track's, declared once in SUBSCRIBE_OK.
@@ -1698,6 +1701,8 @@ struct NamespaceRequest<S: crate::transport::poll::Session> {
 #[cfg(test)]
 mod group_priority_test {
 	use super::*;
+	use crate::coding::Decode;
+	use crate::ietf::priority;
 	use crate::lite::test_transport::SinkSession;
 
 	/// The model's `Subscription::priority` is higher-first ("higher values preempt
@@ -1741,6 +1746,51 @@ mod group_priority_test {
 			vec![200],
 			"model priority must pass through unchanged"
 		);
+	}
+
+	/// The publisher's own ranking of its tracks (`track::Info::priority`) is what a relay
+	/// prefers when it has no subscriber preference to go on, so it has to reach the wire.
+	/// It went out as a flat 0 before, which put catalog, audio, and video in one tier for
+	/// every moq-transport peer.
+	#[tokio::test]
+	async fn group_header_carries_the_publisher_priority() {
+		let log = crate::lite::test_transport::Log::default();
+		let session = SinkSession::new(log.clone());
+
+		let info = track::Info::default().with_priority(hang_audio_priority());
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", info);
+		let subscriber = track.subscribe(None);
+
+		let mut group = track.append_group().unwrap();
+		group.write_frame(crate::Timestamp::ZERO, b"hello".as_slice()).unwrap();
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		let mut serve = TrackServe::new(session, subscriber, RequestId(0), Version::Draft14);
+		kio::wait(|waiter| serve.poll(waiter)).await.unwrap();
+
+		let written = log.writes.lock().unwrap().clone();
+		let mut buf = bytes::Bytes::from(written);
+		let header = ietf::GroupHeader::decode(&mut buf, Version::Draft14).expect("a group header");
+		assert_eq!(
+			header.publisher_priority,
+			priority::to_wire(hang_audio_priority()),
+			"the wire is lower-first, so audio must encode below video"
+		);
+		assert!(
+			priority::to_wire(hang_audio_priority()) < priority::to_wire(hang_video_priority()),
+			"audio outranks video on the wire"
+		);
+	}
+
+	/// `hang::catalog::PRIORITY` isn't reachable from `moq-net` (hang depends on it, not the
+	/// other way round), so the two ranks it publishes audio and video at are spelled here.
+	fn hang_audio_priority() -> u8 {
+		80
+	}
+
+	fn hang_video_priority() -> u8 {
+		60
 	}
 
 	/// A subgroup waiting for stream credit keeps its subscription expiry armed.

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1053,7 +1053,7 @@ impl<S: crate::transport::poll::Session> ProbeStream<S> {
 						let Some(probe) = ready!(stream.reader.poll_decode_maybe::<lite::Probe>(&mut cx))? else {
 							return Poll::Ready(Ok(()));
 						};
-						bandwidth.set(probe.bitrate)?;
+						bandwidth.set(probe.bitrate.map(bandwidth::Rate::from_bps))?;
 					}
 				}
 			}

--- a/rs/moq-net/src/model/bandwidth.rs
+++ b/rs/moq-net/src/model/bandwidth.rs
@@ -1,4 +1,4 @@
-//! Bandwidth estimation, split into a [Producer] and [Consumer] handle.
+//! Rate estimation, split into a [Producer] and [Consumer] handle.
 //!
 //! A [Producer] is used to set the current estimated bitrate, notifying consumers.
 //! A [Consumer] can read the current estimate and wait for changes.
@@ -8,14 +8,69 @@
 //! *follows* its share is policy and lives with the sender: see
 //! `moq_video::encode::rate` for the encoder's.
 
-use std::sync::Arc;
 use std::task::Poll;
 
 use crate::{Error, Result, track};
 
+/// A rate, in bits per second.
+///
+/// A newtype rather than a bare integer because everything that meets in an
+/// [`Allocator`] is the same quantity measured the same way: a congestion
+/// controller's estimate, a track's reservation, an encoder's ceiling. One of them
+/// reading bytes per second, or kilobits, is off by a factor of eight or a thousand
+/// and still typechecks, which is the kind of wrong that reaches production.
+///
+/// Named for what it measures rather than for the module: `Session::stats` has called
+/// this quantity a rate all along (`estimated_send_rate`).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Rate(u64);
+
+impl Rate {
+	/// No bandwidth at all.
+	pub const ZERO: Self = Self(0);
+
+	/// A rate in bits per second, the unit every wire and codec API here uses.
+	pub const fn from_bps(bps: u64) -> Self {
+		Self(bps)
+	}
+
+	/// A rate in kilobits (1000 bits) per second, saturating.
+	pub const fn from_kbps(kbps: u64) -> Self {
+		Self(kbps.saturating_mul(1_000))
+	}
+
+	/// A rate in megabits (1000 kilobits) per second, saturating.
+	pub const fn from_mbps(mbps: u64) -> Self {
+		Self(mbps.saturating_mul(1_000_000))
+	}
+
+	/// This rate in bits per second, for handing to a codec or FFI that wants a plain integer.
+	pub const fn as_bps(self) -> u64 {
+		self.0
+	}
+
+	/// This rate scaled by `factor`, saturating at both ends.
+	///
+	/// For the fractional arithmetic rate control does (a ramp allowance, a hysteresis
+	/// band) without spreading `as` casts across the callers.
+	pub fn scaled(self, factor: f64) -> Self {
+		let scaled = self.0 as f64 * factor.max(0.0);
+		if scaled >= u64::MAX as f64 {
+			Self(u64::MAX)
+		} else {
+			Self(scaled as u64)
+		}
+	}
+
+	/// The absolute difference between two rates.
+	pub const fn abs_diff(self, other: Self) -> Self {
+		Self(self.0.abs_diff(other.0))
+	}
+}
+
 #[derive(Default)]
 struct State {
-	bitrate: Option<u64>,
+	bitrate: Option<Rate>,
 	abort: Option<Error>,
 }
 
@@ -33,8 +88,8 @@ impl Producer {
 		}
 	}
 
-	/// Set the current bandwidth estimate in bits per second.
-	pub fn set(&self, bitrate: Option<u64>) -> Result<()> {
+	/// Set the current bandwidth estimate, or `None` while the backend has none.
+	pub fn set(&self, bitrate: Option<Rate>) -> Result<()> {
 		let mut state = self.modify()?;
 		if state.bitrate != bitrate {
 			state.bitrate = bitrate;
@@ -121,7 +176,7 @@ impl Default for Producer {
 ///
 /// Advisory, not enforced. A track that ignores its slice, or can't follow it at
 /// all (PCM audio has a fixed bitrate), still sends what it sends; the transport
-/// sheds the excess by dropping groups. Bandwidth estimation isn't exact enough
+/// sheds the excess by dropping groups. Rate estimation isn't exact enough
 /// for the difference to be worth policing.
 ///
 /// Clones share one registry, so hand a clone to each sender.
@@ -141,7 +196,23 @@ impl Allocator {
 		}
 	}
 
-	/// Reserve up to `max` bits per second for `track`, returning that track's slice.
+	/// An allocator with nothing to divide, so every reservation reports `None`.
+	///
+	/// `None` already means "no opinion, hold your rate" to a sender, so this is what
+	/// a transport with no congestion estimate, a local file, or a test harness wants,
+	/// and it saves every config struct on the way down from being an `Option`. It is
+	/// also [`Default`], so a config that never sets one encodes at its configured rate.
+	pub fn unlimited() -> Self {
+		Self {
+			estimate: Consumer {
+				inner: Inner::Unavailable,
+				last: None,
+			},
+			registry: kio::Producer::default(),
+		}
+	}
+
+	/// Reserve up to `max` for `track`, returning the reservation.
 	///
 	/// `max` is a ceiling, not a measurement: reserve the most the track can ever
 	/// send, not what it happens to be sending. A VBR encoder sitting on a black
@@ -165,16 +236,16 @@ impl Allocator {
 	/// `priority` at its default today: one tier of audio and video still serves
 	/// audio's small reservation in full before video takes the remainder.
 	///
-	/// The returned [`Consumer`] reports `None` while nothing is subscribed to the
-	/// track or the connection has no estimate, which tells a sender to hold its
-	/// current rate rather than to encode at zero. The reservation lasts as long as
-	/// that consumer (and any clone of it), and is released when the track closes
-	/// either way: a [`track::Demand`] is a weak handle, so registering one never
-	/// keeps a track alive.
+	/// The reservation lasts as long as the returned [`Reservation`]: hold it for as
+	/// long as the sender is publishing, change the ceiling with
+	/// [`update`](Reservation::update), and drop it to hand the room back. It is
+	/// released when the track closes either way, since a [`track::Demand`] is a weak
+	/// handle and reserving never keeps a track alive.
 	///
-	/// Registering the same track again claims a second reservation, so a sender
-	/// whose ceiling changed must drop the old share before taking a new one.
-	pub fn register(&self, track: &track::Demand, max: u64) -> Consumer {
+	/// Read the current slice through [`Reservation::consumer`], which reports `None`
+	/// while nothing is subscribed to the track or the connection has no estimate.
+	/// That tells a sender to hold its current rate rather than encode at zero.
+	pub fn reserve(&self, track: &track::Demand, max: Rate) -> Reservation {
 		// Read the track before taking the registry lock, so the two are never held
 		// at once and there's no order to get wrong.
 		let priority = track.priority();
@@ -201,17 +272,91 @@ impl Allocator {
 			id
 		};
 
-		Consumer {
-			inner: Inner::Share(Box::new(Share {
+		Reservation {
+			share: Share {
 				estimate: self.estimate.clone(),
 				registry: self.registry.consume(),
-				registration: Arc::new(Registration {
-					registry: self.registry.downgrade(),
-					id,
-				}),
-			})),
+				id,
+			},
+			registry: self.registry.downgrade(),
+		}
+	}
+}
+
+/// One track's standing claim on an [`Allocator`], held for as long as the sender
+/// that took it is publishing.
+///
+/// Separate from the [`Consumer`] that reads the slice, because the two have opposite
+/// lifetimes: read handles are cloned around and dropped freely, while the claim itself
+/// has to outlive every one of them or the sender silently stops claiming anything.
+#[must_use = "a dropped Reservation is released, so the sender claims nothing and its siblings take the room"]
+pub struct Reservation {
+	share: Share,
+	/// Weak so a reservation can't keep the registry alive: one outliving every
+	/// [`Allocator`] reports the estimate as gone rather than holding the channel open.
+	registry: kio::Weak<Registry>,
+}
+
+impl Reservation {
+	/// This reservation's slice right now.
+	///
+	/// Stateless, unlike [`Consumer::changed`], which carries a cursor over what it last
+	/// reported and so needs a handle of its own.
+	pub fn peek(&self) -> Option<Rate> {
+		self.share.grant()
+	}
+
+	/// A handle reading this reservation's current slice of the estimate.
+	///
+	/// Cloneable and independent of the reservation: once the reservation is dropped
+	/// these report `None`, the same "hold your rate" a track nobody is watching reports.
+	pub fn consumer(&self) -> Consumer {
+		Consumer {
+			inner: Inner::Share(Box::new(self.share.clone())),
 			last: None,
 		}
+	}
+
+	/// Change the ceiling, keeping the same claim.
+	///
+	/// For a sender whose ceiling genuinely moved: an encoder reopening at a resolution
+	/// it negotiated with the device, not an encoder observing its own output. A
+	/// reservation that followed the rate a VBR source happens to be sending would hand
+	/// the room away every time the picture went still, and not have it back when the
+	/// picture moved again.
+	///
+	/// Does nothing once every [`Allocator`] is gone, since there is then nothing left
+	/// dividing anything; a reader learns that from its [`consumer`](Self::consumer).
+	pub fn update(&self, max: Rate) {
+		let Some(registry) = self.registry.upgrade() else {
+			return;
+		};
+		let Ok(mut registry) = registry.write() else {
+			return;
+		};
+		if let Some(entry) = registry.entries.iter_mut().find(|entry| entry.id == self.share.id) {
+			entry.max = max;
+		}
+	}
+}
+
+impl Drop for Reservation {
+	fn drop(&mut self) {
+		let Some(registry) = self.registry.upgrade() else {
+			return;
+		};
+		let Ok(mut registry) = registry.write() else {
+			return;
+		};
+		registry.entries.retain(|entry| entry.id != self.share.id);
+	}
+}
+
+/// An allocator with nothing to divide, so a config that never sets one leaves its
+/// senders at their configured rates. See [`Allocator::unlimited`].
+impl Default for Allocator {
+	fn default() -> Self {
+		Self::unlimited()
 	}
 }
 
@@ -237,7 +382,7 @@ struct Entry {
 	id: u64,
 	demand: track::Demand,
 	priority: u8,
-	max: u64,
+	max: Rate,
 }
 
 /// A share's view of the estimate it divides.
@@ -246,32 +391,7 @@ struct Share {
 	/// What's being divided, which may itself be a share.
 	estimate: Consumer,
 	registry: kio::Consumer<Registry>,
-	registration: Arc<Registration>,
-}
-
-/// A reservation's entry in the registry, released when the last clone of the share
-/// holding it goes away.
-///
-/// A track that outlives its share (an encoder reopening at a different ceiling) would
-/// otherwise keep claiming the old reservation for the rest of the connection, since
-/// the registry only ever prunes tracks that have closed.
-struct Registration {
-	/// Weak so a share can't keep the registry alive: a share outliving every
-	/// [`Allocator`] still reports the registry as gone.
-	registry: kio::Weak<Registry>,
 	id: u64,
-}
-
-impl Drop for Registration {
-	fn drop(&mut self) {
-		let Some(registry) = self.registry.upgrade() else {
-			return;
-		};
-		let Ok(mut registry) = registry.write() else {
-			return;
-		};
-		registry.entries.retain(|entry| entry.id != self.id);
-	}
 }
 
 /// One demanded track's claim, snapshotted out of the [`Registry`] so no lock is
@@ -280,12 +400,12 @@ impl Drop for Registration {
 struct Want {
 	id: u64,
 	priority: u8,
-	max: u64,
+	max: Rate,
 }
 
 impl Share {
 	/// This share's slice right now.
-	fn grant(&self) -> Option<u64> {
+	fn grant(&self) -> Option<Rate> {
 		let estimate = self.estimate.peek()?;
 		let wants: Vec<Want> = self
 			.claims()
@@ -293,12 +413,12 @@ impl Share {
 			.filter(|(_, demand)| demand.is_used())
 			.map(|(want, _)| want)
 			.collect();
-		allocate(estimate, &wants, self.registration.id)
+		allocate(estimate, &wants, self.id)
 	}
 
 	/// This share's slice, arming `waiter` for everything that could move it: the
 	/// estimate, the set of registered tracks, and each track's demand.
-	fn poll_grant(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<u64>>> {
+	fn poll_grant(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Rate>>> {
 		// Drain the estimate rather than polling it once. A poll that returns Ready
 		// registers no waker, and this share may still conclude its own slice didn't
 		// move (its reservation caps it, so most estimate changes don't reach it) and
@@ -338,7 +458,7 @@ impl Share {
 		let grant = self
 			.estimate
 			.peek()
-			.and_then(|estimate| allocate(estimate, &wants, self.registration.id));
+			.and_then(|estimate| allocate(estimate, &wants, self.id));
 		Poll::Ready(Ok(grant))
 	}
 
@@ -374,8 +494,10 @@ impl Share {
 ///
 /// `None` when `id` isn't among the wants, which is how an idle or closed track
 /// reports "hold your rate" instead of a grant of zero.
-fn allocate(estimate: u64, wants: &[Want], id: u64) -> Option<u64> {
-	let mut budget = estimate;
+fn allocate(estimate: Rate, wants: &[Want], id: u64) -> Option<Rate> {
+	// Plain bits per second inside: this is where the division actually happens, and
+	// wrapping every intermediate would need arithmetic on `Rate` that no caller wants.
+	let mut budget = estimate.as_bps();
 	let mut tier = wants.iter().map(|want| want.priority).max();
 
 	while let Some(priority) = tier {
@@ -387,9 +509,9 @@ fn allocate(estimate: u64, wants: &[Want], id: u64) -> Option<u64> {
 		let mut remaining = members.len() as u64;
 		for want in members {
 			let even = budget / remaining;
-			let grant = want.max.min(even);
+			let grant = want.max.as_bps().min(even);
 			if want.id == id {
-				return Some(grant);
+				return Some(Rate::from_bps(grant));
 			}
 			budget -= grant;
 			remaining -= 1;
@@ -409,7 +531,7 @@ fn allocate(estimate: u64, wants: &[Want], id: u64) -> Option<u64> {
 #[derive(Clone)]
 pub struct Consumer {
 	inner: Inner,
-	last: Option<u64>,
+	last: Option<Rate>,
 }
 
 /// What a [`Consumer`] is reading: the whole estimate, or one track's slice of it.
@@ -417,14 +539,17 @@ pub struct Consumer {
 enum Inner {
 	Whole(kio::Consumer<State>),
 	Share(Box<Share>),
+	/// [`Allocator::unlimited`]'s: no estimate, and never will be.
+	Unavailable,
 }
 
 impl Consumer {
 	/// Get the current bandwidth estimate synchronously.
-	pub fn peek(&self) -> Option<u64> {
+	pub fn peek(&self) -> Option<Rate> {
 		match &self.inner {
 			Inner::Whole(state) => state.read().bitrate,
 			Inner::Share(share) => share.grant(),
+			Inner::Unavailable => None,
 		}
 	}
 
@@ -438,7 +563,7 @@ impl Consumer {
 	///
 	/// A backend with no bandwidth estimation at all yields no [Consumer] in the
 	/// first place, so that case never reaches here.
-	pub fn poll_changed(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<u64>>> {
+	pub fn poll_changed(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Rate>>> {
 		let last = self.last;
 
 		let bitrate = match &mut self.inner {
@@ -460,6 +585,9 @@ impl Consumer {
 			// A share recomputes its slice on every wakeup, so it filters the
 			// unchanged case here rather than inside the poll. Every waker that could
 			// move the slice was armed by `poll_grant` either way.
+			// Nothing to report and nothing that could ever change it, so park without
+			// arming anything rather than reporting a `None` the caller would re-read forever.
+			Inner::Unavailable => return Poll::Pending,
 			Inner::Share(share) => match share.poll_grant(waiter) {
 				Poll::Ready(Ok(grant)) if grant == last => return Poll::Pending,
 				Poll::Ready(Ok(grant)) => grant,
@@ -479,7 +607,7 @@ impl Consumer {
 	///
 	/// Returns an error once the producer is closed or dropped, so a caller can
 	/// stop watching. See [`poll_changed`](Self::poll_changed).
-	pub async fn changed(&mut self) -> Result<Option<u64>> {
+	pub async fn changed(&mut self) -> Result<Option<Rate>> {
 		kio::wait(|waiter| self.poll_changed(waiter)).await
 	}
 }
@@ -493,8 +621,17 @@ mod tests {
 	const AUDIO: u8 = 80;
 	const VIDEO: u8 = 60;
 
+	/// Bits per second, so the tables below stay readable.
+	fn bps(bps: u64) -> Rate {
+		Rate::from_bps(bps)
+	}
+
 	fn want(id: u64, priority: u8, max: u64) -> Want {
-		Want { id, priority, max }
+		Want {
+			id,
+			priority,
+			max: bps(max),
+		}
 	}
 
 	/// A standalone track at `priority`, plus the broadcast keeping it alive.
@@ -512,18 +649,18 @@ mod tests {
 
 		// Audio takes its reservation off the top; video gets what's left. This is
 		// the job `rate::Policy::headroom` used to approximate with a flat 10%.
-		assert_eq!(allocate(2_000_000, &wants, 0), Some(128_000));
-		assert_eq!(allocate(2_000_000, &wants, 1), Some(1_872_000));
+		assert_eq!(allocate(bps(2_000_000), &wants, 0), Some(bps(128_000)));
+		assert_eq!(allocate(bps(2_000_000), &wants, 1), Some(bps(1_872_000)));
 	}
 
 	#[test]
 	fn a_starved_tier_gets_nothing() {
 		let wants = [want(0, AUDIO, 2_000_000), want(1, VIDEO, 4_000_000)];
 
-		assert_eq!(allocate(1_000_000, &wants, 0), Some(1_000_000));
+		assert_eq!(allocate(bps(1_000_000), &wants, 0), Some(bps(1_000_000)));
 		// Strict, not weighted: the lower tier is not owed a floor. Its encoder
 		// clamps to `rate::Policy::min` and the transport sheds what won't fit.
-		assert_eq!(allocate(1_000_000, &wants, 1), Some(0));
+		assert_eq!(allocate(bps(1_000_000), &wants, 1), Some(bps(0)));
 	}
 
 	/// Publishers don't set [`track::Info::priority`] today (it defaults to 0 and
@@ -538,8 +675,8 @@ mod tests {
 		let tiered = [want(0, AUDIO, 128_000), want(1, VIDEO, 4_000_000)];
 
 		for wants in [flat, tiered] {
-			assert_eq!(allocate(2_000_000, &wants, 0), Some(128_000));
-			assert_eq!(allocate(2_000_000, &wants, 1), Some(1_872_000));
+			assert_eq!(allocate(bps(2_000_000), &wants, 0), Some(bps(128_000)));
+			assert_eq!(allocate(bps(2_000_000), &wants, 1), Some(bps(1_872_000)));
 		}
 	}
 
@@ -547,8 +684,8 @@ mod tests {
 	fn an_even_tier_splits_evenly() {
 		let wants = [want(0, VIDEO, 4_000_000), want(1, VIDEO, 4_000_000)];
 
-		assert_eq!(allocate(6_000_000, &wants, 0), Some(3_000_000));
-		assert_eq!(allocate(6_000_000, &wants, 1), Some(3_000_000));
+		assert_eq!(allocate(bps(6_000_000), &wants, 0), Some(bps(3_000_000)));
+		assert_eq!(allocate(bps(6_000_000), &wants, 1), Some(bps(3_000_000)));
 	}
 
 	/// Max-min fair, not an even split: a 360p rung sharing with a 1080p one takes
@@ -557,8 +694,8 @@ mod tests {
 	fn a_small_share_frees_what_it_does_not_want() {
 		let wants = [want(0, VIDEO, 1_000_000), want(1, VIDEO, 8_000_000)];
 
-		assert_eq!(allocate(6_000_000, &wants, 0), Some(1_000_000));
-		assert_eq!(allocate(6_000_000, &wants, 1), Some(5_000_000));
+		assert_eq!(allocate(bps(6_000_000), &wants, 0), Some(bps(1_000_000)));
+		assert_eq!(allocate(bps(6_000_000), &wants, 1), Some(bps(5_000_000)));
 	}
 
 	/// Capping at the reservation is what keeps an uncongested link encoding at
@@ -566,13 +703,16 @@ mod tests {
 	/// if senders scaled a fraction of their grant, which is what headroom did.
 	#[test]
 	fn surplus_is_left_unclaimed() {
-		assert_eq!(allocate(10_000_000, &[want(0, VIDEO, 4_000_000)], 0), Some(4_000_000));
+		assert_eq!(
+			allocate(bps(10_000_000), &[want(0, VIDEO, 4_000_000)], 0),
+			Some(bps(4_000_000))
+		);
 	}
 
 	#[test]
 	fn an_unregistered_share_has_no_grant() {
-		assert_eq!(allocate(1_000_000, &[], 0), None);
-		assert_eq!(allocate(1_000_000, &[want(0, VIDEO, 1_000)], 7), None);
+		assert_eq!(allocate(bps(1_000_000), &[], 0), None);
+		assert_eq!(allocate(bps(1_000_000), &[want(0, VIDEO, 1_000)], 7), None);
 	}
 
 	/// The headline case: two encoders on one connection must not each target the
@@ -584,20 +724,21 @@ mod tests {
 
 		let (_first_broadcast, first) = track(VIDEO);
 		let _first_sub = first.consume();
-		let mut first_share = allocator.register(&first.demand(), 4_000_000);
+		let first = allocator.reserve(&first.demand(), bps(4_000_000));
+		let mut first_share = first.consumer();
 
-		estimate.set(Some(2_000_000)).unwrap();
+		estimate.set(Some(bps(2_000_000))).unwrap();
 		// Alone, it gets everything it asked for that the link can carry.
-		assert_eq!(first_share.changed().await.unwrap(), Some(2_000_000));
+		assert_eq!(first_share.changed().await.unwrap(), Some(bps(2_000_000)));
 
 		// A second encoder starts. The first must give half back without anyone
 		// telling it to, or the two together target 200% of the uplink.
 		let (_second_broadcast, second) = track(VIDEO);
 		let _second_sub = second.consume();
-		let second_share = allocator.register(&second.demand(), 4_000_000);
+		let second_share = allocator.reserve(&second.demand(), bps(4_000_000));
 
-		assert_eq!(first_share.changed().await.unwrap(), Some(1_000_000));
-		assert_eq!(second_share.peek(), Some(1_000_000));
+		assert_eq!(first_share.changed().await.unwrap(), Some(bps(1_000_000)));
+		assert_eq!(second_share.peek(), Some(bps(1_000_000)));
 	}
 
 	/// An unwatched track releases its reservation, since `publish_capture` stops
@@ -606,24 +747,24 @@ mod tests {
 	async fn an_idle_track_claims_nothing() {
 		let estimate = Producer::new();
 		let allocator = Allocator::new(estimate.consume());
-		estimate.set(Some(2_000_000)).unwrap();
+		estimate.set(Some(bps(2_000_000))).unwrap();
 
 		let (_watched_broadcast, watched) = track(VIDEO);
 		let _watched_sub = watched.consume();
-		let watched_share = allocator.register(&watched.demand(), 4_000_000);
+		let watched_share = allocator.reserve(&watched.demand(), bps(4_000_000));
 
 		let (_idle_broadcast, idle) = track(VIDEO);
-		let idle_share = allocator.register(&idle.demand(), 4_000_000);
+		let idle_share = allocator.reserve(&idle.demand(), bps(4_000_000));
 
-		assert_eq!(watched_share.peek(), Some(2_000_000));
+		assert_eq!(watched_share.peek(), Some(bps(2_000_000)));
 		// Not zero: an idle share reports "no opinion" so a sender that is mid-shutdown
 		// holds its rate instead of retuning to the floor on the way out.
 		assert_eq!(idle_share.peek(), None);
 
 		// It joins, and the split happens.
 		let _idle_sub = idle.consume();
-		assert_eq!(watched_share.peek(), Some(1_000_000));
-		assert_eq!(idle_share.peek(), Some(1_000_000));
+		assert_eq!(watched_share.peek(), Some(bps(1_000_000)));
+		assert_eq!(idle_share.peek(), Some(bps(1_000_000)));
 	}
 
 	/// Demand transitions have to wake a parked share, not just change what a later
@@ -632,21 +773,22 @@ mod tests {
 	async fn a_share_wakes_when_a_sibling_goes_idle() {
 		let estimate = Producer::new();
 		let allocator = Allocator::new(estimate.consume());
-		estimate.set(Some(2_000_000)).unwrap();
+		estimate.set(Some(bps(2_000_000))).unwrap();
 
 		let (_mine_broadcast, mine) = track(VIDEO);
 		let _mine_sub = mine.consume();
-		let mut mine_share = allocator.register(&mine.demand(), 4_000_000);
+		let mine_share_reserved = allocator.reserve(&mine.demand(), bps(4_000_000));
+		let mut mine_share = mine_share_reserved.consumer();
 
 		let (_sibling_broadcast, sibling) = track(VIDEO);
 		let sibling_sub = sibling.consume();
-		let _sibling_share = allocator.register(&sibling.demand(), 4_000_000);
+		let _sibling_share = allocator.reserve(&sibling.demand(), bps(4_000_000));
 
-		assert_eq!(mine_share.changed().await.unwrap(), Some(1_000_000));
+		assert_eq!(mine_share.changed().await.unwrap(), Some(bps(1_000_000)));
 
 		// The sibling's last viewer leaves, so its half comes back to us.
 		drop(sibling_sub);
-		assert_eq!(mine_share.changed().await.unwrap(), Some(2_000_000));
+		assert_eq!(mine_share.changed().await.unwrap(), Some(bps(2_000_000)));
 	}
 
 	/// Records whether a parked poll was actually woken, which re-reading state on a
@@ -691,21 +833,22 @@ mod tests {
 
 		let (_broadcast, track) = track(VIDEO);
 		let _sub = track.consume();
-		let mut share = allocator.register(&track.demand(), 4_000_000);
+		let share_reserved = allocator.reserve(&track.demand(), bps(4_000_000));
+		let mut share = share_reserved.consumer();
 
-		estimate.set(Some(10_000_000)).unwrap();
-		assert_eq!(share.changed().await.unwrap(), Some(4_000_000));
+		estimate.set(Some(bps(10_000_000))).unwrap();
+		assert_eq!(share.changed().await.unwrap(), Some(bps(4_000_000)));
 
 		// Still miles above the reservation, so the slice holds at 4 Mbps: the share
 		// observes the change, decides it doesn't move, and parks.
 		let (woken, waiter) = Woken::new();
-		estimate.set(Some(9_000_000)).unwrap();
+		estimate.set(Some(bps(9_000_000))).unwrap();
 		assert!(share.poll_changed(&waiter).is_pending());
 
 		// The estimate finally drops past the reservation: this has to reach it.
-		estimate.set(Some(1_000_000)).unwrap();
+		estimate.set(Some(bps(1_000_000))).unwrap();
 		assert!(woken.woken(), "a parked share must be woken by the next estimate");
-		assert_eq!(share.changed().await.unwrap(), Some(1_000_000));
+		assert_eq!(share.changed().await.unwrap(), Some(bps(1_000_000)));
 	}
 
 	/// The same, for the other input: a sibling's demand.
@@ -713,17 +856,18 @@ mod tests {
 	async fn a_parked_share_is_woken_by_sibling_demand() {
 		let estimate = Producer::new();
 		let allocator = Allocator::new(estimate.consume());
-		estimate.set(Some(2_000_000)).unwrap();
+		estimate.set(Some(bps(2_000_000))).unwrap();
 
 		let (_mine_broadcast, mine) = track(VIDEO);
 		let _mine_sub = mine.consume();
-		let mut share = allocator.register(&mine.demand(), 4_000_000);
+		let share_reserved = allocator.reserve(&mine.demand(), bps(4_000_000));
+		let mut share = share_reserved.consumer();
 
 		let (_sibling_broadcast, sibling) = track(VIDEO);
 		let sibling_sub = sibling.consume();
-		let _sibling_share = allocator.register(&sibling.demand(), 4_000_000);
+		let _sibling_share = allocator.reserve(&sibling.demand(), bps(4_000_000));
 
-		assert_eq!(share.changed().await.unwrap(), Some(1_000_000));
+		assert_eq!(share.changed().await.unwrap(), Some(bps(1_000_000)));
 
 		let (woken, waiter) = Woken::new();
 		assert!(share.poll_changed(&waiter).is_pending());
@@ -740,10 +884,11 @@ mod tests {
 
 		let (_broadcast, track) = track(VIDEO);
 		let _sub = track.consume();
-		let mut share = allocator.register(&track.demand(), 4_000_000);
+		let share_reserved = allocator.reserve(&track.demand(), bps(4_000_000));
+		let mut share = share_reserved.consumer();
 
-		estimate.set(Some(2_000_000)).unwrap();
-		assert_eq!(share.changed().await.unwrap(), Some(2_000_000));
+		estimate.set(Some(bps(2_000_000))).unwrap();
+		assert_eq!(share.changed().await.unwrap(), Some(bps(2_000_000)));
 
 		estimate.set(None).unwrap();
 		assert_eq!(share.changed().await.unwrap(), None);
@@ -763,44 +908,102 @@ mod tests {
 		// Both shares are held: dropping one releases its reservation on its own,
 		// which would prove nothing about pruning the track that closed.
 		let (_first_broadcast, first) = track(VIDEO);
-		let _first_share = allocator.register(&first.demand(), 4_000_000);
+		let _first_share = allocator.reserve(&first.demand(), bps(4_000_000));
 		first.abort(Error::Cancel).unwrap();
 
 		let (_second_broadcast, second) = track(VIDEO);
-		let _second_share = allocator.register(&second.demand(), 4_000_000);
+		let _second_share = allocator.reserve(&second.demand(), bps(4_000_000));
 
 		assert_eq!(allocator.registry.read().entries.len(), 1);
 	}
 
-	/// An encoder reopening at a different ceiling drops its old share before taking a
-	/// new one, and that has to hand the room straight back. The registry only ever
-	/// prunes tracks that have *closed*, so a reservation left behind by a track that
-	/// is still alive would keep claiming for the rest of the connection.
+	/// Dropping the reservation hands the room back. The registry only ever prunes
+	/// tracks that have *closed*, so a claim left behind by a track that is still
+	/// publishing would stand for the rest of the connection.
 	#[tokio::test]
-	async fn dropping_a_share_releases_its_reservation() {
+	async fn dropping_a_reservation_releases_it() {
 		let estimate = Producer::new();
 		let allocator = Allocator::new(estimate.consume());
-		estimate.set(Some(2_000_000)).unwrap();
+		estimate.set(Some(bps(2_000_000))).unwrap();
 
 		let (_first_broadcast, first) = track(VIDEO);
 		let _first_sub = first.consume();
-		let first_share = allocator.register(&first.demand(), 4_000_000);
+		let first_reserved = allocator.reserve(&first.demand(), bps(4_000_000));
 
 		let (_second_broadcast, second) = track(VIDEO);
 		let _second_sub = second.consume();
-		let second_share = allocator.register(&second.demand(), 4_000_000);
-		assert_eq!(second_share.peek(), Some(1_000_000));
+		let second_reserved = allocator.reserve(&second.demand(), bps(4_000_000));
+		assert_eq!(second_reserved.peek(), Some(bps(1_000_000)));
 
-		// A clone is the same reservation, so the entry outlives the first drop: the
-		// capture loop hands one to its rate controller for the life of an encoder.
-		let clone = first_share.clone();
-		drop(first_share);
-		assert_eq!(allocator.registry.read().entries.len(), 2);
-		assert_eq!(second_share.peek(), Some(1_000_000));
+		// A read handle is not the claim: the reservation outliving it is what keeps the
+		// room, and the reservation going away is what returns it.
+		let mut orphan = first_reserved.consumer();
+		assert_eq!(orphan.changed().await.unwrap(), Some(bps(1_000_000)));
 
-		drop(clone);
+		drop(first_reserved);
 		assert_eq!(allocator.registry.read().entries.len(), 1);
-		assert_eq!(second_share.peek(), Some(2_000_000));
+		assert_eq!(second_reserved.peek(), Some(bps(2_000_000)));
+
+		// The orphaned reader is woken and told, rather than being left parked on a slice
+		// that will never move again. It reports the same "hold your rate" as an unwatched
+		// track, not a grant of zero that would tell an encoder to stop.
+		assert_eq!(orphan.changed().await.unwrap(), None);
+		assert_eq!(orphan.peek(), None);
+	}
+
+	/// A sender whose ceiling moved (a capture reopening at a resolution it negotiated
+	/// with the device) changes the claim in place. Re-reserving instead would claim
+	/// twice, since nothing releases the first entry while the track is still alive.
+	#[tokio::test]
+	async fn update_changes_the_claim_in_place() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+		estimate.set(Some(bps(6_000_000))).unwrap();
+
+		let (_small_broadcast, small) = track(VIDEO);
+		let _small_sub = small.consume();
+		let small_reserved = allocator.reserve(&small.demand(), bps(1_000_000));
+
+		let (_large_broadcast, large) = track(VIDEO);
+		let _large_sub = large.consume();
+		let large_reserved = allocator.reserve(&large.demand(), bps(8_000_000));
+
+		// Max-min fair: the small claim is satisfied in full, the rest goes to the other.
+		assert_eq!(small_reserved.peek(), Some(bps(1_000_000)));
+		assert_eq!(large_reserved.peek(), Some(bps(5_000_000)));
+
+		// It reopens at a mode that can use much more, and the split follows without a
+		// second entry appearing.
+		small_reserved.update(bps(4_000_000));
+		assert_eq!(allocator.registry.read().entries.len(), 2);
+		assert_eq!(small_reserved.peek(), Some(bps(3_000_000)));
+		assert_eq!(large_reserved.peek(), Some(bps(3_000_000)));
+
+		// And back down, which has to release the difference rather than hold it.
+		small_reserved.update(bps(1_000_000));
+		assert_eq!(large_reserved.peek(), Some(bps(5_000_000)));
+	}
+
+	/// A reader parked on `changed` has to be woken by its own reservation moving, not
+	/// just by the estimate or a sibling: the encoder is sitting in a `select!` on it.
+	#[tokio::test]
+	async fn update_wakes_a_parked_reader() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+		estimate.set(Some(bps(6_000_000))).unwrap();
+
+		let (_broadcast, producer) = track(VIDEO);
+		let _sub = producer.consume();
+		let reserved = allocator.reserve(&producer.demand(), bps(1_000_000));
+		let mut share = reserved.consumer();
+		assert_eq!(share.changed().await.unwrap(), Some(bps(1_000_000)));
+
+		let (woken, waiter) = Woken::new();
+		assert!(share.poll_changed(&waiter).is_pending());
+
+		reserved.update(bps(4_000_000));
+		assert!(woken.woken(), "raising the ceiling must wake the reader");
+		assert_eq!(share.changed().await.unwrap(), Some(bps(4_000_000)));
 	}
 
 	/// The registry is the allocator's, not a share's: a share that outlives every
@@ -812,7 +1015,8 @@ mod tests {
 
 		let (_broadcast, producer) = track(VIDEO);
 		let _sub = producer.consume();
-		let mut share = allocator.register(&producer.demand(), 4_000_000);
+		let share_reserved = allocator.reserve(&producer.demand(), bps(4_000_000));
+		let mut share = share_reserved.consumer();
 
 		drop(allocator);
 		drop(estimate);
@@ -828,8 +1032,8 @@ mod tests {
 		let producer = Producer::new();
 		let mut consumer = producer.consume();
 
-		producer.set(Some(1_000_000)).unwrap();
-		assert_eq!(consumer.changed().await.unwrap(), Some(1_000_000));
+		producer.set(Some(bps(1_000_000))).unwrap();
+		assert_eq!(consumer.changed().await.unwrap(), Some(bps(1_000_000)));
 
 		// Live, but the estimate went away (e.g. disconnected): still watchable.
 		producer.set(None).unwrap();

--- a/rs/moq-net/src/model/bandwidth.rs
+++ b/rs/moq-net/src/model/bandwidth.rs
@@ -8,6 +8,7 @@
 //! *follows* its share is policy and lives with the sender: see
 //! `moq_video::encode::rate` for the encoder's.
 
+use std::sync::Arc;
 use std::task::Poll;
 
 use crate::{Error, Result, track};
@@ -166,9 +167,13 @@ impl Allocator {
 	///
 	/// The returned [`Consumer`] reports `None` while nothing is subscribed to the
 	/// track or the connection has no estimate, which tells a sender to hold its
-	/// current rate rather than to encode at zero. The share is released when the
-	/// track closes: a [`track::Demand`] is a weak handle, so registering one never
+	/// current rate rather than to encode at zero. The reservation lasts as long as
+	/// that consumer (and any clone of it), and is released when the track closes
+	/// either way: a [`track::Demand`] is a weak handle, so registering one never
 	/// keeps a track alive.
+	///
+	/// Registering the same track again claims a second reservation, so a sender
+	/// whose ceiling changed must drop the old share before taking a new one.
 	pub fn register(&self, track: &track::Demand, max: u64) -> Consumer {
 		// Read the track before taking the registry lock, so the two are never held
 		// at once and there's no order to get wrong.
@@ -200,7 +205,10 @@ impl Allocator {
 			inner: Inner::Share(Box::new(Share {
 				estimate: self.estimate.clone(),
 				registry: self.registry.consume(),
-				id,
+				registration: Arc::new(Registration {
+					registry: self.registry.downgrade(),
+					id,
+				}),
 			})),
 			last: None,
 		}
@@ -238,7 +246,32 @@ struct Share {
 	/// What's being divided, which may itself be a share.
 	estimate: Consumer,
 	registry: kio::Consumer<Registry>,
+	registration: Arc<Registration>,
+}
+
+/// A reservation's entry in the registry, released when the last clone of the share
+/// holding it goes away.
+///
+/// A track that outlives its share (an encoder reopening at a different ceiling) would
+/// otherwise keep claiming the old reservation for the rest of the connection, since
+/// the registry only ever prunes tracks that have closed.
+struct Registration {
+	/// Weak so a share can't keep the registry alive: a share outliving every
+	/// [`Allocator`] still reports the registry as gone.
+	registry: kio::Weak<Registry>,
 	id: u64,
+}
+
+impl Drop for Registration {
+	fn drop(&mut self) {
+		let Some(registry) = self.registry.upgrade() else {
+			return;
+		};
+		let Ok(mut registry) = registry.write() else {
+			return;
+		};
+		registry.entries.retain(|entry| entry.id != self.id);
+	}
 }
 
 /// One demanded track's claim, snapshotted out of the [`Registry`] so no lock is
@@ -260,7 +293,7 @@ impl Share {
 			.filter(|(_, demand)| demand.is_used())
 			.map(|(want, _)| want)
 			.collect();
-		allocate(estimate, &wants, self.id)
+		allocate(estimate, &wants, self.registration.id)
 	}
 
 	/// This share's slice, arming `waiter` for everything that could move it: the
@@ -305,7 +338,7 @@ impl Share {
 		let grant = self
 			.estimate
 			.peek()
-			.and_then(|estimate| allocate(estimate, &wants, self.id));
+			.and_then(|estimate| allocate(estimate, &wants, self.registration.id));
 		Poll::Ready(Ok(grant))
 	}
 
@@ -727,14 +760,63 @@ mod tests {
 		let estimate = Producer::new();
 		let allocator = Allocator::new(estimate.consume());
 
+		// Both shares are held: dropping one releases its reservation on its own,
+		// which would prove nothing about pruning the track that closed.
 		let (_first_broadcast, first) = track(VIDEO);
-		allocator.register(&first.demand(), 4_000_000);
+		let _first_share = allocator.register(&first.demand(), 4_000_000);
 		first.abort(Error::Cancel).unwrap();
 
 		let (_second_broadcast, second) = track(VIDEO);
-		allocator.register(&second.demand(), 4_000_000);
+		let _second_share = allocator.register(&second.demand(), 4_000_000);
 
 		assert_eq!(allocator.registry.read().entries.len(), 1);
+	}
+
+	/// An encoder reopening at a different ceiling drops its old share before taking a
+	/// new one, and that has to hand the room straight back. The registry only ever
+	/// prunes tracks that have *closed*, so a reservation left behind by a track that
+	/// is still alive would keep claiming for the rest of the connection.
+	#[tokio::test]
+	async fn dropping_a_share_releases_its_reservation() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+		estimate.set(Some(2_000_000)).unwrap();
+
+		let (_first_broadcast, first) = track(VIDEO);
+		let _first_sub = first.consume();
+		let first_share = allocator.register(&first.demand(), 4_000_000);
+
+		let (_second_broadcast, second) = track(VIDEO);
+		let _second_sub = second.consume();
+		let second_share = allocator.register(&second.demand(), 4_000_000);
+		assert_eq!(second_share.peek(), Some(1_000_000));
+
+		// A clone is the same reservation, so the entry outlives the first drop: the
+		// capture loop hands one to its rate controller for the life of an encoder.
+		let clone = first_share.clone();
+		drop(first_share);
+		assert_eq!(allocator.registry.read().entries.len(), 2);
+		assert_eq!(second_share.peek(), Some(1_000_000));
+
+		drop(clone);
+		assert_eq!(allocator.registry.read().entries.len(), 1);
+		assert_eq!(second_share.peek(), Some(2_000_000));
+	}
+
+	/// The registry is the allocator's, not a share's: a share that outlives every
+	/// allocator reports the estimate as gone rather than keeping the channel open.
+	#[tokio::test]
+	async fn a_share_outliving_the_allocator_reports_closed() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+
+		let (_broadcast, producer) = track(VIDEO);
+		let _sub = producer.consume();
+		let mut share = allocator.register(&producer.demand(), 4_000_000);
+
+		drop(allocator);
+		drop(estimate);
+		assert!(share.changed().await.is_err());
 	}
 
 	/// An unavailable estimate and a dead producer must not look alike: a caller

--- a/rs/moq-net/src/model/bandwidth.rs
+++ b/rs/moq-net/src/model/bandwidth.rs
@@ -133,9 +133,6 @@ pub struct Allocator {
 impl Allocator {
 	/// Divide `estimate`, normally a connection's
 	/// [`Session::send_bandwidth`](crate::Session::send_bandwidth).
-	///
-	/// Nesting works: the estimate can itself be a share, which splits one slice
-	/// again among the tracks behind it.
 	pub fn new(estimate: Consumer) -> Self {
 		Self {
 			estimate,
@@ -152,10 +149,16 @@ impl Allocator {
 	/// to somebody else.
 	///
 	/// Priority comes from the track ([`track::Info::priority`], higher served
-	/// first), so allocation and transmission order can't disagree. A tier is
-	/// filled to its reservations before the next one sees a bit; within a tier
-	/// the split is max-min fair, so a share asking for less than an even cut
-	/// takes all of it and leaves the difference to the others.
+	/// first). A tier is filled to its reservations before the next one sees a
+	/// bit; within a tier the split is max-min fair, so a share asking for less
+	/// than an even cut takes all of it and leaves the difference to the others.
+	///
+	/// That is the *publisher's* priority, which is not what orders the local send
+	/// queue: that ranks by each subscription's own priority, so a subscriber
+	/// asking for video ahead of audio is served that way whatever this decides.
+	/// The publisher's is still the right one to divide by, since allocation is a
+	/// decision about what to *produce*, and there is no single subscriber
+	/// priority to read when several are watching one track.
 	///
 	/// That last part is what carries the common case, since publishers leave
 	/// `priority` at its default today: one tier of audio and video still serves

--- a/rs/moq-net/src/model/bandwidth.rs
+++ b/rs/moq-net/src/model/bandwidth.rs
@@ -3,12 +3,14 @@
 //! A [Producer] is used to set the current estimated bitrate, notifying consumers.
 //! A [Consumer] can read the current estimate and wait for changes.
 //!
-//! What a sender does with an estimate is policy and lives with the sender, not
-//! here: see `moq_video::encode::rate` for the encoder's.
+//! One estimate covers a whole connection, so senders sharing one divide it with
+//! an [Allocator] rather than each targeting the whole thing. How a sender then
+//! *follows* its share is policy and lives with the sender: see
+//! `moq_video::encode::rate` for the encoder's.
 
 use std::task::Poll;
 
-use crate::{Error, Result};
+use crate::{Error, Result, track};
 
 #[derive(Default)]
 struct State {
@@ -42,7 +44,7 @@ impl Producer {
 	/// Create a new consumer for the bandwidth estimate.
 	pub fn consume(&self) -> Consumer {
 		Consumer {
-			state: self.state.consume(),
+			inner: Inner::Whole(self.state.consume()),
 			last: None,
 		}
 	}
@@ -109,17 +111,285 @@ impl Default for Producer {
 	}
 }
 
+/// Divides one connection's bandwidth estimate among the tracks sharing it.
+///
+/// Every sender on a connection reads the same estimate, so N senders each
+/// targeting all of it oversubscribe the uplink N times over. Register a track
+/// here and it gets a [`Consumer`] reporting only its own slice, so the slices
+/// sum to the estimate instead of each matching it.
+///
+/// Advisory, not enforced. A track that ignores its slice, or can't follow it at
+/// all (PCM audio has a fixed bitrate), still sends what it sends; the transport
+/// sheds the excess by dropping groups. Bandwidth estimation isn't exact enough
+/// for the difference to be worth policing.
+///
+/// Clones share one registry, so hand a clone to each sender.
+#[derive(Clone)]
+pub struct Allocator {
+	estimate: Consumer,
+	registry: kio::Producer<Registry>,
+}
+
+impl Allocator {
+	/// Divide `estimate`, normally a connection's
+	/// [`Session::send_bandwidth`](crate::Session::send_bandwidth).
+	///
+	/// Nesting works: the estimate can itself be a share, which splits one slice
+	/// again among the tracks behind it.
+	pub fn new(estimate: Consumer) -> Self {
+		Self {
+			estimate,
+			registry: kio::Producer::default(),
+		}
+	}
+
+	/// Reserve up to `max` bits per second for `track`, returning that track's slice.
+	///
+	/// `max` is a ceiling, not a measurement: reserve the most the track can ever
+	/// send, not what it happens to be sending. A VBR encoder sitting on a black
+	/// screen at 1 Mbps can jump to 6 Mbps between one frame and the next, and a
+	/// reservation that had followed it down would have already handed that room
+	/// to somebody else.
+	///
+	/// Priority comes from the track ([`track::Info::priority`], higher served
+	/// first), so allocation and transmission order can't disagree. A tier is
+	/// filled to its reservations before the next one sees a bit; within a tier
+	/// the split is max-min fair, so a share asking for less than an even cut
+	/// takes all of it and leaves the difference to the others.
+	///
+	/// That last part is what carries the common case, since publishers leave
+	/// `priority` at its default today: one tier of audio and video still serves
+	/// audio's small reservation in full before video takes the remainder.
+	///
+	/// The returned [`Consumer`] reports `None` while nothing is subscribed to the
+	/// track or the connection has no estimate, which tells a sender to hold its
+	/// current rate rather than to encode at zero. The share is released when the
+	/// track closes: a [`track::Demand`] is a weak handle, so registering one never
+	/// keeps a track alive.
+	pub fn register(&self, track: &track::Demand, max: u64) -> Consumer {
+		// Read the track before taking the registry lock, so the two are never held
+		// at once and there's no order to get wrong.
+		let priority = track.priority();
+		let demand = track.clone();
+
+		let id = {
+			// Nothing ever closes this channel: the allocator holds the only producer
+			// and never aborts it, so it's open for as long as `self` is.
+			let Ok(mut registry) = self.registry.write() else {
+				unreachable!("the allocator holds its own registry producer")
+			};
+			// Closed tracks can't be demanded again; drop them rather than walking
+			// them on every poll for the rest of the connection.
+			registry.entries.retain(|entry| !entry.demand.is_closed());
+
+			let id = registry.next_id;
+			registry.next_id += 1;
+			registry.entries.push(Entry {
+				id,
+				demand,
+				priority,
+				max,
+			});
+			id
+		};
+
+		Consumer {
+			inner: Inner::Share(Box::new(Share {
+				estimate: self.estimate.clone(),
+				registry: self.registry.consume(),
+				id,
+			})),
+			last: None,
+		}
+	}
+}
+
+// Hand-written so the config structs that carry an allocator can still derive
+// `Debug`. The registry is the only part worth printing.
+impl std::fmt::Debug for Allocator {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Allocator")
+			.field("registered", &self.registry.read().entries.len())
+			.finish()
+	}
+}
+
+/// Every track registered with one [`Allocator`].
+#[derive(Default)]
+struct Registry {
+	entries: Vec<Entry>,
+	next_id: u64,
+}
+
+/// One registered track's standing reservation.
+struct Entry {
+	id: u64,
+	demand: track::Demand,
+	priority: u8,
+	max: u64,
+}
+
+/// A share's view of the estimate it divides.
+#[derive(Clone)]
+struct Share {
+	/// What's being divided, which may itself be a share.
+	estimate: Consumer,
+	registry: kio::Consumer<Registry>,
+	id: u64,
+}
+
+/// One demanded track's claim, snapshotted out of the [`Registry`] so no lock is
+/// held while the tracks themselves are read.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct Want {
+	id: u64,
+	priority: u8,
+	max: u64,
+}
+
+impl Share {
+	/// This share's slice right now.
+	fn grant(&self) -> Option<u64> {
+		let estimate = self.estimate.peek()?;
+		let wants: Vec<Want> = self
+			.claims()
+			.into_iter()
+			.filter(|(_, demand)| demand.is_used())
+			.map(|(want, _)| want)
+			.collect();
+		allocate(estimate, &wants, self.id)
+	}
+
+	/// This share's slice, arming `waiter` for everything that could move it: the
+	/// estimate, the set of registered tracks, and each track's demand.
+	fn poll_grant(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<u64>>> {
+		// Drain the estimate rather than polling it once. A poll that returns Ready
+		// registers no waker, and this share may still conclude its own slice didn't
+		// move (its reservation caps it, so most estimate changes don't reach it) and
+		// park. Without the drain that park would never be woken by the next move.
+		// The value itself is read below, since an unchanged estimate still needs
+		// re-dividing when the tracks sharing it change.
+		loop {
+			match self.estimate.poll_changed(waiter) {
+				// Moved: go round again, which either finds it settled and arms the
+				// waker, or finds it moved again and makes progress toward the latest.
+				Poll::Ready(Ok(_)) => continue,
+				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+				Poll::Pending => break,
+			}
+		}
+
+		// Wake on any registration change. The closure never completes, so the only
+		// ready outcome is the registry being gone, i.e. every allocator dropped.
+		if let Poll::Ready(Err(_)) = self.registry.poll(waiter, |_| Poll::<()>::Pending) {
+			return Poll::Ready(Err(Error::Dropped));
+		}
+
+		let wants: Vec<Want> = self
+			.claims()
+			.into_iter()
+			.filter(|(_, demand)| match demand.poll_state(waiter) {
+				track::DemandState::Active => true,
+				// An idle track claims nothing, so an unwatched encoder's reservation
+				// goes to whoever is actually sending.
+				track::DemandState::Idle => false,
+				// Gone for good, and pruned by the next `register`.
+				track::DemandState::Closed => false,
+			})
+			.map(|(want, _)| want)
+			.collect();
+
+		let grant = self
+			.estimate
+			.peek()
+			.and_then(|estimate| allocate(estimate, &wants, self.id));
+		Poll::Ready(Ok(grant))
+	}
+
+	/// Snapshot the registry so the tracks can be read without holding its lock.
+	fn claims(&self) -> Vec<(Want, track::Demand)> {
+		self.registry
+			.read()
+			.entries
+			.iter()
+			.map(|entry| {
+				(
+					Want {
+						id: entry.id,
+						priority: entry.priority,
+						max: entry.max,
+					},
+					entry.demand.clone(),
+				)
+			})
+			.collect()
+	}
+}
+
+/// Divide `estimate` among `wants`, returning the slice for `id`.
+///
+/// Strict priority: a tier is filled to its reservations before the next tier
+/// sees a bit. Within a tier the split is max-min fair, so a share asking for
+/// less than an even split takes all of it and leaves the rest to the others.
+///
+/// Surplus above the total reserved is left unclaimed rather than spread around.
+/// A reservation is what a sender can use, so handing it more is not a reason to
+/// send more than it was configured for.
+///
+/// `None` when `id` isn't among the wants, which is how an idle or closed track
+/// reports "hold your rate" instead of a grant of zero.
+fn allocate(estimate: u64, wants: &[Want], id: u64) -> Option<u64> {
+	let mut budget = estimate;
+	let mut tier = wants.iter().map(|want| want.priority).max();
+
+	while let Some(priority) = tier {
+		// Ascending by reservation: each share takes an even cut of what's left, or
+		// all it asked for if that's less, which frees the difference for the rest.
+		let mut members: Vec<&Want> = wants.iter().filter(|want| want.priority == priority).collect();
+		members.sort_by_key(|want| want.max);
+
+		let mut remaining = members.len() as u64;
+		for want in members {
+			let even = budget / remaining;
+			let grant = want.max.min(even);
+			if want.id == id {
+				return Some(grant);
+			}
+			budget -= grant;
+			remaining -= 1;
+		}
+
+		tier = wants
+			.iter()
+			.map(|want| want.priority)
+			.filter(|other| *other < priority)
+			.max();
+	}
+
+	None
+}
+
 /// Consumes bandwidth estimates, allowing reads and async change notifications.
 #[derive(Clone)]
 pub struct Consumer {
-	state: kio::Consumer<State>,
+	inner: Inner,
 	last: Option<u64>,
+}
+
+/// What a [`Consumer`] is reading: the whole estimate, or one track's slice of it.
+#[derive(Clone)]
+enum Inner {
+	Whole(kio::Consumer<State>),
+	Share(Box<Share>),
 }
 
 impl Consumer {
 	/// Get the current bandwidth estimate synchronously.
 	pub fn peek(&self) -> Option<u64> {
-		self.state.read().bitrate
+		match &self.inner {
+			Inner::Whole(state) => state.read().bitrate,
+			Inner::Share(share) => share.grant(),
+		}
 	}
 
 	/// Poll for a bandwidth change without blocking.
@@ -135,24 +405,35 @@ impl Consumer {
 	pub fn poll_changed(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<u64>>> {
 		let last = self.last;
 
-		match self.state.poll(waiter, |state| {
-			if state.bitrate != last {
-				Poll::Ready(state.bitrate)
-			} else {
-				Poll::Pending
-			}
-		}) {
-			Poll::Ready(Ok(bitrate)) => {
-				self.last = bitrate;
-				Poll::Ready(Ok(bitrate))
-			}
-			// Closed, and the value hasn't moved since the last read: report it as
-			// terminal. Collapsing this into `Ok(None)` would be indistinguishable
-			// from a live-but-unavailable estimate, and since a closed channel is
-			// always immediately ready, a `select!` over it would spin forever.
-			Poll::Ready(Err(state)) => Poll::Ready(Err(state.abort.clone().unwrap_or(Error::Dropped))),
-			Poll::Pending => Poll::Pending,
-		}
+		let bitrate = match &mut self.inner {
+			Inner::Whole(state) => match state.poll(waiter, |state| {
+				if state.bitrate != last {
+					Poll::Ready(state.bitrate)
+				} else {
+					Poll::Pending
+				}
+			}) {
+				Poll::Ready(Ok(bitrate)) => bitrate,
+				// Closed, and the value hasn't moved since the last read: report it as
+				// terminal. Collapsing this into `Ok(None)` would be indistinguishable
+				// from a live-but-unavailable estimate, and since a closed channel is
+				// always immediately ready, a `select!` over it would spin forever.
+				Poll::Ready(Err(state)) => return Poll::Ready(Err(state.abort.clone().unwrap_or(Error::Dropped))),
+				Poll::Pending => return Poll::Pending,
+			},
+			// A share recomputes its slice on every wakeup, so it filters the
+			// unchanged case here rather than inside the poll. Every waker that could
+			// move the slice was armed by `poll_grant` either way.
+			Inner::Share(share) => match share.poll_grant(waiter) {
+				Poll::Ready(Ok(grant)) if grant == last => return Poll::Pending,
+				Poll::Ready(Ok(grant)) => grant,
+				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+				Poll::Pending => return Poll::Pending,
+			},
+		};
+
+		self.last = bitrate;
+		Poll::Ready(Ok(bitrate))
 	}
 
 	/// Block until the bandwidth estimate changes, returning the new value, or
@@ -170,6 +451,288 @@ impl Consumer {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::broadcast;
+
+	/// Priorities matching `hang`'s, which is what the allocator sees in practice.
+	const AUDIO: u8 = 80;
+	const VIDEO: u8 = 60;
+
+	fn want(id: u64, priority: u8, max: u64) -> Want {
+		Want { id, priority, max }
+	}
+
+	/// A standalone track at `priority`, plus the broadcast keeping it alive.
+	fn track(priority: u8) -> (broadcast::Producer, track::Producer) {
+		let mut broadcast = broadcast::Info::default().produce();
+		let track = broadcast
+			.create_track("t", track::Info::default().with_priority(priority))
+			.unwrap();
+		(broadcast, track)
+	}
+
+	#[test]
+	fn strict_priority_fills_the_top_tier_first() {
+		let wants = [want(0, AUDIO, 128_000), want(1, VIDEO, 4_000_000)];
+
+		// Audio takes its reservation off the top; video gets what's left. This is
+		// the job `rate::Policy::headroom` used to approximate with a flat 10%.
+		assert_eq!(allocate(2_000_000, &wants, 0), Some(128_000));
+		assert_eq!(allocate(2_000_000, &wants, 1), Some(1_872_000));
+	}
+
+	#[test]
+	fn a_starved_tier_gets_nothing() {
+		let wants = [want(0, AUDIO, 2_000_000), want(1, VIDEO, 4_000_000)];
+
+		assert_eq!(allocate(1_000_000, &wants, 0), Some(1_000_000));
+		// Strict, not weighted: the lower tier is not owed a floor. Its encoder
+		// clamps to `rate::Policy::min` and the transport sheds what won't fit.
+		assert_eq!(allocate(1_000_000, &wants, 1), Some(0));
+	}
+
+	/// Publishers don't set [`track::Info::priority`] today (it defaults to 0 and
+	/// `hang::container::track_info` leaves it there), so audio and video land in
+	/// one tier. That has to come out right anyway, and it does: max-min fair
+	/// satisfies the small claim first, so audio still gets its full reservation
+	/// and video takes the rest. Priority only changes the answer once a tier's
+	/// smaller claims outgrow an even split.
+	#[test]
+	fn one_tier_still_serves_audio_before_video() {
+		let flat = [want(0, 0, 128_000), want(1, 0, 4_000_000)];
+		let tiered = [want(0, AUDIO, 128_000), want(1, VIDEO, 4_000_000)];
+
+		for wants in [flat, tiered] {
+			assert_eq!(allocate(2_000_000, &wants, 0), Some(128_000));
+			assert_eq!(allocate(2_000_000, &wants, 1), Some(1_872_000));
+		}
+	}
+
+	#[test]
+	fn an_even_tier_splits_evenly() {
+		let wants = [want(0, VIDEO, 4_000_000), want(1, VIDEO, 4_000_000)];
+
+		assert_eq!(allocate(6_000_000, &wants, 0), Some(3_000_000));
+		assert_eq!(allocate(6_000_000, &wants, 1), Some(3_000_000));
+	}
+
+	/// Max-min fair, not an even split: a 360p rung sharing with a 1080p one takes
+	/// only what it asked for and leaves the rest, instead of both being held to half.
+	#[test]
+	fn a_small_share_frees_what_it_does_not_want() {
+		let wants = [want(0, VIDEO, 1_000_000), want(1, VIDEO, 8_000_000)];
+
+		assert_eq!(allocate(6_000_000, &wants, 0), Some(1_000_000));
+		assert_eq!(allocate(6_000_000, &wants, 1), Some(5_000_000));
+	}
+
+	/// Capping at the reservation is what keeps an uncongested link encoding at
+	/// exactly the configured rate. Spreading the surplus instead would only matter
+	/// if senders scaled a fraction of their grant, which is what headroom did.
+	#[test]
+	fn surplus_is_left_unclaimed() {
+		assert_eq!(allocate(10_000_000, &[want(0, VIDEO, 4_000_000)], 0), Some(4_000_000));
+	}
+
+	#[test]
+	fn an_unregistered_share_has_no_grant() {
+		assert_eq!(allocate(1_000_000, &[], 0), None);
+		assert_eq!(allocate(1_000_000, &[want(0, VIDEO, 1_000)], 7), None);
+	}
+
+	/// The headline case: two encoders on one connection must not each target the
+	/// whole estimate.
+	#[tokio::test]
+	async fn concurrent_tracks_split_the_estimate() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+
+		let (_first_broadcast, first) = track(VIDEO);
+		let _first_sub = first.consume();
+		let mut first_share = allocator.register(&first.demand(), 4_000_000);
+
+		estimate.set(Some(2_000_000)).unwrap();
+		// Alone, it gets everything it asked for that the link can carry.
+		assert_eq!(first_share.changed().await.unwrap(), Some(2_000_000));
+
+		// A second encoder starts. The first must give half back without anyone
+		// telling it to, or the two together target 200% of the uplink.
+		let (_second_broadcast, second) = track(VIDEO);
+		let _second_sub = second.consume();
+		let second_share = allocator.register(&second.demand(), 4_000_000);
+
+		assert_eq!(first_share.changed().await.unwrap(), Some(1_000_000));
+		assert_eq!(second_share.peek(), Some(1_000_000));
+	}
+
+	/// An unwatched track releases its reservation, since `publish_capture` stops
+	/// encoding entirely while nothing is subscribed.
+	#[tokio::test]
+	async fn an_idle_track_claims_nothing() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+		estimate.set(Some(2_000_000)).unwrap();
+
+		let (_watched_broadcast, watched) = track(VIDEO);
+		let _watched_sub = watched.consume();
+		let watched_share = allocator.register(&watched.demand(), 4_000_000);
+
+		let (_idle_broadcast, idle) = track(VIDEO);
+		let idle_share = allocator.register(&idle.demand(), 4_000_000);
+
+		assert_eq!(watched_share.peek(), Some(2_000_000));
+		// Not zero: an idle share reports "no opinion" so a sender that is mid-shutdown
+		// holds its rate instead of retuning to the floor on the way out.
+		assert_eq!(idle_share.peek(), None);
+
+		// It joins, and the split happens.
+		let _idle_sub = idle.consume();
+		assert_eq!(watched_share.peek(), Some(1_000_000));
+		assert_eq!(idle_share.peek(), Some(1_000_000));
+	}
+
+	/// Demand transitions have to wake a parked share, not just change what a later
+	/// `peek` would see; the encoder is sitting in a `select!` on `changed`.
+	#[tokio::test]
+	async fn a_share_wakes_when_a_sibling_goes_idle() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+		estimate.set(Some(2_000_000)).unwrap();
+
+		let (_mine_broadcast, mine) = track(VIDEO);
+		let _mine_sub = mine.consume();
+		let mut mine_share = allocator.register(&mine.demand(), 4_000_000);
+
+		let (_sibling_broadcast, sibling) = track(VIDEO);
+		let sibling_sub = sibling.consume();
+		let _sibling_share = allocator.register(&sibling.demand(), 4_000_000);
+
+		assert_eq!(mine_share.changed().await.unwrap(), Some(1_000_000));
+
+		// The sibling's last viewer leaves, so its half comes back to us.
+		drop(sibling_sub);
+		assert_eq!(mine_share.changed().await.unwrap(), Some(2_000_000));
+	}
+
+	/// Records whether a parked poll was actually woken, which re-reading state on a
+	/// fresh `poll` can't tell you: a lost wakeup still looks correct on the next poll
+	/// and only shows up as a task that never runs again.
+	#[derive(Default)]
+	struct Woken(std::sync::atomic::AtomicBool);
+
+	impl std::task::Wake for Woken {
+		fn wake(self: std::sync::Arc<Self>) {
+			self.wake_by_ref();
+		}
+
+		fn wake_by_ref(self: &std::sync::Arc<Self>) {
+			self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+		}
+	}
+
+	impl Woken {
+		/// A flag and its waiter. Both are returned because a [`kio::WaiterList`]
+		/// holds only a `Weak`, so a waiter dropped at the end of the calling
+		/// statement takes its own registration with it and never fires.
+		fn new() -> (std::sync::Arc<Self>, kio::Waiter) {
+			let flag = std::sync::Arc::new(Self::default());
+			let waiter = kio::Waiter::new(std::task::Waker::from(flag.clone()));
+			(flag, waiter)
+		}
+
+		fn woken(&self) -> bool {
+			self.0.load(std::sync::atomic::Ordering::SeqCst)
+		}
+	}
+
+	/// Regression: a share whose slice didn't move still has to leave the estimate's
+	/// waker armed. Reservations cap the slice, so most estimate changes don't reach
+	/// it, and a poll that returned the value without arming anything would park the
+	/// encoder with nothing left to wake it.
+	#[tokio::test]
+	async fn an_unchanged_slice_keeps_watching_the_estimate() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+
+		let (_broadcast, track) = track(VIDEO);
+		let _sub = track.consume();
+		let mut share = allocator.register(&track.demand(), 4_000_000);
+
+		estimate.set(Some(10_000_000)).unwrap();
+		assert_eq!(share.changed().await.unwrap(), Some(4_000_000));
+
+		// Still miles above the reservation, so the slice holds at 4 Mbps: the share
+		// observes the change, decides it doesn't move, and parks.
+		let (woken, waiter) = Woken::new();
+		estimate.set(Some(9_000_000)).unwrap();
+		assert!(share.poll_changed(&waiter).is_pending());
+
+		// The estimate finally drops past the reservation: this has to reach it.
+		estimate.set(Some(1_000_000)).unwrap();
+		assert!(woken.woken(), "a parked share must be woken by the next estimate");
+		assert_eq!(share.changed().await.unwrap(), Some(1_000_000));
+	}
+
+	/// The same, for the other input: a sibling's demand.
+	#[tokio::test]
+	async fn a_parked_share_is_woken_by_sibling_demand() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+		estimate.set(Some(2_000_000)).unwrap();
+
+		let (_mine_broadcast, mine) = track(VIDEO);
+		let _mine_sub = mine.consume();
+		let mut share = allocator.register(&mine.demand(), 4_000_000);
+
+		let (_sibling_broadcast, sibling) = track(VIDEO);
+		let sibling_sub = sibling.consume();
+		let _sibling_share = allocator.register(&sibling.demand(), 4_000_000);
+
+		assert_eq!(share.changed().await.unwrap(), Some(1_000_000));
+
+		let (woken, waiter) = Woken::new();
+		assert!(share.poll_changed(&waiter).is_pending());
+		drop(sibling_sub);
+		assert!(woken.woken(), "a sibling going idle must wake a parked share");
+	}
+
+	/// A share follows the estimate's own lifecycle: unavailable while disconnected
+	/// (hold the current rate), terminal once the session is gone for good.
+	#[tokio::test]
+	async fn a_share_follows_the_estimate_lifecycle() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+
+		let (_broadcast, track) = track(VIDEO);
+		let _sub = track.consume();
+		let mut share = allocator.register(&track.demand(), 4_000_000);
+
+		estimate.set(Some(2_000_000)).unwrap();
+		assert_eq!(share.changed().await.unwrap(), Some(2_000_000));
+
+		estimate.set(None).unwrap();
+		assert_eq!(share.changed().await.unwrap(), None);
+
+		estimate.abort(Error::Cancel).unwrap();
+		assert!(share.changed().await.is_err());
+		assert!(share.changed().await.is_err());
+	}
+
+	/// A closed track's entry can't linger: it would be walked on every poll for the
+	/// rest of the connection, and a long-lived publisher churns tracks.
+	#[tokio::test]
+	async fn a_closed_track_is_pruned() {
+		let estimate = Producer::new();
+		let allocator = Allocator::new(estimate.consume());
+
+		let (_first_broadcast, first) = track(VIDEO);
+		allocator.register(&first.demand(), 4_000_000);
+		first.abort(Error::Cancel).unwrap();
+
+		let (_second_broadcast, second) = track(VIDEO);
+		allocator.register(&second.demand(), 4_000_000);
+
+		assert_eq!(allocator.registry.read().entries.len(), 1);
+	}
 
 	/// An unavailable estimate and a dead producer must not look alike: a caller
 	/// holds its rate for the former and stops watching for the latter.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1925,10 +1925,61 @@ impl Demand {
 		self.abort_reason()
 	}
 
+	/// The publisher's tie-break priority, as set in [`Info::priority`].
+	pub(crate) fn priority(&self) -> u8 {
+		// Always Some once the track exists; a closed one reads its last value.
+		self.state.read().info.as_ref().map_or(0, |info| info.priority)
+	}
+
+	/// Whether anyone is subscribed right now, without waiting.
+	pub(crate) fn is_used(&self) -> bool {
+		self.state.is_used()
+	}
+
+	/// Whether the track is gone, without waiting.
+	pub(crate) fn is_closed(&self) -> bool {
+		self.state.is_closed()
+	}
+
+	/// Read the current demand and arm `waiter` for the next transition.
+	///
+	/// Level-triggered, unlike [`used`](Self::used) / [`unused`](Self::unused): it
+	/// answers what the demand is *now* and wakes on whichever way it can move
+	/// next, so a poll-driven caller watching several tracks at once doesn't have
+	/// to track which edge it's waiting for.
+	pub(crate) fn poll_state(&self, waiter: &kio::Waiter) -> DemandState {
+		loop {
+			match self.state.poll_used(waiter) {
+				Poll::Ready(None) => return DemandState::Closed,
+				// Not used, and armed for it becoming used.
+				Poll::Pending => return DemandState::Idle,
+				// Used, so arm for the reverse.
+				Poll::Ready(Some(())) => match self.state.poll_unused(waiter) {
+					Poll::Ready(None) => return DemandState::Closed,
+					Poll::Pending => return DemandState::Active,
+					// Went idle between the two reads, so neither poll armed anything.
+					// Start over rather than returning a state with no waker behind it.
+					Poll::Ready(Some(())) => continue,
+				},
+			}
+		}
+	}
+
 	/// The recorded abort reason, or [`Error::Dropped`] if the track closed without one.
 	fn abort_reason(&self) -> Error {
 		self.state.read().abort.clone().unwrap_or(Error::Dropped)
 	}
+}
+
+/// What [`Demand::poll_state`] found.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum DemandState {
+	/// At least one subscriber.
+	Active,
+	/// No subscribers, but the track is still open.
+	Idle,
+	/// The track is gone; it will never be demanded again.
+	Closed,
 }
 
 /// A handle to a single track within a broadcast.

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -123,7 +123,11 @@ impl Session {
 			}
 			state.sample
 		};
-		stats.estimated_recv_rate = self.recv_bandwidth.as_ref().and_then(bandwidth::Consumer::peek);
+		stats.estimated_recv_rate = self
+			.recv_bandwidth
+			.as_ref()
+			.and_then(bandwidth::Consumer::peek)
+			.map(bandwidth::Rate::as_bps);
 		stats
 	}
 
@@ -355,7 +359,10 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Timers> Supervisor<S
 		if let Some(producer) = &self.send_bandwidth {
 			// An error means every consumer is gone for good; the stats cell
 			// still wants the sample.
-			if producer.set(sample.estimated_send_rate).is_err() {
+			if producer
+				.set(sample.estimated_send_rate.map(bandwidth::Rate::from_bps))
+				.is_err()
+			{
 				self.send_bandwidth = None;
 			}
 		}

--- a/rs/moq-rtc/src/codec/av1.rs
+++ b/rs/moq-rtc/src/codec/av1.rs
@@ -15,7 +15,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish an `.av1` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.unique_track(".av1", catalog.track_info())?;
+		let track = broadcast.unique_track(".av1", catalog.track_info(hang::catalog::PRIORITY.video))?;
 		let import = moq_mux::codec::av1::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::av1::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/h264.rs
+++ b/rs/moq-rtc/src/codec/h264.rs
@@ -14,7 +14,7 @@ pub struct Bridge {
 
 impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.unique_track(".avc3", catalog.track_info())?;
+		let track = broadcast.unique_track(".avc3", catalog.track_info(hang::catalog::PRIORITY.video))?;
 		let import = moq_mux::codec::h264::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::h264::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/h265.rs
+++ b/rs/moq-rtc/src/codec/h265.rs
@@ -16,7 +16,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish a `.hev1` track on `broadcast`, adding the catalog rendition once config is known.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.unique_track(".hev1", catalog.track_info())?;
+		let track = broadcast.unique_track(".hev1", catalog.track_info(hang::catalog::PRIORITY.video))?;
 		let import = moq_mux::codec::h265::Import::new(track, catalog.reserve(), Default::default())?;
 		let split = moq_mux::codec::h265::Split::new();
 		Ok(Self { split, import })

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -115,7 +115,7 @@ impl<I: DeferredImport> DeferredVideo<I> {
 		catalog: moq_mux::catalog::Producer,
 		suffix: &str,
 	) -> Result<Self> {
-		let track = broadcast.unique_track(suffix, catalog.track_info())?;
+		let track = broadcast.unique_track(suffix, catalog.track_info(hang::catalog::PRIORITY.video))?;
 		Ok(Self {
 			state: DeferredState::Pending(Box::new(PendingVideo { track, catalog })),
 		})

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -17,7 +17,7 @@ impl Bridge {
 		channel_count: u32,
 	) -> Result<Self> {
 		let config = moq_mux::codec::opus::Config::new(sample_rate, channel_count);
-		let track = broadcast.unique_track(".opus", catalog.track_info())?;
+		let track = broadcast.unique_track(".opus", catalog.track_info(hang::catalog::PRIORITY.audio))?;
 		let import = moq_mux::codec::opus::Import::new(track, catalog.reserve(), config.into())?;
 		Ok(Self { import })
 	}

--- a/rs/moq-tokio/src/connection.rs
+++ b/rs/moq-tokio/src/connection.rs
@@ -1452,9 +1452,9 @@ mod tests {
 		assert!(bw.is_some());
 
 		// A value is mirrored through.
-		src.set(Some(3_000)).unwrap();
+		src.set(Some(moq_net::bandwidth::Rate::from_bps(3_000))).unwrap();
 		poll_forward(&mut bw, &out, &waiter);
-		assert_eq!(out_rx.peek(), Some(3_000));
+		assert_eq!(out_rx.peek(), Some(moq_net::bandwidth::Rate::from_bps(3_000)));
 
 		// The estimate becoming unavailable is mirrored, but the arm stays: the
 		// backend reporting nothing right now is not the session ending.
@@ -1466,9 +1466,9 @@ mod tests {
 		// So a later value on the same live session still gets through. Dropping the
 		// arm on the `None` above would have stranded the estimate at `None` for the
 		// rest of the session.
-		src.set(Some(9_000)).unwrap();
+		src.set(Some(moq_net::bandwidth::Rate::from_bps(9_000))).unwrap();
 		poll_forward(&mut bw, &out, &waiter);
-		assert_eq!(out_rx.peek(), Some(9_000));
+		assert_eq!(out_rx.peek(), Some(moq_net::bandwidth::Rate::from_bps(9_000)));
 
 		// Closing the source is what retires the arm, so we stop polling a dead one.
 		src.abort(moq_net::Error::Cancel).unwrap();

--- a/rs/moq-transcode/src/active.rs
+++ b/rs/moq-transcode/src/active.rs
@@ -72,8 +72,8 @@ impl Rendition {
 		self.0.rung.size
 	}
 
-	/// The target bitrate, in bits per second.
-	pub fn bitrate(&self) -> u64 {
+	/// The target bitrate.
+	pub fn bitrate(&self) -> moq_net::bandwidth::Rate {
 		self.0.rung.bitrate
 	}
 
@@ -360,7 +360,7 @@ mod tests {
 		Resolved {
 			name: name.to_string(),
 			size: moq_video::Size::new(height * 16 / 9, height),
-			bitrate: 100_000,
+			bitrate: moq_net::bandwidth::Rate::from_bps(100_000),
 			framerate: 30,
 		}
 	}

--- a/rs/moq-transcode/src/catalog.rs
+++ b/rs/moq-transcode/src/catalog.rs
@@ -13,7 +13,7 @@ pub(crate) struct Resolved {
 	pub name: String,
 	/// The output resolution, derived from the source aspect ratio.
 	pub size: moq_video::Size,
-	pub bitrate: u64,
+	pub bitrate: moq_net::bandwidth::Rate,
 	pub framerate: u32,
 }
 
@@ -81,7 +81,7 @@ pub(crate) fn resolve_rungs(rungs: &[Rung], source_name: &str, source: &VideoCon
 		if height == source_height && source.bitrate.is_none() {
 			continue;
 		}
-		if source.bitrate.is_some_and(|bitrate| rung.bitrate >= bitrate) {
+		if source.bitrate.is_some_and(|bitrate| rung.bitrate.as_bps() >= bitrate) {
 			continue;
 		}
 		// Preserve the source aspect ratio, rounded to even for I420 chroma.
@@ -211,7 +211,7 @@ mod tests {
 
 	#[test]
 	fn same_height_needs_lower_bitrate() {
-		let rungs = vec![Rung::new(480, 1_200_000)];
+		let rungs = vec![Rung::new(480, moq_net::bandwidth::Rate::from_bps(1_200_000))];
 		// Unknown source bitrate: a same-height rung can't prove it's below.
 		assert!(
 			resolve_rungs(&rungs, "video", &source(854, 480, None))
@@ -229,7 +229,7 @@ mod tests {
 	#[test]
 	fn rung_geometry_follows_source_aspect() {
 		let resolved = resolve_rungs(
-			&[Rung::new(360, 600_000)],
+			&[Rung::new(360, moq_net::bandwidth::Rate::from_bps(600_000))],
 			"video",
 			&source(1920, 1080, Some(6_000_000)),
 		)
@@ -239,7 +239,7 @@ mod tests {
 
 		// Vertical video: aspect preserved, width rounded to even.
 		let resolved = resolve_rungs(
-			&[Rung::new(360, 600_000)],
+			&[Rung::new(360, moq_net::bandwidth::Rate::from_bps(600_000))],
 			"video",
 			&source(1080, 1920, Some(6_000_000)),
 		)
@@ -274,7 +274,11 @@ mod tests {
 		config.coded_width = None;
 		config.coded_height = None;
 		assert!(matches!(
-			resolve_rungs(&[Rung::new(360, 600_000)], "video", &config),
+			resolve_rungs(
+				&[Rung::new(360, moq_net::bandwidth::Rate::from_bps(600_000))],
+				"video",
+				&config
+			),
 			Err(Error::SourceDimensions(_))
 		));
 	}
@@ -287,7 +291,7 @@ mod tests {
 		let rung = Resolved {
 			name: "video/360p".to_string(),
 			size: moq_video::Size::new(640, 360),
-			bitrate: 600_000,
+			bitrate: moq_net::bandwidth::Rate::from_bps(600_000),
 			framerate: 30,
 		};
 		let mut source = source(1920, 1080, Some(6_000_000));

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -24,14 +24,14 @@ pub struct Rung {
 	/// Output height in pixels. Rounded down to even (I420 chroma is 2x2).
 	pub height: u32,
 
-	/// Target bitrate in bits per second: the CBR target and the bitrate
-	/// advertised in the derivative catalog.
-	pub bitrate: u64,
+	/// Target bitrate: the CBR target and the bitrate advertised in the derivative
+	/// catalog.
+	pub bitrate: moq_net::bandwidth::Rate,
 }
 
 impl Rung {
-	/// A rung at `height` pixels and `bitrate` bits per second.
-	pub fn new(height: u32, bitrate: u64) -> Self {
+	/// A rung at `height` pixels and `bitrate`.
+	pub fn new(height: u32, bitrate: moq_net::bandwidth::Rate) -> Self {
 		Self { height, bitrate }
 	}
 }
@@ -78,11 +78,11 @@ impl Default for Config {
 			// The default ladder, top rung first, filtered against the source at
 			// runtime so only strictly-lower renditions are offered.
 			rungs: vec![
-				Rung::new(1080, 5_000_000),
-				Rung::new(720, 2_500_000),
-				Rung::new(480, 1_200_000),
-				Rung::new(360, 600_000),
-				Rung::new(240, 350_000),
+				Rung::new(1080, moq_net::bandwidth::Rate::from_bps(5_000_000)),
+				Rung::new(720, moq_net::bandwidth::Rate::from_bps(2_500_000)),
+				Rung::new(480, moq_net::bandwidth::Rate::from_bps(1_200_000)),
+				Rung::new(360, moq_net::bandwidth::Rate::from_bps(600_000)),
+				Rung::new(240, moq_net::bandwidth::Rate::from_bps(350_000)),
 			],
 			source: None,
 			encoder: moq_video::encode::Kind::default(),

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -270,7 +270,7 @@ mod tests {
 		video.framerate = Some(30.0);
 		catalog.lock().video.insert("video", video).unwrap();
 
-		let info = hang::container::track_info();
+		let info = hang::container::track_info(hang::catalog::PRIORITY.video);
 		let mut track = broadcast.create_track("video", info).unwrap();
 
 		let mut encoder = moq_video::encode::Encoder::new(&{
@@ -326,7 +326,7 @@ mod tests {
 		video.framerate = Some(30.0);
 		catalog.lock().video.insert("video", video).unwrap();
 
-		let info = hang::container::track_info();
+		let info = hang::container::track_info(hang::catalog::PRIORITY.video);
 		let mut track = broadcast.create_track("video", info).unwrap();
 
 		let source = Source {

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -386,7 +386,10 @@ mod tests {
 		// source against the encoders the way a live source does.
 		let (source, producer_task) = source_broadcast_live(3, 5);
 		let config = Config {
-			rungs: vec![Rung::new(120, 100_000), Rung::new(60, 50_000)],
+			rungs: vec![
+				Rung::new(120, moq_net::bandwidth::Rate::from_bps(100_000)),
+				Rung::new(60, moq_net::bandwidth::Rate::from_bps(50_000)),
+			],
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Software,
 			source: None,
@@ -452,7 +455,10 @@ mod tests {
 		// encode resolution), so the hardware ladder stays a bit larger than the
 		// software test's.
 		let mut config = Config {
-			rungs: vec![Rung::new(180, 200_000), Rung::new(120, 100_000)],
+			rungs: vec![
+				Rung::new(180, moq_net::bandwidth::Rate::from_bps(200_000)),
+				Rung::new(120, moq_net::bandwidth::Rate::from_bps(100_000)),
+			],
 			encoder: moq_video::encode::Kind::Hardware,
 			decoder: moq_video::decode::Kind::Hardware,
 			source: None,
@@ -530,7 +536,7 @@ mod tests {
 
 		let source = source_broadcast(2, 5);
 		let mut config = Config {
-			rungs: vec![Rung::new(120, 100_000)],
+			rungs: vec![Rung::new(120, moq_net::bandwidth::Rate::from_bps(100_000))],
 			encoder: moq_video::encode::Kind::Hardware,
 			decoder: moq_video::decode::Kind::Hardware,
 			source: None,
@@ -569,7 +575,7 @@ mod tests {
 		let source = source_broadcast(2, 5);
 
 		let config = Config {
-			rungs: vec![Rung::new(120, 100_000)],
+			rungs: vec![Rung::new(120, moq_net::bandwidth::Rate::from_bps(100_000))],
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Software,
 			source: Some(moq_net::PathRelativeOwned::from(".".to_string())),
@@ -675,7 +681,7 @@ mod tests {
 		let source = source_broadcast(2, 5);
 
 		let config = Config {
-			rungs: vec![Rung::new(120, 100_000)],
+			rungs: vec![Rung::new(120, moq_net::bandwidth::Rate::from_bps(100_000))],
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Software,
 			source: None,
@@ -693,7 +699,7 @@ mod tests {
 		let rendition = update.rendition;
 		assert_eq!(rendition.name(), "video/120p");
 		assert_eq!(rendition.size().height, 120);
-		assert_eq!(rendition.bitrate(), 100_000);
+		assert_eq!(rendition.bitrate(), moq_net::bandwidth::Rate::from_bps(100_000));
 		assert!(!update.encoding, "encoding before anyone asked");
 		assert_eq!(rendition.frames(), 0);
 
@@ -729,7 +735,7 @@ mod tests {
 		let source = source_broadcast(1, 3);
 
 		let config = Config {
-			rungs: vec![Rung::new(120, 100_000)],
+			rungs: vec![Rung::new(120, moq_net::bandwidth::Rate::from_bps(100_000))],
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Software,
 			source: None,

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -547,7 +547,7 @@ mod tests {
 		let rung = Resolved {
 			name: "video/120p".to_string(),
 			size: moq_video::Size::new(160, 120),
-			bitrate: 100_000,
+			bitrate: moq_net::bandwidth::Rate::from_bps(100_000),
 			framerate: 30,
 		};
 
@@ -558,7 +558,7 @@ mod tests {
 
 		let mut broadcast = moq_net::broadcast::Info::default().produce();
 		let mut track = broadcast
-			.create_track("video/120p", hang::container::track_info())
+			.create_track("video/120p", hang::container::track_info(hang::catalog::PRIORITY.video))
 			.unwrap();
 		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		let guard = active.attach(&rung);

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -94,7 +94,7 @@ pub(crate) async fn serve(rung: Rung, request: moq_net::track::Request) -> Resul
 	// Grab the group-request handle before accepting: a Request is dynamic from
 	// birth, so a fetch racing the acceptance queues instead of failing.
 	let dynamic = request.dynamic();
-	let info = hang::container::track_info();
+	let info = hang::container::track_info(hang::catalog::PRIORITY.video);
 	let mut producer = request.accept(info);
 
 	let result = tokio::select! {

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -143,7 +143,7 @@ impl MediaFoundation {
 			width: config.width,
 			height: config.height,
 			framerate: config.framerate,
-			bitrate: clamp_u32(config.resolved_bitrate()),
+			bitrate: clamp_u32(config.resolved_bitrate().as_bps()),
 			gop: config.gop,
 			color: config.resolved_color(),
 			started: false,

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -97,7 +97,7 @@ impl Nvenc {
 		cfg.gopLength = config.gop;
 		cfg.frameIntervalP = 1; // no B-frames
 		cfg.rcParams.rateControlMode = NV_ENC_PARAMS_RC_MODE::NV_ENC_PARAMS_RC_CBR;
-		cfg.rcParams.averageBitRate = config.resolved_bitrate().min(u32::MAX as u64) as u32;
+		cfg.rcParams.averageBitRate = config.resolved_bitrate().as_bps().min(u32::MAX as u64) as u32;
 
 		// Two codec-specific knobs the importer relies on, verified on hardware:
 		//   - repeatSPSPPS: emit the parameter sets in-band ahead of *every* IDR,

--- a/rs/moq-video/src/encode/backend/openh264.rs
+++ b/rs/moq-video/src/encode/backend/openh264.rs
@@ -52,7 +52,9 @@ impl Openh264 {
 		.full_range(!color.limited());
 
 		let cfg = EncoderConfig::new()
-			.bitrate(BitRate::from_bps(config.resolved_bitrate().min(u32::MAX as u64) as u32))
+			.bitrate(BitRate::from_bps(
+				config.resolved_bitrate().as_bps().min(u32::MAX as u64) as u32,
+			))
 			.max_frame_rate(FrameRate::from_hz(config.framerate as f32))
 			.rate_control_mode(RateControlMode::Bitrate)
 			// Real-time camera: prioritize latency over compression.
@@ -211,7 +213,7 @@ mod tests {
 		let mut enc = Openh264::new(&config()).unwrap();
 		enc.encode(&gray(), true).unwrap();
 
-		let lower = config().resolved_bitrate() / 2;
+		let lower = config().resolved_bitrate().as_bps() / 2;
 		enc.set_bitrate(lower).unwrap();
 		assert_eq!(enc.read_bitrate(), lower as i64);
 	}
@@ -225,7 +227,7 @@ mod tests {
 		let mut enc = Openh264::new(&config()).unwrap();
 		enc.encode(&gray(), true).unwrap();
 
-		let higher = config().resolved_bitrate() * 4;
+		let higher = config().resolved_bitrate().as_bps() * 4;
 		assert!(enc.set_bitrate(higher).is_err());
 	}
 
@@ -236,7 +238,7 @@ mod tests {
 	fn set_bitrate_at_the_opening_rate_is_accepted() {
 		let mut enc = Openh264::new(&config()).unwrap();
 		enc.encode(&gray(), true).unwrap();
-		let opened = config().resolved_bitrate();
+		let opened = config().resolved_bitrate().as_bps();
 
 		enc.set_bitrate(opened / 2).unwrap();
 		enc.set_bitrate(opened).unwrap();
@@ -251,7 +253,7 @@ mod tests {
 	#[test]
 	fn a_live_set_supersedes_a_deferred_one() {
 		let mut enc = Openh264::new(&config()).unwrap();
-		let opened = config().resolved_bitrate();
+		let opened = config().resolved_bitrate().as_bps();
 
 		// Deferred: the encoder doesn't exist yet.
 		enc.set_bitrate(opened / 2).unwrap();

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -38,7 +38,7 @@ unsafe impl Send for Vaapi {}
 
 impl Vaapi {
 	pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
-		let bitrate = config.resolved_bitrate().min(u32::MAX as u64) as u32;
+		let bitrate = config.resolved_bitrate().as_bps().min(u32::MAX as u64) as u32;
 		let vaapi = VaapiConfig::new(config.width, config.height, config.framerate, bitrate, config.gop);
 		let encoder = Encoder::new(vaapi).map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI encoder init: {e:?}")))?;
 

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -124,7 +124,7 @@ impl VideoToolbox {
 		set_number(
 			&session,
 			unsafe { kVTCompressionPropertyKey_AverageBitRate },
-			clamp_i32(config.resolved_bitrate()),
+			clamp_i32(config.resolved_bitrate().as_bps()),
 		)?;
 		set_number(
 			&session,

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -56,9 +56,9 @@ pub struct Config {
 	pub width: u32,
 	pub height: u32,
 	pub framerate: u32,
-	/// Target bitrate in bits per second. `None` derives a sane default
+	/// Target bitrate. `None` derives a sane default
 	/// from resolution and framerate (~0.07 bits per pixel per second).
-	pub bitrate: Option<u64>,
+	pub bitrate: Option<moq_net::bandwidth::Rate>,
 	/// Keyframe interval in frames. Subscribers joining mid-stream wait at
 	/// most this many frames before they can start decoding.
 	pub gop: u32,
@@ -152,7 +152,7 @@ impl Config {
 
 		// Neither is in the bitstream: the target bitrate is nowhere in it, and the framerate only
 		// rides in an optional VUI. Fill them from the config that produced the rest.
-		rendition.bitrate.get_or_insert(self.resolved_bitrate());
+		rendition.bitrate.get_or_insert(self.resolved_bitrate().as_bps());
 		rendition.framerate.get_or_insert(self.framerate.into());
 		Ok(rendition)
 	}
@@ -166,7 +166,7 @@ impl Config {
 	}
 
 	/// Resolved bitrate: explicit override, or a pixels-per-second estimate.
-	pub(crate) fn resolved_bitrate(&self) -> u64 {
+	pub(crate) fn resolved_bitrate(&self) -> moq_net::bandwidth::Rate {
 		self.bitrate
 			.unwrap_or_else(|| default_bitrate(self.size(), self.framerate))
 	}
@@ -174,8 +174,8 @@ impl Config {
 
 /// The bitrate an unconfigured encode resolves to: 0.07 bits per pixel per second, which matches
 /// the JS publisher's default and lands ~4.4 Mbps for 1080p30.
-pub(crate) fn default_bitrate(size: Size, framerate: u32) -> u64 {
-	((size.pixels() * framerate as u64) as f64 * 0.07) as u64
+pub(crate) fn default_bitrate(size: Size, framerate: u32) -> moq_net::bandwidth::Rate {
+	moq_net::bandwidth::Rate::from_bps(((size.pixels() * framerate as u64) as f64 * 0.07) as u64)
 }
 
 /// Video encoder. Build one with [`Encoder::new`], feed it raw [`Frame`]s via
@@ -185,7 +185,7 @@ pub struct Encoder {
 	backend: Box<dyn Backend>,
 	codec: Codec,
 	size: Size,
-	bitrate: u64,
+	bitrate: moq_net::bandwidth::Rate,
 	/// What the backend wrote into the bitstream's VUI, kept so a frame declaring
 	/// a different space is caught rather than silently mislabeled.
 	color: Color,
@@ -230,15 +230,13 @@ impl Encoder {
 		self.size
 	}
 
-	/// The current target bitrate in bits per second: what
-	/// [`Config::bitrate`] resolved to at open, or the last value
-	/// [`set_bitrate`](Self::set_bitrate) accepted.
-	pub fn bitrate(&self) -> u64 {
+	/// The current target bitrate: what [`Config::bitrate`] resolved to at open, or
+	/// the last value [`set_bitrate`](Self::set_bitrate) accepted.
+	pub fn bitrate(&self) -> moq_net::bandwidth::Rate {
 		self.bitrate
 	}
 
-	/// Retune the live encoder to `bitrate` bits per second, taking effect from
-	/// roughly the next frame. No IDR is forced, so this is cheap enough to
+	/// Retune the live encoder to `bitrate`, taking effect from roughly the next frame. No IDR is forced, so this is cheap enough to
 	/// drive from a congestion controller: pair it with
 	/// [`rate::Control`](super::rate::Control), which decides *when* the target
 	/// is worth moving.
@@ -251,11 +249,13 @@ impl Encoder {
 	/// running. That's not fatal: the encoder keeps running at its current rate,
 	/// so a caller driving a control loop should stop adapting rather than stop
 	/// encoding.
-	pub fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+	pub fn set_bitrate(&mut self, bitrate: moq_net::bandwidth::Rate) -> Result<(), Error> {
 		if bitrate == self.bitrate {
 			return Ok(());
 		}
-		self.backend.set_bitrate(bitrate)?;
+		// The backends speak to codec APIs that want a plain integer, so the unit is
+		// unwrapped once here rather than in each of them.
+		self.backend.set_bitrate(bitrate.as_bps())?;
 		// Only after the backend accepts it, so a failed set doesn't leave the
 		// getter reporting a rate the encoder isn't using.
 		self.bitrate = bitrate;
@@ -833,7 +833,7 @@ mod tests {
 		// Encode first: this is the live-retune path, once the encoder exists.
 		encoder.encode(&gray_frame(320, 240, 0)).unwrap();
 
-		let halved = opened / 2;
+		let halved = opened.scaled(0.5);
 		encoder.set_bitrate(halved).unwrap();
 		assert_eq!(encoder.bitrate(), halved);
 
@@ -855,7 +855,7 @@ mod tests {
 		};
 		let mut encoder = Encoder::new(&config).unwrap();
 
-		let halved = encoder.bitrate() / 2;
+		let halved = encoder.bitrate().scaled(0.5);
 		encoder.set_bitrate(halved).expect("a retune before the first frame");
 		assert_eq!(encoder.bitrate(), halved);
 
@@ -864,7 +864,7 @@ mod tests {
 		assert!(!frames.is_empty());
 
 		// And the encoder is live now, so a further retune takes the direct path.
-		encoder.set_bitrate(halved / 2).unwrap();
+		encoder.set_bitrate(halved.scaled(0.5)).unwrap();
 		assert!(encoder.encode(&gray_frame(320, 240, 1)).is_ok());
 	}
 
@@ -888,7 +888,7 @@ mod tests {
 		let small = Config::new(320, 240, 30).resolved_bitrate();
 		let large = Config::new(1920, 1080, 30).resolved_bitrate();
 		assert!(large > small);
-		assert!(small > 0);
+		assert!(small > moq_net::bandwidth::Rate::ZERO);
 	}
 
 	/// A backend that holds each frame back by one, like the Media Foundation MFT:

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -219,12 +219,12 @@ impl<E: CatalogExt> Producer<E> {
 #[non_exhaustive]
 #[cfg(feature = "capture")]
 pub struct Options {
-	/// Target bitrate in bits per second; `None` derives from resolution.
+	/// Target bitrate; `None` derives one from the resolution.
 	///
 	/// This is a ceiling, not a fixed rate: with [`bandwidth`](Self::bandwidth)
 	/// set, the encoder backs off below it while the uplink is congested and
 	/// climbs back afterwards, but never exceeds it.
-	pub bitrate: Option<u64>,
+	pub bitrate: Option<moq_net::bandwidth::Rate>,
 	/// Output codec. Defaults to [`Codec::H264`].
 	pub codec: Codec,
 	/// Encoder implementation preference.
@@ -233,18 +233,17 @@ pub struct Options {
 	/// [`Session::send_bandwidth`](moq_net::Session::send_bandwidth) (or
 	/// `moq_tokio::Connection::send_bandwidth`, which survives reconnects).
 	///
-	/// Set it and the encoder registers this track, then tracks its share of the
-	/// estimate per the default [`rate::Policy`](super::rate::Policy), so a closing
-	/// uplink gets a softer picture instead of a stalled one. Pass the same
-	/// allocator to every sender on the connection, including the audio side:
-	/// that's what keeps their bitrates summing to the uplink instead of each
-	/// matching it.
+	/// Set it and the encoder reserves this track's ceiling, then tracks its share of
+	/// the estimate per the default [`rate::Policy`](super::rate::Policy), so a closing
+	/// uplink gets a softer picture instead of a stalled one. Pass the same allocator
+	/// to every sender on the connection, including the audio side: that's what keeps
+	/// their bitrates summing to the uplink instead of each matching it.
 	///
-	/// Leave it `None` and the encoder holds [`bitrate`](Self::bitrate) regardless
-	/// of congestion, which is what you want when the estimate isn't meaningful (a
-	/// local file, a test harness) or unavailable (a publisher that only accepts
-	/// inbound sessions).
-	pub bandwidth: Option<moq_net::bandwidth::Allocator>,
+	/// Defaults to [`Allocator::unlimited`](moq_net::bandwidth::Allocator::unlimited),
+	/// which holds [`bitrate`](Self::bitrate) regardless of congestion. That's what you
+	/// want when the estimate isn't meaningful (a local file, a test harness) or
+	/// unavailable (a publisher that only accepts inbound sessions).
+	pub bandwidth: moq_net::bandwidth::Allocator,
 }
 
 /// Capture a webcam and publish it as an on-demand video track.
@@ -332,21 +331,23 @@ fn assert_publish_capture_send(
 	is_send(&publish_capture(broadcast, catalog, capture, encode, clock));
 }
 
-/// The live rate control state: the estimate source paired with the policy
-/// tracking it. `None` once there's nothing left to track, which is what stops
-/// the `select!` arm from spinning on a channel that is permanently ready.
+/// The live rate control state: the estimate source paired with the policy tracking
+/// it. `None` once it has *retired*, which is the only thing absence means now that
+/// every encoder has a share to read: an allocator with nothing to divide grants
+/// `None` rather than being absent. Retiring stops the `select!` arm from spinning on
+/// a channel that is permanently ready.
 #[cfg(feature = "capture")]
-type Rate = Option<(moq_net::bandwidth::Consumer, Control)>;
+type RateControl = Option<(moq_net::bandwidth::Consumer, Control)>;
 
 /// Wait for the next bandwidth estimate, or forever when rate control is off or
 /// finished. Cancel-safe: [`Consumer::changed`](moq_net::bandwidth::Consumer::changed)
 /// only reads shared state, so losing this race to a frame drops no estimate,
 /// it just re-reads the latest one next time round.
 #[cfg(feature = "capture")]
-async fn next_estimate(rate: &mut Rate) -> Option<Option<u64>> {
+async fn next_estimate(rate: &mut RateControl) -> Option<Option<moq_net::bandwidth::Rate>> {
 	match rate {
 		Some((bandwidth, _)) => bandwidth.changed().await.ok(),
-		// No estimate source: park this arm forever so `select!` ignores it.
+		// Retired: park this arm forever so `select!` ignores it.
 		None => std::future::pending().await,
 	}
 }
@@ -357,7 +358,11 @@ async fn next_estimate(rate: &mut Rate) -> Option<Option<u64>> {
 /// control retires; a `Some(None)` estimate means the value is merely
 /// unavailable right now, which the policy holds through.
 #[cfg(feature = "capture")]
-async fn apply_estimate(encoder: &mut Sink, rate: &mut Rate, estimate: Option<Option<u64>>) {
+async fn apply_estimate(
+	encoder: &mut Sink,
+	rate: &mut RateControl,
+	estimate: Option<Option<moq_net::bandwidth::Rate>>,
+) {
 	let Some((_, control)) = rate.as_mut() else { return };
 
 	let Some(estimate) = estimate else {
@@ -371,7 +376,7 @@ async fn apply_estimate(encoder: &mut Sink, rate: &mut Rate, estimate: Option<Op
 	};
 
 	match encoder.set_bitrate(bitrate).await {
-		Ok(()) => tracing::debug!(bitrate, estimate, "adjusted encoder bitrate"),
+		Ok(()) => tracing::debug!(bitrate = bitrate.as_bps(), "adjusted encoder bitrate"),
 		// The encoder can't retune, so keep encoding at the rate it opened with
 		// and stop asking. Dropping the source also stops the estimate arm, which
 		// would otherwise wake this loop for nothing on every change.
@@ -382,7 +387,7 @@ async fn apply_estimate(encoder: &mut Sink, rate: &mut Rate, estimate: Option<Op
 		// A transient failure: keep the policy running so the next change retries.
 		// The policy already moved its target, so a persistent failure just means
 		// the encoder trails it; that's better than giving up on the first blip.
-		Err(err) => tracing::warn!(error = %err, bitrate, "failed to adjust encoder bitrate"),
+		Err(err) => tracing::warn!(error = %err, bitrate = bitrate.as_bps(), "failed to adjust encoder bitrate"),
 	}
 }
 
@@ -415,11 +420,10 @@ async fn capture_loop<E: CatalogExt>(
 	encode: &Options,
 	clock: &moq_mux::Clock,
 ) -> Result<(), Error> {
-	// This track's slice of the connection, once the encoder's ceiling is known,
-	// paired with the ceiling it was reserved for. Unset when the caller passed no
-	// allocator, which means encode at the configured bitrate and ignore congestion
-	// entirely.
-	let mut share: Option<(moq_net::bandwidth::Consumer, u64)> = None;
+	// This track's claim on the connection. Taken on the first open, because the
+	// negotiated mode is what finally says how much this encoder can ever send, and
+	// held across reopens so the claim doesn't lapse while the camera is closed.
+	let mut reservation: Option<moq_net::bandwidth::Reservation> = None;
 
 	loop {
 		// Idle until a viewer subscribes; the track ending is a clean exit. The
@@ -450,28 +454,19 @@ async fn capture_loop<E: CatalogExt>(
 		let mut force_keyframe = true;
 		tracing::info!(encoder = encoder.name(), device = camera.device(), "capturing");
 
-		// The negotiated mode is what finally says how much this encoder can ever
-		// send, so the reservation waits for the first open. A reopen that lands on
-		// the same mode keeps the reservation it already holds; one that negotiates
-		// a different mode replaces it, since the old ceiling would either cap a
-		// larger mode or keep claiming room a smaller one no longer needs.
+		// A reopen can negotiate a different mode (a display resized while nothing was
+		// subscribed), and the claim follows it: the old ceiling would otherwise cap a
+		// larger mode below what it can send, or keep claiming room a smaller one no
+		// longer needs.
 		let ceiling = encoder_config.resolved_bitrate();
-		if share.as_ref().is_none_or(|(_, reserved)| *reserved != ceiling)
-			&& let Some(allocator) = &encode.bandwidth
-		{
-			// Released before the new claim, since registering again would otherwise
-			// leave the old reservation standing for the rest of the connection.
-			drop(share.take());
-			share = Some((allocator.register(demand, ceiling), ceiling));
-		}
+		let reservation = reservation.get_or_insert_with(|| encode.bandwidth.reserve(demand, ceiling));
+		reservation.update(ceiling);
 
 		// Rate control is per encoder: this one opened at the configured bitrate,
 		// so the policy's ceiling is that rate and the target starts there. A
 		// reopened camera starts optimistic again rather than inheriting the
 		// backed-off rate from whatever the link was doing last time.
-		let mut rate = share
-			.as_ref()
-			.map(|(share, _)| (share.clone(), Control::new(Policy::new(ceiling))));
+		let mut rate = Some((reservation.consumer(), Control::new(Policy::new(ceiling))));
 
 		loop {
 			// Race the next frame against the last viewer leaving so we release the
@@ -606,7 +601,7 @@ mod tests {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let mut config = Config::new(1920, 1080, 30);
-		config.bitrate = Some(6_000_000);
+		config.bitrate = Some(moq_net::bandwidth::Rate::from_mbps(6));
 		// Software (openh264) so the test is deterministic and never touches a hardware backend.
 		config.kind = encoder::Kind::Software;
 		let _producer = Producer::new(broadcast, catalog, config.probe().await.unwrap()).unwrap();

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -215,7 +215,7 @@ impl<E: CatalogExt> Producer<E> {
 ///
 /// `#[non_exhaustive]`: construct via [`Options::default`] and set fields, so
 /// new knobs can be added without breaking callers.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 #[cfg(feature = "capture")]
 pub struct Options {
@@ -229,31 +229,22 @@ pub struct Options {
 	pub codec: Codec,
 	/// Encoder implementation preference.
 	pub kind: encoder::Kind,
-	/// The connection's send-bandwidth estimate, from
+	/// The connection's bandwidth, as an allocator over
 	/// [`Session::send_bandwidth`](moq_net::Session::send_bandwidth) (or
 	/// `moq_tokio::Connection::send_bandwidth`, which survives reconnects).
 	///
-	/// Set it and the encoder tracks the estimate per the default
-	/// [`rate::Policy`](super::rate::Policy), so a closing uplink gets a softer
-	/// picture instead of a stalled one. Leave it `None` and the
-	/// encoder holds [`bitrate`](Self::bitrate) regardless of congestion, which
-	/// is what you want when the estimate isn't meaningful (a local file, a test
-	/// harness) or unavailable (a publisher that only accepts inbound sessions).
-	pub bandwidth: Option<moq_net::bandwidth::Consumer>,
-}
-
-// Hand-written: `bandwidth::Consumer` isn't `Debug`, but its presence is the
-// only part worth printing anyway.
-#[cfg(feature = "capture")]
-impl std::fmt::Debug for Options {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("Options")
-			.field("bitrate", &self.bitrate)
-			.field("codec", &self.codec)
-			.field("kind", &self.kind)
-			.field("bandwidth", &self.bandwidth.is_some())
-			.finish()
-	}
+	/// Set it and the encoder registers this track, then tracks its share of the
+	/// estimate per the default [`rate::Policy`](super::rate::Policy), so a closing
+	/// uplink gets a softer picture instead of a stalled one. Pass the same
+	/// allocator to every sender on the connection, including the audio side:
+	/// that's what keeps their bitrates summing to the uplink instead of each
+	/// matching it.
+	///
+	/// Leave it `None` and the encoder holds [`bitrate`](Self::bitrate) regardless
+	/// of congestion, which is what you want when the estimate isn't meaningful (a
+	/// local file, a test harness) or unavailable (a publisher that only accepts
+	/// inbound sessions).
+	pub bandwidth: Option<moq_net::bandwidth::Allocator>,
 }
 
 /// Capture a webcam and publish it as an on-demand video track.
@@ -424,6 +415,11 @@ async fn capture_loop<E: CatalogExt>(
 	encode: &Options,
 	clock: &moq_mux::Clock,
 ) -> Result<(), Error> {
+	// This track's slice of the connection, once the encoder's ceiling is known.
+	// Unset when the caller passed no allocator, which means encode at the
+	// configured bitrate and ignore congestion entirely.
+	let mut share: Option<moq_net::bandwidth::Consumer> = None;
+
 	loop {
 		// Idle until a viewer subscribes; the track ending is a clean exit. The
 		// catalog rendition was published when the track was created, so a
@@ -453,14 +449,22 @@ async fn capture_loop<E: CatalogExt>(
 		let mut force_keyframe = true;
 		tracing::info!(encoder = encoder.name(), device = camera.device(), "capturing");
 
+		// The negotiated mode is what finally says how much this encoder can ever
+		// send, so the reservation waits for the first open. It's kept across
+		// reopens: one registry entry per publish, and the allocator releases the
+		// share on its own while nothing is subscribed.
+		let ceiling = encoder_config.resolved_bitrate();
+		if share.is_none()
+			&& let Some(allocator) = &encode.bandwidth
+		{
+			share = Some(allocator.register(demand, ceiling));
+		}
+
 		// Rate control is per encoder: this one opened at the configured bitrate,
 		// so the policy's ceiling is that rate and the target starts there. A
 		// reopened camera starts optimistic again rather than inheriting the
 		// backed-off rate from whatever the link was doing last time.
-		let mut rate = encode
-			.bandwidth
-			.clone()
-			.map(|bandwidth| (bandwidth, Control::new(Policy::new(encoder_config.resolved_bitrate()))));
+		let mut rate = share.clone().map(|share| (share, Control::new(Policy::new(ceiling))));
 
 		loop {
 			// Race the next frame against the last viewer leaving so we release the

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -415,10 +415,11 @@ async fn capture_loop<E: CatalogExt>(
 	encode: &Options,
 	clock: &moq_mux::Clock,
 ) -> Result<(), Error> {
-	// This track's slice of the connection, once the encoder's ceiling is known.
-	// Unset when the caller passed no allocator, which means encode at the
-	// configured bitrate and ignore congestion entirely.
-	let mut share: Option<moq_net::bandwidth::Consumer> = None;
+	// This track's slice of the connection, once the encoder's ceiling is known,
+	// paired with the ceiling it was reserved for. Unset when the caller passed no
+	// allocator, which means encode at the configured bitrate and ignore congestion
+	// entirely.
+	let mut share: Option<(moq_net::bandwidth::Consumer, u64)> = None;
 
 	loop {
 		// Idle until a viewer subscribes; the track ending is a clean exit. The
@@ -450,21 +451,27 @@ async fn capture_loop<E: CatalogExt>(
 		tracing::info!(encoder = encoder.name(), device = camera.device(), "capturing");
 
 		// The negotiated mode is what finally says how much this encoder can ever
-		// send, so the reservation waits for the first open. It's kept across
-		// reopens: one registry entry per publish, and the allocator releases the
-		// share on its own while nothing is subscribed.
+		// send, so the reservation waits for the first open. A reopen that lands on
+		// the same mode keeps the reservation it already holds; one that negotiates
+		// a different mode replaces it, since the old ceiling would either cap a
+		// larger mode or keep claiming room a smaller one no longer needs.
 		let ceiling = encoder_config.resolved_bitrate();
-		if share.is_none()
+		if share.as_ref().is_none_or(|(_, reserved)| *reserved != ceiling)
 			&& let Some(allocator) = &encode.bandwidth
 		{
-			share = Some(allocator.register(demand, ceiling));
+			// Released before the new claim, since registering again would otherwise
+			// leave the old reservation standing for the rest of the connection.
+			drop(share.take());
+			share = Some((allocator.register(demand, ceiling), ceiling));
 		}
 
 		// Rate control is per encoder: this one opened at the configured bitrate,
 		// so the policy's ceiling is that rate and the target starts there. A
 		// reopened camera starts optimistic again rather than inheriting the
 		// backed-off rate from whatever the link was doing last time.
-		let mut rate = share.clone().map(|share| (share, Control::new(Policy::new(ceiling))));
+		let mut rate = share
+			.as_ref()
+			.map(|(share, _)| (share.clone(), Control::new(Policy::new(ceiling))));
 
 		loop {
 			// Race the next frame against the last viewer leaving so we release the

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -105,7 +105,7 @@ impl<E: CatalogExt> Producer<E> {
 				)));
 			}
 		};
-		let track = broadcast.unique_track(suffix, catalog.track_info())?;
+		let track = broadcast.unique_track(suffix, catalog.track_info(hang::catalog::PRIORITY.video))?;
 		Self::with_track(track, catalog, rendition)
 	}
 

--- a/rs/moq-video/src/encode/rate.rs
+++ b/rs/moq-video/src/encode/rate.rs
@@ -3,21 +3,36 @@
 //!
 //! [`Control`] is the one place this policy lives, so every sender backs off the
 //! same way. It's a pure function of the estimate: feed it every value from a
-//! [`bandwidth::Consumer`](moq_net::bandwidth::Consumer) and hand what it
+//! [`bandwidth::Consumer`] and hand what it
 //! returns to [`Encoder::set_bitrate`](super::Encoder::set_bitrate).
 
 use std::time::Instant;
 
+use moq_net::bandwidth;
+
+/// Ignore moves smaller than this fraction of the current target, so a jittering
+/// estimate doesn't reconfigure the encoder on every 100ms sample.
+const HYSTERESIS: f64 = 0.05;
+
+/// How fast the target may climb back, as a fraction of the current target per second
+/// (~3s from the floor back to a 2x higher rate).
+///
+/// Drops ignore this and apply at once. Overshooting a closing uplink costs a stalled
+/// picture, while undershooting an opening one costs a few seconds of lower quality,
+/// so the response is deliberately asymmetric.
+const RAMP: f64 = 0.25;
+
 /// How a bandwidth estimate maps onto the bitrate a sender should produce at.
 ///
-/// Build one with [`Policy::new`] and override what you need. The defaults are
-/// tuned for a live contribution encoder on a cellular uplink: give back
-/// bandwidth immediately when the pipe closes, take it back slowly when it
-/// opens, and don't twitch at every jitter in the estimate.
+/// Build one with [`Policy::new`]. The behaviour is tuned for a live contribution
+/// encoder on a cellular uplink: give back bandwidth immediately when the pipe closes,
+/// take it back slowly when it opens, and don't twitch at every jitter in the estimate.
+/// The deadband and ramp that implement that are deliberately not knobs; they are
+/// properties of how congestion control behaves, not of any one sender.
 ///
 /// The estimate handed in is expected to be this sender's alone. Splitting one
 /// connection's estimate among the senders sharing it is
-/// [`bandwidth::Allocator`](moq_net::bandwidth::Allocator)'s job, one layer down,
+/// [`bandwidth::Allocator`]'s job, one layer down,
 /// so nothing here holds a fraction back for anyone else.
 ///
 /// `#[non_exhaustive]`: construct via [`Policy::new`] and set fields, so new
@@ -25,40 +40,25 @@ use std::time::Instant;
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Policy {
-	/// Upper bound in bits per second, normally the bitrate the caller asked
-	/// for. The estimate can only ever take the target *down* from here: an
-	/// optimistic estimate is not a reason to send more than was configured.
-	pub max: u64,
+	/// Upper bound, normally the bitrate the caller asked for. The estimate can only
+	/// ever take the target *down* from here: an optimistic estimate is not a reason
+	/// to send more than was configured.
+	pub max: bandwidth::Rate,
 
-	/// Lower bound in bits per second. Below some rate the picture isn't worth
-	/// sending, so the target holds here and the transport's priority queue
-	/// sheds the excess instead. Defaults to a tenth of `max`.
-	pub min: u64,
-
-	/// Ignore moves smaller than this fraction of the current target, so a
-	/// jittering estimate doesn't reconfigure the encoder every 100ms.
-	/// Defaults to 0.05 (5%).
-	pub hysteresis: f64,
-
-	/// How fast the target may climb back, as a fraction of the current target
-	/// per second. Defaults to 0.25 (25%/s, so ~3s from the floor back to a 2x
-	/// higher rate). Drops ignore this and apply at once: overshooting a closing
-	/// uplink costs a stalled picture, while undershooting an opening one costs
-	/// only a few seconds of lower quality.
-	pub ramp: f64,
+	/// Lower bound. Below some rate the picture isn't worth sending, so the target
+	/// holds here and the transport's priority queue sheds the excess instead.
+	/// Defaults to a tenth of `max`.
+	pub min: bandwidth::Rate,
 }
 
 impl Policy {
-	/// A policy targeting at most `max` bits per second, with the documented
-	/// defaults for every other knob.
-	pub fn new(max: u64) -> Self {
+	/// A policy targeting at most `max`, with a floor a tenth of it.
+	pub fn new(max: bandwidth::Rate) -> Self {
 		Self {
 			max,
 			// A tenth of the ceiling: low enough to ride out a bad uplink, high
 			// enough that what we do send is still worth decoding.
-			min: max / 10,
-			hysteresis: 0.05,
-			ramp: 0.25,
+			min: bandwidth::Rate::from_bps(max.as_bps() / 10),
 		}
 	}
 }
@@ -66,16 +66,20 @@ impl Policy {
 /// Maps bandwidth estimates onto a target bitrate, per a [`Policy`].
 ///
 /// Feed it every estimate from a
-/// [`bandwidth::Consumer`](moq_net::bandwidth::Consumer); it returns a new
+/// [`bandwidth::Consumer`]; it returns a new
 /// target only when one is worth applying, so a caller can hand the result
 /// straight to an encoder without rate-limiting it further:
 ///
 /// ```
 /// # use moq_video::encode::rate::{Control, Policy};
+/// # use moq_net::bandwidth;
 /// # use std::time::Instant;
-/// let mut control = Control::new(Policy::new(4_000_000));
+/// let mut control = Control::new(Policy::new(bandwidth::Rate::from_mbps(4)));
 /// // A 2 Mbps estimate takes the 4 Mbps target down to what the link will carry.
-/// assert_eq!(control.update(Some(2_000_000), Instant::now()), Some(2_000_000));
+/// assert_eq!(
+///     control.update(Some(bandwidth::Rate::from_mbps(2)), Instant::now()),
+///     Some(bandwidth::Rate::from_mbps(2))
+/// );
 /// ```
 ///
 /// The time source is a parameter rather than an [`Instant::now`] call so the
@@ -83,8 +87,8 @@ impl Policy {
 #[derive(Clone, Debug)]
 pub struct Control {
 	policy: Policy,
-	target: u64,
-	/// When the target last moved, anchoring the [`Policy::ramp`] limit. `None`
+	target: bandwidth::Rate,
+	/// When the target last moved, anchoring the [`RAMP`] limit. `None`
 	/// until the first change, when there's nothing to ramp from.
 	applied: Option<Instant>,
 }
@@ -100,8 +104,8 @@ impl Control {
 		}
 	}
 
-	/// The current target in bits per second.
-	pub fn target(&self) -> u64 {
+	/// The current target bitrate.
+	pub fn target(&self) -> bandwidth::Rate {
 		self.target
 	}
 
@@ -111,7 +115,7 @@ impl Control {
 	/// A `None` estimate (no congestion controller, or disconnected) holds the
 	/// current target rather than resetting to [`Policy::max`]: losing the
 	/// estimate is not evidence the uplink got better.
-	pub fn update(&mut self, estimate: Option<u64>, now: Instant) -> Option<u64> {
+	pub fn update(&mut self, estimate: Option<bandwidth::Rate>, now: Instant) -> Option<bandwidth::Rate> {
 		let estimate = estimate?;
 
 		// Normalize rather than trusting the fields: `min > max` would make the
@@ -128,9 +132,8 @@ impl Control {
 			match self.applied {
 				Some(applied) => {
 					let elapsed = now.saturating_duration_since(applied).as_secs_f64();
-					let ramp = self.policy.ramp.max(0.0);
-					let grown = self.target as f64 * (1.0 + ramp * elapsed);
-					(grown as u64).min(desired).clamp(min, self.policy.max)
+					let grown = self.target.scaled(1.0 + RAMP * elapsed);
+					grown.min(desired).clamp(min, self.policy.max)
 				}
 				None => desired,
 			}
@@ -158,8 +161,7 @@ impl Control {
 		// Drops keep the deadband either way: sitting a little above a falling
 		// estimate is what it's for.
 		let settling = next > self.target && next == self.policy.max;
-		let hysteresis = self.policy.hysteresis.max(0.0);
-		if !settling && (next.abs_diff(self.target) as f64) < self.target as f64 * hysteresis {
+		if !settling && next.abs_diff(self.target) < self.target.scaled(HYSTERESIS) {
 			return None;
 		}
 
@@ -175,76 +177,86 @@ mod tests {
 
 	use super::*;
 
+	/// Bits per second, so the tables below stay readable.
+	fn bps(bps: u64) -> bandwidth::Rate {
+		bandwidth::Rate::from_bps(bps)
+	}
+
 	/// 4 Mbps ceiling, so the max/10 floor lands on a round 400 kbps.
 	fn control() -> Control {
-		Control::new(Policy::new(4_000_000))
+		Control::new(Policy::new(bps(4_000_000)))
 	}
 
 	#[test]
 	fn starts_optimistic() {
-		assert_eq!(control().target(), 4_000_000);
+		assert_eq!(control().target(), bps(4_000_000));
 	}
 
 	#[test]
 	fn drop_applies_immediately() {
 		let mut control = control();
 		// A 2 Mbps pipe: take the target down to it at once, no ramp, no waiting.
-		assert_eq!(control.update(Some(2_000_000), Instant::now()), Some(2_000_000));
-		assert_eq!(control.target(), 2_000_000);
+		assert_eq!(
+			control.update(Some(bps(2_000_000)), Instant::now()),
+			Some(bps(2_000_000))
+		);
+		assert_eq!(control.target(), bps(2_000_000));
 	}
 
 	#[test]
 	fn missing_estimate_holds_the_target() {
 		let mut control = control();
 		let now = Instant::now();
-		control.update(Some(2_000_000), now).unwrap();
+		control.update(Some(bps(2_000_000)), now).unwrap();
 
 		// Losing the estimate (disconnected) is not evidence the uplink is
 		// healthy again, so the target must not jump back to max.
 		assert_eq!(control.update(None, now + Duration::from_secs(10)), None);
-		assert_eq!(control.target(), 2_000_000);
+		assert_eq!(control.target(), bps(2_000_000));
 	}
 
 	#[test]
 	fn estimate_never_raises_above_max() {
 		let mut control = control();
 		// A wildly optimistic estimate is not licence to exceed what was configured.
-		assert_eq!(control.update(Some(100_000_000), Instant::now()), None);
-		assert_eq!(control.target(), 4_000_000);
+		assert_eq!(control.update(Some(bps(100_000_000)), Instant::now()), None);
+		assert_eq!(control.target(), bps(4_000_000));
 	}
 
 	#[test]
 	fn target_never_falls_below_min() {
 		let mut control = control();
 		// A near-dead uplink floors at min (max/10) rather than chasing to zero.
-		assert_eq!(control.update(Some(1), Instant::now()), Some(400_000));
-		assert_eq!(control.target(), 400_000);
+		assert_eq!(control.update(Some(bps(1)), Instant::now()), Some(bps(400_000)));
+		assert_eq!(control.target(), bps(400_000));
 	}
 
 	#[test]
 	fn raise_is_ramp_limited() {
 		let mut control = control();
 		let start = Instant::now();
-		control.update(Some(1_000_000), start).unwrap(); // target 1M
+		control.update(Some(bps(1_000_000)), start).unwrap(); // target 1M
 
 		// The pipe reopens to 4 Mbps. One second later the default 25%/s ramp
 		// allows only 1M -> 1.25M, not the full 4 Mbps the estimate wants.
-		let raised = control.update(Some(4_000_000), start + Duration::from_secs(1)).unwrap();
-		assert_eq!(raised, 1_250_000);
+		let raised = control
+			.update(Some(bps(4_000_000)), start + Duration::from_secs(1))
+			.unwrap();
+		assert_eq!(raised, bps(1_250_000));
 	}
 
 	#[test]
 	fn raise_eventually_reaches_the_estimate() {
 		let mut control = control();
 		let start = Instant::now();
-		control.update(Some(1_000_000), start).unwrap(); // target 1M
+		control.update(Some(bps(1_000_000)), start).unwrap(); // target 1M
 
 		// Feed a steady healthy estimate every 100ms; the ramp should walk the
 		// target back up to the ceiling and then stop.
 		for tick in 1..=200 {
-			control.update(Some(4_000_000), start + Duration::from_millis(100 * tick));
+			control.update(Some(bps(4_000_000)), start + Duration::from_millis(100 * tick));
 		}
-		assert_eq!(control.target(), 4_000_000);
+		assert_eq!(control.target(), bps(4_000_000));
 	}
 
 	/// Regression: the ramp allowance per tick (25%/s * 100ms = 2.5%) is smaller
@@ -256,12 +268,12 @@ mod tests {
 	fn suppressed_raises_do_not_starve_the_ramp() {
 		let mut control = control();
 		let start = Instant::now();
-		control.update(Some(1_000_000), start).unwrap(); // target 1M
+		control.update(Some(bps(1_000_000)), start).unwrap(); // target 1M
 
 		// Tick at 100ms: each tick alone is under the 5% threshold.
 		let mut raised = None;
 		for tick in 1..=10 {
-			if let Some(next) = control.update(Some(4_000_000), start + Duration::from_millis(100 * tick)) {
+			if let Some(next) = control.update(Some(bps(4_000_000)), start + Duration::from_millis(100 * tick)) {
 				raised = Some((tick, next));
 				break;
 			}
@@ -270,7 +282,7 @@ mod tests {
 		let (tick, next) = raised.expect("a raise must eventually clear hysteresis");
 		// 5% of 1M needs 0.05/0.25 = 0.2s of ramp, i.e. the tick at 200ms.
 		assert_eq!(tick, 2);
-		assert_eq!(next, 1_050_000);
+		assert_eq!(next, bps(1_050_000));
 	}
 
 	/// Regression: the ramp stops growing `next` once it reaches the ceiling, so a
@@ -282,19 +294,22 @@ mod tests {
 	fn a_raise_reaching_the_ceiling_beats_hysteresis() {
 		let mut control = control();
 		let start = Instant::now();
-		control.update(Some(1_000_000), start).unwrap();
+		control.update(Some(bps(1_000_000)), start).unwrap();
 
 		// Walk up until it settles, then confirm where it settled.
 		let mut last = None;
 		for tick in 1..=200 {
-			if let Some(next) = control.update(Some(4_000_000), start + Duration::from_millis(100 * tick)) {
+			if let Some(next) = control.update(Some(bps(4_000_000)), start + Duration::from_millis(100 * tick)) {
 				last = Some(next);
 			}
 		}
 
-		assert_eq!(last, Some(4_000_000));
+		assert_eq!(last, Some(bps(4_000_000)));
 		// And it stops there rather than reapplying the same value forever.
-		assert_eq!(control.update(Some(4_000_000), start + Duration::from_secs(60)), None);
+		assert_eq!(
+			control.update(Some(bps(4_000_000)), start + Duration::from_secs(60)),
+			None
+		);
 	}
 
 	/// Regression: the ceiling exemption above must not swallow the deadband. Every
@@ -305,11 +320,11 @@ mod tests {
 	fn upward_jitter_stays_inside_the_deadband() {
 		let mut control = control();
 		let start = Instant::now();
-		control.update(Some(2_000_000), start).unwrap(); // target 2M, well under the 4M ceiling
+		control.update(Some(bps(2_000_000)), start).unwrap(); // target 2M, well under the 4M ceiling
 
 		// A 0.5% rise: inside the 5% deadband, and nowhere near the ceiling.
 		assert_eq!(
-			control.update(Some(2_010_000), start + Duration::from_millis(100)),
+			control.update(Some(bps(2_010_000)), start + Duration::from_millis(100)),
 			None
 		);
 
@@ -318,18 +333,18 @@ mod tests {
 		for tick in 2..=9 {
 			let estimate = 2_000_000 + tick * 10_000;
 			assert_eq!(
-				control.update(Some(estimate), start + Duration::from_millis(100 * tick)),
+				control.update(Some(bps(estimate)), start + Duration::from_millis(100 * tick)),
 				None,
 				"estimate {estimate} is inside the deadband"
 			);
 		}
-		assert_eq!(control.target(), 2_000_000);
+		assert_eq!(control.target(), bps(2_000_000));
 
 		// And the deadband is still only a deadband: once the estimate does clear it,
 		// the raise lands normally, without needing the ceiling exemption.
 		assert_eq!(
-			control.update(Some(2_200_000), start + Duration::from_secs(2)),
-			Some(2_200_000)
+			control.update(Some(bps(2_200_000)), start + Duration::from_secs(2)),
+			Some(bps(2_200_000))
 		);
 	}
 
@@ -337,16 +352,16 @@ mod tests {
 	fn small_moves_are_suppressed() {
 		let mut control = control();
 		let now = Instant::now();
-		control.update(Some(2_000_000), now).unwrap(); // target 2M
+		control.update(Some(bps(2_000_000)), now).unwrap(); // target 2M
 
 		// 2% under the current target: inside the 5% deadband, so no reconfigure.
-		assert_eq!(control.update(Some(1_960_000), now + Duration::from_secs(1)), None);
-		assert_eq!(control.target(), 2_000_000);
+		assert_eq!(control.update(Some(bps(1_960_000)), now + Duration::from_secs(1)), None);
+		assert_eq!(control.target(), bps(2_000_000));
 
 		// 20% under: outside the deadband, so it applies.
 		assert_eq!(
-			control.update(Some(1_600_000), now + Duration::from_secs(2)),
-			Some(1_600_000)
+			control.update(Some(bps(1_600_000)), now + Duration::from_secs(2)),
+			Some(bps(1_600_000))
 		);
 	}
 
@@ -354,10 +369,10 @@ mod tests {
 	/// bound is fed straight to `clamp`, which panics on an inverted range.
 	#[test]
 	fn inverted_bounds_do_not_panic() {
-		let mut policy = Policy::new(1_000_000);
-		policy.min = 5_000_000;
+		let mut policy = Policy::new(bps(1_000_000));
+		policy.min = bps(5_000_000);
 		let mut control = Control::new(policy);
-		control.update(Some(2_000_000), Instant::now());
-		assert!(control.target() <= 5_000_000);
+		control.update(Some(bps(2_000_000)), Instant::now());
+		assert!(control.target() <= bps(5_000_000));
 	}
 }

--- a/rs/moq-video/src/encode/rate.rs
+++ b/rs/moq-video/src/encode/rate.rs
@@ -15,17 +15,16 @@ use std::time::Instant;
 /// bandwidth immediately when the pipe closes, take it back slowly when it
 /// opens, and don't twitch at every jitter in the estimate.
 ///
+/// The estimate handed in is expected to be this sender's alone. Splitting one
+/// connection's estimate among the senders sharing it is
+/// [`bandwidth::Allocator`](moq_net::bandwidth::Allocator)'s job, one layer down,
+/// so nothing here holds a fraction back for anyone else.
+///
 /// `#[non_exhaustive]`: construct via [`Policy::new`] and set fields, so new
 /// knobs stay additive.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Policy {
-	/// Fraction of the estimate to target, reserving room for the other tracks
-	/// sharing this connection (audio) and for transport overhead. Defaults to
-	/// 0.9. Must be greater than 0; values above 1.0 target more than the link
-	/// is estimated to carry and are clamped away.
-	pub headroom: f64,
-
 	/// Upper bound in bits per second, normally the bitrate the caller asked
 	/// for. The estimate can only ever take the target *down* from here: an
 	/// optimistic estimate is not a reason to send more than was configured.
@@ -54,7 +53,6 @@ impl Policy {
 	/// defaults for every other knob.
 	pub fn new(max: u64) -> Self {
 		Self {
-			headroom: 0.9,
 			max,
 			// A tenth of the ceiling: low enough to ride out a bad uplink, high
 			// enough that what we do send is still worth decoding.
@@ -76,8 +74,8 @@ impl Policy {
 /// # use moq_video::encode::rate::{Control, Policy};
 /// # use std::time::Instant;
 /// let mut control = Control::new(Policy::new(4_000_000));
-/// // A 2 Mbps estimate takes the 4 Mbps target down to 2 Mbps * 0.9 headroom.
-/// assert_eq!(control.update(Some(2_000_000), Instant::now()), Some(1_800_000));
+/// // A 2 Mbps estimate takes the 4 Mbps target down to what the link will carry.
+/// assert_eq!(control.update(Some(2_000_000), Instant::now()), Some(2_000_000));
 /// ```
 ///
 /// The time source is a parameter rather than an [`Instant::now`] call so the
@@ -116,16 +114,10 @@ impl Control {
 	pub fn update(&mut self, estimate: Option<u64>, now: Instant) -> Option<u64> {
 		let estimate = estimate?;
 
-		// Normalize here rather than trusting the fields: `min > max` would make
-		// the clamp below panic, and a non-finite headroom would poison the cast.
+		// Normalize rather than trusting the fields: `min > max` would make the
+		// clamp below panic.
 		let min = self.policy.min.min(self.policy.max);
-		let headroom = if self.policy.headroom.is_finite() {
-			self.policy.headroom.clamp(0.0, 1.0)
-		} else {
-			0.0
-		};
-
-		let desired = ((estimate as f64 * headroom) as u64).clamp(min, self.policy.max);
+		let desired = estimate.clamp(min, self.policy.max);
 
 		let next = if desired <= self.target {
 			// Attack: the pipe is closing, give the bandwidth back now.
@@ -149,8 +141,17 @@ impl Control {
 		// therefore keeps growing while small raises are suppressed, so a raise
 		// lands once it clears the threshold instead of being starved forever by
 		// a per-tick allowance smaller than the threshold.
+		//
+		// A raise landing exactly on `desired` is exempt: that's the last step of
+		// the ramp, not a twitch. `next` stops growing once it reaches the ceiling,
+		// so a target that arrives within `hysteresis` of it would otherwise have no
+		// move left that could ever clear the threshold, and the encoder would sit a
+		// few percent under its configured rate for good after one congestion event.
+		// Drops keep the deadband: sitting a little above a falling estimate is what
+		// it's for.
+		let settling = next > self.target && next == desired;
 		let hysteresis = self.policy.hysteresis.max(0.0);
-		if (next.abs_diff(self.target) as f64) < self.target as f64 * hysteresis {
+		if !settling && (next.abs_diff(self.target) as f64) < self.target as f64 * hysteresis {
 			return None;
 		}
 
@@ -166,8 +167,7 @@ mod tests {
 
 	use super::*;
 
-	/// 4 Mbps ceiling, so the 0.9 headroom and the max/10 floor land on round
-	/// numbers: 400 kbps floor, and an estimate of E targets 0.9 * E.
+	/// 4 Mbps ceiling, so the max/10 floor lands on a round 400 kbps.
 	fn control() -> Control {
 		Control::new(Policy::new(4_000_000))
 	}
@@ -178,11 +178,11 @@ mod tests {
 	}
 
 	#[test]
-	fn drop_applies_immediately_with_headroom() {
+	fn drop_applies_immediately() {
 		let mut control = control();
-		// A 2 Mbps pipe: target 90% of it at once, no ramp, no waiting.
-		assert_eq!(control.update(Some(2_000_000), Instant::now()), Some(1_800_000));
-		assert_eq!(control.target(), 1_800_000);
+		// A 2 Mbps pipe: take the target down to it at once, no ramp, no waiting.
+		assert_eq!(control.update(Some(2_000_000), Instant::now()), Some(2_000_000));
+		assert_eq!(control.target(), 2_000_000);
 	}
 
 	#[test]
@@ -194,7 +194,7 @@ mod tests {
 		// Losing the estimate (disconnected) is not evidence the uplink is
 		// healthy again, so the target must not jump back to max.
 		assert_eq!(control.update(None, now + Duration::from_secs(10)), None);
-		assert_eq!(control.target(), 1_800_000);
+		assert_eq!(control.target(), 2_000_000);
 	}
 
 	#[test]
@@ -217,26 +217,26 @@ mod tests {
 	fn raise_is_ramp_limited() {
 		let mut control = control();
 		let start = Instant::now();
-		control.update(Some(1_000_000), start).unwrap(); // target 900k
+		control.update(Some(1_000_000), start).unwrap(); // target 1M
 
 		// The pipe reopens to 4 Mbps. One second later the default 25%/s ramp
-		// allows only 900k -> 1125k, not the full 3.6 Mbps the estimate wants.
+		// allows only 1M -> 1.25M, not the full 4 Mbps the estimate wants.
 		let raised = control.update(Some(4_000_000), start + Duration::from_secs(1)).unwrap();
-		assert_eq!(raised, 1_125_000);
+		assert_eq!(raised, 1_250_000);
 	}
 
 	#[test]
 	fn raise_eventually_reaches_the_estimate() {
 		let mut control = control();
 		let start = Instant::now();
-		control.update(Some(1_000_000), start).unwrap(); // target 900k
+		control.update(Some(1_000_000), start).unwrap(); // target 1M
 
 		// Feed a steady healthy estimate every 100ms; the ramp should walk the
-		// target up to the full 90% of it and then stop.
+		// target back up to the ceiling and then stop.
 		for tick in 1..=200 {
 			control.update(Some(4_000_000), start + Duration::from_millis(100 * tick));
 		}
-		assert_eq!(control.target(), 3_600_000);
+		assert_eq!(control.target(), 4_000_000);
 	}
 
 	/// Regression: the ramp allowance per tick (25%/s * 100ms = 2.5%) is smaller
@@ -248,7 +248,7 @@ mod tests {
 	fn suppressed_raises_do_not_starve_the_ramp() {
 		let mut control = control();
 		let start = Instant::now();
-		control.update(Some(1_000_000), start).unwrap(); // target 900k
+		control.update(Some(1_000_000), start).unwrap(); // target 1M
 
 		// Tick at 100ms: each tick alone is under the 5% threshold.
 		let mut raised = None;
@@ -260,25 +260,49 @@ mod tests {
 		}
 
 		let (tick, next) = raised.expect("a raise must eventually clear hysteresis");
-		// 5% of 900k needs 0.05/0.25 = 0.2s of ramp, i.e. the tick at 200ms.
+		// 5% of 1M needs 0.05/0.25 = 0.2s of ramp, i.e. the tick at 200ms.
 		assert_eq!(tick, 2);
-		assert_eq!(next, 945_000);
+		assert_eq!(next, 1_050_000);
+	}
+
+	/// Regression: the ramp stops growing `next` once it reaches the ceiling, so a
+	/// target that lands within the 5% deadband of it has no move left that can
+	/// clear hysteresis. Without the exemption for a raise that reaches `desired`,
+	/// the walk above stalls at 3_866_256 and the encoder never returns to the
+	/// bitrate it was configured with.
+	#[test]
+	fn a_raise_reaching_the_ceiling_beats_hysteresis() {
+		let mut control = control();
+		let start = Instant::now();
+		control.update(Some(1_000_000), start).unwrap();
+
+		// Walk up until it settles, then confirm where it settled.
+		let mut last = None;
+		for tick in 1..=200 {
+			if let Some(next) = control.update(Some(4_000_000), start + Duration::from_millis(100 * tick)) {
+				last = Some(next);
+			}
+		}
+
+		assert_eq!(last, Some(4_000_000));
+		// And it stops there rather than reapplying the same value forever.
+		assert_eq!(control.update(Some(4_000_000), start + Duration::from_secs(60)), None);
 	}
 
 	#[test]
 	fn small_moves_are_suppressed() {
 		let mut control = control();
 		let now = Instant::now();
-		control.update(Some(2_000_000), now).unwrap(); // target 1.8M
+		control.update(Some(2_000_000), now).unwrap(); // target 2M
 
 		// 2% under the current target: inside the 5% deadband, so no reconfigure.
 		assert_eq!(control.update(Some(1_960_000), now + Duration::from_secs(1)), None);
-		assert_eq!(control.target(), 1_800_000);
+		assert_eq!(control.target(), 2_000_000);
 
 		// 20% under: outside the deadband, so it applies.
 		assert_eq!(
 			control.update(Some(1_600_000), now + Duration::from_secs(2)),
-			Some(1_440_000)
+			Some(1_600_000)
 		);
 	}
 
@@ -291,16 +315,5 @@ mod tests {
 		let mut control = Control::new(policy);
 		control.update(Some(2_000_000), Instant::now());
 		assert!(control.target() <= 5_000_000);
-	}
-
-	/// A non-finite headroom would make the `as u64` cast produce garbage rather
-	/// than a rate, so it's normalized away.
-	#[test]
-	fn non_finite_headroom_does_not_poison_the_target() {
-		let mut policy = Policy::new(4_000_000);
-		policy.headroom = f64::NAN;
-		let mut control = Control::new(policy);
-		control.update(Some(2_000_000), Instant::now());
-		assert_eq!(control.target(), 400_000); // floored, not NaN-cast to 0
 	}
 }

--- a/rs/moq-video/src/encode/rate.rs
+++ b/rs/moq-video/src/encode/rate.rs
@@ -142,14 +142,22 @@ impl Control {
 		// lands once it clears the threshold instead of being starved forever by
 		// a per-tick allowance smaller than the threshold.
 		//
-		// A raise landing exactly on `desired` is exempt: that's the last step of
-		// the ramp, not a twitch. `next` stops growing once it reaches the ceiling,
-		// so a target that arrives within `hysteresis` of it would otherwise have no
-		// move left that could ever clear the threshold, and the encoder would sit a
-		// few percent under its configured rate for good after one congestion event.
-		// Drops keep the deadband: sitting a little above a falling estimate is what
-		// it's for.
-		let settling = next > self.target && next == desired;
+		// A raise landing exactly on [`Policy::max`] is exempt: that's the last step
+		// of a recovery, not a twitch. `next` stops growing once it reaches the
+		// ceiling, so a target arriving within `hysteresis` of it has no move left
+		// that could ever clear the threshold, and the encoder would sit a few
+		// percent under its configured rate for good after one congestion event.
+		//
+		// Scoped to the *configured* ceiling, not to any `desired`. Every raise
+		// eventually lands on `desired`, so exempting all of them would let a
+		// slowly-rising estimate reconfigure the encoder on every tick, which is
+		// precisely what the deadband exists to prevent. Stalling a few percent
+		// below a merely estimate-limited ceiling is the deadband working; stalling
+		// below the rate the caller asked for is not.
+		//
+		// Drops keep the deadband either way: sitting a little above a falling
+		// estimate is what it's for.
+		let settling = next > self.target && next == self.policy.max;
 		let hysteresis = self.policy.hysteresis.max(0.0);
 		if !settling && (next.abs_diff(self.target) as f64) < self.target as f64 * hysteresis {
 			return None;
@@ -287,6 +295,42 @@ mod tests {
 		assert_eq!(last, Some(4_000_000));
 		// And it stops there rather than reapplying the same value forever.
 		assert_eq!(control.update(Some(4_000_000), start + Duration::from_secs(60)), None);
+	}
+
+	/// Regression: the ceiling exemption above must not swallow the deadband. Every
+	/// raise eventually lands on `desired`, so keying it on that rather than on the
+	/// configured ceiling let a slowly-rising estimate retune the encoder on every
+	/// single tick, which is the exact behavior `hysteresis` exists to prevent.
+	#[test]
+	fn upward_jitter_stays_inside_the_deadband() {
+		let mut control = control();
+		let start = Instant::now();
+		control.update(Some(2_000_000), start).unwrap(); // target 2M, well under the 4M ceiling
+
+		// A 0.5% rise: inside the 5% deadband, and nowhere near the ceiling.
+		assert_eq!(
+			control.update(Some(2_010_000), start + Duration::from_millis(100)),
+			None
+		);
+
+		// A whole walk of them still doesn't, rather than one reconfigure per tick.
+		// Stops short of 2.1M, which is exactly 5% up and so clears the threshold.
+		for tick in 2..=9 {
+			let estimate = 2_000_000 + tick * 10_000;
+			assert_eq!(
+				control.update(Some(estimate), start + Duration::from_millis(100 * tick)),
+				None,
+				"estimate {estimate} is inside the deadband"
+			);
+		}
+		assert_eq!(control.target(), 2_000_000);
+
+		// And the deadband is still only a deadband: once the estimate does clear it,
+		// the raise lands normally, without needing the ceiling exemption.
+		assert_eq!(
+			control.update(Some(2_200_000), start + Duration::from_secs(2)),
+			Some(2_200_000)
+		);
 	}
 
 	#[test]

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -103,7 +103,7 @@ impl Sink {
 	/// Retune the encoder, waiting for the backend's verdict. See
 	/// [`Encoder::set_bitrate`](super::Encoder::set_bitrate) for what a failure
 	/// means (not fatal: stop adapting, keep encoding).
-	pub async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+	pub async fn set_bitrate(&mut self, bitrate: moq_net::bandwidth::Rate) -> Result<(), Error> {
 		self.0.set_bitrate(bitrate).await
 	}
 
@@ -160,7 +160,7 @@ mod threaded {
 		/// is affordable because the rate control policy only sends one of these
 		/// when the target moves meaningfully, not per frame.
 		SetBitrate {
-			bitrate: u64,
+			bitrate: moq_net::bandwidth::Rate,
 			resp: oneshot::Sender<Result<(), Error>>,
 		},
 		/// Empty the codec at a group boundary, leaving it running. Unlike
@@ -244,7 +244,7 @@ mod threaded {
 			self.0.request(|resp| Request::Encode { frame, resp }).await
 		}
 
-		pub async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		pub async fn set_bitrate(&mut self, bitrate: moq_net::bandwidth::Rate) -> Result<(), Error> {
 			self.0.request(|resp| Request::SetBitrate { bitrate, resp }).await
 		}
 
@@ -290,7 +290,7 @@ mod inline {
 			self.0.encode(&frame)
 		}
 
-		pub async fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		pub async fn set_bitrate(&mut self, bitrate: moq_net::bandwidth::Rate) -> Result<(), Error> {
 			self.0.set_bitrate(bitrate)
 		}
 
@@ -402,7 +402,7 @@ mod tests {
 				let sink = guard.as_mut().unwrap();
 				sink.keyframe();
 				pollster::block_on(sink.encode(gray(index))).unwrap();
-				pollster::block_on(sink.set_bitrate(500_000 + index)).unwrap();
+				pollster::block_on(sink.set_bitrate(moq_net::bandwidth::Rate::from_bps(500_000 + index))).unwrap();
 				// Only the first frame closes a group, so the two after it stay in
 				// the codec and leave the drain below something to find.
 				let flushed = match index {


### PR DESCRIPTION
Closes #2815.

## Problem

`moq_net::bandwidth::Consumer` carries a **per-connection** send estimate, but rate control is applied **per encoder**. Nothing divided it, so N senders on one connection each targeted the whole uplink.

This is reachable today without #2809: a capture publish runs an audio encoder and a video encoder over one connection, and only video's was counted at all. `rate::Policy::headroom` (0.9) was the stand-in, and its doc said so outright: it reserved room "for the other tracks sharing this connection (audio)", i.e. one video encoder per connection, with audio's real bitrate guessed at a flat 10%.

## `bandwidth::Allocator`

Divides one estimate among the tracks registered against it. Registration is keyed on a `track::Demand`, which supplies all three things a share needs:

- **priority**, from `track::Info::priority`;
- **whether it's demanded right now**, so an unwatched track claims nothing (`publish_capture` stops encoding entirely while nothing is subscribed);
- **lifetime**, and a `Demand` is weak, so registering never keeps a track alive.

```rust
let allocator = bandwidth::Allocator::new(session.send_bandwidth()?);
let reservation = allocator.reserve(&track.demand(), Bandwidth::from_mbps(4));
```

`reserve` returns a `Reservation`: the claim lasts as long as that handle, `set_max` moves the ceiling when a sender renegotiates one, and `consumer()` hands out the cloneable readers `rate::Policy` consumes. A sender with no estimate to divide takes `Allocator::unlimited()` rather than an `Option`, since a share reporting `None` already means "hold your current rate".

**Reservations are ceilings, never observed rates.** A VBR encoder sitting on a black screen at 1 Mbps can jump to 6 Mbps between one frame and the next; a reservation that had followed it down would already have handed that room to someone else.

The split is strict priority, max-min fair within a tier, with surplus above the total reserved left unclaimed (capping at the reservation is what keeps an uncongested link encoding at exactly the configured rate).

It is **advisory**. A track that ignores its share, or can't follow one at all (PCM audio's bitrate is fixed by sample rate and channel count), still sends what it sends and the transport sheds the excess. Bandwidth estimation isn't exact enough for the difference to be worth policing.

## Publishers stamp `PRIORITY`

`hang::catalog::PRIORITY` (catalog 100, text 90, audio 80, video 60) was only ever read on the **subscribe** side. `hang::container::track_info()` left `Info::priority` at 0, so every published track advertised one undifferentiated tier and the allocator's tiers were vacuous.

That also makes the publisher priority the draft describes unusable: draft-lcurley-moq-lite says a publisher "advertises a fixed publisher priority (here audio at 2 and video at 1) used only to break ties", and a relay SHOULD prefer it upstream precisely because it cannot pick between its subscribers' priorities. With everything at 0 there is nothing to prefer.

`track_info` now takes the priority instead of defaulting it (and so does its TypeScript twin, `@moq/hang`'s `container.trackInfo`). There is no correct value for "some media track", and the default is what let this sit unnoticed; a parameter turns every new publisher into a decision the compiler asks for.

Two non-media tracks were caught by the same sweep: the MSF catalog and the timeline were both minted with no `Info` at all, so a broadcast advertised its hang catalog at 100 and the identical catalog in MSF at 0. Both now rank with the catalog.

The IETF publisher was caught by it too. `ietf/publisher.rs` sent `publisher_priority: 0` on every group header, so a stamped priority reached moq-lite peers through TRACK_INFO and stopped there, leaving a moq-transport peer with the same one undifferentiated tier. It now carries `priority::to_wire(info.priority)`, the conversion the subscriber side already uses (the model ranks higher-first, that wire field lower-first), mirrored in `js/net`.

**What this does not do:** it doesn't align allocation with transmission order. Allocation ranks by the *publisher's* priority; the local send queue ranks by each subscription's own (`lite::publisher` seeds it from the SUBSCRIBE message; `info.priority` reaches the wire as TRACK_INFO on lite and as the group header's publisher priority on IETF, neither of which orders the local queue). A subscriber asking for video ahead of audio still gets it sent that way. The publisher's priority is the right one to divide by, because allocation decides what to *produce* and there is no single subscriber priority to read when several are watching one track, but the two are genuinely separate rankings.

The allocator was already correct at a single tier (max-min fair serves audio's small reservation before video's large one either way), so this changes what happens once a tier's smaller claims outgrow an even split rather than fixing a live misallocation.

## The unit is a type

Bits per second was a bare integer in four places, one of them a different width (`moq_audio`'s `Option<u32>` against everyone else's `u64`). Bits-versus-bytes is off by eight and still typechecks, and the estimate being divided is a `cwnd * 8 / rtt`, so the unit is load-bearing. `moq_net::Bandwidth` carries it from the congestion controller to the encoder, unwrapped once at each seam where a number leaves Rust: the codec backends, the catalog's serialized `bitrate`, the C ABI, and the CLI flags.

## Three bugs found on the way

**`rate::Policy` stranded the target below its ceiling, permanently.** `next` stops growing once the ramp reaches `desired`, so a target landing within `hysteresis` (5%) of the ceiling has no move left that can ever clear the threshold. A 4 Mbps encoder recovering from one congestion event stalls at **3,866,256** and stays there. It was invisible before because the ramp chased `0.9 * max` and the residual gap hid inside the headroom. A raise that lands exactly on `desired` is now exempt: that's the last step of the ramp, not a twitch. Drops keep the deadband, which is what it's for.

**A reservation outlived the sender that took it.** The registry only ever prunes tracks that have *closed*, so a share dropped by a track that is still alive left its claim standing for the rest of the connection. Harmless while each encoder registered once, but the capture loop reopens its camera whenever demand returns, and a reopen can negotiate a different mode (a screen source resized while nothing was subscribed), which caps the larger mode below what it can send and leaves a smaller one claiming room it no longer needs. A reservation now lives exactly as long as the share it was handed to, through a weak handle so a share outliving every `Allocator` still reports the registry as gone. The capture loop re-registers only when the negotiated ceiling changes.

**Two lost wakeups in the new poll paths.** A share whose slice didn't move (its reservation caps it, so most estimate changes don't reach it) parked without the estimate's waker armed, because a poll returning `Ready` registers nothing; `Demand::poll_state` had the same hole when demand flipped between its two internal reads. Both now loop until something is armed. These are hangs rather than failures, so they're covered by tests that assert on a real `Waker` being woken rather than on a re-read, and I verified each fails with the fix reverted.

## Also

`rate::Policy::headroom` is removed. Its job was reserving room for audio, which is now the allocator's, and holding back a further 10% per encoder for one connection's overhead would double-count it. Going over budget is fine: the transport tail-drops groups.

## Caveat

The estimate being divided is only as good as its input, and on the quinn backend that input is `cwnd * 8 / rtt`, which is a window over a latency rather than a rate. Filed as #2847 (quinn already computes the BBR pacing rate and exposes it on `Controller::metrics()`; it just never reaches `PathStats`). This PR makes the arithmetic honest; it does not make the number good.

Audio reserves but does not follow its share yet: #2848. Three more gaps this surfaced, all filed rather than scoped in: transcode ladders (#2858, the sharpest remaining instance, and one with a catalog-honesty question of its own), passthrough imports (#2859), and bindings, which have no encoder rate control at all (#2857).

## Testing

`just check` and `just test` clean (3490 Rust pass, plus the JS and Python suites). Also ran, since PR CI doesn't: `just rs doctest`, `just rs macos` (the only thing that ever compiles moq-audio's `capture` feature), and `cargo check -p moq-ffi -p libmoq` (`just check` never compiles either).

New coverage: the non-media tracks ranking with the catalog (mutation-checked against reverting the fix), the split itself (strict priority, max-min fairness, starved tiers, unclaimed surplus, and the one-tier case that is what actually runs today), two concurrent encoders splitting an estimate, idle and closed tracks, estimate lifecycle, both wakeup regressions, the hysteresis stall, and `track_info` carrying the priority.

No wire format change, so no draft update: TRACK_INFO has carried `priority` since Lite05 and the draft already specifies these semantics. The IETF group header's publisher priority is likewise a field moq-transport already defines; this only stops sending a flat 0 in it.

`js/hang` is mirrored for the priority half: `container.trackInfo` now requires a `priority`, the browser publisher stamps each rendition's kind, and its catalog track takes the catalog priority. Without it a browser broadcast would keep advertising 0 while a Rust one advertised 80, which is the inconsistency this PR exists to remove. The allocator half has nothing to mirror: `js/publish` has no bandwidth-driven encoder rate control to divide.

(Written by Opus 5)



