### PR TITLE
feat(ffi): decode video inside the bindings

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -263,7 +263,7 @@ If a producer is collected without `Finish()`, the underlying library logs a war
 `PublishAudio` / `PublishVideo` take frames you already encoded. To hand over raw pixels or PCM instead and let the codec run inside the bindings, use `EncodeVideo` / `EncodeAudio`. Pixel format, resolution, and framerate are fixed at publish time, so each frame carries only its pixels and a timestamp:
 
 ```go
-video, err := broadcast.PublishVideo(
+video, err := broadcast.EncodeVideo(
     moq.VideoEncoderInput{
         Format:    moq.VideoPixelFormatRgba,
         Width:     1280,
@@ -283,6 +283,27 @@ err = video.Write(moq.VideoFrame{TimestampUs: ptsUs, Data: rgba})
 // ...
 video.Finish()
 ```
+
+`DecodeVideo` and `DecodeAudio` are the mirrors: they run the codec inside the bindings on the way in, so a subscriber gets pixels and PCM without linking one. Video frames arrive as tightly-packed I420 and carry the size they actually decoded to, since `Resize` is only best effort:
+
+```go
+catalog, err := broadcast.Catalog(ctx)
+// pick a rendition from catalog.Video
+
+video, err := broadcast.DecodeVideo(name, rendition, moq.VideoDecoderOutput{})
+if err != nil {
+    // handle error
+}
+for frame, err := range video.Frames(ctx) {
+    if err != nil {
+        break
+    }
+    render(frame.Data, frame.Width, frame.Height)
+}
+```
+
+An unrecognized codec fails at `DecodeVideo` itself; a recognized one no native backend handles fails when the decoder opens. Either way you find out before the first frame.
+
 
 `AutoEncoder()` prefers a hardware encoder and falls back to software; `SoftwareEncoder()`, `HardwareEncoder()`, and `NamedEncoder("videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), and openh264 (software, everywhere); the Linux hardware codecs are a libmoq-only build option. `SetBitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -161,7 +161,7 @@ broadcast.setVideoProperties(
 `publishAudio` / `publishVideo` take frames you already encoded. To hand over raw pixels or PCM instead and let the codec run inside the bindings, use `encodeVideo` / `encodeAudio`. Pixel format, resolution, and framerate are fixed at publish time, so each frame carries only its pixels and a timestamp:
 
 ```kotlin
-val video = broadcast.publishVideo(
+val video = broadcast.encodeVideo(
     VideoEncoderInput(
         format = VideoPixelFormat.RGBA,
         width = 1280u,
@@ -179,6 +179,21 @@ val video = broadcast.publishVideo(
 video.write(VideoFrame(timestampUs = ptsUs, data = rgba))
 video.finish()
 ```
+
+`decodeVideo` and `decodeAudio` are the mirrors: they run the codec inside the bindings on the way in, so a subscriber gets pixels and PCM without linking one. Video frames arrive as tightly-packed I420 and carry the size they actually decoded to, since `resize` is only best effort:
+
+```kotlin
+val catalog = broadcast.catalog()
+val (name, rendition) = catalog.video.entries.first()
+
+val video = broadcast.decodeVideo(name, rendition, VideoDecoderOutput())
+while (true) {
+    val frame = video.next() ?: break
+    render(frame.data, frame.width, frame.height)
+}
+```
+
+An unrecognized codec throws from `decodeVideo` itself; a recognized one no native backend handles throws when the decoder opens. Either way you find out before the first frame.
 
 `autoEncoder` prefers a hardware encoder and falls back to software; `softwareEncoder`, `hardwareEncoder`, and `namedEncoder("videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), and openh264 (software, everywhere); the Linux hardware codecs are a libmoq-only build option. `setBitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -108,7 +108,7 @@ track it publishes from its own metadata.
 The calls above take frames you already encoded. To hand over raw pixels or PCM instead and let the codec run inside the bindings, use `encode_video` / `encode_audio`. Pixel format, resolution, and framerate are fixed at publish time, so each frame carries only its pixels and a timestamp:
 
 ```python
-video = broadcast.publish_video(
+video = broadcast.encode_video(
     moq.VideoEncoderInput(
         format=moq.VideoPixelFormat.RGBA,
         width=1280,
@@ -128,6 +128,19 @@ video.finish()
 `VideoEncoderKind.AUTO()` prefers a hardware encoder and falls back to software; `SOFTWARE()`, `HARDWARE()`, and `NAMED("videotoolbox")` pin the choice (each variant is a class, so call it). The bindings compile VideoToolbox (macOS), Media Foundation (Windows), and openh264 (software, everywhere); the Linux hardware codecs are a libmoq-only build option. `set_bitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
 The track is named after the codec (`.avc3` / `.hev1`) and its catalog rendition is published immediately, read out of the encoder itself, so subscribers discover it through the catalog rather than a name you pick, and can find it before the first frame exists. `cut()` starts a new group at the next frame, which is optional: the encoder keyframes every `gop` frames on its own, and each of those cuts a group.
+
+`decode_video` and `decode_audio` are the mirrors: they run the codec inside the bindings on the way in, so a subscriber gets pixels and PCM without linking one. Video frames arrive as tightly-packed I420 and carry the size they actually decoded to, since `resize` is only best effort:
+
+```python
+catalog = await broadcast.catalog()
+name, rendition = next(iter(catalog.video.items()))
+
+async with await broadcast.decode_video(name, rendition) as video:
+    async for frame in video:
+        render(frame.data, frame.width, frame.height)
+```
+
+An unrecognized codec raises from `decode_video` itself; a recognized one no native backend handles raises when the decoder opens. Either way you find out before the first frame.
 
 The catalog is filled by parsing the codec bitstream. `publish_video` takes an optional `hint` to supply fields the stream can't reveal (such as `bitrate`), or to publish the catalog before the first keyframe:
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -313,7 +313,7 @@ The served broadcast is not announced. It only resolves consumers that call `req
 `publishAudio` / `publishVideo` take frames you already encoded. To hand over raw pixels or PCM instead and let the codec run inside the bindings, use `encodeVideo` / `encodeAudio`. Pixel format, resolution, and framerate are fixed at publish time, so each frame carries only its pixels and a timestamp:
 
 ```swift
-let video = try broadcast.publishVideo(
+let video = try broadcast.encodeVideo(
     input: VideoEncoderInput(format: .rgba, width: 1280, height: 720, framerate: 30),
     output: VideoEncoderOutput(codec: .h264, bitrate: nil, gop: nil, kind: .auto)
 )
@@ -321,6 +321,20 @@ let video = try broadcast.publishVideo(
 try video.write(VideoFrame(timestampUs: ptsUs, data: rgba))
 try video.finish()
 ```
+
+`decodeVideo` and `decodeAudio` are the mirrors: they run the codec inside the bindings on the way in, so a subscriber gets pixels and PCM without linking one. Video frames arrive as tightly-packed I420 and carry the size they actually decoded to, since `resize` is only best effort:
+
+```swift
+let catalog = try await broadcast.catalog()
+let (name, rendition) = catalog.video.first!
+
+let video = try await broadcast.decodeVideo(name: name, catalogVideo: rendition)
+for try await frame in video {
+    render(frame.data, frame.width, frame.height)
+}
+```
+
+An unrecognized codec throws from `decodeVideo` itself; a recognized one no native backend handles throws when the decoder opens. Either way you find out before the first frame.
 
 `kind: .auto` prefers a hardware encoder and falls back to software; `.software`, `.hardware`, and `.named(name: "videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), and openh264 (software, everywhere); the Linux hardware codecs are a libmoq-only build option. `setBitrate(_:)` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 

--- a/go/wrapper/moq/subscribe.go
+++ b/go/wrapper/moq/subscribe.go
@@ -102,6 +102,17 @@ func (b *BroadcastConsumer) DecodeAudio(name string, catalogAudio Audio, output 
 	return &AudioConsumer{inner: inner}, nil
 }
 
+// DecodeVideo subscribes to a video track and decodes it inside the bindings,
+// yielding packed I420. catalogVideo comes from the catalog. output.Resize is
+// best effort, so read each frame's own dimensions.
+func (b *BroadcastConsumer) DecodeVideo(name string, catalogVideo Video, output VideoDecoderOutput) (*VideoConsumer, error) {
+	inner, err := b.inner.DecodeVideo(name, catalogVideo, output)
+	if err != nil {
+		return nil, err
+	}
+	return &VideoConsumer{inner: inner}, nil
+}
+
 // Catalog subscribes and returns the first catalog. It reports ErrClosed if the
 // catalog track ends before any catalog arrives.
 func (b *BroadcastConsumer) Catalog(ctx context.Context) (*Catalog, error) {
@@ -286,6 +297,26 @@ func (a *AudioConsumer) Frames(ctx context.Context) iter.Seq2[*AudioFrame, error
 // Cancel stops the stream.
 func (a *AudioConsumer) Cancel() {
 	a.inner.Cancel()
+}
+
+// VideoConsumer is a stream of decoded video frames.
+type VideoConsumer struct {
+	inner *ffi.MoqVideoConsumer
+}
+
+// Next returns the next decoded frame, or (nil, nil) when the track ends.
+func (v *VideoConsumer) Next(ctx context.Context) (*VideoDecodedFrame, error) {
+	return runCancellable(ctx, v.inner.Cancel, v.inner.Next)
+}
+
+// Frames ranges over decoded frames until the track ends or the loop breaks.
+func (v *VideoConsumer) Frames(ctx context.Context) iter.Seq2[*VideoDecodedFrame, error] {
+	return streamSeq(ctx, v.Next)
+}
+
+// Cancel stops the stream.
+func (v *VideoConsumer) Cancel() {
+	v.inner.Cancel()
 }
 
 // CatalogConsumer is a stream of catalog updates.

--- a/go/wrapper/moq/types.go
+++ b/go/wrapper/moq/types.go
@@ -47,6 +47,10 @@ type (
 	// Video describes one catalog rendition, including whether the publisher recommends temporarily avoiding it.
 	Video = ffi.MoqVideo
 	// VideoHint supplies catalog fields a video stream can't reveal itself, such as bitrate, filling only the gaps.
+	// VideoDecodedFrame is one decoded video frame: packed I420, its dimensions, and a timestamp in microseconds.
+	VideoDecodedFrame = ffi.MoqVideoDecodedFrame
+	// VideoDecoderOutput configures what DecodeVideo delivers: an optional resize plus a latency budget.
+	VideoDecoderOutput = ffi.MoqVideoDecoderOutput
 	VideoHint = ffi.MoqVideoHint
 	// AudioFormat is a single audio codec an importer can parse.
 	AudioFormat = ffi.MoqAudioFormat

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -75,6 +75,8 @@ typealias MediaGroupConsumer = uniffi.moq.MoqMediaGroupConsumer
 typealias AudioProducer = uniffi.moq.MoqAudioProducer
 /** The read side of a raw-audio track: yields decoded PCM frames. */
 typealias AudioConsumer = uniffi.moq.MoqAudioConsumer
+/** The read side of a video track decoded inside the bindings: yields packed I420 frames. */
+typealias VideoConsumer = uniffi.moq.MoqVideoConsumer
 /** The write side of a raw-video track; pixels written here are encoded inside the FFI boundary. */
 typealias VideoProducer = uniffi.moq.MoqVideoProducer
 /** The read side of a broadcast's catalog: yields updates as the set of tracks changes. */
@@ -135,6 +137,10 @@ typealias AudioCodec = uniffi.moq.MoqAudioCodec
 typealias AudioSampleFormat = uniffi.moq.MoqAudioSampleFormat
 /** The PCM layout an [AudioConsumer] should decode to. */
 typealias AudioDecoderOutput = uniffi.moq.MoqAudioDecoderOutput
+/** What a [VideoConsumer] decodes to: an optional resize plus a latency budget. */
+typealias VideoDecoderOutput = uniffi.moq.MoqVideoDecoderOutput
+/** One decoded video frame: packed I420, its dimensions, and a timestamp. */
+typealias VideoDecodedFrame = uniffi.moq.MoqVideoDecodedFrame
 /** The PCM layout the caller feeds an [AudioProducer]. */
 typealias AudioEncoderInput = uniffi.moq.MoqAudioEncoderInput
 /** The codec-side encoder configuration: codec, output rate/channels, bitrate, and frame duration. */

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -46,6 +46,7 @@ from .subscribe import (
     MediaConsumer,
     MediaGroupConsumer,
     TrackConsumer,
+    VideoConsumer,
 )
 from .types import (
     Audio,
@@ -72,6 +73,8 @@ from .types import (
     TrackInfo,
     Video,
     VideoCodec,
+    VideoDecodedFrame,
+    VideoDecoderOutput,
     VideoEncoderInput,
     VideoEncoderKind,
     VideoEncoderOutput,
@@ -148,6 +151,9 @@ __all__ = [
     "VideoEncoderKind",
     "VideoEncoderOutput",
     "VideoFrame",
+    "VideoConsumer",
+    "VideoDecodedFrame",
+    "VideoDecoderOutput",
     "VideoHint",
     "VideoPixelFormat",
     "VideoProducer",

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -18,6 +18,7 @@ from moq_ffi import (
     MoqMediaConsumer,
     MoqMediaGroupConsumer,
     MoqTrackConsumer,
+    MoqVideoConsumer,
 )
 
 from .types import (
@@ -34,6 +35,8 @@ from .types import (
     Subscription,
     TrackInfo,
     Video,
+    VideoDecodedFrame,
+    VideoDecoderOutput,
 )
 
 
@@ -261,6 +264,38 @@ class AudioConsumer:
         self._inner.cancel()
 
 
+class VideoConsumer:
+    """Async iterator of decoded video frames.
+
+    Built via :meth:`BroadcastConsumer.decode_video`. Each frame is
+    tightly-packed I420 and carries its own ``width`` and ``height``:
+    ``output.resize`` is best effort, so read the frame rather than
+    assuming it took.
+    """
+
+    def __init__(self, inner: MoqVideoConsumer) -> None:
+        self._inner = inner
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        self.cancel()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> VideoDecodedFrame:
+        frame = await self._inner.next()
+        if frame is None:
+            raise StopAsyncIteration
+        return frame
+
+    def cancel(self) -> None:
+        """Cancel the subscription and stop delivering video frames."""
+        self._inner.cancel()
+
+
 class JsonSnapshotConsumer:
     """Async iterator over a JSON snapshot track, yielding the latest value (lossy).
 
@@ -465,6 +500,25 @@ class BroadcastConsumer:
         a future ``latency_min_ms`` jitter-buffer floor.)
         """
         return AudioConsumer(await self._inner.decode_audio(name, catalog_audio, output))
+
+    async def decode_video(
+        self,
+        name: str,
+        catalog_video: Video,
+        output: VideoDecoderOutput | None = None,
+    ) -> VideoConsumer:
+        """Subscribe to a video track and decode it inside the bindings.
+
+        ``catalog_video`` comes from the catalog (e.g.
+        ``await broadcast.catalog()`` followed by ``catalog.video[name]``).
+        Frames arrive as tightly-packed I420. An unrecognized codec raises
+        here; a recognized one no native backend handles raises when the
+        decoder opens, both before the first frame.
+
+        ``output.resize`` asks the decoder for a different size and is best
+        effort, so read each frame's own dimensions.
+        """
+        return VideoConsumer(await self._inner.decode_video(name, catalog_video, output or VideoDecoderOutput()))
 
     async def catalog(self) -> Catalog:
         """Convenience: subscribe and return the first catalog."""

--- a/py/moq-rs/moq/types.py
+++ b/py/moq-rs/moq/types.py
@@ -73,6 +73,12 @@ from moq_ffi import (
     MoqVideoCodec as VideoCodec,
 )
 from moq_ffi import (
+    MoqVideoDecodedFrame as VideoDecodedFrame,
+)
+from moq_ffi import (
+    MoqVideoDecoderOutput as VideoDecoderOutput,
+)
+from moq_ffi import (
     MoqVideoEncoderInput as VideoEncoderInput,
 )
 from moq_ffi import (
@@ -130,6 +136,8 @@ __all__ = [
     "VideoEncoderKind",
     "VideoEncoderOutput",
     "VideoFrame",
+    "VideoDecodedFrame",
+    "VideoDecoderOutput",
     "VideoHint",
     "VideoPixelFormat",
     "VideoProperties",

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -402,7 +402,10 @@ impl MoqVideoConsumer {
 		self.task.run(|mut state| async move { state.next().await }).await
 	}
 
-	/// Stop decoding and release the backend.
+	/// Make current and future reads return `Cancelled`.
+	///
+	/// The decoder backend is released when this object is dropped, not here: a cancelled consumer
+	/// that stays reachable keeps its codec session. Drop it to free one.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -12,6 +12,7 @@
 
 use std::sync::Arc;
 
+use crate::consumer::MoqBroadcastConsumer;
 use crate::error::MoqError;
 use crate::producer::MoqBroadcastProducer;
 
@@ -319,5 +320,189 @@ impl MoqBroadcastProducer {
 				size: config.size(),
 			})),
 		}))
+	}
+}
+
+/// How a subscriber wants decoded video delivered.
+///
+/// Frames always arrive as tightly-packed I420 (Y, then U, then V, no row
+/// padding), so there is no pixel format to choose: a decoder's native output is
+/// flattened to CPU I420 at delivery, since the FFI boundary can't hand back a
+/// GPU surface.
+#[derive(Clone, uniffi::Record)]
+pub struct MoqVideoDecoderOutput {
+	/// Ask the decoder to emit frames at this size instead of the stream's
+	/// native one. Best effort: a backend with a built-in scaler honors it for
+	/// free, others ignore it, so read each frame's own dimensions rather than
+	/// assuming this took. Both dimensions must be even.
+	#[uniffi(default = None)]
+	pub resize: Option<crate::media::MoqDimensions>,
+	/// Upper bound on buffering before skipping a stalled group, in
+	/// milliseconds. Same knob as
+	/// [`MoqAudioDecoderOutput::latency_max_ms`](crate::audio::MoqAudioDecoderOutput::latency_max_ms).
+	/// `None` keeps the moq-mux default of zero (skip aggressively).
+	#[uniffi(default = None)]
+	pub latency_max_ms: Option<u64>,
+}
+
+/// One decoded video frame: packed I420 plus the size it actually decoded to.
+///
+/// Unlike [`MoqVideoFrame`] on the publish side, this carries dimensions: there
+/// they are fixed by the encoder config, here they are whatever the stream
+/// turned out to be, and `resize` is only best effort.
+#[derive(uniffi::Record)]
+pub struct MoqVideoDecodedFrame {
+	/// Presentation timestamp, in microseconds.
+	pub timestamp_us: u64,
+	/// Frame width in pixels.
+	pub width: u32,
+	/// Frame height in pixels.
+	pub height: u32,
+	/// Tightly-packed I420: Y, then U, then V.
+	pub data: Vec<u8>,
+}
+
+struct VideoConsumerInner {
+	consumer: moq_video::decode::Consumer,
+}
+
+impl VideoConsumerInner {
+	async fn next(&mut self) -> Result<Option<MoqVideoDecodedFrame>, MoqError> {
+		let Some(frame) = self.consumer.read().await? else {
+			return Ok(None);
+		};
+
+		let size = frame.size();
+		// The surface may still live on the GPU, so flatten before crossing the
+		// boundary: uniffi has no handle type to hand back a texture with.
+		let data = frame
+			.surface
+			.into_i420()
+			.map_err(|err| MoqError::Codec(err.to_string()))?;
+
+		Ok(Some(MoqVideoDecodedFrame {
+			timestamp_us: frame.timestamp.as_micros() as u64,
+			width: size.width,
+			height: size.height,
+			data: data.to_vec(),
+		}))
+	}
+}
+
+/// Consumer for a video track decoded inside the bindings.
+#[derive(uniffi::Object)]
+pub struct MoqVideoConsumer {
+	task: crate::ffi::Task<VideoConsumerInner>,
+}
+
+#[uniffi::export]
+impl MoqVideoConsumer {
+	/// The next decoded frame, or `None` once the track ends.
+	pub async fn next(&self) -> Result<Option<MoqVideoDecodedFrame>, MoqError> {
+		self.task.run(|mut state| async move { state.next().await }).await
+	}
+
+	/// Stop decoding and release the backend.
+	pub fn cancel(&self) {
+		self.task.cancel();
+	}
+}
+
+/// Rebuild the catalog rendition the decoder needs from what the FFI catalog handed out.
+///
+/// The inverse of the conversion in [`crate::media::convert_catalog`]. An unrecognized codec name
+/// is rejected here; a recognized one the native backends can't open is rejected when the decoder
+/// opens, which is still before the first frame.
+fn video_config(catalog_video: crate::media::MoqVideo) -> Result<hang::catalog::VideoConfig, MoqError> {
+	let codec: hang::catalog::VideoCodec = catalog_video.codec.parse().map_err(|_| MoqError::Unsupported)?;
+	// Parsing is total: an unrecognized name becomes `Unknown` rather than failing. Reject it here
+	// so a typo in the catalog is an error at subscribe, not an opaque backend failure later.
+	if matches!(codec, hang::catalog::VideoCodec::Unknown(_)) {
+		return Err(MoqError::Unsupported);
+	}
+
+	let mut config = hang::catalog::VideoConfig::new(codec);
+	config.label = catalog_video.label;
+	config.description = catalog_video.description.map(Into::into);
+	if let Some(coded) = catalog_video.coded {
+		config.coded_width = Some(coded.width);
+		config.coded_height = Some(coded.height);
+	}
+	if let Some(aspect) = catalog_video.display_aspect {
+		config.display_aspect_width = Some(aspect.width);
+		config.display_aspect_height = Some(aspect.height);
+	}
+	config.bitrate = catalog_video.bitrate;
+	config.framerate = catalog_video.framerate;
+	config.stalled = Some(catalog_video.stalled);
+	config.container = catalog_video.container.into();
+	Ok(config)
+}
+
+#[uniffi::export]
+impl MoqBroadcastConsumer {
+	/// Subscribe to a video track and decode it inside the bindings.
+	///
+	/// `catalog_video` comes from the catalog (see
+	/// [`MoqCatalogConsumer::next`](crate::consumer::MoqCatalogConsumer::next)); the codec is read
+	/// from it. Errors if no native backend handles that codec, rather than failing on the first
+	/// frame.
+	pub async fn decode_video(
+		&self,
+		name: String,
+		catalog_video: crate::media::MoqVideo,
+		output: MoqVideoDecoderOutput,
+	) -> Result<Arc<MoqVideoConsumer>, MoqError> {
+		let cfg = video_config(catalog_video)?;
+
+		let mut config = moq_video::decode::Config::default();
+		config.resize = output.resize.map(|size| moq_video::Size::new(size.width, size.height));
+		config.latency = output
+			.latency_max_ms
+			.map(|ms| moq_mux::Latency::max(std::time::Duration::from_millis(ms)))
+			.unwrap_or_default();
+
+		let consumer = moq_video::decode::Consumer::new(self.inner(), &cfg, name, config).await?;
+
+		Ok(Arc::new(MoqVideoConsumer {
+			task: crate::ffi::Task::new(VideoConsumerInner { consumer }),
+		}))
+	}
+}
+
+#[cfg(test)]
+mod decode_tests {
+	use super::*;
+	use crate::media::{MoqContainer, MoqDimensions, MoqVideo};
+
+	fn catalog_video(codec: &str) -> MoqVideo {
+		MoqVideo {
+			label: None,
+			codec: codec.to_string(),
+			description: None,
+			coded: Some(MoqDimensions {
+				width: 1280,
+				height: 720,
+			}),
+			display_aspect: None,
+			bitrate: None,
+			stalled: false,
+			framerate: Some(30.0),
+			container: MoqContainer::Legacy,
+		}
+	}
+
+	#[test]
+	fn video_config_round_trips_the_catalog_fields() {
+		let config = video_config(catalog_video("avc1.64001f")).unwrap();
+		assert_eq!(config.coded_width, Some(1280));
+		assert_eq!(config.coded_height, Some(720));
+		assert_eq!(config.framerate, Some(30.0));
+	}
+
+	#[test]
+	fn video_config_rejects_an_unknown_codec() {
+		let error = video_config(catalog_video("nope")).unwrap_err();
+		assert!(matches!(error, MoqError::Unsupported));
 	}
 }

--- a/swift/Sources/Moq/Aliases.swift
+++ b/swift/Sources/Moq/Aliases.swift
@@ -41,6 +41,10 @@ public typealias AudioEncoderInput = MoqFFI.MoqAudioEncoderInput
 /// The encoder-side config for a published audio track: codec, rate, channels,
 /// bitrate, and frame duration.
 public typealias AudioEncoderOutput = MoqFFI.MoqAudioEncoderOutput
+/// What a `VideoConsumer` decodes to: an optional resize plus a latency budget.
+public typealias VideoDecoderOutput = MoqVideoDecoderOutput
+/// One decoded video frame: packed I420, its dimensions, and a timestamp.
+public typealias VideoDecodedFrame = MoqVideoDecodedFrame
 /// The PCM layout an `AudioConsumer` decodes to, plus its latency budget.
 public typealias AudioDecoderOutput = MoqFFI.MoqAudioDecoderOutput
 /// A raw PCM sample format, mirroring WebCodecs `AudioData.format`.

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -80,6 +80,18 @@ public final class BroadcastConsumer: Sendable {
         AudioConsumer(try await ffi.decodeAudio(name: name, catalogAudio: catalogAudio, output: output))
     }
 
+    /// Subscribe to a video track and decode it inside the bindings, yielding
+    /// packed I420. `catalogVideo` is the matching rendition from the catalog.
+    ///
+    /// `output.resize` is best effort, so read each frame's own dimensions.
+    public func decodeVideo(
+        name: String,
+        catalogVideo: Video,
+        output: VideoDecoderOutput = VideoDecoderOutput()
+    ) async throws -> VideoConsumer {
+        VideoConsumer(try await ffi.decodeVideo(name: name, catalogVideo: catalogVideo, output: output))
+    }
+
     /// Subscribe to a JSON snapshot track (lossy latest-value), decoding each value as `Value`.
     ///
     /// Yields only the newest value, collapsing the backlog for a reader that has fallen behind.

--- a/swift/Sources/Moq/Video.swift
+++ b/swift/Sources/Moq/Video.swift
@@ -1,5 +1,35 @@
 import MoqFFI
 
+/// Read side of a video track decoded inside the bindings. Iterating yields
+/// tightly-packed I420 frames, each carrying the size it actually decoded to.
+public final class VideoConsumer: AsyncSequence, Sendable {
+    /// The decoded video frame emitted by this sequence.
+    public typealias Element = VideoDecodedFrame
+
+    let ffi: MoqVideoConsumer
+
+    init(_ ffi: MoqVideoConsumer) {
+        self.ffi = ffi
+    }
+
+    /// The next frame, or `nil` once the track ends or is closed.
+    public func next() async throws -> VideoDecodedFrame? {
+        try await ffi.next()
+    }
+
+    /// Cancel all current and future reads.
+    public func cancel() {
+        ffi.cancel()
+    }
+
+    /// Create an iterator that cancels native reads when iteration ends.
+    public func makeAsyncIterator() -> AsyncThrowingStream<VideoDecodedFrame, Swift.Error>.Iterator {
+        moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
+            try await ffi.next()
+        }.makeAsyncIterator()
+    }
+}
+
 /// Write side of a raw-video track. Pixels written here are encoded (H.264 or
 /// H.265) inside the FFI boundary per the `VideoEncoderInput`/`Output` from
 /// publish time.


### PR DESCRIPTION
## Summary

- `moq-ffi` exposed `encode_video` but no decode counterpart, so Python, Swift, Kotlin, and Go could publish raw video and never consume it. Video decode reached callers only through libmoq's C `moq_decode_video`.
- Adds `BroadcastConsumer::decode_video`, mirroring `decode_audio`, plus the wrapper surface in all four languages.
- Closes #2928, which #2927 filed after the `encode_*` / `decode_*` rename put the hole next to its audio counterpart.

## Public API changes

Additive, hence `main`... except it targets `dev` because it builds on #2927, which is only on `dev`.

**moq-ffi**
- `MoqBroadcastConsumer::decode_video(name, catalog_video, output) -> MoqVideoConsumer`
- `MoqVideoDecoderOutput { resize, latency_max_ms }` — both optional, defaulted
- `MoqVideoDecodedFrame { timestamp_us, width, height, data }`
- `MoqVideoConsumer` with `next()` / `cancel()`

Frames carry their own dimensions, unlike `MoqVideoFrame` on the publish side where the encoder config fixes them. Here they're whatever the stream turned out to be, and `resize` is best effort — a backend with a scaler honors it, others ignore it.

**Wrappers**: `decode_video` / `decodeVideo` / `DecodeVideo` and a `VideoConsumer` in each, following each language's existing iteration idiom (async iterator, `AsyncSequence`, `iter.Seq2`, raw uniffi + aliases for Kotlin).

## Codec rejection

`video_config` rejects an unrecognized codec name up front. `VideoCodec` parsing is **total** — `"nope"` becomes `Unknown("nope")` rather than an error — so without that check a catalog typo would surface as an opaque backend failure rather than an error at subscribe. A *recognized* codec no native backend handles is still rejected when the decoder opens, which is also before the first frame.

I found this because the test I wrote to assert rejection failed.

## Drive-by doc fix

The `encode_*` rename in #2927 updated the prose in the Python, Swift, Kotlin, and Go guides but left their code samples calling `publishVideo(VideoEncoderInput(...))`. Docs aren't compiled, so neither `just check` nor CI catches a sample that no longer parses. Fixed in all four.

## Test plan

- [x] `just check`
- [x] `just test` — 3242 passed
- [x] New: `video_config` round-trips catalog fields, and rejects an unknown codec
- [ ] No end-to-end decode test. `decode_audio` has none either; exercising a real backend needs an encoded fixture plus a platform-specific decoder, so the wiring is verified by compile and the config layer by unit test.

## Cross-package sync

`rs/moq-ffi` → `{py,swift,kt}/`, `go/wrapper/moq/`, `doc/lib/{py,swift,kt,go}`. No `rs/libmoq` change: the C ABI already had `moq_decode_video`, which is what made this a gap rather than a missing feature. No wire change.

(Written by Opus 5)
