### PR TITLE
fix(net): count reads as cache accesses for eviction and expiry

### DIFF
--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -374,8 +374,9 @@ impl Charge {
 
 	/// Record a write that charges no new bytes (a chunk written into an
 	/// already-charged in-flight frame): restarts the retention clock like any
-	/// other write.
-	pub(crate) fn record_write(&self) {
+	/// other write. `&mut self` deliberately: reaching it through a kio write
+	/// guard marks the guard modified, so its release wakes parked readers.
+	pub(crate) fn record_write(&mut self) {
 		self.touch(WRITE_BOOST);
 	}
 

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -372,6 +372,13 @@ impl Charge {
 		self.touch(READ_BOOST);
 	}
 
+	/// Record a write that charges no new bytes (a chunk written into an
+	/// already-charged in-flight frame): restarts the retention clock like any
+	/// other write.
+	pub(crate) fn record_write(&self) {
+		self.touch(WRITE_BOOST);
+	}
+
 	/// Advance the last-access tick to `boost` ticks past the coarse clock.
 	///
 	/// The boost breaks ties within one coarse tick: written content outranks

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -11,8 +11,9 @@
 //!
 //! Cross-track ordering comes from one statistic: the mean last-access time of the
 //! evictable population (every cached group except each track's protected latest).
-//! A group accessed more recently than that mean is never evicted, so a fresh fetch
-//! in one track can't die while another track holds staler content, and a track
+//! A group accessed more recently than that mean is never evicted, so freshly read
+//! or fetched content in one track can't die while another track holds staler
+//! content, and a track
 //! whose oldest group is staler than the mean accrues debt at double rate. Evicting
 //! old entries and inserting new ones both advance the mean, so the eviction
 //! frontier moves with cache turnover on its own.
@@ -37,8 +38,8 @@ use super::track::TrackState;
 const ENTRY_OVERHEAD: u64 = 256;
 
 /// Sub-tick boosts applied to the last-access stamp, breaking ties within one
-/// coarse tick: a frame write outranks merely-inserted content, and an explicit
-/// read (FETCH hit or backfill birth) outranks both.
+/// coarse tick: a frame write outranks merely-inserted content, and a read (a
+/// delivered or fetched group, a frame read, a backfill's birth) outranks both.
 const WRITE_BOOST: u64 = 1;
 const READ_BOOST: u64 = 2;
 
@@ -263,7 +264,7 @@ impl Track {
 		Charge {
 			track: Some(self.clone()),
 			bytes: ENTRY_OVERHEAD,
-			last,
+			last: AtomicU64::new(last),
 			counted: false,
 		}
 	}
@@ -306,9 +307,13 @@ pub(crate) struct Charge {
 	track: Option<Arc<Track>>,
 	// Bytes currently charged, including ENTRY_OVERHEAD, released on drop.
 	bytes: u64,
-	// Tick of the last cache access: creation, a FETCH hit, or a fetched backfill's
-	// birth. Eviction protection and age expiry key off this.
-	last: u64,
+	// Tick of the last cache access: creation, every write, and every read (group
+	// delivery, frame reads, FETCH hits, a fetched backfill's birth). Eviction
+	// protection and age expiry key off this. Atomic so the read paths can stamp
+	// it through a shared guard: a kio write guard's release notifies every parked
+	// consumer, which a mere access must not do. Accesses are still serialized by
+	// the owning state's lock, so `counted` can pair with it as a plain bool.
+	last: AtomicU64,
 	// Whether `last` is currently a sample in the pool's access mean, i.e. the
 	// group is in the evictable population.
 	counted: bool,
@@ -345,7 +350,7 @@ impl Charge {
 
 	/// Tick of the group's last cache access.
 	pub(crate) fn accessed(&self) -> u64 {
-		self.last
+		self.last.load(Ordering::Relaxed)
 	}
 
 	/// Enter the group into the evictable population (demoted from the live edge,
@@ -355,13 +360,15 @@ impl Charge {
 		if let Some(track) = &self.track
 			&& !self.counted
 		{
-			track.pool.access_insert(self.last);
+			track.pool.access_insert(self.accessed());
 			self.counted = true;
 		}
 	}
 
-	/// Record a cache read (a FETCH hit, or a fetched backfill's birth).
-	pub(crate) fn refresh(&mut self) {
+	/// Record a cache read: a delivered or fetched group, a frame read, or a
+	/// fetched backfill's birth. `&self` so the read paths can stamp through a
+	/// shared guard without waking parked consumers.
+	pub(crate) fn refresh(&self) {
 		self.touch(READ_BOOST);
 	}
 
@@ -372,16 +379,18 @@ impl Charge {
 	/// same-tick access still reads as strictly newer than the population mean of
 	/// weaker accesses. Idempotent within a tick (monotone, never regressing), so
 	/// repeated accesses can't run ahead of the clock by more than the boost.
-	fn touch(&mut self, boost: u64) {
+	fn touch(&self, boost: u64) {
 		let Some(track) = &self.track else { return };
 		let target = track.pool.now().saturating_add(boost);
-		if target <= self.last {
+		// `fetch_max` keeps the stamp monotone, and its prior value makes the
+		// paired mean update exact even for back-to-back accesses.
+		let prev = self.last.fetch_max(target, Ordering::Relaxed);
+		if target <= prev {
 			return;
 		}
 		if self.counted {
-			track.pool.access_refresh(self.last, target);
+			track.pool.access_refresh(prev, target);
 		}
-		self.last = target;
 	}
 
 	/// Release everything this charge holds: bytes, overhead, and the access
@@ -391,7 +400,7 @@ impl Charge {
 			track.pool.sub(self.bytes);
 			self.bytes = 0;
 			if self.counted {
-				track.pool.access_remove(self.last);
+				track.pool.access_remove(self.accessed());
 				self.counted = false;
 			}
 		}
@@ -523,6 +532,19 @@ mod test {
 		c.clear();
 		assert_eq!(pool.average(), None, "aborted groups leave no ghost sample");
 		drop(c);
+		assert_eq!(pool.average(), None);
+	}
+
+	#[test]
+	fn refresh_updates_a_counted_sample() {
+		let pool = Pool::new(1000);
+		let mut c = charge(&pool);
+		c.demote();
+		c.refresh();
+		// The sample in the pool mean moved with the stamp, so releasing the charge
+		// removes exactly what was inserted and leaves no residue.
+		assert_eq!(pool.average(), Some(c.accessed()));
+		c.clear();
 		assert_eq!(pool.average(), None);
 	}
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -416,11 +416,13 @@ impl Producer {
 
 	/// Wake consumers parked on the group channel (called after a partial write).
 	pub(crate) fn frame_notify(&self) {
-		// Taking the write lock and dropping it triggers kio's notify. The chunk
-		// that was just written is also a write access: restart the retention
+		// The chunk that was just written is a write access: restart the retention
 		// clock so a straggler group streaming a large frame isn't expired
 		// mid-write (its bytes were already charged when the frame was created).
-		if let Ok(state) = self.state.write() {
+		// `record_write` takes `&mut`, which marks the guard modified: kio only
+		// notifies on a mutably-accessed guard's release, and that notify is what
+		// delivers the chunk to parked readers.
+		if let Ok(mut state) = self.state.write() {
 			state.charge.record_write();
 		}
 	}
@@ -1280,6 +1282,33 @@ mod test {
 		// Take one frame so the batch is filled but only partially drained.
 		let _ = consumer.read_frame().now_or_never().unwrap().unwrap().unwrap();
 		drop(consumer);
+	}
+
+	/// A parked chunk reader is woken by each chunk write. kio only notifies when
+	/// a write guard was mutably accessed, so `frame_notify` must mark the guard
+	/// modified; a guard dropped untouched wakes nobody and the reader would
+	/// stall until the frame completed.
+	#[tokio::test]
+	async fn chunk_write_wakes_parked_reader() {
+		let mut producer = Info { sequence: 0 }.produce();
+		let mut consumer = producer.consume();
+		let mut frame = producer
+			.create_frame(frame::Info {
+				size: 6,
+				timestamp: Timestamp::ZERO,
+			})
+			.unwrap();
+		let mut f = consumer.next_frame().await.unwrap().unwrap();
+		let handle = tokio::spawn(async move { f.read_chunk().await });
+		// Let the reader park on the empty partial before the chunk lands.
+		tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+		frame.write(Bytes::from_static(b"foo")).unwrap();
+		let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+			.await
+			.expect("parked chunk reader was never woken by the chunk write")
+			.unwrap()
+			.unwrap();
+		assert_eq!(chunk, Some(Bytes::from_static(b"foo")));
 	}
 
 	/// A frame whose timestamp is at a different scale is converted to the group's

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -122,6 +122,9 @@ impl GroupState {
 		}
 		let local = index - self.offset;
 		if let Some(f) = self.frames.get(local) {
+			// A frame read is a cache access: stamp it so expiry and the eviction
+			// walk spare a group a consumer is actively draining.
+			self.charge.refresh();
 			let info = frame::Info {
 				size: f.payload.len() as u64,
 				timestamp: f.timestamp,
@@ -131,6 +134,7 @@ impl GroupState {
 		if local == self.frames.len()
 			&& let Some(p) = &self.partial
 		{
+			self.charge.refresh();
 			let info = frame::Info {
 				size: p.buf.capacity() as u64,
 				timestamp: p.timestamp,
@@ -487,13 +491,13 @@ impl Producer {
 		}
 	}
 
-	/// Record a cache access (a FETCH hit, or a fetched backfill's birth),
-	/// protecting the group from eviction and restarting its expiry clock. A no-op
-	/// once the group is closed.
+	/// Record a cache access (delivery to a subscriber, a FETCH hit, or a fetched
+	/// backfill's birth), protecting the group from eviction and restarting its
+	/// expiry clock. Stamps through a read guard, whose release never notifies, so
+	/// delivery can't wake every consumer parked on the group. Harmless on a
+	/// closed group: its charge is already cleared.
 	pub(crate) fn cache_refresh(&self) {
-		if let Ok(mut state) = self.state.write() {
-			state.charge.refresh();
-		}
+		self.state.read().charge.refresh();
 	}
 
 	/// Create a new consumer for the group.
@@ -761,6 +765,9 @@ impl Consumer {
 			let local = (index - state.offset).min(state.frames.len());
 			prefetch.fill(state.frames.range(local..).cloned());
 			if prefetch.len > 0 {
+				// One stamp covers the whole batch: frames popped from the prefetch
+				// don't re-stamp until the next refill, which `CAP` bounds.
+				state.charge.refresh();
 				return Poll::Ready(Ok(()));
 			}
 			// Nothing completed at `index`: an in-flight tail waits, otherwise resolve

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -508,6 +508,7 @@ impl Producer {
 			track: self.track.clone(),
 			index: 0,
 			prefetch: Prefetch::default(),
+			last_refresh: web_async::time::Instant::now(),
 			// Untagged: a tagged track attaches the egress meter via `with_meter`
 			// when it hands the consumer to a subscriber/fetch.
 			stats: stats::Meter::default(),
@@ -637,6 +638,12 @@ pub struct Consumer {
 	// A batch of completed frames drained ahead under one lock (whole-frame reads only).
 	prefetch: Prefetch,
 
+	// When this consumer last stamped the group's access time. The prefetch bounds
+	// a batch by frame count, not elapsed time, so pops re-stamp on a time bound
+	// (see [`Self::refresh_if_stale`]) or a slow reader could go a full retention
+	// window without an access and be expired mid-read.
+	last_refresh: web_async::time::Instant,
+
 	// Egress payload meter, set by a tagged track via [`Self::with_meter`]. Empty
 	// (no-op) for an untagged group.
 	stats: stats::Meter,
@@ -652,6 +659,7 @@ impl Clone for Consumer {
 			track: self.track.clone(),
 			index: self.index,
 			prefetch: Prefetch::default(),
+			last_refresh: self.last_refresh,
 			// Inherit the meter without re-counting the group: the original already
 			// counted it when the track handed it out.
 			stats: self.stats.clone(),
@@ -694,6 +702,19 @@ impl Consumer {
 		self.track.timescale
 	}
 
+	/// Re-stamp the group's access time from the lock-free prefetch path once half
+	/// the retention window has passed since this consumer last stamped it. The
+	/// batch bounds frames, not elapsed time, so without this a reader pacing
+	/// through a batch could be expired while demonstrably active. Half the window
+	/// keeps the stamp comfortably inside it while staying rare on the hot path.
+	fn refresh_if_stale(&mut self) {
+		if self.last_refresh.elapsed() * 2 < self.track.latency_max {
+			return;
+		}
+		self.state.read().charge.refresh();
+		self.last_refresh = web_async::time::Instant::now();
+	}
+
 	// A helper to automatically apply Dropped if the state is closed without an error.
 	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R>>
 	where
@@ -719,6 +740,7 @@ impl Consumer {
 		// Their bytes were already counted at the batch fill, so the frame::Consumer
 		// carries no meter.
 		if let Some(frame) = self.prefetch.pop() {
+			self.refresh_if_stale();
 			self.index += 1;
 			let info = frame::Info {
 				size: frame.payload.len() as u64,
@@ -746,6 +768,7 @@ impl Consumer {
 	pub fn poll_read_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Frame>>> {
 		// Fast path: serve from the prefetched batch without locking or allocating a waker.
 		if let Some(frame) = self.prefetch.pop() {
+			self.refresh_if_stale();
 			self.index += 1;
 			return Poll::Ready(Ok(Some(frame)));
 		}
@@ -781,6 +804,10 @@ impl Consumer {
 			Err(state) => return Poll::Ready(Err(state.abort.clone().unwrap_or(Error::Dropped))),
 		}
 
+		// The refill stamped the group under its lock; restart the staleness clock
+		// so the pops that follow don't immediately re-stamp.
+		self.last_refresh = web_async::time::Instant::now();
+
 		// A fresh batch was just filled (empty only on a clean end). Count the whole
 		// batch once here, under no lock, so the drained pops that follow stay free.
 		let (frames, bytes) = self.prefetch.buffered();
@@ -796,6 +823,7 @@ impl Consumer {
 	pub async fn read_frame(&mut self) -> Result<Option<frame::Frame>> {
 		// Serve from the prefetched batch without building a future or allocating a waker.
 		if let Some(frame) = self.prefetch.pop() {
+			self.refresh_if_stale();
 			self.index += 1;
 			return Ok(Some(frame));
 		}

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -416,8 +416,13 @@ impl Producer {
 
 	/// Wake consumers parked on the group channel (called after a partial write).
 	pub(crate) fn frame_notify(&self) {
-		// Taking the write lock and dropping it triggers kio's notify.
-		let _ = self.state.write();
+		// Taking the write lock and dropping it triggers kio's notify. The chunk
+		// that was just written is also a write access: restart the retention
+		// clock so a straggler group streaming a large frame isn't expired
+		// mid-write (its bytes were already charged when the frame was created).
+		if let Ok(state) = self.state.write() {
+			state.charge.record_write();
+		}
 	}
 
 	/// Commit the in-flight frame as a completed frame (called by [`frame::Producer::finish`]).
@@ -688,6 +693,12 @@ impl Consumer {
 	/// dropped the cached frames, so a held consumer has nothing left to read.
 	pub(crate) fn is_aborted(&self) -> bool {
 		self.state.read().abort.is_some()
+	}
+
+	/// Record a cache access from the consumer side: a parked group re-offered to
+	/// its subscriber. Same stamp as [`Producer::cache_refresh`].
+	pub(crate) fn cache_refresh(&self) {
+		self.state.read().charge.refresh();
 	}
 
 	/// Park `waiter` until the group closes (finish, abort, or eviction). Spliced

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -950,6 +950,8 @@ impl Subscriber {
 				&& !beyond_cap(sequence)
 			{
 				let group = seg.parked.remove(&sequence).expect("parked key just observed");
+				// A re-offer is a delivery: stamp it like a fresh hand-out.
+				group.cache_refresh();
 				self.next_sequence = self.next_sequence.max(sequence.saturating_add(1));
 				return Poll::Ready(Ok(Some(group)));
 			}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -3127,6 +3127,37 @@ mod test {
 		assert!(!state.lookup.contains_key(&1), "the unread group still expired");
 	}
 
+	/// Whole-frame reads served from the prefetch batch must also keep the group
+	/// alive: the batch is filled (and stamped) once per `Prefetch::CAP` frames,
+	/// which bounds frames, not elapsed time, so a slow `read_frame` reader has to
+	/// re-stamp on a time bound between refills.
+	#[tokio::test]
+	async fn slow_prefetch_reader_survives_expiry() {
+		tokio::time::pause();
+
+		let mut producer = track_producer("test", None);
+		let mut subscriber = producer.subscribe(None);
+
+		let mut group = producer.create_group(0u64.into()).unwrap();
+		for _ in 0..20 {
+			group.write_frame(Timestamp::ZERO, b"x".as_slice()).unwrap();
+		}
+		group.finish().unwrap();
+		let mut reading = subscriber.assert_group();
+
+		// One whole-frame read per half-window: most are served straight from the
+		// prefetch without locking. New groups keep the expiry scan running.
+		for seq in 1..20u64 {
+			tokio::time::advance(DEFAULT_LATENCY_MAX / 2).await;
+			let frame = reading.read_frame().await;
+			assert!(
+				matches!(frame, Ok(Some(_))),
+				"a slow prefetch reader must not expire mid-read (step {seq})"
+			);
+			producer.create_group(seq.into()).unwrap().finish().unwrap();
+		}
+	}
+
 	/// Receiving a group is itself a cache access: a subscriber that takes
 	/// delivery just before the group would age out still gets to read it a full
 	/// window later.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -2249,7 +2249,10 @@ impl PlainSubscriber {
 		if let Some(&sequence) = self.parked.keys().next()
 			&& self.end_sequence.is_none_or(|end| sequence <= end)
 		{
-			return Poll::Ready(Ok(self.parked.remove(&sequence)));
+			let group = self.parked.remove(&sequence).expect("parked key just observed");
+			// A re-offer is a delivery: stamp it like a fresh hand-out.
+			group.cache_refresh();
+			return Poll::Ready(Ok(Some(group)));
 		}
 
 		loop {
@@ -3185,6 +3188,76 @@ mod test {
 
 		let frame = reading.read_frame().await.unwrap();
 		assert!(frame.is_some(), "a just-delivered group must not expire unread");
+	}
+
+	/// Streaming chunks into an in-flight frame is a write access: a straggler
+	/// group (behind the live edge) trickling a large frame across several
+	/// retention windows must not be expired mid-write.
+	#[tokio::test]
+	async fn streaming_frame_writes_keep_the_group_alive() {
+		tokio::time::pause();
+
+		let mut producer = track_producer("test", None);
+		let mut straggler = producer.create_group(0u64.into()).unwrap();
+		// The live edge moves on, so the straggler is demoted and expirable.
+		producer.create_group(1u64.into()).unwrap().finish().unwrap();
+
+		let mut frame = straggler
+			.create_frame(frame::Info {
+				size: 10,
+				timestamp: Timestamp::ZERO,
+			})
+			.unwrap();
+		// One chunk per half-window; the whole frame spans several windows. New
+		// groups keep the expiry scan running.
+		for seq in 2..12u64 {
+			tokio::time::advance(DEFAULT_LATENCY_MAX / 2).await;
+			frame.write(bytes::Bytes::from_static(b"x")).unwrap();
+			producer.create_group(seq.into()).unwrap().finish().unwrap();
+		}
+		frame.finish().unwrap();
+		straggler.finish().unwrap();
+
+		let state = producer.state.read();
+		assert!(
+			state.lookup.contains_key(&0),
+			"a group streaming a frame survives expiry"
+		);
+	}
+
+	/// Re-offering a parked group (once the cap rises) is a delivery: it restarts
+	/// the expiry clock so the subscriber gets to read what it was just handed.
+	#[tokio::test]
+	async fn parked_reoffer_restarts_the_expiry_clock() {
+		tokio::time::pause();
+
+		let mut producer = track_producer("test", None);
+		let mut subscriber = producer.subscribe(None);
+		subscriber.end_at(0);
+
+		for seq in 0..2u64 {
+			let mut group = producer.create_group(seq.into()).unwrap();
+			group.write_frame(Timestamp::ZERO, b"x".as_slice()).unwrap();
+			group.finish().unwrap();
+		}
+
+		// Group 0 is in range; group 1 is beyond the cap and parks.
+		assert_eq!(subscriber.assert_group().sequence, 0);
+		subscriber.assert_no_group();
+
+		// Just inside the window, the cap rises and the re-offer stamps group 1.
+		tokio::time::advance(DEFAULT_LATENCY_MAX - Duration::from_secs(1)).await;
+		subscriber.end_at(1);
+		let mut reading = subscriber.assert_group();
+		assert_eq!(reading.sequence, 1);
+
+		// Almost another full window passes: far beyond the write, inside the
+		// re-offer stamp. The new group runs the expiry scan.
+		tokio::time::advance(DEFAULT_LATENCY_MAX - Duration::from_secs(1)).await;
+		producer.create_group(2u64.into()).unwrap().finish().unwrap();
+
+		let frame = reading.read_frame().await.unwrap();
+		assert!(frame.is_some(), "a just-re-offered group must not expire unread");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -278,6 +278,9 @@ impl TrackState {
 				&& slot.stamp == *stamp
 				&& !slot.group.is_aborted()
 			{
+				// Delivery is a cache access: stamp it so expiry and the eviction
+				// walk don't kill a group a subscriber is about to read.
+				slot.group.cache_refresh();
 				return Poll::Ready(Ok(Some((slot.group.consume(), self.offset + i))));
 			}
 		}
@@ -425,6 +428,8 @@ impl TrackState {
 		}
 
 		if let Some(group) = best {
+			// Delivery is a cache access, same as the arrival-order path.
+			group.cache_refresh();
 			return Poll::Ready(Ok(Some(group.consume())));
 		}
 
@@ -492,9 +497,9 @@ impl TrackState {
 	///
 	/// One bounded, rotating scan over the eviction order, which holds every cached
 	/// group except the protected latest. The cursor persists across calls, so
-	/// entries beyond one scan window can't be starved by fresh (recently fetched
-	/// or written) entries in front of them: every position is revisited within a
-	/// few writes. Expiry throughput is therefore EVICT_SCAN groups per write; the
+	/// entries beyond one scan window can't be starved by fresh (recently read,
+	/// fetched, or written) entries in front of them: every position is revisited
+	/// within a few writes. Expiry throughput is therefore EVICT_SCAN groups per write; the
 	/// byte budget reclaims the remainder under memory pressure.
 	fn evict_expired(&mut self, max_age: Duration) {
 		let now = self.cache.pool().now();
@@ -752,9 +757,9 @@ impl TrackState {
 			}
 
 			scanned += 1;
-			// Protected: accessed more recently than the average (a fresh insert or
-			// a FETCH hit, which also covers a backfill still being filled). Rotate
-			// to the back.
+			// Protected: accessed more recently than the average (a fresh insert,
+			// an active reader, or a FETCH hit, which also covers a backfill still
+			// being filled). Rotate to the back.
 			if slot.group.cache_accessed() > average {
 				self.evict.push_back((sequence, stamp));
 				continue;
@@ -3082,6 +3087,73 @@ mod test {
 		let _next = producer.create_group(group::Info { sequence: 1 }).unwrap();
 
 		assert!(consumer.next_frame().await.unwrap().is_none());
+	}
+
+	/// An actively-read group is not expired out from under its reader: every frame
+	/// read restarts the retention clock. A group nobody reads still ages out on
+	/// schedule, so reclamation stays intact.
+	#[tokio::test]
+	async fn active_reader_survives_expiry() {
+		tokio::time::pause();
+
+		let mut producer = track_producer("test", None);
+		let mut subscriber = producer.subscribe(None);
+
+		// A finished group with one frame per step of the read loop below.
+		let mut group = producer.create_group(0u64.into()).unwrap();
+		for _ in 0..10 {
+			group.write_frame(Timestamp::ZERO, b"x".as_slice()).unwrap();
+		}
+		group.finish().unwrap();
+		let mut reading = subscriber.assert_group();
+
+		// A sibling written at the same time that nobody ever reads.
+		producer.create_group(1u64.into()).unwrap().finish().unwrap();
+
+		// Each step stays well inside the retention window, but the whole read
+		// spans several windows. New groups keep the expiry scan running.
+		for seq in 2..12u64 {
+			tokio::time::advance(DEFAULT_LATENCY_MAX / 2).await;
+			let frame = reading.next_frame().await;
+			assert!(
+				matches!(frame, Ok(Some(_))),
+				"an actively-read group must not expire mid-read (step {seq})"
+			);
+			producer.create_group(seq.into()).unwrap().finish().unwrap();
+		}
+
+		let state = producer.state.read();
+		assert!(state.lookup.contains_key(&0), "the read group survived");
+		assert!(!state.lookup.contains_key(&1), "the unread group still expired");
+	}
+
+	/// Receiving a group is itself a cache access: a subscriber that takes
+	/// delivery just before the group would age out still gets to read it a full
+	/// window later.
+	#[tokio::test]
+	async fn delivery_restarts_the_expiry_clock() {
+		tokio::time::pause();
+
+		let mut producer = track_producer("test", None);
+		let mut subscriber = producer.subscribe(None);
+
+		let mut group = producer.create_group(0u64.into()).unwrap();
+		group.write_frame(Timestamp::ZERO, b"x".as_slice()).unwrap();
+		group.finish().unwrap();
+		// A second group so seq 0 leaves the protected live edge.
+		producer.create_group(1u64.into()).unwrap().finish().unwrap();
+
+		// Deliver just inside the window: the delivery stamps the group.
+		tokio::time::advance(DEFAULT_LATENCY_MAX - Duration::from_secs(1)).await;
+		let mut reading = subscriber.assert_group();
+
+		// Almost another full window passes: far beyond the write, inside the
+		// delivery stamp. The new group runs the expiry scan.
+		tokio::time::advance(DEFAULT_LATENCY_MAX - Duration::from_secs(1)).await;
+		producer.create_group(2u64.into()).unwrap().finish().unwrap();
+
+		let frame = reading.read_frame().await.unwrap();
+		assert!(frame.is_some(), "a just-delivered group must not expire unread");
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Root cause

`Charge::last` (rs/moq-net/src/model/cache.rs) is the tick every eviction decision keys off: `evict_expired(max_age)` aborts a group with `Error::Old` once `now - accessed > max_age`, and `pay_debt` only protects a group whose `accessed` beats the pool-wide mean. But the stamp was bumped by exactly two things: frame writes (`Charge::add`) and the FETCH path (`cache_refresh`, called from `poll_fetch_cached` and `insert_group_request`).

Arrival-order delivery (`recv_group` / `next_group`) and frame reads never touched it. So a group went cold the instant its last write landed: a subscriber slowly reading a finished group was indistinguishable from a group nobody had touched, and expiry/eviction aborted it mid-read even though it was the hottest content in the pool.

## Fix

Stamp the access everywhere content is actually read, so the LRU is honest for both live and fetch:

- **Group delivery**: `TrackState::poll_recv_group` (arrival order) and `poll_next_in_range` (sequence order) refresh the group before handing out the consumer, matching what `poll_fetch_cached` already did.
- **Frame reads**: `GroupState::poll_frame_source` (per `next_frame`) and the `poll_read_frame` refill (once per prefetch batch, so the hot path stays one stamp per lock acquisition).

To make that cheap, `Charge::last` becomes an `AtomicU64` and `refresh`/`touch` take `&self`. kio backs both guards with one mutex, so accesses stay serialized; the atomic exists so **read** guards can stamp. Stamping via a write guard would be wrong twice over: `Mut`'s release notifies every parked waiter, so per-delivery stamping would spuriously wake all consumers of the group. `fetch_max` keeps the stamp monotone and returns the prior value, so the paired `access_refresh` mean update stays exact. As a bonus, `cache_refresh` on the fetch path no longer takes the write lock either.

What happens once a victim *is* chosen is deliberately unchanged: eviction still aborts readers (`eviction_aborts_readers` and `expired_backfill_reclaimed` still pin that contract), so a byte-budgeted cache reclaims deterministically instead of letting a slow reader decide when memory returns. The fix is only that an actively-read group is no longer chosen as the victim.

## Regression tests

Both fail without the fix (verified by disabling `Charge::refresh`) and encode both directions:

- `active_reader_survives_expiry`: a subscriber reading one frame per half-window across several windows keeps its group alive, while an unread sibling written at the same time still ages out (reclamation intact).
- `delivery_restarts_the_expiry_clock`: taking delivery just inside the window buys the reader a fresh window.

Plus `refresh_updates_a_counted_sample` in cache.rs, pinning that refreshing a demoted (counted) group moves its sample in the pool mean so removal leaves no residue.

## Scope notes

- No wire change, so no draft update; this is local cache policy.
- js/net has no byte-budgeted pool (only per-group frame caps), so there is no mirror to update.
- This does **not** fix the moq.pro HLS flake: that segment loop fetches each group immediately before reading it, and the fetch path already stamped. This closes the gap for fetch-less (subscription) readers.

Gates: `cargo clippy --locked --all-targets -p moq-net -- -D warnings`, `cargo fmt --all --check`, `cargo test -p moq-net --lib` (811 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Fable 5)