### PR TITLE
fix(moq-net): keep an anonymous publisher's source across a NAMESPACE update

### DIFF
--- a/drafts/draft-lcurley-moq-cluster.md
+++ b/drafts/draft-lcurley-moq-cluster.md
@@ -104,11 +104,11 @@ It is used for an endpoint that did not negotiate this extension, and an endpoin
 Because any number of endpoints can be 0, it identifies nothing, which constrains all three uses:
 
 - **Loop detection**: 0 in a HOP_PATH is never a loop. A receiver whose own Hop ID is 0 cannot detect loops through itself, and MUST NOT discard an advertisement merely because the path contains 0.
-- **Origin identity**: an advertisement whose first entry is 0 has an unknown origin. A receiver MUST NOT treat two such advertisements as interchangeable ({{selection}}).
+- **Origin identity**: an advertisement whose first entry is 0 has an unknown origin. A receiver MUST NOT treat two such advertisements as interchangeable ({{selection}}). Updating one advertisement is not two ({{updating}}).
 - **Filtering**: a peer that declared 0 excludes nothing, so the sender applies no filter to that session.
 
 Duplicate *non-zero* Hop IDs in one HOP_PATH are a loop; duplicate zeros are not.
-Declaring 0 therefore trades loop detection, failover, and update continuity ({{updating}}) for anonymity.
+Declaring 0 therefore trades loop detection and failover for anonymity.
 
 
 # Namespace Advertisements {#namespace}
@@ -192,7 +192,10 @@ In {{moqt}} an advertisement lives for the lifetime of its stream, so an update 
 An endpoint MUST NOT open a second stream for a namespace it already advertises on this session.
 
 Replacement is atomic, so a receiver MUST NOT tear down subscriptions or drop cached state merely because an update arrived.
-What it means for existing subscriptions follows the first HOP_PATH entry ({{selection}}): unchanged and non-zero, the content is continuous and subscriptions MAY resume on the new route at a group boundary; changed or 0 ({{zero}}), a different publisher may have taken over and they do not carry over.
+What it means for existing subscriptions follows the first HOP_PATH entry ({{selection}}): unchanged, the content is continuous and subscriptions MAY resume on the new route at a group boundary; changed, a different publisher has taken over and they do not carry over.
+
+This is the one comparison 0 ({{zero}}) does not decide: it identifies nothing, but there is one advertisement here and the stream carrying it is the continuity.
+An endpoint whose publisher did change MUST withdraw the advertisement (NAMESPACE_DONE or PUBLISH_NAMESPACE_DONE) and advertise again rather than update in place.
 
 The expected case is a ROUTE_COST-only change, which is how a relay signals that it started or stopped carrying the namespace.
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -124,13 +124,30 @@ struct Advertised {
 	/// The original publisher: the first entry of HOP_PATH. Two advertisements that
 	/// share a non-zero one carry interchangeable content, so a new path splices in.
 	/// A different one, or `Some(Origin::UNKNOWN)` (which identifies nothing), is a
-	/// distinct publisher reusing the namespace and must not splice.
+	/// distinct publisher reusing the namespace and must not splice. That comparison
+	/// only applies between separate advertisements; see [`Arrival`].
 	///
 	/// `None` when the advertisement carried no path, so there is no identity to
 	/// compare and nothing ever replaces the source on identity grounds. That covers
 	/// base moq-transport entirely: PUBLISH_NAMESPACE and NAMESPACE for one namespace
 	/// are then two messages describing a single source, not two publishers.
 	publisher: Option<crate::Origin>,
+}
+
+/// How an advertisement relates to whatever already holds the path.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Arrival {
+	/// A separate advertisement for a path another one already holds: a
+	/// PUBLISH_NAMESPACE alongside a NAMESPACE. Nothing links the two but the publisher
+	/// identity, so only a matching, real one proves they carry the same content.
+	Separate,
+
+	/// A repeat of the advertisement already holding the path, on the stream that
+	/// carries it. That stream is the continuity: the peer never retracted the
+	/// advertisement, so only a *changed* publisher is a new publisher. The expected
+	/// repeat is a repricing, and a peer that withholds its identity reprices as often
+	/// as any other.
+	Repeat,
 }
 
 #[derive(Clone)]
