### PR TITLE
fix(moq-mux): map containers onto MSF packaging one to one

### DIFF
--- a/js/watch/src/msf.test.ts
+++ b/js/watch/src/msf.test.ts
@@ -47,3 +47,30 @@ test("keeps legacy packaging as the legacy container", () => {
 
 	expect(toHang(catalog).video?.renditions.video?.container).toEqual({ kind: "legacy" });
 });
+
+test("drops a cmaf rendition without a usable init segment", () => {
+	const track: Msf.Track = {
+		name: "video",
+		packaging: "cmaf",
+		role: "video",
+		codec: "vp09.00.10.08",
+	};
+
+	expect(toHang({ tracks: [track] }).video?.renditions.video).toBeUndefined();
+	expect(toHang({ tracks: [{ ...track, initData: "not base64!" }] }).video?.renditions.video).toBeUndefined();
+});
+
+test("drops a rendition whose packaging is unknown", () => {
+	const catalog: Msf.Catalog = {
+		tracks: [
+			{
+				name: "video",
+				packaging: "future",
+				role: "video",
+				codec: "vp09.00.10.08",
+			},
+		],
+	};
+
+	expect(toHang(catalog).video?.renditions.video).toBeUndefined();
+});

--- a/js/watch/src/msf.test.ts
+++ b/js/watch/src/msf.test.ts
@@ -17,3 +17,33 @@ test("preserves stalled video renditions", () => {
 
 	expect(toHang(catalog).video?.renditions.video?.stalled).toBe(true);
 });
+
+test("keeps loc packaging as the loc container", () => {
+	const catalog: Msf.Catalog = {
+		tracks: [
+			{
+				name: "video",
+				packaging: "loc",
+				role: "video",
+				codec: "vp09.00.10.08",
+			},
+		],
+	};
+
+	expect(toHang(catalog).video?.renditions.video?.container).toEqual({ kind: "loc" });
+});
+
+test("keeps legacy packaging as the legacy container", () => {
+	const catalog: Msf.Catalog = {
+		tracks: [
+			{
+				name: "video",
+				packaging: "legacy",
+				role: "video",
+				codec: "vp09.00.10.08",
+			},
+		],
+	};
+
+	expect(toHang(catalog).video?.renditions.video?.container).toEqual({ kind: "legacy" });
+});

--- a/js/watch/src/msf.ts
+++ b/js/watch/src/msf.ts
@@ -17,7 +17,10 @@ interface ContainerInfo {
 	description?: string;
 }
 
