### PR TITLE
fix(audio): drain Opus lookahead on finish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,7 +4636,6 @@ dependencies = [
  "dispatch2",
  "fixed-resample",
  "hang",
- "kio 0.5.5",
  "moq-mux",
  "moq-net",
  "objc2 0.6.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,6 +4636,7 @@ dependencies = [
  "dispatch2",
  "fixed-resample",
  "hang",
+ "kio 0.5.5",
  "moq-mux",
  "moq-net",
  "objc2 0.6.4",

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -332,6 +332,11 @@ The default, used when the `container` field is absent.
 Each frame starts with a timestamp, a QUIC variable-length integer (62-bit max) encoded in microseconds.
 The remainder of the payload is codec specific; see the WebCodecs specification for specifics.
 
+A frame with an empty codec payload is an end marker, not media.
+Its timestamp is the exclusive endpoint of the source media.
+When a codec must receive additional packets to emit buffered source samples, the marker MUST precede those terminal packets.
+A consumer MUST NOT submit the marker to the codec decoder, MUST decode the terminal packets, and MUST discard decoded samples at or after the endpoint.
+
 For example, h.264 with no `description` field would be annex.b encoded, while h.264 with a `description` field would be AVCC encoded.
 
 ## cmaf

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -326,6 +326,10 @@ Each moq-lite group MUST start with a keyframe.
 If the codec does not support delta frames (e.g. audio), a group MAY consist of multiple keyframes.
 Otherwise, a group MUST consist of a single keyframe followed by zero or more delta frames.
 
+An empty group declares a discontinuity between codec epochs.
+A consumer MUST reset codec state before decoding the next non-empty group, including reapplying any codec startup delay or pre-skip.
+This applies whether the resumed timestamps move backward or forward.
+
 ## legacy
 The default, used when the `container` field is absent.
 

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -413,7 +413,53 @@ test("Consumer returns legacy endpoint markers as ordered metadata", async () =>
 
 	const media = await consumer.next();
 	expect(media?.frame?.payload).toEqual(new Uint8Array([0xde, 0xad]));
+	expect(media?.frame?.keyframe).toBe(true);
 	expect(media?.end).toBeUndefined();
+	consumer.close();
+});
+
+test("Consumer delivers a rewound endpoint before its terminal packet", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
+
+	const previous = new Group.Producer(0);
+	previous.writeFrame({
+		payload: encodeLegacyFrame(100_000 as Time.Micro, new Uint8Array([0xca, 0xfe])),
+		timestamp: Time.Timestamp.now(),
+	});
+	track.writeGroup(previous);
+	const first = await consumer.next();
+	expect(first?.frame?.timestamp).toBe(100_000 as Time.Micro);
+
+	const group = new Group.Producer(1);
+	group.writeFrame({
+		payload: encodeLegacyFrame(0 as Time.Micro, new Uint8Array()),
+		timestamp: Time.Timestamp.now(),
+	});
+	group.writeFrame({
+		payload: encodeLegacyFrame(0 as Time.Micro, new Uint8Array([0xde, 0xad])),
+		timestamp: Time.Timestamp.now(),
+	});
+	group.close();
+	track.writeGroup(group);
+	await settle();
+
+	let marker: { end?: Time.Micro; discontinuity: number } | undefined;
+	for (;;) {
+		const next = await consumer.next();
+		if (!next || next.end !== undefined) {
+			marker = next;
+			break;
+		}
+	}
+	expect(marker?.end).toBe(0 as Time.Micro);
+	expect(marker?.discontinuity).toBe(1);
+
+	const terminal = await consumer.next();
+	expect(terminal?.frame?.keyframe).toBe(true);
+	expect(terminal?.discontinuity).toBe(1);
+	previous.close();
+	track.close();
 	consumer.close();
 });
 

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -949,6 +949,28 @@ test("Consumer reports continuity while nothing is dropped", async () => {
 	consumer.close();
 });
 
