### PR TITLE
fix(moq-tokio): enforce peer identity configuration

### DIFF
--- a/rs/moq-tokio/src/quiche.rs
+++ b/rs/moq-tokio/src/quiche.rs
@@ -234,6 +234,12 @@ struct ClientIdentity {
 impl QuicheClient {
 	pub fn new(config: &crate::connect::Config, quic: &crate::quic::Config) -> Result<Self> {
 		let quic = quic.resolve();
+		// Identity holds a rustls signer rather than exportable private-key DER, which
+		// quiche requires. Refuse it instead of silently dialing without mTLS.
+		#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+		if config.tls.identity.is_some() {
+			return Err(crate::tls::Error::MemoryUnsupported.into());
+		}
 		let identity = match (&config.tls.cert, &config.tls.key) {
 			(Some(cert), Some(key)) => {
 				let (chain, key) = load_quiche_cert(cert, key)?;
@@ -806,5 +812,22 @@ mod tests {
 		quic.congestion_control = Some(CongestionControl::Loss);
 		apply_settings(&mut settings, &quic.resolve()).unwrap();
 		assert_eq!(settings.cc_algorithm, "cubic");
+	}
+
+	/// An in-memory identity must not disappear when the quiche backend is selected.
+	#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+	#[test]
+	fn rejects_in_memory_client_identity() {
+		let mut tls = crate::tls::Connect::default();
+		tls.identity = Some(crate::tls::Identity::generate(["client.invalid"]).unwrap());
+		let config = crate::connect::Config {
+			tls,
+			..Default::default()
+		};
+
+		assert!(matches!(
+			QuicheClient::new(&config, &crate::quic::Config::default()),
+			Err(Error::Tls(crate::tls::Error::MemoryUnsupported))
+		));
 	}
 }

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -82,9 +82,9 @@ pub enum Error {
 	ConflictingClientAuth,
 
 	/// An in-memory identity or a pinned peer set was configured on a backend that
-	/// fixes its TLS material when the listener is built.
+	/// cannot consume the live rustls material.
 	#[error(
-		"the quiche backend cannot serve an in-memory Identity or pin client fingerprints; use the quinn or noq backend"
+		"the quiche backend cannot use an in-memory Identity or pin client fingerprints; use the quinn or noq backend"
 	)]
 	MemoryUnsupported,
 
@@ -1301,10 +1301,10 @@ impl Listen {
 		found
 	}
 
-	/// Disable cached client authentication when client roots can reload.
+	/// Disable cached client authentication when client authorization can change.
 	#[cfg(feature = "watch")]
 	pub(crate) fn disable_resumption(&self, tls: &mut rustls::ServerConfig) {
-		if !self.root.is_empty() {
+		if !self.root.is_empty() || self.peers.is_some() {
 			tls.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
 			tls.send_tls13_tickets = 0;
 		}
@@ -2062,6 +2062,41 @@ mod tests {
 		peers.insert(identity.fingerprint()).unwrap();
 		let other_leaf = other.certified().cert[0].clone();
 		assert!(verifier.verify_client_cert(&other_leaf, &[], now).is_err());
+	}
+
+	/// A resumed handshake skips certificate verification, so a listener with a
+	/// live peer set must disable resumption for removals to take effect.
+	#[cfg(all(feature = "watch", any(feature = "quinn", feature = "noq", feature = "quiche")))]
+	#[test]
+	fn removed_peers_cannot_resume() {
+		let server_identity = Identity::generate(["localhost"]).unwrap();
+		let client_identity = Identity::generate(["client.invalid"]).unwrap();
+		let peers = Peers::new();
+		peers.insert(client_identity.fingerprint()).unwrap();
+
+		let client = Arc::new(
+			Connect {
+				identity: Some(client_identity.clone()),
+				fingerprint: vec![server_identity.fingerprint().to_string()],
+				..Default::default()
+			}
+			.build()
+			.unwrap(),
+		);
+		let server = Listen {
+			identity: Some(server_identity),
+			peers: Some(peers.clone()),
+			..Default::default()
+		}
+		.server_config(Vec::new())
+		.unwrap();
+
+		assert_eq!(
+			handshake_kinds(client.clone(), server.clone()).unwrap().1,
+			rustls::HandshakeKind::Full
+		);
+		peers.remove(client_identity.fingerprint()).unwrap();
+		assert!(handshake_kinds(client, server).is_err());
 	}
 
 	/// The fingerprint a listener reads off an accepted session is the one the


### PR DESCRIPTION
## Summary

- Disable server-side TLS resumption while a live fingerprint allowlist is configured, so removing a peer affects every later handshake.
- Reject `Connect::identity` on quiche instead of silently dropping the mTLS identity.

Root causes:

- rustls restores the cached client certificate on resumed sessions without invoking `PeerVerifier`, while resumption was disabled only for reloadable CA roots.
- `QuicheClient::new` translated only on-disk `cert`/`key` pairs and never inspected the new in-memory identity.

## Public API changes

- None. The existing `MemoryUnsupported` error now also covers quiche client identities.

## Test plan

- `MOQ_STRICT=1 nix develop --command just check`
- `MOQ_STRICT=1 nix develop --command just test`
- Targeted regressions: `removed_peers_cannot_resume`, `rejects_in_memory_client_identity`

## Cross-package sync

- Not applicable. No wire format, CLI surface, FFI, or documentation contract changed.

Follow-up to #2944.

(Written by GPT-5)
