### PR TITLE
fix(moq-mux)!: let a Rendition be the only thing that writes its catalog slot

### DIFF
--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -1583,10 +1583,11 @@ pub unsafe extern "C" fn moq_publish_video_properties(broadcast: u32, properties
 /// This is the producer counterpart to [moq_consume_video_config]: instead of
 /// reading a rendition out of a catalog, it writes one into the catalog of a
 /// broadcast created with [moq_origin_publish]. The rendition is keyed by
-/// `config.name`, which must not already exist in this broadcast's catalog:
-/// re-declaring one fails rather than replacing it. Remove it first with
-/// [moq_publish_video_remove] to change a rendition. The updated catalog is
-/// published to subscribers automatically.
+/// `config.name`; calling this again with the same name replaces the rendition
+/// you declared, so a config can be refined in place. It fails only when a
+/// [moq_publish_video] track owns the name, since that track publishes and
+/// retires its own rendition. The updated catalog is published to subscribers
+/// automatically.
 ///
 /// The struct fields are read as inputs:
 /// - `name` / `codec` are required (NOT NULL terminated) string slices.
@@ -1594,7 +1595,7 @@ pub unsafe extern "C" fn moq_publish_video_properties(broadcast: u32, properties
 /// - `description` may be NULL to omit it.
 /// - `coded_width` / `coded_height` may be zero to omit them.
 /// - `container` describes how the frames written to the track are wrapped. A
-///   zeroed one declares the legacy container, which is what [moq_publish_audio]
+///   zeroed one declares the legacy container, which is what [moq_publish_video]
 ///   writes; declare CMAF or LOC for a [moq_publish_track] whose frames you
 ///   already encode that way.
 ///
@@ -1631,10 +1632,10 @@ pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const
 /// Add or replace an audio rendition in a broadcast's catalog.
 ///
 /// This is the producer counterpart to [moq_consume_audio_config]. The rendition
-/// is keyed by `config.name`, which must not already exist in this broadcast's
-/// catalog: re-declaring one fails rather than replacing it. Remove it first with
-/// [moq_publish_audio_remove] to change a rendition. The updated catalog is
-/// published to subscribers automatically.
+/// is keyed by `config.name`, on the same terms as [moq_publish_video_config]:
+/// a repeat call replaces your own rendition, and a name a [moq_publish_audio]
+/// track owns is refused. The updated catalog is published to subscribers
+/// automatically.
 ///
 /// The struct fields are read as inputs:
 /// - `name` / `codec` are required (NOT NULL terminated) string slices.
@@ -1674,8 +1675,10 @@ pub unsafe extern "C" fn moq_publish_audio_config(broadcast: u32, config: *const
 
 /// Remove a video rendition from a broadcast's catalog by name.
 ///
-/// This is a no-op if no rendition with that name exists. The updated catalog is
-/// published to subscribers automatically.
+/// Removes a rendition added by [moq_publish_video_config]. Any other name is a
+/// no-op, including one a [moq_publish_video] track owns, which is retired by
+/// [moq_publish_media_finish] instead. The updated catalog is published to
+/// subscribers automatically.
 ///
 /// Returns a zero on success, or a negative code on failure.
 ///
@@ -1692,8 +1695,7 @@ pub unsafe extern "C" fn moq_publish_video_remove(broadcast: u32, name: *const c
 
 /// Remove an audio rendition from a broadcast's catalog by name.
 ///
-/// This is a no-op if no rendition with that name exists. The updated catalog is
-/// published to subscribers automatically.
+/// Same rules as [moq_publish_video_remove].
 ///
 /// Returns a zero on success, or a negative code on failure.
 ///

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -1,12 +1,51 @@
+use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
+
 use moq_mux::catalog::hang::Extra;
+use moq_mux::catalog::{Rendition, RenditionConfig};
 use moq_mux::import;
 
 use crate::{Error, Id, NonZeroSlab};
 
+/// A published broadcast: its producer, its catalog, and the renditions the caller authored by
+/// hand.
+///
+/// The renditions are held rather than written and forgotten because the handle is what owns the
+/// catalog entry: it publishes on [`set`](Rendition::set) and retires the entry on drop. A media
+/// importer ([`import::Track`] or [`import::Container`]) holds its own for the tracks it publishes,
+/// which is what keeps the two from writing over each other.
+struct Broadcast {
+	producer: moq_net::broadcast::Producer,
+	catalog: moq_mux::catalog::Producer<Extra>,
+	video: BTreeMap<String, Rendition<Extra, hang::catalog::VideoConfig>>,
+	audio: BTreeMap<String, Rendition<Extra, hang::catalog::AudioConfig>>,
+}
+
+/// The caller's rendition under `name`, reserved on first use.
+///
+/// A second write to a name the caller already owns re-sets that rendition, so a config can be
+/// refined in place. A name a media importer owns is refused, since it writes and removes its own.
+fn rendition<'a, C: RenditionConfig<Extra>>(
+	owned: &'a mut BTreeMap<String, Rendition<Extra, C>>,
+	catalog: &moq_mux::catalog::Producer<Extra>,
+	name: &str,
+) -> Result<&'a mut Rendition<Extra, C>, Error> {
+	match owned.entry(name.to_string()) {
+		Entry::Occupied(entry) => Ok(entry.into_mut()),
+		// A duplicate is a hang error either way, so report it under hang's own code rather than
+		// the generic mux one.
+		Entry::Vacant(entry) => match catalog.reserve().init::<C>(name) {
+			Ok(rendition) => Ok(entry.insert(rendition)),
+			Err(moq_mux::Error::Hang(err)) => Err(Error::Hang(err)),
+			Err(err) => Err(err.into()),
+		},
+	}
+}
+
 #[derive(Default)]
 pub struct Publish {
 	/// Active broadcast producers for publishing.
-	broadcasts: NonZeroSlab<(moq_net::broadcast::Producer, moq_mux::catalog::Producer<Extra>)>,
+	broadcasts: NonZeroSlab<Broadcast>,
 
 	/// Single-codec media importers, fed timestamped frames.
 	// Boxed because the codec splitters/imports are much larger than the container ones.
@@ -37,17 +76,32 @@ impl Publish {
 		let catalog =
 			moq_mux::catalog::Producer::with_catalog(&mut broadcast, moq_mux::catalog::hang::Catalog::default())?;
 
-		let id = self.broadcasts.insert((broadcast, catalog))?;
+		let id = self.broadcasts.insert(Broadcast {
+			producer: broadcast,
+			catalog,
+			video: BTreeMap::new(),
+			audio: BTreeMap::new(),
+		})?;
 		Ok(id)
 	}
 
 	/// Set whether the broadcast is announced (announced by its origin), keeping the rest
 	/// of its route (hops, cost).
 	pub fn set_announce(&mut self, broadcast: Id, announce: bool) -> Result<(), Error> {
-		let (broadcast, _) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		let route = broadcast.consume().route();
-		broadcast.set_route(route.with_announce(announce))?;
+		let broadcast = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let route = broadcast.producer.consume().route();
+		broadcast.producer.set_route(route.with_announce(announce))?;
 		Ok(())
+	}
+
+	/// The broadcast's track producer.
+	fn producer(&mut self, id: Id) -> Result<&mut moq_net::broadcast::Producer, Error> {
+		Ok(&mut self.broadcasts.get_mut(id).ok_or(Error::BroadcastNotFound)?.producer)
+	}
+
+	/// The broadcast's catalog producer.
+	fn catalog(&mut self, id: Id) -> Result<&mut moq_mux::catalog::Producer<Extra>, Error> {
+		Ok(&mut self.broadcasts.get_mut(id).ok_or(Error::BroadcastNotFound)?.catalog)
 	}
 
 	/// Mutable access to both the broadcast and its catalog producer.
@@ -63,23 +117,36 @@ impl Publish {
 		),
 		Error,
 	> {
-		let (broadcast, catalog) = self.broadcasts.get_mut(id).ok_or(Error::BroadcastNotFound)?;
-		Ok((broadcast, catalog))
+		let broadcast = self.broadcasts.get_mut(id).ok_or(Error::BroadcastNotFound)?;
+		Ok((&mut broadcast.producer, &mut broadcast.catalog))
 	}
 
 	/// Cleanly finish the broadcast and finalize the catalog stream, so subscribers
 	/// see a normal end rather than [`moq_net::Error::Dropped`].
 	pub fn finish(&mut self, broadcast: Id) -> Result<(), Error> {
-		let (mut broadcast, mut catalog) = self.broadcasts.remove(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let Broadcast {
+			mut producer,
+			mut catalog,
+			video,
+			audio,
+		} = self.broadcasts.remove(broadcast).ok_or(Error::BroadcastNotFound)?;
+		// Retire the caller's renditions while the catalog track is still open, so their removal is
+		// published rather than warned about once `finish` has closed it.
+		drop(video);
+		drop(audio);
 		// Finish the broadcast first so the clean end reaches subscribers even if
 		// finalizing the catalog fails.
-		broadcast.finish();
+		producer.finish();
 		catalog.finish()?;
 		Ok(())
 	}
 
 	pub fn audio(&mut self, broadcast: Id, init: import::AudioInit) -> Result<Id, Error> {
-		let (broadcast, catalog) = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let Broadcast {
+			producer: broadcast,
+			catalog,
+			..
+		} = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
 		let mut broadcast = broadcast.clone();
 		let name = broadcast.unique_name(&format!(".{}", init.format));
 		let request = broadcast.reserve_track(name)?;
@@ -90,7 +157,11 @@ impl Publish {
 	}
 
 	pub fn video(&mut self, broadcast: Id, init: import::VideoInit) -> Result<Id, Error> {
-		let (broadcast, catalog) = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let Broadcast {
+			producer: broadcast,
+			catalog,
+			..
+		} = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
 		let mut broadcast = broadcast.clone();
 		let name = broadcast.unique_name(&format!(".{}", init.format));
 		let request = broadcast.reserve_track(name)?;
@@ -101,7 +172,11 @@ impl Publish {
 	}
 
 	pub fn container(&mut self, broadcast: Id, init: import::ContainerInit) -> Result<Id, Error> {
-		let (broadcast, catalog) = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let Broadcast {
+			producer: broadcast,
+			catalog,
+			..
+		} = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
 		let container = import::Container::new(broadcast.clone(), catalog.reserve(), &init)?;
 		let id = self.containers.insert(container)?;
 		Ok(id)
@@ -171,45 +246,48 @@ impl Publish {
 		Ok(())
 	}
 
-	/// Insert or replace a video rendition in the broadcast's catalog.
+	/// Insert or replace a caller-authored video rendition in the broadcast's catalog.
 	///
+	/// Errors if a media importer owns the name, since it publishes and retires its own rendition.
 	/// The catalog is republished automatically.
 	pub fn video_config(&mut self, broadcast: Id, name: &str, config: hang::catalog::VideoConfig) -> Result<(), Error> {
-		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		catalog.lock().video.insert(name, config).map_err(Error::Hang)?;
+		let broadcast = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		rendition(&mut broadcast.video, &broadcast.catalog, name)?.set(config);
 		Ok(())
 	}
 
-	/// Insert or replace an audio rendition in the broadcast's catalog.
+	/// Insert or replace a caller-authored audio rendition in the broadcast's catalog.
 	///
-	/// The catalog is republished automatically.
+	/// Same rules as [`Self::video_config`].
 	pub fn audio_config(&mut self, broadcast: Id, name: &str, config: hang::catalog::AudioConfig) -> Result<(), Error> {
-		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		catalog.lock().audio.insert(name, config).map_err(Error::Hang)?;
+		let broadcast = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		rendition(&mut broadcast.audio, &broadcast.catalog, name)?.set(config);
 		Ok(())
 	}
 
-	/// Remove a video rendition from the broadcast's catalog by name.
+	/// Remove a caller-authored video rendition from the broadcast's catalog by name.
 	///
-	/// The catalog is republished automatically.
+	/// A no-op for any name the caller didn't author, including one a media importer owns: dropping
+	/// the handle is what retires the entry, and the importer holds its own. The catalog is
+	/// republished automatically.
 	pub fn video_remove(&mut self, broadcast: Id, name: &str) -> Result<(), Error> {
-		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		catalog.lock().video.remove(name);
+		let broadcast = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		broadcast.video.remove(name);
 		Ok(())
 	}
 
-	/// Remove an audio rendition from the broadcast's catalog by name.
+	/// Remove a caller-authored audio rendition from the broadcast's catalog by name.
 	///
-	/// The catalog is republished automatically.
+	/// Same rules as [`Self::video_remove`].
 	pub fn audio_remove(&mut self, broadcast: Id, name: &str) -> Result<(), Error> {
-		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		catalog.lock().audio.remove(name);
+		let broadcast = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		broadcast.audio.remove(name);
 		Ok(())
 	}
 
 	/// Replace the properties shared by every video rendition as one catalog update.
 	pub fn video_properties(&mut self, broadcast: Id, properties: hang::catalog::VideoProperties) -> Result<(), Error> {
-		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let catalog = self.catalog(broadcast)?;
 		let mut catalog = catalog.lock();
 		catalog.video.set_properties(properties)?;
 		catalog.commit()?;
@@ -221,7 +299,7 @@ impl Publish {
 	/// `value` is any JSON document. Errors if `name` is reserved (`video`/`audio`).
 	/// The catalog is republished automatically.
 	pub fn catalog_section_set(&mut self, broadcast: Id, name: &str, value: serde_json::Value) -> Result<(), Error> {
-		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let catalog = self.catalog(broadcast)?;
 		catalog.lock().set_section(name.to_string(), value)?;
 		Ok(())
 	}
@@ -230,7 +308,7 @@ impl Publish {
 	///
 	/// A no-op if no section with that name exists. Republishes the catalog if it did.
 	pub fn catalog_section_remove(&mut self, broadcast: Id, name: &str) -> Result<(), Error> {
-		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let catalog = self.catalog(broadcast)?;
 		catalog.lock().remove_section(name);
 		Ok(())
 	}
@@ -241,7 +319,7 @@ impl Publish {
 	/// for non-media tracks. Pair it with [`Self::video_config`] / [`Self::audio_config`]
 	/// if you want to describe the track in the catalog as well.
 	pub fn track(&mut self, broadcast: Id, name: &str, info: Option<moq_net::track::Info>) -> Result<Id, Error> {
-		let (broadcast, _) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let broadcast = self.producer(broadcast)?;
 		let track = broadcast.create_track(name, info)?;
 		self.tracks.insert(track)
 	}
@@ -315,7 +393,7 @@ impl Publish {
 		name: &str,
 		config: moq_json::snapshot::ProducerConfig,
 	) -> Result<Id, Error> {
-		let (broadcast, _) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let broadcast = self.producer(broadcast)?;
 		let track = broadcast.create_track(name, None)?;
 		let producer = moq_json::snapshot::Producer::new(track, config);
 		self.json_snapshot.insert(producer)
@@ -344,7 +422,7 @@ impl Publish {
 		name: &str,
 		config: moq_json::stream::ProducerConfig,
 	) -> Result<Id, Error> {
-		let (broadcast, _) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let broadcast = self.producer(broadcast)?;
 		let track = broadcast.create_track(name, None)?;
 		let producer = moq_json::stream::Producer::new(track, config);
 		self.json_stream.insert(producer)

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -418,6 +418,112 @@ fn publish_catalog_config_invalid_broadcast() {
 	assert!(unsafe { moq_publish_audio_remove(0, name.as_ptr() as *const c_char, name.len()) } < 0);
 }
 
+/// An avc3 track has no catalog rendition until its first SPS arrives, but it owns the name from
+/// the moment it's published. Writing into that gap used to succeed, then get overwritten by the
+/// importer and deleted when the media handle finished, silently taking the caller's entry with it.
+#[test]
+fn publish_media_owns_its_rendition_before_the_first_keyframe() {
+	let origin = id(moq_origin_create());
+	let broadcast = publish_broadcast(origin, b"media-owns-its-rendition");
+
+	// Annex-B with an empty init, so the parameter sets arrive in band and the importer publishes
+	// nothing until a keyframe lands.
+	let media = id(publish_video(
+		broadcast,
+		moq_video_format::MOQ_VIDEO_FORMAT_AVC3,
+		&[],
+		None,
+	));
+
+	let name = "0.avc3";
+	let codec = "avc1.42c01e";
+	let video = moq_video_config {
+		name: name.as_ptr() as *const c_char,
+		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
+		codec: codec.as_ptr() as *const c_char,
+		codec_len: codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		coded_width: 0,
+		coded_height: 0,
+		container: moq_container::default(),
+	};
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, &video) },
+		-18,
+		"the media track owns 0.avc3 even before its config resolves"
+	);
+	assert_eq!(
+		unsafe { moq_publish_video_remove(broadcast, name.as_ptr() as *const c_char, name.len()) },
+		0,
+		"removing a name the caller never authored is a no-op"
+	);
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, &video) },
+		-18,
+		"and the no-op left the media track's rendition alone"
+	);
+
+	// Once the media handle is gone the name is free again.
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, &video) },
+		0,
+		"finishing the media track releases its rendition name"
+	);
+
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+/// A caller owns the renditions it authored, so re-declaring one refines it in place rather than
+/// failing, and removing one actually retires it.
+#[test]
+fn publish_video_config_replaces_its_own_rendition() {
+	let origin = id(moq_origin_create());
+	let broadcast = publish_broadcast(origin, b"catalog-config-replace");
+
+	let name = "authored";
+	let codec = "vp8";
+	let mut video = moq_video_config {
+		name: name.as_ptr() as *const c_char,
+		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
+		codec: codec.as_ptr() as *const c_char,
+		codec_len: codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		coded_width: 640,
+		coded_height: 360,
+		container: moq_container::default(),
+	};
+
+	assert_eq!(unsafe { moq_publish_video_config(broadcast, &video) }, 0);
+	video.coded_width = 1920;
+	video.coded_height = 1080;
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, &video) },
+		0,
+		"a caller can refine a rendition it owns"
+	);
+
+	assert_eq!(
+		unsafe { moq_publish_video_remove(broadcast, name.as_ptr() as *const c_char, name.len()) },
+		0
+	);
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, &video) },
+		0,
+		"the name is free once the caller removes its rendition"
+	);
+
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
 #[test]
 fn publish_catalog_config_null_pointer() {
 	let origin = id(moq_origin_create());
@@ -446,7 +552,7 @@ fn publish_catalog_roundtrip() {
 	let path = b"catalog-producer";
 	let broadcast = publish_broadcast(origin, path);
 
-	// Author the catalog directly instead of via moq_publish_media.
+	// Author the catalog directly instead of via moq_publish_video.
 	let video_name = "video";
 	let video_label = "Main camera";
 	let video_codec = "vp8";

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -92,7 +92,7 @@ pub struct Producer<E: CatalogExt = ()> {
 	resampler: Option<Resampler>,
 	track: moq_mux::container::Producer<moq_mux::container::legacy::Wire>,
 	/// Owns the catalog rendition, retiring it when this producer goes away.
-	rendition: Rendition<E>,
+	rendition: moq_mux::catalog::AudioTrack<E>,
 	pending: Vec<f32>,
 	/// Samples emitted since the current epoch (reset by [`reset_epoch`](Self::reset_epoch)).
 	frames_produced: u64,
@@ -141,15 +141,16 @@ impl<E: CatalogExt> Producer<E> {
 		let name = track.name().to_string();
 		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;
 
-		let mut catalog_mut = catalog.clone();
-		let config = encoder.catalog();
-		catalog_mut.lock().audio.insert(&name, config)?;
+		// The rendition handle owns the name for as long as this producer lives, and retires the
+		// entry however the producer ends.
+		let mut rendition = catalog.reserve().audio(&name)?;
+		rendition.set(encoder.catalog());
 
 		Ok(Self {
 			encoder,
 			resampler,
 			track,
-			rendition: Rendition { catalog, name },
+			rendition,
 			pending: Vec::new(),
 			frames_produced: 0,
 			epoch_us: None,
@@ -158,7 +159,7 @@ impl<E: CatalogExt> Producer<E> {
 
 	/// The name of the published track, which is [`Options::track`] resolved.
 	pub fn track_name(&self) -> &str {
-		&self.rendition.name
+		self.rendition.name()
 	}
 
 	/// The underlying track producer, e.g. to watch subscriber state via
@@ -282,21 +283,6 @@ impl<E: CatalogExt> Producer<E> {
 	/// real cause rather than [`moq_net::Error::Dropped`]. Pending samples are dropped.
 	pub fn abort(self, err: moq_net::Error) {
 		self.track.abort(err);
-	}
-}
-
-/// The producer's catalog entry, removed however the producer ends.
-///
-/// A separate value rather than a `Drop` on [`Producer`] itself, so the terminal
-/// [`finish`](Producer::finish) / [`abort`](Producer::abort) can consume the track.
-struct Rendition<E: CatalogExt> {
-	catalog: moq_mux::catalog::Producer<E>,
-	name: String,
-}
-
-impl<E: CatalogExt> Drop for Rendition<E> {
-	fn drop(&mut self) {
-		self.catalog.lock().audio.remove(&self.name);
 	}
 }
 

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -314,7 +314,7 @@ impl Pad {
 
 		// Go through the reservation like every codec pad, so the first catalog snapshot waits for
 		// this track and dropping the rendition removes it again.
-		let mut rendition = catalog.reserve().text(name);
+		let mut rendition = catalog.reserve().text(name)?;
 		rendition.set(config);
 
 		Ok(Text {

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -444,7 +444,7 @@ mod tests {
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
-		let mut registration = reserved.video("video0");
+		let mut registration = reserved.video("video0").unwrap();
 		let mut config = video_config();
 		config.coded_width = None;
 		config.coded_height = None;
@@ -521,9 +521,9 @@ mod tests {
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
-		let mut video_registration = reserved.video("video0");
+		let mut video_registration = reserved.video("video0").unwrap();
 		video_registration.set(video_config());
-		let mut audio_registration = reserved.audio("audio0");
+		let mut audio_registration = reserved.audio("audio0").unwrap();
 		let audio_config = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
 		audio_registration.set(audio_config);
 		drop(reserved);
@@ -602,7 +602,7 @@ mod tests {
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
-		let mut registration = reserved.video("video0");
+		let mut registration = reserved.video("video0").unwrap();
 		registration.set(video_config());
 		drop(reserved);
 
@@ -663,7 +663,7 @@ mod tests {
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
-		let mut registration = reserved.video("video0");
+		let mut registration = reserved.video("video0").unwrap();
 		registration.set(hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8));
 		drop(reserved);
 
@@ -700,9 +700,9 @@ mod tests {
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
-		let mut video_registration = reserved.video("video0");
+		let mut video_registration = reserved.video("video0").unwrap();
 		video_registration.set(video_config());
-		let mut audio_registration = reserved.audio("audio0");
+		let mut audio_registration = reserved.audio("audio0").unwrap();
 		let audio_config = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
 		audio_registration.set(audio_config);
 		drop(reserved);
@@ -785,7 +785,7 @@ mod tests {
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
-		let mut registration = reserved.video("video0");
+		let mut registration = reserved.video("video0").unwrap();
 		let config = video_config();
 		registration.set(config);
 		drop(reserved);
@@ -854,7 +854,7 @@ mod tests {
 			let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 			let reserved = catalog.reserve();
-			let mut registration = reserved.video("video0");
+			let mut registration = reserved.video("video0").unwrap();
 			let config = video_config();
 			registration.set(config.clone());
 			drop(reserved);
@@ -1007,7 +1007,7 @@ mod tests {
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
-		let mut registration = reserved.video("video0");
+		let mut registration = reserved.video("video0").unwrap();
 		let config = video_config();
 		registration.set(config);
 		drop(reserved);
@@ -1064,7 +1064,7 @@ mod tests {
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
-		let mut registration = reserved.video("video0");
+		let mut registration = reserved.video("video0").unwrap();
 		let config = video_config();
 		registration.set(config);
 		drop(reserved);

--- a/rs/moq-mux/src/catalog/estimate.rs
+++ b/rs/moq-mux/src/catalog/estimate.rs
@@ -48,7 +48,7 @@ impl Estimate {
 /// # ) -> moq_mux::Result<()> {
 /// use moq_mux::catalog::hang::Container;
 /// let mut track = catalog.media_producer(net, Container::Legacy)?;
-/// let mut rendition = reserved.video(track.name());
+/// let mut rendition = reserved.video(track.name())?;
 /// rendition.set(config);
 ///
 /// track.write(frame)?;

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -1,9 +1,29 @@
+use std::collections::BTreeSet;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use base64::Engine;
 
 use super::hang::{Catalog, CatalogExt, Consumer, Extra};
+
+/// The catalog and the names its live [`Rendition`](super::Rendition)s hold, under one lock.
+///
+/// One lock because a name check only means anything if the catalog can't change under it. Split
+/// them and two reservations of the same name both pass, which is the state that let one
+/// rendition's entry be written over and deleted by the other.
+struct State<E: CatalogExt> {
+	catalog: Catalog<E>,
+
+	/// The names live renditions hold, keyed by section (the [`RenditionConfig`](super::RenditionConfig)
+	/// type) and name. The section is part of the key because each writes a disjoint map: `video["v"]`
+	/// and `audio["v"]` are different renditions and neither says anything about the other.
+	owned: BTreeSet<(std::any::TypeId, String)>,
+}
+
+/// The key a rendition name is held under: its section (the config type) plus the name.
+fn owner_key<C: 'static>(name: &str) -> (std::any::TypeId, String) {
+	(std::any::TypeId::of::<C>(), name.to_string())
+}
 
 /// Reservation bookkeeping shared across a producer's clones and its
 /// [`Reserved`](super::Reserved) handles.
@@ -43,7 +63,7 @@ pub struct Producer<E: CatalogExt = ()> {
 	hangz: moq_json::snapshot::Producer<Catalog<E>>,
 	msf_track: moq_net::track::Producer,
 
-	current: Arc<Mutex<Catalog<E>>>,
+	current: Arc<Mutex<State<E>>>,
 
 	/// Gates the initial catalog publish until all reservations resolve (see [`reserve`](Self::reserve)).
 	reservations: Arc<Mutex<Reservations>>,
@@ -174,7 +194,10 @@ impl<E: CatalogExt> Producer<E> {
 			hang,
 			hangz,
 			msf_track,
-			current: Arc::new(Mutex::new(config.catalog)),
+			current: Arc::new(Mutex::new(State {
+				catalog: config.catalog,
+				owned: BTreeSet::new(),
+			})),
 			reservations: Arc::new(Mutex::new(Reservations::default())),
 			clock: crate::Clock::new(),
 			timeline: crate::timeline::Producer::new(broadcast, crate::timeline::Config::default()),
@@ -213,7 +236,7 @@ impl<E: CatalogExt> Producer<E> {
 	/// [`Guard::commit`] instead to handle the error.
 	pub fn lock(&mut self) -> Guard<'_, E> {
 		Guard {
-			catalog: self.current.lock().unwrap(),
+			state: self.current.lock().unwrap(),
 			hang: &mut self.hang,
 			hangz: &mut self.hangz,
 			msf_track: &mut self.msf_track,
@@ -224,7 +247,7 @@ impl<E: CatalogExt> Producer<E> {
 
 	/// Get a snapshot of the current catalog.
 	pub fn snapshot(&self) -> Catalog<E> {
-		self.current.lock().unwrap().clone()
+		self.current.lock().unwrap().catalog.clone()
 	}
 
 	/// Pace the broadcast's timeline with `config` instead of the default.
@@ -247,6 +270,22 @@ impl<E: CatalogExt> Producer<E> {
 	/// Producers that don't reserve publish incrementally as before.
 	pub fn reserve(&self) -> super::Reserved<E> {
 		super::Reserved::new(self.clone())
+	}
+
+	/// Take `name` in `C`'s section for a new [`Rendition`](super::Rendition), which owns it until
+	/// the handle drops.
+	///
+	/// Errors if a live rendition already holds the name, or if the catalog already carries an entry
+	/// under it. That's what makes the rendition the only thing that writes or removes its own slot:
+	/// a lazily-configured importer (H.264 before its first SPS) has no catalog entry yet, and
+	/// without the name being held an outside write would land in the gap, be overwritten by
+	/// [`set`](super::Rendition::set), and then be deleted by the rendition's `Drop`.
+	pub(super) fn acquire<C: super::RenditionConfig<E>>(&self, name: &str) -> crate::Result<()> {
+		let mut state = self.current.lock().unwrap();
+		if C::get_mut(&mut state.catalog, name).is_some() || !state.owned.insert(owner_key::<C>(name)) {
+			return Err(hang::Error::Duplicate(name.to_string()).into());
+		}
+		Ok(())
 	}
 
 	/// Register a live [`Reserved`](super::Reserved) handle.
@@ -279,7 +318,7 @@ impl<E: CatalogExt> Producer<E> {
 			r.pending = false;
 			r.published = true;
 		}
-		let catalog = self.current.lock().unwrap().clone();
+		let catalog = self.current.lock().unwrap().catalog.clone();
 		if let Err(err) = emit(&mut self.hang, &mut self.hangz, &mut self.msf_track, &catalog) {
 			tracing::warn!(%err, "failed to publish the catalog");
 		}
@@ -354,7 +393,7 @@ impl<E: CatalogExt> Producer<E> {
 /// mutated. That publish can fail (a closed track, or an extension that won't serialize) and only
 /// logs a warning; call [`commit`](Self::commit) instead to handle the error.
 pub struct Guard<'a, E: CatalogExt = ()> {
-	catalog: MutexGuard<'a, Catalog<E>>,
+	state: MutexGuard<'a, State<E>>,
 	hang: &'a mut moq_json::snapshot::Producer<Catalog<E>>,
 	hangz: &'a mut moq_json::snapshot::Producer<Catalog<E>>,
 	msf_track: &'a mut moq_net::track::Producer,
@@ -390,7 +429,20 @@ impl<E: CatalogExt> Guard<'_, E> {
 			r.published = true;
 		}
 
-		emit(self.hang, self.hangz, self.msf_track, &self.catalog)
+		emit(self.hang, self.hangz, self.msf_track, &self.state.catalog)
+	}
+
+	/// Release a name taken by [`Producer::acquire`], along with the entry it owns.
+	///
+	/// Both under one lock, so an [`acquire`](Producer::acquire) never sees the rendition half-gone:
+	/// name freed with its entry still there (a spurious duplicate), or entry gone with the name
+	/// still held (a spurious refusal).
+	pub(super) fn release<C: super::RenditionConfig<E>>(&mut self, name: &str, present: bool) {
+		if present {
+			C::remove(&mut self.state.catalog, name);
+			self.updated = true;
+		}
+		self.state.owned.remove(&owner_key::<C>(name));
 	}
 }
 
@@ -398,14 +450,14 @@ impl<E: CatalogExt> Deref for Guard<'_, E> {
 	type Target = Catalog<E>;
 
 	fn deref(&self) -> &Self::Target {
-		&self.catalog
+		&self.state.catalog
 	}
 }
 
 impl<E: CatalogExt> DerefMut for Guard<'_, E> {
 	fn deref_mut(&mut self) -> &mut Self::Target {
 		self.updated = true;
-		&mut self.catalog
+		&mut self.state.catalog
 	}
 }
 
@@ -414,7 +466,7 @@ impl Guard<'_, Extra> {
 	///
 	/// Errors if `name` collides with a reserved media section (`video`/`audio`).
 	pub fn set_section(&mut self, name: impl Into<String>, value: serde_json::Value) -> crate::Result<()> {
-		self.catalog.ext.set(name, value)?;
+		self.state.catalog.ext.set(name, value)?;
 		self.updated = true;
 		Ok(())
 	}
@@ -423,7 +475,7 @@ impl Guard<'_, Extra> {
 	///
 	/// Returns the section's previous value, or `None` if it was absent.
 	pub fn remove_section(&mut self, name: &str) -> Option<serde_json::Value> {
-		let removed = self.catalog.ext.remove(name);
+		let removed = self.state.catalog.ext.remove(name);
 		if removed.is_some() {
 			self.updated = true;
 		}
@@ -716,8 +768,8 @@ mod test {
 		let waiter = kio::Waiter::noop();
 
 		let reserved = catalog.reserve();
-		let mut audio = reserved.audio("audio0");
-		let mut video = reserved.video("video0");
+		let mut audio = reserved.audio("audio0").unwrap();
+		let mut video = reserved.video("video0").unwrap();
 		drop(reserved); // done reserving; both renditions still outstanding
 
 		// Audio resolves first: withheld, because video is still outstanding.
@@ -751,8 +803,8 @@ mod test {
 		let waiter = kio::Waiter::noop();
 
 		let reserved = catalog.reserve();
-		let mut audio = reserved.audio("audio0");
-		let video = reserved.video("video0");
+		let mut audio = reserved.audio("audio0").unwrap();
+		let video = reserved.video("video0").unwrap();
 		drop(reserved);
 
 		audio.set(AudioConfig::new(AudioCodec::Opus, 48_000, 2));
@@ -784,7 +836,7 @@ mod test {
 		// Meanwhile an eager rendition resolves and stages a catalog change. The importer keeps its
 		// rendition alive (dropping it would retire the track), so bind it.
 		let early = catalog.reserve();
-		let mut a0 = early.audio("audio0");
+		let mut a0 = early.audio("audio0").unwrap();
 		a0.set(AudioConfig::new(AudioCodec::Opus, 48_000, 2));
 		drop(early);
 		assert!(
@@ -793,7 +845,7 @@ mod test {
 		);
 
 		// The deferred importer finally builds its rendition and resolves it.
-		let mut late = deferred.audio("audio1");
+		let mut late = deferred.audio("audio1").unwrap();
 		drop(deferred); // the importer releases its own hold; only the rendition's remains
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 		late.set(AudioConfig::new(AudioCodec::Opus, 48_000, 1));

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -6,11 +6,12 @@ use base64::Engine;
 
 use super::hang::{Catalog, CatalogExt, Consumer, Extra};
 
-/// The catalog and the names its live [`Rendition`](super::Rendition)s hold, under one lock.
+/// Everything a catalog producer shares with its clones, under one lock.
 ///
-/// One lock because a name check only means anything if the catalog can't change under it. Split
-/// them and two reservations of the same name both pass, which is the state that let one
-/// rendition's entry be written over and deleted by the other.
+/// One lock rather than one per concern. A name check only means anything if the catalog can't
+/// change under it: split those and two reservations of the same name both pass, which is the state
+/// that let one rendition's entry be written over and deleted by the other. Keeping the publish
+/// gate here too means a [`Guard`] never has to take a second lock while holding this one.
 struct State<E: CatalogExt> {
 	catalog: Catalog<E>,
 
@@ -18,6 +19,21 @@ struct State<E: CatalogExt> {
 	/// type) and name. The section is part of the key because each writes a disjoint map: `video["v"]`
 	/// and `audio["v"]` are different renditions and neither says anything about the other.
 	owned: BTreeSet<(std::any::TypeId, String)>,
+
+	/// Gates the initial catalog publish until all reservations resolve (see
+	/// [`reserve`](Producer::reserve)).
+	reservations: Reservations,
+}
+
+/// Take the shared state, ignoring a poisoned lock.
+///
+/// A panic under this lock comes from code we hand the catalog to: a [`RenditionConfig::insert`]
+/// implementation, or serializing an extension during a publish. Neither leaves the state
+/// inconsistent (at worst the catalog is missing an entry, while `owned` and `reservations` still
+/// describe exactly what is live), so poisoning protects nothing here. It would only turn the next
+/// [`Rendition`](super::Rendition) drop into a panic during unwinding, which aborts the process.
+fn take<E: CatalogExt>(state: &Mutex<State<E>>) -> MutexGuard<'_, State<E>> {
+	state.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// The key a rendition name is held under: its section (the config type) plus the name.
@@ -25,8 +41,7 @@ fn owner_key<C: 'static>(name: &str) -> (std::any::TypeId, String) {
 	(std::any::TypeId::of::<C>(), name.to_string())
 }
 
-/// Reservation bookkeeping shared across a producer's clones and its
-/// [`Reserved`](super::Reserved) handles.
+/// The initial-publish gate, tracking the [`Reserved`](super::Reserved) handles still outstanding.
 ///
 /// The initial catalog snapshot is withheld from the broadcast until `reservers == 0`. A live
 /// `Reserved` counts as one reserver; a [`Rendition`](super::Rendition) holds its own `Reserved`
@@ -65,9 +80,6 @@ pub struct Producer<E: CatalogExt = ()> {
 
 	current: Arc<Mutex<State<E>>>,
 
-	/// Gates the initial catalog publish until all reservations resolve (see [`reserve`](Self::reserve)).
-	reservations: Arc<Mutex<Reservations>>,
-
 	/// Shared wall clock for the broadcast's tracks. Every importer on this catalog
 	/// gets a clone (a `Copy` of the same epoch), so timestamps they synthesize when
 	/// a caller has none land on one timeline and audio/video stay in sync.
@@ -93,7 +105,6 @@ impl<E: CatalogExt> Clone for Producer<E> {
 			hangz: self.hangz.clone(),
 			msf_track: self.msf_track.clone(),
 			current: self.current.clone(),
-			reservations: self.reservations.clone(),
 			clock: self.clock,
 			timeline: self.timeline.clone(),
 			latency_max: self.latency_max,
@@ -197,8 +208,8 @@ impl<E: CatalogExt> Producer<E> {
 			current: Arc::new(Mutex::new(State {
 				catalog: config.catalog,
 				owned: BTreeSet::new(),
+				reservations: Reservations::default(),
 			})),
-			reservations: Arc::new(Mutex::new(Reservations::default())),
 			clock: crate::Clock::new(),
 			timeline: crate::timeline::Producer::new(broadcast, crate::timeline::Config::default()),
 			latency_max: config.latency_max,
@@ -236,18 +247,17 @@ impl<E: CatalogExt> Producer<E> {
 	/// [`Guard::commit`] instead to handle the error.
 	pub fn lock(&mut self) -> Guard<'_, E> {
 		Guard {
-			state: self.current.lock().unwrap(),
+			state: take(&self.current),
 			hang: &mut self.hang,
 			hangz: &mut self.hangz,
 			msf_track: &mut self.msf_track,
-			reservations: &self.reservations,
 			updated: false,
 		}
 	}
 
 	/// Get a snapshot of the current catalog.
 	pub fn snapshot(&self) -> Catalog<E> {
-		self.current.lock().unwrap().catalog.clone()
+		take(&self.current).catalog.clone()
 	}
 
 	/// Pace the broadcast's timeline with `config` instead of the default.
@@ -281,7 +291,7 @@ impl<E: CatalogExt> Producer<E> {
 	/// without the name being held an outside write would land in the gap, be overwritten by
 	/// [`set`](super::Rendition::set), and then be deleted by the rendition's `Drop`.
 	pub(super) fn acquire<C: super::RenditionConfig<E>>(&self, name: &str) -> crate::Result<()> {
-		let mut state = self.current.lock().unwrap();
+		let mut state = take(&self.current);
 		if C::get_mut(&mut state.catalog, name).is_some() || !state.owned.insert(owner_key::<C>(name)) {
 			return Err(hang::Error::Duplicate(name.to_string()).into());
 		}
@@ -290,14 +300,15 @@ impl<E: CatalogExt> Producer<E> {
 
 	/// Register a live [`Reserved`](super::Reserved) handle.
 	pub(super) fn add_reserver(&self) {
-		self.reservations.lock().unwrap().reservers += 1;
+		take(&self.current).reservations.reservers += 1;
 	}
 
 	/// Drop a [`Reserved`](super::Reserved) handle, flushing the initial snapshot if that was the
 	/// last thing gating it.
 	pub(super) fn release_reserver(&mut self) {
 		{
-			let mut r = self.reservations.lock().unwrap();
+			let mut state = take(&self.current);
+			let r = &mut state.reservations;
 			r.reservers = r.reservers.saturating_sub(1);
 		}
 		self.flush_if_ready();
@@ -305,8 +316,10 @@ impl<E: CatalogExt> Producer<E> {
 
 	/// Publish the buffered snapshot once, if buffering has just finished with a change staged.
 	pub(super) fn flush_if_ready(&mut self) {
-		{
-			let mut r = self.reservations.lock().unwrap();
+		// Snapshot under the lock and emit outside it, since emitting writes to the catalog tracks.
+		let catalog = {
+			let mut state = take(&self.current);
+			let r = &mut state.reservations;
 			if r.published || r.reservers != 0 {
 				return;
 			}
@@ -317,8 +330,8 @@ impl<E: CatalogExt> Producer<E> {
 			}
 			r.pending = false;
 			r.published = true;
-		}
-		let catalog = self.current.lock().unwrap().catalog.clone();
+			state.catalog.clone()
+		};
 		if let Err(err) = emit(&mut self.hang, &mut self.hangz, &mut self.msf_track, &catalog) {
 			tracing::warn!(%err, "failed to publish the catalog");
 		}
@@ -397,7 +410,6 @@ pub struct Guard<'a, E: CatalogExt = ()> {
 	hang: &'a mut moq_json::snapshot::Producer<Catalog<E>>,
 	hangz: &'a mut moq_json::snapshot::Producer<Catalog<E>>,
 	msf_track: &'a mut moq_net::track::Producer,
-	reservations: &'a Mutex<Reservations>,
 	updated: bool,
 }
 
@@ -418,7 +430,7 @@ impl<E: CatalogExt> Guard<'_, E> {
 		self.updated = false;
 
 		{
-			let mut r = self.reservations.lock().unwrap();
+			let r = &mut self.state.reservations;
 			// Withhold every emit while still buffering the initial reserved set; the mutation stays
 			// in `current` and `pending` marks it for the flush once the gate opens.
 			if !r.published && r.reservers != 0 {
@@ -437,12 +449,17 @@ impl<E: CatalogExt> Guard<'_, E> {
 	/// Both under one lock, so an [`acquire`](Producer::acquire) never sees the rendition half-gone:
 	/// name freed with its entry still there (a spurious duplicate), or entry gone with the name
 	/// still held (a spurious refusal).
+	///
+	/// The name goes first, before any caller code. [`RenditionConfig::remove`](super::RenditionConfig::remove)
+	/// is a third-party hook that can panic, and a stranded entry is recoverable while a stranded
+	/// name is not: nothing would ever reserve it again.
 	pub(super) fn release<C: super::RenditionConfig<E>>(&mut self, name: &str, present: bool) {
+		self.state.owned.remove(&owner_key::<C>(name));
+
 		if present {
 			C::remove(&mut self.state.catalog, name);
 			self.updated = true;
 		}
-		self.state.owned.remove(&owner_key::<C>(name));
 	}
 }
 

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -413,9 +413,11 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 		// the reservation. If this was the last one, the release flushes a complete snapshot.
 		{
 			let mut guard = self.catalog.lock();
+			// Mark the slot filled before the write, not after. `insert` is caller code that can panic
+			// partway, and whatever it managed to write still has to be retired when we drop.
+			self.present = true;
 			config.insert(&mut guard, &self.name);
 		}
-		self.present = true;
 		self.gate = None;
 	}
 
@@ -763,6 +765,10 @@ mod tests {
 		struct TelemetryExt {
 			#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
 			telemetry: BTreeMap<String, Telemetry>,
+			#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+			exploding: BTreeMap<String, Exploding>,
+			#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+			stubborn: BTreeMap<String, Stubborn>,
 		}
 
 		impl CatalogExt for TelemetryExt {}
@@ -805,6 +811,115 @@ mod tests {
 			let mut broadcast = moq_net::broadcast::Info::new().produce();
 			let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::default()).unwrap();
 			(broadcast, catalog)
+		}
+
+		/// A config whose `insert` panics, to poison the catalog lock the way any third-party
+		/// [`RenditionConfig`] can: `set` runs it while holding that lock.
+		#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+		struct Exploding {
+			/// Write the entry before panicking, leaving a partially applied config behind.
+			wrote: bool,
+		}
+
+		impl RenditionConfig<TelemetryExt> for Exploding {
+			fn insert(self, catalog: &mut Catalog<TelemetryExt>, name: &str) {
+				if self.wrote {
+					catalog.exploding.insert(name.to_string(), self);
+				}
+				panic!("insert exploded");
+			}
+			fn get_mut<'a>(catalog: &'a mut Catalog<TelemetryExt>, name: &str) -> Option<&'a mut Self> {
+				catalog.exploding.get_mut(name)
+			}
+			fn remove(catalog: &mut Catalog<TelemetryExt>, name: &str) {
+				catalog.exploding.remove(name);
+			}
+		}
+
+		/// A panicking `insert` poisons the catalog lock while `set` holds it. The producer has to
+		/// survive that: an unwinding `Rendition::drop` takes the same lock to release its name, and
+		/// a panic there would be a panic during a panic, which aborts the process rather than
+		/// failing a test.
+		#[test]
+		fn a_poisoned_lock_does_not_take_the_producer_down() {
+			let (_broadcast, catalog) = produce();
+			let reserved = catalog.reserve();
+
+			let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+				let mut boom = reserved.init::<Exploding>("gps").unwrap();
+				boom.set(Exploding { wrote: false });
+			}))
+			.expect_err("the config's insert panics");
+			assert!(
+				err.downcast_ref::<&str>().is_some_and(|msg| *msg == "insert exploded"),
+				"the panic is the one the config raised, not a lock failure"
+			);
+
+			// The rendition unwound, so it released its name and the catalog is still usable.
+			assert!(catalog.snapshot().telemetry.is_empty());
+			reserved
+				.init::<Exploding>("gps")
+				.expect("the unwound rendition released its name");
+		}
+
+		/// A config whose cleanup hook panics after mutating, the other half of untrusted caller code:
+		/// `Drop` runs `remove` while holding the catalog lock.
+		#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+		struct Stubborn;
+
+		impl RenditionConfig<TelemetryExt> for Stubborn {
+			fn insert(self, catalog: &mut Catalog<TelemetryExt>, name: &str) {
+				catalog.stubborn.insert(name.to_string(), self);
+			}
+			fn get_mut<'a>(catalog: &'a mut Catalog<TelemetryExt>, name: &str) -> Option<&'a mut Self> {
+				catalog.stubborn.get_mut(name)
+			}
+			fn remove(catalog: &mut Catalog<TelemetryExt>, name: &str) {
+				catalog.stubborn.remove(name);
+				panic!("remove exploded");
+			}
+		}
+
+		/// A panicking `remove` must not cost the rendition its name. The name is released before any
+		/// caller code runs, so the slot is reservable again even though the hook blew up on the way
+		/// out.
+		#[test]
+		fn a_panicking_remove_still_frees_the_name() {
+			let (_broadcast, catalog) = produce();
+			let reserved = catalog.reserve();
+
+			let mut rendition = reserved.init::<Stubborn>("gps").unwrap();
+			rendition.set(Stubborn);
+
+			std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(rendition)))
+				.expect_err("the config's remove panics");
+
+			reserved
+				.init::<Stubborn>("gps")
+				.expect("a name held by a blown-up cleanup hook would be lost forever");
+		}
+
+		/// The partial-application case: `insert` writes its entry and then panics, so `set` never
+		/// reaches `present = true`. The entry still has to go when the rendition unwinds, or it sits
+		/// in the catalog under a name no handle owns and every later reservation of it is refused.
+		#[test]
+		fn an_unwinding_rendition_retires_a_partially_written_entry() {
+			let (_broadcast, catalog) = produce();
+			let reserved = catalog.reserve();
+
+			std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+				let mut boom = reserved.init::<Exploding>("gps").unwrap();
+				boom.set(Exploding { wrote: true });
+			}))
+			.expect_err("the config's insert panics after writing");
+
+			assert!(
+				catalog.snapshot().exploding.is_empty(),
+				"the entry the panicking insert wrote is retired with its owner"
+			);
+			reserved
+				.init::<Exploding>("gps")
+				.expect("a stranded entry would refuse this forever");
 		}
 
 		/// A custom kind gets the same detection and drop-removal as video/audio.

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -266,22 +266,26 @@ impl<E: CatalogExt> Reserved<E> {
 		self.catalog.track_info()
 	}
 
-	/// Reserve a rendition of config type `C` under `name`, returning a guard to fill it in.
+	/// Reserve a rendition of config type `C` under `name`, returning the handle that owns it.
 	///
-	/// The guard holds its own `Reserved` clone, so the catalog stays withheld until the returned
+	/// The handle holds its own `Reserved` clone, so the catalog stays withheld until the returned
 	/// [`Rendition`] is [`set`](Rendition::set) (or dropped). Prefer [`video`](Self::video) /
 	/// [`audio`](Self::audio) for the built-in media configs.
-	pub fn init<C: RenditionConfig<E>>(&self, name: impl Into<String>) -> Rendition<E, C> {
-		Rendition::new(self.clone(), name)
+	///
+	/// Errors if the name is already taken in this section, whether by a live rendition or by an
+	/// entry in the catalog. Sections are independent, so the same name in `video` and `audio` is
+	/// two unrelated renditions.
+	pub fn init<C: RenditionConfig<E>>(&self, name: impl Into<String>) -> crate::Result<Rendition<E, C>> {
+		Rendition::new(self.clone(), name.into())
 	}
 
 	/// Reserve a video rendition; shorthand for [`init`](Self::init).
-	pub fn video(&self, name: impl Into<String>) -> VideoTrack<E> {
+	pub fn video(&self, name: impl Into<String>) -> crate::Result<VideoTrack<E>> {
 		self.init(name)
 	}
 
 	/// Reserve an audio rendition; shorthand for [`init`](Self::init).
-	pub fn audio(&self, name: impl Into<String>) -> AudioTrack<E> {
+	pub fn audio(&self, name: impl Into<String>) -> crate::Result<AudioTrack<E>> {
 		self.init(name)
 	}
 
@@ -289,7 +293,7 @@ impl<E: CatalogExt> Reserved<E> {
 	///
 	/// Nothing about a cue track is detected from its payload, so the caller [`set`](Rendition::set)s
 	/// a complete config up front rather than waiting on a bitstream.
-	pub fn text(&self, name: impl Into<String>) -> TextTrack<E> {
+	pub fn text(&self, name: impl Into<String>) -> crate::Result<TextTrack<E>> {
 		self.init(name)
 	}
 
@@ -329,6 +333,14 @@ impl<E: CatalogExt> Drop for Reserved<E> {
 /// it in with [`set`](Self::set) and refine it in place with [`update`](Self::update). Until it's
 /// set (or dropped) it holds a [`Reserved`] clone, so an unresolved rendition keeps the initial
 /// catalog publish gated. On drop the rendition is removed from the shared catalog.
+///
+/// It owns its name for its whole lifetime, from reservation rather than from `set`, so nothing
+/// else can reserve that name in the same section meanwhile. That's what a lazily-configured
+/// importer needs: an H.264 track publishes no config until its first SPS, and the name has to be
+/// unavailable through that window or an entry written into it is overwritten by `set` and then
+/// deleted by this `Drop`. Author a rendition by holding one of these, not by writing to
+/// `catalog.video` / `catalog.audio` through a [`Guard`](super::Guard), which is raw access to the
+/// catalog document and enforces nothing.
 pub struct Rendition<E: CatalogExt, C: RenditionConfig<E>> {
 	catalog: Producer<E>,
 	name: String,
@@ -357,17 +369,21 @@ pub type AudioTrack<E = ()> = Rendition<E, hang::catalog::AudioConfig>;
 pub type TextTrack<E = ()> = Rendition<E, hang::catalog::TextConfig>;
 
 impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
-	fn new(reserved: Reserved<E>, name: impl Into<String>) -> Self {
-		Self {
+	fn new(reserved: Reserved<E>, name: String) -> crate::Result<Self> {
+		// Take the name now, not at `set`: a lazily-configured importer (H.264 before its first SPS)
+		// has no catalog entry until much later, and the name has to be ours for that whole window.
+		reserved.catalog.acquire::<C>(&name)?;
+
+		Ok(Self {
 			catalog: reserved.catalog.clone(),
 			gate: Some(reserved),
-			name: name.into(),
+			name,
 			present: false,
 			supplied: Estimate::default(),
 			detected: Estimate::default(),
 			published: None,
 			_config: PhantomData,
-		}
+		})
 	}
 
 	/// The track name this rendition is keyed by.
@@ -449,14 +465,23 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 	}
 }
 
+// Manual so a config that isn't `Debug` doesn't cost the handle its own, and because the interesting
+// state is the name and whether it has published yet, not the estimate bookkeeping.
+impl<E: CatalogExt, C: RenditionConfig<E>> std::fmt::Debug for Rendition<E, C> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Rendition")
+			.field("name", &self.name)
+			.field("published", &self.present)
+			.finish_non_exhaustive()
+	}
+}
+
 impl<E: CatalogExt, C: RenditionConfig<E>> Drop for Rendition<E, C> {
 	fn drop(&mut self) {
-		if self.present {
-			// Removing mutates the catalog, so the guard publishes it (immediately if live, else it
-			// accumulates until the gate opens).
-			let mut guard = self.catalog.lock();
-			C::remove(&mut guard, &self.name);
-		}
+		// The entry and the name it holds are released together under one lock. Removing mutates the
+		// catalog, so the guard publishes it (immediately if live, else it accumulates until the gate
+		// opens).
+		self.catalog.lock().release::<C>(&self.name, self.present);
 		// Our reservation (`gate`) drops here. If still held (never set), its release flushes any
 		// staged change; if already released by `set`, this is a no-op.
 	}
@@ -470,7 +495,7 @@ mod tests {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = super::super::Producer::new(&mut broadcast).unwrap();
 		let reserved = catalog.reserve();
-		let rendition = reserved.video("v");
+		let rendition = reserved.video("v").unwrap();
 		// Drop the standalone reservation so only the rendition's own gate remains, which `set`
 		// clears; the broadcast handle is returned so the produced tracks outlive the catalog.
 		drop(reserved);
@@ -627,6 +652,89 @@ mod tests {
 		assert_eq!(config.bitrate, Some(789), "the re-set bitrate is now authoritative");
 	}
 
+	/// A rendition owns its name from the moment it's reserved, not from `set`. H.264 publishes
+	/// frames before its first SPS resolves the config, and the name has to be unavailable through
+	/// that window: an entry written into the gap used to be overwritten by `set` and then deleted
+	/// by the importer's `Drop`, taking the caller's rendition with it.
+	#[test]
+	fn an_unresolved_rendition_still_owns_its_name() {
+		let (_broadcast, catalog, mut rendition) = video_track();
+		assert!(
+			catalog.snapshot().video.renditions.is_empty(),
+			"nothing is published until the config resolves"
+		);
+
+		let err = catalog
+			.reserve()
+			.video("v")
+			.expect_err("an unresolved rendition still owns its name");
+		assert!(matches!(err, crate::Error::Hang(hang::Error::Duplicate(name)) if name == "v"));
+
+		// The refusal left nothing behind, so the importer's own config is what lands.
+		rendition.set(config(Some(123), None));
+		assert_eq!(
+			catalog.snapshot().video.renditions.get("v").unwrap().bitrate,
+			Some(123),
+			"the importer's config owns the rendition"
+		);
+	}
+
+	/// A resolved rendition still owns its name, now backed by a catalog entry.
+	#[test]
+	fn a_resolved_rendition_still_owns_its_name() {
+		let (_broadcast, catalog, mut rendition) = video_track();
+		rendition.set(config(Some(789), None));
+
+		assert!(catalog.reserve().video("v").is_err(), "owned by the live rendition");
+		assert_eq!(
+			catalog.snapshot().video.renditions.get("v").unwrap().bitrate,
+			Some(789),
+			"the refused reservation left the rendition intact"
+		);
+	}
+
+	/// Ownership lasts exactly as long as the rendition, so the name is free again once it drops
+	/// and the entry it published goes with it.
+	#[test]
+	fn dropping_a_rendition_frees_its_name() {
+		let (_broadcast, catalog, mut rendition) = video_track();
+		rendition.set(config(None, None));
+		drop(rendition);
+		assert!(
+			catalog.snapshot().video.renditions.is_empty(),
+			"the entry is retired with its owner"
+		);
+
+		let mut replacement = catalog
+			.reserve()
+			.video("v")
+			.expect("the name is free once the rendition drops");
+		replacement.set(config(Some(456), None));
+		assert_eq!(catalog.snapshot().video.renditions.get("v").unwrap().bitrate, Some(456));
+	}
+
+	/// Sections are independent maps, so a video rendition says nothing about the same name in
+	/// audio.
+	#[test]
+	fn a_name_is_owned_per_section() {
+		let (_broadcast, catalog, _video) = video_track();
+		catalog
+			.reserve()
+			.audio("v")
+			.expect("an audio rendition is a different section from a video one");
+	}
+
+	/// An entry already in the catalog is taken too, even with no rendition behind it: a caller
+	/// that hand-wrote one through the guard still gets to keep it.
+	#[test]
+	fn an_existing_entry_owns_its_name() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let mut catalog = super::super::Producer::new(&mut broadcast).unwrap();
+		catalog.lock().video.insert("v", config(None, None)).unwrap();
+
+		assert!(catalog.reserve().video("v").is_err(), "the catalog already carries it");
+	}
+
 	/// The broadcast has one timeline: every rendition's groups index into the same track, so
 	/// an aligned ladder (source + rung) shares it by construction.
 	#[test]
@@ -704,7 +812,7 @@ mod tests {
 		fn detects_and_advertises() {
 			let (_broadcast, catalog) = produce();
 			let reserved = catalog.reserve();
-			let mut rendition = reserved.init::<Telemetry>("gps");
+			let mut rendition = reserved.init::<Telemetry>("gps").unwrap();
 			drop(reserved);
 
 			rendition.set(telemetry(None));
@@ -728,7 +836,7 @@ mod tests {
 		fn measures_a_custom_track() {
 			let (mut broadcast, mut catalog) = produce();
 			let reserved = catalog.reserve();
-			let mut rendition = reserved.init::<Telemetry>("gps");
+			let mut rendition = reserved.init::<Telemetry>("gps").unwrap();
 			drop(reserved);
 			rendition.set(telemetry(None));
 
@@ -760,7 +868,7 @@ mod tests {
 		fn keeps_supplied_bitrate() {
 			let (_broadcast, catalog) = produce();
 			let reserved = catalog.reserve();
-			let mut rendition = reserved.init::<Telemetry>("gps");
+			let mut rendition = reserved.init::<Telemetry>("gps").unwrap();
 			drop(reserved);
 
 			rendition.set(telemetry(Some(4_200)));
@@ -777,8 +885,8 @@ mod tests {
 			let mut consumer = catalog.consume().unwrap();
 
 			let reserved = catalog.reserve();
-			let mut video = reserved.video("v");
-			let mut gps = reserved.init::<Telemetry>("gps");
+			let mut video = reserved.video("v").unwrap();
+			let mut gps = reserved.init::<Telemetry>("gps").unwrap();
 			drop(reserved);
 
 			let waiter = kio::Waiter::noop();

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -29,7 +29,7 @@ impl<E: CatalogExt> Import<E> {
 		config: hang::catalog::AudioConfig,
 	) -> crate::Result<Self> {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
-		let mut rendition = reserved.audio(track.name());
+		let mut rendition = reserved.audio(track.name())?;
 		rendition.set(config);
 		Ok(Self {
 			track: reserved

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -44,7 +44,7 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
-		let rendition = reserved.video(track.name());
+		let rendition = reserved.video(track.name())?;
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			track: reserved

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -31,7 +31,7 @@ impl<E: CatalogExt> Import<E> {
 		config: hang::catalog::AudioConfig,
 	) -> crate::Result<Self> {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
-		let mut rendition = reserved.audio(track.name());
+		let mut rendition = reserved.audio(track.name())?;
 		rendition.set(config);
 		Ok(Self {
 			track: reserved

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -47,7 +47,7 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
-		let rendition = reserved.video(track.name());
+		let rendition = reserved.video(track.name())?;
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			avc1: false,

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -52,7 +52,7 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
-		let rendition = reserved.video(track.name());
+		let rendition = reserved.video(track.name())?;
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			hvc1: false,

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -142,7 +142,7 @@ impl<E: CatalogExt> Import<E> {
 		tracing::debug!(name = ?track.name(), config = ?audio_config, "starting track");
 
 		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
-		let mut rendition = reserved.audio(track.name());
+		let mut rendition = reserved.audio(track.name())?;
 		rendition.set(audio_config);
 
 		Ok(Self {

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -119,7 +119,7 @@ impl<E: CatalogExt> Import<E> {
 		config: hang::catalog::AudioConfig,
 	) -> crate::Result<Self> {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
-		let mut rendition = reserved.audio(track.name());
+		let mut rendition = reserved.audio(track.name())?;
 		rendition.set(config);
 		Ok(Self {
 			track: reserved

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -31,7 +31,7 @@ impl<E: CatalogExt> Import<E> {
 		config: hang::catalog::AudioConfig,
 	) -> crate::Result<Self> {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
-		let mut rendition = reserved.audio(track.name());
+		let mut rendition = reserved.audio(track.name())?;
 		rendition.set(config);
 		Ok(Self {
 			track: reserved

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -31,7 +31,7 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
-		let rendition = reserved.video(track.name());
+		let rendition = reserved.video(track.name())?;
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			track: reserved

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -31,7 +31,7 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
-		let rendition = reserved.video(track.name());
+		let rendition = reserved.video(track.name())?;
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			track: reserved


### PR DESCRIPTION
## Root cause

A `moq_mux::catalog::Rendition` claimed its name only once `set` published a config. A lazily-configured importer resolves that config much later: an avc3/annexb H.264 track has no rendition at all until its first SPS arrives.

In that window an outside write succeeded, and then quietly lost:

1. `moq_publish_video(MOQ_VIDEO_FORMAT_AVC3)` reserves track `0.avc3`. No catalog rendition yet.
2. `moq_publish_video_config(name="0.avc3")` succeeds, since the name is vacant.
3. The first keyframe arrives; the importer's `Rendition::set` **overwrites** the caller's entry.
4. `moq_publish_media_finish` drops the rendition, whose `Drop` **removes `0.avc3`**, deleting what the caller published.

The mechanism is two write paths that disagreed. `Rendition::set` goes through `RenditionConfig::insert`, a bare `BTreeMap::insert` that overwrites *because the rendition owns the name*; `hang::catalog::Video::insert` takes a `Vacant` entry and otherwise returns `Duplicate`. Nothing connected them, so "this name belongs to an importer" was unrepresentable.

## Fix

`Rendition` was already the ownership handle for a catalog slot: it reserves a name, publishes on `set`, and retires the entry on `Drop`. So rather than guard the second write path, delete it.

A rendition takes its name at **reservation** rather than at `set`, and holds it until it drops. `Reserved::init` (and `video` / `audio` / `text`) refuses a name that a live rendition or an existing catalog entry already holds. The name and the entry are released together under one lock, so nothing can observe a rendition half-gone.

The two places that hand-rolled a rendition now hold a real one:

- **libmoq** keeps a rendition per caller-authored name. `moq_publish_{video,audio}_config` replaces the caller's own rendition, which is what the shipped doc comment always claimed and the code never did, and is refused only for a name a media importer owns. `moq_publish_{video,audio}_remove` drops the handle, and is a no-op for a name the caller never authored.
- **moq-audio**'s encode producer had its own private `Rendition { catalog, name }` struct duplicating the insert/remove-on-drop lifecycle, so it could author into a name an importer had reserved but not yet resolved. Deleted in favor of `moq_mux::catalog::AudioTrack`.

`catalog.video.insert` is **untouched**. It stays the way to build a catalog document, and a `Guard` still derefs to the raw catalog. What changed is that nothing needs to reach through it to publish a rendition, so no parallel `insert_video` / `Guard::insert` surface exists to keep in sync with it. The guard's deref is still raw access that enforces nothing, but that was already true of `catalog.video.renditions`, a `pub` `BTreeMap`. Ownership is enforced by holding the handle, not by policing the data type.

## Unwind safety

Review follow-up, in the second commit. The catalog's two `Arc<Mutex>` are folded into one `State`, since `Guard::publish` was taking the reservations lock while already holding the catalog one.

That lock is held across code we don't own: `Rendition::set` runs a caller's `RenditionConfig::insert` under it, and a publish serializes a caller's catalog extension. A panic in either poisoned the mutex, and the rendition unwinding through it took the same lock to release its name, which is a panic during a panic and aborts the process. Poisoning protects nothing here, so the guard is recovered instead. The rest of the unwind path is ordered around the caller code rather than after it:

- `set` marks the slot filled **before** calling `insert`. An `insert` that writes and then panics never reached the flag, and its entry would stay in the catalog under a name no handle owns, refusing every later reservation.
- `release` frees the name **before** calling `remove`. That hook can panic too, and a stranded entry is recoverable while a stranded name is not.

## Public API changes

Breaking, so this targets `dev`:

- `Reserved::{init, video, audio, text}` return `crate::Result<Rendition<..>>` instead of the rendition directly. A taken name is `hang::Error::Duplicate`. Every call site is an importer's `new(..) -> Result`, so it's a `?`.
- `Rendition` gains a `Debug` impl (name plus whether it has published).
- No new error variant, no new `Guard` methods, no C ABI signature changes.

Behavior changes for previously-broken calls: `moq_publish_video_config` on an importer-owned name returns -18 instead of corrupting the catalog, and on the caller's own name replaces it instead of returning -18. `moq_publish_video_remove` on an importer-owned name is a no-op instead of deleting it.

## Tests

Ten tests, each verified to fail without the piece it covers (the two complements aside):

- Ownership: `an_unresolved_rendition_still_owns_its_name`, `a_resolved_rendition_still_owns_its_name`, `an_existing_entry_owns_its_name`, plus `dropping_a_rendition_frees_its_name` and `a_name_is_owned_per_section` pinning the scope of the rule.
- Unwind safety: `a_poisoned_lock_does_not_take_the_producer_down` (aborts with SIGABRT without the fix, which only reads as a failure under nextest), `an_unwinding_rendition_retires_a_partially_written_entry`, `a_panicking_remove_still_frees_the_name`.
- libmoq: `publish_media_owns_its_rendition_before_the_first_keyframe` drives the avc3 sequence above through the C ABI, and `publish_video_config_replaces_its_own_rendition` covers the caller-owned path.

`just check` and `just test` pass (1319 tests). `just check` never compiles libmoq, so `cargo nextest run -p libmoq` was run separately: 69 passed. `cargo check` also run for `moq-ffi` and `moq-gst`, and `cargo doc` with `-D warnings` for the intra-doc links.

## Cross-package sync

`rs/libmoq` C ABI: no signature changed, so `moq.h`, `cpp/obs/src`, and `doc/bin/obs.md` need no update. `cpp/obs` and `doc/lib/c` only reference the consume side (`moq_consume_video_config`), which is untouched. Doc comments in `api.rs` were corrected in place, including re-pointing the ones that referenced the `moq_publish_media` entry point #2927 replaced. No wire format or catalog JSON change, so no draft update.

(written by Opus 5)
