### PR TITLE
fix(cli): serve TCP and Unix listeners without QUIC

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -84,8 +84,13 @@ moq <MoQ side>  play [playback options]
   - `--connect <url>` dials a relay. The URL path is the relay auth path
     (e.g. `/anon`), `?jwt=<token>` supplies a token, and `--broadcast` names the
     broadcast.
-  - `--listen <addr>` hosts MoQ sessions directly (with `--listen-tls-generate` /
-    `--listen-tls-cert` + `--listen-tls-key`).
+  - `--listen <addr>` hosts encrypted QUIC/WebTransport sessions directly (with
+    `--listen-tls-generate` / `--listen-tls-cert` + `--listen-tls-key`).
+  - `--listen-tcp-bind <addr>` hosts plaintext qmux over TCP. Bind it only to
+    loopback or a trusted private network.
+  - `--listen-unix-bind <path>` hosts qmux over a Unix socket. The socket's
+    filesystem permissions control access, and an optional peer-credential
+    allowlist can restrict it further.
   - `--cluster-lan` meshes with every other participating process on the LAN via
     mDNS, no relay or internet needed. See [LAN Cluster](#lan-cluster-mdns).
 

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -88,9 +88,9 @@ moq <MoQ side>  play [playback options]
     `--listen-tls-generate` / `--listen-tls-cert` + `--listen-tls-key`).
   - `--listen-tcp-bind <addr>` hosts plaintext qmux over TCP. Bind it only to
     loopback or a trusted private network.
