### PR TITLE
feat(mux): proxy TDT/TOT as a latest-value SI slot

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -645,9 +645,10 @@ are carried as opaque sections on dedicated snapshot tracks, one per PID and
 table, and re-emitted byte-for-byte on their original PIDs, each at its own
 repetition interval. So the service name, provider, type, network, and EPG
 survive the round-trip without being parsed, and only TS exporters pay for
-them. TDT/TOT is the one exception: it is a clock rather than state, so the
-exporter's own clock beats a time relayed from an upstream multiplexer of
-unknown delay.
+them. TDT/TOT rides along as a latest-value slot, each tick replacing the
+last: the EPG's event times are on the source's clock, so the source's own
+time table is the one that stays consistent with it, and TOT's local-time
+offsets (DST transitions) are operator data no exporter could invent.
 
 ### FLV
 

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -534,7 +534,8 @@ A publisher SHOULD carry the end of the last group's content into that value, si
 
 # MPEG-TS Service Information {#mpegts-si}
 A broadcast imported from an MPEG-TS multiplex can carry the multiplex's standalone service-information tables (ISO/IEC 13818-1 program-specific information and ETSI EN 300 468 DVB SI: SDT, NIT, BAT, EIT, and any table the publisher does not recognize) so an exporter can re-emit them byte-for-byte.
-The sections are opaque: nothing in this mechanism parses a table, so an unrecognized table round-trips exactly like a known one.
+The sections are opaque: nothing in this mechanism parses a table, so an unrecognized long-form table round-trips exactly like a known one.
+Short-form tables, recognized or not, are carried with latest-value semantics instead (see below): the short-form tables broadcast systems define are clocks and stuffing, and a hypothetical multi-section static one would collapse to its most recent section.
 
 The tables are state, not events: a transport stream retransmits them continuously only because a TS receiver can tune in at any moment, so the repetition rate is a property of the unreliable transport, not of the data.
 Here each table rides a dedicated snapshot track, delivered once at join and republished on change, per the root catalog's guidance that dynamic content is delegated to other tracks.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -579,7 +579,9 @@ Completeness is contiguity (all of `0..=last_section_number` present) or one obs
 A section lost before the cycle wraps is indistinguishable from a legitimately skipped number, so a committed set can transiently omit it until the next cycle re-supplies it; no section-counting receiver can do better.
 A publisher SHOULD carry only sections whose `current_next_indicator` is set.
 
-Tables that are clocks rather than state (TDT/TOT, PID 0x0014) SHOULD NOT be carried: every section is new content, and an exporter's own clock is a better source than a time relayed from an upstream multiplexer of unknown delay.
+A section without a long-form header (short-form syntax: TDT/TOT and similar) has no extension, version, or numbering, so its table is a single latest-value slot: each arrival replaces the last, and a byte-identical repetition is not a change.
+This is what makes a time table proxyable: each tick republishes a small snapshot, a joiner reads the newest, and staleness is bounded by the source's own repetition interval plus path latency, the same bound a receiver of the original multiplex has.
+Carrying the source's time rather than synthesizing one keeps the clock consistent with the EPG (event times are expressed on the source's clock) and preserves TOT's local-time-offset descriptors, which are operator policy a re-multiplexer cannot invent.
 
 
 # Security Considerations

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -24,14 +24,18 @@ use crate::catalog::hang::CatalogExt;
 /// both now/next and the full schedule, and a table we've never heard of is exactly
 /// as worth preserving as one we have.
 ///
