### PR TITLE
fix(relay): bound WebSocket sessions by their credential lifetime

### DIFF
--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -633,6 +633,17 @@ pub struct AuthToken {
 }
 
 impl AuthToken {
+	/// Wait until the backing credential expires, or forever when it has no expiry.
+	pub(crate) async fn expired(&self) {
+		match self.expires {
+			Some(expires) => {
+				let remaining = expires.duration_since(std::time::SystemTime::now()).unwrap_or_default();
+				tokio::time::sleep(remaining).await
+			}
+			None => std::future::pending().await,
+		}
+	}
+
 	/// Construct a token for a peer that was authenticated at the TLS layer
 	/// via mTLS. These peers are granted full publish and subscribe access
 	/// within `root`. The billing tier is left at the default; the caller (mTLS
@@ -1105,18 +1116,6 @@ impl Auth {
 		};
 
 		Self::finalize(&params.path, &params.path, claims)
-	}
-
-	/// Wait until `token`'s credential stops being valid: its JWT `exp` or client
-	/// cert `notAfter` passes. Pends forever for a token without an expiry.
-	pub async fn expired(&self, token: &AuthToken) {
-		match token.expires {
-			Some(expires) => {
-				let remaining = expires.duration_since(std::time::SystemTime::now()).unwrap_or_default();
-				tokio::time::sleep(remaining).await
-			}
-			None => std::future::pending().await,
-		}
 	}
 
 	/// Reduce verified `claims` into an [`AuthToken`].