+test("Consumer reports an empty group as a codec discontinuity", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
+
+	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro]);
+	const marker = new Group.Producer(1);
+	track.writeGroup(marker);
+	marker.close();
+	writeGroupWithLegacyFrames(track, 2, [1_000_000 as Time.Micro]);
+	await settle();
+
+	expect((await consumer.next())?.discontinuity).toBe(0);
+	expect((await consumer.next())?.discontinuity).toBe(0); // group 0 done
+	const reset = await consumer.next();
+	expect(reset?.frame).toBeUndefined();
+	expect(reset?.discontinuity).toBe(1);
+	expect(reset?.continuous).toBe(false);
+	expect((await consumer.next())?.discontinuity).toBe(1);
+
+	consumer.close();
+});
+
 // The case the group-number heuristic got backwards: ids jump, but the PTS timeline is unbroken.
 test("Consumer reports continuity across a PTS-contiguous group id jump (CMAF)", async () => {
 	const track = new Track.Producer("test");

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -971,6 +971,30 @@ test("Consumer reports an empty group as a codec discontinuity", async () => {
 	consumer.close();
 });
 
+test("Consumer preserves an empty-group discontinuity while latency-skipping", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 0 as Time.Milli });
+
+	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro]);
+	await settle();
+	expect((await consumer.next())?.frame?.timestamp).toBe(0 as Time.Micro);
+	expect((await consumer.next())?.frame).toBeUndefined();
+
+	const marker = new Group.Producer(2);
+	track.writeGroup(marker);
+	marker.close();
+	await settle();
+
+	writeGroupWithLegacyFrames(track, 3, [1_000_000 as Time.Micro, 1_100_000 as Time.Micro]);
+	await settle();
+
+	const resumed = await consumer.next();
+	expect(resumed?.frame?.timestamp).toBe(1_000_000 as Time.Micro);
+	expect(resumed?.discontinuity).toBe(1);
+
+	consumer.close();
+});
+
 // The case the group-number heuristic got backwards: ids jump, but the PTS timeline is unbroken.
 test("Consumer reports continuity across a PTS-contiguous group id jump (CMAF)", async () => {
 	const track = new Track.Producer("test");

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -51,13 +51,13 @@ test("LegacyFormat decodes a valid frame", () => {
 	expect(result[0].keyframe).toBe(false);
 });
 
-test("LegacyFormat skips a marker instead of decoding an empty chunk", () => {
+test("LegacyFormat preserves an endpoint marker", () => {
 	const format = new LegacyFormat();
 	const frame = encodeLegacyFrame(1000 as Time.Micro, new Uint8Array());
 
-	// An empty payload is a marker: no media, so no frames -- and no throw. A
-	// publisher emitting these must not break an older decoder.
-	expect(format.decode(frame)).toEqual([]);
+	const [marker] = format.decode(frame);
+	expect(marker.timestamp).toBe(1000 as Time.Micro);
+	expect(marker.payload).toHaveLength(0);
 });
 
 test("LegacyFormat always returns keyframe: false", () => {
@@ -390,6 +390,33 @@ test("Consumer next() returns group-done signals", async () => {
 	consumer.close();
 });
 
+test("Consumer returns legacy endpoint markers as ordered metadata", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
+
+	const group = new Group.Producer(0);
+	group.writeFrame({
+		payload: encodeLegacyFrame(20_000 as Time.Micro, new Uint8Array()),
+		timestamp: Time.Timestamp.now(),
+	});
+	group.writeFrame({
+		payload: encodeLegacyFrame(20_000 as Time.Micro, new Uint8Array([0xde, 0xad])),
+		timestamp: Time.Timestamp.now(),
+	});
+	group.close();
+	track.writeGroup(group);
+	track.close();
+
+	const marker = await consumer.next();
+	expect(marker?.frame).toBeUndefined();
+	expect(marker?.end).toBe(20_000 as Time.Micro);
+
+	const media = await consumer.next();
+	expect(media?.frame?.payload).toEqual(new Uint8Array([0xde, 0xad]));
+	expect(media?.end).toBeUndefined();
+	consumer.close();
+});
+
 // --- Buffered signal ---
 
 test("Consumer buffered signal updates as frames arrive", async () => {
@@ -462,6 +489,26 @@ test("Consumer handles empty decode result without deadlock", async () => {
 	// So the next frame's first sample gets index=0 → keyframe=true.
 	expect(frames).toHaveLength(1);
 	expect(frames[0].keyframe).toBe(true);
+	consumer.close();
+});
+
+test("Consumer preserves empty media from formats without endpoint markers", async () => {
+	const format: ContainerFormat = {
+		decode(): Frame[] {
+			return [{ payload: new Uint8Array(), timestamp: 0 as Time.Micro, keyframe: false }];
+		},
+	};
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format, latency: 500 as Time.Milli });
+	const group = new Group.Producer(0);
+	group.writeFrame({ payload: new Uint8Array([1]), timestamp: Time.Timestamp.now() });
+	group.close();
+	track.writeGroup(group);
+	track.close();
+
+	const result = await consumer.next();
+	expect(result?.frame?.payload).toHaveLength(0);
+	expect(result?.end).toBeUndefined();
 	consumer.close();
 });
 

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -971,7 +971,7 @@ test("Consumer reports an empty group as a codec discontinuity", async () => {
 	consumer.close();
 });
 
-test("Consumer preserves an empty-group discontinuity while latency-skipping", async () => {
+test("Consumer advances a completed empty group across a sequence gap", async () => {
 	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 0 as Time.Milli });
 
@@ -985,9 +985,44 @@ test("Consumer preserves an empty-group discontinuity while latency-skipping", a
 	marker.close();
 	await settle();
 
+	writeGroupWithLegacyFrames(track, 3, [1_000_000 as Time.Micro]);
+	await settle();
+
+	const reset = await consumer.next();
+	expect(reset?.frame).toBeUndefined();
+	expect(reset?.discontinuity).toBe(1);
+	const resumed = await consumer.next();
+	expect(resumed?.frame?.timestamp).toBe(1_000_000 as Time.Micro);
+	expect(resumed?.discontinuity).toBe(1);
+
+	consumer.close();
+});
+
+test("Consumer waits for an empty-group FIN before latency-skipping it", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 0 as Time.Milli });
+
+	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro]);
+	await settle();
+	expect((await consumer.next())?.frame?.timestamp).toBe(0 as Time.Micro);
+	expect((await consumer.next())?.frame).toBeUndefined();
+
+	const marker = new Group.Producer(2);
+	track.writeGroup(marker);
 	writeGroupWithLegacyFrames(track, 3, [1_000_000 as Time.Micro, 1_100_000 as Time.Micro]);
 	await settle();
 
+	const pending = consumer.next();
+	const beforeFin = await Promise.race([
+		pending.then(() => "ready" as const),
+		settle(50).then(() => "pending" as const),
+	]);
+	expect(beforeFin).toBe("pending");
+
+	marker.close();
+	const reset = await pending;
+	expect(reset?.frame).toBeUndefined();
+	expect(reset?.discontinuity).toBe(1);
 	const resumed = await consumer.next();
 	expect(resumed?.frame?.timestamp).toBe(1_000_000 as Time.Micro);
 	expect(resumed?.discontinuity).toBe(1);

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -498,8 +498,9 @@ export class Consumer {
 
 	/**
 	 * Returns the next frame in order along with its group number and the current
-	 * {@link discontinuity} count, awaiting one if needed. A `frame` of undefined signals the
-	 * end of that group; the overall result is undefined once closed. When `discontinuity`
+	 * {@link discontinuity} count, awaiting one if needed. A `frame` of undefined signals either
+	 * the end of that group or, when `end` is present, an exclusive media endpoint carried by a
+	 * legacy marker. The overall result is undefined once closed. When `discontinuity`
 	 * jumps relative to the previous call, the publisher rewound the timeline: flush any
 	 * downstream decoder or render buffers before playing this frame.
 	 *
@@ -515,7 +516,14 @@ export class Consumer {
 	 * the missing span will never arrive.
 	 */
 	async next(): Promise<
-		{ frame: Frame | undefined; group: number; discontinuity: number; continuous: boolean } | undefined
+		| {
+				frame: Frame | undefined;
+				group: number;
+				discontinuity: number;
+				continuous: boolean;
+				end?: Time.Micro;
+		  }
+		| undefined
 	> {
 		for (;;) {
 			// A group may have buffered a rewind while the live edge was still behind it; catch it
@@ -549,6 +557,17 @@ export class Consumer {
 				if (frame) {
 					const seq = this.#groups[0].consumer.sequence;
 					const continuous = this.#continuesDelivery(seq);
+					const end = this.#format.end?.(frame);
+					if (end !== undefined) {
+						this.#updateBuffered();
+						return {
+							frame: undefined,
+							group: seq,
+							discontinuity: this.#rewind.discontinuity,
+							continuous,
+							end,
+						};
+					}
 					if (seq !== this.#deliveredGroup) this.#gap = false;
 					this.#deliveredGroup = seq;
 

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -341,6 +341,8 @@ export class Consumer {
 		// group, the latency span proves the missing content is too old to wait for.
 		while (this.#groups.length >= 2) {
 			const threshold = Moq.Time.Micro.fromMilli(this.#latency.peek());
+			const first = this.#groups[0];
+			if (first.empty && !first.consumer.done) break;
 
 			// Check the difference between the earliest and latest known frames.
 			let min: number | undefined;
@@ -359,14 +361,13 @@ export class Consumer {
 			const latency = max - min;
 			if (latency <= threshold) break;
 
-			const first = this.#groups.shift();
-			if (!first) break;
+			this.#groups.shift();
 			this.#active = this.#groups[0]?.consumer.sequence;
 			console.warn(
 				`skipping slow group: track=${this.#track.name} ${first.consumer.sequence} -> ${this.#active}`,
 			);
 
-			if (first.empty && first.consumer.done) this.#markDiscontinuity();
+			if (first.empty) this.#markDiscontinuity();
 			first.consumer.close();
 			first.frames.length = 0;
 			skipped = true;
@@ -539,15 +540,17 @@ export class Consumer {
 			// fallback fired because no later group was buffered yet, and the real (large-gap,
 			// non-sequential) next group has since arrived -- promote #active to the first real
 			// group so delivery resumes instead of stalling on a nonexistent sequence.
-			// Promote #active up to the first buffered group ONLY when it continues the timeline we left
-			// off at (PTS-contiguous with #presentedEnd). Otherwise a real gap sits before it and an
-			// in-transit group may still arrive, so wait -- #checkLatency skips the gap once the buffered
-			// span exceeds the latency budget, and #tryDurationSkip once the duration covers it.
+			// Promote #active to the first buffered group when it continues the timeline we left off at,
+			// or when a completed empty group declares a boundary that makes the earlier gap irrelevant.
+			// Otherwise a real gap sits before it and an in-transit group may still arrive, so wait.
+			// #checkLatency skips the gap once the buffered span exceeds the latency budget, and
+			// #tryDurationSkip once the duration covers it.
 			if (this.#active !== undefined && this.#groups.length > 0) {
 				const head = this.#groups[0];
 				if (
 					head.consumer.sequence > this.#active &&
-					ptsContiguous(this.#presentedEnd, head.frames.at(0)?.timestamp)
+					((head.empty && head.consumer.done) ||
+						ptsContiguous(this.#presentedEnd, head.frames.at(0)?.timestamp))
 				) {
 					this.#active = head.consumer.sequence;
 				}

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -17,6 +17,7 @@ export interface ConsumerProps {
 interface Group {
 	consumer: Moq.Group.Consumer;
 	frames: Frame[]; // decode order
+	empty: boolean; // no wire frame was published, which declares a discontinuity
 	latest?: Time.Micro; // The timestamp of the latest known frame
 	end?: Time.Micro; // The furthest presentation point so far, i.e. max(timestamp + duration)
 	done?: boolean; // Set when #runGroup finishes reading all frames
@@ -58,19 +59,19 @@ class Reset {
 }
 
 /**
- * Live state for detecting timeline rewinds and classifying out-of-order groups.
+ * Live state for declared discontinuities and detected timeline rewinds.
  *
  * A publisher reneges its buffered tail by rewinding timestamps while group sequence keeps
  * climbing (e.g. a voice agent interrupted mid-utterance). We track the live edge to spot the
- * jump, a {@link Reset} boundary to classify out-of-order groups across it, and a counter that
- * downstream consumers watch to flush their own queues.
+ * jump and a {@link Reset} boundary to classify out-of-order groups across it. The counter also
+ * advances when delivery reaches an explicit empty-group discontinuity.
  */
 class Rewind {
 	/** The live edge of playback: max delivered timestamp and the group that carried it. */
 	liveEdge?: { group: number; timestamp: Time.Micro };
 	/** The active rewind boundary, if any. */
 	boundary?: Reset;
-	/** Increments on every rewind; downstream consumers flush their queues when it changes. */
+	/** Increments on every declared discontinuity or rewind. */
 	discontinuity = 0;
 }
 
@@ -188,6 +189,7 @@ export class Consumer {
 			const group: Group = {
 				consumer,
 				frames: [],
+				empty: true,
 			};
 
 			// Insert into #groups based on the group sequence number (ascending).
@@ -207,6 +209,7 @@ export class Consumer {
 			for (;;) {
 				const next = await group.consumer.readFrame();
 				if (!next) break;
+				group.empty = false;
 
 				const decoded = this.#format.decode(next.payload);
 
@@ -502,8 +505,8 @@ export class Consumer {
 	 * {@link discontinuity} count, awaiting one if needed. A `frame` of undefined signals either
 	 * the end of that group or, when `end` is present, an exclusive media endpoint carried by a
 	 * legacy marker. The overall result is undefined once closed. When `discontinuity`
-	 * jumps relative to the previous call, the publisher rewound the timeline: flush any
-	 * downstream decoder or render buffers before playing this frame.
+	 * jumps relative to the previous call, the publisher declared a break or rewound the
+	 * timeline: reset codec state and flush downstream render buffers before playing this frame.
 	 *
 	 * `continuous` is true when this result picks up exactly where the previous frame left off, so
 	 * the span between them can be treated as delivered. It is false on the first frame, after a
@@ -512,8 +515,8 @@ export class Consumer {
 	 * comparing group numbers, which are not required to be sequential: adjacency neither proves
 	 * the timeline is unbroken nor catches a group dropped on the way past.
 	 *
-	 * It reports what this consumer dropped, not holes the publisher left. A publisher that jumps
-	 * its timeline between two groups still reads as continuous, because nothing on the wire says
+	 * It reports what this consumer dropped plus empty-group discontinuities the publisher declared.
+	 * An unmarked forward timestamp jump still reads as continuous because nothing on the wire says
 	 * the missing span will never arrive.
 	 */
 	async next(): Promise<
@@ -600,6 +603,7 @@ export class Consumer {
 					const group = this.#groups.shift();
 					if (group) {
 						const seq = group.consumer.sequence;
+						if (group.empty) this.#markDiscontinuity();
 						this.#updateBuffered();
 						return {
 							frame: undefined,
@@ -639,6 +643,17 @@ export class Consumer {
 		}
 	}
 
+	// An empty group is an ordered codec boundary. Unlike a detected rewind it needs no
+	// stale-group classification, because delivery has already reached the marker in sequence.
+	#markDiscontinuity(): void {
+		this.#rewind.discontinuity++;
+		this.#rewind.liveEdge = undefined;
+		this.#rewind.boundary = undefined;
+		this.#presentedEnd = undefined;
+		this.#deliveredGroup = undefined;
+		this.#gap = true;
+	}
+
 	#updateBuffered(): void {
 		const ranges: BufferedRanges = [];
 
@@ -666,9 +681,9 @@ export class Consumer {
 	}
 
 	/**
-	 * A counter that increments each time the consumer detects a timeline rewind and drops the
-	 * reneged buffer. Also surfaced per-read via {@link next}; downstream consumers flush their
-	 * decoder and render buffers when it changes.
+	 * A counter that increments at each declared discontinuity or detected timeline rewind.
+	 * Also surfaced per-read via {@link next}; downstream consumers reset codec state and flush
+	 * render buffers when it changes.
 	 */
 	get discontinuity(): number {
 		return this.#rewind.discontinuity;

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -366,6 +366,7 @@ export class Consumer {
 				`skipping slow group: track=${this.#track.name} ${first.consumer.sequence} -> ${this.#active}`,
 			);
 
+			if (first.empty && first.consumer.done) this.#markDiscontinuity();
 			first.consumer.close();
 			first.frames.length = 0;
 			skipped = true;

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -211,13 +211,14 @@ export class Consumer {
 				const decoded = this.#format.decode(next.payload);
 
 				for (const sample of decoded) {
+					const marker = this.#format.end?.(sample) !== undefined;
 					const frame: Frame = {
 						payload: sample.payload,
 						timestamp: sample.timestamp,
 						// Protocol invariant: groups always start at a keyframe.
 						// For index 0, we enforce this regardless of what the format reports.
 						// For index > 0, we trust the format's keyframe detection.
-						keyframe: index === 0 ? true : sample.keyframe,
+						keyframe: !marker && index === 0 ? true : sample.keyframe,
 						// Carry the container's per-sample duration through so group.end is the real
 						// presentation end (ts + duration), not just the last frame's ts. This is what
 						// makes the PTS-contiguity check (next.firstPTS <= group.end) work; without it a
@@ -225,7 +226,7 @@ export class Consumer {
 						duration: sample.duration,
 					};
 
-					index++;
+					if (!marker) index++;
 
 					group.frames.push(frame);
 

--- a/js/hang/src/container/format.ts
+++ b/js/hang/src/container/format.ts
@@ -1,7 +1,10 @@
+import type { Time } from "@moq/net";
 import type { Frame } from "./types";
 
 /** A container format that decodes raw MoQ frames into media frames. */
 export interface Format {
 	/** Parse one MoQ frame (raw bytes) into decoded media frames. */
 	decode(frame: Uint8Array): Frame[];
+	/** Return the exclusive media endpoint when `frame` is a container marker. */
+	end?(frame: Frame): Time.Micro | undefined;
 }

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -9,15 +9,14 @@ import type { Frame } from "./types";
 
 /** The legacy hang container: a microsecond timestamp varint followed by the raw codec payload. */
 export class Format implements ContainerFormat {
-	/** Decode one legacy frame into a single media frame, or none if it's a marker. */
+	/** Return the marker timestamp for an empty codec payload. */
+	end(frame: Frame): Time.Micro | undefined {
+		return frame.payload.byteLength === 0 ? frame.timestamp : undefined;
+	}
+
+	/** Decode one legacy frame, including an empty-payload endpoint marker. */
 	decode(frame: Uint8Array): Frame[] {
 		const [timestamp, data] = Moq.Varint.decode(frame);
-
-		// An empty payload is a marker, not a sample: it says content stops at this
-		// timestamp, so there's nothing to decode. Yield no frames rather than hand an
-		// empty chunk to a decoder -- a publisher emitting these must not break us.
-		if (data.byteLength === 0) return [];
-
 		return [{ payload: data, timestamp: timestamp as Time.Micro, keyframe: false }];
 	}
 }

--- a/js/hang/src/util/opus.test.ts
+++ b/js/hang/src/util/opus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { pickRate, SAMPLE_RATES, supportsRate, toDOps } from "./opus";
+import { pickRate, preSkip, SAMPLE_RATES, supportsRate, toDOps } from "./opus";
 
 describe("pickRate", () => {
 	// Matches the pick_opus_rate tests in rs/moq-audio/src/codec.rs.
@@ -65,5 +65,18 @@ describe("toDOps", () => {
 	it("passes an existing dOps payload through", () => {
 		const dops = Uint8Array.from([0, 2, 1, 56, 0, 0, 187, 128, 0, 0, 0]);
 		expect(toDOps(dops)).toEqual(dops);
+	});
+});
+
+describe("preSkip", () => {
+	it("reads OpusHead and dOps byte order", () => {
+		const head = new Uint8Array(19);
+		head.set(new TextEncoder().encode("OpusHead"));
+		head[8] = 1;
+		new DataView(head.buffer).setUint16(10, 312, true);
+
+		const dops = Uint8Array.from([0, 2, 1, 56, 0, 0, 187, 128, 0, 0, 0]);
+		expect(preSkip(head)).toBe(312);
+		expect(preSkip(dops)).toBe(312);
 	});
 });

--- a/js/hang/src/util/opus.ts
+++ b/js/hang/src/util/opus.ts
@@ -32,13 +32,7 @@ export function pickRate(rate: number): number {
 
 const OPUS_HEAD = new TextEncoder().encode("OpusHead");
 
-/**
- * Convert an OpusHead decoder description into an ISO BMFF dOps payload.
- *
- * Existing dOps payloads pass through unchanged so CMAF descriptions can be
- * remuxed without another format conversion.
- */
-export function toDOps(description: Uint8Array): Uint8Array {
+function header(description: Uint8Array): { offset: number; littleEndian: boolean } {
 	let offset = 0;
 	let littleEndian = false;
 
@@ -55,6 +49,24 @@ export function toDOps(description: Uint8Array): Uint8Array {
 	if (description.length - offset < 11) {
 		throw new Error("Opus decoder description must contain at least 11 bytes");
 	}
+
+	return { offset, littleEndian };
+}
+
+/** Read the codec pre-skip in 48 kHz frames from an OpusHead or dOps payload. */
+export function preSkip(description: Uint8Array): number {
+	const { offset, littleEndian } = header(description);
+	return new DataView(description.buffer, description.byteOffset + offset, 11).getUint16(2, littleEndian);
+}
+
+/**
+ * Convert an OpusHead decoder description into an ISO BMFF dOps payload.
+ *
+ * Existing dOps payloads pass through unchanged so CMAF descriptions can be
+ * remuxed without another format conversion.
+ */
+export function toDOps(description: Uint8Array): Uint8Array {
+	const { offset, littleEndian } = header(description);
 
 	if (!littleEndian) {
 		return description.slice(offset);

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -339,7 +339,6 @@ export class Decoder {
 				const next = await consumer.next();
 				if (!next) break;
 				if (this.#onNext(next)) {
-					warmup.reset();
 					decoder.reset();
 					decoder.configure(decoderConfig);
 				}

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -18,6 +18,7 @@ import { Warmup } from "./warmup";
 // How long the latency target must hold steady before a floor increase re-anchors. Coalesces a
 // slider drag (many small steps) into a single re-anchor once the user settles on a value.
 const LATENCY_REANCHOR_DEBOUNCE_MS = 150;
+const LEGACY_WARMUP_CALLBACKS = 3;
 
 export type DecoderInput = {
 	// Enable to download the audio track.
@@ -303,13 +304,13 @@ export class Decoder {
 			const loaded = await Util.Libav.polyfill();
 			if (!loaded) return; // cancelled
 
-			const warmup = new Warmup(3);
+			const warmup = new Warmup(LEGACY_WARMUP_CALLBACKS);
 
 			const decoder = new AudioDecoder({
 				output: (data) => {
 					const decoded = this.#terminal.span(data);
 					if (warmup.drop()) {
-						// Drop the first 3 frames to prime the decoder.
+						// Drop initial callbacks to prime the decoder.
 						data.close();
 						return;
 					}

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -11,7 +11,7 @@ import { type AudioBuffer, createAudioBuffer } from "./buffer";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
-import { Terminal, terminalFrames } from "./terminal";
+import { type DecodedSpan, Terminal } from "./terminal";
 import { unlockOnGesture } from "./unlock";
 
 // How long the latency target must hold steady before a floor increase re-anchors. Coalesces a
@@ -279,7 +279,9 @@ export class Decoder {
 	}
 
 	#runLegacyDecoder(effect: Effect, sub: Moq.Track.Subscriber, config: Catalog.AudioConfig): void {
-		this.#terminal.clear();
+		const preSkip =
+			config.codec === "opus" && config.description ? Util.Opus.preSkip(Util.Hex.toBytes(config.description)) : 0;
+		this.#terminal.clear(preSkip);
 		const format = config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer with slightly less latency than the render worklet to avoid underflowing.
 		// TODO include JITTER_UNDERHEAD
@@ -304,13 +306,14 @@ export class Decoder {
 
 			const decoder = new AudioDecoder({
 				output: (data) => {
+					const decoded = this.#terminal.span(data);
 					warmed++;
 					if (warmed <= 3) {
 						// Drop the first 3 frames to prime the decoder.
 						data.close();
 						return;
 					}
-					this.#emit(data);
+					this.#emit(data, decoded);
 				},
 				error: (error) => console.error("audio decoder error", error),
 			});
@@ -325,15 +328,19 @@ export class Decoder {
 					: config.description
 						? Util.Hex.toBytes(config.description)
 						: undefined;
-			decoder.configure({
+			const decoderConfig: AudioDecoderConfig = {
 				...config,
 				description,
-			});
+			};
+			decoder.configure(decoderConfig);
 
 			for (;;) {
 				const next = await consumer.next();
 				if (!next) break;
-				this.#onNext(next);
+				if (this.#onNext(next)) {
+					decoder.reset();
+					decoder.configure(decoderConfig);
+				}
 				if (next.end !== undefined) {
 					continue;
 				}
@@ -369,10 +376,12 @@ export class Decoder {
 
 	#runCmafDecoder(effect: Effect, sub: Moq.Track.Subscriber, config: Catalog.AudioConfig): void {
 		if (config.container.kind !== "cmaf") return; // just to help typescript
-		this.#terminal.clear();
 
 		const initSegment = base64ToBytes(config.container.init);
 		const init = Container.Cmaf.decodeInitSegment(initSegment);
+		const opusDescription = config.description ? Util.Hex.toBytes(config.description) : init.description;
+		const preSkip = config.codec === "opus" && opusDescription ? Util.Opus.preSkip(opusDescription) : 0;
+		this.#terminal.clear(preSkip);
 		// Opus in CMAF uses raw packets (not OGG-wrapped), so description must be omitted.
 		// The dOps box from the init segment is not a valid OGG Identification Header.
 		const description =
@@ -408,19 +417,23 @@ export class Decoder {
 			});
 
 			// Configure decoder with description from catalog
-			decoder.configure({
+			const decoderConfig: AudioDecoderConfig = {
 				codec: config.codec,
 				sampleRate: config.sampleRate,
 				numberOfChannels: config.numberOfChannels,
 				description,
-			});
+			};
+			decoder.configure(decoderConfig);
 
 			for (;;) {
 				const next = await consumer.next();
 				if (!next) break;
 
-				// Publisher rewound the timeline: flush + re-anchor before decoding the new frame.
-				this.#onNext(next);
+				// Reset and re-anchor before decoding the first frame of a new codec epoch.
+				if (this.#onNext(next)) {
+					decoder.reset();
+					decoder.configure(decoderConfig);
+				}
 
 				const { frame } = next;
 				if (!frame) continue;
@@ -448,10 +461,9 @@ export class Decoder {
 		});
 	}
 
-	#emit(sample: AudioData) {
-		const timestamp = sample.timestamp as Time.Micro;
+	#emit(sample: AudioData, decoded: DecodedSpan = this.#terminal.span(sample)) {
+		const { timestamp, frameOffset, frames } = decoded;
 		const timestampMilli = Time.Milli.fromMicro(timestamp);
-		const frames = terminalFrames(sample, this.#terminal.end);
 		if (frames === 0) {
 			sample.close();
 			return;
@@ -488,7 +500,7 @@ export class Decoder {
 		const channelData: Float32Array[] = [];
 		for (let channel = 0; channel < channels; channel++) {
 			const data = new Float32Array(frames);
-			sample.copyTo(data, { format: "f32-planar", planeIndex: channel, frameCount: frames });
+			sample.copyTo(data, { format: "f32-planar", planeIndex: channel, frameOffset, frameCount: frames });
 			channelData.push(data);
 		}
 
@@ -535,12 +547,13 @@ export class Decoder {
 		this.#ring?.reset();
 	}
 
-	// Apply ordered container metadata before handling the result. A marker that also
-	// starts a rewound epoch must survive the reset so its following drain is trimmed.
-	#onNext(next: { discontinuity: number; end?: Time.Micro }): void {
-		if (!this.#terminal.update(next)) return;
+	// Apply ordered container metadata before handling the result. An endpoint that also
+	// starts a new epoch must survive the reset so its following drain is trimmed.
+	#onNext(next: { discontinuity: number; end?: Time.Micro; frame?: { timestamp: Time.Micro } }): boolean {
+		if (!this.#terminal.update(next)) return false;
 		this.#ring?.reset();
 		this.sync.reset();
+		return true;
 	}
 
 	close() {

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -11,7 +11,7 @@ import { type AudioBuffer, createAudioBuffer } from "./buffer";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
-import { terminalFrames } from "./terminal";
+import { Terminal, terminalFrames } from "./terminal";
 import { unlockOnGesture } from "./unlock";
 
 // How long the latency target must hold steady before a floor increase re-anchors. Coalesces a
@@ -82,12 +82,8 @@ export class Decoder {
 	// arrives we pre-build the graph from the catalog rate; if the real rate differs we rebuild it.
 	#decodedSampleRate = new Signal<number | undefined>(undefined);
 
-	// The last discontinuity count seen from the container consumer. A change means the
-	// publisher rewound the timeline (e.g. a voice agent interrupted) and we must flush.
-	#discontinuity = 0;
-
-	// Exclusive source endpoint carried before terminal codec drain packets.
-	#terminalEnd?: Time.Micro;
+	// Ordered discontinuity and endpoint state from the container consumer.
+	#terminal = new Terminal();
 
 	// How much buffered audio the container consumer retains before skipping
 	// ahead. This must be the latency CEILING (maxBuffer), not the floor
@@ -283,7 +279,7 @@ export class Decoder {
 	}
 
 	#runLegacyDecoder(effect: Effect, sub: Moq.Track.Subscriber, config: Catalog.AudioConfig): void {
-		this.#terminalEnd = undefined;
+		this.#terminal.clear();
 		const format = config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer with slightly less latency than the render worklet to avoid underflowing.
 		// TODO include JITTER_UNDERHEAD
@@ -337,13 +333,10 @@ export class Decoder {
 			for (;;) {
 				const next = await consumer.next();
 				if (!next) break;
+				this.#onNext(next);
 				if (next.end !== undefined) {
-					this.#terminalEnd = next.end;
 					continue;
 				}
-
-				// Publisher rewound the timeline: flush + re-anchor before decoding the new frame.
-				this.#onDiscontinuity(next.discontinuity);
 
 				const { frame } = next;
 				if (!frame) continue;
@@ -376,7 +369,7 @@ export class Decoder {
 
 	#runCmafDecoder(effect: Effect, sub: Moq.Track.Subscriber, config: Catalog.AudioConfig): void {
 		if (config.container.kind !== "cmaf") return; // just to help typescript
-		this.#terminalEnd = undefined;
+		this.#terminal.clear();
 
 		const initSegment = base64ToBytes(config.container.init);
 		const init = Container.Cmaf.decodeInitSegment(initSegment);
@@ -427,7 +420,7 @@ export class Decoder {
 				if (!next) break;
 
 				// Publisher rewound the timeline: flush + re-anchor before decoding the new frame.
-				this.#onDiscontinuity(next.discontinuity);
+				this.#onNext(next);
 
 				const { frame } = next;
 				if (!frame) continue;
@@ -458,7 +451,7 @@ export class Decoder {
 	#emit(sample: AudioData) {
 		const timestamp = sample.timestamp as Time.Micro;
 		const timestampMilli = Time.Milli.fromMicro(timestamp);
-		const frames = terminalFrames(sample, this.#terminalEnd);
+		const frames = terminalFrames(sample, this.#terminal.end);
 		if (frames === 0) {
 			sample.close();
 			return;
@@ -542,14 +535,10 @@ export class Decoder {
 		this.#ring?.reset();
 	}
 
-	// React to the container consumer's discontinuity counter. When it changes the publisher
-	// has rewound the timeline, so flush the queued PCM and re-anchor the shared clock before
-	// the first frame of the new utterance is decoded. This makes the wire signal trigger the
-	// same flush as a manual `reset()`, with no app involvement.
-	#onDiscontinuity(count: number): void {
-		if (count === this.#discontinuity) return;
-		this.#discontinuity = count;
-		this.#terminalEnd = undefined;
+	// Apply ordered container metadata before handling the result. A marker that also
+	// starts a rewound epoch must survive the reset so its following drain is trimmed.
+	#onNext(next: { discontinuity: number; end?: Time.Micro }): void {
+		if (!this.#terminal.update(next)) return;
 		this.#ring?.reset();
 		this.sync.reset();
 	}

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -13,6 +13,7 @@ import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
 import { type DecodedSpan, Terminal } from "./terminal";
 import { unlockOnGesture } from "./unlock";
+import { Warmup } from "./warmup";
 
 // How long the latency target must hold steady before a floor increase re-anchors. Coalesces a
 // slider drag (many small steps) into a single re-anchor once the user settles on a value.
@@ -302,13 +303,12 @@ export class Decoder {
 			const loaded = await Util.Libav.polyfill();
 			if (!loaded) return; // cancelled
 
-			let warmed = 0;
+			const warmup = new Warmup(3);
 
 			const decoder = new AudioDecoder({
 				output: (data) => {
 					const decoded = this.#terminal.span(data);
-					warmed++;
-					if (warmed <= 3) {
+					if (warmup.drop()) {
 						// Drop the first 3 frames to prime the decoder.
 						data.close();
 						return;
@@ -338,6 +338,7 @@ export class Decoder {
 				const next = await consumer.next();
 				if (!next) break;
 				if (this.#onNext(next)) {
+					warmup.reset();
 					decoder.reset();
 					decoder.configure(decoderConfig);
 				}

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -11,6 +11,7 @@ import { type AudioBuffer, createAudioBuffer } from "./buffer";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
+import { terminalFrames } from "./terminal";
 import { unlockOnGesture } from "./unlock";
 
 // How long the latency target must hold steady before a floor increase re-anchors. Coalesces a
@@ -84,6 +85,9 @@ export class Decoder {
 	// The last discontinuity count seen from the container consumer. A change means the
 	// publisher rewound the timeline (e.g. a voice agent interrupted) and we must flush.
 	#discontinuity = 0;
+
+	// Exclusive source endpoint carried before terminal codec drain packets.
+	#terminalEnd?: Time.Micro;
 
 	// How much buffered audio the container consumer retains before skipping
 	// ahead. This must be the latency CEILING (maxBuffer), not the floor
@@ -279,6 +283,7 @@ export class Decoder {
 	}
 
 	#runLegacyDecoder(effect: Effect, sub: Moq.Track.Subscriber, config: Catalog.AudioConfig): void {
+		this.#terminalEnd = undefined;
 		const format = config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer with slightly less latency than the render worklet to avoid underflowing.
 		// TODO include JITTER_UNDERHEAD
@@ -332,6 +337,10 @@ export class Decoder {
 			for (;;) {
 				const next = await consumer.next();
 				if (!next) break;
+				if (next.end !== undefined) {
+					this.#terminalEnd = next.end;
+					continue;
+				}
 
 				// Publisher rewound the timeline: flush + re-anchor before decoding the new frame.
 				this.#onDiscontinuity(next.discontinuity);
@@ -367,6 +376,7 @@ export class Decoder {
 
 	#runCmafDecoder(effect: Effect, sub: Moq.Track.Subscriber, config: Catalog.AudioConfig): void {
 		if (config.container.kind !== "cmaf") return; // just to help typescript
+		this.#terminalEnd = undefined;
 
 		const initSegment = base64ToBytes(config.container.init);
 		const init = Container.Cmaf.decodeInitSegment(initSegment);
@@ -448,6 +458,11 @@ export class Decoder {
 	#emit(sample: AudioData) {
 		const timestamp = sample.timestamp as Time.Micro;
 		const timestampMilli = Time.Milli.fromMicro(timestamp);
+		const frames = terminalFrames(sample, this.#terminalEnd);
+		if (frames === 0) {
+			sample.close();
+			return;
+		}
 
 		const ring = this.#ring;
 		if (!ring) {
@@ -467,7 +482,7 @@ export class Decoder {
 		}
 
 		// Calculate end time from sample duration
-		const durationMicro = ((sample.numberOfFrames / sample.sampleRate) * 1_000_000) as Time.Micro;
+		const durationMicro = ((frames / sample.sampleRate) * 1_000_000) as Time.Micro;
 		const durationMilli = Time.Milli.fromMicro(durationMicro);
 		const end = Time.Milli.add(timestampMilli, durationMilli);
 
@@ -479,8 +494,8 @@ export class Decoder {
 		const channels = Math.min(sample.numberOfChannels, ring.channels);
 		const channelData: Float32Array[] = [];
 		for (let channel = 0; channel < channels; channel++) {
-			const data = new Float32Array(sample.numberOfFrames);
-			sample.copyTo(data, { format: "f32-planar", planeIndex: channel });
+			const data = new Float32Array(frames);
+			sample.copyTo(data, { format: "f32-planar", planeIndex: channel, frameCount: frames });
 			channelData.push(data);
 		}
 
@@ -534,6 +549,7 @@ export class Decoder {
 	#onDiscontinuity(count: number): void {
 		if (count === this.#discontinuity) return;
 		this.#discontinuity = count;
+		this.#terminalEnd = undefined;
 		this.#ring?.reset();
 		this.sync.reset();
 	}

--- a/js/watch/src/audio/terminal.test.ts
+++ b/js/watch/src/audio/terminal.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type { Time } from "@moq/net";
-import { terminalFrames } from "./terminal";
+import { Terminal, terminalFrames } from "./terminal";
 
 test("terminalFrames trims a partial Opus packet to the source endpoint", () => {
 	const frames = terminalFrames({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }, 17_916 as Time.Micro);
@@ -15,4 +15,16 @@ test("terminalFrames drops drain output starting at the source endpoint", () => 
 test("terminalFrames preserves samples before the source endpoint", () => {
 	const frames = terminalFrames({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }, 20_000 as Time.Micro);
 	expect(frames).toBe(960);
+});
+
+test("a rewound endpoint survives the discontinuity reset and trims its terminal packet", () => {
+	const terminal = new Terminal();
+	terminal.update({ discontinuity: 0, end: 40_000 as Time.Micro });
+
+	const reset = terminal.update({ discontinuity: 1, end: 20_000 as Time.Micro });
+	expect(reset).toBe(true);
+	expect(terminal.end).toBe(20_000 as Time.Micro);
+
+	const frames = terminalFrames({ timestamp: 20_000, sampleRate: 48_000, numberOfFrames: 960 }, terminal.end);
+	expect(frames).toBe(0);
 });

--- a/js/watch/src/audio/terminal.test.ts
+++ b/js/watch/src/audio/terminal.test.ts
@@ -1,30 +1,54 @@
 import { expect, test } from "bun:test";
 import type { Time } from "@moq/net";
-import { Terminal, terminalFrames } from "./terminal";
+import { Terminal } from "./terminal";
 
-test("terminalFrames trims a partial Opus packet to the source endpoint", () => {
-	const frames = terminalFrames({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }, 17_916 as Time.Micro);
-	expect(frames).toBe(860);
+test("Terminal trims a partial packet to the source endpoint", () => {
+	const terminal = new Terminal();
+	terminal.update({ discontinuity: 0, frame: { timestamp: 0 as Time.Micro }, end: 17_916 as Time.Micro });
+	expect(terminal.span({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }).frames).toBe(860);
 });
 
-test("terminalFrames drops drain output starting at the source endpoint", () => {
-	const frames = terminalFrames({ timestamp: 20_000, sampleRate: 48_000, numberOfFrames: 960 }, 20_000 as Time.Micro);
-	expect(frames).toBe(0);
+test("Terminal maps Opus delay back before trimming terminal output", () => {
+	const terminal = new Terminal();
+	terminal.clear(312);
+	terminal.update({ discontinuity: 0, frame: { timestamp: 0 as Time.Micro } });
+	const body = terminal.span({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 });
+	expect(body).toEqual({ timestamp: 0 as Time.Micro, frameOffset: 312, frames: 648 });
+
+	terminal.update({ discontinuity: 0, end: 20_000 as Time.Micro });
+	terminal.update({ discontinuity: 0, frame: { timestamp: 20_000 as Time.Micro } });
+	const drain = terminal.span({ timestamp: 20_000, sampleRate: 48_000, numberOfFrames: 960 });
+	expect(drain).toEqual({ timestamp: 13_500 as Time.Micro, frameOffset: 0, frames: 312 });
+	expect(body.frames + drain.frames).toBe(960);
 });
 
-test("terminalFrames preserves samples before the source endpoint", () => {
-	const frames = terminalFrames({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }, 20_000 as Time.Micro);
-	expect(frames).toBe(960);
+test("Terminal preserves samples before the source endpoint", () => {
+	const terminal = new Terminal();
+	terminal.update({ discontinuity: 0, frame: { timestamp: 0 as Time.Micro }, end: 20_000 as Time.Micro });
+	expect(terminal.span({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }).frames).toBe(960);
 });
 
 test("a rewound endpoint survives the discontinuity reset and trims its terminal packet", () => {
 	const terminal = new Terminal();
+	terminal.clear(312);
 	terminal.update({ discontinuity: 0, end: 40_000 as Time.Micro });
 
 	const reset = terminal.update({ discontinuity: 1, end: 20_000 as Time.Micro });
 	expect(reset).toBe(true);
 	expect(terminal.end).toBe(20_000 as Time.Micro);
 
-	const frames = terminalFrames({ timestamp: 20_000, sampleRate: 48_000, numberOfFrames: 960 }, terminal.end);
-	expect(frames).toBe(0);
+	terminal.update({ discontinuity: 1, frame: { timestamp: 20_000 as Time.Micro } });
+	const span = terminal.span({ timestamp: 20_000, sampleRate: 48_000, numberOfFrames: 960 });
+	expect(span).toEqual({ timestamp: 20_000 as Time.Micro, frameOffset: 312, frames: 0 });
+});
+
+test("a discontinuity reapplies Opus pre-skip in the resumed epoch", () => {
+	const terminal = new Terminal();
+	terminal.clear(312);
+	terminal.update({ discontinuity: 0, frame: { timestamp: 0 as Time.Micro } });
+	expect(terminal.span({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }).frameOffset).toBe(312);
+
+	terminal.update({ discontinuity: 1, frame: { timestamp: 1_000_000 as Time.Micro } });
+	const resumed = terminal.span({ timestamp: 1_000_000, sampleRate: 48_000, numberOfFrames: 960 });
+	expect(resumed).toEqual({ timestamp: 1_000_000 as Time.Micro, frameOffset: 312, frames: 648 });
 });

--- a/js/watch/src/audio/terminal.test.ts
+++ b/js/watch/src/audio/terminal.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import type { Time } from "@moq/net";
+import { terminalFrames } from "./terminal";
+
+test("terminalFrames trims a partial Opus packet to the source endpoint", () => {
+	const frames = terminalFrames({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }, 17_916 as Time.Micro);
+	expect(frames).toBe(860);
+});
+
+test("terminalFrames drops drain output starting at the source endpoint", () => {
+	const frames = terminalFrames({ timestamp: 20_000, sampleRate: 48_000, numberOfFrames: 960 }, 20_000 as Time.Micro);
+	expect(frames).toBe(0);
+});
+
+test("terminalFrames preserves samples before the source endpoint", () => {
+	const frames = terminalFrames({ timestamp: 0, sampleRate: 48_000, numberOfFrames: 960 }, 20_000 as Time.Micro);
+	expect(frames).toBe(960);
+});

--- a/js/watch/src/audio/terminal.ts
+++ b/js/watch/src/audio/terminal.ts
@@ -1,0 +1,17 @@
+import type { Time } from "@moq/net";
+
+interface SampleSpan {
+	readonly timestamp: number;
+	readonly sampleRate: number;
+	readonly numberOfFrames: number;
+}
+
+/** Return the source frames before an exclusive terminal endpoint. */
+export function terminalFrames(sample: SampleSpan, end?: Time.Micro): number {
+	if (end === undefined) return sample.numberOfFrames;
+	if (end <= sample.timestamp) return 0;
+
+	const duration = end - sample.timestamp;
+	const frames = Math.round((duration * sample.sampleRate) / 1_000_000);
+	return Math.min(frames, sample.numberOfFrames);
+}

--- a/js/watch/src/audio/terminal.ts
+++ b/js/watch/src/audio/terminal.ts
@@ -6,6 +6,39 @@ interface SampleSpan {
 	readonly numberOfFrames: number;
 }
 
+interface Update {
+	readonly discontinuity: number;
+	readonly end?: Time.Micro;
+}
+
+/** Track discontinuities and their ordered terminal endpoint metadata. */
+export class Terminal {
+	#discontinuity = 0;
+	#end?: Time.Micro;
+
+	/** The exclusive source endpoint most recently received. */
+	get end(): Time.Micro | undefined {
+		return this.#end;
+	}
+
+	/** Reset state for a new container consumer. */
+	clear(): void {
+		this.#discontinuity = 0;
+		this.#end = undefined;
+	}
+
+	/** Apply one ordered consumer result and report whether its timeline rewound. */
+	update(next: Update): boolean {
+		const reset = next.discontinuity !== this.#discontinuity;
+		if (reset) {
+			this.#discontinuity = next.discontinuity;
+			this.#end = undefined;
+		}
+		if (next.end !== undefined) this.#end = next.end;
+		return reset;
+	}
+}
+
 /** Return the source frames before an exclusive terminal endpoint. */
 export function terminalFrames(sample: SampleSpan, end?: Time.Micro): number {
 	if (end === undefined) return sample.numberOfFrames;

--- a/js/watch/src/audio/terminal.ts
+++ b/js/watch/src/audio/terminal.ts
@@ -9,42 +9,81 @@ interface SampleSpan {
 interface Update {
 	readonly discontinuity: number;
 	readonly end?: Time.Micro;
+	readonly frame?: { readonly timestamp: Time.Micro };
 }
 
-/** Track discontinuities and their ordered terminal endpoint metadata. */
+/** The portion of decoded audio that belongs to the source timeline. */
+export interface DecodedSpan {
+	/** Source timestamp of the first retained frame. */
+	readonly timestamp: Time.Micro;
+	/** Decoded frames to skip before copying. */
+	readonly frameOffset: number;
+	/** Decoded frames to retain after the offset. */
+	readonly frames: number;
+}
+
+/** Track codec epochs and map decoded output onto the source timeline. */
 export class Terminal {
 	#discontinuity = 0;
 	#end?: Time.Micro;
+	#epoch?: Time.Micro;
+	#preSkip = 0;
+	#preSkipRemaining?: number;
 
 	/** The exclusive source endpoint most recently received. */
 	get end(): Time.Micro | undefined {
 		return this.#end;
 	}
 
-	/** Reset state for a new container consumer. */
-	clear(): void {
+	/** Reset state for a new container consumer with Opus pre-skip in 48 kHz frames. */
+	clear(preSkip = 0): void {
 		this.#discontinuity = 0;
 		this.#end = undefined;
+		this.#preSkip = preSkip;
+		this.#resetEpoch();
 	}
 
-	/** Apply one ordered consumer result and report whether its timeline rewound. */
+	/** Apply one ordered consumer result and report whether its codec epoch changed. */
 	update(next: Update): boolean {
 		const reset = next.discontinuity !== this.#discontinuity;
 		if (reset) {
 			this.#discontinuity = next.discontinuity;
 			this.#end = undefined;
+			this.#resetEpoch();
 		}
+		if (next.frame && this.#epoch === undefined) this.#epoch = next.frame.timestamp;
 		if (next.end !== undefined) this.#end = next.end;
 		return reset;
 	}
-}
 
-/** Return the source frames before an exclusive terminal endpoint. */
-export function terminalFrames(sample: SampleSpan, end?: Time.Micro): number {
-	if (end === undefined) return sample.numberOfFrames;
-	if (end <= sample.timestamp) return 0;
+	/** Remove codec pre-skip and terminal padding from one decoded sample. */
+	span(sample: SampleSpan): DecodedSpan {
+		const epoch = this.#epoch ?? (sample.timestamp as Time.Micro);
+		this.#epoch = epoch;
 
-	const duration = end - sample.timestamp;
-	const frames = Math.round((duration * sample.sampleRate) / 1_000_000);
-	return Math.min(frames, sample.numberOfFrames);
+		const delayFrames = Math.floor((this.#preSkip * sample.sampleRate) / 48_000);
+		const remaining = this.#preSkipRemaining ?? delayFrames;
+		const frameOffset = Math.min(remaining, sample.numberOfFrames);
+		this.#preSkipRemaining = remaining - frameOffset;
+
+		const delay = Math.round((delayFrames * 1_000_000) / sample.sampleRate);
+		const timestamp = Math.max(epoch, sample.timestamp - delay) as Time.Micro;
+		let frames = sample.numberOfFrames - frameOffset;
+		if (this.#end !== undefined) {
+			if (this.#end <= timestamp) {
+				frames = 0;
+			} else {
+				const duration = this.#end - timestamp;
+				const terminalFrames = Math.round((duration * sample.sampleRate) / 1_000_000);
+				frames = Math.min(frames, terminalFrames);
+			}
+		}
+
+		return { timestamp, frameOffset, frames };
+	}
+
+	#resetEpoch(): void {
+		this.#epoch = undefined;
+		this.#preSkipRemaining = undefined;
+	}
 }

--- a/js/watch/src/audio/warmup.test.ts
+++ b/js/watch/src/audio/warmup.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+import { Warmup } from "./warmup";
+
+test("decoder warm-up restarts for each codec epoch", () => {
+	const warmup = new Warmup(3);
+
+	expect([warmup.drop(), warmup.drop(), warmup.drop(), warmup.drop()]).toEqual([true, true, true, false]);
+	warmup.reset();
+	expect([warmup.drop(), warmup.drop(), warmup.drop(), warmup.drop()]).toEqual([true, true, true, false]);
+});

--- a/js/watch/src/audio/warmup.test.ts
+++ b/js/watch/src/audio/warmup.test.ts
@@ -1,10 +1,14 @@
 import { expect, test } from "bun:test";
 import { Warmup } from "./warmup";
 
-test("decoder warm-up restarts for each codec epoch", () => {
+test("decoder warm-up drops only the configured initial callbacks", () => {
 	const warmup = new Warmup(3);
 
-	expect([warmup.drop(), warmup.drop(), warmup.drop(), warmup.drop()]).toEqual([true, true, true, false]);
-	warmup.reset();
-	expect([warmup.drop(), warmup.drop(), warmup.drop(), warmup.drop()]).toEqual([true, true, true, false]);
+	expect([warmup.drop(), warmup.drop(), warmup.drop(), warmup.drop(), warmup.drop()]).toEqual([
+		true,
+		true,
+		true,
+		false,
+		false,
+	]);
 });

--- a/js/watch/src/audio/warmup.ts
+++ b/js/watch/src/audio/warmup.ts
@@ -1,17 +1,10 @@
-/** Tracks decoder callbacks discarded after each codec configuration. */
+/** Tracks decoder callbacks discarded during initial playback setup. */
 export class Warmup {
-	#frames: number;
 	#remaining: number;
 
-	/** Create a warm-up window containing `frames` decoder callbacks. */
-	constructor(frames: number) {
-		this.#frames = frames;
-		this.#remaining = frames;
-	}
-
-	/** Restart the warm-up window for a fresh codec epoch. */
-	reset(): void {
-		this.#remaining = this.#frames;
+	/** Create a warm-up window containing `callbacks` decoder callbacks. */
+	constructor(callbacks: number) {
+		this.#remaining = callbacks;
 	}
 
 	/** Consume one callback and report whether it belongs to the warm-up window. */

--- a/js/watch/src/audio/warmup.ts
+++ b/js/watch/src/audio/warmup.ts
@@ -1,0 +1,23 @@
+/** Tracks decoder callbacks discarded after each codec configuration. */
+export class Warmup {
+	#frames: number;
+	#remaining: number;
+
+	/** Create a warm-up window containing `frames` decoder callbacks. */
+	constructor(frames: number) {
+		this.#frames = frames;
+		this.#remaining = frames;
+	}
+
+	/** Restart the warm-up window for a fresh codec epoch. */
+	reset(): void {
+		this.#remaining = this.#frames;
+	}
+
+	/** Consume one callback and report whether it belongs to the warm-up window. */
+	drop(): boolean {
+		if (this.#remaining === 0) return false;
+		this.#remaining--;
+		return true;
+	}
+}

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -63,7 +63,6 @@ cpal = { version = "0.18", optional = true }
 # `fft-resampler` stays off, matching the sinc-only stance below.
 fixed-resample = { version = "0.12", optional = true, default-features = false, features = ["channel", "resampler"] }
 hang = { workspace = true }
-kio = { workspace = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
 # We only use the sinc resampler (Async::new_sinc), so skip the default

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -63,6 +63,7 @@ cpal = { version = "0.18", optional = true }
 # `fft-resampler` stays off, matching the sinc-only stance below.
 fixed-resample = { version = "0.12", optional = true, default-features = false, features = ["channel", "resampler"] }
 hang = { workspace = true }
+kio = { workspace = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
 # We only use the sinc resampler (Async::new_sinc), so skip the default

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -1,6 +1,10 @@
 //! Subscribe to an encoded audio track and emit raw PCM.
 
-use bytes::Bytes;
+use std::task::{Poll, ready};
+
+use bytes::{Buf, Bytes};
+
+use moq_mux::container::{Container as ContainerTrait, Frame as MuxFrame};
 
 use super::decoder::{Config, Decoder};
 use crate::resample::{Resampler, remix, validate_channels};
@@ -14,7 +18,7 @@ use crate::{Error, Frame};
 /// [`read`](Self::read) returns plain [`Frame`]s.
 pub struct Consumer {
 	decoder: Decoder,
-	track: moq_mux::container::Consumer<moq_mux::catalog::hang::Container>,
+	track: moq_mux::container::Consumer<AudioContainer>,
 	resampler: Option<Resampler>,
 	config: Config,
 	resolved_sample_rate: u32,
@@ -22,6 +26,64 @@ pub struct Consumer {
 	/// One past the last sample handed to the resampler, so the tail it is still
 	/// holding at end of track can be stamped. `None` until the first packet.
 	tail: Option<moq_net::Timestamp>,
+	/// Timestamp of the first encoded packet, used to interpret a terminal marker.
+	epoch: Option<moq_net::Timestamp>,
+	/// Codec-rate terminal frames emitted since `terminal_start`.
+	frames_decoded: usize,
+	/// Logical endpoint carried by an empty legacy frame before terminal packets.
+	end: Option<moq_net::Timestamp>,
+	/// Presentation time of the first decoded terminal frame.
+	terminal_start: Option<moq_net::Timestamp>,
+}
+
+/// Runtime container dispatch that preserves legacy endpoint markers for audio trimming.
+enum AudioContainer {
+	Legacy,
+	Other(moq_mux::catalog::hang::Container),
+}
+
+impl AudioContainer {
+	fn new(container: &hang::catalog::Container) -> Result<Self, moq_mux::Error> {
+		match container {
+			hang::catalog::Container::Legacy => Ok(Self::Legacy),
+			_ => Ok(Self::Other(moq_mux::catalog::hang::Container::try_from(container)?)),
+		}
+	}
+}
+
+impl ContainerTrait for AudioContainer {
+	type Error = moq_mux::Error;
+
+	fn write(&self, group: &mut moq_net::group::Producer, frames: &[MuxFrame]) -> Result<(), Self::Error> {
+		match self {
+			Self::Legacy => moq_mux::container::legacy::Wire.write(group, frames),
+			Self::Other(container) => container.write(group, frames),
+		}
+	}
+
+	fn poll_read(
+		&self,
+		group: &mut moq_net::group::Consumer,
+		waiter: &kio::Waiter,
+	) -> Poll<Result<Option<Vec<MuxFrame>>, Self::Error>> {
+		let Self::Legacy = self else {
+			let Self::Other(container) = self else { unreachable!() };
+			return container.poll_read(group, waiter);
+		};
+
+		let Some(data) = ready!(group.poll_read_frame(waiter).map_err(hang::Error::from)?) else {
+			return Poll::Ready(Ok(None));
+		};
+		let mut frame = hang::container::Frame::decode(data.payload)?;
+		let payload = frame.payload.copy_to_bytes(frame.payload.remaining());
+
+		Poll::Ready(Ok(Some(vec![MuxFrame {
+			timestamp: frame.timestamp,
+			payload,
+			keyframe: false,
+			duration: None,
+		}])))
+	}
 }
 
 impl Consumer {
@@ -58,7 +120,7 @@ impl Consumer {
 		// The catalog says how the track is framed, and it is not always the legacy
 		// wire: `moq import fmp4` publishes CMAF. Reading a moof+mdat fragment as a
 		// varint timestamp plus a payload decodes to garbage rather than failing.
-		let container = moq_mux::catalog::hang::Container::try_from(&catalog.container)?;
+		let container = AudioContainer::new(&catalog.container)?;
 		let mut track = moq_mux::container::Consumer::new(track, container);
 		if let Some(latency) = config.latency_max {
 			track = track.with_latency(latency);
@@ -72,6 +134,10 @@ impl Consumer {
 			resolved_sample_rate: sample_rate,
 			resolved_channels: channels,
 			tail: None,
+			epoch: None,
+			frames_decoded: 0,
+			end: None,
+			terminal_start: None,
 		})
 	}
 
@@ -94,31 +160,61 @@ impl Consumer {
 
 	/// Read the next decoded PCM frame, or `None` when the track ends.
 	pub async fn read(&mut self) -> Result<Option<Frame>, Error> {
-		let Some(mux_frame) = self.track.read().await? else {
-			return self.flush();
-		};
+		loop {
+			let Some(mux_frame) = self.track.read().await? else {
+				return self.flush();
+			};
 
-		let rate = self.decoder.sample_rate();
-		let decoded = self.decoder.decode(&mux_frame.payload)?;
-		let frames = decoded.len() / self.decoder.channel_count().max(1) as usize;
-
-		let (pcm, timestamp) = match self.resampler.as_mut() {
-			// The resampler works in fixed chunks, so it holds back whatever didn't
-			// fill one. What comes out next starts with those held-back samples, which
-			// arrived before this packet did: stamping it with this packet's timestamp
-			// would place the audio late by up to a chunk, sawtoothing A/V sync.
-			Some(r) => {
-				let pending = r.pending_frames();
-				let skipped = r.skipped();
-				let pcm = r.process(&decoded)?;
-				(pcm, self.starts_at(mux_frame.timestamp, pending, skipped, rate)?)
+			if mux_frame.payload.is_empty() {
+				self.end = Some(mux_frame.timestamp);
+				self.frames_decoded = 0;
+				self.terminal_start = None;
+				continue;
 			}
-			None => (decoded, mux_frame.timestamp),
-		};
 
-		self.tail = Some(advance(mux_frame.timestamp, frames, rate)?);
+			let rate = self.decoder.sample_rate();
+			let epoch = *self.epoch.get_or_insert(mux_frame.timestamp);
+			let mut decoded = self.decoder.decode(&mux_frame.payload)?;
+			if let Some(end) = self.end {
+				let terminal_start = *self
+					.terminal_start
+					.get_or_insert(rewind(mux_frame.timestamp, self.decoder.delay(), rate)?.max(epoch));
+				let total = frames_between(terminal_start, end, rate)?;
+				let remaining = total.saturating_sub(self.frames_decoded);
+				decoded.truncate(remaining.saturating_mul(self.decoder.channel_count() as usize));
+			}
 
-		Ok(Some(self.frame(pcm, timestamp)?))
+			let frames = decoded.len() / self.decoder.channel_count().max(1) as usize;
+			let decoded_at = if let Some(terminal_start) = self.terminal_start {
+				advance(terminal_start, self.frames_decoded, rate)?
+			} else {
+				mux_frame.timestamp
+			};
+			if self.end.is_some() {
+				self.frames_decoded += frames;
+			}
+			if decoded.is_empty() {
+				continue;
+			}
+
+			let (pcm, timestamp) = match self.resampler.as_mut() {
+				// The resampler works in fixed chunks, so it holds back whatever didn't
+				// fill one. What comes out next starts with those held-back samples, which
+				// arrived before this packet did: stamping it with this packet's timestamp
+				// would place the audio late by up to a chunk, sawtoothing A/V sync.
+				Some(r) => {
+					let pending = r.pending_frames();
+					let skipped = r.skipped();
+					let pcm = r.process(&decoded)?;
+					(pcm, self.starts_at(decoded_at, pending, skipped, rate)?)
+				}
+				None => (decoded, decoded_at),
+			};
+
+			self.tail = Some(advance(decoded_at, frames, rate)?);
+
+			return Ok(Some(self.frame(pcm, timestamp)?));
+		}
 	}
 
 	/// The tail the resampler is still holding when the track ends, once.
@@ -186,6 +282,13 @@ fn advance(timestamp: moq_net::Timestamp, frames: usize, sample_rate: u32) -> Re
 
 	let offset = moq_net::Timestamp::from_scale(frames as u64, sample_rate as u64)?.convert(timestamp.scale())?;
 	Ok(timestamp.checked_add(offset)?)
+}
+
+/// Codec-rate frames in the interval, rounding a microsecond marker to the nearest frame.
+fn frames_between(start: moq_net::Timestamp, end: moq_net::Timestamp, sample_rate: u32) -> Result<usize, Error> {
+	let duration = end.checked_sub(start)?;
+	let frames = (std::time::Duration::from(duration).as_nanos() * sample_rate as u128 + 500_000_000) / 1_000_000_000;
+	usize::try_from(frames).map_err(|_| Error::Unsupported("audio duration does not fit in memory".into()))
 }
 
 /// `timestamp` moved back by `frames` at `sample_rate`, in its own timescale.

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -1,10 +1,6 @@
 //! Subscribe to an encoded audio track and emit raw PCM.
 
-use std::task::{Poll, ready};
-
-use bytes::{Buf, Bytes};
-
-use moq_mux::container::{Container as ContainerTrait, Frame as MuxFrame};
+use bytes::Bytes;
 
 use super::decoder::{Config, Decoder};
 use crate::resample::{Resampler, remix, validate_channels};
@@ -18,7 +14,7 @@ use crate::{Error, Frame};
 /// [`read`](Self::read) returns plain [`Frame`]s.
 pub struct Consumer {
 	decoder: Decoder,
-	track: moq_mux::container::Consumer<AudioContainer>,
+	track: moq_mux::container::Consumer<moq_mux::catalog::hang::Container>,
 	resampler: Option<Resampler>,
 	config: Config,
 	resolved_sample_rate: u32,
@@ -34,56 +30,6 @@ pub struct Consumer {
 	end: Option<moq_net::Timestamp>,
 	/// Presentation time of the first decoded terminal frame.
 	terminal_start: Option<moq_net::Timestamp>,
-}
-
-/// Runtime container dispatch that preserves legacy endpoint markers for audio trimming.
-enum AudioContainer {
-	Legacy,
-	Other(moq_mux::catalog::hang::Container),
-}
-
-impl AudioContainer {
-	fn new(container: &hang::catalog::Container) -> Result<Self, moq_mux::Error> {
-		match container {
-			hang::catalog::Container::Legacy => Ok(Self::Legacy),
-			_ => Ok(Self::Other(moq_mux::catalog::hang::Container::try_from(container)?)),
-		}
-	}
-}
-
-impl ContainerTrait for AudioContainer {
-	type Error = moq_mux::Error;
-
-	fn write(&self, group: &mut moq_net::group::Producer, frames: &[MuxFrame]) -> Result<(), Self::Error> {
-		match self {
-			Self::Legacy => moq_mux::container::legacy::Wire.write(group, frames),
-			Self::Other(container) => container.write(group, frames),
-		}
-	}
-
-	fn poll_read(
-		&self,
-		group: &mut moq_net::group::Consumer,
-		waiter: &kio::Waiter,
-	) -> Poll<Result<Option<Vec<MuxFrame>>, Self::Error>> {
-		let Self::Legacy = self else {
-			let Self::Other(container) = self else { unreachable!() };
-			return container.poll_read(group, waiter);
-		};
-
-		let Some(data) = ready!(group.poll_read_frame(waiter).map_err(hang::Error::from)?) else {
-			return Poll::Ready(Ok(None));
-		};
-		let mut frame = hang::container::Frame::decode(data.payload)?;
-		let payload = frame.payload.copy_to_bytes(frame.payload.remaining());
-
-		Poll::Ready(Ok(Some(vec![MuxFrame {
-			timestamp: frame.timestamp,
-			payload,
-			keyframe: false,
-			duration: None,
-		}])))
-	}
 }
 
 impl Consumer {
@@ -120,7 +66,7 @@ impl Consumer {
 		// The catalog says how the track is framed, and it is not always the legacy
 		// wire: `moq import fmp4` publishes CMAF. Reading a moof+mdat fragment as a
 		// varint timestamp plus a payload decodes to garbage rather than failing.
-		let container = AudioContainer::new(&catalog.container)?;
+		let container = moq_mux::catalog::hang::Container::try_from(&catalog.container)?;
 		let mut track = moq_mux::container::Consumer::new(track, container);
 		if let Some(latency) = config.latency_max {
 			track = track.with_latency(latency);
@@ -165,11 +111,12 @@ impl Consumer {
 				return self.flush();
 			};
 
-			if mux_frame.payload.is_empty() {
-				self.end = Some(mux_frame.timestamp);
+			if let Some(end) = self.track.end()
+				&& self.end != Some(end)
+			{
+				self.end = Some(end);
 				self.frames_decoded = 0;
 				self.terminal_start = None;
-				continue;
 			}
 
 			let rate = self.decoder.sample_rate();

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -30,6 +30,8 @@ pub struct Consumer {
 	end: Option<moq_net::Timestamp>,
 	/// Presentation time of the first decoded terminal frame.
 	terminal_start: Option<moq_net::Timestamp>,
+	/// Last container discontinuity applied to codec and resampler state.
+	discontinuity: u64,
 }
 
 impl Consumer {
@@ -84,6 +86,7 @@ impl Consumer {
 			frames_decoded: 0,
 			end: None,
 			terminal_start: None,
+			discontinuity: 0,
 		})
 	}
 
@@ -107,7 +110,9 @@ impl Consumer {
 	/// Read the next decoded PCM frame, or `None` when the track ends.
 	pub async fn read(&mut self) -> Result<Option<Frame>, Error> {
 		loop {
-			let Some(mux_frame) = self.track.read().await? else {
+			let mux_frame = self.track.read().await?;
+			self.apply_discontinuity()?;
+			let Some(mux_frame) = mux_frame else {
 				return self.flush();
 			};
 
@@ -162,6 +167,26 @@ impl Consumer {
 
 			return Ok(Some(self.frame(pcm, timestamp)?));
 		}
+	}
+
+	/// Reset every stateful decode stage before the first packet of a new epoch.
+	fn apply_discontinuity(&mut self) -> Result<(), Error> {
+		let discontinuity = self.track.discontinuity();
+		if discontinuity == self.discontinuity {
+			return Ok(());
+		}
+
+		self.discontinuity = discontinuity;
+		self.decoder.reset()?;
+		if let Some(resampler) = self.resampler.as_mut() {
+			resampler.reset();
+		}
+		self.tail = None;
+		self.epoch = None;
+		self.frames_decoded = 0;
+		self.end = None;
+		self.terminal_start = None;
+		Ok(())
 	}
 
 	/// The tail the resampler is still holding when the track ends, once.

--- a/rs/moq-audio/src/decode/decoder.rs
+++ b/rs/moq-audio/src/decode/decoder.rs
@@ -67,6 +67,7 @@ pub struct Decoder {
 	backend: Backend,
 	sample_rate: u32,
 	channel_count: u32,
+	delay: usize,
 }
 
 enum Backend {
@@ -142,6 +143,7 @@ impl Decoder {
 			}),
 			sample_rate,
 			channel_count,
+			delay: pre_skip_remaining,
 		})
 	}
 
@@ -184,6 +186,7 @@ impl Decoder {
 			backend: Backend::Aac(Box::new(Aac { inner })),
 			sample_rate,
 			channel_count: channel_count as u32,
+			delay: 0,
 		})
 	}
 
@@ -209,6 +212,7 @@ impl Decoder {
 			backend: Backend::Pcm { bytes_per_frame },
 			sample_rate: catalog.sample_rate,
 			channel_count: catalog.channel_count,
+			delay: 0,
 		})
 	}
 
@@ -220,6 +224,11 @@ impl Decoder {
 	/// The channel count the codec decodes at, read from the catalog.
 	pub fn channel_count(&self) -> u32 {
 		self.channel_count
+	}
+
+	/// Codec delay trimmed from the beginning of a fresh decoder, in native-rate frames.
+	pub(super) fn delay(&self) -> usize {
+		self.delay
 	}
 
 	/// Decode one packet into interleaved `f32` PCM.

--- a/rs/moq-audio/src/decode/decoder.rs
+++ b/rs/moq-audio/src/decode/decoder.rs
@@ -5,7 +5,10 @@
 
 use std::time::Duration;
 
-use unsafe_libopus::{OPUS_OK, OpusDecoder, opus_decode_float, opus_decoder_create, opus_decoder_destroy};
+use unsafe_libopus::{
+	OPUS_OK, OPUS_RESET_STATE, OpusDecoder, opus_decode_float, opus_decoder_create, opus_decoder_ctl_impl,
+	opus_decoder_destroy, varargs,
+};
 
 #[cfg(feature = "aac")]
 use symphonia_core::codecs::audio::AudioDecoder;
@@ -224,6 +227,24 @@ impl Decoder {
 	/// The channel count the codec decodes at, read from the catalog.
 	pub fn channel_count(&self) -> u32 {
 		self.channel_count
+	}
+
+	/// Reset codec history and reapply startup delay for a new discontinuous epoch.
+	pub fn reset(&mut self) -> Result<(), Error> {
+		match &mut self.backend {
+			Backend::Opus(opus) => {
+				// SAFETY: `inner` owns a live decoder and OPUS_RESET_STATE takes no arguments.
+				let rc = unsafe { opus_decoder_ctl_impl(opus.inner, OPUS_RESET_STATE, varargs![]) };
+				if rc != OPUS_OK {
+					return Err(crate::opus::error(rc, "OPUS_RESET_STATE"));
+				}
+				opus.pre_skip_remaining = self.delay;
+			}
+			Backend::Pcm { .. } => {}
+			#[cfg(feature = "aac")]
+			Backend::Aac(aac) => aac.inner.reset(),
+		}
+		Ok(())
 	}
 
 	/// Codec delay trimmed from the beginning of a fresh decoder, in native-rate frames.

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -139,9 +139,9 @@ impl Config {
 
 /// Audio encoder over the PCM layout declared in [`Config::input`].
 ///
-/// Build one with [`Encoder::new`], feed it PCM via [`encode`](Self::encode),
-/// and publish the resulting packets through a [`Producer`](super::Producer)
-/// built from the same [`Config`].
+/// Build one with [`Encoder::new`], feed full PCM frames via
+/// [`encode`](Self::encode), then pass the trailing partial frame to
+/// [`finish`](Self::finish) and publish every packet either call returns.
 pub struct Encoder {
 	backend: Backend,
 	config: Config,
@@ -154,7 +154,11 @@ pub struct Encoder {
 	bitrate: u64,
 	/// Encoder lookahead expressed in the OpusHead 48 kHz timebase.
 	pre_skip: u16,
+	/// Encoder lookahead in codec-rate frames.
+	lookahead: usize,
 	frame_size: usize,
+	/// Whether input has reached the codec, since a fresh encoder owes no drain.
+	started: bool,
 }
 
 enum Backend {
@@ -206,7 +210,7 @@ impl Encoder {
 		}
 
 		let configured = Self::configure_opus(inner, &config, codec_rate, codec_channels);
-		let (bitrate, pre_skip) = match configured {
+		let (bitrate, lookahead, pre_skip) = match configured {
 			Ok(configured) => configured,
 			Err(err) => {
 				// SAFETY: `inner` was created above and not yet handed out.
@@ -225,7 +229,9 @@ impl Encoder {
 			codec_channels,
 			bitrate,
 			pre_skip,
+			lookahead,
 			frame_size,
+			started: false,
 		})
 	}
 
@@ -262,7 +268,9 @@ impl Encoder {
 			codec_channels,
 			bitrate,
 			pre_skip: 0,
+			lookahead: 0,
 			frame_size,
+			started: false,
 		})
 	}
 
@@ -271,7 +279,7 @@ impl Encoder {
 		config: &Config,
 		codec_rate: u32,
 		codec_channels: u32,
-	) -> Result<(u64, u16), Error> {
+	) -> Result<(u64, usize, u16), Error> {
 		if let Some(bitrate) = config.bitrate {
 			Self::set_opus_bitrate(inner, codec_channels, bitrate as u64)?;
 		}
@@ -291,8 +299,10 @@ impl Encoder {
 			.map_err(|_| Error::Unsupported(format!("Opus reported negative lookahead {lookahead}")))?;
 		let pre_skip = u16::try_from((lookahead * 48_000) / codec_rate as u64)
 			.map_err(|_| Error::Unsupported(format!("Opus lookahead {lookahead} does not fit in OpusHead")))?;
+		let lookahead = usize::try_from(lookahead)
+			.map_err(|_| Error::Unsupported(format!("Opus lookahead {lookahead} does not fit in memory")))?;
 
-		Ok((bitrate, pre_skip))
+		Ok((bitrate, lookahead, pre_skip))
 	}
 
 	fn set_opus_bitrate(inner: *mut OpusEncoder, channels: u32, bitrate: u64) -> Result<(), Error> {
@@ -385,7 +395,7 @@ impl Encoder {
 				expected: expected * std::mem::size_of::<f32>(),
 			});
 		}
-		match &mut self.backend {
+		let packet = match &mut self.backend {
 			Backend::Opus(opus) => {
 				// SAFETY: `inner` owns a live OpusEncoder; pcm and scratch slices
 				// are bounded by the lengths we pass.
@@ -401,16 +411,65 @@ impl Encoder {
 				if n < 0 {
 					return Err(crate::opus::error(n, "opus_encode_float"));
 				}
-				Ok(Bytes::copy_from_slice(&opus.scratch[..n as usize]))
+				Bytes::copy_from_slice(&opus.scratch[..n as usize])
 			}
 			Backend::Pcm => {
 				let mut payload = Vec::with_capacity(std::mem::size_of_val(pcm));
 				for sample in pcm {
 					payload.extend_from_slice(&sample.to_le_bytes());
 				}
-				Ok(payload.into())
+				payload.into()
 			}
+		};
+		self.started = true;
+		Ok(packet)
+	}
+
+	/// Finish encoding, zero-padding `pcm` as the final partial frame and
+	/// returning every packet needed to drain codec lookahead.
+	///
+	/// `pcm` is interleaved at [`codec_rate`](Self::codec_rate), may be empty,
+	/// and must contain at most one frame. Silence added here only drains
+	/// audio already supplied; callers must not count it as source duration.
+	/// Consuming the encoder prevents encoding across the artificial terminal
+	/// padding.
+	pub fn finish(mut self, pcm: &[f32]) -> Result<Vec<Bytes>, Error> {
+		let channels = self.codec_channels as usize;
+		let frame_samples = self.frame_size * channels;
+		if pcm.len() > frame_samples || !pcm.len().is_multiple_of(channels) {
+			return Err(Error::Misaligned {
+				got: std::mem::size_of_val(pcm),
+				expected: if pcm.len() > frame_samples {
+					frame_samples * std::mem::size_of::<f32>()
+				} else {
+					pcm.len().next_multiple_of(channels) * std::mem::size_of::<f32>()
+				},
+			});
 		}
+
+		let mut packets = Vec::new();
+		let padding = if pcm.is_empty() {
+			0
+		} else {
+			let mut frame = Vec::with_capacity(frame_samples);
+			frame.extend_from_slice(pcm);
+			frame.resize(frame_samples, 0.0);
+			let padding = (frame_samples - pcm.len()) / channels;
+			packets.push(self.encode(&frame)?);
+			padding
+		};
+
+		if !self.started {
+			return Ok(packets);
+		}
+
+		let drain = self.lookahead.saturating_sub(padding);
+		let silence = vec![0.0; frame_samples];
+		for _ in 0..drain.div_ceil(self.frame_size) {
+			packets.push(self.encode(&silence)?);
+		}
+
+		Ok(packets)
 	}
 
 	/// hang catalog entry describing this encoder's output stream.
@@ -567,6 +626,38 @@ mod tests {
 
 		let second = dec.decode(&enc.encode(&frame).unwrap()).unwrap();
 		assert_eq!(second.len(), frame.len());
+	}
+
+	#[test]
+	fn opus_finish_accounts_for_partial_frame_padding() {
+		let enc = Encoder::new(&Config::new(Input {
+			channels: 1,
+			..Input::default()
+		}))
+		.unwrap();
+
+		// The 360 frames of terminal padding exceed the 312-frame lookahead,
+		// so the partial packet itself completes the drain.
+		let packets = enc.finish(&vec![0.0; 600]).unwrap();
+		assert_eq!(packets.len(), 1);
+	}
+
+	#[test]
+	fn opus_finish_drains_lookahead_across_multiple_short_packets() {
+		let mut enc = Encoder::new(&Config {
+			frame_duration: Duration::from_micros(2_500),
+			..Config::new(Input {
+				channels: 1,
+				..Input::default()
+			})
+		})
+		.unwrap();
+		let frame = vec![0.0; enc.frame_size()];
+		enc.encode(&frame).unwrap();
+
+		// Three 120-frame packets are required to push out 312 frames.
+		let packets = enc.finish(&[]).unwrap();
+		assert_eq!(packets.len(), 3);
 	}
 
 	#[test]

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -9,9 +9,9 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use unsafe_libopus::{
-	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK, OPUS_SET_BITRATE_REQUEST,
-	OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder, opus_encode_float, opus_encoder_create,
-	opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
+	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK, OPUS_RESET_STATE,
+	OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder, opus_encode_float,
+	opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
 };
 
 use crate::opus;
@@ -141,7 +141,8 @@ impl Config {
 ///
 /// Build one with [`Encoder::new`], feed full PCM frames via
 /// [`encode`](Self::encode), then pass the trailing partial frame to
-/// [`finish`](Self::finish) and publish every packet either call returns.
+/// [`finish`](Self::finish). Publish every packet either call returns and apply
+/// the terminal [`Finish::discard_padding`] when the container supports it.
 pub struct Encoder {
 	backend: Backend,
 	config: Config,
@@ -175,6 +176,29 @@ struct Opus {
 // struct; libopus encoder methods take a single &mut, so a unique owner is
 // allowed to move it across threads.
 unsafe impl Send for Opus {}
+
+/// Packets emitted by [`Encoder::finish`] and the decoded padding at their end.
+pub struct Finish {
+	packets: Vec<Bytes>,
+	discard_padding: usize,
+}
+
+impl Finish {
+	/// Encoded packets in decode order.
+	pub fn packets(&self) -> &[Bytes] {
+		&self.packets
+	}
+
+	/// Decoded frames per channel to discard from the end of the final packet.
+	pub fn discard_padding(&self) -> usize {
+		self.discard_padding
+	}
+
+	/// Consume the result and return its encoded packets.
+	pub fn into_packets(self) -> Vec<Bytes> {
+		self.packets
+	}
+}
 
 impl Encoder {
 	/// Open an encoder for `config`.
@@ -382,6 +406,16 @@ impl Encoder {
 		Ok(())
 	}
 
+	/// Drop all codec history so a later epoch cannot emit audio from this one.
+	pub(super) fn reset(&mut self) {
+		if let Backend::Opus(opus) = &mut self.backend {
+			// SAFETY: `inner` owns a live encoder and OPUS_RESET_STATE takes no arguments.
+			let rc = unsafe { opus_encoder_ctl_impl(opus.inner, OPUS_RESET_STATE, varargs![]) };
+			debug_assert_eq!(rc, OPUS_OK, "OPUS_RESET_STATE failed with {rc}");
+		}
+		self.started = false;
+	}
+
 	/// Encode one frame of interleaved `f32` PCM at [`codec_rate`](Self::codec_rate).
 	///
 	/// `pcm.len()` must equal `frame_size() * codec_channels()`. The
@@ -430,10 +464,11 @@ impl Encoder {
 	///
 	/// `pcm` is interleaved at [`codec_rate`](Self::codec_rate), may be empty,
 	/// and must contain at most one frame. Silence added here only drains
-	/// audio already supplied; callers must not count it as source duration.
+	/// audio already supplied; [`Finish::discard_padding`] reports how much of
+	/// the decoded tail is artificial and must not count as source duration.
 	/// Consuming the encoder prevents encoding across the artificial terminal
 	/// padding.
-	pub fn finish(mut self, pcm: &[f32]) -> Result<Vec<Bytes>, Error> {
+	pub fn finish(mut self, pcm: &[f32]) -> Result<Finish, Error> {
 		let channels = self.codec_channels as usize;
 		let frame_samples = self.frame_size * channels;
 		if pcm.len() > frame_samples || !pcm.len().is_multiple_of(channels) {
@@ -447,6 +482,7 @@ impl Encoder {
 			});
 		}
 
+		let source_frames = pcm.len() / channels;
 		let mut packets = Vec::new();
 		let padding = if pcm.is_empty() {
 			0
@@ -460,7 +496,10 @@ impl Encoder {
 		};
 
 		if !self.started {
-			return Ok(packets);
+			return Ok(Finish {
+				packets,
+				discard_padding: 0,
+			});
 		}
 
 		let drain = self.lookahead.saturating_sub(padding);
@@ -469,7 +508,16 @@ impl Encoder {
 			packets.push(self.encode(&silence)?);
 		}
 
-		Ok(packets)
+		let discard_padding = packets
+			.len()
+			.saturating_mul(self.frame_size)
+			.saturating_sub(self.lookahead)
+			.saturating_sub(source_frames);
+
+		Ok(Finish {
+			packets,
+			discard_padding,
+		})
 	}
 
 	/// hang catalog entry describing this encoder's output stream.
@@ -639,7 +687,8 @@ mod tests {
 		// The 360 frames of terminal padding exceed the 312-frame lookahead,
 		// so the partial packet itself completes the drain.
 		let packets = enc.finish(&vec![0.0; 600]).unwrap();
-		assert_eq!(packets.len(), 1);
+		assert_eq!(packets.packets().len(), 1);
+		assert_eq!(packets.discard_padding(), 48);
 	}
 
 	#[test]
@@ -657,7 +706,33 @@ mod tests {
 
 		// Three 120-frame packets are required to push out 312 frames.
 		let packets = enc.finish(&[]).unwrap();
-		assert_eq!(packets.len(), 3);
+		assert_eq!(packets.packets().len(), 3);
+		assert_eq!(packets.discard_padding(), 48);
+	}
+
+	#[test]
+	fn reset_drops_pending_opus_lookahead() {
+		let mut enc = Encoder::new(&Config::new(Input {
+			channels: 1,
+			..Input::default()
+		}))
+		.unwrap();
+		let mut old = vec![0.0; enc.frame_size()];
+		old[enc.frame_size() - 1] = 1.0;
+		enc.encode(&old).unwrap();
+
+		enc.reset();
+		let next = vec![0.0; enc.frame_size()];
+		let actual = enc.encode(&next).unwrap();
+		let mut decoder = Decoder::new(&enc.catalog()).unwrap();
+		let decoded = decoder.decode(&actual).unwrap();
+		let peak = decoded.iter().fold(0.0f32, |peak, sample| peak.max(sample.abs()));
+		assert!(peak < 0.001, "pre-reset impulse leaked into the next epoch: {peak}");
+
+		enc.reset();
+		let finish = enc.finish(&[]).unwrap();
+		assert!(finish.packets().is_empty());
+		assert_eq!(finish.discard_padding(), 0);
 	}
 
 	#[test]

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -416,6 +416,11 @@ impl Encoder {
 		self.started = false;
 	}
 
+	/// Whether this epoch has submitted audio to the codec.
+	pub(super) fn started(&self) -> bool {
+		self.started
+	}
+
 	/// Encode one frame of interleaved `f32` PCM at [`codec_rate`](Self::codec_rate).
 	///
 	/// `pcm.len()` must equal `frame_size() * codec_channels()`. The

--- a/rs/moq-audio/src/encode/mod.rs
+++ b/rs/moq-audio/src/encode/mod.rs
@@ -24,7 +24,7 @@ mod producer;
 #[cfg(feature = "capture")]
 mod capture;
 
-pub use encoder::{Codec, Config, Encoder, Input};
+pub use encoder::{Codec, Config, Encoder, Finish, Input};
 pub use producer::{Options, Producer};
 
 #[cfg(feature = "capture")]

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -234,21 +234,25 @@ impl<E: CatalogExt> Producer<E> {
 			let chunk: Vec<f32> = self.pending.drain(..frame_samples).collect();
 			let packet = self.encoder.encode(&chunk)?;
 
-			let timestamp = self.timestamp(epoch_us)?;
+			let timestamp = Self::timestamp(epoch_us, self.frames_produced, self.encoder.codec_rate())?;
 			self.frames_produced += self.encoder.frame_size() as u64;
-			self.publish(packet, timestamp)?;
+			Self::publish(&mut self.track, packet, timestamp)?;
 		}
 
 		Ok(())
 	}
 
 	/// PTS of the next frame: the epoch plus the samples emitted since it.
-	fn timestamp(&self, epoch_us: u64) -> Result<Timestamp, Error> {
-		let offset_us = (self.frames_produced * 1_000_000) / self.encoder.codec_rate() as u64;
+	fn timestamp(epoch_us: u64, frames_produced: u64, codec_rate: u32) -> Result<Timestamp, Error> {
+		let offset_us = (frames_produced * 1_000_000) / codec_rate as u64;
 		Ok(Timestamp::from_micros(epoch_us + offset_us)?)
 	}
 
-	fn publish(&mut self, payload: Bytes, timestamp: Timestamp) -> Result<(), Error> {
+	fn publish(
+		track: &mut moq_mux::container::Producer<moq_mux::container::legacy::Wire>,
+		payload: Bytes,
+		timestamp: Timestamp,
+	) -> Result<(), Error> {
 		// Publish each audio packet as its own moq-lite group: write it as a keyframe, then cut
 		// (below) so the relay forwards it without waiting for the next. Codecs can recover
 		// independently after a dropped group.
@@ -258,10 +262,10 @@ impl<E: CatalogExt> Producer<E> {
 			keyframe: true,
 			duration: None,
 		};
-		self.track.write(mux_frame)?;
+		track.write(mux_frame)?;
 		// No boundary to give: the next packet bounds this one, and Opus frames have a
 		// deterministic duration anyway.
-		self.track.cut(None)?;
+		track.cut(None)?;
 		Ok(())
 	}
 
@@ -277,8 +281,8 @@ impl<E: CatalogExt> Producer<E> {
 		Ok(())
 	}
 
-	/// Flush any pending samples (zero-padded to a full frame) and finalize the
-	/// track.
+	/// Flush pending samples, resampler output, and codec lookahead, then finalize
+	/// the track.
 	pub fn finish(mut self) -> Result<(), Error> {
 		// Whatever the resampler still holds belongs to this track: its last partial
 		// chunk, plus the audio its filter is running behind on. Dropping it here
@@ -287,18 +291,18 @@ impl<E: CatalogExt> Producer<E> {
 			self.pending.extend(resampler.flush()?);
 		}
 
-		// The drained tail can be longer than one frame, and the `resize` below
-		// would truncate it rather than encode it.
+		// The drained resampler tail can span multiple frames. Publish those first
+		// so only the final partial frame reaches the encoder's terminal drain.
 		let epoch_us = self.epoch_us.unwrap_or(0);
 		self.publish_full_frames(epoch_us)?;
 
-		let frame_samples = self.encoder.frame_size() * self.encoder.codec_channels() as usize;
-		if !self.pending.is_empty() {
-			self.pending.resize(frame_samples, 0.0);
-			let chunk = std::mem::take(&mut self.pending);
-			let packet = self.encoder.encode(&chunk)?;
-			let timestamp = self.timestamp(epoch_us)?;
-			self.publish(packet, timestamp)?;
+		let frame_size = self.encoder.frame_size();
+		let codec_rate = self.encoder.codec_rate();
+		let packets = self.encoder.finish(&self.pending)?;
+		for packet in packets {
+			let timestamp = Self::timestamp(epoch_us, self.frames_produced, codec_rate)?;
+			Self::publish(&mut self.track, packet, timestamp)?;
+			self.frames_produced += frame_size as u64;
 		}
 
 		self.track.finish()?;
@@ -331,6 +335,61 @@ impl<E: CatalogExt> Drop for Rendition<E> {
 mod tests {
 	use super::*;
 	use crate::Format;
+	use crate::decode::Decoder;
+
+	/// Opus retains its final lookahead until later input pushes it into a
+	/// packet. Ending exactly on a codec-frame boundary used to leave no pending
+	/// producer buffer to pad, so the track dropped that tail outright. A nearly
+	/// full partial frame failed the same way when its padding was too short.
+	#[tokio::test]
+	async fn finish_publishes_the_opus_lookahead_tail() {
+		for frames in [960, 860] {
+			let input = Input {
+				format: Format::F32,
+				sample_rate: 48_000,
+				channels: 1,
+			};
+			let options = Options {
+				track: Some("audio".to_string()),
+				bitrate: Some(128_000),
+				..Options::default()
+			};
+			let mut decoder = Decoder::new(&Encoder::new(&options.config(input.clone())).unwrap().catalog()).unwrap();
+
+			let mut broadcast = moq_net::broadcast::Info::new().produce();
+			let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+			let consumer = broadcast.consume();
+			let mut producer = Producer::new(&mut broadcast, catalog, input, &options).unwrap();
+			let mut track = moq_mux::container::Consumer::new(
+				consumer
+					.track("audio")
+					.unwrap()
+					.subscribe(moq_net::track::Subscription::default())
+					.await
+					.unwrap(),
+				moq_mux::catalog::hang::Container::Legacy,
+			);
+
+			let mut pcm = vec![0.0f32; frames];
+			let impulse = pcm.len() - 100;
+			pcm[impulse] = 1.0;
+			let data: Vec<u8> = pcm.iter().flat_map(|sample| sample.to_le_bytes()).collect();
+			producer
+				.write(&Frame {
+					timestamp: Timestamp::ZERO,
+					data: Bytes::from(data),
+				})
+				.unwrap();
+			producer.finish().unwrap();
+
+			let mut decoded = Vec::new();
+			while let Some(packet) = track.read().await.unwrap() {
+				decoded.extend(decoder.decode(&packet.payload).unwrap());
+			}
+			let peak = decoded.iter().fold(0.0f32, |peak, sample| peak.max(sample.abs()));
+			assert!(peak > 0.1, "the {frames}-frame Opus tail lost the impulse: peak {peak}");
+		}
+	}
 
 	/// A resampled publisher used to end its track early: `finish` flushed the
 	/// encoder's own buffer but left the resampler holding its last partial chunk,

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -102,6 +102,14 @@ pub struct Producer<E: CatalogExt = ()> {
 	epoch_us: Option<u64>,
 }
 
+struct Terminal {
+	packets: Vec<Bytes>,
+	end: Timestamp,
+	start: Timestamp,
+	frame_size: usize,
+	codec_rate: u32,
+}
+
 impl<E: CatalogExt> Producer<E> {
 	/// Publish a track encoding `input` into `broadcast`, registering its
 	/// rendition in `catalog` immediately.
@@ -188,6 +196,7 @@ impl<E: CatalogExt> Producer<E> {
 		self.epoch_us = None;
 		self.frames_produced = 0;
 		self.pending.clear();
+		self.encoder.reset();
 		// The resampler holds samples of its own, plus filter state primed by them.
 		// Left alone, `finish` would flush that pre-reset audio onto the track
 		// (stamped at an epoch that no longer exists), and the next write would run
@@ -269,6 +278,33 @@ impl<E: CatalogExt> Producer<E> {
 		Ok(())
 	}
 
+	/// Publish terminal packets after an empty frame that carries their logical endpoint.
+	fn publish_terminal(
+		track: &mut moq_mux::container::Producer<moq_mux::container::legacy::Wire>,
+		terminal: Terminal,
+	) -> Result<(), Error> {
+		track.write(MuxFrame {
+			timestamp: terminal.end,
+			payload: Bytes::new(),
+			keyframe: true,
+			duration: None,
+		})?;
+
+		for (index, packet) in terminal.packets.into_iter().enumerate() {
+			let offset = Timestamp::from_scale((index * terminal.frame_size) as u64, terminal.codec_rate as u64)?
+				.convert(terminal.start.scale())?;
+			track.write(MuxFrame {
+				timestamp: terminal.start.checked_add(offset)?,
+				payload: packet,
+				keyframe: false,
+				duration: None,
+			})?;
+		}
+
+		track.cut(Some(terminal.end))?;
+		Ok(())
+	}
+
 	/// Mark a break in the published timeline: whatever is published next does not continue
 	/// what came before.
 	///
@@ -298,11 +334,31 @@ impl<E: CatalogExt> Producer<E> {
 
 		let frame_size = self.encoder.frame_size();
 		let codec_rate = self.encoder.codec_rate();
-		let packets = self.encoder.finish(&self.pending)?;
-		for packet in packets {
-			let timestamp = Self::timestamp(epoch_us, self.frames_produced, codec_rate)?;
-			Self::publish(&mut self.track, packet, timestamp)?;
-			self.frames_produced += frame_size as u64;
+		let channels = self.encoder.codec_channels() as usize;
+		let source_frames = self.pending.len() / channels;
+		let start = Self::timestamp(epoch_us, self.frames_produced, codec_rate)?;
+		let end = Self::timestamp(epoch_us, self.frames_produced + source_frames as u64, codec_rate)?;
+		let finish = self.encoder.finish(&self.pending)?;
+		let discard_padding = finish.discard_padding();
+		let packets = finish.into_packets();
+
+		if discard_padding > 0 {
+			Self::publish_terminal(
+				&mut self.track,
+				Terminal {
+					packets,
+					end,
+					start,
+					frame_size,
+					codec_rate,
+				},
+			)?;
+		} else {
+			for packet in packets {
+				let timestamp = Self::timestamp(epoch_us, self.frames_produced, codec_rate)?;
+				Self::publish(&mut self.track, packet, timestamp)?;
+				self.frames_produced += frame_size as u64;
+			}
 		}
 
 		self.track.finish()?;
@@ -335,12 +391,9 @@ impl<E: CatalogExt> Drop for Rendition<E> {
 mod tests {
 	use super::*;
 	use crate::Format;
-	use crate::decode::Decoder;
+	use crate::decode::{Config as DecodeConfig, Consumer as AudioConsumer};
 
-	/// Opus retains its final lookahead until later input pushes it into a
-	/// packet. Ending exactly on a codec-frame boundary used to leave no pending
-	/// producer buffer to pad, so the track dropped that tail outright. A nearly
-	/// full partial frame failed the same way when its padding was too short.
+	/// Terminal Opus lookahead samples survive both exact-frame and partial-frame input.
 	#[tokio::test]
 	async fn finish_publishes_the_opus_lookahead_tail() {
 		for frames in [960, 860] {
@@ -354,21 +407,15 @@ mod tests {
 				bitrate: Some(128_000),
 				..Options::default()
 			};
-			let mut decoder = Decoder::new(&Encoder::new(&options.config(input.clone())).unwrap().catalog()).unwrap();
+			let decoder_config = Encoder::new(&options.config(input.clone())).unwrap().catalog();
 
 			let mut broadcast = moq_net::broadcast::Info::new().produce();
 			let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 			let consumer = broadcast.consume();
 			let mut producer = Producer::new(&mut broadcast, catalog, input, &options).unwrap();
-			let mut track = moq_mux::container::Consumer::new(
-				consumer
-					.track("audio")
-					.unwrap()
-					.subscribe(moq_net::track::Subscription::default())
-					.await
-					.unwrap(),
-				moq_mux::catalog::hang::Container::Legacy,
-			);
+			let mut audio = AudioConsumer::new(&consumer, &decoder_config, "audio", DecodeConfig::new())
+				.await
+				.unwrap();
 
 			let mut pcm = vec![0.0f32; frames];
 			let impulse = pcm.len() - 100;
@@ -383,9 +430,11 @@ mod tests {
 			producer.finish().unwrap();
 
 			let mut decoded = Vec::new();
-			while let Some(packet) = track.read().await.unwrap() {
-				decoded.extend(decoder.decode(&packet.payload).unwrap());
+			while let Some(frame) = audio.read().await.unwrap() {
+				let pcm = Format::F32.as_interleaved_f32(&frame.data, 1).unwrap();
+				decoded.extend_from_slice(&pcm);
 			}
+			assert_eq!(decoded.len(), frames, "terminal padding extended the source");
 			let peak = decoded.iter().fold(0.0f32, |peak, sample| peak.max(sample.abs()));
 			assert!(peak > 0.1, "the {frames}-frame Opus tail lost the impulse: peak {peak}");
 		}
@@ -484,6 +533,44 @@ mod tests {
 		producer.finish().unwrap();
 
 		// The reset dropped everything, so the track ends without a packet.
+		assert!(track.read().await.unwrap().is_none());
+	}
+
+	/// Resetting after a full frame drops codec lookahead as well as producer buffers.
+	#[tokio::test]
+	async fn reset_epoch_drops_the_encoder_lookahead() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let consumer = broadcast.consume();
+		let options = Options {
+			track: Some("audio".to_string()),
+			..Options::default()
+		};
+		let mut producer = Producer::new(
+			&mut broadcast,
+			catalog,
+			Input {
+				channels: 1,
+				..Input::default()
+			},
+			&options,
+		)
+		.unwrap();
+		let mut track = moq_mux::container::Consumer::new(
+			consumer
+				.track("audio")
+				.unwrap()
+				.subscribe(moq_net::track::Subscription::default())
+				.await
+				.unwrap(),
+			moq_mux::catalog::hang::Container::Legacy,
+		);
+
+		producer.write(&full_frame(1_000_000)).unwrap();
+		producer.reset_epoch();
+		producer.finish().unwrap();
+
+		assert!(track.read().await.unwrap().is_some());
 		assert!(track.read().await.unwrap().is_none());
 	}
 

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -100,6 +100,10 @@ pub struct Producer<E: CatalogExt = ()> {
 	/// (re)start. Emitted PTS = `epoch + frames_produced / codec_rate`. `None`
 	/// until the first write so the next frame re-anchors to its timestamp.
 	epoch_us: Option<u64>,
+	/// An encoder reset that still needs an empty group before its next packet.
+	pending_discontinuity: bool,
+	/// Whether an empty group already separates the next packet from prior codec state.
+	decoder_boundary: bool,
 }
 
 struct Terminal {
@@ -162,6 +166,8 @@ impl<E: CatalogExt> Producer<E> {
 			pending: Vec::new(),
 			frames_produced: 0,
 			epoch_us: None,
+			pending_discontinuity: false,
+			decoder_boundary: true,
 		})
 	}
 
@@ -191,8 +197,16 @@ impl<E: CatalogExt> Producer<E> {
 	/// released-then-reopened microphone) so the gap appears in the PTS and
 	/// audio stays aligned with a wall-clock video track, rather than the gap
 	/// being compressed out by the running sample count. Mirrors moq-boy's
-	/// `reset_epoch`.
+	/// `reset_epoch`. If the codec had started, an empty group is published before
+	/// the next packet so subscribers reset their decoders too.
 	pub fn reset_epoch(&mut self) {
+		if self.encoder.started() && !self.decoder_boundary {
+			self.pending_discontinuity = true;
+		}
+		self.reset_state();
+	}
+
+	fn reset_state(&mut self) {
 		self.epoch_us = None;
 		self.frames_produced = 0;
 		self.pending.clear();
@@ -218,6 +232,12 @@ impl<E: CatalogExt> Producer<E> {
 	/// the next frame's wall-clock stamp); writing straight across a gap without
 	/// resetting compresses it out.
 	pub fn write(&mut self, frame: &Frame) -> Result<(), Error> {
+		if self.pending_discontinuity {
+			self.track.discontinuity()?;
+			self.pending_discontinuity = false;
+			self.decoder_boundary = true;
+		}
+
 		let timestamp_us = u64::try_from(frame.timestamp.as_micros())
 			.map_err(|_| Error::Unsupported(format!("frame timestamp {:?} out of range", frame.timestamp)))?;
 		let epoch_us = *self.epoch_us.get_or_insert(timestamp_us);
@@ -246,6 +266,7 @@ impl<E: CatalogExt> Producer<E> {
 			let timestamp = Self::timestamp(epoch_us, self.frames_produced, self.encoder.codec_rate())?;
 			self.frames_produced += self.encoder.frame_size() as u64;
 			Self::publish(&mut self.track, packet, timestamp)?;
+			self.decoder_boundary = false;
 		}
 
 		Ok(())
@@ -305,15 +326,17 @@ impl<E: CatalogExt> Producer<E> {
 		Ok(())
 	}
 
-	/// Mark a break in the published timeline: whatever is published next does not continue
-	/// what came before.
+	/// Mark a break in the published timeline and reset codec state.
 	///
-	/// Call this when capture stops rather than merely gapping between packets -- going idle,
-	/// switching source, anything that resumes on a re-anchored epoch (see
-	/// [`reset_epoch`](Self::reset_epoch)). See
+	/// Call this when capture stops rather than merely gapping between packets: going idle,
+	/// switching source, or anything else that resumes on a re-anchored epoch. Buffered samples
+	/// are dropped, and the next frame anchors a fresh codec epoch. See
 	/// [`Producer::discontinuity`](moq_mux::container::Producer::discontinuity).
 	pub fn discontinuity(&mut self) -> Result<(), Error> {
 		self.track.discontinuity()?;
+		self.pending_discontinuity = false;
+		self.decoder_boundary = true;
+		self.reset_state();
 		Ok(())
 	}
 
@@ -572,6 +595,52 @@ mod tests {
 
 		assert!(track.read().await.unwrap().is_some());
 		assert!(track.read().await.unwrap().is_none());
+	}
+
+	/// A codec reset starts a new pre-skip interval at the receiver too.
+	#[tokio::test]
+	async fn reset_epoch_restarts_the_decoder() {
+		let input = Input {
+			format: Format::F32,
+			sample_rate: 48_000,
+			channels: 1,
+		};
+		let options = Options {
+			track: Some("audio".to_string()),
+			..Options::default()
+		};
+		let decoder_config = Encoder::new(&options.config(input.clone())).unwrap().catalog();
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let subscriber = broadcast.consume();
+		let mut producer = Producer::new(&mut broadcast, catalog, input, &options).unwrap();
+		let mut audio = AudioConsumer::new(
+			&subscriber,
+			&decoder_config,
+			"audio",
+			DecodeConfig {
+				latency_max: Some(Duration::from_millis(500)),
+				..DecodeConfig::new()
+			},
+		)
+		.await
+		.unwrap();
+
+		producer.write(&full_frame(0)).unwrap();
+		let first = audio.read().await.unwrap().expect("first epoch packet");
+		assert_eq!(first.data.len() / size_of::<f32>(), 960 - 312);
+
+		producer.reset_epoch();
+		producer.write(&full_frame(1_000_000)).unwrap();
+		producer.finish().unwrap();
+
+		let mut resumed_frames = 0;
+		while let Some(frame) = audio.read().await.unwrap() {
+			assert!(frame.timestamp.as_micros() >= 1_000_000);
+			resumed_frames += frame.data.len() / size_of::<f32>();
+		}
+		assert_eq!(resumed_frames, 960, "the resumed epoch must trim its own pre-skip once");
 	}
 
 	// One 20 ms Opus frame at 48 kHz mono is exactly 960 f32 samples, so each

--- a/rs/moq-mux/src/catalog/hang/container.rs
+++ b/rs/moq-mux/src/catalog/hang/container.rs
@@ -49,6 +49,14 @@ pub(crate) fn supported(rendition: &str, container: &hang::catalog::Container) -
 impl ContainerTrait for Container {
 	type Error = crate::Error;
 
+	fn end(&self, frame: &Frame) -> Option<moq_net::Timestamp> {
+		match self {
+			Self::Legacy => legacy::Wire.end(frame),
+			Self::Cmaf(cmaf) => cmaf.end(frame),
+			Self::Loc => loc::Wire.end(frame),
+		}
+	}
+
 	fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 		match self {
 			Self::Legacy => legacy::Wire.write(group, frames),

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -556,6 +556,7 @@ impl GroupBuffer {
 		};
 
 		for mut frame in frames {
+			let marker = format.end(&frame).is_some();
 			self.min_timestamp = Some(match self.min_timestamp {
 				Some(existing) => existing.min(frame.timestamp),
 				None => frame.timestamp,
@@ -578,8 +579,10 @@ impl GroupBuffer {
 
 			// First frame of a group is always a keyframe by protocol invariant; trust
 			// the container's flag otherwise so CMAF mid-group keyframes survive.
-			frame.keyframe = frame.keyframe || self.index == 0;
-			self.index += 1;
+			if !marker {
+				frame.keyframe = frame.keyframe || self.index == 0;
+				self.index += 1;
+			}
 
 			self.buffered.push_back(frame);
 		}
@@ -1142,6 +1145,33 @@ mod tests {
 		assert_eq!(frames[0].timestamp, ts(0));
 		assert_eq!(frames[1].timestamp, ts(33_000));
 		assert_eq!(consumer.end(), Some(ts(50_000)), "the latest endpoint is exposed");
+	}
+
+	#[tokio::test]
+	async fn leading_marker_preserves_the_first_media_keyframe() {
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
+		write_marker(&mut group, ts(20_000));
+		Container::Legacy
+			.write(
+				&mut group,
+				&[Frame {
+					timestamp: ts(20_000),
+					payload: Bytes::from_static(&[0xDE, 0xAD]),
+					keyframe: false,
+					duration: None,
+				}],
+			)
+			.unwrap();
+		group.finish().unwrap();
+		track.finish().unwrap();
+
+		let frame = consumer.read().await.unwrap().unwrap();
+		assert!(frame.keyframe, "the marker does not consume the first-media slot");
+		assert_eq!(consumer.end(), Some(ts(20_000)));
 	}
 
 	/// Reading a marker consumes its frame, so a run of them makes progress and the

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -32,12 +32,12 @@ use super::{Container, Frame};
 /// Set the latency with [`with_latency`](Self::with_latency) (builder) or
 /// [`set_latency`](Self::set_latency) (mid-stream).
 ///
-/// ## Timeline rewinds
+/// ## Timeline discontinuities
 ///
-/// If a newer group's timestamps jump backwards past the live edge, the publisher is
-/// reneging the buffered tail (e.g. a voice agent interrupted mid-utterance). The consumer
-/// drops the reneged groups, resumes at the rewound timeline, and bumps
-/// [`discontinuity`](Self::discontinuity) so downstream consumers can flush their own
+/// An empty group declares a codec boundary. A newer group whose timestamps jump backwards
+/// past the live edge also reneges the buffered tail (e.g. a voice agent interrupted
+/// mid-utterance). The consumer bumps [`discontinuity`](Self::discontinuity) for either,
+/// dropping reneged groups when needed so downstream consumers can reset codec and render
 /// buffers. This is always on.
 pub struct Consumer<F: Container> {
 	track: moq_net::track::Subscriber,
@@ -57,7 +57,7 @@ pub struct Consumer<F: Container> {
 	// The maximum buffer size before skipping a group.
 	latency: std::time::Duration,
 
-	// Timeline-rewind tracking: the live edge, the active boundary, and the discontinuity count.
+	// Timeline-discontinuity tracking: the live edge, rewind boundary, and event count.
 	rewind: Rewind,
 
 	// Exclusive endpoint from the most recently delivered legacy end marker.
@@ -66,10 +66,8 @@ pub struct Consumer<F: Container> {
 
 /// Live state for detecting timeline rewinds and classifying out-of-order groups.
 ///
-/// A publisher reneges its buffered tail by rewinding timestamps while group sequence keeps
-/// climbing (e.g. a voice agent interrupted mid-utterance). We track the live edge to spot the
-/// jump, a [`Reset`] boundary to classify out-of-order groups across it, and a counter that
-/// downstream consumers watch to flush their own queues.
+/// Tracks the live edge and [`Reset`] boundary used to classify a timestamp rewind, plus the
+/// counter shared by rewinds and explicit empty-group discontinuities.
 #[derive(Default)]
 struct Rewind {
 	// The live edge of playback: the largest timestamp delivered so far and the group that
@@ -80,8 +78,8 @@ struct Rewind {
 	// late new-epoch group is kept while a reneged old-epoch straggler is dropped.
 	boundary: Option<Reset>,
 
-	// Increments on every rewind. Downstream consumers compare it across reads and, when it
-	// changes, drop media still queued in their decoder or render buffers.
+	// Increments on every declared discontinuity or rewind. Downstream consumers compare it
+	// across reads and reset codec and render buffers when it changes.
 	discontinuity: u64,
 }
 
@@ -154,14 +152,14 @@ impl<F: Container> Consumer<F> {
 		self
 	}
 
-	/// A counter that increments each time the consumer detects a timeline rewind and drops
-	/// the reneged buffer.
+	/// A counter that increments each time the consumer reaches a declared discontinuity or
+	/// detects a timeline rewind and drops the reneged buffer.
 	///
-	/// When a newer group's timestamps jump backwards past the live edge, the publisher is
-	/// reneging everything buffered after that point (e.g. a voice agent interrupted
-	/// mid-utterance). Downstream consumers should compare this across reads and, when it
-	/// changes, flush any media still queued in their decoder or render buffers. The frame
-	/// returned by the read that bumps it is the first of the new timeline.
+	/// A publisher declares a discontinuity with an empty group. A newer group whose timestamps
+	/// jump backwards past the live edge also reneges everything buffered after that point.
+	/// Downstream consumers should compare this across reads and, when it changes, reset codec
+	/// state and flush media still queued in decoder or render buffers. The frame returned by
+	/// the read that bumps it is the first of the new timeline.
 	pub fn discontinuity(&self) -> u64 {
 		self.rewind.discontinuity
 	}
@@ -265,8 +263,15 @@ impl<F: Container> Consumer<F> {
 					}
 					// Cleanly finished group: advance to the next sequence.
 					Poll::Ready(Ok(None)) => {
+						let empty = group.empty;
 						self.pending.pop_front();
 						self.current += 1;
+						if empty {
+							self.rewind.discontinuity += 1;
+							self.rewind.live_edge = None;
+							self.rewind.boundary = None;
+							self.end = None;
+						}
 					}
 				}
 			}
@@ -447,6 +452,7 @@ impl<F: Container> Consumer<F> {
 		});
 
 		self.rewind.discontinuity += 1;
+		self.end = None;
 		tracing::debug!(
 			prev_max = reset.prev_max,
 			group = reset.group,
@@ -508,6 +514,10 @@ struct GroupBuffer {
 	// The current frame index within the group.
 	index: usize,
 
+	// Whether the group has carried any wire frame. A cleanly finished group with
+	// none is an explicit discontinuity marker.
+	empty: bool,
+
 	// Read frames that haven't been consumed yet.
 	buffered: VecDeque<Frame>,
 
@@ -528,6 +538,7 @@ impl GroupBuffer {
 		Self {
 			group,
 			index: 0,
+			empty: true,
 			buffered: VecDeque::new(),
 			max_timestamp: None,
 			min_timestamp: None,
@@ -554,6 +565,7 @@ impl GroupBuffer {
 		let Some(frames) = ready!(format.poll_read(&mut self.group, waiter)?) else {
 			return Poll::Ready(Ok(false));
 		};
+		self.empty = false;
 
 		for mut frame in frames {
 			let marker = format.end(&frame).is_some();
@@ -796,6 +808,27 @@ mod tests {
 
 		// Next read returns None (track ended)
 		assert!(consumer.read().await.unwrap().is_none());
+	}
+
+	#[tokio::test]
+	async fn empty_group_declares_a_discontinuity() {
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		write_group(&mut track, 0, &[ts(0)]);
+		track
+			.create_group(moq_net::group::Info { sequence: 1 })
+			.unwrap()
+			.finish()
+			.unwrap();
+		write_group(&mut track, 2, &[ts(1_000_000)]);
+		track.finish().unwrap();
+
+		assert_eq!(consumer.read().await.unwrap().unwrap().timestamp, ts(0));
+		assert_eq!(consumer.discontinuity(), 0);
+		assert_eq!(consumer.read().await.unwrap().unwrap().timestamp, ts(1_000_000));
+		assert_eq!(consumer.discontinuity(), 1);
 	}
 
 	#[tokio::test]

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -267,10 +267,7 @@ impl<F: Container> Consumer<F> {
 						self.pending.pop_front();
 						self.current += 1;
 						if empty {
-							self.rewind.discontinuity += 1;
-							self.rewind.live_edge = None;
-							self.rewind.boundary = None;
-							self.end = None;
+							self.mark_discontinuities(1);
 						}
 					}
 				}
@@ -340,7 +337,13 @@ impl<F: Container> Consumer<F> {
 			if let Some((new_idx, _)) = next_group
 				&& should_skip
 			{
+				let discontinuities = self
+					.pending
+					.iter_mut()
+					.take(new_idx)
+					.fold(0, |count, group| count + u64::from(group.poll_empty(waiter)));
 				self.pending.drain(0..new_idx);
+				self.mark_discontinuities(discontinuities);
 				let new_current = self.pending.front().map(|g| g.sequence).unwrap();
 
 				tracing::debug!(old = self.current, new = new_current, "skipping slow groups");
@@ -355,6 +358,17 @@ impl<F: Container> Consumer<F> {
 
 			return Poll::Pending;
 		}
+	}
+
+	fn mark_discontinuities(&mut self, count: u64) {
+		if count == 0 {
+			return;
+		}
+
+		self.rewind.discontinuity += count;
+		self.rewind.live_edge = None;
+		self.rewind.boundary = None;
+		self.end = None;
 	}
 
 	// Reads any new groups from the track until we're completely finished.
@@ -666,6 +680,10 @@ impl GroupBuffer {
 	fn poll_aborted(&mut self, waiter: &kio::Waiter) -> bool {
 		matches!(self.group.poll_finished(waiter), Poll::Ready(Err(_)))
 	}
+
+	fn poll_empty(&mut self, waiter: &kio::Waiter) -> bool {
+		self.empty && matches!(self.group.poll_finished(waiter), Poll::Ready(Ok(_)))
+	}
 }
 
 impl std::ops::Deref for GroupBuffer {
@@ -823,6 +841,27 @@ mod tests {
 			.finish()
 			.unwrap();
 		write_group(&mut track, 2, &[ts(1_000_000)]);
+		track.finish().unwrap();
+
+		assert_eq!(consumer.read().await.unwrap().unwrap().timestamp, ts(0));
+		assert_eq!(consumer.discontinuity(), 0);
+		assert_eq!(consumer.read().await.unwrap().unwrap().timestamp, ts(1_000_000));
+		assert_eq!(consumer.discontinuity(), 1);
+	}
+
+	#[tokio::test]
+	async fn latency_skip_preserves_empty_group_discontinuity() {
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::ZERO);
+
+		write_group(&mut track, 0, &[ts(0)]);
+		track
+			.create_group(moq_net::group::Info { sequence: 2 })
+			.unwrap()
+			.finish()
+			.unwrap();
+		write_group(&mut track, 3, &[ts(1_000_000)]);
 		track.finish().unwrap();
 
 		assert_eq!(consumer.read().await.unwrap().unwrap().timestamp, ts(0));

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -337,11 +337,16 @@ impl<F: Container> Consumer<F> {
 			if let Some((new_idx, _)) = next_group
 				&& should_skip
 			{
-				let discontinuities = self
-					.pending
-					.iter_mut()
-					.take(new_idx)
-					.fold(0, |count, group| count + u64::from(group.poll_empty(waiter)));
+				// A zero-frame group is ambiguous until its FIN arrives. Keep it in order so a
+				// delayed empty-group boundary cannot be discarded before it is recognized.
+				let mut discontinuities = 0;
+				for group in self.pending.iter_mut().take(new_idx) {
+					match group.poll_empty(waiter) {
+						Poll::Ready(true) => discontinuities += 1,
+						Poll::Ready(false) => {}
+						Poll::Pending => return Poll::Pending,
+					}
+				}
 				self.pending.drain(0..new_idx);
 				self.mark_discontinuities(discontinuities);
 				let new_current = self.pending.front().map(|g| g.sequence).unwrap();
@@ -349,6 +354,15 @@ impl<F: Container> Consumer<F> {
 				tracing::debug!(old = self.current, new = new_current, "skipping slow groups");
 
 				self.current = new_current;
+				continue;
+			}
+
+			if finished
+				&& let Some(group) = self.pending.front_mut()
+				&& group.sequence > self.current
+				&& matches!(group.poll_empty(waiter), Poll::Ready(true))
+			{
+				self.current = group.sequence;
 				continue;
 			}
 
@@ -681,8 +695,16 @@ impl GroupBuffer {
 		matches!(self.group.poll_finished(waiter), Poll::Ready(Err(_)))
 	}
 
-	fn poll_empty(&mut self, waiter: &kio::Waiter) -> bool {
-		self.empty && matches!(self.group.poll_finished(waiter), Poll::Ready(Ok(_)))
+	fn poll_empty(&mut self, waiter: &kio::Waiter) -> Poll<bool> {
+		if !self.empty {
+			return Poll::Ready(false);
+		}
+
+		match self.group.poll_finished(waiter) {
+			Poll::Ready(Ok(_)) => Poll::Ready(true),
+			Poll::Ready(Err(_)) => Poll::Ready(false),
+			Poll::Pending => Poll::Pending,
+		}
 	}
 }
 
@@ -856,16 +878,19 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::ZERO);
 
 		write_group(&mut track, 0, &[ts(0)]);
-		track
-			.create_group(moq_net::group::Info { sequence: 2 })
-			.unwrap()
-			.finish()
-			.unwrap();
+		let mut marker = track.create_group(moq_net::group::Info { sequence: 2 }).unwrap();
 		write_group(&mut track, 3, &[ts(1_000_000)]);
-		track.finish().unwrap();
 
 		assert_eq!(consumer.read().await.unwrap().unwrap().timestamp, ts(0));
 		assert_eq!(consumer.discontinuity(), 0);
+		assert!(
+			tokio::time::timeout(Duration::from_millis(20), consumer.read())
+				.await
+				.is_err()
+		);
+
+		marker.finish().unwrap();
+		track.finish().unwrap();
 		assert_eq!(consumer.read().await.unwrap().unwrap().timestamp, ts(1_000_000));
 		assert_eq!(consumer.discontinuity(), 1);
 	}

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -59,6 +59,9 @@ pub struct Consumer<F: Container> {
 
 	// Timeline-rewind tracking: the live edge, the active boundary, and the discontinuity count.
 	rewind: Rewind,
+
+	// Exclusive endpoint from the most recently delivered legacy end marker.
+	end: Option<Timestamp>,
 }
 
 /// Live state for detecting timeline rewinds and classifying out-of-order groups.
@@ -138,6 +141,7 @@ impl<F: Container> Consumer<F> {
 			startup: true,
 			latency: std::time::Duration::ZERO,
 			rewind: Rewind::default(),
+			end: None,
 		}
 	}
 
@@ -160,6 +164,15 @@ impl<F: Container> Consumer<F> {
 	/// returned by the read that bumps it is the first of the new timeline.
 	pub fn discontinuity(&self) -> u64 {
 		self.rewind.discontinuity
+	}
+
+	/// The exclusive media endpoint from the most recently consumed legacy end marker.
+	///
+	/// The marker itself is not returned by [`read`](Self::read). Once this changes,
+	/// decoders should consume any following terminal codec packets but discard decoded
+	/// samples at or after this timestamp.
+	pub fn end(&self) -> Option<Timestamp> {
+		self.end
 	}
 
 	/// Read the next frame from the track.
@@ -216,6 +229,10 @@ impl<F: Container> Consumer<F> {
 			{
 				match group.poll_read(waiter, &self.format) {
 					Poll::Ready(Ok(Some(frame))) => {
+						if let Some(end) = self.format.end(&frame) {
+							self.end = Some(end);
+							continue;
+						}
 						// Track the live edge (the max timestamp and the group that carries it) so a
 						// later backwards jump is detectable and the old epoch's tail is anchored.
 						let seq = group.group.sequence;
@@ -1124,6 +1141,7 @@ mod tests {
 		assert_eq!(frames.len(), 2, "markers are not surfaced as media");
 		assert_eq!(frames[0].timestamp, ts(0));
 		assert_eq!(frames[1].timestamp, ts(33_000));
+		assert_eq!(consumer.end(), Some(ts(50_000)), "the latest endpoint is exposed");
 	}
 
 	/// Reading a marker consumes its frame, so a run of them makes progress and the

--- a/rs/moq-mux/src/container/legacy/mod.rs
+++ b/rs/moq-mux/src/container/legacy/mod.rs
@@ -6,8 +6,6 @@
 
 use std::task::Poll;
 
-use bytes::Buf;
-
 use crate::container::{Container, Frame};
 
 /// Hang Legacy wire format. Stateless; one instance serves every track.
@@ -16,6 +14,10 @@ pub struct Wire;
 
 impl Container for Wire {
 	type Error = crate::Error;
+
+	fn end(&self, frame: &Frame) -> Option<moq_net::Timestamp> {
+		frame.payload.is_empty().then_some(frame.timestamp)
+	}
 
 	fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 		for frame in frames {
@@ -35,26 +37,19 @@ impl Container for Wire {
 	) -> Poll<Result<Option<Vec<Frame>>, Self::Error>> {
 		use std::task::ready;
 
-		loop {
-			let Some(data) = ready!(group.poll_read_frame(waiter).map_err(hang::Error::from)?) else {
-				return Poll::Ready(Ok(None));
-			};
+		let Some(data) = ready!(group.poll_read_frame(waiter).map_err(hang::Error::from)?) else {
+			return Poll::Ready(Ok(None));
+		};
 
-			let mut hang_frame = hang::container::Frame::decode(data.payload)?;
-			if !hang_frame.payload.has_remaining() {
-				continue;
-			}
-
-			let payload = hang_frame.payload.copy_to_bytes(hang_frame.payload.remaining());
-			return Poll::Ready(Ok(Some(vec![Frame {
-				timestamp: hang_frame.timestamp,
-				payload,
-				// Legacy doesn't carry the keyframe bit on the wire; the
-				// wrapping Consumer fills it in from group position.
-				keyframe: false,
-				// Legacy carries no per-frame duration.
-				duration: None,
-			}])));
-		}
+		let hang_frame = hang::container::Frame::decode(data.payload)?;
+		Poll::Ready(Ok(Some(vec![Frame {
+			timestamp: hang_frame.timestamp,
+			payload: hang_frame.payload,
+			// Legacy doesn't carry the keyframe bit on the wire; the
+			// wrapping Consumer fills it in from group position.
+			keyframe: false,
+			// Legacy carries no per-frame duration.
+			duration: None,
+		}])))
 	}
 }

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -111,6 +111,13 @@ pub trait Container {
 		waiter: &kio::Waiter,
 	) -> Poll<Result<Option<Vec<Frame>>, Self::Error>>;
 
+	/// Return the exclusive media endpoint when `frame` is a container marker.
+	///
+	/// Formats without endpoint markers use the default implementation.
+	fn end(&self, _frame: &Frame) -> Option<moq_net::Timestamp> {
+		None
+	}
+
 	/// Async wrapper around [`Self::poll_read`]. Carries the same contract: only
 	/// `Ok(None)` ends the group, and `Ok(Some(batch))` may hand back an empty
 	/// `batch` (poll again for more), so a caller loop must key completion off


### PR DESCRIPTION
## Summary

- drain libopus lookahead when an audio producer finishes, including tracks ending exactly on an encoder-frame boundary
- return terminal discard-padding metadata and publish the logical source endpoint before terminal codec packets
- expose Legacy endpoint markers as ordered metadata in the shared Rust and TypeScript Hang consumers
- signal fresh codec epochs with empty groups and reset native and browser decoders before resumed media
- preserve empty-group codec boundaries when latency skipping crosses them, including delayed group FINs
- account for Opus pre-skip when mapping browser decoder timestamps, then trim decoded output to the source endpoint
- keep browser decoder warm-up limited to initial playback setup so reset epochs retain their source audio
- reset libopus state with each producer epoch so abandoned lookahead cannot leak into a later source or terminal drain

The root cause was that `Producer::finish` drained only producer and resampler buffers. Libopus retains 312 frames of codec lookahead, while decoding the packets needed to release that tail also produces zero-padding that must be discarded. `reset_epoch` likewise cleared outer buffers but left encoder and receiver codec history live. Browser playback also compared endpoint timestamps against decoder output without removing the Opus pre-skip delay. Finally, latency skipping could discard a timestamp-less group before its delayed FIN established that it was a codec boundary. Browser decoder resets must preserve the one-time playback warm-up state because their next callbacks contain resumed source audio.

Closes #2994.

## Public API changes

- adds `moq_audio::encode::Encoder::finish(self, pcm: &[f32]) -> Result<Finish, Error>`, an additive terminal operation for partial-frame padding and codec drain
- adds `moq_audio::encode::Finish` with packet accessors and `discard_padding()` in decoded frames per channel
- adds `moq_audio::decode::Decoder::reset()` for starting a fresh codec epoch
- adds `moq_mux::container::Consumer::end()` for the exclusive endpoint from the latest consumed container marker
- adds optional endpoint recognition to the Rust and TypeScript container format interfaces
- adds `Opus.preSkip` to `@moq/hang/util` for reading the codec delay from Opus configuration

## Test plan

- `just fix`
- `just check`
- `just test` (all affected JS packages and 1,257 Rust tests passed)
- `just drafts check`
- `just test smoke-full` (all 21 Rust, Python, JS, C, and GStreamer publisher/subscriber combinations passed)
- verified exact-frame and partial-frame Opus output preserves the tail and decodes to the original source length
- verified browser pre-skip handling keeps exact-frame source audio and drops only decoded drain output at the endpoint
- verified reset after a full frame emits no abandoned drain packet and no pre-reset impulse in the next epoch
- verified continued native subscriptions reset decoder state and reapply pre-skip after a discontinuity
- verified browser decoder warm-up drops only initial setup callbacks and does not discard resumed-epoch output
- verified Rust and TypeScript latency skipping preserves completed empty-group boundaries and waits for delayed FINs
- verified endpoint markers do not consume the first-media keyframe slot
- verified a rewound endpoint survives its discontinuity reset and trims the following drain packet

## Cross-package sync

The Legacy wire semantics are documented in `draft-lcurley-moq-hang.md`, including empty groups as codec epoch boundaries. Matching endpoint and discontinuity handling is implemented in `moq-mux`, `js/hang`, native `moq-audio`, and browser `js/watch`. Marker detection stays container-specific, so custom formats may still carry legitimate empty media payloads. FFI and command-line surfaces are unaffected.

(Written by GPT-5)
