### PR TITLE
fix(moq-gst): let a flush restart a pad that already sent EOS

### DIFF
--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -490,6 +490,12 @@ impl MoqSink {
 		if state.session.errored() {
 			return Err(gst::FlowError::Error);
 		}
+		// The publication was finalized: the producers this buffer would be written into are gone, and a
+		// flush cannot bring them back. Answer the streaming thread rather than dropping it as `Ok`
+		// against nothing. Recovery is a cycle through READY, which builds another session.
+		if state.eos_posted {
+			return Err(gst::FlowError::Eos);
+		}
 
 		// The pad almost always exists already (caps arrive before buffers), so look it up without
 		// allocating an owned name; only the rare first-buffer insert pays for the key.
@@ -586,12 +592,26 @@ impl MoqSink {
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
 			// FLUSH_STOP re-anchors the timeline; the trailing SEGMENT is accepted fresh. The producer is
-			// kept (FLUSH is not EOS).
+			// kept (FLUSH is not EOS), and the pad flows again, so it no longer counts as ended.
 			gst::EventView::FlushStop(_) => {
 				if let Some(state) = self.state.lock().unwrap().as_mut()
-					&& let Some(media) = state.pads.get_mut(pad.name().as_str())
+					&& !state.eos_posted
 				{
-					media.flush();
+					let name = pad.name();
+					state.ended.remove(name.as_str());
+					if let Some(media) = state.pads.get_mut(name.as_str()) {
+						media.flush();
+					}
+				}
+				drop(reservation);
+				gst::Pad::event_default(pad, Some(&*self.obj()), event)
+			}
+			// A new stream on this pad is a fresh start, so it no longer counts as ended either.
+			gst::EventView::StreamStart(_) => {
+				if let Some(state) = self.state.lock().unwrap().as_mut()
+					&& !state.eos_posted
+				{
+					state.ended.remove(pad.name().as_str());
 				}
 				drop(reservation);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -591,6 +591,18 @@ impl MoqSink {
 				drop(reservation);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
+			// A pad that starts flushing stops counting towards EOS immediately, not when the flush
+			// finishes. Waiting for FLUSH_STOP lets another pad's EOS complete the element inside the
+			// flush window, and the finalize that follows is not something FLUSH_STOP can undo.
+			gst::EventView::FlushStart(_) => {
+				if let Some(state) = self.state.lock().unwrap().as_mut()
+					&& !state.eos_posted
+				{
+					state.ended.remove(pad.name().as_str());
+				}
+				drop(reservation);
+				gst::Pad::event_default(pad, Some(&*self.obj()), event)
+			}
 			// FLUSH_STOP re-anchors the timeline; the trailing SEGMENT is accepted fresh. The producer is
 			// kept (FLUSH is not EOS), and the pad flows again, so it no longer counts as ended.
 			gst::EventView::FlushStop(_) => {
@@ -606,12 +618,19 @@ impl MoqSink {
 				drop(reservation);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
-			// A new stream on this pad is a fresh start, so it no longer counts as ended either.
+			// A new stream on this pad is a fresh start: it no longer counts as ended, and its timeline is
+			// re-anchored like a flush. Without that the old stream's segment base stays current, and a
+			// new stream restarting at zero reads as a rewind, which invalidates the pad and silently
+			// drops its buffers.
 			gst::EventView::StreamStart(_) => {
 				if let Some(state) = self.state.lock().unwrap().as_mut()
 					&& !state.eos_posted
 				{
-					state.ended.remove(pad.name().as_str());
+					let name = pad.name();
+					state.ended.remove(name.as_str());
+					if let Some(media) = state.pads.get_mut(name.as_str()) {
+						media.flush();
+					}
 				}
 				drop(reservation);
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -128,6 +128,30 @@ fn a_buffer_after_the_publication_ended_reports_eos() {
 	let _ = sink.set_state(gst::State::Null);
 }
 
+// The flush window: a pad that has begun flushing must stop counting towards EOS right away. Waiting
+// for FLUSH_STOP let pad B's EOS complete the element mid-flush, and the finalize that follows is not
+// something pad A's FLUSH_STOP can undo.
+#[test]
+fn an_eos_during_another_pads_flush_does_not_complete_the_element() {
+	init();
+	let sink = publisher();
+	let first = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let second = sink.request_pad_simple("sink_1").expect("request sink_1");
+	sink.set_state(gst::State::Paused).expect("start the publication");
+	let bus = recording_bus(&sink);
+
+	assert!(first.send_event(gst::event::Eos::new()));
+	assert!(first.send_event(gst::event::FlushStart::new()));
+	assert!(second.send_event(gst::event::Eos::new()));
+
+	assert_eq!(
+		posted_eos(&bus),
+		0,
+		"the flushing pad is not ended, so the element has not completed"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
 // Request pads appear and disappear through the real GObject boundary, with no session attached.
 #[test]
 fn request_and_release_sink_pads() {

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -33,6 +33,23 @@ fn publisher() -> gst::Element {
 		.expect("create moqsink")
 }
 
+/// Every message type the element posted, in order.
+fn recording_bus(sink: &gst::Element) -> gst::Bus {
+	let bus = gst::Bus::new();
+	sink.set_bus(Some(&bus));
+	bus
+}
+
+fn posted_eos(bus: &gst::Bus) -> usize {
+	let mut seen = 0;
+	while let Some(message) = bus.pop() {
+		if message.type_() == gst::MessageType::Eos {
+			seen += 1;
+		}
+	}
+	seen
+}
+
 fn h264_caps() -> gst::Caps {
 	gst::Caps::builder("video/x-h264")
 		.field("stream-format", "byte-stream")
@@ -44,6 +61,71 @@ fn h264_caps() -> gst::Caps {
 /// order, CAPS builds the producer.
 fn send_caps(pad: &gst::Pad) -> bool {
 	pad.send_event(gst::event::StreamStart::new("test")) && pad.send_event(gst::event::Caps::new(&h264_caps()))
+}
+
+// A flush re-anchors the pad's timeline and it flows again, so it must stop counting towards the
+// element's EOS aggregation. Leaving it ended let the *next* pad's EOS complete the element while this
+// one was still publishing.
+#[test]
+fn a_flush_after_eos_makes_the_pad_flow_again() {
+	init();
+	let sink = publisher();
+	let first = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let second = sink.request_pad_simple("sink_1").expect("request sink_1");
+	sink.set_state(gst::State::Paused).expect("start the publication");
+	let bus = recording_bus(&sink);
+
+	assert!(first.send_event(gst::event::Eos::new()));
+	assert!(first.send_event(gst::event::FlushStart::new()));
+	assert!(first.send_event(gst::event::FlushStop::builder(true).build()));
+	assert!(second.send_event(gst::event::Eos::new()));
+
+	assert_eq!(
+		posted_eos(&bus),
+		0,
+		"the flushed pad is publishing again, so the element has not ended"
+	);
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// STREAM_START is the same fresh start.
+#[test]
+fn a_new_stream_after_eos_makes_the_pad_flow_again() {
+	init();
+	let sink = publisher();
+	let first = sink.request_pad_simple("sink_0").expect("request sink_0");
+	let second = sink.request_pad_simple("sink_1").expect("request sink_1");
+	sink.set_state(gst::State::Paused).expect("start the publication");
+	let bus = recording_bus(&sink);
+
+	assert!(first.send_event(gst::event::Eos::new()));
+	assert!(first.send_event(gst::event::StreamStart::new("second-stream")));
+	assert!(second.send_event(gst::event::Eos::new()));
+
+	assert_eq!(posted_eos(&bus), 0, "the restarted pad has not ended");
+	let _ = sink.set_state(gst::State::Null);
+}
+
+// Once the publication is finalized the producers are gone, and a flush cannot bring them back. The
+// streaming thread gets an answer instead of an `Ok` written into nothing.
+#[test]
+fn a_buffer_after_the_publication_ended_reports_eos() {
+	init();
+	let sink = publisher();
+	let pad = sink.request_pad_simple("sink_0").expect("request sink_0");
+	sink.set_state(gst::State::Paused).expect("start the publication");
+	pad.set_active(true).expect("activate the pad");
+	assert!(send_caps(&pad));
+	assert!(pad.send_event(gst::event::Eos::new()));
+
+	assert!(pad.send_event(gst::event::FlushStart::new()));
+	assert!(pad.send_event(gst::event::FlushStop::builder(true).build()));
+	assert_eq!(
+		pad.chain(gst::Buffer::new()),
+		Err(gst::FlowError::Eos),
+		"the finalized publication answers rather than accepting the buffer"
+	);
+	let _ = sink.set_state(gst::State::Null);
 }
 
 // Request pads appear and disappear through the real GObject boundary, with no session attached.


### PR DESCRIPTION
Split out of #2998. That PR needs all three of its fixes, but bundles them with a rewrite of the element's per-pad state; this is the last of the three against `main` on its own.

## Summary

- **Root cause:** `FLUSH_STOP` re-anchors the pad's timeline and it flows again, but the element never removed it from the `ended` set it aggregates EOS over. The pad stayed ended, so the *next* pad's EOS completed the element while the flushed one was still publishing: the pipeline saw EOS with a live track. `STREAM_START` had the same problem and was not handled at all.
- Both now clear the pad's ended flag, but only while the publication is still open.
- Once the publication is finalized the producers are gone and a flush cannot bring them back, so a buffer arriving after that reports `Eos` to its streaming thread instead of being written into nothing. Recovery is a cycle through READY, which builds another session, broadcast and catalog.

## Scope

#2998 goes further here and separates "the producers were finalized" from "the EOS message was posted", which `eos_posted` conflates today. That separation is what its per-pad lifecycle rewrite buys, and it is not reproducible standalone. This change keeps the conflation and fixes only the reset, which is the user-visible half.

## Public API changes

None. `handle_event` and `forward_buffer` are internal.

## Test plan

`just check` and `just test`, plus three regression tests, all verified failing on `main` and passing with the fix:

- `a_flush_after_eos_makes_the_pad_flow_again` — two pads; `sink_0` sends EOS then flushes, `sink_1` sends EOS. The element must not post EOS.
- `a_new_stream_after_eos_makes_the_pad_flow_again` — the same via `STREAM_START`.
- `a_buffer_after_the_publication_ended_reports_eos` — a buffer pushed after the publication finalized answers `Eos` rather than being accepted.

## Cross-package sync

No row applies: no wire format and no CLI surface. `doc/bin/gstreamer.md` documents `moqsink`'s properties and pad naming, none of which change; it does not document flush or EOS aggregation semantics.

(Written by Claude Opus 5)