### PR TITLE
feat(obs): compile the plugin in CI, and type-check it without obs-deps

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,10 @@ name: Nightly
 # stays silent on the days nobody pushes. `features` is diff-independent for a
 # different reason: it compiles the workspace at feature sets that share almost
 # no artifacts with the default one, which is several minutes of duplicate work
-# that a PR gate can't justify for how rarely it catches something.
+# that a PR gate can't justify for how rarely it catches something. `obs` is
+# diff-independent because its PR-time counterpart can't be: obs.yml has to
+# name the paths that can break an external link to libmoq.a, and no list of
+# paths covers every one of them (see the comment there).
 #
 # A failure here lands on main rather than being caught in review, which is the
 # accepted trade. Anything that must block a merge belongs in check.yml.
@@ -60,3 +63,14 @@ jobs:
       - name: Audit
         if: ${{ !cancelled() }}
         run: nix develop --command just rs audit
+
+      # The OBS plugin is the only thing that links libmoq.a from outside cargo,
+      # so a stale `rs/libmoq/native-libs/*.txt` breaks it and nothing else.
+      # obs.yml lists the inputs that can do that, but a list of paths can't be
+      # complete: a build script emitting `cargo::rustc-link-lib` needs no
+      # manifest change, and widening that filter to `rs/**` would run a link on
+      # nearly every PR. Being diff-independent, this run covers whatever the
+      # filter misses, at the cost of surfacing a day late rather than in review.
+      - name: OBS
+        if: ${{ !cancelled() }}
+        run: nix develop --command just obs ci

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -12,11 +12,19 @@ name: OBS
 # Narrow trigger, like swift.yml: the plugin's own sources, the libmoq header
 # they call through, and the flake that supplies the toolchain.
 #
-# Cargo.lock is in there for the one way a crate the plugin never names can
-# break it: linking libmoq.a from outside cargo needs the native libraries in
-# `rs/libmoq/native-libs/*.txt`, which are maintained by hand. A dependency that
-# starts pulling in a new one leaves that list stale, and every Rust gate stays
-# green because cargo passes the flag itself. Such a change lands in Cargo.lock.
+# The manifests and Cargo.lock are in there for the one way a crate the plugin
+# never names can break it: linking libmoq.a from outside cargo needs the native
+# libraries in `rs/libmoq/native-libs/*.txt`, which are maintained by hand. A
+# dependency that starts pulling in a new one leaves that list stale, and every
+# Rust gate stays green, because cargo passes the flag itself and only this job
+# links without it.
+#
+# Manifests rather than Cargo.lock alone, because a feature toggle is enough:
+# libmoq takes moq-native with default features, so flipping one of those
+# defaults on (`jemalloc` gates `dep:tikv-jemallocator`) changes what libmoq.a
+# needs at link time while Cargo.lock stays byte-identical, since moq-relay
+# already put that package in the graph. Not `rs/**`: sources can't move the
+# link line, and this job would then run on nearly every PR.
 
 permissions:
   contents: read
@@ -29,7 +37,10 @@ on:
     paths:
       - "cpp/obs/**"
       - "rs/libmoq/**"
+      - "rs/**/Cargo.toml"
+      - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - "flake.nix"
       - "flake.lock"
       - ".github/workflows/obs.yml"

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -9,8 +9,14 @@ name: OBS
 # platform-independent C++ over libmoq's C ABI, so a Linux compile catches the
 # breakage a macOS developer would otherwise ship uncompiled.
 #
-# Narrow trigger, like swift.yml: this fires only for changes that can break
-# the plugin, which is its own sources or the libmoq header they call through.
+# Narrow trigger, like swift.yml: the plugin's own sources, the libmoq header
+# they call through, and the flake that supplies the toolchain.
+#
+# Cargo.lock is in there for the one way a crate the plugin never names can
+# break it: linking libmoq.a from outside cargo needs the native libraries in
+# `rs/libmoq/native-libs/*.txt`, which are maintained by hand. A dependency that
+# starts pulling in a new one leaves that list stale, and every Rust gate stays
+# green because cargo passes the flag itself. Such a change lands in Cargo.lock.
 
 permissions:
   contents: read
@@ -23,6 +29,7 @@ on:
     paths:
       - "cpp/obs/**"
       - "rs/libmoq/**"
+      - "Cargo.lock"
       - "flake.nix"
       - "flake.lock"
       - ".github/workflows/obs.yml"

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -1,0 +1,74 @@
+name: OBS
+
+# Compiles and links the OBS plugin, which nothing else does: `just check`
+# lints cpp/obs but never builds it, and a local build needs the
+# multi-hundred-MB obs-deps bundle on macOS and Windows.
+#
+# Linux is the platform that needs no bundle at all -- nixpkgs has obs-studio,
+# Qt6 and ffmpeg, so the dev shell is the whole dependency set. The plugin is
+# platform-independent C++ over libmoq's C ABI, so a Linux compile catches the
+# breakage a macOS developer would otherwise ship uncompiled.
+#
+# Narrow trigger, like swift.yml: this fires only for changes that can break
+# the plugin, which is its own sources or the libmoq header they call through.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    # `closed` is here only so merging/closing a PR cancels its in-flight run
+    # via the concurrency group below; the job itself is skipped on close.
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "cpp/obs/**"
+      - "rs/libmoq/**"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/obs.yml"
+
+concurrency:
+  group: obs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: OBS
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+        with:
+          tool-cache: false
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        with:
+          determinate: false
+          # Trust the flake's cachix substituter, so the dev shell substitutes
+          # instead of building from source. See check.yml for the full story.
+          extra-conf: |
+            extra-substituters = https://kixelated.cachix.org
+            extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
+
+      # Restore only. cache.yml is the single writer, on `main`; see the comment
+      # there for why. `shared-key` has to match the one it saves under. It
+      # holds dev-profile artifacts, which is why `just obs ci` builds libmoq in
+      # debug rather than the preset's release.
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: rust
+          save-if: false
+
+      # The same recipe a developer runs on Linux. Warnings are errors here, via
+      # the platform's CI preset.
+      - name: Build
+        run: nix develop --command just obs ci

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -19,12 +19,19 @@ name: OBS
 # Rust gate stays green, because cargo passes the flag itself and only this job
 # links without it.
 #
