### PR TITLE
feat(moq-gst): expose QUIC timeout properties

### DIFF
--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -39,6 +39,7 @@ For `http://` URLs, `moq-native` automatically fetches the server's certificate 
 
 An idle timeout of `0` disables it locally.
 These values apply only to QUIC connections. WebSocket fallback uses its own heartbeat policy.
+The iroh backend applies the idle timeout but ignores keep-alive because it has no keep-alive setting.
 
 ```bash
 gst-launch-1.0 -e \

--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -30,6 +30,24 @@ Both elements support the following properties:
 For `http://` URLs, `moq-native` automatically fetches the server's certificate fingerprint from `/certificate.sha256` and verifies TLS against it. You don't need `tls-disable-verify` for local development.
 :::
 
+`moqsink` additionally supports these QUIC connection properties:
+
+| Property            | Type   | Description                                                     |
+| ------------------- | ------ | --------------------------------------------------------------- |
+| `quic-idle-timeout` | uint64 | Idle timeout in milliseconds (default 30000; 0 disables locally) |
+| `quic-keep-alive`   | uint64 | Keep-alive interval in milliseconds (default 5000; 0 disables)   |
+
+An idle timeout of `0` disables it locally.
+These values apply only to QUIC connections. WebSocket fallback uses its own heartbeat policy.
+
+```bash
+gst-launch-1.0 -e \
+  videotestsrc is-live=true ! x264enc tune=zerolatency ! h264parse \
+    ! video/x-h264,stream-format=byte-stream,alignment=au ! mux.sink_0 \
+  moqsink name=mux url=http://localhost:4443 broadcast=test \
+    quic-idle-timeout=15000 quic-keep-alive=3000
+```
+
 `moqsink` additionally exposes these read-only properties for monitoring. Each emits a `notify`
 signal when it changes, so you can poll it via `g_object_get` or connect to `notify::<property>`:
 

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
@@ -25,6 +26,12 @@ struct Settings {
 	url: Option<String>,
 	broadcast: Option<String>,
 	tls_disable_verify: bool,
+	quic_idle_timeout: Option<Duration>,
+	quic_keep_alive: Option<Duration>,
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+	duration.as_millis().try_into().unwrap_or(u64::MAX)
 }
 
 impl TryFrom<Settings> for ResolvedSettings {
@@ -39,6 +46,8 @@ impl TryFrom<Settings> for ResolvedSettings {
 				.context("broadcast property is required")?
 				.clone(),
 			tls_disable_verify: value.tls_disable_verify,
+			quic_idle_timeout: value.quic_idle_timeout,
+			quic_keep_alive: value.quic_keep_alive,
 		})
 	}
 }
