### PR TITLE
fix(moq-net): report PROBE partially, and only advertise Probe we can honour

### DIFF
--- a/js/net/src/lite/connection.test.ts
+++ b/js/net/src/lite/connection.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { probeLevel } from "./connection.ts";
+import { ProbeLevel } from "./setup.ts";
+import { Version } from "./version.ts";
+
+/** A transport whose `getStats` behaves as described, or is absent entirely. */
+function transport(getStats?: () => Promise<unknown>): WebTransport {
+	return (getStats ? { getStats } : {}) as unknown as WebTransport;
+}
+
+// `Report` claims we can measure and periodically report. The qmux/WebSocket
+// fallback implements no `getStats()`, so a publisher there has nothing to send;
+// advertising Report and then holding the subscriber's PROBE stream open with
+// nothing on it is the state this avoids.
+test("no getStats advertises None", async () => {
+	expect(await probeLevel(transport(), Version.DRAFT_05)).toBe(ProbeLevel.None);
+});
+
+// Having the method is not the same as having a measurement.
+test("getStats with no usable metric advertises None", async () => {
+	const quic = transport(async () => ({ estimatedSendRate: null }));
+	expect(await probeLevel(quic, Version.DRAFT_05)).toBe(ProbeLevel.None);
+});
+
+test("either metric alone is enough to advertise Report", async () => {
+	const rateOnly = transport(async () => ({ estimatedSendRate: 1_000_000 }));
+	expect(await probeLevel(rateOnly, Version.DRAFT_05)).toBe(ProbeLevel.Report);
+
+	const rttOnly = transport(async () => ({ estimatedSendRate: null, smoothedRtt: 12.34 }));
+	expect(await probeLevel(rttOnly, Version.DRAFT_05)).toBe(ProbeLevel.Report);
+});
+
+// A transport that cannot answer tells us nothing, which is itself an answer. A
+// throwing getStats must not escape into the SETUP path.
+test("a throwing getStats advertises None rather than propagating", async () => {
+	const quic = transport(async () => {
+		throw new Error("no stats for you");
+	});
+	expect(await probeLevel(quic, Version.DRAFT_05)).toBe(ProbeLevel.None);
+});

--- a/js/net/src/lite/connection.test.ts
+++ b/js/net/src/lite/connection.test.ts
@@ -30,6 +30,13 @@ test("either metric alone is enough to advertise Report", async () => {
 	expect(await probeLevel(rttOnly, Version.DRAFT_05)).toBe(ProbeLevel.Report);
 });
 
