### PR TITLE
feat(moq-gst): expose sink-pad publication lifecycle

### DIFF
--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -299,15 +299,15 @@ logs or asking a consumer:
 
 | Property      | Type   | Description                                       |
 | ------------- | ------ | ------------------------------------------------- |
-| `status`      | enum   | `pending` until CAPS builds a producer, `active` once the broadcast reserved the track, `ended` when it was finalized, `error` when the pad was invalidated |
+| `track-status` | enum   | `pending` until CAPS builds a producer, `active` once the broadcast reserved the track, `ended` when it was finalized, `error` when the pad was invalidated |
 | `track-error` | string | Why the pad was invalidated, null when it was not  |
 
-Both emit `notify`, so an application can connect to `notify::status` rather than poll. `active`
+Both emit `notify`, so an application can connect to `notify::track-status` rather than poll. `active`
 means the producer exists and the track is registered, not merely that the pad was requested, and a
 pad that sent EOS stays `active` until every pad has ended and the producers are finalized. `error`
 is terminal: it survives EOS, and clears when the pad is released or the element goes back to
 `READY`. A pad still waiting for CAPS is `pending` with no error, because nothing has failed yet.
-Connection loss is the element's own `status`, not the pad's.
+Connection loss is the element's own `status`.
 
 A pad negotiated as `application/octet-stream` publishes application data instead of media. The bytes
 go out exactly as they arrive: no codec, no media container, no interpretation. A data pad's

--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -294,6 +294,21 @@ element (back to `READY`) releases the reservation and makes it writable again. 
 the generated name. A name another pad already holds invalidates only that pad, so the rest of the
 broadcast keeps publishing.
 
+Each pad also reports what its track is doing, so a publication can be diagnosed without reading the
+logs or asking a consumer:
+
+| Property      | Type   | Description                                       |
+| ------------- | ------ | ------------------------------------------------- |
+| `status`      | enum   | `pending` until CAPS builds a producer, `active` once the broadcast reserved the track, `ended` when it was finalized, `error` when the pad was invalidated |
+| `track-error` | string | Why the pad was invalidated, null when it was not  |
+
+Both emit `notify`, so an application can connect to `notify::status` rather than poll. `active`
+means the producer exists and the track is registered, not merely that the pad was requested, and a
+pad that sent EOS stays `active` until every pad has ended and the producers are finalized. `error`
+is terminal: it survives EOS, and clears when the pad is released or the element goes back to
+`READY`. A pad still waiting for CAPS is `pending` with no error, because nothing has failed yet.
+Connection loss is the element's own `status`, not the pad's.
+
 A pad negotiated as `application/octet-stream` publishes application data instead of media. The bytes
 go out exactly as they arrive: no codec, no media container, no interpretation. A data pad's
 `container` property has no effect.

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -22,7 +22,7 @@ use hang::moq_net;
 
 use super::pad::{CapsOutcome, ProducerOptions, PushOutcome, caps_supported};
 use super::request_pad::{MoqSinkPad, Notifications};
