### PR TITLE
fix(ffi): release the state when a handle is cancelled

### DIFF
--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -38,7 +38,7 @@ moq-video = { workspace = true }
 pollster = "1.0"
 serde_json = "1"
 thiserror = "2"
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "sync", "time"] }
 tracing = "0.1"
 uniffi = { version = "0.31", features = ["cli"] }
 url = "2"

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -226,10 +226,14 @@ pub struct MoqAudioConsumer {
 
 #[uniffi::export]
 impl MoqAudioConsumer {
+	/// The next decoded frame, or `None` once the track ends.
 	pub async fn next(&self) -> Result<Option<MoqAudioFrame>, MoqError> {
 		self.task.run(|mut state| async move { state.next().await }).await
 	}
 
+	/// Make current and future reads return `Cancelled`.
+	///
+	/// Terminal: the decoder session is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -489,7 +489,7 @@ impl MoqTrackConsumer {
 		let _ = self.control.update(subscription.into());
 	}
 
-	/// Cancel all current and future group reads.
+	/// Cancel all current and future reads.
 	///
 	/// Terminal: the subscription is released here, not when the handle is.
 	pub fn cancel(&self) {

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -187,6 +187,8 @@ impl MoqRouteWatch {
 	}
 
 	/// Cancel all current and future `next()` calls.
+	///
+	/// Terminal: the subscription is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -487,6 +489,9 @@ impl MoqTrackConsumer {
 		let _ = self.control.update(subscription.into());
 	}
 
+	/// Cancel all current and future group reads.
+	///
+	/// Terminal: the subscription is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -549,6 +554,8 @@ impl MoqMediaGroupConsumer {
 	}
 
 	/// Cancel all current and future `next()` calls.
+	///
+	/// Terminal: the subscription is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -577,6 +584,9 @@ impl MoqGroupConsumer {
 		self.task.run(|mut state| async move { state.read_frame().await }).await
 	}
 
+	/// Cancel all current and future `read_frame()` calls.
+	///
+	/// Terminal: the group and whatever it still buffers are released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -592,6 +602,8 @@ impl MoqCatalogConsumer {
 	}
 
 	/// Cancel all current and future `next()` calls.
+	///
+	/// Terminal: the subscription is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -607,6 +619,8 @@ impl MoqMediaConsumer {
 	}
 
 	/// Cancel all current and future `next()` calls.
+	///
+	/// Terminal: the subscription is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/ffi.rs
+++ b/rs/moq-ffi/src/ffi.rs
@@ -46,6 +46,15 @@ impl<T: Send + 'static> Task<T> {
 	/// Try to lock the state synchronously. Returns `None` if a task is running or it was cancelled.
 	pub fn lock(&self) -> Option<Guard<T>> {
 		let guard = self.state.clone().try_lock_owned().ok()?;
+
+		// The state is still `Some` between a cancel and the take it schedules, so ask the flag
+		// rather than the state. Reading it under the lock is what makes that answer stable:
+		// `cancel` publishes the flag before it queues for this same lock, so a cancel we don't
+		// see here cannot have taken the state either.
+		if *self.cancel.borrow() {
+			return None;
+		}
+
 		tokio::sync::OwnedMutexGuard::try_map(guard, Option::as_mut).ok()
 	}
 
