### PR TITLE
perf(moq-net): hand lite group chunks to the transport by reference

### DIFF
--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1,7 +1,6 @@
 use crate::{announce, frame, group, origin, track};
 use std::{sync::Arc, task::Poll, time::Duration};
 
-use bytes::Buf;
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use web_transport_trait::Stats;
 
@@ -2285,18 +2284,15 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		self.track_priority_seen
 	}
 
-	/// Write a whole chunk, applying priority changes between partial writes.
+	/// Write a whole chunk at the current priority.
 	async fn write_chunk(
 		&mut self,
 		stream: &mut Writer<S::SendStream, Version>,
 		priority: &mut PriorityHandle,
-		mut chunk: bytes::Bytes,
+		chunk: bytes::Bytes,
 	) -> Result<(), Error> {
-		while chunk.has_remaining() {
-			self.apply_priority(stream, priority);
-			stream.write(&mut chunk).await?;
-		}
-		Ok(())
+		self.apply_priority(stream, priority);
+		stream.write_chunk(chunk).await
 	}
 
 	fn apply_priority(&mut self, stream: &mut Writer<S::SendStream, Version>, priority: &mut PriorityHandle) {


### PR DESCRIPTION
## Summary

- The lite publisher wrote each frame chunk through the generic `Buf` write, which reaches the transport as a slice write that it copies into its send queue. `Writer::write_chunk(Bytes)` hands the chunk over by reference count, so a frame travels from the producer to the QUIC send queue without a copy. The IETF publisher already writes chunks this way.
- Priority changes still apply while waiting for the next chunk; one that lands while the transport drains a chunk now takes effect at the next chunk boundary rather than between partial writes of the same chunk, which is where the IETF path applies them too.

## Public API changes

- None (private `Publisher::write_chunk` in `rs/moq-net/src/lite`). No wire change, so no `js/net` row.

## Test plan

- `cargo test -p moq-net` (lib and doctests), `cargo clippy -p moq-net --all-targets`, `cargo fmt --check`: clean.

(Written by Claude Fable 5)
