### PR TITLE
feat(moq-gst): let sink pads name the track they publish

### DIFF
--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -239,6 +239,26 @@ The first pad of each kind is always `video_0` / `audio_0` regardless of catalog
 | Audio | MP3   | `audio/mpeg` (v1/v2, layer 3) |
 | Audio | Opus  | `audio/x-opus`        |
 
+Each `sink_%u` request pad publishes one track. By default the track is named after its codec
+(`0.avc3`, `0.aac`, and so on) and the catalog advertises that name. To choose the name, set the pad's
+`track` property through `GstChildProxy`:
+
+```bash
+gst-launch-1.0 -v -e \
+  multifilesrc location=bbb.mp4 loop=true ! parsebin name=parse \
+    parse. ! queue ! identity sync=true ! mux.sink_0 \
+    parse. ! queue ! identity sync=true ! mux.sink_1 \
+  moqsink name=mux url=http://localhost:4443 broadcast=bbb.hang \
+    sink_0::track=camera sink_1::track=commentary
+```
+
+`track` is writable in any state until the pad's CAPS event reserves the track, so a pad requested
+while the pipeline runs can still be named before its first buffer. From then on it reads back the
+reserved name, the generated one included, and further writes are ignored with a warning; stopping the
+element (back to `READY`) releases the reservation and makes it writable again. An empty string keeps
+the generated name. A name another pad already holds invalidates only that pad, so the rest of the
+broadcast keeps publishing.
+
 ### moqsrc (subscribe)
 
 Outputs the same caps based on the catalog, compatible with `decodebin3`.

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -319,7 +319,8 @@ impl ElementImpl for MoqSink {
 	fn release_pad(&self, pad: &gst::Pad) {
 		// CAPS takes the pad lock before the element state lock. Keep the same order here so a CAPS
 		// handler cannot insert a producer after this removal.
-		let reservation = pad.downcast_ref::<MoqSinkPad>().map(MoqSinkPad::reserve_track);
+		let sink_pad = pad.downcast_ref::<MoqSinkPad>();
+		let retirement = sink_pad.map(MoqSinkPad::retire_track);
 		{
 			let _rt = RUNTIME.enter();
 			if let Some(state) = self.state.lock().unwrap().as_mut() {
@@ -334,11 +335,14 @@ impl ElementImpl for MoqSink {
 		}
 		// The producer is gone, so the pad no longer holds a reservation: an application
 		// keeping the released pad reads what it asked for, not a name nothing publishes.
-		if let Some(reservation) = reservation {
-			reservation.release();
+		if let Some(retirement) = retirement {
+			retirement.release();
 		}
 		if self.obj().remove_pad(pad).is_ok() {
 			self.obj().child_removed(pad, pad.name().as_str());
+		}
+		if let Some(sink_pad) = sink_pad {
+			sink_pad.finish_release();
 		}
 		// Removing a still-active pad can leave only already-ended pads, which now satisfies EOS.
 		self.maybe_post_eos();
@@ -461,7 +465,9 @@ impl MoqSink {
 					return false;
 				}
 				if let Some(sink_pad) = pad.downcast_ref::<MoqSinkPad>() {
-					let reservation = sink_pad.reserve_track();
+					let Some(reservation) = sink_pad.reserve_track() else {
+						return false;
+					};
 					let reserved = {
 						let _rt = RUNTIME.enter();
 						let mut guard = self.state.lock().unwrap();

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -17,6 +17,7 @@ use gst::subclass::prelude::*;
 use hang::moq_net;
 
 use super::pad::{Pad, caps_supported};
+use super::request_pad::MoqSinkPad;
 use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session};
 
 #[derive(Debug, Clone, Default)]
@@ -110,6 +111,7 @@ impl ObjectSubclass for MoqSink {
 	const NAME: &'static str = "MoqSink";
 	type Type = super::MoqSink;
 	type ParentType = gst::Element;
+	type Interfaces = (gst::ChildProxy,);
 }
 
 impl ObjectImpl for MoqSink {
@@ -204,6 +206,26 @@ impl ObjectImpl for MoqSink {
 
 impl GstObjectImpl for MoqSink {}
 
+/// Request pads are reachable as children, which is how a pipeline description names their tracks
+/// (`moqsink sink_0::track=camera`).
+impl ChildProxyImpl for MoqSink {
+	fn children_count(&self) -> u32 {
+		self.obj().num_pads() as u32
+	}
+
+	fn child_by_name(&self, name: &str) -> Option<glib::Object> {
+		self.obj().static_pad(name).map(|pad| pad.upcast())
+	}
+
+	fn child_by_index(&self, index: u32) -> Option<glib::Object> {
+		self.obj()
+			.pads()
+			.into_iter()
+			.nth(index as usize)
+			.map(|pad| pad.upcast())
+	}
+}
+
 impl ElementImpl for MoqSink {
 	fn metadata() -> Option<&'static gst::subclass::ElementMetadata> {
 		static METADATA: LazyLock<gst::subclass::ElementMetadata> = LazyLock::new(|| {
@@ -269,16 +291,20 @@ impl ElementImpl for MoqSink {
 		// Wrap both pad functions in catch_panic_pad_function: these run on the streaming thread across the
 		// C FFI boundary, and they hit `state.lock().unwrap()` (poisonable) and `expect()`. An escaping
 		// panic would abort the process; here it becomes a clean FlowError / `false` instead.
-		let pad_builder = gst::Pad::builder_from_template(templ)
+		let pad_builder = gst::PadBuilder::<MoqSinkPad>::from_template(templ)
 			.chain_function(|pad, parent, buffer| {
 				MoqSink::catch_panic_pad_function(
 					parent,
 					|| Err(gst::FlowError::Error),
-					|this| this.forward_buffer(pad, buffer),
+					|this| this.forward_buffer(pad.upcast_ref::<gst::Pad>(), buffer),
 				)
 			})
 			.event_function(|pad, parent, event| {
-				MoqSink::catch_panic_pad_function(parent, || false, |this| this.handle_event(pad, event))
+				MoqSink::catch_panic_pad_function(
+					parent,
+					|| false,
+					|this| this.handle_event(pad.upcast_ref::<gst::Pad>(), event),
+				)
 			});
 
 		let pad = match name {
@@ -286,7 +312,8 @@ impl ElementImpl for MoqSink {
 			None => pad_builder.generated_name().build(),
 		};
 		self.obj().add_pad(&pad).ok()?;
-		Some(pad)
+		self.obj().child_added(&pad, pad.name().as_str());
+		Some(pad.upcast())
 	}
 
 	fn release_pad(&self, pad: &gst::Pad) {
@@ -302,7 +329,14 @@ impl ElementImpl for MoqSink {
 				state.ended.remove(name.as_str());
 			}
 		}
-		let _ = self.obj().remove_pad(pad);
+		// The producer is gone, so the pad no longer holds a reservation: an application
+		// keeping the released pad reads what it asked for, not a name nothing publishes.
+		if let Some(pad) = pad.downcast_ref::<MoqSinkPad>() {
+			pad.release_track();
+		}
+		if self.obj().remove_pad(pad).is_ok() {
+			self.obj().child_removed(pad, pad.name().as_str());
+		}
 		// Removing a still-active pad can leave only already-ended pads, which now satisfies EOS.
 		self.maybe_post_eos();
 	}
@@ -353,6 +387,12 @@ impl MoqSink {
 		// warning) before reaping the session task.
 		state.broadcast.finish();
 		state.session.stop();
+		// The producers are gone, so each pad's name is configurable again for the next run.
+		for pad in self.obj().sink_pads() {
+			if let Some(pad) = pad.downcast_ref::<MoqSinkPad>() {
+				pad.release_track();
+			}
+		}
 	}
 
 	/// Write one buffer straight into its pad's producer. Per-pad failures (bad caps/bitstream) drop
@@ -417,19 +457,28 @@ impl MoqSink {
 					gst::warning!(CAT, "rejecting unsupported caps on pad {}", pad.name());
 					return false;
 				}
-				let _rt = RUNTIME.enter();
-				if let Some(state) = self.state.lock().unwrap().as_mut() {
-					let State {
-						broadcast,
-						catalog,
-						pads,
-						..
-					} = state;
-					if let Some(catalog) = catalog.as_ref() {
+				let sink_pad = pad.downcast_ref::<MoqSinkPad>();
+				let requested = sink_pad.and_then(MoqSinkPad::requested_track);
+				let reserved = {
+					let _rt = RUNTIME.enter();
+					let mut guard = self.state.lock().unwrap();
+					guard.as_mut().and_then(|state| {
+						let State {
+							broadcast,
+							catalog,
+							pads,
+							..
+						} = state;
+						let catalog = catalog.as_ref()?;
 						pads.entry(pad.name().to_string())
 							.or_insert_with(Pad::new)
-							.observe_caps(broadcast, catalog, &caps);
-					}
+							.observe_caps(broadcast, catalog, &caps, requested.as_deref())
+					})
+				};
+				// A notify handler can read this pad, so the reserved name is published with the state
+				// lock released.
+				if let (Some(sink_pad), Some(track)) = (sink_pad, reserved) {
+					sink_pad.commit_track(track);
 				}
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -317,6 +317,9 @@ impl ElementImpl for MoqSink {
 	}
 
 	fn release_pad(&self, pad: &gst::Pad) {
+		// CAPS takes the pad lock before the element state lock. Keep the same order here so a CAPS
+		// handler cannot insert a producer after this removal.
+		let reservation = pad.downcast_ref::<MoqSinkPad>().map(MoqSinkPad::reserve_track);
 		{
 			let _rt = RUNTIME.enter();
 			if let Some(state) = self.state.lock().unwrap().as_mut() {
@@ -331,8 +334,8 @@ impl ElementImpl for MoqSink {
 		}
 		// The producer is gone, so the pad no longer holds a reservation: an application
 		// keeping the released pad reads what it asked for, not a name nothing publishes.
-		if let Some(pad) = pad.downcast_ref::<MoqSinkPad>() {
-			pad.release_track();
+		if let Some(reservation) = reservation {
+			reservation.release();
 		}
 		if self.obj().remove_pad(pad).is_ok() {
 			self.obj().child_removed(pad, pad.name().as_str());

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -417,6 +417,9 @@ impl MoqSink {
 		})?;
 		let data = Bytes::copy_from_slice(map.as_slice());
 		drop(map);
+		let Some(activity) = pad.downcast_ref::<MoqSinkPad>().and_then(MoqSinkPad::reserve_track) else {
+			return Err(gst::FlowError::Flushing);
+		};
 
 		// Producer writes can touch tokio time (group eviction), so hold the runtime context here.
 		let _rt = RUNTIME.enter();
@@ -441,6 +444,7 @@ impl MoqSink {
 
 		let no_segment = media.push_buffer(data, pts);
 		drop(guard);
+		drop(activity);
 
 		if no_segment {
 			gst::element_warning!(
@@ -456,6 +460,9 @@ impl MoqSink {
 	}
 
 	fn handle_event(&self, pad: &gst::Pad, event: gst::Event) -> bool {
+		let Some(reservation) = pad.downcast_ref::<MoqSinkPad>().and_then(MoqSinkPad::reserve_track) else {
+			return false;
+		};
 		match event.view() {
 			gst::EventView::Caps(caps) => {
 				let caps = caps.caps().to_owned();
@@ -464,29 +471,24 @@ impl MoqSink {
 					gst::warning!(CAT, "rejecting unsupported caps on pad {}", pad.name());
 					return false;
 				}
-				if let Some(sink_pad) = pad.downcast_ref::<MoqSinkPad>() {
-					let Some(reservation) = sink_pad.reserve_track() else {
-						return false;
-					};
-					let reserved = {
-						let _rt = RUNTIME.enter();
-						let mut guard = self.state.lock().unwrap();
-						guard.as_mut().and_then(|state| {
-							let State {
-								broadcast,
-								catalog,
-								pads,
-								..
-							} = state;
-							let catalog = catalog.as_ref()?;
-							pads.entry(pad.name().to_string())
-								.or_insert_with(Pad::new)
-								.observe_caps(broadcast, catalog, &caps, reservation.requested())
-						})
-					};
-					if let Some(track) = reserved {
-						reservation.commit(track);
-					}
+				let reserved = {
+					let _rt = RUNTIME.enter();
+					let mut guard = self.state.lock().unwrap();
+					guard.as_mut().and_then(|state| {
+						let State {
+							broadcast,
+							catalog,
+							pads,
+							..
+						} = state;
+						let catalog = catalog.as_ref()?;
+						pads.entry(pad.name().to_string())
+							.or_insert_with(Pad::new)
+							.observe_caps(broadcast, catalog, &caps, reservation.requested())
+					})
+				};
+				if let Some(track) = reserved {
+					reservation.commit(track);
 				}
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
@@ -498,10 +500,12 @@ impl MoqSink {
 						.or_insert_with(Pad::new)
 						.observe_segment(segment.segment().to_owned());
 				}
+				drop(reservation);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
 			gst::EventView::Eos(_) => {
 				self.handle_eos(pad);
+				drop(reservation);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
 			// FLUSH_STOP re-anchors the timeline; the trailing SEGMENT is accepted fresh. The producer is
@@ -512,9 +516,14 @@ impl MoqSink {
 				{
 					media.flush();
 				}
+				drop(reservation);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
-			_ => gst::Pad::event_default(pad, Some(&*self.obj()), event),
+			_ => {
+				let handled = gst::Pad::event_default(pad, Some(&*self.obj()), event);
+				drop(reservation);
+				handled
+			}
 		}
 	}
 

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -457,28 +457,23 @@ impl MoqSink {
 					gst::warning!(CAT, "rejecting unsupported caps on pad {}", pad.name());
 					return false;
 				}
-				let sink_pad = pad.downcast_ref::<MoqSinkPad>();
-				let requested = sink_pad.and_then(MoqSinkPad::requested_track);
-				let reserved = {
-					let _rt = RUNTIME.enter();
-					let mut guard = self.state.lock().unwrap();
-					guard.as_mut().and_then(|state| {
-						let State {
-							broadcast,
-							catalog,
-							pads,
-							..
-						} = state;
-						let catalog = catalog.as_ref()?;
-						pads.entry(pad.name().to_string())
-							.or_insert_with(Pad::new)
-							.observe_caps(broadcast, catalog, &caps, requested.as_deref())
-					})
-				};
-				// A notify handler can read this pad, so the reserved name is published with the state
-				// lock released.
-				if let (Some(sink_pad), Some(track)) = (sink_pad, reserved) {
-					sink_pad.commit_track(track);
+				if let Some(sink_pad) = pad.downcast_ref::<MoqSinkPad>() {
+					sink_pad.reserve_track(|requested| {
+						let _rt = RUNTIME.enter();
+						let mut guard = self.state.lock().unwrap();
+						guard.as_mut().and_then(|state| {
+							let State {
+								broadcast,
+								catalog,
+								pads,
+								..
+							} = state;
+							let catalog = catalog.as_ref()?;
+							pads.entry(pad.name().to_string())
+								.or_insert_with(Pad::new)
+								.observe_caps(broadcast, catalog, &caps, requested)
+						})
+					});
 				}
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -458,7 +458,8 @@ impl MoqSink {
 					return false;
 				}
 				if let Some(sink_pad) = pad.downcast_ref::<MoqSinkPad>() {
-					sink_pad.reserve_track(|requested| {
+					let reservation = sink_pad.reserve_track();
+					let reserved = {
 						let _rt = RUNTIME.enter();
 						let mut guard = self.state.lock().unwrap();
 						guard.as_mut().and_then(|state| {
@@ -471,9 +472,12 @@ impl MoqSink {
 							let catalog = catalog.as_ref()?;
 							pads.entry(pad.name().to_string())
 								.or_insert_with(Pad::new)
-								.observe_caps(broadcast, catalog, &caps, requested)
+								.observe_caps(broadcast, catalog, &caps, reservation.requested())
 						})
-					});
+					};
+					if let Some(track) = reserved {
+						reservation.commit(track);
+					}
 				}
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}

--- a/rs/moq-gst/src/sink/mod.rs
+++ b/rs/moq-gst/src/sink/mod.rs
@@ -3,6 +3,7 @@ use gst::prelude::*;
 
 mod imp;
 mod pad;
+mod request_pad;
 mod session;
 mod timeline;
 
@@ -12,7 +13,9 @@ pub use session::ConnectionStatus;
 glib::wrapper! {
 	/// The `moqsink` element: publishes its `sink_%u` pads as a single MoQ broadcast, writing each pad's
 	/// frames directly into the moq producers from its streaming thread (no intermediate queue).
-	pub struct MoqSink(ObjectSubclass<imp::MoqSink>) @extends gst::Element, gst::Object;
+	pub struct MoqSink(ObjectSubclass<imp::MoqSink>)
+		@extends gst::Element, gst::Object,
+		@implements gst::ChildProxy;
 }
 
 pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -60,21 +60,27 @@ impl Pad {
 		self.failed
 	}
 
-	/// (Re)build the producer when the pad's caps change. A build failure invalidates only this pad
-	/// (`failed` is set); the caller keeps the session and other pads alive. Identical caps re-sent as a
+	/// (Re)build the producer when the pad's caps change, under `track` when the pad was given a name.
+	/// Returns the name the broadcast reserved, so the caller can publish it. A build failure invalidates
+	/// only this pad; the caller keeps the session and other pads alive. Identical caps re-sent as a
 	/// sticky event keep the live producer.
 	pub fn observe_caps(
 		&mut self,
 		broadcast: &moq_net::broadcast::Producer,
 		catalog: &moq_mux::catalog::Producer,
 		caps: &gst::Caps,
-	) {
+		track: Option<&str>,
+	) -> Option<String> {
 		if self.failed || (self.track.is_some() && self.caps.as_deref() == Some(caps)) {
-			return;
+			return None;
 		}
-		if let Err(err) = self.build(broadcast, catalog, caps) {
-			gst::warning!(CAT, "invalidating pad: {err:?}");
-			self.fail();
+		match self.build(broadcast, catalog, caps, track) {
+			Ok(name) => Some(name),
+			Err(err) => {
+				gst::warning!(CAT, "invalidating pad: {err:?}");
+				self.fail();
+				None
+			}
 		}
 	}
 
@@ -83,7 +89,8 @@ impl Pad {
 		broadcast: &moq_net::broadcast::Producer,
 		catalog: &moq_mux::catalog::Producer,
 		caps: &gst::Caps,
-	) -> Result<()> {
+		requested: Option<&str>,
+	) -> Result<String> {
 		let structure = caps.structure(0).context("empty caps")?;
 		// Renegotiation: finalize the previous producer before replacing it (closed once, not abandoned).
 		self.finalize()?;
@@ -92,14 +99,14 @@ impl Pad {
 		// Every codec converges on one import::Track; only the caps -> importer construction differs. The
 		// pad template fixes the structural fields (h264/h265 byte-stream/au, AAC mpegversion=4/stream-format=raw),
 		// so negotiation rejects non-conforming caps before they reach here; only fields the template can't
-		// pin (the AAC codec_data) are checked below. The importer reserves a uniquely named track, which it
+		// pin (the AAC codec_data) are checked below. The importer reserves the pad's track, which it
 		// accepts (setting the timescale) inside `Track::new`.
-		let track: import::Track = match structure.name().as_str() {
-			"video/x-h264" => Self::reserve(&mut broadcast, catalog, ".avc3", "avc3", &[])?,
-			"video/x-h265" => Self::reserve(&mut broadcast, catalog, ".hev1", "hev1", &[])?,
-			"video/x-av1" => Self::reserve(&mut broadcast, catalog, ".av01", "av01", &[])?,
-			"video/x-vp8" => Self::reserve(&mut broadcast, catalog, ".vp8", "vp8", &[])?,
-			"video/x-vp9" => Self::reserve(&mut broadcast, catalog, ".vp9", "vp9", &[])?,
+		let (track, name): (import::Track, String) = match structure.name().as_str() {
+			"video/x-h264" => Self::reserve(&mut broadcast, catalog, requested, ".avc3", "avc3", &[])?,
+			"video/x-h265" => Self::reserve(&mut broadcast, catalog, requested, ".hev1", "hev1", &[])?,
+			"video/x-av1" => Self::reserve(&mut broadcast, catalog, requested, ".av01", "av01", &[])?,
+			"video/x-vp8" => Self::reserve(&mut broadcast, catalog, requested, ".vp8", "vp8", &[])?,
+			"video/x-vp9" => Self::reserve(&mut broadcast, catalog, requested, ".vp9", "vp9", &[])?,
 			// MP3: no config blob to parse (the config lives in each frame header), so the importer is
 			// built straight from the caps rate/channels. Keyed on `layer == 3`, which positively
 			// identifies Layer III: AAC (`audio/mpeg`, no layer field) and MP2 (`layer=2`) fall through
@@ -115,10 +122,13 @@ impl Pad {
 				};
 				// MP3 builds its config from caps, so like Opus it constructs the codec importer
 				// directly and lifts it into a `Track` via `.into()`.
-				let name = broadcast.unique_name(".mp3");
-				let request = broadcast.reserve_track(name)?;
+				let name = Self::track_name(&broadcast, requested, ".mp3");
+				let request = broadcast.reserve_track(name.clone())?;
 				let producer = request.accept(hang::container::track_info());
-				moq_mux::codec::mp3::Import::new(producer, catalog.reserve(), config.into())?.into()
+				(
+					moq_mux::codec::mp3::Import::new(producer, catalog.reserve(), config.into())?.into(),
+					name,
+				)
 			}
 			"audio/mpeg" => {
 				// AAC: the AudioSpecificConfig rides in caps as codec_data, not in the bitstream.
@@ -126,7 +136,7 @@ impl Pad {
 					.get::<gst::Buffer>("codec_data")
 					.context("AAC caps missing codec_data")?;
 				let map = codec_data.map_readable().context("failed to map AAC codec_data")?;
-				Self::reserve(&mut broadcast, catalog, ".aac", "aac", map.as_slice())?
+				Self::reserve(&mut broadcast, catalog, requested, ".aac", "aac", map.as_slice())?
 			}
 			"audio/x-opus" => {
 				// Opus: GStreamer carries channels/rate in caps (not an OpusHead), and valid Opus caps
@@ -143,34 +153,45 @@ impl Pad {
 				let config = moq_mux::codec::opus::Config::new(rate as u32, channels as u32);
 				// Opus builds its config from caps (not an OpusHead init buffer), so it constructs the codec
 				// importer directly and lifts it into a `Track` via `.into()`.
-				let name = broadcast.unique_name(".opus");
-				let request = broadcast.reserve_track(name)?;
+				let name = Self::track_name(&broadcast, requested, ".opus");
+				let request = broadcast.reserve_track(name.clone())?;
 				let producer = request.accept(hang::container::track_info());
-				moq_mux::codec::opus::Import::new(producer, catalog.reserve(), config.into())?.into()
+				(
+					moq_mux::codec::opus::Import::new(producer, catalog.reserve(), config.into())?.into(),
+					name,
+				)
 			}
 			other => anyhow::bail!("unsupported caps: {other}"),
 		};
 		self.track = Some(track);
 		self.caps = Some(caps.clone());
-		Ok(())
+		Ok(name)
 	}
 
-	/// Reserve a uniquely named track and hand it to the single-codec importer, which accepts the request
+	/// The name this pad publishes under: the one it was given, else a generated `0{suffix}`.
+	fn track_name(broadcast: &moq_net::broadcast::Producer, requested: Option<&str>, suffix: &str) -> String {
+		requested
+			.map(str::to_owned)
+			.unwrap_or_else(|| broadcast.unique_name(suffix))
+	}
+
+	/// Reserve the pad's track and hand it to the single-codec importer, which accepts the request
 	/// (setting the microsecond timescale) and registers the catalog rendition once the config resolves.
+	/// Returns the reserved name alongside the importer.
 	fn reserve(
 		broadcast: &mut moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer,
+		requested: Option<&str>,
 		suffix: &str,
 		format: &str,
 		init: &[u8],
-	) -> Result<import::Track> {
-		let name = broadcast.unique_name(suffix);
-		let request = broadcast.reserve_track(name)?;
-		Ok(import::Track::new(
-			request,
-			catalog.reserve(),
-			import::Init::new(format, init.to_vec()),
-		)?)
+	) -> Result<(import::Track, String)> {
+		let name = Self::track_name(broadcast, requested, suffix);
+		let request = broadcast.reserve_track(name.clone())?;
+		Ok((
+			import::Track::new(request, catalog.reserve(), import::Init::new(format, init.to_vec()))?,
+			name,
+		))
 	}
 
 	/// Drops the producer (closing its track) and marks the pad failed so further buffers are dropped.
@@ -379,10 +400,88 @@ mod tests {
 		gst::init().unwrap();
 		let (broadcast, catalog) = producers();
 		let mut pad = Pad::new();
-		pad.observe_caps(&broadcast, &catalog, &h264_caps());
+		pad.observe_caps(&broadcast, &catalog, &h264_caps(), None);
 		assert!(!pad.is_failed());
 		assert!(pad.finalize().unwrap(), "a producer was built");
 		assert!(!pad.finalize().unwrap(), "second finalize is a no-op");
+	}
+
+	// A named pad reserves that track instead of the generated one, and the catalog advertises the same
+	// name (the rendition resolves off the SPS, so it needs one AU).
+	#[test]
+	fn an_explicit_name_reaches_the_broadcast_and_the_catalog() {
+		gst::init().unwrap();
+		let (broadcast, catalog) = producers();
+		let mut pad = Pad::new();
+		assert_eq!(
+			pad.observe_caps(&broadcast, &catalog, &h264_caps(), Some("camera")),
+			Some("camera".to_string()),
+			"the reserved name is the requested one"
+		);
+		pad.observe_segment(time_segment());
+		pad.push_buffer(h264_keyframe_au(), Some(gst::ClockTime::ZERO));
+
+		let snapshot = catalog.snapshot();
+		let renditions: Vec<String> = snapshot.video.renditions.keys().map(|name| name.to_string()).collect();
+		assert_eq!(renditions, ["camera"], "the catalog advertises the explicit name");
+	}
+
+	// Without a name the generated one is kept, and it is reported so the element can publish it.
+	#[test]
+	fn a_generated_name_is_reported_too() {
+		gst::init().unwrap();
+		let (broadcast, catalog) = producers();
+		let mut pad = Pad::new();
+		assert_eq!(
+			pad.observe_caps(&broadcast, &catalog, &h264_caps(), None),
+			Some("0.avc3".to_string())
+		);
+	}
+
+	// A name another pad already holds invalidates only the second pad: the broadcast, the catalog and
+	// the first pad's producer survive.
+	#[test]
+	fn a_colliding_name_invalidates_only_that_pad() {
+		gst::init().unwrap();
+		let (broadcast, catalog) = producers();
+		let mut first = Pad::new();
+		let mut second = Pad::new();
+		assert_eq!(
+			first.observe_caps(&broadcast, &catalog, &h264_caps(), Some("camera")),
+			Some("camera".to_string())
+		);
+		assert_eq!(
+			second.observe_caps(&broadcast, &catalog, &h264_caps(), Some("camera")),
+			None,
+			"the duplicate reservation is rejected"
+		);
+		assert!(second.is_failed(), "the collision fails the second pad");
+		assert!(!first.is_failed(), "the first pad keeps its producer");
+		assert!(first.finalize().unwrap(), "the first producer is still live");
+	}
+
+	// Renegotiation re-reserves the same explicit name. `build` finalizes the old producer first and the
+	// broadcast reclaims closed entries on insert, so the pad does not collide with itself.
+	#[test]
+	fn renegotiation_keeps_the_explicit_name() {
+		gst::init().unwrap();
+		let (broadcast, catalog) = producers();
+		let mut pad = Pad::new();
+		assert_eq!(
+			pad.observe_caps(&broadcast, &catalog, &h264_caps(), Some("camera")),
+			Some("camera".to_string())
+		);
+		let renegotiated = gst::Caps::builder("video/x-h264")
+			.field("stream-format", "byte-stream")
+			.field("alignment", "au")
+			.field("width", 1280i32)
+			.build();
+		assert_eq!(
+			pad.observe_caps(&broadcast, &catalog, &renegotiated, Some("camera")),
+			Some("camera".to_string()),
+			"the same name is reserved again, not rejected as a duplicate"
+		);
+		assert!(!pad.is_failed());
 	}
 
 	// AAC carries its config in caps; without codec_data the producer cannot be built.
@@ -395,7 +494,7 @@ mod tests {
 			.field("mpegversion", 4i32)
 			.field("stream-format", "raw")
 			.build();
-		pad.observe_caps(&broadcast, &catalog, &caps);
+		pad.observe_caps(&broadcast, &catalog, &caps, None);
 		assert!(pad.is_failed(), "AAC without codec_data fails the pad");
 	}
 
@@ -407,7 +506,7 @@ mod tests {
 		let (broadcast, catalog) = producers();
 		let mut pad = Pad::new();
 		let caps = gst::Caps::builder("audio/x-opus").field("rate", 48_000i32).build();
-		pad.observe_caps(&broadcast, &catalog, &caps);
+		pad.observe_caps(&broadcast, &catalog, &caps, None);
 		assert!(pad.is_failed(), "Opus without channels fails the pad");
 	}
 
@@ -418,7 +517,7 @@ mod tests {
 		gst::init().unwrap();
 		let (broadcast, catalog) = producers();
 		let mut pad = Pad::new();
-		pad.observe_caps(&broadcast, &catalog, &h264_caps());
+		pad.observe_caps(&broadcast, &catalog, &h264_caps(), None);
 		// No observe_segment: the pad stays in NoSegment.
 		assert!(
 			pad.push_buffer(h264_keyframe_au(), Some(gst::ClockTime::ZERO)),
@@ -436,7 +535,7 @@ mod tests {
 		gst::init().unwrap();
 		let (broadcast, catalog) = producers();
 		let mut pad = Pad::new();
-		pad.observe_caps(&broadcast, &catalog, &gst::Caps::builder("video/x-raw").build());
+		pad.observe_caps(&broadcast, &catalog, &gst::Caps::builder("video/x-raw").build(), None);
 		assert!(pad.is_failed());
 	}
 
@@ -446,7 +545,7 @@ mod tests {
 		gst::init().unwrap();
 		let (broadcast, catalog) = producers();
 		let mut pad = Pad::new();
-		pad.observe_caps(&broadcast, &catalog, &gst::Caps::builder("video/x-raw").build());
+		pad.observe_caps(&broadcast, &catalog, &gst::Caps::builder("video/x-raw").build(), None);
 		assert!(pad.is_failed());
 		pad.observe_segment(time_segment());
 		pad.push_buffer(Bytes::from_static(b"x"), Some(gst::ClockTime::ZERO));
@@ -458,7 +557,7 @@ mod tests {
 		gst::init().unwrap();
 		let (broadcast, catalog) = producers();
 		let mut pad = Pad::new();
-		pad.observe_caps(&broadcast, &catalog, &h264_caps());
+		pad.observe_caps(&broadcast, &catalog, &h264_caps(), None);
 		pad.observe_segment(time_segment());
 		pad.push_buffer(h264_keyframe_au(), Some(gst::ClockTime::ZERO));
 
@@ -605,7 +704,7 @@ mod tests {
 		gst::init().unwrap();
 		let (broadcast, catalog) = producers();
 		let mut pad = Pad::new();
-		pad.observe_caps(&broadcast, &catalog, &h264_caps());
+		pad.observe_caps(&broadcast, &catalog, &h264_caps(), None);
 		pad.observe_segment(time_segment());
 
 		pad.flush();

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -1,7 +1,7 @@
 //! The `sink_%u` request pad as its own GObject, so the track it publishes can be named from a
 //! pipeline description through `GstChildProxy` (`moqsink sink_0::track=camera`).
 
-use std::sync::{LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use gst::glib;
 use gst::prelude::*;
@@ -23,6 +23,31 @@ struct Settings {
 #[derive(Debug, Default)]
 pub struct MoqSinkPadImp {
 	settings: Mutex<Settings>,
+}
+
+/// A pending track reservation that serializes property writes until it is committed or dropped.
+pub(super) struct TrackReservation<'a> {
+	pad: &'a MoqSinkPad,
+	settings: MutexGuard<'a, Settings>,
+}
+
+impl TrackReservation<'_> {
+	/// The name configured when this reservation began.
+	pub(super) fn requested(&self) -> Option<&str> {
+		self.settings.requested.as_deref()
+	}
+
+	/// Fix the property to the name the broadcast reserved, then notify after releasing the lock.
+	pub(super) fn commit(self, track: String) {
+		let TrackReservation { pad, mut settings } = self;
+		let before = settings.effective.clone().or_else(|| settings.requested.clone());
+		settings.effective = Some(track);
+		let changed = before != settings.effective;
+		drop(settings);
+		if changed {
+			pad.notify("track");
+		}
+	}
 }
 
 #[glib::object_subclass]
@@ -96,18 +121,11 @@ glib::wrapper! {
 }
 
 impl MoqSinkPad {
-	/// Reserve a track under the configured name and fix the property for the producer's lifetime.
-	pub(super) fn reserve_track(&self, reserve: impl FnOnce(Option<&str>) -> Option<String>) {
-		let mut settings = self.imp().settings.lock().unwrap();
-		let before = settings.effective.clone().or_else(|| settings.requested.clone());
-		let Some(track) = reserve(settings.requested.as_deref()) else {
-			return;
-		};
-		settings.effective = Some(track);
-		let changed = before != settings.effective;
-		drop(settings);
-		if changed {
-			self.notify("track");
+	/// Lock the configured name until the caller commits or abandons its track reservation.
+	pub(super) fn reserve_track(&self) -> TrackReservation<'_> {
+		TrackReservation {
+			pad: self,
+			settings: self.imp().settings.lock().unwrap(),
 		}
 	}
 
@@ -136,17 +154,23 @@ mod tests {
 			.build();
 		pad.set_property("track", "camera");
 
-		pad.reserve_track(|requested| {
-			assert_eq!(requested, Some("camera"));
-			let pad = pad.clone();
-			assert!(
-				std::thread::spawn(move || pad.imp().settings.try_lock().is_err())
-					.join()
-					.unwrap(),
-				"a concurrent property write cannot enter during reservation"
-			);
-			Some("camera".to_string())
-		});
+		let abandoned = pad.reserve_track();
+		assert_eq!(abandoned.requested(), Some("camera"));
+		drop(abandoned);
+		pad.set_property("track", "other");
+		assert_eq!(pad.property::<String>("track"), "other");
+		pad.set_property("track", "camera");
+
+		let reservation = pad.reserve_track();
+		assert_eq!(reservation.requested(), Some("camera"));
+		let other = pad.clone();
+		assert!(
+			std::thread::spawn(move || other.imp().settings.try_lock().is_err())
+				.join()
+				.unwrap(),
+			"a concurrent property write cannot enter during reservation"
+		);
+		reservation.commit("camera".to_string());
 
 		pad.set_property("track", "other");
 		pad.release_track();

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -48,6 +48,17 @@ impl TrackReservation<'_> {
 			pad.notify("track");
 		}
 	}
+
+	/// Drop the effective name, then notify after releasing the lock.
+	pub(super) fn release(self) {
+		let TrackReservation { pad, mut settings } = self;
+		let before = settings.effective.take();
+		let changed = before.is_some() && before != settings.requested;
+		drop(settings);
+		if changed {
+			pad.notify("track");
+		}
+	}
 }
 
 #[glib::object_subclass]
@@ -132,13 +143,7 @@ impl MoqSinkPad {
 	/// Drop the reserved name once its producer is finalized, so the pad is configurable again on the
 	/// next run. The requested name stays: that run reserves the same one.
 	pub(super) fn release_track(&self) {
-		let mut settings = self.imp().settings.lock().unwrap();
-		let before = settings.effective.take();
-		let changed = before.is_some() && before != settings.requested;
-		drop(settings);
-		if changed {
-			self.notify("track");
-		}
+		self.reserve_track().release();
 	}
 }
 
@@ -179,5 +184,28 @@ mod tests {
 			"camera",
 			"the write rejected after reservation was not retained for the next run"
 		);
+	}
+
+	#[test]
+	fn track_release_can_share_the_reservation_lock() {
+		gst::init().unwrap();
+		let pad = gst::PadBuilder::<MoqSinkPad>::new(gst::PadDirection::Sink)
+			.name("sink_0")
+			.build();
+		pad.set_property("track", "camera");
+		pad.reserve_track().commit("camera".to_string());
+
+		let release = pad.reserve_track();
+		let other = pad.clone();
+		assert!(
+			std::thread::spawn(move || other.imp().settings.try_lock().is_err())
+				.join()
+				.unwrap(),
+			"CAPS cannot reserve a track while release removes its producer"
+		);
+		release.release();
+
+		pad.set_property("track", "other");
+		assert_eq!(pad.property::<String>("track"), "other");
 	}
 }

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -1,0 +1,127 @@
+//! The `sink_%u` request pad as its own GObject, so the track it publishes can be named from a
+//! pipeline description through `GstChildProxy` (`moqsink sink_0::track=camera`).
+
+use std::sync::{LazyLock, Mutex};
+
+use gst::glib;
+use gst::prelude::*;
+use gst::subclass::prelude::*;
+
+use super::session::CAT;
+
+#[derive(Debug, Default)]
+struct Settings {
+	/// The name asked for through the property. Outlives the producer, so a restarted element reserves
+	/// the same name again.
+	requested: Option<String>,
+	/// The name the broadcast actually reserved. Present only while that producer lives, and while it is
+	/// present the property is fixed.
+	effective: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct MoqSinkPadImp {
+	settings: Mutex<Settings>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for MoqSinkPadImp {
+	const NAME: &'static str = "MoqSinkPad";
+	type Type = MoqSinkPad;
+	type ParentType = gst::Pad;
+}
+
+impl ObjectImpl for MoqSinkPadImp {
+	fn properties() -> &'static [glib::ParamSpec] {
+		static PROPS: LazyLock<Vec<glib::ParamSpec>> = LazyLock::new(|| {
+			vec![
+				// MUTABLE_PLAYING because a pad requested while the element runs is configurable right
+				// there; the window closes at this pad's CAPS event, which no state-based flag can express.
+				glib::ParamSpecString::builder("track")
+					.nick("Track")
+					.blurb(
+						"Name this pad publishes as, both in the broadcast and in the catalog. Writable \
+						 in any state until the CAPS event reserves the track, and read-only from then \
+						 on, when it reads back the reserved name. Going back to READY releases the \
+						 reservation and makes it writable again. Empty keeps the generated name \
+						 (0.avc3, 0.aac, ...)",
+					)
+					.mutable_playing()
+					.build(),
+			]
+		});
+		PROPS.as_ref()
+	}
+
+	fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+		let mut settings = self.settings.lock().unwrap();
+		// A producer keeps the name it reserved for its whole life, so a later write would read back
+		// without ever reaching the broadcast or the catalog.
+		if settings.effective.is_some() {
+			gst::warning!(
+				CAT,
+				obj = self.obj(),
+				"{} ignored: the track is already reserved",
+				pspec.name()
+			);
+			return;
+		}
+		match pspec.name() {
+			// An empty name is not a track name: it selects the generated one.
+			"track" => settings.requested = value.get::<Option<String>>().unwrap().filter(|name| !name.is_empty()),
+			_ => unreachable!(),
+		}
+	}
+
+	fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+		let settings = self.settings.lock().unwrap();
+		match pspec.name() {
+			"track" => settings
+				.effective
+				.clone()
+				.or_else(|| settings.requested.clone())
+				.to_value(),
+			_ => unreachable!(),
+		}
+	}
+}
+
+impl GstObjectImpl for MoqSinkPadImp {}
+impl PadImpl for MoqSinkPadImp {}
+
+glib::wrapper! {
+	/// A `moqsink` request pad: one track of the broadcast.
+	pub struct MoqSinkPad(ObjectSubclass<MoqSinkPadImp>) @extends gst::Pad, gst::Object;
+}
+
+impl MoqSinkPad {
+	/// The name configured for this pad, read at the CAPS event to reserve the track.
+	pub(super) fn requested_track(&self) -> Option<String> {
+		self.imp().settings.lock().unwrap().requested.clone()
+	}
+
+	/// Record the name the broadcast reserved, fixing the property for the producer's lifetime. The
+	/// caller must not hold the element state lock: `notify` runs handlers that read properties.
+	pub(super) fn commit_track(&self, track: String) {
+		let mut settings = self.imp().settings.lock().unwrap();
+		let before = settings.effective.clone().or_else(|| settings.requested.clone());
+		settings.effective = Some(track);
+		let changed = before != settings.effective;
+		drop(settings);
+		if changed {
+			self.notify("track");
+		}
+	}
+
+	/// Drop the reserved name once its producer is finalized, so the pad is configurable again on the
+	/// next run. The requested name stays: that run reserves the same one.
+	pub(super) fn release_track(&self) {
+		let mut settings = self.imp().settings.lock().unwrap();
+		let before = settings.effective.take();
+		let changed = before.is_some() && before != settings.requested;
+		drop(settings);
+		if changed {
+			self.notify("track");
+		}
+	}
+}

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -19,6 +19,7 @@ struct Settings {
 	effective: Option<String>,
 }
 
+/// The GObject implementation backing a named `moqsink` request pad.
 #[derive(Debug, Default)]
 pub struct MoqSinkPadImp {
 	settings: Mutex<Settings>,
@@ -95,16 +96,13 @@ glib::wrapper! {
 }
 
 impl MoqSinkPad {
-	/// The name configured for this pad, read at the CAPS event to reserve the track.
-	pub(super) fn requested_track(&self) -> Option<String> {
-		self.imp().settings.lock().unwrap().requested.clone()
-	}
-
-	/// Record the name the broadcast reserved, fixing the property for the producer's lifetime. The
-	/// caller must not hold the element state lock: `notify` runs handlers that read properties.
-	pub(super) fn commit_track(&self, track: String) {
+	/// Reserve a track under the configured name and fix the property for the producer's lifetime.
+	pub(super) fn reserve_track(&self, reserve: impl FnOnce(Option<&str>) -> Option<String>) {
 		let mut settings = self.imp().settings.lock().unwrap();
 		let before = settings.effective.clone().or_else(|| settings.requested.clone());
+		let Some(track) = reserve(settings.requested.as_deref()) else {
+			return;
+		};
 		settings.effective = Some(track);
 		let changed = before != settings.effective;
 		drop(settings);
@@ -123,5 +121,39 @@ impl MoqSinkPad {
 		if changed {
 			self.notify("track");
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn track_selection_is_locked_until_the_reservation_is_committed() {
+		gst::init().unwrap();
+		let pad = gst::PadBuilder::<MoqSinkPad>::new(gst::PadDirection::Sink)
+			.name("sink_0")
+			.build();
+		pad.set_property("track", "camera");
+
+		pad.reserve_track(|requested| {
+			assert_eq!(requested, Some("camera"));
+			let pad = pad.clone();
+			assert!(
+				std::thread::spawn(move || pad.imp().settings.try_lock().is_err())
+					.join()
+					.unwrap(),
+				"a concurrent property write cannot enter during reservation"
+			);
+			Some("camera".to_string())
+		});
+
+		pad.set_property("track", "other");
+		pad.release_track();
+		assert_eq!(
+			pad.property::<String>("track"),
+			"camera",
+			"the write rejected after reservation was not retained for the next run"
+		);
 	}
 }

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -17,6 +17,8 @@ struct Settings {
 	/// The name the broadcast actually reserved. Present only while that producer lives, and while it is
 	/// present the property is fixed.
 	effective: Option<String>,
+	/// Blocks CAPS from creating a producer while the element removes this pad.
+	releasing: bool,
 }
 
 /// The GObject implementation backing a named `moqsink` request pad.
@@ -92,6 +94,15 @@ impl ObjectImpl for MoqSinkPadImp {
 
 	fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
 		let mut settings = self.settings.lock().unwrap();
+		if settings.releasing {
+			gst::warning!(
+				CAT,
+				obj = self.obj(),
+				"{} ignored: the pad is being released",
+				pspec.name()
+			);
+			return;
+		}
 		// A producer keeps the name it reserved for its whole life, so a later write would read back
 		// without ever reaching the broadcast or the catalog.
 		if settings.effective.is_some() {
@@ -133,17 +144,32 @@ glib::wrapper! {
 
 impl MoqSinkPad {
 	/// Lock the configured name until the caller commits or abandons its track reservation.
-	pub(super) fn reserve_track(&self) -> TrackReservation<'_> {
-		TrackReservation {
-			pad: self,
-			settings: self.imp().settings.lock().unwrap(),
+	pub(super) fn reserve_track(&self) -> Option<TrackReservation<'_>> {
+		let settings = self.imp().settings.lock().unwrap();
+		if settings.releasing {
+			return None;
 		}
+		Some(TrackReservation { pad: self, settings })
+	}
+
+	/// Mark the pad as releasing and lock its track settings during producer removal.
+	pub(super) fn retire_track(&self) -> TrackReservation<'_> {
+		let mut settings = self.imp().settings.lock().unwrap();
+		settings.releasing = true;
+		TrackReservation { pad: self, settings }
+	}
+
+	/// Make a detached pad configurable after CAPS can no longer reach the element.
+	pub(super) fn finish_release(&self) {
+		self.imp().settings.lock().unwrap().releasing = false;
 	}
 
 	/// Drop the reserved name once its producer is finalized, so the pad is configurable again on the
 	/// next run. The requested name stays: that run reserves the same one.
 	pub(super) fn release_track(&self) {
-		self.reserve_track().release();
+		if let Some(reservation) = self.reserve_track() {
+			reservation.release();
+		}
 	}
 }
 
@@ -159,14 +185,14 @@ mod tests {
 			.build();
 		pad.set_property("track", "camera");
 
-		let abandoned = pad.reserve_track();
+		let abandoned = pad.reserve_track().unwrap();
 		assert_eq!(abandoned.requested(), Some("camera"));
 		drop(abandoned);
 		pad.set_property("track", "other");
 		assert_eq!(pad.property::<String>("track"), "other");
 		pad.set_property("track", "camera");
 
-		let reservation = pad.reserve_track();
+		let reservation = pad.reserve_track().unwrap();
 		assert_eq!(reservation.requested(), Some("camera"));
 		let other = pad.clone();
 		assert!(
@@ -184,28 +210,5 @@ mod tests {
 			"camera",
 			"the write rejected after reservation was not retained for the next run"
 		);
-	}
-
-	#[test]
-	fn track_release_can_share_the_reservation_lock() {
-		gst::init().unwrap();
-		let pad = gst::PadBuilder::<MoqSinkPad>::new(gst::PadDirection::Sink)
-			.name("sink_0")
-			.build();
-		pad.set_property("track", "camera");
-		pad.reserve_track().commit("camera".to_string());
-
-		let release = pad.reserve_track();
-		let other = pad.clone();
-		assert!(
-			std::thread::spawn(move || other.imp().settings.try_lock().is_err())
-				.join()
-				.unwrap(),
-			"CAPS cannot reserve a track while release removes its producer"
-		);
-		release.release();
-
-		pad.set_property("track", "other");
-		assert_eq!(pad.property::<String>("track"), "other");
 	}
 }

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -15,6 +15,33 @@ fn init() {
 	});
 }
 
+fn child_of(sink: &gst::Element, name: &str) -> gst::glib::Object {
+	sink.dynamic_cast_ref::<gst::ChildProxy>()
+		.expect("moqsink implements GstChildProxy")
+		.child_by_name(name)
+		.expect("the request pad is a child")
+}
+
+/// A publisher pointed at a relay that cannot answer. Connect runs in the background, so the element
+/// still reaches PAUSED and creates its producers, which is all these tests need.
+fn publisher() -> gst::Element {
+	gst::ElementFactory::make("moqsink")
+		.property("url", "https://127.0.0.1:1")
+		.property("broadcast", "test")
+		.build()
+		.expect("create moqsink")
+}
+
+/// Drive one pad to the point where it reserves its track: STREAM_START keeps the sticky events in
+/// order, CAPS builds the producer.
+fn send_caps(pad: &gst::Pad) -> bool {
+	let caps = gst::Caps::builder("video/x-h264")
+		.field("stream-format", "byte-stream")
+		.field("alignment", "au")
+		.build();
+	pad.send_event(gst::event::StreamStart::new("test")) && pad.send_event(gst::event::Caps::new(&caps))
+}
+
 // Request pads appear and disappear through the real GObject boundary, with no session attached.
 #[test]
 fn request_and_release_sink_pads() {
@@ -30,6 +57,107 @@ fn request_and_release_sink_pads() {
 	assert_eq!(sink.num_sink_pads(), 1);
 	sink.release_request_pad(&pad0);
 	assert_eq!(sink.num_sink_pads(), 0);
+}
+
+// Request pads are children, so a pipeline description can name the track each one publishes
+// (`moqsink sink_0::track=camera`). With no session nothing is reserved yet, so the property reads
+// back what was asked for.
+#[test]
+fn sink_pads_are_named_through_child_proxy() {
+	init();
+	let sink = gst::ElementFactory::make("moqsink").build().expect("create moqsink");
+	let proxy = sink
+		.dynamic_cast_ref::<gst::ChildProxy>()
+		.expect("moqsink implements GstChildProxy");
+
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	assert_eq!(proxy.children_count(), 1);
+	let child = proxy.child_by_name("sink_0").expect("sink_0 is a child");
+	child.set_property("track", "camera");
+	assert_eq!(child.property::<String>("track"), "camera");
+
+	// An empty name is not a track name: it selects the generated one.
+	child.set_property("track", "");
+	assert_eq!(child.property::<Option<String>>("track"), None);
+
+	sink.release_request_pad(&pad);
+	assert!(
+		proxy.child_by_name("sink_0").is_none(),
+		"a released pad is no longer a child"
+	);
+}
+
+// The announced syntax, through the parser that users actually type. The pad does not exist when the
+// description is parsed, so the value lands on it as a delayed child-proxy set once it is requested.
+#[test]
+fn a_pipeline_description_names_the_track() {
+	init();
+	let sink = gst::parse::launch("moqsink name=publisher url=https://127.0.0.1:1 broadcast=test sink_0::track=camera")
+		.expect("parse the description");
+	let _pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	assert_eq!(
+		child_of(&sink, "sink_0").property::<String>("track"),
+		"camera",
+		"sink_0::track reached the pad"
+	);
+}
+
+// The acceptance criterion: once CAPS reserves the track, `track` reads the effective name, further
+// writes are ignored, and stopping the element makes it configurable again.
+#[test]
+fn a_reserved_name_reads_back_and_is_released_on_ready() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let child = child_of(&sink, "sink_0");
+	child.set_property("track", "camera");
+
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&pad), "the CAPS event is accepted");
+	assert_eq!(
+		child.property::<String>("track"),
+		"camera",
+		"the pad reads back the name its producer reserved"
+	);
+
+	child.set_property("track", "other");
+	assert_eq!(
+		child.property::<String>("track"),
+		"camera",
+		"a write after the reservation is ignored, not stored"
+	);
+
+	sink.set_state(gst::State::Ready)
+		.expect("Paused -> Ready stops the session");
+	child.set_property("track", "other");
+	assert_eq!(
+		child.property::<String>("track"),
+		"other",
+		"a stopped element is configurable again"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// An unnamed pad reports the generated name, so `track` tells a pad that reserved a track apart from
+// one that never received CAPS without going to the consumer.
+#[test]
+fn an_unnamed_pad_reads_back_its_generated_name() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let child = child_of(&sink, "sink_0");
+	assert_eq!(
+		child.property::<Option<String>>("track"),
+		None,
+		"nothing is reserved before CAPS"
+	);
+
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&pad), "the CAPS event is accepted");
+	assert_eq!(child.property::<String>("track"), "0.avc3");
+	let _ = sink.set_state(gst::State::Null);
 }
 
 // Settings are validated synchronously: a missing url fails the state change, not the bus.

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -3,7 +3,8 @@
 //! Flows that need a connected session (multipad EOS aggregation, per-pad error propagation, remote
 //! close) are validated against a real relay, separately from this hermetic suite.
 
-use std::sync::Once;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Once};
 
 use gst::prelude::*;
 
@@ -158,6 +159,48 @@ fn an_unnamed_pad_reads_back_its_generated_name() {
 	assert!(send_caps(&pad), "the CAPS event is accepted");
 	assert_eq!(child.property::<String>("track"), "0.avc3");
 	let _ = sink.set_state(gst::State::Null);
+}
+
+// Releasing an active pad emits notify::track after its producer is removed but before GStreamer
+// detaches the pad. Re-enter CAPS handling from that exact window: it must be rejected, and a new pad
+// with the same GStreamer name must build a fresh producer instead of finding a ghost one in the map.
+#[test]
+fn release_rejects_caps_before_the_pad_is_detached() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let child = child_of(&sink, "sink_0");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&pad), "the initial CAPS event is accepted");
+	assert_eq!(child.property::<Option<String>>("track").as_deref(), Some("0.avc3"));
+
+	let attempted = Arc::new(AtomicBool::new(false));
+	let accepted = Arc::new(AtomicBool::new(false));
+	let attempted_notify = attempted.clone();
+	let accepted_notify = accepted.clone();
+	let pad_notify = pad.clone();
+	child.connect_notify(Some("track"), move |_, _| {
+		if !attempted_notify.swap(true, Ordering::SeqCst) {
+			accepted_notify.store(send_caps(&pad_notify), Ordering::SeqCst);
+		}
+	});
+
+	sink.release_request_pad(&pad);
+	assert!(
+		attempted.load(Ordering::SeqCst),
+		"release reached the vulnerable notify window"
+	);
+	assert!(!accepted.load(Ordering::SeqCst), "CAPS was rejected once release began");
+
+	let replacement = sink.request_pad_simple("sink_0").expect("request replacement sink_0");
+	assert!(send_caps(&replacement), "the replacement CAPS event is accepted");
+	let replacement_track = child_of(&sink, "sink_0").property::<Option<String>>("track");
+	let _ = sink.set_state(gst::State::Null);
+	assert!(
+		replacement_track.is_some(),
+		"the removed pad left no ghost producer under sink_0"
+	);
 }
 
 // Settings are validated synchronously: a missing url fails the state change, not the bus.

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -33,14 +33,17 @@ fn publisher() -> gst::Element {
 		.expect("create moqsink")
 }
 
+fn h264_caps() -> gst::Caps {
+	gst::Caps::builder("video/x-h264")
+		.field("stream-format", "byte-stream")
+		.field("alignment", "au")
+		.build()
+}
+
 /// Drive one pad to the point where it reserves its track: STREAM_START keeps the sticky events in
 /// order, CAPS builds the producer.
 fn send_caps(pad: &gst::Pad) -> bool {
-	let caps = gst::Caps::builder("video/x-h264")
-		.field("stream-format", "byte-stream")
-		.field("alignment", "au")
-		.build();
-	pad.send_event(gst::event::StreamStart::new("test")) && pad.send_event(gst::event::Caps::new(&caps))
+	pad.send_event(gst::event::StreamStart::new("test")) && pad.send_event(gst::event::Caps::new(&h264_caps()))
 }
 
 // Request pads appear and disappear through the real GObject boundary, with no session attached.
@@ -165,7 +168,7 @@ fn an_unnamed_pad_reads_back_its_generated_name() {
 // detaches the pad. Re-enter CAPS handling from that exact window: it must be rejected, and a new pad
 // with the same GStreamer name must build a fresh producer instead of finding a ghost one in the map.
 #[test]
-fn release_rejects_caps_before_the_pad_is_detached() {
+fn release_rejects_pad_traffic_before_detach() {
 	init();
 	let sink = publisher();
 	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
@@ -176,13 +179,22 @@ fn release_rejects_caps_before_the_pad_is_detached() {
 	assert_eq!(child.property::<Option<String>>("track").as_deref(), Some("0.avc3"));
 
 	let attempted = Arc::new(AtomicBool::new(false));
-	let accepted = Arc::new(AtomicBool::new(false));
+	let caps_accepted = Arc::new(AtomicBool::new(false));
+	let eos_accepted = Arc::new(AtomicBool::new(false));
+	let buffer_accepted = Arc::new(AtomicBool::new(false));
 	let attempted_notify = attempted.clone();
-	let accepted_notify = accepted.clone();
+	let caps_notify = caps_accepted.clone();
+	let eos_notify = eos_accepted.clone();
+	let buffer_notify = buffer_accepted.clone();
 	let pad_notify = pad.clone();
 	child.connect_notify(Some("track"), move |_, _| {
 		if !attempted_notify.swap(true, Ordering::SeqCst) {
-			accepted_notify.store(send_caps(&pad_notify), Ordering::SeqCst);
+			caps_notify.store(
+				pad_notify.send_event(gst::event::Caps::new(&h264_caps())),
+				Ordering::SeqCst,
+			);
+			eos_notify.store(pad_notify.send_event(gst::event::Eos::new()), Ordering::SeqCst);
+			buffer_notify.store(pad_notify.chain(gst::Buffer::new()).is_ok(), Ordering::SeqCst);
 		}
 	});
 
@@ -191,7 +203,18 @@ fn release_rejects_caps_before_the_pad_is_detached() {
 		attempted.load(Ordering::SeqCst),
 		"release reached the vulnerable notify window"
 	);
-	assert!(!accepted.load(Ordering::SeqCst), "CAPS was rejected once release began");
+	assert!(
+		!caps_accepted.load(Ordering::SeqCst),
+		"CAPS was rejected once release began"
+	);
+	assert!(
+		!eos_accepted.load(Ordering::SeqCst),
+		"EOS was rejected once release began"
+	);
+	assert!(
+		!buffer_accepted.load(Ordering::SeqCst),
+		"a buffer was rejected once release began"
+	);
 
 	let replacement = sink.request_pad_simple("sink_0").expect("request replacement sink_0");
 	assert!(send_caps(&replacement), "the replacement CAPS event is accepted");


### PR DESCRIPTION
`moqsink` names every track after its codec (`0.avc3`, `0.aac`), so a consumer that expects a stable name cannot ask for one. Each `sink_%u` pad is now a `MoqSinkPad` with a `track` property, reachable through `GstChildProxy`.

```
moqsink sink_0::track=camera sink_1::track=commentary
```

They are:

- Writable in any state until the pad's CAPS event reserves the track.
- Read-only after that, reading back the reserved name, the generated one included.
- Releasing the pad or stopping the element drops the reservation and makes it writable again.
- Empty keeps the generated name, so a pipeline that never sets it is unchanged.
- A name another pad already holds invalidates only that pad.

The name is what the catalog advertises. Track selection and producer reservation share the pad settings lock, so a concurrent property write cannot slip between selecting the requested name and making the reservation effective. Pad release marks the pad as releasing before producer removal. Every pad event and buffer holds that same guard across state access, so release waits for existing traffic and waiting or re-entrant traffic cannot leave ghost state before GStreamer detaches the pad.

Tests: 5 unit and 5 element tests cover reservation locking, real release traffic re-entry with CAPS, EOS, and a buffer, reserved-name readback, the generated name, a collision, renegotiation under the same name, and the `sink_0::track=camera` syntax through `gst::parse::launch`. `doc/bin/gstreamer.md` updated. Scoped `just check` and `just test` pass.

(Written by GPT-5.6 Sol)