### PR TITLE
feat(moq-ffi): expose raw audio track demand

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -247,6 +247,8 @@ video.Finish()
 
 Set `Track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `Used(ctx)` and `Unused(ctx)` monitor subscriber demand. Call `Cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
+Raw audio takes an explicit track name at publish time. Read it back through `audio.Name()`; `audio.Used(ctx)` and `audio.Unused(ctx)` monitor subscriber demand so capture and encoding can stay idle when nobody is listening.
+
 ## Raw Track Controls
 
 Raw track subscribers can query the publisher's track properties and change their own delivery preferences without resubscribing:

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -247,7 +247,7 @@ video.Finish()
 
 Set `Track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `Used(ctx)` and `Unused(ctx)` monitor subscriber demand. Call `Cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
-Raw audio takes an explicit track name at publish time. Read it back through `audio.Name()`; `audio.Used(ctx)` and `audio.Unused(ctx)` monitor subscriber demand so capture and encoding can stay idle when nobody is listening.
+Raw audio takes an explicit track name at publish time. Read it back through `audio.Name()`; `audio.Used(ctx)` and `audio.Unused(ctx)` monitor subscriber demand so capture and encoding can stay idle when nobody is listening. Call `audio.ResetEpoch()` before the first frame after resuming so its timestamp preserves the idle gap.
 
 ## Raw Track Controls
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -163,7 +163,7 @@ video.finish()
 
 Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `used()` and `unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
-Raw audio takes an explicit track name at publish time. Read it back through `audio.name()`; `audio.used()` and `audio.unused()` suspend on subscriber-demand transitions so capture and encoding can stay idle when nobody is listening.
+Raw audio takes an explicit track name at publish time. Read it back through `audio.name()`; `audio.used()` and `audio.unused()` suspend on subscriber-demand transitions so capture and encoding can stay idle when nobody is listening. Call `audio.resetEpoch()` before the first frame after resuming so its timestamp preserves the idle gap.
 
 ## Serve
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -163,6 +163,8 @@ video.finish()
 
 Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `used()` and `unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
+Raw audio takes an explicit track name at publish time. Read it back through `audio.name()`; `audio.used()` and `audio.unused()` suspend on subscriber-demand transitions so capture and encoding can stay idle when nobody is listening.
+
 ## Serve
 
 `Server.listen(bind)` binds a listener, wires an internal origin for both directions, and returns an `AutoCloseable` `Server`. `serve()` accepts every session and holds it alive until it closes:

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -114,6 +114,8 @@ video.finish()
 
 Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
+Raw audio takes an explicit track name at publish time. Read it back through `audio.name`; `await audio.used()` and `await audio.unused()` monitor subscriber demand so capture and encoding can stay idle when nobody is listening.
+
 `publish_media` fills the catalog by parsing the codec bitstream. For a video format you can pass a `VideoHint` to supply fields the stream can't reveal (such as `bitrate`), or to publish the catalog before the first keyframe:
 
 ```python

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -114,7 +114,7 @@ video.finish()
 
 Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `await video.used()` and `await video.unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
