### PR TITLE
fix(rs): select crates by package id so a published workspace crate is not ambiguous

### DIFF
--- a/rs/justfile
+++ b/rs/justfile
@@ -108,7 +108,15 @@ _select $FILES:
     			for (i = 1; i <= NR; i++)
     				if (want[dep[i]] && !want[pkg[i]]) { want[pkg[i]] = 1; grew = 1 }
     		} while (grew)
-    		for (i = 1; i <= NR; i++) if (want[pkg[i]]) print pkg[i]
+    		# Every wanted crate, not just those that appear as an edge source: a
+    		# crate with no dependencies of its own emits no edge, so keying the
+    		# output on `pkg[i]` would drop it and select nothing for a direct
+    		# change to it. Test the VALUE, not the key -- awk creates a key on
+    		# every `want[dep[i]]` read above, so iterating keys alone would emit
+    		# every crate the workspace mentions. The lookup below drops names that
+    		# are not workspace crates, which is what keeps a seed like the
+    		# non-crate `rs/scripts` from reaching cargo.
+    		for (name in want) if (want[name]) print name
     	}
     ' <<< "$edges" | sort -u)
 
@@ -184,6 +192,11 @@ _select-test:
     if just rs _wants-wasm "$relay"; then
     	fail "a moq-relay diff must not drive it: $(just rs _names "$relay")"
     fi
+
+    # A non-crate directory under rs/ seeds a name that is not a package. It must
+    # select nothing rather than reach cargo as a bogus spec.
+    [[ -z "$(just rs _select "rs/scripts/package-binary.sh")" ]] \
+    	|| fail "a non-crate seed must select nothing"
 
     echo "rs: selection ok"
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -28,6 +28,7 @@ default:
 
 # Compile, lint, format-check, doc-check, and verify dependency hygiene.
 check *args:
+    just rs _select-test
     cargo clippy --locked --all-targets {{ args }} -- -D warnings
     cargo fmt --all --check
     RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps {{ args }}
@@ -134,12 +135,57 @@ _select $FILES:
 # and `_select` has already verified every crate directory matches its crate
 # name, so the last path segment is the name.
 
+# True when a selection includes a crate the wasm32 pass covers. One predicate
+# rather than the same alternation in each gate, so the test below exercises what
+# the gates actually run instead of a copy of it.
+[private]
+_wants-wasm $PACKAGES:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    grep -qwE '(moq-wasm|moq-mux|moq-ffi)' <<< "$(just rs _names "$PACKAGES")"
+
 # Print the crate names behind a list of `--package` flags.
 [private]
 _names $PACKAGES:
     #!/usr/bin/env bash
     set -euo pipefail
     tr ' ' '\n' <<< "$PACKAGES" | sed -n 's|.*/\([^/#]*\)#.*|\1|p' | sort -u | tr '\n' ' '
+
+# Guards the two things about selection that fail SILENTLY rather than loudly:
+# a `--package` spec cargo cannot resolve takes the gate down before it compiles
+# anything, and a wasm gate that stops matching skips the only pass that ever
+# looks at moq-wasm's code (its crate root is `#![cfg(target_arch = "wasm32")]`,
+# so the host pass sees an empty crate and reports success). Both have happened.
+
+# Check that selection emits resolvable specs and still drives the wasm gate.
+[private]
+_select-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    fail() { echo "rs: _select-test: $1" >&2; exit 1; }
+
+    # `kio` is published and pulled from crates.io by the web-transport-* crates,
+    # so the workspace copy and the registry copy share a name: a bare name is
+    # ambiguous and cargo refuses. Every emitted spec must name its source, and
+    # cargo must accept it.
+    packages=$(just rs _select "rs/kio/src/waiter.rs")
+    for spec in $(sed 's/--package //g' <<< "$packages"); do
+    	[[ "$spec" == *"file://"* ]] || fail "expected a source-qualified id, got: $spec"
+    	cargo pkgid --offline "$spec" > /dev/null 2>&1 || fail "cargo cannot resolve: $spec"
+    done
+
+    # The wasm gate keys on names, so it survives whatever spec form the ids use.
+    just rs _wants-wasm "$packages" \
+    	|| fail "a kio diff must still drive the wasm gate: $(just rs _names "$packages")"
+
+    # ...and it must still be able to say no, or it is not a gate.
+    relay=$(just rs _select "rs/moq-relay/src/web.rs")
+    if just rs _wants-wasm "$relay"; then
+    	fail "a moq-relay diff must not drive it: $(just rs _names "$relay")"
+    fi
+
+    echo "rs: selection ok"
 
 # Takes a newline-separated list of changed files; skips when no crate is
 # affected. The `just rs ...` calls below go through the root justfile's