-use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session, SessionId};
+use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session, SessionId, SessionRegistration};
 
 #[derive(Debug, Clone, Default)]
 struct Settings {
@@ -432,25 +432,46 @@ impl ElementImpl for MoqSink {
 
 	fn change_state(&self, transition: gst::StateChange) -> Result<gst::StateChangeSuccess, gst::StateChangeError> {
 		match transition {
-			gst::StateChange::ReadyToPaused => self.start_session()?,
-			gst::StateChange::PausedToReady => self.stop_session(),
-			_ => {}
+			gst::StateChange::ReadyToPaused => {
+				let registration = self.start_session()?;
+				// Rolled back on a failed parent transition: otherwise the session would keep publishing
+				// while the element sits in READY, with no later transition left to clean it up.
+				match self.parent_change_state(transition) {
+					Ok(success) => {
+						registration.mark_registered();
+						Ok(success)
+					}
+					Err(error) => {
+						self.stop_session();
+						Err(error)
+					}
+				}
+			}
+			// The parent goes first so it deactivates the pads and waits for the streaming functions to
+			// return before the session they write into is torn down. Cleanup is unconditional: a failed
+			// downward transition still leaves nothing that would ever release the publication.
+			gst::StateChange::PausedToReady => {
+				let result = self.parent_change_state(transition);
+				self.stop_session();
+				result
+			}
+			_ => self.parent_change_state(transition),
 		}
-		self.parent_change_state(transition)
 	}
 }
 
 impl MoqSink {
 	/// Create the session and producers before any buffer flows.
-	fn start_session(&self) -> Result<(), gst::StateChangeError> {
+	fn start_session(&self) -> Result<SessionRegistration, gst::StateChangeError> {
 		let settings = ResolvedSettings::try_from(self.settings.lock().unwrap().clone()).map_err(|err| {
 			gst::error!(CAT, obj = self.obj(), "invalid settings: {err:#}");
 			gst::StateChangeError
 		})?;
-		let (session, broadcast, catalog) = Session::start(settings, self.obj().downgrade()).map_err(|err| {
-			gst::error!(CAT, obj = self.obj(), "failed to start session: {err:?}");
-			gst::StateChangeError
-		})?;
+		let (session, registration, broadcast, catalog) =
+			Session::start(settings, self.obj().downgrade()).map_err(|err| {
+				gst::error!(CAT, obj = self.obj(), "failed to start session: {err:?}");
+				gst::StateChangeError
+			})?;
 		let error = session.error_flag();
 		let updates = {
 			let mut control = self.control.lock().unwrap();
@@ -476,7 +497,7 @@ impl MoqSink {
 				.collect::<Vec<_>>()
 		};
 		self.notify_updates(updates);
-		Ok(())
+		Ok(registration)
 	}
 
 	/// Finalize the producers (catalog last) and tear down the session. Finalize is best-effort: we are

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -9,7 +9,6 @@
 //! Locks are nested in one direction only: GStreamer's stream lock, then the element control, then a
 //! pad lifecycle, then an object lock. No path takes the element control while holding a pad lifecycle.
 
-use std::sync::atomic::Ordering;
 use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
@@ -22,7 +21,9 @@ use hang::moq_net;
 
 use super::pad::{CapsOutcome, ProducerOptions, PushOutcome, caps_supported};
 use super::request_pad::{MoqSinkPad, Notifications};
-use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session, SessionId, SessionRegistration};
+use super::session::{
+	CAT, Completion, ConnectionStatus, RUNTIME, ResolvedSettings, Session, SessionId, SessionRegistration,
+};
 
 #[derive(Debug, Clone, Default)]
 struct Settings {
@@ -60,7 +61,16 @@ struct State {
 	session: Session,
 	broadcast: moq_net::broadcast::Producer,
 	catalog: Option<moq_mux::catalog::Producer>,
-	eos_posted: bool,
+	/// Whether this publication's single EOS message already went out. One per publication, not per
+	/// entry to PLAYING: a finished publication is terminal here, so there is nothing to announce twice.
+	eos_delivered: bool,
+}
+
+impl State {
+	/// Whether this publication still accepts pads, negotiation and buffers.
+	fn is_open(&self) -> bool {
+		self.session.completion().is_open()
+	}
 }
 
 /// Element state that survives session replacement.
@@ -68,6 +78,31 @@ struct State {
 struct Control {
 	live: Option<State>,
 	admissions: usize,
+	/// Whether the element completed its transition into PLAYING. Tracked here rather than read from
+	/// GStreamer: the current state is not committed until `change_state` returns, so a message earned
+	/// inside that window would read PAUSED and be held with nobody left to release it.
+	playing: bool,
+}
+
+/// Claim this publication's EOS, if it is owed and may go out now.
+///
+/// One claim per publication, so whichever arrives first (the transition into PLAYING, or the pad that
+/// ended it) is the only one that posts. Called under `control`, which is what serializes the two.
+fn claim_eos(control: &mut Control) -> Posted {
+	if !control.playing {
+		return Posted::Nothing;
+	}
+	let Some(state) = control.live.as_mut() else {
+		return Posted::Nothing;
+	};
+	if state.eos_delivered || state.session.completion().get() != Completion::Eos {
+		return Posted::Nothing;
+	}
+	state.eos_delivered = true;
+	Posted::Message {
+		session: state.session.id().clone(),
+		kind: MessageKind::Eos,
+	}
 }
 
 /// A pad whose already-applied state change still needs GObject notification.
@@ -94,6 +129,12 @@ enum MessageKind {
 	FinalizeError(String),
 	/// The reconnect task stopped on a terminal error.
 	SessionError(String),
+}
+
+/// Whether confirming an admission left a usable pad.
+enum Admission {
+	Accepted,
+	Rejected,
 }
 
 /// The result of a finalize pass: which pads to report, and what the element owes the bus.
@@ -371,8 +412,8 @@ impl ElementImpl for MoqSink {
 		};
 		{
 			let mut control = self.control.lock().unwrap();
-			if control.live.as_ref().is_some_and(|state| state.eos_posted) {
-				gst::warning!(CAT, "refusing a pad after EOS: the session is finalized");
+			if control.live.as_ref().is_some_and(|state| !state.is_open()) {
+				gst::warning!(CAT, "refusing a pad: the publication has ended");
 				return None;
 			}
 			control.admissions += 1;
@@ -387,13 +428,19 @@ impl ElementImpl for MoqSink {
 			return None;
 		}
 		self.obj().child_added(&pad, pad.name().as_str());
-		let finished = self.confirm_admission(&pad);
+		let (admission, finished) = self.confirm_admission(&pad);
 		self.publish_finished(finished);
-		if !self.owns_pad(&pad) {
-			pad.reset_detached();
-			return None;
+		// The ownership check is a second question, about what the notifications above may have done.
+		match admission {
+			Admission::Accepted if self.owns_pad(&pad) => Some(pad.upcast()),
+			_ => {
+				match self.owns_pad(&pad) {
+					true => self.release_pad(pad.upcast_ref()),
+					false => pad.reset_detached(),
+				}
+				None
+			}
 		}
-		Some(pad.upcast())
 	}
 
 	fn release_pad(&self, pad: &gst::Pad) {
@@ -447,11 +494,25 @@ impl ElementImpl for MoqSink {
 					}
 				}
 			}
+			// The parent finishes the transition before the element is allowed to speak for PLAYING.
+			gst::StateChange::PausedToPlaying => {
+				let success = self.parent_change_state(transition)?;
+				self.enter_playing();
+				Ok(success)
+			}
+			// Fail-closed like the transition below it: a failed parent still left PLAYING, and a gate
+			// held open would let the next EOS out as if the element were still playing.
+			gst::StateChange::PlayingToPaused => {
+				let result = self.parent_change_state(transition);
+				self.leave_playing();
+				result
+			}
 			// The parent goes first so it deactivates the pads and waits for the streaming functions to
 			// return before the session they write into is torn down. Cleanup is unconditional: a failed
 			// downward transition still leaves nothing that would ever release the publication.
 			gst::StateChange::PausedToReady => {
 				let result = self.parent_change_state(transition);
+				self.leave_playing();
 				self.stop_session();
 				result
 			}
@@ -472,14 +533,14 @@ impl MoqSink {
 				gst::error!(CAT, obj = self.obj(), "failed to start session: {err:?}");
 				gst::StateChangeError
 			})?;
-		let error = session.error_flag();
+		let completion = session.completion();
 		let updates = {
 			let mut control = self.control.lock().unwrap();
 			control.live = Some(State {
 				session,
 				broadcast,
 				catalog: Some(catalog),
-				eos_posted: false,
+				eos_delivered: false,
 			});
 			self.obj()
 				.sink_pads()
@@ -489,7 +550,7 @@ impl MoqSink {
 					let changes = {
 						let mut lifecycle = pad.lifecycle();
 						let changes = lifecycle.reset();
-						lifecycle.session_error = Some(error.clone());
+						lifecycle.completion = Some(completion.clone());
 						changes
 					};
 					PadUpdate { pad, changes }
@@ -570,15 +631,15 @@ impl MoqSink {
 		let _rt = RUNTIME.enter();
 		let (outcome, changes) = {
 			let mut lifecycle = pad.lifecycle();
-			if lifecycle.releasing || lifecycle.session_error.is_none() {
+			let Some(completion) = lifecycle.completion.as_ref().filter(|_| !lifecycle.releasing) else {
 				return Err(gst::FlowError::Flushing);
-			}
-			if lifecycle
-				.session_error
-				.as_ref()
-				.is_some_and(|error| error.load(Ordering::Relaxed))
-			{
-				return Err(gst::FlowError::Error);
+			};
+			// The element's own end comes before the pad's: a broken rendition is isolated so the others
+			// keep publishing, but a finished publication is not something one pad may report as OK.
+			match completion.get() {
+				Completion::Failed => return Err(gst::FlowError::Error),
+				Completion::Eos => return Err(gst::FlowError::Eos),
+				Completion::Open => {}
 			}
 			if lifecycle.media.is_failed() {
 				return Ok(gst::FlowSuccess::Ok);
@@ -626,27 +687,46 @@ impl MoqSink {
 		match event.view() {
 			gst::EventView::Caps(caps) => {
 				let caps = caps.caps().to_owned();
+				// A pure check, so it runs before any lock is taken.
 				if !caps_supported(&caps) {
 					gst::warning!(CAT, "rejecting unsupported caps on pad {}", pad.name());
+					// The negotiation is refused either way, but recording it on the pad is not always
+					// allowed. No publication yet is not the same as one that ended: with no session, or
+					// with an open one, the pad takes the error; after a terminal state `ended` and
+					// `error` are settled and a late caps event must not rewrite one as the other.
 					let changes = {
 						let _rt = RUNTIME.enter();
-						let mut lifecycle = sink_pad.lifecycle();
-						lifecycle.media.invalidate();
-						lifecycle.fail(format!("unsupported caps: {caps}"))
+						let control = self.control.lock().unwrap();
+						let terminal = control.live.as_ref().is_some_and(|state| !state.is_open());
+						match terminal {
+							true => None,
+							false => {
+								let mut lifecycle = sink_pad.lifecycle();
+								match lifecycle.releasing {
+									true => None,
+									false => {
+										lifecycle.media.invalidate();
+										Some(lifecycle.fail(format!("unsupported caps: {caps}")))
+									}
+								}
+							}
+						}
 					};
-					sink_pad.notify_changes(changes);
+					if let Some(changes) = changes {
+						sink_pad.notify_changes(changes);
+					}
 					return false;
 				}
 				let (changes, accepted) = {
 					let _rt = RUNTIME.enter();
 					let control = self.control.lock().unwrap();
-					let Some(state) = control.live.as_ref().filter(|state| !state.eos_posted) else {
+					let Some(state) = control.live.as_ref().filter(|state| state.is_open()) else {
 						return gst::Pad::event_default(pad, Some(&*self.obj()), event);
 					};
 					let Some(catalog) = state.catalog.as_ref() else {
 						return gst::Pad::event_default(pad, Some(&*self.obj()), event);
 					};
-					let error = state.session.error_flag();
+					let completion = state.session.completion();
 					let mut lifecycle = sink_pad.lifecycle();
 					if lifecycle.releasing {
 						return false;
@@ -657,7 +737,7 @@ impl MoqSink {
 						options = options.with_track(track);
 					}
 					let outcome = lifecycle.media.observe_caps(&state.broadcast, catalog, options);
-					lifecycle.session_error = Some(error);
+					lifecycle.completion = Some(completion);
 					match outcome {
 						CapsOutcome::Active(track) => (Some(lifecycle.commit(track)), true),
 						CapsOutcome::Failed(reason) => (Some(lifecycle.fail(reason)), false),
@@ -671,15 +751,18 @@ impl MoqSink {
 			}
 			gst::EventView::Segment(segment) => {
 				let control = self.control.lock().unwrap();
-				let error = control
-					.live
-					.as_ref()
-					.filter(|state| !state.eos_posted)
-					.map(|state| state.session.error_flag());
+				let completion = control.live.as_ref().map(|state| state.session.completion());
 				let mut lifecycle = sink_pad.lifecycle();
 				if !lifecycle.releasing {
-					lifecycle.session_error = error;
-					if lifecycle.session_error.is_some() {
+					// The link is which publication the pad belongs to, not whether that publication is
+					// still open. Dropping it after the end would answer the next buffer with Flushing
+					// instead of the terminal result it earned.
+					lifecycle.completion = completion;
+					if lifecycle
+						.completion
+						.as_ref()
+						.is_some_and(|completion| completion.is_open())
+					{
 						lifecycle.media.observe_segment(segment.segment().to_owned());
 					}
 				}
@@ -690,7 +773,7 @@ impl MoqSink {
 			gst::EventView::Eos(_) => {
 				let finished = {
 					let mut control = self.control.lock().unwrap();
-					if control.live.as_ref().is_some_and(|state| !state.eos_posted) {
+					if control.live.as_ref().is_some_and(|state| state.is_open()) {
 						let mut lifecycle = sink_pad.lifecycle();
 						if !lifecycle.releasing {
 							lifecycle.ended = true;
@@ -703,7 +786,7 @@ impl MoqSink {
 			}
 			gst::EventView::FlushStop(_) => {
 				let control = self.control.lock().unwrap();
-				if control.live.as_ref().is_some_and(|state| !state.eos_posted) {
+				if control.live.as_ref().is_some_and(|state| state.is_open()) {
 					let mut lifecycle = sink_pad.lifecycle();
 					if !lifecycle.releasing {
 						lifecycle.ended = false;
@@ -715,7 +798,7 @@ impl MoqSink {
 			}
 			gst::EventView::StreamStart(_) => {
 				let control = self.control.lock().unwrap();
-				if control.live.as_ref().is_some_and(|state| !state.eos_posted) {
+				if control.live.as_ref().is_some_and(|state| state.is_open()) {
 					let mut lifecycle = sink_pad.lifecycle();
 					if !lifecycle.releasing {
 						lifecycle.ended = false;
@@ -753,19 +836,29 @@ impl MoqSink {
 		self.maybe_finish_locked(control)
 	}
 
-	fn confirm_admission(&self, pad: &MoqSinkPad) -> Finished {
+	fn confirm_admission(&self, pad: &MoqSinkPad) -> (Admission, Finished) {
 		let mut control = self.control.lock().unwrap();
-		let error = control
-			.live
-			.as_ref()
-			.filter(|state| !state.eos_posted)
-			.map(|state| state.session.error_flag());
+		let completion = control.live.as_ref().map(|state| state.session.completion());
 		let mut lifecycle = pad.lifecycle();
-		if !lifecycle.releasing {
-			lifecycle.session_error = error;
-		}
+		// Decided here, holding both locks. `owns_pad` cannot answer it: a pad stays the element's
+		// between being marked `releasing` and being removed, and a second look at the publication
+		// would read a different instant than the one this confirmation ran in.
+		let admission = match lifecycle.releasing {
+			true => Admission::Rejected,
+			false => {
+				let failed = completion
+					.as_ref()
+					.is_some_and(|completion| completion.get() == Completion::Failed);
+				lifecycle.completion = completion;
+				match failed {
+					true => Admission::Rejected,
+					false => Admission::Accepted,
+				}
+			}
+		};
 		drop(lifecycle);
-		self.finish_admission_locked(&mut control)
+		let finished = self.finish_admission_locked(&mut control);
+		(admission, finished)
 	}
 
 	fn maybe_finish_locked(&self, control: &mut Control) -> Finished {
@@ -782,11 +875,10 @@ impl MoqSink {
 			.filter_map(|pad| pad.downcast::<MoqSinkPad>().ok())
 			.collect::<Vec<_>>();
 		let all_ended = !pads.is_empty() && pads.iter().all(|pad| pad.lifecycle().ended);
-		if !all_ended || state.eos_posted {
+		if !all_ended || !state.is_open() {
 			return Finished::default();
 		}
 
-		state.eos_posted = true;
 		let _rt = RUNTIME.enter();
 		let mut updates = Vec::new();
 		let mut failure = None;
@@ -819,13 +911,22 @@ impl MoqSink {
 		{
 			failure = Some(err);
 		}
-		let kind = match failure {
-			Some(err) => MessageKind::FinalizeError(format!("{err:?}")),
-			None => MessageKind::Eos,
-		};
-		let message = Posted::Message {
-			session: state.session.id().clone(),
-			kind,
+		// Claimed after the work, not before: the outcome decides which terminal state this pass takes.
+		// Losing the claim means the session task already ended the publication and posted its own
+		// error, so this pass owes the bus nothing.
+		let completion = state.session.completion();
+		let message = match failure {
+			Some(err) => match completion.fail() {
+				true => Posted::Message {
+					session: state.session.id().clone(),
+					kind: MessageKind::FinalizeError(format!("{err:?}")),
+				},
+				false => Posted::Nothing,
+			},
+			None => {
+				completion.finish();
+				claim_eos(control)
+			}
 		};
 		Finished { updates, message }
 	}
@@ -836,6 +937,24 @@ impl MoqSink {
 		}
 	}
 
+	/// Open the EOS gate for this run and post the message if the publication already ended.
+	fn enter_playing(&self) {
+		let message = {
+			let mut control = self.control.lock().unwrap();
+			control.playing = true;
+			claim_eos(&mut control)
+		};
+		self.publish_finished(Finished {
+			updates: Vec::new(),
+			message,
+		});
+	}
+
+	/// Close the gate: an EOS earned from here on waits for the next entry to PLAYING.
+	fn leave_playing(&self) {
+		self.control.lock().unwrap().playing = false;
+	}
+
 	fn publish_finished(&self, finished: Finished) {
 		self.notify_updates(finished.updates);
 		self.post_current(finished.message);
@@ -843,9 +962,12 @@ impl MoqSink {
 
 	/// Route a terminal reconnect error through the same session gate as finalization messages.
 	pub(super) fn post_session_error(&self, session: &SessionId, error: String) {
-		self.post_current(Posted::Message {
-			session: session.clone(),
-			kind: MessageKind::SessionError(error),
+		self.publish_finished(Finished {
+			updates: Vec::new(),
+			message: Posted::Message {
+				session: session.clone(),
+				kind: MessageKind::SessionError(error),
+			},
 		});
 	}
 
@@ -890,10 +1012,10 @@ impl MoqSink {
 #[cfg(test)]
 mod tests {
 	use std::sync::Arc;
-	use std::sync::atomic::AtomicBool;
 
 	use super::super::MediaContainer;
 	use super::super::request_pad::Status;
+	use super::super::session::CompletionState;
 	use super::*;
 
 	fn sink() -> super::super::MoqSink {
@@ -902,6 +1024,116 @@ mod tests {
 
 	fn spec(element: &super::super::MoqSink, name: &str) -> glib::ParamSpec {
 		element.find_property(name).unwrap()
+	}
+
+	/// The live publication's completion, for a test that needs to race it.
+	fn completion_of(sink: &super::super::MoqSink) -> super::super::session::CompletionHandle {
+		sink.imp()
+			.control
+			.lock()
+			.unwrap()
+			.live
+			.as_ref()
+			.expect("live session")
+			.session
+			.completion()
+	}
+
+	// A pad marked for release is still the element's until it is removed, so the confirmation has to
+	// say it refused. Inferring it from `owns_pad` would hand the caller a pad already on its way out.
+	#[test]
+	fn confirming_an_admission_refuses_a_pad_already_releasing() {
+		gst::init().unwrap();
+		let sink = sink();
+		sink.set_property("url", "https://127.0.0.1:1");
+		sink.set_property("broadcast", "test");
+		let element = sink.clone().upcast::<gst::Element>();
+		let pad = element.request_pad_simple("sink_0").expect("request sink_0");
+		element.set_state(gst::State::Paused).expect("start session");
+		let pad = pad.downcast::<MoqSinkPad>().expect("MoqSinkPad");
+
+		pad.lifecycle().releasing = true;
+		sink.imp().control.lock().unwrap().admissions += 1;
+		let (admission, finished) = sink.imp().confirm_admission(&pad);
+		sink.imp().publish_finished(finished);
+
+		assert!(matches!(admission, Admission::Rejected), "the confirmation refused it");
+		assert!(
+			sink.imp().owns_pad(&pad),
+			"and it did so while the pad still belonged to the element, which is the window \
+			 `owns_pad` cannot see"
+		);
+		pad.lifecycle().releasing = false;
+		let _ = element.set_state(gst::State::Null);
+	}
+
+	// The transition is a compare-exchange, not a store: whoever arrives second changes nothing and is
+	// told so. A store would let a late session error rewrite an EOS the element already earned.
+	#[test]
+	fn only_the_first_terminal_transition_wins() {
+		let completion = CompletionState::new();
+		assert!(completion.finish(), "the first transition wins");
+		assert!(!completion.fail(), "the second is refused");
+		assert_eq!(completion.get(), Completion::Eos);
+		assert!(!completion.is_open());
+
+		let completion = CompletionState::new();
+		assert!(completion.fail());
+		assert!(!completion.finish(), "a clean end cannot follow a failure");
+		assert_eq!(completion.get(), Completion::Failed);
+	}
+
+	// A pad admitted while the publication was open must not be handed back once it failed underneath:
+	// it would only refuse every buffer. A clean EOS is the opposite case, covered by the pad-added
+	// tests that let a pad end the publication and still read its own status.
+	#[test]
+	fn a_pad_is_withdrawn_when_the_publication_fails_while_it_is_admitted() {
+		gst::init().unwrap();
+		let sink = sink();
+		sink.set_property("url", "https://127.0.0.1:1");
+		sink.set_property("broadcast", "test");
+		let element = sink.clone().upcast::<gst::Element>();
+		element.set_state(gst::State::Paused).expect("start session");
+
+		let failing = sink.clone();
+		element.connect_pad_added(move |_, _| {
+			completion_of(&failing).fail();
+		});
+
+		assert!(
+			element.request_pad_simple("sink_0").is_none(),
+			"the pad is withdrawn instead of returned unusable"
+		);
+		assert_eq!(element.num_sink_pads(), 0, "and it is not left on the element");
+		let _ = element.set_state(gst::State::Null);
+	}
+
+	// A task outliving its session writes into the handle nobody reads any more. Scoping falls out of
+	// the topology: no id comparison guards the state the pads see.
+	#[test]
+	fn a_stale_completion_cannot_end_the_next_publication() {
+		gst::init().unwrap();
+		let sink = sink();
+		sink.set_property("url", "https://127.0.0.1:1");
+		sink.set_property("broadcast", "test");
+		let element = sink.clone().upcast::<gst::Element>();
+		let pad = element.request_pad_simple("sink_0").expect("request sink_0");
+
+		element.set_state(gst::State::Paused).expect("first session");
+		let stale = completion_of(&sink);
+		element.set_state(gst::State::Ready).expect("stop the first session");
+		element.set_state(gst::State::Paused).expect("second session");
+
+		assert!(stale.fail(), "the old task still owns its own handle");
+		assert!(
+			completion_of(&sink).is_open(),
+			"the publication the pads read is untouched"
+		);
+		let pad = pad.downcast::<MoqSinkPad>().expect("MoqSinkPad");
+		let linked = pad.lifecycle().completion.clone().expect("session link");
+		assert!(!Arc::ptr_eq(&linked, &stale), "the pad was relinked to the new session");
+		assert!(linked.is_open());
+		let _ = element.set_state(gst::State::Null);
 	}
 
 	#[test]
@@ -954,23 +1186,24 @@ mod tests {
 			.as_ref()
 			.expect("live session")
 			.session
-			.error_flag();
-		let stale = Arc::new(AtomicBool::new(true));
-		pad.lifecycle().session_error = Some(stale.clone());
+			.completion();
+		let stale = CompletionState::new();
+		stale.fail();
+		pad.lifecycle().completion = Some(stale.clone());
 		sink.imp().control.lock().unwrap().admissions += 1;
-		let finished = sink.imp().confirm_admission(&pad);
+		let (_, finished) = sink.imp().confirm_admission(&pad);
 		sink.imp().publish_finished(finished);
 
-		let actual = pad.lifecycle().session_error.clone().expect("session link");
+		let actual = pad.lifecycle().completion.clone().expect("session link");
 		assert!(Arc::ptr_eq(&actual, &expected));
 		assert!(!Arc::ptr_eq(&actual, &stale));
 
 		element.set_state(gst::State::Ready).expect("stop session");
-		pad.lifecycle().session_error = Some(stale);
+		pad.lifecycle().completion = Some(stale);
 		sink.imp().control.lock().unwrap().admissions += 1;
-		let finished = sink.imp().confirm_admission(&pad);
+		let (_, finished) = sink.imp().confirm_admission(&pad);
 		sink.imp().publish_finished(finished);
-		assert!(pad.lifecycle().session_error.is_none());
+		assert!(pad.lifecycle().completion.is_none());
 		let _ = element.set_state(gst::State::Null);
 	}
 

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -1179,11 +1179,11 @@ mod tests {
 		sink.imp().control.lock().unwrap().admissions += 1;
 		assert!(pad.send_event(gst::event::Eos::new()));
 		let pad = pad.downcast::<MoqSinkPad>().expect("MoqSinkPad");
-		assert_eq!(pad.property::<Status>("status"), Status::Active);
+		assert_eq!(pad.property::<Status>("track-status"), Status::Active);
 
 		let finished = sink.imp().finish_admission();
 		sink.imp().publish_finished(finished);
-		assert_eq!(pad.property::<Status>("status"), Status::Ended);
+		assert_eq!(pad.property::<Status>("track-status"), Status::Ended);
 		let _ = element.set_state(gst::State::Null);
 	}
 
@@ -1243,7 +1243,7 @@ mod tests {
 		sink.imp().release_pad(&pad);
 
 		let pad = pad.downcast::<MoqSinkPad>().expect("MoqSinkPad");
-		assert_eq!(pad.property::<Status>("status"), Status::Pending);
+		assert_eq!(pad.property::<Status>("track-status"), Status::Pending);
 		assert!(pad.parent().is_none());
 	}
 
@@ -1271,10 +1271,10 @@ mod tests {
 			},
 		]);
 
-		assert_eq!(ended.property::<Status>("status"), Status::Ended);
+		assert_eq!(ended.property::<Status>("track-status"), Status::Ended);
 		assert_eq!(ended.property::<Option<String>>("track-error"), None);
 		assert_eq!(
-			failed.property::<Status>("status"),
+			failed.property::<Status>("track-status"),
 			Status::Error,
 			"a producer that would not close leaves its pad in error, not ended"
 		);

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -722,32 +722,38 @@ impl MoqSink {
 					}
 					return false;
 				}
-				let (changes, accepted) = {
+				// Negotiated under the control lock, but `event_default` runs after it drops: a sync
+				// handler reached from there can re-enter the element and take the same lock.
+				let negotiated = {
 					let _rt = RUNTIME.enter();
 					let control = self.control.lock().unwrap();
-					let Some(state) = control.live.as_ref().filter(|state| state.is_open()) else {
-						return gst::Pad::event_default(pad, Some(&*self.obj()), event);
-					};
-					let Some(catalog) = state.catalog.as_ref() else {
-						return gst::Pad::event_default(pad, Some(&*self.obj()), event);
-					};
-					let completion = state.session.completion();
-					let mut lifecycle = sink_pad.lifecycle();
-					if lifecycle.releasing {
-						return false;
+					if let Some(state) = control.live.as_ref().filter(|state| state.is_open())
+						&& let Some(catalog) = state.catalog.as_ref()
+					{
+						let completion = state.session.completion();
+						let mut lifecycle = sink_pad.lifecycle();
+						if lifecycle.releasing {
+							return false;
+						}
+						let requested = lifecycle.requested().map(str::to_owned);
+						let mut options = ProducerOptions::new(&caps).with_container(lifecycle.container().into());
+						if let Some(track) = requested.as_deref() {
+							options = options.with_track(track);
+						}
+						let outcome = lifecycle.media.observe_caps(&state.broadcast, catalog, options);
+						lifecycle.completion = Some(completion);
+						Some(match outcome {
+							CapsOutcome::Active(track) => (Some(lifecycle.commit(track)), true),
+							CapsOutcome::Failed(reason) => (Some(lifecycle.fail(reason)), false),
+							CapsOutcome::Unchanged => (None, true),
+						})
+					} else {
+						None
 					}
-					let requested = lifecycle.requested().map(str::to_owned);
-					let mut options = ProducerOptions::new(&caps).with_container(lifecycle.container().into());
-					if let Some(track) = requested.as_deref() {
-						options = options.with_track(track);
-					}
-					let outcome = lifecycle.media.observe_caps(&state.broadcast, catalog, options);
-					lifecycle.completion = Some(completion);
-					match outcome {
-						CapsOutcome::Active(track) => (Some(lifecycle.commit(track)), true),
-						CapsOutcome::Failed(reason) => (Some(lifecycle.fail(reason)), false),
-						CapsOutcome::Unchanged => (None, true),
-					}
+				};
+				// No live publication to negotiate against, so forward without touching the pad.
+				let Some((changes, accepted)) = negotiated else {
+					return gst::Pad::event_default(pad, Some(&*self.obj()), event);
 				};
 				if let Some(changes) = changes {
 					sink_pad.notify_changes(changes);

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -503,12 +503,13 @@ impl ElementImpl for MoqSink {
 				self.enter_playing();
 				Ok(success)
 			}
-			// Fail-closed like the transition below it: a failed parent still left PLAYING, and a gate
-			// held open would let the next EOS out as if the element were still playing.
+			// Symmetric with the transition below: a failed parent is not committed, so the element is
+			// still PLAYING and the gate stays open. Closing it anyway would strand an EOS earned
+			// afterwards, because no later entry to PLAYING would come along to claim it.
 			gst::StateChange::PlayingToPaused => {
-				let result = self.parent_change_state(transition);
+				let success = self.parent_change_state(transition)?;
 				self.leave_playing();
-				result
+				Ok(success)
 			}
 			// The parent goes first so it deactivates the pads and waits for the streaming functions to
 			// return before the session they write into is torn down. A failed parent leaves the element

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -22,7 +22,7 @@ use hang::moq_net;
 use super::pad::{CapsOutcome, ProducerOptions, PushOutcome, caps_supported};
 use super::request_pad::{MoqSinkPad, Notifications};
 use super::session::{
-	CAT, Completion, ConnectionStatus, RUNTIME, ResolvedSettings, Session, SessionId, SessionRegistration,
+	CAT, Completion, CompletionHandle, ConnectionStatus, RUNTIME, ResolvedSettings, Session, SessionRegistration,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -100,7 +100,7 @@ fn claim_eos(control: &mut Control) -> Posted {
 	}
 	state.eos_delivered = true;
 	Posted::Message {
-		session: state.session.id().clone(),
+		session: state.session.completion(),
 		kind: MessageKind::Eos,
 	}
 }
@@ -117,8 +117,11 @@ enum Posted {
 	/// Nothing to post: the pass did not run.
 	#[default]
 	Nothing,
-	/// A message earned by one publishing session.
-	Message { session: SessionId, kind: MessageKind },
+	/// A message earned by one publishing session, identified by that session's completion handle.
+	Message {
+		session: CompletionHandle,
+		kind: MessageKind,
+	},
 }
 
 /// The element-wide outcome a publishing session earned.
@@ -939,7 +942,7 @@ impl MoqSink {
 		let message = match failure {
 			Some(err) => match completion.fail() {
 				true => Posted::Message {
-					session: state.session.id().clone(),
+					session: state.session.completion(),
 					kind: MessageKind::FinalizeError(format!("{err:?}")),
 				},
 				false => Posted::Nothing,
@@ -982,7 +985,7 @@ impl MoqSink {
 	}
 
 	/// Route a terminal reconnect error through the same session gate as finalization messages.
-	pub(super) fn post_session_error(&self, session: &SessionId, error: String) {
+	pub(super) fn post_session_error(&self, session: &CompletionHandle, error: String) {
 		self.publish_finished(Finished {
 			updates: Vec::new(),
 			message: Posted::Message {
@@ -1004,7 +1007,7 @@ impl MoqSink {
 			.unwrap()
 			.live
 			.as_ref()
-			.is_some_and(|state| state.session.id().matches(&session));
+			.is_some_and(|state| std::sync::Arc::ptr_eq(&state.session.completion(), &session));
 		if !current {
 			gst::debug!(
 				CAT,
@@ -1301,8 +1304,7 @@ mod tests {
 			.as_ref()
 			.expect("live session")
 			.session
-			.id()
-			.clone();
+			.completion();
 		while bus.pop().is_some() {}
 
 		sink.imp().post_current(Posted::Message {
@@ -1340,8 +1342,7 @@ mod tests {
 			.as_ref()
 			.expect("first session")
 			.session
-			.id()
-			.clone();
+			.completion();
 
 		element.set_state(gst::State::Ready).expect("stop first session");
 		element
@@ -1356,8 +1357,7 @@ mod tests {
 			.as_ref()
 			.expect("replacement session")
 			.session
-			.id()
-			.clone();
+			.completion();
 		while bus.pop().is_some() {}
 		sink.imp().post_current(Posted::Message {
 			session: first.clone(),

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -5,8 +5,11 @@
 //! writes are synchronous (an in-memory append, bounded by group eviction), so the streaming thread
 //! never blocks on the network. A thin async task only owns connect and the session lifetime. Pads are
 //! fully independent: one pad's chain never waits on another's data.
+//!
+//! Locks are nested in one direction only: GStreamer's stream lock, then the element control, then a
+//! pad lifecycle, then an object lock. No path takes the element control while holding a pad lifecycle.
 
-use std::collections::{HashMap, HashSet};
+use std::sync::atomic::Ordering;
 use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
@@ -17,8 +20,8 @@ use gst::prelude::*;
 use gst::subclass::prelude::*;
 use hang::moq_net;
 
-use super::pad::{Pad, ProducerOptions, caps_supported};
-use super::request_pad::MoqSinkPad;
+use super::pad::{CapsOutcome, ProducerOptions, PushOutcome, caps_supported};
+use super::request_pad::{MoqSinkPad, Notifications};
 use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session};
 
 #[derive(Debug, Clone, Default)]
@@ -52,67 +55,51 @@ impl TryFrom<Settings> for ResolvedSettings {
 	}
 }
 
-/// Live state, present only while started. The producers are created up front (so frames buffered
-/// before connect are sent once it completes); the catalog is `Option` because it is taken on the first
-/// finalize. Per-pad media lives in `pads`; `ended` tracks EOS for element-level EOS aggregation.
+/// Live state for one READY to PAUSED run.
 struct State {
 	session: Session,
 	broadcast: moq_net::broadcast::Producer,
 	catalog: Option<moq_mux::catalog::Producer>,
-	pads: HashMap<String, Pad>,
-	ended: HashSet<String>,
 	eos_posted: bool,
 }
 
-impl State {
-	/// Finalize every live producer once, catalog last; runs on EOS and on stop. Idempotent. The names of
-	/// the producers finalized are accumulated into the `Ok` order until the first error, which is logged
-	/// and then surfaced as the returned `Err`.
-	fn finalize_all(&mut self) -> Result<Vec<String>> {
-		let mut result: Result<Vec<String>> = Ok(Vec::new());
-		for (name, pad) in self.pads.iter_mut() {
-			match pad.finalize() {
-				Ok(true) => {
-					if let Ok(order) = result.as_mut() {
-						order.push(name.clone());
-					}
-				}
-				Ok(false) => {}
-				Err(err) => {
-					gst::warning!(CAT, "finalize {name}: {err:?}");
-					if result.is_ok() {
-						result = Err(err);
-					}
-				}
-			}
-		}
-		if let Some(mut catalog) = self.catalog.take() {
-			match catalog.finish().context("finalize catalog") {
-				Ok(()) => {
-					if let Ok(order) = result.as_mut() {
-						order.push("catalog".to_string());
-					}
-				}
-				Err(err) => {
-					if result.is_ok() {
-						result = Err(err);
-					}
-				}
-			}
-		}
-		result
-	}
+/// Element state that survives session replacement.
+#[derive(Default)]
+struct Control {
+	live: Option<State>,
+	admissions: usize,
+}
+
+/// A pad whose already-applied state change still needs GObject notification.
+struct PadUpdate {
+	pad: MoqSinkPad,
+	changes: Notifications,
+}
+
+/// What a finalize pass leaves for the caller to put on the bus, once it holds no pad lock.
+#[derive(Default)]
+enum Posted {
+	/// Nothing to post: the pass did not run.
+	#[default]
+	Nothing,
+	/// Every pad ended and the producers closed.
+	Eos,
+	/// A producer failed to close, already formatted for the bus.
+	Error(String),
+}
+
+/// The result of a finalize pass: which pads to report, and what the element owes the bus.
+#[derive(Default)]
+struct Finished {
+	updates: Vec<PadUpdate>,
+	message: Posted,
 }
 
 /// The `moqsink` element implementation: its GObject properties plus the live session state.
 #[derive(Default)]
 pub struct MoqSink {
 	settings: Mutex<Settings>,
-	/// Live state between Ready->Paused and Paused->Ready. One Mutex, not Arc<Mutex>: glib already owns
-	/// and shares the subclass instance across GStreamer's threads, so we need interior mutability but
-	/// not a second ownership layer. Held only briefly per buffer, so independent pad threads barely
-	/// contend.
-	state: Mutex<Option<State>>,
+	control: Mutex<Control>,
 }
 
 #[glib::object_subclass]
@@ -220,8 +207,8 @@ impl ObjectImpl for MoqSink {
 	fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
 		match pspec.name() {
 			"status" | "connected" | "moq-version" | "estimated-send-bitrate" | "estimated-recv-bitrate" => {
-				let state = self.state.lock().unwrap();
-				let session = state.as_ref().map(|s| &s.session);
+				let control = self.control.lock().unwrap();
+				let session = control.live.as_ref().map(|s| &s.session);
 				match pspec.name() {
 					"status" => session.map(|s| s.status().status()).unwrap_or_default().to_value(),
 					"connected" => session.is_some_and(|s| s.status().connected()).to_value(),
@@ -334,8 +321,12 @@ impl ElementImpl for MoqSink {
 			// Opaque application data: published byte for byte, so there is no structural field to pin.
 			caps.merge(gst::Caps::builder("application/octet-stream").build());
 
-			let sink =
-				gst::PadTemplate::new("sink_%u", gst::PadDirection::Sink, gst::PadPresence::Request, &caps).unwrap();
+			// The GType is what makes gst-inspect-1.0 list the pad's own properties; without it the
+			// template reports none, however many the pad declares.
+			let sink = gst::PadTemplate::builder("sink_%u", gst::PadDirection::Sink, gst::PadPresence::Request, &caps)
+				.gtype(MoqSinkPad::static_type())
+				.build()
+				.unwrap();
 			vec![sink]
 		});
 		PAD_TEMPLATES.as_ref()
@@ -370,41 +361,65 @@ impl ElementImpl for MoqSink {
 			Some(name) => pad_builder.name(name).build(),
 			None => pad_builder.generated_name().build(),
 		};
-		self.obj().add_pad(&pad).ok()?;
+		{
+			let mut control = self.control.lock().unwrap();
+			if control.live.as_ref().is_some_and(|state| state.eos_posted) {
+				gst::warning!(CAT, "refusing a pad after EOS: the session is finalized");
+				return None;
+			}
+			control.admissions += 1;
+		}
+
+		if self.obj().add_pad(&pad).is_err() {
+			self.cancel_admission(&pad);
+			return None;
+		}
+		if !self.owns_pad(&pad) {
+			self.cancel_admission(&pad);
+			return None;
+		}
 		self.obj().child_added(&pad, pad.name().as_str());
+		let finished = self.confirm_admission(&pad);
+		self.publish_finished(finished);
+		if !self.owns_pad(&pad) {
+			pad.reset_detached();
+			return None;
+		}
 		Some(pad.upcast())
 	}
 
 	fn release_pad(&self, pad: &gst::Pad) {
-		// CAPS takes the pad lock before the element state lock. Keep the same order here so a CAPS
-		// handler cannot insert a producer after this removal.
-		let sink_pad = pad.downcast_ref::<MoqSinkPad>();
-		let retirement = sink_pad.map(MoqSinkPad::retire_track);
-		{
+		let Some(sink_pad) = pad.downcast_ref::<MoqSinkPad>() else {
+			return;
+		};
+		if !self.owns_pad(sink_pad) {
+			sink_pad.reset_detached();
+			return;
+		}
+
+		let _ = pad.set_active(false);
+		let changes = {
 			let _rt = RUNTIME.enter();
-			if let Some(state) = self.state.lock().unwrap().as_mut() {
-				let name = pad.name();
-				if let Some(mut media) = state.pads.remove(name.as_str())
-					&& let Err(err) = media.finalize()
-				{
-					gst::warning!(CAT, "finalize on release {name}: {err:?}");
-				}
-				state.ended.remove(name.as_str());
+			let mut lifecycle = sink_pad.lifecycle();
+			if lifecycle.releasing {
+				return;
 			}
-		}
-		// The producer is gone, so the pad no longer holds a reservation: an application
-		// keeping the released pad reads what it asked for, not a name nothing publishes.
-		if let Some(retirement) = retirement {
-			retirement.release();
-		}
+			lifecycle.releasing = true;
+			if let Err(err) = lifecycle.media.finalize() {
+				gst::warning!(CAT, "finalize on release {}: {err:?}", pad.name());
+			}
+			lifecycle.reset()
+		};
 		if self.obj().remove_pad(pad).is_ok() {
 			self.obj().child_removed(pad, pad.name().as_str());
 		}
-		if let Some(sink_pad) = sink_pad {
-			sink_pad.finish_release();
-		}
-		// Removing a still-active pad can leave only already-ended pads, which now satisfies EOS.
-		self.maybe_post_eos();
+		sink_pad.lifecycle().releasing = false;
+		sink_pad.notify_changes(changes);
+		let finished = {
+			let mut control = self.control.lock().unwrap();
+			self.maybe_finish_locked(&mut control)
+		};
+		self.publish_finished(finished);
 	}
 
 	fn change_state(&self, transition: gst::StateChange) -> Result<gst::StateChangeSuccess, gst::StateChangeError> {
@@ -428,47 +443,89 @@ impl MoqSink {
 			gst::error!(CAT, obj = self.obj(), "failed to start session: {err:?}");
 			gst::StateChangeError
 		})?;
-		*self.state.lock().unwrap() = Some(State {
-			session,
-			broadcast,
-			catalog: Some(catalog),
-			pads: HashMap::new(),
-			ended: HashSet::new(),
-			eos_posted: false,
-		});
+		let error = session.error_flag();
+		let updates = {
+			let mut control = self.control.lock().unwrap();
+			control.live = Some(State {
+				session,
+				broadcast,
+				catalog: Some(catalog),
+				eos_posted: false,
+			});
+			self.obj()
+				.sink_pads()
+				.into_iter()
+				.filter_map(|pad| pad.downcast::<MoqSinkPad>().ok())
+				.map(|pad| {
+					let changes = {
+						let mut lifecycle = pad.lifecycle();
+						let changes = lifecycle.reset();
+						lifecycle.session_error = Some(error.clone());
+						changes
+					};
+					PadUpdate { pad, changes }
+				})
+				.collect::<Vec<_>>()
+		};
+		self.notify_updates(updates);
 		Ok(())
 	}
 
 	/// Finalize the producers (catalog last) and tear down the session. Finalize is best-effort: we are
 	/// tearing down regardless.
 	fn stop_session(&self) {
-		let Some(mut state) = self.state.lock().unwrap().take() else {
-			return;
+		let (mut state, updates, mut failure) = {
+			let mut control = self.control.lock().unwrap();
+			let Some(state) = control.live.take() else {
+				return;
+			};
+			let _rt = RUNTIME.enter();
+			let mut failure = None;
+			let updates = self
+				.obj()
+				.sink_pads()
+				.into_iter()
+				.filter_map(|pad| pad.downcast::<MoqSinkPad>().ok())
+				.map(|pad| {
+					let changes = {
+						let mut lifecycle = pad.lifecycle();
+						if let Err(err) = lifecycle.media.finalize() {
+							gst::warning!(CAT, "finalize {} on stop: {err:?}", pad.name());
+							if failure.is_none() {
+								failure = Some(err);
+							}
+						}
+						lifecycle.reset()
+					};
+					PadUpdate { pad, changes }
+				})
+				.collect::<Vec<_>>();
+			(state, updates, failure)
 		};
 		let _rt = RUNTIME.enter();
-		if let Err(err) = state.finalize_all() {
+		if let Some(mut catalog) = state.catalog.take()
+			&& let Err(err) = catalog.finish().context("finalize catalog")
+			&& failure.is_none()
+		{
+			failure = Some(err);
+		}
+		if let Some(err) = failure {
 			gst::warning!(CAT, "finalize on stop: {err:?}");
 		}
 		// Finish the broadcast (a deliberate end, so no dropped-without-finish
 		// warning) before reaping the session task.
 		state.broadcast.finish();
 		state.session.stop();
-		// The producers are gone, so each pad's name is configurable again for the next run.
-		for pad in self.obj().sink_pads() {
-			if let Some(pad) = pad.downcast_ref::<MoqSinkPad>() {
-				pad.release_track();
-			}
-		}
+		self.notify_updates(updates);
 	}
 
 	/// Write one buffer straight into its pad's producer. Per-pad failures (bad caps/bitstream) drop
 	/// quietly so the session and other pads keep going; an unmappable buffer or a dead session is a hard
 	/// error on this pad's streaming thread.
 	fn forward_buffer(&self, pad: &gst::Pad, buffer: gst::Buffer) -> Result<gst::FlowSuccess, gst::FlowError> {
-		// Map and copy outside the lock: neither needs shared state, so the per-pad lock is held only for
-		// the producer write. An oversized buffer is still copied here (it already exists upstream), but
-		// moq-net rejects it (FrameTooLarge) before reserving its own group slot, and that error invalidates
-		// just this pad.
+		// Map and copy outside the lock so the per-pad lock covers only the producer write. Avoiding the
+		// copy for an oversized buffer needs a reliable, media-aware size heuristic; moq-net remains the
+		// authority and rejects FrameTooLarge before reserving its own group slot.
 		let pts = buffer.pts();
 		let current_running_time = self.obj().current_running_time();
 		let map = buffer.map_readable().map_err(|_| {
@@ -477,38 +534,40 @@ impl MoqSink {
 		})?;
 		let data = Bytes::copy_from_slice(map.as_slice());
 		drop(map);
-		let Some(activity) = pad.downcast_ref::<MoqSinkPad>().and_then(MoqSinkPad::reserve_track) else {
+		let Some(pad) = pad.downcast_ref::<MoqSinkPad>() else {
 			return Err(gst::FlowError::Flushing);
 		};
 
-		// Producer writes can touch tokio time (group eviction), so hold the runtime context here.
 		let _rt = RUNTIME.enter();
-		let mut guard = self.state.lock().unwrap();
-		let Some(state) = guard.as_mut() else {
-			return Err(gst::FlowError::Flushing); // not started
+		let (outcome, changes) = {
+			let mut lifecycle = pad.lifecycle();
+			if lifecycle.releasing || lifecycle.session_error.is_none() {
+				return Err(gst::FlowError::Flushing);
+			}
+			if lifecycle
+				.session_error
+				.as_ref()
+				.is_some_and(|error| error.load(Ordering::Relaxed))
+			{
+				return Err(gst::FlowError::Error);
+			}
+			if lifecycle.media.is_failed() {
+				return Ok(gst::FlowSuccess::Ok);
+			}
+			let outcome = lifecycle.media.push_buffer(data, pts, current_running_time);
+			let changes = match &outcome {
+				Ok(PushOutcome::Failed(reason)) => Some(lifecycle.fail(reason.clone())),
+				_ => None,
+			};
+			(outcome, changes)
 		};
-		if state.session.errored() {
-			return Err(gst::FlowError::Error);
+		if let Some(changes) = changes {
+			pad.notify_changes(changes);
 		}
-
-		// The pad almost always exists already (caps arrive before buffers), so look it up without
-		// allocating an owned name; only the rare first-buffer insert pays for the key.
-		let name = pad.name();
-		let media = match state.pads.get_mut(name.as_str()) {
-			Some(media) => media,
-			None => state.pads.entry(name.to_string()).or_insert_with(Pad::new),
-		};
-		if media.is_failed() {
-			return Ok(gst::FlowSuccess::Ok); // drop quietly; the pad already reported its failure
-		}
-
-		let result = media.push_buffer(data, pts, current_running_time);
-		drop(guard);
-		drop(activity);
-		let no_segment = match result {
-			Ok(no_segment) => no_segment,
+		let outcome = match outcome {
+			Ok(outcome) => outcome,
 			Err(err) => {
-				// Bus sync handlers run inline and may read a property that locks `state` again.
+				// Bus sync handlers run inline and may read a property that locks the lifecycle again.
 				gst::element_error!(
 					self.obj(),
 					gst::StreamError::Format,
@@ -518,8 +577,7 @@ impl MoqSink {
 				return Err(gst::FlowError::Error);
 			}
 		};
-
-		if no_segment {
+		if outcome == PushOutcome::NoSegment {
 			gst::element_warning!(
 				self.obj(),
 				gst::StreamError::Format,
@@ -533,112 +591,236 @@ impl MoqSink {
 	}
 
 	fn handle_event(&self, pad: &gst::Pad, event: gst::Event) -> bool {
-		let Some(reservation) = pad.downcast_ref::<MoqSinkPad>().and_then(MoqSinkPad::reserve_track) else {
+		let Some(sink_pad) = pad.downcast_ref::<MoqSinkPad>() else {
 			return false;
 		};
 		match event.view() {
 			gst::EventView::Caps(caps) => {
 				let caps = caps.caps().to_owned();
-				// Reject unsupported caps synchronously (NotNegotiated) before building a producer.
 				if !caps_supported(&caps) {
 					gst::warning!(CAT, "rejecting unsupported caps on pad {}", pad.name());
+					let changes = {
+						let _rt = RUNTIME.enter();
+						let mut lifecycle = sink_pad.lifecycle();
+						lifecycle.media.invalidate();
+						lifecycle.fail(format!("unsupported caps: {caps}"))
+					};
+					sink_pad.notify_changes(changes);
 					return false;
 				}
-				let reserved = {
+				let (changes, accepted) = {
 					let _rt = RUNTIME.enter();
-					let mut guard = self.state.lock().unwrap();
-					guard.as_mut().and_then(|state| {
-						let State {
-							broadcast,
-							catalog,
-							pads,
-							..
-						} = state;
-						let catalog = catalog.as_ref()?;
-						let mut options = ProducerOptions::new(&caps).with_container(reservation.container().into());
-						if let Some(track) = reservation.requested() {
-							options = options.with_track(track);
-						}
-						pads.entry(pad.name().to_string())
-							.or_insert_with(Pad::new)
-							.observe_caps(broadcast, catalog, options)
-					})
+					let control = self.control.lock().unwrap();
+					let Some(state) = control.live.as_ref().filter(|state| !state.eos_posted) else {
+						return gst::Pad::event_default(pad, Some(&*self.obj()), event);
+					};
+					let Some(catalog) = state.catalog.as_ref() else {
+						return gst::Pad::event_default(pad, Some(&*self.obj()), event);
+					};
+					let error = state.session.error_flag();
+					let mut lifecycle = sink_pad.lifecycle();
+					if lifecycle.releasing {
+						return false;
+					}
+					let requested = lifecycle.requested().map(str::to_owned);
+					let mut options = ProducerOptions::new(&caps).with_container(lifecycle.container().into());
+					if let Some(track) = requested.as_deref() {
+						options = options.with_track(track);
+					}
+					let outcome = lifecycle.media.observe_caps(&state.broadcast, catalog, options);
+					lifecycle.session_error = Some(error);
+					match outcome {
+						CapsOutcome::Active(track) => (Some(lifecycle.commit(track)), true),
+						CapsOutcome::Failed(reason) => (Some(lifecycle.fail(reason)), false),
+						CapsOutcome::Unchanged => (None, true),
+					}
 				};
-				if let Some(track) = reserved {
-					reservation.commit(track);
+				if let Some(changes) = changes {
+					sink_pad.notify_changes(changes);
 				}
-				gst::Pad::event_default(pad, Some(&*self.obj()), event)
+				accepted && gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
 			gst::EventView::Segment(segment) => {
-				if let Some(state) = self.state.lock().unwrap().as_mut() {
-					state
-						.pads
-						.entry(pad.name().to_string())
-						.or_insert_with(Pad::new)
-						.observe_segment(segment.segment().to_owned());
+				let control = self.control.lock().unwrap();
+				let error = control
+					.live
+					.as_ref()
+					.filter(|state| !state.eos_posted)
+					.map(|state| state.session.error_flag());
+				let mut lifecycle = sink_pad.lifecycle();
+				if !lifecycle.releasing {
+					lifecycle.session_error = error;
+					if lifecycle.session_error.is_some() {
+						lifecycle.media.observe_segment(segment.segment().to_owned());
+					}
 				}
-				drop(reservation);
+				drop(lifecycle);
+				drop(control);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
 			gst::EventView::Eos(_) => {
-				self.handle_eos(pad);
-				drop(reservation);
+				let finished = {
+					let mut control = self.control.lock().unwrap();
+					if control.live.as_ref().is_some_and(|state| !state.eos_posted) {
+						let mut lifecycle = sink_pad.lifecycle();
+						if !lifecycle.releasing {
+							lifecycle.ended = true;
+						}
+					}
+					self.maybe_finish_locked(&mut control)
+				};
+				self.publish_finished(finished);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
-			// FLUSH_STOP re-anchors the timeline; the trailing SEGMENT is accepted fresh. The producer is
-			// kept (FLUSH is not EOS).
 			gst::EventView::FlushStop(_) => {
-				if let Some(state) = self.state.lock().unwrap().as_mut()
-					&& let Some(media) = state.pads.get_mut(pad.name().as_str())
-				{
-					media.flush();
+				let control = self.control.lock().unwrap();
+				if control.live.as_ref().is_some_and(|state| !state.eos_posted) {
+					let mut lifecycle = sink_pad.lifecycle();
+					if !lifecycle.releasing {
+						lifecycle.ended = false;
+						lifecycle.media.flush();
+					}
 				}
-				drop(reservation);
+				drop(control);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
-			_ => {
-				let handled = gst::Pad::event_default(pad, Some(&*self.obj()), event);
-				drop(reservation);
-				handled
+			gst::EventView::StreamStart(_) => {
+				let control = self.control.lock().unwrap();
+				if control.live.as_ref().is_some_and(|state| !state.eos_posted) {
+					let mut lifecycle = sink_pad.lifecycle();
+					if !lifecycle.releasing {
+						lifecycle.ended = false;
+					}
+				}
+				drop(control);
+				gst::Pad::event_default(pad, Some(&*self.obj()), event)
+			}
+			_ => gst::Pad::event_default(pad, Some(&*self.obj()), event),
+		}
+	}
+
+	fn owns_pad(&self, pad: &MoqSinkPad) -> bool {
+		pad.parent().as_ref() == Some(self.obj().upcast_ref::<gst::Object>())
+	}
+
+	fn cancel_admission(&self, pad: &MoqSinkPad) {
+		let finished = self.finish_admission();
+		self.publish_finished(finished);
+		if self.owns_pad(pad) {
+			self.release_pad(pad.upcast_ref());
+		} else {
+			pad.reset_detached();
+		}
+	}
+
+	fn finish_admission(&self) -> Finished {
+		let mut control = self.control.lock().unwrap();
+		self.finish_admission_locked(&mut control)
+	}
+
+	fn finish_admission_locked(&self, control: &mut Control) -> Finished {
+		debug_assert!(control.admissions > 0);
+		control.admissions = control.admissions.saturating_sub(1);
+		self.maybe_finish_locked(control)
+	}
+
+	fn confirm_admission(&self, pad: &MoqSinkPad) -> Finished {
+		let mut control = self.control.lock().unwrap();
+		let error = control
+			.live
+			.as_ref()
+			.filter(|state| !state.eos_posted)
+			.map(|state| state.session.error_flag());
+		let mut lifecycle = pad.lifecycle();
+		if !lifecycle.releasing {
+			lifecycle.session_error = error;
+		}
+		drop(lifecycle);
+		self.finish_admission_locked(&mut control)
+	}
+
+	fn maybe_finish_locked(&self, control: &mut Control) -> Finished {
+		if control.admissions > 0 {
+			return Finished::default();
+		}
+		let Some(state) = control.live.as_mut() else {
+			return Finished::default();
+		};
+		let pads = self
+			.obj()
+			.sink_pads()
+			.into_iter()
+			.filter_map(|pad| pad.downcast::<MoqSinkPad>().ok())
+			.collect::<Vec<_>>();
+		let all_ended = !pads.is_empty() && pads.iter().all(|pad| pad.lifecycle().ended);
+		if !all_ended || state.eos_posted {
+			return Finished::default();
+		}
+
+		state.eos_posted = true;
+		let _rt = RUNTIME.enter();
+		let mut updates = Vec::new();
+		let mut failure = None;
+		for pad in pads {
+			let mut lifecycle = pad.lifecycle();
+			if lifecycle.releasing || !self.owns_pad(&pad) {
+				continue;
+			}
+			let result = lifecycle.media.finalize();
+			let changes = match result {
+				Ok(true) => Some(lifecycle.end()),
+				Ok(false) => None,
+				Err(err) => {
+					gst::warning!(CAT, "finalize {}: {err:?}", pad.name());
+					let reason = format!("{err:#}");
+					if failure.is_none() {
+						failure = Some(err);
+					}
+					Some(lifecycle.fail(reason))
+				}
+			};
+			drop(lifecycle);
+			if let Some(changes) = changes {
+				updates.push(PadUpdate { pad, changes });
 			}
 		}
-	}
-
-	/// Mark a pad ended, then post the element EOS if that was the last active pad.
-	fn handle_eos(&self, pad: &gst::Pad) {
-		if let Some(state) = self.state.lock().unwrap().as_mut() {
-			state.ended.insert(pad.name().to_string());
+		if let Some(mut catalog) = state.catalog.take()
+			&& let Err(err) = catalog.finish().context("finalize catalog")
+			&& failure.is_none()
+		{
+			failure = Some(err);
 		}
-		self.maybe_post_eos();
-	}
-
-	/// Finalize and post the element EOS once every active sink pad has ended. Locks internally and is
-	/// idempotent via `eos_posted`, so both the EOS handler and `release_pad` (releasing the last active
-	/// pad can satisfy aggregation for pads that already ended) can call it.
-	fn maybe_post_eos(&self) {
-		let _rt = RUNTIME.enter();
-		let mut guard = self.state.lock().unwrap();
-		let Some(state) = guard.as_mut() else {
-			return;
+		let message = match failure {
+			Some(err) => Posted::Error(format!("{err:?}")),
+			None => Posted::Eos,
 		};
-		let sink_pads = self.obj().sink_pads();
-		let all_ended = !sink_pads.is_empty() && sink_pads.iter().all(|p| state.ended.contains(p.name().as_str()));
-		if !all_ended || state.eos_posted {
-			return;
-		}
-		state.eos_posted = true;
-		let result = state.finalize_all();
-		drop(guard);
+		Finished { updates, message }
+	}
 
-		match result {
-			Ok(order) => {
-				gst::debug!(CAT, "finalized on EOS: {order:?}");
+	fn notify_updates(&self, updates: Vec<PadUpdate>) {
+		for update in updates {
+			update.pad.notify_changes(update.changes);
+		}
+	}
+
+	fn publish_finished(&self, finished: Finished) {
+		self.notify_updates(finished.updates);
+		self.post_finished(finished.message);
+	}
+
+	/// Put the finalize pass on the bus. Deliberately separate from the pass itself: `post_message` runs
+	/// the bus sync handlers on this thread, and one reading `status` or `track-error` (the reason they
+	/// exist) would take a pad's settings lock that the EOS path is still holding.
+	fn post_finished(&self, message: Posted) {
+		match message {
+			Posted::Nothing => {}
+			Posted::Eos => {
 				gst::info!(CAT, "all pads ended, posting EOS");
 				let obj = self.obj();
 				let _ = obj.post_message(gst::message::Eos::builder().src(&*obj).build());
 			}
-			Err(err) => {
-				gst::element_error!(self.obj(), gst::CoreError::Failed, ("finalize failed"), ["{err:?}"]);
+			Posted::Error(err) => {
+				gst::element_error!(self.obj(), gst::CoreError::Failed, ("finalize failed"), ["{err}"]);
 			}
 		}
 	}
@@ -646,7 +828,11 @@ impl MoqSink {
 
 #[cfg(test)]
 mod tests {
+	use std::sync::atomic::AtomicBool;
+	use std::sync::Arc;
+
 	use super::super::MediaContainer;
+	use super::super::request_pad::Status;
 	use super::*;
 
 	fn sink() -> super::super::MoqSink {
@@ -655,6 +841,151 @@ mod tests {
 
 	fn spec(element: &super::super::MoqSink, name: &str) -> glib::ParamSpec {
 		element.find_property(name).unwrap()
+	}
+
+	#[test]
+	fn an_admission_defers_finalization_until_membership_is_stable() {
+		gst::init().unwrap();
+		let sink = sink();
+		sink.set_property("url", "https://127.0.0.1:1");
+		sink.set_property("broadcast", "test");
+		let element = sink.clone().upcast::<gst::Element>();
+		let pad = element.request_pad_simple("sink_0").expect("request sink_0");
+		element.set_state(gst::State::Paused).expect("start session");
+		assert!(pad.send_event(gst::event::StreamStart::new("test")));
+		let caps = gst::Caps::builder("video/x-h264")
+			.field("stream-format", "byte-stream")
+			.field("alignment", "au")
+			.build();
+		assert!(pad.send_event(gst::event::Caps::new(&caps)));
+
+		sink.imp().control.lock().unwrap().admissions += 1;
+		assert!(pad.send_event(gst::event::Eos::new()));
+		let pad = pad.downcast::<MoqSinkPad>().expect("MoqSinkPad");
+		assert_eq!(pad.property::<Status>("status"), Status::Active);
+
+		let finished = sink.imp().finish_admission();
+		sink.imp().publish_finished(finished);
+		assert_eq!(pad.property::<Status>("status"), Status::Ended);
+		let _ = element.set_state(gst::State::Null);
+	}
+
+	#[test]
+	fn confirming_an_admission_replaces_and_clears_stale_session_links() {
+		gst::init().unwrap();
+		let sink = sink();
+		sink.set_property("url", "https://127.0.0.1:1");
+		sink.set_property("broadcast", "test");
+		let element = sink.clone().upcast::<gst::Element>();
+		let pad = element
+			.request_pad_simple("sink_0")
+			.expect("request sink_0")
+			.downcast::<MoqSinkPad>()
+			.expect("MoqSinkPad");
+		element.set_state(gst::State::Paused).expect("start session");
+
+		let expected = sink
+			.imp()
+			.control
+			.lock()
+			.unwrap()
+			.live
+			.as_ref()
+			.expect("live session")
+			.session
+			.error_flag();
+		let stale = Arc::new(AtomicBool::new(true));
+		pad.lifecycle().session_error = Some(stale.clone());
+		sink.imp().control.lock().unwrap().admissions += 1;
+		let finished = sink.imp().confirm_admission(&pad);
+		sink.imp().publish_finished(finished);
+
+		let actual = pad.lifecycle().session_error.clone().expect("session link");
+		assert!(Arc::ptr_eq(&actual, &expected));
+		assert!(!Arc::ptr_eq(&actual, &stale));
+
+		element.set_state(gst::State::Ready).expect("stop session");
+		pad.lifecycle().session_error = Some(stale);
+		sink.imp().control.lock().unwrap().admissions += 1;
+		let finished = sink.imp().confirm_admission(&pad);
+		sink.imp().publish_finished(finished);
+		assert!(pad.lifecycle().session_error.is_none());
+		let _ = element.set_state(gst::State::Null);
+	}
+
+	#[test]
+	fn internal_release_tolerates_an_already_detached_pad() {
+		gst::init().unwrap();
+		let sink = sink();
+		let element = sink.clone().upcast::<gst::Element>();
+		let pad = element.request_pad_simple("sink_0").expect("request sink_0");
+
+		sink.imp().release_pad(&pad);
+		assert!(pad.parent().is_none());
+		sink.imp().release_pad(&pad);
+
+		let pad = pad.downcast::<MoqSinkPad>().expect("MoqSinkPad");
+		assert_eq!(pad.property::<Status>("status"), Status::Pending);
+		assert!(pad.parent().is_none());
+	}
+
+	/// A finalize pass can apply clean and failed outcomes before notifying either pad.
+	#[test]
+	fn a_partial_finalization_reports_both_outcomes() {
+		gst::init().unwrap();
+		let sink = sink();
+		let element = sink.clone().upcast::<gst::Element>();
+		let ended = element.request_pad_simple("sink_0").expect("request sink_0");
+		let failed = element.request_pad_simple("sink_1").expect("request sink_1");
+		let ended = ended.downcast::<MoqSinkPad>().expect("sink_0 is a MoqSinkPad");
+		let failed = failed.downcast::<MoqSinkPad>().expect("sink_1 is a MoqSinkPad");
+
+		let ended_changes = ended.lifecycle().end();
+		let failed_changes = failed.lifecycle().fail("finalize sink_1: closed".to_string());
+		sink.imp().notify_updates(vec![
+			PadUpdate {
+				pad: ended.clone(),
+				changes: ended_changes,
+			},
+			PadUpdate {
+				pad: failed.clone(),
+				changes: failed_changes,
+			},
+		]);
+
+		assert_eq!(ended.property::<Status>("status"), Status::Ended);
+		assert_eq!(ended.property::<Option<String>>("track-error"), None);
+		assert_eq!(
+			failed.property::<Status>("status"),
+			Status::Error,
+			"a producer that would not close leaves its pad in error, not ended"
+		);
+		assert_eq!(
+			failed.property::<Option<String>>("track-error").as_deref(),
+			Some("finalize sink_1: closed")
+		);
+	}
+
+	// The element still owes the bus a failure, even though each pad reported its own.
+	#[test]
+	fn a_finalize_failure_reaches_the_bus() {
+		gst::init().unwrap();
+		let sink = sink();
+		let element = sink.clone().upcast::<gst::Element>();
+		let bus = gst::Bus::new();
+		element.set_bus(Some(&bus));
+
+		sink.imp()
+			.post_finished(Posted::Error("finalize sink_1: closed".to_string()));
+
+		let message = bus.pop().expect("the element posted a message");
+		let gst::MessageView::Error(error) = message.view() else {
+			panic!("expected an error message, got {:?}", message.type_());
+		};
+		assert!(
+			error.debug().is_some_and(|debug| debug.contains("closed")),
+			"the reason travels with the message"
+		);
 	}
 
 	#[test]
@@ -780,8 +1111,8 @@ mod tests {
 		}
 
 		let snapshot = {
-			let state = sink.imp().state.lock().unwrap();
-			state.as_ref().unwrap().catalog.as_ref().unwrap().snapshot()
+			let control = sink.imp().control.lock().unwrap();
+			control.live.as_ref().unwrap().catalog.as_ref().unwrap().snapshot()
 		};
 		assert_eq!(
 			snapshot.video.renditions.get("camera").unwrap().container,

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -22,7 +22,7 @@ use hang::moq_net;
 
 use super::pad::{CapsOutcome, ProducerOptions, PushOutcome, caps_supported};
 use super::request_pad::{MoqSinkPad, Notifications};
-use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session};
+use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session, SessionId};
 
 #[derive(Debug, Clone, Default)]
 struct Settings {
@@ -76,16 +76,24 @@ struct PadUpdate {
 	changes: Notifications,
 }
 
-/// What a finalize pass leaves for the caller to put on the bus, once it holds no pad lock.
+/// A deferred element message together with the publishing session that earned it.
 #[derive(Default)]
 enum Posted {
 	/// Nothing to post: the pass did not run.
 	#[default]
 	Nothing,
+	/// A message earned by one publishing session.
+	Message { session: SessionId, kind: MessageKind },
+}
+
+/// The element-wide outcome a publishing session earned.
+enum MessageKind {
 	/// Every pad ended and the producers closed.
 	Eos,
 	/// A producer failed to close, already formatted for the bus.
-	Error(String),
+	FinalizeError(String),
+	/// The reconnect task stopped on a terminal error.
+	SessionError(String),
 }
 
 /// The result of a finalize pass: which pads to report, and what the element owes the bus.
@@ -790,9 +798,13 @@ impl MoqSink {
 		{
 			failure = Some(err);
 		}
-		let message = match failure {
-			Some(err) => Posted::Error(format!("{err:?}")),
-			None => Posted::Eos,
+		let kind = match failure {
+			Some(err) => MessageKind::FinalizeError(format!("{err:?}")),
+			None => MessageKind::Eos,
+		};
+		let message = Posted::Message {
+			session: state.session.id().clone(),
+			kind,
 		};
 		Finished { updates, message }
 	}
@@ -805,22 +817,50 @@ impl MoqSink {
 
 	fn publish_finished(&self, finished: Finished) {
 		self.notify_updates(finished.updates);
-		self.post_finished(finished.message);
+		self.post_current(finished.message);
 	}
 
-	/// Put the finalize pass on the bus. Deliberately separate from the pass itself: `post_message` runs
-	/// the bus sync handlers on this thread, and one reading `status` or `track-error` (the reason they
-	/// exist) would take a pad's settings lock that the EOS path is still holding.
-	fn post_finished(&self, message: Posted) {
-		match message {
-			Posted::Nothing => {}
-			Posted::Eos => {
+	/// Route a terminal reconnect error through the same session gate as finalization messages.
+	pub(super) fn post_session_error(&self, session: &SessionId, error: String) {
+		self.post_current(Posted::Message {
+			session: session.clone(),
+			kind: MessageKind::SessionError(error),
+		});
+	}
+
+	/// Post a message only while the publishing session that produced it remains current. The control
+	/// lock is released first because bus sync handlers can re-enter element and pad properties.
+	fn post_current(&self, message: Posted) {
+		let Posted::Message { session, kind } = message else {
+			return;
+		};
+		let current = self
+			.control
+			.lock()
+			.unwrap()
+			.live
+			.as_ref()
+			.is_some_and(|state| state.session.id().matches(&session));
+		if !current {
+			gst::debug!(
+				CAT,
+				obj = self.obj(),
+				"discarding a message from a stopped publishing session"
+			);
+			return;
+		}
+
+		match kind {
+			MessageKind::Eos => {
 				gst::info!(CAT, "all pads ended, posting EOS");
 				let obj = self.obj();
 				let _ = obj.post_message(gst::message::Eos::builder().src(&*obj).build());
 			}
-			Posted::Error(err) => {
+			MessageKind::FinalizeError(err) => {
 				gst::element_error!(self.obj(), gst::CoreError::Failed, ("finalize failed"), ["{err}"]);
+			}
+			MessageKind::SessionError(err) => {
+				gst::element_error!(self.obj(), gst::CoreError::Failed, ("session error"), ["{err}"]);
 			}
 		}
 	}
@@ -828,8 +868,8 @@ impl MoqSink {
 
 #[cfg(test)]
 mod tests {
-	use std::sync::atomic::AtomicBool;
 	use std::sync::Arc;
+	use std::sync::atomic::AtomicBool;
 
 	use super::super::MediaContainer;
 	use super::super::request_pad::Status;
@@ -971,12 +1011,29 @@ mod tests {
 	fn a_finalize_failure_reaches_the_bus() {
 		gst::init().unwrap();
 		let sink = sink();
+		sink.set_property("url", "https://127.0.0.1:1");
+		sink.set_property("broadcast", "test");
 		let element = sink.clone().upcast::<gst::Element>();
 		let bus = gst::Bus::new();
 		element.set_bus(Some(&bus));
+		element.set_state(gst::State::Paused).expect("start session");
+		let session = sink
+			.imp()
+			.control
+			.lock()
+			.unwrap()
+			.live
+			.as_ref()
+			.expect("live session")
+			.session
+			.id()
+			.clone();
+		while bus.pop().is_some() {}
 
-		sink.imp()
-			.post_finished(Posted::Error("finalize sink_1: closed".to_string()));
+		sink.imp().post_current(Posted::Message {
+			session,
+			kind: MessageKind::FinalizeError("finalize sink_1: closed".to_string()),
+		});
 
 		let message = bus.pop().expect("the element posted a message");
 		let gst::MessageView::Error(error) = message.view() else {
@@ -986,6 +1043,73 @@ mod tests {
 			error.debug().is_some_and(|debug| debug.contains("closed")),
 			"the reason travels with the message"
 		);
+		let _ = element.set_state(gst::State::Null);
+	}
+
+	#[test]
+	fn errors_are_scoped_to_the_session_that_produced_them() {
+		gst::init().unwrap();
+		let sink = sink();
+		sink.set_property("url", "https://127.0.0.1:1");
+		sink.set_property("broadcast", "test");
+		let element = sink.clone().upcast::<gst::Element>();
+		let bus = gst::Bus::new();
+		element.set_bus(Some(&bus));
+		element.set_state(gst::State::Paused).expect("start first session");
+		let first = sink
+			.imp()
+			.control
+			.lock()
+			.unwrap()
+			.live
+			.as_ref()
+			.expect("first session")
+			.session
+			.id()
+			.clone();
+
+		element.set_state(gst::State::Ready).expect("stop first session");
+		element
+			.set_state(gst::State::Paused)
+			.expect("start replacement session");
+		let replacement = sink
+			.imp()
+			.control
+			.lock()
+			.unwrap()
+			.live
+			.as_ref()
+			.expect("replacement session")
+			.session
+			.id()
+			.clone();
+		while bus.pop().is_some() {}
+		sink.imp().post_current(Posted::Message {
+			session: first.clone(),
+			kind: MessageKind::FinalizeError("old finalization failed".to_string()),
+		});
+		sink.imp().post_session_error(&first, "old session failed".to_string());
+
+		assert!(
+			bus.timed_pop_filtered(gst::ClockTime::ZERO, &[gst::MessageType::Error])
+				.is_none(),
+			"the stopped session posted an error into its replacement"
+		);
+
+		sink.imp()
+			.post_session_error(&replacement, "current session failed".to_string());
+		let message = bus
+			.timed_pop_filtered(gst::ClockTime::ZERO, &[gst::MessageType::Error])
+			.expect("the current session posted its error");
+		let gst::MessageView::Error(error) = message.view() else {
+			unreachable!();
+		};
+		assert!(
+			error
+				.debug()
+				.is_some_and(|debug| debug.contains("current session failed"))
+		);
+		let _ = element.set_state(gst::State::Null);
 	}
 
 	#[test]

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -60,12 +60,40 @@ impl<'a> ProducerOptions<'a> {
 	}
 }
 
+/// What a CAPS event did to the pad. Distinguishing "nothing to do" from "the build failed" is what
+/// lets the caller report a status instead of only logging one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapsOutcome {
+	/// Already publishing under these caps, or already failed: no producer was built.
+	Unchanged,
+	/// A producer was built, reserving this track name.
+	Active(String),
+	/// The build was rejected and only this pad is invalidated.
+	Failed(String),
+}
+
+/// What a buffer did. Returned rather than stored, like `CapsOutcome`: a mailbox the caller had to
+/// remember to empty is what let one failure hide another.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PushOutcome {
+	/// The frame reached the producer.
+	Published,
+	/// Dropped without invalidating the pad. The reason is logged; it is not the pad's status.
+	Dropped,
+	/// The first buffer dropped for want of a TIME segment. Reported once per pad, because without a
+	/// timeline the pad can never publish and the caller should say so on the bus.
+	NoSegment,
+	/// The producer rejected the write, invalidating only this pad.
+	Failed(String),
+}
+
 /// One sink pad's producer plus its timeline policy.
 pub struct Pad {
 	track: Option<Producer>,
 	caps: Option<gst::Caps>,
 	/// Set once a producer build rejects this pad's caps or bitstream; further buffers are dropped and
-	/// the track stays finalized. Isolated to the pad, so the session and other pads keep going.
+	/// the track stays finalized. Isolated to the pad, so the session and other pads keep going. The
+	/// reason is not kept here: whichever call failed returns it.
 	failed: bool,
 	state: PadState,
 	segment_info: Option<SegmentInfo>,
@@ -96,24 +124,23 @@ impl Pad {
 	}
 
 	/// (Re)build the producer when the pad's caps change, under `track` when the pad was given a name.
-	/// Returns the name the broadcast reserved, so the caller can publish it. A build failure invalidates
-	/// only this pad; the caller keeps the session and other pads alive. Identical caps re-sent as a
-	/// sticky event keep the live producer.
+	/// A build failure invalidates only this pad; the caller keeps the session and other pads alive.
+	/// Identical caps re-sent as a sticky event keep the live producer.
 	pub(super) fn observe_caps(
 		&mut self,
 		broadcast: &moq_net::broadcast::Producer,
 		catalog: &moq_mux::catalog::Producer,
 		options: ProducerOptions<'_>,
-	) -> Option<String> {
+	) -> CapsOutcome {
 		if self.failed || (self.track.is_some() && self.caps.as_deref() == Some(options.caps)) {
-			return None;
+			return CapsOutcome::Unchanged;
 		}
 		match self.build(broadcast, catalog, options) {
-			Ok(name) => Some(name),
+			Ok(name) => CapsOutcome::Active(name),
 			Err(err) => {
 				gst::warning!(CAT, "invalidating pad: {err:?}");
 				self.fail();
-				None
+				CapsOutcome::Failed(format!("{err:#}"))
 			}
 		}
 	}
@@ -139,7 +166,9 @@ impl Pad {
 				.context("an opaque data pad requires a track name")?
 				.to_owned();
 			let mut broadcast = broadcast.clone();
-			let request = broadcast.reserve_track(name.clone())?;
+			let request = broadcast
+				.reserve_track(name.clone())
+				.with_context(|| format!("cannot reserve track {name}"))?;
 			// Followed at the live edge, so it keeps the default retention the media helper raises.
 			let info = moq_net::track::Info::default().with_timescale(moq_net::Timescale::MICRO);
 			self.track = Some(Producer::Opaque(request.accept(info)));
@@ -215,7 +244,9 @@ impl Pad {
 				// MP3 builds its config from caps, so like Opus it constructs the codec importer
 				// directly and lifts it into a `Track` via `.into()`.
 				let name = Self::track_name(&broadcast, requested, ".mp3");
-				let request = broadcast.reserve_track(name.clone())?;
+				let request = broadcast
+					.reserve_track(name.clone())
+					.with_context(|| format!("cannot reserve track {name}"))?;
 				let producer = request.accept(hang::container::track_info());
 				(
 					moq_mux::codec::mp3::Import::new(
@@ -259,7 +290,9 @@ impl Pad {
 				// Opus builds its config from caps (not an OpusHead init buffer), so it constructs the codec
 				// importer directly and lifts it into a `Track` via `.into()`.
 				let name = Self::track_name(&broadcast, requested, ".opus");
-				let request = broadcast.reserve_track(name.clone())?;
+				let request = broadcast
+					.reserve_track(name.clone())
+					.with_context(|| format!("cannot reserve track {name}"))?;
 				let producer = request.accept(hang::container::track_info());
 				(
 					moq_mux::codec::opus::Import::new(
@@ -298,7 +331,9 @@ impl Pad {
 		container: hang::catalog::Container,
 	) -> Result<(import::Track, String)> {
 		let name = Self::track_name(broadcast, requested, suffix);
-		let request = broadcast.reserve_track(name.clone())?;
+		let request = broadcast
+			.reserve_track(name.clone())
+			.with_context(|| format!("cannot reserve track {name}"))?;
 		let init = import::Init::new(format, init.to_vec()).with_container(container);
 		Ok((import::Track::new(request, reserved, init)?, name))
 	}
@@ -313,11 +348,17 @@ impl Pad {
 	}
 
 	/// Drops the producer (closing its track) and marks the pad failed so further buffers are dropped.
+	/// The reason belongs to whichever call failed, which returns it.
 	fn fail(&mut self) {
 		if let Err(err) = self.finalize() {
 			gst::warning!(CAT, "finalize on failed pad: {err:?}");
 		}
 		self.failed = true;
+	}
+
+	/// Invalidate this producer after a failure detected outside the codec importer.
+	pub fn invalidate(&mut self) {
+		self.fail();
 	}
 
 	/// Record a SEGMENT, re-anchoring the timeline. An `Active` pad enforces continuity against its
@@ -385,22 +426,21 @@ impl Pad {
 
 	/// Import one buffer into the producer. A failed or producer-less pad drops the buffer; a timeline
 	/// drop is logged. Unstamped opaque data on an active timeline uses the element's current running
-	/// time. A bad bitstream (or an oversized frame, rejected by moq-net) invalidates only this pad.
-	/// Returns `true` the first time a buffer is dropped because the pad has no TIME segment, so the
-	/// caller can surface it once on the bus. Returns an error when an unstamped opaque buffer has no
-	/// current running time, so the caller fails the flow instead of silently dropping data.
+	/// time. A bad bitstream (or an oversized frame, rejected by moq-net) invalidates only this pad and
+	/// says so in the returned outcome. Returns an error when an unstamped opaque buffer has no current
+	/// running time, so the caller fails the flow instead of silently dropping data.
 	pub fn push_buffer(
 		&mut self,
 		data: Bytes,
 		pts: Option<gst::ClockTime>,
 		current_running_time: Option<gst::ClockTime>,
-	) -> std::result::Result<bool, &'static str> {
+	) -> std::result::Result<PushOutcome, &'static str> {
 		if self.failed {
-			return Ok(false);
+			return Ok(PushOutcome::Dropped);
 		}
 		if self.track.is_none() {
 			gst::warning!(CAT, "dropping buffer received before caps");
-			return Ok(false);
+			return Ok(PushOutcome::Dropped);
 		}
 		let opaque = matches!(self.track.as_ref(), Some(Producer::Opaque(_)));
 		let timestamp = if opaque && pts.is_none() && self.state == PadState::Active {
@@ -421,22 +461,29 @@ impl Pad {
 						ts.map(|ts| producer.write_frame(ts, &data).map_err(|err| err.to_string()))
 					}
 				};
-				match result {
+				Ok(match result {
 					Some(Err(err)) => {
 						gst::warning!(CAT, "invalidating pad: {err}");
 						self.fail();
+						PushOutcome::Failed(err)
 					}
-					Some(Ok(())) => {}
-					None => gst::warning!(CAT, "dropping frame: timestamp out of range"),
-				}
-				Ok(false)
+					Some(Ok(())) => PushOutcome::Published,
+					None => {
+						gst::warning!(CAT, "dropping frame: timestamp out of range");
+						PushOutcome::Dropped
+					}
+				})
 			}
 			Err(reason) => {
 				gst::warning!(CAT, "dropping frame: {reason}");
 				// A pad stuck in NoSegment has no timeline and will never publish; report it once.
 				let first = self.state == PadState::NoSegment && !self.no_segment_reported;
 				self.no_segment_reported |= first;
-				Ok(first)
+				Ok(if first {
+					PushOutcome::NoSegment
+				} else {
+					PushOutcome::Dropped
+				})
 			}
 		}
 	}
@@ -449,9 +496,16 @@ impl Pad {
 		let Some(mut track) = self.track.take() else {
 			return Ok(false);
 		};
-		match &mut track {
-			Producer::Media(track) => track.finish()?,
-			Producer::Opaque(producer) => producer.finish()?,
+		let closed = match &mut track {
+			Producer::Media(track) => track.finish().map_err(anyhow::Error::from),
+			Producer::Opaque(producer) => producer.finish().map_err(anyhow::Error::from),
+		};
+		if let Err(err) = closed {
+			// The producer is gone either way, so the pad publishes nothing from here: mark it failed so
+			// later buffers drop the way they do after any other failure, rather than looking pre-caps.
+			// The reason is not stored: the caller gets it from this `Err`.
+			self.failed = true;
+			return Err(err);
 		}
 		Ok(true)
 	}
@@ -581,7 +635,7 @@ mod tests {
 		let mut pad = Pad::new();
 		assert_eq!(
 			pad.observe_caps(&broadcast, &catalog, producer_options(&h264_caps(), Some("camera")),),
-			Some("camera".to_string()),
+			CapsOutcome::Active("camera".to_string()),
 			"the reserved name is the requested one"
 		);
 		pad.observe_segment(time_segment());
@@ -601,7 +655,7 @@ mod tests {
 		let mut pad = Pad::new();
 		assert_eq!(
 			pad.observe_caps(&broadcast, &catalog, producer_options(&h264_caps(), None)),
-			Some("0.avc3".to_string())
+			CapsOutcome::Active("0.avc3".to_string())
 		);
 	}
 
@@ -615,11 +669,11 @@ mod tests {
 		let mut second = Pad::new();
 		assert_eq!(
 			first.observe_caps(&broadcast, &catalog, producer_options(&h264_caps(), Some("camera")),),
-			Some("camera".to_string())
+			CapsOutcome::Active("camera".to_string())
 		);
 		assert_eq!(
 			second.observe_caps(&broadcast, &catalog, producer_options(&h264_caps(), Some("camera")),),
-			None,
+			CapsOutcome::Failed("cannot reserve track camera: duplicate".to_string()),
 			"the duplicate reservation is rejected"
 		);
 		assert!(second.is_failed(), "the collision fails the second pad");
@@ -636,7 +690,7 @@ mod tests {
 		let mut pad = Pad::new();
 		assert_eq!(
 			pad.observe_caps(&broadcast, &catalog, producer_options(&h264_caps(), Some("camera")),),
-			Some("camera".to_string())
+			CapsOutcome::Active("camera".to_string())
 		);
 		let renegotiated = gst::Caps::builder("video/x-h264")
 			.field("stream-format", "byte-stream")
@@ -645,7 +699,7 @@ mod tests {
 			.build();
 		assert_eq!(
 			pad.observe_caps(&broadcast, &catalog, producer_options(&renegotiated, Some("camera")),),
-			Some("camera".to_string()),
+			CapsOutcome::Active("camera".to_string()),
 			"the same name is reserved again, not rejected as a duplicate"
 		);
 		assert!(!pad.is_failed());
@@ -686,14 +740,16 @@ mod tests {
 		let mut pad = Pad::new();
 		pad.observe_caps(&broadcast, &catalog, producer_options(&h264_caps(), None));
 		// No observe_segment: the pad stays in NoSegment.
-		assert!(
+		assert_eq!(
 			pad.push_buffer(h264_keyframe_au(), Some(gst::ClockTime::ZERO), None)
 				.unwrap(),
+			PushOutcome::NoSegment,
 			"first no-segment buffer is reported"
 		);
-		assert!(
-			!pad.push_buffer(h264_keyframe_au(), Some(gst::ClockTime::ZERO), None)
+		assert_eq!(
+			pad.push_buffer(h264_keyframe_au(), Some(gst::ClockTime::ZERO), None)
 				.unwrap(),
+			PushOutcome::Dropped,
 			"subsequent no-segment buffers are not re-reported"
 		);
 	}
@@ -721,7 +777,7 @@ mod tests {
 		let mut pad = Pad::new();
 		assert_eq!(
 			pad.observe_caps(&broadcast, &catalog, producer_options(&opaque_caps(), None)),
-			None
+			CapsOutcome::Failed("an opaque data pad requires a track name".to_string())
 		);
 		assert!(
 			pad.is_failed(),
@@ -771,7 +827,7 @@ mod tests {
 					.with_container(hang::catalog::Container::Loc)
 					.with_track("audiolevels"),
 			),
-			Some("audiolevels".to_string())
+			CapsOutcome::Active("audiolevels".to_string())
 		);
 		pad.observe_segment(time_segment());
 		// Opens with a zero byte and carries a non-UTF-8 one: nothing here may be reinterpreted.
@@ -832,7 +888,7 @@ mod tests {
 					.with_container(hang::catalog::Container::Loc)
 					.with_track("camera"),
 			),
-			Some("camera".to_string())
+			CapsOutcome::Active("camera".to_string())
 		);
 		pad.observe_segment(time_segment());
 		pad.push_buffer(h264_keyframe_au(), Some(gst::ClockTime::ZERO), None)

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -11,7 +11,7 @@ use super::MediaContainer;
 use super::pad::Pad;
 use super::session::{CAT, CompletionHandle};
 
-/// What the pad's track is doing, as reported by the `status` property.
+/// What the pad's track is doing, as reported by the `track-status` property.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, glib::Enum)]
 #[repr(u32)]
 #[enum_type(name = "GstMoqSinkPadStatus")]
@@ -119,10 +119,11 @@ impl PadLifecycle {
 		}
 	}
 
-	/// Record a terminal failure without changing an earlier failure's EOS semantics.
+	/// Record a terminal failure. The first reason wins: `error` is terminal for the run, so a later
+	/// failure on an already-failed pad must not rewrite why it stopped. Cleared by [`Self::reset`].
 	pub(super) fn fail(&mut self, reason: String) -> Notifications {
-		let error = self.settings.error.as_deref() != Some(reason.as_str());
-		self.settings.error = Some(reason);
+		let error = self.settings.error.is_none();
+		self.settings.error.get_or_insert(reason);
 		Notifications {
 			status: self.settings.set_status(Status::Error),
 			error,
@@ -340,6 +341,31 @@ mod tests {
 			pad.property::<Option<String>>("track-error"),
 			None,
 			"and carries no stale reason"
+		);
+	}
+
+	// `error` is terminal for the run, so the reason the pad actually stopped has to survive a later
+	// failure. A pad that fails on its bitstream and then sees an unsupported caps event still reports
+	// the bitstream.
+	#[test]
+	fn the_first_failure_reason_wins() {
+		let pad = sink_pad();
+		apply(&pad, |lifecycle| lifecycle.fail("aac without codec_data".to_string()));
+		apply(&pad, |lifecycle| {
+			lifecycle.fail("unsupported caps: video/x-raw".to_string())
+		});
+		assert_eq!(
+			pad.property::<Option<String>>("track-error").as_deref(),
+			Some("aac without codec_data"),
+			"the later failure did not rewrite why the pad stopped"
+		);
+
+		apply(&pad, PadLifecycle::reset);
+		apply(&pad, |lifecycle| lifecycle.fail("a new run's failure".to_string()));
+		assert_eq!(
+			pad.property::<Option<String>>("track-error").as_deref(),
+			Some("a new run's failure"),
+			"but a reset clears it for the next run"
 		);
 	}
 

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -1,14 +1,36 @@
 //! The `sink_%u` request pad as its own GObject, so the track it publishes can be named from a
 //! pipeline description through `GstChildProxy` (`moqsink sink_0::track=camera`).
 
-use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 
 use gst::glib;
 use gst::prelude::*;
 use gst::subclass::prelude::*;
 
 use super::MediaContainer;
+use super::pad::Pad;
 use super::session::CAT;
+
+/// What the pad's track is doing, as reported by the `status` property.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, glib::Enum)]
+#[repr(u32)]
+#[enum_type(name = "MoqSinkPadStatus")]
+pub enum Status {
+	/// Requested, with no producer yet: CAPS has not arrived, or the element is not started.
+	#[default]
+	#[enum_value(name = "No producer yet", nick = "pending")]
+	Pending = 0,
+	/// CAPS built a producer and the broadcast reserved the track.
+	#[enum_value(name = "Publishing", nick = "active")]
+	Active = 1,
+	/// The track was finalized cleanly.
+	#[enum_value(name = "Track finalized", nick = "ended")]
+	Ended = 2,
+	/// The pad was invalidated; `track-error` carries the reason.
+	#[enum_value(name = "Terminal pad failure", nick = "error")]
+	Error = 3,
+}
 
 #[derive(Debug, Default)]
 struct Settings {
@@ -20,54 +42,112 @@ struct Settings {
 	effective: Option<String>,
 	/// The wire container selected for this pad's media producer.
 	container: MediaContainer,
-	/// Blocks CAPS from creating a producer while the element removes this pad.
-	releasing: bool,
+	/// What the track is doing, read back through `status`.
+	status: Status,
+	/// The reason the pad was invalidated, read back through `track-error`.
+	error: Option<String>,
+}
+
+/// Everything owned by one request pad, protected by one lock.
+pub(super) struct PadLifecycle {
+	settings: Settings,
+	pub(super) media: Pad,
+	pub(super) ended: bool,
+	pub(super) releasing: bool,
+	pub(super) session_error: Option<Arc<AtomicBool>>,
+}
+
+impl Default for PadLifecycle {
+	fn default() -> Self {
+		Self {
+			settings: Settings::default(),
+			media: Pad::new(),
+			ended: false,
+			releasing: false,
+			session_error: None,
+		}
+	}
+}
+
+/// Property notifications earned by one lifecycle operation.
+#[derive(Default)]
+pub(super) struct Notifications {
+	track: bool,
+	status: bool,
+	error: bool,
 }
 
 /// The GObject implementation backing a named `moqsink` request pad.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct MoqSinkPadImp {
-	settings: Mutex<Settings>,
+	lifecycle: Mutex<PadLifecycle>,
 }
 
-/// A pending track reservation that serializes property writes until it is committed or dropped.
-pub(super) struct TrackReservation<'a> {
-	pad: &'a MoqSinkPad,
-	settings: MutexGuard<'a, Settings>,
+impl Settings {
+	/// Set the status, reporting whether it moved.
+	fn set_status(&mut self, status: Status) -> bool {
+		let changed = self.status != status;
+		self.status = status;
+		changed
+	}
 }
 
-impl TrackReservation<'_> {
-	/// The name configured when this reservation began.
+impl PadLifecycle {
+	/// The configured track name while this pad is not releasing.
 	pub(super) fn requested(&self) -> Option<&str> {
 		self.settings.requested.as_deref()
 	}
 
-	/// The media container configured when this reservation began.
+	/// The wire container configured for this pad's media producer.
 	pub(super) fn container(&self) -> MediaContainer {
 		self.settings.container
 	}
 
-	/// Fix the property to the name the broadcast reserved, then notify after releasing the lock.
-	pub(super) fn commit(self, track: String) {
-		let TrackReservation { pad, mut settings } = self;
-		let before = settings.effective.clone().or_else(|| settings.requested.clone());
-		settings.effective = Some(track);
-		let changed = before != settings.effective;
-		drop(settings);
-		if changed {
-			pad.notify("track");
+	/// Record the name reserved by a successful CAPS event.
+	pub(super) fn commit(&mut self, track: String) -> Notifications {
+		let before = self
+			.settings
+			.effective
+			.clone()
+			.or_else(|| self.settings.requested.clone());
+		self.settings.effective = Some(track);
+		Notifications {
+			track: before != self.settings.effective,
+			status: self.settings.set_status(Status::Active),
+			error: false,
 		}
 	}
 
-	/// Drop the effective name, then notify after releasing the lock.
-	pub(super) fn release(self) {
-		let TrackReservation { pad, mut settings } = self;
-		let before = settings.effective.take();
-		let changed = before.is_some() && before != settings.requested;
-		drop(settings);
-		if changed {
-			pad.notify("track");
+	/// Record a terminal failure without changing an earlier failure's EOS semantics.
+	pub(super) fn fail(&mut self, reason: String) -> Notifications {
+		let error = self.settings.error.as_deref() != Some(reason.as_str());
+		self.settings.error = Some(reason);
+		Notifications {
+			status: self.settings.set_status(Status::Error),
+			error,
+			..Default::default()
 		}
+	}
+
+	/// Record clean finalization unless the failure is the more useful terminal state.
+	pub(super) fn end(&mut self) -> Notifications {
+		let status = self.settings.status != Status::Error && self.settings.set_status(Status::Ended);
+		Notifications {
+			status,
+			..Default::default()
+		}
+	}
+
+	/// Reset this pad for another run while preserving its requested name.
+	pub(super) fn reset(&mut self) -> Notifications {
+		let before = self.settings.effective.take();
+		let track = before.is_some() && before != self.settings.requested;
+		let error = self.settings.error.take().is_some();
+		let status = self.settings.set_status(Status::Pending);
+		self.media = Pad::new();
+		self.ended = false;
+		self.session_error = None;
+		Notifications { track, status, error }
 	}
 }
 
@@ -104,14 +184,31 @@ impl ObjectImpl for MoqSinkPadImp {
 					.default_value(MediaContainer::Legacy)
 					.mutable_playing()
 					.build(),
+				glib::ParamSpecEnum::builder::<Status>("status")
+					.nick("Status")
+					.blurb(
+						"What this pad's track is doing: pending until CAPS builds a producer, active \
+						 once the broadcast reserved the track, ended when it was finalized, error when \
+						 the pad was invalidated. A connection drop is the element's status, not this one",
+					)
+					.read_only()
+					.build(),
+				glib::ParamSpecString::builder("track-error")
+					.nick("Track error")
+					.blurb(
+						"Why this pad was invalidated, or null when it was not. Set with status=error \
+						 and cleared when the pad is released or the element goes back to READY",
+					)
+					.read_only()
+					.build(),
 			]
 		});
 		PROPS.as_ref()
 	}
 
 	fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
-		let mut settings = self.settings.lock().unwrap();
-		if settings.releasing {
+		let mut lifecycle = self.lifecycle.lock().unwrap();
+		if lifecycle.releasing {
 			gst::warning!(
 				CAT,
 				obj = self.obj(),
@@ -122,7 +219,7 @@ impl ObjectImpl for MoqSinkPadImp {
 		}
 		// A producer keeps its reserved name and wire container for its whole life, so a later write
 		// would read back without ever reaching the broadcast or the catalog.
-		if settings.effective.is_some() {
+		if lifecycle.settings.effective.is_some() {
 			gst::warning!(
 				CAT,
 				obj = self.obj(),
@@ -133,21 +230,26 @@ impl ObjectImpl for MoqSinkPadImp {
 		}
 		match pspec.name() {
 			// An empty name is not a track name: it selects the generated one.
-			"track" => settings.requested = value.get::<Option<String>>().unwrap().filter(|name| !name.is_empty()),
-			"container" => settings.container = value.get().unwrap(),
+			"track" => {
+				lifecycle.settings.requested = value.get::<Option<String>>().unwrap().filter(|name| !name.is_empty())
+			}
+			"container" => lifecycle.settings.container = value.get().unwrap(),
 			_ => unreachable!(),
 		}
 	}
 
 	fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
-		let settings = self.settings.lock().unwrap();
+		let lifecycle = self.lifecycle.lock().unwrap();
 		match pspec.name() {
-			"track" => settings
+			"track" => lifecycle
+				.settings
 				.effective
 				.clone()
-				.or_else(|| settings.requested.clone())
+				.or_else(|| lifecycle.settings.requested.clone())
 				.to_value(),
-			"container" => settings.container.to_value(),
+			"container" => lifecycle.settings.container.to_value(),
+			"status" => lifecycle.settings.status.to_value(),
+			"track-error" => lifecycle.settings.error.clone().to_value(),
 			_ => unreachable!(),
 		}
 	}
@@ -162,33 +264,33 @@ glib::wrapper! {
 }
 
 impl MoqSinkPad {
-	/// Lock the configured name until the caller commits or abandons its track reservation.
-	pub(super) fn reserve_track(&self) -> Option<TrackReservation<'_>> {
-		let settings = self.imp().settings.lock().unwrap();
-		if settings.releasing {
-			return None;
+	/// Lock this pad's complete lifecycle state.
+	pub(super) fn lifecycle(&self) -> MutexGuard<'_, PadLifecycle> {
+		self.imp().lifecycle.lock().unwrap()
+	}
+
+	/// Emit property notifications after the lifecycle lock has been released.
+	pub(super) fn notify_changes(&self, changes: Notifications) {
+		if changes.track {
+			self.notify("track");
 		}
-		Some(TrackReservation { pad: self, settings })
-	}
-
-	/// Mark the pad as releasing and lock its track settings during producer removal.
-	pub(super) fn retire_track(&self) -> TrackReservation<'_> {
-		let mut settings = self.imp().settings.lock().unwrap();
-		settings.releasing = true;
-		TrackReservation { pad: self, settings }
-	}
-
-	/// Make a detached pad configurable after CAPS can no longer reach the element.
-	pub(super) fn finish_release(&self) {
-		self.imp().settings.lock().unwrap().releasing = false;
-	}
-
-	/// Drop the reserved name once its producer is finalized, so the pad is configurable again on the
-	/// next run. The requested name stays: that run reserves the same one.
-	pub(super) fn release_track(&self) {
-		if let Some(reservation) = self.reserve_track() {
-			reservation.release();
+		if changes.status {
+			self.notify("status");
 		}
+		if changes.error {
+			self.notify("track-error");
+		}
+	}
+
+	/// Reset a detached pad without asking GStreamer to remove it twice.
+	pub(super) fn reset_detached(&self) {
+		let changes = {
+			let mut lifecycle = self.lifecycle();
+			let changes = lifecycle.reset();
+			lifecycle.releasing = false;
+			changes
+		};
+		self.notify_changes(changes);
 	}
 }
 
@@ -196,8 +298,65 @@ impl MoqSinkPad {
 mod tests {
 	use super::*;
 
+	fn sink_pad() -> MoqSinkPad {
+		gst::init().unwrap();
+		gst::PadBuilder::<MoqSinkPad>::new(gst::PadDirection::Sink)
+			.name("sink_0")
+			.build()
+	}
+
+	fn apply(pad: &MoqSinkPad, operation: impl FnOnce(&mut PadLifecycle) -> Notifications) {
+		let changes = operation(&mut pad.lifecycle());
+		pad.notify_changes(changes);
+	}
+
 	#[test]
-	fn track_selection_is_locked_until_the_reservation_is_committed() {
+	fn the_status_follows_the_lifecycle() {
+		let pad = sink_pad();
+		assert_eq!(pad.property::<Status>("status"), Status::Pending);
+		assert_eq!(pad.property::<Option<String>>("track-error"), None);
+
+		apply(&pad, |lifecycle| lifecycle.commit("camera".to_string()));
+		assert_eq!(pad.property::<Status>("status"), Status::Active);
+
+		apply(&pad, PadLifecycle::end);
+		assert_eq!(pad.property::<Status>("status"), Status::Ended);
+
+		apply(&pad, |lifecycle| lifecycle.fail("no caps".to_string()));
+		assert_eq!(pad.property::<Status>("status"), Status::Error);
+		assert_eq!(
+			pad.property::<Option<String>>("track-error").as_deref(),
+			Some("no caps")
+		);
+
+		apply(&pad, PadLifecycle::reset);
+		assert_eq!(
+			pad.property::<Status>("status"),
+			Status::Pending,
+			"a released pad is pending again"
+		);
+		assert_eq!(
+			pad.property::<Option<String>>("track-error"),
+			None,
+			"and carries no stale reason"
+		);
+	}
+
+	// A failure is what ended the pad, and it is the more useful of the two, so EOS does not bury it.
+	#[test]
+	fn ending_a_failed_pad_keeps_the_error() {
+		let pad = sink_pad();
+		apply(&pad, |lifecycle| lifecycle.fail("bad bitstream".to_string()));
+		apply(&pad, PadLifecycle::end);
+		assert_eq!(pad.property::<Status>("status"), Status::Error);
+		assert_eq!(
+			pad.property::<Option<String>>("track-error").as_deref(),
+			Some("bad bitstream")
+		);
+	}
+
+	#[test]
+	fn track_selection_is_serialized_with_the_lifecycle() {
 		gst::init().unwrap();
 		let pad = gst::PadBuilder::<MoqSinkPad>::new(gst::PadDirection::Sink)
 			.name("sink_0")
@@ -206,30 +365,30 @@ mod tests {
 		pad.set_property("track", "camera");
 		pad.set_property("container", MediaContainer::Loc);
 
-		let abandoned = pad.reserve_track().unwrap();
-		assert_eq!(abandoned.requested(), Some("camera"));
-		assert_eq!(abandoned.container(), MediaContainer::Loc);
-		drop(abandoned);
+		assert_eq!(pad.lifecycle().requested(), Some("camera"));
+		assert_eq!(pad.lifecycle().container(), MediaContainer::Loc);
 		pad.set_property("track", "other");
 		assert_eq!(pad.property::<String>("track"), "other");
 		pad.set_property("track", "camera");
 
-		let reservation = pad.reserve_track().unwrap();
-		assert_eq!(reservation.requested(), Some("camera"));
-		assert_eq!(reservation.container(), MediaContainer::Loc);
+		let mut lifecycle = pad.lifecycle();
+		assert_eq!(lifecycle.requested(), Some("camera"));
+		assert_eq!(lifecycle.container(), MediaContainer::Loc);
 		let other = pad.clone();
 		assert!(
-			std::thread::spawn(move || other.imp().settings.try_lock().is_err())
+			std::thread::spawn(move || other.imp().lifecycle.try_lock().is_err())
 				.join()
 				.unwrap(),
 			"a concurrent property write cannot enter during reservation"
 		);
-		reservation.commit("camera".to_string());
+		let changes = lifecycle.commit("camera".to_string());
+		drop(lifecycle);
+		pad.notify_changes(changes);
 
 		pad.set_property("track", "other");
 		pad.set_property("container", MediaContainer::Legacy);
 		assert_eq!(pad.property::<MediaContainer>("container"), MediaContainer::Loc);
-		pad.release_track();
+		apply(&pad, PadLifecycle::reset);
 		pad.set_property("container", MediaContainer::Legacy);
 		assert_eq!(
 			pad.property::<String>("track"),

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -1,8 +1,7 @@
 //! The `sink_%u` request pad as its own GObject, so the track it publishes can be named from a
 //! pipeline description through `GstChildProxy` (`moqsink sink_0::track=camera`).
 
-use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
+use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use gst::glib;
 use gst::prelude::*;
@@ -10,7 +9,7 @@ use gst::subclass::prelude::*;
 
 use super::MediaContainer;
 use super::pad::Pad;
-use super::session::CAT;
+use super::session::{CAT, CompletionHandle};
 
 /// What the pad's track is doing, as reported by the `status` property.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, glib::Enum)]
@@ -54,7 +53,9 @@ pub(super) struct PadLifecycle {
 	pub(super) media: Pad,
 	pub(super) ended: bool,
 	pub(super) releasing: bool,
-	pub(super) session_error: Option<Arc<AtomicBool>>,
+	/// This pad's link to its publication. `None` is no live session for the pad, which is why a buffer
+	/// arriving before one exists is refused rather than dropped.
+	pub(super) completion: Option<CompletionHandle>,
 }
 
 impl Default for PadLifecycle {
@@ -64,7 +65,7 @@ impl Default for PadLifecycle {
 			media: Pad::new(),
 			ended: false,
 			releasing: false,
-			session_error: None,
+			completion: None,
 		}
 	}
 }
@@ -146,7 +147,7 @@ impl PadLifecycle {
 		let status = self.settings.set_status(Status::Pending);
 		self.media = Pad::new();
 		self.ended = false;
-		self.session_error = None;
+		self.completion = None;
 		Notifications { track, status, error }
 	}
 }

--- a/rs/moq-gst/src/sink/request_pad.rs
+++ b/rs/moq-gst/src/sink/request_pad.rs
@@ -14,7 +14,7 @@ use super::session::{CAT, CompletionHandle};
 /// What the pad's track is doing, as reported by the `status` property.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, glib::Enum)]
 #[repr(u32)]
-#[enum_type(name = "MoqSinkPadStatus")]
+#[enum_type(name = "GstMoqSinkPadStatus")]
 pub enum Status {
 	/// Requested, with no producer yet: CAPS has not arrived, or the element is not started.
 	#[default]
@@ -185,12 +185,12 @@ impl ObjectImpl for MoqSinkPadImp {
 					.default_value(MediaContainer::Legacy)
 					.mutable_playing()
 					.build(),
-				glib::ParamSpecEnum::builder::<Status>("status")
+				glib::ParamSpecEnum::builder::<Status>("track-status")
 					.nick("Status")
 					.blurb(
 						"What this pad's track is doing: pending until CAPS builds a producer, active \
 						 once the broadcast reserved the track, ended when it was finalized, error when \
-						 the pad was invalidated. A connection drop is the element's status, not this one",
+						 the pad was invalidated. A connection drop is the element's `status`",
 					)
 					.read_only()
 					.build(),
@@ -249,7 +249,7 @@ impl ObjectImpl for MoqSinkPadImp {
 				.or_else(|| lifecycle.settings.requested.clone())
 				.to_value(),
 			"container" => lifecycle.settings.container.to_value(),
-			"status" => lifecycle.settings.status.to_value(),
+			"track-status" => lifecycle.settings.status.to_value(),
 			"track-error" => lifecycle.settings.error.clone().to_value(),
 			_ => unreachable!(),
 		}
@@ -276,7 +276,7 @@ impl MoqSinkPad {
 			self.notify("track");
 		}
 		if changes.status {
-			self.notify("status");
+			self.notify("track-status");
 		}
 		if changes.error {
 			self.notify("track-error");
@@ -314,17 +314,17 @@ mod tests {
 	#[test]
 	fn the_status_follows_the_lifecycle() {
 		let pad = sink_pad();
-		assert_eq!(pad.property::<Status>("status"), Status::Pending);
+		assert_eq!(pad.property::<Status>("track-status"), Status::Pending);
 		assert_eq!(pad.property::<Option<String>>("track-error"), None);
 
 		apply(&pad, |lifecycle| lifecycle.commit("camera".to_string()));
-		assert_eq!(pad.property::<Status>("status"), Status::Active);
+		assert_eq!(pad.property::<Status>("track-status"), Status::Active);
 
 		apply(&pad, PadLifecycle::end);
-		assert_eq!(pad.property::<Status>("status"), Status::Ended);
+		assert_eq!(pad.property::<Status>("track-status"), Status::Ended);
 
 		apply(&pad, |lifecycle| lifecycle.fail("no caps".to_string()));
-		assert_eq!(pad.property::<Status>("status"), Status::Error);
+		assert_eq!(pad.property::<Status>("track-status"), Status::Error);
 		assert_eq!(
 			pad.property::<Option<String>>("track-error").as_deref(),
 			Some("no caps")
@@ -332,7 +332,7 @@ mod tests {
 
 		apply(&pad, PadLifecycle::reset);
 		assert_eq!(
-			pad.property::<Status>("status"),
+			pad.property::<Status>("track-status"),
 			Status::Pending,
 			"a released pad is pending again"
 		);
@@ -349,7 +349,7 @@ mod tests {
 		let pad = sink_pad();
 		apply(&pad, |lifecycle| lifecycle.fail("bad bitstream".to_string()));
 		apply(&pad, PadLifecycle::end);
-		assert_eq!(pad.property::<Status>("status"), Status::Error);
+		assert_eq!(pad.property::<Status>("track-status"), Status::Error);
 		assert_eq!(
 			pad.property::<Option<String>>("track-error").as_deref(),
 			Some("bad bitstream")

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use anyhow::Result;
 use gst::glib;
 use gst::prelude::*;
+use gst::subclass::prelude::*;
 
 use hang::moq_net;
 
@@ -50,9 +51,8 @@ pub enum ConnectionStatus {
 
 /// The connect/version surface behind the `status`, `connected`, and `moq-version` properties. One per
 /// session: the element swaps in a fresh `Arc` on every start, so a previous session's task (which may
-/// still be unwinding) writes only its own detached copy and can never clobber the live status. No
-/// generation bookkeeping needed. The bitrate properties read a [`moq_net::bandwidth::Consumer`] directly,
-/// so they aren't mirrored here.
+/// still be unwinding) writes only its own detached copy and can never clobber the live status. The
+/// bitrate properties read a [`moq_net::bandwidth::Consumer`] directly, so they aren't mirrored here.
 #[derive(Default)]
 struct StatusInner {
 	status: ConnectionStatus,
@@ -63,6 +63,21 @@ struct StatusInner {
 #[derive(Default)]
 pub struct Status {
 	inner: Mutex<StatusInner>,
+}
+
+/// Opaque identity retained by one publishing session and all of its pending messages.
+#[derive(Clone)]
+pub(super) struct SessionId(Arc<()>);
+
+impl SessionId {
+	fn new() -> Self {
+		Self(Arc::new(()))
+	}
+
+	/// Whether both tokens identify the same publishing session.
+	pub(super) fn matches(&self, other: &Self) -> bool {
+		Arc::ptr_eq(&self.0, &other.0)
+	}
 }
 
 impl Status {
@@ -118,6 +133,7 @@ pub(super) fn client_config(settings: &ResolvedSettings) -> moq_native::ClientCo
 /// A running session: the connect/lifecycle task plus the state the property getters read. Dropping the
 /// `Session` (or the producers held by the element) tears it down.
 pub(crate) struct Session {
+	id: SessionId,
 	join: tokio::task::JoinHandle<()>,
 	status: Arc<Status>,
 	/// The live send-bitrate estimate, tracked across reconnects by the reconnect loop. Read directly
@@ -149,6 +165,7 @@ impl Session {
 
 		let status = Arc::new(Status::default());
 		let errored = Arc::new(AtomicBool::new(false));
+		let id = SessionId::new();
 
 		// Publish through a background reconnect loop: connect, wait for close, reconnect with backoff.
 		// `timeout = 0` drops the give-up deadline so an unattended publisher outlives relay/QUIC
@@ -164,10 +181,18 @@ impl Session {
 		let send_bandwidth = reconnect.send_bandwidth();
 		let recv_bandwidth = reconnect.recv_bandwidth();
 
-		let join = RUNTIME.spawn(forward(reconnect, origin, status.clone(), errored.clone(), element));
+		let join = RUNTIME.spawn(forward(
+			reconnect,
+			origin,
+			status.clone(),
+			errored.clone(),
+			id.clone(),
+			element,
+		));
 
 		Ok((
 			Self {
+				id,
 				join,
 				status,
 				send_bandwidth,
@@ -177,6 +202,11 @@ impl Session {
 			broadcast,
 			catalog,
 		))
+	}
+
+	/// The identity that scopes element-wide messages to this session.
+	pub(super) fn id(&self) -> &SessionId {
+		&self.id
 	}
 
 	/// The live status, read by the element's property getters.
@@ -228,6 +258,7 @@ async fn forward(
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
 	errored: Arc<AtomicBool>,
+	id: SessionId,
 	element: glib::WeakRef<Element>,
 ) {
 	// Hold the origin producer for the task's lifetime so the broadcast created on it stays routable:
@@ -267,7 +298,7 @@ async fn forward(
 					status.set(ConnectionStatus::Failed, None);
 					notify(&element, &["status", "connected", "moq-version"]);
 					if let Some(obj) = element.upgrade() {
-						gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
+						obj.imp().post_session_error(&id, format!("{err:?}"));
 					}
 					return;
 				}

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -5,7 +5,7 @@
 //! streaming thread. This task only owns connect, the transport's lifetime, and stats; it touches no
 //! media.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use anyhow::Result;
@@ -130,6 +130,72 @@ pub(super) fn client_config(settings: &ResolvedSettings) -> moq_native::ClientCo
 	config
 }
 
+/// Whether the publication is still open, and if not, how it ended.
+///
+/// Monotonic: `Open` moves once, and the first terminal transition wins. `Eos` beating a later error
+/// is deliberate, not a tie-break: by then the producers and the catalog were consumed cleanly, so the
+/// failure happened after the publication was already complete and must not rewrite it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Completion {
+	/// Request pads, negotiation, publication and flow resets are allowed.
+	Open,
+	/// Every pad ended cleanly and the producers were consumed.
+	Eos,
+	/// A session or finalize error ended the publication.
+	Failed,
+}
+
+/// The atomic behind a [`CompletionHandle`], reached only through the typed methods so no caller can
+/// write a state the transition rules forbid.
+pub(crate) struct CompletionState(AtomicU8);
+
+/// One publication's completion, shared by its session task and by its pads.
+///
+/// Every clone belongs to one exact session. A task that outlived its session still holds only that
+/// session's handle, so it cannot reach the state a newer session's pads read: a terminal error
+/// staying inside its own session falls out of the topology instead of being checked against an id.
+pub(crate) type CompletionHandle = Arc<CompletionState>;
+
+impl CompletionState {
+	const OPEN: u8 = 0;
+	const EOS: u8 = 1;
+	const FAILED: u8 = 2;
+
+	pub(crate) fn new() -> CompletionHandle {
+		Arc::new(Self(AtomicU8::new(Self::OPEN)))
+	}
+
+	pub(crate) fn get(&self) -> Completion {
+		match self.0.load(Ordering::Relaxed) {
+			Self::EOS => Completion::Eos,
+			Self::FAILED => Completion::Failed,
+			_ => Completion::Open,
+		}
+	}
+
+	pub(crate) fn is_open(&self) -> bool {
+		self.0.load(Ordering::Relaxed) == Self::OPEN
+	}
+
+	/// Take the clean terminal state, returning whether this call is the one that took it.
+	pub(crate) fn finish(&self) -> bool {
+		self.take(Self::EOS)
+	}
+
+	/// Take the failed terminal state, returning whether this call is the one that took it.
+	pub(crate) fn fail(&self) -> bool {
+		self.take(Self::FAILED)
+	}
+
+	/// Compare-exchange rather than a store: a loser that overwrote the winner would turn an EOS the
+	/// element already earned into a bus error.
+	fn take(&self, terminal: u8) -> bool {
+		self.0
+			.compare_exchange(Self::OPEN, terminal, Ordering::Relaxed, Ordering::Relaxed)
+			.is_ok()
+	}
+}
+
 /// Permission for one session's task to report a terminal failure on the bus.
 ///
 /// Held between creating the session and completing `READY -> PAUSED`. Marking it releases the task;
@@ -158,8 +224,9 @@ pub(crate) struct Session {
 	/// The live recv-bitrate estimate, tracked across reconnects by the reconnect loop. Read directly
 	/// by the `estimated-recv-bitrate` getter.
 	recv_bandwidth: moq_net::bandwidth::Consumer,
-	/// Set by the task on a fatal transport error so the pad streaming threads stop feeding a dead session.
-	errored: Arc<AtomicBool>,
+	/// This publication's completion. The task moves it to `Failed` on a fatal transport error, so the
+	/// pad streaming threads stop feeding a dead session without consulting the element.
+	completion: CompletionHandle,
 }
 
 impl Session {
@@ -185,7 +252,7 @@ impl Session {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 
 		let status = Arc::new(Status::default());
-		let errored = Arc::new(AtomicBool::new(false));
+		let completion = CompletionState::new();
 		let id = SessionId::new();
 
 		// Publish through a background reconnect loop: connect, wait for close, reconnect with backoff.
@@ -209,7 +276,7 @@ impl Session {
 			reconnect,
 			origin,
 			status.clone(),
-			errored.clone(),
+			completion.clone(),
 			id.clone(),
 			element,
 			gate.clone(),
@@ -222,7 +289,7 @@ impl Session {
 				status,
 				send_bandwidth,
 				recv_bandwidth,
-				errored,
+				completion,
 			},
 			SessionRegistration { gate },
 			broadcast,
@@ -250,9 +317,9 @@ impl Session {
 		self.recv_bandwidth.peek().unwrap_or(0)
 	}
 
-	/// Share the fatal-session flag with a pad's buffer path.
-	pub fn error_flag(&self) -> Arc<AtomicBool> {
-		self.errored.clone()
+	/// Share this publication's completion with a pad's buffer path.
+	pub fn completion(&self) -> CompletionHandle {
+		self.completion.clone()
 	}
 
 	/// Stop the session: a clean local close, never an error. [`Drop`] aborts the task, cancelling the
@@ -283,13 +350,13 @@ async fn forward(
 	reconnect: moq_native::Reconnect,
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
-	errored: Arc<AtomicBool>,
+	completion: CompletionHandle,
 	id: SessionId,
 	element: glib::WeakRef<Element>,
 	registered: Arc<tokio::sync::Notify>,
 ) {
 	wait_for_registration(registered).await;
-	forward_registered(reconnect, origin, status, errored, id, element).await;
+	forward_registered(reconnect, origin, status, completion, id, element).await;
 }
 
 async fn wait_for_registration(registered: Arc<tokio::sync::Notify>) {
@@ -302,7 +369,7 @@ async fn forward_registered(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
-	errored: Arc<AtomicBool>,
+	completion: CompletionHandle,
 	id: SessionId,
 	element: glib::WeakRef<Element>,
 ) {
@@ -337,12 +404,12 @@ async fn forward_registered(
 				}
 				Err(err) => {
 					// The reconnect loop stopped on a terminal error (a non-retryable auth failure, or a
-					// bounded backoff's give-up). Flag `errored` so the pad threads stop feeding a dead
-					// session, and post a fatal element error.
-					errored.store(true, Ordering::Relaxed);
+					// bounded backoff's give-up). Ending the publication stops the pad threads feeding a
+					// dead session; losing that race means it already ended, so there is nothing to report.
+					let won = completion.fail();
 					status.set(ConnectionStatus::Failed, None);
 					notify(&element, &["status", "connected", "moq-version"]);
-					if let Some(obj) = element.upgrade() {
+					if won && let Some(obj) = element.upgrade() {
 						obj.imp().post_session_error(&id, format!("{err:?}"));
 					}
 					return;
@@ -382,20 +449,20 @@ mod tests {
 	async fn a_terminal_result_waits_until_the_session_is_registered() {
 		let gate = Arc::new(tokio::sync::Notify::new());
 		let registration = SessionRegistration { gate: gate.clone() };
-		let errored = Arc::new(AtomicBool::new(false));
-		let task_errored = errored.clone();
+		let completion = CompletionState::new();
+		let task_completion = completion.clone();
 		let (entered, reached) = tokio::sync::oneshot::channel();
 
 		let task = tokio::spawn(async move {
 			entered.send(()).unwrap();
 			wait_for_registration(gate).await;
-			task_errored.store(true, Ordering::Relaxed);
+			task_completion.fail();
 		});
 		reached.await.unwrap();
-		assert!(!errored.load(Ordering::Relaxed), "the terminal result stayed parked");
+		assert_eq!(completion.get(), Completion::Open, "the terminal result stayed parked");
 
 		registration.mark_registered();
 		task.await.unwrap();
-		assert!(errored.load(Ordering::Relaxed), "registration released it");
+		assert_eq!(completion.get(), Completion::Failed, "registration released it");
 	}
 }

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -194,9 +194,9 @@ impl Session {
 		self.recv_bandwidth.peek().unwrap_or(0)
 	}
 
-	/// Whether the transport has hit a fatal error (the pad streaming threads stop feeding it on this).
-	pub fn errored(&self) -> bool {
-		self.errored.load(Ordering::Relaxed)
+	/// Share the fatal-session flag with a pad's buffer path.
+	pub fn error_flag(&self) -> Arc<AtomicBool> {
+		self.errored.clone()
 	}
 
 	/// Stop the session: a clean local close, never an error. [`Drop`] aborts the task, cancelling the
@@ -263,9 +263,9 @@ async fn forward(
 					// The reconnect loop stopped on a terminal error (a non-retryable auth failure, or a
 					// bounded backoff's give-up). Flag `errored` so the pad threads stop feeding a dead
 					// session, and post a fatal element error.
+					errored.store(true, Ordering::Relaxed);
 					status.set(ConnectionStatus::Failed, None);
 					notify(&element, &["status", "connected", "moq-version"]);
-					errored.store(true, Ordering::Relaxed);
 					if let Some(obj) = element.upgrade() {
 						gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
 					}

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -130,6 +130,22 @@ pub(super) fn client_config(settings: &ResolvedSettings) -> moq_native::ClientCo
 	config
 }
 
+/// Permission for one session's task to report a terminal failure on the bus.
+///
+/// Held between creating the session and completing `READY -> PAUSED`. Marking it releases the task;
+/// dropping it unmarked leaves the task parked, which is what a rolled-back transition wants, since
+/// the session it belonged to is torn down with it.
+pub(crate) struct SessionRegistration {
+	gate: Arc<tokio::sync::Notify>,
+}
+
+impl SessionRegistration {
+	/// Release the task: the element installed this session, so its errors now have somewhere to land.
+	pub(crate) fn mark_registered(self) {
+		self.gate.notify_one();
+	}
+}
+
 /// A running session: the connect/lifecycle task plus the state the property getters read. Dropping the
 /// `Session` (or the producers held by the element) tears it down.
 pub(crate) struct Session {
@@ -152,7 +168,12 @@ impl Session {
 	pub fn start(
 		settings: ResolvedSettings,
 		element: glib::WeakRef<Element>,
-	) -> Result<(Self, moq_net::broadcast::Producer, moq_mux::catalog::Producer)> {
+	) -> Result<(
+		Self,
+		SessionRegistration,
+		moq_net::broadcast::Producer,
+		moq_mux::catalog::Producer,
+	)> {
 		// Producer setup may touch tokio time (group eviction), so run it inside the runtime context.
 		let _rt = RUNTIME.enter();
 
@@ -181,6 +202,9 @@ impl Session {
 		let send_bandwidth = reconnect.send_bandwidth();
 		let recv_bandwidth = reconnect.recv_bandwidth();
 
+		// The task is spawned parked. An immediate auth rejection would otherwise race the element
+		// installing this session, and its bus error would be discarded for belonging to no live one.
+		let gate = Arc::new(tokio::sync::Notify::new());
 		let join = RUNTIME.spawn(forward(
 			reconnect,
 			origin,
@@ -188,6 +212,7 @@ impl Session {
 			errored.clone(),
 			id.clone(),
 			element,
+			gate.clone(),
 		));
 
 		Ok((
@@ -199,6 +224,7 @@ impl Session {
 				recv_bandwidth,
 				errored,
 			},
+			SessionRegistration { gate },
 			broadcast,
 			catalog,
 		))
@@ -254,6 +280,25 @@ impl Drop for Session {
 /// [`Session`]'s `Drop` aborts this task, which drops the `Reconnect` handle and quietly tears the loop
 /// down.
 async fn forward(
+	reconnect: moq_native::Reconnect,
+	origin: moq_net::origin::Producer,
+	status: Arc<Status>,
+	errored: Arc<AtomicBool>,
+	id: SessionId,
+	element: glib::WeakRef<Element>,
+	registered: Arc<tokio::sync::Notify>,
+) {
+	wait_for_registration(registered).await;
+	forward_registered(reconnect, origin, status, errored, id, element).await;
+}
+
+async fn wait_for_registration(registered: Arc<tokio::sync::Notify>) {
+	// `Notify` keeps the permit, so marking before the task parks here is not a lost wakeup. A session
+	// rolled back instead of marked is aborted by `Session`'s `Drop`, which unparks nothing.
+	registered.notified().await;
+}
+
+async fn forward_registered(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
@@ -326,5 +371,31 @@ fn notify(element: &glib::WeakRef<Element>, props: &[&str]) {
 		for prop in props {
 			obj.notify(prop);
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn a_terminal_result_waits_until_the_session_is_registered() {
+		let gate = Arc::new(tokio::sync::Notify::new());
+		let registration = SessionRegistration { gate: gate.clone() };
+		let errored = Arc::new(AtomicBool::new(false));
+		let task_errored = errored.clone();
+		let (entered, reached) = tokio::sync::oneshot::channel();
+
+		let task = tokio::spawn(async move {
+			entered.send(()).unwrap();
+			wait_for_registration(gate).await;
+			task_errored.store(true, Ordering::Relaxed);
+		});
+		reached.await.unwrap();
+		assert!(!errored.load(Ordering::Relaxed), "the terminal result stayed parked");
+
+		registration.mark_registered();
+		task.await.unwrap();
+		assert!(errored.load(Ordering::Relaxed), "registration released it");
 	}
 }

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -65,21 +65,6 @@ pub struct Status {
 	inner: Mutex<StatusInner>,
 }
 
-/// Opaque identity retained by one publishing session and all of its pending messages.
-#[derive(Clone)]
-pub(super) struct SessionId(Arc<()>);
-
-impl SessionId {
-	fn new() -> Self {
-		Self(Arc::new(()))
-	}
-
-	/// Whether both tokens identify the same publishing session.
-	pub(super) fn matches(&self, other: &Self) -> bool {
-		Arc::ptr_eq(&self.0, &other.0)
-	}
-}
-
 impl Status {
 	/// Set the connection status and negotiated version together, so a `notify::status` handler that
 	/// re-reads `moq-version` sees the two consistent.
@@ -151,9 +136,10 @@ pub(crate) struct CompletionState(AtomicU8);
 
 /// One publication's completion, shared by its session task and by its pads.
 ///
-/// Every clone belongs to one exact session. A task that outlived its session still holds only that
-/// session's handle, so it cannot reach the state a newer session's pads read: a terminal error
-/// staying inside its own session falls out of the topology instead of being checked against an id.
+/// Every clone belongs to one exact session, so this doubles as the session's identity: a task that
+/// outlived its session still holds only that session's handle, and `Arc::ptr_eq` answers whether a
+/// deferred message still belongs to the live publication. A terminal error staying inside its own
+/// session falls out of the topology rather than being checked against a separate id.
 pub(crate) type CompletionHandle = Arc<CompletionState>;
 
 impl CompletionState {
@@ -215,7 +201,6 @@ impl SessionRegistration {
 /// A running session: the connect/lifecycle task plus the state the property getters read. Dropping the
 /// `Session` (or the producers held by the element) tears it down.
 pub(crate) struct Session {
-	id: SessionId,
 	join: tokio::task::JoinHandle<()>,
 	status: Arc<Status>,
 	/// The live send-bitrate estimate, tracked across reconnects by the reconnect loop. Read directly
@@ -253,7 +238,6 @@ impl Session {
 
 		let status = Arc::new(Status::default());
 		let completion = CompletionState::new();
-		let id = SessionId::new();
 
 		// Publish through a background reconnect loop: connect, wait for close, reconnect with backoff.
 		// `timeout = 0` drops the give-up deadline so an unattended publisher outlives relay/QUIC
@@ -277,14 +261,12 @@ impl Session {
 			origin,
 			status.clone(),
 			completion.clone(),
-			id.clone(),
 			element,
 			gate.clone(),
 		));
 
 		Ok((
 			Self {
-				id,
 				join,
 				status,
 				send_bandwidth,
@@ -295,11 +277,6 @@ impl Session {
 			broadcast,
 			catalog,
 		))
-	}
-
-	/// The identity that scopes element-wide messages to this session.
-	pub(super) fn id(&self) -> &SessionId {
-		&self.id
 	}
 
 	/// The live status, read by the element's property getters.
@@ -351,12 +328,11 @@ async fn forward(
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
 	completion: CompletionHandle,
-	id: SessionId,
 	element: glib::WeakRef<Element>,
 	registered: Arc<tokio::sync::Notify>,
 ) {
 	wait_for_registration(registered).await;
-	forward_registered(reconnect, origin, status, completion, id, element).await;
+	forward_registered(reconnect, origin, status, completion, element).await;
 }
 
 async fn wait_for_registration(registered: Arc<tokio::sync::Notify>) {
@@ -370,7 +346,6 @@ async fn forward_registered(
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
 	completion: CompletionHandle,
-	id: SessionId,
 	element: glib::WeakRef<Element>,
 ) {
 	// Hold the origin producer for the task's lifetime so the broadcast created on it stays routable:
@@ -410,7 +385,7 @@ async fn forward_registered(
 					status.set(ConnectionStatus::Failed, None);
 					notify(&element, &["status", "connected", "moq-version"]);
 					if won && let Some(obj) = element.upgrade() {
-						obj.imp().post_session_error(&id, format!("{err:?}"));
+						obj.imp().post_session_error(&completion, format!("{err:?}"));
 					}
 					return;
 				}

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -45,6 +45,31 @@ fn publisher() -> gst::Element {
 		.expect("create moqsink")
 }
 
+fn state_change_blocker(fail_when_active: bool) -> (gst::Pad, Arc<AtomicBool>) {
+	let enabled = Arc::new(AtomicBool::new(true));
+	let fail = enabled.clone();
+	let pad = gst::Pad::builder(gst::PadDirection::Sink)
+		.name("state-change-blocker")
+		.activatemode_function(move |_, _, _, active| {
+			if fail.load(Ordering::SeqCst) && active == fail_when_active {
+				return Err(gst::loggable_error!(gst::CAT_DEFAULT, "forced state-change failure"));
+			}
+			Ok(())
+		})
+		.build();
+	(pad, enabled)
+}
+
+fn assert_pad_has_no_live_publication(pad: &gst::Pad) {
+	pad.set_active(true).expect("activate the pad for the probe");
+	assert_eq!(
+		pad.chain(gst::Buffer::new()),
+		Err(gst::FlowError::Flushing),
+		"the failed transition left no publication attached to the pad"
+	);
+	pad.set_active(false).expect("deactivate the probe pad");
+}
+
 fn h264_caps() -> gst::Caps {
 	gst::Caps::builder("video/x-h264")
 		.field("stream-format", "byte-stream")
@@ -73,6 +98,58 @@ fn h264_keyframe() -> gst::Buffer {
 /// order, CAPS builds the producer.
 fn send_caps(pad: &gst::Pad) -> bool {
 	pad.send_event(gst::event::StreamStart::new("test")) && pad.send_event(gst::event::Caps::new(&h264_caps()))
+}
+
+// READY -> PAUSED is synchronous: the element creates its session without waiting for a buffer, which
+// is the preroll policy it inherits from deriving on GstElement rather than a sink base class.
+#[test]
+fn ready_to_paused_completes_without_a_buffer() {
+	init();
+	let sink = publisher();
+	let _pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	assert_eq!(
+		sink.set_state(gst::State::Paused),
+		Ok(gst::StateChangeSuccess::Success),
+		"the transition completed rather than going async"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+#[test]
+fn a_failed_ready_to_paused_rolls_back_the_publication() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let (blocker, enabled) = state_change_blocker(true);
+	sink.add_pad(&blocker).expect("add activation blocker");
+
+	assert!(
+		sink.set_state(gst::State::Paused).is_err(),
+		"the parent transition reached the controlled activation failure"
+	);
+	assert_pad_has_no_live_publication(&pad);
+
+	enabled.store(false, Ordering::SeqCst);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+#[test]
+fn a_failed_paused_to_ready_still_releases_the_publication() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let (blocker, enabled) = state_change_blocker(false);
+	sink.add_pad(&blocker).expect("add deactivation blocker");
+	sink.set_state(gst::State::Paused).expect("start the publication");
+
+	assert!(
+		sink.set_state(gst::State::Ready).is_err(),
+		"the parent transition reached the controlled deactivation failure"
+	);
+	assert_pad_has_no_live_publication(&pad);
+
+	enabled.store(false, Ordering::SeqCst);
+	let _ = sink.set_state(gst::State::Null);
 }
 
 // Request pads appear and disappear through the real GObject boundary, with no session attached.

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -641,6 +641,44 @@ fn a_sync_bus_handler_can_read_the_status_on_eos() {
 	let _ = sink.set_state(gst::State::Null);
 }
 
+// Finalization settles the pad before notifying it. A handler can therefore stop that run and start
+// another before the deferred EOS reaches the bus; the old run must not complete its replacement.
+#[test]
+fn replacing_the_session_from_eos_notify_discards_the_old_eos() {
+	init();
+	let sink = publisher();
+	let bus = gst::Bus::new();
+	sink.set_bus(Some(&bus));
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let restarted = Arc::new(AtomicBool::new(false));
+	let done = restarted.clone();
+	let element = sink.clone();
+	child_of(&sink, "sink_0").connect_notify(Some("status"), move |pad, _| {
+		let value = pad.property_value("status");
+		let (_, status) = gst::glib::EnumValue::from_value(&value).expect("status enum");
+		if status.nick() == "ended" && !done.swap(true, Ordering::SeqCst) {
+			element
+				.set_state(gst::State::Ready)
+				.expect("stop the completed session");
+			element.set_state(gst::State::Paused).expect("start its replacement");
+		}
+	});
+
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&pad));
+	while bus.pop().is_some() {}
+
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert!(restarted.load(Ordering::SeqCst));
+	assert!(
+		bus.timed_pop_filtered(gst::ClockTime::ZERO, &[gst::MessageType::Eos])
+			.is_none(),
+		"the completed session posted EOS into its replacement"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
 // A pad that ends and then starts a new stream is publishing again. Leaving it counted as ended would
 // let the next pad EOS finalize the whole element, cutting a track that is still live.
 #[test]

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -77,6 +77,23 @@ fn h264_caps() -> gst::Caps {
 		.build()
 }
 
+fn unsupported_caps() -> gst::Caps {
+	gst::Caps::builder("video/x-raw").build()
+}
+
+fn request_unrestricted_sink_pad(sink: &gst::Element) -> gst::Pad {
+	let template = gst::PadTemplate::builder(
+		"sink_%u",
+		gst::PadDirection::Sink,
+		gst::PadPresence::Request,
+		&gst::Caps::new_any(),
+	)
+	.build()
+	.expect("build unrestricted request-pad template");
+	sink.request_pad(&template, Some("sink_0"), None)
+		.expect("request unrestricted sink_0")
+}
+
 fn h264_keyframe() -> gst::Buffer {
 	let sps: &[u8] = &[
 		0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xe9, 0xb8, 0x08, 0x08, 0x0a, 0x00, 0x00, 0x07, 0xd0, 0x00,
@@ -98,6 +115,27 @@ fn h264_keyframe() -> gst::Buffer {
 /// order, CAPS builds the producer.
 fn send_caps(pad: &gst::Pad) -> bool {
 	pad.send_event(gst::event::StreamStart::new("test")) && pad.send_event(gst::event::Caps::new(&h264_caps()))
+}
+
+/// Collect every message the element posts, so a test can assert what reached the bus and what did not.
+fn recording_bus(sink: &gst::Element) -> Arc<Mutex<Vec<gst::MessageType>>> {
+	let seen = Arc::new(Mutex::new(Vec::new()));
+	let recorder = seen.clone();
+	let bus = gst::Bus::new();
+	bus.set_sync_handler(move |_, message| {
+		recorder.lock().unwrap().push(message.type_());
+		gst::BusSyncReply::Drop
+	});
+	sink.set_bus(Some(&bus));
+	seen
+}
+
+fn posted_eos(seen: &Arc<Mutex<Vec<gst::MessageType>>>) -> usize {
+	seen.lock()
+		.unwrap()
+		.iter()
+		.filter(|kind| **kind == gst::MessageType::Eos)
+		.count()
 }
 
 // READY -> PAUSED is synchronous: the element creates its session without waiting for a buffer, which
@@ -149,6 +187,187 @@ fn a_failed_paused_to_ready_still_releases_the_publication() {
 	assert_pad_has_no_live_publication(&pad);
 
 	enabled.store(false, Ordering::SeqCst);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A sink posts EOS only in PLAYING. Reaching it in PAUSED still finalizes the pad; the message waits.
+#[test]
+fn eos_in_paused_finalizes_but_holds_the_message() {
+	init();
+	let sink = publisher();
+	let seen = recording_bus(&sink);
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused).expect("start the session");
+	assert!(send_caps(&pad));
+
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert_eq!(status_of(&sink, "sink_0"), "ended", "the pad finalized in PAUSED");
+	assert_eq!(posted_eos(&seen), 0, "the message waits for PLAYING");
+
+	sink.set_state(gst::State::Playing).expect("Paused -> Playing");
+	assert_eq!(posted_eos(&seen), 1, "entering PLAYING released it");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// One EOS per publication, not one per entry to PLAYING. Re-posting exists for a player that pauses at
+// the end of a file and resumes without seeking; here the publication is already consumed and the only
+// way back is a cycle through READY, so a second announcement would say nothing new.
+#[test]
+fn the_eos_is_posted_once_per_publication() {
+	init();
+	let sink = publisher();
+	let seen = recording_bus(&sink);
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Playing).expect("start playing");
+	assert!(send_caps(&pad));
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert_eq!(posted_eos(&seen), 1);
+
+	sink.set_state(gst::State::Paused).expect("Playing -> Paused");
+	sink.set_state(gst::State::Playing).expect("Paused -> Playing");
+	assert_eq!(posted_eos(&seen), 1, "the second entry adds nothing");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// After the publication ends, a buffer that got past the pad's own EOS flag (a flush clears it) must
+// report the end rather than be dropped as if it had been published.
+#[test]
+fn a_buffer_after_the_end_reports_eos_instead_of_ok() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Playing).expect("start playing");
+	assert!(send_caps(&pad));
+	let mut segment = gst::FormattedSegment::<gst::ClockTime>::new();
+	segment.set_start(gst::ClockTime::ZERO);
+	assert!(pad.send_event(gst::event::Segment::new(&segment)));
+	assert!(pad.send_event(gst::event::Eos::new()));
+
+	// FLUSH_STOP clears the pad's EOS in the core, so the buffer reaches the chain function.
+	assert!(pad.send_event(gst::event::FlushStart::new()));
+	assert!(pad.send_event(gst::event::FlushStop::new(true)));
+	assert_eq!(
+		pad.chain(h264_keyframe()),
+		Err(gst::FlowError::Eos),
+		"the publication ended, so the buffer is refused rather than silently dropped"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A SEGMENT after the end must not cost the pad its link. Losing it answered the next buffer with
+// Flushing, which reads as "this pad is going away" rather than "the publication is over".
+#[test]
+fn a_segment_after_the_end_keeps_the_terminal_result() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Playing).expect("start playing");
+	assert!(send_caps(&pad));
+	let mut segment = gst::FormattedSegment::<gst::ClockTime>::new();
+	segment.set_start(gst::ClockTime::ZERO);
+	assert!(pad.send_event(gst::event::Segment::new(&segment)));
+	assert!(pad.send_event(gst::event::Eos::new()));
+
+	// The usual restart sequence: flush, then a fresh segment, then data.
+	assert!(pad.send_event(gst::event::FlushStart::new()));
+	assert!(pad.send_event(gst::event::FlushStop::new(true)));
+	assert!(pad.send_event(gst::event::Segment::new(&segment)));
+	assert_eq!(
+		pad.chain(h264_keyframe()),
+		Err(gst::FlowError::Eos),
+		"the publication ended, and a new segment does not change that"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// The authorization is the claim, taken while the element was playing. A handler that drops the
+// element to PAUSED between the notifications and the post does not revoke it: holding anything across
+// post_message() to make it revocable is the re-entrancy this element avoids by design.
+#[test]
+fn an_eos_claimed_while_playing_survives_a_handler_that_pauses() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Playing).expect("start playing");
+	assert!(send_caps(&pad));
+
+	let pause_succeeded = Arc::new(AtomicBool::new(false));
+	let eos_after_pause = Arc::new(AtomicBool::new(false));
+	let observed = eos_after_pause.clone();
+	let paused_before_eos = pause_succeeded.clone();
+	let bus = gst::Bus::new();
+	bus.set_sync_handler(move |_, message| {
+		if message.type_() == gst::MessageType::Eos {
+			observed.store(paused_before_eos.load(Ordering::SeqCst), Ordering::SeqCst);
+		}
+		gst::BusSyncReply::Drop
+	});
+	sink.set_bus(Some(&bus));
+
+	let paused = sink.clone();
+	let transition = pause_succeeded.clone();
+	child_of(&sink, "sink_0").connect_notify(Some("status"), move |_, _| {
+		if status_of(&paused, "sink_0") == "ended" {
+			transition.store(
+				paused.set_state(gst::State::Paused) == Ok(gst::StateChangeSuccess::Success),
+				Ordering::SeqCst,
+			);
+		}
+	});
+
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert_eq!(
+		sink.current_state(),
+		gst::State::Paused,
+		"the notify handler completed the downward transition"
+	);
+	assert!(
+		eos_after_pause.load(Ordering::SeqCst),
+		"the EOS was posted only after that transition completed"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// Leaving PLAYING closes the gate. Without that arm an EOS reached in PAUSED would go out immediately,
+// which is the rule the whole retention exists to keep.
+#[test]
+fn leaving_playing_holds_a_later_eos_until_the_next_entry() {
+	init();
+	let sink = publisher();
+	let seen = recording_bus(&sink);
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Playing).expect("start playing");
+	assert!(send_caps(&pad));
+	sink.set_state(gst::State::Paused).expect("Playing -> Paused");
+
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert_eq!(posted_eos(&seen), 0, "the gate closed on the way down");
+
+	sink.set_state(gst::State::Playing).expect("Paused -> Playing");
+	assert_eq!(posted_eos(&seen), 1, "and the next entry delivers it once");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// The publication does not reopen: recovery is a cycle through READY, not a late pad.
+#[test]
+fn a_pad_requested_after_the_end_is_refused() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Playing).expect("start playing");
+	assert!(send_caps(&pad));
+	assert!(pad.send_event(gst::event::Eos::new()));
+
+	assert!(
+		sink.request_pad_simple("sink_1").is_none(),
+		"a finished publication admits no new pad"
+	);
+	sink.set_state(gst::State::Ready).expect("Playing -> Ready");
+	sink.set_state(gst::State::Paused).expect("Ready -> Paused");
+	assert!(
+		sink.request_pad_simple("sink_1").is_some(),
+		"a new run admits pads again"
+	);
 	let _ = sink.set_state(gst::State::Null);
 }
 
@@ -449,9 +668,12 @@ fn invalid_caps_are_refused_at_the_caps_event() {
 #[test]
 fn unsupported_caps_are_refused_at_the_caps_event() {
 	init();
+	// Through an unrestricted pad, so the refusal comes from the element and not from the template
+	// filtering the caps out before the event function ever runs. Asserting the pad's status as well as
+	// the return value is what tells the two apart.
 	for refused in ["application/json", "video/x-raw"] {
 		let sink = publisher();
-		let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+		let pad = request_unrestricted_sink_pad(&sink);
 		sink.set_state(gst::State::Paused)
 			.expect("Ready -> Paused starts the session");
 		assert!(pad.send_event(gst::event::StreamStart::new("test")));
@@ -460,8 +682,61 @@ fn unsupported_caps_are_refused_at_the_caps_event() {
 			!pad.send_event(gst::event::Caps::new(&caps)),
 			"{refused} is refused at the CAPS event"
 		);
+		assert_eq!(
+			status_of(&sink, "sink_0"),
+			"error",
+			"{refused} reached the element and failed the pad"
+		);
 		let _ = sink.set_state(gst::State::Null);
 	}
+}
+
+#[test]
+fn unsupported_caps_mark_the_pad_unless_the_publication_is_terminal() {
+	init();
+
+	let sink = publisher();
+	let pad = request_unrestricted_sink_pad(&sink);
+	sink.set_state(gst::State::Ready)
+		.expect("enter READY without starting a session");
+	pad.set_active(true).expect("activate the pad without a session");
+	assert!(pad.send_event(gst::event::StreamStart::new("no-session")));
+	assert!(!pad.send_event(gst::event::Caps::new(&unsupported_caps())));
+	assert_eq!(
+		status_of(&sink, "sink_0"),
+		"error",
+		"no session still records the pad error"
+	);
+	pad.set_active(false).expect("deactivate the pad");
+	let _ = sink.set_state(gst::State::Null);
+
+	let sink = publisher();
+	let pad = request_unrestricted_sink_pad(&sink);
+	sink.set_state(gst::State::Paused).expect("start the publication");
+	assert!(pad.send_event(gst::event::StreamStart::new("open")));
+	assert!(!pad.send_event(gst::event::Caps::new(&unsupported_caps())));
+	assert_eq!(
+		status_of(&sink, "sink_0"),
+		"error",
+		"an open publication records the pad error"
+	);
+	let _ = sink.set_state(gst::State::Null);
+
+	let sink = publisher();
+	let pad = request_unrestricted_sink_pad(&sink);
+	sink.set_state(gst::State::Playing).expect("start playing");
+	assert!(send_caps(&pad));
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert_eq!(status_of(&sink, "sink_0"), "ended");
+	assert!(pad.send_event(gst::event::StreamStart::new("terminal")));
+	assert!(!pad.send_event(gst::event::Caps::new(&unsupported_caps())));
+	assert_eq!(
+		status_of(&sink, "sink_0"),
+		"ended",
+		"late CAPS do not rewrite a terminal pad"
+	);
+	assert_eq!(track_error_of(&sink, "sink_0"), None);
+	let _ = sink.set_state(gst::State::Null);
 }
 
 // The acceptance criterion: a failed pad names its own reason, and the failure is isolated to it.
@@ -698,6 +973,8 @@ fn a_sync_bus_handler_can_read_the_status_on_eos() {
 	sink.set_state(gst::State::Paused)
 		.expect("Ready -> Paused starts the session");
 	assert!(send_caps(&pad));
+	// A sink posts EOS only in PLAYING, so the handler under test needs the element there to run at all.
+	sink.set_state(gst::State::Playing).expect("Paused -> Playing");
 
 	let seen = Arc::new(Mutex::new(None));
 	let recorder = seen.clone();

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -26,7 +26,7 @@ fn child_of(sink: &gst::Element, name: &str) -> gst::glib::Object {
 /// The `status` nick, read the way an application without this crate's types would: through the enum
 /// class rather than by naming the Rust enum.
 fn status_of(sink: &gst::Element, pad: &str) -> String {
-	let value = child_of(sink, pad).property_value("status");
+	let value = child_of(sink, pad).property_value("track-status");
 	let (_, variant) = gst::glib::EnumValue::from_value(&value).expect("status is an enum property");
 	variant.nick().to_string()
 }
@@ -287,7 +287,7 @@ fn an_eos_claimed_while_playing_survives_a_handler_that_pauses() {
 
 	let paused = sink.clone();
 	let transition = pause_succeeded.clone();
-	child_of(&sink, "sink_0").connect_notify(Some("status"), move |_, _| {
+	child_of(&sink, "sink_0").connect_notify(Some("track-status"), move |_, _| {
 		if status_of(&paused, "sink_0") == "ended" {
 			transition.store(
 				paused.set_state(gst::State::Paused) == Ok(gst::StateChangeSuccess::Success),
@@ -1007,7 +1007,7 @@ fn a_pad_requested_from_the_eos_notify_is_refused() {
 	let swap = swapped.clone();
 	let element = sink.clone();
 	let old = second.clone();
-	child_of(&sink, "sink_0").connect_notify(Some("status"), move |_, _| {
+	child_of(&sink, "sink_0").connect_notify(Some("track-status"), move |_, _| {
 		if swap.swap(true, Ordering::SeqCst) {
 			return;
 		}
@@ -1023,7 +1023,7 @@ fn a_pad_requested_from_the_eos_notify_is_refused() {
 	let released = second
 		.downcast_ref::<gst::Pad>()
 		.expect("the released pad is still held");
-	let value = released.property_value("status");
+	let value = released.property_value("track-status");
 	let (_, variant) = gst::glib::EnumValue::from_value(&value).expect("status is an enum property");
 	assert_eq!(
 		variant.nick(),
@@ -1068,7 +1068,7 @@ fn a_rejected_write_moves_the_pad_to_error() {
 	assert_eq!(track_error_of(&sink, "sink_0").as_deref(), Some("frame too large"));
 	let notifies = notifies.lock().unwrap();
 	assert_eq!(
-		notifies.iter().filter(|n| *n == "status").count(),
+		notifies.iter().filter(|n| *n == "track-status").count(),
 		1,
 		"the move to error is announced once"
 	);
@@ -1124,8 +1124,8 @@ fn replacing_the_session_from_eos_notify_discards_the_old_eos() {
 	let restarted = Arc::new(AtomicBool::new(false));
 	let done = restarted.clone();
 	let element = sink.clone();
-	child_of(&sink, "sink_0").connect_notify(Some("status"), move |pad, _| {
-		let value = pad.property_value("status");
+	child_of(&sink, "sink_0").connect_notify(Some("track-status"), move |pad, _| {
+		let value = pad.property_value("track-status");
 		let (_, status) = gst::glib::EnumValue::from_value(&value).expect("status enum");
 		if status.nick() == "ended" && !done.swap(true, Ordering::SeqCst) {
 			element
@@ -1349,7 +1349,7 @@ fn release_leaves_the_pad_inactive_and_detached() {
 	sink.release_request_pad(&pad);
 	assert!(!pad.is_active());
 	assert!(pad.parent().is_none());
-	let value = pad.property_value("status");
+	let value = pad.property_value("track-status");
 	let (_, status) = gst::glib::EnumValue::from_value(&value).expect("status enum");
 	assert_eq!(status.nick(), "pending");
 	let _ = sink.set_state(gst::State::Null);
@@ -1366,7 +1366,7 @@ fn releasing_a_pad_from_its_own_notify_returns() {
 	let done = released.clone();
 	let element = sink.clone();
 	let target = pad.clone();
-	child_of(&sink, "sink_0").connect_notify(Some("status"), move |_, _| {
+	child_of(&sink, "sink_0").connect_notify(Some("track-status"), move |_, _| {
 		if !done.swap(true, Ordering::SeqCst) {
 			element.release_request_pad(&target);
 		}
@@ -1434,8 +1434,8 @@ fn status_notifies_on_each_transition() {
 	let child = child_of(&sink, "sink_0");
 	let seen = Arc::new(Mutex::new(Vec::new()));
 	let recorder = seen.clone();
-	child.connect_notify(Some("status"), move |obj, _| {
-		let value = obj.property_value("status");
+	child.connect_notify(Some("track-status"), move |obj, _| {
+		let value = obj.property_value("track-status");
 		let (_, variant) = gst::glib::EnumValue::from_value(&value).expect("status is an enum property");
 		recorder.lock().unwrap().push(variant.nick().to_string());
 	});

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -4,7 +4,7 @@
 //! close) are validated against a real relay, separately from this hermetic suite.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Once};
+use std::sync::{Arc, Mutex, Once};
 
 use gst::prelude::*;
 
@@ -23,6 +23,18 @@ fn child_of(sink: &gst::Element, name: &str) -> gst::glib::Object {
 		.expect("the request pad is a child")
 }
 
+/// The `status` nick, read the way an application without this crate's types would: through the enum
+/// class rather than by naming the Rust enum.
+fn status_of(sink: &gst::Element, pad: &str) -> String {
+	let value = child_of(sink, pad).property_value("status");
+	let (_, variant) = gst::glib::EnumValue::from_value(&value).expect("status is an enum property");
+	variant.nick().to_string()
+}
+
+fn track_error_of(sink: &gst::Element, pad: &str) -> Option<String> {
+	child_of(sink, pad).property::<Option<String>>("track-error")
+}
+
 /// A publisher pointed at a relay that cannot answer. Connect runs in the background, so the element
 /// still reaches PAUSED and creates its producers, which is all these tests need.
 fn publisher() -> gst::Element {
@@ -38,6 +50,23 @@ fn h264_caps() -> gst::Caps {
 		.field("stream-format", "byte-stream")
 		.field("alignment", "au")
 		.build()
+}
+
+fn h264_keyframe() -> gst::Buffer {
+	let sps: &[u8] = &[
+		0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xe9, 0xb8, 0x08, 0x08, 0x0a, 0x00, 0x00, 0x07, 0xd0, 0x00,
+		0x01, 0xd4, 0xc0, 0x80,
+	];
+	let pps: &[u8] = &[0x68, 0xce, 0x3c, 0x80];
+	let idr: &[u8] = &[0x65, 0x88, 0x84, 0x00, 0x21];
+	let mut au = Vec::new();
+	for nal in [sps, pps, idr] {
+		au.extend_from_slice(&[0, 0, 0, 1]);
+		au.extend_from_slice(nal);
+	}
+	let mut buffer = gst::Buffer::from_mut_slice(au);
+	buffer.get_mut().unwrap().set_pts(gst::ClockTime::ZERO);
+	buffer
 }
 
 /// Drive one pad to the point where it reserves its track: STREAM_START keeps the sticky events in
@@ -298,9 +327,10 @@ fn the_pad_template_announces_opaque_data() {
 	);
 }
 
-// The CAPS event is the synchronous gate: an unsupported type is refused there, not published.
+// The CAPS event is the synchronous gate: caps admitted by the template but lacking required codec
+// configuration are refused there, not published.
 #[test]
-fn unsupported_caps_are_refused_at_the_caps_event() {
+fn invalid_caps_are_refused_at_the_caps_event() {
 	init();
 	let sink = publisher();
 	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
@@ -310,25 +340,609 @@ fn unsupported_caps_are_refused_at_the_caps_event() {
 		.expect("Ready -> Paused starts the session");
 	assert!(pad.send_event(gst::event::StreamStart::new("test")));
 
-	for refused in ["application/json", "video/x-raw"] {
-		let caps = gst::Caps::builder(refused).build();
-		assert!(
-			!pad.send_event(gst::event::Caps::new(&caps)),
-			"{refused} is refused at the CAPS event"
-		);
-	}
-	let caps = gst::Caps::builder("application/octet-stream").build();
-	assert!(
-		pad.send_event(gst::event::Caps::new(&caps)),
-		"opaque data passes the same gate"
-	);
+	let opaque = gst::Caps::builder("application/octet-stream").build();
+	assert!(pad.send_event(gst::event::Caps::new(&opaque)));
+	assert_eq!(status_of(&sink, "sink_0"), "active");
 	child.set_property("track", "other");
 	assert_eq!(
 		child.property::<String>("track"),
 		"audiolevels",
 		"the CAPS event committed the effective track and made it immutable"
 	);
+
+	let invalid = gst::Caps::builder("audio/mpeg")
+		.field("mpegversion", 4i32)
+		.field("stream-format", "raw")
+		.build();
+	assert!(!pad.send_event(gst::event::Caps::new(&invalid)));
+	assert_eq!(status_of(&sink, "sink_0"), "error");
+	assert!(track_error_of(&sink, "sink_0").is_some());
+
+	assert!(pad.send_event(gst::event::Caps::new(&h264_caps())));
+	assert_eq!(status_of(&sink, "sink_0"), "error", "a failed pad stays terminal");
+	assert_eq!(
+		child.property::<String>("track"),
+		"audiolevels",
+		"the requested name remains visible while the failed pad is retained"
+	);
 	let _ = sink.set_state(gst::State::Null);
+}
+
+// Types neither the media importer nor the opaque-data path supports fail synchronously at CAPS.
+#[test]
+fn unsupported_caps_are_refused_at_the_caps_event() {
+	init();
+	for refused in ["application/json", "video/x-raw"] {
+		let sink = publisher();
+		let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+		sink.set_state(gst::State::Paused)
+			.expect("Ready -> Paused starts the session");
+		assert!(pad.send_event(gst::event::StreamStart::new("test")));
+		let caps = gst::Caps::builder(refused).build();
+		assert!(
+			!pad.send_event(gst::event::Caps::new(&caps)),
+			"{refused} is refused at the CAPS event"
+		);
+		let _ = sink.set_state(gst::State::Null);
+	}
+}
+
+// The acceptance criterion: a failed pad names its own reason, and the failure is isolated to it.
+#[test]
+fn an_unnamed_opaque_pad_reports_its_error() {
+	init();
+	let sink = publisher();
+	let data = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let video = sink.request_pad_simple("sink_1").expect("request sink_1");
+	child_of(&sink, "sink_1").set_property("track", "camera");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+
+	assert!(video.send_event(gst::event::StreamStart::new("video")));
+	assert!(send_caps(&video), "the video CAPS event is accepted");
+	assert!(data.send_event(gst::event::StreamStart::new("data")));
+	let opaque = gst::Caps::builder("application/octet-stream").build();
+	assert!(
+		!data.send_event(gst::event::Caps::new(&opaque)),
+		"the missing required track name rejects the CAPS event"
+	);
+
+	assert_eq!(status_of(&sink, "sink_0"), "error");
+	assert_eq!(
+		track_error_of(&sink, "sink_0").as_deref(),
+		Some("an opaque data pad requires a track name")
+	);
+	assert_eq!(status_of(&sink, "sink_1"), "active", "the video pad is untouched");
+	assert_eq!(track_error_of(&sink, "sink_1"), None);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// No timeout invents a failure: a pad with no CAPS has not failed, it has not started.
+#[test]
+fn a_pad_without_caps_stays_pending() {
+	init();
+	let sink = publisher();
+	let _pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	assert_eq!(status_of(&sink, "sink_0"), "pending");
+
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert_eq!(status_of(&sink, "sink_0"), "pending", "starting is not publishing");
+	assert_eq!(track_error_of(&sink, "sink_0"), None);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A CAPS event that reaches no catalog built no producer and rejected nothing, so it must not move
+// the status. Renegotiating after EOS is the reachable form of that: the catalog is already gone.
+#[test]
+fn caps_with_no_catalog_left_does_not_move_the_status() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&pad), "the CAPS event is accepted");
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert_eq!(status_of(&sink, "sink_0"), "ended");
+
+	let renegotiated = gst::Caps::builder("video/x-h264")
+		.field("stream-format", "byte-stream")
+		.field("alignment", "au")
+		.field("width", 1280i32)
+		.build();
+	// STREAM_START first: the EOS flag makes the pad refuse serialized events, so without it the CAPS
+	// event never reaches the handler and the assertion below would pass on inertia.
+	assert!(pad.send_event(gst::event::StreamStart::new("restart")));
+	assert!(pad.send_event(gst::event::Caps::new(&renegotiated)));
+	assert_eq!(
+		status_of(&sink, "sink_0"),
+		"ended",
+		"no catalog means no outcome to report, not a failure"
+	);
+	assert_eq!(track_error_of(&sink, "sink_0"), None);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A name another pad holds invalidates only the second one, and says so.
+#[test]
+fn a_colliding_name_reports_on_the_second_pad() {
+	init();
+	let sink = publisher();
+	let first = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let second = sink.request_pad_simple("sink_1").expect("request sink_1");
+	child_of(&sink, "sink_0").set_property("track", "camera");
+	child_of(&sink, "sink_1").set_property("track", "camera");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+
+	assert!(send_caps(&first));
+	assert!(second.send_event(gst::event::StreamStart::new("second")));
+	assert!(!send_caps(&second), "the duplicate track name rejects the CAPS event");
+
+	assert_eq!(status_of(&sink, "sink_0"), "active");
+	assert_eq!(status_of(&sink, "sink_1"), "error");
+	assert!(
+		track_error_of(&sink, "sink_1")
+			.expect("the second pad names its failure")
+			.contains("camera"),
+		"the reason names the track it could not reserve"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// EOS ends the track only when the producer is actually finalized, which is once every pad ended.
+#[test]
+fn eos_ends_a_pad_only_once_every_pad_ended() {
+	init();
+	let sink = publisher();
+	let first = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let second = sink.request_pad_simple("sink_1").expect("request sink_1");
+	child_of(&sink, "sink_0").set_property("track", "camera");
+	child_of(&sink, "sink_1").set_property("track", "commentary");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&first));
+	assert!(second.send_event(gst::event::StreamStart::new("second")));
+	assert!(send_caps(&second));
+
+	assert!(first.send_event(gst::event::Eos::new()));
+	assert_eq!(
+		status_of(&sink, "sink_0"),
+		"active",
+		"its track is still open while the other pad runs"
+	);
+
+	assert!(second.send_event(gst::event::Eos::new()));
+	assert_eq!(status_of(&sink, "sink_0"), "ended");
+	assert_eq!(status_of(&sink, "sink_1"), "ended");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// The first notify of the finalize pass runs application code, which may release a pad and request
+// the same name again. The session is already finalized by then, so the request is refused.
+#[test]
+fn a_pad_requested_from_the_eos_notify_is_refused() {
+	init();
+	let sink = publisher();
+	let first = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let second = sink.request_pad_simple("sink_1").expect("request sink_1");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&first));
+	assert!(second.send_event(gst::event::StreamStart::new("second")));
+	assert!(send_caps(&second));
+	assert!(second.send_event(gst::event::Eos::new()));
+
+	// Swap sink_1 out from under the pass, from inside the first status notify it emits.
+	let swapped = Arc::new(AtomicBool::new(false));
+	let swap = swapped.clone();
+	let element = sink.clone();
+	let old = second.clone();
+	child_of(&sink, "sink_0").connect_notify(Some("status"), move |_, _| {
+		if swap.swap(true, Ordering::SeqCst) {
+			return;
+		}
+		element.release_request_pad(&old);
+		assert!(element.request_pad_simple("sink_1").is_none());
+	});
+
+	assert!(first.send_event(gst::event::Eos::new()));
+	assert!(swapped.load(Ordering::SeqCst), "the swap ran inside the notify");
+	assert_eq!(sink.num_sink_pads(), 1, "the refused pad left nothing attached");
+	// The object the application kept: released is released, and a result from the life it just left
+	// must not be written back onto it.
+	let released = second
+		.downcast_ref::<gst::Pad>()
+		.expect("the released pad is still held");
+	let value = released.property_value("status");
+	let (_, variant) = gst::glib::EnumValue::from_value(&value).expect("status is an enum property");
+	assert_eq!(
+		variant.nick(),
+		"pending",
+		"the released pad kept its reset instead of taking a stale ended"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A write that the producer rejects is the failure the property exists for. A frame past
+// MAX_GROUP_CACHE is the deterministic way to cause one: moq-net refuses it before reserving a group.
+#[test]
+fn a_rejected_write_moves_the_pad_to_error() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let child = child_of(&sink, "sink_0");
+	child.set_property("track", "audiolevels");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+
+	assert!(pad.send_event(gst::event::StreamStart::new("data")));
+	let opaque = gst::Caps::builder("application/octet-stream").build();
+	assert!(pad.send_event(gst::event::Caps::new(&opaque)));
+	let mut segment = gst::FormattedSegment::<gst::ClockTime>::new();
+	segment.set_start(gst::ClockTime::ZERO);
+	assert!(pad.send_event(gst::event::Segment::new(&segment)));
+	assert_eq!(status_of(&sink, "sink_0"), "active");
+
+	let notifies = Arc::new(Mutex::new(Vec::new()));
+	let recorder = notifies.clone();
+	child.connect_notify(None, move |_, spec| {
+		recorder.lock().unwrap().push(spec.name().to_string())
+	});
+
+	// One byte past the cache ceiling, so the producer rejects the frame instead of storing it.
+	let mut buffer = gst::Buffer::with_size(32 * 1024 * 1024 + 1).expect("allocate an oversized buffer");
+	buffer.get_mut().unwrap().set_pts(gst::ClockTime::ZERO);
+	assert!(pad.chain(buffer).is_ok(), "a per-pad failure is not a flow error");
+
+	assert_eq!(status_of(&sink, "sink_0"), "error");
+	assert_eq!(track_error_of(&sink, "sink_0").as_deref(), Some("frame too large"));
+	let notifies = notifies.lock().unwrap();
+	assert_eq!(
+		notifies.iter().filter(|n| *n == "status").count(),
+		1,
+		"the move to error is announced once"
+	);
+	assert_eq!(notifies.iter().filter(|n| *n == "track-error").count(), 1);
+	drop(notifies);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A bus sync handler runs on the thread that posts, and reading `status` there is the point of the
+// property. The EOS message must therefore go out with no pad lock held, and with the status already
+// settled: this hangs if the finalize pass posts while it still holds the pad it is reporting on.
+#[test]
+fn a_sync_bus_handler_can_read_the_status_on_eos() {
+	init();
+	let sink = publisher();
+	let bus = gst::Bus::new();
+	sink.set_bus(Some(&bus));
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&pad));
+
+	let seen = Arc::new(Mutex::new(None));
+	let recorder = seen.clone();
+	let element = sink.clone();
+	bus.set_sync_handler(move |_, message| {
+		if message.type_() == gst::MessageType::Eos {
+			*recorder.lock().unwrap() = Some(status_of(&element, "sink_0"));
+		}
+		gst::BusSyncReply::Drop
+	});
+
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert_eq!(
+		seen.lock().unwrap().as_deref(),
+		Some("ended"),
+		"the handler read the settled status instead of deadlocking on it"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A pad that ends and then starts a new stream is publishing again. Leaving it counted as ended would
+// let the next pad EOS finalize the whole element, cutting a track that is still live.
+#[test]
+fn a_restarted_pad_is_no_longer_counted_as_ended() {
+	init();
+	let sink = publisher();
+	let first = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let second = sink.request_pad_simple("sink_1").expect("request sink_1");
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&first));
+	assert!(second.send_event(gst::event::StreamStart::new("second")));
+	assert!(send_caps(&second));
+
+	assert!(first.send_event(gst::event::Eos::new()));
+	// sink_0 comes back with a new stream before sink_1 ever ends.
+	assert!(first.send_event(gst::event::StreamStart::new("restart")));
+	assert!(second.send_event(gst::event::Eos::new()));
+
+	assert_eq!(
+		status_of(&sink, "sink_0"),
+		"active",
+		"a restarted pad is publishing, so nothing finalized it"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A live request pad accepts data before CAPS and drops it locally. Once released, GStreamer rejects
+// the same operation because release deactivated the pad.
+#[test]
+fn a_registered_pad_takes_data_before_caps() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused).expect("start the session");
+	assert!(pad.send_event(gst::event::StreamStart::new("test")));
+	let mut segment = gst::FormattedSegment::<gst::ClockTime>::new();
+	segment.set_start(gst::ClockTime::ZERO);
+	assert!(pad.send_event(gst::event::Segment::new(&segment)));
+
+	let mut buffer = gst::Buffer::with_size(4).expect("allocate buffer");
+	buffer.get_mut().unwrap().set_pts(gst::ClockTime::ZERO);
+	assert_eq!(pad.chain(buffer), Ok(gst::FlowSuccess::Ok));
+	assert_eq!(status_of(&sink, "sink_0"), "pending");
+
+	sink.release_request_pad(&pad);
+	let mut buffer = gst::Buffer::with_size(4).expect("allocate buffer");
+	buffer.get_mut().unwrap().set_pts(gst::ClockTime::ZERO);
+	assert_eq!(pad.chain(buffer), Err(gst::FlowError::Flushing));
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// SEGMENT can arrive from pad-added before request_new_pad confirms the admission. It must bind the
+// new member to the live session so the following pre-CAPS buffer is dropped locally, not flushed.
+#[test]
+fn a_segment_from_pad_added_binds_the_live_session() {
+	init();
+	let sink = publisher();
+	sink.set_state(gst::State::Paused).expect("start the session");
+	let accepted = Arc::new(AtomicBool::new(false));
+	let result = accepted.clone();
+	sink.connect_pad_added(move |_, pad| {
+		assert!(pad.send_event(gst::event::StreamStart::new("test")));
+		let mut segment = gst::FormattedSegment::<gst::ClockTime>::new();
+		segment.set_start(gst::ClockTime::ZERO);
+		assert!(pad.send_event(gst::event::Segment::new(&segment)));
+		let mut buffer = gst::Buffer::with_size(4).expect("allocate buffer");
+		buffer.get_mut().unwrap().set_pts(gst::ClockTime::ZERO);
+		result.store(pad.chain(buffer).is_ok(), Ordering::SeqCst);
+	});
+
+	let _pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	assert!(accepted.load(Ordering::SeqCst));
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A pad is a member as soon as GStreamer lists it. EOS delivered from its pad-added callback must not
+// finalize past it while request_new_pad is still running.
+#[test]
+fn a_pad_the_element_already_lists_holds_the_aggregation() {
+	init();
+	let sink = publisher();
+	let ended = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused).expect("start the session");
+	assert!(send_caps(&ended));
+
+	let first = ended.clone();
+	let signalled = Arc::new(AtomicBool::new(false));
+	let done = signalled.clone();
+	sink.connect_pad_added(move |_, _| {
+		if !done.swap(true, Ordering::SeqCst) {
+			assert!(first.send_event(gst::event::Eos::new()));
+		}
+	});
+
+	let _quiet = sink.request_pad_simple("sink_1").expect("request sink_1");
+	assert!(signalled.load(Ordering::SeqCst));
+	assert_eq!(status_of(&sink, "sink_0"), "active");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// pad-added can negotiate, publish and end before the request returns. The complete lifecycle must
+// land on the new pad while its admission is still open.
+#[test]
+fn a_pad_negotiated_from_pad_added_still_publishes() {
+	init();
+	let sink = publisher();
+	sink.set_state(gst::State::Paused).expect("start the session");
+
+	let published = Arc::new(AtomicBool::new(false));
+	let done = published.clone();
+	sink.connect_pad_added(move |_, pad| {
+		if !send_caps(pad) {
+			return;
+		}
+		let mut segment = gst::FormattedSegment::<gst::ClockTime>::new();
+		segment.set_start(gst::ClockTime::ZERO);
+		if !pad.send_event(gst::event::Segment::new(&segment)) {
+			return;
+		}
+		let completed = pad.chain(h264_keyframe()).is_ok() && pad.send_event(gst::event::Eos::new());
+		done.store(completed, Ordering::SeqCst);
+	});
+
+	let _pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	assert!(
+		published.load(Ordering::SeqCst),
+		"the callback published its first buffer"
+	);
+	assert_eq!(status_of(&sink, "sink_0"), "ended");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// EOS from pad-added counts for the new member and is settled before the request returns.
+#[test]
+fn an_eos_sent_from_pad_added_counts() {
+	init();
+	let sink = publisher();
+	sink.set_state(gst::State::Paused).expect("start the session");
+	sink.connect_pad_added(move |_, pad| {
+		assert!(pad.send_event(gst::event::StreamStart::new("early")));
+		assert!(send_caps(pad));
+		assert!(pad.send_event(gst::event::Eos::new()));
+	});
+
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	assert_eq!(status_of(&sink, "sink_0"), "ended");
+	assert_eq!(pad.parent(), Some(sink.clone().upcast()));
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// Releasing from pad-added detaches the pad before request_new_pad can return it.
+#[test]
+fn a_pad_released_from_pad_added_is_not_returned() {
+	init();
+	let sink = publisher();
+	let released = Arc::new(AtomicBool::new(false));
+	let done = released.clone();
+	sink.connect_pad_added(move |element, pad| {
+		if !done.swap(true, Ordering::SeqCst) {
+			element.release_request_pad(pad);
+		}
+	});
+
+	assert!(sink.request_pad_simple("sink_0").is_none());
+	assert!(released.load(Ordering::SeqCst));
+	assert_eq!(sink.num_sink_pads(), 0);
+}
+
+// Removing an active pad can make all remaining pads ended, so release must reevaluate aggregation.
+#[test]
+fn a_released_pad_does_not_hold_back_the_element_eos() {
+	init();
+	let sink = publisher();
+	let kept = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let released = sink.request_pad_simple("sink_1").expect("request sink_1");
+	sink.set_state(gst::State::Paused).expect("start the session");
+	assert!(send_caps(&kept));
+	assert!(released.send_event(gst::event::StreamStart::new("second")));
+	assert!(send_caps(&released));
+	assert!(kept.send_event(gst::event::Eos::new()));
+
+	sink.release_request_pad(&released);
+	assert_eq!(status_of(&sink, "sink_0"), "ended");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// Release leaves a retained pad inactive, detached and pending.
+#[test]
+fn release_leaves_the_pad_inactive_and_detached() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused).expect("start the session");
+	assert!(send_caps(&pad));
+
+	sink.release_request_pad(&pad);
+	assert!(!pad.is_active());
+	assert!(pad.parent().is_none());
+	let value = pad.property_value("status");
+	let (_, status) = gst::glib::EnumValue::from_value(&value).expect("status enum");
+	assert_eq!(status.nick(), "pending");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// Notify handlers run without lifecycle or control locks, so releasing from the pad's own transition
+// returns instead of deadlocking.
+#[test]
+fn releasing_a_pad_from_its_own_notify_returns() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let released = Arc::new(AtomicBool::new(false));
+	let done = released.clone();
+	let element = sink.clone();
+	let target = pad.clone();
+	child_of(&sink, "sink_0").connect_notify(Some("status"), move |_, _| {
+		if !done.swap(true, Ordering::SeqCst) {
+			element.release_request_pad(&target);
+		}
+	});
+
+	sink.set_state(gst::State::Paused).expect("start the session");
+	let _ = send_caps(&pad);
+	assert!(released.load(Ordering::SeqCst));
+	assert!(!pad.is_active());
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// A retained request pad is reset at READY and can reserve and publish again in the next run.
+#[test]
+fn a_pad_kept_across_runs_publishes_again() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused).expect("start first run");
+	assert!(send_caps(&pad));
+	assert!(pad.send_event(gst::event::Eos::new()));
+	assert_eq!(status_of(&sink, "sink_0"), "ended");
+
+	sink.set_state(gst::State::Ready).expect("stop first run");
+	assert_eq!(status_of(&sink, "sink_0"), "pending");
+	sink.set_state(gst::State::Paused).expect("start second run");
+	assert!(pad.send_event(gst::event::StreamStart::new("second")));
+	assert!(send_caps(&pad));
+	let mut segment = gst::FormattedSegment::<gst::ClockTime>::new();
+	segment.set_start(gst::ClockTime::ZERO);
+	assert!(pad.send_event(gst::event::Segment::new(&segment)));
+	assert_eq!(pad.chain(h264_keyframe()), Ok(gst::FlowSuccess::Ok));
+	assert_eq!(status_of(&sink, "sink_0"), "active");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// Final EOS closes admission only for that run. Returning to READY and starting again must accept a
+// new request pad instead of retaining eos_posted from the previous session.
+#[test]
+fn a_new_run_accepts_pads_again() {
+	init();
+	let sink = publisher();
+	let first = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused).expect("start first run");
+	assert!(send_caps(&first));
+	assert!(first.send_event(gst::event::Eos::new()));
+	assert!(
+		sink.request_pad_simple("sink_1").is_none(),
+		"the finalized run refuses another pad"
+	);
+
+	sink.set_state(gst::State::Ready).expect("stop first run");
+	sink.set_state(gst::State::Paused).expect("start second run");
+	let second = sink.request_pad_simple("sink_1").expect("the new run accepts sink_1");
+	assert_eq!(second.parent(), Some(sink.clone().upcast()));
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// An application polls the status through notify rather than by asking on a timer.
+#[test]
+fn status_notifies_on_each_transition() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let child = child_of(&sink, "sink_0");
+	let seen = Arc::new(Mutex::new(Vec::new()));
+	let recorder = seen.clone();
+	child.connect_notify(Some("status"), move |obj, _| {
+		let value = obj.property_value("status");
+		let (_, variant) = gst::glib::EnumValue::from_value(&value).expect("status is an enum property");
+		recorder.lock().unwrap().push(variant.nick().to_string());
+	});
+
+	sink.set_state(gst::State::Paused)
+		.expect("Ready -> Paused starts the session");
+	assert!(send_caps(&pad));
+	assert!(pad.send_event(gst::event::Eos::new()));
+	let _ = sink.set_state(gst::State::Null);
+
+	let seen = seen.lock().unwrap();
+	assert_eq!(
+		seen.as_slice(),
+		["active", "ended", "pending"],
+		"each move is announced once, including the reset on stop"
+	);
 }
 
 // Settings are validated synchronously: a missing url fails the state change, not the bus.


### PR DESCRIPTION
Adds `track-status` and `track-error`, two read-only GObject properties on the `moqsink` request pad, so an application can tell why a pad stopped publishing without parsing bus messages.

## History

This started as four commits: the properties plus three fixes they made visible. Those three fixes have since landed on `main` separately, rewritten against the older structure rather than cherry-picked (#3101, #3102, #3104). `main` was then merged in rather than rebased, so the original commits stay as written and the reconciliation is one reviewable merge commit. What is left on top of `main` is the refactor and the properties.

## Summary

- **Two pad properties.** `track-status` moves `pending -> active -> ended`, or to `error` with `track-error` carrying the reason. Both emit `notify`. Named `track-status` rather than `status` because the element already has a `status` (the connection lifecycle) that means something else.
- **The per-pad lifecycle moves into `MoqSinkPad`,** behind one mutex. It owns the producer, timeline state, requested and effective track names, status, error, EOS state and release state. GStreamer's sink pad list stays the authority for membership; the element no longer keeps a parallel name-keyed pad map. A request pad was previously represented in three places that had to be kept aligned across CAPS, EOS, release, session replacement and reentrant GObject callbacks.
- **`Completion` replaces `eos_posted`,** which answered four questions at once. One `Arc` per session, cloned into every pad. Only `Open -> Eos` and `Open -> Failed`, first writer wins via compare-exchange. It doubles as the session's identity, so a message deferred by a session that has since been replaced is dropped on `Arc::ptr_eq` rather than against a separate token.
- **The pad GType is declared in the template,** so `gst-inspect-1.0` and `GstChildProxy` list the pad's own properties.

## Lock order

One nesting order, in one direction: GStreamer's stream lock, then the element `Control`, then a pad lifecycle, then the GObject object lock. No path takes `Control` while holding a pad lifecycle. Property notifications and bus messages are emitted only after lifecycle locks are released, since both synchronously call application code that can re-enter element and pad properties.

## Known limitation

`post_current` checks that a deferred message still belongs to the live session, releases the control lock, then posts. A session replaced inside `post_message` still gets its message posted. The lock cannot be held across the post: bus sync handlers run inline on the calling thread and a handler reading a property would take it again. The obvious remedy (an in-flight posting permit that teardown waits on) moves the same reentrancy onto a different primitive and can self-deadlock.

Closing this needs the publication to have a notion of a **generation**, which is tracked in #3115 along with the two related gaps on `main`. Out of scope here.

## API

No Rust API changes. Adds two GObject sink-pad properties and one new GType, `GstMoqSinkPadStatus`.

## Test plan

`just check` and `just test`; 115 `moq-gst` tests pass. The merge preserved `main`'s regression tests for the three fixes that landed separately, and the review on top added `the_first_failure_reason_wins`.

One fix has no regression test: a failed `PLAYING -> PAUSED` no longer closes the EOS gate. Pads are deactivated on `PAUSED -> READY`, not on `PLAYING -> PAUSED`, so an activate-mode blocker never fires there and a plain `GstElement` parent has no other hermetic failure path.

## Cross-package sync

`doc/bin/gstreamer.md` documents both new properties.

(Written by Claude Opus 5)