### PR TITLE
fix(moq-gst): tie the session's lifetime to the state transition

### DIFF
--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -409,11 +409,25 @@ impl ElementImpl for MoqSink {
 
 	fn change_state(&self, transition: gst::StateChange) -> Result<gst::StateChangeSuccess, gst::StateChangeError> {
 		match transition {
-			gst::StateChange::ReadyToPaused => self.start_session()?,
-			gst::StateChange::PausedToReady => self.stop_session(),
-			_ => {}
+			// Roll the session back when the parent transition fails. Otherwise the element sits in READY
+			// with the session still publishing and the broadcast still announced, and nothing releases it
+			// later: there is no READY -> NULL path that stops a session.
+			gst::StateChange::ReadyToPaused => {
+				self.start_session()?;
+				self.parent_change_state(transition)
+					.inspect_err(|_| self.stop_session())
+			}
+			// The parent goes first, because it is what deactivates the pads and waits for the streaming
+			// functions to return; finalizing the producers before that lets a chain function write into a
+			// finalized producer. The cleanup runs whatever the parent answers, since a failed downward
+			// transition still leaves nothing that would ever release the publication.
+			gst::StateChange::PausedToReady => {
+				let result = self.parent_change_state(transition);
+				self.stop_session();
+				result
+			}
+			_ => self.parent_change_state(transition),
 		}
-		self.parent_change_state(transition)
 	}
 }
 

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -419,12 +419,13 @@ impl ElementImpl for MoqSink {
 			}
 			// The parent goes first, because it is what deactivates the pads and waits for the streaming
 			// functions to return; finalizing the producers before that lets a chain function write into a
-			// finalized producer. The cleanup runs whatever the parent answers, since a failed downward
-			// transition still leaves nothing that would ever release the publication.
+			// finalized producer. A failed parent leaves the element in PAUSED rather than committing the
+			// transition, so the session stays with it: tearing down anyway would leave a PAUSED element
+			// publishing nothing, with no transition left to build a replacement. The retry cleans up.
 			gst::StateChange::PausedToReady => {
-				let result = self.parent_change_state(transition);
+				let success = self.parent_change_state(transition)?;
 				self.stop_session();
-				result
+				Ok(success)
 			}
 			_ => self.parent_change_state(transition),
 		}

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -4,7 +4,7 @@
 //! close) are validated against a real relay, separately from this hermetic suite.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Once};
+use std::sync::{Arc, Mutex, Once};
 
 use gst::prelude::*;
 
@@ -48,6 +48,34 @@ fn posted_eos(bus: &gst::Bus) -> usize {
 		}
 	}
 	seen
