### PR TITLE
perf(kio): dedup waiter registration so Park can reuse a parked waiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4271,6 +4271,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 name = "kio"
 version = "0.5.4"
 dependencies = [
+ "criterion",
  "loom",
  "smallvec",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ resolver = "2"
 rust-version = "1.91"
 
 [workspace.dependencies]
+criterion = "0.8"
 flate2 = "1.1"
 hang = { version = "0.20", path = "rs/hang" }
 kio = { version = "0.5", path = "rs/kio" }

--- a/rs/kio/Cargo.toml
+++ b/rs/kio/Cargo.toml
@@ -30,7 +30,12 @@ web-async = { workspace = true, optional = true }
 loom = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
+[[bench]]
+name = "waiter"
+harness = false

--- a/rs/kio/benches/waiter.rs
+++ b/rs/kio/benches/waiter.rs
@@ -1,0 +1,137 @@
+//! Microbenchmarks for waiter registration.
+//!
+//! `WaiterList::register` runs on every pending poll of every kio channel, so it is
+//! the per-wakeup overhead of the whole stack. These benchmarks isolate the cases
+//! that matter: a fresh registration against lists of various sizes, the
+//! steady-state re-registration of an already-parked waiter, reclaiming slots from
+//! abandoned waiters, and the full park/wake/re-register cycle a poll function
+//! actually drives.
+//!
+//! Contention is deliberately absent: a `WaiterList` is always behind its caller's
+//! lock (`register` takes `&mut`), so cross-thread cost belongs to that lock, not to
+//! the list.
+//!
+//! Run with `cargo bench -p kio`.
+
+use std::task::{Context, Waker};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use kio::{Park, Waiter, WaiterList};
+
+/// Live-waiter populations to sweep. The top end is the inline capacity, past which
+/// the list spills to the heap.
+const SIZES: [usize; 4] = [1, 2, 8, 32];
+
+/// A list holding `n` live registrations, plus the waiters keeping them live.
+fn populated(n: usize) -> (WaiterList, Vec<Waiter>) {
+	let mut list = WaiterList::new();
+	let waiters: Vec<_> = (0..n)
+		.map(|_| {
+			let waiter = Waiter::new(Waker::noop().clone());
+			waiter.register(&mut list);
+			waiter
+		})
+		.collect();
+	(list, waiters)
+}
+
+/// Register a fresh waiter into a list of N live entries: the dedup scan misses,
+/// the dead-slot probe finds nothing, and the entry is appended.
+fn bench_register(c: &mut Criterion) {
+	let mut g = c.benchmark_group("waiter_register_live");
+	for &n in &SIZES {
+		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+			b.iter_batched(
+				|| {
+					let (list, waiters) = populated(n);
+					(list, waiters, Waiter::new(Waker::noop().clone()))
+				},
+				|(mut list, waiters, fresh)| {
+					fresh.register(&mut list);
+					(list, waiters, fresh)
+				},
+				BatchSize::SmallInput,
+			)
+		});
+	}
+	g.finish();
+}
+
+/// Re-register a waiter already in a list of N live entries. The scan hits the
+/// worst-case entry (the last one registered), which is the steady-state cost of a
+/// poll that re-runs while still parked.
+fn bench_reregister(c: &mut Criterion) {
+	let mut g = c.benchmark_group("waiter_reregister");
+	for &n in &SIZES {
+		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+			let (mut list, waiters) = populated(n);
+			let last = waiters.last().unwrap();
+			b.iter(|| last.register(&mut list));
+		});
+	}
+	g.finish();
+}
+
+/// Register a fresh waiter into a list whose N entries are all dead: the dedup scan
+/// misses and the probe reclaims a slot in place.
+fn bench_register_dead(c: &mut Criterion) {
+	let mut g = c.benchmark_group("waiter_register_dead");
+	for &n in &SIZES {
+		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+			b.iter_batched(
+				|| {
+					let (list, waiters) = populated(n);
+					drop(waiters);
+					(list, Waiter::new(Waker::noop().clone()))
+				},
+				|(mut list, fresh)| {
+					fresh.register(&mut list);
+					(list, fresh)
+				},
+				BatchSize::SmallInput,
+			)
+		});
+	}
+	g.finish();
+}
+
+/// Register-and-abandon without a wake: every iteration allocates a waiter, parks
+/// it, and drops it, so the list must keep reclaiming the dead slot it leaves.
+fn bench_cancel(c: &mut Criterion) {
+	c.bench_function("waiter_cancel", |b| {
+		let mut list = WaiterList::new();
+		b.iter(|| Waiter::new(Waker::noop().clone()).register(&mut list));
+	});
+}
+
+/// The cycle a poll function actually drives: hold the park, register with L lists,
+/// then one list wakes. The re-poll arrives with live registrations still parked on
+/// the other lists, which is exactly the case `Park` must not retire on.
+fn bench_park_cycle(c: &mut Criterion) {
+	let mut g = c.benchmark_group("waiter_park_cycle");
+	for &lists in &[1usize, 2, 4] {
+		g.bench_with_input(BenchmarkId::from_parameter(lists), &lists, |b, &n| {
+			let cx = Context::from_waker(Waker::noop());
+			let mut park = Park::default();
+			let mut lists: Vec<_> = (0..n).map(|_| WaiterList::new()).collect();
+			b.iter(|| {
+				let waiter = park.hold(&cx);
+				for list in &mut lists {
+					waiter.register(list);
+				}
+				lists[0].wake();
+			});
+		});
+	}
+	g.finish();
+}
+
+criterion_group!(
+	benches,
+	bench_register,
+	bench_reregister,
+	bench_register_dead,
+	bench_cancel,
+	bench_park_cycle
+);
+criterion_main!(benches);