@@ -222,13 +231,16 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn lock_is_empty_after_cancel() {
+	async fn lock_is_empty_from_the_moment_cancel_returns() {
 		let (task, dropped) = tracked();
 		assert!(task.lock().is_some());
 
+		// No await in between: the answer can't depend on whether the scheduled take has run,
+		// or a caller could still reach the state it is about to drop.
 		task.cancel();
-		soon(dropped).await.expect("state should be dropped");
+		assert!(task.lock().is_none());
 
+		soon(dropped).await.expect("state should be dropped");
 		assert!(task.lock().is_none());
 	}
 

--- a/rs/moq-ffi/src/ffi.rs
+++ b/rs/moq-ffi/src/ffi.rs
@@ -20,32 +20,43 @@ pub(crate) static RUNTIME: LazyLock<tokio::runtime::Handle> = LazyLock::new(|| {
 	handle
 });
 
+/// Serializes access to `T` across the FFI boundary, and releases it on cancel.
+///
+/// The state is dropped rather than parked once [Self::cancel] runs, so a handle the foreign
+/// side has cancelled but not yet released stops holding whatever it wrapped: a subscription,
+/// a codec session.
 pub(crate) struct Task<T: Send + 'static> {
-	state: Arc<tokio::sync::Mutex<T>>,
+	/// `None` once cancelled, which is what makes running against a released state
+	/// unrepresentable rather than merely documented.
+	state: Arc<tokio::sync::Mutex<Option<T>>>,
 	cancel: tokio::sync::watch::Sender<bool>,
 }
+
+/// Exclusive access to a [Task]'s state, held for as long as the guard lives.
+pub(crate) type Guard<T> = tokio::sync::OwnedMappedMutexGuard<Option<T>, T>;
 
 impl<T: Send + 'static> Task<T> {
 	pub fn new(inner: T) -> Self {
 		Self {
-			state: Arc::new(tokio::sync::Mutex::new(inner)),
+			state: Arc::new(tokio::sync::Mutex::new(Some(inner))),
 			cancel: tokio::sync::watch::Sender::new(false),
 		}
 	}
 
-	/// Try to lock the state synchronously. Returns `None` if a task is running.
-	pub fn lock(&self) -> Option<tokio::sync::OwnedMutexGuard<T>> {
-		self.state.clone().try_lock_owned().ok()
+	/// Try to lock the state synchronously. Returns `None` if a task is running or it was cancelled.
+	pub fn lock(&self) -> Option<Guard<T>> {
+		let guard = self.state.clone().try_lock_owned().ok()?;
+		tokio::sync::OwnedMutexGuard::try_map(guard, Option::as_mut).ok()
 	}
 
 	/// Spawn an async closure on the runtime.
 	///
-	/// The closure receives an [OwnedMutexGuard] which derefs to `T`.
+	/// The closure receives a [Guard] which derefs to `T`.
 	/// If two calls are made concurrently, the second waits for the first to finish.
 	pub async fn run<R, F, Fut>(&self, f: F) -> Result<R, MoqError>
 	where
 		R: Send + 'static,
-		F: FnOnce(tokio::sync::OwnedMutexGuard<T>) -> Fut + Send + 'static,
+		F: FnOnce(Guard<T>) -> Fut + Send + 'static,
 		Fut: Future<Output = Result<R, MoqError>> + Send + 'static,
 	{
 		let mut cancel = self.cancel.subscribe();
@@ -57,6 +68,10 @@ impl<T: Send + 'static> Task<T> {
 				Ok(_) = cancel.wait_for(|&c| c) => return Err(MoqError::Cancelled),
 				state = state.lock_owned() => state,
 			};
+
+			// Cancelled while we queued behind another call, and the state is already gone.
+			let state =
+				tokio::sync::OwnedMutexGuard::try_map(state, Option::as_mut).map_err(|_| MoqError::Cancelled)?;
 
 			let mut cancel = cancel;
 			tokio::select! {
@@ -80,12 +95,26 @@ impl<T: Send + 'static> Task<T> {
 		}
 	}
 
-	/// Cancel all current and future [Self::run] calls, causing them to return [MoqError::Cancelled].
+	/// Cancel all current and future [Self::run] calls, causing them to return [MoqError::Cancelled],
+	/// and drop the state.
+	///
+	/// Terminal: there is no way back from here, and the state is gone rather than idle.
+	/// The drop is not synchronous with this call, because an in-flight [Self::run] holds the
+	/// state until it observes the flag and unwinds. It also lands on the runtime thread, which
+	/// is where the state was built and the only place with a reactor for what it unregisters.
 	pub fn cancel(&self) {
 		// send_replace, not send: `send` refuses to store the value while no
 		// receiver exists, so a cancel BEFORE the first `run` would silently
 		// no-op and the run would proceed.
-		self.cancel.send_replace(true);
+		if self.cancel.send_replace(true) {
+			// Already cancelled, so the first call is the one dropping the state.
+			return;
+		}
+
+		let state = self.state.clone();
+		RUNTIME.spawn(async move {
+			state.lock().await.take();
+		});
 	}
 }
 
