### PR TITLE
fix(go): point `just go clean` at the real generated paths

### DIFF
--- a/go/justfile
+++ b/go/justfile
@@ -42,5 +42,4 @@ package-wrapper *args:
 
 # Remove the generated bindings, native libs, and vendoring from go/.
 clean:
-    rm -rf ffi/moq/moq.go ffi/moq/moq.h ffi/moq/lib \
-    	ffi/go.sum ffi/vendor wrapper/go.sum wrapper/vendor
+    rm -rf ffi/moq/moq.go ffi/moq/moq.h ffi/moq/lib ffi/go.sum ffi/vendor wrapper/go.sum wrapper/vendor

--- a/go/justfile
+++ b/go/justfile
@@ -36,8 +36,11 @@ package-ffi *args:
 package-wrapper *args:
     bash scripts/package-wrapper.sh {{ args }}
 
-# Remove the generated bindings, native libs, and vendoring that
-# scripts/check.sh produces in go/ (see go/.gitignore). The tmp staging
-# under the workspace dist/ is swept by `just js clean`.
+# The paths are the gitignored ones in go/.gitignore. `just go check` stages
+# into the workspace dist/ instead, which `just js clean` sweeps, so these only
+# show up when uniffi-bindgen-go or `go mod` is pointed at the tree directly.
+
+# Remove the generated bindings, native libs, and vendoring from go/.
 clean:
-    rm -rf moq/moq.go moq/lib go.sum vendor
+    rm -rf ffi/moq/moq.go ffi/moq/moq.h ffi/moq/lib \
+    	ffi/go.sum ffi/vendor wrapper/go.sum wrapper/vendor


### PR DESCRIPTION
`just go clean` has never removed anything.

The recipe was `rm -rf moq/moq.go moq/lib go.sum vendor`, relative to `go/`. None of those paths exist:

- `go/moq/` was split into `go/ffi/` and `go/wrapper/` in #1563. `clean` was added *afterwards* in #1641 already carrying the dead paths, so this is a path that never worked rather than one that rotted.
- Neither module root is `go/` — `ffi/` and `wrapper/` each have their own `go.mod` — so a bare `go.sum`/`vendor` at `go/` can't exist either. `go/.gitignore`'s patterns match at any depth, which is why the two spellings looked equivalent and the gap went unnoticed.

Now it removes what `go/.gitignore` actually names: the generated bindings and header at `ffi/moq/moq.go` and `ffi/moq/moq.h`, the native libs under `ffi/moq/lib/`, and `go.sum`/`vendor` scoped to each of the two modules.

## Note for reviewers: these artifacts don't come from `just go check`

The old comment said these were what `scripts/check.sh` "produces in `go/`". That is not true today — `check.sh` stages everything into the workspace `dist/` and says so itself ("Nothing is written into go/ffi or go/wrapper"). I confirmed it: after a full `just go check`, `git status --porcelain --ignored go/` showed only this justfile edit, and a `find` under `go/` for `moq.go`/`moq.h`/`go.sum`/`vendor`/`lib`/`*.a` came back empty. Nothing in the repo writes into `go/ffi` or `go/wrapper`; they are only ever read as a `--source-dir`.

So the recipe is a safety net for artifacts that appear when `uniffi-bindgen-go` or `go mod` is pointed at the tree directly, not a sweep of `check.sh` output. The comment now says that instead. The one-line summary also moved adjacent to the recipe, because `just --list` uses the *last* comment line and was previously showing "under the workspace dist/ is swept by \`just js clean\`." as the description.

## Verification

Since `just go check` leaves nothing behind, I verified against the real generated artifacts from a check run: copied `dist/go-ffi-pkg/.../moq/{moq.go,moq.h,lib/}` to `go/ffi/moq/`, added `go.sum`/`vendor` in both modules, confirmed git treated all seven as ignored, then ran `just go clean`. All seven removed; the tracked sources in `ffi/moq/` (`cgo.go`, `errors.go`, `link_test.go`) and `wrapper/` untouched.

`just fix` made no further changes (the continuation line is already canonical `just --fmt` output), and `just check` / `just test` both pass.

## Cross-package sync

None applicable — justfile recipe only, no wire format, no FFI surface, no CLI interface. `just go clean` isn't referenced in `/doc`.

Targets `main`: a `just` recipe fix is not a semver break in a published API.

(written by Opus 5)