### PR TITLE
fix(net): encode draft 17 message parameters by type

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -182,7 +182,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -151,6 +151,20 @@ test("Message Parameters: Location preserves bigint precision", async () => {
 	}
 });
 
+test("Message Parameters: Location preserves full uint64 values in draft 17", async () => {
+	const largest = { groupId: 2n ** 64n - 1n, objectId: 2n ** 62n };
+	const params = new Parameters();
+	params.largest = largest;
+
+	expect(params.largest).toEqual(largest);
+
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19]) {
+		const encoded = await encodeVersioned(params, version);
+		const decoded = await decodeVersioned(encoded, Parameters.decode, version);
+		expect(decoded.largest).toEqual(largest);
+	}
+});
+
 // Subscribe tests (v14)
 test("Subscribe v14: round trip", async () => {
 	const msg = new Subscribe.Subscribe({

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -130,6 +130,27 @@ test("Message Parameters: Location loses its length prefix in draft 17", async (
 	}
 });
 
+test("Message Parameters: Location preserves bigint precision", async () => {
+	const largest = { groupId: 9007199254740993n, objectId: 9007199254740995n };
+	const params = new Parameters();
+	params.largest = largest;
+
+	expect(params.largest).toEqual(largest);
+
+	for (const version of [
+		Version.DRAFT_14,
+		Version.DRAFT_15,
+		Version.DRAFT_16,
+		Version.DRAFT_17,
+		Version.DRAFT_18,
+		Version.DRAFT_19,
+	]) {
+		const encoded = await encodeVersioned(params, version);
+		const decoded = await decodeVersioned(encoded, Parameters.decode, version);
+		expect(decoded.largest).toEqual(largest);
+	}
+});
+
 // Subscribe tests (v14)
 test("Subscribe v14: round trip", async () => {
 	const msg = new Subscribe.Subscribe({

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -6,7 +6,7 @@ import * as Varint from "../varint.ts";
 import * as GoAway from "./goaway.ts";
 import * as Namespace from "./namespace.ts";
 import { Frame, Group, type GroupFlags } from "./object.ts";
-import { SetupOptions } from "./parameters.ts";
+import { Parameters, SetupOptions } from "./parameters.ts";
 import { Publish, PublishDone } from "./publish.ts";
 import * as Announce from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
@@ -75,6 +75,60 @@ async function encodeFrameVersioned(
 	await writer.closed;
 	return concatChunks(written);
 }
+
+test("Message Parameters: uint8 wire encoding changes in draft 17", async () => {
+	const params = new Parameters();
+	params.subscriberPriority = 255;
+
+	expect(Array.from(await encodeVersioned(params, Version.DRAFT_16))).toEqual([
+		0x01, // parameter count
+		0x20, // SUBSCRIBER_PRIORITY
+		0x40,
+		0xff, // QUIC varint 255
+	]);
+
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19]) {
+		const expected = new Uint8Array([
+			0x01, // parameter count
+			0x20, // SUBSCRIBER_PRIORITY
+			0xff, // raw uint8 255
+		]);
+		expect(Array.from(await encodeVersioned(params, version))).toEqual(Array.from(expected));
+
+		const decoded = await decodeVersioned(expected, Parameters.decode, version);
+		expect(decoded.subscriberPriority).toBe(255);
+	}
+});
+
+test("Message Parameters: Location loses its length prefix in draft 17", async () => {
+	const params = new Parameters();
+	params.largest = { groupId: 255n, objectId: 128n };
+
+	expect(Array.from(await encodeVersioned(params, Version.DRAFT_16))).toEqual([
+		0x01, // parameter count
+		0x09, // LARGEST_OBJECT
+		0x04, // byte-string length
+		0x40,
+		0xff, // QUIC varint 255
+		0x40,
+		0x80, // QUIC varint 128
+	]);
+
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19]) {
+		const expected = new Uint8Array([
+			0x01, // parameter count
+			0x09, // LARGEST_OBJECT
+			0x80,
+			0xff, // leading-ones varint 255
+			0x80,
+			0x80, // leading-ones varint 128
+		]);
+		expect(Array.from(await encodeVersioned(params, version))).toEqual(Array.from(expected));
+
+		const decoded = await decodeVersioned(expected, Parameters.decode, version);
+		expect(decoded.largest).toEqual({ groupId: 255n, objectId: 128n });
+	}
+});
 
 // Subscribe tests (v14)
 test("Subscribe v14: round trip", async () => {

--- a/js/net/src/ietf/parameters.ts
+++ b/js/net/src/ietf/parameters.ts
@@ -183,7 +183,8 @@ export class SetupOptions {
 }
 
 // ---- Message Parameters (used in Subscribe, Publish, Fetch, etc.) ----
-// Count-prefixed KVPs with delta-encoded keys (d16+).
+// Count-prefixed KVPs through d16, then definition-specific Type-Value pairs.
+// Parameter types are delta-encoded from d16 onward.
 
 // Varint parameter IDs (even)
 const MSG_PARAM_DELIVERY_TIMEOUT = 0x02n;
@@ -198,7 +199,48 @@ const MSG_PARAM_GROUP_ORDER = 0x22n;
 const MSG_PARAM_LARGEST_OBJECT = 0x09n;
 const MSG_PARAM_SUBSCRIPTION_FILTER = 0x21n;
 
-/// Message Parameters — count-prefixed KVPs used in control messages.
+type MessageParamKind = "varint" | "uint8" | "bool" | "location" | "bytes";
+
+function getMessageParamKind(id: bigint): MessageParamKind {
+	switch (id) {
+		case MSG_PARAM_DELIVERY_TIMEOUT:
+		case MSG_PARAM_MAX_CACHE_DURATION:
+		case MSG_PARAM_EXPIRES:
+			return "varint";
+		case MSG_PARAM_PUBLISHER_PRIORITY:
+		case MSG_PARAM_SUBSCRIBER_PRIORITY:
+		case MSG_PARAM_GROUP_ORDER:
+			return "uint8";
+		case MSG_PARAM_FORWARD:
+			return "bool";
+		case MSG_PARAM_LARGEST_OBJECT:
+			return "location";
+		case MSG_PARAM_SUBSCRIPTION_FILTER:
+			return "bytes";
+		default:
+			throw new Error(`unknown message parameter id: ${id.toString()}`);
+	}
+}
+
+function decodeLocation(data: Uint8Array): { groupId: bigint; objectId: bigint } {
+	const [groupId, objectData] = Varint.decode(data);
+	const [objectId, trailing] = Varint.decode(objectData);
+	if (trailing.length !== 0) {
+		throw new Error("trailing bytes in message parameter Location");
+	}
+	return { groupId: BigInt(groupId), objectId: BigInt(objectId) };
+}
+
+function encodeLocation({ groupId, objectId }: { groupId: bigint; objectId: bigint }): Uint8Array {
+	const group = Varint.encode(Number(groupId));
+	const object = Varint.encode(Number(objectId));
+	const combined = new Uint8Array(group.length + object.length);
+	combined.set(group, 0);
+	combined.set(object, group.length);
+	return combined;
+}
+
+/// Message Parameters used in control messages.
 export class Parameters {
 	vars: Map<bigint, bigint>;
 	bytes: Map<bigint, Uint8Array>;
@@ -208,7 +250,7 @@ export class Parameters {
 		this.bytes = new Map();
 	}
 
-	// --- Varint accessors ---
+	// --- Numeric accessors ---
 
 	get subscriberPriority(): number | undefined {
 		const v = this.vars.get(MSG_PARAM_SUBSCRIBER_PRIORITY);
@@ -275,18 +317,11 @@ export class Parameters {
 	get largest(): { groupId: bigint; objectId: bigint } | undefined {
 		const data = this.bytes.get(MSG_PARAM_LARGEST_OBJECT);
 		if (!data || data.length === 0) return undefined;
-		const [groupId, rest] = Varint.decode(data);
-		const [objectId] = Varint.decode(rest);
-		return { groupId: BigInt(groupId), objectId: BigInt(objectId) };
+		return decodeLocation(data);
 	}
 
 	set largest(v: { groupId: bigint; objectId: bigint }) {
-		const buf1 = Varint.encode(Number(v.groupId));
-		const buf2 = Varint.encode(Number(v.objectId));
-		const combined = new Uint8Array(buf1.length + buf2.length);
-		combined.set(buf1, 0);
-		combined.set(buf2, buf1.length);
-		this.bytes.set(MSG_PARAM_LARGEST_OBJECT, combined);
+		this.bytes.set(MSG_PARAM_LARGEST_OBJECT, encodeLocation(v));
 	}
 
 	get subscriptionFilter(): number | undefined {
@@ -328,14 +363,58 @@ export class Parameters {
 				prevId = key;
 				await w.u62(delta);
 
-				if (isVar) {
-					// biome-ignore lint/style/noNonNullAssertion: key is guaranteed to exist in vars map
-					await w.u62(this.vars.get(key)!);
-				} else {
-					// biome-ignore lint/style/noNonNullAssertion: key is guaranteed to exist in bytes map
-					const value = this.bytes.get(key)!;
-					await w.u53(value.length);
-					await w.write(value);
+				if (version === Version.DRAFT_16) {
+					if (isVar) {
+						// biome-ignore lint/style/noNonNullAssertion: key is guaranteed to exist in vars map
+						await w.u62(this.vars.get(key)!);
+					} else {
+						// biome-ignore lint/style/noNonNullAssertion: key is guaranteed to exist in bytes map
+						const value = this.bytes.get(key)!;
+						await w.u53(value.length);
+						await w.write(value);
+					}
+					continue;
+				}
+
+				switch (getMessageParamKind(key)) {
+					case "varint": {
+						const value = this.vars.get(key);
+						if (value === undefined) throw new Error(`invalid varint message parameter: ${key.toString()}`);
+						await w.u62(value);
+						break;
+					}
+					case "uint8": {
+						const value = this.vars.get(key);
+						if (value === undefined || value < 0n || value > 0xffn) {
+							throw new Error(`invalid uint8 message parameter: ${key.toString()}`);
+						}
+						await w.u8(Number(value));
+						break;
+					}
+					case "bool": {
+						const value = this.vars.get(key);
+						if (value !== 0n && value !== 1n) {
+							throw new Error(`invalid bool message parameter: ${key.toString()}`);
+						}
+						await w.bool(value === 1n);
+						break;
+					}
+					case "location": {
+						const value = this.bytes.get(key);
+						if (value === undefined)
+							throw new Error(`invalid Location message parameter: ${key.toString()}`);
+						const location = decodeLocation(value);
+						await w.u62(location.groupId);
+						await w.u62(location.objectId);
+						break;
+					}
+					case "bytes": {
+						const value = this.bytes.get(key);
+						if (value === undefined) throw new Error(`invalid bytes message parameter: ${key.toString()}`);
+						await w.u53(value.length);
+						await w.write(value);
+						break;
+					}
 				}
 			}
 		}
@@ -358,19 +437,49 @@ export class Parameters {
 				prevType = id;
 			}
 
-			if (id % 2n === 0n) {
-				if (params.vars.has(id)) {
-					throw new Error(`duplicate message parameter id: ${id.toString()}`);
+			if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
+				if (id % 2n === 0n) {
+					if (params.vars.has(id)) {
+						throw new Error(`duplicate message parameter id: ${id.toString()}`);
+					}
+					const varint = await r.u62();
+					params.vars.set(id, varint);
+				} else {
+					if (params.bytes.has(id)) {
+						throw new Error(`duplicate message parameter id: ${id.toString()}`);
+					}
+					const size = await r.u53();
+					const bytes = await r.read(size);
+					params.bytes.set(id, bytes);
 				}
-				const varint = await r.u62();
-				params.vars.set(id, varint);
-			} else {
-				if (params.bytes.has(id)) {
-					throw new Error(`duplicate message parameter id: ${id.toString()}`);
+				continue;
+			}
+
+			if (params.vars.has(id) || params.bytes.has(id)) {
+				throw new Error(`duplicate message parameter id: ${id.toString()}`);
+			}
+
+			switch (getMessageParamKind(id)) {
+				case "varint":
+					params.vars.set(id, await r.u62());
+					break;
+				case "uint8":
+					params.vars.set(id, BigInt(await r.u8()));
+					break;
+				case "bool":
+					params.vars.set(id, (await r.bool()) ? 1n : 0n);
+					break;
+				case "location": {
+					const groupId = await r.u62();
+					const objectId = await r.u62();
+					params.bytes.set(id, encodeLocation({ groupId, objectId }));
+					break;
 				}
-				const size = await r.u53();
-				const bytes = await r.read(size);
-				params.bytes.set(id, bytes);
+				case "bytes": {
+					const size = await r.u53();
+					params.bytes.set(id, await r.read(size));
+					break;
+				}
 			}
 		}
 

--- a/js/net/src/ietf/parameters.ts
+++ b/js/net/src/ietf/parameters.ts
@@ -200,6 +200,7 @@ const MSG_PARAM_LARGEST_OBJECT = 0x09n;
 const MSG_PARAM_SUBSCRIPTION_FILTER = 0x21n;
 
 type MessageParamKind = "varint" | "uint8" | "bool" | "location" | "bytes";
+type MessageLocation = { groupId: bigint; objectId: bigint };
 
 function getMessageParamKind(id: bigint): MessageParamKind {
 	switch (id) {
@@ -222,7 +223,7 @@ function getMessageParamKind(id: bigint): MessageParamKind {
 	}
 }
 
-function decodeLocation(data: Uint8Array): { groupId: bigint; objectId: bigint } {
+function decodeLocation(data: Uint8Array): MessageLocation {
 	const [groupId, objectData] = Varint.decodeBigInt(data);
 	const [objectId, trailing] = Varint.decodeBigInt(objectData);
 	if (trailing.length !== 0) {
@@ -231,7 +232,7 @@ function decodeLocation(data: Uint8Array): { groupId: bigint; objectId: bigint }
 	return { groupId, objectId };
 }
 
-function encodeLocation({ groupId, objectId }: { groupId: bigint; objectId: bigint }): Uint8Array {
+function encodeLocation({ groupId, objectId }: MessageLocation): Uint8Array {
 	const group = Varint.encode(groupId);
 	const object = Varint.encode(objectId);
 	const combined = new Uint8Array(group.length + object.length);
@@ -244,10 +245,12 @@ function encodeLocation({ groupId, objectId }: { groupId: bigint; objectId: bigi
 export class Parameters {
 	vars: Map<bigint, bigint>;
 	bytes: Map<bigint, Uint8Array>;
+	#locations: Map<bigint, MessageLocation>;
 
 	constructor() {
 		this.vars = new Map();
 		this.bytes = new Map();
+		this.#locations = new Map();
 	}
 
 	// --- Numeric accessors ---
@@ -314,14 +317,13 @@ export class Parameters {
 
 	// --- Bytes accessors ---
 
-	get largest(): { groupId: bigint; objectId: bigint } | undefined {
-		const data = this.bytes.get(MSG_PARAM_LARGEST_OBJECT);
-		if (!data || data.length === 0) return undefined;
-		return decodeLocation(data);
+	get largest(): MessageLocation | undefined {
+		const location = this.#locations.get(MSG_PARAM_LARGEST_OBJECT);
+		return location && { ...location };
 	}
 
-	set largest(v: { groupId: bigint; objectId: bigint }) {
-		this.bytes.set(MSG_PARAM_LARGEST_OBJECT, encodeLocation(v));
+	set largest(v: MessageLocation) {
+		this.#locations.set(MSG_PARAM_LARGEST_OBJECT, { ...v });
 	}
 
 	get subscriptionFilter(): number | undefined {
@@ -336,7 +338,7 @@ export class Parameters {
 	}
 
 	async encode(w: Writer, version: IetfVersion) {
-		await w.u53(this.vars.size + this.bytes.size);
+		await w.u53(this.vars.size + this.bytes.size + this.#locations.size);
 
 		if (version === Version.DRAFT_14 || version === Version.DRAFT_15) {
 			for (const [id, value] of this.vars) {
@@ -349,27 +351,39 @@ export class Parameters {
 				await w.u53(value.length);
 				await w.write(value);
 			}
+
+			for (const [id, value] of this.#locations) {
+				const encoded = encodeLocation(value);
+				await w.u62(id);
+				await w.u53(encoded.length);
+				await w.write(encoded);
+			}
 		} else {
-			// d16+: Delta encoding, merge vars and bytes, sort by key
-			const all: { key: bigint; isVar: boolean }[] = [];
-			for (const id of this.vars.keys()) all.push({ key: id, isVar: true });
-			for (const id of this.bytes.keys()) all.push({ key: id, isVar: false });
+			// d16+: Delta encoding, merge all parameter storage, sort by key
+			const all: { key: bigint; storage: "var" | "bytes" | "location" }[] = [];
+			for (const id of this.vars.keys()) all.push({ key: id, storage: "var" });
+			for (const id of this.bytes.keys()) all.push({ key: id, storage: "bytes" });
+			for (const id of this.#locations.keys()) all.push({ key: id, storage: "location" });
 			all.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
 
 			let prevId = 0n;
 			for (let i = 0; i < all.length; i++) {
-				const { key, isVar } = all[i];
+				const { key, storage } = all[i];
 				const delta = i === 0 ? key : key - prevId;
 				prevId = key;
 				await w.u62(delta);
 
 				if (version === Version.DRAFT_16) {
-					if (isVar) {
+					if (storage === "var") {
 						// biome-ignore lint/style/noNonNullAssertion: key is guaranteed to exist in vars map
 						await w.u62(this.vars.get(key)!);
 					} else {
-						// biome-ignore lint/style/noNonNullAssertion: key is guaranteed to exist in bytes map
-						const value = this.bytes.get(key)!;
+						const value =
+							storage === "bytes"
+								? // biome-ignore lint/style/noNonNullAssertion: key is guaranteed to exist in bytes map
+									this.bytes.get(key)!
+								: // biome-ignore lint/style/noNonNullAssertion: key is guaranteed to exist in locations map
+									encodeLocation(this.#locations.get(key)!);
 						await w.u53(value.length);
 						await w.write(value);
 					}
@@ -400,10 +414,9 @@ export class Parameters {
 						break;
 					}
 					case "location": {
-						const value = this.bytes.get(key);
-						if (value === undefined)
+						const location = this.#locations.get(key);
+						if (location === undefined)
 							throw new Error(`invalid Location message parameter: ${key.toString()}`);
-						const location = decodeLocation(value);
 						await w.u62(location.groupId);
 						await w.u62(location.objectId);
 						break;
@@ -445,17 +458,24 @@ export class Parameters {
 					const varint = await r.u62();
 					params.vars.set(id, varint);
 				} else {
-					if (params.bytes.has(id)) {
-						throw new Error(`duplicate message parameter id: ${id.toString()}`);
-					}
 					const size = await r.u53();
 					const bytes = await r.read(size);
-					params.bytes.set(id, bytes);
+					if (id === MSG_PARAM_LARGEST_OBJECT) {
+						if (params.#locations.has(id)) {
+							throw new Error(`duplicate message parameter id: ${id.toString()}`);
+						}
+						params.#locations.set(id, decodeLocation(bytes));
+					} else {
+						if (params.bytes.has(id)) {
+							throw new Error(`duplicate message parameter id: ${id.toString()}`);
+						}
+						params.bytes.set(id, bytes);
+					}
 				}
 				continue;
 			}
 
-			if (params.vars.has(id) || params.bytes.has(id)) {
+			if (params.vars.has(id) || params.bytes.has(id) || params.#locations.has(id)) {
 				throw new Error(`duplicate message parameter id: ${id.toString()}`);
 			}
 
@@ -472,7 +492,7 @@ export class Parameters {
 				case "location": {
 					const groupId = await r.u62();
 					const objectId = await r.u62();
-					params.bytes.set(id, encodeLocation({ groupId, objectId }));
+					params.#locations.set(id, { groupId, objectId });
 					break;
 				}
 				case "bytes": {

--- a/js/net/src/ietf/parameters.ts
+++ b/js/net/src/ietf/parameters.ts
@@ -223,24 +223,24 @@ function getMessageParamKind(id: bigint): MessageParamKind {
 }
 
 function decodeLocation(data: Uint8Array): { groupId: bigint; objectId: bigint } {
-	const [groupId, objectData] = Varint.decode(data);
-	const [objectId, trailing] = Varint.decode(objectData);
+	const [groupId, objectData] = Varint.decodeBigInt(data);
+	const [objectId, trailing] = Varint.decodeBigInt(objectData);
 	if (trailing.length !== 0) {
 		throw new Error("trailing bytes in message parameter Location");
 	}
-	return { groupId: BigInt(groupId), objectId: BigInt(objectId) };
+	return { groupId, objectId };
 }
 
 function encodeLocation({ groupId, objectId }: { groupId: bigint; objectId: bigint }): Uint8Array {
-	const group = Varint.encode(Number(groupId));
-	const object = Varint.encode(Number(objectId));
+	const group = Varint.encode(groupId);
+	const object = Varint.encode(objectId);
 	const combined = new Uint8Array(group.length + object.length);
 	combined.set(group, 0);
 	combined.set(object, group.length);
 	return combined;
 }
 
-/// Message Parameters used in control messages.
+/** Message parameters used in control messages. */
 export class Parameters {
 	vars: Map<bigint, bigint>;
 	bytes: Map<bigint, Uint8Array>;

--- a/js/net/src/varint.test.ts
+++ b/js/net/src/varint.test.ts
@@ -53,6 +53,14 @@ test("Varint encode/decode roundtrip - 8 byte values (1073741824+)", () => {
 	}
 });
 
+test("Varint bigint roundtrip preserves 62-bit precision", () => {
+	const value = 9007199254740993n;
+	const encoded = Varint.encode(value);
+	const [decoded, remaining] = Varint.decodeBigInt(encoded);
+	expect(decoded).toBe(value);
+	expect(remaining.byteLength).toBe(0);
+});
+
 test("Varint size calculation", () => {
 	expect(Varint.size(0)).toBe(1);
 	expect(Varint.size(63)).toBe(1);

--- a/js/net/src/varint.test.ts
+++ b/js/net/src/varint.test.ts
@@ -54,11 +54,12 @@ test("Varint encode/decode roundtrip - 8 byte values (1073741824+)", () => {
 });
 
 test("Varint bigint roundtrip preserves 62-bit precision", () => {
-	const value = 9007199254740993n;
-	const encoded = Varint.encode(value);
-	const [decoded, remaining] = Varint.decodeBigInt(encoded);
-	expect(decoded).toBe(value);
-	expect(remaining.byteLength).toBe(0);
+	for (const value of [9007199254740993n, 2n ** 62n - 1n]) {
+		const encoded = Varint.encode(value);
+		const [decoded, remaining] = Varint.decodeBigInt(encoded);
+		expect(decoded).toBe(value);
+		expect(remaining.byteLength).toBe(0);
+	}
 });
 
 test("Varint size calculation", () => {

--- a/js/net/src/varint.ts
+++ b/js/net/src/varint.ts
@@ -251,18 +251,18 @@ export function encodeTo(dst: ArrayBuffer, v: number | bigint): Uint8Array {
 }
 
 /**
- * Encodes a number as a QUIC variable-length integer.
+ * Encodes a number or bigint as a QUIC variable-length integer.
  * Returns a new Uint8Array containing the encoded bytes.
  */
-export function encode(v: number): Uint8Array {
+export function encode(v: number | bigint): Uint8Array {
 	return encodeTo(new ArrayBuffer(8), v);
 }
 
 /**
- * Decodes a QUIC variable-length integer from a buffer.
+ * Decodes a QUIC variable-length integer exactly from a buffer.
  * Returns a tuple of [value, remaining buffer].
  */
-export function decode(buf: Uint8Array): [number, Uint8Array] {
+export function decodeBigInt(buf: Uint8Array): [bigint, Uint8Array] {
 	if (buf.length === 0) {
 		throw new Error("buffer is empty");
 	}
@@ -276,20 +276,28 @@ export function decode(buf: Uint8Array): [number, Uint8Array] {
 	const view = new DataView(buf.buffer, buf.byteOffset, size);
 	const remain = buf.subarray(size);
 
-	let v: number;
+	let value: bigint;
 
 	if (size === 1) {
-		v = buf[0] & 0x3f;
+		value = BigInt(buf[0] & 0x3f);
 	} else if (size === 2) {
-		v = view.getUint16(0) & 0x3fff;
+		value = BigInt(view.getUint16(0) & 0x3fff);
 	} else if (size === 4) {
-		v = view.getUint32(0) & 0x3fffffff;
+		value = BigInt(view.getUint32(0) & 0x3fffffff);
 	} else if (size === 8) {
-		// NOTE: Precision loss above 2^53, but we're using number type
-		v = Number(view.getBigUint64(0) & 0x3fffffffffffffffn);
+		value = view.getBigUint64(0) & 0x3fffffffffffffffn;
 	} else {
 		throw new Error("impossible");
 	}
 
-	return [v, remain];
+	return [value, remain];
+}
+
+/**
+ * Decodes a QUIC variable-length integer from a buffer.
+ * Values above 53 bits lose precision; use {@link decodeBigInt} for exact decoding.
+ */
+export function decode(buf: Uint8Array): [number, Uint8Array] {
+	const [value, remain] = decodeBigInt(buf);
+	return [Number(value), remain];
 }

--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -527,7 +527,7 @@ macro_rules! decode_params {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use bytes::{Buf, BytesMut};
+	use bytes::{Buf, Bytes, BytesMut};
 
 	// ---- Setup Parameters tests (unchanged) ----
 
@@ -653,6 +653,15 @@ mod tests {
 			let mut buf = BytesMut::new();
 			encode_params!(&mut buf, version, 0x20 => u8::MAX);
 			assert_eq!(&buf[..], expected, "{version}");
+
+			let mut encoded = Bytes::copy_from_slice(expected);
+			let decoded = (|| -> Result<Option<u8>, DecodeError> {
+				decode_params!(&mut encoded, version, 0x20 => value: Option<u8>);
+				Ok(value)
+			})()
+			.expect("fixed uint8 vector should decode");
+			assert_eq!(decoded, Some(u8::MAX), "{version}");
+			assert!(!encoded.has_remaining(), "{version}");
 		}
 		Ok(())
 	}
@@ -721,6 +730,15 @@ mod tests {
 			let mut buf = BytesMut::new();
 			encode_params!(&mut buf, version, 0x09 => location.clone());
 			assert_eq!(&buf[..], expected, "{version}");
+
+			let mut encoded = Bytes::copy_from_slice(expected);
+			let decoded = (|| -> Result<Option<Location>, DecodeError> {
+				decode_params!(&mut encoded, version, 0x09 => value: Option<Location>);
+				Ok(value)
+			})()
+			.expect("fixed Location vector should decode");
+			assert_eq!(decoded, Some(location.clone()), "{version}");
+			assert!(!encoded.has_remaining(), "{version}");
 		}
 		Ok(())
 	}

--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -643,6 +643,21 @@ mod tests {
 	}
 
 	#[test]
+	fn test_param_u8_wire_vectors() -> Result<(), EncodeError> {
+		for (version, expected) in [
+			(Version::Draft16, &[0x01, 0x20, 0x40, 0xff][..]),
+			(Version::Draft17, &[0x01, 0x20, 0xff][..]),
+			(Version::Draft18, &[0x01, 0x20, 0xff][..]),
+			(Version::Draft19, &[0x01, 0x20, 0xff][..]),
+		] {
+			let mut buf = BytesMut::new();
+			encode_params!(&mut buf, version, 0x20 => u8::MAX);
+			assert_eq!(&buf[..], expected, "{version}");
+		}
+		Ok(())
+	}
+
+	#[test]
 	fn test_param_bool_all_versions() {
 		for version in [
 			Version::Draft14,
@@ -689,6 +704,25 @@ mod tests {
 				},
 			);
 		}
+	}
+
+	#[test]
+	fn test_param_location_wire_vectors() -> Result<(), EncodeError> {
+		let location = Location {
+			group: 255,
+			object: 128,
+		};
+		for (version, expected) in [
+			(Version::Draft16, &[0x01, 0x09, 0x04, 0x40, 0xff, 0x40, 0x80][..]),
+			(Version::Draft17, &[0x01, 0x09, 0x80, 0xff, 0x80, 0x80][..]),
+			(Version::Draft18, &[0x01, 0x09, 0x80, 0xff, 0x80, 0x80][..]),
+			(Version::Draft19, &[0x01, 0x09, 0x80, 0xff, 0x80, 0x80][..]),
+		] {
+			let mut buf = BytesMut::new();
+			encode_params!(&mut buf, version, 0x09 => location.clone());
+			assert_eq!(&buf[..], expected, "{version}");
+		}
+		Ok(())
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

- Encode draft 17+ JS message parameters using each parameter's defined value type instead of the legacy key-parity framing.
- Preserve draft 14 through draft 16 behavior and add matching JS/Rust wire vectors for raw uint8 and Location values.
- Preserve exact Location identifiers without JavaScript `Number` rounding, including full `uint64` values in drafts 17+.
- Root cause: the JS codec continued inferring value framing from parameter ID parity after draft 17 introduced definition-specific value encodings. Its legacy Location cache also used number-only QUIC varint helpers despite exposing bigint identifiers.

Closes #2864.

## Public API changes

- Add `Varint.decodeBigInt` for exact QUIC varint decoding.
- Allow `Varint.encode` to accept `bigint` as well as `number`.
- `Parameters.largest` now preserves full `uint64` identifiers when using drafts 17+.
- Bump `@moq/net` from 0.3.0 to 0.3.1.

## Test plan

- [x] Original head: `just check`
- [x] Original head: `bun test js/net/src/ietf/ietf.test.ts` (88 passed)
- [x] Original head: `just rs test -p moq-net test_param_` (13 passed)
- [x] Intermediate head `859a765`: GitHub Actions `Check` and `Test`
- [x] Latest head `4890cbd`: GitHub Actions `Check` and `Test`
- [ ] Draft 17 JS-to-Rust browser smoke test. Playwright Chromium crashed with SIGTRAP before loading the publisher, so no protocol session formed.

## Cross-package sync

- Updated both `js/net` and `rs/moq-net` golden vectors.
- No draft update is needed because this corrects the implementations to the existing draft 17 framing.
- No other language package exposes the JS `Varint` API.

(Written by GPT-5)