-# Manifests rather than Cargo.lock alone, because a feature toggle is enough:
-# libmoq takes moq-native with default features, so flipping one of those
-# defaults on (`jemalloc` gates `dep:tikv-jemallocator`) changes what libmoq.a
-# needs at link time while Cargo.lock stays byte-identical, since moq-relay
-# already put that package in the graph. Not `rs/**`: sources can't move the
-# link line, and this job would then run on nearly every PR.
+# Manifests and build scripts rather than Cargo.lock alone, because neither a
+# feature toggle nor a build script has to touch the lockfile. libmoq takes
+# moq-native with default features, so flipping one of those defaults on
+# (`jemalloc` gates `dep:tikv-jemallocator`) changes what libmoq.a needs at link
+# time while Cargo.lock stays byte-identical, since moq-relay already put that
+# package in the graph; a build.rs emitting `cargo::rustc-link-lib` needs no
+# manifest change at all.
+#
+# A list of paths still can't be complete here -- a vendored C source or a
+# .cargo/config.toml could do it too -- and `rs/**` would run this on nearly
+# every PR, which is the cost that removed the Windows and macOS gates (#2600).
+# So this filter covers the likely inputs at PR time and nightly.yml runs the
+# same recipe diff-independently to cover the rest.
 
 permissions:
   contents: read
@@ -38,6 +45,7 @@ on:
       - "cpp/obs/**"
       - "rs/libmoq/**"
       - "rs/**/Cargo.toml"
+      - "rs/**/build.rs"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ One tool stays unrequired: `swift` exists only on macOS, so swift.yml is its gat
 
 Two path-filtered workflows run recipes of their own alongside `check.yml`, each for something the Linux `just check` can't reach: swift.yml (`swift/scripts/check.sh`, on a Mac) and obs.yml (`just obs ci`, which links the OBS plugin against nixpkgs' libobs/Qt6 -- Linux is the only platform where that needs no obs-deps download).
 
-Two gates live outside the PR path, in `.github/workflows/nightly.yml`: `just rs audit` (cargo-deny) because an advisory lands without this repo changing, and `just rs features` (the `--all-features` and `--no-default-features` compiles) because each is a full extra workspace compile that shares almost nothing with the default one. A break there lands on `main` rather than being caught in review, which is the accepted trade; anything that must block a merge belongs in `check`.
+Three gates live outside the PR path, in `.github/workflows/nightly.yml`: `just rs audit` (cargo-deny) because an advisory lands without this repo changing, `just rs features` (the `--all-features` and `--no-default-features` compiles) because each is a full extra workspace compile that shares almost nothing with the default one, and `just obs ci` because obs.yml's path filter can't be complete (a build script can change what linking `libmoq.a` needs without touching a manifest). A break there lands on `main` rather than being caught in review, which is the accepted trade; anything that must block a merge belongs in `check`.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ The Rust build cache is written by `main` and read by pull requests, never the o
 
 One tool stays unrequired: `swift` exists only on macOS, so swift.yml is its gate rather than the PR path.
 
+Two path-filtered workflows run recipes of their own alongside `check.yml`, each for something the Linux `just check` can't reach: swift.yml (`swift/scripts/check.sh`, on a Mac) and obs.yml (`just obs ci`, which links the OBS plugin against nixpkgs' libobs/Qt6 -- Linux is the only platform where that needs no obs-deps download).
+
 Two gates live outside the PR path, in `.github/workflows/nightly.yml`: `just rs audit` (cargo-deny) because an advisory lands without this repo changing, and `just rs features` (the `--all-features` and `--no-default-features` compiles) because each is a full extra workspace compile that shares almost nothing with the default one. A break there lands on `main` rather than being caught in review, which is the accepted trade; anything that must block a merge belongs in `check`.
 
 ## Architecture
