### PR TITLE
fix(net): assign anonymous server peers an origin

### DIFF
--- a/drafts/draft-lcurley-moq-cluster.md
+++ b/drafts/draft-lcurley-moq-cluster.md
@@ -105,10 +105,27 @@ Because any number of endpoints can be 0, it identifies nothing, which constrain
 
 - **Loop detection**: 0 in a HOP_PATH is never a loop. A receiver whose own Hop ID is 0 cannot detect loops through itself, and MUST NOT discard an advertisement merely because the path contains 0.
 - **Origin identity**: an advertisement whose first entry is 0 has an unknown origin. A receiver MUST NOT treat two such advertisements as interchangeable ({{selection}}). Updating one advertisement is not two ({{updating}}).
-- **Filtering**: a peer that declared 0 excludes nothing, so the sender applies no filter to that session.
+- **Filtering**: a peer that declared 0 declared no identity, so there is nothing on the wire to filter that session on. A receiver MAY assign one ({{assigned}}), which covers what it attributes to that session itself but not an advertisement that arrived carrying its own HOP_PATH.
 
 Duplicate *non-zero* Hop IDs in one HOP_PATH are a loop; duplicate zeros are not.
-Declaring 0 therefore trades loop detection and failover for anonymity.
+Declaring 0 therefore trades loop detection and failover for anonymity, except against a receiver that assigns an identity of its own.
+
+## Assigned Identities {#assigned}
+A receiver MAY assign a Hop ID of its own to a peer that declared none, whether by declaring 0 or by not negotiating this extension at all.
+It uses that ID wherever it would otherwise have nothing to name the peer with: as the entry it creates for an upstream that sent no HOP_PATH, and as what it filters that session on.
+
+The ID is the receiver's own, not the peer's.
+An advertisement that arrives carrying its own HOP_PATH names the sender there, as 0 if the sender withheld it, and this document does not define rewriting that entry.
+So an assigned ID governs the advertisements a receiver attributed itself, and a peer that both declares 0 and sends its own HOP_PATH keeps the consequences in {{zero}}.
+
+An assigned ID MUST NOT be shared between peers not known to be the same endpoint.
+Sharing one makes their content interchangeable ({{selection}}) and suppresses each one's advertisements to the other, so two unrelated publishers would be spliced into one and starve each other of routes.
+
+How an endpoint scopes the ID follows from what it can establish about the peer.
+One it authenticated, or one it dialed and therefore chose, SHOULD get a single stable ID, which additionally lets reconnects and redundant sessions be recognized as the same content ({{selection}}); assigning per connection there would make one peer look like several.
+An endpoint accepting an anonymous session can establish nothing and cannot correlate it with any other, so it SHOULD assign a distinct ID per session: less than an identity, but enough to keep that session's own routes from being advertised back to it, which is the loop 0 cannot prevent.
+
+An assigned ID is indistinguishable on the wire from a declared one, so it identifies the peer to everyone the receiver forwards to; a peer that declared 0 for anonymity did not ask for that.
 
 
 # Namespace Advertisements {#namespace}
@@ -132,7 +149,7 @@ An endpoint MUST NOT append them on a session that did not negotiate the extensi
 
 NAMESPACE_DONE ({{moqt}} Section 10.17) carries no state from this extension and is not extended.
 
-## HOP_PATH Parameter
+## HOP_PATH Parameter {#hop-path}
 HOP_PATH is the ordered list of Hop IDs an advertisement has traversed, from the original publisher to the relay immediately upstream of the receiver:
 
 ~~~
@@ -164,7 +181,7 @@ The original publisher seeds the value with its production cost: 0 for content i
 
 # Relay Behavior
 When forwarding an advertisement downstream, a relay MUST append its own Hop ID to the HOP_PATH it received, so its own ID is always the last entry.
-An advertisement arriving from an upstream that did not negotiate the extension has no HOP_PATH; the relay creates one containing a single 0 for that upstream ({{zero}}), then appends its own.
+An advertisement arriving from an upstream that did not negotiate the extension has no HOP_PATH; the relay creates one containing a single entry for that upstream, 0 ({{zero}}) or an ID it assigned ({{assigned}}), then appends its own.
 
 On receipt, a relay MUST discard an advertisement whose HOP_PATH already contains its own non-zero Hop ID: forwarding it would extend a loop, and subscribing through it would route the relay back to itself.
 This receiver-side check catches loops of any length and is the only loop defense required.
@@ -219,6 +236,7 @@ Applying one rule to both advertisement and dispatch keeps advertised paths trut
 
 # Security Considerations
 A Hop ID reveals nothing beyond what its operator encodes in it, and a deployment that considers its identifiers sensitive can use random values or declare 0 ({{zero}}).
+Declaring 0 hides an identity from the mesh but not from the peer itself, which MAY assign one and forward it onward ({{assigned}}); an endpoint that needs to stay unlinkable past its first hop cannot get that from this extension.
 A HOP_PATH does expose how many hops an advertisement crossed, which hints at the size of a deployment; a relay MAY coalesce its internal hops into one entry, or strip HOP_PATH, before forwarding across a trust boundary.
 
 Because a relay only appends to HOP_PATH, it cannot make a competing path look shorter than it is; the worst it can do is under-report its own upstream portion to win an advisory tie-break.

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -1105,6 +1105,23 @@ impl Request {
 		}
 	}
 
