### PR TITLE
docs: scope the LAN mesh to the LAN, and document the firewall case

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -234,6 +234,14 @@ https://relay.example.com/anon` serves viewers on the same network directly
 while the relay serves external ones, all from one process and one set of
 broadcasts. With `--cluster-lan` alone nothing leaves the local network.
 
+That pairing is the recommended shape, and the split is deliberate. Peer-to-peer
+is a local network feature: peers are on one link, so a direct session is the
+shortest path there is and no third party sees anything. A viewer somewhere else
+should come through a [relay](/bin/relay/), which has an address both sides can
+already reach and which caches and fans out, so the second viewer costs nothing
+extra. Punching a hole to a peer across the internet buys you the same hop
+without any of that.
+
 By default anyone who can reach the listener joins, exactly like a bare
 `--listen`, so use it on networks you trust. On a network you don't
 control, generate a key and give the same one to every peer:
@@ -256,6 +264,28 @@ the network, and peers with different keys (or none) are mutually invisible.
 Because the proofs are HMACs over a public nonce, a weak key can be brute-forced
 offline by anyone watching the network. Generate 32 random bytes as above rather
 than choosing something memorable.
+
+#### Firewalls
+
+Both halves of the mesh need inbound packets, and a host firewall that drops
+them fails in ways worth recognizing.
+
+mDNS is inbound multicast UDP on port 5353. A host that blocks it still
+multicasts its own announcements out, so peers discover *it* while it discovers
+nobody. Startup won't catch this: readiness waits for an interface to announce,
+which proves the socket opened, not that anything answered.
+
+The session itself is one dial per pair, and only one side makes it. Both peers
+see each other and a MoQ session carries both directions, so the lower peer id
+dials and the higher one waits, which means the higher one has to accept an
+inbound QUIC connection on its `--listen` port. If that side is the one behind
+the firewall, the dial retries until the peer stops advertising and the pair
+never meshes, even though a dial in the other direction would have worked.
+Which side waits is a coin flip on a random id, so the same two machines can
+mesh on one run and not the next.
+
+If a pair won't come up, check `--listen` (and 5353) against the firewall on
+*both* hosts, not just the one that looks stuck.
 
 ### Multiple Stages
 

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -284,8 +284,10 @@ never meshes, even though a dial in the other direction would have worked.
 Which side waits is a coin flip on a random id, so the same two machines can
 mesh on one run and not the next.
 
-If a pair won't come up, check `--listen` (and 5353) against the firewall on
-*both* hosts, not just the one that looks stuck.
+If a pair won't come up, check the firewall on *both* hosts, not just the one
+that looks stuck. Pass `--listen` yourself first: the port it fills in is
+ephemeral and changes every run, so there is nothing stable to allow until you
+pin it. Then allow that port and UDP 5353 on both.
 
 ### Multiple Stages
 

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -109,6 +109,21 @@ multicast is blocked fails the relay rather than releasing the units that depend
 on it. One working interface is enough: a down VPN adapter or a container bridge
 with multicast off doesn't hold startup back.
 
+`lan` is for relays sharing a link, and only that. Peers off the network are
+gossiped, listed by `connect_api`, or seeded in `connect`, and they reach each
+other over their `node` URLs like any other cluster link. A relay is already the
+public address both sides can reach, so there is nothing for peer-to-peer to
+save there; on one link it saves the round trip out and back.
+
+Both hosts need inbound packets for this to work, in two places. mDNS is inbound
+multicast UDP on port 5353, and a host that blocks it still multicasts its own
+announcements out, so peers discover it while it discovers nobody. The session
+is then one dial per pair, taken by whichever side loses the `node` URL
+tiebreaker, so the other side has to accept an inbound connection on its `node`
+port. Startup readiness only proves an interface announced, not that anything
+answered, so a firewall shows up as a pair that never meshes rather than as a
+relay that fails to start.
+
 ## Origin id
 
 Each relay has an origin id: the value it adds to a broadcast's hop list for loop detection and shortest-path routing. On `moq-lite`, and on a `moqt-17`-or-later session that negotiated the cluster extension, each end declares it at setup so the other can avoid announcing (or serving) a path that already flows through it. Older sessions carry no identity, so a peer only has one if you assign it. By default a fresh random id is picked on every start, which is fine for loop detection but means a relay looks like a brand-new node each time it restarts.

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -104,10 +104,11 @@ cannot be copied into someone else's, and a relay only dials peers whose proof
 verifies.
 
 Startup waits for the mesh to come up before the relay reports itself ready
