### PR TITLE
feat(hang): signal stalled video renditions

### DIFF
--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -75,6 +75,9 @@ For example, it's not possible to have a different `flip` or `rotation` value fo
 Each rendition is an extension of [VideoDecoderConfig](https://www.w3.org/TR/webcodecs/#video-decoder-config).
 This is the minimum amount of information required to initialize a video decoder.
 
+A publisher can set a rendition's optional `stalled` field to recommend temporarily avoiding it without removing or closing the track.
+Players prefer decoder-supported unstalled renditions and can fall back to a stalled rendition when none remain.
+
 ### Cross-broadcast renditions
 
 A rendition may set an optional `broadcast` field: a path relative to the broadcast that served the catalog (e.g. `"./source"`), pointing at another broadcast that publishes the actual track.

--- a/doc/concept/standard/msf.md
+++ b/doc/concept/standard/msf.md
@@ -17,4 +17,7 @@ moved init data out of the track into a root `initDataList` referenced by `initR
 Our implementation hides this on the wire: the catalog API is a version-agnostic snapshot, draft-00
 catalogs still decode, and init data is always presented inline regardless of how it was carried.
 
+Our implementation also carries an optional `stalled` boolean on video tracks as a non-standard extension shared with the hang catalog.
+It recommends temporarily avoiding a track without making that track unavailable.
+
 [See the draft](https://www.ietf.org/archive/id/draft-ietf-moq-msf-01.html) for the latest details.

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -225,6 +225,17 @@ if (moq_consume_video_properties(catalog, &snapshot) < 0) {
 }
 ```
 
+## Stalled video renditions
+
+`moq_consume_video_stalled` reports whether the publisher recommends temporarily avoiding a rendition. The track remains directly usable, and catalogs that omit the hint report false. Pass the same catalog snapshot and rendition index used by `moq_consume_video_config`:
+
+```c
+bool stalled;
+if (moq_consume_video_stalled(catalog, index, &stalled) < 0) {
+    fprintf(stderr, "video stalled state failed: %s\n", moq_error());
+}
+```
+
 ## Raw media
 
 The `moq_publish_media_*` and `moq_consume_video` / `moq_consume_audio` calls carry already-encoded frames, for a caller that brings its own codec. The `_raw` calls carry uncompressed media instead and run the codec inside libmoq, so a C application can publish pixels and PCM without linking one.

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -163,6 +163,8 @@ media, err := broadcast.PublishMedia("avc3", nil, moq.WithVideoHint(moq.VideoHin
 }))
 ```
 
+Each catalog `Video` has a `Stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
+
 Properties that apply to every video rendition are updated together. Nil fields clear the corresponding catalog property, and rotation is normalized to the nearest clockwise quarter turn:
 
 ```go

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -120,6 +120,8 @@ Moq.connect("https://relay.example.com").use { moq ->
 }
 ```
 
