### PR TITLE
fix(tokio)!: leave process signals to the owner of the accept loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,6 +4929,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "jsonwebtoken",
+ "libc",
  "moq-net",
  "moq-stats",
  "moq-token",

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -82,3 +82,8 @@ sd-notify = "0.5"
 rcgen = "0.14"
 tempfile = "3"
 wiremock = "0.6"
+
+# `raise(SIGINT)` at ourselves, so the shutdown test exercises the real signal
+# path rather than the trigger behind it.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/rs/moq-relay/tests/shutdown_signal.rs
+++ b/rs/moq-relay/tests/shutdown_signal.rs
@@ -1,0 +1,144 @@
+//! SIGINT has to go through the relay's graceful drain.
+//!
+//! `--drain-timeout` promises that the first shutdown signal sends every session
+//! a GOAWAY and keeps serving for that long, so clients reconnect elsewhere
+//! instead of being cut off. This raises a real SIGINT at a relay with a live
+//! session and checks the promise end to end.
+//!
+//! The regression it guards: the accept loop installed its own ctrl-C handler
+//! and reported the interrupt as end-of-stream, so `serve` returned "stopped
+//! accepting connections" in milliseconds and won `Relay::run`'s `select!`
+//! against the drain future that deliberately waits out the window. SIGTERM was
+//! unaffected (only the drain future watches it), which is how the gap stayed
+//! hidden behind systemd while an operator's ctrl-C dropped every session.
+
+#![cfg(unix)]
+
+use std::{net::TcpListener, time::Duration};
+
+use moq_relay::{AuthConfig, Config, PublicConfig, Relay};
+
+/// Long enough that "exited immediately" and "waited out the window" cannot be
+/// confused, short enough to keep the test quick: `Relay::run` sleeps this plus
+/// one second before exiting.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[test]
+fn sigint_drains_sessions_before_exiting() {
+	// Same reason as the cluster tests: under `--all-features` a `Connection`
+	// carries every transport backend, and holding one across awaits overflows
+	// libtest's 2 MiB per-test stack in an unoptimized build.
+	std::thread::Builder::new()
+		.stack_size(32 * 1024 * 1024)
+		.spawn(|| {
+			tokio::runtime::Builder::new_current_thread()
+				.enable_all()
+				.build()
+				.expect("build test runtime")
+				.block_on(sigint_drains_sessions_before_exiting_inner());
+		})
+		.expect("spawn test thread")
+		.join()
+		.expect("test thread panicked");
+}
+
+async fn sigint_drains_sessions_before_exiting_inner() {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	// Install tokio's SIGINT handler before anything raises one: the default
+	// disposition would kill the test process instead. Held for the whole test so
+	// nothing can conclude the signal is unwatched.
+	let _interrupt =
+		tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()).expect("register SIGINT");
+
+	let (port, config) = relay_config();
+	let relay = Relay::load(config).await.expect("load relay");
+	let run = tokio::spawn(relay.run());
+	wait_listening(port).await;
+
+	let mut client_config = moq_tokio::connect::Config::default();
+	client_config.tls.insecure = Some(true);
+	let client = client_config.init(Default::default()).expect("client init");
+	// One-shot: a reconnecting client would migrate on the GOAWAY and hide whether
+	// the original session outlived the signal.
+	let url: url::Url = format!("tcp://127.0.0.1:{port}/").parse().expect("parse url");
+	let connection = client
+		.with_reconnect(false)
+		.connect(url)
+		.established()
+		.await
+		.expect("connect");
+	let draining = connection.draining().expect("connected");
+
+	let signalled = std::time::Instant::now();
+	// SAFETY: `raise` is async-signal-safe, and SIGINT's disposition is tokio's
+	// handler, registered above.
+	assert_eq!(unsafe { libc::raise(libc::SIGINT) }, 0, "failed to raise SIGINT");
+
+	let goaway = tokio::time::timeout(Duration::from_secs(5), draining.recv())
+		.await
+		.expect("no GOAWAY within 5s of SIGINT")
+		.expect("session closed without a GOAWAY");
+	// Empty URI: the relay is restarting, not moving. The window itself is the
+	// sender's own timer here (only moq-transport draft-17+ puts it on the wire),
+	// so it is the elapsed time below that proves it was honored.
+	assert_eq!(goaway.uri, "", "expected a reconnect-to-me GOAWAY");
+
+	// Mid-window the relay is still running: the point of the drain is the time it
+	// buys, not the notice. This is what the old ctrl-C race broke.
+	tokio::time::sleep(DRAIN_TIMEOUT / 2).await;
+	assert!(
+		!run.is_finished(),
+		"relay exited {:?} after SIGINT, well inside the {DRAIN_TIMEOUT:?} drain window",
+		signalled.elapsed()
+	);
+
+	// Then it exits on its own, cleanly.
+	tokio::time::timeout(Duration::from_secs(15), run)
+		.await
+		.expect("relay never exited after the drain window")
+		.expect("relay task panicked")
+		.expect("relay exited with an error");
+	assert!(
+		signalled.elapsed() >= DRAIN_TIMEOUT,
+		"relay exited after {:?}, short of the {DRAIN_TIMEOUT:?} drain window",
+		signalled.elapsed()
+	);
+}
+
+/// A stream-only relay on a free loopback TCP port, fully public, with a short
+/// drain window. Returns the port and the config to hand [`Relay::load`].
+fn relay_config() -> (u16, Config) {
+	// The listener is bound by `Relay::run`, not here, so this leaves the usual
+	// probe/bind gap; on loopback it is not worth retrying around.
+	let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
+	let port = probe.local_addr().expect("local addr").port();
+	drop(probe);
+
+	// Fully public auth: any no-JWT stream client gets the whole root.
+	#[allow(deprecated)]
+	let public = PublicConfig::Simple(vec![String::new()]);
+	let mut auth = AuthConfig::default();
+	auth.public = Some(public);
+
+	let mut config = Config::default();
+	config.listen.tcp.bind = Some(format!("127.0.0.1:{port}").parse().expect("parse addr"));
+	config.auth = auth;
+	config.drain_timeout = Some(DRAIN_TIMEOUT);
+
+	(port, config)
+}
+
+async fn wait_listening(port: u16) {
+	let deadline = std::time::Instant::now() + Duration::from_secs(5);
+	loop {
+		if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+			break;
+		}
+		assert!(
+			std::time::Instant::now() < deadline,
+			"relay never became ready on port {port}"
+		);
+		tokio::time::sleep(Duration::from_millis(25)).await;
+	}
+}