--- a/rs/kio/benches/waiter.rs
+++ b/rs/kio/benches/waiter.rs
@@ -109,7 +109,9 @@ fn bench_cancel(c: &mut Criterion) {
 /// the other lists, which is exactly the case `Park` must not retire on.
 fn bench_park_cycle(c: &mut Criterion) {
 	let mut g = c.benchmark_group("waiter_park_cycle");
-	for &lists in &[1usize, 2, 4, 8] {
+	// 16 lists overflow the waiter's record table, exercising eviction and the
+	// scan fallback rather than the pure record fast path.
+	for &lists in &[1usize, 2, 4, 8, 16] {
 		g.bench_with_input(BenchmarkId::from_parameter(lists), &lists, |b, &n| {
 			let cx = Context::from_waker(Waker::noop());
 			let mut park = Park::default();

--- a/rs/kio/benches/waiter.rs
+++ b/rs/kio/benches/waiter.rs
@@ -15,7 +15,7 @@
 
 use std::task::{Context, Waker};
 
-use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use kio::{Park, Waiter, WaiterList};
 
 /// Live-waiter populations to sweep. The top end is the inline capacity, past which
@@ -126,12 +126,68 @@ fn bench_park_cycle(c: &mut Criterion) {
 	g.finish();
 }
 
+/// Fan-out sizes to sweep, crossing the inline capacity into heap spill.
+const FANOUT: [usize; 4] = [8, 32, 128, 512];
+
+/// The fan-out cycle: N waiters all parked on one list, a wake drains it, and every
+/// waiter re-registers. Throughput is per registration, so a super-linear per-cycle
+/// cost shows up as falling throughput at higher N.
+fn bench_fanout_cycle(c: &mut Criterion) {
+	let mut g = c.benchmark_group("waiter_fanout_cycle");
+	for &n in &FANOUT {
+		g.throughput(Throughput::Elements(n as u64));
+		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+			let mut list = WaiterList::new();
+			let waiters: Vec<_> = (0..n).map(|_| Waiter::new(Waker::noop().clone())).collect();
+			b.iter(|| {
+				for waiter in &waiters {
+					waiter.register(&mut list);
+				}
+				list.wake();
+			});
+		});
+	}
+	g.finish();
+}
+
+/// The fan-out cycle when every waiter is also parked on a second, never-woken list
+/// (a value list and a closed list under one lock, say). The live second
+/// registration is what forecloses the registered-nowhere fast path, so this is the
+/// worst case for rebuilding the drained list.
+fn bench_fanout_cycle_parked(c: &mut Criterion) {
+	let mut g = c.benchmark_group("waiter_fanout_cycle_parked");
+	for &n in &FANOUT {
+		g.throughput(Throughput::Elements(n as u64));
+		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+			let mut list = WaiterList::new();
+			let mut parked = WaiterList::new();
+			let waiters: Vec<_> = (0..n)
+				.map(|_| {
+					let waiter = Waiter::new(Waker::noop().clone());
+					waiter.register(&mut parked);
+					waiter
+				})
+				.collect();
+			b.iter(|| {
+				for waiter in &waiters {
+					waiter.register(&mut list);
+					waiter.register(&mut parked);
+				}
+				list.wake();
+			});
+		});
+	}
+	g.finish();
+}
+
 criterion_group!(
 	benches,
 	bench_register,
 	bench_reregister,
 	bench_register_dead,
 	bench_cancel,
-	bench_park_cycle
+	bench_park_cycle,
+	bench_fanout_cycle,
+	bench_fanout_cycle_parked
 );
 criterion_main!(benches);

--- a/rs/kio/benches/waiter.rs
+++ b/rs/kio/benches/waiter.rs
@@ -57,9 +57,9 @@ fn bench_register(c: &mut Criterion) {
 	g.finish();
 }
 
-/// Re-register a waiter already in a list of N live entries. The scan hits the
-/// worst-case entry (the last one registered), which is the steady-state cost of a
-/// poll that re-runs while still parked.
+/// Re-register a waiter already in a list of N live entries: the record fast path,
+/// which is the steady-state cost of a poll that re-runs while still parked. Flat
+/// in N, since membership is settled by the waiter's own record, not a scan.
 fn bench_reregister(c: &mut Criterion) {
 	let mut g = c.benchmark_group("waiter_reregister");
 	for &n in &SIZES {
@@ -109,7 +109,7 @@ fn bench_cancel(c: &mut Criterion) {
 /// the other lists, which is exactly the case `Park` must not retire on.
 fn bench_park_cycle(c: &mut Criterion) {
 	let mut g = c.benchmark_group("waiter_park_cycle");
-	for &lists in &[1usize, 2, 4] {
+	for &lists in &[1usize, 2, 4, 8] {
 		g.bench_with_input(BenchmarkId::from_parameter(lists), &lists, |b, &n| {
 			let cx = Context::from_waker(Waker::noop());
 			let mut park = Park::default();
@@ -143,7 +143,8 @@ fn bench_fanout_cycle(c: &mut Criterion) {
 				for waiter in &waiters {
 					waiter.register(&mut list);
 				}
-				list.wake();
+				// Drain the production way: snapshot under the lock, wake outside.
+				list.take().wake();
 			});
 		});
 	}
@@ -173,7 +174,8 @@ fn bench_fanout_cycle_parked(c: &mut Criterion) {
 					waiter.register(&mut list);
 					waiter.register(&mut parked);
 				}
-				list.wake();
+				// Drain the production way: snapshot under the lock, wake outside.
+				list.take().wake();
 			});
 		});
 	}

--- a/rs/kio/src/loom.rs
+++ b/rs/kio/src/loom.rs
@@ -254,39 +254,58 @@ fn queue_close_wakes_a_parked_pop() {
 }
 
 /// A poll parked on two lists is re-woken by one while still registered with the
-/// other. The re-poll reuses the parked waiter, so its re-registration must dedup
-/// rather than stack, and the second list's wake must still reach it.
+/// other. The re-poll reuses the parked waiter, so re-registering into the drained
+/// list must actually land (not be skipped as a false duplicate), and re-registering
+/// into the still-parked list must dedup rather than stack.
+///
+/// The terminal wake is on the *drained* list, so an execution whose re-poll fails
+/// to re-register there parks forever, which loom reports as a deadlock. `parked` is
+/// never woken at all: it exists to keep the waiter's registrations live across
+/// re-polls, which is exactly the state the old code retired on.
 #[test]
-fn a_reused_waiter_hears_the_second_list() {
+fn a_reused_waiter_hears_the_drained_list_again() {
 	loom::model(|| {
-		let first = Fan::new();
-		let second = Fan::new();
+		let woken = Fan::new();
+		let parked = Fan::new();
 		let done = Arc::new(AtomicBool::new(false));
 
 		let waker = {
-			let first = first.clone();
-			let second = second.clone();
+			let woken = woken.clone();
 			let done = done.clone();
 
 			thread::spawn(move || {
-				first.wake();
+				// Drains `woken`; a re-poll now re-registers while still parked on
+				// `parked`.
+				woken.wake();
 				done.store(true, Ordering::SeqCst);
-				second.wake();
+				// Must reach the re-registered waiter, or the model deadlocks.
+				woken.wake();
 			})
 		};
 
-		// Register with both before reading `done`, as in `a_held_wake_is_never_lost`:
-		// a re-poll triggered by `first` re-registers a waiter that is still parked on
-		// `second`.
-		block_on(wait(|waiter| {
-			first.register(waiter);
-			second.register(waiter);
+		// Register before reading `done`, as in `a_held_wake_is_never_lost`: the
+		// other order has a window where the store and both wakes land between the
+		// read and the registration.
+		//
+		// The closure holds its own waiter rather than using the parked one: loom's
+		// `block_on` waker fails `will_wake` between polls (its vtable is a
+		// const-promoted static, duplicated across codegen units in release builds),
+		// so `Park` retires every poll under loom and would never model the reuse
+		// this test exists for. Waking the first poll's waker still unparks the
+		// task, so a stable identity is safe here.
+		block_on({
+			let mut stable = None;
+			wait(move |parked_waiter| {
+				let waiter = stable.get_or_insert_with(|| Waiter::new(parked_waiter.waker().clone()));
+				woken.register(waiter);
+				parked.register(waiter);
 
-			match done.load(Ordering::SeqCst) {
-				true => Poll::Ready(()),
-				false => Poll::Pending,
-			}
-		}));
+				match done.load(Ordering::SeqCst) {
+					true => Poll::Ready(()),
+					false => Poll::Pending,
+				}
+			})
+		});
 
 		waker.join().unwrap();
 	});

--- a/rs/kio/src/loom.rs
+++ b/rs/kio/src/loom.rs
@@ -253,6 +253,45 @@ fn queue_close_wakes_a_parked_pop() {
 	});
 }
 
+/// A poll parked on two lists is re-woken by one while still registered with the
+/// other. The re-poll reuses the parked waiter, so its re-registration must dedup
+/// rather than stack, and the second list's wake must still reach it.
+#[test]
+fn a_reused_waiter_hears_the_second_list() {
+	loom::model(|| {
+		let first = Fan::new();
+		let second = Fan::new();
+		let done = Arc::new(AtomicBool::new(false));
+
+		let waker = {
+			let first = first.clone();
+			let second = second.clone();
+			let done = done.clone();
+
+			thread::spawn(move || {
+				first.wake();
+				done.store(true, Ordering::SeqCst);
+				second.wake();
+			})
+		};
+
+		// Register with both before reading `done`, as in `a_held_wake_is_never_lost`:
+		// a re-poll triggered by `first` re-registers a waiter that is still parked on
+		// `second`.
+		block_on(wait(|waiter| {
+			first.register(waiter);
+			second.register(waiter);
+
+			match done.load(Ordering::SeqCst) {
+				true => Poll::Ready(()),
+				false => Poll::Pending,
+			}
+		}));
+
+		waker.join().unwrap();
+	});
+}
+
 /// `Fan` holds wakes back while a guard is out and delivers them when the last
 /// one drops. A wake racing that window must still reach the parked waiter, whichever
 /// side of the hold it lands on.

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -5,7 +5,7 @@ use std::{
 	pin::Pin,
 	// std, not `crate::sync`: loom's Arc has no `downgrade`, and `Waker::from` takes
 	// std's. See `sync.rs`.
-	sync::{Arc, OnceLock, Weak},
+	sync::{Arc, OnceLock, Weak, atomic::AtomicU64},
 	task::{Context, Poll, Wake, Waker},
 };
 
@@ -19,13 +19,71 @@ use crate::{
 /// Number of slots stored inline before spilling to the heap.
 const INLINE_WAITERS: usize = 32;
 
+/// Registrations remembered per waiter identity for O(1) dedup. A poll typically
+/// parks on a small handful of lists; overflow falls back to the scan, so this
+/// bounds memory, never correctness.
+const RECORDED_LISTS: usize = 4;
+
+/// The shared identity behind a [`Waiter`], referenced weakly by every list entry.
+struct Identity {
+	/// The task waker the lists deliver to.
+	waker: Waker,
+
+	/// Registrations this identity has made, as `(list id, list epoch)` pairs. A
+	/// pair matching a list's current epoch proves the registration is still in
+	/// place, and a stale pair proves it is gone: live entries only leave through a
+	/// drain, every drain bumps the epoch, and every registration refreshes the
+	/// pair. Either way membership is settled in O(1); only a missing pair (never
+	/// registered, or evicted) needs the scan.
+	recorded: Mutex<SmallVec<[(u64, u64); RECORDED_LISTS]>>,
+}
+
+/// What an identity's records prove about its membership in one list.
+enum Presence {
+	/// Recorded at the list's current epoch: still registered.
+	Present,
+	/// Recorded at an older epoch: the drain that bumped it removed every entry,
+	/// and registering again would have refreshed the record, so: not registered.
+	Absent,
+	/// No record (never registered, or evicted): membership must be checked.
+	Unknown,
+}
+
+impl Identity {
+	/// What the records prove about membership in list `id` at `epoch`.
+	///
+	/// Also refreshes the record to `(id, epoch)` before returning. That is sound
+	/// even though the caller has not registered yet: every path out of
+	/// [`WaiterList::register`] leaves the waiter registered, and folding the write
+	/// into the lookup keeps registration at one lock round-trip.
+	fn presume(&self, id: u64, epoch: u64) -> Presence {
+		let mut recorded = self.recorded.lock().expect("mutex poisoned");
+
+		if let Some(entry) = recorded.iter_mut().find(|entry| entry.0 == id) {
+			let presence = match entry.1 == epoch {
+				true => Presence::Present,
+				false => Presence::Absent,
+			};
+			entry.1 = epoch;
+			return presence;
+		}
+
+		// Evict the oldest record when full: eviction only costs a scan later.
+		if recorded.len() == RECORDED_LISTS {
+			recorded.remove(0);
+		}
+		recorded.push((id, epoch));
+		Presence::Unknown
+	}
+}
+
 /// Handle passed to poll functions for registering with [`WaiterList`]s.
 ///
-/// Holds the task's [`Waker`] by value and, lazily, a shared `Arc<Waker>` that list
-/// entries reference weakly. The `Arc` is allocated on the first [`Self::register`],
-/// so a poll that resolves without ever parking never touches the heap. Its `Weak`s
-/// go dead the moment the owning [`Waiter`] drops, which is how a [`WaiterList`]
-/// reclaims slots with no explicit deregister.
+/// Holds the task's [`Waker`] by value and, lazily, a shared identity that list
+/// entries reference weakly. The identity is allocated on the first
+/// [`Self::register`], so a poll that resolves without ever parking never touches
+/// the heap. Its `Weak`s go dead the moment the owning [`Waiter`] drops, which is
+/// how a [`WaiterList`] reclaims slots with no explicit deregister.
 ///
 /// A clone shares this identity: it wakes the same task, its registrations count as
 /// the original's, and they all stay live until every clone drops.
@@ -36,7 +94,7 @@ pub struct Waiter {
 	// The shared handle downgraded into every list this waiter registers with. Created on the
 	// first `register` (a poll that never parks never allocates it), then reused so multiple
 	// lists in one poll share a single allocation whose `Weak`s die together when the waiter drops.
-	shared: OnceLock<Arc<Waker>>,
+	shared: OnceLock<Arc<Identity>>,
 }
 
 impl Waiter {
@@ -64,10 +122,15 @@ impl Waiter {
 		&self.waker
 	}
 
-	/// The shared waker handle downgraded into lists, allocated on first use and cached so
+	/// The shared identity downgraded into lists, allocated on first use and cached so
 	/// repeat registrations (across polls, or across lists in one poll) share one allocation.
-	fn shared(&self) -> &Arc<Waker> {
-		self.shared.get_or_init(|| Arc::new(self.waker.clone()))
+	fn shared(&self) -> &Arc<Identity> {
+		self.shared.get_or_init(|| {
+			Arc::new(Identity {
+				waker: self.waker.clone(),
+				recorded: Mutex::new(SmallVec::new()),
+			})
+		})
 	}
 
 	/// Poll a foreign [`Future`] against this waiter, so it re-wakes the enclosing
@@ -90,6 +153,10 @@ impl Clone for Waiter {
 	}
 }
 
+/// Source of unique [`WaiterList`] ids, so a waiter's recorded registrations can
+/// never confuse two lists (ids are handed out once and never reused).
+static NEXT_LIST_ID: AtomicU64 = AtomicU64::new(0);
+
 /// A list of weak wakers waiting for notification.
 ///
 /// Slots live inline (up to `INLINE_WAITERS`) and only spill to the heap
@@ -97,9 +164,14 @@ impl Clone for Waiter {
 /// collection across many `register` calls so the list doesn't grow
 /// unboundedly while keeping per-call cost O(1).
 pub struct WaiterList {
-	entries: SmallVec<[Weak<Waker>; INLINE_WAITERS]>,
+	entries: SmallVec<[Weak<Identity>; INLINE_WAITERS]>,
 	/// Rotating cursor for opportunistic GC on `register`.
 	cursor: usize,
+	/// Never-reused identity for this list, paired with `epoch` in waiter records.
+	id: u64,
+	/// Bumped on every drain. A waiter whose record carries the current epoch is
+	/// still registered: live entries only ever leave through a drain.
+	epoch: u64,
 }
 
 impl WaiterList {
@@ -108,37 +180,55 @@ impl WaiterList {
 		Self {
 			entries: SmallVec::new(),
 			cursor: 0,
+			id: NEXT_LIST_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+			epoch: 0,
 		}
 	}
 
 	/// Register a waiter. Idempotent: a waiter already in the list stays as one entry.
 	///
-	/// The dedup scan compares allocation addresses only. A `Weak` in the list keeps
-	/// its allocation alive even after the owner drops, so an address can never be
-	/// recycled out from under an entry, and equal pointers always mean the same
-	/// waiter. No refcounts are touched and no foreign cache lines are read, which is
-	/// what makes the steady-state re-register (the hot path) a short scan over
-	/// contiguous memory.
+	/// The cost is O(1) whenever the waiter's own records settle membership, which is
+	/// every steady state: still registered since the last drain (a re-poll while
+	/// parked) returns immediately, and registered before the last drain (rebuilding
+	/// after a wake) appends immediately. Only a waiter with no record of this list
+	/// falls back to a membership scan: pointer equality over contiguous entries,
+	/// exact because a `Weak` pins its allocation's address, so an equal pointer
+	/// always means the same waiter. The scan too is skipped when the waiter is
+	/// registered nowhere at all (one atomic load on its own allocation).
 	///
-	/// A miss also performs a small, bounded amount of garbage collection: probes the
-	/// slot at the rotating cursor, replacing it in place if dead. The cursor advances
-	/// on each append so the probe window covers the whole list over time.
+	/// An append also performs a small, bounded amount of garbage collection: probes
+	/// the slot at the rotating cursor, replacing it in place if dead. The cursor
+	/// advances on each append so the probe window covers the whole list over time.
 	pub fn register(&mut self, waiter: &Waiter) {
 		let shared = waiter.shared();
-		let ptr = Arc::as_ptr(shared);
 
-		// Already registered: nothing to do. This is what lets `Park` keep reusing a
-		// still-registered waiter instead of retiring it every poll.
-		if self.entries.iter().any(|entry| std::ptr::eq(entry.as_ptr(), ptr)) {
-			return;
+		match shared.presume(self.id, self.epoch) {
+			// Still registered since the last drain: nothing to do. This is what
+			// lets `Park` keep reusing a still-registered waiter instead of
+			// retiring it every poll.
+			Presence::Present => return,
+
+			// Provably not in the list: straight to the append.
+			Presence::Absent => {}
+
+			// No record either way, so membership needs the scan, except when the
+			// waiter is registered nowhere at all.
+			Presence::Unknown => {
+				if Arc::weak_count(shared) > 0 {
+					let ptr = Arc::as_ptr(shared);
+					if self.entries.iter().any(|entry| std::ptr::eq(entry.as_ptr(), ptr)) {
+						return;
+					}
+				}
+			}
 		}
 
 		let new_weak = Arc::downgrade(shared);
 
 		for _ in 0..self.entries.len().min(2) {
 			if self.entries[self.cursor].strong_count() == 0 {
-				// Reuse the dead slot in place. Each Waiter owns a
-				// unique Arc<Waker>, so strong_count == 0 uniquely
+				// Reuse the dead slot in place. Each Waiter owns a unique
+				// identity allocation, so strong_count == 0 uniquely
 				// identifies a slot whose owner has been dropped.
 				self.entries[self.cursor] = new_weak;
 				return;
@@ -152,17 +242,23 @@ impl WaiterList {
 	/// Drain all entries into a new [`WaiterList`], leaving this one empty.
 	pub fn take(&mut self) -> Self {
 		self.cursor = 0;
+		self.epoch += 1;
 		Self {
 			entries: std::mem::take(&mut self.entries),
 			cursor: 0,
+			// The drained snapshot is only ever woken, never registered with, so it
+			// gets an id of its own rather than impersonating this list.
+			id: NEXT_LIST_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+			epoch: 0,
 		}
 	}
 
 	/// Wake all live waiters, draining the list.
 	pub fn wake(&mut self) {
 		self.cursor = 0;
-		for waker in self.entries.drain(..).filter_map(|w| w.upgrade()) {
-			waker.wake_by_ref();
+		self.epoch += 1;
+		for identity in self.entries.drain(..).filter_map(|w| w.upgrade()) {
+			identity.waker.wake_by_ref();
 		}
 	}
 }
@@ -788,6 +884,46 @@ mod tests {
 		let other = Waiter::new(Waker::noop().clone());
 		other.register(&mut list);
 		assert_eq!(list.entries.len(), 2);
+	}
+
+	#[test]
+	fn dedup_survives_record_eviction() {
+		// More lists than the identity keeps records for: the evicted ones fall back
+		// to the scan, which must still find the registration.
+		let waiter = Waiter::new(Waker::noop().clone());
+		let mut lists: Vec<_> = (0..2 * RECORDED_LISTS).map(|_| WaiterList::new()).collect();
+		for list in &mut lists {
+			waiter.register(list);
+		}
+
+		// Re-registering must not stack anywhere, recorded or evicted alike.
+		for list in lists.iter_mut().rev() {
+			waiter.register(list);
+			assert_eq!(list.entries.len(), 1, "re-registration stacked a duplicate");
+		}
+	}
+
+	#[test]
+	fn a_drain_invalidates_the_record() {
+		let waiter = Waiter::new(Waker::noop().clone());
+		let mut list = WaiterList::new();
+
+		// A wake drains the registration; the stale record must not convince the
+		// next register that it is still present, or its wakeup is lost.
+		waiter.register(&mut list);
+		list.wake();
+		assert_eq!(list.entries.len(), 0);
+		waiter.register(&mut list);
+		assert_eq!(list.entries.len(), 1);
+		assert!(list.entries[0].strong_count() > 0, "the registration must be live");
+
+		// Same for a drain via take.
+		let taken = list.take();
+		assert_eq!(list.entries.len(), 0);
+		drop(taken);
+		waiter.register(&mut list);
+		assert_eq!(list.entries.len(), 1);
+		assert!(list.entries[0].strong_count() > 0, "the registration must be live");
 	}
 
 	#[test]

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -186,10 +186,27 @@ pub struct WaiterList {
 impl WaiterList {
 	/// Create an empty list, allocating nothing until the first [`register`](Self::register).
 	pub fn new() -> Self {
+		// A CAS loop rather than fetch_add, so exhaustion fails closed instead of
+		// wrapping into reissued ids (a reissued id could fake presence). List
+		// creation is cold, and the loop is contention-free in practice.
+		let mut id = NEXT_LIST_ID.load(std::sync::atomic::Ordering::Relaxed);
+		loop {
+			assert_ne!(id, u64::MAX, "waiter list id space exhausted");
+			match NEXT_LIST_ID.compare_exchange_weak(
+				id,
+				id + 1,
+				std::sync::atomic::Ordering::Relaxed,
+				std::sync::atomic::Ordering::Relaxed,
+			) {
+				Ok(_) => break,
+				Err(current) => id = current,
+			}
+		}
+
 		Self {
 			entries: SmallVec::new(),
 			cursor: 0,
-			id: NEXT_LIST_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+			id,
 			epoch: 0,
 		}
 	}

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -111,21 +111,35 @@ impl WaiterList {
 		}
 	}
 
-	/// Register a waiter.
+	/// Register a waiter. Idempotent: a waiter already in the list stays as one entry.
 	///
-	/// Performs a small, bounded amount of garbage collection: probes the
-	/// slot at the rotating cursor, replacing it in place if dead. The
-	/// cursor advances on each append so the probe window covers the
-	/// whole list over time.
+	/// The dedup scan compares allocation addresses only. A `Weak` in the list keeps
+	/// its allocation alive even after the owner drops, so an address can never be
+	/// recycled out from under an entry, and equal pointers always mean the same
+	/// waiter. No refcounts are touched and no foreign cache lines are read, which is
+	/// what makes the steady-state re-register (the hot path) a short scan over
+	/// contiguous memory.
+	///
+	/// A miss also performs a small, bounded amount of garbage collection: probes the
+	/// slot at the rotating cursor, replacing it in place if dead. The cursor advances
+	/// on each append so the probe window covers the whole list over time.
 	pub fn register(&mut self, waiter: &Waiter) {
-		let new_weak = Arc::downgrade(waiter.shared());
+		let shared = waiter.shared();
+		let ptr = Arc::as_ptr(shared);
+
+		// Already registered: nothing to do. This is what lets `Park` keep reusing a
+		// still-registered waiter instead of retiring it every poll.
+		if self.entries.iter().any(|entry| std::ptr::eq(entry.as_ptr(), ptr)) {
+			return;
+		}
+
+		let new_weak = Arc::downgrade(shared);
 
 		for _ in 0..self.entries.len().min(2) {
 			if self.entries[self.cursor].strong_count() == 0 {
 				// Reuse the dead slot in place. Each Waiter owns a
 				// unique Arc<Waker>, so strong_count == 0 uniquely
 				// identifies a slot whose owner has been dropped.
-				// No will_wake / pointer comparison needed.
 				self.entries[self.cursor] = new_weak;
 				return;
 			}
@@ -215,19 +229,18 @@ impl Park {
 	/// (the usual `ready!` on a nested poll) still leaves its registrations live.
 	/// There is no second call to forget.
 	///
-	/// The held waiter is reused when it would wake the same task *and* has no live
-	/// list registrations (the usual case after a wakeup, which drains every entry),
-	/// so a steady-state park allocates nothing. Otherwise it is retired for a fresh
-	/// one: a still-registered waiter must not be registered again, because
-	/// [`WaiterList`] reclaims a slot only once its `Arc` dies, so reusing one with
-	/// live entries would stack duplicates the list could never collect.
+	/// The held waiter is reused whenever it would wake the same task, so a
+	/// steady-state park allocates nothing. Live registrations are no obstacle: a poll
+	/// that waits on several lists is re-woken by one while still parked on the rest,
+	/// and re-registering there is a no-op because [`WaiterList::register`] is
+	/// idempotent. Only a waker for a *different* task retires the waiter, dropping
+	/// its registrations so the lists can reclaim those slots.
 	pub fn hold(&mut self, cx: &Context<'_>) -> &Waiter {
-		let reuse = self.0.as_ref().is_some_and(|waiter| {
-			cx.waker().will_wake(&waiter.waker) && waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0)
-		});
+		let reuse = self
+			.0
+			.as_ref()
+			.is_some_and(|waiter| cx.waker().will_wake(&waiter.waker));
 		if !reuse {
-			// The outgoing waiter drops here, killing its registrations so the lists
-			// can reclaim those slots.
 			self.0 = Some(Waiter::new(cx.waker().clone()));
 		}
 		self.0.as_ref().unwrap()
@@ -729,30 +742,99 @@ mod tests {
 	}
 
 	#[test]
-	fn park_reuses_a_drained_waiter_and_retires_a_registered_one() {
+	fn park_reuses_a_still_registered_waiter() {
 		let waker = Waker::noop().clone();
 		let cx = Context::from_waker(&waker);
 		let mut park = Park::default();
 		let mut list = WaiterList::new();
 
-		// Poll 1 parks with a live registration. Hold the Arc so a pointer comparison
-		// can't alias a recycled allocation.
+		// Poll 1 parks with a live registration.
 		let waiter = park.hold(&cx);
 		waiter.register(&mut list);
 		let first = waiter.shared().clone();
 
-		// Poll 2 with that registration still live must retire the waiter: reusing it
-		// would stack a duplicate entry the list could never reclaim.
+		// Poll 2 with that registration still live (a wake from some other list, say)
+		// reuses the waiter without allocating, and re-registering it dedups rather
+		// than stacking a duplicate.
 		let waiter = park.hold(&cx);
-		assert!(!Arc::ptr_eq(&first, waiter.shared()), "a registered waiter was reused");
+		assert!(
+			Arc::ptr_eq(&first, waiter.shared()),
+			"a still-registered waiter was retired"
+		);
 		waiter.register(&mut list);
-		let second = waiter.shared().clone();
+		assert_eq!(list.entries.len(), 1, "re-registration stacked a duplicate");
 
-		// The wake drains the list, so poll 3 reuses: same task, nothing left to
-		// duplicate, and no allocation.
+		// The wake drains the list; poll 3 reuses the same waiter and registers anew.
 		list.wake();
 		let waiter = park.hold(&cx);
-		assert!(Arc::ptr_eq(&second, waiter.shared()), "a drained waiter was not reused");
+		assert!(Arc::ptr_eq(&first, waiter.shared()), "a drained waiter was not reused");
+		waiter.register(&mut list);
+		assert_eq!(list.entries.len(), 1);
+		assert!(list.entries[0].strong_count() > 0, "the registration must stay live");
+	}
+
+	#[test]
+	fn register_is_idempotent_per_identity() {
+		let mut list = WaiterList::new();
+
+		// Repeat registrations of one identity, directly or via a clone, are one entry.
+		let waiter = Waiter::new(Waker::noop().clone());
+		waiter.register(&mut list);
+		waiter.register(&mut list);
+		waiter.clone().register(&mut list);
+		assert_eq!(list.entries.len(), 1, "one identity must occupy one slot");
+
+		// A distinct waiter is a distinct entry, even for the same task.
+		let other = Waiter::new(Waker::noop().clone());
+		other.register(&mut list);
+		assert_eq!(list.entries.len(), 2);
+	}
+
+	#[test]
+	fn abandoned_waiters_do_not_grow_the_list() {
+		let mut list = WaiterList::new();
+
+		// Register-and-drop, over and over, without a single wake. The rotating probe
+		// must keep reclaiming the dead slots, or the list grows by one per waiter.
+		for _ in 0..1_000 {
+			Waiter::new(Waker::noop().clone()).register(&mut list);
+		}
+		assert!(list.entries.len() <= 2, "the list grew to {}", list.entries.len());
+	}
+
+	/// The steady state this shape exists for: a poll waiting on several lists is
+	/// re-woken by one while still parked on the others, and the re-poll must not
+	/// allocate a new waiter or stack duplicate registrations.
+	#[test]
+	fn a_multi_list_poll_reuses_across_a_partial_wake() {
+		let waker = Waker::noop().clone();
+		let cx = Context::from_waker(&waker);
+		let mut park = Park::default();
+		let mut first = WaiterList::new();
+		let mut second = WaiterList::new();
+
+		// Poll 1 waits on both lists.
+		let waiter = park.hold(&cx);
+		waiter.register(&mut first);
+		waiter.register(&mut second);
+		let shared = waiter.shared().clone();
+
+		// One list wakes; the other still holds a live registration.
+		first.wake();
+
+		// Poll 2 reuses the waiter and re-registers with both: an append into the
+		// drained list, a no-op in the still-parked one.
+		let waiter = park.hold(&cx);
+		assert!(
+			Arc::ptr_eq(&shared, waiter.shared()),
+			"the waiter was retired mid-operation"
+		);
+		waiter.register(&mut first);
+		waiter.register(&mut second);
+
+		assert_eq!(first.entries.len(), 1);
+		assert_eq!(second.entries.len(), 1, "re-registration stacked a duplicate");
+		assert!(second.entries[0].strong_count() > 0, "the registration must stay live");
 	}
 
 	#[test]

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -20,9 +20,10 @@ use crate::{
 const INLINE_WAITERS: usize = 32;
 
 /// Registrations remembered per waiter identity for O(1) dedup. A poll typically
-/// parks on a small handful of lists; overflow falls back to the scan, so this
-/// bounds memory, never correctness.
-const RECORDED_LISTS: usize = 4;
+/// parks on a small handful of lists; a poll cycling through more than this many
+/// evicts its own records and falls back to the scan, so the cap bounds memory,
+/// never correctness.
+const RECORDED_LISTS: usize = 8;
 
 /// The shared identity behind a [`Waiter`], referenced weakly by every list entry.
 struct Identity {
@@ -154,8 +155,16 @@ impl Clone for Waiter {
 }
 
 /// Source of unique [`WaiterList`] ids, so a waiter's recorded registrations can
-/// never confuse two lists (ids are handed out once and never reused).
-static NEXT_LIST_ID: AtomicU64 = AtomicU64::new(0);
+/// never confuse two lists (ids are handed out once and never reused). Exhausting
+/// it would take 2^64 list creations, centuries at one per nanosecond, so wraparound
+/// is unreachable in any process lifetime.
+static NEXT_LIST_ID: AtomicU64 = AtomicU64::new(1);
+
+/// The id of a list that opts out of record-keeping: [`WaiterList::take`] snapshots,
+/// which exist to be woken, not registered with. Never handed out by
+/// [`NEXT_LIST_ID`], so no record can ever match one, and registering into such a
+/// list just uses the scan fallback.
+const UNTRACKED: u64 = 0;
 
 /// A list of weak wakers waiting for notification.
 ///
@@ -202,7 +211,12 @@ impl WaiterList {
 	pub fn register(&mut self, waiter: &Waiter) {
 		let shared = waiter.shared();
 
-		match shared.presume(self.id, self.epoch) {
+		let presence = match self.id {
+			UNTRACKED => Presence::Unknown,
+			id => shared.presume(id, self.epoch),
+		};
+
+		match presence {
 			// Still registered since the last drain: nothing to do. This is what
 			// lets `Park` keep reusing a still-registered waiter instead of
 			// retiring it every poll.
@@ -242,13 +256,15 @@ impl WaiterList {
 	/// Drain all entries into a new [`WaiterList`], leaving this one empty.
 	pub fn take(&mut self) -> Self {
 		self.cursor = 0;
-		self.epoch += 1;
+		self.epoch = self.epoch.checked_add(1).expect("waiter list epoch overflow");
 		Self {
 			entries: std::mem::take(&mut self.entries),
 			cursor: 0,
-			// The drained snapshot is only ever woken, never registered with, so it
-			// gets an id of its own rather than impersonating this list.
-			id: NEXT_LIST_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+			// This runs on every notification, so the snapshot must not touch the
+			// global id counter (a shared cache line across all channels). It is
+			// untracked instead: it exists to be woken, and registering into it
+			// falls back to the scan rather than impersonating this list.
+			id: UNTRACKED,
 			epoch: 0,
 		}
 	}
@@ -256,7 +272,9 @@ impl WaiterList {
 	/// Wake all live waiters, draining the list.
 	pub fn wake(&mut self) {
 		self.cursor = 0;
-		self.epoch += 1;
+		// Fail closed rather than wrap: a wrapped epoch would let a stale record
+		// claim presence. Unreachable in practice (2^64 drains of one list).
+		self.epoch = self.epoch.checked_add(1).expect("waiter list epoch overflow");
 		for identity in self.entries.drain(..).filter_map(|w| w.upgrade()) {
 			identity.waker.wake_by_ref();
 		}
@@ -924,6 +942,25 @@ mod tests {
 		waiter.register(&mut list);
 		assert_eq!(list.entries.len(), 1);
 		assert!(list.entries[0].strong_count() > 0, "the registration must be live");
+	}
+
+	#[test]
+	fn a_taken_snapshot_tracks_nothing() {
+		let waiter = Waiter::new(Waker::noop().clone());
+		let mut list = WaiterList::new();
+		waiter.register(&mut list);
+
+		// The snapshot inherits the entries but no identity of its own, so a
+		// register against it must settle membership by scan: the entry moved with
+		// the snapshot, so this dedups rather than stacking.
+		let mut taken = list.take();
+		waiter.register(&mut taken);
+		assert_eq!(taken.entries.len(), 1, "the snapshot register stacked a duplicate");
+
+		// And a second waiter still gets in; untracked means unproven, not closed.
+		let other = Waiter::new(Waker::noop().clone());
+		other.register(&mut taken);
+		assert_eq!(taken.entries.len(), 2);
 	}
 
 	#[test]

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -30,13 +30,27 @@ struct Identity {
 	/// The task waker the lists deliver to.
 	waker: Waker,
 
-	/// Registrations this identity has made, as `(list id, list epoch)` pairs. A
-	/// pair matching a list's current epoch proves the registration is still in
-	/// place, and a stale pair proves it is gone: live entries only leave through a
-	/// drain, every drain bumps the epoch, and every registration refreshes the
-	/// pair. Either way membership is settled in O(1); only a missing pair (never
-	/// registered, or evicted) needs the scan.
-	recorded: Mutex<SmallVec<[(u64, u64); RECORDED_LISTS]>>,
+	/// Registrations this identity has made. A record matching a list's current
+	/// epoch proves the registration is still in place, and a stale one proves it
+	/// is gone: live entries only leave through a drain, every drain bumps the
+	/// epoch, and every registration refreshes the record. Either way membership is
+	/// settled in O(1); only a missing record (never registered, or evicted) needs
+	/// the scan.
+	recorded: Mutex<Records>,
+}
+
+/// The record table behind an [`Identity`].
+#[derive(Default)]
+struct Records {
+	/// `(list id, list epoch)` pairs, at most [`RECORDED_LISTS`] of them.
+	entries: SmallVec<[(u64, u64); RECORDED_LISTS]>,
+
+	/// State for choosing an eviction victim pseudo-randomly. Deterministic
+	/// policies (FIFO, LRU) evict exactly the next-needed record when a poll
+	/// cycles through more lists than the cap, degrading every registration to the
+	/// scan; a random victim keeps an expected `cap / lists` fraction of hits
+	/// instead.
+	seed: u64,
 }
 
 /// What an identity's records prove about its membership in one list.
@@ -60,7 +74,7 @@ impl Identity {
 	fn presume(&self, id: u64, epoch: u64) -> Presence {
 		let mut recorded = self.recorded.lock().expect("mutex poisoned");
 
-		if let Some(entry) = recorded.iter_mut().find(|entry| entry.0 == id) {
+		if let Some(entry) = recorded.entries.iter_mut().find(|entry| entry.0 == id) {
 			let presence = match entry.1 == epoch {
 				true => Presence::Present,
 				false => Presence::Absent,
@@ -69,11 +83,18 @@ impl Identity {
 			return presence;
 		}
 
-		// Evict the oldest record when full: eviction only costs a scan later.
-		if recorded.len() == RECORDED_LISTS {
-			recorded.remove(0);
+		if recorded.entries.len() < RECORDED_LISTS {
+			recorded.entries.push((id, epoch));
+			return Presence::Unknown;
 		}
-		recorded.push((id, epoch));
+
+		// Evict a pseudo-random record (a Weyl-style step, no external RNG):
+		// eviction only ever costs a scan later, and a random victim avoids the
+		// deterministic worst case where a cyclic visit pattern one list wider
+		// than the cap evicts exactly the record it needs next, every time.
+		recorded.seed = recorded.seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+		let victim = (recorded.seed >> 33) as usize % RECORDED_LISTS;
+		recorded.entries[victim] = (id, epoch);
 		Presence::Unknown
 	}
 }
@@ -129,7 +150,7 @@ impl Waiter {
 		self.shared.get_or_init(|| {
 			Arc::new(Identity {
 				waker: self.waker.clone(),
-				recorded: Mutex::new(SmallVec::new()),
+				recorded: Mutex::new(Records::default()),
 			})
 		})
 	}

--- a/rs/moq-json/Cargo.toml
+++ b/rs/moq-json/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "2"
 tracing = "0.1"
 
 [dev-dependencies]
-criterion = "0.8"
+criterion = { workspace = true }
 
 [[bench]]
 name = "codec"

--- a/rs/moq-net/Cargo.toml
+++ b/rs/moq-net/Cargo.toml
@@ -28,7 +28,7 @@ web-async = { workspace = true }
 web-transport-trait = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.8"
+criterion = { workspace = true }
 serde_json = "1"
 # test-util (tokio::time::pause/advance) is test-only and is NOT supported on
 # wasm, so it must not leak into the normal dependency feature set.


### PR DESCRIPTION
Relay profiling in #2899 put `kio::waiter::WaiterList::register` at 3.53% of self cycles (clean Quinn run), concentrated in Arc/Weak refcount atomics and cache-missing `Weak::strong_count` probes of dead slots. This PR adds the focused benchmarks the issue asked for and removes the mechanism that generates most of that work.

## Root cause

`Park::hold` refused to reuse a waiter that still had live list registrations (`Arc::weak_count > 0`), because re-registering it would stack duplicate entries the list could never reclaim. But a poll that waits on several lists is routinely re-woken by *one* of them while still parked on the rest, so nearly every re-poll hit the retire path: allocate a fresh `Arc<Waker>`, `Arc::downgrade` into every list again, and leave dead `Weak`s behind for later registrations to probe. The profile is that cycle: the downgrade/count atomics on every registration, plus `strong_count` pointer-chases into the dead allocations the cycle itself creates.

## Fix

`WaiterList::register` is now idempotent, so `Park::hold` reuses a still-registered waiter (only a waker for a different task retires it), deleting the per-poll retire/realloc/re-register churn. Idempotency is O(1) via generational records (the issue's direction 3): each list carries a never-reused id and an epoch bumped on every drain, and the waiter's shared identity records `(id, epoch)` for the lists it registers with. A record at the current epoch proves the registration is still in place (live entries only leave through drains); a stale record proves it is gone (every registration refreshes the record), so a rebuild after a wake appends without scanning. Only a missing record (never registered, or evicted past the 8-entry record cap) falls back to a pointer-equality scan, which is exact because a `Weak` pins its allocation's address, and is itself skipped when the waiter is registered nowhere (`weak_count == 0`). The bounded rotating dead-slot probe stays as the reclamation path for abandoned waiters.

An earlier revision of this branch used the scan alone; adversarial review (Codex) and the codex-connector P1 both flagged that as O(N²) per wake cycle at high fan-in, and the fan-out benchmarks below confirmed it. The generational records are the response: registration stays O(1) at any list size. Further review rounds hardened the details: `take()` snapshots are untracked rather than drawing an id, so the per-notification drain path never touches the global id counter (a shared cache line across all channels); the record cap is 8 with pseudo-random eviction (FIFO's worst case, a poll cycling one list wider than the cap, evicts exactly the next-needed record every time) and the correct scan fallback behind it; and both the id allocator and epoch increments fail closed on exhaustion instead of wrapping, since a reissued id or wrapped epoch could fake presence. `park_cycle/16` measures past the cap: ~10ns per list versus ~7.9ns under it.

## Benchmarks

New `cargo bench -p kio` (`rs/kio/benches/waiter.rs`) covering the issue's suggested validation: registration against 1/2/8/32 live waiters, re-registration, mostly-dead lists, cancellation churn, the park/wake/re-register cycle, and fan-out rebuild cycles (single-list, and dual-list where every waiter also stays parked on a never-woken sibling list, as `waiters_value`/`waiters_closed` do). On M-series macOS (`--warm-up-time 1 --measurement-time 2`):

| bench | main | this PR | |
|---|---|---|---|
| `park_cycle/2` (poll on 2 lists, one wakes) | 517 ns | 17 ns | −97% |
| `park_cycle/4` | 611 ns | 29 ns | −95% |
| `reregister/{1,2,8,32}` | 6–10 ns* | ~5.5 ns flat | O(1), no leak |
| `fanout_cycle/512` (drain + rebuild) | quadratic | 6.1 µs, 84 Melem/s | linear |
| `fanout_cycle_parked/512` (dual-list rebuild) | quadratic | 9.1 µs, 57 Melem/s | linear |
| `register_live/{1,2,8,32}` | 76 / 81 / 104 / 142 ns | 64 / 62 / 77 / 90 ns | −16% to −37% |
| `cancel` (register + abandon) | 50 ns | 83 ns | +33 ns† |

\* main's `reregister` numbers look small but are the cost of appending a *duplicate* entry per call, growing the list without bound for as long as the waiter stays parked; the PR's flat ~5.5 ns is one uncontended mutex round-trip on the waiter's own record. Fan-out throughput is flat-to-rising in N for both cycle shapes, where a scan-based dedup measured 12 Melem/s (single) and 6 Melem/s (dual) at N=512.

† the abandon-churn path allocates the identity (which now carries the record table) per waiter; register-and-abandon-without-ever-waking is not a steady state anywhere in the stack, so the flat +33 ns is traded for the O(1) paths above.

## Tests

- Rewrote `park_reuses_a_drained_waiter_and_retires_a_registered_one` as `park_reuses_a_still_registered_waiter` (the old test asserted the retire behavior this PR removes).
- New regression tests: `register_is_idempotent_per_identity`, `a_multi_list_poll_reuses_across_a_partial_wake` (both fail on main), `a_drain_invalidates_the_record` and `dedup_survives_record_eviction` (fail if the generational bookkeeping lies in either direction), and `abandoned_waiters_do_not_grow_the_list` (bounds the list under register-and-abandon churn).
- New loom model `a_reused_waiter_hears_the_drained_list_again`: a waiter parked on two fans is re-woken by one and must hear that fan's *second* wake, so a skipped or falsely-deduplicated re-registration deadlocks the model. Mutation-checked: treating a stale record as present makes the model fail; restoring the code makes the full `just rs loom` suite pass. The model holds its own stable `Waiter` because loom's `block_on` waker fails `will_wake` between polls (const-promoted vtable, duplicated across codegen units in release builds), which silently retires the park every poll and would otherwise leave the reuse path unmodeled.

## Cross-package sync

No wire, API-shape, or doc-surface change: `register` and `hold` keep their signatures, and the idempotency is a strictly wider contract. JS has its own signals implementation, so no `js/` mirror applies. Also hoisted `criterion` to `[workspace.dependencies]` since kio is its third consumer.

Not covered here: re-running the relay `perf` workload from the issue (needs the Linux rig), so this deliberately does not close the issue; it stays open for that measurement and the remaining brainstorm directions.

Refs #2899

(written by Fable 5)

