### PR TITLE
fix(tokio): refuse a listen address an existing reuseport group holds

### DIFF
--- a/rs/moq-tokio/src/error.rs
+++ b/rs/moq-tokio/src/error.rs
@@ -122,6 +122,18 @@ pub enum Error {
 		first: std::net::SocketAddr,
 	},
 
+	/// Another worker group already holds this listen port.
+	///
+	/// A second group on an overlapping address would silently join the first's
+	/// `SO_REUSEPORT` group and break its steering, so the port is locked while
+	/// the first is alive, whatever the address: a group on a different address
+	/// sharing the port is refused too.
+	#[error("another QUIC worker group already holds port {}", addr.port())]
+	WorkerOverlap {
+		/// The address this group asked for.
+		addr: std::net::SocketAddr,
+	},
+
 	/// The worker group's listen address did not resolve.
 	///
 	/// Resolved once for the whole group, so a DNS answer that rotates between

--- a/rs/moq-tokio/src/steer.rs
+++ b/rs/moq-tokio/src/steer.rs
@@ -48,6 +48,23 @@ use crate::listen::Shard;
 /// kernel identifies a member by its position in the group, which is the order
 /// the sockets bound. An unsharded bind is the plain one.
 pub(crate) fn bind(addr: SocketAddr, shard: Option<Shard>) -> io::Result<UdpSocket> {
+	// The first member probes with a plain bind before the group forms.
+	// `SO_REUSEPORT` groups by address and UID, so a member would otherwise
+	// *join* any group a same-UID process already has on the address, as two
+	// relays overlapping in a rolling restart do: the old group's filter keeps
+	// steering every packet to the old process, the new group reports ready
+	// while serving nothing, and the old process exiting renumbers the
+	// survivors. A plain bind refuses a held port outright, which turns that
+	// overlap back into the `AddrInUse` startup failure it is everywhere else.
+	//
+	// The probe only sees a group that is already bound. Two processes
+	// *constructing* concurrently could each probe while the other holds
+	// nothing yet, which is what [`Lock`] excludes; the probe's job is the
+	// holder the lock cannot see, one that predates it or never took it.
+	if shard.is_some_and(|shard| shard.index() == 0) {
+		drop(crate::bind::udp(crate::bind::Udp::new(addr))?);
+	}
+
 	let options = crate::bind::Udp::new(addr).with_reuse_port(shard.is_some());
 	let socket = crate::bind::udp(options)?;
 
@@ -59,6 +76,197 @@ pub(crate) fn bind(addr: SocketAddr, shard: Option<Shard>) -> io::Result<UdpSock
 	}
 
 	Ok(socket)
