### PR TITLE
feat(js)!: default standalone components to enabled

### DIFF
--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -114,6 +114,12 @@ The overlay has no `simulcast` control; enable it via the attribute on the neste
 
 ## JavaScript API
 
+Standalone components start enabled when the `enabled` input is omitted. Pass `false` to construct
+one inactive, or supply a `Signal<boolean>` when activation follows application lifecycle state.
+Camera and microphone sources may request permission immediately. Construct an enabled screen source
+during the user gesture that authorizes screen capture, or pass a false live input and enable it from
+that gesture.
+
 ```typescript
 import * as Publish from "@moq/publish";
 import * as Moq from "@moq/net";
@@ -124,11 +130,10 @@ const connection = new Moq.Connection.Shared({ url: new URL("https://relay.examp
 
 const broadcast = new Publish.Broadcast({
     origin: connection.origin,
-    enabled: true,
     name: "alice.hang",
     // Publish two video renditions: video/hd plus a lower-resolution video/sd.
-    video: { hd: { enabled: true }, sd: { enabled: true } },
-    audio: { enabled: true },
+    video: { hd: {}, sd: {} },
+    audio: {},
 });
 
 // Reactive controls

--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -102,7 +102,6 @@ const connection = new Moq.Connection.Shared({ url: new URL("https://relay.examp
 
 const broadcast = new Watch.Broadcast({
     origin: connection.origin,
-    enabled: true,
     name: "alice.hang",
     catalogFormat: "msf",
 });
@@ -124,7 +123,6 @@ import * as Watch from "@moq/watch";
 
 const broadcast = new Watch.Broadcast({
     origin: connection.origin,
-    enabled: true,
     name: "alice.hang",
     catalogFormat: "manual",
     catalog: {
@@ -271,6 +269,9 @@ The `<moq-watch-ui>` element automatically discovers the nested `<moq-watch>` an
 
 ## JavaScript API
 
+Standalone components start enabled when the `enabled` input is omitted. Pass `false` to construct
+one inactive, or supply a `Signal<boolean>` when activation follows application lifecycle state.
+
 ```typescript
 import * as Watch from "@moq/watch";
 import * as Moq from "@moq/net";