-/// TDT/TOT (0x0014) is deliberately absent: it is a clock, not state, so every
-/// section is new content, and it is the table with the least to gain from being
-/// relayed. An exporter's own clock is a better source than a time forwarded from
-/// an upstream multiplexer of unknown delay.
+/// TDT/TOT (0x0014) is proxied, not synthesized (#2914): EIT event times are
+/// expressed on the source's clock, so a locally-minted time next to a relayed
+/// schedule can disagree with it, and TOT's `local_time_offset` descriptors (DST
+/// transitions, per-country offsets) are operator data an exporter cannot invent.
+/// Each tick replaces the last on its latest-value slot, so staleness is bounded by
+/// the source's own repetition interval plus path latency, the same class a TS
+/// receiver already lives with.
 pub(super) const SI_PIDS: &[u16] = &[
 	0x0010, // NIT (network description)
 	0x0011, // SDT and BAT (service and bouquet description)
 	0x0012, // EIT (event information: now/next and schedule)
+	0x0014, // TDT and TOT (time and local-time offset)
 ];
 
 /// The DVB maximum repetition interval for a known `table_id` (ETSI TS 101 211).
@@ -60,6 +64,8 @@ pub(super) fn si_interval(table_id: u8) -> Option<Duration> {
 		0x50..=0x5F => Some(Duration::from_secs(10)),
 		// EIT schedule other.
 		0x60..=0x6F => Some(Duration::from_secs(30)),
+		// TDT and TOT.
+		0x70 | 0x73 => Some(Duration::from_secs(30)),
 		_ => None,
 	}
 }

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1820,30 +1820,41 @@ async fn next_version_sections_are_dropped() {
 	assert!(!si.contains_key(&0x0011), "a next-version section creates no entry");
 }
 
-/// TDT/TOT (0x0014) stays out by policy: it is a clock, not state, so every
-/// section is new content, and an exporter's own clock beats a time relayed from
-/// an upstream multiplexer of unknown delay. The SDT is the positive control
-/// proving the pipeline ran.
+/// TDT/TOT (0x0014) is proxied as a latest-value slot (#2914): each tick replaces
+/// the last, so the newest snapshot is the source's most recent time, never an
+/// accumulation of stale ones. The SDT is the positive control proving the
+/// pipeline ran.
 #[tokio::test(start_paused = true)]