+	/// Override the fallback origin for a peer that did not declare one on the wire.
+	pub fn with_peer_origin(self, origin: moq_net::Origin) -> Self {
+		let Request {
+			transport,
+			url,
+			identity,
+			kind,
+		} = self;
+		let kind = request_map!(kind, request => request.with_peer_origin(origin));
+		Request {
+			transport,
+			url,
+			identity,
+			kind,
+		}
+	}
+
 	/// Attach a per-connection [`moq_net::stats::Session`] context to this session.
 	pub fn with_stats(self, stats: moq_net::stats::Session) -> Self {
 		let Request {

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -1105,7 +1105,9 @@ impl Request {
 		}
 	}
 
-	/// Override the fallback origin for a peer that did not declare one on the wire.
+	/// Assign the identity this peer's routes are attributed to; see
+	/// [`moq_net::Request::with_peer_origin`]. Derive it from [`Self::peer_identity`],
+	/// never from something coarser.
 	pub fn with_peer_origin(self, origin: moq_net::Origin) -> Self {
 		let Request {
 			transport,

--- a/rs/moq-net/src/ietf/cluster.rs
+++ b/rs/moq-net/src/ietf/cluster.rs
@@ -182,11 +182,9 @@ impl Advert {
 /// What the peer declared in its SETUP.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Peer {
-	/// The peer's Hop ID, or `None` when it did not negotiate the extension.
-	///
-	/// A peer that declared the reserved 0 negotiated the extension but withheld its
-	/// identity, which decodes to `Some(Origin::UNKNOWN)`: the extension is on, but
-	/// there is nothing to exclude.
+	/// What the peer put in RELAY_HOPS, or `None` when it did not negotiate the
+	/// extension. Read [`Self::identity`] for the identity; this field answers whether
+	/// the extension is on, which is a different question when the peer declared 0.
 	pub origin: Option<Origin>,
 
 	/// What the peer said subscribing from it costs, or `None` when it priced nothing
@@ -196,15 +194,19 @@ pub struct Peer {
 }
 
 impl Peer {
-	/// Whether the peer negotiated the extension.
+	/// Whether the peer negotiated the extension, which is what decides the NAMESPACE
+	/// encoding. True even for a peer that declared the reserved 0.
 	pub fn negotiated(&self) -> bool {
 		self.origin.is_some()
 	}
 
-	/// The Hop ID to exclude when advertising to (and serving) this peer.
-	/// [`Origin::UNKNOWN`] excludes nothing.
-	pub fn exclude(&self) -> Origin {
-		self.origin.unwrap_or(Origin::UNKNOWN)
+	/// The identity the peer declared, or `None` when it declared none.
+	///
+	/// Declaring the reserved 0 turns the extension on while withholding an identity,
+	/// which reads here exactly like declaring nothing at all. The receiver assigns one
+	/// instead, so there is no third state for callers to get wrong.
+	pub fn identity(&self) -> Option<Origin> {
+		self.origin.filter(|origin| *origin != Origin::UNKNOWN)
 	}
 }
 
@@ -414,19 +416,29 @@ mod tests {
 		assert_eq!(absurd.route(10).cost, u64::MAX);
 	}
 
+	/// Negotiating the extension and declaring an identity are separate questions, and a
+	/// peer that declared the reserved 0 answers them differently: the extension is on,
+	/// so the NAMESPACE encoding changes, but it named nobody, so it reads exactly like a
+	/// peer that declared nothing and the receiver assigns an identity instead.
 	#[test]
-	fn peer_defaults() {
+	fn declared_zero_negotiates_without_an_identity() {
 		let peer = Peer::default();
 		assert!(!peer.negotiated());
-		assert_eq!(peer.exclude(), Origin::UNKNOWN);
+		assert_eq!(peer.identity(), None);
 
-		// A declared 0 negotiates the extension but excludes nothing.
 		let anonymous = Peer {
 			origin: Some(Origin::UNKNOWN),
 			cost: Some(0),
 		};
 		assert!(anonymous.negotiated());
-		assert_eq!(anonymous.exclude(), Origin::UNKNOWN);
+		assert_eq!(anonymous.identity(), None);
+
+		let named = Peer {
+			origin: Some(origin(9)),
+			cost: None,
+		};
+		assert!(named.negotiated());
+		assert_eq!(named.identity(), Some(origin(9)));
 	}
 
 	#[test]

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -248,9 +248,10 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 	// origin we consume so it matches the local relay identity across every session,
 	// which is what makes cross-session loop detection work.
 	self_origin: crate::Origin,
-	// The identity assigned to the peer by `Client::with_peer_origin`, used when the
-	// peer declares none itself. A peer that negotiates the MoQ Cluster extension
-	// declares its own, which wins.
+	// The identity assigned to the peer by the caller (`Client::with_peer_origin`, or
+	// the per-session default a server hands every request), used when the peer declares
+	// none itself. A peer that negotiates the MoQ Cluster extension declares its own,
+	// which wins unless it withheld it as the reserved 0.
 	peer_origin: Option<crate::Origin>,
 	// What the peer declared in its SETUP, filled when that stream is read.
 	peer_setup: peer::PeerSetup,
@@ -304,8 +305,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	/// The same exclusion the announce path applies (see [`Self::select`]), which is what
 	/// keeps advertised paths truthful and prevents subscription cycles of any length.
 	async fn serving_origin(&self) -> origin::Consumer {
-		let peer = self.peer().await;
-		match self.exclude(&peer) {
+		self.excluding(&self.peer().await)
+	}
+
+	/// Our origin handle with [`Self::exclude`] applied, the view both the data plane
+	/// and the announce loops read this peer's routes through.
+	fn excluding(&self, peer: &cluster::Peer) -> origin::Consumer {
+		match self.exclude(peer) {
 			crate::Origin::UNKNOWN => self.origin.clone(),
 			exclude => self.origin.clone().excluding(exclude),
 		}
@@ -313,14 +319,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	/// The Hop ID whose paths must not be advertised (or served) back to this peer.
 	///
-	/// A peer that negotiated the extension declares its own; otherwise fall back to
-	/// one the caller assigned out of band (`Client::with_peer_origin`), since
-	/// moq-transport itself carries no identity.
+	/// A peer that declared an identity supplies its own; otherwise fall back to the one
+	/// we assigned it (`Client::with_peer_origin` when dialing, `Request::with_peer_origin`
+	/// or a fresh per-session id when accepting), since moq-transport carries no identity
+	/// of its own. A peer that declared the reserved 0 declared no identity, so it takes
+	/// the fallback like any other anonymous peer.
 	fn exclude(&self, peer: &cluster::Peer) -> crate::Origin {
-		match peer.negotiated() {
-			true => peer.exclude(),
-			false => self.peer_origin.unwrap_or(crate::Origin::UNKNOWN),
-		}
+		peer.identity().or(self.peer_origin).unwrap_or(crate::Origin::UNKNOWN)
 	}
 
 	/// Pick what to advertise to this peer for one broadcast.
@@ -1288,10 +1293,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Split horizon, as the solicited loop applies it: never advertise a route back
 		// to the peer it came from.
-		let origin = match self.exclude(&peer) {
-			crate::Origin::UNKNOWN => self.origin.clone(),
-			exclude => self.origin.clone().excluding(exclude),
-		};
+		let origin = self.excluding(&peer);
 
 		let ns = Namespaces::new(peer, Target::Requests(None));
 		self.run_namespaces(origin, crate::Path::empty().to_owned(), ns).await
@@ -1644,15 +1646,18 @@ mod tests {
 		declared(Some(true))
 	}
 
-	/// A broadcast whose every route flows through the peer's assigned identity
-	/// (`Client::with_peer_origin`) is never advertised to that peer; it would only
-	/// echo the peer's own content back at it. A broadcast with an independent
-	/// route still is.
-	#[tokio::test]
-	async fn assigned_peer_origin_filters_echoed_announces() {
-		let assigned = crate::Origin::new(777).unwrap();
+	/// A publisher for a peer assigned `assigned`, over an origin holding two
+	/// broadcasts: `from/peer`, whose only route flows through `assigned`, and
+	/// `from/us`, which does not. The producers are returned so the routes outlive
+	/// the assertions.
+	async fn echo_harness(
+		assigned: crate::Origin,
+	) -> (
+		Publisher<SinkSession>,
+		origin::Consumer,
+		Vec<crate::broadcast::Producer>,
+	) {
 		let other = crate::Origin::new(778).unwrap();
-
 		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 
@@ -1668,7 +1673,7 @@ mod tests {
 
 		let mut echoed_hops = crate::OriginList::new();
 		echoed_hops.push(assigned).unwrap();
-		let _echoed = origin
+		let echoed = origin
 			.create_broadcast(
 				"from/peer",
 				crate::broadcast::Route::new()
@@ -1679,7 +1684,7 @@ mod tests {
 
 		let mut local_hops = crate::OriginList::new();
 		local_hops.push(other).unwrap();
-		let _local = origin
+		let local = origin
 			.create_broadcast(
 				"from/us",
 				crate::broadcast::Route::new().with_hops(local_hops).with_announce(true),
@@ -1689,6 +1694,18 @@ mod tests {
 		// Broadcast visibility is deferred until the executor ticks.
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
+		(publisher, consumer, vec![echoed, local])
+	}
+
+	/// A broadcast whose every route flows through the peer's assigned identity
+	/// (`Client::with_peer_origin`) is never advertised to that peer; it would only
+	/// echo the peer's own content back at it. A broadcast with an independent
+	/// route still is.
+	#[tokio::test(start_paused = true)]
+	async fn assigned_peer_origin_filters_echoed_announces() {
+		let assigned = crate::Origin::new(777).unwrap();
+		let (publisher, consumer, _routes) = echo_harness(assigned).await;
+
 		let peer = cluster::Peer::default();
 
 		let echoed = consumer.get_broadcast("from/peer").unwrap();
@@ -1696,6 +1713,27 @@ mod tests {
 
 		let local = consumer.get_broadcast("from/us").unwrap();
 		assert_eq!(publisher.select(&Watched::new(local), &peer), Advert::Plain);
+	}
+
+	/// A peer that negotiates the cluster extension but declares the reserved 0 has
+	/// withheld its identity, which excludes nothing. The identity we assigned it
+	/// stands in, so its own routes still don't come back to it.
+	#[tokio::test(start_paused = true)]
+	async fn withheld_peer_origin_falls_back_to_assigned() {
+		let assigned = crate::Origin::new(777).unwrap();
+		let (publisher, consumer, _routes) = echo_harness(assigned).await;
+
+		let peer = cluster::Peer {
+			origin: Some(crate::Origin::UNKNOWN),
+			cost: None,
+		};
+		assert!(peer.negotiated());
+
+		let echoed = consumer.get_broadcast("from/peer").unwrap();
+		assert!(!publisher.select(&Watched::new(echoed), &peer).wanted());
+
+		let local = consumer.get_broadcast("from/us").unwrap();
+		assert!(publisher.select(&Watched::new(local), &peer).wanted());
 	}
 
 	/// A drained broadcast arms a linger so the cold cost is restored after a grace

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -244,10 +244,10 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	// sessions dialing the same relay.
 	//
 	// Otherwise this is `Origin::UNKNOWN` (0), the reserved "no identity" value.
-	// Inventing a random id here would look like a real identity without being
-	// one: the peer never learns it, so it cannot exclude it for loop detection,
-	// and two unrelated publishers would each get an id that made their content
-	// look distinct rather than merely unknown.
+	// Minting one here is not this layer's call: the peer never learns the id, so
+	// only the side that assigned it can exclude it for loop detection, and whether
+	// two sessions should look like one identity or two is the caller's policy. A
+	// server answers it per accepted session; a client only when it knows the peer.
 	session_origin: crate::Origin,
 	// Our own Hop ID, which an advertisement must not already contain: one that does
 	// looped back through us.

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -70,10 +70,10 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 	// peer from a source whose chain excludes them, keeping the data plane on
 	// the same split-horizon rule as the announces we send them.
 	peer_setup: super::PeerSetup,
-	// The identity assigned to the peer by `Client::with_peer_origin`, standing
-	// in wherever the peer declines to declare one. The data-plane half (serving
-	// from a chain that excludes it) is applied by the client on the origin
-	// handle itself; here it only backs the announce filter.
+	// The identity assigned to the peer by the caller (`Client::with_peer_origin`, or
+	// the per-session default a server hands every request), standing in wherever the
+	// peer declines to declare one. Backs both the announce filter and the serving
+	// origin, so a peer that names itself nowhere on the wire is still split-horizoned.
 	peer_origin: Option<Origin>,
 	// The excluded origin handle, resolved once: the peer sends exactly one
 	// SETUP, so its declared id never changes for the session.
@@ -101,23 +101,25 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// The origin to resolve a peer-requested broadcast from: excludes routes
-	/// through the peer when its SETUP declared an origin id, so a subscription
-	/// is never served data that flowed through the subscriber. The first call
-	/// waits for the peer's SETUP (sent at startup on every lite-05+ session,
-	/// well before it could learn of anything to subscribe to); the result is
-	/// cached, since the peer sends exactly one SETUP per session.
+	/// through the peer, so a subscription is never served data that flowed
+	/// through the subscriber. The identity is the one the peer declared in its
+	/// SETUP, or the one the caller assigned it when it declared none, the same
+	/// order the announce filter applies. The first call waits for the peer's
+	/// SETUP (sent at startup on every lite-05+ session, well before it could
+	/// learn of anything to subscribe to); the result is cached, since the peer
+	/// sends exactly one SETUP per session.
 	async fn serving_origin(&self) -> origin::Consumer {
 		if let Some(origin) = self.serving.get() {
 			return origin.clone();
 		}
-		// Pre-SETUP versions never declare an id; there is nothing to exclude.
-		let origin = if !self.version.has_setup_stream() {
-			self.origin.clone()
-		} else {
-			match self.peer_setup.origin().await {
-				Some(peer) => self.origin.clone().excluding(peer),
-				None => self.origin.clone(),
-			}
+		// Pre-SETUP versions never declare an id, so only the assigned one applies.
+		let declared = match self.version.has_setup_stream() {
+			true => self.peer_setup.origin().await,
+			false => None,
+		};
+		let origin = match declared.or(self.peer_origin) {
+			Some(peer) => self.origin.clone().excluding(peer),
+			None => self.origin.clone(),
 		};
 		// A concurrent first call may have won the race; either value is
 		// identical, so keep whichever landed.
@@ -2396,6 +2398,62 @@ mod serve_group_test {
 mod tests {
 	use super::*;
 	use crate::lite::test_transport::SinkSession;
+
+	/// A peer that declares no origin in its SETUP is split-horizoned by the identity
+	/// the caller assigned it, on the data plane and not just the announce filter.
+	/// Otherwise it can subscribe its way back to content that already flowed through
+	/// it, which is the loop the announce filter exists to prevent.
+	#[tokio::test(start_paused = true)]
+	async fn serving_origin_falls_back_to_the_assigned_identity() {
+		let assigned = crate::Origin::new(777).unwrap();
+		let upstream = crate::Origin::new(778).unwrap();
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+
+		let mut echoed_hops = OriginList::new();
+		echoed_hops.push(assigned).unwrap();
+		let _echoed = origin
+			.create_broadcast(
+				"echoed",
+				crate::broadcast::Route::new()
+					.with_hops(echoed_hops)
+					.with_announce(true),
+			)
+			.unwrap();
+
+		let mut local_hops = OriginList::new();
+		local_hops.push(upstream).unwrap();
+		let _local = origin
+			.create_broadcast(
+				"local",
+				crate::broadcast::Route::new().with_hops(local_hops).with_announce(true),
+			)
+			.unwrap();
+
+		// Broadcast visibility is deferred until the executor ticks.
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+		// A SETUP that declares no origin of its own, so only the assigned one applies.
+		let peer_setup = crate::lite::PeerSetup::default();
+		peer_setup.set(crate::lite::Setup::default());
+
+		let publisher = Publisher::new(PublisherConfig {
+			session: SinkSession::new(Default::default()),
+			origin: origin.consume(),
+			version: Version::Lite06Wip,
+			peer_setup,
+			peer_origin: Some(assigned),
+		});
+
+		let serving = publisher.serving_origin().await;
+		assert!(
+			serving.get_broadcast("echoed").is_none(),
+			"served the peer its own route"
+		);
+		assert!(
+			serving.get_broadcast("local").is_some(),
+			"withheld an independent route"
+		);
+	}
 
 	/// Lite01/02 send the initial active set as ANNOUNCE_INIT. It must apply the
 	/// same per-peer route selection as the live loop: a broadcast whose only

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -62,13 +62,16 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	//
 	// This is the peer's assigned identity (`peer_origin`) when the caller gave
 	// it one, which also makes the route recognizable across sessions. Otherwise
-	// it is `Origin::UNKNOWN` (0), the reserved "no identity" value: a random id
-	// would look like an identity the peer never agreed to and cannot exclude
-	// for loop detection.
+	// it is `Origin::UNKNOWN` (0), the reserved "no identity" value.
+	//
+	// Assigning one is the caller's call, not this layer's: a server gives every
+	// accepted session a fresh id so its routes are at least distinguishable from
+	// another session's, while a client only assigns one it knows out of band. Either
+	// way the peer never learns the id, so only we can exclude it for loop detection.
 	session_origin: crate::Origin,
-	// The identity assigned to the peer by `Client::with_peer_origin`, standing
-	// in wherever the peer declines to declare one (an AnnounceOk reporting
-	// origin id 0).
+	// The identity assigned to the peer by the caller (`Client::with_peer_origin`,
+	// or the per-session default a server hands every request), standing in wherever
+	// the peer declines to declare one (an AnnounceOk reporting origin id 0).
 	peer_origin: Option<crate::Origin>,
 	subscribes: Lock<HashMap<u64, TrackEntry>>,
 	next_id: Arc<atomic::AtomicU64>,
@@ -458,7 +461,24 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		responder_origin: Option<crate::Origin>,
 		routes: &mut HashMap<PathOwned, AnnouncedRoute>,
 	) -> Result<bool, Error> {
+		// Make sure the peer doesn't double announce. Decided first: the drops below
+		// return `Ok(false)`, and the caller has already assigned this announce an id,
+		// so letting one of them pre-empt this check leaves that id bound to a path
+		// whose route belongs to the earlier announce. The `ANNOUNCE_END` that follows
+		// would then retire the wrong one.
+		if routes.contains_key(&path) {
+			return Err(Error::Duplicate);
+		}
+
 		if let Some(responder) = responder_origin {
+			// A chain already naming the sender came back through it: a reflection, and
+			// appending the sender again would name it twice. That is legal in a lite
+			// chain but a PROTOCOL_VIOLATION for an IETF peer we forward it to, so it
+			// must not enter the model at all. Zero names nobody, so it may repeat.
+			if responder != crate::Origin::UNKNOWN && hops.contains(&responder) {
+				tracing::debug!(broadcast = %self.log_path(&path), "dropping announce reflected by its sender");
+				return Ok(false);
+			}
 			// If the chain is already full, drop the announce. This is the same decision
 			// the Lite04 sender makes at its push site.
 			if hops.push(responder).is_err() {
@@ -497,11 +517,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		if hops.is_empty() {
 			hops.push(self.session_origin)
 				.expect("an empty hop chain always has room for one entry");
-		}
-
-		// Make sure the peer doesn't double announce.
-		if routes.contains_key(&path) {
-			return Err(Error::Duplicate);
 		}
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");
@@ -561,7 +576,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	) -> Result<bool, Error> {
 		// Reflected loop (or a full chain): the route can't be used here anymore. Retire it.
 		let reflected = match responder_origin {
-			Some(responder) => hops.push(responder).is_err() || hops.contains(&self.self_origin),
+			// A chain already naming the sender came back through it; see `start_announce`.
+			Some(responder) => {
+				(responder != crate::Origin::UNKNOWN && hops.contains(&responder))
+					|| hops.push(responder).is_err()
+					|| hops.contains(&self.self_origin)
+			}
 			None => hops.contains(&self.self_origin),
 		};
 		if reflected {
@@ -900,6 +920,98 @@ mod tests {
 		assert!(wire.is_empty(), "a second SUBSCRIBE trailed the first");
 	}
 
+	/// A second announce for a live path is a protocol error whatever its hops say. It
+	/// must be caught before the reflection drops, because the caller has already bound
+	/// an announce id to it: dropping it silently leaves that id pointing at a path
+	/// owned by the earlier announce, and the `ANNOUNCE_END` that follows retires the
+	/// wrong route.
+	#[tokio::test]
+	async fn a_double_announce_is_an_error_even_when_reflected() {
+		let assigned = crate::Origin::new(777).unwrap();
+		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let (tasks, _task_set) = TaskSet::new();
+		let mut subscriber = Subscriber::new(SubscriberConfig {
+			session: SinkSession::new(Default::default()),
+			origin,
+			recv_bandwidth: None,
+			version: VERSION,
+			peer_setup: Default::default(),
+			cost: None,
+			peer_origin: Some(assigned),
+			tasks,
+		});
+
+		let path = Path::new("room/host").to_owned();
+		let mut routes = HashMap::new();
+		assert!(
+			subscriber
+				.start_announce(
+					path.clone(),
+					crate::OriginList::new(),
+					RouteCost::default(),
+					0,
+					Some(assigned),
+					&mut routes,
+				)
+				.unwrap()
+		);
+
+		// The same path again, this time with a chain that names the sender.
+		let mut reflected = crate::OriginList::new();
+		reflected.push(assigned).unwrap();
+		assert!(
+			matches!(
+				subscriber.start_announce(path, reflected, RouteCost::default(), 0, Some(assigned), &mut routes),
+				Err(Error::Duplicate)
+			),
+			"the double announce must be reported, not silently dropped",
+		);
+	}
+
+	/// An announce whose chain already names the sender came back through the sender.
+	/// Appending it again would name one identity twice, which is tolerated in a lite
+	/// chain but is a PROTOCOL_VIOLATION for an IETF peer the route is later forwarded
+	/// to, so the route must never enter the model carrying it.
+	#[tokio::test]
+	async fn an_announce_reflected_by_its_sender_is_dropped() {
+		let assigned = crate::Origin::new(777).unwrap();
+
+		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let consumer = origin.consume();
+		let (tasks, _task_set) = TaskSet::new();
+		let mut subscriber = Subscriber::new(SubscriberConfig {
+			session: SinkSession::new(Default::default()),
+			origin,
+			recv_bandwidth: None,
+			version: VERSION,
+			peer_setup: Default::default(),
+			cost: None,
+			peer_origin: Some(assigned),
+			tasks,
+		});
+
+		// The sender reports origin 0, so it takes the assigned identity, and its chain
+		// already carries that identity: the route came back through it.
+		let mut hops = crate::OriginList::new();
+		hops.push(assigned).unwrap();
+
+		let mut routes = HashMap::new();
+		let accepted = subscriber
+			.start_announce(
+				Path::new("room/host").to_owned(),
+				hops,
+				RouteCost::default(),
+				0,
+				Some(assigned),
+				&mut routes,
+			)
+			.unwrap();
+		assert!(!accepted, "a chain naming its own sender must not become a route");
+
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		assert!(consumer.get_broadcast("room/host").is_none());
+	}
+
 	/// A peer that declares no identity gets attributed the origin the caller
 	/// assigned it (`Client::with_peer_origin`), so every session dialing the same
 	/// relay yields one recognizable hop instead of a random id per connection.
@@ -946,8 +1058,9 @@ mod tests {
 	}
 
 	/// A peer with no assigned identity is attributed the reserved origin 0
-	/// (UNKNOWN), not a random one: a random id would look like a real identity
-	/// the peer never agreed to and cannot exclude for loop detection.
+	/// (UNKNOWN). This layer never mints one of its own: whether an anonymous peer
+	/// gets an identity, and whether two of its sessions share it, is the caller's
+	/// policy, and a minted id here would be indistinguishable from a declared one.
 	#[tokio::test]
 	async fn absent_peer_origin_stamps_unknown() {
 		let (mut subscriber, consumer) = restart_subscriber(SinkSession::new(Default::default()));

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -85,6 +85,7 @@ impl Server {
 			path: None,
 			role: None,
 			origin: None,
+			assigned_origin: crate::Origin::random(),
 			inner: Some(RequestInner {
 				server: self.clone(),
 				handshake,
@@ -146,6 +147,7 @@ impl Server {
 					path: client_setup.path.clone(),
 					role: client_setup.role,
 					origin: client_setup.origin,
+					assigned_origin: crate::Origin::random(),
 					inner: Some(RequestInner {
 						server: self.clone(),
 						handshake: Handshake::LiteSetup {
@@ -223,6 +225,7 @@ impl Server {
 			path,
 			role: None,
 			origin: None,
+			assigned_origin: crate::Origin::random(),
 			inner: Some(RequestInner {
 				server: self.clone(),
 				handshake: Handshake::Legacy {
@@ -254,6 +257,7 @@ impl Server {
 				.cluster
 				.origin
 				.filter(|o| *o != crate::Origin::UNKNOWN),
+			assigned_origin: crate::Origin::random(),
 			inner: Some(RequestInner {
 				server: self.clone(),
 				handshake: Handshake::IetfModern {
@@ -277,6 +281,7 @@ pub struct Request<S: web_transport_trait::Session> {
 	path: Option<String>,
 	role: Option<Role>,
 	origin: Option<crate::Origin>,
+	assigned_origin: crate::Origin,
 	// Taken by `ok`/`close`; `Drop` rejects the handshake if neither ran.
 	inner: Option<RequestInner<S>>,
 }
@@ -368,6 +373,15 @@ impl<S: web_transport_trait::Session> Request<S> {
 		self
 	}
 
+	/// Override the origin assigned to a peer when the protocol does not carry one.
+	///
+	/// Each request defaults to a fresh per-session origin. Use this method when the
+	/// peer has a stable identity known out of band. A peer-declared origin still wins.
+	pub fn with_peer_origin(mut self, origin: crate::Origin) -> Self {
+		self.assigned_origin = origin;
+		self
+	}
+
 	/// Set the per-connection [`stats::Session`] context. Overrides any value from the
 	/// [`Server`] builder.
 	pub fn with_stats(mut self, stats: stats::Session) -> Self {
@@ -382,6 +396,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 	/// Accept the session, returning the [`Session`] and the [`Driver`] that runs
 	/// its protocol work.
 	pub async fn ok(mut self) -> Result<(Session, Driver), Error> {
+		let peer_origin = Some(self.assigned_origin);
 		let RequestInner { server, handshake } = self.inner.take().expect("request already responded");
 
 		// Tag the origin pair with the stats context so the model attributes reads
@@ -405,7 +420,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					client: false,
 					publish,
 					subscribe,
-					peer_origin: None,
+					peer_origin,
 					// Only the dialing side prices a link.
 					cost: None,
 					version,
@@ -422,7 +437,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					setup_stream: None,
 					publish,
 					subscribe,
-					peer_origin: None,
+					peer_origin,
 					version,
 					our_setup: lite::Setup::default(),
 					peer_setup: None,
@@ -455,7 +470,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					setup_stream: None,
 					publish,
 					subscribe,
-					peer_origin: None,
+					peer_origin,
 					version,
 					our_setup,
 					peer_setup: Some(client_setup),
@@ -503,7 +518,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					setup_stream: Some(stream),
 					publish,
 					subscribe,
-					peer_origin: None,
+					peer_origin,
 					version: v,
 					our_setup: lite::Setup::default(),
 					peer_setup: None,
@@ -520,7 +535,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					client: false,
 					publish,
 					subscribe,
-					peer_origin: None,
+					peer_origin,
 					cost: None,
 					version: v,
 					path: None,
@@ -575,6 +590,11 @@ mod tests {
 
 	use crate::ALPN_LITE_05;
 	use bytes::Bytes;
+
+	fn occurrences(log: &crate::lite::test_transport::Log, needle: &[u8]) -> usize {
+		let writes = log.writes.lock().unwrap();
+		writes.windows(needle.len()).filter(|window| *window == needle).count()
+	}
 
 	#[derive(Debug, Clone, Default)]
 	struct FakeError;
@@ -806,5 +826,72 @@ mod tests {
 		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None, None, Some(origin))]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.peer_origin(), Some(origin));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn anonymous_peer_origin_filters_routes_from_server_session() {
+		let other = Origin::new(778).unwrap();
+		let origin = crate::origin::Info::new(Origin::new(1).unwrap()).produce();
+
+		let gate = kio::Producer::new(true);
+		let transport = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
+		let log = transport.log.clone();
+		let version = ietf::Version::Draft18;
+		let request = Request {
+			path: None,
+			role: None,
+			origin: None,
+			assigned_origin: Origin::random(),
+			inner: Some(RequestInner {
+				server: Server::new().with_publisher(&origin),
+				handshake: Handshake::IetfModern {
+					session: transport,
+					version,
+					peer_setup: ietf::PeerSetup {
+						stream: crate::coding::Reader::new(
+							crate::lite::test_transport::PendingRecv,
+							Version::Ietf(version),
+						),
+						path: None,
+						declared: ietf::peer::Peer::default(),
+					},
+				},
+			}),
+		};
+		let assigned = request.assigned_origin;
+
+		let mut echoed_hops = crate::OriginList::new();
+		echoed_hops.push(assigned).unwrap();
+		let _echoed = origin
+			.create_broadcast(
+				"echoed-route",
+				crate::broadcast::Route::new()
+					.with_hops(echoed_hops)
+					.with_announce(true),
+			)
+			.unwrap();
+
+		let mut local_hops = crate::OriginList::new();
+		local_hops.push(other).unwrap();
+		let _local = origin
+			.create_broadcast(
+				"local-route",
+				crate::broadcast::Route::new().with_hops(local_hops).with_announce(true),
+			)
+			.unwrap();
+
+		let (session, driver) = request.ok().await.unwrap();
+		let _driver = tokio::spawn(driver);
+
+		for _ in 0..100 {
+			if occurrences(&log, b"local-route") > 0 {
+				break;
+			}
+			tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		}
+
+		assert_eq!(occurrences(&log, b"echoed-route"), 0);
+		assert_eq!(occurrences(&log, b"local-route"), 1);
+		drop(session);
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -281,6 +281,9 @@ pub struct Request<S: web_transport_trait::Session> {
 	path: Option<String>,
 	role: Option<Role>,
 	origin: Option<crate::Origin>,
+	/// The identity this session's routes are stamped with when the peer declares none
+	/// on the wire. Fresh per request unless the caller overrides it
+	/// ([`Request::with_peer_origin`]).
 	assigned_origin: crate::Origin,
 	// Taken by `ok`/`close`; `Drop` rejects the handshake if neither ran.
 	inner: Option<RequestInner<S>>,
@@ -373,10 +376,18 @@ impl<S: web_transport_trait::Session> Request<S> {
 		self
 	}
 
-	/// Override the origin assigned to a peer when the protocol does not carry one.
+	/// Assign the identity this peer's routes are attributed to, overriding the fresh
+	/// per-session default.
 	///
-	/// Each request defaults to a fresh per-session origin. Use this method when the
-	/// peer has a stable identity known out of band. A peer-declared origin still wins.
+	/// Only for a peer whose identity the server has actually established, such as one
+	/// authenticated by mTLS or a token ([`crate::Client::with_peer_origin`] is the
+	/// dialing-side equivalent). An identity the peer declares on the wire still wins.
+	///
+	/// Two sessions given the same origin are treated as one endpoint: routes learned
+	/// from either are kept off both, and content arriving on either is interchangeable
+	/// with the other's. That is the point when they really are one peer reconnecting or
+	/// running redundant links, and a bug otherwise. Derive it from the authenticated
+	/// identity, never from something coarser like the remote address.
 	pub fn with_peer_origin(mut self, origin: crate::Origin) -> Self {
 		self.assigned_origin = origin;
 		self


### PR DESCRIPTION
## Summary

Give every accepted moq-net server session a fresh per-session fallback origin, and make every path that reads a peer's identity resolve it the same way: declared first, then assigned.

## Root cause

Anonymous server-side sessions passed no fallback peer origin into the protocol adapters. Routes learned from those sessions were stamped with the unknown origin (0), which identifies nothing and excludes nothing, so publisher route selection could not recognize a route as having arrived on the session it was about to be advertised back to. Cloudflare moq-rs then received its own PUBLISH_NAMESPACE repeatedly and rejected it as a duplicate.

The identity is per session rather than per remote host. Separate publisher and subscriber connections must stay distinct, and nothing at this layer can prove two connections are the same peer.

## What else that identity had to reach

Assigning it was not enough on its own. Several paths read a peer's identity and only some consulted the fallback:

- `lite::Publisher::serving_origin` excluded only an origin the peer declared in its SETUP. A peer that declared none, which is every anonymous session and every pre-lite-05 version since they cannot declare one at all, was served from the unexcluded origin. The client half hid this: `Client::connect` pre-excludes the origin handle and a server request does not.
- `ietf::Publisher::exclude` keyed off `cluster::Peer::negotiated()`, which is true for a peer that negotiated the extension and declared the reserved 0. That was a third state nothing wanted: the NAMESPACE encoding changes, but the identity excludes nothing, so the fallback was skipped. `Peer` now answers the two questions separately, `negotiated()` for the encoding and `identity()` for who the peer named.
- The lite ingress appends the sender's identity to the hop chain without checking whether the chain already names it, and lite's `OriginList` caps length without rejecting duplicates. Reachable only now: an anonymous server peer used to contribute 0, which may legally repeat, and now contributes an assigned id. Lite tolerates the duplicate until the route reaches an IETF peer, which must answer a duplicate non-zero Hop ID with a PROTOCOL_VIOLATION. Both append sites reject it, and the double-announce check moved ahead of every drop that returns `Ok(false)`, since the caller has bound an announce id by then and a silent drop leaves it naming another route.

## Public API changes

`Request::with_peer_origin` on moq-net and moq-native, additive, per request only.

Sharing one identity across peers that are not the same endpoint is the hazard: their routes suppress each other's announcements, and since `attach_source` reads the first hop as content identity, two unrelated publishers sharing an id pass `same_publisher` and splice into one broadcast. A per-request setter does not force that, because the caller has that connection's authenticated identity right there (`moq_native::Request::peer_identity`). A `Server`-level setter would force it, so there isn't one.

`Client::with_peer_origin` is unchanged.

## Deliberately out of scope

An advertisement that arrives carrying its own HOP_PATH from a peer that declared 0 still names that peer as 0, so it cannot be filtered on the assigned identity. That is unchanged behavior, not a regression, and the reported failure never reaches it: a peer that does not implement the cluster extension sends no HOP_PATH at all, so it goes through `session_route`, which stamps the assigned identity and is fixed here.

Rewriting the arriving chain was implemented on this branch and reverted. It produced four defects across four review rounds, all in the same fifteen lines, and it is a wire-visible change that wants designing rather than patching. moq-dev/moq#3053 records the constraints those four defects mapped out.

## Wire spec

`drafts/draft-lcurley-moq-cluster.md` gains an "Assigned Identities" section. A receiver assigning an identity is observable on the wire, in the entry it creates for an upstream that sent no HOP_PATH, so it needs to be normative rather than an implementation detail; Relay Behavior previously said that entry is "a single 0". The section documents assignment without substitution, matching the code.

No changes to the encoding itself, and no browser API changes, so the JS implementation and concept docs need no updates.

## Tests

- `lite::publisher::tests::serving_origin_falls_back_to_the_assigned_identity`
- `ietf::publisher::tests::withheld_peer_origin_falls_back_to_assigned`
- `ietf::cluster::tests::declared_zero_negotiates_without_an_identity`
- `lite::subscriber::tests::an_announce_reflected_by_its_sender_is_dropped`
- `lite::subscriber::tests::a_double_announce_is_an_error_even_when_reflected`
- `server::tests::anonymous_peer_origin_filters_routes_from_server_session`

Each fix is mutation-checked: reverting it fails its test.

`just fix`, `just check`, `just test` (2749 passed) and `just drafts check` pass locally.

## Also filed

- moq-dev/moq#3049: outbound HOP_PATH construction is never validated, so a chain no conforming receiver will accept can be emitted.
- moq-dev/moq#3050: a dropped lite announce keeps its id bound, letting a later ANNOUNCE_END retire the wrong route.

Reviewed adversarially by Codex over five rounds; its findings drove both the fixes above and the decision to cut the ingress rewriting.

(written by Claude Opus 5, taking over from GPT-5.6)
