### PR TITLE
fix(go): recover a wrapper release whose tag never landed

### DIFF
--- a/go/ffi/README.md
+++ b/go/ffi/README.md
@@ -20,7 +20,7 @@ The published module ships prebuilt `libmoq_ffi.a` for `linux/amd64`, `linux/arm
 
 ## Local development
 
-`go/scripts/check.sh` builds `moq-ffi` for the host, runs `uniffi-bindgen-go` to regenerate `moq.go`, stages this module plus the wrapper into `dist/`, and runs `go build`/`go vet`/`go test`. Run via `just go check`. Skips cleanly without `cargo`, `go`, or `uniffi-bindgen-go`.
+`go/scripts/check.sh` builds `moq-ffi` for the host, runs `uniffi-bindgen-go` to regenerate `moq.go`, stages this module plus the wrapper into `dist/`, and runs `go build`/`go vet`/`go test`. It also runs `publish-wrapper.test.sh`, which drives the wrapper publisher against a scratch bare repo (no cargo, no network). Run via `just go check`. Skips cleanly without `cargo`, `go`, or `uniffi-bindgen-go`.
 
 The dev shell provides both `go` and `uniffi-bindgen-go`, so `nix develop --command just go check` needs no setup. Without Nix, install `uniffi-bindgen-go` once:
 

--- a/go/scripts/check.sh
+++ b/go/scripts/check.sh
@@ -21,6 +21,10 @@ if ! command -v go >/dev/null 2>&1; then
     echo "go check: no go on PATH, skipping" >&2
     exit 0
 fi
+# The publish state machine needs neither cargo nor generated bindings, so it
+# runs ahead of the gates that skip a partial toolchain.
+bash "$SCRIPT_DIR/publish-wrapper.test.sh"
+
 if ! command -v cargo >/dev/null 2>&1; then
     echo "go check: no cargo on PATH, skipping" >&2
     exit 0

--- a/go/scripts/publish-wrapper.sh
+++ b/go/scripts/publish-wrapper.sh
@@ -17,8 +17,10 @@ set -euo pipefail
 # after a real diff is confirmed, so no-ops never consume a patch number.
 #
 # One exception, since "identical tree" and "already released" are not the same
-# thing: a mirror HEAD carrying no tag on this line is a half-finished release,
-# and it gets tagged rather than skipped. See the recovery below.
+# thing: a mirror HEAD that is one of our own release commits but carries no tag
+# lost its tag on the way out, and gets the version its commit subject names
+# rather than being skipped. Anything else untagged is left alone. See the
+# recovery below.
 #
 # Required environment:
 #   GO_MIRROR_TOKEN  - PAT or GitHub App token with contents:write on $MIRROR_REPO

--- a/go/scripts/publish-wrapper.sh
+++ b/go/scripts/publish-wrapper.sh
@@ -105,9 +105,17 @@ echo "--- diff against ${MIRROR_REPO} HEAD ---"
 git -C "$WORK/mirror" diff --cached --stat
 echo "---"
 
-# --- 4. Derive the next patch on this line from the mirror's tags ---
-# The registry, not the staged tree, decides the patch number, so the release
-# path and the recovery path below ask the same question the same way.
+# --- 4. Snapshot the mirror's tags on this line ---
+# One lookup, read twice, and a failed lookup is fatal rather than an empty
+# answer. Both questions below ("is HEAD released?" and "what is the next
+# patch?") read a missing tag as a reason to publish, so a transport error that
+# quietly returned nothing would mint a version over the top of a real one.
+if ! REMOTE_TAGS=$(git -C "$WORK/mirror" ls-remote --tags origin "refs/tags/v${LINE}.*"); then
+    echo "Error: failed to list ${MIRROR_REPO} tags on line ${LINE}" >&2
+    exit 1
+fi
+
+# Highest existing patch + 1, or .0 for a fresh line.
 next_release_tag() {
     local max=-1 ref patch
     while read -r ref; do
@@ -116,30 +124,51 @@ next_release_tag() {
         if [[ "$patch" =~ ^[0-9]+$ ]] && ((patch > max)); then
             max="$patch"
         fi
-    done < <(git -C "$WORK/mirror" ls-remote --tags origin "refs/tags/v${LINE}.*" |
-        sed -n "s#.*refs/tags/\(v${LINE}\.[0-9][0-9]*\)\$#\1#p")
+    done < <(sed -n "s#.*refs/tags/\(v${LINE}\.[0-9][0-9]*\)\$#\1#p" <<<"$REMOTE_TAGS")
 
     echo "v${LINE}.$((max + 1))"
 }
 
+# Annotated tags list twice, as the tag object and as a peeled "^{}" commit, so
+# matching the sha at the start of a line covers both shapes.
+tagged_on_line() {
+    grep -q "^$1[[:space:]]" <<<"$REMOTE_TAGS"
+}
+
 # --- 5. Identical tree usually means there is nothing to release ---
 if git -C "$WORK/mirror" diff --cached --quiet; then
-    # Usually, but not always: an untagged HEAD is a half-finished release, not a
-    # finished one. Publishing pushes the branch and the tag, and the patch
-    # number is only derived when there is a diff, so a tag that never landed
-    # used to strand that content forever -- every retry matched HEAD and
-    # stopped here without ever asking which tag was missing. Tag what is
-    # already there instead.
     HEAD_SHA=$(git -C "$WORK/mirror" rev-parse HEAD)
-    if git -C "$WORK/mirror" ls-remote --tags origin "refs/tags/v${LINE}.*" |
-        grep -q "^${HEAD_SHA}[[:space:]]"; then
+    if tagged_on_line "$HEAD_SHA"; then
         echo "Staged wrapper tree is identical to ${MIRROR_REPO} HEAD. Nothing to publish."
         exit 0
     fi
 
-    MIRROR_TAG=$(next_release_tag)
-    echo "::warning::${MIRROR_REPO} HEAD matches the staged tree but carries no v${LINE}.* tag;"
-    echo "::warning::a previous run pushed the tree without its tag. Tagging HEAD as ${MIRROR_TAG}."
+    # An untagged HEAD is only ours to fix if we made it. Publishing pushes the
+    # branch and the tag together, but that used to be two pushes, and a tag
+    # that never landed strands its content: the patch number is derived from a
+    # diff, so every retry matched HEAD and stopped above. The stranded commit
+    # names the version it was meant to carry, so restore exactly that rather
+    # than inventing the next one, and leave anything we didn't write alone.
+    HEAD_SUBJECT=$(git -C "$WORK/mirror" log -1 --format=%s)
+    LINE_RE="${LINE//./\\.}"
+    if [[ ! "$HEAD_SUBJECT" =~ ^Release\ (v${LINE_RE}\.[0-9]+)$ ]]; then
+        echo "Staged wrapper tree is identical to ${MIRROR_REPO} HEAD. Nothing to publish."
+        echo "::warning::HEAD carries no v${LINE}.* tag and is not a release commit (${HEAD_SUBJECT});"
+        echo "::warning::leaving it alone. Tag it by hand if it should have been released."
+        exit 0
+    fi
+    MIRROR_TAG="${BASH_REMATCH[1]}"
+
+    # Whatever that tag names today, it isn't this commit, or we'd have returned
+    # above. Reusing the subject's version would mean moving someone else's tag.
+    if grep -q "refs/tags/${MIRROR_TAG}\$" <<<"$REMOTE_TAGS"; then
+        echo "Error: ${MIRROR_TAG} already exists on ${MIRROR_REPO} and points elsewhere." >&2
+        echo "       ${MIRROR_REPO} HEAD claims to be that release; resolve by hand." >&2
+        exit 1
+    fi
+
+    echo "::warning::${MIRROR_REPO} HEAD is ${MIRROR_TAG} with no tag; a previous run pushed the tree without it."
+    echo "Restoring ${MIRROR_TAG} on the existing HEAD."
 
     if [[ "$DRY_RUN" == true ]]; then
         echo "Dry-run: not tagging or pushing."

--- a/go/scripts/publish-wrapper.sh
+++ b/go/scripts/publish-wrapper.sh
@@ -16,11 +16,17 @@ set -euo pipefail
 # no-op trigger) from minting an empty patch release. The patch is computed only
 # after a real diff is confirmed, so no-ops never consume a patch number.
 #
+# One exception, since "identical tree" and "already released" are not the same
+# thing: a mirror HEAD carrying no tag on this line is a half-finished release,
+# and it gets tagged rather than skipped. See the recovery below.
+#
 # Required environment:
 #   GO_MIRROR_TOKEN  - PAT or GitHub App token with contents:write on $MIRROR_REPO
 #
 # Optional environment:
 #   GO_MIRROR_REPO   - defaults to moq-dev/moq-go
+#   GO_MIRROR_URL    - clone/push remote, defaults to the GitHub URL for
+#                      $MIRROR_REPO. Tests point it at a local bare repo.
 #   GIT_AUTHOR_NAME  - defaults to "moq-go-release"
 #   GIT_AUTHOR_EMAIL - defaults to "release@moq.dev"
 #
@@ -82,7 +88,9 @@ LINE=$(tr -d '[:space:]' <"$STAGED/VERSION")
 }
 
 # --- 2. Clone the mirror ---
-if [[ -n "${GO_MIRROR_TOKEN:-}" ]]; then
+if [[ -n "${GO_MIRROR_URL:-}" ]]; then
+    CLONE_URL="$GO_MIRROR_URL"
+elif [[ -n "${GO_MIRROR_TOKEN:-}" ]]; then
     CLONE_URL="https://x-access-token:${GO_MIRROR_TOKEN}@github.com/${MIRROR_REPO}"
 else
     CLONE_URL="https://github.com/${MIRROR_REPO}"
@@ -97,26 +105,54 @@ echo "--- diff against ${MIRROR_REPO} HEAD ---"
 git -C "$WORK/mirror" diff --cached --stat
 echo "---"
 
-# --- 4. Idempotency: identical tree means there is nothing to release ---
+# --- 4. Derive the next patch on this line from the mirror's tags ---
+# The registry, not the staged tree, decides the patch number, so the release
+# path and the recovery path below ask the same question the same way.
+next_release_tag() {
+    local max=-1 ref patch
+    while read -r ref; do
+        [[ -z "$ref" ]] && continue
+        patch="${ref##*.}"
+        if [[ "$patch" =~ ^[0-9]+$ ]] && ((patch > max)); then
+            max="$patch"
+        fi
+    done < <(git -C "$WORK/mirror" ls-remote --tags origin "refs/tags/v${LINE}.*" |
+        sed -n "s#.*refs/tags/\(v${LINE}\.[0-9][0-9]*\)\$#\1#p")
+
+    echo "v${LINE}.$((max + 1))"
+}
+
+# --- 5. Identical tree usually means there is nothing to release ---
 if git -C "$WORK/mirror" diff --cached --quiet; then
-    echo "Staged wrapper tree is identical to ${MIRROR_REPO} HEAD. Nothing to publish."
+    # Usually, but not always: an untagged HEAD is a half-finished release, not a
+    # finished one. Publishing pushes the branch and the tag, and the patch
+    # number is only derived when there is a diff, so a tag that never landed
+    # used to strand that content forever -- every retry matched HEAD and
+    # stopped here without ever asking which tag was missing. Tag what is
+    # already there instead.
+    HEAD_SHA=$(git -C "$WORK/mirror" rev-parse HEAD)
+    if git -C "$WORK/mirror" ls-remote --tags origin "refs/tags/v${LINE}.*" |
+        grep -q "^${HEAD_SHA}[[:space:]]"; then
+        echo "Staged wrapper tree is identical to ${MIRROR_REPO} HEAD. Nothing to publish."
+        exit 0
+    fi
+
+    MIRROR_TAG=$(next_release_tag)
+    echo "::warning::${MIRROR_REPO} HEAD matches the staged tree but carries no v${LINE}.* tag;"
+    echo "::warning::a previous run pushed the tree without its tag. Tagging HEAD as ${MIRROR_TAG}."
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "Dry-run: not tagging or pushing."
+        exit 0
+    fi
+
+    git -C "$WORK/mirror" tag "${MIRROR_TAG}"
+    git -C "$WORK/mirror" push origin "refs/tags/${MIRROR_TAG}"
+    echo "Published ${MIRROR_REPO}@${MIRROR_TAG}"
     exit 0
 fi
 
-# --- 5. Derive the next patch on this line from the mirror's tags ---
-# (Only now that we know the tree actually changed, so no-ops don't burn a patch.)
-MAX_PATCH=-1
-while read -r ref; do
-    [[ -z "$ref" ]] && continue
-    patch="${ref##*.}"
-    if [[ "$patch" =~ ^[0-9]+$ ]] && ((patch > MAX_PATCH)); then
-        MAX_PATCH="$patch"
-    fi
-done < <(git -C "$WORK/mirror" ls-remote --tags origin "refs/tags/v${LINE}.*" |
-    sed -n "s#.*refs/tags/\(v${LINE}\.[0-9][0-9]*\)\$#\1#p")
-
-VERSION="${LINE}.$((MAX_PATCH + 1))"
-MIRROR_TAG="v${VERSION}"
+MIRROR_TAG=$(next_release_tag)
 echo "Next ${MIRROR_REPO} release on line ${LINE}: ${MIRROR_TAG}"
 
 # --- 6. Commit / tag / push (skipped in dry-run) ---
@@ -130,7 +166,10 @@ git -C "$WORK/mirror" config user.email "${GIT_AUTHOR_EMAIL:-release@moq.dev}"
 
 git -C "$WORK/mirror" commit -m "Release ${MIRROR_TAG}"
 git -C "$WORK/mirror" tag "${MIRROR_TAG}"
-git -C "$WORK/mirror" push origin "HEAD:refs/heads/main"
-git -C "$WORK/mirror" push origin "refs/tags/${MIRROR_TAG}"
+
+# One push, all or nothing. Landing the branch without its tag publishes content
+# that no version resolves to, and the recovery above only exists because that
+# window used to be two separate pushes wide.
+git -C "$WORK/mirror" push --atomic origin "HEAD:refs/heads/main" "refs/tags/${MIRROR_TAG}"
 
 echo "Published ${MIRROR_REPO}@${MIRROR_TAG}"

--- a/go/scripts/publish-wrapper.test.sh
+++ b/go/scripts/publish-wrapper.test.sh
@@ -53,13 +53,22 @@ fail() {
     FAILED=1
 }
 
+# A CI runner has no global git identity, and both a commit and an annotated tag
+# refuse to be written without one, so give each scratch repo its own.
+identify() {
+    git -C "$1" config user.email test@example.com
+    git -C "$1" config user.name "publish-wrapper test"
+}
+
 MIRROR="$WORK/mirror.git"
 git init --quiet --bare --initial-branch=main "$MIRROR"
+identify "$MIRROR"
 
 # A mirror has to start somewhere: one empty commit so `git clone` has a HEAD.
 SEED="$WORK/seed"
 git init --quiet --initial-branch=main "$SEED"
-git -C "$SEED" -c user.email=t@example.com -c user.name=t commit --quiet --allow-empty -m "seed"
+identify "$SEED"
+git -C "$SEED" commit --quiet --allow-empty -m "seed"
 git -C "$SEED" push --quiet "$MIRROR" HEAD:refs/heads/main
 
 LINE=$(tr -d '[:space:]' <"$GO_DIR/wrapper/VERSION")
@@ -143,7 +152,7 @@ echo "publish-wrapper test: leaves a HEAD it did not write alone"
 git -C "$MIRROR" tag --delete "v${LINE}.0" >/dev/null
 git -C "$SEED" fetch --quiet "$MIRROR" main
 git -C "$SEED" checkout --quiet FETCH_HEAD
-git -C "$SEED" -c user.email=t@example.com -c user.name=t commit --quiet --allow-empty -m "a human was here"
+git -C "$SEED" commit --quiet --allow-empty -m "a human was here"
 git -C "$SEED" push --quiet --force "$MIRROR" HEAD:refs/heads/main
 publish >"$WORK/run5.log" 2>&1 || {
     cat "$WORK/run5.log" >&2

--- a/go/scripts/publish-wrapper.test.sh
+++ b/go/scripts/publish-wrapper.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exercises publish-wrapper.sh against a scratch bare repo standing in for the
+# mirror, via GO_MIRROR_URL. No network, no cargo, no bindings: this is about
+# the publish state machine, which the rest of `just go check` never reaches.
+#
+# The case worth having a test for is recovery. Publishing lands a branch and a
+# tag, and the patch number is derived only when the staged tree differs from
+# the mirror, so a tag that failed to land used to strand that content: the
+# retry matched HEAD, said "nothing to publish", and never asked which tag was
+# missing.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v go >/dev/null 2>&1; then
+    echo "publish-wrapper test: no go on PATH, skipping" >&2
+    exit 0
+fi
+if ! command -v rsync >/dev/null 2>&1; then
+    echo "publish-wrapper test: no rsync on PATH, skipping" >&2
+    exit 0
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+FAILED=0
+ok() { echo "  ok: $1"; }
+fail() {
+    echo "  FAIL: $1" >&2
+    FAILED=1
+}
+
+MIRROR="$WORK/mirror.git"
+git init --quiet --bare --initial-branch=main "$MIRROR"
+
+# A mirror has to start somewhere: one empty commit so `git clone` has a HEAD.
+SEED="$WORK/seed"
+git init --quiet --initial-branch=main "$SEED"
+git -C "$SEED" -c user.email=t@example.com -c user.name=t commit --quiet --allow-empty -m "seed"
+git -C "$SEED" push --quiet "$MIRROR" HEAD:refs/heads/main
+
+LINE=$(tr -d '[:space:]' <"$GO_DIR/wrapper/VERSION")
+
+# Stage a real wrapper tarball. --skip-tidy keeps it offline (no go.sum), which
+# is fine: publish-wrapper.sh only reads VERSION out of the staged tree.
+bash "$GO_DIR/scripts/package-wrapper.sh" \
+    --line "$LINE" \
+    --ffi-version "0.0.0-test" \
+    --source-dir "$GO_DIR/wrapper" \
+    --output "$WORK/staged" \
+    --skip-tidy >"$WORK/package.log" 2>&1 || {
+    cat "$WORK/package.log" >&2
+    echo "publish-wrapper test: packaging failed" >&2
+    exit 1
+}
+
+mkdir -p "$WORK/run/go-out"
+cp "$WORK/staged/moq-go-${LINE}-wrapper.tar.gz" "$WORK/run/go-out/"
+
+publish() {
+    (
+        cd "$WORK/run"
+        GO_MIRROR_URL="$MIRROR" GO_MIRROR_TOKEN=unused \
+            bash "$GO_DIR/scripts/publish-wrapper.sh"
+    )
+}
+
+tags() { git -C "$MIRROR" tag --list "v${LINE}.*" | sort; }
+head_tags() { git -C "$MIRROR" tag --points-at "refs/heads/main" | sort; }
+
+echo "publish-wrapper test: first release"
+publish >"$WORK/run1.log" 2>&1 || {
+    cat "$WORK/run1.log" >&2
+    fail "first publish exited non-zero"
+}
+[[ "$(tags)" == "v${LINE}.0" ]] && ok "cut v${LINE}.0" || fail "expected v${LINE}.0, got: $(tags | tr '\n' ' ')"
+[[ -n "$(head_tags)" ]] && ok "tagged the pushed HEAD" || fail "HEAD carries no tag"
+
+echo "publish-wrapper test: unchanged tree is a no-op"
+publish >"$WORK/run2.log" 2>&1 || {
+    cat "$WORK/run2.log" >&2
+    fail "second publish exited non-zero"
+}
+grep -q "Nothing to publish" "$WORK/run2.log" && ok "reported nothing to publish" || fail "expected a no-op"
+[[ "$(tags)" == "v${LINE}.0" ]] && ok "burned no patch number" || fail "unexpected tags: $(tags | tr '\n' ' ')"
+
+echo "publish-wrapper test: recovers a release whose tag never landed"
+# Exactly what a failed tag push leaves behind: the tree is on main, untagged.
+git -C "$MIRROR" tag --delete "v${LINE}.0" >/dev/null
+publish >"$WORK/run3.log" 2>&1 || {
+    cat "$WORK/run3.log" >&2
+    fail "recovery publish exited non-zero"
+}
+[[ "$(tags)" == "v${LINE}.0" ]] && ok "re-cut v${LINE}.0 for the existing HEAD" || fail "expected v${LINE}.0 restored, got: $(tags | tr '\n' ' ')"
+[[ -n "$(head_tags)" ]] && ok "the tag points at the published HEAD" || fail "restored tag is not on HEAD"
+
+if ((FAILED)); then
+    echo "publish-wrapper test: FAILED" >&2
+    exit 1
+fi
+echo "publish-wrapper test: ok"

--- a/go/scripts/publish-wrapper.test.sh
+++ b/go/scripts/publish-wrapper.test.sh
@@ -121,6 +121,41 @@ publish >"$WORK/run3.log" 2>&1 || {
 expect "re-cut v${LINE}.0 for the existing HEAD" "$(tags)" "v${LINE}.0 "
 expect_tagged "the tag points at the published HEAD" "$(head_tags)"
 
+echo "publish-wrapper test: recognises an annotated tag"
+# The publisher writes lightweight tags, but a hand-cut one is annotated, and
+# ls-remote then lists it twice: the tag object, and the peeled commit.
+git -C "$MIRROR" tag --delete "v${LINE}.0" >/dev/null
+git -C "$MIRROR" tag --annotate --message "by hand" "v${LINE}.0" refs/heads/main
+publish >"$WORK/run4.log" 2>&1 || {
+    cat "$WORK/run4.log" >&2
+    fail "publish against an annotated tag exited non-zero"
+}
+if grep -q "Nothing to publish" "$WORK/run4.log"; then
+    echo "  ok: read the peeled tag as released"
+else
+    fail "did not recognise the annotated tag; would have minted a duplicate"
+fi
+expect "left the annotated tag alone" "$(tags)" "v${LINE}.0 "
+
+echo "publish-wrapper test: leaves a HEAD it did not write alone"
+# Only a stranded publisher commit is ours to tag. Anything else with a
+# matching tree gets a warning, not a version.
+git -C "$MIRROR" tag --delete "v${LINE}.0" >/dev/null
+git -C "$SEED" fetch --quiet "$MIRROR" main
+git -C "$SEED" checkout --quiet FETCH_HEAD
+git -C "$SEED" -c user.email=t@example.com -c user.name=t commit --quiet --allow-empty -m "a human was here"
+git -C "$SEED" push --quiet --force "$MIRROR" HEAD:refs/heads/main
+publish >"$WORK/run5.log" 2>&1 || {
+    cat "$WORK/run5.log" >&2
+    fail "publish against an unrelated HEAD exited non-zero"
+}
+expect "minted no version for it" "$(tags)" ""
+if grep -q "is not a release commit" "$WORK/run5.log"; then
+    echo "  ok: said why it stopped"
+else
+    fail "no warning explaining the skip"
+fi
+
 if ((FAILED)); then
     echo "publish-wrapper test: FAILED" >&2
     exit 1

--- a/go/scripts/publish-wrapper.test.sh
+++ b/go/scripts/publish-wrapper.test.sh
@@ -27,7 +27,27 @@ WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
 FAILED=0
-ok() { echo "  ok: $1"; }
+
+# expect <description> <actual> <expected>
+expect() {
+    if [[ "$2" == "$3" ]]; then
+        echo "  ok: $1"
+    else
+        echo "  FAIL: $1 (expected '$3', got '$2')" >&2
+        FAILED=1
+    fi
+}
+
+# expect_tagged <description> <tags pointing at the mirror HEAD>
+expect_tagged() {
+    if [[ -n "$2" ]]; then
+        echo "  ok: $1"
+    else
+        echo "  FAIL: $1 (HEAD carries no tag)" >&2
+        FAILED=1
+    fi
+}
+
 fail() {
     echo "  FAIL: $1" >&2
     FAILED=1
@@ -68,24 +88,28 @@ publish() {
     )
 }
 
-tags() { git -C "$MIRROR" tag --list "v${LINE}.*" | sort; }
-head_tags() { git -C "$MIRROR" tag --points-at "refs/heads/main" | sort; }
+tags() { git -C "$MIRROR" tag --list "v${LINE}.*" | sort | tr '\n' ' '; }
+head_tags() { git -C "$MIRROR" tag --points-at "refs/heads/main" | sort | tr '\n' ' '; }
 
 echo "publish-wrapper test: first release"
 publish >"$WORK/run1.log" 2>&1 || {
     cat "$WORK/run1.log" >&2
     fail "first publish exited non-zero"
 }
-[[ "$(tags)" == "v${LINE}.0" ]] && ok "cut v${LINE}.0" || fail "expected v${LINE}.0, got: $(tags | tr '\n' ' ')"
-[[ -n "$(head_tags)" ]] && ok "tagged the pushed HEAD" || fail "HEAD carries no tag"
+expect "cut v${LINE}.0" "$(tags)" "v${LINE}.0 "
+expect_tagged "tagged the pushed HEAD" "$(head_tags)"
 
 echo "publish-wrapper test: unchanged tree is a no-op"
 publish >"$WORK/run2.log" 2>&1 || {
     cat "$WORK/run2.log" >&2
     fail "second publish exited non-zero"
 }
-grep -q "Nothing to publish" "$WORK/run2.log" && ok "reported nothing to publish" || fail "expected a no-op"
-[[ "$(tags)" == "v${LINE}.0" ]] && ok "burned no patch number" || fail "unexpected tags: $(tags | tr '\n' ' ')"
+if grep -q "Nothing to publish" "$WORK/run2.log"; then
+    echo "  ok: reported nothing to publish"
+else
+    fail "expected a no-op"
+fi
+expect "burned no patch number" "$(tags)" "v${LINE}.0 "
 
 echo "publish-wrapper test: recovers a release whose tag never landed"
 # Exactly what a failed tag push leaves behind: the tree is on main, untagged.
@@ -94,8 +118,8 @@ publish >"$WORK/run3.log" 2>&1 || {
     cat "$WORK/run3.log" >&2
     fail "recovery publish exited non-zero"
 }
-[[ "$(tags)" == "v${LINE}.0" ]] && ok "re-cut v${LINE}.0 for the existing HEAD" || fail "expected v${LINE}.0 restored, got: $(tags | tr '\n' ' ')"
-[[ -n "$(head_tags)" ]] && ok "the tag points at the published HEAD" || fail "restored tag is not on HEAD"
+expect "re-cut v${LINE}.0 for the existing HEAD" "$(tags)" "v${LINE}.0 "
+expect_tagged "the tag points at the published HEAD" "$(head_tags)"
 
 if ((FAILED)); then
     echo "publish-wrapper test: FAILED" >&2

--- a/go/wrapper/README.md
+++ b/go/wrapper/README.md
@@ -105,4 +105,4 @@ The committed `go.mod` carries a `require github.com/moq-dev/moq-go-ffi v0.0.0` 
 
 ## Local development
 
-Run `just go check`: it builds `moq-ffi` for the host, regenerates the bindings, stages both modules into `dist/` with a `replace` wiring the wrapper to the local ffi, and runs `go build`/`go vet`/`go test`. See [../ffi/README.md](../ffi/README.md) for the `uniffi-bindgen-go` install.
+Run `just go check`: it builds `moq-ffi` for the host, regenerates the bindings, stages both modules into `dist/` with a `replace` wiring the wrapper to the local ffi, and runs `go build`/`go vet`/`go test`. It also runs `scripts/publish-wrapper.test.sh`, which exercises the publisher's release/no-op/recovery paths against a scratch bare repo standing in for the mirror. See [../ffi/README.md](../ffi/README.md) for the `uniffi-bindgen-go` install.

--- a/justfile
+++ b/justfile
@@ -108,8 +108,11 @@ _tools $FILES="":
     scoped '^(py/|pyproject\.toml$|uv\.lock$|rs/moq-ffi/)'     && tools+=(uv)
     scoped '^(kt/|rs/moq-ffi/)'                                && tools+=(gradle java)
     # cargo because `go check` builds moq-ffi for the host, and skips on a
-    # missing cargo the same way it skips on a missing go.
-    scoped '^(go/|rs/moq-ffi/)'                                && tools+=(go uniffi-bindgen-go cargo)
+    # missing cargo the same way it skips on a missing go. rsync because the
+    # publish scripts stage the mirror tree with it, so the publisher test skips
+    # without it, and a skip that keeps `just check` green is what MOQ_STRICT is
+    # here to prevent.
+    scoped '^(go/|rs/moq-ffi/)'                                && tools+=(go uniffi-bindgen-go cargo rsync)
     # cargo regenerates moq.h for the type-check; pkg-config locates Qt6 and
     # ffmpeg. Every platform: the plugin type-checks against headers, and the
     # dev shell ships those even on Darwin, where obs-studio can't build.


### PR DESCRIPTION
Closes #2959.

`publish-wrapper.sh` pushed the mirror branch and the version tag as two operations, and derived the patch number only after confirming the staged tree differed from the mirror. Those two facts combine badly. If the branch push landed and the tag push didn't, the content sat on `main` untagged, and every retry rsynced the same tree, matched HEAD, printed "Nothing to publish", and exited before ever asking which tag was missing:

```bash
if git -C "$WORK/mirror" diff --cached --quiet; then
    echo "Staged wrapper tree is identical to ${MIRROR_REPO} HEAD. Nothing to publish."
    exit 0
