### PR TITLE
fix(relay): redial reconfigured cluster peers

### DIFF
--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -95,25 +95,25 @@ connect_api = "https://api.example.com/cluster/connect"
 node        = "us-west.example.com:4443"
 ```
 
-The source returns a bare JSON array of peer hostnames:
+The source returns a JSON array of peer URLs. Legacy bare hosts remain accepted:
 
 ```json
-["eu-west.example.com:4443", "us-east.example.com:4443"]
+["https://eu-west.example.com/?cost=10", "us-east.example.com:4443"]
 ```
 
-The relay reconciles that list against its live dials: new entries are dialed, entries that disappear are dropped. It composes with `connect` (static seeds that are never reconciled away) and `mesh` (gossip). The relay's own `node` value, when set, is sent as a `?node=` query parameter so the endpoint can return the peers for that specific node; for mTLS-gated endpoints the cluster client certificate identifies the caller as well.
+The relay reconciles that list against its live dials: new entries are dialed, entries that disappear are dropped, and a changed URL for a `connect_api`-owned peer replaces its session. That includes dial-side inputs such as `?cost=` and an inline `?jwt=`. An identical render is a no-op. It composes with `connect` (static seeds that are never reconciled away) and `mesh` (gossip). If another source already owns a peer's session, the API entry remains its updated fallback until that source disappears. The relay's own `node` value, when set, is sent as a `?node=` query parameter so the endpoint can return the peers for that specific node; for mTLS-gated endpoints the cluster client certificate identifies the caller as well.
 
 - **HTTP(S) URL**: re-checked every 30s, but freshness is delegated to a standard HTTP cache (`http-cache`), so the response's `Cache-Control` controls how often a check turns into a real fetch. While the cached list is still fresh (`max-age`), the re-check is served from cache with no network round-trip; once it's stale the cache issues a conditional GET (`ETag` / `Last-Modified`) and falls back to the last cached body if revalidation fails (stale-if-error). Set a longer `max-age` to reduce load on your endpoint, or `no-cache` to force a conditional GET on every tick. Transient endpoint blips don't churn the dial set.
 - **Local file** (a path or `file://` URL): watched via OS filesystem notifications (inotify / FSEvents / kqueue), with a periodic re-check as a safety net.
 
-If a fetch fails or returns garbage, the relay logs and keeps the last good list rather than tearing the cluster down. This keeps the moq-relay binary generic: all routing decisions (which node connects where) live in whatever service answers the endpoint.
+If a fetch fails, an entry is invalid, or one identity has conflicting entries, the relay logs and keeps the entire last good list rather than applying a partial topology. This keeps the moq-relay binary generic: all routing decisions (which node connects where) live in whatever service answers the endpoint.
 
 ## Authentication
 
 Cluster peers must authenticate to each other:
 
 - **mTLS** (recommended). Set `tls.root` to the CA that signed the cluster certificates. Inbound connections presenting a valid client cert are granted full access; outbound dials use `client.tls.cert` / `client.tls.key`.
-- **JWT**. For static `connect` peers, supply the token inline as a `?jwt=` query parameter on the URL. For gossip- and `connect_api`-discovered peers (whose addresses can't carry an inline token), set `cluster.token` to a file holding the JWT; it's presented on any dial whose URL has no inline `?jwt=` (so an inline token wins per-peer). Either way the token needs broad enough scope to cover whatever paths the cluster carries.
+- **JWT**. Supply a per-peer token inline as a `?jwt=` query parameter on a static or `connect_api` URL. Alternatively, set `cluster.token` to a file holding the shared JWT; it is presented on any dial whose URL has no inline token. Gossip must use the shared token or mTLS: never put a JWT in `cluster.node`, because that URL is advertised to the mesh and written to logs. Either way the token needs broad enough scope to cover whatever paths the cluster carries.
 
 See [Authentication](/bin/relay/auth) for the full setup.
 
@@ -127,7 +127,7 @@ peer stays loudly visible in the logs and a returning one is picked up within se
 
 `cluster.root` was removed. To dial cluster peers use `cluster.connect`; to advertise this relay's own address set `cluster.node` and enable `cluster.mesh`. `cluster.mesh` is now a boolean gossip toggle (it used to take this relay's URL); the URL moved to `cluster.node`. The old `mesh = "<url>"` form still works for backwards compatibility: it enables gossip and is treated as `cluster.node`, with a deprecation warning (or an error if it conflicts with an explicit `cluster.node`).
 
