### PR TITLE
fix(publish): include Opus decoder description

### DIFF
--- a/js/publish/src/audio/encoder.test.ts
+++ b/js/publish/src/audio/encoder.test.ts
@@ -1,4 +1,5 @@
 import { expect, mock, spyOn, test } from "bun:test";
+import type * as Catalog from "@moq/hang/catalog";
 import { Signal } from "@moq/signals";
 
 // The encoder pulls the capture processor in as a `?worklet` blob URL, which the bun test loader can't
@@ -11,6 +12,21 @@ type Codec = import("./encoder.ts").Codec;
 const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
 async function settle(times = 5): Promise<void> {
 	for (let i = 0; i < times; i++) await flush();
+}
+
+function installGlobals(globals: Record<string, unknown>) {
+	const originals = new Map<string, PropertyDescriptor | undefined>();
+	for (const [name, value] of Object.entries(globals)) {
+		originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+		Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+	}
+
+	return () => {
+		for (const [name, original] of originals) {
+			if (original) Object.defineProperty(globalThis, name, original);
+			else Reflect.deleteProperty(globalThis, name);
+		}
+	};
 }
 
 // Models the WebAudio surface `#runSource` touches. The key detail is `AudioContext.close()`: on
@@ -58,11 +74,7 @@ function installFakeWebAudio() {
 		AudioWorkletNode: FakeAudioWorkletNode,
 	};
 
-	const originals = new Map<string, PropertyDescriptor | undefined>();
-	for (const [name, value] of Object.entries(globals)) {
-		originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
-		Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
-	}
+	const restore = installGlobals(globals);
 
 	return {
 		get audioWorkletNodes() {
@@ -72,10 +84,140 @@ function installFakeWebAudio() {
 			return requestedRates;
 		},
 		[Symbol.dispose]() {
-			for (const [name, original] of originals) {
-				if (original) Object.defineProperty(globalThis, name, original);
-				else Reflect.deleteProperty(globalThis, name);
-			}
+			restore();
+		},
+	};
+}
+
+function installEncodingHarness(description: Uint8Array) {
+	let worklet: FakeAudioWorkletNode | undefined;
+	let audioEncoders = 0;
+
+	class FakePort extends EventTarget {
+		start(): void {}
+
+		emit(data: unknown): void {
+			this.dispatchEvent(new MessageEvent("message", { data }));
+		}
+	}
+
+	class FakeAudioContext {
+		readonly sampleRate: number;
+		state: AudioContextState = "running";
+		currentTime = 0;
+		audioWorklet = { addModule: () => Promise.resolve() };
+
+		constructor(options?: AudioContextOptions) {
+			this.sampleRate = options?.sampleRate ?? 48_000;
+		}
+
+		close(): Promise<void> {
+			this.state = "closed";
+			return Promise.resolve();
+		}
+	}
+
+	class FakeMediaStream {}
+
+	class FakeGraphNode {
+		channelCount = 2;
+		connect(): void {}
+		disconnect(): void {}
+	}
+
+	class FakeGainNode extends FakeGraphNode {
+		readonly context: FakeAudioContext;
+		gain = {
+			cancelScheduledValues: () => {},
+			exponentialRampToValueAtTime: () => {},
+			setValueAtTime: () => {},
+		};
+
+		constructor(context: FakeAudioContext) {
+			super();
+			this.context = context;
+		}
+	}
+
+	class FakeAudioWorkletNode extends FakeGraphNode {
+		readonly port = new FakePort();
+		readonly context: FakeAudioContext;
+
+		constructor(context: FakeAudioContext) {
+			super();
+			this.context = context;
+			worklet = this;
+		}
+	}
+
+	class FakeAudioData {
+		readonly timestamp: number;
+
+		constructor(init: AudioDataInit) {
+			this.timestamp = init.timestamp;
+		}
+
+		close(): void {}
+	}
+
+	class FakeAudioEncoder {
+		readonly #output: EncodedAudioChunkOutputCallback;
+
+		constructor(init: AudioEncoderInit) {
+			audioEncoders++;
+			this.#output = init.output;
+		}
+
+		configure(_config: AudioEncoderConfig): void {}
+
+		encode(frame: AudioData): void {
+			const storage = new Uint8Array(description.byteLength + 2);
+			storage.set(description, 1);
+			const view = new DataView(storage.buffer, 1, description.byteLength);
+			const chunk = {
+				type: "key",
+				timestamp: frame.timestamp,
+				byteLength: 1,
+				copyTo: (buffer: Uint8Array) => {
+					buffer[0] = 0;
+				},
+			} as EncodedAudioChunk;
+
+			this.#output(chunk, {
+				decoderConfig: {
+					codec: "opus",
+					sampleRate: 48_000,
+					numberOfChannels: 1,
+					description: view,
+				},
+			});
+		}
+
+		close(): void {}
+	}
+
+	class FakeAudioDecoder {}
+
+	const restore = installGlobals({
+		AudioContext: FakeAudioContext,
+		MediaStream: FakeMediaStream,
+		MediaStreamAudioSourceNode: FakeGraphNode,
+		GainNode: FakeGainNode,
+		AudioWorkletNode: FakeAudioWorkletNode,
+		AudioData: FakeAudioData,
+		AudioEncoder: FakeAudioEncoder,
+		AudioDecoder: FakeAudioDecoder,
+	});
+
+	return {
+		get worklet() {
+			return worklet;
+		},
+		get audioEncoders() {
+			return audioEncoders;
+		},
+		[Symbol.dispose]() {
+			restore();
 		},
 	};
 }