@@ -103,5 +132,112 @@ struct AbortOnDrop(tokio::task::AbortHandle);
 impl Drop for AbortOnDrop {
 	fn drop(&mut self) {
 		self.0.abort();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::Arc;
+	use std::sync::atomic::{AtomicBool, Ordering};
+	use std::time::Duration;
+
+	use super::*;
+
+	/// A state that reports its own drop, which is what a terminal cancel has to trigger.
+	struct Tracked(Option<tokio::sync::oneshot::Sender<()>>);
+
+	impl Drop for Tracked {
+		fn drop(&mut self) {
+			let _ = self.0.take().expect("dropped once").send(());
+		}
+	}
+
+	fn tracked() -> (Task<Tracked>, tokio::sync::oneshot::Receiver<()>) {
+		let (tx, rx) = tokio::sync::oneshot::channel();
+		(Task::new(Tracked(Some(tx))), rx)
+	}
+
+	/// Fail the test instead of hanging when a wakeup goes missing.
+	async fn soon<F: Future>(f: F) -> F::Output {
+		tokio::time::timeout(Duration::from_secs(5), f)
+			.await
+			.expect("timed out")
+	}
+
+	#[tokio::test]
+	async fn cancel_drops_an_idle_state() {
+		let (task, dropped) = tracked();
+
+		task.cancel();
+		soon(dropped).await.expect("state should be dropped");
+	}
+
+	#[tokio::test]
+	async fn cancel_drops_the_state_under_an_in_flight_run() {
+		let (task, dropped) = tracked();
+
+		// Park a run holding the state, so the drop has to wait for it to unwind.
+		let (started, running) = tokio::sync::oneshot::channel();
+		let run = task.run(move |_state| async move {
+			started.send(()).expect("test should still be waiting");
+			std::future::pending::<Result<(), MoqError>>().await
+		});
+		tokio::pin!(run);
+
+		// Poll the run far enough to take the lock; it parks forever after that.
+		soon(async {
+			tokio::select! {
+				_ = &mut run => panic!("a pending run should not resolve"),
+				started = running => started.expect("the run should start"),
+			}
+		})
+		.await;
+
+		task.cancel();
+
+		let err = soon(&mut run).await.expect_err("the in-flight run should be cancelled");
+		assert!(matches!(err, MoqError::Cancelled));
+		soon(dropped).await.expect("state should be dropped");
+	}
+
+	#[tokio::test]
+	async fn run_after_cancel_is_cancelled_without_touching_the_state() {
+		let (task, dropped) = tracked();
+
+		task.cancel();
+		soon(dropped).await.expect("state should be dropped");
+
+		// The closure would deref a state that no longer exists, so it must never be called.
+		let called = Arc::new(AtomicBool::new(false));
+		let flag = called.clone();
+		let err = soon(task.run(move |_state| {
+			flag.store(true, Ordering::SeqCst);
+			async move { Ok(()) }
+		}))
+		.await
+		.expect_err("a run after cancel should be cancelled");
+
+		assert!(matches!(err, MoqError::Cancelled));
+		assert!(!called.load(Ordering::SeqCst));
+	}
+
+	#[tokio::test]
+	async fn lock_is_empty_after_cancel() {
+		let (task, dropped) = tracked();
+		assert!(task.lock().is_some());
+
+		task.cancel();
+		soon(dropped).await.expect("state should be dropped");
+
+		assert!(task.lock().is_none());
+	}
+
+	#[tokio::test]
+	async fn cancel_twice_is_a_no_op() {
+		let (task, dropped) = tracked();
+
+		task.cancel();
+		task.cancel();
+		soon(dropped).await.expect("state should be dropped");
 	}
 }

--- a/rs/moq-ffi/src/ffi.rs
+++ b/rs/moq-ffi/src/ffi.rs
@@ -58,6 +58,12 @@ impl<T: Send + 'static> Task<T> {
 		tokio::sync::OwnedMutexGuard::try_map(guard, Option::as_mut).ok()
 	}
 
