### PR TITLE
test(net): assert a stalled write releases the group it was serving

### DIFF
--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -2392,6 +2392,98 @@ mod serve_group_test {
 			"rank 0 must reach the transport as send order 255: {priorities:?}",
 		);
 	}
+
+	/// A subscriber that stops reading must not pin the group it was being served.
+	///
+	/// The publisher stamps the group's cache access once per frame, immediately
+	/// before writing it, so a delivery in progress gets a full `latency_max` of
+	/// grace per frame handed out. Nothing re-stamps inside the write itself: a peer
+	/// whose flow control window stays shut for longer than the whole retention
+	/// window lets the group expire mid-stream and the stream resets with `Old`.
+	/// That is the point. Holding the group for as long as a wedged peer refuses to
+	/// read would let any subscriber pin cache indefinitely.
+	#[tokio::test(start_paused = true)]
+	async fn stalled_write_releases_the_group() {
+		let gate = kio::Producer::new(true);
+		let session = SinkSession::gated_uni(gate.consume());
+		let log = session.log.clone();
+
+		let track_priority = kio::Producer::new(0u8);
+		let subscription = Subscription {
+			session,
+			id: 0,
+			track_name: "test".into(),
+			priority: PriorityQueue::default(),
+			track_priority: track_priority.consume(),
+			track_priority_seen: 0,
+			version: Version::Lite06Wip,
+			timescale: Some(crate::Timescale::default()),
+		};
+
+		let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
+		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+		group
+			.write_frame(Timestamp::from_millis(0).unwrap(), b"first".as_slice())
+			.unwrap();
+
+		// The live edge moves on, so the served group is demoted and expirable.
+		track
+			.create_group(group::Info { sequence: 1 })
+			.unwrap()
+			.finish()
+			.unwrap();
+
+		let handle = subscription.priority.insert(Priority::new(0, 0));
+		let mut serve = std::pin::pin!(subscription.serve_group(0, handle, group.consume()));
+
+		// Write the header and the first frame, leaving the task awaiting the next.
+		assert!(futures::poll!(serve.as_mut()).is_pending());
+
+		// From here every write blocks, the way a shut flow control window does.
+		*gate.write().ok().expect("gate open") = false;
+
+		group
+			.write_frame(Timestamp::from_millis(10).unwrap(), b"second".as_slice())
+			.unwrap();
+		group
+			.write_frame(Timestamp::from_millis(20).unwrap(), b"third".as_slice())
+			.unwrap();
+		group.finish().unwrap();
+
+		// The publisher takes "second" (stamping the group) and blocks writing it.
+		assert!(futures::poll!(serve.as_mut()).is_pending());
+
+		// The write stays blocked well past the retention window while the source
+		// keeps publishing, which is what runs the expiry scan.
+		for sequence in 2..8u64 {
+			tokio::time::advance(crate::track::DEFAULT_LATENCY_MAX / 2).await;
+			track.create_group(group::Info { sequence }).unwrap().finish().unwrap();
+			assert!(futures::poll!(serve.as_mut()).is_pending());
+		}
+
+		*gate.write().ok().expect("gate open") = true;
+		let res = serve.await;
+		assert!(
+			matches!(res, Err(Error::Old)),
+			"a wedged peer must not hold an expired group open: {res:?}"
+		);
+
+		// The reason reaches the peer, so it reads as a truncated group rather than
+		// a routine cancel and it can re-request the sequence.
+		assert_eq!(log.resets(), vec![Error::Old.to_code()]);
+
+		// Only the untaken tail is lost: the frame already handed to the publisher
+		// owns its payload, so the release can't reclaim it mid-write.
+		let writes = log.writes.lock().unwrap();
+		assert!(
+			writes.windows(b"second".len()).any(|w| w == b"second"),
+			"the in-flight frame still reached the wire"
+		);
+		assert!(
+			!writes.windows(b"third".len()).any(|w| w == b"third"),
+			"the untaken tail was released with the group"
+		);
+	}
 }
 
 #[cfg(test)]

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -302,6 +302,8 @@ pub struct SinkSession {
 	/// Set by [`Self::gated_bi`]. `None` parks `open_bi` itself forever, which is all
 	/// a test driving only uni streams needs.
 	bi_gate: Option<kio::Consumer<bool>>,
+	/// Set by [`Self::gated_uni`]. `None` writes immediately.
+	uni_gate: Option<kio::Consumer<bool>>,
 	/// The ALPN to report, for a test that needs a specific negotiated version rather
 	/// than the SETUP-negotiated fallback an absent one selects.
 	protocol: Option<&'static str>,
@@ -316,6 +318,7 @@ impl SinkSession {
 		Self {
 			log,
 			bi_gate: None,
+			uni_gate: None,
 			protocol: None,
 			stats: Arc::new(Mutex::new(SinkStats::default())),
 		}
@@ -347,6 +350,22 @@ impl SinkSession {
 		Self {
 			log: Log::default(),
 			bi_gate: Some(gate),
+			uni_gate: None,
+			protocol: None,
+			stats: Arc::new(Mutex::new(SinkStats::default())),
+		}
+	}
+
+	/// Serve uni streams, holding every write while `gate` reads false.
+	///
+	/// Groups travel on uni streams, so this is how a test stalls delivery the way
+	/// QUIC flow control does: the publisher keeps its consumer and its place in the
+	/// group, but no byte reaches the wire until the gate reopens.
+	pub fn gated_uni(gate: kio::Consumer<bool>) -> Self {
+		Self {
+			log: Log::default(),
+			bi_gate: None,
+			uni_gate: Some(gate),
 			protocol: None,
 			stats: Arc::new(Mutex::new(SinkStats::default())),
 		}
@@ -381,7 +400,11 @@ impl web_transport_trait::Session for SinkSession {
 	}
 
 	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-		Ok(SinkSend::new(self.log.clone()))
+		Ok(SinkSend {
+			log: self.log.clone(),
+			gate: self.uni_gate.clone(),
+			finished: false,
+		})
 	}
 
 	fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {


### PR DESCRIPTION
## Summary

A group being actively served can expire mid-stream when a single transport write stalls. CodeRabbit raised this as a truncation bug on #3090 ([thread](https://github.com/moq-dev/moq/pull/3090#discussion_r3867669769)); it is pre-existing on `main` and it is **working as intended**.

Mechanism: `GroupState::poll_frame_source` stamps the group's cache access on every frame the publisher takes, immediately before writing it. Nothing re-stamps inside `write_chunk`. A peer whose flow control window stays shut for longer than the whole retention window therefore stops accessing the group, `evict_expired` ages it out, and the stream resets with `Old`.

That absence of a refresh *is* the DoS bound. The obvious fix (an RAII retention lease held across the delivery) would let any subscriber pin cache indefinitely by simply refusing to read, which is precisely what the retention window exists to prevent. A bounded lease only moves the cliff, and a pool-budgeted one is a no-op in the default config where the pool is unbounded.

Three details worth recording, all verified by the test:

- The grace is a full `latency_max` **per frame handed out**, not per group delivery. The failure needs one write to move zero bytes for the entire window, not merely a slow subscriber.
- The abort only truncates frames the publisher has **not yet taken**. A handed-out `frame::Consumer` owns a cloned `Bytes` that `release()` cannot reclaim, and `poll_terminal` gives a reader that consumed everything a clean end rather than an error.
- The live edge is protected on both eviction paths and is never enqueued into `evict` at all (`insert_group` pushes only the *previous* latest, once superseded). Since `evict_expired` runs solely from `commit_group`, an idle publisher's latest group is never scanned. Already covered by `evict_keeps_max_sequence` and `latest_group_never_evicted`.

The policy was emergent and unasserted, which is how it got re-filed as a bug. This locks it in so the next reader finds the rationale instead of reaching for a lease.

## Changes

- `rs/moq-net/src/lite/publisher.rs`: `stalled_write_releases_the_group`. Stalls a uni-stream write past the retention window while the source keeps publishing (which is what runs the expiry scan), then asserts the serve fails with `Old`, the stream carries that reset code so the peer can tell truncation from a routine cancel, and the in-flight frame still reached the wire while the untaken one did not.
- `rs/moq-net/src/lite/test_transport.rs`: `SinkSession::gated_uni`, mirroring the existing `gated_bi`. Groups travel on uni streams, so this is how a test stalls delivery the way a shut flow control window does.

## Public API changes

None. Test-only; `gated_uni` is on a `#[cfg(test)]`-gated transport double.

## Test plan

- `just test` — 2795 passed, 0 failed, 1 skipped.
- `just rs check-changed` (clippy `-D warnings`, workspace + wasm target) and `just _check-common` — clean. `just check` additionally runs `_flake` (`nix flake check`), which needs network unavailable locally; it is unaffected by this diff.
- Confirmed the new test fails as a genuine repro before being inverted: asserting the group *survives* the stall produced `Old`, which is what pinned the diagnosis.

## Cross-Package Sync

No rows apply: no wire format, `moq-ffi`, config, or CLI surface changed.

(Written by Claude Opus 5)