### PR TITLE
feat(kio): let Tasks hold named machines, unboxing the protocol children

### DIFF
--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -49,7 +49,7 @@ pub use producer::{Mut, Producer, Ref};
 pub use queue::{PushError, Queue};
 pub use send::MaybeSend;
 pub use shared::Shared;
-pub use task::Tasks;
+pub use task::{Task, Tasks};
 pub use waiter::{Fan, Hold, Park, Waiter, WaiterList, wait};
 pub use weak::{ConsumerWeak, ProducerWeak, Weak};
 

--- a/rs/kio/src/task.rs
+++ b/rs/kio/src/task.rs
@@ -5,14 +5,15 @@
 //! the task it was aimed at (plus any newly pushed ones). A driver serving
 //! hundreds of children steps one machine per event, not all of them.
 //!
-//! A task is a plain poll closure, the same `FnMut(&Waiter) -> Poll<()>` shape
-//! [`wait`](crate::wait) takes: no trait to implement, state lives in the
-//! captures. `Send` is therefore purely inferred: a [`Tasks`] of `Send`
-//! closures is `Send` and drives from any thread, one capturing an `Rc` is not
-//! and drives locally, and the same code compiles either way. One set holds one
-//! closure type, which one construction site provides naturally; a set that
-//! must mix shapes boxes them (`Box<dyn FnMut(&Waiter) -> Poll<()>>`, adding
-//! `+ Send` only if it crosses threads), and a future adapts with one line:
+//! A task is anything implementing [`Task`]: a plain poll closure (the same
+//! `FnMut(&Waiter) -> Poll<()>` shape [`wait`](crate::wait) takes, state in the
+//! captures) or a named machine implementing the trait directly. `Send` is
+//! purely inferred either way: a [`Tasks`] of `Send` tasks is `Send` and drives
+//! from any thread, one capturing an `Rc` is not and drives locally, and the
+//! same code compiles either way. One set holds one task type, which one
+//! construction site provides naturally; a set that must mix shapes boxes them
+//! (`Box<dyn FnMut(&Waiter) -> Poll<()>>`, adding `+ Send` only if it crosses
+//! threads), and a future adapts with one line:
 //!
 //! ```
 //! let mut tasks = kio::Tasks::new();
@@ -61,7 +62,7 @@ impl Chunk {
 	}
 }
 
-/// A set of poll-closure tasks polled by their owner with per-task granularity.
+/// A set of [`Task`]s polled by their owner with per-task granularity.
 ///
 /// [`poll`](Self::poll) drives the tasks that are new or woken and reports
 /// `Ready` when the set is empty; [`push`](Self::push) wakes the owner, so a
@@ -194,7 +195,24 @@ impl<T> Tasks<T> {
 	}
 }
 
