### PR TITLE
fix(js/watch): hide renditions whose broadcast isn't announced

### DIFF
--- a/js/watch/src/broadcast.test.ts
+++ b/js/watch/src/broadcast.test.ts
@@ -85,3 +85,24 @@ describe("Broadcast cross-broadcast renditions", () => {
 		broadcast.close();
 	});
 });
+
+describe("Broadcast manual catalog", () => {
+	it("republishes a manual catalog mutated in place", async () => {
+		const catalog = new Signal<Catalog.Root>({
+			video: { renditions: { one: video("avc1.64001e") } },
+		});
+		const broadcast = new Broadcast({ enabled: true, catalogFormat: "manual", catalog });
+
+		await settle();
+		expect(renditions(broadcast)).toEqual(["one"]);
+
+		// The input is a signal the caller owns, so it can be updated in place.
+		catalog.mutate((c) => {
+			if (c.video) c.video.renditions.two = video("avc1.640028");
+		});
+		await settle();
+		expect(renditions(broadcast)).toEqual(["one", "two"]);
+
+		broadcast.close();
+	});
+});

--- a/js/watch/src/broadcast.test.ts
+++ b/js/watch/src/broadcast.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import * as Catalog from "@moq/hang/catalog";
+import type * as Moq from "@moq/net";
+import { Path } from "@moq/net";
+import { Signal } from "@moq/signals";
+import { Broadcast } from "./broadcast";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function settle(): Promise<void> {
+	for (let i = 0; i < 5; i++) await flush();
+}
+
+type Announcement = { path: Moq.Path.Valid; active: boolean };
+
+// A connection whose announcement stream the test drives by hand.
+class FakeAnnounced {
+	#pending: Announcement[] = [];
+	#waiting: Array<(entry: Announcement | undefined) => void> = [];
+
+	push(entry: Announcement): void {
+		const waiting = this.#waiting.shift();
+		if (waiting) waiting(entry);
+		else this.#pending.push(entry);
+	}
+
+	next(): Promise<Announcement | undefined> {
+		const pending = this.#pending.shift();
+		if (pending) return Promise.resolve(pending);
+		return new Promise((resolve) => this.#waiting.push(resolve));
+	}
+
+	close(): void {}
+}
+
+function mockConnection(announced: FakeAnnounced): Moq.Connection.Established {
+	return {
+		discovery: true,
+		announced: () => announced,
+		announcedBroadcast: () => ({ active: new Signal(undefined), close: () => {} }),
+	} as unknown as Moq.Connection.Established;
+}
+
+function video(codec: string, fields: Record<string, unknown> = {}): Catalog.VideoConfig {
+	return Catalog.VideoConfigSchema.parse({ codec, container: { kind: "legacy" }, ...fields });
+}
+
+function renditions(broadcast: Broadcast): string[] {
+	return Object.keys(broadcast.out.catalog.peek()?.video?.renditions ?? {}).sort();
+}
+
+describe("Broadcast cross-broadcast renditions", () => {
+	it("hides a rendition until its broadcast is announced", async () => {
+		// A transcoder under `public/` referencing a source under `private/`: a viewer scoped to
+		// `public/` is never told the source exists, and selecting it would render nothing.
+		const announced = new FakeAnnounced();
+		const broadcast = new Broadcast({
+			enabled: true,
+			connection: new Signal(mockConnection(announced)),
+			name: Path.from("public/transcode.hang"),
+			catalogFormat: "manual",
+			catalog: {
+				video: {
+					renditions: {
+						local: video("avc1.64001e", { bitrate: 1_000_000 }),
+						remote: video("avc1.640028", { bitrate: 9_000_000, broadcast: "../private/source" }),
+					},
+				},
+			},
+		});
+
+		await settle();
+		expect(renditions(broadcast)).toEqual(["local"]);
+
+		// The source is announced, so it becomes usable without a new catalog.
+		announced.push({ path: Path.from("private/source"), active: true });
+		await settle();
+		expect(renditions(broadcast)).toEqual(["local", "remote"]);
+
+		// ...and withdrawn again when it goes away.
+		announced.push({ path: Path.from("private/source"), active: false });
+		await settle();
+		expect(renditions(broadcast)).toEqual(["local"]);
+
+		broadcast.close();
+	});
+});

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -96,7 +96,9 @@ type BroadcastOutput = {
 	status: Signal<Status>;
 	active: Signal<Moq.Broadcast.Consumer | undefined>;
 
-	// The effective catalog: the fetched one, or a copy of input.catalog in manual mode.
+	// The effective catalog: the fetched one, or a copy of input.catalog in manual mode, minus
+	// any rendition this consumer can't use (see `#runFiltered`). A rendition referencing another
+	// broadcast appears once that broadcast is announced, so this can change without a new catalog.
 	catalog: Signal<Catalog.Root | undefined>;
 };
 
@@ -123,6 +125,10 @@ export class Broadcast {
 
 	// The catalog as published, before renditions this consumer cannot use are dropped. Kept
 	// separate so the effective catalog can be re-derived when a reference becomes reachable.
+	//
+	// Writes notify unconditionally. A manual catalog can be mutated in place, and the rerun that
+	// delivers it lands inside the same flush, where a value-compare coalesces the write away and
+	// strands the filtered copy on the previous contents.
 	readonly #raw = new Signal<Catalog.Root | undefined>(undefined);
 
 	#signals = new Effect();
@@ -243,7 +249,8 @@ export class Broadcast {
 		if (format === "manual") {
 			// Mirror the caller-supplied catalog into the effective output.
 			const catalog = effect.get(this.in.catalog);
-			effect.set(this.#raw, catalog, undefined);
+			this.#raw.set(catalog, true);
+			effect.cleanup(() => this.#raw.set(undefined, true));
 			this.#out.status.set(catalog ? "live" : "loading");
 			return;
 		}
@@ -281,7 +288,7 @@ export class Broadcast {
 
 					console.debug("received catalog", format, this.in.name.peek(), update);
 
-					this.#raw.set(update);
+					this.#raw.set(update, true);
 					this.#out.status.set("live");
 				}
 			} catch (err) {

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -28,25 +28,24 @@ type ReferencedRendition = {
 	broadcast?: string;
 };
 
+// Either the catalog's own broadcast, or a sibling to consume by path.
+type RelativeTarget = { local: true } | { local: false; path: Moq.Path.Valid };
+
 function filterRenditions<T extends ReferencedRendition>(
-	base: Moq.Path.Valid,
 	renditions: Record<string, T>,
+	usable: (rel: string | undefined) => boolean,
 ): Record<string, T> {
-	return Object.fromEntries(
-		Object.entries(renditions).filter(([, config]) =>
-			config.broadcast === undefined ? true : Path.tryResolve(base, config.broadcast) !== undefined,
-		),
-	);
+	return Object.fromEntries(Object.entries(renditions).filter(([, config]) => usable(config.broadcast)));
 }
 
-function filterCatalog(base: Moq.Path.Valid, catalog: Catalog.Root): Catalog.Root {
+function filterCatalog(catalog: Catalog.Root, usable: (rel: string | undefined) => boolean): Catalog.Root {
 	return {
 		...catalog,
 		video: catalog.video
-			? { ...catalog.video, renditions: filterRenditions(base, catalog.video.renditions) }
+			? { ...catalog.video, renditions: filterRenditions(catalog.video.renditions, usable) }
 			: undefined,
 		audio: catalog.audio
-			? { ...catalog.audio, renditions: filterRenditions(base, catalog.audio.renditions) }
+			? { ...catalog.audio, renditions: filterRenditions(catalog.audio.renditions, usable) }
 			: undefined,
 	};
 }
@@ -122,6 +121,10 @@ export class Broadcast {
 	// no cross-broadcast renditions never opens the (broad) connection-scoped announcement stream.
 	readonly #wantAnnounced = new Signal(false);
 
+	// The catalog as published, before renditions this consumer cannot use are dropped. Kept
+	// separate so the effective catalog can be re-derived when a reference becomes reachable.
+	readonly #raw = new Signal<Catalog.Root | undefined>(undefined);
+
 	#signals = new Effect();
 
 	constructor(props?: Inputs<BroadcastInput>) {
@@ -137,6 +140,7 @@ export class Broadcast {
 		this.#signals.run(this.#runAnnounced.bind(this));
 		this.#signals.run(this.#runBroadcast.bind(this));
 		this.#signals.run(this.#runCatalog.bind(this));
+		this.#signals.run(this.#runFiltered.bind(this));
 	}
 
 	// Maintain the set of announced paths used by `relativeBroadcast`, by draining a connection-scoped
@@ -168,6 +172,16 @@ export class Broadcast {
 		});
 	}
 
+	// Publish the catalog minus every rendition this consumer cannot use: one whose reference
+	// escapes above the root, or names a broadcast that isn't announced to us. Selecting one of
+	// those would render nothing, since `relativeBroadcast` resolves it to no broadcast at all.
+	// Reruns as announcements arrive, so a rendition appears once its broadcast does.
+	#runFiltered(effect: Effect): void {
+		const raw = effect.get(this.#raw);
+		const usable = (rel: string | undefined) => this.#relativeTarget(effect, rel) !== undefined;
+		effect.set(this.#out.catalog, raw ? filterCatalog(raw, usable) : undefined);
+	}
+
 	// Whether `path` is currently announced, for `relativeBroadcast`'s cross-broadcast refs. Returns
 	// true (subscribe immediately) when the gate can't apply: reload is off, or the relay doesn't
 	// support discovery. Opens the announcement stream on first use.
@@ -175,7 +189,10 @@ export class Broadcast {
 		if (!effect.get(this.in.reload)) return true;
 
 		const conn = effect.get(this.in.connection);
-		if (conn && skipDiscovery(conn)) return true;
+		// Nothing to ask yet. `relativeBroadcast` still bails on the missing connection, and this
+		// keeps a reconnect from briefly hiding every cross-broadcast rendition from selection.
+		if (!conn) return true;
+		if (skipDiscovery(conn)) return true;
 
 		this.#wantAnnounced.set(true);
 
@@ -226,7 +243,7 @@ export class Broadcast {
 		if (format === "manual") {
 			// Mirror the caller-supplied catalog into the effective output.
 			const catalog = effect.get(this.in.catalog);
-			effect.set(this.#out.catalog, catalog ? filterCatalog(name, catalog) : undefined, undefined);
+			effect.set(this.#raw, catalog, undefined);
 			this.#out.status.set(catalog ? "live" : "loading");
 			return;
 		}
@@ -264,13 +281,13 @@ export class Broadcast {
 
 					console.debug("received catalog", format, this.in.name.peek(), update);
 
-					this.#out.catalog.set(filterCatalog(name, update));
+					this.#raw.set(update);
 					this.#out.status.set("live");
 				}
 			} catch (err) {
 				console.warn("error fetching catalog", this.in.name.peek(), err);
 			} finally {
-				this.#out.catalog.set(undefined);
+				this.#raw.set(undefined);
 				this.#out.status.set("offline");
 			}
 		});
@@ -287,8 +304,11 @@ export class Broadcast {
 	 * reference resolves lazily and reacts to `enabled` / connection / announcement
 	 * changes exactly like the catalog broadcast.
 	 */
-	relativeBroadcast(effect: Effect, rel: string | undefined): Moq.Broadcast.Consumer | undefined {
-		if (!rel) return effect.get(this.out.active);
+	// Where a rendition's `broadcast` reference points once resolved and gated on the announcement
+	// stream, or `undefined` when it names nothing consumable right now. Playback and rendition
+	// selection both go through this so they cannot disagree about what is reachable.
+	#relativeTarget(effect: Effect, rel: string | undefined): RelativeTarget | undefined {
+		if (!rel) return { local: true };
 
 		const base = effect.get(this.in.name);
 		const resolved = Path.tryResolve(base, rel);
@@ -296,16 +316,25 @@ export class Broadcast {
 		// Ignore a rendition whose reference escapes above the root. A valid empty result
 		// names the root broadcast, while a reference back to the catalog uses its active handle.
 		if (resolved === undefined) return undefined;
-		if (resolved === base) return effect.get(this.out.active);
+		if (resolved === base) return { local: true };
+
+		if (!this.#isPathAnnounced(effect, resolved)) return undefined;
+
+		return { local: false, path: resolved };
+	}
+
+	/** Resolve a rendition's `broadcast` reference to a consumer, or `undefined` if unreachable. */
+	relativeBroadcast(effect: Effect, rel: string | undefined): Moq.Broadcast.Consumer | undefined {
+		const target = this.#relativeTarget(effect, rel);
+		if (!target) return undefined;
+		if (target.local) return effect.get(this.out.active);
 
 		if (!effect.get(this.in.enabled)) return undefined;
 
 		const conn = effect.get(this.in.connection);
 		if (!conn) return undefined;
 
-		if (!this.#isPathAnnounced(effect, resolved)) return undefined;
-
-		const broadcast = conn.consume(resolved);
+		const broadcast = conn.consume(target.path);
 		effect.cleanup(() => broadcast.close());
 		return broadcast;
 	}


### PR DESCRIPTION
## Summary

Follow-up to #2906, from a Codex review that landed after it merged.

**Root cause.** A `Broadcast` already publishes the catalog minus renditions this consumer can't use: `filterCatalog` drops any whose reference escapes above the root. It missed the other way a reference can name nothing, a broadcast that isn't announced to us, because that is dynamic while the filter ran once per catalog update.

So a catalog referencing a broadcast the viewer can't see, e.g. a transcoder published under `public/` pointing at a source under `private/`, kept a rendition that selection would happily pick as the highest quality. `relativeBroadcast` then resolved it to nothing and the decoder cleared the current frame and emptied the buffer, with no signal back to selection and no runtime stall feeding re-selection. The result is a blank picture rather than a fallback to a rung the viewer can actually fetch.

**Fix.** The effective catalog moves into its own effect, derived from the published one. Both halves of "can this reference name anything" become a single predicate, shared with `relativeBroadcast` so playback and selection can't disagree, and it is re-evaluated as announcements arrive: a rendition appears when its broadcast does and disappears when it goes away, without waiting for a new catalog.

Splitting the derivation out needed one more fix, caught in review: the writes into the internal signal notify unconditionally. A caller who mutates their catalog signal in place keeps the same object, and the rerun that delivers it lands inside the same flush, where the value-compare coalesces the write away and strands the filtered copy on the previous contents. The old single-effect path avoided this by building a fresh filtered object per update.

One related change: the announcement check no longer reports "not announced" when there is no connection at all. There is nothing to ask, `relativeBroadcast` still bails on the missing connection, and without it a reconnect would briefly hide every cross-broadcast rendition.

This is the player-side gap #2906 exposed rather than created: it applies to any catalog carrying cross-broadcast references, including hand-authored ones. #2906 made it reachable from the transcoder by referencing a source outside the output's subtree.

## Public API changes

**None.** An earlier revision of this PR added `Broadcast.relativeAvailable` and an exported `reachableRenditions` helper, with video and audio selection each filtering through them. Putting the rule where the catalog is already filtered removes both, and leaves `video/source.ts` and `audio/source.ts` untouched: everything downstream of the catalog inherits the fix. No Rust changes, no wire changes.

## Test plan

- `just check` and `just test` clean: 116 `@moq/watch` tests, 0 failures across every JS package.
- New `js/watch/src/broadcast.test.ts` drives the real announcement stream through a fake connection rather than stubbing the predicate: a rendition referencing `../private/source` is absent from the effective catalog, appears when that path is announced, and disappears when it is withdrawn.
- A second test pins the coalescing regression above: a manual catalog mutated in place republishes the added rendition. It fails without the forced notification.
- **Verified it fails without the fix** by restoring the escaping-only filter, which keeps the unreachable rendition and is exactly the blank-playback bug.
- The existing "ignores escaping renditions before selecting a valid fallback" test still passes unchanged, so the escaping half of the rule kept its behavior while moving into the shared predicate.

(Written by Opus 5)
