### PR TITLE
fix(native): apply TLS hostname to WebSocket fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,6 +4909,7 @@ dependencies = [
  "tikv-jemallocator",
  "time",
  "tokio",
+ "tokio-rustls",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-android",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ percent-encoding = "2"
 qmux = { version = "0.5.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"
+tokio-rustls = { version = "0.26", default-features = false }
 web-async = { version = "0.1.5", features = ["tracing"] }
 web-transport-iroh = "0.7"
 # default-features off so the QUIC crypto provider is chosen by moq-native's

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -106,5 +106,6 @@ rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc
 tempfile = "3"
 # test-util adds tokio::time::pause/auto-advance for the time-dependent tests.
 tokio = { workspace = true, features = ["test-util"] }
+tokio-rustls = { version = "0.26", default-features = false }
 toml = "1.1"
 tracing-test = "0.2"

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -106,6 +106,6 @@ rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc
 tempfile = "3"
 # test-util adds tokio::time::pause/auto-advance for the time-dependent tests.
 tokio = { workspace = true, features = ["test-util"] }
-tokio-rustls = { version = "0.26", default-features = false }
+tokio-rustls = { workspace = true }
 toml = "1.1"
 tracing-test = "0.2"

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -232,6 +232,10 @@ pub struct Client {
 	resolution_delay: std::time::Duration,
 	#[cfg(feature = "websocket")]
 	websocket: crate::websocket::Client,
+	/// The TLS server name override used by the WebSocket fallback. QUIC backends
+	/// capture their own copy from the config.
+	#[cfg(feature = "websocket")]
+	tls_host_name: Option<String>,
 	/// Only the rustls-based dials read this. quiche builds its own TLS stack, and the
 	/// plaintext qmux transports have none.
 	#[cfg(any(feature = "noq", feature = "quinn", feature = "websocket"))]
@@ -316,6 +320,8 @@ impl Client {
 		let failover_delay = config.resolved_failover_delay();
 		#[cfg(feature = "tcp")]
 		let resolution_delay = config.resolved_resolution_delay();
+		#[cfg(feature = "websocket")]
+		let tls_host_name = config.tls.host_name.clone();
 		let timeout = config.resolved_connect_timeout();
 
 		Ok(Self {
@@ -338,6 +344,8 @@ impl Client {
 			resolution_delay,
 			#[cfg(feature = "websocket")]
 			websocket: config.websocket,
+			#[cfg(feature = "websocket")]
+			tls_host_name,
 			#[cfg(any(feature = "noq", feature = "quinn", feature = "websocket"))]
 			tls,
 			#[cfg(feature = "noq")]
@@ -618,7 +626,9 @@ impl Client {
 		#[cfg(feature = "websocket")]
 		{
 			let alpns = self.versions.alpns();
-			let session = crate::websocket::connect(&self.websocket, &self.tls, url, &alpns).await?;
+			let session =
+				crate::websocket::connect(&self.websocket, &self.tls, self.tls_host_name.as_deref(), url, &alpns)
+					.await?;
 			return Ok(moq.connect(session).await?);
 		}
 
@@ -648,8 +658,9 @@ impl Client {
 		let alpns = self.versions.alpns();
 		let ws_config = self.websocket.clone();
 		let ws_tls = self.tls.clone();
+		let ws_tls_host_name = self.tls_host_name.clone();
 		let websocket = async move {
-			crate::websocket::race_handle(&ws_config, &ws_tls, url, &alpns)
+			crate::websocket::race_handle(&ws_config, &ws_tls, ws_tls_host_name.as_deref(), url, &alpns)
 				.await
 				.map(|res| res.map_err(Error::from))
 		};

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -6,7 +6,7 @@
 //! through. Servers accept it on a separate TCP port via [`Listener`].
 
 use qmux::ws::tokio_tungstenite;
-use qmux::ws::tokio_tungstenite::tungstenite::{self, http};
+use qmux::ws::tokio_tungstenite::tungstenite::{self, client::IntoClientRequest, http};
 use std::collections::HashSet;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::{net, time};
@@ -108,6 +108,7 @@ impl Default for Client {
 pub(crate) async fn race_handle(
 	config: &Client,
 	tls: &rustls::ClientConfig,
+	tls_host_name: Option<&str>,
 	url: Url,
 	alpns: &[&str],
 ) -> Option<Result<qmux::Session>> {
@@ -122,7 +123,7 @@ pub(crate) async fn race_handle(
 		_ => return None,
 	}
 
-	let res = connect(config, tls, url, alpns).await;
+	let res = connect(config, tls, tls_host_name, url, alpns).await;
 	if let Err(err) = &res {
 		tracing::warn!(%err, "WebSocket connection failed");
 	}
@@ -132,6 +133,7 @@ pub(crate) async fn race_handle(
 pub(crate) async fn connect(
 	config: &Client,
 	tls: &rustls::ClientConfig,
+	tls_host_name: Option<&str>,
 	mut url: Url,
 	alpns: &[&str],
 ) -> Result<qmux::Session> {
@@ -145,7 +147,7 @@ pub(crate) async fn connect(
 		"http" | "ws" => 80,
 		_ => 443,
 	});
-	let key = (host, port);
+	let key = (host.clone(), port);
 
 	// Apply a small penalty to WebSocket to improve odds for QUIC to connect first,
 	// unless we've already had to fall back to WebSockets for this server.
@@ -176,30 +178,84 @@ pub(crate) async fn connect(
 
 	tracing::debug!(%url, "connecting via WebSocket");
 
-	// Use the existing TLS config (which respects tls-disable-verify) for secure connections.
-	let connector = if needs_tls {
-		tokio_tungstenite::Connector::Rustls(Arc::new(tls.clone()))
-	} else {
-		tokio_tungstenite::Connector::Plain
-	};
+	let session = match (needs_tls, tls_host_name) {
+		(true, Some(tls_host_name)) => connect_tls_override(tls, tls_host_name, &url, &host, port, alpns).await?,
+		_ => {
+			// Use the existing TLS config (which respects tls-disable-verify) for secure connections.
+			let connector = if needs_tls {
+				tokio_tungstenite::Connector::Rustls(Arc::new(tls.clone()))
+			} else {
+				tokio_tungstenite::Connector::Plain
+			};
 
-	// Most moq ALPNs can ride on any QMux draft (`&[]` lets the polyfill expand
-	// to every version it knows). `qmux_versions_for` pins the few that the spec
-	// restricts. qmux also offers the bare ALPNs (`qmux-01`, `qmux-00`,
-	// `webtransport`) by default so we still interop with relays that only know a
-	// wire-format version.
-	let session = qmux::ws::Client::new()
-		.with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))))
-		.with_connector(connector)
-		.with_keep_alive(qmux::ws::KeepAlive::default()) // 5s ping / 30s deadline, parity with QUIC
-		.connect(url.as_str())
-		.await
-		.map_err(Error::Connect)?;
+			// Most moq ALPNs can ride on any QMux draft (`&[]` lets the polyfill expand
+			// to every version it knows). `qmux_versions_for` pins the few that the spec
+			// restricts. qmux also offers the bare ALPNs (`qmux-01`, `qmux-00`,
+			// `webtransport`) by default so we still interop with relays that only know a
+			// wire-format version.
+			qmux::ws::Client::new()
+				.with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))))
+				.with_connector(connector)
+				.with_keep_alive(qmux::ws::KeepAlive::default()) // 5s ping / 30s deadline, parity with QUIC
+				.connect(url.as_str())
+				.await
+				.map_err(Error::Connect)?
+		}
+	};
 
 	tracing::warn!(%url, "using WebSocket fallback");
 	WEBSOCKET_WON.lock().unwrap().insert(key);
 
 	Ok(session)
+}
+
+/// Dial the URL address while using a different server name for the TLS layer.
+async fn connect_tls_override(
+	tls: &rustls::ClientConfig,
+	tls_host_name: &str,
+	url: &Url,
+	host: &str,
+	port: u16,
+	alpns: &[&str],
+) -> Result<qmux::Session> {
+	let original_request = url.as_str().into_client_request().map_err(Error::BuildRequest)?;
+	let original_host = original_request
+		.headers()
+		.get(http::header::HOST)
+		.cloned()
+		.ok_or(Error::MissingHostname)?;
+	let mut tls_url = url.clone();
+	tls_url
+		.set_host(Some(tls_host_name))
+		.map_err(|_| Error::Connect(qmux::Error::InvalidServerName))?;
+	let mut request = tls_url.as_str().into_client_request().map_err(Error::BuildRequest)?;
+	request.headers_mut().insert(http::header::HOST, original_host);
+	let protocols = supported_subprotocols(alpns).join(", ");
+	request.headers_mut().insert(
+		http::header::SEC_WEBSOCKET_PROTOCOL,
+		http::HeaderValue::from_str(&protocols).map_err(Error::ProtocolHeader)?,
+	);
+
+	let host = host
+		.strip_prefix('[')
+		.and_then(|host| host.strip_suffix(']'))
+		.unwrap_or(host);
+	let stream = tokio::net::TcpStream::connect((host, port)).await?;
+	let connector = tokio_tungstenite::Connector::Rustls(Arc::new(tls.clone()));
+	let (websocket, response) = tokio_tungstenite::client_async_tls_with_config(request, stream, None, Some(connector))
+		.await
+		.map_err(qmux::Error::from)
+		.map_err(Error::Connect)?;
+
+	let negotiated = response
+		.headers()
+		.get(http::header::SEC_WEBSOCKET_PROTOCOL)
+		.and_then(|value| value.to_str().ok());
+	let upgraded = qmux::ws::Upgraded::new(websocket).with_keep_alive(qmux::ws::KeepAlive::default());
+	Ok(match negotiated {
+		Some(protocol) => upgraded.with_alpn(protocol).connect(),
+		None => upgraded.connect(),
+	})
 }
 
 /// The QMux drafts a moq ALPN is allowed to ride on, for `qmux::ws::Client::with_protocols`.
@@ -425,6 +481,7 @@ fn supported_subprotocols(alpns: &[&str]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 
 	#[test]
 	fn subprotocol_selection_preserves_legacy_clients() {
@@ -453,6 +510,80 @@ mod tests {
 		assert_eq!(url.query(), Some("jwt=test"));
 		drop(session);
 		drop(websocket);
+	}
+
+	#[tokio::test]
+	async fn tls_host_name_override_dials_url_address() {
+		let rcgen::CertifiedKey { cert, signing_key } =
+			rcgen::generate_simple_self_signed(["relay.example".to_string()]).unwrap();
+		let cert = CertificateDer::from(cert);
+		let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
+		let provider = crate::crypto::provider();
+		let server_tls = rustls::ServerConfig::builder_with_provider(provider.clone())
+			.with_safe_default_protocol_versions()
+			.unwrap()
+			.with_no_client_auth()
+			.with_single_cert(vec![cert.clone()], key)
+			.unwrap();
+
+		let mut roots = rustls::RootCertStore::empty();
+		roots.add(cert).unwrap();
+		let client_tls = rustls::ClientConfig::builder_with_provider(provider)
+			.with_safe_default_protocol_versions()
+			.unwrap()
+			.with_root_certificates(roots)
+			.with_no_client_auth();
+
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = listener.local_addr().unwrap();
+		let accepted = tokio::spawn(async move {
+			let (stream, _) = listener.accept().await.unwrap();
+			let tls = tokio_rustls::TlsAcceptor::from(Arc::new(server_tls))
+				.accept(stream)
+				.await
+				.unwrap();
+			let server_name = tls.get_ref().1.server_name().map(str::to_string);
+			let host = Arc::new(Mutex::new(None));
+			let request_host = host.clone();
+			#[allow(clippy::result_large_err)]
+			let callback = move |request: &tungstenite::handshake::server::Request,
+			            mut response: tungstenite::handshake::server::Response| {
+				*request_host.lock().unwrap() = request
+					.headers()
+					.get(http::header::HOST)
+					.and_then(|value| value.to_str().ok())
+					.map(str::to_string);
+				if let Some(protocol) = request
+					.headers()
+					.get(http::header::SEC_WEBSOCKET_PROTOCOL)
+					.and_then(|value| value.to_str().ok())
+					.and_then(|value| value.split(',').next())
+					.map(str::trim)
+				{
+					response.headers_mut().insert(
+						http::header::SEC_WEBSOCKET_PROTOCOL,
+						http::HeaderValue::from_str(protocol).unwrap(),
+					);
+				}
+				Ok(response)
+			};
+			let _websocket = tokio_tungstenite::accept_hdr_async(tls, callback).await.unwrap();
+			let host = host.lock().unwrap().take();
+			(server_name, host)
+		});
+
+		let config = Client {
+			delay: None,
+			..Default::default()
+		};
+		let url = Url::parse(&format!("wss://127.0.0.1:{}/anon", addr.port())).unwrap();
+		let session = connect(&config, &client_tls, Some("relay.example"), url, moq_net::ALPNS)
+			.await
+			.unwrap();
+		drop(session);
+		let (server_name, host) = accepted.await.unwrap();
+		assert_eq!(server_name.as_deref(), Some("relay.example"));
+		assert_eq!(host.as_deref(), Some(format!("127.0.0.1:{}", addr.port()).as_str()));
 	}
 
 	#[test]

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -66,7 +66,7 @@ serde_with = { version = "3", features = ["json", "base64"] }
 sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }
-tokio-rustls = { version = "0.26", default-features = false }
+tokio-rustls = { workspace = true }
 toml = "1.1"
 tower-http = { version = "0.7", features = ["cors"] }
 tower-service = "0.3"

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -50,7 +50,7 @@ tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "time"
 # RTMPS: TLS-terminate accepted connections. Mirrors moq-relay's pinning so the
 # workspace shares one tokio-rustls; the crypto provider comes from the supplied
 # `rustls::ServerConfig`, so no default crypto feature is needed here.
-tokio-rustls = { version = "0.26", default-features = false, optional = true }
+tokio-rustls = { workspace = true, optional = true }
 tracing = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- Pass the configured client TLS hostname into the WebSocket fallback.
- Dial the address from the connect URL while using the override for TLS SNI and certificate verification, preserving the original HTTP Host header.
- Share the existing `tokio-rustls` version through the workspace dependency table, converting the relay and RTMP consumers so repository policy has one authoritative pin.
- Root cause: the WebSocket path delegated both dialing and TLS naming to the raw connect URL, so direct IP dials verified the certificate against the IP.

## Public API changes

- None. The new plumbing is private to moq-native.

## Test plan

- `nix develop --command just check`
- `nix develop --command just test` (3,156 passed, 1 skipped)
- The regression test verifies that a raw-IP WebSocket dial uses the configured TLS hostname for SNI and certificate verification.
- Cross-package sync is not applicable because this does not change the wire format or public API.

Closes #3077

(Written by GPT-5.6)