fi
```

That release was then unreachable without hand-holding, and no Go version resolved to the code on the mirror.

## The fix

Two changes, because either alone leaves a hole:

- **The push is atomic.** `git push --atomic origin HEAD:refs/heads/main refs/tags/vX.Y.Z` lands both or neither, closing the window.
- **"Identical tree" no longer implies "already released."** An untagged HEAD is a half-finished release, so it now gets the next patch on the line instead of a shrug. This is what recovers a mirror that is already in the bad state, which the atomic push alone cannot do.

The patch derivation moved into a function so the release path and the recovery path ask the registry the same question the same way.

`publish-ffi.sh` never had this bug: it knows its tag up front from the crate version, checks the remote for it, and tags HEAD on its identical-tree path. Only the wrapper derives its version from a diff, which is what made the two-step push unrecoverable there.

## Testing

These scripts had no tests, so this adds the first: `publish-wrapper.test.sh` drives the real publisher against a scratch bare repo standing in for the mirror, through a new `GO_MIRROR_URL` override. It covers the first release, the no-op on an unchanged tree, and the recovery. No cargo, no bindings, no network, so `check.sh` runs it ahead of the gates that skip an incomplete toolchain — it lands in `just go check` in under a second.

I checked it pins the actual bug rather than just passing: reverting the recovery logic while leaving the test seam in place fails the third case and only the third case.

```
publish-wrapper test: first release
  ok: cut v0.5.0
  ok: tagged the pushed HEAD
publish-wrapper test: unchanged tree is a no-op
  ok: reported nothing to publish
  ok: burned no patch number
publish-wrapper test: recovers a release whose tag never landed
  ok: re-cut v0.5.0 for the existing HEAD
  ok: the tag points at the published HEAD
```

`just fix`, `just check` pass.

## Base

Targets `main`: a release-script fix, no published API change.

(written by Opus 5)
