### PR TITLE
fix(cli): apply the deprecated `--client-*` flags instead of only warning

### DIFF
--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -82,6 +82,26 @@ pub struct Config {
 	pub log: moq_tokio::Log,
 }
 
+impl Config {
+	/// Parse the command line, folding the released `--client-*` spellings into the
+	/// canonical fields before anything can read them.
+	///
+	/// The only way in, rather than clap's own `parse`: the fold is invisible at the
+	/// use site, so a reader that skips it sees the canonical field still unset and
+	/// acts as if the flag were never passed. `--client-connect` would warn by name
+	/// and then bail as though no relay had been named.
+	fn parse_argv<I, T>(argv: I) -> Result<Self, clap::Error>
+	where
+		I: IntoIterator<Item = T>,
+		T: Into<std::ffi::OsString> + Clone,
+	{
+		let mut config = Self::try_parse_from(argv)?;
+		config.client = config.client.resolved();
+		config.quic = config.quic.resolved();
+		Ok(config)
+	}
+}
+
 /// Shared state for a game session, accessible from multiple threads/tasks.
 ///
 /// Everything here is either atomic, behind a mutex, or immutable —
@@ -446,7 +466,7 @@ fn run_emulator(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-	let config = Config::parse();
+	let config = Config::parse_argv(std::env::args_os()).unwrap_or_else(|err| err.exit());
 	config.log.init()?;
 
 	#[cfg(feature = "jemalloc")]
@@ -477,15 +497,13 @@ async fn main() -> Result<()> {
 mod tests {
 	use super::*;
 
-	/// `--connect` is the only way to reach the relay: it must parse without
-	/// a connect flag of our own alongside it, and the URL must land where `run`
-	/// reads it. A second required flag would leave `--connect` inert.
-	///
-	/// The argv is a copy of `demo/boy/justfile`, not a read of it, so this pins the
-	/// binary's flag surface rather than the two staying in sync.
+	/// `--connect` is the only way to reach the relay, so its released
+	/// `--client-connect` spelling has to land where `run` reads it. Folding only
+	/// where a check happens to look leaves the flag warning by its replacement's
+	/// name and then bailing as though no relay had been named.
 	#[test]
-	fn matches_demo_invocation() {
-		let config = Config::try_parse_from([
+	fn released_connect_spelling_reaches_the_dial() {
+		let config = Config::parse_argv([
 			"moq-boy",
 			"--client-connect",
 			"http://localhost:4443",
@@ -496,11 +514,9 @@ mod tests {
 		])
 		.expect("demo/boy/justfile invocation should parse");
 
-		let connect = config
-			.client
-			.resolved()
-			.url
-			.expect("the connect URL should reach the dial config");
+		// The raw field, which is what `run` dials from: a fold applied only here
+		// would leave the released spelling warning by name and then bailing.
+		let connect = config.client.url.expect("the connect URL should reach the dial config");
 		assert_eq!(connect.scheme(), "http");
 		assert_eq!(connect.host_str(), Some("localhost"));
 		assert_eq!(connect.port(), Some(4443));

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -60,6 +60,28 @@ pub struct Cli {
 	pub command: Command,
 }
 
+impl Cli {
+	/// Parse the globals chunk, folding the released `--client-*` / `--server-*`
+	/// spellings into the canonical fields before anything can read them.
+	///
+	/// The only way in, rather than clap's own `try_parse_from`: the fold is
+	/// invisible at the use site, so a reader that skips it sees the canonical field
+	/// still unset and acts as if the flag were never passed. That is a deprecated
+	/// spelling that warns by name and then does nothing, which is worse than
+	/// refusing it outright.
+	fn parse_globals<I, T>(argv: I) -> Result<Self, clap::Error>
+	where
+		I: IntoIterator<Item = T>,
+		T: Into<OsString> + Clone,
+	{
+		let mut cli = Self::try_parse_from(argv)?;
+		cli.moq.client = cli.moq.client.resolved();
+		cli.moq.server = cli.moq.server.resolved();
+		cli.moq.quic = cli.moq.quic.resolved();
+		Ok(cli)
+	}
+}
+
 // `no_binary_name` because the chunk after a `--` starts at the verb, and the
 // globals are deliberately absent: `--connect` past the first stage would
 // read like it scopes that stage, when there is only ever one connection. As with
@@ -105,7 +127,7 @@ impl Invocation {
 
 		// `split` always yields at least one chunk, even for an empty argv; clap then
 		// reports the missing subcommand as usual.
-		let cli = Cli::try_parse_from(chunks.next().unwrap_or_default())?;
+		let cli = Cli::parse_globals(chunks.next().unwrap_or_default())?;
 
 		let mut stages = vec![cli.command];
 		for chunk in chunks {
@@ -260,7 +282,7 @@ impl MoqSide {
 	/// generated certificate. An explicit `--listen` or `--listen-tls-*` wins, which
 	/// is what puts the mesh on the same port and certificate as everything else.
 	pub fn server_config(&self) -> moq_tokio::listen::Config {
-		let mut config = self.server.resolved();
+		let mut config = self.server.clone();
 		if self.lan() {
 			config.bind.get_or_insert_with(|| "[::]:0".to_string());
 			if config.tls.generate.is_empty() && config.tls.cert.is_empty() {
@@ -280,14 +302,14 @@ impl MoqSide {
 	/// `devices` is exempt.
 	pub fn validate(&self) -> anyhow::Result<()> {
 		anyhow::ensure!(
-			self.client.resolved().url.is_some() || self.serves(),
+			self.client.url.is_some() || self.serves(),
 			"a MoQ side is required: pass --connect <url> to dial a relay, a --listen option to self-host, or --cluster-lan to mesh over the LAN"
 		);
 		#[cfg(feature = "cluster-lan")]
 		{
 			self.cluster.validate()?;
 			if self.lan() {
-				crate::cluster::validate_versions(&self.client.resolved(), &self.server_config())?;
+				crate::cluster::validate_versions(&self.client, &self.server_config())?;
 			}
 		}
 		Ok(())
@@ -306,10 +328,8 @@ impl MoqSide {
 		#[cfg(not(feature = "cluster-lan"))]
 		let cluster_secret = false;
 
-		// Read through the fold: a legacy `--client-connect` must be rejected here
-		// too, and it only lands in `url` once resolved.
-		let connect = self.client.resolved();
-		let listen = self.server.resolved();
+		let connect = &self.client;
+		let listen = &self.server;
 		let ignored = [
 			("--connect", connect.url.is_some()),
 			("--listen", listen.bind.is_some()),
@@ -694,6 +714,43 @@ mod tests {
 		assert_eq!(cli.stages[1].broadcast(&cli.moq), "other.hang");
 	}
 
+	/// The released spellings have to land in the fields the run actually reads, not
+	/// only in the ones `validate` and `reject` consult.
+	///
+	/// `--client-connect` warned by name and then dialed nothing: the dial reads
+	/// `client.url`, which the fold fills, and nothing had folded by the time it was
+	/// read. A shim that names the replacement and then no-ops is worse than no shim,
+	/// so every released spelling is checked through the parse the binary uses.
+	#[test]
+	fn released_spellings_reach_the_fields_the_run_reads() {
+		let cli = Invocation::try_parse_from([
+			"moq",
+			"--client-connect",
+			"https://relay.example.com/anon",
+			"--client-bind",
+			"127.0.0.1:0",
+			"--client-connect-timeout",
+			"5s",
+			"--client-quic-gso=false",
+			"--server-bind",
+			"[::]:4443",
+			"export",
+			"ts",
+		])
+		.expect("parse");
+
+		assert_eq!(
+			cli.moq.client.url.as_ref().map(ToString::to_string).as_deref(),
+			Some("https://relay.example.com/anon"),
+			"the dial reads this field directly"
+		);
+		assert_eq!(cli.moq.client.bind, Some("127.0.0.1:0".parse().unwrap()));
+		assert_eq!(cli.moq.client.timeout, Some(Duration::from_secs(5)));
+		assert_eq!(cli.moq.quic.gso, Some(false));
+		assert_eq!(cli.moq.server.bind.as_deref(), Some("[::]:4443"));
+		assert!(cli.moq.validate().is_ok());
+	}
+
 	/// An unnamed broadcast is the root one at the connection path, not an error.
 	#[test]
 	fn broadcast_defaults_to_root() {
@@ -916,20 +973,20 @@ mod tests {
 		// Unset rather than defaulted to hang's constant, so the publisher's own default is
 		// what every source falls back to. A `default_value` here would put the number in the
 		// CLI as well, and the two would drift.
-		let cli = Cli::try_parse_from(["moq", "import", "ts"]).unwrap();
+		let cli = Cli::parse_globals(["moq", "import", "ts"]).unwrap();
 		let Command::Import(import) = cli.command else {
 			panic!("expected import")
 		};
 		assert_eq!(import.latency_max, None);
 
 		// It sits on the parent `import`, so it parses ahead of any source, gateway or not.
-		let cli = Cli::try_parse_from(["moq", "import", "--latency-max", "5s", "ts"]).unwrap();
+		let cli = Cli::parse_globals(["moq", "import", "--latency-max", "5s", "ts"]).unwrap();
 		let Command::Import(import) = cli.command else {
 			panic!("expected import")
 		};
 		assert_eq!(import.latency_max, Some(std::time::Duration::from_secs(5)));
 
-		let cli = Cli::try_parse_from([
+		let cli = Cli::parse_globals([
 			"moq",
 			"import",
 			"--latency-max",
@@ -947,7 +1004,7 @@ mod tests {
 
 	#[test]
 	fn token_verb() {
-		let cli = Cli::try_parse_from(["moq", "token", "generate", "--algorithm", "ES256"]).unwrap();
+		let cli = Cli::parse_globals(["moq", "token", "generate", "--algorithm", "ES256"]).unwrap();
 		assert!(matches!(cli.command, Command::Token(_)));
 		// Local verb: it needs no MoQ side, so what every other verb demands...
 		assert!(cli.moq.validate().is_err());
@@ -962,7 +1019,7 @@ mod tests {
 			("--listen-tcp-bind", "127.0.0.1:0", "--listen-tcp-bind"),
 			("--broadcast", "room", "--broadcast"),
 		] {
-			let cli = Cli::try_parse_from(["moq", flag, value, "token", "generate"]).unwrap();
+			let cli = Cli::parse_globals(["moq", flag, value, "token", "generate"]).unwrap();
 			let err = cli.moq.reject("token").unwrap_err().to_string();
 			assert!(err.contains(reported), "{err}");
 		}
@@ -976,7 +1033,7 @@ mod tests {
 				("--listen-unix-allow-pid", "1000", "--listen-unix-allow-pid"),
 				("--server-unix-allow-uid", "1000", "--listen-unix-allow-uid"),
 			] {
-				let cli = Cli::try_parse_from(["moq", flag, value, "token", "generate"]).unwrap();
+				let cli = Cli::parse_globals(["moq", flag, value, "token", "generate"]).unwrap();
 				let err = cli.moq.reject("token").unwrap_err().to_string();
 				assert!(err.contains(reported), "{err}");
 			}
@@ -984,14 +1041,14 @@ mod tests {
 
 		#[cfg(feature = "cluster-lan")]
 		{
-			let cli = Cli::try_parse_from(["moq", "--cluster-lan", "token", "generate"]).unwrap();
+			let cli = Cli::parse_globals(["moq", "--cluster-lan", "token", "generate"]).unwrap();
 			let err = cli.moq.reject("token").unwrap_err().to_string();
 			assert!(err.contains("--cluster-lan"), "{err}");
 
 			// Clap considers the secret's `requires` satisfied when the boolean flag
 			// is explicitly present but false. The local verb still has to reject the
 			// otherwise silently ignored secret.
-			let cli = Cli::try_parse_from([
+			let cli = Cli::parse_globals([
 				"moq",
 				"--cluster-lan=false",
 				"--cluster-lan-secret",
@@ -1010,7 +1067,7 @@ mod tests {
 	#[cfg(feature = "cluster-lan")]
 	#[test]
 	fn cluster_lan_is_a_moq_side_and_fills_in_a_listener() {
-		let cli = Cli::try_parse_from(["moq", "--cluster-lan", "import", "ts"]).expect("parse");
+		let cli = Cli::parse_globals(["moq", "--cluster-lan", "import", "ts"]).expect("parse");
 		assert!(cli.moq.lan());
 		assert!(cli.moq.validate().is_ok(), "the LAN mesh is a MoQ side on its own");
 
@@ -1020,7 +1077,7 @@ mod tests {
 
 		// An explicit listener wins, so the mesh shares one port and certificate
 		// with ordinary clients.
-		let cli = Cli::try_parse_from([
+		let cli = Cli::parse_globals([
 			"moq",
 			"--cluster-lan",
 			"--server-bind",
@@ -1036,7 +1093,7 @@ mod tests {
 		assert_eq!(server.tls.generate, ["localhost"]);
 
 		// Without the mesh, nothing is filled in.
-		let cli = Cli::try_parse_from(["moq", "--client-connect", "https://relay.example.com", "import", "ts"])
+		let cli = Cli::parse_globals(["moq", "--client-connect", "https://relay.example.com", "import", "ts"])
 			.expect("parse");
 		assert!(!cli.moq.lan());
 		assert_eq!(cli.moq.server_config().bind, None);
@@ -1047,7 +1104,7 @@ mod tests {
 	#[cfg(feature = "cluster-lan")]
 	#[test]
 	fn cluster_lan_secret_requires_the_mesh() {
-		let err = Cli::try_parse_from(["moq", "--cluster-lan-secret", "cluster.key", "import", "ts"])
+		let err = Cli::parse_globals(["moq", "--cluster-lan-secret", "cluster.key", "import", "ts"])
 			.err()
 			.expect("the secret must require --cluster-lan")
 			.to_string();
@@ -1055,7 +1112,7 @@ mod tests {
 
 		// `--cluster-lan=false` satisfies clap's `requires` (the flag is present),
 		// so the real check lives in `validate`.
-		let cli = Cli::try_parse_from([
+		let cli = Cli::parse_globals([
 			"moq",
 			"--cluster-lan=false",
 			"--cluster-lan-secret",
@@ -1069,7 +1126,7 @@ mod tests {
 		let err = cli.moq.validate().unwrap_err().to_string();
 		assert!(err.contains("--cluster-lan=true"), "{err}");
 
-		let cli = Cli::try_parse_from([
+		let cli = Cli::parse_globals([
 			"moq",
 			"--cluster-lan",
 			"--cluster-lan-secret",
@@ -1094,13 +1151,12 @@ mod tests {
 			("--client-version", "--connect-version"),
 			("--server-version", "--listen-version"),
 		] {
-			let cli =
-				Cli::try_parse_from(["moq", "--cluster-lan", flag, "moq-lite-04", "import", "ts"]).expect("parse");
+			let cli = Cli::parse_globals(["moq", "--cluster-lan", flag, "moq-lite-04", "import", "ts"]).expect("parse");
 			let err = cli.moq.validate().unwrap_err().to_string();
 			assert!(err.contains(reported), "{flag}: {err}");
 		}
 
-		let cli = Cli::try_parse_from([
+		let cli = Cli::parse_globals([
 			"moq",
 			"--cluster-lan",
 			"--client-version",
@@ -1119,7 +1175,7 @@ mod tests {
 	#[cfg(feature = "play")]
 	#[test]
 	fn play_verb() {
-		let cli = Cli::try_parse_from([
+		let cli = Cli::parse_globals([
 			"moq",
 			"--connect",
 			"https://relay.example.com/anon",
@@ -1146,7 +1202,7 @@ mod tests {
 	#[test]
 	fn play_rejects_undecodable_codecs() {
 		for flag in [["--video-codec", "vp9"], ["--audio-codec", "aac"]] {
-			let cli = Cli::try_parse_from([
+			let cli = Cli::parse_globals([
 				"moq",
 				"--connect",
 				"https://relay.example.com/anon",


### PR DESCRIPTION
Closes #2913.

## Summary

- **Root cause**: the dial-side rename left the fold opt-in per read. `connect::Config::resolved()` merges the hidden `--client-*` args into the canonical fields, and every reader had to remember to call it. `moq-cli` called it in `MoqSide::validate` and `MoqSide::reject`, but `spawn_moq` dials from the raw `moq.client.url`. So `--client-connect` passed validation (which folds), warned by name, and then left `url` unset at the one read that decides whether to dial: no connect attempt, no error, no exit. `moq-boy` had the same split, and its test hid it by asserting through `resolved()` while `run` reads the raw field.
- **Fix**: fold once at the parse boundary, so nothing downstream can read an unfolded field. `Cli::parse_globals` and `Config::parse_argv` are now the only way in, mirroring how `moq-relay` already calls `Config::resolve` once in `Relay::new`. The scattered per-read `.resolved()` calls are gone rather than left as redundant no-ops.
- `demo/boy/justfile` already uses `--connect`, so the moq-boy test's claim to mirror it was stale; it is now named and documented for what it actually pins.

## Not reproduced

The issue's second row (`--connect` + `--client-quic-gso=false` exporting 0 bytes) does not reproduce here, and the mechanism does not exist: `quic::Config::resolved()` runs inside `Client::new`, so that flag reaches the socket on every path. Measured on macOS against a local relay, 10 s export windows, publisher paced with `ffmpeg -re`:

| client flags | bytes exported |
|---|---|
| `--quic-gso=false` | 628,108 |
| `--client-quic-gso=false` | 633,748 |
| neither | 646,908 |

The likely explanation for that row is the relay having died between runs, which is how I first reproduced an identical all-zero table.

## Public API changes

None. `Cli::parse_globals` and `Config::parse_argv` are private to their binaries; no `pub` item in any library crate changed.

## Cross-package sync

No rows apply: this is binary-local, and per the deprecation rules the `--client-*` spellings are hidden from `--help` and absent from `/doc`, so there is nothing documented to update. `grep` confirms no deprecated spelling remains under `demo/` or `doc/`.

## Test plan

- New regression tests, each verified to fail with the fold removed and pass with it: `moq-cli`'s `released_spellings_reach_the_fields_the_run_reads` (asserts `--client-connect`, `--client-bind`, `--client-connect-timeout`, `--client-quic-gso`, `--server-bind` all land in the fields the run reads) and `moq-boy`'s `released_connect_spelling_reaches_the_dial`.
- `just check` and `just test` (45 tests, moq-boy + moq-cli).
- End-to-end against a local relay, publisher on `--connect`, exporter on the released spellings: `--client-tls-fingerprint` + `--client-connect` now logs `connected version=moq-lite-05` and exports 629,424 bytes, where before it logged only the deprecation warning and exported 0.

(Written by Opus 5)