### PR TITLE
fix(moq-srt): preserve SCTE-35 through the SRT gateway

### DIFF
--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -189,7 +189,8 @@ mod tests {
 			.expect("cue read timed out")
 			.unwrap()
 			.expect("a published cue section");
-		assert_eq!(cue.payload[0], 0xFC, "a verbatim splice_info_section (table_id 0xFC)");
+		let expected_cue = cue.payload;
+		assert_eq!(expected_cue[0], 0xFC, "a verbatim splice_info_section (table_id 0xFC)");
 
 		let mut subscriber = Subscriber::new(&origin.consume(), "ingest", Duration::ZERO)
 			.await
@@ -237,5 +238,9 @@ mod tests {
 			.unwrap()
 			.expect("SRT egress preserves a cue section");
 		assert_eq!(cue.payload[0], 0xFC, "the round-trip cue is a splice_info_section");
+		assert_eq!(
+			cue.payload, expected_cue,
+			"SRT egress preserves the complete cue section"
+		);
 	}
 }

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -23,7 +23,10 @@ use crate::Result;
 /// Either [`Self::finish`] or dropping the publisher ends the broadcast and
 /// unannounces the path, the former without the dropped-without-finish warning.
 pub struct Publisher {
-	importer: ts::Import,
+	// TS carries undecoded elementary streams (SCTE-35, teletext, DVB AC-3, ...)
+	// verbatim, so the importer uses the `mpegts` catalog extension rather than the
+	// media-only `()`, which would route those PIDs to `Stream::Ignored` and drop them.
+	importer: ts::Import<ts::Ext>,
 	// A clone of the importer's producer, so a deliberate end can finish() the
 	// broadcast (prompt unannounce) even though the importer owns it.
 	broadcast: moq_net::broadcast::Producer,
@@ -34,7 +37,10 @@ impl Publisher {
 	/// catalog.
 	pub fn new(origin: &origin::Producer, path: &str) -> Result<Self> {
 		let mut broadcast = origin.create_broadcast(path, broadcast::Route::new().with_announce(true))?;
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		let catalog = moq_mux::catalog::Producer::with_catalog(
+			&mut broadcast,
+			moq_mux::catalog::hang::Catalog::<ts::Ext>::default(),
+		)?;
 		let handle = broadcast.clone();
 		let importer = ts::Import::new(broadcast, catalog.reserve());
 		tracing::info!(%path, "publishing ingest broadcast");
@@ -111,5 +117,78 @@ impl Subscriber {
 	/// broadcast ends.
 	pub async fn next(&mut self) -> Result<Option<Frame>> {
 		Ok(self.export.next().await?)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	use moq_mux::catalog::hang::Container;
+	use moq_mux::catalog::{CatalogFormat, Stream};
+	use tokio::time::timeout;
+
+	use super::*;
+
+	/// Real 5s H.264 + AAC capture with SCTE-35 time_signal cues on a
+	/// CUEI-registered section PID (0x21, stream_type 0x86) — the same fixture
+	/// moq-mux's export tests replay.
+	const BBB5S: &[u8] = include_bytes!("../../moq-mux/src/container/ts/test_data/scte35/bbb5s.ts");
+
+	/// SRT is a contribution protocol, so the cues riding the feed must survive
+	/// ingest: [`Publisher`] builds a `ts::Import<Ext>`, which catalogs the
+	/// SCTE-35 PID in the `mpegts` section and publishes the sections verbatim.
+	/// With the media-only `Catalog<()>` the CUEI PID routes to `Stream::Ignored`
+	/// and the cues silently vanish.
+	#[tokio::test]
+	async fn publisher_preserves_scte35_cues() {
+		let origin = moq_net::Origin::random().produce();
+		let mut publisher = Publisher::new(&origin, "ingest").unwrap();
+
+		// Resolve the broadcast like any subscriber would (waits for the announce).
+		let broadcast = timeout(Duration::from_secs(5), origin.consume().announced_broadcast("ingest"))
+			.await
+			.expect("announce timed out")
+			.expect("the ingest broadcast is announced");
+
+		publisher.feed(bytes::Bytes::from_static(BBB5S)).unwrap();
+
+		// The catalog advertises the cue track in its `mpegts` section...
+		let mut catalog = moq_mux::catalog::Consumer::<ts::Ext>::new(&broadcast, CatalogFormat::Hang)
+			.await
+			.unwrap();
+		let name = loop {
+			let snapshot = timeout(Duration::from_secs(5), catalog.next())
+				.await
+				.expect("no catalog snapshot carried the cue track")
+				.unwrap()
+				.expect("the catalog ended without the cue track");
+			if let Some((name, track)) = snapshot
+				.mpegts
+				.tracks
+				.iter()
+				.find(|(_, t)| t.verbatim.as_ref().is_some_and(|v| v.stream_type == 0x86))
+			{
+				assert_eq!(track.pid, 0x21, "the cue PID is preserved");
+				assert_eq!(
+					track.verbatim.as_ref().unwrap().framing,
+					ts::Framing::Section,
+					"SCTE-35 is section-framed"
+				);
+				break name.clone();
+			}
+		};
+
+		// ...and the splice_info_sections themselves are published verbatim.
+		let track = broadcast.track(name.as_str()).unwrap().subscribe(None).await.unwrap();
+		let mut reader = moq_mux::container::Consumer::new(track, Container::Legacy).with_latency(Duration::ZERO);
+		let cue = timeout(Duration::from_secs(5), reader.read())
+			.await
+			.expect("cue read timed out")
+			.unwrap()
+			.expect("a published cue section");
+		assert_eq!(cue.payload[0], 0xFC, "a verbatim splice_info_section (table_id 0xFC)");
+
+		publisher.finish().unwrap();
 	}
 }

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -83,7 +83,7 @@ impl Publisher {
 /// SRT caller can play it. Pull frames with [`next`](Self::next); each carries
 /// the TS bytes plus the media timestamp used to pace delivery.
 pub struct Subscriber {
-	export: ts::Export,
+	export: ts::Export<ts::Ext>,
 }
 
 impl Subscriber {
@@ -109,7 +109,9 @@ impl Subscriber {
 		}
 
 		let source = moq_mux::Source::new(origin.consume(), path);
-		let export = ts::Export::new(source).await?.with_latency(latency);
+		let export = ts::Export::with_ts(source, moq_mux::catalog::CatalogFormat::Hang)
+			.await?
+			.with_latency(latency);
 		Ok(Some(Self { export }))
 	}
 
@@ -131,7 +133,7 @@ mod tests {
 	use super::*;
 
 	/// Real 5s H.264 + AAC capture with SCTE-35 time_signal cues on a
-	/// CUEI-registered section PID (0x21, stream_type 0x86) — the same fixture
+	/// CUEI-registered section PID (0x21, stream_type 0x86), the same fixture
 	/// moq-mux's export tests replay.
 	const BBB5S: &[u8] = include_bytes!("../../moq-mux/src/container/ts/test_data/scte35/bbb5s.ts");
 
@@ -140,7 +142,7 @@ mod tests {
 	/// SCTE-35 PID in the `mpegts` section and publishes the sections verbatim.
 	/// With the media-only `Catalog<()>` the CUEI PID routes to `Stream::Ignored`
 	/// and the cues silently vanish.
-	#[tokio::test]
+	#[tokio::test(start_paused = true)]
 	async fn publisher_preserves_scte35_cues() {
 		let origin = moq_net::Origin::random().produce();
 		let mut publisher = Publisher::new(&origin, "ingest").unwrap();
@@ -189,6 +191,51 @@ mod tests {
 			.expect("a published cue section");
 		assert_eq!(cue.payload[0], 0xFC, "a verbatim splice_info_section (table_id 0xFC)");
 
+		let mut subscriber = Subscriber::new(&origin.consume(), "ingest", Duration::ZERO)
+			.await
+			.unwrap()
+			.expect("the ingest broadcast is available for SRT egress");
+		let mut output = Vec::new();
+		loop {
+			match timeout(Duration::from_secs(5), subscriber.next()).await {
+				Ok(Ok(Some(frame))) => output.extend_from_slice(&frame.payload),
+				Ok(Ok(None)) => break,
+				Ok(Err(err)) => panic!("SRT egress failed: {err}"),
+				Err(_) => break,
+			}
+		}
 		publisher.finish().unwrap();
+
+		let mut roundtrip = moq_net::broadcast::Info::new().produce();
+		let roundtrip_consumer = roundtrip.consume();
+		let roundtrip_catalog = moq_mux::catalog::Producer::with_catalog(
+			&mut roundtrip,
+			moq_mux::catalog::hang::Catalog::<ts::Ext>::default(),
+		)
+		.unwrap();
+		let mut roundtrip_import = ts::Import::new(roundtrip, roundtrip_catalog.reserve());
+		roundtrip_import.decode(&output).unwrap();
+		roundtrip_import.finish().unwrap();
+
+		let snapshot = roundtrip_catalog.snapshot();
+		let (name, _) = snapshot
+			.mpegts
+			.tracks
+			.iter()
+			.find(|(_, track)| {
+				track
+					.verbatim
+					.as_ref()
+					.is_some_and(|verbatim| verbatim.stream_type == 0x86)
+			})
+			.expect("SRT egress preserves the SCTE-35 track");
+		let track = roundtrip_consumer.track(name).unwrap().subscribe(None).await.unwrap();
+		let mut reader = moq_mux::container::Consumer::new(track, Container::Legacy);
+		let cue = timeout(Duration::from_secs(5), reader.read())
+			.await
+			.expect("round-trip cue read timed out")
+			.unwrap()
+			.expect("SRT egress preserves a cue section");
+		assert_eq!(cue.payload[0], 0xFC, "the round-trip cue is a splice_info_section");
 	}
 }


### PR DESCRIPTION
## Summary

- Root cause: `Publisher` used a media-only `ts::Import<()>`, so PMT-registered SCTE-35 section PIDs were routed to `Stream::Ignored` during ingest.
- The SRT egress mirror also used media-only `ts::Export<()>`, so even retained MPEG-TS extension tracks were omitted from requested output.
- Use the `mpegts` catalog extension and TS-aware importer/exporter in both directions so SCTE-35 cue sections survive the complete SRT gateway path.

## Public API changes

None. The changed fields are private, and the `Publisher` and `Subscriber` method signatures are unchanged. Ingest broadcasts and SRT egress now additionally carry cataloged MPEG-TS extension streams, which is additive behavior.

## Test plan

- Expanded `publisher_preserves_scte35_cues` to feed the real cue-bearing `bbb5s.ts` fixture, verify the imported cue track and section, drain it through `Subscriber`, re-import the emitted MPEG-TS, and compare the complete cue payload byte for byte across the round trip.
- Paused Tokio time so timeout-backed failure paths are deterministic and do not wait on wall-clock time.
- `just check`
- `just test` (43 passed)

Cross-package sync does not apply because this changes no wire format or public API. The generic TS import/export support already exists in `moq-mux`.

(Written by GPT-5.6 Sol)