### PR TITLE
feat(bench): chat workloads, JSONL stats, and a production-safe host sampler (M0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,7 +4653,7 @@ dependencies = [
  "humantime-serde",
  "moq-native",
  "moq-net",
- "procfs",
+ "procfs 0.18.0",
  "rand 0.10.2",
  "rustls",
  "serde",
@@ -7024,11 +7024,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.13.1",
+ "hex",
+ "procfs-core 0.17.0",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
+dependencies = [
+ "bitflags 2.13.1",
  "chrono",
  "flate2",
- "hex",
- "procfs-core",
- "rustix 0.38.44",
+ "procfs-core 0.18.0",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -7036,6 +7047,16 @@ name = "procfs-core"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.13.1",
+ "hex",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags 2.13.1",
  "chrono",
@@ -7060,7 +7081,7 @@ dependencies = [
  "libc",
  "memchr",
  "parking_lot",
- "procfs",
+ "procfs 0.17.0",
  "thiserror 2.0.20",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,6 +4653,7 @@ dependencies = [
  "humantime-serde",
  "moq-native",
  "moq-net",
+ "procfs",
  "rand 0.10.2",
  "rustls",
  "serde",
@@ -7023,6 +7024,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.13.1",
+ "chrono",
+ "flate2",
  "hex",
  "procfs-core",
  "rustix 0.38.44",
@@ -7035,6 +7038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.13.1",
+ "chrono",
  "hex",
 ]
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -329,7 +329,7 @@ build:
 # Run a moq-bench preset against a relay, e.g. `just rs bench chat https://relay.example.com`.
 # Extra args pass through, so `--connections 500 --output stats.jsonl` work as-is.
 bench preset url *args:
-    cargo run --release -p moq-bench -- --file rs/moq-bench/config/{{ preset }}.toml --client-connect {{ url }} {{ args }}
+    cargo run --release -p moq-bench -- --file 'rs/moq-bench/config/{{ preset }}.toml' --client-connect '{{ url }}' {{ args }}
 
 # Sample a process's CPU/memory/context switches on this host (run it where the
 # relay runs; it only reads /proc). E.g. `just rs bench-host --name moq-relay`.

--- a/rs/justfile
+++ b/rs/justfile
@@ -326,6 +326,16 @@ loom *args:
 build:
     cargo build
 
+# Run a moq-bench preset against a relay, e.g. `just rs bench chat https://relay.example.com`.
+# Extra args pass through, so `--connections 500 --output stats.jsonl` work as-is.
+bench preset url *args:
+    cargo run --release -p moq-bench -- --file rs/moq-bench/config/{{ preset }}.toml --client-connect {{ url }} {{ args }}
+
+# Sample a process's CPU/memory/context switches on this host (run it where the
+# relay runs; it only reads /proc). E.g. `just rs bench-host --name moq-relay`.
+bench-host *args:
+    cargo run --release -p moq-bench --bin moq-bench-host -- {{ args }}
+
 # Remove the Rust target directory.
 clean:
     cargo clean

--- a/rs/moq-bench/Cargo.toml
+++ b/rs/moq-bench/Cargo.toml
@@ -19,6 +19,12 @@ name = "moq-bench"
 path = "src/main.rs"
 doc = false
 
+# Host-side resource sampler, run next to the process under test (see src/host.rs).
+[[bin]]
+name = "moq-bench-host"
+path = "src/host.rs"
+doc = false
+
 [features]
 default = ["quinn", "websocket"]
 iroh = ["moq-native/iroh"]
@@ -41,6 +47,10 @@ serde_json = "1"
 tokio = { workspace = true, features = ["full"] }
 toml = "1.1"
 tracing = "0.1"
+
+# The host sampler reads /proc, so it is Linux-only (production relays are Linux).
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = "0.17"
 
 [dev-dependencies]
 # test-util enables tokio::time::pause/advance for the deterministic produce tests.

--- a/rs/moq-bench/Cargo.toml
+++ b/rs/moq-bench/Cargo.toml
@@ -13,6 +13,8 @@ keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
 publish = false
+# `cargo run -p moq-bench` means the load generator; the sampler needs --bin.
+default-run = "moq-bench"
 
 [[bin]]
 name = "moq-bench"
@@ -50,7 +52,7 @@ tracing = "0.1"
 
 # The host sampler reads /proc, so it is Linux-only (production relays are Linux).
 [target.'cfg(target_os = "linux")'.dependencies]
-procfs = "0.17"
+procfs = "0.18"
 
 [dev-dependencies]
 # test-util enables tokio::time::pause/advance for the deterministic produce tests.

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -73,6 +73,7 @@ table (`fps = { min = 24, max = 60 }`).
 | `--startup` | | Ramp window for staggering connections/subscriptions |
 | `--duration` | | Stop after this long (runs until interrupted otherwise) |
 | `--report` | | How often to log throughput stats |
+| `--output` | | Also append the stats as JSON lines to this file |
 
 Client TLS/QUIC flags (`--client-tls-disable-verify`, `--client-bind`, ...) come from
 `moq-native` and behave the same as in `moq-cli` and `moq-relay`.
@@ -85,3 +86,58 @@ The `config/` directory has a few starting points:
 - `sd.toml`: standard-definition video with more viewers per publisher.
 - `audio.toml`: small, frequent frames with short groups (Opus-like).
 - `announce.toml`: many broadcasts, near-zero media, to stress announcements.
+- `chat.toml`: a chat message bus, 1:1. Many connections, tiny frames, one
+  group per message, so the cost is per-message overhead rather than bandwidth.
+- `chat-pub.toml` / `chat-sub.toml`: chat rooms, 1:N. A pair of configs run as
+  two instances against the same relay: a few busy rooms and a large
+  subscriber-only audience that discovers them via announcements. Scale the
+  audience's `--connections` (or run more instances) to push the fanout.
+
+## Machine-readable output
+
+`--output stats.jsonl` mirrors every report interval to a file as one JSON line
+of the cumulative counters (`frames_sent`, `bytes_recv`, `connections`, ...),
+each stamped with `timestamp_ms`. Counters are cumulative and monotonic, so a
+consumer diffs successive lines to compute rates, the same convention as
+`moq-stats` frames.
+
+## Host-side sampling: moq-bench-host
+
+`moq-bench` measures the load it generates; `moq-bench-host` measures what that
+load costs. It runs on the host of the process under test, production included:
+it only reads `/proc` (Linux-only), needs no privileges beyond visibility of the
+target process, and never touches the process itself (no ptrace, no perf, no
+signals).
+
+```bash
+# On the relay host: sample the relay once per second, forever, to stdout.
+moq-bench-host --name moq-relay
+
+# Bounded run to a file, with the per-thread breakdown.
+moq-bench-host --name moq-relay --interval 1s --duration 5m \
+  --threads --output host.jsonl
+```
+
+Each line carries cumulative CPU seconds (`cpu_user`, `cpu_system`), RSS, and
+context switches summed across threads (`ctx_voluntary`, `ctx_involuntary`),
+plus the host's total busy CPU seconds (`host_cpu_busy`) and core count so the
+process's share of the machine is computable. `--threads` adds a per-thread
+breakdown including the core each thread last ran on, which is how to verify
+pinning once the relay grows a thread-per-core mode.
+
+## Measuring CPU cost
+
+Run the load from one machine and the sampler on the relay's host, then join
+the two JSONL files on `timestamp_ms` over the same steady-state window (skip
+the `--startup` ramp):
+
+- CPU per connection: `(delta cpu_user + delta cpu_system) / delta seconds / connections`.
+- CPU per message: `(delta cpu_user + delta cpu_system) / (delta frames_sent + delta frames_recv)`,
+  using the frame counters from the load side, since every chat message is one
+  frame.
+- Context switches per message: same shape, with `delta ctx_voluntary + delta ctx_involuntary`
+  as the numerator.
+
+Comparisons are only meaningful between runs on the same hardware with the same
+preset. Pin the relay build (`--version` appears in the logs) and record it next
+to the results.

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -18,10 +18,12 @@ For a run, `moq-bench` establishes **A** connections. Each connection:
 
 The first frame of every group is a JSON keyframe describing the rolled
 parameters (connection id, broadcast path, group sequence, fps, frame size,
-group size, and a wall-clock timestamp). The remaining **F** frames in the group
-are zeroed. **F may be 0**, in which case each group is a lone JSON keyframe,
-which is useful for stressing the announce/subscribe control plane rather than
-the data path.
+group size, and a wall-clock timestamp), padded up to **E** bytes so the
+configured frame size holds even when it is the only frame. The remaining **F**
+frames in the group are zeroed. **F may be 0**, in which case each group is a
+lone JSON keyframe: that is the chat shape (every message pays a full group),
+and it also stresses the announce/subscribe control plane rather than the data
+path.
 
 To avoid a thundering herd at startup, connections and subscriptions are
 staggered over a `--startup` ramp window instead of all firing at once.
@@ -119,7 +121,8 @@ moq-bench-host --name moq-relay --interval 1s --duration 5m \
 ```
 
 Each line carries cumulative CPU seconds (`cpu_user`, `cpu_system`), RSS, and
-context switches summed across threads (`ctx_voluntary`, `ctx_involuntary`),
+context switches summed across threads (`ctx_voluntary`, `ctx_involuntary`;
+an exited thread's contribution is retained, so the counters stay monotonic),
 plus the host's total busy CPU seconds (`host_cpu_busy`) and core count so the
 process's share of the machine is computable. `--threads` adds a per-thread
 breakdown including the core each thread last ran on, which is how to verify
@@ -129,7 +132,9 @@ pinning once the relay grows a thread-per-core mode.
 
 Run the load from one machine and the sampler on the relay's host, then join
 the two JSONL files on `timestamp_ms` over the same steady-state window (skip
-the `--startup` ramp):
+the `--startup` ramp). `timestamp_ms` is wall clock from two different hosts,
+so keep both NTP-synced; the join only has to agree on the window boundaries,
+since every rate comes from deltas within a single file:
 
 - CPU per connection: `(delta cpu_user + delta cpu_system) / delta seconds / connections`.
 - CPU per message: `(delta cpu_user + delta cpu_system) / (delta frames_sent + delta frames_recv)`,

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -134,8 +134,9 @@ pinning once the relay grows a thread-per-core mode.
 ## Measuring CPU cost
 
 Run the load from one machine and the sampler on the relay's host, then join
-the two JSONL files on `timestamp_ms` over the same steady-state window (skip
-the `--startup` ramp). `timestamp_ms` is wall clock from two different hosts,
+the two JSONL files on `timestamp_ms` over the same steady-state window. Skip
+the first two `--startup` windows: connections ramp across the first, and each
+connection then gathers announcements for one more window before subscribing. `timestamp_ms` is wall clock from two different hosts,
 so keep both NTP-synced; the join only has to agree on the window boundaries,
 since every rate comes from deltas within a single file:
 

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -19,11 +19,13 @@ For a run, `moq-bench` establishes **A** connections. Each connection:
 The first frame of every group is a JSON keyframe describing the rolled
 parameters (connection id, broadcast path, group sequence, fps, frame size,
 group size, and a wall-clock timestamp), padded up to **E** bytes so the
-configured frame size holds even when it is the only frame. The remaining **F**
-frames in the group are zeroed. **F may be 0**, in which case each group is a
-lone JSON keyframe: that is the chat shape (every message pays a full group),
-and it also stresses the announce/subscribe control plane rather than the data
-path.
+configured frame size holds even when it is the only frame. The keyframe's own
+header is the floor: an **E** below roughly 170 bytes sends the header at its
+natural size, so configure **E** at 200 or above when exact sizes matter. The
+remaining **F** frames in the group are zeroed. **F may be 0**, in which case
+each group is a lone JSON keyframe: that is the chat shape (every message pays
+a full group), and it also stresses the announce/subscribe control plane rather
+than the data path.
 
 To avoid a thundering herd at startup, connections and subscriptions are
 staggered over a `--startup` ramp window instead of all firing at once.
@@ -97,11 +99,12 @@ The `config/` directory has a few starting points:
 
 ## Machine-readable output
 
-`--output stats.jsonl` mirrors every report interval to a file as one JSON line
-of the cumulative counters (`frames_sent`, `bytes_recv`, `connections`, ...),
-each stamped with `timestamp_ms`. Counters are cumulative and monotonic, so a
-consumer diffs successive lines to compute rates, the same convention as
-`moq-stats` frames.
+`--output stats.jsonl` mirrors every report interval to a file as one JSON
+line, each stamped with `timestamp_ms`. The frame, byte, and group counters are
+cumulative and monotonic, so a consumer diffs successive lines to compute
+rates, the same convention as `moq-stats` frames. `connections`, `broadcasts`,
+and `subscriptions` are live gauges that fall as work ends; diff only the
+counters.
 
 ## Host-side sampling: moq-bench-host
 
@@ -137,10 +140,14 @@ so keep both NTP-synced; the join only has to agree on the window boundaries,
 since every rate comes from deltas within a single file:
 
 - CPU per connection: `(delta cpu_user + delta cpu_system) / delta seconds / connections`.
-- CPU per message: `(delta cpu_user + delta cpu_system) / (delta frames_sent + delta frames_recv)`,
-  using the frame counters from the load side, since every chat message is one
-  frame.
-- Context switches per message: same shape, with `delta ctx_voluntary + delta ctx_involuntary`
+- CPU per published message: `(delta cpu_user + delta cpu_system) / delta frames_sent`.
+  This charges each message once, including its whole fanout, so it is the
+  number that answers "what does one chat message cost the relay".
+- CPU per delivered copy: same numerator over `delta frames_recv`, when the
+  per-subscriber cost is the question. Do not sum the two frame counters: in
+  the 1:1 preset every message is counted by both, so the sum double-counts
+  and halves the apparent cost.
+- Context switches per message: either shape, with `delta ctx_voluntary + delta ctx_involuntary`
   as the numerator.
 
 Comparisons are only meaningful between runs on the same hardware with the same

--- a/rs/moq-bench/config/chat-pub.toml
+++ b/rs/moq-bench/config/chat-pub.toml
@@ -1,0 +1,20 @@
+# Chat rooms, publisher half of the 1:N fanout pair. Run this against the relay
+# alongside chat-sub.toml (another process or host): this instance is the small
+# set of busy rooms, the other is the audience. Both use the default broadcast
+# namespace, so the subscribers discover these rooms via announcements.
+
+startup = "5s"
+report = "5s"
+
+# A: a handful of rooms
+connections = 10
+# B: one broadcast per room
+broadcasts = 1
+# C: rooms publish only
+subscribe = 0
+# D: messages per second per room
+fps = "1:10"
+# E: bytes per message
+frame_size = "100:400"
+# F: each group is a lone JSON keyframe
+group_size = 0

--- a/rs/moq-bench/config/chat-pub.toml
+++ b/rs/moq-bench/config/chat-pub.toml
@@ -14,7 +14,8 @@ broadcasts = 1
 subscribe = 0
 # D: messages per second per room
 fps = "1:10"
-# E: bytes per message
-frame_size = "100:400"
+# E: bytes per message. The floor sits above the JSON keyframe header (roughly
+# 170 bytes), so every rolled size is delivered exactly.
+frame_size = "200:400"
 # F: each group is a lone JSON keyframe
 group_size = 0

--- a/rs/moq-bench/config/chat-sub.toml
+++ b/rs/moq-bench/config/chat-sub.toml
@@ -1,0 +1,14 @@
+# Chat rooms, audience half of the 1:N fanout pair (see chat-pub.toml).
+# Subscriber-only: publishes nothing and follows a few of the announced rooms.
+# Scale --connections, or run several instances, to push the fanout: 10 rooms
+# with 2000 subscribers at 1 to 3 rooms each is roughly 1:400 per room.
+
+startup = "60s"
+report = "5s"
+
+# A: audience size
+connections = 2000
+# B: the audience publishes nothing
+broadcasts = 0
+# C: rooms followed per audience member
+subscribe = "1:3"

--- a/rs/moq-bench/config/chat.toml
+++ b/rs/moq-bench/config/chat.toml
@@ -16,7 +16,8 @@ subscribe = 1
 # the CPU-per-message signal easier to read, and the math normalizes by message
 # count rather than wall clock anyway.
 fps = 1
-# E: bytes per message
-frame_size = "100:400"
+# E: bytes per message. The floor sits above the JSON keyframe header (roughly
+# 170 bytes), so every rolled size is delivered exactly.
+frame_size = "200:400"
 # F: each group is a lone JSON keyframe
 group_size = 0

--- a/rs/moq-bench/config/chat.toml
+++ b/rs/moq-bench/config/chat.toml
@@ -1,0 +1,22 @@
+# Chat message bus, 1:1. Every connection is one "user": it publishes a single
+# broadcast and follows one peer, so egress is tiny and the cost is per-message
+# overhead, not bandwidth. Each group is a lone JSON keyframe (group_size = 0),
+# so every message pays a full group/stream open, the worst case per message.
+
+startup = "30s"
+report = "5s"
+
+# A: number of connections (users)
+connections = 1000
+# B: one broadcast per user
+broadcasts = 1
+# C: each user follows one peer
+subscribe = 1
+# D: one message per second per user. Hotter than real chat on purpose: it makes
+# the CPU-per-message signal easier to read, and the math normalizes by message
+# count rather than wall clock anyway.
+fps = 1
+# E: bytes per message
+frame_size = "100:400"
+# F: each group is a lone JSON keyframe
+group_size = 0

--- a/rs/moq-bench/src/config.rs
+++ b/rs/moq-bench/src/config.rs
@@ -67,6 +67,12 @@ pub struct Config {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub group_size: Option<Range>,
 
+	/// Write machine-readable stats to this file: one JSON line of cumulative
+	/// counters per report interval. Truncates on start.
+	#[arg(long, env = "MOQ_BENCH_OUTPUT")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub output: Option<std::path::PathBuf>,
+
 	/// The MoQ client (QUIC/TLS) configuration.
 	#[command(flatten)]
 	#[serde(default)]
@@ -195,6 +201,30 @@ tls.disable_verify = true
 		assert_eq!(config.connections(), Range::new(5, 10));
 		// Untouched TOML field is still intact.
 		assert_eq!(config.fps(), Range::new(24, 60));
+	}
+
+	#[test]
+	fn output_survives_toml_merge() {
+		// The TOML->CLI merge re-applies clap defaults, which clobbers bare fields;
+		// `output` must stay Option so an absent flag leaves the TOML value alone.
+		let toml = r#"
+output = "stats.jsonl"
+
+[client]
+connect = "https://example.com"
+"#;
+		let dir = std::env::temp_dir().join("moq-bench-output-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("bench.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![
+			std::ffi::OsString::from("moq-bench"),
+			std::ffi::OsString::from("--file"),
+			path.into(),
+		];
+		let config = Config::parse_and_merge(args).unwrap();
+		assert_eq!(config.output.as_deref(), Some(std::path::Path::new("stats.jsonl")));
 	}
 
 	#[test]

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -82,15 +82,19 @@ pub async fn run(ctx: Connection) {
 	let publish = Origin::random().produce();
 	// Consume side: the session fills this with peer announcements.
 	let consume = Origin::random().produce();
-	let announced = consume.consume().announced();
 
 	let name = config.name();
+	let announced = discover(&consume, name);
+
 	let mut broadcasts = Vec::new();
 	let mut own = HashSet::new();
 	let mut tasks = JoinSet::new();
 
 	for index in 0..rolled.broadcasts {
-		let path = format!("{name}/{run_id:08x}/{connection}/{index}");
+		// The announce consumer is rooted at `name`, so `own` (compared against
+		// announced paths) stays relative while the full path goes on the wire.
+		let relative = format!("{run_id:08x}/{connection}/{index}");
+		let path = format!("{name}/{relative}");
 
 		let mut broadcast = match publish.create_broadcast(&path, broadcast::Route::new().with_announce(true)) {
 			Ok(broadcast) => broadcast,
@@ -106,7 +110,7 @@ pub async fn run(ctx: Connection) {
 				continue;
 			}
 		};
-		own.insert(path.clone());
+		own.insert(relative);
 		// Hold the broadcast producer for the connection's lifetime so it stays announced.
 		broadcasts.push(broadcast);
 
@@ -223,6 +227,19 @@ async fn produce(
 		group.finish()?;
 		sequence += 1;
 	}
+}
+
+/// Announce consumer scoped to the bench namespace, emitting paths relative to it.
+///
+/// The relay announces its own broadcasts too (`.stats/...` when stats publishing
+/// is on, which production relays enable), and a subscription slot burned on one
+/// of those is never retried, so an unscoped consumer starves the subscribe side.
+fn discover(consume: &moq_net::origin::Producer, name: &str) -> moq_net::announce::Consumer {
+	consume
+		.consume()
+		.with_root(name)
+		.expect("origin must permit the bench namespace")
+		.announced()
 }
 
 /// Watch announcements and drain up to `want` peer broadcasts (excluding our own),
@@ -472,6 +489,44 @@ mod tests {
 		assert!(group.read_frame().await.unwrap().is_none(), "no payload frames");
 
 		task.abort();
+	}
+
+	/// Discovery must skip broadcasts outside the bench namespace: a relay with
+	/// stats publishing enabled announces `.stats/...` too, and a subscription
+	/// slot burned on it is never retried, so a chat-shaped run (`subscribe = 1`)
+	/// used to end up with zero working subscriptions.
+	#[tokio::test]
+	async fn subscribe_ignores_relay_internal_broadcasts() {
+		tokio::time::pause();
+
+		let stats = Arc::new(Stats::default());
+		let origin = Origin::random().produce();
+
+		// The relay-internal broadcast: announced, but with no bench data track.
+		let _internal = origin
+			.create_broadcast(".stats/node/host", broadcast::Route::new().with_announce(true))
+			.unwrap();
+
+		// One legitimate peer under the bench namespace with a single finished group.
+		let mut peer = origin
+			.create_broadcast("bench/00000000/0/0", broadcast::Route::new().with_announce(true))
+			.unwrap();
+		let mut track = peer.create_track(TRACK, None).unwrap();
+		let mut group = track.append_group().unwrap();
+		group
+			.write_frame(moq_net::Timestamp::now(), Bytes::from_static(b"{}"))
+			.unwrap();
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		let announced = discover(&origin, "bench");
+		subscribe(announced, HashSet::new(), 1, Duration::ZERO, stats.clone())
+			.await
+			.unwrap();
+
+		// The one wanted slot went to the bench peer, not `.stats`.
+		assert_eq!(stats.frames_recv.load(Ordering::Relaxed), 1);
+		assert_eq!(stats.groups_recv.load(Ordering::Relaxed), 1);
 	}
 
 	fn lost(stats: &Stats) -> u64 {

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -257,14 +257,18 @@ fn discover(consume: &moq_net::origin::Producer, name: &str) -> moq_net::announc
 		.announced()
 }
 
-/// Watch announcements and drain up to `want` peer broadcasts (excluding our own),
-/// spreading each subscription's start over `startup` to avoid a thundering herd.
+/// Watch announcements and drain up to `want` peer broadcasts (excluding our own).
 ///
 /// Candidates are gathered over the `startup` window and picked at random. The
 /// relay replays existing announcements in deterministic path order, so a
 /// first-come pick would put every subscriber on the same first few broadcasts
 /// and collapse the 1:N presets into hotspots. Announcements arriving after the
 /// window fill any remaining slots in arrival order.
+///
+/// The gather window is the only delay added here: connections are already
+/// staggered across `startup` by main, so subscriptions land spread over the
+/// second startup window of the run, and the whole swarm is subscribed within
+/// two of them.
 async fn subscribe(
 	mut announced: moq_net::announce::Consumer,
 	own: HashSet<String>,
@@ -281,6 +285,9 @@ async fn subscribe(
 	tokio::pin!(deadline);
 	loop {
 		tokio::select! {
+			// Deadline first: with random polling, a stream that always has another
+			// announcement ready could keep gathering past the startup window.
+			biased;
 			_ = &mut deadline => break,
 			update = announced.next() => {
 				let Some(moq_net::announce::Update { path, broadcast }) = update else { break };
@@ -297,7 +304,7 @@ async fn subscribe(
 	pick_random(&mut pool, want as usize);
 	let mut selected = pool.len() as u64;
 	for (path, broadcast) in pool {
-		spawn_drain(&mut tasks, path, broadcast, startup, stats.clone());
+		spawn_drain(&mut tasks, path, broadcast, stats.clone());
 	}
 
 	// Top up from late announcements, first-come: the pool was too small, so
@@ -314,7 +321,7 @@ async fn subscribe(
 			continue;
 		}
 		selected += 1;
-		spawn_drain(&mut tasks, path, broadcast, startup, stats.clone());
+		spawn_drain(&mut tasks, path, broadcast, stats.clone());
 	}
 
 	// Keep the drain tasks alive; they run until their broadcasts close.
@@ -332,21 +339,10 @@ fn pick_random<T>(pool: &mut Vec<T>, want: usize) {
 	pool.truncate(want);
 }
 
-/// Queue one broadcast for draining, staggered somewhere within the startup
-/// window so `want` subscriptions don't all fire at once.
-fn spawn_drain(
-	tasks: &mut JoinSet<()>,
-	path: String,
-	broadcast: broadcast::Consumer,
-	startup: Duration,
-	stats: Arc<Stats>,
-) {
-	let delay = {
-		let mut rng = rand::rng();
-		startup.mul_f64(rng.random_range(0.0..1.0))
-	};
+/// Queue one broadcast for draining. No extra delay: the caller's gather window
+/// and main's connection stagger already spread subscription starts.
+fn spawn_drain(tasks: &mut JoinSet<()>, path: String, broadcast: broadcast::Consumer, stats: Arc<Stats>) {
 	tasks.spawn(async move {
-		tokio::time::sleep(delay).await;
 		if let Err(err) = drain(broadcast, &stats).await {
 			tracing::debug!(%path, %err, "subscription ended");
 		}

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -279,6 +279,7 @@ async fn subscribe(
 	let mut tasks = JoinSet::new();
 	let mut seen: HashSet<String> = HashSet::new();
 	let mut pool = Vec::new();
+	let mut eligible = 0;
 
 	// Gather candidates until the startup window closes (or the announce stream ends).
 	let deadline = tokio::time::sleep(startup);
@@ -296,12 +297,12 @@ async fn subscribe(
 				if own.contains(&path) || !seen.insert(path.clone()) {
 					continue;
 				}
-				pool.push((path, broadcast));
+				eligible += 1;
+				reservoir_push(&mut pool, want as usize, eligible, (path, broadcast));
 			}
 		}
 	}
 
-	pick_random(&mut pool, want as usize);
 	let mut selected = pool.len() as u64;
 	for (path, broadcast) in pool {
 		spawn_drain(&mut tasks, path, broadcast, stats.clone());
@@ -329,14 +330,19 @@ async fn subscribe(
 	Ok(())
 }
 
-/// Keep `want` elements of the pool, chosen uniformly at random (Fisher-Yates,
-/// then truncate). The whole pool survives when it is smaller than `want`.
-fn pick_random<T>(pool: &mut Vec<T>, want: usize) {
-	let mut rng = rand::rng();
-	for i in (1..pool.len()).rev() {
-		pool.swap(i, rng.random_range(0..=i));
+/// Reservoir-sample (Algorithm R): offer the `eligible`-th stream item (1-based)
+/// to a pool holding at most `want` uniform picks. Bounded memory, so a big
+/// namespace never piles a copy of itself into every subscriber; dropped
+/// candidates release their broadcast handles immediately.
+fn reservoir_push<T>(pool: &mut Vec<T>, want: usize, eligible: usize, item: T) {
+	if pool.len() < want {
+		pool.push(item);
+		return;
 	}
-	pool.truncate(want);
+	let slot = rand::rng().random_range(0..eligible);
+	if slot < want {
+		pool[slot] = item;
+	}
 }
 
 /// Queue one broadcast for draining. No extra delay: the caller's gather window
@@ -658,26 +664,29 @@ mod tests {
 		assert_eq!(stats.groups_recv.load(Ordering::Relaxed), 1);
 	}
 
-	/// Subscription targets must be picked at random from the gathered pool.
+	/// Subscription targets must be picked at random from the announced stream.
 	/// Announcements replay in deterministic path order, so a first-come pick
 	/// put every subscriber on the same first rooms and turned the 1:N presets
 	/// into hotspots on one or two broadcasts.
 	#[test]
-	fn pick_random_spreads_selections() {
+	fn reservoir_spreads_selections() {
 		let mut distinct = HashSet::new();
 		for _ in 0..64 {
-			let mut pool = vec![0, 1, 2, 3, 4, 5, 6, 7];
-			pick_random(&mut pool, 1);
+			let mut pool = Vec::new();
+			for item in 0..8 {
+				reservoir_push(&mut pool, 1, item + 1, item);
+			}
 			distinct.insert(pool[0]);
 		}
 		// First-come always yields element 0. Randomness missing this over 64
 		// draws from 8 elements has probability (1/8)^63, i.e. never.
 		assert!(distinct.len() > 1, "selection must not be deterministic");
 
-		// A pool smaller than want survives whole.
-		let mut pool = vec![1, 2];
-		pick_random(&mut pool, 5);
-		assert_eq!(pool.len(), 2);
+		// Fewer eligible items than want: everything survives.
+		let mut pool = Vec::new();
+		reservoir_push(&mut pool, 5, 1, 1);
+		reservoir_push(&mut pool, 5, 2, 2);
+		assert_eq!(pool, vec![1, 2]);
 	}
 
 	fn lost(stats: &Stats) -> u64 {

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -39,6 +39,10 @@ struct GroupHeader<'a> {
 	subscribe: u64,
 	/// Wall-clock milliseconds, handy for rough one-way latency when clocks agree.
 	timestamp_ms: u128,
+	/// Zero padding sizing the keyframe up to the rolled frame size, so a
+	/// lone-keyframe group (`group_size = 0`, the chat shape) still costs
+	/// `frame_size` bytes on the wire.
+	pad: String,
 }
 
 /// The subset of [`GroupHeader`] a subscriber reads back to learn the shape of a
@@ -199,7 +203,7 @@ async fn produce(
 
 		// Keyframe: the JSON header describing this connection's rolled parameters.
 		ticker.tick().await;
-		let header = GroupHeader {
+		let mut header = GroupHeader {
 			connection,
 			broadcast: &path,
 			group: sequence,
@@ -212,8 +216,19 @@ async fn produce(
 				.duration_since(UNIX_EPOCH)
 				.unwrap_or_default()
 				.as_millis(),
+			pad: String::new(),
 		};
-		let header = Bytes::from(serde_json::to_vec(&header)?);
+		let mut payload = serde_json::to_vec(&header)?;
+		// Pad the keyframe up to the rolled frame size, so `frame_size` holds even
+		// when the keyframe is the only frame (`group_size = 0`, the chat shape).
+		// A header already at or past the target is sent as-is.
+		if let Some(n) = (rolled.frame_size as usize).checked_sub(payload.len())
+			&& n > 0
+		{
+			header.pad = "0".repeat(n);
+			payload = serde_json::to_vec(&header)?;
+		}
+		let header = Bytes::from(payload);
 		group.write_frame(moq_net::Timestamp::now(), header.clone())?;
 		stats.frame_sent(header.len());
 
@@ -487,6 +502,39 @@ mod tests {
 		// Just the keyframe, then the group ends.
 		assert!(group.read_frame().await.unwrap().is_some(), "keyframe");
 		assert!(group.read_frame().await.unwrap().is_none(), "no payload frames");
+
+		task.abort();
+	}
+
+	/// A lone-keyframe group (`group_size = 0`) must still cost `frame_size`
+	/// bytes: the keyframe is padded via its `pad` field, and stays valid JSON.
+	/// Without this, the chat presets' frame_size setting had no effect at all.
+	#[tokio::test]
+	async fn keyframe_padded_to_frame_size() {
+		tokio::time::pause();
+
+		let stats = Arc::new(Stats::default());
+		let mut broadcast = broadcast::Info::new().produce();
+		let track = broadcast.create_track(TRACK, None).unwrap();
+		let consumer = broadcast.consume();
+
+		// 10fps, 300-byte messages, lone-keyframe groups (the chat shape).
+		let task = tokio::spawn(produce(
+			3,
+			"bench/test".into(),
+			rolled(10, 300, 0),
+			track,
+			stats.clone(),
+		));
+		tokio::time::advance(Duration::from_millis(250)).await;
+
+		let mut sub = consumer.track(TRACK).unwrap().subscribe(None).await.unwrap();
+		let mut group = sub.next_group().await.unwrap().expect("a group");
+		let keyframe = group.read_frame().await.unwrap().expect("keyframe").payload;
+
+		assert_eq!(keyframe.len(), 300, "keyframe padded to the rolled frame size");
+		let header: serde_json::Value = serde_json::from_slice(&keyframe).expect("padded keyframe is valid JSON");
+		assert_eq!(header["frame_size"], 300);
 
 		task.abort();
 	}

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -539,6 +539,33 @@ mod tests {
 		task.abort();
 	}
 
+	/// A frame size below the JSON header's own length is a floor, not an error:
+	/// the keyframe goes out at its natural size and still parses. The chat
+	/// presets stay above the floor so their configured sizes hold exactly.
+	#[tokio::test]
+	async fn keyframe_below_header_floor_is_unpadded() {
+		tokio::time::pause();
+
+		let stats = Arc::new(Stats::default());
+		let mut broadcast = broadcast::Info::new().produce();
+		let track = broadcast.create_track(TRACK, None).unwrap();
+		let consumer = broadcast.consume();
+
+		// 50 bytes is well under the serialized header (roughly 170 bytes).
+		let task = tokio::spawn(produce(3, "bench/test".into(), rolled(10, 50, 0), track, stats.clone()));
+		tokio::time::advance(Duration::from_millis(250)).await;
+
+		let mut sub = consumer.track(TRACK).unwrap().subscribe(None).await.unwrap();
+		let mut group = sub.next_group().await.unwrap().expect("a group");
+		let keyframe = group.read_frame().await.unwrap().expect("keyframe").payload;
+
+		assert!(keyframe.len() > 50, "header is the floor; no truncation to fit");
+		let header: serde_json::Value = serde_json::from_slice(&keyframe).expect("unpadded keyframe is valid JSON");
+		assert_eq!(header["pad"], "");
+
+		task.abort();
+	}
+
 	/// Discovery must skip broadcasts outside the bench namespace: a relay with
 	/// stats publishing enabled announces `.stats/...` too, and a subscription
 	/// slot burned on it is never retried, so a chat-shaped run (`subscribe = 1`)
@@ -555,6 +582,13 @@ mod tests {
 			.create_broadcast(".stats/node/host", broadcast::Route::new().with_announce(true))
 			.unwrap();
 
+		// Our own broadcast: in the namespace, but excluded via the `own` set
+		// (paths relative to the namespace, matching the scoped announce consumer).
+		let _own = origin
+			.create_broadcast("bench/00000000/9/9", broadcast::Route::new().with_announce(true))
+			.unwrap();
+		let own = HashSet::from(["00000000/9/9".to_string()]);
+
 		// One legitimate peer under the bench namespace with a single finished group.
 		let mut peer = origin
 			.create_broadcast("bench/00000000/0/0", broadcast::Route::new().with_announce(true))
@@ -568,11 +602,11 @@ mod tests {
 		track.finish().unwrap();
 
 		let announced = discover(&origin, "bench");
-		subscribe(announced, HashSet::new(), 1, Duration::ZERO, stats.clone())
+		subscribe(announced, own, 1, Duration::ZERO, stats.clone())
 			.await
 			.unwrap();
 
-		// The one wanted slot went to the bench peer, not `.stats`.
+		// The one wanted slot went to the peer, not `.stats` and not our own.
 		assert_eq!(stats.frames_recv.load(Ordering::Relaxed), 1);
 		assert_eq!(stats.groups_recv.load(Ordering::Relaxed), 1);
 	}

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -259,6 +259,12 @@ fn discover(consume: &moq_net::origin::Producer, name: &str) -> moq_net::announc
 
 /// Watch announcements and drain up to `want` peer broadcasts (excluding our own),
 /// spreading each subscription's start over `startup` to avoid a thundering herd.
+///
+/// Candidates are gathered over the `startup` window and picked at random. The
+/// relay replays existing announcements in deterministic path order, so a
+/// first-come pick would put every subscriber on the same first few broadcasts
+/// and collapse the 1:N presets into hotspots. Announcements arriving after the
+/// window fill any remaining slots in arrival order.
 async fn subscribe(
 	mut announced: moq_net::announce::Consumer,
 	own: HashSet<String>,
@@ -268,38 +274,83 @@ async fn subscribe(
 ) -> anyhow::Result<()> {
 	let mut tasks = JoinSet::new();
 	let mut seen: HashSet<String> = HashSet::new();
+	let mut pool = Vec::new();
 
-	while (seen.len() as u64) < want {
+	// Gather candidates until the startup window closes (or the announce stream ends).
+	let deadline = tokio::time::sleep(startup);
+	tokio::pin!(deadline);
+	loop {
+		tokio::select! {
+			_ = &mut deadline => break,
+			update = announced.next() => {
+				let Some(moq_net::announce::Update { path, broadcast }) = update else { break };
+				let Some(broadcast) = broadcast else { continue };
+				let path = path.as_str().to_string();
+				if own.contains(&path) || !seen.insert(path.clone()) {
+					continue;
+				}
+				pool.push((path, broadcast));
+			}
+		}
+	}
+
+	pick_random(&mut pool, want as usize);
+	let mut selected = pool.len() as u64;
+	for (path, broadcast) in pool {
+		spawn_drain(&mut tasks, path, broadcast, startup, stats.clone());
+	}
+
+	// Top up from late announcements, first-come: the pool was too small, so
+	// there is nothing to spread over.
+	while selected < want {
 		let Some(moq_net::announce::Update { path, broadcast }) = announced.next().await else {
 			break;
 		};
 		let Some(broadcast) = broadcast else {
 			continue;
 		};
-
 		let path = path.as_str().to_string();
 		if own.contains(&path) || !seen.insert(path.clone()) {
 			continue;
 		}
-
-		// Stagger the subscription start somewhere within the startup window.
-		let delay = {
-			let mut rng = rand::rng();
-			startup.mul_f64(rng.random_range(0.0..1.0))
-		};
-
-		let stats = stats.clone();
-		tasks.spawn(async move {
-			tokio::time::sleep(delay).await;
-			if let Err(err) = drain(broadcast, &stats).await {
-				tracing::debug!(%path, %err, "subscription ended");
-			}
-		});
+		selected += 1;
+		spawn_drain(&mut tasks, path, broadcast, startup, stats.clone());
 	}
 
 	// Keep the drain tasks alive; they run until their broadcasts close.
 	while tasks.join_next().await.is_some() {}
 	Ok(())
+}
+
+/// Keep `want` elements of the pool, chosen uniformly at random (Fisher-Yates,
+/// then truncate). The whole pool survives when it is smaller than `want`.
+fn pick_random<T>(pool: &mut Vec<T>, want: usize) {
+	let mut rng = rand::rng();
+	for i in (1..pool.len()).rev() {
+		pool.swap(i, rng.random_range(0..=i));
+	}
+	pool.truncate(want);
+}
+
+/// Queue one broadcast for draining, staggered somewhere within the startup
+/// window so `want` subscriptions don't all fire at once.
+fn spawn_drain(
+	tasks: &mut JoinSet<()>,
+	path: String,
+	broadcast: broadcast::Consumer,
+	startup: Duration,
+	stats: Arc<Stats>,
+) {
+	let delay = {
+		let mut rng = rand::rng();
+		startup.mul_f64(rng.random_range(0.0..1.0))
+	};
+	tasks.spawn(async move {
+		tokio::time::sleep(delay).await;
+		if let Err(err) = drain(broadcast, &stats).await {
+			tracing::debug!(%path, %err, "subscription ended");
+		}
+	});
 }
 
 /// Subscribe to the broadcast's track, counting every frame received and tracking
@@ -609,6 +660,28 @@ mod tests {
 		// The one wanted slot went to the peer, not `.stats` and not our own.
 		assert_eq!(stats.frames_recv.load(Ordering::Relaxed), 1);
 		assert_eq!(stats.groups_recv.load(Ordering::Relaxed), 1);
+	}
+
+	/// Subscription targets must be picked at random from the gathered pool.
+	/// Announcements replay in deterministic path order, so a first-come pick
+	/// put every subscriber on the same first rooms and turned the 1:N presets
+	/// into hotspots on one or two broadcasts.
+	#[test]
+	fn pick_random_spreads_selections() {
+		let mut distinct = HashSet::new();
+		for _ in 0..64 {
+			let mut pool = vec![0, 1, 2, 3, 4, 5, 6, 7];
+			pick_random(&mut pool, 1);
+			distinct.insert(pool[0]);
+		}
+		// First-come always yields element 0. Randomness missing this over 64
+		// draws from 8 elements has probability (1/8)^63, i.e. never.
+		assert!(distinct.len() > 1, "selection must not be deterministic");
+
+		// A pool smaller than want survives whole.
+		let mut pool = vec![1, 2];
+		pick_random(&mut pool, 5);
+		assert_eq!(pool.len(), 2);
 	}
 
 	fn lost(stats: &Stats) -> u64 {

--- a/rs/moq-bench/src/host.rs
+++ b/rs/moq-bench/src/host.rs
@@ -9,21 +9,34 @@
 //! Every interval it writes one JSON line per sampled process. Counters are
 //! cumulative and monotonic, mirroring the moq-stats convention: a consumer diffs
 //! successive lines to compute rates, and a counter going backwards means the
-//! process restarted. Combine with the load generator's `--output` to compute
-//! CPU per connection and CPU per message (see the README).
+//! process restarted. The context-switch counters keep that promise across thread
+//! churn: an exited thread's contribution is retained rather than vanishing with
+//! its `/proc` entry. Combine with the load generator's `--output` to compute CPU
+//! per connection and CPU per message (see the README).
 
 #[cfg(target_os = "linux")]
 mod linux {
+	use std::collections::HashMap;
 	use std::io::Write;
 	use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+	use anyhow::Context;
 	use clap::Parser;
 	use procfs::CurrentSI;
 	use procfs::process::Process;
 	use serde::Serialize;
 
+	/// Parse a duration and reject zero: a zero interval would busy-loop over
+	/// /proc and flood the output, which a sampler meant to sit on production
+	/// hosts must never do.
+	fn positive_duration(arg: &str) -> anyhow::Result<Duration> {
+		let duration = humantime::parse_duration(arg)?;
+		anyhow::ensure!(!duration.is_zero(), "must be greater than 0s");
+		Ok(duration)
+	}
+
 	/// Sample CPU, memory, and context-switch counters for a running process.
-	#[derive(Parser)]
+	#[derive(Parser, Debug)]
 	#[command(version = env!("VERSION"))]
 	pub struct Args {
 		/// Sample these PIDs. When set, --name is ignored.
@@ -35,7 +48,7 @@ mod linux {
 		pub name: String,
 
 		/// How often to sample.
-		#[arg(long, value_parser = humantime::parse_duration, default_value = "1s")]
+		#[arg(long, value_parser = positive_duration, default_value = "1s")]
 		pub interval: Duration,
 
 		/// Stop after this duration. Runs until interrupted (or the targets exit) otherwise.
@@ -66,10 +79,10 @@ mod linux {
 		rss_bytes: u64,
 		threads: u64,
 		/// Voluntary context switches (blocked waiting for I/O or a lock), summed
-		/// across all threads. A dip means a thread exited and took its count along.
+		/// across all threads the sampler has seen, including exited ones.
 		ctx_voluntary: u64,
-		/// Involuntary context switches (preempted by the scheduler), summed across
-		/// all threads.
+		/// Involuntary context switches (preempted by the scheduler), summed the
+		/// same way.
 		ctx_involuntary: u64,
 		/// Busy (non-idle, non-iowait) seconds summed across every core on the host,
 		/// so the process's share of the whole machine is computable.
@@ -92,13 +105,56 @@ mod linux {
 		ctx_involuntary: u64,
 	}
 
+	/// Monotonic context-switch totals for one process.
+	///
+	/// `/proc/<pid>/task/*` counters vanish when a thread exits, so a plain
+	/// per-sample sum can go backwards, which would read as a process restart
+	/// downstream. Instead, only nonnegative per-thread deltas accumulate, and an
+	/// exited thread's contribution stays in the total.
+	#[derive(Default)]
+	struct CtxTotals {
+		/// Last observed cumulative counters per live thread.
+		seen: HashMap<i32, (u64, u64)>,
+		voluntary: u64,
+		involuntary: u64,
+	}
+
+	impl CtxTotals {
+		/// Fold one thread's current cumulative counters into the running totals.
+		fn observe(&mut self, tid: i32, voluntary: u64, involuntary: u64) {
+			let (prev_voluntary, prev_involuntary) = self.seen.get(&tid).copied().unwrap_or((0, 0));
+			self.voluntary += voluntary.saturating_sub(prev_voluntary);
+			self.involuntary += involuntary.saturating_sub(prev_involuntary);
+			self.seen.insert(tid, (voluntary, involuntary));
+		}
+
+		/// Forget threads that no longer exist, so a reused tid starts a fresh
+		/// baseline instead of diffing against a dead thread's counters.
+		fn retain(&mut self, live: impl Fn(i32) -> bool) {
+			self.seen.retain(|tid, _| live(*tid));
+		}
+	}
+
+	/// One process under observation: the /proc handle plus the sampler-side
+	/// state that outlives individual threads.
+	struct Target {
+		proc: Process,
+		ctx: CtxTotals,
+	}
+
 	/// Resolve the target processes from --pid or --name.
-	fn find(args: &Args) -> anyhow::Result<Vec<Process>> {
+	fn find(args: &Args) -> anyhow::Result<Vec<Target>> {
 		if !args.pid.is_empty() {
 			return args
 				.pid
 				.iter()
-				.map(|&pid| Process::new(pid).map_err(|err| anyhow::anyhow!("pid {pid}: {err}")))
+				.map(|&pid| {
+					let proc = Process::new(pid).with_context(|| format!("pid {pid}"))?;
+					Ok(Target {
+						proc,
+						ctx: CtxTotals::default(),
+					})
+				})
 				.collect();
 		}
 
@@ -109,45 +165,44 @@ mod linux {
 			let Ok(proc) = proc else { continue };
 			let Ok(stat) = proc.stat() else { continue };
 			if stat.comm == args.name {
-				found.push(proc);
+				found.push(Target {
+					proc,
+					ctx: CtxTotals::default(),
+				});
 			}
 		}
 		Ok(found)
 	}
 
 	/// Cumulative busy seconds across all cores, and the core count.
+	///
+	/// `guest`/`guest_nice` are excluded: the kernel already accounts guest time
+	/// inside `user`/`nice`, so adding them again would double-count it.
 	fn host_cpu(tps: f64) -> anyhow::Result<(f64, u64)> {
 		let kernel = procfs::KernelStats::current()?;
 		let t = &kernel.total;
-		let busy = t.user
-			+ t.nice + t.system
-			+ t.irq.unwrap_or(0)
-			+ t.softirq.unwrap_or(0)
-			+ t.steal.unwrap_or(0)
-			+ t.guest.unwrap_or(0)
-			+ t.guest_nice.unwrap_or(0);
+		let busy = t.user + t.nice + t.system + t.irq.unwrap_or(0) + t.softirq.unwrap_or(0) + t.steal.unwrap_or(0);
 		Ok((busy as f64 / tps, kernel.cpu_time.len() as u64))
 	}
 
 	/// Snapshot one process; `Err` means it exited (or /proc denied us) and should be dropped.
-	fn sample(proc: &Process, tps: f64, page: u64, threads: bool) -> anyhow::Result<Sample> {
-		let stat = proc.stat()?;
+	fn sample(target: &mut Target, tps: f64, page: u64, threads: bool) -> anyhow::Result<Sample> {
+		let stat = target.proc.stat()?;
 		let (host_cpu_busy, host_cores) = host_cpu(tps)?;
 
 		// /proc/<pid>/status reports the context-switch counters of the thread group
 		// leader alone (utime/stime in stat are the aggregated ones), so the
-		// process-wide numbers have to be summed over /proc/<pid>/task/*.
-		let mut ctx_voluntary = 0;
-		let mut ctx_involuntary = 0;
+		// process-wide numbers have to be folded over /proc/<pid>/task/*.
+		let mut live = Vec::new();
 		let mut per_thread = threads.then(Vec::new);
-		for task in proc.tasks()? {
+		for task in target.proc.tasks()? {
 			// Threads come and go mid-iteration; skip the ones that vanished.
 			let Ok(task) = task else { continue };
 			let Ok(tstatus) = task.status() else { continue };
 			let voluntary = tstatus.voluntary_ctxt_switches.unwrap_or(0);
 			let involuntary = tstatus.nonvoluntary_ctxt_switches.unwrap_or(0);
-			ctx_voluntary += voluntary;
-			ctx_involuntary += involuntary;
+			target.ctx.observe(task.tid, voluntary, involuntary);
+			live.push(task.tid);
 
 			if let Some(out) = &mut per_thread {
 				let Ok(tstat) = task.stat() else { continue };
@@ -162,17 +217,18 @@ mod linux {
 				});
 			}
 		}
+		target.ctx.retain(|tid| live.contains(&tid));
 
 		Ok(Sample {
 			timestamp_ms: SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
-			pid: proc.pid,
+			pid: target.proc.pid,
 			comm: stat.comm.clone(),
 			cpu_user: stat.utime as f64 / tps,
 			cpu_system: stat.stime as f64 / tps,
 			rss_bytes: stat.rss * page,
 			threads: stat.num_threads.max(0) as u64,
-			ctx_voluntary,
-			ctx_involuntary,
+			ctx_voluntary: target.ctx.voluntary,
+			ctx_involuntary: target.ctx.involuntary,
 			host_cpu_busy,
 			host_cores,
 			per_thread,
@@ -189,23 +245,27 @@ mod linux {
 			None => Box::new(std::io::stdout().lock()),
 		};
 
-		let mut procs = find(&args)?;
+		let mut targets = find(&args)?;
 		anyhow::ensure!(
-			!procs.is_empty(),
+			!targets.is_empty(),
 			"no process matched (name = {:?}); pass --pid or --name",
 			args.name
 		);
 		eprintln!(
 			"sampling {} process(es) every {}: {}",
-			procs.len(),
+			targets.len(),
 			humantime::format_duration(args.interval),
-			procs.iter().map(|p| p.pid.to_string()).collect::<Vec<_>>().join(", ")
+			targets
+				.iter()
+				.map(|t| t.proc.pid.to_string())
+				.collect::<Vec<_>>()
+				.join(", ")
 		);
 
 		let start = std::time::Instant::now();
 		loop {
 			// Drop targets that exited; sampling the survivors is still useful.
-			procs.retain(|proc| match sample(proc, tps, page, args.threads) {
+			targets.retain_mut(|target| match sample(target, tps, page, args.threads) {
 				Ok(record) => {
 					// A serialization failure is a bug, not a runtime condition.
 					let line = serde_json::to_string(&record).expect("sample must serialize");
@@ -216,20 +276,64 @@ mod linux {
 					true
 				}
 				Err(_) => {
-					eprintln!("pid {} exited, dropping", proc.pid);
+					eprintln!("pid {} exited, dropping", target.proc.pid);
 					false
 				}
 			});
 			// Every line lands on disk before the sleep, so a Ctrl-C loses nothing.
 			out.flush()?;
 
-			anyhow::ensure!(!procs.is_empty(), "all target processes exited");
+			anyhow::ensure!(!targets.is_empty(), "all target processes exited");
 			if let Some(duration) = args.duration
 				&& start.elapsed() >= duration
 			{
 				return Ok(());
 			}
 			std::thread::sleep(args.interval);
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+
+		/// `--interval 0s` must be rejected at parse time: with no pacing the
+		/// sampler busy-loops over /proc on the very hosts it is meant to be
+		/// harmless on.
+		#[test]
+		fn zero_interval_rejected() {
+			let err = Args::try_parse_from(["moq-bench-host", "--interval", "0s"]).unwrap_err();
+			assert!(err.to_string().contains("greater than 0s"), "unexpected error: {err}");
+
+			// Nonzero still parses, and the default holds.
+			let args = Args::try_parse_from(["moq-bench-host"]).unwrap();
+			assert_eq!(args.interval, Duration::from_secs(1));
+		}
+
+		/// The process-wide context-switch totals must stay monotonic when a
+		/// thread exits between samples. A naive per-sample sum would drop the
+		/// dead thread's counters, go backwards, and read as a process restart
+		/// downstream.
+		#[test]
+		fn ctx_totals_survive_thread_exit() {
+			let mut ctx = CtxTotals::default();
+
+			// Sample 1: two live threads.
+			ctx.observe(1, 10, 1);
+			ctx.observe(2, 5, 2);
+			ctx.retain(|tid| [1, 2].contains(&tid));
+			assert_eq!((ctx.voluntary, ctx.involuntary), (15, 3));
+
+			// Sample 2: thread 2 exited; thread 1 advanced. Thread 2's counts stay.
+			ctx.observe(1, 12, 1);
+			ctx.retain(|tid| tid == 1);
+			assert_eq!((ctx.voluntary, ctx.involuntary), (17, 3));
+
+			// Sample 3: tid 2 is reused by a fresh thread; its counters start over
+			// and must add in full rather than diff against the dead thread's.
+			ctx.observe(1, 12, 1);
+			ctx.observe(2, 3, 1);
+			assert_eq!((ctx.voluntary, ctx.involuntary), (20, 4));
 		}
 	}
 }

--- a/rs/moq-bench/src/host.rs
+++ b/rs/moq-bench/src/host.rs
@@ -1,0 +1,245 @@
+//! Host-side resource sampler, the other half of `moq-bench`.
+//!
+//! `moq-bench` drives load from one machine; this binary runs next to the process
+//! under test (a relay, usually) and records what that load costs. It is safe on
+//! production hosts: it only reads `/proc`, needs no privileges beyond visibility
+//! of the target process, and never touches the process itself (no ptrace, no
+//! perf, no signals).
+//!
+//! Every interval it writes one JSON line per sampled process. Counters are
+//! cumulative and monotonic, mirroring the moq-stats convention: a consumer diffs
+//! successive lines to compute rates, and a counter going backwards means the
+//! process restarted. Combine with the load generator's `--output` to compute
+//! CPU per connection and CPU per message (see the README).
+
+#[cfg(target_os = "linux")]
+mod linux {
+	use std::io::Write;
+	use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+	use clap::Parser;
+	use procfs::CurrentSI;
+	use procfs::process::Process;
+	use serde::Serialize;
+
+	/// Sample CPU, memory, and context-switch counters for a running process.
+	#[derive(Parser)]
+	#[command(version = env!("VERSION"))]
+	pub struct Args {
+		/// Sample these PIDs. When set, --name is ignored.
+		#[arg(long)]
+		pub pid: Vec<i32>,
+
+		/// Find target processes by name (/proc/<pid>/comm, 15 bytes max).
+		#[arg(long, default_value = "moq-relay")]
+		pub name: String,
+
+		/// How often to sample.
+		#[arg(long, value_parser = humantime::parse_duration, default_value = "1s")]
+		pub interval: Duration,
+
+		/// Stop after this duration. Runs until interrupted (or the targets exit) otherwise.
+		#[arg(long, value_parser = humantime::parse_duration)]
+		pub duration: Option<Duration>,
+
+		/// Write JSON lines to this file instead of stdout. Truncates on start.
+		#[arg(long)]
+		pub output: Option<std::path::PathBuf>,
+
+		/// Include a per-thread breakdown in every sample. Costs one /proc read per
+		/// thread per interval, so leave it off for casual monitoring.
+		#[arg(long)]
+		pub threads: bool,
+	}
+
+	/// One process snapshot. All counters are cumulative since process (or system) start.
+	#[derive(Serialize)]
+	struct Sample {
+		/// Wall-clock milliseconds since the Unix epoch.
+		timestamp_ms: u128,
+		pid: i32,
+		comm: String,
+		/// Seconds this process spent in user mode.
+		cpu_user: f64,
+		/// Seconds this process spent in kernel mode.
+		cpu_system: f64,
+		rss_bytes: u64,
+		threads: u64,
+		/// Voluntary context switches (blocked waiting for I/O or a lock), summed
+		/// across all threads. A dip means a thread exited and took its count along.
+		ctx_voluntary: u64,
+		/// Involuntary context switches (preempted by the scheduler), summed across
+		/// all threads.
+		ctx_involuntary: u64,
+		/// Busy (non-idle, non-iowait) seconds summed across every core on the host,
+		/// so the process's share of the whole machine is computable.
+		host_cpu_busy: f64,
+		host_cores: u64,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		per_thread: Option<Vec<ThreadSample>>,
+	}
+
+	/// One thread's slice of a [`Sample`], for spotting scheduler imbalance and
+	/// verifying pinning (the `processor` field is the core it last ran on).
+	#[derive(Serialize)]
+	struct ThreadSample {
+		tid: i32,
+		name: String,
+		cpu_user: f64,
+		cpu_system: f64,
+		processor: i32,
+		ctx_voluntary: u64,
+		ctx_involuntary: u64,
+	}
+
+	/// Resolve the target processes from --pid or --name.
+	fn find(args: &Args) -> anyhow::Result<Vec<Process>> {
+		if !args.pid.is_empty() {
+			return args
+				.pid
+				.iter()
+				.map(|&pid| Process::new(pid).map_err(|err| anyhow::anyhow!("pid {pid}: {err}")))
+				.collect();
+		}
+
+		// A process can exit between the directory listing and the stat read, so
+		// per-process errors here mean "gone", not failure.
+		let mut found = Vec::new();
+		for proc in procfs::process::all_processes()? {
+			let Ok(proc) = proc else { continue };
+			let Ok(stat) = proc.stat() else { continue };
+			if stat.comm == args.name {
+				found.push(proc);
+			}
+		}
+		Ok(found)
+	}
+
+	/// Cumulative busy seconds across all cores, and the core count.
+	fn host_cpu(tps: f64) -> anyhow::Result<(f64, u64)> {
+		let kernel = procfs::KernelStats::current()?;
+		let t = &kernel.total;
+		let busy = t.user
+			+ t.nice + t.system
+			+ t.irq.unwrap_or(0)
+			+ t.softirq.unwrap_or(0)
+			+ t.steal.unwrap_or(0)
+			+ t.guest.unwrap_or(0)
+			+ t.guest_nice.unwrap_or(0);
+		Ok((busy as f64 / tps, kernel.cpu_time.len() as u64))
+	}
+
+	/// Snapshot one process; `Err` means it exited (or /proc denied us) and should be dropped.
+	fn sample(proc: &Process, tps: f64, page: u64, threads: bool) -> anyhow::Result<Sample> {
+		let stat = proc.stat()?;
+		let (host_cpu_busy, host_cores) = host_cpu(tps)?;
+
+		// /proc/<pid>/status reports the context-switch counters of the thread group
+		// leader alone (utime/stime in stat are the aggregated ones), so the
+		// process-wide numbers have to be summed over /proc/<pid>/task/*.
+		let mut ctx_voluntary = 0;
+		let mut ctx_involuntary = 0;
+		let mut per_thread = threads.then(Vec::new);
+		for task in proc.tasks()? {
+			// Threads come and go mid-iteration; skip the ones that vanished.
+			let Ok(task) = task else { continue };
+			let Ok(tstatus) = task.status() else { continue };
+			let voluntary = tstatus.voluntary_ctxt_switches.unwrap_or(0);
+			let involuntary = tstatus.nonvoluntary_ctxt_switches.unwrap_or(0);
+			ctx_voluntary += voluntary;
+			ctx_involuntary += involuntary;
+
+			if let Some(out) = &mut per_thread {
+				let Ok(tstat) = task.stat() else { continue };
+				out.push(ThreadSample {
+					tid: task.tid,
+					name: tstat.comm,
+					cpu_user: tstat.utime as f64 / tps,
+					cpu_system: tstat.stime as f64 / tps,
+					processor: tstat.processor.unwrap_or(-1),
+					ctx_voluntary: voluntary,
+					ctx_involuntary: involuntary,
+				});
+			}
+		}
+
+		Ok(Sample {
+			timestamp_ms: SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+			pid: proc.pid,
+			comm: stat.comm.clone(),
+			cpu_user: stat.utime as f64 / tps,
+			cpu_system: stat.stime as f64 / tps,
+			rss_bytes: stat.rss * page,
+			threads: stat.num_threads.max(0) as u64,
+			ctx_voluntary,
+			ctx_involuntary,
+			host_cpu_busy,
+			host_cores,
+			per_thread,
+		})
+	}
+
+	pub fn run() -> anyhow::Result<()> {
+		let args = Args::parse();
+		let tps = procfs::ticks_per_second() as f64;
+		let page = procfs::page_size();
+
+		let mut out: Box<dyn Write> = match &args.output {
+			Some(path) => Box::new(std::fs::File::create(path)?),
+			None => Box::new(std::io::stdout().lock()),
+		};
+
+		let mut procs = find(&args)?;
+		anyhow::ensure!(
+			!procs.is_empty(),
+			"no process matched (name = {:?}); pass --pid or --name",
+			args.name
+		);
+		eprintln!(
+			"sampling {} process(es) every {}: {}",
+			procs.len(),
+			humantime::format_duration(args.interval),
+			procs.iter().map(|p| p.pid.to_string()).collect::<Vec<_>>().join(", ")
+		);
+
+		let start = std::time::Instant::now();
+		loop {
+			// Drop targets that exited; sampling the survivors is still useful.
+			procs.retain(|proc| match sample(proc, tps, page, args.threads) {
+				Ok(record) => {
+					// A serialization failure is a bug, not a runtime condition.
+					let line = serde_json::to_string(&record).expect("sample must serialize");
+					if let Err(err) = writeln!(out, "{line}") {
+						eprintln!("write failed: {err}");
+						std::process::exit(1);
+					}
+					true
+				}
+				Err(_) => {
+					eprintln!("pid {} exited, dropping", proc.pid);
+					false
+				}
+			});
+			// Every line lands on disk before the sleep, so a Ctrl-C loses nothing.
+			out.flush()?;
+
+			anyhow::ensure!(!procs.is_empty(), "all target processes exited");
+			if let Some(duration) = args.duration
+				&& start.elapsed() >= duration
+			{
+				return Ok(());
+			}
+			std::thread::sleep(args.interval);
+		}
+	}
+}
+
+#[cfg(target_os = "linux")]
+fn main() -> anyhow::Result<()> {
+	linux::run()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() -> anyhow::Result<()> {
+	anyhow::bail!("moq-bench-host reads /proc, so it only runs on Linux")
+}

--- a/rs/moq-bench/src/host.rs
+++ b/rs/moq-bench/src/host.rs
@@ -185,10 +185,12 @@ mod linux {
 		Ok((busy as f64 / tps, kernel.cpu_time.len() as u64))
 	}
 
-	/// Snapshot one process; `Err` means it exited (or /proc denied us) and should be dropped.
-	fn sample(target: &mut Target, tps: f64, page: u64, threads: bool) -> anyhow::Result<Sample> {
+	/// Snapshot one process; `Err` means it exited (or /proc denied us) and should
+	/// be dropped. Everything read here is per-target, so an error only ever
+	/// condemns this target; host-wide reads live in the caller and fail the run.
+	fn sample(target: &mut Target, tps: f64, page: u64, threads: bool, host: (f64, u64)) -> anyhow::Result<Sample> {
 		let stat = target.proc.stat()?;
-		let (host_cpu_busy, host_cores) = host_cpu(tps)?;
+		let (host_cpu_busy, host_cores) = host;
 
 		// /proc/<pid>/status reports the context-switch counters of the thread group
 		// leader alone (utime/stime in stat are the aggregated ones), so the
@@ -220,7 +222,10 @@ mod linux {
 		target.ctx.retain(|tid| live.contains(&tid));
 
 		Ok(Sample {
-			timestamp_ms: SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+			timestamp_ms: SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.unwrap_or_default()
+				.as_millis(),
 			pid: target.proc.pid,
 			comm: stat.comm.clone(),
 			cpu_user: stat.utime as f64 / tps,
@@ -235,6 +240,8 @@ mod linux {
 		})
 	}
 
+	/// Resolve the targets, then sample them every interval until the duration
+	/// elapses, the process is interrupted, or every target exits (an error).
 	pub fn run() -> anyhow::Result<()> {
 		let args = Args::parse();
 		let tps = procfs::ticks_per_second() as f64;
@@ -264,8 +271,12 @@ mod linux {
 
 		let start = std::time::Instant::now();
 		loop {
+			// Host-wide once per round: unlike the per-target reads inside `sample`,
+			// a failure here is not a target exiting, so it fails the run.
+			let host = host_cpu(tps).context("failed to read /proc/stat")?;
+
 			// Drop targets that exited; sampling the survivors is still useful.
-			targets.retain_mut(|target| match sample(target, tps, page, args.threads) {
+			targets.retain_mut(|target| match sample(target, tps, page, args.threads, host) {
 				Ok(record) => {
 					// A serialization failure is a bug, not a runtime condition.
 					let line = serde_json::to_string(&record).expect("sample must serialize");
@@ -284,13 +295,25 @@ mod linux {
 			out.flush()?;
 
 			anyhow::ensure!(!targets.is_empty(), "all target processes exited");
-			if let Some(duration) = args.duration
-				&& start.elapsed() >= duration
-			{
+			let Some(delay) = next_delay(args.interval, args.duration, start.elapsed()) else {
 				return Ok(());
-			}
-			std::thread::sleep(args.interval);
+			};
+			std::thread::sleep(delay);
 		}
+	}
+
+	/// How long to sleep before the next sample: the interval, capped at the time
+	/// left in `duration`. `None` means the duration has elapsed and the run is
+	/// done, so a `--duration` shorter than `--interval` cannot overshoot.
+	fn next_delay(interval: Duration, duration: Option<Duration>, elapsed: Duration) -> Option<Duration> {
+		let Some(duration) = duration else {
+			return Some(interval);
+		};
+		let remaining = duration.checked_sub(elapsed)?;
+		if remaining.is_zero() {
+			return None;
+		}
+		Some(interval.min(remaining))
 	}
 
 	#[cfg(test)]
@@ -308,6 +331,23 @@ mod linux {
 			// Nonzero still parses, and the default holds.
 			let args = Args::try_parse_from(["moq-bench-host"]).unwrap();
 			assert_eq!(args.interval, Duration::from_secs(1));
+		}
+
+		/// A duration shorter than the interval must cap the sleep, not stretch the
+		/// run to the full interval (10ms of sampling used to take a whole second).
+		#[test]
+		fn short_duration_caps_the_sleep() {
+			let second = Duration::from_secs(1);
+			let ms = Duration::from_millis(10);
+
+			// No duration: always the full interval.
+			assert_eq!(next_delay(second, None, second * 100), Some(second));
+			// Time remains: sleep the smaller of interval and what's left.
+			assert_eq!(next_delay(second, Some(ms), Duration::ZERO), Some(ms));
+			assert_eq!(next_delay(ms, Some(second), Duration::ZERO), Some(ms));
+			// Elapsed at or past the duration: done.
+			assert_eq!(next_delay(second, Some(ms), ms), None);
+			assert_eq!(next_delay(second, Some(ms), second), None);
 		}
 
 		/// The process-wide context-switch totals must stay monotonic when a

--- a/rs/moq-bench/src/main.rs
+++ b/rs/moq-bench/src/main.rs
@@ -31,11 +31,12 @@ async fn main() -> anyhow::Result<()> {
 	let client = config.client.clone().init()?;
 	let stats = Arc::new(Stats::default());
 
-	// Periodic throughput reporter.
+	// Periodic throughput reporter, optionally mirrored to a JSONL file.
 	{
 		let stats = stats.clone();
 		let interval = config.report();
-		tokio::spawn(async move { stats.report(interval).await });
+		let output = config.output.as_ref().map(std::fs::File::create).transpose()?;
+		tokio::spawn(async move { stats.report(interval, output).await });
 	}
 
 	// Roll the per-connection parameters up front: `ThreadRng` is not `Send`, so it

--- a/rs/moq-bench/src/main.rs
+++ b/rs/moq-bench/src/main.rs
@@ -31,13 +31,14 @@ async fn main() -> anyhow::Result<()> {
 	let client = config.client.clone().init()?;
 	let stats = Arc::new(Stats::default());
 
-	// Periodic throughput reporter, optionally mirrored to a JSONL file.
-	{
+	// Periodic throughput reporter, optionally mirrored to a JSONL file. Keep the
+	// handle: a failed stats write must fail the whole run (see Stats::report).
+	let mut reporter = {
 		let stats = stats.clone();
 		let interval = config.report();
 		let output = config.output.as_ref().map(std::fs::File::create).transpose()?;
-		tokio::spawn(async move { stats.report(interval, output).await });
-	}
+		tokio::spawn(async move { stats.report(interval, output).await })
+	};
 
 	// Roll the per-connection parameters up front: `ThreadRng` is not `Send`, so it
 	// can't cross the spawn boundary.
@@ -93,6 +94,9 @@ async fn main() -> anyhow::Result<()> {
 		_ = stop => tracing::info!("duration elapsed, stopping"),
 		_ = tokio::signal::ctrl_c() => tracing::info!("interrupted, stopping"),
 		_ = drained => tracing::warn!("all connections ended"),
+		// The reporter only returns on a stats-output failure; die loudly rather
+		// than exit green with a partial JSONL file.
+		res = &mut reporter => res??,
 	}
 
 	Ok(())

--- a/rs/moq-bench/src/stats.rs
+++ b/rs/moq-bench/src/stats.rs
@@ -1,5 +1,8 @@
+use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
 
 /// Shared counters bumped by the connection tasks and drained by the reporter.
 #[derive(Default)]
@@ -32,7 +35,11 @@ impl Stats {
 	}
 
 	/// Periodically log totals plus the throughput since the previous report.
-	pub async fn report(&self, interval: Duration) {
+	///
+	/// With an `output` file, each report also appends one JSON line of the
+	/// cumulative counters, timestamped so it can be joined against the host
+	/// sampler's records (see `moq-bench-host`).
+	pub async fn report(&self, interval: Duration, mut output: Option<std::fs::File>) {
 		let mut ticker = tokio::time::interval(interval);
 		// Skip the immediate first tick so the first report covers a full interval.
 		ticker.tick().await;
@@ -41,6 +48,24 @@ impl Stats {
 		loop {
 			ticker.tick().await;
 			let now = Snapshot::take(self);
+
+			if let Some(file) = &mut output {
+				let record = Record {
+					timestamp_ms: SystemTime::now()
+						.duration_since(UNIX_EPOCH)
+						.unwrap_or_default()
+						.as_millis(),
+					snapshot: &now,
+				};
+				// A serialization failure is a bug, not a runtime condition.
+				let line = serde_json::to_string(&record).expect("stats must serialize");
+				// Losing lines mid-run makes the whole file lie, so stop writing at
+				// the first error instead of leaving a silent gap.
+				if let Err(err) = writeln!(file, "{line}").and_then(|_| file.flush()) {
+					tracing::error!(%err, "stats output failed, disabling");
+					output = None;
+				}
+			}
 			let secs = interval.as_secs_f64().max(f64::MIN_POSITIVE);
 
 			let send_mbps = (now.bytes_sent.saturating_sub(prev.bytes_sent) as f64 * 8.0) / secs / 1e6;
@@ -75,6 +100,18 @@ impl Stats {
 	}
 }
 
+/// One machine-readable stats line: a timestamp plus the cumulative counters.
+/// Cumulative and monotonic like moq-stats frames: consumers diff successive
+/// lines to compute rates.
+#[derive(Serialize)]
+struct Record<'a> {
+	/// Wall-clock milliseconds since the Unix epoch.
+	timestamp_ms: u128,
+	#[serde(flatten)]
+	snapshot: &'a Snapshot,
+}
+
+#[derive(Serialize)]
 struct Snapshot {
 	connections: u64,
 	broadcasts: u64,

--- a/rs/moq-bench/src/stats.rs
+++ b/rs/moq-bench/src/stats.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use anyhow::Context;
 use serde::Serialize;
 
 /// Shared counters bumped by the connection tasks and drained by the reporter.
@@ -38,8 +39,10 @@ impl Stats {
 	///
 	/// With an `output` file, each report also appends one JSON line of the
 	/// cumulative counters, timestamped so it can be joined against the host
-	/// sampler's records (see `moq-bench-host`).
-	pub async fn report(&self, interval: Duration, mut output: Option<std::fs::File>) {
+	/// sampler's records (see `moq-bench-host`). Returns only on a failed write:
+	/// a benchmark whose recorded stats are partial is invalid, so the caller
+	/// must fail the run rather than exit green.
+	pub async fn report(&self, interval: Duration, mut output: Option<std::fs::File>) -> anyhow::Result<()> {
 		let mut ticker = tokio::time::interval(interval);
 		// Skip the immediate first tick so the first report covers a full interval.
 		ticker.tick().await;
@@ -59,12 +62,9 @@ impl Stats {
 				};
 				// A serialization failure is a bug, not a runtime condition.
 				let line = serde_json::to_string(&record).expect("stats must serialize");
-				// Losing lines mid-run makes the whole file lie, so stop writing at
-				// the first error instead of leaving a silent gap.
-				if let Err(err) = writeln!(file, "{line}").and_then(|_| file.flush()) {
-					tracing::error!(%err, "stats output failed, disabling");
-					output = None;
-				}
+				writeln!(file, "{line}")
+					.and_then(|_| file.flush())
+					.context("failed to write stats output")?;
 			}
 			let secs = interval.as_secs_f64().max(f64::MIN_POSITIVE);
 
@@ -139,5 +139,35 @@ impl Snapshot {
 			groups_expected: stats.groups_expected.load(Ordering::Relaxed),
 			groups_present: stats.groups_present.load(Ordering::Relaxed),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::Arc;
+
+	use super::*;
+
+	/// A failed stats write must surface as an error so the run dies loudly.
+	/// Silently dropping output leaves a partial JSONL file behind a green exit,
+	/// which reads as a valid benchmark that quietly lost data.
+	#[tokio::test(start_paused = true)]
+	async fn report_fails_on_output_error() {
+		let dir = std::env::temp_dir().join("moq-bench-stats-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("out.jsonl");
+		std::fs::write(&path, b"").unwrap();
+		// A read-only handle: the first write fails.
+		let file = std::fs::File::open(&path).unwrap();
+
+		let stats = Arc::new(Stats::default());
+		let task = tokio::spawn({
+			let stats = stats.clone();
+			async move { stats.report(Duration::from_secs(1), Some(file)).await }
+		});
+
+		tokio::time::advance(Duration::from_secs(3)).await;
+		let result = task.await.unwrap();
+		assert!(result.is_err(), "report must surface the output failure");
 	}
 }

--- a/rs/moq-bench/src/stats.rs
+++ b/rs/moq-bench/src/stats.rs
@@ -151,8 +151,10 @@ mod tests {
 	/// A failed stats write must surface as an error so the run dies loudly.
 	/// Silently dropping output leaves a partial JSONL file behind a green exit,
 	/// which reads as a valid benchmark that quietly lost data.
-	#[tokio::test(start_paused = true)]
+	#[tokio::test]
 	async fn report_fails_on_output_error() {
+		tokio::time::pause();
+
 		let dir = std::env::temp_dir().join("moq-bench-stats-test");
 		std::fs::create_dir_all(&dir).unwrap();
 		let path = dir.join("out.jsonl");


### PR DESCRIPTION
First slice of #2876 (Milestone 0 of the thread-per-core runtime plan, #2875): the tooling to measure what a chat-shaped load costs the relay, runnable against production hosts.

## What's here

**`moq-bench-host`, a new binary in the moq-bench crate.** It runs next to the process under test and is safe on production relays: it only reads `/proc` (Linux-only), needs no privileges beyond visibility of the target process, and never touches the process (no ptrace, no perf, no signals). Every interval it emits one JSON line per process with cumulative CPU seconds, RSS, and context switches, plus host-wide busy CPU so share-of-machine is computable. `--threads` adds a per-thread breakdown including the core each thread last ran on, which is how pinning gets verified once a thread-per-core relay mode exists (M1). Host metrics stay out of the relay itself, matching the existing separation of concerns (`rs/moq-relay/src/internal.rs` deliberately excludes them).

**`moq-bench --output`**: mirrors each report interval to a JSONL file of cumulative counters, timestamped so it joins against the sampler's records. The README documents the formulas (CPU per connection, CPU per message, context switches per message).

**Chat presets**: `chat.toml` (1:1, tiny frames, one group per message) and the `chat-pub.toml` / `chat-sub.toml` pair (1:N rooms via two instances discovering each other through announcements).

**`just rs bench <preset> <url>` and `just rs bench-host`** wrap the two binaries.

## Bug found and fixed along the way

The end-to-end smoke test surfaced a moq-bench bug that specifically breaks benchmarking production-shaped relays: a relay with stats publishing enabled announces its own `.stats/...` broadcasts, the subscribe side counted any announcement against its `want` budget, and a slot burned on a relay-internal broadcast errored out (`code=13`, no `data` track) without retry. A chat-shaped run with `subscribe = 1` ended up with zero working subscriptions.

Root cause: discovery was unscoped. Fix: root the announce consumer at the bench namespace with `with_root`, so relay-internal broadcasts are never announced to the bench at all. Regression test included (`subscribe_ignores_relay_internal_broadcasts`), verified to fail against the unscoped consumer.

## Testing

- `cargo test -p moq-bench`: 13 tests pass, including the new regression test and a config-merge test for `--output`.
- `cargo clippy --all-targets` (`-D warnings`), `cargo fmt --check`, and `cargo doc` (`-D warnings`) clean on the crate.
- End-to-end smoke: local relay (stats enabled) + `chat.toml` at 20 connections + `moq-bench-host` sampling it. 20/20 subscriptions, zero group loss, and the two JSONL outputs join on `timestamp_ms`. `nix` was unavailable in this environment, so this ran through `cargo` directly rather than `just check`/`just test`; the recipes run the same commands.
- Context switches are summed over `/proc/<pid>/task/*` because `/proc/<pid>/status` only reports the thread-group leader (verified against a live multi-threaded process: leader showed 234 voluntary switches while one worker alone had 7k).

## Cross-package sync

moq-bench is an unpublished internal tool with no doc-site page or wrapper bindings, so no table rows apply. No wire changes, so no `drafts/` update.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjBDLC46WXZQmh5zKWEtra)_