### PR TITLE
fix(net)!: enforce the loop-free hop chain where chains are built

### DIFF
--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -829,6 +829,10 @@ When forwarding an announcement received from an upstream peer, a relay MUST app
 The first entry of the reconstructed path identifies the original publisher of the broadcast; it is the fallback content identity when `Epoch` is 0 (see [Routing](#routing)).
 A Hop ID value of 0 means the hop is unknown: either it was never assigned or a relay deliberately withholds it (see [Routing](#routing)).
 
+A receiver MUST close the stream with a PROTOCOL_VIOLATION if a non-zero Hop ID appears twice in the reconstructed path.
+An announcement that traversed the same relay twice looped, so neither forwarding it nor subscribing through it is safe.
+Duplicate values of 0 are not a violation, since 0 identifies nothing and any number of hops may be unknown.
+
 **Warm Route Cost** and **Cold Route Cost**:
 What subscribing to the broadcast via this advertisement costs, in units chosen by the deployment, priced against two different cache states.
 The Warm cost is what one more subscription would cost the mesh as it stands, and is what routing minimizes.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -829,7 +829,7 @@ When forwarding an announcement received from an upstream peer, a relay MUST app
 The first entry of the reconstructed path identifies the original publisher of the broadcast; it is the fallback content identity when `Epoch` is 0 (see [Routing](#routing)).
 A Hop ID value of 0 means the hop is unknown: either it was never assigned or a relay deliberately withholds it (see [Routing](#routing)).
 
-A receiver MUST close the stream with a PROTOCOL_VIOLATION if a non-zero Hop ID appears twice in the reconstructed path.
+A receiver MUST close the session with a PROTOCOL_VIOLATION if a non-zero Hop ID appears twice in the reconstructed path.
 An announcement that traversed the same relay twice looped, so neither forwarding it nor subscribing through it is safe.
 Duplicate values of 0 are not a violation, since 0 identifies nothing and any number of hops may be unknown.
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -829,8 +829,7 @@ When forwarding an announcement received from an upstream peer, a relay MUST app
 The first entry of the reconstructed path identifies the original publisher of the broadcast; it is the fallback content identity when `Epoch` is 0 (see [Routing](#routing)).
 A Hop ID value of 0 means the hop is unknown: either it was never assigned or a relay deliberately withholds it (see [Routing](#routing)).
 
-A receiver MUST close the session with a PROTOCOL_VIOLATION if a non-zero Hop ID appears twice in the reconstructed path.
-An announcement that traversed the same relay twice looped, so neither forwarding it nor subscribing through it is safe.
+A receiver MUST close the session with a PROTOCOL_VIOLATION if a non-zero Hop ID appears twice in this list.
 Duplicate values of 0 are not a violation, since 0 identifies nothing and any number of hops may be unknown.
 
 **Warm Route Cost** and **Cold Route Cost**:
@@ -1340,6 +1339,7 @@ The `Message Length` describes the payload size on the wire.
 # Appendix A: Changelog
 
 ## moq-lite-06
+- Made a repeated non-zero Hop ID in one announcement's Hop ID list a PROTOCOL_VIOLATION, matching draft-lcurley-moq-cluster. Repeated 0 entries stay legal.
 - Moved the Qmux-over-WebSocket binding details to draft-lcurley-qmux-websocket; the binding itself is unchanged.
 - Extended the SETUP `Path` parameter to carry the URI query: a client appends `?` and the query component after the path, matching moq-transport's PATH option. The credential a deployment puts in the query was previously unrepresentable on a binding with no request URI.
 - Allowed an empty SETUP `Path` parameter, equivalent to omitting it; both request the server's default path. Previously an empty value was a protocol violation, which made the two ways of asking for the default disagree.

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { ProtocolViolation } from "../error.ts";
 import { OriginSchema } from "../hop.ts";
 import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
@@ -135,7 +136,7 @@ test("a hop chain that revisits a hop is refused in both directions", async () =
 	const eight = OriginSchema.parse(8n);
 	const looped: AnnounceBroadcast = { status: "active", suffix: Path.from("room"), hops: [four, eight, four] };
 
-	// Outbound: refused before it reaches the wire. A receiver must close the stream over
+	// Outbound: refused before it reaches the wire. A receiver must close the session over
 	// a repeated Hop ID, so sending one costs someone else their session.
 	await expect(bytes((w) => encodeAnnounceBroadcast(w, looped, Version.DRAFT_06))).rejects.toThrow("appears twice");
 
@@ -152,6 +153,12 @@ test("a hop chain that revisits a hop is refused in both directions", async () =
 	expect(nine).toBeGreaterThan(0);
 	forged[nine] = 4;
 
+	// The type carries the consequence, not just the text: the subscriber's dispatch closes
+	// the session on `instanceof ProtocolViolation`, so a plain Error here would reset the
+	// stream and leave a nonconforming peer free to repeat itself.
+	await expect(decodeAnnounceBroadcast(new Reader(undefined, forged), Version.DRAFT_06)).rejects.toThrow(
+		ProtocolViolation,
+	);
 	await expect(decodeAnnounceBroadcast(new Reader(undefined, forged), Version.DRAFT_06)).rejects.toThrow(
 		"appears twice",
 	);

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -129,3 +129,40 @@ test("AnnounceRequest drops excludeHop on draft-06", async () => {
 	const with06 = await bytes((w) => msg.encode(w, Version.DRAFT_06));
 	expect(with06.byteLength).toBeLessThan(with05.byteLength);
 });
+
+test("a hop chain that revisits a hop is refused in both directions", async () => {
+	const four = OriginSchema.parse(4n);
+	const eight = OriginSchema.parse(8n);
+	const looped: AnnounceBroadcast = { status: "active", suffix: Path.from("room"), hops: [four, eight, four] };
+
+	// Outbound: refused before it reaches the wire. A receiver must close the stream over
+	// a repeated Hop ID, so sending one costs someone else their session.
+	await expect(bytes((w) => encodeAnnounceBroadcast(w, looped, Version.DRAFT_06))).rejects.toThrow("appears twice");
+
+	// Inbound: encode a chain that is legal, then rewrite its last hop to repeat the
+	// first. Only a non-conforming sender produces these bytes, which is why they have to
+	// be built by hand. Every id here is a one-byte varint, so the length is unchanged.
+	const legal: AnnounceBroadcast = {
+		status: "active",
+		suffix: Path.from("room"),
+		hops: [four, eight, OriginSchema.parse(9n)],
+	};
+	const forged = await bytes((w) => encodeAnnounceBroadcast(w, legal, Version.DRAFT_06));
+	const nine = forged.lastIndexOf(9);
+	expect(nine).toBeGreaterThan(0);
+	forged[nine] = 4;
+
+	await expect(decodeAnnounceBroadcast(new Reader(undefined, forged), Version.DRAFT_06)).rejects.toThrow(
+		"appears twice",
+	);
+
+	// Repeated unknowns are not a loop: 0 identifies nothing, so any number of hops may
+	// be unknown. A lite-03 announcement is nothing but these.
+	const unknown = OriginSchema.parse(0n);
+	const anonymous: AnnounceBroadcast = {
+		status: "active",
+		suffix: Path.from("room"),
+		hops: [unknown, four, unknown],
+	};
+	expect(await roundTrip(anonymous, Version.DRAFT_05)).toEqual(anonymous);
+});

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -57,9 +57,22 @@ export type AnnounceBroadcast =
 	 * chain after a relay failover, or a route whose cost moved). The id stays live. */
 	| { status: "restart"; id: bigint; hops: Origin[]; cost?: Cost };
 
+// Both wire rules on a hop chain, applied to what we send and to what we receive: a
+// chain that revisits a hop looped, so neither forwarding it nor subscribing through it
+// is safe, and a receiver must close the stream over one. `UNKNOWN_ORIGIN` identifies
+// nothing, so any number of hops may be unknown.
 function checkHops(hops: Origin[]) {
 	if (hops.length > MAX_HOPS) {
 		throw new Error(`hop count ${hops.length} exceeds maximum ${MAX_HOPS}`);
+	}
+
+	// MAX_HOPS is 32, so the quadratic scan is cheaper than allocating a set.
+	for (let i = 0; i < hops.length; i++) {
+		const hop = hops[i];
+		if (hop === UNKNOWN_ORIGIN) continue;
+		if (hops.indexOf(hop, i + 1) !== -1) {
+			throw new Error(`hop ${hop} appears twice in the chain`);
+		}
 	}
 }
 
@@ -102,6 +115,7 @@ async function decodeHops(r: Reader, version: Version): Promise<Origin[]> {
 			for (let i = 0; i < count; i++) {
 				hops.push(OriginSchema.parse(await r.u62()));
 			}
+			checkHops(hops);
 			return hops;
 		}
 	}

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -1,3 +1,4 @@
+import { ProtocolViolation } from "../error.ts";
 import { MAX_HOPS, type Origin, OriginSchema, UNKNOWN_ORIGIN } from "../hop.ts";
 import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
@@ -59,11 +60,14 @@ export type AnnounceBroadcast =
 
 // Both wire rules on a hop chain, applied to what we send and to what we receive: a
 // chain that revisits a hop looped, so neither forwarding it nor subscribing through it
-// is safe, and a receiver must close the stream over one. `UNKNOWN_ORIGIN` identifies
+// is safe, and a receiver must end the session over one. `UNKNOWN_ORIGIN` identifies
 // nothing, so any number of hops may be unknown.
+//
+// `ProtocolViolation` so a receipt takes the session down rather than the one stream,
+// matching what `ietf/cluster.ts` throws for the identical rule.
 function checkHops(hops: Origin[]) {
 	if (hops.length > MAX_HOPS) {
-		throw new Error(`hop count ${hops.length} exceeds maximum ${MAX_HOPS}`);
+		throw new ProtocolViolation(`hop count ${hops.length} exceeds maximum ${MAX_HOPS}`);
 	}
 
 	// MAX_HOPS is 32, so the quadratic scan is cheaper than allocating a set.
@@ -71,7 +75,7 @@ function checkHops(hops: Origin[]) {
 		const hop = hops[i];
 		if (hop === UNKNOWN_ORIGIN) continue;
 		if (hops.indexOf(hop, i + 1) !== -1) {
-			throw new Error(`hop ${hop} appears twice in the chain`);
+			throw new ProtocolViolation(`hop ${hop} appears twice in the chain`);
 		}
 	}
 }

--- a/rs/moq-net/src/ietf/cluster.rs
+++ b/rs/moq-net/src/ietf/cluster.rs
@@ -66,8 +66,11 @@ pub fn supported(version: Version) -> bool {
 pub struct HopPath(OriginList);
 
 impl HopPath {
-	/// Wrap a hop chain. The list must be non-empty and free of repeated non-zero
-	/// entries to be legal on the wire; [`Self::validate`] is what checks that.
+	/// Wrap a hop chain.
+	///
+	/// [`OriginList`] already refuses a repeated non-zero entry, so the only wire rule
+	/// left to check is that the list is non-empty; [`Self::validate`] does that on
+	/// decode, where an empty parameter can arrive.
 	pub fn new(hops: OriginList) -> Self {
 		Self(hops)
 	}
@@ -77,26 +80,16 @@ impl HopPath {
 		&self.0
 	}
 
-	/// Reject a path that cannot have come from a conforming sender: an empty list, or
-	/// a non-zero Hop ID appearing twice (a loop). Duplicate zeros are legal, since 0
-	/// identifies nothing.
+	/// Reject a path that cannot have come from a conforming sender.
+	///
+	/// Only the empty list is left to catch: the other rule, that a non-zero Hop ID may
+	/// not appear twice, is enforced by [`OriginList`] wherever a chain is built, so it
+	/// holds on the outbound path too rather than only where one was parsed.
 	fn validate(&self) -> Result<(), DecodeError> {
-		if self.0.is_empty() {
-			return Err(DecodeError::InvalidValue);
+		match self.0.is_empty() {
+			true => Err(DecodeError::InvalidValue),
+			false => Ok(()),
 		}
-
-		// MAX_HOPS is 32, so the quadratic scan is cheaper than allocating a set.
-		let hops = self.0.as_slice();
-		for (i, hop) in hops.iter().enumerate() {
-			if *hop == Origin::UNKNOWN {
-				continue;
-			}
-			if hops[i + 1..].contains(hop) {
-				return Err(DecodeError::InvalidValue);
-			}
-		}
-
-		Ok(())
 	}
 }
 
@@ -145,9 +138,15 @@ impl Advert {
 	/// Build the advertisement to send for a route, appending our own Hop ID.
 	///
 	/// A relay's own ID is always the last entry, so a receiver reconstructs the full
-	/// path without the sender restating it. Fails once the chain is at
-	/// [`MAX_HOPS`](crate::TooManyOrigins), which a real path never reaches and a loop does.
-	pub fn forward(hops: &OriginList, cost: u64, self_origin: Origin) -> Result<Self, crate::TooManyOrigins> {
+	/// path without the sender restating it.
+	///
+	/// Fails for a chain this cannot be legally appended to: one already at
+	/// [`MAX_HOPS`](crate::InvalidHop::TooMany), which a real path never reaches and a
+	/// loop does, or one that already names us. Either is a loop, and the caller's job
+	/// is to advertise a different route rather than send this one: a receiver must
+	/// close the session over a repeated Hop ID, so a malformed chain we build costs
+	/// someone else their session rather than degrading our own routing.
+	pub fn forward(hops: &OriginList, cost: u64, self_origin: Origin) -> Result<Self, crate::InvalidHop> {
 		let mut hops = hops.clone();
 		hops.push(self_origin)?;
 		Ok(Self {
@@ -345,14 +344,49 @@ mod tests {
 
 	#[test]
 	fn hop_path_rejects_repeated_hop() {
-		// A non-zero id appearing twice is a loop, which the receiver must reject.
+		// A non-zero id appearing twice is a loop, which the receiver must reject. The
+		// bytes are forged rather than encoded from a `HopPath`, because `OriginList`
+		// no longer lets one be built: only a non-conforming sender produces this.
+		let mut value = Vec::new();
+		for id in [4u64, 8, 4] {
+			origin(id).encode(&mut value, VERSION).unwrap();
+		}
+
 		let mut buf = BytesMut::new();
-		hop_path(&[4, 8, 4]).param_encode(&mut buf, VERSION).unwrap();
+		value.encode(&mut buf, VERSION).unwrap();
+
 		let mut bytes = buf.freeze();
 		assert!(matches!(
 			HopPath::param_decode(&mut bytes, VERSION),
 			Err(DecodeError::InvalidValue)
 		));
+	}
+
+	/// The rule the receiver enforces has to hold on the way out too. A chain that
+	/// already names us, or one with no room left, cannot be appended to, and the
+	/// caller's job is to advertise a different route rather than send this one: a
+	/// receiver must close the session over a repeated Hop ID, so a malformed chain we
+	/// build costs someone else their session rather than degrading our own routing.
+	#[test]
+	fn forward_refuses_a_chain_it_cannot_extend() {
+		let mut hops = OriginList::new();
+		hops.push(origin(1)).unwrap();
+		hops.push(origin(3)).unwrap();
+
+		assert_eq!(
+			Advert::forward(&hops, 5, origin(3)),
+			Err(crate::InvalidHop::Duplicate),
+			"appending an id the chain already names must not produce an advertisement"
+		);
+
+		// Fill the chain with distinct ids, so the next append fails on length rather
+		// than on the id already being there.
+		let mut full = OriginList::new();
+		let mut next = 1;
+		while full.push(origin(next)).is_ok() {
+			next += 1;
+		}
+		assert_eq!(Advert::forward(&full, 0, origin(next)), Err(crate::InvalidHop::TooMany));
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -303,8 +303,12 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// the route is attributable to the upstream session, without changing
 		// the hop count (shortest-path selection and the MAX_HOPS limit stay
 		// accurate). Lite01/02 send no placeholders; they're covered below.
-		if self.version_lacks_hops() {
-			hops.replace_first(crate::Origin::UNKNOWN, self.session_origin);
+		//
+		// The rewrite fails if the chain already names this session, which would put one
+		// id in it twice: a loop, and one a cluster receiver must close the session over.
+		if self.version_lacks_hops() && hops.replace_first(crate::Origin::UNKNOWN, self.session_origin).is_err() {
+			tracing::debug!(broadcast = %self.log_path(&path), "dropping announce reflected by its session");
+			return Ok(false);
 		}
 
 		// Guarantee at least one attributable hop for versions that did not provide
@@ -314,7 +318,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// the AnnounceOk is read).
 		if hops.is_empty() {
 			hops.push(self.session_origin)
-				.expect("an empty hop chain always has room for one entry");
+				.expect("an empty hop chain always has room for one entry, and repeats nothing");
 		}
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -247,9 +247,9 @@ impl Route {
 
 	/// Append a hop to the chain, oldest first.
 	///
-	/// Fails with [`crate::TooManyOrigins`] once the chain is full, the same limit
-	/// the wire enforces.
-	pub fn with_hop(mut self, origin: super::Origin) -> Result<Self, super::TooManyOrigins> {
+	/// Fails with [`crate::InvalidHop`] for a hop the wire would reject: one past the
+	/// chain's length cap, or one already in it, which is a loop.
+	pub fn with_hop(mut self, origin: super::Origin) -> Result<Self, super::InvalidHop> {
 		self.hops.push(origin)?;
 		Ok(self)
 	}

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -46,7 +46,7 @@ pub mod announce {
 
 // Origin identity and the `Consume` conversion trait aren't part of a role
 // module; keep them flat at the crate root.
-pub use origin_impl::{Consume, InvalidOrigin, Origin, OriginList, TooManyOrigins};
+pub use origin_impl::{Consume, InvalidHop, InvalidOrigin, Origin, OriginList};
 
 #[cfg(test)]
 pub(crate) use origin_impl::ProduceTest;

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -285,19 +285,27 @@ impl OriginList {
 	/// Replace the first entry equal to `target` with `replacement`, returning
 	/// true if a match was found. The length is unchanged.
 	///
-	/// Fails with [`InvalidHop::Duplicate`] if `replacement` is already in the chain,
-	/// since naming it twice is the loop [`Self::push`] refuses to build.
+	/// Fails with [`InvalidHop::Duplicate`] only when the rewrite would actually name
+	/// `replacement` twice, which is the loop [`Self::push`] refuses to build. A `target`
+	/// that is not present changes nothing and so cannot duplicate anything, and the slot
+	/// being overwritten is not a duplicate of itself.
 	pub fn replace_first(&mut self, target: Origin, replacement: Origin) -> Result<bool, InvalidHop> {
-		if replacement != Origin::UNKNOWN && self.0.contains(&replacement) {
+		let Some(index) = self.0.iter().position(|entry| *entry == target) else {
+			return Ok(false);
+		};
+
+		if replacement != Origin::UNKNOWN
+			&& self
+				.0
+				.iter()
+				.enumerate()
+				.any(|(i, entry)| i != index && *entry == replacement)
+		{
 			return Err(InvalidHop::Duplicate);
 		}
-		for entry in &mut self.0 {
-			if *entry == target {
-				*entry = replacement;
-				return Ok(true);
-			}
-		}
-		Ok(false)
+
+		self.0[index] = replacement;
+		Ok(true)
 	}
 
 	/// Returns true if any entry matches `origin`.
@@ -5261,6 +5269,24 @@ mod tests {
 		assert_eq!(
 			list.replace_first(Origin::UNKNOWN, Origin::new(7).unwrap()),
 			Err(InvalidHop::Duplicate)
+		);
+
+		// A target that is not there changes nothing, so it cannot duplicate anything,
+		// however many times the replacement already appears.
+		assert_eq!(
+			list.replace_first(Origin::new(99).unwrap(), Origin::new(7).unwrap()),
+			Ok(false)
+		);
+
+		// Overwriting a slot with what it already holds is a no-op, not a duplicate: the
+		// entry being replaced is not a second occurrence of itself.
+		assert_eq!(
+			list.replace_first(Origin::new(7).unwrap(), Origin::new(7).unwrap()),
+			Ok(true)
+		);
+		assert_eq!(
+			list.as_slice(),
+			&[Origin::new(7).unwrap(), Origin::UNKNOWN, Origin::UNKNOWN]
 		);
 	}
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -212,33 +212,51 @@ where
 /// Maximum number of origins (hops) an [`OriginList`] can hold.
 ///
 /// Caps pathological or loop-induced announcements at a reasonable cluster
-/// diameter; appending past this limit returns [`TooManyOrigins`] rather than
+/// diameter; appending past this limit returns [`InvalidHop::TooMany`] rather than
 /// silently truncating.
 pub(crate) const MAX_HOPS: usize = 32;
 
-/// Bounded list of [`Origin`] entries, typically the hop chain of a broadcast.
+/// Bounded, loop-free list of [`Origin`] entries: the hop chain of a broadcast.
 ///
-/// Guarantees `len() <= MAX_HOPS`. Construct via [`OriginList::new`] +
-/// [`OriginList::push`], or fall back to the fallible [`TryFrom<Vec<Origin>>`].
+/// Guarantees `len() <= MAX_HOPS` and that no non-zero [`Origin`] appears twice. Both
+/// are wire rules, and both hold wherever a list exists rather than only where one was
+/// parsed, so a chain that a conforming receiver would reject cannot be built and sent.
+/// Construct via [`OriginList::new`] + [`OriginList::push`], or fall back to the
+/// fallible [`TryFrom<Vec<Origin>>`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct OriginList(Vec<Origin>);
 
-/// Returned when an operation would grow an [`OriginList`] past its hop-count cap.
+/// Why an [`Origin`] cannot join an [`OriginList`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct TooManyOrigins;
+pub enum InvalidHop {
+	/// The list is already at its hop-count cap, which a real path never reaches and a
+	/// loop does.
+	TooMany,
 
-impl fmt::Display for TooManyOrigins {
+	/// The id is already in the list. A chain that revisits a hop looped, which every
+	/// receiver of it must reject, so it must not be built in the first place. The
+	/// reserved id 0 identifies nothing and may repeat.
+	Duplicate,
+}
+
+impl fmt::Display for InvalidHop {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "too many origins (max {MAX_HOPS})")
+		match self {
+			Self::TooMany => write!(f, "too many origins (max {MAX_HOPS})"),
+			Self::Duplicate => write!(f, "origin already in the hop chain"),
+		}
 	}
 }
 
-impl std::error::Error for TooManyOrigins {}
+impl std::error::Error for InvalidHop {}
 
-impl From<TooManyOrigins> for DecodeError {
-	fn from(_: TooManyOrigins) -> Self {
-		DecodeError::BoundsExceeded
+impl From<InvalidHop> for DecodeError {
+	fn from(err: InvalidHop) -> Self {
+		match err {
+			InvalidHop::TooMany => DecodeError::BoundsExceeded,
+			InvalidHop::Duplicate => DecodeError::InvalidValue,
+		}
 	}
 }
 
@@ -248,10 +266,17 @@ impl OriginList {
 		Self(Vec::new())
 	}
 
-	/// Append an [`Origin`]. Returns [`TooManyOrigins`] if the list is full.
-	pub fn push(&mut self, origin: Origin) -> Result<(), TooManyOrigins> {
+	/// Append an [`Origin`], rejecting anything a conforming receiver would.
+	///
+	/// Fails with [`InvalidHop::TooMany`] once the list is full, and with
+	/// [`InvalidHop::Duplicate`] for an id already in the chain, which is a loop. The
+	/// reserved id 0 identifies nothing, so it may repeat.
+	pub fn push(&mut self, origin: Origin) -> Result<(), InvalidHop> {
 		if self.0.len() >= MAX_HOPS {
-			return Err(TooManyOrigins);
+			return Err(InvalidHop::TooMany);
+		}
+		if origin != Origin::UNKNOWN && self.0.contains(&origin) {
+			return Err(InvalidHop::Duplicate);
 		}
 		self.0.push(origin);
 		Ok(())
@@ -259,14 +284,20 @@ impl OriginList {
 
 	/// Replace the first entry equal to `target` with `replacement`, returning
 	/// true if a match was found. The length is unchanged.
-	pub fn replace_first(&mut self, target: Origin, replacement: Origin) -> bool {
+	///
+	/// Fails with [`InvalidHop::Duplicate`] if `replacement` is already in the chain,
+	/// since naming it twice is the loop [`Self::push`] refuses to build.
+	pub fn replace_first(&mut self, target: Origin, replacement: Origin) -> Result<bool, InvalidHop> {
+		if replacement != Origin::UNKNOWN && self.0.contains(&replacement) {
+			return Err(InvalidHop::Duplicate);
+		}
 		for entry in &mut self.0 {
 			if *entry == target {
 				*entry = replacement;
-				return true;
+				return Ok(true);
 			}
 		}
-		false
+		Ok(false)
 	}
 
 	/// Returns true if any entry matches `origin`.
@@ -296,11 +327,17 @@ impl OriginList {
 }
 
 impl TryFrom<Vec<Origin>> for OriginList {
-	type Error = TooManyOrigins;
+	type Error = InvalidHop;
 
 	fn try_from(v: Vec<Origin>) -> Result<Self, Self::Error> {
 		if v.len() > MAX_HOPS {
-			return Err(TooManyOrigins);
+			return Err(InvalidHop::TooMany);
+		}
+		// MAX_HOPS is 32, so the quadratic scan is cheaper than allocating a set.
+		for (i, origin) in v.iter().enumerate() {
+			if *origin != Origin::UNKNOWN && v[i + 1..].contains(origin) {
+				return Err(InvalidHop::Duplicate);
+			}
 		}
 		Ok(Self(v))
 	}
@@ -339,11 +376,13 @@ where
 		if count > MAX_HOPS {
 			return Err(DecodeError::BoundsExceeded);
 		}
-		let mut list = Vec::with_capacity(count);
+		// Through `push`, so a chain that revisits a hop is rejected here rather than
+		// entering the model and being forwarded on to a receiver that must close on it.
+		let mut list = Self(Vec::with_capacity(count));
 		for _ in 0..count {
-			list.push(Origin::decode(r, version)?);
+			list.push(Origin::decode(r, version)?)?;
 		}
-		Ok(Self(list))
+		Ok(list)
 	}
 }
 
@@ -5173,7 +5212,26 @@ mod tests {
 			list.push(Origin::random()).unwrap();
 		}
 		assert_eq!(list.len(), MAX_HOPS);
-		assert_eq!(list.push(Origin::random()), Err(TooManyOrigins));
+		assert_eq!(list.push(Origin::random()), Err(InvalidHop::TooMany));
+	}
+
+	/// A chain that revisits a hop looped, and every receiver of one must close the
+	/// session over it. Refusing it here is what keeps that unbuildable rather than a
+	/// rule each place that constructs a chain has to remember.
+	#[test]
+	fn origin_list_push_rejects_a_repeat() {
+		let seven = Origin::new(7).unwrap();
+		let mut list = OriginList::new();
+		list.push(seven).unwrap();
+		list.push(Origin::new(9).unwrap()).unwrap();
+
+		assert_eq!(list.push(seven), Err(InvalidHop::Duplicate));
+		assert_eq!(list.len(), 2, "a refused push must not grow the chain");
+
+		// 0 identifies nothing, so two unknown hops are two hops, not a loop.
+		list.push(Origin::UNKNOWN).unwrap();
+		list.push(Origin::UNKNOWN).unwrap();
+		assert_eq!(list.len(), 4);
 	}
 
 	#[test]
@@ -5184,15 +5242,26 @@ mod tests {
 		}
 
 		// Rewrites only the first placeholder, keeping the length the same.
-		assert!(list.replace_first(Origin::UNKNOWN, Origin::new(7).unwrap()));
+		assert!(list.replace_first(Origin::UNKNOWN, Origin::new(7).unwrap()).unwrap());
 		assert_eq!(
 			list.as_slice(),
 			&[Origin::new(7).unwrap(), Origin::UNKNOWN, Origin::UNKNOWN]
 		);
 
 		// No match leaves the list untouched.
-		assert!(!list.replace_first(Origin::new(99).unwrap(), Origin::new(8).unwrap()));
+		assert!(
+			!list
+				.replace_first(Origin::new(99).unwrap(), Origin::new(8).unwrap())
+				.unwrap()
+		);
 		assert_eq!(list.len(), 3);
+
+		// Writing in an id the chain already carries would name it twice, which is the
+		// loop `push` refuses; the rewrite has to refuse it for the same reason.
+		assert_eq!(
+			list.replace_first(Origin::UNKNOWN, Origin::new(7).unwrap()),
+			Err(InvalidHop::Duplicate)
+		);
 	}
 
 	#[test]
@@ -5201,7 +5270,15 @@ mod tests {
 		assert!(OriginList::try_from(under).is_ok());
 
 		let over: Vec<Origin> = (0..MAX_HOPS + 1).map(|_| Origin::random()).collect();
-		assert_eq!(OriginList::try_from(over), Err(TooManyOrigins));
+		assert_eq!(OriginList::try_from(over), Err(InvalidHop::TooMany));
+
+		// The other wire rule, on the path that skips `push` entirely.
+		let seven = Origin::new(7).unwrap();
+		assert_eq!(
+			OriginList::try_from(vec![seven, Origin::new(9).unwrap(), seven]),
+			Err(InvalidHop::Duplicate)
+		);
+		assert!(OriginList::try_from(vec![Origin::UNKNOWN, seven, Origin::UNKNOWN]).is_ok());
 	}
 
 	/// Exact lookups and eligible announcements land synchronously in


### PR DESCRIPTION
Fixes #3049. Targets `dev`: it changes the error type on published `moq-net` API.

## Root cause

`HopPath::validate` ran only on decode, so nothing stopped us constructing and sending an outbound HOP_PATH that a conforming receiver must reject. `Advert::forward` appended our own Hop ID and wrapped the result without revalidating, and the encode path checked nothing, so a `broadcast::Route` whose `hops` already carried a duplicate went out as-is.

`draft-lcurley-moq-cluster` makes that the receiver's problem: *"A receiver MUST close the session with a PROTOCOL_VIOLATION if the entries do not exactly fill `Length`, if the list is empty, or if a non-zero Hop ID appears twice."* So a malformed chain we build does not degrade our own routing. It closes someone else's session.

Routes reach the model from more than one place and only the IETF decode path was checked:

- The moq-lite ingress builds hop chains itself. `OriginList` capped length without rejecting duplicates, so a lite chain could legally carry one and, once shared through the origin, be forwarded to an IETF cluster peer.
- `broadcast::Route` is public with a public `hops` field, so any in-process producer could attach one.

The general shape is that validity was enforced where a chain is *parsed* rather than where one *exists*, so every new route source had to remember the rule again.

## The fix

Move the rule into `OriginList`, which is where the state lives. `push` and `TryFrom<Vec<Origin>>` reject a repeated non-zero id; `Decode` goes through `push`, so a looped chain never enters the model rather than being caught later; `replace_first` refuses a replacement already in the chain, since writing one in names it twice by another door.

Two things fall out:

- `HopPath::validate` is left with only the empty-list check. The duplicate rule now holds on the outbound path too, not just where a parameter was parsed.
- `Advert::forward` fails on a chain it cannot legally extend, and `Publisher::select` already advances to the next route on that error. So a route that cannot be advertised is *skipped* rather than emitted, and stays servable by exact path — which is what the issue asked for, since a route that is illegal to advertise may still be fine to serve locally.

`Origin::UNKNOWN` identifies nothing, so duplicate zeros stay legal. That is the whole of a lite-03 chain, and it is what #3060 changes next.

## The lite draft never stated the rule

That asymmetry is what let the two dialects disagree, and it was not deliberate. `draft-lcurley-moq-lite` now says it in the same words as the cluster draft, alongside the existing Hop Count rule. Validated with `just drafts check`.

## Breaking change

- `OriginList::push` and `TryFrom<Vec<Origin>>` return `InvalidHop` (`TooMany` / `Duplicate`) instead of `TooManyOrigins`, which is removed.
- `OriginList::replace_first` returns `Result<bool, InvalidHop>`.
- `Route::with_hop` and `cluster::Advert::forward` carry the new error.

Outside `moq-net` these are named only by tests and `moq-relay/src/nodes.rs`.

## Tests

- `origin_list_push_rejects_a_repeat` and the `try_from` case cover both construction paths, including that repeated zeros stay legal.
- `origin_list_replace_first` covers the rewrite refusing an id already in the chain.
- `forward_refuses_a_chain_it_cannot_extend` covers the outbound half: a chain that already names us, and one with no room left.
- `hop_path_rejects_repeated_hop` now forges its bytes, because `OriginList` no longer lets an invalid chain be built. That is the change working, and the test still proves decode rejects one arriving from a non-conforming sender.

## Cross-package sync

- `drafts/draft-lcurley-moq-lite.md`: the new receiver MUST (wire spec change).
- `js/net`: third commit. `checkHops` guarded only length and only on encode; it now applies both rules in both directions, with a test that patches a valid encoding into a looped one.
- `just test smoke-full` passes: all 21 publisher/subscriber pairs across rust, python, js, js-native-node, js-native-bun, c, and gst.

## Follow-up

#3060 extends the same rule to ban 0 from chains entirely, which is what closes #3053. This is its prerequisite: it is what makes an invalid chain unbuildable rather than something each ingress path remembers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Opus 5)