@@ -165,7 +211,7 @@ check-changed $FILES:
     # nothing in the workspace depends on moq-ffi, so an moq-ffi-only diff selects
     # only itself and would never reach the gate that exists to cover it. moq-mux
     # is selected by its dependents, none of which are moq-wasm.
-    if [[ "$packages" == "ALL" ]] || grep -qwE '(moq-wasm|moq-mux|moq-ffi)' <<< "$(just rs _names "$packages")"; then
+    if [[ "$packages" == "ALL" ]] || just rs _wants-wasm "$packages"; then
     	just rs wasm
     fi
 
@@ -182,7 +228,7 @@ fix-changed $FILES:
 
     # Mirrors `check-changed`'s gate, alternation included: without this a wasm32
     # lint is never auto-fixed, and `check`'s wasm32 clippy pass fails on it later.
-    if [[ "$packages" == "ALL" ]] || grep -qwE '(moq-wasm|moq-mux|moq-ffi)' <<< "$(just rs _names "$packages")"; then
+    if [[ "$packages" == "ALL" ]] || just rs _wants-wasm "$packages"; then
     	just rs wasm-fix
     fi
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -126,6 +126,21 @@ _select $FILES:
     	| "--package \(.id)"
     ' <<< "$metadata" | sort -u | tr '\n' ' '
 
+# Bare crate names for the `--package <id>` flags `_select` emits, for log lines
+# and for the wasm gate's alternation below. Matching names rather than the flag
+# spelling keeps those call sites working whatever spec form `_select` uses; the
+# previous alternation matched `--package <name>` literally and silently stopped
+# firing the moment the spec form changed. Ids are `path+file://<dir>#<version>`
+# and `_select` has already verified every crate directory matches its crate
+# name, so the last path segment is the name.
+
+# Print the crate names behind a list of `--package` flags.
+[private]
+_names $PACKAGES:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tr ' ' '\n' <<< "$PACKAGES" | sed -n 's|.*/\([^/#]*\)#.*|\1|p' | sort -u | tr '\n' ' '
+
 # Takes a newline-separated list of changed files; skips when no crate is
 # affected. The `just rs ...` calls below go through the root justfile's
 # `mod rs` because these recipes run from the repo root, where a bare `check`
@@ -139,7 +154,7 @@ check-changed $FILES:
     case "$packages" in
     	"")    echo "rs: no crates affected; skipping." ;;
     	ALL)   just rs check --workspace ;;
-    	*)     echo "rs: checking ${packages//--package /}"; just rs check $packages ;;
+    	*)     echo "rs: checking $(just rs _names "$packages")"; just rs check $packages ;;
     esac
 
     # moq-wasm's crate root is entirely `#![cfg(target_arch = "wasm32")]`, so
@@ -150,7 +165,7 @@ check-changed $FILES:
     # nothing in the workspace depends on moq-ffi, so an moq-ffi-only diff selects
     # only itself and would never reach the gate that exists to cover it. moq-mux
     # is selected by its dependents, none of which are moq-wasm.
-    if [[ "$packages" == "ALL" ]] || grep -qE -- '--package (moq-wasm|moq-mux|moq-ffi)' <<< "$packages"; then
+    if [[ "$packages" == "ALL" ]] || grep -qwE '(moq-wasm|moq-mux|moq-ffi)' <<< "$(just rs _names "$packages")"; then
     	just rs wasm
     fi
 
@@ -162,12 +177,12 @@ fix-changed $FILES:
     case "$packages" in
     	"")    echo "rs: no crates affected; skipping." ;;
     	ALL)   just rs fix --workspace ;;
-    	*)     echo "rs: fixing ${packages//--package /}"; just rs fix $packages ;;
+    	*)     echo "rs: fixing $(just rs _names "$packages")"; just rs fix $packages ;;
     esac
 
     # Mirrors `check-changed`'s gate, alternation included: without this a wasm32
     # lint is never auto-fixed, and `check`'s wasm32 clippy pass fails on it later.
-    if [[ "$packages" == "ALL" ]] || grep -qE -- '--package (moq-wasm|moq-mux|moq-ffi)' <<< "$packages"; then
+    if [[ "$packages" == "ALL" ]] || grep -qwE '(moq-wasm|moq-mux|moq-ffi)' <<< "$(just rs _names "$packages")"; then
     	just rs wasm-fix
     fi
 
