### PR TITLE
feat(moq-native): size the UDP socket buffers, warning when the kernel clamps

### DIFF
--- a/doc/setup/prod.md
+++ b/doc/setup/prod.md
@@ -47,6 +47,26 @@ TLS is where most people get stuck.
 And of course, make sure UDP is allowed on your firewall.
 The default WebTransport port is UDP/443 but anything will work if you put it in the URL.
 
+## Tuning
+
+A relay multiplexes every connection over a single UDP socket, so a burst that doesn't fit in the kernel's socket buffer is dropped before the relay ever sees it, and QUIC congestion control reads those drops as congestion.
+
+`moq-relay` and `moq-cli` request an 8 MiB socket buffer in each direction, but Linux silently clamps the request to `net.core.rmem_max` and `net.core.wmem_max`, which default to 208 KiB.
+You'll get a warning on startup when that happens:
+
+```
+WARN moq_native::bind: UDP receive buffer is smaller than requested; raise `net.core.rmem_max` or expect packet loss under load wanted=8388608 granted=212992
+```
+
+Raise both limits, persisting them across reboots:
+
+```bash
+printf 'net.core.rmem_max = 8388608\nnet.core.wmem_max = 8388608\n' | sudo tee /etc/sysctl.d/60-moq.conf
+sudo sysctl --system
+```
+
+macOS caps both directions with `kern.ipc.maxsockbuf` instead, and Windows sizes each socket on its own so there's nothing to raise.
+
 ## Next Steps
 
 - Set up [Authentication](/bin/relay/auth)

--- a/doc/setup/prod.md
+++ b/doc/setup/prod.md
@@ -54,7 +54,7 @@ A relay multiplexes every connection over a single UDP socket, so a burst that d
 `moq-relay` and `moq-cli` request an 8 MiB socket buffer in each direction, but Linux silently clamps the request to `net.core.rmem_max` and `net.core.wmem_max`, which default to 208 KiB.
 You'll get a warning on startup when that happens:
 
