### PR TITLE
fix(moq-cli): pace the TS stdout export on each frame's timestamp

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -560,6 +560,10 @@ ffmpeg -i input.mp4 -c copy -f mpegts - | \
 moq --client-connect https://relay.example.com --broadcast my-stream.hang export ts | ffplay -
 ```
 
+TS export is paced: bytes leave stdout at the instant the stream's clock (PCR)
+asserts, smoothed within the `--latency-max` budget, so the pipe carries a
+real-time transport stream rather than draining as fast as frames arrive.
+
 TS export carries H.264 / H.265 as Annex-B and AAC as ADTS. Both in-band
 (avc3 / hev1) and out-of-band (avc1 / hvc1, e.g. from an fMP4 import) video
 sources work: the parameter sets are read from the bitstream or the catalog

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -301,9 +301,18 @@ impl Subscribe {
 			.await?
 			.with_latency(self.args.max_latency);
 
+		// A TS byte stream carries no per-frame timing, so delivery time is the only
+		// carrier of each frame's spacing: the exporter emits its PCR grid as
+		// standalone frames stamped at their slot boundaries, on the contract that
+		// the caller writes the bytes at the time the stamp asserts. Draining on
+		// arrival instead collapses the clock into position clusters no downstream
+		// stage can repair (#2984). The lead reuses the latency budget: it's how
+		// much this consumer is willing to buffer, so an arrival burst within it is
+		// smoothed while anything larger re-anchors to the live edge (and the
+		// exporter's group skipping bounds the backlog to the same budget).
+		let mut pacer = moq_mux::Pacer::default().with_lead(self.args.max_latency);
 		while let Some(frame) = ts.next().await? {
-			stdout.write_all(&frame.payload).await?;
-			stdout.flush().await?;
+			write_paced(&mut pacer, &frame, &mut stdout).await?;
 		}
 
 		Ok(())
@@ -326,5 +335,68 @@ impl Subscribe {
 		}
 
 		Ok(())
+	}
+}
+
+/// Write one export frame to `out` at its paced instant.
+///
+/// Sleeps until the pacer's send time (a no-op for a frame that is due or late),
+/// then writes and flushes the payload.
+async fn write_paced(
+	pacer: &mut moq_mux::Pacer,
+	frame: &moq_mux::container::Frame,
+	out: &mut (impl tokio::io::AsyncWrite + Unpin),
+) -> anyhow::Result<()> {
+	// tokio's clock rather than the bare std one so tests can pause it; in
+	// production they are identical.
+	let send_at = pacer.pace(frame.timestamp, tokio::time::Instant::now().into_std());
+	tokio::time::sleep_until(tokio::time::Instant::from_std(send_at)).await;
+	out.write_all(&frame.payload).await?;
+	out.flush().await?;
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use hang::moq_net::{Timescale, Timestamp};
+
+	/// Regression for #2984: the TS stdout writer must deliver each frame at the
+	/// instant its timestamp asserts, not as fast as frames arrive. The exporter
+	/// stamps PCR grid frames in microseconds and media frames at the source's own
+	/// timescale, so the spacing must also survive a scale change mid-stream.
+	#[tokio::test(start_paused = true)]
+	async fn ts_frames_are_paced_on_the_media_clock() {
+		let mut pacer = moq_mux::Pacer::default().with_lead(Duration::from_millis(500));
+		let mut out = Vec::new();
+
+		let frame = |value, scale| moq_mux::container::Frame {
+			timestamp: Timestamp::new(value, scale).unwrap(),
+			duration: None,
+			payload: bytes::Bytes::from_static(&[0x47; 188]),
+			keyframe: false,
+		};
+
+		let start = tokio::time::Instant::now();
+
+		// The first frame anchors the pacer and is written immediately.
+		write_paced(&mut pacer, &frame(0, Timescale::MICRO), &mut out)
+			.await
+			.unwrap();
+		assert_eq!(start.elapsed(), Duration::ZERO);
+
+		// A PCR slot 25ms later waits for its grid boundary.
+		write_paced(&mut pacer, &frame(25_000, Timescale::MICRO), &mut out)
+			.await
+			.unwrap();
+		assert_eq!(start.elapsed(), Duration::from_millis(25));
+
+		// A media frame at the source's 90 kHz timescale paces on the same clock.
+		write_paced(&mut pacer, &frame(3_600, Timescale::new(90_000).unwrap()), &mut out)
+			.await
+			.unwrap();
+		assert_eq!(start.elapsed(), Duration::from_millis(40));
+
+		assert_eq!(out.len(), 3 * 188, "every payload was written");
 	}
 }

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -359,19 +359,27 @@ impl Subscribe {
 /// export's group skipping can't shed that lag either: it fires when the
 /// *current group* is blocked with a newer alternative, so it measures producer
 /// stalls, never consumer lag. So lag is measured here instead, against
-/// `arrived`: a frame obtained without waiting arrived no later than the last
-/// instant the export made us wait, and when its schedule overshoots that bound
-/// by more than the lead, it is delivered immediately and becomes the live edge
+/// `arrived`: the last instant the export made us wait, which is when a frame
+/// obtained without waiting could first have been queued. When a frame's
+/// schedule overshoots that epoch by more than the lead, it is delivered
+/// immediately and becomes the live edge
 /// ([`Pacer::hurry`](moq_mux::Pacer::hurry)). The anchor then rides the newest
 /// frame through a backlog, so pacing resumes from the live edge once the
 /// export makes us wait again.
+///
+/// The epoch is deliberately conservative: a ready frame may in truth have
+/// arrived later, during a pacing sleep, but one-frame polling can't observe
+/// that, and crediting sleep intervals would let a pre-queued backlog restart
+/// the budget on every sleep. The cost is bounded: a hurry can collapse at
+/// most the lead-sized interval ahead of the epoch, and smoothing resumes at
+/// the next actual wait.
 struct Delivery {
 	pacer: moq_mux::Pacer,
 	/// The delivery-lag bound, and the pacer's lead: both are the export's
 	/// latency budget.
 	lead: Duration,
-	/// The last instant the export made us wait for a frame; frames obtained
-	/// without waiting arrived no later than this.
+	/// The last instant the export made us wait for a frame: the conservative
+	/// arrival epoch for frames obtained without waiting (see the type docs).
 	arrived: tokio::time::Instant,
 }
 

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -306,13 +306,23 @@ impl Subscribe {
 		// standalone frames stamped at their slot boundaries, on the contract that
 		// the caller writes the bytes at the time the stamp asserts. Draining on
 		// arrival instead collapses the clock into position clusters no downstream
-		// stage can repair (#2984). The lead reuses the latency budget: it's how
-		// much this consumer is willing to buffer, so an arrival burst within it is
-		// smoothed while anything larger re-anchors to the live edge (and the
-		// exporter's group skipping bounds the backlog to the same budget).
-		let mut pacer = moq_mux::Pacer::default().with_lead(self.args.max_latency);
-		while let Some(frame) = ts.next().await? {
-			write_paced(&mut pacer, &frame, &mut stdout).await?;
+		// stage can repair (#2984). See [`Delivery`] for how the pacing stays
+		// bounded; it needs to know whether each frame was waited for, hence the
+		// hand-rolled poll instead of `ts.next()`.
+		let mut delivery = Delivery::new(self.args.max_latency);
+		loop {
+			let mut waited = false;
+			let frame = hang::moq_net::kio::wait(|waiter| match ts.poll_next(waiter) {
+				std::task::Poll::Pending => {
+					waited = true;
+					std::task::Poll::Pending
+				}
+				ready => ready,
+			})
+			.await?;
+
+			let Some(frame) = frame else { break };
+			delivery.deliver(&frame, waited, &mut stdout).await?;
 		}
 
 		Ok(())
@@ -338,22 +348,67 @@ impl Subscribe {
 	}
 }
 
-/// Write one export frame to `out` at its paced instant.
+/// Paced stdout delivery for the TS export: sleeps until each frame's send
+/// instant, with total delivery lag bounded by the latency budget.
 ///
-/// Sleeps until the pacer's send time (a no-op for a frame that is due or late),
-/// then writes and flushes the payload.
-async fn write_paced(
-	pacer: &mut moq_mux::Pacer,
-	frame: &moq_mux::container::Frame,
-	out: &mut (impl tokio::io::AsyncWrite + Unpin),
-) -> anyhow::Result<()> {
-	// tokio's clock rather than the bare std one so tests can pause it; in
-	// production they are identical.
-	let send_at = pacer.pace(frame.timestamp, tokio::time::Instant::now().into_std());
-	tokio::time::sleep_until(tokio::time::Instant::from_std(send_at)).await;
-	out.write_all(&frame.payload).await?;
-	out.flush().await?;
-	Ok(())
+/// The bound is the subtle part. The pacer alone caps how far one frame may be
+/// scheduled past the `now` it paces with, but our own sleeps push that `now`
+/// forward, so a backlog arriving faster than real time (a tune-in group
+/// replaying from its keyframe, a catch-up after a stall) stays within the lead
+/// of every individual call while total delivery lag grows without bound. The
+/// export's group skipping can't shed that lag either: it fires when the
+/// *current group* is blocked with a newer alternative, so it measures producer
+/// stalls, never consumer lag. So lag is measured here instead, against
+/// `arrived`: a frame obtained without waiting arrived no later than the last
+/// instant the export made us wait, and when its schedule overshoots that bound
+/// by more than the lead, it is delivered immediately and becomes the live edge
+/// ([`Pacer::hurry`](moq_mux::Pacer::hurry)). The anchor then rides the newest
+/// frame through a backlog, so pacing resumes from the live edge once the
+/// export makes us wait again.
+struct Delivery {
+	pacer: moq_mux::Pacer,
+	/// The delivery-lag bound, and the pacer's lead: both are the export's
+	/// latency budget.
+	lead: Duration,
+	/// The last instant the export made us wait for a frame; frames obtained
+	/// without waiting arrived no later than this.
+	arrived: tokio::time::Instant,
+}
+
+impl Delivery {
+	fn new(lead: Duration) -> Self {
+		Self {
+			pacer: moq_mux::Pacer::default().with_lead(lead),
+			lead,
+			// tokio's clock rather than the bare std one so tests can pause it; in
+			// production they are identical.
+			arrived: tokio::time::Instant::now(),
+		}
+	}
+
+	/// Write one export frame to `out` at its paced instant. `waited` is whether
+	/// the export made us wait for this frame rather than having it ready.
+	async fn deliver(
+		&mut self,
+		frame: &moq_mux::container::Frame,
+		waited: bool,
+		out: &mut (impl tokio::io::AsyncWrite + Unpin),
+	) -> anyhow::Result<()> {
+		let now = tokio::time::Instant::now();
+		if waited {
+			self.arrived = now;
+		}
+
+		let mut send_at = self.pacer.pace(frame.timestamp, now.into_std());
+		if send_at.saturating_duration_since(self.arrived.into_std()) > self.lead {
+			send_at = self.pacer.hurry(frame.timestamp, now.into_std());
+		}
+
+		tokio::time::sleep_until(tokio::time::Instant::from_std(send_at)).await;
+		out.write_all(&frame.payload).await?;
+		out.flush().await?;
+		Ok(())
+	}
 }
 
 #[cfg(test)]
@@ -361,42 +416,97 @@ mod tests {
 	use super::*;
 	use hang::moq_net::{Timescale, Timestamp};
 
+	fn frame(value: u64, scale: Timescale) -> moq_mux::container::Frame {
+		moq_mux::container::Frame {
+			timestamp: Timestamp::new(value, scale).unwrap(),
+			duration: None,
+			payload: bytes::Bytes::from_static(&[0x47; 188]),
+			keyframe: false,
+		}
+	}
+
 	/// Regression for #2984: the TS stdout writer must deliver each frame at the
 	/// instant its timestamp asserts, not as fast as frames arrive. The exporter
 	/// stamps PCR grid frames in microseconds and media frames at the source's own
 	/// timescale, so the spacing must also survive a scale change mid-stream.
 	#[tokio::test(start_paused = true)]
 	async fn ts_frames_are_paced_on_the_media_clock() {
-		let mut pacer = moq_mux::Pacer::default().with_lead(Duration::from_millis(500));
+		let mut delivery = Delivery::new(Duration::from_millis(500));
 		let mut out = Vec::new();
-
-		let frame = |value, scale| moq_mux::container::Frame {
-			timestamp: Timestamp::new(value, scale).unwrap(),
-			duration: None,
-			payload: bytes::Bytes::from_static(&[0x47; 188]),
-			keyframe: false,
-		};
 
 		let start = tokio::time::Instant::now();
 
 		// The first frame anchors the pacer and is written immediately.
-		write_paced(&mut pacer, &frame(0, Timescale::MICRO), &mut out)
+		delivery
+			.deliver(&frame(0, Timescale::MICRO), true, &mut out)
 			.await
 			.unwrap();
 		assert_eq!(start.elapsed(), Duration::ZERO);
 
-		// A PCR slot 25ms later waits for its grid boundary.
-		write_paced(&mut pacer, &frame(25_000, Timescale::MICRO), &mut out)
+		// A PCR slot 25ms later (ready without waiting, like a backfilled grid
+		// slot) waits for its grid boundary.
+		delivery
+			.deliver(&frame(25_000, Timescale::MICRO), false, &mut out)
 			.await
 			.unwrap();
 		assert_eq!(start.elapsed(), Duration::from_millis(25));
 
 		// A media frame at the source's 90 kHz timescale paces on the same clock.
-		write_paced(&mut pacer, &frame(3_600, Timescale::new(90_000).unwrap()), &mut out)
+		delivery
+			.deliver(&frame(3_600, Timescale::new(90_000).unwrap()), true, &mut out)
 			.await
 			.unwrap();
 		assert_eq!(start.elapsed(), Duration::from_millis(40));
 
 		assert_eq!(out.len(), 3 * 188, "every payload was written");
+	}
+
+	/// A backlog delivered faster than real time (a tune-in group replaying from
+	/// its keyframe) must not be slept through step by step: each frame is within
+	/// the lead of the previous sleep's end, but total delivery lag versus the
+	/// frames' arrival would grow with the backlog's length and then stand for
+	/// the pipe's lifetime. Lag is measured against the last wait instead, so the
+	/// drain hurries once it overshoots the latency budget.
+	#[tokio::test(start_paused = true)]
+	async fn backlog_lag_is_bounded_by_the_latency_budget() {
+		let mut delivery = Delivery::new(Duration::from_millis(500));
+		let mut out = Vec::new();
+
+		let start = tokio::time::Instant::now();
+
+		// Frames spanning 1200ms of media, all available at once (waited = false
+		// after the first): pacing may hold each for at most the 500ms budget
+		// past the last wait, not restart the budget after every sleep.
+		delivery
+			.deliver(&frame(0, Timescale::MICRO), true, &mut out)
+			.await
+			.unwrap();
+		delivery
+			.deliver(&frame(400_000, Timescale::MICRO), false, &mut out)
+			.await
+			.unwrap();
+		assert_eq!(start.elapsed(), Duration::from_millis(400), "within the budget: paced");
+
+		delivery
+			.deliver(&frame(800_000, Timescale::MICRO), false, &mut out)
+			.await
+			.unwrap();
+		delivery
+			.deliver(&frame(1_200_000, Timescale::MICRO), false, &mut out)
+			.await
+			.unwrap();
+		assert_eq!(
+			start.elapsed(),
+			Duration::from_millis(400),
+			"past the budget: the drain hurries instead of sleeping"
+		);
+
+		// The hurry made the newest frame the live edge, so pacing resumes
+		// relative to it once the export makes us wait again.
+		delivery
+			.deliver(&frame(1_240_000, Timescale::MICRO), true, &mut out)
+			.await
+			.unwrap();
+		assert_eq!(start.elapsed(), Duration::from_millis(440));
 	}
 }

--- a/rs/moq-mux/src/lib.rs
+++ b/rs/moq-mux/src/lib.rs
@@ -16,6 +16,9 @@
 //!   a format string. It picks the right concrete importer for you.
 //! - [`select`] picks which renditions of a broadcast to keep, on either
 //!   the import or the consume side.
+//! - [`Pacer`] maps each exported frame's media timestamp to the wall-clock
+//!   instant it should be delivered at, for byte streams whose spacing is
+//!   part of the format (MPEG-TS).
 //! - [`timeline`](mod@timeline) publishes the broadcast's group index: one
 //!   record per media group mapping it to its start timestamp, so consumers
 //!   can seek or build playlists without downloading media.
@@ -26,12 +29,14 @@ pub mod codec;
 pub mod container;
 mod error;
 pub mod import;
+mod pace;
 pub mod select;
 mod source;
 pub mod timeline;
 
 pub use clock::Clock;
 pub use error::*;
+pub use pace::Pacer;
 pub use source::Source;
 
 /// Re-export of the [`mp4_atom`] crate, whose types appear in the public CMAF

--- a/rs/moq-mux/src/pace.rs
+++ b/rs/moq-mux/src/pace.rs
@@ -1,0 +1,174 @@
+//! Pacing of export frames onto the wall clock.
+
+use std::time::{Duration, Instant};
+
+use moq_net::Timestamp;
+
+/// Maps each export frame's media timestamp to the wall-clock instant it should
+/// be delivered at, re-anchored to the live edge.
+///
+/// The exporters stamp every [`Frame`](crate::container::Frame) with its media
+/// timestamp on the contract that the caller delivers the bytes at the time the
+/// stamp asserts. That matters most for MPEG-TS, where the byte stream itself
+/// carries no per-frame timing: [`ts::Export`](crate::container::ts::Export)
+/// emits its PCR grid as standalone frames stamped at their slot boundaries, and
+/// a caller that drains them on arrival collapses the clock into position
+/// clusters no downstream stage can repair. "Deliver" is up to the transport:
+/// a paced sink sleeps until the returned instant before writing, while a
+/// transport with receiver-side buffering (e.g. SRT's TSBPD) stamps the payload
+/// with it and sends immediately.
+///
+/// `send_at = anchor + (ts - base)` maps the frame's media time onto the wall
+/// clock, where `base`'s media time and `anchor`'s wall instant were pinned to
+/// each other at the last re-anchor. Offsets are computed in nanoseconds, so the
+/// frames may change [`Timescale`](moq_net::Timescale) mid-stream (the TS
+/// exporter stamps PCR frames in microseconds and media frames at the source's
+/// own scale).
+///
+/// When `send_at` would lead `now` by more than the configured
+/// [`lead`](Self::with_lead), the media clock has outrun wall-clock by more than
+/// the caller is willing to buffer: a tune-in burst, a group skip, or producer
+/// drift. The pacer re-anchors instead, making this newest frame the live edge
+/// (delivered at `now`), and later frames pace relative to it. Re-anchoring only
+/// ever moves the anchor *forward*: a frame that merely arrives late (network
+/// or CPU jitter, or a reordered B-frame whose timestamp trails the edge) keeps
+/// its earlier media instant instead of collapsing to its arrival instant.
+#[derive(Default)]
+pub struct Pacer {
+	/// How far ahead of `now` a frame may be scheduled before re-anchoring.
+	lead: Duration,
+	/// The wall instant and media time (in nanoseconds) pinned to each other at
+	/// the last re-anchor; every frame paces relative to this pair.
+	anchor: Option<(Instant, u128)>,
+}
+
+impl Pacer {
+	/// Set how far ahead of the wall clock a frame may be scheduled.
+	///
+	/// This is the smoothing buffer the caller holds: a paced sink sleeps up to
+	/// this long per frame, so an arrival burst spanning at most `lead` of media
+	/// time drains evenly instead of re-anchoring. Zero (the default) never
+	/// schedules into the future, for transports whose receiver owns the jitter
+	/// buffer and reconstructs spacing from the stamped instants.
+	pub fn with_lead(mut self, lead: Duration) -> Self {
+		self.lead = lead;
+		self
+	}
+
+	/// The wall-clock instant `ts` should be delivered at, given that it is
+	/// being scheduled at `now`.
+	///
+	/// The first call pins `ts` to `now` and returns `now`; later calls pace
+	/// relative to that anchor, re-anchoring whenever the result would lead
+	/// `now` by more than the configured lead (see the type docs). The result is
+	/// never later than `now + lead`, but may be arbitrarily far in the past for
+	/// a frame that arrived late.
+	pub fn pace(&mut self, ts: Timestamp, now: Instant) -> Instant {
+		let nanos = ts.as_nanos();
+		let (anchor, base) = *self.anchor.get_or_insert((now, nanos));
+
+		let send_at = if nanos >= base {
+			anchor.checked_add(duration(nanos - base))
+		} else {
+			// A reordered (B-frame) timestamp can trail the anchor: pace it at that
+			// earlier instant instead of collapsing it onto the anchor, falling back
+			// to the anchor if the platform clock can't express it.
+			Some(anchor.checked_sub(duration(base - nanos)).unwrap_or(anchor))
+		};
+
+		match send_at {
+			Some(at) if at <= now + self.lead => at,
+			// Media outran wall-clock (or overflowed the platform clock):
+			// re-anchor so this newest frame is the live edge.
+			_ => {
+				self.anchor = Some((now, nanos));
+				now
+			}
+		}
+	}
+}
+
+/// A nanosecond span as a [`Duration`], saturating at ~584 years.
+fn duration(nanos: u128) -> Duration {
+	Duration::from_nanos(nanos.try_into().unwrap_or(u64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn ms(m: u64) -> Timestamp {
+		Timestamp::from_micros(m * 1_000).unwrap()
+	}
+
+	#[test]
+	fn re_anchors_to_live_edge() {
+		// Tune-in burst: the live edge (4132ms of media) is produced ~8ms after the
+		// first frame (1400ms). It must re-anchor to `now` rather than schedule
+		// ~2.7s into the future.
+		let start = Instant::now();
+		let mut pacer = Pacer::default();
+		assert_eq!(pacer.pace(ms(1_400), start), start, "the first frame anchors at now");
+
+		let now = start + Duration::from_millis(8);
+		assert_eq!(pacer.pace(ms(4_132), now), now, "the live edge paces to now");
+
+		// The re-anchor moved the base up to the live edge (4132ms <-> now). A frame
+		// 33ms newer in MEDIA that arrives 80ms later in WALL-clock (jitter) paces
+		// from that carried-forward anchor: its media instant (+33ms off the edge),
+		// not its 80ms arrival instant.
+		let jittered = pacer.pace(ms(4_165), now + Duration::from_millis(80));
+		assert_eq!(
+			jittered,
+			now + Duration::from_millis(33),
+			"a late frame keeps its media instant, not its arrival instant"
+		);
+
+		// A reordered B-frame can carry a timestamp before the re-anchored live
+		// edge. Keep that earlier media instant instead of flattening it onto the
+		// anchor.
+		let reordered = pacer.pace(ms(4_099), now + Duration::from_millis(100));
+		assert_eq!(
+			reordered,
+			now - Duration::from_millis(33),
+			"a reordered frame can pace before the anchor"
+		);
+	}
+
+	/// Regression for #2984: the TS exporter stamps PCR frames in microseconds and
+	/// media frames at the source's own timescale (90 kHz for a TS import), so the
+	/// pacer must compare timestamps across scales. A scale-strict subtraction
+	/// (`Timestamp::checked_sub`) errors on the mix and collapsed every media
+	/// frame onto the anchor.
+	#[test]
+	fn paces_across_timescales() {
+		let start = Instant::now();
+		let mut pacer = Pacer::default().with_lead(Duration::from_millis(500));
+
+		// A PCR slot at microsecond scale anchors the stream.
+		assert_eq!(pacer.pace(ms(0), start), start);
+
+		// A media frame 40ms later at 90 kHz (3600 ticks) paces on the same clock.
+		let media = Timestamp::from_scale(3_600, 90_000).unwrap();
+		assert_eq!(pacer.pace(media, start), start + Duration::from_millis(40));
+
+		// The next PCR slot, back at microsecond scale, lands on its own boundary.
+		assert_eq!(pacer.pace(ms(50), start), start + Duration::from_millis(50));
+	}
+
+	#[test]
+	fn lead_schedules_bursts_into_the_future() {
+		let start = Instant::now();
+		let mut pacer = Pacer::default().with_lead(Duration::from_millis(500));
+		assert_eq!(pacer.pace(ms(0), start), start);
+
+		// An arrival burst within the lead window is spaced, not re-anchored.
+		assert_eq!(pacer.pace(ms(40), start), start + Duration::from_millis(40));
+		assert_eq!(pacer.pace(ms(500), start), start + Duration::from_millis(500));
+
+		// One step beyond the lead is a discontinuity: re-anchor to now.
+		assert_eq!(pacer.pace(ms(1_200), start), start);
+		// And later frames pace off the new anchor.
+		assert_eq!(pacer.pace(ms(1_240), start), start + Duration::from_millis(40));
+	}
+}

--- a/rs/moq-mux/src/pace.rs
+++ b/rs/moq-mux/src/pace.rs
@@ -77,14 +77,26 @@ impl Pacer {
 		};
 
 		match send_at {
-			Some(at) if at <= now + self.lead => at,
-			// Media outran wall-clock (or overflowed the platform clock):
-			// re-anchor so this newest frame is the live edge.
-			_ => {
-				self.anchor = Some((now, nanos));
-				now
-			}
+			// `saturating_duration_since` is zero for an `at` in the past, which any
+			// lead admits; the subtraction form can't overflow on a huge lead.
+			Some(at) if at.saturating_duration_since(now) <= self.lead => at,
+			// Media outran wall-clock (or overflowed the platform clock).
+			_ => self.hurry(ts, now),
 		}
+	}
+
+	/// Deliver `ts` at `now` and make it the live edge: later frames pace
+	/// relative to this pair.
+	///
+	/// This is the re-anchor [`pace`](Self::pace) applies when a frame overshoots
+	/// the lead, exposed for callers whose own lag detection is stricter than
+	/// `pace`'s. A sleeping sink's sleeps push the `now` it paces with forward, so
+	/// a backlog can stay within the lead of every individual call while total
+	/// delivery lag grows; such a caller measures lag against when the frame could
+	/// have arrived and hurries when that overshoots.
+	pub fn hurry(&mut self, ts: Timestamp, now: Instant) -> Instant {
+		self.anchor = Some((now, ts.as_nanos()));
+		now
 	}
 }
 
@@ -154,6 +166,29 @@ mod tests {
 
 		// The next PCR slot, back at microsecond scale, lands on its own boundary.
 		assert_eq!(pacer.pace(ms(50), start), start + Duration::from_millis(50));
+	}
+
+	/// Regression: the lead comparison must not construct `now + lead`, which
+	/// panics on a large but valid `Duration` (`--latency-max` is unbounded).
+	#[test]
+	fn huge_lead_does_not_overflow() {
+		let start = Instant::now();
+		let mut pacer = Pacer::default().with_lead(Duration::MAX);
+		assert_eq!(pacer.pace(ms(0), start), start);
+		assert_eq!(pacer.pace(ms(40), start), start + Duration::from_millis(40));
+	}
+
+	#[test]
+	fn hurry_makes_the_frame_the_live_edge() {
+		let start = Instant::now();
+		let mut pacer = Pacer::default().with_lead(Duration::from_millis(500));
+		assert_eq!(pacer.pace(ms(0), start), start);
+
+		// A caller's stricter lag detection can force the re-anchor `pace` alone
+		// would not apply: the frame goes out at `now` and becomes the new base.
+		let now = start + Duration::from_millis(100);
+		assert_eq!(pacer.hurry(ms(800), now), now);
+		assert_eq!(pacer.pace(ms(840), now), now + Duration::from_millis(40));
 	}
 
 	#[test]

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -390,27 +390,21 @@ pub(crate) async fn serve_subscribe(
 	// Pace each payload on the media clock: the Instant handed to `send` is the
 	// payload's origin time feeding the receiver's TSBPD, which reconstructs the
 	// inter-frame spacing from it. We don't know the live playhead when a subscriber
-	// attaches, so `pace` anchors it for us -- the newest frame is "now" and earlier
-	// frames map to proportionally earlier instants, re-anchoring whenever the media
-	// outruns wall-clock (a tune-in burst, a catch-up, or producer drift). `anchor`
-	// and `base` are that media-clock anchor (`base`'s media time maps to `anchor`),
-	// carried across frames and moved forward by `pace`.
-	let mut anchor = Instant::now();
-	let mut base = None;
+	// attaches, so the pacer anchors it for us -- the newest frame is "now" and
+	// earlier frames map to proportionally earlier instants, re-anchoring whenever
+	// the media outruns wall-clock (a tune-in burst, a catch-up, or producer
+	// drift). The default zero lead is deliberate: the receiver owns the jitter
+	// buffer (the SRT latency parameter), so the sender adds no lookahead of its
+	// own.
+	let mut pacer = moq_mux::Pacer::default();
 	// The first payload's send instant, the floor every later one is clamped up to
 	// (see `clamp_to_floor`).
 	let mut floor = None;
 	let mut chunker = SrtChunker::default();
 	while let Some(frame) = subscriber.next().await? {
-		// The media zero-point the rest pace against; `pace` re-anchors it forward to
-		// the live edge whenever the media outruns wall-clock.
-		let zero = *base.get_or_insert(frame.timestamp);
-		let paced = pace(anchor, zero, frame.timestamp, Instant::now());
-		anchor = paced.anchor;
-		base = Some(paced.base);
-		// Preserve the media-clock anchor for future frames, but never transmit a
+		// Preserve the media-clock pacing for future frames, but never transmit a
 		// timestamp below the first packet's (see `floor` above).
-		let send_at = clamp_to_floor(paced.send_at, &mut floor);
+		let send_at = clamp_to_floor(pacer.pace(frame.timestamp, Instant::now()), &mut floor);
 
 		for chunk in chunker.push(send_at, &frame.payload) {
 			socket.send(chunk).await?;
@@ -436,57 +430,6 @@ pub(crate) async fn serve_subscribe(
 /// sits at the first packet, so without this clamp that reorder underflows.
 fn clamp_to_floor(send_at: Instant, floor: &mut Option<Instant>) -> Instant {
 	send_at.max(*floor.get_or_insert(send_at))
-}
-
-/// One frame's SRT send time plus the media-clock anchor to carry into the next
-/// frame. `base`'s media time maps to `anchor` on the wall clock.
-struct Paced {
-	/// The Instant to stamp this payload with: its TSBPD origin time.
-	send_at: Instant,
-	anchor: Instant,
-	base: moq_net::Timestamp,
-}
-
-/// Pace one SRT payload on the media clock, re-anchored to the live edge.
-///
-/// `send_at = anchor + (ts - base)` stamps the payload at its media time, so the
-/// receiver's TSBPD reconstructs inter-frame spacing from it. But when that runs
-/// ahead of `now` -- the media clock has outrun wall-clock: a subscriber tuning in
-/// bursts the current GOP plus any catch-up backlog (frames whose media timestamps
-/// span seconds, produced within milliseconds), or the producer drifts faster than
-/// real time -- re-anchor the live edge to `now` (this frame becomes the playhead).
-/// Otherwise the payload is stamped seconds into the future, where SRT holds it in
-/// the sender past the receiver's TSBPD latency window and playback stalls after
-/// ~one packet.
-///
-/// Re-anchoring only ever moves the anchor *forward*, so a frame that merely arrives
-/// late -- network/CPU jitter, or a reordered B-frame whose PTS trails the edge --
-/// keeps its earlier media instant instead of collapsing to its arrival instant, and
-/// TSBPD still smooths the jitter into even playout. The cap is "never lead `now`":
-/// the receiver owns the jitter buffer (the SRT latency parameter), so the sender
-/// adds no lookahead of its own (a deliberate lead would just be `now + lead` here).
-fn pace(anchor: Instant, base: moq_net::Timestamp, ts: moq_net::Timestamp, now: Instant) -> Paced {
-	let send_at = match ts.checked_sub(base) {
-		Ok(offset) => anchor + Duration::from(offset),
-		// A reordered B-frame can carry a PTS before the anchor: pace it at that earlier
-		// instant instead of collapsing it onto the anchor. `ts.checked_sub(base)` failed,
-		// so `base >= ts` (same scale); fall back to the anchor if it can't be expressed.
-		Err(_) => base
-			.checked_sub(ts)
-			.ok()
-			.and_then(|behind| anchor.checked_sub(Duration::from(behind)))
-			.unwrap_or(anchor),
-	};
-	if send_at > now {
-		// Media outran wall-clock: re-anchor so this newest frame is the live edge.
-		Paced {
-			send_at: now,
-			anchor: now,
-			base: ts,
-		}
-	} else {
-		Paced { send_at, anchor, base }
-	}
 }
 
 /// Resolve once the SRT caller hangs up (a clean close or an error), draining and
@@ -619,62 +562,6 @@ mod tests {
 		}
 	}
 
-	#[test]
-	fn pace_re_anchors_to_live_edge() {
-		use moq_net::Timestamp;
-		use std::time::{Duration, Instant};
-		let ms = |m: u64| Timestamp::from_micros(m * 1_000).unwrap();
-
-		// Tune-in burst: the live edge (4132ms of media) is produced ~8ms after the
-		// first frame (1400ms). It must re-anchor to `now` rather than stamp ~2.7s
-		// into the future, which would stall the receiver's TSBPD after ~one payload.
-		let start = Instant::now();
-		let now = start + Duration::from_millis(8);
-		let edge = pace(start, ms(1_400), ms(4_132), now);
-		assert_eq!(edge.send_at, now, "live edge should pace to now");
-		assert_eq!(edge.anchor, now);
-		assert_eq!(
-			edge.base.as_micros(),
-			ms(4_132).as_micros(),
-			"anchor moves up to the live edge"
-		);
-
-		// Part 1 moved the anchor to the live edge (now / 4132ms). A frame 33ms newer in
-		// MEDIA that arrives 80ms later in WALL-clock (jitter) paces from that carried-
-		// forward anchor -- its media instant (+33ms off the edge), not its 80ms arrival
-		// instant -- so TSBPD still reconstructs smooth spacing.
-		let jittered = pace(
-			edge.anchor,
-			edge.base,
-			ms(4_165),
-			edge.anchor + Duration::from_millis(80),
-		);
-		assert_eq!(
-			jittered.send_at,
-			edge.anchor + Duration::from_millis(33),
-			"a late frame keeps its media instant, not its arrival instant"
-		);
-		assert_eq!(
-			jittered.anchor, edge.anchor,
-			"no re-anchor when media is behind wall-clock"
-		);
-
-		// A reordered B-frame can carry a PTS before the re-anchored live edge. Keep that
-		// earlier media instant instead of flattening it onto the anchor.
-		let reordered = pace(
-			edge.anchor,
-			edge.base,
-			ms(4_099),
-			edge.anchor + Duration::from_millis(20),
-		);
-		assert_eq!(
-			reordered.send_at,
-			edge.anchor - Duration::from_millis(33),
-			"a reordered frame can pace before the anchor"
-		);
-		assert_eq!(reordered.anchor, edge.anchor, "no re-anchor when media trails the edge");
-	}
-
 	/// Regression: a reordered frame paced before the first packet must be clamped up
 	/// to it, not transmitted with an earlier SRT timestamp. Reproduces the tune-in
 	/// sequence a looping TS source triggers intermittently: a fast first delivery
@@ -691,36 +578,16 @@ mod tests {
 		// the second frame re-anchors (its media outruns wall-clock) and the third is a
 		// reorder whose media trails the new anchor.
 		let start = Instant::now();
-		let mut anchor = start;
-		let mut base = None;
+		let mut pacer = moq_mux::Pacer::default();
 		let mut floor = None;
 
-		let step = |anchor: &mut Instant, base: &mut Option<Timestamp>, floor: &mut Option<Instant>, ts, now| {
-			let zero = *base.get_or_insert(ts);
-			let paced = pace(*anchor, zero, ts, now);
-			*anchor = paced.anchor;
-			*base = Some(paced.base);
-			(paced.send_at, clamp_to_floor(paced.send_at, floor))
-		};
-
 		// i0: first frame, delivered ~instantly -> stamped at the live edge.
-		let (_, first) = step(&mut anchor, &mut base, &mut floor, ms(1_400), start);
+		let first = clamp_to_floor(pacer.pace(ms(1_400), start), &mut floor);
 		// i1: 83ms newer in media, produced ~1ms later -> re-anchors to `now`.
-		let (_, _) = step(
-			&mut anchor,
-			&mut base,
-			&mut floor,
-			ms(1_483),
-			start + Duration::from_millis(1),
-		);
+		let _ = clamp_to_floor(pacer.pace(ms(1_483), start + Duration::from_millis(1)), &mut floor);
 		// i2: a reordered B-frame 41ms behind the new anchor.
-		let (unclamped, clamped) = step(
-			&mut anchor,
-			&mut base,
-			&mut floor,
-			ms(1_442),
-			start + Duration::from_millis(2),
-		);
+		let unclamped = pacer.pace(ms(1_442), start + Duration::from_millis(2));
+		let clamped = clamp_to_floor(unclamped, &mut floor);
 
 		assert!(
 			unclamped < first,


### PR DESCRIPTION
## Root cause

#2967 made the TS exporter emit each PCR as its own `Frame` stamped at its grid-slot boundary, on the documented contract that the caller delivers the bytes at the time the stamp asserts. `run_ts` in `rs/moq-cli/src/subscribe.rs` never read `frame.timestamp`: it wrote each payload on arrival, so the spacing was discarded at the exporter's only byte-stream interface and the clustering moved from the value domain to the position domain, exactly as measured in #2984.

## Fix

- **`moq_mux::Pacer`** (new, `rs/moq-mux/src/pace.rs`): moq-srt's `pace` helper extracted next to `Clock`, since two in-tree callers now need it and both consume moq-mux frames. `pace(ts, now)` maps a frame's media time onto the wall clock against an anchor taken at the first frame, re-anchoring to the live edge when media outruns wall-clock.
- **`with_lead(..)`**: the one new concept. A sleeping sink needs to schedule frames *into* the future to smooth an arrival burst, while SRT must never lead `now` (the receiver's TSBPD buffer owns the smoothing, and a future stamp stalls the sender). Lead is that buffer budget: zero (default) for SRT, `--latency-max` for stdout.
- **Bounded delivery lag** (`Delivery` in moq-cli, added by the adversarial review pass): the pacer alone caps how far one frame is scheduled past the `now` it paces with, but the sink's own sleeps push that `now` forward, so a backlog arriving faster than real time (a tune-in group replaying from its keyframe) stays within the lead of every call while total delivery lag grows and then stands for the pipe's lifetime. The export's group skipping cannot shed it: it fires when the current group is blocked with a newer alternative, so it measures producer stalls, never consumer lag. Delivery lag is therefore measured against the last instant the export made us wait (an upper bound on when a ready frame actually arrived); a frame whose schedule overshoots that bound by more than the budget is delivered immediately and becomes the live edge (`Pacer::hurry`), so a drain sheds its lag and pacing resumes from the live edge. Net contract: `moq export ts` never voluntarily holds delivery more than `--latency-max` behind arrival.
- **`run_ts`** sleeps until each frame's paced instant before writing (`write_paced`).
- **Scale fix that the extraction forced**: the exporter stamps PCR frames in microseconds and media frames at the source's own timescale (90 kHz for a TS import). moq-srt's old `pace` used the scale-strict `Timestamp::checked_sub`, whose `Err` arm assumed "reordered frame": a cross-scale pair fell through both subtractions and collapsed onto the anchor, so media frames on the SRT lane were not actually paced. `Pacer` computes offsets in nanoseconds, fixing this for both callers; without it, pacing `run_ts` would not have fixed #2984 at all.

## Consequence worth naming

`moq export ts` becomes a real-time pipe, as the issue anticipated: bytes leave stdout at the stream's clock rate rather than as fast as frames arrive. The subscription is live and already produces no faster than the broadcast, so steady-state throughput is unchanged; what changes is intra-burst spacing. `doc/bin/cli.md` documents it. The other stdout formats are untouched: they are consumed by players that buffer, and only TS carries a decoder clock in its bytes.

## Tests

- `moq-mux pace::tests`: the re-anchor/jitter/reorder cases ported from moq-srt, plus regressions for cross-timescale pacing and the lead window.
- `moq-cli subscribe::tests::ts_frames_are_paced_on_the_media_clock`: paused-clock regression that the stdout writer delivers frames at their stamped instants (including across a mid-stream timescale change), not on arrival.
- `moq-srt` keeps its `clamp_to_floor` regression, rewritten against `Pacer`; the full suites for all three crates pass (`just check`, `just test`, rustdoc `-D warnings`).

## Cross-package sync

- `rs/moq-cli` → `doc/bin/cli.md`: paced-export note added.
- No wire change, so no draft update: the pacing is delivery behavior, not framing.
- Not addressed here: #2978 (SRT chunk coalescing re-stamps buffered bytes) is unchanged; it is the bounded sub-chunk case of the same class and owns its own trade.

(written by Fable 5)