+}
+
+/// Holds a listen port for one worker group's lifetime.
+///
+/// The [`bind`] probe refuses an address whose group is already *bound*, but
+/// two processes constructing concurrently could each probe while the other
+/// holds nothing yet, then both join one interleaved reuseport group. This is
+/// the exclusion the probe cannot provide: an `flock`ed file named by the
+/// port, taken before the first member binds and released by the kernel with
+/// the file descriptor, so the lock cannot go stale and dies with its process.
+///
+/// Keyed by the port alone, because every address space that can overlap on a
+/// port must share one lock: `[::]` (dual-stack), `0.0.0.0`, and any specific
+/// address all conflict with each other, and giving each spelling a lock of
+/// its own would let two of them construct concurrently and race the probe.
+/// The price is over-exclusion: two same-UID groups on *distinct* specific
+/// addresses sharing a port, or in distinct network namespaces sharing this
+/// filesystem, are refused although they could coexist. That failure is loud
+/// and names the port; the alternative failure was silent traffic loss.
+///
+/// The file lives in a directory only this UID can write ([`dir`]), which is
+/// what makes the lock immune to other users: a reuseport group only admits
+/// same-UID sockets, so same-UID is exactly the set that must be excluded,
+/// and no other user can touch the lock to deny it. When no such directory
+/// can be had, the lock is skipped with a warning rather than refusing to
+/// start, and the probe carries the remaining risk.
+pub(crate) struct Lock {
+	#[cfg(target_os = "linux")]
+	_file: std::fs::File,
+}
+
+impl Lock {
+	/// Take the lock for `port`. An error always means another group holds it;
+	/// lock infrastructure that is missing or broken (no protected directory,
+	/// an unwritable file) skips the lock with a warning and returns `Ok(None)`,
+	/// preferring to start on probe-only protection over refusing to start.
+	///
+	/// Elsewhere than Linux this is a no-op: the platform refuses the reuseport
+	/// bind itself, so there is nothing to exclude.
+	pub(crate) fn acquire(port: u16) -> io::Result<Option<Self>> {
+		#[cfg(target_os = "linux")]
+		{
+			use std::os::unix::fs::OpenOptionsExt;
+
+			let Some(dir) = dir() else {
+				return Ok(None);
+			};
+
+			// Mode 0600 and O_NOFOLLOW are defense in depth: the directory is
+			// verified accessible to this UID alone, so nobody else can reach the
+			// file (an exclusive flock needs no write access, so a readable lock
+			// file would be deniable), and a symlink here would be our own doing.
+			// O_NONBLOCK keeps a planted FIFO from hanging the open; on a regular
+			// file it does nothing.
+			let path = dir.join(format!("quic-workers-{port}.lock"));
+			let file = match std::fs::OpenOptions::new()
+				.write(true)
+				.create(true)
+				.truncate(false)
+				.mode(0o600)
+				.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+				.open(&path)
+			{
+				Ok(file) => file,
+				Err(err) => {
+					tracing::warn!(?path, %err, "cannot open the lock file; worker overlap detection falls back to the bind probe");
+					return Ok(None);
+				}
+			};
+
+			// `mode` above only applies when the open creates the file, so verify
+			// and normalize what was actually opened, through the descriptor
+			// rather than the path: an inode that predates this directory's
+			// lockdown could still be reachable by another user, and an exclusive
+			// flock on it needs no write access.
+			{
+				use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+				let euid = unsafe { libc::geteuid() };
+				let trusted = file.metadata().is_ok_and(|meta| meta.is_file() && meta.uid() == euid);
+				if !trusted || file.set_permissions(std::fs::Permissions::from_mode(0o600)).is_err() {
+					tracing::warn!(
+						?path,
+						"the lock file is not exclusively ours; worker overlap detection falls back to the bind probe"
+					);
+					return Ok(None);
+				}
+			}
+
+			// SAFETY: `file` is an open descriptor for the duration of the call.
+			let res = unsafe { libc::flock(std::os::fd::AsRawFd::as_raw_fd(&file), libc::LOCK_EX | libc::LOCK_NB) };
+			if res == 0 {
+				return Ok(Some(Self { _file: file }));
+			}
+
+			let err = io::Error::last_os_error();
+			if err.kind() == io::ErrorKind::WouldBlock {
+				return Err(err);
+			}
+			tracing::warn!(?path, %err, "cannot lock the lock file; worker overlap detection falls back to the bind probe");
+			Ok(None)
+		}
+		#[cfg(not(target_os = "linux"))]
+		{
+			let _ = port;
+			Ok(None)
+		}
+	}
+}
+
+/// A directory only this UID can write, for the group locks. `None` disables
+/// locking with a warning rather than trusting a directory another user could
+/// tamper with.
+///
+/// `XDG_RUNTIME_DIR` is preferred: per-UID, mode 0700, and living with the
+/// session is exactly the shape the lock wants. But it is an environment
+/// variable, not a guarantee, so its candidate is verified exactly like the
+/// temp-dir fallback rather than trusted, and a bad value falls through to
+/// the fallback instead of costing more protection than no value at all.
+#[cfg(target_os = "linux")]
+fn dir() -> Option<std::path::PathBuf> {
+	if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR").filter(|dir| !dir.is_empty())
+		&& let Some(dir) = prepare(std::path::PathBuf::from(runtime).join("moq"))
+	{
+		return Some(dir);
+	}
+
+	let euid = unsafe { libc::geteuid() };
+	prepare(std::env::temp_dir().join(format!("moq-{euid}")))
+}
+
+/// Create `dir` with mode 0700 if missing, then verify it is a directory this
+/// UID alone can reach. `/tmp` is world-writable and `XDG_RUNTIME_DIR` is only
+/// an environment variable, so the name could already be held by another
+/// user's file or symlink, and trusting it would hand them the lock.
+///
+/// The parent is checked first: it must be sticky (an entry in `/tmp` can only
+/// be renamed or unlinked by its owner) or writable by this UID alone, or
+/// another user could rename the verified directory out from under its path
+/// and split two groups onto different lock files. Components above the
+/// parent are the operator's: a runtime directory placed inside another
+/// user's tree is a misconfiguration no check here can launder.
+#[cfg(target_os = "linux")]
+fn prepare(dir: std::path::PathBuf) -> Option<std::path::PathBuf> {
+	use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+
+	let euid = unsafe { libc::geteuid() };
+	let parent = dir
+		.parent()
+		.and_then(|parent| std::fs::symlink_metadata(parent).ok())
+		.is_some_and(|meta| {
+			let mode = meta.permissions().mode();
+			// A trusted owner first: the parent's owner can rename entries
+			// regardless of the sticky bit, so an arbitrary user's 1777
+			// directory protects nothing while root's /tmp does. Then either
+			// sticky (other writers cannot touch entries they do not own) or
+			// no other writers at all.
+			let owner = meta.uid() == euid || meta.uid() == 0;
+			meta.is_dir() && owner && (mode & 0o1000 != 0 || mode & 0o022 == 0)
+		});
+	if !parent {
+		tracing::warn!(
+			?dir,
+			"the lock directory's parent cannot protect it; worker overlap detection falls back to the bind probe"
+		);
+		return None;
+	}
+
+	let created = std::fs::DirBuilder::new().mode(0o700).create(&dir);
+	if let Err(err) = &created
+		&& err.kind() != io::ErrorKind::AlreadyExists
+	{
+		tracing::warn!(?dir, %err, "cannot create a lock directory; worker overlap detection falls back to the bind probe");
+		return None;
+	}
+
+	// `symlink_metadata` so a symlink is seen as itself and fails `is_dir`,
+	// rather than being followed to wherever it points. No group or world
+	// access at all: an exclusive flock needs no write access, so even a
+	// readable lock file would let another user deny the port.
+	let safe = std::fs::symlink_metadata(&dir)
+		.map(|meta| meta.is_dir() && meta.uid() == euid && meta.permissions().mode() & 0o077 == 0)
+		.unwrap_or(false);
+	if !safe {
+		tracing::warn!(
+			?dir,
+			"lock directory is not exclusively ours; worker overlap detection falls back to the bind probe"
+		);
+		return None;
+	}
+	Some(dir)
 }
 
 /// The first byte of a connection ID issued by `shard`.

