### PR TITLE
perf(net): seek instead of scan for the next in-range group

### DIFF
--- a/rs/moq-net/benches/group.rs
+++ b/rs/moq-net/benches/group.rs
@@ -1,4 +1,4 @@
-//! Per-frame overhead benchmarks for the group model.
+//! Delivery-path benchmarks for the group and track models.
 //!
 //! The point of interest is small frames: today each frame in a group is a
 //! `frame::Producer` owning its own `kio` channel plus a couple of `Arc`s, so a
@@ -6,6 +6,9 @@
 //! objects. These benchmarks write and read many small frames so that cost shows
 //! up as wall-clock time, giving a before/after for reshaping frames into plain
 //! data.
+//!
+//! `track_recv_groups` covers the layer above: how much it costs to hand out one
+//! cached group, swept over cache depth so a per-delivery scan shows up as a slope.
 //!
 //! Run with `cargo bench -p moq-net`.
 
@@ -24,6 +27,12 @@ const PAYLOAD: usize = 64;
 /// Frame counts to sweep. The top end intentionally reaches the raised
 /// `MAX_GROUP_FRAMES` so a full group of tiny frames is exercised.
 const COUNTS: [usize; 3] = [512, 8_192, 32_768];
+
+/// Cached group counts to sweep for the track-level delivery benchmarks. A track
+/// publishing one group per frame at the default 5s retention sits in the hundreds,
+/// so the top end is deliberately past anything realistic: a per-delivery scan over
+/// the cache shows up as a slope here, while a seek stays flat.
+const DEPTHS: [usize; 3] = [64, 512, 4_096];
 
 /// Keeps the broadcast/track producers alive alongside the group so the group
 /// isn't torn down mid-benchmark. Only `group` is written to.
@@ -101,6 +110,76 @@ fn bench_read(c: &mut Criterion) {
 	g.finish();
 }
 
