### PR TITLE
fix(ci): save the Swift Rust cache from main, not from pull requests

### DIFF
--- a/.github/workflows/alert.yml
+++ b/.github/workflows/alert.yml
@@ -18,8 +18,13 @@ on:
   workflow_run:
     # Matched by workflow `name:`, not filename. Every workflow that can run
     # outside a pull request belongs here; the pull-request-only ones (Check,
-    # macOS, Swift, Windows) are omitted so they don't spawn a skipped Alert run
-    # on every push to every PR. `just gh check` enforces both halves of that.
+    # macOS, Windows) are omitted so they don't spawn a skipped Alert run on
+    # every push to every PR. `just gh check` enforces both halves of that.
+    #
+    # Swift is here despite also running on pull requests: it warms its own
+    # Rust cache on `main`, and that push run is nobody's check, so a break in
+    # it would otherwise go unseen. The cost is a skipped Alert run per Swift
+    # pull request.
     workflows:
       - apt-repo
       - Cache
@@ -45,6 +50,7 @@ on:
       - release-winget
       - rpm-repo
       - Smoke
+      - Swift
       - Update Flake
     types:
       - completed

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,6 +4,20 @@ permissions:
   contents: read
 
 on:
+  # `main` is the single writer of this workflow's Rust cache, mirroring
+  # cache.yml. Actions scopes cache reads to the current branch plus the default
+  # branch, so an entry saved by a pull request is readable only by that same
+  # pull request while still counting against the repository's 10 GB budget,
+  # evicting the shared entries everyone else restores. This run exists to save
+  # one; it checks a commit that was already checked as a pull request.
+  push:
+    branches: [main]
+    paths:
+      - "swift/**"
+      - "rs/moq-ffi/**"
+      - "rs/moq-video/**"
+      - "Cargo.lock"
+      - ".github/workflows/swift.yml"
   pull_request:
     # `closed` is here only so merging/closing a PR cancels its in-flight run
     # via the concurrency group below; the job itself is skipped on close.
@@ -16,7 +30,10 @@ on:
       - ".github/workflows/swift.yml"
 
 concurrency:
-  group: swift-${{ github.ref }}
+  # Keyed by event as well as ref: a merged pull request's `closed` run and the
+  # `main` push run it triggers are simultaneous, and if they shared a group the
+  # skipped one could cancel the cache writer.
+  group: swift-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -40,6 +57,11 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
         with:
+          # Restore everywhere, save only on `main`; see the `on:` comment. The
+          # key is derived from the job id, the rustc identity and the manifests,
+          # none of which depend on the event, so a pull request restores what a
+          # push saved.
+          save-if: ${{ github.event_name == 'push' }}
           cache-on-failure: true
 
       - name: Rust simulator check


### PR DESCRIPTION
## Problem

`swift.yml` runs `Swatinem/rust-cache` with the default `save-if`, so every macOS pull request job saves its own entry:

```
0.77GB  refs/pull/3026/merge  v0-rust-check-Darwin-arm64-9d958888-838bc9fa
0.77GB  refs/pull/3026/merge  v0-rust-check-Darwin-arm64-9d958888-b05d0016
0.78GB  refs/pull/3081/merge  v0-rust-check-Darwin-arm64-9d958888-bbcf512d
```

Actions scopes cache reads to the current branch plus the default branch, so a `refs/pull/N` entry is readable only by that same pull request. It still counts against the shared budget: ~2.3 GB of it, against `active_caches_size_in_bytes: 10250402887` over an allowance of 10 GB. Everything above the line is evicted LRU, so these unshared entries push out the `refs/heads/main` Rust caches that `check.yml` restores on every pull request.

`cache.yml` already documents the rule ("Pull requests are readers (`save-if: false`) rather than writers of private entries that fill the repository's 10 GB budget") and elects a single writer on `main`. This workflow was never brought in line, and it could not be: it only triggers on `pull_request`, so there was no run on `main` to write the entry a reader would restore.

## Change

Give it the same shape as `cache.yml`:

- Trigger on `main` pushes under the existing path filter, so there is a writer.
- `save-if: ${{ github.event_name == 'push' }}`, so pull requests restore without saving.

The cache key is composed of the job id (`check`), the rustc identity and the manifest/lockfile hashes. None of those depend on the event, so a pull request restores exactly what the push saved. `if: github.event.action != 'closed'` still passes on `push`, where `github.event.action` is null.

### Concurrency

The group is now keyed on the event as well as the ref. GitHub documents that a merged pull request's `closed` run reports `github.ref` as the base branch rather than `refs/pull/N/merge`:

> If a pull request was closed as a result of being merged, it will be the fully qualified `ref` of the branch it was merged into, for example `/refs/heads/main`.

That skipped `closed` run fires alongside the `main` push run this change adds. Sharing one group with `cancel-in-progress: true` would let the no-op cancel the only cache writer.

### alert.yml

Carrying a non-`pull_request` trigger puts Swift under `alert.sh check-coverage`, which fails the build until the workflow is listed. Added, and wanted on its own terms: the `main` run is nobody's check, so a break in it would otherwise go unseen. The cost is a skipped Alert run per Swift pull request.

## Noticed while measuring, not addressed here

- `cache.yml`'s `Warm (ubuntu-latest)` leg has been failing on `_wants-wasm` for several runs, so the x64 entries are only as fresh as the last green run. The arm64 leg is green, which is the one `check.yml` restores.
- By the same documented ref behavior, `check.yml`'s comment that `closed` "cancels its in-flight run via the concurrency group" holds only for a pull request closed *without* merging. On a merge, the `closed` run lands in `check-refs/heads/main` while the in-flight run sits in `check-refs/pull/N/merge`, so nothing is cancelled and the superseded run keeps a runner until it finishes.

(Written by Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)