### PR TITLE
fix(net): track lite announces the peer sent, not the ones we kept

### DIFF
--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -250,7 +250,6 @@ Each broadcast has at most one current advertisement per stream.
 A second ANNOUNCE_START for an already-available path is a protocol violation; an ANNOUNCE_UPDATE atomically replaces the current advertisement (equivalent to ANNOUNCE_END+ANNOUNCE_START) while keeping its id live.
 
 The subscriber MUST close the session with a PROTOCOL_VIOLATION if it receives an ANNOUNCE_END or ANNOUNCE_UPDATE referencing an Announce ID that was never assigned or already retired, an ANNOUNCE_START for a path that is already available, or any announcement before ANNOUNCE_OK.
-Resetting only the stream would leave the peer free to repeat the violation on the next one, and a sender that has lost track of what it advertised has nothing left that the receiver can trust.
 When the stream is closed, the subscriber MUST assume that all broadcasts are now unavailable.
 
 Path prefix matching and equality is done on a byte-by-byte basis.
@@ -1147,6 +1146,7 @@ The `Message Length` describes the payload size on the wire.
 - Added implicit Announce IDs: each ANNOUNCE_START assigns the next per-stream ordinal.
 - ANNOUNCE_END and ANNOUNCE_UPDATE reference the Announce ID instead of repeating the broadcast path.
 - Replaced the duplicate-`active` restart idiom with ANNOUNCE_UPDATE; a second ANNOUNCE_START for an already-available path is now a protocol violation.
+- Made the Announce Stream violations close the session rather than reset the stream: an unknown or retired Announce ID, an ANNOUNCE_START for an already-available path, and any announcement before ANNOUNCE_OK.
 - Added an `Epoch` to ANNOUNCE_START and ANNOUNCE_UPDATE: a per-path content generation minted by the original publisher and forwarded unchanged, 0 meaning unspecified. The highest Epoch wins (non-zero outranks 0) and replacement is decided by value rather than arrival order; equal non-zero Epochs splice, and the first entry of the path remains the identity only when both are 0. That fallback identity requires a non-zero first entry: 0 identifies nothing, so it never proves continuity, and publishers SHOULD assign themselves a Hop ID (a random per-session value suffices).
 - Added an `Ended` flag to ANNOUNCE_START and ANNOUNCE_UPDATE, and as an opt-in filter on ANNOUNCE_REQUEST: ended broadcasts reject SUBSCRIBE, are read via FETCH, and are only announced to subscribers that asked for them.
 - Added an `Epoch` to SUBSCRIBE, FETCH, and TRACK (0 = current, mismatch = reset) and the resolved `Epoch` to TRACK_INFO, so metadata and groups always come from the same generation and requests cannot race a replacement.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -249,7 +249,8 @@ ANNOUNCE_END and ANNOUNCE_UPDATE reference the Announce ID instead of repeating 
 Each broadcast has at most one current advertisement per stream.
 A second ANNOUNCE_START for an already-available path is a protocol violation; an ANNOUNCE_UPDATE atomically replaces the current advertisement (equivalent to ANNOUNCE_END+ANNOUNCE_START) while keeping its id live.
 
-The subscriber MUST reset the stream if it receives an ANNOUNCE_END or ANNOUNCE_UPDATE referencing an Announce ID that was never assigned or already retired, an ANNOUNCE_START for a path that is already available, or any announcement before ANNOUNCE_OK.
+The subscriber MUST close the session with a PROTOCOL_VIOLATION if it receives an ANNOUNCE_END or ANNOUNCE_UPDATE referencing an Announce ID that was never assigned or already retired, an ANNOUNCE_START for a path that is already available, or any announcement before ANNOUNCE_OK.
+Resetting only the stream would leave the peer free to repeat the violation on the next one, and a sender that has lost track of what it advertised has nothing left that the receiver can trust.
 When the stream is closed, the subscriber MUST assume that all broadcasts are now unavailable.
 
 Path prefix matching and equality is done on a byte-by-byte basis.

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -1,6 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import { Signal } from "@moq/signals";
 import type { Probe as ProbeStats } from "../connection/stats.ts";
+import { error, reason } from "../error.ts";
 import { OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Writer } from "../stream.ts";
@@ -40,10 +41,14 @@ test("closing the subscriber suppresses probe stream warnings", async () => {
 // forged announce messages into the stream the subscriber opens.
 function announceHarness(version: Version, origin = 1n) {
 	let inbound!: ReadableStreamDefaultController<Uint8Array>;
+	// Resolves with the reason once the subscriber resets the stream, which is how a peer
+	// learns it violated the protocol. Never resolving is the failure this observes.
+	let onAbort!: (reason: unknown) => void;
+	const aborted = new Promise<unknown>((resolve) => (onAbort = resolve));
 	const quic = {
 		createBidirectionalStream: async () => ({
 			readable: new ReadableStream<Uint8Array>({ start: (controller) => (inbound = controller) }),
-			writable: new WritableStream<Uint8Array>(),
+			writable: new WritableStream<Uint8Array>({ abort: (reason) => void onAbort(reason) }),
 		}),
 	} as unknown as WebTransport;
 
@@ -68,7 +73,22 @@ function announceHarness(version: Version, origin = 1n) {
 		inbound.enqueue(out);
 	};
 
-	return { subscriber, send, settle: () => new Promise((resolve) => setTimeout(resolve, 0)) };
+	// The reason the subscriber reset the stream, or a prompt rejection if it never did.
+	// A peer that is not told about its own violation should fail the test visibly rather
+	// than hang it out to the suite timeout.
+	const abortReason = async () => {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => reject(new Error("stream was never aborted")), 250);
+		});
+		try {
+			return reason(error(await Promise.race([aborted, timeout])));
+		} finally {
+			clearTimeout(timer);
+		}
+	};
+
+	return { subscriber, send, abortReason, settle: () => new Promise((resolve) => setTimeout(resolve, 0)) };
 }
 
 const PUBLISHER_A = OriginSchema.parse(7n);
