### PR TITLE
fix(js/net): keep a republished broadcast when its predecessor closes

### DIFF
--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -9,6 +9,7 @@ import type * as Cluster from "./cluster.ts";
 import { PublishNamespace } from "./publish_namespace.ts";
 import { Publisher } from "./publisher.ts";
 import { RequestError, RequestOk } from "./request.ts";
+import { Subscribe, SubscribeOk } from "./subscribe.ts";
 import { SubscribeNamespace } from "./subscribe_namespace.ts";
 import { ALPN, Version } from "./version.ts";
 
@@ -372,5 +373,35 @@ test("an advertisement carries our hop id once the peer declared one", async () 
 		}
 
 		pub.close();
+	}
+});
+
+test("a same-tick republish survives its predecessor closing", async () => {
+	const pair = createMockTransportPair(ALPN.DRAFT_19);
+	const pub = publisher(pair.server);
+	const path = Path.from("test");
+
+	const first = new BroadcastProducer();
+	pub.publish(path, first);
+	first.close();
+
+	const second = new BroadcastProducer();
+	second.createTrack("video");
+	pub.publish(path, second);
+
+	await first.closed;
+
+	const client = await Stream.open(pair.client);
+	const server = await nextStream(pair.server);
+	if (!server) throw new Error("publisher never accepted the subscribe stream");
+
+	const msg = new Subscribe({ requestId: 0n, trackNamespace: path, trackName: "video", subscriberPriority: 0 });
+	void pub.runSubscribe(msg, server);
+
+	try {
+		expect(await client.reader.u53()).toBe(SubscribeOk.id);
+	} finally {
+		pub.close();
+		client.close();
 	}
 });

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -123,10 +123,12 @@ export class Publisher {
 			broadcasts.set(path, broadcast);
 		});
 
-		// Remove the broadcast from the lookup when it's closed.
+		// Remove the broadcast from the lookup when it's closed, unless the path was republished.
 		void broadcast.closed.then(() => {
 			this.#broadcasts.mutate((broadcasts) => {
-				broadcasts?.delete(path);
+				if (broadcasts?.get(path) === broadcast) {
+					broadcasts.delete(path);
+				}
 			});
 		});
 	}

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -620,3 +620,40 @@ test("runProbe rounds a fractional smoothedRtt instead of killing the stream", a
 		await probing;
 	}
 });
+
+test("a same-tick republish survives its predecessor closing", async () => {
+	const pair = createMockTransportPair(ALPN_05);
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin());
+	const path = Path.from("test");
+
+	const first = new BroadcastProducer();
+	publisher.publish(path, first);
+	first.close();
+
+	const second = new BroadcastProducer();
+	const track = second.createTrack("video");
+	publisher.publish(path, second);
+
+	await first.closed;
+
+	const client = await Stream.open(pair.client);
+	const server = await Stream.accept(pair.server);
+	if (!server) throw new Error("publisher never accepted the subscribe stream");
+
+	const msg = new Subscribe({ id: 0n, broadcast: path, track: "video", priority: 0 });
+	void publisher.runSubscribe(msg, server);
+
+	const group = new GroupProducer(0);
+	group.writeString("hello");
+	group.close();
+	track.writeGroup(group);
+	track.close();
+
+	try {
+		const resp = await decodeSubscribeResponse(client.reader, Version.DRAFT_05);
+		expect("start" in resp || "end" in resp).toBe(true);
+	} finally {
+		publisher.close();
+		client.close();
+	}
+});

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -130,10 +130,12 @@ export class Publisher {
 			broadcasts.set(path, broadcast);
 		});
 
-		// Remove the broadcast from the lookup when it's closed.
+		// Remove the broadcast from the lookup when it's closed, unless the path was republished.
 		void broadcast.closed.then(() => {
 			this.#broadcasts.mutate((broadcasts) => {
-				broadcasts?.delete(path);
+				if (broadcasts?.get(path) === broadcast) {
+					broadcasts.delete(path);
+				}
 			});
 		});
 	}


### PR DESCRIPTION
## Summary

- Root cause: `Publisher.publish` registers `broadcast.closed.then(...)` to delete the path from the lookup. The handler settles a tick after `close()`, so closing a broadcast and publishing a successor on the same path in one tick leaves the successor in the map only until the predecessor's handler runs and evicts it; subscribes then answer "not found" while the producer believes it is live.
- Delete the entry only when it still holds the broadcast that closed. Both the lite and IETF publishers carry the same handler and get the same guard.

## Public API changes

- None.

## Test plan

- New test in `js/net/src/lite/publisher.test.ts` and `js/net/src/ietf/publisher.test.ts`: close and republish on one path in the same tick, let the close settle, subscribe and expect the successor to answer. Both fail without the guard.
- `bun test` on both files, `biome check`, `bun run check` in `js/net`: clean.

Cross-Package Sync: no `rs/moq-net` mirror; the Rust publisher serves from the `Origin` and has no per-publish close handler to race.

(Written by Claude Fable 5)
