### PR TITLE
Compile the udp_tokio bench stub off Linux

### DIFF
--- a/rs/moq-uring/benches/udp_tokio.rs
+++ b/rs/moq-uring/benches/udp_tokio.rs
@@ -362,7 +362,7 @@ mod linux {
 use linux::benchmark;
 
 #[cfg(not(target_os = "linux"))]
-fn benchmark(_: &mut Criterion) {}
+fn benchmark(_: &mut criterion::Criterion) {}
 
 criterion_group!(benches, benchmark);
 criterion_main!(benches);


### PR DESCRIPTION
The non-Linux fallback stub in `rs/moq-uring/benches/udp_tokio.rs` references `Criterion` without a path or import, so `cargo test --all-targets` (what `just test` compiles) fails on any macOS checkout. Linux CI never compiles that cfg arm, which is how #3003 landed with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Fable 5)