-Raw audio takes an explicit track name at publish time. Read it back through `audio.name`; `await audio.used()` and `await audio.unused()` monitor subscriber demand so capture and encoding can stay idle when nobody is listening.
+Raw audio takes an explicit track name at publish time. Read it back through `audio.name`; `await audio.used()` and `await audio.unused()` monitor subscriber demand so capture and encoding can stay idle when nobody is listening. Call `audio.reset_epoch()` before the first frame after resuming so its timestamp preserves the idle gap.
 
 `publish_media` fills the catalog by parsing the codec bitstream. For a video format you can pass a `VideoHint` to supply fields the stream can't reveal (such as `bitrate`), or to publish the catalog before the first keyframe:
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -300,6 +300,8 @@ try video.finish()
 
 Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `try await video.used()` and `try await video.unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
+Raw audio takes an explicit track name at publish time. Read it back through `try audio.name`; `try await audio.used()` and `try await audio.unused()` monitor subscriber demand so capture and encoding can stay idle when nobody is listening.
+
 ## Cancellation
 
 All async sequences cooperate with structured concurrency. Cancelling the surrounding `Task` propagates to the underlying `cancel()` on the consumer:

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -300,7 +300,7 @@ try video.finish()
 
 Set `track` to choose the track name; omit it to derive one from the codec (`.avc3` / `.hev1`). The catalog rendition is published immediately so subscribers can discover it before the first frame exists. `try await video.used()` and `try await video.unused()` monitor subscriber demand. Call `cut()` before the first frame after an idle gap so the resumed stream starts with a keyframe in a new group.
 
-Raw audio takes an explicit track name at publish time. Read it back through `try audio.name`; `try await audio.used()` and `try await audio.unused()` monitor subscriber demand so capture and encoding can stay idle when nobody is listening.
+Raw audio takes an explicit track name at publish time. Read it back through `try audio.name`; `try await audio.used()` and `try await audio.unused()` monitor subscriber demand so capture and encoding can stay idle when nobody is listening. Call `try audio.resetEpoch()` before the first frame after resuming so its timestamp preserves the idle gap.
 
 ## Cancellation
 

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -461,6 +461,21 @@ type AudioProducer struct {
 	inner *ffi.MoqAudioProducer
 }
 
+// Name returns the audio track's name.
+func (a *AudioProducer) Name() (string, error) {
+	return a.inner.Name()
+}
+
+// Used blocks until the audio track has at least one active subscriber.
+func (a *AudioProducer) Used(ctx context.Context) error {
+	return runErr(ctx, nil, a.inner.Used)
+}
+
+// Unused blocks until the audio track has no active subscribers.
+func (a *AudioProducer) Unused(ctx context.Context) error {
+	return runErr(ctx, nil, a.inner.Unused)
+}
+
 // Write pushes one frame of PCM in the configured input format.
 func (a *AudioProducer) Write(frame AudioFrame) error {
 	return a.inner.Write(frame)

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -466,14 +466,21 @@ func (a *AudioProducer) Name() (string, error) {
 	return a.inner.Name()
 }
 
-// Used blocks until the audio track has at least one active subscriber.
+// Used blocks until the audio track has at least one active subscriber. See
+// MediaProducer.Used regarding cancellation.
 func (a *AudioProducer) Used(ctx context.Context) error {
 	return runErr(ctx, nil, a.inner.Used)
 }
 
-// Unused blocks until the audio track has no active subscribers.
+// Unused blocks until the audio track has no active subscribers. See
+// MediaProducer.Used regarding cancellation.
 func (a *AudioProducer) Unused(ctx context.Context) error {
 	return runErr(ctx, nil, a.inner.Unused)
+}
+
+// ResetEpoch re-anchors the timeline to the next frame after an idle gap.
+func (a *AudioProducer) ResetEpoch() error {
+	return a.inner.ResetEpoch()
 }
 
 // Write pushes one frame of PCM in the configured input format.

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -67,7 +67,7 @@ typealias MediaStreamProducer = uniffi.moq.MoqMediaStreamProducer
 typealias MediaConsumer = uniffi.moq.MoqMediaConsumer
 /** A finite fetched media group: yields container-decoded frames until the group ends. */
 typealias MediaGroupConsumer = uniffi.moq.MoqMediaGroupConsumer
-/** The write side of a raw-audio track; PCM written here is encoded inside the FFI boundary. */
+/** A demand-observable raw-audio track producer; PCM written here is encoded inside the FFI boundary. */
 typealias AudioProducer = uniffi.moq.MoqAudioProducer
 /** The read side of a raw-audio track: yields decoded PCM frames. */
 typealias AudioConsumer = uniffi.moq.MoqAudioConsumer

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -67,7 +67,7 @@ typealias MediaStreamProducer = uniffi.moq.MoqMediaStreamProducer
 typealias MediaConsumer = uniffi.moq.MoqMediaConsumer
 /** A finite fetched media group: yields container-decoded frames until the group ends. */
 typealias MediaGroupConsumer = uniffi.moq.MoqMediaGroupConsumer
-/** A demand-observable raw-audio track producer; PCM written here is encoded inside the FFI boundary. */
+/** A demand-observable raw-audio track producer with explicit timeline re-anchoring after idle gaps. */
 typealias AudioProducer = uniffi.moq.MoqAudioProducer
 /** The read side of a raw-audio track: yields decoded PCM frames. */
 typealias AudioConsumer = uniffi.moq.MoqAudioConsumer

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -339,6 +339,10 @@ class AudioProducer:
         """Wait until this audio track has no active subscribers."""
         await self._inner.unused()
 
+    def reset_epoch(self) -> None:
+        """Re-anchor the timeline to the next frame after an idle gap."""
+        self._inner.reset_epoch()
+
     def write(self, frame: AudioFrame) -> None:
         """Push one frame of PCM in the configured input format."""
         self._inner.write(frame)

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -326,6 +326,19 @@ class AudioProducer:
     def __init__(self, inner: MoqAudioProducer) -> None:
         self._inner = inner
 
+    @property
+    def name(self) -> str:
+        """The audio track name."""
+        return self._inner.name()
+
+    async def used(self) -> None:
+        """Wait until this audio track has at least one active subscriber."""
+        await self._inner.used()
+
+    async def unused(self) -> None:
+        """Wait until this audio track has no active subscribers."""
+        await self._inner.unused()
+
     def write(self, frame: AudioFrame) -> None:
         """Push one frame of PCM in the configured input format."""
         self._inner.write(frame)

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -148,8 +148,34 @@ pub struct MoqAudioProducer {
 	inner: std::sync::Mutex<Option<moq_audio::encode::Producer<moq_mux::catalog::hang::Extra>>>,
 }
 
+impl MoqAudioProducer {
+	fn demand(&self) -> Result<moq_net::track::Demand, MoqError> {
+		let guard = self.inner.lock().unwrap();
+		let producer = guard.as_ref().ok_or(MoqError::Closed)?;
+		Ok(producer.track().demand())
+	}
+}
+
 #[uniffi::export]
 impl MoqAudioProducer {
+	/// Return the name of this audio track.
+	pub fn name(&self) -> Result<String, MoqError> {
+		let _guard = crate::ffi::enter();
+		Ok(self.demand()?.name().to_string())
+	}
+
+	/// Wait until this audio track has at least one active consumer.
+	pub async fn used(&self) -> Result<(), MoqError> {
+		let demand = self.demand()?;
+		crate::ffi::detached(async move { demand.used().await }).await
+	}
+
+	/// Wait until this audio track has no active consumers.
+	pub async fn unused(&self) -> Result<(), MoqError> {
+		let demand = self.demand()?;
+		crate::ffi::detached(async move { demand.unused().await }).await
+	}
+
 	pub fn write(&self, frame: MoqAudioFrame) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let frame = moq_audio::Frame::try_from(frame)?;

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -176,6 +176,18 @@ impl MoqAudioProducer {
 		crate::ffi::detached(async move { demand.unused().await }).await
 	}
 
+	/// Re-anchor the timeline to the next frame's timestamp.
+	///
+	/// Call this before writing after an idle gap so the gap remains visible in
+	/// the audio PTS instead of being compressed out by the running sample count.
+	pub fn reset_epoch(&self) -> Result<(), MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let mut guard = self.inner.lock().unwrap();
+		let producer = guard.as_mut().ok_or(MoqError::Closed)?;
+		producer.reset_epoch();
+		Ok(())
+	}
+
 	pub fn write(&self, frame: MoqAudioFrame) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let frame = moq_audio::Frame::try_from(frame)?;

--- a/rs/moq-ffi/src/ffi.rs
+++ b/rs/moq-ffi/src/ffi.rs
@@ -50,7 +50,17 @@ where
 	T: Send + 'static,
 	E: Into<MoqError> + Send + 'static,
 {
-	match RUNTIME.spawn(future).await {
+	struct AbortOnDrop(tokio::task::AbortHandle);
+
+	impl Drop for AbortOnDrop {
+		fn drop(&mut self) {
+			self.0.abort();
+		}
+	}
+
+	let task = RUNTIME.spawn(future);
+	let _abort = AbortOnDrop(task.abort_handle());
+	match task.await {
 		Ok(result) => result.map_err(Into::into),
 		Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
 		Err(e) => Err(MoqError::Task(e)),

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -102,6 +102,12 @@ async fn raw_track_activity() {
 
 #[tokio::test]
 async fn raw_audio_activity() {
+	const SAMPLE_RATE: u32 = 48_000;
+	const FRAME_DURATION_MS: u32 = 20;
+	const FRAME_SAMPLES: usize = (SAMPLE_RATE * FRAME_DURATION_MS / 1_000) as usize;
+	const FIRST_TIMESTAMP_US: u64 = 1_000_000;
+	const RESUMED_TIMESTAMP_US: u64 = 2_000_000;
+
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let consumer = broadcast.consume().unwrap();
 	let catalog_consumer = consumer.subscribe_catalog().await.unwrap();
@@ -110,7 +116,7 @@ async fn raw_audio_activity() {
 			"microphone".into(),
 			MoqAudioEncoderInput {
 				format: MoqAudioFormat::F32,
-				sample_rate: 48_000,
+				sample_rate: SAMPLE_RATE,
 				channels: 1,
 			},
 			MoqAudioEncoderOutput {
@@ -118,7 +124,7 @@ async fn raw_audio_activity() {
 				sample_rate: None,
 				channels: None,
 				bitrate: None,
-				frame_duration_ms: 20,
+				frame_duration_ms: FRAME_DURATION_MS,
 			},
 		)
 		.unwrap();
@@ -140,8 +146,8 @@ async fn raw_audio_activity() {
 		.unwrap();
 	audio
 		.write(MoqAudioFrame {
-			timestamp_us: 1_000_000,
-			data: vec![0; 960 * std::mem::size_of::<f32>()],
+			timestamp_us: FIRST_TIMESTAMP_US,
+			data: vec![0; FRAME_SAMPLES * std::mem::size_of::<f32>()],
 		})
 		.unwrap();
 	let first = tokio::time::timeout(TIMEOUT, subscription.next())
@@ -149,7 +155,7 @@ async fn raw_audio_activity() {
 		.expect("timed out waiting for raw audio frame")
 		.unwrap()
 		.expect("expected a raw audio frame");
-	assert_eq!(first.timestamp_us, 1_000_000);
+	assert_eq!(first.timestamp_us, FIRST_TIMESTAMP_US);
 
 	drop(subscription);
 	tokio::time::timeout(TIMEOUT, audio.unused())
@@ -168,8 +174,8 @@ async fn raw_audio_activity() {
 	audio.reset_epoch().unwrap();
 	audio
 		.write(MoqAudioFrame {
-			timestamp_us: 2_000_000,
-			data: vec![0; 960 * std::mem::size_of::<f32>()],
+			timestamp_us: RESUMED_TIMESTAMP_US,
+			data: vec![0; FRAME_SAMPLES * std::mem::size_of::<f32>()],
 		})
 		.unwrap();
 	let mut resumed = tokio::time::timeout(TIMEOUT, subscription.next())
@@ -184,7 +190,7 @@ async fn raw_audio_activity() {
 			.unwrap()
 			.expect("expected a re-anchored raw audio frame");
 	}
-	assert_eq!(resumed.timestamp_us, 2_000_000);
+	assert_eq!(resumed.timestamp_us, RESUMED_TIMESTAMP_US);
 
 	audio.finish().unwrap();
 	broadcast.finish().unwrap();

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -2,7 +2,7 @@ use super::origin::*;
 use super::producer::*;
 use super::server::MoqServer;
 use super::session::MoqClient;
-use crate::audio::{MoqAudioCodec, MoqAudioEncoderInput, MoqAudioEncoderOutput, MoqAudioFormat};
+use crate::audio::{MoqAudioCodec, MoqAudioEncoderInput, MoqAudioEncoderOutput, MoqAudioFormat, MoqAudioFrame};
 use crate::consumer::MoqBroadcastConsumer;
 use crate::consumer::MoqFetchGroupOptions;
 use crate::consumer::MoqRouteWatch;
@@ -103,6 +103,8 @@ async fn raw_track_activity() {
 #[tokio::test]
 async fn raw_audio_activity() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let consumer = broadcast.consume().unwrap();
+	let catalog_consumer = consumer.subscribe_catalog().await.unwrap();
 	let audio = broadcast
 		.publish_audio(
 			"microphone".into(),
@@ -122,18 +124,67 @@ async fn raw_audio_activity() {
 		.unwrap();
 	assert_eq!(audio.name().unwrap(), "microphone");
 
-	let consumer = broadcast.consume().unwrap();
-	let subscription = consumer.subscribe_track("microphone".into(), None).await.unwrap();
+	let catalog = tokio::time::timeout(TIMEOUT, catalog_consumer.next())
+		.await
+		.expect("timed out waiting for raw audio catalog")
+		.unwrap()
+		.expect("expected a raw audio catalog");
+	let container = catalog.audio.get("microphone").unwrap().container.clone();
+	let subscription = consumer
+		.subscribe_media("microphone".into(), container.clone(), None)
+		.await
+		.unwrap();
 	tokio::time::timeout(TIMEOUT, audio.used())
 		.await
 		.expect("timed out waiting for raw audio to become used")
 		.unwrap();
+	audio
+		.write(MoqAudioFrame {
+			timestamp_us: 1_000_000,
+			data: vec![0; 960 * std::mem::size_of::<f32>()],
+		})
+		.unwrap();
+	let first = tokio::time::timeout(TIMEOUT, subscription.next())
+		.await
+		.expect("timed out waiting for raw audio frame")
+		.unwrap()
+		.expect("expected a raw audio frame");
+	assert_eq!(first.timestamp_us, 1_000_000);
 
 	drop(subscription);
 	tokio::time::timeout(TIMEOUT, audio.unused())
 		.await
 		.expect("timed out waiting for raw audio to become unused")
 		.unwrap();
+
+	let subscription = consumer
+		.subscribe_media("microphone".into(), container, None)
+		.await
+		.unwrap();
+	tokio::time::timeout(TIMEOUT, audio.used())
+		.await
+		.expect("timed out waiting for raw audio to become used again")
+		.unwrap();
+	audio.reset_epoch().unwrap();
+	audio
+		.write(MoqAudioFrame {
+			timestamp_us: 2_000_000,
+			data: vec![0; 960 * std::mem::size_of::<f32>()],
+		})
+		.unwrap();
+	let mut resumed = tokio::time::timeout(TIMEOUT, subscription.next())
+		.await
+		.expect("timed out waiting for resumed raw audio frame")
+		.unwrap()
+		.expect("expected a resumed raw audio frame");
+	if resumed.timestamp_us == first.timestamp_us {
+		resumed = tokio::time::timeout(TIMEOUT, subscription.next())
+			.await
+			.expect("timed out waiting for re-anchored raw audio frame")
+			.unwrap()
+			.expect("expected a re-anchored raw audio frame");
+	}
+	assert_eq!(resumed.timestamp_us, 2_000_000);
 
 	audio.finish().unwrap();
 	broadcast.finish().unwrap();

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -15,6 +15,36 @@ use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
+#[tokio::test]
+async fn detached_cancels_inner_on_drop() {
+	struct DropSignal(Option<tokio::sync::oneshot::Sender<()>>);
+
+	impl Drop for DropSignal {
+		fn drop(&mut self) {
+			let _ = self.0.take().unwrap().send(());
+		}
+	}
+
+	let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+	let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+	let outer = tokio::spawn(crate::ffi::detached(async move {
+		let _drop = DropSignal(Some(dropped_tx));
+		started_tx.send(()).unwrap();
+		std::future::pending::<Result<(), MoqError>>().await
+	}));
+
+	tokio::time::timeout(TIMEOUT, started_rx)
+		.await
+		.expect("timed out waiting for detached task to start")
+		.unwrap();
+	outer.abort();
+	assert!(outer.await.unwrap_err().is_cancelled());
+	tokio::time::timeout(TIMEOUT, dropped_rx)
+		.await
+		.expect("timed out waiting for detached task to be dropped")
+		.unwrap();
+}
+
 /// A bare [`MoqInit`] with a format and init bytes, no catalog hints.
 fn media_init(format: &str, data: Vec<u8>) -> MoqInit {
 	MoqInit {

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -2,6 +2,7 @@ use super::origin::*;
 use super::producer::*;
 use super::server::MoqServer;
 use super::session::MoqClient;
+use crate::audio::{MoqAudioCodec, MoqAudioEncoderInput, MoqAudioEncoderOutput, MoqAudioFormat};
 use crate::consumer::MoqBroadcastConsumer;
 use crate::consumer::MoqFetchGroupOptions;
 use crate::consumer::MoqRouteWatch;
@@ -97,6 +98,45 @@ async fn raw_track_activity() {
 		.await
 		.expect("timed out waiting for raw track to become unused")
 		.unwrap();
+}
+
+#[tokio::test]
+async fn raw_audio_activity() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let audio = broadcast
+		.publish_audio(
+			"microphone".into(),
+			MoqAudioEncoderInput {
+				format: MoqAudioFormat::F32,
+				sample_rate: 48_000,
+				channels: 1,
+			},
+			MoqAudioEncoderOutput {
+				codec: MoqAudioCodec::Opus,
+				sample_rate: None,
+				channels: None,
+				bitrate: None,
+				frame_duration_ms: 20,
+			},
+		)
+		.unwrap();
+	assert_eq!(audio.name().unwrap(), "microphone");
+
+	let consumer = broadcast.consume().unwrap();
+	let subscription = consumer.subscribe_track("microphone".into(), None).await.unwrap();
+	tokio::time::timeout(TIMEOUT, audio.used())
+		.await
+		.expect("timed out waiting for raw audio to become used")
+		.unwrap();
+
+	drop(subscription);
+	tokio::time::timeout(TIMEOUT, audio.unused())
+		.await
+		.expect("timed out waiting for raw audio to become unused")
+		.unwrap();
+
+	audio.finish().unwrap();
+	broadcast.finish().unwrap();
 }
 
 #[tokio::test]

--- a/swift/Sources/Moq/Audio.swift
+++ b/swift/Sources/Moq/Audio.swift
@@ -54,6 +54,11 @@ public final class AudioProducer: Sendable {
         try await ffi.unused()
     }
 
+    /// Re-anchor the timeline to the next frame after an idle gap.
+    public func resetEpoch() throws {
+        try ffi.resetEpoch()
+    }
+
     /// Encode and write one PCM frame.
     public func write(_ frame: AudioFrame) throws {
         try ffi.write(frame: frame)

--- a/swift/Sources/Moq/Audio.swift
+++ b/swift/Sources/Moq/Audio.swift
@@ -39,6 +39,21 @@ public final class AudioProducer: Sendable {
         self.ffi = ffi
     }
 
+    /// The audio track's name.
+    public var name: String {
+        get throws { try ffi.name() }
+    }
+
+    /// Suspend until the audio track has at least one active consumer.
+    public func used() async throws {
+        try await ffi.used()
+    }
+
+    /// Suspend until the audio track has no active consumers.
+    public func unused() async throws {
+        try await ffi.unused()
+    }
+
     /// Encode and write one PCM frame.
     public func write(_ frame: AudioFrame) throws {
         try ffi.write(frame: frame)


### PR DESCRIPTION
## Summary

- expose the raw audio track name plus `used` / `unused` subscriber-demand waits through `moq-ffi`
- expose timeline re-anchoring so demand-driven capture preserves idle gaps
- cancel native detached waits when their foreign-facing future is dropped
- mirror the API in the Python, Swift, Kotlin, and Go wrappers
- document demand-driven audio capture and encoding
- test an idle, used, unused, and resumed cycle with timestamp assertions

## Public API changes

All changes are additive and target `main`.

- Rust/UniFFI: `MoqAudioProducer::{name, used, unused, reset_epoch}`
- Python: `AudioProducer.{name, used, unused, reset_epoch}`
- Swift: `AudioProducer.{name, used, unused, resetEpoch}`
- Kotlin: the `AudioProducer` alias exposes the generated `name`, `used`, `unused`, and `resetEpoch` methods
- Go: `AudioProducer.{Name, Used, Unused, ResetEpoch}`

## Cross-package sync

`libmoq` is intentionally unchanged. Its C ABI uses callbacks and explicit lifecycle handles rather than the additive async object methods used by the UniFFI language wrappers.

No package versions are changed; the release workflows own version bumps.

## Test plan

- `just fix`
- `just check` (Swift skipped because this Linux host has no Swift toolchain; Rust, Python, Kotlin, Go, docs, and generated bindings passed)
- `just test`
- focused `raw_audio_activity` and `detached_cancels_inner_on_drop` regressions
- `just test smoke-full` (all 21 publisher/subscriber combinations passed)

(Written by GPT-5.6 Codex)