### PR TITLE
feat(mux)!: carry standalone SI on per-table snapshot tracks

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -637,13 +637,17 @@ cues, teletext, DVB subtitles, ...) are carried verbatim too, one MoQ track per
 PID, described in the catalog `mpegts` section, and survive `import ts` /
 `export ts` end-to-end.
 
-The service layer rides the same `mpegts` section. The program identity
-(transport stream ID, service number, PMT PID) is captured from the PAT and used to
-rebuild a matching PAT/PMT, while the standalone SI tables (SDT, NIT) are carried as
-opaque sections and re-emitted byte-for-byte on their original PIDs, each at its own
-repetition interval. So the service name, provider, type, and network survive the
-round-trip without being parsed. Regenerated tables (TDT/TOT) and EPG (EIT) are not
-captured: they are live or bulky rather than static identity.
+The service layer survives too. The program identity (transport stream ID,
+service number, PMT PID) is captured from the PAT into the catalog `mpegts`
+section and used to rebuild a matching PAT/PMT. The standalone SI tables (SDT,
+NIT, BAT, EIT now/next and schedule, and any table the CLI does not recognize)
+are carried as opaque sections on dedicated snapshot tracks, one per PID and
+table, and re-emitted byte-for-byte on their original PIDs, each at its own
+repetition interval. So the service name, provider, type, network, and EPG
+survive the round-trip without being parsed, and only TS exporters pay for
+them. TDT/TOT is the one exception: it is a clock rather than state, so the
+exporter's own clock beats a time relayed from an upstream multiplexer of
+unknown delay.
 
 ### FLV
 

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -574,8 +574,9 @@ Each group is a snapshot: reading its frames in order yields the table's complet
 A joiner reads only the newest group and is current; older groups never need to be fetched.
 A writer MAY append a frame to an open group to revise one sub-table incrementally; a writer that only ever cuts complete groups is trivially conformant.
 
-A publisher MUST NOT publish a partially-acquired sub-table: sections of one version are buffered until the generation is complete and committed atomically.
-A torn set (sections disagreeing about their version, or a section set that a receiver cannot complete) is not something a conformant multiplexer emits, and the group boundary makes it unrepresentable here.
+A publisher MUST NOT mix versions within a sub-table's frame: sections of one version are buffered until the generation is judged complete and committed atomically.
+Completeness is contiguity (all of `0..=last_section_number` present) or one observed full transmission cycle, whichever comes first: some tables number their sections sparsely (DVB EIT schedule skips unused numbers per segment), so a repeated section within the pending generation proves the cycle wrapped and the set is complete as transmitted.
+A section lost before the cycle wraps is indistinguishable from a legitimately skipped number, so a committed set can transiently omit it until the next cycle re-supplies it; no section-counting receiver can do better.
 A publisher SHOULD carry only sections whose `current_next_indicator` is set.
 
 Tables that are clocks rather than state (TDT/TOT, PID 0x0014) SHOULD NOT be carried: every section is new content, and an exporter's own clock is a better source than a time relayed from an upstream multiplexer of unknown delay.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -532,6 +532,55 @@ The final segment of an ended broadcast has no closing boundary; its `duration` 
 A publisher SHOULD carry the end of the last group's content into that value, since a publisher that knows only where each group *started* would report a duration one group short, and zero for a final segment that is a single group.
 
 
+# MPEG-TS Service Information {#mpegts-si}
+A broadcast imported from an MPEG-TS multiplex can carry the multiplex's standalone service-information tables (ISO/IEC 13818-1 program-specific information and ETSI EN 300 468 DVB SI: SDT, NIT, BAT, EIT, and any table the publisher does not recognize) so an exporter can re-emit them byte-for-byte.
+The sections are opaque: nothing in this mechanism parses a table, so an unrecognized table round-trips exactly like a known one.
+
+The tables are state, not events: a transport stream retransmits them continuously only because a TS receiver can tune in at any moment, so the repetition rate is a property of the unreliable transport, not of the data.
+Here each table rides a dedicated snapshot track, delivered once at join and republished on change, per the root catalog's guidance that dynamic content is delegated to other tracks.
+Consumers that are not TS exporters never pay for it.
+
+## Catalog Section {#mpegts-si-catalog}
+The catalog's `mpegts` section maps each carried table to its track under an `si` field, keyed by the PID the sections ride on and then by `table_id`:
+
+~~~
+type Mpegts = {
+  // ... other MPEG-TS carriage fields ...
+  "si": { [pid: string]: { [tableId: string]: SiEntry } } | undefined,
+}
+
+type SiEntry = {
+  "track": string,
+  "interval": number | undefined,
+}
+~~~
+
+Both keys are written in decimal, since JSON object keys are strings.
+`table_id` is byte 0 of generic section syntax, so the key is no less generic than the PID; which table_id ranges mean what is a DVB convention that appears nowhere in the schema.
+
+* `track`: the name of the snapshot track carrying this table's sections, on the same broadcast as the catalog.
+* `interval`: how often an exporter MUST re-emit the sections at most, in milliseconds. A hint carrying the table's own repetition requirement (for DVB, the ETSI TS 101 211 maxima). When absent, an exporter SHOULD fall back to a fast cadence of its own choosing, so an unknown table degrades to a safe rate rather than being dropped.
+
+Entries are added when a table is first observed, which is acquisition-time traffic; steady-state table revisions touch only the named track, never the catalog.
+
+## Track Format {#mpegts-si-track}
+An SI track is binary, without the media container framing ({{container}}).
+
+Each frame is one sub-table: its complete current sections, concatenated verbatim in `section_number` order, each including its header and CRC.
+Sections are self-delimiting via `section_length`, so the frame needs no framing of its own.
+A sub-table's identity is its generic section header (`table_id`, `table_id_extension`) extended by the documented disambiguators for two DVB table families: `original_network_id` (bytes 8..10) for SDT other (`table_id` 0x46), and `transport_stream_id` plus `original_network_id` (bytes 8..12) for EIT (0x4E..0x6F), whose generic identities are only unique within one network or transport stream.
+
+Each group is a snapshot: reading its frames in order yields the table's complete current state, where a later frame replaces an earlier one with the same sub-table identity.
+A joiner reads only the newest group and is current; older groups never need to be fetched.
+A writer MAY append a frame to an open group to revise one sub-table incrementally; a writer that only ever cuts complete groups is trivially conformant.
+
+A publisher MUST NOT publish a partially-acquired sub-table: sections of one version are buffered until the generation is complete and committed atomically.
+A torn set (sections disagreeing about their version, or a section set that a receiver cannot complete) is not something a conformant multiplexer emits, and the group boundary makes it unrepresentable here.
+A publisher SHOULD carry only sections whose `current_next_indicator` is set.
+
+Tables that are clocks rather than state (TDT/TOT, PID 0x0014) SHOULD NOT be carried: every section is new content, and an exporter's own clock is a better source than a time relayed from an upstream multiplexer of unknown delay.
+
+
 # Security Considerations
 A rendition's `broadcast` reference ({{field-broadcast}}) resolves against the consumer's root, which is the subtree it is authorized for.
 Clamping a reference that escapes above that root would silently redirect the subscription to an unrelated broadcast, so a consumer rejects the catalog instead.

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -33,7 +33,7 @@ serde = { workspace = true }
 serde_json = "1"
 serde_with = { version = "3", features = ["base64"] }
 thiserror = "2"
-tokio = { workspace = true, features = ["macros", "rt", "time"] }
+tokio = { workspace = true, features = ["macros"] }
 tracing = "0.1"
 url = "2"
 webm-iterable = "0.6"

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -33,7 +33,7 @@ serde = { workspace = true }
 serde_json = "1"
 serde_with = { version = "3", features = ["base64"] }
 thiserror = "2"
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 tracing = "0.1"
 url = "2"
 webm-iterable = "0.6"

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -5,7 +5,7 @@
 //! entry per track (its original PID and PMT descriptors), a `verbatim` carriage
 //! record for every elementary stream we don't decode (SCTE-35, teletext, DVB
 //! subtitles, private data, ...), the program-level PMT descriptors, the program
-//! identity ([`Program`]), and the standalone SI tables ([`Si`]).
+//! identity ([`Program`]), and the standalone SI table map ([`SiEntry`]).
 //! Demuxed media tracks keep their codec config in the base `video`/`audio`
 //! sections; only their MPEG-TS identity lands here.
 
@@ -19,19 +19,50 @@ use serde_with::{DisplayFromStr, DurationMilliSeconds, serde_as};
 
 use crate::catalog::hang::CatalogExt;
 
-/// A standalone SI PID we capture, and how often export must re-emit it.
+/// The standalone SI PIDs we capture. Everything on a captured PID is carried,
+/// whatever its `table_id`: the SDT PID also carries the BAT, the EIT PID carries
+/// both now/next and the full schedule, and a table we've never heard of is exactly
+/// as worth preserving as one we have.
 ///