--- a/rs/moq-tokio/src/worker.rs
+++ b/rs/moq-tokio/src/worker.rs
@@ -83,6 +83,11 @@ pub struct Workers {
 	workers: Vec<Worker>,
 	certificates: crate::tls::Certificates,
 	addr: SocketAddr,
+
+	/// Holds the listen port against a second group for as long as this one
+	/// lives. `None` for an ephemeral port, or when no lock directory was
+	/// available and the group started on probe-only protection.
+	_lock: Option<crate::steer::Lock>,
 }
 
 impl std::fmt::Debug for Workers {
@@ -125,14 +130,30 @@ impl Workers {
 		// One resolution for the whole group. Each worker resolves its own config
 		// otherwise, so a DNS answer that rotates between queries would hand
 		// members different addresses and fail the bind on whichever member drew a
-		// fresh one. An unset `bind` stays unset: the backends fall back to a
-		// literal default, and `Some` here would flip a stream-only config into
+		// fresh one. An unset `bind` stays unset: the backends fall back to the
+		// default literal, and `Some` here would flip a stream-only config into
 		// opening a QUIC listener.
 		let mut listen = listen;
-		if let Some(bind) = listen.bind.as_deref() {
-			let addr = crate::util::resolve(Some(bind), bind).map_err(|err| Error::WorkerResolve(Arc::new(err)))?;
-			listen.bind = Some(addr.to_string());
-		}
+		let requested = match listen.bind.as_deref() {
+			Some(bind) => {
+				let addr = crate::util::resolve(Some(bind), bind).map_err(|err| Error::WorkerResolve(Arc::new(err)))?;
+				listen.bind = Some(addr.to_string());
+				addr
+			}
+			None => crate::server::DEFAULT_BIND
+				.parse()
+				.expect("the default bind is a literal"),
+		};
+
+		// Two groups constructing concurrently would each pass the bind-time
+		// probe before either holds the port, then interleave into one reuseport
+		// group, so the port is locked before the first member binds and held
+		// until the group is gone. An ephemeral port has nothing to lock: only a
+		// lone worker may use one, and its port cannot be named in advance.
+		let lock = match requested.port() {
+			0 => None,
+			port => crate::steer::Lock::acquire(port).map_err(|_| Error::WorkerOverlap { addr: requested })?,
+		};
 
 		let mut workers = Vec::with_capacity(count as usize);
 		let mut certificates = None;
@@ -180,6 +201,7 @@ impl Workers {
 			// answers for the fingerprint endpoint.
 			certificates: certificates.expect("at least one worker"),
 			addr,
+			_lock: lock,
 		})
 	}
 

--- a/rs/moq-tokio/tests/worker.rs
+++ b/rs/moq-tokio/tests/worker.rs
@@ -116,6 +116,117 @@ async fn an_ephemeral_port_is_refused() {
 	);
 }
 
