### PR TITLE
feat(moq-relay): hand qmux the socket under a WebSocket upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,11 +788,10 @@ checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "blake3"
-version = "1.8.6"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
 dependencies = [
- "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
@@ -1485,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f77b11176c37874be37e8d691c946e31b2b8c357abce9526f6a99eb469e1028"
+checksum = "6f02e8d0327b42d3e2e4ab2119af397344eb9fc54a34bf0ddeaa1277af8681f1"
 dependencies = [
  "alsa",
  "block2 0.6.2",
@@ -2332,9 +2331,9 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enum-assoc"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872ece5a3d5aa63541e400219676c38e8f5474cf3366834c3f2d1fe23d29bc55"
+checksum = "0590c4a94da3372e83493b956755a6e2266830b6e4e3b101afe66e3f39477b91"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2407,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2581,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "foundations"
-version = "5.9.0"
+version = "5.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c5a08bded019d15c789a5e64aff8f0013416130fbfabd757d2232199cb0527"
+checksum = "12a62fa20c0203e73a20912b2dacf0513133351c0486e12e4504be0008584ae7"
 dependencies = [
  "anyhow",
  "cf-rustracing",
@@ -2621,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "foundations-macros"
-version = "5.9.0"
+version = "5.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46317fec5543083ec837c5d1d40f2ec813922f76962e745ce0db173579fe9c3"
+checksum = "9fd77b60b7eeca55a566489846ff8454889fea71859e56249e9010f8d900f10c"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3130,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3180,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "hang"
-version = "0.20.5"
+version = "0.20.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3574,7 +3573,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -4019,7 +4018,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4269,7 +4268,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kio"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "criterion",
  "loom",
@@ -4280,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "kio"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdaadab1a06c04819b8f7cabe4ead8c9f1e86016c4c2a9384829bbc555f477a7"
+checksum = "7fa984c3b737520c30b414041ec63b013614abba31418585d83c5c792fb5bb7d"
 dependencies = [
  "loom",
  "smallvec",
@@ -4357,7 +4356,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmoq"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4392,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "libspa"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2909f3be29d674e7f10604aff18d1bbe1bb03c4cd61c8a8ba19c0b1d162f7d4e"
+checksum = "882f7427e7989dcc9d388b7f05c4630390a1d7696f9ffa469cd4a7a48f0b4c40"
 dependencies = [
  "bitflags 2.13.1",
  "cc",
@@ -4408,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "libspa-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ad52764fca54818486f3cf75afec844d1f1a1568c24dcee25d41b1ab007dda"
+checksum = "3b6e17bdaf63ed0d5e4144022624032b41fd9733112e8c74ac26fc9bf1291924"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -4629,7 +4628,7 @@ dependencies = [
 
 [[package]]
 name = "moq-audio"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "block2 0.6.2",
  "bytes",
@@ -4676,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "moq-boy"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "boytacean",
@@ -4696,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "moq-cli"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -4727,12 +4726,12 @@ dependencies = [
 
 [[package]]
 name = "moq-ffi"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "hang",
- "kio 0.5.4",
+ "kio 0.5.5",
  "moq-audio",
  "moq-json",
  "moq-mux",
@@ -4762,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "moq-gst"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4780,14 +4779,14 @@ dependencies = [
 
 [[package]]
 name = "moq-hls"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "axum",
  "bytes",
  "hang",
  "humantime",
- "kio 0.5.4",
+ "kio 0.5.5",
  "m3u8-rs",
  "moq-mux",
  "moq-net",
@@ -4803,12 +4802,12 @@ dependencies = [
 
 [[package]]
 name = "moq-json"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytes",
  "criterion",
  "json-patch",
- "kio 0.5.4",
+ "kio 0.5.5",
  "moq-flate",
  "moq-net",
  "serde",
@@ -4829,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "moq-msf"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4838,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "moq-mux"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4846,7 +4845,7 @@ dependencies = [
  "futures",
  "h264-parser",
  "hang",
- "kio 0.5.4",
+ "kio 0.5.5",
  "memchr",
  "moq-json",
  "moq-loc",
@@ -4870,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "moq-native"
-version = "0.19.11"
+version = "0.19.12"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4923,13 +4922,13 @@ dependencies = [
 
 [[package]]
 name = "moq-net"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "bytes",
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "kio 0.5.4",
+ "kio 0.5.5",
  "loom",
  "num_enum",
  "rand 0.10.2",
@@ -4954,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.14.11"
+version = "0.14.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -4998,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "moq-rtc"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -5018,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "moq-rtmp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5042,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "moq-srt"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5057,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "moq-stats"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "futures",
  "moq-json",
@@ -5101,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "moq-transcode"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5134,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "moq-video"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -5578,7 +5577,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
@@ -5625,7 +5624,7 @@ checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6731,9 +6730,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipewire"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8585aba8a52ad74ccc633b8e293c1dc4277976bd5d510b925533f34fd6685f38"
+checksum = "bde71084c4e25959d68f1ea54daa75e5ecdb338e5caf0b5510143b79baa32d5c"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -6745,9 +6744,9 @@ dependencies = [
 
 [[package]]
 name = "pipewire-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2089f245b548723e60325773c27f586b7a2372c79ea941b246cd0d654706adc"
+checksum = "9ce653f53e63e5b93853218092ee9a8906a5d082c92f3f1db26316955dd63ce0"
 dependencies = [
  "bindgen 0.72.1",
  "libspa-sys",
@@ -7288,7 +7287,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7297,9 +7296,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -7330,9 +7329,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7547,18 +7546,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7806,7 +7805,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7865,7 +7864,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8129,7 +8128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9052,10 +9051,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10405,7 +10404,7 @@ dependencies = [
  "bytes",
  "http",
  "iroh",
- "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-error",
  "n0-future",
  "tokio",
@@ -10424,7 +10423,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -10461,7 +10460,7 @@ dependencies = [
  "flume",
  "futures",
  "http",
- "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-pki-types",
  "thiserror 2.0.20",
  "tokio",
@@ -10474,14 +10473,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quinn"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b494e7a90c7c576bac11d7506128cea266d63ed9a8b0be39269c7b9ea402a5e"
+checksum = "63a239cba370789ab705c39b66d223e3b8aef85e2762046fd6b59e560f156756"
 dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quinn",
  "rustls",
  "rustls-native-certs",
@@ -10777,7 +10776,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11601,9 +11600,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -11612,9 +11611,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11672,9 +11671,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
@@ -11687,9 +11686,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11700,9 +11699,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,10 +788,11 @@ checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "blake3"
-version = "1.8.7"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
+ "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
@@ -1484,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.18.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f02e8d0327b42d3e2e4ab2119af397344eb9fc54a34bf0ddeaa1277af8681f1"
+checksum = "5f77b11176c37874be37e8d691c946e31b2b8c357abce9526f6a99eb469e1028"
 dependencies = [
  "alsa",
  "block2 0.6.2",
@@ -2331,9 +2332,9 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enum-assoc"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0590c4a94da3372e83493b956755a6e2266830b6e4e3b101afe66e3f39477b91"
+checksum = "872ece5a3d5aa63541e400219676c38e8f5474cf3366834c3f2d1fe23d29bc55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2406,7 +2407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2580,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "foundations"
-version = "5.9.1"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a62fa20c0203e73a20912b2dacf0513133351c0486e12e4504be0008584ae7"
+checksum = "84c5a08bded019d15c789a5e64aff8f0013416130fbfabd757d2232199cb0527"
 dependencies = [
  "anyhow",
  "cf-rustracing",
@@ -2620,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "foundations-macros"
-version = "5.9.1"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd77b60b7eeca55a566489846ff8454889fea71859e56249e9010f8d900f10c"
+checksum = "d46317fec5543083ec837c5d1d40f2ec813922f76962e745ce0db173579fe9c3"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3129,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3179,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "hang"
-version = "0.20.6"
+version = "0.20.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3573,7 +3574,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4018,7 +4019,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4268,7 +4269,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kio"
-version = "0.5.5"
+version = "0.5.4"
 dependencies = [
  "criterion",
  "loom",
@@ -4279,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "kio"
-version = "0.5.5"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa984c3b737520c30b414041ec63b013614abba31418585d83c5c792fb5bb7d"
+checksum = "bdaadab1a06c04819b8f7cabe4ead8c9f1e86016c4c2a9384829bbc555f477a7"
 dependencies = [
  "loom",
  "smallvec",
@@ -4356,7 +4357,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmoq"
-version = "0.5.9"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4391,9 +4392,9 @@ dependencies = [
 
 [[package]]
 name = "libspa"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882f7427e7989dcc9d388b7f05c4630390a1d7696f9ffa469cd4a7a48f0b4c40"
+checksum = "2909f3be29d674e7f10604aff18d1bbe1bb03c4cd61c8a8ba19c0b1d162f7d4e"
 dependencies = [
  "bitflags 2.13.1",
  "cc",
@@ -4407,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "libspa-sys"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6e17bdaf63ed0d5e4144022624032b41fd9733112e8c74ac26fc9bf1291924"
+checksum = "69ad52764fca54818486f3cf75afec844d1f1a1568c24dcee25d41b1ab007dda"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -4628,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "moq-audio"
-version = "0.0.18"
+version = "0.0.17"
 dependencies = [
  "block2 0.6.2",
  "bytes",
@@ -4675,7 +4676,7 @@ dependencies = [
 
 [[package]]
 name = "moq-boy"
-version = "0.4.9"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "boytacean",
@@ -4695,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "moq-cli"
-version = "0.9.12"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -4726,12 +4727,12 @@ dependencies = [
 
 [[package]]
 name = "moq-ffi"
-version = "0.3.12"
+version = "0.3.11"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "hang",
- "kio 0.5.5",
+ "kio 0.5.4",
  "moq-audio",
  "moq-json",
  "moq-mux",
@@ -4761,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "moq-gst"
-version = "0.3.6"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4779,14 +4780,14 @@ dependencies = [
 
 [[package]]
 name = "moq-hls"
-version = "0.4.9"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "axum",
  "bytes",
  "hang",
  "humantime",
- "kio 0.5.5",
+ "kio 0.5.4",
  "m3u8-rs",
  "moq-mux",
  "moq-net",
@@ -4802,12 +4803,12 @@ dependencies = [
 
 [[package]]
 name = "moq-json"
-version = "0.3.4"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "criterion",
  "json-patch",
- "kio 0.5.5",
+ "kio 0.5.4",
  "moq-flate",
  "moq-net",
  "serde",
@@ -4828,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "moq-msf"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4837,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "moq-mux"
-version = "0.9.8"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4845,7 +4846,7 @@ dependencies = [
  "futures",
  "h264-parser",
  "hang",
- "kio 0.5.5",
+ "kio 0.5.4",
  "memchr",
  "moq-json",
  "moq-loc",
@@ -4869,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "moq-native"
-version = "0.19.12"
+version = "0.19.11"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4922,13 +4923,13 @@ dependencies = [
 
 [[package]]
 name = "moq-net"
-version = "0.2.13"
+version = "0.2.12"
 dependencies = [
  "bytes",
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "kio 0.5.5",
+ "kio 0.5.4",
  "loom",
  "num_enum",
  "rand 0.10.2",
@@ -4953,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.14.12"
+version = "0.14.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -4997,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "moq-rtc"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -5017,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "moq-rtmp"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5041,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "moq-srt"
-version = "0.2.4"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5056,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "moq-stats"
-version = "0.1.5"
+version = "0.1.4"
 dependencies = [
  "futures",
  "moq-json",
@@ -5100,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "moq-transcode"
-version = "0.0.12"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5133,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "moq-video"
-version = "0.0.18"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -5577,7 +5578,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
@@ -5624,7 +5625,7 @@ checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6730,9 +6731,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipewire"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde71084c4e25959d68f1ea54daa75e5ecdb338e5caf0b5510143b79baa32d5c"
+checksum = "8585aba8a52ad74ccc633b8e293c1dc4277976bd5d510b925533f34fd6685f38"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -6744,9 +6745,9 @@ dependencies = [
 
 [[package]]
 name = "pipewire-sys"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce653f53e63e5b93853218092ee9a8906a5d082c92f3f1db26316955dd63ce0"
+checksum = "f2089f245b548723e60325773c27f586b7a2372c79ea941b246cd0d654706adc"
 dependencies = [
  "bindgen 0.72.1",
  "libspa-sys",
@@ -7287,7 +7288,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7296,9 +7297,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.17"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -7329,9 +7330,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7546,18 +7547,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.27"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.27"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7805,7 +7806,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7864,7 +7865,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8128,7 +8129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9051,10 +9052,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10404,7 +10405,7 @@ dependencies = [
  "bytes",
  "http",
  "iroh",
- "kio 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-error",
  "n0-future",
  "tokio",
@@ -10423,7 +10424,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -10460,7 +10461,7 @@ dependencies = [
  "flume",
  "futures",
  "http",
- "kio 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-pki-types",
  "thiserror 2.0.20",
  "tokio",
@@ -10473,14 +10474,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quinn"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a239cba370789ab705c39b66d223e3b8aef85e2762046fd6b59e560f156756"
+checksum = "0b494e7a90c7c576bac11d7506128cea266d63ed9a8b0be39269c7b9ea402a5e"
 dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quinn",
  "rustls",
  "rustls-native-certs",
@@ -10776,7 +10777,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11600,9 +11601,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.8"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -11611,9 +11612,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11671,9 +11672,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.15.0"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
 dependencies = [
  "endi",
  "enumflags2",
@@ -11686,9 +11687,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.15.0"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11699,9 +11700,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "4.2.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ moq-vaapi = "0.0.3"
 # that argument, so moq-ffi and libmoq opt them back in by name.
 moq-video = { version = "0.0.18", path = "rs/moq-video", default-features = false }
 percent-encoding = "2"
-qmux = { version = "0.5.0", default-features = false }
+qmux = { version = "0.5.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"
 web-async = { version = "0.1.5", features = ["tracing"] }

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -354,6 +354,18 @@ async fn reload_https_config(config: RustlsConfig, cert: Vec<PathBuf>, key: Vec<
 	}
 }
 
+/// The kernel's view of the TCP connection a request arrived on.
+///
+/// An HTTP upgrade hands the WebSocket a type-erased stream, so qmux can't find the
+/// socket underneath it and would otherwise report no RTT until its own `QX_PING`
+/// completes a round trip. Capturing the descriptor at accept time, before TLS and
+/// hyper take ownership, lets the MoQ session report latency from the first moment.
+///
+/// Absent on platforms with no readable TCP info, and on any socket the read fails
+/// for; handlers extract `Option<Extension<SocketStats>>` accordingly.
+#[derive(Clone)]
+pub struct SocketStats(pub(crate) qmux::SharedSocketStats);
+
 /// Marker inserted as a request extension after HTTPS mTLS verifies a client certificate.
 ///
 /// Embedded routes can extract `Option<Extension<MtlsPeer>>` to mirror the
@@ -370,9 +382,26 @@ struct MtlsAcceptor {
 	inner: RustlsAcceptor<DefaultAcceptor>,
 }
 
+/// The connection [`MtlsAcceptor`] accepts: a byte stream, plus a descriptor to
+/// read socket statistics from on platforms that expose them.
+///
+/// The concrete stream is always the `TcpStream` from [`crate::listener::Peer`], so
+/// the extra bound narrows nothing; it exists because a `cfg` can't be written on a
+/// `where` clause directly.
+#[cfg(unix)]
+pub(crate) trait AcceptStream: AsyncRead + AsyncWrite + Unpin + Send + std::os::fd::AsFd + 'static {}
+#[cfg(unix)]
+impl<T: AsyncRead + AsyncWrite + Unpin + Send + std::os::fd::AsFd + 'static> AcceptStream for T {}
+
+/// As above, where no descriptor is available.
+#[cfg(not(unix))]
+pub(crate) trait AcceptStream: AsyncRead + AsyncWrite + Unpin + Send + 'static {}
+#[cfg(not(unix))]
+impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> AcceptStream for T {}
+
 impl<I, S> Accept<I, S> for MtlsAcceptor
 where
-	I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+	I: AcceptStream,
 	S: Send + 'static,
 {
 	type Stream = TlsStream<I>;
@@ -380,6 +409,9 @@ where
 	type Future = BoxFuture<'static, std::io::Result<(Self::Stream, Self::Service)>>;
 
 	fn accept(&self, stream: I, service: S) -> Self::Future {
+		// Read the socket here, while it is still a plain `TcpStream`. Once TLS and
+		// then hyper's upgrade have wrapped it there is no descriptor left to find.
+		let socket = socket_stats(&stream);
 		let inner = self.inner.accept(stream, service);
 		async move {
 			let (tls, service) = inner.await?;
@@ -389,10 +421,30 @@ where
 				.peer_certificates()
 				.filter(|certs| !certs.is_empty())
 				.map(|_| MtlsPeer);
-			Ok((tls, SetMtlsExtension { inner: service, peer }))
+			Ok((
+				tls,
+				SetMtlsExtension {
+					inner: service,
+					peer,
+					socket,
+				},
+			))
 		}
 		.boxed()
 	}
+}
+
+/// The kernel's view of `stream`, when this platform exposes one.
+#[cfg(unix)]
+fn socket_stats<I: AcceptStream>(stream: &I) -> Option<SocketStats> {
+	qmux::TcpStats::new(stream)
+		.ok()
+		.map(|s| SocketStats(std::sync::Arc::new(s)))
+}
+
+#[cfg(not(unix))]
+fn socket_stats<I: AcceptStream>(_stream: &I) -> Option<SocketStats> {
+	None
 }
 
 /// Per-connection tower service that injects `Extension<Option<MtlsPeer>>` on
@@ -401,6 +453,7 @@ where
 struct SetMtlsExtension<S> {
 	inner: S,
 	peer: Option<MtlsPeer>,
+	socket: Option<SocketStats>,
 }
 
 impl<S, B> Service<http::Request<B>> for SetMtlsExtension<S>
@@ -420,6 +473,9 @@ where
 		// `Option<Extension<MtlsPeer>>` so absence is the no-cert case.
 		if let Some(peer) = self.peer.clone() {
 			req.extensions_mut().insert(peer);
+		}
+		if let Some(socket) = self.socket.clone() {
+			req.extensions_mut().insert(socket);
 		}
 		self.inner.call(req)
 	}
@@ -860,13 +916,17 @@ mod tests {
 			}
 		}
 
+		// This test is about the mTLS marker; the socket handle rides the same
+		// per-connection service but is independent of it.
 		let mut with_peer = SetMtlsExtension {
 			inner: EchoExt,
 			peer: Some(MtlsPeer),
+			socket: None,
 		};
 		let mut no_peer = SetMtlsExtension {
 			inner: EchoExt,
 			peer: None,
+			socket: None,
 		};
 
 		let req = Request::builder().body(()).unwrap();

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -245,7 +245,8 @@ impl Web {
 			let listener = moq_native::bind::tcp(listen).context("failed to bind HTTP listener")?;
 			// Same socket capture the HTTPS path gets from `MtlsAcceptor`: without it
 			// a `ws://` session reaches qmux with no descriptor and reports no RTT.
-			let server = crate::listener::server(listener, self.health.clone())?.acceptor(SocketAcceptor);
+			let server =
+				crate::listener::server(listener, self.health.clone())?.acceptor(SocketAcceptor { ws: config.ws });
 			Some(server.serve(app.clone()))
 		} else {
 			None
@@ -267,6 +268,7 @@ impl Web {
 			// a near-no-op, but keeping a single path simplifies reload + serve.
 			let acceptor = MtlsAcceptor {
 				inner: RustlsAcceptor::new(rustls_config),
+				ws: config.ws,
 			};
 			let listener = moq_native::bind::tcp(listen).context("failed to bind HTTPS listener")?;
 			let server = crate::listener::server(listener, self.health.clone())?.acceptor(acceptor);
@@ -367,14 +369,14 @@ async fn reload_https_config(config: RustlsConfig, cert: Vec<PathBuf>, key: Vec<
 /// for; handlers extract `Option<Extension<SocketStats>>` accordingly.
 #[cfg(feature = "websocket")]
 #[derive(Clone)]
-pub struct SocketStats(pub(crate) qmux::SharedSocketStats);
+pub(crate) struct SocketStats(pub(crate) qmux::SharedSocketStats);
 
 /// Without the `websocket` feature there is no qmux to hand a socket to, so this
 /// carries nothing and is never constructed. Keeping the type present either way
 /// lets the acceptor and its service stay free of feature gates.
 #[cfg(not(feature = "websocket"))]
 #[derive(Clone)]
-pub struct SocketStats(std::convert::Infallible);
+pub(crate) struct SocketStats(std::convert::Infallible);
 
 /// Marker inserted as a request extension after HTTPS mTLS verifies a client certificate.
 ///
@@ -390,6 +392,8 @@ pub struct MtlsPeer;
 #[derive(Clone)]
 struct MtlsAcceptor {
 	inner: RustlsAcceptor<DefaultAcceptor>,
+	/// As [`SocketAcceptor::ws`].
+	ws: bool,
 }
 
 /// The connection [`MtlsAcceptor`] accepts: a byte stream, plus a descriptor to
@@ -416,7 +420,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> AcceptStream for T {}
 /// qmux with no descriptor and report no RTT. This is the same capture without the
 /// TLS half.
 #[derive(Clone, Copy)]
-struct SocketAcceptor;
+struct SocketAcceptor {
+	/// Whether a WebSocket route exists to use the handle. The capture holds a
+	/// duplicated descriptor for the life of the connection, so doing it when
+	/// nothing can read it would cost every API, HLS, and health-check connection a
+	/// second descriptor for nothing.
+	ws: bool,
+}
 
 impl<I, S> Accept<I, S> for SocketAcceptor
 where
@@ -428,7 +438,7 @@ where
 	type Future = BoxFuture<'static, std::io::Result<(Self::Stream, Self::Service)>>;
 
 	fn accept(&self, stream: I, service: S) -> Self::Future {
-		let socket = socket_stats(&stream);
+		let socket = self.ws.then(|| socket_stats(&stream)).flatten();
 		async move {
 			Ok((
 				stream,
@@ -455,7 +465,7 @@ where
 	fn accept(&self, stream: I, service: S) -> Self::Future {
 		// Read the socket here, while it is still a plain `TcpStream`. Once TLS and
 		// then hyper's upgrade have wrapped it there is no descriptor left to find.
-		let socket = socket_stats(&stream);
+		let socket = self.ws.then(|| socket_stats(&stream)).flatten();
 		let inner = self.inner.accept(stream, service);
 		async move {
 			let (tls, service) = inner.await?;
@@ -976,7 +986,7 @@ mod tests {
 		let (accepted, _) = listener.accept().await.unwrap();
 		let _client = connecting.await.unwrap();
 
-		let (stream, mut service) = Accept::<_, EchoSocket>::accept(&SocketAcceptor, accepted, EchoSocket)
+		let (stream, mut service) = Accept::<_, EchoSocket>::accept(&SocketAcceptor { ws: true }, accepted, EchoSocket)
 			.await
 			.unwrap();
 
@@ -1003,6 +1013,32 @@ mod tests {
 				"a connected TCP socket must report an RTT immediately"
 			);
 		}
+
+		drop(stream);
+	}
+
+	/// With no WebSocket route to read them, the capture is skipped.
+	///
+	/// The handle holds a duplicated descriptor for the life of the connection, so
+	/// capturing it for every API, HLS, and health-check connection would halve the
+	/// descriptors a relay can spend on connections, for nothing.
+	#[cfg(all(unix, feature = "websocket"))]
+	#[tokio::test]
+	async fn socket_acceptor_skips_capture_without_websockets() {
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = listener.local_addr().unwrap();
+		let connecting = tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+		let (accepted, _) = listener.accept().await.unwrap();
+		let _client = connecting.await.unwrap();
+
+		let (stream, service) = Accept::<_, ()>::accept(&SocketAcceptor { ws: false }, accepted, ())
+			.await
+			.unwrap();
+
+		assert!(
+			service.socket.is_none(),
+			"no WebSocket route can use the handle, so it must not hold a descriptor"
+		);
 
 		drop(stream);
 	}

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -992,12 +992,17 @@ mod tests {
 		);
 
 		// The kernel measured this during the handshake, so it is readable already --
-		// which is what lets the Probe capability be decided at SETUP.
-		let stats = service.socket.as_ref().unwrap();
-		assert!(
-			qmux::SocketStats::rtt(&*stats.0).is_some(),
-			"a connected TCP socket must report an RTT immediately"
-		);
+		// which is what lets the Probe capability be decided at SETUP. Only where
+		// qmux actually reads a TCP info struct: elsewhere on unix it supplies an
+		// empty implementation and every metric is `None`, which is not a failure.
+		#[cfg(any(target_os = "linux", target_os = "macos"))]
+		{
+			let stats = service.socket.as_ref().unwrap();
+			assert!(
+				qmux::SocketStats::rtt(&*stats.0).is_some(),
+				"a connected TCP socket must report an RTT immediately"
+			);
+		}
 
 		drop(stream);
 	}

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -243,7 +243,9 @@ impl Web {
 			// Dual-stack so the cert endpoint + WebSocket fallback answer over IPv4
 			// too, even on Windows where `[::]` is IPv6-only by default.
 			let listener = moq_native::bind::tcp(listen).context("failed to bind HTTP listener")?;
-			let server = crate::listener::server(listener, self.health.clone())?;
+			// Same socket capture the HTTPS path gets from `MtlsAcceptor`: without it
+			// a `ws://` session reaches qmux with no descriptor and reports no RTT.
+			let server = crate::listener::server(listener, self.health.clone())?.acceptor(SocketAcceptor);
 			Some(server.serve(app.clone()))
 		} else {
 			None
@@ -363,8 +365,16 @@ async fn reload_https_config(config: RustlsConfig, cert: Vec<PathBuf>, key: Vec<
 ///
 /// Absent on platforms with no readable TCP info, and on any socket the read fails
 /// for; handlers extract `Option<Extension<SocketStats>>` accordingly.
+#[cfg(feature = "websocket")]
 #[derive(Clone)]
 pub struct SocketStats(pub(crate) qmux::SharedSocketStats);
+
+/// Without the `websocket` feature there is no qmux to hand a socket to, so this
+/// carries nothing and is never constructed. Keeping the type present either way
+/// lets the acceptor and its service stay free of feature gates.
+#[cfg(not(feature = "websocket"))]
+#[derive(Clone)]
+pub struct SocketStats(std::convert::Infallible);
 
 /// Marker inserted as a request extension after HTTPS mTLS verifies a client certificate.
 ///
@@ -399,13 +409,47 @@ pub(crate) trait AcceptStream: AsyncRead + AsyncWrite + Unpin + Send + 'static {
 #[cfg(not(unix))]
 impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> AcceptStream for T {}
 
+/// Captures the socket for a plain-HTTP connection.
+///
+/// [`MtlsAcceptor`] does this for HTTPS on its way through the TLS handshake, but
+/// the HTTP listener has no acceptor of its own, so a `ws://` session would reach
+/// qmux with no descriptor and report no RTT. This is the same capture without the
+/// TLS half.
+#[derive(Clone, Copy)]
+struct SocketAcceptor;
+
+impl<I, S> Accept<I, S> for SocketAcceptor
+where
+	I: AcceptStream,
+	S: Send + 'static,
+{
+	type Stream = I;
+	type Service = SetConnectionExtensions<S>;
+	type Future = BoxFuture<'static, std::io::Result<(Self::Stream, Self::Service)>>;
+
+	fn accept(&self, stream: I, service: S) -> Self::Future {
+		let socket = socket_stats(&stream);
+		async move {
+			Ok((
+				stream,
+				SetConnectionExtensions {
+					inner: service,
+					peer: None,
+					socket,
+				},
+			))
+		}
+		.boxed()
+	}
+}
+
 impl<I, S> Accept<I, S> for MtlsAcceptor
 where
 	I: AcceptStream,
 	S: Send + 'static,
 {
 	type Stream = TlsStream<I>;
-	type Service = SetMtlsExtension<S>;
+	type Service = SetConnectionExtensions<S>;
 	type Future = BoxFuture<'static, std::io::Result<(Self::Stream, Self::Service)>>;
 
 	fn accept(&self, stream: I, service: S) -> Self::Future {
@@ -423,7 +467,7 @@ where
 				.map(|_| MtlsPeer);
 			Ok((
 				tls,
-				SetMtlsExtension {
+				SetConnectionExtensions {
 					inner: service,
 					peer,
 					socket,
@@ -434,29 +478,32 @@ where
 	}
 }
 
-/// The kernel's view of `stream`, when this platform exposes one.
-#[cfg(unix)]
+/// The kernel's view of `stream`, when this platform exposes one and there is a
+/// qmux session that could use it.
+#[cfg(all(unix, feature = "websocket"))]
 fn socket_stats<I: AcceptStream>(stream: &I) -> Option<SocketStats> {
 	qmux::TcpStats::new(stream)
 		.ok()
 		.map(|s| SocketStats(std::sync::Arc::new(s)))
 }
 
-#[cfg(not(unix))]
+#[cfg(not(all(unix, feature = "websocket")))]
 fn socket_stats<I: AcceptStream>(_stream: &I) -> Option<SocketStats> {
 	None
 }
 
-/// Per-connection tower service that injects `Extension<Option<MtlsPeer>>` on
-/// every request before forwarding to the inner service.
+/// Per-connection tower service that injects the connection's extensions -- the
+/// mTLS marker and the captured socket -- on every request before forwarding to the
+/// inner service. Both are per-connection facts, so they are attached once at accept
+/// and replayed onto each request that arrives on it.
 #[derive(Clone)]
-struct SetMtlsExtension<S> {
+struct SetConnectionExtensions<S> {
 	inner: S,
 	peer: Option<MtlsPeer>,
 	socket: Option<SocketStats>,
 }
 
-impl<S, B> Service<http::Request<B>> for SetMtlsExtension<S>
+impl<S, B> Service<http::Request<B>> for SetConnectionExtensions<S>
 where
 	S: Service<http::Request<B>>,
 {
@@ -893,7 +940,7 @@ mod tests {
 		);
 	}
 
-	/// Confirm `SetMtlsExtension` injects the marker into request extensions
+	/// Confirm `SetConnectionExtensions` injects the marker into request extensions
 	/// when a peer cert was presented, and leaves them untouched otherwise.
 	#[tokio::test]
 	async fn set_mtls_extension_injects_marker() {
@@ -918,12 +965,12 @@ mod tests {
 
 		// This test is about the mTLS marker; the socket handle rides the same
 		// per-connection service but is independent of it.
-		let mut with_peer = SetMtlsExtension {
+		let mut with_peer = SetConnectionExtensions {
 			inner: EchoExt,
 			peer: Some(MtlsPeer),
 			socket: None,
 		};
-		let mut no_peer = SetMtlsExtension {
+		let mut no_peer = SetConnectionExtensions {
 			inner: EchoExt,
 			peer: None,
 			socket: None,
@@ -932,13 +979,13 @@ mod tests {
 		let req = Request::builder().body(()).unwrap();
 		assert!(
 			with_peer.call(req).await.unwrap(),
-			"SetMtlsExtension(Some) must surface MtlsPeer"
+			"SetConnectionExtensions(Some) must surface MtlsPeer"
 		);
 
 		let req = Request::builder().body(()).unwrap();
 		assert!(
 			!no_peer.call(req).await.unwrap(),
-			"SetMtlsExtension(None) must NOT surface MtlsPeer"
+			"SetConnectionExtensions(None) must NOT surface MtlsPeer"
 		);
 	}
 }

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -940,6 +940,68 @@ mod tests {
 		);
 	}
 
+	/// A real accepted socket must reach the request as an extension.
+	///
+	/// This is the whole point of the plain-HTTP path: `MtlsAcceptor` captures the
+	/// descriptor on its way through the TLS handshake, and `SocketAcceptor` has to
+	/// do the same for `ws://`. Without a capture the handle is `None`, qmux gets no
+	/// socket, and the session advertises no Probe capability -- silently, which is
+	/// why this drives an actual `TcpStream` rather than constructing the service by
+	/// hand.
+	#[cfg(all(unix, feature = "websocket"))]
+	#[tokio::test]
+	async fn socket_acceptor_surfaces_the_accepted_socket() {
+		use axum::http::Request;
+		use std::convert::Infallible;
+
+		/// Reports whether the socket extension arrived on the request.
+		#[derive(Clone)]
+		struct EchoSocket;
+		impl Service<Request<()>> for EchoSocket {
+			type Response = bool;
+			type Error = Infallible;
+			type Future = std::pin::Pin<Box<dyn Future<Output = Result<bool, Infallible>> + Send>>;
+			fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+				Poll::Ready(Ok(()))
+			}
+			fn call(&mut self, req: Request<()>) -> Self::Future {
+				let has = req.extensions().get::<SocketStats>().is_some();
+				Box::pin(async move { Ok(has) })
+			}
+		}
+
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = listener.local_addr().unwrap();
+		let connecting = tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+		let (accepted, _) = listener.accept().await.unwrap();
+		let _client = connecting.await.unwrap();
+
+		let (stream, mut service) = Accept::<_, EchoSocket>::accept(&SocketAcceptor, accepted, EchoSocket)
+			.await
+			.unwrap();
+
+		assert!(
+			service.socket.is_some(),
+			"the acceptor must capture the descriptor of the socket it accepted"
+		);
+
+		let req = Request::builder().body(()).unwrap();
+		assert!(
+			service.call(req).await.unwrap(),
+			"the captured socket must reach the request, or qmux never sees it"
+		);
+
+		// The kernel measured this during the handshake, so it is readable already --
+		// which is what lets the Probe capability be decided at SETUP.
+		let stats = service.socket.as_ref().unwrap();
+		assert!(
+			qmux::SocketStats::rtt(&*stats.0).is_some(),
+			"a connected TCP socket must report an RTT immediately"
+		);
+
+		drop(stream);
+	}
+
 	/// Confirm `SetConnectionExtensions` injects the marker into request extensions
 	/// when a peer cert was presented, and leaves them untouched otherwise.
 	#[tokio::test]

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -21,6 +21,7 @@ pub(crate) async fn serve_ws(
 	OriginalUri(uri): OriginalUri,
 	headers: HeaderMap,
 	mtls: Option<Extension<MtlsPeer>>,
+	socket_stats: Option<Extension<crate::web::SocketStats>>,
 	Extension(versions): Extension<moq_net::Versions>,
 	State(state): State<Arc<WebState>>,
 ) -> axum::response::Result<Response> {
@@ -72,6 +73,7 @@ pub(crate) async fn serve_ws(
 			publish,
 			subscribe,
 			stats,
+			socket_stats: socket_stats.map(|Extension(s)| s),
 		};
 		let _ = handle_socket(socket, session).await;
 	}))
@@ -91,6 +93,8 @@ struct SessionInputs {
 	publish: Option<origin::Producer>,
 	subscribe: Option<origin::Producer>,
 	stats: Session,
+	/// The kernel's view of the socket under the upgrade, captured at accept time.
+	socket_stats: Option<crate::web::SocketStats>,
 }
 
 #[tracing::instrument("ws", err, skip_all, fields(id = session.id))]
@@ -109,6 +113,7 @@ where
 		publish,
 		subscribe,
 		stats,
+		socket_stats,
 	} = session;
 
 	// Wrap the WebSocket in a WebTransport compatibility layer. We have to
@@ -121,7 +126,14 @@ where
 	// broadcast it published stays announced for that entire window and the
 	// announce propagates to the rest of the cluster. QUIC gets this from its
 	// idle timeout; WebSocket has no equivalent of its own.
-	let upgraded = qmux::ws::Upgraded::new(socket).with_keep_alive(qmux::ws::KeepAlive::default());
+	let mut upgraded = qmux::ws::Upgraded::new(socket).with_keep_alive(qmux::ws::KeepAlive::default());
+	// Hand qmux the socket we captured before the upgrade erased it, so the session
+	// reports the kernel's RTT (and, on Linux, its delivery rate) from the start
+	// rather than only what QX_PING can measure a round trip later. This is what
+	// fills in the moq-lite PROBE for a WebSocket viewer.
+	if let Some(crate::web::SocketStats(stats)) = socket_stats {
+		upgraded = upgraded.with_socket_stats(stats);
+	}
 	let upgraded = match alpn.as_deref() {
 		Some(alpn) => upgraded.with_alpn(alpn),
 		None => upgraded,
@@ -807,6 +819,9 @@ mod tests {
 			publish: None,
 			subscribe: None,
 			stats: Session::default(),
+			// No descriptor to hand over: this drives the transport directly rather
+			// than through an accepted socket.
+			socket_stats: None,
 		};
 		let server = tokio::spawn(handle_socket(
 			Pipe::new(server_incoming, server_to_client, frozen.clone()),


### PR DESCRIPTION
Completes the chain started in #2945 and moq-dev/web-transport#380. This is the piece that actually recovers the latency.

## The problem

A WebSocket MoQ session reported no RTT, so `moq-lite` PROBE had nothing to send and Firefox and Safari viewers stayed pinned to `@moq/watch`'s fixed 100ms jitter buffer instead of its 20ms adaptive floor. `@moq/net` declines WebTransport for both engines by user-agent check, so qmux is their ordinary path rather than a fallback.

qmux 0.5.1 can now measure a round trip itself with `QX_PING`, but only once one has completed. The Probe level goes out in SETUP at `accept()` — before any ping could have been answered — and `ProbeLevel::detect` samples what the transport reports at that moment. On a WebSocket session with nothing to sample, it correctly advertises `None`, and the subscriber's gate then skips the probe stream for the rest of the session.

TCP already knows the answer. The kernel measures a smoothed RTT during the three-way handshake, before any of our code runs, so it is readable the instant we accept. The obstacle is purely one of plumbing: an HTTP upgrade hands the WebSocket a type-erased stream (axum's `WebSocket` over hyper's `Upgraded`, optionally over TLS), leaving no descriptor for qmux to find.

## The seam

`Accept::accept` sees the raw `TcpStream` before TLS wraps it. The socket handle is captured there and injected as a per-connection request extension, exactly as `MtlsPeer` already is, then handed to `ws::Upgraded` via `with_socket_stats`.

The stream bound moves to an `AcceptStream` trait alias so the descriptor requirement can be `cfg`'d — attributes are not allowed on a `where` clause. The concrete stream is always the `TcpStream` from `listener::Peer`, so this narrows nothing in practice. Platforms without a readable descriptor keep the `QX_PING` fallback, and a socket we cannot read simply reports nothing.

## Dependency

qmux 0.5.1 is additive over 0.5.0 (a defaulted trait method, a new field on an already-`#[non_exhaustive]` `Config`, and new types), so the workspace requirement is unchanged and only the lockfile moves.

## Testing

`just check` and `just test` clean. The relay's own suites cover the per-connection extension path; the socket-stats reads themselves are covered upstream in qmux, including offset guards on the mirrored `tcp_info` structs.

Worth stating plainly: I have verified this compiles and passes against the published qmux 0.5.1 and that the wiring is correct by inspection, but I have not observed the end-to-end latency improvement in a browser. The measurement in the original report was Chrome-to-Firefox at ~80ms; confirming that gap closes needs a real deployment.

(written by Opus 5)
