### PR TITLE
fix(rs): publish current workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4271,16 +4271,6 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kio"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa984c3b737520c30b414041ec63b013614abba31418585d83c5c792fb5bb7d"
-dependencies = [
- "loom",
- "smallvec",
-]
-
-[[package]]
-name = "kio"
 version = "0.5.6"
 dependencies = [
  "criterion",
@@ -4288,6 +4278,16 @@ dependencies = [
  "smallvec",
  "tokio",
  "web-async",
+]
+
+[[package]]
+name = "kio"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d64d03bab237df643a5013adcf07764e4bd3265117e4c4f69e856d37928e69"
+dependencies = [
+ "loom",
+ "smallvec",
 ]
 
 [[package]]
@@ -10435,7 +10435,7 @@ dependencies = [
  "bytes",
  "http",
  "iroh",
- "kio 0.5.5",
+ "kio 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-error",
  "n0-future",
  "tokio",
@@ -10454,7 +10454,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.5",
+ "kio 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -10491,7 +10491,7 @@ dependencies = [
  "flume",
  "futures",
  "http",
- "kio 0.5.5",
+ "kio 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-pki-types",
  "thiserror 2.0.20",
  "tokio",
@@ -10511,7 +10511,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.5",
+ "kio 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quinn",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rust-version = "1.91"
 criterion = "0.8"
 flate2 = "1.1"
 getrandom = { version = "0.4", features = ["wasm_js"] }
-hang = { version = "0.20", path = "rs/hang" }
+hang = { version = "0.20.6", path = "rs/hang" }
 kio = { version = "0.5.6", path = "rs/kio" }
 libc = "0.2"
 linux-raw-sys = { version = "0.12.1", features = ["ioctl"] }
@@ -87,11 +87,11 @@ moq-audio = { version = "0.0.19", path = "rs/moq-audio" }
 moq-flate = { version = "0.1.1", path = "rs/moq-flate" }
 moq-hls = { version = "0.4.10", path = "rs/moq-hls", default-features = false }
 moq-json = { version = "0.3.5", path = "rs/moq-json" }
-moq-loc = { version = "0.2", path = "rs/moq-loc" }
-moq-msf = { version = "0.4", path = "rs/moq-msf" }
-moq-mux = { version = "0.9", path = "rs/moq-mux" }
-moq-native = { version = "0.19", path = "rs/moq-native", default-features = false }
-moq-net = { version = "0.2", path = "rs/moq-net" }
+moq-loc = { version = "0.2.1", path = "rs/moq-loc" }
+moq-msf = { version = "0.4.1", path = "rs/moq-msf" }
+moq-mux = { version = "0.9.9", path = "rs/moq-mux" }
+moq-native = { version = "0.19.13", path = "rs/moq-native", default-features = false }
+moq-net = { version = "0.2.14", path = "rs/moq-net" }
 # NVENC bindings, forked from ViliamVadocz/nvidia-video-codec-sdk to dlopen the
 # driver at runtime. Compiles on any platform (macOS included) but only actually
 # used by moq-video on Linux.
@@ -100,8 +100,8 @@ moq-rtc = { version = "0.2.5", path = "rs/moq-rtc" }
 moq-rtmp = { version = "0.2.5", path = "rs/moq-rtmp" }
 moq-srt = { version = "0.2.5", path = "rs/moq-srt" }
 moq-stats = { version = "0.1.6", path = "rs/moq-stats" }
-moq-token = { version = "0.7", path = "rs/moq-token" }
-moq-token-cli = { version = "0.5", path = "rs/moq-token-cli" }
+moq-token = { version = "0.7.2", path = "rs/moq-token" }
+moq-token-cli = { version = "0.5.45", path = "rs/moq-token-cli" }
 # default-features off (the NVIDIA hardware codecs) on moq-transcode and
 # moq-video so each consumer opts in. Binaries enable them, but a self-compiler
 # can leave them off to drop the CUDA dependencies. Both crates still default

--- a/rs/justfile
+++ b/rs/justfile
@@ -29,6 +29,7 @@ default:
 # Compile, lint, format-check, doc-check, and verify dependency hygiene.
 check *args:
     just rs _select-test
+    just rs _publish-test
     cargo clippy --locked --all-targets {{ args }} -- -D warnings
     cargo fmt --all --check
     RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps {{ args }}
@@ -199,6 +200,35 @@ _select-test:
     	|| fail "a non-crate seed must select nothing"
 
     echo "rs: selection ok"
+
+# Published crates need the current workspace version as the lower bound for
+# internal dependencies. The workspace only tests that version set, and a looser
+# bound lets package verification combine incompatible older releases.
+[private]
+_publish-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    metadata=$(cargo metadata --locked --format-version 1 --no-deps)
+    stale=$(jq -r '
+        .packages as $packages
+        | $packages[] as $package
+        | select($package.publish != [])
+        | $package.dependencies[]
+        | select(.source == null and .path != null and .kind != "dev")
+        | . as $dependency
+        | ($packages[] | select(.name == $dependency.name)) as $current
+        | select($dependency.req != ("^" + $current.version))
+        | "\($package.name): \($dependency.name) requires \($dependency.req), current is ^\($current.version)"
+    ' <<< "$metadata")
+
+    if [[ -n "$stale" ]]; then
+        echo "rs: published workspace dependency lower bounds are stale:" >&2
+        echo "$stale" >&2
+        exit 1
+    fi
+
+    echo "rs: published workspace dependencies current"
 
 # Takes a newline-separated list of changed files; skips when no crate is
 # affected. The `just rs ...` calls below go through the root justfile's


### PR DESCRIPTION
## Summary

- Require published workspace crates to depend on the current internal package versions.
- Align the registry copy of `kio` with the workspace release.
- Add a Rust check that rejects stale internal dependency lower bounds.
- Root cause: `libmoq` package verification combined `moq-native` 0.19.11 with `moq-net` 0.2.14, introducing incompatible `web-transport-trait` 0.3 and 0.4 copies.

## Public API changes

- None.

## Test plan

- `just check`
- `just test` (3,085 passed, 1 skipped)
- `cargo package --locked --allow-dirty -p libmoq`

(Written by GPT-5)
