### PR TITLE
fix(moq-mux): emit SI when the snapshot changes, floor the repeats

### DIFF
--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -1055,11 +1055,15 @@ impl<E: catalog::Catalog> Export<E> {
 			})
 			.map(|((pid, _), si)| {
 				si.dirty = false;
-				// This never moves the anchor backwards: `si_due` saturates elapsed
-				// time, so with a non-zero interval it only passes timestamps strictly
-				// above the anchor (a reordered B-frame earns no emission at all), and
-				// with a zero interval every frame emits regardless of the anchor.
-				si.last_emit = Some(frame.timestamp);
+				// The anchor never moves backwards. A non-zero interval cannot regress
+				// it on its own (`si_due` saturates, admitting only timestamps strictly
+				// above it), but a zero-interval entry emits on every frame including
+				// reordered (B-frame) timestamps below the anchor, and a catalog update
+				// can raise the interval later; a regressed anchor would then credit
+				// the reorder span against the floor.
+				if si.last_emit.is_none_or(|last| frame.timestamp > last) {
+					si.last_emit = Some(frame.timestamp);
+				}
 				(*pid, si.active.sections().cloned().collect())
 			})
 			.collect();

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -183,7 +183,13 @@ struct SiTrack {
 	/// A group still being read; swapped into `active` when it ends, so a torn
 	/// half-received snapshot is never emitted.
 	pending: Option<(moq_net::group::Consumer, super::si::Snapshot)>,
-	/// Media timestamp of the last emission ([`due`]).
+	/// A promoted snapshot changed `active` and has not hit the wire yet: emit with
+	/// the next frame instead of waiting out the repetition interval. For a clock
+	/// table (TDT/TOT) the cadence is the content, so holding a revision to the
+	/// interval delivers the time seconds late and can re-assert an already-sent
+	/// value (#2934).
+	dirty: bool,
+	/// Media timestamp of the last emission ([`Export::write_frame`]).
 	last_emit: Option<Timestamp>,
 	/// The same budget the media sources use. SI carries table snapshots at a low
 	/// rate, so the real-time default would take only the newest group and drop
@@ -215,6 +221,7 @@ impl SiTrack {
 			state: SiState::Requesting(source.request_catalog(), track.to_string()),
 			active: Default::default(),
 			pending: None,
+			dirty: false,
 			last_emit: None,
 			latency,
 		}
@@ -316,6 +323,10 @@ impl SiTrack {
 			};
 			if promote {
 				let (_, snapshot) = self.pending.take().unwrap();
+				// A repeated group (the same section set re-published) is not a change:
+				// treating it as one would turn the source's snapshot cadence into extra
+				// wire repetitions.
+				self.dirty |= snapshot != self.active;
 				self.active = snapshot;
 			} else if drop_pending {
 				self.pending = None;
@@ -585,6 +596,7 @@ impl<E: catalog::Catalog> Export<E> {
 					Some(existing) if existing.track != entry.track => {
 						let mut replacement = SiTrack::new(&self.source, &entry.track, entry.interval, self.latency);
 						replacement.active = std::mem::take(&mut existing.active);
+						replacement.dirty = existing.dirty;
 						replacement.last_emit = existing.last_emit;
 						*existing = replacement;
 					}
@@ -1009,20 +1021,25 @@ impl<E: catalog::Catalog> Export<E> {
 			self.last_psi = Some(frame.timestamp);
 		}
 
-		// Re-emit each SI entry's sections verbatim on its own cadence, which is the
-		// table's own repetition requirement rather than the PSI interval: an SDT
-		// wants 2s where the PSI wants 500ms, and an EPG schedule slice wants 30s.
-		// Unknown tables have no declared interval and fall back to the PSI cadence.
-		// `Bytes` clones are refcount bumps, and only a due entry is collected at all.
+		// Emit each SI entry's sections verbatim: immediately when the snapshot
+		// changed (`dirty`), else once its own repetition interval has elapsed since
+		// the entry last hit the wire. The interval is the table's repetition
+		// requirement, a *floor* between unchanged repeats rather than an emission
+		// grid: an SDT wants 2s where the PSI wants 500ms, and a TDT/TOT revision
+		// held to a 30s grid would deliver the clock up to a whole slot late and
+		// re-assert an already-sent time (#2934). Unknown tables have no declared
+		// interval and fall back to the PSI cadence. `Bytes` clones are refcount
+		// bumps, and only a due entry is collected at all.
 		let pending: Vec<(u16, Vec<Bytes>)> = self
 			.si
 			.iter_mut()
 			.filter(|(_, si)| !si.active.is_empty())
 			.filter(|(_, si)| {
 				let interval = si.interval.unwrap_or(PSI_INTERVAL);
-				due(frame.timestamp, si.last_emit, interval)
+				si.dirty || si_due(frame.timestamp, si.last_emit, interval)
 			})
 			.map(|((pid, _), si)| {
+				si.dirty = false;
 				si.last_emit = Some(frame.timestamp);
 				(*pid, si.active.sections().cloned().collect())
 			})
@@ -1259,6 +1276,27 @@ fn due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> boo
 	slot(timestamp, interval) > slot(last, interval)
 }
 
+/// Whether an unchanged SI entry owes a repeat: `interval` has elapsed on the media
+/// timeline since it last hit the wire.
+///
+/// A floor measured from the entry's own last emission, unlike [`due`]'s absolute
+/// grid, because SI emission is content-driven: a changed snapshot goes out with
+/// the next frame (`SiTrack::dirty`) whenever that lands, and a grid boundary
+/// shortly after would re-send it as a near-immediate stale repeat. For a clock
+/// table that repeat asserts an already-sent time and steps a receiver backwards
+/// (#2934). The cost is that *unchanged* repeats are phased by each exporter's own
+/// emission history rather than shared slots; the emissions that carry information
+/// (the revisions) stay driven by the broadcast alone. `None` (never emitted) is
+/// always due, so a fresh exporter leads with the tables.
+fn si_due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> bool {
+	let Some(last) = last else {
+		return true;
+	};
+	// Reordered (B-frame) timestamps step backwards; saturate rather than wrap so a
+	// dip never counts as elapsed time (a zero interval still means "every frame").
+	Duration::from(timestamp).saturating_sub(Duration::from(last)) >= interval
+}
+
 /// Index of `timestamp`'s repetition slot: how many whole `interval`s fit under it.
 ///
 /// Nanoseconds, so the divisor is zero only for a genuinely zero `interval`, which [`due`]
@@ -1470,7 +1508,7 @@ mod tests {
 
 	use moq_net::Timestamp;
 
-	use super::{DEFAULT_DTS_RESERVE, PSI_INTERVAL, author_dts, due, is_complete_section, slot};
+	use super::{DEFAULT_DTS_RESERVE, PSI_INTERVAL, author_dts, due, is_complete_section, si_due, slot};
 
 	fn ms(value: u64) -> Timestamp {
 		Timestamp::from_millis(value).unwrap()
@@ -1607,17 +1645,35 @@ mod tests {
 		// fire on every B-frame that steps back across a boundary (see `due_ignores_reorder`).
 		assert!(!due(ms(750), Some(ms(1_000)), PSI_INTERVAL));
 
-		// A per-PID SI interval is honored independently of the PSI cadence: an SDT at
-		// 2s is not due when the 500ms PSI would be.
-		let sdt = Duration::from_millis(2_000);
-		assert!(!due(ms(1_500), Some(ms(1_000)), sdt));
-		assert!(due(ms(3_000), Some(ms(1_000)), sdt));
+		// The slot grid honors whatever interval it is given, not just the PSI's own.
+		let coarse = Duration::from_millis(2_000);
+		assert!(!due(ms(1_500), Some(ms(1_000)), coarse));
+		assert!(due(ms(3_000), Some(ms(1_000)), coarse));
 	}
 
-	/// Drive a run of timestamps through the interval cadence, advancing the stored emission
-	/// only when one fires, and return how many tables it emitted. That is the whole of the SI
-	/// path; PSI additionally emits (and re-anchors) at every video keyframe, which is what
-	/// keeps two exporters of a program *with* video in step even before this.
+	#[test]
+	fn si_due_floors_repeats_from_the_last_emission() {
+		// Never emitted: always due, so a fresh exporter leads with the tables.
+		assert!(si_due(ms(1_000), None, PSI_INTERVAL));
+
+		// The interval is measured from the entry's own last emission, not an absolute
+		// grid: an emission at 1.4s holds the next repeat to 3.4s, where the grid
+		// would have re-sent at 2s.
+		let interval = Duration::from_millis(2_000);
+		assert!(!si_due(ms(2_000), Some(ms(1_400)), interval));
+		assert!(!si_due(ms(3_399), Some(ms(1_400)), interval));
+		assert!(si_due(ms(3_400), Some(ms(1_400)), interval));
+
+		// A reordered (B-frame) timestamp behind the last emission is not elapsed time.
+		assert!(!si_due(ms(1_000), Some(ms(1_400)), interval));
+		// A zero interval means every frame, even one sharing the last timestamp.
+		assert!(si_due(ms(1_400), Some(ms(1_400)), Duration::ZERO));
+	}
+
+	/// Drive a run of timestamps through the slot cadence, advancing the stored emission
+	/// only when one fires, and return how many tables it emitted. PSI additionally emits
+	/// (and re-anchors) at every video keyframe; SI does not use the grid at all
+	/// ([`si_due`] floors unchanged repeats from the last emission instead).
 	fn run_cadence(stamps: &[Timestamp], interval: Duration) -> usize {
 		let mut last = None;
 		let mut emissions = 0;

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -190,11 +190,11 @@ struct SiTrack {
 	/// A group still being read; swapped into `active` when it ends, so a torn
 	/// half-received snapshot is never emitted.
 	pending: Option<(moq_net::group::Consumer, super::si::Snapshot)>,
-	/// A promoted snapshot changed `active` and has not hit the wire yet: emit with
-	/// the next frame instead of waiting out the repetition interval. For a clock
-	/// table (TDT/TOT) the cadence is the content, so holding a revision to the
-	/// interval delivers the time seconds late and can re-assert an already-sent
-	/// value (#2934).
+	/// A promoted snapshot changed `active` and has not hit the wire yet: emit on
+	/// the revision floor ([`SI_REVISION_INTERVAL`]) instead of waiting out the
+	/// repetition interval. For a clock table (TDT/TOT) the cadence is the content,
+	/// so holding a revision to the interval delivers the time seconds late and can
+	/// re-assert an already-sent value (#2934).
 	dirty: bool,
 	/// Media timestamp of the last emission ([`Export::write_frame`]).
 	last_emit: Option<Timestamp>,
@@ -1055,13 +1055,11 @@ impl<E: catalog::Catalog> Export<E> {
 			})
 			.map(|((pid, _), si)| {
 				si.dirty = false;
-				// The anchor never moves backwards: a dirty emission can ride a
-				// reordered (B-frame) timestamp below the previous anchor, and
-				// re-anchoring there would credit the reorder span against the floor,
-				// repeating the unchanged snapshot early.
-				if si.last_emit.is_none_or(|last| frame.timestamp > last) {
-					si.last_emit = Some(frame.timestamp);
-				}
+				// This never moves the anchor backwards: `si_due` saturates elapsed
+				// time, so with a non-zero interval it only passes timestamps strictly
+				// above the anchor (a reordered B-frame earns no emission at all), and
+				// with a zero interval every frame emits regardless of the anchor.
+				si.last_emit = Some(frame.timestamp);
 				(*pid, si.active.sections().cloned().collect())
 			})
 			.collect();
@@ -1301,8 +1299,8 @@ fn due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> boo
 /// timeline since it last hit the wire.
 ///
 /// A floor measured from the entry's own last emission, unlike [`due`]'s absolute
-/// grid, because SI emission is content-driven: a changed snapshot goes out with
-/// the next frame (`SiTrack::dirty`) whenever that lands, and a grid boundary
+/// grid, because SI emission is content-driven: a changed snapshot goes out on the
+/// revision floor (`SiTrack::dirty`, [`SI_REVISION_INTERVAL`]), and a grid boundary
 /// shortly after would re-send it as a near-immediate stale repeat. For a clock
 /// table that repeat asserts an already-sent time and steps a receiver backwards
 /// (#2934). The cost is that *unchanged* repeats are phased by each exporter's own

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -45,6 +45,13 @@ const PMT_PID: u16 = 0x1000;
 const FIRST_ES_PID: u16 = 0x1001;
 /// Re-emit PAT/PMT at least this often (wall-clock of the media) for tune-in.
 const PSI_INTERVAL: Duration = Duration::from_millis(500);
+/// The floor between emissions of a *changed* SI snapshot, bounding how fast a
+/// revising publisher can make the mux re-emit its tables. The import side
+/// debounces its own snapshot cuts (`si::DEBOUNCE`), but export consumes any
+/// catalog-named snapshot track, so the bound cannot live only there; this one is
+/// enforced on the media timeline. Clamped to the entry's own interval, so a
+/// table asking for faster repetition than this still gets it.
+const SI_REVISION_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Subscribe to a broadcast and produce an MPEG-TS byte stream.
 ///
@@ -1021,26 +1028,40 @@ impl<E: catalog::Catalog> Export<E> {
 			self.last_psi = Some(frame.timestamp);
 		}
 
-		// Emit each SI entry's sections verbatim: immediately when the snapshot
-		// changed (`dirty`), else once its own repetition interval has elapsed since
-		// the entry last hit the wire. The interval is the table's repetition
-		// requirement, a *floor* between unchanged repeats rather than an emission
-		// grid: an SDT wants 2s where the PSI wants 500ms, and a TDT/TOT revision
-		// held to a 30s grid would deliver the clock up to a whole slot late and
-		// re-assert an already-sent time (#2934). Unknown tables have no declared
-		// interval and fall back to the PSI cadence. `Bytes` clones are refcount
-		// bumps, and only a due entry is collected at all.
+		// Emit each SI entry's sections verbatim: on the revision floor when the
+		// snapshot changed (`dirty`), else once its own repetition interval has
+		// elapsed since the entry last hit the wire. The interval is the table's
+		// repetition requirement, a *floor* between unchanged repeats rather than an
+		// emission grid: an SDT wants 2s where the PSI wants 500ms, and a TDT/TOT
+		// revision held to a 30s grid would deliver the clock up to a whole slot
+		// late and re-assert an already-sent time (#2934). Unknown tables have no
+		// declared interval and fall back to the PSI cadence. `Bytes` clones are
+		// refcount bumps, and only a due entry is collected at all.
 		let pending: Vec<(u16, Vec<Bytes>)> = self
 			.si
 			.iter_mut()
 			.filter(|(_, si)| !si.active.is_empty())
 			.filter(|(_, si)| {
 				let interval = si.interval.unwrap_or(PSI_INTERVAL);
-				si.dirty || si_due(frame.timestamp, si.last_emit, interval)
+				// A revision waits only for the revision floor; an unchanged snapshot
+				// waits for the full interval. A deferred revision stays dirty and
+				// carries whatever `active` holds when it finally rides.
+				let due = if si.dirty {
+					SI_REVISION_INTERVAL.min(interval)
+				} else {
+					interval
+				};
+				si_due(frame.timestamp, si.last_emit, due)
 			})
 			.map(|((pid, _), si)| {
 				si.dirty = false;
-				si.last_emit = Some(frame.timestamp);
+				// The anchor never moves backwards: a dirty emission can ride a
+				// reordered (B-frame) timestamp below the previous anchor, and
+				// re-anchoring there would credit the reorder span against the floor,
+				// repeating the unchanged snapshot early.
+				if si.last_emit.is_none_or(|last| frame.timestamp > last) {
+					si.last_emit = Some(frame.timestamp);
+				}
 				(*pid, si.active.sections().cloned().collect())
 			})
 			.collect();

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -2624,7 +2624,7 @@ struct SiCadenceRig {
 	producer: Producer<HangContainer>,
 	si_track: moq_net::track::Producer,
 	exporter: Export<tscat::Ext>,
-	_catalog: crate::catalog::Producer<tscat::Ext>,
+	catalog: crate::catalog::Producer<tscat::Ext>,
 }
 
 async fn si_cadence_rig(pid: u16, table_id: u8, interval: Duration) -> SiCadenceRig {
@@ -2671,7 +2671,7 @@ async fn si_cadence_rig(pid: u16, table_id: u8, interval: Duration) -> SiCadence
 		producer,
 		si_track,
 		exporter,
-		_catalog: catalog,
+		catalog,
 	}
 }
 
@@ -2805,6 +2805,41 @@ async fn si_reordered_frames_earn_no_emission_credit() {
 		1,
 		"the deferred revision rides the floor"
 	);
+}
+
+/// The emission anchor never moves backwards, even where a zero-interval entry
+/// emits on a reordered (B-frame) timestamp below it: a catalog update can raise
+/// the interval afterwards, and a regressed anchor would then credit the reorder
+/// span against the floor. (Non-zero intervals cannot regress the anchor on their
+/// own, since `si_due` saturates; the zero-to-nonzero transition is the one
+/// reachable path.)
+#[tokio::test(start_paused = true)]
+async fn si_anchor_survives_a_zero_interval_reorder() {
+	let section = |version: u8| make_long_section(0x42, 1, version, 0, 0, &[version; 8]);
+	// Zero interval: the table rides every frame, whatever its timestamp.
+	let mut rig = si_cadence_rig(0x0011, 0x42, Duration::ZERO).await;
+
+	rig.si_track
+		.write_frame(Timestamp::ZERO, Bytes::from(section(0)))
+		.unwrap();
+	assert_eq!(rig.media(1_000, 0x0011).await, 1, "zero interval rides every frame");
+	assert_eq!(rig.media(2_500, 0x0011).await, 1, "the anchor advances to 2.5s");
+	// A reordered frame steps back behind the anchor; zero interval still emits.
+	assert_eq!(rig.media(2_400, 0x0011).await, 1, "and still rides a reordered frame");
+
+	// The catalog raises the interval to 1s. The floor must measure from the 2.5s
+	// anchor, not the reordered 2.4s emission.
+	rig.catalog
+		.lock()
+		.mpegts
+		.si
+		.get_mut(&0x0011)
+		.unwrap()
+		.get_mut(&0x42)
+		.unwrap()
+		.interval = Some(Duration::from_secs(1));
+	assert_eq!(rig.media(3_400, 0x0011).await, 0, "the reorder span is not credited");
+	assert_eq!(rig.media(3_500, 0x0011).await, 1, "due 1s after the true anchor");
 }
 
 /// A publisher revising its snapshot before every frame must not drive the mux at

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -2714,12 +2714,13 @@ fn count_pid(frames: &[Frame], pid: u16) -> usize {
 		.sum()
 }
 
-/// #2934: a revised SI snapshot rides the next media frame instead of waiting out
-/// the repetition interval. For a clock table (TDT/TOT) the old interval-grid hold
+/// #2934: a revised SI snapshot goes out on the revision floor instead of waiting
+/// out the repetition interval (here the floor has long elapsed, so it rides the
+/// very next frame). For a clock table (TDT/TOT) the old interval-grid hold
 /// delivered the asserted time up to a whole 30 s slot late, and a source ticking
 /// slower than the grid had its stale value re-sent, stepping receivers backwards.
 #[tokio::test(start_paused = true)]
-async fn si_revision_rides_the_next_frame() {
+async fn si_revision_does_not_wait_for_the_interval() {
 	let tick = |mjd: u8| make_short_section(0x70, &[0xc0, mjd, 0x12, 0x34, 0x56]);
 	let mut rig = si_cadence_rig(0x0014, 0x70, Duration::from_secs(30)).await;
 
@@ -2771,10 +2772,10 @@ async fn si_repeats_are_floored_from_the_last_emission() {
 	assert_eq!(rig.media(5_500, 0x0011).await, 1, "repeat 2s after the revision");
 }
 
-/// A reordered (B-frame) timestamp below the emission anchor earns no credit: a
-/// revision arriving there is deferred (elapsed time saturates at zero), and the
-/// anchor itself never moves backwards, so neither revisions nor repeats can fire
-/// early off the reorder span.
+/// A reordered (B-frame) timestamp below the emission anchor earns no credit:
+/// `si_due` saturates elapsed time, so a revision arriving there is deferred, the
+/// anchor never moves backwards, and neither revisions nor repeats can fire early
+/// off the reorder span.
 #[tokio::test(start_paused = true)]
 async fn si_reordered_frames_earn_no_emission_credit() {
 	let section = |version: u8| make_long_section(0x42, 1, version, 0, 0, &[version; 8]);

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -2617,6 +2617,138 @@ async fn si_revision_after_final_media_frame_is_flushed() {
 	assert!(end.is_none(), "end of stream after the trailing flush");
 }
 
+/// A broadcast with one avc1 video track and one SI entry, for driving SI emission
+/// frame by frame: `media(millis, pid)` writes one keyframe group and reports how
+/// many packets of `pid` ride the output it produced.
+struct SiCadenceRig {
+	producer: Producer<HangContainer>,
+	si_track: moq_net::track::Producer,
+	exporter: Export<tscat::Ext>,
+	_catalog: crate::catalog::Producer<tscat::Ext>,
+}
+
+async fn si_cadence_rig(pid: u16, table_id: u8, interval: Duration) -> SiCadenceRig {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+
+	let si_name = format!("{pid:#06x}-{table_id:#04x}.si");
+	let si_track = broadcast.create_track(si_name.as_str(), None).unwrap();
+
+	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
+	let track = broadcast
+		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
+		.unwrap();
+	let name = track.name().to_string();
+	{
+		let mut guard = catalog.lock();
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0,
+			level: 0x1f,
+			inline: false,
+		});
+		cfg.container = Container::Legacy;
+		cfg.description = Some(avcc);
+		guard.video.renditions.insert(name, cfg);
+		guard.mpegts.si.entry(pid).or_default().insert(
+			table_id,
+			tscat::SiEntry {
+				track: si_name,
+				interval: Some(interval),
+				..Default::default()
+			},
+		);
+	}
+
+	let producer = Producer::new(track, HangContainer::Legacy);
+	let exporter = Export::with_ts(crate::source::announced(&consumer), crate::catalog::CatalogFormat::Hang)
+		.await
+		.unwrap();
+	SiCadenceRig {
+		producer,
+		si_track,
+		exporter,
+		_catalog: catalog,
+	}
+}
+
+impl SiCadenceRig {
+	async fn media(&mut self, millis: u64, pid: u16) -> usize {
+		let mut idr = vec![0x65u8];
+		idr.extend(std::iter::repeat_n(0xAB, 64));
+		self.producer
+			.write(Frame {
+				timestamp: Timestamp::from_millis(millis).unwrap(),
+				duration: None,
+				payload: length_prefixed(&[&idr]),
+				keyframe: true,
+			})
+			.unwrap();
+		self.producer.cut(None).unwrap();
+
+		let mut count = 0;
+		for frame in drain_frames(&mut self.exporter).await {
+			assert_packet_aligned(&frame.payload);
+			count += frame
+				.payload
+				.chunks_exact(188)
+				.filter(|p| ((((p[1] & 0x1f) as u16) << 8) | p[2] as u16) == pid)
+				.count();
+		}
+		count
+	}
+}
+
+/// #2934: a revised SI snapshot rides the next media frame instead of waiting out
+/// the repetition interval. For a clock table (TDT/TOT) the old interval-grid hold
+/// delivered the asserted time up to a whole 30 s slot late, and a source ticking
+/// slower than the grid had its stale value re-sent, stepping receivers backwards.
+#[tokio::test(start_paused = true)]
+async fn si_revision_rides_the_next_frame() {
+	let tick = |mjd: u8| make_short_section(0x70, &[0xc0, mjd, 0x12, 0x34, 0x56]);
+	let mut rig = si_cadence_rig(0x0014, 0x70, Duration::from_secs(30)).await;
+
+	rig.si_track.write_frame(Timestamp::ZERO, Bytes::from(tick(1))).unwrap();
+	assert_eq!(rig.media(0, 0x0014).await, 1, "a fresh exporter leads with the table");
+	assert_eq!(rig.media(1_000, 0x0014).await, 0, "unchanged: held by the 30s floor");
+	assert_eq!(rig.media(2_000, 0x0014).await, 0, "unchanged: still held");
+
+	// The clock ticks. Nothing about the 30 s interval has elapsed, but the value
+	// changed: it must go out with the very next frame.
+	rig.si_track.write_frame(Timestamp::ZERO, Bytes::from(tick(2))).unwrap();
+	assert_eq!(rig.media(3_000, 0x0014).await, 1, "the revision rides the next frame");
+	assert_eq!(rig.media(4_000, 0x0014).await, 0, "emitted once, then floored again");
+}
+
+/// #2934, the repeat half: an *unchanged* snapshot repeats only once its interval
+/// has elapsed since the entry last hit the wire, not on an absolute grid slot. A
+/// grid boundary shortly after a change emission would re-send the section as a
+/// near-immediate stale repeat, which for a clock table re-asserts an old time.
+#[tokio::test(start_paused = true)]
+async fn si_repeats_are_floored_from_the_last_emission() {
+	let sdt_v1 = make_long_section(0x42, 1, 0, 0, 0, &[0xaa; 8]);
+	let sdt_v2 = make_long_section(0x42, 1, 1, 0, 0, &[0xbb; 8]);
+	let mut rig = si_cadence_rig(0x0011, 0x42, Duration::from_secs(2)).await;
+
+	rig.si_track.write_frame(Timestamp::ZERO, Bytes::from(sdt_v1)).unwrap();
+	assert_eq!(rig.media(0, 0x0011).await, 1, "lead emission");
+	assert_eq!(rig.media(1_000, 0x0011).await, 0, "within the floor");
+	assert_eq!(rig.media(2_000, 0x0011).await, 1, "repeat once 2s elapsed");
+
+	// A revision lands mid-interval and goes out immediately (at 2.5s)...
+	rig.si_track.write_frame(Timestamp::ZERO, Bytes::from(sdt_v2)).unwrap();
+	assert_eq!(rig.media(2_500, 0x0011).await, 1, "the revision goes out immediately");
+
+	// ...so the next repeat is due at 4.5s. The absolute grid would have re-sent at
+	// the 4s boundary, 1.5s after the wire last carried the identical sections.
+	assert_eq!(rig.media(3_000, 0x0011).await, 0, "within the floor of the revision");
+	assert_eq!(rig.media(4_000, 0x0011).await, 0, "the old grid slot must not fire");
+	assert_eq!(rig.media(4_500, 0x0011).await, 1, "repeat 2s after the revision");
+}
+
 /// Two captures overlapping on one broadcast (a supervisor restarting its
 /// importer before the old one is dropped) contend for the same `(PID, table_id)`
 /// key: the newer one wins the catalog mapping under a fallback track name, and

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -2676,7 +2676,7 @@ async fn si_cadence_rig(pid: u16, table_id: u8, interval: Duration) -> SiCadence
 }
 
 impl SiCadenceRig {
-	async fn media(&mut self, millis: u64, pid: u16) -> usize {
+	async fn media_frames(&mut self, millis: u64) -> Vec<Frame> {
 		let mut idr = vec![0x65u8];
 		idr.extend(std::iter::repeat_n(0xAB, 64));
 		self.producer
@@ -2689,17 +2689,29 @@ impl SiCadenceRig {
 			.unwrap();
 		self.producer.cut(None).unwrap();
 
-		let mut count = 0;
-		for frame in drain_frames(&mut self.exporter).await {
+		let frames = drain_frames(&mut self.exporter).await;
+		for frame in &frames {
 			assert_packet_aligned(&frame.payload);
-			count += frame
-				.payload
+		}
+		frames
+	}
+
+	async fn media(&mut self, millis: u64, pid: u16) -> usize {
+		count_pid(&self.media_frames(millis).await, pid)
+	}
+}
+
+/// How many TS packets of `pid` ride the given frames.
+fn count_pid(frames: &[Frame], pid: u16) -> usize {
+	frames
+		.iter()
+		.map(|f| {
+			f.payload
 				.chunks_exact(188)
 				.filter(|p| ((((p[1] & 0x1f) as u16) << 8) | p[2] as u16) == pid)
-				.count();
-		}
-		count
-	}
+				.count()
+		})
+		.sum()
 }
 
 /// #2934: a revised SI snapshot rides the next media frame instead of waiting out
@@ -2738,15 +2750,93 @@ async fn si_repeats_are_floored_from_the_last_emission() {
 	assert_eq!(rig.media(1_000, 0x0011).await, 0, "within the floor");
 	assert_eq!(rig.media(2_000, 0x0011).await, 1, "repeat once 2s elapsed");
 
-	// A revision lands mid-interval and goes out immediately (at 2.5s)...
+	// A revision lands mid-interval: it waits only for the 1s revision floor
+	// (measured from the 2s repeat), not for the 2s interval or a grid slot.
 	rig.si_track.write_frame(Timestamp::ZERO, Bytes::from(sdt_v2)).unwrap();
-	assert_eq!(rig.media(2_500, 0x0011).await, 1, "the revision goes out immediately");
+	assert_eq!(
+		rig.media(2_500, 0x0011).await,
+		0,
+		"a revision honors the revision floor"
+	);
+	assert_eq!(
+		rig.media(3_500, 0x0011).await,
+		1,
+		"the revision rides the floor, not the interval"
+	);
 
-	// ...so the next repeat is due at 4.5s. The absolute grid would have re-sent at
-	// the 4s boundary, 1.5s after the wire last carried the identical sections.
-	assert_eq!(rig.media(3_000, 0x0011).await, 0, "within the floor of the revision");
+	// The next repeat is due 2s after that. The absolute grid would have re-sent
+	// at the 4s boundary, 0.5s after the wire last carried the identical sections.
 	assert_eq!(rig.media(4_000, 0x0011).await, 0, "the old grid slot must not fire");
-	assert_eq!(rig.media(4_500, 0x0011).await, 1, "repeat 2s after the revision");
+	assert_eq!(rig.media(5_000, 0x0011).await, 0, "within the floor of the revision");
+	assert_eq!(rig.media(5_500, 0x0011).await, 1, "repeat 2s after the revision");
+}
+
+/// A reordered (B-frame) timestamp below the emission anchor earns no credit: a
+/// revision arriving there is deferred (elapsed time saturates at zero), and the
+/// anchor itself never moves backwards, so neither revisions nor repeats can fire
+/// early off the reorder span.
+#[tokio::test(start_paused = true)]
+async fn si_reordered_frames_earn_no_emission_credit() {
+	let section = |version: u8| make_long_section(0x42, 1, version, 0, 0, &[version; 8]);
+	let mut rig = si_cadence_rig(0x0011, 0x42, Duration::from_secs(10)).await;
+
+	rig.si_track
+		.write_frame(Timestamp::ZERO, Bytes::from(section(0)))
+		.unwrap();
+	assert_eq!(rig.media(1_000, 0x0011).await, 1, "lead emission");
+
+	rig.si_track
+		.write_frame(Timestamp::ZERO, Bytes::from(section(1)))
+		.unwrap();
+	assert_eq!(rig.media(2_500, 0x0011).await, 1, "revision after the floor");
+
+	// The next revision arrives on a frame stepping back behind the 2.5s anchor,
+	// like a B-frame emitted in decode order: no elapsed time, no emission.
+	rig.si_track
+		.write_frame(Timestamp::ZERO, Bytes::from(section(2)))
+		.unwrap();
+	assert_eq!(rig.media(2_400, 0x0011).await, 0, "a reordered frame earns no credit");
+
+	// The floor measures from the 2.5s anchor: not due at 3.4s, due at 3.5s.
+	assert_eq!(rig.media(3_400, 0x0011).await, 0, "still inside the floor");
+	assert_eq!(
+		rig.media(3_500, 0x0011).await,
+		1,
+		"the deferred revision rides the floor"
+	);
+}
+
+/// A publisher revising its snapshot before every frame must not drive the mux at
+/// that rate: revisions coalesce onto the revision floor, newest snapshot wins.
+/// The import side debounces its own cuts, but export consumes any catalog-named
+/// snapshot track, so the bound has to hold here too.
+#[tokio::test(start_paused = true)]
+async fn si_rapid_revisions_are_rate_bounded() {
+	let section = |version: u8| make_long_section(0x42, 1, version, 0, 0, &[version; 8]);
+	let mut rig = si_cadence_rig(0x0011, 0x42, Duration::from_secs(30)).await;
+
+	let mut emitted = 0;
+	for i in 0..13u8 {
+		rig.si_track
+			.write_frame(Timestamp::ZERO, Bytes::from(section(i)))
+			.unwrap();
+		let frames = rig.media_frames(u64::from(i) * 250).await;
+		let count = count_pid(&frames, 0x0011);
+		emitted += count;
+		if i == 4 {
+			// The 1s floor lapses here; the emission carries the newest revision,
+			// not the three that were coalesced over.
+			assert_eq!(count, 1, "the floored emission fires at 1s");
+			let needle = section(4);
+			assert!(
+				frames
+					.iter()
+					.any(|f| f.payload.windows(needle.len()).any(|w| w == needle)),
+				"the floored emission carries the newest revision"
+			);
+		}
+	}
+	assert_eq!(emitted, 4, "lead plus one per second, not one per revision");
 }
 
 /// Two captures overlapping on one broadcast (a supervisor restarting its

--- a/rs/moq-mux/src/container/ts/si.rs
+++ b/rs/moq-mux/src/container/ts/si.rs
@@ -465,7 +465,8 @@ impl<E: catalog::Catalog> Drop for Capture<E> {
 
 /// Export-side reduction of a snapshot track: frames apply in order, later-wins
 /// by sub-table identity. Reset per group (a group is a complete snapshot).
-#[derive(Default)]
+/// Equality is by content, so a re-published identical snapshot is not a change.
+#[derive(Default, PartialEq)]
 pub(super) struct Snapshot {
 	subs: BTreeMap<Identity, Vec<Bytes>>,
 }


### PR DESCRIPTION
## Root cause

SI emission was gated purely by `due()`: an entry's sections went out only when a media timestamp crossed an absolute `interval` slot boundary. For a latest-value slot holding a clock table (TDT/TOT, carried since #2929) that grid is wrong twice over, which is what #2934 measured:

- A revision arriving mid-slot waits for the boundary, so the asserted time is delivered up to a whole slot late (median 14.4 s at the 30 s TDT interval), and with a source cadence below the interval, half the ticks are dropped in favor of the newer one held.
- A source ticking slower than the grid gets its stored section re-sent on the boundary, asserting a time the wire already asserted: a receiver that set its clock from the first copy steps backwards.

As the issue puts it: for a static table any repetition carries the same information whenever it is sent, but for a clock the cadence *is* the information.

## Fix

Emission is now content-driven, with intervals as floors rather than an emission grid (the issue's suggested shape):

- `SiTrack` marks itself dirty when a promoted snapshot group differs from the active one (`Snapshot` gained content equality; a re-published identical snapshot is not a change). A dirty entry rides the next media frame once a 1 s revision floor (clamped to the entry's own interval) has elapsed since the entry last hit the wire; a deferred revision coalesces to the newest snapshot. The floor bounds a faulty or hostile publisher revising per-frame: the import-side `Capture` debounce cannot protect export, which consumes any catalog-named snapshot track.
- An *unchanged* entry repeats only once its full `interval` has elapsed since the last emission (`si_due`), which both satisfies the DVB maximum and stops a grid boundary shortly after a change emission from re-sending the sections as a near-immediate stale repeat.
- The emission anchor never moves backwards, and `si_due` saturates elapsed time, so a reordered (B-frame) timestamp below the anchor earns no emission credit.

`due()` (the absolute grid) still drives the PSI, where the grid is right: PAT/PMT are static and keyframe-anchored, and absolute slots keep redundant exporters byte-identical. For SI, the emissions that carry information (revisions) are driven by the broadcast content alone and stay aligned across exporters; only the placement of unchanged repeats is now phased by each exporter's own history, which is the trade the fix makes deliberately (documented on `si_due`).

## Tests

All fail on the old code:

- `si_revision_rides_the_next_frame`: a TDT-style short-form revision under a 30 s interval goes out with the next media frame instead of waiting ~27 s for the slot, and is not repeated afterwards within the floor.
- `si_repeats_are_floored_from_the_last_emission`: a mid-interval revision rides the revision floor (not the old grid slot), and the unchanged repeat follows a full interval after it.
- `si_reordered_frames_earn_no_emission_credit`: a revision arriving on a backward B-frame timestamp is deferred, and the floor keeps measuring from the forward anchor.
- `si_rapid_revisions_are_rate_bounded`: a publisher revising before every frame yields one emission per second, newest snapshot winning, not one per revision.
- `si_due_floors_repeats_from_the_last_emission`: unit coverage for the floor, reorder dips, and the zero-interval (every frame) case.

## Cross-package sync

No wire (MoQ) change and no catalog schema change, so no draft updates; the `mpegts.si` catalog section is untouched. No public API change (all crate-private). No docs describe the SI cadence. Targets `dev` because the TDT/TOT latest-value carriage this fixes landed there (#2929).

Closes #2934

(written by Fable 5)