-  - `--listen-unix-bind <path>` hosts qmux over a Unix socket. The socket's
-    filesystem permissions control access, and an optional peer-credential
-    allowlist can restrict it further.
+  - `--listen-unix-bind <path>` hosts qmux over a Unix socket. The socket is
+    created with mode `0666`, so restrict access through its parent directory or
+    an explicit peer-credential allowlist.
   - `--cluster-lan` meshes with every other participating process on the LAN via
     mDNS, no relay or internet needed. See [LAN Cluster](#lan-cluster-mdns).
 

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -331,7 +331,9 @@ A Unix socket lets the relay additionally gate the connecting process by its
 kernel credentials (`SO_PEERCRED` / `LOCAL_PEERCRED`), so you can restrict
 access to a specific worker user. Requires the relay to be built with the `uds`
 feature. The allowlist (`--listen-unix-allow-uid` / `-gid` / `-pid`) applies to
-the `unix://` listener.
+the `unix://` listener. The socket is created with mode `0666`, so use a
+restrictive parent directory or an explicit allowlist when local users must not
+reach it.
 
 ```toml
 [listen.unix]

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -72,7 +72,8 @@ moq-audio = { workspace = true, optional = true }
 # `server` enables the HTTP egress server for `moq export hls`; the importer is always available.
 moq-hls = { workspace = true, features = ["server"] }
 moq-mux = { workspace = true }
-moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
+# Raw qmux listeners are part of the CLI surface. `uds` compiles only on Unix.
+moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs", "tcp", "uds"] }
 moq-rtc = { workspace = true }
 moq-rtmp = { workspace = true }
 moq-srt = { workspace = true }

--- a/rs/moq-cli/README.md
+++ b/rs/moq-cli/README.md
@@ -19,7 +19,7 @@ Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub
 
 ## Usage
 
-`moq-cli` routes endpoints onto a shared MoQ Origin: `moq <MoQ side> <import|export> <endpoint>`. The MoQ side (before the verb) is either `--connect <url>` (dial a relay) or `--listen <addr>` (self-host). `import` moves media into MoQ, `export` moves it out. The endpoint is a container format (`fmp4`, `ts`, `flv`, ... read from stdin / written to stdout), or a gateway (`hls`, `rtmp`, `srt`, `rtc`). A build with the `play` feature can also render a broadcast locally with `moq <MoQ side> play`.
+`moq-cli` routes endpoints onto a shared MoQ Origin: `moq <MoQ side> <import|export> <endpoint>`. The MoQ side (before the verb) dials with `--connect <url>`, self-hosts QUIC/WebTransport with `--listen <addr>`, or self-hosts raw qmux with `--listen-tcp-bind <addr>` / `--listen-unix-bind <path>` (Unix only). `import` moves media into MoQ, `export` moves it out. The endpoint is a container format (`fmp4`, `ts`, `flv`, ... read from stdin / written to stdout), or a gateway (`hls`, `rtmp`, `srt`, `rtc`). A build with the `play` feature can also render a broadcast locally with `moq <MoQ side> play`.
 
 Separate additional stages with `--` to bridge several broadcasts (or both directions) over one connection, each naming its own `--broadcast`:
 

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -321,7 +321,18 @@ impl MoqSide {
 		];
 		let ignored = ignored.into_iter().find(|(_, given)| *given).map(|(flag, _)| flag);
 		#[cfg(unix)]
-		let ignored = ignored.or_else(|| listen.unix.bind.is_some().then_some("--listen-unix-bind"));
+		let ignored = ignored
+			.or_else(|| listen.unix.bind.is_some().then_some("--listen-unix-bind"))
+			.or_else(|| {
+				let allow = listen.unix.allow.as_ref()?;
+				[
+					("--listen-unix-allow-uid", !allow.uid.is_empty()),
+					("--listen-unix-allow-gid", !allow.gid.is_empty()),
+					("--listen-unix-allow-pid", !allow.pid.is_empty()),
+				]
+				.into_iter()
+				.find_map(|(flag, given)| given.then_some(flag))
+			});
 
 		if let Some(flag) = ignored {
 			anyhow::bail!("`{command}` runs locally and takes no MoQ side; drop {flag}");
@@ -959,10 +970,17 @@ mod tests {
 
 		#[cfg(unix)]
 		{
-			let cli =
-				Cli::try_parse_from(["moq", "--listen-unix-bind", "/tmp/moq-cli.sock", "token", "generate"]).unwrap();
-			let err = cli.moq.reject("token").unwrap_err().to_string();
-			assert!(err.contains("--listen-unix-bind"), "{err}");
+			for (flag, value, reported) in [
+				("--listen-unix-bind", "/tmp/moq-cli.sock", "--listen-unix-bind"),
+				("--listen-unix-allow-uid", "1000", "--listen-unix-allow-uid"),
+				("--listen-unix-allow-gid", "1000", "--listen-unix-allow-gid"),
+				("--listen-unix-allow-pid", "1000", "--listen-unix-allow-pid"),
+				("--server-unix-allow-uid", "1000", "--listen-unix-allow-uid"),
+			] {
+				let cli = Cli::try_parse_from(["moq", flag, value, "token", "generate"]).unwrap();
+				let err = cli.moq.reject("token").unwrap_err().to_string();
+				assert!(err.contains(reported), "{err}");
+			}
 		}
 
 		#[cfg(feature = "cluster-lan")]

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -4,10 +4,10 @@
 //! `<import|export> <endpoint> [endpoint opts]`, plus `moq <MoQ side> play` for
 //! native playback.
 //!
-//! - The MoQ side (`--connect`, `--listen`, `--cluster-lan`; all
-//!   optional, at least one) attaches the shared Origin to the MoQ network, and
-//!   comes before the first stage. They compose: dial a relay, accept incoming
-//!   sessions, and mesh with the LAN all at once.
+//! - The MoQ side (`--connect`, the `--listen*` transport binds, and
+//!   `--cluster-lan`; all optional, at least one) attaches the shared Origin to
+//!   the MoQ network, and comes before the first stage. They compose: dial a
+//!   relay, accept incoming sessions, and mesh with the LAN all at once.
 //! - `import` routes media INTO MoQ from one source; `export` routes it OUT to
 //!   one sink. The verb fixes the data direction (and thus, for the
 //!   bidirectional gateways, whether `--connect`/`--listen` push or pull).
@@ -218,7 +218,8 @@ pub struct MoqSide {
 	#[command(flatten)]
 	pub quic: moq_native::quic::Config,
 
-	/// MoQ server transport config (`--listen`, `--listen-tls-*`).
+	/// MoQ server transport config (`--listen`, `--listen-tcp-bind`,
+	/// `--listen-unix-bind`, `--listen-tls-*`).
 	#[command(flatten)]
 	pub server: moq_native::listen::Config,
 
@@ -272,7 +273,7 @@ impl MoqSide {
 
 	/// Whether a listener has to be bound at all.
 	pub fn serves(&self) -> bool {
-		self.server.resolved().bind.is_some() || self.lan()
+		self.server.has_explicit_listener() || self.lan()
 	}
 
 	/// Reject a verb that needs the MoQ network but was given no way to reach it.
@@ -281,7 +282,7 @@ impl MoqSide {
 	pub fn validate(&self) -> anyhow::Result<()> {
 		anyhow::ensure!(
 			self.client.resolved().url.is_some() || self.serves(),
-			"a MoQ side is required: pass --connect <url> to dial a relay, --listen <addr> to self-host, or --cluster-lan to mesh over the LAN"
+			"a MoQ side is required: pass --connect <url> to dial a relay, a --listen option to self-host, or --cluster-lan to mesh over the LAN"
 		);
 		#[cfg(feature = "cluster-lan")]
 		{
@@ -313,12 +314,16 @@ impl MoqSide {
 		let ignored = [
 			("--connect", connect.url.is_some()),
 			("--listen", listen.bind.is_some()),
+			("--listen-tcp-bind", listen.tcp.bind.is_some()),
 			("--cluster-lan", self.lan()),
 			("--cluster-lan-secret", cluster_secret),
 			("--broadcast", self.broadcast.is_some()),
 		];
+		let ignored = ignored.into_iter().find(|(_, given)| *given).map(|(flag, _)| flag);
+		#[cfg(unix)]
+		let ignored = ignored.or_else(|| listen.unix.bind.is_some().then_some("--listen-unix-bind"));
 
-		if let Some((flag, _)) = ignored.into_iter().find(|(_, given)| *given) {
+		if let Some(flag) = ignored {
 			anyhow::bail!("`{command}` runs locally and takes no MoQ side; drop {flag}");
 		}
 
@@ -587,6 +592,28 @@ mod tests {
 		assert_eq!(cli.stages.len(), 1);
 		assert_eq!(cli.stages[0].name(), "import");
 		assert!(cli.validate().is_ok());
+	}
+
+	#[test]
+	fn tcp_only_listener_is_a_moq_side() {
+		let cli =
+			Invocation::try_parse_from(["moq", "--listen-tcp-bind", "127.0.0.1:0", "import", "ts"]).expect("parse");
+		assert!(cli.moq.validate().is_ok());
+		assert!(cli.moq.serves());
+		assert_eq!(cli.moq.server_config().tcp.bind, Some("127.0.0.1:0".parse().unwrap()));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn unix_only_listener_is_a_moq_side() {
+		let cli = Invocation::try_parse_from(["moq", "--listen-unix-bind", "/tmp/moq-cli.sock", "export", "ts"])
+			.expect("parse");
+		assert!(cli.moq.validate().is_ok());
+		assert!(cli.moq.serves());
+		assert_eq!(
+			cli.moq.server_config().unix.bind.as_deref(),
+			Some(std::path::Path::new("/tmp/moq-cli.sock"))
+		);
 	}
 
 	/// The grammar clap can't express: one connection, several endpoints.
@@ -922,11 +949,20 @@ mod tests {
 			// The released spelling folds in, so it is rejected under its
 			// canonical name rather than silently ignored.
 			("--client-connect", "https://relay.example.com", "--connect"),
+			("--listen-tcp-bind", "127.0.0.1:0", "--listen-tcp-bind"),
 			("--broadcast", "room", "--broadcast"),
 		] {
 			let cli = Cli::try_parse_from(["moq", flag, value, "token", "generate"]).unwrap();
 			let err = cli.moq.reject("token").unwrap_err().to_string();
 			assert!(err.contains(reported), "{err}");
+		}
+
+		#[cfg(unix)]
+		{
+			let cli =
+				Cli::try_parse_from(["moq", "--listen-unix-bind", "/tmp/moq-cli.sock", "token", "generate"]).unwrap();
+			let err = cli.moq.reject("token").unwrap_err().to_string();
+			assert!(err.contains("--listen-unix-bind"), "{err}");
 		}
 
 		#[cfg(feature = "cluster-lan")]

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -273,7 +273,7 @@ impl MoqSide {
 
 	/// Whether a listener has to be bound at all.
 	pub fn serves(&self) -> bool {
-		self.server.has_explicit_listener() || self.lan()
+		self.server.has_explicit_bind() || self.lan()
 	}
 
 	/// Reject a verb that needs the MoQ network but was given no way to reach it.

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -302,7 +302,7 @@ pub async fn serve(
 	lan: Lan,
 	origin: moq_net::origin::Producer,
 	directions: crate::Directions,
-	public: bool,
+	public_quic: bool,
 ) -> anyhow::Result<()> {
 	let mut server = server.listen().await.context("failed to bind listeners")?;
 	let mut tasks = tokio::task::JoinSet::new();
@@ -327,7 +327,7 @@ pub async fn serve(
 		// asked to serve viewers, and the membership proof gates the mesh path
 		// alone. Attaching an unauthenticated stranger to the origin here would
 		// hand them exactly what the secret is meant to withhold.
-		if !public {
+		if !is_public_transport(request.transport(), public_quic) {
 			tracing::debug!(path = %request.path(), "refusing a non-peer request on the LAN mesh listener");
 			request.close(404).await.ok();
 			continue;
@@ -424,6 +424,16 @@ impl Args {
 			.map(mdns::Secret::load)
 			.transpose()
 			.context("invalid --cluster-lan-secret")
+	}
+}
+
+/// Whether ordinary clients may use this transport on the shared LAN server.
+fn is_public_transport(transport: moq_native::Transport, public_quic: bool) -> bool {
+	match transport {
+		// Stream listeners exist only when explicitly configured, while the LAN mesh
+		// can add its own QUIC listener that must remain private.
+		moq_native::Transport::Tcp | moq_native::Transport::Unix => true,
+		_ => public_quic,
 	}
 }
 
@@ -692,7 +702,7 @@ mod tests {
 		let (server, peer) = listener();
 		let mut accept = lan("the-real-proof");
 		accept.origin = origin.clone();
-		// `public: false` is what `--cluster-lan` passes with no `--listen`.
+		// `public_quic: false` is what `--cluster-lan` passes with no `--listen`.
 		tokio::spawn(serve(
 			server,
 			accept,
@@ -725,5 +735,13 @@ mod tests {
 			"a mesh-only listener must not serve broadcasts to an unauthenticated client"
 		);
 		drop(connection);
+	}
+
+	#[test]
+	fn explicit_stream_listeners_are_public_without_exposing_mesh_quic() {
+		assert!(is_public_transport(moq_native::Transport::Tcp, false));
+		assert!(is_public_transport(moq_native::Transport::Unix, false));
+		assert!(!is_public_transport(moq_native::Transport::Quic, false));
+		assert!(is_public_transport(moq_native::Transport::Quic, true));
 	}
 }

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -298,13 +298,12 @@ fn split_credential(request: &str) -> (&str, Option<&str>) {
 /// [`moq_native::Server::serve_publish`] and its sibling already do the ordinary
 /// half, so this exists only to interleave the two.
 pub async fn serve(
-	server: moq_native::Server,
+	mut server: moq_native::Listener,
 	lan: Lan,
 	origin: moq_net::origin::Producer,
 	directions: crate::Directions,
 	public_quic: bool,
 ) -> anyhow::Result<()> {
-	let mut server = server.listen().await.context("failed to bind listeners")?;
 	let mut tasks = tokio::task::JoinSet::new();
 
 	while let Some(request) = server.accept().await {
@@ -607,6 +606,7 @@ mod tests {
 			.expect("failed to create broadcast");
 
 		let (server, peer) = listener();
+		let server = server.listen().await.expect("listen");
 		let mut accept = lan("listener-proof");
 		accept.origin = origin_b.clone();
 		// The mesh shares the listener with ordinary clients, so go through the
@@ -661,6 +661,7 @@ mod tests {
 			.expect("failed to create broadcast");
 
 		let (server, peer) = listener();
+		let server = server.listen().await.expect("listen");
 		let mut accept = lan("the-real-proof");
 		accept.origin = origin_b.clone();
 		tokio::spawn(serve(
@@ -700,6 +701,7 @@ mod tests {
 			.expect("failed to create broadcast");
 
 		let (server, peer) = listener();
+		let server = server.listen().await.expect("listen");
 		let mut accept = lan("the-real-proof");
 		accept.origin = origin.clone();
 		// `public_quic: false` is what `--cluster-lan` passes with no `--listen`.

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -90,10 +90,22 @@ async fn spawn_server(
 		false => None,
 	};
 	#[cfg(feature = "cluster-lan")]
+	let server = match lan {
+		Some(_) => server,
+		None => route_server(server, origin, directions),
+	};
+	#[cfg(not(feature = "cluster-lan"))]
+	let server = route_server(server, origin, directions);
+
+	// Stream sockets bind asynchronously in `listen`, so this must finish before
+	// `spawn_moq` reports readiness. The serve task only owns an already-bound
+	// listener and cannot discover a late bind failure.
+	let listener = server.listen().await.context("failed to bind listeners")?;
+	#[cfg(feature = "cluster-lan")]
 	match lan {
 		Some((lan, discovery)) => {
 			tasks.spawn(cluster::serve(
-				server,
+				listener,
 				lan.clone(),
 				origin.clone(),
 				directions,
@@ -101,10 +113,10 @@ async fn spawn_server(
 			));
 			tasks.spawn(lan.run(discovery));
 		}
-		None => spawn_serve(tasks, server, origin, directions),
+		None => spawn_serve(tasks, listener),
 	}
 	#[cfg(not(feature = "cluster-lan"))]
-	spawn_serve(tasks, server, origin, directions);
+	spawn_serve(tasks, listener);
 
 	// The certificate endpoint is for clients dialing a URL, so it follows the
 	// explicit listener rather than the mesh's ephemeral one.
@@ -115,34 +127,47 @@ async fn spawn_server(
 	Ok(())
 }
 
-/// Serve ordinary clients with moq-native's own accept loop.
-fn spawn_serve(
-	tasks: &mut JoinSet<anyhow::Result<()>>,
+/// Attach the requested directions before stream accept loops capture the server.
+fn route_server(
 	server: moq_native::Server,
 	origin: &moq_net::origin::Producer,
 	directions: Directions,
-) {
-	let origin = origin.clone();
+) -> moq_native::Server {
+	match directions {
+		Directions {
+			publish: true,
+			consume: true,
+		} => server.with_publisher(origin.consume()).with_subscriber(origin.clone()),
+		Directions {
+			publish: true,
+			consume: false,
+		} => server.with_publisher(origin.consume()),
+		Directions {
+			publish: false,
+			consume: true,
+		} => server.with_subscriber(origin.clone()),
+		Directions {
+			publish: false,
+			consume: false,
+		} => unreachable!("a stage always needs a direction"),
+	}
+}
+
+/// Serve ordinary clients from an already-bound listener.
+fn spawn_serve(tasks: &mut JoinSet<anyhow::Result<()>>, mut listener: moq_native::Listener) {
+	if let Ok(addr) = listener.local_addr() {
+		tracing::info!(%addr, "listening");
+	}
 	tasks.spawn(async move {
-		let _: () = match directions {
-			Directions {
-				publish: true,
-				consume: true,
-			} => server.serve_both(origin.consume(), origin).await?,
-			Directions {
-				publish: true,
-				consume: false,
-			} => server.serve_publish(origin.consume()).await?,
-			Directions {
-				publish: false,
-				consume: true,
-			} => server.serve_consume(origin).await?,
-			// Every caller attaches a direction: each stage is an import or an export.
-			Directions {
-				publish: false,
-				consume: false,
-			} => unreachable!("a stage always needs a direction"),
-		};
+		while let Some(request) = listener.accept().await {
+			tokio::spawn(async move {
+				let err = match request.ok().await {
+					Ok(session) => session.closed().await.into(),
+					Err(err) => err,
+				};
+				tracing::warn!(%err, "session ended with error");
+			});
+		}
 		Ok(())
 	});
 }
@@ -274,13 +299,19 @@ async fn spawn_moq(
 		bandwidth = Some(reconnect.send_bandwidth());
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
-	spawn_server(tasks, moq, origin, net, directions).await?;
-	// Every configured MoQ attachment is now initialized. In particular, a
-	// combined client + LAN process must not report ready before the listener and
-	// mDNS announcement have succeeded.
-	moq::notify_ready();
+	notify_when_initialized(spawn_server(tasks, moq, origin, net, directions), moq::notify_ready).await?;
 
 	Ok(bandwidth)
+}
+
+/// Report readiness only after every configured MoQ attachment initializes.
+async fn notify_when_initialized(
+	initialization: impl std::future::Future<Output = anyhow::Result<()>>,
+	notify_ready: impl FnOnce(),
+) -> anyhow::Result<()> {
+	initialization.await?;
+	notify_ready();
+	Ok(())
 }
 
 /// Fill the shared Origin from MoQ, then play one broadcast locally.
@@ -623,6 +654,7 @@ fn reject_listener_cors(cors: &crate::web::Cors, endpoint: &str) -> anyhow::Resu
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::cell::Cell;
 	use std::future::Future;
 	use std::pin::Pin;
 
@@ -657,5 +689,43 @@ mod tests {
 		supervise(&local, pipelines, &mut tasks);
 
 		local.run_until(drive(tasks)).await.unwrap();
+	}
+
+	/// A stream bind failure is part of initialization, so systemd must never see
+	/// READY=1 for a process that has no listening socket.
+	#[tokio::test]
+	async fn a_stream_bind_failure_prevents_readiness() {
+		let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("occupy a port");
+		let addr = occupied.local_addr().expect("occupied address").to_string();
+		let invocation = Invocation::try_parse_from(["moq", "--listen-tcp-bind", &addr, "import", "ts"])
+			.expect("parse stream-only invocation");
+		let origin = invocation.moq.origin().expect("create origin");
+		let net = Net {
+			quic: invocation.moq.quic.clone(),
+			#[cfg(feature = "iroh")]
+			iroh: None,
+		};
+		let mut tasks = JoinSet::new();
+		let ready = Cell::new(false);
+
+		let err = notify_when_initialized(
+			spawn_server(
+				&mut tasks,
+				&invocation.moq,
+				&origin,
+				&net,
+				Directions {
+					publish: true,
+					consume: false,
+				},
+			),
+			|| ready.set(true),
+		)
+		.await
+		.expect_err("the occupied port must fail initialization");
+
+		assert!(err.to_string().contains("failed to bind listeners"), "{err:#}");
+		assert!(!ready.get(), "readiness must be withheld after a bind failure");
+		assert!(tasks.is_empty(), "nothing should be spawned after a bind failure");
 	}
 }

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -803,8 +803,8 @@ impl StreamListeners {
 						.await?
 						.with_protocols(alpns)
 						.with_accept_health(health);
-					// Loose file perms: the uid/gid/pid allow list is the real gate,
-					// and the worker usually runs as a different user than the server.
+					// Loose socket perms let workers run as a different user. The parent
+					// directory or uid/gid/pid allowlist is the access gate.
 					listener.set_mode(0o666)?;
 					tracing::info!(path = %path.display(), allow = ?self.unix_allow, "listening (unix)");
 					bound.push(BoundListener::Unix(listener));

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -37,8 +37,8 @@ impl crate::listen::Config {
 		}
 	}
 
-	/// Whether a QUIC, TCP, or Unix listener is explicitly configured.
-	pub fn has_explicit_listener(&self) -> bool {
+	/// Whether a QUIC, TCP, or Unix bind is explicitly configured.
+	pub fn has_explicit_bind(&self) -> bool {
 		let config = self.resolved();
 		config.bind.is_some() || config.has_stream_listener()
 	}
@@ -1525,7 +1525,7 @@ uid = [1001, 1002]
 		assert_eq!(config.unix.bind.as_deref(), Some(std::path::Path::new("/run/moq.sock")));
 		assert_eq!(config.unix.allow.as_ref().expect("allow").uid, vec![1001, 1002]);
 		assert!(config.has_stream_listener());
-		assert!(config.has_explicit_listener());
+		assert!(config.has_explicit_bind());
 	}
 
 	#[cfg(all(feature = "uds", unix))]
@@ -1535,11 +1535,11 @@ uid = [1001, 1002]
 		let mut config = crate::listen::Config::default();
 		config.unix.bind = Some(PathBuf::from("/run/moq.sock"));
 		assert!(config.has_stream_listener());
-		assert!(config.has_explicit_listener());
+		assert!(config.has_explicit_bind());
 		assert!(config.bind.is_none());
 
 		// The default (nothing configured) still runs QUIC.
 		assert!(!crate::listen::Config::default().has_stream_listener());
-		assert!(!crate::listen::Config::default().has_explicit_listener());
+		assert!(!crate::listen::Config::default().has_explicit_bind());
 	}
 }

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -37,6 +37,12 @@ impl crate::listen::Config {
 		}
 	}
 
+	/// Whether a QUIC, TCP, or Unix listener is explicitly configured.
+	pub fn has_explicit_listener(&self) -> bool {
+		let config = self.resolved();
+		config.bind.is_some() || config.has_stream_listener()
+	}
+
 	/// Whether a `tcp`/`unix` stream listener is configured.
 	///
 	/// When true and [`bind`](Self::bind) is unset, the server runs stream-only
@@ -1519,6 +1525,7 @@ uid = [1001, 1002]
 		assert_eq!(config.unix.bind.as_deref(), Some(std::path::Path::new("/run/moq.sock")));
 		assert_eq!(config.unix.allow.as_ref().expect("allow").uid, vec![1001, 1002]);
 		assert!(config.has_stream_listener());
+		assert!(config.has_explicit_listener());
 	}
 
 	#[cfg(all(feature = "uds", unix))]
@@ -1528,9 +1535,11 @@ uid = [1001, 1002]
 		let mut config = crate::listen::Config::default();
 		config.unix.bind = Some(PathBuf::from("/run/moq.sock"));
 		assert!(config.has_stream_listener());
+		assert!(config.has_explicit_listener());
 		assert!(config.bind.is_none());
 
 		// The default (nothing configured) still runs QUIC.
 		assert!(!crate::listen::Config::default().has_stream_listener());
+		assert!(!crate::listen::Config::default().has_explicit_listener());
 	}
 }

--- a/rs/moq-native/src/unix.rs
+++ b/rs/moq-native/src/unix.rs
@@ -32,7 +32,7 @@ pub struct Config {
 	pub bind: Option<PathBuf>,
 
 	/// Peer-credential allowlist. `None` (the default) enforces nothing, so the
-	/// socket's filesystem permissions are the only gate.
+	/// parent directory's permissions are the only filesystem gate.
 	#[command(flatten)]
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub allow: Option<Allow>,
@@ -464,8 +464,8 @@ mod legacy_tests {
 		assert_eq!(once.resolved().allow.map(|a| a.uid), once.allow.map(|a| a.uid));
 	}
 
-	/// No flag at all leaves the allowlist unset, so the socket's own permissions
-	/// stay the only gate.
+	/// No flag at all leaves the allowlist unset, so the parent directory's
+	/// permissions stay the only filesystem gate.
 	#[test]
 	fn no_allowlist_stays_unset() {
 		let config = parse(&["--listen-unix-bind", "/tmp/moq.sock"]).resolved();


### PR DESCRIPTION
## Summary

- Treat explicit TCP and Unix qmux binds as a MoQ server side during validation and startup.
- Bind every listener before reporting systemd readiness, including TCP and Unix stream listeners.
- Keep explicit stream listeners public when they share a server with the LAN mesh, without exposing the mesh-created QUIC listener.
- Compile the raw qmux listener features into `moq-cli` release builds.
- Document the canonical listener flags and reject them on local-only commands.

## Root cause

Both CLI validation and server startup use `MoqSide::serves()`, but it only checked the QUIC `--listen` bind and LAN discovery. The native server already supports stream-only operation, so a TCP-only or Unix-only configuration was parsed and then treated as if no server had been requested. Also, `moq-cli` disabled `moq-native` default features without explicitly enabling `tcp` and `uds`, which made those flags depend on workspace feature unification instead of the released CLI feature graph.

Stream sockets are bound asynchronously by `Server::listen()`. The CLI previously moved `Server` into a spawned serve task and immediately notified systemd, so `READY=1` could precede the socket bind and could even be emitted when the bind later failed. The CLI now attaches ordinary-session routing before the stream accept loops capture it, awaits `listen()`, and gives the spawned task an already-bound `Listener`. A failed bind therefore aborts initialization before readiness.

LAN dispatch used the presence of an explicit QUIC bind as a server-wide public flag. That rejected ordinary requests arriving on explicit TCP and Unix listeners, while changing the flag to cover every listener would also expose the mesh-created QUIC port. Public access is now decided per transport. Local-only command rejection also omitted Unix credential allowlist flags, and the CLI documentation overstated the protection from a socket that is deliberately created with mode `0666`.

## Public API changes

- Add the documented, additive `moq_native::listen::Config::has_explicit_bind()` query.
- Include `tcp` and `uds` in the `moq-cli` dependency feature set.

## Test plan

- `nix develop --command just fix`
- `nix develop --command env CARGO_TARGET_DIR=/home/kixelated/work/moq/target/codex-cli-stream-only CARGO_INCREMENTAL=0 just check`
- `nix develop --command env CARGO_TARGET_DIR=/home/kixelated/work/moq/target/codex-cli-stream-only CARGO_INCREMENTAL=0 cargo test -p moq-cli a_stream_bind_failure_prevents_readiness -- --nocapture`
- `nix develop --command cargo test -p moq-cli --no-default-features --features quinn`
- `nix develop --command cargo test -p moq-native --lib --no-default-features --features aws-lc-rs,tcp,uds stream_`
- `nix develop --command cargo test -p moq-cli --no-default-features --features quinn,cluster-lan explicit_stream_listeners_are_public_without_exposing_mesh_quic`
- `nix develop --command cargo test -p moq-cli --no-default-features --features quinn token_verb`
- `nix develop --command bun remark doc/bin/cli.md rs/moq-cli/README.md --quiet --frail`

The `rs/moq-cli` documentation sync is included. This does not change the wire protocol, FFI, gateways, catalog, or container format.

Closes #2834

(Written by GPT-5)