-function toContainer(track: Msf.Track): ContainerInfo {
+// `packaging` declares how the bytes are framed, not an optional capability, so every value maps to
+// its own container and an unrecognized one drops the rendition. Reading LOC's property block as
+// legacy's VarInt prefix is exactly what a permissive fallback caused.
+function toContainer(track: Msf.Track): ContainerInfo | undefined {
 	let initBytes: Uint8Array | undefined;
 	try {
 		initBytes = track.initData ? base64ToBytes(track.initData) : undefined;
@@ -25,34 +28,30 @@ function toContainer(track: Msf.Track): ContainerInfo {
 		initBytes = undefined;
 	}
 
-	if (track.packaging === "cmaf" && track.initData && initBytes) {
-		return {
-			container: { kind: "cmaf", init: track.initData },
-			// hang's CMAF path reads codec metadata from the init segment, so we
-			// don't need to surface a separate description here.
-			description: undefined,
-		};
-	}
+	const description = initBytes ? bytesToHex(initBytes) : undefined;
 
-	// LOC and legacy carry the same codec payload but frame it differently, so the kind has to survive
-	// an MSF catalog the same way it survives a hang one.
-	if (track.packaging === "loc") {
-		return {
-			container: { kind: "loc" },
-			description: initBytes ? bytesToHex(initBytes) : undefined,
-		};
+	switch (track.packaging) {
+		case "cmaf":
+			// Unusable without its init segment, so a missing or malformed one drops the rendition rather
+			// than falling back to a different framing. hang's CMAF path reads the codec metadata from
+			// that segment, so there is no separate description to surface.
+			if (!track.initData || !initBytes) return undefined;
+			return { container: { kind: "cmaf", init: track.initData }, description: undefined };
+		case "loc":
+			return { container: { kind: "loc" }, description };
+		case "legacy":
+			return { container: { kind: "legacy" }, description };
+		default:
+			return undefined;
 	}
-
-	return {
-		container: { kind: "legacy" },
-		description: initBytes ? bytesToHex(initBytes) : undefined,
-	};
 }
 
 function toVideoConfig(track: Msf.Track): Catalog.VideoConfig | undefined {
 	if (!track.codec) return undefined;
 
-	const { container, description } = toContainer(track);
+	const info = toContainer(track);
+	if (!info) return undefined;
+	const { container, description } = info;
 	return {
 		codec: track.codec,
 		container,
@@ -75,7 +74,9 @@ function toAudioConfig(track: Msf.Track): Catalog.AudioConfig | undefined {
 		return Number.isFinite(parsed) ? parsed : DEFAULT_NUMBER_OF_CHANNELS;
 	})();
 
-	const { container, description } = toContainer(track);
+	const info = toContainer(track);
+	if (!info) return undefined;
+	const { container, description } = info;
 	return {
 		codec: track.codec,
 		container,

--- a/js/watch/src/msf.ts
+++ b/js/watch/src/msf.ts
@@ -34,6 +34,15 @@ function toContainer(track: Msf.Track): ContainerInfo {
 		};
 	}
 
+	// LOC and legacy carry the same codec payload but frame it differently, so the kind has to survive
+	// an MSF catalog the same way it survives a hang one.
+	if (track.packaging === "loc") {
+		return {
+			container: { kind: "loc" },
+			description: initBytes ? bytesToHex(initBytes) : undefined,
+		};
+	}
+
 	return {
 		container: { kind: "legacy" },
 		description: initBytes ? bytesToHex(initBytes) : undefined,

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -88,9 +88,10 @@ impl From<moq_net::track::Subscriber> for Consumer {
 /// description, custom roles), or with packaging other than [`moq_msf::Packaging::Loc`],
 /// [`moq_msf::Packaging::Cmaf`], or [`moq_msf::Packaging::Legacy`] are skipped with a warning.
 ///
-/// Both [`moq_msf::Packaging::Loc`] and [`moq_msf::Packaging::Legacy`] map to
-/// [`Container::Legacy`]. [`moq_msf::Packaging::Cmaf`] requires `init_data` to be present
-/// (base64-encoded ftyp+moov); a missing or malformed init segment is an error.
+/// [`moq_msf::Packaging::Loc`] and [`moq_msf::Packaging::Legacy`] map to their own containers:
+/// they carry the same codec payload but frame it differently.
+/// [`moq_msf::Packaging::Cmaf`] requires `init_data` to be present (base64-encoded ftyp+moov);
+/// a missing or malformed init segment is an error.
 ///
 /// Fields with no representation in `hang::Catalog` (`generated_at`, `is_complete`, `is_live`,
 /// `render_group`, `alt_group`, `max_grp_sap_starting_type`, `max_obj_sap_starting_type`) are
@@ -150,8 +151,10 @@ pub(crate) fn from_msf(msf: &moq_msf::Catalog) -> Result<hang::Catalog> {
 /// segment, and silently skipping it would mask a publisher bug.
 fn container_from_msf(track: &moq_msf::Track) -> Result<Option<Container>> {
 	match &track.packaging {
-		// Both LOC and Legacy represent raw payloads without ISO-BMFF boxing.
-		moq_msf::Packaging::Loc | moq_msf::Packaging::Legacy => Ok(Some(Container::Legacy)),
+		// Neither is ISO-BMFF boxed, but they frame differently: a LOC property block against a VarInt
+		// timestamp prefix. Reading one as the other misparses the head of every frame.
+		moq_msf::Packaging::Loc => Ok(Some(Container::Loc)),
+		moq_msf::Packaging::Legacy => Ok(Some(Container::Legacy)),
 		moq_msf::Packaging::Cmaf => {
 			let init = decode_init_data(track)?.ok_or_else(|| Error::MissingCmafInit(track.name.clone()))?;
 			Ok(Some(Container::Cmaf { init }))
@@ -429,13 +432,13 @@ mod test {
 	}
 
 	#[test]
-	fn loc_audio_yields_legacy_container() {
+	fn loc_audio_yields_loc_container() {
 		let msf = moq_msf::Catalog::new(vec![audio_track("audio0", moq_msf::Packaging::Loc)]);
 
 		let catalog = from_msf(&msf).expect("LOC audio should convert");
 		let audio = catalog.audio.renditions.get("audio0").expect("audio0 rendition");
 
-		assert_eq!(audio.container, Container::Legacy);
+		assert_eq!(audio.container, Container::Loc);
 		assert_eq!(audio.codec, AudioCodec::Opus);
 		assert_eq!(audio.sample_rate, 48_000);
 		assert_eq!(audio.channel_count, 2);

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -476,16 +476,30 @@ fn video_sap_type(codec: &hang::catalog::VideoCodec) -> Option<u8> {
 	}
 }
 
+/// The MSF packaging that announces `container`, or `None` to leave the rendition out of the catalog.
+///
+/// Exhaustive on purpose: a catch-all is what announced LOC as legacy, and it would do the same to the
+/// next container added. hang says an unrecognized one must be ignored, so it keeps its wire kind (no
+/// MSF consumer claims one it does not know) and is dropped when it does not even name one.
+fn packaging_of(container: &hang::catalog::Container) -> Option<moq_msf::Packaging> {
+	match container {
+		hang::catalog::Container::Cmaf { .. } => Some(moq_msf::Packaging::Cmaf),
+		hang::catalog::Container::Loc => Some(moq_msf::Packaging::Loc),
+		hang::catalog::Container::Legacy => Some(moq_msf::Packaging::Legacy),
+		hang::catalog::Container::Unknown(unknown) => {
+			unknown.kind().map(|kind| moq_msf::Packaging::Unknown(kind.to_string()))
+		}
+	}
+}
+
 /// Convert a hang catalog to an MSF catalog.
 fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 	let mut tracks = Vec::new();
 
 	let has_multiple_video = catalog.video.renditions.len() > 1;
 	for (name, config) in &catalog.video.renditions {
-		let packaging = match &config.container {
-			hang::catalog::Container::Cmaf { .. } => moq_msf::Packaging::Cmaf,
-			hang::catalog::Container::Loc => moq_msf::Packaging::Loc,
-			_ => moq_msf::Packaging::Legacy,
+		let Some(packaging) = packaging_of(&config.container) else {
+			continue;
 		};
 
 		let init_data = match &config.container {
@@ -517,10 +531,8 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 
 	let has_multiple_audio = catalog.audio.renditions.len() > 1;
 	for (name, config) in &catalog.audio.renditions {
-		let packaging = match &config.container {
-			hang::catalog::Container::Cmaf { .. } => moq_msf::Packaging::Cmaf,
-			hang::catalog::Container::Loc => moq_msf::Packaging::Loc,
-			_ => moq_msf::Packaging::Legacy,
+		let Some(packaging) = packaging_of(&config.container) else {
+			continue;
 		};
 
 		let init_data = match &config.container {
@@ -890,6 +902,30 @@ mod test {
 		let msf = to_msf(&catalog);
 		assert_eq!(msf.tracks.len(), 1);
 		assert_eq!(msf.tracks[0].packaging, moq_msf::Packaging::Loc);
+	}
+
+	// An unrecognized container keeps its wire kind instead of posing as legacy: hang says such a
+	// rendition must be ignored, and no MSF consumer claims an unknown packaging.
+	#[test]
+	fn convert_unknown_container_keeps_its_kind() {
+		let container: Container = serde_json::from_value(serde_json::json!({ "kind": "future" })).unwrap();
+		assert!(matches!(container, Container::Unknown(_)));
+
+		let mut audio_config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		audio_config.container = container;
+
+		let mut audio_renditions = BTreeMap::new();
+		audio_renditions.insert("audio0".to_string(), audio_config);
+
+		let mut catalog = hang::Catalog::default();
+		catalog.audio.renditions = audio_renditions;
+
+		let msf = to_msf(&catalog);
+		assert_eq!(msf.tracks.len(), 1);
+		assert_eq!(
+			msf.tracks[0].packaging,
+			moq_msf::Packaging::Unknown("future".to_string())
+		);
 	}
 
 	#[test]

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -484,6 +484,7 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 	for (name, config) in &catalog.video.renditions {
 		let packaging = match &config.container {
 			hang::catalog::Container::Cmaf { .. } => moq_msf::Packaging::Cmaf,
+			hang::catalog::Container::Loc => moq_msf::Packaging::Loc,
 			_ => moq_msf::Packaging::Legacy,
 		};
 
@@ -518,6 +519,7 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 	for (name, config) in &catalog.audio.renditions {
 		let packaging = match &config.container {
 			hang::catalog::Container::Cmaf { .. } => moq_msf::Packaging::Cmaf,
+			hang::catalog::Container::Loc => moq_msf::Packaging::Loc,
 			_ => moq_msf::Packaging::Legacy,
 		};
 
@@ -849,6 +851,45 @@ mod test {
 		assert_eq!(audio.max_grp_sap_starting_type, Some(1));
 		assert_eq!(audio.max_obj_sap_starting_type, Some(1));
 		assert_eq!(audio.jitter, None);
+	}
+
+	// A LOC rendition must advertise `packaging: loc`. MSF-01 has no legacy packaging, so falling into
+	// the legacy arm published a catalog that named a container the receiver would not find on the wire.
+	#[test]
+	fn convert_video_loc_container() {
+		let mut video_config = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0x00,
+			level: 0x1f,
+			inline: true,
+		});
+		video_config.container = Container::Loc;
+
+		let mut video_renditions = BTreeMap::new();
+		video_renditions.insert("video0.avc3".to_string(), video_config);
+
+		let mut catalog = hang::Catalog::default();
+		catalog.video.renditions = video_renditions;
+
+		let msf = to_msf(&catalog);
+		assert_eq!(msf.tracks.len(), 1);
+		assert_eq!(msf.tracks[0].packaging, moq_msf::Packaging::Loc);
+	}
+
+	#[test]
+	fn convert_audio_loc_container() {
+		let mut audio_config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		audio_config.container = Container::Loc;
+
+		let mut audio_renditions = BTreeMap::new();
+		audio_renditions.insert("audio0".to_string(), audio_config);
+
+		let mut catalog = hang::Catalog::default();
+		catalog.audio.renditions = audio_renditions;
+
+		let msf = to_msf(&catalog);
+		assert_eq!(msf.tracks.len(), 1);
+		assert_eq!(msf.tracks[0].packaging, moq_msf::Packaging::Loc);
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes #2986.

`packaging` declares how a track's bytes are framed, not an optional capability, so it must map one to one onto the hang container. It did not, in either direction: a LOC rendition was announced as `packaging: legacy`, and reading an MSF catalog back handed LOC data to the legacy reader, which parses the LOC property block as if it were the VarInt timestamp prefix. `js/watch` had the same defect on the other side of the same catalog.

Two commits, separable on purpose:

1. `map the LOC container onto loc packaging` is the bug alone, both directions plus `js/watch`. It is reachable today rather than after some future change: moq-audio publishes `Container::Loc`, and libmoq and moq-ffi expose LOC to their C callers.
2. `stop announcing an unknown container as legacy` is the policy the first commit exposes. The catch-all that hid LOC would hide the next container added just the same. Each container now maps to its own packaging with no catch-all, an unknown one keeps the kind it arrived with, and one that names no kind is left out of the catalog. `js/watch` drops a rendition whose packaging it does not recognize, and a CMAF one whose init segment is missing or malformed.

If you would rather settle the unknown-container policy separately, the second commit can be dropped and the first stands on its own.

Measured: `cargo test -p moq-mux` (535 + 5), `bun test js/watch/src/msf.test.ts` (5), `cargo clippy -p moq-mux --all-targets` and `cargo fmt --check` clean. The first commit was also run in isolation: 113 catalog tests and 3 JS tests.
