### PR TITLE
fix(watch): apply Sync max age to audio subscriptions

### DIFF
--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -12,6 +12,7 @@ import { Handover } from "./handover";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
+import { subscribe } from "./subscription";
 import { type DecodedSpan, Terminal } from "./terminal";
 import { unlockOnGesture } from "./unlock";
 import { Warmup } from "./warmup";
@@ -267,19 +268,7 @@ export class Decoder {
 
 		// The Sync ceiling is the maximum age of a non-latest group before both the network and
 		// container consumers skip it. Omitting startGroup keeps a new subscription at the live edge.
-		const priority = Catalog.PRIORITY.audio;
-		let maxAge = this.sync.out.maxBuffer.peek();
-		const sub = active.track(track).subscribe({
-			priority,
-			latencyMax: maxAge,
-		});
-		effect.cleanup(() => sub.close());
-		effect.run((inner) => {
-			const next = inner.get(this.sync.out.maxBuffer);
-			if (next === maxAge) return;
-			maxAge = next;
-			sub.update({ priority, latencyMax: maxAge });
-		});
+		const sub = subscribe(effect, active, track, this.sync.out.maxBuffer);
 
 		if (config.container.kind === "cmaf") {
 			this.#runCmafDecoder(effect, sub, config);

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -268,7 +268,7 @@ export class Decoder {
 
 		// The Sync ceiling is the maximum age of a non-latest group before both the network and
 		// container consumers skip it. Omitting startGroup keeps a new subscription at the live edge.
-		const sub = subscribe(effect, active, track, this.sync.out.maxBuffer);
+		const sub = subscribe(effect, { broadcast: active, track, maxLatency: this.sync.out.maxBuffer });
 
 		if (config.container.kind === "cmaf") {
 			this.#runCmafDecoder(effect, sub, config);

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -24,14 +24,6 @@ const LEGACY_WARMUP_CALLBACKS = 3;
 export type DecoderInput = {
 	// Enable to download the audio track.
 	enabled: Getter<boolean>;
-
-	// The oldest audio a new subscription will take, in milliseconds. Undefined, the default,
-	// starts at the live edge, which is what a continuous broadcast wants.
-	//
-	// Set it for a publisher that opens a track per utterance: it is already writing by the time the
-	// subscription lands, so the live edge skips the head of every track. Asking for the track from
-	// its start and bounding that by age replays the head and nothing older.
-	maxAge: Getter<Time.Milli | undefined>;
 };
 
 type DecoderOutput = {
@@ -96,18 +88,6 @@ export class Decoder {
 	// Ordered discontinuity and endpoint state from the container consumer.
 	#terminal = new Terminal();
 
-	// How much buffered audio the container consumer retains before skipping
-	// ahead. This must be the latency CEILING (maxBuffer), not the floor
-	// (buffer): in buffered playback the producer writes faster than real-time
-	// with future PTS, so the group span legitimately exceeds the floor and
-	// would otherwise be skipped. When collapsed, maxBuffer equals the floor.
-	//
-	// Held in a plain Signal driven by a running effect (below) rather than a
-	// lazy `computed`: the container consumer only `.peek()`s this (it never
-	// subscribes), and an unsubscribed computed peeks as `undefined`, which
-	// would make the consumer's threshold NaN and skip every group.
-	#consumerLatency = new Signal<Time.Milli>(Time.Milli.zero);
-
 	// The latency floor as of the last settled change, to detect a floor *increase* (needs a deeper
 	// cushion) versus a decrease or a real-time RTT wiggle. See #runLatencyReanchor.
 	#prevFloor?: Bound;
@@ -120,15 +100,10 @@ export class Decoder {
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
 		this.in = {
 			enabled: getter(props?.enabled ?? false),
-			maxAge: getter(props?.maxAge),
 		};
 
 		this.source = source;
 		this.sync = sync;
-
-		this.#signals.run((effect) => {
-			this.#consumerLatency.set(effect.get(this.sync.out.maxBuffer));
-		});
 
 		this.#signals.run(this.#runWorklet.bind(this));
 		this.#signals.run(this.#runEnabled.bind(this));
@@ -290,16 +265,21 @@ export class Decoder {
 		// of tail beyond them. Drop that once the replacement's first frame says where it starts.
 		this.#handover.opened();
 
-		// Asking for group 0 requests the track from its start; the age bound is what keeps that to
-		// the caller's window, applied by whoever serves it. A publisher that ignores the bound
-		// replays its whole retention instead, which the container consumer then trims to the
-		// latency target. Omitting both leaves the subscription at the live edge.
-		const maxAge = effect.get(this.in.maxAge);
+		// The Sync ceiling is the maximum age of a non-latest group before both the network and
+		// container consumers skip it. Omitting startGroup keeps a new subscription at the live edge.
+		const priority = Catalog.PRIORITY.audio;
+		let maxAge = this.sync.out.maxBuffer.peek();
 		const sub = active.track(track).subscribe({
-			priority: Catalog.PRIORITY.audio,
-			...(maxAge !== undefined ? { startGroup: 0, latencyMax: maxAge } : {}),
+			priority,
+			latencyMax: maxAge,
 		});
 		effect.cleanup(() => sub.close());
+		effect.run((inner) => {
+			const next = inner.get(this.sync.out.maxBuffer);
+			if (next === maxAge) return;
+			maxAge = next;
+			sub.update({ priority, latencyMax: maxAge });
+		});
 
 		if (config.container.kind === "cmaf") {
 			this.#runCmafDecoder(effect, sub, config);
@@ -317,7 +297,7 @@ export class Decoder {
 		// TODO include JITTER_UNDERHEAD
 		const consumer = new Container.Consumer(sub, {
 			format,
-			latency: this.#consumerLatency,
+			latency: this.sync.out.maxBuffer,
 		});
 		effect.cleanup(() => consumer.close());
 
@@ -422,7 +402,7 @@ export class Decoder {
 
 		const consumer = new Container.Consumer(sub, {
 			format: new Container.Cmaf.Format(init),
-			latency: this.#consumerLatency,
+			latency: this.sync.out.maxBuffer,
 		});
 		effect.cleanup(() => consumer.close());
 

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -24,6 +24,14 @@ const LEGACY_WARMUP_CALLBACKS = 3;
 export type DecoderInput = {
 	// Enable to download the audio track.
 	enabled: Getter<boolean>;
+
+	// The oldest audio a new subscription will take, in milliseconds. Undefined, the default,
+	// starts at the live edge, which is what a continuous broadcast wants.
+	//
+	// Set it for a publisher that opens a track per utterance: it is already writing by the time the
+	// subscription lands, so the live edge skips the head of every track. Asking for the track from
+	// its start and bounding that by age replays the head and nothing older.
+	maxAge: Getter<Time.Milli | undefined>;
 };
 
 type DecoderOutput = {
@@ -112,6 +120,7 @@ export class Decoder {
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
 		this.in = {
 			enabled: getter(props?.enabled ?? false),
+			maxAge: getter(props?.maxAge),
 		};
 
 		this.source = source;
@@ -281,7 +290,15 @@ export class Decoder {
 		// of tail beyond them. Drop that once the replacement's first frame says where it starts.
 		this.#handover.opened();
 
-		const sub = active.track(track).subscribe({ priority: Catalog.PRIORITY.audio });
+		// Asking for group 0 requests the track from its start; the age bound is what keeps that to
+		// the caller's window, applied by whoever serves it. A publisher that ignores the bound
+		// replays its whole retention instead, which the container consumer then trims to the
+		// latency target. Omitting both leaves the subscription at the live edge.
+		const maxAge = effect.get(this.in.maxAge);
+		const sub = active.track(track).subscribe({
+			priority: Catalog.PRIORITY.audio,
+			...(maxAge !== undefined ? { startGroup: 0, latencyMax: maxAge } : {}),
+		});
 		effect.cleanup(() => sub.close());
 
 		if (config.container.kind === "cmaf") {

--- a/js/watch/src/audio/subscription.test.ts
+++ b/js/watch/src/audio/subscription.test.ts
@@ -10,27 +10,27 @@ test("audio subscription tracks the playback latency ceiling without restarting"
 	const source = new Broadcast.Producer();
 	source.createTrack("audio");
 	const broadcast = source.consume();
-	const maxLatency = new Signal<Time.Milli>(Time.Milli(100));
+	const maxLatency = new Signal<Time.Milli>(Time.Milli(38.75));
 	const effect = new Effect();
 	const subscriber = subscribe(effect, { broadcast, track: "audio", maxLatency });
 
 	expect(subscriber.subscription.peek()).toEqual({
 		priority: Catalog.PRIORITY.audio,
 		ordered: false,
-		latencyMax: 100,
+		latencyMax: 39,
 		startGroup: undefined,
 		endGroup: undefined,
 	});
 
 	await settle();
-	maxLatency.set(Time.Milli(500));
+	maxLatency.set(Time.Milli(500.25));
 	await settle();
 
 	expect(subscriber.closed.peek()).toBeUndefined();
 	expect(subscriber.subscription.peek()).toEqual({
 		priority: Catalog.PRIORITY.audio,
 		ordered: false,
-		latencyMax: 500,
+		latencyMax: 501,
 		startGroup: undefined,
 		endGroup: undefined,
 	});

--- a/js/watch/src/audio/subscription.test.ts
+++ b/js/watch/src/audio/subscription.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import * as Catalog from "@moq/hang/catalog";
+import { Broadcast, Time } from "@moq/net";
+import { Effect, Signal } from "@moq/signals";
+import { subscribe } from "./subscription";
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test("audio subscription tracks the playback latency ceiling without restarting", async () => {
+	const source = new Broadcast.Producer();
+	source.createTrack("audio");
+	const broadcast = source.consume();
+	const maxLatency = new Signal<Time.Milli>(Time.Milli(100));
+	const effect = new Effect();
+	const subscriber = subscribe(effect, broadcast, "audio", maxLatency);
+
+	expect(subscriber.subscription.peek()).toEqual({
+		priority: Catalog.PRIORITY.audio,
+		ordered: false,
+		latencyMax: 100,
+		startGroup: undefined,
+		endGroup: undefined,
+	});
+
+	await settle();
+	maxLatency.set(Time.Milli(500));
+	await settle();
+
+	expect(subscriber.closed.peek()).toBeUndefined();
+	expect(subscriber.subscription.peek()).toEqual({
+		priority: Catalog.PRIORITY.audio,
+		ordered: false,
+		latencyMax: 500,
+		startGroup: undefined,
+		endGroup: undefined,
+	});
+
+	effect.close();
+	expect(subscriber.closed.peek()).toBeNull();
+	broadcast.close();
+	source.close();
+});

--- a/js/watch/src/audio/subscription.test.ts
+++ b/js/watch/src/audio/subscription.test.ts
@@ -12,7 +12,7 @@ test("audio subscription tracks the playback latency ceiling without restarting"
 	const broadcast = source.consume();
 	const maxLatency = new Signal<Time.Milli>(Time.Milli(100));
 	const effect = new Effect();
-	const subscriber = subscribe(effect, broadcast, "audio", maxLatency);
+	const subscriber = subscribe(effect, { broadcast, track: "audio", maxLatency });
 
 	expect(subscriber.subscription.peek()).toEqual({
 		priority: Catalog.PRIORITY.audio,

--- a/js/watch/src/audio/subscription.ts
+++ b/js/watch/src/audio/subscription.ts
@@ -17,12 +17,12 @@ export function subscribe(
 	},
 ): Moq.Track.Subscriber {
 	const priority = Catalog.PRIORITY.audio;
-	let latencyMax = maxLatency.peek();
+	let latencyMax = Math.ceil(maxLatency.peek());
 	const subscriber = broadcast.track(track).subscribe({ priority, latencyMax });
 	effect.cleanup(() => subscriber.close());
 
 	effect.run((inner) => {
-		const next = inner.get(maxLatency);
+		const next = Math.ceil(inner.get(maxLatency));
 		if (next === latencyMax) return;
 		latencyMax = next;
 		subscriber.update({ priority, latencyMax });

--- a/js/watch/src/audio/subscription.ts
+++ b/js/watch/src/audio/subscription.ts
@@ -6,9 +6,15 @@ import type { Effect, Getter } from "@moq/signals";
 /** Opens a live-edge audio subscription and keeps its expiry budget aligned with playback. @internal */
 export function subscribe(
 	effect: Effect,
-	broadcast: Moq.Broadcast.Consumer,
-	track: string,
-	maxLatency: Getter<Time.Milli>,
+	{
+		broadcast,
+		track,
+		maxLatency,
+	}: {
+		broadcast: Moq.Broadcast.Consumer;
+		track: string;
+		maxLatency: Getter<Time.Milli>;
+	},
 ): Moq.Track.Subscriber {
 	const priority = Catalog.PRIORITY.audio;
 	let latencyMax = maxLatency.peek();

--- a/js/watch/src/audio/subscription.ts
+++ b/js/watch/src/audio/subscription.ts
@@ -1,0 +1,26 @@
+import * as Catalog from "@moq/hang/catalog";
+import type * as Moq from "@moq/net";
+import type { Time } from "@moq/net";
+import type { Effect, Getter } from "@moq/signals";
+
+/** Opens a live-edge audio subscription and keeps its expiry budget aligned with playback. @internal */
+export function subscribe(
+	effect: Effect,
+	broadcast: Moq.Broadcast.Consumer,
+	track: string,
+	maxLatency: Getter<Time.Milli>,
+): Moq.Track.Subscriber {
+	const priority = Catalog.PRIORITY.audio;
+	let latencyMax = maxLatency.peek();
+	const subscriber = broadcast.track(track).subscribe({ priority, latencyMax });
+	effect.cleanup(() => subscriber.close());
+
+	effect.run((inner) => {
+		const next = inner.get(maxLatency);
+		if (next === latencyMax) return;
+		latencyMax = next;
+		subscriber.update({ priority, latencyMax });
+	});
+
+	return subscriber;
+}


### PR DESCRIPTION
## Summary

- Audio subscriptions use `Sync.out.maxBuffer` as Subscriber Max Latency, matching the container consumer playback ceiling.
- New subscriptions continue to start at the live edge because `startGroup` remains omitted.
- Live Sync ceiling changes call `Subscriber.update` without restarting the subscription or decoder.
- Wire-facing latency values are rounded up to whole milliseconds so fractional RTT-derived ceilings remain encodable.
- A regression test verifies fractional initial and updated budgets, the live-edge range, and subscription continuity.

## Root cause

The audio decoder enforced the Sync ceiling only in the container consumer. The network subscription kept its default zero tolerance for non-latest groups, so moq-lite could discard reordered audio immediately even when the playback buffer still had room to absorb it.

Sync can derive fractional millisecond ceilings from RTT. Forwarding those fractions unchanged would fail moq-lite varint encoding, so the subscription boundary now rounds upward without reducing the requested tolerance.

## Public API changes

- None. `DecoderInput` is unchanged from `main`.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (140 `@moq/watch` tests passed; all affected suites passed)

## Cross-package sync

- Not applicable. This uses the existing subscription field and does not change the wire format.

(Written by GPT-5.6)