### PR TITLE
docs: scope P2P to the local network, relay across the internet

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -523,15 +523,25 @@ All three flags also accept CLI arguments (`--cache-capacity`,
 ### \[iroh]
 
 Experimental P2P support via [iroh](/concept/layer/iroh). Clients dial the relay's
-endpoint id (`iroh://<endpoint-id>/<path>`) instead of a hostname, with hole punching
-for peers that can't be reached directly.
+endpoint id (`iroh://<endpoint-id>/<path>`) instead of a hostname, with hole punching and an
+n0 relay for clients that can't be reached directly.
 
-Meant for peers on the local network. A client that can't be reached directly should fall
-back to this relay over `https://`, not to the iroh relay: forwarding opaque packets through
-an n0 server buys a hop that caches nothing and fans out to nobody, which is the job this
-process is already doing. Set `disable_relay = true` so a failed hole punch fails instead.
-Note that it only turns off packet forwarding. Discovery still publishes this endpoint's
-addresses to n0's `iroh.link` DNS server and resolves peers from it either way.
+Prefer `https://` for anything off this relay's own network. A client reaching this relay
+over the internet gains nothing from iroh (this process is already the public address, and it
+caches and fans out, which an n0 relay forwarding opaque packets does not), and there's no
+automatic relationship between the two: `iroh://` and `https://` are separate MoQ connections
+to this relay, and dialing one never falls back to the other. That choice belongs to whoever
+writes the URL.
+
+`disable_relay = true` keeps an n0 relay out of the media path entirely. Read
+[Connectivity](/concept/layer/iroh#connectivity) first: it also removes hole punching and the
+probes an endpoint uses to learn its own public address, so it suits a relay meeting peers on
+its own network and breaks one that clients dial over `iroh://` from elsewhere. On a cloud VM
+behind 1:1 NAT it is the difference between advertising your public address and advertising a
+private one nobody can route to.
+
+Either way, discovery still publishes this endpoint's addresses to n0's `iroh.link` DNS
+server, so enabling iroh at all is visible off the network.
 
 ```toml
 [iroh]
@@ -546,8 +556,10 @@ secret = "./relay-iroh-secret.key"
 # bind_v4 = "0.0.0.0:4444"
 # bind_v6 = "[::]:4444"
 
-# Require a direct path, skipping the iroh relay fallback. Recommended.
-disable_relay = true
+# Direct addresses only: no n0 relay, and no hole punching either.
+# Right for peers on this relay's network; see the note above before
+# enabling it on a relay that clients dial from the internet.
+# disable_relay = false
 ```
 
 The endpoint id is logged at startup (`iroh listening endpoint_id=...`). Without `secret`

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -523,8 +523,9 @@ All three flags also accept CLI arguments (`--cache-capacity`,
 ### \[iroh]
 
 Experimental P2P support via [iroh](/concept/layer/iroh). Clients dial the relay's
-endpoint id (`iroh://<endpoint-id>/<path>`) instead of a hostname, with hole punching and an
-n0 relay for clients that can't be reached directly.
+endpoint id (`iroh://<endpoint-id>/<path>`) instead of a hostname. An n0 relay carries the
+connection from the start and hole punching moves it onto a direct path, or fails and leaves
+it there.
 
 Prefer `https://` for anything off this relay's own network. A client reaching this relay
 over the internet gains nothing from iroh (this process is already the public address, and it
@@ -556,10 +557,11 @@ secret = "./relay-iroh-secret.key"
 # bind_v4 = "0.0.0.0:4444"
 # bind_v6 = "[::]:4444"
 
-# Direct addresses only: no n0 relay, and no hole punching either.
-# Right for peers on this relay's network; see the note above before
-# enabling it on a relay that clients dial from the internet.
-# disable_relay = false
+# Uncomment for direct addresses only: no n0 relay, and no hole
+# punching either. Right for peers on this relay's own network; see
+# the note above before enabling it on a relay that clients dial
+# over iroh:// from the internet.
+# disable_relay = true
 ```
 
 The endpoint id is logged at startup (`iroh listening endpoint_id=...`). Without `secret`

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -524,7 +524,14 @@ All three flags also accept CLI arguments (`--cache-capacity`,
 
 Experimental P2P support via [iroh](/concept/layer/iroh). Clients dial the relay's
 endpoint id (`iroh://<endpoint-id>/<path>`) instead of a hostname, with hole punching
-and a relay fallback for peers that can't be reached directly.
+for peers that can't be reached directly.
+
+Meant for peers on the local network. A client that can't be reached directly should fall
+back to this relay over `https://`, not to the iroh relay: forwarding opaque packets through
+an n0 server buys a hop that caches nothing and fans out to nobody, which is the job this
+process is already doing. Set `disable_relay = true` so a failed hole punch fails instead.
+Note that it only turns off packet forwarding. Discovery still publishes this endpoint's
+addresses to n0's `iroh.link` DNS server and resolves peers from it either way.
 
 ```toml
 [iroh]
@@ -539,8 +546,8 @@ secret = "./relay-iroh-secret.key"
 # bind_v4 = "0.0.0.0:4444"
 # bind_v6 = "[::]:4444"
 
-# Require a direct path, skipping the iroh relay fallback.
-# disable_relay = false
+# Require a direct path, skipping the iroh relay fallback. Recommended.
+disable_relay = true
 ```
 
 The endpoint id is logged at startup (`iroh listening endpoint_id=...`). Without `secret`

--- a/doc/concept/layer/index.md
+++ b/doc/concept/layer/index.md
@@ -42,10 +42,14 @@ It sucks but sometimes *media over QUIC* isn't actually an option.
 
 [iroh](/concept/layer/iroh) is a peer-to-peer alternative to dialing a server.
 
-You dial a public key instead of a hostname, and iroh handles discovery, hole punching, and
-a relay fallback when a direct path can't be established.
+You dial a public key instead of a hostname, and iroh handles discovery and hole punching.
 It's still QUIC underneath, so nothing above this layer changes.
 Native only, since a browser can't hole punch.
+
+Reach for it on a local network, where two peers can talk without anything in the middle.
+Across the internet, run a [MoQ relay](/bin/relay/) instead: iroh's own relay fallback forwards
+opaque packets like WebRTC's TURN, so it costs you a hop without the caching and fanout that
+hop should be buying.
 
 ## MoQ Transport
 

--- a/doc/concept/layer/index.md
+++ b/doc/concept/layer/index.md
@@ -47,9 +47,12 @@ It's still QUIC underneath, so nothing above this layer changes.
 Native only, since a browser can't hole punch.
 
 Reach for it on a local network, where two peers can talk without anything in the middle.
-Across the internet, run a [MoQ relay](/bin/relay/) instead: iroh's own relay fallback forwards
-opaque packets like WebRTC's TURN, so it costs you a hop without the caching and fanout that
-hop should be buying.
+Across the internet, run a [MoQ relay](/bin/relay/) instead: iroh's own relay forwards opaque
+packets like WebRTC's TURN, so it costs you a hop without the caching and fanout that hop
+should be buying.
+
+Note that only the media path can be kept local. An endpoint publishes its address to n0's
+discovery servers whichever way it's configured.
 
 ## MoQ Transport
 

--- a/doc/concept/layer/iroh.md
+++ b/doc/concept/layer/iroh.md
@@ -25,11 +25,29 @@ The usual MoQ deployment is a [relay](/bin/relay/) with a public IP, a DNS name,
 certificate. That's the right answer at scale, but it's a lot of ceremony when:
 
 - Two machines on the same LAN want to exchange media and neither is a server.
-- A laptop behind a NAT wants to publish, and you'd rather not run a relay in the middle.
+- Neither of them has a public address, a stable one, or any address you can write down.
 - You want a stable identity for a node whose IP address keeps changing.
 - You don't want to own a domain or provision a certificate just to move some frames.
 
 iroh solves all four with the same mechanism: the endpoint's key **is** its address.
+
+## Scope
+
+Peer-to-peer is a **local network** feature. Keep it there.
+
+- **On one network**, peers dial each other directly and nothing but the media crosses the
+  link. That's the case iroh is for here.
+- **Across the internet**, run a [MoQ relay](/bin/relay/). It has an address both sides can
+  already reach, it caches and fans out, and it's the only shape that scales past two peers.
+
+The iroh relay fallback is the part to be careful with. When hole punching fails it forwards
+your packets through an n0 server, which is the same shape as WebRTC's TURN: a third party in
+the media path that has no idea what it's carrying, can't cache a group, can't serve the
+second viewer from the first one's fetch, and adds however many milliseconds its location
+costs. If media has to cross a server anyway, that server should be a MoQ relay.
+
+So pass `--iroh-disable-relay`, let a failed hole punch be a failed connection, and put a
+relay you chose behind it.
 
 ## Addressing
 
@@ -67,16 +85,25 @@ Getting a packet to a peer behind a NAT happens in stages:
 
 The connection starts over the iroh relay and upgrades to a direct path once hole punching
 succeeds, so there's no connect-time stall while the two sides negotiate.
-By default this uses the public discovery and relay servers operated by
-[n0](https://n0.computer/). Pass `--iroh-disable-relay` to require a direct path and skip
-the fallback entirely.
+`--iroh-disable-relay` drops that first stage, so a peer is reachable only once a direct path
+opens and an unreachable one stays unreachable. That's the [recommended](#scope) setting.
+
+Both stages use the public servers operated by [n0](https://n0.computer/), and **discovery
+runs either way**. An endpoint publishes its own addressing record to n0's `iroh.link` DNS
+server whenever its addresses change, and resolves its peers from the same place, so turning
+iroh on tells a third party which endpoint ids are live and where they are. Disabling the
+relay doesn't opt out of that; it only changes what the record holds, since with no relay URL
+to publish it carries direct IP addresses instead.
+
+Weigh that before enabling iroh for something that has to stay local. The media can be pinned
+to a direct path, the addressing can't.
 
 ::: tip Two different things called "relay"
 An **iroh relay** forwards opaque UDP packets between two peers that can't reach each
 other. It doesn't speak MoQ and doesn't know a track from a group.
 A [**MoQ relay**](/bin/relay/) is a CDN node that understands broadcasts, fans them out,
 and caches groups.
-They're unrelated, and you can use either, both, or neither.
+They're unrelated, and when media has to cross a server, it should be the second one.
 :::
 
 ## Binding
@@ -143,7 +170,7 @@ Dialing an `iroh://` URL without `--iroh-enabled` is an error, not a silent fall
 | `--iroh-secret` | `MOQ_IROH_SECRET` | Hex key or a path to persist one. |
 | `--iroh-bind-v4` | `MOQ_IROH_BIND_V4` | UDP bind address, default `0.0.0.0:0`. |
 | `--iroh-bind-v6` | `MOQ_IROH_BIND_V6` | UDP bind address, default `[::]:0`. |
-| `--iroh-disable-relay` | `MOQ_IROH_DISABLE_RELAY` | Direct paths only, no relay fallback. |
+| `--iroh-disable-relay` | `MOQ_IROH_DISABLE_RELAY` | Direct paths only, no relay fallback. Recommended. |
 
 The endpoint is shared by the client and server halves of a process, so one set of flags
 covers both dialing out and accepting in.
@@ -185,6 +212,8 @@ transport config, so a few of the shared QUIC knobs behave differently:
 - **GSO can't be disabled.** `--client-quic-gso=false` is refused rather than ignored.
 - **No keep-alive knob.** Stream limits, idle timeout, MTU discovery, and congestion
   control carry over; nothing else does.
+- **Discovery is not local.** Publishing and resolving go through n0's servers whatever the
+  relay setting, as above.
 - **No browser support**, as above.
 
 ## More Info

--- a/doc/concept/layer/iroh.md
+++ b/doc/concept/layer/iroh.md
@@ -34,17 +34,18 @@ iroh solves all three with the same mechanism: the endpoint's key **is** its add
 
 Peer-to-peer is a **local network** feature. Keep it there.
 
-- **On one network**, peers dial each other directly and the media never leaves the link.
-  That's the case iroh is for here. (The addressing still does; see
-  [Connectivity](#connectivity).)
+- **On one network**, peers dial each other directly, and with `--iroh-disable-relay` the
+  media never leaves the link. That's the case iroh is for here. (The addressing leaves
+  either way; see [Connectivity](#connectivity).)
 - **Across the internet**, run a [MoQ relay](/bin/relay/). It has an address both sides can
   already reach, it caches and fans out, and it's the only shape that scales past two peers.
 
-The iroh relay is the part to be careful with. When hole punching fails it forwards your
-packets through an n0 server, which is the same shape as WebRTC's TURN: a third party in the
-media path that has no idea what it's carrying, can't cache a group, can't serve the second
-viewer from the first one's fetch, and adds however many milliseconds its location costs. If
-media has to cross a server anyway, that server should be a MoQ relay.
+The iroh relay is the part to be careful with. By default your packets go through an n0
+server from the first byte, and stay there for good if the hole punch never lands. That's the
+same shape as WebRTC's TURN: a third party in the media path that has no idea what it's
+carrying, can't cache a group, can't serve the second viewer from the first one's fetch, and
+adds however many milliseconds its location costs. If media has to cross a server anyway,
+that server should be a MoQ relay.
 
 `--iroh-disable-relay` takes that off the table, but read [Connectivity](#connectivity)
 before reaching for it: an iroh relay is not only the fallback path, it is also how two peers
@@ -145,12 +146,12 @@ enabled = true
 # Persist the key so the endpoint id survives a restart.
 # Generated on first run if the file doesn't exist.
 secret = "./iroh-secret.key"
-
-# Peers on this relay's own network, and no n0 relay in the media path.
-# Leave it out if clients dial this relay over iroh:// from elsewhere;
-# see the note in the relay config reference.
-disable_relay = true
 ```
+
+Whether to add `disable_relay` depends on where this relay's iroh clients are, and the
+[relay config reference](/bin/relay/config#iroh) has the trade. It keeps n0 out of the media
+path, and it breaks a relay that clients dial over `iroh://` from anywhere but its own
+network.
 
 Without `secret` the relay generates a fresh key on every start, which means a new
 endpoint id and a stale URL for everyone who wrote the old one down.

--- a/doc/concept/layer/iroh.md
+++ b/doc/concept/layer/iroh.md
@@ -25,29 +25,33 @@ The usual MoQ deployment is a [relay](/bin/relay/) with a public IP, a DNS name,
 certificate. That's the right answer at scale, but it's a lot of ceremony when:
 
 - Two machines on the same LAN want to exchange media and neither is a server.
-- Neither of them has a public address, a stable one, or any address you can write down.
 - You want a stable identity for a node whose IP address keeps changing.
 - You don't want to own a domain or provision a certificate just to move some frames.
 
-iroh solves all four with the same mechanism: the endpoint's key **is** its address.
+iroh solves all three with the same mechanism: the endpoint's key **is** its address.
 
 ## Scope
 
 Peer-to-peer is a **local network** feature. Keep it there.
 
-- **On one network**, peers dial each other directly and nothing but the media crosses the
-  link. That's the case iroh is for here.
+- **On one network**, peers dial each other directly and the media never leaves the link.
+  That's the case iroh is for here. (The addressing still does; see
+  [Connectivity](#connectivity).)
 - **Across the internet**, run a [MoQ relay](/bin/relay/). It has an address both sides can
   already reach, it caches and fans out, and it's the only shape that scales past two peers.
 
-The iroh relay fallback is the part to be careful with. When hole punching fails it forwards
-your packets through an n0 server, which is the same shape as WebRTC's TURN: a third party in
-the media path that has no idea what it's carrying, can't cache a group, can't serve the
-second viewer from the first one's fetch, and adds however many milliseconds its location
-costs. If media has to cross a server anyway, that server should be a MoQ relay.
+The iroh relay is the part to be careful with. When hole punching fails it forwards your
+packets through an n0 server, which is the same shape as WebRTC's TURN: a third party in the
+media path that has no idea what it's carrying, can't cache a group, can't serve the second
+viewer from the first one's fetch, and adds however many milliseconds its location costs. If
+media has to cross a server anyway, that server should be a MoQ relay.
 
-So pass `--iroh-disable-relay`, let a failed hole punch be a failed connection, and put a
-relay you chose behind it.
+`--iroh-disable-relay` takes that off the table, but read [Connectivity](#connectivity)
+before reaching for it: an iroh relay is not only the fallback path, it is also how two peers
+coordinate a hole punch and how an endpoint learns its own public address. Turning it off
+leaves direct addresses and nothing else, which is exactly right on one link and not much use
+across the internet. That is the trade this page is recommending, not a way to keep NAT
+traversal while dropping the forwarding.
 
 ## Addressing
 
@@ -80,20 +84,27 @@ which is what makes a true peer-to-peer topology possible.
 Getting a packet to a peer behind a NAT happens in stages:
 
 1. **Discovery** finds the peer's candidate addresses from its endpoint id.
-2. **Hole punching** tries to establish a direct path between the two hosts.
-3. **iroh relay** carries the traffic when a direct path can't be established.
+2. **iroh relay** carries the connection immediately, so there's no connect-time stall.
+3. **Hole punching** then tries to open a direct path, and the connection migrates onto it.
 
-The connection starts over the iroh relay and upgrades to a direct path once hole punching
-succeeds, so there's no connect-time stall while the two sides negotiate.
-`--iroh-disable-relay` drops that first stage, so a peer is reachable only once a direct path
-opens and an unreachable one stays unreachable. That's the [recommended](#scope) setting.
+The relay does more than carry the traffic. It's the rendezvous both sides reach first, so
+it's also how they coordinate the punch, and its probes are how an endpoint learns the public
+address to advertise in the first place. Only once the direct path is up does it drop out,
+and it stays in the path as a fallback if the punch never succeeds.
 
-Both stages use the public servers operated by [n0](https://n0.computer/), and **discovery
-runs either way**. An endpoint publishes its own addressing record to n0's `iroh.link` DNS
-server whenever its addresses change, and resolves its peers from the same place, so turning
-iroh on tells a third party which endpoint ids are live and where they are. Disabling the
-relay doesn't opt out of that; it only changes what the record holds, since with no relay URL
-to publish it carries direct IP addresses instead.
+So `--iroh-disable-relay` is not "punch, but don't fall back". It removes stages 2 and 3
+together and leaves stage 1: a peer is reachable if its advertised addresses reach you, and
+unreachable otherwise. On one link that's all you need, and it's the [recommended](#scope)
+setting there. Across a NAT it mostly means no connection, and an endpoint that can't see its
+own public address advertises only its local ones.
+
+**Discovery runs either way.** An endpoint publishes its own addressing record to n0's
+`iroh.link` DNS server whenever its addresses change, so turning iroh on tells a third party
+which endpoint ids are live and where they are, whatever the relay setting. Disabling the
+relay doesn't opt out; it only changes what the record holds, since with no relay URL to
+publish it carries direct IP addresses instead. Resolution is the half you can avoid:
+`Client::with_iroh_addrs` seeds a peer's addresses so a LAN dial needs no lookup. Publishing
+has no such escape hatch.
 
 Weigh that before enabling iroh for something that has to stay local. The media can be pinned
 to a direct path, the addressing can't.
@@ -134,6 +145,11 @@ enabled = true
 # Persist the key so the endpoint id survives a restart.
 # Generated on first run if the file doesn't exist.
 secret = "./iroh-secret.key"
+
+# Peers on this relay's own network, and no n0 relay in the media path.
+# Leave it out if clients dial this relay over iroh:// from elsewhere;
+# see the note in the relay config reference.
+disable_relay = true
 ```
 
 Without `secret` the relay generates a fresh key on every start, which means a new
@@ -150,17 +166,20 @@ The CLI takes the same settings as flags. `--iroh-enabled` binds the endpoint, a
 `iroh://` URL works anywhere an `https://` one would:
 
 ```bash
-# Publish to a peer.
+# Publish to a peer on this network.
 ffmpeg -i video.mp4 -c copy -f mpegts - | \
-    moq --iroh-enabled \
+    moq --iroh-enabled --iroh-disable-relay \
         --client-connect "iroh://k5lnrlndqpqcgh4d5nhbnbnhcyrgvw6ttxwrsvsu4nlt6foorxaa/anon" \
         --broadcast my-stream.hang import ts
 
-# Play it back from another machine.
-moq --iroh-enabled \
+# Play it back from another machine on the same network.
+moq --iroh-enabled --iroh-disable-relay \
     --client-connect "iroh://k5lnrlndqpqcgh4d5nhbnbnhcyrgvw6ttxwrsvsu4nlt6foorxaa/anon" \
     --broadcast my-stream.hang play
 ```
+
+Drop `--iroh-disable-relay` and the two machines can be anywhere, at the cost of an n0 relay
+in the media path until a punch succeeds. Prefer a [MoQ relay](/bin/relay/) for that case.
 
 Dialing an `iroh://` URL without `--iroh-enabled` is an error, not a silent fallback.
 
@@ -170,7 +189,7 @@ Dialing an `iroh://` URL without `--iroh-enabled` is an error, not a silent fall
 | `--iroh-secret` | `MOQ_IROH_SECRET` | Hex key or a path to persist one. |
 | `--iroh-bind-v4` | `MOQ_IROH_BIND_V4` | UDP bind address, default `0.0.0.0:0`. |
 | `--iroh-bind-v6` | `MOQ_IROH_BIND_V6` | UDP bind address, default `[::]:0`. |
-| `--iroh-disable-relay` | `MOQ_IROH_DISABLE_RELAY` | Direct paths only, no relay fallback. Recommended. |
+| `--iroh-disable-relay` | `MOQ_IROH_DISABLE_RELAY` | Direct addresses only: no fallback, and no hole punching. Recommended on a LAN. |
 
 The endpoint is shared by the client and server halves of a process, so one set of flags
 covers both dialing out and accepting in.
@@ -212,8 +231,8 @@ transport config, so a few of the shared QUIC knobs behave differently:
 - **GSO can't be disabled.** `--client-quic-gso=false` is refused rather than ignored.
 - **No keep-alive knob.** Stream limits, idle timeout, MTU discovery, and congestion
   control carry over; nothing else does.
-- **Discovery is not local.** Publishing and resolving go through n0's servers whatever the
-  relay setting, as above.
+- **Publishing is not local.** An endpoint's addressing record goes to n0's servers whatever
+  the relay setting, as above. Resolution can be skipped, publishing can't.
 - **No browser support**, as above.
 
 ## More Info


### PR DESCRIPTION
Docs only. Writes down a policy the iroh page was silent on, and corrects two things it got wrong.

## The policy

P2P is a local-network feature. Across the internet, run a MoQ relay.

The page presented hole punching and the iroh relay as one feature, but they aren't the same trade. A direct path between two peers costs nothing and is the whole point. The relay forwards opaque UDP through an n0 server, which is WebRTC's TURN with none of what a MoQ relay buys for that same hop: it can't cache a group, can't serve a second viewer from the first one's fetch, and adds whatever latency its location costs. If media has to cross a server, that server should be a relay we chose.

## Correction 1: discovery isn't local either

Both n0 presets in `iroh 1.0` install a `PkarrPublisher`, a `PkarrResolver`, and (outside browsers) a `DnsAddressLookup`, all pointed at n0's `iroh.link`. `N0DisableRelay` is `N0` with nothing but `relay_mode(Disabled)` on top:

```rust
impl Preset for N0DisableRelay {
    fn apply(self, builder: Builder) -> Builder {
        N0.apply(builder).relay_mode(RelayMode::Disabled)
    }
}
```

So enabling iroh publishes this endpoint's addressing record to a third party whatever the relay setting; disabling the relay only changes what the record holds, since with no relay URL to publish it carries direct IPs instead. Resolution is the half you can avoid, via `Client::with_iroh_addrs`. Publishing has no equivalent escape hatch. That distinction matters to anyone enabling iroh *so traffic stays local*, and the page didn't make it.

## Correction 2: what `--iroh-disable-relay` actually costs

The first draft of this PR recommended the flag on the theory that it keeps hole punching and drops only the TURN-style fallback. It doesn't, and review caught it. Per iroh's crate docs, a relay is the rendezvous both sides reach first, so it's also how they coordinate the punch, and its probes are the "services to help endpoints understand their own network situation" that let an endpoint learn the public address it advertises. Disabling it removes punching and public-address discovery along with the forwarding, leaving direct addresses only.

That doesn't change the recommendation for the case this page is about, since two peers on one link need none of the three. It does change what the page can claim, and it makes a blanket recommendation unsafe: an earlier revision flipped the relay config sample to `disable_relay = true`, which on a cloud VM behind 1:1 NAT leaves the relay advertising a private address nobody can route to. That sample stays at the default with the trade written out and the deployment each setting suits.

## Changes

- `doc/concept/layer/iroh.md`: new `## Scope` section with the policy; `## Connectivity` rewritten around the real relay model (carries first, migrates on a successful punch) and what discovery publishes; `## Why` no longer headlines the cross-internet case Scope rules out; usage snippets, flag table, and limitations brought in line.
- `doc/concept/layer/index.md`: the iroh summary says LAN, relay otherwise, and that only the media path can be kept local.
- `doc/bin/relay/config.md`: same model in the `[iroh]` section, plus the `disable_relay` trade and a note that `iroh://` and `https://` are separate connections with no automatic fallback between them.

## Not covered

The LAN mDNS mesh (`--cluster-lan`, `cluster.lan`) is the other half of this policy and its docs live only on `dev`, so they're in #2942. Those pages don't exist on `main`, so adding them here would just conflict when `main` merges down. Nothing else in the Cross-Package Sync table applies: no code, wire format, or CLI surface changed.

## Testing

Prose in existing files. Both automated reviewers were out of credits when this opened, so the review ran locally instead; two rounds of findings are folded in, including both corrections above. Claims were checked against `iroh 1.0.3` in the cargo registry and `rs/moq-native/src/iroh.rs`; internal anchors (`#scope`, `#connectivity`) and the `/bin/relay/` link resolve. `nix` and `just` aren't available in this environment, so `just check` was not run; there's nothing in the diff for the Rust or JS halves to compile.

(Written by Claude Opus 5)