### PR TITLE
fix(path): resolve catalog references like URLs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.9.8",
@@ -182,7 +182,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.2.8",
+      "version": "0.3.0",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",
@@ -265,7 +265,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.4.6",
+      "version": "0.5.0",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/msf": "workspace:^",

--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -77,12 +77,12 @@ This is the minimum amount of information required to initialize a video decoder
 
 ### Cross-broadcast renditions
 
-A rendition may set an optional `broadcast` field: a path relative to the broadcast that served the catalog (e.g. `"../source"`), pointing at another broadcast that publishes the actual track.
-A consumer resolves the reference against the catalog broadcast's own path (`..` pops a segment, other segments append) and subscribes to the track on the resolved broadcast over the same connection.
+A rendition may set an optional `broadcast` field: a path relative to the broadcast that served the catalog (e.g. `"./source"`), pointing at another broadcast that publishes the actual track.
+A consumer resolves a non-empty reference like a relative URL: it replaces the catalog broadcast's last path segment, then applies `.` and `..` segments. An empty reference names the catalog broadcast itself.
 When the field is absent, the track lives in the same broadcast as the catalog.
 
 This lets a transcoder publish a sidecar catalog that adds new renditions while pointing unchanged ones at the original broadcast, instead of re-publishing those bytes through the transcoder.
-For example, a transcoder consuming `room/source` can publish `room/transcode` whose catalog contains a downscaled `480p` rendition plus the original `1080p` rendition marked `"broadcast": "../source"`.
+For example, a transcoder consuming `room/source` can publish `room/transcode` whose catalog contains a downscaled `480p` rendition plus the original `1080p` rendition marked `"broadcast": "./source"`.
 A viewer of `room/transcode` then pulls `480p` from the transcoder and `1080p` directly from the source, and the relay dedupes the source subscription with the transcoder's own.
 
 `@moq/watch` resolves the reference automatically. In Rust, the `moq-mux` exporters do the same: they take a `Source::new(origin, path)`, and both the catalog broadcast and any referenced broadcast resolve through the origin over the same connection.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -270,7 +270,9 @@ By default a rendition's track lives in the same broadcast that served the catal
 The `broadcast` field overrides that, naming a different broadcast that publishes the track.
 
 The value is a relative path, resolved against the path of the broadcast that served the catalog.
