### PR TITLE
refactor(watch)!: let Sync own the instant latency

### DIFF
--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -252,8 +252,8 @@ The component exposes everything via its `broadcast` property
 frame that arrives early waits until its timestamp comes up. That's what keeps
 motion smooth, and it costs at least a frame interval.
 
-`latency="instant"` stops pacing off the clock instead of shrinking the buffer.
-Frames paint the moment they decode, so latency drops to whatever the display costs
+`latency="instant"` empties the buffer and stops pacing off the clock, rather than
+just shrinking the buffer. Frames paint the moment they decode, so latency drops to whatever the display costs
 (about half a refresh interval on average) and the canvas shows the newest frame at
 every repaint:
 
@@ -276,13 +276,18 @@ This disables audio. The audio ring needs a target depth to avoid underrunning,
 and unsynced video has nothing pulling it back toward the audio clock, so the two
 would drift apart.
 
-The clock itself keeps running: video still reports every frame it receives and
-still resets it on a rewind. Only the wait is skipped. That keeps anything else
-reading the clock working, and it means switching back to a paced latency resumes
-from a current reference instead of a stale one.
+Note that `latency-min="0"` is not the same thing, and neither half of this is
+redundant. A zero floor still holds the selected rendition's own delay, a frame
+interval at 60fps, and it still sleeps, because the wait comes from the playback
+anchor rather than the buffer. `"instant"` drops both.
 
-Captions are one such reader, so they keep working, trailing the picture by roughly
-the jitter buffer.
+The clock itself keeps running: video still reports every frame it receives and
+still resets it on a rewind. That keeps anything else reading the clock working, and
+it means switching back to a paced latency resumes from a current reference instead
+of a stale one.
+
+Captions are one such reader, so they keep working. With nothing buffered they track
+the picture directly rather than trailing it.
 
 ## UI Overlay
 

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -9,7 +9,7 @@ import { subscribeMedia } from "../media";
 
 import type { Sync } from "../sync";
 import { type AudioBuffer, createAudioBuffer } from "./buffer";
-import { reanchorFloor } from "./latency";
+import { reanchorFloor, ringSamples } from "./latency";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
@@ -21,16 +21,6 @@ import { Warmup } from "./warmup";
 // slider drag (many small steps) into a single re-anchor once the user settles on a value.
 const LATENCY_REANCHOR_DEBOUNCE_MS = 150;
 