+Each catalog `Video` has a `stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
+
 Properties that apply to every video rendition are updated together. `null` fields clear the corresponding catalog property, and rotation is normalized to the nearest clockwise quarter turn:
 
 ```kotlin

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -125,6 +125,8 @@ video = broadcast.publish_media(
 
 A value the stream later detects fills only a gap the hint left, so a detected value always wins. Audio formats resolve entirely from their init bytes, so they take no hint.
 
+Each catalog `Video` has a `stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
+
 Properties that apply to every video rendition are updated together. Omitted fields clear the corresponding catalog property, and rotation is normalized to the nearest clockwise quarter turn:
 
 ```python

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -127,6 +127,8 @@ try broadcast.finish()
 
 Video publishers can pass `video: VideoHint(...)` to seed catalog fields before the stream reveals them. Use `publishMedia(on:format:initData:video:)` to accept a media track obtained from `BroadcastDynamic`.
 
+Each catalog `Video` has a `stalled` boolean. A true value recommends temporarily avoiding that rendition, but the track remains directly usable. Existing catalogs default it to false.
+
 Properties that apply to every video rendition are updated together. `nil` fields clear the corresponding catalog property, and rotation is normalized to the nearest clockwise quarter turn:
 
 ```swift

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -152,12 +152,18 @@ In addition to the WebCodecs fields, each rendition MAY carry the fields common 
 type VideoDecoderConfigExtensions = {
   "displayAspectWidth": number | undefined,
   "displayAspectHeight": number | undefined,
+  "stalled": boolean | undefined,
 }
 ~~~
 
 `displayAspectWidth` and `displayAspectHeight` give the display aspect ratio of the media, stretching or shrinking the coded pixels.
 A consumer that understands neither field MUST assume square pixels, a 1:1 ratio.
 Both MUST be present together; a consumer that sees only one MUST ignore it.
+
+`stalled` indicates that the publisher recommends temporarily avoiding the rendition.
+The track remains available when `stalled` is true.
+A consumer SHOULD select an unstalled rendition when it supports one, but MAY select a stalled rendition when no unstalled rendition is suitable.
+If absent, `stalled` defaults to false.
 
 For example:
 
@@ -170,6 +176,7 @@ For example:
       "codedWidth": 1280,
       "codedHeight": 720,
       "bitrate": 6000000,
+      "stalled": true,
       "framerate": 30.0,
       "jitter": 33
     },

--- a/go/wrapper/moq/types.go
+++ b/go/wrapper/moq/types.go
@@ -42,7 +42,7 @@ type (
 	Subscription = ffi.MoqSubscription
 	// TrackInfo holds publisher-side track properties: priority, ordering, latency budget, and timescale.
 	TrackInfo = ffi.MoqTrackInfo
-	// Video describes one video rendition in a broadcast catalog: codec, dimensions, bitrate, framerate, and container.
+	// Video describes one catalog rendition, including whether the publisher recommends temporarily avoiding it.
 	Video = ffi.MoqVideo
 	// VideoHint supplies catalog fields a video stream can't reveal itself, such as bitrate, filling only the gaps.
 	VideoHint = ffi.MoqVideoHint

--- a/js/hang/src/catalog/video.test.ts
+++ b/js/hang/src/catalog/video.test.ts
@@ -15,6 +15,17 @@ test("video config accepts canonical display aspect fields", () => {
 	expect("displayRatioHeight" in parsed).toBe(false);
 });
 
+test("video config accepts optional stalled state", () => {
+	const active = VideoConfigSchema.parse({
+		codec: "avc1.64001f",
+		container: { kind: "legacy" },
+	});
+	const stalled = VideoConfigSchema.parse({ ...active, stalled: true });
+
+	expect(active.stalled).toBeUndefined();
+	expect(stalled.stalled).toBe(true);
+});
+
 test("legacy video arrays derive display size from display aspect fields", () => {
 	const parsed = VideoSchema.parse([
 		{

--- a/js/hang/src/catalog/video.ts
+++ b/js/hang/src/catalog/video.ts
@@ -46,6 +46,10 @@ export const VideoConfigSchema = z.object({
 	// TODO: Support up to Number.MAX_SAFE_INTEGER
 	bitrate: z.optional(u53Schema),
 
+	// Whether the publisher recommends temporarily avoiding this rendition.
+	// The track remains available and may still be selected as a fallback.
+	stalled: z.optional(z.boolean()),
+
 	// If true, the decoder will optimize for latency.
 	// Default: true
 	optimizeForLatency: z.optional(z.boolean()),

--- a/js/msf/src/catalog.test.ts
+++ b/js/msf/src/catalog.test.ts
@@ -184,3 +184,24 @@ test("preserves SAP fields through decode and encode", () => {
 	expect(wireTracks[0].maxObjSapStartingType).toBe(2);
 	expect(wireTracks[0].jitter).toBe(15);
 });
+
+test.each([
+	["omitted", undefined],
+	["false", false],
+	["true", true],
+] as const)("preserves %s stalled state through decode and encode", (_name, stalled) => {
+	const track = {
+		name: "video0",
+		packaging: "loc",
+		isLive: true,
+		role: "video",
+		codec: "av01.0.08M.10.0.110.09",
+		...(stalled === undefined ? {} : { stalled }),
+	};
+	const catalog = decode(encodeJson({ version: "draft-01", tracks: [track] }));
+
+	expect(catalog.tracks[0].stalled).toBe(stalled);
+	const wire = decodeJson(encode(catalog));
+	const tracks = wire.tracks as { stalled?: boolean }[];
+	expect(tracks[0].stalled).toBe(stalled);
+});

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -35,6 +35,8 @@ const trackShape = {
 	samplerate: z.optional(z.number()),
 	channelConfig: z.optional(z.string()),
 	bitrate: z.optional(z.number()),
+	// Non-standard: whether the publisher recommends temporarily avoiding this track.
+	stalled: z.optional(z.boolean()),
 	/** Resolved base64 initialization data (draft-01's initRef indirection is resolved away). */
 	initData: z.optional(z.string()),
 	renderGroup: z.optional(z.number()),

--- a/js/watch/src/msf.test.ts
+++ b/js/watch/src/msf.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import type * as Msf from "@moq/msf";
+import { toHang } from "./msf";
+
+test("preserves stalled video renditions", () => {
+	const catalog: Msf.Catalog = {
+		tracks: [
+			{
+				name: "video",
+				packaging: "loc",
+				role: "video",
+				codec: "vp09.00.10.08",
+				stalled: true,
+			},
+		],
+	};
+
+	expect(toHang(catalog).video?.renditions.video?.stalled).toBe(true);
+});

--- a/js/watch/src/msf.ts
+++ b/js/watch/src/msf.ts
@@ -52,6 +52,7 @@ function toVideoConfig(track: Msf.Track): Catalog.VideoConfig | undefined {
 		codedHeight: track.height != null ? u53(track.height) : undefined,
 		framerate: track.framerate,
 		bitrate: track.bitrate != null ? u53(track.bitrate) : undefined,
+		stalled: track.stalled,
 		jitter: track.jitter != null ? u53(track.jitter) : undefined,
 	};
 }

--- a/js/watch/src/video/config.test.ts
+++ b/js/watch/src/video/config.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import * as Catalog from "@moq/hang/catalog";
+import { Effect, Signal } from "@moq/signals";
+import { playbackIdentity } from "./config";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function config(fields: Record<string, unknown> = {}): Catalog.VideoConfig {
+	return Catalog.VideoConfigSchema.parse({
+		codec: "avc1.64001f",
+		container: { kind: "legacy" },
+		description: "0142002a",
+		optimizeForLatency: true,
+		...fields,
+	});
+}
+
+test("metadata changes do not change the playback identity", async () => {
+	const rendition = new Signal<Catalog.VideoConfig>(config());
+	const root = new Effect();
+	const identity = root.computed((effect) => playbackIdentity(effect.get(rendition)));
+	let runs = 0;
+
+	root.run((effect) => {
+		effect.get(identity);
+		runs++;
+	});
+	await flush();
+	expect(runs).toBe(1);
+
+	rendition.set(
+		config({
+			bitrate: 2_000_000,
+			stalled: true,
+			codedWidth: 1280,
+			codedHeight: 720,
+			framerate: 30,
+			jitter: 33,
+		}),
+	);
+	await flush();
+	expect(runs).toBe(1);
+
+	rendition.set(config({ codec: "avc1.640028" }));
+	await flush();
+	expect(runs).toBe(2);
+
+	root.close();
+});
+
+test("routing and decoder inputs change the playback identity", () => {
+	const base = playbackIdentity(config());
+
+	expect(playbackIdentity(config({ broadcast: "../source" }))).not.toEqual(base);
+	expect(playbackIdentity(config({ description: "0164001f" }))).not.toEqual(base);
+	expect(playbackIdentity(config({ container: { kind: "loc" } }))).not.toEqual(base);
+	expect(playbackIdentity(config({ displayAspectWidth: 16, displayAspectHeight: 9 }))).not.toEqual(base);
+	expect(playbackIdentity(config({ optimizeForLatency: false }))).not.toEqual(base);
+});

--- a/js/watch/src/video/config.ts
+++ b/js/watch/src/video/config.ts
@@ -1,0 +1,38 @@
+import type * as Catalog from "@moq/hang/catalog";
+
+/** Internal key used to describe which fields can change a support probe's result. */
+export const supportCacheKey = Symbol("supportCacheKey");
+
+/** The catalog fields that determine the demuxer and WebCodecs decoder instance. */
+export type DecoderConfig = Pick<
+	Catalog.VideoConfig,
+	"codec" | "container" | "description" | "displayAspectWidth" | "displayAspectHeight"
+> & {
+	optimizeForLatency: boolean;
+};
+
+/** The routing and decoder state whose changes require a new playback pipeline. */
+export type PlaybackIdentity = {
+	broadcast: Catalog.VideoConfig["broadcast"];
+	decoder: DecoderConfig;
+};
+
+/** Reduce a rendition config to the fields that require a new playback pipeline. */
+export function playbackIdentity(config: Catalog.VideoConfig): PlaybackIdentity {
+	return {
+		broadcast: config.broadcast,
+		decoder: {
+			codec: config.codec,
+			container: config.container,
+			description: config.description,
+			displayAspectWidth: config.displayAspectWidth,
+			displayAspectHeight: config.displayAspectHeight,
+			optimizeForLatency: config.optimizeForLatency ?? true,
+		},
+	};
+}
+
+/** Return a stable cache key for the fields used by the WebCodecs support probe. */
+export function decoderConfigKey(config: Catalog.VideoConfig): string {
+	return JSON.stringify(playbackIdentity(config).decoder);
+}

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -3,10 +3,26 @@ import * as Container from "@moq/hang/container";
 import * as Util from "@moq/hang/util";
 import type * as Moq from "@moq/net";
 import { Time } from "@moq/net";
-import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
+import {
+	type Computed,
+	Effect,
+	type Getter,
+	getter,
+	type Inputs,
+	type Readonlys,
+	readonlys,
+	Signal,
+} from "@moq/signals";
 import { base64ToBytes } from "../base64";
 
 import type { Sync } from "../sync";
+import {
+	type DecoderConfig,
+	decoderConfigKey,
+	type PlaybackIdentity,
+	playbackIdentity,
+	supportCacheKey,
+} from "./config";
 import { caughtUp } from "./playhead";
 import { rotateVideoDimensions } from "./presentation";
 import type { Source } from "./source";
@@ -45,11 +61,6 @@ type DecoderOutput = {
 	buffered: Signal<Container.BufferedRanges>;
 };
 
-// The types in VideoDecoderConfig that cause a hard reload.
-// ex. codedWidth/Height are optional and can be changed in-band, so we don't want to trigger a reload.
-// This way we can keep the current subscription active.
-type RequiredDecoderConfig = Omit<Catalog.VideoConfig, "codedWidth" | "codedHeight">;
-
 /** Downloads video from a track and decodes it into {@link VideoFrame}s with WebCodecs. */
 export class Decoder {
 	readonly in: Readonlys<DecoderInput>;
@@ -68,6 +79,7 @@ export class Decoder {
 
 	// The current track running, held so we can cancel it when the new track is ready.
 	#active = new Signal<DecoderTrack | undefined>(undefined);
+	readonly #identity: Computed<PlaybackIdentity | undefined>;
 
 	#signals = new Effect();
 
@@ -86,6 +98,10 @@ export class Decoder {
 
 		this.source = source;
 		this.sync = sync;
+		this.#identity = this.#signals.computed((effect) => {
+			const config = effect.get(this.source.out.config);
+			return config ? playbackIdentity(config) : undefined;
+		});
 
 		this.#signals.run(this.#runPending.bind(this));
 		this.#signals.run(this.#runActive.bind(this));
@@ -98,7 +114,7 @@ export class Decoder {
 			this.in.enabled,
 			this.source.in.broadcast,
 			this.source.out.track,
-			this.source.out.config,
+			this.#identity,
 		]);
 		if (!values) {
 			// Close the active track when disabled (e.g. paused or not visible).
@@ -106,11 +122,11 @@ export class Decoder {
 			this.#active.set(undefined);
 			return;
 		}
-		const [_, broadcast, track, config] = values;
+		const [_, broadcast, track, identity] = values;
 
 		// Honor a per-rendition `broadcast` override: subscribe on the resolved source
 		// broadcast instead of the catalog's own broadcast.
-		const active: Moq.Broadcast.Consumer | undefined = broadcast.relativeBroadcast(effect, config.broadcast);
+		const active: Moq.Broadcast.Consumer | undefined = broadcast.relativeBroadcast(effect, identity.broadcast);
 		if (!active) {
 			// Going offline should clear the last rendered frame.
 			this.#active.set(undefined);
@@ -124,7 +140,7 @@ export class Decoder {
 			sync: this.sync,
 			broadcast: active,
 			track,
-			config,
+			config: identity.decoder,
 			stats: this.#out.stats,
 		});
 
@@ -226,7 +242,7 @@ interface DecoderTrackProps {
 	sync: Sync;
 	broadcast: Moq.Broadcast.Consumer;
 	track: string;
-	config: Catalog.VideoConfig;
+	config: DecoderConfig;
 
 	stats: Signal<Stats | undefined>;
 }
@@ -235,7 +251,7 @@ class DecoderTrack {
 	sync: Sync;
 	broadcast: Moq.Broadcast.Consumer;
 	track: string;
-	config: RequiredDecoderConfig;
+	config: DecoderConfig;
 	stats: Signal<Stats | undefined>;
 
 	timestamp = new Signal<Time.Milli | undefined>(undefined);
@@ -254,13 +270,10 @@ class DecoderTrack {
 	#signals = new Effect();
 
 	constructor(props: DecoderTrackProps) {
-		// Remove the codedWidth/Height from the config to avoid a hard reload if nothing else has changed.
-		const { codedWidth: _, codedHeight: __, ...requiredConfig } = props.config;
-
 		this.sync = props.sync;
 		this.broadcast = props.broadcast;
 		this.track = props.track;
-		this.config = requiredConfig;
+		this.config = props.config;
 		this.stats = props.stats;
 
 		this.#signals.run(this.#run.bind(this));
@@ -348,9 +361,11 @@ class DecoderTrack {
 		});
 
 		decoder.configure({
-			...this.config,
+			codec: this.config.codec,
 			description: this.config.description ? Util.Hex.toBytes(this.config.description) : undefined,
-			optimizeForLatency: this.config.optimizeForLatency ?? true,
+			displayAspectWidth: this.config.displayAspectWidth,
+			displayAspectHeight: this.config.displayAspectHeight,
+			optimizeForLatency: this.config.optimizeForLatency,
 			// @ts-expect-error Only supported by Chrome, so the renderer has to flip manually.
 			flip: false,
 		});
@@ -425,7 +440,9 @@ class DecoderTrack {
 		decoder.configure({
 			codec: this.config.codec,
 			description,
-			optimizeForLatency: this.config.optimizeForLatency ?? true,
+			displayAspectWidth: this.config.displayAspectWidth,
+			displayAspectHeight: this.config.displayAspectHeight,
+			optimizeForLatency: this.config.optimizeForLatency,
 			// @ts-expect-error Only supported by Chrome, so the renderer has to flip manually.
 			flip: false,
 		});
@@ -557,6 +574,8 @@ async function supported(config: Catalog.VideoConfig): Promise<boolean> {
 	const { supported } = await VideoDecoder.isConfigSupported({
 		codec: config.codec,
 		description,
+		displayAspectWidth: config.displayAspectWidth,
+		displayAspectHeight: config.displayAspectHeight,
 		optimizeForLatency: config.optimizeForLatency ?? true,
 	});
 
@@ -570,6 +589,8 @@ async function supported(config: Catalog.VideoConfig): Promise<boolean> {
 		const retry = await VideoDecoder.isConfigSupported({
 			codec: avc1,
 			description,
+			displayAspectWidth: config.displayAspectWidth,
+			displayAspectHeight: config.displayAspectHeight,
 			optimizeForLatency: config.optimizeForLatency ?? true,
 		});
 		if (retry.supported) {
@@ -580,3 +601,5 @@ async function supported(config: Catalog.VideoConfig): Promise<boolean> {
 
 	return false;
 }
+
+Object.assign(supported, { [supportCacheKey]: decoderConfigKey });

--- a/js/watch/src/video/source.test.ts
+++ b/js/watch/src/video/source.test.ts
@@ -3,6 +3,7 @@ import * as Catalog from "@moq/hang/catalog";
 import { Path } from "@moq/net";
 import { Signal } from "@moq/signals";
 import { Broadcast } from "../broadcast";
+import { decoderConfigKey, supportCacheKey } from "./config";
 import { Source } from "./source";
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -11,8 +12,8 @@ async function settle(): Promise<void> {
 	for (let i = 0; i < 5; i++) await flush();
 }
 
-function config(codec: string): Catalog.VideoConfig {
-	return { codec, container: { kind: "legacy" } };
+function config(codec: string, fields: Record<string, unknown> = {}): Catalog.VideoConfig {
+	return Catalog.VideoConfigSchema.parse({ codec, container: { kind: "legacy" }, ...fields });
 }
 
 function mockBroadcast(renditions: Record<string, Catalog.VideoConfig>): Broadcast {
@@ -24,6 +25,20 @@ function mockBroadcast(renditions: Record<string, Catalog.VideoConfig>): Broadca
 			catalog: new Signal({ video: { renditions } }),
 		},
 	} as unknown as Broadcast;
+}
+
+function mutableBroadcast(renditions: Record<string, Catalog.VideoConfig>): {
+	broadcast: Broadcast;
+	catalog: Signal<Catalog.Root>;
+} {
+	const catalog = new Signal<Catalog.Root>({ video: { renditions } });
+	return {
+		broadcast: {
+			in: { connection: new Signal(undefined) },
+			out: { catalog },
+		} as unknown as Broadcast,
+		catalog,
+	};
 }
 
 async function withoutWarnings(fn: () => Promise<void>): Promise<void> {
@@ -147,4 +162,112 @@ describe("Source error signal", () => {
 		source.close();
 		broadcast.close();
 	});
+});
+
+describe("Source stalled rendition selection", () => {
+	it("skips a stalled manual target while an unstalled rendition exists", async () => {
+		const source = new Source({
+			broadcast: mockBroadcast({
+				low: config("avc1.64001e", { bitrate: 1_000_000 }),
+				high: config("avc1.640028", { bitrate: 2_000_000, stalled: true }),
+			}),
+			target: { name: "high" },
+			supported: async () => true,
+		});
+
+		await settle();
+		expect(source.out.track.peek()).toBe("low");
+		expect(Object.keys(source.out.available.peek())).toEqual(["low", "high"]);
+		source.close();
+	});
+
+	it("selects the lowest rendition when every supported rendition is stalled", async () => {
+		const source = new Source({
+			broadcast: mockBroadcast({
+				high: config("avc1.640028", { bitrate: 2_000_000, stalled: true }),
+				low: config("avc1.64001e", { bitrate: 1_000_000, stalled: true }),
+			}),
+			supported: async () => true,
+		});
+
+		await settle();
+		expect(source.out.track.peek()).toBe("low");
+		source.close();
+	});
+
+	it("uses coded dimensions when stalled renditions omit bitrate", async () => {
+		const source = new Source({
+			broadcast: mockBroadcast({
+				high: config("avc1.640028", { codedWidth: 1920, codedHeight: 1080, stalled: true }),
+				low: config("avc1.64001e", { codedWidth: 854, codedHeight: 480, stalled: true }),
+			}),
+			supported: async () => true,
+		});
+
+		await settle();
+		expect(source.out.track.peek()).toBe("low");
+		source.close();
+	});
+
+	it("does not repeat support probes for metadata-only changes", async () => {
+		const state = mutableBroadcast({ high: config("avc1.640028", { bitrate: 2_000_000 }) });
+		let probes = 0;
+		const supported = async () => {
+			probes++;
+			return true;
+		};
+		Object.assign(supported, { [supportCacheKey]: decoderConfigKey });
+		const source = new Source({
+			broadcast: state.broadcast,
+			supported,
+		});
+
+		await settle();
+		expect(probes).toBe(1);
+
+		state.catalog.set({
+			video: {
+				renditions: {
+					high: config("avc1.640028", {
+						bitrate: 1_500_000,
+						stalled: true,
+						codedWidth: 1280,
+						codedHeight: 720,
+					}),
+				},
+			},
+		});
+		await settle();
+
+		expect(probes).toBe(1);
+		expect(Number(source.out.config.peek()?.bitrate)).toBe(1_500_000);
+		expect(source.out.config.peek()?.stalled).toBe(true);
+		source.close();
+	});
+
+	it("repeats custom support probes when metadata changes", async () =>
+		withoutWarnings(async () => {
+			const state = mutableBroadcast({ high: config("avc1.640028", { codedWidth: 1280 }) });
+			let probes = 0;
+			const source = new Source({
+				broadcast: state.broadcast,
+				supported: async (rendition) => {
+					probes++;
+					return (rendition.codedWidth ?? 0) <= 1920;
+				},
+			});
+
+			await settle();
+			expect(probes).toBe(1);
+			expect(Object.keys(source.out.available.peek())).toEqual(["high"]);
+
+			state.catalog.set({
+				video: { renditions: { high: config("avc1.640028", { codedWidth: 3840 }) } },
+			});
+			await settle();
+
+			expect(probes).toBe(2);
+			expect(source.out.available.peek()).toEqual({});
+			source.close();
+		}));
 });

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -2,6 +2,7 @@ import type * as Catalog from "@moq/hang/catalog";
 import type * as Moq from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
 import type { Broadcast } from "../broadcast";
+import { supportCacheKey } from "./config";
 import { renditionJitter } from "./playhead";
 
 /**
@@ -10,6 +11,10 @@ import { renditionJitter } from "./playhead";
  * `Decoder.supported` is the WebCodecs probe used by `<moq-watch>`.
  */
 export type Supported = (config: Catalog.VideoConfig) => Promise<boolean>;
+
+type CacheableSupported = Supported & {
+	[supportCacheKey]?: (config: Catalog.VideoConfig) => string;
+};
 
 /** A video source error that prevents choosing a usable rendition. */
 export type SourceError = "unsupported";
@@ -96,7 +101,7 @@ function byPixels(target: number): RenditionFilter {
 			return [rest[0].name];
 		}
 
-		// No entries had resolution metadata — return all names unranked.
+		// No entries had resolution metadata, so return all names unranked.
 		return entries.map(([name]) => name);
 	};
 }
@@ -137,7 +142,7 @@ function byDimensions(width?: number, height?: number): RenditionFilter {
 			return [rest[0].name];
 		}
 
-		// No entries had resolution metadata — return all names unranked.
+		// No entries had resolution metadata, so return all names unranked.
 		return entries.map(([name]) => name);
 	};
 }
@@ -174,7 +179,7 @@ function byBitrate(target: number): RenditionFilter {
 			return [rest[0].name];
 		}
 
-		// No entries had bitrate metadata — return all names unranked.
+		// No entries had bitrate metadata, so return all names unranked.
 		return entries.map(([name]) => name);
 	};
 }
@@ -207,6 +212,18 @@ function bestRendition(entries: [string, Catalog.VideoConfig][]): string {
 	return best[0];
 }
 
+/** Return unstalled renditions, or the lowest bitrate or resolution when every option is stalled. */
+function selectableRenditions(renditions: Record<string, Catalog.VideoConfig>): Record<string, Catalog.VideoConfig> {
+	const active = Object.entries(renditions).filter(([, config]) => !config.stalled);
+	if (active.length > 0) return Object.fromEntries(active);
+
+	const entries = Object.entries(renditions);
+	if (entries.length === 0) return {};
+	const byRate = byBitrate(0)(entries);
+	const lowest = byRate.length === 1 ? byRate[0] : byDimensions(0, 0)(entries)[0];
+	return { [lowest]: renditions[lowest] };
+}
+
 /**
  * Source handles catalog extraction, support checking, and rendition selection
  * for video playback. The Decoder consumes whichever rendition it picks.
@@ -225,6 +242,7 @@ export class Source {
 	readonly out = readonlys(this.#out);
 
 	#signals = new Effect();
+	#supportCache = new WeakMap<Supported, Map<string, { key: string; supported: boolean }>>();
 
 	constructor(props?: Inputs<SourceInput>) {
 		this.in = {
@@ -257,6 +275,15 @@ export class Source {
 
 		const renditions = effect.get(this.#out.catalog)?.renditions ?? {};
 		this.#out.error.set(undefined);
+		let cache = this.#supportCache.get(supported);
+		if (!cache) {
+			cache = new Map();
+			this.#supportCache.set(supported, cache);
+		}
+		const names = new Set(Object.keys(renditions));
+		for (const name of cache.keys()) {
+			if (!names.has(name)) cache.delete(name);
+		}
 
 		effect.spawn(async () => {
 			const available: Record<string, Catalog.VideoConfig> = {};
@@ -267,14 +294,29 @@ export class Source {
 			const cancelled = effect.cancel.then(() => undefined);
 
 			for (const [name, config] of Object.entries(renditions)) {
+				const cacheKey = (supported as CacheableSupported)[supportCacheKey];
+				const key = cacheKey ? cacheKey(config) : JSON.stringify(config);
+				const cached = cache.get(name);
 				let isSupported: boolean | undefined = false;
-				try {
-					isSupported = await Promise.race([supported(config), cancelled]);
-				} catch (err) {
-					console.warn(
-						`[Source] video rendition ${name} (${config.codec}) support probe failed; treating as unsupported`,
-						err,
-					);
+				if (cached?.key === key) {
+					isSupported = cached.supported;
+				} else {
+					let failed = false;
+					try {
+						isSupported = await Promise.race([supported(config), cancelled]);
+					} catch (err) {
+						failed = true;
+						console.warn(
+							`[Source] video rendition ${name} (${config.codec}) support probe failed; treating as unsupported`,
+							err,
+						);
+					}
+					if (!failed && isSupported !== undefined) {
+						cache.set(name, {
+							key: cacheKey ? cacheKey(config) : JSON.stringify(config),
+							supported: isSupported,
+						});
+					}
 				}
 
 				// Torn down: stop probing and publish nothing, since the rerun redoes this.
@@ -295,12 +337,12 @@ export class Source {
 	}
 
 	#runSelected(effect: Effect): void {
-		const available = effect.get(this.#out.available);
+		const available = selectableRenditions(effect.get(this.#out.available));
 		if (Object.keys(available).length === 0) return;
 
 		const target = effect.get(this.in.target);
 
-		// Manual selection by name — skip all ABR logic.
+		// Manual selection by name skips all ABR logic.
 		if (target?.name && target.name in available) {
 			const config = available[target.name];
 			effect.set(this.#out.track, target.name);
@@ -357,7 +399,7 @@ export class Source {
 			filters.push(byBitrate(target.bitrate));
 		}
 
-		// No filters — pick the best rendition by quality.
+		// With no filters, pick the best rendition by quality.
 		if (filters.length === 0) {
 			return bestRendition(entries);
 		}

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -93,7 +93,7 @@ typealias Datagram = uniffi.moq.MoqDatagram
 typealias Frame = uniffi.moq.MoqFrame
 /** A [Frame] plus the codec metadata a media track carries. */
 typealias MediaFrame = uniffi.moq.MoqMediaFrame
-/** The catalog description of a video track: codec, dimensions, bitrate, and container. */
+/** The catalog description of a video track, including whether the publisher recommends temporarily avoiding it. */
 typealias Video = uniffi.moq.MoqVideo
 /** Caller-provided catalog fields for a video track. */
 typealias VideoHint = uniffi.moq.MoqVideoHint

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -197,7 +197,7 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 - **`MediaFrame`**. `.payload: bytes`, `.timestamp_us: int`, `.keyframe: bool`. Returned by media subscriptions.
 - **`Datagram`**. `.sequence: int`, `.timestamp_us: int`, `.payload: bytes`. Delivered only on datagram-capable transports and lite-05 or newer moq-lite.
 - **`Audio`**. `.codec`, `.sample_rate`, `.channel_count`, `.bitrate`, `.description`.
-- **`Video`**. `.codec`, `.coded: Dimensions`, `.display_aspect`, `.bitrate`, `.framerate`, `.description`.
+- **`Video`**. `.codec`, `.coded: Dimensions`, `.display_aspect`, `.bitrate`, `.stalled`, `.framerate`, `.description`. A true `.stalled` recommends temporarily avoiding the rendition without making it unavailable.
 - **`Subscription`**. Subscriber delivery preferences: priority, ordering priority, staleness, and optional group range.
 - **`TrackInfo`**. Publisher track properties: priority, ordering priority, cache window, and timescale.
 - **`Dimensions`**. `.width: int`, `.height: int`.

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -215,6 +215,7 @@ mod test {
 				display_aspect_width: None,
 				display_aspect_height: None,
 				bitrate: None,
+				stalled: None,
 				framerate: None,
 				optimize_for_latency: None,
 				container: Container::Legacy,

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -187,6 +187,13 @@ pub struct VideoConfig {
 	#[serde(default)]
 	pub bitrate: Option<u64>,
 
+	/// Whether the publisher recommends temporarily avoiding this rendition.
+	///
+	/// The track remains available. Consumers may still select it when no
+	/// unstalled rendition is suitable.
+	#[serde(default)]
+	pub stalled: Option<bool>,
+
 	/// The frame rate of the video track, if known.
 	#[serde(default)]
 	pub framerate: Option<f64>,
@@ -239,6 +246,7 @@ impl VideoConfig {
 			display_aspect_width: None,
 			display_aspect_height: None,
 			bitrate: None,
+			stalled: None,
 			framerate: None,
 			optimize_for_latency: None,
 			container: Container::default(),
@@ -285,6 +293,20 @@ mod test {
 		let config: VideoConfig = serde_json::from_value(json).expect("failed to decode legacy keys");
 		assert_eq!(config.display_aspect_width, Some(16));
 		assert_eq!(config.display_aspect_height, Some(9));
+	}
+
+	#[test]
+	fn stalled_is_optional_and_round_trips() {
+		let mut config = VideoConfig::new(VideoCodec::VP8);
+		let encoded = serde_json::to_value(&config).expect("failed to encode");
+		assert!(encoded.get("stalled").is_none());
+
+		config.stalled = Some(true);
+		let encoded = serde_json::to_value(&config).expect("failed to encode");
+		assert_eq!(encoded["stalled"], true);
+
+		let decoded: VideoConfig = serde_json::from_value(encoded).expect("failed to decode");
+		assert_eq!(decoded.stalled, Some(true));
 	}
 
 	#[test]

--- a/rs/libmoq/README.md
+++ b/rs/libmoq/README.md
@@ -62,6 +62,7 @@ int32_t moq_consume_catalog(uint32_t broadcast, void (*on_catalog)(void *user_da
 int32_t moq_consume_catalog_close(uint32_t catalog);
 int32_t moq_consume_catalog_free(uint32_t catalog);
 int32_t moq_consume_video_config(uint32_t catalog, uint32_t index, moq_video_config *dst);
+int32_t moq_consume_video_stalled(uint32_t catalog, uint32_t index, bool *dst);
 int32_t moq_consume_audio_config(uint32_t catalog, uint32_t index, moq_audio_config *dst);
 
 // Consuming: Video

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -2359,6 +2359,29 @@ pub unsafe extern "C" fn moq_consume_video_config(catalog: u32, index: u32, dst:
 	})
 }
 
+/// Query whether the publisher recommends temporarily avoiding a video rendition.
+///
+/// The track remains available. A false value also covers catalogs that omit the
+/// optional field.
+///
+/// Returns zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that `dst` points to properly aligned, writable storage for a `bool`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_consume_video_stalled(catalog: u32, index: u32, dst: *mut bool) -> i32 {
+	ffi::enter(move || {
+		let catalog = ffi::parse_id(catalog)?;
+		if dst.is_null() {
+			return Err(Error::InvalidPointer);
+		}
+
+		let stalled = State::lock().consume.video_stalled(catalog, index as usize)?;
+		unsafe { dst.write(stalled) };
+		Ok(())
+	})
+}
+
 /// Query the catalog properties shared by every video rendition.
 ///
 /// The destination is filled by value and remains valid after the catalog snapshot is freed.

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -219,6 +219,19 @@ impl Consume {
 		Ok(())
 	}
 
+	/// Return whether the publisher recommends temporarily avoiding a video rendition.
+	pub fn video_stalled(&self, catalog: Id, index: usize) -> Result<bool, Error> {
+		let consume = self.catalog.get(catalog).ok_or(Error::CatalogNotFound)?;
+		let (_, config) = consume
+			.catalog
+			.video
+			.renditions
+			.iter()
+			.nth(index)
+			.ok_or(Error::NoIndex)?;
+		Ok(config.stalled.unwrap_or(false))
+	}
+
 	/// Fill `dst` with the properties shared by every video rendition.
 	pub fn video_properties(&self, catalog: Id, dst: &mut moq_video_properties) -> Result<(), Error> {
 		let consume = self.catalog.get(catalog).ok_or(Error::CatalogNotFound)?;

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -285,6 +285,30 @@ fn publish_catalog_roundtrip() {
 		container: moq_container::default(),
 	};
 	assert_eq!(unsafe { moq_publish_video_config(broadcast, &video) }, 0);
+	let stalled_video_name = "video-stalled";
+	let stalled_video = moq_video_config {
+		name: stalled_video_name.as_ptr() as *const c_char,
+		name_len: stalled_video_name.len(),
+		codec: video_codec.as_ptr() as *const c_char,
+		codec_len: video_codec.len(),
+		description: description.as_ptr(),
+		description_len: description.len(),
+		coded_width: &width,
+		coded_height: &height,
+		container: moq_container::default(),
+	};
+	assert_eq!(unsafe { moq_publish_video_config(broadcast, &stalled_video) }, 0);
+	{
+		let mut state = State::lock();
+		let (_, catalog) = state.publish.pair_mut(Id::try_from(broadcast).unwrap()).unwrap();
+		catalog
+			.lock()
+			.video
+			.renditions
+			.get_mut(stalled_video_name)
+			.unwrap()
+			.stalled = Some(true);
+	}
 	let properties = moq_video_properties {
 		display_width: 1080,
 		display_height: 1920,
@@ -340,6 +364,35 @@ fn publish_catalog_roundtrip() {
 	assert_eq!(codec, "vp8");
 	assert_eq!(unsafe { *video_cfg.coded_width }, 1920);
 	assert_eq!(unsafe { *video_cfg.coded_height }, 1080);
+	let mut stalled = std::mem::MaybeUninit::<bool>::uninit();
+	assert_eq!(
+		unsafe { moq_consume_video_stalled(catalog_id, 0, stalled.as_mut_ptr()) },
+		0
+	);
+	assert!(!unsafe { stalled.assume_init() });
+
+	let mut stalled = std::mem::MaybeUninit::<bool>::uninit();
+	assert_eq!(
+		unsafe { moq_consume_video_stalled(catalog_id, 1, stalled.as_mut_ptr()) },
+		0
+	);
+	assert!(unsafe { stalled.assume_init() });
+	assert_eq!(
+		unsafe { moq_consume_video_stalled(catalog_id, 0, std::ptr::null_mut()) },
+		-6,
+		"null stalled pointer should return InvalidPointer (-6)"
+	);
+	assert_eq!(
+		unsafe {
+			moq_publish_video_remove(
+				broadcast,
+				stalled_video_name.as_ptr() as *const c_char,
+				stalled_video_name.len(),
+			)
+		},
+		0
+	);
+	let active_catalog_id = id(catalog_cb.recv());
 
 	let mut properties = moq_video_properties::default();
 	assert_eq!(unsafe { moq_consume_video_properties(catalog_id, &mut properties) }, 0);
@@ -380,6 +433,7 @@ fn publish_catalog_roundtrip() {
 	assert_eq!(unsafe { moq_consume_audio_config(catalog_id2, 0, &mut audio_cfg) }, 0);
 
 	assert_eq!(moq_consume_catalog_free(catalog_id), 0);
+	assert_eq!(moq_consume_catalog_free(active_catalog_id), 0);
 	assert_eq!(moq_consume_catalog_free(catalog_id2), 0);
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -84,6 +84,9 @@ pub struct MoqVideo {
 	pub coded: Option<MoqDimensions>,
 	pub display_aspect: Option<MoqDimensions>,
 	pub bitrate: Option<u64>,
+	/// Whether the publisher recommends temporarily avoiding this rendition.
+	#[uniffi(default = false)]
+	pub stalled: bool,
 	pub framerate: Option<f64>,
 	pub container: MoqContainer,
 }
@@ -217,6 +220,7 @@ pub(crate) fn convert_catalog(catalog: &moq_mux::catalog::hang::Catalog<moq_mux:
 						_ => None,
 					},
 					bitrate: config.bitrate,
+					stalled: config.stalled.unwrap_or(false),
 					framerate: config.framerate,
 					container: MoqContainer::from_catalog(&config.container)?,
 				},
@@ -260,5 +264,24 @@ pub(crate) fn convert_catalog(catalog: &moq_mux::catalog::hang::Catalog<moq_mux:
 		rotation: catalog.video.rotation,
 		flip: catalog.video.flip,
 		sections,
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn catalog_exposes_stalled_renditions() {
+		let mut catalog = moq_mux::catalog::hang::Catalog::default();
+		let active = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		catalog.video.renditions.insert("active".to_string(), active);
+		let mut video = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		video.stalled = Some(true);
+		catalog.video.renditions.insert("video".to_string(), video);
+
+		let converted = convert_catalog(&catalog);
+		assert!(!converted.video["active"].stalled);
+		assert!(converted.video["video"].stalled);
 	}
 }

--- a/rs/moq-msf/src/lib.rs
+++ b/rs/moq-msf/src/lib.rs
@@ -102,6 +102,11 @@ pub struct Track {
 	/// Bitrate in bits per second.
 	pub bitrate: Option<u64>,
 
+	/// Whether the publisher recommends temporarily avoiding this track.
+	///
+	/// This is a non-standard extension shared with the hang catalog.
+	pub stalled: Option<bool>,
+
 	/// Resolved base64 initialization data.
 	///
 	/// On the wire this is carried indirectly through draft-01's `initDataList` +
@@ -372,6 +377,7 @@ impl Track {
 			samplerate: None,
 			channel_config: None,
 			bitrate: None,
+			stalled: None,
 			init_data: None,
 			init_ref: None,
 			render_group: None,
@@ -522,6 +528,7 @@ mod test {
 			samplerate: None,
 			channel_config: None,
 			bitrate: Some(6_000_000),
+			stalled: Some(true),
 			init_data: None,
 			init_ref: None,
 			render_group: Some(1),
@@ -545,6 +552,7 @@ mod test {
 			samplerate: Some(48_000),
 			channel_config: Some("2".to_string()),
 			bitrate: Some(128_000),
+			stalled: None,
 			init_data: None,
 			init_ref: None,
 			render_group: Some(1),
@@ -568,6 +576,7 @@ mod test {
 			samplerate: None,
 			channel_config: None,
 			bitrate: Some(5_000_000),
+			stalled: None,
 			init_data: None,
 			init_ref: None,
 			render_group: Some(1),
@@ -596,6 +605,7 @@ mod test {
 		assert!(track.get("maxGrpSapStartingType").is_none());
 		assert!(track.get("maxObjSapStartingType").is_none());
 		assert!(track.get("jitter").is_none());
+		assert_eq!(track["stalled"], true);
 	}
 
 	#[test]

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -215,6 +215,7 @@ fn video_config_from_msf(track: &moq_msf::Track) -> Result<Option<VideoConfig>> 
 	config.coded_width = track.width;
 	config.coded_height = track.height;
 	config.bitrate = track.bitrate;
+	config.stalled = track.stalled;
 	config.framerate = track.framerate;
 	config.container = container;
 	config.jitter = track.jitter;
@@ -386,6 +387,7 @@ mod test {
 		track.height = Some(1080);
 		track.framerate = Some(30.0);
 		track.bitrate = Some(5_000_000);
+		track.stalled = Some(true);
 		track.init_data = init_data.map(str::to_string);
 		track.render_group = Some(1);
 		track
@@ -423,6 +425,7 @@ mod test {
 		assert_eq!(video.coded_height, Some(1080));
 		assert_eq!(video.framerate, Some(30.0));
 		assert_eq!(video.bitrate, Some(5_000_000));
+		assert_eq!(video.stalled, Some(true));
 	}
 
 	#[test]

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -500,6 +500,7 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 		track.height = config.coded_height;
 		track.framerate = config.framerate;
 		track.bitrate = config.bitrate;
+		track.stalled = config.stalled;
 		track.init_data = init_data;
 		track.render_group = Some(1);
 		track.alt_group = if has_multiple_video { Some(1) } else { None };
@@ -795,6 +796,7 @@ mod test {
 		video_config.coded_width = Some(1280);
 		video_config.coded_height = Some(720);
 		video_config.bitrate = Some(6_000_000);
+		video_config.stalled = Some(true);
 		video_config.framerate = Some(30.0);
 		video_config.container = Container::Legacy;
 
@@ -825,6 +827,7 @@ mod test {
 		assert_eq!(video.height, Some(720));
 		assert_eq!(video.framerate, Some(30.0));
 		assert_eq!(video.bitrate, Some(6_000_000));
+		assert_eq!(video.stalled, Some(true));
 		assert!(video.init_data.is_none());
 		// H.264 may carry B-frames, so SAP starting type is 2 (leading pictures allowed).
 		assert_eq!(video.max_grp_sap_starting_type, Some(2));

--- a/swift/Sources/Moq/Aliases.swift
+++ b/swift/Sources/Moq/Aliases.swift
@@ -14,8 +14,8 @@ public typealias MediaFrame = MoqFFI.MoqMediaFrame
 /// The JSON manifest describing a broadcast's tracks: video and audio
 /// renditions, display geometry, and untyped application sections.
 public typealias Catalog = MoqFFI.MoqCatalog
-/// A video rendition in the catalog: codec, coded/display dimensions, bitrate,
-/// framerate, and container.
+/// A video rendition in the catalog: codec, dimensions, bitrate, temporary
+/// avoidance recommendation, framerate, and container.
 public typealias Video = MoqFFI.MoqVideo
 /// Caller-provided catalog fields for a video track.
 public typealias VideoHint = MoqFFI.MoqVideoHint


### PR DESCRIPTION
Part of #2858.

## Summary

- add an optional `stalled` rendition hint to HANG and the repository's MSF extension
- make `@moq/watch` skip stalled renditions while an unstalled supported option exists, and choose the lowest rendition when all supported options are stalled
- split playback routing and decoder identity from selection metadata so bitrate, stalled state, coded dimensions, framerate, jitter, and timeline updates do not rebuild the decoder or repeat the built-in codec support probe; display-aspect changes still rebuild because WebCodecs consumes them
- make custom support callbacks re-evaluate on full catalog config changes unless they explicitly provide the internal decoder-only cache key
- document the wire semantics in the HANG draft and concept docs

## Root cause

The catalog had no way to explain that a rendition remained directly usable but should be avoided by adaptive selection. Updating bitrate or other selection metadata also flowed through the full decoder config signal, so a metadata-only catalog update rebuilt WebCodecs and repeated support probing.

## Public API changes

All changes are additive and target `main`.

- add `VideoConfig.stalled` in Rust HANG and JS HANG
- add the non-standard `Track.stalled` extension in Rust and JS MSF
- add `MoqVideo.stalled` to the UniFFI catalog record, defaulting to false
- add the C function `moq_consume_video_stalled`; the existing `moq_video_config` layout is unchanged

No public item is renamed, removed, or signature-changed. Generated Swift, Kotlin, Python, and Go bindings expose the UniFFI record field without handwritten wrapper changes. Their build and test gates pass.

## Compatibility and scope

- missing `stalled` defaults to false
- the track remains available and directly selectable
- the C ABI is preserved by using an additive getter
- custom `Supported` callbacks keep their existing full-`VideoConfig` semantics; only the built-in WebCodecs probe uses the reduced decoder-config cache key
- OBS behavior is unchanged. The additive C getter lets native applications implement their own policy, while automatic OBS switching needs a separately tested atomic decoder/track handoff
- this does not implement the transcode bandwidth allocator or encoder retuning from #2858
- the HANG, MSF, mux, UniFFI, C, language-wrapper docs, draft, and concept-documentation sync surfaces are included

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test`
- `nix develop --command just drafts check`
- `nix develop --command just test smoke-full`
- exact revised head: 115 watch tests, 1,220 Rust tests, and 50 Python tests passed
- cross-language smoke: all 21 Rust/Python/JS to Rust/Python/JS/native Node/native Bun/C/GStreamer combinations passed before the final watch-selection and documentation follow-up

A local Vite server started successfully for a manual browser check, but both available browser-control surfaces blocked loopback navigation before page load. The reactive browser behavior is covered by the watch regression tests.

The exact revised head passes the repository check and test gates.

(Written by GPT-5)
