### PR TITLE
chore(rs): point shared dependencies at [workspace.dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,12 +73,31 @@ resolver = "2"
 rust-version = "1.91"
 
 [workspace.dependencies]
+anyhow = "1"
+aws-lc-rs = "1"
+axum = { version = "0.8", features = ["tokio"] }
+axum-server = { version = "0.8", features = ["tls-rustls"] }
+base64 = "0.23"
+block2 = "0.6.2"
+bytes = "1"
+clap = { version = "4", features = ["derive"] }
 criterion = "0.8"
+# CUDA driver bindings for the NVENC/NVDEC path. dlopen'd at runtime
+# (`fallback-dynamic-loading`), so nothing links against libcuda at build time.
+cudarc = { version = "0.19", default-features = false, features = ["driver", "fallback-dynamic-loading", "cuda-12020"] }
+dispatch2 = "0.3.1"
 flate2 = "1.1"
+futures = "0.3"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 hang = { version = "0.20.7", path = "rs/hang" }
+hex = "0.4"
+humantime = "2.3"
+humantime-serde = "1.1"
+jsonwebtoken = "11"
 kio = { version = "0.5.6", path = "rs/kio" }
+lazy_static = "1.5"
 libc = "0.2"
+libloading = "0.9"
 linux-raw-sys = { version = "0.12.1", features = ["ioctl"] }
 # Permutation testing for the kio primitives (and everything built on them).
 # Only compiled under `--cfg loom`; see `just rs loom`.
@@ -117,11 +136,34 @@ moq-vaapi = "0.0.3"
 # whole device graph into every one of them. The NVIDIA codecs are not part of
 # that argument, so moq-ffi and libmoq opt them back in by name.
 moq-video = { version = "0.0.20", path = "rs/moq-video", default-features = false }
+num_enum = "0.7"
+objc2 = "0.6.4"
+objc2-av-foundation = "0.3.2"
+objc2-core-media = "0.3.2"
+objc2-foundation = "0.3.2"
+objc2-screen-capture-kit = "0.3.2"
 percent-encoding = "2"
+pollster = "1.0"
 qmux = { version = "0.5.1", default-features = false }
+rand = "0.10.1"
+# default-features off so each consumer picks its own TLS backend and body
+# features; nothing here wants the default native-tls stack.
+reqwest = { version = "0.13", default-features = false }
+sd-notify = "0.5"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_with = "3"
+socket2 = "0.6"
+tempfile = "3"
+thiserror = "2"
 tokio = "1.48"
 tokio-rustls = { version = "0.26", default-features = false }
+toml = "1.1"
+tower-http = { version = "0.7", features = ["cors"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tracing-test = "0.2"
+url = "2"
 web-async = { version = "0.1.5", features = ["tracing"] }
 web-transport-iroh = "0.7"
 # default-features off so the QUIC crypto provider is chosen by moq-native's

--- a/rs/hang/Cargo.toml
+++ b/rs/hang/Cargo.toml
@@ -13,25 +13,25 @@ keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
 [dependencies]
-bytes = "1"
-hex = "0.4"
-lazy_static = "1"
+bytes = { workspace = true }
+hex = { workspace = true }
+lazy_static = { workspace = true }
 moq-net = { workspace = true }
 regex = "1"
 serde = { workspace = true }
-serde_json = "1"
-serde_with = { version = "3", features = ["base64"] }
-thiserror = "2"
-url = "2"
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["base64"] }
+thiserror = { workspace = true }
+url = { workspace = true }
 
 [dependencies.derive_more]
 version = "2"
 features = ["from", "display", "debug"]
 
 [dev-dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 moq-mux = { path = "../moq-mux" }
 moq-native = { path = "../moq-native" }
 tokio = { workspace = true, features = ["macros", "fs"] }
-tracing = "0.1"
-url = "2"
+tracing = { workspace = true }
+url = { workspace = true }

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -17,8 +17,8 @@ name = "moq"
 crate-type = ["staticlib"]
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-bytes = "1"
+anyhow = { workspace = true, features = ["backtrace"] }
+bytes = { workspace = true }
 hang = { workspace = true }
 moq-audio = { workspace = true }
 moq-json = { workspace = true }
@@ -29,12 +29,12 @@ moq-net = { workspace = true }
 moq-video = { workspace = true, features = ["nvidia"] }
 # Blocking on `encode::Sink` from the synchronous C entry points; see
 # `video::block_on` for why not a tokio helper.
-pollster = "1.0"
-serde_json = "1"
-thiserror = "2"
+pollster = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-tracing = "0.1"
-url = "2"
+tracing = { workspace = true }
+url = { workspace = true }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -50,7 +50,7 @@ playback = ["dep:cpal", "dep:fixed-resample", "dep:tokio", "dep:tracing"]
 aec = ["capture", "dep:sonora", "playback"]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 # Pure-Rust cross-platform audio I/O. Optional: only the `capture` and
 # `playback` features need it. Encode stays on unsafe-libopus, so a build
 # without either pulls no new dependency.
@@ -67,7 +67,7 @@ moq-mux = { workspace = true }
 moq-net = { workspace = true }
 # We only use the sinc resampler (Async::new_sinc), so skip the default
 # fft_resampler feature and its RustFFT/realfft dependencies.
-rand = "0.10"
+rand = { workspace = true }
 rubato = { version = "4.0", default-features = false }
 # Pure-Rust port of WebRTC's audio processing module (AEC3, noise suppression,
 # AGC2). The reason the `aec` feature can exist at all: every other option is a
@@ -87,12 +87,12 @@ sonora = { version = "0.2", optional = true }
 # parameter and packet types the decoder is driven with.
 symphonia-codec-aac = { version = "0.6.1", optional = true }
 symphonia-core = { version = "0.6.1", optional = true }
-thiserror = "2"
+thiserror = { workspace = true }
 # Only the device features need an async runtime: the on-demand capture loop
 # awaits frames and demand transitions, and playback awaits the driver thread.
 tokio = { workspace = true, optional = true, features = ["rt", "macros", "sync", "time"] }
 # Only used by the device features, for stream-error logging.
-tracing = { version = "0.1", optional = true }
+tracing = { workspace = true, optional = true }
 # Pure-Rust transpilation of libopus 1.3.1. No CMake toolchain, no C
 # linker hackery, and crucially still maintained, unlike the
 # `opus`/`audiopus_sys` combo which is stuck on a 5-year-old vendored
@@ -108,14 +108,14 @@ unsafe-libopus = "0.2"
 # ScreenCaptureKit (plus CoreMedia/CoreAudioTypes to read the PCM out of its
 # sample buffers) is how macOS exposes system audio.
 [target.'cfg(target_os="macos")'.dependencies]
-block2 = { version = "0.6.2", optional = true }
-dispatch2 = { version = "0.3.0", optional = true }
-objc2 = { version = "0.6.4", optional = true }
-objc2-av-foundation = { version = "0.3.2", optional = true }
+block2 = { workspace = true, optional = true }
+dispatch2 = { workspace = true, optional = true }
+objc2 = { workspace = true, optional = true }
+objc2-av-foundation = { workspace = true, optional = true }
 objc2-core-audio-types = { version = "0.3.2", optional = true }
-objc2-core-media = { version = "0.3.2", optional = true, features = ["CMSampleBuffer", "CMBlockBuffer", "CMSync", "objc2-core-audio-types"] }
-objc2-foundation = { version = "0.3.2", optional = true }
-objc2-screen-capture-kit = { version = "0.3.2", optional = true, features = ["SCStream", "SCShareableContent"] }
+objc2-core-media = { workspace = true, features = ["CMSampleBuffer", "CMBlockBuffer", "CMSync", "objc2-core-audio-types"], optional = true }
+objc2-foundation = { workspace = true, optional = true }
+objc2-screen-capture-kit = { workspace = true, features = ["SCStream", "SCShareableContent"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }

--- a/rs/moq-bench/Cargo.toml
+++ b/rs/moq-bench/Cargo.toml
@@ -36,19 +36,19 @@ quiche = ["moq-native/quiche"]
 websocket = ["moq-native/websocket"]
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-clap = { version = "4", features = ["derive", "env"] }
-humantime = "2.3"
-humantime-serde = "1.1"
+anyhow = { workspace = true, features = ["backtrace"] }
+clap = { workspace = true, features = ["env"] }
+humantime = { workspace = true }
+humantime-serde = { workspace = true }
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
 moq-net = { workspace = true }
-rand = "0.10.1"
+rand = { workspace = true }
 rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-toml = "1.1"
-tracing = "0.1"
+toml = { workspace = true }
+tracing = { workspace = true }
 
 # The host sampler reads /proc, so it is Linux-only (production relays are Linux).
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/rs/moq-boy/Cargo.toml
+++ b/rs/moq-boy/Cargo.toml
@@ -19,10 +19,10 @@ quinn = ["moq-native/quinn"]
 websocket = ["moq-native/websocket"]
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 boytacean = { version = "0.13", features = ["gen-mock"] }
-bytes = "1"
-clap = { version = "4", features = ["derive"] }
+bytes = { workspace = true }
+clap = { workspace = true }
 hang = { workspace = true }
 moq-audio = { workspace = true }
 moq-json = { workspace = true }
@@ -33,4 +33,4 @@ moq-net = { workspace = true }
 moq-video = { workspace = true, features = ["nvidia"] }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tracing = "0.1"
+tracing = { workspace = true }

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -64,13 +64,13 @@ vaapi = ["moq-video?/vaapi", "moq-transcode?/vaapi"]
 pipewire = ["moq-video?/pipewire"]
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-axum = { version = "0.8", features = ["tokio"] }
-axum-server = { version = "0.8", features = ["tls-rustls"] }
-bytes = "1"
-clap = { version = "4", features = ["derive"] }
+anyhow = { workspace = true, features = ["backtrace"] }
+axum = { workspace = true }
+axum-server = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true }
 hang = { workspace = true }
-humantime = "2.3"
+humantime = { workspace = true }
 moq-audio = { workspace = true, optional = true }
 # `server` enables the HTTP egress server for `moq export hls`; the importer is always available.
 moq-hls = { workspace = true, features = ["server"] }
@@ -82,16 +82,16 @@ moq-srt = { workspace = true }
 moq-token-cli = { workspace = true }
 moq-transcode = { workspace = true, optional = true }
 moq-video = { workspace = true, optional = true }
-pollster = { version = "1.0", optional = true }
+pollster = { workspace = true, optional = true }
 rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }
 tokio = { workspace = true, features = ["full"] }
-tower-http = { version = "0.7", features = ["cors"] }
-tracing = "0.1"
-url = "2"
+tower-http = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
 winit = { version = "0.30.13", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-sd-notify = "0.5"
+sd-notify = { workspace = true }
 
 [dev-dependencies]
 # `test-util` enables `tokio::time::pause` so the TS round-trip test simulates the

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -35,20 +35,20 @@ audio = ["dep:moq-audio"]
 video = ["dep:moq-video", "dep:pollster"]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 hang = { workspace = true }
 # `kio::MaybeSend` is the `Send` bound that vanishes on wasm; see `ffi::Task`.
 kio = { workspace = true }
 moq-json = { workspace = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
-serde_json = "1"
-thiserror = "2"
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 # `sync` (Mutex, watch) and `macros` (select!) are the only tokio pieces that build
 # on wasm32; the runtime and its drivers are native-only.
 tokio = { workspace = true, features = ["macros", "sync"] }
-tracing = "0.1"
-url = "2"
+tracing = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 moq-audio = { workspace = true, optional = true }
@@ -63,7 +63,7 @@ moq-native = { workspace = true, default-features = true }
 moq-video = { workspace = true, optional = true, features = ["nvidia"] }
 # Blocking on `encode::Sink` from the synchronous producer exports; see
 # `video::block_on` for why not a tokio helper.
-pollster = { version = "1.0", optional = true }
+pollster = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync"] }
 uniffi = { version = "0.32", features = ["cli"] }
 
@@ -84,4 +84,4 @@ uniffi = { version = "0.32", features = ["build"] }
 
 [dev-dependencies]
 # One non-codec test blocks on a future; the main dep is `video`-only.
-pollster = "1.0"
+pollster = { workspace = true }

--- a/rs/moq-flate/Cargo.toml
+++ b/rs/moq-flate/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["deflate", "compression", "streaming", "live"]
 categories = ["compression"]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 flate2 = { workspace = true }
-thiserror = "2"
+thiserror = { workspace = true }

--- a/rs/moq-gst/Cargo.toml
+++ b/rs/moq-gst/Cargo.toml
@@ -16,17 +16,17 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 
-anyhow = { version = "1", features = ["backtrace"] }
-bytes = "1"
+anyhow = { workspace = true, features = ["backtrace"] }
+bytes = { workspace = true }
 gst = { package = "gstreamer", version = "0.23" }
 hang = { workspace = true }
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = true }
 moq-net = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"
-url = "2"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+url = { workspace = true }
 
 [build-dependencies]
 gst-plugin-version-helper = "0.8"

--- a/rs/moq-hls/Cargo.toml
+++ b/rs/moq-hls/Cargo.toml
@@ -18,24 +18,24 @@ server = ["dep:axum"]
 
 [dependencies]
 # Always required (import + export library).
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 
 # Only needed by the HTTP export server (gated by `server`).
-axum = { version = "0.8", features = ["tokio"], optional = true }
-bytes = "1"
+axum = { workspace = true, optional = true }
+bytes = { workspace = true }
 hang = { workspace = true }
-humantime = "2"
+humantime = { workspace = true }
 kio = { workspace = true }
 m3u8-rs = "6"
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
 percent-encoding = { workspace = true }
-rand = "0.10"
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "gzip"] }
-thiserror = "2"
+rand = { workspace = true }
+reqwest = { workspace = true, features = ["rustls", "gzip"] }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tracing = "0.1"
-url = "2"
+tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-json/Cargo.toml
+++ b/rs/moq-json/Cargo.toml
@@ -13,16 +13,16 @@ keywords = ["quic", "http3", "webtransport", "json", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 json-patch = "4"
 kio = { workspace = true }
 moq-flate = { workspace = true }
 moq-net = { workspace = true }
 serde = { workspace = true }
-serde_json = "1"
+serde_json = { workspace = true }
 serde_path_to_error = "0.1"
-thiserror = "2"
-tracing = "0.1"
+thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/rs/moq-loc/Cargo.toml
+++ b/rs/moq-loc/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 moq-net = { workspace = true }
-thiserror = "2"
+thiserror = { workspace = true }

--- a/rs/moq-msf/Cargo.toml
+++ b/rs/moq-msf/Cargo.toml
@@ -14,5 +14,5 @@ categories = ["multimedia", "network-programming", "web-programming"]
 
 [dependencies]
 serde = { workspace = true }
-serde_json = "1"
-serde_with = "3"
+serde_json = { workspace = true }
+serde_with = { workspace = true }

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -13,9 +13,9 @@ keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
 [dependencies]
-anyhow = "1"
-base64 = "0.23"
-bytes = "1"
+anyhow = { workspace = true }
+base64 = { workspace = true }
+bytes = { workspace = true }
 h264-parser = { version = "0.4.0" }
 hang = { workspace = true }
 kio = { workspace = true }
@@ -26,19 +26,19 @@ moq-msf = { workspace = true }
 moq-net = { workspace = true }
 mp4-atom = { version = "0.15", features = ["tokio", "bytes", "serde"] }
 mpeg2ts = "0.6.0"
-num_enum = "0.7"
+num_enum = { workspace = true }
 scuffle-av1 = { version = "0.1.4" }
 scuffle-h265 = { version = "0.2.2" }
 serde = { workspace = true }
-serde_json = "1"
-serde_with = { version = "3", features = ["base64"] }
-thiserror = "2"
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["base64"] }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-tracing = "0.1"
-url = "2"
+tracing = { workspace = true }
+url = { workspace = true }
 web-async = { workspace = true }
 webm-iterable = "0.6"
 
 [dev-dependencies]
-futures = "0.3"
+futures = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -40,14 +40,14 @@ ring = ["rustls/ring", "rcgen?/ring", "quinn?/rustls-ring", "web-transport-noq?/
 android-logcat = ["dep:tracing-android"]
 
 [dependencies]
-clap = { version = "4", features = ["derive", "env"] }
+clap = { workspace = true, features = ["env"] }
 # Family-restricted `getaddrinfo`, so the AAAA and A queries can be issued separately
 # (RFC 8305 section 3) while still going through the system resolver.
 dns-lookup = { version = "3", optional = true }
-futures = "0.3"
-hex = "0.4"
-humantime = "2.3"
-humantime-serde = "1.1"
+futures = { workspace = true }
+hex = { workspace = true }
+humantime = { workspace = true }
+humantime-serde = { workspace = true }
 
 moq-net = { workspace = true }
 # iroh runs on noq but re-exports only the ControllerFactory trait, not the concrete
@@ -57,26 +57,26 @@ notify = { version = "8", optional = true }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 qmux = { workspace = true, features = ["wss", "tls", "tcp"], optional = true }
 quinn = { version = "0.11", default-features = false, features = ["platform-verifier", "runtime-tokio", "bloom"], optional = true }
-rand = "0.10.1"
+rand = { workspace = true }
 rcgen = { version = "0.14", default-features = false, optional = true }
-reqwest = { version = "0.13", default-features = false, optional = true }
+reqwest = { workspace = true, optional = true }
 rustls = "0.23"
 rustls-native-certs = { version = "0.8", optional = true }
 # OS-native server-cert verifier for the rustls backends. Version matched to the
 # copy quinn-proto already pulls in, to avoid duplication.
 rustls-platform-verifier = "0.7"
 rustls-webpki = { version = "0.103", features = ["aws-lc-rs"], optional = true }
-serde = { version = "1", features = ["derive"] }
-serde_with = { version = "3", features = ["hex"] }
-socket2 = "0.6"
-thiserror = "2"
+serde = { workspace = true }
+serde_with = { workspace = true, features = ["hex"] }
+socket2 = { workspace = true }
+thiserror = { workspace = true }
 tikv-jemalloc-ctl = { version = "0.6", optional = true }
 tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"], optional = true }
 time = "0.3"
 tokio = { workspace = true, features = ["full"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = { version = "2", features = ["serde"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+url = { workspace = true, features = ["serde"] }
 web-transport-iroh = { workspace = true, optional = true }
 web-transport-noq = { workspace = true, optional = true }
 web-transport-proto = { workspace = true, optional = true }
@@ -99,16 +99,16 @@ webpki-roots = "1"
 libc = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1"
-bytes = "1"
+anyhow = { workspace = true }
+bytes = { workspace = true }
 chrono = "0.4"
 rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs"] }
-tempfile = "3"
+tempfile = { workspace = true }
 # test-util adds tokio::time::pause/auto-advance for the time-dependent tests.
 tokio = { workspace = true, features = ["test-util"] }
 tokio-rustls = { workspace = true }
-toml = "1.1"
+toml = { workspace = true }
 # no-env-filter: traced_test's default filter scopes to the test binary's own
 # crate name, which never matches log lines from a dependency crate (e.g.
 # moq-net's), so a test asserting on those needs this to see them at all.
-tracing-test = { version = "0.2", features = ["no-env-filter"] }
+tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/rs/moq-net/Cargo.toml
+++ b/rs/moq-net/Cargo.toml
@@ -17,20 +17,20 @@ ignored = ["getrandom"]
 
 [dependencies]
 arrayvec = "0.7"
-bytes = "1"
-futures = "0.3"
+bytes = { workspace = true }
+futures = { workspace = true }
 kio = { workspace = true, features = ["time"] }
-num_enum = "0.7"
-rand = "0.10.1"
+num_enum = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
-thiserror = "2"
-tracing = "0.1"
+thiserror = { workspace = true }
+tracing = { workspace = true }
 web-async = { workspace = true }
 web-transport-trait = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-serde_json = "1"
+serde_json = { workspace = true }
 # test-util (tokio::time::pause/advance) is test-only and is NOT supported on
 # wasm, so it must not leak into the normal dependency feature set.
 tokio = { workspace = true, features = ["macros", "io-util", "sync", "test-util", "time", "rt"] }
@@ -44,7 +44,7 @@ loom = { workspace = true }
 # only here (dev), so it isn't forced on downstream consumers. They select
 # their own backend in the leaf binary.
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
-getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom = { workspace = true }
 # Keep this in lockstep with rs/moq-wasm's pinned wasm-bindgen CLI schema.
 wasm-bindgen-test = "=0.3.71"
 

--- a/rs/moq-nvenc/Cargo.toml
+++ b/rs/moq-nvenc/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["multimedia::encoding", "hardware-support"]
 # Only cudarc's `driver` API is used, always dlopen'd at runtime:
 # `fallback-dynamic-loading` loads libcuda, and `cuda-12020` pins the CUDA API
 # version so the build needs no CUDA toolkit or driver present.
-cudarc = { version = "0.19", default-features = false, features = ["driver", "fallback-dynamic-loading", "cuda-12020"] }
-lazy_static = "1.5.0"
+cudarc = { workspace = true }
+lazy_static = { workspace = true }
 # dlopen libnvidia-encode at runtime (the two NVENC bootstrap symbols).
-libloading = "0.9"
+libloading = { workspace = true }

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -39,45 +39,45 @@ websocket = ["moq-native/websocket", "dep:qmux", "axum/ws"]
 uds = ["moq-native/uds"]
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-axum = { version = "0.8", features = ["tokio"] }
-axum-server = { version = "0.8", features = ["tls-rustls"] }
-bytes = "1"
+anyhow = { workspace = true, features = ["backtrace"] }
+axum = { workspace = true }
+axum-server = { workspace = true }
+bytes = { workspace = true }
 bytesize = "2.4.2"
-clap = { version = "4", features = ["derive"] }
-futures = "0.3"
+clap = { workspace = true }
+futures = { workspace = true }
 http-body = "1"
 http-cache-reqwest = { version = "1.0.0-alpha.6", features = ["manager-moka", "reqwest-middleware", "url-standard"], default-features = false }
-humantime = "2.3"
-humantime-serde = "1.1"
-jsonwebtoken = "11"
+humantime = { workspace = true }
+humantime-serde = { workspace = true }
+jsonwebtoken = { workspace = true }
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs", "watch", "tcp"] }
 moq-net = { workspace = true }
 moq-stats = { workspace = true }
 moq-token = { workspace = true, features = ["tokio"] }
 qmux = { workspace = true, features = ["ws"], optional = true }
-rand = "0.10"
-reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+rand = { workspace = true }
+reqwest = { workspace = true, features = ["rustls"] }
 reqwest-middleware = "0.5"
 rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_with = { version = "3", features = ["json", "base64"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["json", "base64"] }
 sysinfo = { version = "0.39", default-features = false, features = ["system"] }
-thiserror = "2"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-rustls = { workspace = true }
-toml = "1.1"
-tower-http = { version = "0.7", features = ["cors"] }
+toml = { workspace = true }
+tower-http = { workspace = true }
 tower-service = "0.3"
-tracing = "0.1"
-url = { version = "2", features = ["serde"] }
+tracing = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 web-transport-trait = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-sd-notify = "0.5"
+sd-notify = { workspace = true }
 
 [dev-dependencies]
 rcgen = "0.14"
-tempfile = "3"
+tempfile = { workspace = true }
 wiremock = "0.6"

--- a/rs/moq-rtc/Cargo.toml
+++ b/rs/moq-rtc/Cargo.toml
@@ -16,22 +16,22 @@ categories = ["multimedia", "network-programming", "web-programming"]
 # The CLI lives in `moq-cli` (the `rtc` subcommand); embedders mount the routers
 # / dial with `Client` against their own origin.
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-axum = { version = "0.8", features = ["tokio"] }
-bytes = "1"
+anyhow = { workspace = true, features = ["backtrace"] }
+axum = { workspace = true }
+bytes = { workspace = true }
 hang = { workspace = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
-reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+reqwest = { workspace = true, features = ["rustls"] }
 str0m = "0.22"
-thiserror = "2"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tracing = "0.1"
-url = "2"
+tracing = { workspace = true }
+url = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 # Signs the MESSAGE-INTEGRITY on a forged STUN binding request: str0m rejects a
 # request without one, and its own SHA1 provider is private.
-aws-lc-rs = "1"
+aws-lc-rs = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -26,32 +26,32 @@ tls = ["dep:rustls", "dep:tokio-rustls"]
 # subcommand); a relay can also embed `moq_rtmp::run` / `Server` against its own
 # origin. Only rustls + tokio-rustls (RTMPS, the `tls` feature) are optional.
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 # Deps of the vendored `rml` module (our fork of the unmaintained rml_rtmp 0.8):
 # the RTMP handshake + chunk/message codec + session state machine, so no
 # librtmp / ffmpeg. RTMP carries FLV, demuxed by moq-mux.
 byteorder = "1"
-bytes = "1"
-futures = "0.3"
+bytes = { workspace = true }
+futures = { workspace = true }
 hang = { workspace = true }
 hmac = "0.13"
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
-rand = "0.10"
+rand = { workspace = true }
 rml_amf0 = "0.3"
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"], optional = true }
 sha2 = "0.11"
 # TCP keepalive on accepted sockets, so a half-open connection (a peer that
 # vanished without a FIN/RST) is reaped instead of pinning a broadcast and its
 # stream-key slot forever.
-socket2 = "0.6"
-thiserror = "2"
+socket2 = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "time"] }
 # RTMPS: TLS-terminate accepted connections. Mirrors moq-relay's pinning so the
 # workspace shares one tokio-rustls; the crypto provider comes from the supplied
 # `rustls::ServerConfig`, so no default crypto feature is needed here.
 tokio-rustls = { workspace = true, optional = true }
-tracing = "0.1"
+tracing = { workspace = true }
 
 [dev-dependencies]
 # The RTMPS test borrows moq-native's self-signed cert generation to build a

--- a/rs/moq-srt/Cargo.toml
+++ b/rs/moq-srt/Cargo.toml
@@ -16,13 +16,13 @@ categories = ["multimedia", "network-programming", "web-programming"]
 # subcommand); a relay can also embed `moq_srt::run` / `Server` against its own
 # origin.
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-bytes = "1"
-futures = "0.3"
+anyhow = { workspace = true, features = ["backtrace"] }
+bytes = { workspace = true }
+futures = { workspace = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
 # Pure-Rust SRT (no libsrt / ffmpeg). SRT carries MPEG-TS, demuxed by moq-mux.
 srt-tokio = "0.4"
-thiserror = "2"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tracing = "0.1"
+tracing = { workspace = true }

--- a/rs/moq-stats/Cargo.toml
+++ b/rs/moq-stats/Cargo.toml
@@ -16,11 +16,11 @@ categories = ["multimedia", "network-programming", "web-programming"]
 moq-json = { workspace = true }
 moq-net = { workspace = true }
 serde = { workspace = true }
-serde_json = "1"
-thiserror = "2"
-tracing = "0.1"
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 web-async = { workspace = true }
 
 [dev-dependencies]
-futures = "0.3"
+futures = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }

--- a/rs/moq-token-cli/Cargo.toml
+++ b/rs/moq-token-cli/Cargo.toml
@@ -22,9 +22,9 @@ name = "moq-token"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+anyhow = { workspace = true }
+clap = { workspace = true }
 moq-token = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }

--- a/rs/moq-token/Cargo.toml
+++ b/rs/moq-token/Cargo.toml
@@ -14,18 +14,18 @@ jwks-loader = ["reqwest"]
 tokio = ["dep:tokio"]
 
 [dependencies]
-aws-lc-rs = "1"
-base64 = "0.23"
-jsonwebtoken = { version = "11", features = ["aws_lc_rs"] }
+aws-lc-rs = { workspace = true }
+base64 = { workspace = true }
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 p256 = "0.14.0"
 p384 = "0.14.0"
-reqwest = { version = "0.13", default-features = false, features = ["rustls"], optional = true }
+reqwest = { workspace = true, features = ["rustls"], optional = true }
 rsa = "0.9.10"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_with = { version = "3", features = ["base64"] }
-thiserror = "2"
-tokio = { version = "1", features = ["fs"], optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["base64"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs"], optional = true }
 
 [dev-dependencies]
-anyhow = "1"
+anyhow = { workspace = true }

--- a/rs/moq-transcode/Cargo.toml
+++ b/rs/moq-transcode/Cargo.toml
@@ -30,21 +30,21 @@ nvdec = ["nvidia"]
 vaapi = ["moq-video/vaapi"]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 hang = { workspace = true }
 kio = { workspace = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
 moq-video = { workspace = true }
-thiserror = "2"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
-tracing = "0.1"
+tracing = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+anyhow = { workspace = true }
+clap = { workspace = true }
 # Default features on (unlike the workspace entry) so the example gets a QUIC backend.
 moq-native = { path = "../moq-native" }
 # test-util unlocks tokio::time::pause for the deterministic live-feed tests.
 tokio = { workspace = true, features = ["full", "test-util"] }
-url = "2"
+url = { workspace = true }

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -66,11 +66,11 @@ render = [
 pipewire = ["capture", "dmabuf", "dep:pipewire", "dep:ashpd"]
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 # Casting the color-conversion uniform to the bytes wgpu wants, without an
 # unsafe reinterpret of our own. Already in the graph via wgpu.
 bytemuck = { version = "1", optional = true }
-bytes = "1"
+bytes = { workspace = true }
 # CPU I420 resize (SIMD per-plane convolution), the software fallback for
 # Frame::resize; CUDA and macOS pixel-buffer frames resize on the GPU instead.
 fast_image_resize = "6"
@@ -89,9 +89,9 @@ openh264 = "0.9.8"
 # features it needs; cargo unifies this on the same version it depends on, so the
 # raw API types stay identical.
 openh264-sys2 = { version = "0.9.8", default-features = false }
-thiserror = "2"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
-tracing = "0.1"
+tracing = { workspace = true }
 # GPU rendering behind the `render` feature. `wgpu::hal` is re-exported by wgpu
 # itself, so the zero-copy import paths reach the platform handles without a
 # separate wgpu-hal dependency that could drift to a different version.
@@ -113,7 +113,7 @@ ashpd = { version = "0.13", optional = true, default-features = false, features 
 # The `nvrtc` feature only unlocks the `Ptx` type and `load_module` (both free of
 # extra dependencies); libnvrtc itself is never loaded since we ship pre-built PTX
 # (see frame/nv12_resize.ptx) that the driver JIT-compiles.
-cudarc = { version = "0.19", optional = true, default-features = false, features = ["driver", "fallback-dynamic-loading", "cuda-12020", "nvrtc"] }
+cudarc = { workspace = true, features = ["nvrtc"], optional = true }
 # Mapping a linear DMA-BUF for the universal CPU I420 fallback. Non-linear
 # modifiers stay GPU-only and return an honest error instead of treating tiled
 # memory as rows.
@@ -121,7 +121,7 @@ libc = { workspace = true, optional = true }
 # Probe for the NVIDIA driver libraries before calling cudarc / the NVENC SDK,
 # which panic (process-abort under release `panic = "abort"`) if their library is
 # absent. Lets a GPU-less host fall back to the next encoder instead of crashing.
-libloading = { version = "0.9", optional = true }
+libloading = { workspace = true, optional = true }
 # Architecture-correct DMA_BUF_IOCTL_SYNC request values for CPU access.
 linux-raw-sys = { workspace = true, optional = true }
 moq-nvenc = { workspace = true, optional = true }
@@ -140,20 +140,20 @@ v4l = { version = "0.14", optional = true }
 zune-jpeg = { version = "0.5", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
-block2 = "0.6.2"
-dispatch2 = "0.3.1"
-objc2 = "0.6.4"
-objc2-av-foundation = "0.3.2"
+block2 = { workspace = true }
+dispatch2 = { workspace = true }
+objc2 = { workspace = true }
+objc2-av-foundation = { workspace = true }
 objc2-core-foundation = "0.3.2"
 objc2-core-graphics = { version = "0.3.2", features = ["CGDirectDisplay"] }
-objc2-core-media = "0.3.2"
+objc2-core-media = { workspace = true }
 objc2-core-video = "0.3.2"
-objc2-foundation = "0.3.2"
+objc2-foundation = { workspace = true }
 # MTLDevice / MTLTexture for the `render` feature's zero-copy CVPixelBuffer
 # import (CVMetalTextureCache aliases the decoder's IOSurface as a Metal texture,
 # which wgpu then adopts).
 objc2-metal = { version = "0.3.2", optional = true }
-objc2-screen-capture-kit = "0.3.2"
+objc2-screen-capture-kit = { workspace = true }
 objc2-video-toolbox = "0.3.2"
 
 [target.'cfg(target_os="windows")'.dependencies]
@@ -179,8 +179,8 @@ windows = { version = "0.62", features = [
 
 [dev-dependencies]
 # `poll!`, to cancel an `encode::Sink` request exactly where a `select!` would.
-futures = "0.3"
+futures = { workspace = true }
 h264-reader = "0.8.0"
 # Driving `encode::Sink` from a plain test thread, the way an FFI caller does.
-pollster = "1.0"
-tracing-test = "0.2"
+pollster = { workspace = true }
+tracing-test = { workspace = true }

--- a/rs/moq-wasm/Cargo.toml
+++ b/rs/moq-wasm/Cargo.toml
@@ -25,14 +25,14 @@ crate-type = ["cdylib", "rlib"]
 # (native filesystem), unsupported on wasm32. Gating `fs` behind a native-only
 # cfg in those crates is a prerequisite for browser media muxing.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bytes = "1"
+bytes = { workspace = true }
 console_error_panic_hook = "0.1"
 getrandom = { workspace = true } # wasm_js backend for rand-via-moq-net; cfg flag in .cargo/config.toml
 js-sys = "0.3"
 moq-net = { workspace = true }
-thiserror = "2"
+thiserror = { workspace = true }
 tracing-wasm = "0.2"
-url = "2"
+url = { workspace = true }
 # Pinned to the wasm-bindgen-cli version in the Nix dev shell: the bindgen
 # schema must match exactly between crate and CLI. Bump both together.
 wasm-bindgen = "=0.2.121"


### PR DESCRIPTION
Shared versions are supposed to be pinned under `[workspace.dependencies]` (rs/CLAUDE.md), but most crates were still declaring their own. `bytes` was spelled out in 21 manifests, `thiserror` and `tracing` in 20, `anyhow` in 17.

## Summary

- Added 39 entries to `[workspace.dependencies]` and pointed 206 declarations across 27 crates at them via `{ workspace = true }`.
  - Ubiquitous: `bytes`, `thiserror`, `tracing`, `anyhow`, `url`, `serde_json`, `futures`.
  - CLI/server: `clap`, `axum`, `axum-server`, `tower-http`, `reqwest`, `humantime`, `humantime-serde`, `toml`, `sd-notify`, `jsonwebtoken`, `aws-lc-rs`.
  - Misc shared: `rand`, `serde_with`, `base64`, `hex`, `num_enum`, `socket2`, `pollster`, `lazy_static`, `libloading`, `tempfile`, `tracing-subscriber`, `tracing-test`.
  - Platform: `cudarc`, plus the macOS `objc2*` / `block2` / `dispatch2` set shared by moq-audio and moq-video.
- Fixed four deps that already had a workspace entry but were re-declared locally anyway: `serde` (moq-bench, moq-native, moq-relay, moq-token), `getrandom` (moq-net), `tokio` (moq-token).
- Crate-specific features stay at the call site (`clap = { workspace = true, features = ["env"] }`, `url = { workspace = true, features = ["serde"] }`, `cudarc = { workspace = true, features = ["nvrtc"], optional = true }`), as do `optional` flags.

## Deliberately left alone

- **`rustls`** (5 crates, 3 specs): moq-native takes rustls default features, which include `prefer-post-quantum`; every other consumer is `default-features = false` + `aws-lc-rs`. Any single workspace entry silently changes the enabled crypto/provider set for one group or the other, so that belongs in its own change rather than a manifest sweep.
- **`rcgen`** (2 crates): same shape. moq-relay's dev-dep gets the default `ring` provider; moq-native disables defaults and selects the provider by feature.
- **hang / moq-transcode dev-deps on moq-mux / moq-native**: deliberately path-only with no version, which keeps them out of the published manifest and breaks the hang <-> moq-mux publish cycle.

## Public API changes

None. Manifests only, no source changes.

## Test plan

- Diffed `cargo metadata` before and after over every workspace member. The only differences are nine version-floor widenings where a crate had a looser requirement than the workspace pin: `rand ^0.10` -> `^0.10.1` (moq-audio, moq-hls, moq-relay, moq-rtmp), `humantime ^2` -> `^2.3` (moq-hls), `lazy_static ^1` -> `^1.5` (hang) and `^1.5.0` -> `^1.5` (moq-nvenc), `dispatch2 ^0.3.0` -> `^0.3.1` (moq-audio), `tokio ^1` -> `^1.48` (moq-token). Zero feature or `default-features` changes anywhere.
- `Cargo.lock` is byte-identical, so nothing re-resolved.
- `just check` and `just test` pass (3197 Rust tests, 50 Python).

## Cross-package sync

No rows apply: no wire format, FFI surface, config, or CLI interface changed.

(Written by claude-opus-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)