### PR TITLE
fix: accept the reserved unknown Hop ID, and stop the cargo doc collision

### DIFF
--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -1,9 +1,10 @@
 import { expect, test } from "bun:test";
-import { OriginSchema } from "../origin.ts";
+import { OriginSchema, UNKNOWN_ORIGIN } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
 import {
 	type AnnounceBroadcast,
+	AnnounceOk,
 	AnnounceRequest,
 	decodeAnnounceBroadcast,
 	encodeAnnounceBroadcast,
@@ -128,4 +129,23 @@ test("AnnounceRequest drops excludeHop on draft-06", async () => {
 	const with05 = await bytes((w) => msg.encode(w, Version.DRAFT_05));
 	const with06 = await bytes((w) => msg.encode(w, Version.DRAFT_06));
 	expect(with06.byteLength).toBeLessThan(with05.byteLength);
+});
+
+// The draft reserves Hop ID 0 for a responder that was never assigned an id, or that
+// withholds it to obscure its routing. Rejecting it tore down the announce stream of a
+// conforming publisher.
+test("AnnounceOk accepts the reserved unknown origin", async () => {
+	const msg = new AnnounceOk(UNKNOWN_ORIGIN, 3);
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
+	const got = await AnnounceOk.decode(reader, Version.DRAFT_05);
+	expect(got.origin).toBe(UNKNOWN_ORIGIN);
+	expect(got.active).toBe(3);
+});
+
+test("AnnounceOk round-trips a declared origin", async () => {
+	const msg = new AnnounceOk(OriginSchema.parse(42n), 1);
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
+	const got = await AnnounceOk.decode(reader, Version.DRAFT_05);
+	expect(got.origin).toBe(OriginSchema.parse(42n));
+	expect(got.active).toBe(1);
 });

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -313,8 +313,9 @@ export class AnnounceInit {
 /// individual Announce messages. Lite05+ only; the successor to AnnounceInit.
 ///
 /// `origin` is the responder's origin id, which the subscriber stamps onto each
-/// announce's hop chain (the publisher no longer stamps itself). `active` is the
-/// number of initial Announce messages that follow immediately.
+/// announce's hop chain (the publisher no longer stamps itself), or the reserved
+/// {@link UNKNOWN_ORIGIN} when the responder has no identity to give. `active` is
+/// the number of initial Announce messages that follow immediately.
 export class AnnounceOk {
 	origin: Origin;
 	active: number;
@@ -336,10 +337,10 @@ export class AnnounceOk {
 	}
 
 	static async #decode(r: Reader): Promise<AnnounceOk> {
-		const raw = await r.u62();
-		// A zero responder id is never legitimate; it would stamp a placeholder onto chains.
-		if (raw === 0n) throw new Error("announce ok origin must be non-zero");
-		const origin = OriginSchema.parse(raw);
+		// The draft reserves 0 for "unknown": the responder was never assigned an id, or
+		// withholds it to obscure its routing. It names nobody, so callers must not stamp
+		// it onto a hop chain, but it is a legal message and not grounds to drop the stream.
+		const origin = OriginSchema.parse(await r.u62());
 		const active = await r.u53();
 		return new AnnounceOk(origin, active);
 	}

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -2,7 +2,7 @@ import { expect, spyOn, test } from "bun:test";
 import { Signal } from "@moq/signals";
 import type { Probe as ProbeStats } from "../connection/stats.ts";
 import { error, reason } from "../error.ts";
-import { OriginSchema } from "../origin.ts";
+import { OriginSchema, UNKNOWN_ORIGIN } from "../origin.ts";
 import * as Path from "../path.ts";
 import { Writer } from "../stream.ts";
 import * as Time from "../time.ts";
@@ -183,6 +183,31 @@ test("a lite-05 duplicate announce follows the same restart rule", async () => {
 	// On lite-05 a restart travels as a duplicate ANNOUNCE rather than its own message.
 	await send(active([PUBLISHER_A]));
 	await send(active([PUBLISHER_B]));
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: false });
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
+
+	announced.close();
+	subscriber.close();
+});
+
+// A responder that withholds its Hop ID sends the reserved 0, and an empty chain means it
+// originated the path itself, so the advertisement names nobody. Two such advertisements can
+// be unrelated publishers, so a restart must replace the broadcast rather than reroute it:
+// cached track info and in-flight subscriptions must not splice across them. Mirrors the Rust
+// `unknown_publisher_restart_replaces` regression.
+test("a restart from an unidentified publisher replaces rather than reroutes", async () => {
+	const { subscriber, send, settle } = announceHarness(Version.DRAFT_06);
+	const announced = subscriber.announced(Path.empty());
+	await settle();
+
+	await send((w) => new AnnounceOk(UNKNOWN_ORIGIN, 0).encode(w, Version.DRAFT_06));
+	await send((w) =>
+		encodeAnnounceBroadcast(w, { status: "active", suffix: Path.from("room"), hops: [] }, Version.DRAFT_06),
+	);
+	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
+
+	// Nobody is named on either side, so this is not provably the same content.
+	await send((w) => encodeAnnounceBroadcast(w, { status: "restart", id: 0n, hops: [] }, Version.DRAFT_06));
 	expect(await announced.next()).toEqual({ path: Path.from("room"), active: false });
 	expect(await announced.next()).toEqual({ path: Path.from("room"), active: true });
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -5,7 +5,7 @@ import type { Probe as ProbeStats } from "../connection/stats.ts";
 import { BroadcastCache } from "../consume.ts";
 import { error, ProtocolViolation, reason } from "../error.ts";
 import * as netGroup from "../group.ts";
-import type { Origin } from "../origin.ts";
+import { type Origin, UNKNOWN_ORIGIN } from "../origin.ts";
 import * as Path from "../path.ts";
 import { type Reader, Stream } from "../stream.ts";
 import * as Time from "../time.ts";
@@ -217,7 +217,11 @@ export class Subscriber {
 			let responderOrigin: Origin | undefined;
 			if (hasAnnounceOk(this.version)) {
 				const ok = await AnnounceOk.decode(stream.reader, this.version);
-				responderOrigin = ok.origin;
+				// A responder that withholds its identity sends the reserved 0. It names
+				// nobody, so folding it into a chain would stamp a placeholder that cannot
+				// close a loop or tell two publishers apart. Treat it as absent instead,
+				// which is the loop-blind route the draft describes.
+				responderOrigin = ok.origin === UNKNOWN_ORIGIN ? undefined : ok.origin;
 			}
 
 			// Every advertisement the peer currently has live, keyed by suffix (at most one

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -371,13 +371,20 @@ export class Subscriber {
 					// peer itself originated it. See `restart_announce` in the Rust subscriber.
 					const publisher = hops?.[0] ?? responderOrigin;
 
+					// A publisher with no identity (an empty chain from a peer that withheld its
+					// own id, or a lite-03 UNKNOWN placeholder) never proves continuity: two such
+					// advertisements can be unrelated publishers. Mirrors the
+					// `publisher == Origin::UNKNOWN` arm of the Rust `restart_announce`.
+					const identified = publisher !== undefined && publisher !== UNKNOWN_ORIGIN;
+
 					// A second advertisement for a path we already carry is a restart: either an
 					// explicit ANNOUNCE_UPDATE, or (lite-05) a duplicate ANNOUNCE.
 					const previous = advertised.get(suffix);
 					if (previous?.live) {
-						if (previous.publisher === publisher) {
+						if (identified && previous.publisher === publisher) {
 							// Same publisher, new route. In-flight subscriptions resume across it,
-							// so there is nothing for a consumer to react to.
+							// so there is nothing for a consumer to react to. An unidentified
+							// publisher falls through to the replacement path below instead.
 							console.debug(`announced: broadcast=${path} rerouted`);
 							continue;
 						}

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -16,6 +16,11 @@ categories = ["multimedia", "network-programming", "web-programming"]
 [[bin]]
 name = "moq"
 path = "src/main.rs"
+# `libmoq`'s staticlib is also named `moq`, so a `cargo doc` selecting both renders
+# them to `target/doc/moq` and the two rustdoc processes race to clean it (#3094).
+# This binary's page is the one to give up: nothing links it, and a bin target has
+# no public API to render, whereas docs.rs/libmoq is the published C API reference.
+doc = false
 
 [features]
 default = ["iroh", "quinn", "websocket", "nvidia", "pipewire"]


### PR DESCRIPTION
Two unrelated small fixes from a sweep of the open issues, kept in one PR because each is a few lines.

## `js/net`: accept the reserved unknown Hop ID (#3072)

`AnnounceOk.#decode` threw on a Hop ID of 0, which tears down the announce stream. The lite draft reserves 0 for "unknown": the responder was never assigned an id (bridging from an older protocol version), or deliberately withholds it to obscure its routing. Both are conforming, so a publisher doing either lost its announce stream to a js subscriber.

The Rust subscriber handles this by substituting an assigned identity (`run_announce_prefix` in `rs/moq-net/src/lite/subscriber.rs`), but js has no `peer_origin` equivalent on the lite `Subscriber`, so this treats the value as absent instead. That keeps 0 out of the hop chain, where it could neither close a loop nor tell two publishers apart, and leaves the route loop-blind, which is the cost the draft already names for withholding an identity.

`setup.ts` already maps a zero origin to `undefined` on the SETUP path, so this matches existing precedent rather than adding a convention.

Two round-trip tests cover the unknown and declared cases.

### Follow-on: an unidentified publisher must replace, not reroute

Accepting 0 made `publisher === undefined` reachable at the restart comparison in `subscriber.ts`. A responder that withholds its id, advertising a path it originated itself, names nobody on either side, so `previous.publisher === publisher` matched `undefined === undefined` and took the reroute path. Cached TRACK_INFO and in-flight subscriptions would then carry across two advertisements never shown to be the same content.

The same hole already existed for a lite-03 UNKNOWN placeholder, which decodes to 0 rather than `undefined`, so the comparison is now gated on the publisher being identified at all. This mirrors `restart_announce` in the Rust subscriber, where `publisher == Origin::UNKNOWN` forces the replacement arm for exactly this reason, and its `unknown_publisher_restart_replaces` regression ("plain `==` on the publisher id treated 0 == 0 as content-continuous and spliced unrelated broadcasts").

The added subscriber-level test times out on the missing `active: false` without the guard.

Found by the Codex adversarial review of this PR, and independently by the Codex connector bot.

## `rs`: stop `moq-cli` and `libmoq` colliding on `target/doc/moq` (#3094)

`libmoq` declares `[lib] name = "moq"` and `moq-cli` declares `[[bin]] name = "moq"`, so both render to `target/doc/moq` and one `cargo doc` selecting both races to clean the directory:

```
warning: output filename collision at target/doc/moq/index.html
error: failed to remove directory `target/doc/moq`
```

### Root cause

The warning is deterministic; whether it escalates to the hard error depends on which rustdoc process cleans the shared directory first, which is why it presented as an intermittent flake and got re-run rather than fixed. `RUSTDOCFLAGS="-D warnings"` never caught it because cargo emits the collision, not rustdoc.

It fires on any PR whose diff selects both crates. `just check` is diff-aware, so a `moq-net` change pulls both in as dependents, and the failure then points at `moq-cli` internals the PR never touched (most recently #3091 and #3066).

### Why `doc = false` on the binary

Both alternatives in the issue cost more:

- Renaming `libmoq`'s `[lib] name` changes the `libmoq.a` artifact every C consumer links, including `cpp/obs`.
- Splitting the `cargo doc` pass in the justfile does not compose with the diff-aware `-p` selection, and would need to be done twice.

The binary's page is the one worth giving up. Nothing links `docs.rs/moq-cli`, and a bin target has no public API to render, whereas `docs.rs/libmoq` is cited as the C API reference from seven places across `doc/lib/c/`, `doc/lib/rs/`, and the README.

Verified directly: `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps -p libmoq -p moq-cli` now emits no collision, and `libmoq`'s 167 symbols still generate at `target/doc/moq/index.html`.

The nightly `just rs features` recipe documents the whole workspace with `--all-features`, so it hit the same collision every night. One fix covers both callers.

## Not covered

Neither change touches the wire, so no draft update applies. No `rs/moq-net` or `hang` change, so the Cross-Package Sync table has no other rows in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)

