### PR TITLE
refactor(net)!: make origin lifecycle caller-driven

### DIFF
--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -82,12 +82,14 @@ See the [Authentication guide](/bin/relay/auth) for how to generate tokens.
 
 The [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs) demonstrates publishing end-to-end.
 
-Wire an [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Producer.html) into the client before connecting and publish your broadcasts into that. The origin outlives any single session, so a reconnect resumes where it left off; reaching for the session's own [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) instead ties your broadcasts to one transport.
+Wire an [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Producer.html) into the client before connecting and publish your broadcasts into that. The origin outlives any single session, so a reconnect resumes where it left off; reaching for the session's own [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) instead ties your broadcasts to one transport. The native `origin::spawn` helper runs the origin driver on Tokio. Direct `moq-net` users must retain and poll the driver returned by `origin::Producer::new` for the origin's entire lifetime; dropping it tears the origin down.
 
 ```rust
 // Publish into an origin wired before connecting: it outlives any one session,
 // so the broadcast survives a reconnect. Hold the connection to keep redialing.
-let origin = moq_net::Origin::random().produce();
+let origin = moq_native::origin::spawn(moq_net::origin::Info::new(
+    moq_net::Origin::random(),
+));
 let _connection = client.with_publisher(origin.consume()).connect(url);
 
 let route = moq_net::broadcast::Route::new().with_announce(true);
@@ -106,7 +108,9 @@ Subscribing works the same way round: wire an origin in before connecting and re
 ```rust
 // Consume into an origin wired before connecting, so announcements keep flowing
 // across a reconnect. Hold the connection to keep redialing.
-let origin = moq_net::Origin::random().produce();
+let origin = moq_native::origin::spawn(moq_net::origin::Info::new(
+    moq_net::Origin::random(),
+));
 let mut announced = origin.consume().announced();
 let _connection = client.with_subscriber(origin).connect(url);
 

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -76,19 +76,22 @@ let url = url::Url::parse("https://cdn.moq.dev/anon")?;
 let transport = moq_wasm::transport::connect(url, Default::default()).await?;
 
 // Hand the transport to moq-net and run the MoQ handshake.
-let origin = moq_net::Origin::random().produce();
+let (origin, origin_driver) = moq_net::origin::Producer::new(
+    moq_net::origin::Info::new(moq_net::Origin::random()),
+);
 let mut consumer = origin.consume();
 let (session, driver) = moq_net::Client::new()
     .with_subscriber(origin)
     .connect(transport)
     .await?;
 
-// Nothing drives the protocol but the driver, so run it for as long as you hold
-// the session. It holds no session clone, so dropping your last `session` still
-// closes the transport, which in turn ends the spawned task.
+// Nothing drives the protocol or origin lifecycle but these drivers, so run
+// them for as long as their handles are in use. Neither driver retains its
+// corresponding handle.
 wasm_bindgen_futures::spawn_local(async move {
     let _ = driver.await;
 });
+wasm_bindgen_futures::spawn_local(origin_driver);
 
 // Read announcements off `consumer` exactly as on native...
 ```

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -284,11 +284,15 @@ let connection = client.connect(url);
 
 To publish or consume, wire an [`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html)
 into the client before connecting. The origin outlives any individual session, so