@@ -3355,12 +3354,11 @@ api = "https://api.example.com/access"
 
 	#[tokio::test(start_paused = true)]
 	async fn expired_resolves_at_credential_expiry() {
-		let auth = Auth::default();
 		let mut token = AuthToken::unrestricted(Path::new("").to_owned());
 		token.expires = Some(std::time::SystemTime::now() + std::time::Duration::from_millis(100));
 
 		let start = tokio::time::Instant::now();
-		tokio::time::timeout(std::time::Duration::from_secs(5), auth.expired(&token))
+		tokio::time::timeout(std::time::Duration::from_secs(5), token.expired())
 			.await
 			.expect("an expiring credential must resolve the bound");
 		assert!(
@@ -3371,10 +3369,9 @@ api = "https://api.example.com/access"
 
 	#[tokio::test(start_paused = true)]
 	async fn expired_pends_without_an_expiry() {
-		let auth = Auth::default();
 		let token = AuthToken::unrestricted(Path::new("").to_owned());
 
-		let bounded = tokio::time::timeout(std::time::Duration::from_millis(200), auth.expired(&token)).await;
+		let bounded = tokio::time::timeout(std::time::Duration::from_millis(200), token.expired()).await;
 		assert!(bounded.is_err(), "a token without exp must never expire");
 	}
 }

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -1107,6 +1107,18 @@ impl Auth {
 		Self::finalize(&params.path, &params.path, claims)
 	}
 
+	/// Wait until `token`'s credential stops being valid: its JWT `exp` or client
+	/// cert `notAfter` passes. Pends forever for a token without an expiry.
+	pub async fn expired(&self, token: &AuthToken) {
+		match token.expires {
+			Some(expires) => {
+				let remaining = expires.duration_since(std::time::SystemTime::now()).unwrap_or_default();
+				tokio::time::sleep(remaining).await
+			}
+			None => std::future::pending().await,
+		}
+	}
+
 	/// Reduce verified `claims` into an [`AuthToken`].
 	///
 	/// [`Claims::authorize`](moq_token::Claims::authorize) does the overlap check and
@@ -3339,5 +3351,30 @@ api = "https://api.example.com/access"
 		})
 		.await;
 		assert!(result.is_err());
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn expired_resolves_at_credential_expiry() {
+		let auth = Auth::default();
+		let mut token = AuthToken::unrestricted(Path::new("").to_owned());
+		token.expires = Some(std::time::SystemTime::now() + std::time::Duration::from_millis(100));
+
+		let start = tokio::time::Instant::now();
+		tokio::time::timeout(std::time::Duration::from_secs(5), auth.expired(&token))
+			.await
+			.expect("an expiring credential must resolve the bound");
+		assert!(
+			start.elapsed() >= std::time::Duration::from_millis(100),
+			"resolved before expiry"
+		);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn expired_pends_without_an_expiry() {
+		let auth = Auth::default();
+		let token = AuthToken::unrestricted(Path::new("").to_owned());
+
+		let bounded = tokio::time::timeout(std::time::Duration::from_millis(200), auth.expired(&token)).await;
+		assert!(bounded.is_err(), "a token without exp must never expire");
 	}
 }

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -128,14 +128,9 @@ impl Connection {
 		// The credential (JWT `exp` or client cert `notAfter`) is only checked at
 		// connect time, so hold the session open no longer than the credential is
 		// valid. Without an expiry, just wait for the session to close.
-		let Some(expires) = token.expires else {
-			return Err(session.closed().await.into());
-		};
-
-		let remaining = expires.duration_since(std::time::SystemTime::now()).unwrap_or_default();
-		match tokio::time::timeout(remaining, session.closed()).await {
-			Ok(err) => Err(err.into()),
-			Err(_) => {
+		tokio::select! {
+			err = session.closed() => Err(err.into()),
+			_ = self.auth.expired(&token) => {
 				tracing::info!("credential expired, closing session");
 				session.abort(moq_net::Error::Unauthorized);
 				Ok(())

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -130,7 +130,7 @@ impl Connection {
 		// valid. Without an expiry, just wait for the session to close.
 		tokio::select! {
 			err = session.closed() => Err(err.into()),
-			_ = self.auth.expired(&token) => {
+			_ = token.expired() => {
 				tracing::info!("credential expired, closing session");
 				session.abort(moq_net::Error::Unauthorized);
 				Ok(())

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -73,7 +73,9 @@ pub(crate) async fn serve_ws(
 			subscribe,
 			stats,
 		};
-		let _ = handle_socket(socket, session).await;
+		let auth = state.auth.clone();
+		let expired = async move { auth.expired(&token).await };
+		let _ = handle_socket(socket, session, expired).await;
 	}))
 }
 
@@ -93,8 +95,10 @@ struct SessionInputs {
 	stats: Session,
 }
 
+/// Serve one upgraded WebSocket until it closes or `expired` (the session's
+/// credential bound, [`Auth::expired`]) resolves and aborts it with `Unauthorized`.
 #[tracing::instrument("ws", err, skip_all, fields(id = session.id))]
-async fn handle_socket<T>(socket: T, session: SessionInputs) -> anyhow::Result<()>
+async fn handle_socket<T>(socket: T, session: SessionInputs, expired: impl Future<Output = ()>) -> anyhow::Result<()>
 where
 	T: futures::Stream<Item = Result<tungstenite::Message, tungstenite::Error>>
 		+ futures::Sink<tungstenite::Message, Error = tungstenite::Error>
@@ -138,8 +142,17 @@ where
 		server = server.with_subscriber(publish);
 	}
 	// Hold the session so it doesn't close early; the driver serves it in place.
-	let (_session, driver) = server.accept(ws).await?;
-	driver.await.map_err(Into::into)
+	let (session, driver) = server.accept(ws).await?;
+	let mut driver = std::pin::pin!(driver);
+	tokio::select! {
+		res = &mut driver => res.map_err(Into::into),
+		_ = expired => {
+			tracing::info!("credential expired, closing session");
+			session.abort(moq_net::Error::Unauthorized);
+			// Drive the teardown so the close reaches the peer.
+			driver.await.map_err(Into::into)
+		}
+	}
 }
 
 /// Pick a subprotocol for the upgrade, or fail the handshake outright.
@@ -811,6 +824,7 @@ mod tests {
 		let server = tokio::spawn(handle_socket(
 			Pipe::new(server_incoming, server_to_client, frozen.clone()),
 			session,
+			std::future::pending::<()>(),
 		));
 
 		// A real qmux peer, so the transport handshake completes and its 10s

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -73,8 +73,7 @@ pub(crate) async fn serve_ws(
 			subscribe,
 			stats,
 		};
-		let auth = state.auth.clone();
-		let expired = async move { auth.expired(&token).await };
+		let expired = async move { token.expired().await };
 		let _ = handle_socket(socket, session, expired).await;
 	}))
 }
@@ -95,8 +94,7 @@ struct SessionInputs {
 	stats: Session,
 }
 
