### PR TITLE
feat(moq-ffi): compile for wasm32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4729,7 +4729,9 @@ name = "moq-ffi"
 version = "0.3.11"
 dependencies = [
  "bytes",
+ "getrandom 0.4.3",
  "hang",
+ "kio 0.5.4",
  "moq-audio",
  "moq-json",
  "moq-mux",
@@ -4743,6 +4745,9 @@ dependencies = [
  "tracing",
  "uniffi",
  "url",
+ "web-async",
+ "web-transport-trait",
+ "web-transport-wasm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ rust-version = "1.91"
 
 [workspace.dependencies]
 flate2 = "1.1"
+getrandom = { version = "0.4", features = ["wasm_js"] }
 hang = { version = "0.20", path = "rs/hang" }
 kio = { version = "0.5", path = "rs/kio" }
 libc = "0.2"
@@ -129,6 +130,7 @@ web-transport-proto = "0.6"
 web-transport-quiche = "0.6"
 web-transport-quinn = "0.12"
 web-transport-trait = "0.4.0"
+web-transport-wasm = "0.5"
 
 [profile.dev]
 panic = "abort"

--- a/rs/justfile
+++ b/rs/justfile
@@ -129,10 +129,13 @@ check-changed $FILES:
 
     # moq-wasm's crate root is entirely `#![cfg(target_arch = "wasm32")]`, so
     # however it got selected the host-target pass above compiled it to nothing
-    # and saw no errors in it. This wasm32 pass is what actually checks it, and
-    # the selection already says whether moq-wasm or anything it depends on
-    # changed.
-    if [[ "$packages" == "ALL" ]] || grep -q -- '--package moq-wasm' <<< "$packages"; then
+    # and saw no errors in it. This wasm32 pass is what actually checks it.
+    #
+    # The alternation must list every package `wasm` compiles, not just moq-wasm:
+    # nothing in the workspace depends on moq-ffi, so an moq-ffi-only diff selects
+    # only itself and would never reach the gate that exists to cover it. moq-mux
+    # is selected by its dependents, none of which are moq-wasm.
+    if [[ "$packages" == "ALL" ]] || grep -qE -- '--package (moq-wasm|moq-mux|moq-ffi)' <<< "$packages"; then
     	just rs wasm
     fi
 
@@ -147,9 +150,9 @@ fix-changed $FILES:
     	*)     echo "rs: fixing ${packages//--package /}"; just rs fix $packages ;;
     esac
 
-    # Mirrors `check-changed`'s gate: without this a moq-wasm lint is never
-    # auto-fixed, and `check`'s wasm32 clippy pass fails on it later.
-    if [[ "$packages" == "ALL" ]] || grep -q -- '--package moq-wasm' <<< "$packages"; then
+    # Mirrors `check-changed`'s gate, alternation included: without this a wasm32
+    # lint is never auto-fixed, and `check`'s wasm32 clippy pass fails on it later.
+    if [[ "$packages" == "ALL" ]] || grep -qE -- '--package (moq-wasm|moq-mux|moq-ffi)' <<< "$packages"; then
     	just rs wasm-fix
     fi
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -209,23 +209,24 @@ macos *args:
 # which builds the shippable `@moq/wasm` package (wasm-bindgen, release profile);
 # this is the compile gate.
 
-# `moq-mux` rides along in the same invocation on purpose: it needs `getrandom`'s
-# `wasm_js` backend, which only `moq-wasm` declares, and feature unification only
-# happens within one cargo invocation. Splitting these into two fails on getrandom.
-# `--lib` rather than `--all-targets` because moq-mux's tests use tokio's native
-# timers; moq-wasm has no test targets, so it loses no coverage.
+# `moq-mux` and `moq-ffi` ride along in the same invocation on purpose: `moq-mux`
+# needs `getrandom`'s `wasm_js` backend that only its siblings declare, and feature
+# unification only happens within one cargo invocation. Splitting them fails on
+# getrandom. `--lib` rather than `--all-targets` because moq-mux's tests use tokio's
+# native timers and moq-ffi's drive a native relay; moq-wasm has no test targets, so
+# it loses no coverage.
 
 # Compile and lint the browser/WASM bindings, which the host-target check skips.
 wasm *args:
-    cargo clippy -p moq-wasm -p moq-mux --target wasm32-unknown-unknown --lib {{ args }} -- -D warnings
+    cargo clippy -p moq-wasm -p moq-mux -p moq-ffi --target wasm32-unknown-unknown --lib {{ args }} -- -D warnings
 
 # The `fix` counterpart to `wasm`. `cargo fmt` is scoped rather than `--all`
 # because this runs alongside `fix`, which already formats everything else.
 
 # Auto-fix the browser/WASM bindings.
 wasm-fix *args:
-    cargo clippy --fix --allow-staged --allow-dirty -p moq-wasm -p moq-mux --target wasm32-unknown-unknown --lib {{ args }}
-    cargo fmt -p moq-wasm -p moq-mux
+    cargo clippy --fix --allow-staged --allow-dirty -p moq-wasm -p moq-mux -p moq-ffi --target wasm32-unknown-unknown --lib {{ args }}
+    cargo fmt -p moq-wasm -p moq-mux -p moq-ffi
 
 # Dependency advisories plus the license/ban policy. Time-based rather than
 # diff-based: an advisory lands without this repo changing, so a per-PR run both

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -65,14 +65,14 @@ uniffi = { version = "0.31", features = ["cli"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # Enables the `wasm_js` backend for rand-via-moq-net; the cfg flag lives in
 # `.cargo/config.toml`. Referenced only as a feature enabler, hence the shear ignore.
-getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom = { workspace = true }
 # `wasm-unstable-single-threaded` drops the `Send`/`Sync` bounds on
 # `UniffiCompatibleFuture` and `FfiConverterArc`, which moq-net's wasm futures
 # (LocalBoxFuture) and Rc-backed handles cannot satisfy.
 uniffi = { version = "0.31", features = ["wasm-unstable-single-threaded"] }
 web-async = { workspace = true }
 web-transport-trait = { workspace = true }
-web-transport-wasm = "0.5"
+web-transport-wasm = { workspace = true }
 
 [build-dependencies]
 uniffi = { version = "0.31", features = ["build"] }

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -24,7 +24,15 @@ name = "uniffi-bindgen"
 path = "./uniffi-bindgen.rs"
 
 [features]
+# On by default so every existing consumer (the language wrappers, `build.sh`)
+# keeps the surface it has. Opt out with `default-features = false` to skip the
+# ~40 crates that only the codecs pull in, including openh264's vendored C++.
+# They are unavailable on wasm32 regardless: the browser encodes via WebCodecs.
+default = ["audio", "video"]
+
 android-logcat = ["moq-native/android-logcat"]
+audio = ["dep:moq-audio"]
+video = ["dep:moq-video", "dep:pollster"]
 
 [dependencies]
 bytes = "1"
@@ -43,14 +51,14 @@ tracing = "0.1"
 url = "2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-moq-audio = { workspace = true }
+moq-audio = { workspace = true, optional = true }
 moq-native = { workspace = true, default-features = true }
 # Default features only: the Linux hardware codecs stay off so the wrappers'
 # cross-compiled targets (Android, iOS) don't pull a CUDA graph.
-moq-video = { workspace = true }
+moq-video = { workspace = true, optional = true }
 # Blocking on `encode::Sink` from the synchronous producer exports; see
 # `video::block_on` for why not a tokio helper.
-pollster = "1.0"
+pollster = { version = "1.0", optional = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync"] }
 uniffi = { version = "0.31", features = ["cli"] }
 
@@ -68,3 +76,7 @@ web-transport-wasm = "0.5"
 
 [build-dependencies]
 uniffi = { version = "0.31", features = ["build"] }
+
+[dev-dependencies]
+# One non-codec test blocks on a future; the main dep is `video`-only.
+pollster = "1.0"

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2024"
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
+[package.metadata.cargo-shear]
+# Required indirectly (a feature enabler with no `use`), so cargo-shear can't see it.
+ignored = ["getrandom"]
+
 [lib]
 name = "moq_ffi"
 crate-type = ["staticlib", "cdylib"]
@@ -25,25 +29,42 @@ android-logcat = ["moq-native/android-logcat"]
 [dependencies]
 bytes = "1"
 hang = { workspace = true }
-moq-audio = { workspace = true }
+# `kio::MaybeSend` is the `Send` bound that vanishes on wasm; see `ffi::Task`.
+kio = { workspace = true }
 moq-json = { workspace = true }
 moq-mux = { workspace = true }
-moq-native = { workspace = true, default-features = true }
 moq-net = { workspace = true }
+serde_json = "1"
+thiserror = "2"
+# `sync` (Mutex, watch) and `macros` (select!) are the only tokio pieces that build
+# on wasm32; the runtime and its drivers are native-only.
+tokio = { workspace = true, features = ["macros", "sync"] }
+tracing = "0.1"
+url = "2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+moq-audio = { workspace = true }
+moq-native = { workspace = true, default-features = true }
 # Default features only: the Linux hardware codecs stay off so the wrappers'
 # cross-compiled targets (Android, iOS) don't pull a CUDA graph.
 moq-video = { workspace = true }
 # Blocking on `encode::Sink` from the synchronous producer exports; see
 # `video::block_on` for why not a tokio helper.
 pollster = "1.0"
-serde_json = "1"
-thiserror = "2"
-tokio = { workspace = true, features = ["macros"] }
-tracing = "0.1"
+tokio = { workspace = true, features = ["rt", "macros", "sync"] }
 uniffi = { version = "0.31", features = ["cli"] }
-url = "2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# Enables the `wasm_js` backend for rand-via-moq-net; the cfg flag lives in
+# `.cargo/config.toml`. Referenced only as a feature enabler, hence the shear ignore.
+getrandom = { version = "0.4", features = ["wasm_js"] }
+# `wasm-unstable-single-threaded` drops the `Send`/`Sync` bounds on
+# `UniffiCompatibleFuture` and `FfiConverterArc`, which moq-net's wasm futures
+# (LocalBoxFuture) and Rc-backed handles cannot satisfy.
+uniffi = { version = "0.31", features = ["wasm-unstable-single-threaded"] }
+web-async = { workspace = true }
+web-transport-trait = { workspace = true }
+web-transport-wasm = "0.5"
 
 [build-dependencies]
 uniffi = { version = "0.31", features = ["build"] }
-
-[dev-dependencies]

--- a/rs/moq-ffi/src/error.rs
+++ b/rs/moq-ffi/src/error.rs
@@ -15,12 +15,12 @@ pub enum MoqError {
 	#[error(transparent)]
 	JsonTrack(#[from] moq_json::Error),
 
-	// Native codec errors; the browser encodes and decodes through WebCodecs.
-	#[cfg(not(target_arch = "wasm32"))]
+	// Native codec errors, behind the optional `audio`/`video` features.
+	#[cfg(all(feature = "audio", not(target_arch = "wasm32")))]
 	#[error(transparent)]
 	Audio(#[from] moq_audio::Error),
 
-	#[cfg(not(target_arch = "wasm32"))]
+	#[cfg(all(feature = "video", not(target_arch = "wasm32")))]
 	#[error(transparent)]
 	Video(#[from] moq_video::Error),
 

--- a/rs/moq-ffi/src/error.rs
+++ b/rs/moq-ffi/src/error.rs
@@ -15,9 +15,12 @@ pub enum MoqError {
 	#[error(transparent)]
 	JsonTrack(#[from] moq_json::Error),
 
+	// Native codec errors; the browser encodes and decodes through WebCodecs.
+	#[cfg(not(target_arch = "wasm32"))]
 	#[error(transparent)]
 	Audio(#[from] moq_audio::Error),
 
+	#[cfg(not(target_arch = "wasm32"))]
 	#[error(transparent)]
 	Video(#[from] moq_video::Error),
 
@@ -30,6 +33,8 @@ pub enum MoqError {
 	#[error(transparent)]
 	LogLevel(#[from] tracing::metadata::ParseLevelError),
 
+	// Only the native path spawns onto a runtime, so only it can fail to join.
+	#[cfg(not(target_arch = "wasm32"))]
 	#[error(transparent)]
 	Task(#[from] tokio::task::JoinError),
 

--- a/rs/moq-ffi/src/ffi.rs
+++ b/rs/moq-ffi/src/ffi.rs
@@ -1,9 +1,14 @@
 use std::future::Future;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use crate::error::MoqError;
 
-pub(crate) static RUNTIME: LazyLock<tokio::runtime::Handle> = LazyLock::new(|| {
+/// A dedicated runtime thread, so a foreign caller's thread never has to drive our futures.
+///
+/// wasm32 has neither threads nor a tokio driver. uniffi's `RustFuture` is polled by the
+/// JS event loop instead, so [`Task::run`] awaits in place there.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) static RUNTIME: std::sync::LazyLock<tokio::runtime::Handle> = std::sync::LazyLock::new(|| {
 	let runtime = tokio::runtime::Builder::new_current_thread()
 		.enable_all()
 		.build()
@@ -20,12 +25,55 @@ pub(crate) static RUNTIME: LazyLock<tokio::runtime::Handle> = LazyLock::new(|| {
 	handle
 });
 
-pub(crate) struct Task<T: Send + 'static> {
+/// Enter the runtime context, so a handle built outside [`Task::run`] can still spawn.
+///
+/// A no-op on wasm32, where the JS event loop is the only runtime.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn enter() -> tokio::runtime::EnterGuard<'static> {
+	RUNTIME.enter()
+}
+
+/// Stands in for tokio's `EnterGuard` on wasm32, so callers bind a guard either way.
+#[cfg(target_arch = "wasm32")]
+pub(crate) struct EnterGuard;
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn enter() -> EnterGuard {
+	EnterGuard
+}
+
+/// Run a future to completion off the caller's thread, mapping its error into [`MoqError`].
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn detached<F, T, E>(future: F) -> Result<T, MoqError>
+where
+	F: Future<Output = Result<T, E>> + Send + 'static,
+	T: Send + 'static,
+	E: Into<MoqError> + Send + 'static,
+{
+	match RUNTIME.spawn(future).await {
+		Ok(result) => result.map_err(Into::into),
+		Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
+		Err(e) => Err(MoqError::Task(e)),
+	}
+}
+
+/// Await a future in place: wasm32 has no other thread to hand it to.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn detached<F, T, E>(future: F) -> Result<T, MoqError>
+where
+	F: Future<Output = Result<T, E>> + 'static,
+	T: 'static,
+	E: Into<MoqError> + 'static,
+{
+	future.await.map_err(Into::into)
+}
+
+pub(crate) struct Task<T: kio::MaybeSend + 'static> {
 	state: Arc<tokio::sync::Mutex<T>>,
 	cancel: tokio::sync::watch::Sender<bool>,
 }
 
-impl<T: Send + 'static> Task<T> {
+impl<T: kio::MaybeSend + 'static> Task<T> {
 	pub fn new(inner: T) -> Self {
 		Self {
 			state: Arc::new(tokio::sync::Mutex::new(inner)),
@@ -40,36 +88,61 @@ impl<T: Send + 'static> Task<T> {
 
 	/// Spawn an async closure on the runtime.
 	///
-	/// The closure receives an [OwnedMutexGuard] which derefs to `T`.
+	/// The closure receives an [tokio::sync::OwnedMutexGuard] which derefs to `T`.
 	/// If two calls are made concurrently, the second waits for the first to finish.
+	#[cfg(not(target_arch = "wasm32"))]
 	pub async fn run<R, F, Fut>(&self, f: F) -> Result<R, MoqError>
 	where
 		R: Send + 'static,
 		F: FnOnce(tokio::sync::OwnedMutexGuard<T>) -> Fut + Send + 'static,
 		Fut: Future<Output = Result<R, MoqError>> + Send + 'static,
 	{
-		let mut cancel = self.cancel.subscribe();
+		let cancel = self.cancel.subscribe();
 		let state = self.state.clone();
 
-		let handle = RUNTIME.spawn(async move {
-			let state = tokio::select! {
-				biased;
-				Ok(_) = cancel.wait_for(|&c| c) => return Err(MoqError::Cancelled),
-				state = state.lock_owned() => state,
-			};
-
-			let mut cancel = cancel;
-			tokio::select! {
-				biased;
-				Ok(_) = cancel.wait_for(|&c| c) => Err(MoqError::Cancelled),
-				result = f(state) => result,
-			}
-		});
+		let handle = RUNTIME.spawn(async move { Self::drive(cancel, state, f).await });
 
 		match handle.await {
 			Ok(result) => result,
 			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
 			Err(e) => Err(MoqError::Task(e)),
+		}
+	}
+
+	/// Run an async closure, awaiting it in place.
+	///
+	/// Unlike the native path this does not detach, so dropping the returned future
+	/// cancels the work rather than leaving it running on a runtime thread.
+	#[cfg(target_arch = "wasm32")]
+	pub async fn run<R, F, Fut>(&self, f: F) -> Result<R, MoqError>
+	where
+		R: 'static,
+		F: FnOnce(tokio::sync::OwnedMutexGuard<T>) -> Fut + 'static,
+		Fut: Future<Output = Result<R, MoqError>> + 'static,
+	{
+		Self::drive(self.cancel.subscribe(), self.state.clone(), f).await
+	}
+
+	/// Wait for the lock, then run `f`, with [Self::cancel] able to interrupt either.
+	async fn drive<R, F, Fut>(
+		mut cancel: tokio::sync::watch::Receiver<bool>,
+		state: Arc<tokio::sync::Mutex<T>>,
+		f: F,
+	) -> Result<R, MoqError>
+	where
+		F: FnOnce(tokio::sync::OwnedMutexGuard<T>) -> Fut,
+		Fut: Future<Output = Result<R, MoqError>>,
+	{
+		let state = tokio::select! {
+			biased;
+			Ok(_) = cancel.wait_for(|&c| c) => return Err(MoqError::Cancelled),
+			state = state.lock_owned() => state,
+		};
+
+		tokio::select! {
+			biased;
+			Ok(_) = cancel.wait_for(|&c| c) => Err(MoqError::Cancelled),
+			result = f(state) => result,
 		}
 	}
 
@@ -79,7 +152,7 @@ impl<T: Send + 'static> Task<T> {
 	}
 }
 
-impl<T: Send + 'static> Drop for Task<T> {
+impl<T: kio::MaybeSend + 'static> Drop for Task<T> {
 	fn drop(&mut self) {
 		self.cancel();
 	}

--- a/rs/moq-ffi/src/json.rs
+++ b/rs/moq-ffi/src/json.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 use crate::consumer::MoqBroadcastConsumer;
 use crate::error::MoqError;
-use crate::ffi::{RUNTIME, Task};
+use crate::ffi::Task;
 use crate::producer::MoqBroadcastProducer;
 
 /// Options for a JSON snapshot track (lossy latest-value mode).
@@ -100,7 +100,7 @@ impl MoqBroadcastProducer {
 		name: String,
 		config: MoqJsonSnapshotConfig,
 	) -> Result<Arc<MoqJsonSnapshotProducer>, MoqError> {
-		let _guard = RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		self.with_state(|state| {
 			let mut broadcast = state.broadcast.clone();
 			let track = broadcast.create_track(name, None)?;
@@ -117,7 +117,7 @@ impl MoqBroadcastProducer {
 		name: String,
 		config: MoqJsonStreamConfig,
 	) -> Result<Arc<MoqJsonStreamProducer>, MoqError> {
-		let _guard = RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		self.with_state(|state| {
 			let mut broadcast = state.broadcast.clone();
 			let track = broadcast.create_track(name, None)?;
@@ -173,7 +173,7 @@ impl MoqJsonSnapshotProducer {
 	/// Publish a new value, encoded as a snapshot or delta automatically. `value` is a JSON
 	/// document. A no-op if unchanged from the previous update.
 	pub fn update(&self, value: String) -> Result<(), MoqError> {
-		let _guard = RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let value: Value = serde_json::from_str(&value)?;
 		let mut guard = self.inner.lock().unwrap();
 		let producer = guard.as_mut().ok_or(MoqError::Closed)?;
@@ -183,7 +183,7 @@ impl MoqJsonSnapshotProducer {
 
 	/// Finish the track, closing any open group.
 	pub fn finish(&self) -> Result<(), MoqError> {
-		let _guard = RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut producer = self.inner.lock().unwrap().take().ok_or(MoqError::Closed)?;
 		producer.finish()?;
 		Ok(())
@@ -236,7 +236,7 @@ pub struct MoqJsonStreamProducer {
 impl MoqJsonStreamProducer {
 	/// Append one record to the log. `value` is a JSON document.
 	pub fn append(&self, value: String) -> Result<(), MoqError> {
-		let _guard = RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let value: Value = serde_json::from_str(&value)?;
 		let mut guard = self.inner.lock().unwrap();
 		let producer = guard.as_mut().ok_or(MoqError::Closed)?;
@@ -246,7 +246,7 @@ impl MoqJsonStreamProducer {
 
 	/// Finish the track, closing the group.
 	pub fn finish(&self) -> Result<(), MoqError> {
-		let _guard = RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut producer = self.inner.lock().unwrap().take().ok_or(MoqError::Closed)?;
 		producer.finish()?;
 		Ok(())

--- a/rs/moq-ffi/src/lib.rs
+++ b/rs/moq-ffi/src/lib.rs
@@ -3,22 +3,37 @@
 //! Provides a Kotlin/Swift-compatible API for real-time pub/sub over QUIC.
 //! Uses async UniFFI objects instead of callbacks for a native async experience.
 
+// uniffi lowers every exported object as an `Arc<T>`, and on wasm moq-net's handles are
+// `Rc`-backed, so clippy sees a pointlessly atomic `Arc` at every construction site. The
+// `Arc` is uniffi's ABI rather than our choice, and the target is single-threaded, so the
+// wasted atomics are what one type serving both targets costs.
+#![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
+
 #[cfg(target_os = "android")]
 mod android;
+// Native codecs, the QUIC server, and moq-native's logger have no browser
+// equivalent: the browser encodes through WebCodecs and logs through tracing-web.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod audio;
 pub mod consumer;
 pub mod error;
 mod ffi;
 pub mod json;
+#[cfg(not(target_arch = "wasm32"))]
 mod log;
 pub mod media;
 pub mod origin;
 pub mod producer;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod server;
 pub mod session;
+#[cfg(target_arch = "wasm32")]
+mod transport;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod video;
 
 uniffi::setup_scaffolding!("moq");
 
-#[cfg(test)]
+// The test suite drives a native relay over a tokio runtime.
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod test;

--- a/rs/moq-ffi/src/lib.rs
+++ b/rs/moq-ffi/src/lib.rs
@@ -11,9 +11,10 @@
 
 #[cfg(target_os = "android")]
 mod android;
-// Native codecs, the QUIC server, and moq-native's logger have no browser
-// equivalent: the browser encodes through WebCodecs and logs through tracing-web.
-#[cfg(not(target_arch = "wasm32"))]
+// The QUIC server and moq-native's logger have no browser equivalent, and the
+// native codecs are both browser-inapplicable (WebCodecs does this) and optional,
+// since they are the heaviest thing in the dependency graph.
+#[cfg(all(feature = "audio", not(target_arch = "wasm32")))]
 pub mod audio;
 pub mod consumer;
 pub mod error;
@@ -29,7 +30,7 @@ pub mod server;
 pub mod session;
 #[cfg(target_arch = "wasm32")]
 mod transport;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "video", not(target_arch = "wasm32")))]
 pub mod video;
 
 uniffi::setup_scaffolding!("moq");

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -202,13 +202,13 @@ impl MoqOriginProducer {
 	/// Create a new origin for publishing and/or consuming broadcasts.
 	#[uniffi::constructor]
 	pub fn new(options: MoqOriginOptions) -> Arc<Self> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		Arc::new(Self::from_options(options))
 	}
 
 	/// Create a consumer for this origin.
 	pub fn consume(&self) -> Arc<MoqOriginConsumer> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		Arc::new(MoqOriginConsumer {
 			inner: self.inner.consume(),
 		})
@@ -219,7 +219,7 @@ impl MoqOriginProducer {
 	/// Hold the returned object while missing broadcast requests should be accepted.
 	/// Dropping it makes future requests to unknown broadcasts fail.
 	pub fn dynamic(&self) -> Arc<MoqOriginDynamic> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		Arc::new(MoqOriginDynamic {
 			task: Task::new(OriginDynamic {
 				inner: self.inner.dynamic(),
@@ -238,7 +238,7 @@ impl MoqOriginProducer {
 	/// without finishing is treated as a failure: the path lingers briefly so a
 	/// replacement publisher can take over without subscribers noticing.
 	pub fn create_broadcast(&self, path: String) -> Result<Arc<MoqBroadcastProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		// Surfaces Error::Unauthorized (out of scope) via the MoqError::Protocol conversion.
 		let broadcast = self
 			.inner
@@ -251,7 +251,7 @@ impl MoqOriginProducer {
 impl MoqOriginConsumer {
 	/// Subscribe to all broadcast announcements under a prefix.
 	pub fn announced(&self, prefix: String) -> Result<Arc<MoqAnnounced>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let origin = self.inner.with_root(prefix).ok_or(MoqError::Unauthorized)?;
 		Ok(Arc::new(MoqAnnounced {
 			task: Task::new(Announced {
@@ -265,7 +265,7 @@ impl MoqOriginConsumer {
 	/// This is how you resolve a path right after connecting: announcements arrive over the
 	/// session after it opens, so `request_broadcast` on its own races them.
 	pub fn announced_broadcast(&self, path: String) -> Result<Arc<MoqAnnouncedBroadcast>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let origin = self.inner.with_root(path).ok_or(MoqError::Unauthorized)?;
 		Ok(Arc::new(MoqAnnouncedBroadcast {
 			task: Task::new(Announced {
@@ -335,7 +335,7 @@ impl MoqBroadcastRequest {
 
 	/// Accept the request with an unannounced broadcast.
 	pub fn accept(&self, broadcast: &MoqBroadcastProducer) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let consumer = broadcast.consume_inner()?;
 		let request = self.take()?;
 		request.accept(&consumer);
@@ -344,7 +344,7 @@ impl MoqBroadcastRequest {
 
 	/// Abort the request with an application error code.
 	pub fn abort(&self, error_code: u16) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let request = self.take()?;
 		request.reject(moq_net::Error::App(error_code));
 		Ok(())

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -237,7 +237,7 @@ pub struct MoqMediaStreamProducer {
 impl MoqBroadcastProducer {
 	/// Create a consumer that reads from this broadcast's tracks.
 	pub fn consume(&self) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		Ok(Arc::new(MoqBroadcastConsumer::new(self.consume_inner()?)))
 	}
 
@@ -246,7 +246,7 @@ impl MoqBroadcastProducer {
 	/// Hold the returned object for as long as missing track requests should be
 	/// accepted. Dropping it makes future subscriptions to unknown tracks fail.
 	pub fn dynamic(&self) -> Result<Arc<MoqBroadcastDynamic>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 		Ok(Arc::new(MoqBroadcastDynamic {
@@ -263,7 +263,7 @@ impl MoqBroadcastProducer {
 	/// [`MoqOriginProducer::create_broadcast`](crate::origin::MoqOriginProducer::create_broadcast) instead.
 	#[uniffi::constructor]
 	pub fn new() -> Result<Arc<Self>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		Ok(Arc::new(Self::from_inner(moq_net::broadcast::Info::new().produce())?))
 	}
 
@@ -273,7 +273,7 @@ impl MoqBroadcastProducer {
 	/// once it is warm); consumers observe the change via
 	/// `MoqBroadcastConsumer::route_updates` and sessions forward it downstream.
 	pub fn set_route(&self, route: MoqRoute) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let route = route.try_into()?;
 		self.with_state(|state| Ok(state.broadcast.set_route(route)?))
 	}
@@ -284,7 +284,7 @@ impl MoqBroadcastProducer {
 	/// broadcast stays reachable by exact path for subscribes and fetches. This is
 	/// how a publisher goes on and off the air without tearing down the broadcast.
 	pub fn set_announce(&self, announce: bool) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		self.with_state(|state| {
 			let route = state.broadcast.consume().route();
 			Ok(state.broadcast.set_route(route.with_announce(announce))?)
@@ -295,7 +295,7 @@ impl MoqBroadcastProducer {
 	///
 	/// Rotation is clockwise and normalized to the nearest quarter turn. An absent field is removed from the next catalog update.
 	pub fn set_video_properties(&self, properties: MoqVideoProperties) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut value = hang::catalog::VideoProperties::default();
 		value.display = properties.display.map(|display| hang::catalog::Display {
 			width: display.width,
@@ -319,7 +319,7 @@ impl MoqBroadcastProducer {
 	/// error if `name` is `video`/`audio` (owned by the media pipeline). The section is
 	/// republished on the catalog track immediately.
 	pub fn set_catalog_section(&self, name: String, json: String) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let value: serde_json::Value = serde_json::from_str(&json)?;
 		self.with_state(|state| Ok(state.catalog.lock().set_section(name, value)?))
 	}
@@ -328,7 +328,7 @@ impl MoqBroadcastProducer {
 	///
 	/// Republishes the catalog if the section existed; a no-op otherwise.
 	pub fn remove_catalog_section(&self, name: String) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		self.with_state(|state| {
 			state.catalog.lock().remove_section(&name);
 			Ok(())
@@ -341,7 +341,7 @@ impl MoqBroadcastProducer {
 	/// its hints seed the catalog. Hints apply to single-codec formats; container formats auto-detect
 	/// every track.
 	pub fn publish_media(&self, init: MoqInit) -> Result<Arc<MoqMediaProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 
@@ -391,7 +391,7 @@ impl MoqBroadcastProducer {
 		request: &MoqTrackRequest,
 		init: MoqInit,
 	) -> Result<Arc<MoqMediaProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 
@@ -419,7 +419,7 @@ impl MoqBroadcastProducer {
 	/// (avc3, hev1, av01, fmp4, mkv). [`MoqInit`] carries the format, any
 	/// seed bytes, and catalog hints.
 	pub fn publish_media_stream(&self, init: MoqInit) -> Result<Arc<MoqMediaStreamProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 
@@ -458,7 +458,7 @@ impl MoqBroadcastProducer {
 	/// bytes written directly to moq-lite groups with no media framing. `info` sets
 	/// track properties (priority, latency_max, timescale); omit for defaults.
 	pub fn publish_track(&self, name: String, info: Option<MoqTrackInfo>) -> Result<Arc<MoqTrackProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 		let info = raw_track_info(info)?;
@@ -473,7 +473,7 @@ impl MoqBroadcastProducer {
 	/// Finish this publisher, finalizing the catalog stream and cleanly closing the
 	/// broadcast so subscribers see a normal end rather than `Error::Dropped`.
 	pub fn finish(&self) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.state.lock().unwrap();
 		let mut state = guard.take().ok_or(MoqError::Closed)?;
 		// Finish the broadcast first so the clean end reaches subscribers even if
@@ -564,7 +564,7 @@ impl MoqGroupRequest {
 
 	/// Accept the request and return a producer for filling the fetched group.
 	pub fn accept(&self) -> Result<Arc<MoqGroupProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let group = self.take()?.accept(None)?;
 		Ok(Arc::new(MoqGroupProducer {
 			sequence: group.sequence,
@@ -574,7 +574,7 @@ impl MoqGroupRequest {
 
 	/// Reject the fetch with an application error code.
 	pub fn abort(&self, error_code: u16) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		self.take()?.reject(moq_net::Error::App(error_code));
 		Ok(())
 	}
@@ -621,7 +621,7 @@ impl MoqTrackRequest {
 	/// requested by a fetch. This keeps the pending group request serviceable across
 	/// the transition from request to producer.
 	pub fn dynamic(&self) -> Result<Arc<MoqTrackDynamic>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.inner.lock().unwrap();
 		let request = guard.as_ref().ok_or(MoqError::Closed)?;
 		Ok(Arc::new(MoqTrackDynamic::new(request.dynamic())))
@@ -632,7 +632,7 @@ impl MoqTrackRequest {
 	/// For media use [`MoqBroadcastProducer::publish_media_on_track`] instead, which lets
 	/// the importer pick the timescale.
 	pub fn accept(&self, info: Option<MoqTrackInfo>) -> Result<Arc<MoqTrackProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let info = raw_track_info(info)?;
 		let request = self.take()?;
 		Ok(Arc::new(MoqTrackProducer {
@@ -642,7 +642,7 @@ impl MoqTrackRequest {
 
 	/// Reject the request with an application error code, failing the waiting subscriber.
 	pub fn abort(&self, error_code: u16) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let request = self.take()?;
 		request.reject(moq_net::Error::App(error_code));
 		Ok(())
@@ -660,7 +660,7 @@ pub struct MoqTrackProducer {
 impl MoqTrackProducer {
 	/// Return the name of this track.
 	pub fn name(&self) -> Result<String, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.inner.lock().unwrap();
 		let track = guard.as_ref().ok_or(MoqError::Closed)?;
 		Ok(track.name().to_string())
@@ -671,7 +671,7 @@ impl MoqTrackProducer {
 	/// Hold the returned object for as long as cache misses should wait to be
 	/// served. Without a live dynamic handler, a missing group fails with `NotFound`.
 	pub fn dynamic(&self) -> Result<Arc<MoqTrackDynamic>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.inner.lock().unwrap();
 		let track = guard.as_ref().ok_or(MoqError::Closed)?;
 		Ok(Arc::new(MoqTrackDynamic::new(track.dynamic())))
@@ -680,21 +680,13 @@ impl MoqTrackProducer {
 	/// Wait until this track has at least one active consumer.
 	pub async fn used(&self) -> Result<(), MoqError> {
 		let track = self.inner.lock().unwrap().as_ref().ok_or(MoqError::Closed)?.clone();
-		match crate::ffi::RUNTIME.spawn(async move { track.used().await }).await {
-			Ok(result) => result.map_err(Into::into),
-			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
-			Err(e) => Err(MoqError::Task(e)),
-		}
+		crate::ffi::detached(async move { track.used().await }).await
 	}
 
 	/// Wait until this track has no active consumers.
 	pub async fn unused(&self) -> Result<(), MoqError> {
 		let track = self.inner.lock().unwrap().as_ref().ok_or(MoqError::Closed)?.clone();
-		match crate::ffi::RUNTIME.spawn(async move { track.unused().await }).await {
-			Ok(result) => result.map_err(Into::into),
-			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
-			Err(e) => Err(MoqError::Task(e)),
-		}
+		crate::ffi::detached(async move { track.unused().await }).await
 	}
 
 	/// Create a consumer that reads from this producer's track.
@@ -702,7 +694,7 @@ impl MoqTrackProducer {
 	/// Useful for local pub/sub without going through an origin/broadcast. `subscription`
 	/// tunes delivery priority, group ordering priority, and group range; omit for defaults.
 	pub fn consume(&self, subscription: Option<MoqSubscription>) -> Result<Arc<MoqTrackConsumer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.inner.lock().unwrap();
 		let track = guard.as_ref().ok_or(MoqError::Closed)?;
 		let subscription = subscription.map(moq_net::track::Subscription::from);
@@ -711,7 +703,7 @@ impl MoqTrackProducer {
 
 	/// Append a new group to the track, returning a producer for writing frames into it.
 	pub fn append_group(&self) -> Result<Arc<MoqGroupProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or(MoqError::Closed)?;
 		let group = track.append_group()?;
@@ -726,7 +718,7 @@ impl MoqTrackProducer {
 	/// Use this for sparse or replayed tracks. [`append_group`](Self::append_group)
 	/// remains the convenient live-stream path.
 	pub fn create_group(&self, sequence: u64) -> Result<Arc<MoqGroupProducer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or(MoqError::Closed)?;
 		let group = track.create_group(moq_net::group::Info { sequence })?;
@@ -741,7 +733,7 @@ impl MoqTrackProducer {
 	/// Raw tracks default to a microsecond timescale. Custom timescales may round
 	/// the timestamp during conversion.
 	pub fn write_frame(&self, frame: MoqFrame) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let timestamp = moq_net::Timestamp::from_micros(frame.timestamp_us)?;
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or(MoqError::Closed)?;
@@ -754,7 +746,7 @@ impl MoqTrackProducer {
 	/// The payload must be at most 1200 bytes. Datagrams are only delivered on transports and
 	/// wire versions with a datagram channel; there is no stream fallback.
 	pub fn append_datagram(&self, frame: MoqFrame) -> Result<u64, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let timestamp = moq_net::Timestamp::from_micros(frame.timestamp_us)?;
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or(MoqError::Closed)?;
@@ -763,7 +755,7 @@ impl MoqTrackProducer {
 
 	/// Abort this track with an application error code.
 	pub fn abort(&self, error_code: u16) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.take().ok_or(MoqError::Closed)?;
 		track.abort(moq_net::Error::App(error_code))?;
@@ -775,7 +767,7 @@ impl MoqTrackProducer {
 	/// [`finish_at`](Self::finish_at) declares the boundary ahead of time, so this keeps
 	/// that boundary and only releases the producer.
 	pub fn finish(&self) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let mut track = guard.take().ok_or(MoqError::Closed)?;
 		if track.final_sequence().is_none() {
@@ -790,7 +782,7 @@ impl MoqTrackProducer {
 	/// above it are rejected. The producer remains open for groups below the boundary;
 	/// call [`finish`](Self::finish) after producing the remaining groups.
 	pub fn finish_at(&self, final_sequence: u64) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or(MoqError::Closed)?;
 		track.finish_at(final_sequence)?;
@@ -813,7 +805,7 @@ impl MoqGroupProducer {
 
 	/// Create a consumer that reads frames from this group.
 	pub fn consume(&self) -> Result<Arc<MoqGroupConsumer>, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.inner.lock().unwrap();
 		let group = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 		Ok(Arc::new(MoqGroupConsumer::new(group.consume())))
@@ -824,7 +816,7 @@ impl MoqGroupProducer {
 	/// Raw tracks default to a microsecond timescale. Custom timescales may round
 	/// the timestamp during conversion.
 	pub fn write_frame(&self, frame: MoqFrame) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let timestamp = moq_net::Timestamp::from_micros(frame.timestamp_us)?;
 		let mut guard = self.inner.lock().unwrap();
 		let group = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
@@ -834,7 +826,7 @@ impl MoqGroupProducer {
 
 	/// Mark the group as complete. No more frames can be written.
 	pub fn finish(&self) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let mut group = guard.take().ok_or_else(|| MoqError::Closed)?;
 		group.finish()?;
@@ -843,7 +835,7 @@ impl MoqGroupProducer {
 
 	/// Abort this group with an application error code.
 	pub fn abort(&self, error_code: u16) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let group = guard.take().ok_or(MoqError::Closed)?;
 		group.abort(moq_net::Error::App(error_code))?;
@@ -859,7 +851,7 @@ impl MoqMediaProducer {
 	///
 	/// Errors for a multi-track container source, which has no single track name.
 	pub fn name(&self) -> Result<String, MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let guard = self.inner.lock().unwrap();
 		let media = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 		let demand = media
@@ -882,11 +874,7 @@ impl MoqMediaProducer {
 			.demand
 			.clone()
 			.ok_or_else(|| MoqError::Codec("demand unavailable for a multi-track container".into()))?;
-		match crate::ffi::RUNTIME.spawn(async move { demand.used().await }).await {
-			Ok(result) => result.map_err(Into::into),
-			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
-			Err(e) => Err(MoqError::Task(e)),
-		}
+		crate::ffi::detached(async move { demand.used().await }).await
 	}
 
 	/// Wait until this media track has no active consumers.
@@ -902,11 +890,7 @@ impl MoqMediaProducer {
 			.demand
 			.clone()
 			.ok_or_else(|| MoqError::Codec("demand unavailable for a multi-track container".into()))?;
-		match crate::ffi::RUNTIME.spawn(async move { demand.unused().await }).await {
-			Ok(result) => result.map_err(Into::into),
-			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
-			Err(e) => Err(MoqError::Task(e)),
-		}
+		crate::ffi::detached(async move { demand.unused().await }).await
 	}
 
 	/// Write `frame` to this media track.
@@ -914,7 +898,7 @@ impl MoqMediaProducer {
 	/// The importer derives keyframe status from the bitstream, so a [`MoqFrame`] carries only
 	/// the payload and its timestamp.
 	pub fn write_frame(&self, frame: MoqFrame) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let media = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
 
@@ -929,7 +913,7 @@ impl MoqMediaProducer {
 
 	/// Finish this media track and finalize encoding.
 	pub fn finish(&self) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let mut media = guard.take().ok_or_else(|| MoqError::Closed)?;
 		media
@@ -946,7 +930,7 @@ impl MoqMediaStreamProducer {
 	/// frames whole access units and keeps any partial trailing frame for the
 	/// next call, so callers can write arbitrary chunks.
 	pub fn write(&self, payload: Vec<u8>) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let media = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
 
@@ -963,7 +947,7 @@ impl MoqMediaStreamProducer {
 	/// arrives, so a trailing access unit with no following delimiter (e.g. the
 	/// last frame at EOF) is not emitted. This matches moq-cli's stdin path.
 	pub fn finish(&self) -> Result<(), MoqError> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		let mut guard = self.inner.lock().unwrap();
 		let mut media = guard.take().ok_or_else(|| MoqError::Closed)?;
 		media

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -84,8 +84,16 @@ mod tests {
 
 	#[test]
 	fn rejects_non_hex_digits() {
-		let bad = format!("zz{}", &VALID[2..]);
-		assert!(decode_hex(&bad).is_err());
+		for bad in [
+			format!("zz{}", &VALID[2..]),
+			// `u8::from_str_radix` accepts a leading sign, so an unchecked chunk would
+			// decode "+a" to 10 and silently yield a fingerprint matching no certificate.
+			format!("+0{}", &VALID[2..]),
+			format!("{}+0", &VALID[..62]),
+			format!(" 0{}", &VALID[2..]),
+		] {
+			assert!(matches!(decode_hex(&bad), Err(MoqError::Connect(_))), "{bad}");
+		}
 	}
 
 	#[test]
@@ -185,9 +193,10 @@ fn decode_hex(hex: &str) -> Result<Vec<u8>, MoqError> {
 
 	let hex = hex.replace(':', "");
 
-	// This string comes straight from the caller. Rejecting non-ASCII up front is what
-	// keeps the 2-byte chunks below aligned with characters rather than splitting one.
-	if !hex.is_ascii() {
+	// This string comes straight from the caller, and one check covers two hazards:
+	// non-ASCII would let a 2-byte chunk split a character, and `from_str_radix` accepts
+	// a leading sign, so an unchecked "+a" would decode to 10 rather than erroring.
+	if !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
 		return Err(MoqError::Connect(format!("fingerprint is not hex: {hex}")));
 	}
 

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -47,6 +47,47 @@ fn map_connect_error(err: moq_native::Error) -> MoqError {
 mod tests {
 	use super::*;
 
+	const VALID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+	#[test]
+	fn decodes_a_sha256_fingerprint() {
+		let bytes = decode_hex(VALID).unwrap();
+		assert_eq!(bytes.len(), 32);
+		assert_eq!(bytes[0], 0x01);
+
+		// Colons are the other shape `MoqServer::cert_fingerprints` and openssl print.
+		let colons = VALID
+			.as_bytes()
+			.chunks(2)
+			.map(|c| std::str::from_utf8(c).unwrap())
+			.collect::<Vec<_>>()
+			.join(":");
+		assert_eq!(decode_hex(&colons).unwrap(), bytes);
+	}
+
+	/// Byte-index slicing used to land inside a multi-byte character and panic, which an
+	/// FFI caller could reach with any non-ASCII string of even byte length.
+	#[test]
+	fn rejects_non_ascii_instead_of_panicking() {
+		for input in ["aéa", "é", "ééééééééééééééééééééééééééééééé"] {
+			assert!(matches!(decode_hex(input), Err(MoqError::Connect(_))), "{input}");
+		}
+	}
+
+	#[test]
+	fn rejects_a_wrong_length_fingerprint() {
+		assert!(decode_hex("").is_err());
+		assert!(decode_hex("abcd").is_err());
+		assert!(decode_hex(&VALID[..62]).is_err());
+		assert!(decode_hex(&format!("{VALID}ab")).is_err());
+	}
+
+	#[test]
+	fn rejects_non_hex_digits() {
+		let bad = format!("zz{}", &VALID[2..]);
+		assert!(decode_hex(&bad).is_err());
+	}
+
 	#[test]
 	fn maps_native_auth_connect_errors() {
 		assert!(matches!(
@@ -134,18 +175,46 @@ impl Client {
 }
 
 /// Decode a hex-encoded SHA-256 certificate fingerprint into raw bytes.
-#[cfg(target_arch = "wasm32")]
+///
+/// Not gated on wasm alone so the native test suite covers it: this parses a string an
+/// FFI caller controls, and nothing in this repo runs a wasm test.
+#[cfg(any(target_arch = "wasm32", test))]
 fn decode_hex(hex: &str) -> Result<Vec<u8>, MoqError> {
+	/// A sha-256 digest is 32 bytes, so 64 hex characters.
+	const LEN: usize = 64;
+
 	let hex = hex.replace(':', "");
-	if !hex.len().is_multiple_of(2) {
-		return Err(MoqError::Connect(format!("odd-length fingerprint: {hex}")));
+
+	// This string comes straight from the caller. Rejecting non-ASCII up front is what
+	// keeps the 2-byte chunks below aligned with characters rather than splitting one.
+	if !hex.is_ascii() {
+		return Err(MoqError::Connect(format!("fingerprint is not hex: {hex}")));
 	}
-	(0..hex.len())
-		.step_by(2)
-		.map(|i| u8::from_str_radix(&hex[i..i + 2], 16).map_err(|err| MoqError::Connect(format!("{err}"))))
+
+	// WebTransport's `serverCertificateHashes` only accepts a 32-byte sha-256, so a
+	// different length can never match a certificate. Rejecting here beats failing
+	// opaquely inside the browser.
+	if hex.len() != LEN {
+		return Err(MoqError::Connect(format!(
+			"expected a {LEN}-character sha-256 fingerprint, got {}",
+			hex.len()
+		)));
+	}
+
+	hex.as_bytes()
+		.chunks(2)
+		.map(|pair| {
+			let pair = std::str::from_utf8(pair).expect("checked ascii above");
+			u8::from_str_radix(pair, 16).map_err(|err| MoqError::Connect(format!("{err}")))
+		})
 		.collect()
 }
 
+/// Builds a [`MoqSession`]: configure it, then [`connect`](Self::connect).
+///
+/// The configuration differs by target, because the transport does. Native builds expose
+/// the QUIC socket and TLS trust store; the browser owns both, so a wasm build exposes
+/// only the certificate hashes WebTransport accepts.
 #[derive(uniffi::Object)]
 pub struct MoqClient {
 	task: Task<Client>,

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -6,12 +6,15 @@ use crate::error::MoqError;
 use crate::ffi::Task;
 use crate::origin::{MoqOriginConsumer, MoqOriginProducer};
 
+/// Native QUIC/WebTransport client configuration.
+#[cfg(not(target_arch = "wasm32"))]
 struct Client {
 	config: moq_native::ClientConfig,
 	publish: Option<Arc<MoqOriginProducer>>,
 	consume: Option<Arc<MoqOriginProducer>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Client {
 	async fn connect(&self, url: Url) -> Result<Arc<MoqSession>, MoqError> {
 		let client = self.config.clone().init().map_err(map_connect_error)?;
@@ -31,6 +34,7 @@ impl Client {
 	}
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn map_connect_error(err: moq_native::Error) -> MoqError {
 	match err.connect_error() {
 		Some(moq_native::ConnectError::Unauthorized) => MoqError::Unauthorized,
@@ -39,7 +43,7 @@ fn map_connect_error(err: moq_native::Error) -> MoqError {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
 	use super::*;
 
@@ -90,17 +94,128 @@ mod tests {
 	}
 }
 
+/// Browser WebTransport client configuration.
+///
+/// The browser owns the socket and the trust store, so none of the native TLS knobs
+/// (roots, mTLS, bind address) have an equivalent. Certificate hashes are the one
+/// thing WebTransport does expose.
+#[cfg(target_arch = "wasm32")]
+struct Client {
+	fingerprints: Vec<Vec<u8>>,
+	publish: Option<Arc<MoqOriginProducer>>,
+	consume: Option<Arc<MoqOriginProducer>>,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Client {
+	async fn connect(&self, url: Url) -> Result<Arc<MoqSession>, MoqError> {
+		let (publish, subscribe) = crate::origin::resolve_pair(self.publish.as_ref(), self.consume.as_ref());
+
+		let transport = match self.fingerprints.is_empty() {
+			true => crate::transport::connect(url).await,
+			false => crate::transport::connect_with_hashes(url, self.fingerprints.clone()).await,
+		}
+		.map_err(|err| MoqError::Connect(format!("{err}")))?;
+
+		let (session, driver) = moq_net::Client::new()
+			.with_publisher(&publish)
+			.with_subscriber(subscribe.clone())
+			.connect(transport)
+			.await?;
+
+		// The session only progresses while the driver runs. The driver holds no session
+		// clone, so dropping the last handle still closes the transport and ends this task.
+		web_async::spawn(async move {
+			let _ = driver.await;
+		});
+
+		Ok(Arc::new(MoqSession::new(session, publish, subscribe)))
+	}
+}
+
+/// Decode a hex-encoded SHA-256 certificate fingerprint into raw bytes.
+#[cfg(target_arch = "wasm32")]
+fn decode_hex(hex: &str) -> Result<Vec<u8>, MoqError> {
+	let hex = hex.replace(':', "");
+	if !hex.len().is_multiple_of(2) {
+		return Err(MoqError::Connect(format!("odd-length fingerprint: {hex}")));
+	}
+	(0..hex.len())
+		.step_by(2)
+		.map(|i| u8::from_str_radix(&hex[i..i + 2], 16).map_err(|err| MoqError::Connect(format!("{err}"))))
+		.collect()
+}
+
 #[derive(uniffi::Object)]
 pub struct MoqClient {
 	task: Task<Client>,
 }
 
+#[cfg(target_arch = "wasm32")]
 #[uniffi::export]
 impl MoqClient {
 	/// Create a new MoQ client with default configuration.
 	#[uniffi::constructor]
 	pub fn new() -> Arc<Self> {
-		let _guard = crate::ffi::RUNTIME.enter();
+		Arc::new(Self {
+			task: Task::new(Client {
+				fingerprints: Vec::new(),
+				publish: None,
+				consume: None,
+			}),
+		})
+	}
+
+	/// Pin the peer to a certificate with one of these SHA-256 fingerprints, encoded as hex.
+	///
+	/// Passed through to WebTransport's `serverCertificateHashes`. An empty list restores
+	/// the browser's normal certificate verification.
+	pub fn set_tls_fingerprints(&self, fingerprints: Vec<String>) -> Result<(), MoqError> {
+		let parsed = fingerprints
+			.iter()
+			.map(|hex| decode_hex(hex))
+			.collect::<Result<Vec<_>, _>>()?;
+		if let Some(mut state) = self.task.lock() {
+			state.fingerprints = parsed;
+		}
+		Ok(())
+	}
+
+	/// Set the origin to publish local broadcasts to the remote.
+	pub fn set_publish(&self, origin: Option<Arc<MoqOriginProducer>>) {
+		if let Some(mut state) = self.task.lock() {
+			state.publish = origin;
+		}
+	}
+
+	/// Set the origin to consume remote broadcasts from the remote.
+	pub fn set_consume(&self, origin: Option<Arc<MoqOriginProducer>>) {
+		if let Some(mut state) = self.task.lock() {
+			state.consume = origin;
+		}
+	}
+
+	/// Connect to a MoQ server and wait for the session to be established.
+	///
+	/// Can be cancelled by calling `cancel()`.
+	pub async fn connect(&self, url: String) -> Result<Arc<MoqSession>, MoqError> {
+		let url = Url::parse(&url)?;
+		self.task.run(|state| async move { state.connect(url).await }).await
+	}
+
+	/// Cancel all current and future `connect()` calls.
+	pub fn cancel(&self) {
+		self.task.cancel();
+	}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[uniffi::export]
+impl MoqClient {
+	/// Create a new MoQ client with default configuration.
+	#[uniffi::constructor]
+	pub fn new() -> Arc<Self> {
+		let _guard = crate::ffi::enter();
 		Arc::new(Self {
 			task: Task::new(Client {
 				config: moq_native::ClientConfig::default(),
@@ -295,7 +410,7 @@ impl MoqSession {
 
 impl Drop for MoqSession {
 	fn drop(&mut self) {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		// Close the transport while the runtime is entered. The backend spawns a
 		// lingering CLOSE task, which panics (aborting under panic=abort) if no reactor
 		// is in context. We can't leave this to the last `Session` clone's drop: that
@@ -319,7 +434,7 @@ impl MoqSession {
 
 	/// Close the session with the given error code.
 	pub fn cancel(&self, code: u32) {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		if let Some(inner) = &self.inner {
 			inner.abort(moq_net::Error::Remote(code));
 		}
@@ -359,7 +474,7 @@ impl MoqSession {
 	/// Individual fields are `None` when the transport backend doesn't report
 	/// them; see [`MoqConnectionStats`].
 	pub fn stats(&self) -> MoqConnectionStats {
-		let _guard = crate::ffi::RUNTIME.enter();
+		let _guard = crate::ffi::enter();
 		self.inner
 			.as_ref()
 			.map(moq_net::Session::stats)

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -1044,6 +1044,7 @@ async fn video_publish_consume() {
 /// The raw-video publish path: hand mid-gray RGBA to `publish_video` and check
 /// that the encoder's own output reaches a subscriber, described by a catalog
 /// rendition the importer built from the encoded keyframe.
+#[cfg(feature = "video")]
 #[tokio::test]
 async fn video_raw_publish_consume() {
 	use crate::video::*;
@@ -1146,6 +1147,7 @@ async fn video_raw_publish_consume() {
 /// whichever thread dropped the object. The confinement itself is asserted in
 /// moq-video (`encode::sink`); this pins that the binding supports the usage
 /// end to end, including the drain on `finish`.
+#[cfg(feature = "video")]
 #[tokio::test]
 async fn video_raw_publish_from_many_threads() {
 	use crate::video::*;
@@ -1221,6 +1223,7 @@ async fn video_raw_publish_from_many_threads() {
 /// A raw video producer rejects a buffer that isn't one picture at the
 /// configured resolution, rather than reinterpreting it, and rejects any write
 /// after `finish`.
+#[cfg(feature = "video")]
 #[tokio::test]
 async fn video_raw_publish_rejects_bad_frames() {
 	use crate::video::*;

--- a/rs/moq-ffi/src/transport.rs
+++ b/rs/moq-ffi/src/transport.rs
@@ -1,0 +1,161 @@
+//! Adapt `web-transport-wasm` (the browser WebTransport API) to the
+//! `web-transport-trait` abstraction that `moq-net` is generic over.
+//!
+//! Both the trait and the wasm types are foreign, so the orphan rule forces
+//! newtype wrappers. The shapes line up closely; the only real impedance
+//! mismatches are documented inline (sync-vs-async datagrams, byte-count vs
+//! write-all, string-vs-code stream resets).
+
+use bytes::Bytes;
+use url::Url;
+use web_transport_trait as wtt;
+
+/// A connected browser WebTransport session, usable by `moq-net`.
+#[derive(Clone)]
+pub struct Session(web_transport_wasm::Session);
+
+/// Advertise every version `moq-net` supports, so the peer picks one via ALPN.
+/// Without this the browser negotiates no subprotocol and the session has no
+/// version to start from.
+fn builder() -> web_transport_wasm::ClientBuilder {
+	web_transport_wasm::ClientBuilder::new().with_protocols(moq_net::ALPNS.iter().copied())
+}
+
+/// Open a browser WebTransport connection to `url`.
+pub async fn connect(url: Url) -> Result<Session, Error> {
+	let client = builder().with_system_roots();
+	let session = client.connect(url).await.map_err(Error)?;
+	Ok(Session(session))
+}
+
+/// Connect, trusting only the given sha-256 certificate hashes (serverless dev,
+/// matching the browser's `serverCertificateHashes` option).
+pub async fn connect_with_hashes(url: Url, hashes: Vec<Vec<u8>>) -> Result<Session, Error> {
+	let client = builder().with_server_certificate_hashes(hashes);
+	let session = client.connect(url).await.map_err(Error)?;
+	Ok(Session(session))
+}
+
+pub struct SendStream(web_transport_wasm::SendStream);
+pub struct RecvStream(web_transport_wasm::RecvStream);
+
+/// Wraps `web_transport_wasm::Error` so we can implement the foreign error trait.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error(transparent)]
+pub struct Error(web_transport_wasm::Error);
+
+impl wtt::Error for Error {
+	fn session_error(&self) -> Option<(u32, String)> {
+		self.0.code().map(|code| (code as u32, self.0.to_string()))
+	}
+
+	fn stream_error(&self) -> Option<u32> {
+		self.0.code().map(|c| c as u32)
+	}
+}
+
+impl wtt::Session for Session {
+	type SendStream = SendStream;
+	type RecvStream = RecvStream;
+	type Error = Error;
+
+	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
+		Ok(RecvStream(self.0.accept_uni().await.map_err(Error)?))
+	}
+
+	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+		let (s, r) = self.0.accept_bi().await.map_err(Error)?;
+		Ok((SendStream(s), RecvStream(r)))
+	}
+
+	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+		let (s, r) = self.0.open_bi().await.map_err(Error)?;
+		Ok((SendStream(s), RecvStream(r)))
+	}
+
+	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
+		Ok(SendStream(self.0.open_uni().await.map_err(Error)?))
+	}
+
+	fn send_datagram(&self, payload: Bytes) -> Result<(), Self::Error> {
+		// The browser datagram API is async; the trait is sync. moq drives all
+		// control/media over streams, so fire-and-forget is acceptable here.
+		let session = self.0.clone();
+		web_async::spawn(async move {
+			let _ = session.send_datagram(payload).await;
+		});
+		Ok(())
+	}
+
+	async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
+		self.0.recv_datagram().await.map_err(Error)
+	}
+
+	fn max_datagram_size(&self) -> usize {
+		// The browser doesn't expose this; use the conservative QUIC default.
+		1200
+	}
+
+	fn protocol(&self) -> Option<&str> {
+		// The browser reports "" when no subprotocol was negotiated, which means the
+		// same thing as `None`: fall back to negotiating the version over SETUP.
+		self.0.protocol().filter(|p| !p.is_empty())
+	}
+
+	fn close(&self, code: u32, reason: &str) {
+		self.0.close(code, reason);
+	}
+
+	async fn closed(&self) -> Self::Error {
+		Error(self.0.closed().await)
+	}
+}
+
+impl wtt::SendStream for SendStream {
+	type Error = Error;
+
+	async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+		// The wasm writer writes the whole slice or errors.
+		self.0.write(buf).await.map_err(Error)?;
+		Ok(buf.len())
+	}
+
+	fn set_priority(&mut self, order: u8) {
+		self.0.set_priority(order as i32);
+	}
+
+	fn finish(&mut self) -> Result<(), Self::Error> {
+		self.0.finish().map_err(Error)
+	}
+
+	fn reset(&mut self, code: u32) {
+		self.0.reset(&code.to_string());
+	}
+
+	async fn closed(&mut self) -> Result<(), Self::Error> {
+		self.0.closed().await.map(|_| ()).map_err(Error)
+	}
+}
+
+impl wtt::RecvStream for RecvStream {
+	type Error = Error;
+
+	async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+		match self.0.read(dst.len()).await.map_err(Error)? {
+			Some(chunk) => {
+				let n = chunk.len();
+				dst[..n].copy_from_slice(&chunk);
+				Ok(Some(n))
+			}
+			None => Ok(None),
+		}
+	}
+
+	fn stop(&mut self, code: u32) {
+		self.0.stop(&code.to_string());
+	}
+
+	async fn closed(&mut self) -> Result<(), Self::Error> {
+		self.0.closed().await.map(|_| ()).map_err(Error)
+	}
+}

--- a/rs/moq-ffi/src/transport.rs
+++ b/rs/moq-ffi/src/transport.rs
@@ -36,7 +36,9 @@ pub async fn connect_with_hashes(url: Url, hashes: Vec<Vec<u8>>) -> Result<Sessi
 	Ok(Session(session))
 }
 
+/// The writable half of a browser WebTransport stream.
 pub struct SendStream(web_transport_wasm::SendStream);
+/// The readable half of a browser WebTransport stream.
 pub struct RecvStream(web_transport_wasm::RecvStream);
 
 /// Wraps `web_transport_wasm::Error` so we can implement the foreign error trait.

--- a/rs/moq-wasm/Cargo.toml
+++ b/rs/moq-wasm/Cargo.toml
@@ -27,7 +27,7 @@ crate-type = ["cdylib", "rlib"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bytes = "1"
 console_error_panic_hook = "0.1"
-getrandom = { version = "0.4", features = ["wasm_js"] } # wasm_js backend for rand-via-moq-net; cfg flag in .cargo/config.toml
+getrandom = { workspace = true } # wasm_js backend for rand-via-moq-net; cfg flag in .cargo/config.toml
 js-sys = "0.3"
 moq-net = { workspace = true }
 thiserror = "2"
@@ -39,4 +39,4 @@ wasm-bindgen = "=0.2.121"
 wasm-bindgen-futures = "0.4"
 web-async = { workspace = true }
 web-transport-trait = { workspace = true }
-web-transport-wasm = "0.5"
+web-transport-wasm = { workspace = true }


### PR DESCRIPTION
Step 1 of #2907. Independently landable: it adds a target, and changes nothing about the native one.

## Before

`cargo check --target wasm32-unknown-unknown -p moq-ffi` died inside `aws-lc-sys`' C compilation, by way of `moq-native` to `rustls`, without type-checking a single line of `moq-ffi`. So there was no signal at all about what this crate actually needs to reach a browser.

## What is gated

Four native-only dependencies (`moq-native`, `moq-video`, `moq-audio`, `pollster`) and the modules built on them: `video`, `audio`, `server`, and the moq-native logger.

That is all. Everything else compiles, **including the entire media layer**, because `moq-mux` is wasm-portable as of 743c9d8b6. That is worth stating plainly, since my original spike had to gate `hang`, `moq-mux` and `moq-json` too and came in at 82 of 160 methods. Keeping the media layer takes it to **117 of 160**:

| module | native | wasm |
|---|---|---|
| `consumer`, `producer`, `origin`, `json` | 105 | 105 |
| `session` | 24 | 12 |
| `video`, `audio`, `server` | 31 | 0 |

What drops is native codecs, the QUIC server, and the TLS and bind knobs a browser has no equivalent for. Nothing is dropped that a browser could have used.

## What made it possible

uniffi 0.31's `wasm-unstable-single-threaded` feature drops the `Send` bound from `UniffiCompatibleFuture` and `Send + Sync` from `FfiConverterArc`. moq-net's wasm futures are `LocalBoxFuture` and its handles are `Rc`-backed, so without that feature this is a hard stop rather than a porting exercise.

## The one real behavioral difference

`ffi::Task` grows a wasm arm. There is no runtime thread to hand work to, since uniffi's `RustFuture` is polled by the JS event loop, so it awaits in place.

**The native path detaches and the wasm path does not.** Dropping the returned future cancels the work on wasm, where natively it keeps running on the runtime thread until `cancel()`. Queue-and-cancel semantics are otherwise identical. Flagging it because it is a semantic split hiding behind a `#[cfg]`, and it is the kind of thing worth disagreeing with now rather than discovering later.

While there, `RUNTIME.enter()` and the open-coded `RUNTIME.spawn` match blocks moved behind `ffi::enter` and `ffi::detached`, so each has one definition per target rather than one per call site.

## A UniFFI trap worth writing down

**uniffi's proc macro ignores `#[cfg]` on a method inside a `#[uniffi::export] impl` block.** It emits the scaffolding regardless, which produces duplicate symbols and calls to methods that no longer exist. The native and browser clients therefore live in two separately-gated export blocks rather than one block with gated methods.

This is the UniFFI sibling of the wasm-bindgen ident trap already documented in `rs/CLAUDE.md`, and it is the same shape of bug: the macro layer does not see what the source says.

## Known duplication

`transport.rs` is copied from `moq-wasm`. Deliberate here and called out in #2907: the adapter belongs in one crate, but moving it is a separate change from proving `moq-ffi` can target wasm at all. I did not want to entangle the two.

One crate-level `allow(clippy::arc_with_non_send_sync)`, scoped to wasm. uniffi lowers every exported object as `Arc<T>`; on a single-threaded target clippy flags every construction site. The `Arc` is uniffi's ABI, not a choice this crate makes.

## Keeping it fixed

`just rs wasm` now covers `moq-ffi`. This matters more here than usual: `just check` never compiles `moq-ffi` on *any* target, so without the gate this regresses invisibly on the first native-only type someone adds.

## Verification

`just check` clean, including the extended wasm gate. `just test` green at **2922 tests**.

**The native surface is provably unchanged**: I diffed the exported method names under the native cfg before and after, and both sides have the same 154 exports. `Task`'s new `kio::MaybeSend` bound is implied by `Send` natively, and `web_async::time` re-exports tokio's own types. This matters because cargo-semver-checks cannot see `moq-ffi` (no rlib), so "no API change" needs to be shown rather than assumed.

Nothing here has run in a browser. This is a compile target, not a working binding; #2907 step 4 is where that gets settled, and #2904 just landed the harness for it.

## Cross-Package Sync

The `moq-ffi` row calls for updating `libmoq`, the `{py,swift,kt,go}` wrappers and `doc/lib/`. None apply: the native surface is byte-identical, so there is nothing for a wrapper or a doc to track. No wire, catalog or container change either.

(written by Opus 5)
