### PR TITLE
fix(moq-net): serve an IETF subscribe from the live edge

### DIFF
--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -678,6 +678,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
 	async fn run_track(&self, mut track: track::Subscriber, request_id: RequestId) -> Result<(), Error> {
+		// A fresh cursor starts at the oldest cached group, so leaving it there replays the
+		// whole retained history at once, one concurrent stream per group. LargestObject is
+		// the only filter we accept and it means the live edge.
+		if let Some(latest) = track.latest() {
+			track.start_at(latest);
+		}
+
 		let mut tasks = FuturesUnordered::new();
 
 		loop {
@@ -1558,6 +1565,51 @@ mod group_priority_test {
 			vec![200],
 			"model priority must pass through unchanged"
 		);
+	}
+}
+
+#[cfg(test)]
+mod subscribe_cursor_test {
+	use super::*;
+	use crate::lite::test_transport::{Log, SinkSession};
+
+	/// A subscription's cursor starts at the oldest cached group, so serving it verbatim
+	/// replays every retained group at once, each on its own stream. Relays reject the burst
+	/// and players skip straight back to the live edge, so the catch-up is pure waste.
+	#[tokio::test]
+	async fn a_subscribe_is_served_from_the_live_edge() {
+		let log = Log::default();
+		let session = SinkSession::new(log.clone());
+
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let peer_setup = peer::PeerSetup::default();
+		peer_setup.set(peer::Peer::default());
+
+		let publisher = Publisher::new(
+			session,
+			origin.consume(),
+			Control::new(None, false),
+			None,
+			peer_setup,
+			Version::Draft16,
+		);
+
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "video", None);
+		for sequence in 0..4 {
+			let mut group = track.create_group(group::Info { sequence }).unwrap();
+			group
+				.write_frame(crate::Timestamp::from_millis(0).unwrap(), b"frame".as_slice())
+				.unwrap();
+			group.finish().unwrap();
+		}
+
+		let subscriber = track.subscribe(None);
+		track.finish().unwrap();
+
+		publisher.run_track(subscriber, RequestId(1)).await.unwrap();
+
+		// `run_group` sets the priority once per stream it opens, so this counts groups served.
+		assert_eq!(log.priorities().len(), 1, "only group 3 should have been served");
 	}
 }
 


### PR DESCRIPTION
### Summary

- A subscription's read cursor starts at the oldest cached group, not the live edge. `Subscription::group_start: None` is only the **wire preference**; the local cursor is separate state, as documented under "Local cursor vs wire preference" on `track::Subscriber`.
- The IETF publisher set the preference and never placed the cursor, so `run_track` drained the entire retained history on subscribe. Its unbounded `FuturesUnordered` then opened one concurrent uni stream per group, all in the same tick.
- Observed against a draft-16 relay: a viewer joining ~40s into a broadcast got every retained group served in a single millisecond. With the default 5s `latency_max` that is dozens of streams; relays reject the burst, and a player that does receive it skips the replayed groups straight back to live, so the catch-up is pure waste either way.
- `lite::publisher`'s `run_track` already does this (`start_group.or_else(|| track.latest())`). This brings the IETF path in line. `LargestObject` is the only filter the IETF publisher accepts, and it means the live edge, so no filter branching is needed yet.

### Public API changes

None.

`run_track` is private; `Subscriber::start_at` and `Subscriber::latest` are existing public API, now actually used by this caller.

 ### Test plan

- New `subscribe_cursor_test::a_subscribe_is_served_from_the_live_edge`: 4 cached groups, one served. Confirmed it fails with the fix reverted (`left: 4, right: 1`).
- `cargo test -p moq-net`: 766 passed, 0 failed, plus 7 doc-tests.
- `cargo clippy -p moq-net --all-targets -- -D warnings` and `cargo fmt --check`: clean.
- Cross-Package Sync: no row applies. This is publisher-side stream scheduling with no wire-format, catalog, or binding surface change.


Co-Authored-By: Claude Opus 5