-```
+```text
 WARN moq_native::bind: UDP receive buffer is smaller than requested; raise `net.core.rmem_max` or expect packet loss under load wanted=8388608 granted=212992
 ```
 

--- a/rs/moq-native/src/bind.rs
+++ b/rs/moq-native/src/bind.rs
@@ -83,70 +83,108 @@ pub fn udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
 
 /// Request [`UDP_BUFFER`] in both directions, best-effort.
 fn grow_buffers(socket: &Socket) {
-	// One warning per direction per process: a client that reconnects rebinds, and
-	// the operator only needs telling once.
-	static RECV: Once = Once::new();
-	static SEND: Once = Once::new();
-
-	grow_buffer(
-		"receive",
-		RECV_SYSCTL,
-		&RECV,
-		|| socket.recv_buffer_size(),
-		|size| socket.set_recv_buffer_size(size),
-	);
-	grow_buffer(
-		"send",
-		SEND_SYSCTL,
-		&SEND,
-		|| socket.send_buffer_size(),
-		|size| socket.set_send_buffer_size(size),
-	);
+	for direction in [Direction::Recv, Direction::Send] {
+		direction.grow(socket);
+	}
 }
 
-/// Raise one direction's buffer to [`UDP_BUFFER`], then read back what the kernel
-/// actually granted and warn through `warned` when it fell short.
-///
-/// Reading back is the whole point: Linux silently clamps the request to its
-/// sysctl, so `setsockopt` returning `Ok` says nothing about the size we ended up
-/// with, and `SO_RCVBUFFORCE` (the clamp-free version) needs `CAP_NET_ADMIN` that
-/// a relay shouldn't be asking for.
-fn grow_buffer(
-	direction: &str,
-	sysctl: Option<&str>,
-	warned: &Once,
-	get: impl Fn() -> std::io::Result<usize>,
-	set: impl Fn(usize) -> std::io::Result<()>,
-) {
-	// Never shrink a system that's already tuned above our default.
-	if get().is_ok_and(|size| granted(size) >= UDP_BUFFER) {
-		return;
-	}
+/// One direction of a socket's buffering, owning everything that differs between
+/// the two: the socket options, the sysctl to name, and the warning.
+#[derive(Clone, Copy)]
+enum Direction {
+	Recv,
+	Send,
+}
 
-	let size = match set(UDP_BUFFER).and_then(|()| get()) {
-		Ok(size) => granted(size),
-		Err(err) => {
-			warned.call_once(|| tracing::warn!(%err, "failed to set the UDP {direction} buffer size"));
+impl Direction {
+	/// Raise this direction's buffer to [`UDP_BUFFER`], then read back what the
+	/// kernel actually granted and warn once when it fell short.
+	///
+	/// Reading back is the whole point: Linux silently clamps the request to its
+	/// sysctl, so `setsockopt` returning `Ok` says nothing about the size we ended
+	/// up with, and `SO_RCVBUFFORCE` (the clamp-free version) needs `CAP_NET_ADMIN`
+	/// that a relay shouldn't be asking for.
+	fn grow(self, socket: &Socket) {
+		// Never shrink a system that's already tuned above our default.
+		if self.size(socket).is_ok_and(sufficient) {
 			return;
 		}
-	};
 
-	if size >= UDP_BUFFER {
-		return;
+		match self.set_size(socket, UDP_BUFFER).and_then(|()| self.size(socket)) {
+			Ok(reported) if sufficient(reported) => {}
+			Ok(reported) => self.warn_short(granted(reported)),
+			Err(err) => self.warn_failed(&err),
+		}
 	}
 
-	warned.call_once(|| match sysctl {
-		Some(sysctl) => tracing::warn!(
-			wanted = UDP_BUFFER,
-			granted = size,
-			"UDP {direction} buffer is smaller than requested; raise `{sysctl}` or expect packet loss under load"
-		),
-		None => tracing::warn!(
-			wanted = UDP_BUFFER,
-			granted = size,
-			"UDP {direction} buffer is smaller than requested; expect packet loss under load"
-		),
-	});
+	fn size(self, socket: &Socket) -> std::io::Result<usize> {
+		match self {
+			Self::Recv => socket.recv_buffer_size(),
+			Self::Send => socket.send_buffer_size(),
+		}
+	}
+
+	fn set_size(self, socket: &Socket, size: usize) -> std::io::Result<()> {
+		match self {
+			Self::Recv => socket.set_recv_buffer_size(size),
+			Self::Send => socket.set_send_buffer_size(size),
+		}
+	}
+
+	fn name(self) -> &'static str {
+		match self {
+			Self::Recv => "receive",
+			Self::Send => "send",
+		}
+	}
+
+	fn sysctl(self) -> Option<&'static str> {
+		match self {
+			Self::Recv => RECV_SYSCTL,
+			Self::Send => SEND_SYSCTL,
+		}
+	}
+
+	/// One warning per direction per process: a client that reconnects rebinds, and
+	/// the operator only needs telling once.
+	fn warned(self) -> &'static Once {
+		static RECV: Once = Once::new();
+		static SEND: Once = Once::new();
+
+		match self {
+			Self::Recv => &RECV,
+			Self::Send => &SEND,
+		}
+	}
+
+	/// The kernel accepted the request and quietly handed back `granted` instead.
+	fn warn_short(self, granted: usize) {
+		let name = self.name();
+		self.warned().call_once(|| match self.sysctl() {
+			Some(sysctl) => tracing::warn!(
+				wanted = UDP_BUFFER,
+				granted,
+				"UDP {name} buffer is smaller than requested; raise `{sysctl}` or expect packet loss under load"
+			),
+			None => tracing::warn!(
+				wanted = UDP_BUFFER,
+				granted,
+				"UDP {name} buffer is smaller than requested; expect packet loss under load"
+			),
+		});
+	}
+
+	/// The option itself was rejected, so we don't even know what we're running with.
+	fn warn_failed(self, err: &std::io::Error) {
+		let name = self.name();
+		self.warned()
+			.call_once(|| tracing::warn!(%err, "failed to set the UDP {name} buffer size"));
+	}
+}
+
+/// Whether a buffer size the kernel reported already covers [`UDP_BUFFER`].
+fn sufficient(reported: usize) -> bool {
+	granted(reported) >= UDP_BUFFER
 }
 
 /// The usable size behind a buffer size the kernel reported.
@@ -256,56 +294,43 @@ mod tests {
 
 	#[test]
 	fn udp_buffers_grow() {
-		// The exact size depends on the host's sysctls, but a tuned socket should
-		// never come back smaller than an untuned one.
-		let tuned = Socket::from(udp("127.0.0.1:0".parse().unwrap()).unwrap());
-		let plain = Socket::from(std::net::UdpSocket::bind("127.0.0.1:0").unwrap());
+		fn check(direction: Direction) {
+			let plain = Socket::from(std::net::UdpSocket::bind("127.0.0.1:0").unwrap());
+			let before = direction.size(&plain).unwrap();
 
-		assert!(tuned.recv_buffer_size().unwrap() >= plain.recv_buffer_size().unwrap());
-		assert!(tuned.send_buffer_size().unwrap() >= plain.send_buffer_size().unwrap());
+			let tuned = Socket::from(udp("127.0.0.1:0".parse().unwrap()).unwrap());
+			let after = direction.size(&tuned).unwrap();
+
+			// A host whose default already covers UDP_BUFFER is left alone. Anywhere
+			// else the bind has to have actually raised it, whatever the sysctls
+			// clamped it to.
+			if sufficient(before) {
+				assert_eq!(after, before, "{} buffer should be left alone", direction.name());
+			} else {
+				assert!(after > before, "{} buffer should grow past {before}", direction.name());
+			}
+		}
+
+		check(Direction::Recv);
+		check(Direction::Send);
+	}
+
+	#[test]
+	fn sufficient_accounts_for_the_doubled_report() {
+		// Doubled, since that's how Linux reports back a buffer it granted.
+		assert!(sufficient(UDP_BUFFER * 2));
+		assert!(!sufficient(512 * 1024));
 	}
 
 	#[tracing_test::traced_test]
 	#[test]
-	fn udp_buffer_warns_when_the_kernel_clamps() {
-		// Stand in for a kernel that accepts the request and quietly hands back
-		// less, which is what a small `net.core.rmem_max` does.
-		let current = std::cell::Cell::new(0);
-		let warned = Once::new();
-		grow_buffer(
-			"receive",
-			Some("net.core.rmem_max"),
-			&warned,
-			|| Ok(current.get()),
-			|_| {
-				current.set(512 * 1024);
-				Ok(())
-			},
-		);
+	fn a_clamped_buffer_warns_and_names_the_sysctl() {
+		Direction::Recv.warn_short(512 * 1024);
 
-		assert!(warned.is_completed());
-		assert!(logs_contain("net.core.rmem_max"));
-	}
-
-	#[test]
-	fn udp_buffer_keeps_a_larger_existing_size() {
-		// Doubled, so this reads as already-larger on Linux too.
-		let reported = UDP_BUFFER * 2;
-		let touched = std::cell::Cell::new(false);
-		let warned = Once::new();
-		grow_buffer(
-			"receive",
-			None,
-			&warned,
-			|| Ok(reported),
-			|_| {
-				touched.set(true);
-				Ok(())
-			},
-		);
-
-		assert!(!touched.get(), "should not shrink a tuned socket");
-		assert!(!warned.is_completed());
+		assert!(logs_contain("UDP receive buffer is smaller than requested"));
+		if let Some(sysctl) = Direction::Recv.sysctl() {
+			assert!(logs_contain(sysctl));
+		}
 	}
 
 	#[test]

--- a/rs/moq-native/src/bind.rs
+++ b/rs/moq-native/src/bind.rs
@@ -159,8 +159,14 @@ impl Direction {
 
 	/// The kernel accepted the request and quietly handed back `granted` instead.
 	fn warn_short(self, granted: usize) {
+		self.warned().call_once(|| self.emit_short(granted));
+	}
+
+	/// The warning itself, minus the once-guard, so a test can read it back
+	/// whatever a previous bind on this host already consumed.
+	fn emit_short(self, granted: usize) {
 		let name = self.name();
-		self.warned().call_once(|| match self.sysctl() {
+		match self.sysctl() {
 			Some(sysctl) => tracing::warn!(
 				wanted = UDP_BUFFER,
 				granted,
@@ -171,7 +177,7 @@ impl Direction {
 				granted,
 				"UDP {name} buffer is smaller than requested; expect packet loss under load"
 			),
-		});
+		}
 	}
 
 	/// The option itself was rejected, so we don't even know what we're running with.
@@ -325,7 +331,7 @@ mod tests {
 	#[tracing_test::traced_test]
 	#[test]
 	fn a_clamped_buffer_warns_and_names_the_sysctl() {
-		Direction::Recv.warn_short(512 * 1024);
+		Direction::Recv.emit_short(512 * 1024);
 
 		assert!(logs_contain("UDP receive buffer is smaller than requested"));
 		if let Some(sysctl) = Direction::Recv.sysctl() {

--- a/rs/moq-native/src/bind.rs
+++ b/rs/moq-native/src/bind.rs
@@ -11,6 +11,7 @@
 
 use socket2::{Domain, Protocol, Socket, TcpKeepalive, Type};
 use std::net::{SocketAddr, TcpListener, UdpSocket};
+use std::sync::Once;
 use std::time::Duration;
 
 /// TCP keepalive idle period before the kernel starts probing a silent peer, and
@@ -23,13 +24,142 @@ use std::time::Duration;
 const KEEPALIVE_IDLE: Duration = Duration::from_secs(30);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 
+/// UDP socket buffer size requested in each direction, in bytes.
+///
+/// A QUIC stack absorbs bursts in the kernel socket buffer: whatever doesn't fit
+/// while the process is off the CPU is dropped before quinn ever sees it, and
+/// congestion control reads those drops as congestion. The OS defaults are sized
+/// for a chatty TCP-era socket (208 KiB on Linux), which a single relay socket
+/// carrying every connection blows through in milliseconds. 8 MiB is roughly 64ms
+/// of a saturated 1Gbps link, generous next to a scheduler delay and cheap next to
+/// what a relay already spends per connection. quic-go asks for 7 MiB.
+///
+/// Compiled in rather than derived from the NIC: the buffer is a ceiling on queued
+/// bytes rather than an allocation, so an oversized request costs an idle socket
+/// nothing, while a link's nominal speed says little about the path it feeds (a
+/// VM's virtio NIC reports 10Gbps through a 100Mbps uplink).
+const UDP_BUFFER: usize = 8 * 1024 * 1024;
+
+/// The sysctl capping `SO_RCVBUF`, named in the warning so an operator knows what
+/// to raise. `None` on platforms that size socket buffers per socket only.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const RECV_SYSCTL: Option<&str> = Some("net.core.rmem_max");
+#[cfg(any(
+	target_vendor = "apple",
+	target_os = "freebsd",
+	target_os = "netbsd",
+	target_os = "openbsd"
+))]
+const RECV_SYSCTL: Option<&str> = Some("kern.ipc.maxsockbuf");
+#[cfg(not(any(
+	target_os = "linux",
+	target_os = "android",
+	target_vendor = "apple",
+	target_os = "freebsd",
+	target_os = "netbsd",
+	target_os = "openbsd"
+)))]
+const RECV_SYSCTL: Option<&str> = None;
+
+/// The sysctl capping `SO_SNDBUF`. See [`RECV_SYSCTL`]; the BSDs cap both
+/// directions with the same knob.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const SEND_SYSCTL: Option<&str> = Some("net.core.wmem_max");
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+const SEND_SYSCTL: Option<&str> = RECV_SYSCTL;
+
 /// Bind a UDP socket, making an IPv6 socket dual-stack so it also serves IPv4.
+///
+/// The socket buffers are grown to 8 MiB where the OS allows it, and a warning
+/// names the sysctl to raise where it doesn't.
 pub fn udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
 	let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
 	let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
 	make_dual_stack(&socket, addr);
+	grow_buffers(&socket);
 	socket.bind(&addr.into())?;
 	Ok(socket.into())
+}
+
+/// Request [`UDP_BUFFER`] in both directions, best-effort.
+fn grow_buffers(socket: &Socket) {
+	// One warning per direction per process: a client that reconnects rebinds, and
+	// the operator only needs telling once.
+	static RECV: Once = Once::new();
+	static SEND: Once = Once::new();
+
+	grow_buffer(
+		"receive",
+		RECV_SYSCTL,
+		&RECV,
+		|| socket.recv_buffer_size(),
+		|size| socket.set_recv_buffer_size(size),
+	);
+	grow_buffer(
+		"send",
+		SEND_SYSCTL,
+		&SEND,
+		|| socket.send_buffer_size(),
+		|size| socket.set_send_buffer_size(size),
+	);
+}
+
+/// Raise one direction's buffer to [`UDP_BUFFER`], then read back what the kernel
+/// actually granted and warn through `warned` when it fell short.
+///
+/// Reading back is the whole point: Linux silently clamps the request to its
+/// sysctl, so `setsockopt` returning `Ok` says nothing about the size we ended up
+/// with, and `SO_RCVBUFFORCE` (the clamp-free version) needs `CAP_NET_ADMIN` that
+/// a relay shouldn't be asking for.
+fn grow_buffer(
+	direction: &str,
+	sysctl: Option<&str>,
+	warned: &Once,
+	get: impl Fn() -> std::io::Result<usize>,
+	set: impl Fn(usize) -> std::io::Result<()>,
+) {
+	// Never shrink a system that's already tuned above our default.
+	if get().is_ok_and(|size| granted(size) >= UDP_BUFFER) {
+		return;
+	}
+
+	let size = match set(UDP_BUFFER).and_then(|()| get()) {
+		Ok(size) => granted(size),
+		Err(err) => {
+			warned.call_once(|| tracing::warn!(%err, "failed to set the UDP {direction} buffer size"));
+			return;
+		}
+	};
+
+	if size >= UDP_BUFFER {
+		return;
+	}
+
+	warned.call_once(|| match sysctl {
+		Some(sysctl) => tracing::warn!(
+			wanted = UDP_BUFFER,
+			granted = size,
+			"UDP {direction} buffer is smaller than requested; raise `{sysctl}` or expect packet loss under load"
+		),
+		None => tracing::warn!(
+			wanted = UDP_BUFFER,
+			granted = size,
+			"UDP {direction} buffer is smaller than requested; expect packet loss under load"
+		),
+	});
+}
+
+/// The usable size behind a buffer size the kernel reported.
+///
+/// Linux reports back double what it granted, reserving the other half for
+/// per-packet bookkeeping, so halving keeps the numbers we compare and log in the
+/// same units an operator writes into the sysctl.
+fn granted(reported: usize) -> usize {
+	if cfg!(any(target_os = "linux", target_os = "android")) {
+		reported / 2
+	} else {
+		reported
+	}
 }
 
 /// Whether `socket` also reaches IPv4, through IPv4-mapped addresses.
@@ -122,6 +252,60 @@ mod tests {
 		};
 		let socket = Socket::from(socket);
 		assert!(!socket.only_v6().unwrap(), "IPv6 socket should be dual-stack");
+	}
+
+	#[test]
+	fn udp_buffers_grow() {
+		// The exact size depends on the host's sysctls, but a tuned socket should
+		// never come back smaller than an untuned one.
+		let tuned = Socket::from(udp("127.0.0.1:0".parse().unwrap()).unwrap());
+		let plain = Socket::from(std::net::UdpSocket::bind("127.0.0.1:0").unwrap());
+
+		assert!(tuned.recv_buffer_size().unwrap() >= plain.recv_buffer_size().unwrap());
+		assert!(tuned.send_buffer_size().unwrap() >= plain.send_buffer_size().unwrap());
+	}
+
+	#[tracing_test::traced_test]
+	#[test]
+	fn udp_buffer_warns_when_the_kernel_clamps() {
+		// Stand in for a kernel that accepts the request and quietly hands back
+		// less, which is what a small `net.core.rmem_max` does.
+		let current = std::cell::Cell::new(0);
+		let warned = Once::new();
+		grow_buffer(
+			"receive",
+			Some("net.core.rmem_max"),
+			&warned,
+			|| Ok(current.get()),
+			|_| {
+				current.set(512 * 1024);
+				Ok(())
+			},
+		);
+
+		assert!(warned.is_completed());
+		assert!(logs_contain("net.core.rmem_max"));
+	}
+
+	#[test]
+	fn udp_buffer_keeps_a_larger_existing_size() {
+		// Doubled, so this reads as already-larger on Linux too.
+		let reported = UDP_BUFFER * 2;
+		let touched = std::cell::Cell::new(false);
+		let warned = Once::new();
+		grow_buffer(
+			"receive",
+			None,
+			&warned,
+			|| Ok(reported),
+			|_| {
+				touched.set(true);
+				Ok(())
+			},
+		);
+
+		assert!(!touched.get(), "should not shrink a tuned socket");
+		assert!(!warned.is_completed());
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

- `bind::udp` requests an 8 MiB socket buffer in each direction before binding, then reads back what the kernel granted and warns once per direction per process when it fell short, naming the sysctl to raise. This is the single chokepoint for the quinn, quiche, and noq backends (client and server).
- Reading back is the point: Linux silently clamps `SO_RCVBUF`/`SO_SNDBUF` to `net.core.{r,w}mem_max`, so `setsockopt` returning `Ok` says nothing about the size we ended up with. `SO_RCVBUFFORCE` skips the clamp but needs `CAP_NET_ADMIN`, which a relay shouldn't be asking for. This is why every quic-go operator knows about this knob and no quinn operator does.
- Linux reports back double what it granted (half is per-packet bookkeeping), so the comparison and the logged numbers halve it. Otherwise the check never fires and the log doesn't match what an operator writes into the sysctl.
- Never shrinks a system already tuned above 8 MiB. Warn-once matters because a reconnecting client rebinds (quiche's reconnect path calls `bind::udp` again).
- The sysctl named in the warning is per-platform: `net.core.{r,w}mem_max` on Linux, `kern.ipc.maxsockbuf` on Apple/BSD, omitted on Windows.
- A private `Direction` enum owns the two socket options, the sysctl name, and the warning, so there are no callback parameters and the warning is directly callable from a test.
- `doc/setup/prod.md` gains a Tuning section with the warning text and a `sysctl.d` snippet, since a self-hoster otherwise has no way to know.

Why it matters: a QUIC stack absorbs bursts in the kernel socket buffer, and whatever doesn't fit while the process is off the CPU is dropped before quinn sees it, which congestion control then reads as congestion. Measured defaults on a Mac: **786896 recv / 9216 send**, versus 8388608 both ways after this change. The send side is the bigger surprise.

## Why a constant, not a flag

8 MiB is compiled in rather than derived from the NIC or exposed as a flag. A socket buffer is a ceiling on queued bytes rather than an allocation, so an oversized request costs an idle client socket nothing, which removes the main reason to size it dynamically. A link's nominal speed is also a poor proxy for the path it feeds (a VM's virtio NIC reports 10 Gbps through a 100 Mbps uplink), and the real constraint is how long the process can be off the CPU, not the line rate. 8 MiB is roughly 64ms of a saturated 1 Gbps link; quic-go asks for 7 MiB. A knob would only earn its place if a deployer needed to *shrink* it.

## Public API changes

None. `bind::udp`'s signature is unchanged; everything added is private to the module. Additive behavior only, so this targets `main`.

## Test plan

- `just check` and `just test` green (1670 tests).
- New unit tests in `bind.rs`:
  - `udp_buffers_grow`: binds through `udp()` and asserts the buffer actually grew past a plain socket's default, or that the host's default already covered 8 MiB and was left untouched. Mutation-checked: deleting the `grow_buffers` call fails it.
  - `a_clamped_buffer_warns_and_names_the_sysctl`: asserts the operator-facing warning names the platform's sysctl (via `tracing_test`). Mutation-checked against the expected string.
  - `sufficient_accounts_for_the_doubled_report`: encodes the Linux doubling rule, which is the subtle part of the comparison.

## Not covered here

- `moq-rtc`'s WebRTC sockets (`server/mux.rs`, `session::bind_udp`) still bind through tokio directly and don't get this treatment. Routing them through `bind::udp` would mean a `moq-native` dependency on `moq-rtc` for one function, plus a `0.0.0.0` to dual-stack change to its ICE candidates. Worth doing, but it's a separate call. `moq-srt` binds no sockets of its own (srt-tokio owns them), and iroh binds its own endpoint.
- Surfacing UDP send/recv drops as `moq-stats` counters (quinn buries them) is left for a follow-up.

## Cross-Package Sync

No row applies: no wire format, `moq-ffi`, catalog, or CLI surface change. The `doc/setup/prod.md` update is included above.

(Written by Opus 5)