@@ -283,7 +284,6 @@ const reload = new Signal(true);
 
 const broadcast = new Watch.Broadcast({
     origin: connection.origin,
-    enabled: true,
     name: "alice.hang",
     reload,
 });

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -20,6 +20,7 @@
 	"scripts": {
 		"build": "rimraf dist && vite build && tsc -p tsconfig.build.json && bun ../common/package.ts",
 		"check": "tsc --noEmit",
+		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {

--- a/js/moq-boy/src/game.test.ts
+++ b/js/moq-boy/src/game.test.ts
@@ -1,0 +1,50 @@
+import { expect, mock, test } from "bun:test";
+import * as Moq from "@moq/net";
+
+// Bun cannot load the blob-URL worklet import used by the audio decoder. This test never provides
+// an audio rendition, so the decoder never creates an AudioContext or reaches the worklet.
+mock.module("../../watch/src/audio/render-worklet.ts?worklet", () => ({ default: "blob:fake-render" }));
+
+const { Game } = await import("./game");
+
+const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+async function settle(times = 5): Promise<void> {
+	for (let i = 0; i < times; i++) await flush();
+}
+
+test("audio downloads only while the tile is active and audible", async () => {
+	const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+	Object.defineProperty(globalThis, "document", { configurable: true, value: new EventTarget() });
+
+	const connection = new Moq.Connection.Reload({ enabled: false });
+	const origin = new Moq.Origin.Producer();
+	const game = new Game({
+		sessionId: "test",
+		connection,
+		origin,
+		expanded: new Moq.Signals.Signal<string | undefined>(undefined),
+		gamePrefix: "game",
+		viewerPrefix: "viewer",
+	});
+
+	try {
+		expect(game.audioEmitter.out.enabled.peek()).toBe(false);
+		expect(game.audioDecoder.in.enabled.peek()).toBe(false);
+
+		game.hovered.set(true);
+		await settle();
+		expect(game.audioEmitter.out.enabled.peek()).toBe(true);
+		expect(game.audioDecoder.in.enabled.peek()).toBe(true);
+
+		game.userMuted.set(true);
+		await settle();
+		expect(game.audioEmitter.out.enabled.peek()).toBe(false);
+		expect(game.audioDecoder.in.enabled.peek()).toBe(false);
+	} finally {
+		game.close();
+		origin.close();
+		connection.close();
+		if (originalDocument) Object.defineProperty(globalThis, "document", originalDocument);
+		else Reflect.deleteProperty(globalThis, "document");
+	}
+});

--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -163,7 +163,8 @@ export class Game {
 		this.#signals.run(this.#runVideoEnabled.bind(this, videoEnabled));
 
 		// Audio pipeline. The emitter stops the download when muted or paused.
-		this.audioDecoder = new Watch.Audio.Decoder(this.audioSource, this.sync);
+		const audioEnabled = new Moq.Signals.Signal(false);
+		this.audioDecoder = new Watch.Audio.Decoder(this.audioSource, this.sync, { enabled: audioEnabled });
 		this.#signals.cleanup(() => this.audioDecoder.close());
 
 		const audioPaused = new Moq.Signals.Signal(true);
@@ -175,6 +176,7 @@ export class Game {
 			paused: audioPaused,
 		});
 		this.#signals.cleanup(() => this.audioEmitter.close());
+		this.#signals.proxy(audioEnabled, this.audioEmitter.out.enabled);
 
 		// Resume AudioContext on first user interaction (browser autoplay policy).
 		for (const event of ["click", "touchstart", "touchend", "mousedown", "keydown"]) {

--- a/js/net/examples/wait.ts
+++ b/js/net/examples/wait.ts
@@ -5,7 +5,7 @@ const { Effect } = Moq.Signals;
 
 async function main() {
 	const url = new URL("https://cdn.moq.dev/anon");
-	const connection = new Moq.Connection.Reload({ url, enabled: true });
+	const connection = new Moq.Connection.Reload({ url });
 
 	// Wait for a broadcast that may not exist yet. `consume` would subscribe blind and get reset
 	// if nobody is publishing the path; this waits for the announcement instead.

--- a/js/net/src/connection/reload.test.ts
+++ b/js/net/src/connection/reload.test.ts
@@ -13,6 +13,22 @@ async function settle() {
 	await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+test("enabled defaults to true", () => {
+	const omitted = new Reload();
+	const explicitUndefined = new Reload({ enabled: undefined });
+	const disabled = new Reload({ enabled: false });
+
+	try {
+		expect(omitted.enabled.peek()).toBe(true);
+		expect(explicitUndefined.enabled.peek()).toBe(true);
+		expect(disabled.enabled.peek()).toBe(false);
+	} finally {
+		omitted.close();
+		explicitUndefined.close();
+		disabled.close();
+	}
+});
+
 test("equivalent URL instances do not restart a pending connection", async () => {
 	const original = globalThis.WebTransport;
 	let connects = 0;

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -161,7 +161,7 @@ export class Reload {
 	#url: Getter<string | undefined>;
 	constructor(props?: ReloadProps) {
 		this.url = Signal.from(props?.url);
-		this.enabled = Signal.from(props?.enabled ?? false);
+		this.enabled = Signal.from(props?.enabled ?? true);
 		this.delay = props?.delay ?? {};
 		this.webtransport = props?.webtransport;
 		this.websocket = props?.websocket;

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -78,14 +78,17 @@ The simplest way to publish a stream:
 
 For more control:
 
+Standalone components start enabled when `enabled` is omitted. Camera and microphone sources may
+request permission immediately. Create an enabled screen source during the user gesture that
+authorizes screen capture, or pass a live input that is false until that gesture.
+
 ```typescript
 import * as Publish from "@moq/publish";
 
 const publish = new Publish.Broadcast(connection, {
-    enabled: true,
-    name: "alice.hang",
-    video: { enabled: true },
-    audio: { enabled: true },
+	name: "alice.hang",
+	video: {},
+	audio: {},
 });
 
 // Change source at runtime

--- a/js/publish/src/audio/capture.ts
+++ b/js/publish/src/audio/capture.ts
@@ -40,7 +40,7 @@ export type CaptureInput = {
 	// The track or decoded samples to pump PCM off.
 	source: Getter<Source | undefined>;
 
-	// Whether to hold the capture device. Decoded samples ignore this: there's no device to release,
+	// Whether to hold the capture device. Defaults to true. Decoded samples ignore this: there's no device to release,
 	// and their stream is one-shot, so dropping it would mean never reading it again.
 	enabled: Getter<boolean>;
 };
@@ -94,7 +94,7 @@ export class Capture {
 	constructor(props?: CaptureProps) {
 		this.in = {
 			source: getter(props?.source),
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 		};
 		this.sampleRate = Signal.from<number | undefined>(props?.sampleRate);
 		this.channelCount = Signal.from<number | undefined>(props?.channelCount);

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -62,7 +62,7 @@ export interface Stats {
 
 // Signals the encoder reads.
 export type EncoderInput = {
-	// Whether to publish (and encode) this rendition. When false the rendition drops out of the
+	// Whether to publish (and encode) this rendition. Defaults to true. When false the rendition drops out of the
 	// catalog and stops encoding, but stays registered so a subscriber still gets an idle track.
 	enabled: Getter<boolean>;
 
@@ -158,7 +158,7 @@ export class Encoder {
 
 		this.name = name;
 		this.in = {
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 			broadcast: getter(props?.broadcast),
 			capture: getter(props?.capture),
 		};

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -12,7 +12,7 @@ export type BroadcastInput = {
 	// origin announce the broadcast, and it survives their reconnects.
 	origin: Getter<Moq.Origin.Table | undefined>;
 
-	// Whether to publish the broadcast. Defaults to false so nothing is announced until ready.
+	// Whether to publish the broadcast. Defaults to true.
 	enabled: Getter<boolean>;
 
 	// The broadcast name.
@@ -79,7 +79,7 @@ export class Broadcast {
 	constructor(props?: Inputs<BroadcastInput>) {
 		this.in = {
 			origin: getter(props?.origin),
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 			name: getter(props?.name ?? Moq.Path.empty()),
 			display: getter(props?.display),
 			flip: getter(props?.flip ?? false),

--- a/js/publish/src/enabled.test.ts
+++ b/js/publish/src/enabled.test.ts
@@ -1,0 +1,115 @@
+import { expect, mock, test } from "bun:test";
+
+// Bun cannot load the blob-URL worker/worklet imports used by the media pipelines. Nothing in
+// these default-input tests reaches either implementation.
+mock.module("./video/capture-worker.ts?worker&inline", () => ({ default: class {} }));
+mock.module("./audio/capture-worklet.ts?worklet", () => ({ default: "blob:fake-capture" }));
+
+const Publish = await import("./index");
+
+type Mode = "omitted" | boolean | undefined;
+
+class FakeMediaDevices extends EventTarget {
+	userMedia = 0;
+	displayMedia = 0;
+
+	async enumerateDevices(): Promise<MediaDeviceInfo[]> {
+		return [device("camera", "videoinput"), device("microphone", "audioinput")];
+	}
+
+	getUserMedia(): Promise<MediaStream> {
+		this.userMedia++;
+		return new Promise(() => {});
+	}
+
+	getDisplayMedia(): Promise<MediaStream> {
+		this.displayMedia++;
+		return new Promise(() => {});
+	}
+}
+
+function device(deviceId: string, kind: MediaDeviceKind): MediaDeviceInfo {
+	return { deviceId, label: deviceId, groupId: deviceId, kind, toJSON: () => ({}) };
+}
+
+type InstalledMediaDevices = {
+	media: FakeMediaDevices;
+	restore(): void;
+};
+
+function installMediaDevices(): InstalledMediaDevices {
+	const media = new FakeMediaDevices();
+	const navigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+	const self = Object.getOwnPropertyDescriptor(globalThis, "self");
+	Object.defineProperty(globalThis, "navigator", {
+		configurable: true,
+		value: { mediaDevices: media, userAgent: "bun" },
+	});
+	Object.defineProperty(globalThis, "self", { configurable: true, value: globalThis });
+
+	return {
+		media,
+		restore() {
+			if (navigator) Object.defineProperty(globalThis, "navigator", navigator);
+			else Reflect.deleteProperty(globalThis, "navigator");
+			if (self) Object.defineProperty(globalThis, "self", self);
+			else Reflect.deleteProperty(globalThis, "self");
+		},
+	};
+}
+
+function inputs(mode: Mode): { enabled?: boolean } | undefined {
+	return mode === "omitted" ? undefined : { enabled: mode };
+}
+
+const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+async function settle(times = 5): Promise<void> {
+	for (let i = 0; i < times; i++) await flush();
+}
+
+async function enabled(mode: Mode): Promise<{ values: boolean[]; userMedia: number; displayMedia: number }> {
+	const installed = installMediaDevices();
+	const props = inputs(mode);
+	const components = [
+		new Publish.Broadcast(props),
+		new Publish.Video.Encoder("video", props),
+		new Publish.Audio.Capture(props),
+		new Publish.Audio.Encoder("audio", props),
+		new Publish.Source.Camera(props),
+		new Publish.Source.Microphone(props),
+		new Publish.Source.Screen(props),
+		new Publish.Source.File(props),
+	];
+
+	try {
+		await settle();
+		const values = components.map((component) => component.in.enabled.peek());
+		return {
+			values,
+			userMedia: installed.media.userMedia,
+			displayMedia: installed.media.displayMedia,
+		};
+	} finally {
+		for (const component of components) component.close();
+		await settle();
+		installed.restore();
+	}
+}
+
+test("standalone components default enabled", async () => {
+	expect(await enabled("omitted")).toEqual({
+		values: [true, true, true, true, true, true, true, true],
+		userMedia: 2,
+		displayMedia: 1,
+	});
+	expect(await enabled(undefined)).toEqual({
+		values: [true, true, true, true, true, true, true, true],
+		userMedia: 2,
+		displayMedia: 1,
+	});
+	expect(await enabled(false)).toEqual({
+		values: [false, false, false, false, false, false, false, false],
+		userMedia: 0,
+		displayMedia: 0,
+	});
+});

--- a/js/publish/src/source/camera.ts
+++ b/js/publish/src/source/camera.ts
@@ -5,7 +5,7 @@ import { Retry } from "./retry";
 
 // Signals the camera reads.
 export type CameraInput = {
-	// Whether to hold the camera open. When false the track is stopped and `out.source` clears.
+	// Whether to hold the camera open. Defaults to true. When false the track is stopped and `out.source` clears.
 	enabled: Getter<boolean>;
 };
 
@@ -54,7 +54,7 @@ export class Camera {
 
 	constructor(props?: CameraProps) {
 		this.in = {
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 		};
 		this.device = new Device("video", props?.device);
 		this.constraints = Signal.from(props?.constraints);

--- a/js/publish/src/source/file.ts
+++ b/js/publish/src/source/file.ts
@@ -17,7 +17,7 @@ import { Timeline } from "./timeline";
 
 // Signals the file source reads.
 export type FileInput = {
-	// Whether to decode the file. When false the decode stops and `out.source` clears.
+	// Whether to decode the file. Defaults to true. When false the decode stops and `out.source` clears.
 	enabled: Getter<boolean>;
 };
 
@@ -64,7 +64,7 @@ export class File {
 
 	constructor(props?: FileProps) {
 		this.in = {
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 		};
 		this.file = Signal.from(props?.file);
 

--- a/js/publish/src/source/microphone.ts
+++ b/js/publish/src/source/microphone.ts
@@ -5,7 +5,7 @@ import { Retry } from "./retry";
 
 // Signals the microphone reads.
 export type MicrophoneInput = {
-	// Whether to hold the microphone open. When false the track is stopped and `out.source` clears.
+	// Whether to hold the microphone open. Defaults to true. When false the track is stopped and `out.source` clears.
 	enabled: Getter<boolean>;
 };
 
@@ -42,7 +42,7 @@ export class Microphone {
 
 	constructor(props?: MicrophoneProps) {
 		this.in = {
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 		};
 		this.device = new Device("audio", props?.device);
 		this.constraints = Signal.from(props?.constraints);

--- a/js/publish/src/source/screen.ts
+++ b/js/publish/src/source/screen.ts
@@ -4,7 +4,8 @@ import type * as Video from "../video";
 
 // Signals the screen capture reads.
 export type ScreenInput = {
-	// Whether to hold the capture open. Enabling it prompts the user to pick a surface.
+	// Whether to hold the capture open. Defaults to true. Enabling prompts the user to pick a surface,
+	// so construct an enabled screen source during a user gesture or start it later with a live input.
 	enabled: Getter<boolean>;
 };
 
@@ -45,7 +46,7 @@ export class Screen {
 
 	constructor(props?: ScreenProps) {
 		this.in = {
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 		};
 		this.video = Signal.from(props?.video);
 		this.audio = Signal.from(props?.audio);

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -62,7 +62,7 @@ export interface Config {
 
 // Signals the encoder reads.
 export type EncoderInput = {
-	// Whether to publish (and encode) this rendition. When false the rendition drops out of the
+	// Whether to publish (and encode) this rendition. Defaults to true. When false the rendition drops out of the
 	// catalog and stops encoding, but stays registered so a subscriber still gets an idle track.
 	enabled: Getter<boolean>;
 
@@ -145,7 +145,7 @@ export class Encoder {
 	constructor(name: string, props?: EncoderProps) {
 		this.name = name;
 		this.in = {
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 			broadcast: getter(props?.broadcast),
 			capture: getter(props?.capture),
 			bandwidth: getter(props?.bandwidth),

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -89,14 +89,16 @@ Only the distance mode suspends video while the tab is hidden; `always` keeps do
 
 For more control:
 
+Standalone components start enabled when `enabled` is omitted. Pass `false` or a live signal when
+activation follows application lifecycle state.
+
 ```typescript
 import * as Watch from "@moq/watch";
 
 const watch = new Watch.Broadcast(connection, {
-    enabled: true,
-    name: "alice.hang",
-    video: { enabled: true },
-    audio: { enabled: true },
+	name: "alice.hang",
+	video: {},
+	audio: {},
 });
 
 // Access the video stream

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -19,7 +19,7 @@ import { unlockOnGesture } from "./unlock";
 const LATENCY_REANCHOR_DEBOUNCE_MS = 150;
 
 export type DecoderInput = {
-	// Enable to download the audio track.
+	// Whether to download the audio track. Defaults to true.
 	enabled: Getter<boolean>;
 };
 
@@ -106,7 +106,7 @@ export class Decoder {
 
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
 		this.in = {
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 		};
 
 		this.source = source;

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -61,8 +61,7 @@ export type BroadcastInput = {
 	// the origin resolve the broadcast, and the handle spans their reconnects.
 	origin: Getter<Moq.Origin.Table | undefined>;
 
-	// Whether to start downloading the broadcast.
-	// Defaults to false so you can make sure everything is ready before starting.
+	// Whether to start downloading the broadcast. Defaults to true.
 	enabled: Getter<boolean>;
 
 	// The broadcast name.
@@ -119,7 +118,7 @@ export class Broadcast {
 		this.in = {
 			origin: getter(props?.origin),
 			name: getter(props?.name ?? Path.empty()),
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 			reload: getter(props?.reload ?? true),
 			catalogFormat: getter<CatalogFormat | undefined>(props?.catalogFormat),
 			catalog: getter(props?.catalog),

--- a/js/watch/src/enabled.test.ts
+++ b/js/watch/src/enabled.test.ts
@@ -1,0 +1,43 @@
+import { expect, mock, test } from "bun:test";
+
+// Bun cannot load the blob-URL worklet import used by the audio decoder. This default-input test
+// never creates an AudioContext or reaches the worklet implementation.
+mock.module("./audio/render-worklet.ts?worklet", () => ({ default: "blob:fake-render" }));
+
+const Watch = await import("./index");
+
+type Mode = "omitted" | boolean | undefined;
+
+function inputs(mode: Mode): { enabled?: boolean } | undefined {
+	return mode === "omitted" ? undefined : { enabled: mode };
+}
+
+function enabled(mode: Mode): boolean[] {
+	const sync = new Watch.Sync();
+	const audioSource = new Watch.Audio.Source();
+	const videoSource = new Watch.Video.Source();
+	const textSource = new Watch.Text.Source();
+	const props = inputs(mode);
+	const components = [
+		new Watch.Broadcast(props),
+		new Watch.Audio.Decoder(audioSource, sync, props),
+		new Watch.Video.Decoder(videoSource, sync, props),
+		new Watch.Text.Renderer(textSource, sync, props),
+	];
+
+	try {
+		return components.map((component) => component.in.enabled.peek());
+	} finally {
+		for (const component of components) component.close();
+		audioSource.close();
+		videoSource.close();
+		textSource.close();
+		sync.close();
+	}
+}
+
+test("standalone components default enabled", () => {
+	expect(enabled("omitted")).toEqual([true, true, true, true]);
+	expect(enabled(undefined)).toEqual([true, true, true, true]);
+	expect(enabled(false)).toEqual([false, false, false, false]);
+});

--- a/js/watch/src/text/renderer.ts
+++ b/js/watch/src/text/renderer.ts
@@ -160,7 +160,7 @@ export type RendererInput = {
 	// which positions it over the video canvas.
 	container: Getter<HTMLElement | undefined>;
 
-	// Whether to subscribe and render. The parent gates this (e.g. on connection).
+	// Whether to subscribe and render. Defaults to true; the parent may gate this (e.g. on connection).
 	enabled: Getter<boolean>;
 };
 
@@ -188,7 +188,7 @@ export class Renderer {
 		this.sync = sync;
 		this.in = {
 			container: getter(props?.container),
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 		};
 
 		this.#signals.run(this.#run.bind(this));

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -15,7 +15,7 @@ import type { Source } from "./source";
 const BUFFERING = Time.Milli(500);
 
 export type DecoderInput = {
-	// Whether to download the video track. Wired from the renderer's output by the parent.
+	// Whether to download the video track. Defaults to true; the parent may wire it from the renderer's output.
 	enabled: Getter<boolean>;
 };
 
@@ -86,7 +86,7 @@ export class Decoder {
 
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
 		this.in = {
-			enabled: getter(props?.enabled ?? false),
+			enabled: getter(props?.enabled ?? true),
 		};
 
 		this.source = source;


### PR DESCRIPTION
## Summary

- Default omitted or explicitly undefined `enabled` inputs to `true` across standalone connection, watch, and publish components.
- Preserve explicit `false` behavior and reactive signal teardown and restart semantics.
- Keep the high-level watch and publish web components unchanged because they already provide explicit lifecycle signals.
- Preserve MoQ Boy's pause and mute download gating through an explicit decoder enable signal.
- Document immediate camera and microphone permission requests and the screen-capture user-gesture requirement.
- Add regression coverage for omitted, undefined, and false inputs, including capture side effects.

## User impact

Standalone components now start work without `enabled: true` boilerplate. Constructing camera, microphone, or screen sources without an explicit false input can immediately request capture, so screen sources must be constructed during the authorizing gesture or enabled later through a live signal.

This is a breaking behavior change targeting `dev`. JavaScript package-version bumps are intentionally deferred.

## Validation

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test`
- `nix develop --command bun test js/net/src/connection/reload.test.ts js/watch/src/enabled.test.ts js/publish/src/enabled.test.ts`
- `nix develop --command bun test js/moq-boy/src/game.test.ts`

Closes #1238

(Written by GPT-5)