-// An AudioWorkletProcessor renders in fixed 128-sample quanta, so a ring shallower than one can
-// never be read from. `latency="instant"` asks Sync for a zero buffer, and the ring rejects that
-// outright: the worklet's construction throws, leaving it with no backend and no way back, since
-// every later resize is gated on the backend existing. Audio keeps its own floor for that reason.
-const RENDER_QUANTUM = 128;
-
-/** The ring depth for a target latency, floored at one render quantum. */
-function ringSamples(rate: number, latency: Time.Milli): number {
-	return Math.max(RENDER_QUANTUM, Math.ceil(rate * Time.Second.fromMilli(latency)));
-}
 const LEGACY_WARMUP_CALLBACKS = 3;
 
 export type DecoderInput = {

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -20,6 +20,17 @@ import { Warmup } from "./warmup";
 // How long the latency target must hold steady before a floor increase re-anchors. Coalesces a
 // slider drag (many small steps) into a single re-anchor once the user settles on a value.
 const LATENCY_REANCHOR_DEBOUNCE_MS = 150;
+
+// An AudioWorkletProcessor renders in fixed 128-sample quanta, so a ring shallower than one can
+// never be read from. `latency="instant"` asks Sync for a zero buffer, and the ring rejects that
+// outright: the worklet's construction throws, leaving it with no backend and no way back, since
+// every later resize is gated on the backend existing. Audio keeps its own floor for that reason.
+const RENDER_QUANTUM = 128;
+
+/** The ring depth for a target latency, floored at one render quantum. */
+function ringSamples(rate: number, latency: Time.Milli): number {
+	return Math.max(RENDER_QUANTUM, Math.ceil(rate * Time.Second.fromMilli(latency)));
+}
 const LEGACY_WARMUP_CALLBACKS = 3;
 
 export type DecoderInput = {
@@ -177,7 +188,7 @@ export class Decoder {
 
 			// Initial target latency in samples.
 			const latency = this.sync.out.buffer.peek();
-			const latencySamples = Math.ceil(sampleRate * Time.Second.fromMilli(latency));
+			const latencySamples = ringSamples(sampleRate, latency);
 			const buffered = this.sync.out.buffered.peek();
 
 			// Let the factory pick the best transport (SharedArrayBuffer or postMessage).
@@ -225,8 +236,7 @@ export class Decoder {
 		if (!ring) return;
 
 		const latency = effect.get(this.sync.out.buffer);
-		const latencySamples = Math.ceil(ring.rate * Time.Second.fromMilli(latency));
-		ring.setLatency(latencySamples);
+		ring.setLatency(ringSamples(ring.rate, latency));
 	}
 
 	// Re-anchor when the latency floor *increases*. A larger floor needs a deeper cushion: video

--- a/js/watch/src/audio/latency.test.ts
+++ b/js/watch/src/audio/latency.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Time } from "@moq/net";
-import { reanchorFloor } from "./latency";
+import { reanchorFloor, ringSamples } from "./latency";
 
 const ms = (value: number) => value as Time.Milli;
 
@@ -12,5 +12,22 @@ describe("reanchorFloor", () => {
 	it("tracks rendition delay without adaptive RTT jitter", () => {
 		expect(reanchorFloor({ latency: "real-time", audio: ms(20), video: ms(80) })).toBe(ms(80));
 		expect(reanchorFloor({ latency: "real-time", audio: ms(20), video: ms(200) })).toBe(ms(200));
+	});
+});
+
+describe("ringSamples", () => {
+	// `latency="instant"` reports a zero buffer. Passed through, the ring rejects it and the
+	// worklet is left with no backend that any later resize can revive.
+	it("floors a zero latency at one render quantum", () => {
+		expect(ringSamples(48_000, ms(0))).toBe(128);
+	});
+
+	it("floors a latency too short to fill a quantum", () => {
+		// 1ms at 48kHz is 48 samples.
+		expect(ringSamples(48_000, ms(1))).toBe(128);
+	});
+
+	it("leaves a latency above the floor alone", () => {
+		expect(ringSamples(48_000, ms(100))).toBe(4_800);
 	});
 });

--- a/js/watch/src/audio/latency.ts
+++ b/js/watch/src/audio/latency.ts
@@ -20,3 +20,19 @@ export function reanchorFloor(props: ReanchorFloor): Time.Milli {
 	const media = Time.Milli.max(props.audio ?? Time.Milli.zero, props.video ?? Time.Milli.zero);
 	return Time.Milli.add(target, media);
 }
+
+// An AudioWorkletProcessor renders in fixed 128-sample quanta, so a ring shallower than one can
+// never be read from.
+const RENDER_QUANTUM = 128;
+
+/**
+ * The ring depth for a target latency, floored at one AudioWorklet render quantum.
+ *
+ * `latency="instant"` reports a zero buffer, which the ring rejects outright: construction throws,
+ * the worklet is left with no backend, and every later resize is gated on that backend existing, so
+ * audio never recovers. Audio keeps its own floor rather than deriving its depth verbatim from a
+ * buffer whose meaning is "video holds nothing".
+ */
+export function ringSamples(rate: number, latency: Time.Milli): number {
+	return Math.max(RENDER_QUANTUM, Math.ceil(rate * Time.Second.fromMilli(latency)));
+}

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -11,7 +11,7 @@ import * as Moq from "@moq/net";
 import { Effect, Signal } from "@moq/signals";
 import * as Audio from "./audio";
 import { Broadcast, type CatalogFormat, parseCatalogFormat } from "./broadcast";
-import { type Bound, type Latency, latencyBounds, latencyFromBounds, type Paced, Sync } from "./sync";
+import { type Bound, type Latency, latencyBounds, latencyFromBounds, Sync } from "./sync";
 import * as Text from "./text";
 import * as Video from "./video";
 
@@ -136,12 +136,6 @@ export default class MoqWatch extends HTMLElement {
 	// clobber the range that replaced it.
 	#reflectingLatency = false;
 
-	// Whether video paces off the clock, cleared while the latency is "instant".
-	#videoPaced = new Signal(true);
-
-	// The latency handed to Sync, which has no way to express "instant".
-	#syncLatency = new Signal<Paced>("real-time");
-
 	// Set when the element is connected to the DOM.
 	#enabled = new Signal(false);
 
@@ -202,31 +196,15 @@ export default class MoqWatch extends HTMLElement {
 		// parent-owned signal so Sync can be constructed first without exposing mutable wiring.
 		const videoJitter = new Signal<Time.Milli | undefined>(undefined);
 
-		// Sync can't implement "instant" on its own: not pacing video and disabling audio happens
-		// here. Hand it a zero buffer instead, which is what the caption clock should run at.
-		this.signals.run((effect) => {
-			const latency = effect.get(this.controls.latency);
-			this.#syncLatency.set(latency === "instant" ? Moq.Time.Milli.zero : latency);
-		});
-
 		this.sync = new Sync({
-			latency: this.#syncLatency,
+			latency: this.controls.latency,
 			probe: this.connection.probe,
 			video: videoJitter,
 			audio: audioSource.out.jitter,
 		});
 		this.signals.cleanup(() => this.sync.close());
 
-		// `latency="instant"` stops video waiting on the clock, so frames paint the moment they
-		// decode. The clock stays wired: it still tracks receipts and rewinds for the captions.
-		this.signals.run((effect) => {
-			this.#videoPaced.set(effect.get(this.controls.latency) !== "instant");
-		});
-
-		this.video = new Video.Decoder(videoSource, this.sync, {
-			enabled: this.#videoEnabled,
-			paced: this.#videoPaced,
-		});
+		this.video = new Video.Decoder(videoSource, this.sync, { enabled: this.#videoEnabled });
 		this.signals.proxy(videoJitter, this.video.out.jitter);
 		this.audio = new Audio.Decoder(audioSource, this.sync, { enabled: this.#audioEnabled });
 		this.signals.cleanup(() => {

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -13,15 +13,13 @@ export type Bound = "real-time" | Time.Milli;
  * bounds default to `"real-time"` when omitted. The ceiling is always finite (no uncapped buffering),
  * so worst case the audio ring drops its oldest samples rather than exhausting memory.
  *
- * `"instant"` drops the clock instead of bounding it: video paints the moment it decodes and
- * audio is disabled. It replaces the range rather than sitting inside it, so it is not a
- * {@link Bound} and cannot be used as a floor or ceiling. Not pacing video and disabling audio is
- * the owner's job, so a {@link Sync} handed this value resolves it to a zero buffer and no more.
+ * `"instant"` drops the buffer and the pacing together: nothing is held, and {@link Sync.wait}
+ * returns without sleeping, so a frame presents as soon as it exists. It replaces the range rather
+ * than sitting inside it, so it is not a {@link Bound} and can't be used as a floor or ceiling.
+ * Audio is the owner's business: a ring with no depth underruns, so whoever wants this mode is
+ * expected to turn audio off.
  */
-export type Latency = "instant" | Paced;
-
-/** A latency target the playback clock can pace off on its own: every {@link Latency} but `"instant"`. */
-export type Paced = Bound | { min?: Bound; max?: Bound };
+export type Latency = "instant" | Bound | { min?: Bound; max?: Bound };
 
 /**
  * Resolve a {@link Latency} into explicit floor/ceiling bounds (a scalar collapses to `min == max`).
@@ -35,8 +33,8 @@ export function latencyBounds(latency: Latency): { min: Bound; max: Bound } {
 	return { min: latency.min ?? "real-time", max: latency.max ?? "real-time" };
 }
 
-/** Build a {@link Paced} latency from explicit bounds, collapsing to a scalar when they're equal. */
-export function latencyFromBounds(min: Bound, max: Bound): Paced {
+/** Build a {@link Latency} from explicit bounds, collapsing to a scalar when they're equal. */
+export function latencyFromBounds(min: Bound, max: Bound): Latency {
 	return min === max ? min : { min, max };
 }
 
@@ -45,10 +43,8 @@ const FALLBACK_JITTER = Time.Milli(100);
 
 export type SyncInput = {
 	/**
-	 * Latency target: a scalar minimizes (collapsed range), an object opens a range. See {@link Paced}.
-	 *
-	 * A clock cannot implement `"instant"` on its own, since not pacing video and disabling audio
-	 * are the owner's job. Pass a {@link Paced} value: `"instant"` resolves to a zero buffer here.
+	 * Latency target: a scalar minimizes (collapsed range), an object opens a range, and
+	 * `"instant"` holds nothing and never sleeps. See {@link Latency}.
 	 */
 	latency: Getter<Latency>;
 
@@ -188,7 +184,10 @@ export class Sync {
 		const video = effect.get(this.in.video) ?? Time.Milli.zero;
 		const audio = effect.get(this.in.audio) ?? Time.Milli.zero;
 
-		const buffer = Time.Milli.add(Time.Milli.max(video, audio), jitter);
+		// A zero floor still holds the rendition's own delay, which is a frame interval at 60fps.
+		// "instant" holds nothing at all.
+		const instant = effect.get(this.in.latency) === "instant";
+		const buffer = instant ? Time.Milli.zero : Time.Milli.add(Time.Milli.max(video, audio), jitter);
 		this.#out.buffer.set(buffer);
 
 		this.#update.resolve();
@@ -269,12 +268,19 @@ export class Sync {
 
 	// Sleep until it's time to render this frame.
 	async wait(timestamp: Time.Milli): Promise<void> {
+		// A zero buffer still sleeps: the sleep comes from the reference, which holds an early frame
+		// until its timestamp comes up. "instant" is the only thing that skips the wait itself.
+		if (this.in.latency.peek() === "instant") return;
+
 		const reference = this.#out.reference.peek();
 		if (reference === undefined) {
 			throw new Error("reference not set; call received() first");
 		}
 
 		for (;;) {
+			// Switching to "instant" resolves `#update`, so frames parked here wake and leave.
+			if (this.in.latency.peek() === "instant") return;
+
 			// Sleep until it's time to decode the next frame.
 			// NOTE: This function runs in parallel for each frame.
 			const now = Time.Milli.now();

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -5,7 +5,6 @@ import type * as Moq from "@moq/net";
 import { Time } from "@moq/net";
 import {
 	type Computed,
-	type Dispose,
 	Effect,
 	type Getter,
 	getter,
@@ -35,16 +34,6 @@ const BUFFERING = Time.Milli(500);
 export type DecoderInput = {
 	/** Whether to download the video track. Defaults to true; the parent may wire it from the renderer's output. */
 	enabled: Getter<boolean>;
-
-	/**
-	 * Whether to pace playback off the clock, holding each decoded frame until its presentation
-	 * time. Defaults to true.
-	 *
-	 * False paints on decode instead, trading smooth motion for the lowest latency the display can
-	 * offer. The clock stays wired either way and keeps tracking receipts and rewinds, so anything
-	 * else reading it (captions, the UI) still works and re-enabling this resumes cleanly.
-	 */
-	paced: Getter<boolean>;
 };
 
 /** Cumulative video statistics since the decoder started. */
@@ -111,7 +100,6 @@ export class Decoder {
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
 		this.in = {
 			enabled: getter(props?.enabled ?? true),
-			paced: getter(props?.paced ?? true),
 		};
 
 		this.source = source;
@@ -163,7 +151,6 @@ export class Decoder {
 		// Start a new pending effect.
 		let pending: DecoderTrack | undefined = new DecoderTrack({
 			sync: this.sync,
-			paced: this.in.paced,
 			broadcast: active,
 			track,
 			config: identity.decoder,
@@ -268,7 +255,6 @@ export class Decoder {
 
 interface DecoderTrackProps {
 	sync: Sync;
-	paced: Getter<boolean>;
 	broadcast: Moq.Broadcast.Consumer;
 	track: string;
 	config: DecoderConfig;
@@ -278,7 +264,6 @@ interface DecoderTrackProps {
 
 class DecoderTrack {
 	sync: Sync;
-	paced: Getter<boolean>;
 	broadcast: Moq.Broadcast.Consumer;
 	track: string;
 	config: DecoderConfig;
@@ -294,10 +279,6 @@ class DecoderTrack {
 	// Decoded frames waiting to be rendered.
 	#buffered = new Signal<Container.BufferedRanges>([]);
 
-	// The container's reorder/skip budget, mirroring the sync ceiling. Zero when unpaced,
-	// matching the consumer's own default: don't wait, skip to the live edge.
-	#latency = new Signal<Time.Milli>(Time.Milli.zero);
-
 	// The last discontinuity count seen from the container consumer; doubles as a generation
 	// so in-flight decodes from before a rewind can be dropped on output.
 	#discontinuity = 0;
@@ -306,17 +287,11 @@ class DecoderTrack {
 
 	constructor(props: DecoderTrackProps) {
 		this.sync = props.sync;
-		this.paced = props.paced;
 		this.broadcast = props.broadcast;
 		this.track = props.track;
 		this.config = props.config;
 		this.stats = props.stats;
 		this.jitter = renditionJitter(props.config);
-
-		this.#signals.run((effect) => {
-			const paced = effect.get(this.paced);
-			this.#latency.set(paced ? effect.get(this.sync.out.maxBuffer) : Time.Milli.zero);
-		});
 
 		this.#signals.run(this.#run.bind(this));
 	}
@@ -326,7 +301,7 @@ class DecoderTrack {
 			broadcast: this.broadcast,
 			track: this.track,
 			priority: Catalog.PRIORITY.video,
-			latency: this.#latency,
+			latency: this.sync.out.maxBuffer,
 		});
 
 		const decoder = new VideoDecoder({
@@ -342,26 +317,27 @@ class DecoderTrack {
 						return;
 					}
 
-					if (this.paced.peek()) {
-						// `received()` runs at submit, so a frame is anchored by the time it decodes.
-						// Reaching here unanchored means a rewind reset the clock after this frame's
-						// received(), so it predates the current timeline. Drop it: painting it would
-						// set `timestamp` from the old timeline and late-reject the whole rewind.
-						if (this.sync.out.reference.peek() === undefined) return;
+					// `received()` runs at submit, so a frame is anchored by the time it decodes.
+					// Reaching here unanchored means a rewind reset the clock after this frame's
+					// received(), so it predates the current timeline. Drop it: painting it would
+					// set `timestamp` from the old timeline and late-reject the whole rewind.
+					if (this.sync.out.reference.peek() === undefined) return;
 
-						if (this.frame.peek() === undefined) {
-							// Render something while we wait for the sync to catch up.
-							this.frame.set(frame.clone());
-						}
+					if (this.frame.peek() === undefined) {
+						// Render something while we wait for the sync to catch up.
+						this.frame.set(frame.clone());
+					}
 
-						if (!(await this.#park(timestamp, effect))) return;
-						if (generation !== this.#discontinuity) return; // a rewind happened while waiting
+					// Returns immediately when the latency is "instant".
+					const wait = this.sync.wait(timestamp).then(() => true);
+					const ok = await Promise.race([wait, effect.cancel]);
+					if (!ok) return;
+					if (generation !== this.#discontinuity) return; // a rewind happened while waiting
 
-						if (timestamp < (this.timestamp.peek() ?? 0)) {
-							// Late frame, don't render it.
-							// NOTE: This can happen when the ref is updated, such as on playback start.
-							return;
-						}
+					if (timestamp < (this.timestamp.peek() ?? 0)) {
+						// Late frame, don't render it.
+						// NOTE: This can happen when the ref is updated, such as on playback start.
+						return;
 					}
 
 					this.timestamp.set(timestamp);
@@ -401,7 +377,7 @@ class DecoderTrack {
 		// Create consumer that reorders groups/frames up to the provided latency.
 		const consumer = new Container.Consumer(sub, {
 			format,
-			latency: this.#latency,
+			latency: this.sync.out.maxBuffer,
 		});
 		effect.cleanup(() => consumer.close());
 
@@ -477,7 +453,7 @@ class DecoderTrack {
 
 		const consumer = new Container.Consumer(sub, {
 			format: new Container.Cmaf.Format(init),
-			latency: this.#latency,
+			latency: this.sync.out.maxBuffer,
 		});
 		effect.cleanup(() => consumer.close());
 
@@ -556,28 +532,6 @@ class DecoderTrack {
 		this.#buffered.set([]);
 		this.sync.reset();
 		return true;
-	}
-
-	// Sleep until the clock says to paint this frame, waking early if pacing is turned off or the
-	// run is torn down. Returns false when the frame should be dropped.
-	//
-	// Turning pacing off has to release parked frames, otherwise a deep buffer holds them (and their
-	// GPU memory) until deadlines that no longer apply. They paint rather than drop: a parked frame
-	// is early, not stale, so it is the freshest picture available the moment pacing stops.
-	//
-	// Dispose the registration once the race settles: one that outlives the frame retains an entry
-	// per decoded frame for as long as the track lives, which is unbounded during steady playback.
-	async #park(timestamp: Time.Milli, effect: Effect): Promise<boolean> {
-		let release: Dispose | undefined;
-		try {
-			const released = new Promise<boolean>((resolve) => {
-				release = this.paced.changed(() => resolve(!this.paced.peek()));
-			});
-			const wait = this.sync.wait(timestamp).then(() => true);
-			return (await Promise.race([wait, released, effect.cancel])) ?? false;
-		} finally {
-			release?.();
-		}
 	}
 
 	// Add a range to the decode buffer (decoded, waiting to render)


### PR DESCRIPTION
Supersedes #3061 and closes #3052, both of which addressed the same wart the harder way.

## Why

`"instant"` was implemented in three places at once. The element mapped it to a zero buffer before handing it to `Sync`, separately cleared a `paced` flag on the video decoder, and the decoder skipped its wait. `Sync` can just do it.

The reason it was split up was the belief that `Sync` couldn't honor the mode. That is only true of the audio half. The timing half is entirely `Sync`'s.

## The two things that are not the same

A **zero buffer** is not **no pacing**, which is what made this look harder than it is:

- A zero floor still holds `max(video, audio)` in `#runBuffer`, the selected rendition's own delay. That's a frame interval at 60fps.
- `wait()` still sleeps at a zero floor, because the sleep comes from the reference (`sleep = currentRef - ref + floor`), which holds an early frame until its timestamp comes up. That is exactly why `latency-min="0"` was never instant.

So `"instant"` now does both: `#runBuffer` returns zero outright, and `wait()` returns without sleeping. The check sits inside `wait()`'s loop as well as at the top, so frames already parked wake through the existing `#update` resolve and leave.

## What that deletes

- `DecoderInput.paced` — the decoder no longer knows the mode exists.
- `DecoderTrack.#latency` and its effect — `maxBuffer` is already zero in the mode via `#runRange`, so the mirror had nothing left to do. The three call sites read `sync.out.maxBuffer` directly again.
- `#park` — inlined back to `Promise.race([wait, effect.cancel])`. With no `paced` input there is nothing extra to race, and the disposable-registration bookkeeping goes with it.
- `#videoPaced` and `#syncLatency` in the element.
- The `Paced` type. It existed only to keep `"instant"` away from a component that can now honor it.

Net: 110 lines removed, 48 added.

## What stays

Audio remains the element's business: a ring with no target depth underruns, and `Sync` has no way to reach the audio decoder. The disable and ring flush are unchanged.

The rewind fix from #3048 stays and is now unconditional, since there is no `paced` branch to nest it in: an unanchored reference at output time means a `reset()` landed after the frame's `received()`, so the frame predates the current timeline and is dropped rather than painted.

## Reviewer notes

- **Targets `dev`**: removing `DecoderInput.paced` and the `Paced` export are semver breaks.
- `just fix`, `just check`, and `just test` all pass.
- Still no automated coverage of the instant path itself; it needs a real WebCodecs `VideoDecoder`, which bun's test environment lacks.

(Written by claude-opus-5)