### PR TITLE
feat(net)!: add cold route rank for pop skipping

### DIFF
--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -351,7 +351,7 @@ Path prefix matching and equality is done on a byte-by-byte basis.
 There MAY be multiple Announce Streams, potentially containing overlapping prefixes, that get their own ANNOUNCE_OK + announcements.
 
 #### Routing {#routing}
-Each advertisement carries an `Epoch` identifying the generation of content at the path, the path of Hop IDs it traversed, and an accumulated Route Cost (see [ANNOUNCE_START](#announce-start)), which relays use to build a loop-free mesh.
+Each advertisement carries an `Epoch` identifying the generation of content at the path, the path of Hop IDs it traversed, an accumulated Route Cost, and an undiscounted Cold Route Cost (see [ANNOUNCE_START](#announce-start)), which relays use to build a loop-free mesh.
 
 A receiver MUST discard an announcement whose reconstructed path contains its own Hop ID: it has looped back, so forwarding it would extend the loop and subscribing through it would route the receiver back to itself.
 This is the only loop defense moq-lite requires, and it catches loops of any length.
@@ -368,7 +368,10 @@ When serving a subscription, a publisher MUST select the source by that same exc
 Applying one rule to both advertisement and dispatch keeps advertised paths truthful, which is what prevents subscription cycles of any length.
 
 A subscriber that sees the same broadcast advertised across multiple streams MUST prefer the highest `Epoch` (any non-zero value outranks 0): a lower Epoch never displaces a higher one, regardless of cost or arrival order.
-Among interchangeable advertisements, the subscriber SHOULD route subscriptions to the lowest Route Cost after adding each arriving link's cost (see [Cost Parameter](#cost-parameter)), breaking ties toward the shortest path and then toward the most recently received, so a reconnecting publisher is not outranked by the stale session it replaced.
+Among interchangeable advertisements, the subscriber SHOULD route subscriptions to the lowest Route Cost after adding each arriving link's cost (see [Cost Parameter](#cost-parameter)).
+When a warm relay and the current route tie on Route Cost, the subscriber SHOULD compare the warm relay's rank `(Cold Route Cost, hash(Broadcast Path, relay Hop ID))` before hop count; a non-warm route represents the subscriber's own rank.
+Only a warm relay whose rank is strictly lower may displace the route of a subscriber that is itself carrying the broadcast.
+Remaining ties prefer the shortest path and then the most recently received, so a reconnecting publisher is not outranked by the stale session it replaced.
 
 Advertisements with the same non-zero `Epoch` carry interchangeable content: a relay MAY hold them as redundant routes for one broadcast and splice a live subscription across them at a [Position](#positions).
 If a route ends partway through a Group, the replacement continues from the next frame instead of abandoning the rest of the Group.
@@ -791,6 +794,7 @@ ANNOUNCE_START Message {
   Hop Count (i),
   Hop ID (i) ...,
   Route Cost (i),
+  Cold Route Cost (i),
 }
 ~~~
 
@@ -843,9 +847,16 @@ The rule is deliberately keyed on the value rather than on why it was reached: a
 Forgoing the discount is also what carries a drain across a mesh: each carrying relay along the path repeats it, so the ceiling survives hops that would otherwise re-mask it as 0.
 
 Two relays that independently begin carrying the same broadcast would each see the other's 0 as cheaper than its own source, and both switching at once would leave the broadcast with no source.
-Before re-parenting onto a 0-cost advertisement from another actively-carrying relay (one whose path has two or more entries), a relay SHOULD apply a deterministic tie-break, such as comparing a hash of the broadcast path and each Hop ID, so exactly one side moves.
+Before re-parenting onto a 0-cost advertisement from another actively-carrying relay (one whose path has two or more entries), a relay MUST compare that peer's `(Cold Route Cost, hash(Broadcast Path, relay Hop ID))` rank with its own and move only when the peer's rank is strictly lower.
+The relay continues to advertise its own rank after moving, rather than inheriting its parent's, so every warm edge descends and a cycle cannot form.
 Equal Hop IDs (including two relays that both declared 0) cannot be ordered, and neither side SHOULD move.
-Cheaper advertisements from anything else carry no such hazard and SHOULD be adopted immediately.
+Cheaper advertisements from a relay that is not actively carrying, or directly from the original publisher, carry no simultaneous-handover hazard and SHOULD be adopted immediately.
+
+**Cold Route Cost**:
+The advertising relay's cheapest cost to the broadcast with every warm-copy discount removed.
+An original publisher sets it to the same production cost as Route Cost.
+A relay computes its own value from all of its cold routes, adding link costs as usual, and advertises that value even after adopting another warm relay; it MUST NOT copy the active parent's uncharged value.
+This makes every warm adoption strictly descend the rank described in [Routing](#routing), preventing cycles while allowing a relay with a cheaper cold upstream to become the aggregation point.
 
 
 ## ANNOUNCE_END {#announce-end}
@@ -894,6 +905,7 @@ ANNOUNCE_UPDATE Message {
   Hop Count (i),
   Hop ID (i) ...,
   Route Cost (i),
+  Cold Route Cost (i),
 }
 ~~~
 
@@ -904,9 +916,9 @@ Set to 0x2 to indicate an ANNOUNCE_UPDATE message.
 The ordinal implicitly assigned by a prior ANNOUNCE_START on this stream.
 Referencing an id that was never assigned, or one already retired by an ANNOUNCE_END, is a protocol violation.
 
-**Epoch**, **Ended**, **Hop Count**, **Hop ID**, and **Route Cost**:
+**Epoch**, **Ended**, **Hop Count**, **Hop ID**, **Route Cost**, and **Cold Route Cost**:
 As defined for [ANNOUNCE_START](#announce-start).
-An update whose only change is the Route Cost is valid: it is how a relay advertises that it started or stopped actively carrying the broadcast.
+An update whose only change is the Route Cost or Cold Route Cost is valid: it is how a relay advertises that it started or stopped actively carrying the broadcast, or that its undiscounted route changed.
 An update whose only change is the `Ended` flag is likewise valid: it is how a live broadcast ends into a recording without retiring its Announce ID.
 
 
@@ -1321,7 +1333,7 @@ The `Message Length` describes the payload size on the wire.
 - Added an `Epoch` to ANNOUNCE_START and ANNOUNCE_UPDATE: a per-path content generation minted by the original publisher and forwarded unchanged, 0 meaning unspecified. The highest Epoch wins (non-zero outranks 0) and replacement is decided by value rather than arrival order; equal non-zero Epochs splice, and the first entry of the path remains the identity only when both are 0. That fallback identity requires a non-zero first entry: 0 identifies nothing, so it never proves continuity, and publishers SHOULD assign themselves a Hop ID (a random per-session value suffices).
 - Added an `Ended` flag to ANNOUNCE_START and ANNOUNCE_UPDATE, and as an opt-in filter on ANNOUNCE_REQUEST: ended broadcasts reject SUBSCRIBE, are read via FETCH, and are only announced to subscribers that asked for them.
 - Added an `Epoch` to SUBSCRIBE, FETCH, and TRACK (0 = current, mismatch = reset) and the resolved `Epoch` to TRACK_INFO, so metadata and groups always come from the same generation and requests cannot race a replacement.
-- Added a `Route Cost` field to ANNOUNCE_START and ANNOUNCE_UPDATE: the accumulated cost of the transfers a subscription via this advertisement would newly cause. Route selection prefers the lowest cost, with path length as the tie-break, and the most recently received advertisement below that.
+- Added `Route Cost` and `Cold Route Cost` fields to ANNOUNCE_START and ANNOUNCE_UPDATE. Route Cost is the marginal cost a new subscription would cause; Cold Route Cost is the advertising relay's own undiscounted path cost. Marginal cost remains primary, then a warm relay's `(Cold Route Cost, per-broadcast relay hash)` rank precedes hop count and recency.
 - Added a SETUP `Cost` parameter (0x4) declaring what subscribing from the sender costs, added by the receiver to every announcement that sender forwards. Both endpoints send their own, so the two directions are priced independently, and a receiver MAY charge a locally configured value instead. Unpriced directions default to 1, degrading to shortest-path routing.
 - Removed `Exclude Hop` from ANNOUNCE_REQUEST. The receiver's hop-based loop check already discards a looped announcement, so the field only saved the wasted send.
 - Stated the receiver's loop check normatively in ANNOUNCE_START: an announcement whose reconstructed path contains the receiver's own Hop ID is neither forwarded nor selected as a route.

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -48,28 +48,28 @@ test("AnnounceBroadcast round-trips on draft-05", async () => {
 
 test("AnnounceBroadcast round-trips on draft-06", async () => {
 	const hops = [OriginSchema.parse(7n)];
-	// An absent cost encodes as zero and decodes explicitly.
+	// Absent marginal and cold costs encode as zero and decode explicitly.
 	const gotActive = await roundTrip({ status: "active", suffix: Path.from("room/cam"), hops }, Version.DRAFT_06);
-	expect(gotActive).toEqual({ status: "active", suffix: Path.from("room/cam"), hops, cost: 0n });
+	expect(gotActive).toEqual({ status: "active", suffix: Path.from("room/cam"), hops, cost: 0n, cold: 0n });
 
 	const gotCost = await roundTrip(
-		{ status: "active", suffix: Path.from("room/cam"), hops, cost: 12n },
+		{ status: "active", suffix: Path.from("room/cam"), hops, cost: 12n, cold: 34n },
 		Version.DRAFT_06,
 	);
-	expect(gotCost).toEqual({ status: "active", suffix: Path.from("room/cam"), hops, cost: 12n });
+	expect(gotCost).toEqual({ status: "active", suffix: Path.from("room/cam"), hops, cost: 12n, cold: 34n });
 
 	const gotEnded = await roundTrip({ status: "endedId", id: 3n }, Version.DRAFT_06);
 	expect(gotEnded).toEqual({ status: "endedId", id: 3n });
 
-	const gotRestart = await roundTrip({ status: "restart", id: 3n, hops, cost: 12n }, Version.DRAFT_06);
-	expect(gotRestart).toEqual({ status: "restart", id: 3n, hops, cost: 12n });
+	const gotRestart = await roundTrip({ status: "restart", id: 3n, hops, cost: 12n, cold: 34n }, Version.DRAFT_06);
+	expect(gotRestart).toEqual({ status: "restart", id: 3n, hops, cost: 12n, cold: 34n });
 });
 
-test("AnnounceBroadcast drops the route cost before draft-06", async () => {
-	// Pre-lite-06 has no room for a cost on the wire, so one set locally is
-	// simply not sent, keeping mixed-version meshes ranking on hop count.
+test("AnnounceBroadcast drops route costs before draft-06", async () => {
+	// Pre-lite-06 has no room for costs on the wire, so values set locally are
+	// simply not sent.
 	const got = await roundTrip(
-		{ status: "active", suffix: Path.from("room/cam"), hops: [], cost: 9n },
+		{ status: "active", suffix: Path.from("room/cam"), hops: [], cost: 9n, cold: 11n },
 		Version.DRAFT_05,
 	);
 	expect(got).toEqual({ status: "active", suffix: Path.from("room/cam"), hops: [] });

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -32,17 +32,17 @@ const ANNOUNCE_RESTART = 2;
  * message that retracts by path (`ended`).
  */
 export type AnnounceBroadcast =
-	/** A broadcast is now available, carrying the path suffix, the hop chain, and
-	 * (lite-06+) the route cost. An absent cost encodes as zero. */
-	| { status: "active"; suffix: Path.Valid; hops: Origin[]; cost?: bigint }
+	/** A broadcast is now available, carrying the path suffix, hop chain, and
+	 * (lite-06+) marginal and undiscounted cold costs. Absent costs encode as zero. */
+	| { status: "active"; suffix: Path.Valid; hops: Origin[]; cost?: bigint; cold?: bigint }
 	/** Pre-lite-06: a broadcast is no longer available, retracted by path. */
 	| { status: "ended"; suffix: Path.Valid }
 	/** Lite06+: a broadcast is no longer available, retracted by announce id.
 	 * The id is retired; referencing it again is a protocol violation. */
 	| { status: "endedId"; id: bigint }
 	/** Lite06+: atomically replace the announcement with this id (e.g. a new hop
-	 * chain after a relay failover, or a route whose cost moved). The id stays live. */
-	| { status: "restart"; id: bigint; hops: Origin[]; cost?: bigint };
+	 * chain after a relay failover, or a route whose cost or cold rank moved). */
+	| { status: "restart"; id: bigint; hops: Origin[]; cost?: bigint; cold?: bigint };
 
 function checkHops(hops: Origin[]) {
 	if (hops.length > MAX_HOPS) {
@@ -95,8 +95,8 @@ async function decodeHops(r: Reader, version: Version): Promise<Origin[]> {
 	}
 }
 
-// The route cost rides lite-06+ announcements as a single varint; older
-// versions carry nothing and decode as zero.
+// Each route cost rides lite-06+ announcements as a varint; older versions
+// carry nothing and decode as zero.
 async function encodeRouteCost(w: Writer, version: Version, cost: bigint | undefined) {
 	if (!hasRouteCost(version)) return;
 	await w.u62(cost ?? 0n);
@@ -114,6 +114,7 @@ async function encodeAnnounce06Body(w: Writer, msg: AnnounceBroadcast, version: 
 			await w.string(Path.encode(msg.suffix));
 			await encodeHops(w, version, msg.hops);
 			await encodeRouteCost(w, version, msg.cost);
+			await encodeRouteCost(w, version, msg.cold);
 			break;
 		case "endedId":
 			await w.u62(msg.id);
@@ -122,6 +123,7 @@ async function encodeAnnounce06Body(w: Writer, msg: AnnounceBroadcast, version: 
 			await w.u62(msg.id);
 			await encodeHops(w, version, msg.hops);
 			await encodeRouteCost(w, version, msg.cost);
+			await encodeRouteCost(w, version, msg.cold);
 			break;
 		case "ended":
 			// The pre-lite-06 path-form retraction has no place on lite-06.
@@ -148,14 +150,16 @@ async function decodeAnnounce06Body(r: Reader, typ: number, version: Version): P
 		case ANNOUNCE_START: {
 			const suffix = Path.decode(await r.string());
 			const hops = await decodeHops(r, version);
-			return { status: "active", suffix, hops, cost: await decodeRouteCost(r, version) };
+			const cost = await decodeRouteCost(r, version);
+			return { status: "active", suffix, hops, cost, cold: await decodeRouteCost(r, version) };
 		}
 		case ANNOUNCE_END:
 			return { status: "endedId", id: await r.u62() };
 		case ANNOUNCE_RESTART: {
 			const id = await r.u62();
 			const hops = await decodeHops(r, version);
-			return { status: "restart", id, hops, cost: await decodeRouteCost(r, version) };
+			const cost = await decodeRouteCost(r, version);
+			return { status: "restart", id, hops, cost, cold: await decodeRouteCost(r, version) };
 		}
 		default:
 			throw new Error(`unknown announce message type: ${typ}`);

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -95,10 +95,8 @@ export function hasExcludeHop(version: Version): boolean {
 	}
 }
 
-/** Whether announcements carry a route cost varint alongside the hop chain: the
- * marginal cost of pulling the broadcast via this route, accumulated per link.
- * Added in lite-06. Older versions carry nothing, so a received route stays at
- * zero and routing falls back to the hop-count tie-break. */
+/** Whether announcements carry marginal and cold route cost varints alongside
+ * the hop chain. Added in lite-06. Older versions carry neither value. */
 export function hasRouteCost(version: Version): boolean {
 	// Explicitly list older versions so future versions keep the lite-06+ behavior.
 	switch (version) {

--- a/rs/moq-net/src/ietf/cluster.rs
+++ b/rs/moq-net/src/ietf/cluster.rs
@@ -174,6 +174,9 @@ impl Advert {
 			.with_hops(self.hops.hops().clone())
 			.with_cost(self.cost.saturating_add(link_cost))
 			.with_announce(true);
+		// The current MoQ Cluster extension carries only marginal cost. Keep the
+		// cold rank unknown instead of mistaking a warm zero for a stable cold path.
+		route.cold = None;
 		route.advertised = self.cost;
 		route
 	}

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -250,10 +250,12 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		let mut hops = crate::OriginList::new();
 		hops.push(self.session_origin)
 			.expect("an empty hop chain has room for one entry");
-		broadcast::Route::new()
+		let mut route = broadcast::Route::new()
 			.with_hops(hops)
 			.with_cost(cluster::link_cost(self.cost, peer))
-			.with_announce(true)
+			.with_announce(true);
+		route.cold = None;
+		route
 	}
 
 	/// The route an advertisement describes, or `None` when it must be discarded.
@@ -924,6 +926,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// no race between the two.
 		if self.going_away.is_set() {
 			route.cost = broadcast::DRAIN_COST;
+			route.cold = Some(broadcast::DRAIN_COST);
 		}
 
 		// A different original publisher, or one that identifies nothing, means a

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -37,12 +37,13 @@ pub fn restart_supported(version: Version) -> bool {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AnnounceBroadcast<'a> {
 	/// ANNOUNCE_START (lite-06) / active (older): a broadcast is now available.
-	/// Carries the path suffix, the hop chain, and (lite-06+) the route cost, and
-	/// assigns the next announce id.
+	/// Carries the path suffix, the hop chain, and (lite-06+) the marginal and cold
+	/// route costs, and assigns the next announce id.
 	Active {
 		suffix: Path<'a>,
 		hops: OriginList,
 		cost: RouteCost,
+		cold: RouteCost,
 	},
 	/// Pre-lite-06: a broadcast is no longer available, retracted by path.
 	Ended { suffix: Path<'a>, hops: OriginList },
@@ -50,26 +51,27 @@ pub enum AnnounceBroadcast<'a> {
 	/// announce id. The id is retired; referencing it again is a protocol violation.
 	EndedId { id: u64 },
 	/// ANNOUNCE_RESTART (lite-06+): atomically replace the announcement with this id
-	/// (e.g. a new hop chain after a relay failover, or a route whose cost moved).
+	/// (e.g. a new hop chain after a relay failover, or a route whose costs moved).
 	/// The id stays live.
 	///
 	/// Only ever received: we advertise a replacement as an `EndedId` + `Active` pair.
-	Restart { id: u64, hops: OriginList, cost: RouteCost },
+	Restart {
+		id: u64,
+		hops: OriginList,
+		cost: RouteCost,
+		cold: RouteCost,
+	},
 }
 
-/// The marginal cost of pulling the broadcast via this route, carried on lite-06
-/// announcements as a single varint.
+/// A route cost carried on lite-06 announcements as a varint.
 ///
-/// The original publisher seeds it with its production cost: zero for a live
-/// publish, something large for a standby that would have to start working (a
-/// cold transcoder). Each link adds its own price when the announcement crosses
-/// it, and a node actively carrying the broadcast re-announces zero instead: its
-/// ingress is already paid for, so a peer should pull the copy that exists rather
-/// than open a second one all the way back. The sum is what routing minimizes:
-/// what one more subscription would actually cost the mesh.
+/// Each lite-06 announcement carries two of these. The marginal cost is what one
+/// more subscription would cost the mesh, including a warm-copy discount when the
+/// announcing relay already carries the broadcast. The cold cost follows the same
+/// path with that discount removed, giving every carrying relay a stable rank.
+/// Each link charges both values as the announcement crosses it.
 ///
-/// Pre-lite-06 peers don't carry it, so it stays zero and routing falls back to
-/// the hop-count tie-break.
+/// Pre-lite-06 peers carry neither value, so both stay zero on their wire messages.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct RouteCost(pub u64);
 
@@ -113,20 +115,27 @@ impl Encode<Version> for AnnounceBroadcast<'_> {
 			// infrequent, so the scratch buffer is cheap.
 			let mut body = Vec::new();
 			let typ = match self {
-				Self::Active { suffix, hops, cost } => {
+				Self::Active {
+					suffix,
+					hops,
+					cost,
+					cold,
+				} => {
 					suffix.encode(&mut body, version)?;
 					hops.encode(&mut body, version)?;
 					cost.encode(&mut body, version)?;
+					cold.encode(&mut body, version)?;
 					ANNOUNCE_START
 				}
 				Self::EndedId { id } => {
 					id.encode(&mut body, version)?;
 					ANNOUNCE_END
 				}
-				Self::Restart { id, hops, cost } => {
+				Self::Restart { id, hops, cost, cold } => {
 					id.encode(&mut body, version)?;
 					hops.encode(&mut body, version)?;
 					cost.encode(&mut body, version)?;
+					cold.encode(&mut body, version)?;
 					ANNOUNCE_RESTART
 				}
 				// The pre-lite-06 path-form retraction has no place on lite-06.
@@ -177,6 +186,7 @@ impl Decode<Version> for AnnounceBroadcast<'_> {
 					suffix: Path::decode(&mut body, version)?,
 					hops: OriginList::decode(&mut body, version)?,
 					cost: RouteCost::decode(&mut body, version)?,
+					cold: RouteCost::decode(&mut body, version)?,
 				},
 				ANNOUNCE_END => Self::EndedId {
 					id: u64::decode(&mut body, version)?,
@@ -185,6 +195,7 @@ impl Decode<Version> for AnnounceBroadcast<'_> {
 					id: u64::decode(&mut body, version)?,
 					hops: OriginList::decode(&mut body, version)?,
 					cost: RouteCost::decode(&mut body, version)?,
+					cold: RouteCost::decode(&mut body, version)?,
 				},
 				_ => return Err(DecodeError::InvalidMessage(typ)),
 			};
@@ -234,6 +245,7 @@ impl AnnounceBroadcast<'_> {
 				suffix,
 				hops,
 				cost: RouteCost::default(),
+				cold: RouteCost::default(),
 			},
 			AnnounceStatus::Ended => Self::Ended { suffix, hops },
 			// On lite-05 a restart travels as a duplicate ANNOUNCE (a second `Active`), so accept
@@ -245,6 +257,7 @@ impl AnnounceBroadcast<'_> {
 				suffix,
 				hops,
 				cost: RouteCost::default(),
+				cold: RouteCost::default(),
 			},
 			AnnounceStatus::Restart => return Err(DecodeError::InvalidValue),
 		})
@@ -411,6 +424,7 @@ mod tests {
 			suffix: Path::new("foo/bar"),
 			hops: OriginList::new(),
 			cost: RouteCost::default(),
+			cold: RouteCost::default(),
 		}
 		.encode(&mut buf, version)
 		.expect("encode");
@@ -489,17 +503,23 @@ mod tests {
 		assert!(slice.is_empty(), "trailing bytes after decode");
 		// Decode borrows from `buf`; re-own so the value can outlive this frame.
 		match got {
-			AnnounceBroadcast::Active { suffix, hops, cost } => AnnounceBroadcast::Active {
+			AnnounceBroadcast::Active {
+				suffix,
+				hops,
+				cost,
+				cold,
+			} => AnnounceBroadcast::Active {
 				suffix: suffix.to_owned(),
 				hops,
 				cost,
+				cold,
 			},
 			AnnounceBroadcast::Ended { suffix, hops } => AnnounceBroadcast::Ended {
 				suffix: suffix.to_owned(),
 				hops,
 			},
 			AnnounceBroadcast::EndedId { id } => AnnounceBroadcast::EndedId { id },
-			AnnounceBroadcast::Restart { id, hops, cost } => AnnounceBroadcast::Restart { id, hops, cost },
+			AnnounceBroadcast::Restart { id, hops, cost, cold } => AnnounceBroadcast::Restart { id, hops, cost, cold },
 		}
 	}
 
@@ -511,6 +531,7 @@ mod tests {
 			suffix: Path::new("room/cam"),
 			hops: hops.clone(),
 			cost: RouteCost::default(),
+			cold: RouteCost::default(),
 		};
 		assert_eq!(broadcast_round_trip(&msg, Version::Lite05), msg);
 
@@ -527,18 +548,25 @@ mod tests {
 		hops.push(Origin::new(7).unwrap()).unwrap();
 
 		let cost = RouteCost(12);
+		let cold = RouteCost(34);
 
 		let active = AnnounceBroadcast::Active {
 			suffix: Path::new("room/cam"),
 			hops: hops.clone(),
 			cost,
+			cold,
 		};
 		assert_eq!(broadcast_round_trip(&active, Version::Lite06Wip), active);
 
 		let ended = AnnounceBroadcast::EndedId { id: 3 };
 		assert_eq!(broadcast_round_trip(&ended, Version::Lite06Wip), ended);
 
-		let restart = AnnounceBroadcast::Restart { id: 3, hops, cost };
+		let restart = AnnounceBroadcast::Restart {
+			id: 3,
+			hops,
+			cost,
+			cold,
+		};
 		assert_eq!(broadcast_round_trip(&restart, Version::Lite06Wip), restart);
 	}
 
@@ -554,7 +582,8 @@ mod tests {
 			AnnounceBroadcast::Restart {
 				id: 1,
 				hops: OriginList::new(),
-				cost: RouteCost::default()
+				cost: RouteCost::default(),
+				cold: RouteCost::default(),
 			}
 			.encode(&mut buf, Version::Lite05),
 			Err(EncodeError::Version)
@@ -578,6 +607,7 @@ mod tests {
 			suffix: Path::new("room/cam"),
 			hops: OriginList::new(),
 			cost: RouteCost(9),
+			cold: RouteCost(11),
 		};
 		let got = broadcast_round_trip(&msg, Version::Lite05);
 		assert_eq!(
@@ -586,6 +616,7 @@ mod tests {
 				suffix: Path::new("room/cam"),
 				hops: OriginList::new(),
 				cost: RouteCost::default(),
+				cold: RouteCost::default(),
 			}
 		);
 	}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -44,6 +44,8 @@ struct WatchedRoute {
 struct SentRoute {
 	hops: OriginList,
 	cost: lite::RouteCost,
+	/// This relay's cold route cost, which stays stable while `cost` is discounted.
+	cold: lite::RouteCost,
 	/// Whether this is the route we actually serve from (the table's first
 	/// entry) rather than a standby selected because the serving chain flows
 	/// through the peer. Only a serving advertisement carries the demand
@@ -664,6 +666,7 @@ impl AnnounceRun {
 						suffix: suffix.as_path(),
 						hops: route.hops.clone(),
 						cost: route.cost,
+						cold: route.cold,
 					})?;
 				}
 			}
@@ -830,6 +833,7 @@ impl AnnounceRun {
 								suffix,
 								hops: route.hops,
 								cost: route.cost,
+								cold: route.cold,
 							})?;
 						}
 						None => {
@@ -885,7 +889,9 @@ impl AnnounceRun {
 						// send. The serving flag may still have flipped (a failover
 						// onto the already-advertised standby), so store it for the
 						// demand watches without a wire message.
-						(Some(route), Some(sent)) if route.hops == sent.hops && route.cost == sent.cost => {
+						(Some(route), Some(sent))
+							if route.hops == sent.hops && route.cost == sent.cost && route.cold == sent.cold =>
+						{
 							entry.sent = Some(route);
 						}
 						// The chain or the cost changed (an upstream failover, a repriced
@@ -907,6 +913,7 @@ impl AnnounceRun {
 									id,
 									hops: route.hops,
 									cost: route.cost,
+									cold: route.cold,
 								})?;
 							} else {
 								// Lite05: a duplicate ANNOUNCE for a live path is the restart.
@@ -915,6 +922,7 @@ impl AnnounceRun {
 									suffix,
 									hops: route.hops,
 									cost: route.cost,
+									cold: route.cold,
 								})?;
 							}
 						}
@@ -930,6 +938,7 @@ impl AnnounceRun {
 								suffix,
 								hops: route.hops,
 								cost: route.cost,
+								cold: route.cold,
 							})?;
 						}
 						// The new chain must not be forwarded (it now loops through the
@@ -993,6 +1002,13 @@ fn select_route(
 		id => Origin::new(id).unwrap_or(Origin::UNKNOWN),
 	};
 
+	let cold = routes
+		.iter()
+		.filter(|route| route.announce && route.cost < crate::broadcast::DRAIN_COST)
+		.filter_map(|route| route.cold)
+		.min()
+		.unwrap_or(crate::broadcast::MAX_COST);
+
 	for (route, serving) in crate::broadcast::advertisable_routes(routes, self_origin, exclude) {
 		let mut hops = route.hops.clone();
 		// Lite05+ moves the self-stamp to the receiver, which appends our id (reported
@@ -1003,7 +1019,23 @@ fn select_route(
 			continue;
 		}
 		let cost = outgoing_cost(version, demand, route, serving);
-		return Some(SentRoute { hops, cost, serving });
+		let cold = if version.has_route_cost() {
+			lite::RouteCost(
+				match serving {
+					true => cold,
+					false => route.cold.unwrap_or(route.cost),
+				}
+				.min(crate::broadcast::MAX_COST),
+			)
+		} else {
+			lite::RouteCost::default()
+		};
+		return Some(SentRoute {
+			hops,
+			cost,
+			cold,
+			serving,
+		});
 	}
 	tracing::debug!(broadcast = %absolute, %exclude_hop, "no advertisable route for this peer");
 	None
@@ -1809,17 +1841,25 @@ mod announce_test {
 	/// Re-own a decoded message so it can outlive the decode buffer.
 	fn own(msg: lite::AnnounceBroadcast<'_>) -> lite::AnnounceBroadcast<'static> {
 		match msg {
-			lite::AnnounceBroadcast::Active { suffix, hops, cost } => lite::AnnounceBroadcast::Active {
+			lite::AnnounceBroadcast::Active {
+				suffix,
+				hops,
+				cost,
+				cold,
+			} => lite::AnnounceBroadcast::Active {
 				suffix: suffix.to_owned(),
 				hops,
 				cost,
+				cold,
 			},
 			lite::AnnounceBroadcast::Ended { suffix, hops } => lite::AnnounceBroadcast::Ended {
 				suffix: suffix.to_owned(),
 				hops,
 			},
 			lite::AnnounceBroadcast::EndedId { id } => lite::AnnounceBroadcast::EndedId { id },
-			lite::AnnounceBroadcast::Restart { id, hops, cost } => lite::AnnounceBroadcast::Restart { id, hops, cost },
+			lite::AnnounceBroadcast::Restart { id, hops, cost, cold } => {
+				lite::AnnounceBroadcast::Restart { id, hops, cost, cold }
+			}
 		}
 	}
 
@@ -2068,6 +2108,7 @@ mod announce_test {
 					id: 0,
 					hops: sent,
 					cost,
+					..
 				},
 			] => {
 				assert_eq!(sent, &hops);
@@ -2299,6 +2340,40 @@ mod announce_test {
 			other => panic!("expected the re-announce, got {other:?}"),
 		}
 		assert!(!task.is_finished(), "the announce loop ended unexpectedly");
+	}
+
+	/// A relay that adopted a warm parent advertises its own cold route cost, not
+	/// the parent's rank. Otherwise every descendant would claim the root's rank
+	/// and the strict descent that prevents warm cycles would disappear.
+	#[test]
+	fn outgoing_cold_rank_belongs_to_this_relay() {
+		let publisher = Origin::new(9).unwrap();
+		let parent = Origin::new(8).unwrap();
+		let self_origin = Origin::new(7).unwrap();
+		let mut adopted = crate::broadcast::Route::announced()
+			.with_hops(OriginList::try_from(vec![publisher, parent]).unwrap())
+			.with_cost(0);
+		adopted.advertised = 0;
+		adopted.advertised_cold = Some(1);
+		adopted.cold = Some(2);
+		let direct = crate::broadcast::Route::announced()
+			.with_hops(OriginList::try_from(vec![publisher]).unwrap())
+			.with_cost(2);
+		let routes = vec![adopted, direct];
+
+		let producer = crate::broadcast::Info::new().produce();
+		let demand = producer.consume().demand();
+		let sent = select_route(
+			&routes,
+			&demand,
+			self_origin,
+			0,
+			Version::Lite06Wip,
+			&crate::Path::new("cam"),
+		)
+		.expect("route");
+
+		assert_eq!(sent.cold, lite::RouteCost(2));
 	}
 
 	/// A locally created route may set `Route::cost` past what a varint can carry,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -90,6 +90,15 @@ struct TrackEntry {
 	timescale: Option<Timescale>,
 }
 
+#[derive(Clone, Copy)]
+struct AnnounceCosts {
+	/// Costs received from the peer before this link's charge.
+	marginal: RouteCost,
+	cold: RouteCost,
+	/// This link's local charge, applied to both wire values.
+	link: u64,
+}
+
 impl<S: crate::transport::poll::Session> Subscriber<S> {
 	pub fn new(config: SubscriberConfig<S>) -> Self {
 		// Identity for incoming-hop loop detection. Derived from the local
@@ -160,8 +169,18 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		run: &mut PrefixRun,
 	) -> Result<(), Error> {
 		match announce {
-			lite::AnnounceBroadcast::Active { suffix, hops, cost } => {
+			lite::AnnounceBroadcast::Active {
+				suffix,
+				hops,
+				cost,
+				cold,
+			} => {
 				let path = prefix.join(&suffix);
+				let costs = AnnounceCosts {
+					marginal: cost,
+					cold,
+					link: run.link_cost,
+				};
 				if self.version.has_announce_id() {
 					// Every `active` assigns the next ordinal, even ones we drop locally.
 					run.announced_by_id.insert(run.next_announce_id, path.clone());
@@ -175,23 +194,9 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 					// atomically replace the broadcast. Lite06+ restarts by announce id, and older
 					// versions never defined restarts, so both fall through to start_announce, which
 					// rejects the duplicate (Error::Duplicate).
-					self.restart_announce(
-						path.clone(),
-						hops,
-						cost,
-						run.link_cost,
-						run.responder_origin,
-						&mut run.routes,
-					)?;
+					self.restart_announce(path.clone(), hops, costs, run.responder_origin, &mut run.routes)?;
 				} else {
-					self.start_announce(
-						path.clone(),
-						hops,
-						cost,
-						run.link_cost,
-						run.responder_origin,
-						&mut run.routes,
-					)?;
+					self.start_announce(path.clone(), hops, costs, run.responder_origin, &mut run.routes)?;
 				}
 			}
 			lite::AnnounceBroadcast::Ended { suffix, .. } => {
@@ -219,18 +224,23 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 					entry.finish();
 				}
 			}
-			lite::AnnounceBroadcast::Restart { id, hops, cost } => {
+			lite::AnnounceBroadcast::Restart { id, hops, cost, cold } => {
 				// Resolve the id; it stays live (the replacement reuses it). An unknown
 				// or retired id is a protocol violation.
 				let Some(path) = run.announced_by_id.get(&id).cloned() else {
 					return Err(Error::ProtocolViolation);
 				};
+				let costs = AnnounceCosts {
+					marginal: cost,
+					cold,
+					link: run.link_cost,
+				};
 				if run.routes.contains_key(&path) {
-					self.restart_announce(path, hops, cost, run.link_cost, run.responder_origin, &mut run.routes)?;
+					self.restart_announce(path, hops, costs, run.responder_origin, &mut run.routes)?;
 				} else {
 					// The original announce was dropped locally (e.g. a reflected loop);
 					// the replacement may be routable, so treat it as a fresh start.
-					self.start_announce(path, hops, cost, run.link_cost, run.responder_origin, &mut run.routes)?;
+					self.start_announce(path, hops, costs, run.responder_origin, &mut run.routes)?;
 				}
 			}
 		}
@@ -244,12 +254,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		&mut self,
 		path: PathOwned,
 		mut hops: crate::OriginList,
-		// The route cost off the wire, i.e. as the peer advertised it. Zero before
-		// lite-06, leaving the hop chain as the only routing input as before.
-		cost: RouteCost,
-		// This link's price, added to the wire cost; the pre-charge value is kept
-		// on the route so the origin's handover gate can tell a warm peer apart.
-		link_cost: u64,
+		costs: AnnounceCosts,
 		// Lite05+: the announce sender's origin id (from AnnounceOk). The sender no
 		// longer stamps itself onto the chain, so we append it here to reconstruct
 		// the full `[src...sender]` chain Lite04 stored. None for older versions,
@@ -315,7 +320,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// (other sessions announcing the same path) join it silently as standbys.
 		// An error means the path is outside our scope, so don't serve it.
 		// Reflections are already filtered above.
-		let route = self.announced_route(hops, cost, link_cost);
+		let route = self.announced_route(hops, costs);
 		let Ok(source) = self.origin.create_broadcast(&path, route) else {
 			return Ok(false);
 		};
@@ -334,15 +339,22 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	/// Once the peer has sent a GOAWAY every route it announces starts out draining,
 	/// including a restart of one already attached: a connection on its way out must
 	/// not win selection, however good the path it advertises looks.
-	fn announced_route(&self, hops: crate::OriginList, cost: RouteCost, link_cost: u64) -> crate::broadcast::Route {
+	fn announced_route(&self, hops: crate::OriginList, costs: AnnounceCosts) -> crate::broadcast::Route {
 		let mut route = crate::broadcast::Route::new()
 			.with_hops(hops)
-			.with_cost(cost.charged(link_cost).0)
+			.with_cost(costs.marginal.charged(costs.link).0)
 			.with_announce(true);
-		route.advertised = cost.0;
+		route.advertised = costs.marginal.0;
+		if self.version.has_route_cost() {
+			route.cold = Some(costs.cold.charged(costs.link).0);
+			route.advertised_cold = Some(costs.cold.0);
+		} else {
+			route.cold = None;
+		}
 
 		if self.going_away.is_set() {
 			route.cost = crate::broadcast::DRAIN_COST;
+			route.cold = Some(crate::broadcast::DRAIN_COST);
 		}
 
 		route
@@ -364,9 +376,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		&mut self,
 		path: PathOwned,
 		mut hops: crate::OriginList,
-		// The route cost off the wire and this link's price. See `start_announce`.
-		cost: RouteCost,
-		link_cost: u64,
+		costs: AnnounceCosts,
 		// Lite05+: the announce sender's origin id (from AnnounceOk), appended here to
 		// rebuild the full chain since the sender no longer stamps itself. None for older
 		// versions. See `start_announce`.
@@ -389,7 +399,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 		let publisher = hops.iter().next().copied().unwrap_or(self.session_origin);
-		let metadata = self.announced_route(hops, cost, link_cost);
+		let metadata = self.announced_route(hops, costs);
 
 		match routes.get_mut(&path) {
 			Some(entry) if entry.publisher != publisher || publisher == crate::Origin::UNKNOWN => {
@@ -1203,8 +1213,11 @@ impl<S: crate::transport::poll::Session> AnnouncePrefix<S> {
 						self.subscriber.start_announce(
 							path.clone(),
 							crate::OriginList::new(),
-							RouteCost::default(),
-							0,
+							AnnounceCosts {
+								marginal: RouteCost::default(),
+								cold: RouteCost::default(),
+								link: 0,
+							},
 							run.responder_origin,
 							&mut run.routes,
 						)?;
@@ -1312,6 +1325,14 @@ mod tests {
 	use crate::lite::test_transport::SinkSession;
 
 	const VERSION: Version = Version::Lite05;
+
+	fn announce_costs(marginal: u64, cold: u64, link: u64) -> AnnounceCosts {
+		AnnounceCosts {
+			marginal: RouteCost(marginal),
+			cold: RouteCost(cold),
+			link,
+		}
+	}
 
 	/// `establish` puts exactly one SUBSCRIBE on the wire, and the id is registered
 	/// before any of it reaches the transport.
@@ -1843,8 +1864,7 @@ mod tests {
 			.start_announce(
 				Path::new("room/host").to_owned(),
 				crate::OriginList::new(),
-				RouteCost::default(),
-				0,
+				announce_costs(0, 0, 0),
 				None,
 				&mut routes,
 			)
@@ -1871,8 +1891,7 @@ mod tests {
 			.start_announce(
 				Path::new("room/host").to_owned(),
 				crate::OriginList::new(),
-				RouteCost::default(),
-				0,
+				announce_costs(0, 0, 0),
 				None,
 				&mut routes,
 			)
@@ -1882,6 +1901,31 @@ mod tests {
 		let broadcast = consumer.get_broadcast("room/host").unwrap();
 		let hops: Vec<_> = broadcast.routes()[0].hops.iter().copied().collect();
 		assert_eq!(hops, vec![crate::Origin::UNKNOWN]);
+	}
+
+	/// Lite-06 charges both advertised costs while retaining the peer's uncharged
+	/// cold value for the strict warm-rank comparison.
+	#[test]
+	fn lite06_announcement_preserves_cold_rank() {
+		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let subscriber = Subscriber::new(SubscriberConfig {
+			session: SinkSession::new(Default::default()),
+			origin,
+			recv_bandwidth: None,
+			version: Version::Lite06Wip,
+			peer_setup: Default::default(),
+			peer_origin: None,
+			cost: None,
+			going_away: Default::default(),
+		});
+
+		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
+		let route = subscriber.announced_route(hops, announce_costs(0, 5, 2));
+
+		assert_eq!(route.cost, 2);
+		assert_eq!(route.advertised, 0);
+		assert_eq!(route.cold, Some(7));
+		assert_eq!(route.advertised_cold, Some(5));
 	}
 
 	fn restart_subscriber(session: SinkSession) -> (Subscriber<SinkSession>, crate::origin::Consumer) {
@@ -1914,8 +1958,7 @@ mod tests {
 			.start_announce(
 				path.clone(),
 				crate::OriginList::new(),
-				RouteCost::default(),
-				0,
+				announce_costs(0, 0, 0),
 				Some(crate::Origin::UNKNOWN),
 				&mut routes,
 			)
@@ -1927,8 +1970,7 @@ mod tests {
 			.restart_announce(
 				path,
 				crate::OriginList::new(),
-				RouteCost::default(),
-				0,
+				announce_costs(0, 0, 0),
 				Some(crate::Origin::UNKNOWN),
 				&mut routes,
 			)
@@ -1955,8 +1997,7 @@ mod tests {
 			.start_announce(
 				path.clone(),
 				crate::OriginList::new(),
-				RouteCost::default(),
-				0,
+				announce_costs(0, 0, 0),
 				Some(publisher),
 				&mut routes,
 			)
@@ -1968,8 +2009,7 @@ mod tests {
 			.restart_announce(
 				path,
 				crate::OriginList::new(),
-				RouteCost(5),
-				0,
+				announce_costs(5, 5, 0),
 				Some(publisher),
 				&mut routes,
 			)
@@ -2008,7 +2048,7 @@ mod tests {
 		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
 		let mut routes = HashMap::new();
 		subscriber
-			.start_announce(path.clone(), hops, RouteCost(0), 1, None, &mut routes)
+			.start_announce(path.clone(), hops, announce_costs(0, 0, 1), None, &mut routes)
 			.unwrap();
 		tokio::time::sleep(Duration::from_millis(1)).await;
 		assert!(consumer.get_broadcast("room/host").is_some());
@@ -2026,7 +2066,7 @@ mod tests {
 		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
 		let mut routes = HashMap::new();
 		subscriber
-			.start_announce(path.clone(), hops, RouteCost(0), 1, None, &mut routes)
+			.start_announce(path.clone(), hops, announce_costs(0, 0, 1), None, &mut routes)
 			.unwrap();
 		tokio::time::sleep(Duration::from_millis(1)).await;
 		routes.remove(&path).expect("announced").finish();

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -13,8 +13,8 @@ pub enum Version {
 	Lite05,
 	/// Work-in-progress lite-06. Adds announce ids: each `active` ANNOUNCE_BROADCAST
 	/// implicitly assigns the next ordinal, and `ended`/`restart` reference that id
-	/// instead of repeating the path. Also adds the route cost carried alongside the
-	/// hop chain, ranking above hop count in route selection. Advertised over ALPN
+	/// instead of repeating the path. Also adds marginal and cold route costs carried
+	/// alongside the hop chain, ranking above hop count in route selection. Advertised over ALPN
 	/// (`moq-lite-06`, no `-wip` suffix on the wire) and the preferred version in the
 	/// default sets. The wire format is still WIP; finalizing is a pure rename to
 	/// `Lite06` with no wire change.
@@ -126,10 +126,8 @@ impl Version {
 		}
 	}
 
-	/// Whether announcements carry the route cost: the marginal cost of pulling
-	/// the broadcast via this route, accumulated per link. Added in lite-06.
-	/// Older versions carry nothing, so a received route stays at zero and ranks
-	/// on hop count alone, exactly as before.
+	/// Whether announcements carry marginal and cold route costs, accumulated per
+	/// link. Added in lite-06. Older versions carry neither value.
 	#[allow(clippy::match_like_matches_macro)]
 	pub fn has_route_cost(self) -> bool {
 		// Match form so future versions default forward (CLAUDE.md convention).

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -92,7 +92,7 @@ pub const DRAIN_COST: u64 = MAX_COST;
 /// Publish a change with [`Producer::set_route`] and observe one with
 /// [`Consumer::route_changed`]; downstream sessions forward updates as a restart
 /// on the wire, so route churn never looks like a new broadcast.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Route {
 	/// The chain of origins the broadcast has traversed, oldest first. Each relay
@@ -101,8 +101,8 @@ pub struct Route {
 	pub hops: OriginList,
 
 	/// The cost of pulling the broadcast via this route, accumulated per link:
-	/// lower wins, with ties broken by hop length, then a deterministic hash, and
-	/// finally the most recently attached route.
+	/// lower wins, with ties broken by the warm relay's cold rank when available,
+	/// then hop length, a deterministic hash, and the most recently attached route.
 	///
 	/// Selection accepts any value, but only [`MAX_COST`] of it survives a hop:
 	/// forwarding clamps to what a varint can carry, so a cost set beyond the
@@ -121,11 +121,25 @@ pub struct Route {
 	/// the hop-count tie-break as the effective metric exactly as before.
 	pub cost: u64,
 
+	/// The cost of this route without any warm-copy discount.
+	///
+	/// Kept inside the routing model rather than exposed as a second public metric:
+	/// consumers still select on [`Self::cost`]. Lite-06 relays carry this value so a
+	/// warm relay can advertise its own stable rank even after its marginal cost drops
+	/// to zero. `None` marks a route learned from a wire version that did not carry it.
+	pub(crate) cold: Option<u64>,
+
 	/// The cost as the announcing peer advertised it, before this link's charge
 	/// was added to [`Self::cost`]. Local bookkeeping, never forwarded: zero on a
 	/// chain of two or more hops means the announcing relay is actively carrying
 	/// the broadcast, which is what the origin's handover gate keys on.
 	pub(crate) advertised: u64,
+
+	/// The announcing peer's cold cost before this link's charge was added.
+	///
+	/// Present on lite-06 and used with the announcing peer's per-broadcast hash to
+	/// order warm relays without inheriting the rank of their current parent.
+	pub(crate) advertised_cold: Option<u64>,
 
 	/// Whether the broadcast should be announced: advertised to consumers via
 	/// [`crate::origin::Consumer::announced`] while this is the best route. A
@@ -134,6 +148,19 @@ pub struct Route {
 	/// [`Producer::set_route`] announces or unannounces without touching the
 	/// broadcast itself. Defaults to `false`.
 	pub announce: bool,
+}
+
+impl Default for Route {
+	fn default() -> Self {
+		Self {
+			hops: OriginList::new(),
+			cost: 0,
+			cold: Some(0),
+			advertised: 0,
+			advertised_cold: None,
+			announce: false,
+		}
+	}
 }
 
 impl Route {
@@ -175,6 +202,7 @@ impl Route {
 	/// Set the cost: lower wins among routes serving the same broadcast.
 	pub fn with_cost(mut self, cost: u64) -> Self {
 		self.cost = cost;
+		self.cold = Some(cost);
 		self
 	}
 
@@ -826,6 +854,7 @@ impl Dynamic {
 		}
 
 		state.route.cost = DRAIN_COST;
+		state.route.cold = Some(DRAIN_COST);
 		state.route_epoch += 1;
 
 		// An ordinary source's table is just its own route, and the origin reads the

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -417,13 +417,13 @@ fn fnv_key(name: &Path, origins: impl IntoIterator<Item = Origin>) -> u64 {
 
 /// Full ordering key for an attached route: announced routes first (an actively
 /// published source beats an offline one), then the marginal cost of pulling via
-/// the route, then the [`route_key`] hop ordering, and finally the newest source
-/// to attach. Lower wins.
+/// the route, the warm-relay rank, the [`route_key`] hop ordering, and finally the
+/// newest source to attach. Lower wins.
 ///
-/// Hop length stays the tie-break below cost, so peers that never carry a cost
-/// (pre-lite-06, or a plain local publish) rank exactly as they did before route
-/// cost existed, and equal-cost warm copies resolve to the closest one, which
-/// bounds same-datacenter chains to a single hop.
+/// The warm rank only differs from the local rank when lite-06 supplied a cold
+/// cost. Peers that do not carry it retain the old cost, hop length, and hash
+/// ordering. Among ranked routes, a lower-rooted warm copy can beat an equal-cost
+/// direct route before hop count, which is what consolidates a transitive tree.
 ///
 /// Recency is the last word, so it only separates routes that are identical in
 /// every advertised respect: same hop chain, same cost. That is a publisher
@@ -433,9 +433,16 @@ fn fnv_key(name: &Path, origins: impl IntoIterator<Item = Origin>) -> u64 {
 /// retires the corpse. Local attach order never leaks into cluster convergence:
 /// routes it can reorder are indistinguishable downstream, since what is
 /// forwarded is the chain and cost, which are equal by construction here.
-fn route_order(name: &Path, route: &FrontRoute) -> (bool, u64, usize, u64, Reverse<u64>) {
+fn route_order(name: &Path, route: &FrontRoute, rank: (u64, u64)) -> (bool, u64, (u64, u64), usize, u64, Reverse<u64>) {
 	let (len, hash) = route_key(name, &route.route.hops);
-	(!route.route.announce, route.route.cost, len, hash, Reverse(route.id))
+	(
+		!route.route.announce,
+		route.route.cost,
+		rank,
+		len,
+		hash,
+		Reverse(route.id),
+	)
 }
 
 /// One coalesced update queued for an `AnnounceConsumer`.
@@ -1252,6 +1259,44 @@ struct FrontState {
 }
 
 impl FrontState {
+	/// This relay's stable per-broadcast rank: its cheapest path without warm
+	/// discounts, followed by its own deterministic hash.
+	///
+	/// The cost is recomputed from every announced route rather than inherited from
+	/// the active parent. Every warm adoption therefore descends a node rank even
+	/// after the active route changes.
+	fn own_rank(&self) -> (u64, u64) {
+		let cold = self
+			.routes
+			.iter()
+			.filter(|route| route.route.announce && route.route.cost < broadcast::DRAIN_COST)
+			.filter_map(|route| route.route.cold)
+			.min()
+			.unwrap_or(broadcast::MAX_COST);
+		(cold, fnv_key(&self.path.as_path(), [self.self_origin]))
+	}
+
+	/// The announcing relay's rank when `route` is a warm-copy advertisement.
+	fn peer_rank(&self, route: &broadcast::Route) -> Option<(u64, u64)> {
+		if route.advertised != 0 || route.hops.len() < 2 {
+			return None;
+		}
+		let peer = route.hops.iter().last().copied()?;
+		let cold = route.advertised_cold?;
+		Some((cold, fnv_key(&self.path.as_path(), [peer])))
+	}
+
+	/// Route ordering in this front's local rank context.
+	///
+	/// Non-warm routes stand for keeping our own cold upstream. A warm peer stands
+	/// for adopting that peer's rank. On equal marginal cost this comparison happens
+	/// before hop count, so an already-carried copy rooted on a cheaper cold path is
+	/// not bypassed merely because the direct path has fewer hops.
+	fn route_order(&self, route: &FrontRoute) -> (bool, u64, (u64, u64), usize, u64, Reverse<u64>) {
+		let rank = self.peer_rank(&route.route).unwrap_or_else(|| self.own_rank());
+		route_order(&self.path.as_path(), route, rank)
+	}
+
 	/// The one selection primitive every picker goes through: the best route by
 	/// [`route_order`] among those surviving `keep`. With `untainted`, the pick
 	/// also steers away from routes that flow through a peer currently reading
@@ -1264,16 +1309,13 @@ impl FrontState {
 			true => self.prefer_untainted(&candidates),
 			false => candidates,
 		};
-		candidates
-			.into_iter()
-			.min_by_key(|r| route_order(&self.path.as_path(), r))
-			.map(|r| r.id)
+		candidates.into_iter().min_by_key(|r| self.route_order(r)).map(|r| r.id)
 	}
 
 	/// The source new track requests should dispatch to: live first, then lowest
-	/// cost, then shortest hop chain with a deterministic hash tie-break and the
-	/// newest source last, skipping routes that flow through a peer currently
-	/// reading the front while any other route remains.
+	/// marginal cost, warm rank, shortest hop chain, deterministic hash, and newest
+	/// source last. Routes flowing through a current reader are skipped while any
+	/// other route remains.
 	fn best_route(&self) -> Option<u64> {
 		self.pick(|_| true, true)
 	}
@@ -1366,33 +1408,36 @@ impl FrontState {
 			&& let Some(candidate) = self.routes.iter().find(|r| r.id == best_id)
 			&& let Some(incumbent) = self.routes.iter().find(|r| r.id == cur_id)
 			&& incumbent.route.announce
-			&& candidate.route.cost < incumbent.route.cost
 			&& candidate.route.advertised == 0
 			&& candidate.route.hops.len() >= 2
-			&& !self.handover_allowed(&candidate.route)
+			&& !self.handover_allowed(&candidate.route, &incumbent.route)
 		{
-			// We won the key comparison: keep our source and let the peer come to us.
+			// Our rank wins: keep our source and let the peer come to us.
 			return;
 		}
 		self.active = best;
 	}
 
-	/// Whether re-parenting onto `route` is allowed while actively carrying: the
-	/// announcing peer (the chain's last hop) must hash strictly below our own
-	/// origin for this broadcast name.
+	/// Whether re-parenting onto `route` is allowed while actively carrying.
 	///
-	/// Both sides compute the same two keys (the hash is build-stable and the
-	/// inputs are shared), so the comparison resolves the same way everywhere:
-	/// the lower-keyed node keeps its source, the higher-keyed one re-parents.
-	/// A strict total order has no cycles, so mutual pulls cannot happen. Mixing
-	/// the broadcast name in spreads ownership across a region's relays instead
-	/// of funneling every broadcast onto the lowest-keyed one. A route with no
-	/// hops is a local publish and always allowed.
-	fn handover_allowed(&self, route: &broadcast::Route) -> bool {
+	/// Lite-06 compares the announcing peer's `(cold cost, per-broadcast hash)` with
+	/// our own rank. Both sides compute the same strict total order, so mutual pulls
+	/// cannot happen. Older wire versions fall back to the hash-only comparison.
+	/// A route with no hops is a local publish and is always allowed.
+	fn handover_allowed(&self, route: &broadcast::Route, incumbent: &broadcast::Route) -> bool {
 		let name = self.path.as_path();
-		match route.hops.iter().last() {
-			Some(peer) => fnv_key(&name, [*peer]) < fnv_key(&name, [self.self_origin]),
-			None => true,
+		let Some(peer) = route.hops.iter().last().copied() else {
+			return true;
+		};
+		// A fresh session from the same relay is a reconnect, not a new parent.
+		if incumbent.hops.iter().last().copied() == Some(peer) {
+			return true;
+		}
+		match route.advertised_cold {
+			Some(cold) => (cold, fnv_key(&name, [peer])) < self.own_rank(),
+			// MoQ Cluster and older lite versions do not carry a cold cost. Preserve
+			// their original symmetric-race gate until their wire can express one.
+			None => fnv_key(&name, [peer]) < fnv_key(&name, [self.self_origin]),
 		}
 	}
 
@@ -1403,7 +1448,7 @@ impl FrontState {
 	/// always what this node is actually serving from.
 	fn routes_snapshot(&self) -> Vec<broadcast::Route> {
 		let mut routes: Vec<&FrontRoute> = self.routes.iter().collect();
-		routes.sort_by_key(|r| route_order(&self.path.as_path(), r));
+		routes.sort_by_key(|r| self.route_order(r));
 		routes.sort_by_key(|r| Some(r.id) != self.active);
 		routes.into_iter().map(|r| r.route.clone()).collect()
 	}
@@ -3120,6 +3165,16 @@ mod tests {
 		announce().with_hops(hops)
 	}
 
+	/// A lite-06 warm-sibling route. `cold` includes this relay's link charge;
+	/// `advertised_cold` is the peer's own uncharged rank from the wire.
+	fn ranked_sibling_route(peer: Origin, marginal: u64, peer_cold: u64, cold: u64) -> broadcast::Route {
+		let mut route = sibling_route(peer).with_cost(marginal);
+		route.advertised = 0;
+		route.advertised_cold = Some(peer_cold);
+		route.cold = Some(cold);
+		route
+	}
+
 	/// A route as the upstream announces it: priced, one hop.
 	fn upstream_route(cost: u64) -> broadcast::Route {
 		let hops = OriginList::try_from(vec![Origin::new(90).unwrap()]).unwrap();
@@ -3176,6 +3231,107 @@ mod tests {
 			a_moved != b_moved,
 			"exactly one side must re-parent (a: {a_moved}, b: {b_moved})"
 		);
+	}
+
+	/// A lower cold cost outranks the local relay regardless of the hash. This is
+	/// the asymmetric SJC/DAL case: DAL's direct cold path costs 1, while SJC's
+	/// costs 2, so SJC must aggregate onto DAL even when SJC wins the hash.
+	#[test]
+	fn test_carrying_gate_prefers_lower_cold_rank() {
+		let peer = Origin::new(3).unwrap();
+		let self_origin = origin_keyed("test", peer, false);
+		let mut state = front_state(
+			self_origin,
+			vec![upstream_route(2), ranked_sibling_route(peer, 0, 1, 2)],
+		);
+
+		state.reselect(true);
+		assert_eq!(state.active, Some(1), "the lower cold-cost relay must win");
+	}
+
+	/// A warm route with the same marginal cost as the direct route compares the
+	/// cold rank before hop count. Otherwise the shorter direct path would bypass
+	/// an already-carried copy rooted on a cheaper upstream.
+	#[test]
+	fn test_equal_marginal_cost_prefers_lower_warm_rank_before_hops() {
+		let peer = Origin::new(3).unwrap();
+		let mut direct = upstream_route(1);
+		direct.cold = Some(2);
+		let warm = ranked_sibling_route(peer, 1, 1, 2);
+		let mut state = front_state(Origin::new(4).unwrap(), vec![direct, warm]);
+
+		state.reselect(true);
+		assert_eq!(state.active, Some(1), "hop count bypassed the lower-ranked warm copy");
+	}
+
+	/// Equal cold costs fall through to the per-broadcast relay hash, so two relays
+	/// activating simultaneously choose exactly one root.
+	#[test]
+	fn test_equal_cold_rank_race_uses_hash() {
+		let a = Origin::new(1).unwrap();
+		let b = Origin::new(2).unwrap();
+		let mut a_view = front_state(a, vec![upstream_route(10), ranked_sibling_route(b, 0, 10, 10)]);
+		let mut b_view = front_state(b, vec![upstream_route(10), ranked_sibling_route(a, 0, 10, 10)]);
+
+		a_view.reselect(true);
+		b_view.reselect(true);
+		assert_ne!(
+			a_view.active == Some(1),
+			b_view.active == Some(1),
+			"equal-rank peers must elect exactly one root"
+		);
+	}
+
+	/// Each relay advertises its own cold rank rather than inheriting its active
+	/// parent's. That makes a transitive warm tree strictly descend A <- B <- C.
+	#[test]
+	fn test_cold_rank_stays_local_across_transitive_adoption() {
+		let a = Origin::new(1).unwrap();
+		let b = Origin::new(2).unwrap();
+		let c = Origin::new(3).unwrap();
+
+		let mut b_view = front_state(b, vec![upstream_route(2), ranked_sibling_route(a, 0, 1, 2)]);
+		b_view.reselect(true);
+		assert_eq!(b_view.active, Some(1));
+		assert_eq!(b_view.own_rank().0, 2, "B inherited A's rank");
+
+		let mut c_view = front_state(
+			c,
+			vec![upstream_route(3), ranked_sibling_route(b, 0, b_view.own_rank().0, 3)],
+		);
+		c_view.reselect(true);
+		assert_eq!(c_view.active, Some(1));
+		assert_eq!(c_view.own_rank().0, 3, "C inherited B's rank");
+	}
+
+	/// Losing the lower-ranked warm peer returns the relay to its cold upstream.
+	#[test]
+	fn test_ranked_parent_loss_reverts_to_cold_route() {
+		let peer = Origin::new(3).unwrap();
+		let mut state = front_state(
+			Origin::new(4).unwrap(),
+			vec![upstream_route(2), ranked_sibling_route(peer, 0, 1, 2)],
+		);
+		state.reselect(true);
+		assert_eq!(state.active, Some(1));
+
+		state.routes.retain(|route| route.id != 1);
+		state.reselect(true);
+		assert_eq!(state.active, Some(0), "the cold route was not restored");
+	}
+
+	/// A warm peer whose cold rank is not lower cannot attract a carrying relay,
+	/// even when its marginal route looks cheaper.
+	#[test]
+	fn test_carrying_gate_rejects_higher_cold_rank() {
+		let peer = Origin::new(3).unwrap();
+		let mut state = front_state(
+			origin_keyed("test", peer, true),
+			vec![upstream_route(5), ranked_sibling_route(peer, 0, 6, 6)],
+		);
+
+		state.reselect(true);
+		assert_eq!(state.active, Some(0), "a higher-ranked warm peer was adopted");
 	}
 
 	/// The gate is scoped to warm siblings: a cheaper route via a relay that is
@@ -3972,6 +4128,54 @@ mod tests {
 		assert_eq!(advertised.hops, hops_b);
 		assert_eq!(advertised.cost, 5);
 		announced.assert_next_wait();
+	}
+
+	/// An equal-marginal warm route with a lower cold rank takes a live track over
+	/// at a group boundary without origin-level announce churn.
+	#[tokio::test]
+	async fn test_warm_rank_handover_is_group_boundary_safe() {
+		tokio::time::pause();
+
+		let publisher = Origin::new(1).unwrap();
+		let peer = Origin::new(3).unwrap();
+		let origin = Info::new(Origin::new(4).unwrap()).produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let direct_hops = OriginList::try_from(vec![publisher]).unwrap();
+		let mut direct = announce().with_hops(direct_hops).with_cost(1);
+		direct.cold = Some(2);
+		let source_a = origin.create_broadcast("test", direct).unwrap();
+		let mut dynamic_a = source_a.dynamic();
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer_a = accept_track(&mut dynamic_a, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+		producer_a.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+
+		let mut warm = announce()
+			.with_hops(OriginList::try_from(vec![publisher, peer]).unwrap())
+			.with_cost(1);
+		warm.advertised = 0;
+		warm.advertised_cold = Some(1);
+		warm.cold = Some(2);
+		let source_b = origin.create_broadcast("test", warm).unwrap();
+		let mut dynamic_b = source_b.dynamic();
+		settle().await;
+		announced.assert_next_wait();
+
+		let mut producer_b = accept_track(&mut dynamic_b, "video").await;
+		settle().await;
+		sub.assert_no_group();
+		assert_eq!(producer_b.subscription().unwrap().start, Some(Position::group(1)));
+		producer_b.create_group(group::Info { sequence: 1 }).unwrap();
+		assert_eq!(sub.assert_group().sequence, 1);
+		sub.assert_not_closed();
 	}
 
 	/// A track completed for good must survive later source churn: it is never
@@ -6965,15 +7169,16 @@ mod tests {
 		};
 
 		let draining = front(9, announce().with_cost(broadcast::DRAIN_COST));
+		let rank = (0, 0);
 
-		assert!(route_order(&name, &draining) > route_order(&name, &front(0, announce())));
-		assert!(route_order(&name, &draining) > route_order(&name, &front(0, announce().with_cost(1000))));
+		assert!(route_order(&name, &draining, rank) > route_order(&name, &front(0, announce()), rank));
+		assert!(route_order(&name, &draining, rank) > route_order(&name, &front(0, announce().with_cost(1000)), rank));
 
 		// Two hops beats one when the cheaper one is draining: the longer path is
 		// still the one that will still be there.
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap(), Origin::new(2).unwrap()]).unwrap();
 		let long = front(0, announce().with_hops(hops).with_cost(1));
-		assert!(route_order(&name, &draining) > route_order(&name, &long));
+		assert!(route_order(&name, &draining, rank) > route_order(&name, &long, rank));
 	}
 
 	/// The whole point of the mechanism: with two sources for one broadcast,


### PR DESCRIPTION
## Summary

- add a Lite06 Cold Route Cost beside marginal Route Cost so a carrying relay keeps a stable per-broadcast rank
- adopt a warm peer only when its `(cold cost, relay hash)` rank is strictly lower, and compare warm rank before hop count when marginal costs tie
- advertise each relay's own cold rank rather than inheriting its active parent, preserving strict descent across transitive warm trees
- keep IETF and older Lite routes on the existing hash-only compatibility path because those wire formats do not carry cold cost
- mirror the wire field in `js/net` and specify it in the moq-lite draft

This replaces the viable remaining rank slice from #2179. The old base/transit-cost prototype was superseded by cumulative Route Cost in #2424 and is now far behind `dev`. The current design comes from the [pop-skipping quest](https://github.com/moq-dev/moq.pro/blob/main/quest/feat/pop-skipping.md).

Marginal warm discounts intentionally collapse to zero, but that erases the upstream path cost needed to select an aggregation root in asymmetric and simultaneous activation topologies. Cold Route Cost preserves that undiscounted path signal without changing marginal cost as the primary routing metric.

## Public API changes

- **Breaking Rust:** `lite::AnnounceBroadcast::Active` and `Restart` add the required `cold: RouteCost` field. This is why the PR targets `dev`.
- **Additive TypeScript:** active and restart `AnnounceBroadcast` variants add optional `cold?: bigint`.
- The routing model's cold bookkeeping remains `pub(crate)`; no second public `broadcast::Route` metric is exposed.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command cargo test -p moq-net` (864 unit tests plus integration and docs)
- `nix develop --command bun test js/net/src/lite/announce.test.ts`
- `nix develop --command just test smoke-full` (21 Rust/Python/JS/C/GStreamer combinations)

Cross-package sync: updated `js/net` and `drafts/draft-lcurley-moq-lite.md`. There is no existing `doc/concept` route-selection page to update. The IETF cluster wire is intentionally unchanged because the current quest rollout is Lite06-only.

(Written by GPT-5)