-/// Intervals are the DVB maximum repetition intervals (ETSI TS 101 211); export
-/// treats them as an upper bound, not the source's observed cadence, which is a
-/// property of that multiplexer's bitrate shaping and means nothing downstream.
-/// Adding a table here is a one-line change: the sections themselves are opaque.
-pub(super) const SI_PIDS: &[(u16, Duration)] = &[
-	// NIT (network description): 10s.
-	(0x0010, Duration::from_secs(10)),
-	// SDT and BAT (service and bouquet description): 2s for SDT Actual, the tightest
-	// of the two, so one interval per PID stays conservative.
-	(0x0011, Duration::from_secs(2)),
+/// TDT/TOT (0x0014) is deliberately absent: it is a clock, not state, so every
+/// section is new content, and it is the table with the least to gain from being
+/// relayed. An exporter's own clock is a better source than a time forwarded from
+/// an upstream multiplexer of unknown delay.
+pub(super) const SI_PIDS: &[u16] = &[
+	0x0010, // NIT (network description)
+	0x0011, // SDT and BAT (service and bouquet description)
+	0x0012, // EIT (event information: now/next and schedule)
 ];
+
+/// The DVB maximum repetition interval for a known `table_id` (ETSI TS 101 211).
+///
+/// Export treats the interval as an upper bound, not the source's observed cadence,
+/// which is a property of that multiplexer's bitrate shaping and means nothing
+/// downstream. `None` for a table we don't recognize; export then falls back to its
+/// PSI cadence, so an unknown table degrades to a safe (fast) rate rather than being
+/// dropped. Keyed by `table_id` rather than PID because that is the granularity the
+/// spec defines: the EIT PID alone carries tables wanting 2s and 30s.
+pub(super) fn si_interval(table_id: u8) -> Option<Duration> {
+	match table_id {
+		// NIT actual/other.
+		0x40..=0x41 => Some(Duration::from_secs(10)),
+		// SDT actual.
+		0x42 => Some(Duration::from_secs(2)),
+		// SDT other.
+		0x46 => Some(Duration::from_secs(10)),
+		// BAT.
+		0x4A => Some(Duration::from_secs(10)),
+		// EIT now/next actual.
+		0x4E => Some(Duration::from_secs(2)),
+		// EIT now/next other.
+		0x4F => Some(Duration::from_secs(10)),
+		// EIT schedule actual.
+		0x50..=0x5F => Some(Duration::from_secs(10)),
+		// EIT schedule other.
+		0x60..=0x6F => Some(Duration::from_secs(30)),
+		_ => None,
+	}
+}
 
 /// The `mpegts` catalog section.
 ///
@@ -58,17 +89,23 @@ pub struct Mpegts {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub program: Option<Program>,
 
-	/// Standalone SI tables carried verbatim, keyed by the PID they ride on (0x0011
-	/// SDT, 0x0010 NIT, ...). Export re-emits each PID's sections byte-for-byte on that
-	/// PID, so the service name, provider, and network survive without anyone parsing
-	/// them.
+	/// Standalone SI tables, keyed by the PID they ride on (0x0011 SDT, 0x0010 NIT,
+	/// 0x0012 EIT, ...) and then by `table_id`. The section bytes themselves live on
+	/// each entry's snapshot [track](SiEntry::track); the catalog only maps where they
+	/// are and how often export must re-emit them. Export re-emits each entry's
+	/// sections byte-for-byte on its PID, so the service name, provider, network, and
+	/// EPG survive without anyone parsing them.
 	///
-	/// JSON object keys are strings, so the PID is written in decimal (`"17"`) rather
-	/// than as a number. The catalog is parsed via `serde_json::Value`, which will not
-	/// coerce a string key back to an integer on its own.
+	/// `table_id` is byte 0 of generic section syntax (ISO 13818-1), so the key is no
+	/// less generic than the PID: which *ranges* mean what is a DVB convention, and
+	/// none appears here.
+	///
+	/// JSON object keys are strings, so both keys are written in decimal (`"17"`)
+	/// rather than as numbers. The catalog is parsed via `serde_json::Value`, which
+	/// will not coerce a string key back to an integer on its own.
 	#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-	#[serde_as(as = "BTreeMap<DisplayFromStr, _>")]
-	pub si: BTreeMap<u16, Si>,
+	#[serde_as(as = "BTreeMap<DisplayFromStr, BTreeMap<DisplayFromStr, _>>")]
+	pub si: BTreeMap<u16, BTreeMap<u8, SiEntry>>,
 }
 
 impl Mpegts {
@@ -81,9 +118,9 @@ impl Mpegts {
 /// Program identity, from the PAT.
 ///
 /// The only part of the service layer we parse, because export has to: these three
-/// values rebuild a PAT/PMT consistent with the SI tables carried alongside in
-/// [`Si`]. Everything else about the program (its name, provider, type, network)
-/// stays opaque bytes. Named for the MPEG concept rather than the DVB one: DVB calls
+/// values rebuild a PAT/PMT consistent with the SI tables carried on the tracks
+/// [`SiEntry`] maps. Everything else about the program (its name, provider, type,
+/// network) stays opaque bytes. Named for the MPEG concept rather than the DVB one: DVB calls
 /// a program a service, but the same PAT fields carry an ATSC or ISDB stream too.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
@@ -101,68 +138,33 @@ pub struct Program {
 	pub pmt_pid: u16,
 }
 
-/// The standalone SI tables on one PID, carried verbatim.
+/// One standalone SI table's carriage: which track holds its sections, and how
+/// often export must re-emit them.
 ///
-/// Sections are opaque: nothing here parses a table, so an SDT, a NIT, a BAT, or a
-/// table we've never heard of all round-trip the same way. A PID carries a *set* of
-/// sections (a multi-service SDT is several, and the SDT PID also carries the BAT),
-/// so they are held together and replaced individually as each is re-signaled.
+/// The sections themselves ride the named snapshot track (see the `ts` module docs
+/// for the track format), not the catalog, so a table revision republishes a small
+/// track group instead of the whole catalog. Sections stay opaque: nothing here
+/// parses a table, so an SDT, a BAT, an EPG, or a table we've never heard of all
+/// round-trip the same way.
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct Si {
-	/// The current sections, in the order they were first seen. Each is a complete
-	/// section including its header and CRC, re-emitted byte-for-byte.
-	#[serde_as(as = "Vec<Base64>")]
-	pub sections: Vec<Bytes>,
+pub struct SiEntry {
+	/// Name of the snapshot track carrying this table's sections, on the same
+	/// broadcast as the catalog. Each group is a complete snapshot of the table's
+	/// current sections; a joiner reads only the newest group.
+	pub track: String,
 
 	/// Re-emit at least this often. A hint: import fills in the DVB maximum for the
-	/// PIDs it knows, and export is free to clamp it. Absent for an unrecognized PID,
-	/// which export then re-emits on its own PSI cadence, so an unknown table degrades
-	/// to a safe rate rather than being dropped.
+	/// tables it recognizes, and export is free to clamp it. Absent for an unknown
+	/// `table_id`, which export then re-emits on its own PSI cadence, so an unknown
+	/// table degrades to a safe rate rather than being dropped.
 	///
 	/// Serialized as an integer number of milliseconds (sub-ms precision is truncated).
 	#[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub interval: Option<Duration>,
-}
-
-impl Si {
-	/// Add `section`, replacing an earlier one with the same identity. Returns whether
-	/// the set actually changed, so a caller can skip republishing on a repetition (SI
-	/// repeats every couple of seconds; almost every section is a repeat).
-	pub fn upsert(&mut self, section: Bytes) -> bool {
-		let key = section_key(&section);
-		match self.sections.iter_mut().find(|s| section_key(s) == key) {
-			Some(existing) if *existing == section => false,
-			Some(existing) => {
-				*existing = section;
-				true
-			}
-			None => {
-				self.sections.push(section);
-				true
-			}
-		}
-	}
-}
-
-/// Identify a section within its PID: `(table_id, table_id_extension, section_number)`.
-///
-/// Generic section syntax (ISO 13818-1 / EN 300 468), not table-specific: a long-form
-/// section (`section_syntax_indicator` set) is one part of one version of one table,
-/// while a short-form one (TDT and friends) has no extension or numbering and so is
-/// identified by its `table_id` alone. A runt is keyed by whatever it has, leaving the
-/// byte-equality check to decide.
-fn section_key(section: &[u8]) -> (u8, u16, u8) {
-	let table_id = section.first().copied().unwrap_or(0);
-	let long_form = section.get(1).is_some_and(|b| b & 0x80 != 0);
-	if !long_form || section.len() < 8 {
-		return (table_id, 0, 0);
-	}
-	let extension = ((section[3] as u16) << 8) | section[4] as u16;
-	(table_id, extension, section[6])
 }
 
 /// One track's MPEG-TS identity and signaling.
@@ -351,14 +353,11 @@ mod test {
 
 	#[test]
 	fn program_and_si_roundtrip() {
-		let mut si = Si {
+		let entry = SiEntry {
+			track: "0x0011-0x42.si".to_string(),
 			interval: Some(Duration::from_secs(2)),
 			..Default::default()
 		};
-		assert!(
-			si.upsert(Bytes::from_static(b"\x42\xf0\x25")),
-			"first section is a change"
-		);
 
 		let mpegts = Mpegts {
 			program: Some(Program {
@@ -367,17 +366,20 @@ mod test {
 				pmt_pid: 0x0064,
 				..Default::default()
 			}),
-			si: BTreeMap::from([(0x0011, si)]),
+			si: BTreeMap::from([(0x0011, BTreeMap::from([(0x42u8, entry)]))]),
 			..Default::default()
 		};
 		assert!(!mpegts.is_empty(), "a program record is not empty");
 
 		let json = serde_json::to_string(&Ext { mpegts: mpegts.clone() }).unwrap();
-		// Sections are base64 under their PID; the PMT PID is structured, not a section.
-		assert!(json.contains("\"sections\""), "sections present: {json}");
 		assert!(json.contains("\"pmtPid\":100"), "identity stays structured: {json}");
-		// The PID key is a decimal string, since JSON object keys are strings.
+		// Both keys are decimal strings, since JSON object keys are strings.
 		assert!(json.contains("\"17\":"), "PID key written as a string: {json}");
+		assert!(json.contains("\"66\":"), "table_id key written as a string: {json}");
+		assert!(
+			json.contains("\"track\":\"0x0011-0x42.si\""),
+			"the entry names its track: {json}"
+		);
 		// Lock in the interval's wire shape: a bare integer number of milliseconds.
 		// Without the `DurationMilliSeconds` adapter this regresses to serde's default
 		// `{secs, nanos}` object.
@@ -385,44 +387,5 @@ mod test {
 
 		let parsed: Ext = serde_json::from_str(&json).unwrap();
 		assert_eq!(parsed.mpegts, mpegts, "program and SI round-trip");
-	}
-
-	/// A repeated section must not count as a change: SI repeats every couple of
-	/// seconds, so treating a repeat as an update would republish the catalog forever.
-	/// A *revised* section (same identity, new bytes) replaces in place, and a sibling
-	/// section (same table, different `section_number`) is added alongside.
-	#[test]
-	fn si_upsert_dedupes_by_section_identity() {
-		// Long-form SDT Actual: table_id 0x42, syntax indicator set, extension 0x0001.
-		let section = |section_number: u8, fill: u8| {
-			Bytes::from(vec![
-				0x42,
-				0xf0,
-				0x0b,
-				0x00,
-				0x01,
-				0xc1,
-				section_number,
-				0x01,
-				fill,
-				fill,
-				fill,
-				fill,
-				fill,
-				fill,
-			])
-		};
-
-		let mut si = Si::default();
-		assert!(si.upsert(section(0, 0xaa)), "first section");
-		assert!(!si.upsert(section(0, 0xaa)), "a byte-identical repeat is not a change");
-		assert_eq!(si.sections.len(), 1);
-
-		assert!(si.upsert(section(0, 0xbb)), "revised section 0 is a change");
-		assert_eq!(si.sections.len(), 1, "the revision replaced in place");
-		assert_eq!(si.sections[0], section(0, 0xbb));
-
-		assert!(si.upsert(section(1, 0xcc)), "section 1 is a sibling, not a replacement");
-		assert_eq!(si.sections.len(), 2, "both sections of the table are held");
 	}
 }

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -66,11 +66,11 @@ pub struct Export<E: catalog::Catalog = ()> {
 	/// Transport/service identity captured on import, used to rebuild a consistent
 	/// PAT/PMT. `None` for a media-only source, so a minimal identity is synthesized.
 	program: Option<catalog::Program>,
-	/// Standalone SI sections captured on import, keyed by PID and re-emitted verbatim
-	/// on their own cadence. Opaque: export never parses a table it carries.
-	si: BTreeMap<u16, catalog::Si>,
-	/// When each SI PID was last emitted, so each honors its own interval ([`due`]).
-	last_si: HashMap<u16, Timestamp>,
+	/// Standalone SI subscriptions, keyed by `(PID, table_id)` from the catalog's
+	/// `mpegts.si` map. Each reduces its snapshot track into the section set
+	/// re-emitted verbatim on its PID at its own cadence. Opaque: export never
+	/// parses a table it carries.
+	si: BTreeMap<(u16, u8), SiTrack>,
 
 	/// Program tables, built once the track layout is known.
 	psi: Option<Psi>,
@@ -164,6 +164,149 @@ struct PesUnit {
 	stream_id: Option<u8>,
 }
 
+/// One SI entry's subscription: resolves the snapshot track named by the catalog,
+/// reduces its newest complete group into the current section set, and remembers
+/// when it last hit the wire so it re-emits on its own cadence.
+struct SiTrack {
+	interval: Option<Duration>,
+	state: SiState,
+	/// The reduced newest *complete* group: what emission re-transmits.
+	active: super::si::Snapshot,
+	/// A group still being read; swapped into `active` when it ends, so a torn
+	/// half-received snapshot is never emitted.
+	pending: Option<(moq_net::group::Consumer, super::si::Snapshot)>,
+	/// Media timestamp of the last emission ([`due`]).
+	last_emit: Option<Timestamp>,
+}
+
+/// The SI subscription's lifecycle, mirroring `ExportSource`'s but reading raw
+/// snapshot groups instead of timestamp-paced container frames.
+enum SiState {
+	/// Waiting for the catalog broadcast to resolve; the track (by name) is
+	/// subscribed once it does.
+	Requesting(kio::Pending<moq_net::origin::Requesting>, String),
+	/// Waiting for the subscription to resolve.
+	Subscribing(kio::Pending<moq_net::track::Subscribing>),
+	/// The resolved subscription, reading snapshot groups.
+	Active(moq_net::track::Subscriber),
+	/// The track ended or failed; the last complete snapshot keeps re-emitting,
+	/// mirroring how a real mux repeats its tables between (absent) revisions.
+	Done,
+}
+
+impl SiTrack {
+	fn new(source: &crate::Source, track: &str, interval: Option<Duration>) -> Self {
+		Self {
+			interval,
+			state: SiState::Requesting(source.request_catalog(), track.to_string()),
+			active: Default::default(),
+			pending: None,
+			last_emit: None,
+		}
+	}
+
+	/// Drive the subscription and fold arrived groups into `active`. Never returns
+	/// an error: SI is auxiliary, so a failed or ended track logs and keeps the last
+	/// snapshot rather than killing the mux.
+	fn poll(&mut self, waiter: &kio::Waiter) {
+		if matches!(self.state, SiState::Requesting(..)) {
+			// Scope the borrow of `self.state` so the transitions below can assign it.
+			let resolved = {
+				let SiState::Requesting(pending, name) = &self.state else {
+					unreachable!("just matched Requesting");
+				};
+				match pending.poll_ok(waiter) {
+					Poll::Ready(Ok(broadcast)) => Ok((broadcast, name.clone())),
+					Poll::Ready(Err(err)) => Err(err),
+					Poll::Pending => return,
+				}
+			};
+			self.state = match resolved {
+				Ok((broadcast, name)) => match broadcast.track(&name) {
+					Ok(track) => SiState::Subscribing(track.subscribe(None)),
+					Err(err) => {
+						tracing::warn!(%err, track = %name, "SI track unavailable; carrying the last snapshot");
+						SiState::Done
+					}
+				},
+				Err(err) => {
+					tracing::warn!(%err, "SI broadcast unavailable; carrying the last snapshot");
+					SiState::Done
+				}
+			};
+		}
+
+		if matches!(self.state, SiState::Subscribing(_)) {
+			let resolved = {
+				let SiState::Subscribing(pending) = &self.state else {
+					unreachable!("just matched Subscribing");
+				};
+				match pending.poll_ok(waiter) {
+					Poll::Ready(result) => result,
+					Poll::Pending => return,
+				}
+			};
+			self.state = match resolved {
+				Ok(track) => SiState::Active(track),
+				Err(err) => {
+					tracing::warn!(%err, "SI subscription failed; carrying the last snapshot");
+					SiState::Done
+				}
+			};
+		}
+
+		let mut ended = false;
+		if let SiState::Active(track) = &mut self.state {
+			loop {
+				// Drain to the newest group first: a snapshot obsoletes every older
+				// one, including a partially-read pending group.
+				match track.poll_next_group(waiter) {
+					Poll::Ready(Ok(Some(group))) => {
+						self.pending = Some((group, Default::default()));
+					}
+					Poll::Ready(Ok(None)) => {
+						ended = true;
+						break;
+					}
+					Poll::Ready(Err(err)) => {
+						tracing::warn!(%err, "SI track failed; carrying the last snapshot");
+						ended = true;
+						break;
+					}
+					Poll::Pending => break,
+				}
+			}
+		}
+		if ended {
+			self.state = SiState::Done;
+		}
+
+		// Read the pending group to its end, then promote it wholesale: emitting a
+		// half-received snapshot would re-introduce the torn state the group
+		// boundary exists to prevent.
+		while let Some((group, snapshot)) = &mut self.pending {
+			let (promote, drop_pending) = match group.poll_read_frame(waiter) {
+				Poll::Ready(Ok(Some(frame))) => {
+					snapshot.apply(&frame.payload);
+					(false, false)
+				}
+				Poll::Ready(Ok(None)) => (true, false),
+				Poll::Ready(Err(err)) => {
+					tracing::warn!(%err, "SI group failed; carrying the last snapshot");
+					(false, true)
+				}
+				Poll::Pending => break,
+			};
+			if promote {
+				let (_, snapshot) = self.pending.take().unwrap();
+				self.active = snapshot;
+			} else if drop_pending {
+				self.pending = None;
+			}
+		}
+	}
+}
+
 impl Export {
 	/// Subscribe to `source`, using the default catalog format.
 	pub async fn new(source: crate::Source) -> Result<Self, crate::Error> {
@@ -204,7 +347,6 @@ impl<E: catalog::Catalog> Export<E> {
 			program_descriptors: Vec::new(),
 			program: None,
 			si: BTreeMap::new(),
-			last_si: HashMap::new(),
 			psi: None,
 			last_psi: None,
 			video_start: None,
@@ -244,6 +386,12 @@ impl<E: catalog::Catalog> Export<E> {
 				}
 				Poll::Pending => break,
 			}
+		}
+
+		// 1b. Drive the SI subscriptions, folding arrived snapshots into each
+		// entry's active set (emission happens on cadence in `write_frame`).
+		for si in self.si.values_mut() {
+			si.poll(waiter);
 		}
 
 		// 2. Pull a frame into every idle track. ExportSource has already
@@ -297,12 +445,15 @@ impl<E: catalog::Catalog> Export<E> {
 				}
 				return Poll::Pending;
 			}
-			if !self.header_ready() || !self.video_ready() {
+			if !self.header_ready() || !self.video_ready() || !self.si_ready() {
 				// Hold all output (tables and audio alike) until codec configs resolve
 				// and, when the program has a video rendition, its first keyframe is
 				// buffered: the stream must begin on that keyframe so the in-band
 				// parameter sets lead it. An audio-only program has nothing to wait for.
-				// If every track finished without producing a config, it can't be muxed.
+				// Every SI entry the catalog names must have its first snapshot too, so
+				// the service layer leads the stream instead of trailing the media by a
+				// subscription round-trip. If every track finished without producing a
+				// config, it can't be muxed.
 				if self.catalog.is_none() && self.tracks.values().all(|t| t.finished) {
 					return Poll::Ready(Ok(None));
 				}
@@ -351,7 +502,26 @@ impl<E: catalog::Catalog> Export<E> {
 		let mpegts = catalog.mpegts_mut().cloned().unwrap_or_default();
 		self.program_descriptors = mpegts.program_descriptors.clone();
 		self.program = mpegts.program.clone();
-		self.si = mpegts.si.clone();
+
+		// Reconcile the SI subscriptions with the catalog's map. Entries may appear
+		// after the PAT/PMT is built (a table acquired late): they ride standalone
+		// PIDs outside the program, so unlike the elementary tracks below they are
+		// not part of the latched layout.
+		self.si
+			.retain(|key, _| mpegts.si.get(&key.0).is_some_and(|t| t.contains_key(&key.1)));
+		for (pid, tables) in mpegts.si.iter() {
+			for (table_id, entry) in tables.iter() {
+				match self.si.get_mut(&(*pid, *table_id)) {
+					Some(existing) => existing.interval = entry.interval,
+					None => {
+						self.si.insert(
+							(*pid, *table_id),
+							SiTrack::new(&self.source, &entry.track, entry.interval),
+						);
+					}
+				}
+			}
+		}
 
 		// The desired track set: media renditions plus the verbatim streams.
 		let mut active: BTreeMap<String, ()> = BTreeMap::new();
@@ -522,6 +692,15 @@ impl<E: catalog::Catalog> Export<E> {
 			.values()
 			.filter(|t| matches!(t.kind, Kind::Video(_)))
 			.all(|t| t.pending.is_some() || t.finished)
+	}
+
+	/// Every SI entry named by the catalog has reduced its first snapshot (or
+	/// terminally failed), so the first output frame already carries the service
+	/// layer. Entries appearing later (a table acquired mid-stream) don't re-gate.
+	fn si_ready(&self) -> bool {
+		self.si
+			.values()
+			.all(|si| !si.active.is_empty() || matches!(si.state, SiState::Done))
 	}
 
 	/// The smallest timestamp among the video tracks' buffered frames: the first
@@ -763,25 +942,28 @@ impl<E: catalog::Catalog> Export<E> {
 			self.last_psi = Some(frame.timestamp);
 		}
 
-		// Re-emit each SI PID's sections verbatim on its own cadence, which is the
-		// table's own repetition requirement rather than the PSI interval: an SDT wants
-		// 2s where the PSI wants 500ms, and an EPG table would want far less again.
-		// Unknown PIDs have no declared interval and fall back to the PSI cadence.
-		// `Bytes` clones are refcount bumps, and only a due PID is collected at all.
+		// Re-emit each SI entry's sections verbatim on its own cadence, which is the
+		// table's own repetition requirement rather than the PSI interval: an SDT
+		// wants 2s where the PSI wants 500ms, and an EPG schedule slice wants 30s.
+		// Unknown tables have no declared interval and fall back to the PSI cadence.
+		// `Bytes` clones are refcount bumps, and only a due entry is collected at all.
 		let pending: Vec<(u16, Vec<Bytes>)> = self
 			.si
-			.iter()
-			.filter(|(pid, si)| {
+			.iter_mut()
+			.filter(|(_, si)| !si.active.is_empty())
+			.filter(|(_, si)| {
 				let interval = si.interval.unwrap_or(PSI_INTERVAL);
-				due(frame.timestamp, self.last_si.get(*pid).copied(), interval)
+				due(frame.timestamp, si.last_emit, interval)
 			})
-			.map(|(pid, si)| (*pid, si.sections.clone()))
+			.map(|((pid, _), si)| {
+				si.last_emit = Some(frame.timestamp);
+				(*pid, si.active.sections().cloned().collect())
+			})
 			.collect();
 		for (pid, sections) in pending {
 			for section in &sections {
 				self.write_section(&mut out, pid, section)?;
 			}
-			self.last_si.insert(pid, frame.timestamp);
 		}
 
 		match es_payload {

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -45,6 +45,12 @@ const PMT_PID: u16 = 0x1000;
 const FIRST_ES_PID: u16 = 0x1001;
 /// Re-emit PAT/PMT at least this often (wall-clock of the media) for tune-in.
 const PSI_INTERVAL: Duration = Duration::from_millis(500);
+/// How long the first output frame waits for the catalog's SI entries to deliver
+/// their first snapshot. A healthy entry resolves in one round-trip; an entry that
+/// never will (a stale announce naming a track whose publisher is gone) must not
+/// hold the programme dark, so expiry proceeds without it, exactly as a failed
+/// track is treated. Late snapshots still fold in and start emitting.
+const SI_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Subscribe to a broadcast and produce an MPEG-TS byte stream.
 ///
@@ -71,6 +77,14 @@ pub struct Export<E: catalog::Catalog = ()> {
 	/// re-emitted verbatim on its PID at its own cadence. Opaque: export never
 	/// parses a table it carries.
 	si: BTreeMap<(u16, u8), SiTrack>,
+	/// Deadline for the SI half of the first-frame gate ([`SI_READY_TIMEOUT`]),
+	/// armed the first time an entry blocks output and cleared if they all deliver
+	/// first. `None` also when no tokio runtime is present to drive it, in which
+	/// case the gate is unbounded as before.
+	si_gate: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
+	/// The deadline expired: stop gating on SI (entries keep resolving in the
+	/// background and emit once they do).
+	si_expired: bool,
 
 	/// Program tables, built once the track layout is known.
 	psi: Option<Psi>,
@@ -347,6 +361,8 @@ impl<E: catalog::Catalog> Export<E> {
 			program_descriptors: Vec::new(),
 			program: None,
 			si: BTreeMap::new(),
+			si_gate: None,
+			si_expired: false,
 			psi: None,
 			last_psi: None,
 			video_start: None,
@@ -392,6 +408,27 @@ impl<E: catalog::Catalog> Export<E> {
 		// entry's active set (emission happens on cadence in `write_frame`).
 		for si in self.si.values_mut() {
 			si.poll(waiter);
+		}
+
+		// Bound the SI half of the first-frame gate. Without a deadline, an entry
+		// that never delivers (a stale announce) would hold all output dark forever,
+		// and by this point every media source can have a frame buffered, leaving
+		// the stuck subscription as the only registered waker. Polling the sleep
+		// registers the timer as a wake source, so expiry actually re-runs us.
+		if self.psi.is_none() && !self.si_expired {
+			if self.si_delivered() {
+				self.si_gate = None;
+			} else if tokio::runtime::Handle::try_current().is_ok() {
+				let gate = self
+					.si_gate
+					.get_or_insert_with(|| Box::pin(tokio::time::sleep(SI_READY_TIMEOUT)));
+				if waiter.poll_future(gate.as_mut()).is_ready() {
+					let stuck = self.si.values().filter(|si| si.active.is_empty()).count();
+					tracing::warn!(stuck, "SI first-snapshot wait expired; starting without");
+					self.si_expired = true;
+					self.si_gate = None;
+				}
+			}
 		}
 
 		// 2. Pull a frame into every idle track. ExportSource has already
@@ -694,13 +731,20 @@ impl<E: catalog::Catalog> Export<E> {
 			.all(|t| t.pending.is_some() || t.finished)
 	}
 
-	/// Every SI entry named by the catalog has reduced its first snapshot (or
-	/// terminally failed), so the first output frame already carries the service
-	/// layer. Entries appearing later (a table acquired mid-stream) don't re-gate.
-	fn si_ready(&self) -> bool {
+	/// Every SI entry named by the catalog has reduced its first snapshot or
+	/// terminally failed.
+	fn si_delivered(&self) -> bool {
 		self.si
 			.values()
 			.all(|si| !si.active.is_empty() || matches!(si.state, SiState::Done))
+	}
+
+	/// The SI half of the first-frame gate: every entry delivered, so the first
+	/// output frame already carries the service layer, or the wait expired
+	/// ([`SI_READY_TIMEOUT`]) and output proceeds without the stragglers. Entries
+	/// appearing later (a table acquired mid-stream) don't re-gate.
+	fn si_ready(&self) -> bool {
+		self.si_expired || self.si_delivered()
 	}
 
 	/// The smallest timestamp among the video tracks' buffered frames: the first

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -71,6 +71,10 @@ pub struct Export<E: catalog::Catalog = ()> {
 	/// re-emitted verbatim on its PID at its own cadence. Opaque: export never
 	/// parses a table it carries.
 	si: BTreeMap<(u16, u8), SiTrack>,
+	/// Timestamp of the last emitted frame, stamped onto the trailing SI flush.
+	last_timestamp: Option<Timestamp>,
+	/// The trailing SI flush ran (once, just before end of stream).
+	si_flushed: bool,
 
 	/// Program tables, built once the track layout is known.
 	psi: Option<Psi>,
@@ -168,6 +172,10 @@ struct PesUnit {
 /// reduces its newest complete group into the current section set, and remembers
 /// when it last hit the wire so it re-emits on its own cadence.
 struct SiTrack {
+	/// The catalog's track name for this entry, so a catalog update that repoints
+	/// the entry at a different track (a restarted publisher) is detected and the
+	/// subscription rebuilt rather than left repeating the old track's sections.
+	track: String,
 	interval: Option<Duration>,
 	state: SiState,
 	/// The reduced newest *complete* group: what emission re-transmits.
@@ -197,6 +205,7 @@ enum SiState {
 impl SiTrack {
 	fn new(source: &crate::Source, track: &str, interval: Option<Duration>) -> Self {
 		Self {
+			track: track.to_string(),
 			interval,
 			state: SiState::Requesting(source.request_catalog(), track.to_string()),
 			active: Default::default(),
@@ -347,6 +356,8 @@ impl<E: catalog::Catalog> Export<E> {
 			program_descriptors: Vec::new(),
 			program: None,
 			si: BTreeMap::new(),
+			last_timestamp: None,
+			si_flushed: false,
 			psi: None,
 			last_psi: None,
 			video_start: None,
@@ -484,11 +495,22 @@ impl<E: catalog::Catalog> Export<E> {
 		if let Some(name) = self.pick_next_track() {
 			let frame = self.tracks.get_mut(&name).unwrap().pending.take().unwrap();
 			let out = self.write_frame(&name, frame)?;
+			self.last_timestamp = Some(out.timestamp);
 			return Poll::Ready(Ok(Some(out)));
 		}
 
 		// 5. End of stream once every track has drained and the catalog is closed.
+		// SI emission rides media frames, so a snapshot that arrived (or was
+		// revised) behind the last one would otherwise never reach the TS; flush
+		// every entry's current sections in one trailing frame first. Entries still
+		// resolving are not waited for: media is done, and a wait could be unbounded.
 		if self.catalog.is_none() && !self.tracks.is_empty() && self.tracks.values().all(|t| t.finished) {
+			if !self.si_flushed {
+				self.si_flushed = true;
+				if let Some(out) = self.write_si_tail()? {
+					return Poll::Ready(Ok(Some(out)));
+				}
+			}
 			return Poll::Ready(Ok(None));
 		}
 		if self.catalog.is_none() && self.tracks.is_empty() {
@@ -496,6 +518,37 @@ impl<E: catalog::Catalog> Export<E> {
 		}
 
 		Poll::Pending
+	}
+
+	/// The trailing SI frame for end of stream: every entry's current sections,
+	/// re-emitted once. Duplicates of already-emitted sections are harmless
+	/// repetitions; `None` when there are no tables or no program was ever built.
+	fn write_si_tail(&mut self) -> anyhow::Result<Option<Frame>> {
+		if self.psi.is_none() {
+			return Ok(None);
+		}
+		let pending: Vec<(u16, Vec<Bytes>)> = self
+			.si
+			.iter()
+			.filter(|(_, si)| !si.active.is_empty())
+			.map(|((pid, _), si)| (*pid, si.active.sections().cloned().collect()))
+			.collect();
+		if pending.is_empty() {
+			return Ok(None);
+		}
+		let timestamp = self.last_timestamp.unwrap_or(Timestamp::ZERO);
+		let mut out = Vec::new();
+		for (pid, sections) in pending {
+			for section in &sections {
+				self.write_section(&mut out, pid, section)?;
+			}
+		}
+		Ok(Some(Frame {
+			timestamp,
+			duration: None,
+			payload: Bytes::from(out),
+			keyframe: false,
+		}))
 	}
 
 	fn update_catalog(&mut self, mut catalog: Catalog<E>) -> anyhow::Result<()> {
@@ -517,6 +570,16 @@ impl<E: catalog::Catalog> Export<E> {
 		for (pid, tables) in mpegts.si.iter() {
 			for (table_id, entry) in tables.iter() {
 				match self.si.get_mut(&(*pid, *table_id)) {
+					// A repointed entry (same key, new track) rebuilds the subscription:
+					// the old track is a restarted or replaced publisher's leftover, and
+					// staying attached would repeat its stale sections forever. The last
+					// snapshot carries across so emission never goes dark mid-swap.
+					Some(existing) if existing.track != entry.track => {
+						let mut replacement = SiTrack::new(&self.source, &entry.track, entry.interval);
+						replacement.active = std::mem::take(&mut existing.active);
+						replacement.last_emit = existing.last_emit;
+						*existing = replacement;
+					}
 					Some(existing) => existing.interval = entry.interval,
 					None => {
 						self.si.insert(

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -45,12 +45,6 @@ const PMT_PID: u16 = 0x1000;
 const FIRST_ES_PID: u16 = 0x1001;
 /// Re-emit PAT/PMT at least this often (wall-clock of the media) for tune-in.
 const PSI_INTERVAL: Duration = Duration::from_millis(500);
-/// How long the first output frame waits for the catalog's SI entries to deliver
-/// their first snapshot. A healthy entry resolves in one round-trip; an entry that
-/// never will (a stale announce naming a track whose publisher is gone) must not
-/// hold the programme dark, so expiry proceeds without it, exactly as a failed
-/// track is treated. Late snapshots still fold in and start emitting.
-const SI_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Subscribe to a broadcast and produce an MPEG-TS byte stream.
 ///
@@ -77,14 +71,6 @@ pub struct Export<E: catalog::Catalog = ()> {
 	/// re-emitted verbatim on its PID at its own cadence. Opaque: export never
 	/// parses a table it carries.
 	si: BTreeMap<(u16, u8), SiTrack>,
-	/// Deadline for the SI half of the first-frame gate ([`SI_READY_TIMEOUT`]),
-	/// armed the first time an entry blocks output and cleared if they all deliver
-	/// first. `None` also when no tokio runtime is present to drive it, in which
-	/// case the gate is unbounded as before.
-	si_gate: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
-	/// The deadline expired: stop gating on SI (entries keep resolving in the
-	/// background and emit once they do).
-	si_expired: bool,
 
 	/// Program tables, built once the track layout is known.
 	psi: Option<Psi>,
@@ -361,8 +347,6 @@ impl<E: catalog::Catalog> Export<E> {
 			program_descriptors: Vec::new(),
 			program: None,
 			si: BTreeMap::new(),
-			si_gate: None,
-			si_expired: false,
 			psi: None,
 			last_psi: None,
 			video_start: None,
@@ -406,29 +390,16 @@ impl<E: catalog::Catalog> Export<E> {
 
 		// 1b. Drive the SI subscriptions, folding arrived snapshots into each
 		// entry's active set (emission happens on cadence in `write_frame`).
+		//
+		// Deliberately not part of the first-frame gate below: nothing in SI is
+		// something a TS stream cannot begin without (the PAT/PMT are built locally,
+		// and receivers acquire the service layer mid-stream by design), whereas
+		// gating on it would let a catalog entry that never delivers (a stale
+		// announce naming a dead track) hold the programme dark. An entry that
+		// resolves late simply starts emitting on its cadence from then on, at most
+		// one subscription round-trip behind the media.
 		for si in self.si.values_mut() {
 			si.poll(waiter);
-		}
-
-		// Bound the SI half of the first-frame gate. Without a deadline, an entry
-		// that never delivers (a stale announce) would hold all output dark forever,
-		// and by this point every media source can have a frame buffered, leaving
-		// the stuck subscription as the only registered waker. Polling the sleep
-		// registers the timer as a wake source, so expiry actually re-runs us.
-		if self.psi.is_none() && !self.si_expired {
-			if self.si_delivered() {
-				self.si_gate = None;
-			} else if tokio::runtime::Handle::try_current().is_ok() {
-				let gate = self
-					.si_gate
-					.get_or_insert_with(|| Box::pin(tokio::time::sleep(SI_READY_TIMEOUT)));
-				if waiter.poll_future(gate.as_mut()).is_ready() {
-					let stuck = self.si.values().filter(|si| si.active.is_empty()).count();
-					tracing::warn!(stuck, "SI first-snapshot wait expired; starting without");
-					self.si_expired = true;
-					self.si_gate = None;
-				}
-			}
 		}
 
 		// 2. Pull a frame into every idle track. ExportSource has already
@@ -482,15 +453,12 @@ impl<E: catalog::Catalog> Export<E> {
 				}
 				return Poll::Pending;
 			}
-			if !self.header_ready() || !self.video_ready() || !self.si_ready() {
+			if !self.header_ready() || !self.video_ready() {
 				// Hold all output (tables and audio alike) until codec configs resolve
 				// and, when the program has a video rendition, its first keyframe is
 				// buffered: the stream must begin on that keyframe so the in-band
 				// parameter sets lead it. An audio-only program has nothing to wait for.
-				// Every SI entry the catalog names must have its first snapshot too, so
-				// the service layer leads the stream instead of trailing the media by a
-				// subscription round-trip. If every track finished without producing a
-				// config, it can't be muxed.
+				// If every track finished without producing a config, it can't be muxed.
 				if self.catalog.is_none() && self.tracks.values().all(|t| t.finished) {
 					return Poll::Ready(Ok(None));
 				}
@@ -729,22 +697,6 @@ impl<E: catalog::Catalog> Export<E> {
 			.values()
 			.filter(|t| matches!(t.kind, Kind::Video(_)))
 			.all(|t| t.pending.is_some() || t.finished)
-	}
-
-	/// Every SI entry named by the catalog has reduced its first snapshot or
-	/// terminally failed.
-	fn si_delivered(&self) -> bool {
-		self.si
-			.values()
-			.all(|si| !si.active.is_empty() || matches!(si.state, SiState::Done))
-	}
-
-	/// The SI half of the first-frame gate: every entry delivered, so the first
-	/// output frame already carries the service layer, or the wait expired
-	/// ([`SI_READY_TIMEOUT`]) and output proceeds without the stragglers. Entries
-	/// appearing later (a table acquired mid-stream) don't re-gate.
-	fn si_ready(&self) -> bool {
-		self.si_expired || self.si_delivered()
 	}
 
 	/// The smallest timestamp among the video tracks' buffered frames: the first

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1261,26 +1261,10 @@ async fn scte35_fixtures_survive_roundtrip() {
 	}
 }
 
-/// Build a PSI section: `table_id`, the 12-bit `section_length` (covering `body` plus a
-/// 4-byte CRC), then `body` and a dummy CRC. The reassembler carries it verbatim and
-/// never validates the CRC, so the bytes only need a self-consistent length.
-fn make_section(table_id: u8, body: &[u8]) -> Vec<u8> {
-	let section_length = body.len() + 4;
-	let mut s = vec![
-		table_id,
-		0xb0 | ((section_length >> 8) as u8 & 0x0f),
-		(section_length & 0xff) as u8,
-	];
-	s.extend_from_slice(body);
-	s.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
-	s
-}
-
 /// Build a well-formed long-form section: the full generic header (extension,
 /// current version, `number` of `last`), then `body` and a CRC placeholder
 /// (capture is verbatim, nothing checks it). The SI store buffers a sub-table
-/// until its generation completes, so unlike [`make_section`] the header fields
-/// here must be coherent.
+/// until its generation completes, so the header fields must be coherent.
 fn make_long_section(table_id: u8, ext: u16, version: u8, number: u8, last: u8, body: &[u8]) -> Vec<u8> {
 	let section_length = 5 + body.len() + 4;
 	let mut s = vec![
@@ -1924,11 +1908,11 @@ async fn content_section_churn_at_the_cap_cuts_no_group() {
 	assert_eq!(groups[0].len(), 32, "the snapshot holds the cap's worth of sections");
 }
 
-/// The first-frame SI gate must have a deadline: an advertised entry whose track
-/// resolves but never delivers a snapshot (a stale announce) must not hold the
-/// whole programme dark. After [`SI_READY_TIMEOUT`] the export starts without it.
+/// SI never gates output: an advertised entry whose track resolves but never
+/// delivers a snapshot (a stale announce) must not hold the programme dark.
+/// Media flows immediately and the entry simply emits nothing.
 #[tokio::test(start_paused = true)]
-async fn si_gate_expires_on_a_stale_entry() {
+async fn stale_si_entry_does_not_block_output() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog =
@@ -1981,11 +1965,11 @@ async fn si_gate_expires_on_a_stale_entry() {
 	let mut exporter = Export::with_ts(crate::source::announced(&consumer), crate::catalog::CatalogFormat::Hang)
 		.await
 		.unwrap();
-	// Paused time auto-advances to the gate's deadline; a generous outer timeout
-	// distinguishes "expired and produced output" from "held dark forever".
-	let frame = tokio::time::timeout(Duration::from_secs(60), exporter.next())
+	// The timeout distinguishes "produced output promptly" from "held dark";
+	// under paused time a wedged exporter would hit it instantly.
+	let frame = tokio::time::timeout(Duration::from_secs(1), exporter.next())
 		.await
-		.expect("the SI gate must expire rather than hold output dark")
+		.expect("a stale SI entry must not hold output dark")
 		.unwrap()
 		.expect("a muxed frame");
 	assert!(!frame.payload.is_empty());

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -2569,3 +2569,37 @@ async fn si_revision_after_final_media_frame_is_flushed() {
 		.unwrap();
 	assert!(end.is_none(), "end of stream after the trailing flush");
 }
+
+/// Two captures overlapping on one broadcast (a supervisor restarting its
+/// importer before the old one is dropped) contend for the same `(PID, table_id)`
+/// key: the newer one wins the catalog mapping under a fallback track name, and
+/// the older one's teardown must not strip it, since the survivor never
+/// re-advertises.
+#[tokio::test(start_paused = true)]
+async fn overlapping_capture_teardown_keeps_the_survivors_mapping() {
+	let sdt = make_long_section(0x42, 1, 0, 0, 0, &[0xaa; 4]);
+	let mut input = si_packet(0x0011, &sdt);
+	input.extend_from_slice(&si_packet_cc(0x0011, &sdt, 1));
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let _consumer = broadcast.consume();
+	let catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let mut old = crate::container::ts::Import::new(broadcast.clone(), catalog.reserve());
+	old.decode(&BytesMut::from(&input[..])).unwrap();
+
+	// The replacement importer captures the same table; its deterministic track
+	// name is taken, so it advertises under a fallback name, overwriting the key.
+	let mut new = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	new.decode(&BytesMut::from(&input[..])).unwrap();
+	let survivor = catalog.snapshot().mpegts.si[&0x0011][&0x42].track.clone();
+	assert_ne!(survivor, "0x0011-0x42.si", "the replacement fell back to a unique name");
+
+	drop(old);
+	assert_eq!(
+		catalog.snapshot().mpegts.si[&0x0011][&0x42].track,
+		survivor,
+		"the old capture's teardown left the survivor's mapping in place"
+	);
+}

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -2603,3 +2603,62 @@ async fn overlapping_capture_teardown_keeps_the_survivors_mapping() {
 		"the old capture's teardown left the survivor's mapping in place"
 	);
 }
+
+/// A contiguous commit replaces even a same-version active generation: versions
+/// are five bits, so a reception gap can bring the same value back with fewer
+/// sections, and merging would resurrect the removed one forever.
+#[tokio::test(start_paused = true)]
+async fn contiguous_same_version_commit_replaces_stale_sections() {
+	let sdt = |number: u8, last: u8, fill: u8| make_long_section(0x42, 1, 0, number, last, &[fill; 4]);
+
+	// Three sections at v0, committed contiguously.
+	let mut input = si_packet(0x0011, &sdt(0, 2, 0xa0));
+	input.extend_from_slice(&si_packet_cc(0x0011, &sdt(1, 2, 0xa1), 1));
+	input.extend_from_slice(&si_packet_cc(0x0011, &sdt(2, 2, 0xa2), 2));
+	// After a gap the table comes back at v0 again (wrapped), now two sections.
+	let b0 = sdt(0, 1, 0xb0);
+	let b1 = sdt(1, 1, 0xb1);
+	input.extend_from_slice(&si_packet_cc(0x0011, &b0, 3));
+	input.extend_from_slice(&si_packet_cc(0x0011, &b1, 4));
+	let mut rig = si_rig();
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	rig.import.finish().unwrap();
+
+	let si = rig.catalog.snapshot().mpegts.si.clone();
+	assert_eq!(
+		read_si_sections(&rig.consumer, &si[&0x0011][&0x42].track).await,
+		vec![Bytes::from(b0), Bytes::from(b1)],
+		"the complete new generation retired the stale third section"
+	);
+}
+
+/// The cut debounce runs on the host clock, so a revision publishes even when no
+/// media ever advances a PTS (an audio-only or SI-only input). This test spends
+/// real wall time on the debounce window; media timestamps stay pinned at zero
+/// throughout, which is exactly the case a media-clock debounce wedges on.
+#[tokio::test(start_paused = true)]
+async fn debounce_opens_without_a_media_clock() {
+	let sdt = |version: u8, fill: u8| make_long_section(0x42, 1, version, 0, 0, &[fill; 4]);
+	let mut rig = si_rig();
+
+	let mut input = si_packet(0x0011, &sdt(0, 0xaa));
+	input.extend_from_slice(&si_packet_cc(0x0011, &sdt(0, 0xaa), 1));
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+
+	let name = rig.catalog.snapshot().mpegts.si[&0x0011][&0x42].track.clone();
+	let track = rig.consumer.track(&name).unwrap().subscribe(None).await.unwrap();
+	assert_eq!(track.latest(), Some(0), "the first snapshot cut immediately");
+
+	// A revision inside the window is coalesced...
+	rig.import
+		.decode(&BytesMut::from(&si_packet_cc(0x0011, &sdt(1, 0xbb), 2)[..]))
+		.unwrap();
+	assert_eq!(track.latest(), Some(0), "a revision inside the window is held");
+
+	// ...and publishes once the window passes in *real* time, no finish, no PTS.
+	std::thread::sleep(std::time::Duration::from_millis(1200));
+	rig.import
+		.decode(&BytesMut::from(&si_packet_cc(0x0011, &sdt(1, 0xbb), 3)[..]))
+		.unwrap();
+	assert_eq!(track.latest(), Some(1), "the held revision cut after the window");
+}

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1814,42 +1814,189 @@ async fn sdt_other_networks_do_not_collide() {
 }
 
 /// A next-version section (current_next_indicator clear) describes a future state
-/// and is dropped: only what is currently in force is carried.
+/// and is dropped: only what is currently in force is carried. The current NIT is
+/// the positive control proving the pipeline ran; a lone dropped packet would pass
+/// vacuously, since sync lock needs a second packet before anything routes.
 #[tokio::test(start_paused = true)]
 async fn next_version_sections_are_dropped() {
 	let mut next = make_long_section(0x42, 1, 3, 0, 0, &[0xaa; 4]);
 	next[5] &= !0x01;
+	let nit = make_long_section(0x40, 1, 0, 0, 0, &[0xbb; 4]);
 
+	let mut input = si_packet(0x0011, &next);
+	input.extend_from_slice(&si_packet_cc(0x0011, &next, 1));
+	input.extend_from_slice(&si_packet(0x0010, &nit));
+	input.extend_from_slice(&si_packet_cc(0x0010, &nit, 1));
 	let mut rig = si_rig();
-	rig.import
-		.decode(&BytesMut::from(&si_packet(0x0011, &next)[..]))
-		.unwrap();
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
 	rig.import.finish().unwrap();
 
-	assert!(
-		rig.catalog.snapshot().mpegts.si.is_empty(),
-		"a next-version section creates no entry"
-	);
+	let si = rig.catalog.snapshot().mpegts.si.clone();
+	assert!(si.contains_key(&0x0010), "the current NIT was captured (control)");
+	assert!(!si.contains_key(&0x0011), "a next-version section creates no entry");
 }
 
 /// TDT/TOT (0x0014) stays out by policy: it is a clock, not state, so every
 /// section is new content, and an exporter's own clock beats a time relayed from
-/// an upstream multiplexer of unknown delay.
+/// an upstream multiplexer of unknown delay. The SDT is the positive control
+/// proving the pipeline ran.
 #[tokio::test(start_paused = true)]
 async fn tdt_is_not_captured() {
 	// A short-form TDT: table_id 0x70, no long-form header.
-	let tdt = make_section(0x70, &[0xc0, 0x79, 0x12, 0x34, 0x56]);
+	let tdt = make_short_section(0x70, &[0xc0, 0x79, 0x12, 0x34, 0x56]);
+	let sdt = make_long_section(0x42, 1, 0, 0, 0, &[0xaa; 4]);
 
+	let mut input = si_packet(0x0014, &tdt);
+	input.extend_from_slice(&si_packet_cc(0x0014, &tdt, 1));
+	input.extend_from_slice(&si_packet(0x0011, &sdt));
+	input.extend_from_slice(&si_packet_cc(0x0011, &sdt, 1));
 	let mut rig = si_rig();
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	rig.import.finish().unwrap();
+
+	let si = rig.catalog.snapshot().mpegts.si.clone();
+	assert!(si.contains_key(&0x0011), "the SDT was captured (control)");
+	assert!(
+		!si.contains_key(&0x0014),
+		"TDT is not captured; the omission is policy, not oversight"
+	);
+}
+
+/// Build a well-formed short-form section (syntax indicator clear): header + body,
+/// no extension, versioning, or CRC.
+fn make_short_section(table_id: u8, body: &[u8]) -> Vec<u8> {
+	let mut s = vec![
+		table_id,
+		0x30 | ((body.len() >> 8) as u8 & 0x0f),
+		(body.len() & 0xff) as u8,
+	];
+	s.extend_from_slice(body);
+	s
+}
+
+/// Aborting the importer must remove the advertised SI entries from the catalog:
+/// a map naming aborted tracks would strand every later exporter on subscriptions
+/// that can never deliver.
+#[tokio::test(start_paused = true)]
+async fn abort_removes_si_catalog_entries() {
+	let sdt = make_long_section(0x42, 1, 0, 0, 0, &[0xaa; 4]);
+	// Twice: sync lock needs a second packet before the first routes at all.
+	let mut input = si_packet(0x0011, &sdt);
+	input.extend_from_slice(&si_packet_cc(0x0011, &sdt, 1));
+	let mut rig = si_rig();
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	assert!(
+		!rig.catalog.snapshot().mpegts.si.is_empty(),
+		"the SDT entry was advertised"
+	);
+
+	rig.import.abort(moq_net::Error::Cancel);
+	assert!(
+		rig.catalog.snapshot().mpegts.si.is_empty(),
+		"abort removed the advertised entries"
+	);
+}
+
+/// Content-identified sections (short-form: no version, nothing to revise in
+/// place) are retained up to a cap, and churn at the cap is not a change: a
+/// clock-like table whose every repetition differs would otherwise cut a group
+/// per debounce forever, carrying the cap's worth of stale sections.
+#[tokio::test(start_paused = true)]
+async fn content_section_churn_at_the_cap_cuts_no_group() {
+	let section = |i: u8| make_short_section(0x72, &[i, 0x00, 0xee]);
+
+	// One over the cap in one batch: the 33rd evicts the 1st.
+	let mut input = Vec::new();
+	for i in 0..33u8 {
+		input.extend_from_slice(&si_packet_cc(0x0011, &section(i), i & 0x0f));
+	}
+	let mut rig = si_rig();
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	// Another distinct section, pure rotation at the cap: must not re-dirty.
 	rig.import
-		.decode(&BytesMut::from(&si_packet(0x0014, &tdt)[..]))
+		.decode(&BytesMut::from(&si_packet_cc(0x0011, &section(33), 1)[..]))
 		.unwrap();
 	rig.import.finish().unwrap();
 
+	let si = rig.catalog.snapshot().mpegts.si.clone();
+	let groups = read_si_groups(&rig.consumer, &si[&0x0011][&0x72].track).await;
+	assert_eq!(groups.len(), 1, "rotation at the cap cut no further group");
+	assert_eq!(groups[0].len(), 32, "the snapshot holds the cap's worth of sections");
+}
+
+/// The first-frame SI gate must have a deadline: an advertised entry whose track
+/// resolves but never delivers a snapshot (a stale announce) must not hold the
+/// whole programme dark. After [`SI_READY_TIMEOUT`] the export starts without it.
+#[tokio::test(start_paused = true)]
+async fn si_gate_expires_on_a_stale_entry() {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+
+	// A track that exists (the subscription resolves) but never produces a group.
+	let ghost = broadcast.create_track("ghost.si", None).unwrap();
+
+	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
+	let track = broadcast
+		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.unwrap();
+	let name = track.name().to_string();
+	{
+		let mut guard = catalog.lock();
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0,
+			level: 0x1f,
+			inline: false,
+		});
+		cfg.container = Container::Legacy;
+		cfg.description = Some(avcc);
+		guard.video.renditions.insert(name.clone(), cfg);
+		guard.mpegts.si.entry(0x0011).or_default().insert(
+			0x42,
+			tscat::SiEntry {
+				track: "ghost.si".to_string(),
+				interval: Some(Duration::from_secs(2)),
+				..Default::default()
+			},
+		);
+	}
+
+	let mut producer = Producer::new(track, HangContainer::Legacy);
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xAB, 64));
+	producer
+		.write(Frame {
+			timestamp: Timestamp::ZERO,
+			duration: None,
+			payload: length_prefixed(&[&idr]),
+			keyframe: true,
+		})
+		.unwrap();
+	producer.cut(None).unwrap();
+	producer.finish().unwrap();
+
+	let mut exporter = Export::with_ts(crate::source::announced(&consumer), crate::catalog::CatalogFormat::Hang)
+		.await
+		.unwrap();
+	// Paused time auto-advances to the gate's deadline; a generous outer timeout
+	// distinguishes "expired and produced output" from "held dark forever".
+	let frame = tokio::time::timeout(Duration::from_secs(60), exporter.next())
+		.await
+		.expect("the SI gate must expire rather than hold output dark")
+		.unwrap()
+		.expect("a muxed frame");
+	assert!(!frame.payload.is_empty());
 	assert!(
-		rig.catalog.snapshot().mpegts.si.is_empty(),
-		"TDT is not captured; the omission is policy, not oversight"
+		!frame
+			.payload
+			.chunks_exact(188)
+			.any(|p| ((((p[1] & 0x1f) as u16) << 8) | p[2] as u16) == 0x0011),
+		"nothing was emitted for the undelivered entry"
 	);
+	drop(ghost);
 }
 
 /// A raw Opus packet: a one-byte TOC (config 1 = SILK NB 20 ms, stereo, code 0) plus

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1276,9 +1276,73 @@ fn make_section(table_id: u8, body: &[u8]) -> Vec<u8> {
 	s
 }
 
+/// Build a well-formed long-form section: the full generic header (extension,
+/// current version, `number` of `last`), then `body` and a CRC placeholder
+/// (capture is verbatim, nothing checks it). The SI store buffers a sub-table
+/// until its generation completes, so unlike [`make_section`] the header fields
+/// here must be coherent.
+fn make_long_section(table_id: u8, ext: u16, version: u8, number: u8, last: u8, body: &[u8]) -> Vec<u8> {
+	let section_length = 5 + body.len() + 4;
+	let mut s = vec![
+		table_id,
+		0xb0 | ((section_length >> 8) as u8 & 0x0f),
+		(section_length & 0xff) as u8,
+		(ext >> 8) as u8,
+		(ext & 0xff) as u8,
+		0xc0 | (version << 1) | 0x01,
+		number,
+		last,
+	];
+	s.extend_from_slice(body);
+	s.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+	s
+}
+
+/// Read an SI snapshot track from the start: every group, as its frames' payloads.
+async fn read_si_groups(consumer: &moq_net::broadcast::Consumer, name: &str) -> Vec<Vec<Bytes>> {
+	let mut track = consumer
+		.track(name)
+		.unwrap()
+		.subscribe(moq_net::track::Subscription::default().with_start(moq_net::track::Position::group(0)))
+		.await
+		.unwrap();
+	let mut groups = Vec::new();
+	while let Some(mut group) = track.recv_group().await.unwrap() {
+		let mut frames = Vec::new();
+		while let Some(frame) = kio::wait(|waiter| group.poll_read_frame(waiter)).await.unwrap() {
+			frames.push(frame.payload);
+		}
+		groups.push(frames);
+	}
+	groups
+}
+
+/// The newest snapshot of an SI track, reduced to its sections.
+async fn read_si_sections(consumer: &moq_net::broadcast::Consumer, name: &str) -> Vec<Bytes> {
+	let groups = read_si_groups(consumer, name).await;
+	let frames = groups.last().expect("at least one snapshot group");
+	frames
+		.iter()
+		.flat_map(crate::container::ts::si::split_sections)
+		.collect()
+}
+
 /// Wrap a complete section in one PUSI TS packet on `pid` (pointer_field 0), padded to 188.
 fn si_packet(pid: u16, section: &[u8]) -> Vec<u8> {
-	let mut p = vec![0x47, 0x40 | ((pid >> 8) as u8 & 0x1f), (pid & 0xff) as u8, 0x10, 0x00];
+	si_packet_cc(pid, section, 0)
+}
+
+/// [`si_packet`] with an explicit continuity counter. A repetition must vary the
+/// counter to reach the SI store at all: a byte-identical packet is dropped as a TS
+/// duplicate before reassembly.
+fn si_packet_cc(pid: u16, section: &[u8], cc: u8) -> Vec<u8> {
+	let mut p = vec![
+		0x47,
+		0x40 | ((pid >> 8) as u8 & 0x1f),
+		(pid & 0xff) as u8,
+		0x10 | (cc & 0x0f),
+		0x00,
+	];
 	p.extend_from_slice(section);
 	assert!(p.len() <= 188, "section overflows one TS packet");
 	p.resize(188, 0xff);
@@ -1349,13 +1413,15 @@ fn parse_sdt_service(sec: &[u8]) -> (u8, String, String) {
 #[tokio::test(start_paused = true)]
 async fn service_layer_survives_roundtrip() {
 	let data = include_bytes!("test_data/bbb.ts");
-	let nit = make_section(0x40, &[0x12, 0x34, 0xff, 0x01]);
+	let nit = make_long_section(0x40, 0x1234, 1, 0, 0, &[0xff, 0x01]);
 
 	// Prepend a synthetic NIT Actual packet (0x0010); prepend keeps bbb's alignment.
 	// Twice, because real SI repeats every few seconds: the repetition must collapse
-	// into the same single section rather than accumulating a duplicate.
+	// into the same single committed section rather than cutting a second group. The
+	// repeat varies the continuity counter so it reaches the store (an identical
+	// packet would be dropped as a TS duplicate before reassembly).
 	let mut input = si_packet(0x0010, &nit);
-	input.extend_from_slice(&si_packet(0x0010, &nit));
+	input.extend_from_slice(&si_packet_cc(0x0010, &nit, 1));
 	input.extend_from_slice(&data[..]);
 
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
@@ -1373,25 +1439,44 @@ async fn service_layer_survives_roundtrip() {
 	assert_eq!(program.program_number, 1, "program number captured from the PAT");
 	assert_eq!(program.pmt_pid, 0x1000, "original PMT PID captured from the PAT");
 	let si = snapshot.mpegts.si.clone();
-	let entry = |pid: u16| si.get(&pid).expect("an SI entry for the PID");
+	let entry = |pid: u16, table_id: u8| {
+		si.get(&pid)
+			.and_then(|tables| tables.get(&table_id))
+			.expect("an SI entry for the (PID, table_id)")
+	};
 
-	assert_eq!(entry(0x0011).sections.len(), 1, "bbb.ts carries one SDT section");
-	let sdt = entry(0x0011).sections[0].clone();
-	assert_eq!(sdt.first(), Some(&0x42), "SDT Actual (table_id 0x42)");
+	let sdt_entry = entry(0x0011, 0x42);
 	assert_eq!(
-		entry(0x0011).interval,
+		sdt_entry.interval,
 		Some(std::time::Duration::from_secs(2)),
 		"the DVB SDT interval was filled in"
 	);
+	let sdt_sections = read_si_sections(&consumer, &sdt_entry.track).await;
+	assert_eq!(sdt_sections.len(), 1, "bbb.ts carries one SDT section");
+	let sdt = sdt_sections[0].clone();
+	assert_eq!(sdt.first(), Some(&0x42), "SDT Actual (table_id 0x42)");
 	let (service_type, provider, name) = parse_sdt_service(&sdt);
 	assert_eq!(
 		(service_type, provider.as_str(), name.as_str()),
 		(0x01, "FFmpeg", "Service01")
 	);
+
+	let nit_entry = entry(0x0010, 0x40);
 	assert_eq!(
-		entry(0x0010).sections,
-		vec![Bytes::from(make_section(0x40, &[0x12, 0x34, 0xff, 0x01]))],
-		"the repeated NIT deduped to one section"
+		nit_entry.interval,
+		Some(std::time::Duration::from_secs(10)),
+		"the DVB NIT interval was filled in"
+	);
+	let nit_groups = read_si_groups(&consumer, &nit_entry.track).await;
+	assert_eq!(
+		nit_groups.len(),
+		1,
+		"the repeated NIT committed once; a repetition cuts no group"
+	);
+	assert_eq!(
+		nit_groups[0],
+		vec![Bytes::from(nit.clone())],
+		"the NIT snapshot is the section, byte-for-byte"
 	);
 
 	// `import` and `catalog` stay alive: retained tracks the exporter subscribes to.
@@ -1420,7 +1505,7 @@ async fn service_layer_survives_roundtrip() {
 
 	// Re-import: the SDT and NIT must come back byte-for-byte.
 	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
-	let _consumer2 = broadcast2.consume();
+	let consumer2 = broadcast2.consume();
 	let catalog2 =
 		crate::catalog::Producer::with_catalog(&mut broadcast2, crate::catalog::hang::Catalog::<tscat::Ext>::default())
 			.unwrap();
@@ -1443,7 +1528,17 @@ async fn service_layer_survives_roundtrip() {
 		"program number survived"
 	);
 	assert_eq!(program2.pmt_pid, program.pmt_pid, "PMT PID survived");
-	assert_eq!(snapshot2.mpegts.si, si, "every SI PID survived byte-for-byte");
+	assert_eq!(snapshot2.mpegts.si, si, "every SI entry survived the round-trip");
+	assert_eq!(
+		read_si_sections(&consumer2, &snapshot2.mpegts.si[&0x0011][&0x42].track).await,
+		vec![sdt],
+		"the SDT survived byte-for-byte"
+	);
+	assert_eq!(
+		read_si_sections(&consumer2, &snapshot2.mpegts.si[&0x0010][&0x40].track).await,
+		vec![Bytes::from(nit)],
+		"the NIT survived byte-for-byte"
+	);
 }
 
 /// Each SI PID must be re-emitted on its own interval, independently of the PSI cadence
@@ -1464,6 +1559,23 @@ async fn si_pids_are_re_emitted_on_their_own_interval() {
 		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
 		.unwrap();
 	let name = track.name().to_string();
+
+	// SI snapshot tracks, one group each: an SDT (2s) and a NIT (10s).
+	let mut sdt_track = broadcast.create_track("0x0011-0x42.si", None).unwrap();
+	sdt_track
+		.write_frame(
+			Timestamp::ZERO,
+			Bytes::from(make_long_section(0x42, 1, 0, 0, 0, &[0xaa; 8])),
+		)
+		.unwrap();
+	let mut nit_track = broadcast.create_track("0x0010-0x40.si", None).unwrap();
+	nit_track
+		.write_frame(
+			Timestamp::ZERO,
+			Bytes::from(make_long_section(0x40, 1, 0, 0, 0, &[0xbb; 8])),
+		)
+		.unwrap();
+
 	{
 		let mut guard = catalog.lock();
 		let mut cfg = VideoConfig::new(H264 {
@@ -1477,18 +1589,18 @@ async fn si_pids_are_re_emitted_on_their_own_interval() {
 		guard.video.renditions.insert(name.clone(), cfg);
 
 		// SDT every 2s, NIT every 10s: the DVB maxima import fills in.
-		guard.mpegts.si.insert(
-			0x0011,
-			tscat::Si {
-				sections: vec![Bytes::from(make_section(0x42, &[0xaa; 8]))],
+		guard.mpegts.si.entry(0x0011).or_default().insert(
+			0x42,
+			tscat::SiEntry {
+				track: "0x0011-0x42.si".to_string(),
 				interval: Some(Duration::from_secs(2)),
 				..Default::default()
 			},
 		);
-		guard.mpegts.si.insert(
-			0x0010,
-			tscat::Si {
-				sections: vec![Bytes::from(make_section(0x40, &[0xbb; 8]))],
+		guard.mpegts.si.entry(0x0010).or_default().insert(
+			0x40,
+			tscat::SiEntry {
+				track: "0x0010-0x40.si".to_string(),
 				interval: Some(Duration::from_secs(10)),
 				..Default::default()
 			},
@@ -1538,17 +1650,17 @@ async fn si_pids_are_re_emitted_on_their_own_interval() {
 /// A DVB SI section larger than one TS packet must be reassembled and captured verbatim.
 /// `si_packet` only covers a single-packet section; a real SDT with several services (or a
 /// NIT) spans packets, exercising the `SectionReassembler` PUSI + continuity path that
-/// feeds `service.sdt`. The body is arbitrary here (capture is verbatim, not parsed).
-#[test]
-fn multi_packet_si_section_is_captured() {
+/// feeds the SI store. The body is arbitrary here (capture is verbatim, not parsed).
+#[tokio::test(start_paused = true)]
+async fn multi_packet_si_section_is_captured() {
 	// 400-byte body forces the SDT Actual across three TS packets (183 + 184 + rest).
 	let body: Vec<u8> = (0..400u16).map(|i| i as u8).collect();
-	let sdt = make_section(0x42, &body);
+	let sdt = make_long_section(0x42, 1, 0, 0, 0, &body);
 	let input = si_packets_multi(0x0011, &sdt);
 	assert!(input.len() > 188, "the SDT must span more than one TS packet");
 
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
-	let _consumer = broadcast.consume();
+	let consumer = broadcast.consume();
 	let catalog =
 		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
 			.unwrap();
@@ -1557,10 +1669,186 @@ fn multi_packet_si_section_is_captured() {
 	import.finish().unwrap();
 
 	let si = catalog.snapshot().mpegts.si.clone();
+	let entry = si
+		.get(&0x0011)
+		.and_then(|tables| tables.get(&0x42))
+		.expect("an SDT entry");
 	assert_eq!(
-		si.get(&0x0011).expect("an SDT entry").sections,
+		read_si_sections(&consumer, &entry.track).await,
 		vec![Bytes::from(sdt)],
 		"the multi-packet SDT was reassembled and captured byte-for-byte"
+	);
+}
+
+/// Import rig for SI-only fixtures: importer, catalog, and a consumer, all kept
+/// alive so the SI tracks stay readable after `finish`.
+struct SiRig {
+	import: crate::container::ts::Import<tscat::Ext>,
+	catalog: crate::catalog::Producer<tscat::Ext>,
+	consumer: moq_net::broadcast::Consumer,
+}
+
+fn si_rig() -> SiRig {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let import = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	SiRig {
+		import,
+		catalog,
+		consumer,
+	}
+}
+
+/// #2881: a multi-section table revised one section at a time must never publish a
+/// torn set. The store buffers the incoming generation and commits it atomically,
+/// so every snapshot group holds a single version.
+#[tokio::test(start_paused = true)]
+async fn torn_transition_is_never_published() {
+	let sdt = |version: u8, number: u8, fill: u8| make_long_section(0x42, 1, version, number, 1, &[fill; 4]);
+	let mut rig = si_rig();
+
+	// Version 5 arrives complete in one batch.
+	let mut input = si_packet(0x0011, &sdt(5, 0, 0xaa));
+	input.extend_from_slice(&si_packet_cc(0x0011, &sdt(5, 1, 0xab), 1));
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	// Version 6 arrives torn across two batches; the intermediate state (section 0
+	// at v6, section 1 still v5) must never hit the track.
+	rig.import
+		.decode(&BytesMut::from(&si_packet_cc(0x0011, &sdt(6, 0, 0xba), 2)[..]))
+		.unwrap();
+	rig.import
+		.decode(&BytesMut::from(&si_packet_cc(0x0011, &sdt(6, 1, 0xbb), 3)[..]))
+		.unwrap();
+	rig.import.finish().unwrap();
+
+	let si = rig.catalog.snapshot().mpegts.si.clone();
+	let track = &si[&0x0011][&0x42].track;
+	let groups = read_si_groups(&rig.consumer, track).await;
+	assert!(!groups.is_empty(), "at least one snapshot group");
+	for (i, frames) in groups.iter().enumerate() {
+		let versions: Vec<u8> = frames
+			.iter()
+			.flat_map(crate::container::ts::si::split_sections)
+			.map(|section| (section[5] >> 1) & 0x1f)
+			.collect();
+		assert!(
+			versions.windows(2).all(|w| w[0] == w[1]),
+			"group {i} mixes versions: {versions:?}"
+		);
+	}
+	assert_eq!(
+		read_si_sections(&rig.consumer, track).await,
+		vec![Bytes::from(sdt(6, 0, 0xba)), Bytes::from(sdt(6, 1, 0xbb))],
+		"the newest snapshot is version 6, complete"
+	);
+}
+
+/// EIT rides per-table entries (#2800): now/next (0x4E) and schedule (0x50) each
+/// get their own track and their own cadence, and the schedule's deliberately
+/// sparse section numbering (segments skip unused numbers) commits on cycle wrap
+/// rather than waiting for a contiguity that never comes.
+#[tokio::test(start_paused = true)]
+async fn eit_now_next_and_schedule_are_captured() {
+	// Body layout past the generic header: TSID(2), ONID(2), then filler.
+	let pf0 = make_long_section(0x4E, 1, 0, 0, 1, &[0x00, 0x01, 0x00, 0x02, 0x01, 0x4E, 0xaa]);
+	let pf1 = make_long_section(0x4E, 1, 0, 1, 1, &[0x00, 0x01, 0x00, 0x02, 0x01, 0x4E, 0xbb]);
+	let sc0 = make_long_section(0x50, 1, 0, 0, 8, &[0x00, 0x01, 0x00, 0x02, 0x08, 0x50, 0xcc]);
+	let sc8 = make_long_section(0x50, 1, 0, 8, 8, &[0x00, 0x01, 0x00, 0x02, 0x08, 0x50, 0xdd]);
+
+	let mut input = Vec::new();
+	for (cc, section) in [&pf0, &pf1, &sc0, &sc8, &sc0].into_iter().enumerate() {
+		input.extend_from_slice(&si_packet_cc(0x0012, section, cc as u8));
+	}
+	let mut rig = si_rig();
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	rig.import.finish().unwrap();
+
+	let si = rig.catalog.snapshot().mpegts.si.clone();
+	let eit = si.get(&0x0012).expect("EIT entries");
+
+	let pf = eit.get(&0x4E).expect("a now/next entry");
+	assert_eq!(pf.interval, Some(Duration::from_secs(2)), "now/next actual: 2s");
+	assert_eq!(
+		read_si_sections(&rig.consumer, &pf.track).await,
+		vec![Bytes::from(pf0), Bytes::from(pf1)],
+		"now/next committed on contiguity"
+	);
+
+	let sched = eit.get(&0x50).expect("a schedule entry");
+	assert_eq!(sched.interval, Some(Duration::from_secs(10)), "schedule actual: 10s");
+	assert_eq!(
+		read_si_sections(&rig.consumer, &sched.track).await,
+		vec![Bytes::from(sc0), Bytes::from(sc8)],
+		"the sparse schedule committed on cycle wrap"
+	);
+}
+
+/// #2842: SDT other sections from two networks that reuse a transport_stream_id
+/// must not collide. The identity reads original_network_id (bytes 8..10) for
+/// table_id 0x46, so both survive as separate sub-tables; a revision within one
+/// network still replaces in place.
+#[tokio::test(start_paused = true)]
+async fn sdt_other_networks_do_not_collide() {
+	// Same TSID (the extension), different ONID leading the body.
+	let net1 = make_long_section(0x46, 7, 0, 0, 0, &[0x00, 0x01, 0xaa]);
+	let net2 = make_long_section(0x46, 7, 0, 0, 0, &[0x00, 0x02, 0xbb]);
+	let net1v2 = make_long_section(0x46, 7, 1, 0, 0, &[0x00, 0x01, 0xcc]);
+
+	let mut input = si_packet(0x0011, &net1);
+	input.extend_from_slice(&si_packet_cc(0x0011, &net2, 1));
+	input.extend_from_slice(&si_packet_cc(0x0011, &net1v2, 2));
+	let mut rig = si_rig();
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	rig.import.finish().unwrap();
+
+	let si = rig.catalog.snapshot().mpegts.si.clone();
+	let entry = &si[&0x0011][&0x46];
+	assert_eq!(
+		read_si_sections(&rig.consumer, &entry.track).await,
+		vec![Bytes::from(net1v2), Bytes::from(net2)],
+		"both networks survive; the revision replaced only its own network"
+	);
+}
+
+/// A next-version section (current_next_indicator clear) describes a future state
+/// and is dropped: only what is currently in force is carried.
+#[tokio::test(start_paused = true)]
+async fn next_version_sections_are_dropped() {
+	let mut next = make_long_section(0x42, 1, 3, 0, 0, &[0xaa; 4]);
+	next[5] &= !0x01;
+
+	let mut rig = si_rig();
+	rig.import
+		.decode(&BytesMut::from(&si_packet(0x0011, &next)[..]))
+		.unwrap();
+	rig.import.finish().unwrap();
+
+	assert!(
+		rig.catalog.snapshot().mpegts.si.is_empty(),
+		"a next-version section creates no entry"
+	);
+}
+
+/// TDT/TOT (0x0014) stays out by policy: it is a clock, not state, so every
+/// section is new content, and an exporter's own clock beats a time relayed from
+/// an upstream multiplexer of unknown delay.
+#[tokio::test(start_paused = true)]
+async fn tdt_is_not_captured() {
+	// A short-form TDT: table_id 0x70, no long-form header.
+	let tdt = make_section(0x70, &[0xc0, 0x79, 0x12, 0x34, 0x56]);
+
+	let mut rig = si_rig();
+	rig.import
+		.decode(&BytesMut::from(&si_packet(0x0014, &tdt)[..]))
+		.unwrap();
+	rig.import.finish().unwrap();
+
+	assert!(
+		rig.catalog.snapshot().mpegts.si.is_empty(),
+		"TDT is not captured; the omission is policy, not oversight"
 	);
 }
 

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -2333,3 +2333,239 @@ async fn late_join_matches_a_running_exporter_without_video() {
 	// rendering the same stream.
 	assert_only_continuity_differs(&a, &b, b[1].timestamp);
 }
+
+/// A section lost before the cycle wraps commits an observed subset; the next
+/// cycle must *converge* to the full set rather than flip-flop between subsets.
+/// The repetition fast-path skips sections already active, so without the
+/// same-version merge in `commit` the stragglers would replace the subset instead
+/// of completing it, oscillating forever.
+#[tokio::test(start_paused = true)]
+async fn lost_dense_section_recovers_on_the_next_cycle() {
+	let sdt = |number: u8, fill: u8| make_long_section(0x42, 1, 0, number, 2, &[fill; 4]);
+	let s0 = sdt(0, 0xa0);
+	let s1 = sdt(1, 0xa1);
+	let s2 = sdt(2, 0xa2);
+
+	// Cycle 1 loses section 1; the repeat of section 0 wraps and commits {0, 2}.
+	let mut input = si_packet(0x0011, &s0);
+	input.extend_from_slice(&si_packet_cc(0x0011, &s2, 1));
+	input.extend_from_slice(&si_packet_cc(0x0011, &s0, 2));
+	// Cycle 2 supplies section 1; sections 0 and 2 short-circuit as repetitions,
+	// so the wrap carries only the straggler, which must merge, not replace.
+	input.extend_from_slice(&si_packet_cc(0x0011, &s1, 3));
+	input.extend_from_slice(&si_packet_cc(0x0011, &s1, 4));
+	let mut rig = si_rig();
+	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	rig.import.finish().unwrap();
+
+	let si = rig.catalog.snapshot().mpegts.si.clone();
+	assert_eq!(
+		read_si_sections(&rig.consumer, &si[&0x0011][&0x42].track).await,
+		vec![Bytes::from(s0), Bytes::from(s1), Bytes::from(s2)],
+		"the lost section joined the committed generation instead of replacing it"
+	);
+}
+
+/// A catalog update that keeps the `(PID, table_id)` key but repoints it at a new
+/// track (a restarted publisher) must rebuild the subscription: staying attached
+/// to the old track would repeat its stale sections forever.
+#[tokio::test(start_paused = true)]
+async fn repointed_si_entry_resubscribes() {
+	let sdt_a = make_long_section(0x42, 1, 0, 0, 0, &[0xaa; 8]);
+	let sdt_b = make_long_section(0x42, 1, 1, 0, 0, &[0xbb; 8]);
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+
+	let mut track_a = broadcast.create_track("a.si", None).unwrap();
+	track_a
+		.write_frame(Timestamp::ZERO, Bytes::from(sdt_a.clone()))
+		.unwrap();
+	let mut track_b = broadcast.create_track("b.si", None).unwrap();
+	track_b
+		.write_frame(Timestamp::ZERO, Bytes::from(sdt_b.clone()))
+		.unwrap();
+
+	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
+	let track = broadcast
+		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.unwrap();
+	let name = track.name().to_string();
+	{
+		let mut guard = catalog.lock();
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0,
+			level: 0x1f,
+			inline: false,
+		});
+		cfg.container = Container::Legacy;
+		cfg.description = Some(avcc);
+		guard.video.renditions.insert(name.clone(), cfg);
+		guard.mpegts.si.entry(0x0011).or_default().insert(
+			0x42,
+			tscat::SiEntry {
+				track: "a.si".to_string(),
+				interval: Some(Duration::from_secs(2)),
+				..Default::default()
+			},
+		);
+	}
+
+	let mut producer = Producer::new(track, HangContainer::Legacy);
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xAB, 64));
+	let write_key = |producer: &mut Producer<HangContainer>, sec: u64| {
+		producer
+			.write(Frame {
+				timestamp: Timestamp::from_micros(sec * 1_000_000).unwrap(),
+				duration: None,
+				payload: length_prefixed(&[&idr]),
+				keyframe: true,
+			})
+			.unwrap();
+		producer.cut(None).unwrap();
+	};
+
+	let mut exporter = Export::with_ts(crate::source::announced(&consumer), crate::catalog::CatalogFormat::Hang)
+		.await
+		.unwrap();
+	let mut before = BytesMut::new();
+	write_key(&mut producer, 0);
+	write_key(&mut producer, 1);
+	for _ in 0..2 {
+		let frame = tokio::time::timeout(Duration::from_secs(1), exporter.next())
+			.await
+			.expect("a frame before the switch")
+			.unwrap()
+			.unwrap();
+		before.extend_from_slice(&frame.payload);
+	}
+
+	// Repoint the entry at the replacement track.
+	catalog.lock().mpegts.si.get_mut(&0x0011).unwrap().insert(
+		0x42,
+		tscat::SiEntry {
+			track: "b.si".to_string(),
+			interval: Some(Duration::from_secs(2)),
+			..Default::default()
+		},
+	);
+
+	write_key(&mut producer, 2);
+	write_key(&mut producer, 3);
+	write_key(&mut producer, 4);
+	producer.finish().unwrap();
+	let mut after = BytesMut::new();
+	while let Ok(res) = tokio::time::timeout(Duration::from_secs(1), exporter.next()).await {
+		let Some(frame) = res.unwrap() else { break };
+		after.extend_from_slice(&frame.payload);
+	}
+
+	let contains = |haystack: &[u8], needle: &[u8]| haystack.windows(needle.len()).any(|w| w == needle);
+	assert!(
+		contains(&before, &sdt_a),
+		"the original track's SDT was emitted (control)"
+	);
+	assert!(
+		contains(&after, &sdt_b),
+		"the replacement track's SDT is emitted after the repoint"
+	);
+}
+
+/// An SI revision that lands after the final media frame still reaches the TS:
+/// emission rides media frames, so end of stream flushes every entry's current
+/// sections in one trailing frame before yielding `None`.
+#[tokio::test(start_paused = true)]
+async fn si_revision_after_final_media_frame_is_flushed() {
+	let sdt_v1 = make_long_section(0x42, 1, 0, 0, 0, &[0xaa; 8]);
+	let sdt_v2 = make_long_section(0x42, 1, 1, 0, 0, &[0xbb; 8]);
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+
+	let mut si_track = broadcast.create_track("0x0011-0x42.si", None).unwrap();
+	si_track
+		.write_frame(Timestamp::ZERO, Bytes::from(sdt_v1.clone()))
+		.unwrap();
+
+	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
+	let track = broadcast
+		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.unwrap();
+	let name = track.name().to_string();
+	{
+		let mut guard = catalog.lock();
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0,
+			level: 0x1f,
+			inline: false,
+		});
+		cfg.container = Container::Legacy;
+		cfg.description = Some(avcc);
+		guard.video.renditions.insert(name.clone(), cfg);
+		guard.mpegts.si.entry(0x0011).or_default().insert(
+			0x42,
+			tscat::SiEntry {
+				track: "0x0011-0x42.si".to_string(),
+				interval: Some(Duration::from_secs(2)),
+				..Default::default()
+			},
+		);
+	}
+
+	let mut producer = Producer::new(track, HangContainer::Legacy);
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xAB, 64));
+	producer
+		.write(Frame {
+			timestamp: Timestamp::ZERO,
+			duration: None,
+			payload: length_prefixed(&[&idr]),
+			keyframe: true,
+		})
+		.unwrap();
+	producer.cut(None).unwrap();
+	producer.finish().unwrap();
+
+	let mut exporter = Export::with_ts(crate::source::announced(&consumer), crate::catalog::CatalogFormat::Hang)
+		.await
+		.unwrap();
+	let first = tokio::time::timeout(Duration::from_secs(1), exporter.next())
+		.await
+		.expect("the only media frame")
+		.unwrap()
+		.unwrap();
+	let contains = |haystack: &[u8], needle: &[u8]| haystack.windows(needle.len()).any(|w| w == needle);
+	assert!(contains(&first.payload, &sdt_v1), "v1 rode the media frame (control)");
+
+	// The revision lands after the last media frame; only the trailing flush can
+	// carry it. Closing the catalog lets the exporter reach end of stream.
+	si_track
+		.write_frame(Timestamp::ZERO, Bytes::from(sdt_v2.clone()))
+		.unwrap();
+	catalog.finish().unwrap();
+
+	let tail = tokio::time::timeout(Duration::from_secs(1), exporter.next())
+		.await
+		.expect("a trailing SI frame rather than an immediate end")
+		.unwrap()
+		.expect("the trailing SI frame");
+	assert_packet_aligned(&tail.payload);
+	assert!(
+		contains(&tail.payload, &sdt_v2),
+		"the trailing flush carries the revision"
+	);
+	let end = tokio::time::timeout(Duration::from_secs(1), exporter.next())
+		.await
+		.expect("the stream ends after the flush")
+		.unwrap();
+	assert!(end.is_none(), "end of stream after the trailing flush");
+}

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -9,11 +9,12 @@
 //! other private sections, which are not PES) are intercepted before the mpeg2ts
 //! reader and reassembled. TS adds PAT/PMT discovery, PES reassembly, the
 //! private-section path, and the 90 kHz -> microsecond PTS conversion. The service
-//! layer is captured into the `mpegts` catalog too: the identity parsed from the PAT
-//! as a [`Program`](catalog::Program) record, and the standalone SI PIDs as opaque
-//! [`Si`](catalog::Si) sections, so both survive the round-trip.
+//! layer is captured too: the identity parsed from the PAT as a
+//! [`Program`](catalog::Program) record in the `mpegts` catalog section, and the
+//! standalone SI PIDs as opaque sections on per-`(PID, table_id)` snapshot tracks
+//! (see [`si`](super::si)), so both survive the round-trip.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::sync::{Arc, Mutex};
 
@@ -106,10 +107,9 @@ pub struct Import<E: catalog::Catalog = ()> {
 	/// Intercepted before the reader (like SCTE-35 sections) so the service layer
 	/// survives the round-trip. Only populated with `mpegts` catalog support.
 	si_sections: HashMap<u16, SectionReassembler>,
-	/// The SI sections currently published, keyed by PID. Kept alongside the catalog
-	/// so a repetition can be recognized without taking the catalog's write lock,
-	/// which would mark it modified and republish it every couple of seconds.
-	si: BTreeMap<u16, catalog::Si>,
+	/// The SI store: buffers each sub-table to a complete generation, publishes the
+	/// per-`(PID, table_id)` snapshot tracks, and advertises them in the catalog.
+	si: super::si::Capture<E>,
 	/// Whether the service identity (TSID/service_id/PMT PID) has been captured from
 	/// the PAT into the catalog service record yet (set once; the PAT is stable).
 	identity_recorded: bool,
@@ -131,6 +131,7 @@ impl<E: catalog::Catalog> Import<E> {
 		// may carry the section by value, and a snapshot clones under the mutex (no publish).
 		let mut snapshot = catalog.snapshot();
 		let supports_mpegts = snapshot.mpegts_mut().is_some();
+		let si = super::si::Capture::new(broadcast.clone(), catalog.clone());
 		Self {
 			broadcast,
 			catalog,
@@ -151,7 +152,7 @@ impl<E: catalog::Catalog> Import<E> {
 			recorded_media: HashSet::new(),
 			program_recorded: false,
 			si_sections: HashMap::new(),
-			si: BTreeMap::new(),
+			si,
 			identity_recorded: false,
 			last_pts: None,
 			media_unwrap: PtsUnwrap::default(),
@@ -218,8 +219,8 @@ impl<E: catalog::Catalog> Import<E> {
 			// Intercept the standalone SI PIDs before the routing gate below drops them:
 			// they carry the service layer, not media, and are not fed to the reader
 			// (which only routes the PAT/PMT/ES PIDs it learns).
-			if self.supports_mpegts && catalog::SI_PIDS.iter().any(|(p, _)| *p == pid) {
-				self.si_section(pid, &pkt);
+			if self.supports_mpegts && catalog::SI_PIDS.contains(&pid) {
+				self.si_section(pid, &pkt)?;
 				continue;
 			}
 			// An elementary stream's PES is as vulnerable to a break as a section is. A
@@ -290,6 +291,10 @@ impl<E: catalog::Catalog> Import<E> {
 		}
 
 		self.scratch.drain(..off);
+		// Cut the snapshot groups for whatever SI committed in this batch. Batching per
+		// decode call (plus the store's own media-clock debounce) coalesces a junction's
+		// burst of sub-table commits into few groups instead of one per commit.
+		self.si.flush(self.last_pts.unwrap_or(Timestamp::ZERO), false)?;
 		Ok(())
 	}
 
@@ -652,43 +657,22 @@ impl<E: catalog::Catalog> Import<E> {
 		self.identity_recorded = true;
 	}
 
-	/// Feed one TS packet on a standalone SI PID to its reassembler, recording each
-	/// completed section verbatim into that PID's catalog entry.
+	/// Feed one TS packet on a standalone SI PID to its reassembler, folding each
+	/// completed section into the SI store.
 	///
 	/// Every section is captured, whatever its `table_id`: the SDT PID also carries
-	/// the BAT, an SDT can describe several services across several sections, and a
-	/// table we don't recognize is exactly as worth preserving as one we do. The
-	/// catalog holds a *set* per PID, so these coexist instead of overwriting each
-	/// other, and a plain repetition (SI repeats every couple of seconds) leaves the
-	/// set untouched rather than republishing the catalog.
-	fn si_section(&mut self, pid: u16, pkt: &[u8]) {
+	/// the BAT, the EIT PID carries now/next and the schedule, and a table we don't
+	/// recognize is exactly as worth preserving as one we do. The store buffers each
+	/// sub-table to a complete generation and commits it atomically, so a plain
+	/// repetition (SI repeats every couple of seconds) publishes nothing and a torn
+	/// multi-section transition is never visible.
+	fn si_section(&mut self, pid: u16, pkt: &[u8]) -> anyhow::Result<()> {
 		let mut sections = Vec::new();
 		self.si_sections.entry(pid).or_default().push(pkt, &mut sections);
-		if sections.is_empty() {
-			return;
+		for section in sections {
+			self.si.section(pid, section)?;
 		}
-
-		// Apply to the local copy first and bail on a repetition. Taking the catalog's
-		// write lock marks it modified even when the value is unchanged, so doing this
-		// the other way round would republish the catalog on every SI cycle.
-		let updated = {
-			let si = self.si.entry(pid).or_insert_with(|| catalog::Si {
-				interval: catalog::SI_PIDS.iter().find(|(p, _)| *p == pid).map(|(_, i)| *i),
-				..Default::default()
-			});
-			let mut changed = false;
-			for section in sections {
-				changed |= si.upsert(bytes::Bytes::from(section));
-			}
-			changed.then(|| si.clone())
-		};
-		let Some(updated) = updated else {
-			return;
-		};
-
-		if let Some(mpegts) = self.catalog.lock().mpegts_mut() {
-			mpegts.si.insert(pid, updated);
-		}
+		Ok(())
 	}
 
 	/// Close the current group on every track and reopen at `sequence`.
@@ -714,6 +698,7 @@ impl<E: catalog::Catalog> Import<E> {
 		for section in self.sections.values_mut() {
 			section.finish()?;
 		}
+		self.si.finish(self.last_pts.unwrap_or(Timestamp::ZERO))?;
 		Ok(())
 	}
 
@@ -727,6 +712,11 @@ impl<E: catalog::Catalog> Import<E> {
 		for section in std::mem::take(&mut self.sections).into_values() {
 			section.abort(err.clone());
 		}
+		let si = std::mem::replace(
+			&mut self.si,
+			super::si::Capture::new(self.broadcast.clone(), self.catalog.clone()),
+		);
+		si.abort(err);
 	}
 }
 

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -292,7 +292,7 @@ impl<E: catalog::Catalog> Import<E> {
 
 		self.scratch.drain(..off);
 		// Cut the snapshot groups for whatever SI committed in this batch. Batching per
-		// decode call (plus the store's own media-clock debounce) coalesces a junction's
+		// decode call (plus the store's own host-clock debounce) coalesces a junction's
 		// burst of sub-table commits into few groups instead of one per commit.
 		self.si.flush(self.last_pts.unwrap_or(Timestamp::ZERO), false)?;
 		Ok(())

--- a/rs/moq-mux/src/container/ts/mod.rs
+++ b/rs/moq-mux/src/container/ts/mod.rs
@@ -9,21 +9,26 @@
 //! Elementary streams we don't decode (SCTE-35, teletext, DVB subtitles, private
 //! data, ...) are carried verbatim, one MoQ track per PID, described in the
 //! [`Mpegts`] catalog section. SCTE-35 is just one such stream (`stream_type` 0x86).
-//! The service layer rides the same section: the transport/service identity as a
-//! [`Program`] record, and the standalone SI tables (SDT, NIT, ...) as opaque [`Si`]
-//! sections re-emitted on their original PIDs, so the service name, provider, and
-//! network survive the round-trip without anything parsing them.
+//! The service layer rides alongside: the transport/service identity as a
+//! [`Program`] record, and the standalone SI tables (SDT, NIT, EIT, ...) as opaque
+//! sections on per-`(PID, table_id)` snapshot tracks mapped by [`SiEntry`] and
+//! re-emitted on their original PIDs, so the service name, provider, network, and
+//! EPG survive the round-trip without anything parsing them. Each SI track group is
+//! a complete snapshot (one frame per sub-table, sections concatenated verbatim);
+//! frames apply in order with later-wins by sub-table identity, and a joiner reads
+//! only the newest group.
 
 mod adts;
 mod export;
 mod import;
+mod si;
 
 // The `mpegts` catalog section (per-track PID + descriptors plus verbatim carriage
 // of undecoded elementary streams) and the `Catalog` capability, re-exported flat so
 // they read as `ts::Catalog`, `ts::Mpegts`, ... instead of stuttering under `catalog`.
 mod catalog;
 
-pub use catalog::{Catalog, Descriptor, Ext, Framing, Mpegts, Program, Si, Track, Verbatim};
+pub use catalog::{Catalog, Descriptor, Ext, Framing, Mpegts, Program, SiEntry, Track, Verbatim};
 pub use export::*;
 pub use import::*;
 

--- a/rs/moq-mux/src/container/ts/si.rs
+++ b/rs/moq-mux/src/container/ts/si.rs
@@ -127,8 +127,12 @@ struct Pending {
 }
 
 impl Pending {
-	/// All of 0..=last present. Sufficient for a complete commit, but not necessary:
-	/// a sparse table (EIT schedule) commits on cycle wrap instead.
+	/// All of 0..=last present: the fast path for densely-numbered tables (SDT, NIT,
+	/// EIT now/next), committing the moment the last section lands. EIT schedule
+	/// never satisfies this: its numbering is deliberately sparse (a real 8-day
+	/// guide declares `last_section_number` 248 and transmits 32 sections), so the
+	/// cycle-wrap path in [`Entry::section`] is its *only* commit path, not a
+	/// fallback.
 	fn contiguous(&self) -> bool {
 		self.sections.len() == self.last as usize + 1
 	}
@@ -176,6 +180,11 @@ impl Entry {
 			if self.content_order.len() > MAX_CONTENT_SECTIONS {
 				let evict = self.content_order.remove(0);
 				self.active.remove(&evict);
+				// At the cap the set is churning, not growing: a clock-like table whose
+				// every repetition differs would otherwise mint a key per arrival and
+				// cut a group per debounce forever, carrying the cap's worth of stale
+				// sections. Rotation without net growth is not worth republishing.
+				return;
 			}
 			self.dirty = true;
 			return;
@@ -202,9 +211,12 @@ impl Entry {
 			if *prior == section {
 				// The same section came round again before the set completed: the
 				// transmission cycle wrapped, so what we hold is the whole sub-table as
-				// this mux transmits it. EIT schedule is deliberately sparse (segments
-				// skip unused section numbers), so this, not contiguity, is its commit
-				// path.
+				// this mux transmits it. For EIT schedule this is the *only* commit
+				// path (see [`Pending::contiguous`]). The limit: a section lost before
+				// the wrap is indistinguishable from a legitimately skipped number, so
+				// the committed set is complete-as-observed, self-healing on the next
+				// cycle. No section-counting receiver can do better; version mixing is
+				// still unrepresentable either way.
 				let sections = std::mem::take(&mut pending.sections);
 				self.commit(id, version, sections);
 				return;
@@ -375,17 +387,19 @@ impl<E: catalog::Catalog> Capture<E> {
 		Ok(())
 	}
 
-	/// Abort every track with `err` instead of finishing. The catalog entries are
-	/// removed by `Drop`.
+	/// Abort every track with `err` instead of finishing, removing their catalog
+	/// entries so the map never names an aborted track.
 	pub fn abort(mut self, err: moq_net::Error) {
+		self.unadvertise();
 		for (_, entry) in std::mem::take(&mut self.entries) {
 			let _ = entry.track.abort(err.clone());
 		}
 	}
-}
 
-impl<E: catalog::Catalog> Drop for Capture<E> {
-	fn drop(&mut self) {
+	/// Remove every advertised entry from the catalog's `si` map, once (idempotent:
+	/// entries are marked unadvertised as they go, so the `Drop` after an `abort`
+	/// finds nothing left to do).
+	fn unadvertise(&mut self) {
 		if !self.entries.values().any(|e| e.advertised) {
 			return;
 		}
@@ -393,10 +407,11 @@ impl<E: catalog::Catalog> Drop for Capture<E> {
 		let Some(mpegts) = guard.mpegts_mut() else {
 			return;
 		};
-		for ((pid, table_id), entry) in self.entries.iter() {
+		for ((pid, table_id), entry) in self.entries.iter_mut() {
 			if !entry.advertised {
 				continue;
 			}
+			entry.advertised = false;
 			if let Some(tables) = mpegts.si.get_mut(pid) {
 				tables.remove(table_id);
 				if tables.is_empty() {
@@ -404,6 +419,12 @@ impl<E: catalog::Catalog> Drop for Capture<E> {
 				}
 			}
 		}
+	}
+}
+
+impl<E: catalog::Catalog> Drop for Capture<E> {
+	fn drop(&mut self) {
+		self.unadvertise();
 	}
 }
 

--- a/rs/moq-mux/src/container/ts/si.rs
+++ b/rs/moq-mux/src/container/ts/si.rs
@@ -434,7 +434,13 @@ impl<E: catalog::Catalog> Capture<E> {
 			}
 			entry.advertised = false;
 			if let Some(tables) = mpegts.si.get_mut(pid) {
-				tables.remove(table_id);
+				// Remove only a mapping this capture still owns: a second capture on
+				// the same broadcast (same key, unique fallback track name) may have
+				// overwritten it, and it will not re-advertise, so blindly removing
+				// here would strip the live capture's table for good.
+				if tables.get(table_id).is_some_and(|e| e.track == entry.name) {
+					tables.remove(table_id);
+				}
 				if tables.is_empty() {
 					mpegts.si.remove(pid);
 				}

--- a/rs/moq-mux/src/container/ts/si.rs
+++ b/rs/moq-mux/src/container/ts/si.rs
@@ -1,0 +1,435 @@
+//! Standalone SI carriage over snapshot tracks.
+//!
+//! Import captures each `(PID, table_id)` pair onto its own MoQ track, mapped from
+//! the catalog's `mpegts.si` section ([`catalog::SiEntry`]). The track format is
+//! snapshot-shaped: every group is a complete picture of the table's current
+//! sections, one frame per sub-table, each frame the sub-table's sections
+//! concatenated verbatim in `section_number` order. Frames apply in order and a
+//! later frame replaces an earlier one with the same sub-table identity, so a
+//! writer may append incremental updates within a group; this writer never does
+//! (every group is a full set), but readers honor the rule so that stays a writer
+//! choice rather than a format change. A joiner reads only the newest group.
+//!
+//! [`Capture`] is the import half: it buffers each sub-table's sections until a
+//! complete generation is assembled, commits the generation atomically, and cuts a
+//! new snapshot group, so a torn multi-section transition (half old version, half
+//! new) is unrepresentable on the track. [`Snapshot`] is the export half: it
+//! reduces a track's frames back into the current section set.
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+use std::time::Duration;
+
+use bytes::Bytes;
+use moq_net::Timestamp;
+
+use super::catalog;
+
+/// Coalesce snapshot cuts: a junction revises many sub-tables inside a second
+/// (every service's now/next rolls on the hour), and one group carrying all of them
+/// beats a burst of near-identical groups. Measured on the media clock, like the
+/// export cadence, and the first snapshot is never delayed.
+const DEBOUNCE: Duration = Duration::from_secs(1);
+
+/// Keep at most this many sections without any parseable identity (short-form or
+/// runt) per entry. They can only be deduplicated by content, never replaced, so a
+/// broken source could otherwise accumulate without bound.
+const MAX_CONTENT_SECTIONS: usize = 32;
+
+/// A sub-table's identity within its `(PID, table_id)` entry: what a revised
+/// generation replaces.
+///
+/// Generic section syntax carries `table_id_extension`; for two documented table
+/// families that alone is ambiguous, so the spec-fixed scope bytes join the key
+/// (see [`scope`]). A section with no long-form header has no identity at all and
+/// is tracked by content: it can be deduplicated but never revised in place.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(super) enum Identity {
+	/// A long-form sub-table: `table_id_extension` plus any table-specific scope.
+	Sub { ext: u16, scope: u32 },
+	/// A short-form or runt section, identified by a hash of its bytes.
+	Content(u64),
+}
+
+/// Compute a section's sub-table identity.
+pub(super) fn identity(section: &[u8]) -> Identity {
+	if !long_form(section) {
+		let mut hasher = std::collections::hash_map::DefaultHasher::new();
+		section.hash(&mut hasher);
+		return Identity::Content(hasher.finish());
+	}
+	let ext = u16::from_be_bytes([section[3], section[4]]);
+	Identity::Sub {
+		ext,
+		scope: scope(section),
+	}
+}
+
+/// The table-specific bytes that extend the generic identity, for the two table
+/// families whose `table_id_extension` alone is ambiguous (#2842).
+///
+/// These are fixed offsets of published ETSI EN 300 468 layouts, gated on
+/// `table_id`; reading them narrows *identity*, not what export claims to
+/// understand (the sections stay opaque bytes).
+fn scope(section: &[u8]) -> u32 {
+	match section[0] {
+		// SDT other: the extension is a transport_stream_id, unique only within a
+		// network; original_network_id at bytes 8..10 disambiguates.
+		0x46 if section.len() >= 10 => u32::from(u16::from_be_bytes([section[8], section[9]])),
+		// EIT: the extension is a service_id, unique only within a transport stream;
+		// transport_stream_id at 8..10 and original_network_id at 10..12 disambiguate.
+		0x4E..=0x6F if section.len() >= 12 => u32::from_be_bytes([section[8], section[9], section[10], section[11]]),
+		_ => 0,
+	}
+}
+
+/// Whether the section has a complete long-form header (syntax indicator set and
+/// the 8 header bytes present).
+fn long_form(section: &[u8]) -> bool {
+	section.len() >= 8 && section[1] & 0x80 != 0
+}
+
+/// Split a frame payload back into its individual sections (they are
+/// self-delimiting via `section_length`). Stops at the first malformed or
+/// truncated header.
+pub(super) fn split_sections(payload: &Bytes) -> Vec<Bytes> {
+	let mut out = Vec::new();
+	let mut off = 0;
+	while payload.len() >= off + 3 {
+		let len = 3 + ((((payload[off + 1] & 0x0f) as usize) << 8) | payload[off + 2] as usize);
+		if payload.len() < off + len {
+			break;
+		}
+		out.push(payload.slice(off..off + len));
+		off += len;
+	}
+	out
+}
+
+/// One committed generation of a sub-table: the sections currently in force.
+///
+/// Keyed by `section_number`, sparse on purpose: DVB EIT schedule segments skip
+/// unused section numbers, so 0..=last is not a contiguous range there.
+#[derive(Default, PartialEq)]
+struct Generation {
+	version: Option<u8>,
+	sections: BTreeMap<u8, Bytes>,
+}
+
+/// A generation still being assembled, section by section.
+#[derive(Default)]
+struct Pending {
+	/// Highest section number this generation can hold, from `last_section_number`
+	/// (also raised by any observed `section_number`, so a malformed header cannot
+	/// hide a section).
+	last: u8,
+	sections: BTreeMap<u8, Bytes>,
+}
+
+impl Pending {
+	/// All of 0..=last present. Sufficient for a complete commit, but not necessary:
+	/// a sparse table (EIT schedule) commits on cycle wrap instead.
+	fn contiguous(&self) -> bool {
+		self.sections.len() == self.last as usize + 1
+	}
+}
+
+/// One `(PID, table_id)` entry: its snapshot track and the state of every
+/// sub-table riding it.
+struct Entry {
+	track: moq_net::track::Producer,
+	name: String,
+	interval: Option<Duration>,
+	active: BTreeMap<Identity, Generation>,
+	/// In-flight generations, keyed by sub-table and version.
+	pending: HashMap<(Identity, u8), Pending>,
+	/// Insertion order of content-identified sections, for bounded retention.
+	content_order: Vec<Identity>,
+	/// A commit changed `active` since the last cut.
+	dirty: bool,
+	/// The entry appears in the catalog's `mpegts.si` map (deferred until the first
+	/// snapshot group exists, so a subscriber never finds an empty track).
+	advertised: bool,
+	last_cut: Option<u128>,
+}
+
+impl Entry {
+	/// Fold one completed, current section into the store, committing its
+	/// generation when it completes. Returns nothing; a commit marks the entry
+	/// dirty and [`Capture::flush`] cuts the group.
+	fn section(&mut self, section: Bytes) {
+		let id = identity(&section);
+
+		let Identity::Sub { .. } = id else {
+			// No identity to revise under: dedupe by content and retain a bounded set.
+			if self.active.contains_key(&id) {
+				return;
+			}
+			self.active.insert(
+				id,
+				Generation {
+					version: None,
+					sections: BTreeMap::from([(0u8, section)]),
+				},
+			);
+			self.content_order.push(id);
+			if self.content_order.len() > MAX_CONTENT_SECTIONS {
+				let evict = self.content_order.remove(0);
+				self.active.remove(&evict);
+			}
+			self.dirty = true;
+			return;
+		};
+
+		let version = (section[5] >> 1) & 0x1f;
+		let number = section[6];
+		let last = section[7];
+
+		// A byte-identical repetition of the current state is the overwhelmingly
+		// common case (SI repeats every couple of seconds); recognize it before
+		// touching any pending state.
+		if let Some(current) = self.active.get(&id)
+			&& current.version == Some(version)
+			&& current.sections.get(&number) == Some(&section)
+		{
+			return;
+		}
+
+		let pending = self.pending.entry((id, version)).or_default();
+		pending.last = pending.last.max(last).max(number);
+
+		if let Some(prior) = pending.sections.get(&number) {
+			if *prior == section {
+				// The same section came round again before the set completed: the
+				// transmission cycle wrapped, so what we hold is the whole sub-table as
+				// this mux transmits it. EIT schedule is deliberately sparse (segments
+				// skip unused section numbers), so this, not contiguity, is its commit
+				// path.
+				let sections = std::mem::take(&mut pending.sections);
+				self.commit(id, version, sections);
+				return;
+			}
+			// Same version, new bytes: non-conformant (a revision must bump the
+			// version), but taking the newer bytes degrades more gracefully than
+			// pinning the older ones.
+			pending.sections.insert(number, section);
+			return;
+		}
+
+		pending.sections.insert(number, section);
+		if pending.contiguous() {
+			let sections = std::mem::take(&mut pending.sections);
+			self.commit(id, version, sections);
+		}
+	}
+
+	/// Replace the sub-table's generation atomically and retire everything pending
+	/// for it. Repetition of an unchanged set refreshes the version without
+	/// marking the entry dirty.
+	fn commit(&mut self, id: Identity, version: u8, sections: BTreeMap<u8, Bytes>) {
+		self.pending.retain(|(pid, _), _| *pid != id);
+		let changed = self.active.get(&id).is_none_or(|current| current.sections != sections);
+		self.active.insert(
+			id,
+			Generation {
+				version: Some(version),
+				sections,
+			},
+		);
+		if changed {
+			self.dirty = true;
+		}
+	}
+
+	/// Cut a snapshot group: the complete active set, one frame per sub-table.
+	fn cut(&mut self, pts: Timestamp) -> anyhow::Result<()> {
+		let mut group = self.track.append_group()?;
+		for generation in self.active.values() {
+			let mut payload = Vec::new();
+			for section in generation.sections.values() {
+				payload.extend_from_slice(section);
+			}
+			group.write_frame(pts, payload)?;
+		}
+		group.finish()?;
+		self.dirty = false;
+		self.last_cut = Some(pts.as_micros());
+		Ok(())
+	}
+}
+
+/// Import-side SI capture: reassembled sections in, snapshot tracks and catalog
+/// entries out.
+///
+/// Owned by the TS importer, which feeds it every completed section on a captured
+/// SI PID and calls [`flush`](Self::flush) once per decode batch. Dropping it
+/// removes the advertised entries from the catalog, mirroring the verbatim tracks.
+pub(super) struct Capture<E: catalog::Catalog> {
+	broadcast: moq_net::broadcast::Producer,
+	catalog: crate::catalog::Producer<E>,
+	entries: BTreeMap<(u16, u8), Entry>,
+}
+
+impl<E: catalog::Catalog> Capture<E> {
+	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
+		Self {
+			broadcast,
+			catalog,
+			entries: BTreeMap::new(),
+		}
+	}
+
+	/// Fold one completed section from `pid` into its `(pid, table_id)` entry,
+	/// creating the entry (and its track) on first sight of the pair.
+	pub fn section(&mut self, pid: u16, section: Vec<u8>) -> anyhow::Result<()> {
+		let Some(&table_id) = section.first() else {
+			return Ok(());
+		};
+		// A next-version section (current_next_indicator clear) describes a future
+		// state, not the current one; carrying it would need a second generation slot
+		// per sub-table for a table nothing re-emits, so it is dropped until the
+		// version becomes current.
+		let section = Bytes::from(section);
+		if long_form(&section) && section[5] & 0x01 == 0 {
+			return Ok(());
+		}
+
+		if !self.entries.contains_key(&(pid, table_id)) {
+			// Deterministic, greppable name; fall back to a unique suffix on the
+			// (pathological) collision with an existing track.
+			let name = format!("{pid:#06x}-{table_id:#04x}.si");
+			let track = match self.broadcast.create_track(name, None) {
+				Ok(track) => track,
+				Err(_) => self.broadcast.unique_track(".si", None)?,
+			};
+			self.entries.insert(
+				(pid, table_id),
+				Entry {
+					name: track.name().to_string(),
+					track,
+					interval: catalog::si_interval(table_id),
+					active: BTreeMap::new(),
+					pending: HashMap::new(),
+					content_order: Vec::new(),
+					dirty: false,
+					advertised: false,
+					last_cut: None,
+				},
+			);
+		}
+		let entry = self.entries.get_mut(&(pid, table_id)).unwrap();
+		entry.section(section);
+		Ok(())
+	}
+
+	/// Cut snapshot groups for the dirty entries and advertise any entry with its
+	/// first snapshot in the catalog (one lock for the whole batch).
+	///
+	/// `pts` is the media clock, used both to stamp the frames and to coalesce cuts
+	/// ([`DEBOUNCE`]); a first snapshot is never delayed. `force` overrides the
+	/// debounce, for end of stream.
+	pub fn flush(&mut self, pts: Timestamp, force: bool) -> anyhow::Result<()> {
+		let now = pts.as_micros();
+		for entry in self.entries.values_mut() {
+			if !entry.dirty {
+				continue;
+			}
+			if !force
+				&& let Some(last) = entry.last_cut
+				&& now.saturating_sub(last) < DEBOUNCE.as_micros()
+			{
+				continue;
+			}
+			entry.cut(pts)?;
+		}
+
+		if self.entries.values().any(|e| !e.advertised && e.last_cut.is_some()) {
+			let mut guard = self.catalog.lock();
+			let Some(mpegts) = guard.mpegts_mut() else {
+				anyhow::bail!("catalog extension no longer carries an mpegts section");
+			};
+			for ((pid, table_id), entry) in self.entries.iter_mut() {
+				if entry.advertised || entry.last_cut.is_none() {
+					continue;
+				}
+				mpegts.si.entry(*pid).or_default().insert(
+					*table_id,
+					catalog::SiEntry {
+						track: entry.name.clone(),
+						interval: entry.interval,
+						..Default::default()
+					},
+				);
+				entry.advertised = true;
+			}
+		}
+		Ok(())
+	}
+
+	/// Flush everything and finish every track.
+	pub fn finish(&mut self, pts: Timestamp) -> anyhow::Result<()> {
+		self.flush(pts, true)?;
+		for entry in self.entries.values_mut() {
+			entry.track.finish()?;
+		}
+		Ok(())
+	}
+
+	/// Abort every track with `err` instead of finishing. The catalog entries are
+	/// removed by `Drop`.
+	pub fn abort(mut self, err: moq_net::Error) {
+		for (_, entry) in std::mem::take(&mut self.entries) {
+			let _ = entry.track.abort(err.clone());
+		}
+	}
+}
+
+impl<E: catalog::Catalog> Drop for Capture<E> {
+	fn drop(&mut self) {
+		if !self.entries.values().any(|e| e.advertised) {
+			return;
+		}
+		let mut guard = self.catalog.lock();
+		let Some(mpegts) = guard.mpegts_mut() else {
+			return;
+		};
+		for ((pid, table_id), entry) in self.entries.iter() {
+			if !entry.advertised {
+				continue;
+			}
+			if let Some(tables) = mpegts.si.get_mut(pid) {
+				tables.remove(table_id);
+				if tables.is_empty() {
+					mpegts.si.remove(pid);
+				}
+			}
+		}
+	}
+}
+
+/// Export-side reduction of a snapshot track: frames apply in order, later-wins
+/// by sub-table identity. Reset per group (a group is a complete snapshot).
+#[derive(Default)]
+pub(super) struct Snapshot {
+	subs: BTreeMap<Identity, Vec<Bytes>>,
+}
+
+impl Snapshot {
+	/// Apply one frame: the payload's sections replace the sub-table they identify.
+	pub fn apply(&mut self, payload: &Bytes) {
+		let sections = split_sections(payload);
+		let Some(first) = sections.first() else {
+			return;
+		};
+		self.subs.insert(identity(first), sections);
+	}
+
+	/// Every section in the snapshot, in stable sub-table order.
+	pub fn sections(&self) -> impl Iterator<Item = &Bytes> {
+		self.subs.values().flatten()
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.subs.is_empty()
+	}
+}

--- a/rs/moq-mux/src/container/ts/si.rs
+++ b/rs/moq-mux/src/container/ts/si.rs
@@ -27,8 +27,10 @@ use super::catalog;
 
 /// Coalesce snapshot cuts: a junction revises many sub-tables inside a second
 /// (every service's now/next rolls on the hour), and one group carrying all of them
-/// beats a burst of near-identical groups. Measured on the media clock, like the
-/// export cadence, and the first snapshot is never delayed.
+/// beats a burst of near-identical groups. Measured on the host clock, not the
+/// media clock: bursts arrive in real time, and an audio-only stream never
+/// advances the media clock at all (which would wedge every revision behind the
+/// debounce forever). The first snapshot is never delayed.
 const DEBOUNCE: Duration = Duration::from_secs(1);
 
 /// Keep at most this many sections without any parseable identity (short-form or
@@ -154,6 +156,7 @@ struct Entry {
 	/// The entry appears in the catalog's `mpegts.si` map (deferred until the first
 	/// snapshot group exists, so a subscriber never finds an empty track).
 	advertised: bool,
+	/// Host-clock micros of the last cut ([`DEBOUNCE`]); `None` until the first.
 	last_cut: Option<u128>,
 }
 
@@ -214,9 +217,9 @@ impl Entry {
 				// this mux transmits it. For EIT schedule this is the *only* commit
 				// path (see [`Pending::contiguous`]). The limit: a section lost before
 				// the wrap is indistinguishable from a legitimately skipped number, so
-				// the committed set is complete-as-observed, self-healing on the next
-				// cycle. No section-counting receiver can do better; version mixing is
-				// still unrepresentable either way.
+				// the committed set is complete-as-observed; the same-version merge in
+				// [`Self::commit`] fills it in on the next cycle. No section-counting
+				// receiver can do better; version mixing is still unrepresentable.
 				let sections = std::mem::take(&mut pending.sections);
 				self.commit(id, version, sections);
 				return;
@@ -235,11 +238,25 @@ impl Entry {
 		}
 	}
 
-	/// Replace the sub-table's generation atomically and retire everything pending
-	/// for it. Repetition of an unchanged set refreshes the version without
-	/// marking the entry dirty.
-	fn commit(&mut self, id: Identity, version: u8, sections: BTreeMap<u8, Bytes>) {
+	/// Commit the sub-table's generation atomically and retire everything pending
+	/// for it. A new version replaces the old wholesale; the *same* version merges
+	/// into what is already active. The merge is what makes a loss recoverable: a
+	/// section lost before the cycle wrapped commits an observed subset, and on the
+	/// next cycle the already-committed sections short-circuit as repetitions, so
+	/// the wrap only ever carries the stragglers. Replacing would flip-flop between
+	/// incomplete subsets forever; merging converges to the full set. Sound because
+	/// one version is one logical content: a mux removing a section must bump the
+	/// version, which takes the replace path. Repetition of an unchanged set is not
+	/// a change.
+	fn commit(&mut self, id: Identity, version: u8, mut sections: BTreeMap<u8, Bytes>) {
 		self.pending.retain(|(pid, _), _| *pid != id);
+		if let Some(current) = self.active.get(&id)
+			&& current.version == Some(version)
+		{
+			for (number, section) in current.sections.iter() {
+				sections.entry(*number).or_insert_with(|| section.clone());
+			}
+		}
 		let changed = self.active.get(&id).is_none_or(|current| current.sections != sections);
 		self.active.insert(
 			id,
@@ -254,7 +271,8 @@ impl Entry {
 	}
 
 	/// Cut a snapshot group: the complete active set, one frame per sub-table.
-	fn cut(&mut self, pts: Timestamp) -> anyhow::Result<()> {
+	/// `pts` stamps the frames; `now` is the host clock for the debounce.
+	fn cut(&mut self, pts: Timestamp, now: u128) -> anyhow::Result<()> {
 		let mut group = self.track.append_group()?;
 		for generation in self.active.values() {
 			let mut payload = Vec::new();
@@ -265,7 +283,7 @@ impl Entry {
 		}
 		group.finish()?;
 		self.dirty = false;
-		self.last_cut = Some(pts.as_micros());
+		self.last_cut = Some(now);
 		Ok(())
 	}
 }
@@ -280,6 +298,8 @@ pub(super) struct Capture<E: catalog::Catalog> {
 	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 	entries: BTreeMap<(u16, u8), Entry>,
+	/// Host clock driving the cut debounce (see [`DEBOUNCE`]).
+	clock: crate::Clock,
 }
 
 impl<E: catalog::Catalog> Capture<E> {
@@ -288,6 +308,7 @@ impl<E: catalog::Catalog> Capture<E> {
 			broadcast,
 			catalog,
 			entries: BTreeMap::new(),
+			clock: crate::Clock::new(),
 		}
 	}
 
@@ -337,11 +358,11 @@ impl<E: catalog::Catalog> Capture<E> {
 	/// Cut snapshot groups for the dirty entries and advertise any entry with its
 	/// first snapshot in the catalog (one lock for the whole batch).
 	///
-	/// `pts` is the media clock, used both to stamp the frames and to coalesce cuts
-	/// ([`DEBOUNCE`]); a first snapshot is never delayed. `force` overrides the
-	/// debounce, for end of stream.
+	/// `pts` is the media clock, used to stamp the frames; the cut debounce runs on
+	/// the host clock ([`DEBOUNCE`]), and a first snapshot is never delayed. `force`
+	/// overrides the debounce, for end of stream.
 	pub fn flush(&mut self, pts: Timestamp, force: bool) -> anyhow::Result<()> {
-		let now = pts.as_micros();
+		let now = u128::from(self.clock.micros());
 		for entry in self.entries.values_mut() {
 			if !entry.dirty {
 				continue;
@@ -352,7 +373,7 @@ impl<E: catalog::Catalog> Capture<E> {
 			{
 				continue;
 			}
-			entry.cut(pts)?;
+			entry.cut(pts, now)?;
 		}
 
 		if self.entries.values().any(|e| !e.advertised && e.last_cut.is_some()) {

--- a/rs/moq-mux/src/container/ts/si.rs
+++ b/rs/moq-mux/src/container/ts/si.rs
@@ -128,6 +128,16 @@ struct Pending {
 	sections: BTreeMap<u8, Bytes>,
 }
 
+/// How a generation was judged complete, deciding whether the commit replaces or
+/// merges (see [`Entry::commit`]).
+enum Complete {
+	/// Every section of the declaration is present.
+	Contiguous,
+	/// The transmission cycle wrapped: complete as observed, bounded by the
+	/// highest `last_section_number` seen.
+	Wrapped { last: u8 },
+}
+
 impl Pending {
 	/// All of 0..=last present: the fast path for densely-numbered tables (SDT, NIT,
 	/// EIT now/next), committing the moment the last section lands. EIT schedule
@@ -220,8 +230,9 @@ impl Entry {
 				// the committed set is complete-as-observed; the same-version merge in
 				// [`Self::commit`] fills it in on the next cycle. No section-counting
 				// receiver can do better; version mixing is still unrepresentable.
+				let last = pending.last;
 				let sections = std::mem::take(&mut pending.sections);
-				self.commit(id, version, sections);
+				self.commit(id, version, sections, Complete::Wrapped { last });
 				return;
 			}
 			// Same version, new bytes: non-conformant (a revision must bump the
@@ -234,27 +245,34 @@ impl Entry {
 		pending.sections.insert(number, section);
 		if pending.contiguous() {
 			let sections = std::mem::take(&mut pending.sections);
-			self.commit(id, version, sections);
+			self.commit(id, version, sections, Complete::Contiguous);
 		}
 	}
 
 	/// Commit the sub-table's generation atomically and retire everything pending
-	/// for it. A new version replaces the old wholesale; the *same* version merges
-	/// into what is already active. The merge is what makes a loss recoverable: a
-	/// section lost before the cycle wrapped commits an observed subset, and on the
-	/// next cycle the already-committed sections short-circuit as repetitions, so
-	/// the wrap only ever carries the stragglers. Replacing would flip-flop between
-	/// incomplete subsets forever; merging converges to the full set. Sound because
-	/// one version is one logical content: a mux removing a section must bump the
-	/// version, which takes the replace path. Repetition of an unchanged set is not
-	/// a change.
-	fn commit(&mut self, id: Identity, version: u8, mut sections: BTreeMap<u8, Bytes>) {
+	/// for it.
+	///
+	/// A contiguous commit replaces the old generation wholesale: it holds every
+	/// section its declaration promises, so anything else active is stale, even
+	/// under the same version number (versions are five bits, so a reception gap
+	/// can bring the same value back with different content). A wrap commit is
+	/// complete-as-observed, not complete, so it *merges* into a same-version
+	/// active generation instead: a section lost before the cycle wrapped
+	/// short-circuits as a repetition on the next cycle and the wrap only ever
+	/// carries the stragglers, so replacing would flip-flop between incomplete
+	/// subsets forever while merging converges. The merge is bounded by the new
+	/// declaration's `last_section_number`, so a shrunken table cannot resurrect
+	/// sections past its own end. Repetition of an unchanged set is not a change.
+	fn commit(&mut self, id: Identity, version: u8, mut sections: BTreeMap<u8, Bytes>, complete: Complete) {
 		self.pending.retain(|(pid, _), _| *pid != id);
-		if let Some(current) = self.active.get(&id)
+		if let Complete::Wrapped { last } = complete
+			&& let Some(current) = self.active.get(&id)
 			&& current.version == Some(version)
 		{
 			for (number, section) in current.sections.iter() {
-				sections.entry(*number).or_insert_with(|| section.clone());
+				if *number <= last {
+					sections.entry(*number).or_insert_with(|| section.clone());
+				}
 			}
 		}
 		let changed = self.active.get(&id).is_none_or(|current| current.sections != sections);


### PR DESCRIPTION
Implements the design accepted on #2882: carried standalone SI moves out of the catalog onto per-`(PID, table_id)` snapshot tracks. Closes #2800 (EIT now round-trips, schedule included), closes #2881 (the generation-aware store), closes #2842 (the identity fix rides along). Supersedes #2824, closed unmerged.

## Root cause

Three defects and one structural cost all traced to one decision: section bytes lived in the whole-state catalog and were replaced one section at a time by generic-header identity.

- A multi-section table transition **published torn intermediate states**: section 0 of the new version alongside section 1 of the old, visible to joiners and re-emittable by exporters as a table no conformant multiplexer produces (#2881, measured at 5.2s of incompletable SDT during acquisition at 40 services).
- The section identity `(table_id, table_id_extension, section_number)` **collides for SDT other and EIT**, whose full identities include ONID/TSID bytes past the generic header (#2842); the prior fix was to narrow capture rather than fix identity.
- EIT could not be carried at all without a junction storm: t0ms measured **61 full-catalog republishes in 1.27s** at a 40-service programme boundary, on a document that was 92.7% SI and paid by every subscriber before media discovery (#2882).
- SI-only catalog changes appended byte-identical groups to the derived MSF track (120 groups, 4 distinct payloads).

## The change

**Catalog** (`mpegts.si`): now a descriptor only, `pid -> table_id -> { track, interval? }`. `table_id` is byte 0 of generic section syntax, so the key leaks nothing DVB-specific; keying the interval by table finally states what the spec defines (the EIT PID alone carries 2s and 30s tables, the wall #2824 hit). Section bytes leave the catalog entirely.

**Track format** (`container/ts/si.rs`, specced in the hang draft): binary, one track per entry, named `0x0011-0x42.si`-style. A group is a complete snapshot; a frame is one sub-table's sections concatenated verbatim in section order. Readers apply frames in order with later-wins by sub-table identity, so incremental within-group updates stay a writer choice rather than a format change; this writer only ever cuts full groups. A joiner reads the newest group and is current.

**Import** (`si::Capture`): buffers each sub-table's sections and commits a generation atomically, so a version-mixed set is unrepresentable on the track. Two commit paths: contiguous completeness (all of `0..=last_section_number`) for densely-numbered tables, and **cycle wrap** (a repeated section for the pending generation proves a full rotation), which is the *only* commit path for EIT schedule: its numbering is deliberately sparse (a real 8-day guide declares 248 and transmits 32 sections), so contiguity never fires there. The limit of the wrap path: a section lost before the cycle wraps is indistinguishable from a legitimately skipped number, so a committed set can transiently omit it until the next cycle re-supplies it; no section-counting receiver can do better. The wrap path also degrades gracefully for malformed `last_section_number`. Sub-table identity is the generic header plus the two documented disambiguators (`original_network_id` at 8..10 for SDT other; TSID+ONID at 8..12 for EIT), gated on `table_id`; short-form/runt sections fall back to bounded content-identity. Next-version sections (`current_next_indicator` clear) are dropped. Group cuts are debounced (~1s on the media clock) so a junction's burst of commits coalesces; a first snapshot is never delayed, and entries are advertised in the catalog only after their first group exists. EIT (0x0012) joins the captured PIDs; TDT/TOT stays out with its rationale in `SI_PIDS`.

**Export**: subscribes each catalog entry's track (a small state machine reading raw snapshot groups; `ExportSource` is timestamp-driven end to end, which snapshot tracks are not), promotes only fully-received groups, and re-emits each entry's sections at its own interval via the existing `due` cadence. **SI never gates output**: nothing in SI is something a TS stream cannot begin without (the PAT/PMT are built locally, and receivers acquire the service layer mid-stream by design), whereas any gate lets a catalog entry that never delivers (a stale announce naming a dead track) hold the programme dark — and no timeout constant makes that trade-off principled. In practice the SI subscriptions resolve within the first poll and lead the stream anyway; a late entry starts emitting on its cadence at most one subscription round-trip behind the media, indistinguishable from tuning in just before an SDT repetition. A failed or ended SI track logs and keeps re-emitting the last snapshot, mirroring how a mux repeats tables between revisions.

**Everything on a captured PID is carried** — now/next, the 8-day schedule, BAT, unknown tables — with no policy filter and no knobs: cost lands only on subscribers (TS exporters), and a mux re-transmits its whole EPG every 10-30s standing still, so snapshot-per-change sits at or below the baseline TS itself sets.

## Breaking

Targets `dev`: reshapes the shipped `mpegts.si` catalog schema and the published `pub` surface (`ts::Si` removed, `ts::SiEntry` added). Clean break, no dual-publish: an old exporter reading a new broadcast degrades gracefully (the field parses as absent) but loses SDT/NIT fidelity; pre-1.0 with consumers overwhelmingly in-tree, we chose not to keep shipping the torn-state path for a deprecation window.

## Tests

All in `export_test.rs`, transplanting #2824's corpus onto the track model:

- `torn_transition_is_never_published`: v6 arriving one section at a time never mixes with v5 in any published group; the newest snapshot is v6 complete. Regression for #2881's measured defect.
- `eit_now_next_and_schedule_are_captured`: per-table entries and cadences on one PID, plus the sparse-schedule wrap commit. Closes the #2800 gap.
- `sdt_other_networks_do_not_collide`: two networks sharing a TSID coexist; a revision replaces only its own network. Regression for #2842.
- `next_version_sections_are_dropped`, `tdt_is_not_captured`: policy pins, each with a positive control (a lone packet never routes, so a control-free absence assertion passes vacuously).
- `stale_si_entry_does_not_block_output`: an advertised entry whose track resolves but never delivers cannot hold output dark; media flows immediately.
- `abort_removes_si_catalog_entries`: abort unadvertises, so the catalog never names aborted tracks.
- `content_section_churn_at_the_cap_cuts_no_group`: rotation at the content-identity retention cap is not a change.
- `service_layer_survives_roundtrip`: now also pins that a repetition cuts no group, and that the synthetic sections are well-formed (the store requires coherent `last_section_number`, which real tables have; the old helper's was garbage bytes).
- `si_pids_are_re_emitted_on_their_own_interval` and `multi_packet_si_section_is_captured` adapted.

`just check` and `cargo nextest run -p moq-mux` (565 tests) pass; `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-mux` clean; `just drafts check` clean.

## Cross-package sync

- `drafts/draft-lcurley-moq-hang.md`: new "MPEG-TS Service Information" section specifying the descriptor and track format. This is the first normative text for any of the `mpegts` section (the rest remains implementation-defined, a pre-existing gap); written now because there is a second implementation building against this surface.
- `doc/bin/cli.md`: the SI prose updated; the old "live or bulky rather than static identity" conflation (two rationales, three tables) replaced.
- No js mirror (`js/` has no MPEG-TS support). No moq-ffi/libmoq surface change.

Not taken here: t0ms's measurement harness and MPTS fixture generators (offered in-tree on #2882); worth a follow-up so this path is testable in CI against a realistic multiplex.

(written by Fable 5)