-/// Serve one upgraded WebSocket until it closes or `expired` (the session's
-/// credential bound, [`Auth::expired`]) resolves and aborts it with `Unauthorized`.
+/// Serve one upgraded WebSocket until it closes or its credential expires.
 #[tracing::instrument("ws", err, skip_all, fields(id = session.id))]
 async fn handle_socket<T>(socket: T, session: SessionInputs, expired: impl Future<Output = ()>) -> anyhow::Result<()>
 where

--- a/rs/moq-relay/tests/auth_lifetime.rs
+++ b/rs/moq-relay/tests/auth_lifetime.rs
@@ -1,0 +1,177 @@
+//! End-to-end test of the session credential bound through a real moq-relay.
+//!
+//! Stands up the relay's axum WebSocket path (`serve_ws`), connects a publisher
+//! and a subscriber with JWTs, confirms media flows, then asserts the relay
+//! closes the live sessions once the credential stops being valid.
+
+use std::{net::TcpListener, time::Duration};
+
+use moq_native::moq_net::{self, Origin};
+use moq_relay::{AuthConfig, Cluster, ClusterConfig, Web, WebConfig};
+use moq_token::{Algorithm, Key};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// An auth stack verifying JWTs with `key` alone. The key file is re-read per
+/// connection, so the returned guard must outlive the relay.
+async fn build_auth(key: &Key) -> (moq_relay::Auth, tempfile::NamedTempFile) {
+	let key_file = tempfile::NamedTempFile::new().expect("temp key file");
+	key.to_file(key_file.path()).expect("write key");
+	let mut auth_config = AuthConfig::default();
+	auth_config.key = Some(key_file.path().to_string_lossy().into_owned());
+	let auth = auth_config
+		.init(&moq_native::tls::Client::default())
+		.await
+		.expect("auth init");
+	(auth, key_file)
+}
+
+/// Wait for a TCP listener to become dialable, or panic.
+async fn wait_for_listener(port: u16) {
+	let deadline = std::time::Instant::now() + Duration::from_secs(5);
+	while tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_err() {
+		assert!(
+			std::time::Instant::now() < deadline,
+			"relay listener never became ready on port {port}"
+		);
+		tokio::time::sleep(Duration::from_millis(25)).await;
+	}
+}
+
+/// Stand up the relay's axum web stack with WebSocket enabled and return the
+/// port plus an abort handle.
+async fn spawn_ws_relay(auth: moq_relay::Auth) -> (u16, tokio::task::JoinHandle<()>) {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
+	let port = probe.local_addr().expect("local addr").port();
+	drop(probe);
+
+	let cluster = Cluster::new(ClusterConfig::default()).expect("cluster init");
+
+	// Stream listeners bind lazily, so this server never opens a socket; only
+	// its certificate handle is used.
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.tcp.bind = Some("127.0.0.1:0".parse().expect("parse addr"));
+	let certificates = server_config.init().expect("server init").certificates();
+
+	let mut web_config = WebConfig::default();
+	web_config.ws = true;
+	web_config.http.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
+	let web = Web::new(auth, cluster, certificates, web_config);
+
+	let handle = tokio::spawn(async move {
+		let _ = web.run().await;
+	});
+
+	wait_for_listener(port).await;
+
+	(port, handle)
+}
+
+fn client() -> moq_native::Client {
+	let mut config = moq_native::ClientConfig::default();
+	config.tls.disable_verify = Some(true);
+	config.bind = "127.0.0.1:0".parse().expect("parse bind");
+	config.websocket.delay = None;
+	config.init().expect("client init")
+}
+
+/// Full access under the `room` root.
+fn room_claims() -> moq_token::Claims {
+	moq_token::Claims::default()
+		.with_root("room")
+		.with_subscribe([""])
+		.with_publish([""])
+}
+
+/// A relay URL for the `/room` root carrying a freshly minted JWT.
+fn room_url(scheme: &str, port: u16, key: &Key, claims: &moq_token::Claims) -> url::Url {
+	let jwt = key.sign(claims).expect("sign token");
+	format!("{scheme}://127.0.0.1:{port}/room?jwt={jwt}")
+		.parse()
+		.expect("parse url")
+}
+
+/// Connect a publisher and a subscriber to `url` and prove one frame
+/// round-trips. Returns both sessions so the caller can watch them close.
+async fn connect_and_round_trip(url: &url::Url) -> (moq_net::Session, moq_net::Session) {
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin
+		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
+		.expect("create broadcast");
+	let mut track = broadcast.create_track("video", None).expect("create track");
+	let mut group = track.append_group().expect("append group");
+	group
+		.write_frame(moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
+	group.finish().expect("finish group");
+
+	let pub_session = tokio::time::timeout(
+		TIMEOUT,
+		client().with_publisher(pub_origin.consume()).connect(url.clone()),
+	)
+	.await
+	.expect("publisher connect timeout")
+	.expect("publisher connect failed");
+
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume().announced();
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url.clone()))
+		.await
+		.expect("subscriber connect timeout")
+		.expect("subscriber connect failed");
+
+	let moq_net::announce::Update { path, broadcast: bc } = tokio::time::timeout(TIMEOUT, announcements.next())
+		.await
+		.expect("announcement timeout")
+		.expect("origin closed");
+	assert_eq!(path.as_str(), "test");
+	let bc = bc.expect("expected announce, got unannounce");
+
+	let mut track_sub = bc.track("video").unwrap().subscribe(None).await.expect("consume_track");
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
+		.await
+		.expect("recv_group timeout")
+		.expect("recv_group failed")
+		.expect("track closed prematurely");
+	let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())
+		.await
+		.expect("read_frame timeout")
+		.expect("read_frame failed")
+		.expect("group closed prematurely");
+	assert_eq!(&frame.payload[..], b"hello");
+
+	drop(track);
+	drop(broadcast);
+
+	(pub_session, sub_session)
+}
+
+/// WebSocket sessions close at their token's `exp`.
+#[tokio::test]
+async fn ws_expired_token_closes_live_sessions() {
+	let key = Key::generate(Algorithm::HS256, None).expect("generate key");
+	let (auth, _key_file) = build_auth(&key).await;
+	let (port, relay) = spawn_ws_relay(auth).await;
+
+	let claims = room_claims().with_expires(std::time::SystemTime::now() + Duration::from_secs(2));
+	let admitted = std::time::Instant::now();
+	let (pub_session, sub_session) = connect_and_round_trip(&room_url("ws", port, &key, &claims)).await;
+
+	tokio::time::timeout(Duration::from_secs(6), pub_session.closed())
+		.await
+		.expect("relay should close the publisher WS session once its token expires");
+	tokio::time::timeout(Duration::from_secs(6), sub_session.closed())
+		.await
+		.expect("relay should close the subscriber WS session once its token expires");
+
+	// `exp` has whole-second granularity, so the close lands in roughly [1.5s, 2.5s].
+	let elapsed = admitted.elapsed();
+	assert!(
+		elapsed >= Duration::from_secs(1),
+		"sessions closed before the token's exp: {elapsed:?}"
+	);
+
+	relay.abort();
+}


### PR DESCRIPTION
## Summary

- Root cause: `serve_ws` verifies the token at the WebSocket upgrade and then serves the session with no time bound, while the native accept path (`Connection::run`) closes a session at its JWT `exp` / client cert `notAfter`. A WebSocket client therefore kept its access for as long as it kept the connection open.
- Keep the credential bound on `AuthToken` as an internal expiry future and select on it from both accept paths. `handle_socket` aborts with `Unauthorized` like the native path and drives the teardown so the close reaches the peer.
- mTLS WebSocket sessions still carry no expiry: the axum layer surfaces only certificate presence, not `notAfter`.

## Public API changes

- None. The credential-expiry helper is internal to `moq-relay`.

## Test plan

- New `rs/moq-relay/tests/auth_lifetime.rs`: stands up the axum WebSocket path against a static `--auth-key`, round-trips a frame, asserts both sessions close at the token's `exp`. Fails without the fix (WS sessions stay open).
- Unit tests on the internal `AuthToken::expired` helper (resolves at `exp`, pends without a bound).
- `just check origin/main` and `just test default origin/main`: clean.

Cross-Package Sync: no `doc/bin/relay/` change; the auth docs already describe `exp` as the session bound, and WebSocket now matches.

(Written by GPT-5)