### PR TITLE
feat(moq-ffi): expose raw video track demand

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -245,7 +245,7 @@ video.Finish()
 
 `AutoEncoder()` prefers a hardware encoder and falls back to software; `SoftwareEncoder()`, `HardwareEncoder()`, and `NamedEncoder("videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `SetBitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-Set `Track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `Used(ctx)` and `Unused(ctx)` monitor subscriber demand, and `Cut()` starts a new group at the next frame.
+Set `Track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `Used(ctx)` and `Unused(ctx)` monitor subscriber demand. Call `Cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
 ## Raw Track Controls
 

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -220,6 +220,7 @@ If a producer is collected without `Finish()`, the underlying library logs a war
 `PublishMedia` takes frames you already encoded. To hand over raw pixels or PCM instead and let the codec run inside the bindings, use `PublishVideo` / `PublishAudio`. Pixel format, resolution, and framerate are fixed at publish time, so each frame carries only its pixels and a timestamp:
 
 ```go
+track := "camera"
 video, err := broadcast.PublishVideo(
     moq.VideoEncoderInput{
         Format:    moq.VideoPixelFormatRgba,
@@ -229,6 +230,7 @@ video, err := broadcast.PublishVideo(
     },
     moq.VideoEncoderOutput{
         Codec: moq.VideoCodecH264,
+        Track: &track,
         Kind:  moq.AutoEncoder(),
     },
 )
@@ -243,7 +245,7 @@ video.Finish()
 
 `AutoEncoder()` prefers a hardware encoder and falls back to software; `SoftwareEncoder()`, `HardwareEncoder()`, and `NamedEncoder("videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `SetBitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-The track is named after the codec (`.avc3` / `.hev1`) and its catalog rendition is published immediately, read out of the encoder itself, so subscribers discover it through the catalog rather than a name you pick, and can find it before the first frame exists. `Cut()` starts a new group at the next frame, which is optional: the encoder keyframes every `Gop` frames on its own, and each of those cuts a group.
+Set `Track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `Used(ctx)` and `Unused(ctx)` monitor subscriber demand, and `Cut()` starts a new group at the next frame.
 
 ## Raw Track Controls
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -148,6 +148,7 @@ val video = broadcast.publishVideo(
     ),
     VideoEncoderOutput(
         codec = VideoCodec.H264,
+        track = "camera",
         bitrate = null,
         gop = null,
         kind = autoEncoder,
@@ -160,7 +161,7 @@ video.finish()
 
 `autoEncoder` prefers a hardware encoder and falls back to software; `softwareEncoder`, `hardwareEncoder`, and `namedEncoder("videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `setBitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-The track is named after the codec (`.avc3` / `.hev1`) and its catalog rendition is published immediately, read out of the encoder itself, so subscribers discover it through the catalog rather than a name you pick, and can find it before the first frame exists. `cut()` starts a new group at the next frame, which is optional: the encoder keyframes every `gop` frames on its own, and each of those cuts a group.
+Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `used()` and `unused()` monitor subscriber demand, and `cut()` starts a new group at the next frame.
 
 ## Serve
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -161,7 +161,7 @@ video.finish()
 
 `autoEncoder` prefers a hardware encoder and falls back to software; `softwareEncoder`, `hardwareEncoder`, and `namedEncoder("videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `setBitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `used()` and `unused()` monitor subscriber demand, and `cut()` starts a new group at the next frame.
+Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `used()` and `unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
 ## Serve
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -101,6 +101,7 @@ video = broadcast.publish_video(
     ),
     moq.VideoEncoderOutput(
         codec=moq.VideoCodec.H264,
+        track="camera",
         kind=moq.VideoEncoderKind.AUTO(),
     ),
 )
@@ -111,7 +112,7 @@ video.finish()
 
 `VideoEncoderKind.AUTO()` prefers a hardware encoder and falls back to software; `SOFTWARE()`, `HARDWARE()`, and `NAMED("videotoolbox")` pin the choice (each variant is a class, so call it). The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `set_bitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-The track is named after the codec (`.avc3` / `.hev1`) and its catalog rendition is published immediately, read out of the encoder itself, so subscribers discover it through the catalog rather than a name you pick, and can find it before the first frame exists. `cut()` starts a new group at the next frame, which is optional: the encoder keyframes every `gop` frames on its own, and each of those cuts a group.
+Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand, and `cut()` starts a new group at the next frame.
 
 `publish_media` fills the catalog by parsing the codec bitstream. For a video format you can pass a `VideoHint` to supply fields the stream can't reveal (such as `bitrate`), or to publish the catalog before the first keyframe:
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -112,7 +112,7 @@ video.finish()
 
 `VideoEncoderKind.AUTO()` prefers a hardware encoder and falls back to software; `SOFTWARE()`, `HARDWARE()`, and `NAMED("videotoolbox")` pin the choice (each variant is a class, so call it). The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `set_bitrate` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand, and `cut()` starts a new group at the next frame.
+Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
 `publish_media` fills the catalog by parsing the codec bitstream. For a video format you can pass a `VideoHint` to supply fields the stream can't reveal (such as `bitrate`), or to publish the catalog before the first keyframe:
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -298,7 +298,7 @@ try video.finish()
 
 `kind: .auto` prefers a hardware encoder and falls back to software; `.software`, `.hardware`, and `.named(name: "videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `setBitrate(_:)` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
+Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `try await video.used()` and `try await video.unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
 ## Cancellation
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -298,7 +298,7 @@ try video.finish()
 
 `kind: .auto` prefers a hardware encoder and falls back to software; `.software`, `.hardware`, and `.named(name: "videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `setBitrate(_:)` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand, and `cut()` starts a new group at the next frame.
+Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
 ## Cancellation
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -289,7 +289,7 @@ The served broadcast is not announced. It only resolves consumers that call `req
 ```swift
 let video = try broadcast.publishVideo(
     input: VideoEncoderInput(format: .rgba, width: 1280, height: 720, framerate: 30),
-    output: VideoEncoderOutput(codec: .h264, bitrate: nil, gop: nil, kind: .auto)
+    output: VideoEncoderOutput(codec: .h264, track: "camera", bitrate: nil, gop: nil, kind: .auto)
 )
 
 try video.write(VideoFrame(timestampUs: ptsUs, data: rgba))
@@ -298,7 +298,7 @@ try video.finish()
 
 `kind: .auto` prefers a hardware encoder and falls back to software; `.software`, `.hardware`, and `.named(name: "videotoolbox")` pin the choice. The bindings compile VideoToolbox (macOS), Media Foundation (Windows), NVENC (Linux, NVIDIA), and openh264 (software, everywhere). A hardware encoder that is compiled in but can't open, because there is no GPU or because its driver libraries aren't on the loader path, logs a warning naming the reason and falls through to software, so a host that quietly encodes on the CPU says so. `setBitrate(_:)` retunes the live encoder without forcing a keyframe, cheap enough to drive from a congestion controller.
 
-The track is named after the codec (`.avc3` / `.hev1`) and its catalog rendition is published immediately, read out of the encoder itself, so subscribers discover it through the catalog rather than a name you pick, and can find it before the first frame exists. `cut()` starts a new group at the next frame, which is optional: the encoder keyframes every `gop` frames on its own, and each of those cuts a group.
+Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand, and `cut()` starts a new group at the next frame.
 
 ## Cancellation
 

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -482,12 +482,14 @@ func (v *VideoProducer) Name() (string, error) {
 	return v.inner.Name()
 }
 
-// Used blocks until the video track has at least one active subscriber.
+// Used blocks until the video track has at least one active subscriber. See
+// MediaProducer.Used regarding cancellation.
 func (v *VideoProducer) Used(ctx context.Context) error {
 	return runErr(ctx, nil, v.inner.Used)
 }
 
-// Unused blocks until the video track has no active subscribers.
+// Unused blocks until the video track has no active subscribers. See
+// MediaProducer.Used regarding cancellation.
 func (v *VideoProducer) Unused(ctx context.Context) error {
 	return runErr(ctx, nil, v.inner.Unused)
 }

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -126,10 +126,9 @@ func (b *BroadcastProducer) PublishAudio(name string, input AudioEncoderInput, o
 // PublishVideo publishes a raw-video track with an in-process H.264/H.265
 // encoder.
 //
-// The track is named after the codec (.avc3 / .hev1) and its catalog rendition
-// is published immediately, read out of the encoder itself, so subscribers
-// discover it through the catalog rather than a name you pick, and can find it
-// before the first frame exists.
+// Set output.Track to choose the track name; otherwise one is derived from the
+// codec (.avc3 / .hev1). The catalog rendition is published immediately so
+// subscribers can discover it before the first frame exists.
 func (b *BroadcastProducer) PublishVideo(input VideoEncoderInput, output VideoEncoderOutput) (*VideoProducer, error) {
 	inner, err := b.inner.PublishVideo(input, output)
 	if err != nil {
@@ -476,6 +475,21 @@ func (a *AudioProducer) Finish() error {
 // the way out.
 type VideoProducer struct {
 	inner *ffi.MoqVideoProducer
+}
+
+// Name returns the video track's name.
+func (v *VideoProducer) Name() (string, error) {
+	return v.inner.Name()
+}
+
+// Used blocks until the video track has at least one active subscriber.
+func (v *VideoProducer) Used(ctx context.Context) error {
+	return runErr(ctx, nil, v.inner.Used)
+}
+
+// Unused blocks until the video track has no active subscribers.
+func (v *VideoProducer) Unused(ctx context.Context) error {
+	return runErr(ctx, nil, v.inner.Unused)
 }
 
 // Write encodes and publishes one frame in the configured input format. A

--- a/go/wrapper/moq/types.go
+++ b/go/wrapper/moq/types.go
@@ -54,7 +54,7 @@ type (
 	VideoPixelFormat = ffi.MoqVideoPixelFormat
 	// VideoEncoderInput declares the pixel layout, resolution, and framerate of frames written to a video producer.
 	VideoEncoderInput = ffi.MoqVideoEncoderInput
-	// VideoEncoderOutput configures the video encoder: codec, optional bitrate and keyframe interval, and backend preference.
+	// VideoEncoderOutput configures the video track name, codec, bitrate, keyframe interval, and backend preference.
 	VideoEncoderOutput = ffi.MoqVideoEncoderOutput
 	// VideoFrame is one raw video frame: pixels in the configured layout plus a presentation timestamp in microseconds.
 	VideoFrame = ffi.MoqVideoFrame

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -133,7 +133,7 @@ typealias VideoCodec = uniffi.moq.MoqVideoCodec
 typealias VideoPixelFormat = uniffi.moq.MoqVideoPixelFormat
 /** The pixel layout, resolution, and framerate the caller feeds a [VideoProducer]. */
 typealias VideoEncoderInput = uniffi.moq.MoqVideoEncoderInput
-/** The codec-side encoder configuration: codec, bitrate, keyframe interval, and backend preference. */
+/** The video track name, codec, bitrate, keyframe interval, and backend preference. */
 typealias VideoEncoderOutput = uniffi.moq.MoqVideoEncoderOutput
 /** Which encoder implementation to use: automatic, hardware, software, or one named backend. */
 typealias VideoEncoderKind = uniffi.moq.MoqVideoEncoderKind

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -346,6 +346,19 @@ class VideoProducer:
     def __init__(self, inner: MoqVideoProducer) -> None:
         self._inner = inner
 
+    @property
+    def name(self) -> str:
+        """The video track name."""
+        return self._inner.name()
+
+    async def used(self) -> None:
+        """Wait until this video track has at least one active subscriber."""
+        await self._inner.used()
+
+    async def unused(self) -> None:
+        """Wait until this video track has no active subscribers."""
+        await self._inner.unused()
+
     def write(self, frame: VideoFrame) -> None:
         """Encode and publish one frame in the configured input format.
 
@@ -493,10 +506,10 @@ class BroadcastProducer:
     ) -> VideoProducer:
         """Publish a raw-video track with an in-process H.264/H.265 encoder.
 
-        The track is named after the codec (``.avc3`` / ``.hev1``) and its
-        catalog rendition is published immediately, read out of the encoder
-        itself, so subscribers discover it through the catalog rather than a
-        name you pick, and can find it before the first frame exists.
+        Set ``output.track`` to choose the track name; otherwise one is derived
+        from the codec (``.avc3`` / ``.hev1``). The catalog rendition is
+        published immediately so subscribers can discover it before the first
+        frame exists.
         """
         return VideoProducer(self._inner.publish_video(input, output))
 

--- a/py/moq-rs/pyproject.toml
+++ b/py/moq-rs/pyproject.toml
@@ -14,7 +14,7 @@ name = "moq-rs"
 # isn't already there (no tag needed; the registry is the gate).
 # Starts at 0.3.0 to open a new line above the old lockstep 0.2.x releases that
 # bundled the bindings.
-version = "0.4.5"
+version = "0.4.6"
 description = "Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization, with a Pythonic API. Import as `moq`."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/py/moq-rs/pyproject.toml
+++ b/py/moq-rs/pyproject.toml
@@ -14,7 +14,7 @@ name = "moq-rs"
 # isn't already there (no tag needed; the registry is the gate).
 # Starts at 0.3.0 to open a new line above the old lockstep 0.2.x releases that
 # bundled the bindings.
-version = "0.4.6"
+version = "0.4.5"
 description = "Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization, with a Pythonic API. Import as `moq`."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -1062,6 +1062,7 @@ async fn video_raw_publish_consume() {
 			},
 			MoqVideoEncoderOutput {
 				codec: MoqVideoCodec::H264,
+				track: Some("camera".into()),
 				bitrate: None,
 				gop: None,
 				// Software so the test is deterministic everywhere: `Auto` would
@@ -1070,9 +1071,21 @@ async fn video_raw_publish_consume() {
 			},
 		)
 		.unwrap();
+	assert_eq!(video.name().unwrap(), "camera");
+	let local_consumer = broadcast.consume().unwrap();
+	let demand_consumer = local_consumer.subscribe_track("camera".into(), None).await.unwrap();
+	tokio::time::timeout(TIMEOUT, video.used())
+		.await
+		.expect("timed out waiting for video demand")
+		.unwrap();
+	drop(demand_consumer);
+	tokio::time::timeout(TIMEOUT, video.unused())
+		.await
+		.expect("timed out waiting for video demand to clear")
+		.unwrap();
 
-	// The catalog rendition only exists once the importer has parsed the codec
-	// config out of an encoded keyframe, so write before subscribing.
+	// Seed the track before subscribing so the consumer below has encoded media
+	// waiting at the live edge as soon as it joins.
 	video.cut().unwrap();
 	let rgba = vec![0x80u8; 320 * 240 * 4];
 	for i in 0..5u64 {
@@ -1102,7 +1115,7 @@ async fn video_raw_publish_consume() {
 
 	assert_eq!(catalog.video.len(), 1);
 	let (track_name, rendition) = catalog.video.iter().next().unwrap();
-	assert!(track_name.ends_with(".avc3"), "track name: {track_name}");
+	assert_eq!(track_name, "camera");
 	assert!(
 		rendition.codec.starts_with("avc3."),
 		"codec should be avc3, got {}",
@@ -1165,6 +1178,7 @@ async fn video_raw_publish_from_many_threads() {
 			},
 			MoqVideoEncoderOutput {
 				codec: MoqVideoCodec::H264,
+				track: None,
 				// An explicit ceiling so the retunes below stay under the rate the
 				// encoder opened at, which openh264 requires.
 				bitrate: Some(1_000_000),
@@ -1239,6 +1253,7 @@ async fn video_raw_publish_rejects_bad_frames() {
 	};
 	let output = || MoqVideoEncoderOutput {
 		codec: MoqVideoCodec::H264,
+		track: None,
 		bitrate: None,
 		gop: None,
 		kind: MoqVideoEncoderKind::Software,

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -97,6 +97,9 @@ pub struct MoqVideoEncoderInput {
 #[derive(uniffi::Record)]
 pub struct MoqVideoEncoderOutput {
 	pub codec: MoqVideoCodec,
+	/// Track name. `None` derives a unique name from the codec.
+	#[uniffi(default = None)]
+	pub track: Option<String>,
 	/// Target bitrate in bits per second. `None` derives one from the resolution
 	/// and framerate.
 	#[uniffi(default = None)]
@@ -212,8 +215,34 @@ pub struct MoqVideoProducer {
 	inner: std::sync::Mutex<Option<VideoProducer>>,
 }
 
+impl MoqVideoProducer {
+	fn demand(&self) -> Result<moq_net::track::Demand, MoqError> {
+		let guard = self.inner.lock().unwrap();
+		let producer = guard.as_ref().ok_or(MoqError::Closed)?;
+		Ok(producer.producer.demand())
+	}
+}
+
 #[uniffi::export]
 impl MoqVideoProducer {
+	/// Return the name of this video track.
+	pub fn name(&self) -> Result<String, MoqError> {
+		let _guard = crate::ffi::enter();
+		Ok(self.demand()?.name().to_string())
+	}
+
+	/// Wait until this video track has at least one active consumer.
+	pub async fn used(&self) -> Result<(), MoqError> {
+		let demand = self.demand()?;
+		crate::ffi::detached(async move { demand.used().await }).await
+	}
+
+	/// Wait until this video track has no active consumers.
+	pub async fn unused(&self) -> Result<(), MoqError> {
+		let demand = self.demand()?;
+		crate::ffi::detached(async move { demand.unused().await }).await
+	}
+
 	/// Encode and publish one raw frame.
 	///
 	/// A backend that pipelines publishes an earlier frame's output here, so a
@@ -279,10 +308,10 @@ impl MoqBroadcastProducer {
 	/// it.
 	///
 	/// The encoder opens here, so an unsupported codec, resolution, or backend
-	/// fails now rather than on the first frame. The track is named after the
-	/// codec (`.avc3` / `.hev1`) and its catalog rendition is published
-	/// immediately, read out of the encoder rather than guessed, so a subscriber
-	/// can find the track before a frame is written to it.
+	/// fails now rather than on the first frame. [`MoqVideoEncoderOutput::track`]
+	/// chooses the track name; `None` derives one from the codec. The catalog
+	/// rendition is published immediately so a subscriber can discover the track
+	/// before a frame is written to it.
 	pub fn publish_video(
 		&self,
 		input: MoqVideoEncoderInput,
@@ -303,12 +332,20 @@ impl MoqBroadcastProducer {
 		// closes its encoder before this one opens, so only one codec session is live.
 		let rendition = block_on(config.probe())?;
 		let encoder = block_on(moq_video::encode::Sink::open(&config))?;
-		let producer = self.with_state(|state| {
-			Ok(moq_video::encode::Producer::new(
+		let producer = self.with_state(|state| match output.track {
+			Some(name) => {
+				let track = state.broadcast.create_track(name, state.catalog.track_info())?;
+				Ok(moq_video::encode::Producer::with_track(
+					track,
+					state.catalog.clone(),
+					rendition,
+				)?)
+			}
+			None => Ok(moq_video::encode::Producer::new(
 				state.broadcast.clone(),
 				state.catalog.clone(),
 				rendition,
-			)?)
+			)?),
 		})?;
 
 		Ok(Arc::new(MoqVideoProducer {

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -99,21 +99,37 @@ impl<E: CatalogExt> Producer<E> {
 		catalog: moq_mux::catalog::Producer<E>,
 		rendition: hang::catalog::VideoConfig,
 	) -> Result<Self, Error> {
+		let suffix = match &rendition.codec {
+			hang::catalog::VideoCodec::H264(_) => ".avc3",
+			hang::catalog::VideoCodec::H265(_) => ".hev1",
+			other => {
+				return Err(Error::Codec(anyhow::anyhow!(
+					"{other} is not a codec this producer can publish"
+				)));
+			}
+		};
+		let track = broadcast.unique_track(suffix, catalog.track_info())?;
+		Self::with_track(track, catalog, rendition)
+	}
+
+	/// Publish `rendition` on an existing track, registering it in `catalog`.
+	///
+	/// Use this when the caller owns the track name. [`new`](Self::new) derives a
+	/// unique name from the codec instead.
+	pub fn with_track(
+		track: moq_net::track::Producer,
+		catalog: moq_mux::catalog::Producer<E>,
+		rendition: hang::catalog::VideoConfig,
+	) -> Result<Self, Error> {
 		let codecs = match &rendition.codec {
-			hang::catalog::VideoCodec::H264(_) => {
-				let track = broadcast.unique_track(".avc3", catalog.track_info())?;
-				Codecs::H264 {
-					split: moq_mux::codec::h264::Split::new(),
-					import: moq_mux::codec::h264::Import::new(track, catalog.reserve(), rendition_hint(rendition))?,
-				}
-			}
-			hang::catalog::VideoCodec::H265(_) => {
-				let track = broadcast.unique_track(".hev1", catalog.track_info())?;
-				Codecs::H265 {
-					split: moq_mux::codec::h265::Split::new(),
-					import: moq_mux::codec::h265::Import::new(track, catalog.reserve(), rendition_hint(rendition))?,
-				}
-			}
+			hang::catalog::VideoCodec::H264(_) => Codecs::H264 {
+				split: moq_mux::codec::h264::Split::new(),
+				import: moq_mux::codec::h264::Import::new(track, catalog.reserve(), rendition_hint(rendition))?,
+			},
+			hang::catalog::VideoCodec::H265(_) => Codecs::H265 {
+				split: moq_mux::codec::h265::Split::new(),
+				import: moq_mux::codec::h265::Import::new(track, catalog.reserve(), rendition_hint(rendition))?,
+			},
 			// Unreachable via `Config::probe`, which only encodes what `Codec` covers.
 			other => {
 				return Err(Error::Codec(anyhow::anyhow!(

--- a/swift/Sources/Moq/Aliases.swift
+++ b/swift/Sources/Moq/Aliases.swift
@@ -46,7 +46,7 @@ public typealias AudioCodec = MoqFFI.MoqAudioCodec
 public typealias VideoFrame = MoqFFI.MoqVideoFrame
 /// The pixel layout, resolution, and framerate written to a `VideoProducer`.
 public typealias VideoEncoderInput = MoqFFI.MoqVideoEncoderInput
-/// The encoder-side config for a published video track: codec, bitrate,
+/// The encoder-side config for a published video track: name, codec, bitrate,
 /// keyframe interval, and backend preference.
 public typealias VideoEncoderOutput = MoqFFI.MoqVideoEncoderOutput
 /// A raw pixel layout (I420 or RGBA) fed to a `VideoProducer`.

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -235,10 +235,9 @@ public final class BroadcastProducer: Sendable {
     /// Open a raw-video track. Pixels written via `VideoProducer.write` are
     /// encoded (H.264 or H.265) inside the FFI boundary per `input`/`output`.
     ///
-    /// The track is named after the codec (`.avc3` / `.hev1`) and its catalog
-    /// rendition is published immediately, read out of the encoder itself, so
-    /// subscribers discover it through the catalog rather than a name you pick,
-    /// and can find it before the first frame exists.
+    /// Set `output.track` to choose the track name; otherwise one is derived from
+    /// the codec (`.avc3` / `.hev1`). The catalog rendition is published
+    /// immediately so subscribers can discover it before the first frame exists.
     public func publishVideo(input: VideoEncoderInput, output: VideoEncoderOutput) throws -> VideoProducer {
         VideoProducer(try ffi.publishVideo(input: input, output: output))
     }

--- a/swift/Sources/Moq/Video.swift
+++ b/swift/Sources/Moq/Video.swift
@@ -10,6 +10,21 @@ public final class VideoProducer: Sendable {
         self.ffi = ffi
     }
 
+    /// The video track's name.
+    public var name: String {
+        get throws { try ffi.name() }
+    }
+
+    /// Suspend until the video track has at least one active consumer.
+    public func used() async throws {
+        try await ffi.used()
+    }
+
+    /// Suspend until the video track has no active consumers.
+    public func unused() async throws {
+        try await ffi.unused()
+    }
+
     /// Encode and publish one raw frame.
     ///
     /// A hardware encoder pipelines, so a call that puts nothing on the wire is

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ name = "accessible-pygments"
 version = "0.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
 wheels = [
@@ -61,8 +61,8 @@ name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "soupsieve", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
@@ -264,7 +264,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -276,11 +276,11 @@ name = "furo"
 version = "2025.12.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "accessible-pygments", marker = "python_full_version >= '3.12'" },
-    { name = "beautifulsoup4", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "sphinx", marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-basic-ng", marker = "python_full_version >= '3.12'" },
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx" },
+    { name = "sphinx-basic-ng" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
 wheels = [
@@ -319,7 +319,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "python_full_version >= '3.12'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -331,7 +331,7 @@ name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.12'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -452,7 +452,7 @@ name = "mdit-py-plugins"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version >= '3.12'" },
+    { name = "markdown-it-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
 wheels = [
@@ -509,7 +509,7 @@ source = { editable = "py/moq-ffi" }
 
 [[package]]
 name = "moq-rs"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "py/moq-rs" }
 dependencies = [
     { name = "moq-ffi" },
@@ -523,12 +523,12 @@ name = "myst-parser"
 version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "markdown-it-py", marker = "python_full_version >= '3.12'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "sphinx", marker = "python_full_version >= '3.12'" },
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
 wheels = [
@@ -685,10 +685,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.12'" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.12'" },
-    { name = "idna", marker = "python_full_version >= '3.12'" },
-    { name = "urllib3", marker = "python_full_version >= '3.12'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -752,23 +752,23 @@ name = "sphinx"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -780,7 +780,7 @@ name = "sphinx-basic-ng"
 version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", marker = "python_full_version >= '3.12'" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -509,7 +509,7 @@ source = { editable = "py/moq-ffi" }
 
 [[package]]
 name = "moq-rs"
-version = "0.4.6"
+version = "0.4.5"
 source = { editable = "py/moq-rs" }
 dependencies = [
     { name = "moq-ffi" },


### PR DESCRIPTION
## Summary

- Let raw-video publishers choose a stable track name and observe used/unused transitions.
- Mirror the additive API through Python, Swift, Kotlin, and Go wrappers.
- Allow capture and encoding to stay idle until a named rendition has a subscriber.
- Document that a resumed publisher must cut before its first frame so it starts a keyframed group.

## Public API changes

- Add `moq_video::encode::Producer::with_track`.
- Add `MoqVideoEncoderOutput::track` and `MoqVideoProducer::{name, used, unused}`.
- Expose the matching wrapper members in Python, Swift, Kotlin, and Go.

These are additive changes targeting `main`. No package versions are changed; the release workflows own version bumps.

## Cross-package sync

`libmoq` is intentionally unchanged. Its C output struct is ABI-stable and has a callback-oriented lifecycle rather than the async object methods exposed by UniFFI. Adding the field there would be breaking, and Pronto consumes the Python binding.

## Test plan

- `just fix`
- `just check`
- `just test`: 246 selected Rust tests plus the Python and JavaScript suites passed
- Construct both named Pronto publishers through the generated Python binding

(Written by GPT-5.6 Codex)