### PR TITLE
docs(relay): spell out read-only and write-only tokens

### DIFF
--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -170,9 +170,10 @@ Full publish path = root + "/" + put
 Full subscribe path = root + "/" + get
 ```
 
-Both claims are lists, and the two kinds of empty mean opposite things:
+Each claim is one suffix or a list of them, and the two kinds of empty mean
+opposite things:
 
-- **A list holding the empty suffix** (`[""]`) grants everything under the root.
+- **The empty suffix** (`""`, or `[""]`) grants everything under the root.
 - **An empty list** (`[]`), or the claim omitted entirely, grants nothing in that
   role. That is how you mint a read-only token (no `put`) or a write-only one
   (no `get`).
@@ -181,16 +182,18 @@ Suffixes match on path boundaries, so `foo` grants `foo` and `foo/bar` but never
 `foobar`. A token that grants neither role is useless, and is rejected both when
 signing and when verifying.
 
-**Examples:**
+**Examples**, written in the list form. A bare string is the same claim, so
+`"put": "alice"` and `"put": ["alice"]` produce the same token, and `[]` is the
+same as leaving the claim out:
 
 | root | put | get | Can publish | Can subscribe |
 |------|-----|-----|-------------|---------------|
 | `demo` | `["my-stream"]` | `[""]` | `demo/my-stream` | `demo/*` |
 | `rooms/123` | `["alice"]` | `[""]` | `rooms/123/alice` | `rooms/123/*` |
 | `""` | `[""]` | `[""]` | Everything | Everything |
-| `""` | empty | `[""]` | Nothing | Everything |
-| `""` | `[""]` | empty | Everything | Nothing |
-| `demo` | empty | `[""]` | Nothing | `demo/*` |
+| `""` | `[]` | `[""]` | Nothing | Everything |
+| `""` | `[""]` | `[]` | Everything | Nothing |
+| `demo` | `[]` | `[""]` | Nothing | `demo/*` |
 
 On the CLI the difference is simply whether the flag appears at all. `--publish ""`
 grants everything under the root; dropping `--publish` grants no publish access:

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -152,8 +152,8 @@ The JWT payload contains these claims:
 | Claim | Description |
 |-------|-------------|
 | `root` | Base path for publish/subscribe permissions. Optional, defaulting to the top-level path |
-| `put` | Suffix, or list of suffixes, appended to root for publish permission |
-| `get` | Suffix, or list of suffixes, appended to root for subscribe permission |
+| `put` | Suffix, or list of suffixes, appended to root for publish permission. Omit for a token that cannot publish |
+| `get` | Suffix, or list of suffixes, appended to root for subscribe permission. Omit for a token that cannot subscribe |
 | `exp` | Expiration time (Unix timestamp) |
 | `iat` | Issued-at time (Unix timestamp) |
 
@@ -170,8 +170,16 @@ Full publish path = root + "/" + put
 Full subscribe path = root + "/" + get
 ```
 
-An empty suffix (`""`) allows access to anything under the root. Suffixes match on
-path boundaries, so `foo` grants `foo` and `foo/bar` but never `foobar`.
+Both claims are lists, and the two kinds of empty mean opposite things:
+
+- **A list holding the empty suffix** (`[""]`) grants everything under the root.
+- **An empty list** (`[]`), or the claim omitted entirely, grants nothing in that
+  role. That is how you mint a read-only token (no `put`) or a write-only one
+  (no `get`).
+
+Suffixes match on path boundaries, so `foo` grants `foo` and `foo/bar` but never
+`foobar`. A token that grants neither role is useless, and is rejected both when
+signing and when verifying.
 
 **Examples:**
 
@@ -180,6 +188,23 @@ path boundaries, so `foo` grants `foo` and `foo/bar` but never `foobar`.
 | `demo` | `["my-stream"]` | `[""]` | `demo/my-stream` | `demo/*` |
 | `rooms/123` | `["alice"]` | `[""]` | `rooms/123/alice` | `rooms/123/*` |
 | `""` | `[""]` | `[""]` | Everything | Everything |
+| `""` | empty | `[""]` | Nothing | Everything |
+| `""` | `[""]` | empty | Everything | Nothing |
+| `demo` | empty | `[""]` | Nothing | `demo/*` |
+
+On the CLI the difference is simply whether the flag appears at all. `--publish ""`
+grants everything under the root; dropping `--publish` grants no publish access:
+
+```bash
+# Read-only: watch anything under demo/, publish nothing.
+moq-token sign --key my-key.jwk --root demo --subscribe ""
+
+# Write-only: publish demo/my-stream, subscribe to nothing.
+moq-token sign --key my-key.jwk --root demo --publish my-stream
+```
+
+The same split applies to a [key scope](#scope-a-key): a key generated with only
+`--subscribe` can never sign a token that publishes.
 
 ### Connection Path
 
@@ -189,7 +214,7 @@ The client's connection URL path does **not** need to match the token's `root` e
 - If the connection path is a **parent** of the root (e.g., token root=`demo`, connect to `/`), permissions still apply but are scoped to the token's root. You can only access paths under `demo/`.
 - If the connection path is **unrelated** to the root (e.g., token root=`demo`, connect to `/other`), the connection is rejected.
 
-The connection is also rejected if the resulting permissions are empty (no publish or subscribe paths remain after scoping).
+The connection is also rejected when scoping leaves *both* roles empty, i.e. no publish and no subscribe path survives. Losing just one role is fine: that is what a read-only or write-only token looks like.
 
 ### Unified Auth API (`--auth-api`)
 

--- a/doc/lib/js/@moq/token.md
+++ b/doc/lib/js/@moq/token.md
@@ -35,8 +35,8 @@ For a complete working example covering key loading, signing, and verification, 
 | Claim | Type | Description |
 |-------|------|-------------|
 | `root` | string? | Root path for operations, defaulting to the top-level path |
-| `put` | `string \| string[]?` | Publishing permission paths, relative to `root` |
-| `get` | `string \| string[]?` | Subscription permission paths, relative to `root` |
+| `put` | `string \| string[]?` | Publishing permission paths, relative to `root`. `""` is everything under the root; omit it for a read-only token |
+| `get` | `string \| string[]?` | Subscription permission paths, relative to `root`. `""` is everything under the root; omit it for a write-only token |
 | `exp` | number? | Expiration timestamp |
 | `iat` | number? | Issued at timestamp |
 

--- a/doc/lib/js/@moq/token.md
+++ b/doc/lib/js/@moq/token.md
@@ -35,8 +35,8 @@ For a complete working example covering key loading, signing, and verification, 
 | Claim | Type | Description |
 |-------|------|-------------|
 | `root` | string? | Root path for operations, defaulting to the top-level path |
-| `put` | `string \| string[]?` | Publishing permission paths, relative to `root`. `""` is everything under the root; omit it for a read-only token |
-| `get` | `string \| string[]?` | Subscription permission paths, relative to `root`. `""` is everything under the root; omit it for a write-only token |
+| `put` | `string \| string[]?` | Publishing permission paths, relative to `root`. `""` or `[""]` is everything under the root; `[]` or omitted grants no publish access, i.e. a read-only token |
+| `get` | `string \| string[]?` | Subscription permission paths, relative to `root`. `""` or `[""]` is everything under the root; `[]` or omitted grants no subscribe access, i.e. a write-only token |
 | `exp` | number? | Expiration timestamp |
 | `iat` | number? | Issued at timestamp |
 


### PR DESCRIPTION
## Summary

- The path-matching table in `doc/bin/relay/auth#path-matching` only showed tokens granting both roles, so the difference between the two kinds of empty was invisible: `[""]` grants everything under the root, while an empty list (or an omitted claim) grants nothing in that role. Added rows for a read-only token (`""`, empty, `[""]` → Nothing / Everything), the write-only mirror, and a scoped read-only one (`demo`, empty, `[""]`).
- Replaced the single "an empty suffix allows access to anything under the root" sentence with the two-bullet distinction, plus the CLI form of each: `--publish ""` grants everything, dropping `--publish` grants nothing. Noted that only a token empty in *both* roles is rejected (`Claims::validate` → `UselessToken`), and that the same split applies to a key scope, since `Scope::covers` treats an empty prefix list as a denial per role.
- Fixed the Connection Path sentence that read as if losing either role rejected the connection. `Claims::authorize` returns `NoAccess` only when both survive empty.
- Same one-line clarification on the `put`/`get` rows of the claims tables in `doc/bin/relay/auth.md` and `doc/lib/js/@moq/token.md`.

No behavior change; docs only.

## Public API changes

None.

## Test plan

- `bun remark doc/bin/relay/auth.md doc/lib/js/@moq/token.md --frail` clean, and `--output` is a no-op (already in the repo's markdown format).
- `cd doc && bun run build` (vitepress) builds clean, so the new `#scope-a-key` link resolves.
- Behavior claims read off `rs/moq-token/src/claims.rs` (`Claims::authorize`, `Claims::validate`, `Scope::allows`/`covers`) and the `sign`/`generate` flags in `rs/moq-token-cli/src/lib.rs`.
- `just check`/`just test` not run: no nix or just in this environment, and the diff is markdown-only.

## Cross-package sync

`rs/moq-token` → `js/token` row: no code change, but the JS claims doc page picked up the same clarification.

(Written by Claude Code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XmcoDDvDRy1TjDm6GJrxp7)_