--- a/rs/moq-tokio/src/server.rs
+++ b/rs/moq-tokio/src/server.rs
@@ -444,22 +444,25 @@ impl Server {
 			let ws_accept = async {
 				match ws_ref {
 					Some(ws) => ws.accept_with_url().await,
-					None => std::future::pending().await,
+					None => None,
 				}
 			};
 			#[cfg(not(feature = "websocket"))]
-			let ws_accept = std::future::pending::<Option<crate::Result<()>>>();
+			let ws_accept = std::future::ready(None::<crate::Result<()>>);
 
 			#[allow(unused_variables)]
 			let server = self.moq.clone();
 			#[allow(unused_variables)]
 			let versions = self.versions.clone();
 
-			// No streams configured: never resolves, so it doesn't disturb select!.
+			// An absent transport resolves `None` rather than parking, so its arm is
+			// disabled instead of holding the `select!` open. That is what lets `else`
+			// mean "nothing is left that could accept" instead of "the one transport
+			// nobody configured is still notionally pending".
 			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 			let stream_accept = self.streams.recv();
 			#[cfg(not(any(feature = "tcp", all(feature = "uds", unix))))]
-			let stream_accept = std::future::pending::<Option<Request>>();
+			let stream_accept = std::future::ready(None::<Request>);
 
 			tokio::select! {
 				Some(request) = stream_accept => {
@@ -532,9 +535,10 @@ impl Server {
 						Err(err) => tracing::debug!(%err, "failed to accept session"),
 					}
 				}
-				// Every listener has stopped, so nothing more can arrive. Process signals
-				// are the owner's: an accept loop that consumes a global ctrl-C leaves no
-				// way to sequence shutdown around it (moq-relay drains sessions first).
+				// Nothing is left that could accept: every configured listener has stopped
+				// and no handshake is still in flight. Process signals are the owner's; an
+				// accept loop that consumes a global ctrl-C leaves no way to sequence
+				// shutdown around it (moq-relay drains sessions first).
 				else => return None,
 			}
 		}