@@ -321,7 +336,7 @@ test-changed $FILES:
     case "$packages" in
     	"")    echo "rs: no crates affected; skipping tests." ;;
     	ALL)   just rs test --workspace ;;
-    	*)     echo "rs: testing ${packages//--package /}"; just rs test --no-tests=pass $packages ;;
+    	*)     echo "rs: testing $(just rs _names "$packages")"; just rs test --no-tests=pass $packages ;;
     esac
 
 # Compile and run the `/// ```` examples, which nextest skips.

--- a/rs/justfile
+++ b/rs/justfile
@@ -98,7 +98,7 @@ _select $FILES:
 
     # A crate has to be rebuilt when anything it depends on changed, so walk the
     # edges backwards until the selection stops growing.
-    awk -v seeds="$seeds" '
+    selected=$(awk -v seeds="$seeds" '
     	BEGIN { split(seeds, s, "\n"); for (i in s) want[s[i]] = 1 }
     	{ pkg[NR] = $1; dep[NR] = $2 }
     	END {
@@ -109,7 +109,22 @@ _select $FILES:
     		} while (grew)
     		for (i = 1; i <= NR; i++) if (want[pkg[i]]) print pkg[i]
     	}
-    ' <<< "$edges" | sort -u | sed 's/^/--package /' | tr '\n' ' '
+    ' <<< "$edges" | sort -u)
+
+    [[ -n "$selected" ]] || exit 0
+
+    # Emit cargo's own package ids, not bare names. A workspace crate we also
+    # publish collides with its crates.io copy as soon as any dependency pulls
+    # that copy in (the web-transport-* crates depend on a published `kio`), and
+    # `--package kio` is then ambiguous: cargo refuses during package selection,
+    # before compiling anything, so the whole gate fails. Ids from `cargo
+    # metadata` carry the source, so they are unambiguous by construction.
+    jq -r --arg selected "$selected" '
+    	($selected | split("\n")) as $want
+    	| .packages[]
+    	| select(.name as $name | $want | index($name) != null)
+    	| "--package \(.id)"
+    ' <<< "$metadata" | sort -u | tr '\n' ' '
 
 # Takes a newline-separated list of changed files; skips when no crate is
 # affected. The `just rs ...` calls below go through the root justfile's

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -17,7 +17,32 @@ use crate::{
 };
 
 /// Number of slots stored inline before spilling to the heap.
-const INLINE_WAITERS: usize = 32;
+///
+/// Sized for the common list, not the worst one. The array lives inside the
+/// enclosing `Arc<Mutex<State<T>>>`, so every list pays it whether or not
+/// anything ever parks, and a state cell holds three lists. At 32 that was 840 B
+/// of mostly-empty slots on every channel; downstream in moq-net a broadcast
+/// holds four to five cells and a cached group holds one, so it dominated their
+/// footprint.
+///
+/// It cannot go to zero, because `take()` moves the entries out to be woken
+/// outside the lock: a spilled list hands its heap buffer to the snapshot, which
+/// frees it, so the capacity does not survive a wake and the next registration
+/// re-allocates. Inline slots have no such cost. That makes this the count of
+/// waiters a list can hold without allocating once per wake, measured per
+/// take/wake cycle:
+///
+/// | inline | `WaiterList` | allocs/cycle at 2 / 4 / 8 waiters |
+/// |---|---|---|
+/// | 32 | 296 B | 0 / 0 / 0 |
+/// | 8 | 104 B | 0 / 0 / 0 |
+/// | 4 | 72 B | 0 / 0 / 1 |
+/// | 2 | 56 B | 0 / 1 / 2 |
+///
+/// 4 keeps the steady state allocation-free for the small lists that dominate
+/// while giving back most of the memory. A genuinely hot fan-out list spills
+/// under any of these; it did at 32 too.
+const INLINE_WAITERS: usize = 4;
 
 /// Registrations remembered per waiter identity for O(1) dedup. A poll typically
 /// parks on a small handful of lists; a poll cycling through more than this many


### PR DESCRIPTION
## Summary

Four related fixes to changed-crate selection in `rs/justfile`, all of the same shape: selection failing in a way that does not announce itself.

1. **Ambiguous package specs (the original bug).** `_select` emitted a bare `--package NAME`. `rs/kio` is at 0.5.5 and `web-transport-quinn` / `-noq` / `-quiche` / `-iroh` depend on `kio 0.5.5` from crates.io, so the resolve graph holds two packages named `kio` and cargo refuses to guess. It fires during package selection, before anything compiles, so it takes the whole gate down. Fixed by emitting ids from `cargo metadata`, which carry their source and so are unambiguous by construction. This fixes the class, not `kio` specifically.