-`cluster.connect` entries are now full URLs; a bare host or `host:port` still works but logs a deprecation warning. A JWT for a static peer belongs inline as a `?jwt=` query parameter (the `cluster.token` file remains for gossip / `connect_api` peers, which can't carry an inline token).
+`cluster.connect` entries are now full URLs; a bare host or `host:port` still works but logs a deprecation warning. A per-peer JWT belongs inline as a `?jwt=` query parameter on a static or `connect_api` URL. The `cluster.token` file remains the shared fallback and is required for JWT-authenticated gossip; never put a JWT in the advertised `cluster.node` URL.
 
 | Old | New |
 |---|---|

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -186,12 +186,14 @@ node = "us-west.example.com:4443"
 mesh = true
 
 # Optional. Fetch the peer list from an HTTP(S) endpoint or local file (a JSON
-# array of hostnames) and reconcile it at runtime, no restart needed.
+# array of peer URLs) and reconcile it at runtime, replacing sessions when URL
+# configuration such as ?cost= or ?jwt= changes.
 connect_api = "https://api.example.com/cluster/connect"
 
 # JWT for outbound cluster dials (alternative to mTLS), applied to any peer
-# whose URL has no inline ?jwt=. Required to authenticate gossip / connect_api
-# discovered peers; for static `connect` peers, prefer an inline ?jwt=.
+# whose URL has no inline ?jwt=. An inline token works for static and
+# connect_api-discovered peers. Gossip must use this shared token or mTLS because
+# the advertised cluster.node URL is public.
 token = "cluster.jwt"
 
 # Optional. How long a broadcast stays alive and announced after abruptly

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -1,5 +1,5 @@
 use std::{
-	collections::{HashMap, HashSet},
+	collections::HashMap,
 	path::PathBuf,
 	sync::{
 		Arc, Mutex,
@@ -51,6 +51,94 @@ fn should_dial(self_url: &str, peer: &str) -> bool {
 	peer > self_url
 }
 
+/// One peer's stable identity and the dial-affecting configuration currently
+/// supplied by a discovery source.
+#[derive(Clone, PartialEq, Eq)]
+struct DialTarget {
+	key: String,
+	url: Url,
+	cost: Option<u64>,
+}
+
+impl DialTarget {
+	fn parse(peer: &str) -> anyhow::Result<Self> {
+		let mut url = peer_url(peer)?;
+		let key = {
+			let mut identity = url.clone();
+			identity.set_query(None);
+			identity.into()
+		};
+		let cost = take_cost(&mut url)?;
+		Ok(Self { key, url, cost })
+	}
+}
+
+/// Every currently-live gossip path for a canonical peer, in announcement order.
+/// Query changes create a new path before the old path necessarily unannounces,
+/// so the latest live path owns the dial configuration.
+#[derive(Default)]
+struct GossipTargets {
+	by_key: HashMap<String, Vec<(String, DialTarget)>>,
+}
+
+enum GossipUpdate {
+	/// The current advertisement changed to this target.
+	Current(DialTarget),
+	/// A non-current or unknown advertisement disappeared.
+	Unchanged,
+	/// The peer has no live advertisements left.
+	Gone,
+}
+
+impl GossipTargets {
+	fn announce(&mut self, advertisement: String, target: DialTarget) -> DialTarget {
+		let targets = self.by_key.entry(target.key.clone()).or_default();
+		targets.retain(|(existing, _)| existing != &advertisement);
+		targets.push((advertisement, target.clone()));
+		target
+	}
+
+	fn unannounce(&mut self, advertisement: &str, key: &str) -> GossipUpdate {
+		let Some(targets) = self.by_key.get_mut(key) else {
+			return GossipUpdate::Unchanged;
+		};
+		let was_current = targets.last().is_some_and(|(current, _)| current == advertisement);
+		let previous_len = targets.len();
+		targets.retain(|(existing, _)| existing != advertisement);
+		if targets.len() == previous_len {
+			return GossipUpdate::Unchanged;
+		}
+		if targets.is_empty() {
+			self.by_key.remove(key);
+			return GossipUpdate::Gone;
+		}
+		if was_current {
+			return GossipUpdate::Current(targets.last().expect("live target exists").1.clone());
+		}
+		GossipUpdate::Unchanged
+	}
+}
+
+/// Parse a complete dynamic peer list before mutating the live dial set. A bad
+/// entry or conflicting duplicate rejects the whole update, preserving the
+/// last-known-good topology.
+fn parse_peer_list(list: Vec<String>, node: Option<&str>) -> anyhow::Result<HashMap<String, DialTarget>> {
+	let self_key = node.map(canonicalize_peer_key);
+	let mut desired = HashMap::new();
+	for (index, peer) in list.into_iter().enumerate() {
+		let target = DialTarget::parse(&peer).with_context(|| format!("invalid peer at index {index}"))?;
+		if Some(&target.key) == self_key.as_ref() {
+			continue;
+		}
+		if let Some(previous) = desired.insert(target.key.clone(), target.clone())
+			&& previous != target
+		{
+			anyhow::bail!("peer identity {} has conflicting configurations", target.key);
+		}
+	}
+	Ok(desired)
+}
+
 /// A mechanism that wants a dial kept alive. A single peer can be wanted by more
 /// than one at once (e.g. gossiped *and* listed by `--cluster-connect-api`), so
 /// [`DialEntry`] tracks a set of these and only tears the dial down when the last
@@ -69,32 +157,44 @@ enum DialSource {
 }
 
 /// The set of [`DialSource`]s currently keeping a dial alive.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 struct DialSources {
-	seeded: bool,
-	gossip: bool,
-	api: bool,
+	seeded: Option<DialTarget>,
+	gossip: Option<DialTarget>,
+	api: Option<DialTarget>,
 }
 
 impl DialSources {
-	fn set(&mut self, source: DialSource) {
+	fn get(&self, source: DialSource) -> Option<&DialTarget> {
 		match source {
-			DialSource::Static => self.seeded = true,
-			DialSource::Gossip => self.gossip = true,
-			DialSource::Api => self.api = true,
+			DialSource::Static => self.seeded.as_ref(),
+			DialSource::Gossip => self.gossip.as_ref(),
+			DialSource::Api => self.api.as_ref(),
+		}
+	}
+
+	fn set(&mut self, source: DialSource, target: DialTarget) {
+		match source {
+			DialSource::Static => self.seeded = Some(target),
+			DialSource::Gossip => self.gossip = Some(target),
+			DialSource::Api => self.api = Some(target),
 		}
 	}
 
 	fn clear(&mut self, source: DialSource) {
 		match source {
-			DialSource::Static => self.seeded = false,
-			DialSource::Gossip => self.gossip = false,
-			DialSource::Api => self.api = false,
+			DialSource::Static => self.seeded = None,
+			DialSource::Gossip => self.gossip = None,
+			DialSource::Api => self.api = None,
 		}
 	}
 
-	fn any(&self) -> bool {
-		self.seeded || self.gossip || self.api
+	fn fallback(&self) -> Option<(DialSource, &DialTarget)> {
+		self.seeded
+			.as_ref()
+			.map(|target| (DialSource::Static, target))
+			.or_else(|| self.api.as_ref().map(|target| (DialSource::Api, target)))
+			.or_else(|| self.gossip.as_ref().map(|target| (DialSource::Gossip, target)))
 	}
 }
 
@@ -104,10 +204,11 @@ impl DialSources {
 struct DialEntry {
 	handle: AbortHandle,
 	sources: DialSources,
+	active: DialSource,
 	unannounced_at: Option<Instant>,
 }
 
-/// Map of in-flight cluster dials, keyed by peer URL. Cloneable: the inner
+/// Map of in-flight cluster dials, keyed by canonical peer identity. Cloneable: the inner
 /// map is shared via `Arc<Mutex<_>>` so the discovery task and the static-seed
 /// phase write to the same set of entries.
 #[derive(Clone, Default)]
@@ -121,43 +222,80 @@ impl DialMap {
 		self.inner.lock().expect("dial map poisoned").contains_key(peer)
 	}
 
-	/// Record a freshly-spawned dial for `peer` under `source`. If `peer` is
-	/// already dialed, add `source` to its set and abort the redundant `handle`
-	/// (the existing dial stands, since dialing dedupes by URL). Always spawn the
-	/// task first, then call this: it resolves the "two sources discover the same
-	/// peer at once" race without leaking a task.
-	fn insert(&self, peer: String, handle: AbortHandle, source: DialSource) {
-		let mut map = self.inner.lock().expect("dial map poisoned");
-		if let Some(entry) = map.get_mut(&peer) {
-			entry.sources.set(source);
-			if source == DialSource::Gossip {
-				entry.unannounced_at = None;
-			}
-			drop(map);
+	/// Record an already-spawned dial under `source`. If the source is redundant,
+	/// abort its task instead of leaking a second session.
+	fn insert(&self, target: DialTarget, handle: AbortHandle, source: DialSource) {
+		let mut handle = Some(handle);
+		self.upsert(target, source, &mut |_| handle.take().expect("dial handle used once"));
+		if let Some(handle) = handle {
 			handle.abort();
-		} else {
-			let mut sources = DialSources::default();
-			sources.set(source);
-			map.insert(
-				peer,
-				DialEntry {
-					handle,
-					sources,
-					unannounced_at: None,
-				},
-			);
 		}
 	}
 
-	/// Add `source` to an already-dialed `peer` (no-op if absent). Used when a
-	/// peer reached via one source is also discovered via another, without opening
-	/// a second dial. Adding [`DialSource::Gossip`] also clears any pending
-	/// unannounce; returns whether such a timestamp was cleared (a reannounce).
-	fn add_source(&self, peer: &str, source: DialSource) -> bool {
+	/// Add or update one source's target, replacing the live dial only when that
+	/// source already owns it. Other sources retain their latest target as a
+	/// fallback without changing the first source's active configuration.
+	fn upsert<F>(&self, target: DialTarget, source: DialSource, spawn: &mut F) -> bool
+	where
+		F: FnMut(DialTarget) -> AbortHandle,
+	{
 		let mut map = self.inner.lock().expect("dial map poisoned");
-		let Some(entry) = map.get_mut(peer) else { return false };
-		entry.sources.set(source);
-		source == DialSource::Gossip && entry.unannounced_at.take().is_some()
+		if let Some(entry) = map.get_mut(&target.key) {
+			let replace = entry.active == source && entry.sources.get(source) != Some(&target);
+			entry.sources.set(source, target.clone());
+			let reannounced = source == DialSource::Gossip && entry.unannounced_at.take().is_some();
+			if replace {
+				entry.handle.abort();
+				entry.handle = spawn(target);
+			}
+			return reannounced;
+		}
+
+		let key = target.key.clone();
+		let handle = spawn(target.clone());
+		let mut sources = DialSources::default();
+		sources.set(source, target);
+		map.insert(
+			key,
+			DialEntry {
+				handle,
+				sources,
+				active: source,
+				unannounced_at: None,
+			},
+		);
+		false
+	}
+
+	/// Release one source. If it owned the live dial, switch to a remaining
+	/// source's latest target or abandon the peer when no source remains.
+	fn release<F>(&self, peer: &str, source: DialSource, spawn: &mut F)
+	where
+		F: FnMut(DialTarget) -> AbortHandle,
+	{
+		let mut map = self.inner.lock().expect("dial map poisoned");
+		let Some(entry) = map.get_mut(peer) else { return };
+		if entry.sources.get(source).is_none() {
+			return;
+		}
+		let active_target = entry.sources.get(source).cloned();
+		entry.sources.clear(source);
+		if entry.active != source {
+			return;
+		}
+
+		if let Some((next_source, next_target)) = entry.sources.fallback() {
+			let next_target = next_target.clone();
+			entry.active = next_source;
+			if active_target.as_ref() != Some(&next_target) {
+				entry.handle.abort();
+				entry.handle = spawn(next_target);
+			}
+			return;
+		}
+
+		let entry = map.remove(peer).expect("entry exists");
+		entry.handle.abort();
 	}
 
 	/// Start the gossip stale timer on `peer` if it isn't already pending. No-op
@@ -166,7 +304,7 @@ impl DialMap {
 	fn mark_unannounced(&self, peer: &str, now: Instant) {
 		let mut map = self.inner.lock().expect("dial map poisoned");
 		if let Some(entry) = map.get_mut(peer)
-			&& entry.sources.gossip
+			&& entry.sources.gossip.is_some()
 		{
 			entry.unannounced_at.get_or_insert(now);
 		}
@@ -174,60 +312,49 @@ impl DialMap {
 
 	/// Release the gossip source from entries whose unannounce has stuck for at
 	/// least `threshold`, aborting the dial only if no other source still wants it.
-	fn sweep_stale(&self, now: Instant, threshold: Duration) {
+	fn sweep_stale<F>(&self, now: Instant, threshold: Duration, spawn: &mut F)
+	where
+		F: FnMut(DialTarget) -> AbortHandle,
+	{
 		let mut map = self.inner.lock().expect("dial map poisoned");
-		map.retain(|peer, entry| {
-			let Some(at) = entry.unannounced_at else { return true };
-			if now.duration_since(at) < threshold {
-				return true;
-			}
-			entry.unannounced_at = None;
-			entry.sources.clear(DialSource::Gossip);
-			if entry.sources.any() {
-				tracing::debug!(%peer, "peer no longer gossiped; still wanted by another source");
-				true
-			} else {
-				tracing::info!(%peer, "peer no longer gossiped; abandoning dial");
-				entry.handle.abort();
-				false
-			}
-		});
+		let expired: Vec<String> = map
+			.iter_mut()
+			.filter_map(|(peer, entry)| {
+				let at = entry.unannounced_at?;
+				(now.duration_since(at) >= threshold).then(|| {
+					entry.unannounced_at = None;
+					peer.clone()
+				})
+			})
+			.collect();
+		drop(map);
+
+		for peer in expired {
+			self.release(&peer, DialSource::Gossip, spawn);
+		}
 	}
 
-	/// Reconcile the API source against `desired`: release [`DialSource::Api`] from
-	/// entries no longer listed (aborting only those nothing else wants), mark the
-	/// API source on already-dialed peers that are listed, and return the desired
-	/// peers not yet dialed (the caller spawns those and re-inserts them).
-	fn reconcile_api(&self, desired: &HashSet<String>) -> Vec<String> {
-		let mut map = self.inner.lock().expect("dial map poisoned");
+	/// Reconcile the API source against `desired`, including changes to a peer's
+	/// dial-affecting URL or link cost while its canonical identity stays fixed.
+	fn reconcile_api<F>(&self, desired: &HashMap<String, DialTarget>, mut spawn: F)
+	where
+		F: FnMut(DialTarget) -> AbortHandle,
+	{
+		for target in desired.values() {
+			self.upsert(target.clone(), DialSource::Api, &mut spawn);
+		}
 
-		// One mutable pass: set the API source on listed peers, release it from the
-		// rest (aborting only those nothing else wants).
-		map.retain(|peer, entry| {
-			if desired.contains(peer) {
-				entry.sources.set(DialSource::Api);
-				return true;
-			}
-			if !entry.sources.api {
-				return true;
-			}
-			entry.sources.clear(DialSource::Api);
-			if entry.sources.any() {
-				tracing::debug!(%peer, "peer dropped from cluster-connect-api; still wanted by another source");
-				true
-			} else {
-				tracing::info!(%peer, "peer dropped from cluster-connect-api; abandoning dial");
-				entry.handle.abort();
-				false
-			}
-		});
-
-		// Whatever's left in `desired` but absent from the map needs a fresh dial.
-		desired
+		let removed: Vec<String> = self
+			.inner
+			.lock()
+			.expect("dial map poisoned")
 			.iter()
-			.filter(|peer| !map.contains_key(*peer))
-			.cloned()
-			.collect()
+			.filter(|(peer, entry)| entry.sources.api.is_some() && !desired.contains_key(*peer))
+			.map(|(peer, _)| peer.clone())
+			.collect();
+		for peer in removed {
+			self.release(&peer, DialSource::Api, &mut spawn);
+		}
 	}
 }
 
@@ -280,7 +407,7 @@ pub struct ClusterConfig {
 
 	/// Fetch the list of peers to dial from an HTTP(S) URL or a local file,
 	/// reloading at runtime without a restart. The source returns a JSON array
-	/// of peer hostnames: `["a.pop.example", "b.pop.example"]`. An http(s) URL is
+	/// of peer URLs: `["https://a.pop.example/?cost=1", "b.pop.example"]`. An http(s) URL is
 	/// re-checked on a fixed cadence, with caching, conditional revalidation
 	/// (`ETag` / `Last-Modified`), and stale-if-error handled by the shared HTTP
 	/// cache client, so the response's `Cache-Control` controls how often a real
@@ -325,8 +452,9 @@ pub struct ClusterConfig {
 
 	/// JWT presented on outbound cluster dials, read from this file. Applied to
 	/// any peer whose URL doesn't already carry a `?jwt=` (so it authenticates
-	/// gossip- and `connect_api`-discovered peers, whose addresses can't embed a
-	/// token). For static `--cluster-connect` peers, prefer an inline `?jwt=`.
+	/// any peer whose URL has no inline token). An inline `?jwt=` can provide a
+	/// per-peer credential for static or `connect_api` peers. Gossip should use
+	/// this shared token or mTLS because the advertised node URL is public.
 	#[arg(id = "cluster-token", long = "cluster-token", env = "MOQ_CLUSTER_TOKEN")]
 	pub token: Option<PathBuf>,
 
@@ -577,9 +705,8 @@ impl Cluster {
 		}
 
 		// Token presented on outbound dials whose URL doesn't already carry a
-		// `?jwt=`. This is how gossip- and connect_api-discovered peers (whose
-		// addresses can't carry an inline token) authenticate, so it isn't
-		// deprecated; for static `connect` peers, an inline `?jwt=` is preferred.
+		// `?jwt=`. This remains the shared credential for any peer without a
+		// per-peer inline token.
 		let token = match &self.config.token {
 			Some(path) => std::fs::read_to_string(path)
 				.context("failed to read cluster token")?
@@ -590,7 +717,7 @@ impl Cluster {
 
 		// Static `--cluster-connect` peers and gossip-discovered peers share one
 		// dial map so a peer reached via both paths only opens a single dial.
-		// Gossip-driven unannounces don't abort immediately — the discovery loop
+		// Gossip-driven unannounces don't abort immediately. The discovery loop
 		// runs a periodic sweep that only aborts entries whose unannounce has
 		// stuck for [`STALE_AFTER`]. That filters out the prefer-shorter-hop flap
 		// (sub-millisecond unannounce-then-announce) while still cleaning up
@@ -599,8 +726,8 @@ impl Cluster {
 		let mut tasks = tokio::task::JoinSet::new();
 
 		for peer in &self.config.connect {
-			let key = canonicalize_peer_key(peer);
-			if dialed.contains(&key) {
+			let target = DialTarget::parse(peer).context("invalid --cluster-connect peer URL")?;
+			if dialed.contains(&target.key) {
 				continue;
 			}
 			if is_legacy_peer(peer) {
@@ -612,13 +739,9 @@ impl Cluster {
 			}
 			let this = self.clone();
 			let token = token.clone();
-			let peer_for_task = peer.clone();
-			let handle = tasks.spawn(async move {
-				if let Err(err) = this.run_remote(&peer_for_task, token).await {
-					tracing::warn!(%err, peer = %peer_for_task, "cluster peer connection ended");
-				}
-			});
-			dialed.insert(key, handle, DialSource::Static);
+			let peer_for_task = target.clone();
+			let handle = tasks.spawn(this.supervise_remote(peer_for_task, token));
+			dialed.insert(target, handle, DialSource::Static);
 		}
 
 		if let Some(source) = self.config.connect_api.clone() {
@@ -696,6 +819,7 @@ impl Cluster {
 			return;
 		};
 		let mut announced = consumer.announced();
+		let mut live = GossipTargets::default();
 
 		let mut sweep = tokio::time::interval(SWEEP_INTERVAL);
 		sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -709,41 +833,50 @@ impl Cluster {
 					// The address to dial, which keeps its query: `run_remote` reads
 					// `?cost=` and `?jwt=` off it. The key is only its identity.
 					let peer = advertised_node_url(relative.as_str());
-					let key = canonicalize_peer_key(&peer);
+					let target = match DialTarget::parse(&peer) {
+						Ok(target) => target,
+						Err(err) => {
+							tracing::warn!(%err, "invalid gossiped cluster peer URL; ignoring update");
+							continue;
+						}
+					};
 					// Skip self and any peer we lose the tiebreaker to; that side
 					// dials us instead, so each pair forms a single session.
-					if !should_dial(&self_url, &key) {
+					if !should_dial(&self_url, &target.key) {
 						continue;
 					}
+					let advertisement = relative.as_str().to_owned();
 					match broadcast {
 						Some(_) => {
-							if dialed.contains(&key) {
-								// Already dialed (possibly via another source). Mark gossip as
-								// a wanter and cancel any pending stale-sweep.
-								if dialed.add_source(&key, DialSource::Gossip) {
-									tracing::debug!(peer = %key, "reannounce within sweep window; keeping dial");
-								}
-								continue;
+							let target = live.announce(advertisement, target);
+							let mut spawn = |target: DialTarget| {
+								tracing::info!(peer = %target.key, "discovered cluster peer; dialing");
+								tokio::spawn(self.clone().supervise_remote(target, token.clone())).abort_handle()
+							};
+							let key = target.key.clone();
+							if dialed.upsert(target, DialSource::Gossip, &mut spawn) {
+								tracing::debug!(peer = %key, "reannounce within sweep window; keeping dial");
 							}
-							tracing::info!(peer = %key, "discovered cluster peer; dialing");
-							let this = self.clone();
-							let token = token.clone();
-							// Logged by key, never `peer`, so an inline jwt stays out of the logs.
-							let log_peer = key.clone();
-							let handle = tokio::spawn(async move {
-								if let Err(err) = this.run_remote(&peer, token).await {
-									tracing::warn!(%err, peer = %log_peer, "cluster peer connection ended");
-								}
-							});
-							dialed.insert(key, handle.abort_handle(), DialSource::Gossip);
 						}
-						None => {
-							dialed.mark_unannounced(&key, Instant::now());
-						}
+						None => match live.unannounce(&advertisement, &target.key) {
+							GossipUpdate::Current(target) => {
+								let mut spawn = |target: DialTarget| {
+									tracing::info!(peer = %target.key, "cluster peer advertisement changed; redialing");
+									tokio::spawn(self.clone().supervise_remote(target, token.clone())).abort_handle()
+								};
+								dialed.upsert(target, DialSource::Gossip, &mut spawn);
+							}
+							GossipUpdate::Unchanged => {}
+							GossipUpdate::Gone => dialed.mark_unannounced(&target.key, Instant::now()),
+						},
 					}
 				}
 				_ = sweep.tick() => {
-					dialed.sweep_stale(Instant::now(), STALE_AFTER);
+					let mut spawn = |target: DialTarget| {
+						tracing::info!(peer = %target.key, "cluster peer source changed; redialing");
+						tokio::spawn(self.clone().supervise_remote(target, token.clone())).abort_handle()
+					};
+					dialed.sweep_stale(Instant::now(), STALE_AFTER, &mut spawn);
 				}
 			}
 		}
@@ -751,7 +884,7 @@ impl Cluster {
 
 	/// Drive `--cluster-connect-api`: an http(s) URL is polled, a local path (or
 	/// `file://` URL) is watched for changes. Either way the source yields a JSON
-	/// array of peer hostnames that's reconciled into the shared dial map.
+	/// array of peer URLs that's reconciled into the shared dial map.
 	async fn run_connect_api(self, source: String, node: Option<String>, token: String, dialed: DialMap) {
 		match Url::parse(&source) {
 			Ok(url) if matches!(url.scheme(), "http" | "https") => {
@@ -867,50 +1000,45 @@ impl Cluster {
 			.await
 			.context("failed to read cluster.connect_api body")?;
 
-		serde_json::from_str(&body).context("cluster.connect_api response is not a JSON array of hostnames")
+		serde_json::from_str(&body).context("cluster.connect_api response is not a JSON array of peer URLs")
 	}
 
 	/// Reconcile a freshly fetched peer list into the dial map: dial peers that
 	/// are new and drop API peers that disappeared. The relay's own [`node`] URL
 	/// is filtered out so it never dials itself.
 	fn apply_peer_list(&self, list: Vec<String>, node: &Option<String>, token: &str, dialed: &DialMap) {
-		// Dedupe against the shared dial map (and filter out self) on the canonical
-		// key, so an API entry matches the same peer reached via `connect`/gossip
-		// regardless of how each spells it. reconcile_api then yields canonical keys.
-		let self_key = node.as_deref().map(canonicalize_peer_key);
-		let desired: HashSet<String> = list
-			.into_iter()
-			.map(|peer| canonicalize_peer_key(&peer))
-			.filter(|key| Some(key) != self_key.as_ref())
-			.collect();
+		// Dedupe against the shared dial map (and filter out self) on stable identity,
+		// while retaining the full dial configuration so a cost or credential update
+		// replaces the existing session.
+		let desired = match parse_peer_list(list, node.as_deref()) {
+			Ok(desired) => desired,
+			Err(err) => {
+				tracing::warn!(%err, "invalid cluster.connect_api peer list; keeping current peers");
+				return;
+			}
+		};
 
-		for peer in dialed.reconcile_api(&desired) {
-			tracing::info!(%peer, "cluster.connect_api peer; dialing");
-			let this = self.clone();
-			let token = token.to_string();
-			let peer_for_task = peer.clone();
-			let handle = tokio::spawn(async move {
-				if let Err(err) = this.run_remote(&peer_for_task, token).await {
-					tracing::warn!(%err, peer = %peer_for_task, "cluster peer connection ended");
-				}
-			});
-			dialed.insert(peer, handle.abort_handle(), DialSource::Api);
+		dialed.reconcile_api(&desired, |target| {
+			tracing::info!(peer = %target.key, "cluster.connect_api peer; dialing");
+			let handle = tokio::spawn(self.clone().supervise_remote(target, token.to_string()));
+			handle.abort_handle()
+		});
+	}
+
+	async fn supervise_remote(self, target: DialTarget, token: String) {
+		let log_peer = target.key.clone();
+		if let Err(err) = self.run_remote(&target, token).await {
+			tracing::warn!(%err, peer = %log_peer, "cluster peer connection ended");
 		}
 	}
 
-	#[tracing::instrument("remote", skip_all, err, fields(%remote))]
-	async fn run_remote(self, remote: &str, token: String) -> anyhow::Result<()> {
-		let mut url = peer_url(remote)?;
-		// The link's price, declared by us as the dialing side and charged to
-		// every announcement crossing the connection (see
-		// `moq_net::Client::with_cost`). Carried as a `?cost=` query
-		// param on the peer URL so static lists, gossip, and connect-api feeds can
-		// each price their links: 0 for a same-datacenter sibling, higher for a
-		// metered backbone. Stripped here; the value rides SETUP, not the URL.
-		let cost = take_cost(&mut url)?;
+	#[tracing::instrument("remote", skip_all, err, fields(remote = %target.key))]
+	async fn run_remote(self, target: &DialTarget, token: String) -> anyhow::Result<()> {
+		let mut url = target.url.clone();
+		let cost = target.cost;
 		// Apply the shared cluster token unless the URL already carries its own
-		// non-empty `?jwt=` (an inline token on a static `connect` peer wins; the
-		// shared token still covers discovered peers that have none). An empty
+		// non-empty `?jwt=` (a per-peer inline token wins; the shared token still
+		// covers peers that have none). An empty
 		// `?jwt=` counts as absent, matching `AuthParams::from_url`.
 		if !token.is_empty() && !url.query_pairs().any(|(key, value)| key == "jwt" && !value.is_empty()) {
 			url.query_pairs_mut().append_pair("jwt", &token);
@@ -1078,10 +1206,10 @@ fn peer_url(peer: &str) -> anyhow::Result<Url> {
 	// A full URL has a scheme separator; a bare host or `host:port` does not
 	// (and `Url::parse` would otherwise mis-read `host:port` as scheme `host`).
 	if peer.contains("://") {
-		return Url::parse(peer).with_context(|| format!("invalid cluster peer URL: {peer}"));
+		return Url::parse(peer).context("invalid cluster peer URL");
 	}
 
-	Url::parse(&format!("https://{peer}/")).with_context(|| format!("invalid cluster peer host: {peer}"))
+	Url::parse(&format!("https://{peer}/")).context("invalid cluster peer host")
 }
 
 /// The address to dial for a node advertised under `MESH_PREFIX`.
@@ -1248,16 +1376,64 @@ mod tests {
 		tokio::spawn(std::future::pending::<()>()).abort_handle()
 	}
 
+	fn target(key: &str) -> DialTarget {
+		DialTarget {
+			key: key.to_string(),
+			url: Url::parse(&format!("https://{key}/")).expect("test URL"),
+			cost: None,
+		}
+	}
+
+	fn desired(keys: &[&str]) -> HashMap<String, DialTarget> {
+		keys.iter().map(|key| ((*key).to_string(), target(key))).collect()
+	}
+
+	/// A query change creates a new gossip path before the old path necessarily
+	/// unannounces. Removing that old path must not stale the replacement.
+	#[test]
+	fn gossip_old_unannounce_keeps_new_target() {
+		let mut live = GossipTargets::default();
+		let old = DialTarget::parse("https://peer.example/?cost=1").unwrap();
+		let new = DialTarget::parse("https://peer.example/?cost=2").unwrap();
+		live.announce("peer.example/?cost=1".to_string(), old.clone());
+		live.announce("peer.example/?cost=2".to_string(), new.clone());
+
+		assert!(matches!(
+			live.unannounce("peer.example/?cost=1", &old.key),
+			GossipUpdate::Unchanged
+		));
+		assert!(matches!(
+			live.unannounce("peer.example/?cost=2", &new.key),
+			GossipUpdate::Gone
+		));
+	}
+
+	/// If the current gossip path disappears while an older one is still live,
+	/// the remaining target becomes current again.
+	#[test]
+	fn gossip_current_unannounce_restores_live_fallback() {
+		let mut live = GossipTargets::default();
+		let old = DialTarget::parse("https://peer.example/?cost=1").unwrap();
+		let new = DialTarget::parse("https://peer.example/?cost=2").unwrap();
+		live.announce("peer.example/?cost=1".to_string(), old.clone());
+		live.announce("peer.example/?cost=2".to_string(), new.clone());
+
+		let GossipUpdate::Current(current) = live.unannounce("peer.example/?cost=2", &new.key) else {
+			panic!("older live advertisement must become current");
+		};
+		assert!(current == old);
+	}
+
 	/// `mark_unannounced` is a no-op for static peers (operator intent says
 	/// "always dial"), so the sweep never has a stale timestamp to act on.
 	#[tokio::test]
 	async fn sweep_preserves_static_peer() {
 		let dialed = DialMap::default();
-		dialed.insert("static-peer:4443".into(), placeholder_handle(), DialSource::Static);
+		dialed.insert(target("static-peer:4443"), placeholder_handle(), DialSource::Static);
 
 		let long_ago = Instant::now() - Duration::from_secs(3600);
 		dialed.mark_unannounced("static-peer:4443", long_ago);
-		dialed.sweep_stale(Instant::now(), STALE_AFTER);
+		dialed.sweep_stale(Instant::now(), STALE_AFTER, &mut |_| panic!("must not redial"));
 
 		assert!(dialed.contains("static-peer:4443"));
 	}
@@ -1268,10 +1444,10 @@ mod tests {
 	async fn sweep_evicts_stale_gossip_peer() {
 		let dialed = DialMap::default();
 		let now = Instant::now();
-		dialed.insert("gone:4443".into(), placeholder_handle(), DialSource::Gossip);
+		dialed.insert(target("gone:4443"), placeholder_handle(), DialSource::Gossip);
 		dialed.mark_unannounced("gone:4443", now - STALE_AFTER - Duration::from_secs(1));
 
-		dialed.sweep_stale(now, STALE_AFTER);
+		dialed.sweep_stale(now, STALE_AFTER, &mut |_| panic!("must not redial"));
 
 		assert!(!dialed.contains("gone:4443"));
 	}
@@ -1284,10 +1460,10 @@ mod tests {
 	async fn sweep_keeps_recently_unannounced_peer() {
 		let dialed = DialMap::default();
 		let now = Instant::now();
-		dialed.insert("flapping:4443".into(), placeholder_handle(), DialSource::Gossip);
+		dialed.insert(target("flapping:4443"), placeholder_handle(), DialSource::Gossip);
 		dialed.mark_unannounced("flapping:4443", now - Duration::from_millis(50));
 
-		dialed.sweep_stale(now, STALE_AFTER);
+		dialed.sweep_stale(now, STALE_AFTER, &mut |_| panic!("must not redial"));
 
 		assert!(dialed.contains("flapping:4443"));
 	}
@@ -1296,10 +1472,10 @@ mod tests {
 	#[tokio::test]
 	async fn sweep_keeps_currently_announced_peer() {
 		let dialed = DialMap::default();
-		dialed.insert("healthy:4443".into(), placeholder_handle(), DialSource::Gossip);
+		dialed.insert(target("healthy:4443"), placeholder_handle(), DialSource::Gossip);
 		// No mark_unannounced -> stays announced.
 
-		dialed.sweep_stale(Instant::now(), STALE_AFTER);
+		dialed.sweep_stale(Instant::now(), STALE_AFTER, &mut |_| panic!("must not redial"));
 
 		assert!(dialed.contains("healthy:4443"));
 	}
@@ -1311,19 +1487,20 @@ mod tests {
 	async fn reannounce_cancels_pending_sweep() {
 		let dialed = DialMap::default();
 		let now = Instant::now();
-		dialed.insert("flap:4443".into(), placeholder_handle(), DialSource::Gossip);
+		let target = target("flap:4443");
+		dialed.insert(target.clone(), placeholder_handle(), DialSource::Gossip);
 		dialed.mark_unannounced("flap:4443", now - STALE_AFTER - Duration::from_secs(1));
 
 		// Re-adding the gossip source (a reannounce) clears the pending sweep.
 		assert!(
-			dialed.add_source("flap:4443", DialSource::Gossip),
+			dialed.upsert(target.clone(), DialSource::Gossip, &mut |_| panic!("must not redial")),
 			"should report a cleared pending-sweep"
 		);
-		dialed.sweep_stale(now, STALE_AFTER);
+		dialed.sweep_stale(now, STALE_AFTER, &mut |_| panic!("must not redial"));
 
 		assert!(dialed.contains("flap:4443"));
 		// A second reannounce has nothing to clear.
-		assert!(!dialed.add_source("flap:4443", DialSource::Gossip));
+		assert!(!dialed.upsert(target, DialSource::Gossip, &mut |_| panic!("must not redial")));
 	}
 
 	/// A peer wanted by both gossip and the API survives losing either source: the
@@ -1333,20 +1510,16 @@ mod tests {
 		let dialed = DialMap::default();
 		let now = Instant::now();
 		// Gossiped first, then also appears in the API list.
-		dialed.insert("both:4443".into(), placeholder_handle(), DialSource::Gossip);
-		let desired: HashSet<String> = ["both:4443".to_string()].into_iter().collect();
-		assert!(
-			dialed.reconcile_api(&desired).is_empty(),
-			"already dialed; no new spawn"
-		);
+		dialed.insert(target("both:4443"), placeholder_handle(), DialSource::Gossip);
+		dialed.reconcile_api(&desired(&["both:4443"]), |_| panic!("already dialed"));
 
 		// Dropped from the API list -> still wanted by gossip.
-		assert!(dialed.reconcile_api(&HashSet::new()).is_empty());
+		dialed.reconcile_api(&HashMap::new(), |_| panic!("gossip dial stays active"));
 		assert!(dialed.contains("both:4443"), "gossip still wants it");
 
 		// Now gossip goes stale too -> the dial is finally released.
 		dialed.mark_unannounced("both:4443", now - STALE_AFTER - Duration::from_secs(1));
-		dialed.sweep_stale(now, STALE_AFTER);
+		dialed.sweep_stale(now, STALE_AFTER, &mut |_| panic!("must not redial"));
 		assert!(!dialed.contains("both:4443"));
 	}
 
@@ -1355,11 +1528,11 @@ mod tests {
 	#[tokio::test]
 	async fn insert_merges_redundant_dial() {
 		let dialed = DialMap::default();
-		dialed.insert("p:4443".into(), placeholder_handle(), DialSource::Gossip);
-		dialed.insert("p:4443".into(), placeholder_handle(), DialSource::Api);
+		dialed.insert(target("p:4443"), placeholder_handle(), DialSource::Gossip);
+		dialed.insert(target("p:4443"), placeholder_handle(), DialSource::Api);
 
 		// Dropping the API source leaves the gossip source holding the dial.
-		assert!(dialed.reconcile_api(&HashSet::new()).is_empty());
+		dialed.reconcile_api(&HashMap::new(), |_| panic!("gossip dial stays active"));
 		assert!(dialed.contains("p:4443"), "gossip source still holds the dial");
 	}
 
@@ -1369,17 +1542,18 @@ mod tests {
 	#[tokio::test]
 	async fn reconcile_api_adds_and_removes_only_api() {
 		let dialed = DialMap::default();
-		dialed.insert("static:4443".into(), placeholder_handle(), DialSource::Static);
-		dialed.insert("gossip:4443".into(), placeholder_handle(), DialSource::Gossip);
-		dialed.insert("api-keep:4443".into(), placeholder_handle(), DialSource::Api);
-		dialed.insert("api-drop:4443".into(), placeholder_handle(), DialSource::Api);
+		dialed.insert(target("static:4443"), placeholder_handle(), DialSource::Static);
+		dialed.insert(target("gossip:4443"), placeholder_handle(), DialSource::Gossip);
+		dialed.insert(target("api-keep:4443"), placeholder_handle(), DialSource::Api);
+		dialed.insert(target("api-drop:4443"), placeholder_handle(), DialSource::Api);
 
 		// Desired: keep one existing API peer, drop the other, add a new one.
 		// Static/Gossip peers are not in the list but must survive.
-		let desired: HashSet<String> = ["api-keep:4443".to_string(), "api-new:4443".to_string()]
-			.into_iter()
-			.collect();
-		let mut to_add = dialed.reconcile_api(&desired);
+		let mut to_add = Vec::new();
+		dialed.reconcile_api(&desired(&["api-keep:4443", "api-new:4443"]), |target| {
+			to_add.push(target.key);
+			placeholder_handle()
+		});
 		to_add.sort();
 
 		assert_eq!(to_add, vec!["api-new:4443".to_string()]);
@@ -1394,14 +1568,171 @@ mod tests {
 	#[tokio::test]
 	async fn reconcile_api_dedupes_against_other_sources() {
 		let dialed = DialMap::default();
-		dialed.insert("shared:4443".into(), placeholder_handle(), DialSource::Static);
+		dialed.insert(target("shared:4443"), placeholder_handle(), DialSource::Static);
 
-		let desired: HashSet<String> = ["shared:4443".to_string()].into_iter().collect();
-		assert!(dialed.reconcile_api(&desired).is_empty());
+		dialed.reconcile_api(&desired(&["shared:4443"]), |_| panic!("already dialed"));
 		assert!(dialed.contains("shared:4443"));
 	}
 
-	/// The peer-list wire format is a bare JSON array of host strings.
+	/// A secondary source can update its target without disturbing the source that
+	/// opened the session. If the active source disappears, its latest fallback
+	/// configuration is used for the replacement.
+	#[tokio::test]
+	async fn inactive_source_update_applies_on_takeover() {
+		let dialed = DialMap::default();
+		let gossip = DialTarget::parse("https://peer.example/?cost=1").unwrap();
+		let api = DialTarget::parse("https://peer.example/?cost=3").unwrap();
+		let old_task = tokio::spawn(std::future::pending::<()>());
+		dialed.insert(gossip.clone(), old_task.abort_handle(), DialSource::Gossip);
+
+		let desired = [(api.key.clone(), api.clone())].into_iter().collect();
+		dialed.reconcile_api(&desired, |_| panic!("inactive source must not redial"));
+		assert!(!old_task.is_finished());
+
+		let now = Instant::now();
+		dialed.mark_unannounced(&gossip.key, now - STALE_AFTER - Duration::from_secs(1));
+		let mut spawned = Vec::new();
+		dialed.sweep_stale(now, STALE_AFTER, &mut |target| {
+			spawned.push(target);
+			placeholder_handle()
+		});
+
+		tokio::task::yield_now().await;
+		assert!(old_task.is_finished(), "old source must be aborted");
+		assert_eq!(spawned.len(), 1);
+		assert!(spawned[0] == api);
+	}
+
+	/// If the fallback source requests the same target, ownership transfers without
+	/// interrupting the healthy session.
+	#[tokio::test]
+	async fn identical_fallback_takeover_keeps_task() {
+		let dialed = DialMap::default();
+		let target = DialTarget::parse("https://peer.example/?cost=1").unwrap();
+		let task = tokio::spawn(std::future::pending::<()>());
+		dialed.insert(target.clone(), task.abort_handle(), DialSource::Gossip);
+
+		let desired = [(target.key.clone(), target.clone())].into_iter().collect();
+		dialed.reconcile_api(&desired, |_| panic!("inactive source must not redial"));
+
+		let now = Instant::now();
+		dialed.mark_unannounced(&target.key, now - STALE_AFTER - Duration::from_secs(1));
+		dialed.sweep_stale(now, STALE_AFTER, &mut |_| panic!("identical fallback must not redial"));
+
+		assert!(!task.is_finished(), "healthy dial must be preserved");
+		let map = dialed.inner.lock().expect("dial map");
+		let entry = map.get(&target.key).expect("current dial");
+		assert_eq!(entry.active, DialSource::Api);
+		assert!(entry.sources.get(entry.active) == Some(&target));
+		drop(map);
+		task.abort();
+	}
+
+	/// A cost-only API update has the same identity but different SETUP input, so
+	/// it must replace the live task instead of being mistaken for an unchanged
+	/// peer.
+	#[tokio::test]
+	async fn reconcile_api_replaces_cost_only_change() {
+		let dialed = DialMap::default();
+		let old = DialTarget::parse("https://peer.example/?cost=1").unwrap();
+		let new = DialTarget::parse("https://peer.example/?cost=2").unwrap();
+		assert_eq!(old.key, new.key);
+		assert!(old != new);
+
+		let old_task = tokio::spawn(std::future::pending::<()>());
+		dialed.insert(old, old_task.abort_handle(), DialSource::Api);
+		let desired = [(new.key.clone(), new.clone())].into_iter().collect();
+		let mut spawned = Vec::new();
+		dialed.reconcile_api(&desired, |target| {
+			spawned.push(target);
+			placeholder_handle()
+		});
+
+		tokio::task::yield_now().await;
+		assert!(old_task.is_finished(), "old dial must be aborted");
+		assert_eq!(spawned.len(), 1);
+		assert!(spawned[0] == new);
+	}
+
+	/// An identical API render keeps the live task, avoiding connection churn.
+	#[tokio::test]
+	async fn reconcile_api_identical_target_is_noop() {
+		let dialed = DialMap::default();
+		let target = DialTarget::parse("https://peer.example/?cost=2&jwt=secret").unwrap();
+		let task = tokio::spawn(std::future::pending::<()>());
+		dialed.insert(target.clone(), task.abort_handle(), DialSource::Api);
+		let desired = [(target.key.clone(), target)].into_iter().collect();
+
+		dialed.reconcile_api(&desired, |_| panic!("identical target must not redial"));
+		assert!(!task.is_finished(), "live dial must be preserved");
+		task.abort();
+	}
+
+	/// Inline credentials are dial-affecting even though they are excluded from
+	/// peer identity, so rotating one replaces the session too.
+	#[tokio::test]
+	async fn reconcile_api_replaces_inline_credential() {
+		let dialed = DialMap::default();
+		let old = DialTarget::parse("https://peer.example/?jwt=old").unwrap();
+		let new = DialTarget::parse("https://peer.example/?jwt=new").unwrap();
+		assert_eq!(old.key, new.key);
+
+		let old_task = tokio::spawn(std::future::pending::<()>());
+		dialed.insert(old, old_task.abort_handle(), DialSource::Api);
+		let desired = [(new.key.clone(), new.clone())].into_iter().collect();
+		let mut spawned = Vec::new();
+		dialed.reconcile_api(&desired, |target| {
+			spawned.push(target);
+			placeholder_handle()
+		});
+
+		tokio::task::yield_now().await;
+		assert!(old_task.is_finished(), "old dial must be aborted");
+		assert_eq!(spawned.len(), 1);
+		assert!(spawned[0] == new);
+	}
+
+	/// A malformed replacement is rejected before reconciliation, so it cannot
+	/// tear down or reconfigure the last-known-good dial set.
+	#[tokio::test]
+	async fn malformed_peer_list_preserves_current_dial() {
+		let cluster = Cluster::new(ClusterConfig::default()).expect("cluster");
+		let dialed = DialMap::default();
+		let current = DialTarget::parse("https://peer.example/?cost=1").unwrap();
+		let task = tokio::spawn(std::future::pending::<()>());
+		dialed.insert(current.clone(), task.abort_handle(), DialSource::Api);
+
+		cluster.apply_peer_list(
+			vec!["https://peer.example/?cost=invalid".to_string()],
+			&None,
+			"",
+			&dialed,
+		);
+
+		assert!(!task.is_finished(), "last-known-good dial must stay active");
+		let map = dialed.inner.lock().expect("dial map");
+		let entry = map.get(&current.key).expect("current dial");
+		assert!(entry.sources.get(entry.active) == Some(&current));
+		task.abort();
+	}
+
+	/// The same identity cannot appear twice with different SETUP inputs because
+	/// input ordering must not choose which configuration wins.
+	#[test]
+	fn peer_list_rejects_conflicting_duplicate() {
+		let Err(err) = parse_peer_list(
+			vec![
+				"https://peer.example/?cost=1".to_string(),
+				"https://peer.example/?cost=2".to_string(),
+			],
+			None,
+		) else {
+			panic!("conflicting duplicate must fail");
+		};
+		assert!(format!("{err:#}").contains("conflicting configurations"));
+	}
+
+	/// The peer-list wire format is a JSON array of URL strings.
 	#[test]
 	fn peer_list_parses_as_string_array() {
 		let body = r#"["a.pop.example", "b.pop.example:4443"]"#;
@@ -1565,6 +1896,14 @@ mod tests {
 		assert!(!is_legacy_peer("https://cdn.example.com/?jwt=abc"));
 	}
 
+	/// A malformed URL may contain a credential, so parse errors must not echo the
+	/// raw input into logs.
+	#[test]
+	fn peer_url_error_redacts_inline_credential() {
+		let err = peer_url("https://peer.example:bad/?jwt=top-secret").unwrap_err();
+		assert!(!format!("{err:#}").contains("top-secret"));
+	}
+
 	/// What a discovering relay reads off `announced()` for this node.
 	fn advertised(node: &str) -> String {
 		Path::new(MESH_PREFIX)
@@ -1584,7 +1923,7 @@ mod tests {
 			"https://a.example/",
 			"https://b.example:4443/",
 			"tcp://c.example:4443",
-			"https://d.example/?jwt=abc",
+			"https://d.example/?cost=7",
 			"https://e.example/deep/path",
 			// Legacy bare forms, which carry no scheme and default to https.
 			"rendezvous.example.com:4443",
@@ -1604,13 +1943,13 @@ mod tests {
 	/// every gossip-discovered link silently at the default cost.
 	#[test]
 	fn an_advertised_url_keeps_the_query_it_is_dialed_with() {
-		let dialed = advertised_node_url(&advertised("https://a.example/?cost=10&jwt=abc"));
-		assert_eq!(dialed, "https://a.example/?cost=10&jwt=abc");
+		let dialed = advertised_node_url(&advertised("https://a.example/?cost=10"));
+		assert_eq!(dialed, "https://a.example/?cost=10");
 
 		// The value has to reach where `run_remote` reads it.
 		let mut url = peer_url(&dialed).unwrap();
 		assert_eq!(take_cost(&mut url).unwrap(), Some(10));
-		assert_eq!(url.as_str(), "https://a.example/?jwt=abc");
+		assert_eq!(url.as_str(), "https://a.example/");
 	}
 
 	/// The colon that ends a scheme is the only signal, so a bare `host:port` (whose
@@ -1650,7 +1989,7 @@ mod tests {
 		// A URL form and the legacy host:port form dedupe against each other.
 		let dialed = DialMap::default();
 		dialed.insert(
-			canonicalize_peer_key("https://host:4443/?jwt=abc"),
+			DialTarget::parse("https://host:4443/?jwt=abc").unwrap(),
 			placeholder_handle(),
 			DialSource::Static,
 		);


### PR DESCRIPTION
## Summary

- separate canonical cluster peer identity from dial-affecting URL and cost configuration
- replace active dynamic peer sessions when cost or inline credentials change, while preserving inactive source fallbacks
- reject malformed or conflicting peer lists before mutating the last-known-good topology
- document dynamic peer URL reconciliation and authentication behavior

The root cause was that peer reconciliation stripped query parameters before building the desired set. A cost-only or inline-JWT update therefore looked identical to the existing peer, and the old session could retain stale SETUP state indefinitely.

## Public API changes

- None. The reconciliation types and behavior are private to moq-relay.

## Test plan

- nix develop --command just check origin/main
- nix develop --command just test default origin/main
- regression coverage for cost-only changes, inline credential rotation, identical renders, malformed lists, duplicate identities, and multi-source takeover

(Written by GPT-5)