### PR TITLE
fix(cli): accept AAC in playback validation test

### DIFF
--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -888,6 +888,8 @@ mod tests {
 			"play",
 			"--video-name",
 			"hd",
+			"--audio-codec",
+			"aac",
 		])
 		.unwrap();
 		let Command::Play(play) = cli.command else {
@@ -905,21 +907,21 @@ mod tests {
 	#[cfg(feature = "play")]
 	#[test]
 	fn play_rejects_undecodable_codecs() {
-		for flag in [["--video-codec", "vp9"], ["--audio-codec", "aac"]] {
+		for codec in ["vp8", "vp9"] {
 			let cli = Cli::try_parse_from([
 				"moq",
 				"--client-connect",
 				"https://relay.example.com/anon",
 				"play",
-				flag[0],
-				flag[1],
+				"--video-codec",
+				codec,
 			])
 			.unwrap();
 			let Command::Play(play) = cli.command else {
 				panic!("expected play")
 			};
 			let err = play.validate().unwrap_err().to_string();
-			assert!(err.contains(flag[1]), "{err}");
+			assert!(err.contains(codec), "{err}");
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Update the playback codec regression test after AAC-LC decoding became supported.
- Keep validation coverage for the unsupported VP8 and VP9 codecs.
- Root cause: the production AAC rejection was removed when AAC-LC playback landed, but the older all-features test still expected AAC validation to fail, breaking the nightly Features gate.

## Public API changes

None.

## Test plan

- just fix
- just check
- just test
- cargo nextest run --locked -p moq-cli --all-targets --all-features (37 passed)

Cross-package sync is not applicable because this is a test-only change.

(Written by GPT-5)