@@ -622,10 +626,10 @@ impl Listener {
 	/// rejected early on an invalid path or missing auth. Call [Request::ok] or
 	/// [Request::close] to complete the handshake.
 	///
-	/// `None` means every listener has stopped; everything is already bound, so a
-	/// bind failure cannot arrive here. No process signal is watched: race this
-	/// against your own ctrl-C future and drop the listener if you want one to stop
-	/// the loop.
+	/// `None` means every configured listener has stopped and no handshake is still
+	/// in flight, so nothing can arrive again. Everything is already bound, so a bind
+	/// failure cannot arrive here. No process signal is watched: race this against
+	/// your own ctrl-C future and drop the listener if you want one to stop the loop.
 	pub async fn accept(&mut self) -> Option<Request> {
 		self.server.accept_next().await
 	}
@@ -830,11 +834,12 @@ impl StreamListeners {
 		Ok(())
 	}
 
-	/// Yield the next stream [`Request`], or pend forever if none are running.
+	/// Yield the next stream [`Request`], or `None` if no listener is running:
+	/// either none was configured, or every accept loop has ended.
 	async fn recv(&mut self) -> Option<Request> {
 		match self.rx.as_mut() {
 			Some(rx) => rx.recv().await,
-			None => std::future::pending().await,
+			None => None,
 		}
 	}
 

--- a/rs/moq-tokio/src/server.rs
+++ b/rs/moq-tokio/src/server.rs
@@ -246,10 +246,11 @@ impl Server {
 	/// Accept sessions until the listener stops, serving `origin` to each subscriber.
 	///
 	/// Spawns a task per session and logs (rather than propagates) per-session
-	/// errors, so one bad peer never tears down the listener. Returns when
-	/// interrupted (Ctrl-C) or on a fatal bind failure. For per-session auth or
-	/// routing, [`listen`](Self::listen) and drive [`Listener::accept`] yourself
-	/// instead.
+	/// errors, so one bad peer never tears down the listener. Returns on a fatal
+	/// bind failure, or once every listener has stopped; no process signal ends it,
+	/// so race it against your own ctrl-C future to stop on one. For per-session
+	/// auth or routing, [`listen`](Self::listen) and drive [`Listener::accept`]
+	/// yourself instead.
 	pub async fn serve_publish(self, origin: moq_net::origin::Consumer) -> crate::Result<()> {
 		self.with_publisher(origin).serve().await
 	}
@@ -531,10 +532,10 @@ impl Server {
 						Err(err) => tracing::debug!(%err, "failed to accept session"),
 					}
 				}
-				_ = tokio::signal::ctrl_c() => {
-					self.shutdown().await;
-					return None;
-				}
+				// Every listener has stopped, so nothing more can arrive. Process signals
+				// are the owner's: an accept loop that consumes a global ctrl-C leaves no
+				// way to sequence shutdown around it (moq-relay drains sessions first).
+				else => return None,
 			}
 		}
 	}
