### PR TITLE
feat(moq-net): add Path::relative, replacing moq_transcode::source_reference

### DIFF
--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -90,7 +90,6 @@ A viewer of `room/transcode` then pulls `480p` from the transcoder and `1080p` d
 
 Publishers author the reference with the inverse operation, so the two stay in step: `Path::relative` in Rust (`moq-net`) and `Path.relative` in TypeScript (`@moq/net`), each taking the target broadcast and the catalog broadcast it is named from.
 Both refuse a target no reference can name, since a path segment may itself be called `.` or `..`.
-A publisher that only wants to point at an enclosing broadcast, rather than into a sibling subtree, can gate on the reference with `PathRelative::is_ancestor` / `Path.isAncestor`.
 
 `@moq/watch` resolves the reference automatically. In Rust, the `moq-mux` exporters do the same: they take a `Source::new(origin, path)`, and both the catalog broadcast and any referenced broadcast resolve through the origin over the same connection.
 

--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -88,7 +88,7 @@ This lets a transcoder publish a sidecar catalog that adds new renditions while 
 For example, a transcoder consuming `room/source` can publish `room/transcode` whose catalog contains a downscaled `480p` rendition plus the original `1080p` rendition marked `"broadcast": "./source"`.
 A viewer of `room/transcode` then pulls `480p` from the transcoder and `1080p` directly from the source, and the relay dedupes the source subscription with the transcoder's own.
 
-Publishers author the reference with the inverse operation, so the two stay in step: `Path::relative_to` in Rust (`moq-net`) and `Path.relativeTo` in TypeScript (`@moq/net`), each taking the target broadcast and the catalog broadcast it is named from.
+Publishers author the reference with the inverse operation, so the two stay in step: `Path::relative` in Rust (`moq-net`) and `Path.relative` in TypeScript (`@moq/net`), each taking the target broadcast and the catalog broadcast it is named from.
 Both refuse a target no reference can name, since a path segment may itself be called `.` or `..`.
 
 `@moq/watch` resolves the reference automatically. In Rust, the `moq-mux` exporters do the same: they take a `Source::new(origin, path)`, and both the catalog broadcast and any referenced broadcast resolve through the origin over the same connection.

--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -90,6 +90,7 @@ A viewer of `room/transcode` then pulls `480p` from the transcoder and `1080p` d
 
 Publishers author the reference with the inverse operation, so the two stay in step: `Path::relative` in Rust (`moq-net`) and `Path.relative` in TypeScript (`@moq/net`), each taking the target broadcast and the catalog broadcast it is named from.
 Both refuse a target no reference can name, since a path segment may itself be called `.` or `..`.
+A publisher that only wants to point at an enclosing broadcast, rather than into a sibling subtree, can gate on the reference with `PathRelative::is_ancestor` / `Path.isAncestor`.
 
 `@moq/watch` resolves the reference automatically. In Rust, the `moq-mux` exporters do the same: they take a `Source::new(origin, path)`, and both the catalog broadcast and any referenced broadcast resolve through the origin over the same connection.
 

--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -88,6 +88,9 @@ This lets a transcoder publish a sidecar catalog that adds new renditions while 
 For example, a transcoder consuming `room/source` can publish `room/transcode` whose catalog contains a downscaled `480p` rendition plus the original `1080p` rendition marked `"broadcast": "./source"`.
 A viewer of `room/transcode` then pulls `480p` from the transcoder and `1080p` directly from the source, and the relay dedupes the source subscription with the transcoder's own.
 
+Publishers author the reference with the inverse operation, so the two stay in step: `Path::relative_to` in Rust (`moq-net`) and `Path.relativeTo` in TypeScript (`@moq/net`), each taking the target broadcast and the catalog broadcast it is named from.
+Both refuse a target no reference can name, since a path segment may itself be called `.` or `..`.
+
 `@moq/watch` resolves the reference automatically. In Rust, the `moq-mux` exporters do the same: they take a `Source::new(origin, path)`, and both the catalog broadcast and any referenced broadcast resolve through the origin over the same connection.
 
 ### Extensions

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -235,6 +235,20 @@ test("relative inverts resolve", () => {
 	expect(Path.relative(Path.empty(), Path.empty())).toBe("");
 });
 
