### PR TITLE
fix(js/net): preserve sequences across producer replacements

### DIFF
--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -1,6 +1,6 @@
 import { expect, setSystemTime, test } from "bun:test";
 import { Consumer as BroadcastConsumer, Producer as BroadcastProducer } from "./broadcast.ts";
-import { Lagged, MAX_GROUP_FRAMES } from "./group.ts";
+import { Producer as GroupProducer, Lagged, MAX_GROUP_FRAMES } from "./group.ts";
 import { Timestamp } from "./time.ts";
 import type { Request as TrackRequest } from "./track.ts";
 import { Producer as TrackProducer } from "./track.ts";
@@ -49,6 +49,81 @@ test("consumer dedupes repeat subscriptions onto one upstream request", async ()
 	producer.close();
 	consumer.subscribe("video");
 	expect((await pendingRequest(consumer))?.name).toBe("video");
+});
+
+test("dynamic track sequences continue across producer replacements", async () => {
+	const broadcast = new BroadcastProducer();
+
+	const firstSubscriber = broadcast.subscribe("media");
+	const firstRequest = await broadcast.requested();
+	if (!firstRequest) throw new Error("expected first request");
+	const firstProducer = firstRequest.accept();
+	expect(firstProducer.appendGroup().sequence).toBe(0);
+	expect(firstProducer.appendDatagram(Timestamp.fromMillis(0), new Uint8Array())).toBe(1);
+	firstProducer.writeGroup(new GroupProducer(8));
+	firstProducer.writeDatagram({ sequence: 12, timestamp: Timestamp.fromMillis(0), payload: new Uint8Array() });
+	firstSubscriber.close();
+	firstProducer.close();
+
+	const secondSubscriber = broadcast.subscribe("media");
+	const secondRequest = await broadcast.requested();
+	if (!secondRequest) throw new Error("expected second request");
+	const secondProducer = secondRequest.accept();
+	expect(secondProducer.appendGroup().sequence).toBe(13);
+
+	const nextGeneration = new BroadcastProducer();
+	const nextSubscriber = nextGeneration.subscribe("media");
+	const nextRequest = await nextGeneration.requested();
+	if (!nextRequest) throw new Error("expected next-generation request");
+	expect(nextRequest.accept().appendGroup().sequence).toBe(0);
+
+	secondSubscriber.close();
+	secondProducer.close();
+	nextSubscriber.close();
+	broadcast.close();
+	nextGeneration.close();
+});
+
+test("concurrent dynamic producers share a sequence namespace", async () => {
+	const broadcast = new BroadcastProducer();
+	const firstSubscriber = broadcast.subscribe("media");
+	const secondSubscriber = broadcast.subscribe("media");
+	const firstRequest = await broadcast.requested();
+	const secondRequest = await broadcast.requested();
+	if (!firstRequest || !secondRequest) throw new Error("expected requests");
+	const firstProducer = firstRequest.accept();
+	const secondProducer = secondRequest.accept();
+
+	expect(firstProducer.appendGroup().sequence).toBe(0);
+	expect(secondProducer.appendGroup().sequence).toBe(1);
+	expect(firstProducer.appendGroup().sequence).toBe(2);
+
+	firstSubscriber.close();
+	secondSubscriber.close();
+	firstProducer.close();
+	secondProducer.close();
+	broadcast.close();
+});
+
+test("closing a broadcast preserves dequeued request sequences", async () => {
+	const broadcast = new BroadcastProducer();
+	const firstSubscriber = broadcast.subscribe("media");
+	const firstRequest = await broadcast.requested();
+	if (!firstRequest) throw new Error("expected first request");
+	const firstProducer = firstRequest.accept();
+	expect(firstProducer.appendGroup().sequence).toBe(0);
+
+	const secondSubscriber = broadcast.subscribe("media");
+	const secondRequest = await broadcast.requested();
+	if (!secondRequest) throw new Error("expected second request");
+	broadcast.close();
+	const secondProducer = secondRequest.accept();
+	expect(secondProducer.appendGroup().sequence).toBe(1);
+
+	firstSubscriber.close();
+	secondSubscriber.close();
+	firstProducer.close();
+	secondProducer.close();
 });
 
 test("a request exposes the aggregate subscription options", async () => {

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -76,7 +76,7 @@ function subscribe(
 	}
 
 	state.requested.mutate((requested) => {
-		requested.push(hooks.makeRequest(name, producer, state.sequences));
+		requested.push(hooks.makeRequest({ name, producer, sequences: state.sequences }));
 	});
 
 	return subscriber;
@@ -94,7 +94,7 @@ async function resolveTrackInfo(state: BroadcastState, name: string): Promise<tr
 
 	const producer = new track.Producer(name);
 	state.requested.mutate((requested) => {
-		requested.push(hooks.makeRequest(name, producer, state.sequences));
+		requested.push(hooks.makeRequest({ name, producer, sequences: state.sequences }));
 	});
 
 	try {

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -5,7 +5,7 @@
  */
 import { type GetPromise, Once, Signal } from "@moq/signals";
 import type { Consumer as GroupConsumer } from "./group.ts";
-import { hooks } from "./internal.ts";
+import { hooks, type TrackSequence } from "./internal.ts";
 import * as track from "./track.ts";
 
 /** Reactive backing state shared by broadcast producers and consumers. */
@@ -13,6 +13,7 @@ class BroadcastState {
 	requested = new Signal<track.Request[]>([]);
 	closed = new Once<Error | null>();
 	tracks = new Map<string, track.Producer>();
+	sequences = new Map<string, TrackSequence>();
 	// Live consumer handles sharing this state (see {@link Consumer.clone}). The broadcast
 	// closes once the last one closes, so a shared consumer can be handed to several callers.
 	consumers = 0;
@@ -75,7 +76,7 @@ function subscribe(
 	}
 
 	state.requested.mutate((requested) => {
-		requested.push(hooks.makeRequest(name, producer));
+		requested.push(hooks.makeRequest(name, producer, state.sequences));
 	});
 
 	return subscriber;
@@ -93,7 +94,7 @@ async function resolveTrackInfo(state: BroadcastState, name: string): Promise<tr
 
 	const producer = new track.Producer(name);
 	state.requested.mutate((requested) => {
-		requested.push(hooks.makeRequest(name, producer));
+		requested.push(hooks.makeRequest(name, producer, state.sequences));
 	});
 
 	try {

--- a/js/net/src/internal.ts
+++ b/js/net/src/internal.ts
@@ -15,10 +15,20 @@ export interface TrackSequence {
 /** Per-track sequence namespaces owned by one broadcast generation. */
 export type TrackSequences = Map<string, TrackSequence>;
 
+/** Inputs for creating a package-internal track request. */
+export interface TrackRequestOptions {
+	/** The requested track name. */
+	name: string;
+	/** The producer that will serve the request. */
+	producer: Producer;
+	/** Sequence namespaces shared by the broadcast generation. */
+	sequences: TrackSequences;
+}
+
 /** Hooks assigned in static blocks by the owning class. */
 export const hooks: {
 	/** Mint a track {@link Request}; assigned by `track.ts`. */
-	makeRequest: (name: string, producer: Producer, sequences: TrackSequences) => Request;
+	makeRequest: (options: TrackRequestOptions) => Request;
 } = {
 	makeRequest: () => {
 		throw new Error("track.ts not loaded");

--- a/js/net/src/internal.ts
+++ b/js/net/src/internal.ts
@@ -7,10 +7,18 @@
  */
 import type { Producer, Request } from "./track.ts";
 
+/** The next group or datagram sequence shared by dynamic producers of one broadcast track. */
+export interface TrackSequence {
+	next: number;
+}
+
+/** Per-track sequence namespaces owned by one broadcast generation. */
+export type TrackSequences = Map<string, TrackSequence>;
+
 /** Hooks assigned in static blocks by the owning class. */
 export const hooks: {
 	/** Mint a track {@link Request}; assigned by `track.ts`. */
-	makeRequest: (name: string, producer: Producer) => Request;
+	makeRequest: (name: string, producer: Producer, sequences: TrackSequences) => Request;
 } = {
 	makeRequest: () => {
 		throw new Error("track.ts not loaded");

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -6,7 +6,7 @@
 import { type GetPromise, type Getter, Once, Signal } from "@moq/signals";
 import type { Datagram } from "./datagram.ts";
 import { type Frame, type Consumer as GroupConsumer, Producer as GroupProducer, Lagged } from "./group.ts";
-import { hooks, type TrackSequence, type TrackSequences } from "./internal.ts";
+import { hooks, type TrackRequestOptions, type TrackSequence, type TrackSequences } from "./internal.ts";
 import { Timescale, type Timestamp } from "./time.ts";
 
 export type { Datagram } from "./datagram.ts";
@@ -147,14 +147,14 @@ export class Request {
 	#producer: Producer;
 	#sequences: TrackSequences;
 
-	private constructor(name: string, producer: Producer, sequences: TrackSequences) {
-		this.name = name;
-		this.#producer = producer;
-		this.#sequences = sequences;
+	private constructor(options: TrackRequestOptions) {
+		this.name = options.name;
+		this.#producer = options.producer;
+		this.#sequences = options.sequences;
 	}
 
 	static {
-		hooks.makeRequest = (name, producer, sequences) => new Request(name, producer, sequences);
+		hooks.makeRequest = (options) => new Request(options);
 	}
 
 	/** The aggregate subscription requested for this track. */

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -6,7 +6,7 @@
 import { type GetPromise, type Getter, Once, Signal } from "@moq/signals";
 import type { Datagram } from "./datagram.ts";
 import { type Frame, type Consumer as GroupConsumer, Producer as GroupProducer, Lagged } from "./group.ts";
-import { hooks } from "./internal.ts";
+import { hooks, type TrackSequence, type TrackSequences } from "./internal.ts";
 import { Timescale, type Timestamp } from "./time.ts";
 
 export type { Datagram } from "./datagram.ts";
@@ -145,14 +145,16 @@ export class Request {
 	readonly name: string;
 
 	#producer: Producer;
+	#sequences: TrackSequences;
 
-	private constructor(name: string, producer: Producer) {
+	private constructor(name: string, producer: Producer, sequences: TrackSequences) {
 		this.name = name;
 		this.#producer = producer;
+		this.#sequences = sequences;
 	}
 
 	static {
-		hooks.makeRequest = (name, producer) => new Request(name, producer);
+		hooks.makeRequest = (name, producer, sequences) => new Request(name, producer, sequences);
 	}
 
 	/** The aggregate subscription requested for this track. */
@@ -167,6 +169,7 @@ export class Request {
 
 	/** Accept the request, committing the track's immutable {@link Info}. */
 	accept(info: Partial<Info> = {}): Producer {
+		bindProducer(this.name, this.#producer, this.#sequences);
 		return this.#producer.accept(info);
 	}
 
@@ -277,6 +280,17 @@ async function resolveInfo(state: TrackState): Promise<Info> {
 // so eviction can drop them together.
 type CachedGroup = { group: GroupProducer; time: number; mirrors: Map<TrackState, GroupConsumer> };
 
+function bindProducer(name: string, producer: Producer, sequences: TrackSequences): void {
+	let shared = sequences.get(name);
+	if (!shared) {
+		shared = { next: 0 };
+		sequences.set(name, shared);
+	}
+	bindProducerSequence(producer, shared);
+}
+
+let bindProducerSequence: (producer: Producer, sequence: TrackSequence) => void;
+
 // Constructs a Subscriber from within this module without exposing a public
 // constructor that would leak the unexported TrackState. Assigned in the class's
 // static block.
@@ -301,8 +315,7 @@ export class Producer {
 	// The producer's own state is the source of truth (info/closed); subscribers
 	// read mirrored sinks, never this state directly.
 	#state = new TrackState();
-
-	#next?: number;
+	#sequence: TrackSequence = { next: 0 };
 
 	// Recently written source groups, retained for replay to late subscribers and
 	// pruned once closed and older than the cache window. Each entry tracks the mirror
@@ -319,6 +332,12 @@ export class Producer {
 
 	constructor(name: string) {
 		this.name = name;
+	}
+
+	static {
+		bindProducerSequence = (producer, sequence) => {
+			producer.#sequence = sequence;
+		};
 	}
 
 	/**
@@ -487,8 +506,9 @@ export class Producer {
 	appendGroup(): GroupProducer {
 		if (this.#state.closed.peek() !== undefined) throw new Error("track is closed");
 
-		const group = new GroupProducer(this.#next ?? 0);
-		this.#next = group.sequence + 1;
+		const sequence = this.#sequence;
+		const group = new GroupProducer(sequence.next);
+		sequence.next = group.sequence + 1;
 		this.#publish(group);
 
 		return group;
@@ -515,9 +535,10 @@ export class Producer {
 			this.#cache.splice(existing, 1);
 		}
 
-		// Only advance #next upward (for appendGroup auto-increment).
-		if (group.sequence >= (this.#next ?? 0)) {
-			this.#next = group.sequence + 1;
+		// Only advance the shared counter upward (for appendGroup auto-increment).
+		const sequence = this.#sequence;
+		if (group.sequence >= sequence.next) {
+			sequence.next = group.sequence + 1;
 		}
 
 		this.#publish(group);
@@ -552,8 +573,9 @@ export class Producer {
 		if (this.#state.closed.peek() !== undefined) throw new Error("track is closed");
 		if (payload.byteLength > MAX_DATAGRAM_BYTES) throw new Error("datagram payload too large");
 
-		const sequence = this.#next ?? 0;
-		this.#next = sequence + 1;
+		const counter = this.#sequence;
+		const sequence = counter.next;
+		counter.next = sequence + 1;
 		this.#publishDatagram({ sequence, timestamp, payload });
 		return sequence;
 	}
@@ -569,8 +591,9 @@ export class Producer {
 		if (this.#state.closed.peek() !== undefined) throw new Error("track is closed");
 		if (datagram.payload.byteLength > MAX_DATAGRAM_BYTES) throw new Error("datagram payload too large");
 
-		if (datagram.sequence >= (this.#next ?? 0)) {
-			this.#next = datagram.sequence + 1;
+		const sequence = this.#sequence;
+		if (datagram.sequence >= sequence.next) {
+			sequence.next = datagram.sequence + 1;
 		}
 		this.#publishDatagram(datagram);
 	}


### PR DESCRIPTION
## Summary

- Keep group and datagram sequences monotonic when an on-demand JS track producer is replaced within the same broadcast generation.
- Fix prolonged playback stalls caused by replacement producers restarting at sequence zero while the relay still retained a higher live edge.
- Preserve a zero start for a new broadcast generation and cover replacement, overlap, explicit writes, and close ordering.

## Public API changes

- None. The sequence namespace is package-internal, and the wire format is unchanged.

## Test plan

- [x] `just js check`
- [x] `just test` (`@moq/net`: 424 passed; `@moq/publish`: 44 passed)
- [x] Focused broadcast regression tests: 19 passed

## Cross-package sync

- No Rust, protocol draft, or documentation update is needed because this fixes internal JS producer sequencing without changing the wire format or exported API.

(Written by Codex GPT-5.6)