@@ -117,6 +126,7 @@ impl ObjectSubclass for MoqSink {
 impl ObjectImpl for MoqSink {
 	fn properties() -> &'static [glib::ParamSpec] {
 		static PROPS: LazyLock<Vec<glib::ParamSpec>> = LazyLock::new(|| {
+			let quic = moq_native::quic::Resolved::default();
 			vec![
 				glib::ParamSpecString::builder("url")
 					.nick("Destination URL")
@@ -132,6 +142,18 @@ impl ObjectImpl for MoqSink {
 					.nick("TLS disable verify")
 					.blurb("Disable TLS verification")
 					.default_value(false)
+					.mutable_ready()
+					.build(),
+				glib::ParamSpecUInt64::builder("quic-idle-timeout")
+					.nick("QUIC idle timeout")
+					.blurb("QUIC idle timeout in milliseconds, 0 to disable locally")
+					.default_value(duration_millis(quic.idle_timeout))
+					.mutable_ready()
+					.build(),
+				glib::ParamSpecUInt64::builder("quic-keep-alive")
+					.nick("QUIC keep-alive")
+					.blurb("QUIC keep-alive interval in milliseconds, 0 to disable")
+					.default_value(quic.keep_alive.map(duration_millis).unwrap_or(0))
 					.mutable_ready()
 					.build(),
 				// Read-only, served from the live session's status. Each notifies on change.
@@ -189,6 +211,8 @@ impl ObjectImpl for MoqSink {
 			"url" => settings.url = value.get().unwrap(),
 			"broadcast" => settings.broadcast = value.get().unwrap(),
 			"tls-disable-verify" => settings.tls_disable_verify = value.get().unwrap(),
+			"quic-idle-timeout" => settings.quic_idle_timeout = Some(Duration::from_millis(value.get().unwrap())),
+			"quic-keep-alive" => settings.quic_keep_alive = Some(Duration::from_millis(value.get().unwrap())),
 			_ => unreachable!(),
 		}
 	}
@@ -213,6 +237,18 @@ impl ObjectImpl for MoqSink {
 					"url" => settings.url.to_value(),
 					"broadcast" => settings.broadcast.to_value(),
 					"tls-disable-verify" => settings.tls_disable_verify.to_value(),
+					"quic-idle-timeout" => duration_millis(
+						settings
+							.quic_idle_timeout
+							.unwrap_or_else(|| moq_native::quic::Resolved::default().idle_timeout),
+					)
+					.to_value(),
+					"quic-keep-alive" => settings
+						.quic_keep_alive
+						.or_else(|| moq_native::quic::Resolved::default().keep_alive)
+						.map(duration_millis)
+						.unwrap_or(0)
+						.to_value(),
 					_ => unreachable!(),
 				}
 			}
@@ -620,11 +656,21 @@ mod tests {
 	fn startup_properties_declare_their_window() {
 		gst::init().unwrap();
 		let sink = sink();
-		for name in ["url", "broadcast", "tls-disable-verify"] {
+		for name in [
+			"url",
+			"broadcast",
+			"tls-disable-verify",
+			"quic-idle-timeout",
+			"quic-keep-alive",
+		] {
 			assert!(
 				spec(&sink, name).flags().contains(gst::PARAM_FLAG_MUTABLE_READY),
 				"{name} does not declare MUTABLE_READY"
 			);
+		}
+		for (name, value) in [("quic-idle-timeout", 30_000), ("quic-keep-alive", 5_000)] {
+			assert_eq!(spec(&sink, name).value_type(), u64::static_type());
+			assert_eq!(sink.property::<u64>(name), value);
 		}
 		for name in [
 			"status",
@@ -641,25 +687,62 @@ mod tests {
 	}
 
 	#[test]
+	fn duration_millis_saturates() {
+		assert_eq!(duration_millis(Duration::MAX), u64::MAX);
+	}
+
+	#[test]
+	fn quic_properties_reach_the_client_config() {
+		gst::init().unwrap();
+		let sink = sink();
+		sink.set_property("url", "https://relay.example.com/anon");
+		sink.set_property("broadcast", "test");
+		sink.set_property("quic-idle-timeout", 15_000u64);
+		sink.set_property("quic-keep-alive", 3_000u64);
+
+		let resolved = ResolvedSettings::try_from(sink.imp().settings.lock().unwrap().clone()).unwrap();
+		let quic = super::super::session::client_config(&resolved).quic.resolve();
+		assert_eq!(quic.idle_timeout, Duration::from_secs(15));
+		assert_eq!(quic.keep_alive, Some(Duration::from_secs(3)));
+
+		sink.set_property("quic-keep-alive", 0u64);
+		sink.set_property("quic-idle-timeout", 0u64);
+		let resolved = ResolvedSettings::try_from(sink.imp().settings.lock().unwrap().clone()).unwrap();
+		let quic = super::super::session::client_config(&resolved).quic.resolve();
+		assert_eq!(quic.idle_timeout, Duration::ZERO);
+		assert_eq!(quic.keep_alive, None);
+	}
+
+	#[test]
 	fn a_started_element_keeps_its_startup_properties() {
 		gst::init().unwrap();
 		let sink = sink();
 		sink.set_property("url", "https://127.0.0.1:1");
 		sink.set_property("broadcast", "before");
+		sink.set_property("quic-idle-timeout", 15_000u64);
+		sink.set_property("quic-keep-alive", 3_000u64);
 		assert_eq!(sink.property::<String>("broadcast"), "before");
 
 		sink.set_state(gst::State::Paused).unwrap();
 		sink.set_property("broadcast", "after");
+		sink.set_property("quic-idle-timeout", 20_000u64);
+		sink.set_property("quic-keep-alive", 4_000u64);
 		assert_eq!(
 			sink.property::<String>("broadcast"),
 			"before",
 			"a write above READY must not be stored: it would read back without taking effect"
 		);
+		assert_eq!(sink.property::<u64>("quic-idle-timeout"), 15_000);
+		assert_eq!(sink.property::<u64>("quic-keep-alive"), 3_000);
 
 		// MUTABLE_READY means configurable on every run, not just before the first.
 		sink.set_state(gst::State::Ready).unwrap();
 		sink.set_property("broadcast", "after");
+		sink.set_property("quic-idle-timeout", 20_000u64);
+		sink.set_property("quic-keep-alive", 4_000u64);
 		assert_eq!(sink.property::<String>("broadcast"), "after");
+		assert_eq!(sink.property::<u64>("quic-idle-timeout"), 20_000);
+		assert_eq!(sink.property::<u64>("quic-keep-alive"), 4_000);
 		sink.set_state(gst::State::Null).unwrap();
 	}
 }

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -152,7 +152,7 @@ impl ObjectImpl for MoqSink {
 					.build(),
 				glib::ParamSpecUInt64::builder("quic-keep-alive")
 					.nick("QUIC keep-alive")
-					.blurb("QUIC keep-alive interval in milliseconds, 0 to disable")
+					.blurb("QUIC keep-alive interval in milliseconds, 0 to disable; ignored by iroh")
 					.default_value(quic.keep_alive.map(duration_millis).unwrap_or(0))
 					.mutable_ready()
 					.build(),

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -105,6 +105,7 @@ pub struct ResolvedSettings {
 	pub quic_keep_alive: Option<std::time::Duration>,
 }
 
+/// Builds the native client configuration with the sink's TLS, QUIC, and backoff overrides.
 pub(super) fn client_config(settings: &ResolvedSettings) -> moq_native::ClientConfig {
 	let mut config = moq_native::ClientConfig::default();
 	config.tls.disable_verify = Some(settings.tls_disable_verify);

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -99,6 +99,19 @@ pub struct ResolvedSettings {
 	pub broadcast: String,
 	/// Disable TLS certificate verification (local/dev use).
 	pub tls_disable_verify: bool,
+	/// QUIC idle timeout override.
+	pub quic_idle_timeout: Option<std::time::Duration>,
+	/// QUIC keep-alive override, including zero to disable it.
+	pub quic_keep_alive: Option<std::time::Duration>,
+}
+
+pub(super) fn client_config(settings: &ResolvedSettings) -> moq_native::ClientConfig {
+	let mut config = moq_native::ClientConfig::default();
+	config.tls.disable_verify = Some(settings.tls_disable_verify);
+	config.quic.idle_timeout = settings.quic_idle_timeout;
+	config.quic.keep_alive = settings.quic_keep_alive;
+	config.backoff.timeout = std::time::Duration::ZERO;
+	config
 }
 
 /// A running session: the connect/lifecycle task plus the state the property getters read. Dropping the
@@ -144,10 +157,7 @@ impl Session {
 		// retry), posting the bus error below. During an outage the pad threads keep writing (bounded
 		// by moq-net's per-group eviction) and the relay catches up from a group boundary on
 		// reconnect. A bounded policy is available via `ClientConfig::backoff`.
-		let mut config = moq_native::ClientConfig::default();
-		config.tls.disable_verify = Some(settings.tls_disable_verify);
-		config.backoff.timeout = std::time::Duration::ZERO;
-		let client = config.init()?.with_publisher(origin.consume());
+		let client = client_config(&settings).init()?.with_publisher(origin.consume());
 		let reconnect = client.reconnect(settings.url.clone());
 		// Persistent handles that survive reconnects; the getters read them without touching the loop.
 		let send_bandwidth = reconnect.send_bandwidth();

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -106,6 +106,17 @@ fn a_pipeline_description_names_the_track() {
 	);
 }
 
+#[test]
+fn a_pipeline_description_configures_quic_timeouts() {
+	init();
+	let sink = gst::parse::launch(
+		"moqsink url=https://127.0.0.1:1 broadcast=test quic-idle-timeout=15000 quic-keep-alive=3000",
+	)
+	.expect("parse the description");
+	assert_eq!(sink.property::<u64>("quic-idle-timeout"), 15_000);
+	assert_eq!(sink.property::<u64>("quic-keep-alive"), 3_000);
+}
+
 // The acceptance criterion: once CAPS reserves the track, `track` reads the effective name, further
 // writes are ignored, and stopping the element makes it configurable again.
 #[test]


### PR DESCRIPTION
Fixes #3022 

  - Expose `quic-idle-timeout` and `quic-keep-alive` on `moqsink`.
  - Apply both values to the native QUIC client configuration.
  - Document millisecond units, defaults, validation, and zero-value behavior.
  - Add coverage for property resolution and duration conversion.
