### PR TITLE
fix(uring): close abandoned handshakes and stop conflating H3 codes

### DIFF
--- a/rs/moq-uring/src/quic/mod.rs
+++ b/rs/moq-uring/src/quic/mod.rs
@@ -318,6 +318,16 @@ pub enum Error {
 	/// stream that could not be framed.
 	#[error("webtransport error: {0}")]
 	Web(String),
+	/// HTTP/3 failed with a code of its own, one that names no WebTransport
+	/// error (`H3_NO_ERROR`, say). Neither trait accessor reports it, because
+	/// it is not a code the peer's application chose.
+	#[error("http/3 closed: code={code} reason={reason:?}")]
+	Http3 {
+		/// The HTTP/3 error code.
+		code: u64,
+		/// The UTF-8 lossy close reason, empty for a stream-level code.
+		reason: String,
+	},
 }
 
 impl web_transport_trait::Error for Error {

--- a/rs/moq-uring/src/quic/stream.rs
+++ b/rs/moq-uring/src/quic/stream.rs
@@ -39,6 +39,13 @@ impl SendStream {
 		self.id
 	}
 
+	/// Whether the send side is already terminated, so [`Drop`] would do
+	/// nothing. The WebTransport wrapper asks before mapping a reset of its
+	/// own, since a finished stream must not be reset instead.
+	pub(crate) fn ended(&self) -> bool {
+		self.fin || self.reset
+	}
+
 	/// Queue as much of `buf` as quiche will take right now, without parking.
 	/// Best-effort, for the close path where nobody is left to poll.
 	pub(crate) fn try_write(&mut self, buf: &[u8]) -> usize {
@@ -218,6 +225,12 @@ impl RecvStream {
 			stopped: false,
 			backlog: BytesMut::new(),
 		}
+	}
+
+	/// Whether the read side is already terminated, so [`Drop`] would do
+	/// nothing.
+	pub(crate) fn ended(&self) -> bool {
+		self.finished || self.stopped
 	}
 
 	/// [`stop`](web_transport_trait::poll::RecvStream::stop) with a

--- a/rs/moq-uring/src/quic/web.rs
+++ b/rs/moq-uring/src/quic/web.rs
@@ -177,16 +177,16 @@ impl Request {
 				// Stop adopting past the cap, but do not give up on what is
 				// already here: the control stream may be sitting at the head
 				// of a queue a pipelining peer filled behind it, and refusing
-				// that peer is the bug the cap is not for.
+				// that peer is the bug the cap is not for. The one that tips
+				// it over is kept rather than dropped, since dropping it would
+				// cancel a legitimate stream on a handshake that then succeeds.
 				let mut over = false;
 				while !over {
 					match web_transport_trait::poll::Session::poll_accept_uni(&mut conn, cx) {
 						Poll::Ready(Ok(recv)) => {
 							arrivals += 1;
+							pending.push(PendingUni::new(recv));
 							over = arrivals > HANDSHAKE_STREAMS;
-							if !over {
-								pending.push(PendingUni::new(recv));
-							}
 						}
 						Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
 						Poll::Pending => break,

--- a/rs/moq-uring/src/quic/web.rs
+++ b/rs/moq-uring/src/quic/web.rs
@@ -63,6 +63,9 @@ const HELD_STREAMS: usize = 8;
 /// `H3_GENERAL_PROTOCOL_ERROR`, for closing a connection whose HTTP/3
 /// handshake never produced a session.
 const H3_GENERAL_PROTOCOL_ERROR: u64 = 0x0101;
+/// `H3_NO_ERROR`, for closing a connection that did what it came to do: a
+/// rejection the peer has been told about.
+const H3_NO_ERROR: u64 = 0x0100;
 
 /// An incoming WebTransport handshake: the CONNECT request, ready to answer.
 ///
@@ -72,6 +75,8 @@ const H3_GENERAL_PROTOCOL_ERROR: u64 = 0x0101;
 pub struct Request {
 	handle: Handle,
 	conn: Connection,
+	/// Closes the connection on every way out of here that is not an answer.
+	guard: Guard,
 	request: proto::ConnectRequest,
 	send: super::SendStream,
 	recv: super::RecvStream,
@@ -83,6 +88,42 @@ pub struct Request {
 	/// WebTransport streams a pipelining peer opened before its CONNECT was
 	/// answered, headers consumed, keyed by the session id they claimed.
 	early: Vec<(u64, super::RecvStream)>,
+	/// Streams that arrived during the handshake and are still mid-header;
+	/// the session goes on classifying them.
+	pending: Vec<PendingUni>,
+}
+
+/// Closes a connection whose handshake was abandoned, disarmed once the peer
+/// has an answer.
+///
+/// Dropping a [`Connection`] does not close QUIC: the endpoint keeps it, its
+/// routes, and its driver task until the driver sees a terminal state, and the
+/// backlog stopped counting it at accept. The peer picks the path it asks for
+/// and the subprotocols it offers, so it decides which of [`Request::respond`]'s
+/// early returns the server takes; a guard covers every way out rather than
+/// each one remembering.
+struct Guard {
+	conn: Option<Connection>,
+}
+
+impl Guard {
+	fn new(conn: Connection) -> Self {
+		Self { conn: Some(conn) }
+	}
+
+	/// The peer got an answer, so the connection is the answer's to close.
+	fn disarm(&mut self) {
+		self.conn = None;
+	}
+}
+
+impl Drop for Guard {
+	fn drop(&mut self) {
+		if let Some(conn) = self.conn.take() {
+			conn.shared()
+				.close_code(H3_GENERAL_PROTOCOL_ERROR, "webtransport handshake abandoned");
+		}
+	}
 }
 
 impl Request {
@@ -118,7 +159,11 @@ impl Request {
 
 		// The peer's control stream carries its SETTINGS, but its QPACK
 		// streams race it, and an eager client's WebTransport streams can
-		// arrive ahead of everything; classify each arrival by its header.
+		// arrive ahead of everything, so classify every arrival at once.
+		// Taking them one at a time would let a stream that sends its type
+		// byte and then stalls hold off a control stream that has already
+		// fully arrived, for as long as the peer keeps the connection alive.
+		let mut pending: Vec<PendingUni> = Vec::new();
 		let mut held = Vec::new();
 		let mut early = Vec::new();
 		// Every arrival counts, not just the ones kept: a stream of unknown
@@ -126,28 +171,62 @@ impl Request {
 		// counting what we retain would let a peer loop this forever while
 		// never sending a control stream.
 		let mut arrivals = 0usize;
-		loop {
-			arrivals += 1;
-			if arrivals > HANDSHAKE_STREAMS {
-				return Err(Error::Web("too many streams before the control stream".into()));
-			}
-			let recv = accept_uni(&mut conn).await?;
-			let mut pending = PendingUni::new(recv);
-			let class = std::future::poll_fn(|cx| pending.poll_classify(cx)).await;
-			match class {
-				UniClass::Control => {
-					let settings = read_settings(&mut pending.recv).await?;
-					if settings.supports_webtransport() == 0 {
-						return Err(Error::Web("peer does not support WebTransport".into()));
+		let mut peer_control = None;
+		std::future::poll_fn(|cx| {
+			loop {
+				loop {
+					match web_transport_trait::poll::Session::poll_accept_uni(&mut conn, cx) {
+						Poll::Ready(Ok(recv)) => {
+							arrivals += 1;
+							if arrivals > HANDSHAKE_STREAMS {
+								return Poll::Ready(Err(Error::Web(
+									"too many streams before the control stream".into(),
+								)));
+							}
+							pending.push(PendingUni::new(recv));
+						}
+						Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+						Poll::Pending => break,
 					}
-					held.push(pending.recv);
-					break;
 				}
-				UniClass::Qpack => held.push(pending.recv),
-				UniClass::Web(session) => early.push((session, pending.recv)),
-				UniClass::Unknown => {}
+
+				// Each mid-header stream parks the caller in its own stream's
+				// waiters, so progress on any of them re-polls us.
+				let mut progressed = false;
+				let mut index = 0;
+				while index < pending.len() {
+					let Poll::Ready(class) = pending[index].poll_classify(cx) else {
+						index += 1;
+						continue;
+					};
+					// Whatever was last takes this slot, so it is polled by
+					// this same pass rather than waited for.
+					let stream = pending.swap_remove(index);
+					progressed = true;
+					match class {
+						UniClass::Control => {
+							peer_control = Some(stream.recv);
+							return Poll::Ready(Ok(()));
+						}
+						UniClass::Qpack => held.push(stream.recv),
+						UniClass::Web(session) => early.push((session, stream.recv)),
+						UniClass::Unknown => {}
+					}
+				}
+
+				if !progressed {
+					return Poll::Pending;
+				}
 			}
+		})
+		.await?;
+
+		let mut peer_control = peer_control.expect("the loop only ends with a control stream");
+		let settings = read_settings(&mut peer_control).await?;
+		if settings.supports_webtransport() == 0 {
+			return Err(Error::Web("peer does not support WebTransport".into()));
 		}
+		held.push(peer_control);
 
 		// The CONNECT request rides the client's first bidirectional stream,
 		// which arrives first: QUIC creates lower-numbered streams
@@ -157,6 +236,7 @@ impl Request {
 
 		Ok(Self {
 			handle: handle.clone(),
+			guard: Guard::new(conn.clone()),
 			conn,
 			request,
 			send,
@@ -164,6 +244,7 @@ impl Request {
 			held,
 			control,
 			early,
+			pending,
 		})
 	}
 
@@ -195,6 +276,7 @@ impl Request {
 		let mut buf = Vec::new();
 		encoded.encode(&mut buf).map_err(|err| Error::Web(err.to_string()))?;
 		write_all(&mut self.send, &buf).await?;
+		self.guard.disarm();
 
 		Ok(Session::establish(self, protocol))
 	}
@@ -205,12 +287,36 @@ impl Request {
 	}
 
 	/// Refuse with `reason`, ending the handshake.
+	///
+	/// Returns once the peer has the response, or after a grace period if it
+	/// never acknowledges one, and closes the connection deliberately. The
+	/// HTTP/3 critical streams (the peer's control and QPACK streams, and
+	/// ours) stay open until then: RFC 9114 makes closing one a connection
+	/// error, so tearing them down here would show the peer an H3 failure
+	/// instead of the status it was sent.
 	pub async fn reject(mut self, reason: Rejected) -> Result<(), Error> {
 		let response = proto::ConnectResponse::new(reason.status());
 		let mut buf = Vec::new();
 		response.encode(&mut buf).map_err(|err| Error::Web(err.to_string()))?;
 		write_all(&mut self.send, &buf).await?;
 		web_transport_trait::poll::SendStream::finish(&mut self.send)?;
+
+		// The close below is the deliberate one; the guard's abrupt
+		// `H3_GENERAL_PROTOCOL_ERROR` would race the response out.
+		self.guard.disarm();
+
+		let mut deadline = moq_net::runtime::Deadline::after(&self.handle, CLOSE_GRACE);
+		let send = &mut self.send;
+		kio::wait(|waiter| {
+			let mut cx = Context::from_waker(waiter.waker());
+			if web_transport_trait::poll::SendStream::poll_closed(send, &mut cx).is_ready() {
+				return Poll::Ready(());
+			}
+			deadline.poll(waiter)
+		})
+		.await;
+
+		self.conn.shared().close_code(H3_NO_ERROR, "");
 		Ok(())
 	}
 }
@@ -332,12 +438,14 @@ impl Session {
 		let Request {
 			handle,
 			conn,
+			guard: _,
 			request: _,
 			send,
 			recv,
 			held,
 			control,
 			early,
+			pending,
 		} = request;
 
 		let session_id = send.id();
@@ -364,7 +472,10 @@ impl Session {
 			header_bi: header_bi.into(),
 			header_datagram: header_datagram.into(),
 			state: RefCell::new(State {
-				pending_uni: Vec::new(),
+				// Still mid-header when the control stream turned up; the
+				// session finishes classifying them, so a pipelined
+				// WebTransport stream is not lost to the handshake ending.
+				pending_uni: pending,
 				pending_bi: Vec::new(),
 				ready_uni,
 				ready_bi: VecDeque::new(),
@@ -459,6 +570,7 @@ impl web_transport_trait::poll::Session for Session {
 				SendStream {
 					inner: send,
 					prefix: Bytes::new(),
+					finishing: false,
 					web: false,
 				},
 				RecvStream {
@@ -474,6 +586,7 @@ impl web_transport_trait::poll::Session for Session {
 					SendStream {
 						inner: send,
 						prefix: Bytes::new(),
+						finishing: false,
 						web: true,
 					},
 					RecvStream { inner: recv, web: true },
@@ -501,6 +614,7 @@ impl web_transport_trait::poll::Session for Session {
 		Poll::Ready(Ok(SendStream {
 			inner,
 			prefix,
+			finishing: false,
 			web: self.web.is_some(),
 		}))
 	}
@@ -516,6 +630,7 @@ impl web_transport_trait::poll::Session for Session {
 			SendStream {
 				inner: send,
 				prefix,
+				finishing: false,
 				web: self.web.is_some(),
 			},
 			RecvStream {
@@ -667,6 +782,10 @@ pub struct SendStream {
 	inner: super::SendStream,
 	/// Header bytes still owed to the wire before any payload.
 	prefix: Bytes,
+	/// [`finish`](web_transport_trait::poll::SendStream::finish) ran with the
+	/// header still owed, so [`poll_closed`](web_transport_trait::poll::SendStream::poll_closed)
+	/// writes the rest and finishes then.
+	finishing: bool,
 	web: bool,
 }
 
@@ -683,6 +802,12 @@ impl web_transport_trait::poll::SendStream for SendStream {
 	type Error = Error;
 
 	fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+		// The FIN is owed the moment the header lands, so there is no room
+		// left for a payload; the inner stream refuses a post-FIN write the
+		// same way.
+		if self.finishing {
+			return Poll::Ready(Err(Error::Quic(quiche::Error::FinalSize)));
+		}
 		while !self.prefix.is_empty() {
 			let n = ready!(web_transport_trait::poll::SendStream::poll_write(
 				&mut self.inner,
@@ -709,7 +834,12 @@ impl web_transport_trait::poll::SendStream for SendStream {
 			let n = self.inner.try_write(&self.prefix);
 			self.prefix.advance(n);
 			if !self.prefix.is_empty() {
-				return Err(Error::Web("no capacity to frame the stream before finishing".into()));
+				// Zero capacity here is ordinary flow control, which clears
+				// once the peer reads. Reporting it terminally would have the
+				// caller drop (and so reset) a stream that is finishing
+				// cleanly; `poll_closed` writes the rest instead.
+				self.finishing = true;
+				return Ok(());
 			}
 		}
 		web_transport_trait::poll::SendStream::finish(&mut self.inner).map_err(|err| self.map(err))
@@ -723,9 +853,38 @@ impl web_transport_trait::poll::SendStream for SendStream {
 	}
 
 	fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		// `finish` left the header owed, so finishing is still this call's job.
+		while self.finishing {
+			match ready!(web_transport_trait::poll::SendStream::poll_write(
+				&mut self.inner,
+				cx,
+				&self.prefix
+			)) {
+				Ok(n) => self.prefix.advance(n),
+				Err(err) => return Poll::Ready(Err(self.map(err))),
+			}
+			if self.prefix.is_empty() {
+				self.finishing = false;
+				if let Err(err) = web_transport_trait::poll::SendStream::finish(&mut self.inner) {
+					return Poll::Ready(Err(self.map(err)));
+				}
+			}
+		}
 		match web_transport_trait::poll::SendStream::poll_closed(&mut self.inner, cx) {
 			Poll::Ready(Err(err)) => Poll::Ready(Err(self.map(err))),
 			other => other,
+		}
+	}
+}
+
+impl Drop for SendStream {
+	fn drop(&mut self) {
+		// The inner `Drop` resets with a raw 0, which reads to a browser as an
+		// HTTP/3 stream error rather than the WebTransport cancellation that
+		// dropping a stream means. moq cancels subscriptions by dropping, so
+		// this is the ordinary path.
+		if self.web && !self.inner.ended() {
+			self.inner.reset_code(proto::error_to_http3(0));
 		}
 	}
 }
@@ -776,6 +935,15 @@ impl web_transport_trait::poll::RecvStream for RecvStream {
 	}
 }
 
+impl Drop for RecvStream {
+	fn drop(&mut self) {
+		// Same as the send side: the inner `Drop` stops with a raw 0.
+		if self.web && !self.inner.ended() {
+			self.inner.stop_code(proto::error_to_http3(0));
+		}
+	}
+}
+
 impl std::fmt::Debug for RecvStream {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		self.inner.fmt(f)
@@ -783,14 +951,34 @@ impl std::fmt::Debug for RecvStream {
 }
 
 /// Rewrite HTTP/3-mapped error codes back into WebTransport code space.
+///
+/// Only a sparse range of HTTP/3 codes names a WebTransport error. Anything
+/// else is HTTP/3's own failure rather than a code the peer's application
+/// chose, so it becomes [`Error::Http3`]: keeping the `App`/`Reset`/`Stop`
+/// variant would advertise it through `session_error()`/`stream_error()` as
+/// the very thing this mapping exists to tell it apart from.
 fn unmap_err(err: Error) -> Error {
-	let unmap = |code: u64| proto::error_from_http3(code).map(u64::from).unwrap_or(code);
+	fn unmap(code: u64) -> Option<u64> {
+		proto::error_from_http3(code).map(u64::from)
+	}
 	match err {
-		Error::Reset(code) => Error::Reset(unmap(code)),
-		Error::Stop(code) => Error::Stop(unmap(code)),
-		Error::App { code, reason } => Error::App {
-			code: unmap(code),
-			reason,
+		Error::Reset(code) => match unmap(code) {
+			Some(code) => Error::Reset(code),
+			None => Error::Http3 {
+				code,
+				reason: String::new(),
+			},
+		},
+		Error::Stop(code) => match unmap(code) {
+			Some(code) => Error::Stop(code),
+			None => Error::Http3 {
+				code,
+				reason: String::new(),
+			},
+		},
+		Error::App { code, reason } => match unmap(code) {
+			Some(code) => Error::App { code, reason },
+			None => Error::Http3 { code, reason },
 		},
 		other => other,
 	}
@@ -1027,10 +1215,6 @@ async fn open_uni(conn: &mut Connection) -> Result<super::SendStream, Error> {
 	std::future::poll_fn(|cx| web_transport_trait::poll::Session::poll_open_uni(conn, cx)).await
 }
 
-async fn accept_uni(conn: &mut Connection) -> Result<super::RecvStream, Error> {
-	std::future::poll_fn(|cx| web_transport_trait::poll::Session::poll_accept_uni(conn, cx)).await
-}
-
 async fn accept_bi(conn: &mut Connection) -> Result<(super::SendStream, super::RecvStream), Error> {
 	std::future::poll_fn(|cx| web_transport_trait::poll::Session::poll_accept_bi(conn, cx)).await
 }
@@ -1205,6 +1389,43 @@ impl Capsules {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// A code with a WebTransport meaning comes back out as itself; one
+	/// without is HTTP/3's own failure, and must stop advertising itself as an
+	/// application error through the trait accessors.
+	#[test]
+	fn an_unmappable_code_is_not_an_application_error() {
+		use web_transport_trait::Error as _;
+
+		let app = unmap_err(Error::App {
+			code: proto::error_to_http3(7),
+			reason: "seven".into(),
+		});
+		assert!(
+			matches!(&app, Error::App { code: 7, reason } if reason == "seven"),
+			"got {app:?}"
+		);
+		assert_eq!(app.session_error(), Some((7, "seven".to_string())));
+
+		// H3_NO_ERROR: HTTP/3's, and no WebTransport code at all.
+		let h3 = unmap_err(Error::App {
+			code: 0x100,
+			reason: "done".into(),
+		});
+		assert!(
+			matches!(&h3, Error::Http3 { code: 0x100, reason } if reason == "done"),
+			"got {h3:?}"
+		);
+		assert_eq!(h3.session_error(), None, "not a code the peer's application chose");
+
+		let reset = unmap_err(Error::Reset(0x100));
+		assert!(matches!(reset, Error::Http3 { code: 0x100, .. }), "got {reset:?}");
+		assert_eq!(reset.stream_error(), None, "not a MoQ stream code");
+		assert!(matches!(
+			unmap_err(Error::Stop(proto::error_to_http3(3))),
+			Error::Stop(3)
+		));
+	}
 
 	/// Wrap `payload` in an HTTP/3 frame of type `typ`.
 	fn frame(typ: u64, payload: &[u8]) -> Vec<u8> {

--- a/rs/moq-uring/src/quic/web.rs
+++ b/rs/moq-uring/src/quic/web.rs
@@ -788,6 +788,14 @@ impl web_transport_trait::poll::Session for Session {
 }
 
 /// An outgoing stream, WebTransport-framed when its session is.
+///
+/// [`finish`](web_transport_trait::poll::SendStream::finish) can leave the
+/// WebTransport header owed, when the connection has no flow-control credit
+/// for it. The FIN then goes out on a later
+/// [`poll_closed`](web_transport_trait::poll::SendStream::poll_closed), or on
+/// `Drop` if credit has returned by then. Dropping immediately after
+/// finishing, with no poll in between, leaves no moment for it to return and
+/// cancels the stream instead, so pair the two when a clean end matters.
 pub struct SendStream {
 	inner: super::SendStream,
 	/// Header bytes still owed to the wire before any payload.

--- a/rs/moq-uring/src/quic/web.rs
+++ b/rs/moq-uring/src/quic/web.rs
@@ -174,16 +174,19 @@ impl Request {
 		let mut peer_control = None;
 		std::future::poll_fn(|cx| {
 			loop {
-				loop {
+				// Stop adopting past the cap, but do not give up on what is
+				// already here: the control stream may be sitting at the head
+				// of a queue a pipelining peer filled behind it, and refusing
+				// that peer is the bug the cap is not for.
+				let mut over = false;
+				while !over {
 					match web_transport_trait::poll::Session::poll_accept_uni(&mut conn, cx) {
 						Poll::Ready(Ok(recv)) => {
 							arrivals += 1;
-							if arrivals > HANDSHAKE_STREAMS {
-								return Poll::Ready(Err(Error::Web(
-									"too many streams before the control stream".into(),
-								)));
+							over = arrivals > HANDSHAKE_STREAMS;
+							if !over {
+								pending.push(PendingUni::new(recv));
 							}
-							pending.push(PendingUni::new(recv));
 						}
 						Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
 						Poll::Pending => break,
@@ -214,6 +217,11 @@ impl Request {
 					}
 				}
 
+				// Only now, with everything adopted classified: the peer sent
+				// this many streams and none of them was a control stream.
+				if over {
+					return Poll::Ready(Err(Error::Web("too many streams before the control stream".into())));
+				}
 				if !progressed {
 					return Poll::Pending;
 				}
@@ -301,10 +309,9 @@ impl Request {
 		write_all(&mut self.send, &buf).await?;
 		web_transport_trait::poll::SendStream::finish(&mut self.send)?;
 
-		// The close below is the deliberate one; the guard's abrupt
-		// `H3_GENERAL_PROTOCOL_ERROR` would race the response out.
-		self.guard.disarm();
-
+		// The guard stays armed across the wait below. Cancelling this future
+		// mid-grace would otherwise skip the deliberate close and leak the
+		// connection, which is the very thing the guard is here to prevent.
 		let mut deadline = moq_net::runtime::Deadline::after(&self.handle, CLOSE_GRACE);
 		let send = &mut self.send;
 		kio::wait(|waiter| {
@@ -316,6 +323,9 @@ impl Request {
 		})
 		.await;
 
+		// The peer has the response, so this close is the deliberate one; the
+		// guard's abrupt `H3_GENERAL_PROTOCOL_ERROR` would have raced it out.
+		self.guard.disarm();
 		self.conn.shared().close_code(H3_NO_ERROR, "");
 		Ok(())
 	}
@@ -837,7 +847,8 @@ impl web_transport_trait::poll::SendStream for SendStream {
 				// Zero capacity here is ordinary flow control, which clears
 				// once the peer reads. Reporting it terminally would have the
 				// caller drop (and so reset) a stream that is finishing
-				// cleanly; `poll_closed` writes the rest instead.
+				// cleanly, so the FIN becomes this stream's debt: `poll_closed`
+				// writes the rest, and `Drop` pays what it can if nobody polls.
 				self.finishing = true;
 				return Ok(());
 			}
@@ -879,6 +890,17 @@ impl web_transport_trait::poll::SendStream for SendStream {
 
 impl Drop for SendStream {
 	fn drop(&mut self) {
+		// `finish` returned `Ok` with the header still owed, so the FIN is
+		// this stream's debt rather than the caller's. Pay it if the credit
+		// has since arrived, instead of letting a stream the caller finished
+		// cleanly go out as a cancellation.
+		if self.finishing {
+			let n = self.inner.try_write(&self.prefix);
+			self.prefix.advance(n);
+			if self.prefix.is_empty() {
+				let _ = web_transport_trait::poll::SendStream::finish(&mut self.inner);
+			}
+		}
 		// The inner `Drop` resets with a raw 0, which reads to a browser as an
 		// HTTP/3 stream error rather than the WebTransport cancellation that
 		// dropping a stream means. moq cancels subscriptions by dropping, so

--- a/rs/moq-uring/tests/support/quiche.rs
+++ b/rs/moq-uring/tests/support/quiche.rs
@@ -178,8 +178,35 @@ impl Peer {
 		server: SocketAddr,
 		alpn: &[&[u8]],
 	) -> anyhow::Result<Self> {
+		Self::dial(handle, sock, server, alpn, None)
+	}
+
+	/// A client offering `alpn` that advertises only `max_data` bytes of
+	/// connection-level flow control, for a test that needs the server to run
+	/// out of credit. Reading a stream is what returns it, so a peer that
+	/// stops reading holds the server there.
+	pub fn connect_throttled(
+		handle: &Handle,
+		sock: udp::Socket,
+		server: SocketAddr,
+		alpn: &[&[u8]],
+		max_data: u64,
+	) -> anyhow::Result<Self> {
+		Self::dial(handle, sock, server, alpn, Some(max_data))
+	}
+
+	fn dial(
+		handle: &Handle,
+		sock: udp::Socket,
+		server: SocketAddr,
+		alpn: &[&[u8]],
+		max_data: Option<u64>,
+	) -> anyhow::Result<Self> {
 		let local = sock.local_addr()?;
 		let mut config = config(None, alpn)?;
+		if let Some(max_data) = max_data {
+			config.set_initial_max_data(max_data);
+		}
 		let conn = quiche::connect(Some("localhost"), &connection_id(), local, server, &mut config)?;
 		Ok(Self {
 			sock,

--- a/rs/moq-uring/tests/web.rs
+++ b/rs/moq-uring/tests/web.rs
@@ -356,3 +356,402 @@ fn unknown_streams_cannot_stall_the_handshake() {
 		})
 		.expect("worker");
 }
+
+// ── Handshake and teardown edge cases ───────────────────────────────
+
+/// Connection-level flow control the throttled peer advertises, which is what
+/// the server runs out of below. Big enough for the handshake, small enough to
+/// fill in a handful of writes.
+const THROTTLE: u64 = 64 * 1024;
+/// The client's first bidirectional stream, which the CONNECT rides.
+const CLIENT_BI: u64 = 0;
+/// The client's first two unidirectional streams. QUIC creates lower-numbered
+/// streams implicitly, so the server's accept queue hands them out in this
+/// order however the packets arrive.
+const CLIENT_UNI: [u64; 2] = [2, 6];
+
+/// A client offering `alpn` on its own socket, not yet handshaken.
+fn raw_peer(handle: &moq_uring::Handle, server: std::net::SocketAddr, throttle: Option<u64>) -> support::Peer {
+	let sock = handle
+		.udp(UdpSocket::bind("127.0.0.1:0").expect("bind"), udp::Config::default())
+		.expect("client socket");
+	match throttle {
+		Some(max_data) => support::Peer::connect_throttled(handle, sock, server, &[b"h3"], max_data).expect("client"),
+		None => support::Peer::connect_alpn(handle, sock, server, &[b"h3"]).expect("client"),
+	}
+}
+
+/// Queue the client half of the HTTP/3 handshake: SETTINGS on `control`, then
+/// the CONNECT request. Raw quiche, because these tests need arrivals a real
+/// WebTransport client would never produce.
+fn h3_request(peer: &mut support::Peer, control: u64, url: &str) {
+	let mut settings = web_transport_quinn::proto::Settings::default();
+	settings.enable_webtransport(1);
+	let mut buf = Vec::new();
+	settings.encode(&mut buf);
+	peer.conn.stream_send(control, &buf, false).expect("control stream");
+
+	let mut buf = Vec::new();
+	web_transport_quinn::proto::ConnectRequest::new(url::Url::parse(url).expect("url"))
+		.with_protocol(PROTO)
+		.encode(&mut buf)
+		.expect("encode CONNECT");
+	peer.conn.stream_send(CLIENT_BI, &buf, false).expect("connect stream");
+}
+
+/// Await `future`, failing rather than hanging if it takes too long.
+///
+/// Everything here is a stall or a leak, so the failure mode without the fix
+/// is a test that never finishes.
+async fn within<T>(handle: &moq_uring::Handle, what: &str, future: impl Future<Output = T>) -> T {
+	let mut deadline = moq_net::runtime::Deadline::after(handle, std::time::Duration::from_secs(5));
+	let mut future = std::pin::pin!(future);
+	kio::wait(|waiter| {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		if let std::task::Poll::Ready(value) = future.as_mut().poll(&mut cx) {
+			return std::task::Poll::Ready(Some(value));
+		}
+		deadline.poll(waiter).map(|()| None)
+	})
+	.await
+	.unwrap_or_else(|| panic!("timed out waiting for {what}"))
+}
+
+/// A client whose CONNECT is expected to fail, reporting how it failed.
+fn quinn_client_err(url: String) -> std::thread::JoinHandle<web_transport_quinn::ClientError> {
+	std::thread::spawn(move || {
+		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+		let rt = tokio::runtime::Builder::new_current_thread()
+			.enable_all()
+			.build()
+			.expect("tokio runtime");
+		rt.block_on(async move {
+			let client = web_transport_quinn::ClientBuilder::new()
+				.dangerous()
+				.with_no_certificate_verification()
+				.expect("client");
+			let request = web_transport_quinn::proto::ConnectRequest::new(url::Url::parse(&url).expect("url"))
+				.with_protocol(PROTO);
+			client.connect(request).await.expect_err("the CONNECT must fail")
+		})
+	})
+}
+
+/// A unidirectional stream that names its type and then stalls must not hold
+/// off a control stream that has fully arrived.
+///
+/// The accept queue is strictly id-ordered, so the stalled stream is always
+/// adopted first. Classifying one at a time parked there for as long as the
+/// peer kept the connection alive, with a complete SETTINGS sitting behind it.
+#[test]
+fn a_stalled_stream_cannot_block_the_handshake() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let certs = support::certs().expect("certificates");
+	let endpoint = h3_endpoint(&handle, &certs);
+	let server = endpoint.local_addr();
+
+	let peer_handle = handle.clone();
+	worker
+		.block_on(async move {
+			peer_handle.clone().spawn(async move {
+				let mut peer = raw_peer(&peer_handle, server, None);
+				peer.flush().await.expect("first flight");
+				while !peer.conn.is_established() {
+					peer.step().await.expect("step");
+					peer.flush().await.expect("flush");
+				}
+
+				// A WebTransport unidirectional header, complete except for
+				// the session id it never sends.
+				let stalled = [0x40, 0x54];
+				peer.conn
+					.stream_send(CLIENT_UNI[0], &stalled, false)
+					.expect("stalled stream");
+				h3_request(&mut peer, CLIENT_UNI[1], "https://localhost/stall");
+				peer.flush().await.expect("flush");
+
+				// Keep turning so the handshake can complete against it.
+				while !peer.conn.is_closed() {
+					if peer.step().await.is_err() || peer.flush().await.is_err() {
+						break;
+					}
+				}
+			});
+
+			let conn = endpoint.accept().await.expect("accepted connection");
+			let request = within(
+				&handle,
+				"the handshake to get past the stalled stream",
+				quic::web::Request::accept(&handle, conn),
+			)
+			.await
+			.expect("handshake");
+			assert_eq!(request.url().path(), "/stall");
+		})
+		.expect("worker");
+}
+
+/// A handshake the server abandons must close the connection.
+///
+/// Dropping the public `Connection` does not: the endpoint keeps it, its
+/// routes, and its driver task until the driver sees a terminal state, and the
+/// backlog stopped counting it at accept. The peer picks which subprotocols it
+/// offers, so answering with one it did not is a path it controls.
+#[test]
+fn an_abandoned_handshake_closes_the_connection() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let certs = support::certs().expect("certificates");
+	let endpoint = h3_endpoint(&handle, &certs);
+	let addr = endpoint.local_addr();
+
+	let client = quinn_client_err(format!("https://{addr}/"));
+
+	worker
+		.block_on(async move {
+			let conn = endpoint.accept().await.expect("accept");
+			let mut watch = conn.clone();
+			let request = quic::web::Request::accept(&handle, conn).await.expect("handshake");
+			let err = request
+				.respond(quic::web::Response::default().with_protocol("never-offered"))
+				.await
+				.expect_err("a subprotocol the peer did not offer");
+			assert!(matches!(err, quic::Error::Web(_)), "got {err:?}");
+
+			// Nothing here closed it by hand; the guard on the dropped request
+			// is what does.
+			within(
+				&handle,
+				"the abandoned connection to close",
+				std::future::poll_fn(|cx| watch.poll_closed(cx)),
+			)
+			.await;
+		})
+		.expect("worker");
+
+	client.join().expect("client thread");
+}
+
+/// A rejection reaches the peer as the status it was sent.
+///
+/// The HTTP/3 critical streams (the peer's control and QPACK streams, and
+/// ours) have to outlive the response: RFC 9114 makes closing one a connection
+/// error, so tearing them down would show an H3 failure instead of the 404.
+#[test]
+fn a_rejection_reaches_the_peer() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let certs = support::certs().expect("certificates");
+	let endpoint = h3_endpoint(&handle, &certs);
+	let addr = endpoint.local_addr();
+
+	let client = quinn_client_err(format!("https://{addr}/nope"));
+
+	worker
+		.block_on(async move {
+			let conn = endpoint.accept().await.expect("accept");
+			let request = quic::web::Request::accept(&handle, conn).await.expect("handshake");
+			within(
+				&handle,
+				"the rejection to be delivered",
+				request.reject(quic::web::Rejected::NotFound),
+			)
+			.await
+			.expect("reject");
+		})
+		.expect("worker");
+
+	let err = client.join().expect("client thread");
+	assert!(
+		matches!(
+			&err,
+			web_transport_quinn::ClientError::HttpError(web_transport_quinn::ConnectError::ProtoError(
+				web_transport_quinn::proto::ConnectError::WrongStatus(Some(status))
+			)) if *status == http::StatusCode::NOT_FOUND
+		),
+		"got {err:?}"
+	);
+}
+
+/// Dropping a web-mode stream cancels it with a WebTransport code, not the
+/// raw zero the inner stream would send.
+///
+/// moq cancels a subscription by dropping its stream, so this is the ordinary
+/// path: unmapped, a browser reads it as an HTTP/3 stream error instead.
+#[test]
+fn a_dropped_stream_carries_a_webtransport_code() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let certs = support::certs().expect("certificates");
+	let endpoint = h3_endpoint(&handle, &certs);
+	let addr = endpoint.local_addr();
+
+	let client = quinn_client(format!("https://{addr}/"), |session| {
+		Box::pin(async move {
+			// The server writes this and then drops the stream unfinished.
+			let mut recv = session.accept_uni().await.expect("accept_uni");
+			let mut buf = [0u8; 4096];
+			let n = recv.read(&mut buf).await.expect("read").expect("payload");
+			assert_eq!(&buf[..n], PAYLOAD);
+
+			// Tell it we have the payload, so the reset below cannot race it.
+			let mut ack = session.open_uni().await.expect("open_uni");
+			ack.write_all(b"ack").await.expect("write");
+			ack.finish().expect("finish");
+
+			let err = recv.read(&mut buf).await.expect_err("the server dropped it");
+			assert!(matches!(err, web_transport_quinn::ReadError::Reset(0)), "got {err:?}");
+
+			// And the other direction: the server drops the read half of this
+			// one, which must arrive as a WebTransport cancellation too.
+			let mut send = session.open_uni().await.expect("open_uni");
+			let err = loop {
+				match send.write_all(PAYLOAD).await {
+					Ok(()) => tokio::task::yield_now().await,
+					Err(err) => break err,
+				}
+			};
+			assert!(
+				matches!(err, web_transport_quinn::WriteError::Stopped(0)),
+				"got {err:?}"
+			);
+
+			session.close(CLOSE_CODE, CLOSE_REASON.as_bytes());
+			session.closed().await;
+		})
+	});
+
+	worker
+		.block_on(async move {
+			let conn = endpoint.accept().await.expect("accept");
+			let request = quic::web::Request::accept(&handle, conn).await.expect("handshake");
+			let mut session = request
+				.respond(quic::web::Response::default().with_protocol(PROTO))
+				.await
+				.expect("respond");
+
+			let mut send = std::future::poll_fn(|cx| session.poll_open_uni(cx))
+				.await
+				.expect("open_uni");
+			let mut payload = PAYLOAD;
+			while !payload.is_empty() {
+				let n = std::future::poll_fn(|cx| send.poll_write(cx, payload))
+					.await
+					.expect("write");
+				payload = &payload[n..];
+			}
+
+			let mut ack = std::future::poll_fn(|cx| session.poll_accept_uni(cx))
+				.await
+				.expect("accept_uni");
+			assert_eq!(drain(&mut ack).await, b"ack");
+			drop(send);
+
+			// The client's stream, whose read half we abandon.
+			let mut recv = std::future::poll_fn(|cx| session.poll_accept_uni(cx))
+				.await
+				.expect("accept_uni");
+			let mut buf = [0u8; 4096];
+			std::future::poll_fn(|cx| recv.poll_read(cx, &mut buf))
+				.await
+				.expect("read");
+			drop(recv);
+
+			std::future::poll_fn(|cx| session.poll_closed(cx)).await;
+		})
+		.expect("worker");
+
+	client.join().expect("client thread");
+}
+
+/// Finishing a web-mode stream that cannot frame itself yet is backpressure,
+/// not a failure.
+///
+/// A stream opened while the connection's flow-control credit is spent still
+/// owes its WebTransport header, and callers drop (and so reset) a stream that
+/// reports a terminal error. The finish has to complete once credit returns.
+#[test]
+fn finishing_under_backpressure_is_not_an_error() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let certs = support::certs().expect("certificates");
+	let endpoint = h3_endpoint(&handle, &certs);
+	let server = endpoint.local_addr();
+
+	// Set by the server once it has filled the peer's credit: reading is what
+	// returns it, so the peer must not read before then.
+	let reading = std::rc::Rc::new(std::cell::Cell::new(false));
+
+	let peer_handle = handle.clone();
+	let peer_reading = reading.clone();
+	worker
+		.block_on(async move {
+			peer_handle.clone().spawn(async move {
+				let mut peer = raw_peer(&peer_handle, server, Some(THROTTLE));
+				peer.flush().await.expect("first flight");
+				while !peer.conn.is_established() {
+					peer.step().await.expect("step");
+					peer.flush().await.expect("flush");
+				}
+				h3_request(&mut peer, CLIENT_UNI[0], "https://localhost/backpressure");
+				peer.flush().await.expect("flush");
+
+				let mut scratch = vec![0u8; 64 * 1024];
+				while !peer.conn.is_closed() {
+					if peer.step().await.is_err() {
+						break;
+					}
+					if peer_reading.get() {
+						let readable: Vec<u64> = peer.conn.readable().collect();
+						for stream in readable {
+							while peer.conn.stream_recv(stream, &mut scratch).is_ok() {}
+						}
+					}
+					if peer.flush().await.is_err() {
+						break;
+					}
+				}
+			});
+
+			let conn = endpoint.accept().await.expect("accepted connection");
+			let request = quic::web::Request::accept(&handle, conn).await.expect("handshake");
+			let mut session = request
+				.respond(quic::web::Response::default().with_protocol(PROTO))
+				.await
+				.expect("respond");
+
+			// Spend the peer's connection-level credit on a stream it is not
+			// reading. Polling with a no-op waker stops at the first refusal
+			// rather than parking.
+			let mut filler = std::future::poll_fn(|cx| session.poll_open_uni(cx))
+				.await
+				.expect("open_uni");
+			let chunk = [0u8; 4096];
+			let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+			loop {
+				match filler.poll_write(&mut cx, &chunk) {
+					std::task::Poll::Ready(Ok(_)) => {}
+					std::task::Poll::Ready(Err(err)) => panic!("filling the credit failed: {err}"),
+					std::task::Poll::Pending => break,
+				}
+			}
+
+			// A fresh stream still owes its header and has no credit to write
+			// it with, which is exactly the case that used to fail.
+			let mut blocked = std::future::poll_fn(|cx| session.poll_open_uni(cx))
+				.await
+				.expect("open_uni");
+			blocked.finish().expect("finishing under backpressure");
+
+			reading.set(true);
+			within(
+				&handle,
+				"the finished stream to close once credit returns",
+				std::future::poll_fn(|cx| blocked.poll_closed(cx)),
+			)
+			.await
+			.expect("closed");
+		})
+		.expect("worker");
+}

--- a/rs/moq-uring/tests/web.rs
+++ b/rs/moq-uring/tests/web.rs
@@ -682,6 +682,12 @@ fn finishing_under_backpressure_is_not_an_error() {
 	// Set by the server once it has filled the peer's credit: reading is what
 	// returns it, so the peer must not read before then.
 	let reading = std::rc::Rc::new(std::cell::Cell::new(false));
+	// How many streams the peer has seen end cleanly. A reset arrives instead
+	// of a FIN, so this never reaches its target if a finished stream is
+	// cancelled on the way out. A kio channel rather than a flag polled on a
+	// timer: the tests share a machine, and a wall clock loses that race.
+	let ended = kio::Producer::new(0usize);
+	let counted = ended.consume();
 
 	let peer_handle = handle.clone();
 	let peer_reading = reading.clone();
@@ -705,7 +711,18 @@ fn finishing_under_backpressure_is_not_an_error() {
 					if peer_reading.get() {
 						let readable: Vec<u64> = peer.conn.readable().collect();
 						for stream in readable {
-							while peer.conn.stream_recv(stream, &mut scratch).is_ok() {}
+							loop {
+								match peer.conn.stream_recv(stream, &mut scratch) {
+									Ok((_, true)) => {
+										if let Ok(mut count) = ended.write() {
+											*count += 1;
+										}
+										break;
+									}
+									Ok((_, false)) => {}
+									Err(_) => break,
+								}
+							}
 						}
 					}
 					if peer.flush().await.is_err() {
@@ -744,6 +761,14 @@ fn finishing_under_backpressure_is_not_an_error() {
 				.expect("open_uni");
 			blocked.finish().expect("finishing under backpressure");
 
+			// The same case, for a caller that finishes and drops rather than
+			// polling: the FIN is the stream's debt by then, so `Drop` has to
+			// pay it instead of resetting a stream that finished cleanly.
+			let mut dropped = std::future::poll_fn(|cx| session.poll_open_uni(cx))
+				.await
+				.expect("open_uni");
+			dropped.finish().expect("finishing under backpressure");
+
 			reading.set(true);
 			within(
 				&handle,
@@ -752,6 +777,161 @@ fn finishing_under_backpressure_is_not_an_error() {
 			)
 			.await
 			.expect("closed");
+
+			// Credit is back by now, so the drop can make good on the finish.
+			// Both streams have to reach the peer as clean ends; a cancelled
+			// one arrives as a reset and never counts.
+			drop(dropped);
+			within(
+				&handle,
+				"both finished streams to arrive intact",
+				counted.wait(|count| match **count >= 2 {
+					true => std::task::Poll::Ready(()),
+					false => std::task::Poll::Pending,
+				}),
+			)
+			.await
+			.expect("the peer is still reading");
+		})
+		.expect("worker");
+}
+
+/// The arrival cap must not refuse a peer whose control stream is already
+/// first in the queue.
+///
+/// The cap bounds a peer that never sends a control stream. Counting arrivals
+/// before classifying any of them turned it into a limit on how much a valid
+/// client may pipeline: the control stream sat at the head of the queue,
+/// fully arrived, while the streams behind it tripped the cap.
+#[test]
+fn a_pipelining_peer_is_not_refused_by_the_arrival_cap() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let certs = support::certs().expect("certificates");
+	let endpoint = h3_endpoint(&handle, &certs);
+	let server = endpoint.local_addr();
+
+	// Closed once the server has acknowledged every stream, which is what
+	// proves they are all sitting in its accept queue rather than still on
+	// the wire. The handshake below must not start before that.
+	let queued = kio::Producer::new(());
+	let ready = queued.consume();
+
+	let peer_handle = handle.clone();
+	worker
+		.block_on(async move {
+			peer_handle.clone().spawn(async move {
+				let mut peer = raw_peer(&peer_handle, server, None);
+				peer.flush().await.expect("first flight");
+				while !peer.conn.is_established() {
+					peer.step().await.expect("step");
+					peer.flush().await.expect("flush");
+				}
+
+				// The control stream leads, then comfortably more than the cap
+				// behind it.
+				h3_request(&mut peer, CLIENT_UNI[0], "https://localhost/pipelined");
+				for i in 1..90u64 {
+					let stream = CLIENT_UNI[0] + i * 4;
+					if peer.conn.stream_send(stream, &[0x3f], true).is_err() {
+						break;
+					}
+				}
+				peer.flush().await.expect("flush");
+				// Wait for the server to answer, which it must: the streams
+				// above are ack-eliciting, and an acknowledgement means its
+				// driver has already ingested them into the accept queue. That
+				// is what makes the handshake below start against a full queue
+				// instead of racing the packets into it, which is the
+				// difference between reproducing the bug and not.
+				//
+				// Exactly one round trip. Waiting for a second would hang
+				// until the idle timeout, since the server sends nothing more
+				// while it waits for the signal below.
+				let received = peer.conn.stats().recv;
+				while peer.conn.stats().recv == received {
+					peer.step().await.expect("step");
+					peer.flush().await.expect("flush");
+				}
+				let _ = queued.close();
+
+				while !peer.conn.is_closed() {
+					if peer.step().await.is_err() || peer.flush().await.is_err() {
+						break;
+					}
+				}
+			});
+
+			let conn = endpoint.accept().await.expect("accepted connection");
+			within(&handle, "the peer to queue every stream", ready.closed()).await;
+			let request = within(
+				&handle,
+				"the handshake to accept a pipelining peer",
+				quic::web::Request::accept(&handle, conn),
+			)
+			.await
+			.expect("handshake");
+			assert_eq!(request.url().path(), "/pipelined");
+		})
+		.expect("worker");
+}
+
+/// A rejection abandoned mid-grace still closes the connection.
+///
+/// `reject` waits for the peer to acknowledge the response before closing
+/// deliberately. Disarming the guard before that wait meant a cancelled
+/// `reject` skipped both, leaving the endpoint holding the connection, its
+/// routes, and its driver for a peer that keeps sending.
+#[test]
+fn an_abandoned_rejection_still_closes_the_connection() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let certs = support::certs().expect("certificates");
+	let endpoint = h3_endpoint(&handle, &certs);
+	let server = endpoint.local_addr();
+
+	let peer_handle = handle.clone();
+	worker
+		.block_on(async move {
+			peer_handle.clone().spawn(async move {
+				let mut peer = raw_peer(&peer_handle, server, None);
+				peer.flush().await.expect("first flight");
+				while !peer.conn.is_established() {
+					peer.step().await.expect("step");
+					peer.flush().await.expect("flush");
+				}
+				h3_request(&mut peer, CLIENT_UNI[0], "https://localhost/abandoned");
+				peer.flush().await.expect("flush");
+
+				// Deliberately never acknowledges the response, so the
+				// rejection stays parked in its grace period.
+				std::future::pending::<()>().await;
+			});
+
+			let conn = endpoint.accept().await.expect("accepted connection");
+			let mut watch = conn.clone();
+			let request = quic::web::Request::accept(&handle, conn).await.expect("handshake");
+
+			// Drive the rejection until it parks waiting for the peer, then
+			// walk away from it.
+			// Boxed, not `pin!`: dropping a `Pin<&mut F>` leaves the future
+			// itself alive in its hidden local, which is not the case here.
+			let mut reject = Box::pin(request.reject(quic::web::Rejected::NotFound));
+			let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+			for _ in 0..64 {
+				match reject.as_mut().poll(&mut cx) {
+					std::task::Poll::Ready(result) => panic!("the rejection must still be waiting: {result:?}"),
+					std::task::Poll::Pending => {}
+				}
+			}
+			drop(reject);
+
+			within(
+				&handle,
+				"the abandoned rejection to close the connection",
+				std::future::poll_fn(|cx| watch.poll_closed(cx)),
+			)
+			.await;
 		})
 		.expect("worker");
 }

--- a/rs/moq-uring/tests/web.rs
+++ b/rs/moq-uring/tests/web.rs
@@ -363,6 +363,9 @@ fn unknown_streams_cannot_stall_the_handshake() {
 /// the server runs out of below. Big enough for the handshake, small enough to
 /// fill in a handful of writes.
 const THROTTLE: u64 = 64 * 1024;
+/// Mirrors the crate's own cap on unidirectional streams accepted before the
+/// control stream arrives.
+const HANDSHAKE_STREAMS: usize = 64;
 /// The client's first bidirectional stream, which the CONNECT rides.
 const CLIENT_BI: u64 = 0;
 /// The client's first two unidirectional streams. QUIC creates lower-numbered
@@ -829,11 +832,25 @@ fn a_pipelining_peer_is_not_refused_by_the_arrival_cap() {
 				}
 
 				// The control stream leads, then comfortably more than the cap
-				// behind it.
+				// behind it. The one that tips the cap over is a real
+				// WebTransport stream rather than junk, so losing it is
+				// visible: junk is dropped by classification either way.
 				h3_request(&mut peer, CLIENT_UNI[0], "https://localhost/pipelined");
 				for i in 1..90u64 {
 					let stream = CLIENT_UNI[0] + i * 4;
-					if peer.conn.stream_send(stream, &[0x3f], true).is_err() {
+					// Arrivals are in id order, and the control stream is the
+					// first, so this one is arrival HANDSHAKE_STREAMS + 1.
+					let payload: &[u8] = match i as usize == HANDSHAKE_STREAMS {
+						// `0x4054` is the WebTransport stream type, then the
+						// session id: the CONNECT stream, which is 0.
+						true => &[0x40, 0x54, 0x00],
+						false => &[0x3f],
+					};
+					if peer
+						.conn
+						.stream_send(stream, payload, i as usize != HANDSHAKE_STREAMS)
+						.is_err()
+					{
 						break;
 					}
 				}
@@ -872,6 +889,20 @@ fn a_pipelining_peer_is_not_refused_by_the_arrival_cap() {
 			.await
 			.expect("handshake");
 			assert_eq!(request.url().path(), "/pipelined");
+
+			// And the stream that tipped the cap over is still the peer's to
+			// use, rather than one the handshake quietly cancelled.
+			let mut session = request
+				.respond(quic::web::Response::default().with_protocol(PROTO))
+				.await
+				.expect("respond");
+			within(
+				&handle,
+				"the stream that tipped the cap over to survive the handshake",
+				std::future::poll_fn(|cx| session.poll_accept_uni(cx)),
+			)
+			.await
+			.expect("accept_uni");
 		})
 		.expect("worker");
 }


### PR DESCRIPTION
Six findings from the Codex review of #3081, all in `rs/moq-uring/src/quic/web.rs`. They were filed rather than fixed in that PR because each needed a decision or a Linux test; this is that pass.

Closes #3096, closes #3103, closes #3105, closes #3106.

## `unmap_err` reported unmappable HTTP/3 codes as application errors

Only a sparse range of HTTP/3 codes names a WebTransport error. The fallback kept the original `App`/`Reset`/`Stop` variant for anything else, and those variants are exactly what `session_error()` / `stream_error()` advertise, so `H3_NO_ERROR` (0x100) reached moq-net looking like an application code the peer chose.

Unmappable codes now become a new `Error::Http3 { code, reason }`, whose trait accessors report neither a session nor a stream error. Additive on a `#[non_exhaustive]` enum, and it keeps the code for logs.

## An abandoned `Request` never closed the connection

`Request::accept` closed `conn` when `handshake` failed, but `respond` has its own early return when the peer names a subprotocol it did not offer, and that consumed and dropped `self`. Dropping the public `Connection` does not close QUIC: the endpoint keeps the connection, its routes, and its driver task until the driver sees a terminal state, and the backlog stopped counting it at accept. The peer picks its own subprotocol offer, so it could hold each abandoned handshake open indefinitely.

A close-on-drop `Guard`, disarmed only by a completed response or rejection, now covers every path out rather than each one remembering.

## `reject()` tore down the H3 critical streams

`reject` wrote the response and returned; dropping the consumed `Request` then dropped the peer's control and QPACK receive streams and our unfinished control stream, whose `Drop` impls send `RESET_STREAM` / `STOP_SENDING`. RFC 9114 treats closing a critical stream as a connection error, so a client could surface an H3 connection failure instead of the 4xx it was sent.

It now waits for the response to be acknowledged (bounded by `CLOSE_GRACE`, the same one the close capsule uses), then closes with `H3_NO_ERROR`. Everything stays open until that returns.

## One stalled stream head-of-line blocked the whole handshake

The handshake awaited each unidirectional stream's classification in turn. The accept queue is strictly id-ordered, so a stream that sent its type byte and then stalled before the session-id varint was always adopted first and parked the loop there, while a fully arrived control stream carrying SETTINGS sat behind it. `HANDSHAKE_STREAMS` did not help, since only one stream had been adopted.

It now polls every adopted stream each pass, the way the established session already does, and hands the still-unclassified ones to the session's `pending_uni` instead of dropping them, so a pipelined WebTransport stream is no longer lost to the handshake ending.

## `finish()` turned transient backpressure into a terminal error

Finishing a web-mode stream that had not written its header yet called `try_write` and reported `Error::Web` when connection-level flow control returned zero. That is ordinary backpressure that clears once the peer reads, and callers drop the stream on an unexpected error, resetting one that should have finished cleanly.

`finish` now records that the header is still owed and returns `Ok`; `poll_closed` writes the rest and finishes then. moq-net's writers already pair `finish()` with `poll_closed`, so nothing else changes.

## Dropping a web-mode stream sent an unmapped code

Neither wrapper implemented `Drop`, so an unfinished stream fell through to the inner `Drop` in `stream.rs`, which issues `stream_shutdown(.., 0)` with a raw 0. Browsers therefore saw routine application cancellation as an HTTP/3 stream error. moq cancels subscriptions by dropping streams, so this was the common path.

Both wrappers now map 0 through `error_to_http3` before the inner fallback runs, using a new crate-private `ended()` on the inner streams so a finished stream is not reset instead.

## Testing

Five new tests in `rs/moq-uring/tests/web.rs`, plus a unit test for `unmap_err`. Four of them cover a stall or a leak, so they are bounded by a `within(..)` helper that fails instead of hanging.

- `a_stalled_stream_cannot_block_the_handshake` and `finishing_under_backpressure_is_not_an_error` drive a raw quiche peer (a real client will not produce either case). The second advertises 64 KiB of connection-level flow control and stops reading, so the server genuinely runs out of credit mid-stream.
- `an_abandoned_handshake_closes_the_connection`, `a_rejection_reaches_the_peer`, and `a_dropped_stream_carries_a_webtransport_code` go through `web-transport-quinn`, which is what browsers interop with. The last one asserts `ReadError::Reset(0)` / `WriteError::Stopped(0)` rather than the `InvalidReset` / `InvalidStopped` the unmapped code produced.

Verified each fails without its fix: reverting all five behaviors at once fails exactly the four tests that cover them, on the right assertion each time.

`a_rejection_reaches_the_peer` is honest about its limit: it proves the 404 reaches the client, but `web-transport-quinn` does not police critical-stream teardown, so it would not have caught the reset on its own. The stream lifetimes are the reviewable part there.

Run on real io_uring (kernel 6.19 container): `cargo test -p moq-uring` is 40 tests green, `cargo clippy -p moq-uring -p moq-relay --features moq-relay/io-uring --all-targets -- -D warnings` and `RUSTDOCFLAGS=-D warnings cargo doc -p moq-uring` are clean. `just check` and `just test` pass locally (they compile no moq-uring on macOS, since the crate is `cfg(linux)`).

Not in scope, still open: #3097 and #3108, the relay-side gaps. Those need a new `moq_tokio::tls::Certificates` constructor and the mTLS wiring, and are a separate PR.

(Written by Claude Opus 5)