### PR TITLE
fix(moq-net): cancel IETF subscriptions instead of only closing the stream

### DIFF
--- a/js/net/src/ietf/aliases.test.ts
+++ b/js/net/src/ietf/aliases.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "bun:test";
-import { RetiredTrackAlias, TrackAliases } from "./aliases.ts";
+import { DuplicateTrackAlias, RetiredTrackAlias, SharedTrackAlias, TrackAliases } from "./aliases.ts";
 
 test("waits for the control message that establishes an alias", async () => {
 	const aliases = new TrackAliases<object>();
 	const track = {};
 	const pending = aliases.get(7n);
 
-	aliases.set(7n, track);
+	aliases.set(7n, track, "cam/video");
 
 	expect(await pending).toBe(track);
 });
@@ -16,22 +16,32 @@ test("resolves every subgroup waiting for the same alias", async () => {
 	const track = {};
 	const pending = [aliases.get(7n), aliases.get(7n)];
 
-	aliases.set(7n, track);
+	aliases.set(7n, track, "cam/video");
 
 	expect(await Promise.all(pending)).toEqual([track, track]);
 });
 
 test("rejects an alias used by two active tracks", () => {
 	const aliases = new TrackAliases<object>();
-	aliases.set(7n, {});
+	aliases.set(7n, {}, "cam/video");
 
-	expect(() => aliases.set(7n, {})).toThrow("duplicate track alias");
+	expect(() => aliases.set(7n, {}, "cam/audio")).toThrow(DuplicateTrackAlias);
+});
+
+// Draft-19 section 5.1 lets a publisher give several subscriptions to one track the same
+// alias. We cannot demux that, but it is a legal choice: failing the session over it would
+// drop every other broadcast on the connection.
+test("sharing an alias across subscriptions to one track is not fatal", () => {
+	const aliases = new TrackAliases<object>();
+	aliases.set(7n, {}, "cam/video");
+
+	expect(() => aliases.set(7n, {}, "cam/video")).toThrow(SharedTrackAlias);
 });
 
 test("does not let stale cleanup retire a reused alias", async () => {
 	const aliases = new TrackAliases<object>();
 	const active = {};
-	aliases.set(7n, active);
+	aliases.set(7n, active, "cam/video");
 
 	aliases.retire(7n, {});
 
@@ -43,7 +53,7 @@ test("does not let stale cleanup retire a reused alias", async () => {
 test("a retired alias rejects late groups immediately", async () => {
 	const aliases = new TrackAliases<object>();
 	const track = {};
-	aliases.set(7n, track);
+	aliases.set(7n, track, "cam/video");
 	aliases.retire(7n, track);
 
 	await expect(aliases.get(7n)).rejects.toBeInstanceOf(RetiredTrackAlias);
@@ -54,11 +64,11 @@ test("a retired alias rejects late groups immediately", async () => {
 test("a later subscribe reclaims a retired alias", async () => {
 	const aliases = new TrackAliases<object>();
 	const old = {};
-	aliases.set(7n, old);
+	aliases.set(7n, old, "cam/video");
 	aliases.retire(7n, old);
 
 	const fresh = {};
-	aliases.set(7n, fresh);
+	aliases.set(7n, fresh, "cam/video");
 
 	expect(await aliases.get(7n)).toBe(fresh);
 });
@@ -70,7 +80,7 @@ test("retired aliases are capped", async () => {
 
 	for (let i = 0n; i < 74n; i++) {
 		const track = {};
-		aliases.set(i, track);
+		aliases.set(i, track, "cam/video");
 		aliases.retire(i, track);
 	}
 

--- a/js/net/src/ietf/aliases.test.ts
+++ b/js/net/src/ietf/aliases.test.ts
@@ -6,7 +6,7 @@ test("waits for the control message that establishes an alias", async () => {
 	const track = {};
 	const pending = aliases.get(7n);
 
-	aliases.set(7n, track, "cam/video");
+	aliases.set(7n, track, { broadcast: "cam", name: "video" });
 
 	expect(await pending).toBe(track);
 });
@@ -16,16 +16,26 @@ test("resolves every subgroup waiting for the same alias", async () => {
 	const track = {};
 	const pending = [aliases.get(7n), aliases.get(7n)];
 
-	aliases.set(7n, track, "cam/video");
+	aliases.set(7n, track, { broadcast: "cam", name: "video" });
 
 	expect(await Promise.all(pending)).toEqual([track, track]);
 });
 
 test("rejects an alias used by two active tracks", () => {
 	const aliases = new TrackAliases<object>();
-	aliases.set(7n, {}, "cam/video");
+	aliases.set(7n, {}, { broadcast: "cam", name: "video" });
 
-	expect(() => aliases.set(7n, {}, "cam/audio")).toThrow(DuplicateTrackAlias);
+	expect(() => aliases.set(7n, {}, { broadcast: "cam", name: "audio" })).toThrow(DuplicateTrackAlias);
+});
+
+// A track name may contain the separator a broadcast path uses, so identity has to keep the
+// two apart: "a" + "b/c" and "a/b" + "c" are different tracks, and a publisher pointing one
+// live alias at both is the collision section 11.1 makes fatal, not legal sharing.
+test("a track name containing a slash does not collide with a longer namespace", () => {
+	const aliases = new TrackAliases<object>();
+	aliases.set(7n, {}, { broadcast: "a", name: "b/c" });
+
+	expect(() => aliases.set(7n, {}, { broadcast: "a/b", name: "c" })).toThrow(DuplicateTrackAlias);
 });
 
 // Draft-19 section 5.1 lets a publisher give several subscriptions to one track the same
@@ -33,15 +43,15 @@ test("rejects an alias used by two active tracks", () => {
 // drop every other broadcast on the connection.
 test("sharing an alias across subscriptions to one track is not fatal", () => {
 	const aliases = new TrackAliases<object>();
-	aliases.set(7n, {}, "cam/video");
+	aliases.set(7n, {}, { broadcast: "cam", name: "video" });
 
-	expect(() => aliases.set(7n, {}, "cam/video")).toThrow(SharedTrackAlias);
+	expect(() => aliases.set(7n, {}, { broadcast: "cam", name: "video" })).toThrow(SharedTrackAlias);
 });
 
 test("does not let stale cleanup retire a reused alias", async () => {
 	const aliases = new TrackAliases<object>();
 	const active = {};
-	aliases.set(7n, active, "cam/video");
+	aliases.set(7n, active, { broadcast: "cam", name: "video" });
 
 	aliases.retire(7n, {});
 
@@ -53,7 +63,7 @@ test("does not let stale cleanup retire a reused alias", async () => {
 test("a retired alias rejects late groups immediately", async () => {
 	const aliases = new TrackAliases<object>();
 	const track = {};
-	aliases.set(7n, track, "cam/video");
+	aliases.set(7n, track, { broadcast: "cam", name: "video" });
 	aliases.retire(7n, track);
 
 	await expect(aliases.get(7n)).rejects.toBeInstanceOf(RetiredTrackAlias);
@@ -64,11 +74,11 @@ test("a retired alias rejects late groups immediately", async () => {
 test("a later subscribe reclaims a retired alias", async () => {
 	const aliases = new TrackAliases<object>();
 	const old = {};
-	aliases.set(7n, old, "cam/video");
+	aliases.set(7n, old, { broadcast: "cam", name: "video" });
 	aliases.retire(7n, old);
 
 	const fresh = {};
-	aliases.set(7n, fresh, "cam/video");
+	aliases.set(7n, fresh, { broadcast: "cam", name: "video" });
 
 	expect(await aliases.get(7n)).toBe(fresh);
 });
@@ -80,7 +90,7 @@ test("retired aliases are capped", async () => {
 
 	for (let i = 0n; i < 74n; i++) {
 		const track = {};
-		aliases.set(i, track, "cam/video");
+		aliases.set(i, track, { broadcast: "cam", name: "video" });
 		aliases.retire(i, track);
 	}
 

--- a/js/net/src/ietf/aliases.test.ts
+++ b/js/net/src/ietf/aliases.test.ts
@@ -48,6 +48,17 @@ test("sharing an alias across subscriptions to one track is not fatal", () => {
 	expect(() => aliases.set(7n, {}, { broadcast: "cam", name: "video" })).toThrow(SharedTrackAlias);
 });
 
+// Metadata keyed by an alias (the track's timescale) must only be torn down by whoever
+// still owns the binding, so retirement reports ownership rather than returning void.
+test("retire reports whether the caller still owned the alias", () => {
+	const aliases = new TrackAliases<object>();
+	const owner = {};
+	aliases.set(7n, owner, { broadcast: "cam", name: "video" });
+
+	expect(aliases.retire(7n, {})).toBe(false);
+	expect(aliases.retire(7n, owner)).toBe(true);
+});
+
 test("does not let stale cleanup retire a reused alias", async () => {
 	const aliases = new TrackAliases<object>();
 	const active = {};

--- a/js/net/src/ietf/aliases.test.ts
+++ b/js/net/src/ietf/aliases.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { TrackAliases } from "./aliases.ts";
+import { RetiredTrackAlias, TrackAliases } from "./aliases.ts";
 
 test("waits for the control message that establishes an alias", async () => {
 	const aliases = new TrackAliases<object>();
@@ -28,12 +28,53 @@ test("rejects an alias used by two active tracks", () => {
 	expect(() => aliases.set(7n, {})).toThrow("duplicate track alias");
 });
 
-test("does not let stale cleanup remove a reused alias", async () => {
+test("does not let stale cleanup retire a reused alias", async () => {
 	const aliases = new TrackAliases<object>();
 	const active = {};
 	aliases.set(7n, active);
 
-	aliases.delete(7n, {});
+	aliases.retire(7n, {});
 
 	expect(await aliases.get(7n)).toBe(active);
+});
+
+// A cancelled subscription leaves its alias behind, so the groups the publisher is still
+// sending are discarded at once instead of waiting out the timeout (draft-19 section 11.1).
+test("a retired alias rejects late groups immediately", async () => {
+	const aliases = new TrackAliases<object>();
+	const track = {};
+	aliases.set(7n, track);
+	aliases.retire(7n, track);
+
+	await expect(aliases.get(7n)).rejects.toBeInstanceOf(RetiredTrackAlias);
+});
+
+// The publisher may point a retired alias at a new track, so a later SUBSCRIBE_OK
+// reclaims it rather than colliding with the tombstone.
+test("a later subscribe reclaims a retired alias", async () => {
+	const aliases = new TrackAliases<object>();
+	const old = {};
+	aliases.set(7n, old);
+	aliases.retire(7n, old);
+
+	const fresh = {};
+	aliases.set(7n, fresh);
+
+	expect(await aliases.get(7n)).toBe(fresh);
+});
+
+// Tombstones are bounded: a session churning through subscriptions must not accumulate
+// one entry per alias it ever used.
+test("retired aliases are capped", async () => {
+	const aliases = new TrackAliases<object>();
+
+	for (let i = 0n; i < 74n; i++) {
+		const track = {};
+		aliases.set(i, track);
+		aliases.retire(i, track);
+	}
+
+	// The oldest tombstones are forgotten, so they fall back to the unknown-alias wait.
+	await expect(aliases.get(0n)).rejects.toThrow("unknown track alias");
+	await expect(aliases.get(73n)).rejects.toBeInstanceOf(RetiredTrackAlias);
 });

--- a/js/net/src/ietf/aliases.ts
+++ b/js/net/src/ietf/aliases.ts
@@ -2,8 +2,14 @@ const TRACK_ALIAS_TIMEOUT_MS = 1000;
 
 /**
  * How many cancelled aliases to remember. Objects keep arriving for about a round trip
- * after STOP_SENDING, so a handful covers the window, while the cap keeps a long session
- * with heavy subscription churn from accumulating tombstones for its whole lifetime.
+ * after we cancel, so a handful covers the window, while the cap keeps a long session with
+ * heavy subscription churn from accumulating tombstones for its whole lifetime.
+ *
+ * The bound is a count rather than a deadline, so eviction stays synchronous with
+ * retirement instead of needing a timer. The trade is that a session cancelling more than
+ * this many distinct aliases inside one round trip evicts a tombstone whose objects are
+ * still arriving; those fall back to the unknown-alias wait, which is the old behavior
+ * rather than a new failure.
  */
 const RETIRED_ALIAS_CAPACITY = 64;
 
@@ -12,9 +18,13 @@ type Resolver<T> = PromiseWithResolvers<T>["resolve"];
 /**
  * Thrown when a group arrives for a subscription we already cancelled.
  *
- * The publisher only stops once our STOP_SENDING reaches it, so objects keep arriving for
+ * The publisher only stops once our cancellation reaches it, so objects keep arriving for
  * at least a round trip afterwards. Draft-19 section 11.1 asks us to keep enough state to
  * discard them quickly "rather than treating them as belonging to an unknown Track Alias".
+ *
+ * This makes the window quiet, not safe. Once a publisher reassigns the alias the tombstone
+ * is reclaimed, and nothing on a group stream distinguishes the old subscription's objects
+ * from the new one's. Cancelling promptly is what bounds the exposure to a round trip.
  * @internal
  */
 export class RetiredTrackAlias extends Error {

--- a/js/net/src/ietf/aliases.ts
+++ b/js/net/src/ietf/aliases.ts
@@ -16,6 +16,20 @@ const RETIRED_ALIAS_CAPACITY = 64;
 type Resolver<T> = PromiseWithResolvers<T>["resolve"];
 
 /**
+ * The full track name an alias is bound to.
+ *
+ * Kept as two components rather than one joined string: a track name may contain the same
+ * separator a broadcast path uses, so `a` + `b/c` and `a/b` + `c` would otherwise compare
+ * equal and turn a genuine collision into apparent sharing.
+ * @internal
+ */
+export type TrackIdentity = { broadcast: string; name: string };
+
+function sameTrack(a: TrackIdentity, b: TrackIdentity): boolean {
+	return a.broadcast === b.broadcast && a.name === b.name;
+}
+
+/**
  * Thrown when a group arrives for a subscription we already cancelled.
  *
  * The publisher only stops once our cancellation reaches it, so objects keep arriving for
@@ -64,7 +78,7 @@ export class DuplicateTrackAlias extends Error {
 
 /** Resolves publisher-chosen track aliases after control/data stream reordering. @internal */
 export class TrackAliases<T> {
-	#active = new Map<bigint, { value: T; track: string }>();
+	#active = new Map<bigint, { value: T; track: TrackIdentity }>();
 	#pending = new Map<bigint, Set<Resolver<T>>>();
 
 	/** Aliases whose subscription we cancelled, in retirement order so the oldest is forgotten first. */
@@ -112,11 +126,11 @@ export class TrackAliases<T> {
 	 * ({@link SharedTrackAlias}) or the collision that must fail the session
 	 * ({@link DuplicateTrackAlias}).
 	 */
-	set(alias: bigint, value: T, track: string) {
+	set(alias: bigint, value: T, track: TrackIdentity) {
 		const active = this.#active.get(alias);
 		if (active !== undefined) {
 			if (active.value === value) return;
-			throw active.track === track ? new SharedTrackAlias(alias) : new DuplicateTrackAlias(alias);
+			throw sameTrack(active.track, track) ? new SharedTrackAlias(alias) : new DuplicateTrackAlias(alias);
 		}
 
 		// Our subscription is gone, so the publisher is free to point the alias somewhere

--- a/js/net/src/ietf/aliases.ts
+++ b/js/net/src/ietf/aliases.ts
@@ -149,12 +149,15 @@ export class TrackAliases<T> {
 	 *
 	 * Only retires an alias that still belongs to the supplied value: a later subscription
 	 * may already have reclaimed it, and that binding outranks a departing owner.
+	 *
+	 * Returns whether this caller still owned the binding, so metadata keyed by the alias is
+	 * only torn down by the owner and never out from under whoever reclaimed it.
 	 */
-	retire(alias: bigint, value: T) {
-		if (this.#active.get(alias)?.value !== value) return;
+	retire(alias: bigint, value: T): boolean {
+		if (this.#active.get(alias)?.value !== value) return false;
 		this.#active.delete(alias);
 
-		if (this.#retiredSet.has(alias)) return;
+		if (this.#retiredSet.has(alias)) return true;
 		this.#retiredSet.add(alias);
 		this.#retired.push(alias);
 
@@ -162,6 +165,8 @@ export class TrackAliases<T> {
 			const oldest = this.#retired.shift();
 			if (oldest !== undefined) this.#retiredSet.delete(oldest);
 		}
+
+		return true;
 	}
 
 	#forget(alias: bigint) {

--- a/js/net/src/ietf/aliases.ts
+++ b/js/net/src/ietf/aliases.ts
@@ -34,9 +34,37 @@ export class RetiredTrackAlias extends Error {
 	}
 }
 
+/**
+ * Thrown when a publisher gives one alias to two subscriptions of the same track.
+ *
+ * Draft-19 section 5.1 permits this and expects the subscriber to demux by re-applying
+ * each subscription's filter. Ours are all LargestObject, so they are indistinguishable and
+ * we cannot, which costs the one subscription. It is not a protocol error, so it must not
+ * take the session down with it.
+ * @internal
+ */
+export class SharedTrackAlias extends Error {
+	constructor(alias: bigint) {
+		super(`track alias shared by another subscription: ${alias}`);
+		this.name = "SharedTrackAlias";
+	}
+}
+
+/**
+ * Thrown when a publisher points one alias at two different tracks at once, which
+ * draft-19 section 11.1 makes fatal to the session.
+ * @internal
+ */
+export class DuplicateTrackAlias extends Error {
+	constructor(alias: bigint) {
+		super(`duplicate track alias: ${alias}`);
+		this.name = "DuplicateTrackAlias";
+	}
+}
+
 /** Resolves publisher-chosen track aliases after control/data stream reordering. @internal */
 export class TrackAliases<T> {
-	#active = new Map<bigint, T>();
+	#active = new Map<bigint, { value: T; track: string }>();
 	#pending = new Map<bigint, Set<Resolver<T>>>();
 
 	/** Aliases whose subscription we cancelled, in retirement order so the oldest is forgotten first. */
@@ -50,7 +78,8 @@ export class TrackAliases<T> {
 	 * waiting out the timeout for a binding that is never coming.
 	 */
 	async get(alias: bigint): Promise<T> {
-		if (this.#active.has(alias)) return this.#active.get(alias) as T;
+		const bound = this.#active.get(alias);
+		if (bound !== undefined) return bound.value;
 		if (this.#retiredSet.has(alias)) throw new RetiredTrackAlias(alias);
 
 		const { promise, resolve } = Promise.withResolvers<T>();
@@ -75,19 +104,26 @@ export class TrackAliases<T> {
 		}
 	}
 
-	/** Establishes an alias and releases any data streams waiting for it. */
-	set(alias: bigint, value: T) {
+	/**
+	 * Establishes an alias and releases any data streams waiting for it.
+	 *
+	 * `track` is the full track name the alias was bound to, which is what decides whether a
+	 * repeat is the legal sharing of an alias across subscriptions to one track
+	 * ({@link SharedTrackAlias}) or the collision that must fail the session
+	 * ({@link DuplicateTrackAlias}).
+	 */
+	set(alias: bigint, value: T, track: string) {
 		const active = this.#active.get(alias);
-		if (this.#active.has(alias)) {
-			if (active !== value) throw new Error(`duplicate track alias: ${alias}`);
-			return;
+		if (active !== undefined) {
+			if (active.value === value) return;
+			throw active.track === track ? new SharedTrackAlias(alias) : new DuplicateTrackAlias(alias);
 		}
 
 		// Our subscription is gone, so the publisher is free to point the alias somewhere
 		// new. Reclaiming it also drops the tombstone early.
 		this.#forget(alias);
 
-		this.#active.set(alias, value);
+		this.#active.set(alias, { value, track });
 		const resolvers = this.#pending.get(alias);
 		this.#pending.delete(alias);
 		for (const resolve of resolvers ?? []) resolve(value);
@@ -101,7 +137,7 @@ export class TrackAliases<T> {
 	 * may already have reclaimed it, and that binding outranks a departing owner.
 	 */
 	retire(alias: bigint, value: T) {
-		if (this.#active.get(alias) !== value) return;
+		if (this.#active.get(alias)?.value !== value) return;
 		this.#active.delete(alias);
 
 		if (this.#retiredSet.has(alias)) return;

--- a/js/net/src/ietf/aliases.ts
+++ b/js/net/src/ietf/aliases.ts
@@ -1,15 +1,47 @@
 const TRACK_ALIAS_TIMEOUT_MS = 1000;
 
+/**
+ * How many cancelled aliases to remember. Objects keep arriving for about a round trip
+ * after STOP_SENDING, so a handful covers the window, while the cap keeps a long session
+ * with heavy subscription churn from accumulating tombstones for its whole lifetime.
+ */
+const RETIRED_ALIAS_CAPACITY = 64;
+
 type Resolver<T> = PromiseWithResolvers<T>["resolve"];
+
+/**
+ * Thrown when a group arrives for a subscription we already cancelled.
+ *
+ * The publisher only stops once our STOP_SENDING reaches it, so objects keep arriving for
+ * at least a round trip afterwards. Draft-19 section 11.1 asks us to keep enough state to
+ * discard them quickly "rather than treating them as belonging to an unknown Track Alias".
+ * @internal
+ */
+export class RetiredTrackAlias extends Error {
+	constructor(alias: bigint) {
+		super(`track alias retired: ${alias}`);
+		this.name = "RetiredTrackAlias";
+	}
+}
 
 /** Resolves publisher-chosen track aliases after control/data stream reordering. @internal */
 export class TrackAliases<T> {
 	#active = new Map<bigint, T>();
 	#pending = new Map<bigint, Set<Resolver<T>>>();
 
-	/** Waits briefly for an alias to be established by SUBSCRIBE_OK or PUBLISH. */
+	/** Aliases whose subscription we cancelled, in retirement order so the oldest is forgotten first. */
+	#retired: bigint[] = [];
+	#retiredSet = new Set<bigint>();
+
+	/**
+	 * Waits briefly for an alias to be established by SUBSCRIBE_OK or PUBLISH.
+	 *
+	 * Throws {@link RetiredTrackAlias} at once for an alias we cancelled, rather than
+	 * waiting out the timeout for a binding that is never coming.
+	 */
 	async get(alias: bigint): Promise<T> {
 		if (this.#active.has(alias)) return this.#active.get(alias) as T;
+		if (this.#retiredSet.has(alias)) throw new RetiredTrackAlias(alias);
 
 		const { promise, resolve } = Promise.withResolvers<T>();
 		let resolvers = this.#pending.get(alias);
@@ -41,14 +73,40 @@ export class TrackAliases<T> {
 			return;
 		}
 
+		// Our subscription is gone, so the publisher is free to point the alias somewhere
+		// new. Reclaiming it also drops the tombstone early.
+		this.#forget(alias);
+
 		this.#active.set(alias, value);
 		const resolvers = this.#pending.get(alias);
 		this.#pending.delete(alias);
 		for (const resolve of resolvers ?? []) resolve(value);
 	}
 
-	/** Removes an alias only if it still belongs to the supplied value. */
-	delete(alias: bigint, value: T) {
-		if (this.#active.get(alias) === value) this.#active.delete(alias);
+	/**
+	 * Retires an alias whose subscription was cancelled, so groups still in flight for it
+	 * are discarded promptly instead of reported as unknown.
+	 *
+	 * Only retires an alias that still belongs to the supplied value: a later subscription
+	 * may already have reclaimed it, and that binding outranks a departing owner.
+	 */
+	retire(alias: bigint, value: T) {
+		if (this.#active.get(alias) !== value) return;
+		this.#active.delete(alias);
+
+		if (this.#retiredSet.has(alias)) return;
+		this.#retiredSet.add(alias);
+		this.#retired.push(alias);
+
+		while (this.#retired.length > RETIRED_ALIAS_CAPACITY) {
+			const oldest = this.#retired.shift();
+			if (oldest !== undefined) this.#retiredSet.delete(oldest);
+		}
+	}
+
+	#forget(alias: bigint) {
+		if (!this.#retiredSet.delete(alias)) return;
+		const at = this.#retired.indexOf(alias);
+		if (at !== -1) this.#retired.splice(at, 1);
 	}
 }

--- a/js/net/src/ietf/subscriber.test.ts
+++ b/js/net/src/ietf/subscriber.test.ts
@@ -4,10 +4,11 @@ import { createMockTransportPair } from "../mock.ts";
 import { type Origin, OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Stream } from "../stream.ts";
-import { NativeSession } from "./adapter.ts";
+import { ControlStreamAdapter, NativeSession } from "./adapter.ts";
 import type * as Cluster from "./cluster.ts";
 import { PublishNamespace } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
+import { Unsubscribe } from "./subscribe.ts";
 import { SubscribeNamespace, SubscribeNamespaceEntry, SubscribeNamespaceEntryDone } from "./subscribe_namespace.ts";
 import { Subscriber } from "./subscriber.ts";
 import { ALPN, Version } from "./version.ts";
@@ -461,4 +462,53 @@ test("a PUBLISH_NAMESPACE update that starts looping back is detached", async ()
 
 	peer.close();
 	await handler;
+});
+
+/**
+ * Drafts 14-16 carry every request over the control stream adapter's virtual streams,
+ * whose abort is local. UNSUBSCRIBE is the only cancellation that reaches the peer there,
+ * so a cancelled subscription is only really cancelled if that message lands on the real
+ * control stream.
+ */
+test("a legacy cancel reaches the control stream", async () => {
+	const LEGACY = Version.DRAFT_16;
+	const pair = createMockTransportPair(ALPN.DRAFT_16);
+
+	// The one real bidi everything is multiplexed onto.
+	const controlStream = await Stream.open(pair.server, { version: LEGACY });
+	const session = new ControlStreamAdapter(pair.server, controlStream, LEGACY, 100n, true);
+	const subscriber = new Subscriber({ session });
+
+	// The peer's view of that control stream.
+	const peer = await nextStream(pair.client);
+	expect(peer).toBeDefined();
+
+	// Ask for a track, which writes SUBSCRIBE, then drop the only consumer.
+	const broadcast = subscriber.consume(Path.from("room"));
+	const track = broadcast.subscribe("video");
+
+	// Let the SUBSCRIBE reach the control stream before walking away.
+	await new Promise((resolve) => setTimeout(resolve, 50));
+	track.close();
+
+	// Everything the subscriber actually put on the wire.
+	const seen: bigint[] = [];
+	const deadline = Date.now() + STREAM_WAIT;
+	while (Date.now() < deadline) {
+		const type = await Promise.race([
+			// biome-ignore lint/style/noNonNullAssertion: guarded by the expect above
+			peer!.reader.u53().catch(() => undefined),
+			new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 100)),
+		]);
+		if (type === undefined) break;
+
+		seen.push(BigInt(type));
+		// biome-ignore lint/style/noNonNullAssertion: guarded by the expect above
+		const size = await peer!.reader.u16();
+		// biome-ignore lint/style/noNonNullAssertion: guarded by the expect above
+		if (size > 0) await peer!.reader.read(size);
+		if (BigInt(type) === BigInt(Unsubscribe.id)) break;
+	}
+
+	expect(seen).toContain(BigInt(Unsubscribe.id));
 });

--- a/js/net/src/ietf/subscriber.test.ts
+++ b/js/net/src/ietf/subscriber.test.ts
@@ -512,3 +512,53 @@ test("a legacy cancel reaches the control stream", async () => {
 
 	expect(seen).toContain(BigInt(Unsubscribe.id));
 });
+
+/**
+ * A publisher that rejects a SUBSCRIBE has torn the request down before answering, so there
+ * is nothing left to cancel. Naming a dead request id back at it is what a strict peer can
+ * read as a protocol violation and close an otherwise healthy session over.
+ */
+test("a rejected subscribe is not unsubscribed", async () => {
+	const LEGACY = Version.DRAFT_16;
+	const pair = createMockTransportPair(ALPN.DRAFT_16);
+
+	const controlStream = await Stream.open(pair.server, { version: LEGACY });
+	const session = new ControlStreamAdapter(pair.server, controlStream, LEGACY, 100n, true);
+	// The mux read loop, which is what routes a response back to its virtual stream.
+	void session.run().catch(() => void 0);
+	const subscriber = new Subscriber({ session });
+
+	const peer = await nextStream(pair.client);
+	expect(peer).toBeDefined();
+	// biome-ignore lint/style/noNonNullAssertion: guarded above
+	const wire = peer!;
+
+	const broadcast = subscriber.consume(Path.from("room"));
+	const track = broadcast.subscribe("video");
+
+	// Read the SUBSCRIBE, then reject it the way a publisher that cannot serve it would.
+	const subscribeType = await wire.reader.u53();
+	const subscribeSize = await wire.reader.u16();
+	await wire.reader.read(subscribeSize);
+	expect(subscribeType).toBe(3);
+
+	await wire.writer.u53(RequestError.id);
+	await new RequestError({
+		requestId: 0n,
+		errorCode: 404,
+		reasonPhrase: "not found",
+		retryInterval: 0n,
+	}).encode(wire.writer, LEGACY);
+
+	await new Promise((resolve) => setTimeout(resolve, 100));
+	track.close();
+	await new Promise((resolve) => setTimeout(resolve, 100));
+
+	// Nothing further belongs on the control stream: the request is already gone.
+	const next = await Promise.race([
+		wire.reader.u53().catch(() => undefined),
+		new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 200)),
+	]);
+
+	expect(next).toBeUndefined();
+});

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -44,6 +44,12 @@ const SUBSCRIBE_OK_TIMEOUT_MS = 10_000;
 type SubscribeSetupState = {
 	stream?: Stream;
 	registeredAlias?: bigint;
+	/**
+	 * Whether SUBSCRIBE_OK arrived, meaning the publisher holds an Established subscription
+	 * and will keep serving it until told otherwise. Set before the alias is bound, since
+	 * binding is one of the things that can fail after the publisher has already accepted.
+	 */
+	established?: boolean;
 };
 
 /**
@@ -377,7 +383,6 @@ export class Subscriber {
 	}
 
 	async #runSubscribe(broadcast: Path.Valid, request: track.Request) {
-		const version = this.#session.version;
 		const requestId = await this.#session.nextRequestId();
 		if (requestId === undefined) {
 			request.reject(new Error("session closed"));
@@ -420,9 +425,16 @@ export class Subscriber {
 			// and drop any registration so we don't leak. Cover both branches:
 			// setup may resolve late, or reject (e.g. SUBSCRIBE error) after the
 			// stream is already open.
-			const cleanup = () => {
+			const cleanup = async () => {
 				if (state.registeredAlias !== undefined) this.#aliases.retire(state.registeredAlias, producer);
-				state.stream?.abort(e);
+				// SUBSCRIBE_OK may already have arrived, in which case the publisher holds an
+				// Established subscription and keeps serving it. Aborting says nothing on
+				// v14-16, where the request rides a virtual stream whose reset is local, so
+				// the UNSUBSCRIBE has to go out explicitly.
+				if (state.stream) {
+					if (state.established) await this.#cancelSubscribe(state.stream, requestId);
+					state.stream.abort(e);
+				}
 			};
 			setup.then(cleanup, cleanup);
 			return;
@@ -443,16 +455,7 @@ export class Subscriber {
 				break;
 			}
 
-			// For v14-v16: send Unsubscribe before closing (removed in v17+)
-			if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
-				try {
-					await stream.writer.u53(Unsubscribe.id);
-					const unsub = new Unsubscribe({ requestId });
-					await unsub.encode(stream.writer, version);
-				} catch {
-					// Stream might already be closed
-				}
-			}
+			await this.#cancelSubscribe(stream, requestId);
 
 			producer.close();
 			stream.close();
@@ -467,6 +470,27 @@ export class Subscriber {
 		} finally {
 			this.#aliases.retire(trackAlias, producer);
 			this.#timescales.delete(trackAlias);
+		}
+	}
+
+	/**
+	 * Tell the publisher to stop serving a subscription we are walking away from.
+	 *
+	 * v14-16 cancel with UNSUBSCRIBE (draft-16 section 9.12), which is what lets the
+	 * publisher destroy the subscription (section 5.1.1); v17+ removed the message and
+	 * rely on the stream reset instead. Every path that abandons an Established
+	 * subscription goes through here, because those versions carry the request over a
+	 * virtual stream whose reset never reaches the peer.
+	 */
+	async #cancelSubscribe(stream: Stream, requestId: bigint) {
+		const version = this.#session.version;
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15 && version !== Version.DRAFT_16) return;
+
+		try {
+			await stream.writer.u53(Unsubscribe.id);
+			await new Unsubscribe({ requestId }).encode(stream.writer, version);
+		} catch {
+			// The stream may already be gone; there is nothing further to tell the peer.
 		}
 	}
 
@@ -513,8 +537,10 @@ export class Subscriber {
 		}
 
 		const ok = await SubscribeOk.decode(state.stream.reader, version);
+		state.established = true;
+
 		try {
-			this.#aliases.set(ok.trackAlias, producer, `${broadcast}/${request.name}`);
+			this.#aliases.set(ok.trackAlias, producer, { broadcast, name: request.name });
 			if (ok.timescale !== undefined) {
 				this.#timescales.set(ok.trackAlias, ok.timescale);
 			}

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -45,11 +45,17 @@ type SubscribeSetupState = {
 	stream?: Stream;
 	registeredAlias?: bigint;
 	/**
-	 * Whether SUBSCRIBE_OK arrived, meaning the publisher holds an Established subscription
-	 * and will keep serving it until told otherwise. Set before the alias is bound, since
-	 * binding is one of the things that can fail after the publisher has already accepted.
+	 * Whether the caller has given up. Setup checks this once the stream exists so a request
+	 * opened after the timeout still unwinds: nothing else settles setup if the peer has
+	 * gone quiet, and the cleanup that fired first saw no stream to tear down.
 	 */
-	established?: boolean;
+	cancelled?: boolean;
+	/**
+	 * Whether the SUBSCRIBE reached the wire. From that moment the publisher may be serving,
+	 * even before it answers, so abandoning owes it a cancellation regardless of whether we
+	 * ever saw the SUBSCRIBE_OK.
+	 */
+	sent?: boolean;
 };
 
 /**
@@ -426,6 +432,8 @@ export class Subscriber {
 			// the first pass; the stream is torn down once.
 			let torn = false;
 			const cleanup = async () => {
+				state.cancelled = true;
+
 				if (state.registeredAlias !== undefined && this.#aliases.retire(state.registeredAlias, producer)) {
 					this.#timescales.delete(state.registeredAlias);
 				}
@@ -433,11 +441,11 @@ export class Subscriber {
 				if (!state.stream || torn) return;
 				torn = true;
 
-				// SUBSCRIBE_OK may already have arrived, in which case the publisher holds an
-				// Established subscription and keeps serving it. Aborting says nothing on
-				// v14-16, where the request rides a virtual stream whose reset is local, so
-				// the UNSUBSCRIBE has to go out explicitly.
-				if (state.established) await this.#cancelSubscribe(state.stream, requestId);
+				// Once the SUBSCRIBE is out the publisher may be serving, whether or not it has
+				// answered yet: data streams are independent of the request stream. Aborting says
+				// nothing on v14-16, where the request rides a virtual stream whose reset is
+				// local, so the UNSUBSCRIBE has to go out explicitly.
+				if (state.sent) await this.#cancelSubscribe(state.stream, requestId);
 				state.stream.abort(e);
 			};
 
@@ -532,6 +540,11 @@ export class Subscriber {
 
 		state.stream = await this.#session.openBi();
 
+		// The timeout can fire while the open is still in flight, in which case cleanup ran
+		// with nothing to release. Bail now that the stream is recorded, so settling this
+		// promise hands it back to be torn down.
+		if (state.cancelled) throw new Error("subscribe cancelled before it was sent");
+
 		await state.stream.writer.u53(Subscribe.id);
 		const msg = new Subscribe({
 			requestId,
@@ -540,6 +553,7 @@ export class Subscriber {
 			subscriberPriority: toWire(request.priority),
 		});
 		await msg.encode(state.stream.writer, version);
+		state.sent = true;
 		console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.name}`);
 
 		const respTypeId = await state.stream.reader.u53();
@@ -560,7 +574,6 @@ export class Subscriber {
 		}
 
 		const ok = await SubscribeOk.decode(state.stream.reader, version);
-		state.established = true;
 
 		try {
 			this.#aliases.set(ok.trackAlias, producer, { broadcast, name: request.name });

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -410,14 +410,30 @@ export class Subscriber {
 		const state: SubscribeSetupState = {};
 		const setup = this.#openSubscribe(state, broadcast, request, producer, requestId);
 
+		// The publisher can be serving before it answers, so waiting only on the response
+		// would miss the local side going away and leave it serving a track nobody reads.
+		// Demand returning before we commit is not abandonment, matching the serving loop.
+		const waitAbandoned = async (): Promise<null> => {
+			for (;;) {
+				await producer.unused();
+				if (producer.closed.peek() !== undefined || !producer.used.peek()) return null;
+			}
+		};
+
 		let stream: Stream;
 		let trackAlias: bigint;
 		try {
-			const result = await withTimeout(
-				setup,
-				SUBSCRIBE_OK_TIMEOUT_MS,
-				`subscribe timed out after ${SUBSCRIBE_OK_TIMEOUT_MS}ms waiting for SUBSCRIBE_OK (browser stream limit reached?)`,
-			);
+			const result = await Promise.race([
+				withTimeout(
+					setup,
+					SUBSCRIBE_OK_TIMEOUT_MS,
+					`subscribe timed out after ${SUBSCRIBE_OK_TIMEOUT_MS}ms waiting for SUBSCRIBE_OK (browser stream limit reached?)`,
+				),
+				waitAbandoned(),
+			]);
+
+			if (result === null) throw new Error("subscribe abandoned before it was accepted");
+
 			stream = result.stream;
 			trackAlias = result.alias;
 			console.debug(`subscribe ok: id=${requestId} broadcast=${broadcast} track=${request.name}`);
@@ -431,7 +447,7 @@ export class Subscriber {
 			// Retirement is repeated because a late SUBSCRIBE_OK can register an alias after
 			// the first pass; the stream is torn down once.
 			let torn = false;
-			const cleanup = async () => {
+			const cleanup = async (afterSetup: boolean) => {
 				state.cancelled = true;
 
 				if (state.registeredAlias !== undefined && this.#aliases.retire(state.registeredAlias, producer)) {
@@ -439,6 +455,13 @@ export class Subscriber {
 				}
 
 				if (!state.stream || torn) return;
+
+				// A SUBSCRIBE still being written must not be torn down from here. Aborting a
+				// Web Stream waits for the in-flight write, so the request can still reach the
+				// peer while the abort destroys the stream we would have cancelled on. Setup
+				// unwinds on the cancelled flag once that write lands, and its pass below has
+				// the finished picture.
+				if (!state.sent && !afterSetup) return;
 				torn = true;
 
 				// Once the SUBSCRIBE is out the publisher may be serving, whether or not it has
@@ -453,8 +476,11 @@ export class Subscriber {
 			// opened the stream and then went quiet never settles it, and deferring would
 			// leave the request outstanding for the life of the session -- which is the
 			// timeout case, not a rare one.
-			void cleanup();
-			setup.then(cleanup, cleanup);
+			void cleanup(false);
+			setup.then(
+				() => cleanup(true),
+				() => cleanup(true),
+			);
 			return;
 		}
 
@@ -554,6 +580,11 @@ export class Subscriber {
 		});
 		await msg.encode(state.stream.writer, version);
 		state.sent = true;
+
+		// The caller may have given up while that write was in flight. It deliberately left
+		// the stream alone, so unwind here and let its cleanup send the cancellation now that
+		// the SUBSCRIBE has actually reached the peer.
+		if (state.cancelled) throw new Error("subscribe cancelled while it was being sent");
 		console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.name}`);
 
 		const respTypeId = await state.stream.reader.u53();

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -441,21 +441,33 @@ export class Subscriber {
 		}
 
 		try {
+			// Which terminal fired decides whether we owe the publisher a cancellation, so
+			// tag them rather than racing bare promises.
+			const publisherEnded = Symbol("publisher");
+			const localEnded = Symbol("local");
+			const idle = Symbol("idle");
+
 			// Terminal conditions settle at most once (stream close = PublishDone, track close =
 			// local unsubscribe); race them once so the demand loop doesn't re-subscribe each pass.
-			const done = Promise.race([stream.reader.closed, producer.closed]);
+			const done = Promise.race([
+				stream.reader.closed.then(() => publisherEnded),
+				producer.closed.then(() => localEnded),
+			]);
 
 			// Serve until a terminal condition fires or the last local subscriber leaves. The unused
 			// wake is level-triggered: re-check demand so a subscriber that returns before we tear
 			// down resumes on the same stream.
-			const idle = Symbol("idle");
+			let terminal = localEnded;
 			for (;;) {
 				const reason = await Promise.race([done, producer.unused().then(() => idle)]);
 				if (reason === idle && producer.closed.peek() === undefined && producer.used.peek()) continue;
+				terminal = reason;
 				break;
 			}
 
-			await this.#cancelSubscribe(stream, requestId);
+			// The publisher already ended the request, so there is nothing to cancel. Sending
+			// UNSUBSCRIBE here would name a request it has already torn down.
+			if (terminal !== publisherEnded) await this.#cancelSubscribe(stream, requestId);
 
 			producer.close();
 			stream.close();

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -9,7 +9,7 @@ import { type Timescale, Timestamp } from "../time.ts";
 import type * as track from "../track.ts";
 import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
-import { RetiredTrackAlias, TrackAliases } from "./aliases.ts";
+import { DuplicateTrackAlias, RetiredTrackAlias, TrackAliases } from "./aliases.ts";
 import * as Cluster from "./cluster.ts";
 import { Frame, type Group as GroupMessage } from "./object.ts";
 import { toWire } from "./priority.ts";
@@ -514,12 +514,15 @@ export class Subscriber {
 
 		const ok = await SubscribeOk.decode(state.stream.reader, version);
 		try {
-			this.#aliases.set(ok.trackAlias, producer);
+			this.#aliases.set(ok.trackAlias, producer, `${broadcast}/${request.name}`);
 			if (ok.timescale !== undefined) {
 				this.#timescales.set(ok.trackAlias, ok.timescale);
 			}
 		} catch (err) {
-			this.#session.close();
+			// Only one alias naming two different tracks is the session's problem. A publisher
+			// sharing an alias between subscriptions to one track is allowed to do that, and
+			// disconnecting over it would drop every other broadcast on the session.
+			if (err instanceof DuplicateTrackAlias) this.#session.close();
 			throw err;
 		}
 		state.registeredAlias = ok.trackAlias;

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -56,6 +56,12 @@ type SubscribeSetupState = {
 	 * ever saw the SUBSCRIBE_OK.
 	 */
 	sent?: boolean;
+	/**
+	 * Whether the publisher answered with an error. It has torn the request down already, so
+	 * there is nothing left to cancel and naming the dead request id at it risks being read
+	 * as a protocol violation.
+	 */
+	rejected?: boolean;
 };
 
 /**
@@ -468,7 +474,7 @@ export class Subscriber {
 				// answered yet: data streams are independent of the request stream. Aborting says
 				// nothing on v14-16, where the request rides a virtual stream whose reset is
 				// local, so the UNSUBSCRIBE has to go out explicitly.
-				if (state.sent) await this.#cancelSubscribe(state.stream, requestId);
+				if (state.sent && !state.rejected) await this.#cancelSubscribe(state.stream, requestId);
 				state.stream.abort(e);
 			};
 
@@ -601,6 +607,7 @@ export class Subscriber {
 			} catch {
 				// Decoding error response failed, use default message
 			}
+			state.rejected = true;
 			throw new Error(`SUBSCRIBE error: ${reasonPhrase}`);
 		}
 

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -421,21 +421,31 @@ export class Subscriber {
 			console.warn(
 				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${reason(e)}`,
 			);
-			// If setup eventually settles after the timeout, abort the stream
-			// and drop any registration so we don't leak. Cover both branches:
-			// setup may resolve late, or reject (e.g. SUBSCRIBE error) after the
-			// stream is already open.
+			// Runs now for whatever is already open, and again if `setup` settles late.
+			// Retirement is repeated because a late SUBSCRIBE_OK can register an alias after
+			// the first pass; the stream is torn down once.
+			let torn = false;
 			const cleanup = async () => {
-				if (state.registeredAlias !== undefined) this.#aliases.retire(state.registeredAlias, producer);
+				if (state.registeredAlias !== undefined && this.#aliases.retire(state.registeredAlias, producer)) {
+					this.#timescales.delete(state.registeredAlias);
+				}
+
+				if (!state.stream || torn) return;
+				torn = true;
+
 				// SUBSCRIBE_OK may already have arrived, in which case the publisher holds an
 				// Established subscription and keeps serving it. Aborting says nothing on
 				// v14-16, where the request rides a virtual stream whose reset is local, so
 				// the UNSUBSCRIBE has to go out explicitly.
-				if (state.stream) {
-					if (state.established) await this.#cancelSubscribe(state.stream, requestId);
-					state.stream.abort(e);
-				}
+				if (state.established) await this.#cancelSubscribe(state.stream, requestId);
+				state.stream.abort(e);
 			};
+
+			// Tear down what is already open rather than waiting on `setup`. A peer that
+			// opened the stream and then went quiet never settles it, and deferring would
+			// leave the request outstanding for the life of the session -- which is the
+			// timeout case, not a rare one.
+			void cleanup();
 			setup.then(cleanup, cleanup);
 			return;
 		}
@@ -480,8 +490,9 @@ export class Subscriber {
 				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${reason(e)}`,
 			);
 		} finally {
-			this.#aliases.retire(trackAlias, producer);
-			this.#timescales.delete(trackAlias);
+			// Only the owner tears down the alias metadata: a later subscription may have
+			// reclaimed the alias and installed its own timescale.
+			if (this.#aliases.retire(trackAlias, producer)) this.#timescales.delete(trackAlias);
 		}
 	}
 

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -9,7 +9,7 @@ import { type Timescale, Timestamp } from "../time.ts";
 import type * as track from "../track.ts";
 import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
-import { TrackAliases } from "./aliases.ts";
+import { RetiredTrackAlias, TrackAliases } from "./aliases.ts";
 import * as Cluster from "./cluster.ts";
 import { Frame, type Group as GroupMessage } from "./object.ts";
 import { toWire } from "./priority.ts";
@@ -421,7 +421,7 @@ export class Subscriber {
 			// setup may resolve late, or reject (e.g. SUBSCRIBE error) after the
 			// stream is already open.
 			const cleanup = () => {
-				if (state.registeredAlias !== undefined) this.#aliases.delete(state.registeredAlias, producer);
+				if (state.registeredAlias !== undefined) this.#aliases.retire(state.registeredAlias, producer);
 				state.stream?.abort(e);
 			};
 			setup.then(cleanup, cleanup);
@@ -465,7 +465,7 @@ export class Subscriber {
 				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${reason(e)}`,
 			);
 		} finally {
-			this.#aliases.delete(trackAlias, producer);
+			this.#aliases.retire(trackAlias, producer);
 			this.#timescales.delete(trackAlias);
 		}
 	}
@@ -672,11 +672,18 @@ export class Subscriber {
 	async runPublish(msg: Publish, stream: Stream) {
 		const version = this.#session.version;
 
+		// NOT_SUPPORTED, from the PUBLISH error codes in draft-19 section 10.10. We decline
+		// the method itself rather than this particular track, which is UNINTERESTED (0x4).
+		//
+		// The alias the message carries is deliberately not recorded. Nothing will ever bind
+		// it, and a rejected request has no lifetime of ours to hang the cleanup on.
+		const NOT_SUPPORTED = 0x3;
+
 		if (version === Version.DRAFT_14) {
 			await stream.writer.u53(PublishError.id);
 			const err = new PublishError({
 				requestId: msg.requestId,
-				errorCode: 500,
+				errorCode: NOT_SUPPORTED,
 				reasonPhrase: "publish not supported",
 			});
 			await err.encode(stream.writer, version);
@@ -684,7 +691,7 @@ export class Subscriber {
 			await stream.writer.u53(RequestError.id);
 			const err = new RequestError({
 				requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
-				errorCode: 500,
+				errorCode: NOT_SUPPORTED,
 				reasonPhrase: "publish not supported",
 			});
 			await err.encode(stream.writer, version);
@@ -728,6 +735,12 @@ export class Subscriber {
 			producer.close();
 		} catch (err: unknown) {
 			const e = error(err);
+			// Ours: we cancelled the subscription and the publisher has not stopped yet.
+			// Anything else on this alias is the publisher sending data for a track it never
+			// acknowledged, which is worth seeing.
+			if (e instanceof RetiredTrackAlias) {
+				console.debug(`dropping group for a cancelled subscription: alias=${group.trackAlias}`);
+			}
 			producer.close(e);
 			stream.stop(e);
 		}

--- a/rs/moq-net/src/coding/reader.rs
+++ b/rs/moq-net/src/coding/reader.rs
@@ -152,6 +152,15 @@ impl<S: web_transport_trait::RecvStream, V> Reader<S, V> {
 		self.stream.stop(err.to_code());
 	}
 
+	/// Abort the stream with a raw application code.
+	///
+	/// [`Self::abort`] encodes the moq-lite error space. A protocol with its own registry
+	/// of stream reset codes has to name one directly, since the two spaces do not agree
+	/// on what a given number means.
+	pub fn stop(&mut self, code: u32) {
+		self.stream.stop(code);
+	}
+
 	/// Cast the reader to a different version, used during version negotiation.
 	pub fn with_version<V2>(self, version: V2) -> Reader<S, V2> {
 		Reader {

--- a/rs/moq-net/src/ietf/error.rs
+++ b/rs/moq-net/src/ietf/error.rs
@@ -2,31 +2,36 @@
 
 use crate::Error;
 
-/// The stream reset codes from draft-19 section 3.3.4.
+/// The stream died on our side, with no registry entry for why.
 ///
 /// Deliberately separate from [`Error::to_code`], which encodes moq-lite's space. Those
 /// codes are our own and unstandardized; these are the registry every moq-transport peer
 /// reads. The same number means different things on the two wires, so the mappings must
-/// not be interchanged: moq-lite's cancel is 0, which here is an internal failure.
+/// not be interchanged: moq-lite's cancel is 0, which here is this.
 pub const INTERNAL_ERROR: u32 = 0x0;
+
 /// The stream was cancelled by either endpoint.
 pub const CANCELLED: u32 = 0x1;
-/// A delivery timeout was exceeded for this stream.
-pub const DELIVERY_TIMEOUT: u32 = 0x2;
-/// The session is being closed.
-pub const SESSION_CLOSED: u32 = 0x3;
+
+// Draft-19 section 3.3.4 also defines DELIVERY_TIMEOUT (0x2) and SESSION_CLOSED (0x3).
+// Neither is named here because nothing we can currently detect earns them: the first is
+// the negotiated timeout of section 8 rather than any expiry, and the second asserts the
+// whole session is going away. Add them alongside the path that can actually prove one.
 
 /// The code to reset a stream or send STOP_SENDING with.
 ///
-/// Anything without a registry entry is an internal failure, which is what the code means:
-/// the peer learns that the stream died on our side rather than being told a reason we made
-/// up. A routine cancellation is the one worth distinguishing, since reporting it as a
-/// failure is what distorts a publisher's error handling and telemetry.
+/// Only cancellation maps, because only cancellation has a meaning both spaces agree on.
+/// The rest of the registry is narrower than it looks: DELIVERY_TIMEOUT is the negotiated
+/// timeout of draft-19 section 8, not any expiry we happen to hit, and SESSION_CLOSED
+/// asserts the session is going away rather than one handle or one piece of content. Our
+/// generic errors do not establish either, so claiming them would tell a peer something
+/// specific and untrue.
+///
+/// Everything else is INTERNAL_ERROR, which is the honest answer: the stream died on our
+/// side and we have no registry entry for why.
 pub fn to_stream_code(err: &Error) -> u32 {
 	match err {
 		Error::Cancel => CANCELLED,
-		Error::Timeout => DELIVERY_TIMEOUT,
-		Error::Closed | Error::Dropped => SESSION_CLOSED,
 		_ => INTERNAL_ERROR,
 	}
 }
@@ -49,10 +54,19 @@ mod tests {
 	}
 
 	/// An error with no registry entry says "this died on our side" rather than inventing a
-	/// meaning a peer would read as something specific.
+	/// meaning a peer would read as something specific. That includes errors whose names
+	/// echo a registry entry: our timeouts are not the negotiated delivery timeout, and a
+	/// closed handle is not a closing session.
 	#[test]
 	fn unmapped_errors_are_internal() {
-		assert_eq!(to_stream_code(&Error::NotFound), INTERNAL_ERROR);
-		assert_eq!(to_stream_code(&Error::Duplicate), INTERNAL_ERROR);
+		for err in [
+			Error::NotFound,
+			Error::Duplicate,
+			Error::Timeout,
+			Error::Closed,
+			Error::Dropped,
+		] {
+			assert_eq!(to_stream_code(&err), INTERNAL_ERROR, "{err:?} has no registry meaning");
+		}
 	}
 }

--- a/rs/moq-net/src/ietf/error.rs
+++ b/rs/moq-net/src/ietf/error.rs
@@ -1,0 +1,58 @@
+//! Stream reset codes for the moq-transport wire.
+
+use crate::Error;
+
+/// The stream reset codes from draft-19 section 3.3.4.
+///
+/// Deliberately separate from [`Error::to_code`], which encodes moq-lite's space. Those
+/// codes are our own and unstandardized; these are the registry every moq-transport peer
+/// reads. The same number means different things on the two wires, so the mappings must
+/// not be interchanged: moq-lite's cancel is 0, which here is an internal failure.
+pub const INTERNAL_ERROR: u32 = 0x0;
+/// The stream was cancelled by either endpoint.
+pub const CANCELLED: u32 = 0x1;
+/// A delivery timeout was exceeded for this stream.
+pub const DELIVERY_TIMEOUT: u32 = 0x2;
+/// The session is being closed.
+pub const SESSION_CLOSED: u32 = 0x3;
+
+/// The code to reset a stream or send STOP_SENDING with.
+///
+/// Anything without a registry entry is an internal failure, which is what the code means:
+/// the peer learns that the stream died on our side rather than being told a reason we made
+/// up. A routine cancellation is the one worth distinguishing, since reporting it as a
+/// failure is what distorts a publisher's error handling and telemetry.
+pub fn to_stream_code(err: &Error) -> u32 {
+	match err {
+		Error::Cancel => CANCELLED,
+		Error::Timeout => DELIVERY_TIMEOUT,
+		Error::Closed | Error::Dropped => SESSION_CLOSED,
+		_ => INTERNAL_ERROR,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The two spaces disagree on every value that matters, which is the whole reason this
+	/// mapping exists rather than reusing `Error::to_code`.
+	#[test]
+	fn the_two_error_spaces_disagree() {
+		assert_eq!(to_stream_code(&Error::Cancel), CANCELLED);
+		assert_ne!(to_stream_code(&Error::Cancel), Error::Cancel.to_code());
+		assert_eq!(
+			Error::Cancel.to_code(),
+			INTERNAL_ERROR,
+			"moq-lite's cancel is this wire's failure"
+		);
+	}
+
+	/// An error with no registry entry says "this died on our side" rather than inventing a
+	/// meaning a peer would read as something specific.
+	#[test]
+	fn unmapped_errors_are_internal() {
+		assert_eq!(to_stream_code(&Error::NotFound), INTERNAL_ERROR);
+		assert_eq!(to_stream_code(&Error::Duplicate), INTERNAL_ERROR);
+	}
+}

--- a/rs/moq-net/src/ietf/mod.rs
+++ b/rs/moq-net/src/ietf/mod.rs
@@ -9,6 +9,7 @@ mod parameters;
 mod adapter;
 pub mod cluster;
 mod control;
+mod error;
 mod fetch;
 mod goaway;
 mod group;

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -576,7 +576,11 @@ async fn run_unis<S: web_transport_trait::Session>(
 			let mut reader = reader.with_version(version);
 			if let Err(err) = run_uni_group(&mut sub, &mut reader).await {
 				tracing::debug!(%err, "uni stream error");
-				reader.abort(&err);
+				// A moq-transport code, not `Error::to_code`'s moq-lite one. A group arriving
+				// for an alias we retired is the expected tail of our own cancellation, and
+				// moq-lite's cancel encodes to 0, which on this wire means the stream died of
+				// an internal failure on our side.
+				reader.stop(super::error::to_stream_code(&err));
 			}
 		});
 	}

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -30,13 +30,6 @@ const TRACK_ALIAS_TIMEOUT: Duration = Duration::from_secs(1);
 /// wait, which is the old behavior rather than a new failure.
 const RETIRED_ALIAS_CAPACITY: usize = 64;
 
-/// The stream reset code for a cancellation, from draft-19 section 3.3.4.
-///
-/// Not [`Error::Cancel`]'s code. That one belongs to the moq-lite space, where cancel is 0,
-/// and 0 here is INTERNAL_ERROR: a routine unsubscribe would reach the publisher looking
-/// like a failure on our side and be counted as one.
-const STREAM_CANCELLED: u32 = 0x1;
-
 /// What a track alias currently refers to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Alias {
@@ -1437,7 +1430,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		// STOP_SENDING needs no acknowledgement, so it goes first and the wait below covers
 		// only what we still have to deliver.
-		reader.stop(STREAM_CANCELLED);
+		reader.stop(super::error::CANCELLED);
 
 		// Finishing alone would leave the writer's Drop free to RESET_STREAM, and a stream
 		// that has sent its FIN is still retransmitting: the reset would discard the
@@ -1920,6 +1913,27 @@ mod tests {
 		);
 	}
 
+	/// A group arriving for a retired alias is the expected tail of our own cancellation, so
+	/// the code that ends up stopping its stream has to say so. moq-lite's cancel encodes to
+	/// 0, which on this wire is an internal failure, and reporting one to a publisher for a
+	/// routine unsubscribe is what distorts its error handling.
+	#[tokio::test(start_paused = true)]
+	async fn a_retired_alias_stops_its_group_stream_as_cancelled() {
+		let aliases = TrackAliases::default();
+		insert_track_alias(&aliases, 7, RequestId(11)).unwrap();
+		retire_track_alias(&aliases, 7, RequestId(11));
+
+		let err = resolve_track_alias(aliases.consume(), 7)
+			.await
+			.expect_err("a retired alias resolves to a cancellation");
+
+		assert_eq!(
+			crate::ietf::error::to_stream_code(&err),
+			crate::ietf::error::CANCELLED,
+			"the wire code the dispatch loop stops this stream with",
+		);
+	}
+
 	/// The publisher may point a retired alias at a new track, so a later SUBSCRIBE_OK
 	/// reclaims it rather than colliding with the tombstone.
 	#[test]
@@ -2050,13 +2064,13 @@ mod tests {
 			// routine unsubscribe would read to the publisher as a fault on our side.
 			assert_eq!(
 				log.stops(),
-				vec![STREAM_CANCELLED],
+				vec![crate::ietf::error::CANCELLED],
 				"{version:?}: cancelling must STOP_SENDING the publisher's direction, not just FIN ours",
 			);
 			assert_ne!(
-				STREAM_CANCELLED,
+				crate::ietf::error::CANCELLED,
 				Error::Cancel.to_code(),
-				"the two error spaces disagree; that is why this code is named separately",
+				"the two error spaces disagree; that is why this code is mapped separately",
 			);
 		}
 	}
@@ -2137,7 +2151,7 @@ mod tests {
 		);
 		assert_eq!(
 			log.stops(),
-			vec![STREAM_CANCELLED],
+			vec![crate::ietf::error::CANCELLED],
 			"and must stop the direction the publisher writes",
 		);
 	}

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -19,15 +19,55 @@ use web_async::Lock;
 
 const TRACK_ALIAS_TIMEOUT: Duration = Duration::from_secs(1);
 
-type TrackAliases = kio::Producer<HashMap<u64, RequestId>>;
+/// How many cancelled aliases to remember. Objects keep arriving for about a round trip
+/// after STOP_SENDING, so a handful covers the window, while the cap keeps a long session
+/// with heavy subscription churn from accumulating tombstones for its whole lifetime.
+const RETIRED_ALIAS_CAPACITY: usize = 64;
+
+/// What a track alias currently refers to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Alias {
+	/// An established subscription. Groups carrying this alias belong to it.
+	Active(RequestId),
+
+	/// A subscription we cancelled, whose publisher may still be feeding the alias.
+	///
+	/// The publisher only stops once our STOP_SENDING reaches it, so objects keep arriving
+	/// for at least a round trip afterwards. Remembering the alias is what lets us discard
+	/// them immediately instead of stalling each one on [`TRACK_ALIAS_TIMEOUT`] and calling
+	/// it unknown. It also stops one of those late groups from being spliced into a later
+	/// subscription that reuses the alias.
+	Retired,
+}
+
+/// The aliases a remote publisher has bound on this session, plus the cancelled ones we
+/// still remember.
+#[derive(Default)]
+struct AliasTable {
+	map: HashMap<u64, Alias>,
+
+	/// Retired aliases in retirement order, so the oldest is forgotten first.
+	retired: std::collections::VecDeque<u64>,
+}
+
+type TrackAliases = kio::Producer<AliasTable>;
 
 fn insert_track_alias(aliases: &TrackAliases, alias: u64, request_id: RequestId) -> Result<(), Error> {
 	let mut aliases = aliases.write().map_err(|_| Error::Dropped)?;
-	match aliases.entry(alias) {
-		Entry::Occupied(entry) if *entry.get() == request_id => Ok(()),
+	let table = &mut *aliases;
+
+	match table.map.entry(alias) {
+		// Our subscription is gone, so the publisher is free to point the alias somewhere
+		// new. Reclaiming it also drops the tombstone early.
+		Entry::Occupied(mut entry) if *entry.get() == Alias::Retired => {
+			entry.insert(Alias::Active(request_id));
+			table.retired.retain(|&retired| retired != alias);
+			Ok(())
+		}
+		Entry::Occupied(entry) if *entry.get() == Alias::Active(request_id) => Ok(()),
 		Entry::Occupied(_) => Err(Error::Duplicate),
 		Entry::Vacant(entry) => {
-			entry.insert(request_id);
+			entry.insert(Alias::Active(request_id));
 			Ok(())
 		}
 	}
@@ -51,12 +91,31 @@ pub(super) fn is_protocol_violation(err: &Error) -> bool {
 	)
 }
 
-fn remove_track_alias(aliases: &TrackAliases, alias: u64, request_id: RequestId) {
+/// Retire an alias, so groups still in flight for it are dropped promptly rather than
+/// reported as unknown (draft-19 section 11.1).
+///
+/// Only retires an alias that still belongs to this request: a later subscription may
+/// already have reclaimed it, and that binding outranks a departing owner.
+fn retire_track_alias(aliases: &TrackAliases, alias: u64, request_id: RequestId) {
 	let Ok(mut aliases) = aliases.write() else {
 		return;
 	};
-	if aliases.get(&alias) == Some(&request_id) {
-		aliases.remove(&alias);
+	let table = &mut *aliases;
+
+	if table.map.get(&alias) != Some(&Alias::Active(request_id)) {
+		return;
+	}
+
+	table.map.insert(alias, Alias::Retired);
+	table.retired.push_back(alias);
+
+	while table.retired.len() > RETIRED_ALIAS_CAPACITY {
+		let oldest = table.retired.pop_front().expect("non-empty above the capacity");
+		// Only forget an entry that is still a tombstone. A reclaimed alias is live again
+		// and its own retirement is queued separately.
+		if table.map.get(&oldest) == Some(&Alias::Retired) {
+			table.map.remove(&oldest);
+		}
 	}
 }
 
@@ -75,6 +134,11 @@ struct State {
 struct TrackState {
 	producer: track::Producer,
 	alias: Option<u64>,
+
+	// The broadcast this track was subscribed from. With the track name it forms the full
+	// track name, which is what decides whether a repeated alias is the fatal collision
+	// (one alias, two tracks) or the legal sharing of an alias across subscriptions.
+	broadcast: PathOwned,
 
 	// Units for this track's object Timestamps, from the TIMESCALE Track Property in
 	// SUBSCRIBE_OK. `None` until it arrives, and for a track that declares none: the
@@ -182,15 +246,25 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	version: Version,
 }
 
-async fn resolve_track_alias(aliases: kio::Consumer<HashMap<u64, RequestId>>, alias: u64) -> Result<RequestId, Error> {
+/// Resolve the subscription a data stream belongs to.
+///
+/// SUBSCRIBE_OK can be reordered behind the stream it describes, so an alias we have not
+/// seen is worth waiting on briefly (draft-19 section 11.4.2). Three outcomes:
+/// the subscription, [`Error::Cancel`] for an alias we retired, and [`Error::NotFound`]
+/// once the wait expires without any binding at all.
+async fn resolve_track_alias(aliases: kio::Consumer<AliasTable>, alias: u64) -> Result<RequestId, Error> {
 	let mut timeout = kio::time::Deadline::after(TRACK_ALIAS_TIMEOUT);
 	kio::wait(|waiter| {
-		let resolved = aliases.poll(waiter, |aliases| match aliases.get(&alias) {
-			Some(request_id) => Poll::Ready(*request_id),
+		let resolved = aliases.poll(waiter, |aliases| match aliases.map.get(&alias) {
+			Some(Alias::Active(request_id)) => Poll::Ready(Ok(*request_id)),
+			// A subscription we already cancelled, whose publisher has not caught up with
+			// our STOP_SENDING. Discard the group now rather than waiting out the timeout
+			// for a binding that is never coming.
+			Some(Alias::Retired) => Poll::Ready(Err(Error::Cancel)),
 			None => Poll::Pending,
 		});
 		if let Poll::Ready(result) = resolved {
-			return Poll::Ready(result.map_err(|_| Error::Dropped));
+			return Poll::Ready(result.unwrap_or(Err(Error::Dropped)));
 		}
 		if timeout.poll(waiter).is_ready() {
 			return Poll::Ready(Err(Error::NotFound));
@@ -301,22 +375,51 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		})
 	}
 
+	/// Bind the alias the publisher chose for this subscription.
+	///
+	/// Two failures, and only one of them is the session's. A publisher may hand the same
+	/// alias to several subscriptions of one track, which draft-19 section 5.1 allows and
+	/// expects the subscriber to demux by re-applying each subscription's filter. Ours are
+	/// all LargestObject, so they are indistinguishable and we cannot: that costs the one
+	/// subscription ([`Error::Unsupported`]). The same alias naming a *different* track is
+	/// the collision section 11.1 makes fatal ([`Error::Duplicate`]).
 	fn register_alias(&self, request_id: RequestId, alias: u64) -> Result<(), Error> {
 		let mut state = self.state.lock();
 		if !state.subscribes.contains_key(&request_id) {
 			return Err(Error::NotFound);
 		}
 
-		insert_track_alias(&state.aliases, alias, request_id)?;
+		if let Err(err) = insert_track_alias(&state.aliases, alias, request_id) {
+			return Err(match self.alias_names_same_track(&state, alias, request_id) {
+				true => Error::Unsupported,
+				false => err,
+			});
+		}
+
 		state.subscribes.get_mut(&request_id).unwrap().alias = Some(alias);
 		Ok(())
+	}
+
+	/// Whether the subscription already holding `alias` is for the same full track name as
+	/// `request_id`, making the repeat legal sharing rather than a collision.
+	fn alias_names_same_track(&self, state: &State, alias: u64, request_id: RequestId) -> bool {
+		let aliases = state.aliases.read();
+		let Some(Alias::Active(holder)) = aliases.map.get(&alias).copied() else {
+			return false;
+		};
+
+		let (Some(held), Some(new)) = (state.subscribes.get(&holder), state.subscribes.get(&request_id)) else {
+			return false;
+		};
+
+		held.broadcast == new.broadcast && held.producer.name() == new.producer.name()
 	}
 
 	fn remove_subscribe(&self, request_id: RequestId) -> Option<TrackState> {
 		let mut state = self.state.lock();
 		let track = state.subscribes.remove(&request_id)?;
 		if let Some(alias) = track.alias {
-			remove_track_alias(&state.aliases, alias, request_id);
+			retire_track_alias(&state.aliases, alias, request_id);
 		}
 		Some(track)
 	}
@@ -757,7 +860,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	) -> Result<(), Error> {
 		tracing::debug!(broadcast = %msg.track_namespace, track = %msg.track_name, "rejecting publish");
 
-		self.write_publish_error(&mut stream, msg.request_id, 400, "PUBLISH is not supported")
+		// NOT_SUPPORTED, from the PUBLISH error codes in draft-19 section 10.10. We decline
+		// the method itself rather than this particular track, which is UNINTERESTED (0x4).
+		//
+		// The alias the message carries is deliberately not recorded. Nothing will ever bind
+		// it, and a rejected request has no lifetime of ours to hang the cleanup on, so the
+		// entry would have to be swept asynchronously. Any data streams the publisher opened
+		// before reading this are dropped by the unknown-alias path instead.
+		const NOT_SUPPORTED: u64 = 0x3;
+
+		self.write_publish_error(&mut stream, msg.request_id, NOT_SUPPORTED, "PUBLISH is not supported")
 			.await?;
 		// The rejection is the whole exchange, but it still has to arrive: a finish alone
 		// leaves the drop-time reset free to discard it before the peer acknowledges it.
@@ -1110,6 +1222,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				TrackState {
 					producer: track.clone(),
 					alias: None,
+					broadcast: broadcast_path.to_owned(),
 					timescale: None,
 				},
 			);
@@ -1139,7 +1252,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				}
 
 				if let Err(err) = self.register_alias(request_id, alias) {
-					self.session.close(err.to_code(), err.to_string().as_ref());
+					// Only one alias naming two different tracks is the session's problem. A
+					// shared alias we cannot demux, or a request that went away underneath us,
+					// costs this subscription and nothing else.
+					if matches!(err, Error::Duplicate) {
+						tracing::warn!(track_alias = %alias, "publisher reused a live track alias for another track");
+						self.session.close(err.to_code(), err.to_string().as_ref());
+					} else {
+						tracing::warn!(track_alias = %alias, %err, "could not bind track alias");
+					}
 					self.remove_subscribe(request_id);
 					let _ = track.abort(err);
 					return;
@@ -1176,31 +1297,49 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			.await
 		};
 
-		match end {
+		// Whether we are walking away from a subscription the publisher still considers
+		// Established, which is what obliges us to cancel it rather than just close.
+		let cancelled = match end {
 			End::Unused => {
 				tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name(), "subscribe cancelled");
 				let _ = track.abort(Error::Cancel);
+				true
 			}
 			End::BroadcastClosed(err) => {
 				tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name(), "broadcast closed");
 				let _ = track.abort(err);
+				true
 			}
-			End::StreamClosed(res) => match res {
-				Ok(()) => {
-					tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name(), "subscribe complete");
-					let _ = track.finish();
+			End::StreamClosed(res) => {
+				match res {
+					Ok(()) => {
+						tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name(), "subscribe complete");
+						let _ = track.finish();
+					}
+					Err(err) => {
+						tracing::debug!(%err, "subscribe stream closed with error");
+						let _ = track.abort(err);
+					}
 				}
-				Err(err) => {
-					tracing::debug!(%err, "subscribe stream closed with error");
-					let _ = track.abort(err);
-				}
-			},
-		}
+				// The publisher already ended the request, so there is nothing to cancel.
+				false
+			}
+		};
 
 		// Clean up
 		self.remove_subscribe(request_id);
 
+		// A FIN is not a cancellation: it only says we will send no more messages on our
+		// direction (draft-19 section 3.3.2). A publisher holding an Established subscription
+		// keeps serving it until STOP_SENDING arrives on the direction it is writing
+		// (sections 3.3.3 and 5.1.1), so finishing alone leaves it feeding an alias we just
+		// retired, forever. Section 3.3.3 spells out this pair: an endpoint that has already
+		// FINed its sending direction cancels by sending STOP_SENDING on the receiving one.
 		stream.writer.finish().ok();
+
+		if cancelled {
+			stream.reader.abort(&Error::Cancel);
+		}
 	}
 
 	async fn write_subscribe(
@@ -1265,9 +1404,24 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// SUBSCRIBE_OK or PUBLISH can be reordered behind this stream. Hold only the
 		// subgroup header while waiting so the data stream cannot consume flow control.
 		let aliases = self.state.lock().aliases.consume();
-		let request_id = resolve_track_alias(aliases, group.track_alias).await.inspect_err(|_| {
-			tracing::warn!(track_alias = %group.track_alias, "unknown track alias");
-		})?;
+		let request_id = match resolve_track_alias(aliases, group.track_alias).await {
+			Ok(request_id) => request_id,
+			// Ours: we cancelled the subscription and the publisher has not stopped yet.
+			Err(err @ Error::Cancel) => {
+				tracing::debug!(track_alias = %group.track_alias, "dropping group for a cancelled subscription");
+				return Err(err);
+			}
+			// Theirs: nothing ever bound this alias. Either the publisher sent data for a
+			// track it never acknowledged, or SUBSCRIBE_OK is more than a timeout behind.
+			Err(err) => {
+				tracing::warn!(
+					track_alias = %group.track_alias,
+					timeout = ?TRACK_ALIAS_TIMEOUT,
+					"unknown track alias: no SUBSCRIBE_OK bound it"
+				);
+				return Err(err);
+			}
+		};
 
 		let (mut producer, track, timescale) = {
 			let mut state = self.state.lock();
@@ -1617,12 +1771,241 @@ mod tests {
 	}
 
 	#[test]
-	fn removing_old_track_does_not_remove_reused_alias() {
+	fn retiring_old_track_does_not_retire_reused_alias() {
 		let aliases = TrackAliases::default();
 		insert_track_alias(&aliases, 7, RequestId(11)).unwrap();
-		remove_track_alias(&aliases, 7, RequestId(13));
+		retire_track_alias(&aliases, 7, RequestId(13));
 
-		assert_eq!(aliases.read().get(&7), Some(&RequestId(11)));
+		assert_eq!(aliases.read().map.get(&7), Some(&Alias::Active(RequestId(11))));
+	}
+
+	/// A cancelled subscription leaves its alias behind, so the groups the publisher is
+	/// still sending are discarded at once instead of stalling out the timeout and being
+	/// reported as unknown (draft-19 section 11.1).
+	#[tokio::test(start_paused = true)]
+	async fn retired_alias_drops_late_groups_immediately() {
+		let aliases = TrackAliases::default();
+		insert_track_alias(&aliases, 7, RequestId(11)).unwrap();
+		retire_track_alias(&aliases, 7, RequestId(11));
+
+		let resolve = resolve_track_alias(aliases.consume(), 7);
+		tokio::pin!(resolve);
+
+		assert!(
+			matches!(poll!(&mut resolve), std::task::Poll::Ready(Err(Error::Cancel))),
+			"a retired alias must resolve without waiting on the timeout",
+		);
+	}
+
+	/// The publisher may point a retired alias at a new track, so a later SUBSCRIBE_OK
+	/// reclaims it rather than colliding with the tombstone.
+	#[test]
+	fn subscribe_ok_reclaims_a_retired_alias() {
+		let aliases = TrackAliases::default();
+		insert_track_alias(&aliases, 7, RequestId(11)).unwrap();
+		retire_track_alias(&aliases, 7, RequestId(11));
+
+		insert_track_alias(&aliases, 7, RequestId(13)).unwrap();
+
+		assert_eq!(aliases.read().map.get(&7), Some(&Alias::Active(RequestId(13))));
+		assert!(
+			aliases.read().retired.is_empty(),
+			"reclaiming an alias must drop its tombstone",
+		);
+	}
+
+	/// An alias still serving a live subscription is not a tombstone, so a publisher
+	/// pointing it at a second track is the duplicate the draft makes fatal.
+	#[test]
+	fn active_alias_rejects_a_second_track() {
+		let aliases = TrackAliases::default();
+		insert_track_alias(&aliases, 7, RequestId(11)).unwrap();
+
+		assert!(matches!(
+			insert_track_alias(&aliases, 7, RequestId(13)),
+			Err(Error::Duplicate)
+		));
+	}
+
+	/// Build a subscriber with `subscribes` pre-populated, so alias binding can be
+	/// exercised without driving a whole SUBSCRIBE exchange.
+	fn subscriber_with_tracks(
+		tracks: &[(RequestId, &str, &str)],
+	) -> Subscriber<crate::lite::test_transport::SinkSession> {
+		let (tasks, task_set) = crate::util::TaskSet::new();
+		// The tests drive binding directly, so nothing spawns; leaking keeps the handle alive
+		// without a spawner.
+		std::mem::forget(task_set);
+
+		let subscriber = Subscriber::new(
+			crate::lite::test_transport::SinkSession::new(Default::default()),
+			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			Control::new(None, false),
+			None,
+			peer::PeerSetup::default(),
+			crate::Origin::new(1).unwrap(),
+			None,
+			Version::Draft19,
+			tasks,
+		);
+
+		{
+			let mut state = subscriber.state.lock();
+			for (request_id, broadcast, name) in tracks {
+				state.subscribes.insert(
+					*request_id,
+					TrackState {
+						producer: track::Producer::new(
+							std::sync::Arc::new(crate::broadcast::Info::default()),
+							*name,
+							None,
+						),
+						alias: None,
+						broadcast: Path::new(broadcast).to_owned(),
+						timescale: None,
+					},
+				);
+			}
+		}
+
+		subscriber
+	}
+
+	/// Draft-19 section 5.1 lets a publisher give several subscriptions to one track the
+	/// same alias. Our filters are all LargestObject, so we cannot re-apply them to tell the
+	/// groups apart, but that is one subscription's problem. Killing the session over a
+	/// legal choice would take every other broadcast down with it.
+	#[test]
+	fn a_shared_alias_for_one_track_costs_only_that_subscription() {
+		let subscriber = subscriber_with_tracks(&[(RequestId(11), "cam", "video"), (RequestId(13), "cam", "video")]);
+
+		subscriber.register_alias(RequestId(11), 7).unwrap();
+
+		assert!(
+			matches!(subscriber.register_alias(RequestId(13), 7), Err(Error::Unsupported)),
+			"a shared alias must not be reported as the fatal collision",
+		);
+	}
+
+	/// One alias naming two different tracks is the collision section 11.1 makes fatal.
+	#[test]
+	fn an_alias_reused_for_another_track_is_fatal() {
+		let subscriber = subscriber_with_tracks(&[(RequestId(11), "cam", "video"), (RequestId(13), "cam", "audio")]);
+
+		subscriber.register_alias(RequestId(11), 7).unwrap();
+
+		assert!(matches!(
+			subscriber.register_alias(RequestId(13), 7),
+			Err(Error::Duplicate)
+		));
+	}
+
+	/// Same track name under a different broadcast is a different full track name, so it is
+	/// a collision too.
+	#[test]
+	fn an_alias_reused_across_broadcasts_is_fatal() {
+		let subscriber = subscriber_with_tracks(&[(RequestId(11), "cam", "video"), (RequestId(13), "screen", "video")]);
+
+		subscriber.register_alias(RequestId(11), 7).unwrap();
+
+		assert!(matches!(
+			subscriber.register_alias(RequestId(13), 7),
+			Err(Error::Duplicate)
+		));
+	}
+
+	/// A FIN only says we will send nothing further; it is not a cancellation (draft-19
+	/// section 3.3.2). A publisher holding an Established subscription keeps serving it
+	/// until STOP_SENDING arrives on the direction it writes (sections 3.3.3 and 5.1.1),
+	/// so a subscriber that only finishes leaves it feeding an alias forever. That is what
+	/// turns a routine unsubscribe into an endless "unknown track alias" stream.
+	#[tokio::test]
+	async fn cancelling_a_subscription_stops_the_publisher() {
+		const VERSION: Version = Version::Draft19;
+
+		// A peer that accepts the subscription, binding alias 7, then says nothing more.
+		let subscribe_ok = {
+			let log = crate::lite::test_transport::Log::default();
+			let mut writer =
+				crate::coding::Writer::new(crate::lite::test_transport::SinkSend::new(log.clone()), VERSION);
+			writer.encode(&ietf::SubscribeOk::ID).await.unwrap();
+			writer
+				.encode(&ietf::SubscribeOk {
+					request_id: None,
+					track_alias: 7,
+					properties: Default::default(),
+				})
+				.await
+				.unwrap();
+
+			log.writes.lock().unwrap().clone()
+		};
+
+		let session = crate::lite::test_transport::ScriptedSession::new(subscribe_ok);
+		let log = session.log.clone();
+
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+		let mut subscriber = Subscriber::new(
+			session,
+			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			Control::new(None, false),
+			None,
+			peer::PeerSetup::default(),
+			crate::Origin::new(1).unwrap(),
+			None,
+			VERSION,
+			tasks,
+		);
+
+		// A consumer asking for a track is what dispatches a request to the session.
+		let producer = crate::broadcast::Info::default().produce();
+		let mut dynamic = producer.dynamic();
+		let consumer = producer.consume();
+		let track = consumer.track("video").unwrap();
+		let subscription = track.subscribe(None);
+
+		let request = dynamic.requested_track().await.expect("no track requested");
+
+		let serving = tokio::spawn(async move {
+			subscriber.run_subscribe(Path::new("broadcast"), dynamic, request).await;
+		});
+
+		// Let the SUBSCRIBE go out and the SUBSCRIBE_OK come back, so the subscription is
+		// Established when we walk away from it.
+		settle().await;
+
+		// The last consumer leaves: nothing wants this track any more.
+		drop(subscription);
+		drop(track);
+		drop(consumer);
+
+		tokio::time::timeout(std::time::Duration::from_secs(1), serving)
+			.await
+			.expect("run_subscribe did not finish")
+			.unwrap();
+
+		assert_eq!(
+			log.stops(),
+			vec![Error::Cancel.to_code()],
+			"cancelling must STOP_SENDING the publisher's direction, not just FIN ours",
+		);
+	}
+
+	/// Tombstones are bounded: a session churning through subscriptions must not
+	/// accumulate one entry per alias it ever used.
+	#[test]
+	fn retired_aliases_are_capped() {
+		let aliases = TrackAliases::default();
+
+		for i in 0..(RETIRED_ALIAS_CAPACITY as u64 + 10) {
+			insert_track_alias(&aliases, i, RequestId(i)).unwrap();
+			retire_track_alias(&aliases, i, RequestId(i));
+		}
+
+		let table = aliases.read();
+		assert_eq!(table.retired.len(), RETIRED_ALIAS_CAPACITY);
+		assert_eq!(table.map.len(), RETIRED_ALIAS_CAPACITY);
+		assert!(!table.map.contains_key(&0), "the oldest tombstone is forgotten first");
 	}
 
 	/// moq-transport carries no hop ids, so a peer's broadcasts are normally

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -3211,10 +3211,34 @@ mod tests {
 			consumer.get_broadcast("room/host").is_none(),
 			"a rejected PUBLISH must not announce a broadcast"
 		);
+		// Encode the reply we expect rather than matching the reason alone, so the error code
+		// regressing to something outside draft-19 section 10.10's table cannot slip through.
+		let expected = {
+			const NOT_SUPPORTED: u64 = 0x3;
+
+			let log = crate::lite::test_transport::Log::default();
+			let mut writer = crate::coding::Writer::new(
+				crate::lite::test_transport::SinkSend::new(log.clone()),
+				Version::Draft19,
+			);
+			writer.encode(&ietf::RequestError::ID).await.unwrap();
+			writer
+				.encode(&ietf::RequestError {
+					request_id: None,
+					error_code: NOT_SUPPORTED,
+					reason_phrase: "PUBLISH is not supported".into(),
+					retry_interval: 0,
+				})
+				.await
+				.unwrap();
+
+			log.writes.lock().unwrap().clone()
+		};
+
 		assert_eq!(
-			occurrences(&session.log, b"PUBLISH is not supported"),
+			occurrences(&session.log, &expected),
 			1,
-			"the decline reaches the peer"
+			"the decline reaches the peer as NOT_SUPPORTED"
 		);
 	}
 }

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1973,7 +1973,7 @@ mod tests {
 	/// until STOP_SENDING arrives on the direction it writes (sections 3.3.3 and 5.1.1),
 	/// so a subscriber that only finishes leaves it feeding an alias forever. That is what
 	/// turns a routine unsubscribe into an endless "unknown track alias" stream.
-	#[tokio::test]
+	#[tokio::test(start_paused = true)]
 	async fn cancelling_a_subscription_stops_the_publisher() {
 		for version in [Version::Draft16, Version::Draft19] {
 			let log = cancel_a_subscription(version).await;
@@ -1988,7 +1988,7 @@ mod tests {
 	/// Draft-14 through 16 have an UNSUBSCRIBE message, and draft-16 section 5.1.1 makes it
 	/// the thing that lets the publisher destroy the subscription. Resetting the stream
 	/// without it leaves a peer that predates draft-17 serving the track forever.
-	#[tokio::test]
+	#[tokio::test(start_paused = true)]
 	async fn a_legacy_cancel_sends_unsubscribe() {
 		let log = cancel_a_subscription(Version::Draft16).await;
 		assert!(
@@ -2016,7 +2016,7 @@ mod tests {
 	/// the new subscription. Those versions carry requests over the control stream adapter,
 	/// whose virtual streams drop silently, so UNSUBSCRIBE is the only way the publisher
 	/// ever learns to stop serving it.
-	#[tokio::test]
+	#[tokio::test(start_paused = true)]
 	async fn a_legacy_shared_alias_is_unsubscribed() {
 		let log = cancel_a_subscription_inner(Version::Draft16, true).await;
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -30,6 +30,13 @@ const TRACK_ALIAS_TIMEOUT: Duration = Duration::from_secs(1);
 /// wait, which is the old behavior rather than a new failure.
 const RETIRED_ALIAS_CAPACITY: usize = 64;
 
+/// The stream reset code for a cancellation, from draft-19 section 3.3.4.
+///
+/// Not [`Error::Cancel`]'s code. That one belongs to the moq-lite space, where cancel is 0,
+/// and 0 here is INTERNAL_ERROR: a routine unsubscribe would reach the publisher looking
+/// like a failure on our side and be counted as one.
+const STREAM_CANCELLED: u32 = 0x1;
+
 /// What a track alias currently refers to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Alias {
@@ -1383,7 +1390,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		// STOP_SENDING needs no acknowledgement, so it goes first and the wait below covers
 		// only what we still have to deliver.
-		reader.abort(&Error::Cancel);
+		reader.stop(STREAM_CANCELLED);
 
 		// Finishing alone would leave the writer's Drop free to RESET_STREAM, and a stream
 		// that has sent its FIN is still retransmitting: the reset would discard the
@@ -1992,10 +1999,17 @@ mod tests {
 	async fn cancelling_a_subscription_stops_the_publisher() {
 		for version in [Version::Draft16, Version::Draft19] {
 			let log = cancel_a_subscription(version).await;
+			// CANCELLED, not the moq-lite cancel code: 0 on this wire is INTERNAL_ERROR, so a
+			// routine unsubscribe would read to the publisher as a fault on our side.
 			assert_eq!(
 				log.stops(),
-				vec![Error::Cancel.to_code()],
+				vec![STREAM_CANCELLED],
 				"{version:?}: cancelling must STOP_SENDING the publisher's direction, not just FIN ours",
+			);
+			assert_ne!(
+				STREAM_CANCELLED,
+				Error::Cancel.to_code(),
+				"the two error spaces disagree; that is why this code is named separately",
 			);
 		}
 	}

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1264,8 +1264,55 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name(), "subscribe started");
 
+		// A publisher can be serving before its SUBSCRIBE_OK reaches us, since the data
+		// streams are independent of the request stream. Waiting for the response alone would
+		// miss the local side going away in that window and leave the publisher serving a
+		// track nobody reads, which is the leak this whole path exists to close.
+		enum Setup {
+			Response(Result<Option<(u64, Option<Timescale>)>, Error>),
+			Unused,
+			BroadcastClosed(Error),
+		}
+
+		let setup = {
+			let mut response = std::pin::pin!(self.read_subscribe_response(&mut stream));
+			kio::wait(|waiter| {
+				if track.poll_unused(waiter).is_ready() {
+					return Poll::Ready(Setup::Unused);
+				}
+				if let Poll::Ready(err) = broadcast.poll_closed(waiter) {
+					return Poll::Ready(Setup::BroadcastClosed(err));
+				}
+				waiter.poll_future(response.as_mut()).map(Setup::Response)
+			})
+			.await
+		};
+
+		// Abandoned before the publisher answered. It may already be serving, so this still
+		// owes it a cancellation rather than a silent walk away.
+		let response = match setup {
+			Setup::Response(res) => res,
+			Setup::Unused | Setup::BroadcastClosed(_) => {
+				let err = match setup {
+					Setup::BroadcastClosed(err) => err,
+					_ => Error::Cancel,
+				};
+
+				tracing::info!(
+					broadcast = %self.origin.absolute(&broadcast_path),
+					track = %track.name(),
+					"subscribe abandoned before it was accepted"
+				);
+
+				let _ = track.abort(err);
+				self.remove_subscribe(request_id);
+				self.cancel_subscribe(stream, request_id).await;
+				return;
+			}
+		};
+
 		// Read the response and register the alias mapping
-		match self.read_subscribe_response(&mut stream).await {
+		match response {
 			Ok(Some((alias, timescale))) => {
 				if let Some(timescale) = timescale {
 					let mut state = self.state.lock();
@@ -2031,6 +2078,170 @@ mod tests {
 			occurrences(&log, &[ietf::Unsubscribe::ID as u8]),
 			0,
 			"draft-17+ has no UNSUBSCRIBE",
+		);
+	}
+
+	/// A publisher can be serving before its SUBSCRIBE_OK arrives, since data streams are
+	/// independent of the request stream. If the last consumer leaves in that window, the
+	/// subscriber still owes it a cancellation: walking away silently is what leaves it
+	/// serving a track nobody reads.
+	#[tokio::test(start_paused = true)]
+	async fn abandoning_before_subscribe_ok_still_cancels() {
+		const VERSION: Version = Version::Draft16;
+
+		// A peer that accepts the stream and then says nothing at all.
+		let session = crate::lite::test_transport::ScriptedSession::new(Vec::new());
+		let log = session.log.clone();
+
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+		let mut subscriber = Subscriber::new(
+			session,
+			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			Control::new(None, false),
+			None,
+			peer::PeerSetup::default(),
+			crate::Origin::new(1).unwrap(),
+			None,
+			VERSION,
+			tasks,
+		);
+
+		let producer = crate::broadcast::Info::default().produce();
+		let mut dynamic = producer.dynamic();
+		let consumer = producer.consume();
+		let track = consumer.track("video").unwrap();
+		let subscription = track.subscribe(None);
+
+		let request = dynamic.requested_track().await.expect("no track requested");
+
+		let serving = tokio::spawn(async move {
+			subscriber.run_subscribe(Path::new("broadcast"), dynamic, request).await;
+		});
+
+		// Let the SUBSCRIBE go out. No SUBSCRIBE_OK is coming, so the subscription never
+		// reaches Established on our side.
+		settle().await;
+
+		drop(subscription);
+		drop(track);
+		drop(consumer);
+
+		tokio::time::timeout(std::time::Duration::from_secs(1), serving)
+			.await
+			.expect("run_subscribe parked waiting for a response that never came")
+			.unwrap();
+
+		assert!(
+			occurrences(&log, &[ietf::Unsubscribe::ID as u8]) > 0,
+			"a subscribe abandoned before SUBSCRIBE_OK must still be cancelled",
+		);
+		assert_eq!(
+			log.stops(),
+			vec![STREAM_CANCELLED],
+			"and must stop the direction the publisher writes",
+		);
+	}
+
+	/// The control messages that actually reached the wire, by type id.
+	///
+	/// Decoding the framing rather than scanning for a byte: a type id is one varint among
+	/// many, and a substring match would happily find one inside a length or a payload.
+	fn control_message_types(log: &crate::lite::test_transport::Log, version: Version) -> Vec<u64> {
+		use crate::coding::Decode;
+
+		let writes = log.writes.lock().unwrap().clone();
+		let mut buf = writes.as_slice();
+		let mut types = Vec::new();
+
+		while !buf.is_empty() {
+			let Ok(type_id) = u64::decode(&mut buf, version) else {
+				break;
+			};
+			let Ok(size) = u16::decode(&mut buf, version) else {
+				break;
+			};
+			if buf.len() < size as usize {
+				break;
+			}
+			buf = &buf[size as usize..];
+			types.push(type_id);
+		}
+
+		types
+	}
+
+	/// Drafts 14-16 carry every request over `ControlStreamAdapter`'s virtual streams, so a
+	/// cancellation only counts if it traverses the mux and reaches the real control stream
+	/// writer. A test that drives a direct stream proves the subscriber's own logic and
+	/// nothing about the path production takes: the virtual writer's reset is a no-op and
+	/// its close returns as soon as the bytes are queued, so an adapter that dropped them
+	/// would look identical.
+	#[tokio::test(start_paused = true)]
+	async fn a_legacy_cancel_reaches_the_control_stream() {
+		const VERSION: Version = Version::Draft16;
+
+		// A peer that opens the control stream and then says nothing, so the subscribe is
+		// abandoned before it is accepted and cancelled from there.
+		let session = crate::lite::test_transport::ScriptedSession::new(Vec::new());
+		let log = session.log.clone();
+
+		let control = Control::new(None, false);
+		let adapter = super::super::adapter::ControlStreamAdapter::new(session.clone(), control.clone(), VERSION);
+
+		// The one real bidi everything is multiplexed onto.
+		let control_stream = Stream::open(&session, VERSION).await.unwrap();
+		let running = adapter.clone();
+		tokio::spawn(async move {
+			let _ = running.run(control_stream.reader, control_stream.writer).await;
+		});
+
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+		let mut subscriber = Subscriber::new(
+			adapter,
+			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			control,
+			None,
+			peer::PeerSetup::default(),
+			crate::Origin::new(1).unwrap(),
+			None,
+			VERSION,
+			tasks,
+		);
+
+		let producer = crate::broadcast::Info::default().produce();
+		let mut dynamic = producer.dynamic();
+		let consumer = producer.consume();
+		let track = consumer.track("video").unwrap();
+		let subscription = track.subscribe(None);
+
+		let request = dynamic.requested_track().await.expect("no track requested");
+
+		let serving = tokio::spawn(async move {
+			subscriber.run_subscribe(Path::new("broadcast"), dynamic, request).await;
+		});
+
+		settle().await;
+		drop(subscription);
+		drop(track);
+		drop(consumer);
+
+		tokio::time::timeout(std::time::Duration::from_secs(1), serving)
+			.await
+			.expect("run_subscribe did not finish")
+			.unwrap();
+
+		// Let the adapter's writer task drain the queue onto the control stream.
+		settle().await;
+
+		let types = control_message_types(&log, VERSION);
+		assert!(
+			types.contains(&ietf::Subscribe::ID),
+			"the SUBSCRIBE reached the control stream: {types:?}"
+		);
+		assert!(
+			types.contains(&ietf::Unsubscribe::ID),
+			"the UNSUBSCRIBE must traverse the adapter to the control stream, not stop at the \
+			 virtual writer: {types:?}"
 		);
 	}
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1260,6 +1260,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						self.session.close(err.to_code(), err.to_string().as_ref());
 					} else {
 						tracing::warn!(track_alias = %alias, %err, "could not bind track alias");
+						// SUBSCRIBE_OK arrived, so the publisher considers this Established and
+						// will keep serving it. Dropping the stream says nothing on the versions
+						// that need UNSUBSCRIBE, so cancel it properly.
+						self.cancel_subscribe(&mut stream, request_id).await;
 					}
 					self.remove_subscribe(request_id);
 					let _ = track.abort(err);
@@ -1329,17 +1333,51 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Clean up
 		self.remove_subscribe(request_id);
 
-		// A FIN is not a cancellation: it only says we will send no more messages on our
-		// direction (draft-19 section 3.3.2). A publisher holding an Established subscription
-		// keeps serving it until STOP_SENDING arrives on the direction it is writing
-		// (sections 3.3.3 and 5.1.1), so finishing alone leaves it feeding an alias we just
-		// retired, forever. Section 3.3.3 spells out this pair: an endpoint that has already
-		// FINed its sending direction cancels by sending STOP_SENDING on the receiving one.
-		stream.writer.finish().ok();
-
-		if cancelled {
-			stream.reader.abort(&Error::Cancel);
+		match cancelled {
+			true => self.cancel_subscribe(&mut stream, request_id).await,
+			// The publisher already ended the request, so a FIN is all we owe it.
+			false => {
+				stream.writer.finish().ok();
+			}
 		}
+	}
+
+	/// Tell the publisher to stop serving a subscription we are walking away from.
+	///
+	/// Every path that abandons an Established subscription goes through here, because
+	/// staying silent is what leaves the publisher serving a track nobody is reading and
+	/// feeding an alias we already retired.
+	///
+	/// Two mechanisms, by version. Draft-14 through 16 carry requests over the control
+	/// stream adapter, whose virtual streams have no reset or stop of their own, so
+	/// UNSUBSCRIBE (draft-16 section 9.12) is the only thing the peer ever sees, and
+	/// draft-16 section 5.1.1 makes receiving it what frees the subscription. Draft-17
+	/// removed the message, leaving the stream itself: a FIN is explicitly not a
+	/// cancellation (draft-19 section 3.3.2), so section 3.3.3's pair applies, an endpoint
+	/// that has already FINed its sending direction cancels with STOP_SENDING on the
+	/// receiving one.
+	async fn cancel_subscribe(&self, stream: &mut Stream<S, Version>, request_id: RequestId) {
+		if self.unsubscribes()
+			&& let Err(err) = self.write_unsubscribe(stream, request_id).await
+		{
+			tracing::debug!(%err, "failed to write unsubscribe");
+		}
+
+		stream.writer.finish().ok();
+		stream.reader.abort(&Error::Cancel);
+	}
+
+	/// Whether this version cancels a subscription with an UNSUBSCRIBE message.
+	///
+	/// Draft-17 removed it, leaving the stream reset as the only signal.
+	fn unsubscribes(&self) -> bool {
+		matches!(self.version, Version::Draft14 | Version::Draft15 | Version::Draft16)
+	}
+
+	async fn write_unsubscribe(&self, stream: &mut Stream<S, Version>, request_id: RequestId) -> Result<(), Error> {
+		stream.writer.encode(&ietf::Unsubscribe::ID).await?;
+		stream.writer.encode(&ietf::Unsubscribe { request_id }).await?;
+		Ok(())
 	}
 
 	async fn write_subscribe(
@@ -1921,17 +1959,72 @@ mod tests {
 	/// turns a routine unsubscribe into an endless "unknown track alias" stream.
 	#[tokio::test]
 	async fn cancelling_a_subscription_stops_the_publisher() {
-		const VERSION: Version = Version::Draft19;
+		for version in [Version::Draft16, Version::Draft19] {
+			let log = cancel_a_subscription(version).await;
+			assert_eq!(
+				log.stops(),
+				vec![Error::Cancel.to_code()],
+				"{version:?}: cancelling must STOP_SENDING the publisher's direction, not just FIN ours",
+			);
+		}
+	}
 
+	/// Draft-14 through 16 have an UNSUBSCRIBE message, and draft-16 section 5.1.1 makes it
+	/// the thing that lets the publisher destroy the subscription. Resetting the stream
+	/// without it leaves a peer that predates draft-17 serving the track forever.
+	#[tokio::test]
+	async fn a_legacy_cancel_sends_unsubscribe() {
+		let log = cancel_a_subscription(Version::Draft16).await;
+		assert!(
+			occurrences(&log, &[ietf::Unsubscribe::ID as u8]) > 0,
+			"draft-16 cancels with UNSUBSCRIBE",
+		);
+
+		// Draft-17 removed the message, so sending one would be a protocol violation.
+		let log = cancel_a_subscription(Version::Draft19).await;
+		assert_eq!(
+			occurrences(&log, &[ietf::Unsubscribe::ID as u8]),
+			0,
+			"draft-17+ has no UNSUBSCRIBE",
+		);
+	}
+
+	/// Establish a subscription on `version`, then drop its last consumer, and hand back
+	/// what the session recorded on the way out.
+	async fn cancel_a_subscription(version: Version) -> crate::lite::test_transport::Log {
+		cancel_a_subscription_inner(version, false).await
+	}
+
+	/// A publisher on draft-14 through 16 that legally hands a second subscription to one
+	/// track the alias the first already holds. We cannot demux that, so we walk away from
+	/// the new subscription. Those versions carry requests over the control stream adapter,
+	/// whose virtual streams drop silently, so UNSUBSCRIBE is the only way the publisher
+	/// ever learns to stop serving it.
+	#[tokio::test]
+	async fn a_legacy_shared_alias_is_unsubscribed() {
+		let log = cancel_a_subscription_inner(Version::Draft16, true).await;
+
+		assert!(
+			occurrences(&log, &[ietf::Unsubscribe::ID as u8]) > 0,
+			"abandoning a shared alias must still tell the publisher to stop",
+		);
+	}
+
+	/// When `conflict` is set, an alias-7 binding for the same full track name is seeded
+	/// first, so the subscription under test loses the race to bind it.
+	async fn cancel_a_subscription_inner(version: Version, conflict: bool) -> crate::lite::test_transport::Log {
 		// A peer that accepts the subscription, binding alias 7, then says nothing more.
 		let subscribe_ok = {
 			let log = crate::lite::test_transport::Log::default();
 			let mut writer =
-				crate::coding::Writer::new(crate::lite::test_transport::SinkSend::new(log.clone()), VERSION);
+				crate::coding::Writer::new(crate::lite::test_transport::SinkSend::new(log.clone()), version);
 			writer.encode(&ietf::SubscribeOk::ID).await.unwrap();
 			writer
 				.encode(&ietf::SubscribeOk {
-					request_id: None,
+					request_id: match version {
+						Version::Draft14 | Version::Draft15 | Version::Draft16 => Some(RequestId(0)),
+						_ => None,
+					},
 					track_alias: 7,
 					properties: Default::default(),
 				})
@@ -1953,9 +2046,28 @@ mod tests {
 			peer::PeerSetup::default(),
 			crate::Origin::new(1).unwrap(),
 			None,
-			VERSION,
+			version,
 			tasks,
 		);
+
+		if conflict {
+			let holder = RequestId(999);
+			let mut state = subscriber.state.lock();
+			state.subscribes.insert(
+				holder,
+				TrackState {
+					producer: track::Producer::new(
+						std::sync::Arc::new(crate::broadcast::Info::default()),
+						"video",
+						None,
+					),
+					alias: Some(7),
+					broadcast: Path::new("broadcast").to_owned(),
+					timescale: None,
+				},
+			);
+			insert_track_alias(&state.aliases, 7, holder).unwrap();
+		}
 
 		// A consumer asking for a track is what dispatches a request to the session.
 		let producer = crate::broadcast::Info::default().produce();
@@ -1966,6 +2078,10 @@ mod tests {
 
 		let request = dynamic.requested_track().await.expect("no track requested");
 
+		// A handle on the same state the spawned task mutates, so the test can prove the
+		// subscription reached Established rather than assume it.
+		let probe = subscriber.clone();
+
 		let serving = tokio::spawn(async move {
 			subscriber.run_subscribe(Path::new("broadcast"), dynamic, request).await;
 		});
@@ -1973,6 +2089,13 @@ mod tests {
 		// Let the SUBSCRIBE go out and the SUBSCRIBE_OK come back, so the subscription is
 		// Established when we walk away from it.
 		settle().await;
+
+		// Without this the test would still pass if SUBSCRIBE_OK never landed, and it would
+		// then be asserting against a subscription that was never established.
+		assert!(
+			matches!(probe.state.lock().aliases.read().map.get(&7), Some(Alias::Active(_))),
+			"{version:?}: alias 7 must be bound before we cancel",
+		);
 
 		// The last consumer leaves: nothing wants this track any more.
 		drop(subscription);
@@ -1984,11 +2107,7 @@ mod tests {
 			.expect("run_subscribe did not finish")
 			.unwrap();
 
-		assert_eq!(
-			log.stops(),
-			vec![Error::Cancel.to_code()],
-			"cancelling must STOP_SENDING the publisher's direction, not just FIN ours",
-		);
+		log
 	}
 
 	/// Tombstones are bounded: a session churning through subscriptions must not

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1914,11 +1914,15 @@ mod tests {
 	}
 
 	/// A group arriving for a retired alias is the expected tail of our own cancellation, so
-	/// the code that ends up stopping its stream has to say so. moq-lite's cancel encodes to
-	/// 0, which on this wire is an internal failure, and reporting one to a publisher for a
-	/// routine unsubscribe is what distorts its error handling.
+	/// the code it maps to has to say so. moq-lite's cancel encodes to 0, which on this wire
+	/// is an internal failure, and reporting one to a publisher for a routine unsubscribe is
+	/// what distorts its error handling.
+	///
+	/// Covers the error this path produces and the code it maps to, not the dispatch loop
+	/// that sends it: `run_unis` is private to `session`, and retiring an alias reaches into
+	/// state private to this module, so nothing here can drive one end to end. See #3002.
 	#[tokio::test(start_paused = true)]
-	async fn a_retired_alias_stops_its_group_stream_as_cancelled() {
+	async fn a_retired_alias_maps_to_the_cancelled_code() {
 		let aliases = TrackAliases::default();
 		insert_track_alias(&aliases, 7, RequestId(11)).unwrap();
 		retire_track_alias(&aliases, 7, RequestId(11));
@@ -1930,7 +1934,7 @@ mod tests {
 		assert_eq!(
 			crate::ietf::error::to_stream_code(&err),
 			crate::ietf::error::CANCELLED,
-			"the wire code the dispatch loop stops this stream with",
+			"the code the dispatch loop maps this error onto",
 		);
 	}
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -20,8 +20,14 @@ use web_async::Lock;
 const TRACK_ALIAS_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// How many cancelled aliases to remember. Objects keep arriving for about a round trip
-/// after STOP_SENDING, so a handful covers the window, while the cap keeps a long session
-/// with heavy subscription churn from accumulating tombstones for its whole lifetime.
+/// after we cancel, so a handful covers the window, while the cap keeps a long session with
+/// heavy subscription churn from accumulating tombstones for its whole lifetime.
+///
+/// The bound is a count rather than a deadline, which is what keeps eviction synchronous
+/// with retirement instead of needing a timer to sweep expired entries. The trade is that a
+/// session cancelling more than this many distinct aliases inside one round trip evicts a
+/// tombstone whose objects are still arriving; those groups fall back to the unknown-alias
+/// wait, which is the old behavior rather than a new failure.
 const RETIRED_ALIAS_CAPACITY: usize = 64;
 
 /// What a track alias currently refers to.
@@ -32,11 +38,19 @@ enum Alias {
 
 	/// A subscription we cancelled, whose publisher may still be feeding the alias.
 	///
-	/// The publisher only stops once our STOP_SENDING reaches it, so objects keep arriving
+	/// The publisher only stops once our cancellation reaches it, so objects keep arriving
 	/// for at least a round trip afterwards. Remembering the alias is what lets us discard
 	/// them immediately instead of stalling each one on [`TRACK_ALIAS_TIMEOUT`] and calling
-	/// it unknown. It also stops one of those late groups from being spliced into a later
-	/// subscription that reuses the alias.
+	/// it unknown.
+	///
+	/// It does not make that window safe, only quiet. A publisher that has processed the
+	/// cancellation may reassign the alias, and nothing on a group stream distinguishes the
+	/// old subscription's objects from the new one's, so a group still in flight when the
+	/// new SUBSCRIBE_OK binds the alias is delivered to the new track. The protocol offers
+	/// no way to tell them apart: the alias is the only identifier a group carries, and the
+	/// draft permits the reuse as long as the two tracks are not live at once. Cancelling
+	/// promptly is what bounds the exposure, since it caps the arrival window at a round
+	/// trip rather than leaving it open for the life of the session.
 	Retired,
 }
 
@@ -58,7 +72,9 @@ fn insert_track_alias(aliases: &TrackAliases, alias: u64, request_id: RequestId)
 
 	match table.map.entry(alias) {
 		// Our subscription is gone, so the publisher is free to point the alias somewhere
-		// new. Reclaiming it also drops the tombstone early.
+		// new. Reclaiming it also drops the tombstone early, which reopens the window
+		// described on `Alias::Retired`: a group from the old subscription arriving after
+		// this lands is indistinguishable from one for the new track.
 		Entry::Occupied(mut entry) if *entry.get() == Alias::Retired => {
 			entry.insert(Alias::Active(request_id));
 			table.retired.retain(|&retired| retired != alias);

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1279,7 +1279,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						// SUBSCRIBE_OK arrived, so the publisher considers this Established and
 						// will keep serving it. Dropping the stream says nothing on the versions
 						// that need UNSUBSCRIBE, so cancel it properly.
-						self.cancel_subscribe(&mut stream, request_id).await;
+						self.cancel_subscribe(stream, request_id).await;
 					}
 					self.remove_subscribe(request_id);
 					let _ = track.abort(err);
@@ -1350,7 +1350,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		self.remove_subscribe(request_id);
 
 		match cancelled {
-			true => self.cancel_subscribe(&mut stream, request_id).await,
+			true => self.cancel_subscribe(stream, request_id).await,
 			// The publisher already ended the request, so a FIN is all we owe it.
 			false => {
 				stream.writer.finish().ok();
@@ -1372,15 +1372,26 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// cancellation (draft-19 section 3.3.2), so section 3.3.3's pair applies, an endpoint
 	/// that has already FINed its sending direction cancels with STOP_SENDING on the
 	/// receiving one.
-	async fn cancel_subscribe(&self, stream: &mut Stream<S, Version>, request_id: RequestId) {
+	async fn cancel_subscribe(&self, stream: Stream<S, Version>, request_id: RequestId) {
+		let Stream { mut writer, mut reader } = stream;
+
 		if self.unsubscribes()
-			&& let Err(err) = self.write_unsubscribe(stream, request_id).await
+			&& let Err(err) = self.write_unsubscribe(&mut writer, request_id).await
 		{
 			tracing::debug!(%err, "failed to write unsubscribe");
 		}
 
-		stream.writer.finish().ok();
-		stream.reader.abort(&Error::Cancel);
+		// STOP_SENDING needs no acknowledgement, so it goes first and the wait below covers
+		// only what we still have to deliver.
+		reader.abort(&Error::Cancel);
+
+		// Finishing alone would leave the writer's Drop free to RESET_STREAM, and a stream
+		// that has sent its FIN is still retransmitting: the reset would discard the
+		// UNSUBSCRIBE before the peer ever read it, which is the whole message. Closing
+		// consumes the writer, removing that fallback, and waits for the acknowledgement.
+		if let Err(err) = writer.close().await {
+			tracing::debug!(%err, "failed to close the subscribe stream");
+		}
 	}
 
 	/// Whether this version cancels a subscription with an UNSUBSCRIBE message.
@@ -1390,9 +1401,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		matches!(self.version, Version::Draft14 | Version::Draft15 | Version::Draft16)
 	}
 
-	async fn write_unsubscribe(&self, stream: &mut Stream<S, Version>, request_id: RequestId) -> Result<(), Error> {
-		stream.writer.encode(&ietf::Unsubscribe::ID).await?;
-		stream.writer.encode(&ietf::Unsubscribe { request_id }).await?;
+	async fn write_unsubscribe(
+		&self,
+		writer: &mut crate::coding::Writer<S::SendStream, Version>,
+		request_id: RequestId,
+	) -> Result<(), Error> {
+		writer.encode(&ietf::Unsubscribe::ID).await?;
+		writer.encode(&ietf::Unsubscribe { request_id }).await?;
 		Ok(())
 	}
 
@@ -2024,6 +2039,21 @@ mod tests {
 			occurrences(&log, &[ietf::Unsubscribe::ID as u8]) > 0,
 			"abandoning a shared alias must still tell the publisher to stop",
 		);
+	}
+
+	/// Writing the UNSUBSCRIBE is not the same as delivering it. A stream that has only been
+	/// finished is still retransmitting, so the writer's Drop reset would discard the message
+	/// before the peer read it. Closing consumes the writer, which is what removes that
+	/// fallback, so a reset here means the cancellation never landed.
+	#[tokio::test(start_paused = true)]
+	async fn cancelling_does_not_reset_away_the_unsubscribe() {
+		for version in [Version::Draft16, Version::Draft19] {
+			let log = cancel_a_subscription(version).await;
+			assert!(
+				log.resets().is_empty(),
+				"{version:?}: the send side must be closed, not reset out from under the cancellation",
+			);
+		}
 	}
 
 	/// When `conflict` is set, an alias-7 binding for the same full track name is seeded

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -47,6 +47,9 @@ impl Log {
 	/// The STOP_SENDING codes sent on the session's receive streams, in call order.
 	/// Cancelling a request is a reset of what we send plus one of these on what we
 	/// receive, so a test for a cancellation has to be able to see them.
+	///
+	/// Only [`ScriptedRecv`] records them. The other receive streams here discard the code,
+	/// so an empty result on those is not evidence that nothing was sent.
 	pub fn stops(&self) -> Vec<u32> {
 		self.stops.lock().unwrap().clone()
 	}

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -33,6 +33,7 @@ impl web_transport_trait::Error for SinkError {
 pub struct Log {
 	pub writes: Arc<Mutex<Vec<u8>>>,
 	pub resets: Arc<Mutex<Vec<u32>>>,
+	stops: Arc<Mutex<Vec<u32>>>,
 	closes: Arc<Mutex<Vec<(u32, String)>>>,
 	bi_opens: Arc<AtomicUsize>,
 	priorities: Arc<Mutex<Vec<u8>>>,
@@ -41,6 +42,13 @@ pub struct Log {
 impl Log {
 	pub fn resets(&self) -> Vec<u32> {
 		self.resets.lock().unwrap().clone()
+	}
+
+	/// The STOP_SENDING codes sent on the session's receive streams, in call order.
+	/// Cancelling a request is a reset of what we send plus one of these on what we
+	/// receive, so a test for a cancellation has to be able to see them.
+	pub fn stops(&self) -> Vec<u32> {
+		self.stops.lock().unwrap().clone()
 	}
 
 	/// Every value handed to the transport's `set_priority`, in call order. These are
@@ -444,6 +452,7 @@ pub struct ScriptedRecv {
 	/// Report EOF once the script is exhausted rather than parking, so a test can drive
 	/// a read loop all the way through its exit path. See [`ScriptedSession::eof`].
 	eof: bool,
+	log: Log,
 }
 
 impl web_transport_trait::RecvStream for ScriptedRecv {
@@ -469,7 +478,9 @@ impl web_transport_trait::RecvStream for ScriptedRecv {
 		}
 	}
 
-	fn stop(&mut self, _code: u32) {}
+	fn stop(&mut self, code: u32) {
+		self.log.stops.lock().unwrap().push(code);
+	}
 
 	async fn closed(&mut self) -> Result<(), Self::Error> {
 		std::future::pending().await
@@ -565,7 +576,14 @@ impl web_transport_trait::Session for ScriptedSession {
 			Some(queue) => Arc::new(Mutex::new(queue.lock().unwrap().pop_front().unwrap_or_default())),
 			None => self.script.clone(),
 		};
-		Ok((SinkSend::new(self.log.clone()), ScriptedRecv { script, eof: self.eof }))
+		Ok((
+			SinkSend::new(self.log.clone()),
+			ScriptedRecv {
+				script,
+				eof: self.eof,
+				log: self.log.clone(),
+			},
+		))
 	}
 
 	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {


### PR DESCRIPTION
## Root cause

A subscriber walking away from an IETF subscription never told the publisher to stop. It called `stream.writer.finish()` and nothing else, so a conformant publisher kept the subscription Established and kept serving it indefinitely, while `remove_subscribe` had already deleted the alias mapping. Every subsequent group then stalled the full 1s `TRACK_ALIAS_TIMEOUT`, logged `unknown track alias`, and was dropped.

The observed signature was a **single** alias against 13,717 dropped objects, sustained. Subscription churn would have sprayed many aliases; one alias means one track that was never unbound.

There are two cancellation mechanisms, and we implemented neither:

**Draft-14 through 16** cancel with the `UNSUBSCRIBE` message (0xA, [draft-16 §9.12](https://www.ietf.org/archive/id/draft-ietf-moq-transport-16.txt)). §5.1.1 there:

> The Publisher can destroy subscription state as soon as it has received UNSUBSCRIBE. It MUST reset any open streams associated with the SUBSCRIBE.

`ietf::Unsubscribe` was fully defined in `subscribe.rs` and decoded by the adapter, but `run_subscribe` had **no call site** — the type was decode-only. `js/net` sends it; the Rust path never did.

This matters more than it looks: 14–16 install `ControlStreamAdapter`, whose `open_bi` returns *virtual* streams. `VirtualSendStream::reset` and `VirtualRecvStream::stop` are local-queue no-ops, so `RESET_STREAM` and `STOP_SENDING` are invisible to the peer on those versions. `UNSUBSCRIBE` is the **only** signal that crosses the wire on draft-16.

**Draft-17+** removed the message, leaving the stream. [draft-19 §3.3.2](https://www.ietf.org/archive/id/draft-ietf-moq-transport-19.txt): *"A FIN only indicates that an endpoint will send no further messages in that direction; it is not a request cancellation."* §3.3.3 gives the pair — an endpoint that has already FINed its sending direction cancels with `STOP_SENDING` on the receiving one — and §5.1.1 makes receiving it what frees the subscription.

Both now go through a single `cancel_subscribe`, which every path that abandons an Established subscription uses, so the two exits cannot drift apart.

## Also fixed, same machinery

- **Retired aliases instead of removed** (§11.1: *"retain sufficient state to quickly discard these unwanted Objects, rather than treating them as belonging to an unknown Track Alias"*). Late groups resolve immediately rather than stalling, and a group from a dead subscription can no longer be spliced into a later one that reuses the alias. Tombstones are a fixed 64-entry FIFO, so this needs no asynchronous sweeper.
- **A repeated alias is judged by full track name, not `RequestId`.** §5.1 lets a publisher assign one alias to several subscriptions of the same track; answering that with `session.close()` took down every other broadcast on the connection. Only one alias naming two *different* tracks is the collision §11.1 makes fatal. A shared alias we cannot demux (our filters are all `LargestObject`, so §5.1's "re-apply each subscription's filter" is unavailable to us) now costs just that subscription — and still sends `UNSUBSCRIBE`, since that path abandons an Established subscription too.
- **PUBLISH rejected with `NOT_SUPPORTED` (0x3)** from §10.10's table rather than an HTTP-ish 400/500. The alias it carries is deliberately **not** recorded: nothing will ever bind it, and a rejected request has no lifetime of ours to hang the cleanup on.

## Attribution

The drop path now splits in two, so an operator can tell whose problem a drop is:

- `dropping group for a cancelled subscription` (debug) — ours, expected during the teardown round trip.
- `unknown track alias: no SUBSCRIBE_OK bound it` (warn) — nothing ever bound it, so genuinely upstream.

## js/net

Alias handling mirrored per the Cross-Package Sync table. `js/net` did **not** have the cancellation bug: it already sends `UNSUBSCRIBE` on v14–16, and `Stream.close()` stops the reader. That divergence is why this only bit the Rust path.

## Out of scope

- No datagram receive loop exists on the IETF path (§11.3). Unimplemented in both directions, so not a regression.
- The cancellation path now sends `CANCELLED` (0x1) from §3.3.4 rather than `Error::Cancel`'s moq-lite code, which is `0` and reads as `INTERNAL_ERROR` on this wire. **Other** IETF paths still reset with moq-lite codes, notably `run_uni_group`. Fixing the whole mapping means reworking `Error::from_transport`, where `0` decodes back to `Cancel`, so it belongs in its own change.

No `drafts/` update: the IETF path implements the IETF's own draft, and moq-lite has no Track Alias (it is in `draft-lcurley-moq-lite`'s "Deleted Fields" list). Nothing public changed — `lite::test_transport` is `pub(crate)`.

## Testing

`just check` and `just test` pass. New coverage, each verified to fail without its fix rather than assumed:

- `cancelling_a_subscription_stops_the_publisher` — Draft16 and Draft19, asserts the alias is bound before cancelling so it cannot pass against a subscription that was never Established.
- `a_legacy_cancel_sends_unsubscribe` — UNSUBSCRIBE on 16, absent on 19.
- `a_legacy_shared_alias_is_unsubscribed` — the duplicate-alias abandonment path still cancels.
- Retired-alias resolution, alias reclaim, the tombstone cap, and the three duplicate-alias outcomes.

## Known limits

- The alias reuse window is narrowed, not closed. A group in flight when a publisher reassigns a freed alias is delivered to the new track, and nothing on a group stream distinguishes them. Prompt cancellation caps the exposure at a round trip rather than the life of the session; closing it properly means holding tombstones until the old subscription streams are observably closed. See the thread on `Alias::Retired`.
- Tombstone eviction is bounded by count, not by a deadline, so a session cancelling more than 64 distinct aliases inside one round trip falls back to the unknown-alias wait for the evicted ones. That is the pre-existing behavior, not a new failure.
- **`js/net` has no session harness.** The alias table is covered by tests, but every caller behavior is verified by inspection only: closing the session on the fatal case, and cancelling only when the local side ended. `#runSubscribe`/`#openSubscribe` are private and there is no session harness to drive a SUBSCRIBE_OK through, which is the gap the Rust side only avoids because this PR built the `ScriptedSession` path for it.

## Correction

An earlier commit claimed the writer's drop-time reset could discard the `UNSUBSCRIBE`. It cannot. `UNSUBSCRIBE` travels only on drafts 14-16, which carry requests over `ControlStreamAdapter`'s virtual streams, where `reset` is a no-op and bytes are forwarded to the control queue eagerly. Closing the writer instead of finishing it is still the correct call and is now pinned by the adapter-level test, but it fixed no live bug. The adapter test exists because nothing was checking that claim against the path production actually takes.

## Not verified

The mechanism is established from the draft text and the code, and the failure signature matches. It has **not** been reproduced against the relay that surfaced it; confirmation is the warning going quiet in production.

(written by Opus 5)