+/// Keeps the broadcast alive alongside the track being drained.
+struct TrackCtx {
+	_broadcast: broadcast::Producer,
+	track: track::Producer,
+}
+
+/// Build a track holding N cached groups, each with a single small frame.
+fn filled_track(n: usize, payload: &Bytes) -> TrackCtx {
+	let mut broadcast = broadcast::Producer::new(broadcast::Info::default());
+	let mut track = broadcast.create_track("bench", None).unwrap();
+	for _ in 0..n {
+		let mut group = track.append_group().unwrap();
+		group.write_frame(Timestamp::ZERO, payload.clone()).unwrap();
+		group.finish().unwrap();
+	}
+	TrackCtx {
+		_broadcast: broadcast,
+		track,
+	}
+}
+
+/// Drain N cached groups from a track, in arrival order and in sequence order.
+///
+/// The two differ in how they find the next group: `recv_group` walks an arrival
+/// index, while `next_group` seeks by sequence. Both should be flat in the cache
+/// depth; a per-delivery scan over the cache makes the sequence-ordered arm
+/// quadratic in N.
+fn bench_track_recv(c: &mut Criterion) {
+	let payload = Bytes::from(vec![0u8; PAYLOAD]);
+	let mut g = c.benchmark_group("track_recv_groups");
+	for &n in &DEPTHS {
+		g.throughput(Throughput::Elements(n as u64));
+		g.bench_with_input(BenchmarkId::new("arrival", n), &n, |b, &n| {
+			b.iter_batched(
+				|| {
+					let ctx = filled_track(n, &payload);
+					let subscriber = ctx.track.subscribe(None);
+					(ctx, subscriber)
+				},
+				|(ctx, mut subscriber)| {
+					for _ in 0..n {
+						let group = subscriber.recv_group().now_or_never().unwrap().unwrap().unwrap();
+						black_box(group);
+					}
+					(ctx, subscriber)
+				},
+				BatchSize::SmallInput,
+			);
+		});
+		g.bench_with_input(BenchmarkId::new("sequence", n), &n, |b, &n| {
+			b.iter_batched(
+				|| {
+					let ctx = filled_track(n, &payload);
+					let subscriber = ctx.track.subscribe(None);
+					(ctx, subscriber)
+				},
+				|(ctx, mut subscriber)| {
+					for _ in 0..n {
+						let group = subscriber.next_group().now_or_never().unwrap().unwrap().unwrap();
+						black_box(group);
+					}
+					(ctx, subscriber)
+				},
+				BatchSize::SmallInput,
+			);
+		});
+	}
+	g.finish();
+}
+
 /// The full lifecycle: build a group, write N frames, then drain them.
 fn bench_roundtrip(c: &mut Criterion) {
 	let payload = Bytes::from(vec![0u8; PAYLOAD]);
@@ -129,5 +208,5 @@ fn bench_roundtrip(c: &mut Criterion) {
 	g.finish();
 }
 
-criterion_group!(benches, bench_write, bench_read, bench_roundtrip);
+criterion_group!(benches, bench_write, bench_read, bench_roundtrip, bench_track_recv);
 criterion_main!(benches);

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -21,7 +21,7 @@ use super::{Datagram, Requests};
 pub use super::subscription::Subscription;
 
 use std::{
-	collections::{BTreeMap, HashMap, VecDeque},
+	collections::{BTreeMap, VecDeque},
 	sync::Arc,
 	sync::OnceLock,
 	sync::atomic::{AtomicBool, Ordering},
@@ -146,7 +146,11 @@ pub(crate) struct TrackState {
 	// Cached groups by sequence: the single source of truth for what is cached. The
 	// two orderings below hold bare sequences and validate against this map, so a
 	// removed or replaced group turns their entries into discarded-on-pop hints.
-	lookup: HashMap<u64, Slot>,
+	//
+	// Ordered rather than hashed so `poll_next_in_range` can seek to the first
+	// cached sequence at or above a subscriber's cursor. A hash map forces a full
+	// scan per delivery, making a drain of N cached groups quadratic.
+	lookup: BTreeMap<u64, Slot>,
 
 	// Publisher-produced groups in arrival order as (sequence, stamp), walked by
 	// subscriptions; an entry only resolves while its stamp matches the slot's.
@@ -408,24 +412,14 @@ impl TrackState {
 			return Poll::Pending;
 		}
 
-		let mut best: Option<&group::Producer> = None;
-		for slot in self.lookup.values() {
-			let group = &slot.group;
-			if group.sequence < next_sequence {
-				continue;
-			}
-			if let Some(end) = end_sequence
-				&& group.sequence > end
-			{
-				continue;
-			}
-			if group.is_aborted() {
-				continue;
-			}
-			if best.is_none_or(|b| group.sequence < b.sequence) {
-				best = Some(group);
-			}
-		}
+		// Seek straight to the cursor: only aborted groups (waiting on the next
+		// eviction scan to reclaim their slots) are stepped over.
+		let best = self
+			.lookup
+			.range(next_sequence..)
+			.map(|(_, slot)| &slot.group)
+			.take_while(|group| end_sequence.is_none_or(|end| group.sequence <= end))
+			.find(|group| !group.is_aborted());
 
 		if let Some(group) = best {
 			// Delivery is a cache access, same as the arrival-order path.


### PR DESCRIPTION
## Summary

- **Root cause**: `TrackState::lookup` was a `HashMap<u64, Slot>`. A hash map has no order, so `poll_next_in_range` had to scan every cached slot to find the lowest sequence at or above the subscriber's cursor. `Subscriber::next_group` calls it once per delivery, so draining N cached groups was O(N * cache_size).
- This is the path the media consumers use (`moq-mux`'s container and MSF catalog readers, `moq-json`, `moq-ffi`, `moq-transcode`'s feed, and `moq-net`'s resume), and cache depth is the retained group count. A track publishing one group per frame (hang audio, any `write_frame` track) at the default 5s retention holds ~250 groups, so every delivery scanned ~250 entries.
- **Fix**: make `lookup` a `BTreeMap` and seek with `range(next_sequence..)`. The `end_sequence` cap becomes a `take_while`, which is only correct because iteration is now ascending; the old scan had to `continue` past it. Aborted slots (awaiting the next eviction scan to reclaim them) are still stepped over, and the early return that *parks* rather than ends the stream when `end < next_sequence` is unchanged, as is `final_sequence` termination.
- **Trade**: `lookup` get/insert/remove go from O(1) to O(log n). Those are the eviction and fetch paths, which touch one entry at a time, so it is a good trade against removing a full scan per delivery. There is a single insert site and it keys on `group.sequence`, so the seek key is exact.

## Numbers

New `track_recv_groups` bench arm, sweeping cache depth across both delivery orders. `arrival` is `recv_group` (an arrival-order index walk, already flat); `sequence` is `next_group`.

| cached groups | arrival | sequence (before) | sequence (after) |
|---|---|---|---|
| 64 | 1.79 Melem/s | 720 Kelem/s | 1.64 Melem/s |
| 512 | 1.72 Melem/s | 110 Kelem/s | 1.89 Melem/s |
| 4096 | 1.76 Melem/s | 16.7 Kelem/s | 1.79 Melem/s |

Flat across a 64x depth increase, ~107x at the top end. The "before" column is from the original report; the "after" column and the `arrival` baseline are from this branch.

## Public API changes

None. `TrackState` and its `lookup` field are `pub(crate)`; no `pub` item in `rs/moq-*` or `js/*` is added, renamed, removed, or resignatured. The only additions are private helpers in the benchmark. Targets `main` accordingly.

## Test plan

- `just fix` (no changes beyond the two files here), `just check`, `just test`: 2799 tests pass, 1 skipped.
- Added the `track_recv_groups` arm to `rs/moq-net/benches/group.rs` as the regression guard. nextest runs criterion benches in test mode, so the arm is exercised in CI rather than rotting until someone next runs `cargo bench`.
- Ran `cargo bench -p moq-net --bench group -- track_recv_groups` for the table above.

## Cross-Package Sync

No row applies: this is an internal data-structure change in `moq-net` with no wire, catalog, config, or CLI surface touched, so `js/net` and the drafts are unaffected.

## Follow-up

#3086 covers making the delivery order a handle (`ordered()`) rather than a method choice, and moving `moq-mux`'s timestamp-based group skipping down into `moq-net`. Worth noting for reviewers: this fix removes the *performance* argument for treating sequence order as the slower opt-in path, but the API argument stands on its own, since `recv_datagram` bumps `next_sequence` and `read_frame` bumps both cursors, making the two orders quietly interact on one `Subscriber`.

---

(Written by Claude Opus 5)
