### PR TITLE
Reactive firefox 153+ via bowser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -187,6 +187,7 @@
         "@moq/qmux": "^0.3.3",
         "@moq/signals": "workspace:*",
         "async-mutex": "^0.5.0",
+        "bowser": "^2.14.1",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -959,6 +960,8 @@
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -19,7 +19,8 @@
 	"dependencies": {
 		"@moq/qmux": "^0.3.3",
 		"@moq/signals": "workspace:*",
-		"async-mutex": "^0.5.0"
+		"async-mutex": "^0.5.0",
+		"bowser": "^2.14.1"
 	},
 	"peerDependencies": {
 		"zod": "^4.0.0"

--- a/js/net/src/connection/browser.ts
+++ b/js/net/src/connection/browser.ts
@@ -1,19 +1,23 @@
+import Bowser from "bowser";
+
 /** Returns whether a browser user agent has a usable WebTransport implementation. */
 export function isWebTransportUserAgentSupported(userAgent: string): boolean {
-	const normalized = userAgent.toLowerCase();
+	const browser = Bowser.getParser(userAgent);
+	const supported = browser.satisfies({
+		// Fixed with 153.0.0, Firefox only allows two concurrent remote-initiated streams:
+		// https://bugzilla.mozilla.org/show_bug.cgi?id=2046262
+		firefox: ">=153.0",
 
-	// Firefox only allows two concurrent remote-initiated streams:
-	// https://bugzilla.mozilla.org/show_bug.cgi?id=2046262
-	if (normalized.includes("firefox")) return false;
+		// Safari's flow-control window never refills, which permanently stalls sessions:
+		// https://bugs.webkit.org/show_bug.cgi?id=319818
+		safari: "<0",
+	});
 
-	// Safari's flow-control window never refills, which permanently stalls sessions:
-	// https://bugs.webkit.org/show_bug.cgi?id=319818
-	const isSafari =
-		normalized.includes("safari") &&
-		!normalized.includes("chrome") &&
-		!normalized.includes("chromium") &&
-		!normalized.includes("android");
-	return !isSafari;
+	if (supported === undefined) {
+		//By default, other browsers are considered to support WebTransport.
+		return true;
+	}
+	return supported;
 }
 
 /** Returns whether this runtime can connect with WebTransport. */


### PR DESCRIPTION
## Description
This PR replaces the base string match on `navigator.userAgent` with `bowser` in `@moq/net` for more stable browser filtering with version management.

As noted in [this comment](https://github.com/moq-dev/moq/issues/1329#issuecomment-5238290592) (Bugzilla #2046262 has been fixed and updated to Firefox 153). Firefox support is now enabled for versions 153 and above, but blocked for versions below 153. And I left the Safari browser disabled like before.

## Changes
- Added `bowser` dependency to `@moq/net`.
- Refactored `isWebTransportUserAgentSupported` using Bowser parser.
- Firefox WebTransport support for versions 153.0.0 and later.

## Validation
- Ran `just js` locally with success.
- I tested this `@moq/net` with a moq-rs server on Firefox 153.0.4 and Google Chrome successfully.

Fixes #1329 

(Written by Gemini-3.6 Flash)