### PR TITLE
fix(native): restore nightly checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -12,8 +12,6 @@ use std::net;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 use url::Url;
-use web_transport_quiche::proto::ConnectRequest;
-
 /// Re-exported because this module's public API exposes its types. A major
 /// `web-transport-quiche` bump is therefore a breaking change for this crate.
 pub use web_transport_quiche;
@@ -374,14 +372,13 @@ impl QuicheClient {
 		})
 		.await?;
 
-		let mut request = web_transport_quiche::proto::ConnectRequest::new(url.clone());
-		for alpn in versions.alpns() {
-			request = request.with_protocol(alpn.to_string());
-		}
-
 		match url.scheme() {
 			"https" => {
 				// WebTransport over HTTP/3
+				let mut request = web_transport_quiche::proto::ConnectRequest::new(url.clone());
+				for alpn in versions.alpns() {
+					request = request.with_protocol(alpn.to_string());
+				}
 				let session = web_transport_quiche::Connection::connect(conn, request)
 					.await
 					.map_err(map_client_error)?;
@@ -390,10 +387,9 @@ impl QuicheClient {
 			"moqt" | "moql" => {
 				// Raw QUIC mode
 				let alpn = conn.alpn().ok_or(Error::MissingAlpn)?;
-				let alpn = std::str::from_utf8(&alpn)?;
+				std::str::from_utf8(&alpn)?;
 
-				let response = web_transport_quiche::proto::ConnectResponse::OK.with_protocol(alpn);
-				Ok(web_transport_quiche::Connection::raw(conn, request, response))
+				Ok(web_transport_quiche::Connection::raw(conn))
 			}
 			_ => unreachable!("unsupported URL scheme: {}", url.scheme()),
 		}
@@ -748,10 +744,8 @@ pub(crate) async fn accept(
 		// not the global default set, so opt-in / work-in-progress versions (e.g.
 		// moq-lite-06-wip) that are deliberately absent from `moq_net::ALPNS` still work.
 		alpn if alpns.contains(&alpn) => {
-			let request = ConnectRequest::new("moqt://".to_string().parse::<Url>().unwrap());
-			let response = web_transport_quiche::proto::ConnectResponse::OK.with_protocol(alpn);
 			// Raw QUIC carries no request URL; the path rides the SETUP.
-			let session = web_transport_quiche::Connection::raw(conn, request, response);
+			let session = web_transport_quiche::Connection::raw(conn);
 			Ok((session, None, identity))
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn.to_string())),


### PR DESCRIPTION
## Summary

- Adapt raw Quiche sessions to the web-transport-quiche 0.6 API. The dependency upgrade left the feature-gated client and server paths calling the removed request/response form of Connection::raw, so the nightly all-features build no longer compiled.
- Preserve negotiated-ALPN validation for raw clients while limiting CONNECT request construction to HTTP/3 sessions.
- Update h2 from 0.4.15 to 0.4.17 to resolve RUSTSEC-2026-0258.
- Keep legitimate arrayref 0.3.9. Its yanked status was restored after the crates.io supply-chain incident: https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/

## Public API changes

- None.

No cross-package updates are needed because this changes neither the public API nor the wire format.

## Test plan

- nix develop --command just fix
- nix develop --command just check
- nix develop --command just test
- nix develop --command just rs audit
- nix develop --command just rs features
- git diff --check

(Written by GPT-5)
