### PR TITLE
fix(net): encode even-keyed message parameters as varints in draft-17+

### DIFF
--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -230,11 +230,16 @@ impl Parameters {
 
 /// Trait for encoding/decoding parameter values with version-specific formats.
 ///
-/// Parameter encoding differs from field encoding:
-/// - Draft-14/15/16: u8 and bool are encoded as varints (cast to u64)
-/// - Draft-17: type-specific encoding (u8 as raw byte, bool as raw byte, etc.)
+/// A message parameter is a Key-Value-Pair, so the *key* decides the value's framing: an even
+/// key carries a bare varint, an odd key a length-prefixed byte string. That framing is the
+/// same in every draft, which is why `u8`, `bool` and `u64` (all of which only ever sit at even
+/// keys) are varints unconditionally. What does change with the draft is how a varint is spelled
+/// (QUIC through draft-16, leading-ones from draft-17), and `Encode`/`Decode for u64` already
+/// dispatches on that.
 ///
-/// Use `_ =>` for the newest draft behavior so future versions default forward.
+/// The types at odd keys still need a version split, because what goes *inside* their length
+/// prefix is draft-specific. Use `_ =>` for the newest draft behavior there so future versions
+/// default forward.
 pub trait Param: Sized {
 	fn param_encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError>;
 	fn param_decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError>;
@@ -247,44 +252,25 @@ pub trait Param: Sized {
 
 impl Param for u8 {
 	fn param_encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		match version {
-			// Draft-14/15/16: u8 encoded as varint (cast to u64)
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => (*self as u64).encode(w, version),
-			_ => Encode::encode(self, w, version),
-		}
+		(*self as u64).encode(w, version)
 	}
 
 	fn param_decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		match version {
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
-				let v = u64::decode(r, version)?;
-				u8::try_from(v).map_err(|_| DecodeError::InvalidValue)
-			}
-			_ => u8::decode(r, version),
-		}
+		let v = u64::decode(r, version)?;
+		u8::try_from(v).map_err(|_| DecodeError::InvalidValue)
 	}
 }
 
 impl Param for bool {
 	fn param_encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		match version {
-			// Draft-14/15/16: bool encoded as varint (cast to u64)
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => (*self as u64).encode(w, version),
-			_ => Encode::encode(self, w, version),
-		}
+		(*self as u64).encode(w, version)
 	}
 
 	fn param_decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		match version {
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
-				let v = u64::decode(r, version)?;
-				match v {
-					0 => Ok(false),
-					1 => Ok(true),
-					_ => Err(DecodeError::InvalidValue),
-				}
-			}
-			_ => bool::decode(r, version),
+		match u64::decode(r, version)? {
+			0 => Ok(false),
+			1 => Ok(true),
+			_ => Err(DecodeError::InvalidValue),
 		}
 	}
 }
@@ -639,6 +625,53 @@ mod tests {
 					Ok(())
 				},
 			);