+/// `SO_REUSEPORT` groups by address and UID, so a second group on a served
+/// address would silently join the first, as two relays overlapping in a rolling
+/// restart do: the old group's filter keeps steering every packet to the old
+/// process while the new one reports ready and serves nothing. The group locks
+/// its address for its lifetime, which turns the overlap back into the loud
+/// startup failure it is without workers.
+#[tokio::test]
+async fn an_occupied_port_is_refused() {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (cert, key) = certificate(dir.path());
+	let port = free_udp_port();
+
+	let workers =
+		Workers::bind(listen_config(&cert, &key, port), Default::default(), config(WORKERS)).expect("bind workers");
+
+	let err = Workers::bind(listen_config(&cert, &key, port), Default::default(), config(WORKERS))
+		.expect_err("a second group must not join the first");
+	assert!(
+		matches!(err, moq_tokio::Error::WorkerOverlap { .. }),
+		"unexpected error: {err}"
+	);
+
+	// The lock and the probe must be gone with the group: a second group takes
+	// the same address cleanly once the first shuts down.
+	workers.shutdown().await;
+	let again = Workers::bind(listen_config(&cert, &key, port), Default::default(), config(WORKERS))
+		.expect("the released address must be bindable again");
+	drop(again);
+}
+
+/// A dual-stack `[::]` group and a `0.0.0.0` group overlap on IPv4, so both
+/// spellings must share one lock: constructing them concurrently under
+/// different locks would silently strip the dual-stack group's IPv4 side. The
+/// lock has to catch this, not the probe, so the error is asserted exactly.
+#[tokio::test]
+async fn the_other_wildcard_spelling_is_refused() {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (cert, key) = certificate(dir.path());
+	let port = free_udp_port();
+
+	let mut v4 = listen_config(&cert, &key, port);
+	v4.bind = Some(format!("0.0.0.0:{port}"));
+	let workers = Workers::bind(v4, Default::default(), config(WORKERS)).expect("bind v4 wildcard workers");
+
+	let mut v6 = listen_config(&cert, &key, port);
+	v6.bind = Some(format!("[::]:{port}"));
+	let err = Workers::bind(v6, Default::default(), config(WORKERS))
+		.expect_err("the overlapping wildcard spelling must be refused");
+	assert!(
+		matches!(err, moq_tokio::Error::WorkerOverlap { .. }),
+		"unexpected error: {err}"
+	);
+
+	drop(workers);
+}
+
+/// The lock is keyed by port alone, so a group on a *different* address sharing
+/// the port is refused too. Deliberate over-exclusion: wildcard and specific
+/// addresses overlap in ways a per-address lock cannot serialize, and this
+/// failure is loud and names the port, while the failure it prevents was
+/// silent traffic loss. Asserted exactly so the lock, not the probe, catches it
+/// (the probe would let two specific addresses coexist).
+#[tokio::test]
+async fn a_shared_port_is_refused_across_addresses() {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (cert, key) = certificate(dir.path());
+	let port = free_udp_port();
+
+	let workers =
+		Workers::bind(listen_config(&cert, &key, port), Default::default(), config(WORKERS)).expect("bind workers");
+
+	// A distinct loopback address: no bind conflict with 127.0.0.1, only the
+	// shared port.
+	let mut other = listen_config(&cert, &key, port);
+	other.bind = Some(format!("127.0.0.2:{port}"));
+	let err = Workers::bind(other, Default::default(), config(WORKERS))
+		.expect_err("a second group sharing the port must be refused");
+	assert!(
+		matches!(err, moq_tokio::Error::WorkerOverlap { .. }),
+		"unexpected error: {err}"
+	);
+
+	drop(workers);
+}
+
+/// The lifetime lock only excludes groups that take it, so a reuseport member
+/// bound by something else entirely, a relay predating the lock or an unrelated
+/// same-UID process, is caught by the first member's plain-bind probe instead:
+/// a plain bind refuses a port any socket holds, reuseport or not.
+#[tokio::test]
+async fn a_foreign_reuseport_group_is_refused() {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (cert, key) = certificate(dir.path());
+
+	// A reuseport socket bound outside any worker group, holding no lock.
+	let foreign = moq_tokio::bind::udp(moq_tokio::bind::Udp::new("127.0.0.1:0".parse().unwrap()).with_reuse_port(true))
+		.expect("bind foreign reuseport socket");
+	let port = foreign.local_addr().expect("local addr").port();
+
+	Workers::bind(listen_config(&cert, &key, port), Default::default(), config(WORKERS))
+		.expect_err("a group must not join a foreign reuseport member");
+}
+
 /// A bind that fails midway drops the members it already spawned, and the error
 /// must not return before their sockets are closed: an owner that immediately
 /// rebinds the address would otherwise join the half-dead reuseport group and be