+// lite-03's PROBE has no RTT field, so an RTT is not something we could report
+// there even though we can measure it.
+test("an RTT alone is not reportable on a version that cannot carry one", async () => {
+	const rttOnly = transport(async () => ({ estimatedSendRate: null, smoothedRtt: 12.34 }));
+	expect(await probeLevel(rttOnly, Version.DRAFT_03)).toBe(ProbeLevel.None);
+});
+
 // A transport that cannot answer tells us nothing, which is itself an answer. A
 // throwing getStats must not escape into the SETUP path.
 test("a throwing getStats advertises None rather than propagating", async () => {

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -204,8 +204,8 @@ export class Connection implements Established {
 
 	// Open the unidirectional Setup Stream, send our single SETUP, and FIN (lite-05+).
 	// The browser uses WebTransport, which carries the request URI, so we advertise no
-	// path and leave routing to the URL. We advertise probe = Report (we measure and
-	// report bitrate over the PROBE stream, but don't actively pad the connection).
+	// path and leave routing to the URL. The probe level reflects what this transport
+	// can actually measure; we never pad, so we never advertise Increase.
 	// Role stays Both: publish/consume are called after this point, so there is nothing
 	// to narrow yet. The origin declares our session identity so the peer can filter
 	// reflected announcements (lite-06 removed ANNOUNCE_REQUEST's exclude_hop for it).
@@ -213,7 +213,7 @@ export class Connection implements Established {
 		const writer = await Writer.open(this.#quic);
 		try {
 			await writer.u53(DataType.Setup);
-			await new Setup({ probe: ProbeLevel.Report, origin: this.origin }).encode(writer, this.#version);
+			await new Setup({ probe: probeLevel(this.#quic), origin: this.origin }).encode(writer, this.#version);
 			writer.close();
 		} catch (err: unknown) {
 			writer.reset(err);
@@ -304,4 +304,17 @@ export class Connection implements Established {
 	get closed(): Promise<void> {
 		return this.#quic.closed.then(() => undefined);
 	}
+}
+
+/**
+ * The probe level to advertise in SETUP, from what the transport can measure.
+ *
+ * `Report` claims we can measure and periodically report. The qmux/WebSocket
+ * fallback implements no `getStats()`, so a publisher there has nothing to send;
+ * advertising `Report` and then resetting the stream the subscriber opens is not a
+ * conformant state, and the subscriber's own gate skips a stream it can't use.
+ */
+function probeLevel(quic: WebTransport): ProbeLevel {
+	const getStats = (quic as unknown as { getStats?: unknown }).getStats;
+	return typeof getStats === "function" ? ProbeLevel.Report : ProbeLevel.None;
 }

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -18,7 +18,7 @@ import { DataType, StreamId } from "./stream.ts";
 import { Subscribe } from "./subscribe.ts";
 import { Subscriber } from "./subscriber.ts";
 import { Track as TrackMessage } from "./track.ts";
-import { hasDatagrams, hasSetupStream, type Version, versionName } from "./version.ts";
+import { hasDatagrams, hasProbeRtt, hasSetupStream, type Version, versionName } from "./version.ts";
 
 /**
  * Constructor options for {@link Connection}.
@@ -213,7 +213,8 @@ export class Connection implements Established {
 		const writer = await Writer.open(this.#quic);
 		try {
 			await writer.u53(DataType.Setup);
-			await new Setup({ probe: probeLevel(this.#quic), origin: this.origin }).encode(writer, this.#version);
+			const probe = await probeLevel(this.#quic, this.#version);
+			await new Setup({ probe, origin: this.origin }).encode(writer, this.#version);
 			writer.close();
 		} catch (err: unknown) {
 			writer.reset(err);
@@ -309,12 +310,32 @@ export class Connection implements Established {
 /**
  * The probe level to advertise in SETUP, from what the transport can measure.
  *
- * `Report` claims we can measure and periodically report. The qmux/WebSocket
- * fallback implements no `getStats()`, so a publisher there has nothing to send;
- * advertising `Report` and then resetting the stream the subscriber opens is not a
- * conformant state, and the subscriber's own gate skips a stream it can't use.
+ * `Report` claims we can measure and periodically report, so it is only truthful
+ * when a metric this version can carry actually exists. The qmux/WebSocket fallback
+ * implements no `getStats()` at all, and even a transport that has one may report
+ * neither figure. Advertising `Report` and then holding the subscriber's PROBE
+ * stream open with nothing to send is the state this avoids; the subscriber's own
+ * gate then skips a stream it could not use.
+ *
+ * Mirrors `ProbeLevel::detect` in `moq-net`, including its limitation: a metric
+ * that only appears after SETUP reads as unsupported here.
  */
-function probeLevel(quic: WebTransport): ProbeLevel {
-	const getStats = (quic as unknown as { getStats?: unknown }).getStats;
-	return typeof getStats === "function" ? ProbeLevel.Report : ProbeLevel.None;
+async function probeLevel(quic: WebTransport, version: Version): Promise<ProbeLevel> {
+	const getStats = (
+		quic as unknown as {
+			getStats?: () => Promise<{ estimatedSendRate: number | null; smoothedRtt?: number | null }>;
+		}
+	).getStats;
+	if (typeof getStats !== "function") return ProbeLevel.None;
+
+	// A transport that can't answer tells us nothing, which is itself an answer.
+	let stats: { estimatedSendRate: number | null; smoothedRtt?: number | null };
+	try {
+		stats = await getStats.call(quic);
+	} catch {
+		return ProbeLevel.None;
+	}
+
+	const rtt = hasProbeRtt(version) ? stats.smoothedRtt : undefined;
+	return stats.estimatedSendRate != null || rtt != null ? ProbeLevel.Report : ProbeLevel.None;
 }

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -319,8 +319,10 @@ export class Connection implements Established {
  *
  * Mirrors `ProbeLevel::detect` in `moq-net`, including its limitation: a metric
  * that only appears after SETUP reads as unsupported here.
+ *
+ * @internal
  */
-async function probeLevel(quic: WebTransport, version: Version): Promise<ProbeLevel> {
+export async function probeLevel(quic: WebTransport, version: Version): Promise<ProbeLevel> {
 	const getStats = (
 		quic as unknown as {
 			getStats?: () => Promise<{ estimatedSendRate: number | null; smoothedRtt?: number | null }>;

--- a/js/net/src/lite/probe.test.ts
+++ b/js/net/src/lite/probe.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { Reader, Writer } from "../stream.ts";
+import { Probe } from "./probe.ts";
+import { Version } from "./version.ts";
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+	const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const c of chunks) {
+		out.set(c, offset);
+		offset += c.byteLength;
+	}
+	return out;
+}
+
+async function bytes(f: (w: Writer) => Promise<void>): Promise<Uint8Array> {
+	const written: Uint8Array[] = [];
+	const writer = new Writer(
+		new WritableStream<Uint8Array>({ write: (chunk) => void written.push(new Uint8Array(chunk)) }),
+	);
+	await f(writer);
+	writer.close();
+	await writer.closed;
+	return concat(written);
+}
+
+async function roundTrip(msg: Probe, version: Version = Version.DRAFT_05): Promise<Probe> {
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, version)));
+	const got = await Probe.decode(reader, version);
+	expect(await reader.done()).toBe(true);
+	return got;
+}
+
+// Both fields travel as 0 for unknown, independently, so a transport exposing only
+// one still has a legal message to send.
+test("each field is independently unknown", async () => {
+	for (const [bitrate, rtt] of [
+		[1_000_000, 40],
+		[undefined, 40],
+		[1_000_000, undefined],
+		[undefined, undefined],
+	] as const) {
+		const got = await roundTrip(new Probe({ bitrate, rtt }));
+		expect(got.bitrate).toBe(bitrate);
+		expect(got.rtt).toBe(rtt);
+	}
+});
+
+// A measured zero is indistinguishable from unknown on the wire, so it rounds up to
+// the smallest value that still reads as a measurement.
+test("a measured zero rounds up", async () => {
+	const got = await roundTrip(new Probe({ bitrate: 0, rtt: 0 }));
+	expect(got.bitrate).toBe(1);
+	expect(got.rtt).toBe(1);
+});
+
+// lite-03 predates the RTT field; the bitrate half still round-trips.
+test("lite-03 carries the bitrate alone", async () => {
+	const got = await roundTrip(new Probe({ bitrate: 1_000_000, rtt: 40 }), Version.DRAFT_03);
+	expect(got.bitrate).toBe(1_000_000);
+	expect(got.rtt).toBeUndefined();
+});
+
+// `smoothedRtt` is a DOMHighResTimeStamp, so a real browser hands us a fraction. The
+// varint encoder converts with `BigInt`, which throws on one, and the publisher's
+// catch would then close the probe stream for the rest of the session.
+test("a fractional RTT must not reach the encoder", async () => {
+	await expect(bytes((w) => new Probe({ bitrate: 1_000, rtt: 12.34 }).encode(w, Version.DRAFT_05))).rejects.toThrow();
+
+	// Rounding first is what the publisher does, and it encodes cleanly.
+	const got = await roundTrip(new Probe({ bitrate: 1_000, rtt: Math.round(12.34) }));
+	expect(got.rtt).toBe(12);
+});

--- a/js/net/src/lite/probe.ts
+++ b/js/net/src/lite/probe.ts
@@ -1,6 +1,6 @@
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
-import { Version } from "./version.ts";
+import { hasProbeRtt, Version } from "./version.ts";
 
 function guardProbe(version: Version) {
 	switch (version) {
@@ -12,13 +12,23 @@ function guardProbe(version: Version) {
 	}
 }
 
+/** The metrics a PROBE message carries. Each is independently optional. */
+export interface ProbeInit {
+	/** Estimated send bitrate in bits per second. Omit if unknown. */
+	bitrate?: number;
+	/** Smoothed round-trip time in milliseconds. Omit if unknown. */
+	rtt?: number;
+}
+
 export class Probe {
 	/** Estimated send bitrate in bits per second, or undefined if unknown. */
 	bitrate?: number;
 	/** Smoothed round-trip time in milliseconds, or undefined if unknown. */
 	rtt?: number;
 
-	constructor(bitrate?: number, rtt?: number) {
+	// Named rather than positional: the two fields share a type, so positional
+	// arguments could be swapped without a type error.
+	constructor({ bitrate, rtt }: ProbeInit = {}) {
 		this.bitrate = bitrate;
 		this.rtt = rtt;
 	}
@@ -26,14 +36,8 @@ export class Probe {
 	async #encode(w: Writer, version: Version) {
 		// 0 means unknown; round a measured 0 up to 1.
 		await w.u53(this.bitrate !== undefined ? Math.max(this.bitrate, 1) : 0);
-		switch (version) {
-			case Version.DRAFT_03:
-				break;
-			default: {
-				const wire = this.rtt !== undefined ? Math.max(this.rtt, 1) : 0;
-				await w.u53(wire);
-				break;
-			}
+		if (hasProbeRtt(version)) {
+			await w.u53(this.rtt !== undefined ? Math.max(this.rtt, 1) : 0);
 		}
 	}
 
@@ -42,16 +46,11 @@ export class Probe {
 		const bitrateWire = await r.u53();
 		const bitrate = bitrateWire === 0 ? undefined : bitrateWire;
 		let rtt: number | undefined;
-		switch (version) {
-			case Version.DRAFT_03:
-				break;
-			default: {
-				const wire = await r.u53();
-				rtt = wire === 0 ? undefined : wire;
-				break;
-			}
+		if (hasProbeRtt(version)) {
+			const wire = await r.u53();
+			rtt = wire === 0 ? undefined : wire;
 		}
-		return new Probe(bitrate, rtt);
+		return new Probe({ bitrate, rtt });
 	}
 
 	async encode(w: Writer, version: Version): Promise<void> {

--- a/js/net/src/lite/probe.ts
+++ b/js/net/src/lite/probe.ts
@@ -13,21 +13,23 @@ function guardProbe(version: Version) {
 }
 
 export class Probe {
-	bitrate: number;
+	/** Estimated send bitrate in bits per second, or undefined if unknown. */
+	bitrate?: number;
+	/** Smoothed round-trip time in milliseconds, or undefined if unknown. */
 	rtt?: number;
 
-	constructor(bitrate: number, rtt?: number) {
+	constructor(bitrate?: number, rtt?: number) {
 		this.bitrate = bitrate;
 		this.rtt = rtt;
 	}
 
 	async #encode(w: Writer, version: Version) {
-		await w.u53(this.bitrate);
+		// 0 means unknown; round a measured 0 up to 1.
+		await w.u53(this.bitrate !== undefined ? Math.max(this.bitrate, 1) : 0);
 		switch (version) {
 			case Version.DRAFT_03:
 				break;
 			default: {
-				// 0 means unknown; round Some(0) up to 1.
 				const wire = this.rtt !== undefined ? Math.max(this.rtt, 1) : 0;
 				await w.u53(wire);
 				break;
@@ -36,7 +38,9 @@ export class Probe {
 	}
 
 	static async #decode(r: Reader, version: Version): Promise<Probe> {
-		const bitrate = await r.u53();
+		// 0 means unknown, the same as the RTT below.
+		const bitrateWire = await r.u53();
+		const bitrate = bitrateWire === 0 ? undefined : bitrateWire;
 		let rtt: number | undefined;
 		switch (version) {
 			case Version.DRAFT_03:

--- a/js/net/src/lite/probe.ts
+++ b/js/net/src/lite/probe.ts
@@ -20,6 +20,13 @@ export interface ProbeInit {
 	rtt?: number;
 }
 
+/**
+ * A PROBE message: the publisher's current view of the connection.
+ *
+ * Both metrics are independently optional and travel as 0 for unknown, so a
+ * transport exposing only one still has something to report. A measured 0 is
+ * rounded up to 1, since the wire cannot tell it from unknown.
+ */
 export class Probe {
 	/** Estimated send bitrate in bits per second, or undefined if unknown. */
 	bitrate?: number;

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -8,6 +8,7 @@ import { Reader, Stream } from "../stream.ts";
 import { Fetch } from "./fetch.ts";
 import { Group as GroupMessage } from "./group.ts";
 import { sendOrder } from "./priority.ts";
+import { Probe as ProbeMessage } from "./probe.ts";
 import { Publisher } from "./publisher.ts";
 import { decodeSubscribeResponse, Subscribe, SubscribeUpdate } from "./subscribe.ts";
 import { ALPN_05, Version } from "./version.ts";
@@ -589,4 +590,27 @@ test("lite draft-05: a group waiting for a stream slot survives the track finish
 	expect(await outcome).toBe("sent");
 
 	close();
+});
+
+// `smoothedRtt` is a DOMHighResTimeStamp, so a real browser hands back a fractional
+// millisecond. The varint encoder converts with `BigInt`, which throws on a fraction,
+// and `runProbe`'s catch would then close the probe stream for the rest of the
+// session. Drive the real loop so removing the rounding fails this test.
+test("runProbe rounds a fractional smoothedRtt instead of killing the stream", async () => {
+	const pair = createMockTransportPair(ALPN_05, {
+		stats: { estimatedSendRate: 1_000_000, smoothedRtt: 12.34 },
+	});
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin());
+
+	// The subscriber opens the probe stream; the publisher only replies on it.
+	const client = await Stream.open(pair.client);
+	const server = await Stream.accept(pair.server);
+	if (!server) throw new Error("publisher never accepted the probe stream");
+
+	void publisher.runProbe(server);
+
+	const probe = await ProbeMessage.decodeMaybe(client.reader, Version.DRAFT_05);
+	expect(probe).toBeDefined();
+	expect(probe?.rtt).toBe(12);
+	expect(probe?.bitrate).toBe(1_000_000);
 });

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -607,10 +607,16 @@ test("runProbe rounds a fractional smoothedRtt instead of killing the stream", a
 	const server = await Stream.accept(pair.server);
 	if (!server) throw new Error("publisher never accepted the probe stream");
 
-	void publisher.runProbe(server);
-
-	const probe = await ProbeMessage.decodeMaybe(client.reader, Version.DRAFT_05);
-	expect(probe).toBeDefined();
-	expect(probe?.rtt).toBe(12);
-	expect(probe?.bitrate).toBe(1_000_000);
+	// `runProbe` loops until the stream closes, so close it rather than leaving the
+	// task running past the end of the test.
+	const probing = publisher.runProbe(server);
+	try {
+		const probe = await ProbeMessage.decodeMaybe(client.reader, Version.DRAFT_05);
+		expect(probe).toBeDefined();
+		expect(probe?.rtt).toBe(12);
+		expect(probe?.bitrate).toBe(1_000_000);
+	} finally {
+		client.close();
+		await probing;
+	}
 });

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -699,9 +699,13 @@ export class Publisher {
 				// report. Anything this version can't carry is dropped here rather
 				// than by the encoder, so it reads as unknown to every check below.
 				const stats = await quic.getStats();
+				// `smoothedRtt` is a DOMHighResTimeStamp, i.e. a double, but the wire
+				// carries whole milliseconds and the varint encoder throws on a
+				// fractional value. Round before it ever reaches `Probe`.
+				const rtt = stats.smoothedRtt != null ? Math.round(stats.smoothedRtt) : undefined;
 				const report = new Probe({
 					bitrate: stats.estimatedSendRate ?? undefined,
-					rtt: hasProbeRtt(this.version) ? (stats.smoothedRtt ?? undefined) : undefined,
+					rtt: hasProbeRtt(this.version) ? rtt : undefined,
 				});
 
 				// Nothing left to report. Say so once if it retracts a value the peer

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -23,7 +23,7 @@ import {
 	SubscribeUpdate,
 } from "./subscribe.ts";
 import { TrackInfo as TrackInfoMessage, type Track as TrackMessage } from "./track.ts";
-import { hasAnnounceId, hasAnnounceOk, hasDatagrams, Version } from "./version.ts";
+import { hasAnnounceId, hasAnnounceOk, hasDatagrams, hasProbeRtt, Version } from "./version.ts";
 
 const PROBE_INTERVAL = 100; // ms
 const PROBE_MAX_AGE = 10_000; // ms
@@ -696,12 +696,22 @@ export class Publisher {
 
 				// The two fields are independent on the wire, each using 0 for
 				// unknown, so a transport exposing only one still has something to
-				// report.
+				// report. Anything this version can't carry is dropped here rather
+				// than by the encoder, so it reads as unknown to every check below.
 				const stats = await quic.getStats();
-				const report = new Probe(stats.estimatedSendRate ?? undefined, stats.smoothedRtt ?? undefined);
+				const report = new Probe({
+					bitrate: stats.estimatedSendRate ?? undefined,
+					rtt: hasProbeRtt(this.version) ? (stats.smoothedRtt ?? undefined) : undefined,
+				});
 
-				// Neither metric is measurable, so there is nothing to say.
-				if (report.bitrate === undefined && report.rtt === undefined) continue;
+				// Nothing left to report. Say so once if it retracts a value the peer
+				// is still holding, then stay quiet rather than repeating "unknown"
+				// every time the max age comes around.
+				if (report.bitrate === undefined && report.rtt === undefined) {
+					const retracts =
+						lastSent !== undefined && (lastSent.bitrate !== undefined || lastSent.rtt !== undefined);
+					if (!retracts) continue;
+				}
 
 				let shouldSend: boolean;
 				if (lastSent === undefined || lastSentTime === undefined) {

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -28,6 +28,7 @@ import { hasAnnounceId, hasAnnounceOk, hasDatagrams, Version } from "./version.t
 const PROBE_INTERVAL = 100; // ms
 const PROBE_MAX_AGE = 10_000; // ms
 const PROBE_MAX_DELTA = 0.25;
+const PROBE_RTT_DELTA = 0.25;
 
 /** Map a signed delta to an unsigned zigzag varint value (mirrors Rust `VarInt::from_zigzag`). */
 function zigzag(delta: bigint): bigint {
@@ -664,7 +665,7 @@ export class Publisher {
 	async runProbe(stream: Stream) {
 		// getStats is not yet in the TypeScript WebTransport type definitions.
 		const quic = this.#quic as unknown as {
-			getStats?: () => Promise<{ estimatedSendRate: number | null }>;
+			getStats?: () => Promise<{ estimatedSendRate: number | null; smoothedRtt?: number | null }>;
 		};
 		if (!quic.getStats) {
 			// Best-effort: we can't supply bandwidth estimates, so close the
@@ -673,8 +674,17 @@ export class Publisher {
 			return;
 		}
 
-		let lastSentBitrate: number | undefined;
+		let lastSent: Probe | undefined;
 		let lastSentTime: number | undefined;
+
+		// Whether a metric moved enough to be worth another report. Gaining or
+		// losing a value always counts; both unknown never does.
+		const moved = (prev?: number, next?: number, threshold = 0): boolean => {
+			if (prev === undefined && next === undefined) return false;
+			if (prev === undefined || next === undefined) return true;
+			if (prev === 0) return next !== 0;
+			return Math.abs(next - prev) / prev >= threshold;
+		};
 
 		try {
 			for (;;) {
@@ -684,27 +694,34 @@ export class Publisher {
 				const result = await Promise.race([timeout, stream.reader.closed]);
 				if (result !== "timeout") break;
 
+				// The two fields are independent on the wire, each using 0 for
+				// unknown, so a transport exposing only one still has something to
+				// report.
 				const stats = await quic.getStats();
-				const bitrate = stats.estimatedSendRate;
-				if (bitrate == null) continue;
+				const report = new Probe(stats.estimatedSendRate ?? undefined, stats.smoothedRtt ?? undefined);
+
+				// Neither metric is measurable, so there is nothing to say.
+				if (report.bitrate === undefined && report.rtt === undefined) continue;
 
 				let shouldSend: boolean;
-				if (lastSentBitrate === undefined || lastSentTime === undefined) {
+				if (lastSent === undefined || lastSentTime === undefined) {
 					shouldSend = true;
-				} else if (lastSentBitrate === 0) {
-					shouldSend = bitrate > 0;
 				} else {
 					const elapsed = performance.now() - lastSentTime;
+					// The bitrate threshold decays to zero as the last report ages: a
+					// stale estimate is worth refreshing for a smaller move.
 					const t = Math.max(PROBE_INTERVAL, Math.min(PROBE_MAX_AGE, elapsed));
 					const range = PROBE_MAX_AGE - PROBE_INTERVAL;
 					const threshold = (PROBE_MAX_DELTA * (PROBE_MAX_AGE - t)) / range;
-					const change = Math.abs(bitrate - lastSentBitrate) / lastSentBitrate;
-					shouldSend = change >= threshold;
+					shouldSend =
+						elapsed >= PROBE_MAX_AGE ||
+						moved(lastSent.bitrate, report.bitrate, threshold) ||
+						moved(lastSent.rtt, report.rtt, PROBE_RTT_DELTA);
 				}
 
 				if (shouldSend) {
-					await new Probe(bitrate).encode(stream.writer, this.version);
-					lastSentBitrate = bitrate;
+					await report.encode(stream.writer, this.version);
+					lastSent = report;
 					lastSentTime = performance.now();
 				}
 			}

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -1,10 +1,11 @@
 import { expect, spyOn, test } from "bun:test";
 import { Signal } from "@moq/signals";
-import type { Probe } from "../connection/stats.ts";
+import type { Probe as ProbeStats } from "../connection/stats.ts";
 import { OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Writer } from "../stream.ts";
 import { AnnounceOk, encodeAnnounceBroadcast } from "./announce.ts";
+import { Probe } from "./probe.ts";
 import { Subscriber } from "./subscriber.ts";
 import { Version } from "./version.ts";
 
@@ -16,7 +17,7 @@ test("closing the subscriber suppresses probe stream warnings", async () => {
 			writable: new WritableStream<Uint8Array>(),
 		}),
 	} as unknown as WebTransport;
-	const subscriber = new Subscriber(quic, Version.DRAFT_03, OriginSchema.parse(1n), new Signal<Probe>({}));
+	const subscriber = new Subscriber(quic, Version.DRAFT_03, OriginSchema.parse(1n), new Signal<ProbeStats>({}));
 	const warn = spyOn(console, "warn").mockImplementation(() => {});
 
 	try {
@@ -134,4 +135,87 @@ test("a lite-05 duplicate announce follows the same restart rule", async () => {
 
 	announced.close();
 	subscriber.close();
+});
+
+// Encode PROBE messages the way a publisher would, so the subscriber's own loop
+// decodes them.
+async function probeBytes(probes: Probe[], version: Version): Promise<Uint8Array> {
+	const chunks: Uint8Array[] = [];
+	const writer = new Writer(
+		new WritableStream<Uint8Array>({ write: (chunk) => void chunks.push(new Uint8Array(chunk)) }),
+	);
+	for (const probe of probes) await probe.encode(writer, version);
+	writer.close();
+	await writer.closed;
+
+	const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const c of chunks) {
+		out.set(c, offset);
+		offset += c.byteLength;
+	}
+	return out;
+}
+
+/**
+ * Drive `Subscriber.runProbe` over a canned script and return what the probe signal
+ * held once the last message had been applied.
+ *
+ * Snapshotted before the stream is closed: `runProbe`'s `finally` blanks the signal
+ * on exit, so reading afterwards would report `{}` no matter what the loop did.
+ */
+async function runProbeScript(version: Version, probes: Probe[]): Promise<ProbeStats> {
+	let readable!: ReadableStreamDefaultController<Uint8Array>;
+	const quic = {
+		createBidirectionalStream: async () => ({
+			readable: new ReadableStream<Uint8Array>({ start: (controller) => (readable = controller) }),
+			writable: new WritableStream<Uint8Array>(),
+		}),
+	} as unknown as WebTransport;
+
+	const signal = new Signal<ProbeStats>({});
+	const subscriber = new Subscriber(quic, version, OriginSchema.parse(1n), signal);
+	const running = subscriber.runProbe();
+
+	await Promise.resolve();
+	readable.enqueue(await probeBytes(probes, version));
+	// Each message costs several awaits to decode, so drain generously rather than
+	// guessing an exact count.
+	for (let i = 0; i < 200; i++) await Promise.resolve();
+
+	const snapshot = signal.peek();
+
+	readable.close();
+	await running.catch(() => {});
+	return snapshot;
+}
+
+// From lite-04 the RTT field is always on the wire and 0 explicitly means unknown, so
+// an absent value is the publisher retracting a reading rather than declining to
+// repeat it. Holding the old value would keep the jitter buffer adapting to a
+// measurement the publisher had already withdrawn.
+test("an RTT retraction clears the reading on lite-04+", async () => {
+	const got = await runProbeScript(Version.DRAFT_05, [
+		new Probe({ bitrate: 1_000_000, rtt: 40 }),
+		new Probe({ bitrate: 1_000_000, rtt: undefined }),
+	]);
+	// The bitrate proves both messages were applied, so an undefined RTT here is the
+	// retraction landing rather than the loop never having run.
+	expect(got.estimatedRecvRate).toBe(1_000_000);
+	expect(got.rtt).toBeUndefined();
+});
+
+// lite-03's PROBE carries no RTT field at all, so an absent value there means "not
+// carried" and the last reading must stand.
+test("lite-03 keeps the last RTT, since its PROBE cannot carry one", async () => {
+	const got = await runProbeScript(Version.DRAFT_03, [
+		new Probe({ bitrate: 1_000_000, rtt: 40 }),
+		new Probe({ bitrate: 2_000_000 }),
+	]);
+	expect(got.estimatedRecvRate).toBe(2_000_000);
+	// lite-03 never carried the 40 on the wire, so there is nothing to retract and
+	// nothing to preserve; what matters is that the absent field is not mistaken for
+	// a retraction the way it is from lite-04 on.
+	expect(got.rtt).toBeUndefined();
 });

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -4,6 +4,7 @@ import type { Probe as ProbeStats } from "../connection/stats.ts";
 import { OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Writer } from "../stream.ts";
+import * as Time from "../time.ts";
 import { AnnounceOk, encodeAnnounceBroadcast } from "./announce.ts";
 import { Probe } from "./probe.ts";
 import { Subscriber } from "./subscriber.ts";
@@ -158,35 +159,47 @@ async function probeBytes(probes: Probe[], version: Version): Promise<Uint8Array
 	return out;
 }
 
+/** Bound on the microtask turns we will spend waiting for the decode loop. */
+const MAX_DRAIN_TURNS = 1000;
+
+/** Yield until `predicate` holds, rather than guessing a fixed number of turns. */
+async function drainUntil(predicate: () => boolean): Promise<void> {
+	for (let i = 0; i < MAX_DRAIN_TURNS; i++) {
+		if (predicate()) return;
+		await Promise.resolve();
+	}
+	throw new Error("probe messages never drained");
+}
+
 /**
  * Drive `Subscriber.runProbe` over a canned script and return what the probe signal
  * held once the last message had been applied.
  *
  * Snapshotted before the stream is closed: `runProbe`'s `finally` blanks the signal
- * on exit, so reading afterwards would report `{}` no matter what the loop did.
+ * on exit, so reading afterwards would report `{}` no matter what the loop did. The
+ * wait keys off the final message's bitrate, so give the script a distinct one.
  */
-async function runProbeScript(version: Version, probes: Probe[]): Promise<ProbeStats> {
-	let readable!: ReadableStreamDefaultController<Uint8Array>;
+async function runProbeScript(version: Version, probes: Probe[], initial: ProbeStats = {}): Promise<ProbeStats> {
+	let readableController!: ReadableStreamDefaultController<Uint8Array>;
 	const quic = {
 		createBidirectionalStream: async () => ({
-			readable: new ReadableStream<Uint8Array>({ start: (controller) => (readable = controller) }),
+			readable: new ReadableStream<Uint8Array>({ start: (controller) => (readableController = controller) }),
 			writable: new WritableStream<Uint8Array>(),
 		}),
 	} as unknown as WebTransport;
 
-	const signal = new Signal<ProbeStats>({});
+	const signal = new Signal<ProbeStats>(initial);
 	const subscriber = new Subscriber(quic, version, OriginSchema.parse(1n), signal);
 	const running = subscriber.runProbe();
 
 	await Promise.resolve();
-	readable.enqueue(await probeBytes(probes, version));
-	// Each message costs several awaits to decode, so drain generously rather than
-	// guessing an exact count.
-	for (let i = 0; i < 200; i++) await Promise.resolve();
+	readableController.enqueue(await probeBytes(probes, version));
 
+	const last = probes[probes.length - 1];
+	await drainUntil(() => signal.peek().estimatedRecvRate === last.bitrate);
 	const snapshot = signal.peek();
 
-	readable.close();
+	readableController.close();
 	await running.catch(() => {});
 	return snapshot;
 }
@@ -198,24 +211,21 @@ async function runProbeScript(version: Version, probes: Probe[]): Promise<ProbeS
 test("an RTT retraction clears the reading on lite-04+", async () => {
 	const got = await runProbeScript(Version.DRAFT_05, [
 		new Probe({ bitrate: 1_000_000, rtt: 40 }),
-		new Probe({ bitrate: 1_000_000, rtt: undefined }),
+		new Probe({ bitrate: 2_000_000, rtt: undefined }),
 	]);
-	// The bitrate proves both messages were applied, so an undefined RTT here is the
-	// retraction landing rather than the loop never having run.
-	expect(got.estimatedRecvRate).toBe(1_000_000);
+	// The second bitrate proves the retracting message was applied, so an undefined
+	// RTT here is the retraction landing rather than the loop never having run.
+	expect(got.estimatedRecvRate).toBe(2_000_000);
 	expect(got.rtt).toBeUndefined();
 });
 
-// lite-03's PROBE carries no RTT field at all, so an absent value there means "not
-// carried" and the last reading must stand.
-test("lite-03 keeps the last RTT, since its PROBE cannot carry one", async () => {
-	const got = await runProbeScript(Version.DRAFT_03, [
-		new Probe({ bitrate: 1_000_000, rtt: 40 }),
-		new Probe({ bitrate: 2_000_000 }),
-	]);
+// lite-03's PROBE carries no RTT field at all, so an absent value there is "not
+// carried" rather than a retraction, and a reading already on the signal must stand.
+// Seeded rather than sent, because lite-03 has no way to put one on the wire.
+test("lite-03 keeps an existing RTT, since its PROBE cannot carry one", async () => {
+	const got = await runProbeScript(Version.DRAFT_03, [new Probe({ bitrate: 2_000_000 })], {
+		rtt: Time.Milli(40),
+	});
 	expect(got.estimatedRecvRate).toBe(2_000_000);
-	// lite-03 never carried the 40 on the wire, so there is nothing to retract and
-	// nothing to preserve; what matters is that the absent field is not mistaken for
-	// a retraction the way it is from lite-04 on.
-	expect(got.rtt).toBeUndefined();
+	expect(got.rtt).toBe(Time.Milli(40));
 });

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -22,7 +22,7 @@ import { ProbeLevel, type Setup } from "./setup.ts";
 import { StreamId } from "./stream.ts";
 import { decodeSubscribeResponse, decodeSubscribeResponseMaybe, Subscribe, SubscribeUpdate } from "./subscribe.ts";
 import { TrackInfo, Track as TrackMessage } from "./track.ts";
-import { hasAnnounceId, hasAnnounceOk, hasDatagrams, hasExcludeHop, Version } from "./version.ts";
+import { hasAnnounceId, hasAnnounceOk, hasDatagrams, hasExcludeHop, hasProbeRtt, Version } from "./version.ts";
 
 // Bound on how long stream-open plus the first response (SUBSCRIBE_OK on older
 // drafts, or TRACK_INFO on lite-05+) may take. Browsers cap concurrent QUIC streams
@@ -888,14 +888,17 @@ export class Subscriber {
 			for (;;) {
 				const probe = await Probe.decodeMaybe(stream.reader, this.version);
 				if (!probe) break;
-				// A message that omits the RTT leaves the last one standing, so a
-				// bitrate-only report doesn't blank it.
+				// lite-03 carries no RTT field, so an absent value there means "not
+				// carried" and the last reading stands. From lite-04 the field is
+				// always present and 0 explicitly means unknown, so undefined is the
+				// peer retracting a value we would otherwise hold forever.
 				const prev = this.#probe.peek();
+				const rtt = probe.rtt !== undefined ? Time.Milli(probe.rtt) : undefined;
 				this.#probe.set({
 					// `undefined` is the peer reporting "unknown", not an estimate of
 					// zero; letting it through would become a real 0 bps ABR target.
 					estimatedRecvRate: probe.bitrate,
-					rtt: probe.rtt !== undefined ? Time.Milli(probe.rtt) : prev.rtt,
+					rtt: hasProbeRtt(this.version) ? rtt : (rtt ?? prev.rtt),
 				});
 			}
 		} catch (err: unknown) {

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -892,7 +892,9 @@ export class Subscriber {
 				// bitrate-only report doesn't blank it.
 				const prev = this.#probe.peek();
 				this.#probe.set({
-					estimatedRecvRate: probe.bitrate ?? undefined,
+					// `undefined` is the peer reporting "unknown", not an estimate of
+					// zero; letting it through would become a real 0 bps ABR target.
+					estimatedRecvRate: probe.bitrate,
 					rtt: probe.rtt !== undefined ? Time.Milli(probe.rtt) : prev.rtt,
 				});
 			}

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -12,8 +12,12 @@ export const Version = {
 
 export type Version = (typeof Version)[keyof typeof Version];
 
-/// Whether the PROBE message carries the RTT field. Added in lite-04; lite-03 carries the
-/// bitrate alone, so a report with only an RTT to give says nothing there and must not be sent.
+/**
+ * Whether the PROBE message carries the RTT field.
+ *
+ * Added in lite-04. Lite-03 carries the bitrate alone, so a report with only an RTT to
+ * give says nothing there and must not be sent.
+ */
 export function hasProbeRtt(version: Version): boolean {
 	// Explicitly list older versions so future versions default to carrying RTT.
 	switch (version) {

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -12,6 +12,20 @@ export const Version = {
 
 export type Version = (typeof Version)[keyof typeof Version];
 
+/// Whether the PROBE message carries the RTT field. Added in lite-04; lite-03 carries the
+/// bitrate alone, so a report with only an RTT to give says nothing there and must not be sent.
+export function hasProbeRtt(version: Version): boolean {
+	// Explicitly list older versions so future versions default to carrying RTT.
+	switch (version) {
+		case Version.DRAFT_01:
+		case Version.DRAFT_02:
+		case Version.DRAFT_03:
+			return false;
+		default:
+			return true;
+	}
+}
+
 /// Whether the session opens a unidirectional Setup Stream carrying a single SETUP message
 /// (capabilities + optional Path). Added in lite-05; older drafts have no Setup Stream.
 export function hasSetupStream(version: Version): boolean {

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -257,12 +257,13 @@ impl Client {
 				};
 				self.versions.select(Version::Lite(version)).ok_or(Error::Version)?;
 
-				// Advertise our capabilities (we report send bitrate; we don't pad) plus
+				// Advertise our capabilities (we report what the transport measures; we
+				// don't pad) plus
 				// the request path on URI-less transports, and the direction we intend to
 				// use so the server can reject a token that lacks the matching scope during
 				// the handshake instead of silently carrying no media.
 				let our_setup = lite::Setup {
-					probe: lite::ProbeLevel::Report,
+					probe: lite::ProbeLevel::detect(&session),
 					path: self.setup_path.clone(),
 					role: lite::Role::from_origins(self.publish.is_some(), self.subscribe.is_some()),
 					cost: self.cost,

--- a/rs/moq-net/src/lite/probe.rs
+++ b/rs/moq-net/src/lite/probe.rs
@@ -8,7 +8,7 @@ use super::{Message, Version};
 /// On the wire, 0 means unknown (None). Some(0) is rounded up to Some(1).
 #[derive(Clone, Debug)]
 pub struct Probe {
-	pub bitrate: u64,
+	pub bitrate: Option<u64>,
 	pub rtt: Option<u64>,
 }
 
@@ -21,7 +21,12 @@ impl Message for Probe {
 			_ => {}
 		}
 
-		let bitrate = u64::decode(r, version)?;
+		// 0 means unknown, the same as RTT below. A publisher whose transport
+		// exposes no congestion controller reports the RTT half alone.
+		let bitrate = match u64::decode(r, version)? {
+			0 => None,
+			v => Some(v),
+		};
 		let rtt = match version {
 			Version::Lite03 => None,
 			_ => match u64::decode(r, version)? {
@@ -41,15 +46,76 @@ impl Message for Probe {
 			_ => {}
 		}
 
-		self.bitrate.encode(w, version)?;
+		// 0 means unknown; round Some(0) up to 1.
+		let wire = self.bitrate.map(|v| v.max(1)).unwrap_or(0);
+		wire.encode(w, version)?;
 		match version {
 			Version::Lite03 => {}
 			_ => {
-				// 0 means unknown; round Some(0) up to 1.
 				let wire = self.rtt.map(|v| v.max(1)).unwrap_or(0);
 				wire.encode(w, version)?;
 			}
 		}
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn round_trip(msg: &Probe, version: Version) -> Probe {
+		let mut buf = bytes::BytesMut::new();
+		msg.encode(&mut buf, version).unwrap();
+		let mut slice = &buf[..];
+		let got = Probe::decode(&mut slice, version).unwrap();
+		assert!(bytes::Buf::remaining(&slice) == 0, "trailing bytes after decode");
+		got
+	}
+
+	/// Both fields use 0 for unknown, independently, so a publisher that can
+	/// measure only one still has a legal message to send.
+	#[test]
+	fn each_field_is_independently_unknown() {
+		for (bitrate, rtt) in [
+			(Some(1_000_000), Some(40)),
+			(None, Some(40)),
+			(Some(1_000_000), None),
+			(None, None),
+		] {
+			let msg = Probe { bitrate, rtt };
+			let got = round_trip(&msg, Version::Lite05);
+			assert_eq!(got.bitrate, bitrate);
+			assert_eq!(got.rtt, rtt);
+		}
+	}
+
+	/// A measured zero is indistinguishable from unknown on the wire, so it rounds
+	/// up to the smallest value that still reads as a measurement.
+	#[test]
+	fn measured_zero_rounds_up() {
+		let got = round_trip(
+			&Probe {
+				bitrate: Some(0),
+				rtt: Some(0),
+			},
+			Version::Lite05,
+		);
+		assert_eq!(got.bitrate, Some(1));
+		assert_eq!(got.rtt, Some(1));
+	}
+
+	/// Lite03 predates the RTT field; the bitrate half still round-trips.
+	#[test]
+	fn lite03_carries_bitrate_only() {
+		let got = round_trip(
+			&Probe {
+				bitrate: Some(1_000_000),
+				rtt: Some(40),
+			},
+			Version::Lite03,
+		);
+		assert_eq!(got.bitrate, Some(1_000_000));
+		assert_eq!(got.rtt, None);
 	}
 }

--- a/rs/moq-net/src/lite/probe.rs
+++ b/rs/moq-net/src/lite/probe.rs
@@ -27,9 +27,9 @@ impl Message for Probe {
 			0 => None,
 			v => Some(v),
 		};
-		let rtt = match version {
-			Version::Lite03 => None,
-			_ => match u64::decode(r, version)? {
+		let rtt = match version.has_probe_rtt() {
+			false => None,
+			true => match u64::decode(r, version)? {
 				0 => None,
 				v => Some(v),
 			},
@@ -49,12 +49,9 @@ impl Message for Probe {
 		// 0 means unknown; round Some(0) up to 1.
 		let wire = self.bitrate.map(|v| v.max(1)).unwrap_or(0);
 		wire.encode(w, version)?;
-		match version {
-			Version::Lite03 => {}
-			_ => {
-				let wire = self.rtt.map(|v| v.max(1)).unwrap_or(0);
-				wire.encode(w, version)?;
-			}
+		if version.has_probe_rtt() {
+			let wire = self.rtt.map(|v| v.max(1)).unwrap_or(0);
+			wire.encode(w, version)?;
 		}
 		Ok(())
 	}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -175,7 +175,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		}
 	}
 
-	async fn run_probe(session: &S, stream: &mut Stream<S, Version>, _version: Version) -> Result<(), Error> {
+	async fn run_probe(session: &S, stream: &mut Stream<S, Version>, version: Version) -> Result<(), Error> {
 		const PROBE_INTERVAL: Duration = Duration::from_millis(100);
 		const PROBE_MAX_AGE: Duration = Duration::from_secs(10);
 		const PROBE_MAX_DELTA: f64 = 0.25;
@@ -228,20 +228,31 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 			// The two fields are independent on the wire, each using 0 for unknown,
 			// so a transport that exposes only one still has something to report.
+			// Anything this version can't carry is dropped here rather than by the
+			// encoder, so it reads as unknown to every check below.
 			// Scoped so the borrowed stats handle is dropped before the encode
 			// below awaits; it isn't `Send`.
 			let report = {
 				let stats = session.stats();
 				lite::Probe {
 					bitrate: stats.estimated_send_rate(),
-					rtt: stats.rtt().map(|d| d.as_millis() as u64),
+					rtt: version
+						.has_probe_rtt()
+						.then(|| stats.rtt().map(|d| d.as_millis() as u64))
+						.flatten(),
 				}
 			};
 
-			// Neither metric is measurable. A publisher in that position shouldn't
-			// have advertised Report at all, so there is nothing to say.
+			// Nothing left to report. Say so once if it retracts a value the peer is
+			// still holding, then stay quiet rather than repeating "unknown" every
+			// time the max age comes around.
 			if report.bitrate.is_none() && report.rtt.is_none() {
-				continue;
+				let retracts = last_sent
+					.as_ref()
+					.is_some_and(|(prev, _)| prev.bitrate.is_some() || prev.rtt.is_some());
+				if !retracts {
+					continue;
+				}
 			}
 
 			let should_send = match &last_sent {
@@ -2456,11 +2467,15 @@ mod tests {
 	/// Decode the PROBE messages the publisher wrote. The publisher only replies on
 	/// a stream the subscriber opened, so there is no leading ControlType here.
 	fn decode_probes(bytes: &[u8]) -> Vec<lite::Probe> {
+		decode_probes_version(bytes, Version::Lite05)
+	}
+
+	fn decode_probes_version(bytes: &[u8], version: Version) -> Vec<lite::Probe> {
 		use crate::coding::Decode as _;
 		let mut slice = bytes;
 		let mut out = Vec::new();
 		while bytes::Buf::remaining(&slice) > 0 {
-			out.push(lite::Probe::decode(&mut slice, Version::Lite05).unwrap());
+			out.push(lite::Probe::decode(&mut slice, version).unwrap());
 		}
 		out
 	}
@@ -2468,16 +2483,17 @@ mod tests {
 	/// Drive `run_probe` against a transport reporting `stats`, and return whatever
 	/// it wrote before parking.
 	async fn probe_writes(stats: crate::lite::test_transport::SinkStats) -> Vec<lite::Probe> {
+		probe_writes_version(stats, Version::Lite05).await
+	}
+
+	/// As above, on a specific negotiated version.
+	async fn probe_writes_version(stats: crate::lite::test_transport::SinkStats, version: Version) -> Vec<lite::Probe> {
 		let gate = kio::Producer::new(true);
 		let session = SinkSession::gated_bi(gate.consume()).with_stats(stats);
 		let log = session.log.clone();
-		let mut stream = Stream::open(&session, Version::Lite05).await.unwrap();
+		let mut stream = Stream::open(&session, version).await.unwrap();
 
-		let mut run = std::pin::pin!(Publisher::<SinkSession>::run_probe(
-			&session,
-			&mut stream,
-			Version::Lite05
-		));
+		let mut run = std::pin::pin!(Publisher::<SinkSession>::run_probe(&session, &mut stream, version));
 		// The loop reports on a 100ms cadence, so let the first tick land before
 		// reading what it wrote. It parks on the next tick either way.
 		assert!(futures::poll!(run.as_mut()).is_pending());
@@ -2485,7 +2501,7 @@ mod tests {
 		assert!(futures::poll!(run.as_mut()).is_pending());
 
 		let writes = log.writes.lock().unwrap().clone();
-		decode_probes(&writes)
+		decode_probes_version(&writes, version)
 	}
 
 	/// A transport that exposes an RTT but no send-rate estimate must still report.
@@ -2520,5 +2536,67 @@ mod tests {
 	async fn reports_nothing_when_nothing_is_measurable() {
 		let probes = probe_writes(crate::lite::test_transport::SinkStats::default()).await;
 		assert!(probes.is_empty(), "expected no report, got {probes:?}");
+	}
+
+	/// Lite03's PROBE carries no RTT field, so an RTT-only report has nothing to
+	/// say there. Sending one anyway would serialize as a bare "bitrate unknown"
+	/// and, worse, fire again on every RTT movement.
+	#[tokio::test(start_paused = true)]
+	async fn lite03_sends_nothing_for_an_rtt_only_report() {
+		let stats = crate::lite::test_transport::SinkStats::default().with_rtt(std::time::Duration::from_millis(40));
+		let probes = probe_writes_version(stats, Version::Lite03).await;
+		assert!(probes.is_empty(), "expected no report on lite-03, got {probes:?}");
+	}
+
+	/// Lite03 still reports the half it can carry.
+	#[tokio::test(start_paused = true)]
+	async fn lite03_reports_the_bitrate() {
+		let stats = crate::lite::test_transport::SinkStats::default()
+			.with_send_rate(1_000_000)
+			.with_rtt(std::time::Duration::from_millis(40));
+		let probes = probe_writes_version(stats, Version::Lite03).await;
+
+		assert_eq!(probes.len(), 1);
+		assert_eq!(probes[0].bitrate, Some(1_000_000));
+		assert_eq!(probes[0].rtt, None, "lite-03 carries no RTT field");
+	}
+
+	/// A bitrate that becomes unknown is worth one report: the peer is still
+	/// holding the last value we sent. But only one, however long the stream runs.
+	#[tokio::test(start_paused = true)]
+	async fn a_bitrate_going_unknown_is_retracted_once() {
+		let gate = kio::Producer::new(true);
+		let stats = crate::lite::test_transport::SinkStats::default().with_send_rate(1_000_000);
+		let session = SinkSession::gated_bi(gate.consume()).with_stats(stats);
+		let log = session.log.clone();
+		let mut stream = Stream::open(&session, Version::Lite05).await.unwrap();
+
+		let mut run = std::pin::pin!(Publisher::<SinkSession>::run_probe(
+			&session,
+			&mut stream,
+			Version::Lite05
+		));
+		assert!(futures::poll!(run.as_mut()).is_pending());
+		tokio::time::sleep(Duration::from_millis(150)).await;
+		assert!(futures::poll!(run.as_mut()).is_pending());
+
+		// The transport stops measuring. Everything after this is unknown.
+		session.set_stats(crate::lite::test_transport::SinkStats::default());
+
+		// Well past PROBE_MAX_AGE, so a stale-report timer would have fired repeatedly.
+		for _ in 0..3 {
+			tokio::time::sleep(Duration::from_secs(11)).await;
+			assert!(futures::poll!(run.as_mut()).is_pending());
+		}
+
+		let writes = log.writes.lock().unwrap().clone();
+		let probes = decode_probes(&writes);
+		assert_eq!(
+			probes.len(),
+			2,
+			"the measurement then one retraction, not a repeating 'unknown': {probes:?}"
+		);
+		assert_eq!(probes[0].bitrate, Some(1_000_000));
+		assert_eq!(probes[1].bitrate, None);
 	}
 }

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -179,8 +179,34 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		const PROBE_INTERVAL: Duration = Duration::from_millis(100);
 		const PROBE_MAX_AGE: Duration = Duration::from_secs(10);
 		const PROBE_MAX_DELTA: f64 = 0.25;
+		const PROBE_RTT_DELTA: f64 = 0.25;
 
-		let mut last_sent: Option<(u64, web_async::time::Instant)> = None;
+		/// Whether a metric moved enough to be worth another report. Gaining or
+		/// losing a value always counts; both unknown never does.
+		fn moved(prev: Option<u64>, next: Option<u64>, threshold: f64) -> bool {
+			match (prev, next) {
+				(None, None) => false,
+				(Some(prev), Some(next)) => {
+					if prev == 0 {
+						return next != 0;
+					}
+					(next as f64 - prev as f64).abs() / prev as f64 >= threshold
+				}
+				_ => true,
+			}
+		}
+
+		/// The bitrate change worth reporting, decaying to zero as the last report
+		/// ages: a stale estimate is worth refreshing for a smaller move.
+		fn bitrate_threshold(elapsed: Duration) -> f64 {
+			let t = elapsed
+				.as_secs_f64()
+				.clamp(PROBE_INTERVAL.as_secs_f64(), PROBE_MAX_AGE.as_secs_f64());
+			let range = PROBE_MAX_AGE.as_secs_f64() - PROBE_INTERVAL.as_secs_f64();
+			PROBE_MAX_DELTA * (PROBE_MAX_AGE.as_secs_f64() - t) / range
+		}
+
+		let mut last_sent: Option<(lite::Probe, web_async::time::Instant)> = None;
 		let mut interval = web_async::time::interval(PROBE_INTERVAL);
 
 		loop {
@@ -200,27 +226,37 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				return res;
 			}
 
-			let Some(bitrate) = session.stats().estimated_send_rate() else {
-				continue;
+			// The two fields are independent on the wire, each using 0 for unknown,
+			// so a transport that exposes only one still has something to report.
+			// Scoped so the borrowed stats handle is dropped before the encode
+			// below awaits; it isn't `Send`.
+			let report = {
+				let stats = session.stats();
+				lite::Probe {
+					bitrate: stats.estimated_send_rate(),
+					rtt: stats.rtt().map(|d| d.as_millis() as u64),
+				}
 			};
 
-			let should_send = match last_sent {
+			// Neither metric is measurable. A publisher in that position shouldn't
+			// have advertised Report at all, so there is nothing to say.
+			if report.bitrate.is_none() && report.rtt.is_none() {
+				continue;
+			}
+
+			let should_send = match &last_sent {
 				None => true,
-				Some((0, _)) => bitrate > 0,
 				Some((prev, at)) => {
-					let elapsed = at.elapsed().as_secs_f64();
-					let t = elapsed.clamp(PROBE_INTERVAL.as_secs_f64(), PROBE_MAX_AGE.as_secs_f64());
-					let range = PROBE_MAX_AGE.as_secs_f64() - PROBE_INTERVAL.as_secs_f64();
-					let threshold = PROBE_MAX_DELTA * (PROBE_MAX_AGE.as_secs_f64() - t) / range;
-					let change = (bitrate as f64 - prev as f64).abs() / prev as f64;
-					change >= threshold
+					let elapsed = at.elapsed();
+					elapsed >= PROBE_MAX_AGE
+						|| moved(prev.bitrate, report.bitrate, bitrate_threshold(elapsed))
+						|| moved(prev.rtt, report.rtt, PROBE_RTT_DELTA)
 				}
 			};
 
 			if should_send {
-				let rtt = session.stats().rtt().map(|d| d.as_millis() as u64);
-				stream.writer.encode(&lite::Probe { bitrate, rtt }).await?;
-				last_sent = Some((bitrate, web_async::time::Instant::now()));
+				stream.writer.encode(&report).await?;
+				last_sent = Some((report, web_async::time::Instant::now()));
 			}
 		}
 	}
@@ -2415,5 +2451,74 @@ mod tests {
 			!writes.windows(b"echoed".len()).any(|w| w == b"echoed"),
 			"echoed broadcast filtered from ANNOUNCE_INIT"
 		);
+	}
+
+	/// Decode the PROBE messages the publisher wrote. The publisher only replies on
+	/// a stream the subscriber opened, so there is no leading ControlType here.
+	fn decode_probes(bytes: &[u8]) -> Vec<lite::Probe> {
+		use crate::coding::Decode as _;
+		let mut slice = bytes;
+		let mut out = Vec::new();
+		while bytes::Buf::remaining(&slice) > 0 {
+			out.push(lite::Probe::decode(&mut slice, Version::Lite05).unwrap());
+		}
+		out
+	}
+
+	/// Drive `run_probe` against a transport reporting `stats`, and return whatever
+	/// it wrote before parking.
+	async fn probe_writes(stats: crate::lite::test_transport::SinkStats) -> Vec<lite::Probe> {
+		let gate = kio::Producer::new(true);
+		let session = SinkSession::gated_bi(gate.consume()).with_stats(stats);
+		let log = session.log.clone();
+		let mut stream = Stream::open(&session, Version::Lite05).await.unwrap();
+
+		let mut run = std::pin::pin!(Publisher::<SinkSession>::run_probe(
+			&session,
+			&mut stream,
+			Version::Lite05
+		));
+		// The loop reports on a 100ms cadence, so let the first tick land before
+		// reading what it wrote. It parks on the next tick either way.
+		assert!(futures::poll!(run.as_mut()).is_pending());
+		tokio::time::sleep(Duration::from_millis(150)).await;
+		assert!(futures::poll!(run.as_mut()).is_pending());
+
+		let writes = log.writes.lock().unwrap().clone();
+		decode_probes(&writes)
+	}
+
+	/// A transport that exposes an RTT but no send-rate estimate must still report.
+	///
+	/// The two PROBE fields are independent, each using 0 for unknown, so discarding
+	/// the whole message for want of a bitrate leaves a subscriber with no RTT at
+	/// all. That is what pins a qmux viewer to its fallback jitter buffer.
+	#[tokio::test(start_paused = true)]
+	async fn reports_rtt_without_a_bitrate() {
+		let stats = crate::lite::test_transport::SinkStats::default().with_rtt(std::time::Duration::from_millis(40));
+		let probes = probe_writes(stats).await;
+
+		assert_eq!(probes.len(), 1, "expected exactly one report");
+		assert_eq!(probes[0].rtt, Some(40));
+		assert_eq!(probes[0].bitrate, None, "unknown bitrate, not a measured zero");
+	}
+
+	/// The mirror case: a send rate with no RTT still reports.
+	#[tokio::test(start_paused = true)]
+	async fn reports_bitrate_without_an_rtt() {
+		let stats = crate::lite::test_transport::SinkStats::default().with_send_rate(1_000_000);
+		let probes = probe_writes(stats).await;
+
+		assert_eq!(probes.len(), 1);
+		assert_eq!(probes[0].bitrate, Some(1_000_000));
+		assert_eq!(probes[0].rtt, None);
+	}
+
+	/// A transport measuring neither has nothing to say, and must not emit a report
+	/// claiming two zeroes.
+	#[tokio::test(start_paused = true)]
+	async fn reports_nothing_when_nothing_is_measurable() {
+		let probes = probe_writes(crate::lite::test_transport::SinkStats::default()).await;
+		assert!(probes.is_empty(), "expected no report, got {probes:?}");
 	}
 }

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -41,6 +41,26 @@ pub enum ProbeLevel {
 }
 
 impl ProbeLevel {
+	/// The level to advertise for `session`, from what its transport actually exposes.
+	///
+	/// [`Report`](Self::Report) claims the publisher can measure and periodically
+	/// report. A transport that exposes neither a send-rate estimate nor an RTT can
+	/// honour neither, and the draft requires such a publisher to reset any Probe
+	/// Stream a subscriber opens. Advertising [`None`](Self::None) instead stops the
+	/// subscriber opening one at all.
+	///
+	/// Both metrics are sampled rather than declared, so this only works for a
+	/// transport whose figures exist by the time the session starts. QUIC and TCP
+	/// both qualify: their RTT comes from the handshake, which has already happened.
+	pub fn detect<S: web_transport_trait::Session>(session: &S) -> Self {
+		use web_transport_trait::Stats as _;
+		let stats = session.stats();
+		match stats.estimated_send_rate().is_some() || stats.rtt().is_some() {
+			true => Self::Report,
+			false => Self::None,
+		}
+	}
+
 	/// Map the wire value to a level, saturating unknown values to [`Increase`](Self::Increase).
 	fn from_code(code: u64) -> Self {
 		match code {
@@ -295,6 +315,31 @@ mod tests {
 	fn empty_round_trip() {
 		let msg = Setup::default();
 		assert_eq!(round_trip(&msg), msg);
+	}
+
+	/// A transport exposing neither metric can't honour a `Report` claim, and the
+	/// draft makes such a publisher reset any Probe Stream a subscriber opens. It
+	/// must advertise `None` so the subscriber never opens one.
+	#[test]
+	fn detect_reports_nothing_without_stats() {
+		use crate::lite::test_transport::{SinkSession, SinkStats};
+		let session = SinkSession::new(Default::default()).with_stats(SinkStats::default());
+		assert_eq!(ProbeLevel::detect(&session), ProbeLevel::None);
+	}
+
+	/// Either metric alone is enough to report, since the two PROBE fields are
+	/// independent on the wire.
+	#[test]
+	fn detect_reports_with_either_metric() {
+		use crate::lite::test_transport::{SinkSession, SinkStats};
+
+		let rtt_only = SinkStats::default().with_rtt(std::time::Duration::from_millis(40));
+		let session = SinkSession::new(Default::default()).with_stats(rtt_only);
+		assert_eq!(ProbeLevel::detect(&session), ProbeLevel::Report);
+
+		let rate_only = SinkStats::default().with_send_rate(1_000_000);
+		let session = SinkSession::new(Default::default()).with_stats(rate_only);
+		assert_eq!(ProbeLevel::detect(&session), ProbeLevel::Report);
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -34,7 +34,9 @@ pub enum ProbeLevel {
 	/// No probing. Equivalent to omitting the parameter.
 	#[default]
 	None,
-	/// The publisher can measure and periodically report its estimated bitrate.
+	/// The publisher can measure and periodically report at least one of the PROBE
+	/// metrics: its estimated bitrate, its round-trip time, or both. Either may be
+	/// unknown in any given report, since the two are independent on the wire.
 	Report,
 	/// The publisher can additionally pad the connection (or send redundant data).
 	Increase,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -431,7 +431,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		stream.writer.encode(&lite::ControlType::Probe).await?;
 
 		while let Some(probe) = stream.reader.decode_maybe::<lite::Probe>().await? {
-			bandwidth.set(Some(probe.bitrate))?;
+			// `None` is the publisher reporting "unknown", not an estimate of zero.
+			bandwidth.set(probe.bitrate)?;
 		}
 
 		Ok(())

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -280,7 +280,7 @@ impl web_transport_trait::Session for DeadStreamSession {
 	}
 
 	fn stats(&self) -> impl web_transport_trait::Stats {
-		SinkStats
+		SinkStats::default()
 	}
 }
 
@@ -294,6 +294,9 @@ pub struct SinkSession {
 	/// The ALPN to report, for a test that needs a specific negotiated version rather
 	/// than the SETUP-negotiated fallback an absent one selects.
 	protocol: Option<&'static str>,
+	/// What the transport claims to measure. Defaults to nothing, like a transport
+	/// with no congestion controller exposed.
+	stats: SinkStats,
 }
 
 impl SinkSession {
@@ -302,7 +305,14 @@ impl SinkSession {
 			log,
 			bi_gate: None,
 			protocol: None,
+			stats: SinkStats::default(),
 		}
+	}
+
+	/// Report these connection statistics, as a real transport would.
+	pub fn with_stats(mut self, stats: SinkStats) -> Self {
+		self.stats = stats;
+		self
 	}
 
 	/// Report `protocol` as the negotiated ALPN.
@@ -321,6 +331,7 @@ impl SinkSession {
 			log: Log::default(),
 			bi_gate: Some(gate),
 			protocol: None,
+			stats: SinkStats::default(),
 		}
 	}
 }
@@ -381,15 +392,39 @@ impl web_transport_trait::Session for SinkSession {
 	}
 
 	fn stats(&self) -> impl web_transport_trait::Stats {
-		SinkStats
+		self.stats
 	}
 }
 
-pub struct SinkStats;
+/// Connection statistics a test can dictate. Every metric defaults to unknown,
+/// matching a transport that exposes no congestion controller.
+#[derive(Default, Clone, Copy)]
+pub struct SinkStats {
+	pub estimated_send_rate: Option<u64>,
+	pub rtt: Option<std::time::Duration>,
+}
+
+impl SinkStats {
+	/// Report a send-rate estimate, in bits per second.
+	pub fn with_send_rate(mut self, rate: u64) -> Self {
+		self.estimated_send_rate = Some(rate);
+		self
+	}
+
+	/// Report a round-trip time.
+	pub fn with_rtt(mut self, rtt: std::time::Duration) -> Self {
+		self.rtt = Some(rtt);
+		self
+	}
+}
 
 impl web_transport_trait::Stats for SinkStats {
 	fn estimated_send_rate(&self) -> Option<u64> {
-		None
+		self.estimated_send_rate
+	}
+
+	fn rtt(&self) -> Option<std::time::Duration> {
+		self.rtt
 	}
 }
 
@@ -556,6 +591,6 @@ impl web_transport_trait::Session for ScriptedSession {
 	}
 
 	fn stats(&self) -> impl web_transport_trait::Stats {
-		SinkStats
+		SinkStats::default()
 	}
 }

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -295,8 +295,9 @@ pub struct SinkSession {
 	/// than the SETUP-negotiated fallback an absent one selects.
 	protocol: Option<&'static str>,
 	/// What the transport claims to measure. Defaults to nothing, like a transport
-	/// with no congestion controller exposed.
-	stats: SinkStats,
+	/// with no congestion controller exposed. Shared and mutable so a test can
+	/// change it mid-session, the way a real transport's figures move.
+	stats: Arc<Mutex<SinkStats>>,
 }
 
 impl SinkSession {
@@ -305,14 +306,19 @@ impl SinkSession {
 			log,
 			bi_gate: None,
 			protocol: None,
-			stats: SinkStats::default(),
+			stats: Arc::new(Mutex::new(SinkStats::default())),
 		}
 	}
 
 	/// Report these connection statistics, as a real transport would.
-	pub fn with_stats(mut self, stats: SinkStats) -> Self {
-		self.stats = stats;
+	pub fn with_stats(self, stats: SinkStats) -> Self {
+		self.set_stats(stats);
 		self
+	}
+
+	/// Change what the transport reports, mid-session.
+	pub fn set_stats(&self, stats: SinkStats) {
+		*self.stats.lock().unwrap() = stats;
 	}
 
 	/// Report `protocol` as the negotiated ALPN.
@@ -331,7 +337,7 @@ impl SinkSession {
 			log: Log::default(),
 			bi_gate: Some(gate),
 			protocol: None,
-			stats: SinkStats::default(),
+			stats: Arc::new(Mutex::new(SinkStats::default())),
 		}
 	}
 }
@@ -392,7 +398,7 @@ impl web_transport_trait::Session for SinkSession {
 	}
 
 	fn stats(&self) -> impl web_transport_trait::Stats {
-		self.stats
+		*self.stats.lock().unwrap()
 	}
 }
 

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -36,6 +36,18 @@ impl Version {
 		}
 	}
 
+	/// Whether the PROBE message carries the RTT field. Added in lite-04; lite-03
+	/// carries the bitrate alone, so a report with only an RTT to give says nothing
+	/// there and must not be sent.
+	#[allow(clippy::match_like_matches_macro)]
+	pub fn has_probe_rtt(self) -> bool {
+		// Match form so future versions default forward (CLAUDE.md convention).
+		match self {
+			Self::Lite01 | Self::Lite02 | Self::Lite03 => false,
+			_ => true,
+		}
+	}
+
 	/// Whether the session opens a unidirectional Setup Stream carrying a single SETUP
 	/// message (capabilities + optional Path). Added in lite-05; the older bidirectional
 	/// setup exchange (Lite01/02) and the no-setup drafts (Lite03/04) don't use it.

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -439,9 +439,10 @@ impl<S: web_transport_trait::Session> Request<S> {
 				version,
 				client_setup,
 			} => {
-				// We report send bitrate; a server never advertises a request Path or Role.
+				// We report what the transport actually measures; a server never
+				// advertises a request Path or Role.
 				let our_setup = lite::Setup {
-					probe: lite::ProbeLevel::Report,
+					probe: lite::ProbeLevel::detect(&session),
 					path: None,
 					role: None,
 					// The dialing side prices the link; we charge what its SETUP declared.


### PR DESCRIPTION
Fixes the ~80ms of avoidable latency reported for every Firefox and Safari viewer.

`@moq/net` disables WebTransport for both engines by user-agent check, so qmux is their *normal* path, not a fallback. Over qmux the relay advertised `Probe: Report` in SETUP and then never sent a single PROBE message, so `@moq/watch`'s `latency: "real-time"` never saw an RTT and fell back to its fixed 100ms jitter buffer instead of the 20ms adaptive floor. The reported Chrome-to-Firefox delta of 79.9ms matches `FALLBACK_JITTER (100) - MIN_JITTER (20)` exactly, which pins both halves at once.

I reproduced each defect against the code before fixing it. Two are addressed here; the transport-level cause is upstream (see below).

## Root causes

### The send gate discarded the whole message for want of a bitrate

`run_probe` bailed on `estimated_send_rate()` *before* it ever looked at RTT. But the two PROBE fields are independent on the wire, and the draft states **"A value of 0 means unknown"** for each of them separately. A bitrate-unknown report is the prescribed encoding, not a workaround.

The gate now reports whenever either metric is measurable, and stays quiet only when neither is. The bitrate threshold keeps its existing age-decaying behaviour; RTT gets a flat relative threshold, and a `PROBE_MAX_AGE` term bounds staleness.

### `Probe.bitrate` could not express what the wire could

`lite::Probe::bitrate` was `u64` while `rtt` was `Option<u64>`. The wire could say "unknown"; the type could not, so the receive side turned it into a *measured zero*. That fed `bandwidth.set(Some(0))` here, and in the JS mirror `probe.bitrate ?? undefined` misses it because `0` is not nullish — so a spec-legal "unknown" became a genuine 0 bps ABR target in `js/watch/src/video/source.ts`.

**This half is a QUIC bug too, not just a qmux one.**

`bitrate` is now `Option<u64>`, mirroring `rtt`. `mod lite` is private (`rs/moq-net/src/lib.rs`), so this is not a semver break and targets `main`.

### SETUP advertised a capability independent of the transport

Both `client.rs` and `server.rs` hardcoded `ProbeLevel::Report`. The draft is explicit that a publisher which advertised no Probe capability MUST reset the stream, so advertising `Report` and then holding the stream open sending nothing is not a conformant state.

`ProbeLevel::detect` now samples what the transport actually exposes. Sampling at SETUP is sound because both QUIC and TCP derive their RTT from the handshake, which has already completed by the time SETUP is written. The subscriber's existing gate in `lite/subscriber.rs` then skips opening a probe stream it would get nothing from.

## No draft update

The wire format is unchanged. `0 = unknown` for **both** fields is already normative in `draft-lcurley-moq-lite` (see the PROBE section and the changelog entry "Bitrate and RTT use 0 for unknown"). This PR makes the code match the spec rather than the other way round, so the Cross-Package Sync draft row does not apply.

`js/net` is updated in the same PR per the sync table: `probe.ts`, `subscriber.ts`, and `publisher.ts` — the JS publisher had the same send-gate defect *and* never sent RTT at all.

## What this PR does not fix

**It does not on its own recover the 80ms.** The transport-level cause is that `qmux::Session` never implemented `stats()`, so `web_transport_trait`'s `StatsUnavailable` default made both metrics `None`. With only this PR, the relay correctly advertises `None` over qmux and the viewer stays on the fallback — honest, but not faster.

Two upstream qmux commits supply the missing measurement (RTT from `QX_PING`, plus `TCP_INFO` for RTT and delivery rate). They are additive, so they ship as **0.5.1** and the existing `qmux = "0.5.0"` requirement picks them up with no manifest change here. A stacked branch (`claude/relay-socket-stats`) then hands qmux the socket underneath the relay's WebSocket upgrade, which is the last link in the chain.

Also not addressed, and worth a follow-up issue: `js/watch/src/sync.ts` gives the application no way to distinguish adaptive jitter from the 100ms fallback.

## Testing

`just check` and `just test` both clean; 2610 tests pass.

New regression tests, each failing without its fix:
- `reports_rtt_without_a_bitrate` / `reports_bitrate_without_an_rtt` / `reports_nothing_when_nothing_is_measurable` — the send gate
- `each_field_is_independently_unknown` / `measured_zero_rounds_up` / `lite03_carries_bitrate_only` — the message encoding
- `detect_reports_nothing_without_stats` / `detect_reports_with_either_metric` — level detection

`SinkSession` gained a configurable `SinkStats` so a test can dictate what the transport claims to measure.

## Note for reviewers

`session.stats()` returns `impl Stats`, which is not `Send`, so the read is scoped to drop before the encode awaits — otherwise the probe future stops being `Send`.

(written by Opus 5)
