### PR TITLE
fix(ffi)!: carry the rendition's broadcast reference across the FFI

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -249,7 +249,7 @@ if (moq_consume_video_stalled(catalog, index, &stalled) < 0) {
 
 A catalog rendition may name a *different* broadcast than the one whose catalog you subscribed to, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `moq_consume_video` and `moq_consume_audio` take a catalog snapshot and a rendition index, so they follow that reference for you and subscribe wherever the track really is. Nothing to pass.
 
-The reference is resolved through the origin the broadcast came from, so it only works for a broadcast obtained via `moq_origin_request` or `moq_origin_consume_announced`.
+Only a rendition that actually names another broadcast needs an origin to fetch it from, and the origin used is the one the broadcast came from: `moq_origin_request` or `moq_origin_consume_announced`. A rendition with no reference is served by the broadcast you already hold, so it works the same either way.
 
 ## Raw media
 

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -245,6 +245,12 @@ if (moq_consume_video_stalled(catalog, index, &stalled) < 0) {
 }
 ```
 
+## Cross-broadcast renditions
+
+A catalog rendition may name a *different* broadcast than the one whose catalog you subscribed to, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `moq_consume_video` and `moq_consume_audio` take a catalog snapshot and a rendition index, so they follow that reference for you and subscribe wherever the track really is. Nothing to pass.
+
+The reference is resolved through the origin the broadcast came from, so it only works for a broadcast obtained via `moq_origin_request` or `moq_origin_consume_announced`.
+
 ## Raw media
 
 The `moq_publish_audio` / `moq_publish_video` / `moq_publish_container` calls carry already-encoded frames, for a caller that brings its own codec. The `moq_encode_*` calls carry uncompressed media instead and run the codec inside libmoq, so a C application can publish pixels and PCM without linking one.

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -249,7 +249,7 @@ if (moq_consume_video_stalled(catalog, index, &stalled) < 0) {
 
 A catalog rendition may name a *different* broadcast than the one whose catalog you subscribed to, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `moq_consume_video` and `moq_consume_audio` take a catalog snapshot and a rendition index, so they follow that reference for you and subscribe wherever the track really is. Nothing to pass.
 
-Only a rendition that actually names another broadcast needs an origin to fetch it from, and the origin used is the one the broadcast came from: `moq_origin_request` or `moq_origin_consume_announced`. A rendition with no reference is served by the broadcast you already hold, so it works the same either way.
+Only a rendition that actually names another broadcast needs an origin to fetch it from, and the origin used is the one the broadcast came from: `moq_origin_request` or `moq_origin_consume_announced`. A rendition with no reference is served by the broadcast you already hold, so it works the same either way. A referenced broadcast that exists but has not been announced yet is reported as unroutable rather than waited for, so wait for its announcement first if you may be racing it.
 
 ## Raw media
 

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -310,7 +310,7 @@ The track is named after the codec (`.avc3` / `.hev1`) and its catalog rendition
 
 ## Cross-broadcast renditions
 
-A catalog rendition may name a *different* broadcast: `Video.Broadcast` / `Audio.Broadcast` is a path relative to the broadcast the catalog came from, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `DecodeAudio` and `DecodeVideo` follow it for you. `SubscribeMedia`, `SubscribeTrack`, and `FetchGroup` take a track name rather than a rendition, so resolve first:
+A catalog rendition may name a *different* broadcast: `Video.Broadcast` / `Audio.Broadcast` is a path relative to the broadcast the catalog came from, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `DecodeAudio` and `DecodeVideo` follow it for you. `SubscribeMedia`, `SubscribeTrack`, `FetchGroup`, and `FetchMediaGroup` take a track name rather than a rendition, so resolve first:
 
 ```go
 source, err := broadcast.Resolve(rendition.Broadcast)

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -320,7 +320,7 @@ if err != nil {
 consumer, err := source.SubscribeMedia(name, rendition.Container, nil)
 ```
 
-`Resolve(nil)` (or an empty reference) returns the same broadcast, so it is safe to call unconditionally. It needs an origin to fetch a sibling from, so it fails on a broadcast consumed straight from a local producer.
+`Resolve(nil)` (or an empty reference) returns the same broadcast, so it is safe to call unconditionally. It needs an origin to fetch a sibling from, so it fails on a broadcast consumed straight from a local producer. `Resolve` reports a sibling that exists but has not been announced yet as unroutable rather than waiting for it, so await the referenced broadcast's announcement first if you may be racing it.
 
 ## Raw Track Controls
 

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -304,10 +304,23 @@ for frame, err := range video.Frames(ctx) {
 
 An unrecognized codec fails at `DecodeVideo` itself; a recognized one no native backend handles fails when the decoder opens. Either way you find out before the first frame.
 
-
 `AutoEncoder()` prefers a hardware encoder and falls back to software; `SoftwareEncoder()`, `HardwareEncoder()`, and `NamedEncoder("videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), and openh264 (software, everywhere); the Linux hardware codecs are a libmoq-only build option. `SetBitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
 The track is named after the codec (`.avc3` / `.hev1`) and its catalog rendition is published immediately, read out of the encoder itself, so subscribers discover it through the catalog rather than a name you pick, and can find it before the first frame exists. `Cut()` starts a new group at the next frame, which is optional: the encoder keyframes every `Gop` frames on its own, and each of those cuts a group.
+
+## Cross-broadcast renditions
+
+A catalog rendition may name a *different* broadcast: `Video.Broadcast` / `Audio.Broadcast` is a path relative to the broadcast the catalog came from, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `DecodeAudio` and `DecodeVideo` follow it for you. `SubscribeMedia`, `SubscribeTrack`, and `FetchGroup` take a track name rather than a rendition, so resolve first:
+
+```go
+source, err := broadcast.Resolve(rendition.Broadcast)
+if err != nil {
+    // handle error
+}
+consumer, err := source.SubscribeMedia(name, rendition.Container, nil)
+```
+
+`Resolve(nil)` (or an empty reference) returns the same broadcast, so it is safe to call unconditionally. It needs an origin to fetch a sibling from, so it fails on a broadcast consumed straight from a local producer.
 
 ## Raw Track Controls
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -115,7 +115,7 @@ track.update(Subscription(priority = 20u.toUByte(), ordered = false))
 
 `ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
 
-A catalog rendition may name a *different* broadcast: `MoqVideo.broadcast` / `MoqAudio.broadcast` is a path relative to the broadcast the catalog came from, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `decodeAudio` and `decodeVideo` follow it for you. `subscribeMedia`, `subscribeTrack`, and `fetchGroup` take a track name rather than a rendition, so resolve first:
+A catalog rendition may name a *different* broadcast: `MoqVideo.broadcast` / `MoqAudio.broadcast` is a path relative to the broadcast the catalog came from, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `decodeAudio` and `decodeVideo` follow it for you. `subscribeMedia`, `subscribeTrack`, `fetchGroup`, and `fetchMediaGroup` take a track name rather than a rendition, so resolve first:
 
 ```kotlin
 val source = announcement.broadcast().resolve(rendition.broadcast)

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -115,6 +115,15 @@ track.update(Subscription(priority = 20u.toUByte(), ordered = false))
 
 `ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
 
+A catalog rendition may name a *different* broadcast: `MoqVideo.broadcast` / `MoqAudio.broadcast` is a path relative to the broadcast the catalog came from, so a transcode output at `live/hd` can describe a track that actually lives in `live/source`. `decodeAudio` and `decodeVideo` follow it for you. `subscribeMedia`, `subscribeTrack`, and `fetchGroup` take a track name rather than a rendition, so resolve first:
+
+```kotlin
+val source = announcement.broadcast().resolve(rendition.broadcast)
+val consumer = source.subscribeMedia(name, rendition.container)
+```
+
+`resolve(null)` (or an empty reference) returns the same broadcast, so it is safe to call unconditionally. It needs an origin to fetch a sibling from, so it throws on a broadcast consumed straight from a local producer.
+
 ## Publish
 
 ```kotlin

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -122,7 +122,7 @@ val source = announcement.broadcast().resolve(rendition.broadcast)
 val consumer = source.subscribeMedia(name, rendition.container)
 ```
 
-`resolve(null)` (or an empty reference) returns the same broadcast, so it is safe to call unconditionally. It needs an origin to fetch a sibling from, so it throws on a broadcast consumed straight from a local producer.
+`resolve(null)` (or an empty reference) returns the same broadcast, so it is safe to call unconditionally. It needs an origin to fetch a sibling from, so it throws on a broadcast consumed straight from a local producer. `resolve` reports a sibling that exists but has not been announced yet as unroutable rather than waiting for it, so await the referenced broadcast's announcement first if you may be racing it.
 
 ## Publish
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -180,6 +180,25 @@ async for announcement in client.announced("prefix/"):
         ...
 ```
 
+### Cross-broadcast renditions
+
+A catalog rendition may name a *different* broadcast: `track.broadcast` is a path relative to the
+broadcast the catalog came from, so a transcode output at `live/hd` can describe a track that
+actually lives in `live/source`. `decode_audio` and `decode_video` follow it for you. `subscribe_media`,
+`subscribe_track`, and `fetch_group` take a track name rather than a rendition, so resolve first:
+
+```python
+catalog = await announcement.broadcast.catalog()
+track_name, track = next(iter(catalog.video.items()))
+
+source = await announcement.broadcast.resolve(track.broadcast)
+consumer = await source.subscribe_media(track_name, track)
+```
+
+`resolve(None)` (or an empty reference) returns the same broadcast, so it is safe to call
+unconditionally. It needs an origin to fetch a sibling from, so it raises on a broadcast consumed
+straight from a local producer.
+
 ### Catalog extensions
 
 Advertise application-specific metadata (for example a side-channel transcript track) as an untyped catalog section. The value is any JSON-serializable object; it rides alongside `video`/`audio` and reaches subscribers as `Catalog.sections`.

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -185,7 +185,8 @@ async for announcement in client.announced("prefix/"):
 A catalog rendition may name a *different* broadcast: `track.broadcast` is a path relative to the
 broadcast the catalog came from, so a transcode output at `live/hd` can describe a track that
 actually lives in `live/source`. `decode_audio` and `decode_video` follow it for you. `subscribe_media`,
-`subscribe_track`, and `fetch_group` take a track name rather than a rendition, so resolve first:
+`subscribe_track`, `fetch_group`, and `fetch_media_group` take a track name rather than a rendition,
+so resolve first:
 
 ```python
 catalog = await announcement.broadcast.catalog()

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -199,6 +199,8 @@ consumer = await source.subscribe_media(track_name, track)
 `resolve(None)` (or an empty reference) returns the same broadcast, so it is safe to call
 unconditionally. It needs an origin to fetch a sibling from, so it raises on a broadcast consumed
 straight from a local producer.
+`resolve` reports a sibling that exists but has not been announced yet as unroutable rather than
+waiting for it, so await the referenced broadcast's announcement first if you may be racing it.
 
 ### Catalog extensions
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -142,6 +142,8 @@ let consumer = try await source.subscribeMedia(name: name, container: rendition.
 `resolve(nil)` (or an empty reference) returns the same broadcast, so it is safe to call
 unconditionally. It needs an origin to fetch a sibling from, so it throws on a broadcast consumed
 straight from a local producer.
+`resolve` reports a sibling that exists but has not been announced yet as unroutable rather than
+waiting for it, so await the referenced broadcast's announcement first if you may be racing it.
 
 ## Publish
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -128,6 +128,21 @@ track.update(subscription: Subscription(priority: 20, ordered: false))
 
 `ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
 
+A catalog rendition may name a *different* broadcast: `Video.broadcast` / `Audio.broadcast` is a path
+relative to the broadcast the catalog came from, so a transcode output at `live/hd` can describe a
+track that actually lives in `live/source`. `decodeAudio` and `decodeVideo` follow it for you.
+`subscribeMedia`, `subscribeTrack`, and `fetchGroup` take a track name rather than a rendition, so
+resolve first:
+
+```swift
+let source = try await announcement.broadcast.resolve(rendition.broadcast)
+let consumer = try await source.subscribeMedia(name: name, container: rendition.container)
+```
+
+`resolve(nil)` (or an empty reference) returns the same broadcast, so it is safe to call
+unconditionally. It needs an origin to fetch a sibling from, so it throws on a broadcast consumed
+straight from a local producer.
+
 ## Publish
 
 ```swift

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -131,8 +131,8 @@ track.update(subscription: Subscription(priority: 20, ordered: false))
 A catalog rendition may name a *different* broadcast: `Video.broadcast` / `Audio.broadcast` is a path
 relative to the broadcast the catalog came from, so a transcode output at `live/hd` can describe a
 track that actually lives in `live/source`. `decodeAudio` and `decodeVideo` follow it for you.
-`subscribeMedia`, `subscribeTrack`, and `fetchGroup` take a track name rather than a rendition, so
-resolve first:
+`subscribeMedia`, `subscribeTrack`, `fetchGroup`, and `fetchMediaGroup` take a track name rather than
+a rendition, so resolve first:
 
 ```swift
 let source = try await announcement.broadcast.resolve(rendition.broadcast)

--- a/go/wrapper/moq/subscribe.go
+++ b/go/wrapper/moq/subscribe.go
@@ -94,9 +94,10 @@ func (b *BroadcastConsumer) SubscribeMedia(name string, container Container, sub
 
 // Resolve returns the broadcast serving a catalog rendition, honoring its broadcast
 // reference: Video.Broadcast / Audio.Broadcast. A nil or empty reference names this
-// broadcast, anything else names a sibling relative to it (e.g. "./source"). Call it
-// before SubscribeMedia, SubscribeTrack, or FetchGroup on a rendition that carries one;
-// DecodeAudio and DecodeVideo resolve it themselves.
+// broadcast, anything else names a sibling relative to it (e.g. "./source"). Call it on a
+// rendition that carries one before SubscribeMedia, SubscribeTrack, FetchGroup, or
+// FetchMediaGroup, which take a track name rather than a rendition; DecodeAudio and
+// DecodeVideo resolve it themselves.
 //
 // Errors if this broadcast came from a local producer rather than an origin, since a
 // standalone broadcast has no sibling to name.

--- a/go/wrapper/moq/subscribe.go
+++ b/go/wrapper/moq/subscribe.go
@@ -92,6 +92,22 @@ func (b *BroadcastConsumer) SubscribeMedia(name string, container Container, sub
 	return &MediaConsumer{inner: inner}, nil
 }
 
+// Resolve returns the broadcast serving a catalog rendition, honoring its broadcast
+// reference: Video.Broadcast / Audio.Broadcast. A nil or empty reference names this
+// broadcast, anything else names a sibling relative to it (e.g. "./source"). Call it
+// before SubscribeMedia, SubscribeTrack, or FetchGroup on a rendition that carries one;
+// DecodeAudio and DecodeVideo resolve it themselves.
+//
+// Errors if this broadcast came from a local producer rather than an origin, since a
+// standalone broadcast has no sibling to name.
+func (b *BroadcastConsumer) Resolve(reference *string) (*BroadcastConsumer, error) {
+	inner, err := b.inner.Resolve(reference)
+	if err != nil {
+		return nil, err
+	}
+	return &BroadcastConsumer{inner: inner}, nil
+}
+
 // DecodeAudio subscribes to a raw-audio track; samples come back in the
 // format declared by output. catalogAudio comes from the catalog.
 func (b *BroadcastConsumer) DecodeAudio(name string, catalogAudio Audio, output AudioDecoderOutput) (*AudioConsumer, error) {

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -482,6 +482,22 @@ class BroadcastConsumer:
         container = track if isinstance(track, Container) else track.container
         return MediaConsumer(await self._inner.subscribe_media(name, container, subscription))
 
+    async def resolve(self, reference: str | None) -> "BroadcastConsumer":
+        """Resolve a catalog rendition's ``broadcast`` reference to the broadcast
+        serving its track.
+
+        ``reference`` is ``catalog.video[name].broadcast`` /
+        ``catalog.audio[name].broadcast``: ``None`` or empty names this broadcast,
+        anything else names a sibling relative to it (e.g. ``./source``). Call it
+        before :meth:`subscribe_media`, :meth:`subscribe_track`, or
+        :meth:`fetch_group` on a rendition that carries one; :meth:`decode_audio`
+        and :meth:`decode_video` resolve it themselves.
+
+        Raises if this broadcast came from a local producer rather than an origin,
+        since a standalone broadcast has no sibling to name.
+        """
+        return BroadcastConsumer(await self._inner.resolve(reference))
+
     async def decode_audio(
         self,
         name: str,

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -488,10 +488,11 @@ class BroadcastConsumer:
 
         ``reference`` is ``catalog.video[name].broadcast`` /
         ``catalog.audio[name].broadcast``: ``None`` or empty names this broadcast,
-        anything else names a sibling relative to it (e.g. ``./source``). Call it
-        before :meth:`subscribe_media`, :meth:`subscribe_track`, or
-        :meth:`fetch_group` on a rendition that carries one; :meth:`decode_audio`
-        and :meth:`decode_video` resolve it themselves.
+        anything else names a sibling relative to it (e.g. ``./source``). Call it on
+        a rendition that carries one before :meth:`subscribe_media`,
+        :meth:`subscribe_track`, :meth:`fetch_group`, or :meth:`fetch_media_group`,
+        which take a track name rather than a rendition; :meth:`decode_audio` and
+        :meth:`decode_video` resolve it themselves.
 
         Raises if this broadcast came from a local producer rather than an origin,
         since a standalone broadcast has no sibling to name.

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -10,6 +10,11 @@ use crate::{
 struct ConsumeCatalog {
 	broadcast: moq_net::broadcast::Consumer,
 
+	/// The origin `broadcast` was resolved through, if any. A rendition may name a sibling
+	/// broadcast, and only an origin can fetch one; a broadcast handed over without one (a
+	/// local producer) leaves such a rendition unresolvable rather than silently wrong.
+	origin: Option<moq_net::origin::Consumer>,
+
 	// Carries the untyped `Extra` extension so application catalog sections survive
 	// into `moq_catalog_section_*` instead of being dropped on parse.
 	catalog: moq_mux::catalog::hang::Catalog<moq_mux::catalog::hang::Extra>,
@@ -21,6 +26,38 @@ struct ConsumeCatalog {
 	/// Section names and their JSON, serialized on the heap so the section iterator
 	/// and direct-lookup APIs can hand C borrowed pointers into stable storage.
 	sections: Vec<(String, String)>,
+}
+
+/// A broadcast handed to C, plus the origin cursor that named it.
+///
+/// The origin is what lets a catalog rendition reference a sibling broadcast: only an origin
+/// can fetch one, and it must be the cursor that named this broadcast, since the reference
+/// resolves against the path that cursor stamped. A broadcast that never came from an origin
+/// has none, which makes such a rendition unresolvable rather than silently wrong.
+#[derive(Clone)]
+struct ConsumeBroadcast {
+	broadcast: moq_net::broadcast::Consumer,
+	origin: Option<moq_net::origin::Consumer>,
+}
+
+/// The broadcast serving a rendition, honoring its catalog `broadcast` reference.
+///
+/// An absent or empty reference names the catalog's own broadcast, which the caller already
+/// holds; anything else resolves against that broadcast's path through the origin, which
+/// deduplicates the subscription the catalog itself already holds. Awaited inside the track
+/// task, never under the state lock, so `origin` is cloned out rather than borrowed.
+async fn resolve(
+	broadcast: moq_net::broadcast::Consumer,
+	origin: Option<moq_net::origin::Consumer>,
+	reference: Option<moq_net::PathRelativeOwned>,
+) -> Result<moq_net::broadcast::Consumer, Error> {
+	let Some(reference) = reference.filter(|reference| !reference.is_empty()) else {
+		return Ok(broadcast);
+	};
+
+	let origin = origin.ok_or_else(|| Error::UnresolvableBroadcast(reference.as_str().to_string()))?;
+	let source = moq_mux::Source::new(origin, &broadcast.info().path);
+	Ok(source.resolve(Some(&reference.borrow())).await?)
 }
 
 /// A spawned task entry: `close` signals shutdown, `callback` delivers status.
@@ -54,7 +91,7 @@ enum RawStep<T> {
 #[derive(Default)]
 pub struct Consume {
 	/// Active broadcast consumers.
-	broadcast: NonZeroSlab<moq_net::broadcast::Consumer>,
+	broadcast: NonZeroSlab<ConsumeBroadcast>,
 
 	/// Active catalog consumers and their broadcast references.
 	catalog: NonZeroSlab<ConsumeCatalog>,
@@ -88,12 +125,19 @@ pub struct Consume {
 }
 
 impl Consume {
-	pub fn start(&mut self, broadcast: moq_net::broadcast::Consumer) -> Result<Id, Error> {
-		self.broadcast.insert(broadcast)
+	/// Buffer a broadcast the origin handed out, keeping the cursor that named it so a catalog
+	/// rendition referencing a sibling broadcast resolves through the same origin.
+	pub fn start(
+		&mut self,
+		broadcast: moq_net::broadcast::Consumer,
+		origin: Option<moq_net::origin::Consumer>,
+	) -> Result<Id, Error> {
+		self.broadcast.insert(ConsumeBroadcast { broadcast, origin })
 	}
 
 	pub fn catalog(&mut self, broadcast: Id, on_catalog: OnStatus) -> Result<Id, Error> {
-		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
+		let ConsumeBroadcast { broadcast, origin } =
+			self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
 
 		let channel = oneshot::channel();
 		let entry = TaskEntry {
@@ -110,7 +154,7 @@ impl Consume {
 					.track(hang::catalog::Catalog::DEFAULT_NAME)?
 					.subscribe(hang::catalog::Catalog::default_subscription())
 					.await?;
-				Self::run_catalog(on_catalog, broadcast.clone(), catalog.into(), channel.1).await
+				Self::run_catalog(on_catalog, broadcast.clone(), origin, catalog.into(), channel.1).await
 			}
 			.await;
 
@@ -128,6 +172,7 @@ impl Consume {
 	async fn run_catalog(
 		callback: OnStatus,
 		broadcast: moq_net::broadcast::Consumer,
+		origin: Option<moq_net::origin::Consumer>,
 		mut catalog: moq_mux::catalog::hang::Consumer<moq_mux::catalog::hang::Extra>,
 		mut close: oneshot::Receiver<()>,
 	) -> Result<(), Error> {
@@ -168,6 +213,7 @@ impl Consume {
 
 			let snapshot = ConsumeCatalog {
 				broadcast: broadcast.clone(),
+				origin: origin.clone(),
 				catalog: update,
 				audio_codec,
 				video_codec,
@@ -365,7 +411,11 @@ impl Consume {
 		// instead of assuming Legacy, otherwise CMAF/fMP4 sources (e.g. ffmpeg moqenc,
 		// browser @moq/publish) are misread as raw frames.
 		let container = moq_mux::catalog::hang::Container::try_from(&config.container)?;
+		// The rendition may live in a sibling broadcast, so resolve its reference rather than
+		// assuming the catalog's own broadcast serves the track.
+		let reference = config.broadcast.clone();
 		let broadcast = consume.broadcast.clone();
+		let origin = consume.origin.clone();
 
 		let channel = oneshot::channel();
 		let entry = TaskEntry {
@@ -377,6 +427,7 @@ impl Consume {
 		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task.
 		tokio::spawn(async move {
 			let res = async move {
+				let broadcast = resolve(broadcast, origin, reference).await?;
 				let track = broadcast
 					.track(&name)?
 					.subscribe(
@@ -418,7 +469,9 @@ impl Consume {
 			.ok_or(Error::NoIndex)?;
 		let name = name.clone();
 		let container = moq_mux::catalog::hang::Container::try_from(&config.container)?;
+		let reference = config.broadcast.clone();
 		let broadcast = consume.broadcast.clone();
+		let origin = consume.origin.clone();
 
 		let channel = oneshot::channel();
 		let entry = TaskEntry {
@@ -430,6 +483,7 @@ impl Consume {
 		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task.
 		tokio::spawn(async move {
 			let res = async move {
+				let broadcast = resolve(broadcast, origin, reference).await?;
 				let track = broadcast
 					.track(&name)?
 					.subscribe(
@@ -529,7 +583,12 @@ impl Consume {
 		subscription: Option<moq_net::track::Subscription>,
 		on_frame: OnStatus,
 	) -> Result<Id, Error> {
-		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
+		let broadcast = self
+			.broadcast
+			.get(broadcast)
+			.ok_or(Error::BroadcastNotFound)?
+			.broadcast
+			.clone();
 		let name = name.to_string();
 
 		let channel = oneshot::channel();
@@ -723,7 +782,12 @@ impl Consume {
 	/// `on_datagram` is called with a datagram ID for each datagram in arrival order;
 	/// each must be released with [`Self::datagram_close`].
 	pub fn datagram_track(&mut self, broadcast: Id, name: &str, on_datagram: OnStatus) -> Result<Id, Error> {
-		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
+		let broadcast = self
+			.broadcast
+			.get(broadcast)
+			.ok_or(Error::BroadcastNotFound)?
+			.broadcast
+			.clone();
 		let name = name.to_string();
 
 		let channel = oneshot::channel();
@@ -837,7 +901,12 @@ impl Consume {
 		config: moq_json::snapshot::ConsumerConfig,
 		on_value: OnStatus,
 	) -> Result<Id, Error> {
-		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
+		let broadcast = self
+			.broadcast
+			.get(broadcast)
+			.ok_or(Error::BroadcastNotFound)?
+			.broadcast
+			.clone();
 		let name = name.to_string();
 
 		let channel = oneshot::channel();
@@ -901,7 +970,12 @@ impl Consume {
 		config: moq_json::stream::ConsumerConfig,
 		on_value: OnStatus,
 	) -> Result<Id, Error> {
-		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
+		let broadcast = self
+			.broadcast
+			.get(broadcast)
+			.ok_or(Error::BroadcastNotFound)?
+			.broadcast
+			.clone();
 		let name = name.to_string();
 
 		let channel = oneshot::channel();

--- a/rs/libmoq/src/error.rs
+++ b/rs/libmoq/src/error.rs
@@ -158,6 +158,11 @@ pub enum Error {
 	/// A client configuration value could not be parsed or initialized.
 	#[error("invalid config: {0}")]
 	InvalidConfig(String),
+
+	/// A catalog rendition named another broadcast, but the broadcast it came from was not
+	/// resolved through an origin, so there is nothing to resolve the reference against.
+	#[error("unresolvable broadcast reference: {0}")]
+	UnresolvableBroadcast(String),
 }
 
 impl From<moq_json::Error> for Error {
@@ -236,6 +241,7 @@ impl ffi::ReturnCode for Error {
 			Error::Json(_) => -37,
 			Error::JsonTrack(_) => -38,
 			Error::InvalidConfig(_) => -40,
+			Error::UnresolvableBroadcast(_) => -41,
 		}
 	}
 }

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -175,7 +175,7 @@ impl Origin {
 		};
 
 		// Hold the lock only to buffer the broadcast; release it before the callback.
-		let broadcast_id = State::lock().consume.start(broadcast)?;
+		let broadcast_id = State::lock().consume.start(broadcast, Some(consumer))?;
 		callback.call(broadcast_id);
 		Ok(())
 	}
@@ -230,7 +230,7 @@ impl Origin {
 		};
 
 		// Hold the lock only to buffer the broadcast; release it before the callback.
-		let broadcast_id = State::lock().consume.start(broadcast)?;
+		let broadcast_id = State::lock().consume.start(broadcast, Some(consumer))?;
 		callback.call(broadcast_id);
 		Ok(())
 	}

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -2074,6 +2074,103 @@ fn consume_announced_local() {
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
+/// A catalog rendition may name a sibling broadcast (`./source`), and the track then lives
+/// there, not on the broadcast the catalog came from. Ignoring the reference subscribes on the
+/// catalog's own broadcast: `NotFound`, or a same-named local track with mismatched metadata.
+#[test]
+fn consume_audio_follows_a_sibling_broadcast_reference() {
+	let origin = id(moq_origin_create());
+
+	// Only the sibling serves the track; the catalog broadcast just describes it.
+	let source = publish_broadcast(origin, b"a/source");
+	let init = opus_head();
+	let media = id(publish_audio(
+		source,
+		moq_audio_format::MOQ_AUDIO_FORMAT_OPUS,
+		&init,
+		None,
+	));
+
+	// The importer picks the track name, and the catalog rendition must key on the same one.
+	let name = {
+		let mut state = State::lock();
+		let (_, catalog) = state.publish.pair_mut(Id::try_from(source).unwrap()).unwrap();
+		let catalog = catalog.lock();
+		catalog
+			.audio
+			.renditions
+			.keys()
+			.next()
+			.expect("the importer publishes one audio rendition")
+			.clone()
+	};
+
+	let broadcast = publish_broadcast(origin, b"a/pub");
+	let codec = "opus";
+	let config = moq_audio_config {
+		name: name.as_ptr() as *const c_char,
+		name_len: name.len(),
+		label: std::ptr::null(),
+		label_len: 0,
+		codec: codec.as_ptr() as *const c_char,
+		codec_len: codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 48000,
+		channel_count: 2,
+		container: moq_container::default(),
+	};
+	assert_eq!(unsafe { moq_publish_audio_config(broadcast, &config) }, 0);
+
+	// The C config struct has no broadcast field, so point the rendition at the sibling here.
+	{
+		let mut state = State::lock();
+		let (_, catalog) = state.publish.pair_mut(Id::try_from(broadcast).unwrap()).unwrap();
+		catalog.lock().audio.renditions.get_mut(&name).unwrap().broadcast =
+			Some(moq_net::PathRelative::new("./source").into_owned());
+	}
+
+	let consume = request_broadcast(origin, b"a/pub");
+	let catalog_cb = Callback::new();
+	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
+	let catalog_id = id(catalog_cb.recv());
+
+	let frame_cb = Callback::new();
+	let track = id(unsafe { moq_consume_audio(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
+
+	// Published on the sibling, so it only arrives if the reference was followed.
+	let payload = b"opus audio payload data";
+	let timestamp_us: u64 = 1_000_000;
+	assert_eq!(
+		unsafe { moq_publish_media_frame(media, payload.as_ptr(), payload.len(), timestamp_us) },
+		0
+	);
+
+	let frame_id = id(frame_cb.recv());
+	let mut frame = moq_frame {
+		payload: std::ptr::null(),
+		payload_size: 0,
+		timestamp_us: 0,
+		keyframe: false,
+	};
+	assert_eq!(unsafe { moq_consume_frame(frame_id, &mut frame) }, 0);
+	let received = unsafe { std::slice::from_raw_parts(frame.payload, frame.payload_size) };
+	assert_eq!(received, payload, "the sibling broadcast's frame should arrive");
+	assert_eq!(frame.timestamp_us, timestamp_us);
+
+	assert_eq!(moq_consume_frame_free(frame_id), 0);
+	assert_eq!(moq_consume_audio_close(track), 0);
+	assert_eq!(frame_cb.recv_terminal(), 0, "audio close delivers terminal 0");
+	assert_eq!(moq_consume_catalog_free(catalog_id), 0);
+	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
+	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
+	assert_eq!(moq_consume_close(consume), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
+	assert_eq!(moq_publish_finish(source), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
 #[test]
 fn consume_announced_close_cancels() {
 	let origin = id(moq_origin_create());

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -264,8 +264,11 @@ impl MoqBroadcastConsumer {
 		catalog_audio: crate::media::MoqAudio,
 		output: MoqAudioDecoderOutput,
 	) -> Result<Arc<MoqAudioConsumer>, MoqError> {
-		let broadcast = self.resolve_inner(catalog_audio.broadcast.as_deref()).await?;
+		// Reject the codec before resolving: resolving reaches the origin, which can invoke a
+		// dynamic handler and open an upstream subscription we would immediately drop.
+		let reference = catalog_audio.broadcast.clone();
 		let cfg = audio_config(catalog_audio)?;
+		let broadcast = self.resolve_inner(reference.as_deref()).await?;
 
 		let mut config = moq_audio::decode::Config::default();
 		config.format = output.format.into();

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -255,12 +255,16 @@ impl MoqBroadcastConsumer {
 	/// the catalog (see
 	/// [`MoqCatalogConsumer::next`](crate::consumer::MoqCatalogConsumer::next));
 	/// the codec is inferred from it. Only Opus is currently supported.
+	///
+	/// A rendition whose [`broadcast`](crate::media::MoqAudio::broadcast) names another broadcast
+	/// is subscribed there, so `name` is always read from the broadcast the catalog points at.
 	pub async fn decode_audio(
 		&self,
 		name: String,
 		catalog_audio: crate::media::MoqAudio,
 		output: MoqAudioDecoderOutput,
 	) -> Result<Arc<MoqAudioConsumer>, MoqError> {
+		let broadcast = self.resolve_inner(catalog_audio.broadcast.as_deref()).await?;
 		let cfg = audio_config(catalog_audio)?;
 
 		let mut config = moq_audio::decode::Config::default();
@@ -272,7 +276,7 @@ impl MoqBroadcastConsumer {
 			.map(|ms| moq_mux::Latency::max(Duration::from_millis(ms)))
 			.unwrap_or_default();
 
-		let consumer = moq_audio::decode::Consumer::new(self.inner(), &cfg, name, config).await?;
+		let consumer = moq_audio::decode::Consumer::new(&broadcast, &cfg, name, config).await?;
 
 		Ok(Arc::new(MoqAudioConsumer {
 			task: Task::new(ConsumerInner { consumer }),
@@ -288,6 +292,7 @@ mod tests {
 	fn catalog_audio(codec: &str) -> MoqAudio {
 		MoqAudio {
 			label: None,
+			broadcast: None,
 			codec: codec.to_string(),
 			description: None,
 			sample_rate: 48_000,

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -136,6 +136,10 @@ impl MoqBroadcastConsumer {
 		&self,
 		reference: Option<&str>,
 	) -> Result<moq_net::broadcast::Consumer, MoqError> {
+		// Normalize before testing emptiness: this is a caller-supplied string, and one made only
+		// of slashes normalizes to the empty reference, which names this broadcast.
+		let reference = reference.map(moq_net::PathRelative::new);
+
 		// An absent or empty reference names the catalog's own broadcast, which we already hold.
 		// Short-circuiting also keeps a standalone broadcast usable: the common case needs no origin.
 		let Some(reference) = reference.filter(|reference| !reference.is_empty()) else {
@@ -145,10 +149,10 @@ impl MoqBroadcastConsumer {
 		let origin = self
 			.origin
 			.clone()
-			.ok_or_else(|| MoqError::UnresolvableBroadcast(reference.to_string()))?;
+			.ok_or_else(|| MoqError::UnresolvableBroadcast(reference.as_str().to_string()))?;
 
 		let source = moq_mux::Source::new(origin, &self.inner.info().path);
-		Ok(source.resolve(Some(&moq_net::PathRelative::new(reference))).await?)
+		Ok(source.resolve(Some(&reference)).await?)
 	}
 }
 
@@ -254,7 +258,9 @@ impl MoqBroadcastConsumer {
 	/// rendition; `decode_video` and `decode_audio` resolve it themselves.
 	///
 	/// Errors if this broadcast came from a local producer rather than an origin, since a
-	/// standalone broadcast has no sibling to name.
+	/// standalone broadcast has no sibling to name, and reports a sibling that exists but is not
+	/// announced yet as unroutable rather than waiting for it (see
+	/// [`MoqOriginConsumer::request_broadcast`](crate::origin::MoqOriginConsumer::request_broadcast)).
 	pub async fn resolve(&self, reference: Option<String>) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
 		let broadcast = self.resolve_inner(reference.as_deref()).await?;
 		Ok(Arc::new(match self.origin.clone() {

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -248,9 +248,10 @@ impl MoqBroadcastConsumer {
 	/// Resolve a catalog rendition's `broadcast` reference to the broadcast serving its track.
 	///
 	/// `reference` is [`MoqVideo::broadcast`] / [`MoqAudio::broadcast`]: absent or empty names
-	/// this broadcast, anything else names a sibling relative to it (e.g. `./source`). Call it
-	/// before [`Self::subscribe_media`], [`Self::subscribe_track`], or [`Self::fetch_group`] on
-	/// a rendition that carries one; `decode_video` and `decode_audio` resolve it themselves.
+	/// this broadcast, anything else names a sibling relative to it (e.g. `./source`). Call it on a
+	/// rendition that carries one before [`Self::subscribe_media`], [`Self::subscribe_track`],
+	/// [`Self::fetch_group`], or [`Self::fetch_media_group`], which take a track name rather than a
+	/// rendition; `decode_video` and `decode_audio` resolve it themselves.
 	///
 	/// Errors if this broadcast came from a local producer rather than an origin, since a
 	/// standalone broadcast has no sibling to name.

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -100,17 +100,55 @@ impl From<MoqSubscription> for moq_net::track::Subscription {
 #[derive(Clone, uniffi::Object)]
 pub struct MoqBroadcastConsumer {
 	inner: moq_net::broadcast::Consumer,
+	/// The origin this broadcast was resolved through, if any. A catalog rendition may name a
+	/// sibling broadcast, and only an origin can fetch one; a standalone broadcast (a local
+	/// producer's `consume`) has none, so such a rendition is unresolvable rather than wrong.
+	origin: Option<moq_net::origin::Consumer>,
 }
 
 impl MoqBroadcastConsumer {
+	/// Wrap a standalone broadcast, with no origin to resolve cross-broadcast references against.
 	pub(crate) fn new(inner: moq_net::broadcast::Consumer) -> Self {
-		Self { inner }
+		Self { inner, origin: None }
+	}
+
+	/// Wrap a broadcast the origin handed out, so a rendition referencing a sibling broadcast
+	/// resolves through the same origin (which deduplicates the shared subscription).
+	///
+	/// `origin` must be the cursor that named `inner`: the broadcast's path is stamped per
+	/// cursor, and a reference resolves against that path, so an origin rooted elsewhere would
+	/// read a legal reference as escaping (or worse, resolve it to the wrong broadcast).
+	pub(crate) fn routed(inner: moq_net::broadcast::Consumer, origin: moq_net::origin::Consumer) -> Self {
+		Self {
+			inner,
+			origin: Some(origin),
+		}
 	}
 
 	/// Access the underlying `moq_net::broadcast::Consumer` for sibling
 	/// modules (e.g. `audio`) that need to subscribe a typed track.
 	pub(crate) fn inner(&self) -> &moq_net::broadcast::Consumer {
 		&self.inner
+	}
+
+	/// Resolve a catalog rendition's `broadcast` reference to the broadcast serving its track.
+	pub(crate) async fn resolve_inner(
+		&self,
+		reference: Option<&str>,
+	) -> Result<moq_net::broadcast::Consumer, MoqError> {
+		// An absent or empty reference names the catalog's own broadcast, which we already hold.
+		// Short-circuiting also keeps a standalone broadcast usable: the common case needs no origin.
+		let Some(reference) = reference.filter(|reference| !reference.is_empty()) else {
+			return Ok(self.inner.clone());
+		};
+
+		let origin = self
+			.origin
+			.clone()
+			.ok_or_else(|| MoqError::UnresolvableBroadcast(reference.to_string()))?;
+
+		let source = moq_mux::Source::new(origin, &self.inner.info().path);
+		Ok(source.resolve(Some(&moq_net::PathRelative::new(reference))).await?)
 	}
 }
 
@@ -205,6 +243,23 @@ impl MoqBroadcastConsumer {
 				inner: self.inner.clone(),
 			}),
 		})
+	}
+
+	/// Resolve a catalog rendition's `broadcast` reference to the broadcast serving its track.
+	///
+	/// `reference` is [`MoqVideo::broadcast`] / [`MoqAudio::broadcast`]: absent or empty names
+	/// this broadcast, anything else names a sibling relative to it (e.g. `./source`). Call it
+	/// before [`Self::subscribe_media`], [`Self::subscribe_track`], or [`Self::fetch_group`] on
+	/// a rendition that carries one; `decode_video` and `decode_audio` resolve it themselves.
+	///
+	/// Errors if this broadcast came from a local producer rather than an origin, since a
+	/// standalone broadcast has no sibling to name.
+	pub async fn resolve(&self, reference: Option<String>) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
+		let broadcast = self.resolve_inner(reference.as_deref()).await?;
+		Ok(Arc::new(match self.origin.clone() {
+			Some(origin) => Self::routed(broadcast, origin),
+			None => Self::new(broadcast),
+		}))
 	}
 
 	/// Subscribe to the catalog for this broadcast.

--- a/rs/moq-ffi/src/error.rs
+++ b/rs/moq-ffi/src/error.rs
@@ -75,6 +75,11 @@ pub enum MoqError {
 	#[error("invalid route: {0}")]
 	InvalidRoute(String),
 
+	/// A catalog rendition named another broadcast, but this consumer came from a standalone
+	/// broadcast rather than an origin, so there is nothing to resolve the reference against.
+	#[error("unresolvable broadcast reference: {0}")]
+	UnresolvableBroadcast(String),
+
 	#[error("log: {0}")]
 	Log(String),
 }

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -82,6 +82,10 @@ pub struct MoqVideo {
 	/// Human-readable rendition name for track pickers.
 	#[uniffi(default = None)]
 	pub label: Option<String>,
+	/// The broadcast serving this rendition's track, relative to the catalog's own broadcast
+	/// (e.g. `./source`). Absent or empty means the catalog's broadcast.
+	#[uniffi(default = None)]
+	pub broadcast: Option<String>,
 	pub codec: String,
 	pub description: Option<Vec<u8>>,
 	pub coded: Option<MoqDimensions>,
@@ -99,6 +103,10 @@ pub struct MoqAudio {
 	/// Human-readable rendition name for track pickers.
 	#[uniffi(default = None)]
 	pub label: Option<String>,
+	/// The broadcast serving this rendition's track, relative to the catalog's own broadcast
+	/// (e.g. `./source`). Absent or empty means the catalog's broadcast.
+	#[uniffi(default = None)]
+	pub broadcast: Option<String>,
 	pub codec: String,
 	pub description: Option<Vec<u8>>,
 	pub sample_rate: u32,
@@ -346,6 +354,7 @@ pub(crate) fn convert_catalog(catalog: &moq_mux::catalog::hang::Catalog<moq_mux:
 				name.clone(),
 				MoqVideo {
 					label: config.label.clone(),
+					broadcast: config.broadcast.as_ref().map(|path| path.as_str().to_string()),
 					codec: config.codec.to_string(),
 					description: config.description.as_ref().map(|d| d.to_vec()),
 					coded: match (config.coded_width, config.coded_height) {
@@ -374,6 +383,7 @@ pub(crate) fn convert_catalog(catalog: &moq_mux::catalog::hang::Catalog<moq_mux:
 				name.clone(),
 				MoqAudio {
 					label: config.label.clone(),
+					broadcast: config.broadcast.as_ref().map(|path| path.as_str().to_string()),
 					codec: config.codec.to_string(),
 					description: config.description.as_ref().map(|d| d.to_vec()),
 					sample_rate: config.sample_rate,
@@ -421,6 +431,32 @@ mod test {
 		let converted = convert_catalog(&catalog);
 		assert!(!converted.video["active"].stalled);
 		assert!(converted.video["video"].stalled);
+	}
+
+	/// A rendition may name a sibling broadcast, and the track then lives there. Dropping the
+	/// reference here loses it for every binding, which then opens the track on the wrong
+	/// broadcast: `NotFound`, or a same-named local track with mismatched metadata.
+	#[test]
+	fn catalog_exposes_rendition_broadcast_references() {
+		let mut catalog = moq_mux::catalog::hang::Catalog::default();
+
+		let mut video = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		video.broadcast = Some(moq_net::PathRelative::new("./source").into_owned());
+		catalog.video.renditions.insert("video".to_string(), video);
+		let local = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		catalog.video.renditions.insert("local".to_string(), local);
+
+		let mut audio = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
+		audio.broadcast = Some(moq_net::PathRelative::new("../elsewhere").into_owned());
+		catalog.audio.renditions.insert("audio".to_string(), audio);
+
+		let converted = convert_catalog(&catalog);
+		// `PathRelative` strips redundant `.` segments on creation, so the reference crosses as
+		// the normalized form the catalog itself holds. It round-trips: rebuilding a
+		// `PathRelative` from it is a no-op.
+		assert_eq!(converted.video["video"].broadcast.as_deref(), Some("source"));
+		assert_eq!(converted.video["local"].broadcast, None);
+		assert_eq!(converted.audio["audio"].broadcast.as_deref(), Some("../elsewhere"));
 	}
 
 	#[test]

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -86,6 +86,9 @@ pub struct MoqBroadcastRequest {
 
 struct Announced {
 	inner: moq_net::announce::Consumer,
+	/// The same rooted cursor `inner` was drawn from, so an announced broadcast can resolve a
+	/// catalog reference to a sibling under that root.
+	origin: moq_net::origin::Consumer,
 }
 
 struct OriginDynamic {
@@ -112,7 +115,7 @@ impl Announced {
 					};
 					return Ok(Some(Arc::new(MoqAnnouncement {
 						path: path.to_string(),
-						broadcast: Arc::new(MoqBroadcastConsumer::new(broadcast)),
+						broadcast: Arc::new(MoqBroadcastConsumer::routed(broadcast, self.origin.clone())),
 					})));
 				}
 				None => return Ok(None),
@@ -130,7 +133,7 @@ struct AnnouncedBroadcast {
 impl AnnouncedBroadcast {
 	async fn available(&mut self) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
 		match self.origin.announced_broadcast(&self.path).await {
-			Some(broadcast) => Ok(Arc::new(MoqBroadcastConsumer::new(broadcast))),
+			Some(broadcast) => Ok(Arc::new(MoqBroadcastConsumer::routed(broadcast, self.origin.clone()))),
 			None => Err(MoqError::Closed),
 		}
 	}
@@ -268,6 +271,7 @@ impl MoqOriginConsumer {
 		Ok(Arc::new(MoqAnnounced {
 			task: Task::new(Announced {
 				inner: origin.announced(),
+				origin,
 			}),
 		}))
 	}
@@ -308,7 +312,7 @@ impl MoqOriginConsumer {
 	/// and can report a live broadcast as unroutable. Await `announced_broadcast` first.
 	pub async fn request_broadcast(&self, path: String) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
 		let broadcast = self.inner.request_broadcast(path.as_str()).await?;
-		Ok(Arc::new(MoqBroadcastConsumer::new(broadcast)))
+		Ok(Arc::new(MoqBroadcastConsumer::routed(broadcast, self.inner.clone())))
 	}
 }
 

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -2,13 +2,14 @@ use super::origin::*;
 use super::producer::*;
 use super::server::MoqServer;
 use super::session::MoqClient;
+use crate::audio::{MoqAudioDecoderOutput, MoqAudioSampleFormat};
 use crate::consumer::MoqBroadcastConsumer;
 use crate::consumer::MoqFetchGroupOptions;
 use crate::consumer::MoqRouteWatch;
 use crate::consumer::MoqSubscription;
 use crate::error::MoqError;
 use crate::json::{MoqJsonSnapshotConfig, MoqJsonStreamConfig};
-use crate::media::{MoqAudioFormat, MoqAudioInit, MoqFrame, MoqVideoFormat, MoqVideoInit};
+use crate::media::{MoqAudio, MoqAudioFormat, MoqAudioInit, MoqContainer, MoqFrame, MoqVideoFormat, MoqVideoInit};
 use crate::session::{MoqBackoff, MoqConnectionStatus};
 
 use std::time::Duration;
@@ -30,6 +31,29 @@ fn video_init(format: MoqVideoFormat, data: Vec<u8>) -> MoqVideoInit {
 		data,
 		label: None,
 		hint: None,
+	}
+}
+
+/// An Opus rendition whose catalog `broadcast` field names `reference`.
+fn sibling_audio(reference: &str) -> MoqAudio {
+	MoqAudio {
+		label: None,
+		broadcast: Some(reference.to_string()),
+		codec: "opus".to_string(),
+		description: None,
+		sample_rate: 48_000,
+		channel_count: 2,
+		bitrate: None,
+		container: MoqContainer::Legacy,
+	}
+}
+
+fn audio_output() -> MoqAudioDecoderOutput {
+	MoqAudioDecoderOutput {
+		format: MoqAudioSampleFormat::F32,
+		sample_rate: None,
+		channels: None,
+		latency_max_ms: None,
 	}
 }
 
@@ -893,6 +917,145 @@ async fn announced_broadcast_keeps_the_requested_path() {
 	assert_eq!(requested.inner().info().path.as_str(), "a/pub");
 
 	broadcast.finish().unwrap();
+}
+
+/// A catalog rendition may name a sibling broadcast (`./source`), and the track then lives
+/// there, not on the broadcast the catalog came from. Dropping the reference either fails to
+/// find the track or silently decodes a same-named local one with mismatched metadata.
+#[tokio::test]
+async fn decode_audio_follows_a_sibling_broadcast_reference() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let consumer = origin.consume();
+
+	// The catalog's broadcast deliberately has no "audio" track: only the sibling serves it.
+	let catalog = origin.create_broadcast("a/pub".into()).unwrap();
+	let source = origin.create_broadcast("a/source".into()).unwrap();
+	let _audio = source.publish_track("audio".into(), None).unwrap();
+
+	let announced = consumer.announced_broadcast("a/pub".into()).unwrap();
+	let broadcast = tokio::time::timeout(TIMEOUT, announced.available())
+		.await
+		.expect("timed out waiting for the announcement")
+		.unwrap();
+
+	let decoded = tokio::time::timeout(
+		TIMEOUT,
+		broadcast.decode_audio("audio".into(), sibling_audio("./source"), audio_output()),
+	)
+	.await
+	.expect("timed out subscribing to the referenced track");
+	decoded.expect("the rendition's broadcast reference should resolve to the sibling");
+
+	// Without the reference the same call has nowhere to find the track.
+	let missing = tokio::time::timeout(
+		TIMEOUT,
+		broadcast.decode_audio("audio".into(), sibling_audio(""), audio_output()),
+	)
+	.await
+	.expect("timed out subscribing to the catalog broadcast");
+	assert!(
+		missing.is_err(),
+		"the catalog broadcast does not serve the track itself"
+	);
+
+	catalog.finish().unwrap();
+	source.finish().unwrap();
+}
+
+/// An announcement stream is drawn from a cursor rooted at the prefix, and the broadcast it hands
+/// out is named relative to that root. Resolving against a differently-rooted origin would read a
+/// legal reference as escaping, or land on the wrong broadcast entirely.
+#[tokio::test]
+async fn announced_broadcasts_resolve_siblings_under_the_prefix() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let consumer = origin.consume();
+	let announced = consumer.announced("a/".into()).unwrap();
+
+	let catalog = origin.create_broadcast("a/pub".into()).unwrap();
+	let source = origin.create_broadcast("a/source".into()).unwrap();
+	let _video = source.publish_track("video".into(), None).unwrap();
+
+	// `a/source` may be announced first, so keep reading until the catalog broadcast arrives.
+	let broadcast = loop {
+		let announcement = tokio::time::timeout(TIMEOUT, announced.next())
+			.await
+			.expect("timed out waiting for the announcement")
+			.unwrap()
+			.expect("the origin should keep announcing");
+		if announcement.path() == "pub" {
+			break announcement.broadcast();
+		}
+	};
+
+	let sibling = tokio::time::timeout(TIMEOUT, broadcast.resolve(Some("./source".into())))
+		.await
+		.expect("timed out resolving the reference")
+		.unwrap();
+	tokio::time::timeout(TIMEOUT, sibling.subscribe_track("video".into(), None))
+		.await
+		.expect("timed out subscribing on the resolved broadcast")
+		.unwrap();
+
+	catalog.finish().unwrap();
+	source.finish().unwrap();
+}
+
+/// A broadcast consumed straight from a local producer has no origin, so a rendition naming a
+/// sibling names nothing. Reporting that beats silently reading the catalog's own broadcast.
+#[tokio::test]
+async fn resolve_rejects_a_reference_without_an_origin() {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let _audio = broadcast.create_track("audio", None).unwrap();
+	let consumer = MoqBroadcastConsumer::new(broadcast.consume());
+
+	// An absent or empty reference still names this broadcast, so it needs no origin.
+	consumer.resolve(None).await.unwrap();
+	consumer.resolve(Some(String::new())).await.unwrap();
+
+	match consumer.resolve(Some("./source".into())).await {
+		Err(MoqError::UnresolvableBroadcast(reference)) => assert_eq!(reference, "./source"),
+		Err(err) => panic!("wrong error for an unresolvable reference: {err:?}"),
+		Ok(_) => panic!("a standalone broadcast cannot resolve a sibling"),
+	}
+}
+
+/// A resolved sibling carries the origin too, so its own catalog's references keep resolving.
+#[tokio::test]
+async fn resolve_returns_a_broadcast_that_resolves_further_references() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let consumer = origin.consume();
+
+	let catalog = origin.create_broadcast("a/pub".into()).unwrap();
+	let source = origin.create_broadcast("a/source".into()).unwrap();
+	let _video = source.publish_track("video".into(), None).unwrap();
+
+	let announced = consumer.announced_broadcast("a/pub".into()).unwrap();
+	let broadcast = tokio::time::timeout(TIMEOUT, announced.available())
+		.await
+		.expect("timed out waiting for the announcement")
+		.unwrap();
+
+	let sibling = tokio::time::timeout(TIMEOUT, broadcast.resolve(Some("./source".into())))
+		.await
+		.expect("timed out resolving the reference")
+		.unwrap();
+	assert_eq!(sibling.inner().info().path.as_str(), "a/source");
+
+	// The sibling is a full consumer: the referenced track subscribes on it directly.
+	tokio::time::timeout(TIMEOUT, sibling.subscribe_track("video".into(), None))
+		.await
+		.expect("timed out subscribing on the resolved broadcast")
+		.unwrap();
+
+	// And it can follow a reference of its own, back to where we started.
+	let back = tokio::time::timeout(TIMEOUT, sibling.resolve(Some("./pub".into())))
+		.await
+		.expect("timed out resolving back")
+		.unwrap();
+	assert_eq!(back.inner().info().path.as_str(), "a/pub");
+
+	catalog.finish().unwrap();
+	source.finish().unwrap();
 }
 
 #[tokio::test]

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -12,6 +12,7 @@ use crate::json::{MoqJsonSnapshotConfig, MoqJsonStreamConfig};
 use crate::media::{MoqAudio, MoqAudioFormat, MoqAudioInit, MoqContainer, MoqFrame, MoqVideoFormat, MoqVideoInit};
 use crate::session::{MoqBackoff, MoqConnectionStatus};
 
+use std::sync::Arc;
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -32,6 +33,19 @@ fn video_init(format: MoqVideoFormat, data: Vec<u8>) -> MoqVideoInit {
 		label: None,
 		hint: None,
 	}
+}
+
+/// Wait for `path` to be announced on `origin` and return its consumer.
+///
+/// A created broadcast becomes routable asynchronously, and resolving a reference goes through
+/// `request_broadcast`, which reports a not-yet-announced path as unroutable rather than waiting.
+/// So every broadcast a test resolves has to be awaited, not just the one it starts from.
+async fn await_announced(consumer: &MoqOriginConsumer, path: &str) -> Arc<MoqBroadcastConsumer> {
+	let announced = consumer.announced_broadcast(path.into()).unwrap();
+	tokio::time::timeout(TIMEOUT, announced.available())
+		.await
+		.unwrap_or_else(|_| panic!("timed out waiting for {path} to be announced"))
+		.unwrap()
 }
 
 /// An Opus rendition whose catalog `broadcast` field names `reference`.
@@ -932,11 +946,9 @@ async fn decode_audio_follows_a_sibling_broadcast_reference() {
 	let source = origin.create_broadcast("a/source".into()).unwrap();
 	let _audio = source.publish_track("audio".into(), None).unwrap();
 
-	let announced = consumer.announced_broadcast("a/pub".into()).unwrap();
-	let broadcast = tokio::time::timeout(TIMEOUT, announced.available())
-		.await
-		.expect("timed out waiting for the announcement")
-		.unwrap();
+	// Both, not just the catalog broadcast: the reference resolves against `a/source`.
+	let broadcast = await_announced(&consumer, "a/pub").await;
+	await_announced(&consumer, "a/source").await;
 
 	let decoded = tokio::time::timeout(
 		TIMEOUT,
@@ -987,6 +999,8 @@ async fn announced_broadcasts_resolve_siblings_under_the_prefix() {
 		}
 	};
 
+	await_announced(&consumer, "a/source").await;
+
 	let sibling = tokio::time::timeout(TIMEOUT, broadcast.resolve(Some("./source".into())))
 		.await
 		.expect("timed out resolving the reference")
@@ -1008,12 +1022,17 @@ async fn resolve_rejects_a_reference_without_an_origin() {
 	let _audio = broadcast.create_track("audio", None).unwrap();
 	let consumer = MoqBroadcastConsumer::new(broadcast.consume());
 
-	// An absent or empty reference still names this broadcast, so it needs no origin.
+	// An absent or empty reference still names this broadcast, so it needs no origin. A reference
+	// made only of slashes normalizes to the empty one, so it must be treated the same rather than
+	// looking like a cross-broadcast reference.
 	consumer.resolve(None).await.unwrap();
 	consumer.resolve(Some(String::new())).await.unwrap();
+	consumer.resolve(Some("/".into())).await.unwrap();
 
+	// Reported in normalized form, matching `EscapingBroadcast` and libmoq: it names what the
+	// resolver actually tried to reach, not the caller's spelling of it.
 	match consumer.resolve(Some("./source".into())).await {
-		Err(MoqError::UnresolvableBroadcast(reference)) => assert_eq!(reference, "./source"),
+		Err(MoqError::UnresolvableBroadcast(reference)) => assert_eq!(reference, "source"),
 		Err(err) => panic!("wrong error for an unresolvable reference: {err:?}"),
 		Ok(_) => panic!("a standalone broadcast cannot resolve a sibling"),
 	}
@@ -1029,11 +1048,8 @@ async fn resolve_returns_a_broadcast_that_resolves_further_references() {
 	let source = origin.create_broadcast("a/source".into()).unwrap();
 	let _video = source.publish_track("video".into(), None).unwrap();
 
-	let announced = consumer.announced_broadcast("a/pub".into()).unwrap();
-	let broadcast = tokio::time::timeout(TIMEOUT, announced.available())
-		.await
-		.expect("timed out waiting for the announcement")
-		.unwrap();
+	let broadcast = await_announced(&consumer, "a/pub").await;
+	await_announced(&consumer, "a/source").await;
 
 	let sibling = tokio::time::timeout(TIMEOUT, broadcast.resolve(Some("./source".into())))
 		.await

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -459,8 +459,11 @@ impl MoqBroadcastConsumer {
 		catalog_video: crate::media::MoqVideo,
 		output: MoqVideoDecoderOutput,
 	) -> Result<Arc<MoqVideoConsumer>, MoqError> {
-		let broadcast = self.resolve_inner(catalog_video.broadcast.as_deref()).await?;
+		// Reject the codec before resolving: resolving reaches the origin, which can invoke a
+		// dynamic handler and open an upstream subscription we would immediately drop.
+		let reference = catalog_video.broadcast.clone();
 		let cfg = video_config(catalog_video)?;
+		let broadcast = self.resolve_inner(reference.as_deref()).await?;
 
 		let mut config = moq_video::decode::Config::default();
 		config.resize = output.resize.map(|size| moq_video::Size::new(size.width, size.height));

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -450,12 +450,16 @@ impl MoqBroadcastConsumer {
 	/// [`MoqCatalogConsumer::next`](crate::consumer::MoqCatalogConsumer::next)); the codec is read
 	/// from it. Errors if no native backend handles that codec, rather than failing on the first
 	/// frame.
+	///
+	/// A rendition whose [`broadcast`](crate::media::MoqVideo::broadcast) names another broadcast
+	/// is subscribed there, so `name` is always read from the broadcast the catalog points at.
 	pub async fn decode_video(
 		&self,
 		name: String,
 		catalog_video: crate::media::MoqVideo,
 		output: MoqVideoDecoderOutput,
 	) -> Result<Arc<MoqVideoConsumer>, MoqError> {
+		let broadcast = self.resolve_inner(catalog_video.broadcast.as_deref()).await?;
 		let cfg = video_config(catalog_video)?;
 
 		let mut config = moq_video::decode::Config::default();
@@ -465,7 +469,7 @@ impl MoqBroadcastConsumer {
 			.map(|ms| moq_mux::Latency::max(std::time::Duration::from_millis(ms)))
 			.unwrap_or_default();
 
-		let consumer = moq_video::decode::Consumer::new(self.inner(), &cfg, name, config).await?;
+		let consumer = moq_video::decode::Consumer::new(&broadcast, &cfg, name, config).await?;
 
 		Ok(Arc::new(MoqVideoConsumer {
 			task: crate::ffi::Task::new(VideoConsumerInner { consumer }),
@@ -481,6 +485,7 @@ mod decode_tests {
 	fn catalog_video(codec: &str) -> MoqVideo {
 		MoqVideo {
 			label: None,
+			broadcast: None,
 			codec: codec.to_string(),
 			description: None,
 			coded: Some(MoqDimensions {

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -77,9 +77,10 @@ public final class BroadcastConsumer: Sendable {
     /// Resolve a catalog rendition's `broadcast` reference to the broadcast serving its track.
     ///
     /// `reference` is `Video.broadcast` / `Audio.broadcast`: `nil` or empty names this
-    /// broadcast, anything else names a sibling relative to it (e.g. `./source`). Call it
-    /// before `subscribeMedia`, `subscribeTrack`, or `fetchGroup` on a rendition that carries
-    /// one; `decodeAudio` and `decodeVideo` resolve it themselves.
+    /// broadcast, anything else names a sibling relative to it (e.g. `./source`). Call it on a
+    /// rendition that carries one before `subscribeMedia`, `subscribeTrack`, `fetchGroup`, or
+    /// `fetchMediaGroup`, which take a track name rather than a rendition; `decodeAudio` and
+    /// `decodeVideo` resolve it themselves.
     ///
     /// Throws if this broadcast came from a local producer rather than an origin, since a
     /// standalone broadcast has no sibling to name.

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -74,6 +74,19 @@ public final class BroadcastConsumer: Sendable {
                 name: name, container: container, subscription: subscription))
     }
 
+    /// Resolve a catalog rendition's `broadcast` reference to the broadcast serving its track.
+    ///
+    /// `reference` is `Video.broadcast` / `Audio.broadcast`: `nil` or empty names this
+    /// broadcast, anything else names a sibling relative to it (e.g. `./source`). Call it
+    /// before `subscribeMedia`, `subscribeTrack`, or `fetchGroup` on a rendition that carries
+    /// one; `decodeAudio` and `decodeVideo` resolve it themselves.
+    ///
+    /// Throws if this broadcast came from a local producer rather than an origin, since a
+    /// standalone broadcast has no sibling to name.
+    public func resolve(_ reference: String?) async throws -> BroadcastConsumer {
+        BroadcastConsumer(try await ffi.resolve(reference: reference))
+    }
+
     /// Subscribe to a raw-audio track, decoding to PCM in the layout `output`
     /// declares. `catalogAudio` is the matching rendition from the catalog.
     public func decodeAudio(name: String, catalogAudio: Audio, output: AudioDecoderOutput) async throws -> AudioConsumer {


### PR DESCRIPTION
Closes #2931.

## Summary

- **Root cause**: `hang::catalog::{VideoConfig,AudioConfig}` carry `broadcast: Option<PathRelativeOwned>`, a path relative to the catalog's own broadcast that names where the rendition's track actually lives (e.g. a transcode output at `live/hd` describing a track in `live/source`). Neither FFI surface modelled it. `moq-ffi`'s `convert_catalog` dropped it, and both `decode_audio`/`decode_video` opened the named track on `self.inner()`; `libmoq`'s `moq_consume_video`/`moq_consume_audio` did the same with `consume.broadcast`. A cross-broadcast rendition therefore yields `NotFound`, or silently decodes a same-named local track with mismatched metadata.
- Resolution needs an origin (only an origin can fetch a sibling broadcast) and the catalog broadcast's own path, which is what `moq_mux::Source` already bundles. Both crates now keep the origin cursor that named the broadcast alongside the consumer and resolve through `Source::resolve`, so the catalog and every rendition share one upstream subscription and an escaping reference still fails as `EscapingBroadcast`.
- The origin has to be *the cursor that named the broadcast*: the path is stamped per cursor, and a reference resolves against that path, so a differently-rooted origin would read a legal reference as escaping or land on the wrong broadcast. `announced(prefix)` therefore stores its rooted cursor, `announced_broadcast`/`request_broadcast` the unrooted one.
- A broadcast consumed straight from a local producer has no origin, so a rendition naming a sibling names nothing. That is a new explicit error rather than a silent fallback to the catalog's own broadcast.
- `decode_video`/`decode_audio` reject an unsupported codec *before* resolving. Resolving reaches the origin, which can invoke a dynamic handler and open an upstream subscription, so the cheap local check goes first — the same reason `fetch_media_group` parses its container before fetching.
- `libmoq`'s C ABI is unchanged: `moq_consume_video`/`moq_consume_audio` take a catalog snapshot and a rendition index, so they follow the reference with nothing extra from the caller. `moq_video_config`/`moq_audio_config` gain no field (that would change their size); a C publisher still cannot author a cross-broadcast rendition, which is pre-existing and out of scope here.

## Public API changes

`rs/moq-ffi` (breaking, hence `dev`):

- `MoqVideo` and `MoqAudio` gain `broadcast: Option<String>` (defaulted `None`). Breaking for a binding that builds the record positionally.
- `MoqBroadcastConsumer::resolve(reference: Option<String>) -> MoqBroadcastConsumer` is new. It is the composable primitive for the paths that take a track name rather than a rendition (`subscribe_media`, `subscribe_track`, `fetch_group`, `fetch_media_group`), which are otherwise broken the same way; `decode_video`/`decode_audio` call it internally. The resolved consumer keeps the origin, so its own catalog's references resolve too. The reference is normalized before use, so an empty or all-slashes one names this broadcast and needs no origin.
- `MoqError::UnresolvableBroadcast(String)` is new. Additive in Rust (`#[non_exhaustive]`), breaking for a binding that switches exhaustively over the generated error enum.

`rs/libmoq`: no ABI change. New error code `-41` for the same unresolvable-reference case; `Consume::start` (crate-internal) takes the origin.

Wrappers: `resolve` passthroughs added to `py/moq-rs`, `go/wrapper`, and `swift`; `kt` gets it from the generated bindings via `Aliases.kt`.

## Wire behavior changes

None. This changes which broadcast a subscriber opens a track on, per what the catalog already said; no encoding, message, or default moved.

Worth knowing for callers: resolution goes through `origin::Consumer::request_broadcast`, which reports a sibling that exists but is not announced yet as unroutable rather than waiting for it. That is inherited from `moq_mux::Source` and matches every other exporter; the new docs now say so.

## Cross-Package Sync

Walked the `rs/moq-ffi` row: `rs/libmoq` fixed in the same PR, `{py,swift,kt}/` and `go/wrapper/moq/*.go` updated, `doc/lib/{py,swift,kt,go,c}` documented. `js/` needs nothing: `js/hang` already resolves rendition references (#2918).

## Test plan

- `just check` and `just fix` clean; `just test` green.
- `cargo clippy -p moq-ffi -p libmoq --all-targets -- -D warnings` clean. Neither crate is compiled by `just check`, so both were built and tested explicitly (70 + 72 tests).
- `just go check` (vet/build/test against regenerated bindings), `just py check` + `just py test` (52 passed), `just swift check` (10 passed).
- New regression tests, each verified to fail without its fix:
  - `moq-ffi`: `decode_audio_follows_a_sibling_broadcast_reference` (catalog broadcast serves no `audio` track; only `./source` does) fails with `Audio(Net(NotFound))` before the fix.
  - `libmoq`: `consume_audio_follows_a_sibling_broadcast_reference` (end-to-end, a frame published on the sibling) returns `-2` before the fix.
  - Plus `catalog_exposes_rendition_broadcast_references`, `resolve_rejects_a_reference_without_an_origin` (including the all-slashes case), `resolve_returns_a_broadcast_that_resolves_further_references`, and `announced_broadcasts_resolve_siblings_under_the_prefix` (covers the rooted-cursor case).
  - Every test that resolves a reference now awaits the *referenced* broadcast's announcement, not just the one it starts from: `request_broadcast` fails fast on an unannounced path, so awaiting only the catalog broadcast left a latent race. 350 stress runs across the cross-broadcast tests, no failures.

## Review

CodeRabbit reviewed the diff and raised two documentation findings; both are addressed and it confirmed the fix. The Codex adversarial pass could not run (usage limit), so a Claude `/code-review` at high effort stood in at the user's direction. It found five issues, all fixed here: the two decode-path ordering bugs above, the reference-normalization gap, the latent test race, and the missing `request_broadcast` fail-fast note in the docs.

(written by Opus 5)