-(`READY=1` under systemd), so a bad key, a missing `node`, or a host where
-multicast is blocked fails the relay rather than releasing the units that depend
-on it. One working interface is enough: a down VPN adapter or a container bridge
-with multicast off doesn't hold startup back.
+(`READY=1` under systemd), so a bad key, a missing `node`, or a host that cannot
+announce on any interface fails the relay rather than releasing the units that
+depend on it. One working interface is enough: a down VPN adapter or a container
+bridge with multicast off doesn't hold startup back. It only proves this host
+can send, though, so see below for what it doesn't catch.
 
 `lan` is for relays sharing a link, and only that. Peers off the network are
 gossiped, listed by `connect_api`, or seeded in `connect`, and they reach each
@@ -118,8 +119,8 @@ save there; on one link it saves the round trip out and back.
 Both hosts need inbound packets for this to work, in two places. mDNS is inbound
 multicast UDP on port 5353, and a host that blocks it still multicasts its own
 announcements out, so peers discover it while it discovers nobody. The session
-is then one dial per pair, taken by whichever side loses the `node` URL
-tiebreaker, so the other side has to accept an inbound connection on its `node`
+is then one dial per pair, taken by the side whose `node` URL sorts first, so the
+*other* side is the one that has to accept an inbound connection on its `node`
 port. Startup readiness only proves an interface announced, not that anything
 answered, so a firewall shows up as a pair that never meshes rather than as a
 relay that fails to start.


### PR DESCRIPTION
Docs only, the `dev` half of #2941. That PR covers the iroh page, which only exists on `main`; the `--cluster-lan` / `cluster.lan` pages only exist here, so the same policy needs writing down in both places.

## Scope

Peer-to-peer is a local network feature. Peers on one link are the case it wins: a direct session is the shortest path there is and nothing leaves the network. A viewer somewhere else should come through a relay, which is already a public address both sides can reach and which caches and fans out, so the second viewer costs nothing extra. Hole punching to a peer across the internet buys the same hop with none of that.

`doc/bin/cli.md` half said this already ("with `--cluster-lan` alone nothing leaves the local network"). It now says why that's the shape to want rather than a side effect of the transport. `doc/bin/relay/cluster.md` gets the same, phrased for a relay: `lan` is for relays sharing a link, everything else is gossip / `connect_api` / `connect` over `node` URLs.

## Firewalls

Neither page mentioned this, and both halves of the mesh fail quietly without inbound packets.

**Discovery.** mDNS is inbound multicast UDP/5353. A host that blocks it still multicasts its own announcements outward, so peers discover *it* while it discovers nobody, and it's the side that then never dials. The readiness gate doesn't catch it: `announced()` in `rs/moq-tokio/src/mdns.rs` waits for `DaemonEvent::Announce` on one interface, which proves the socket opened, not that anything answered.

**The dial.** `Discovery::should_dial` is `local < remote`, so the lower peer id dials and the higher one waits in `accept`. There's no fallback, so the waiting side has to accept an inbound QUIC connection on its listener. When that's the firewalled side, the dial retries until the advertisement expires: `rs/moq-cli/src/cluster.rs` sets `client.backoff.timeout = Some(Duration::ZERO)`, which is unlimited retries capped at a 5s delay. Which side waits is a coin flip on a random instance id, so the same two machines can mesh on one run and not the next. That's the symptom someone would otherwise file as a flake, hence documenting it.

Documented as a limitation here rather than fixed. The fix (let the waiting side dial too after a short delay, and drop the loser's dial when both land) is a behavior change, and it's being discussed separately alongside using a client certificate to identify the dialer.

## Cross-package sync

Nothing else in the table applies. No code, wire format, or CLI surface changed.

## Testing

Prose in two existing pages. The one new link (`/bin/relay/`) matches the absolute style already used elsewhere in `cli.md`, and the new `#### Firewalls` heading sits at the end of the `### LAN Cluster (mDNS)` section so nothing following it changes level. `nix` and `just` aren't available in this environment, so `just check` was not run; there's nothing in the diff for the Rust or JS halves to compile.

(Written by Claude Opus 5)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDHxYmtSzej5eaz3NUAfhQ)_