@@ -175,6 +317,51 @@ test("does not rebuild the capture graph when an encode-only knob changes", asyn
 	codec.set({ mime: "aac" });
 	await settle();
 	expect(webaudio.requestedRates.length).toBe(2);
+
+	encoder.close();
+	await settle();
+});
+
+test("publishes the Opus decoder description reported by the encoder", async () => {
+	const description = Uint8Array.from([
+		0x4f, 0x70, 0x75, 0x73, 0x48, 0x65, 0x61, 0x64, 0x01, 0x01, 0x38, 0x01, 0x80, 0xbb, 0x00, 0x00, 0x00, 0x00,
+		0x00,
+	]);
+	using harness = installEncodingHarness(description);
+
+	let writes = 0;
+	const track = {
+		writeFrame: () => {
+			writes++;
+		},
+		close: () => {},
+	};
+	const rendition = {
+		config: new Signal<Catalog.AudioConfig | undefined>(undefined),
+		track: new Signal(track),
+		close: () => {},
+	};
+	const broadcast = { audio: () => rendition };
+
+	const encoder = new Encoder("audio", {
+		enabled: true,
+		source: new Signal(fakeSource()) as never,
+		broadcast: new Signal(broadcast) as never,
+	});
+	await settle();
+
+	const worklet = harness.worklet;
+	expect(worklet).toBeDefined();
+	worklet?.port.emit({ timestamp: 0, channels: [new Float32Array(960)] });
+	await settle();
+	expect(rendition.config.peek()?.description).toBeUndefined();
+
+	worklet?.port.emit({ timestamp: 20_000, channels: [new Float32Array(960)] });
+	await settle();
+
+	expect(rendition.config.peek()?.description).toBe("4f707573486561640101380180bb0000000000");
+	expect(harness.audioEncoders).toBe(1);
+	expect(writes).toBe(1);
 
 	encoder.close();
 	await settle();

--- a/js/publish/src/audio/encoder.test.ts
+++ b/js/publish/src/audio/encoder.test.ts
@@ -175,14 +175,15 @@ function installEncodingHarness(description: Uint8Array) {
 				},
 			} as EncodedAudioChunk;
 
-			this.#output(chunk, {
+			const metadata = {
 				decoderConfig: {
 					codec: "opus",
 					sampleRate: 48_000,
 					numberOfChannels: 1,
 					description: view,
 				},
-			});
+			};
+			queueMicrotask(() => this.#output(chunk, metadata));
 		}
 
 		close(): void {}

