### PR TITLE
refactor(watch)!: narrow Sync's latency input to Paced

### DIFF
--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -74,7 +74,7 @@ export class Game {
 	// Reactive state exposed to UI.
 	readonly hovered = new Moq.Signals.Signal(false);
 	readonly active = new Moq.Signals.Signal(false);
-	readonly latency = new Moq.Signals.Signal<Watch.Latency>("real-time");
+	readonly latency = new Moq.Signals.Signal<Watch.Paced>("real-time");
 	readonly userMuted = new Moq.Signals.Signal(false);
 	readonly volume = new Moq.Signals.Signal(0.25);
 	readonly status = new Moq.Signals.Signal<GameStatus | undefined>(undefined);

--- a/js/watch/src/sync.test.ts
+++ b/js/watch/src/sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Time } from "@moq/net";
 import { Signal } from "@moq/signals";
-import { type Latency, Sync } from "./sync";
+import { type Paced, Sync } from "./sync";
 
 // Effects in @moq/signals flush on a microtask, so let pending updates drain before asserting.
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -39,7 +39,7 @@ describe("latency range", () => {
 	});
 
 	it("reacts to a ceiling set after construction", async () => {
-		const latency = new Signal<Latency>("real-time");
+		const latency = new Signal<Paced>("real-time");
 		const sync = new Sync({ latency });
 		await flush();
 		expect(sync.out.buffered.peek()).toBe(false);

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -16,7 +16,7 @@ export type Bound = "real-time" | Time.Milli;
  * `"instant"` drops the clock instead of bounding it: video paints the moment it decodes and
  * audio is disabled. It replaces the range rather than sitting inside it, so it is not a
  * {@link Bound} and cannot be used as a floor or ceiling. Not pacing video and disabling audio is
- * the owner's job, so a {@link Sync} handed this value resolves it to a zero buffer and no more.
+ * the owner's job, so {@link Sync} takes the narrower {@link Paced} and never sees it.
  */
 export type Latency = "instant" | Paced;
 
@@ -47,10 +47,10 @@ export type SyncInput = {
 	/**
 	 * Latency target: a scalar minimizes (collapsed range), an object opens a range. See {@link Paced}.
 	 *
-	 * A clock cannot implement `"instant"` on its own, since not pacing video and disabling audio
-	 * are the owner's job. Pass a {@link Paced} value: `"instant"` resolves to a zero buffer here.
+	 * `"instant"` is deliberately absent from this type. Honoring it means not pacing video and
+	 * disabling audio, which only the owner can do, so a clock is never handed one.
 	 */
-	latency: Getter<Latency>;
+	latency: Getter<Paced>;
 
 	/**
 	 * The connection's PROBE estimates, whose RTT drives "real-time" jitter. Usually wired
@@ -118,7 +118,7 @@ export class Sync {
 
 	constructor(props?: Inputs<SyncInput>) {
 		this.in = {
-			latency: getter(props?.latency ?? ("real-time" as Latency)),
+			latency: getter(props?.latency ?? ("real-time" as Paced)),
 			probe: getter(props?.probe),
 			audio: getter(props?.audio),
 			video: getter(props?.video),


### PR DESCRIPTION
Closes #3052. Follow-up to #3048, which added `latency="instant"` and deliberately left this out because it targeted `main`.

## Why

`Sync` accepted the full `Latency` union, including `"instant"`, but has no way to honor it. Not pacing video and disabling audio both happen in `MoqWatch`, so this compiled and did nothing of the sort:

```ts
const sync = new Sync({ latency: "instant" });
new Video.Decoder(source, sync, { enabled });
```

The clock still paced video, and an independently wired audio decoder stayed enabled. `latencyBounds` resolved `"instant"` to zero bounds, so it degraded to a zero jitter buffer rather than breaking, but that isn't the mode that was asked for. The restriction was documented in a comment; now it's in the type.

## What changed

```diff
-	latency: Getter<Latency>;
+	latency: Getter<Paced>;
```

plus the matching constructor default cast, and the `Latency` doc comment restored to the accurate "`Sync` takes the narrower `Paced` and never sees it".

`Paced` was already exported by `js/watch/src/sync.ts`, so the type side is a three-line change.

## Call sites

Narrowing an input rejects callers passing a `Signal<Latency>`. Both in-tree ones were over-wide in the same way:

- `js/moq-boy/src/game.ts` — its public `latency` knob was typed `Watch.Latency`, so a caller could set `"instant"` and get nothing. Same bug, one layer out.
- `js/watch/src/sync.test.ts` — same annotation.

## Reviewer notes

- **Targets `dev`**: narrowing an input is a semver break in a published package.
- `moq-boy`'s knob narrows too. It's an app rather than a library, and the alternative is leaving it advertising a mode it can't perform.
- `just fix`, `just check`, and `just test` all pass.

(Written by claude-opus-5)