### PR TITLE
fix(kio)!: Producer::poll drains buffered state before reporting closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,16 +4288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kio"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdaadab1a06c04819b8f7cabe4ead8c9f1e86016c4c2a9384829bbc555f477a7"
-dependencies = [
- "loom",
- "smallvec",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4806,7 +4796,7 @@ dependencies = [
  "bytes",
  "hang",
  "humantime",
- "kio 0.5.4",
+ "kio",
  "m3u8-rs",
  "moq-mux",
  "moq-net",
@@ -4827,7 +4817,7 @@ dependencies = [
  "bytes",
  "criterion",
  "json-patch",
- "kio 0.5.4",
+ "kio",
  "moq-flate",
  "moq-net",
  "serde",
@@ -4865,7 +4855,7 @@ dependencies = [
  "futures",
  "h264-parser",
  "hang",
- "kio 0.5.4",
+ "kio",
  "memchr",
  "moq-json",
  "moq-loc",
@@ -4898,7 +4888,7 @@ dependencies = [
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "kio 0.5.4",
+ "kio",
  "loom",
  "num_enum",
  "rand 0.10.2",
@@ -10415,7 +10405,7 @@ dependencies = [
  "bytes",
  "http",
  "iroh",
- "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio",
  "n0-error",
  "n0-future",
  "tokio",
@@ -10434,7 +10424,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -10471,7 +10461,7 @@ dependencies = [
  "flume",
  "futures",
  "http",
- "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio",
  "rustls-pki-types",
  "thiserror 2.0.20",
  "tokio",
@@ -10491,7 +10481,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio",
  "quinn",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,3 +186,10 @@ opt-level = "z"
 lto = "fat"
 codegen-units = 1
 strip = true
+
+# External crates (web-transport-iroh) depend on the published kio, which
+# otherwise coexists with the workspace copy at the same version and makes
+# `--package kio` ambiguous the moment the crate changes. Point everyone at the
+# workspace copy so exactly one kio is built.
+[patch.crates-io]
+kio = { path = "rs/kio" }

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -90,25 +90,29 @@ impl<T> Producer<T> {
 	/// the predicate, then mutate through the returned `Mut`. Registers `waiter`
 	/// while pending.
 	///
-	/// Returns `Poll::Ready(Err(`[`Ref`]`))` if the channel is closed.
+	/// The predicate runs before closure is reported, matching [`Consumer::poll`]
+	/// and [`Self::poll_ref`]: buffered state drains first, so
+	/// `Poll::Ready(Err(`[`Ref`]`))` means the predicate is unsatisfied *and* no
+	/// more updates can arrive. A satisfied poll on a closed channel still yields
+	/// the [`Mut`], letting the caller take what remains.
 	pub fn poll<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<Mut<'_, T>, Ref<'_, T>>>
 	where
 		F: FnMut(&Ref<'_, T>) -> Poll<()>,
 	{
-		let state = self.state.lock();
-		if state.closed {
-			return Poll::Ready(Err(Ref { state }));
+		let mut guard = Ref {
+			state: self.state.lock(),
+		};
+		if f(&guard).is_ready() {
+			// Upgrade the Ref to a Mut, keeping the same lock guard.
+			return Poll::Ready(Ok(Mut::new(guard.state)));
 		}
 
-		let mut guard = Ref { state };
-		match f(&guard) {
-			// Upgrade the Ref to a Mut, keeping the same lock guard.
-			Poll::Ready(()) => Poll::Ready(Ok(Mut::new(guard.state))),
-			Poll::Pending => {
-				waiter.register(&mut guard.state.waiters_value);
-				Poll::Pending
-			}
+		if guard.state.closed {
+			return Poll::Ready(Err(guard));
 		}
+
+		waiter.register(&mut guard.state.waiters_value);
+		Poll::Pending
 	}
 
 	/// Poll read-only access with waker registration.
@@ -139,7 +143,8 @@ impl<T> Producer<T> {
 	/// Wait until the read-only predicate holds, then acquire write access.
 	///
 	/// The async sibling of [`poll`](Self::poll): returns `Ok(Mut)` once `f` returns
-	/// [`Poll::Ready`], or [`Closed`] if the channel closes first. The `Ok` guard is the
+	/// [`Poll::Ready`], or [`Closed`] once the channel is closed with the predicate
+	/// still unsatisfied (buffered state drains first). The `Ok` guard is the
 	/// write access you asked for, so it's yours to hold; the `Err` case hands back no
 	/// guard at all. Call [`read`](Self::read) if you need the final state.
 	pub async fn wait<F>(&self, mut f: F) -> Result<Mut<'_, T>, Closed>
@@ -342,10 +347,11 @@ impl<'a, T> Mut<'a, T> {
 		}
 	}
 
-	/// NOTE: This takes self so it's impossible to be in a closed state.
+	/// Close the channel. Takes `self`, so the guard can't be used afterwards.
 	pub fn close(mut self) {
 		let state = self.state.as_mut().unwrap();
-		// We don't need to check for state.closed because we checked when making Mut
+		// Idempotent: a drain-after-close poll can hand out a Mut on an already
+		// closed channel (see [`Producer::poll`]).
 		state.closed = true;
 		self.modified = true;
 	}

--- a/rs/kio/src/tests.rs
+++ b/rs/kio/src/tests.rs
@@ -163,3 +163,29 @@ fn close_wakes_value_closed_and_consumer() {
 	assert!(matches!(closed_fut.as_mut().poll(&mut closed_cx), Poll::Ready(())));
 	assert!(matches!(unused_fut.as_mut().poll(&mut unused_cx), Poll::Ready(Err(_))));
 }
+
+/// `Producer::poll` runs the predicate before reporting closure, so state
+/// buffered inside the value drains first and `Err` is terminal: unsatisfied
+/// *and* no more updates coming. Mirrors `Consumer::poll` / `poll_ref`.
+#[test]
+fn producer_poll_drains_before_reporting_closure() {
+	let producer = Producer::new(vec![1u32, 2]);
+	assert!(producer.close().is_ok());
+
+	let waiter = crate::Waiter::noop();
+	let ready = |value: &crate::Ref<'_, Vec<u32>>| match value.is_empty() {
+		true => Poll::Pending,
+		false => Poll::Ready(()),
+	};
+
+	// Both buffered items drain through the satisfied predicate.
+	for expected in [1, 2] {
+		match producer.poll(&waiter, ready) {
+			Poll::Ready(Ok(mut value)) => assert_eq!(value.remove(0), expected),
+			_ => panic!("expected a drained value"),
+		}
+	}
+
+	// Empty and closed: now the closure is reported.
+	assert!(matches!(producer.poll(&waiter, ready), Poll::Ready(Err(_))));
+}


### PR DESCRIPTION
Split out of the #2901 mockup at the author's request.

`Consumer::poll` and `Producer::poll_ref` already evaluate the predicate before checking the closed flag; `Producer::poll` was the odd one out, reporting `Err(Ref)` on a closed channel even when the predicate was satisfied, which silently discarded state still buffered inside the value. It now matches its siblings: buffered state drains through the satisfied predicate first, `Err` means unsatisfied *and* final, and a satisfied poll on a closed channel yields the `Mut` so the caller can take what remains. This is the same drain-then-closed contract `Queue::poll_pop` already documents.

Concretely, this lets an announce-style cursor deliver its final buffered unannounces and then end via a plain `close()`, instead of hand-rolling an `ended: bool` inside the value the way #2897 currently does; that simplification is a follow-up once both land.

Semantics note: `Mut` handed out on a closed channel can still mutate (that's the point, e.g. draining a `Vec`), and `Mut::close` is now documented idempotent. `write()` still refuses closed channels, so plain writes can't sneak past a close; only predicate-gated drains can.

Also carries the `[patch.crates-io] kio` fix (duplicated in #2901; the identical hunk merges cleanly whichever lands first): `web-transport-iroh` depends on the published kio at the same version as the workspace copy, making `cargo clippy --package kio` ambiguous, so `just check`/`just fix` failed on any branch touching kio.

Regression test: `producer_poll_drains_before_reporting_closure`. `just fix` / `just check` / `just test` pass (3191 tests), plus `just rs loom`.

(Written by Fable 5)