+test("isAncestor tells an enclosing reference from a descending one", () => {
+	expect(Path.isAncestor(".")).toBe(true);
+	expect(Path.isAncestor("..")).toBe(true);
+	expect(Path.isAncestor("../..")).toBe(true);
+	// The empty reference names the base itself, which is not an ancestor of itself.
+	expect(Path.isAncestor("")).toBe(false);
+	expect(Path.isAncestor("./sibling")).toBe(false);
+	expect(Path.isAncestor("../other/deep")).toBe(false);
+
+	// It answers exactly "is the target an ancestor of the base".
+	expect(Path.isAncestor(Path.relative(Path.from("a"), Path.from("a/b")) as string)).toBe(true);
+	expect(Path.isAncestor(Path.relative(Path.from("a/c"), Path.from("a/b")) as string)).toBe(false);
+});
+
 test("relative rejects unnameable targets", () => {
 	// A segment literally named `.` or `..` is a legal path component, but resolution
 	// would walk on it instead of naming it.

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -244,6 +244,12 @@ test("isAncestor tells an enclosing reference from a descending one", () => {
 	expect(Path.isAncestor("./sibling")).toBe(false);
 	expect(Path.isAncestor("../other/deep")).toBe(false);
 
+	// Loose input is normalized first, so this agrees with resolve and with Rust.
+	expect(Path.isAncestor("../")).toBe(true);
+	expect(Path.isAncestor("..//..")).toBe(true);
+	expect(Path.isAncestor("./.")).toBe(true);
+	expect(Path.isAncestor("/")).toBe(false);
+
 	// It answers exactly "is the target an ancestor of the base".
 	expect(Path.isAncestor(Path.relative(Path.from("a"), Path.from("a/b")) as string)).toBe(true);
 	expect(Path.isAncestor(Path.relative(Path.from("a/c"), Path.from("a/b")) as string)).toBe(false);

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -217,6 +217,35 @@ test("resolve excess dotdot clamps at empty", () => {
 	expect(Path.resolve(Path.from("a"), "..")).toBe(Path.from(""));
 });
 
+test("relativeTo inverts resolve", () => {
+	// Nested under the base: the base's own last segment is replaced, so it repeats.
+	expect(Path.relativeTo(Path.from("foo/bar/baz"), Path.from("foo/bar"))).toBe("bar/baz");
+	// Sibling.
+	expect(Path.relativeTo(Path.from("foo/baz"), Path.from("foo/bar"))).toBe("baz");
+	// Different subtree.
+	expect(Path.relativeTo(Path.from("foo/baz/bar"), Path.from("foo/bar/baz"))).toBe("../baz/bar");
+	// The base's parent, which only `.` can name.
+	expect(Path.relativeTo(Path.from("a/b"), Path.from("a/b/transcode.hang"))).toBe(".");
+	expect(Path.relativeTo(Path.from("a/b"), Path.from("a/b/one/two/transcode.hang"))).toBe("../..");
+	// Roots.
+	expect(Path.relativeTo(Path.from("foo/bar"), Path.empty())).toBe("foo/bar");
+	expect(Path.relativeTo(Path.empty(), Path.from("foo"))).toBe(".");
+	expect(Path.relativeTo(Path.empty(), Path.empty())).toBe(".");
+});
+
+test("relativeTo round trips through resolve", () => {
+	const paths = ["", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z"].map((p) => Path.from(p));
+
+	for (const base of paths) {
+		for (const target of paths) {
+			const rel = Path.relativeTo(target, base);
+			expect(Path.resolve(base, rel)).toBe(target);
+			// The reference is derived from a real target, so it never escapes the root.
+			expect(Path.tryResolve(base, rel)).toBe(target);
+		}
+	}
+});
+
 test("resolve with empty base", () => {
 	expect(Path.resolve(Path.empty(), "foo")).toBe(Path.from("foo"));
 	expect(Path.resolve(Path.empty(), "..")).toBe(Path.from(""));

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -233,12 +233,31 @@ test("relativeTo inverts resolve", () => {
 	expect(Path.relativeTo(Path.empty(), Path.empty())).toBe(".");
 });
 
+test("relativeTo rejects unnameable targets", () => {
+	// A segment literally named `.` or `..` is a legal path component, but resolution
+	// would walk on it instead of naming it.
+	expect(Path.relativeTo(Path.from("a/../b"), Path.empty())).toBeUndefined();
+	expect(Path.relativeTo(Path.from("x/./y"), Path.from("x/z"))).toBeUndefined();
+	expect(Path.relativeTo(Path.from("a/.."), Path.from("a/b"))).toBeUndefined();
+
+	// Dot segments inside the shared prefix are never emitted, so they are fine.
+	const rel = Path.relativeTo(Path.from("a/../b/x"), Path.from("a/../b/c"));
+	expect(rel).toBe("x");
+	expect(Path.resolve(Path.from("a/../b/c"), rel as string)).toBe(Path.from("a/../b/x"));
+});
+
 test("relativeTo round trips through resolve", () => {
-	const paths = ["", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z"].map((p) => Path.from(p));
+	const paths = ["", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z", "a/../b", "a/./b"].map((p) => Path.from(p));
 
 	for (const base of paths) {
 		for (const target of paths) {
 			const rel = Path.relativeTo(target, base);
+			if (rel === undefined) {
+				// Only an unnameable target may be refused.
+				expect(target.split("/").some((part) => part === "." || part === "..")).toBe(true);
+				continue;
+			}
+
 			expect(Path.resolve(base, rel)).toBe(target);
 			// The reference is derived from a real target, so it never escapes the root.
 			expect(Path.tryResolve(base, rel)).toBe(target);

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -235,26 +235,6 @@ test("relative inverts resolve", () => {
 	expect(Path.relative(Path.empty(), Path.empty())).toBe("");
 });
 
-test("isAncestor tells an enclosing reference from a descending one", () => {
-	expect(Path.isAncestor(".")).toBe(true);
-	expect(Path.isAncestor("..")).toBe(true);
-	expect(Path.isAncestor("../..")).toBe(true);
-	// The empty reference names the base itself, which is not an ancestor of itself.
-	expect(Path.isAncestor("")).toBe(false);
-	expect(Path.isAncestor("./sibling")).toBe(false);
-	expect(Path.isAncestor("../other/deep")).toBe(false);
-
-	// Loose input is normalized first, so this agrees with resolve and with Rust.
-	expect(Path.isAncestor("../")).toBe(true);
-	expect(Path.isAncestor("..//..")).toBe(true);
-	expect(Path.isAncestor("./.")).toBe(true);
-	expect(Path.isAncestor("/")).toBe(false);
-
-	// It answers exactly "is the target an ancestor of the base".
-	expect(Path.isAncestor(Path.relative(Path.from("a"), Path.from("a/b")) as string)).toBe(true);
-	expect(Path.isAncestor(Path.relative(Path.from("a/c"), Path.from("a/b")) as string)).toBe(false);
-});
-
 test("relative rejects unnameable targets", () => {
 	// A segment literally named `.` or `..` is a legal path component, but resolution
 	// would walk on it instead of naming it.

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -217,48 +217,48 @@ test("resolve excess dotdot clamps at empty", () => {
 	expect(Path.resolve(Path.from("a"), "..")).toBe(Path.from(""));
 });
 
-test("relativeTo inverts resolve", () => {
+test("relative inverts resolve", () => {
 	// Nested under the base: the base's own last segment is replaced, so it repeats.
-	expect(Path.relativeTo(Path.from("foo/bar/baz"), Path.from("foo/bar"))).toBe("bar/baz");
+	expect(Path.relative(Path.from("foo/bar/baz"), Path.from("foo/bar"))).toBe("bar/baz");
 	// Sibling.
-	expect(Path.relativeTo(Path.from("foo/baz"), Path.from("foo/bar"))).toBe("baz");
+	expect(Path.relative(Path.from("foo/baz"), Path.from("foo/bar"))).toBe("baz");
 	// Different subtree.
-	expect(Path.relativeTo(Path.from("foo/baz/bar"), Path.from("foo/bar/baz"))).toBe("../baz/bar");
+	expect(Path.relative(Path.from("foo/baz/bar"), Path.from("foo/bar/baz"))).toBe("../baz/bar");
 	// The base's parent, which only `.` can name.
-	expect(Path.relativeTo(Path.from("a/b"), Path.from("a/b/transcode.hang"))).toBe(".");
-	expect(Path.relativeTo(Path.from("a/b"), Path.from("a/b/one/two/transcode.hang"))).toBe("../..");
+	expect(Path.relative(Path.from("a/b"), Path.from("a/b/transcode.hang"))).toBe(".");
+	expect(Path.relative(Path.from("a/b"), Path.from("a/b/one/two/transcode.hang"))).toBe("../..");
 	// Roots.
-	expect(Path.relativeTo(Path.from("foo/bar"), Path.empty())).toBe("foo/bar");
-	expect(Path.relativeTo(Path.empty(), Path.from("foo"))).toBe(".");
+	expect(Path.relative(Path.from("foo/bar"), Path.empty())).toBe("foo/bar");
+	expect(Path.relative(Path.empty(), Path.from("foo"))).toBe(".");
 	// The base itself, which only the empty reference names.
-	expect(Path.relativeTo(Path.from("a/b"), Path.from("a/b"))).toBe("");
-	expect(Path.relativeTo(Path.empty(), Path.empty())).toBe("");
+	expect(Path.relative(Path.from("a/b"), Path.from("a/b"))).toBe("");
+	expect(Path.relative(Path.empty(), Path.empty())).toBe("");
 });
 
-test("relativeTo rejects unnameable targets", () => {
+test("relative rejects unnameable targets", () => {
 	// A segment literally named `.` or `..` is a legal path component, but resolution
 	// would walk on it instead of naming it.
-	expect(Path.relativeTo(Path.from("a/../b"), Path.empty())).toBeUndefined();
-	expect(Path.relativeTo(Path.from("x/./y"), Path.from("x/z"))).toBeUndefined();
-	expect(Path.relativeTo(Path.from("a/.."), Path.from("a/b"))).toBeUndefined();
+	expect(Path.relative(Path.from("a/../b"), Path.empty())).toBeUndefined();
+	expect(Path.relative(Path.from("x/./y"), Path.from("x/z"))).toBeUndefined();
+	expect(Path.relative(Path.from("a/.."), Path.from("a/b"))).toBeUndefined();
 
 	// A base is always nameable by itself, however its last segment is spelled.
-	expect(Path.relativeTo(Path.from("a/.."), Path.from("a/.."))).toBe("");
+	expect(Path.relative(Path.from("a/.."), Path.from("a/.."))).toBe("");
 
 	// Dot segments inside the shared prefix are never emitted, so they are fine.
-	const rel = Path.relativeTo(Path.from("a/../b/x"), Path.from("a/../b/c"));
+	const rel = Path.relative(Path.from("a/../b/x"), Path.from("a/../b/c"));
 	expect(rel).toBe("x");
 	expect(Path.resolve(Path.from("a/../b/c"), rel as string)).toBe(Path.from("a/../b/x"));
 });
 
-test("relativeTo round trips through resolve", () => {
+test("relative round trips through resolve", () => {
 	const paths = ["", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z", "a/../b", "a/./b", "a/..", "a/."].map((p) =>
 		Path.from(p),
 	);
 
 	for (const base of paths) {
 		for (const target of paths) {
-			const rel = Path.relativeTo(target, base);
+			const rel = Path.relative(target, base);
 			if (rel === undefined) {
 				// Only an unnameable target may be refused, and never the base itself.
 				expect(target !== base && target.split("/").some((part) => part === "." || part === "..")).toBe(true);

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -230,7 +230,9 @@ test("relativeTo inverts resolve", () => {
 	// Roots.
 	expect(Path.relativeTo(Path.from("foo/bar"), Path.empty())).toBe("foo/bar");
 	expect(Path.relativeTo(Path.empty(), Path.from("foo"))).toBe(".");
-	expect(Path.relativeTo(Path.empty(), Path.empty())).toBe(".");
+	// The base itself, which only the empty reference names.
+	expect(Path.relativeTo(Path.from("a/b"), Path.from("a/b"))).toBe("");
+	expect(Path.relativeTo(Path.empty(), Path.empty())).toBe("");
 });
 
 test("relativeTo rejects unnameable targets", () => {
@@ -240,6 +242,9 @@ test("relativeTo rejects unnameable targets", () => {
 	expect(Path.relativeTo(Path.from("x/./y"), Path.from("x/z"))).toBeUndefined();
 	expect(Path.relativeTo(Path.from("a/.."), Path.from("a/b"))).toBeUndefined();
 
+	// A base is always nameable by itself, however its last segment is spelled.
+	expect(Path.relativeTo(Path.from("a/.."), Path.from("a/.."))).toBe("");
+
 	// Dot segments inside the shared prefix are never emitted, so they are fine.
 	const rel = Path.relativeTo(Path.from("a/../b/x"), Path.from("a/../b/c"));
 	expect(rel).toBe("x");
@@ -247,14 +252,16 @@ test("relativeTo rejects unnameable targets", () => {
 });
 
 test("relativeTo round trips through resolve", () => {
-	const paths = ["", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z", "a/../b", "a/./b"].map((p) => Path.from(p));
+	const paths = ["", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z", "a/../b", "a/./b", "a/..", "a/."].map((p) =>
+		Path.from(p),
+	);
 
 	for (const base of paths) {
 		for (const target of paths) {
 			const rel = Path.relativeTo(target, base);
 			if (rel === undefined) {
-				// Only an unnameable target may be refused.
-				expect(target.split("/").some((part) => part === "." || part === "..")).toBe(true);
+				// Only an unnameable target may be refused, and never the base itself.
+				expect(target !== base && target.split("/").some((part) => part === "." || part === "..")).toBe(true);
 				continue;
 			}
 

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -265,6 +265,8 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
  * A relative reference replaces the last segment of the base, matching relative URL
  * resolution, so a target nested under the base repeats the base's own last segment.
  *
+ * The empty reference names the base itself, so that is what a self-reference returns.
+ *
  * Returns `undefined` for a target no reference can name: a path segment may literally be
  * `.` or `..`, which resolution reads as navigation instead of as a name. Only the segments
  * past the shared prefix matter, since the rest are never emitted.
@@ -277,10 +279,15 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
  * Path.relativeTo(Path.from("a/b/c"), Path.from("a/b")); // "b/c"
  * Path.relativeTo(Path.from("a/c"), Path.from("a/b"));   // "c"
  * Path.relativeTo(Path.from("a"), Path.from("a/b"));     // "."
+ * Path.relativeTo(Path.from("a/b"), Path.from("a/b"));   // ""
  * Path.relativeTo(Path.from("a/.."), Path.from("a/b"));  // undefined
  * ```
  */
 export function relativeTo(target: Valid, base: Valid): string | undefined {
+	// Only the empty reference can name a base whose last segment is itself `.` or `..`,
+	// since resolution replaces that segment rather than emitting it.
+	if (target === base) return "";
+
 	// Resolution replaces the base's last segment, so walk from its parent.
 	const dir = base === "" ? [] : base.split("/");
 	dir.pop();

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -255,3 +255,42 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
 
 	return segments.join("/") as Valid;
 }
+
+/**
+ * Express `target` relative to `base`: the inverse of {@link resolve}.
+ *
+ * The result always round-trips (`resolve(base, relativeTo(target, base)) === target`)
+ * and never walks above the root, so {@link tryResolve} accepts it too.
+ *
+ * A relative reference replaces the last segment of the base, matching relative URL
+ * resolution, so a target nested under the base repeats the base's own last segment.
+ *
+ * Mirrors the Rust `Path::relative_to`, used to author the cross-broadcast track
+ * references a hang catalog carries.
+ *
+ * @example
+ * ```typescript
+ * Path.relativeTo(Path.from("a/b/c"), Path.from("a/b")); // "b/c"
+ * Path.relativeTo(Path.from("a/c"), Path.from("a/b"));   // "c"
+ * Path.relativeTo(Path.from("a"), Path.from("a/b"));     // "."
+ * ```
+ */
+export function relativeTo(target: Valid, base: Valid): string {
+	// Resolution replaces the base's last segment, so walk from its parent.
+	const dir = base === "" ? [] : base.split("/");
+	dir.pop();
+
+	const parts = target === "" ? [] : target.split("/");
+
+	let common = 0;
+	while (common < dir.length && common < parts.length && dir[common] === parts[common]) {
+		common += 1;
+	}
+
+	const rel = Array(dir.length - common)
+		.fill("..")
+		.concat(parts.slice(common));
+
+	// An empty reference resolves to the base itself, so name the parent explicitly.
+	return rel.length === 0 ? "." : rel.join("/");
+}

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -264,7 +264,8 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
  * so it is not an ancestor. Resolution clamps at the root, so a reference with more `..` than
  * the base has segments still lands on the root.
  *
- * Mirrors the Rust `PathRelative::is_ancestor`.
+ * Mirrors the Rust `PathRelative::is_ancestor`. The reference is normalized first, since
+ * Rust normalizes on construction and {@link resolve} accepts the same loose input.
  *
  * @example
  * ```typescript
@@ -274,7 +275,8 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
  * ```
  */
 export function isAncestor(rel: string): boolean {
-	return rel !== "" && rel.split("/").every((seg) => seg === "." || seg === "..");
+	const normalized = normalizeRelative(rel);
+	return normalized !== "" && normalized.split("/").every((seg) => seg === "." || seg === "..");
 }
 
 /**

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -259,7 +259,7 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
 /**
  * Express `target` relative to `base`: the inverse of {@link resolve}.
  *
- * The result round-trips (`resolve(base, relativeTo(target, base)) === target`) and never
+ * The result round-trips (`resolve(base, relative(target, base)) === target`) and never
  * walks above the root, so {@link tryResolve} accepts it too.
  *
  * A relative reference replaces the last segment of the base, matching relative URL
@@ -271,19 +271,20 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
  * `.` or `..`, which resolution reads as navigation instead of as a name. Only the segments
  * past the shared prefix matter, since the rest are never emitted.
  *
- * Mirrors the Rust `Path::relative_to`, used to author the cross-broadcast track
- * references a hang catalog carries.
+ * Mirrors the Rust `Path::relative`, used to author the cross-broadcast track
+ * references a hang catalog carries. Note the argument order: the target comes first,
+ * the opposite of Node's `path.relative(from, to)`.
  *
  * @example
  * ```typescript
- * Path.relativeTo(Path.from("a/b/c"), Path.from("a/b")); // "b/c"
- * Path.relativeTo(Path.from("a/c"), Path.from("a/b"));   // "c"
- * Path.relativeTo(Path.from("a"), Path.from("a/b"));     // "."
- * Path.relativeTo(Path.from("a/b"), Path.from("a/b"));   // ""
- * Path.relativeTo(Path.from("a/.."), Path.from("a/b"));  // undefined
+ * Path.relative(Path.from("a/b/c"), Path.from("a/b")); // "b/c"
+ * Path.relative(Path.from("a/c"), Path.from("a/b"));   // "c"
+ * Path.relative(Path.from("a"), Path.from("a/b"));     // "."
+ * Path.relative(Path.from("a/b"), Path.from("a/b"));   // ""
+ * Path.relative(Path.from("a/.."), Path.from("a/b"));  // undefined
  * ```
  */
-export function relativeTo(target: Valid, base: Valid): string | undefined {
+export function relative(target: Valid, base: Valid): string | undefined {
 	// Only the empty reference can name a base whose last segment is itself `.` or `..`,
 	// since resolution replaces that segment rather than emitting it.
 	if (target === base) return "";

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -259,11 +259,15 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
 /**
  * Express `target` relative to `base`: the inverse of {@link resolve}.
  *
- * The result always round-trips (`resolve(base, relativeTo(target, base)) === target`)
- * and never walks above the root, so {@link tryResolve} accepts it too.
+ * The result round-trips (`resolve(base, relativeTo(target, base)) === target`) and never
+ * walks above the root, so {@link tryResolve} accepts it too.
  *
  * A relative reference replaces the last segment of the base, matching relative URL
  * resolution, so a target nested under the base repeats the base's own last segment.
+ *
+ * Returns `undefined` for a target no reference can name: a path segment may literally be
+ * `.` or `..`, which resolution reads as navigation instead of as a name. Only the segments
+ * past the shared prefix matter, since the rest are never emitted.
  *
  * Mirrors the Rust `Path::relative_to`, used to author the cross-broadcast track
  * references a hang catalog carries.
@@ -273,9 +277,10 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
  * Path.relativeTo(Path.from("a/b/c"), Path.from("a/b")); // "b/c"
  * Path.relativeTo(Path.from("a/c"), Path.from("a/b"));   // "c"
  * Path.relativeTo(Path.from("a"), Path.from("a/b"));     // "."
+ * Path.relativeTo(Path.from("a/.."), Path.from("a/b"));  // undefined
  * ```
  */
-export function relativeTo(target: Valid, base: Valid): string {
+export function relativeTo(target: Valid, base: Valid): string | undefined {
 	// Resolution replaces the base's last segment, so walk from its parent.
 	const dir = base === "" ? [] : base.split("/");
 	dir.pop();
@@ -287,9 +292,13 @@ export function relativeTo(target: Valid, base: Valid): string {
 		common += 1;
 	}
 
+	const down = parts.slice(common);
+	// Resolution would walk on these instead of naming them.
+	if (down.some((part) => part === "." || part === "..")) return undefined;
+
 	const rel = Array(dir.length - common)
 		.fill("..")
-		.concat(parts.slice(common));
+		.concat(down);
 
 	// An empty reference resolves to the base itself, so name the parent explicitly.
 	return rel.length === 0 ? "." : rel.join("/");

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -257,6 +257,27 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
 }
 
 /**
+ * Whether a relative reference names an ancestor of its base rather than descending
+ * somewhere else.
+ *
+ * True when every segment walks up (`.` or `..`). The empty reference names the base itself,
+ * so it is not an ancestor. Resolution clamps at the root, so a reference with more `..` than
+ * the base has segments still lands on the root.
+ *
+ * Mirrors the Rust `PathRelative::is_ancestor`.
+ *
+ * @example
+ * ```typescript
+ * Path.isAncestor("..");        // true
+ * Path.isAncestor("./sibling"); // false
+ * Path.isAncestor("");          // false, that names the base itself
+ * ```
+ */
+export function isAncestor(rel: string): boolean {
+	return rel !== "" && rel.split("/").every((seg) => seg === "." || seg === "..");
+}
+
+/**
  * Express `target` relative to `base`: the inverse of {@link resolve}.
  *
  * The result round-trips (`resolve(base, relative(target, base)) === target`) and never

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -257,29 +257,6 @@ export function tryResolve(base: Valid, rel: string): Valid | undefined {
 }
 
 /**
- * Whether a relative reference names an ancestor of its base rather than descending
- * somewhere else.
- *
- * True when every segment walks up (`.` or `..`). The empty reference names the base itself,
- * so it is not an ancestor. Resolution clamps at the root, so a reference with more `..` than
- * the base has segments still lands on the root.
- *
- * Mirrors the Rust `PathRelative::is_ancestor`. The reference is normalized first, since
- * Rust normalizes on construction and {@link resolve} accepts the same loose input.
- *
- * @example
- * ```typescript
- * Path.isAncestor("..");        // true
- * Path.isAncestor("./sibling"); // false
- * Path.isAncestor("");          // false, that names the base itself
- * ```
- */
-export function isAncestor(rel: string): boolean {
-	const normalized = normalizeRelative(rel);
-	return normalized !== "" && normalized.split("/").every((seg) => seg === "." || seg === "..");
-}
-
-/**
  * Express `target` relative to `base`: the inverse of {@link resolve}.
  *
  * The result round-trips (`resolve(base, relative(target, base)) === target`) and never

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -140,10 +140,10 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 	// Reference the source renditions only when the output nests beneath the source, so a
 	// player that can reach the output can reach the source too. Otherwise the derivative
 	// catalog advertises the rungs alone.
-	config.source = output_path
-		.strip_prefix(&source_path)
-		.is_some_and(|rest| !rest.is_empty())
-		.then(|| source_path.relative_to(&output_path));
+	config.source = match output_path.strip_prefix(&source_path) {
+		Some(rest) if !rest.is_empty() => source_path.relative_to(&output_path),
+		_ => None,
+	};
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -137,9 +137,13 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		name => moq_video::decode::Kind::Named(name.to_string()),
 	};
 	config.resize.acceleration = args.resize_acceleration;
-	// Reference the source renditions relatively when the output nests under it;
-	// otherwise the derivative catalog advertises only the rungs.
-	config.source = moq_transcode::source_reference(&source_path, &output_path);
+	// Reference the source renditions only when the output nests beneath the source, so a
+	// player that can reach the output can reach the source too. Otherwise the derivative
+	// catalog advertises the rungs alone.
+	config.source = output_path
+		.strip_prefix(&source_path)
+		.is_some_and(|rest| !rest.is_empty())
+		.then(|| source_path.relative_to(&output_path));
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -141,7 +141,7 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 	// player that can reach the output can reach the source too. Otherwise the derivative
 	// catalog advertises the rungs alone.
 	config.source = match output_path.strip_prefix(&source_path) {
-		Some(rest) if !rest.is_empty() => source_path.relative_to(&output_path),
+		Some(rest) if !rest.is_empty() => source_path.relative(&output_path),
 		_ => None,
 	};
 

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -140,10 +140,7 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 	// Reference the source renditions only when the output nests beneath the source, so a
 	// player that can reach the output can reach the source too. Otherwise the derivative
 	// catalog advertises the rungs alone.
-	config.source = match output_path.strip_prefix(&source_path) {
-		Some(rest) if !rest.is_empty() => source_path.relative(&output_path),
-		_ => None,
-	};
+	config.source = source_path.relative(&output_path).filter(|rel| rel.is_ancestor());
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -137,10 +137,10 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		name => moq_video::decode::Kind::Named(name.to_string()),
 	};
 	config.resize.acceleration = args.resize_acceleration;
-	// Reference the source renditions only when the output nests beneath the source, so a
-	// player that can reach the output can reach the source too. Otherwise the derivative
-	// catalog advertises the rungs alone.
-	config.source = source_path.relative(&output_path).filter(|rel| rel.is_ancestor());
+	// Point the derivative catalog at the source renditions so players fetch them from the
+	// source directly. An empty reference would name the derivative broadcast itself, which
+	// publishes the rungs and nothing else.
+	config.source = source_path.relative(&output_path).filter(|rel| !rel.is_empty());
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -1632,6 +1632,12 @@ mod tests {
 		assert!(!PathRelative::new("./sibling").is_ancestor());
 		assert!(!PathRelative::new("../other/deep").is_ancestor());
 
+		// Loose input is normalized on construction, so this agrees with resolve.
+		assert!(PathRelative::new("../").is_ancestor());
+		assert!(PathRelative::new("..//..").is_ancestor());
+		assert!(PathRelative::new("./.").is_ancestor());
+		assert!(!PathRelative::new("/").is_ancestor());
+
 		// It answers exactly "is the target an ancestor of the base", so a caller can gate on
 		// the reference instead of re-deriving the relationship from the two paths.
 		for (target, base) in [("a", "a/b"), ("a/b", "a/b/c/d"), ("", "a")] {

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -412,6 +412,8 @@ impl<'a> Path<'a> {
 	/// A relative reference replaces the last segment of the base, matching relative URL
 	/// resolution, so a target nested under the base repeats the base's own last segment.
 	///
+	/// The empty reference names the base itself, so that is what a self-reference returns.
+	///
 	/// Returns `None` for a target no reference can name: a path segment may literally be
 	/// `.` or `..`, which resolution reads as navigation instead of as a name. Only the
 	/// segments past the shared prefix matter, since the rest are never emitted.
@@ -429,11 +431,20 @@ impl<'a> Path<'a> {
 	/// // The lone `.` names the base's parent, which the empty reference cannot.
 	/// assert_eq!(Path::new("a").relative_to(&base).unwrap().as_str(), ".");
 	///
+	/// // The base itself.
+	/// assert_eq!(Path::new("a/b").relative_to(&base).unwrap().as_str(), "");
+	///
 	/// // A segment named `..` is a legal path component but an unnameable target.
 	/// assert!(Path::new("a/..").relative_to(&base).is_none());
 	/// ```
 	pub fn relative_to(&self, base: impl AsPath) -> Option<PathRelativeOwned> {
 		let base = base.as_path();
+
+		// Only the empty reference can name a base whose last segment is itself `.` or `..`,
+		// since resolution replaces that segment rather than emitting it.
+		if *self == base {
+			return Some(PathRelative::empty());
+		}
 
 		// Resolution replaces the base's last segment, so walk from its parent.
 		let mut dir: Vec<&str> = base.parts().collect();
@@ -1564,7 +1575,9 @@ mod tests {
 		// Roots.
 		assert_eq!(rel("foo/bar", "").as_str(), "foo/bar");
 		assert_eq!(rel("", "foo").as_str(), ".");
-		assert_eq!(rel("", "").as_str(), ".");
+		// The base itself, which only the empty reference names.
+		assert_eq!(rel("a/b", "a/b").as_str(), "");
+		assert_eq!(rel("", "").as_str(), "");
 		// Slashes are normalized first.
 		assert_eq!(rel("/a//b/", "//a/b/dir//").as_str(), ".");
 	}
@@ -1577,6 +1590,9 @@ mod tests {
 		assert!(Path::new("x/./y").relative_to("x/z").is_none());
 		assert!(Path::new("a/..").relative_to("a/b").is_none());
 
+		// A base is always nameable by itself, however its last segment is spelled.
+		assert_eq!(Path::new("a/..").relative_to("a/..").unwrap().as_str(), "");
+
 		// Dot segments inside the shared prefix are never emitted, so they are fine.
 		let rel = Path::new("a/../b/x").relative_to("a/../b/c").unwrap();
 		assert_eq!(rel.as_str(), "x");
@@ -1586,7 +1602,7 @@ mod tests {
 	#[test]
 	fn test_relative_to_round_trips() {
 		let paths = [
-			"", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z", "a/../b", "a/./b",
+			"", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z", "a/../b", "a/./b", "a/..", "a/.",
 		];
 
 		for base in paths {
@@ -1594,9 +1610,9 @@ mod tests {
 				let base = Path::new(base);
 				let target = Path::new(target);
 				let Some(rel) = target.relative_to(&base) else {
-					// Only an unnameable target may be refused.
+					// Only an unnameable target may be refused, and never the base itself.
 					assert!(
-						target.parts().any(|part| part == "." || part == ".."),
+						target != base && target.parts().any(|part| part == "." || part == ".."),
 						"{base} -> {target} refused a nameable target"
 					);
 					continue;

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -656,6 +656,29 @@ impl<'a> PathRelative<'a> {
 	pub fn borrow(&'a self) -> PathRelative<'a> {
 		PathRelative(Cow::Borrowed(&self.0))
 	}
+
+	/// Whether this reference names an ancestor of its base rather than descending
+	/// somewhere else.
+	///
+	/// True when every segment walks up (`.` or `..`). The empty reference names the base
+	/// itself, so it is not an ancestor. Resolution clamps at the root, so a reference with
+	/// more `..` than the base has segments still lands on the root.
+	///
+	/// # Examples
+	/// ```
+	/// use moq_net::{Path, PathRelative};
+	///
+	/// // A broadcast published beneath another names it by walking up.
+	/// let rel = Path::new("room").relative("room/transcode.hang").unwrap();
+	/// assert!(rel.is_ancestor());
+	///
+	/// // A sibling subtree does not.
+	/// let rel = Path::new("other").relative("room/transcode.hang").unwrap();
+	/// assert!(!rel.is_ancestor());
+	/// ```
+	pub fn is_ancestor(&self) -> bool {
+		!self.is_empty() && self.0.split('/').all(|seg| seg == "." || seg == "..")
+	}
 }
 
 impl<'a> From<&'a str> for PathRelative<'a> {
@@ -1597,6 +1620,28 @@ mod tests {
 		let rel = Path::new("a/../b/x").relative("a/../b/c").unwrap();
 		assert_eq!(rel.as_str(), "x");
 		assert_eq!(Path::new("a/../b/c").resolve(&rel).as_str(), "a/../b/x");
+	}
+
+	#[test]
+	fn test_relative_is_ancestor() {
+		assert!(PathRelative::new(".").is_ancestor());
+		assert!(PathRelative::new("..").is_ancestor());
+		assert!(PathRelative::new("../..").is_ancestor());
+		// The empty reference names the base itself, which is not an ancestor of itself.
+		assert!(!PathRelative::empty().is_ancestor());
+		assert!(!PathRelative::new("./sibling").is_ancestor());
+		assert!(!PathRelative::new("../other/deep").is_ancestor());
+
+		// It answers exactly "is the target an ancestor of the base", so a caller can gate on
+		// the reference instead of re-deriving the relationship from the two paths.
+		for (target, base) in [("a", "a/b"), ("a/b", "a/b/c/d"), ("", "a")] {
+			let rel = Path::new(target).relative(base).unwrap();
+			assert!(rel.is_ancestor(), "{target} is an ancestor of {base}, got {rel}");
+		}
+		for (target, base) in [("a/c", "a/b"), ("a/b", "a/b"), ("x", "a/b")] {
+			let rel = Path::new(target).relative(base).unwrap();
+			assert!(!rel.is_ancestor(), "{target} is not an ancestor of {base}, got {rel}");
+		}
 	}
 
 	#[test]

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -656,29 +656,6 @@ impl<'a> PathRelative<'a> {
 	pub fn borrow(&'a self) -> PathRelative<'a> {
 		PathRelative(Cow::Borrowed(&self.0))
 	}
-
-	/// Whether this reference names an ancestor of its base rather than descending
-	/// somewhere else.
-	///
-	/// True when every segment walks up (`.` or `..`). The empty reference names the base
-	/// itself, so it is not an ancestor. Resolution clamps at the root, so a reference with
-	/// more `..` than the base has segments still lands on the root.
-	///
-	/// # Examples
-	/// ```
-	/// use moq_net::{Path, PathRelative};
-	///
-	/// // A broadcast published beneath another names it by walking up.
-	/// let rel = Path::new("room").relative("room/transcode.hang").unwrap();
-	/// assert!(rel.is_ancestor());
-	///
-	/// // A sibling subtree does not.
-	/// let rel = Path::new("other").relative("room/transcode.hang").unwrap();
-	/// assert!(!rel.is_ancestor());
-	/// ```
-	pub fn is_ancestor(&self) -> bool {
-		!self.is_empty() && self.0.split('/').all(|seg| seg == "." || seg == "..")
-	}
 }
 
 impl<'a> From<&'a str> for PathRelative<'a> {
@@ -1620,34 +1597,6 @@ mod tests {
 		let rel = Path::new("a/../b/x").relative("a/../b/c").unwrap();
 		assert_eq!(rel.as_str(), "x");
 		assert_eq!(Path::new("a/../b/c").resolve(&rel).as_str(), "a/../b/x");
-	}
-
-	#[test]
-	fn test_relative_is_ancestor() {
-		assert!(PathRelative::new(".").is_ancestor());
-		assert!(PathRelative::new("..").is_ancestor());
-		assert!(PathRelative::new("../..").is_ancestor());
-		// The empty reference names the base itself, which is not an ancestor of itself.
-		assert!(!PathRelative::empty().is_ancestor());
-		assert!(!PathRelative::new("./sibling").is_ancestor());
-		assert!(!PathRelative::new("../other/deep").is_ancestor());
-
-		// Loose input is normalized on construction, so this agrees with resolve.
-		assert!(PathRelative::new("../").is_ancestor());
-		assert!(PathRelative::new("..//..").is_ancestor());
-		assert!(PathRelative::new("./.").is_ancestor());
-		assert!(!PathRelative::new("/").is_ancestor());
-
-		// It answers exactly "is the target an ancestor of the base", so a caller can gate on
-		// the reference instead of re-deriving the relationship from the two paths.
-		for (target, base) in [("a", "a/b"), ("a/b", "a/b/c/d"), ("", "a")] {
-			let rel = Path::new(target).relative(base).unwrap();
-			assert!(rel.is_ancestor(), "{target} is an ancestor of {base}, got {rel}");
-		}
-		for (target, base) in [("a/c", "a/b"), ("a/b", "a/b"), ("x", "a/b")] {
-			let rel = Path::new(target).relative(base).unwrap();
-			assert!(!rel.is_ancestor(), "{target} is not an ancestor of {base}, got {rel}");
-		}
 	}
 
 	#[test]

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -403,6 +403,48 @@ impl<'a> Path<'a> {
 			}))
 		}
 	}
+
+	/// Express this path relative to `base`: the inverse of [`Path::resolve`].
+	///
+	/// The result always round-trips (`base.resolve(&target.relative_to(base)) == target`)
+	/// and never walks above the root, so [`Path::try_resolve`] accepts it too.
+	///
+	/// A relative reference replaces the last segment of the base, matching relative URL
+	/// resolution, so a target nested under the base repeats the base's own last segment.
+	///
+	/// # Examples
+	/// ```
+	/// use moq_net::Path;
+	///
+	/// // The base names a broadcast, so its last segment is replaced, not descended into.
+	/// let base = Path::new("a/b");
+	/// assert_eq!(Path::new("a/b/c").relative_to(&base).as_str(), "b/c");
+	/// assert_eq!(Path::new("a/c").relative_to(&base).as_str(), "c");
+	/// assert_eq!(Path::new("c").relative_to(&base).as_str(), "../c");
+	///
+	/// // The lone `.` names the base's parent, which the empty reference cannot.
+	/// assert_eq!(Path::new("a").relative_to(&base).as_str(), ".");
+	/// ```
+	pub fn relative_to(&self, base: impl AsPath) -> PathRelativeOwned {
+		let base = base.as_path();
+
+		// Resolution replaces the base's last segment, so walk from its parent.
+		let mut dir: Vec<&str> = base.parts().collect();
+		dir.pop();
+
+		let target: Vec<&str> = self.parts().collect();
+		let common = dir.iter().zip(&target).take_while(|(a, b)| a == b).count();
+
+		let mut rel: Vec<&str> = vec![".."; dir.len() - common];
+		rel.extend(&target[common..]);
+
+		if rel.is_empty() {
+			// An empty reference resolves to the base itself, so name the parent explicitly.
+			return PathRelative::new(".");
+		}
+
+		PathRelativeOwned::from(rel.join("/"))
+	}
 }
 
 // Comparisons, ordering, and hashing all go through `as_str()` so a borrowed and a
@@ -1491,5 +1533,50 @@ mod tests {
 		let nested = Path::new("a/b");
 		assert_eq!(nested.try_resolve(&PathRelative::new("..")).unwrap().as_str(), "");
 		assert!(nested.try_resolve(&PathRelative::new("../..")).is_none());
+	}
+
+	#[test]
+	fn test_relative_to() {
+		// Nested under the base: the base's own last segment is replaced, so it repeats.
+		assert_eq!(Path::new("foo/bar/baz").relative_to("foo/bar").as_str(), "bar/baz");
+		// Sibling.
+		assert_eq!(Path::new("foo/baz").relative_to("foo/bar").as_str(), "baz");
+		// Different subtree.
+		assert_eq!(
+			Path::new("foo/baz/bar").relative_to("foo/bar/baz").as_str(),
+			"../baz/bar"
+		);
+		// The base's parent, which only `.` can name.
+		assert_eq!(Path::new("a/b").relative_to("a/b/transcode.hang").as_str(), ".");
+		assert_eq!(
+			Path::new("a/b").relative_to("a/b/one/two/transcode.hang").as_str(),
+			"../.."
+		);
+		// Roots.
+		assert_eq!(Path::new("foo/bar").relative_to("").as_str(), "foo/bar");
+		assert_eq!(Path::new("").relative_to("foo").as_str(), ".");
+		assert_eq!(Path::new("").relative_to("").as_str(), ".");
+		// Slashes are normalized first.
+		assert_eq!(Path::new("/a//b/").relative_to("//a/b/dir//").as_str(), ".");
+	}
+
+	#[test]
+	fn test_relative_to_round_trips() {
+		let paths = ["", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z"];
+
+		for base in paths {
+			for target in paths {
+				let base = Path::new(base);
+				let target = Path::new(target);
+				let rel = target.relative_to(&base);
+
+				assert_eq!(base.resolve(&rel), target, "{base} -> {target} via {rel}");
+				// The reference is derived from a real target, so it never escapes the root.
+				assert!(
+					base.try_resolve(&rel).is_some(),
+					"{base} -> {target} via {rel} escaped the root"
+				);
+			}
+		}
 	}
 }

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -406,11 +406,15 @@ impl<'a> Path<'a> {
 
 	/// Express this path relative to `base`: the inverse of [`Path::resolve`].
 	///
-	/// The result always round-trips (`base.resolve(&target.relative_to(base)) == target`)
-	/// and never walks above the root, so [`Path::try_resolve`] accepts it too.
+	/// The result round-trips (`base.resolve(&rel) == self`) and never walks above the
+	/// root, so [`Path::try_resolve`] accepts it too.
 	///
 	/// A relative reference replaces the last segment of the base, matching relative URL
 	/// resolution, so a target nested under the base repeats the base's own last segment.
+	///
+	/// Returns `None` for a target no reference can name: a path segment may literally be
+	/// `.` or `..`, which resolution reads as navigation instead of as a name. Only the
+	/// segments past the shared prefix matter, since the rest are never emitted.
 	///
 	/// # Examples
 	/// ```
@@ -418,14 +422,17 @@ impl<'a> Path<'a> {
 	///
 	/// // The base names a broadcast, so its last segment is replaced, not descended into.
 	/// let base = Path::new("a/b");
-	/// assert_eq!(Path::new("a/b/c").relative_to(&base).as_str(), "b/c");
-	/// assert_eq!(Path::new("a/c").relative_to(&base).as_str(), "c");
-	/// assert_eq!(Path::new("c").relative_to(&base).as_str(), "../c");
+	/// assert_eq!(Path::new("a/b/c").relative_to(&base).unwrap().as_str(), "b/c");
+	/// assert_eq!(Path::new("a/c").relative_to(&base).unwrap().as_str(), "c");
+	/// assert_eq!(Path::new("c").relative_to(&base).unwrap().as_str(), "../c");
 	///
 	/// // The lone `.` names the base's parent, which the empty reference cannot.
-	/// assert_eq!(Path::new("a").relative_to(&base).as_str(), ".");
+	/// assert_eq!(Path::new("a").relative_to(&base).unwrap().as_str(), ".");
+	///
+	/// // A segment named `..` is a legal path component but an unnameable target.
+	/// assert!(Path::new("a/..").relative_to(&base).is_none());
 	/// ```
-	pub fn relative_to(&self, base: impl AsPath) -> PathRelativeOwned {
+	pub fn relative_to(&self, base: impl AsPath) -> Option<PathRelativeOwned> {
 		let base = base.as_path();
 
 		// Resolution replaces the base's last segment, so walk from its parent.
@@ -435,15 +442,21 @@ impl<'a> Path<'a> {
 		let target: Vec<&str> = self.parts().collect();
 		let common = dir.iter().zip(&target).take_while(|(a, b)| a == b).count();
 
+		let down = &target[common..];
+		if down.iter().any(|part| *part == "." || *part == "..") {
+			// Resolution would walk on these instead of naming them.
+			return None;
+		}
+
 		let mut rel: Vec<&str> = vec![".."; dir.len() - common];
-		rel.extend(&target[common..]);
+		rel.extend(down);
 
 		if rel.is_empty() {
 			// An empty reference resolves to the base itself, so name the parent explicitly.
-			return PathRelative::new(".");
+			return Some(PathRelative::new("."));
 		}
 
-		PathRelativeOwned::from(rel.join("/"))
+		Some(PathRelativeOwned::from(rel.join("/")))
 	}
 }
 
@@ -1537,38 +1550,57 @@ mod tests {
 
 	#[test]
 	fn test_relative_to() {
+		let rel = |target: &str, base: &str| Path::new(target).relative_to(base).unwrap();
+
 		// Nested under the base: the base's own last segment is replaced, so it repeats.
-		assert_eq!(Path::new("foo/bar/baz").relative_to("foo/bar").as_str(), "bar/baz");
+		assert_eq!(rel("foo/bar/baz", "foo/bar").as_str(), "bar/baz");
 		// Sibling.
-		assert_eq!(Path::new("foo/baz").relative_to("foo/bar").as_str(), "baz");
+		assert_eq!(rel("foo/baz", "foo/bar").as_str(), "baz");
 		// Different subtree.
-		assert_eq!(
-			Path::new("foo/baz/bar").relative_to("foo/bar/baz").as_str(),
-			"../baz/bar"
-		);
+		assert_eq!(rel("foo/baz/bar", "foo/bar/baz").as_str(), "../baz/bar");
 		// The base's parent, which only `.` can name.
-		assert_eq!(Path::new("a/b").relative_to("a/b/transcode.hang").as_str(), ".");
-		assert_eq!(
-			Path::new("a/b").relative_to("a/b/one/two/transcode.hang").as_str(),
-			"../.."
-		);
+		assert_eq!(rel("a/b", "a/b/transcode.hang").as_str(), ".");
+		assert_eq!(rel("a/b", "a/b/one/two/transcode.hang").as_str(), "../..");
 		// Roots.
-		assert_eq!(Path::new("foo/bar").relative_to("").as_str(), "foo/bar");
-		assert_eq!(Path::new("").relative_to("foo").as_str(), ".");
-		assert_eq!(Path::new("").relative_to("").as_str(), ".");
+		assert_eq!(rel("foo/bar", "").as_str(), "foo/bar");
+		assert_eq!(rel("", "foo").as_str(), ".");
+		assert_eq!(rel("", "").as_str(), ".");
 		// Slashes are normalized first.
-		assert_eq!(Path::new("/a//b/").relative_to("//a/b/dir//").as_str(), ".");
+		assert_eq!(rel("/a//b/", "//a/b/dir//").as_str(), ".");
+	}
+
+	#[test]
+	fn test_relative_to_rejects_unnameable_targets() {
+		// A segment literally named `.` or `..` is a legal path component, but resolution
+		// would walk on it instead of naming it.
+		assert!(Path::new("a/../b").relative_to("").is_none());
+		assert!(Path::new("x/./y").relative_to("x/z").is_none());
+		assert!(Path::new("a/..").relative_to("a/b").is_none());
+
+		// Dot segments inside the shared prefix are never emitted, so they are fine.
+		let rel = Path::new("a/../b/x").relative_to("a/../b/c").unwrap();
+		assert_eq!(rel.as_str(), "x");
+		assert_eq!(Path::new("a/../b/c").resolve(&rel).as_str(), "a/../b/x");
 	}
 
 	#[test]
 	fn test_relative_to_round_trips() {
-		let paths = ["", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z"];
+		let paths = [
+			"", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z", "a/../b", "a/./b",
+		];
 
 		for base in paths {
 			for target in paths {
 				let base = Path::new(base);
 				let target = Path::new(target);
-				let rel = target.relative_to(&base);
+				let Some(rel) = target.relative_to(&base) else {
+					// Only an unnameable target may be refused.
+					assert!(
+						target.parts().any(|part| part == "." || part == ".."),
+						"{base} -> {target} refused a nameable target"
+					);
+					continue;
+				};
 
 				assert_eq!(base.resolve(&rel), target, "{base} -> {target} via {rel}");
 				// The reference is derived from a real target, so it never escapes the root.

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -424,20 +424,20 @@ impl<'a> Path<'a> {
 	///
 	/// // The base names a broadcast, so its last segment is replaced, not descended into.
 	/// let base = Path::new("a/b");
-	/// assert_eq!(Path::new("a/b/c").relative_to(&base).unwrap().as_str(), "b/c");
-	/// assert_eq!(Path::new("a/c").relative_to(&base).unwrap().as_str(), "c");
-	/// assert_eq!(Path::new("c").relative_to(&base).unwrap().as_str(), "../c");
+	/// assert_eq!(Path::new("a/b/c").relative(&base).unwrap().as_str(), "b/c");
+	/// assert_eq!(Path::new("a/c").relative(&base).unwrap().as_str(), "c");
+	/// assert_eq!(Path::new("c").relative(&base).unwrap().as_str(), "../c");
 	///
 	/// // The lone `.` names the base's parent, which the empty reference cannot.
-	/// assert_eq!(Path::new("a").relative_to(&base).unwrap().as_str(), ".");
+	/// assert_eq!(Path::new("a").relative(&base).unwrap().as_str(), ".");
 	///
 	/// // The base itself.
-	/// assert_eq!(Path::new("a/b").relative_to(&base).unwrap().as_str(), "");
+	/// assert_eq!(Path::new("a/b").relative(&base).unwrap().as_str(), "");
 	///
 	/// // A segment named `..` is a legal path component but an unnameable target.
-	/// assert!(Path::new("a/..").relative_to(&base).is_none());
+	/// assert!(Path::new("a/..").relative(&base).is_none());
 	/// ```
-	pub fn relative_to(&self, base: impl AsPath) -> Option<PathRelativeOwned> {
+	pub fn relative(&self, base: impl AsPath) -> Option<PathRelativeOwned> {
 		let base = base.as_path();
 
 		// Only the empty reference can name a base whose last segment is itself `.` or `..`,
@@ -1560,8 +1560,8 @@ mod tests {
 	}
 
 	#[test]
-	fn test_relative_to() {
-		let rel = |target: &str, base: &str| Path::new(target).relative_to(base).unwrap();
+	fn test_relative() {
+		let rel = |target: &str, base: &str| Path::new(target).relative(base).unwrap();
 
 		// Nested under the base: the base's own last segment is replaced, so it repeats.
 		assert_eq!(rel("foo/bar/baz", "foo/bar").as_str(), "bar/baz");
@@ -1583,24 +1583,24 @@ mod tests {
 	}
 
 	#[test]
-	fn test_relative_to_rejects_unnameable_targets() {
+	fn test_relative_rejects_unnameable_targets() {
 		// A segment literally named `.` or `..` is a legal path component, but resolution
 		// would walk on it instead of naming it.
-		assert!(Path::new("a/../b").relative_to("").is_none());
-		assert!(Path::new("x/./y").relative_to("x/z").is_none());
-		assert!(Path::new("a/..").relative_to("a/b").is_none());
+		assert!(Path::new("a/../b").relative("").is_none());
+		assert!(Path::new("x/./y").relative("x/z").is_none());
+		assert!(Path::new("a/..").relative("a/b").is_none());
 
 		// A base is always nameable by itself, however its last segment is spelled.
-		assert_eq!(Path::new("a/..").relative_to("a/..").unwrap().as_str(), "");
+		assert_eq!(Path::new("a/..").relative("a/..").unwrap().as_str(), "");
 
 		// Dot segments inside the shared prefix are never emitted, so they are fine.
-		let rel = Path::new("a/../b/x").relative_to("a/../b/c").unwrap();
+		let rel = Path::new("a/../b/x").relative("a/../b/c").unwrap();
 		assert_eq!(rel.as_str(), "x");
 		assert_eq!(Path::new("a/../b/c").resolve(&rel).as_str(), "a/../b/x");
 	}
 
 	#[test]
-	fn test_relative_to_round_trips() {
+	fn test_relative_round_trips() {
 		let paths = [
 			"", "a", "b", "a/b", "a/c", "a/b/c", "a/b/c/d", "x/y/z", "a/../b", "a/./b", "a/..", "a/.",
 		];
@@ -1609,7 +1609,7 @@ mod tests {
 			for target in paths {
 				let base = Path::new(base);
 				let target = Path::new(target);
-				let Some(rel) = target.relative_to(&base) else {
+				let Some(rel) = target.relative(&base) else {
 					// Only an unnameable target may be refused, and never the base itself.
 					assert!(
 						target != base && target.parts().any(|part| part == "." || part == ".."),

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -80,10 +80,7 @@ async fn main() -> anyhow::Result<()> {
 	// Reference the source renditions only when the output nests beneath the source, so a
 	// player that can reach the output can reach the source too. Otherwise the derivative
 	// catalog advertises the rungs alone.
-	config.source = match output_path.strip_prefix(&source_path) {
-		Some(rest) if !rest.is_empty() => source_path.relative(&output_path),
-		_ => None,
-	};
+	config.source = source_path.relative(&output_path).filter(|rel| rel.is_ancestor());
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
 	// player that can reach the output can reach the source too. Otherwise the derivative
 	// catalog advertises the rungs alone.
 	config.source = match output_path.strip_prefix(&source_path) {
-		Some(rest) if !rest.is_empty() => source_path.relative_to(&output_path),
+		Some(rest) if !rest.is_empty() => source_path.relative(&output_path),
 		_ => None,
 	};
 

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -74,10 +74,16 @@ async fn main() -> anyhow::Result<()> {
 		.await
 		.context("source broadcast unavailable")?;
 
+	// The default ladder and encoder (hardware first: NVENC on Linux) apply.
 	let mut config = moq_transcode::Config::default();
-	// Reference the source when the normalized output is nested beneath it. The
-	// default ladder and encoder (hardware first: NVENC on Linux) apply.
-	config.source = moq_transcode::source_reference(&source_path, &output_path);
+
+	// Reference the source renditions only when the output nests beneath the source, so a
+	// player that can reach the output can reach the source too. Otherwise the derivative
+	// catalog advertises the rungs alone.
+	config.source = output_path
+		.strip_prefix(&source_path)
+		.is_some_and(|rest| !rest.is_empty())
+		.then(|| source_path.relative_to(&output_path));
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -77,10 +77,10 @@ async fn main() -> anyhow::Result<()> {
 	// The default ladder and encoder (hardware first: NVENC on Linux) apply.
 	let mut config = moq_transcode::Config::default();
 
-	// Reference the source renditions only when the output nests beneath the source, so a
-	// player that can reach the output can reach the source too. Otherwise the derivative
-	// catalog advertises the rungs alone.
-	config.source = source_path.relative(&output_path).filter(|rel| rel.is_ancestor());
+	// Point the derivative catalog at the source renditions so players fetch them from the
+	// source directly. An empty reference would name the derivative broadcast itself, which
+	// publishes the rungs and nothing else.
+	config.source = source_path.relative(&output_path).filter(|rel| !rel.is_empty());
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -80,10 +80,10 @@ async fn main() -> anyhow::Result<()> {
 	// Reference the source renditions only when the output nests beneath the source, so a
 	// player that can reach the output can reach the source too. Otherwise the derivative
 	// catalog advertises the rungs alone.
-	config.source = output_path
-		.strip_prefix(&source_path)
-		.is_some_and(|rest| !rest.is_empty())
-		.then(|| source_path.relative_to(&output_path));
+	config.source = match output_path.strip_prefix(&source_path) {
+		Some(rest) if !rest.is_empty() => source_path.relative_to(&output_path),
+		_ => None,
+	};
 
 	let output = publish
 		.create_broadcast(&output_path, moq_net::broadcast::Route::new().with_announce(true))

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -1,6 +1,21 @@
 //! Transcoder configuration: the rung ladder and catalog wiring.
 
-use moq_net::PathRelativeOwned;
+use moq_net::{AsPath, PathRelativeOwned};
+
+// Superseded by `moq_net::Path::relative_to` plus the caller's own nesting check, which is
+// what the moq-cli verb and the example now do. Kept as a hidden shim so an external caller
+// keeps compiling; drop it on the next `dev` cycle.
+#[doc(hidden)]
+#[deprecated(note = "use moq_net::Path::relative_to, guarded by your own nesting check")]
+pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<PathRelativeOwned> {
+	let source = source.as_path();
+	let output = output.as_path();
+	if output.strip_prefix(&source)?.is_empty() {
+		return None;
+	}
+
+	source.relative_to(&output)
+}
 
 /// One candidate output rendition: a target resolution (by height) and bitrate.
 ///
@@ -77,5 +92,27 @@ impl Default for Config {
 			decoder: moq_video::decode::Kind::default(),
 			resize: moq_video::resize::Config::default(),
 		}
+	}
+}
+
+#[cfg(test)]
+#[allow(deprecated)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn source_reference_normalizes_and_counts_output_depth() {
+		assert_eq!(source_reference("a/b", "a/b/transcode.hang").unwrap().as_str(), ".");
+		assert_eq!(source_reference("/a//b/", "a/b/dir/").unwrap().as_str(), ".");
+		assert_eq!(
+			source_reference("a/b", "a/b/dir/transcode.hang").unwrap().as_str(),
+			".."
+		);
+		assert_eq!(
+			source_reference("a/b", "a/b/one/two/transcode.hang").unwrap().as_str(),
+			"../.."
+		);
+		assert!(source_reference("a/b", "other/transcode.hang").is_none());
+		assert!(source_reference("a/b", "a/b").is_none());
 	}
 }

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -6,21 +6,17 @@ use moq_net::{AsPath, PathRelativeOwned};
 ///
 /// Both paths are normalized before comparison. Returns `None` when `output` is
 /// not a descendant of `source`, so callers can omit passthrough renditions.
+///
+/// This is [`moq_net::Path::relative_to`] plus that nesting policy; reach for the
+/// path method directly to reference a source anywhere in the namespace.
 pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<PathRelativeOwned> {
 	let source = source.as_path();
 	let output = output.as_path();
-	let rest = output.strip_prefix(&source)?;
-	if rest.is_empty() {
+	if output.strip_prefix(&source)?.is_empty() {
 		return None;
 	}
 
-	let parents = rest.parts().count().saturating_sub(1);
-	let rel = if parents == 0 {
-		".".to_string()
-	} else {
-		vec![".."; parents].join("/")
-	};
-	Some(PathRelativeOwned::from(rel))
+	Some(source.relative_to(&output))
 }
 
 /// One candidate output rendition: a target resolution (by height) and bitrate.

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -2,9 +2,6 @@
 
 use moq_net::{AsPath, PathRelativeOwned};
 
-// Superseded by `moq_net::Path::relative_to` plus the caller's own nesting check, which is
-// what the moq-cli verb and the example now do. Kept as a hidden shim so an external caller
-// keeps compiling; drop it on the next `dev` cycle.
 #[doc(hidden)]
 #[deprecated(note = "use moq_net::Path::relative_to, guarded by your own nesting check")]
 pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<PathRelativeOwned> {

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -3,7 +3,7 @@
 use moq_net::{AsPath, PathRelativeOwned};
 
 #[doc(hidden)]
-#[deprecated(note = "use moq_net::Path::relative_to, guarded by your own nesting check")]
+#[deprecated(note = "use moq_net::Path::relative, guarded by your own nesting check")]
 pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<PathRelativeOwned> {
 	let source = source.as_path();
 	let output = output.as_path();
@@ -11,7 +11,7 @@ pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<Path
 		return None;
 	}
 
-	source.relative_to(&output)
+	source.relative(&output)
 }
 
 /// One candidate output rendition: a target resolution (by height) and bitrate.

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -3,9 +3,15 @@
 use moq_net::{AsPath, PathRelativeOwned};
 
 #[doc(hidden)]
-#[deprecated(note = "use moq_net::Path::relative, filtered with PathRelative::is_ancestor")]
+#[deprecated(note = "use moq_net::Path::relative")]
 pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<PathRelativeOwned> {
-	source.as_path().relative(output).filter(|rel| rel.is_ancestor())
+	let source = source.as_path();
+	let output = output.as_path();
+	if output.strip_prefix(&source)?.is_empty() {
+		return None;
+	}
+
+	source.relative(&output)
 }
 
 /// One candidate output rendition: a target resolution (by height) and bitrate.

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -3,15 +3,9 @@
 use moq_net::{AsPath, PathRelativeOwned};
 
 #[doc(hidden)]
-#[deprecated(note = "use moq_net::Path::relative, guarded by your own nesting check")]
+#[deprecated(note = "use moq_net::Path::relative, filtered with PathRelative::is_ancestor")]
 pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<PathRelativeOwned> {
-	let source = source.as_path();
-	let output = output.as_path();
-	if output.strip_prefix(&source)?.is_empty() {
-		return None;
-	}
-
-	source.relative(&output)
+	source.as_path().relative(output).filter(|rel| rel.is_ancestor())
 }
 
 /// One candidate output rendition: a target resolution (by height) and bitrate.

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -1,23 +1,6 @@
 //! Transcoder configuration: the rung ladder and catalog wiring.
 
-use moq_net::{AsPath, PathRelativeOwned};
-
-/// Compute the source broadcast reference for an output nested beneath it.
-///
-/// Both paths are normalized before comparison. Returns `None` when `output` is
-/// not a descendant of `source`, so callers can omit passthrough renditions.
-///
-/// This is [`moq_net::Path::relative_to`] plus that nesting policy; reach for the
-/// path method directly to reference a source anywhere in the namespace.
-pub fn source_reference(source: impl AsPath, output: impl AsPath) -> Option<PathRelativeOwned> {
-	let source = source.as_path();
-	let output = output.as_path();
-	if output.strip_prefix(&source)?.is_empty() {
-		return None;
-	}
-
-	Some(source.relative_to(&output))
-}
+use moq_net::PathRelativeOwned;
 
 /// One candidate output rendition: a target resolution (by height) and bitrate.
 ///
@@ -94,26 +77,5 @@ impl Default for Config {
 			decoder: moq_video::decode::Kind::default(),
 			resize: moq_video::resize::Config::default(),
 		}
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn source_reference_normalizes_and_counts_output_depth() {
-		assert_eq!(source_reference("a/b", "a/b/transcode.hang").unwrap().as_str(), ".");
-		assert_eq!(source_reference("/a//b/", "a/b/dir/").unwrap().as_str(), ".");
-		assert_eq!(
-			source_reference("a/b", "a/b/dir/transcode.hang").unwrap().as_str(),
-			".."
-		);
-		assert_eq!(
-			source_reference("a/b", "a/b/one/two/transcode.hang").unwrap().as_str(),
-			"../.."
-		);
-		assert!(source_reference("a/b", "other/transcode.hang").is_none());
-		assert!(source_reference("a/b", "a/b").is_none());
 	}
 }

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -28,6 +28,9 @@ mod feed;
 mod rung;
 
 pub use config::{Config, Rung};
+
+#[allow(deprecated)]
+pub use config::source_reference;
 pub use error::Error;
 
 /// Transcode `source` into `output` until the source broadcast ends.

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -27,7 +27,7 @@ mod error;
 mod feed;
 mod rung;
 
-pub use config::{Config, Rung, source_reference};
+pub use config::{Config, Rung};
 pub use error::Error;
 
 /// Transcode `source` into `output` until the source broadcast ends.


### PR DESCRIPTION
## Summary

Requested by a user: access `moq_transcode::source_reference` without pulling in the rest of `moq-transcode`, since the whole encode/decode stack is a lot to depend on for relative-path resolution.

- Adds `Path::relative(&self, base)` to `moq-net`, next to `Path::resolve`. It's the inverse: `base.resolve(&rel) == target`. `moq-net` is where it belongs rather than a new crate, since `resolve` is the only thing that defines what a relative reference means here (it replaces the base's last segment, URL-style), and callers already depend on `moq-net` for `AsPath`/`PathRelativeOwned`.
- It returns `Option`, but not for the reason `source_reference` did. Some targets are genuinely unnameable: `Path::new` normalizes slashes only, so a path segment may literally be `.` or `..`, and resolution reads those as navigation. `a/../b` relative to the root would emit `a/../b`, which resolves back to `b` (caught by Codex review). `None` covers exactly that case; segments inside the shared prefix are never emitted, so they still work, and a base is always nameable by itself.
- A self-reference returns the empty reference (`base.resolve("") == base`), which is the canonical same-broadcast form, rather than repeating the base's last segment.
- **Behavior change:** the transcoder now references the source renditions wherever the source lives, not only when the output nests beneath it. That rule came from the old `strip_prefix` implementation, which could only express downward nesting; a reference across subtrees (`../../room/alice`) resolves just as well. Only the self-reference is excluded, since an empty reference names the derivative broadcast itself, which publishes the rungs and nothing else. The whole policy is now `source.relative(&output).filter(|rel| !rel.is_empty())`.
- `moq_transcode::source_reference` keeps working, now `#[doc(hidden)] #[deprecated]`. Its body is the nesting check plus `relative`, so there is one implementation of the path math and the dead name stays off docs.rs. The two in-repo callers (`moq-cli`'s transcode verb and the example) no longer use it: they spell out the policy it encoded, with the reason, where the decision belongs. Only reference the source renditions when the output nests beneath them, so a player that can reach the output can reach the source too.
- One semantic worth flagging, documented on the method: a target *below* the base repeats the base's own last segment (`a/b/c` relative to `a/b` is `b/c`), and a lone `.` is preserved because it names the base's parent, which the empty reference cannot.
- Mirrored in `js/net` as `Path.relative`, per the Cross-Package Sync row for `rs/moq-net` API changes. `js/net/src/path.ts` already mirrors `resolve`/`tryResolve`/`normalizeRelative` byte-for-byte, and the JS publish side authors the same catalog references.
- `doc/concept/layer/hang.md` documented consumer-side resolution but not how a publisher authors the reference; the "Cross-broadcast renditions" section now names both helpers.

No wire format change, so no draft update.

## Public API changes

- **Added** `moq_net::Path::relative(&self, base: impl AsPath) -> Option<PathRelativeOwned>`.
- **Added** `Path.relative(target, base): string | undefined` in `@moq/net`.
- **Deprecated (not removed)** `moq_transcode::source_reference`: same signature, same behavior, now hidden. Nothing breaks, so this stays on `main`; deleting it belongs in a `dev` cycle whenever you want it gone.

## Test plan

- `just check` (clippy `-D warnings` across the changed crates and dependents, plus the wasm target) clean.
- `just test`: 2596 Rust tests, 402 `@moq/net` tests, 0 failures.
- `test_relative` covers nesting, siblings, different subtrees, both empty roots, and slash normalization. `test_relative_rejects_unnameable_targets` covers the dot-segment cases, including that a dot segment inside the shared prefix still round-trips.
- `test_relative_round_trips` exhaustively checks every ordered pair of 12 sample paths (including `a/../b`, `a/./b`, `a/..` and `a/.`), asserting `base.resolve(&rel) == target`, that `try_resolve` accepts it (the result never escapes above the root, since it emits at most `dir.len()` `..` segments), and that a refusal only ever happens for a target carrying a dot segment that is not the base itself.
- `source_reference`'s own regression test is retained, so the deprecated path stays covered. It keeps the old nesting rule, which the live call sites no longer apply, so the deprecated entry point still behaves exactly as its callers compiled against.
- Matching JS tests mirror the new Rust ones, so the two implementations are pinned to the same strings.
- Doctests on the new method run under `just rs doctest`.

(Written by Opus 5)