-impl<T: FnMut(&Waiter) -> Poll<()>> Tasks<T> {
+/// A unit of work a [`Tasks`] set drives: polled with a [`Waiter`] until `Ready`.
+///
+/// Every `FnMut(&Waiter) -> Poll<()>` closure implements it, so captures-based
+/// tasks need nothing extra. Implement it on a named machine to store one
+/// concrete type in a set without boxing; `Send` then stays inferred from the
+/// machine's fields, exactly as it is from a closure's captures.
+pub trait Task {
+	/// Drive the task, registering `waiter` for its next wakeup.
+	fn poll(&mut self, waiter: &Waiter) -> Poll<()>;
+}
+
+impl<F: FnMut(&Waiter) -> Poll<()>> Task for F {
+	fn poll(&mut self, waiter: &Waiter) -> Poll<()> {
+		self(waiter)
+	}
+}
+
+impl<T: Task> Tasks<T> {
 	/// Poll every task that is new or was woken since the last call, retiring
 	/// the ones that return `Ready`.
 	///
@@ -247,7 +265,7 @@ impl<T: FnMut(&Waiter) -> Poll<()>> Tasks<T> {
 				};
 				let cx = Context::from_waker(&self.wakers[index]);
 				let child_waiter = occupant.park.hold(&cx);
-				if (occupant.task)(child_waiter).is_ready() {
+				if occupant.task.poll(child_waiter).is_ready() {
 					self.children[index] = None;
 					self.free.push(index);
 					self.len -= 1;

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1417,7 +1417,7 @@ struct TrackServe<S: crate::transport::poll::Session> {
 	track: track::Subscriber,
 	request_id: RequestId,
 	version: Version,
-	children: kio::Tasks<crate::util::MaybeSendTask>,
+	children: kio::Tasks<GroupServe<S>>,
 	/// The track finished: the in-flight group machines drain, then FIN.
 	draining: bool,
 }
@@ -1467,7 +1467,7 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 						},
 					};
 
-					let mut serve = GroupServe {
+					self.children.push(GroupServe {
 						session: self.session.clone(),
 						msg,
 						priority: self.track.subscription().priority,
@@ -1475,9 +1475,7 @@ impl<S: crate::transport::poll::Session> TrackServe<S> {
 						timescale: self.track.info().timescale,
 						version: self.version,
 						state: GroupState::Open,
-					};
-					self.children
-						.push(crate::util::poll_task(move |waiter| serve.poll(waiter)));
+					});
 				}
 				Poll::Ready(Ok(None)) => {
 					self.draining = true;
@@ -1526,7 +1524,7 @@ enum GroupState<S: crate::transport::poll::Session> {
 	Done,
 }
 
-impl<S: crate::transport::poll::Session> GroupServe<S> {
+impl<S: crate::transport::poll::Session> kio::Task for GroupServe<S> {
 	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
 		// Errors just drop the writer, whose Drop resets the stream, exactly like
 		// the old future being discarded.

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -143,7 +143,7 @@ pub(super) struct Publisher<S: crate::transport::poll::Session, R: crate::runtim
 	// A dedicated accept handle: the poll interface takes `&mut self`, and the
 	// shared context stays behind the Arc for the per-stream children.
 	accept: S,
-	children: kio::Tasks<crate::util::MaybeSendTask>,
+	children: kio::Tasks<Control<S, R>>,
 }
 
 impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> Publisher<S, R> {
@@ -185,13 +185,11 @@ where
 		loop {
 			match Stream::poll_accept(&mut self.accept, self.shared.version, &mut cx) {
 				Poll::Ready(Ok(stream)) => {
-					let mut child = Control {
+					self.children.push(Control {
 						shared: self.shared.clone(),
 						runtime: self.runtime.clone(),
 						state: ControlState::Start { stream },
-					};
-					self.children
-						.push(crate::util::poll_task(move |waiter| child.poll(waiter)));
+					});
 				}
 				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
 				Poll::Pending => break,
@@ -251,7 +249,7 @@ enum ControlState<S: crate::transport::poll::Session, R: crate::runtime::Runtime
 	Done,
 }
 
-impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> Control<S, R> {
+impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> kio::Task for Control<S, R> {
 	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
 		if let Err(err) = ready!(self.poll_serve(waiter)) {
 			tracing::warn!(%err, "control stream error");
@@ -1315,7 +1313,7 @@ enum SubscribeState<S: crate::transport::poll::Session> {
 	Run(Box<TrackRun<S>>),
 	/// The track finished: draining the in-flight group streams before the FIN.
 	Drain {
-		children: kio::Tasks<crate::util::MaybeSendTask>,
+		children: kio::Tasks<GroupServe<S>>,
 	},
 	/// FIN and wait for the acknowledgement.
 	Finish {
@@ -2821,7 +2819,7 @@ struct TrackRun<S: crate::transport::poll::Session> {
 	// datagram-capable transport (qmux/WebSocket/TCP/UDS report size 0). No group
 	// fallback: otherwise off.
 	datagrams: bool,
-	children: kio::Tasks<crate::util::MaybeSendTask>,
+	children: kio::Tasks<GroupServe<S>>,
 }
 
 impl<S: crate::transport::poll::Session> TrackRun<S> {
@@ -2955,9 +2953,8 @@ impl<S: crate::transport::poll::Session> TrackRun<S> {
 							false => Priority::new(current_priority, self.ctx.id, sequence),
 						};
 						let handle = self.ctx.priority.insert(priority);
-						let mut serve = GroupServe::new(self.ctx.clone(), sequence, frame_start, handle, group);
 						self.children
-							.push(crate::util::poll_task(move |waiter| serve.poll(waiter)));
+							.push(GroupServe::new(self.ctx.clone(), sequence, frame_start, handle, group));
 					}
 					Recv::Datagram(datagram) => self.ctx.serve_datagram(datagram),
 					Recv::Boundary(group) => {
@@ -3196,7 +3193,7 @@ impl<S: crate::transport::poll::Session> GroupServe<S> {
 	}
 }
 
-impl<S: crate::transport::poll::Session> GroupServe<S> {
+impl<S: crate::transport::poll::Session> kio::Task for GroupServe<S> {
 	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
 		// The machine owns its outcome: the stream was aborted with the reason (or
 		// reset by the writer's Drop), which is all the subscriber sees.

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -6,8 +6,6 @@ use std::{
 	time::Duration,
 };
 
-use crate::util::poll_task;
-
 use crate::{
 	AsPath, Error, Path, PathOwned, Timescale, Timestamp, bandwidth,
 	coding::{Decode, Reader, Stream},
@@ -475,7 +473,7 @@ pub(super) struct SubscriberDriver<S: crate::transport::poll::Session> {
 	/// Datagram receive; inert on a version or transport without datagrams.
 	datagrams: Option<DatagramRecv<S>>,
 	/// One machine per announced source, serving the origin's track requests.
-	sources: kio::Tasks<crate::util::MaybeSendTask>,
+	sources: kio::Tasks<SourceServe<S>>,
 }
 
 impl<S: crate::transport::poll::Session> SubscriberDriver<S> {
@@ -531,8 +529,8 @@ impl<S: crate::transport::poll::Session> SubscriberDriver<S> {
 		// Sources created by the announce half; their completion never ends the
 		// session (the origin delivers the unannounce itself).
 		while let Poll::Ready(Ok((path, dynamic))) = self.subscriber.sources.poll_pop(waiter) {
-			let mut serve = SourceServe::new(self.subscriber.clone(), path, dynamic);
-			self.sources.push(poll_task(move |waiter| serve.poll(waiter)));
+			self.sources
+				.push(SourceServe::new(self.subscriber.clone(), path, dynamic));
 		}
 		let _ = self.sources.poll(waiter);
 
@@ -546,7 +544,7 @@ struct UniAccept<S: crate::transport::poll::Session> {
 	subscriber: Subscriber<S>,
 	// A dedicated accept handle: the poll interface takes `&mut self`.
 	accept: S,
-	children: kio::Tasks<crate::util::MaybeSendTask>,
+	children: kio::Tasks<UniServe<S>>,
 }
 
 impl<S: crate::transport::poll::Session> UniAccept<S> {
@@ -566,13 +564,12 @@ impl<S: crate::transport::poll::Session> UniAccept<S> {
 		loop {
 			match self.accept.poll_accept_uni(&mut cx) {
 				Poll::Ready(Ok(stream)) => {
-					let mut child = UniServe {
+					self.children.push(UniServe {
 						subscriber: self.subscriber.clone(),
 						state: UniState::Start {
 							reader: Reader::new(stream, self.subscriber.version),
 						},
-					};
-					self.children.push(poll_task(move |waiter| child.poll(waiter)));
+					});
 				}
 				Poll::Ready(Err(err)) => return Poll::Ready(Err(Error::from_transport(err))),
 				Poll::Pending => break,
@@ -608,7 +605,7 @@ enum UniState<S: crate::transport::poll::Session> {
 	Done,
 }
 
-impl<S: crate::transport::poll::Session> UniServe<S> {
+impl<S: crate::transport::poll::Session> kio::Task for UniServe<S> {
 	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
 		if let Err(err) = ready!(self.poll_serve(waiter)) {
 			tracing::debug!(%err, "error running uni stream");
@@ -1255,7 +1252,7 @@ struct SourceServe<S: crate::transport::poll::Session> {
 	dynamic: crate::broadcast::Dynamic,
 	// A dedicated close-watch handle, since each pending operation needs its own.
 	closed: S,
-	tracks: kio::Tasks<crate::util::MaybeSendTask>,
+	tracks: kio::Tasks<TrackServeRun<S>>,
 }
 
 impl<S: crate::transport::poll::Session> SourceServe<S> {
@@ -1271,7 +1268,7 @@ impl<S: crate::transport::poll::Session> SourceServe<S> {
 	}
 }
 
-impl<S: crate::transport::poll::Session> SourceServe<S> {
+impl<S: crate::transport::poll::Session> kio::Task for SourceServe<S> {
 	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
 		let _ = self.tracks.poll(waiter);
 
@@ -1297,8 +1294,7 @@ impl<S: crate::transport::poll::Session> SourceServe<S> {
 					};
 					// One machine per track serves its lone subscription and any number
 					// of fetches concurrently.
-					let mut run = TrackServeRun::new(serve, request);
-					self.tracks.push(poll_task(move |waiter| run.poll(waiter)));
+					self.tracks.push(TrackServeRun::new(serve, request));
 				}
 				// The source was finished (unannounced) or aborted.
 				Poll::Ready(Err(err)) => {
@@ -2560,7 +2556,7 @@ impl<S: crate::transport::poll::Session> TrackServeRun<S> {
 	}
 }
 
-impl<S: crate::transport::poll::Session> TrackServeRun<S> {
+impl<S: crate::transport::poll::Session> kio::Task for TrackServeRun<S> {
 	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
 		loop {
 			match &mut self.state {
@@ -2709,7 +2705,7 @@ struct ServeLoop<S: crate::transport::poll::Session> {
 	/// Serve on-demand fetches of uncached groups from this session.
 	dynamic: track::Dynamic,
 	sub: Sub<S>,
-	fetches: kio::Tasks<crate::util::MaybeSendTask>,
+	fetches: kio::Tasks<FetchServeRun<S>>,
 	// A dedicated close-watch handle for the session-died arm.
 	closed: S,
 	// SUBSCRIBE_UPDATE only exists on Lite03+, so older peers can't carry a
@@ -2793,8 +2789,8 @@ impl<S: crate::transport::poll::Session> ServeLoop<S> {
 					match self.dynamic.poll_requested_group(waiter) {
 						Poll::Ready(Ok(req)) => {
 							if self.supports_fetch {
-								let mut run = FetchServeRun::new(serve.clone(), req, self.timescale);
-								self.fetches.push(poll_task(move |waiter| run.poll(waiter)));
+								self.fetches
+									.push(FetchServeRun::new(serve.clone(), req, self.timescale));
 							} else {
 								req.reject(Error::Version);
 							}
@@ -2958,7 +2954,7 @@ impl<S: crate::transport::poll::Session> FetchServeRun<S> {
 	}
 }
 
-impl<S: crate::transport::poll::Session> FetchServeRun<S> {
+impl<S: crate::transport::poll::Session> kio::Task for FetchServeRun<S> {
 	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
 		let mut cx = std::task::Context::from_waker(waiter.waker());
 		loop {

--- a/rs/moq-net/src/util.rs
+++ b/rs/moq-net/src/util.rs
@@ -3,7 +3,7 @@
 //! Native transports (Quinn) are `Send`, so boxed futures and tasks carry the
 //! `Send` bound. Browser WebTransport is `!Send`, so on wasm we box without it.
 //! `MaybeSendBox` / `MaybeSendTask` resolve to the right form per target, and
-//! `.maybe_boxed()` / [`poll_task`] pick the matching constructor.
+//! `.maybe_boxed()` / `future_task` pick the matching constructor.
 
 use std::{collections::VecDeque, future::Future, pin::Pin, task::Poll};
 

--- a/rs/moq-net/src/util.rs
+++ b/rs/moq-net/src/util.rs
@@ -36,17 +36,6 @@ pub(crate) trait MaybeBoxedExt<'a>: Future + Sized + 'a {
 #[cfg(target_family = "wasm")]
 impl<'a, F: Future + 'a> MaybeBoxedExt<'a> for F {}
 
-/// Box a poll closure into a [`MaybeSendTask`], for pushing a hand-rolled
-/// machine into a [`kio::Tasks`] stored behind the type-erased alias.
-#[cfg(not(target_family = "wasm"))]
-pub(crate) fn poll_task(task: impl FnMut(&kio::Waiter) -> Poll<()> + Send + 'static) -> MaybeSendTask {
-	Box::new(task)
-}
-#[cfg(target_family = "wasm")]
-pub(crate) fn poll_task(task: impl FnMut(&kio::Waiter) -> Poll<()> + 'static) -> MaybeSendTask {
-	Box::new(task)
-}
-
 /// Adapt a boxed future into a [`kio::Tasks`] task.
 fn future_task(mut task: MaybeSendBox<'static, ()>) -> MaybeSendTask {
 	Box::new(move |waiter| waiter.poll_future(task.as_mut()))


### PR DESCRIPTION
## Summary

PR 3b of the io_uring plan on #2875 (https://github.com/moq-dev/moq/issues/2875#issuecomment-5382468199), stacked on #3027: the erasure half of the de-future step.

`kio::Tasks` previously accepted only `FnMut` closures, so a struct field holding a task set had to erase (`Box<dyn FnMut(&Waiter) -> Poll<()> + Send>`), and the `Send` in that box is chosen per-target by `cfg` (`util::MaybeSendTask`) instead of being inferred, which is exactly what a pinned `!Send` transport cannot satisfy on native.

**kio**: a new `Task` trait (`poll(&mut self, &Waiter) -> Poll<()>`), blanket-implemented for every matching `FnMut` closure, so existing closure-based sets (including `Box<dyn FnMut>` ones like moq-uring's) compile unchanged. A named machine implements it directly and is stored in a `Tasks` concretely; `Send` then stays inferred from its fields, exactly as it is from a closure's captures. Additive: the `impl<T: FnMut> Tasks<T>` bound widened to `impl<T: Task> Tasks<T>` with the blanket covering every prior instantiation.

**moq-net**: every task set whose occupants were already hand-rolled machines (the box was pure type erasure) now stores the machine type itself, with the machines' inherent `poll` becoming the `kio::Task` impl:

- lite subscriber: `SourceServe`, `UniServe`, `TrackServeRun`, `FetchServeRun`
- lite publisher: `Control`, `GroupServe` (including the `Drain` state that inherits `TrackRun`'s set)
- ietf publisher: `GroupServe`

`util::poll_task` is deleted. What remains erased is the genuinely-async ietf machinery (session driver blocks, `run_broadcast`/`run_subscribe`, `handle_stream` arms) plus the boxed `Machine` internals; those convert in the next step of the series, which then deletes `MaybeSendBox`/`MaybeSendTask` and the last `cfg(wasm)` split in util.rs and makes `Machine<R>` `Send` exactly when `R::Transport` is.

## Validation

- `just check` and `just test` pass: 3171 tests (kio, moq-net, and every dependent), wasm32 gate included.
- moq-uring cross-checked for `x86_64-unknown-linux-gnu` (its `Tasks<Box<dyn FnMut>>` rides the blanket impl unchanged).
- No public moq-net API changes; kio's addition is additive (no version bump per release policy).

No wire changes, so no draft updates.

(Written by Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)