### PR TITLE
fix(watch): drop the audio ring's stale tail on a track change

### DIFF
--- a/js/watch/src/audio/buffer.ts
+++ b/js/watch/src/audio/buffer.ts
@@ -1,6 +1,6 @@
 import { Time } from "@moq/net";
 import { Effect, type Getter, Signal } from "@moq/signals";
-import type { Data, InitPost, InitShared, Latency, Reset, State } from "./render";
+import type { Data, InitPost, InitShared, Latency, Reset, State, Truncate } from "./render";
 import { allocSharedRingBuffer, SharedRingBuffer } from "./shared-ring-buffer";
 
 /**
@@ -76,6 +76,15 @@ export interface AudioBuffer {
 
 	/** Flush buffered samples and re-stall, ready to anchor the next utterance (buffered mode). */
 	reset(): void;
+
+	/**
+	 * Drop buffered samples at or after `timestamp`, keeping what is already due.
+	 *
+	 * Used when a new track takes over the timeline: its samples overwrite the slots they land on,
+	 * but the previous track's write-ahead tail would otherwise play once the new audio runs out.
+	 * Unlike `reset()` this keeps playing, so there's no gap at the handover.
+	 */
+	truncate(timestamp: Time.Micro): void;
 
 	/**
 	 * Resolve once the playhead is near enough to decode a frame at `timestamp`. In buffered mode this
@@ -189,6 +198,10 @@ class SharedAudioBuffer implements AudioBuffer {
 		}
 	}
 
+	truncate(timestamp: Time.Micro): void {
+		this.#ring.truncate(timestamp);
+	}
+
 	reset(): void {
 		this.#ring.reset();
 		this.#backpressure.flush(); // the old timeline is gone; let the decode loop re-anchor
@@ -265,6 +278,11 @@ class PostAudioBuffer implements AudioBuffer {
 
 		const latency = Time.Milli.fromSecond((samples / this.rate) as Time.Second);
 		const msg: Latency = { type: "latency", latency };
+		this.#worklet.port.postMessage(msg);
+	}
+
+	truncate(timestamp: Time.Micro): void {
+		const msg: Truncate = { type: "truncate", timestamp };
 		this.#worklet.port.postMessage(msg);
 	}
 

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -103,6 +103,11 @@ export class Decoder {
 	// cushion) versus a decrease or a real-time RTT wiggle. See #runLatencyReanchor.
 	#prevFloor?: Bound;
 
+	// The track the current subscription was opened on, and whether the next decoded frame takes
+	// over the timeline from a different one. See #runDecoder.
+	#prevTrack?: string;
+	#truncatePending = false;
+
 	#signals = new Effect();
 
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
@@ -261,6 +266,14 @@ export class Decoder {
 
 		const track = effect.get(this.source.out.track);
 		if (!track) return;
+
+		// The ring outlives this effect (it's keyed on the sample rate and channel count), so a track
+		// swap leaves whatever the previous track decoded still buffered. Its samples are timestamp
+		// indexed, so the successor overwrites the slots it lands on, but a publisher writing ahead of
+		// real-time can leave seconds of tail beyond them. Drop it once the successor's first frame
+		// tells us where the new timeline starts.
+		if (this.#prevTrack !== undefined && this.#prevTrack !== track) this.#truncatePending = true;
+		this.#prevTrack = track;
 
 		const config = effect.get(this.source.out.config);
 		if (!config) return;
@@ -492,6 +505,14 @@ export class Decoder {
 		const durationMilli = Time.Milli.fromMicro(durationMicro);
 		const end = Time.Milli.add(timestampMilli, durationMilli);
 
+		// A new track has taken over the timeline: drop the previous one's write-ahead tail rather
+		// than letting it play out after this frame. See #runDecoder.
+		if (this.#truncatePending) {
+			this.#truncatePending = false;
+			ring.truncate(timestamp);
+			this.#truncateDecodeBuffered(timestampMilli);
+		}
+
 		// Add to decode buffer
 		this.#addDecodeBuffered(timestampMilli, end);
 
@@ -527,6 +548,15 @@ export class Decoder {
 
 			current.push({ start, end });
 			current.sort((a, b) => a.start - b.start);
+		});
+	}
+
+	// Drop reported decode ranges at or after `timestamp`, mirroring a ring truncation.
+	#truncateDecodeBuffered(timestamp: Time.Milli): void {
+		this.#decodeBuffered.mutate((current) => {
+			while (current.length > 0 && current[current.length - 1].start >= timestamp) current.pop();
+			const last = current[current.length - 1];
+			if (last && last.end > timestamp) last.end = timestamp;
 		});
 	}
 

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -8,6 +8,7 @@ import { base64ToBytes } from "../base64";
 
 import { type Bound, latencyBounds, type Sync } from "../sync";
 import { type AudioBuffer, createAudioBuffer } from "./buffer";
+import { Handover } from "./handover";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
@@ -103,10 +104,8 @@ export class Decoder {
 	// cushion) versus a decrease or a real-time RTT wiggle. See #runLatencyReanchor.
 	#prevFloor?: Bound;
 
-	// The track the current subscription was opened on, and whether the next decoded frame takes
-	// over the timeline from a different one. See #runDecoder.
-	#prevTrack?: string;
-	#truncatePending = false;
+	// Which subscription the ring's buffered samples came from. See #runDecoder.
+	#handover = new Handover();
 
 	#signals = new Effect();
 
@@ -267,14 +266,6 @@ export class Decoder {
 		const track = effect.get(this.source.out.track);
 		if (!track) return;
 
-		// The ring outlives this effect (it's keyed on the sample rate and channel count), so a track
-		// swap leaves whatever the previous track decoded still buffered. Its samples are timestamp
-		// indexed, so the successor overwrites the slots it lands on, but a publisher writing ahead of
-		// real-time can leave seconds of tail beyond them. Drop it once the successor's first frame
-		// tells us where the new timeline starts.
-		if (this.#prevTrack !== undefined && this.#prevTrack !== track) this.#truncatePending = true;
-		this.#prevTrack = track;
-
 		const config = effect.get(this.source.out.config);
 		if (!config) return;
 
@@ -282,6 +273,13 @@ export class Decoder {
 		// broadcast instead of the catalog's own broadcast.
 		const active = broadcast.relativeBroadcast(effect, config.broadcast);
 		if (!active) return;
+
+		// The ring outlives this effect (it's keyed on the sample rate and channel count), so a
+		// replacement subscription (a rendition swap, a republished broadcast, a reconnect) inherits
+		// whatever its predecessor decoded. Samples are timestamp indexed, so the replacement
+		// overwrites the slots it lands on, but a publisher writing ahead of real-time leaves seconds
+		// of tail beyond them. Drop that once the replacement's first frame says where it starts.
+		this.#handover.opened();
 
 		const sub = active.track(track).subscribe({ priority: Catalog.PRIORITY.audio });
 		effect.cleanup(() => sub.close());
@@ -505,10 +503,9 @@ export class Decoder {
 		const durationMilli = Time.Milli.fromMicro(durationMicro);
 		const end = Time.Milli.add(timestampMilli, durationMilli);
 
-		// A new track has taken over the timeline: drop the previous one's write-ahead tail rather
-		// than letting it play out after this frame. See #runDecoder.
-		if (this.#truncatePending) {
-			this.#truncatePending = false;
+		// A new subscription has taken over the timeline: drop the previous one's write-ahead tail
+		// rather than letting it play out after this frame. See #runDecoder.
+		if (this.#handover.takeover()) {
 			ring.truncate(timestamp);
 			this.#truncateDecodeBuffered(timestampMilli);
 		}

--- a/js/watch/src/audio/handover.test.ts
+++ b/js/watch/src/audio/handover.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { Handover } from "./handover";
+
+describe("handover", () => {
+	it("does not take over for the first subscription", () => {
+		const handover = new Handover();
+		handover.opened();
+		expect(handover.takeover()).toBe(false);
+	});
+
+	it("takes over on the first frame of a replacement, and only that frame", () => {
+		const handover = new Handover();
+		handover.opened();
+		handover.takeover();
+
+		handover.opened();
+		expect(handover.takeover()).toBe(true);
+		// The rest of the replacement's audio is its own; only its first frame drops the tail.
+		expect(handover.takeover()).toBe(false);
+	});
+
+	it("takes over once no matter how many subscriptions came and went", () => {
+		// The decoder effect can rerun several times before a frame decodes (a rendition swap
+		// landing mid-reconnect, say). The ring only needs dropping once, at the survivor's frame.
+		const handover = new Handover();
+		handover.opened();
+		handover.opened();
+		handover.opened();
+
+		expect(handover.takeover()).toBe(true);
+		expect(handover.takeover()).toBe(false);
+	});
+});

--- a/js/watch/src/audio/handover.ts
+++ b/js/watch/src/audio/handover.ts
@@ -1,0 +1,25 @@
+/**
+ * Tracks whether the audio ring still holds samples from a superseded subscription.
+ *
+ * The ring outlives the subscription that fills it, so reopening one (a rendition swap, a
+ * republished broadcast, a reconnect) leaves the previous subscription's decoded audio buffered.
+ * The replacement is the authority from its first frame onwards, so everything the ring holds past
+ * that timestamp is stale and has to go.
+ */
+export class Handover {
+	#open = false;
+	#pending = false;
+
+	/** Record a subscription opening on the current ring. */
+	opened(): void {
+		if (this.#open) this.#pending = true;
+		this.#open = true;
+	}
+
+	/** Consume one decoded frame and report whether it is the first of a replacement subscription. */
+	takeover(): boolean {
+		const pending = this.#pending;
+		this.#pending = false;
+		return pending;
+	}
+}

--- a/js/watch/src/audio/render-worklet.ts
+++ b/js/watch/src/audio/render-worklet.ts
@@ -27,6 +27,9 @@ class Render extends AudioWorkletProcessor {
 			} else if (msg.type === "latency") {
 				// Only meaningful in post mode.
 				if (this.#backend instanceof AudioRingBuffer) this.#backend.resize(msg.latency);
+			} else if (msg.type === "truncate") {
+				// Only meaningful in post mode; shared mode truncates via the control array.
+				if (this.#backend instanceof AudioRingBuffer) this.#backend.truncate(msg.timestamp);
 			} else if (msg.type === "reset") {
 				// Only meaningful in post mode; shared mode resets via the control array.
 				if (this.#backend instanceof AudioRingBuffer) this.#backend.reset();

--- a/js/watch/src/audio/render.ts
+++ b/js/watch/src/audio/render.ts
@@ -1,7 +1,7 @@
 import type { Time } from "@moq/net";
 import type { SharedRingBufferInit } from "./shared-ring-buffer";
 
-export type Message = InitShared | InitPost | Data | Latency | Reset;
+export type Message = InitShared | InitPost | Data | Latency | Reset | Truncate;
 export type ToMain = State;
 
 /** Init message when SharedArrayBuffer is available. */
@@ -23,6 +23,15 @@ export interface InitPost {
 /** Flush the buffer and re-stall (fallback path only; shared path resets via Atomics). */
 export interface Reset {
 	type: "reset";
+}
+
+/**
+ * Drop buffered samples at or after `timestamp`, keeping what is already due (fallback path only;
+ * the shared path truncates via Atomics).
+ */
+export interface Truncate {
+	type: "truncate";
+	timestamp: Time.Micro;
 }
 
 /** Audio samples sent via postMessage (fallback path only). */

--- a/js/watch/src/audio/render.ts
+++ b/js/watch/src/audio/render.ts
@@ -1,6 +1,7 @@
 import type { Time } from "@moq/net";
 import type { SharedRingBufferInit } from "./shared-ring-buffer";
 
+/** Everything the main thread sends the render worklet over its port. */
 export type Message = InitShared | InitPost | Data | Latency | Reset | Truncate;
 export type ToMain = State;
 

--- a/js/watch/src/audio/ring-buffer.test.ts
+++ b/js/watch/src/audio/ring-buffer.test.ts
@@ -714,6 +714,37 @@ describe("buffered mode", () => {
 		expect(Time.Milli.fromMicro(buffer.timestamp)).toBe(100 as Time.Milli);
 		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.2, 5);
 	});
+
+	it("truncate drops the write-ahead tail a successor supersedes", () => {
+		// 600ms floor at 1000Hz -> 1200-sample ring, holding a 1s write-ahead utterance.
+		const buffer = createBuffered(600);
+		for (let i = 0; i < 10; i++) {
+			write(buffer, (2000 + i * 100) as Time.Milli, 100, { channels: 1, value: 0.1 });
+		}
+		read(buffer, 100, 1); // playhead at 2100
+
+		// A successor track takes over at 2200 with 100ms of its own audio. Writing it only overwrites
+		// [2200, 2300); without the truncate, [2300, 3000) of the old track still plays after it.
+		buffer.truncate(Time.Micro.fromMilli(2200 as Time.Milli));
+		write(buffer, 2200 as Time.Milli, 100, { channels: 1, value: 0.9 });
+
+		expect(buffer.stalled).toBe(false); // truncate keeps playing, unlike reset()
+		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.1, 5); // [2100, 2200) was already due
+		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.9, 5); // the successor
+		expect(read(buffer, 100, 1)[0].length).toBe(0); // and nothing after it
+	});
+
+	it("truncate never rewinds past the playhead", () => {
+		const buffer = createBuffered(600);
+		write(buffer, 2000 as Time.Milli, 1000, { channels: 1, value: 0.1 });
+		read(buffer, 100, 1); // playhead at 2100
+
+		// A successor whose first frame predates the playhead: those samples are already due, so the
+		// write index floors there rather than going backwards.
+		buffer.truncate(Time.Micro.fromMilli(1000 as Time.Milli));
+		expect(buffer.length).toBe(0);
+		expect(read(buffer, 100, 1)[0].length).toBe(0);
+	});
 });
 
 describe("latency increase re-anchor", () => {

--- a/js/watch/src/audio/ring-buffer.ts
+++ b/js/watch/src/audio/ring-buffer.ts
@@ -177,6 +177,19 @@ export class AudioRingBuffer {
 		}
 	}
 
+	/**
+	 * Drop buffered samples at or after `timestamp`, keeping whatever is already due.
+	 *
+	 * A successor track overwrites the slots its own samples land on, but anything the previous
+	 * track wrote beyond them would otherwise still play once the successor runs out.
+	 */
+	truncate(timestamp: Time.Micro): void {
+		const target = Math.round(Time.Second.fromMicro(timestamp) * this.rate);
+		if (target >= this.#writeIndex) return;
+		// Never retreat past the playhead: those samples are already due.
+		this.#writeIndex = Math.max(target, this.#readIndex);
+	}
+
 	// Flush all buffered samples and re-stall, ready to anchor the next utterance.
 	reset(): void {
 		this.#readIndex = 0;

--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -629,4 +629,34 @@ describe("buffered mode", () => {
 		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.2, 5);
 		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.3, 5);
 	});
+
+	it("truncate drops the write-ahead tail a successor supersedes", () => {
+		const buffer = createBuffered(50);
+		for (let i = 0; i < 10; i++) {
+			insert(buffer, 2000 + i * 100, 100, { channels: 1, value: 0.1 });
+		}
+		read(buffer, 100, 1); // playhead at 2100
+
+		// A successor track takes over at 2200 with 100ms of its own audio. Writing it only overwrites
+		// [2200, 2300); without the truncate, [2300, 3000) of the old track still plays after it.
+		buffer.truncate(Time.Micro.fromMilli(2200 as Time.Milli));
+		insert(buffer, 2200, 100, { channels: 1, value: 0.9 });
+
+		expect(buffer.stalled).toBe(false); // truncate keeps playing, unlike reset()
+		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.1, 5); // [2100, 2200) was already due
+		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.9, 5); // the successor
+		expect(read(buffer, 100, 1)[0].length).toBe(0); // and nothing after it
+	});
+
+	it("truncate never rewinds past the playhead", () => {
+		const buffer = createBuffered(50);
+		insert(buffer, 2000, 1000, { channels: 1, value: 0.1 });
+		read(buffer, 100, 1); // playhead at 2100
+
+		// A successor whose first frame predates the playhead: those samples are already due, so WRITE
+		// floors there rather than going backwards.
+		buffer.truncate(Time.Micro.fromMilli(1000 as Time.Milli));
+		expect(buffer.length).toBe(0);
+		expect(read(buffer, 100, 1)[0].length).toBe(0);
+	});
 });

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -210,6 +210,26 @@ export class SharedRingBuffer {
 	}
 
 	/**
+	 * Drop buffered samples at or after `timestamp`, keeping whatever is already due.
+	 * Main thread only.
+	 *
+	 * A successor track overwrites the slots its own samples land on, but anything the previous
+	 * track wrote beyond them would otherwise still play once the successor runs out.
+	 */
+	truncate(timestamp: Time.Micro): void {
+		const target = Math.round(Time.Second.fromMicro(timestamp) * this.rate) | 0;
+		for (;;) {
+			const write = Atomics.load(this.#control, WRITE);
+			if (((write - target) | 0) <= 0) return; // nothing buffered past the new timeline
+			// Never retreat past the playhead: those samples are already due. READ can only advance
+			// under us, which leaves the ring empty rather than replaying anything.
+			const clamped = i32Max(target, Atomics.load(this.#control, READ));
+			if (((write - clamped) | 0) <= 0) return;
+			if (Atomics.compareExchange(this.#control, WRITE, write, clamped) === write) return;
+		}
+	}
+
+	/**
 	 * Flush buffered samples and re-stall, ready to anchor the next utterance (buffered mode).
 	 * Main thread only. The worklet reader sees STALLED and stops until the next insert.
 	 */

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -221,8 +221,11 @@ export class SharedRingBuffer {
 		for (;;) {
 			const write = Atomics.load(this.#control, WRITE);
 			if (((write - target) | 0) <= 0) return; // nothing buffered past the new timeline
-			// Never retreat past the playhead: those samples are already due. READ can only advance
-			// under us, which leaves the ring empty rather than replaying anything.
+			// Never retreat past the playhead: those samples are already due. The worklet can still
+			// advance READ past the value read here, leaving READ ahead of WRITE. That reads as an
+			// empty ring (read() returns nothing, insert() trims what the worklet already played) and
+			// heals on the first successor sample past the playhead, so it costs a quantum of silence
+			// rather than replaying anything.
 			const clamped = i32Max(target, Atomics.load(this.#control, READ));
 			if (((write - clamped) | 0) <= 0) return;
 			if (Atomics.compareExchange(this.#control, WRITE, write, clamped) === write) return;


### PR DESCRIPTION
Fixes #3064.

## Summary

- **Root cause**: `#runDecoder` reopens its subscription whenever the rendition, the resolved broadcast, or the connection changes, and `effect.cleanup` closes the old subscription and container consumer. The ring is not part of that effect (it lives alongside the worklet and audio context, keyed on sample rate and channel count), so it survives holding whatever the previous subscription decoded. Writes are timestamp-indexed, so the replacement overwrites the slots its own samples land on, but `WRITE` only ever advances. Everything between the end of the new audio and the old frontier is stale and plays once the new audio runs out. With a publisher writing ahead of real-time, that tail is seconds long.
- **Fix**: `AudioBuffer.truncate(timestamp)` clamps the write frontier down to the replacement's first timestamp, floored at the playhead. `reset()` would also discard samples that are already due and re-stall until the ring refills to the latency floor, costing a gap at exactly the handover; clamping keeps what is due and drops only the future-dated remainder.
- **Trigger**: a `Handover` unit counts subscription generations against the current ring, and the decoder truncates on the first decoded frame after a replacement. Keying on the track name alone missed a replacement that keeps the name (a rendition whose `broadcast` ref moves, a republished broadcast, a reconnect), which reproduced the same bug. A replacement is the authority from its first frame onward, so truncating there only ever drops audio it is about to supersede.

## Known limitation

The `SharedArrayBuffer` path retreats `WRITE` while the worklet may already have snapshotted the old frontier for the render quantum in flight. That quantum can still emit stale samples, and the replacement's overlapping first samples are then trimmed by `insert()` as already played. It is bounded at one quantum (2.7ms at 48kHz), self-heals on the first sample past the playhead, and every reader tolerates the transient `READ > WRITE` (`read()` returns nothing, `resize()` clamps to empty). Closing it entirely needs an epoch/version protocol between the ring and the worklet, which is a larger change than this fix.

## Public API changes

All additive, in `@moq/watch` (`js/watch/src/audio/`):

- `AudioBuffer.truncate(timestamp)`, implemented by both transports (`SharedAudioBuffer` clamps `WRITE` with a CAS retreat; `PostAudioBuffer` posts a new `Truncate` message).
- `AudioRingBuffer.truncate(timestamp)` and `SharedRingBuffer.truncate(timestamp)`.
- `Truncate` message added to the worklet `Message` union.
- New internal `Handover` class (not exported from the package entrypoint).

No wire format, `moq-net`, or `hang` changes, so no Cross-Package Sync rows apply.

## Test plan

- `just check` and `just test` pass.
- Ring tests on both implementations: a replacement supersedes the write-ahead tail (the old audio past the handover no longer plays, and the ring keeps playing rather than re-stalling), and `truncate` never rewinds past the playhead.
- `Handover` tests for the trigger: no takeover on the first subscription, exactly one on a replacement, and one regardless of how many reopens happen before a frame decodes.
- Not exercised in a browser: reproducing it live needs a publisher that writes seconds ahead and then retires its audio track mid-utterance.

(Written by Claude Opus 5)