2. **The wasm gate stopped firing.** Caught in review here, before it landed. The gate matched `--package (moq-wasm|moq-mux|moq-ffi)` literally, which never matches an id, so `just rs wasm` silently stopped running — and `moq-wasm`'s crate root is entirely `#[cfg(target_arch = "wasm32")]`, so the host pass compiles it to nothing and reports success. CI would have gone green while checking none of its code. Now keyed on crate names via `_names`, so it cannot break again when the spec form changes.

3. **A regression test**, since this PR shipped exactly the kind of bug it was meant to prevent. `_select-test` runs in `check`.

4. **A dependency-free crate would select nothing.** Reported by CodeRabbit, latent rather than live. The traversal printed `pkg[i]`, the source side of the dependency edges, so a crate is only selectable if it depends on something. Every crate does today (minimum three), but one added with no dependencies would emit no edge, select nothing, and be checked by nothing — reading as "no crates affected", a legitimate outcome for a docs-only diff.

## Public API changes

None. Build tooling only.

## Notes for review

**`want[name]`, not key existence.** The obvious form of fix 4 is wrong: awk creates a key on every `want[dep[i]]` read in the traversal, so `for (name in want) if (name != "")` emits every crate the workspace mentions — 20 packages for a diff touching only `rs/scripts/`. Testing the value is what keeps it exact. The metadata lookup that follows drops names that are not workspace crates, which is what stops the non-crate `rs/scripts` seed reaching cargo as a bogus spec.

**One predicate, not two.** The wasm gate moved into `_wants-wasm`, shared by `check-changed`, `fix-changed`, and the test. It was duplicated in both gates, and a test written against a copy of the alternation would not have caught fix 2.

## Test plan

**This PR's own green CI does not exercise the change.** `rs/justfile` is in `_select`'s workspace-wide input list, so a diff touching it returns `ALL` and exits before reaching the new code; `check-changed` then runs `just rs check --workspace`. Green here means the `ALL` route still works, nothing more.

The end-to-end proof is #2988, whose diff touches `rs/kio` and so genuinely makes `_select` emit ids. It was red on `Check` and `Test` with the ambiguity error; based on this branch it is now green on both.

Reproduced on `5755897` unmodified, so the bug is not specific to any in-flight branch:

```
$ cargo clippy --locked --all-targets --package kio --package moq-native -- -D warnings
error: specification `kio` is ambiguous
```

`--package moq-native` alone suffices, since its default `quinn` feature pulls `web-transport-quinn`.

Verified locally by running the recipe bodies directly, so the new path is actually exercised:

- **Selection is unchanged on every real input.** 23 crates for a `rs/kio` diff — byte-identical to the 23 the name-based version chose — 1 for `rs/moq-relay`, none for `rs/scripts`. Only the spec form changed.
- **The ids resolve.** Feeding `_select`'s flags to the real clippy command gets past package selection with zero ambiguity errors and builds 425 crates, including `kio v0.5.5 (/home/user/moq/rs/kio)` and the registry `kio v0.5.5` side by side, which is the coexistence that broke the bare name.
- **The wasm gate discriminates**, rather than always firing: fires for `rs/moq-wasm`, `rs/moq-ffi`, `rs/moq-mux` and `rs/kio` (which selects all three as dependents), skips for `rs/moq-relay` and `rs/moq-bench`.
- **`_select-test` fails on both regressions**, checked rather than assumed: bare names give `expected a source-qualified id, got: kio`, and restoring the old matcher gives `a kio diff must still drive the wasm gate`.
- That clippy run does not reach the end in my sandbox: `gstreamer-sys` fails its build script for want of `PKG_CONFIG_PATH` / `gstreamer-1.0.pc`, which the nix devshell provides and my environment does not. Unrelated to this change.

Not covered: the dependency-free case in fix 4 has no test, because exercising it needs a zero-dependency fixture crate in the workspace. Adding one to test build tooling seemed the worse trade. `_select-test` does pin the risk that fix introduces, namely that a non-crate seed still selects nothing.

Worth a look from someone who knows whether the `.id` format is pinned across the cargo versions CI uses. Both the `path+file://…#version` form (cargo 1.95 in CI, 1.97 locally) and the older `name version (source)` form are valid pkgid specs, so I believe it is safe either way.