### PR TITLE
perf(kio): size the inline waiter array for the common list, not the worst one

### DIFF
--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -17,7 +17,32 @@ use crate::{
 };
 
 /// Number of slots stored inline before spilling to the heap.
-const INLINE_WAITERS: usize = 32;
+///
+/// Sized for the common list, not the worst one. The array lives inside the
+/// enclosing `Arc<Mutex<State<T>>>`, so every list pays it whether or not
+/// anything ever parks, and a state cell holds three lists. At 32 that was 840 B
+/// of mostly-empty slots on every channel; downstream in moq-net a broadcast
+/// holds four to five cells and a cached group holds one, so it dominated their
+/// footprint.
+///
+/// It cannot go to zero, because `take()` moves the entries out to be woken
+/// outside the lock: a spilled list hands its heap buffer to the snapshot, which
+/// frees it, so the capacity does not survive a wake and the next registration
+/// re-allocates. Inline slots have no such cost. That makes this the count of
+/// waiters a list can hold without allocating once per wake, measured per
+/// take/wake cycle:
+///
+/// | inline | `WaiterList` | allocs/cycle at 2 / 4 / 8 waiters |
+/// |---|---|---|
+/// | 32 | 296 B | 0 / 0 / 0 |
+/// | 8 | 104 B | 0 / 0 / 0 |
+/// | 4 | 72 B | 0 / 0 / 1 |
+/// | 2 | 56 B | 0 / 1 / 2 |
+///
+/// 4 keeps the steady state allocation-free for the small lists that dominate
+/// while giving back most of the memory. A genuinely hot fan-out list spills
+/// under any of these; it did at 32 too.
+const INLINE_WAITERS: usize = 4;
 
 /// Registrations remembered per waiter identity for O(1) dedup. A poll typically
 /// parks on a small handful of lists; a poll cycling through more than this many


### PR DESCRIPTION
## Summary

`WaiterList` held 32 inline `Weak<Identity>` slots. That array lives inside the enclosing `Arc<Mutex<State<T>>>` and is paid whether or not anything ever parks, and a state cell holds three lists, so an idle channel carried 840 B of mostly-empty slots. Lists are per channel and channels are many, so the empty case is what to size for.

Drop it to 4.

This came out of profiling relay memory on a downstream fleet, where a relay holds one broadcast object graph per announcement per neighbour. The waiter slots were ~4.2 KB of the ~9 KB an announced broadcast cost, which is what sent me here rather than to `moq-net`.

**This PR previously replaced the `SmallVec` with one inline `Option` plus a spill `Vec`.** Review caught that this regresses the fan-out path, and measurement confirmed it, so the rewrite is gone and only the constant changes. See below.

## Public API changes

None. One constant and its comment.

## Why not zero, and why not a `Vec`

`take()` moves the entries out to be woken outside the lock, so a spilled list hands its heap buffer to the snapshot, which frees it. The capacity does not survive a wake, and the next registration allocates again. Inline slots have no such cost, which makes this constant the number of waiters a list can hold without allocating once per wake.

Measured allocations per take/wake cycle, driving a real `WaiterList` through `register`/`take`/`wake` under a counting allocator:

| inline slots | `WaiterList` | announced broadcast (1 route) | allocs/cycle at 2 / 4 / 8 waiters |
|---|---|---|---|
| 32 (before) | 296 B | 9,367 B | 0 / 0 / 0 |
| 8 | 104 B | 6,487 B | 0 / 0 / 0 |
| **4** | **72 B** | **6,005 B** | **0 / 0 / 1** |
| 2 | 56 B | 5,756 B | 0 / 1 / 2 |
| `Option` + `Vec` | 56 B | 5,802 B | 1 / 1 / 2 |

The `Option` + `Vec` shape is the one this PR originally shipped. It is the worst row on churn and no better on memory than `SmallVec[2]`, because `take()` does `mem::take` on the `Vec` and the snapshot frees it — so a channel with two or more parked waiters allocates on *every* wake, where 32 inline slots allocated on none. The earlier description claimed the `Vec` retained its capacity; that was wrong, and the benches did not catch it because `group_*` is not a fan-out shape.

4 keeps the steady state allocation-free for the small lists that dominate while giving back most of the memory. A genuinely hot fan-out list spills under any of these, as it did at 32.

## Measurements

Downstream in `moq-net`, where a broadcast holds four to five state cells and a cached group holds one (RSS plus counting-allocator harness against `5755897`):

| | before | after |
|---|---|---|
| announced broadcast, one route | 9,367 B | 6,005 B |
| announced broadcast, five routes | 27,628 B | 18,892 B |
| cached group, one 150 B frame | 1,685 B | 1,013 B |

## Test plan

- `cargo test -p kio`: 53 pass, unmodified. The earlier rewrite needed test edits to reach `WaiterList::entries`; this does not touch them.
- `cargo test -p moq-net`: 784 pass.
- `cargo clippy --locked --all-targets -p kio -p moq-net -- -D warnings`, `cargo fmt --all --check`, `RUSTDOCFLAGS="-D warnings" cargo doc -p kio`: clean.
- `cargo test -p moq-relay`: 193 pass; 7 in `tests/smoke.rs` fail identically on the unmodified parent commit, so not from this change. They are environmental to my sandbox: no IPv6 (`/proc/net/if_inet6` is empty) while `build_web_with` binds QUIC to `[::]:0`, giving `Quinn(BindSocket(EAFNOSUPPORT))`. Worth confirming they pass in CI, since I could not run them anywhere with IPv6.
- `cargo bench -p moq-net --bench group`, 20 samples, against a baseline on the parent commit. Seven of nine improved, two unchanged, none regressed:

```
group_write_frames/512    -16.16%     group_read_frames/512     -4.79%
group_write_frames/8192    -3.27%     group_read_frames/8192    -2.49%
group_write_frames/32768   -4.34%     group_read_frames/32768   no change
group_roundtrip/512        -6.29%     group_roundtrip/8192      -5.06%
group_roundtrip/32768     no change
```

Based on #2989 while that is open, so CI here runs against the fixed package selection; GitHub retargets this to `main` when it merges.