### PR TITLE
feat(net): batch frame reads and writes through a reusable buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,6 +4930,7 @@ dependencies = [
 name = "moq-net"
 version = "0.2.15"
 dependencies = [
+ "arrayvec",
  "bytes",
  "criterion",
  "futures",

--- a/rs/moq-net/Cargo.toml
+++ b/rs/moq-net/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["multimedia", "network-programming", "web-programming"]
 ignored = ["getrandom"]
 
 [dependencies]
+arrayvec = "0.7"
 bytes = "1"
 futures = "0.3"
 kio = { workspace = true, features = ["time"] }

--- a/rs/moq-net/benches/group.rs
+++ b/rs/moq-net/benches/group.rs
@@ -131,6 +131,10 @@ fn drain_batched<const N: usize>(consumer: &mut group::Consumer, buf: &mut frame
 /// `single` is one frame at a time via [`group::Consumer::read_frame`]: a lock and a
 /// waker each. `batch{N}` is [`group::Consumer::read_frames`] cloning the ready tail
 /// into a reused `N`-frame buffer, amortizing both across the batch.
+///
+/// Throughput keeps climbing to 32 and stalls after (128 falls out of L1), but the
+/// default capacity is 8: the tail of that curve only pays off for a reader draining a
+/// backlog, while every buffer pays its stack whether or not the batch fills.
 fn bench_read(c: &mut Criterion) {
 	let payload = Bytes::from(vec![0u8; PAYLOAD]);
 	let mut g = c.benchmark_group("group_read_frames");

--- a/rs/moq-net/benches/group.rs
+++ b/rs/moq-net/benches/group.rs
@@ -17,7 +17,7 @@ use std::hint::black_box;
 use bytes::Bytes;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use futures::FutureExt;
-use moq_net::{Timestamp, broadcast, group, track};
+use moq_net::{Timestamp, broadcast, frame, group, track};
 
 /// A small, fixed payload shared across every frame. Cloning a `Bytes` is a
 /// refcount bump (no allocation), so the benchmark isolates the per-frame control
@@ -55,12 +55,37 @@ fn fresh_group() -> Ctx {
 }
 
 /// Write N small frames into a fresh group (producer-side per-frame cost).
+///
+/// `single` is one `write_frame` per frame: a group lock plus a track-level eviction
+/// settle each. `batch32` fills a `frame::Buffer` and hands the whole thing to
+/// `write_frames`, paying both once per batch.
 fn bench_write(c: &mut Criterion) {
 	let payload = Bytes::from(vec![0u8; PAYLOAD]);
 	let mut g = c.benchmark_group("group_write_frames");
 	for &n in &COUNTS {
 		g.throughput(Throughput::Elements(n as u64));
-		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+		g.bench_with_input(BenchmarkId::new("batch32", n), &n, |b, &n| {
+			b.iter_batched(
+				|| (fresh_group(), frame::Buffer::<32>::new()),
+				|(mut ctx, mut buf)| {
+					for _ in 0..n {
+						let frame = frame::Frame {
+							timestamp: Timestamp::ZERO,
+							payload: payload.clone(),
+						};
+						// A full buffer hands the frame back: flush, then take it.
+						if let Err(frame) = buf.push(frame) {
+							ctx.group.write_frames(&mut buf).unwrap();
+							buf.push(frame).unwrap();
+						}
+					}
+					ctx.group.write_frames(&mut buf).unwrap();
+					(ctx, buf)
+				},
+				BatchSize::SmallInput,
+			);
+		});
+		g.bench_with_input(BenchmarkId::new("single", n), &n, |b, &n| {
 			b.iter_batched(
 				fresh_group,
 				|mut ctx| {
@@ -77,23 +102,43 @@ fn bench_write(c: &mut Criterion) {
 	g.finish();
 }
 
+/// A pre-filled, finished group plus a consumer positioned at its first frame.
+fn filled_group(n: usize, payload: &Bytes) -> (Ctx, group::Consumer) {
+	let mut ctx = fresh_group();
+	for _ in 0..n {
+		ctx.group.write_frame(Timestamp::ZERO, payload.clone()).unwrap();
+	}
+	ctx.group.finish().unwrap();
+	let consumer = ctx.group.consume();
+	(ctx, consumer)
+}
+
+/// Drain a whole group through a reused `frame::Buffer<N>`.
+fn drain_batched<const N: usize>(consumer: &mut group::Consumer, buf: &mut frame::Buffer<N>) {
+	loop {
+		let batch = consumer.read_frames(buf).now_or_never().unwrap().unwrap();
+		if batch.is_empty() {
+			break;
+		}
+		for frame in batch.iter() {
+			black_box(frame);
+		}
+	}
+}
+
 /// Drain N small frames from a pre-filled group (consumer-side per-frame cost).
+///
+/// `single` is one frame at a time via [`group::Consumer::read_frame`]: a lock and a
+/// waker each. `batch{N}` is [`group::Consumer::read_frames`] cloning the ready tail
+/// into a reused `N`-frame buffer, amortizing both across the batch.
 fn bench_read(c: &mut Criterion) {
 	let payload = Bytes::from(vec![0u8; PAYLOAD]);
 	let mut g = c.benchmark_group("group_read_frames");
 	for &n in &COUNTS {
 		g.throughput(Throughput::Elements(n as u64));
-		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+		g.bench_with_input(BenchmarkId::new("single", n), &n, |b, &n| {
 			b.iter_batched(
-				|| {
-					let mut ctx = fresh_group();
-					for _ in 0..n {
-						ctx.group.write_frame(Timestamp::ZERO, payload.clone()).unwrap();
-					}
-					ctx.group.finish().unwrap();
-					let consumer = ctx.group.consume();
-					(ctx, consumer)
-				},
+				|| filled_group(n, &payload),
 				|(ctx, mut consumer)| {
 					for _ in 0..n {
 						// All frames are already present and finished, so a single poll
@@ -106,6 +151,31 @@ fn bench_read(c: &mut Criterion) {
 				BatchSize::SmallInput,
 			);
 		});
+
+		// The buffer is allocated in setup and refilled for the whole group, like a
+		// real reader that keeps one per task.
+		macro_rules! batched {
+			($cap:expr) => {
+				g.bench_with_input(BenchmarkId::new(concat!("batch", $cap), n), &n, |b, &n| {
+					b.iter_batched(
+						|| {
+							let (ctx, consumer) = filled_group(n, &payload);
+							(ctx, consumer, frame::Buffer::<$cap>::new())
+						},
+						|(ctx, mut consumer, mut buf)| {
+							drain_batched(&mut consumer, &mut buf);
+							(ctx, consumer, buf)
+						},
+						BatchSize::SmallInput,
+					);
+				});
+			};
+		}
+
+		batched!(4);
+		batched!(8);
+		batched!(32);
+		batched!(128);
 	}
 	g.finish();
 }

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -139,6 +139,13 @@ pub enum Error {
 	/// A remote error received via a stream/session reset code.
 	#[error("remote error: code={0}")]
 	Remote(u32),
+	/// A whole-frame write was refused because a frame is already open on the group.
+	///
+	/// A [`crate::group::Producer`] streaming a frame with `create_frame` blocks the
+	/// whole-frame writes on every clone of that producer until it finishes, since
+	/// appending around it would reorder the group.
+	#[error("frame already open")]
+	FrameOpen,
 }
 
 impl Error {
@@ -173,6 +180,8 @@ impl Error {
 			Self::TimestampMismatch => 29,
 			Self::Unroutable => 30,
 			Self::Evicted => 31,
+			// 22 was unused in the 0-31 library range.
+			Self::FrameOpen => 22,
 			Self::App(app) => *app as u32 + 64,
 			Self::Remote(code) => *code,
 		}

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -793,6 +793,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						} else {
 							stream.write_chunk(frame.payload).await?;
 						}
+						// The fill stamped the group once. A flow-controlled peer can
+						// take longer than `latency_max` to accept one batch, so keep
+						// stamping or the rest of the group expires mid-serve.
+						group.keep_alive();
 					}
 				}
 				Step::Partial(mut frame) => {

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1626,56 +1626,91 @@ mod group_priority_test {
 	/// live edge.
 	#[tokio::test]
 	async fn batched_and_streamed_frames_encode_identically() {
-		const FRAMES: usize = 40;
+		const FRAMES: usize = 12;
+		const PAYLOAD: usize = 7;
 
-		async fn serve(chunked: bool) -> Vec<u8> {
-			let log = crate::lite::test_transport::Log::default();
-			let session = SinkSession::new(log.clone());
-
-			let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
-			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
-			for i in 0..FRAMES {
-				let timestamp = crate::Timestamp::from_millis(i as u64 * 10).unwrap();
-				let payload = vec![i as u8; 7];
-				if chunked {
-					// Written a byte at a time and completed, so the group holds no open
-					// tail by the time it is served: the batch read takes them all.
-					let mut frame = group
-						.create_frame(crate::frame::Info {
-							size: payload.len() as u64,
-							timestamp,
-						})
-						.unwrap();
-					for byte in &payload {
-						frame.write(&[*byte][..]).unwrap();
-					}
-					frame.finish().unwrap();
-				} else {
-					group.write_frame(timestamp, payload.as_slice()).unwrap();
-				}
-			}
-			let consumer = group.consume();
-			group.finish().unwrap();
-
-			let msg = ietf::GroupHeader {
+		fn header() -> ietf::GroupHeader {
+			ietf::GroupHeader {
 				track_alias: 0,
 				group_id: 0,
 				sub_group_id: 0,
 				publisher_priority: 0,
 				flags: Default::default(),
-			};
-
-			Publisher::<SinkSession>::run_group(session, msg, 0, consumer, Timescale::default(), Version::Draft14)
-				.await
-				.unwrap();
-
-			log.writes.lock().unwrap().clone()
+			}
 		}
 
-		let whole = serve(false).await;
-		let chunked = serve(true).await;
-		assert!(!whole.is_empty(), "the group produced no bytes");
-		assert_eq!(whole, chunked, "batched and chunked writes must encode the same");
+		fn payload(i: usize) -> Vec<u8> {
+			vec![i as u8; PAYLOAD]
+		}
+
+		fn timestamp(i: usize) -> crate::Timestamp {
+			crate::Timestamp::from_millis(i as u64 * 10).unwrap()
+		}
+
+		// Every frame complete before serving starts: the batch read takes them all.
+		let batched = {
+			let log = crate::lite::test_transport::Log::default();
+			let session = SinkSession::new(log.clone());
+			let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
+			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+			for i in 0..FRAMES {
+				group.write_frame(timestamp(i), payload(i).as_slice()).unwrap();
+			}
+			let consumer = group.consume();
+			group.finish().unwrap();
+
+			Publisher::<SinkSession>::run_group(session, header(), 0, consumer, Timescale::default(), Version::Draft14)
+				.await
+				.unwrap();
+			log.writes.lock().unwrap().clone()
+		};
+
+		// Every frame still open when the publisher reaches it, so each one streams a
+		// chunk at a time down the `Step::Partial` path.
+		let streamed = {
+			let log = crate::lite::test_transport::Log::default();
+			let session = SinkSession::new(log.clone());
+			let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
+			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+			let consumer = group.consume();
+
+			let mut serve = std::pin::pin!(Publisher::<SinkSession>::run_group(
+				session,
+				header(),
+				0,
+				consumer,
+				Timescale::default(),
+				Version::Draft14
+			));
+			// Past the group header, parked with nothing to send.
+			assert!(futures::poll!(serve.as_mut()).is_pending());
+
+			for i in 0..FRAMES {
+				{
+					let mut frame = group
+						.create_frame(crate::frame::Info {
+							size: PAYLOAD as u64,
+							timestamp: timestamp(i),
+						})
+						.unwrap();
+					// The publisher is parked on this frame, so each chunk is forwarded
+					// before the next one is written.
+					for byte in payload(i) {
+						frame.write(&[byte][..]).unwrap();
+						assert!(futures::poll!(serve.as_mut()).is_pending());
+					}
+					frame.finish().unwrap();
+				}
+				assert!(futures::poll!(serve.as_mut()).is_pending());
+			}
+
+			group.finish().unwrap();
+			serve.await.unwrap();
+			log.writes.lock().unwrap().clone()
+		};
+
+		assert!(!batched.is_empty(), "the group produced no bytes");
+		assert_eq!(batched, streamed, "batched and streamed writes must encode the same");
 	}
 
 	/// A frame still being written must reach the wire as it fills rather than waiting

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1,10 +1,10 @@
-use crate::{group, origin, track};
+use crate::{frame, group, origin, track};
 use std::{collections::HashMap, task::Poll};
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 
 use crate::{
-	AsPath, Error, Timescale,
+	AsPath, Error, Timescale, Timestamp,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
 	track::Subscription,
@@ -43,6 +43,17 @@ struct Watched {
 /// A peer answers a request it declines with a retry interval ({{moqt}} REQUEST_ERROR),
 /// and ignoring it is how a permanent refusal (unauthorized, uninterested) turns into a
 /// request every few seconds for the life of the session.
+/// What a group has next for [`Publisher::run_group`]: a batch of complete frames
+/// waiting in the buffer, a consumer for the in-flight tail, or the end of the group.
+enum Step {
+	/// The buffer was refilled; its frames are the next ones to send.
+	Batch,
+	/// Nothing is complete yet, so stream the open tail chunk by chunk.
+	Partial(frame::Consumer),
+	/// The group ended.
+	Done,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 enum Refused {
 	/// Never refused, or refused on a draft whose error carries no interval, so our own
@@ -748,62 +759,75 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		stream.encode(&msg).await?;
 
+		// A subscriber catching up on a cached group takes the whole backlog under one
+		// lock; at the live edge the batch comes up empty and the open tail streams
+		// chunk by chunk, so forwarding never waits for a frame to complete.
+		let mut buf: frame::Buffer = frame::Buffer::new();
 		loop {
-			// Wait for the next frame, bailing if the peer closes the stream first.
-			let frame = {
+			// Wait for whatever the group has next, bailing if the peer closes first.
+			let step = {
 				let mut closed = std::pin::pin!(stream.closed());
 				kio::wait(|waiter| {
 					if waiter.poll_future(closed.as_mut()).is_ready() {
 						return Poll::Ready(Err(Error::Cancel));
 					}
-					group.poll_next_frame(waiter)
+					match group.poll_read_frames(waiter, &mut buf) {
+						Poll::Pending => group
+							.poll_next_frame(waiter)
+							.map_ok(|frame| frame.map_or(Step::Done, Step::Partial)),
+						res => res.map_ok(|count| if count == 0 { Step::Done } else { Step::Batch }),
+					}
 				})
 				.await
 			};
 
-			let mut frame = match frame? {
-				Some(frame) => frame,
-				None => break,
-			};
-
-			// object id delta is always 0.
-			stream.encode(&0u64).await?;
-
-			// Per-object extension headers carry the frame's presentation timestamp.
-			if msg.flags.has_extensions {
-				let mut ext = bytes::BytesMut::new();
-				ietf::encode_object_time(&mut ext, frame.timestamp, timescale, version)?;
-				stream.encode(&(ext.len() as u64)).await?;
-				stream.write_chunk(ext.freeze()).await?;
-			}
-
-			// Write the size of the frame.
-			stream.encode(&frame.size).await?;
-
-			if frame.size == 0 {
-				// Have to write the object status too.
-				stream.encode(&0u8).await?;
-			} else {
-				// Stream each chunk of the frame.
-				loop {
-					let chunk = {
-						let mut closed = std::pin::pin!(stream.closed());
-						kio::wait(|waiter| {
-							if waiter.poll_future(closed.as_mut()).is_ready() {
-								return Poll::Ready(Err(Error::Cancel));
-							}
-							frame.poll_read_chunk(waiter)
-						})
-						.await
-					};
-
-					match chunk? {
-						Some(chunk) => {
-							stream.write_chunk(chunk).await?;
+			match step? {
+				Step::Batch => {
+					for i in 0..buf.filled().len() {
+						let frame = buf.filled()[i].clone();
+						Self::write_object_header(&mut stream, &msg, frame.timestamp, timescale, version).await?;
+						stream.encode(&(frame.payload.len() as u64)).await?;
+						if frame.payload.is_empty() {
+							// Have to write the object status too.
+							stream.encode(&0u8).await?;
+						} else {
+							stream.write_chunk(frame.payload).await?;
 						}
-						None => break,
 					}
 				}
+				Step::Partial(mut frame) => {
+					Self::write_object_header(&mut stream, &msg, frame.timestamp, timescale, version).await?;
+
+					// Write the size of the frame.
+					stream.encode(&frame.size).await?;
+
+					if frame.size == 0 {
+						// Have to write the object status too.
+						stream.encode(&0u8).await?;
+					} else {
+						// Stream each chunk of the frame.
+						loop {
+							let chunk = {
+								let mut closed = std::pin::pin!(stream.closed());
+								kio::wait(|waiter| {
+									if waiter.poll_future(closed.as_mut()).is_ready() {
+										return Poll::Ready(Err(Error::Cancel));
+									}
+									frame.poll_read_chunk(waiter)
+								})
+								.await
+							};
+
+							match chunk? {
+								Some(chunk) => {
+									stream.write_chunk(chunk).await?;
+								}
+								None => break,
+							}
+						}
+					}
+				}
+				Step::Done => break,
 			}
 		}
 
@@ -813,6 +837,29 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		stream.close().await?;
 
 		tracing::debug!(sequence = %msg.group_id, "finished group");
+
+		Ok(())
+	}
+
+	/// Write one object's header: the id delta (always 0) and, when the group carries
+	/// extensions, the presentation timestamp.
+	async fn write_object_header(
+		stream: &mut Writer<S::SendStream, Version>,
+		msg: &ietf::GroupHeader,
+		timestamp: Timestamp,
+		timescale: Timescale,
+		version: Version,
+	) -> Result<(), Error> {
+		// object id delta is always 0.
+		stream.encode(&0u64).await?;
+
+		// Per-object extension headers carry the frame's presentation timestamp.
+		if msg.flags.has_extensions {
+			let mut ext = bytes::BytesMut::new();
+			ietf::encode_object_time(&mut ext, timestamp, timescale, version)?;
+			stream.encode(&(ext.len() as u64)).await?;
+			stream.write_chunk(ext.freeze()).await?;
+		}
 
 		Ok(())
 	}
@@ -1566,6 +1613,110 @@ mod group_priority_test {
 			log.priorities(),
 			vec![200],
 			"model priority must pass through unchanged"
+		);
+	}
+
+	/// `run_group` takes two routes to the wire: complete frames come out of a batch
+	/// read, while an in-flight frame streams chunk by chunk. The two must encode
+	/// identically, or a subscriber catching up sees different bytes than one at the
+	/// live edge.
+	#[tokio::test]
+	async fn batched_and_streamed_frames_encode_identically() {
+		const FRAMES: usize = 40;
+
+		async fn serve(chunked: bool) -> Vec<u8> {
+			let log = crate::lite::test_transport::Log::default();
+			let session = SinkSession::new(log.clone());
+
+			let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
+			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+			for i in 0..FRAMES {
+				let timestamp = crate::Timestamp::from_millis(i as u64 * 10).unwrap();
+				let payload = vec![i as u8; 7];
+				if chunked {
+					// Written a byte at a time and completed, so the group holds no open
+					// tail by the time it is served: the batch read takes them all.
+					let mut frame = group
+						.create_frame(crate::frame::Info {
+							size: payload.len() as u64,
+							timestamp,
+						})
+						.unwrap();
+					for byte in &payload {
+						frame.write(&[*byte][..]).unwrap();
+					}
+					frame.finish().unwrap();
+				} else {
+					group.write_frame(timestamp, payload.as_slice()).unwrap();
+				}
+			}
+			let consumer = group.consume();
+			group.finish().unwrap();
+
+			let msg = ietf::GroupHeader {
+				track_alias: 0,
+				group_id: 0,
+				sub_group_id: 0,
+				publisher_priority: 0,
+				flags: Default::default(),
+			};
+
+			Publisher::<SinkSession>::run_group(session, msg, 0, consumer, Timescale::default(), Version::Draft14)
+				.await
+				.unwrap();
+
+			log.writes.lock().unwrap().clone()
+		}
+
+		let whole = serve(false).await;
+		let chunked = serve(true).await;
+		assert!(!whole.is_empty(), "the group produced no bytes");
+		assert_eq!(whole, chunked, "batched and chunked writes must encode the same");
+	}
+
+	/// A frame still being written must reach the wire as it fills rather than waiting
+	/// for the whole thing: the batch read has to yield to the open tail.
+	#[tokio::test]
+	async fn an_open_frame_streams_before_it_completes() {
+		let log = crate::lite::test_transport::Log::default();
+		let session = SinkSession::new(log.clone());
+
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
+		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+		let consumer = group.consume();
+
+		// A large frame, opened but far from complete.
+		let mut frame = group
+			.create_frame(crate::frame::Info {
+				size: 4096,
+				timestamp: crate::Timestamp::from_millis(0).unwrap(),
+			})
+			.unwrap();
+		frame.write(&[7u8; 512][..]).unwrap();
+
+		let msg = ietf::GroupHeader {
+			track_alias: 0,
+			group_id: 0,
+			sub_group_id: 0,
+			publisher_priority: 0,
+			flags: Default::default(),
+		};
+
+		let mut serving = std::pin::pin!(Publisher::<SinkSession>::run_group(
+			session,
+			msg,
+			0,
+			consumer,
+			Timescale::default(),
+			Version::Draft14
+		));
+		// Let it run until it blocks on the rest of the frame.
+		assert!(futures::poll!(serving.as_mut()).is_pending());
+
+		let written = log.writes.lock().unwrap().len();
+		assert!(
+			written >= 512,
+			"the open frame's first chunk must be forwarded before it completes, wrote {written}"
 		);
 	}
 }

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1136,6 +1136,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					for i in 0..buf.filled().len() {
 						let frame = buf.filled()[i].clone();
 						write_fetch_frame(&mut stream.writer, frame, timescale, &mut prev_ts).await?;
+						// One stamp per batch isn't enough for a slow peer; see `write_group`.
+						group.keep_alive();
 					}
 				}
 				Step::Partial(mut frame) => {
@@ -2185,6 +2187,10 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 						// across them for no reason.
 						let frame = buf.filled()[i].clone();
 						self.serve_whole_frame(stream, priority, frame, &mut prev_ts).await?;
+						// The fill stamped the group once. A flow-controlled peer can
+						// take longer than `latency_max` to accept one batch, so keep
+						// stamping or the rest of the group expires mid-serve.
+						group.keep_alive();
 					}
 				}
 				Step::Partial(frame) => self.serve_frame(stream, priority, frame, &mut prev_ts).await?,

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -2630,6 +2630,11 @@ mod serve_group_test {
 	/// window lets the group expire mid-stream and the stream resets with `Old`.
 	/// That is the point. Holding the group for as long as a wedged peer refuses to
 	/// read would let any subscriber pin cache indefinitely.
+	///
+	/// A batch read takes up to `frame::Buffer` frames out of the group at once and
+	/// owns their payloads, so the grace is that many frames rather than one. It is
+	/// still bounded: the tail past the buffer goes with the group, which is why the
+	/// group here runs longer than one batch.
 	#[tokio::test(start_paused = true)]
 	async fn stalled_write_releases_the_group() {
 		let gate = kio::Producer::new(true);
@@ -2673,12 +2678,21 @@ mod serve_group_test {
 		group
 			.write_frame(Timestamp::from_millis(10).unwrap(), b"second".as_slice())
 			.unwrap();
+		// Enough filler to overrun the publisher's batch, so the tail below is left in
+		// the group rather than taken along with "second".
+		let batch = <frame::Buffer>::new().capacity();
+		for i in 0..batch {
+			group
+				.write_frame(Timestamp::from_millis(11 + i as u64).unwrap(), b"pad".as_slice())
+				.unwrap();
+		}
 		group
 			.write_frame(Timestamp::from_millis(20).unwrap(), b"third".as_slice())
 			.unwrap();
 		group.finish().unwrap();
 
-		// The publisher takes "second" (stamping the group) and blocks writing it.
+		// The publisher takes a batch ending at the filler (stamping the group) and
+		// blocks writing "second".
 		assert!(futures::poll!(serve.as_mut()).is_pending());
 
 		// The write stays blocked well past the retention window while the source
@@ -2700,12 +2714,12 @@ mod serve_group_test {
 		// a routine cancel and it can re-request the sequence.
 		assert_eq!(log.resets(), vec![Error::Old.to_code()]);
 
-		// Only the untaken tail is lost: the frame already handed to the publisher
-		// owns its payload, so the release can't reclaim it mid-write.
+		// Only the untaken tail is lost: the frames already handed to the publisher
+		// own their payloads, so the release can't reclaim them mid-write.
 		let writes = log.writes.lock().unwrap();
 		assert!(
 			writes.windows(b"second".len()).any(|w| w == b"second"),
-			"the in-flight frame still reached the wire"
+			"the in-flight batch still reached the wire"
 		);
 		assert!(
 			!writes.windows(b"third".len()).any(|w| w == b"third"),

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -2444,20 +2444,18 @@ mod serve_group_test {
 	}
 
 	/// `write_group` takes two routes to the wire: complete frames come out of a batch
-	/// read, while an in-flight frame streams chunk by chunk. The two must encode
-	/// identically, or a subscriber catching up sees different bytes than one at the
-	/// live edge.
+	/// read via `serve_whole_frame`, while an in-flight frame streams chunk by chunk
+	/// via `serve_frame`. The two must encode identically, or a subscriber catching up
+	/// sees different bytes than one at the live edge.
 	#[tokio::test]
 	async fn batched_and_streamed_frames_encode_identically() {
-		const FRAMES: usize = 40;
+		const FRAMES: usize = 12;
+		const PAYLOAD: usize = 7;
 
-		async fn serve(chunked: bool) -> Vec<u8> {
-			let log = Log::default();
-			let session = SinkSession::new(log.clone());
-
+		fn subscription(log: &Log) -> Subscription<SinkSession> {
 			let track_priority = kio::Producer::new(0u8);
-			let subscription = Subscription {
-				session,
+			Subscription {
+				session: SinkSession::new(log.clone()),
 				id: 0,
 				track_name: "test".into(),
 				priority: PriorityQueue::default(),
@@ -2465,43 +2463,74 @@ mod serve_group_test {
 				track_priority_seen: 0,
 				version: Version::Lite06Wip,
 				timescale: Some(crate::Timescale::default()),
-			};
+			}
+		}
 
+		fn payload(i: usize) -> Vec<u8> {
+			vec![i as u8; PAYLOAD]
+		}
+
+		fn timestamp(i: usize) -> Timestamp {
+			Timestamp::from_millis(i as u64 * 10).unwrap()
+		}
+
+		// Every frame complete before serving starts: the batch read takes them all.
+		let batched = {
+			let log = Log::default();
+			let subscription = subscription(&log);
 			let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
 			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
 			for i in 0..FRAMES {
-				let timestamp = Timestamp::from_millis(i as u64 * 10).unwrap();
-				let payload = vec![i as u8; 7];
-				if chunked {
-					// Written a byte at a time and completed, so the group holds no open
-					// tail by the time it is served: the batch read takes them all.
-					let mut frame = group
-						.create_frame(frame::Info {
-							size: payload.len() as u64,
-							timestamp,
-						})
-						.unwrap();
-					for byte in &payload {
-						frame.write(&[*byte][..]).unwrap();
-					}
-					frame.finish().unwrap();
-				} else {
-					group.write_frame(timestamp, payload.as_slice()).unwrap();
-				}
+				group.write_frame(timestamp(i), payload(i).as_slice()).unwrap();
 			}
 			let consumer = group.consume();
 			group.finish().unwrap();
 
 			let handle = subscription.priority.insert(Priority::new(0, 0));
 			subscription.serve_group(0, handle, consumer).await.unwrap();
-
 			log.writes.lock().unwrap().clone()
-		}
+		};
 
-		let whole = serve(false).await;
-		let chunked = serve(true).await;
-		assert!(!whole.is_empty(), "the group produced no bytes");
-		assert_eq!(whole, chunked, "batched and chunked writes must encode the same");
+		// Every frame still open when the publisher reaches it, so each one streams a
+		// chunk at a time down the `Step::Partial` path.
+		let streamed = {
+			let log = Log::default();
+			let subscription = subscription(&log);
+			let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
+			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+			let consumer = group.consume();
+
+			let handle = subscription.priority.insert(Priority::new(0, 0));
+			let mut serve = std::pin::pin!(subscription.serve_group(0, handle, consumer));
+			// Past the group header, parked with nothing to send.
+			assert!(futures::poll!(serve.as_mut()).is_pending());
+
+			for i in 0..FRAMES {
+				{
+					let mut frame = group
+						.create_frame(frame::Info {
+							size: PAYLOAD as u64,
+							timestamp: timestamp(i),
+						})
+						.unwrap();
+					// The publisher is parked on this frame, so each chunk is forwarded
+					// before the next one is written.
+					for byte in payload(i) {
+						frame.write(&[byte][..]).unwrap();
+						assert!(futures::poll!(serve.as_mut()).is_pending());
+					}
+					frame.finish().unwrap();
+				}
+				assert!(futures::poll!(serve.as_mut()).is_pending());
+			}
+
+			group.finish().unwrap();
+			serve.await.unwrap();
+			log.writes.lock().unwrap().clone()
+		};
+
+		assert!(!batched.is_empty(), "the group produced no bytes");
+		assert_eq!(batched, streamed, "batched and streamed writes must encode the same");
 	}
 
 	/// A frame still being written must reach the wire as it fills rather than waiting

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1117,9 +1117,32 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// Stream every frame in order. The delta-timestamp baseline resets to 0, so the
 		// first served frame's delta is its absolute timestamp (the subscriber decodes
 		// against the same baseline).
+		//
+		// A fetched group is usually cached whole, so the batch takes it under one lock;
+		// a fetch that catches the live edge falls back to streaming the open tail.
 		let mut prev_ts: u64 = 0;
-		while let Some(mut frame) = group.next_frame().await? {
-			write_fetch_frame(&mut stream.writer, &mut frame, timescale, &mut prev_ts).await?;
+		let mut buf: frame::Buffer = frame::Buffer::new();
+		loop {
+			let step = kio::wait(|waiter| match group.poll_read_frames(waiter, &mut buf) {
+				Poll::Pending => group
+					.poll_next_frame(waiter)
+					.map_ok(|frame| frame.map_or(Step::Done, Step::Partial)),
+				res => res.map_ok(|count| if count == 0 { Step::Done } else { Step::Batch }),
+			})
+			.await?;
+
+			match step {
+				Step::Batch => {
+					for i in 0..buf.filled().len() {
+						let frame = buf.filled()[i].clone();
+						write_fetch_frame(&mut stream.writer, frame, timescale, &mut prev_ts).await?;
+					}
+				}
+				Step::Partial(mut frame) => {
+					write_fetch_partial(&mut stream.writer, &mut frame, timescale, &mut prev_ts).await?;
+				}
+				Step::Done => break,
+			}
 		}
 
 		stream.writer.finish()?;
@@ -1796,7 +1819,7 @@ mod announce_test {
 /// the decode in the subscriber's `run_group`.
 async fn encode_frame_timing<W: web_transport_trait::SendStream>(
 	writer: &mut Writer<W, Version>,
-	frame: &frame::Consumer,
+	timestamp: crate::Timestamp,
 	timescale: Option<crate::Timescale>,
 	prev_ts: &mut u64,
 ) -> Result<(), Error> {
@@ -1804,8 +1827,7 @@ async fn encode_frame_timing<W: web_transport_trait::SendStream>(
 		return Ok(());
 	}
 
-	let ts = frame.timestamp.value();
-	encode_zigzag_delta(writer, ts, prev_ts).await?;
+	encode_zigzag_delta(writer, timestamp.value(), prev_ts).await?;
 
 	Ok(())
 }
@@ -1831,13 +1853,31 @@ async fn encode_zigzag_delta<W: web_transport_trait::SendStream>(
 /// per-frame encoding in [`Subscription::serve_frame`] without the priority
 /// machinery, since a one-shot fetch carries a single static priority set on the
 /// stream up front.
+/// Write one already-complete frame of a fetched group.
 async fn write_fetch_frame<W: web_transport_trait::SendStream>(
+	writer: &mut Writer<W, Version>,
+	frame: frame::Frame,
+	timescale: Option<crate::Timescale>,
+	prev_ts: &mut u64,
+) -> Result<(), Error> {
+	encode_frame_timing(writer, frame.timestamp, timescale, prev_ts).await?;
+
+	writer.encode(&(frame.payload.len() as u64)).await?;
+	if !frame.payload.is_empty() {
+		writer.write_chunk(frame.payload).await?;
+	}
+
+	Ok(())
+}
+
+/// Write one in-flight frame of a fetched group, streaming its chunks as they land.
+async fn write_fetch_partial<W: web_transport_trait::SendStream>(
 	writer: &mut Writer<W, Version>,
 	frame: &mut frame::Consumer,
 	timescale: Option<crate::Timescale>,
 	prev_ts: &mut u64,
 ) -> Result<(), Error> {
-	encode_frame_timing(writer, frame, timescale, prev_ts).await?;
+	encode_frame_timing(writer, frame.timestamp, timescale, prev_ts).await?;
 
 	writer.encode(&frame.size).await?;
 	while let Some(chunk) = frame.read_chunk().await? {
@@ -1847,13 +1887,20 @@ async fn write_fetch_frame<W: web_transport_trait::SendStream>(
 	Ok(())
 }
 
+/// What a group has next for [`Publisher::next_frames`]: a batch of complete frames
+/// waiting in the buffer, a consumer for the in-flight tail, or the end of the group.
+enum Step {
+	/// The buffer was refilled; its frames are the next ones to send.
+	Batch,
+	/// Nothing is complete yet, so stream the open tail chunk by chunk.
+	Partial(frame::Consumer),
+	/// The group ended.
+	Done,
+}
+
 /// What [`recv_next`] pulled from the one subscriber: the next group to serve, the next
 /// best-effort datagram to forward, the track declaring its exclusive final sequence, or
 /// the track finishing (the live edge having reached that boundary).
-// A `group::Consumer` carries an inline frame prefetch, so the `Group` variant dwarfs the
-// others. This is a transient, one-at-a-time return value, so the padding is never held in
-// bulk; boxing would only add a per-group allocation.
-#[allow(clippy::large_enum_variant)]
 enum Recv {
 	Group(group::Consumer),
 	Datagram(crate::Datagram),
@@ -2128,8 +2175,21 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		// frame's delta is absolute (against an implicit prev value of 0), every
 		// subsequent delta is signed against the previous frame.
 		let mut prev_ts: u64 = 0;
-		while let Some(frame) = self.next_frame(stream, priority, group).await? {
-			self.serve_frame(stream, priority, frame, &mut prev_ts).await?;
+		let mut buf = frame::Buffer::new();
+		loop {
+			match self.next_frames(stream, priority, group, &mut buf).await? {
+				Step::Batch => {
+					for i in 0..buf.filled().len() {
+						// Index rather than iterate: the writes below borrow `self`
+						// mutably, and a live `buf.filled()` iterator would pin `buf`
+						// across them for no reason.
+						let frame = buf.filled()[i].clone();
+						self.serve_whole_frame(stream, priority, frame, &mut prev_ts).await?;
+					}
+				}
+				Step::Partial(frame) => self.serve_frame(stream, priority, frame, &mut prev_ts).await?,
+				Step::Done => break,
+			}
 		}
 
 		Ok(())
@@ -2175,7 +2235,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		mut frame: frame::Consumer,
 		prev_ts: &mut u64,
 	) -> Result<(), Error> {
-		encode_frame_timing(stream, &frame, self.timescale, prev_ts).await?;
+		encode_frame_timing(stream, frame.timestamp, self.timescale, prev_ts).await?;
 
 		stream.encode(&frame.size).await?;
 
@@ -2186,22 +2246,50 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		Ok(())
 	}
 
-	/// Await the next frame in the group, applying any priority changes that
-	/// arrive meanwhile. Errors with [`Error::Cancel`] if the peer closes first.
-	async fn next_frame(
+	/// Await whatever the group has next: a batch of already-complete frames, or a
+	/// consumer for the in-flight tail when nothing is complete yet.
+	///
+	/// A subscriber catching up on a cached group takes the whole backlog under one
+	/// lock instead of one wait per frame. At the live edge the batch comes up empty
+	/// and the tail streams chunk by chunk, exactly as it did before, so forwarding
+	/// never waits for a frame to complete.
+	async fn next_frames(
 		&mut self,
 		stream: &mut Writer<S::SendStream, Version>,
 		priority: &mut PriorityHandle,
 		group: &mut group::Consumer,
-	) -> Result<Option<frame::Consumer>, Error> {
+		buf: &mut frame::Buffer,
+	) -> Result<Step, Error> {
 		Self::serve_step(
 			stream,
 			priority,
 			&self.track_priority,
 			&mut self.track_priority_seen,
-			|waiter| group.poll_next_frame(waiter),
+			|waiter| match group.poll_read_frames(waiter, buf) {
+				// Nothing complete: the tail is either in flight or the group ended.
+				Poll::Pending => group
+					.poll_next_frame(waiter)
+					.map_ok(|frame| frame.map_or(Step::Done, Step::Partial)),
+				res => res.map_ok(|count| if count == 0 { Step::Done } else { Step::Batch }),
+			},
 		)
 		.await
+	}
+
+	/// Send one already-complete frame: the timestamp, the size, then the payload.
+	async fn serve_whole_frame(
+		&mut self,
+		stream: &mut Writer<S::SendStream, Version>,
+		priority: &mut PriorityHandle,
+		frame: frame::Frame,
+		prev_ts: &mut u64,
+	) -> Result<(), Error> {
+		encode_frame_timing(stream, frame.timestamp, self.timescale, prev_ts).await?;
+		stream.encode(&(frame.payload.len() as u64)).await?;
+		if !frame.payload.is_empty() {
+			self.write_chunk(stream, priority, frame.payload).await?;
+		}
+		Ok(())
 	}
 
 	/// Await the next chunk of `frame`, applying priority changes meanwhile.
@@ -2347,6 +2435,111 @@ mod serve_group_test {
 
 		assert!(matches!(serve.await, Err(Error::Old)));
 		assert_eq!(log.resets(), vec![Error::Old.to_code()]);
+	}
+
+	/// `write_group` takes two routes to the wire: complete frames come out of a batch
+	/// read, while an in-flight frame streams chunk by chunk. The two must encode
+	/// identically, or a subscriber catching up sees different bytes than one at the
+	/// live edge.
+	#[tokio::test]
+	async fn batched_and_streamed_frames_encode_identically() {
+		const FRAMES: usize = 40;
+
+		async fn serve(chunked: bool) -> Vec<u8> {
+			let log = Log::default();
+			let session = SinkSession::new(log.clone());
+
+			let track_priority = kio::Producer::new(0u8);
+			let subscription = Subscription {
+				session,
+				id: 0,
+				track_name: "test".into(),
+				priority: PriorityQueue::default(),
+				track_priority: track_priority.consume(),
+				track_priority_seen: 0,
+				version: Version::Lite06Wip,
+				timescale: Some(crate::Timescale::default()),
+			};
+
+			let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
+			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+			for i in 0..FRAMES {
+				let timestamp = Timestamp::from_millis(i as u64 * 10).unwrap();
+				let payload = vec![i as u8; 7];
+				if chunked {
+					// Written a byte at a time and completed, so the group holds no open
+					// tail by the time it is served: the batch read takes them all.
+					let mut frame = group
+						.create_frame(frame::Info {
+							size: payload.len() as u64,
+							timestamp,
+						})
+						.unwrap();
+					for byte in &payload {
+						frame.write(&[*byte][..]).unwrap();
+					}
+					frame.finish().unwrap();
+				} else {
+					group.write_frame(timestamp, payload.as_slice()).unwrap();
+				}
+			}
+			let consumer = group.consume();
+			group.finish().unwrap();
+
+			let handle = subscription.priority.insert(Priority::new(0, 0));
+			subscription.serve_group(0, handle, consumer).await.unwrap();
+
+			log.writes.lock().unwrap().clone()
+		}
+
+		let whole = serve(false).await;
+		let chunked = serve(true).await;
+		assert!(!whole.is_empty(), "the group produced no bytes");
+		assert_eq!(whole, chunked, "batched and chunked writes must encode the same");
+	}
+
+	/// A frame still being written must reach the wire as it fills rather than waiting
+	/// for the whole thing: the batch read has to yield to the open tail.
+	#[tokio::test]
+	async fn an_open_frame_streams_before_it_completes() {
+		let log = Log::default();
+		let session = SinkSession::new(log.clone());
+
+		let track_priority = kio::Producer::new(0u8);
+		let subscription = Subscription {
+			session,
+			id: 0,
+			track_name: "test".into(),
+			priority: PriorityQueue::default(),
+			track_priority: track_priority.consume(),
+			track_priority_seen: 0,
+			version: Version::Lite06Wip,
+			timescale: Some(crate::Timescale::default()),
+		};
+
+		let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
+		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+		let consumer = group.consume();
+
+		// A large frame, opened but far from complete.
+		let mut frame = group
+			.create_frame(frame::Info {
+				size: 4096,
+				timestamp: Timestamp::from_millis(0).unwrap(),
+			})
+			.unwrap();
+		frame.write(&[7u8; 512][..]).unwrap();
+
+		let handle = subscription.priority.insert(Priority::new(0, 0));
+		let mut serve = std::pin::pin!(subscription.serve_group(0, handle, consumer));
+		// Let it run until it blocks on the rest of the frame.
+		assert!(futures::poll!(serve.as_mut()).is_pending());
+
+		let written = log.writes.lock().unwrap().len();
+		assert!(
+			written >= 512,
+			"the open frame's first chunk must be forwarded before it completes, wrote {written}"
+		);
 	}
 
 	/// A group that completes cleanly must not reset at all. The completion path

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -10,6 +10,7 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Poll, ready};
 
+use arrayvec::ArrayVec;
 use bytes::Bytes;
 
 use crate::group::{self, GroupState};
@@ -41,6 +42,91 @@ pub struct Frame {
 	pub timestamp: Timestamp,
 	/// The full frame payload.
 	pub payload: Bytes,
+}
+
+/// A reusable batch of frames, filled by [`group::Consumer::read_frames`] and drained
+/// by [`group::Producer::write_frames`].
+///
+/// A fixed-capacity inline buffer: `N` frames of stack storage, never a heap
+/// allocation and never a spill. Allocate one per task and reuse it for the life of
+/// the group rather than one per read.
+///
+/// `N` defaults to 32, chosen from `benches/group.rs`: batches of 32 read ~7x faster
+/// than a frame at a time, and 128 buys nothing back for four times the stack. A
+/// default on a const parameter only applies in type position, so name the type to
+/// get it: `let buf: frame::Buffer = Buffer::new()`.
+///
+/// A fill stamps the group's cache access once for the whole batch, so a reader that
+/// takes longer than the track's `latency_max` to work through one batch can find the
+/// rest of the group expired. Size the buffer so a batch is comfortably quicker than
+/// that window.
+#[derive(Debug, Default)]
+pub struct Buffer<const N: usize = 32>(ArrayVec<Frame, N>);
+
+impl<const N: usize> Buffer<N> {
+	/// An empty buffer with room for `N` frames.
+	pub fn new() -> Self {
+		Self(ArrayVec::new())
+	}
+
+	/// How many frames a single fill can hold.
+	pub const fn capacity(&self) -> usize {
+		N
+	}
+
+	/// How many frames the buffer currently holds.
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
+
+	/// Whether the buffer holds no frames.
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
+
+	/// Whether the buffer is at capacity, so [`Self::push`] would refuse.
+	pub fn is_full(&self) -> bool {
+		self.0.is_full()
+	}
+
+	/// The frames from the most recent fill, in order.
+	pub fn filled(&self) -> &[Frame] {
+		&self.0
+	}
+
+	/// The frames from the most recent fill, mutably (to take payloads out, say).
+	pub fn filled_mut(&mut self) -> &mut [Frame] {
+		&mut self.0
+	}
+
+	/// Append a frame, handing it back if the buffer is already full.
+	///
+	/// Fill a buffer this way to hand a whole batch to
+	/// [`group::Producer::write_frames`].
+	pub fn push(&mut self, frame: Frame) -> std::result::Result<(), Frame> {
+		self.0.try_push(frame).map_err(|err| err.element())
+	}
+
+	/// Move every frame out, leaving the buffer empty.
+	///
+	/// Frames left in the iterator when it drops are dropped with it, so the buffer
+	/// ends up empty either way.
+	pub fn drain(&mut self) -> impl ExactSizeIterator<Item = Frame> + '_ {
+		self.0.drain(..)
+	}
+
+	/// Drop the current batch, leaving the buffer empty.
+	pub fn clear(&mut self) {
+		self.0.clear();
+	}
+
+	/// Replace the contents with up to `N` frames, returning how many were written.
+	/// Must be cleared first.
+	pub(crate) fn fill(&mut self, frames: impl Iterator<Item = Frame>) -> usize {
+		debug_assert!(self.is_empty(), "fill on a non-empty buffer would drop frames");
+		self.0.extend(frames.take(N));
+		self.len()
+	}
 }
 
 /// Payload storage for the single in-flight frame, shared between the writing
@@ -351,9 +437,8 @@ pub struct Consumer {
 	source: Source,
 	// Byte offset consumed so far.
 	read_idx: usize,
-	// Egress payload meter. Set only for frames read directly from the group (not
-	// from the prefetch batch, whose bytes were already counted at fill), so chunks
-	// bump `bytes` exactly once. Empty (no-op) otherwise.
+	// Egress payload meter, so chunks bump `bytes` exactly once as they're read out.
+	// Empty (no-op) for an untagged group.
 	stats: stats::Meter,
 }
 

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -51,9 +51,13 @@ pub struct Frame {
 /// allocation and never a spill. Allocate one per task and reuse it for the life of
 /// the group rather than one per read.
 ///
-/// `N` defaults to 32, chosen from `benches/group.rs`: batches of 32 read ~7x faster
-/// than a frame at a time, and 128 buys nothing back for four times the stack. A
-/// default on a const parameter only applies in type position, so name the type to
+/// `N` defaults to 8. Most reads are not big batches: at the live edge a frame arrives
+/// at a time, so the capacity past the first frame or two is idle stack, and a
+/// publisher holds one buffer per in-flight group. 8 costs 384 bytes and still reads
+/// ~5x faster than a frame at a time (`benches/group.rs`). Ask for a larger `N` when
+/// you know you are draining a backlog: 32 is ~8x, for 1.5 KB.
+///
+/// A default on a const parameter only applies in type position, so name the type to
 /// get it: `let buf: frame::Buffer = Buffer::new()`.
 ///
 /// A fill stamps the group's cache access once for the whole batch, which bounds
@@ -62,7 +66,7 @@ pub struct Frame {
 /// [`group::Consumer::keep_alive`] between frames, or the rest of the group is
 /// expired out from under it.
 #[derive(Debug, Default)]
-pub struct Buffer<const N: usize = 32>(ArrayVec<Frame, N>);
+pub struct Buffer<const N: usize = 8>(ArrayVec<Frame, N>);
 
 impl<const N: usize> Buffer<N> {
 	/// An empty buffer with room for `N` frames.

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -56,10 +56,11 @@ pub struct Frame {
 /// default on a const parameter only applies in type position, so name the type to
 /// get it: `let buf: frame::Buffer = Buffer::new()`.
 ///
-/// A fill stamps the group's cache access once for the whole batch, so a reader that
-/// takes longer than the track's `latency_max` to work through one batch can find the
-/// rest of the group expired. Size the buffer so a batch is comfortably quicker than
-/// that window.
+/// A fill stamps the group's cache access once for the whole batch, which bounds
+/// frames rather than elapsed time. A reader that may take longer than the track's
+/// `latency_max` to work through one batch calls
+/// [`group::Consumer::keep_alive`] between frames, or the rest of the group is
+/// expired out from under it.
 #[derive(Debug, Default)]
 pub struct Buffer<const N: usize = 32>(ArrayVec<Frame, N>);
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -12,7 +12,6 @@ use crate::cache;
 use crate::frame::{self, Frame, FrameBuf};
 use crate::{Timescale, stats, track};
 use std::collections::VecDeque;
-use std::mem::MaybeUninit;
 use std::sync::Arc;
 use std::task::{Poll, ready};
 
@@ -366,6 +365,55 @@ impl Producer {
 		Ok(())
 	}
 
+	/// Write a whole batch of frames at once, draining `frames`.
+	///
+	/// One lock covers the batch, so an ingest with several frames in hand pays the
+	/// group mutex and the track's eviction settle once rather than per frame. Build
+	/// the batch with [`frame::Buffer::push`].
+	///
+	/// The batch is validated before anything is written, so a rejected frame leaves
+	/// the group untouched and the buffer intact.
+	pub fn write_frames<const N: usize>(&mut self, frames: &mut frame::Buffer<N>) -> Result<()> {
+		// Convert and check up front: a failure half way through would leave the group
+		// holding part of a batch the caller thinks it still owns.
+		for frame in frames.filled_mut() {
+			frame.timestamp = frame
+				.timestamp
+				.convert(self.track.timescale)
+				.map_err(|_| Error::TimestampMismatch)?;
+			if frame.payload.len() as u64 > MAX_GROUP_CACHE {
+				return Err(Error::FrameTooLarge);
+			}
+		}
+
+		let count = frames.len() as u64;
+		let mut bytes = 0;
+
+		let mut state = modify(&self.state)?;
+		if state.fin.is_some() {
+			return Err(Error::Closed);
+		}
+		debug_assert!(state.partial.is_none(), "a frame is already open");
+		for frame in frames.drain() {
+			let size = frame.payload.len() as u64;
+			bytes += size;
+			state.cache += size;
+			state.charge.add(size);
+			state.frames.push_back(frame);
+		}
+		state.evict();
+		drop(state);
+
+		// With the group lock released (lock order is track then group), settle
+		// eviction debt if enough has been written since the track last paid.
+		self.cache.settle();
+
+		// Ingress payload: the whole batch, counted once.
+		self.stats.frames(count);
+		self.stats.bytes(bytes);
+		Ok(())
+	}
+
 	/// Create a frame with an upfront size and presentation timestamp, streamed in
 	/// chunks. Borrows the group exclusively until the returned [`frame::Producer`]
 	/// is finished or dropped, so only one frame is open at a time.
@@ -514,8 +562,6 @@ impl Producer {
 			state: self.state.consume(),
 			track: self.track.clone(),
 			index: 0,
-			prefetch: Prefetch::default(),
-			last_refresh: web_async::time::Instant::now(),
 			// Untagged: a tagged track attaches the egress meter via `with_meter`
 			// when it hands the consumer to a subscriber/fetch.
 			stats: stats::Meter::default(),
@@ -556,76 +602,6 @@ impl Clone for Producer {
 	}
 }
 
-/// A small inline batch of completed frames, drained from the shared group state
-/// under one lock and then handed out without re-locking.
-///
-/// Each [`Consumer::read_frame`] otherwise takes the group mutex and allocates a
-/// waker just to clone one `Bytes`; draining a batch amortizes both across `CAP`
-/// frames. Storage is inline and uninitialized (no heap), so a consumer that never
-/// reads whole frames, or drains through a higher-level buffer, pays nothing.
-struct Prefetch {
-	// Initialized, not-yet-taken frames are `frames[pos..len]`; the rest are uninitialized.
-	frames: [MaybeUninit<Frame>; Self::CAP],
-	pos: usize,
-	len: usize,
-}
-
-impl Prefetch {
-	const CAP: usize = 8;
-
-	/// Take the next buffered frame, or `None` if the batch is drained.
-	fn pop(&mut self) -> Option<Frame> {
-		if self.pos == self.len {
-			return None;
-		}
-		// SAFETY: `pos < len`, so this slot was written by `fill` and not yet taken.
-		let frame = unsafe { self.frames[self.pos].assume_init_read() };
-		self.pos += 1;
-		Some(frame)
-	}
-
-	/// Refill with up to `CAP` frames. Must be drained first (`pop` returned `None`).
-	fn fill(&mut self, frames: impl Iterator<Item = Frame>) {
-		debug_assert_eq!(self.pos, self.len, "fill on a non-empty batch would leak frames");
-		self.pos = 0;
-		self.len = 0;
-		for frame in frames.take(Self::CAP) {
-			self.frames[self.len].write(frame);
-			self.len += 1;
-		}
-	}
-
-	/// `(frame count, total payload bytes)` of the buffered, not-yet-taken frames.
-	/// Read once per fill to bump the egress payload counters for the whole batch.
-	fn buffered(&self) -> (u64, u64) {
-		let mut bytes = 0u64;
-		for slot in &self.frames[self.pos..self.len] {
-			// SAFETY: slots in `pos..len` are initialized (written by `fill`, not yet popped).
-			bytes += unsafe { slot.assume_init_ref() }.payload.len() as u64;
-		}
-		((self.len - self.pos) as u64, bytes)
-	}
-}
-
-impl Default for Prefetch {
-	fn default() -> Self {
-		Self {
-			frames: [const { MaybeUninit::uninit() }; Self::CAP],
-			pos: 0,
-			len: 0,
-		}
-	}
-}
-
-impl Drop for Prefetch {
-	fn drop(&mut self) {
-		for slot in &mut self.frames[self.pos..self.len] {
-			// SAFETY: slots in `pos..len` are initialized and were never taken.
-			unsafe { slot.assume_init_drop() };
-		}
-	}
-}
-
 /// Consume a group, frame-by-frame.
 pub struct Consumer {
 	// Shared state with the producer.
@@ -642,15 +618,6 @@ pub struct Consumer {
 	// NOTE: Cloned readers inherit this offset, but then run in parallel.
 	index: usize,
 
-	// A batch of completed frames drained ahead under one lock (whole-frame reads only).
-	prefetch: Prefetch,
-
-	// When this consumer last stamped the group's access time. The prefetch bounds
-	// a batch by frame count, not elapsed time, so pops re-stamp on a time bound
-	// (see [`Self::refresh_if_stale`]) or a slow reader could go a full retention
-	// window without an access and be expired mid-read.
-	last_refresh: web_async::time::Instant,
-
 	// Egress payload meter, set by a tagged track via [`Self::with_meter`]. Empty
 	// (no-op) for an untagged group.
 	stats: stats::Meter,
@@ -658,15 +625,12 @@ pub struct Consumer {
 
 impl Clone for Consumer {
 	fn clone(&self) -> Self {
-		// A clone shares the channel and inherits `index`, but starts with an empty
-		// prefetch: it re-reads its batch from the shared state, in parallel.
+		// A clone shares the channel and inherits `index`, but then runs in parallel.
 		Self {
 			state: self.state.clone(),
 			info: self.info,
 			track: self.track.clone(),
 			index: self.index,
-			prefetch: Prefetch::default(),
-			last_refresh: self.last_refresh,
 			// Inherit the meter without re-counting the group: the original already
 			// counted it when the track handed it out.
 			stats: self.stats.clone(),
@@ -715,23 +679,10 @@ impl Consumer {
 		self.track.timescale
 	}
 
-	/// Re-stamp the group's access time from the lock-free prefetch path once half
-	/// the retention window has passed since this consumer last stamped it. The
-	/// batch bounds frames, not elapsed time, so without this a reader pacing
-	/// through a batch could be expired while demonstrably active. Half the window
-	/// keeps the stamp comfortably inside it while staying rare on the hot path.
-	fn refresh_if_stale(&mut self) {
-		if self.last_refresh.elapsed() * 2 < self.track.latency_max {
-			return;
-		}
-		self.state.read().charge.refresh();
-		self.last_refresh = web_async::time::Instant::now();
-	}
-
 	// A helper to automatically apply Dropped if the state is closed without an error.
 	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R>>
 	where
-		F: Fn(&kio::Ref<'_, GroupState>) -> Poll<Result<R>>,
+		F: FnMut(&kio::Ref<'_, GroupState>) -> Poll<Result<R>>,
 	{
 		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
 			Ok(res) => res,
@@ -749,28 +700,14 @@ impl Consumer {
 	///
 	/// Returns None if the group is finished and the index is out of range.
 	pub fn poll_next_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Consumer>>> {
-		// Hand out any frames a prior read_frame prefetched before touching the tail.
-		// Their bytes were already counted at the batch fill, so the frame::Consumer
-		// carries no meter.
-		if let Some(frame) = self.prefetch.pop() {
-			self.refresh_if_stale();
-			self.index += 1;
-			let info = frame::Info {
-				size: frame.payload.len() as u64,
-				timestamp: frame.timestamp,
-			};
-			let source = frame::Source::Complete(frame.payload);
-			return Poll::Ready(Ok(Some(frame::Consumer::new(self.state.clone(), info, source))));
-		}
-
 		let index = self.index;
 		let Some((info, source)) = ready!(self.poll(waiter, |state| state.poll_frame_source(index))?) else {
 			return Poll::Ready(Ok(None));
 		};
 
 		self.index += 1;
-		// A direct read (not prefetched): count the frame here; the frame::Consumer
-		// counts its bytes per chunk as they're read out.
+		// Count the frame here; the frame::Consumer counts its bytes per chunk as
+		// they're read out.
 		self.stats.frames(1);
 		Poll::Ready(Ok(Some(
 			frame::Consumer::new(self.state.clone(), info, source).with_meter(self.stats.clone()),
@@ -778,69 +715,103 @@ impl Consumer {
 	}
 
 	/// Read the next frame (timestamp and payload) all at once, without blocking.
+	///
+	/// Use [`Self::read_frames`] to pull a whole batch under one lock; a group of small
+	/// frames drains several times faster that way.
 	pub fn poll_read_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Frame>>> {
-		// Fast path: serve from the prefetched batch without locking or allocating a waker.
-		if let Some(frame) = self.prefetch.pop() {
-			self.refresh_if_stale();
-			self.index += 1;
-			return Poll::Ready(Ok(Some(frame)));
-		}
-
-		// The batch is drained: refill it under a single lock, registering the waiter if
-		// nothing is ready. Borrow the two fields disjointly so the closure can fill.
 		let index = self.index;
-		let prefetch = &mut self.prefetch;
-		let res = self.state.poll(waiter, |state| {
+		let frame = ready!(self.poll(waiter, |state| {
 			if index < state.offset {
 				return Poll::Ready(Err(Error::Lagged));
 			}
-			// `local` can run past the buffered count when frames were cleared or evicted out
-			// from under us (abort, unfinished drop, an eviction gap); clamp so `range` never
-			// panics on an out-of-bounds start. `fill` always resets the batch, so an empty
-			// range leaves `len == 0` and the terminal checks below resolve abort/fin/pending.
-			let local = (index - state.offset).min(state.frames.len());
-			prefetch.fill(state.frames.range(local..).cloned());
-			if prefetch.len > 0 {
-				// One stamp covers the whole batch: frames popped from the prefetch
-				// don't re-stamp until the next refill, which `CAP` bounds.
+			if let Some(frame) = state.frames.get(index - state.offset) {
+				// A frame read is a cache access: stamp it so expiry and the eviction
+				// walk spare a group a consumer is actively draining.
 				state.charge.refresh();
-				return Poll::Ready(Ok(()));
+				return Poll::Ready(Ok(Some(frame.clone())));
 			}
 			// Nothing completed at `index`: an in-flight tail waits, otherwise resolve
 			// the terminal state (whole-frame reads never stream the partial).
-			state.poll_terminal(index)
-		});
+			state.poll_terminal(index).map_ok(|()| None)
+		})?);
 
-		match ready!(res) {
-			Ok(Ok(())) => {}
-			Ok(Err(err)) => return Poll::Ready(Err(err)),
-			Err(state) => return Poll::Ready(Err(state.abort.clone().unwrap_or(Error::Dropped))),
+		if let Some(frame) = &frame {
+			self.index += 1;
+			self.stats.frames(1);
+			self.stats.bytes(frame.payload.len() as u64);
 		}
 
-		// The refill stamped the group under its lock; restart the staleness clock
-		// so the pops that follow don't immediately re-stamp.
-		self.last_refresh = web_async::time::Instant::now();
-
-		// A fresh batch was just filled (empty only on a clean end). Count the whole
-		// batch once here, under no lock, so the drained pops that follow stay free.
-		let (frames, bytes) = self.prefetch.buffered();
-		self.stats.frames(frames);
-		self.stats.bytes(bytes);
-
-		Poll::Ready(Ok(self.prefetch.pop().inspect(|_| {
-			self.index += 1;
-		})))
+		Poll::Ready(Ok(frame))
 	}
 
 	/// Read the next frame (timestamp and payload) all at once.
 	pub async fn read_frame(&mut self) -> Result<Option<frame::Frame>> {
-		// Serve from the prefetched batch without building a future or allocating a waker.
-		if let Some(frame) = self.prefetch.pop() {
-			self.refresh_if_stale();
-			self.index += 1;
-			return Ok(Some(frame));
-		}
 		kio::wait(|waiter| self.poll_read_frame(waiter)).await
+	}
+
+	/// Fill `out` with every frame that is ready, up to its capacity, without blocking.
+	///
+	/// Returns how many frames were written; they're in [`frame::Buffer::filled`]. The
+	/// buffer's previous batch is dropped first, so one buffer serves a whole group.
+	///
+	/// This is a *short* read: it returns as soon as anything is ready rather than
+	/// waiting for `out` to fill, so a partial batch does not mean the group ended.
+	/// Only a count of `0` does (and only for a non-zero capacity).
+	pub fn poll_read_frames<const N: usize>(
+		&mut self,
+		waiter: &kio::Waiter,
+		out: &mut frame::Buffer<N>,
+	) -> Poll<Result<usize>> {
+		// Drop the previous batch before taking the lock: deallocating payloads is the
+		// caller's cost to pay, not something to hold the group's mutex through.
+		out.clear();
+
+		let index = self.index;
+		let res = self.poll(waiter, |state| {
+			if index < state.offset {
+				return Poll::Ready(Err(Error::Lagged));
+			}
+			// `local` can run past the buffered count when frames were cleared or evicted
+			// out from under us (abort, unfinished drop, an eviction gap); clamp so
+			// `range` never panics on an out-of-bounds start.
+			let local = (index - state.offset).min(state.frames.len());
+			if out.fill(state.frames.range(local..).cloned()) > 0 {
+				// One stamp covers the whole batch.
+				state.charge.refresh();
+				return Poll::Ready(Ok(()));
+			}
+			// An empty fill means nothing completed at `index`: park on an in-flight
+			// tail, otherwise resolve the terminal state. A finished group resolves to
+			// `Ok`, leaving the zero count to report the end.
+			state.poll_terminal(index)
+		});
+
+		// A `Pending` here leaves `out` cleared, which is what an empty batch should look
+		// like to a caller that inspects it anyway.
+		ready!(res)?;
+
+		let filled = out.filled().len();
+		self.index += filled;
+		// Count the whole batch once, under no lock.
+		self.stats.frames(filled as u64);
+		self.stats
+			.bytes(out.filled().iter().map(|f| f.payload.len() as u64).sum());
+
+		Poll::Ready(Ok(filled))
+	}
+
+	/// Fill `out` with every frame that is ready, blocking until at least one is or the
+	/// group ends. Returns the batch, empty only at the end of the group.
+	///
+	/// See [`Self::poll_read_frames`] for the short-read semantics.
+	pub async fn read_frames<'a, const N: usize>(
+		&mut self,
+		out: &'a mut frame::Buffer<N>,
+	) -> Result<&'a mut [frame::Frame]> {
+		// The closure reborrows `out` for less than `'a`, so the buffer is free again
+		// once the wait resolves.
+		kio::wait(|waiter| self.poll_read_frames(waiter, out)).await?;
+		Ok(out.filled_mut())
 	}
 
 	/// Poll for the final number of frames in the group.
@@ -895,6 +866,216 @@ mod test {
 		assert_eq!(f1.size, 6);
 		let end = consumer.next_frame().now_or_never().unwrap().unwrap();
 		assert!(end.is_none());
+	}
+
+	/// Write `n` frames with payloads "0".."n-1" into a fresh group.
+	fn filled_group(n: usize) -> Producer {
+		let mut producer = Info { sequence: 0 }.produce();
+		for i in 0..n {
+			producer
+				.write_frame(Timestamp::ZERO, Bytes::from(i.to_string()))
+				.unwrap();
+		}
+		producer
+	}
+
+	/// The payload strings of a batch.
+	fn payloads(frames: &[Frame]) -> Vec<String> {
+		frames
+			.iter()
+			.map(|frame| String::from_utf8(frame.payload.to_vec()).unwrap())
+			.collect()
+	}
+
+	/// Drain a consumer through a batch buffer of `N`, collecting payload strings.
+	fn drain<const N: usize>(consumer: &mut Consumer) -> Vec<String> {
+		let mut buf = frame::Buffer::<N>::new();
+		let mut seen = Vec::new();
+		loop {
+			let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+			if batch.is_empty() {
+				break;
+			}
+			seen.extend(payloads(batch));
+		}
+		seen
+	}
+
+	#[test]
+	fn write_frames_appends_the_whole_batch() {
+		let mut producer = Info { sequence: 0 }.produce();
+		let mut buf = frame::Buffer::<8>::new();
+		for i in 0..5u8 {
+			buf.push(frame::Frame {
+				timestamp: Timestamp::ZERO,
+				payload: Bytes::from(i.to_string()),
+			})
+			.unwrap();
+		}
+		producer.write_frames(&mut buf).unwrap();
+		assert!(buf.is_empty(), "the batch was drained");
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		assert_eq!(drain::<8>(&mut consumer), ["0", "1", "2", "3", "4"]);
+	}
+
+	/// A rejected frame must leave both the group and the batch untouched, or the
+	/// caller has no way to tell what was written.
+	#[test]
+	fn write_frames_rejects_the_batch_atomically() {
+		let mut producer = Info { sequence: 0 }.produce();
+		let mut buf = frame::Buffer::<4>::new();
+		buf.push(frame::Frame {
+			timestamp: Timestamp::ZERO,
+			payload: Bytes::from_static(b"ok"),
+		})
+		.unwrap();
+		// Larger than the group's whole byte budget.
+		buf.push(frame::Frame {
+			timestamp: Timestamp::ZERO,
+			payload: Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize + 1]),
+		})
+		.unwrap();
+
+		assert!(matches!(producer.write_frames(&mut buf), Err(Error::FrameTooLarge)));
+		assert_eq!(buf.len(), 2, "the batch is still the caller's");
+
+		producer.finish().unwrap();
+		let mut consumer = producer.consume();
+		assert!(drain::<4>(&mut consumer).is_empty(), "nothing was written");
+	}
+
+	#[test]
+	fn buffer_push_refuses_past_capacity() {
+		let mut buf = frame::Buffer::<2>::new();
+		let frame = || frame::Frame {
+			timestamp: Timestamp::ZERO,
+			payload: Bytes::from_static(b"x"),
+		};
+		buf.push(frame()).unwrap();
+		buf.push(frame()).unwrap();
+		assert!(buf.is_full());
+		assert!(buf.push(frame()).is_err(), "a full buffer hands the frame back");
+	}
+
+	/// A partially consumed drain still empties the buffer, dropping the rest.
+	#[test]
+	fn buffer_drain_empties_even_when_abandoned() {
+		let mut buf = frame::Buffer::<4>::new();
+		for i in 0..4u8 {
+			buf.push(frame::Frame {
+				timestamp: Timestamp::ZERO,
+				payload: Bytes::from(vec![i; 1]),
+			})
+			.unwrap();
+		}
+		let taken: Vec<_> = buf.drain().take(2).collect();
+		assert_eq!(taken.len(), 2);
+		assert!(buf.is_empty(), "an abandoned drain still empties the buffer");
+	}
+
+	#[test]
+	fn read_frames_fills_whole_batch() {
+		let mut producer = filled_group(5);
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		let mut buf = frame::Buffer::<8>::new();
+
+		let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+		assert_eq!(payloads(batch), ["0", "1", "2", "3", "4"]);
+
+		// A finished group reports the end with an empty batch.
+		let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+		assert!(batch.is_empty());
+	}
+
+	#[test]
+	fn read_frames_bounded_by_capacity() {
+		let mut producer = filled_group(5);
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		assert_eq!(drain::<2>(&mut consumer), ["0", "1", "2", "3", "4"]);
+	}
+
+	#[test]
+	fn read_frames_resumes_after_a_single_read() {
+		let mut producer = filled_group(12);
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		let first = consumer.read_frame().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(first.payload, Bytes::from_static(b"0"));
+
+		assert_eq!(
+			drain::<8>(&mut consumer),
+			["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]
+		);
+	}
+
+	#[test]
+	fn read_frames_returns_short_instead_of_waiting() {
+		let mut producer = filled_group(2);
+
+		let mut consumer = producer.consume();
+		let mut buf = frame::Buffer::<8>::new();
+
+		// The group is still open, so the batch is short rather than blocking for more.
+		let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+		assert_eq!(payloads(batch), ["0", "1"]);
+
+		// Nothing left and no terminal state: this one parks.
+		assert!(consumer.read_frames(&mut buf).now_or_never().is_none());
+
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"2")).unwrap();
+		let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+		assert_eq!(payloads(batch), ["2"]);
+	}
+
+	#[test]
+	fn read_frames_reports_an_abort() {
+		let producer = filled_group(2);
+		let mut consumer = producer.consume();
+		producer.abort(Error::Cancel).unwrap();
+
+		// The abort released the cached frames, so nothing survives it.
+		let mut buf = frame::Buffer::<8>::new();
+		let res = consumer.read_frames(&mut buf).now_or_never().unwrap();
+		assert!(matches!(res, Err(Error::Cancel)));
+	}
+
+	/// A refill drops the previous batch, so a reused buffer never accumulates frames.
+	#[test]
+	fn read_frames_refill_replaces_the_previous_batch() {
+		let mut producer = filled_group(3);
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		let mut buf = frame::Buffer::<2>::new();
+
+		let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+		assert_eq!(payloads(batch), ["0", "1"]);
+
+		let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+		assert_eq!(payloads(batch), ["2"]);
+		assert_eq!(buf.filled().len(), 1, "the buffer holds only the latest batch");
+	}
+
+	#[test]
+	fn read_frames_zero_capacity_reads_nothing() {
+		let mut producer = filled_group(2);
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		let mut buf = frame::Buffer::<0>::new();
+		let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+		assert!(batch.is_empty());
+
+		// The reader did not advance.
+		let frame = consumer.read_frame().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(frame.payload, Bytes::from_static(b"0"));
 	}
 
 	#[test]
@@ -1163,11 +1344,12 @@ mod test {
 		assert!(end.is_none());
 	}
 
-	/// Reading more than one prefetch batch drains every frame in order across the
-	/// batch boundary (the refill starts exactly where the previous batch ended).
+	/// Refilling a buffer several times drains every frame in order across the batch
+	/// boundary (each refill starts exactly where the previous batch ended).
 	#[test]
-	fn read_frame_crosses_prefetch_batches() {
-		let n = Prefetch::CAP * 3 + 5;
+	fn read_frames_crosses_batches() {
+		const CAP: usize = 8;
+		let n = CAP * 3 + 5;
 		let mut producer = Info { sequence: 0 }.produce();
 		for i in 0..n {
 			producer
@@ -1177,10 +1359,19 @@ mod test {
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
-		for i in 0..n {
-			let frame = consumer.read_frame().now_or_never().unwrap().unwrap().unwrap();
-			assert_eq!(frame.payload, Bytes::from(vec![i as u8; 4]));
+		let mut buf = frame::Buffer::<CAP>::new();
+		let mut seen = 0;
+		loop {
+			let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+			if batch.is_empty() {
+				break;
+			}
+			for frame in batch.iter() {
+				assert_eq!(frame.payload, Bytes::from(vec![seen as u8; 4]));
+				seen += 1;
+			}
 		}
+		assert_eq!(seen, n);
 		assert!(consumer.read_frame().now_or_never().unwrap().unwrap().is_none());
 	}
 
@@ -1225,7 +1416,7 @@ mod test {
 		assert_eq!(consumer.finished().now_or_never().unwrap().unwrap(), 2);
 	}
 
-	/// `next_frame` drains frames a prior `read_frame` prefetched, preserving order.
+	/// `next_frame` picks up where a prior `read_frame` left off, preserving order.
 	#[test]
 	fn interleave_read_and_next_frame() {
 		let mut producer = Info { sequence: 0 }.produce();
@@ -1235,11 +1426,10 @@ mod test {
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
-		// The first whole-frame read prefetches all five frames into the batch.
 		let f0 = consumer.read_frame().now_or_never().unwrap().unwrap().unwrap();
 		assert_eq!(f0.payload, Bytes::from(vec![0u8; 1]));
 
-		// next_frame must continue from the batch, not skip ahead or repeat.
+		// next_frame must continue from there, not skip ahead or repeat.
 		for i in 1..5u8 {
 			let mut f = consumer.next_frame().now_or_never().unwrap().unwrap().unwrap();
 			let data = f.read_all().now_or_never().unwrap().unwrap();
@@ -1268,20 +1458,25 @@ mod test {
 		assert!(matches!(result, Err(Error::Cancel)), "expected Cancel, got {result:?}");
 	}
 
-	/// Dropping a consumer mid-batch must drop the buffered-but-untaken frames
+	/// Dropping a filled buffer must drop its frames rather than leak them
 	/// (exercises the `MaybeUninit` Drop path; run under miri to catch leaks/UB).
 	#[test]
-	fn drop_with_partial_batch() {
+	fn drop_with_a_filled_buffer() {
+		const CAP: usize = 8;
 		let mut producer = Info { sequence: 0 }.produce();
-		for _ in 0..Prefetch::CAP {
+		for _ in 0..CAP {
 			producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"x")).unwrap();
 		}
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
-		// Take one frame so the batch is filled but only partially drained.
-		let _ = consumer.read_frame().now_or_never().unwrap().unwrap().unwrap();
-		drop(consumer);
+		let mut buf = frame::Buffer::<CAP>::new();
+		// Fill the buffer, then drop it without taking anything out.
+		assert_eq!(
+			consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap().len(),
+			CAP
+		);
+		drop(buf);
 	}
 
 	/// A parked chunk reader is woken by each chunk write. kio only notifies when

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -372,12 +372,14 @@ impl Producer {
 	/// the batch with [`frame::Buffer::push`].
 	///
 	/// The batch is validated before anything is written, so a rejected frame leaves
-	/// the group untouched and the buffer intact.
+	/// both the group and the buffer exactly as they were, ready to retry or redirect.
 	pub fn write_frames<const N: usize>(&mut self, frames: &mut frame::Buffer<N>) -> Result<()> {
-		// Convert and check up front: a failure half way through would leave the group
-		// holding part of a batch the caller thinks it still owns.
-		for frame in frames.filled_mut() {
-			frame.timestamp = frame
+		// Check the whole batch up front, without touching it: a rejected batch stays
+		// exactly as the caller built it, so it can be retried or sent elsewhere.
+		// Timestamp conversion is lossy across scales that don't divide evenly, so
+		// converting in place here would silently shift presentation times on retry.
+		for frame in frames.filled() {
+			frame
 				.timestamp
 				.convert(self.track.timescale)
 				.map_err(|_| Error::TimestampMismatch)?;
@@ -394,7 +396,13 @@ impl Producer {
 			return Err(Error::Closed);
 		}
 		debug_assert!(state.partial.is_none(), "a frame is already open");
-		for frame in frames.drain() {
+		// Past every fallible check: converting again can't fail, and the batch is
+		// ours from here.
+		for mut frame in frames.drain() {
+			frame.timestamp = frame
+				.timestamp
+				.convert(self.track.timescale)
+				.expect("timestamp scale checked above");
 			let size = frame.payload.len() as u64;
 			bytes += size;
 			state.cache += size;
@@ -661,10 +669,25 @@ impl Consumer {
 		self.state.read().abort.is_some()
 	}
 
+	/// Mark the group as still being read, so a slow drain doesn't expire it.
+	///
+	/// [`Self::read_frames`] stamps the group's cache access once per batch, which
+	/// bounds frames rather than elapsed time. A reader that takes longer than the
+	/// track's `latency_max` to work through one batch (a publisher writing to a
+	/// flow-controlled peer, say) calls this between frames, or the rest of the group
+	/// is expired out from under it mid-serve. [`Self::read_frame`] stamps on every
+	/// call and needs no help.
+	///
+	/// Cheap and idempotent within a coarse clock tick, so calling it per frame is
+	/// fine.
+	pub fn keep_alive(&self) {
+		self.state.read().charge.refresh();
+	}
+
 	/// Record a cache access from the consumer side: a parked group re-offered to
 	/// its subscriber. Same stamp as [`Producer::cache_refresh`].
 	pub(crate) fn cache_refresh(&self) {
-		self.state.read().charge.refresh();
+		self.keep_alive();
 	}
 
 	/// Park `waiter` until the group closes (finish, abort, or eviction). Spliced
@@ -757,6 +780,9 @@ impl Consumer {
 	/// This is a *short* read: it returns as soon as anything is ready rather than
 	/// waiting for `out` to fill, so a partial batch does not mean the group ended.
 	/// Only a count of `0` does (and only for a non-zero capacity).
+	///
+	/// One stamp covers the whole batch, so a slow drain calls
+	/// [`Self::keep_alive`] between frames.
 	pub fn poll_read_frames<const N: usize>(
 		&mut self,
 		waiter: &kio::Waiter,
@@ -944,6 +970,70 @@ mod test {
 		producer.finish().unwrap();
 		let mut consumer = producer.consume();
 		assert!(drain::<4>(&mut consumer).is_empty(), "nothing was written");
+	}
+
+	/// A batch rejected mid-validation must leave the caller's frames byte-identical,
+	/// including their timestamps: converting in place would compound scale loss if
+	/// the batch is retried against another track.
+	#[test]
+	fn write_frames_leaves_a_rejected_batch_unconverted() {
+		use crate::Timescale;
+
+		let mut producer = Producer::new(
+			Info { sequence: 0 },
+			track::Info::default().with_timescale(Timescale::MICRO),
+			Default::default(),
+		);
+
+		let mut buf = frame::Buffer::<4>::new();
+		buf.push(frame::Frame {
+			timestamp: Timestamp::from_millis(1).unwrap(),
+			payload: Bytes::from_static(b"ok"),
+		})
+		.unwrap();
+		// Refused after the first frame would already have been converted in place.
+		buf.push(frame::Frame {
+			timestamp: Timestamp::from_millis(2).unwrap(),
+			payload: Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize + 1]),
+		})
+		.unwrap();
+
+		assert!(matches!(producer.write_frames(&mut buf), Err(Error::FrameTooLarge)));
+		let kept = buf.filled();
+		assert_eq!(kept.len(), 2, "the batch is still the caller's");
+		assert_eq!(kept[0].timestamp.scale(), Timescale::MILLI, "timestamp was rewritten");
+		assert_eq!(kept[0].timestamp.value(), 1);
+	}
+
+	/// A batch that is accepted still converts into the track's scale.
+	#[test]
+	fn write_frames_converts_into_the_track_scale() {
+		use crate::Timescale;
+
+		let mut producer = Producer::new(
+			Info { sequence: 0 },
+			track::Info::default().with_timescale(Timescale::MICRO),
+			Default::default(),
+		);
+
+		let mut buf = frame::Buffer::<4>::new();
+		buf.push(frame::Frame {
+			timestamp: Timestamp::from_millis(1).unwrap(),
+			payload: Bytes::from_static(b"x"),
+		})
+		.unwrap();
+		producer.write_frames(&mut buf).unwrap();
+		producer.finish().unwrap();
+
+		let frame = producer
+			.consume()
+			.read_frame()
+			.now_or_never()
+			.unwrap()
+			.unwrap()
+			.unwrap();
+		assert_eq!(frame.timestamp.scale(), Timescale::MICRO);
+		assert_eq!(frame.timestamp.value(), 1000);
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -343,11 +343,7 @@ impl Producer {
 			return Err(Error::FrameTooLarge);
 		}
 
-		let mut state = modify(&self.state)?;
-		if state.fin.is_some() {
-			return Err(Error::Closed);
-		}
-		debug_assert!(state.partial.is_none(), "a frame is already open");
+		let mut state = self.writable()?;
 		let size = payload.len() as u64;
 		state.cache += size;
 		state.charge.add(size);
@@ -365,6 +361,23 @@ impl Producer {
 		Ok(())
 	}
 
+	/// Take the group state for a write, refusing one that can no longer accept frames.
+	///
+	/// A group with an open frame rejects rather than appends: `create_frame` borrows
+	/// its producer exclusively, but `Producer` is `Clone`, so a second handle can
+	/// reach this while the first is still streaming. Appending around the open frame
+	/// would hand readers the batch before the frame that was opened first.
+	fn writable(&self) -> Result<kio::Mut<'_, GroupState>> {
+		let state = modify(&self.state)?;
+		if state.fin.is_some() {
+			return Err(Error::Closed);
+		}
+		if state.partial.is_some() {
+			return Err(Error::FrameOpen);
+		}
+		Ok(state)
+	}
+
 	/// Write a whole batch of frames at once, draining `frames`.
 	///
 	/// One lock covers the batch, so an ingest with several frames in hand pays the
@@ -373,6 +386,8 @@ impl Producer {
 	///
 	/// The batch is validated before anything is written, so a rejected frame leaves
 	/// both the group and the buffer exactly as they were, ready to retry or redirect.
+	/// Returns [`Error::FrameOpen`] if another handle is streaming a frame into this
+	/// group, since appending around it would reorder the group.
 	pub fn write_frames<const N: usize>(&mut self, frames: &mut frame::Buffer<N>) -> Result<()> {
 		// Check the whole batch up front, without touching it: a rejected batch stays
 		// exactly as the caller built it, so it can be retried or sent elsewhere.
@@ -391,11 +406,7 @@ impl Producer {
 		let count = frames.len() as u64;
 		let mut bytes = 0;
 
-		let mut state = modify(&self.state)?;
-		if state.fin.is_some() {
-			return Err(Error::Closed);
-		}
-		debug_assert!(state.partial.is_none(), "a frame is already open");
+		let mut state = self.writable()?;
 		// Past every fallible check: converting again can't fail, and the batch is
 		// ours from here.
 		for mut frame in frames.drain() {
@@ -440,11 +451,7 @@ impl Producer {
 		}
 		let buf = FrameBuf::new(frame.size as usize);
 
-		let mut state = modify(&self.state)?;
-		if state.fin.is_some() {
-			return Err(Error::Closed);
-		}
-		debug_assert!(state.partial.is_none(), "a frame is already open");
+		let mut state = self.writable()?;
 		state.cache += frame.size;
 		state.charge.add(frame.size);
 		state.partial = Some(Partial {
@@ -925,6 +932,56 @@ mod test {
 			seen.extend(payloads(batch));
 		}
 		seen
+	}
+
+	/// `create_frame` borrows its producer exclusively, but `Producer` is `Clone`, so a
+	/// second handle can reach the whole-frame writes while a frame is still open.
+	/// Appending there would hand readers the new frames before the one opened first,
+	/// so every whole-frame path refuses instead.
+	#[test]
+	fn writes_are_refused_while_a_frame_is_open() {
+		let mut producer = Info { sequence: 0 }.produce();
+		let mut other = producer.clone();
+
+		// One handle opens a frame and holds it, incomplete.
+		let mut open = producer
+			.create_frame(frame::Info {
+				size: 4,
+				timestamp: Timestamp::ZERO,
+			})
+			.unwrap();
+
+		let mut buf = frame::Buffer::<4>::new();
+		buf.push(frame::Frame {
+			timestamp: Timestamp::ZERO,
+			payload: Bytes::from_static(b"batch"),
+		})
+		.unwrap();
+
+		assert!(matches!(other.write_frames(&mut buf), Err(Error::FrameOpen)));
+		assert_eq!(buf.len(), 1, "the batch is still the caller's");
+		assert!(matches!(
+			other.write_frame(Timestamp::ZERO, Bytes::from_static(b"single")),
+			Err(Error::FrameOpen)
+		));
+		assert!(matches!(
+			other
+				.create_frame(frame::Info {
+					size: 1,
+					timestamp: Timestamp::ZERO,
+				})
+				.err(),
+			Some(Error::FrameOpen)
+		));
+
+		// Once the open frame lands, the group takes writes again in order.
+		open.write(&b"open"[..]).unwrap();
+		open.finish().unwrap();
+		other.write_frames(&mut buf).unwrap();
+		other.finish().unwrap();
+
+		let mut consumer = other.consume();
+		assert_eq!(drain::<4>(&mut consumer), ["open", "batch"]);
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -518,6 +518,13 @@ impl Producer {
 	/// [`abort`](Self::abort). The handle also keeps the cached frames readable.
 	pub fn finish(&mut self) -> Result<()> {
 		let mut state = modify(&self.state)?;
+		// The recorded count is what tells readers the group ended, so an open frame
+		// would be left out of it and read as a clean end rather than a frame still
+		// coming. Another clone can reach this while the frame's producer holds the
+		// handle, so refuse rather than strand it. Use `abort` to end a group early.
+		if state.partial.is_some() {
+			return Err(Error::FrameOpen);
+		}
 		state.fin = Some(state.offset + state.frames.len());
 		Ok(())
 	}
@@ -982,6 +989,43 @@ mod test {
 
 		let mut consumer = other.consume();
 		assert_eq!(drain::<4>(&mut consumer), ["open", "batch"]);
+	}
+
+	/// Finishing records the frame count, and a batch read consults that count to
+	/// decide the group ended. `create_frame` borrows its producer exclusively, but
+	/// `Producer` is `Clone`, so a second handle can finish the group while the first
+	/// is still writing a frame. The open frame would be left out of the count and
+	/// read as a clean end of group, so a publisher would close the stream without
+	/// ever sending it.
+	#[test]
+	fn finish_is_refused_while_a_frame_is_open() {
+		let mut producer = Info { sequence: 0 }.produce();
+		let mut other = producer.clone();
+		let mut consumer = producer.consume();
+
+		let mut frame = producer
+			.create_frame(frame::Info {
+				size: 4,
+				timestamp: Timestamp::ZERO,
+			})
+			.unwrap();
+
+		assert!(matches!(other.finish(), Err(Error::FrameOpen)));
+
+		// Not "the group ended": the batch read parks until the frame lands.
+		let mut buf = frame::Buffer::<4>::new();
+		assert!(
+			consumer.read_frames(&mut buf).now_or_never().is_none(),
+			"an open frame must not read as the end of the group"
+		);
+
+		frame.write(&b"open"[..]).unwrap();
+		frame.finish().unwrap();
+		other.finish().unwrap();
+
+		let batch = consumer.read_frames(&mut buf).now_or_never().unwrap().unwrap();
+		assert_eq!(batch.len(), 1);
+		assert_eq!(batch[0].payload, Bytes::from_static(b"open"));
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -3124,12 +3124,11 @@ mod test {
 		assert!(!state.lookup.contains_key(&1), "the unread group still expired");
 	}
 
-	/// Whole-frame reads served from the prefetch batch must also keep the group
-	/// alive: the batch is filled (and stamped) once per `Prefetch::CAP` frames,
-	/// which bounds frames, not elapsed time, so a slow `read_frame` reader has to
-	/// re-stamp on a time bound between refills.
+	/// A whole-frame read is a cache access: a reader that paces through a group
+	/// slower than the retention window must keep it alive rather than watch it
+	/// expire out from under itself.
 	#[tokio::test]
-	async fn slow_prefetch_reader_survives_expiry() {
+	async fn slow_frame_reader_survives_expiry() {
 		tokio::time::pause();
 
 		let mut producer = track_producer("test", None);
@@ -3142,14 +3141,13 @@ mod test {
 		group.finish().unwrap();
 		let mut reading = subscriber.assert_group();
 
-		// One whole-frame read per half-window: most are served straight from the
-		// prefetch without locking. New groups keep the expiry scan running.
+		// One whole-frame read per half-window; new groups keep the expiry scan running.
 		for seq in 1..20u64 {
 			tokio::time::advance(DEFAULT_LATENCY_MAX / 2).await;
 			let frame = reading.read_frame().await;
 			assert!(
 				matches!(frame, Ok(Some(_))),
-				"a slow prefetch reader must not expire mid-read (step {seq})"
+				"a slow reader must not expire mid-read (step {seq})"
 			);
 			producer.create_group(seq.into()).unwrap().finish().unwrap();
 		}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -3153,6 +3153,45 @@ mod test {
 		}
 	}
 
+	/// A batch read stamps the group once per fill, which bounds frames rather than
+	/// elapsed time. A reader pacing through one batch slower than the retention
+	/// window keeps it alive with `keep_alive`, the way the publishers do while
+	/// writing a batch to a flow-controlled peer.
+	#[tokio::test]
+	async fn slow_batch_reader_survives_expiry_with_keep_alive() {
+		tokio::time::pause();
+
+		let mut producer = track_producer("test", None);
+		let mut subscriber = producer.subscribe(None);
+
+		let mut group = producer.create_group(0u64.into()).unwrap();
+		for _ in 0..20 {
+			group.write_frame(Timestamp::ZERO, b"x".as_slice()).unwrap();
+		}
+		group.finish().unwrap();
+		let mut reading = subscriber.assert_group();
+
+		// A short buffer, so the reader still has frames outstanding while it works
+		// through the batch and nothing else re-stamps the group.
+		let mut buf = crate::frame::Buffer::<8>::new();
+		let count = reading.read_frames(&mut buf).await.unwrap().len();
+		assert_eq!(count, 8, "the batch is bounded by the buffer");
+
+		for step in 0..8u64 {
+			tokio::time::advance(DEFAULT_LATENCY_MAX / 2).await;
+			reading.keep_alive();
+			// New groups keep the expiry scan running.
+			producer.create_group((step + 1).into()).unwrap().finish().unwrap();
+		}
+
+		// The group outlived the drain, so the rest of it is still readable.
+		let rest = reading
+			.read_frames(&mut buf)
+			.await
+			.expect("a batch reader that kept the group alive must not be expired");
+		assert_eq!(rest.len(), 8, "the next batch picks up where the last one stopped");
+	}
+
 	/// Receiving a group is itself a cache access: a subscriber that takes
 	/// delivery just before the group would age out still gets to read it a full
 	/// window later.


### PR DESCRIPTION
## Summary

- Reading a group one frame at a time paid a group mutex, a `kio::wait` future and a waker **per frame**. `group::Consumer::read_frames` fills a caller-owned `frame::Buffer` under a single lock; `group::Producer::write_frames` drains one back the other way, paying the group lock and the track's `cache.settle()` once per batch.
- **Deleting the inline `Prefetch` (from #2116) made `read_frame` ~2x faster on its own**, before any batching. Its `pop` called `Instant::now()` on every frame to decide whether to re-stamp the group's cache access — a clock read per frame, costing more than the lock it was amortizing — and it eagerly cloned 8 payloads to serve one.
- Publishers (lite `write_group` + `run_fetch`, ietf `run_group`) now take whatever the group has next: the complete backlog in one lock, or a `frame::Consumer` for the in-flight tail when nothing is complete. A plain `read_frames` would have been a latency regression, since it parks until a frame *completes* — a relay forwarding a large keyframe would buffer the whole thing instead of forwarding chunks. Batch-first-then-partial keeps chunk streaming at the live edge and collapses the backlog on catch-up.
- `frame::Buffer` is a newtype over `arrayvec::ArrayVec<Frame, N>`, so the fixed-capacity storage is a maintained crate rather than hand-rolled `MaybeUninit`, and no third-party type appears in a public signature. `arrayvec` was already in the lockfile (blake3 -> iroh -> `moq-native`) and has no dependencies of its own. `tinyvec` can't be used (`Item: Default`, which `Frame` isn't); `smallvec` spills to the heap instead of refusing, which would silently break the flush-on-full protocol `write_frames` relies on.

## Benchmarks

`cargo bench -p moq-net --bench group`, 64-byte frames, Apple silicon. `single` is the existing one-at-a-time path.

| frames | `read_frame` (main) | `read_frame` (here) | batch8 | batch32 | batch128 |
|---|---|---|---|---|---|
| 512 | 38.1 µs | 19.5 µs | 3.87 µs | 2.67 µs | 2.99 µs |
| 8192 | 558 µs | 312 µs | 60.0 µs | 40.1 µs | 38.0 µs |
| 32768 | 2.31 ms | 1.30 ms | 260 µs | 169 µs | 322 µs |

Throughput climbs to 32 and stalls after (128 falls out of L1), but **`N` defaults to 8**: most reads never fill a big batch, since at the live edge a frame arrives at a time, and a publisher holds one buffer per in-flight group. 8 costs 384 bytes of stack for ~5x; 32 costs 1.5 KB for ~8x. Callers draining a known backlog can ask for more. Batched writes are a more modest ~1.4-1.7x, since `write_frame` is dominated by payload accounting rather than the lock.

Buffer shape was chosen by measurement. `Option<Frame>` is the same 48 bytes as `Frame` (the `&'static Vtable` inside `Bytes` supplies a niche) and benchmarks identically; `&mut Vec<Frame>` is 10-25% slower. The wrapper earns its place by returning `&mut [Frame]` rather than requiring `.take().unwrap()` per slot, and by giving `write_frames` something to drain.

## Not done, deliberately

Batching group *delivery* was investigated and rejected: `recv_group` is flat at ~2.0 Melem/s across cache depths and is dominated by constructing a `group::Consumer`, not the lock, so a batch would buy ~30% for a new public type.

Two things this branch's benchmarks surfaced have since landed on `main` separately, and this PR is rebased on both: the quadratic `next_group` cache scan (#3088) and a test pinning what a stalled publisher write does to the group it is serving (#3095).

## Public API changes

All additive, hence `main`:

- `frame::Buffer<const N: usize = 8>` — `new`, `capacity`, `len`, `is_empty`, `is_full`, `filled`, `filled_mut`, `push`, `drain`, `clear`
- `group::Consumer::poll_read_frames` / `read_frames` / `keep_alive`
- `group::Producer::write_frames`
- `Error::FrameOpen` (wire code 22, previously unused in the library range). Returned by every operation that would otherwise strand or reorder an open frame: `write_frame`, `write_frames`, `create_frame`, and `finish`. The enum is `#[non_exhaustive]` and the variant is appended, so external `match`es keep compiling. The draft describes the field only as an application-specific error code rather than enumerating them, so no spec change goes with it.
- new dependency: `arrayvec` on `moq-net`

No existing signature changed. `write_frame`, `create_frame`, and `finish` can now return the new `Error::FrameOpen` where they previously only `debug_assert`ed or silently proceeded. `group::Producer` is `Clone`, so a second handle can reach them while a first is streaming a frame; release builds appended around the open frame and reordered the group. The three whole-frame writes share a `writable()` guard.

`finish` is the one Codex caught in review, and it was a regression this PR introduced. It records the frame count that tells readers the group ended, and an open frame is not in `state.frames` yet, so it was left out. That was harmless while every whole-frame read consulted the in-flight tail first (`poll_frame_source` does); the batch read has no partial to hand back, so it goes straight to the terminal check, reports the group ended, and the publisher closes the stream without ever sending the open frame. Guarding `finish` makes `poll_terminal`'s `(Some(_), _) => Ok` arm sound again. Ending a group early mid-frame is what `abort` is for, and it already reports the truncation. Private only: `Prefetch`, `Consumer::{refresh_if_stale, last_refresh}` removed; `encode_frame_timing` takes a `Timestamp` instead of a `&frame::Consumer`; the ietf per-object header moved into `write_object_header`.

## Behavior note

A batch stamps the group's cache access once per fill, where `read_frame` stamps on every call. `group::Consumer::keep_alive` re-stamps between frames and the publisher batch loops call it per frame, restoring `main`'s once-per-frame cadence; a batch reader that paces slower than `latency_max` needs to do the same.

A batch also clones up to `N` frames' payloads out of the group, so a peer whose flow control window stays shut gets that many frames of grace before the group expires under it, rather than one. Still bounded — the tail past the buffer goes with the group — but it is why `stalled_write_releases_the_group` (#3095) now serves a group longer than one batch. The smaller default `N` keeps this modest.

Within one batch the publisher also doesn't re-check `stream.closed()`, so a cancelling subscriber may get up to `N` more frames written before the transport errors.

## Test plan

- `just check` and `just test` — 3197 tests pass, rebased on `main` (#3088, #3095, and the release bump).
- New in `model/group.rs`: `finish_is_refused_while_a_frame_is_open` (verified to fail before the guard), `writes_are_refused_while_a_frame_is_open`, batch bounds, short reads, refill replacing the previous batch, zero capacity, abort reporting, atomic write rejection (including that a rejected batch keeps its original timescale), `push` at capacity, and an abandoned `drain` still emptying the buffer.
- New in `model/track.rs`: `slow_batch_reader_survives_expiry_with_keep_alive`, verified to fail with `Error::Old` when the `keep_alive` call is removed.
- New per protocol (lite + ietf): the batch and partial paths must produce **byte-identical** wire output, with the streamed case driving the serve future by hand so the publisher meets each frame in flight. Verified to fail when the `Step::Partial` arm is made `unreachable!()`. Plus: an open frame must reach the wire before it completes.
- The `slow_prefetch_reader_survives_expiry` track test was retargeted to `slow_frame_reader_survives_expiry`; it still guards the same invariant for `read_frame`.

## Cross-package sync

No wire change, so no `drafts/` update. `js/net` is not mirrored: the batching wins here are a Rust mutex and async-plumbing cost that has no JS equivalent.

(Written by Claude Opus 5)