@@ -233,7 +253,7 @@ test("lite-03 keeps an existing RTT, since its PROBE cannot carry one", async ()
 test("an announce skipped as a reflected loop still holds its path", async () => {
 	// The subscriber's own origin, so a chain naming it reflects back through us.
 	const SELF = 1n;
-	const { subscriber, send, settle } = announceHarness(Version.DRAFT_06, SELF);
+	const { subscriber, send, abortReason, settle } = announceHarness(Version.DRAFT_06, SELF);
 	const announced = subscriber.announced(Path.empty());
 	await settle();
 
@@ -261,6 +281,9 @@ test("an announce skipped as a reflected loop still holds its path", async () =>
 	);
 
 	await expect(announced.next()).rejects.toThrow("duplicate announce");
+	// The peer has to hear about it: closing only our side would leave it announcing
+	// into a stream nobody reads.
+	expect(await abortReason()).toContain("duplicate announce");
 
 	announced.close();
 	subscriber.close();
@@ -385,7 +408,7 @@ test("a duplicate start is reported even when its own route reflects", async () 
 });
 
 test("a draft-02 initial set naming a path twice is refused", async () => {
-	const { subscriber, send, settle } = announceHarness(Version.DRAFT_02);
+	const { subscriber, send, abortReason, settle } = announceHarness(Version.DRAFT_02);
 	const announced = subscriber.announced(Path.empty());
 	await settle();
 
@@ -397,6 +420,7 @@ test("a draft-02 initial set naming a path twice is refused", async () => {
 	// Erroring the stream discards what it had already queued, so the consumer sees the
 	// violation rather than the first entry followed by it.
 	await expect(announced.next()).rejects.toThrow("duplicate announce");
+	expect(await abortReason()).toContain("duplicate announce");
 
 	announced.close();
 	subscriber.close();

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -383,3 +383,21 @@ test("a duplicate start is reported even when its own route reflects", async () 
 	announced.close();
 	subscriber.close();
 });
+
+test("a draft-02 initial set naming a path twice is refused", async () => {
+	const { subscriber, send, settle } = announceHarness(Version.DRAFT_02);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	// One advertisement per path, and the initial set is advertisements. Two entries for
+	// one path is the same violation as two ANNOUNCE_STARTs for it, which `start_announce`
+	// already rejects on the Rust side.
+	await send((w) => new AnnounceInit([Path.from("room"), Path.from("room")]).encode(w, Version.DRAFT_02));
+
+	// Erroring the stream discards what it had already queued, so the consumer sees the
+	// violation rather than the first entry followed by it.
+	await expect(announced.next()).rejects.toThrow("duplicate announce");
+
+	announced.close();
+	subscriber.close();
+});

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -45,11 +45,16 @@ function announceHarness(version: Version, origin = 1n) {
 	// learns it violated the protocol. Never resolving is the failure this observes.
 	let onAbort!: (reason: unknown) => void;
 	const aborted = new Promise<unknown>((resolve) => (onAbort = resolve));
+	// Resolves once the subscriber ends the session, which is what the draft requires of a
+	// protocol violation: a stream reset alone would let the peer repeat it on the next one.
+	let onSessionClose!: () => void;
+	const sessionClosed = new Promise<void>((resolve) => (onSessionClose = resolve));
 	const quic = {
 		createBidirectionalStream: async () => ({
 			readable: new ReadableStream<Uint8Array>({ start: (controller) => (inbound = controller) }),
 			writable: new WritableStream<Uint8Array>({ abort: (reason) => void onAbort(reason) }),
 		}),
+		close: () => void onSessionClose(),
 	} as unknown as WebTransport;
 
 	const subscriber = new Subscriber(quic, version, OriginSchema.parse(origin));
@@ -88,7 +93,26 @@ function announceHarness(version: Version, origin = 1n) {
 		}
 	};
 
-	return { subscriber, send, abortReason, settle: () => new Promise((resolve) => setTimeout(resolve, 0)) };
+	// Rejects promptly if the session outlives the violation, rather than hanging the test.
+	const sessionEnded = async () => {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => reject(new Error("session was never closed")), 250);
+		});
+		try {
+			await Promise.race([sessionClosed, timeout]);
+		} finally {
+			clearTimeout(timer);
+		}
+	};
+
+	return {
+		subscriber,
+		send,
+		abortReason,
+		sessionEnded,
+		settle: () => new Promise((resolve) => setTimeout(resolve, 0)),
+	};
 }
 
 const PUBLISHER_A = OriginSchema.parse(7n);
@@ -253,7 +277,7 @@ test("lite-03 keeps an existing RTT, since its PROBE cannot carry one", async ()
 test("an announce skipped as a reflected loop still holds its path", async () => {
 	// The subscriber's own origin, so a chain naming it reflects back through us.
 	const SELF = 1n;
-	const { subscriber, send, abortReason, settle } = announceHarness(Version.DRAFT_06, SELF);
+	const { subscriber, send, abortReason, sessionEnded, settle } = announceHarness(Version.DRAFT_06, SELF);
 	const announced = subscriber.announced(Path.empty());
 	await settle();
 
@@ -284,6 +308,9 @@ test("an announce skipped as a reflected loop still holds its path", async () =>
 	// The peer has to hear about it: closing only our side would leave it announcing
 	// into a stream nobody reads.
 	expect(await abortReason()).toContain("duplicate announce");
+	// The draft makes this session-fatal: resetting only the stream would let the peer
+	// repeat the violation on the next one.
+	await sessionEnded();
 
 	announced.close();
 	subscriber.close();
@@ -408,7 +435,7 @@ test("a duplicate start is reported even when its own route reflects", async () 
 });
 
 test("a draft-02 initial set naming a path twice is refused", async () => {
-	const { subscriber, send, abortReason, settle } = announceHarness(Version.DRAFT_02);
+	const { subscriber, send, abortReason, sessionEnded, settle } = announceHarness(Version.DRAFT_02);
 	const announced = subscriber.announced(Path.empty());
 	await settle();
 
@@ -421,6 +448,9 @@ test("a draft-02 initial set naming a path twice is refused", async () => {
 	// violation rather than the first entry followed by it.
 	await expect(announced.next()).rejects.toThrow("duplicate announce");
 	expect(await abortReason()).toContain("duplicate announce");
+	// The draft makes this session-fatal: resetting only the stream would let the peer
+	// repeat the violation on the next one.
+	await sessionEnded();
 
 	announced.close();
 	subscriber.close();

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -229,3 +229,105 @@ test("lite-03 keeps an existing RTT, since its PROBE cannot carry one", async ()
 	expect(got.estimatedRecvRate).toBe(2_000_000);
 	expect(got.rtt).toBe(Time.Milli(40));
 });
+
+test("an announce skipped as a reflected loop still holds its path", async () => {
+	// The subscriber's own origin, so a chain naming it reflects back through us.
+	const SELF = 1n;
+	const { subscriber, send, settle } = announceHarness(Version.DRAFT_06, SELF);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	await send((w) => new AnnounceOk(PEER, 0).encode(w, Version.DRAFT_06));
+
+	// Announce id 0: the chain loops back through us, so it is skipped locally. The peer
+	// numbered it regardless and still holds the path.
+	await send((w) =>
+		encodeAnnounceBroadcast(
+			w,
+			{ status: "active", suffix: Path.from("room"), hops: [OriginSchema.parse(SELF)] },
+			Version.DRAFT_06,
+		),
+	);
+	await settle();
+
+	// A second start for that path is one advertisement too many, whether or not we made
+	// anything of the first. Accepting it is what let id 0's end retract this one's state.
+	await send((w) =>
+		encodeAnnounceBroadcast(
+			w,
+			{ status: "active", suffix: Path.from("room"), hops: [PUBLISHER_A] },
+			Version.DRAFT_06,
+		),
+	);
+
+	await expect(announced.next()).rejects.toThrow("duplicate announce");
+
+	announced.close();
+	subscriber.close();
+});
+
+test("a restart replaces an announce that was skipped as a reflected loop", async () => {
+	const SELF = 1n;
+	const { subscriber, send, settle } = announceHarness(Version.DRAFT_06, SELF);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	await send((w) => new AnnounceOk(PEER, 0).encode(w, Version.DRAFT_06));
+
+	// Skipped: the chain reflects back through us.
+	await send((w) =>
+		encodeAnnounceBroadcast(
+			w,
+			{ status: "active", suffix: Path.from("room"), hops: [OriginSchema.parse(SELF)] },
+			Version.DRAFT_06,
+		),
+	);
+	await settle();
+
+	// The id stays live, so the peer may restart it into a route that is usable here.
+	await send((w) => encodeAnnounceBroadcast(w, { status: "restart", id: 0n, hops: [PUBLISHER_A] }, Version.DRAFT_06));
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
+
+	// Retiring the id ends what the restart attached, and nothing else.
+	await send((w) => encodeAnnounceBroadcast(w, { status: "endedId", id: 0n }, Version.DRAFT_06));
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: false });
+
+	announced.close();
+	subscriber.close();
+});
+
+test("retiring an id whose announce was skipped ends nothing", async () => {
+	const SELF = 1n;
+	const { subscriber, send, settle } = announceHarness(Version.DRAFT_06, SELF);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	await send((w) => new AnnounceOk(PEER, 0).encode(w, Version.DRAFT_06));
+
+	// Id 0 for "room": skipped as a reflected loop.
+	await send((w) =>
+		encodeAnnounceBroadcast(
+			w,
+			{ status: "active", suffix: Path.from("room"), hops: [OriginSchema.parse(SELF)] },
+			Version.DRAFT_06,
+		),
+	);
+	// Id 1 for a different path, which is routable.
+	await send((w) =>
+		encodeAnnounceBroadcast(
+			w,
+			{ status: "active", suffix: Path.from("lobby"), hops: [PUBLISHER_A] },
+			Version.DRAFT_06,
+		),
+	);
+	expect(await announced.next()).toEqual({ path: Path.from("lobby"), active: true });
+
+	// Retire the skipped one, then the live one. The first must surface nothing, so the
+	// only end a consumer sees is "lobby".
+	await send((w) => encodeAnnounceBroadcast(w, { status: "endedId", id: 0n }, Version.DRAFT_06));
+	await send((w) => encodeAnnounceBroadcast(w, { status: "endedId", id: 1n }, Version.DRAFT_06));
+	expect(await announced.next()).toEqual({ path: Path.from("lobby"), active: false });
+
+	announced.close();
+	subscriber.close();
+});

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -6,7 +6,7 @@ import { OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Writer } from "../stream.ts";
 import * as Time from "../time.ts";
-import { AnnounceInit, AnnounceOk, encodeAnnounceBroadcast } from "./announce.ts";
+import { type AnnounceBroadcast, AnnounceInit, AnnounceOk, encodeAnnounceBroadcast } from "./announce.ts";
 import { Probe } from "./probe.ts";
 import { Subscriber } from "./subscriber.ts";
 import { Version } from "./version.ts";
@@ -54,7 +54,15 @@ function announceHarness(version: Version, origin = 1n) {
 			readable: new ReadableStream<Uint8Array>({ start: (controller) => (inbound = controller) }),
 			writable: new WritableStream<Uint8Array>({ abort: (reason) => void onAbort(reason) }),
 		}),
-		close: (info?: WebTransportCloseInfo) => void onSessionClose(info),
+		close: (info?: WebTransportCloseInfo) => {
+			// WebTransport throws rather than closing when the reason exceeds 1024 bytes of
+			// UTF-8. Enforced here so an unbounded reason fails as a session that stayed up,
+			// which is what it does in a browser, rather than as a long string.
+			if (new TextEncoder().encode(info?.reason ?? "").byteLength > 1024) {
+				throw new TypeError("close reason exceeds 1024 bytes");
+			}
+			onSessionClose(info);
+		},
 	} as unknown as WebTransport;
 
 	const subscriber = new Subscriber(quic, version, OriginSchema.parse(origin));
@@ -456,4 +464,28 @@ test("a draft-02 initial set naming a path twice is refused", async () => {
 
 	announced.close();
 	subscriber.close();
+});
+
+test("a violation on a very long path still ends the session", async () => {
+	const SELF = 1n;
+	const { subscriber, send, sessionEnded, settle } = announceHarness(Version.DRAFT_06, SELF);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	await send((w) => new AnnounceOk(PEER, 0).encode(w, Version.DRAFT_06));
+
+	// The path is peer-supplied and lands in the close reason. WebTransport throws on a
+	// reason over 1024 bytes of UTF-8, and `#runAnnounced` is launched with `void`, so an
+	// unbounded reason would surface as an unhandled rejection with the session still up.
+	const long = Path.from("x".repeat(2000));
+	const active: AnnounceBroadcast = { status: "active", suffix: long, hops: [PUBLISHER_A] };
+	await send((w) => encodeAnnounceBroadcast(w, active, Version.DRAFT_06));
+	expect(await announced.next()).toEqual({ path: long, active: true });
+
+	await send((w) => encodeAnnounceBroadcast(w, active, Version.DRAFT_06));
+	await expect(announced.next()).rejects.toThrow("duplicate announce");
+
+	const info = await sessionEnded();
+	expect(info?.closeCode).toBe(15);
+	expect(new TextEncoder().encode(info?.reason ?? "").byteLength).toBeLessThanOrEqual(1024);
 });

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -5,7 +5,7 @@ import { OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Writer } from "../stream.ts";
 import * as Time from "../time.ts";
-import { AnnounceOk, encodeAnnounceBroadcast } from "./announce.ts";
+import { AnnounceInit, AnnounceOk, encodeAnnounceBroadcast } from "./announce.ts";
 import { Probe } from "./probe.ts";
 import { Subscriber } from "./subscriber.ts";
 import { Version } from "./version.ts";
@@ -327,6 +327,58 @@ test("retiring an id whose announce was skipped ends nothing", async () => {
 	await send((w) => encodeAnnounceBroadcast(w, { status: "endedId", id: 0n }, Version.DRAFT_06));
 	await send((w) => encodeAnnounceBroadcast(w, { status: "endedId", id: 1n }, Version.DRAFT_06));
 	expect(await announced.next()).toEqual({ path: Path.from("lobby"), active: false });
+
+	announced.close();
+	subscriber.close();
+});
+
+test("a draft-02 initial announcement can still be retracted", async () => {
+	const { subscriber, send, settle } = announceHarness(Version.DRAFT_02);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	// ANNOUNCE_INIT carries the initial set. These are advertisements like any other, so
+	// the peer may retract one later and the consumer has to hear about it.
+	await send((w) => new AnnounceInit([Path.from("room")]).encode(w, Version.DRAFT_02));
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
+
+	await send((w) => encodeAnnounceBroadcast(w, { status: "ended", suffix: Path.from("room") }, Version.DRAFT_02));
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: false });
+
+	announced.close();
+	subscriber.close();
+});
+
+test("a duplicate start is reported even when its own route reflects", async () => {
+	const SELF = 1n;
+	const { subscriber, send, settle } = announceHarness(Version.DRAFT_06, SELF);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	await send((w) => new AnnounceOk(PEER, 0).encode(w, Version.DRAFT_06));
+
+	// A first start we accept and surface.
+	await send((w) =>
+		encodeAnnounceBroadcast(
+			w,
+			{ status: "active", suffix: Path.from("room"), hops: [PUBLISHER_A] },
+			Version.DRAFT_06,
+		),
+	);
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
+
+	// A second start for that path, carrying a route that loops back through us. Skipping
+	// it must not pre-empt the violation: the peer sent two starts with no end between
+	// them regardless of whether the second one's route was usable.
+	await send((w) =>
+		encodeAnnounceBroadcast(
+			w,
+			{ status: "active", suffix: Path.from("room"), hops: [OriginSchema.parse(SELF)] },
+			Version.DRAFT_06,
+		),
+	);
+
+	await expect(announced.next()).rejects.toThrow("duplicate announce");
 
 	announced.close();
 	subscriber.close();

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -489,3 +489,48 @@ test("a violation on a very long path still ends the session", async () => {
 	expect(info?.closeCode).toBe(15);
 	expect(new TextEncoder().encode(info?.reason ?? "").byteLength).toBeLessThanOrEqual(1024);
 });
+
+test("a draft-04 duplicate start is a violation, not a restart", async () => {
+	// Pre-lite-05 has no replacement idiom, so a second ANNOUNCE_START for a live path is
+	// the same violation lite-06 treats it as. Only lite-05, where the duplicate *is* the
+	// restart, is exempt. The Rust loop routes every other version through `start_announce`,
+	// which rejects it.
+	const { subscriber, send, sessionEnded, settle } = announceHarness(Version.DRAFT_04);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	const active: AnnounceBroadcast = { status: "active", suffix: Path.from("room"), hops: [PUBLISHER_A] };
+	await send((w) => encodeAnnounceBroadcast(w, active, Version.DRAFT_04));
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
+
+	await send((w) => encodeAnnounceBroadcast(w, active, Version.DRAFT_04));
+
+	// Session first: it is the bounded assertion, so a version that treats this as a
+	// restart fails here in 250ms instead of hanging on a rejection that never comes.
+	expect((await sessionEnded())?.closeCode).toBe(15);
+	await expect(announced.next()).rejects.toThrow("duplicate announce");
+});
+
+test("a draft-05 duplicate start is still a restart", async () => {
+	const { subscriber, send, settle } = announceHarness(Version.DRAFT_05);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	await send((w) => new AnnounceOk(PEER, 0).encode(w, Version.DRAFT_05));
+
+	const active: AnnounceBroadcast = { status: "active", suffix: Path.from("room"), hops: [PUBLISHER_A] };
+	await send((w) => encodeAnnounceBroadcast(w, active, Version.DRAFT_05));
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
+
+	// Same publisher over a new route: transparent, and emphatically not an error.
+	await send((w) => encodeAnnounceBroadcast(w, active, Version.DRAFT_05));
+
+	// A different publisher does surface, which is what proves the reroute above passed.
+	const replaced: AnnounceBroadcast = { status: "active", suffix: Path.from("room"), hops: [PUBLISHER_B] };
+	await send((w) => encodeAnnounceBroadcast(w, replaced, Version.DRAFT_05));
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: false });
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
+
+	announced.close();
+	subscriber.close();
+});

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -47,14 +47,14 @@ function announceHarness(version: Version, origin = 1n) {
 	const aborted = new Promise<unknown>((resolve) => (onAbort = resolve));
 	// Resolves once the subscriber ends the session, which is what the draft requires of a
 	// protocol violation: a stream reset alone would let the peer repeat it on the next one.
-	let onSessionClose!: () => void;
-	const sessionClosed = new Promise<void>((resolve) => (onSessionClose = resolve));
+	let onSessionClose!: (info?: WebTransportCloseInfo) => void;
+	const sessionClosed = new Promise<WebTransportCloseInfo | undefined>((resolve) => (onSessionClose = resolve));
 	const quic = {
 		createBidirectionalStream: async () => ({
 			readable: new ReadableStream<Uint8Array>({ start: (controller) => (inbound = controller) }),
 			writable: new WritableStream<Uint8Array>({ abort: (reason) => void onAbort(reason) }),
 		}),
-		close: () => void onSessionClose(),
+		close: (info?: WebTransportCloseInfo) => void onSessionClose(info),
 	} as unknown as WebTransport;
 
 	const subscriber = new Subscriber(quic, version, OriginSchema.parse(origin));
@@ -100,7 +100,7 @@ function announceHarness(version: Version, origin = 1n) {
 			timer = setTimeout(() => reject(new Error("session was never closed")), 250);
 		});
 		try {
-			await Promise.race([sessionClosed, timeout]);
+			return await Promise.race([sessionClosed, timeout]);
 		} finally {
 			clearTimeout(timer);
 		}
@@ -309,8 +309,9 @@ test("an announce skipped as a reflected loop still holds its path", async () =>
 	// into a stream nobody reads.
 	expect(await abortReason()).toContain("duplicate announce");
 	// The draft makes this session-fatal: resetting only the stream would let the peer
-	// repeat the violation on the next one.
-	await sessionEnded();
+	// repeat the violation on the next one. The code has to say so too, or the peer reads
+	// the default 0 as a clean close.
+	expect((await sessionEnded())?.closeCode).toBe(15);
 
 	announced.close();
 	subscriber.close();
@@ -449,8 +450,9 @@ test("a draft-02 initial set naming a path twice is refused", async () => {
 	await expect(announced.next()).rejects.toThrow("duplicate announce");
 	expect(await abortReason()).toContain("duplicate announce");
 	// The draft makes this session-fatal: resetting only the stream would let the peer
-	// repeat the violation on the next one.
-	await sessionEnded();
+	// repeat the violation on the next one. The code has to say so too, or the peer reads
+	// the default 0 as a clean close.
+	expect((await sessionEnded())?.closeCode).toBe(15);
 
 	announced.close();
 	subscriber.close();

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -167,9 +167,18 @@ export class Subscriber {
 		// as lite-05. Lite01-03 carry no real hop ids, so the check never matches there.
 		const dropReflected = options.ignoreSelf || !hasExcludeHop(this.version);
 
+		// Opened outside the try so the catch can reach it: a protocol violation below has
+		// to reset the stream, not just close our side of it.
+		let stream: Stream;
 		try {
-			// Open a stream and send the announce interest.
-			const stream = await Stream.open(this.#quic);
+			stream = await Stream.open(this.#quic);
+		} catch (err: unknown) {
+			announced.close(error(err));
+			return;
+		}
+
+		try {
+			// Send the announce interest.
 			await stream.writer.u53(StreamId.Announce);
 			await msg.encode(stream.writer, this.version);
 
@@ -354,7 +363,13 @@ export class Subscriber {
 
 			announced.close();
 		} catch (err: unknown) {
-			announced.close(error(err));
+			const e = error(err);
+			// Reaches here on a protocol violation the peer committed (a second
+			// advertisement for a live path, an unknown announce id) as well as on a
+			// transport failure. Either way the peer has to be told: closing only our side
+			// would leave it announcing into a stream nobody reads.
+			stream.abort(e);
+			announced.close(e);
 		}
 	}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -83,6 +83,13 @@ interface SubscribeEntry {
  *
  * @internal
  */
+// What we close a session with on a protocol violation.
+//
+// The draft names the condition but assigns no numbers, so this is the Rust
+// implementation's code for `Error::ProtocolViolation`: matching it is what makes the
+// two report the same thing, where the default 0 would tell the peer it closed cleanly.
+const PROTOCOL_VIOLATION_CODE = 15;
+
 export class Subscriber {
 	#quic: WebTransport;
 
@@ -373,7 +380,9 @@ export class Subscriber {
 			// A violation ends the session, not just this stream, so a nonconforming peer
 			// cannot repeat it on the next one. Matches `ietf::Subscriber` and the Rust
 			// lite subscriber, where the announce half only ever ends the session on error.
-			if (e instanceof ProtocolViolation) this.#quic.close();
+			if (e instanceof ProtocolViolation) {
+				this.#quic.close({ closeCode: PROTOCOL_VIOLATION_CODE, reason: reason(e) });
+			}
 		}
 	}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -207,12 +207,20 @@ export class Subscriber {
 			let nextAnnounceId = 0n;
 			const announcedById = new Map<bigint, Path.Valid>();
 
-			// The publisher behind each path we currently advertise, so a restart can tell a
-			// route change (same publisher, subscriptions resume) from a replacement (a new
-			// generation took the path, nothing carries over). At most one advertisement per
-			// path is current, and every announce on this stream shares `prefix`, so the
-			// suffix is the key.
-			const advertised = new Map<Path.Valid, Origin | undefined>();
+			// Every advertisement the peer currently has live, keyed by suffix (at most one
+			// per path is current, and every announce on this stream shares `prefix`).
+			//
+			// An advertisement skipped locally as a reflected loop is recorded with
+			// `publisher: undefined` and `live: false`: the peer numbered it and will retract
+			// it regardless of what we made of it, so its path is not free. Dropping it from
+			// the map instead would let a later announce take the path, and the skipped one's
+			// `endedId` would then retract that one's state.
+			//
+			// `publisher` is what lets a restart tell a route change (same publisher,
+			// subscriptions resume) from a replacement (a new generation took the path,
+			// nothing carries over).
+			type Advertisement = { publisher: Origin | undefined; live: boolean };
+			const advertised = new Map<Path.Valid, Advertisement>();
 
 			// Receive announce updates (for Draft03, this includes initial state)
 			for (;;) {
@@ -266,9 +274,12 @@ export class Subscriber {
 
 				// Retract the path: forget the advertisement, drop the shared consume entry so a
 				// later announce subscribes fresh rather than cloning the dead generation's tracks,
-				// and tell the consumer.
+				// and tell the consumer. A no-op for an advertisement never surfaced, which is
+				// what an id retiring a skipped announce resolves to.
 				const retract = () => {
+					const previous = advertised.get(suffix);
 					advertised.delete(suffix);
+					if (!previous?.live) return;
 					this.#consumes.evict(path);
 					console.debug(`announced: broadcast=${path} active=false`);
 					announced.append({ path: suffix, active: false });
@@ -280,8 +291,11 @@ export class Subscriber {
 					const full = responderOrigin !== undefined ? [...hops, responderOrigin] : hops;
 					if (full.includes(this.origin)) {
 						// A reflected restart means the peer's remaining route loops back through
-						// us, so the advertisement is gone even though the message says active.
-						if (advertised.has(suffix)) retract();
+						// us, so the route is gone even though the message says active. The
+						// advertisement stays live: the peer still holds the path and its id still
+						// resolves here.
+						retract();
+						advertised.set(suffix, { publisher: undefined, live: false });
 						continue;
 					}
 				}
@@ -291,10 +305,18 @@ export class Subscriber {
 					// peer itself originated it. See `restart_announce` in the Rust subscriber.
 					const publisher = hops?.[0] ?? responderOrigin;
 
+					// One current advertisement per path per stream. From lite-06 a replacement
+					// is an explicit RESTART, so a second ANNOUNCE_START for a path the peer
+					// already advertised is a violation, whether or not we skipped the first.
+					if (announce.status === "active" && hasAnnounceId(this.version) && advertised.has(suffix)) {
+						throw new Error(`duplicate announce for ${path}`);
+					}
+
 					// A second advertisement for a path we already carry is a restart: either an
 					// explicit ANNOUNCE_UPDATE, or (lite-05) a duplicate ANNOUNCE.
-					if (advertised.has(suffix)) {
-						if (advertised.get(suffix) === publisher) {
+					const previous = advertised.get(suffix);
+					if (previous?.live) {
+						if (previous.publisher === publisher) {
 							// Same publisher, new route. In-flight subscriptions resume across it,
 							// so there is nothing for a consumer to react to.
 							console.debug(`announced: broadcast=${path} rerouted`);
@@ -309,7 +331,7 @@ export class Subscriber {
 					// After `retract()`, which clears the entry: the path is advertised again, by
 					// whoever just took it over. Recording it before would leave nothing behind, so
 					// the *next* takeover would read as a first announcement and skip its own end.
-					advertised.set(suffix, publisher);
+					advertised.set(suffix, { publisher, live: true });
 				} else {
 					retract();
 					continue;

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -22,7 +22,15 @@ import { ProbeLevel, type Setup } from "./setup.ts";
 import { StreamId } from "./stream.ts";
 import { decodeSubscribeResponse, decodeSubscribeResponseMaybe, Subscribe, SubscribeUpdate } from "./subscribe.ts";
 import { TrackInfo, Track as TrackMessage } from "./track.ts";
-import { hasAnnounceId, hasAnnounceOk, hasDatagrams, hasExcludeHop, hasProbeRtt, Version } from "./version.ts";
+import {
+	hasAnnounceId,
+	hasAnnounceOk,
+	hasDatagrams,
+	hasExcludeHop,
+	hasProbeRtt,
+	restartSupported,
+	Version,
+} from "./version.ts";
 
 // Bound on how long stream-open plus the first response (SUBSCRIBE_OK on older
 // drafts, or TRACK_INFO on lite-05+) may take. Browsers cap concurrent QUIC streams
@@ -311,12 +319,18 @@ export class Subscriber {
 				const path = Path.join(prefix, suffix);
 
 				// One current advertisement per path per stream, decided before anything below
-				// can skip this announcement. From lite-06 a replacement is an explicit RESTART,
-				// so a second ANNOUNCE_START for a path the peer already advertised is a
-				// violation whether or not its route would be usable here, and whether or not we
-				// kept the first. Letting a skip pre-empt it would retract the live route and
-				// leave the stream open on a peer that is already out of spec.
-				if (announce.status === "active" && hasAnnounceId(this.version) && advertised.has(suffix)) {
+				// can skip this announcement. A second ANNOUNCE_START for a path the peer
+				// already advertised is a violation whether or not its route would be usable
+				// here, and whether or not we kept the first; letting a skip pre-empt it would
+				// retract the live route and leave the stream open on a peer already out of
+				// spec.
+				//
+				// lite-05 alone is exempt, where a duplicate ANNOUNCE *is* the replacement
+				// idiom. lite-06 gave that its own message and older versions never had one, so
+				// a duplicate means the same thing on both sides of it. Mirrors the branch the
+				// Rust announce loop takes before `start_announce`.
+				const duplicateIsRestart = restartSupported(this.version) && !hasAnnounceId(this.version);
+				if (announce.status === "active" && !duplicateIsRestart && advertised.has(suffix)) {
 					throw new ProtocolViolation(`duplicate announce for ${path}`);
 				}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -182,15 +182,35 @@ export class Subscriber {
 				responderOrigin = ok.origin;
 			}
 
+			// Every advertisement the peer currently has live, keyed by suffix (at most one
+			// per path is current, and every announce on this stream shares `prefix`).
+			//
+			// An advertisement skipped locally as a reflected loop is recorded with
+			// `publisher: undefined` and `live: false`: the peer numbered it and will retract
+			// it regardless of what we made of it, so its path is not free. Dropping it from
+			// the map instead would let a later announce take the path, and the skipped one's
+			// `endedId` would then retract that one's state.
+			//
+			// `publisher` is what lets a restart tell a route change (same publisher,
+			// subscriptions resume) from a replacement (a new generation took the path,
+			// nothing carries over).
+			type Advertisement = { publisher: Origin | undefined; live: boolean };
+			const advertised = new Map<Path.Valid, Advertisement>();
+
 			switch (this.version) {
 				case Version.DRAFT_01:
 				case Version.DRAFT_02: {
 					// Receive ANNOUNCE_INIT first
 					const init = await AnnounceInit.decode(stream.reader, this.version);
 
-					// Process initial announcements
+					// Process initial announcements. These are advertisements like any other, so
+					// they go on record: a later `ended` for one has to find it here to retract
+					// it, and a second announcement at the same path is still one too many.
+					// Draft01/02 carry no hop ids and no ANNOUNCE_OK, so nothing names the
+					// publisher.
 					for (const suffix of init.suffixes) {
 						const path = Path.join(prefix, suffix);
+						advertised.set(suffix, { publisher: undefined, live: true });
 						console.debug(`announced: broadcast=${path} active=true`);
 						announced.append({ path: suffix, active: true });
 					}
@@ -206,21 +226,6 @@ export class Subscriber {
 			// announces we skip via ignoreSelf, since the sender doesn't know we skipped.
 			let nextAnnounceId = 0n;
 			const announcedById = new Map<bigint, Path.Valid>();
-
-			// Every advertisement the peer currently has live, keyed by suffix (at most one
-			// per path is current, and every announce on this stream shares `prefix`).
-			//
-			// An advertisement skipped locally as a reflected loop is recorded with
-			// `publisher: undefined` and `live: false`: the peer numbered it and will retract
-			// it regardless of what we made of it, so its path is not free. Dropping it from
-			// the map instead would let a later announce take the path, and the skipped one's
-			// `endedId` would then retract that one's state.
-			//
-			// `publisher` is what lets a restart tell a route change (same publisher,
-			// subscriptions resume) from a replacement (a new generation took the path,
-			// nothing carries over).
-			type Advertisement = { publisher: Origin | undefined; live: boolean };
-			const advertised = new Map<Path.Valid, Advertisement>();
 
 			// Receive announce updates (for Draft03, this includes initial state)
 			for (;;) {
@@ -272,6 +277,16 @@ export class Subscriber {
 
 				const path = Path.join(prefix, suffix);
 
+				// One current advertisement per path per stream, decided before anything below
+				// can skip this announcement. From lite-06 a replacement is an explicit RESTART,
+				// so a second ANNOUNCE_START for a path the peer already advertised is a
+				// violation whether or not its route would be usable here, and whether or not we
+				// kept the first. Letting a skip pre-empt it would retract the live route and
+				// leave the stream open on a peer that is already out of spec.
+				if (announce.status === "active" && hasAnnounceId(this.version) && advertised.has(suffix)) {
+					throw new Error(`duplicate announce for ${path}`);
+				}
+
 				// Retract the path: forget the advertisement, drop the shared consume entry so a
 				// later announce subscribes fresh rather than cloning the dead generation's tracks,
 				// and tell the consumer. A no-op for an advertisement never surfaced, which is
@@ -304,13 +319,6 @@ export class Subscriber {
 					// The first hop identifies the original publisher; an empty chain means the
 					// peer itself originated it. See `restart_announce` in the Rust subscriber.
 					const publisher = hops?.[0] ?? responderOrigin;
-
-					// One current advertisement per path per stream. From lite-06 a replacement
-					// is an explicit RESTART, so a second ANNOUNCE_START for a path the peer
-					// already advertised is a violation, whether or not we skipped the first.
-					if (announce.status === "active" && hasAnnounceId(this.version) && advertised.has(suffix)) {
-						throw new Error(`duplicate announce for ${path}`);
-					}
 
 					// A second advertisement for a path we already carry is a restart: either an
 					// explicit ANNOUNCE_UPDATE, or (lite-05) a duplicate ANNOUNCE.

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -3,7 +3,7 @@ import * as announce from "../announced.ts";
 import * as broadcast from "../broadcast.ts";
 import type { Probe as ProbeStats } from "../connection/stats.ts";
 import { BroadcastCache } from "../consume.ts";
-import { error, reason } from "../error.ts";
+import { error, ProtocolViolation, reason } from "../error.ts";
 import * as netGroup from "../group.ts";
 import type { Origin } from "../origin.ts";
 import * as Path from "../path.ts";
@@ -220,7 +220,7 @@ export class Subscriber {
 					for (const suffix of init.suffixes) {
 						const path = Path.join(prefix, suffix);
 						if (advertised.has(suffix)) {
-							throw new Error(`duplicate announce for ${path}`);
+							throw new ProtocolViolation(`duplicate announce for ${path}`);
 						}
 						advertised.set(suffix, { publisher: undefined, live: true });
 						console.debug(`announced: broadcast=${path} active=true`);
@@ -270,7 +270,7 @@ export class Subscriber {
 					case "endedId": {
 						// Resolve and retire the id; an unknown or retired id is a protocol violation.
 						const path = announcedById.get(announce.id);
-						if (path === undefined) throw new Error(`unknown announce id: ${announce.id}`);
+						if (path === undefined) throw new ProtocolViolation(`unknown announce id: ${announce.id}`);
 						announcedById.delete(announce.id);
 						suffix = path;
 						active = false;
@@ -279,7 +279,7 @@ export class Subscriber {
 					case "restart": {
 						// Resolve the id; it stays live (the replacement reuses it).
 						const path = announcedById.get(announce.id);
-						if (path === undefined) throw new Error(`unknown announce id: ${announce.id}`);
+						if (path === undefined) throw new ProtocolViolation(`unknown announce id: ${announce.id}`);
 						suffix = path;
 						active = true;
 						hops = announce.hops;
@@ -296,7 +296,7 @@ export class Subscriber {
 				// kept the first. Letting a skip pre-empt it would retract the live route and
 				// leave the stream open on a peer that is already out of spec.
 				if (announce.status === "active" && hasAnnounceId(this.version) && advertised.has(suffix)) {
-					throw new Error(`duplicate announce for ${path}`);
+					throw new ProtocolViolation(`duplicate announce for ${path}`);
 				}
 
 				// Retract the path: forget the advertisement, drop the shared consume entry so a
@@ -370,6 +370,10 @@ export class Subscriber {
 			// would leave it announcing into a stream nobody reads.
 			stream.abort(e);
 			announced.close(e);
+			// A violation ends the session, not just this stream, so a nonconforming peer
+			// cannot repeat it on the next one. Matches `ietf::Subscriber` and the Rust
+			// lite subscriber, where the announce half only ever ends the session on error.
+			if (e instanceof ProtocolViolation) this.#quic.close();
 		}
 	}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -204,12 +204,15 @@ export class Subscriber {
 					const init = await AnnounceInit.decode(stream.reader, this.version);
 
 					// Process initial announcements. These are advertisements like any other, so
-					// they go on record: a later `ended` for one has to find it here to retract
-					// it, and a second announcement at the same path is still one too many.
-					// Draft01/02 carry no hop ids and no ANNOUNCE_OK, so nothing names the
-					// publisher.
+					// they go on record and obey the same one-per-path rule: the initial set
+					// naming a path twice is the same violation as two ANNOUNCE_STARTs for it,
+					// and the record is what catches either. Draft01/02 carry no hop ids and no
+					// ANNOUNCE_OK, so nothing names the publisher.
 					for (const suffix of init.suffixes) {
 						const path = Path.join(prefix, suffix);
+						if (advertised.has(suffix)) {
+							throw new Error(`duplicate announce for ${path}`);
+						}
 						advertised.set(suffix, { publisher: undefined, live: true });
 						console.debug(`announced: broadcast=${path} active=true`);
 						announced.append({ path: suffix, active: true });

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -90,6 +90,20 @@ interface SubscribeEntry {
 // two report the same thing, where the default 0 would tell the peer it closed cleanly.
 const PROTOCOL_VIOLATION_CODE = 15;
 
+// WebTransport rejects a close reason over 1024 bytes of UTF-8 by throwing, so a reason
+// built from peer-supplied data has to be bounded before it gets there. A broadcast path
+// is peer-supplied and long enough to reach this on its own.
+const MAX_CLOSE_REASON = 1024;
+
+// The longest prefix of `text` that fits a close reason. `encodeInto` stops on a whole
+// code point, so `read` never lands mid-character the way slicing bytes would.
+function closeReason(text: string): string {
+	const encoder = new TextEncoder();
+	const buf = new Uint8Array(MAX_CLOSE_REASON);
+	const { read } = encoder.encodeInto(text, buf);
+	return text.slice(0, read);
+}
+
 export class Subscriber {
 	#quic: WebTransport;
 
@@ -381,7 +395,7 @@ export class Subscriber {
 			// cannot repeat it on the next one. Matches `ietf::Subscriber` and the Rust
 			// lite subscriber, where the announce half only ever ends the session on error.
 			if (e instanceof ProtocolViolation) {
-				this.#quic.close({ closeCode: PROTOCOL_VIOLATION_CODE, reason: reason(e) });
+				this.#quic.close({ closeCode: PROTOCOL_VIOLATION_CODE, reason: closeReason(reason(e)) });
 			}
 		}
 	}

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -75,6 +75,22 @@ export function hasAnnounceOk(version: Version): boolean {
 	}
 }
 
+/** Whether the version can replace an advertisement in place rather than retracting and
+ * re-announcing it. Added in lite-05 as a duplicate ANNOUNCE; lite-06 gave it a message of
+ * its own (ANNOUNCE_UPDATE) and made the duplicate a violation. */
+export function restartSupported(version: Version): boolean {
+	// Explicitly list older versions so future versions default to supported.
+	switch (version) {
+		case Version.DRAFT_01:
+		case Version.DRAFT_02:
+		case Version.DRAFT_03:
+		case Version.DRAFT_04:
+			return false;
+		default:
+			return true;
+	}
+}
+
 /** Whether announcements carry implicit announce ids: each `active` assigns the next
  * per-stream ordinal, and `ended`/`restart` reference that id instead of repeating the
  * path. Added in lite-06. */

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -266,7 +266,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// changes for the life of the session.
 		let link_cost = self.resolve_cost().await;
 
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 
 		// Lite06+: announce ids. Each received `active` implicitly assigns the next
 		// per-stream ordinal; `ended`/`restart` reference it instead of repeating the
@@ -290,7 +290,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						RouteCost::default(),
 						0,
 						responder_origin,
-						&mut routes,
+						&mut announced,
 					)?;
 				}
 			}
@@ -310,29 +310,25 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					}
 					if lite::restart_supported(self.version)
 						&& !self.version.has_announce_id()
-						&& routes.contains_key(&path)
+						&& announced.contains(&path)
 					{
 						// lite-05 only: a duplicate ANNOUNCE for an already-announced path is a RESTART;
 						// atomically replace the broadcast. Lite06+ restarts by announce id, and older
 						// versions never defined restarts, so both fall through to start_announce, which
 						// rejects the duplicate (Error::Duplicate).
-						self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
+						self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut announced)?;
 					} else {
-						self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
+						self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut announced)?;
 					}
 				}
 				lite::AnnounceBroadcast::Ended { suffix, .. } => {
 					let path = prefix.join(&suffix);
 					tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
 
-					// The matching Active may have been silently dropped by
-					// start_announce as a reflected loop, in which case
-					// `routes` has no entry; that's expected, not an error.
-					// A deliberate unannounce, so finish() rather than drop; the origin
-					// unannounces if this was the broadcast's last route.
-					if let Some(entry) = routes.remove(&path) {
-						entry.finish();
-					}
+					// A deliberate unannounce, so `retire` finishes the source rather than
+					// dropping it; the origin unannounces if this was the broadcast's last
+					// route. An advertisement we declined locally has none to finish.
+					announced.retire(&path);
 				}
 				lite::AnnounceBroadcast::EndedId { id } => {
 					// Resolve and retire the id; an unknown or already-retired id is a
@@ -342,14 +338,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					};
 					tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
 
-					// The matching Active may have been silently dropped by
-					// start_announce as a reflected loop, in which case
-					// `routes` has no entry; that's expected, not an error.
-					// A deliberate unannounce, so finish() rather than drop; the origin
-					// unannounces if this was the broadcast's last route.
-					if let Some(entry) = routes.remove(&path) {
-						entry.finish();
-					}
+					// The id resolves to whatever the peer advertised at it, which is the
+					// point: an id whose announce we declined locally retires that record
+					// and nothing else, rather than a later announce's route.
+					announced.retire(&path);
 				}
 				lite::AnnounceBroadcast::Restart { id, hops, cost } => {
 					// Resolve the id; it stays live (the replacement reuses it). An unknown
@@ -357,13 +349,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					let Some(path) = announced_by_id.get(&id).cloned() else {
 						return Err(Error::ProtocolViolation);
 					};
-					if routes.contains_key(&path) {
-						self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
-					} else {
-						// The original announce was dropped locally (e.g. a reflected loop);
-						// the replacement may be routable, so treat it as a fresh start.
-						self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
-					}
+					// A restart replaces an advertisement that is already live, so it never
+					// consults the one-advertisement-per-path rule. `restart_announce`
+					// attaches a route whether or not the original had one.
+					self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut announced)?;
 				}
 			}
 		}
@@ -441,9 +430,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	/// Returns `Ok(true)` if the announce was accepted (and a route was attached to
-	/// the origin's broadcast at the path), `Ok(false)` if it was dropped as a
-	/// reflected loop.
+	/// Records the advertisement either way. Returns `Ok(true)` if it was accepted (and
+	/// a route was attached to the origin's broadcast at the path), `Ok(false)` if it was
+	/// dropped as a reflected loop.
 	fn start_announce(
 		&mut self,
 		path: PathOwned,
@@ -459,14 +448,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// the full `[src...sender]` chain Lite04 stored. None for older versions,
 		// where the sender already appended itself.
 		responder_origin: Option<crate::Origin>,
-		routes: &mut HashMap<PathOwned, AnnouncedRoute>,
+		announced: &mut Announced,
 	) -> Result<bool, Error> {
-		// Make sure the peer doesn't double announce. Decided first: the drops below
-		// return `Ok(false)`, and the caller has already assigned this announce an id,
-		// so letting one of them pre-empt this check leaves that id bound to a path
-		// whose route belongs to the earlier announce. The `ANNOUNCE_END` that follows
-		// would then retire the wrong one.
-		if routes.contains_key(&path) {
+		// One current advertisement per path per stream. Tested against what the peer
+		// advertised rather than what we accepted: a second start for a path whose first
+		// announce we declined is the same violation, and letting it through is how an
+		// id ends up bound to a path holding a different announce's route.
+		if announced.contains(&path) {
 			return Err(Error::Duplicate);
 		}
 
@@ -477,6 +465,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			// must not enter the model at all. Zero names nobody, so it may repeat.
 			if responder != crate::Origin::UNKNOWN && hops.contains(&responder) {
 				tracing::debug!(broadcast = %self.log_path(&path), "dropping announce reflected by its sender");
+				announced.declined(path);
 				return Ok(false);
 			}
 			// If the chain is already full, drop the announce. This is the same decision
@@ -486,6 +475,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					broadcast = %self.log_path(&path),
 					"dropping announce; hop chain at MAX_HOPS (possible loop)",
 				);
+				announced.declined(path);
 				return Ok(false);
 			}
 		}
@@ -497,6 +487,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// every other version.
 		if hops.contains(&self.self_origin) {
 			tracing::debug!(broadcast = %self.log_path(&path), "dropping reflected announce");
+			announced.declined(path);
 			return Ok(false);
 		}
 
@@ -537,13 +528,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			.with_announce(true);
 		route.advertised = cost.0;
 		let Ok(source) = self.origin.create_broadcast(&path, route) else {
+			announced.declined(path);
 			return Ok(false);
 		};
 
 		// Serve the origin's track requests for this source in the background; the
 		// announce loop keeps the producer so an unannounce can finish it.
 		self.tasks.push(self.clone().run_source(path.clone(), source.dynamic()));
-		routes.insert(path, AnnouncedRoute::new(source, publisher));
+		announced.attach(path, AnnouncedRoute::new(source, publisher));
 
 		Ok(true)
 	}
@@ -559,6 +551,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// can be unrelated publishers), the old route detaches gracefully and a fresh
 	/// one attaches, so downstream sees a real Ended + Active (a new broadcast,
 	/// nothing resumes).
+	/// The advertisement is already live, so this never applies the one-per-path rule
+	/// and never needs the original to have carried a route: an announce we declined
+	/// may restart into one that is routable.
+	///
 	/// Returns `Ok(false)` if the new hop chain is a reflected loop (this session's
 	/// route is now gone), `Ok(true)` otherwise.
 	fn restart_announce(
@@ -572,9 +568,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// rebuild the full chain since the sender no longer stamps itself. None for older
 		// versions. See `start_announce`.
 		responder_origin: Option<crate::Origin>,
-		routes: &mut HashMap<PathOwned, AnnouncedRoute>,
+		announced: &mut Announced,
 	) -> Result<bool, Error> {
-		// Reflected loop (or a full chain): the route can't be used here anymore. Retire it.
+		// Reflected loop (or a full chain): the route can't be used here anymore. Detach
+		// it, leaving the advertisement live so its id still resolves here.
 		let reflected = match responder_origin {
 			// A chain already naming the sender came back through it; see `start_announce`.
 			Some(responder) => {
@@ -586,10 +583,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		};
 		if reflected {
 			tracing::debug!(broadcast = %self.log_path(&path), "dropping reflected restart");
-			// The peer retracted the route deliberately; detach gracefully.
-			if let Some(entry) = routes.remove(&path) {
-				entry.finish();
-			}
+			// The peer replaced the route deliberately; detach gracefully.
+			announced.declined(path);
 			return Ok(false);
 		}
 
@@ -601,15 +596,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			.with_announce(true);
 		metadata.advertised = cost.0;
 
-		match routes.get_mut(&path) {
+		match announced.attached(&path) {
 			Some(entry) if entry.publisher != publisher || publisher == crate::Origin::UNKNOWN => {
 				// A different original publisher, or no identity at all (UNKNOWN
 				// never proves continuity): a brand-new broadcast may have replaced
 				// the old one at this path. Detach gracefully (downstream unannounces
 				// if this was the last source) and attach fresh below; cached
 				// TRACK_INFO and subscriptions must not carry over.
-				let entry = routes.remove(&path).expect("matched above");
-				entry.finish();
+				announced.declined(path.clone());
 			}
 			Some(entry) => {
 				// Same publisher, new path: update the source's route in place.
@@ -618,14 +612,17 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				entry.set_route(metadata);
 				return Ok(true);
 			}
+			// Nothing attached: either a fresh path, or an advertisement we declined
+			// whose replacement may be routable.
 			None => {}
 		}
 
 		let Ok(source) = self.origin.create_broadcast(&path, metadata) else {
+			announced.declined(path);
 			return Ok(false);
 		};
 		self.tasks.push(self.clone().run_source(path.clone(), source.dynamic()));
-		routes.insert(path, AnnouncedRoute::new(source, publisher));
+		announced.attach(path, AnnouncedRoute::new(source, publisher));
 
 		Ok(true)
 	}
@@ -942,7 +939,7 @@ mod tests {
 		});
 
 		let path = Path::new("room/host").to_owned();
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 		assert!(
 			subscriber
 				.start_announce(
@@ -951,7 +948,7 @@ mod tests {
 					RouteCost::default(),
 					0,
 					Some(assigned),
-					&mut routes,
+					&mut announced,
 				)
 				.unwrap()
 		);
@@ -961,10 +958,72 @@ mod tests {
 		reflected.push(assigned).unwrap();
 		assert!(
 			matches!(
-				subscriber.start_announce(path, reflected, RouteCost::default(), 0, Some(assigned), &mut routes),
+				subscriber.start_announce(path, reflected, RouteCost::default(), 0, Some(assigned), &mut announced),
 				Err(Error::Duplicate)
 			),
 			"the double announce must be reported, not silently dropped",
+		);
+	}
+
+	/// A dropped announce still holds its path.
+	///
+	/// The peer numbers and retracts advertisements regardless of what the receiver made
+	/// of them, so an announce dropped as a reflected loop is still live on the wire. If
+	/// only accepted announces were recorded, its path would read as free: a second start
+	/// would be accepted instead of reported, and the first announce's `ANNOUNCE_END`
+	/// would then resolve to the path and retire the second one's route. A relay meshed
+	/// with its own peer drops reflected announces routinely, so this is the common case
+	/// rather than a corner of one.
+	#[tokio::test]
+	async fn a_dropped_announce_still_holds_its_path() {
+		let assigned = crate::Origin::new(777).unwrap();
+
+		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let consumer = origin.consume();
+		let (tasks, _task_set) = TaskSet::new();
+		let mut subscriber = Subscriber::new(SubscriberConfig {
+			session: SinkSession::new(Default::default()),
+			origin,
+			recv_bandwidth: None,
+			version: VERSION,
+			peer_setup: Default::default(),
+			cost: None,
+			peer_origin: Some(assigned),
+			tasks,
+		});
+
+		let path = Path::new("room/host").to_owned();
+		let mut announced = Announced::default();
+
+		// Announce id 0: reflected by its sender, so it is dropped locally.
+		let mut reflected = crate::OriginList::new();
+		reflected.push(assigned).unwrap();
+		assert!(
+			!subscriber
+				.start_announce(
+					path.clone(),
+					reflected,
+					RouteCost::default(),
+					0,
+					Some(assigned),
+					&mut announced,
+				)
+				.unwrap(),
+			"a chain naming its own sender must be dropped",
+		);
+		assert!(consumer.get_broadcast("room/host").is_none());
+
+		// Announce id 1, for a path the peer never retracted: two starts with no end
+		// between them. The receiver used to miss that because it consulted its own
+		// acceptance record, accept this one, and let id 0's end retire its route.
+		let mut hops = crate::OriginList::new();
+		hops.push(crate::Origin::new(7).unwrap()).unwrap();
+		assert!(
+			matches!(
+				subscriber.start_announce(path, hops, RouteCost::default(), 0, Some(assigned), &mut announced),
+				Err(Error::Duplicate)
+			),
+			"a start for a path the peer already advertised must be reported, even though the first was dropped",
 		);
 	}
 
@@ -995,7 +1054,7 @@ mod tests {
 		let mut hops = crate::OriginList::new();
 		hops.push(assigned).unwrap();
 
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 		let accepted = subscriber
 			.start_announce(
 				Path::new("room/host").to_owned(),
@@ -1003,7 +1062,7 @@ mod tests {
 				RouteCost::default(),
 				0,
 				Some(assigned),
-				&mut routes,
+				&mut announced,
 			)
 			.unwrap();
 		assert!(!accepted, "a chain naming its own sender must not become a route");
@@ -1036,7 +1095,7 @@ mod tests {
 
 		// An announce with an empty chain and no responder id: the versions that
 		// carry no hop information on the wire.
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 		let accepted = subscriber
 			.start_announce(
 				Path::new("room/host").to_owned(),
@@ -1044,7 +1103,7 @@ mod tests {
 				RouteCost::default(),
 				0,
 				None,
-				&mut routes,
+				&mut announced,
 			)
 			.unwrap();
 		assert!(accepted);
@@ -1065,7 +1124,7 @@ mod tests {
 	async fn absent_peer_origin_stamps_unknown() {
 		let (mut subscriber, consumer) = restart_subscriber(SinkSession::new(Default::default()));
 
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 		subscriber
 			.start_announce(
 				Path::new("room/host").to_owned(),
@@ -1073,7 +1132,7 @@ mod tests {
 				RouteCost::default(),
 				0,
 				None,
-				&mut routes,
+				&mut announced,
 			)
 			.unwrap();
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -1110,7 +1169,7 @@ mod tests {
 	async fn unknown_publisher_restart_replaces() {
 		let (mut subscriber, consumer) = restart_subscriber(SinkSession::new(Default::default()));
 
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 		let path = Path::new("room/host").to_owned();
 		subscriber
 			.start_announce(
@@ -1119,7 +1178,7 @@ mod tests {
 				RouteCost::default(),
 				0,
 				Some(crate::Origin::UNKNOWN),
-				&mut routes,
+				&mut announced,
 			)
 			.unwrap();
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -1132,7 +1191,7 @@ mod tests {
 				RouteCost::default(),
 				0,
 				Some(crate::Origin::UNKNOWN),
-				&mut routes,
+				&mut announced,
 			)
 			.unwrap();
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -1151,7 +1210,7 @@ mod tests {
 		let (mut subscriber, consumer) = restart_subscriber(SinkSession::new(Default::default()));
 		let publisher = crate::Origin::new(7).unwrap();
 
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 		let path = Path::new("room/host").to_owned();
 		subscriber
 			.start_announce(
@@ -1160,7 +1219,7 @@ mod tests {
 				RouteCost::default(),
 				0,
 				Some(publisher),
-				&mut routes,
+				&mut announced,
 			)
 			.unwrap();
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -1173,7 +1232,7 @@ mod tests {
 				RouteCost(5),
 				0,
 				Some(publisher),
-				&mut routes,
+				&mut announced,
 			)
 			.unwrap();
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -1188,7 +1247,7 @@ mod tests {
 	/// leaving the origin's linger window open so a source reconnecting into it resumes
 	/// the broadcast rather than viewers seeing it end here.
 	///
-	/// This already falls out of `routes` being a local whose `AnnouncedRoute` guards
+	/// This already falls out of `Announced` being a local whose `AnnouncedRoute` guards
 	/// drop, which is exactly what makes it worth pinning: a refactor that finished them
 	/// on the way out, or hoisted the map to the session, would be a silent behavior
 	/// change. `ietf::Subscriber` names the same distinction explicitly as `Detach`.
@@ -1214,15 +1273,15 @@ mod tests {
 
 		let path = Path::new("room/host").to_owned();
 		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 		subscriber
-			.start_announce(path.clone(), hops, RouteCost(0), 1, None, &mut routes)
+			.start_announce(path.clone(), hops, RouteCost(0), 1, None, &mut announced)
 			.unwrap();
 		tokio::time::sleep(Duration::from_millis(1)).await;
 		assert!(consumer.get_broadcast("room/host").is_some());
 
-		// The stream ends without retracting anything: the map dies with it.
-		drop(routes);
+		// The stream ends without retracting anything: the record dies with it.
+		drop(announced);
 		tokio::time::sleep(Duration::from_millis(1)).await;
 		assert!(
 			consumer.get_broadcast("room/host").is_some(),
@@ -1231,12 +1290,13 @@ mod tests {
 
 		// An explicit retraction still closes it now, linger or not.
 		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
-		let mut routes = HashMap::new();
+		let mut announced = Announced::default();
 		subscriber
-			.start_announce(path.clone(), hops, RouteCost(0), 1, None, &mut routes)
+			.start_announce(path.clone(), hops, RouteCost(0), 1, None, &mut announced)
 			.unwrap();
 		tokio::time::sleep(Duration::from_millis(1)).await;
-		routes.remove(&path).expect("announced").finish();
+		assert!(announced.contains(&path), "the announce was not recorded");
+		announced.retire(&path);
 		tokio::time::sleep(Duration::from_millis(1)).await;
 		assert!(
 			consumer.get_broadcast("room/host").is_none(),
@@ -1263,7 +1323,58 @@ enum Sub<S: web_transport_trait::Session> {
 	Active(SubStream<S>),
 }
 
-/// The source created for one received announce, remembering the publisher
+/// Every advertisement the peer currently has live on one announce stream.
+///
+/// Keyed by path, because that is what the protocol allows one of: a second
+/// `ANNOUNCE_START` for a path already advertised is a violation whether or not the
+/// receiver did anything with the first. An announce declined locally (a reflected
+/// loop, a full hop chain, a path outside our scope) is recorded with no route, since
+/// the peer numbered it and will retract it regardless of what we made of it.
+///
+/// Keeping acceptance in the same record is what stops the two from disagreeing: a
+/// declined announce that fell out of the table entirely would leave its path reading
+/// as free, and its `ANNOUNCE_END` would then retire whatever took it.
+#[derive(Default)]
+struct Announced(HashMap<PathOwned, Option<AnnouncedRoute>>);
+
+impl Announced {
+	/// Whether the peer already has an advertisement live at this path.
+	fn contains(&self, path: &PathOwned) -> bool {
+		self.0.contains_key(path)
+	}
+
+	/// Record an advertisement we accepted, attaching its source.
+	fn attach(&mut self, path: PathOwned, route: AnnouncedRoute) {
+		self.0.insert(path, Some(route));
+	}
+
+	/// Record an advertisement we declined, finishing whatever was attached at the path.
+	///
+	/// The advertisement stays live either way: the peer still holds the path and its
+	/// announce id still resolves here, so a later `ANNOUNCE_END` retires this and a
+	/// later `ANNOUNCE_START` is still the duplicate it always was.
+	fn declined(&mut self, path: PathOwned) {
+		if let Some(Some(route)) = self.0.insert(path, None) {
+			route.finish();
+		}
+	}
+
+	/// The source attached at this path, or `None` if we declined the advertisement or
+	/// the peer never made one.
+	fn attached(&mut self, path: &PathOwned) -> Option<&mut AnnouncedRoute> {
+		self.0.get_mut(path)?.as_mut()
+	}
+
+	/// Retire the advertisement, finishing its source so the origin detaches it
+	/// immediately (unannouncing downstream if it was the last).
+	fn retire(&mut self, path: &PathOwned) {
+		if let Some(Some(route)) = self.0.remove(path) {
+			route.finish();
+		}
+	}
+}
+
+/// The source created for one accepted announce, remembering the publisher
 /// identity (the first hop of the reconstructed chain) so a restart can tell an
 /// alternate route to the same broadcast from a brand-new broadcast.
 struct AnnouncedRoute {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -430,9 +430,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	/// Records the advertisement either way. Returns `Ok(true)` if it was accepted (and
-	/// a route was attached to the origin's broadcast at the path), `Ok(false)` if it was
-	/// dropped as a reflected loop.
+	/// Records the advertisement either way. Returns `Ok(true)` if it was accepted (and a
+	/// route was attached to the origin's broadcast at the path), `Ok(false)` if it was
+	/// declined locally: a chain reflected by its sender, one at `MAX_HOPS`, one reflected
+	/// through us, or a path outside our scope.
 	fn start_announce(
 		&mut self,
 		path: PathOwned,
@@ -1014,8 +1015,8 @@ mod tests {
 		assert!(consumer.get_broadcast("room/host").is_none());
 
 		// Announce id 1, for a path the peer never retracted: two starts with no end
-		// between them. The receiver used to miss that because it consulted its own
-		// acceptance record, accept this one, and let id 0's end retire its route.
+		// between them. Catching it requires testing against what the peer advertised, since
+		// nothing was accepted at this path for an acceptance record to hold.
 		let mut hops = crate::OriginList::new();
 		hops.push(crate::Origin::new(7).unwrap()).unwrap();
 		assert!(

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -315,7 +315,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						// lite-05 only: a duplicate ANNOUNCE for an already-announced path is a RESTART;
 						// atomically replace the broadcast. Lite06+ restarts by announce id, and older
 						// versions never defined restarts, so both fall through to start_announce, which
-						// rejects the duplicate (Error::Duplicate).
+						// rejects the duplicate (Error::ProtocolViolation).
 						self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut announced)?;
 					} else {
 						self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut announced)?;
@@ -455,8 +455,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// advertised rather than what we accepted: a second start for a path whose first
 		// announce we declined is the same violation, and letting it through is how an
 		// id ends up bound to a path holding a different announce's route.
+		//
+		// One of the three conditions the draft ends the session over, alongside an
+		// unknown or retired announce id, so it reports the same code as those rather
+		// than the narrower `Duplicate`.
 		if announced.contains(&path) {
-			return Err(Error::Duplicate);
+			return Err(Error::ProtocolViolation);
 		}
 
 		if let Some(responder) = responder_origin {
@@ -960,7 +964,7 @@ mod tests {
 		assert!(
 			matches!(
 				subscriber.start_announce(path, reflected, RouteCost::default(), 0, Some(assigned), &mut announced),
-				Err(Error::Duplicate)
+				Err(Error::ProtocolViolation)
 			),
 			"the double announce must be reported, not silently dropped",
 		);
@@ -1019,13 +1023,17 @@ mod tests {
 		// nothing was accepted at this path for an acceptance record to hold.
 		let mut hops = crate::OriginList::new();
 		hops.push(crate::Origin::new(7).unwrap()).unwrap();
-		assert!(
-			matches!(
-				subscriber.start_announce(path, hops, RouteCost::default(), 0, Some(assigned), &mut announced),
-				Err(Error::Duplicate)
-			),
-			"a start for a path the peer already advertised must be reported, even though the first was dropped",
-		);
+		let err = subscriber
+			.start_announce(path, hops, RouteCost::default(), 0, Some(assigned), &mut announced)
+			.expect_err(
+				"a start for a path the peer already advertised must be reported, even though the first was dropped",
+			);
+
+		// `lite::session` closes with `to_code()`, and the draft ends the session over this
+		// alongside an unknown or retired announce id. Reporting a narrower code would tell
+		// the peer it hit a different rule than the one it broke.
+		assert!(matches!(err, Error::ProtocolViolation));
+		assert_eq!(err.to_code(), Error::ProtocolViolation.to_code());
 	}
 
 	/// An announce whose chain already names the sender came back through the sender.


### PR DESCRIPTION
Fixes #3050.

## Root cause

`lite::Subscriber` keeps two views of one announce stream and they disagree.

`announced_by_id` assigns every received `ANNOUNCE_START` the next per-stream ordinal, deliberately including announces it drops locally, because the peer numbers them regardless and `ended`/`restart` reference the ordinal rather than repeating the path. The `routes` map held only announces that were *accepted*. So a dropped announce stayed bound to its id while its path read as free:

1. `ANNOUNCE_START` id 0 for path P arrives with a chain that reflects back through us, so it is dropped. Id 0 is still recorded against P.
2. `ANNOUNCE_START` id 1 for path P arrives and is routable. The double-announce check consults `routes`, finds nothing at P, and accepts it.
3. `ANNOUNCE_END` id 0 resolves to P and removes `routes[P]`, which is id 1's route.

Step 2 is also a protocol violation the receiver missed: `draft-lcurley-moq-lite` allows one current advertisement per path on a stream, and the peer sent two starts with no end between them.

Reflected loops are not a corner case. A relay meshed with its own peer drops them routinely, which is what makes step 1 the ordinary path into this.

## The fix

The local *acceptance* record was standing in for the protocol's *advertisement* state. `Announced` replaces it: one record per path holding an `Option<AnnouncedRoute>`, where a declined announce is stored with no route rather than omitted. The id-to-path binding and the one-advertisement rule are then enforced against what the peer actually sent, and an `ANNOUNCE_END` for a declined id retires that record and nothing else.

The four ways an announce is declined (reflected by its sender, chain at `MAX_HOPS`, reflected through us, path outside our scope) all record the advertisement before returning.

`Error::Duplicate` now fires for a second `ANNOUNCE_START` at a path whose first announce we declined, where it previously did not. That is the violation from step 2, and reporting it is the point.

## RESTART

`RESTART` replaces an advertisement that is already live, so it never consults the one-per-path rule, and `restart_announce` becomes its sole handler. It already attached a route when nothing was there, which is what the old "the original announce was dropped locally, so treat it as a fresh start" fallthrough was for; under the new record that path exists either way, so routing a restart through `start_announce` would now trip the duplicate error on a legal restart.

## js/net has the same bug

Second commit. `js/net`'s lite subscriber mirrors the shape exactly: `advertised` records only announces it surfaced, while `announcedById` numbers every one the peer sent, and the reflected-loop branch `continue`s without recording. Same three steps, same outcome.

`advertised` now holds every advertisement the peer has live, carrying `live: false` for one skipped locally. `retract()` is a no-op for an advertisement never surfaced, so retiring a skipped id ends nothing, and a second `ANNOUNCE_START` for an advertised path throws on versions with announce ids, matching `Error::Duplicate`.

## Tests

Rust: `a_dropped_announce_still_holds_its_path` walks steps 1 and 2 and asserts the second start is reported. Fails without the fix.

TypeScript: `an announce skipped as a reflected loop still holds its path` and `retiring an id whose announce was skipped ends nothing` both fail without the fix. `a restart replaces an announce that was skipped as a reflected loop` passes either way and is there to pin that the new declined state does not stop a restart attaching.

## Cross-package sync

No wire, catalog, config, or CLI change: this is receiver-side bookkeeping of messages already defined in `draft-lcurley-moq-lite`, so no draft or doc row applies. The `js/net` row is covered by the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Opus 5)