-your broadcasts and subscriptions carry across reconnects:
+your broadcasts and subscriptions carry across reconnects. The native helper
+spawns the origin driver on Tokio; direct `moq-net` users must retain and poll the
+driver returned by `origin::Producer::new` for as long as the origin is in use:
 
 ```rust
 // Subscribe: wait for broadcasts to be announced.
-let origin = moq_net::Origin::random().produce();
+let origin = moq_native::origin::spawn(moq_net::origin::Info::new(
+    moq_net::Origin::random(),
+));
 let mut announced = origin.consume().announced();
 let _connection = client.with_subscriber(origin).connect(url);
 

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -10,7 +10,7 @@ async fn main() -> anyhow::Result<()> {
 	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that the session can publish incoming broadcasts to.
-	let origin = moq_net::Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 	let consumer = origin.consume();
 
 	// Run the subscription and the session in parallel.

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -8,7 +8,7 @@ async fn main() -> anyhow::Result<()> {
 	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that we can publish to and the session can consume from.
-	let origin = moq_net::Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 
 	// Run the broadcast production and the session in parallel.
 	// This is a simple example of how you can concurrently run multiple tasks.

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -37,7 +37,9 @@ pub struct Origin {
 
 impl Origin {
 	pub fn create(&mut self) -> Result<Id, Error> {
-		self.active.insert(moq_net::Origin::random().produce())
+		self.active.insert(moq_native::origin::spawn(moq_net::origin::Info::new(
+			moq_net::Origin::random(),
+		)))
 	}
 
 	pub fn get(&self, id: Id) -> Result<&moq_net::origin::Producer, Error> {

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -79,9 +79,9 @@ pub async fn run(ctx: Connection) {
 	let url = config.client.url.clone().expect("url required");
 
 	// Publish side: an origin we fill with our broadcasts and hand to the session.
-	let publish = Origin::random().produce();
+	let publish = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	// Consume side: the session fills this with peer announcements.
-	let consume = Origin::random().produce();
+	let consume = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let announced = consume.consume().announced();
 
 	let name = config.name();

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -209,7 +209,7 @@ async fn run(config: &Config) -> Result<()> {
 	let client = config.client.clone().init(config.quic.clone())?;
 
 	// Publish origin: the game session broadcast.
-	let publish_origin = moq_net::Origin::random().produce();
+	let publish_origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 	let default_game_prefix = format!("{}/game", config.prefix);
 	let default_viewer_prefix = format!("{}/viewer", config.prefix);
 	let game_prefix = config.prefix_game.as_deref().unwrap_or(&default_game_prefix);
@@ -224,7 +224,7 @@ async fn run(config: &Config) -> Result<()> {
 	// Consume origin: viewer broadcasts under the viewer prefix.
 	// JS publishes viewer feedback at "{viewer_prefix}/{name}/{viewerId}"
 	let viewer_path = format!("{viewer_prefix}/{name}");
-	let consume_origin = moq_net::Origin::random().produce();
+	let consume_origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 	let mut viewer_consumer = consume_origin
 		.with_root(&viewer_path)
 		.expect("viewer prefix should be valid")

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -239,11 +239,11 @@ impl MoqSide {
 	/// when set, otherwise fresh and random.
 	pub fn origin(&self) -> anyhow::Result<moq_net::origin::Producer> {
 		use anyhow::Context;
-		Ok(match self.origin {
+		let id = match self.origin {
 			Some(id) => moq_net::Origin::new(id).with_context(|| format!("invalid --origin {id}"))?,
 			None => moq_net::Origin::random(),
-		}
-		.produce())
+		};
+		Ok(moq_native::origin::spawn(moq_net::origin::Info::new(id)))
 	}
 
 	/// Whether `--cluster-lan` asked this process to mesh over the LAN.

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -453,18 +453,22 @@ mod tests {
 		assert_eq!(split_credential("/.clusterish/abc"), ("/.clusterish/abc", None));
 	}
 
-	fn lan(credential: &str) -> Lan {
-		Lan {
-			origin: moq_net::Origin::random().produce(),
-			credential: credential.to_string(),
-			client: moq_native::connect::Config::default(),
-		}
+	fn lan(credential: &str) -> (Lan, moq_net::origin::Driver) {
+		let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+		(
+			Lan {
+				origin,
+				credential: credential.to_string(),
+				client: moq_native::connect::Config::default(),
+			},
+			driver,
+		)
 	}
 
 	/// Only this listener's per-advertisement credential gets in.
 	#[test]
 	fn authorized_requires_the_advertised_credential() {
-		let closed = lan("expected-proof");
+		let (closed, _driver) = lan("expected-proof");
 		assert!(closed.authorized("/.cluster/expected-proof"));
 		assert!(!closed.authorized(MESH_PATH), "a missing proof must be rejected");
 		assert!(!closed.authorized("/.cluster/other-proof"));
@@ -476,7 +480,7 @@ mod tests {
 	/// advertisement, at every address the peer offered.
 	#[test]
 	fn dial_urls_carry_the_proof_to_every_address() {
-		let lan = lan("ours");
+		let (lan, _driver) = lan("ours");
 
 		let socket = DialTarget {
 			urls: ["moqt://192.168.1.5:4443", "moqt://127.0.0.1:4443"]
@@ -514,7 +518,7 @@ mod tests {
 	async fn pinning_a_peer_drops_the_relay_roots() {
 		let mut client = moq_native::connect::Config::default();
 		client.tls.root = vec!["ca.pem".into()];
-		let mut lan = lan("ours");
+		let (mut lan, _driver) = lan("ours");
 		lan.client = client;
 
 		let peer = DialTarget {
@@ -597,8 +601,8 @@ mod tests {
 	/// so the test needs no multicast and stays CI-safe.
 	#[tokio::test]
 	async fn session_shares_origin_bidirectionally() {
-		let origin_a = moq_net::Origin::random().produce();
-		let origin_b = moq_net::Origin::random().produce();
+		let origin_a = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
+		let origin_b = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 
 		// Published before the session exists; announcements flow once it connects.
 		let _from_a = origin_a
@@ -607,7 +611,7 @@ mod tests {
 
 		let (server, peer) = listener();
 		let server = server.listen().await.expect("listen");
-		let mut accept = lan("listener-proof");
+		let (mut accept, _accept_driver) = lan("listener-proof");
 		accept.origin = origin_b.clone();
 		// The mesh shares the listener with ordinary clients, so go through the
 		// same dispatch `--cluster-lan` installs rather than calling `accept`.
@@ -622,7 +626,7 @@ mod tests {
 			false,
 		));
 
-		let mut dialer = lan("dialer-proof");
+		let (mut dialer, _dialer_driver) = lan("dialer-proof");
 		dialer.origin = origin_a.clone();
 		let _dial = dialer.dial_target(&peer).expect("dial");
 
@@ -654,15 +658,15 @@ mod tests {
 	/// origin is attached: reaching the listener is not membership.
 	#[tokio::test]
 	async fn mesh_rejects_a_dial_without_the_proof() {
-		let origin_a = moq_net::Origin::random().produce();
-		let origin_b = moq_net::Origin::random().produce();
+		let origin_a = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
+		let origin_b = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let _from_b = origin_b
 			.create_broadcast("from-b", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("failed to create broadcast");
 
 		let (server, peer) = listener();
 		let server = server.listen().await.expect("listen");
-		let mut accept = lan("the-real-proof");
+		let (mut accept, _accept_driver) = lan("the-real-proof");
 		accept.origin = origin_b.clone();
 		tokio::spawn(serve(
 			server,
@@ -676,7 +680,7 @@ mod tests {
 		));
 
 		// A peer that reached the port but never saw a verifiable advertisement.
-		let mut dialer = lan("dialer-proof");
+		let (mut dialer, _dialer_driver) = lan("dialer-proof");
 		dialer.origin = origin_a.clone();
 		let _dial = dialer.dial_target(&peer).expect("dial");
 
@@ -695,14 +699,14 @@ mod tests {
 	/// user who passed `--listen` did ask to serve, so that case still does.
 	#[tokio::test]
 	async fn a_mesh_only_listener_refuses_ordinary_clients() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let _published = origin
 			.create_broadcast("secret-stream", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("failed to create broadcast");
 
 		let (server, peer) = listener();
 		let server = server.listen().await.expect("listen");
-		let mut accept = lan("the-real-proof");
+		let (mut accept, _accept_driver) = lan("the-real-proof");
 		accept.origin = origin.clone();
 		// `public_quic: false` is what `--cluster-lan` passes with no `--listen`.
 		tokio::spawn(serve(
@@ -721,7 +725,7 @@ mod tests {
 		config.tls = moq_native::tls::Connect::default();
 		config.tls.fingerprint = vec![peer.fingerprint.clone().expect("fingerprint")];
 		config.once = Some(true);
-		let stolen = moq_net::Origin::random().produce();
+		let stolen = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let url = peer.urls.into_iter().next().expect("an address");
 		let connection = config
 			.init(Default::default())

--- a/rs/moq-cli/src/play.rs
+++ b/rs/moq-cli/src/play.rs
@@ -936,7 +936,7 @@ mod tests {
 	async fn subscribe_waits_for_the_announcement() {
 		tokio::time::pause();
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let consumer = origin.consume();
 
 		// Resolving straight away, which is what the media task used to do.

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -495,7 +495,7 @@ mod tests {
 
 	async fn manufacture_input() -> Vec<u8> {
 		// Create the broadcast on a throwaway origin so the exporter can resolve it by path.
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut broadcast = origin
 			.create_broadcast("cli", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -578,7 +578,7 @@ mod tests {
 		// Publish side: `Publish::new(Ts)` builds a `ts::Import<Ext>`, so the verbatim
 		// streams land in the broadcast instead of being dropped by the media-only path.
 		// The broadcast is created on a throwaway origin so the exporter can resolve it by path.
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let broadcast = origin
 			.create_broadcast("cli", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();

--- a/rs/moq-cli/src/rtc.rs
+++ b/rs/moq-cli/src/rtc.rs
@@ -70,7 +70,7 @@ pub async fn listen_export(origin: moq_net::origin::Consumer, name: String, list
 		.with_context(|| format!("failed to scope origin to broadcast `{name}`"))?;
 	// A WHEP server only reads; it still needs a publisher handle for the shared
 	// glue, so hand it an unused, empty Origin producer.
-	let publisher = moq_net::Origin::random().produce();
+	let publisher = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 	let server = moq_rtc::Server::new(server_config(&listen), publisher, subscriber);
 	serve(server.subscribe_router(), "WHEP", listen).await
 }

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -88,11 +88,11 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		.connect
 		.clone()
 		.context("`transcode` requires a relay: pass --connect <url>")?;
-	let publish = moq_net::Origin::random().produce();
+	let publish = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 	// A session drop closes the source broadcast and ends the run: the outage is
 	// surfaced rather than transcoded over. The reconnect loop covers the dial;
 	// restarting after a mid-run drop is the caller's call.
-	let remote = moq_net::Origin::random().produce();
+	let remote = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 	let session = net
 		.client(moq.client.clone())?
 		.with_publisher(&publish)

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -166,7 +166,9 @@ impl MoqOriginProducer {
 			info = info.with_pool(moq_net::cache::Pool::new(capacity));
 		}
 
-		Self { inner: info.produce() }
+		Self {
+			inner: moq_native::origin::spawn(info),
+		}
 	}
 }
 
@@ -187,14 +189,14 @@ pub(crate) fn resolve_pair(
 ) -> (moq_net::origin::Producer, moq_net::origin::Producer) {
 	if publish.is_none() && consume.is_none() {
 		// Clones of a Producer share the underlying origin, so this is one origin, not two.
-		let shared = moq_net::Origin::random().produce();
+		let shared = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		return (shared.clone(), shared);
 	}
 
 	let resolve = |origin: Option<&Arc<MoqOriginProducer>>| {
 		origin
 			.map(|o| o.inner().clone())
-			.unwrap_or_else(|| moq_net::Origin::random().produce())
+			.unwrap_or_else(|| moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random())))
 	};
 	(resolve(publish), resolve(consume))
 }

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -126,7 +126,7 @@ impl Session {
 		// Producer setup may touch tokio time (group eviction), so run it inside the runtime context.
 		let _rt = RUNTIME.enter();
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut broadcast = origin.create_broadcast(
 			&settings.broadcast,
 			moq_net::broadcast::Route::new().with_announce(true),

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -283,7 +283,7 @@ async fn run_session(
 	let mut config = moq_native::connect::Config::default();
 	config.tls.insecure = Some(settings.tls_disable_verify);
 
-	let origin = moq_net::Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 	let origin_consumer = origin.consume();
 	let client = config.init(Default::default())?.with_subscriber(origin);
 

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -352,6 +352,12 @@ async fn watch(
 mod tests {
 	use super::*;
 
+	fn spawn_origin() -> moq_net::origin::Producer {
+		let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
+
 	fn frame(micros: u64, keyframe: bool) -> moq_mux::container::Frame {
 		payload_frame(micros, keyframe, &[0xDE, 0xAD, 0xBE, 0xEF])
 	}
@@ -388,7 +394,7 @@ mod tests {
 		config
 	}
 
-	// Let the origin's spawned attach task run so a created broadcast is routable.
+	// Let the spawned origin driver process lifecycle work between test phases.
 	async fn settle() {
 		for _ in 0..10 {
 			tokio::task::yield_now().await;
@@ -397,7 +403,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn escaping_broadcast_reference_is_not_advertised() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let _broadcast = origin
 			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -423,7 +429,7 @@ mod tests {
 	// timeline alone, and a segment request fetches and transmuxes exactly its groups.
 	#[tokio::test]
 	async fn serves_playlist_and_segments_from_the_timeline() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -500,7 +506,7 @@ mod tests {
 	// and $Time$ addressing resolves a segment's pts to the same bytes its number does.
 	#[tokio::test]
 	async fn serves_dash_manifest_and_time_addressed_segments() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -581,7 +587,7 @@ mod tests {
 	// A finished broadcast renders a static presentation, offset to its first listed segment.
 	#[tokio::test]
 	async fn dash_manifest_turns_static_when_finished() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -642,7 +648,7 @@ mod tests {
 	// EXTINF exceeds its target duration is invalid.
 	#[tokio::test]
 	async fn target_duration_covers_the_window_without_a_declared_bound() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -679,7 +685,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn audio_and_video_segments_are_aligned() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -764,7 +770,7 @@ mod tests {
 	// drop the last segment of every recording.
 	#[tokio::test]
 	async fn dropping_the_broadcaster_keeps_a_cursor_drainable() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -879,7 +885,7 @@ mod tests {
 			(rendition, watcher)
 		}
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let (old, config) = publish(&origin, OLD);
 		settle().await;
 
@@ -943,7 +949,7 @@ mod tests {
 	// subscription) would stay alive and the cursor would park at the live edge forever.
 	#[tokio::test]
 	async fn removing_a_rendition_ends_its_segment_cursor() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -986,7 +992,7 @@ mod tests {
 	// source subscription it holds -- for as long as the consumer lived.
 	#[tokio::test]
 	async fn dropping_the_broadcaster_releases_its_renditions() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -1043,7 +1049,7 @@ mod tests {
 	// segment and then ends both cursors.
 	#[tokio::test]
 	async fn record_cursors_yield_renditions_and_segments() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -144,6 +144,12 @@ async fn evict_closed(inner: Arc<Inner>, name: String, broadcaster: Arc<Broadcas
 mod tests {
 	use super::*;
 
+	fn spawn_origin() -> moq_net::origin::Producer {
+		let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
+
 	/// Let the origin's spawned attach/detach tasks run: a created broadcast
 	/// becomes routable (and a finished one unroutable) asynchronously.
 	async fn settle() {
@@ -173,7 +179,7 @@ mod tests {
 
 		// An origin with no broadcasts: a request that reaches the handlers 404s after
 		// RESOLVE_TIMEOUT, so a 401 proves the middleware rejected it first.
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let server = Server::new(origin.consume(), Config::default());
 		let app = server.router().layer(middleware::from_fn(gate));
 
@@ -207,7 +213,7 @@ mod tests {
 		use axum::http::{StatusCode, header};
 		use tower::ServiceExt;
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let server = Server::new(origin.consume(), Config::default());
 		let app = Router::new().nest("/hls", server.router());
 
@@ -227,7 +233,7 @@ mod tests {
 	}
 
 	async fn closed_broadcaster() -> Arc<Broadcaster> {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut producer = origin
 			.create_broadcast("gone", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
@@ -244,7 +250,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn broadcaster_replaces_finished_cached_instance() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let server = Server::new(origin.consume(), Config::default());
 		let stale = closed_broadcaster().await;
 
@@ -267,7 +273,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn eviction_keeps_newer_cached_instance() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let server = Server::new(origin.consume(), Config::default());
 		let old = closed_broadcaster().await;
 		let mut new_producer = origin

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -158,7 +158,7 @@ mod test {
 	/// [`broadcast::Info::path`](moq_net::broadcast::Info::path), the base the consumer
 	/// resolves against.
 	fn publish_catalog(published: Catalog<()>) -> Result<Option<Catalog>> {
-		let origin = moq_net::Origin::random().produce();
+		let (origin, _driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut broadcast = origin
 			.create_broadcast("a/pub", moq_net::broadcast::Route::new())
 			.expect("broadcast should create");
@@ -199,7 +199,7 @@ mod test {
 			.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())
 			.expect("catalog track should create");
 
-		let origin = moq_net::Origin::random().produce();
+		let (origin, _driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let requesting = origin.consume().request_broadcast("a/pub");
 		let served = broadcast.consume();

--- a/rs/moq-mux/src/source.rs
+++ b/rs/moq-mux/src/source.rs
@@ -219,7 +219,8 @@ impl BroadcastConfig for hang::catalog::TextConfig {
 /// lifetime (harmless in a test binary).
 #[cfg(test)]
 pub(crate) fn announced(broadcast: &moq_net::broadcast::Consumer) -> Source {
-	let origin = moq_net::Origin::random().produce();
+	let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+	tokio::spawn(driver);
 	let mut dynamic = origin.dynamic();
 	let served = broadcast.clone();
 	tokio::spawn(async move {
@@ -235,6 +236,12 @@ pub(crate) fn announced(broadcast: &moq_net::broadcast::Consumer) -> Source {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	fn spawn_origin() -> moq_net::origin::Producer {
+		let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
 	use hang::catalog::{H264, VideoConfig};
 	use moq_net::{Origin, PathRelative};
 
@@ -248,7 +255,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn no_override_targets_catalog_broadcast() {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let _producer = origin
 			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -272,7 +279,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn subscribe_track_resolves_catalog_broadcast() {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let mut producer = origin
 			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -289,7 +296,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn self_reference_targets_catalog_broadcast() {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let mut producer = origin
 			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -308,7 +315,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn escaping_reference_is_rejected() {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 
 		let mut catalog = origin
 			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
@@ -352,7 +359,7 @@ mod tests {
 
 	#[test]
 	fn escaping_rendition_is_removed_while_valid_sibling_remains() {
-		let origin = Origin::random().produce();
+		let (origin, _driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(Origin::random()));
 		let source = Source::new(origin.consume(), "a/pub");
 		let mut escaped = VideoConfig::new(H264 {
 			profile: 0x42,
@@ -378,7 +385,7 @@ mod tests {
 	/// it is the one that silently goes unchecked when the two sides drift.
 	#[test]
 	fn escaping_text_rendition_is_removed() {
-		let origin = Origin::random().produce();
+		let (origin, _driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(Origin::random()));
 		let source = Source::new(origin.consume(), "a/pub");
 
 		let mut escaped = hang::catalog::TextConfig::new(hang::catalog::TextFormat::Vtt);
@@ -397,7 +404,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn subscribe_track_resolves_referenced_broadcast() {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 
 		let _catalog = origin
 			.create_broadcast("a/pub", moq_net::broadcast::Route::new().with_announce(true))
@@ -421,7 +428,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn dot_resolves_output_parent() {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 
 		let _catalog = origin
 			.create_broadcast(
@@ -446,7 +453,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn dot_resolves_one_segment_catalog_to_root() {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 
 		let _catalog = origin
 			.create_broadcast("top", moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -8,7 +8,7 @@ async fn main() -> anyhow::Result<()> {
 	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that we can publish to and the session can consume from.
-	let origin = moq_net::Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 
 	// Run the broadcast production and the session in parallel.
 	// This is a simple example of how you can concurrently run multiple tasks.

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
 
 	let track = config.track;
 
-	let origin = moq_net::Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 
 	match config.role {
 		Command::Publish => {

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -28,6 +28,7 @@ pub mod listen;
 mod log;
 #[cfg(feature = "noq")]
 pub mod noq;
+pub mod origin;
 pub mod quic;
 #[cfg(feature = "quinn")]
 pub mod quinn;

--- a/rs/moq-native/src/origin.rs
+++ b/rs/moq-native/src/origin.rs
@@ -1,0 +1,56 @@
+//! Tokio lifecycle helpers for origins.
+
+/// Construct an origin and spawn its driver on the current Tokio runtime.
+///
+/// The returned producer does not keep the driver alive after the producer and
+/// its lifecycle work drain. This function panics when called outside a Tokio
+/// runtime.
+pub fn spawn(info: moq_net::origin::Info) -> moq_net::origin::Producer {
+	let (producer, driver) = moq_net::origin::Producer::new(info);
+	tokio::spawn(driver);
+	producer
+}
+
+#[cfg(test)]
+mod tests {
+	use futures::FutureExt;
+
+	use super::*;
+
+	#[tokio::test]
+	async fn progresses_and_tears_down() {
+		let origin = spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+		let source = origin
+			.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
+			.unwrap();
+
+		assert!(consumer.request_broadcast("test").await.is_ok());
+		assert!(announced.next().await.unwrap().broadcast.is_some());
+
+		drop(origin);
+		drop(source);
+		tokio::task::yield_now().await;
+		assert!(announced.next().await.unwrap().broadcast.is_none());
+		assert!(announced.next().await.is_none());
+	}
+
+	#[test]
+	fn panics_without_tokio_runtime() {
+		let result = std::panic::catch_unwind(|| spawn(moq_net::origin::Info::new(moq_net::Origin::random())));
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn driver_does_not_retain_origin() {
+		let runtime = tokio::runtime::Runtime::new().unwrap();
+		runtime.block_on(async {
+			let origin = spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
+			let consumer = origin.consume();
+			drop(origin);
+			tokio::task::yield_now().await;
+			assert!(consumer.request_broadcast("test").now_or_never().unwrap().is_err());
+		});
+	}
+}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -1302,7 +1302,7 @@ mod tests {
 		let path = PathBuf::from(format!("/tmp/moq-native-publish-{}.sock", std::process::id()));
 		let _ = std::fs::remove_file(&path);
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = crate::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut broadcast = origin
 			.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("create broadcast");
@@ -1340,7 +1340,7 @@ mod tests {
 		const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 		let url: Url = format!("unix://{}", path.display()).parse().expect("parse url");
-		let subscriber = moq_net::Origin::random().produce();
+		let subscriber = crate::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut announced = subscriber.consume().announced();
 		let client = crate::connect::Config::default()
 			.init(Default::default())

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -24,7 +24,9 @@ async fn connect_with_version(version: &str) {
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	// Provide a dummy origin so the MoQ handshake has something to negotiate.
-	let origin = moq_native::moq_net::Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_native::moq_net::origin::Info::new(
+		moq_native::moq_net::Origin::random(),
+	));
 
 	// ── client ──────────────────────────────────────────────────────
 	let mut client_config = moq_native::connect::Config::default();
@@ -75,7 +77,9 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let origin = moq_native::moq_net::Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_native::moq_net::origin::Info::new(
+		moq_native::moq_net::Origin::random(),
+	));
 
 	// ── client ──────────────────────────────────────────────────────
 	let mut client_config = moq_native::connect::Config::default();

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -104,7 +104,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	} = config;
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -128,7 +128,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -279,7 +279,7 @@ struct MtlsPaths {
 async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend, reject: bool) {
 	let (_dir, paths) = generate_mtls_certs();
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 
 	let mut server_config = moq_native::listen::Config::default();
 	server_config.bind = Some("127.0.0.1:0".to_string());
@@ -466,7 +466,7 @@ async fn iroh_connect() {
 	use moq_native::iroh::EndpointConfig;
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -505,7 +505,7 @@ async fn iroh_connect() {
 	let mut server = server.listen().await.expect("failed to listen");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	// Create client iroh endpoint

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -23,7 +23,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	let server_version: Option<moq_net::Version> = server_version.map(|v| v.parse().expect("invalid server version"));
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -48,7 +48,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -127,7 +127,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 async fn lite05_timestamp_roundtrip(scheme: &str) {
 	use moq_native::moq_net::{Timescale, Timestamp};
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -166,7 +166,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -247,7 +247,7 @@ async fn broadcast_moq_lite_05_timestamps_webtransport() {
 async fn lite05_fetch_roundtrip(scheme: &str) {
 	use moq_native::moq_net::{Timescale, Timestamp};
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -284,7 +284,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -376,7 +376,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 		}
 	}
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -409,7 +409,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -497,7 +497,7 @@ async fn broadcast_moq_lite_05_fetch_during_subscribe_webtransport() {
 async fn broadcast_moq_lite_05_default_timescale() {
 	use moq_native::moq_net::Timescale;
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -517,7 +517,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("local addr");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -592,7 +592,7 @@ async fn next_announce(announcements: &mut moq_net::announce::Consumer) -> moq_n
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_lite_06_announce_lifecycle() {
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 
 	// Announced before the client connects, so it rides the initial set.
 	let mut first = pub_origin
@@ -607,7 +607,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("local addr");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -730,7 +730,7 @@ async fn broadcast_route_migration() {
 	let publisher = Origin::new(0x42).unwrap();
 
 	// ── publisher A: the preferred route (shorter hop chain) ────────
-	let origin_a = Origin::random().produce();
+	let origin_a = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut hops_a = moq_net::OriginList::new();
 	hops_a.push(publisher).unwrap();
 	let mut broadcast_a = origin_a
@@ -751,7 +751,7 @@ async fn broadcast_route_migration() {
 	}
 
 	// ── publisher B: the standby, carrying an extra hop so A wins ───
-	let origin_b = Origin::random().produce();
+	let origin_b = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut hops_b = moq_net::OriginList::new();
 	hops_b.push(publisher).unwrap();
 	hops_b.push(Origin::new(0x1234).unwrap()).unwrap();
@@ -809,7 +809,7 @@ async fn broadcast_route_migration() {
 	});
 
 	// ── one subscriber origin fed by both sessions ───────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let connect = |port: u16, sub: moq_net::origin::Producer| {
@@ -890,7 +890,7 @@ async fn route_reannounce_test(version: Option<&str>) {
 	let version: Option<moq_net::Version> = version.map(|v| v.parse().expect("invalid version"));
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let origin = Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	// The original publisher: the first hop of every advertised chain. Keeping
 	// it stable across the update is what makes the restart an in-place route
 	// change rather than a broadcast replacement.
@@ -935,7 +935,7 @@ async fn route_reannounce_test(version: Option<&str>) {
 	});
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -1033,7 +1033,7 @@ async fn route_replaced_test(version: Option<&str>) {
 	let version: Option<moq_net::Version> = version.map(|v| v.parse().expect("invalid version"));
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let origin = Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut hops_a = moq_net::OriginList::new();
 	hops_a.push(Origin::new(0x1111).unwrap()).unwrap();
 	let mut producer = origin
@@ -1071,7 +1071,7 @@ async fn route_replaced_test(version: Option<&str>) {
 	});
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -1331,7 +1331,7 @@ async fn latency_max_test(version: &str) -> Duration {
 	let version: moq_net::Version = version.parse().expect("invalid version");
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -1358,9 +1358,8 @@ async fn latency_max_test(version: &str) -> Duration {
 	// ── subscriber (client) ─────────────────────────────────────────
 	// The origin the session writes remote broadcasts into decides the window for
 	// tracks whose protocol can't carry the publisher's.
-	let sub_origin = moq_net::origin::Info::new(Origin::random())
-		.with_latency_default(LATENCY_DEFAULT)
-		.produce();
+	let sub_origin =
+		moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()).with_latency_default(LATENCY_DEFAULT));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -1612,7 +1611,7 @@ async fn broadcast_websocket() {
 	use moq_native::moq_net::Origin;
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -1641,7 +1640,7 @@ async fn broadcast_websocket() {
 	let mut server = server.listen().await.expect("failed to listen");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -1724,7 +1723,7 @@ async fn broadcast_websocket_fallback() {
 	use moq_native::moq_net::Origin;
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -1753,7 +1752,7 @@ async fn broadcast_websocket_fallback() {
 	let mut server = server.listen().await.expect("failed to listen");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -1847,7 +1846,7 @@ const NEWEST_LITE: &str = "moq-lite-05";
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket_uses_newest_version() {
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -1873,7 +1872,7 @@ async fn broadcast_websocket_uses_newest_version() {
 		.with_websocket(ws_listener);
 	let mut server = server.listen().await.expect("failed to listen");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut client_config = moq_native::connect::Config::default();
 	client_config.tls.insecure = Some(true);
 	client_config.websocket.delay = Some(std::time::Duration::ZERO);
@@ -1918,7 +1917,7 @@ async fn broadcast_websocket_uses_newest_version() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_race_quic_wins() {
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -1947,7 +1946,7 @@ async fn broadcast_race_quic_wins() {
 		.with_websocket(ws_listener);
 	let mut server = server.listen().await.expect("failed to listen");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut client_config = moq_native::connect::Config::default();
 	client_config.tls.insecure = Some(true);
 	// Zero head start: QUIC has to win on its own merit, not by penalising WS.
@@ -2001,7 +2000,7 @@ async fn broadcast_race_quic_wins() {
 /// consumer.
 #[tokio::test]
 async fn resubscribe_keeps_flowing_moq_lite_03() {
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -2021,7 +2020,7 @@ async fn resubscribe_keeps_flowing_moq_lite_03() {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("server addr");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -2133,7 +2132,7 @@ fn active_viewers(registry: &moq_net::stats::Registry) -> u64 {
 /// viewer nobody is watching (chained through relays, one phantom per hop).
 #[tokio::test]
 async fn idle_subscription_releases_the_viewer_count() {
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -2156,7 +2155,7 @@ async fn idle_subscription_releases_the_viewer_count() {
 	let registry = moq_net::stats::Registry::new(moq_net::stats::Config::new());
 	let stats = registry.tier(moq_net::stats::Tier::default()).session("");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -2358,7 +2357,7 @@ async fn one_shot_connect_surfaces_the_session_close() {
 	// close each session as soon as it lands.
 	let accepts = Arc::new(AtomicUsize::new(0));
 	let server_accepts = accepts.clone();
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let server_handle = tokio::spawn(async move {
 		while let Some(request) = server.accept().await {
 			server_accepts.fetch_add(1, Ordering::SeqCst);
@@ -2410,7 +2409,7 @@ async fn a_dead_session_unannounces_while_the_reconnect_retries() {
 	let (mut server, addr) = test_server().await;
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let _broadcast = pub_origin
 		.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -2428,7 +2427,7 @@ async fn a_dead_session_unannounces_while_the_reconnect_retries() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -2472,7 +2471,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 	use moq_native::moq_net::Origin;
 
 	// ── publisher (server): only allowed to announce under "allowed" ──
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("allowed/test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -2492,7 +2491,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 
 	// ── subscriber (client): interested in both "allowed" and "denied" ──
 	// "denied" is disjoint from the publisher's scope, so its announce stream is FINed.
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let consume = sub_origin
 		.scope(&["allowed".into(), "denied".into()])
 		.expect("failed to scope consume origin");
@@ -2550,7 +2549,7 @@ async fn publish_only_client_to_subscribe_only_server() {
 	use moq_native::moq_net::Origin;
 
 	// ── subscriber (server): interested in both "allowed" and "denied" ──
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let consume = sub_origin
 		.scope(&["allowed".into(), "denied".into()])
 		.expect("failed to scope consume origin");
@@ -2608,7 +2607,7 @@ async fn publish_only_client_to_subscribe_only_server() {
 	});
 
 	// ── publisher (client): only allowed to serve under "allowed" ──
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("allowed/test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -2681,7 +2680,7 @@ async fn goaway_test(scheme: &str, version: &str, expect_wire_timeout: bool) {
 	let version: moq_net::Version = version.parse().expect("invalid version");
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -2703,7 +2702,7 @@ async fn goaway_test(scheme: &str, version: &str, expect_wire_timeout: bool) {
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::connect::Config::default();
@@ -2829,7 +2828,7 @@ async fn goaway_moq_transport_19_quic() {
 async fn goaway_timeout_force_close_moq_transport_19_quic() {
 	let version: moq_net::Version = "moq-transport-19".parse().unwrap();
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 
 	let mut server_config = moq_native::listen::Config::default();
 	server_config.bind = Some("[::]:0".to_string());
@@ -2858,7 +2857,7 @@ async fn goaway_timeout_force_close_moq_transport_19_quic() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let (_client, connection) = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
 		.await
 		.expect("client connect timed out")
@@ -2916,7 +2915,7 @@ async fn zero_initial_backoff_still_gives_up_on_a_flapping_peer() {
 	let (mut server, addr) = test_server().await;
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let server_handle = tokio::spawn(async move {
 		// Accept and immediately sever, over and over.
 		while let Some(request) = server.accept().await {

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -720,7 +720,7 @@ mod tests {
 			.with_protocol(crate::version::ALPN_LITE_05);
 
 		// A subscribe origin is what makes the client open an announce stream at all.
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let client = Client::new()
 			.with_versions([Version::Lite(lite::Version::Lite05)].into())
 			.with_subscriber(origin);

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1770,7 +1770,7 @@ mod tests {
 		let assigned = crate::Origin::new(777).unwrap();
 		let other = crate::Origin::new(778).unwrap();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
@@ -1822,7 +1822,7 @@ mod tests {
 	/// spin on it forever.
 	#[tokio::test]
 	async fn linger_clears_when_the_advert_stops_being_discounted() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let broadcast = origin
 			.clone()
 			.create_broadcast("cam", crate::broadcast::Route::announced())
@@ -1870,7 +1870,7 @@ mod tests {
 	async fn namespace_follows_route_eligibility_changes() {
 		let assigned = crate::Origin::new(777).unwrap();
 		let clean_publisher = crate::Origin::new(778).unwrap();
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 
 		let gate = kio::Producer::new(true);
 		let session = SinkSession::gated_bi(gate.consume());
@@ -1968,7 +1968,7 @@ mod tests {
 	async fn a_refusal_that_forbids_retrying_is_not_retried() {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let _cam = origin
 			.create_broadcast("lonely-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2055,7 +2055,7 @@ mod tests {
 	async fn v14_subscribe_namespace_is_answered_with_publish_namespace() {
 		const VERSION: Version = Version::Draft14;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 
 		// Announced before the peer subscribes: it must only hit the wire after.
@@ -2144,7 +2144,7 @@ mod tests {
 	async fn a_peer_that_declared_nothing_is_told_unsolicited() {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let _local = origin
 			.create_broadcast("local-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2191,7 +2191,7 @@ mod tests {
 	async fn advertise_both_ways(solicit: Option<bool>) -> (usize, usize) {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let _cam = origin
 			.create_broadcast("cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2264,7 +2264,7 @@ mod tests {
 	async fn a_parked_open_still_lets_a_namespace_be_withdrawn() {
 		const VERSION: Version = Version::Draft14;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let first = origin
 			.create_broadcast("first-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2347,7 +2347,7 @@ mod tests {
 	async fn a_namespace_that_stops_being_advertisable_stops_being_deferred() {
 		let assigned = crate::Origin::new(777).unwrap();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 
 		// Every route flows through the peer's own identity, so split horizon says this
 		// must never be advertised back to it: `select` wants nothing, which is what the
@@ -2397,7 +2397,7 @@ mod tests {
 	async fn a_route_change_still_waits_out_a_refusal() {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let cam = origin
 			.create_broadcast("solo-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2459,7 +2459,7 @@ mod tests {
 	async fn a_modern_withdrawal_is_the_fin_alone() {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let cam = origin
 			.create_broadcast("solo-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2513,7 +2513,7 @@ mod tests {
 	async fn a_silent_answer_still_lets_the_next_namespace_be_advertised() {
 		const VERSION: Version = Version::Draft14;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let _first = origin
 			.create_broadcast("first-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2564,7 +2564,7 @@ mod tests {
 	async fn a_namespace_refused_a_stream_is_retried_on_its_own() {
 		const VERSION: Version = Version::Draft14;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let _cam = origin
 			.create_broadcast("lonely-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2630,7 +2630,7 @@ mod tests {
 	}
 
 	fn harness(version: Version) -> Harness {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let session = crate::lite::test_transport::ScriptedSession::per_stream(vec![Vec::new()]);
 		let log = session.log.clone();
 

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -884,7 +884,7 @@ mod tests {
 		// bound it: paused time makes the deadline fire the moment nothing else can run.
 		tokio::time::pause();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let session = crate::lite::test_transport::ScriptedSession::new(namespace_without_hop_path(VERSION).await);
 		let log = session.log.clone();
 
@@ -932,7 +932,7 @@ mod tests {
 	/// called `run_subscribe_namespace` itself.
 	#[tokio::test]
 	async fn every_permitted_prefix_gets_its_own_subscribe_namespace() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let scoped = origin
 			.with_root("rootns")
 			.and_then(|rooted| rooted.scope(&[crate::Path::new("cam"), crate::Path::new("mic")]))
@@ -983,7 +983,7 @@ mod tests {
 	/// The scripted peer answers nothing, so an advertisement parks after writing. That is
 	/// enough: the question is only whether the bytes went out unasked.
 	async fn announce_occurrences(peer_declared: Option<peer::Peer>) -> usize {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let _cam = origin
 			.create_broadcast("solo-cam", crate::broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -1070,14 +1070,14 @@ mod tests {
 	fn the_hop_id_comes_from_whichever_origin_the_caller_set() {
 		let ours = crate::Origin::new(42).unwrap();
 
-		let publish = crate::origin::Info::new(ours).produce();
+		let (publish, _publish_driver) = crate::origin::Producer::new(crate::origin::Info::new(ours));
 		assert_eq!(self_origin(Some(&publish.consume()), None), ours, "the publish half");
 
-		let subscribe = crate::origin::Info::new(ours).produce();
+		let (subscribe, _subscribe_driver) = crate::origin::Producer::new(crate::origin::Info::new(ours));
 		assert_eq!(self_origin(None, Some(&subscribe)), ours, "the subscribe half alone");
 
 		// Neither half: nothing to route, so any id will do as long as it is ours.
-		let publish = crate::origin::Info::new(ours).produce();
+		let (publish, _other_driver) = crate::origin::Producer::new(crate::origin::Info::new(ours));
 		assert_eq!(self_origin(Some(&publish.consume()), Some(&subscribe)), ours);
 	}
 
@@ -1096,7 +1096,7 @@ mod tests {
 		// deadline fire the moment nothing else can run.
 		tokio::time::pause();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let log = session.log.clone();
 
 		let (driver, _goaway) = start(Config {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1491,7 +1491,7 @@ mod tests {
 	/// What an unsolicited advertisement means to a subscriber on `version` whose peer
 	/// declared `solicit`.
 	fn unsolicited_is_a_violation(solicit: Option<bool>, version: Version) -> bool {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
 		let peer_setup = peer::PeerSetup::default();
 		peer_setup.set(peer::Peer {
@@ -1559,7 +1559,7 @@ mod tests {
 	/// so sending it asks for a prefix that matches nothing there.
 	#[tokio::test]
 	async fn a_rooted_subscriber_asks_for_its_scope_not_its_root() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let scoped = origin
 			.with_root("rootns")
 			.and_then(|rooted| rooted.scope(&[crate::Path::new("cam")]))
@@ -1629,7 +1629,7 @@ mod tests {
 	async fn a_rooted_subscriber_mounts_a_reply_under_its_root_once() {
 		const VERSION: Version = Version::Draft18;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 		let scoped = origin
 			.with_root("rootns")
@@ -1699,7 +1699,7 @@ mod tests {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
 		let assigned = crate::Origin::new(777).unwrap();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 		let (tasks, _task_set) = crate::util::TaskSet::new();
 		let mut subscriber = Subscriber::new(
@@ -1740,7 +1740,7 @@ mod tests {
 		let peer = crate::Origin::new(777).unwrap();
 		let self_origin = crate::Origin::new(1).unwrap();
 
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(self_origin));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -1805,7 +1805,7 @@ mod tests {
 		let peer = crate::Origin::new(777).unwrap();
 		let self_origin = crate::Origin::new(1).unwrap();
 
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(self_origin));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -1851,9 +1851,10 @@ mod tests {
 	) -> (
 		Subscriber<crate::lite::test_transport::SinkSession>,
 		crate::origin::Producer,
+		crate::origin::Driver,
 	) {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let (origin, driver) = crate::origin::Producer::new(crate::origin::Info::new(self_origin));
 		let (tasks, task_set) = crate::util::TaskSet::new();
 		// The set only drains announce-serving tasks; the tests here drive the model
 		// directly, so leaking it keeps the handles alive without a spawner.
@@ -1871,7 +1872,7 @@ mod tests {
 			tasks,
 			Default::default(),
 		);
-		(subscriber, origin)
+		(subscriber, origin, driver)
 	}
 
 	fn hop_path(ids: &[u64]) -> cluster::HopPath {
@@ -1887,7 +1888,8 @@ mod tests {
 	/// upstream value ranks last rather than wrapping to best).
 	#[tokio::test]
 	async fn cluster_advert_becomes_a_route_with_the_link_charged() {
-		let (subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (subscriber, origin, driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		tokio::spawn(driver);
 		let consumer = origin.consume();
 
 		let peer = cluster::Peer {
@@ -1925,7 +1927,7 @@ mod tests {
 	/// back to ourselves. Hop ID 0 identifies nothing, so it is never a loop.
 	#[test]
 	fn cluster_advert_loop_is_discarded() {
-		let (subscriber, _origin) = cluster_subscriber(crate::Origin::new(5).unwrap());
+		let (subscriber, _origin, _driver) = cluster_subscriber(crate::Origin::new(5).unwrap());
 		let peer = cluster::Peer {
 			origin: Some(crate::Origin::new(9).unwrap()),
 			cost: None,
@@ -1948,7 +1950,7 @@ mod tests {
 	/// hop count and degenerates to shortest-path routing.
 	#[test]
 	fn unpriced_link_costs_one() {
-		let (subscriber, _origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (subscriber, _origin, _driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
 		let peer = cluster::Peer {
 			origin: Some(crate::Origin::new(9).unwrap()),
 			cost: None,
@@ -1979,7 +1981,7 @@ mod tests {
 	async fn a_lost_namespace_stream_closes_the_broadcast() {
 		const VERSION: Version = Version::Draft18;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 
 		// The peer answers, advertises one namespace, then the stream ends without ever
@@ -2021,7 +2023,8 @@ mod tests {
 	/// said the namespace is gone, so a later create at the path is new content.
 	#[tokio::test(start_paused = true)]
 	async fn an_explicit_namespace_done_closes_the_broadcast() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin, driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		tokio::spawn(driver);
 		let consumer = origin.consume();
 
 		let path = crate::Path::new("room/host").to_owned();
@@ -2056,7 +2059,7 @@ mod tests {
 			.unwrap();
 		let script = log.writes.lock().unwrap().clone();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 		let session = crate::lite::test_transport::ScriptedSession::eof(script);
 		let (tasks, task_set) = crate::util::TaskSet::new();
@@ -2102,7 +2105,7 @@ mod tests {
 	async fn a_broken_publish_namespace_stream_closes_the_broadcast() {
 		const VERSION: Version = Version::Draft19;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 
 		// The peer sends something that does not belong on this stream, ending it with an
@@ -2157,7 +2160,8 @@ mod tests {
 	/// what the origin sees.
 	#[tokio::test(start_paused = true)]
 	async fn the_last_owner_out_decides_the_detach() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin, driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		tokio::spawn(driver);
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer::default();
@@ -2190,7 +2194,7 @@ mod tests {
 	/// advertise a paid upstream as the cheapest route in the mesh.
 	#[test]
 	fn a_pathless_advert_still_pays_for_its_link() {
-		let (unpriced, _origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (unpriced, _origin, _driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
 		let peer = cluster::Peer::default();
 
 		// Nothing priced this direction, so it ranks by hop count.
@@ -2204,7 +2208,7 @@ mod tests {
 		assert_eq!(unpriced.route(None, &priced_peer).unwrap().route.cost, 4);
 
 		// Local policy still wins over what the peer declared.
-		let (mut priced, _origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut priced, _origin, _priced_driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
 		priced.cost = Some(6);
 		assert_eq!(priced.route(None, &priced_peer).unwrap().route.cost, 6);
 	}
@@ -2214,7 +2218,8 @@ mod tests {
 	/// it, since that content is not interchangeable.
 	#[tokio::test]
 	async fn cluster_update_replaces_in_place() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin, driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		tokio::spawn(driver);
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 
@@ -2260,7 +2265,8 @@ mod tests {
 	/// still reference the path.
 	#[tokio::test]
 	async fn cluster_publisher_change_replaces_the_source() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin, driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		tokio::spawn(driver);
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 
@@ -2303,7 +2309,8 @@ mod tests {
 	/// as a subscriber is resolving a track through it.
 	#[tokio::test]
 	async fn pathless_adverts_never_replace_the_source() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin, driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		tokio::spawn(driver);
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer::default();
@@ -2338,7 +2345,8 @@ mod tests {
 	#[tokio::test]
 	async fn reflected_replacement_retracts_the_route() {
 		let self_origin = crate::Origin::new(5).unwrap();
-		let (mut subscriber, origin) = cluster_subscriber(self_origin);
+		let (mut subscriber, origin, driver) = cluster_subscriber(self_origin);
+		tokio::spawn(driver);
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer {
@@ -2417,7 +2425,7 @@ mod tests {
 		const VERSION: Version = Version::Draft19;
 		let script = publish_namespace_updates(request_id, "room/host", updates).await;
 		let session = crate::lite::test_transport::ScriptedSession::new(script);
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(self_origin));
 		let consumer = origin.consume();
 		let (tasks, task_set) = crate::util::TaskSet::new();
 		// The tests drive the loop directly, so nothing spawns; leaking keeps the
@@ -2565,7 +2573,8 @@ mod tests {
 	/// session keeps running).
 	#[tokio::test]
 	async fn namespace_stream_close_releases_live_paths() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin, driver) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		tokio::spawn(driver);
 		let consumer = origin.consume();
 		let peer = cluster::Peer::default();
 
@@ -2598,7 +2607,7 @@ mod tests {
 		// An open gate, so the rejection actually reaches the wire.
 		let gate = kio::Producer::new(true);
 		let session = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 		let (tasks, task_set) = crate::util::TaskSet::new();
 		std::mem::forget(task_set);

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -49,12 +49,13 @@
 //! ## Async
 //! This library is async-first. [`Client::connect`] and [`Server::accept`] return a
 //! `(Session, Driver)` pair: the [`Session`] is the handle, and the [`Driver`] is
-//! the future that runs all of its protocol work. Nothing is spawned behind your
-//! back: spawn the driver on your executor, await it in place, or step
-//! [`Driver::poll`] with a [`kio::Waiter`] from your own `poll_*` function. The
-//! driver holds no session handle, so the transport still closes when the last
-//! [`Session`] clone drops (or on [`Session::abort`]), which in turn finishes the
-//! driver.
+//! the future that runs all of its protocol work. Origins follow the same shape:
+//! [`origin::Producer::new`] returns an [`origin::Producer`] and
+//! [`origin::Driver`]. Nothing is spawned behind your back: spawn each driver on
+//! your executor, await it in place, or step its `poll` method with a
+//! [`kio::Waiter`] from your own `poll_*` function. Drivers hold no corresponding
+//! producer or session handle, so they finish after the handles and submitted
+//! work drain.
 //!
 //! The crate has no direct tokio dependency: every future is built on [`kio`]
 //! (plain [`std::task::Waker`] plumbing) and `futures`, so any executor can poll
@@ -64,10 +65,10 @@
 //! The one remaining runtime tie is time. Timers go through `web_async::time`,
 //! which is backed by tokio's time driver on native (and `wasmtimer` in the
 //! browser), and those timers panic when polled outside a tokio runtime. So on
-//! native you still need a tokio runtime to poll a [`Driver`] (bandwidth sampling,
-//! the control stream timeout, and subscription linger all sleep); purely
-//! model-layer methods (tracks, groups, frames, origins) never touch a timer and
-//! run on any executor.
+//! native you still need a tokio runtime with time enabled to poll work that uses
+//! a timer (bandwidth sampling, control stream timeouts, and subscription linger).
+//! Synchronous model-layer operations can run without an executor, but lifecycle
+//! progress still requires the relevant driver to be polled.
 
 #![warn(missing_docs)]
 // The browser transport is `!Send`, so on wasm the shared state behind these `Arc`s is

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1888,7 +1888,7 @@ mod announce_test {
 	/// against it, optionally with a viewer already attached (so the initial
 	/// announce goes out warm, at cost zero).
 	async fn harness(demand: bool) -> (Harness, Option<track::Consumer>) {
-		let origin = Origin::new(1).unwrap().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::new(1).unwrap()));
 		let source = origin
 			.create_broadcast(
 				"cam",
@@ -2132,7 +2132,7 @@ mod announce_test {
 	#[tokio::test(start_paused = true)]
 	async fn excluded_peer_receives_the_standby() {
 		let peer = Origin::new(33).unwrap();
-		let origin = Origin::new(1).unwrap().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::new(1).unwrap()));
 
 		// Active: free, but its chain flows through the peer. Standby: the same
 		// publisher reached directly, at its cold cost.
@@ -2196,7 +2196,7 @@ mod announce_test {
 	#[tokio::test(start_paused = true)]
 	async fn standby_attach_announces_to_excluded_peer() {
 		let peer = Origin::new(33).unwrap();
-		let origin = Origin::new(1).unwrap().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::new(1).unwrap()));
 
 		// The active route: the broadcast as carried via the peer itself.
 		let via_peer = OriginList::try_from(vec![Origin::new(9).unwrap(), peer]).unwrap();
@@ -2247,7 +2247,7 @@ mod announce_test {
 	#[tokio::test(start_paused = true)]
 	async fn retracts_when_route_swings_through_peer() {
 		let peer = Origin::new(33).unwrap();
-		let origin = Origin::new(1).unwrap().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::new(1).unwrap()));
 		let mut source = origin
 			.create_broadcast(
 				"cam",
@@ -3264,7 +3264,7 @@ mod tests {
 		let assigned = crate::Origin::new(777).unwrap();
 		let clean_publisher = crate::Origin::new(778).unwrap();
 		let self_origin = crate::Origin::new(1).unwrap();
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(self_origin));
 
 		let mut tainted_hops = OriginList::new();
 		tainted_hops.push(assigned).unwrap();

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1327,7 +1327,7 @@ mod tests {
 		let gate = kio::Producer::new(false);
 		let session = SinkSession::gated_bi(gate.consume());
 
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(origin::Info::new(crate::Origin::new(1).unwrap()));
 		let subscriber = Subscriber::new(SubscriberConfig {
 			session: session.clone(),
 			origin,
@@ -1399,7 +1399,7 @@ mod tests {
 			// what was true at the instant it would.
 			let gate = kio::Producer::new(true);
 			let session = SinkSession::gated_bi(gate.consume());
-			let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+			let origin = crate::origin::spawn_test(origin::Info::new(crate::Origin::new(1).unwrap()));
 			let subscriber = Subscriber::new(SubscriberConfig {
 				session: session.clone(),
 				origin,
@@ -1823,7 +1823,7 @@ mod tests {
 		let session = SinkSession::new(Default::default());
 		let assigned = crate::Origin::new(777).unwrap();
 
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session,
@@ -1885,7 +1885,7 @@ mod tests {
 	}
 
 	fn restart_subscriber(session: SinkSession) -> (Subscriber<SinkSession>, crate::origin::Consumer) {
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 		let subscriber = Subscriber::new(SubscriberConfig {
 			session,
@@ -1991,7 +1991,7 @@ mod tests {
 	/// to the session (outliving the stream) would leak the announcement instead.
 	#[tokio::test(start_paused = true)]
 	async fn a_lost_announce_stream_closes_the_broadcast() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(crate::Origin::new(1).unwrap()));
 		let consumer = origin.consume();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session: SinkSession::new(Default::default()),

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -33,7 +33,9 @@ pub use time::*;
 
 /// Publishing and consuming the set of broadcasts routed through an origin.
 pub mod origin {
-	pub use super::origin_impl::{Consumer, Dynamic, Info, Producer, Request, Requesting};
+	#[cfg(test)]
+	pub(crate) use super::origin_impl::spawn_test;
+	pub use super::origin_impl::{Consumer, Driver, Dynamic, Info, Producer, Request, Requesting};
 }
 
 /// Subscribing to broadcast (un)announcements from an origin.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1,12 +1,17 @@
-use crate::{broadcast, cache, stats, track};
+use crate::{
+	broadcast, cache, stats, track,
+	util::{TaskSet, Tasks},
+};
 use kio::Pollable;
 use std::{
 	cmp::Reverse,
 	collections::{BTreeMap, HashMap, HashSet},
 	fmt,
+	future::Future,
+	pin::Pin,
 	sync::Arc,
 	sync::atomic::{AtomicU64, Ordering},
-	task::{Poll, ready},
+	task::{Context, Poll, ready},
 	time::Duration,
 };
 
@@ -78,12 +83,6 @@ impl Origin {
 	pub fn id(self) -> u64 {
 		self.id
 	}
-
-	/// Consume this [Origin] to create a producer that carries its id, with an
-	/// unbounded cache pool. Use [`Info::produce`] to configure the pool.
-	pub fn produce(self) -> Producer {
-		Info::new(self).produce()
-	}
 }
 
 /// An origin's identity plus the cache pool its broadcasts inherit.
@@ -92,8 +91,7 @@ impl Origin {
 /// parent handle every broadcast carries ([`broadcast::Info::origin`]): the origin owns
 /// the [`cache::Pool`] every group in the tree charges into, so a relay configures one
 /// bounded pool here and every broadcast, track, and group beneath it reaches that single
-/// budget by walking up the ownership chain. Defaults to an unbounded pool
-/// ([`Origin::produce`] is the shorthand for that). Cheap to clone (a `Copy` id plus an
+/// budget by walking up the ownership chain. Defaults to an unbounded pool. Cheap to clone (a `Copy` id plus an
 /// `Arc`-handle bump), so it's stored by value rather than behind another `Arc`.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -166,11 +164,6 @@ impl Info {
 	pub fn with_latency_default(mut self, latency_default: Duration) -> Self {
 		self.latency_default = latency_default;
 		self
-	}
-
-	/// Consume this config to create an origin [`Producer`].
-	pub fn produce(self) -> Producer {
-		Producer::new(self)
 	}
 }
 
@@ -459,6 +452,7 @@ enum PendingUpdate {
 #[derive(Default)]
 struct OriginConsumerState {
 	pending: BTreeMap<PathOwned, PendingUpdate>,
+	closed: bool,
 }
 
 impl OriginConsumerState {
@@ -779,6 +773,30 @@ impl OriginNode {
 		}
 	}
 
+	/// Tear down this subtree and close every announcement cursor registered here.
+	fn close(&mut self) {
+		for nested in self.nested.values() {
+			nested.lock().close();
+		}
+
+		if let Some(existing) = self.broadcast.take() {
+			if let Ok(mut state) = existing.state.write() {
+				state.closed = true;
+			}
+			existing.broadcast.abort_spliced(Error::Dropped);
+			if existing.announced {
+				self.notify.lock().unannounce(&existing.path);
+			}
+			let _ = existing.broadcast.abort(Error::Dropped);
+		}
+
+		for consumer in self.notify.lock().consumers.values() {
+			if let Ok(mut state) = consumer.state.write() {
+				state.closed = true;
+			}
+		}
+	}
+
 	/// Remove the broadcast at `relative` if it is `expect`, unannouncing it if
 	/// needed and pruning empty nodes on the way back up. The identity check
 	/// keeps a stale teardown from clobbering a replacement.
@@ -816,6 +834,12 @@ struct OriginNodes {
 }
 
 impl OriginNodes {
+	fn close(&self) {
+		for (_, node) in &self.nodes {
+			node.lock().close();
+		}
+	}
+
 	// Returns nested roots that match the prefixes.
 	// PathPrefixes guarantees no duplicates or overlapping prefixes.
 	pub fn select(&self, prefixes: &PathPrefixes) -> Option<Self> {
@@ -938,6 +962,9 @@ pub struct Producer {
 	// [`Info::latency_default`]).
 	latency_default: Duration,
 
+	// Submission handle for every lifecycle task owned by the origin driver.
+	tasks: Tasks,
+
 	// Ingress stats context. Broadcasts created through this producer are attributed
 	// to it (writes counted on the subscriber/ingress side). Empty (no-op) unless a
 	// session tagged this handle via [`Self::with_stats`].
@@ -952,21 +979,109 @@ impl std::ops::Deref for Producer {
 	}
 }
 
+/// Drives an origin's source watchers, fronts, and track-serving tasks.
+///
+/// Poll this future for as long as any associated [`Producer`] is in use. The
+/// origin performs only the initial attachment synchronously; route changes,
+/// serving, failover, timers, and teardown require this driver to be polled.
+/// The driver holds no producer clone and finishes after all producers and
+/// submitted lifecycle work drain.
+///
+/// Dropping the driver cancels its work and immediately tears down the origin
+/// with [`Error::Dropped`]. Existing announcement cursors receive unannounces
+/// and then close, pending dynamic requests are rejected, and later producer
+/// mutations fail with [`Error::Closed`].
+#[must_use = "an origin makes lifecycle progress only while its driver is polled"]
+pub struct Driver {
+	set: TaskSet,
+	nodes: OriginNodes,
+	dynamic: kio::Shared<OriginDynamicState>,
+	park: kio::Park,
+	done: bool,
+}
+
+impl Driver {
+	/// Poll the origin lifecycle once.
+	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		if self.done {
+			return Poll::Ready(());
+		}
+		if self.set.poll(waiter).is_ready() {
+			self.done = true;
+			return Poll::Ready(());
+		}
+		Poll::Pending
+	}
+}
+
+impl Future for Driver {
+	type Output = ();
+
+	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		let this = &mut *self;
+		let waiter = this.park.hold(cx);
+		if this.done {
+			return Poll::Ready(());
+		}
+		if this.set.poll(waiter).is_ready() {
+			this.done = true;
+			return Poll::Ready(());
+		}
+		Poll::Pending
+	}
+}
+
+impl Drop for Driver {
+	fn drop(&mut self) {
+		let pending = {
+			let mut dynamic = self.dynamic.lock();
+			if dynamic.closed {
+				return;
+			}
+			dynamic.closed = true;
+			dynamic.requests.drain()
+		};
+
+		for producer in pending {
+			if let Ok(mut pending) = producer.write()
+				&& pending.resolved.is_none()
+			{
+				pending.resolved = Some(Err(Error::Dropped));
+			}
+		}
+		self.nodes.close();
+	}
+}
+
 impl Producer {
-	/// Build a producer from an [`Info`] (identity + cache pool) with no scoped
-	/// prefix and no pre-existing broadcasts. Prefer [`Info::produce`] /
-	/// [`Origin::produce`].
-	pub fn new(info: Info) -> Self {
-		Self {
+	/// Build an empty origin and the driver that owns its lifecycle work.
+	///
+	/// The caller must retain and poll the returned [`Driver`] for the lifetime of
+	/// the producer. Native Tokio applications may use
+	/// `moq_native::origin::spawn` as a convenience.
+	pub fn new(info: Info) -> (Self, Driver) {
+		let (tasks, set) = TaskSet::new();
+		let nodes = OriginNodes::default();
+		let dynamic = kio::Shared::default();
+		let producer = Self {
 			info: info.id,
-			nodes: OriginNodes::default(),
+			nodes: nodes.clone(),
 			root: PathOwned::default(),
-			dynamic: kio::Shared::default(),
+			dynamic: dynamic.clone(),
 			pool: info.pool,
 			cache_duration: info.cache_duration,
 			latency_default: info.latency_default,
+			tasks,
 			stats: stats::Session::default(),
-		}
+		};
+		let driver = Driver {
+			set,
+			nodes,
+			dynamic,
+			park: kio::Park::default(),
+			done: false,
+		};
+		(producer, driver)
 	}
 
 	/// Attach an ingress stats context: broadcasts created through this handle (and
@@ -999,6 +1114,8 @@ impl Producer {
 	/// subscriber issues no ANNOUNCE_PLEASE). Used to fill an unset session half
 	/// so both the publisher and subscriber loops still run.
 	pub(crate) fn empty(info: Origin) -> Self {
+		let (tasks, set) = TaskSet::new();
+		drop(set);
 		Self {
 			info,
 			nodes: OriginNodes { nodes: Vec::new() },
@@ -1007,6 +1124,7 @@ impl Producer {
 			pool: cache::Pool::default(),
 			cache_duration: Duration::MAX,
 			latency_default: track::DEFAULT_LATENCY_MAX,
+			tasks,
 			stats: stats::Session::default(),
 		}
 	}
@@ -1041,10 +1159,12 @@ impl Producer {
 	/// subscribes and fetches (e.g. serving cached or on-demand content), so
 	/// toggling `live` announces or unannounces without touching the broadcast.
 	///
-	/// The broadcast becomes visible to consumers asynchronously, shortly after
-	/// this returns. Create tracks and register a
-	/// [`broadcast::Producer::dynamic`] handler before awaiting, so the first
-	/// consumer finds them.
+	/// Eligible initial attachment, exact-path visibility, and announcement
+	/// updates happen before this returns. Track serving and every later lifecycle
+	/// transition require the origin's [`Driver`] to be polled. This immediate
+	/// visibility means callers should create tracks or install a dynamic handler
+	/// before exposing the origin to untrusted consumers when readiness must be
+	/// atomic.
 	///
 	/// End the broadcast with [`broadcast::Producer::finish`]; dropping it
 	/// without finishing also works, but logs a warning. Either way the path
@@ -1055,13 +1175,16 @@ impl Producer {
 	/// Fails with [`Error::Unauthorized`] if `path` is outside the prefixes this
 	/// producer may publish under (after [`scope`](Self::scope) /
 	/// [`with_root`](Self::with_root)), or [`Error::BoundsExceeded`] if the full
-	/// rooted path exceeds [`Path::MAX_PARTS`]. Must be called with a runtime
-	/// available (it spawns the broadcast's lifecycle task). Callers must not use
-	/// a route whose hop chain contains this origin's id (it would form a routing
-	/// loop); relays filter such reflections before they reach here, checked by a
-	/// `debug_assert`.
+	/// rooted path exceeds [`Path::MAX_PARTS`], or [`Error::Closed`] if the driver
+	/// was dropped. Callers must not use a route whose hop chain contains this
+	/// origin's id (it would form a routing loop); relays filter such reflections
+	/// before they reach here, checked by a `debug_assert`.
 	pub fn create_broadcast(&self, path: impl AsPath, route: broadcast::Route) -> Result<broadcast::Producer, Error> {
 		let path = path.as_path();
+		let lifecycle = self.dynamic.lock();
+		if lifecycle.closed {
+			return Err(Error::Closed);
+		}
 
 		debug_assert!(
 			!route.hops.contains(&self.info),
@@ -1090,8 +1213,38 @@ impl Producer {
 		.produce()
 		.with_stats(ingress.clone());
 		source.set_route(route).expect("fresh producer");
+		let mut consumer = source.consume();
+		let Poll::Ready(Ok(route)) = consumer.poll_route_changed(&kio::Waiter::noop()) else {
+			unreachable!("a fresh source exposes its initial route synchronously")
+		};
 
-		web_async::spawn(run_source(self.info(), node, full, rest, source.consume(), ingress));
+		let leaf = if rest.is_empty() {
+			node.clone()
+		} else {
+			node.lock().leaf(&rest)
+		};
+		let info = self.info();
+		let ctx = AttachContext {
+			origin: &info,
+			node: &node,
+			full: &full,
+			rest: &rest,
+		};
+		let initial = attach_source(&ctx, &leaf, &consumer, route.clone(), true, &self.tasks);
+		let announce = route.announce.then(|| ingress.announce());
+		self.tasks.push(run_source(SourceTask {
+			info,
+			node,
+			full,
+			rest,
+			source: consumer,
+			ingress,
+			route,
+			announce,
+			initial,
+			tasks: self.tasks.clone(),
+		}));
+		drop(lifecycle);
 
 		Ok(source)
 	}
@@ -1111,6 +1264,7 @@ impl Producer {
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
 			latency_default: self.latency_default,
+			tasks: self.tasks.clone(),
 			stats: self.stats.clone(),
 		})
 	}
@@ -1149,7 +1303,7 @@ impl Producer {
 	/// [`AnnounceProducer::consume`] to get an [`AnnounceConsumer`] that
 	/// receives announce / unannounce events.
 	pub fn announces(&self) -> AnnounceProducer {
-		AnnounceProducer::new(self.root.clone(), self.nodes.clone())
+		AnnounceProducer::new(self.root.clone(), self.nodes.clone(), self.dynamic.clone())
 	}
 
 	/// Returns a new Producer that automatically strips out the provided prefix.
@@ -1167,6 +1321,7 @@ impl Producer {
 			pool: self.pool.clone(),
 			cache_duration: self.cache_duration,
 			latency_default: self.latency_default,
+			tasks: self.tasks.clone(),
 			stats: self.stats.clone(),
 		})
 	}
@@ -1186,6 +1341,13 @@ impl Producer {
 	pub fn absolute(&self, path: impl AsPath) -> Path<'_> {
 		self.root.join(path)
 	}
+}
+
+#[cfg(test)]
+pub(crate) fn spawn_test(info: Info) -> Producer {
+	let (producer, driver) = Producer::new(info);
+	tokio::spawn(driver);
+	producer
 }
 
 /// How long a spliced track stays warm after its last reader leaves.
@@ -1477,49 +1639,59 @@ fn sync_announce(guard: &mut Option<stats::Announce>, announced: bool, ingress: 
 	}
 }
 
-/// Owns one source's lifecycle: attaches it to the front at its path on the first
-/// route observation, forwards route updates, and detaches it when the source
-/// closes. Spawned by [`Producer::create_broadcast`].
+/// Owns one source's lifecycle after its synchronous initial attachment,
+/// forwarding route updates and detaching it when the source closes. Driven by
+/// the origin's [`Driver`].
 ///
 /// An announced source whose original publisher (first hop) differs from the
 /// live front's takes the path over as a fresh broadcast rather than joining; an
 /// offline one parks until the front closes. A route update that changes the
 /// source's own first hop likewise detaches it and re-runs the attach, so a
 /// publisher swap is always a replacement, never a silent splice.
-async fn run_source(
-	origin: Info,
+struct SourceTask {
+	info: Info,
 	node: Lock<OriginNode>,
 	full: PathOwned,
 	rest: PathOwned,
-	mut source: broadcast::Consumer,
+	source: broadcast::Consumer,
 	ingress: stats::Scope,
-) {
+	route: broadcast::Route,
+	announce: Option<stats::Announce>,
+	initial: Attach,
+	tasks: Tasks,
+}
+
+async fn run_source(task: SourceTask) {
+	let SourceTask {
+		info,
+		node,
+		full,
+		rest,
+		mut source,
+		ingress,
+		mut route,
+		mut announce,
+		initial,
+		tasks,
+	} = task;
 	let ctx = AttachContext {
-		origin: &origin,
+		origin: &info,
 		node: &node,
 		full: &full,
 		rest: &rest,
-	};
-
-	// The first `route_changed` yields the current route immediately; nothing is
-	// visible to consumers until this attach, giving the creator a window to set
-	// up tracks and dynamic handlers.
-	let Ok(mut route) = source.route_changed().await else {
-		// Closed before ever attaching; nothing became visible.
-		return;
 	};
 
 	// Ingress announce guard: held while this source's route is announced. Opening
 	// bumps `announced` + `announced_bytes`; dropping (route offline, or the source
 	// closing below) bumps `announced_closed` + `announced_bytes`. Empty scope =
 	// no-op.
-	let mut announce = route.announce.then(|| ingress.announce());
 	// Whether this source still has content the live front has not already beaten.
 	// Cleared when a rival displaces it, so it stands by instead of evicting the
 	// winner straight back; only a new publisher re-arms it, since a repricing is
 	// the same content losing the same argument twice. Whether the route is
 	// announced is a separate gate, owned by `attach_source`.
 	let mut may_take_over = true;
+	let mut initial = Some(initial);
 
 	'attach: loop {
 		// Re-resolved every attempt: between attaches the previous front's
@@ -1532,7 +1704,10 @@ async fn run_source(
 			node.lock().leaf(&rest)
 		};
 
-		let (state, broadcast, id) = match attach_source(&ctx, &leaf, &source, route.clone(), may_take_over) {
+		let attached = initial
+			.take()
+			.unwrap_or_else(|| attach_source(&ctx, &leaf, &source, route.clone(), may_take_over, &tasks));
+		let (state, broadcast, id) = match attached {
 			Attach::Ready(state, broadcast, id) => (state, broadcast, id),
 			Attach::Parked(incumbent) => {
 				tracing::debug!(
@@ -1718,6 +1893,7 @@ fn attach_source(
 	source: &broadcast::Consumer,
 	route: broadcast::Route,
 	may_take_over: bool,
+	tasks: &Tasks,
 ) -> Attach {
 	let publisher = route.hops.iter().next().copied();
 	let mut leaf_guard = leaf.lock();
@@ -1730,7 +1906,13 @@ fn attach_source(
 		if let Ok(mut s) = existing.state.write()
 			&& !s.closed
 		{
-			if same_publisher(s.publisher, publisher) {
+			// A source can close before its driver-owned watcher detaches it. Do not
+			// splice a synchronous republish into a front whose every source is already
+			// terminal; make the new source a replacement and leave teardown to the
+			// driver.
+			if s.routes.iter().all(|route| route.source.is_closing()) {
+				s.closed = true;
+			} else if same_publisher(s.publisher, publisher) {
 				let id = s.next_route;
 				s.next_route += 1;
 				s.routes.push(FrontRoute {
@@ -1808,11 +1990,12 @@ fn attach_source(
 	leaf_guard.broadcast = Some(entry);
 	drop(leaf_guard);
 
-	web_async::spawn(run_front(
+	tasks.push(run_front(
 		state.clone(),
 		broadcast.clone(),
 		ctx.node.clone(),
 		ctx.rest.clone(),
+		tasks.clone(),
 	));
 
 	Attach::Ready(state, broadcast, 0)
@@ -1825,6 +2008,7 @@ async fn run_front(
 	mut broadcast: broadcast::Producer,
 	node: Lock<OriginNode>,
 	rest: PathOwned,
+	tasks: Tasks,
 ) {
 	enum Step {
 		Serve(Arc<str>, super::resume::Producer),
@@ -1851,7 +2035,7 @@ async fn run_front(
 			Step::Serve(name, resume) => {
 				// Serve tasks self-terminate when the track completes or the
 				// front closes.
-				web_async::spawn(serve_track(state.clone(), name, resume));
+				tasks.push(serve_track(state.clone(), name, resume));
 			}
 			Step::Closed => break,
 		}
@@ -2175,6 +2359,9 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 /// drain under one lock. Mirrors the fetch state of the track model.
 #[derive(Default)]
 struct OriginDynamicState {
+	// Set by Driver::drop before the origin tree is torn down.
+	closed: bool,
+
 	// Result channels for pending requests, keyed by absolute path so concurrent
 	// `request_broadcast` calls for the same path coalesce onto one channel.
 	requests: Requests<PathOwned, kio::Producer<PendingBroadcast>>,
@@ -2244,12 +2431,15 @@ impl Dynamic {
 	/// Poll for the next requested broadcast, without blocking.
 	pub fn poll_requested_broadcast(&mut self, waiter: &kio::Waiter) -> Poll<Result<Request, Error>> {
 		let mut state = ready!(self.state.poll(waiter, |state| {
-			if state.requests.has_queued() {
+			if state.closed || state.requests.has_queued() {
 				Poll::Ready(())
 			} else {
 				Poll::Pending
 			}
 		}));
+		if state.closed {
+			return Poll::Ready(Err(Error::Dropped));
+		}
 
 		let path = state.requests.pop().expect("predicate guaranteed a request");
 		// The popped request stays pending, so a repeat request in the window between
@@ -2330,6 +2520,9 @@ impl Request {
 		// than replace a good entry with a duplicate subscription.
 		let resolved = {
 			let mut state = self.state.lock();
+			if state.closed {
+				return;
+			}
 			let existing = state.served.insert(self.path.clone(), broadcast.weak());
 			state
 				.requests
@@ -2337,7 +2530,9 @@ impl Request {
 			existing.map(|weak| weak.consume()).unwrap_or(broadcast)
 		};
 
-		if let Ok(mut pending) = self.producer.write() {
+		if let Ok(mut pending) = self.producer.write()
+			&& pending.resolved.is_none()
+		{
 			pending.resolved = Some(Ok(resolved));
 		}
 		// `self.producer` drops here, closing the channel; the value is still observable.
@@ -2345,11 +2540,17 @@ impl Request {
 
 	/// Reject the request, resolving every awaiting requester with `err`.
 	pub fn reject(self, err: Error) {
-		self.state
-			.lock()
+		let mut origin = self.state.lock();
+		if origin.closed {
+			return;
+		}
+		origin
 			.requests
 			.remove_if(&self.path, |producer| producer.same_channel(&self.producer));
-		if let Ok(mut state) = self.producer.write() {
+		drop(origin);
+		if let Ok(mut state) = self.producer.write()
+			&& state.resolved.is_none()
+		{
 			state.resolved = Some(Err(err));
 		}
 	}
@@ -2629,7 +2830,14 @@ impl Consumer {
 	/// set as initial announcements. Drop the returned [`AnnounceConsumer`]
 	/// to unregister.
 	pub fn announced(&self) -> AnnounceConsumer {
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), self.stats.clone(), self.exclude)
+		let lifecycle = self.dynamic.lock();
+		AnnounceConsumer::new(
+			self.root.clone(),
+			self.nodes.clone(),
+			self.stats.clone(),
+			self.exclude,
+			!lifecycle.closed,
+		)
 	}
 
 	/// Returns a cheap duplicate of this read handle.
@@ -2742,6 +2950,9 @@ impl Consumer {
 	/// broadcast, a dynamically served one is never visible to [`Self::announced`].
 	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<Requesting> {
 		let path = path.as_path();
+		if self.dynamic.read().closed {
+			return kio::Pending::new(Requesting::failed(Error::Dropped));
+		}
 
 		// Key requests by absolute path so a scoped/rooted consumer and the handler
 		// (which may have a different root) agree on the same entry, and so the egress
@@ -2768,6 +2979,9 @@ impl Consumer {
 		}
 
 		let mut state = self.dynamic.lock();
+		if state.closed {
+			return kio::Pending::new(Requesting::failed(Error::Dropped));
+		}
 
 		// Reuse a still-live broadcast a handler already served for this path, so repeat
 		// requests share one upstream subscription. A closed entry is stale; `get` drops it
@@ -2835,11 +3049,12 @@ impl Consumer {
 pub struct AnnounceProducer {
 	nodes: OriginNodes,
 	root: PathOwned,
+	dynamic: kio::Shared<OriginDynamicState>,
 }
 
 impl AnnounceProducer {
-	fn new(root: PathOwned, nodes: OriginNodes) -> Self {
-		Self { nodes, root }
+	fn new(root: PathOwned, nodes: OriginNodes, dynamic: kio::Shared<OriginDynamicState>) -> Self {
+		Self { nodes, root, dynamic }
 	}
 
 	/// Subscribe to announce / unannounce events for this subtree.
@@ -2848,9 +3063,16 @@ impl AnnounceProducer {
 	/// as initial announcements. Drop the returned [`AnnounceConsumer`] to
 	/// unregister.
 	pub fn consume(&self) -> AnnounceConsumer {
+		let lifecycle = self.dynamic.lock();
 		// Untagged: `AnnounceProducer` is used for internal announce plumbing, not
 		// egress attribution (which flows through `origin::Consumer::announced`).
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), stats::Session::default(), None)
+		AnnounceConsumer::new(
+			self.root.clone(),
+			self.nodes.clone(),
+			stats::Session::default(),
+			None,
+			!lifecycle.closed,
+		)
 	}
 
 	/// Returns the prefix that is automatically stripped from announced paths.
@@ -2871,6 +3093,7 @@ pub struct AnnounceConsumer {
 	// Pending updates queued for this cursor. Coalesced so a slow consumer
 	// can't accumulate redundant announce/unannounce pairs.
 	state: kio::Producer<OriginConsumerState>,
+	registered: bool,
 
 	// Egress stats context (empty for an untagged stream). Announce events drive the
 	// per-broadcast announce guards below and tag the broadcasts handed out.
@@ -2883,17 +3106,27 @@ pub struct AnnounceConsumer {
 }
 
 impl AnnounceConsumer {
-	fn new(root: PathOwned, nodes: OriginNodes, stats: stats::Session, exclude: Option<Origin>) -> Self {
+	fn new(
+		root: PathOwned,
+		nodes: OriginNodes,
+		stats: stats::Session,
+		exclude: Option<Origin>,
+		register: bool,
+	) -> Self {
 		let state = kio::Producer::<OriginConsumerState>::default();
 		let id = ConsumerId::new();
 
-		for (_, node) in &nodes.nodes {
-			let notify = AnnounceConsumerNotify {
-				root: root.clone(),
-				state: state.clone(),
-				exclude,
-			};
-			node.lock().consume(id, notify);
+		if register {
+			for (_, node) in &nodes.nodes {
+				let notify = AnnounceConsumerNotify {
+					root: root.clone(),
+					state: state.clone(),
+					exclude,
+				};
+				node.lock().consume(id, notify);
+			}
+		} else {
+			state.write().ok().expect("announcement cursor closed").closed = true;
 		}
 
 		Self {
@@ -2901,6 +3134,7 @@ impl AnnounceConsumer {
 			nodes,
 			root,
 			state,
+			registered: register,
 			stats,
 			guards: HashMap::new(),
 		}
@@ -2951,7 +3185,7 @@ impl AnnounceConsumer {
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Option<OriginAnnounce>> {
 		let update = {
 			let mut state = match ready!(self.state.poll(waiter, |state| {
-				if state.pending.is_empty() {
+				if state.pending.is_empty() && !state.closed {
 					Poll::Pending
 				} else {
 					Poll::Ready(())
@@ -2961,7 +3195,14 @@ impl AnnounceConsumer {
 				// Closed: discard the Ref so its MutexGuard doesn't escape this call.
 				Err(_) => return Poll::Ready(None),
 			};
-			state.take().expect("predicate guaranteed an update")
+			match state.take() {
+				Some(update) => update,
+				None => {
+					debug_assert!(state.closed);
+					state.close();
+					return Poll::Ready(None);
+				}
+			}
 		};
 		Poll::Ready(Some(self.hand_out(update)))
 	}
@@ -2971,13 +3212,22 @@ impl AnnounceConsumer {
 	/// Returns None if there is no update available; NOT because the cursor is closed.
 	/// Use [`Self::is_closed`] to check if the cursor is closed.
 	pub fn try_next(&mut self) -> Option<OriginAnnounce> {
-		let update = self.state.write().ok()?.take()?;
+		let mut state = self.state.write().ok()?;
+		let update = match state.take() {
+			Some(update) => update,
+			None if state.closed => {
+				state.close();
+				return None;
+			}
+			None => return None,
+		};
+		drop(state);
 		Some(self.hand_out(update))
 	}
 
 	/// Returns true if the cursor is closed (no more updates will arrive).
 	pub fn is_closed(&self) -> bool {
-		self.state.write().is_err()
+		self.state.read().closed
 	}
 
 	/// Returns the prefix that is automatically stripped from emitted paths.
@@ -2993,6 +3243,9 @@ impl AnnounceConsumer {
 
 impl Drop for AnnounceConsumer {
 	fn drop(&mut self) {
+		if !self.registered {
+			return;
+		}
 		for (_, root) in &self.nodes.nodes {
 			root.lock().unconsume(self.id);
 		}
@@ -3073,6 +3326,132 @@ mod tests {
 	/// An announced direct route.
 	fn announce() -> broadcast::Route {
 		broadcast::Route::new().with_announce(true)
+	}
+
+	#[test]
+	fn initial_visibility_is_synchronous_without_driver_polling() {
+		let (origin, _driver) = Producer::new(Info::new(Origin::random()));
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let _source = origin.create_broadcast("test", announce()).unwrap();
+
+		assert!(consumer.get_broadcast("test").is_some(), "exact lookup is immediate");
+		assert!(
+			announced.try_next().unwrap().broadcast.is_some(),
+			"announce is immediate"
+		);
+	}
+
+	#[tokio::test]
+	async fn driver_gates_route_changes_and_nested_track_serving() {
+		let (origin, mut driver) = Producer::new(Info::new(Origin::random()));
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+		let mut source = origin.create_broadcast("test", announce()).unwrap();
+		let mut dynamic = source.dynamic();
+		let broadcast = announced.next().await.unwrap().broadcast.unwrap();
+
+		let _subscribing = broadcast.track("video").unwrap().subscribe(None);
+		assert!(dynamic.requested_track().now_or_never().is_none());
+
+		assert!(driver.poll(&kio::Waiter::noop()).is_pending());
+		assert!(
+			dynamic.requested_track().now_or_never().is_none(),
+			"the front may queue nested work, but that work needs another driver poll"
+		);
+		assert!(driver.poll(&kio::Waiter::noop()).is_pending());
+		assert!(dynamic.requested_track().now_or_never().is_some());
+
+		source.set_route(broadcast::Route::new()).unwrap();
+		assert!(
+			announced.next().now_or_never().is_none(),
+			"route updates wait for the driver"
+		);
+		assert!(driver.poll(&kio::Waiter::noop()).is_pending());
+		assert!(announced.next().now_or_never().unwrap().unwrap().broadcast.is_none());
+	}
+
+	#[test]
+	fn initial_attachment_is_not_repeated_by_the_driver() {
+		let (origin, mut driver) = Producer::new(Info::new(Origin::random()));
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+
+		let _first = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		assert!(announced.try_next().unwrap().broadcast.is_some());
+
+		let _parked = origin
+			.create_broadcast(
+				"test",
+				broadcast::Route::new().with_hops(OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap()),
+			)
+			.unwrap();
+
+		let (root, rest) = origin.nodes.get(Path::new("test")).unwrap();
+		let leaf = root.lock().leaf(&rest);
+		assert_eq!(leaf.lock().broadcast.as_ref().unwrap().state.read().routes.len(), 1);
+		assert!(driver.poll(&kio::Waiter::noop()).is_pending());
+		assert_eq!(leaf.lock().broadcast.as_ref().unwrap().state.read().routes.len(), 1);
+		assert!(announced.try_next().is_none(), "neither source announces twice");
+	}
+
+	#[test]
+	fn synchronous_republish_replaces_a_terminal_source() {
+		let (origin, _driver) = Producer::new(Info::new(Origin::random()));
+		let consumer = origin.consume();
+
+		let first = origin.create_broadcast("test", announce()).unwrap();
+		let old = consumer.get_broadcast("test").unwrap();
+		drop(first);
+
+		let _second = origin.create_broadcast("test", announce()).unwrap();
+		let new = consumer.get_broadcast("test").unwrap();
+		assert!(
+			!old.is_clone(&new),
+			"a closed source must not be joined before its watcher runs"
+		);
+	}
+
+	#[tokio::test]
+	async fn dropping_driver_aborts_and_closes_the_origin() {
+		let (origin, driver) = Producer::new(Info::new(Origin::random()));
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+		let source = origin.create_broadcast("test", announce()).unwrap();
+		let broadcast = announced.next().await.unwrap().broadcast.unwrap();
+		let _dynamic = origin.dynamic();
+		let pending = consumer.request_broadcast("missing");
+
+		drop(driver);
+
+		assert!(matches!(broadcast.closed().await, Error::Dropped));
+		assert!(matches!(pending.await, Err(Error::Dropped)));
+		assert!(
+			!announced.state.read().pending.is_empty(),
+			"driver drop queues an unannounce"
+		);
+		assert!(announced.next().await.unwrap().broadcast.is_none());
+		assert!(announced.next().await.is_none());
+		assert!(matches!(
+			origin.create_broadcast("later", announce()),
+			Err(Error::Closed)
+		));
+		drop(source);
+	}
+
+	#[tokio::test]
+	async fn driver_finishes_without_retaining_the_origin() {
+		let (origin, driver) = Producer::new(Info::new(Origin::random()));
+		let mut source = origin.create_broadcast("test", announce()).unwrap();
+		source.finish();
+		drop(origin);
+		tokio::time::timeout(Duration::from_secs(1), driver)
+			.await
+			.expect("submitted lifecycle work should drain");
 	}
 
 	/// The first origin whose handover key for `name` sits above (`true`) or below
@@ -3363,7 +3742,7 @@ mod tests {
 		let registry = Registry::new(Config::new());
 		let ctx = registry.tier(Tier::default()).session("acme");
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let ingress = origin.clone().with_stats(ctx.clone());
 		let egress = origin.consume().with_stats(ctx.clone());
 
@@ -3467,7 +3846,7 @@ mod tests {
 		let registry = Registry::new(Config::new());
 		let ctx = registry.tier(Tier::default()).session("acme");
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let ingress = origin.clone().with_stats(ctx.clone());
 		let egress = origin.consume().with_stats(ctx.clone());
 
@@ -3519,7 +3898,7 @@ mod tests {
 		let registry = Registry::new(Config::new());
 		let ctx = registry.tier(Tier::default()).session("acme");
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let ingress = origin.clone().with_stats(ctx.clone());
 		let egress = origin.consume().with_stats(ctx.clone());
 
@@ -3610,7 +3989,7 @@ mod tests {
 	async fn test_announce() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let mut consumer1 = origin.consume().announced();
 		consumer1.assert_next_wait();
@@ -3667,7 +4046,7 @@ mod tests {
 	async fn test_duplicate() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -3707,7 +4086,7 @@ mod tests {
 	async fn test_route_failover() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -3779,7 +4158,7 @@ mod tests {
 	async fn test_route_failover_restores_every_track() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		// Both routes share the first hop: interchangeable content.
@@ -3905,7 +4284,7 @@ mod tests {
 		// The takeover happens while a subscriber is live (carrying), so the local
 		// origin must win the handover key comparison against B's announcing hop
 		// (origin 3); a random id would flake on the hash.
-		let origin = Info::new(origin_keyed("test", Origin::new(3).unwrap(), true)).produce();
+		let origin = spawn_test(Info::new(origin_keyed("test", Origin::new(3).unwrap(), true)));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -3980,7 +4359,7 @@ mod tests {
 	async fn test_completed_track_survives_route_churn() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		// Shared first hop, so B is a standby rather than a parked replacement.
@@ -4026,7 +4405,7 @@ mod tests {
 	async fn test_refused_track_aborts_instantly() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
@@ -4054,7 +4433,7 @@ mod tests {
 	async fn test_stale_rejection_does_not_abort_a_handover() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let publisher = Origin::new(1).unwrap();
@@ -4098,7 +4477,7 @@ mod tests {
 	async fn test_route_handover() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4157,7 +4536,7 @@ mod tests {
 	/// unannounce propagates promptly and a re-create is a fresh broadcast.
 	#[tokio::test(start_paused = true)]
 	async fn test_route_unannounce_immediate() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4193,7 +4572,7 @@ mod tests {
 	/// it behind a stale route.
 	#[tokio::test(start_paused = true)]
 	async fn test_route_detach_immediate() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4240,7 +4619,7 @@ mod tests {
 	/// re-requesting the track (and its info) every linger.
 	#[tokio::test(start_paused = true)]
 	async fn test_idle_track_releases_without_respinning() {
-		let origin = Info::new(Origin::random()).produce();
+		let origin = spawn_test(Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
@@ -4304,7 +4683,7 @@ mod tests {
 	/// doesn't re-request the track, and its `TRACK_INFO`, for every group.
 	#[tokio::test(start_paused = true)]
 	async fn test_back_to_back_fetches_reuse_the_track() {
-		let origin = Info::new(Origin::random()).produce();
+		let origin = spawn_test(Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
@@ -4355,7 +4734,7 @@ mod tests {
 	async fn test_announce_toggle() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4403,7 +4782,7 @@ mod tests {
 	async fn test_announce_beats_offline() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4435,7 +4814,7 @@ mod tests {
 	async fn test_better_source_no_churn() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut announced = origin.consume().announced();
 
 		// `a` carries two hops; `b` reaches the same publisher in one, so `b`
@@ -4466,7 +4845,7 @@ mod tests {
 	async fn test_publisher_mismatch_replaces() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4509,7 +4888,7 @@ mod tests {
 	async fn test_displaced_publisher_reclaims_path_when_replacement_leaves() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4560,7 +4939,7 @@ mod tests {
 	async fn test_reclaimed_publisher_can_still_replace_itself() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
@@ -4611,7 +4990,7 @@ mod tests {
 	async fn test_repricing_does_not_earn_a_takeover() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4660,7 +5039,7 @@ mod tests {
 	async fn test_reconnect_wins_over_stale_route() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let publisher = Origin::new(1).unwrap();
@@ -4701,7 +5080,7 @@ mod tests {
 	async fn test_carrying_reconnect_switches_immediately() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
@@ -4747,7 +5126,7 @@ mod tests {
 	async fn test_offline_mismatch_never_evicts_a_live_front() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4804,7 +5183,7 @@ mod tests {
 	async fn test_dispatch_excludes_requester() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let peer = Origin::new(5).unwrap();
@@ -4852,7 +5231,7 @@ mod tests {
 	async fn test_unknown_publishers_do_not_splice() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4900,7 +5279,7 @@ mod tests {
 	async fn test_known_publishers_still_splice() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -4932,7 +5311,7 @@ mod tests {
 	async fn test_standby_join_splices_live_subscriber() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let publisher = Origin::new(1).unwrap();
@@ -4979,7 +5358,7 @@ mod tests {
 	async fn test_standby_with_a_partial_track_list_splits_per_track() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let publisher = Origin::new(1).unwrap();
@@ -5060,7 +5439,7 @@ mod tests {
 	async fn test_standby_missing_track_keeps_incumbent() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let publisher = Origin::new(1).unwrap();
@@ -5123,7 +5502,7 @@ mod tests {
 	async fn test_unservable_track_retried_by_a_later_request() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let source = origin.create_broadcast("test", announce()).unwrap();
@@ -5157,7 +5536,7 @@ mod tests {
 	async fn test_track_dying_without_progress_aborts() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
@@ -5196,7 +5575,7 @@ mod tests {
 	async fn test_delivered_copy_death_survives_unrelated_wakes() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
@@ -5241,7 +5620,7 @@ mod tests {
 	async fn test_per_track_fallback_respects_exclusion() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let publisher = Origin::new(1).unwrap();
@@ -5284,7 +5663,7 @@ mod tests {
 	async fn test_exclusion_survives_failover_onto_a_tainted_route() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let publisher = Origin::new(1).unwrap();
@@ -5327,7 +5706,7 @@ mod tests {
 	async fn test_exclusion_holds_when_a_tainted_route_attaches_later() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let publisher = Origin::new(1).unwrap();
@@ -5397,7 +5776,7 @@ mod tests {
 	async fn test_excluded_path_never_reaches_the_dynamic_handler() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut dynamic = origin.dynamic();
 
@@ -5432,7 +5811,7 @@ mod tests {
 	async fn test_dynamic_broadcast_named_by_the_requested_path() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 
 		// A standalone broadcast, with no origin and no path of its own.
@@ -5471,7 +5850,7 @@ mod tests {
 	async fn test_rooted_cursor_names_broadcasts_relatively() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let _source = origin.create_broadcast("a/pub", announce()).unwrap();
 		settle().await;
 		settle().await;
@@ -5497,7 +5876,7 @@ mod tests {
 	async fn test_dispatch_all_tainted_unroutable() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 
 		let peer = Origin::new(5).unwrap();
@@ -5521,7 +5900,7 @@ mod tests {
 	async fn test_duplicate_reverse() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let mut broadcast1 = origin.create_broadcast("test", announce()).unwrap();
 		let mut broadcast2 = origin.create_broadcast("test", announce()).unwrap();
@@ -5555,7 +5934,7 @@ mod tests {
 		// Resolve the advertised route for "test" after creating both sources in
 		// the given order.
 		async fn winner(first: &[u64], second: &[u64]) -> OriginList {
-			let origin = Origin::random().produce();
+			let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 			let _a = origin
 				.create_broadcast("test", announce().with_hops(hops(first)))
 				.unwrap();
@@ -5584,7 +5963,7 @@ mod tests {
 	// Names are zero-padded so lexicographic delivery order matches the loop index.
 	#[tokio::test]
 	async fn test_many_announces() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let mut consumer = origin.consume().announced();
 		// Held for the duration: a dropped source unannounces immediately.
@@ -5602,7 +5981,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_many_announces_try() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let mut consumer = origin.consume().announced();
 		// Held for the duration: a dropped source unannounces immediately.
@@ -5619,7 +5998,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_basic() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Create a producer with root "/foo"
 		let foo_producer = origin.with_root("foo").expect("should create root");
@@ -5642,7 +6021,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_nested() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Create nested roots
 		let foo_producer = origin.with_root("foo").expect("should create foo root");
@@ -5666,7 +6045,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_publish_scope_allows() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Create a producer that can only publish to "allowed" paths
 		let limited_producer = origin
@@ -5693,7 +6072,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_publish_max_parts() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let at_limit = (0..Path::MAX_PARTS)
 			.map(|i| i.to_string())
@@ -5714,7 +6093,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_publish_scope_empty() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Creating a producer with no allowed paths should return None
 		assert!(origin.scope(&[]).is_none());
@@ -5722,7 +6101,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_consume_scope_filters() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let mut consumer = origin.consume().announced();
 
@@ -5752,7 +6131,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_consume_scope_multiple_prefixes() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let _broadcast1 = origin.create_broadcast("foo/test", announce()).unwrap();
 		let _broadcast2 = origin.create_broadcast("bar/test", announce()).unwrap();
@@ -5774,7 +6153,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_and_publish_scope() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// User connects to /foo root
 		let foo_producer = origin.with_root("foo").expect("should create foo root");
@@ -5815,7 +6194,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_and_consume_scope() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Publish broadcasts
 		let _broadcast1 = origin.create_broadcast("foo/bar/test", announce()).unwrap();
@@ -5841,7 +6220,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_unauthorized() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// First limit the producer to specific paths
 		let limited_producer = origin
@@ -5860,7 +6239,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_wildcard_permission() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Producer with root access (empty string means wildcard)
 		let root_producer = origin.clone();
@@ -5881,7 +6260,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_consume_broadcast_with_permissions() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let _broadcast1 = origin.create_broadcast("allowed/test", announce()).unwrap();
 		let _broadcast2 = origin.create_broadcast("notallowed/test", announce()).unwrap();
@@ -5913,7 +6292,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_nested_paths_with_permissions() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Create producer limited to "a/b/c"
 		let limited_producer = origin.scope(&["a/b/c".into()]).expect("should create limited producer");
@@ -5938,7 +6317,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_multiple_consumers_with_different_permissions() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Publish to different paths
 		let _broadcast1 = origin.create_broadcast("foo/test", announce()).unwrap();
@@ -5979,7 +6358,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_with_empty_prefix() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// User with root "demo" allowed to subscribe to "worm-node" and "foobar"
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -6015,7 +6394,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_narrowing_scope() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// User with root "demo" allowed to subscribe to "worm-node" and "foobar"
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -6060,7 +6439,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_multiple_roots_with_empty_prefix() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Producer with multiple allowed roots
 		let limited_producer = origin
@@ -6095,7 +6474,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_publish_scope_with_empty_prefix() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Producer with specific allowed paths
 		let limited_producer = origin
@@ -6120,7 +6499,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_narrowing_to_deeper_path() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Producer with broad permission
 		let limited_producer = origin.scope(&["org".into()]).expect("should create limited producer");
@@ -6161,7 +6540,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_with_non_matching_prefix() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Producer with specific allowed paths
 		let limited_producer = origin
@@ -6179,7 +6558,7 @@ mod tests {
 	// with_root panics when String has trailing slash (AsPath for String skips normalization)
 	#[tokio::test]
 	async fn test_with_root_trailing_slash_consumer() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Use an owned String so the trailing slash is NOT normalized away.
 		let prefix = "some_prefix/".to_string();
@@ -6193,7 +6572,7 @@ mod tests {
 	// Same issue but for the producer side of with_root
 	#[tokio::test]
 	async fn test_with_root_trailing_slash_producer() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Use an owned String so the trailing slash is NOT normalized away.
 		let prefix = "some_prefix/".to_string();
@@ -6211,7 +6590,7 @@ mod tests {
 	async fn test_with_root_trailing_slash_unannounce() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let prefix = "some_prefix/".to_string();
 		let mut consumer = origin.consume().with_root(prefix).unwrap().announced();
@@ -6230,7 +6609,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_maintains_access_with_wider_prefix() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Setup: user with root "demo" allowed to subscribe to specific paths
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -6276,7 +6655,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_duplicate_prefixes_deduped() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// scope with duplicate prefixes should work (deduped internally)
 		let producer = origin
@@ -6295,7 +6674,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_overlapping_prefixes_deduped() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// "demo" and "demo/foo". "demo/foo" is redundant, only "demo" should remain
 		let producer = origin
@@ -6315,7 +6694,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_overlapping_prefixes_no_duplicate_announcements() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		// Both "demo" and "demo/foo" are requested. Should only have one node
 		let producer = origin
@@ -6335,7 +6714,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_allowed_returns_deduped_prefixes() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let producer = origin
 			.scope(&["demo".into(), "demo/foo".into(), "anon".into()])
@@ -6347,7 +6726,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_announced_broadcast_already_announced() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let _broadcast = origin.create_broadcast("test", announce()).unwrap();
 		settle().await;
@@ -6361,7 +6740,7 @@ mod tests {
 	async fn test_announced_broadcast_delayed() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let consumer = origin.consume();
 
@@ -6385,7 +6764,7 @@ mod tests {
 	async fn test_announced_broadcast_ignores_unrelated_paths() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let consumer = origin.consume();
 
@@ -6412,7 +6791,7 @@ mod tests {
 	async fn test_announced_broadcast_skips_nested_paths() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let consumer = origin.consume();
 
@@ -6437,7 +6816,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_announced_broadcast_disallowed() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let limited = origin
 			.consume()
 			.scope(&["allowed".into()])
@@ -6451,7 +6830,7 @@ mod tests {
 	async fn test_announced_broadcast_scope_too_narrow() {
 		// Consumer's scope is narrower than the requested path: asking for `foo` on a consumer
 		// limited to `foo/specific` can never resolve. Must return None, not loop forever.
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let limited = origin
 			.consume()
 			.scope(&["foo/specific".into()])
@@ -6473,7 +6852,7 @@ mod tests {
 		// announce + unannounce that the cursor hasn't observed yet collapses to nothing.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut announced = origin.consume().announced();
 
 		let mut broadcast = origin.create_broadcast("test", announce()).unwrap();
@@ -6491,7 +6870,7 @@ mod tests {
 		// to a single Announce of the latest broadcast.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut announced = origin.consume().announced();
 
 		let mut broadcast1 = origin.create_broadcast("test", announce()).unwrap();
@@ -6511,7 +6890,7 @@ mod tests {
 		// as two deliveries so the cursor learns the origin changed.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut broadcast1 = origin.create_broadcast("test", announce()).unwrap();
 		settle().await;
 
@@ -6537,7 +6916,7 @@ mod tests {
 		// embedded announce was never observed.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut broadcast1 = origin.create_broadcast("test", announce()).unwrap();
 		settle().await;
 
@@ -6564,7 +6943,7 @@ mod tests {
 		// require that churn doesn't accumulate across iterations.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut announced = origin.consume().announced();
 
 		for _ in 0..1000 {
@@ -6594,7 +6973,7 @@ mod tests {
 	// still receives the active backlog.
 	#[tokio::test]
 	async fn test_consumer_clone_is_side_effect_free() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 
 		let _broadcast1 = origin.create_broadcast("test1", announce()).unwrap();
 		let _broadcast2 = origin.create_broadcast("test2", announce()).unwrap();
@@ -6635,7 +7014,7 @@ mod tests {
 	// With no Dynamic handler, an unannounced path resolves to Unroutable.
 	#[tokio::test]
 	async fn dynamic_request_unroutable_without_handler() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		assert!(matches!(
 			consumer.request_broadcast("missing").await,
@@ -6647,7 +7026,7 @@ mod tests {
 	// never announced.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_not_announced() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6684,7 +7063,7 @@ mod tests {
 	// Concurrent requests for the same queued path coalesce onto one handler request.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6711,7 +7090,7 @@ mod tests {
 	// instead of asking the handler again (no duplicate upstream subscription).
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_dedups_served() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6736,7 +7115,7 @@ mod tests {
 	// Once a served broadcast closes, its cache entry is stale, so the next request re-serves.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_reserves_after_close() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6762,7 +7141,7 @@ mod tests {
 	// unboundedly: the amortized GC on `accept` reclaims the stale entries left by closed ones.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_cache_bounded() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6790,7 +7169,7 @@ mod tests {
 	// coalesces onto the in-flight request instead of queuing a duplicate.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces_after_handoff() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6815,7 +7194,7 @@ mod tests {
 	// Dropping a handed-off request without accept/reject rejects every coalesced requester.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_dropped_after_handoff() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6832,7 +7211,7 @@ mod tests {
 	// Rejecting a request resolves the requester with the error.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rejected() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6849,7 +7228,7 @@ mod tests {
 	// (a stale/clobbered entry would strand this request or panic the handler).
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rerequest_after_reject() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6870,7 +7249,7 @@ mod tests {
 	// resolving Unroutable.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_handler_dropped() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6890,7 +7269,7 @@ mod tests {
 	// count to zero. The in-flight request must not be rejected as `Unroutable`.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_accept_after_handler_dropped() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6909,7 +7288,7 @@ mod tests {
 	// A published broadcast wins over the dynamic fallback; no request is queued.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_prefers_announced() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6930,7 +7309,7 @@ mod tests {
 	// Cloning a handler and dropping the clone must not flip the count to zero.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_clone_keeps_alive() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -6981,7 +7360,7 @@ mod tests {
 	/// with nowhere else to go keeps being served by the draining route.
 	#[tokio::test(start_paused = true)]
 	async fn drain_migrates_best_route() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -7026,7 +7405,7 @@ mod tests {
 	/// worth having.
 	#[tokio::test(start_paused = true)]
 	async fn drain_still_serves_when_it_is_the_only_route() {
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -7092,7 +7471,7 @@ mod tests {
 	#[test]
 	fn test_active_corpse_does_not_livelock_takeover() {
 		wedge_watchdog("active-corpse", 20, async {
-			let origin = Origin::random().produce();
+			let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 			let consumer = origin.consume();
 			let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
 
@@ -7163,7 +7542,7 @@ mod tests {
 			rng >> 33
 		};
 
-		let origin = Origin::random().produce();
+		let origin = crate::origin::spawn_test(crate::origin::Info::new(Origin::random()));
 		let consumer = origin.consume();
 		let names: Vec<Arc<str>> = (0..8).map(|i| Arc::from(format!("t{i}"))).collect();
 

--- a/rs/moq-net/src/model/requests.rs
+++ b/rs/moq-net/src/model/requests.rs
@@ -149,6 +149,12 @@ impl<K: Clone + Eq + Hash, V> Requests<K, V> {
 			.filter_map(|key| self.pending.remove(&key))
 			.collect()
 	}
+
+	/// Remove and return every request, including requests already handed to a handler.
+	pub fn drain(&mut self) -> Vec<V> {
+		self.order.clear();
+		self.pending.drain().map(|(_, value)| value).collect()
+	}
 }
 
 #[cfg(test)]

--- a/rs/moq-net/tests/goaway.rs
+++ b/rs/moq-net/tests/goaway.rs
@@ -15,6 +15,12 @@ use support::mock::create_mock_session_pair;
 /// Maximum time any single test may run before being treated as a deadlock.
 const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
+fn spawn_origin() -> moq_net::origin::Producer {
+	let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(Origin::random()));
+	tokio::spawn(driver);
+	origin
+}
+
 /// Every version with GOAWAY support, across both wires and their distinct
 /// channels: the lite Goaway control stream, the IETF draft-14-16 shared
 /// control stream, and the IETF draft-17+ SETUP uni streams.
@@ -310,7 +316,7 @@ async fn goaway_gates_new_subscribes_moq_lite_04() {
 		let version: Version = "moq-lite-04".parse().unwrap();
 
 		// Server publishes a broadcast with one live track.
-		let pub_origin = Origin::random().produce();
+		let pub_origin = spawn_origin();
 		let mut broadcast = pub_origin
 			.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("create broadcast");
@@ -325,7 +331,7 @@ async fn goaway_gates_new_subscribes_moq_lite_04() {
 		audio_group.finish().expect("finish group");
 
 		// Client consumes into its own origin.
-		let sub_origin = Origin::random().produce();
+		let sub_origin = spawn_origin();
 
 		let mut opts = MockConnectOptions::new(version);
 		opts.server_publish = Some(pub_origin.clone());
@@ -410,12 +416,12 @@ async fn goaway_gates_new_subscribes_moq_lite_04() {
 /// draining peer has no reason to send.
 async fn goaway_drains_routes(version: Version) {
 	tokio::time::timeout(TEST_TIMEOUT, async {
-		let pub_origin = Origin::random().produce();
+		let pub_origin = spawn_origin();
 		let _broadcast = pub_origin
 			.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("create broadcast");
 
-		let sub_origin = Origin::random().produce();
+		let sub_origin = spawn_origin();
 
 		let mut opts = MockConnectOptions::new(version);
 		opts.server_publish = Some(pub_origin.clone());

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -666,7 +666,7 @@ impl Cluster {
 			);
 		}
 		let info = origin::Info::new(id);
-		let origin = info.clone().produce();
+		let origin = moq_native::origin::spawn(info.clone());
 		let nodes = crate::nodes::Nodes::new(origin.clone());
 		tracing::info!(origin_id = %origin.id(), configured = config.id.is_some(), "cluster initialized");
 		Ok(Cluster {
@@ -695,7 +695,7 @@ impl Cluster {
 			.clone()
 			.with_pool(cache.pool)
 			.with_cache_duration(cache.duration);
-		self.origin = self.info.clone().produce();
+		self.origin = moq_native::origin::spawn(self.info.clone());
 		self.nodes = self.nodes.with_origin(self.origin.clone());
 		self
 	}
@@ -1678,8 +1678,8 @@ mod tests {
 		assert!(take_cost(&mut url).is_err());
 	}
 
-	#[test]
-	fn cluster_tier_defaults_to_unprefixed() {
+	#[tokio::test]
+	async fn cluster_tier_defaults_to_unprefixed() {
 		let cluster = Cluster::new(ClusterConfig::default()).expect("cluster");
 		assert_eq!(cluster.cluster_tier(), Tier::default());
 
@@ -2091,8 +2091,8 @@ mod tests {
 
 	/// A valid `cluster.id` is used verbatim as the relay's origin id, giving the
 	/// node a stable identity across restarts.
-	#[test]
-	fn cluster_id_sets_origin() {
+	#[tokio::test]
+	async fn cluster_id_sets_origin() {
 		let cluster = Cluster::new(ClusterConfig {
 			id: Some(42),
 			..Default::default()
@@ -2182,8 +2182,8 @@ mod tests {
 
 	/// The legacy `--cluster-mesh <url>` form (now a boolean) is honored for
 	/// backwards compatibility: it enables gossip and supplies the node URL.
-	#[test]
-	fn legacy_mesh_url_enables_gossip_as_node() {
+	#[tokio::test]
+	async fn legacy_mesh_url_enables_gossip_as_node() {
 		let cluster = Cluster::new(ClusterConfig {
 			mesh: Some("rendezvous.example.com:4443".to_string()),
 			..Default::default()
@@ -2359,8 +2359,8 @@ mod tests {
 
 	/// A legacy mesh URL that disagrees with an explicit `--cluster-node` is a
 	/// conflict, not a silent pick.
-	#[test]
-	fn legacy_mesh_url_conflicting_with_node_errors() {
+	#[tokio::test]
+	async fn legacy_mesh_url_conflicting_with_node_errors() {
 		let cluster = Cluster::new(ClusterConfig {
 			mesh: Some("a.example.com:4443".to_string()),
 			node: Some("b.example.com:4443".to_string()),

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -534,7 +534,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn nodes_endpoint_uses_the_attached_cluster_registry() {
-		let origin = moq_net::Origin::new(100).unwrap().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::new(100).unwrap()));
 		let nodes = crate::nodes::Nodes::new(origin);
 		let _connection = nodes.connect_outbound(0, "https://relay-b.example/");
 		let state = InternalState {
@@ -560,7 +560,7 @@ mod tests {
 		// Default-tier egress: an untagged local publisher writes, a tagged egress
 		// consumer reads it out, so publisher `bytes` advance on the default tier.
 		let default_ctx = stats.tier(Tier::default()).session("acme");
-		let pub_origin = Origin::random().produce();
+		let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 		let egress = pub_origin.consume().with_stats(default_ctx.clone());
 		let mut announced = egress.announced();
 		let mut pub_source = pub_origin
@@ -571,7 +571,8 @@ mod tests {
 		// Named-tier ingress: a tagged ingress producer writes, so subscriber
 		// `bytes` advance on the regional tier.
 		let regional_ctx = stats.tier(Tier::new("region/sjc")).session("peer");
-		let sub_origin = Origin::random().produce().with_stats(regional_ctx.clone());
+		let sub_origin =
+			moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random())).with_stats(regional_ctx.clone());
 		let mut sub_source = sub_origin
 			.create_broadcast("demo/x", broadcast::Route::announced())
 			.unwrap();

--- a/rs/moq-relay/src/nodes.rs
+++ b/rs/moq-relay/src/nodes.rs
@@ -300,7 +300,7 @@ mod tests {
 	async fn snapshot_combines_announcements_and_live_connections() {
 		const REMOTE_ID: u64 = 9_007_199_254_740_993;
 
-		let origin = Origin::new(100).unwrap().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::new(100).unwrap()));
 		let nodes = Nodes::new(origin.clone());
 		let _remote = announced_node(&origin, "https://relay-b.example/", &[REMOTE_ID], 7).await;
 		let _outbound = nodes.connect_outbound(0, "https://relay-b.example/");
@@ -333,18 +333,18 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn snapshot_omits_unresolved_inbound_connections() {
-		let origin = Origin::new(100).unwrap().produce();
+	#[tokio::test]
+	async fn snapshot_omits_unresolved_inbound_connections() {
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::new(100).unwrap()));
 		let nodes = Nodes::new(origin);
 		let _inbound = nodes.connect_inbound(0, Origin::new(200).unwrap());
 
 		assert!(nodes.snapshot().nodes.is_empty());
 	}
 
-	#[test]
-	fn snapshot_stops_reporting_closed_outbound_connections() {
-		let origin = Origin::new(100).unwrap().produce();
+	#[tokio::test]
+	async fn snapshot_stops_reporting_closed_outbound_connections() {
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::new(100).unwrap()));
 		let nodes = Nodes::new(origin);
 		let connection = nodes.connect_outbound(0, "https://relay-b.example/");
 		assert_eq!(nodes.snapshot().nodes.len(), 1);
@@ -353,9 +353,9 @@ mod tests {
 		assert!(nodes.snapshot().nodes.is_empty());
 	}
 
-	#[test]
-	fn outbound_node_omits_credentials_from_url() {
-		let origin = Origin::new(100).unwrap().produce();
+	#[tokio::test]
+	async fn outbound_node_omits_credentials_from_url() {
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::new(100).unwrap()));
 		let nodes = Nodes::new(origin);
 		let _connection = nodes.connect_outbound(0, "https://relay-b.example/?jwt=secret");
 
@@ -368,7 +368,7 @@ mod tests {
 	/// churned mid-request.
 	#[tokio::test(start_paused = true)]
 	async fn scan_skips_an_unannounce_queued_ahead_of_another_node() {
-		let origin = Origin::new(100).unwrap().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::new(100).unwrap()));
 		let nodes = Nodes::new(origin.clone());
 		let mut first = announced_node(&origin, "https://relay-a.example/", &[200], 1).await;
 		let _second = announced_node(&origin, "https://relay-b.example/", &[300], 1).await;
@@ -397,7 +397,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn duplicate_origin_ids_do_not_resolve_inbound_connections() {
-		let origin = Origin::new(100).unwrap().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::new(100).unwrap()));
 		let nodes = Nodes::new(origin.clone());
 		let _first = announced_node(&origin, "https://relay-b.example/", &[200], 1).await;
 		let _second = announced_node(&origin, "https://relay-c.example/", &[200], 1).await;

--- a/rs/moq-relay/tests/cluster_unknown.rs
+++ b/rs/moq-relay/tests/cluster_unknown.rs
@@ -82,7 +82,7 @@ impl Drop for Publisher {
 
 async fn publish_version(port: u16, version: &str) -> Publisher {
 	let url: Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
-	let origin = Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = origin
 		.create_broadcast(PATH, moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -133,7 +133,7 @@ async fn publish_unknown(port: u16) -> Publisher {
 /// broke rather than just "no frame".
 async fn read_first_frame(port: u16) -> Result<Vec<u8>, String> {
 	let url: Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
-	let origin = Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let consumer = origin.consume();
 	let session = tokio::time::timeout(TIMEOUT, client(None).with_subscriber(origin).connect(url).established())
 		.await
@@ -172,7 +172,7 @@ async fn read_first_frame(port: u16) -> Result<Vec<u8>, String> {
 
 async fn watch_announces(port: u16, window: Duration) -> Vec<(String, bool)> {
 	let url: Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
-	let origin = Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announced = origin.consume().announced();
 	let _session = tokio::time::timeout(TIMEOUT, client(None).with_subscriber(origin).connect(url).established())
 		.await

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -94,7 +94,7 @@ fn drain_session_with_zero_timeout_closes_at_once() {
 async fn drain_session_with_zero_timeout_closes_at_once_inner() {
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-	let origin = Origin::random().produce();
+	let origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let (port, mut accepted, _handle) = spawn_upstream(origin);
 	wait_listening(port).await;
 
@@ -144,7 +144,7 @@ fn spawn_upstream(
 		let mut server = server.listen().await.expect("listen");
 		while let Some(request) = server.accept().await {
 			// Serve the shared origin bidirectionally, like a relay peer would.
-			let scratch = Origin::random().produce();
+			let scratch = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 			let session = match request.with_publisher(&origin).with_subscriber(scratch).ok().await {
 				Ok(session) => session,
 				Err(err) => {
@@ -181,7 +181,7 @@ async fn cluster_migrates_on_upstream_goaway_inner() {
 
 	tokio::time::timeout(TEST_TIMEOUT, async {
 		// ── the shared "live" broadcast both siblings can serve ─────────
-		let upstream_origin = Origin::random().produce();
+		let upstream_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 		let mut broadcast = upstream_origin
 			.create_broadcast("cam", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("create broadcast");
@@ -368,7 +368,7 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
 	// ── TOP: origin server serving the same broadcast to both mids ──────
-	let top_origin = Origin::random().produce();
+	let top_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = top_origin
 		.create_broadcast("diamond", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -387,7 +387,7 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 		.expect("TOP accept channel closed");
 
 	// ── MID-A: mini-relay consuming TOP, serving BOTTOM, drains later ───
-	let mid_a_origin = Origin::random().produce();
+	let mid_a_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut client_config = moq_native::connect::Config::default();
 	client_config.tls.insecure = Some(true);
 	// Short handover so the test observes the old session close quickly.
@@ -419,7 +419,7 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 		.expect("MID-A accept channel closed");
 
 	// ── SUBSCRIBER: connects to BOTTOM ───────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut sub_client_config = moq_native::connect::Config::default();
 	sub_client_config.tls.insecure = Some(true);
 	let sub_client = sub_client_config
@@ -598,7 +598,7 @@ async fn verify_group(sub: &mut moq_net::track::Subscriber, expected_seq: u64, f
 async fn cluster_reconnects_on_empty_uri_goaway_inner() {
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-	let upstream_origin = Origin::random().produce();
+	let upstream_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = upstream_origin
 		.create_broadcast("cam", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -714,7 +714,7 @@ fn goaway_handover_is_enforced_while_the_replacement_dial_hangs() {
 async fn goaway_handover_is_enforced_while_the_replacement_dial_hangs_inner() {
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-	let upstream_origin = Origin::random().produce();
+	let upstream_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let (port, mut accepted, _handle) = spawn_upstream(upstream_origin);
 	wait_listening(port).await;
 

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -176,7 +176,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let expected_version = newest_lite_version();
 
 	// ── publisher ───────────────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -199,7 +199,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	);
 
 	// ── subscriber ──────────────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 
 	let (_client, sub_connection) =
@@ -369,7 +369,7 @@ async fn relay_websocket_root_path_upgrades() {
 	let url: url::Url = format!("ws://127.0.0.1:{port}").parse().expect("parse url");
 
 	// ── publisher ───────────────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -389,7 +389,7 @@ async fn relay_websocket_root_path_upgrades() {
 	.expect("publisher connect failed (root-path WS upgrade)");
 
 	// ── subscriber ──────────────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 	let (_client, sub_connection) =
 		tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
@@ -436,7 +436,7 @@ async fn two_publish_only_clients_coexist() {
 	let url: url::Url = format!("ws://127.0.0.1:{port}/smoke").parse().expect("parse url");
 
 	// ── two publish-only publishers, each serving a distinct broadcast ──
-	let pub_a = Origin::random().produce();
+	let pub_a = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast_a = pub_a
 		.create_broadcast("alpha", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast a");
@@ -447,7 +447,7 @@ async fn two_publish_only_clients_coexist() {
 		.write_frame(moq_net::Timestamp::ZERO, b"a".as_ref())
 		.expect("write frame a");
 
-	let pub_b = Origin::random().produce();
+	let pub_b = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast_b = pub_b
 		.create_broadcast("beta", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast b");
@@ -474,7 +474,7 @@ async fn two_publish_only_clients_coexist() {
 	.expect("publisher b connect failed");
 
 	// ── one subscriber should see broadcasts from both publish-only clients ──
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 	let (_client, sub_connection) =
 		tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
@@ -594,7 +594,7 @@ async fn internal_tcp_round_trip() {
 	let expected_version = newest_lite_version();
 
 	// ── publisher ───────────────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -619,7 +619,7 @@ async fn internal_tcp_round_trip() {
 	);
 
 	// ── subscriber ──────────────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 	let (_client, sub_connection) =
 		tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
@@ -707,7 +707,7 @@ async fn internal_unix_round_trip() {
 	let expected_version = newest_lite_version();
 
 	// ── publisher ───────────────────────────────────────────────────
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -732,7 +732,7 @@ async fn internal_unix_round_trip() {
 	);
 
 	// ── subscriber ──────────────────────────────────────────────────
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 	let (_client, sub_connection) =
 		tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
@@ -795,7 +795,7 @@ fn path_versions() -> Vec<moq_net::Version> {
 /// whether the request path reached the server (it scopes the publisher's grant
 /// to that root).
 async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: url::Url, broadcast: &str) -> String {
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut bc = pub_origin
 		.create_broadcast(broadcast, moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -812,7 +812,7 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 		.expect("publisher connect timeout")
 		.expect("publisher connect failed");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let mut announcements = sub_origin.consume().announced();
 	let sub_client = client_version(Some(version)).with_subscriber(sub_origin);
 	let (_client, sub_connection) = tokio::time::timeout(TIMEOUT, connect_once(sub_client, sub_url))
@@ -980,7 +980,7 @@ async fn subscribe_only_public_rejects_publisher_role() {
 	let (port, handle) = spawn_subscribe_only_relay().await;
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
-	let pub_origin = Origin::random().produce();
+	let pub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 
 	// The lite-05 client resolves `connect()` optimistically, so it may return Ok
 	// before the relay's verdict lands. Either the connect fails outright, or the
@@ -1012,7 +1012,7 @@ async fn subscribe_only_public_accepts_subscriber_role() {
 	let (port, handle) = spawn_subscribe_only_relay().await;
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 	let (_client, connection) = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
@@ -1068,7 +1068,7 @@ async fn publish_only_public_rejects_subscriber_role() {
 	let (port, handle) = spawn_publish_only_relay().await;
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
-	let sub_origin = Origin::random().produce();
+	let sub_origin = moq_native::origin::spawn(moq_net::origin::Info::new(Origin::random()));
 
 	// Like the publisher case, `connect()` may resolve optimistically; either it fails
 	// outright, or the session the relay hands back closes shortly after.

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -304,7 +304,7 @@ mod tests {
 
 	#[test]
 	fn catalog_codecs_ignores_codecs_available_only_via_escaping_references() {
-		let origin = Origin::random().produce();
+		let (origin, _driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(Origin::random()));
 		let source = moq_mux::Source::new(origin.consume(), "a/pub");
 		let mut catalog = Catalog::default();
 

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -295,10 +295,28 @@ pub(crate) async fn delete(State(server): State<Server>, Path(path): Path<String
 mod tests {
 	use super::*;
 
-	fn server() -> Server {
-		let publisher = moq_net::Origin::random().produce();
-		let subscriber = moq_net::Origin::random().produce().consume();
-		Server::new(Config::default(), publisher, subscriber)
+	struct TestServer {
+		server: Server,
+		_drivers: [moq_net::origin::Driver; 2],
+	}
+
+	impl std::ops::Deref for TestServer {
+		type Target = Server;
+
+		fn deref(&self) -> &Self::Target {
+			&self.server
+		}
+	}
+
+	fn server() -> TestServer {
+		let (publisher, publisher_driver) =
+			moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+		let (subscriber, subscriber_driver) =
+			moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+		TestServer {
+			server: Server::new(Config::default(), publisher, subscriber.consume()),
+			_drivers: [publisher_driver, subscriber_driver],
+		}
 	}
 
 	#[test]

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -535,7 +535,7 @@ mod tests {
 		let mut vframe = vec![0x17, 0x01, 0x00, 0x00, 0x00];
 		vframe.extend_from_slice(&[0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00]);
 
-		let server_origin = moq_net::Origin::random().produce();
+		let server_origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut broadcast = server_origin
 			.create_broadcast("live/cam0", broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -559,7 +559,7 @@ mod tests {
 		});
 
 		// Client: dial, connect(`live`), play(`cam0`), republish into our own origin.
-		let client_origin = moq_net::Origin::random().produce();
+		let client_origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let announced = client_origin.consume();
 		let pull_origin = client_origin.clone();
 		let pull = tokio::spawn(async move {

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -1586,7 +1586,7 @@ mod tests {
 		vseq.extend_from_slice(&[0x01, 0x42, 0xc0, 0x1f, 0xff, 0xe1, 0x00, 0x04, 0x67, 0x42, 0xc0, 0x1f]);
 		vseq.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]);
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut publisher = Publisher::new(&origin, "live/cam0", Some(Duration::from_secs(3))).unwrap();
 		publisher.push(flv::TAG_VIDEO, 0, &vseq).unwrap();
 
@@ -1616,7 +1616,7 @@ mod tests {
 		vframe.extend_from_slice(&[0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00]);
 
 		// Publish the broadcast at `live/cam0` by feeding synthetic FLV to the importer.
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut broadcast = origin
 			.create_broadcast("live/cam0", broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -1665,7 +1665,7 @@ mod tests {
 	async fn play_enhanced_codec_rejects_legacy_client() {
 		const VP9_KEYFRAME_320X240: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00];
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut broadcast = origin
 			.create_broadcast("live/cam0", broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -1788,7 +1788,7 @@ mod tests {
 		let nalu = |b: u8| vec![0, 0, 0, 0, 0, 5, 0x65, b, 0x84, 0x21, 0x00];
 		let frames = multitrack_body(CODED_FRAMES, &[(0, nalu(0x88)), (1, nalu(0x99))]);
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let mut broadcast = origin
 			.create_broadcast("live/cam0", broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -1850,7 +1850,7 @@ mod tests {
 		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
 		let addr = server.local_addr().unwrap();
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let consumer = origin.consume();
 
 		let stream = TcpStream::connect(addr).await.unwrap();

--- a/rs/moq-srt/src/dial.rs
+++ b/rs/moq-srt/src/dial.rs
@@ -144,6 +144,12 @@ mod tests {
 	use super::*;
 	use crate::server::{Request, Server};
 
+	fn spawn_origin() -> moq_net::origin::Producer {
+		let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
+
 	/// Grab a free UDP port by binding `:0` and releasing it. Racy in principle, but
 	/// the window before the SRT server rebinds it is tiny; good enough for a test.
 	async fn free_udp_addr() -> SocketAddr {
@@ -163,7 +169,7 @@ mod tests {
 
 		// Server accepts the publish so the caller's handshake completes; it ingests into
 		// a throwaway origin and returns the routed direction + resource.
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let server_task = tokio::spawn(async move {
 			let request = server.accept().await.expect("a request");
 			let resource = request.resource().to_string();
@@ -203,7 +209,7 @@ mod tests {
 
 		// Empty origin: the subscribe accept parks waiting for the broadcast, which is
 		// fine -- the caller still connects, and the test aborts the wait.
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let consumer = origin.consume();
 		let server_task = tokio::spawn(async move {
 			let request = server.accept().await.expect("a request");

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -124,6 +124,12 @@ impl Subscriber {
 mod tests {
 	use super::*;
 
+	fn spawn_origin() -> moq_net::origin::Producer {
+		let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
+
 	/// One payload-only TS packet carrying a complete PSI section (PUSI + pointer_field
 	/// 0), padded to 188 with stuffing.
 	fn psi_packet(pid: u16, section: &[u8]) -> Vec<u8> {
@@ -172,7 +178,7 @@ mod tests {
 	/// mints off the PMT, not stop at the catalog producer it was set on.
 	#[tokio::test]
 	async fn publisher_declares_the_configured_retention() {
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut publisher = Publisher::new(&origin, "live/cam0", Some(Duration::from_secs(3))).unwrap();
 
 		let mut ts = psi_packet(0x0000, &pat(0x0100));

--- a/rs/moq-stats/src/aggregate.rs
+++ b/rs/moq-stats/src/aggregate.rs
@@ -342,6 +342,12 @@ mod tests {
 
 	use super::*;
 
+	fn spawn_origin() -> origin::Producer {
+		let (origin, driver) = origin::Producer::new(origin::Info::new(Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
+
 	/// A stats producer publishing one node's broadcasts on `origin`, grouped at
 	/// depth 1 (so feeding a broadcast under `<group>/...` announces
 	/// `.stats/<group>/node/<node>`).
@@ -370,7 +376,7 @@ mod tests {
 	/// on its own origin so it never lands on the stats origin.
 	async fn feed(producer: &Producer, tier: Tier, root: &str, path: &str, bytes: usize) -> Feed {
 		let ctx = producer.registry().tier(tier).session(root);
-		let feed_origin = Origin::random().produce();
+		let feed_origin = spawn_origin();
 		let egress = feed_origin.consume().with_stats(ctx.clone());
 
 		let mut announced = egress.announced();
@@ -425,7 +431,7 @@ mod tests {
 	async fn merges_traffic_across_nodes() {
 		// Two nodes each serve the same broadcast; the merged view sums their
 		// cumulative counters per path.
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let node_a = node_producer(&origin, "a");
 		let node_b = node_producer(&origin, "b");
 
@@ -447,7 +453,7 @@ mod tests {
 	async fn node_drop_regresses_the_merged_view() {
 		// Dropping a node unannounces its broadcast; its contribution leaves the
 		// sum, so the merged counter regresses (a fresh segment downstream).
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let node_a = node_producer(&origin, "a");
 		let node_b = node_producer(&origin, "b");
 
@@ -476,7 +482,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn merges_sessions_across_nodes() {
 		// Session presence sums per auth root across nodes.
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let node_a = node_producer(&origin, "a");
 		let node_b = node_producer(&origin, "b");
 

--- a/rs/moq-stats/src/consume.rs
+++ b/rs/moq-stats/src/consume.rs
@@ -109,8 +109,14 @@ mod tests {
 
 	use super::*;
 
+	fn spawn_origin() -> origin::Producer {
+		let (origin, driver) = origin::Producer::new(origin::Info::new(Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
+
 	fn test_producer() -> (Producer, origin::Producer) {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let producer = Producer::new(
 			ProducerConfig::new()
 				.with_origin(origin.clone())
@@ -143,7 +149,7 @@ mod tests {
 
 	async fn feed(producer: &Producer, tier: Tier, root: &str, path: &str) -> Feed {
 		let ctx = producer.registry().tier(tier).session(root);
-		let feed_origin = Origin::random().produce();
+		let feed_origin = spawn_origin();
 		let egress = feed_origin.consume().with_stats(ctx.clone());
 
 		let mut announced = egress.announced();

--- a/rs/moq-stats/src/produce.rs
+++ b/rs/moq-stats/src/produce.rs
@@ -883,8 +883,14 @@ mod tests {
 
 	use super::*;
 
+	fn spawn_origin() -> origin::Producer {
+		let (origin, driver) = origin::Producer::new(origin::Info::new(Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
+
 	fn test_producer(node: Option<&str>) -> (Producer, origin::Producer) {
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		let producer = Producer::new(
 			ProducerConfig::new()
 				.with_origin(origin.clone())
@@ -918,7 +924,7 @@ mod tests {
 		frame_size: usize,
 	) -> Feed {
 		let ctx = registry.tier(tier).session("feed");
-		let origin = Origin::random().produce();
+		let origin = spawn_origin();
 		// Egress (publisher side) is tagged; the local publisher stays untagged.
 		let egress = origin.consume().with_stats(ctx);
 

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -41,8 +41,8 @@ async fn main() -> anyhow::Result<()> {
 
 	// Publish the derivative through one origin and consume the source through
 	// another, over a single auto-reconnecting session.
-	let publish = moq_net::Origin::random().produce();
-	let remote = moq_net::Origin::random().produce();
+	let publish = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
+	let remote = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 
 	let client = moq_native::connect::Config::default().init(Default::default())?;
 	let session = client

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -512,7 +512,7 @@ mod tests {
 		// The passthrough reference (`..`) resolves against the output broadcast's path, so
 		// the output must be minted through an origin: a standalone producer has no path, and
 		// `..` from it would escape, failing the catalog read below.
-		let origin = moq_net::Origin::random().produce();
+		let origin = moq_native::origin::spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
 		let output = origin
 			.create_broadcast("room/transcode", moq_net::broadcast::Route::new())
 			.unwrap();

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -86,6 +86,12 @@ mod tests {
 	use crate::decode::Kind;
 	use crate::encode::{Config as EncodeConfig, Encoder, Kind as EncodeKind, Producer as EncodeProducer};
 
+	fn spawn_origin() -> moq_net::origin::Producer {
+		let (origin, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+		tokio::spawn(driver);
+		origin
+	}
+
 	#[tokio::test]
 	async fn reads_cmaf_container_declared_by_catalog() {
 		let mut source_broadcast = moq_net::broadcast::Info::new().produce();
@@ -106,7 +112,7 @@ mod tests {
 			producer.publish(&encoder.encode(&frame).unwrap()).unwrap();
 		}
 
-		let origin = moq_net::Origin::random().produce();
+		let origin = spawn_origin();
 		let mut requests = origin.dynamic();
 		let served = source_subscriber.clone();
 		tokio::spawn(async move {

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -72,7 +72,9 @@ impl Session {
 	async fn handshake(transport: transport::Session) -> Result<Session, JsValue> {
 		// Wire a subscribe origin so the session has somewhere to insert the
 		// broadcasts the remote announces; keep a consumer to read them.
-		let origin = moq_net::Origin::random().produce();
+		let (origin, origin_driver) =
+			moq_net::origin::Producer::new(moq_net::origin::Info::new(moq_net::Origin::random()));
+		web_async::spawn(origin_driver);
 		let consumer = origin.consume();
 		let client = moq_net::Client::new().with_subscriber(origin);
 		let (inner, driver) = client.connect(transport).await.map_err(js_err)?;


### PR DESCRIPTION
## Summary

- make Origin lifecycle caller-driven through a retained and polled `origin::Driver`
- move source watchers, fronts, track serving, route changes, failover, linger, and teardown into one driver-owned task set
- preserve synchronous initial attachment and visibility while making subsequent lifecycle progress depend on driver polling
- add `moq_native::origin::spawn` and migrate native applications, relay components, libmoq, WASM, tests, and examples
- update Rust documentation for the new construction and lifetime contract

Closes #1073.
Prerequisite for the runtime-neutral migration in #2875.
Atomic publication readiness remains separate and nonblocking in #2895. PR #2472 was used only as prototype evidence.

## Public API changes

This PR intentionally targets `dev` because it breaks the published Rust API:

- `origin::Producer::new(info) -> (Producer, origin::Driver)` is now the only public Origin producer factory
- remove `Origin::produce()`
- remove `origin::Info::produce()`
- add the public `#[must_use]` `origin::Driver` future with `Output = ()` and explicit waiter polling
- add `moq_native::origin::spawn(info) -> Producer` as the Tokio convenience path

Dropping the driver now closes the Origin with `Error::Dropped`, rejects pending dynamic requests, unannounces active broadcasts, closes announcement cursors, and makes later producer mutations fail with `Error::Closed`.

Wire behavior, JavaScript APIs, and public FFI signatures are unchanged. No package versions changed.

## Cross-package sync

- migrated all Rust consumers, native applications, relay components, libmoq internals, and WASM construction
- updated Rust API docs and examples
- no `js/net` or draft changes are needed because the wire format and JavaScript API are unchanged
- no generated language-wrapper changes are needed because the public FFI surface is unchanged

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (2,870 Rust tests passed, 2 skipped; JS, docs, Python, and bindings passed)
- `nix develop --command just test smoke-full` (all 21 publisher/subscriber combinations passed)
- `git diff --check`

(Written by GPT-5)