-It uses the `.` and `..` semantics of a relative URL reference ({{!RFC3986, Section 5.2.4}}), for example `../source`.
+It uses relative reference resolution ({{!RFC3986, Section 5.2}}): a non-empty reference replaces the catalog broadcast's last path segment before applying `.` and `..` segments.
+For example, `./source` in a catalog served by `room/transcode` resolves to `room/source`, while `.` resolves to `room`.
+An empty reference resolves to the catalog broadcast itself.
 A publisher MUST NOT use an absolute path, and a consumer MUST ignore a rendition whose `broadcast` escapes above the root.
 
 This lets a publisher author a catalog that points at tracks it does not republish.

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.3.5",
+	"version": "0.4.0",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/hang/src/catalog/audio.ts
+++ b/js/hang/src/catalog/audio.ts
@@ -16,7 +16,7 @@ const TrackSchema = z.object({
  */
 export const AudioConfigSchema = z.object({
 	// Optional reference to another broadcast that publishes this track, expressed
-	// relative to the broadcast that served this catalog (e.g. "../source").
+	// relative to the broadcast that served this catalog (e.g. "./source").
 	// If unset, the track lives in the same broadcast as the catalog.
 	broadcast: z.optional(RelativeBroadcastSchema),
 

--- a/js/hang/src/catalog/path.ts
+++ b/js/hang/src/catalog/path.ts
@@ -3,7 +3,7 @@ import * as z from "zod/mini";
 
 /**
  * Zod schema for a relative broadcast reference stored in a catalog (a rendition's
- * `broadcast` field, e.g. "../source"). Normalizes the input the same way the Rust
+ * `broadcast` field, e.g. "./source"). Normalizes the input the same way the Rust
  * `PathRelative` type does so JS and Rust agree byte-for-byte after deserialization.
  * Resolve it against the catalog broadcast's own path with `Path.resolve`.
  */

--- a/js/hang/src/catalog/root.test.ts
+++ b/js/hang/src/catalog/root.test.ts
@@ -27,7 +27,7 @@ test("rendition broadcast reference is parsed and normalized", () => {
 		video: {
 			renditions: {
 				video: {
-					broadcast: ".././source/",
+					broadcast: "././source/",
 					codec: "avc1.64001f",
 					container: { kind: "legacy" },
 				},
@@ -36,8 +36,25 @@ test("rendition broadcast reference is parsed and normalized", () => {
 	};
 	const parsed = RootSchema.parse(catalog);
 	if (!parsed.video || !("renditions" in parsed.video)) throw new Error("missing video section");
-	// Normalized like Rust PathRelative: `.` and empty segments dropped, `..` preserved.
-	expect(parsed.video.renditions.video?.broadcast).toBe("../source");
+	// Normalized like Rust PathRelative: redundant `.` and empty segments are dropped.
+	expect(parsed.video.renditions.video?.broadcast).toBe("source");
+});
+
+test("rendition parent broadcast reference stays distinct from empty", () => {
+	const catalog = {
+		video: {
+			renditions: {
+				video: {
+					broadcast: ".",
+					codec: "avc1.64001f",
+					container: { kind: "legacy" },
+				},
+			},
+		},
+	};
+	const parsed = RootSchema.parse(catalog);
+	if (!parsed.video || !("renditions" in parsed.video)) throw new Error("missing video section");
+	expect(parsed.video.renditions.video?.broadcast).toBe(".");
 });
 
 test("rendition without broadcast reference stays undefined", () => {

--- a/js/hang/src/catalog/video.ts
+++ b/js/hang/src/catalog/video.ts
@@ -13,7 +13,7 @@ const TrackSchema = z.object({
 /** Schema for a single video rendition's decoder config. Mirrors WebCodecs VideoDecoderConfig. */
 export const VideoConfigSchema = z.object({
 	// Optional reference to another broadcast that publishes this track, expressed
-	// relative to the broadcast that served this catalog (e.g. "../source").
+	// relative to the broadcast that served this catalog (e.g. "./source").
 	// If unset, the track lives in the same broadcast as the catalog.
 	broadcast: z.optional(RelativeBroadcastSchema),
 

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.2.8",
+	"version": "0.3.0",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/src/consume.ts
+++ b/js/net/src/consume.ts
@@ -6,7 +6,7 @@ import type * as Path from "./path.ts";
  * subscribers.
  *
  * `Connection.consume(path)` must not mint a fresh subscription per call: repeat requests
- * for the same path (e.g. several renditions referencing one `broadcast: "../source"`) should
+ * for the same path (e.g. several renditions referencing one `broadcast: "./source"`) should
  * share a single upstream subscription. This mirrors the Rust `origin::Consumer` weak-cache:
  * a still-live path resolves to a shared {@link broadcast.Consumer.clone}, a closed one is
  * re-consumed on the next request. Each handle is reference-counted, so the shared broadcast

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -233,6 +233,13 @@ test("resolve self-reference via sibling name equals base", () => {
 	expect(Path.resolve(Path.from("a/b"), "./b")).toBe(Path.from("a/b"));
 });
 
+test("tryResolve distinguishes the root from an escape", () => {
+	expect(Path.tryResolve(Path.from("top"), ".")).toBe(Path.empty());
+	expect(Path.tryResolve(Path.from("top"), "..")).toBeUndefined();
+	expect(Path.tryResolve(Path.from("a/b"), "..")).toBe(Path.empty());
+	expect(Path.tryResolve(Path.from("a/b"), "../..")).toBeUndefined();
+});
+
 test("normalizeRelative preserves an all-dot reference", () => {
 	expect(Path.normalizeRelative("")).toBe("");
 	expect(Path.normalizeRelative(".")).toBe(".");

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -190,9 +190,12 @@ test("from sanitizes multiple arguments with slashes", () => {
 	expect(Path.from("foo//", "//bar", "baz")).toBe("foo/bar/baz" as Path.Valid);
 });
 
-test("resolve appends named segments", () => {
-	expect(Path.resolve(Path.from("a/b"), "c")).toBe(Path.from("a/b/c"));
-	expect(Path.resolve(Path.from("a/b"), "c/d")).toBe(Path.from("a/b/c/d"));
+test("resolve replaces the base name", () => {
+	expect(Path.resolve(Path.from("a/b"), "c")).toBe(Path.from("a/c"));
+	expect(Path.resolve(Path.from("a/b"), "c/d")).toBe(Path.from("a/c/d"));
+	expect(Path.resolve(Path.from("foo.hang/catalog.pro"), "./transcode.pro")).toBe(
+		Path.from("foo.hang/transcode.pro"),
+	);
 });
 
 test("resolve with empty rel returns base", () => {
@@ -200,12 +203,12 @@ test("resolve with empty rel returns base", () => {
 });
 
 test("resolve single dotdot pops one segment", () => {
-	expect(Path.resolve(Path.from("a/b/c"), "../d")).toBe(Path.from("a/b/d"));
-	expect(Path.resolve(Path.from("a/b/c"), "..")).toBe(Path.from("a/b"));
+	expect(Path.resolve(Path.from("a/b/c"), "../d")).toBe(Path.from("a/d"));
+	expect(Path.resolve(Path.from("a/b/c"), "..")).toBe(Path.from("a"));
 });
 
 test("resolve multiple dotdot pops multiple segments", () => {
-	expect(Path.resolve(Path.from("a/b/c"), "../../x")).toBe(Path.from("a/x"));
+	expect(Path.resolve(Path.from("a/b/c"), "../../x")).toBe(Path.from("x"));
 	expect(Path.resolve(Path.from("a/b/c"), "../../../x")).toBe(Path.from("x"));
 });
 
@@ -219,20 +222,21 @@ test("resolve with empty base", () => {
 	expect(Path.resolve(Path.empty(), "..")).toBe(Path.from(""));
 });
 
-test("resolve treats dot as a no-op", () => {
-	expect(Path.resolve(Path.from("a/b"), ".")).toBe(Path.from("a/b"));
-	expect(Path.resolve(Path.from("a/b"), "./c")).toBe(Path.from("a/b/c"));
-	expect(Path.resolve(Path.from("a/b"), "./../c")).toBe(Path.from("a/c"));
-	expect(Path.resolve(Path.from("a/b"), "foo/./bar")).toBe(Path.from("a/b/foo/bar"));
+test("resolve dot names the base parent", () => {
+	expect(Path.resolve(Path.from("a/b"), ".")).toBe(Path.from("a"));
+	expect(Path.resolve(Path.from("a/b"), "./c")).toBe(Path.from("a/c"));
+	expect(Path.resolve(Path.from("a/b"), "./../c")).toBe(Path.from("c"));
+	expect(Path.resolve(Path.from("a/b"), "foo/./bar")).toBe(Path.from("a/foo/bar"));
 });
 
-test("resolve self-reference via dotdot equals base", () => {
-	expect(Path.resolve(Path.from("a/b"), "../b")).toBe(Path.from("a/b"));
+test("resolve self-reference via sibling name equals base", () => {
+	expect(Path.resolve(Path.from("a/b"), "./b")).toBe(Path.from("a/b"));
 });
 
-test("normalizeRelative drops empty and dot segments", () => {
+test("normalizeRelative preserves an all-dot reference", () => {
 	expect(Path.normalizeRelative("")).toBe("");
-	expect(Path.normalizeRelative(".")).toBe("");
+	expect(Path.normalizeRelative(".")).toBe(".");
+	expect(Path.normalizeRelative("././")).toBe(".");
 	expect(Path.normalizeRelative("./foo")).toBe("foo");
 	expect(Path.normalizeRelative("foo//bar")).toBe("foo/bar");
 	expect(Path.normalizeRelative("foo/./bar")).toBe("foo/bar");

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -228,3 +228,30 @@ export function resolve(base: Valid, rel: string): Valid {
 
 	return segments.join("/") as Valid;
 }
+
+/**
+ * Resolve a relative path, returning `undefined` if it escapes above the root.
+ *
+ * Unlike {@link resolve}, this distinguishes a valid reference to the empty root
+ * path from excess `..` segments. Use it for untrusted catalog references that
+ * must not be clamped to the root.
+ */
+export function tryResolve(base: Valid, rel: string): Valid | undefined {
+	if (rel === "") return base;
+
+	const segments = base === "" ? [] : base.split("/");
+	segments.pop();
+
+	for (const seg of rel.split("/")) {
+		if (seg === "" || seg === ".") {
+			continue;
+		}
+		if (seg === "..") {
+			if (segments.pop() === undefined) return undefined;
+		} else {
+			segments.push(seg);
+		}
+	}
+
+	return segments.join("/") as Valid;
+}

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -176,41 +176,44 @@ export function empty(): Valid {
 
 /**
  * Normalize a relative path reference: trim leading/trailing slashes, drop empty
- * segments, and drop `.` segments (no-ops, matching POSIX). `..` is preserved and
- * only interpreted by {@link resolve}.
+ * segments, and drop redundant `.` segments. A reference made only of `.` segments
+ * normalizes to `.` because it names the base's parent, while empty names the base.
+ * `..` is preserved and only interpreted by {@link resolve}.
  *
  * Mirrors the Rust `PathRelative::new` normalization, so JS and Rust agree
  * byte-for-byte on the stored form. Two callers comparing normalized strings can
- * detect that `""`, `"."`, `"/./"` etc. all mean "no reference".
+ * detect equivalent references while preserving the distinction between `""` and `"."`.
  */
 export function normalizeRelative(rel: string): string {
-	return rel
-		.split("/")
-		.filter((s) => s !== "" && s !== ".")
-		.join("/");
+	const raw = rel.split("/");
+	const normalized = raw.filter((s) => s !== "" && s !== ".").join("/");
+
+	return normalized === "" && raw.includes(".") ? "." : normalized;
 }
 
 /**
  * Resolve a relative path reference against a base path.
  *
- * `..` segments pop the last segment of the base; other segments are appended.
- * `.` and empty segments are no-ops. Excess `..` once the base is empty is also a
- * no-op (subsequent named segments still append). An empty / normalized-empty `rel`
- * returns the base path unchanged.
+ * A non-empty reference replaces the last segment of the base, matching relative URL
+ * resolution. `..` segments then pop another segment; other segments are appended.
+ * `.` and empty segments are no-ops. Excess `..` once the base is empty is also a no-op
+ * (subsequent named segments still append). An empty `rel` returns the base unchanged.
  *
  * Mirrors the Rust `Path::resolve`, used by hang catalogs to express
  * cross-broadcast track references (a rendition's `broadcast` field).
  *
  * @example
  * ```typescript
- * Path.resolve(Path.from("a/b/c"), "../source"); // "a/b/source"
- * Path.resolve(Path.from("a/b"), "x/y");         // "a/b/x/y"
- * Path.resolve(Path.from("a"), "../../x");       // "x"
- * Path.resolve(Path.from("a/b"), "./c");         // "a/b/c"
+ * Path.resolve(Path.from("a/b/c"), "./source");  // "a/b/source"
+ * Path.resolve(Path.from("a/b"), ".");           // "a"
+ * Path.resolve(Path.from("a/b/c"), "../source"); // "a/source"
  * ```
  */
 export function resolve(base: Valid, rel: string): Valid {
+	if (rel === "") return base;
+
 	const segments = base === "" ? [] : base.split("/");
+	segments.pop();
 
 	for (const seg of rel.split("/")) {
 		if (seg === "" || seg === ".") {

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.4.6",
+	"version": "0.5.0",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -266,9 +266,10 @@ export class Broadcast {
 		const base = effect.get(this.in.name);
 		const resolved = Path.tryResolve(base, rel);
 
-		// An escape or a reference back to the catalog is served by the catalog broadcast.
-		// A valid empty result names the root broadcast and continues below.
-		if (resolved === undefined || resolved === base) return effect.get(this.out.active);
+		// Ignore a rendition whose reference escapes above the root. A valid empty result
+		// names the root broadcast, while a reference back to the catalog uses its active handle.
+		if (resolved === undefined) return undefined;
+		if (resolved === base) return effect.get(this.out.active);
 
 		if (!effect.get(this.in.enabled)) return undefined;
 

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -24,6 +24,33 @@ function skipDiscovery(conn: Moq.Connection.Established): boolean {
 	return true;
 }
 
+type ReferencedRendition = {
+	broadcast?: string;
+};
+
+function filterRenditions<T extends ReferencedRendition>(
+	base: Moq.Path.Valid,
+	renditions: Record<string, T>,
+): Record<string, T> {
+	return Object.fromEntries(
+		Object.entries(renditions).filter(([, config]) =>
+			config.broadcast === undefined ? true : Path.tryResolve(base, config.broadcast) !== undefined,
+		),
+	);
+}
+
+function filterCatalog(base: Moq.Path.Valid, catalog: Catalog.Root): Catalog.Root {
+	return {
+		...catalog,
+		video: catalog.video
+			? { ...catalog.video, renditions: filterRenditions(base, catalog.video.renditions) }
+			: undefined,
+		audio: catalog.audio
+			? { ...catalog.audio, renditions: filterRenditions(base, catalog.audio.renditions) }
+			: undefined,
+	};
+}
+
 // Watch supports the on-the-wire catalog formats from @moq/hang, plus "hangz" (the
 // DEFLATE-compressed `catalog.json.z` track) and a "manual" mode where the user supplies the
 // catalog directly without fetching. "hangz" is opt-in only: it shares the `.hang` broadcast suffix
@@ -199,7 +226,7 @@ export class Broadcast {
 		if (format === "manual") {
 			// Mirror the caller-supplied catalog into the effective output.
 			const catalog = effect.get(this.in.catalog);
-			effect.set(this.#out.catalog, catalog, undefined);
+			effect.set(this.#out.catalog, catalog ? filterCatalog(name, catalog) : undefined, undefined);
 			this.#out.status.set(catalog ? "live" : "loading");
 			return;
 		}
@@ -237,7 +264,7 @@ export class Broadcast {
 
 					console.debug("received catalog", format, this.in.name.peek(), update);
 
-					this.#out.catalog.set(update);
+					this.#out.catalog.set(filterCatalog(name, update));
 					this.#out.status.set("live");
 				}
 			} catch (err) {

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -264,12 +264,11 @@ export class Broadcast {
 		if (!rel) return effect.get(this.out.active);
 
 		const base = effect.get(this.in.name);
-		const resolved = Path.resolve(base, rel);
+		const resolved = Path.tryResolve(base, rel);
 
-		// A reference that walks back to the catalog's own broadcast (or resolves to
-		// the empty root, via excess `..`) is served by the catalog broadcast itself,
-		// avoiding a duplicate subscription on the same path.
-		if (resolved === base || resolved === Path.empty()) return effect.get(this.out.active);
+		// An escape or a reference back to the catalog is served by the catalog broadcast.
+		// A valid empty result names the root broadcast and continues below.
+		if (resolved === undefined || resolved === base) return effect.get(this.out.active);
 
 		if (!effect.get(this.in.enabled)) return undefined;
 

--- a/js/watch/src/video/source.test.ts
+++ b/js/watch/src/video/source.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import type * as Catalog from "@moq/hang/catalog";
+import * as Catalog from "@moq/hang/catalog";
+import { Path } from "@moq/net";
 import { Signal } from "@moq/signals";
-import type { Broadcast } from "../broadcast";
+import { Broadcast } from "../broadcast";
 import { Source } from "./source";
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -14,7 +15,7 @@ function config(codec: string): Catalog.VideoConfig {
 	return { codec, container: { kind: "legacy" } };
 }
 
-function broadcast(renditions: Record<string, Catalog.VideoConfig>): Broadcast {
+function mockBroadcast(renditions: Record<string, Catalog.VideoConfig>): Broadcast {
 	return {
 		in: {
 			connection: new Signal(undefined),
@@ -39,7 +40,7 @@ describe("Source error signal", () => {
 	it("is unsupported when the catalog has video renditions but none are supported", async () => {
 		await withoutWarnings(async () => {
 			const source = new Source({
-				broadcast: broadcast({ hd: config("hev1.1.6.L120.90") }),
+				broadcast: mockBroadcast({ hd: config("hev1.1.6.L120.90") }),
 				supported: async () => false,
 			});
 
@@ -54,7 +55,7 @@ describe("Source error signal", () => {
 	it("treats a support probe throw as unsupported without aborting the remaining renditions", async () => {
 		await withoutWarnings(async () => {
 			const source = new Source({
-				broadcast: broadcast({
+				broadcast: mockBroadcast({
 					bad: config("not-a-codec"),
 					good: config("avc1.640028"),
 				}),
@@ -81,7 +82,7 @@ describe("Source error signal", () => {
 			);
 
 			const source = new Source({
-				broadcast: broadcast({ hd: config("avc1.640028") }),
+				broadcast: mockBroadcast({ hd: config("avc1.640028") }),
 				supported,
 			});
 
@@ -101,7 +102,7 @@ describe("Source error signal", () => {
 
 	it("is undefined when the catalog has no video renditions", async () => {
 		const source = new Source({
-			broadcast: broadcast({}),
+			broadcast: mockBroadcast({}),
 			supported: async () => false,
 		});
 
@@ -110,5 +111,40 @@ describe("Source error signal", () => {
 		expect(source.out.available.peek()).toEqual({});
 
 		source.close();
+	});
+
+	it("ignores escaping renditions before selecting a valid fallback", async () => {
+		const invalidVideo = { ...config("avc1.640028"), broadcast: "../../source" };
+		const validVideo = { ...config("avc1.640028"), broadcast: "./source" };
+		const audioConfig = Catalog.AudioConfigSchema.parse({
+			codec: "opus",
+			container: { kind: "legacy" },
+			sampleRate: 48_000,
+			numberOfChannels: 2,
+		});
+		const broadcast = new Broadcast({
+			enabled: true,
+			name: Path.from("room/catalog.hang"),
+			catalogFormat: "manual",
+			catalog: {
+				video: { renditions: { invalid: invalidVideo, fallback: validVideo } },
+				audio: {
+					renditions: {
+						invalid: { ...audioConfig, broadcast: "../../source" },
+						fallback: { ...audioConfig, broadcast: "./source" },
+					},
+				},
+			},
+		});
+		const source = new Source({ broadcast, supported: async () => true });
+
+		await settle();
+		expect(Object.keys(broadcast.out.catalog.peek()?.video?.renditions ?? {})).toEqual(["fallback"]);
+		expect(Object.keys(broadcast.out.catalog.peek()?.audio?.renditions ?? {})).toEqual(["fallback"]);
+		expect(Object.keys(source.out.available.peek())).toEqual(["fallback"]);
+		expect(source.out.track.peek()).toBe("fallback");
+
+		source.close();
+		broadcast.close();
 	});
 });

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -69,7 +69,7 @@ impl Audio {
 #[non_exhaustive]
 pub struct AudioConfig {
 	/// Optional reference to another broadcast that publishes this track, expressed
-	/// relative to the broadcast that served this catalog (e.g. `../source`). If unset,
+	/// relative to the broadcast that served this catalog (e.g. `./source`). If unset,
 	/// the track lives in the same broadcast as the catalog.
 	#[serde(default)]
 	pub broadcast: Option<moq_net::PathRelativeOwned>,

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -258,7 +258,7 @@ mod test {
 			"video": {
 				"renditions": {
 					"video": {
-						"broadcast": "../source",
+						"broadcast": "./source",
 						"codec": "avc1.64001f",
 						"codedWidth": 1280,
 						"codedHeight": 720,
@@ -272,7 +272,7 @@ mod test {
 		let rendition = parsed.video.renditions.get("video").expect("missing rendition");
 		assert_eq!(
 			rendition.broadcast.as_ref().map(|p| p.as_str()),
-			Some("../source"),
+			Some("source"),
 			"broadcast field did not deserialize"
 		);
 
@@ -335,6 +335,29 @@ mod test {
 			rendition.broadcast.as_ref().map(|p| p.is_empty()),
 			Some(true),
 			"empty broadcast should deserialize as Some(empty)"
+		);
+	}
+
+	#[test]
+	fn rendition_with_parent_broadcast_stays_distinct_from_empty() {
+		let encoded = r#"{
+			"video": {
+				"renditions": {
+					"video": {
+						"broadcast": ".",
+						"codec": "avc1.64001f",
+						"container": {"kind": "legacy"}
+					}
+				}
+			}
+		}"#;
+
+		let parsed = Catalog::from_str(encoded).expect("failed to decode");
+		let rendition = parsed.video.renditions.get("video").expect("missing rendition");
+		assert_eq!(
+			rendition.broadcast.as_ref().map(|p| p.as_str()),
+			Some("."),
+			"parent reference should not normalize to empty"
 		);
 	}
 

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -142,7 +142,7 @@ pub struct Display {
 #[non_exhaustive]
 pub struct VideoConfig {
 	/// Optional reference to another broadcast that publishes this track, expressed
-	/// relative to the broadcast that served this catalog (e.g. `../source`). If unset,
+	/// relative to the broadcast that served this catalog (e.g. `./source`). If unset,
 	/// the track lives in the same broadcast as the catalog.
 	///
 	/// This allows a transcoder to author a downstream catalog that points unchanged

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -499,7 +499,7 @@ async fn run_stdout(consumer: moq_net::origin::Consumer, name: String, args: Sub
 
 	// Confirm the broadcast is reachable and wait for it to be announced; `Subscribe` then
 	// resolves it (and any sibling broadcast a rendition's `broadcast` field references,
-	// e.g. "../source") through the origin.
+	// e.g. "./source") through the origin.
 	consumer
 		.announced_broadcast(&name)
 		.await

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -133,13 +133,9 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		name => moq_video::decode::Kind::Named(name.to_string()),
 	};
 	config.resize.acceleration = args.resize_acceleration;
-	// Reference the source renditions relatively when the output nests under
-	// the source (`a/b` -> `a/b/transcode.hang` is `..`, one `..` per level);
+	// Reference the source renditions relatively when the output nests under it;
 	// otherwise the derivative catalog advertises only the rungs.
-	config.source = output_path.strip_prefix(&format!("{source_path}/")).map(|rest| {
-		let depth = rest.split('/').count();
-		moq_net::PathRelativeOwned::from(vec![".."; depth].join("/"))
-	});
+	config.source = source_reference(&source_path, &output_path);
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))
@@ -149,5 +145,36 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 	tokio::select! {
 		res = moq_transcode::run(source, output, config) => Ok(res?),
 		res = session.closed() => Ok(res?),
+	}
+}
+
+fn source_reference(source: &str, output: &str) -> Option<moq_net::PathRelativeOwned> {
+	output.strip_prefix(&format!("{source}/")).map(|rest| {
+		let parents = rest.split('/').count().saturating_sub(1);
+		let rel = if parents == 0 {
+			".".to_string()
+		} else {
+			vec![".."; parents].join("/")
+		};
+		moq_net::PathRelativeOwned::from(rel)
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn source_reference_resolves_from_output_parent() {
+		assert_eq!(source_reference("a/b", "a/b/transcode.hang").unwrap().as_str(), ".");
+		assert_eq!(
+			source_reference("a/b", "a/b/dir/transcode.hang").unwrap().as_str(),
+			".."
+		);
+		assert_eq!(
+			source_reference("a/b", "a/b/one/two/transcode.hang").unwrap().as_str(),
+			"../.."
+		);
+		assert!(source_reference("a/b", "other/transcode.hang").is_none());
 	}
 }

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -67,15 +67,19 @@ fn parse_resize_acceleration(arg: &str) -> Result<moq_video::resize::Acceleratio
 /// Run the transcoder: subscribe to the source through the relay, publish the
 /// derivative back through the same session, and serve rungs until either ends.
 pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
-	let source_path = moq
-		.broadcast
-		.clone()
-		.filter(|name| !name.is_empty())
-		.context("`transcode` requires the source broadcast: pass --broadcast <name>")?;
-	let output_path = args
-		.output
-		.clone()
-		.unwrap_or_else(|| format!("{source_path}/transcode.hang"));
+	let source_path = moq_net::PathOwned::from(
+		moq.broadcast
+			.clone()
+			.context("`transcode` requires the source broadcast: pass --broadcast <name>")?,
+	);
+	if source_path.is_empty() {
+		anyhow::bail!("`transcode` requires the source broadcast: pass --broadcast <name>");
+	}
+	let output_path = moq_net::PathOwned::from(
+		args.output
+			.clone()
+			.unwrap_or_else(|| format!("{source_path}/transcode.hang")),
+	);
 
 	// Publish the derivative through one origin and consume the source through
 	// another, over a single auto-reconnecting session.
@@ -135,7 +139,7 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 	config.resize.acceleration = args.resize_acceleration;
 	// Reference the source renditions relatively when the output nests under it;
 	// otherwise the derivative catalog advertises only the rungs.
-	config.source = source_reference(&source_path, &output_path);
+	config.source = moq_transcode::source_reference(&source_path, &output_path);
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))
@@ -145,36 +149,5 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 	tokio::select! {
 		res = moq_transcode::run(source, output, config) => Ok(res?),
 		res = session.closed() => Ok(res?),
-	}
-}
-
-fn source_reference(source: &str, output: &str) -> Option<moq_net::PathRelativeOwned> {
-	output.strip_prefix(&format!("{source}/")).map(|rest| {
-		let parents = rest.split('/').count().saturating_sub(1);
-		let rel = if parents == 0 {
-			".".to_string()
-		} else {
-			vec![".."; parents].join("/")
-		};
-		moq_net::PathRelativeOwned::from(rel)
-	})
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn source_reference_resolves_from_output_parent() {
-		assert_eq!(source_reference("a/b", "a/b/transcode.hang").unwrap().as_str(), ".");
-		assert_eq!(
-			source_reference("a/b", "a/b/dir/transcode.hang").unwrap().as_str(),
-			".."
-		);
-		assert_eq!(
-			source_reference("a/b", "a/b/one/two/transcode.hang").unwrap().as_str(),
-			"../.."
-		);
-		assert!(source_reference("a/b", "other/transcode.hang").is_none());
 	}
 }

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -246,6 +246,29 @@ mod tests {
 		}
 	}
 
+	#[tokio::test]
+	async fn escaping_broadcast_reference_is_not_advertised() {
+		let origin = moq_net::Origin::random().produce();
+		let _broadcast = origin
+			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
+			.expect("publish allowed");
+		settle().await;
+		let source = moq_mux::Source::new(origin.consume(), "a/pub");
+		let upstream = Upstream {
+			broadcast: source.broadcast().await.unwrap(),
+			source,
+		};
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		config.broadcast = Some(moq_net::PathRelative::new("../../source").to_owned());
+		config.timeline = Some(hang::catalog::Timeline::new("video.timeline"));
+		let mut catalog = moq_mux::catalog::hang::Catalog::default();
+		catalog.video.renditions.insert("video".to_string(), config);
+
+		let renditions = renditions::Producer::new();
+		renditions.sync(&upstream, &Config::default(), &catalog);
+		assert!(renditions.get(Kind::Video, "video").is_none());
+	}
+
 	// The whole fetch-on-demand path in process: a broadcast publishes media through the
 	// catalog (which records the timeline), the Broadcaster renders playlists from the
 	// timeline alone, and a segment request fetches and transmuxes exactly its groups.

--- a/rs/moq-hls/src/export/renditions.rs
+++ b/rs/moq-hls/src/export/renditions.rs
@@ -132,6 +132,28 @@ impl Producer {
 		let Ok(mut current) = self.state.write() else {
 			return;
 		};
+		let mut catalog = catalog.clone();
+		catalog.video.renditions.retain(|name, config| {
+			let valid = upstream.source.resolve_reference(config.broadcast.as_ref()).is_some();
+			if !valid {
+				tracing::warn!(
+					rendition = name,
+					"ignoring video rendition whose broadcast escapes above the root"
+				);
+			}
+			valid
+		});
+		catalog.audio.renditions.retain(|name, config| {
+			let valid = upstream.source.resolve_reference(config.broadcast.as_ref()).is_some();
+			if !valid {
+				tracing::warn!(
+					rendition = name,
+					"ignoring audio rendition whose broadcast escapes above the root"
+				);
+			}
+			valid
+		});
+		let catalog = &catalog;
 
 		// Renditions the catalog dropped or reconfigured. Close each as it goes so any cursor
 		// over it drains and ends, instead of parking on a timeline that never finishes -- the

--- a/rs/moq-mux/src/codec/h264/export.rs
+++ b/rs/moq-mux/src/codec/h264/export.rs
@@ -121,6 +121,9 @@ impl<S: Stream> Export<S> {
 	}
 
 	fn update_catalog(&mut self, catalog: &Catalog) -> crate::Result<()> {
+		let mut catalog = catalog.clone();
+		self.source.retain_valid_media(&mut catalog);
+
 		let picked = catalog
 			.video
 			.renditions
@@ -149,7 +152,9 @@ impl<S: Stream> Export<S> {
 			return Ok(());
 		}
 
-		let source = ExportSource::for_video_raw(&self.source, name, config, self.latency)?;
+		let Some(source) = ExportSource::for_video_raw(&self.source, name, config, self.latency)? else {
+			unreachable!("invalid broadcast references were removed above");
+		};
 		let convert = match config.description.as_ref().filter(|d| !d.is_empty()) {
 			None => None,
 			Some(avcc) => {

--- a/rs/moq-mux/src/codec/h265/export.rs
+++ b/rs/moq-mux/src/codec/h265/export.rs
@@ -113,6 +113,9 @@ impl<S: Stream> Export<S> {
 	}
 
 	fn update_catalog(&mut self, catalog: &Catalog) -> crate::Result<()> {
+		let mut catalog = catalog.clone();
+		self.source.retain_valid_media(&mut catalog);
+
 		let picked = catalog
 			.video
 			.renditions
@@ -141,7 +144,9 @@ impl<S: Stream> Export<S> {
 			return Ok(());
 		}
 
-		let source = ExportSource::for_video_raw(&self.source, name, config, self.latency)?;
+		let Some(source) = ExportSource::for_video_raw(&self.source, name, config, self.latency)? else {
+			unreachable!("invalid broadcast references were removed above");
+		};
 		let convert = match config.description.as_ref().filter(|d| !d.is_empty()) {
 			None => None,
 			Some(hvcc) => {

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -301,7 +301,9 @@ impl Export {
 		!self.video.is_empty() || !self.audio.is_empty()
 	}
 
-	fn update_catalog(&mut self, catalog: Catalog) -> anyhow::Result<()> {
+	fn update_catalog(&mut self, mut catalog: Catalog) -> anyhow::Result<()> {
+		self.source.retain_valid_media(&mut catalog);
+
 		// A single-track FLV stream binds only the first rendition of each kind;
 		// multitrack binds them all. Bind newly-seen renditions in name order (the
 		// catalog is a BTreeMap) so each keeps a stable track id.
@@ -349,7 +351,9 @@ impl Export {
 				(VideoCodec::AV1(av1), None) => Some(Bytes::copy_from_slice(&av1c_bytes(av1))),
 				_ => None,
 			};
-			let source = ExportSource::for_video(&self.source, name, config, self.latency)?;
+			let Some(source) = ExportSource::for_video(&self.source, name, config, self.latency)? else {
+				continue;
+			};
 			let track_id = u8::try_from(self.video.len()).context("too many FLV video tracks")?;
 			self.video.push(FlvTrack {
 				name: name.clone(),
@@ -377,7 +381,9 @@ impl Export {
 			}
 			let flavor = audio_flavor(config)?;
 			ensure_legacy(&config.container, "audio", name)?;
-			let source = ExportSource::for_audio(&self.source, name, config, self.latency)?;
+			let Some(source) = ExportSource::for_audio(&self.source, name, config, self.latency)? else {
+				continue;
+			};
 			let track_id = u8::try_from(self.audio.len()).context("too many FLV audio tracks")?;
 			self.audio.push(FlvTrack {
 				name: name.clone(),

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -328,6 +328,7 @@ impl<S: Stream> Export<S> {
 			.audio
 			.renditions
 			.retain(|name, config| crate::catalog::hang::supported(name, &config.container));
+		self.source.retain_valid_media(&mut catalog);
 		let catalog = &catalog;
 
 		let mut active: HashMap<String, ()> = HashMap::new();
@@ -346,7 +347,9 @@ impl<S: Stream> Export<S> {
 			if self.tracks.contains_key(name) {
 				continue;
 			}
-			let source = ExportSource::for_video(&self.source, name, config, self.latency)?;
+			let Some(source) = ExportSource::for_video(&self.source, name, config, self.latency)? else {
+				continue;
+			};
 			let timescale = catalog_timescale_video(config)?;
 			let framerate = super::usable_video_framerate(config).unwrap_or(30.0);
 			self.tracks.insert(
@@ -372,7 +375,9 @@ impl<S: Stream> Export<S> {
 			if self.tracks.contains_key(name) {
 				continue;
 			}
-			let source = ExportSource::for_audio(&self.source, name, config, self.latency)?;
+			let Some(source) = ExportSource::for_audio(&self.source, name, config, self.latency)? else {
+				continue;
+			};
 			let timescale = catalog_timescale_audio(config)?;
 			self.tracks.insert(
 				name.clone(),

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -296,7 +296,9 @@ impl<S: Stream> Export<S> {
 		Poll::Pending
 	}
 
-	fn update_catalog(&mut self, catalog: Catalog) -> Result<()> {
+	fn update_catalog(&mut self, mut catalog: Catalog) -> Result<()> {
+		self.source.retain_valid_media(&mut catalog);
+
 		let mut active: HashMap<String, ()> = HashMap::new();
 		for name in catalog.video.renditions.keys() {
 			active.insert(name.clone(), ());
@@ -329,7 +331,9 @@ impl<S: Stream> Export<S> {
 				continue;
 			}
 			ensure_legacy(&config.container, "video", name)?;
-			let source = ExportSource::for_video(&self.source, name, config, self.latency)?;
+			let Some(source) = ExportSource::for_video(&self.source, name, config, self.latency)? else {
+				continue;
+			};
 			self.tracks.insert(
 				name.clone(),
 				MkvTrack {
@@ -348,7 +352,9 @@ impl<S: Stream> Export<S> {
 				continue;
 			}
 			ensure_legacy(&config.container, "audio", name)?;
-			let source = ExportSource::for_audio(&self.source, name, config, self.latency)?;
+			let Some(source) = ExportSource::for_audio(&self.source, name, config, self.latency)? else {
+				continue;
+			};
 			self.tracks.insert(
 				name.clone(),
 				MkvTrack {

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -80,18 +80,21 @@ impl ExportSource {
 		name: &str,
 		config: &VideoConfig,
 		latency: Duration,
-	) -> Result<Self, crate::Error> {
+	) -> Result<Option<Self>, crate::Error> {
 		let media: HangContainer = (&config.container).try_into()?;
 		let transform = build_video_transform(config);
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
+		let Some(request) = source.request(config.broadcast.as_ref()) else {
+			return Ok(None);
+		};
 
-		Ok(Self {
-			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
+		Ok(Some(Self {
+			state: SourceState::Requesting(request, name.to_string()),
 			media: Some(media),
 			latency,
 			transform,
 			description,
-		})
+		}))
 	}
 
 	/// Subscribe to a video rendition without attaching any codec-shape
@@ -103,17 +106,20 @@ impl ExportSource {
 		name: &str,
 		config: &VideoConfig,
 		latency: Duration,
-	) -> Result<Self, crate::Error> {
+	) -> Result<Option<Self>, crate::Error> {
 		let media: HangContainer = (&config.container).try_into()?;
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
+		let Some(request) = source.request(config.broadcast.as_ref()) else {
+			return Ok(None);
+		};
 
-		Ok(Self {
-			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
+		Ok(Some(Self {
+			state: SourceState::Requesting(request, name.to_string()),
 			media: Some(media),
 			latency,
 			transform: None,
 			description,
-		})
+		}))
 	}
 
 	/// Subscribe to an audio rendition. Audio has no codec-shape transform;
@@ -123,25 +129,29 @@ impl ExportSource {
 		name: &str,
 		config: &AudioConfig,
 		latency: Duration,
-	) -> Result<Self, crate::Error> {
+	) -> Result<Option<Self>, crate::Error> {
 		let media: HangContainer = (&config.container).try_into()?;
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
+		let Some(request) = source.request(config.broadcast.as_ref()) else {
+			return Ok(None);
+		};
 
-		Ok(Self {
-			state: SourceState::Requesting(source.request(config.broadcast.as_ref()), name.to_string()),
+		Ok(Some(Self {
+			state: SourceState::Requesting(request, name.to_string()),
 			media: Some(media),
 			latency,
 			transform: None,
 			description,
-		})
+		}))
 	}
 
 	/// Subscribe to a verbatim `mpegts` stream rendition (SCTE-35, private PES, ...).
 	/// No codec-shape transform and no description: the frames are Legacy-framed
 	/// verbatim bytes the muxer writes back out as PES or private sections.
 	pub fn for_stream(source: &crate::Source, name: &str, latency: Duration) -> Result<Self, crate::Error> {
+		let request = source.request(None).expect("the catalog broadcast is always valid");
 		Ok(Self {
-			state: SourceState::Requesting(source.request(None), name.to_string()),
+			state: SourceState::Requesting(request, name.to_string()),
 			media: Some(HangContainer::Legacy),
 			latency,
 			transform: None,

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -340,6 +340,8 @@ impl<E: catalog::Catalog> Export<E> {
 	}
 
 	fn update_catalog(&mut self, mut catalog: Catalog<E>) -> anyhow::Result<()> {
+		self.source.retain_valid(&mut catalog);
+
 		// The MPEG-TS section lives in the extension. The trait only exposes
 		// `mpegts_mut`, and this snapshot is owned, so clone it out (`()` yields the
 		// empty default: no verbatim streams, no preserved PIDs/descriptors).
@@ -424,7 +426,9 @@ impl<E: catalog::Catalog> Export<E> {
 					self.tracks.insert(name.clone(), track);
 				}
 				None => {
-					let source = ExportSource::for_video(&self.source, name, config, self.latency)?;
+					let Some(source) = ExportSource::for_video(&self.source, name, config, self.latency)? else {
+						continue;
+					};
 					self.insert_track(name, source, pid, kind, descriptors, reserve);
 				}
 			}
@@ -441,7 +445,9 @@ impl<E: catalog::Catalog> Export<E> {
 					self.tracks.insert(name.clone(), track);
 				}
 				None => {
-					let source = ExportSource::for_audio(&self.source, name, config, self.latency)?;
+					let Some(source) = ExportSource::for_audio(&self.source, name, config, self.latency)? else {
+						continue;
+					};
 					self.insert_track(name, source, pid, kind, descriptors, DEFAULT_DTS_RESERVE);
 				}
 			}

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -132,6 +132,10 @@ pub enum Error {
 	/// frames cannot be parsed. Such a rendition must be ignored, not guessed at.
 	#[error("unsupported container: {0}")]
 	UnsupportedContainer(String),
+
+	/// A rendition's relative broadcast reference escaped above the origin root.
+	#[error("broadcast reference escapes above the root: {0}")]
+	InvalidBroadcastReference(String),
 }
 
 impl Error {

--- a/rs/moq-mux/src/source.rs
+++ b/rs/moq-mux/src/source.rs
@@ -47,19 +47,16 @@ impl Source {
 	/// Begin resolving the broadcast that serves rendition track `name`, honoring an
 	/// optional cross-broadcast reference.
 	///
-	/// A missing/empty `rel`, or one that resolves back to the catalog's own path (or
-	/// walks past the origin root), targets the catalog broadcast; anything else targets
-	/// the resolved sibling broadcast. Either way the broadcast is fetched from the origin,
+	/// A missing/empty `rel`, one that resolves back to the catalog's own path, or one that
+	/// walks past the origin root targets the catalog broadcast. Anything else, including
+	/// the empty root broadcast, targets the resolved path. Either way it is fetched from the origin,
 	/// which deduplicates repeat requests for the same live path (announced or dynamically
 	/// served) so the catalog and every rendition share one upstream subscription.
 	pub(crate) fn request(&self, rel: Option<&moq_net::PathRelative<'_>>) -> kio::Pending<moq_net::origin::Requesting> {
 		let target = match rel.filter(|rel| !rel.is_empty()) {
-			// Excess `..` clamps to the (empty) origin root, which is not a broadcast; treat
-			// it as a self-reference and use the catalog broadcast instead.
-			Some(rel) => match self.path.resolve(rel) {
-				resolved if resolved.is_empty() => self.path.clone(),
-				resolved => resolved,
-			},
+			// Preserve the existing self-reference fallback for an escape, while allowing
+			// a valid reference to the empty root broadcast to remain empty.
+			Some(rel) => self.path.try_resolve(rel).unwrap_or_else(|| self.path.clone()),
 			None => self.path.clone(),
 		};
 
@@ -240,5 +237,27 @@ mod tests {
 			.subscribe_track(Some(&rel), "video")
 			.await
 			.expect("dot should resolve to the catalog broadcast's parent");
+	}
+
+	#[tokio::test]
+	async fn dot_resolves_one_segment_catalog_to_root() {
+		let origin = Origin::random().produce();
+
+		let _catalog = origin
+			.create_broadcast("top", moq_net::broadcast::Route::new().with_announce(true))
+			.unwrap();
+
+		let mut root = origin
+			.create_broadcast("", moq_net::broadcast::Route::new().with_announce(true))
+			.unwrap();
+		let _video = root.create_track("video", None).unwrap();
+		settle().await;
+
+		let source = Source::new(origin.consume(), "top");
+		let rel = PathRelative::new(".");
+		source
+			.subscribe_track(Some(&rel), "video")
+			.await
+			.expect("dot should resolve to the empty root broadcast");
 	}
 }

--- a/rs/moq-mux/src/source.rs
+++ b/rs/moq-mux/src/source.rs
@@ -47,20 +47,62 @@ impl Source {
 	/// Begin resolving the broadcast that serves rendition track `name`, honoring an
 	/// optional cross-broadcast reference.
 	///
-	/// A missing/empty `rel`, one that resolves back to the catalog's own path, or one that
-	/// walks past the origin root targets the catalog broadcast. Anything else, including
-	/// the empty root broadcast, targets the resolved path. Either way it is fetched from the origin,
+	/// A missing/empty `rel` targets the catalog broadcast. Anything else, including
+	/// the empty root broadcast, targets the resolved path. A reference that escapes above
+	/// the origin root returns `None`. Either valid target is fetched from the origin,
 	/// which deduplicates repeat requests for the same live path (announced or dynamically
 	/// served) so the catalog and every rendition share one upstream subscription.
-	pub(crate) fn request(&self, rel: Option<&moq_net::PathRelative<'_>>) -> kio::Pending<moq_net::origin::Requesting> {
-		let target = match rel.filter(|rel| !rel.is_empty()) {
-			// Preserve the existing self-reference fallback for an escape, while allowing
-			// a valid reference to the empty root broadcast to remain empty.
-			Some(rel) => self.path.try_resolve(rel).unwrap_or_else(|| self.path.clone()),
-			None => self.path.clone(),
-		};
+	pub(crate) fn request(
+		&self,
+		rel: Option<&moq_net::PathRelative<'_>>,
+	) -> Option<kio::Pending<moq_net::origin::Requesting>> {
+		let target = self.resolve_reference(rel)?;
+		Some(self.origin.request_broadcast(&target))
+	}
 
-		self.origin.request_broadcast(&target)
+	/// Resolve a rendition's optional broadcast reference to an origin path.
+	///
+	/// A missing or empty reference returns the catalog broadcast path. A valid reference
+	/// may return the empty root path. `None` means the reference escaped above the root and
+	/// the rendition must be ignored.
+	pub fn resolve_reference(&self, rel: Option<&moq_net::PathRelative<'_>>) -> Option<moq_net::PathOwned> {
+		match rel.filter(|rel| !rel.is_empty()) {
+			Some(rel) => self.path.try_resolve(rel),
+			None => Some(self.path.clone()),
+		}
+	}
+
+	/// Remove renditions whose broadcast reference escapes above the origin root.
+	pub(crate) fn retain_valid<E: crate::catalog::hang::CatalogExt>(
+		&self,
+		catalog: &mut crate::catalog::hang::Catalog<E>,
+	) {
+		self.retain_valid_references("video", &mut catalog.video.renditions);
+		self.retain_valid_references("audio", &mut catalog.audio.renditions);
+	}
+
+	/// Remove media renditions whose broadcast reference escapes above the origin root.
+	pub(crate) fn retain_valid_media(&self, catalog: &mut hang::Catalog) {
+		self.retain_valid_references("video", &mut catalog.video.renditions);
+		self.retain_valid_references("audio", &mut catalog.audio.renditions);
+	}
+
+	fn retain_valid_references<C: BroadcastConfig>(
+		&self,
+		kind: &'static str,
+		renditions: &mut std::collections::BTreeMap<String, C>,
+	) {
+		renditions.retain(|name, config| {
+			let valid = self.resolve_reference(config.broadcast()).is_some();
+			if !valid {
+				tracing::warn!(
+					rendition = name,
+					kind,
+					"ignoring rendition whose broadcast escapes above the root"
+				);
+			}
+			valid
+		});
 	}
 
 	/// Resolve an optional cross-broadcast reference to its broadcast.
@@ -73,7 +115,8 @@ impl Source {
 		&self,
 		rel: Option<&moq_net::PathRelative<'_>>,
 	) -> crate::Result<moq_net::broadcast::Consumer> {
-		Ok(self.request(rel).await?)
+		let request = self.request(rel).ok_or_else(|| invalid_broadcast_reference(rel))?;
+		Ok(request.await?)
 	}
 
 	/// Resolve an optional cross-broadcast reference and subscribe to track `name`,
@@ -91,9 +134,30 @@ impl Source {
 		rel: Option<&moq_net::PathRelative<'_>>,
 		name: &str,
 	) -> crate::Result<moq_net::track::Subscriber> {
-		let broadcast = self.request(rel).await?;
+		let request = self.request(rel).ok_or_else(|| invalid_broadcast_reference(rel))?;
+		let broadcast = request.await?;
 		Ok(broadcast.track(name)?.subscribe(None).await?)
 	}
+}
+
+trait BroadcastConfig {
+	fn broadcast(&self) -> Option<&moq_net::PathRelativeOwned>;
+}
+
+impl BroadcastConfig for hang::catalog::VideoConfig {
+	fn broadcast(&self) -> Option<&moq_net::PathRelativeOwned> {
+		self.broadcast.as_ref()
+	}
+}
+
+impl BroadcastConfig for hang::catalog::AudioConfig {
+	fn broadcast(&self) -> Option<&moq_net::PathRelativeOwned> {
+		self.broadcast.as_ref()
+	}
+}
+
+fn invalid_broadcast_reference(rel: Option<&moq_net::PathRelative<'_>>) -> crate::Error {
+	crate::Error::InvalidBroadcastReference(rel.map_or_else(String::new, |rel| rel.as_str().to_string()))
 }
 
 /// Test helper: serve `broadcast` on a throwaway origin's dynamic handler and return a
@@ -118,6 +182,7 @@ pub(crate) fn announced(broadcast: &moq_net::broadcast::Consumer) -> Source {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use hang::catalog::{H264, VideoConfig};
 	use moq_net::{Origin, PathRelative};
 
 	/// Let the origin's spawned attach task run: a created broadcast becomes
@@ -139,10 +204,15 @@ mod tests {
 		let source = Source::new(origin.consume(), "a/pub");
 
 		// No reference and an empty reference both resolve to the catalog broadcast.
-		source.request(None).await.expect("catalog broadcast should resolve");
+		source
+			.request(None)
+			.expect("catalog reference should be valid")
+			.await
+			.expect("catalog broadcast should resolve");
 		let empty = PathRelative::empty();
 		source
 			.request(Some(&empty))
+			.expect("empty reference should be valid")
 			.await
 			.expect("empty reference should resolve to the catalog broadcast");
 	}
@@ -181,13 +251,47 @@ mod tests {
 			.subscribe_track(Some(&rel), "video")
 			.await
 			.expect("self-reference should resolve to the catalog broadcast");
+	}
 
-		// Excess `..` walks past the (empty) origin root, treated as a self-reference.
-		let rel = PathRelative::new("../../..");
-		source
-			.subscribe_track(Some(&rel), "video")
-			.await
-			.expect("excess `..` should resolve to the catalog broadcast");
+	#[tokio::test]
+	async fn escaping_reference_is_rejected_instead_of_using_the_catalog() {
+		let origin = Origin::random().produce();
+		let mut producer = origin
+			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
+			.unwrap();
+		let _video = producer.create_track("video", None).unwrap();
+		settle().await;
+
+		let source = Source::new(origin.consume(), "a/pub");
+		let rel = PathRelative::new("../../source");
+		assert!(source.resolve_reference(Some(&rel)).is_none());
+		assert!(matches!(
+			source.subscribe_track(Some(&rel), "video").await,
+			Err(crate::Error::InvalidBroadcastReference(reference)) if reference == "../../source"
+		));
+	}
+
+	#[test]
+	fn escaping_rendition_is_removed_while_valid_sibling_remains() {
+		let origin = Origin::random().produce();
+		let source = Source::new(origin.consume(), "a/pub");
+		let mut escaped = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0,
+			level: 0x1e,
+			inline: false,
+		});
+		escaped.broadcast = Some(PathRelative::new("../../source").to_owned());
+		let mut sibling = escaped.clone();
+		sibling.broadcast = Some(PathRelative::new("./source").to_owned());
+
+		let mut catalog = hang::Catalog::default();
+		catalog.video.renditions.insert("escaped".to_string(), escaped);
+		catalog.video.renditions.insert("sibling".to_string(), sibling);
+		source.retain_valid_media(&mut catalog);
+
+		assert!(!catalog.video.renditions.contains_key("escaped"));
+		assert!(catalog.video.renditions.contains_key("sibling"));
 	}
 
 	#[tokio::test]

--- a/rs/moq-mux/src/source.rs
+++ b/rs/moq-mux/src/source.rs
@@ -2,7 +2,7 @@
 //!
 //! A hang catalog rendition may reference a track published in *another*
 //! broadcast via its `broadcast` field (a path relative to the catalog's
-//! broadcast, e.g. `../source`). Resolving that reference needs the catalog
+//! broadcast, e.g. `./source`). Resolving that reference needs the catalog
 //! broadcast's own path and an [`moq_net::origin::Consumer`] to fetch the
 //! referenced broadcast from. [`Source`] bundles the two, and resolves both the
 //! catalog broadcast and any referenced broadcast through the same origin so
@@ -178,8 +178,8 @@ mod tests {
 
 		let source = Source::new(origin.consume(), "a/pub");
 
-		// Walks back to the catalog's own path.
-		let rel = PathRelative::new("../pub");
+		// Names the catalog within its own parent.
+		let rel = PathRelative::new("./pub");
 		source
 			.subscribe_track(Some(&rel), "video")
 			.await
@@ -210,10 +210,35 @@ mod tests {
 		let source = Source::new(origin.consume(), "a/pub");
 
 		// The reference resolves to `a/source`, whose "video" track answers the subscribe.
-		let rel = PathRelative::new("../source");
+		let rel = PathRelative::new("./source");
 		source
 			.subscribe_track(Some(&rel), "video")
 			.await
 			.expect("referenced track should resolve");
+	}
+
+	#[tokio::test]
+	async fn dot_resolves_output_parent() {
+		let origin = Origin::random().produce();
+
+		let _catalog = origin
+			.create_broadcast(
+				"a/source/transcode",
+				moq_net::broadcast::Route::new().with_announce(true),
+			)
+			.unwrap();
+
+		let mut referenced = origin
+			.create_broadcast("a/source", moq_net::broadcast::Route::new().with_announce(true))
+			.unwrap();
+		let _video = referenced.create_track("video", None).unwrap();
+		settle().await;
+
+		let source = Source::new(origin.consume(), "a/source/transcode");
+		let rel = PathRelative::new(".");
+		source
+			.subscribe_track(Some(&rel), "video")
+			.await
+			.expect("dot should resolve to the catalog broadcast's parent");
 	}
 }

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -369,6 +369,40 @@ impl<'a> Path<'a> {
 			})
 		}
 	}
+
+	/// Resolve a [`PathRelative`], returning `None` if it escapes above the root.
+	///
+	/// Unlike [`Path::resolve`], this distinguishes a valid reference to the empty root
+	/// path from excess `..` segments. Use it when an untrusted relative reference must
+	/// not be clamped to the root.
+	pub fn try_resolve(&self, rel: &PathRelative<'_>) -> Option<PathOwned> {
+		if rel.is_empty() {
+			return Some(self.to_owned());
+		}
+
+		let mut segments: Vec<&str> = self.parts().collect();
+		segments.pop();
+
+		for seg in rel.as_str().split('/') {
+			if seg == "." {
+				continue;
+			} else if seg == ".." {
+				segments.pop()?;
+			} else {
+				segments.push(seg);
+			}
+		}
+
+		let path = segments.join("/");
+		if path.is_empty() {
+			Some(Path::empty())
+		} else {
+			Some(Path(Repr::Shared {
+				buf: path.into(),
+				start: 0,
+			}))
+		}
+	}
 }
 
 // Comparisons, ordering, and hashing all go through `as_str()` so a borrowed and a
@@ -1446,5 +1480,16 @@ mod tests {
 		// caller compare resolved == base to detect a self-reference.
 		let base = Path::new("a/b");
 		assert_eq!(base.resolve(&PathRelative::new("./b")).as_str(), "a/b");
+	}
+
+	#[test]
+	fn test_try_resolve_distinguishes_root_from_escape() {
+		let base = Path::new("top");
+		assert_eq!(base.try_resolve(&PathRelative::new(".")).unwrap().as_str(), "");
+		assert!(base.try_resolve(&PathRelative::new("..")).is_none());
+
+		let nested = Path::new("a/b");
+		assert_eq!(nested.try_resolve(&PathRelative::new("..")).unwrap().as_str(), "");
+		assert!(nested.try_resolve(&PathRelative::new("../..")).is_none());
 	}
 }

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -324,20 +324,22 @@ impl<'a> Path<'a> {
 
 	/// Resolve a [`PathRelative`] against this path.
 	///
-	/// `..` segments in `rel` pop the last segment of the base; other segments are appended.
+	/// A non-empty reference replaces the last segment of the base, matching relative URL
+	/// resolution. `..` segments then pop another segment; other segments are appended.
 	/// Excess `..` is a no-op once the base is empty (subsequent named segments still append).
 	/// An empty `rel` returns this path as an owned copy.
 	///
-	/// [`PathRelative::new`] strips `.` and empty segments, so they are not handled here.
+	/// [`PathRelative::new`] strips empty and redundant `.` segments, but preserves a lone `.`
+	/// so it can reference the base's parent.
 	///
 	/// # Examples
 	/// ```
 	/// use moq_net::{Path, PathRelative};
 	///
 	/// let base = Path::new("a/b/c");
-	/// assert_eq!(base.resolve(&PathRelative::new("../d")).as_str(), "a/b/d");
-	/// assert_eq!(base.resolve(&PathRelative::new("d")).as_str(), "a/b/c/d");
-	/// assert_eq!(base.resolve(&PathRelative::new("../../../../x")).as_str(), "x");
+	/// assert_eq!(base.resolve(&PathRelative::new("./d")).as_str(), "a/b/d");
+	/// assert_eq!(base.resolve(&PathRelative::new(".")).as_str(), "a/b");
+	/// assert_eq!(base.resolve(&PathRelative::new("../d")).as_str(), "a/d");
 	/// ```
 	pub fn resolve(&self, rel: &PathRelative<'_>) -> PathOwned {
 		if rel.is_empty() {
@@ -345,9 +347,12 @@ impl<'a> Path<'a> {
 		}
 
 		let mut segments: Vec<&str> = self.parts().collect();
+		segments.pop();
 
 		for seg in rel.as_str().split('/') {
-			if seg == ".." {
+			if seg == "." {
+				continue;
+			} else if seg == ".." {
 				segments.pop();
 			} else {
 				segments.push(seg);
@@ -475,27 +480,29 @@ pub type PathRelativeOwned = PathRelative<'static>;
 /// A relative broadcast path, used to reference one broadcast from another broadcast's content.
 ///
 /// Unlike [`Path`] (which is a complete reference within the broadcast namespace),
-/// `PathRelative` may contain `..` segments to walk up the namespace and is meaningful only
-/// when resolved against a base [`Path`] via [`Path::resolve`]. The hang catalog uses it to
-/// point a rendition at a track published in a sibling broadcast (e.g. `../source`).
+/// `PathRelative` may contain `.` and `..` segments to walk the namespace and is meaningful
+/// only when resolved against a base [`Path`] via [`Path::resolve`]. The hang catalog uses it
+/// to point a rendition at a track published in a sibling broadcast (e.g. `./source`).
 ///
 /// `PathRelative` has no `Encode`/`Decode` impl, so it never appears in announce/subscribe
 /// frames. It does serialize via serde for off-wire use (e.g. as a field inside a catalog
 /// JSON payload, which itself travels as a track).
 ///
 /// Normalization on creation: leading/trailing slashes are trimmed, consecutive internal
-/// slashes collapse to one, and `.` segments are stripped (treated as no-ops, matching
-/// POSIX). `..` is preserved and is interpreted at resolve time.
+/// slashes collapse to one, and redundant `.` segments are stripped. A reference made only
+/// of `.` segments normalizes to `.` rather than empty because `.` resolves to the base's
+/// parent while empty resolves to the base itself. `..` is preserved for resolve time.
 ///
 /// # Examples
 /// ```
 /// use moq_net::{Path, PathRelative};
 ///
-/// let rel = PathRelative::new("../source");
+/// let rel = PathRelative::new("./source");
 /// assert_eq!(Path::new("a/b").resolve(&rel).as_str(), "a/source");
 ///
-/// // `.` segments are stripped on creation.
+/// // Redundant `.` segments are stripped on creation.
 /// assert_eq!(PathRelative::new("./a/./b").as_str(), "a/b");
+/// assert_eq!(PathRelative::new(".").as_str(), ".");
 /// ```
 #[derive(Debug, PartialEq, Eq, Hash, Clone, serde::Serialize)]
 pub struct PathRelative<'a>(Cow<'a, str>);
@@ -504,7 +511,7 @@ impl<'a> PathRelative<'a> {
 	/// Create a new `PathRelative` from a string slice.
 	///
 	/// Leading and trailing slashes are trimmed, consecutive internal slashes collapse to one,
-	/// and `.` segments are stripped. See the type-level doc for the full normalization rules.
+	/// and redundant `.` segments are stripped. See the type-level doc for the full rules.
 	pub fn new(s: &'a str) -> Self {
 		let trimmed = s.trim_start_matches('/').trim_end_matches('/');
 
@@ -582,11 +589,17 @@ fn needs_normalize_relative(trimmed: &str) -> bool {
 }
 
 fn normalize_relative_segments(trimmed: &str) -> String {
-	trimmed
+	let segments = trimmed
 		.split('/')
 		.filter(|seg| !seg.is_empty() && *seg != ".")
 		.collect::<Vec<_>>()
-		.join("/")
+		.join("/");
+
+	if segments.is_empty() && trimmed.split('/').any(|seg| seg == ".") {
+		".".to_string()
+	} else {
+		segments
+	}
 }
 
 impl Default for PathRelative<'_> {
@@ -1360,21 +1373,28 @@ mod tests {
 	}
 
 	#[test]
-	fn test_path_relative_strips_dot_segments() {
-		assert_eq!(PathRelative::new(".").as_str(), "");
+	fn test_path_relative_normalizes_dot_segments() {
+		assert_eq!(PathRelative::new(".").as_str(), ".");
+		assert_eq!(PathRelative::new("././").as_str(), ".");
 		assert_eq!(PathRelative::new("./foo").as_str(), "foo");
 		assert_eq!(PathRelative::new("foo/./bar").as_str(), "foo/bar");
 		assert_eq!(PathRelative::new("./../foo").as_str(), "../foo");
 		// From<String> takes the same normalization.
 		assert_eq!(PathRelative::from("./foo".to_string()).as_str(), "foo");
-		assert_eq!(PathRelative::from(".".to_string()).as_str(), "");
+		assert_eq!(PathRelative::from(".".to_string()).as_str(), ".");
 	}
 
 	#[test]
-	fn test_resolve_no_dotdot() {
+	fn test_resolve_replaces_base_name() {
 		let base = Path::new("a/b");
-		assert_eq!(base.resolve(&PathRelative::new("c")).as_str(), "a/b/c");
-		assert_eq!(base.resolve(&PathRelative::new("c/d")).as_str(), "a/b/c/d");
+		assert_eq!(base.resolve(&PathRelative::new("c")).as_str(), "a/c");
+		assert_eq!(base.resolve(&PathRelative::new("c/d")).as_str(), "a/c/d");
+		assert_eq!(
+			Path::new("foo.hang/catalog.pro")
+				.resolve(&PathRelative::new("./transcode.pro"))
+				.as_str(),
+			"foo.hang/transcode.pro"
+		);
 	}
 
 	#[test]
@@ -1386,14 +1406,14 @@ mod tests {
 	#[test]
 	fn test_resolve_single_dotdot() {
 		let base = Path::new("a/b/c");
-		assert_eq!(base.resolve(&PathRelative::new("../d")).as_str(), "a/b/d");
-		assert_eq!(base.resolve(&PathRelative::new("..")).as_str(), "a/b");
+		assert_eq!(base.resolve(&PathRelative::new("../d")).as_str(), "a/d");
+		assert_eq!(base.resolve(&PathRelative::new("..")).as_str(), "a");
 	}
 
 	#[test]
 	fn test_resolve_multiple_dotdot() {
 		let base = Path::new("a/b/c");
-		assert_eq!(base.resolve(&PathRelative::new("../../x")).as_str(), "a/x");
+		assert_eq!(base.resolve(&PathRelative::new("../../x")).as_str(), "x");
 		assert_eq!(base.resolve(&PathRelative::new("../../../x")).as_str(), "x");
 	}
 
@@ -1413,19 +1433,18 @@ mod tests {
 	}
 
 	#[test]
-	fn test_resolve_dot_is_noop() {
+	fn test_resolve_dot_names_parent() {
 		let base = Path::new("a/b");
-		// `.` is normalized away by PathRelative::new, so resolve ignores it.
-		assert_eq!(base.resolve(&PathRelative::new(".")).as_str(), "a/b");
-		assert_eq!(base.resolve(&PathRelative::new("./c")).as_str(), "a/b/c");
-		assert_eq!(base.resolve(&PathRelative::new("./../c")).as_str(), "a/c");
+		assert_eq!(base.resolve(&PathRelative::new(".")).as_str(), "a");
+		assert_eq!(base.resolve(&PathRelative::new("./c")).as_str(), "a/c");
+		assert_eq!(base.resolve(&PathRelative::new("./../c")).as_str(), "c");
 	}
 
 	#[test]
-	fn test_resolve_self_reference_via_dotdot() {
-		// Walking `..` back to the same path yields the base unchanged, which lets the
+	fn test_resolve_self_reference_via_sibling_name() {
+		// Naming the base within its parent yields the base unchanged, which lets the
 		// caller compare resolved == base to detect a self-reference.
 		let base = Path::new("a/b");
-		assert_eq!(base.resolve(&PathRelative::new("../b")).as_str(), "a/b");
+		assert_eq!(base.resolve(&PathRelative::new("./b")).as_str(), "a/b");
 	}
 }

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -171,11 +171,14 @@ impl EgressSource {
 			.audio
 			.renditions
 			.values()
-			.any(|r| matches!(r.codec, AudioCodec::Opus))
+			.any(|r| matches!(r.codec, AudioCodec::Opus) && valid_reference(&self.source, r.broadcast.as_ref()))
 		{
 			out.push(Codec::Opus);
 		}
 		for rendition in self.catalog.video.renditions.values() {
+			if !valid_reference(&self.source, rendition.broadcast.as_ref()) {
+				continue;
+			}
 			let codec = match rendition.codec.kind() {
 				VideoCodecKind::H264 => Some(Codec::H264),
 				VideoCodecKind::H265 => Some(Codec::H265),
@@ -194,6 +197,10 @@ impl EgressSource {
 	}
 }
 
+fn valid_reference(source: &moq_mux::Source, broadcast: Option<&moq_net::PathRelative<'_>>) -> bool {
+	source.resolve_reference(broadcast).is_some()
+}
+
 /// Find the first catalog rendition for the given codec and build a
 /// [`codec::Track`] subscribed to it, honoring an optional cross-broadcast
 /// reference (the rendition's catalog `broadcast` field). Returns `None` if no
@@ -201,9 +208,11 @@ impl EgressSource {
 async fn pick_track(source: &moq_mux::Source, catalog: &Catalog, codec: Codec) -> Result<Option<codec::Track>> {
 	match codec {
 		Codec::Opus => {
-			let Some((name, config)) = catalog.audio.renditions.iter().find(|(_, c)| {
-				matches!(c.codec, AudioCodec::Opus) && source.resolve_reference(c.broadcast.as_ref()).is_some()
-			}) else {
+			let Some((name, config)) =
+				catalog.audio.renditions.iter().find(|(_, c)| {
+					matches!(c.codec, AudioCodec::Opus) && valid_reference(source, c.broadcast.as_ref())
+				})
+			else {
 				return Ok(None);
 			};
 			let track = source.subscribe_track(config.broadcast.as_ref(), name).await?;
@@ -218,10 +227,11 @@ async fn pick_track(source: &moq_mux::Source, catalog: &Catalog, codec: Codec) -
 				Codec::Av1 => VideoCodecKind::AV1,
 				_ => unreachable!(),
 			};
-			let Some((name, config)) =
-				catalog.video.renditions.iter().find(|(_, c)| {
-					c.codec.kind() == target && source.resolve_reference(c.broadcast.as_ref()).is_some()
-				})
+			let Some((name, config)) = catalog
+				.video
+				.renditions
+				.iter()
+				.find(|(_, c)| c.codec.kind() == target && valid_reference(source, c.broadcast.as_ref()))
 			else {
 				return Ok(None);
 			};
@@ -294,6 +304,42 @@ pub fn dispatch(rtc: &mut str0m::Rtc, request: WriteRequest, wallclock: Instant)
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use hang::catalog::{AudioConfig, H264, VideoCodec, VideoConfig};
+	use moq_net::{Origin, PathRelative};
+
+	#[test]
+	fn catalog_codecs_ignores_codecs_available_only_via_escaping_references() {
+		let origin = Origin::random().produce();
+		let source = moq_mux::Source::new(origin.consume(), "a/pub");
+		let mut catalog = Catalog::default();
+
+		let mut escaped_audio = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		escaped_audio.broadcast = Some(PathRelative::new("../../source").to_owned());
+		catalog.audio.renditions.insert("opus".to_string(), escaped_audio);
+
+		let mut escaped_video = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0,
+			level: 0x1e,
+			inline: false,
+		});
+		escaped_video.broadcast = Some(PathRelative::new("../../source").to_owned());
+		catalog.video.renditions.insert("h264".to_string(), escaped_video);
+
+		let mut valid_video = VideoConfig::new(VideoCodec::VP8);
+		valid_video.broadcast = Some(PathRelative::new("./source").to_owned());
+		catalog.video.renditions.insert("vp8".to_string(), valid_video);
+
+		let (writes_tx, writes_rx) = mpsc::channel(1);
+		let egress = EgressSource {
+			source,
+			catalog,
+			writes_tx,
+			writes_rx: Some(writes_rx),
+		};
+
+		assert_eq!(egress.catalog_codecs(), vec![Codec::Vp8]);
+	}
 
 	#[test]
 	fn egress_clock_ignores_cross_track_dequeue_jitter() {

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -201,12 +201,9 @@ impl EgressSource {
 async fn pick_track(source: &moq_mux::Source, catalog: &Catalog, codec: Codec) -> Result<Option<codec::Track>> {
 	match codec {
 		Codec::Opus => {
-			let Some((name, config)) = catalog
-				.audio
-				.renditions
-				.iter()
-				.find(|(_, c)| matches!(c.codec, AudioCodec::Opus))
-			else {
+			let Some((name, config)) = catalog.audio.renditions.iter().find(|(_, c)| {
+				matches!(c.codec, AudioCodec::Opus) && source.resolve_reference(c.broadcast.as_ref()).is_some()
+			}) else {
 				return Ok(None);
 			};
 			let track = source.subscribe_track(config.broadcast.as_ref(), name).await?;
@@ -221,7 +218,11 @@ async fn pick_track(source: &moq_mux::Source, catalog: &Catalog, codec: Codec) -
 				Codec::Av1 => VideoCodecKind::AV1,
 				_ => unreachable!(),
 			};
-			let Some((name, config)) = catalog.video.renditions.iter().find(|(_, c)| c.codec.kind() == target) else {
+			let Some((name, config)) =
+				catalog.video.renditions.iter().find(|(_, c)| {
+					c.codec.kind() == target && source.resolve_reference(c.broadcast.as_ref()).is_some()
+				})
+			else {
 				return Ok(None);
 			};
 			let track = source.subscribe_track(config.broadcast.as_ref(), name).await?;

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -103,7 +103,7 @@ pub async fn accept(
 	let offer = sdp::parse_offer(offer)?;
 
 	// Resolve the broadcast on the subscribe origin by path. The `Source` fetches it (and any
-	// sibling broadcast a rendition's catalog `broadcast` field references, e.g. `../source`)
+	// sibling broadcast a rendition's catalog `broadcast` field references, e.g. `./source`)
 	// via `request_broadcast`, which resolves an announced broadcast immediately and falls back
 	// to a dynamic handler; with neither it errors and the WHEP client retries (typical).
 	let broadcast = broadcast.as_path().to_string();

--- a/rs/moq-transcode/README.md
+++ b/rs/moq-transcode/README.md
@@ -37,8 +37,8 @@ broadcast.
 ```rust
 let mut config = moq_transcode::Config::default();
 // The derivative is announced at `<source>/transcode.hang`, so the source
-// renditions are referenced one level up.
-config.source = Some(moq_net::PathRelativeOwned::from("..".to_string()));
+// renditions are referenced through its parent.
+config.source = Some(moq_net::PathRelativeOwned::from(".".to_string()));
 
 let output = origin.create_broadcast(
     format!("{path}/transcode.hang"),

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -6,9 +6,9 @@
 //     cargo run -p moq-transcode --example transcode -- \
 //         --url http://localhost:4443/anon --source my-broadcast
 //
-// The derivative appears at `<source>/transcode.hang`: its catalog references
-// the source renditions via a relative `broadcast: "."` pointer and adds the
-// ladder rungs, which are only encoded while someone watches (or fetches) them.
+// When the derivative is nested beneath the source, its catalog references the
+// source renditions relatively and adds the ladder rungs. An unrelated output
+// omits the passthrough renditions. Rungs are only encoded while watched or fetched.
 
 use anyhow::Context;
 use clap::Parser;
@@ -32,10 +32,12 @@ struct Args {
 async fn main() -> anyhow::Result<()> {
 	moq_native::Log::new(tracing::Level::INFO).init()?;
 	let args = Args::parse();
-	let output_path = args
-		.output
-		.clone()
-		.unwrap_or_else(|| format!("{}/transcode.hang", args.source));
+	let source_path = moq_net::PathOwned::from(args.source);
+	let output_path = moq_net::PathOwned::from(
+		args.output
+			.clone()
+			.unwrap_or_else(|| format!("{source_path}/transcode.hang")),
+	);
 
 	// Publish the derivative through one origin and consume the source through
 	// another, over a single auto-reconnecting session.
@@ -57,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
 	// otherwise leave us waiting for an announcement that can never arrive.
 	let consumer = remote.consume();
 	tokio::select! {
-		announced = consumer.announced_broadcast(&args.source) => {
+		announced = consumer.announced_broadcast(&source_path) => {
 			announced.context("origin closed before the source broadcast was announced")?;
 		}
 		closed = session.closed() => {
@@ -68,19 +70,19 @@ async fn main() -> anyhow::Result<()> {
 
 	// Resolve it for real; the session subscribes upstream on demand.
 	let source = consumer
-		.request_broadcast(&args.source)
+		.request_broadcast(&source_path)
 		.await
 		.context("source broadcast unavailable")?;
 
 	let mut config = moq_transcode::Config::default();
-	// The derivative lives one level below the source, so its parent is the source.
-	// The default ladder and encoder (hardware first: NVENC on Linux) apply.
-	config.source = Some(moq_net::PathRelativeOwned::from(".".to_string()));
+	// Reference the source when the normalized output is nested beneath it. The
+	// default ladder and encoder (hardware first: NVENC on Linux) apply.
+	config.source = moq_transcode::source_reference(&source_path, &output_path);
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))
 		.context("failed to create the derivative broadcast")?;
-	tracing::info!(source = %args.source, output = %output_path, "transcoding");
+	tracing::info!(source = %source_path, output = %output_path, "transcoding");
 
 	tokio::select! {
 		res = moq_transcode::run(source, output, config) => Ok(res?),

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -7,7 +7,7 @@
 //         --url http://localhost:4443/anon --source my-broadcast
 //
 // The derivative appears at `<source>/transcode.hang`: its catalog references
-// the source renditions via a relative `broadcast: ".."` pointer and adds the
+// the source renditions via a relative `broadcast: "."` pointer and adds the
 // ladder rungs, which are only encoded while someone watches (or fetches) them.
 
 use anyhow::Context;
@@ -73,9 +73,9 @@ async fn main() -> anyhow::Result<()> {
 		.context("source broadcast unavailable")?;
 
 	let mut config = moq_transcode::Config::default();
-	// The derivative lives one level below the source, so the source is `..`.
+	// The derivative lives one level below the source, so its parent is the source.
 	// The default ladder and encoder (hardware first: NVENC on Linux) apply.
-	config.source = Some(moq_net::PathRelativeOwned::from("..".to_string()));
+	config.source = Some(moq_net::PathRelativeOwned::from(".".to_string()));
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-transcode/src/catalog.rs
+++ b/rs/moq-transcode/src/catalog.rs
@@ -319,7 +319,7 @@ mod tests {
 		video.insert("low", source(640, 360, None)).unwrap();
 		video.insert("high", source(1920, 1080, None)).unwrap();
 		let mut remote = source(3840, 2160, None);
-		remote.broadcast = Some(PathRelativeOwned::from("../other".to_string()));
+		remote.broadcast = Some(PathRelativeOwned::from("./other".to_string()));
 		video.insert("remote", remote).unwrap();
 
 		let (name, config) = choose_source(&video).unwrap();

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -39,7 +39,7 @@ pub struct Config {
 	pub rungs: Vec<Rung>,
 
 	/// Where the source broadcast lives relative to the output broadcast, e.g.
-	/// `".."` when the output is published at `<source>/transcode.hang`. When
+	/// `"."` when the output is published at `<source>/transcode.hang`. When
 	/// set, the derivative catalog references the source renditions (all video
 	/// and audio) through this path so players fetch them from the source
 	/// directly; the transcoder never proxies or subscribes them. `None` omits

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -1,6 +1,27 @@
 //! Transcoder configuration: the rung ladder and catalog wiring.
 
-use moq_net::PathRelativeOwned;
+use moq_net::{AsPath, PathRelativeOwned};
+
+/// Compute the source broadcast reference for an output nested beneath it.
+///
+/// Both paths are normalized before comparison. Returns `None` when `output` is
+/// not a descendant of `source`, so callers can omit passthrough renditions.
+pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<PathRelativeOwned> {
+	let source = source.as_path();
+	let output = output.as_path();
+	let rest = output.strip_prefix(&source)?;
+	if rest.is_empty() {
+		return None;
+	}
+
+	let parents = rest.parts().count().saturating_sub(1);
+	let rel = if parents == 0 {
+		".".to_string()
+	} else {
+		vec![".."; parents].join("/")
+	};
+	Some(PathRelativeOwned::from(rel))
+}
 
 /// One candidate output rendition: a target resolution (by height) and bitrate.
 ///
@@ -77,5 +98,26 @@ impl Default for Config {
 			decoder: moq_video::decode::Kind::default(),
 			resize: moq_video::resize::Config::default(),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn source_reference_normalizes_and_counts_output_depth() {
+		assert_eq!(source_reference("a/b", "a/b/transcode.hang").unwrap().as_str(), ".");
+		assert_eq!(source_reference("/a//b/", "a/b/dir/").unwrap().as_str(), ".");
+		assert_eq!(
+			source_reference("a/b", "a/b/dir/transcode.hang").unwrap().as_str(),
+			".."
+		);
+		assert_eq!(
+			source_reference("a/b", "a/b/one/two/transcode.hang").unwrap().as_str(),
+			"../.."
+		);
+		assert!(source_reference("a/b", "other/transcode.hang").is_none());
+		assert!(source_reference("a/b", "a/b").is_none());
 	}
 }

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -505,7 +505,7 @@ mod tests {
 			rungs: vec![Rung::new(120, 100_000)],
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Software,
-			source: Some(moq_net::PathRelativeOwned::from("..".to_string())),
+			source: Some(moq_net::PathRelativeOwned::from(".".to_string())),
 			..Default::default()
 		};
 
@@ -542,7 +542,7 @@ mod tests {
 		assert!(rung.codec.to_string().starts_with("avc3."));
 
 		let passthrough = derived.video.renditions.get("video").expect("passthrough missing");
-		assert_eq!(passthrough.broadcast.as_ref().map(|b| b.as_ref()), Some(".."));
+		assert_eq!(passthrough.broadcast.as_ref().map(|b| b.as_ref()), Some("."));
 
 		// Subscribing to the rung starts the live loop, which mirrors source
 		// group sequences 1:1.

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -27,7 +27,7 @@ mod error;
 mod feed;
 mod rung;
 
-pub use config::{Config, Rung};
+pub use config::{Config, Rung, source_reference};
 pub use error::Error;
 
 /// Transcode `source` into `output` until the source broadcast ends.


### PR DESCRIPTION
## Summary

- Resolve non-empty broadcast references like relative URLs by replacing the catalog path's last segment before applying `.` and `..`.
- Preserve `.` as distinct from the empty self-reference, so `foo.hang/catalog.pro` plus `./transcode.pro` resolves to `foo.hang/transcode.pro`.
- Distinguish a valid resolution to the root broadcast from a reference that escapes above root.
- Ignore escaping catalog renditions before JavaScript support probing and ABR/audio selection, and before RTC SDP codec discovery.
- Ignore the same invalid references across Rust mux exporters and HLS.
- Normalize transcoder source and output paths before deriving catalog references, and share that derivation between the CLI and standalone example.
- Update Rust and JavaScript consumers, documentation, the Hang draft, package versions, and regression coverage.

The root cause was that both resolvers treated the catalog broadcast's full path as a directory, while relative-path normalization collapsed `.` into the empty self-reference. Consumer fallbacks also conflated three distinct results: the catalog itself, the valid root broadcast, and an above-root escape. Filtering only at subscription time left invalid renditions visible to earlier selection and SDP discovery. The transcode callers independently counted unnormalized path segments, so trailing slashes could produce the wrong reference.

## Public API changes

- Add `moq_net::Path::try_resolve` and JavaScript `Path.tryResolve` for checked relative resolution.
- Add `moq_mux::Source::resolve_reference` and `moq_mux::Error::InvalidBroadcastReference` so Rust callers can distinguish invalid references.
- Add `moq_transcode::source_reference` for deriving a normalized source reference from source and output broadcast paths.
- `moq_net::Path::resolve`, `PathRelative::new`, `Path.resolve`, and `Path.normalizeRelative` change behavior for existing relative inputs.
- Existing catalogs using `../sibling` for a sibling broadcast should use `./sibling` or `sibling`.
- `@moq/net`, `@moq/hang`, and `@moq/watch` receive minor version bumps for the semantic change.

The Rust and JavaScript Hang implementations, conceptual documentation, and normative Hang draft were updated together.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (2,561 Rust tests passed, 1 skipped; JavaScript suites passed, including 107 watch tests)
- `nix develop --command just drafts check`
- Focused `moq-mux`, `moq-hls`, `moq-rtc`, `js/net`, and `js/watch` regression suites
- `git diff --check origin/main...HEAD`

(Written by GPT-5)