### PR TITLE
fix(moq-mux): emit the TS PCR as a uniform grid, not the per-unit decode clock

### DIFF
--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -85,8 +85,8 @@ pub struct Export<E: catalog::Catalog = ()> {
 	psi: Option<Psi>,
 	/// Media timestamp of the last PAT/PMT emission ([`due`]).
 	last_psi: Option<Timestamp>,
-	/// Media timestamp of the last PCR grid emission ([`Self::write_pcr`]).
-	last_pcr: Option<Timestamp>,
+	/// Grid slot of the last PCR emission ([`Self::write_pcr`]).
+	last_pcr: Option<u128>,
 	/// Tune-in point: the first video keyframe's timestamp, captured when the program
 	/// tables are built. Non-video frames before it are dropped so the keyframe leads
 	/// the stream.
@@ -332,8 +332,15 @@ impl<E: catalog::Catalog> Export<E> {
 		}
 
 		// 4. Emit the smallest-timestamp pending frame as a PES packet (the first
-		// one carries the buffered PAT/PMT).
+		// one carries the buffered PAT/PMT). The program clock leads it: each grid
+		// slot the frame's timestamp has crossed goes out first as its own frame,
+		// stamped at the slot boundary, so the caller's pacer places the PCR at the
+		// time it asserts instead of bunching it with the frame that revealed it.
 		if let Some(name) = self.pick_next_track() {
+			let timestamp = self.tracks[&name].pending.as_ref().unwrap().timestamp;
+			if let Some(out) = self.write_pcr(timestamp)? {
+				return Poll::Ready(Ok(Some(out)));
+			}
 			let frame = self.tracks.get_mut(&name).unwrap().pending.take().unwrap();
 			let out = self.write_frame(&name, frame)?;
 			return Poll::Ready(Ok(Some(out)));
@@ -791,10 +798,6 @@ impl<E: catalog::Catalog> Export<E> {
 			self.last_si.insert(pid, frame.timestamp);
 		}
 
-		// The program clock, on its own packets rather than the PES units (see
-		// `write_pcr` for why the units can't carry it).
-		self.write_pcr(&mut out, frame.timestamp)?;
-
 		match es_payload {
 			// Section-framed verbatim (SCTE-35, ...) rides in private sections, not PES;
 			// carry the bytes verbatim.
@@ -829,7 +832,9 @@ impl<E: catalog::Catalog> Export<E> {
 	}
 
 	/// Emit the program clock: one adaptation-field-only packet on the PCR PID per
-	/// [`PCR_INTERVAL`] slot the media timeline has crossed since the last emission.
+	/// [`PCR_INTERVAL`] slot of the media timeline, each returned as its own
+	/// [`Frame`] stamped at its slot boundary so the caller's pacer delivers the
+	/// packet at the time it asserts.
 	///
 	/// The PES units cannot carry the clock. Frames arrive in decode order, so the
 	/// authored DTS is a saw: a reference frame leaps a whole reorder span ahead and
@@ -839,69 +844,90 @@ impl<E: catalog::Catalog> Export<E> {
 	/// because a groomer can only place the clock samples it receives. So the PCR
 	/// asserts its own uniform ramp instead: absolute grid slots on the media
 	/// timeline (shared by every exporter of the broadcast, like [`due`]), each
-	/// backed off by the PCR track's decode-clock reserve so every PES unit still
-	/// decodes at or after the clock that precedes it.
-	fn write_pcr(&mut self, out: &mut Vec<u8>, timestamp: Timestamp) -> anyhow::Result<()> {
+	/// backed off by the largest decode-clock reserve of any track so every PES
+	/// unit, whichever rendition it belongs to, decodes at or after the clock that
+	/// precedes it.
+	///
+	/// `timestamp` is the next media frame's; `None` when its slot has already been
+	/// served (the caller then emits the media frame itself). One slot per call:
+	/// missed slots drain over successive polls, each at its own boundary, capped at
+	/// [`PCR_BACKFILL`]. The clock always leads, including ahead of the very first
+	/// frame's PAT/PMT: a receiver joins a TS mid-stream at an arbitrary packet, so
+	/// there is no "first" on the wire, and holding the clock back would leave the
+	/// leading PES without one.
+	fn write_pcr(&mut self, timestamp: Timestamp) -> anyhow::Result<Option<Frame>> {
 		let pcr_pid = self.psi.as_ref().context("PSI not built")?.pcr_pid;
 		let current = slot(timestamp, PCR_INTERVAL);
-		let start = match self.last_pcr {
+		let index = match self.last_pcr {
 			None => current,
 			Some(last) => {
-				let last = slot(last, PCR_INTERVAL);
 				// A reordered (B-frame) timestamp steps backwards into a slot already
 				// served; the clock only ever moves forward.
 				if current <= last {
-					return Ok(());
+					return Ok(None);
 				}
+				// Backfill every missed slot so the ramp stays uniform when frames are
+				// coarser than the grid, but cap it: past the cap the media itself
+				// gapped, and a dense clock history for a span that carried no bytes
+				// helps nobody.
 				(last + 1).max(current.saturating_sub(PCR_BACKFILL - 1))
 			}
 		};
+		// The largest reserve of any track, not just the PCR track's: every
+		// rendition's PES must decode at or after the clock, and each video track
+		// backs its DTS off by its own catalog jitter.
 		let reserve = self
 			.tracks
 			.values()
-			.find(|t| t.pid == pcr_pid)
 			.map(|t| t.dts_reserve)
+			.max()
 			.unwrap_or(DEFAULT_DTS_RESERVE);
-		for index in start..=current {
-			let ticks = slot_ticks(index, PCR_INTERVAL).saturating_sub(reserve);
-			self.write_pcr_packet(out, pcr_pid, ticks)?;
-		}
-		self.last_pcr = Some(timestamp);
-		Ok(())
+		// Back off through the 33-bit wrap rather than saturating: a timeline that
+		// starts inside the reserve would otherwise clamp its first slots to zero
+		// and break the uniform step. The wire field is a circular clock, so the
+		// masked wrapped value is the correct mod-2^33 back-off.
+		let ticks = slot_ticks(index, PCR_INTERVAL).wrapping_sub(reserve);
+		let payload = self.pcr_packet(pcr_pid, ticks)?;
+		self.last_pcr = Some(index);
+		Ok(Some(Frame {
+			timestamp: Timestamp::from_micros((index * PCR_INTERVAL.as_micros()) as u64)?,
+			duration: None,
+			payload: Bytes::from(payload),
+			keyframe: false,
+		}))
 	}
 
 	/// One adaptation-field-only TS packet carrying `ticks` (continuous 90 kHz) as
-	/// its PCR; stuffing fills the rest. A packet without a payload does not
-	/// increment the continuity counter (ISO 13818-1 2.4.3.3): it repeats the
-	/// previous packet's value, which is one behind the stored next-to-use value.
-	fn write_pcr_packet(&mut self, out: &mut Vec<u8>, pid: u16, ticks: u64) -> anyhow::Result<()> {
-		let next = self.counters.entry(pid).or_default().as_u8();
-		let continuity_counter =
-			ContinuityCounter::from_u8(next.wrapping_sub(1) & ContinuityCounter::MAX).map_err(anyhow::Error::msg)?;
-		let pcr = TsTimestamp::new(ticks & TS_TIMESTAMP_MASK).map_err(anyhow::Error::msg)?;
-		let packet = TsPacket {
-			header: TsHeader {
-				transport_error_indicator: false,
-				transport_priority: false,
-				pid: Pid::new(pid)?,
-				transport_scrambling_control: TransportScramblingControl::NotScrambled,
-				continuity_counter,
-			},
-			adaptation_field: Some(AdaptationField {
-				discontinuity_indicator: false,
-				random_access_indicator: false,
-				es_priority_indicator: false,
-				pcr: Some(pcr.into()),
-				opcr: None,
-				splice_countdown: None,
-				transport_private_data: Vec::new(),
-				extension: None,
-			}),
-			payload: None,
-		};
-		let mut writer = TsPacketWriter::new(out);
-		writer.write_ts_packet(&packet).map_err(anyhow::Error::msg)?;
-		Ok(())
+	/// its PCR, laid out by hand: the `mpeg2ts` serializer writes the six reserved
+	/// bits between PCR base and extension as zeros where ISO 13818-1 requires
+	/// ones, and strict analyzers flag that. There is no payload, so the field's
+	/// stuffing fills the packet and the continuity counter is not incremented
+	/// (ISO 13818-1 2.4.3.3): it repeats the previous packet's value, one behind
+	/// the stored next-to-use value.
+	fn pcr_packet(&mut self, pid: u16, ticks: u64) -> anyhow::Result<Vec<u8>> {
+		anyhow::ensure!(pid <= 0x1FFF, "PID out of range: {pid}");
+		let cc = self.counters.entry(pid).or_default().as_u8().wrapping_sub(1) & ContinuityCounter::MAX;
+		let base = ticks & TS_TIMESTAMP_MASK;
+		let mut p = Vec::with_capacity(TsPacket::SIZE);
+		p.push(0x47);
+		p.push((pid >> 8) as u8);
+		p.push(pid as u8);
+		// adaptation_field_control = adaptation field only, no scrambling.
+		p.push(0x20 | cc);
+		// adaptation_field_length covers the rest of the packet.
+		p.push(183);
+		// PCR_flag alone.
+		p.push(0x10);
+		// program_clock_reference_base (33 bits), 6 reserved '1' bits, and a zero
+		// 9-bit extension (the grid is 90 kHz-exact, so there is nothing sub-tick).
+		p.push((base >> 25) as u8);
+		p.push((base >> 17) as u8);
+		p.push((base >> 9) as u8);
+		p.push((base >> 1) as u8);
+		p.push(((base as u8) << 7) | 0x7e);
+		p.push(0x00);
+		p.resize(TsPacket::SIZE, 0xff);
+		Ok(p)
 	}
 
 	/// Packetize a PES payload into 188-byte TS packets.

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -3,8 +3,9 @@
 //! [`Export`] subscribes to a MoQ broadcast and produces MPEG-TS, yielding one
 //! [`Frame`] per media frame: PAT/PMT program tables followed by one PES packet,
 //! packetized into 188-byte TS packets. Each frame keeps its media timestamp so
-//! the caller can pace delivery on the media clock. Video is carried as Annex-B,
-//! audio as ADTS AAC.
+//! the caller can pace delivery on the media clock. The PCR rides its own
+//! adaptation-field-only packets on a fixed media-time grid ([`Export::write_pcr`]).
+//! Video is carried as Annex-B, audio as ADTS AAC.
 //!
 //! Video flows through [`ExportSource`], which normalizes every H.264/H.265
 //! source to length-prefixed NALU plus a resolved avcC/hvcC (parsing in-band
@@ -45,6 +46,14 @@ const PMT_PID: u16 = 0x1000;
 const FIRST_ES_PID: u16 = 0x1001;
 /// Re-emit PAT/PMT at least this often (wall-clock of the media) for tune-in.
 const PSI_INTERVAL: Duration = Duration::from_millis(500);
+/// Emit a PCR on every crossing of this media-time grid ([`Export::write_pcr`]).
+/// TR 101 290 flags a gap over 40 ms; broadcast muxes emit every 25-40 ms.
+const PCR_INTERVAL: Duration = Duration::from_millis(25);
+/// How many missed PCR slots to backfill at most. Frames coarser than the grid
+/// cross a few slots at a time and every one is filled so the ramp stays uniform;
+/// past this cap the media itself gapped, and a dense clock history for a span
+/// that carried no bytes helps nobody.
+const PCR_BACKFILL: u128 = 8;
 
 /// Subscribe to a broadcast and produce an MPEG-TS byte stream.
 ///
@@ -76,6 +85,8 @@ pub struct Export<E: catalog::Catalog = ()> {
 	psi: Option<Psi>,
 	/// Media timestamp of the last PAT/PMT emission ([`due`]).
 	last_psi: Option<Timestamp>,
+	/// Media timestamp of the last PCR grid emission ([`Self::write_pcr`]).
+	last_pcr: Option<Timestamp>,
 	/// Tune-in point: the first video keyframe's timestamp, captured when the program
 	/// tables are built. Non-video frames before it are dropped so the keyframe leads
 	/// the stream.
@@ -152,7 +163,6 @@ struct Psi {
 /// Per-frame PES descriptor (everything but the payload bytes).
 struct PesUnit {
 	pid: u16,
-	is_pcr: bool,
 	is_video: bool,
 	keyframe: bool,
 	timestamp: Timestamp,
@@ -208,6 +218,7 @@ impl<E: catalog::Catalog> Export<E> {
 			last_si: HashMap::new(),
 			psi: None,
 			last_psi: None,
+			last_pcr: None,
 			video_start: None,
 		})
 	}
@@ -701,7 +712,6 @@ impl<E: catalog::Catalog> Export<E> {
 		let track = self.tracks.get(name).context("missing track")?;
 		let pid = track.pid;
 		let kind = track.kind.clone();
-		let is_pcr = self.psi.as_ref().is_some_and(|p| p.pcr_pid == pid);
 		let is_video = matches!(kind, Kind::Video(_));
 		let timestamp = frame.timestamp;
 		let keyframe = frame.keyframe;
@@ -781,6 +791,10 @@ impl<E: catalog::Catalog> Export<E> {
 			self.last_si.insert(pid, frame.timestamp);
 		}
 
+		// The program clock, on its own packets rather than the PES units (see
+		// `write_pcr` for why the units can't carry it).
+		self.write_pcr(&mut out, frame.timestamp)?;
+
 		match es_payload {
 			// Section-framed verbatim (SCTE-35, ...) rides in private sections, not PES;
 			// carry the bytes verbatim.
@@ -797,7 +811,6 @@ impl<E: catalog::Catalog> Export<E> {
 				};
 				let unit = PesUnit {
 					pid,
-					is_pcr,
 					is_video,
 					keyframe: frame.keyframe,
 					timestamp: frame.timestamp,
@@ -813,6 +826,82 @@ impl<E: catalog::Catalog> Export<E> {
 			payload: Bytes::from(out),
 			keyframe,
 		})
+	}
+
+	/// Emit the program clock: one adaptation-field-only packet on the PCR PID per
+	/// [`PCR_INTERVAL`] slot the media timeline has crossed since the last emission.
+	///
+	/// The PES units cannot carry the clock. Frames arrive in decode order, so the
+	/// authored DTS is a saw: a reference frame leaps a whole reorder span ahead and
+	/// each B-frame nudges one tick past it. A PCR sampled from it freezes and jumps
+	/// (measured as 85% of intervals within 11 us of each other, the rest collected
+	/// into gaps of hundreds of ms), and no downstream CBR stage can repair that,
+	/// because a groomer can only place the clock samples it receives. So the PCR
+	/// asserts its own uniform ramp instead: absolute grid slots on the media
+	/// timeline (shared by every exporter of the broadcast, like [`due`]), each
+	/// backed off by the PCR track's decode-clock reserve so every PES unit still
+	/// decodes at or after the clock that precedes it.
+	fn write_pcr(&mut self, out: &mut Vec<u8>, timestamp: Timestamp) -> anyhow::Result<()> {
+		let pcr_pid = self.psi.as_ref().context("PSI not built")?.pcr_pid;
+		let current = slot(timestamp, PCR_INTERVAL);
+		let start = match self.last_pcr {
+			None => current,
+			Some(last) => {
+				let last = slot(last, PCR_INTERVAL);
+				// A reordered (B-frame) timestamp steps backwards into a slot already
+				// served; the clock only ever moves forward.
+				if current <= last {
+					return Ok(());
+				}
+				(last + 1).max(current.saturating_sub(PCR_BACKFILL - 1))
+			}
+		};
+		let reserve = self
+			.tracks
+			.values()
+			.find(|t| t.pid == pcr_pid)
+			.map(|t| t.dts_reserve)
+			.unwrap_or(DEFAULT_DTS_RESERVE);
+		for index in start..=current {
+			let ticks = slot_ticks(index, PCR_INTERVAL).saturating_sub(reserve);
+			self.write_pcr_packet(out, pcr_pid, ticks)?;
+		}
+		self.last_pcr = Some(timestamp);
+		Ok(())
+	}
+
+	/// One adaptation-field-only TS packet carrying `ticks` (continuous 90 kHz) as
+	/// its PCR; stuffing fills the rest. A packet without a payload does not
+	/// increment the continuity counter (ISO 13818-1 2.4.3.3): it repeats the
+	/// previous packet's value, which is one behind the stored next-to-use value.
+	fn write_pcr_packet(&mut self, out: &mut Vec<u8>, pid: u16, ticks: u64) -> anyhow::Result<()> {
+		let next = self.counters.entry(pid).or_default().as_u8();
+		let continuity_counter =
+			ContinuityCounter::from_u8(next.wrapping_sub(1) & ContinuityCounter::MAX).map_err(anyhow::Error::msg)?;
+		let pcr = TsTimestamp::new(ticks & TS_TIMESTAMP_MASK).map_err(anyhow::Error::msg)?;
+		let packet = TsPacket {
+			header: TsHeader {
+				transport_error_indicator: false,
+				transport_priority: false,
+				pid: Pid::new(pid)?,
+				transport_scrambling_control: TransportScramblingControl::NotScrambled,
+				continuity_counter,
+			},
+			adaptation_field: Some(AdaptationField {
+				discontinuity_indicator: false,
+				random_access_indicator: false,
+				es_priority_indicator: false,
+				pcr: Some(pcr.into()),
+				opcr: None,
+				splice_countdown: None,
+				transport_private_data: Vec::new(),
+				extension: None,
+			}),
+			payload: None,
+		};
+		let mut writer = TsPacketWriter::new(out);
+		writer.write_ts_packet(&packet).map_err(anyhow::Error::msg)?;
+		Ok(())
 	}
 
 	/// Packetize a PES payload into 188-byte TS packets.
@@ -852,18 +941,15 @@ impl<E: catalog::Catalog> Export<E> {
 			u16::try_from(optional_len + payload.len()).unwrap_or(0)
 		};
 
-		// PCR follows the decode clock, so a B-frame stream advertises DTS (not PTS) here.
-		let pcr = dts.unwrap_or(pts);
-
 		let mut offset = 0;
 		let mut first = true;
 		loop {
-			let adaptation = if first && (unit.is_pcr || unit.keyframe) {
+			let adaptation = if first && unit.keyframe {
 				Some(AdaptationField {
 					discontinuity_indicator: false,
-					random_access_indicator: unit.keyframe,
+					random_access_indicator: true,
 					es_priority_indicator: false,
-					pcr: if unit.is_pcr { Some(pcr.into()) } else { None },
+					pcr: None,
 					opcr: None,
 					splice_countdown: None,
 					transport_private_data: Vec::new(),
@@ -1014,6 +1100,11 @@ fn due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> boo
 /// divide by it.
 fn slot(timestamp: Timestamp, interval: Duration) -> u128 {
 	Duration::from(timestamp).as_nanos() / interval.as_nanos()
+}
+
+/// A repetition slot's boundary (`index * interval`) in 90 kHz ticks.
+fn slot_ticks(index: u128, interval: Duration) -> u64 {
+	(index * interval.as_nanos() * 90_000 / 1_000_000_000) as u64
 }
 
 /// External byte size of an adaptation field (manual mirror of the crate's
@@ -1216,7 +1307,9 @@ fn dts_reserve(config: &VideoConfig) -> u64 {
 mod tests {
 	use std::time::Duration;
 
-	use super::{DEFAULT_DTS_RESERVE, PSI_INTERVAL, author_dts, due, is_complete_section, slot};
+	use super::{
+		DEFAULT_DTS_RESERVE, PCR_INTERVAL, PSI_INTERVAL, author_dts, due, is_complete_section, slot, slot_ticks,
+	};
 	use moq_net::Timestamp;
 
 	fn ms(value: u64) -> Timestamp {
@@ -1427,6 +1520,18 @@ mod tests {
 		for last in [1_000, 1_100, 1_499] {
 			assert!(!due(ms(1_499), Some(ms(last)), PSI_INTERVAL), "last={last}");
 			assert!(due(ms(1_500), Some(ms(last)), PSI_INTERVAL), "last={last}");
+		}
+	}
+
+	#[test]
+	fn pcr_slots_are_exact_ticks() {
+		// 25 ms is exactly 2250 ticks at 90 kHz: consecutive slot boundaries differ by
+		// exactly one grid step with no rounding drift, however far the timeline runs.
+		// That is what makes the emitted PCR intervals uniform rather than merely bounded.
+		let step = slot_ticks(1, PCR_INTERVAL);
+		assert_eq!(step, 2250);
+		for index in [0u128, 1, 7, 1_000_000, u32::MAX as u128] {
+			assert_eq!(slot_ticks(index, PCR_INTERVAL), index as u64 * step);
 		}
 	}
 

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -49,11 +49,13 @@ const PSI_INTERVAL: Duration = Duration::from_millis(500);
 /// Emit a PCR on every crossing of this media-time grid ([`Export::write_pcr`]).
 /// TR 101 290 flags a gap over 40 ms; broadcast muxes emit every 25-40 ms.
 const PCR_INTERVAL: Duration = Duration::from_millis(25);
-/// How many missed PCR slots to backfill at most. Frames coarser than the grid
-/// cross a few slots at a time and every one is filled so the ramp stays uniform;
-/// past this cap the media itself gapped, and a dense clock history for a span
-/// that carried no bytes helps nobody.
-const PCR_BACKFILL: u128 = 8;
+/// How many missed PCR slots to backfill at most: one second's worth. Frames
+/// coarser than the grid cross several slots at a time and every one is filled so
+/// the ramp stays uniform, down to a 1 fps cadence. Past this cap the media
+/// didn't have a coarse cadence, it had an outage, and reconstructing a dense
+/// clock history for a span that carried no bytes only stalls anything pacing on
+/// the asserted values.
+const PCR_BACKFILL: u128 = 40;
 
 /// Subscribe to a broadcast and produce an MPEG-TS byte stream.
 ///

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -77,6 +77,11 @@ async fn drain_with<E: tscat::Catalog>(mut exporter: Export<E>) -> BytesMut {
 	out
 }
 
+/// An adaptation-field-only single-packet frame: the exporter's PCR carriage.
+fn is_pcr_frame(frame: &Frame) -> bool {
+	frame.payload.len() == 188 && frame.payload[3] & 0x30 == 0x20
+}
+
 fn assert_packet_aligned(ts: &[u8]) {
 	assert!(!ts.is_empty(), "no TS output");
 	assert_eq!(ts.len() % 188, 0, "output not a whole number of 188-byte packets");
@@ -567,11 +572,14 @@ async fn export_pcr_is_a_uniform_ramp() {
 	// every PES unit's effective decode time against the clock preceding it.
 	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
 	let mut pcr_pid = None;
+	let mut pcr_pids = Vec::new();
 	let mut pcrs: Vec<u64> = Vec::new();
 	let mut units = 0usize;
 	while let Some(packet) = reader.read_ts_packet().unwrap() {
 		if let Some(pcr) = packet.adaptation_field.as_ref().and_then(|af| af.pcr) {
-			assert_eq!(Some(packet.header.pid), pcr_pid, "PCR must ride the announced PID");
+			// The clock leads the stream, so the first PCR precedes the PMT that
+			// names its PID; collect and check at the end.
+			pcr_pids.push(packet.header.pid);
 			assert!(packet.payload.is_none(), "PCR rides adaptation-field-only packets");
 			pcrs.push(pcr.as_u64() / 300);
 		}
@@ -591,11 +599,162 @@ async fn export_pcr_is_a_uniform_ramp() {
 
 	assert!(units > 50, "expected the full feed, got {units} PES units");
 	assert!(pcrs.len() > 50, "expected a dense clock, got {} PCRs", pcrs.len());
+	let pcr_pid = pcr_pid.expect("PMT must announce a PCR PID");
+	assert!(
+		pcr_pids.iter().all(|&pid| pid == pcr_pid),
+		"PCR must ride the announced PID"
+	);
 	// One grid step apart, exactly: uniform, monotonic, and far under the 40 ms gate.
 	let step = Duration::from_millis(25).as_micros() as u64 * 90 / 1_000;
 	for (i, w) in pcrs.windows(2).enumerate() {
 		assert_eq!(w[1] - w[0], step, "PCR interval off the grid at {i}: {w:?}");
 	}
+}
+
+/// A timeline that starts inside the decode-clock reserve backs the PCR off
+/// through the 33-bit wrap instead of saturating at zero: the grid step stays
+/// uniform from the very first slot (saturation would emit 0 then 2234, and a
+/// large catalog jitter would freeze several leading PCRs at zero).
+#[tokio::test(start_paused = true)]
+async fn export_pcr_wraps_below_the_reserve_at_start() {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	let track = broadcast
+		.create_track(broadcast.unique_name(".aac"), hang::container::track_info())
+		.unwrap();
+	{
+		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
+		cfg.container = Container::Legacy;
+		catalog.lock().audio.renditions.insert(track.name().to_string(), cfg);
+	}
+	let mut producer = Producer::new(track, HangContainer::Legacy);
+	for i in 0..4u64 {
+		producer
+			.write(Frame {
+				timestamp: Timestamp::from_micros(i * 20_000).unwrap(),
+				duration: None,
+				payload: Bytes::from_static(&[0x01, 0x02, 0x03, 0x04]),
+				keyframe: true,
+			})
+			.unwrap();
+	}
+	producer.finish().unwrap();
+
+	let mut exporter = Export::new(crate::source::announced(&consumer)).await.unwrap();
+	let frames = drain_frames(&mut exporter).await;
+
+	// Each PCR is its own single-packet frame, stamped at its slot boundary so the
+	// caller's pacer delivers the clock at the time it asserts.
+	let mut pcrs: Vec<u64> = Vec::new();
+	for (i, frame) in frames.iter().enumerate() {
+		assert_packet_aligned(&frame.payload);
+		let packet = &frame.payload[..188];
+		// adaptation-field-only packets (adaptation_field_control == 0b10) are the clock.
+		if packet[3] & 0x30 != 0x20 {
+			continue;
+		}
+		assert_eq!(frame.payload.len(), 188, "a PCR frame is one packet, at {i}");
+		assert_eq!(packet[5], 0x10, "PCR_flag alone, at {i}");
+		// The six reserved bits between base and extension are ones (ISO 13818-1);
+		// the crate's serializer writes zeros here, which is why the packet is
+		// laid out by hand.
+		assert_eq!(packet[10] & 0x7e, 0x7e, "reserved bits must be ones, at {i}");
+		let base = (u64::from(packet[6]) << 25)
+			| (u64::from(packet[7]) << 17)
+			| (u64::from(packet[8]) << 9)
+			| (u64::from(packet[9]) << 1)
+			| u64::from(packet[10] >> 7);
+		// The frame is paced at the slot the value asserts (plus the reserve).
+		let slot_ticks = frame.timestamp.as_micros() * 90_000 / 1_000_000;
+		assert_eq!(
+			base,
+			(slot_ticks as u64).wrapping_sub(16) & WIRE,
+			"pacing off value, at {i}"
+		);
+		pcrs.push(base);
+	}
+
+	const WIRE: u64 = (1 << 33) - 1;
+	assert!(pcrs.len() >= 2, "expected at least two grid slots, got {pcrs:?}");
+	// Slot 0 minus the 16-tick default reserve, mod 2^33.
+	assert_eq!(pcrs[0], WIRE - 15, "slot 0 backs off through the wrap: {pcrs:?}");
+	// Every step is exactly one 25 ms slot (2250 ticks) in the circular clock.
+	for (i, w) in pcrs.windows(2).enumerate() {
+		assert_eq!(w[1].wrapping_sub(w[0]) & WIRE, 2250, "step off the grid at {i}: {w:?}");
+	}
+}
+
+/// The clock backs off by the largest reserve of any track, not just the PCR
+/// track's: a second rendition with a deeper reorder (catalog `jitter`) authors
+/// its DTS further behind the PTS, and a clock respecting only the PCR track's
+/// reserve would run ahead of those frames' decode times.
+#[tokio::test(start_paused = true)]
+async fn export_pcr_respects_every_renditions_reserve() {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
+	let mut make = |name: &str, jitter: Option<Duration>| {
+		let track = broadcast.create_track(name, hang::container::track_info()).unwrap();
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: false,
+		});
+		cfg.container = Container::Legacy;
+		cfg.description = Some(avcc.clone());
+		cfg.jitter = jitter;
+		catalog.lock().video.renditions.insert(name.to_string(), cfg);
+		Producer::new(track, HangContainer::Legacy)
+	};
+	// "a" gets the lowest PID and so carries the PCR, with the tiny default
+	// reserve; "b" declares a 100 ms reorder depth.
+	let mut a = make("a.avc1", None);
+	let mut b = make("b.avc1", Some(Duration::from_millis(100)));
+
+	let idr = [0x65u8; 32];
+	for i in 0..25u64 {
+		let timestamp = Timestamp::from_millis(10_000 + i * 40).unwrap();
+		for video in [&mut a, &mut b] {
+			video
+				.write(Frame {
+					timestamp,
+					duration: None,
+					payload: length_prefixed(&[&idr]),
+					keyframe: true,
+				})
+				.unwrap();
+		}
+	}
+	a.finish().unwrap();
+	b.finish().unwrap();
+
+	let ts = drain(consumer).await;
+	assert_packet_aligned(&ts);
+
+	// In transport order, every PES unit (either rendition) decodes at or after
+	// the last PCR preceding it.
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	let mut last_pcr = None;
+	let mut units = 0usize;
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(pcr) = packet.adaptation_field.as_ref().and_then(|af| af.pcr) {
+			last_pcr = Some(pcr.as_u64() / 300);
+		}
+		if let Some(TsPayload::PesStart(pes)) = packet.payload {
+			units += 1;
+			let pts = pes.header.pts.expect("PES carried no PTS").as_u64();
+			let decode = pes.header.dts.map(|t| t.as_u64()).unwrap_or(pts);
+			if let Some(pcr) = last_pcr {
+				assert!(decode >= pcr, "unit decodes at {decode}, before the clock at {pcr}");
+			}
+		}
+	}
+	assert!(units >= 50, "expected both renditions' units, got {units}");
 }
 
 /// Full SCTE-35 round-trip: import `bbb.ts` (real H.264 + AAC) into a broadcast
@@ -1964,8 +2123,12 @@ async fn late_join_matches_a_running_exporter() {
 async fn late_join_matches_a_running_exporter_without_video() {
 	let (a, b) = export_twice(false).await;
 
-	// The joiner leads with PAT/PMT on its very first frame so a receiver can tune in; the
-	// running exporter has no reason to repeat them there. From the next frame on the two are
-	// rendering the same stream.
-	assert_only_continuity_differs(&a, &b, b[1].timestamp);
+	// The joiner leads with its own PCR and a PAT/PMT-carrying tune-in frame so a receiver
+	// can start; the running exporter has no reason to repeat those there. From the first
+	// timestamp after the tune-in frame the two are rendering the same stream. (The joiner's
+	// leading PCR is stamped at a slot boundary at or before the tune-in frame, so comparing
+	// strictly after the tune-in excludes both.)
+	let tune_in = b.iter().find(|f| !is_pcr_frame(f)).expect("a tune-in frame").timestamp;
+	let from = b.iter().map(|f| f.timestamp).filter(|&t| t > tune_in).min().unwrap();
+	assert_only_continuity_differs(&a, &b, from);
 }

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -310,22 +310,23 @@ fn reassemble_video(ts: &[u8], expected_stream_type: StreamType) -> Vec<u8> {
 				video_pid = Some(pmt.es_info[0].elementary_pid);
 			}
 			Some(TsPayload::PesStart(pes)) => {
-				// The first packet of a keyframe must signal random access and carry a PCR.
+				// The first packet of a keyframe must signal random access.
 				if let Some(af) = &packet.adaptation_field {
 					saw_random_access |= af.random_access_indicator;
-					saw_pcr |= af.pcr.is_some();
 				}
 				unbounded = pes.pes_packet_len == 0;
 				reassembled.extend_from_slice(&pes.data);
 			}
 			Some(TsPayload::PesContinuation(bytes)) => reassembled.extend_from_slice(&bytes),
+			// The clock rides adaptation-field-only packets on the PCR PID.
+			None => saw_pcr |= packet.adaptation_field.as_ref().is_some_and(|af| af.pcr.is_some()),
 			_ => {}
 		}
 	}
 
 	assert!(video_pid.is_some(), "missing video PMT entry");
 	assert!(saw_random_access, "keyframe should set random_access_indicator");
-	assert!(saw_pcr, "PCR pid should carry a PCR on the keyframe");
+	assert!(saw_pcr, "PCR pid should carry the clock");
 	assert!(unbounded, "video PES should be unbounded");
 	reassembled
 }
@@ -540,6 +541,60 @@ async fn export_bframe_video_authors_dts() {
 	}
 	for (i, (&d, &p)) in effective.iter().zip(pts.iter()).enumerate() {
 		assert!(d <= p, "DTS {d} after PTS {p} at frame {i}");
+	}
+}
+
+/// #2937: the PCR must be a uniform bounded-interval ramp, not a sample of the
+/// per-unit decode clock. On a reordered (B-frame) capture the authored DTS is a
+/// saw (reference frames leap a reorder span, B-frames nudge one tick), so a PCR
+/// taken from it froze and jumped: most intervals landed within microseconds of
+/// each other, the rest collected into gaps far over TR 101 290's 40 ms gate.
+#[tokio::test(start_paused = true)]
+async fn export_pcr_is_a_uniform_ramp() {
+	let data = include_bytes!("test_data/scte35/kyrion_dirtystart.ts");
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	import.decode(&BytesMut::from(&data[..])).unwrap();
+	import.finish().unwrap();
+
+	let ts = drain(consumer).await;
+	assert_packet_aligned(&ts);
+
+	// Walk the output in transport order: PCR values (90 kHz) as they appear, and
+	// every PES unit's effective decode time against the clock preceding it.
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	let mut pcr_pid = None;
+	let mut pcrs: Vec<u64> = Vec::new();
+	let mut units = 0usize;
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(pcr) = packet.adaptation_field.as_ref().and_then(|af| af.pcr) {
+			assert_eq!(Some(packet.header.pid), pcr_pid, "PCR must ride the announced PID");
+			assert!(packet.payload.is_none(), "PCR rides adaptation-field-only packets");
+			pcrs.push(pcr.as_u64() / 300);
+		}
+		match packet.payload {
+			Some(TsPayload::Pmt(pmt)) if pcr_pid.is_none() => pcr_pid = pmt.pcr_pid,
+			Some(TsPayload::PesStart(pes)) => {
+				units += 1;
+				let pts = pes.header.pts.expect("PES carried no PTS").as_u64();
+				let decode = pes.header.dts.map(|t| t.as_u64()).unwrap_or(pts);
+				if let Some(&pcr) = pcrs.last() {
+					assert!(decode >= pcr, "unit decodes at {decode}, before the clock at {pcr}");
+				}
+			}
+			_ => {}
+		}
+	}
+
+	assert!(units > 50, "expected the full feed, got {units} PES units");
+	assert!(pcrs.len() > 50, "expected a dense clock, got {} PCRs", pcrs.len());
+	// One grid step apart, exactly: uniform, monotonic, and far under the 40 ms gate.
+	let step = Duration::from_millis(25).as_micros() as u64 * 90 / 1_000;
+	for (i, w) in pcrs.windows(2).enumerate() {
+		assert_eq!(w[1] - w[0], step, "PCR interval off the grid at {i}: {w:?}");
 	}
 }
 

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -809,7 +809,11 @@ async fn export_pcr_backfills_a_coarse_cadence() {
 	}
 
 	// 9 inter-frame spans of 400 ms, 16 slots each: every one backfilled.
-	assert!(pcrs.len() > 100, "expected a dense backfilled clock, got {}", pcrs.len());
+	assert!(
+		pcrs.len() > 100,
+		"expected a dense backfilled clock, got {}",
+		pcrs.len()
+	);
 	for (i, w) in pcrs.windows(2).enumerate() {
 		assert_eq!(w[1] - w[0], 2250, "PCR interval off the grid at {i}: {w:?}");
 	}

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -757,6 +757,64 @@ async fn export_pcr_respects_every_renditions_reserve() {
 	assert!(units >= 50, "expected both renditions' units, got {units}");
 }
 
+/// A frame cadence coarser than the grid backfills every missed slot: low-rate
+/// video-only content (here 2.5 fps, 16 slots per frame) still asserts a uniform
+/// 25 ms ramp. A tight backfill cap would skip slots on every frame and re-create
+/// the clock jumps this grid exists to eliminate.
+#[tokio::test(start_paused = true)]
+async fn export_pcr_backfills_a_coarse_cadence() {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
+	let track = broadcast
+		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.unwrap();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: false,
+		});
+		cfg.container = Container::Legacy;
+		cfg.description = Some(avcc);
+		catalog.lock().video.renditions.insert(track.name().to_string(), cfg);
+	}
+	let mut producer = Producer::new(track, HangContainer::Legacy);
+
+	let idr = [0x65u8; 32];
+	for i in 0..10u64 {
+		producer
+			.write(Frame {
+				timestamp: Timestamp::from_millis(10_000 + i * 400).unwrap(),
+				duration: None,
+				payload: length_prefixed(&[&idr]),
+				keyframe: true,
+			})
+			.unwrap();
+	}
+	producer.finish().unwrap();
+
+	let ts = drain(consumer).await;
+	assert_packet_aligned(&ts);
+
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	let mut pcrs: Vec<u64> = Vec::new();
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(pcr) = packet.adaptation_field.as_ref().and_then(|af| af.pcr) {
+			pcrs.push(pcr.as_u64() / 300);
+		}
+	}
+
+	// 9 inter-frame spans of 400 ms, 16 slots each: every one backfilled.
+	assert!(pcrs.len() > 100, "expected a dense backfilled clock, got {}", pcrs.len());
+	for (i, w) in pcrs.windows(2).enumerate() {
+		assert_eq!(w[1] - w[0], 2250, "PCR interval off the grid at {i}: {w:?}");
+	}
+}
+
 /// Full SCTE-35 round-trip: import `bbb.ts` (real H.264 + AAC) into a broadcast
 /// that also carries a `.scte35` cue track, export to TS, re-import, and assert
 /// the splice_info_section came back byte-for-byte. The PMT must advertise the


### PR DESCRIPTION
## Root cause

`moq export ts` had no interval-based PCR path at all: the only PCR was stamped on the first TS packet of each PES unit on the PCR PID, valued at that unit's `dts.unwrap_or(pts)`. On reordered (B-frame) content the authored decode clock is a saw (`author_dts`): a reference frame leaps a whole reorder span ahead (`pts - reserve`), and each B-frame that dips below the clock is nudged exactly one 90 kHz tick (11.1 us) past the previous DTS. Sampling the PCR from that clock is what #2937 measured: ~85% of PCR intervals land within 11 us of each other (the B-frame crawl) and the residual time collects into gaps of hundreds of ms (the reference-frame leaps), independent of transport. TR 101 290 gates PCR repetition at 40 ms, and a downstream CBR groomer cannot repair it because it can only place the clock samples it receives.

## Fix

Decouple the PCR from the PES units entirely, which is what the issue asked for ("a bounded interval enforced against elapsed clock, independent of PES-unit boundaries"):

- The PCR rides its own adaptation-field-only packets on the PCR PID, one per 25 ms slot of an absolute media-time grid. Slots are absolute (`floor(timestamp / interval)`, like the PSI cadence), so redundant exporters of one broadcast keep emitting identical bytes; the `late_join_matches_a_running_exporter` tests still pass.
- Each PCR is returned as its own output `Frame`, stamped at its slot boundary, so the caller's pacer delivers the packet at the time it asserts rather than bunching backfilled slots into the media frame that revealed them. Missed slots drain one per poll (capped at 8) so the ramp stays uniform when frames are coarser than the grid.
- Each PCR value is its slot boundary backed off by the largest decode-clock reserve of any track (the catalog `jitter`, or the small default), so every PES unit of every rendition decodes at or after the clock preceding it. The back-off wraps through the 33-bit clock domain rather than saturating, so a timeline starting inside the reserve keeps a uniform grid.
- The packet bytes are laid out by hand: the `mpeg2ts` serializer writes the six reserved PCR bits as zeros where ISO 13818-1 requires ones, and strict analyzers flag that. No-payload packets do not increment the continuity counter (ISO 13818-1 2.4.3.3); they repeat the previous packet's value. The importer already classifies no-payload packets as contiguous without advancing its counter, so exported TS still round-trips.
- The PES-leading adaptation field now exists only to flag `random_access_indicator` on keyframes; it no longer carries a PCR (a saw value there would corrupt the ramp's monotonicity).

## Tests

- `export_pcr_is_a_uniform_ramp`: exports the real B-frame capture (`kyrion_dirtystart.ts`) and asserts every consecutive PCR interval is exactly one 25 ms grid step (fails on the old code, where intervals collapse to sub-millisecond), that PCR rides only the announced PID on payload-less packets, and that every PES unit's effective decode time is at or after the last PCR preceding it.
- `export_pcr_wraps_below_the_reserve_at_start`: a zero-based timeline backs off through the 33-bit wrap, each PCR is a standalone 188-byte frame paced at its slot boundary, and the reserved bits are ones on the raw wire.
- `export_pcr_respects_every_renditions_reserve`: two video renditions with unequal catalog jitter; every PES unit of either rendition decodes at or after the preceding clock (fails if the back-off only respects the PCR track's reserve).
- `pcr_slots_are_exact_ticks`: the 25 ms grid is exactly 2250 ticks at 90 kHz, so slot boundaries carry no rounding drift.

## Cross-package sync

No wire (MoQ) change, so no draft updates: this is TS muxing output only. No public API change. No docs mention the PCR. The JS packages have no TS muxer.

Note for reviewers: the DTS saw itself is untouched. Players tolerate it (it exists to keep decode order monotonic, #1843), and the defect measured in #2937 is the clock asserted by the PCR, not the per-unit decode schedule.

Closes #2937

(written by Fable 5)
