### PR TITLE
fix(net): deprecate unsupported dynamic routing

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -317,7 +317,7 @@ _ = producer.Finish()
 
 Call `request.Abort(code)` when the requested group cannot be produced. Fetch is currently a single-group operation and is supported by the moq-lite 05+ FETCH wire path.
 
-To serve requests in a loop, range over `dynamic.Requests(ctx)` instead, the same shape `BroadcastDynamic` and `OriginDynamic` use:
+To serve requests in a loop, range over `dynamic.Requests(ctx)` instead, the same shape `BroadcastDynamic` uses:
 
 ```go
 for request, err := range dynamic.Requests(ctx) {
@@ -404,57 +404,6 @@ for datagram, err := range consumer.Datagrams(ctx) {
 ```
 
 Datagrams are delivered as `Datagram{Sequence, TimestampUs, Payload}`. Payloads are capped at 1200 bytes. Delivery requires a datagram-capable transport and lite-05 or newer moq-lite; IETF moq-transport, pre-lite-05, WebSocket, and TCP paths do not deliver them, and there is no stream fallback.
-
-## On-demand broadcasts
-
-Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
-
-```go
-capacity := uint64(256 * 1024 * 1024)
-origin := moq.NewOriginProducerWithOptions(moq.OriginOptions{
-	CacheCapacityBytes: &capacity,
-})
-
-dynamic := origin.Dynamic()
-defer dynamic.Cancel()
-
-for request, err := range dynamic.Requests(ctx) {
-	if err != nil {
-		if moq.IsShutdown(err) {
-			break
-		}
-		log.Fatal(err)
-	}
-
-	path, err := request.Path()
-	if err != nil {
-		log.Fatal(err)
-	}
-	if path != "events" {
-		if err := request.Abort(404); err != nil {
-			log.Fatal(err)
-		}
-		continue
-	}
-
-	broadcast, err := moq.NewBroadcastProducer()
-	if err != nil {
-		log.Fatal(err)
-	}
-	track, err := broadcast.PublishTrack("status", nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if err := request.Accept(broadcast); err != nil {
-		log.Fatal(err)
-	}
-	if err := track.WriteFrame(moq.Frame{Payload: []byte("ready")}); err != nil {
-		log.Fatal(err)
-	}
-}
-```
-
-The served broadcast is not announced. It only resolves consumers that call `RequestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `Accept(broadcast)` to serve it, or `Abort(code)` to fail the requester.
 
 ## Local development
 

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -405,57 +405,6 @@ for datagram, err := range consumer.Datagrams(ctx) {
 
 Datagrams are delivered as `Datagram{Sequence, TimestampUs, Payload}`. Payloads are capped at 1200 bytes. Delivery requires a datagram-capable transport and lite-05 or newer moq-lite; IETF moq-transport, pre-lite-05, WebSocket, and TCP paths do not deliver them, and there is no stream fallback.
 
-## On-demand broadcasts
-
-Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
-
-```go
-capacity := uint64(256 * 1024 * 1024)
-origin := moq.NewOriginProducerWithOptions(moq.OriginOptions{
-	CacheCapacityBytes: &capacity,
-})
-
-dynamic := origin.Dynamic()
-defer dynamic.Cancel()
-
-for request, err := range dynamic.Requests(ctx) {
-	if err != nil {
-		if moq.IsShutdown(err) {
-			break
-		}
-		log.Fatal(err)
-	}
-
-	path, err := request.Path()
-	if err != nil {
-		log.Fatal(err)
-	}
-	if path != "events" {
-		if err := request.Abort(404); err != nil {
-			log.Fatal(err)
-		}
-		continue
-	}
-
-	broadcast, err := moq.NewBroadcastProducer()
-	if err != nil {
-		log.Fatal(err)
-	}
-	track, err := broadcast.PublishTrack("status", nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if err := request.Accept(broadcast); err != nil {
-		log.Fatal(err)
-	}
-	if err := track.WriteFrame(moq.Frame{Payload: []byte("ready")}); err != nil {
-		log.Fatal(err)
-	}
-}
-```
-
-The served broadcast is not announced. It only resolves consumers that call `RequestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `Accept(broadcast)` to serve it, or `Abort(code)` to fail the requester.
-
 ## Local development
 
 The in-tree `go/wrapper/` directory is the source skeleton; CI publishes it to the [moq-dev/moq-go](https://github.com/moq-dev/moq-go) mirror. To exercise it locally:

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -290,30 +290,6 @@ consumer.datagrams().collect { datagram ->
 
 Datagrams are delivered as `Datagram(sequence, timestampUs, payload)`. Payloads are capped at 1200 bytes. Delivery requires a datagram-capable transport and lite-05 or newer moq-lite; IETF moq-transport, pre-lite-05, WebSocket, and TCP paths do not deliver them, and there is no stream fallback.
 
-### On-demand broadcasts
-
-Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
-
-```kotlin
-import dev.moq.*
-
-val origin = OriginProducer(OriginOptions(cacheCapacityBytes = 256UL * 1024UL * 1024UL))
-val dynamic = origin.dynamic()
-
-dynamic.requestedBroadcasts().collect { request ->
-    if (request.path() == "events") {
-        val broadcast = BroadcastProducer()
-        val track = broadcast.publishTrack("status", null)
-        request.accept(broadcast)
-        track.writeFrame(Frame(payload = "ready".encodeToByteArray()))
-    } else {
-        request.abort(404u)
-    }
-}
-```
-
-The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `abort(code)` to fail the requester.
-
 ### JSON tracks
 
 For JSON payloads, publish and subscribe with the framing handled for you, in one of two modes. Snapshot (lossy) carries one value updated over time; a subscriber only sees the latest. Stream (lossless) is an ordered append-log where every record is preserved.

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -58,7 +58,7 @@ To resolve a single broadcast rather than iterate announcements:
 // Waits for the announcement, however long that takes.
 val broadcast = moq.announcedBroadcast("demos/clock").available()
 
-// Returns an already-announced broadcast, or throws.
+// Resolves without waiting for a future announcement, or throws.
 val broadcast = moq.requestBroadcast("demos/clock")
 ```
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -58,7 +58,7 @@ To resolve a single broadcast rather than iterate announcements:
 // Waits for the announcement, however long that takes.
 val broadcast = moq.announcedBroadcast("demos/clock").available()
 
-// Resolves as soon as it can be served (announced or dynamic), else throws.
+// Returns an already-announced broadcast, or throws.
 val broadcast = moq.requestBroadcast("demos/clock")
 ```
 
@@ -289,30 +289,6 @@ consumer.datagrams().collect { datagram ->
 ```
 
 Datagrams are delivered as `Datagram(sequence, timestampUs, payload)`. Payloads are capped at 1200 bytes. Delivery requires a datagram-capable transport and lite-05 or newer moq-lite; IETF moq-transport, pre-lite-05, WebSocket, and TCP paths do not deliver them, and there is no stream fallback.
-
-### On-demand broadcasts
-
-Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
-
-```kotlin
-import dev.moq.*
-
-val origin = OriginProducer(OriginOptions(cacheCapacityBytes = 256UL * 1024UL * 1024UL))
-val dynamic = origin.dynamic()
-
-dynamic.requestedBroadcasts().collect { request ->
-    if (request.path() == "events") {
-        val broadcast = BroadcastProducer()
-        val track = broadcast.publishTrack("status", null)
-        request.accept(broadcast)
-        track.writeFrame(Frame(payload = "ready".encodeToByteArray()))
-    } else {
-        request.abort(404u)
-    }
-}
-```
-
-The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `abort(code)` to fail the requester.
 
 ### JSON tracks
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -296,24 +296,6 @@ async for request in dynamic:
 
 Missing track subscriptions are accepted while the `BroadcastDynamic` object is alive. Each one arrives as a `TrackRequest`; call `accept()` to turn it into a `TrackProducer` (or `abort(code)` to reject the subscriber).
 
-### On-demand broadcasts
-
-Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
-
-```python
-origin = moq.OriginProducer(cache_capacity_bytes=256 * 1024 * 1024)
-dynamic = origin.dynamic()
-
-async for request in dynamic:
-    if request.path == "events":
-        broadcast = moq.BroadcastProducer()
-        track = broadcast.publish_track("status")
-        request.accept(broadcast)
-        track.write_frame(b"ready", 0)
-```
-
-The served broadcast is not announced. It only resolves consumers that call `request_broadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `abort(code)` to fail the requester.
-
 ### Discovering broadcasts
 
 ```python
@@ -325,12 +307,11 @@ async for announcement in client.announced("live/"):
 # Or wait for a specific path to be announced:
 broadcast = await client.announced_broadcast("live/cam1")
 
-# Or request a path: resolves to the announced broadcast, falls back to a dynamic
-# handler if the origin has one, else raises. Does not wait for a future announce.
+# Or request a path that is already announced. This does not wait for a future announce.
 broadcast = await client.request_broadcast("live/cam1")
 ```
 
-Announcements arrive over the session after it connects, so `request_broadcast` on its own races them: right after connecting it can raise for a broadcast that is live. Await `announced_broadcast(path)` first when you know the path you want; `request_broadcast` is for a path a dynamic handler serves, or one you already know is announced.
+Announcements arrive over the session after it connects, so `request_broadcast` on its own races them: right after connecting it can raise for a broadcast that is live. Await `announced_broadcast(path)` first when you know the path you want; use `request_broadcast` only when you already know the path is announced.
 
 Each broadcast carries a `Route`: `route.hops` is the chain of relay origin ids (as `list[int]`) the broadcast passed through to reach you, oldest first, and `route.cost` is the publisher's advertised preference (lower wins). The route is dynamic; `await broadcast.route_changed()` returns the current route first, then blocks for each change (e.g. an upstream failover), and returns `None` once the broadcast ends. A publisher advertises its own route with `producer.set_route(moq.Route(hops=[], cost=10))`, for example a standby transcoder that lowers its cost to 0 once it is warm.
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -307,11 +307,11 @@ async for announcement in client.announced("live/"):
 # Or wait for a specific path to be announced:
 broadcast = await client.announced_broadcast("live/cam1")
 
-# Or request a path that is already announced. This does not wait for a future announce.
+# Or resolve a path without waiting for a future announce.
 broadcast = await client.request_broadcast("live/cam1")
 ```
 
-Announcements arrive over the session after it connects, so `request_broadcast` on its own races them: right after connecting it can raise for a broadcast that is live. Await `announced_broadcast(path)` first when you know the path you want; use `request_broadcast` only when you already know the path is announced.
+Announcements arrive over the session after it connects, so `request_broadcast` on its own races them: right after connecting it can raise for a broadcast that is live. Await `announced_broadcast(path)` when you want to wait for that announcement; use `request_broadcast` when the path should resolve immediately or fail.
 
 Each broadcast carries a `Route`: `route.hops` is the chain of relay origin ids (as `list[int]`) the broadcast passed through to reach you, oldest first, and `route.cost` is the publisher's advertised preference (lower wins). The route is dynamic; `await broadcast.route_changed()` returns the current route first, then blocks for each change (e.g. an upstream failover), and returns `None` once the broadcast ends. A publisher advertises its own route with `producer.set_route(moq.Route(hops=[], cost=10))`, for example a standby transcoder that lowers its cost to 0 once it is warm.
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -296,24 +296,6 @@ async for request in dynamic:
 
 Missing track subscriptions are accepted while the `BroadcastDynamic` object is alive. Each one arrives as a `TrackRequest`; call `accept()` to turn it into a `TrackProducer` (or `abort(code)` to reject the subscriber).
 
-### On-demand broadcasts
-
-Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
-
-```python
-origin = moq.OriginProducer(cache_capacity_bytes=256 * 1024 * 1024)
-dynamic = origin.dynamic()
-
-async for request in dynamic:
-    if request.path == "events":
-        broadcast = moq.BroadcastProducer()
-        track = broadcast.publish_track("status")
-        request.accept(broadcast)
-        track.write_frame(b"ready", 0)
-```
-
-The served broadcast is not announced. It only resolves consumers that call `request_broadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `abort(code)` to fail the requester.
-
 ### Discovering broadcasts
 
 ```python
@@ -325,12 +307,12 @@ async for announcement in client.announced("live/"):
 # Or wait for a specific path to be announced:
 broadcast = await client.announced_broadcast("live/cam1")
 
-# Or request a path: resolves to the announced broadcast, falls back to a dynamic
-# handler if the origin has one, else raises. Does not wait for a future announce.
+# Or request a path that can be served immediately. This does not wait for a
+# future announcement.
 broadcast = await client.request_broadcast("live/cam1")
 ```
 
-Announcements arrive over the session after it connects, so `request_broadcast` on its own races them: right after connecting it can raise for a broadcast that is live. Await `announced_broadcast(path)` first when you know the path you want; `request_broadcast` is for a path a dynamic handler serves, or one you already know is announced.
+Announcements arrive over the session after it connects, so `request_broadcast` on its own races them: right after connecting it can raise for a broadcast that is live. Await `announced_broadcast(path)` first when you know the path you want; use `request_broadcast` only for a path you already know is available.
 
 Each broadcast carries a `Route`: `route.hops` is the chain of relay origin ids (as `list[int]`) the broadcast passed through to reach you, oldest first, and `route.cost` is the publisher's advertised preference (lower wins). The route is dynamic; `await broadcast.route_changed()` returns the current route first, then blocks for each change (e.g. an upstream failover), and returns `None` once the broadcast ends. A publisher advertises its own route with `producer.set_route(moq.Route(hops=[], cost=10))`, for example a standby transcoder that lowers its cost to 0 once it is warm.
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -260,28 +260,6 @@ for try await record in try await consumer.subscribeJsonStream(name: "events", a
 
 `compression` must match on the producer and subscriber. Snapshot mode also takes `deltaRatio` (`0` disables merge-patch deltas, so every change is a fresh snapshot). Advertise the track with a catalog section (`setCatalogSection`) if subscribers should discover it.
 
-### On-demand broadcasts
-
-Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
-
-```swift
-let origin = OriginProducer(cacheCapacityBytes: 256 * 1024 * 1024)
-let dynamic = origin.dynamic()
-
-for try await request in dynamic {
-    if try request.path == "events" {
-        let broadcast = try BroadcastProducer()
-        let track = try broadcast.publishTrack(name: "status")
-        try request.accept(broadcast: broadcast)
-        try track.writeFrame(Data("ready".utf8), timestampUs: 0)
-    } else {
-        try request.abort(errorCode: 404)
-    }
-}
-```
-
-The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path:)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast:)` to serve it, or `abort(errorCode:)` to fail the requester.
-
 ### Raw media
 
 `publishMedia` above takes frames you already encoded. To hand over raw pixels or PCM instead and let the codec run inside the bindings, use `publishVideo` / `publishAudio`. Pixel format, resolution, and framerate are fixed at publish time, so each frame carries only its pixels and a timestamp:

--- a/go/wrapper/moq/client.go
+++ b/go/wrapper/moq/client.go
@@ -175,9 +175,8 @@ func (c *Client) AnnouncedBroadcast(path string) (*AnnouncedBroadcast, error) {
 	return c.consumer.AnnouncedBroadcast(path)
 }
 
-// RequestBroadcast resolves a broadcast at path as soon as it can be served: the
-// announced broadcast if present, otherwise a dynamic fallback on the origin, or an
-// error. Unlike AnnouncedBroadcast, it does not wait for a future announcement.
+// RequestBroadcast resolves a broadcast at path as soon as it can be served, or
+// returns an error. Unlike AnnouncedBroadcast, it does not wait for a future announcement.
 func (c *Client) RequestBroadcast(path string) (*BroadcastConsumer, error) {
 	return c.consumer.RequestBroadcast(path)
 }

--- a/go/wrapper/moq/moq_test.go
+++ b/go/wrapper/moq/moq_test.go
@@ -31,7 +31,6 @@ func opusHead() []byte {
 func TestOriginLifecycle(t *testing.T) {
 	origin := moq.NewOriginProducer()
 	_ = origin.Consume()
-	origin.Dynamic().Cancel()
 }
 
 func TestDynamicBroadcastRequest(t *testing.T) {

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -112,9 +112,9 @@ func (o *OriginConsumer) AnnouncedBroadcast(path string) (*AnnouncedBroadcast, e
 	return &AnnouncedBroadcast{inner: inner}, nil
 }
 
-// RequestBroadcast returns an already-announced broadcast at path, or an error if
-// none is available. Unlike AnnouncedBroadcast, it does not wait for a future
-// announcement. Blocks until resolved.
+// RequestBroadcast resolves a broadcast at path when it can be served, or returns
+// an error. Unlike AnnouncedBroadcast, it does not wait for a future announcement.
+// Blocks until resolved.
 func (o *OriginConsumer) RequestBroadcast(path string) (*BroadcastConsumer, error) {
 	inner, err := o.inner.RequestBroadcast(path)
 	if err != nil {

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -81,6 +81,8 @@ func (d *OriginDynamic) Cancel() {
 }
 
 // BroadcastRequest is a requested broadcast that has not been accepted yet.
+//
+// Deprecated: dynamic routing is not currently supported by clients.
 type BroadcastRequest struct {
 	inner *ffi.MoqBroadcastRequest
 }

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -30,7 +30,7 @@ func (o *OriginProducer) Consume() *OriginConsumer {
 	return &OriginConsumer{inner: o.inner.Consume()}
 }
 
-// Dynamic serves broadcasts that consumers request without an announcement.
+// Deprecated: Dynamic origin routing is not currently supported by clients.
 func (o *OriginProducer) Dynamic() *OriginDynamic {
 	return &OriginDynamic{inner: o.inner.Dynamic()}
 }

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -30,9 +30,6 @@ func (o *OriginProducer) Consume() *OriginConsumer {
 	return &OriginConsumer{inner: o.inner.Consume()}
 }
 
-// Dynamic serves broadcasts that consumers request without an announcement.
-//
-// Deprecated: dynamic routing is not currently supported by clients.
 func (o *OriginProducer) Dynamic() *OriginDynamic {
 	return &OriginDynamic{inner: o.inner.Dynamic()}
 }
@@ -53,14 +50,10 @@ func (o *OriginProducer) CreateBroadcast(path string) (*BroadcastProducer, error
 	return &BroadcastProducer{inner: inner}, nil
 }
 
-// OriginDynamic streams broadcast requests for paths that are not announced.
-//
-// Deprecated: dynamic routing is not currently supported by clients.
 type OriginDynamic struct {
 	inner *ffi.MoqOriginDynamic
 }
 
-// RequestedBroadcast blocks until a consumer requests an unannounced broadcast.
 func (d *OriginDynamic) RequestedBroadcast(ctx context.Context) (*BroadcastRequest, error) {
 	inner, err := runCancellable(ctx, d.inner.Cancel, d.inner.RequestedBroadcast)
 	if err != nil {
@@ -69,28 +62,22 @@ func (d *OriginDynamic) RequestedBroadcast(ctx context.Context) (*BroadcastReque
 	return &BroadcastRequest{inner: inner}, nil
 }
 
-// Requests ranges over requested broadcasts until the stream errors or the loop
-// breaks.
 func (d *OriginDynamic) Requests(ctx context.Context) iter.Seq2[*BroadcastRequest, error] {
 	return streamSeq(ctx, d.RequestedBroadcast)
 }
 
-// Cancel stops serving requested broadcasts.
 func (d *OriginDynamic) Cancel() {
 	d.inner.Cancel()
 }
 
-// BroadcastRequest is a requested broadcast that has not been accepted yet.
 type BroadcastRequest struct {
 	inner *ffi.MoqBroadcastRequest
 }
 
-// Path returns the requested broadcast path.
 func (r *BroadcastRequest) Path() (string, error) {
 	return r.inner.Path()
 }
 
-// Accept serves the request with an unannounced broadcast.
 func (r *BroadcastRequest) Accept(broadcast *BroadcastProducer) error {
 	if broadcast == nil {
 		return errors.New("moq: nil broadcast producer")
@@ -98,7 +85,6 @@ func (r *BroadcastRequest) Accept(broadcast *BroadcastProducer) error {
 	return r.inner.Accept(broadcast.inner)
 }
 
-// Abort fails the request with an application error code.
 func (r *BroadcastRequest) Abort(errorCode uint16) error {
 	return r.inner.Abort(errorCode)
 }

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -31,6 +31,8 @@ func (o *OriginProducer) Consume() *OriginConsumer {
 }
 
 // Dynamic serves broadcasts that consumers request without an announcement.
+//
+// Deprecated: dynamic routing is not currently supported by clients.
 func (o *OriginProducer) Dynamic() *OriginDynamic {
 	return &OriginDynamic{inner: o.inner.Dynamic()}
 }
@@ -52,6 +54,8 @@ func (o *OriginProducer) CreateBroadcast(path string) (*BroadcastProducer, error
 }
 
 // OriginDynamic streams broadcast requests for paths that are not announced.
+//
+// Deprecated: dynamic routing is not currently supported by clients.
 type OriginDynamic struct {
 	inner *ffi.MoqOriginDynamic
 }
@@ -122,10 +126,9 @@ func (o *OriginConsumer) AnnouncedBroadcast(path string) (*AnnouncedBroadcast, e
 	return &AnnouncedBroadcast{inner: inner}, nil
 }
 
-// RequestBroadcast resolves a broadcast at path as soon as it can be served: the
-// announced broadcast if present, otherwise a dynamic fallback on the origin, or an
-// error if neither can serve it. Unlike AnnouncedBroadcast, it does not wait for a
-// future announcement. Blocks until resolved.
+// RequestBroadcast returns an already-announced broadcast at path, or an error if
+// none is available. Unlike AnnouncedBroadcast, it does not wait for a future
+// announcement. Blocks until resolved.
 func (o *OriginConsumer) RequestBroadcast(path string) (*BroadcastConsumer, error) {
 	inner, err := o.inner.RequestBroadcast(path)
 	if err != nil {

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -40,9 +40,8 @@ type BroadcastProducer struct {
 	inner *ffi.MoqBroadcastProducer
 }
 
-// NewBroadcastProducer creates a standalone broadcast, not attached to any
-// origin: use it to serve a dynamic request ([BroadcastRequest.Accept]) or for
-// local pub/sub. To publish at a path, use [OriginProducer.CreateBroadcast].
+// NewBroadcastProducer creates a standalone broadcast for local pub/sub.
+// To publish at a path, use [OriginProducer.CreateBroadcast].
 func NewBroadcastProducer() (*BroadcastProducer, error) {
 	inner, err := ffi.NewMoqBroadcastProducer()
 	if err != nil {

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -23,9 +23,10 @@ typealias OriginProducer = uniffi.moq.MoqOriginProducer
 typealias OriginOptions = uniffi.moq.MoqOriginOptions
 /** The subscribe side of an origin: discover and request announced broadcasts. */
 typealias OriginConsumer = uniffi.moq.MoqOriginConsumer
+/** @suppress */
 @Deprecated("dynamic routing is not currently supported by clients")
 typealias OriginDynamic = uniffi.moq.MoqOriginDynamic
-/** A requested broadcast not yet accepted: fulfill it with a producer or abort it. */
+/** @suppress */
 typealias BroadcastRequest = uniffi.moq.MoqBroadcastRequest
 /** A stream of broadcast announcements under a prefix. */
 typealias Announced = uniffi.moq.MoqAnnounced

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -23,7 +23,7 @@ typealias OriginProducer = uniffi.moq.MoqOriginProducer
 typealias OriginOptions = uniffi.moq.MoqOriginOptions
 /** The subscribe side of an origin: discover and request announced broadcasts. */
 typealias OriginConsumer = uniffi.moq.MoqOriginConsumer
-/** A stream of broadcasts requested by subscribers, for serving unannounced paths on demand. */
+@Deprecated("dynamic routing is not currently supported by clients")
 typealias OriginDynamic = uniffi.moq.MoqOriginDynamic
 /** A requested broadcast not yet accepted: fulfill it with a producer or abort it. */
 typealias BroadcastRequest = uniffi.moq.MoqBroadcastRequest

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -23,7 +23,7 @@ typealias OriginProducer = uniffi.moq.MoqOriginProducer
 typealias OriginOptions = uniffi.moq.MoqOriginOptions
 /** The subscribe side of an origin: discover and request announced broadcasts. */
 typealias OriginConsumer = uniffi.moq.MoqOriginConsumer
-/** A stream of broadcasts requested by subscribers, for serving unannounced paths on demand. */
+@Deprecated("Dynamic origin routing is not currently supported by clients.")
 typealias OriginDynamic = uniffi.moq.MoqOriginDynamic
 /** A requested broadcast not yet accepted: fulfill it with a producer or abort it. */
 typealias BroadcastRequest = uniffi.moq.MoqBroadcastRequest

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
@@ -178,6 +178,7 @@ fun MoqTrackDynamic.requestedGroups(): Flow<MoqGroupRequest> = flow {
     if (cause is CancellationException) cancel()
 }
 
+/** @suppress */
 @Deprecated("dynamic routing is not currently supported by clients")
 fun MoqOriginDynamic.requestedBroadcasts(): Flow<MoqBroadcastRequest> = flow {
     while (true) {

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
@@ -178,7 +178,7 @@ fun MoqTrackDynamic.requestedGroups(): Flow<MoqGroupRequest> = flow {
     if (cause is CancellationException) cancel()
 }
 
-/** Stream of broadcasts requested by consumers. */
+@Deprecated("Dynamic origin routing is not currently supported by clients.")
 fun MoqOriginDynamic.requestedBroadcasts(): Flow<MoqBroadcastRequest> = flow {
     while (true) {
         currentCoroutineContext().ensureActive()

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
@@ -178,7 +178,7 @@ fun MoqTrackDynamic.requestedGroups(): Flow<MoqGroupRequest> = flow {
     if (cause is CancellationException) cancel()
 }
 
-/** Stream of broadcasts requested by consumers. */
+@Deprecated("dynamic routing is not currently supported by clients")
 fun MoqOriginDynamic.requestedBroadcasts(): Flow<MoqBroadcastRequest> = flow {
     while (true) {
         currentCoroutineContext().ensureActive()

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
@@ -53,11 +53,9 @@ class Moq internal constructor(
     fun announcedBroadcast(path: String): MoqAnnouncedBroadcast = session.consumer().announcedBroadcast(path)
 
     /**
-     * Resolve the broadcast at [path] as soon as it can be served: the announced
-     * broadcast if present, otherwise a dynamic fallback on the origin.
+     * Resolve an already-announced broadcast at [path], or throw if none is available.
      *
-     * Unlike [announcedBroadcast] this does not wait for a future announcement;
-     * it throws when neither can serve the path.
+     * Unlike [announcedBroadcast] this does not wait for a future announcement.
      */
     suspend fun requestBroadcast(path: String): MoqBroadcastConsumer = session.consumer().requestBroadcast(path)
 

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
@@ -53,7 +53,7 @@ class Moq internal constructor(
     fun announcedBroadcast(path: String): MoqAnnouncedBroadcast = session.consumer().announcedBroadcast(path)
 
     /**
-     * Resolve an already-announced broadcast at [path], or throw if none is available.
+     * Resolve a broadcast at [path] when it can be served, or throw otherwise.
      *
      * Unlike [announcedBroadcast] this does not wait for a future announcement.
      */

--- a/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
+++ b/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
@@ -55,7 +55,6 @@ class SmokeTest {
     fun `origin alias constructs and consumes`() = runTest {
         OriginProducer(OriginOptions()).use { origin ->
             origin.consume().use { /* lifecycle smoke */ }
-            origin.dynamic().use { /* dynamic origin smoke */ }
         }
     }
 

--- a/kt/scripts/generate.sh
+++ b/kt/scripts/generate.sh
@@ -82,4 +82,6 @@ cargo run --locked ${CARGO_PROFILE[@]+"${CARGO_PROFILE[@]}"} --package moq-ffi -
     generate --library "$CDYLIB" --language kotlin --no-format --out-dir "$BINDGEN_OUT"
 
 mkdir -p "$KT_DIR/moq-ffi/src/jvmAndAndroidMain/kotlin/uniffi/moq"
-cp "$BINDGEN_OUT/uniffi/moq/moq.kt" "$KT_DIR/moq-ffi/src/jvmAndAndroidMain/kotlin/uniffi/moq/moq.kt"
+GENERATED_KT="$KT_DIR/moq-ffi/src/jvmAndAndroidMain/kotlin/uniffi/moq/moq.kt"
+cp "$BINDGEN_OUT/uniffi/moq/moq.kt" "$GENERATED_KT"
+bash "$SCRIPT_DIR/patch-bindings.sh" "$GENERATED_KT"

--- a/kt/scripts/package.sh
+++ b/kt/scripts/package.sh
@@ -162,7 +162,9 @@ GENERATED_KT="$BINDINGS_DIR/uniffi/moq/moq.kt"
     exit 1
 }
 mkdir -p "$KT_DIR/moq-ffi/src/jvmAndAndroidMain/kotlin/uniffi/moq"
-cp "$GENERATED_KT" "$KT_DIR/moq-ffi/src/jvmAndAndroidMain/kotlin/uniffi/moq/moq.kt"
+PACKAGED_KT="$KT_DIR/moq-ffi/src/jvmAndAndroidMain/kotlin/uniffi/moq/moq.kt"
+cp "$GENERATED_KT" "$PACKAGED_KT"
+bash "$SCRIPT_DIR/patch-bindings.sh" "$PACKAGED_KT"
 
 # --- Maven-local publish ---
 MAVEN_LOCAL="$OUTPUT_DIR/maven-local"

--- a/kt/scripts/patch-bindings.sh
+++ b/kt/scripts/patch-bindings.sh
@@ -2,23 +2,30 @@
 set -euo pipefail
 
 # UniFFI does not propagate Rust deprecation metadata to generated Kotlin.
-# Patch both the interface and implementation declarations so every call site
-# receives the language-native warning.
+# Patch both OriginProducer declarations so every call site receives the
+# language-native warning.
 BINDINGS="${1:?usage: patch-bindings.sh <moq.kt>}"
 OUTPUT=$(mktemp)
 trap 'rm -f "$OUTPUT"' EXIT
 
 awk '
-    /fun dynamic\(/ {
+    /^public interface MoqOriginProducerInterface \{/ {
+        origin = 1
+    }
+    /^open class MoqOriginProducer:/ {
+        origin = 1
+    }
+    origin && /fun dynamic\(/ {
         indent = $0
         sub(/[^ ].*$/, "", indent)
         print indent "@Deprecated(\"dynamic routing is not currently supported by clients\")"
         count++
+        origin = 0
     }
     { print }
     END {
         if (count != 2) {
-            print "expected two generated dynamic declarations, found " count > "/dev/stderr"
+            print "expected two generated OriginProducer.dynamic declarations, found " count > "/dev/stderr"
             exit 1
         }
     }

--- a/kt/scripts/patch-bindings.sh
+++ b/kt/scripts/patch-bindings.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# UniFFI does not propagate Rust deprecation metadata to generated Kotlin.
+# Patch both the interface and implementation declarations so every call site
+# receives the language-native warning.
+BINDINGS="${1:?usage: patch-bindings.sh <moq.kt>}"
+OUTPUT=$(mktemp)
+trap 'rm -f "$OUTPUT"' EXIT
+
+awk '
+    /fun dynamic\(/ {
+        indent = $0
+        sub(/[^ ].*$/, "", indent)
+        print indent "@Deprecated(\"dynamic routing is not currently supported by clients\")"
+        count++
+    }
+    { print }
+    END {
+        if (count != 2) {
+            print "expected two generated dynamic declarations, found " count > "/dev/stderr"
+            exit 1
+        }
+    }
+' "$BINDINGS" >"$OUTPUT"
+
+mv "$OUTPUT" "$BINDINGS"
+trap - EXIT

--- a/kt/scripts/patch-bindings.sh
+++ b/kt/scripts/patch-bindings.sh
@@ -15,9 +15,14 @@ awk '
     /^open class MoqOriginProducer:/ {
         origin = 1
     }
+    /^(public interface MoqOriginDynamicInterface \{|open class MoqOriginDynamic:|public interface MoqBroadcastRequestInterface \{|open class MoqBroadcastRequest:)/ {
+        print "/** @suppress */"
+        hidden_count++
+    }
     origin && /fun `dynamic`\(/ {
         indent = $0
         sub(/[^ ].*$/, "", indent)
+        print indent "/** @suppress */"
         print indent "@Deprecated(\"dynamic routing is not currently supported by clients\")"
         count++
         origin = 0
@@ -26,6 +31,10 @@ awk '
     END {
         if (count != 2) {
             print "expected two generated OriginProducer.dynamic declarations, found " count > "/dev/stderr"
+            exit 1
+        }
+        if (hidden_count != 4) {
+            print "expected four generated dynamic compatibility types, found " hidden_count > "/dev/stderr"
             exit 1
         }
     }

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -180,11 +180,7 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 
 - **`OriginProducer(cache_capacity_bytes=None)`**. Manage broadcast announcements. Set `cache_capacity_bytes` to bound cached groups under this origin.
   - `.consume() → OriginConsumer`
-  - `.dynamic() → OriginDynamic`
   - `.create_broadcast(path) → BroadcastProducer`
-- **`OriginDynamic`**. Async source of broadcasts requested by consumers.
-  - `await .requested_broadcast() → BroadcastRequest`. Call `.accept(broadcast)` to serve it, or `.abort(code)` to fail the requester.
-  - Async iterator yielding `BroadcastRequest`
 - **`OriginConsumer`**. Discover broadcasts.
   - `.announced(prefix) → Announced` (async iterator)
   - `.announced_broadcast(path) → AnnouncedBroadcast` (awaitable, waits for a future announcement)

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -180,15 +180,11 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 
 - **`OriginProducer(cache_capacity_bytes=None)`**. Manage broadcast announcements. Set `cache_capacity_bytes` to bound cached groups under this origin.
   - `.consume() → OriginConsumer`
-  - `.dynamic() → OriginDynamic`
   - `.create_broadcast(path) → BroadcastProducer`
-- **`OriginDynamic`**. Async source of broadcasts requested by consumers.
-  - `await .requested_broadcast() → BroadcastRequest`. Call `.accept(broadcast)` to serve it, or `.abort(code)` to fail the requester.
-  - Async iterator yielding `BroadcastRequest`
 - **`OriginConsumer`**. Discover broadcasts.
   - `.announced(prefix) → Announced` (async iterator)
   - `.announced_broadcast(path) → AnnouncedBroadcast` (awaitable, waits for a future announcement)
-  - `.request_broadcast(path) → BroadcastConsumer` (awaitable; announced now or a dynamic fallback, else raises)
+  - `.request_broadcast(path) → BroadcastConsumer` (awaitable; returns an already-announced broadcast or raises)
 
 ### Types
 

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -184,7 +184,7 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 - **`OriginConsumer`**. Discover broadcasts.
   - `.announced(prefix) → Announced` (async iterator)
   - `.announced_broadcast(path) → AnnouncedBroadcast` (awaitable, waits for a future announcement)
-  - `.request_broadcast(path) → BroadcastConsumer` (awaitable; returns an already-announced broadcast or raises)
+  - `.request_broadcast(path) → BroadcastConsumer` (awaitable; resolves immediately when the path can be served, or raises)
 
 ### Types
 

--- a/py/moq-rs/docs/_templates/autosummary/class.rst
+++ b/py/moq-rs/docs/_templates/autosummary/class.rst
@@ -1,0 +1,31 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in methods %}
+   {% if not (fullname == "moq.OriginProducer" and item == "dynamic") %}
+      ~{{ name }}.{{ item }}
+   {%- endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/py/moq-rs/docs/conf.py
+++ b/py/moq-rs/docs/conf.py
@@ -49,6 +49,22 @@ autodoc_member_order = "bysource"
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 
+
+def _skip_compatibility_member(_app, what, _name, obj, skip, _options):
+    """Hide compatibility-only members from the published API reference."""
+    if (
+        what == "class"
+        and getattr(obj, "__qualname__", "") == "OriginProducer.dynamic"
+    ):
+        return True
+    return skip
+
+
+def setup(app):
+    """Register the API-reference filters."""
+    app.connect("autodoc-skip-member", _skip_compatibility_member)
+
+
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 templates_path = ["_templates"]

--- a/py/moq-rs/docs/index.md
+++ b/py/moq-rs/docs/index.md
@@ -96,7 +96,6 @@ asyncio.run(main())
 
    OriginProducer
    OriginConsumer
-   OriginDynamic
    Announced
    AnnouncedBroadcast
    Announcement

--- a/py/moq-rs/docs/index.md
+++ b/py/moq-rs/docs/index.md
@@ -52,7 +52,6 @@ asyncio.run(main())
 
    BroadcastProducer
    BroadcastDynamic
-   BroadcastRequest
    TrackProducer
    TrackDynamic
    TrackRequest

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from moq_ffi import (
     MoqAnnounced,
     MoqAnnouncedBroadcast,
@@ -165,10 +167,9 @@ class OriginConsumer:
     async def request_broadcast(self, path: str) -> BroadcastConsumer:
         """Request a broadcast by path, resolving as soon as it can be served.
 
-        Returns the announced broadcast immediately if one exists, otherwise falls
-        back to a dynamic handler on the origin (if any), or raises if neither can
-        serve it. Unlike `announced_broadcast`, this does not wait indefinitely for a
-        future announcement.
+        Returns a broadcast that can be served immediately, or raises if none exists.
+        Unlike `announced_broadcast`, this does not wait indefinitely for a future
+        announcement.
         """
         return BroadcastConsumer(await self._inner.request_broadcast(path))
 
@@ -176,8 +177,8 @@ class OriginConsumer:
 class OriginProducer:
     """The publishing side of an origin: announce broadcasts for consumers to discover.
 
-    Call :meth:`create_broadcast` to publish at a path, :meth:`consume` for a
-    matching :class:`OriginConsumer`, or :meth:`dynamic` to serve on-demand requests.
+    Call :meth:`create_broadcast` to publish at a path, or :meth:`consume` for a
+    matching :class:`OriginConsumer`.
     """
 
     def __init__(self, *, cache_capacity_bytes: int | None = None) -> None:
@@ -195,7 +196,11 @@ class OriginProducer:
         return OriginConsumer(self._inner.consume())
 
     def dynamic(self) -> OriginDynamic:
-        """Serve broadcasts that consumers request without an announcement."""
+        warnings.warn(
+            "dynamic origin routing is not currently supported by clients",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return OriginDynamic(self._inner.dynamic())
 
     def create_broadcast(self, path: str) -> BroadcastProducer:

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from moq_ffi import (
     MoqAnnounced,
     MoqAnnouncedBroadcast,
@@ -165,10 +167,9 @@ class OriginConsumer:
     async def request_broadcast(self, path: str) -> BroadcastConsumer:
         """Request a broadcast by path, resolving as soon as it can be served.
 
-        Returns the announced broadcast immediately if one exists, otherwise falls
-        back to a dynamic handler on the origin (if any), or raises if neither can
-        serve it. Unlike `announced_broadcast`, this does not wait indefinitely for a
-        future announcement.
+        Returns an already-announced broadcast immediately, or raises if none is
+        available. Unlike `announced_broadcast`, this does not wait indefinitely for
+        a future announcement.
         """
         return BroadcastConsumer(await self._inner.request_broadcast(path))
 
@@ -176,8 +177,8 @@ class OriginConsumer:
 class OriginProducer:
     """The publishing side of an origin: announce broadcasts for consumers to discover.
 
-    Call :meth:`create_broadcast` to publish at a path, :meth:`consume` for a
-    matching :class:`OriginConsumer`, or :meth:`dynamic` to serve on-demand requests.
+    Call :meth:`create_broadcast` to publish at a path or :meth:`consume` for a
+    matching :class:`OriginConsumer`.
     """
 
     def __init__(self, *, cache_capacity_bytes: int | None = None) -> None:
@@ -195,7 +196,11 @@ class OriginProducer:
         return OriginConsumer(self._inner.consume())
 
     def dynamic(self) -> OriginDynamic:
-        """Serve broadcasts that consumers request without an announcement."""
+        warnings.warn(
+            "dynamic routing is not currently supported by clients",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return OriginDynamic(self._inner.dynamic())
 
     def create_broadcast(self, path: str) -> BroadcastProducer:

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -167,9 +167,9 @@ class OriginConsumer:
     async def request_broadcast(self, path: str) -> BroadcastConsumer:
         """Request a broadcast by path, resolving as soon as it can be served.
 
-        Returns an already-announced broadcast immediately, or raises if none is
-        available. Unlike `announced_broadcast`, this does not wait indefinitely for
-        a future announcement.
+        Resolves when a broadcast can be served, or raises if none is available.
+        Unlike `announced_broadcast`, this does not wait indefinitely for a future
+        announcement.
         """
         return BroadcastConsumer(await self._inner.request_broadcast(path))
 

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -434,9 +434,8 @@ class BroadcastDynamic:
 class BroadcastProducer:
     """Wraps MoqBroadcastProducer with a cleaner interface.
 
-    Constructing one directly creates a standalone broadcast for serving dynamic
-    requests (:meth:`moq.BroadcastRequest.accept`) or local pub/sub. To publish at
-    a path, use :meth:`moq.OriginProducer.create_broadcast` instead.
+    Constructing one directly creates a standalone broadcast for local pub/sub.
+    To publish at a path, use :meth:`moq.OriginProducer.create_broadcast` instead.
     """
 
     def __init__(self) -> None:

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -381,7 +381,8 @@ async def test_dynamic_track_request_can_publish_media():
 
 async def test_dynamic_broadcast_request():
     origin = moq.OriginProducer(cache_capacity_bytes=4096)
-    dynamic = origin.dynamic()
+    with pytest.warns(DeprecationWarning, match="not currently supported by clients"):
+        dynamic = origin.dynamic()
     consumer = origin.consume()
 
     request_broadcast = asyncio.create_task(consumer.request_broadcast("dynamic/broadcast"))
@@ -410,7 +411,8 @@ async def test_dynamic_broadcast_request():
 
 async def test_dynamic_broadcast_request_can_reject():
     origin = moq.OriginProducer()
-    dynamic = origin.dynamic()
+    with pytest.warns(DeprecationWarning, match="not currently supported by clients"):
+        dynamic = origin.dynamic()
     consumer = origin.consume()
 
     request_broadcast = asyncio.create_task(consumer.request_broadcast("missing"))

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -381,7 +381,11 @@ async def test_dynamic_track_request_can_publish_media():
 
 async def test_dynamic_broadcast_request():
     origin = moq.OriginProducer(cache_capacity_bytes=4096)
-    dynamic = origin.dynamic()
+    with pytest.warns(
+        DeprecationWarning,
+        match="dynamic routing is not currently supported by clients",
+    ):
+        dynamic = origin.dynamic()
     consumer = origin.consume()
 
     request_broadcast = asyncio.create_task(consumer.request_broadcast("dynamic/broadcast"))
@@ -410,7 +414,11 @@ async def test_dynamic_broadcast_request():
 
 async def test_dynamic_broadcast_request_can_reject():
     origin = moq.OriginProducer()
-    dynamic = origin.dynamic()
+    with pytest.warns(
+        DeprecationWarning,
+        match="dynamic routing is not currently supported by clients",
+    ):
+        dynamic = origin.dynamic()
     consumer = origin.consume()
 
     request_broadcast = asyncio.create_task(consumer.request_broadcast("missing"))

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -1587,8 +1587,8 @@ pub extern "C" fn moq_origin_announced_close(announced: u32) -> i32 {
 ///
 /// Resolves against future announcements: it waits for the announcement to arrive (e.g. over the
 /// network) and then delivers the broadcast handle via `on_broadcast`. Use it right after
-/// [moq_session_connect] to avoid racing announcement gossip. To resolve against only what is
-/// announced now (plus any dynamic fallback), use [moq_origin_request] instead.
+/// [moq_session_connect] to avoid racing announcement gossip. To resolve without waiting for a
+/// future announcement, use [moq_origin_request] instead.
 ///
 /// `on_broadcast` is invoked with a positive broadcast handle once announced, then exactly once
 /// more with a terminal code: `0` (the wait finished, including after
@@ -1635,11 +1635,9 @@ pub extern "C" fn moq_origin_consume_announced_close(task: u32) -> i32 {
 
 /// Request a broadcast from an origin by path, resolving as soon as it can be served.
 ///
-/// Resolves against what is announced *now* plus any dynamic fallback, where
-/// [moq_origin_consume_announced] waits indefinitely for a future announcement: it returns an
-/// already-announced broadcast at once, otherwise falls back to a dynamic handler on the origin
-/// (if any), and fails when neither can serve the path. It does NOT wait for a later
-/// announcement.
+/// Resolves a broadcast that can be served without waiting for a later announcement, where
+/// [moq_origin_consume_announced] waits indefinitely for a future announcement. The request
+/// fails when no route can serve the path.
 ///
 /// `on_broadcast` is invoked with a positive broadcast handle once served, then exactly once more
 /// with a terminal code: `0` (finished, including after [moq_origin_request_close]) or a negative

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -181,10 +181,10 @@ impl Origin {
 	/// Request the broadcast at `path`, delivering its handle once it can be served.
 	///
 	/// Unlike [`Self::consume`] (announced-only, fails fast) and [`Self::consume_announced`]
-	/// (waits indefinitely for a future announcement), this resolves against what is announced
-	/// now plus any dynamic fallback handler on the origin: the callback fires the broadcast
-	/// handle (> 0) once served, then a terminal `0`; or a single terminal code (`0` on close,
-	/// negative on error) if it can't be served. Returns a task handle for cancellation.
+	/// (waits indefinitely for a future announcement), this resolves without waiting for a
+	/// later announcement. The callback fires the broadcast handle (> 0) once served, then a
+	/// terminal `0`; or a single terminal code (`0` on close, negative on error) if it cannot
+	/// be served. Returns a task handle for cancellation.
 	pub fn request(&mut self, origin: Id, path: String, on_broadcast: OnStatus) -> Result<Id, Error> {
 		let origin = self.active.get_mut(origin).ok_or(Error::OriginNotFound)?;
 		let consumer = origin.consume();

--- a/rs/moq-ffi/src/lib.rs
+++ b/rs/moq-ffi/src/lib.rs
@@ -37,4 +37,5 @@ uniffi::setup_scaffolding!("moq");
 
 // The test suite drives a native relay over a tokio runtime.
 #[cfg(all(test, not(target_arch = "wasm32")))]
+#[allow(deprecated)]
 mod test;

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -77,11 +77,13 @@ pub struct MoqAnnounced {
 	task: Task<Announced>,
 }
 
+#[doc(hidden)]
 #[derive(uniffi::Object)]
 pub struct MoqOriginDynamic {
 	task: Task<OriginDynamic>,
 }
 
+#[doc(hidden)]
 #[derive(uniffi::Object)]
 pub struct MoqBroadcastRequest {
 	inner: std::sync::Mutex<Option<moq_net::origin::Request>>,

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -221,7 +221,7 @@ impl MoqOriginProducer {
 	#[deprecated(note = "dynamic routing is not currently supported by clients")]
 	pub fn dynamic(&self) -> Arc<MoqOriginDynamic> {
 		let _guard = crate::ffi::enter();
-		tracing::warn!("dynamic routing is not currently supported by clients");
+		eprintln!("warning: dynamic routing is not currently supported by clients");
 		Arc::new(MoqOriginDynamic {
 			task: Task::new(OriginDynamic {
 				inner: self.inner.dynamic(),

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -1,3 +1,6 @@
+// UniFFI's generated scaffolding references deprecated methods within this module.
+#![allow(deprecated)]
+
 use std::sync::Arc;
 
 use crate::consumer::MoqBroadcastConsumer;
@@ -214,13 +217,11 @@ impl MoqOriginProducer {
 		})
 	}
 
-	/// Create a dynamic handler for serving unannounced broadcasts on request.
-	///
-	/// Hold the returned object while missing broadcast requests should be accepted.
-	/// Dropping it makes future requests to unknown broadcasts fail.
-	#[allow(deprecated)]
+	#[doc(hidden)]
+	#[deprecated(note = "dynamic routing is not currently supported by clients")]
 	pub fn dynamic(&self) -> Arc<MoqOriginDynamic> {
 		let _guard = crate::ffi::enter();
+		tracing::warn!("dynamic origin routing is not currently supported by clients");
 		Arc::new(MoqOriginDynamic {
 			task: Task::new(OriginDynamic {
 				inner: self.inner.dynamic(),

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -280,9 +280,9 @@ impl MoqOriginConsumer {
 
 	/// Request a broadcast by path, resolving as soon as it can be served.
 	///
-	/// Returns an already-announced broadcast immediately, or errors if none is available.
-	/// Unlike `announced_broadcast`, this does *not* wait indefinitely for a future
-	/// announcement. Drop the returned future to cancel.
+	/// Resolves when a broadcast can be served, or errors if none is available. Unlike
+	/// `announced_broadcast`, this does *not* wait indefinitely for a future announcement.
+	/// Drop the returned future to cancel.
 	///
 	/// Calling this straight after connecting therefore races the session's announcements
 	/// and can report a live broadcast as unroutable. Await `announced_broadcast` first.

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -214,13 +214,11 @@ impl MoqOriginProducer {
 		})
 	}
 
-	/// Create a dynamic handler for serving unannounced broadcasts on request.
-	///
-	/// Hold the returned object while missing broadcast requests should be accepted.
-	/// Dropping it makes future requests to unknown broadcasts fail.
+	#[doc(hidden)]
 	#[allow(deprecated)]
 	pub fn dynamic(&self) -> Arc<MoqOriginDynamic> {
 		let _guard = crate::ffi::enter();
+		tracing::warn!("dynamic routing is not currently supported by clients");
 		Arc::new(MoqOriginDynamic {
 			task: Task::new(OriginDynamic {
 				inner: self.inner.dynamic(),
@@ -277,11 +275,9 @@ impl MoqOriginConsumer {
 
 	/// Request a broadcast by path, resolving as soon as it can be served.
 	///
-	/// Returns the announced broadcast immediately if one exists; otherwise falls back to a
-	/// dynamic handler on the origin (if any) and resolves once it serves the broadcast, or
-	/// errors if nothing can serve it. Unlike `announced_broadcast`, this does *not* wait
-	/// indefinitely for a future announcement: it resolves or fails based on what is
-	/// announced now plus any dynamic fallback. Drop the returned future to cancel.
+	/// Returns an already-announced broadcast immediately, or errors if none is available.
+	/// Unlike `announced_broadcast`, this does *not* wait indefinitely for a future
+	/// announcement. Drop the returned future to cancel.
 	///
 	/// Calling this straight after connecting therefore races the session's announcements
 	/// and can report a live broadcast as unroutable. Await `announced_broadcast` first.

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -218,6 +218,7 @@ impl MoqOriginProducer {
 	///
 	/// Hold the returned object while missing broadcast requests should be accepted.
 	/// Dropping it makes future requests to unknown broadcasts fail.
+	#[allow(deprecated)]
 	pub fn dynamic(&self) -> Arc<MoqOriginDynamic> {
 		let _guard = crate::ffi::enter();
 		Arc::new(MoqOriginDynamic {

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -258,8 +258,7 @@ impl MoqBroadcastProducer {
 
 	/// Create a standalone broadcast, not attached to any origin.
 	///
-	/// Use it to serve a dynamic broadcast request ([`MoqBroadcastRequest::accept`](crate::origin::MoqBroadcastRequest::accept))
-	/// or for local pub/sub via [`consume`](Self::consume). To publish at a path, use
+	/// Use it for local pub/sub via [`consume`](Self::consume). To publish at a path, use
 	/// [`MoqOriginProducer::create_broadcast`](crate::origin::MoqOriginProducer::create_broadcast) instead.
 	#[uniffi::constructor]
 	pub fn new() -> Result<Arc<Self>, MoqError> {

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -58,6 +58,7 @@ impl<E: CatalogExt> From<moq_net::track::Subscriber> for Consumer<E> {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod test {
 	use std::task::Poll;
 

--- a/rs/moq-mux/src/source.rs
+++ b/rs/moq-mux/src/source.rs
@@ -31,7 +31,7 @@ impl Source {
 	/// `broadcast` reference is resolved against it. Both the catalog broadcast and any
 	/// referenced broadcast are fetched via
 	/// [`origin.request_broadcast`](moq_net::origin::Consumer::request_broadcast), so they
-	/// must be reachable through `origin` (announced, or served by a dynamic handler).
+	/// must be reachable through `origin`.
 	pub fn new(origin: moq_net::origin::Consumer, path: impl AsPath) -> Self {
 		Self {
 			origin,
@@ -50,8 +50,8 @@ impl Source {
 	/// A missing/empty `rel` targets the catalog broadcast. Anything else, including
 	/// the empty root broadcast, targets the resolved path. A reference that escapes above
 	/// the origin root returns `None`. Either valid target is fetched from the origin,
-	/// which deduplicates repeat requests for the same live path (announced or dynamically
-	/// served) so the catalog and every rendition share one upstream subscription.
+	/// which deduplicates repeat requests for the same live path so the catalog and every
+	/// rendition share one upstream subscription.
 	pub(crate) fn request(
 		&self,
 		rel: Option<&moq_net::PathRelative<'_>>,

--- a/rs/moq-mux/src/source.rs
+++ b/rs/moq-mux/src/source.rs
@@ -165,6 +165,7 @@ fn invalid_broadcast_reference(rel: Option<&moq_net::PathRelative<'_>>) -> crate
 /// it by path. The origin is leaked so the broadcast stays reachable for the source's
 /// lifetime (harmless in a test binary).
 #[cfg(test)]
+#[allow(deprecated)]
 pub(crate) fn announced(broadcast: &moq_net::broadcast::Consumer) -> Source {
 	let origin = moq_net::Origin::random().produce();
 	let mut dynamic = origin.dynamic();

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2819,11 +2819,11 @@ impl Consumer {
 		})
 	}
 
-	/// Get an already-announced broadcast by path.
+	/// Get a broadcast by path.
 	///
-	/// Returns a [`kio::Pending`] future that resolves synchronously when the
-	/// broadcast is available, or to [`Error::Unroutable`] otherwise. Unlike
-	/// [`Self::announced`], this does not wait for a future announcement.
+	/// Returns a [`kio::Pending`] future that resolves when the broadcast can be
+	/// served, or to [`Error::Unroutable`] otherwise. Unlike [`Self::announced`],
+	/// this does not wait for a future announcement.
 	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<Requesting> {
 		let path = path.as_path();
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1163,10 +1163,6 @@ impl Producer {
 	#[doc(hidden)]
 	#[deprecated(note = "dynamic routing is not currently supported by clients")]
 	pub fn dynamic(&self) -> Dynamic {
-		self.dynamic_inner()
-	}
-
-	fn dynamic_inner(&self) -> Dynamic {
 		Dynamic::new(self.info, self.root.clone(), self.dynamic.clone())
 	}
 
@@ -3151,6 +3147,7 @@ impl AnnounceConsumer {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
 	use crate::coding::Decode;
 	use crate::group;
@@ -5802,7 +5799,7 @@ mod tests {
 
 		let origin = Origin::random().produce();
 		let consumer = origin.consume();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 
 		let peer = Origin::new(5).unwrap();
 		let tainted = OriginList::try_from(vec![Origin::new(1).unwrap(), peer]).unwrap();
@@ -6983,7 +6980,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_not_announced() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		// A separate announce cursor must never observe the dynamic broadcast.
@@ -7020,7 +7017,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		// Both register before the handler drains either.
@@ -7047,7 +7044,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_dedups_served() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7072,7 +7069,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_reserves_after_close() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7098,7 +7095,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_cache_bounded() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		for i in 0..100 {
@@ -7126,7 +7123,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces_after_handoff() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let f1 = consumer.request_broadcast("fallback");
@@ -7151,7 +7148,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_dropped_after_handoff() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let f1 = consumer.request_broadcast("fallback");
@@ -7168,7 +7165,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rejected() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7185,7 +7182,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rerequest_after_reject() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let f1 = consumer.request_broadcast("fallback");
@@ -7206,7 +7203,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_handler_dropped() {
 		let origin = Origin::random().produce();
-		let dynamic = origin.dynamic_inner();
+		let dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7226,7 +7223,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_accept_after_handler_dropped() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7245,7 +7242,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_prefers_announced() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic_inner();
+		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		let _broadcast = origin.create_broadcast("live", announce()).unwrap();
@@ -7266,7 +7263,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_clone_keeps_alive() {
 		let origin = Origin::random().produce();
-		let dynamic = origin.dynamic_inner();
+		let dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
 		drop(dynamic.clone());

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2316,6 +2316,7 @@ struct PendingBroadcast {
 /// Served broadcasts are deliberately *not* announced, so they never appear in
 /// [`Consumer::announced`]. Drop this handle (and every clone) to reject the
 /// requests still waiting to be served.
+#[doc(hidden)]
 pub struct Dynamic {
 	info: Origin,
 	root: PathOwned,
@@ -2405,6 +2406,7 @@ impl Drop for Dynamic {
 /// [`Consumer::request_broadcast`]; [`accept`](Self::accept) resolves it with a live
 /// broadcast (which the handler keeps producing into) and [`reject`](Self::reject) resolves
 /// it with an error. Dropping the request without either rejects it.
+#[doc(hidden)]
 pub struct Request {
 	// Absolute path that was requested.
 	path: PathOwned,
@@ -2817,24 +2819,11 @@ impl Consumer {
 		})
 	}
 
-	/// Get a broadcast by path, falling back to a dynamic request when it is not announced.
+	/// Get an already-announced broadcast by path.
 	///
-	/// Returns a [`kio::Pending`] future (resolved synchronously for an announced broadcast,
-	/// otherwise once a handler serves it), mirroring [`track::Consumer::fetch_group`](track::Consumer::fetch_group).
-	/// The lookup order is: an already-announced broadcast resolves
-	/// immediately; otherwise, if an [`Dynamic`] handler is live (see
-	/// [`Producer::dynamic`]), a fallback request is registered and the future resolves
-	/// when the handler [`accept`](Request::accept)s it (or errors if it
-	/// [`reject`](Request::reject)s or every handler drops). Concurrent requests for
-	/// the same unannounced path coalesce onto one handler request, and once served the
-	/// broadcast is cached weakly so *later* requests for that path also share it (rather
-	/// than re-invoking the handler and opening a duplicate upstream subscription) for as
-	/// long as it stays live; a closed one is re-served on the next request.
-	///
-	/// The returned future resolves to [`Error::Unroutable`] when the path is not announced and no
-	/// dynamic handler exists. A request that is registered while a handler is live but then loses
-	/// every handler before being served also resolves to [`Error::Unroutable`]. Unlike an announced
-	/// broadcast, a dynamically served one is never visible to [`Self::announced`].
+	/// Returns a [`kio::Pending`] future that resolves synchronously when the
+	/// broadcast is available, or to [`Error::Unroutable`] otherwise. Unlike
+	/// [`Self::announced`], this does not wait for a future announcement.
 	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<Requesting> {
 		let path = path.as_path();
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1160,7 +1160,13 @@ impl Producer {
 	/// *not* announced, so [`Consumer::announced`] never sees them; they exist
 	/// only as a fallback for a consumer that asks for an exact path with no live
 	/// announcement. Drop the handler (and every clone) to reject pending requests.
+	#[doc(hidden)]
+	#[deprecated(note = "dynamic routing is not currently supported by clients")]
 	pub fn dynamic(&self) -> Dynamic {
+		self.dynamic_inner()
+	}
+
+	fn dynamic_inner(&self) -> Dynamic {
 		Dynamic::new(self.info, self.root.clone(), self.dynamic.clone())
 	}
 
@@ -5796,7 +5802,7 @@ mod tests {
 
 		let origin = Origin::random().produce();
 		let consumer = origin.consume();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 
 		let peer = Origin::new(5).unwrap();
 		let tainted = OriginList::try_from(vec![Origin::new(1).unwrap(), peer]).unwrap();
@@ -6977,7 +6983,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_not_announced() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		// A separate announce cursor must never observe the dynamic broadcast.
@@ -7014,7 +7020,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		// Both register before the handler drains either.
@@ -7041,7 +7047,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_dedups_served() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7066,7 +7072,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_reserves_after_close() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7092,7 +7098,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_cache_bounded() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		for i in 0..100 {
@@ -7120,7 +7126,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces_after_handoff() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let f1 = consumer.request_broadcast("fallback");
@@ -7145,7 +7151,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_dropped_after_handoff() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let f1 = consumer.request_broadcast("fallback");
@@ -7162,7 +7168,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rejected() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7179,7 +7185,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rerequest_after_reject() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let f1 = consumer.request_broadcast("fallback");
@@ -7200,7 +7206,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_handler_dropped() {
 		let origin = Origin::random().produce();
-		let dynamic = origin.dynamic();
+		let dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7220,7 +7226,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_accept_after_handler_dropped() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let request_fut = consumer.request_broadcast("fallback");
@@ -7239,7 +7245,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_prefers_announced() {
 		let origin = Origin::random().produce();
-		let mut dynamic = origin.dynamic();
+		let mut dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		let _broadcast = origin.create_broadcast("live", announce()).unwrap();
@@ -7260,7 +7266,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_clone_keeps_alive() {
 		let origin = Origin::random().produce();
-		let dynamic = origin.dynamic();
+		let dynamic = origin.dynamic_inner();
 		let consumer = origin.consume();
 
 		drop(dynamic.clone());

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -84,6 +84,7 @@ impl Consumer {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
 	use super::*;
 	use crate::decode::Kind;

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -139,14 +139,13 @@ public final class RouteWatch: AsyncSequence, Sendable {
 
 /// Write side of a broadcast: open tracks and publish frames.
 ///
-/// Constructing one directly creates a standalone broadcast for serving dynamic
-/// requests (`BroadcastRequest.accept`) or local pub/sub. To publish at a path,
-/// use `OriginProducer.createBroadcast(path:)` instead.
+/// Constructing one directly creates a standalone broadcast for local pub/sub.
+/// To publish at a path, use `OriginProducer.createBroadcast(path:)` instead.
 public final class BroadcastProducer: Sendable {
     let ffi: MoqBroadcastProducer
 
-    /// Create a standalone broadcast for serving dynamic requests or local
-    /// pub/sub. To publish at a path, use `OriginProducer.createBroadcast(path:)`.
+    /// Create a standalone broadcast for local pub/sub. To publish at a path,
+    /// use `OriginProducer.createBroadcast(path:)`.
     public init() throws {
         ffi = try MoqBroadcastProducer()
     }

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -20,7 +20,7 @@ public final class OriginProducer: Sendable {
         OriginConsumer(ffi.consume())
     }
 
-    /// Serve broadcasts that consumers request without an announcement.
+    @available(*, deprecated, message: "dynamic routing is not currently supported by clients")
     public func dynamic() -> OriginDynamic {
         OriginDynamic(ffi.dynamic())
     }
@@ -110,10 +110,8 @@ public final class OriginConsumer: Sendable {
         AnnouncedBroadcast(try ffi.announcedBroadcast(path: path))
     }
 
-    /// Request a broadcast by path, resolving as soon as it can be served: the announced
-    /// broadcast if present, otherwise a dynamic fallback on the origin, or an error if
-    /// neither can serve it. Unlike `announcedBroadcast`, this does not wait for a future
-    /// announcement.
+    /// Request an already-announced broadcast by path, or throw if none is available.
+    /// Unlike `announcedBroadcast`, this does not wait for a future announcement.
     public func requestBroadcast(path: String) async throws -> BroadcastConsumer {
         BroadcastConsumer(try await ffi.requestBroadcast(path: path))
     }

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -20,6 +20,7 @@ public final class OriginProducer: Sendable {
         OriginConsumer(ffi.consume())
     }
 
+    @_documentation(visibility: internal)
     @available(*, deprecated, message: "dynamic routing is not currently supported by clients")
     public func dynamic() -> OriginDynamic {
         OriginDynamic(ffi.dynamic())
@@ -38,6 +39,7 @@ public final class OriginProducer: Sendable {
 }
 
 /// A requested broadcast that has not been accepted yet.
+@_documentation(visibility: internal)
 public final class BroadcastRequest: Sendable {
     let ffi: MoqBroadcastRequest
 
@@ -64,6 +66,7 @@ public final class BroadcastRequest: Sendable {
 /// A stream of broadcasts requested by consumers. Iterate directly:
 /// `for try await request in dynamic { ... }`. Hold this while missing
 /// broadcasts should be served; cancelling the consuming task stops serving.
+@_documentation(visibility: internal)
 public final class OriginDynamic: AsyncSequence, Sendable {
     /// The broadcast request emitted by this sequence.
     public typealias Element = BroadcastRequest

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -20,7 +20,8 @@ public final class OriginProducer: Sendable {
         OriginConsumer(ffi.consume())
     }
 
-    /// Serve broadcasts that consumers request without an announcement.
+    @_documentation(visibility: internal)
+    @available(*, deprecated, message: "Dynamic origin routing is not currently supported by clients.")
     public func dynamic() -> OriginDynamic {
         OriginDynamic(ffi.dynamic())
     }
@@ -61,9 +62,7 @@ public final class BroadcastRequest: Sendable {
     }
 }
 
-/// A stream of broadcasts requested by consumers. Iterate directly:
-/// `for try await request in dynamic { ... }`. Hold this while missing
-/// broadcasts should be served; cancelling the consuming task stops serving.
+@_documentation(visibility: internal)
 public final class OriginDynamic: AsyncSequence, Sendable {
     /// The broadcast request emitted by this sequence.
     public typealias Element = BroadcastRequest

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -110,7 +110,7 @@ public final class OriginConsumer: Sendable {
         AnnouncedBroadcast(try ffi.announcedBroadcast(path: path))
     }
 
-    /// Request an already-announced broadcast by path, or throw if none is available.
+    /// Resolve a broadcast by path when it can be served, or throw otherwise.
     /// Unlike `announcedBroadcast`, this does not wait for a future announcement.
     public func requestBroadcast(path: String) async throws -> BroadcastConsumer {
         BroadcastConsumer(try await ffi.requestBroadcast(path: path))

--- a/swift/Tests/MoqTests/SmokeTests.swift
+++ b/swift/Tests/MoqTests/SmokeTests.swift
@@ -34,7 +34,6 @@ final class SmokeTests: XCTestCase {
     func testOriginProducerIsConstructible() {
         let origin = OriginProducer(cacheCapacityBytes: 4096)
         _ = origin.consume()
-        _ = origin.dynamic()
     }
 
     func testBroadcastProducerOpensTracks() throws {


### PR DESCRIPTION
## Summary

- Deprecate `moq_net::origin::Producer::dynamic` because clients do not currently support dynamic routing.
- Hide the Rust and raw FFI compatibility methods and companion types from generated API documentation while preserving behavior.
- Emit a guaranteed stderr warning at the raw FFI boundary, including when logging was never initialized.
- Add language-native deprecation signals to Python, Swift, and Kotlin.
- Keep Go source compatibility while removing all standing documentation for the compatibility-only path.
- Remove origin dynamic-routing examples and guidance from published documentation.

## Public API changes

- `moq_net::origin::Producer::dynamic` now emits `dynamic routing is not currently supported by clients` at Rust call sites.
- Raw UniFFI callers receive the same warning on stderr.
- Python emits `DeprecationWarning`; Swift and Kotlin expose their native deprecation markers.
- Kotlin binding generation suppresses the generated compatibility symbols from Dokka because UniFFI does not propagate Rust deprecation metadata.
- Method signatures and runtime routing behavior are unchanged.

## Wire behavior changes

None.

## Cross-package sync

- Updated `rs/libmoq`, `py/moq-rs`, `swift`, `kt`, `go/wrapper`, and their user documentation.
- C ABI behavior is unchanged because the C API does not expose origin dynamic routing; its request documentation now uses neutral wording.
- `js/net` and drafts are unchanged because there is no equivalent JS API and no wire behavior changed.

## Test plan

- `MOQ_STRICT=1 nix develop --command just check`
- `MOQ_STRICT=1 nix develop --command just test`
- `gradle :moq:dokkaHtml`, then verified the compatibility symbols are absent from the rendered output
- Swift verified by the macOS CI job

(Written by GPT-5)