### PR TITLE
chore: remove GitHub CLI from Nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -219,11 +219,9 @@
             gzip
           ];
 
-        # Developer workflow tooling not needed for builds: the GitHub CLI
-        # for opening/reviewing PRs, plus jq to read `cargo metadata` in
-        # `just rs check-changed`.
+        # Developer workflow tooling not needed for builds: jq reads
+        # `cargo metadata` in `just rs check-changed`.
         devTools = with pkgs; [
-          gh
           jq
         ];
 


### PR DESCRIPTION
## Summary

- stop installing the GitHub CLI through the Nix development shell
- keep `jq` as the only developer workflow tool in `devTools`
- leave GitHub-dependent workflows available to users who install `gh` separately

## Public API changes

None.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test default origin/main`

(Written by GPT-5)