+}
+
+/// A bare pad whose activation (or deactivation) can be made to fail on demand, so a test can drive the
+/// parent transition into an error without a live relay.
+fn state_change_blocker(fail_when_active: bool) -> (gst::Pad, Arc<AtomicBool>) {
+	let enabled = Arc::new(AtomicBool::new(true));
+	let fail = enabled.clone();
+	let pad = gst::Pad::builder(gst::PadDirection::Sink)
+		.name("state-change-blocker")
+		.activatemode_function(move |_, _, _, active| {
+			if fail.load(Ordering::SeqCst) && active == fail_when_active {
+				return Err(gst::loggable_error!(gst::CAT_DEFAULT, "forced state-change failure"));
+			}
+			Ok(())
+		})
+		.build();
+	(pad, enabled)
+}
+
+/// A chain that answers `Flushing` is the element reporting it has no session to write into.
+fn assert_pad_has_no_live_publication(pad: &gst::Pad) {
+	pad.set_active(true).expect("activate the pad for the probe");
+	assert_eq!(
+		pad.chain(gst::Buffer::new()),
+		Err(gst::FlowError::Flushing),
+		"the transition left no publication attached to the pad"
+	);
+	pad.set_active(false).expect("deactivate the probe pad");
 }
 
 fn h264_caps() -> gst::Caps {
@@ -149,6 +177,62 @@ fn an_eos_during_another_pads_flush_does_not_complete_the_element() {
 		0,
 		"the flushing pad is not ended, so the element has not completed"
 	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// READY -> PAUSED is synchronous: the element creates its session without waiting for a buffer, which
+// is the preroll policy it inherits from deriving on GstElement rather than a sink base class.
+#[test]
+fn ready_to_paused_completes_without_a_buffer() {
+	init();
+	let sink = publisher();
+	let _pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	assert_eq!(
+		sink.set_state(gst::State::Paused),
+		Ok(gst::StateChangeSuccess::Success),
+		"the transition completed rather than going async"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// The regression: a failed chain-up used to leave the session publishing in READY, where no later
+// transition would ever stop it.
+#[test]
+fn a_failed_ready_to_paused_rolls_back_the_publication() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let (blocker, enabled) = state_change_blocker(true);
+	sink.add_pad(&blocker).expect("add activation blocker");
+
+	assert!(
+		sink.set_state(gst::State::Paused).is_err(),
+		"the parent transition reached the controlled activation failure"
+	);
+	assert_pad_has_no_live_publication(&pad);
+
+	enabled.store(false, Ordering::SeqCst);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// Going down, the cleanup is unconditional for the same reason. This passed before the reordering too:
+// it guards the property, not the ordering, which is a race no hermetic test observes.
+#[test]
+fn a_failed_paused_to_ready_still_releases_the_publication() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let (blocker, enabled) = state_change_blocker(false);
+	sink.add_pad(&blocker).expect("add deactivation blocker");
+	sink.set_state(gst::State::Paused).expect("start the publication");
+
+	assert!(
+		sink.set_state(gst::State::Ready).is_err(),
+		"the parent transition reached the controlled deactivation failure"
+	);
+	assert_pad_has_no_live_publication(&pad);
+
+	enabled.store(false, Ordering::SeqCst);
 	let _ = sink.set_state(gst::State::Null);
 }
 

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -195,8 +195,8 @@ fn ready_to_paused_completes_without_a_buffer() {
 	let _ = sink.set_state(gst::State::Null);
 }
 
-// The regression: a failed chain-up used to leave the session publishing in READY, where no later
-// transition would ever stop it.
+// A failed chain-up must leave nothing publishing: the element has no READY -> NULL path that would
+// stop a session later, so a publication surviving here survives until the element is destroyed.
 #[test]
 fn a_failed_ready_to_paused_rolls_back_the_publication() {
 	init();
@@ -215,24 +215,77 @@ fn a_failed_ready_to_paused_rolls_back_the_publication() {
 	let _ = sink.set_state(gst::State::Null);
 }
 
-// Going down, the cleanup is unconditional for the same reason. This passed before the reordering too:
-// it guards the property, not the ordering, which is a race no hermetic test observes.
+// A failed parent leaves the element in PAUSED, so the session stays with it. Tearing it down would
+// leave a PAUSED element publishing nothing and no transition left to build a replacement.
 #[test]
-fn a_failed_paused_to_ready_still_releases_the_publication() {
+fn a_failed_paused_to_ready_keeps_the_publication() {
 	init();
 	let sink = publisher();
 	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
 	let (blocker, enabled) = state_change_blocker(false);
 	sink.add_pad(&blocker).expect("add deactivation blocker");
 	sink.set_state(gst::State::Paused).expect("start the publication");
+	pad.set_active(true).expect("activate the pad");
+	assert!(send_caps(&pad));
 
 	assert!(
 		sink.set_state(gst::State::Ready).is_err(),
 		"the parent transition reached the controlled deactivation failure"
 	);
-	assert_pad_has_no_live_publication(&pad);
+	assert!(
+		pad.property::<Option<String>>("track").is_some(),
+		"the element is still in PAUSED, so its publication is still live"
+	);
 
+	// The retry succeeds and is what releases it.
 	enabled.store(false, Ordering::SeqCst);
+	sink.set_state(gst::State::Ready).expect("the retry completes");
+	assert_eq!(
+		pad.property::<Option<String>>("track"),
+		None,
+		"reaching READY released the reservation"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// The teardown ordering: the parent is what deactivates the pads and waits for the streaming functions
+// to return, so the publication has to outlive that. Finalizing first lets a chain function still in
+// flight write into a finalized producer. Observed from inside pad deactivation, where a streaming
+// function would be.
+#[test]
+fn the_publication_outlives_pad_deactivation() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused).expect("start the publication");
+	pad.set_active(true).expect("activate the pad");
+	assert!(send_caps(&pad));
+	let reserved = pad.property::<Option<String>>("track").expect("CAPS reserved a track");
+
+	let seen = Arc::new(Mutex::new(None));
+	let record = seen.clone();
+	let observed = pad.clone();
+	let probe = gst::Pad::builder(gst::PadDirection::Sink)
+		.name("deactivation-probe")
+		.activatemode_function(move |_, _, _, active| {
+			if !active {
+				record
+					.lock()
+					.unwrap()
+					.replace(observed.property::<Option<String>>("track"));
+			}
+			Ok(())
+		})
+		.build();
+	sink.add_pad(&probe).expect("add the probe");
+	probe.set_active(true).expect("activate the probe");
+
+	sink.set_state(gst::State::Ready).expect("tear down");
+	assert_eq!(
+		seen.lock().unwrap().clone().flatten().as_deref(),
+		Some(reserved.as_str()),
+		"the publication was still live while the pads were being deactivated"
+	);
 	let _ = sink.set_state(gst::State::Null);
 }
 


### PR DESCRIPTION
Split out of #2998. That PR needs all three of its fixes, but bundles them with a rewrite of the element's per-pad state; this is the first of the three against `main` on its own.

## Summary

- **Root cause (up):** `READY -> PAUSED` created the session and chained up without a rollback. When the parent transition fails, the element sits in READY with the session still publishing, the broadcast still announced and the reconnect task still running. Nothing releases it later, because the element has no `READY -> NULL` path that stops a session, so the only way out was destroying the element.
- **Root cause (down):** `PAUSED -> READY` tore the session down *before* chaining up. The parent is what deactivates the pads and waits for the streaming functions to return, so finalizing first let a chain function write into a finalized producer. The parent now goes first.
- **A failed downward transition keeps the session.** GStreamer does not commit `PAUSED -> READY` when the parent fails, so the element stays in PAUSED. Tearing down anyway would leave a PAUSED element publishing nothing, with no transition left to build a replacement (setting PAUSED again does not re-run `READY -> PAUSED`). The retry is what cleans up.

## Public API changes

None. `change_state` is a trait impl; no `pub` item added, renamed or resignatured.

## Test plan

`just check` and `just test`, plus three regression tests:

- `a_failed_ready_to_paused_rolls_back_the_publication` — fails without the rollback.
- `the_publication_outlives_pad_deactivation` — pins the teardown ordering. A pad's activate-mode callback runs during the parent's deactivation, exactly where a streaming function would be, and reads whether the pad's track is still reserved: with the cleanup before the parent it is already released, with the cleanup after it is not. Verified failing with the old ordering.
- `a_failed_paused_to_ready_keeps_the_publication` — the publication survives a failed downward transition and is released by the retry.

Plus `ready_to_paused_completes_without_a_buffer`, which pins the synchronous-preroll policy the element gets from deriving on `GstElement`.

## Review

The downward-failure behaviour and the ordering test both came out of the adversarial review, which caught that the original "cleanup runs whatever the parent answers" was wrong and that the ordering *was* hermetically testable after all.

## Cross-package sync

No row applies: no wire format, no CLI surface, and no `moqsink` property or pad behaviour that `doc/bin/gstreamer.md` documents.

(Written by Claude Opus 5)