### PR TITLE
fix(moq-gst): scope a terminal session error to the session that earned it

### DIFF
--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -19,7 +19,7 @@ use hang::moq_net;
 
 use super::pad::{Pad, ProducerOptions, caps_supported};
 use super::request_pad::MoqSinkPad;
-use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session};
+use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session, SessionState};
 
 #[derive(Debug, Clone, Default)]
 struct Settings {
@@ -604,6 +604,32 @@ impl MoqSink {
 		}
 	}
 
+	/// Post a terminal session error, but only while the session that earned it is still the live one.
+	///
+	/// `Session`'s `Drop` aborts the task, but an abort is not synchronous: a task already inside its
+	/// terminal arm runs to completion, so a session the element stopped can still be reporting while
+	/// its replacement publishes. That error belongs to the run that ended.
+	///
+	/// The lock is released before posting, because `post_message` runs the bus sync handlers inline and
+	/// a handler reading a property would take it again.
+	pub(super) fn post_session_error(&self, session: &SessionState, error: String) {
+		let current = self
+			.state
+			.lock()
+			.unwrap()
+			.as_ref()
+			.is_some_and(|state| state.session.state().is(session));
+		if !current {
+			gst::debug!(
+				CAT,
+				obj = self.obj(),
+				"discarding an error from a stopped publishing session: {error}"
+			);
+			return;
+		}
+		gst::element_error!(self.obj(), gst::CoreError::Failed, ("session error"), ["{error}"]);
+	}
+
 	/// Mark a pad ended, then post the element EOS if that was the last active pad.
 	fn handle_eos(&self, pad: &gst::Pad) {
 		if let Some(state) = self.state.lock().unwrap().as_mut() {
@@ -655,6 +681,56 @@ mod tests {
 
 	fn spec(element: &super::super::MoqSink, name: &str) -> glib::ParamSpec {
 		element.find_property(name).unwrap()
+	}
+
+	/// The live session's identity, for a test that needs to outlive it.
+	fn session_of(sink: &super::super::MoqSink) -> SessionState {
+		sink.imp()
+			.state
+			.lock()
+			.unwrap()
+			.as_ref()
+			.expect("live session")
+			.session
+			.state()
+			.clone()
+	}
+
+	// `Session`'s `Drop` aborts the task, but not synchronously: a task already inside its terminal arm
+	// runs to completion, and used to post its error onto whatever session had replaced it.
+	#[test]
+	fn a_stopped_session_does_not_report_into_its_replacement() {
+		gst::init().unwrap();
+		let sink = sink();
+		sink.set_property("url", "https://127.0.0.1:1");
+		sink.set_property("broadcast", "test");
+		let element = sink.clone().upcast::<gst::Element>();
+		let bus = gst::Bus::new();
+		element.set_bus(Some(&bus));
+
+		element.set_state(gst::State::Paused).expect("start a session");
+		let stopped = session_of(&sink);
+		element.set_state(gst::State::Ready).expect("stop it");
+		element.set_state(gst::State::Paused).expect("start its replacement");
+		let live = session_of(&sink);
+		assert!(!stopped.is(&live), "the replacement is a different session");
+		while bus.pop().is_some() {}
+
+		sink.imp()
+			.post_session_error(&stopped, "from the stopped run".to_string());
+		assert!(
+			bus.pop().is_none(),
+			"the stopped session's error did not reach its replacement's bus"
+		);
+
+		sink.imp().post_session_error(&live, "from the live run".to_string());
+		assert_eq!(
+			bus.pop().map(|message| message.type_()),
+			Some(gst::MessageType::Error),
+			"the live session's error still reaches the bus"
+		);
+
+		let _ = element.set_state(gst::State::Null);
 	}
 
 	#[test]

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -424,10 +424,11 @@ impl MoqSink {
 			gst::error!(CAT, obj = self.obj(), "invalid settings: {err:#}");
 			gst::StateChangeError
 		})?;
-		let (session, broadcast, catalog) = Session::start(settings, self.obj().downgrade()).map_err(|err| {
-			gst::error!(CAT, obj = self.obj(), "failed to start session: {err:?}");
-			gst::StateChangeError
-		})?;
+		let (session, registration, broadcast, catalog) =
+			Session::start(settings, self.obj().downgrade()).map_err(|err| {
+				gst::error!(CAT, obj = self.obj(), "failed to start session: {err:?}");
+				gst::StateChangeError
+			})?;
 		*self.state.lock().unwrap() = Some(State {
 			session,
 			broadcast,
@@ -436,6 +437,8 @@ impl MoqSink {
 			ended: HashSet::new(),
 			eos_posted: false,
 		});
+		// Only now can a terminal error be attributed to this session rather than discarded as stale.
+		registration.mark_registered();
 		Ok(())
 	}
 

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -116,6 +116,22 @@ pub(super) fn client_config(settings: &ResolvedSettings) -> moq_native::ClientCo
 	config
 }
 
+/// Permission for one session's task to report a terminal failure on the bus.
+///
+/// Held between creating the session and installing it on the element. Marking it releases the task;
+/// dropping it unmarked leaves the task parked, which is what a failed start wants, since the session
+/// it belonged to is torn down with it.
+pub(crate) struct SessionRegistration {
+	gate: Arc<tokio::sync::Notify>,
+}
+
+impl SessionRegistration {
+	/// Release the task: the element installed this session, so its errors now have somewhere to land.
+	pub(crate) fn mark_registered(self) {
+		self.gate.notify_one();
+	}
+}
+
 /// A running session: the connect/lifecycle task plus the state the property getters read. Dropping the
 /// `Session` (or the producers held by the element) tears it down.
 pub(crate) struct Session {
@@ -166,7 +182,12 @@ impl Session {
 	pub fn start(
 		settings: ResolvedSettings,
 		element: glib::WeakRef<Element>,
-	) -> Result<(Self, moq_net::broadcast::Producer, moq_mux::catalog::Producer)> {
+	) -> Result<(
+		Self,
+		SessionRegistration,
+		moq_net::broadcast::Producer,
+		moq_mux::catalog::Producer,
+	)> {
 		// Producer setup may touch tokio time (group eviction), so run it inside the runtime context.
 		let _rt = RUNTIME.enter();
 
@@ -194,7 +215,18 @@ impl Session {
 		let send_bandwidth = reconnect.send_bandwidth();
 		let recv_bandwidth = reconnect.recv_bandwidth();
 
-		let join = RUNTIME.spawn(forward(reconnect, origin, status.clone(), state.clone(), element));
+		// The task is spawned parked. An immediate rejection would otherwise race the element installing
+		// this session: the error would arrive while there is no live session to attribute it to, and the
+		// gate below would discard a legitimate current failure as a stale one.
+		let gate = Arc::new(tokio::sync::Notify::new());
+		let join = RUNTIME.spawn(forward(
+			reconnect,
+			origin,
+			status.clone(),
+			state.clone(),
+			element,
+			gate.clone(),
+		));
 
 		Ok((
 			Self {
@@ -204,6 +236,7 @@ impl Session {
 				recv_bandwidth,
 				state,
 			},
+			SessionRegistration { gate },
 			broadcast,
 			catalog,
 		))
@@ -259,6 +292,24 @@ impl Drop for Session {
 /// [`Session`]'s `Drop` aborts this task, which drops the `Reconnect` handle and quietly tears the loop
 /// down.
 async fn forward(
+	reconnect: moq_native::Reconnect,
+	origin: moq_net::origin::Producer,
+	status: Arc<Status>,
+	state: SessionState,
+	element: glib::WeakRef<Element>,
+	registered: Arc<tokio::sync::Notify>,
+) {
+	wait_for_registration(registered).await;
+	forward_registered(reconnect, origin, status, state, element).await;
+}
+
+/// `Notify` keeps the permit, so marking before the task parks here is not a lost wakeup. A session
+/// that is never installed is aborted by `Session`'s `Drop`, which unparks nothing.
+async fn wait_for_registration(registered: Arc<tokio::sync::Notify>) {
+	registered.notified().await;
+}
+
+async fn forward_registered(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
@@ -331,5 +382,34 @@ fn notify(element: &glib::WeakRef<Element>, props: &[&str]) {
 		for prop in props {
 			obj.notify(prop);
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// The regression: `forward` used to be runnable the instant it was spawned, so a fast rejection
+	// could report before `start_session` installed the session. The element then saw no live session
+	// and discarded a legitimate current error as a stale one.
+	#[tokio::test]
+	async fn a_terminal_result_waits_until_the_session_is_registered() {
+		let gate = Arc::new(tokio::sync::Notify::new());
+		let registration = SessionRegistration { gate: gate.clone() };
+		let state = SessionState::new();
+		let task_state = state.clone();
+		let (entered, reached) = tokio::sync::oneshot::channel();
+
+		let task = tokio::spawn(async move {
+			entered.send(()).unwrap();
+			wait_for_registration(gate).await;
+			task_state.fail();
+		});
+		reached.await.unwrap();
+		assert!(!state.failed(), "the terminal result stayed parked");
+
+		registration.mark_registered();
+		task.await.unwrap();
+		assert!(state.failed(), "registration released it");
 	}
 }

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use anyhow::Result;
 use gst::glib;
 use gst::prelude::*;
+use gst::subclass::prelude::*;
 
 use hang::moq_net;
 
@@ -126,8 +127,37 @@ pub(crate) struct Session {
 	/// The live recv-bitrate estimate, tracked across reconnects by the reconnect loop. Read directly
 	/// by the `estimated-recv-bitrate` getter.
 	recv_bandwidth: moq_net::bandwidth::Consumer,
-	/// Set by the task on a fatal transport error so the pad streaming threads stop feeding a dead session.
-	errored: Arc<AtomicBool>,
+	/// This session's terminal state, shared with its task and used to scope its deferred messages.
+	state: SessionState,
+}
+
+/// One publishing session's terminal state, shared by the session's task and the element.
+///
+/// Doubles as the session's identity. Every clone belongs to exactly one session, so `Arc::ptr_eq`
+/// answers whether a deferred message still belongs to the live session without a separate id: a task
+/// that outlived its session holds only its own clone.
+#[derive(Clone)]
+pub(crate) struct SessionState(Arc<AtomicBool>);
+
+impl SessionState {
+	fn new() -> Self {
+		Self(Arc::new(AtomicBool::new(false)))
+	}
+
+	/// Flag a fatal transport error so the pad streaming threads stop feeding a dead session.
+	fn fail(&self) {
+		self.0.store(true, Ordering::Relaxed);
+	}
+
+	/// Whether this session hit a fatal transport error.
+	fn failed(&self) -> bool {
+		self.0.load(Ordering::Relaxed)
+	}
+
+	/// Whether both handles belong to the same publishing session.
+	pub(crate) fn is(&self, other: &Self) -> bool {
+		Arc::ptr_eq(&self.0, &other.0)
+	}
 }
 
 impl Session {
@@ -148,7 +178,7 @@ impl Session {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 
 		let status = Arc::new(Status::default());
-		let errored = Arc::new(AtomicBool::new(false));
+		let state = SessionState::new();
 
 		// Publish through a background reconnect loop: connect, wait for close, reconnect with backoff.
 		// `timeout = 0` drops the give-up deadline so an unattended publisher outlives relay/QUIC
@@ -164,7 +194,7 @@ impl Session {
 		let send_bandwidth = reconnect.send_bandwidth();
 		let recv_bandwidth = reconnect.recv_bandwidth();
 
-		let join = RUNTIME.spawn(forward(reconnect, origin, status.clone(), errored.clone(), element));
+		let join = RUNTIME.spawn(forward(reconnect, origin, status.clone(), state.clone(), element));
 
 		Ok((
 			Self {
@@ -172,7 +202,7 @@ impl Session {
 				status,
 				send_bandwidth,
 				recv_bandwidth,
-				errored,
+				state,
 			},
 			broadcast,
 			catalog,
@@ -196,7 +226,12 @@ impl Session {
 
 	/// Whether the transport has hit a fatal error (the pad streaming threads stop feeding it on this).
 	pub fn errored(&self) -> bool {
-		self.errored.load(Ordering::Relaxed)
+		self.state.failed()
+	}
+
+	/// The identity that scopes this session's deferred messages to the run that earned them.
+	pub(super) fn state(&self) -> &SessionState {
+		&self.state
 	}
 
 	/// Stop the session: a clean local close, never an error. [`Drop`] aborts the task, cancelling the
@@ -227,7 +262,7 @@ async fn forward(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::origin::Producer,
 	status: Arc<Status>,
-	errored: Arc<AtomicBool>,
+	state: SessionState,
 	element: glib::WeakRef<Element>,
 ) {
 	// Hold the origin producer for the task's lifetime so the broadcast created on it stays routable:
@@ -261,13 +296,14 @@ async fn forward(
 				}
 				Err(err) => {
 					// The reconnect loop stopped on a terminal error (a non-retryable auth failure, or a
-					// bounded backoff's give-up). Flag `errored` so the pad threads stop feeding a dead
-					// session, and post a fatal element error.
+					// bounded backoff's give-up). Flag the session so the pad threads stop feeding a dead
+					// one, then hand the error to the element, which posts it only if this session is
+					// still the live one.
 					status.set(ConnectionStatus::Failed, None);
 					notify(&element, &["status", "connected", "moq-version"]);
-					errored.store(true, Ordering::Relaxed);
+					state.fail();
 					if let Some(obj) = element.upgrade() {
-						gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
+						obj.imp().post_session_error(&state, format!("{err:?}"));
 					}
 					return;
 				}


### PR DESCRIPTION
Split out of #2998. That PR needs all three of its fixes, but bundles them with a rewrite of the element's per-pad state; this is the second of the three against `main` on its own.

## Summary

- **Root cause:** the reconnect task posted its terminal error straight onto the element. `Session`'s `Drop` aborts that task rather than joining it, and an abort is not synchronous: a task already inside its terminal arm runs to completion. An application that cycles `PAUSED -> READY -> PAUSED` could therefore see the run it stopped report a fatal error onto the bus of the run that replaced it.
- The task now hands its error to the element, which drops it when the session has been replaced.
- **No new identity token.** The session already allocates an `Arc` for its terminal flag, and every clone of it belongs to exactly one session, so `Arc::ptr_eq` answers "is this still the live session?" for free. `errored` and the identity are the same fact, so they are now one type, `SessionState`.
- The control lock is released before posting, because `post_message` runs the bus sync handlers inline and a handler reading a property would take it again.

## Public API changes

None public. `SessionState` is `pub(crate)`, and `Session::errored()` keeps its signature and meaning.

## Test plan

`just check` and `just test`, plus `a_stopped_session_does_not_report_into_its_replacement`: it starts a session, keeps its identity, cycles the element to READY and back to PAUSED, then posts an error as each session. The stopped session's error must not reach the bus and the live one's must. Verified failing without the guard.

It is a unit test in `imp.rs` rather than in `tests/element.rs` because reaching this path for real needs a terminal reconnect error (an auth rejection), which the hermetic suite cannot produce.

## Cross-package sync

No row applies: no wire format, no CLI surface, and no change to what `doc/bin/gstreamer.md` documents. The bus error's text and type are unchanged; only the session it is attributed to.

(Written by Claude Opus 5)