### PR TITLE
feat(watch): add an instant latency mode

### DIFF
--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -71,7 +71,7 @@ a real bundler (the examples below).
 - `muted`: Mute audio (boolean)
 - `volume`: Audio volume (0 to 1, default: 1)
 - `reload`: Wait for (re)announcement before subscribing (default: true). Ignored when the relay does not support broadcast discovery, which subscribes immediately instead of waiting forever.
-- `latency`: Latency target. `"real-time"` (default) derives it from RTT, or a number sets a fixed jitter buffer in ms. Collapses `latency-min` and `latency-max` to one value (minimize latency).
+- `latency`: Latency target. `"real-time"` (default) derives it from RTT, or a number sets a fixed jitter buffer in ms. Collapses `latency-min` and `latency-max` to one value (minimize latency). `"instant"` drops the clock entirely, see [instant playback](#instant-playback).
 - `latency-min`: Latency floor (the jitter/startup buffer). Same units as `latency`; leaves the ceiling untouched.
 - `latency-max`: Latency ceiling. `"real-time"` (default) minimizes latency; a number caps at that many ms. A ceiling above the floor enables [buffered playback](#buffered-playback): build up a buffer from future-dated frames instead of skipping ahead.
 - `catalog-format`: Catalog format. One of `"hang"`, `"hangz"` (the [DEFLATE-compressed](/concept/layer/hang#compression) `catalog.json.z` track), `"msf"` (see [MSF](/concept/standard/msf)), or `"manual"` (supply the catalog yourself). When omitted, the format is auto-detected from the broadcast `name` extension (`.hang` or `.msf`), falling back to `"hang"`. `"hangz"` is opt-in only and never auto-detected (it shares the `.hang` suffix).
@@ -242,6 +242,40 @@ broadcast.subscribeTrack("scte35.json", 100, (track, effect) => {
 
 The component exposes everything via its `broadcast` property
 (`el.broadcast.subscribeTrack(...)`).
+
+## Instant playback
+
+`latency-min="0"` still de-jitters: playback is anchored to the first frame, so a
+frame that arrives early waits until its timestamp comes up. That's what keeps
+motion smooth, and it costs at least a frame interval.
+
+`latency="instant"` removes the clock instead of shrinking it. Frames paint the
+moment they decode, so latency drops to whatever the display costs (about half a
+refresh interval on average) and the canvas shows the newest frame at every repaint:
+
+```html
+<moq-watch url="https://relay.moq.dev/anon" name="demo/bbb" latency="instant">
+    <canvas></canvas>
+</moq-watch>
+```
+
+It is a value of `latency`, not a bound, so `latency-min="instant"` is rejected:
+there is no range to sit inside. Assigning `latency-min` or `latency-max` writes a
+range and therefore leaves the mode.
+
+The tradeoff is motion: frames are presented at network cadence rather than at
+their timestamps, so delivery jitter shows up as judder. Reach for it when a fresh
+picture matters more than a smooth one, such as remote control or a camera
+viewfinder, and prefer `latency` otherwise.
+
+This disables audio. The audio ring needs a target depth to avoid underrunning,
+and unsynced video has nothing pulling it back toward the audio clock, so the two
+would drift apart.
+
+The clock itself keeps running: video still reports every frame it receives and
+still resets it on a rewind. Only the wait is skipped. That keeps anything else
+reading the clock working, and it means switching back to a paced latency resumes
+from a current reference instead of a stale one.
 
 ## UI Overlay
 

--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -71,7 +71,7 @@ a real bundler (the examples below).
 - `muted`: Mute audio (boolean)
 - `volume`: Audio volume (0 to 1, default: 1)
 - `reload`: Wait for (re)announcement before subscribing (default: true). Ignored when the relay does not support broadcast discovery, which subscribes immediately instead of waiting forever.
-- `latency`: Latency target. `"real-time"` (default) derives it from RTT, or a number sets a fixed jitter buffer in ms. Collapses `latency-min` and `latency-max` to one value (minimize latency). `"instant"` drops the clock entirely, see [instant playback](#instant-playback).
+- `latency`: Latency target. `"real-time"` (default) derives it from RTT, or a number sets a fixed jitter buffer in ms. Collapses `latency-min` and `latency-max` to one value (minimize latency). `"instant"` stops pacing off the clock, see [instant playback](#instant-playback).
 - `latency-min`: Latency floor (the jitter/startup buffer). Same units as `latency`; leaves the ceiling untouched.
 - `latency-max`: Latency ceiling. `"real-time"` (default) minimizes latency; a number caps at that many ms. A ceiling above the floor enables [buffered playback](#buffered-playback): build up a buffer from future-dated frames instead of skipping ahead.
 - `catalog-format`: Catalog format. One of `"hang"`, `"hangz"` (the [DEFLATE-compressed](/concept/layer/hang#compression) `catalog.json.z` track), `"msf"` (see [MSF](/concept/standard/msf)), or `"manual"` (supply the catalog yourself). When omitted, the format is auto-detected from the broadcast `name` extension (`.hang` or `.msf`), falling back to `"hang"`. `"hangz"` is opt-in only and never auto-detected (it shares the `.hang` suffix).
@@ -249,9 +249,10 @@ The component exposes everything via its `broadcast` property
 frame that arrives early waits until its timestamp comes up. That's what keeps
 motion smooth, and it costs at least a frame interval.
 
-`latency="instant"` removes the clock instead of shrinking it. Frames paint the
-moment they decode, so latency drops to whatever the display costs (about half a
-refresh interval on average) and the canvas shows the newest frame at every repaint:
+`latency="instant"` stops pacing off the clock instead of shrinking the buffer.
+Frames paint the moment they decode, so latency drops to whatever the display costs
+(about half a refresh interval on average) and the canvas shows the newest frame at
+every repaint:
 
 ```html
 <moq-watch url="https://relay.moq.dev/anon" name="demo/bbb" latency="instant">

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -11,7 +11,7 @@ import * as Moq from "@moq/net";
 import { Effect, Signal } from "@moq/signals";
 import * as Audio from "./audio";
 import { Broadcast, type CatalogFormat, parseCatalogFormat } from "./broadcast";
-import { type Bound, type Latency, latencyBounds, latencyFromBounds, Sync } from "./sync";
+import { type Bound, type Latency, latencyBounds, latencyFromBounds, type Paced, Sync } from "./sync";
 import * as Video from "./video";
 
 const OBSERVED = [
@@ -111,6 +111,17 @@ export default class MoqWatch extends HTMLElement {
 	#videoEnabled = new Signal(false);
 	#audioEnabled = new Signal(false);
 
+	// Set while this element writes the `latency` attribute itself, so attributeChangedCallback
+	// ignores the echo. Dropping a stale value would otherwise parse back as "real-time" and
+	// clobber the range that replaced it.
+	#reflectingLatency = false;
+
+	// Whether video paces off the clock, cleared while the latency is "instant".
+	#videoPaced = new Signal(true);
+
+	// The latency handed to Sync, which has no way to express "instant".
+	#syncLatency = new Signal<Paced>("real-time");
+
 	// Set when the element is connected to the DOM.
 	#enabled = new Signal(false);
 
@@ -162,15 +173,32 @@ export default class MoqWatch extends HTMLElement {
 
 		// Sources produce the per-rendition jitter that Sync reads, so they're created
 		// before Sync to avoid a construction cycle.
+		//
+		// Sync can't implement "instant" on its own: not pacing video and disabling audio happens
+		// here. Hand it a zero buffer instead.
+		this.signals.run((effect) => {
+			const latency = effect.get(this.controls.latency);
+			this.#syncLatency.set(latency === "instant" ? Moq.Time.Milli.zero : latency);
+		});
+
 		this.sync = new Sync({
-			latency: this.controls.latency,
+			latency: this.#syncLatency,
 			connection: this.connection.established,
 			video: videoSource.out.jitter,
 			audio: audioSource.out.jitter,
 		});
 		this.signals.cleanup(() => this.sync.close());
 
-		this.video = new Video.Decoder(videoSource, this.sync, { enabled: this.#videoEnabled });
+		// `latency="instant"` stops video waiting on the clock, so frames paint the moment they
+		// decode. The clock stays wired: it still tracks receipts and rewinds.
+		this.signals.run((effect) => {
+			this.#videoPaced.set(effect.get(this.controls.latency) !== "instant");
+		});
+
+		this.video = new Video.Decoder(videoSource, this.sync, {
+			enabled: this.#videoEnabled,
+			paced: this.#videoPaced,
+		});
 		this.audio = new Audio.Decoder(audioSource, this.sync, { enabled: this.#audioEnabled });
 		this.signals.cleanup(() => {
 			this.video.close();
@@ -191,8 +219,21 @@ export default class MoqWatch extends HTMLElement {
 			this.renderer.close();
 		});
 
-		// Audio download follows the emitter's enable policy (paused/muted).
-		this.signals.proxy(this.#audioEnabled, this.emitter.out.enabled);
+		// Audio download follows the emitter's enable policy (paused/muted), except an instant
+		// latency turns it off outright: the ring needs a target depth to avoid underrunning, and
+		// unpaced video has nothing pulling it back toward the audio clock.
+		this.signals.run((effect) => {
+			const enabled = effect.get(this.emitter.out.enabled);
+			this.#audioEnabled.set(enabled && effect.get(this.controls.latency) !== "instant");
+		});
+
+		// Stopping the download leaves the ring holding a floor's worth of PCM, and the emitter
+		// stays connected to drain it. Flush on the way in so audio stops now instead of playing
+		// against video that just jumped to the live edge.
+		this.signals.run((effect) => {
+			if (effect.get(this.controls.latency) !== "instant") return;
+			this.audio.reset();
+		});
 
 		// Video downloads while playing and on-screen. When paused, keep downloading only
 		// until a frame is on the canvas, then stop: a cold paused start still shows a poster
@@ -290,16 +331,27 @@ export default class MoqWatch extends HTMLElement {
 		});
 
 		this.signals.run((effect) => {
-			const { min, max } = latencyBounds(effect.get(this.controls.latency));
+			const latency = effect.get(this.controls.latency);
+			if (latency === "instant") {
+				this.#reflectLatency("instant");
+				return;
+			}
+
+			const { min, max } = latencyBounds(latency);
 			// Only reflect the collapsed `latency` sugar attribute when the range is actually
 			// collapsed. An open range is expressed via latency-min/latency-max, and writing
 			// `latency` here would round-trip back through attributeChangedCallback and collapse it.
-			if (min !== max) return;
+			if (min !== max) {
+				// Still drop a stale "instant": leaving it would advertise a mode the element is no
+				// longer in, and a clone would come back up in it.
+				if (this.getAttribute("latency") === "instant") this.#reflectLatency(undefined);
+				return;
+			}
 			if (min === "real-time") {
-				this.setAttribute("latency", "real-time");
+				this.#reflectLatency("real-time");
 			} else {
 				const jitter = Math.floor(effect.get(this.sync.out.jitter));
-				this.setAttribute("latency", jitter.toString());
+				this.#reflectLatency(jitter.toString());
 			}
 		});
 
@@ -345,8 +397,30 @@ export default class MoqWatch extends HTMLElement {
 	// Parse a single latency bound: absent or "real-time" is adaptive, otherwise a fixed ms value.
 	#parseBound(value: string | null): Bound {
 		if (!value || value === "real-time") return "real-time";
+		if (value === "instant") {
+			console.warn('moq-watch: "instant" is not a bound, use latency="instant"');
+			return "real-time";
+		}
 		const parsed = Number.parseFloat(value);
 		return Moq.Time.Milli(Number.isFinite(parsed) ? parsed : 100);
+	}
+
+	// Write the `latency` attribute (undefined removes it) without the echo coming back through
+	// attributeChangedCallback. Custom element reactions run before setAttribute/removeAttribute
+	// returns, so the flag still covers the callback.
+	#reflectLatency(value: string | undefined): void {
+		this.#reflectingLatency = true;
+		try {
+			if (value === undefined) this.removeAttribute("latency");
+			else this.setAttribute("latency", value);
+		} finally {
+			this.#reflectingLatency = false;
+		}
+	}
+
+	// Parse the `latency` attribute, which also accepts the range-replacing "instant".
+	#parseLatency(value: string | null): Latency {
+		return value?.trim() === "instant" ? "instant" : this.#parseBound(value);
 	}
 
 	attributeChangedCallback(name: Observed, oldValue: string | null, newValue: string | null) {
@@ -371,7 +445,7 @@ export default class MoqWatch extends HTMLElement {
 			this.#reload.set(parseBoolean(newValue, true));
 		} else if (name === "latency") {
 			// Sugar: collapse the floor and ceiling to a single value.
-			this.latency = this.#parseBound(newValue);
+			if (!this.#reflectingLatency) this.latency = this.#parseLatency(newValue);
 		} else if (name === "latency-min") {
 			this.latencyMin = this.#parseBound(newValue);
 		} else if (name === "latency-max") {
@@ -446,6 +520,9 @@ export default class MoqWatch extends HTMLElement {
 	/**
 	 * The latency target. Assign a scalar (or `"real-time"`) to minimize latency, or an object
 	 * `{ min, max }` to open a range and buffer future-dated frames. See {@link Latency}.
+	 *
+	 * `"instant"` drops the clock instead: video paints the moment it decodes and audio is
+	 * disabled. Assigning `latencyMin` or `latencyMax` leaves that mode, since both write a range.
 	 */
 	get latency(): Latency {
 		return this.controls.latency.peek();

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -15,8 +15,8 @@ export type Bound = "real-time" | Time.Milli;
  *
  * `"instant"` drops the clock instead of bounding it: video paints the moment it decodes and
  * audio is disabled. It replaces the range rather than sitting inside it, so it is not a
- * {@link Bound} and cannot be used as a floor or ceiling. Detaching video and disabling audio is
- * the owner's job, so {@link Sync} takes the narrower {@link Paced} and never sees it.
+ * {@link Bound} and cannot be used as a floor or ceiling. Not pacing video and disabling audio is
+ * the owner's job, so a {@link Sync} handed this value resolves it to a zero buffer and no more.
  */
 export type Latency = "instant" | Paced;
 

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -12,19 +12,31 @@ export type Bound = "real-time" | Time.Milli;
  * frames (e.g. a TTS response with future timestamps) build up instead of being skipped. Both
  * bounds default to `"real-time"` when omitted. The ceiling is always finite (no uncapped buffering),
  * so worst case the audio ring drops its oldest samples rather than exhausting memory.
+ *
+ * `"instant"` drops the clock instead of bounding it: video paints the moment it decodes and
+ * audio is disabled. It replaces the range rather than sitting inside it, so it is not a
+ * {@link Bound} and cannot be used as a floor or ceiling. Detaching video and disabling audio is
+ * the owner's job, so {@link Sync} takes the narrower {@link Paced} and never sees it.
  */
-export type Latency = Bound | { min?: Bound; max?: Bound };
+export type Latency = "instant" | Paced;
 
-/** Resolve a {@link Latency} into explicit floor/ceiling bounds (a scalar collapses to `min == max`). */
+/** A latency target the playback clock can pace off on its own: every {@link Latency} but `"instant"`. */
+export type Paced = Bound | { min?: Bound; max?: Bound };
+
+/**
+ * Resolve a {@link Latency} into explicit floor/ceiling bounds (a scalar collapses to `min == max`).
+ * `"instant"` holds nothing, so both bounds are zero.
+ */
 export function latencyBounds(latency: Latency): { min: Bound; max: Bound } {
+	if (latency === "instant") return { min: Time.Milli.zero, max: Time.Milli.zero };
 	if (latency === "real-time" || typeof latency === "number") {
 		return { min: latency, max: latency };
 	}
 	return { min: latency.min ?? "real-time", max: latency.max ?? "real-time" };
 }
 
-/** Build a {@link Latency} from explicit bounds, collapsing to a scalar when they're equal. */
-export function latencyFromBounds(min: Bound, max: Bound): Latency {
+/** Build a {@link Paced} latency from explicit bounds, collapsing to a scalar when they're equal. */
+export function latencyFromBounds(min: Bound, max: Bound): Paced {
 	return min === max ? min : { min, max };
 }
 
@@ -32,14 +44,21 @@ const MIN_JITTER = Time.Milli(20);
 const FALLBACK_JITTER = Time.Milli(100);
 
 export type SyncInput = {
-	// Latency target: a scalar minimizes (collapsed range), an object opens a range. See {@link Latency}.
+	/**
+	 * Latency target: a scalar minimizes (collapsed range), an object opens a range. See {@link Paced}.
+	 *
+	 * A clock cannot implement `"instant"` on its own, since not pacing video and disabling audio
+	 * are the owner's job. Pass a {@link Paced} value: `"instant"` resolves to a zero buffer here.
+	 */
 	latency: Getter<Latency>;
 
-	// The connection used for "real-time" jitter: PROBE supplies RTT.
+	/** The connection used for "real-time" jitter: PROBE supplies RTT. */
 	connection: Getter<Moq.Connection.Established | undefined>;
 
-	// Any additional delay required for audio or video (wired from the per-rendition source).
+	/** Any additional delay required for audio (wired from the per-rendition source). */
 	audio: Getter<Time.Milli | undefined>;
+
+	/** Any additional delay required for video (wired from the per-rendition source). */
 	video: Getter<Time.Milli | undefined>;
 };
 

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -321,9 +321,13 @@ class DecoderTrack {
 						return;
 					}
 
-					// A rewind clears the reference under the frames already in flight, and wait()
-					// throws on an unanchored clock. Paint now and let the next received() anchor it.
-					if (this.paced.peek() && this.sync.out.reference.peek() !== undefined) {
+					if (this.paced.peek()) {
+						// `received()` runs at submit, so a frame is anchored by the time it decodes.
+						// Reaching here unanchored means a rewind reset the clock after this frame's
+						// received(), so it predates the current timeline. Drop it: painting it would
+						// set `timestamp` from the old timeline and late-reject the whole rewind.
+						if (this.sync.out.reference.peek() === undefined) return;
+
 						if (this.frame.peek() === undefined) {
 							// Render something while we wait for the sync to catch up.
 							this.frame.set(frame.clone());
@@ -536,15 +540,17 @@ class DecoderTrack {
 	// Sleep until the clock says to paint this frame, waking early if pacing is turned off or the
 	// run is torn down. Returns false when the frame should be dropped.
 	//
-	// Turning pacing off has to cut parked frames loose, otherwise a deep buffer holds them (and
-	// their GPU memory) until deadlines that no longer apply. Dispose the registration once the race
-	// settles: one that outlives the frame retains an entry per decoded frame for as long as the
-	// track lives, which is unbounded during steady playback.
+	// Turning pacing off has to release parked frames, otherwise a deep buffer holds them (and their
+	// GPU memory) until deadlines that no longer apply. They paint rather than drop: a parked frame
+	// is early, not stale, so it is the freshest picture available the moment pacing stops.
+	//
+	// Dispose the registration once the race settles: one that outlives the frame retains an entry
+	// per decoded frame for as long as the track lives, which is unbounded during steady playback.
 	async #park(timestamp: Time.Milli, effect: Effect): Promise<boolean> {
 		let release: Dispose | undefined;
 		try {
 			const released = new Promise<boolean>((resolve) => {
-				release = this.paced.changed(() => resolve(false));
+				release = this.paced.changed(() => resolve(!this.paced.peek()));
 			});
 			const wait = this.sync.wait(timestamp).then(() => true);
 			return (await Promise.race([wait, released, effect.cancel])) ?? false;

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -5,6 +5,7 @@ import type * as Moq from "@moq/net";
 import { Time } from "@moq/net";
 import {
 	type Computed,
+	type Dispose,
 	Effect,
 	type Getter,
 	getter,
@@ -31,8 +32,18 @@ import type { Source } from "./source";
 const BUFFERING = Time.Milli(500);
 
 export type DecoderInput = {
-	// Whether to download the video track. Wired from the renderer's output by the parent.
+	/** Whether to download the video track. Wired from the renderer's output by the parent. */
 	enabled: Getter<boolean>;
+
+	/**
+	 * Whether to pace playback off the clock, holding each decoded frame until its presentation
+	 * time. Defaults to true.
+	 *
+	 * False paints on decode instead, trading smooth motion for the lowest latency the display can
+	 * offer. The clock stays wired either way and keeps tracking receipts and rewinds, so anything
+	 * else reading it (captions, the UI) still works and re-enabling this resumes cleanly.
+	 */
+	paced: Getter<boolean>;
 };
 
 /** Cumulative video statistics since the decoder started. */
@@ -94,6 +105,7 @@ export class Decoder {
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
 		this.in = {
 			enabled: getter(props?.enabled ?? false),
+			paced: getter(props?.paced ?? true),
 		};
 
 		this.source = source;
@@ -138,6 +150,7 @@ export class Decoder {
 		// Start a new pending effect.
 		let pending: DecoderTrack | undefined = new DecoderTrack({
 			sync: this.sync,
+			paced: this.in.paced,
 			broadcast: active,
 			track,
 			config: identity.decoder,
@@ -240,6 +253,7 @@ export class Decoder {
 
 interface DecoderTrackProps {
 	sync: Sync;
+	paced: Getter<boolean>;
 	broadcast: Moq.Broadcast.Consumer;
 	track: string;
 	config: DecoderConfig;
@@ -249,6 +263,7 @@ interface DecoderTrackProps {
 
 class DecoderTrack {
 	sync: Sync;
+	paced: Getter<boolean>;
 	broadcast: Moq.Broadcast.Consumer;
 	track: string;
 	config: DecoderConfig;
@@ -263,6 +278,10 @@ class DecoderTrack {
 	// Decoded frames waiting to be rendered.
 	#buffered = new Signal<Container.BufferedRanges>([]);
 
+	// The container's reorder/skip budget, mirroring the sync buffer. Zero when unpaced,
+	// matching the consumer's own default: don't wait, skip to the live edge.
+	#latency = new Signal<Time.Milli>(Time.Milli.zero);
+
 	// The last discontinuity count seen from the container consumer; doubles as a generation
 	// so in-flight decodes from before a rewind can be dropped on output.
 	#discontinuity = 0;
@@ -271,10 +290,16 @@ class DecoderTrack {
 
 	constructor(props: DecoderTrackProps) {
 		this.sync = props.sync;
+		this.paced = props.paced;
 		this.broadcast = props.broadcast;
 		this.track = props.track;
 		this.config = props.config;
 		this.stats = props.stats;
+
+		this.#signals.run((effect) => {
+			const paced = effect.get(this.paced);
+			this.#latency.set(paced ? effect.get(this.sync.out.buffer) : Time.Milli.zero);
+		});
 
 		this.#signals.run(this.#run.bind(this));
 	}
@@ -296,20 +321,22 @@ class DecoderTrack {
 						return;
 					}
 
-					if (this.frame.peek() === undefined) {
-						// Render something while we wait for the sync to catch up.
-						this.frame.set(frame.clone());
-					}
+					// A rewind clears the reference under the frames already in flight, and wait()
+					// throws on an unanchored clock. Paint now and let the next received() anchor it.
+					if (this.paced.peek() && this.sync.out.reference.peek() !== undefined) {
+						if (this.frame.peek() === undefined) {
+							// Render something while we wait for the sync to catch up.
+							this.frame.set(frame.clone());
+						}
 
-					const wait = this.sync.wait(timestamp).then(() => true);
-					const ok = await Promise.race([wait, effect.cancel]);
-					if (!ok) return;
-					if (generation !== this.#discontinuity) return; // a rewind happened while waiting
+						if (!(await this.#park(timestamp, effect))) return;
+						if (generation !== this.#discontinuity) return; // a rewind happened while waiting
 
-					if (timestamp < (this.timestamp.peek() ?? 0)) {
-						// Late frame, don't render it.
-						// NOTE: This can happen when the ref is updated, such as on playback start.
-						return;
+						if (timestamp < (this.timestamp.peek() ?? 0)) {
+							// Late frame, don't render it.
+							// NOTE: This can happen when the ref is updated, such as on playback start.
+							return;
+						}
 					}
 
 					this.timestamp.set(timestamp);
@@ -349,7 +376,7 @@ class DecoderTrack {
 		// Create consumer that reorders groups/frames up to the provided latency.
 		const consumer = new Container.Consumer(sub, {
 			format,
-			latency: this.sync.out.buffer,
+			latency: this.#latency,
 		});
 		effect.cleanup(() => consumer.close());
 
@@ -425,7 +452,7 @@ class DecoderTrack {
 
 		const consumer = new Container.Consumer(sub, {
 			format: new Container.Cmaf.Format(init),
-			latency: this.sync.out.buffer,
+			latency: this.#latency,
 		});
 		effect.cleanup(() => consumer.close());
 
@@ -504,6 +531,26 @@ class DecoderTrack {
 		this.#buffered.set([]);
 		this.sync.reset();
 		return true;
+	}
+
+	// Sleep until the clock says to paint this frame, waking early if pacing is turned off or the
+	// run is torn down. Returns false when the frame should be dropped.
+	//
+	// Turning pacing off has to cut parked frames loose, otherwise a deep buffer holds them (and
+	// their GPU memory) until deadlines that no longer apply. Dispose the registration once the race
+	// settles: one that outlives the frame retains an entry per decoded frame for as long as the
+	// track lives, which is unbounded during steady playback.
+	async #park(timestamp: Time.Milli, effect: Effect): Promise<boolean> {
+		let release: Dispose | undefined;
+		try {
+			const released = new Promise<boolean>((resolve) => {
+				release = this.paced.changed(() => resolve(false));
+			});
+			const wait = this.sync.wait(timestamp).then(() => true);
+			return (await Promise.race([wait, released, effect.cancel])) ?? false;
+		} finally {
+			release?.();
+		}
 	}
 
 	// Add a range to the decode buffer (decoded, waiting to render)


### PR DESCRIPTION
## What

Adds `latency="instant"` to `<moq-watch>`: video paints each frame the moment it decodes, with no jitter buffer.

## Why

`latency-min="0"` collapses the jitter buffer but still de-jitters. `Sync` anchors playback on the first frame and only ever ratchets the reference down, so a frame that arrives *early* still sleeps until its timestamp comes up (`sleep = currentRef - ref + floor`). That is what keeps motion smooth, and it costs at least a frame interval.

Some callers want the opposite trade: a fresh picture over a smooth one. Remote control and camera viewfinders are the motivating cases. Today they have to fork `Video.Renderer` and hand-tune `latency` to approximate it, and they still can't get rid of the anchor.

## API shape

```ts
export type Bound   = "real-time" | Time.Milli;
export type Paced   = Bound | { min?: Bound; max?: Bound };   // new
export type Latency = "instant" | Paced;                      // gained a variant
```

`"instant"` sits on `Latency`, never on `Bound`. It replaces the range rather than sitting inside one, so `latency-min="instant"` and `{ min: "instant" }` don't typecheck. Expressing it as a separate boolean attribute would have allowed `latency-min="100" unbuffered`, which is self-contradictory.

Assigning `latencyMin`/`latencyMax` writes a range and therefore leaves the mode.

## What changed

**`Video.Decoder`** gains a `paced` input (default true): whether to hold each decoded frame until its presentation time. The clock stays wired either way, because `received()` and `reset()` *report* rather than gate. Only the wait is conditional, so anything else reading the clock keeps working and a rewind still resets the reference for whenever pacing comes back. Reading it through a getter means toggling doesn't tear down the `VideoDecoder` and stall on the next keyframe.

Unpaced, the reorder/skip budget falls back to `Time.Milli.zero`, which is `Container.Consumer`'s own default: take the live edge. The out-of-order guard and `#trimBuffered` stay outside the branch, so reordering safety is unchanged.

It is `paced` rather than `buffered` because `Decoder.out.buffered` is already the decoded/network ranges.

**Audio is disabled in the mode**, and the ring is flushed on entry. It sizes itself from the sync buffer and underruns without a target depth, and unpaced video has nothing pulling it back toward the audio clock. Clearing `#audioEnabled` alone only stops the download: the ring keeps its PCM and the emitter stays connected to drain it, so without the flush audio played on for up to a floor against video that had just jumped to the live edge.

**The renderer is unchanged.** Painting the newest frame per `rAF` is already correct here. Queueing frames to pace them at the display refresh rate only differs when two frames land in one refresh interval, and there it trades a dropped frame for a delayed one. That's a real win at 60fps-on-60Hz and actively wrong at 120fps-on-60Hz, so it doesn't belong in the default path.

## Races around pacing

Both found by Codex review, both real:

- Frames parked in `sync.wait()` only observed `effect.cancel`, which doesn't fire because the track stays active. Turning pacing off therefore took effect only once the backlog reached deadlines that no longer applied, holding every queued frame and its GPU memory until then. The park now races a change to the `paced` input, through a registration that is disposed once the race settles (a `Promise.race` on a long-lived promise retains a reaction per decoded frame otherwise).
- `wait()` throws on an unanchored clock, which rejects the async output callback and drops the frame. It now waits only on an anchored clock and paints otherwise. **This path is reachable on `main` today without the feature involved:** `#onDiscontinuity` calls `sync.reset()`, clearing the reference under frames already in flight, and their `wait()` runs before the generation check. So this PR fixes a latent bug it didn't introduce, which is worth a reviewer's eye.

Also: entering the mode and then assigning `latencyMin` left a stale `latency="instant"` attribute in the DOM, so a clone came back up in a mode the element had left. Removing it has to skip its own echo, since `attributeChangedCallback` parses an absent value as `"real-time"` and would clobber the range that triggered the removal.

## Reviewer notes

- **This targets `main`.** The exported surface delta is additive: `Latency` gains a variant, `Paced` is new, and `latencyFromBounds`'s return type narrows to a subtype. Nothing is removed or signature-changed.
- **One follow-up is deliberately held back for `dev`.** `SyncInput.latency` should narrow from `Latency` to `Paced`, since a clock has no way to honor `"instant"` on its own (not pacing video and disabling audio happen in the element). Narrowing an input is a semver break, and it can't be based on anything until this lands and `main` merges into `dev`. Filed as an issue. For now `Sync` documents the restriction and resolves `"instant"` to a zero buffer.
- **No new test.** `DecoderTrack` needs a real WebCodecs `VideoDecoder`, which bun's test environment doesn't provide, and there's no DOM harness for `element.ts`. So neither the unpaced decode path nor the audio-disable policy has automated coverage. `just check` and `just test` both pass, but that is regression cover only.
- **Known wart:** with `controls` set, the UI overlay still shows a latency slider that no longer moves video (`ui/components/buffer-control.ts`) and reports a buffer video isn't honoring (`ui/components/latency.ts`). Left alone because hide-versus-relabel is a design call.

(Written by claude-opus-5)