+		}
+	}
+
+	/// A `u8` parameter value is the key's varint, not a raw byte.
+	///
+	/// The two spellings coincide below 0x80, so a round-trip against ourselves passes at any
+	/// plausible test value and the disagreement only shows at the top of the range. It is
+	/// reachable: SUBSCRIBER_PRIORITY (0x20) carries `priority::to_wire(0)`, which is `u8::MAX`.
+	/// A raw `0xFF` is the 9-byte leading-ones prefix to a draft-17 decoder, so the peer reads
+	/// eight more bytes of whatever followed and then runs off the end of the message.
+	///
+	/// Byte-level, because a round-trip cannot catch a wire format both of our sides get wrong.
+	#[test]
+	fn test_param_u8_max_encodes_as_a_varint() {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+			Version::Draft19,
+		] {
+			round_trip_params(
+				version,
+				|w, v| {
+					encode_params!(w, v, 0x20 => u8::MAX);
+					Ok(())
+				},
+				|r, v| {
+					decode_params!(r, v, 0x20 => val: Option<u8>);
+					assert_eq!(val, Some(u8::MAX), "{v}");
+					Ok(())
+				},
+			);
+		}
+
+		// Draft-17+ spells a varint with leading ones, draft-14/15/16 the QUIC way. Neither is
+		// a bare 0xFF.
+		for (version, expected) in [
+			(Version::Draft15, [0x40, 0xFF].as_slice()),
+			(Version::Draft16, [0x40, 0xFF].as_slice()),
+			(Version::Draft17, [0x80, 0xFF].as_slice()),
+			(Version::Draft18, [0x80, 0xFF].as_slice()),
+		] {
+			let mut buf = BytesMut::new();
+			u8::MAX.param_encode(&mut buf, version).unwrap();
+			assert_eq!(&buf[..], expected, "{version}");
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Root cause**: `Param for u8` and `Param for bool` in `rs/moq-net/src/ietf/parameters.rs` encode message-parameter values as raw fixed bytes at draft-17+. The spec frames Key-Value-Pair values by the Type's parity — *"Value: A single varint encoded value when Type is even, otherwise a sequence of Length bytes"* (§1.4.3, identical wording in drafts 14, 17, and 19) — and every `u8`/`bool` parameter sits at an even Type (FORWARD `0x10`, SUBSCRIBER_PRIORITY `0x20`, GROUP ORDER `0x22`), so their values must be varints in every draft.
- **Observable failure**: the relay sends SUBSCRIBE upstream with `subscriber_priority = priority::to_wire(0) = 0xFF` as a raw byte. To a conforming varint decoder `0xFF` is an 8-byte leading-ones prefix, the message truncates, and the peer must close per §1.4.3's `KEY_VALUE_FORMATTING_ERROR` clause. `@moq/net` does exactly that (`js/net` enforces the parity rule structurally), so **every broadcast published by a JS/browser peer is unreadable through a Rust relay at draft-17+** — the relay's upstream catalog subscribe dies in ~40ms and every downstream subscriber is refused. Values ≤ `0x7F` coincide in both encodings, which is why most parameters appear to work.
- **Why it was never caught**: encoder and decoder were wrong together, so every Rust↔Rust round-trip passes. The new regression test asserts wire bytes, not a round-trip.
- **History**: draft-17 support originally classified these as varints (#1032). #1045 moved draft-17 to a raw-byte arm with a doc comment — *"Draft-17: type-specific encoding (u8 as raw byte…)"* — describing a rule that appears in no draft; drafts 18/19 then defaulted forward into it. The likely misreading is §10.2.7's *"The SUBSCRIBER_PRIORITY parameter (Parameter Type 0x20) is a uint8"*, which constrains the value's range, not its wire framing. This PR restores #1032's classification: the drafts 14–16 arm is promoted to unconditional (byte-identical for those versions; the per-draft varint spelling still dispatches inside `u64::encode`/`decode`), and only draft-17+ changes.

## Public API changes

None. Two `impl Param for {u8, bool}` bodies and the trait's doc comment; no `pub` item added, removed, renamed, or re-signatured in `rs/moq-net` or `js/*`.

## Cross-package sync

- `js/net`: no change needed — it already implements the parity rule (its `Parameters` API only accepts varints at even keys), which is the interop this PR restores.
- `drafts/`: untouched — the governing spec here is IETF `draft-ietf-moq-transport`, not a `draft-lcurley-*` document. No wire *design* changes, only conformance.

## Rollout note

A fixed Rust peer cannot parse an unfixed Rust peer's raw bytes above `0x7F` (and vice versa) at draft-17+, so mixed-version Rust fleets on the IETF path should upgrade together. Verified in a live relay+shim deployment: moving both sides together is clean; moving one side reproduces the original failure in the other direction.

## Test plan

- New `test_param_u8_max_encodes_as_a_varint`: asserts wire bytes per version (`[0x40, 0xFF]` at draft-15/16, `[0x80, 0xFF]` at draft-17/18) — fails without the fix; a round-trip test cannot catch a symmetric encoding bug, which is how this one survived.
- `cargo test -p moq-net --lib`: 766 passed; clippy clean (rebased on current `main`).
- Real interop: `MOQ_SERVER_VERSION=moq-transport-17 ./test/smoke/smoke.sh --publishers js --subscribers rust` — pre-fix the browser dies decoding the relay's SUBSCRIBE (`unexpected end of stream`); post-fix it replies SUBSCRIBE_OK and data flows. Rust and JS SUBSCRIBE encodings verified byte-identical post-fix.
- Deployed to a live two-relay cluster with browser publishers and Rust (`media-shim`) subscribers: previously-impossible browser-publish → relay → Rust-transform pipelines now run end to end.

## Related, deliberately not in this PR

`Param for Location` at draft-17+ writes bare varints at odd Type `0x09` with no length prefix, violating the same parity rule from the other side (`js/net` length-prefixes it). Currently latent — no Rust codepath here constructs one on the wire at 17+ — and a separate change. Happy to file it as an issue.

(Written by Claude Fable 5)