+	/// Whether [Self::cancel] has run, which [Self::lock] folds into the same `None` as a busy
+	/// state. The state may still be a moment away from being dropped.
+	pub fn is_cancelled(&self) -> bool {
+		*self.cancel.borrow()
+	}
+
 	/// Spawn an async closure on the runtime.
 	///
 	/// The closure receives a [Guard] which derefs to `T`.

--- a/rs/moq-ffi/src/json.rs
+++ b/rs/moq-ffi/src/json.rs
@@ -219,6 +219,8 @@ impl MoqJsonSnapshotConsumer {
 	}
 
 	/// Cancel all current and future `next()` calls.
+	///
+	/// Terminal: the subscription is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -280,6 +282,8 @@ impl MoqJsonStreamConsumer {
 	}
 
 	/// Cancel all current and future `next()` calls.
+	///
+	/// Terminal: the subscription is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -331,6 +331,9 @@ impl MoqOriginDynamic {
 	}
 
 	/// Cancel all current and future `requested_broadcast()` calls.
+	///
+	/// Terminal: the dynamic origin is released here, not when the handle is, so any pending
+	/// request is rejected.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -389,6 +392,8 @@ impl MoqAnnounced {
 	}
 
 	/// Cancel all current and future `next()` calls.
+	///
+	/// Terminal: the announcement stream is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -419,6 +424,8 @@ impl MoqAnnouncedBroadcast {
 	}
 
 	/// Cancel all current and future `available()` calls.
+	///
+	/// Terminal: the announcement watch is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -499,6 +499,9 @@ impl MoqBroadcastDynamic {
 	}
 
 	/// Cancel all current and future `requested_track()` calls.
+	///
+	/// Terminal: the dynamic broadcast is released here, not when the handle is, so any pending
+	/// request is rejected.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -519,6 +522,9 @@ impl MoqTrackDynamic {
 	}
 
 	/// Cancel all current and future `requested_group()` calls.