@@ -876,7 +893,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	fn start_announce(&mut self, path: PathOwned, advert: Advertised) -> Result<broadcast::Producer, Error> {
 		let mut state = self.state.lock();
 		let existing = state.broadcasts.contains_key(&path);
-		let producer = self.attach(&mut state, path.clone(), advert)?;
+		let producer = self.attach(&mut state, path.clone(), advert, Arrival::Separate)?;
 		if existing && let Some(entry) = state.broadcasts.get_mut(&path) {
 			// The path was already attached, so this is one more advertisement for it.
 			// A replacement carries the previous count forward, so the increment still
@@ -896,7 +913,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		if !state.broadcasts.contains_key(&path) {
 			return Err(Error::NotFound);
 		}
-		self.attach(&mut state, path, advert)?;
+		self.attach(&mut state, path, advert, Arrival::Repeat)?;
 		Ok(())
 	}
 
@@ -904,14 +921,20 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	///
 	/// The ingress announce stats (announced / announced_bytes) are driven in the model
 	/// by `create_broadcast`'s route transitions below.
-	fn attach(&self, state: &mut State, path: PathOwned, advert: Advertised) -> Result<broadcast::Producer, Error> {
+	fn attach(
+		&self,
+		state: &mut State,
+		path: PathOwned,
+		advert: Advertised,
+		arrival: Arrival,
+	) -> Result<broadcast::Producer, Error> {
 		let publisher = advert.publisher;
 
-		// A different original publisher, or one that identifies nothing, means a
-		// distinct broadcast may have taken over this namespace. Its content is not
-		// interchangeable, so detach the old source and attach fresh instead of splicing
-		// the route in place; cached tracks and subscriptions must not carry over. The
-		// refcount rides along: the same advertisements still reference this path.
+		// A different original publisher means a distinct broadcast has taken over this
+		// namespace. Its content is not interchangeable, so detach the old source and
+		// attach fresh instead of splicing the route in place; cached tracks and
+		// subscriptions must not carry over. The refcount rides along: the same
+		// advertisements still reference this path.
 		//
 		// Both sides must be known for the comparison to mean anything. A session
 		// without the MoQ Cluster extension has no identity on either, so nothing ever
@@ -921,8 +944,17 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let mut carried = None;
 		if let Entry::Occupied(entry) = state.broadcasts.entry(path.clone())
 			&& let (Some(old), Some(new)) = (entry.get().publisher, publisher)
-			&& (old != new || new == crate::Origin::UNKNOWN)
-		{
+			&& match arrival {
+				// Two advertisements, so identity is the only link between them and
+				// UNKNOWN is no link at all: unrelated publishers all present the same
+				// one. Take the later as replacing the earlier.
+				Arrival::Separate => old != new || new == crate::Origin::UNKNOWN,
+				// One advertisement, repeated on the stream that carries it. Continuity
+				// is the stream, not the identity, so an unchanged UNKNOWN stays put; a
+				// peer that never named itself would otherwise lose every subscription
+				// each time it repriced.
+				Arrival::Repeat => old != new,
+			} {
 			tracing::debug!(broadcast = %self.origin.absolute(&path), "publisher changed; replacing the source");
 			carried = Some(entry.get().count);
 			entry.remove().producer.finish();
@@ -2221,6 +2253,104 @@ mod tests {
 		assert_eq!(hops, vec![8, 9]);
 
 		// Still one advertisement, so one unannounce is all it takes.
+		subscriber.stop_announce(path, Detach::Graceful).unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		assert!(consumer.get_broadcast("room/host").is_none());
+	}
+
+	/// Regression: a publisher that declares no identity of its own contributes
+	/// `Origin::UNKNOWN` as the first hop, which identifies nothing. A repeat NAMESPACE
+	/// is still the same advertisement being repriced (the expected update, and how a
+	/// relay signals that it started carrying the namespace), so the source and every
+	/// live subscription on it must survive. Reading the repeat as a new publisher
+	/// detached the source milliseconds after SUBSCRIBE went out.
+	#[tokio::test]
+	async fn anonymous_publisher_survives_a_repricing_update() {
+		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let consumer = origin.consume();
+		let path = crate::Path::new("room/host").to_owned();
+		// A free link, so the route cost is exactly what the peer advertised.
+		let peer = cluster::Peer {
+			origin: Some(crate::Origin::new(9).unwrap()),
+			cost: Some(0),
+		};
+		let hops = cluster::HopPath::new(
+			crate::OriginList::try_from(vec![crate::Origin::UNKNOWN, crate::Origin::new(9).unwrap()]).unwrap(),
+		);
+
+		let advertised = subscriber
+			.route(
+				Some(&cluster::Advert {
+					hops: hops.clone(),
+					cost: 2,
+				}),
+				&peer,
+			)
+			.expect("route");
+		assert_eq!(
+			advertised.publisher,
+			Some(crate::Origin::UNKNOWN),
+			"an anonymous publisher has no identity to carry",
+		);
+		subscriber.start_announce(path.clone(), advertised).unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		let original = consumer.get_broadcast("room/host").unwrap();
+
+		// The peer re-advertises the same path cheaper: it started carrying it.
+		let repriced = subscriber
+			.route(Some(&cluster::Advert { hops, cost: 1 }), &peer)
+			.expect("route");
+		subscriber.update_announce(path.clone(), repriced).unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+		assert!(
+			!original.is_closed(),
+			"a repricing update must not tear down the source"
+		);
+		let broadcast = consumer.get_broadcast("room/host").unwrap();
+		let routes = broadcast.routes();
+		assert_eq!(routes.len(), 1, "the update replaced the route, it did not add one");
+		assert_eq!(routes[0].cost, 1);
+
+		// One advertisement, so one unannounce detaches it.
+		subscriber.stop_announce(path, Detach::Graceful).unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		assert!(consumer.get_broadcast("room/host").is_none());
+	}
+
+	/// Two *separate* advertisements have nothing linking them but the publisher, and
+	/// `Origin::UNKNOWN` links nothing: any number of unrelated publishers present it.
+	/// So the later one replaces the earlier, unlike the repeat above.
+	#[tokio::test]
+	async fn separate_anonymous_adverts_replace_the_source() {
+		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let consumer = origin.consume();
+		let path = crate::Path::new("room/host").to_owned();
+		let peer = cluster::Peer {
+			origin: Some(crate::Origin::new(9).unwrap()),
+			cost: None,
+		};
+		let hops = cluster::HopPath::new(
+			crate::OriginList::try_from(vec![crate::Origin::UNKNOWN, crate::Origin::new(9).unwrap()]).unwrap(),
+		);
+		let advert = cluster::Advert { hops, cost: 0 };
+
+		let first = subscriber.route(Some(&advert), &peer).expect("route");
+		subscriber.start_announce(path.clone(), first).unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		let original = consumer.get_broadcast("room/host").unwrap();
+
+		let second = subscriber.route(Some(&advert), &peer).expect("route");
+		subscriber.start_announce(path.clone(), second).unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+		assert!(original.is_closed(), "the old source was detached");
+		assert!(consumer.get_broadcast("room/host").is_some());
+
+		// Two advertisements, so it takes two unannounces to detach.
+		subscriber.stop_announce(path.clone(), Detach::Graceful).unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		assert!(consumer.get_broadcast("room/host").is_some());
 		subscriber.stop_announce(path, Detach::Graceful).unwrap();
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 		assert!(consumer.get_broadcast("room/host").is_none());

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -2264,7 +2264,7 @@ mod tests {
 	/// relay signals that it started carrying the namespace), so the source and every
 	/// live subscription on it must survive. Reading the repeat as a new publisher
 	/// detached the source milliseconds after SUBSCRIBE went out.
-	#[tokio::test]
+	#[tokio::test(start_paused = true)]
 	async fn anonymous_publisher_survives_a_repricing_update() {
 		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
 		let consumer = origin.consume();
@@ -2321,7 +2321,7 @@ mod tests {
 	/// Two *separate* advertisements have nothing linking them but the publisher, and
 	/// `Origin::UNKNOWN` links nothing: any number of unrelated publishers present it.
 	/// So the later one replaces the earlier, unlike the repeat above.
-	#[tokio::test]
+	#[tokio::test(start_paused = true)]
 	async fn separate_anonymous_adverts_replace_the_source() {
 		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
 		let consumer = origin.consume();

--- a/test/wasm/src/main.ts
+++ b/test/wasm/src/main.ts
@@ -278,15 +278,6 @@ const CASES: Case[] = [
 	},
 	{
 		name: "reads a published broadcast",
-		// The IETF subscriber takes the publisher's identity straight off the hop
-		// chain, so an advert from a publisher that has none (@moq/net speaks no
-		// cluster extension) is attributed to Origin::UNKNOWN. Every repeat NAMESPACE
-		// for that path then reads as a new publisher and detaches the live source,
-		// killing the subscription mid-read. moq-lite has the same rule but stamps the
-		// upstream session's id when the chain has none, so it never reaches it.
-		// See https://github.com/moq-dev/moq/issues/2903. The detached source surfaces
-		// as the recv stream being dropped mid-read, which is the signature below.
-		known: { ietf: { issue: "#2903", error: "dropped" } },
 		run: async (wasm, relay) => {
 			const path = `wasm-test/${relay.name}`;
 			await withPublisher(relay, path, async () => {


### PR DESCRIPTION
Fixes #2903.

## Summary

- **Root cause.** `ietf::Subscriber::attach` replaced the incumbent source whenever the advertised original publisher (the first `HOP_PATH` entry) was `Origin::UNKNOWN`, on *any* advertisement. A publisher that declares no cluster identity contributes exactly that, so every repeat `NAMESPACE` for its path finished the live source and tore down every subscription on it. A plain repricing update was enough, which is the expected update: it is how a relay signals that it started or stopped carrying the namespace. `update_announce`'s own doc says no subscription is torn down merely because an update arrived; the `new == UNKNOWN` clause broke that for exactly the peers that can't prove otherwise.
- **Fix.** Split the rule by what the advertisement is, via a new private `Arrival` enum:
  - `Arrival::Separate` (a `PUBLISH_NAMESPACE` alongside a `NAMESPACE`) keeps the old rule. Nothing links two advertisements but the identity, and `UNKNOWN` links nothing, so the later replaces the earlier.
  - `Arrival::Repeat` (an update on the stream that already carries the advertisement) compares by plain equality. There is one advertisement, and the stream is the continuity, so only a *changed* publisher is a new publisher.
- That is the same split the model layer already makes: `same_publisher` (UNKNOWN never splices) between sources, plain equality for a route update within one source handle.
- Not fixed by stamping the session origin the way `lite::start_announce` does, as the issue floated: `session_origin` is itself `UNKNOWN` for a peer with no assigned identity, and the failing chain is `[UNKNOWN, relay]` rather than empty, so the stamp never fires.
- The wasm harness's `#2903` known-failure marker is removed, so `ietf: reads a published broadcast` is now required to pass.

## Wire spec

`drafts/draft-lcurley-moq-cluster.md` stated the behavior the code implemented, so it changes with it. The "Updating an Advertisement" rule now turns on whether the first `HOP_PATH` entry *changed*, with 0 called out as the one comparison it does not decide, and an endpoint whose publisher really did change MUST withdraw the advertisement (`NAMESPACE_DONE` / `PUBLISH_NAMESPACE_DONE`) and advertise again rather than update in place. `moq-relay` already behaves that way: the origin's announce queue preserves an unannounce/announce pair (`PendingUpdate::UnannounceAnnounce`) rather than collapsing it, so the withdrawal always precedes the new advertisement on the wire. No message, parameter, or encoding changed.

The draft has no changelog appendix (it is unreleased), so there is no bullet to add.

## Cross-package sync

- `js/net`'s IETF implementation has no cluster extension at all, so there is nothing to mirror there. (That gap is what makes the browser publisher anonymous in the first place; the issue suggests tracking it separately.)
- No `moq-ffi`, catalog, token, relay-config, or CLI surface is touched.

## Public API changes

None. `Arrival` and `attach` are private to `rs/moq-net/src/ietf/subscriber.rs`.

## Test plan

- `cargo test -p moq-net` — 770 unit tests plus doctests pass.
- New regression test `anonymous_publisher_survives_a_repricing_update`: an advert with first hop 0, then a repeat at a lower cost. It fails on `main`'s rule (verified by restoring the old condition: the source is closed under the subscription) and passes with the fix.
- New `separate_anonymous_adverts_replace_the_source` pins the other branch, so the `Separate` rule can't be lost with it.
- `cargo clippy -p moq-net --all-targets` clean, `cargo fmt` clean, Biome clean on `test/wasm/src/main.ts`.
- End-to-end: the WASM job is green at 9/9, with `ietf: reads a published broadcast` passing and no marker excusing it. That is the reproduction from the issue.

(Written by Opus 5)