--- a/js/publish/src/audio/encoder.test.ts
+++ b/js/publish/src/audio/encoder.test.ts
@@ -14,21 +14,6 @@ async function settle(times = 5): Promise<void> {
 	for (let i = 0; i < times; i++) await flush();
 }
 
-function installGlobals(globals: Record<string, unknown>) {
-	const originals = new Map<string, PropertyDescriptor | undefined>();
-	for (const [name, value] of Object.entries(globals)) {
-		originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
-		Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
-	}
-
-	return () => {
-		for (const [name, original] of originals) {
-			if (original) Object.defineProperty(globalThis, name, original);
-			else Reflect.deleteProperty(globalThis, name);
-		}
-	};
-}
-
 // Models the WebAudio surface `#runSource` touches. The key detail is `AudioContext.close()`: on
 // Firefox and Safari it does NOT synchronously flip `.state` to "closed" (it stays "suspended"), which
 // is exactly the browser behavior the old `context.state === "closed"` guard failed to account for.
@@ -74,7 +59,11 @@ function installFakeWebAudio() {
 		AudioWorkletNode: FakeAudioWorkletNode,
 	};
 
-	const restore = installGlobals(globals);
+	const originals = new Map<string, PropertyDescriptor | undefined>();
+	for (const [name, value] of Object.entries(globals)) {
+		originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+		Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+	}
 
 	return {
 		get audioWorkletNodes() {
@@ -84,7 +73,10 @@ function installFakeWebAudio() {
 			return requestedRates;
 		},
 		[Symbol.dispose]() {
-			restore();
+			for (const [name, original] of originals) {
+				if (original) Object.defineProperty(globalThis, name, original);
+				else Reflect.deleteProperty(globalThis, name);
+			}
 		},
 	};
 }