+	///
+	/// Terminal: the dynamic track is released here, not when the handle is, so any pending
+	/// fetch is rejected.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/server.rs
+++ b/rs/moq-ffi/src/server.rs
@@ -148,10 +148,14 @@ impl MoqServer {
 	/// WebTransport's `serverCertificateHashes`. Returns an error if called
 	/// before `listen()`.
 	pub fn cert_fingerprints(&self) -> Result<Vec<String>, MoqError> {
-		let state = self
-			.task
-			.lock()
-			.ok_or_else(|| MoqError::Bind("server is busy or cancelled".into()))?;
+		// `lock` folds "busy" and "cancelled" into one `None`, so ask which. A cancelled server
+		// is a shutdown, and the wrappers' `is_shutdown` helpers only recognize it by variant.
+		let Some(state) = self.task.lock() else {
+			return Err(match self.task.is_cancelled() {
+				true => MoqError::Cancelled,
+				false => MoqError::Bind("server is busy".into()),
+			});
+		};
 		let server = state
 			.server
 			.as_ref()
@@ -162,7 +166,7 @@ impl MoqServer {
 	/// Cancel any in-flight `listen()` or `accept()` call.
 	///
 	/// Terminal: the listening socket is closed here, not when the handle is, and
-	/// `cert_fingerprints()` errors afterwards.
+	/// `cert_fingerprints()` returns `Cancelled` afterwards.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/server.rs
+++ b/rs/moq-ffi/src/server.rs
@@ -151,7 +151,7 @@ impl MoqServer {
 		let state = self
 			.task
 			.lock()
-			.ok_or_else(|| MoqError::Bind("server is busy".into()))?;
+			.ok_or_else(|| MoqError::Bind("server is busy or cancelled".into()))?;
 		let server = state
 			.server
 			.as_ref()
@@ -160,6 +160,9 @@ impl MoqServer {
 	}
 
 	/// Cancel any in-flight `listen()` or `accept()` call.
+	///
+	/// Terminal: the listening socket is closed here, not when the handle is, and
+	/// `cert_fingerprints()` errors afterwards.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}
@@ -281,6 +284,9 @@ impl MoqRequest {
 	}
 
 	/// Cancel any in-flight `accept()` or `reject()` call.
+	///
+	/// Terminal: an unanswered request is dropped here rather than when the handle is, which
+	/// rejects the session.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -329,6 +329,9 @@ impl MoqClient {
 	}
 
 	/// Cancel all current and future `connect()` calls.
+	///
+	/// Terminal: the client's configuration and wired origins are released here, not when the
+	/// handle is, so this client can't dial again.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -1956,6 +1956,27 @@ async fn server_cert_fingerprints_available_after_listen() {
 }
 
 #[tokio::test]
+async fn server_cert_fingerprints_rejected_after_cancel() {
+	let server = MoqServer::new();
+	server.set_bind("127.0.0.1:0".into()).unwrap();
+	server.set_tls_generate(vec!["localhost".into()]);
+
+	tokio::time::timeout(TIMEOUT, server.listen())
+		.await
+		.expect("listen timed out")
+		.expect("listen failed");
+	server.cert_fingerprints().expect("fingerprints available");
+
+	// The listener is dropped off-thread, so this must not depend on that landing first:
+	// cancel is terminal the moment it returns.
+	server.cancel();
+	assert!(matches!(
+		server.cert_fingerprints(),
+		Err(crate::error::MoqError::Bind(_))
+	));
+}
+
+#[tokio::test]
 async fn request_double_respond_returns_already_responded() {
 	use crate::error::MoqError;
 

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -1968,11 +1968,12 @@ async fn server_cert_fingerprints_rejected_after_cancel() {
 	server.cert_fingerprints().expect("fingerprints available");
 
 	// The listener is dropped off-thread, so this must not depend on that landing first:
-	// cancel is terminal the moment it returns.
+	// cancel is terminal the moment it returns. `Cancelled`, not `Bind`: the wrappers'
+	// `is_shutdown` helpers read the variant to tell a teardown from a real bind failure.
 	server.cancel();
 	assert!(matches!(
 		server.cert_fingerprints(),
-		Err(crate::error::MoqError::Bind(_))
+		Err(crate::error::MoqError::Cancelled)
 	));
 }
 

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -404,8 +404,7 @@ impl MoqVideoConsumer {
 
 	/// Make current and future reads return `Cancelled`.
 	///
-	/// The decoder backend is released when this object is dropped, not here: a cancelled consumer
-	/// that stays reachable keeps its codec session. Drop it to free one.
+	/// Terminal: the decoder session is released here, not when the handle is.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}


### PR DESCRIPTION
Closes #2932.

## Summary

- **Root cause**: `crate::ffi::Task::cancel` only flipped a `watch` flag. `Task` holds `Arc<Mutex<T>>`, so the inner state (and anything it owns) stayed alive until the whole UniFFI object was destroyed. A cancelled-but-still-reachable handle is the normal shape after a task/context cancellation in Python, Swift, Kotlin, and Go, so `MoqAudioConsumer` / `MoqVideoConsumer` each pinned a hardware codec session until the foreign GC got around to it. Repeat it and the backend hits its session limit.
- `Task` now holds `Option<T>` and `cancel` takes it. The take waits for any in-flight `run` to observe the flag and unwind, so it is not synchronous with the call; it also lands on the runtime thread, which is where the state was built and the only place with a reactor for what it unregisters.
- Because the take is scheduled rather than synchronous, `lock` reads the cancel flag under the lock instead of inferring cancellation from the state being `None`. `cancel` publishes the flag before it queues for that same lock, so a cancel not seen under the guard cannot have taken the state either. Without this, `MoqServer::cert_fingerprints()` still answered for a moment after `cancel()`.
- `run` and `lock` map the guard through the `Option`, so a call that reaches a released state returns `Cancelled` rather than unwrapping. The `Option` is what makes running against a released state unrepresentable instead of merely documented.
- `cert_fingerprints()` asks `Task::is_cancelled` on its failure path, so a cancelled server returns `Cancelled` rather than `Bind`. Both wrappers classify a graceful shutdown purely by variant (`IsShutdown` in `go/wrapper/moq/errors.go`, `is_shutdown` in `py/moq-rs/moq/errors.py`, each matching only `Cancelled` and `Closed`), so without this an ordinary teardown read as a bind failure.
- #2930 had corrected `MoqVideoConsumer::cancel`'s doc to describe the old behavior; that doc (and every other `cancel()` on the FFI surface) now says the resource is released here rather than when the handle is.
- Declared the tokio features moq-ffi actually uses (`net`, `rt`, `sync`, `time`) instead of relying on unification from `moq-tokio`.

## Behavior changes

`cancel()` was already terminal for reads (`run` returned `Cancelled` forever). It is now terminal for the *state* too, which is observable beyond the media consumers:

- `MoqServer::cancel()` closes the listening socket instead of holding the port until the handle is released. `cert_fingerprints()` returns `Cancelled` afterwards. Sessions already accepted are unaffected (verified, see the test plan).
- `MoqRequest::cancel()` drops an unanswered request, which rejects the handshake (`moq_net::Request`'s `Drop` does this when neither `ok` nor `close` ran).
- `MoqClient::cancel()` releases the client's config and wired origins, so it can't dial again.
- Setters guarded by `if let Some(state) = task.lock()` no-op after cancel, as they already did while a call was in flight.

The Swift and Kotlin wrapper docs already promised `cancel()` "releases native resources"; this makes that true.

## Public API changes

None. `Task` is `pub(crate)`; no exported UniFFI signature moved, and nothing was added or removed. Only doc comments changed on the exported surface, plus the error variant `cert_fingerprints()` returns for a cancelled server.

## Base branch

Targeting `dev` rather than `main` despite being a non-breaking fix: `MoqVideoConsumer` and the doc it corrects only exist on `dev` (landed in #2930), and `rs/moq-ffi` has diverged substantially between the two branches. A `main`-targeted version would be an incomplete fix for the reported issue. Rebased onto `dev` after #2936 landed.

## Cross-Package Sync

- `{py,swift,kt}/` and `go/wrapper` bindings are generated from `moq-ffi` at build time (gitignored), so the new docs propagate without an edit.
- `rs/libmoq` does not depend on `moq-ffi` and has its own `*_close` + terminal-callback lifecycle (`doc/lib/c/index.md`), which already frees on shutdown. No change.
- `doc/lib/{py,swift,kt,go,c}` needed no edit: none of them documented the old "cancel keeps the session" behavior, and the two that mention it already described the new one.

## Test plan

Six regression tests, each verified to fail against the old behavior (by reverting the take, and separately the flag check, and re-running).

In `rs/moq-ffi/src/ffi.rs`, over a drop-reporting state:

- the drop happens on cancel when idle, and when a `run` is parked holding the lock
- a later `run` returns `Cancelled` without calling the closure
- `lock()` is empty with no await between it and `cancel()`, so the answer can't depend on whether the scheduled take has run
- a double cancel is a no-op

In `rs/moq-ffi/src/test.rs`, at the FFI surface:

- `cert_fingerprints()` returns `Cancelled` immediately after `MoqServer::cancel()`

Also verified out-of-band, with a scratch test that was not kept: an already-accepted session survives `MoqServer::cancel()` now that it drops the listener. Cancelling the server the instant both sides hold the session still completes the full announce -> catalog -> media-frame roundtrip, which is what `py/moq-rs`'s `Server` docstring promises.

Suites, run on the rebased tree:

- `just check` (clippy, py, kt, swift build + `swift test`, go `vet`/`build`/`test -race`) - pass
- `just test` (78 moq-ffi tests, 52 Python wrapper tests) - pass

(written by Opus 5)