### PR DESCRIPTION
Fixes #2960. Targets `dev` because the worker mode only exists there (#2921).

## Root cause

`SO_REUSEPORT` groups sockets by `(address, port)` and effective UID, so a worker group binding an address a same-UID process already serves *joins* that process's group instead of failing. Two relays overlapping in a rolling restart hit exactly that:

1. The old group holds positions `0..N-1` with a cBPF filter reducing modulo N.
2. The new group's sockets take positions `N..2N-1` and attach a filter of their own, but a reuseport filter covers the whole group, and both reduce modulo N, so every packet keeps selecting the *old* members.
3. The new relay reports ready while serving nothing, and the old process exiting renumbers the survivors out from under every connection ID already issued against them.

Without workers the same overlap is a loud `EADDRINUSE` and the new process exits, which is the behavior this restores.

## Fix: a group-lifetime lock, plus a probe

Two mechanisms, because neither is sufficient alone:

- **A group-lifetime lock**: an `flock`ed file keyed by the port, taken before the first member binds and released by the kernel with the descriptor, so it cannot go stale and dies with its process. This is what excludes two groups *constructing concurrently*: a probe alone races there, since both processes can probe and release before either binds, and preemption makes that window unbounded (caught in review by Codex). A second group fails with a dedicated `WorkerOverlap` error naming the port.

  Two design points, both from review rounds that broke earlier shapes of this lock (an abstract-namespace socket keyed by address):

  - **Port-only keying.** Every address space that can overlap on a port (`[::]` dual-stack, `0.0.0.0`, any specific address) shares one lock, so no two spellings can construct concurrently under different keys. The trade is over-exclusion: two same-UID groups on *distinct* addresses sharing a port are refused although they could coexist. That refusal is loud and names the port; the failure it prevents was silent traffic loss.
  - **A permission-protected home.** The file lives in a directory only this UID can write (`XDG_RUNTIME_DIR`, else a verified 0700 per-UID temp dir). A reuseport group only admits same-UID sockets, so same-UID is exactly the set the lock must exclude, and filesystem permissions mean no other user can squat or tamper with it to deny startup (the flaw of the abstract-namespace approach, which has no permission checks). If no protected directory can be had, the group starts on probe-only protection with a warning rather than refusing to start.

- **A plain-bind probe** by the first member, for holders the lock cannot see: a relay predating this fix, or an unrelated same-UID process. A plain bind refuses a port any socket holds, reuseport or not, so an already-bound foreign group is refused with the same `AddrInUse` as everywhere else.

The group also resolves its listen address once up front, so the lock, the probe, and every member agree on the address a rotating DNS answer could otherwise split. An ephemeral port takes no lock: only a lone worker may use one, and its port cannot be named in advance.

The eBPF `SK_REUSEPORT` + `SOCKARRAY` selector from #2875 remains the structural fix (selection by map slot survives membership changes entirely); until then, the silent-failure case is closed rather than mitigated.

## Testing

Each mechanism is independently mutation-checked on Linux. Neutering the lock fails exactly the three lock tests (same address, the other wildcard spelling, a distinct address sharing the port; that run visibly formed the silent second group the lock exists to prevent), and removing the probe fails the foreign-group test:

- `an_occupied_port_is_refused`: a second group on a served address fails with `WorkerOverlap`, and binds cleanly again after the first group shuts down (the lock dies with its group). **With the lock neutered, this test fails.**
- `a_foreign_reuseport_group_is_refused`: a reuseport socket bound outside any group (no lock held) is refused by the probe. **With the probe removed, this test fails** because the group silently joins the foreign member.

New tests also cover the wildcard-spelling refusal and the deliberate distinct-address-same-port over-exclusion. All 11 worker integration tests, all 207 `moq-tokio` lib tests (steering end-to-end included), and the relay's `runtime_workers` integration test pass in a container on kernel 6.19 aarch64. `just check` and `just test` (1917 tests) pass on macOS.

## Cross-package sync

No wire change (`drafts/` untouched), no `moq-ffi` surface change, no CLI change. `doc/bin/relay/config.md` needs no update: the fix removes a hazard rather than adding behavior, restoring parity with the non-worker path.

Found in passing, filed separately: #2979 (`moq-tokio --no-default-features` does not compile on `dev`, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Fable 5)