@@ -621,8 +622,10 @@ impl Listener {
 	/// rejected early on an invalid path or missing auth. Call [Request::ok] or
 	/// [Request::close] to complete the handshake.
 	///
-	/// `None` means the server stopped, which at this point means it was interrupted
-	/// (Ctrl-C): everything is already bound, so a bind failure cannot arrive here.
+	/// `None` means every listener has stopped; everything is already bound, so a
+	/// bind failure cannot arrive here. No process signal is watched: race this
+	/// against your own ctrl-C future and drop the listener if you want one to stop
+	/// the loop.
 	pub async fn accept(&mut self) -> Option<Request> {
 		self.server.accept_next().await
 	}
@@ -631,8 +634,6 @@ impl Listener {
 	/// shutdown.
 	///
 	/// Consumes the listener so its bound sockets are released before this returns.
-	///
-	/// [`accept`](Self::accept) calls this for you on Ctrl-C.
 	pub async fn close(mut self) {
 		self.server.shutdown().await;
 	}


### PR DESCRIPTION
Closes #2923.

## Summary

- **Root cause**: `Server::accept_next` registered its own `tokio::signal::ctrl_c()` handler and treated the interrupt as end-of-stream. `moq_relay::serve` reads that `None` as the listener stopping and bails with `"stopped accepting connections"`, all within about a second. `Relay::run` races `serve` against `drain_on_signal`, which deliberately waits `drain_timeout + 1s` so sessions get a GOAWAY and time to reconnect elsewhere. `select!` takes whichever *completes* first, so the accept loop won and the documented first-signal drain never happened. SIGTERM was unaffected (only the drain future watches it), so systemd and Kubernetes stops drained correctly while an operator's ctrl-C dropped every session.
- **Fix**: drop the ctrl-C arm and terminate the `select!` with `else => return None` instead. Process-level signals belong to whoever owns the process. Beyond unblocking the relay's drain, `moq-ffi` embeds this same loop in Python, Swift, Kotlin, Go, and C hosts, where a library installing a global SIGINT handler is a bug on its own; `MoqServer.cancel()` was already the intended stop.
- **Second commit**: that `else` was unreachable as written. Every arm is `Some(x) = fut`, and tokio disables an arm only once its future resolves and fails the pattern, but the unconfigured-transport sentinels parked instead (`pending()` for an absent WebSocket listener, for uncompiled stream support, and in `StreamListeners::recv` with no stream bind). One arm therefore stayed enabled forever. That predates this PR as a hang, but it also meant `moq_relay::serve`'s bail was unreachable: a dead QUIC endpoint read as a quiet relay rather than an outage. Those sentinels now resolve `None` so their arms are disabled. In-flight handshakes keep the loop alive on their own, since `self.accept` pends while non-empty, and no shipped configuration is listener-less (`Server::new` builds a QUIC backend whenever no stream listener is configured), so `else` fires only after a listener that existed has stopped.

## Public API changes

No signature moved. Behavior changed on published surface, hence the `!`:

- `moq_tokio::Listener::accept` no longer returns `None` on ctrl-C, and no longer closes the listeners for you. It returns `None` once every configured listener has stopped and no handshake is in flight.
- `moq_tokio::Server::serve_publish` / `serve_consume` / `serve_both` no longer return on ctrl-C. A caller that relied on that now races them against its own signal future. `moq-cli`, the only in-tree consumer of the accept loop besides the relay, already spawns its own `ctrl_c()` in `drive()` and is unaffected.
- `Listener::close` is unchanged, but is now the only thing that closes the listeners.

Docs on all four updated to match.

## Wire behavior changes

None on the MoQ wire. A peer of a SIGINT'd relay now observes what `--drain-timeout` always documented: a GOAWAY with an empty URI, then the full drain window before a force-close, instead of the transport dropping about a second in.

## Cross-package sync

No row applies. No wire format, `moq-ffi` API, or CLI flag changed, so no `drafts/` or binding-doc update is due. `doc/bin/relay/config.md`'s `--drain-timeout` text already described the intended behavior and now matches it.

## Test plan

- New `rs/moq-relay/tests/shutdown_signal.rs` (unix-only, its own test binary): stands up a real stream-only `Relay`, connects a one-shot client, raises a real `SIGINT` at the process, and asserts the session receives a reconnect-to-me GOAWAY, that the relay is still running halfway through the drain window, and that `run()` then exits `Ok` no earlier than the window. It asserts the drain itself, not that `run` returned a particular error.
  - Fails on `origin/dev`: `relay exited 1.506050708s after SIGINT, well inside the 3s drain window`.
  - Passes with the fix.
- `nix develop --command just check` and `just test`: clean, 3307 passed / 2 skipped.
- `cargo check -p moq-tokio --no-default-features --features <...>` for `tcp`, `quinn`, `websocket`, `uds`, `iroh`, and the combined set: all clean. (Bare `--no-default-features` fails at `request_ref!`/`RequestKind`, which is pre-existing and untouched here.)

The `else` path itself has no direct test: reaching it needs a *configured* listener to stop involuntarily, and nothing public can force that. `tcp::Listener::accept` retries `accept(2)` forever and never yields `None`, and `Listener::close` consumes the listener, so the state is only reachable via a fatal endpoint failure. A test hook to force it seemed worse than the reading.

(written by Opus 5)