-async fn tdt_is_not_captured() {
-	// A short-form TDT: table_id 0x70, no long-form header.
-	let tdt = make_short_section(0x70, &[0xc0, 0x79, 0x12, 0x34, 0x56]);
+async fn tdt_round_trips_as_latest_value() {
+	let tick = |mjd: u8| make_short_section(0x70, &[0xc0, mjd, 0x12, 0x34, 0x56]);
 	let sdt = make_long_section(0x42, 1, 0, 0, 0, &[0xaa; 4]);
 
-	let mut input = si_packet(0x0014, &tdt);
-	input.extend_from_slice(&si_packet_cc(0x0014, &tdt, 1));
+	let mut rig = si_rig();
+	let mut input = si_packet(0x0014, &tick(1));
+	input.extend_from_slice(&si_packet_cc(0x0014, &tick(1), 1));
 	input.extend_from_slice(&si_packet(0x0011, &sdt));
 	input.extend_from_slice(&si_packet_cc(0x0011, &sdt, 1));
-	let mut rig = si_rig();
 	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
+	// The clock ticks: the new section replaces the old slot.
+	rig.import
+		.decode(&BytesMut::from(&si_packet_cc(0x0014, &tick(2), 2)[..]))
+		.unwrap();
 	rig.import.finish().unwrap();
 
 	let si = rig.catalog.snapshot().mpegts.si.clone();
 	assert!(si.contains_key(&0x0011), "the SDT was captured (control)");
-	assert!(
-		!si.contains_key(&0x0014),
-		"TDT is not captured; the omission is policy, not oversight"
+	let entry = si
+		.get(&0x0014)
+		.and_then(|tables| tables.get(&0x70))
+		.expect("a TDT entry");
+	assert_eq!(entry.interval, Some(Duration::from_secs(30)), "the TDT/TOT 30s maximum");
+	assert_eq!(
+		read_si_sections(&rig.consumer, &entry.track).await,
+		vec![Bytes::from(tick(2))],
+		"the newest snapshot is the latest tick alone"
 	);
+	let groups = read_si_groups(&rig.consumer, &entry.track).await;
+	assert_eq!(groups.len(), 2, "one group per tick, no accumulation");
 }
 
 /// Build a well-formed short-form section (syntax indicator clear): header + body,
@@ -1881,31 +1892,24 @@ async fn abort_removes_si_catalog_entries() {
 	);
 }
 
-/// Content-identified sections (short-form: no version, nothing to revise in
-/// place) are retained up to a cap, and churn at the cap is not a change: a
-/// clock-like table whose every repetition differs would otherwise cut a group
-/// per debounce forever, carrying the cap's worth of stale sections.
+/// A byte-identical short-form repetition is not a change: the latest-value slot
+/// only cuts a group when the bytes actually differ.
 #[tokio::test(start_paused = true)]
-async fn content_section_churn_at_the_cap_cuts_no_group() {
-	let section = |i: u8| make_short_section(0x72, &[i, 0x00, 0xee]);
+async fn short_form_repetition_cuts_no_group() {
+	let tdt = make_short_section(0x70, &[0xc0, 0x79, 0x12, 0x34, 0x56]);
 
-	// One over the cap in one batch: the 33rd evicts the 1st.
-	let mut input = Vec::new();
-	for i in 0..33u8 {
-		input.extend_from_slice(&si_packet_cc(0x0011, &section(i), i & 0x0f));
-	}
 	let mut rig = si_rig();
+	let mut input = si_packet(0x0014, &tdt);
+	input.extend_from_slice(&si_packet_cc(0x0014, &tdt, 1));
 	rig.import.decode(&BytesMut::from(&input[..])).unwrap();
-	// Another distinct section, pure rotation at the cap: must not re-dirty.
 	rig.import
-		.decode(&BytesMut::from(&si_packet_cc(0x0011, &section(33), 1)[..]))
+		.decode(&BytesMut::from(&si_packet_cc(0x0014, &tdt, 2)[..]))
 		.unwrap();
 	rig.import.finish().unwrap();
 
 	let si = rig.catalog.snapshot().mpegts.si.clone();
-	let groups = read_si_groups(&rig.consumer, &si[&0x0011][&0x72].track).await;
-	assert_eq!(groups.len(), 1, "rotation at the cap cut no further group");
-	assert_eq!(groups[0].len(), 32, "the snapshot holds the cap's worth of sections");
+	let groups = read_si_groups(&rig.consumer, &si[&0x0014][&0x70].track).await;
+	assert_eq!(groups.len(), 1, "a repetition cut no further group");
 }
 
 /// SI never gates output: an advertised entry whose track resolves but never

--- a/rs/moq-mux/src/container/ts/si.rs
+++ b/rs/moq-mux/src/container/ts/si.rs
@@ -40,8 +40,11 @@ const DEBOUNCE: Duration = Duration::from_secs(1);
 /// (see [`scope`]). A section with no long-form header has no extension, version,
 /// or numbering, so its table is a single latest-value slot: each arrival replaces
 /// the last. That is exactly right for the short-form tables DVB defines (TDT/TOT
-/// are clocks; ST is stuffing), and it is what lets a time table be proxied at all
-/// (#2914): content-keyed identity would mint a fresh key per tick.
+/// are clocks; ST is stuffing receivers discard), and it is what lets a time table
+/// be proxied at all (#2914): content-keyed identity would mint a fresh key per
+/// tick. A hypothetical multi-section *static* short-form table would collapse to
+/// its most recent section and alternate; the debounce bounds that at one small
+/// group per second, which is the acceptable cost of not parsing tables.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(super) enum Identity {
 	/// A long-form sub-table: `table_id_extension` plus any table-specific scope.

--- a/rs/moq-mux/src/container/ts/si.rs
+++ b/rs/moq-mux/src/container/ts/si.rs
@@ -17,7 +17,6 @@
 //! reduces a track's frames back into the current section set.
 
 use std::collections::{BTreeMap, HashMap};
-use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -33,32 +32,28 @@ use super::catalog;
 /// debounce forever). The first snapshot is never delayed.
 const DEBOUNCE: Duration = Duration::from_secs(1);
 
-/// Keep at most this many sections without any parseable identity (short-form or
-/// runt) per entry. They can only be deduplicated by content, never replaced, so a
-/// broken source could otherwise accumulate without bound.
-const MAX_CONTENT_SECTIONS: usize = 32;
-
 /// A sub-table's identity within its `(PID, table_id)` entry: what a revised
 /// generation replaces.
 ///
 /// Generic section syntax carries `table_id_extension`; for two documented table
 /// families that alone is ambiguous, so the spec-fixed scope bytes join the key
-/// (see [`scope`]). A section with no long-form header has no identity at all and
-/// is tracked by content: it can be deduplicated but never revised in place.
+/// (see [`scope`]). A section with no long-form header has no extension, version,
+/// or numbering, so its table is a single latest-value slot: each arrival replaces
+/// the last. That is exactly right for the short-form tables DVB defines (TDT/TOT
+/// are clocks; ST is stuffing), and it is what lets a time table be proxied at all
+/// (#2914): content-keyed identity would mint a fresh key per tick.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(super) enum Identity {
 	/// A long-form sub-table: `table_id_extension` plus any table-specific scope.
 	Sub { ext: u16, scope: u32 },
-	/// A short-form or runt section, identified by a hash of its bytes.
-	Content(u64),
+	/// A short-form or runt section: one slot for the whole table, latest wins.
+	Table,
 }
 
 /// Compute a section's sub-table identity.
 pub(super) fn identity(section: &[u8]) -> Identity {
 	if !long_form(section) {
-		let mut hasher = std::collections::hash_map::DefaultHasher::new();
-		section.hash(&mut hasher);
-		return Identity::Content(hasher.finish());
+		return Identity::Table;
 	}
 	let ext = u16::from_be_bytes([section[3], section[4]]);
 	Identity::Sub {
@@ -159,8 +154,6 @@ struct Entry {
 	active: BTreeMap<Identity, Generation>,
 	/// In-flight generations, keyed by sub-table and version.
 	pending: HashMap<(Identity, u8), Pending>,
-	/// Insertion order of content-identified sections, for bounded retention.
-	content_order: Vec<Identity>,
 	/// A commit changed `active` since the last cut.
 	dirty: bool,
 	/// The entry appears in the catalog's `mpegts.si` map (deferred until the first
@@ -178,28 +171,23 @@ impl Entry {
 		let id = identity(&section);
 
 		let Identity::Sub { .. } = id else {
-			// No identity to revise under: dedupe by content and retain a bounded set.
-			if self.active.contains_key(&id) {
-				return;
+			// Latest-value slot: a short-form table has no version to buffer under, so
+			// each arrival replaces the last (a TDT ticks ~every 30s and every section
+			// is new bytes). A byte-identical repetition is not a change.
+			let changed = self
+				.active
+				.get(&id)
+				.is_none_or(|current| current.sections.get(&0) != Some(&section));
+			if changed {
+				self.active.insert(
+					id,
+					Generation {
+						version: None,
+						sections: BTreeMap::from([(0u8, section)]),
+					},
+				);
+				self.dirty = true;
 			}
-			self.active.insert(
-				id,
-				Generation {
-					version: None,
-					sections: BTreeMap::from([(0u8, section)]),
-				},
-			);
-			self.content_order.push(id);
-			if self.content_order.len() > MAX_CONTENT_SECTIONS {
-				let evict = self.content_order.remove(0);
-				self.active.remove(&evict);
-				// At the cap the set is churning, not growing: a clock-like table whose
-				// every repetition differs would otherwise mint a key per arrival and
-				// cut a group per debounce forever, carrying the cap's worth of stale
-				// sections. Rotation without net growth is not worth republishing.
-				return;
-			}
-			self.dirty = true;
 			return;
 		};
 
@@ -361,7 +349,6 @@ impl<E: catalog::Catalog> Capture<E> {
 					interval: catalog::si_interval(table_id),
 					active: BTreeMap::new(),
 					pending: HashMap::new(),
-					content_order: Vec::new(),
 					dirty: false,
 					advertised: false,
 					last_cut: None,

--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -107,7 +107,7 @@ range and transmits only the segment-boundary sections that hold events, so
 **completeness cannot be decided by counting sections**. `--days 8` reaches that
 shape; the default twelve events does not. Censused with `--all-sections`:
 
-| table_id | distinct sections | declared `last_section_number` |
+| table\_id | distinct sections | declared `last_section_number` |
 |---|---:|---:|
 | 0x4E p/f | 2 | 1 |
 | 0x50 schedule, days 0-3 | 32 | 248 |


### PR DESCRIPTION
Implements #2914 the way the issue discussion settled it: TDT/TOT is **proxied from the source**, not synthesized. `export ts` now emits a time table again (the issue's measurement was 0 packets on PID 0x0014 from a source carrying it).

## Why proxy beats synthesis

The issue's original framing had synthesis as the fix and @kixelated pushed back toward proxying; two things make that the right call, beyond drift:

- **Coherence with the EPG.** EIT event times are expressed on the source's clock, and a receiver places the schedule against TDT/TOT. A locally-minted exporter-UTC clock next to a relayed EPG can disagree with it (host NTP skew, source time-base offset); proxying keeps clock and schedule from the same authority, live and on replay alike.
- **TOT is not just a clock.** Its `local_time_offset` descriptors carry country codes and DST transition dates: operator policy an exporter cannot invent. Only proxying preserves them.

Staleness is bounded by the source's own repetition interval (30s max per TS 101 211) plus path latency, which is the same bound a receiver of the original multiplex already has. This also dissolves the issue's open design question ("host UTC or media timeline?"): neither, the source's.

## Mechanism: latest-value short-form identity

A time table is the case the snapshot store previously handled worst: content-keyed identity minted a fresh key per tick, which is why 0x0014 was excluded and why the store carried a retention cap and a churn guard. The fix is to give short-form sections (no long-form header: no extension, version, or numbering) a **single latest-value slot per table**: each arrival replaces the last, a byte-identical repetition is not a change. That is exactly right for every short-form table DVB defines (TDT/TOT are clocks, ST is stuffing), and it *deletes* code: `Identity::Content`, the `MAX_CONTENT_SECTIONS` cap, the insertion-order tracking, and the cap-churn guard all go.

With that in place, 0x0014 simply joins `SI_PIDS`, and `si_interval` learns the TDT/TOT 30s maximum. Each tick cuts a small snapshot group (~30s cadence, debounced like everything else); a joiner reads the newest; export re-emits the latest at the spec interval. No synthesis fallback is built: EN 300 468 makes TDT mandatory in DVB streams, so a source with an EPG and no clock is not a case worth carrying code for until someone hits it.

## Tests

- `tdt_round_trips_as_latest_value`: two ticks produce two groups, the newest snapshot is the latest tick alone, the catalog entry carries the 30s interval; SDT as positive control.
- `short_form_repetition_cuts_no_group`: a byte-identical repetition is not a change.
- `content_section_churn_at_the_cap_cuts_no_group` is deleted with the mechanism it tested.

`cargo nextest run -p moq-mux` (574 tests), `just fix`, `just check`, `just drafts check` all pass.

## Cross-package sync

- `drafts/draft-lcurley-moq-hang.md`: the "SHOULD NOT be carried" clock-table paragraph replaced with the latest-value rule and the proxy rationale.
- `doc/bin/cli.md`: the TDT/TOT exception prose updated.
- No js mirror (no MPEG-TS support); no moq-ffi/libmoq surface change; `SiEntry` schema unchanged (0x0014 entries are additive).

Closes #2914 (manually on merge; dev is not the default branch).

(written by Fable 5)
