### PR TITLE
chore: bump non-Rust package versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
     },
     "js/flate": {
       "name": "@moq/flate",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "pako": "^3.0.1",
       },
@@ -98,7 +98,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.9.8",
@@ -121,7 +121,7 @@
     },
     "js/json": {
       "name": "@moq/json",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@moq/flate": "workspace:^",
         "@moq/net": "workspace:^",
@@ -138,7 +138,7 @@
     },
     "js/loc": {
       "name": "@moq/loc",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@moq/net": "workspace:^",
       },
@@ -170,7 +170,7 @@
     },
     "js/msf": {
       "name": "@moq/msf",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@moq/net": "workspace:^",
         "zod": "^4.4.3",
@@ -182,7 +182,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@moq/qmux": "^0.3.3",
         "@moq/signals": "workspace:*",
@@ -243,7 +243,7 @@
     },
     "js/token": {
       "name": "@moq/token",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "bin": {
         "moq-token": "./src/cli.ts",
       },
@@ -266,7 +266,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/msf": "workspace:^",

--- a/js/flate/package.json
+++ b/js/flate/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/flate",
 	"type": "module",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Group-scoped DEFLATE: a stream of self-delimited frames sharing one compression window.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/json",
 	"type": "module",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, or append-log NDJSON streams.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/loc/package.json
+++ b/js/loc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/loc",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Low Overhead Container (LOC) frame encoding for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/msf",
 	"type": "module",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "MSF (MOQT Streaming Format) catalog types for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/token",
 	"type": "module",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Media over QUIC - Token Generation and Validation",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/py/moq-rs/pyproject.toml
+++ b/py/moq-rs/pyproject.toml
@@ -14,7 +14,7 @@ name = "moq-rs"
 # isn't already there (no tag needed; the registry is the gate).
 # Starts at 0.3.0 to open a new line above the old lockstep 0.2.x releases that
 # bundled the bindings.
-version = "0.4.4"
+version = "0.4.5"
 description = "Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization, with a Pythonic API. Import as `moq`."
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -30,9 +30,9 @@ classifiers = [
 ]
 # Compatible-release pin: floats to the latest 0.3.x moq-ffi patch without a
 # wrapper re-release. A moq-ffi minor bump (0.4) is the only thing that forces
-# bumping this constraint. Floor is 0.3.10, the first release with request path
-# and query accessors.
-dependencies = ["moq-ffi ~= 0.3.10"]
+# bumping this constraint. Floor is 0.3.11, the first release with retained
+# media group decoding.
+dependencies = ["moq-ffi ~= 0.3.11"]
 
 [project.urls]
 Homepage = "https://github.com/moq-dev/moq"

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ source = { editable = "py/moq-ffi" }
 
 [[package]]
 name = "moq-rs"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "py/moq-rs" }
 dependencies = [
     { name = "moq-ffi" },


### PR DESCRIPTION
## Summary

- Bump eight published `@moq/*` packages for unreleased additive APIs, behavior fixes, and the packaging fix that keeps tests out of published tarballs.
- Bump `moq-rs` to 0.4.5 for retained media group decoding.
- Raise the `moq-rs` minimum `moq-ffi` version to 0.3.11, the first bindings release containing that API.

## Public API changes

- This PR changes only release versions and dependency metadata.
- The releases include already-merged additive APIs for stalled rendition metadata, `Path.relative`, the MoQ Cluster extension, and retained media group decoding. There are no breaking changes.

## Test plan

- `just fix`
- JavaScript checks, builds, `publint`, and documentation build from `just check`
- `just py check`
- JavaScript test suite from `just test`
- `CARGO_TARGET_DIR=<isolated> just py test` (50 passed)
- `git diff --check`

(Written by GPT-5)