@@ -198,7 +190,7 @@ function installEncodingHarness(description: Uint8Array) {
 
 	class FakeAudioDecoder {}
 
-	const restore = installGlobals({
+	const globals: Record<string, unknown> = {
 		AudioContext: FakeAudioContext,
 		MediaStream: FakeMediaStream,
 		MediaStreamAudioSourceNode: FakeGraphNode,
@@ -207,7 +199,12 @@ function installEncodingHarness(description: Uint8Array) {
 		AudioData: FakeAudioData,
 		AudioEncoder: FakeAudioEncoder,
 		AudioDecoder: FakeAudioDecoder,
-	});
+	};
+	const originals = new Map<string, PropertyDescriptor | undefined>();
+	for (const [name, value] of Object.entries(globals)) {
+		originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+		Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+	}
 
 	return {
 		get worklet() {
@@ -217,7 +214,10 @@ function installEncodingHarness(description: Uint8Array) {
 			return audioEncoders;
 		},
 		[Symbol.dispose]() {
-			restore();
+			for (const [name, original] of originals) {
+				if (original) Object.defineProperty(globalThis, name, original);
+				else Reflect.deleteProperty(globalThis, name);
+			}
 		},
 	};
 }

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -128,14 +128,19 @@ export class Encoder {
 	/** The live-editable codec selection plus its encoder settings. */
 	codec: Signal<Codec>;
 
-	// Observed capture format. #out.catalog is derived from this plus the codec, so the
-	// worklet handlers only ever write here, never read-modify-write the catalog.
+	// Observed capture format. #config is derived from this plus the codec; #out.catalog also folds in
+	// encoder metadata. Worklet handlers write those inputs, never read-modify-write the catalog.
 	#captured = new Signal<Captured | undefined>(undefined);
 
 	// Only the mime picks the capture sample rate, so the capture graph tracks this rather than the
 	// whole codec signal. Otherwise changing an encode-only knob (bitrate, complexity) would rebuild
 	// the AudioContext, drop #worklet, and close the track we're publishing.
 	#codecMime: Signal<CodecMime>;
+
+	// The catalog fields known before encoding starts. Opus adds its decoder description from the
+	// first encoder output without feeding that catalog-only update back into the encoder.
+	#config = new Signal<Catalog.AudioConfig | undefined>(undefined);
+	#decoderDescription = new Signal<{ config: Catalog.AudioConfig; description: Catalog.Hex } | undefined>(undefined);
 
 	readonly #out: EncoderOutput = {
 		catalog: new Signal<Catalog.AudioConfig | undefined>(undefined),
@@ -174,6 +179,7 @@ export class Encoder {
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runGain.bind(this));
 		this.#signals.run(this.#runConfig.bind(this));
+		this.#signals.run(this.#runCatalog.bind(this));
 		this.#signals.run(this.#runRegister.bind(this));
 	}
 
@@ -332,17 +338,31 @@ export class Encoder {
 		};
 	}
 
-	// Derive the catalog from the captured format and the codec. Re-runs whenever either changes, so a
+	// Derive the encoder config from the captured format and the codec. Re-runs whenever either changes, so a
 	// codec update (bitrate, frame duration) reconfigures without waiting for a channel-count change.
 	#runConfig(effect: Effect): void {
 		const captured = effect.get(this.#captured);
 		if (!captured) {
-			effect.set(this.#out.catalog, undefined);
+			effect.set(this.#config, undefined);
 			return;
 		}
 
 		const codec = normalizeCodec(effect.get(this.codec));
-		effect.set(this.#out.catalog, this.#createConfig(captured, codec));
+		effect.set(this.#config, this.#createConfig(captured, codec));
+	}
+
+	// Publish the config immediately so a consumer can request the demand-gated track. Once encoding
+	// starts, republish Opus with the exact decoder description reported for that encoder config.
+	#runCatalog(effect: Effect): void {
+		const config = effect.get(this.#config);
+		if (!config) {
+			effect.set(this.#out.catalog, undefined);
+			return;
+		}
+
+		const decoder = effect.get(this.#decoderDescription);
+		const catalog = decoder?.config === config ? { ...config, description: decoder.description } : config;
+		effect.set(this.#out.catalog, catalog);
 	}
 
 	// Collect the encode-only Opus knobs that are set, reading the codec through the effect so the
@@ -383,7 +403,7 @@ export class Encoder {
 			await Util.Libav.polyfill();
 
 			effect.run((effect: Effect) => {
-				const config = effect.get(this.out.catalog);
+				const config = effect.get(this.#config);
 				if (!config) return;
 
 				const source = effect.get(this.in.source);
@@ -392,10 +412,12 @@ export class Encoder {
 				const framer = createFramer(config);
 
 				const encoder = new AudioEncoder({
-					output: (frame) => {
+					output: (frame, metadata) => {
 						if (frame.type !== "key") {
 							throw new Error("only key frames are supported");
 						}
+
+						this.#setDecoderDescription(config, metadata?.decoderConfig?.description);
 
 						this.#out.stats.update((stats) => ({
 							frames: stats.frames + 1,
@@ -455,6 +477,19 @@ export class Encoder {
 			});
 			worklet.port.start();
 		});
+	}
+
+	#setDecoderDescription(config: Catalog.AudioConfig, source: AllowSharedBufferSource | undefined): void {
+		if (config.codec !== "opus" || !source) return;
+
+		const bytes = ArrayBuffer.isView(source)
+			? new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
+			: new Uint8Array(source);
+		const description = Util.Hex.fromBytes(bytes);
+		const current = this.#decoderDescription.peek();
+		if (current?.config === config && current.description === description) return;
+
+		this.#decoderDescription.set({ config, description });
 	}
 
 	close() {


### PR DESCRIPTION
## Summary

- Feed the Opus encoder's reported decoder description back into the rendition catalog so consumers trim the exact encoder pre-skip.
- Keep the pre-encode config separate from the published catalog config so the metadata update does not restart the encoder.
- Root cause: the catalog was created before encoding began, so it omitted the encoder-owned Opus description and both JS and Rust consumers fell back to a pre-skip of zero.

Fixes #3063.

## Public API changes

- None.

## Test plan

- `nix develop --command just check origin/main`
- `nix develop --command just test default origin/main`
- Loaded the local web publisher and verified it initialized with no browser console errors.

## Cross-package sync

- Not applicable. The catalog schema and wire format are unchanged, so no paired package, draft, or documentation updates are needed.

(Written by GPT-5)
