### PR TITLE
test(mux): read the SI history with a latency budget that keeps it

### DIFF
--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1313,11 +1313,21 @@ fn make_long_section(table_id: u8, ext: u16, version: u8, number: u8, last: u8, 
 }
 
 /// Read an SI snapshot track from the start: every group, as its frames' payloads.
+///
+/// Starting at group 0 only asks the publisher to send from there; the default
+/// [`moq_net::Latency::REAL_TIME`] budget then skips every group the live edge has
+/// already passed, which is all of them once the importer has finished. A budget
+/// wider than the test's wall-clock span (every cut lands within microseconds) is
+/// what actually delivers the history, so a count of groups counts cuts.
 async fn read_si_groups(consumer: &moq_net::broadcast::Consumer, name: &str) -> Vec<Vec<Bytes>> {
 	let mut track = consumer
 		.track(name)
 		.unwrap()
-		.subscribe(moq_net::track::Subscription::default().with_start(moq_net::track::Position::group(0)))
+		.subscribe(
+			moq_net::track::Subscription::default()
+				.with_start(moq_net::track::Position::group(0))
+				.with_latency(moq_net::Latency::max(moq_net::track::DEFAULT_LATENCY_MAX)),
+		)
 		.await
 		.unwrap();
 	let mut groups = Vec::new();


### PR DESCRIPTION
## Problem

`container::ts::export_test::tdt_round_trips_as_latest_value` (added in #2929) fails, on every run here, 20/20:

```
assertion `left == right` failed: one group per tick, no accumulation
  left: 1
 right: 2
```

## Root cause

Not the importer. Instrumenting `si::Entry::cut` shows both groups are cut, as the test intends:

```
CUT track=0x0011-0x42.si now=972 last=None
CUT track=0x0014-0x70.si now=972 last=None
CUT track=0x0014-0x70.si now=1176 last=Some(972)
```

The reader is what loses one. `read_si_groups` subscribes with `Subscription::default()`, whose `latency` is `Latency::REAL_TIME`, i.e. a zero drift budget. In `TrackState::is_stale`, `budget.is_zero()` short-circuits the age comparison, so *any* group below the live edge is convicted no matter how fresh it is, and `poll_recv_group` skips it. `with_start(Position::group(0))` doesn't counter that: it is a request to the publisher for where to send from, not a promise the subscriber keeps what arrives.

So a reader that joins after the importer has finished is handed the newest group and nothing else. Every other caller of the helper reads `groups.last()` or asserts a single group, so the helper's inability to see history stayed invisible until a test counted cuts.

## Fix

Give the subscription the publisher's own retention window as its drift budget, `Latency::max(DEFAULT_LATENCY_MAX)`. The subscriber's latency is clamped to the publisher's `Info::latency_max` anyway, so this is exactly "everything still cached", and a group count in these tests now counts cuts. The helper's doc comment says why the budget is load-bearing.

Test-only; no production code touched.

## Verification

- `just check` and `just test` pass.
- The named test passes 20/20 (it failed 15/15 before).
- Full `moq-mux` suite: 585 passed.

(written by Opus 5)