@@ -60,7 +62,7 @@ Top-level layout only. Per-crate and per-package detail lives in the nested guid
 - `/rs/` - Rust crates: core networking (`moq-net`), native helpers, the relay, CLIs, media muxing/codecs, and the FFI/C bindings. See `rs/CLAUDE.md`.
 - `/js/` - TypeScript/JavaScript packages for the browser, published as `@moq/*`. See `js/CLAUDE.md`.
 - `/py/`, `/swift/`, `/kt/`, `/go/` - language wrappers over `rs/moq-ffi` (see [Language Bindings](#language-bindings)). `/py/` has `py/CLAUDE.md`; the others defer to their `README.md`.
-- `/cpp/` - C/C++ consumers of `libmoq`. `cpp/obs/` is the OBS Studio plugin (CMake; links `libmoq` via `MOQ_LOCAL`), licensed GPL-2.0-or-later because it links `libobs`. PR CI never compiles it, so `just obs build` and `just obs test` (the latter runs `cpp/obs/test/` against stubbed libobs/libmoq under ThreadSanitizer) are manual gates, like `just rs macos`. See `doc/bin/obs.md`.
+- `/cpp/` - C/C++ consumers of `libmoq`. `cpp/obs/` is the OBS Studio plugin (CMake; links `libmoq` via `MOQ_LOCAL`), licensed GPL-2.0-or-later because it links `libobs`. `just check` type-checks it via `just obs compile`, which needs headers rather than an obs-deps download, and obs.yml links it on Linux for `cpp/obs/` and `rs/libmoq/` PRs. Still manual, like `just rs macos`: `just obs build` (a loadable plugin, and the only path on macOS/Windows) and `just obs test` (`cpp/obs/test/` against stubbed libobs/libmoq under ThreadSanitizer). See `doc/bin/obs.md`.
 - `/demo/` - demos and test media: relay configs, the web demo, MoQ Boy, media hosting, and a network throttle script.
 - `/test/` - cross-language interop smoke tests (`test/smoke/`), run via `just test smoke[-full]`.
 - `/doc/` - documentation site (VitePress, deployed via Cloudflare). The `/draft/` section is generated from `drafts/` by `doc/.vitepress/drafts.ts`.

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -160,11 +160,21 @@ _includes:
 
     (cd ../.. && cargo check --quiet -p libmoq)
 
-    # Ask cargo where the header landed rather than assuming ../../target:
-    # CARGO_TARGET_DIR (or a config target-dir) moves it, and the hardcoded path
-    # would then type-check against whatever stale copy the default directory
-    # still holds, which is worse than not finding one at all.
-    moq_include="$(cd ../.. && cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')/include"
+    # Ask cargo where its build script ran rather than reconstructing the path.
+    # CARGO_TARGET_DIR, a `--target` triple and a custom profile each move the
+    # generated header, and guessing wrong doesn't fail: it type-checks against
+    # whatever stale copy the default directory still holds. Replays the check
+    # above from cache, so it costs a process rather than a compile.
+    out_dir=$(cd ../.. && cargo check -p libmoq --message-format=json |
+        jq -r 'select(.reason == "build-script-executed") | select(.package_id | tostring | test("libmoq")) | .out_dir' |
+        tail -1)
+    if [ -z "$out_dir" ]; then
+        echo "cargo reported no build script output for libmoq" >&2
+        exit 1
+    fi
+    # <target>/<profile>/build/libmoq-<hash>/out, and the header sits beside the
+    # profile directory. rs/libmoq/build.rs derives it from OUT_DIR the same way.
+    moq_include="$(dirname "$(dirname "$(dirname "$(dirname "$out_dir")")")")/include"
     if [ ! -f "$moq_include/moq.h" ]; then
         echo "$moq_include/moq.h missing after 'cargo check -p libmoq'" >&2
         exit 1

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -1,6 +1,9 @@
 #!/usr/bin/env just --justfile
 # OBS Studio plugin for MoQ. See doc/bin/obs.md for the full build guide.
 #
+# `just obs compile` type-checks the sources on any platform with nothing to
+# download. The recipes below build a loadable plugin, which is a bigger ask:
+#
 # Linux:   `nix develop` provides obs-studio/qt6/ffmpeg/cmake, then `just obs build`.
 # macOS:   native, NOT nix. Needs full Xcode; run outside `nix develop` (its
 #          toolchain breaks the Xcode build). `just obs setup` downloads
@@ -58,39 +61,90 @@ run:
     cp -a build_macos/RelWithDebInfo/obs-moq.plugin "$dest/"
     RUST_LOG=debug RUST_BACKTRACE=1 OBS_LOG_LEVEL=debug /Applications/OBS.app/Contents/MacOS/OBS
 
-# Unit-test the plugin sources against stubbed libobs/libmoq, under ThreadSanitizer.
+# Type-check every plugin source, without linking or an obs-deps download.
 #
-# Manual, like `just rs macos` and `just rs windows`: PR CI never compiles this
-# plugin, and the libobs headers come from the multi-hundred-MB obs-deps download
-# that `just obs setup` performs. Run it whenever you touch src/, especially the
-# session callback plumbing, whose orderings the build can't check.
-test:
+# This is the gate to run in a worktree. `just obs build` needs the
+# multi-hundred-MB obs-deps bundle (macOS/Windows) and a full cargo build, per
+# worktree; this needs neither, because the dev shell carries all three header
+# sets: libobs pinned to the same OBS release buildspec.json downloads (see
+# `obs-headers` in flake.nix), Qt6, and ffmpeg. CI links the real thing on Linux
+# (.github/workflows/obs.yml).
+#
+# It compiles the Qt sources too, which the CMake build only does when
+# ENABLE_QT and ENABLE_FRONTEND_API are on, so the definitions they gate on are
+# set here to match.
+compile:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Unlike the lint recipes, this one never skips: a test gate that reports
-    # success without running anything is worse than no gate, and nothing else
-    # covers this code.
+    # Never skips, for the reason `test` doesn't: a compile gate that reports
+    # success without compiling is worse than no gate. Everything it needs is in
+    # the dev shell, so the fix is always to enter it.
     cxx="${CXX:-c++}"
-    unsupported="'$cxx' cannot build with -fsanitize=thread. These tests need a Clang or GCC
-    compiler that supports ThreadSanitizer: set CXX, or on Windows run them from WSL, since
-    neither MSVC nor Clang on Windows implements ThreadSanitizer."
     if ! command -v "$cxx" >/dev/null; then
-        echo "no C++ compiler at '$cxx'." >&2
-        echo "$unsupported" >&2
+        echo "no C++ compiler at '$cxx'" >&2
         exit 1
     fi
-    if ! printf 'int main(){}\n' | "$cxx" -x c++ -fsanitize=thread -o /dev/null - >/dev/null 2>&1; then
-        echo "$unsupported" >&2
-        exit 1
-    fi
+    for pkgs in "Qt6Widgets Qt6Gui Qt6Core" "libavcodec libavutil libswscale libswresample"; do
+        # shellcheck disable=SC2086
+        if ! pkg-config --exists $pkgs; then
+            echo "missing headers for: $pkgs" >&2
+            echo "run inside 'nix develop', which supplies Qt6 and ffmpeg on every platform" >&2
+            exit 1
+        fi
+    done
 
-    # libobs headers: the obs-deps framework (macOS/Windows), the OBS sources
-    # CMake unpacks beside it, or a system install (Linux/nix).
+    includes=$(just _includes)
+    qt=$(pkg-config --cflags Qt6Widgets Qt6Gui Qt6Core)
+    ffmpeg=$(pkg-config --cflags libavcodec libavutil libswscale libswresample)
+
+    # MOQ_VERSION_STRING only reaches a label in the dock, so any value
+    # type-checks the same; CMake stamps the real libmoq version.
+    status=0
+    for source in src/*.cpp; do
+        # shellcheck disable=SC2086
+        # -Wno-unused-command-line-argument: the nix compiler wrapper injects
+        # link flags, which a syntax-only run reports as unused, once per file.
+        if ! "$cxx" -std=c++17 -fsyntax-only -Wno-unused-command-line-argument \
+            $includes $qt $ffmpeg \
+            -DMOQ_FRONTEND_ENABLED -DMOQ_VERSION_STRING='"0.0.0"' "$source"; then
+            status=1
+        fi
+    done
+    exit $status
+
+# Compile and link the plugin the way CI does, against the dev shell's own
+# libobs/Qt6/ffmpeg. Linux-only in practice: it's the one platform where nixpkgs
+# has obs-studio, so nothing has to be downloaded. Manual elsewhere, like
+# `just rs macos`.
+#
+# CMAKE_BUILD_TYPE overrides the preset's RelWithDebInfo because the Rust cache
+# CI restores holds dev-profile artifacts. A release build of libmoq would
+# rebuild its whole dependency tree on every run, and the gate is about whether
+# the plugin compiles, which the profile doesn't change.
+ci preset="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PRESET=$(just preset "{{ preset }}" ci)
+    cmake --preset "$PRESET" -DCMAKE_BUILD_TYPE=Debug
+    cmake --build --preset "$PRESET"
+
+# Print the -I flags for libobs and libmoq, shared by `compile` and `test`.
+#
+# moq.h is generated by cbindgen from rs/libmoq/src, so regenerate rather than
+# just locating it: a stale header is how a plugin call to a since-changed
+# libmoq function type-checks anyway.
+[private]
+_includes:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # The dev shell's pinned headers first, so every platform checks against the
+    # same libobs. Then the obs-deps framework (macOS/Windows), the OBS sources
+    # CMake unpacks beside it, and a system install (Linux without nix).
     obs_include=""
     for candidate in \
+        "${OBS_INCLUDE_DIR:-}" \
         .deps/Frameworks/libobs.framework/Versions/A/Headers \
-        .deps/obs-studio-*/libobs \
-        "${OBS_INCLUDE_DIR:-}"; do
+        .deps/obs-studio-*/libobs; do
         if [ -n "$candidate" ] && [ -f "$candidate/obs.h" ]; then
             obs_include="$candidate"
             break
@@ -100,22 +154,53 @@ test:
         obs_include=$(pkg-config --variable=includedir libobs)/obs
     fi
     if [ -z "$obs_include" ]; then
-        echo "libobs headers not found; run 'just obs setup' (or set OBS_INCLUDE_DIR)" >&2
+        echo "libobs headers not found; run inside 'nix develop' (or set OBS_INCLUDE_DIR)" >&2
         exit 1
     fi
 
-    # moq.h is generated by cbindgen when libmoq builds.
-    moq_include="../../target/include"
-    if [ ! -f "$moq_include/moq.h" ]; then
-        echo "$moq_include/moq.h missing; run 'just obs build' or 'cargo build -p libmoq' first" >&2
+    (cd ../.. && cargo check --quiet -p libmoq)
+    echo "-I src -I $obs_include -I ../../target/include"
+
+# Unit-test the plugin sources against stubbed libobs/libmoq, under ThreadSanitizer.
+#
+# Manual, like `just rs macos` and `just rs windows`: PR CI links the plugin but
+# doesn't run this, since ThreadSanitizer needs its own build. Run it whenever
+# you touch src/, especially the session callback plumbing, whose orderings the
+# build can't check.
+test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Unlike the lint recipes, this one never skips: a test gate that reports
+    # success without running anything is worse than no gate, and nothing else
+    # covers this code.
+    cxx="${CXX:-c++}"
+    unsupported="'$cxx' cannot build and run -fsanitize=thread binaries. These tests need a
+    Clang or GCC whose ThreadSanitizer runtime works on this host: set CXX, or on Windows run
+    them from WSL, since neither MSVC nor Clang on Windows implements ThreadSanitizer."
+    if ! command -v "$cxx" >/dev/null; then
+        echo "no C++ compiler at '$cxx'." >&2
+        echo "$unsupported" >&2
         exit 1
     fi
 
     out=$(mktemp -d)
     trap 'rm -rf "$out"' EXIT
-    echo "Building tests against $obs_include"
-    "$cxx" -std=c++17 -g -O0 -fsanitize=thread \
-        -I "$obs_include" -I src -I "$moq_include" \
+
+    # Run the probe, don't just link it: a mismatch between the compiler's TSan
+    # runtime and the host kernel (macOS is where this shows up) links fine and
+    # then segfaults before main, which is an unreadable way for the real test
+    # to fail.
+    # The subshell keeps bash's own "Segmentation fault" job message out of the
+    # output, so the explanation below is all the reader gets.
+    if ! printf 'int main(){}\n' | "$cxx" -x c++ -fsanitize=thread -o "$out/probe" - >/dev/null 2>&1 \
+        || ! ("$out/probe" >/dev/null 2>&1) 2>/dev/null; then
+        echo "$unsupported" >&2
+        exit 1
+    fi
+
+    includes=$(just _includes)
+    # shellcheck disable=SC2086
+    "$cxx" -std=c++17 -g -O0 -fsanitize=thread $includes \
         -o "$out/moq-output-test" test/moq-output-test.cpp src/moq-output.cpp
     TSAN_OPTIONS="halt_on_error=1" "$out/moq-output-test"
 
@@ -125,6 +210,15 @@ check:
     set -euo pipefail
     if grep -Fq '"MOQ_VERSION"' CMakePresets.json; then
         echo "CMakePresets.json must not pin MOQ_VERSION" >&2
+        exit 1
+    fi
+    # The headers `just obs compile` type-checks against are a second copy of
+    # the OBS version this spec downloads, so a bump here has to reach flake.nix
+    # or the two gates check different libobs.
+    spec_obs=$(sed -n '/"obs-studio"/,/}/p' buildspec.json | sed -n 's/.*"version": "\([^"]*\)".*/\1/p')
+    flake_obs=$(sed -n '/pname = "libobs-headers"/,/}/p' ../../flake.nix | sed -n 's/.*version = "\([^"]*\)".*/\1/p')
+    if [ "$spec_obs" != "$flake_obs" ]; then
+        echo "obs-studio is $spec_obs in buildspec.json but $flake_obs in flake.nix (libobs-headers)" >&2
         exit 1
     fi
     if command -v cmake >/dev/null; then
@@ -158,17 +252,19 @@ fix:
     fi
 
 # Detect the CMake preset for the current platform (or use the override).
-preset override="":
+# Pass `ci` as the second argument for the warnings-as-errors variant, whose
+# name upstream spells differently on each platform.
+preset override="" variant="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ -n "{{ override }}" ]]; then
         echo "{{ override }}"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
-        echo "macos"
+        [[ "{{ variant }}" == "ci" ]] && echo "macos-ci" || echo "macos"
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        echo "ubuntu-x86_64"
+        [[ "{{ variant }}" == "ci" ]] && echo "ubuntu-ci-x86_64" || echo "ubuntu-x86_64"
     elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
-        echo "windows-x64"
+        [[ "{{ variant }}" == "ci" ]] && echo "windows-ci-x64" || echo "windows-x64"
     else
         echo "Unknown platform: $OSTYPE" >&2
         exit 1

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -215,8 +215,15 @@ check:
     # The headers `just obs compile` type-checks against are a second copy of
     # the OBS version this spec downloads, so a bump here has to reach flake.nix
     # or the two gates check different libobs.
-    spec_obs=$(sed -n '/"obs-studio"/,/}/p' buildspec.json | sed -n 's/.*"version": "\([^"]*\)".*/\1/p')
+    spec_obs=$(jq -r '.dependencies["obs-studio"].version // ""' buildspec.json)
     flake_obs=$(sed -n '/pname = "libobs-headers"/,/}/p' ../../flake.nix | sed -n 's/.*version = "\([^"]*\)".*/\1/p')
+    # Both are pattern matches against files this recipe doesn't own the shape
+    # of. An empty parse compares equal to an empty parse, so the guard would
+    # pass by reporting nothing rather than by finding the versions in sync.
+    if [ -z "$spec_obs" ] || [ -z "$flake_obs" ]; then
+        echo "couldn't read the obs-studio version: '$spec_obs' from buildspec.json, '$flake_obs' from flake.nix" >&2
+        exit 1
+    fi
     if [ "$spec_obs" != "$flake_obs" ]; then
         echo "obs-studio is $spec_obs in buildspec.json but $flake_obs in flake.nix (libobs-headers)" >&2
         exit 1

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -93,7 +93,12 @@ compile:
         fi
     done
 
-    includes=$(just _includes)
+    # Assign first so a failure in `_includes` still aborts under `set -e`,
+    # then split on newlines only: an include path may contain spaces.
+    includes_raw=$(just _includes)
+    includes=()
+    while IFS= read -r flag; do includes+=("$flag"); done <<< "$includes_raw"
+
     qt=$(pkg-config --cflags Qt6Widgets Qt6Gui Qt6Core)
     ffmpeg=$(pkg-config --cflags libavcodec libavutil libswscale libswresample)
 
@@ -104,8 +109,10 @@ compile:
         # shellcheck disable=SC2086
         # -Wno-unused-command-line-argument: the nix compiler wrapper injects
         # link flags, which a syntax-only run reports as unused, once per file.
+        # $qt and $ffmpeg stay unquoted on purpose: pkg-config hands back one
+        # space-separated string, and splitting it is the intended reading.
         if ! "$cxx" -std=c++17 -fsyntax-only -Wno-unused-command-line-argument \
-            $includes $qt $ffmpeg \
+            "${includes[@]}" $qt $ffmpeg \
             -DMOQ_FRONTEND_ENABLED -DMOQ_VERSION_STRING='"0.0.0"' "$source"; then
             status=1
         fi
@@ -180,7 +187,9 @@ _includes:
         exit 1
     fi
 
-    echo "-I src -I $obs_include -I $moq_include"
+    # One flag per line, path glued to the -I, so a caller can rebuild the
+    # arguments without splitting on the spaces in a path.
+    printf -- '-I%s\n' src "$obs_include" "$moq_include"
 
 # Unit-test the plugin sources against stubbed libobs/libmoq, under ThreadSanitizer.
 #
@@ -219,9 +228,11 @@ test:
         exit 1
     fi
 
-    includes=$(just _includes)
-    # shellcheck disable=SC2086
-    "$cxx" -std=c++17 -g -O0 -fsanitize=thread $includes \
+    includes_raw=$(just _includes)
+    includes=()
+    while IFS= read -r flag; do includes+=("$flag"); done <<< "$includes_raw"
+
+    "$cxx" -std=c++17 -g -O0 -fsanitize=thread "${includes[@]}" \
         -o "$out/moq-output-test" test/moq-output-test.cpp src/moq-output.cpp
     TSAN_OPTIONS="halt_on_error=1" "$out/moq-output-test"
 

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -159,7 +159,18 @@ _includes:
     fi
 
     (cd ../.. && cargo check --quiet -p libmoq)
-    echo "-I src -I $obs_include -I ../../target/include"
+
+    # Ask cargo where the header landed rather than assuming ../../target:
+    # CARGO_TARGET_DIR (or a config target-dir) moves it, and the hardcoded path
+    # would then type-check against whatever stale copy the default directory
+    # still holds, which is worse than not finding one at all.
+    moq_include="$(cd ../.. && cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')/include"
+    if [ ! -f "$moq_include/moq.h" ]; then
+        echo "$moq_include/moq.h missing after 'cargo check -p libmoq'" >&2
+        exit 1
+    fi
+
+    echo "-I src -I $obs_include -I $moq_include"
 
 # Unit-test the plugin sources against stubbed libobs/libmoq, under ThreadSanitizer.
 #

--- a/doc/bin/obs.md
+++ b/doc/bin/obs.md
@@ -82,7 +82,7 @@ The filter reaches past `cpp/obs/` because this is the only place `libmoq.a` is 
 
 `just obs test` compiles the plugin sources against stubbed `libobs`/`libmoq` under ThreadSanitizer and drives the session status callback's orderings directly: a connection that fails permanently, a terminal arriving mid-`Start()`, a restart, and one arriving while the output is being destroyed. Run it after touching `cpp/obs/src/`.
 
-It finds the `libobs` headers the same way `just obs compile` does, and regenerates `moq.h` the same way; set `OBS_INCLUDE_DIR` to point it somewhere else. It stays a manual gate, like `just rs macos`: CI links the plugin but doesn't run these, since ThreadSanitizer needs its own build.
+It finds the `libobs` headers the same way `just obs compile` does, and regenerates `moq.h` the same way; set `OBS_INCLUDE_DIR` to point it somewhere else. That shared step asks cargo where the header landed and reads the answer with `jq`, so outside the dev shell (running from WSL, say) `jq` has to be installed alongside cargo and the compiler. It stays a manual gate, like `just rs macos`: CI links the plugin but doesn't run these, since ThreadSanitizer needs its own build.
 
 It also needs a Clang or GCC whose ThreadSanitizer runtime *runs* on the host, so it fails rather than skipping when one isn't available. On Windows run it from WSL, since neither MSVC nor Clang on Windows implements ThreadSanitizer.
 

--- a/doc/bin/obs.md
+++ b/doc/bin/obs.md
@@ -24,6 +24,8 @@ It loads into a stock OBS Studio install. You no longer need to build OBS from s
 
 The plugin lives in-tree under `cpp/obs/`. It links `libmoq`, which is built from the in-tree `rs/libmoq` crate via cargo (CMake's `MOQ_LOCAL` points at the repo root by default), so there is no prebuilt release to download.
 
+Build it when you want to *run* it. To check that a change compiles, reach for [`just obs compile`](#type-checking) instead: on macOS and Windows a real build first downloads the multi-hundred-MB obs-deps bundle into the tree it's building in, which is per-worktree.
+
 ### Linux (Nix)
 
 `libobs`, `Qt6`, and `ffmpeg` come from the dev shell; no system packages required.
@@ -57,13 +59,30 @@ just obs setup
 just obs build
 ```
 
+### Type-checking
+
+`just obs compile` type-checks every plugin source without linking, and without downloading anything:
+
+```bash
+nix develop
+just obs compile
+```
+
+This is the gate to run while working, because it needs headers rather than libraries, and the dev shell carries all of them on every platform. `libobs` comes from the `libobs-headers` package in `flake.nix`, which unpacks the headers from the same OBS release `buildspec.json` pins (`just obs check` fails if the two versions drift); `Qt6` and `ffmpeg` come from nixpkgs. It regenerates `target/include/moq.h` first, so a call to a `libmoq` function whose signature has since changed is a compile error rather than something you find out about later.
+
+It compiles the Qt sources too, which the CMake build only does when `ENABLE_QT` and `ENABLE_FRONTEND_API` are on. `just check` runs it for you when a branch touches `cpp/obs/` or `rs/libmoq/`.
+
+### Compiling in CI
+
+[`obs.yml`](https://github.com/moq-dev/moq/blob/main/.github/workflows/obs.yml) compiles **and links** the plugin on every PR that touches `cpp/obs/`, `rs/libmoq/`, or the flake. It runs on Linux, the one platform where the whole dependency set (`libobs`, `Qt6`, `ffmpeg`) comes from nixpkgs with no obs-deps bundle to download. The plugin is platform-independent C++ over libmoq's C ABI, so this catches what a macOS developer would otherwise ship uncompiled. `just obs ci` is the same recipe locally.
+
 ### Tests
 
 `just obs test` compiles the plugin sources against stubbed `libobs`/`libmoq` under ThreadSanitizer and drives the session status callback's orderings directly: a connection that fails permanently, a terminal arriving mid-`Start()`, a restart, and one arriving while the output is being destroyed. Run it after touching `cpp/obs/src/`.
 
-It needs the `libobs` headers plus a built `libmoq` (`target/include/moq.h`). On macOS and Windows the headers come from the obs-deps bundle `just obs setup` downloads; on Linux they come from the Nix dev shell via `pkg-config`. Set `OBS_INCLUDE_DIR` to point it somewhere else. Like `just rs macos` and `just rs windows`, it is a manual gate: PR CI never compiles this plugin.
+It finds the `libobs` headers the same way `just obs compile` does, and regenerates `moq.h` the same way; set `OBS_INCLUDE_DIR` to point it somewhere else. It stays a manual gate, like `just rs macos`: CI links the plugin but doesn't run these, since ThreadSanitizer needs its own build.
 
-It also needs a Clang or GCC compiler that supports ThreadSanitizer, so it fails rather than skipping when one isn't available. Linux and macOS are covered by the toolchains the plugin already builds with; on Windows run it from WSL, since neither MSVC nor Clang on Windows implements ThreadSanitizer.
+It also needs a Clang or GCC whose ThreadSanitizer runtime *runs* on the host, so it fails rather than skipping when one isn't available. On Windows run it from WSL, since neither MSVC nor Clang on Windows implements ThreadSanitizer.
 
 ```bash
 just obs test

--- a/doc/bin/obs.md
+++ b/doc/bin/obs.md
@@ -74,7 +74,9 @@ It compiles the Qt sources too, which the CMake build only does when `ENABLE_QT`
 
 ### Compiling in CI
 
-[`obs.yml`](https://github.com/moq-dev/moq/blob/main/.github/workflows/obs.yml) compiles **and links** the plugin on every PR that touches `cpp/obs/`, `rs/libmoq/`, or the flake. It runs on Linux, the one platform where the whole dependency set (`libobs`, `Qt6`, `ffmpeg`) comes from nixpkgs with no obs-deps bundle to download. The plugin is platform-independent C++ over libmoq's C ABI, so this catches what a macOS developer would otherwise ship uncompiled. `just obs ci` is the same recipe locally.
+[`obs.yml`](https://github.com/moq-dev/moq/blob/main/.github/workflows/obs.yml) compiles **and links** the plugin on every PR that touches the plugin, `rs/libmoq/`, a workspace manifest or build script, or the flake. It runs on Linux, the one platform where the whole dependency set (`libobs`, `Qt6`, `ffmpeg`) comes from nixpkgs with no obs-deps bundle to download. The plugin is platform-independent C++ over libmoq's C ABI, so this catches what a macOS developer would otherwise ship uncompiled. `just obs ci` is the same recipe locally.
+
+The filter reaches past `cpp/obs/` because this is the only place `libmoq.a` is linked from outside cargo, which needs the hand-maintained native-library lists in `rs/libmoq/native-libs/`. A dependency that starts pulling in a new native library leaves those stale, and every Rust gate stays green because cargo passes the flag itself. No list of paths catches all of those, so [`nightly.yml`](https://github.com/moq-dev/moq/blob/main/.github/workflows/nightly.yml) runs the same recipe diff-independently as the backstop.
 
 ### Tests
 

--- a/flake.nix
+++ b/flake.nix
@@ -292,19 +292,62 @@
           uniffi-bindgen-go
         ];
 
-        # Dependencies for building the OBS plugin (`just obs build`).
-        # Linux-only: nixpkgs marks obs-studio broken on Darwin, so macOS
-        # and Windows fetch libobs/Qt6 via the OBS buildspec instead (see
-        # cpp/obs/buildspec.json and doc/bin/obs.md). ffmpeg + cmake come from
-        # rustDeps. clang-tools/gersemi back `just obs check`.
+        # The libobs headers, unpacked from the same OBS release
+        # cpp/obs/buildspec.json downloads. Headers only: nothing here links, so
+        # it works on Darwin even though obs-studio itself does not build there,
+        # and it costs ~2 MB of store instead of the multi-hundred-MB obs-deps
+        # bundle. `just obs compile` type-checks the plugin against it.
+        #
+        # Keep `version` equal to buildspec.json's obs-studio version; `just obs
+        # check` fails when the two drift.
+        obs-headers = pkgs.stdenvNoCC.mkDerivation rec {
+          pname = "libobs-headers";
+          version = "31.1.1";
+
+          src = pkgs.fetchzip {
+            url = "https://github.com/obsproject/obs-studio/archive/refs/tags/${version}.tar.gz";
+            hash = "sha256-ycfROxgm3wUVyC2d1r3vIr7yWb6ErYIoDZX8xZrc+Vk=";
+          };
+
+          dontBuild = true;
+
+          # The layout matches a real OBS install (everything flat under
+          # include/obs, frontend API included), so a plugin's include paths are
+          # the same here as against the system package on Linux.
+          installPhase = ''
+            runHook preInstall
+            (cd libobs && find . \( -name '*.h' -o -name '*.hpp' \) -exec install -Dm444 {} $out/include/obs/{} \;)
+            install -Dm444 frontend/api/obs-frontend-api.h $out/include/obs/obs-frontend-api.h
+            # obs.h includes obsconfig.h, which the OBS build generates. Only the
+            # two version macros have to hold a value; everything else it
+            # configures is internal to libobs, so leave the #cmakedefines unset.
+            sed -e 's/^#cmakedefine.*$//' -e 's/@OBS_RELEASE_CANDIDATE@/0/' -e 's/@OBS_BETA@/0/' \
+              libobs/obsconfig.h.in > $out/include/obs/obsconfig.h
+            runHook postInstall
+          '';
+        };
+
+        # Dependencies for the OBS plugin (`just obs build`, `just obs compile`,
+        # `just obs check`). ffmpeg + cmake come from rustDeps.
+        #
+        # Only the *build* is Linux-only: nixpkgs marks obs-studio broken on
+        # Darwin, so macOS and Windows link libobs/Qt6 from the OBS buildspec
+        # bundle instead (see cpp/obs/buildspec.json and doc/bin/obs.md).
+        # Type-checking needs headers rather than libraries, and those are
+        # cross-platform -- obs-headers above, plus qt6.qtbase, which does build
+        # on Darwin. So `just obs compile` and the lints run everywhere while
+        # `just obs build` stays native.
         obsDeps =
           with pkgs;
-          lib.optionals (!stdenv.isDarwin) [
-            obs-studio
+          [
+            obs-headers
             qt6.qtbase
-            ninja
             clang-tools
             gersemi
+          ]
+          ++ lib.optionals (!stdenv.isDarwin) [
+            obs-studio
+            ninja
           ];
 
         # Apply our overlay to get the package definitions
@@ -372,7 +415,13 @@
           # Nix's _FORTIFY_SOURCE hardening (requires -O).
           hardeningDisable = [ "fortify" ];
 
-          env = pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+          env = {
+            # Where `just obs compile` and `just obs test` look for libobs. Set
+            # on every platform so the plugin type-checks against the pinned OBS
+            # release everywhere, rather than whatever the host happens to have.
+            OBS_INCLUDE_DIR = "${obs-headers}/include/obs";
+          }
+          // pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
             ALSA_PLUGIN_DIR = "${alsaPlugins}/lib/alsa-lib";
           };
         };

--- a/justfile
+++ b/justfile
@@ -110,11 +110,10 @@ _tools $FILES="":
     # cargo because `go check` builds moq-ffi for the host, and skips on a
     # missing cargo the same way it skips on a missing go.
     scoped '^(go/|rs/moq-ffi/)'                                && tools+=(go uniffi-bindgen-go cargo)
-    # The OBS lints ship only in the Linux dev shell; nixpkgs marks obs-studio
-    # broken on Darwin.
-    if [[ "$(uname -s)" == "Linux" ]] && scoped '^cpp/obs/'; then
-    	tools+=(clang-format gersemi)
-    fi
+    # cargo regenerates moq.h for the type-check; pkg-config locates Qt6 and
+    # ffmpeg. Every platform: the plugin type-checks against headers, and the
+    # dev shell ships those even on Darwin, where obs-studio can't build.
+    scoped '^(cpp/obs/|rs/libmoq/)' && tools+=(clang-format gersemi pkg-config cargo)
 
     # Scopes overlap (rs/moq-ffi/ is in four of them), so the same tool can land
     # in the list twice and be reported missing twice. Splitting on whitespace is
@@ -162,8 +161,12 @@ check $BASE="":
     	just kt check "$files"
     	just swift check "$files"
     	just go check "$files"
-    	# The OBS plugin has no compile job in PR CI, so its lint + CMake
-    	# guards are the only automated coverage it gets.
+    	# Type-checking the plugin needs only headers, so it runs here rather
+    	# than waiting for obs.yml to link it on Linux. libmoq is in scope
+    	# because the plugin calls through its generated C header.
+    	if echo "$files" | grep -qE '^(cpp/obs/|rs/libmoq/)'; then
+    		just obs compile
+    	fi
     	if echo "$files" | grep -q '^cpp/obs/'; then
     		just obs check
     	fi
@@ -191,6 +194,7 @@ check-all *args:
     just swift check
     just go check
     just obs check
+    just obs compile
     just _flake
     just _check-common
 

--- a/justfile
+++ b/justfile
@@ -163,11 +163,16 @@ check $BASE="":
     	just go check "$files"
     	# Type-checking the plugin needs only headers, so it runs here rather
     	# than waiting for obs.yml to link it on Linux. libmoq is in scope
-    	# because the plugin calls through its generated C header.
-    	if echo "$files" | grep -qE '^(cpp/obs/|rs/libmoq/)'; then
+    	# because the plugin calls through its generated C header, and flake.nix
+    	# because it owns the libobs headers this compiles against -- obs.yml
+    	# links against nixpkgs' obs-studio instead, so nothing else would notice
+    	# that package going bad.
+    	if echo "$files" | grep -qE '^(cpp/obs/|rs/libmoq/|flake\.nix$)'; then
     		just obs compile
     	fi
-    	if echo "$files" | grep -q '^cpp/obs/'; then
+    	# flake.nix is in scope because `just obs check` is what compares the OBS
+    	# version pinned there against buildspec.json, and either side can move.
+    	if echo "$files" | grep -qE '^(cpp/obs/|flake\.nix$)'; then
     		just obs check
     	fi
     	# Validates flake eval + dev shell build; it no longer compiles the


### PR DESCRIPTION
## Summary

Nothing compiled `cpp/obs`. `just check` lints it, and a real build first unpacks the multi-hundred-MB obs-deps bundle into `${CMAKE_CURRENT_SOURCE_DIR}/.deps` of the tree it's building in, which is per-worktree. So verifying a one-line plugin change costs a fresh download plus a cargo release build, and in practice OBS changes land uncompiled.

Both gates here sidestep the bundle on the same observation: **type-checking the plugin needs headers, not libraries, and headers are small and cross-platform.**

- **`just obs compile`** runs `-fsyntax-only` over every plugin source, Qt ones included (the CMake build only compiles those with `ENABLE_QT` + `ENABLE_FRONTEND_API`, so the definitions they gate on are set to match). `libobs` comes from a new `libobs-headers` package in `flake.nix`, which unpacks the headers from the same OBS release `buildspec.json` pins (~2 MB, shared across worktrees via the nix store); `Qt6` and `ffmpeg` come from nixpkgs. It regenerates `moq.h` first, so calling a since-changed libmoq function is a compile error rather than a runtime surprise. `just check` runs it when a branch touches `cpp/obs/`, `rs/libmoq/`, or `flake.nix`.
- **`obs.yml`** compiles *and links* the real plugin on `ubuntu-24.04-arm`. Linux is the one platform where nixpkgs supplies libobs/Qt6/ffmpeg outright, and the plugin is platform-independent C++ over libmoq's C ABI, so this catches what a macOS developer would otherwise ship unverified. `just obs ci` is the same recipe locally; it builds libmoq in debug because the Rust cache CI restores holds dev-profile artifacts, and a release build would recompile the whole dependency tree every run.

Two things fell out of this:

- **The OBS lints are no longer Linux-only.** They were gated on Linux because nixpkgs marks `obs-studio` broken on Darwin, but that only rules out *building*: `qt6.qtbase` builds on Darwin fine, and the pinned headers work anywhere.
- **`just obs test`'s ThreadSanitizer probe now runs the binary instead of only linking it.** On macOS the TSan runtime links and then segfaults before `main`, which the old compile-only probe passed through as an unexplained `Segmentation fault: 11`. It also shares include discovery with `compile` rather than duplicating it.

## Scope of the link gate

`obs.yml` reaches past `cpp/obs/` because this is the only place `libmoq.a` is linked from outside cargo, which needs the hand-maintained native-library lists in `rs/libmoq/native-libs/`. A dependency that starts pulling in a new native library leaves those stale while every Rust gate stays green, because cargo passes the flag itself. Neither `Cargo.lock` nor the manifests catch all of that (a `build.rs` emitting `cargo::rustc-link-lib` needs no manifest change), and no list of paths can, so the filter covers the likely inputs at PR time and **`nightly.yml` runs the same recipe diff-independently** as the backstop. `rs/**` was rejected deliberately: a source edit can't move the link line, and it would run a link on nearly every PR, which is the cost that removed the Windows and macOS gates in #2600.

## Public API changes

None. No `pub`/exported item added, renamed, or changed; this is tooling, CI, and docs.

## Test plan

- `obs.yml` passes on this PR: `dev` profile libmoq in 57s (cache reused), all 7 sources compiled, `AUTOMOC` ran, then `Linking CXX shared module obs-moq.so`. Green on every commit since.
- `just obs compile` type-checks all 7 sources on macOS in ~12s with no obs-deps present. Verified it fails as intended by changing a call site to `moq_publish_media_finish(handle, 1)`: `no matching function for call`, citing the regenerated `moq.h`.
- Version-sync guard verified in both directions: drifting `buildspec.json` fails with `obs-studio is 31.1.2 in buildspec.json but 31.1.1 in flake.nix`; drifting the flake side fails earlier, at dev-shell build, on the fetchzip hash. An unparseable `buildspec.json` fails rather than comparing empty to empty.
- Header discovery verified under `CARGO_TARGET_DIR` and `CARGO_BUILD_TARGET=aarch64-apple-darwin` (where the header really does move to `target/<triple>/include`), and with an `OBS_INCLUDE_DIR` containing a space, where the previous expansion failed with `no such file or directory: 'headers'`.
- `just check` green locally; `just obs test` runs the plugin's unit test, which passes without `-fsanitize=thread` on this host (its TSan runtime segfaults before `main`, which the new probe now reports).

## Cross-package sync

`doc/bin/obs.md` and `CLAUDE.md` updated; the latter's "PR CI never compiles it" claim was the stale bit.

Reviewed adversarially by Codex over seven rounds; seven findings fixed, two rejected (one withdrawn by its author on re-check). #2868 filed for the one real out-of-scope finding: nixpkgs ships OBS 32.1.2 while the plugin pins 31.1.1, so the Linux gate links a major release ahead of what the macOS/Windows binaries ship.

(Written by Opus 5)