### PR TITLE
fix(moq-net): let a ready response beat local abandonment

### DIFF
--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1270,13 +1270,20 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let setup = {
 			let mut response = std::pin::pin!(self.read_subscribe_response(&mut stream));
 			kio::wait(|waiter| {
+				// An answer that has already arrived wins over the local terminals. Both can
+				// be ready in one poll, and taking abandonment there would discard a response
+				// the publisher has already sent: if it was a rejection, the request is gone
+				// and cancelling it names a dead id back at a peer entitled to object.
+				if let Poll::Ready(res) = waiter.poll_future(response.as_mut()) {
+					return Poll::Ready(Setup::Response(res));
+				}
 				if track.poll_unused(waiter).is_ready() {
 					return Poll::Ready(Setup::Unused);
 				}
 				if let Poll::Ready(err) = broadcast.poll_closed(waiter) {
 					return Poll::Ready(Setup::BroadcastClosed(err));
 				}
-				waiter.poll_future(response.as_mut()).map(Setup::Response)
+				Poll::Pending
 			})
 			.await
 		};
@@ -2096,6 +2103,79 @@ mod tests {
 			occurrences(&log, &[ietf::Unsubscribe::ID as u8]),
 			0,
 			"draft-17+ has no UNSUBSCRIBE",
+		);
+	}
+
+	/// A rejection and the last consumer leaving can both be ready when the task is next
+	/// polled. The publisher destroyed the request when it sent the error, so treating that
+	/// as abandonment would cancel a request that no longer exists and name a dead id back at
+	/// a peer entitled to object. The answer wins.
+	#[tokio::test(start_paused = true)]
+	async fn a_ready_rejection_beats_local_abandonment() {
+		const VERSION: Version = Version::Draft16;
+
+		// A peer that rejects the subscribe outright.
+		let rejection = {
+			let log = crate::lite::test_transport::Log::default();
+			let mut writer =
+				crate::coding::Writer::new(crate::lite::test_transport::SinkSend::new(log.clone()), VERSION);
+			writer.encode(&ietf::RequestError::ID).await.unwrap();
+			writer
+				.encode(&ietf::RequestError {
+					request_id: Some(RequestId(1)),
+					error_code: 404,
+					reason_phrase: "not found".into(),
+					retry_interval: 0,
+				})
+				.await
+				.unwrap();
+
+			log.writes.lock().unwrap().clone()
+		};
+
+		let session = crate::lite::test_transport::ScriptedSession::new(rejection);
+		let log = session.log.clone();
+
+		let (tasks, _task_set) = crate::util::TaskSet::new();
+		let mut subscriber = Subscriber::new(
+			session,
+			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			Control::new(None, false),
+			None,
+			peer::PeerSetup::default(),
+			crate::Origin::new(1).unwrap(),
+			None,
+			VERSION,
+			tasks,
+		);
+
+		let producer = crate::broadcast::Info::default().produce();
+		let mut dynamic = producer.dynamic();
+		let consumer = producer.consume();
+		let track = consumer.track("video").unwrap();
+		let subscription = track.subscribe(None);
+
+		let request = dynamic.requested_track().await.expect("no track requested");
+
+		// Drop the demand before the task runs, so the rejection and the unused wake are both
+		// ready the first time the setup race is polled.
+		drop(subscription);
+		drop(track);
+		drop(consumer);
+
+		let serving = tokio::spawn(async move {
+			subscriber.run_subscribe(Path::new("broadcast"), dynamic, request).await;
+		});
+
+		tokio::time::timeout(std::time::Duration::from_secs(1), serving)
+			.await
+			.expect("run_subscribe did not finish")
+			.unwrap();
+
+		assert_eq!(
+			occurrences(&log, &[ietf::Unsubscribe::ID as u8]),
+			0,
+			"a rejected request is already gone; cancelling it names a dead id at the peer",
 		);
 	}
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -2172,9 +2172,8 @@ mod tests {
 			.expect("run_subscribe did not finish")
 			.unwrap();
 
-		assert_eq!(
-			occurrences(&log, &[ietf::Unsubscribe::ID as u8]),
-			0,
+		assert!(
+			!control_message_types(&log, VERSION).contains(&ietf::Unsubscribe::ID),
 			"a rejected request is already gone; cancelling it names a dead id at the peer",
 		);
 	}


### PR DESCRIPTION
Follow-up to #2993, from a review comment that arrived after it merged.

## The bug

The setup race added in #2993 checks the local terminals before the response:

```rust
if track.poll_unused(waiter).is_ready() { return Poll::Ready(Setup::Unused); }
if let Poll::Ready(err) = broadcast.poll_closed(waiter) { ... }
waiter.poll_future(response.as_mut()).map(Setup::Response)
```

Both can be ready in a single poll. When the publisher has rejected the SUBSCRIBE and the last consumer has left, `Setup::Unused` wins and the answer is never read. The abandonment path then cancels a request the publisher destroyed when it sent `REQUEST_ERROR` ([draft-16 §5.1.1](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16#section-5.1.1)), so `UNSUBSCRIBE` names a dead request id at a peer entitled to treat that as a protocol violation.

## The fix

Poll the response first. An answer that has already arrived is not something abandonment should discard. The local terminals still register their wakers on the way past, so nothing is lost while it is pending.

This is the Rust half of what #2993 fixed for `js/net`, where the same case is handled by not cancelling after a rejection. Both implementations now agree that a rejected request is over.

## Why it was missed

The ordering was noticed while writing that race, and filed under the wrong consequence — the note read "we'd cancel a subscription whose OK had arrived… minor". Against a `SUBSCRIBE_OK` that is true: discarding the response is wasteful, not incorrect. Against a rejection the same ordering produces a protocol error. The observation was right and the severity judgement was wrong, and no test distinguished them.

## Testing

`a_ready_rejection_beats_local_abandonment` drops the demand before spawning the task, so the rejection and the unused wake are both ready the first time the race is polled. Verified against the old ordering, where it fails: the `UNSUBSCRIBE` goes out.

`just check` and `just test` pass.

(written by Opus 5)