### PR TITLE
fix(relay): give the io_uring listener its certificate and mTLS

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -96,9 +96,8 @@ pin = true
 # versions are not offered on this listener, and neither is the pre-lite-05
 # SETUP exchange a browser reaches by offering no subprotocol. Requires
 # `workers`, Linux 6.12+, a build with the `io-uring` cargo feature, and
-# exactly one listen.tls certificate; the certificate is read once at startup
-# (no hot reload yet), and mTLS client roots are not yet honored. Refuses to
-# start anywhere it cannot deliver. Default: false.
+# exactly one listen.tls certificate, read once at startup (no hot reload
+# yet). Refuses to start anywhere it cannot deliver. Default: false.
 io_uring = false
 ```
 
@@ -112,18 +111,19 @@ The `[quic]` section applies to this listener too: `max_streams`,
 so there is nothing to discover), and asking for either is a startup error
 rather than a setting that quietly does nothing.
 
-The same goes for the listener settings this mode cannot deliver: `tls.root`
-(mTLS client roots), `lb_id` (QUIC-LB server ids, which cannot share the
-connection id with the shard prefix), an explicit `backend`, `tls.generate`,
-more than one certificate, and moq-lite 01/02, whose version is negotiated in
-the SETUP rather than by ALPN. Each is refused at startup. `listen.bind` must
-be named too, rather than defaulted: leaving it unset means stream-only when a
-tcp or unix listener is configured, and this mode will not guess.
+The same goes for the listener settings this mode cannot deliver: `lb_id`
+(QUIC-LB server ids, which cannot share the connection id with the shard
+prefix), an explicit `backend`, `tls.generate`, more than one certificate, and
+moq-lite 01/02, whose version is negotiated in the SETUP rather than by ALPN.
+Each is refused at startup. `listen.bind` must be named too, rather than
+defaulted: leaving it unset means stream-only when a tcp or unix listener is
+configured, and this mode will not guess.
 
-One gap worth knowing about: `/certificate.sha256` serves nothing in this mode,
-because the fingerprints come from the shared server's TLS backend and the
-io_uring workers hold the certificate instead. A client that pins a self-signed
-relay through that endpoint needs the tokio workers until this is wired up.
+`tls.root` works here as it does on the tokio listener: a client that presents
+a certificate chaining to one of those roots is authenticated by it, with full
+access within its path's canonical root, and one that presents none falls back
+to the usual token flow. `/certificate.sha256` serves what the workers are
+presenting, so a client can still pin a self-signed relay through it.
 
 The shared runtime is still there for everything that is not QUIC, and it still
 sizes its thread pool to the machine. Set `TOKIO_WORKER_THREADS` in the

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -201,10 +201,16 @@ impl Relay {
 		let drain_timeout = config.drain_timeout.into_std();
 		let (shutdown_trigger, shutdown) = Shutdown::new(drain_timeout);
 		// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
-		// The workers hold the certificates when they own QUIC; the server has none.
-		let certificates = match &workers {
-			Some(workers) => workers.certificates(),
-			None => server.certificates(),
+		// Whichever worker group owns QUIC holds the certificates; the shared
+		// server then has none of its own.
+		#[cfg(all(target_os = "linux", feature = "io-uring"))]
+		let uring_certificates = uring.as_ref().map(crate::uring::Workers::certificates);
+		#[cfg(not(all(target_os = "linux", feature = "io-uring")))]
+		let uring_certificates: Option<moq_tokio::tls::Certificates> = None;
+		let certificates = match (&workers, uring_certificates) {
+			(Some(workers), _) => workers.certificates(),
+			(None, Some(certificates)) => certificates,
+			(None, None) => server.certificates(),
 		};
 		let web = Web::new(auth.clone(), cluster.clone(), certificates, config.web)
 			.with_shutdown(shutdown.clone())

--- a/rs/moq-relay/src/uring.rs
+++ b/rs/moq-relay/src/uring.rs
@@ -88,6 +88,8 @@ pub struct Workers {
 	members: Vec<Member>,
 	addr: SocketAddr,
 	server: moq_uring::quic::server::Config,
+	/// What the workers serve, fingerprinted once, for `/certificate.sha256`.
+	certificates: moq_tokio::tls::Certificates,
 	udp: moq_uring::udp::Config,
 	pin: bool,
 	alpns: Arc<Vec<String>>,
@@ -111,7 +113,7 @@ impl Workers {
 	/// (serve those from an [`init_streams`](moq_tokio::listen::Config::init_streams)
 	/// server), and `tls.generate` is refused since every worker must serve
 	/// one identity. Unlike it, exactly one certificate/key pair is required,
-	/// and mTLS client roots are not yet wired through.
+	/// and it is read here rather than on each worker thread.
 	pub fn bind(
 		listen: &moq_tokio::listen::Config,
 		quic: &moq_tokio::quic::Config,
@@ -125,12 +127,6 @@ impl Workers {
 		// beats starting and quietly behaving differently from what the
 		// operator configured, which is the whole failure mode this mode is
 		// most likely to produce.
-		if !listen.tls.root.is_empty() {
-			anyhow::bail!(
-				"io_uring workers do not implement mTLS client roots (listen.tls.root); \
-				 use token auth, or the tokio workers"
-			);
-		}
 		if listen.lb_id.is_some() {
 			anyhow::bail!(
 				"io_uring workers issue shard-steered connection ids and cannot also carry a \
@@ -144,6 +140,20 @@ impl Workers {
 			([cert], [key]) => (cert.clone(), key.clone()),
 			([], []) => anyhow::bail!("io_uring workers need a certificate (listen.tls.cert/key)"),
 			_ => anyhow::bail!("io_uring workers serve exactly one certificate, got several"),
+		};
+		// Read once, here, rather than per worker: every worker must present
+		// the same identity, and a certificate replaced on disk while the
+		// threads are starting would otherwise split the group between two.
+		let identity = moq_uring::quic::Identity::open(&cert, &key)
+			.with_context(|| format!("failed to load {} / {}", cert.display(), key.display()))?;
+		let certificates = moq_tokio::tls::Certificates::from_pem(identity.cert())
+			.with_context(|| format!("failed to fingerprint {}", cert.display()))?;
+
+		// A client certificate stands in for a JWT, exactly as on the tokio
+		// path; a client that presents none still gets the token flow.
+		let client_auth = match listen.tls.root.is_empty() {
+			true => moq_uring::quic::server::ClientAuth::None,
+			false => moq_uring::quic::server::ClientAuth::Optional(listen.tls.root.clone()),
 		};
 
 		let count = config.count.max(1);
@@ -228,8 +238,9 @@ impl Workers {
 			);
 		}
 
-		let mut server = moq_uring::quic::server::Config::new(moq_uring::quic::Identity::new(cert, key));
+		let mut server = moq_uring::quic::server::Config::new(identity);
 		server.alpn = alpns.iter().cloned().chain(["h3".to_string()]).collect();
+		server.client_auth = client_auth;
 		let quic = quic.resolve();
 		server.transport = transport(&quic)?;
 
@@ -245,6 +256,7 @@ impl Workers {
 			members,
 			addr,
 			server,
+			certificates,
 			udp,
 			pin: config.pin,
 			alpns: Arc::new(alpns),
@@ -260,6 +272,15 @@ impl Workers {
 	/// The address every worker is bound to.
 	pub fn local_addr(&self) -> SocketAddr {
 		self.addr
+	}
+
+	/// The certificate every worker presents, for publishing its SHA-256
+	/// fingerprint.
+	///
+	/// Fixed for the group's lifetime: the identity is read once at
+	/// [`bind`](Self::bind) and nothing reloads it.
+	pub fn certificates(&self) -> moq_tokio::tls::Certificates {
+		self.certificates.clone()
 	}
 
 	/// Spawn the worker threads and start accepting.
@@ -379,8 +400,7 @@ fn transport(quic: &moq_tokio::quic::Resolved) -> anyhow::Result<moq_uring::quic
 		"io_uring workers cannot write qlog traces; drop quic.qlog or use the tokio workers"
 	);
 	// The datagram path fixes both payload ceilings at SEGMENT and hands
-	// `conn.send` slices of exactly that, so discovery has no larger size to
-	// find and would only add probes.
+	// `conn.send` slices of exactly that, so there is no larger size to find.
 	anyhow::ensure!(
 		!quic.mtu_discovery,
 		"io_uring workers send a fixed-size UDP payload, so quic.mtu_discovery has nothing to discover"
@@ -546,6 +566,17 @@ async fn serve_connection(
 ) -> anyhow::Result<()> {
 	use web_transport_trait::poll::Session as _;
 
+	// TLS validated this against the configured roots before the connection
+	// existed, so a chain here is an authenticated peer. Read it now: the
+	// handshake below consumes the connection.
+	let identity = conn.peer_chain().map(|chain| {
+		let chain = chain
+			.into_iter()
+			.map(moq_tokio::rustls::pki_types::CertificateDer::from)
+			.collect();
+		moq_tokio::tls::PeerIdentity::from_chain(chain)
+	});
+
 	// Browsers speak WebTransport; everyone else raw QUIC. The moq version
 	// rides the ALPN for raw QUIC and the WebTransport subprotocol for `h3`.
 	// A browser offering no subprotocol we speak is refused with
@@ -599,14 +630,31 @@ async fn serve_connection(
 	};
 	params.transport = Some(moq_tokio::Transport::Quic);
 
+	// An mTLS peer's certificate is its credential, granting full access within
+	// the path's canonical root; everyone else brings a JWT (or is anonymous).
+	// Either verdict comes from the shared runtime.
 	let auth = serve.auth.clone();
+	let mtls = identity.is_some();
 	let token = match serve
 		.tokio
-		.spawn(async move { auth.verify(&params).await })
+		.spawn(async move {
+			match mtls {
+				true => auth.verify_mtls(&params.path, params.transport).await,
+				false => auth.verify(&params).await,
+			}
+		})
 		.await
 		.context("auth task failed")?
 	{
-		Ok(token) => token,
+		Ok(mut token) => {
+			if let Some(identity) = &identity {
+				tracing::debug!(id, "mTLS peer authenticated");
+				// Close the session when the client certificate expires,
+				// mirroring the JWT `exp` handling.
+				token.expires = identity.expiry();
+			}
+			token
+		}
 		Err(err) => {
 			// The status is what separates "your credential is bad" from "the
 			// auth API is down". Collapsing both into Unauthorized tells a

--- a/rs/moq-relay/tests/runtime_uring.rs
+++ b/rs/moq-relay/tests/runtime_uring.rs
@@ -37,6 +37,33 @@ fn free_udp_port() -> u16 {
 	port
 }
 
+/// A CA on disk plus a certificate it signed, for the mTLS test. Returns the
+/// root, the client's certificate, and its key.
+fn signed_client(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+	let ca_key = rcgen::KeyPair::generate().expect("ca keypair");
+	let mut ca_params = rcgen::CertificateParams::new(Vec::new()).expect("ca params");
+	ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+	ca_params.key_usages = vec![rcgen::KeyUsagePurpose::KeyCertSign, rcgen::KeyUsagePurpose::CrlSign];
+	ca_params
+		.distinguished_name
+		.push(rcgen::DnType::CommonName, "moq test ca");
+	let ca = rcgen::CertifiedIssuer::self_signed(ca_params, ca_key).expect("self-signed ca");
+
+	let key = rcgen::KeyPair::generate().expect("client keypair");
+	let mut params = rcgen::CertificateParams::new(vec!["client.localhost".to_string()]).expect("client params");
+	params.use_authority_key_identifier_extension = true;
+	params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ClientAuth];
+	let cert = params.signed_by(&key, &ca).expect("signed client cert");
+
+	let root_path = dir.join("ca.pem");
+	let cert_path = dir.join("client.pem");
+	let key_path = dir.join("client.key.pem");
+	std::fs::write(&root_path, ca.pem()).expect("write ca");
+	std::fs::write(&cert_path, cert.pem()).expect("write client cert");
+	std::fs::write(&key_path, key.serialize_pem()).expect("write client key");
+	(root_path, cert_path, key_path)
+}
+
 /// A self-signed certificate on disk; the workers refuse `tls.generate`.
 fn certificate(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
 	let key = rcgen::KeyPair::generate().expect("keypair");
@@ -164,6 +191,156 @@ async fn uring_workers_serve_webtransport_and_raw_quic() {
 	drop(publisher);
 	drop(subscribers);
 	// Dropping the run task drops the worker group, which joins its threads.
+	running.abort();
+	let _ = running.await;
+}
+
+/// One HTTP/1.1 GET against `addr`, returning the response body.
+///
+/// Hand-rolled because the relay has no HTTP client among its dev
+/// dependencies, and one GET does not justify pulling one in.
+async fn http_get(addr: SocketAddr, path: &str) -> String {
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+	let mut stream = tokio::net::TcpStream::connect(addr).await.expect("connect");
+	let request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+	stream.write_all(request.as_bytes()).await.expect("write request");
+	let mut response = String::new();
+	stream.read_to_string(&mut response).await.expect("read response");
+	let (head, body) = response.split_once("\r\n\r\n").expect("response has a body");
+	assert!(head.starts_with("HTTP/1.1 200"), "got {head:?}");
+	body.to_string()
+}
+
+/// `/certificate.sha256` serves what the io_uring workers are actually
+/// presenting.
+///
+/// The fingerprints used to come from the shared server's TLS backend, which
+/// is stream-only in this mode, so the endpoint 404'd while the workers served
+/// a certificate. A client that pins a self-signed relay through it stopped
+/// being able to connect the moment the flag was flipped.
+#[tokio::test]
+async fn uring_workers_publish_their_certificate_fingerprint() {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+	if !supported() {
+		return;
+	}
+
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (cert, key) = certificate(dir.path());
+	let relay = Relay::load(uring_config(&cert, &key, free_udp_port()))
+		.await
+		.expect("load relay");
+
+	// The relay's own web listener needs TLS; its router does not, and the
+	// handler reads the same certificate handle either way.
+	let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+	let addr = listener.local_addr().expect("local addr");
+	let routes = relay.web.routes();
+	let serving = tokio::spawn(async move { axum::serve(listener, routes).await });
+
+	let served = http_get(addr, "/certificate.sha256").await;
+
+	// The same value a client pins: SHA-256 over the leaf's DER.
+	let pem = std::fs::read(&cert).expect("read cert");
+	let expected = moq_tokio::tls::Certificates::from_pem(&pem)
+		.expect("fingerprint")
+		.fingerprints()
+		.remove(0);
+	assert_eq!(served, expected, "the fingerprint the workers serve");
+
+	serving.abort();
+	let _ = serving.await;
+}
+
+/// A client certificate is a credential the io_uring workers accept.
+///
+/// `listen.tls.root` used to be refused at startup here, so the mode could not
+/// authenticate a peer mesh at all. There is deliberately no JWT or public path
+/// configured below, so `Auth::verify` refuses every one of these connections:
+/// only the mTLS path can carry the round trip through.
+#[tokio::test]
+async fn an_mtls_client_authenticates_without_a_token() {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+	if !supported() {
+		return;
+	}
+
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (cert, key) = certificate(dir.path());
+	let (root, client_cert, client_key) = signed_client(dir.path());
+	let port = free_udp_port();
+
+	let mut config = uring_config(&cert, &key, port);
+	config.auth.public = None;
+	config.listen.tls.root = vec![root];
+
+	let relay = Relay::load(config).await.expect("load relay");
+	let running = tokio::spawn(relay.run());
+
+	let client = || {
+		let mut dial = moq_tokio::connect::Config::default();
+		dial.tls.insecure = Some(true);
+		dial.once = Some(true);
+		dial.bind = Some("127.0.0.1:0".parse().expect("parse bind"));
+		dial.tls.cert = Some(client_cert.clone());
+		dial.tls.key = Some(client_key.clone());
+		dial.init(Default::default()).expect("client init")
+	};
+
+	// An mTLS token is unrestricted within its root, so one certificate covers
+	// both roles. A publish that reaches a subscriber is the proof: an
+	// unauthorized session establishes and is then closed, so merely
+	// connecting proves nothing.
+	let url: url::Url = format!("moql://127.0.0.1:{port}/mtls").parse().expect("parse url");
+	let origin = moq_tokio::origin::spawn(Origin::random());
+	let mut broadcast = origin
+		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
+		.expect("create broadcast");
+	let mut track = broadcast.create_track("video", None).expect("create track");
+	let mut group = track.append_group().expect("append group");
+	group
+		.write_frame(moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
+	group.finish().expect("finish group");
+	let publisher = connect(client().with_publisher(&origin), url.clone()).await;
+
+	let subscriber_origin = moq_tokio::origin::spawn(Origin::random());
+	let mut announced = subscriber_origin.consume().announced();
+	let subscriber = connect(client().with_subscriber(subscriber_origin), url).await;
+
+	let moq_net::announce::Update {
+		path,
+		broadcast: announced,
+	} = tokio::time::timeout(TIMEOUT, announced.next())
+		.await
+		.expect("announcement timeout")
+		.expect("origin closed");
+	assert_eq!(path.as_str(), "test");
+	let announced = announced.expect("expected announce, got unannounce");
+	let mut subscription = announced
+		.track("video")
+		.unwrap()
+		.subscribe(None)
+		.await
+		.expect("subscribe");
+	let mut group = tokio::time::timeout(TIMEOUT, subscription.recv_group())
+		.await
+		.expect("recv_group timeout")
+		.expect("recv_group failed")
+		.expect("track closed prematurely");
+	let frame = tokio::time::timeout(TIMEOUT, group.read_frame())
+		.await
+		.expect("read_frame timeout")
+		.expect("read_frame failed")
+		.expect("group closed prematurely");
+	assert_eq!(&frame.payload[..], b"hello");
+
+	assert!(!running.is_finished(), "the relay stopped while serving");
+	drop(track);
+	drop(broadcast);
+	drop(publisher);
+	drop(subscriber);
 	running.abort();
 	let _ = running.await;
 }

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -1442,9 +1442,16 @@ impl PeerIdentity {
 		Some(Self { chain: *chain })
 	}
 
-	/// Wrap a certificate chain already exposed by a QUIC backend.
-	#[cfg(feature = "quiche")]
-	pub(crate) fn from_chain(chain: Vec<CertificateDer<'static>>) -> Self {
+	/// Wrap a certificate chain a QUIC backend already validated, leaf first.
+	///
+	/// For a listener living outside this crate (the io_uring workers, say)
+	/// that ran its own mTLS handshake and wants the relay's authenticated-peer
+	/// path. Only pass a chain TLS accepted: nothing here re-verifies it.
+	///
+	/// Takes [`rustls::pki_types::CertificateDer`], already part of this
+	/// crate's public API via [`chain`](Self::chain), so a major `rustls` bump
+	/// is a breaking change for callers of this too.
+	pub fn from_chain(chain: Vec<CertificateDer<'static>>) -> Self {
 		Self { chain }
 	}
 
@@ -1482,9 +1489,9 @@ impl PeerIdentity {
 /// The certificates a server is currently serving.
 ///
 /// Only a QUIC backend serves TLS of its own, so nothing else populates this.
-#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 #[derive(Debug, Default)]
 pub(crate) struct Info {
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	pub(crate) certs: Vec<Arc<rustls::sign::CertifiedKey>>,
 	pub(crate) fingerprints: Vec<String>,
 }
@@ -1496,12 +1503,10 @@ pub(crate) struct Info {
 /// lifetime. Obtained from [`crate::Server::certificates`].
 #[derive(Clone, Debug)]
 pub struct Certificates {
-	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	info: Arc<RwLock<Info>>,
 }
 
 impl Certificates {
-	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	pub(crate) fn new(info: Arc<RwLock<Info>>) -> Self {
 		Self { info }
 	}
@@ -1509,9 +1514,37 @@ impl Certificates {
 	/// An empty set, used when no TLS-bearing backend is configured.
 	pub(crate) fn empty() -> Self {
 		Self {
-			#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 			info: Arc::new(RwLock::new(Info::default())),
 		}
+	}
+
+	/// A fixed handle reporting the certificates in the PEM `chain`, one
+	/// fingerprint each and in file order.
+	///
+	/// For a listener living outside this crate that serves TLS of its own and
+	/// has to publish what it serves (the io_uring workers hold their
+	/// certificate rather than the shared server). Nothing hot reloads here:
+	/// such a listener fixes its TLS material when it is built, so the
+	/// fingerprints are computed once and never change.
+	pub fn from_pem(chain: &[u8]) -> Result<Self> {
+		use rustls::pki_types::pem::PemObject;
+
+		let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(chain)
+			.collect::<std::result::Result<_, _>>()
+			.map_err(Error::Read)?;
+		if certs.is_empty() {
+			return Err(Error::Empty);
+		}
+		let provider = crypto::provider();
+		let fingerprints = certs
+			.iter()
+			.map(|cert| hex::encode(crypto::sha256(&provider, cert.as_ref())))
+			.collect();
+		Ok(Self::new(Arc::new(RwLock::new(Info {
+			#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
+			certs: Vec::new(),
+			fingerprints,
+		}))))
 	}
 
 	/// The SHA-256 fingerprints of the certificates being served right now, hex
@@ -1520,15 +1553,10 @@ impl Certificates {
 	/// Empty when the server has no TLS-bearing backend. Re-read this per use
 	/// rather than caching it: a cert rotation on disk changes the values.
 	pub fn fingerprints(&self) -> Vec<String> {
-		#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
-		{
-			// A panicking writer can't leave the cert list half-updated (it is
-			// replaced wholesale), so a poisoned lock is still safe to read.
-			let info = self.info.read().unwrap_or_else(std::sync::PoisonError::into_inner);
-			info.fingerprints.clone()
-		}
-		#[cfg(not(any(feature = "noq", feature = "quinn", feature = "quiche")))]
-		Vec::new()
+		// A panicking writer can't leave the cert list half-updated (it is
+		// replaced wholesale), so a poisoned lock is still safe to read.
+		let info = self.info.read().unwrap_or_else(std::sync::PoisonError::into_inner);
+		info.fingerprints.clone()
 	}
 }
 

--- a/rs/moq-uring/benches/session_lite.rs
+++ b/rs/moq-uring/benches/session_lite.rs
@@ -154,7 +154,7 @@ mod linux {
 
 			let certs = support::certs().expect("certificates");
 			let mut server_config =
-				quic::server::Config::new(quic::Identity::new(certs.cert.clone(), certs.key.clone()));
+				quic::server::Config::new(quic::Identity::open(&certs.cert, &certs.key).expect("identity"));
 			server_config.alpn = vec![ALPN.to_string()];
 
 			let server_sock = handle

--- a/rs/moq-uring/src/quic/connection.rs
+++ b/rs/moq-uring/src/quic/connection.rs
@@ -246,6 +246,19 @@ impl Connection {
 	pub(crate) fn shared(&self) -> &Shared {
 		&self.shared
 	}
+
+	/// The peer's certificate chain in DER, leaf first, or `None` if it
+	/// presented none.
+	///
+	/// A server only sees one when it asked
+	/// ([`ClientAuth`](super::server::ClientAuth)), and TLS already validated
+	/// it against the configured roots by the time this connection exists: an
+	/// invalid chain fails the handshake instead. So a `Some` here is an
+	/// authenticated peer, and the chain is what names it.
+	pub fn peer_chain(&self) -> Option<Vec<Vec<u8>>> {
+		let conn = self.shared.conn.borrow();
+		Some(conn.peer_cert_chain()?.into_iter().map(<[u8]>::to_vec).collect())
+	}
 }
 
 impl Clone for Connection {

--- a/rs/moq-uring/src/quic/mod.rs
+++ b/rs/moq-uring/src/quic/mod.rs
@@ -37,23 +37,51 @@ pub(crate) const SEGMENT: usize = 1350;
 /// The platform trust store, loaded when a role config asks for it.
 const SYSTEM_ROOTS: &str = "/etc/ssl/certs";
 
-/// A TLS certificate chain and the private key that signs for it, as PEM
-/// files on disk. One value, so neither half can be configured alone.
-#[derive(Clone, Debug)]
+/// A TLS certificate chain and the private key that signs for it, as PEM.
+/// One value, so neither half can be configured alone.
+///
+/// The bytes are read once and held, not re-read per connection: a worker
+/// group builds one of these before it spawns, so replacing the files on disk
+/// afterwards cannot leave two workers serving different identities.
+#[derive(Clone)]
 pub struct Identity {
-	/// The PEM certificate chain to present.
-	pub cert: std::path::PathBuf,
-	/// The PEM private key for the leaf certificate.
-	pub key: std::path::PathBuf,
+	cert: Vec<u8>,
+	key: Vec<u8>,
 }
 
 impl Identity {
-	/// The chain at `cert`, signed for by the key at `key`.
-	pub fn new(cert: impl Into<std::path::PathBuf>, key: impl Into<std::path::PathBuf>) -> Self {
+	/// Read the PEM chain at `cert` and the PEM key at `key`.
+	pub fn open(cert: impl AsRef<std::path::Path>, key: impl AsRef<std::path::Path>) -> Result<Self, Error> {
+		let read = |path: &std::path::Path| {
+			std::fs::read(path).map_err(|err| Error::Tls(format!("{}: {err}", path.display())))
+		};
+		Ok(Self {
+			cert: read(cert.as_ref())?,
+			key: read(key.as_ref())?,
+		})
+	}
+
+	/// The same, from PEM already in hand.
+	pub fn from_pem(cert: impl Into<Vec<u8>>, key: impl Into<Vec<u8>>) -> Self {
 		Self {
 			cert: cert.into(),
 			key: key.into(),
 		}
+	}
+
+	/// The PEM certificate chain being presented, for a caller that publishes
+	/// its fingerprint. The key is deliberately not readable back out.
+	pub fn cert(&self) -> &[u8] {
+		&self.cert
+	}
+}
+
+impl std::fmt::Debug for Identity {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		// Whatever else gets logged, the private key does not.
+		f.debug_struct("Identity")
+			.field("cert", &format_args!("{} PEM bytes", self.cert.len()))
+			.finish_non_exhaustive()
 	}
 }
 
@@ -88,8 +116,6 @@ pub struct Transport {
 	pub max_streams: u64,
 	/// Which congestion controller to run.
 	pub congestion: Congestion,
-	/// Probe for a larger path MTU than the conservative default.
-	pub mtu_discovery: bool,
 	/// How often to send an ack-eliciting packet on an otherwise idle
 	/// connection, or `None` (the default) to send none and let the idle
 	/// timeout decide.
@@ -102,7 +128,6 @@ impl Default for Transport {
 			idle_timeout: std::time::Duration::from_secs(10),
 			max_streams: 1024,
 			congestion: Congestion::default(),
-			mtu_discovery: false,
 			keep_alive: None,
 		}
 	}
@@ -144,18 +169,13 @@ pub(crate) fn tls(
 	trust: Trust,
 	transport: &Transport,
 ) -> Result<quiche::Config, Error> {
-	use boring::ssl::{SslContextBuilder, SslFiletype, SslMethod};
+	use boring::ssl::{SslContextBuilder, SslMethod};
 
 	let mut builder = SslContextBuilder::new(SslMethod::tls()).map_err(|err| Error::Tls(err.to_string()))?;
 	apply_trust(&mut builder, &trust)?;
 
 	if let Some(identity) = identity {
-		builder
-			.set_certificate_chain_file(&identity.cert)
-			.map_err(|err| Error::Tls(format!("{}: {err}", identity.cert.display())))?;
-		builder
-			.set_private_key_file(&identity.key, SslFiletype::PEM)
-			.map_err(|err| Error::Tls(format!("{}: {err}", identity.key.display())))?;
+		apply_identity(&mut builder, identity)?;
 	}
 
 	let mut config = quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, builder)?;
@@ -171,9 +191,31 @@ pub(crate) fn tls(
 	config.set_initial_max_streams_bidi(transport.max_streams);
 	config.set_initial_max_streams_uni(transport.max_streams);
 	config.set_cc_algorithm_name(transport.congestion.name())?;
-	config.discover_pmtu(transport.mtu_discovery);
 	config.enable_dgram(true, 64, 64);
 	Ok(config)
+}
+
+/// Present `identity`, from the PEM it already holds.
+///
+/// The file-based boring setters would re-read the paths on every call, which
+/// is the whole reason [`Identity`] carries bytes.
+fn apply_identity(builder: &mut boring::ssl::SslContextBuilder, identity: &Identity) -> Result<(), Error> {
+	use boring::pkey::PKey;
+	use boring::x509::X509;
+
+	let tls = |err: boring::error::ErrorStack| Error::Tls(err.to_string());
+	let chain = X509::stack_from_pem(identity.cert()).map_err(tls)?;
+	let (leaf, intermediates) = chain
+		.split_first()
+		.ok_or_else(|| Error::Tls("certificate chain holds no certificates".to_string()))?;
+	builder.set_certificate(leaf).map_err(tls)?;
+	for cert in intermediates {
+		builder.add_extra_chain_cert(cert.clone()).map_err(tls)?;
+	}
+
+	let key = PKey::private_key_from_pem(&identity.key).map_err(tls)?;
+	builder.set_private_key(&key).map_err(tls)?;
+	Ok(())
 }
 
 /// Point `builder` at exactly the roots `trust` names.

--- a/rs/moq-uring/src/quic/mod.rs
+++ b/rs/moq-uring/src/quic/mod.rs
@@ -231,19 +231,21 @@ fn apply_trust(builder: &mut boring::ssl::SslContextBuilder, trust: &Trust) -> R
 			.set_default_verify_paths()
 			.map_err(|err| Error::Tls(format!("{SYSTEM_ROOTS}: {err}")))?;
 		for root in &trust.roots {
-			let cert = read_root(root)?;
-			builder
-				.cert_store_mut()
-				.add_cert(cert)
-				.map_err(|err| Error::Tls(format!("{}: {err}", root.display())))?;
+			for cert in read_roots(root)? {
+				builder
+					.cert_store_mut()
+					.add_cert(cert)
+					.map_err(|err| Error::Tls(format!("{}: {err}", root.display())))?;
+			}
 		}
 	} else {
 		let mut store = X509StoreBuilder::new().map_err(|err| Error::Tls(err.to_string()))?;
 		for root in &trust.roots {
-			let cert = read_root(root)?;
-			store
-				.add_cert(cert)
-				.map_err(|err| Error::Tls(format!("{}: {err}", root.display())))?;
+			for cert in read_roots(root)? {
+				store
+					.add_cert(cert)
+					.map_err(|err| Error::Tls(format!("{}: {err}", root.display())))?;
+			}
 		}
 		builder.set_cert_store_builder(store);
 	}
@@ -251,10 +253,19 @@ fn apply_trust(builder: &mut boring::ssl::SslContextBuilder, trust: &Trust) -> R
 	Ok(())
 }
 
-/// Read one PEM root, naming the file when it fails.
-fn read_root(path: &std::path::Path) -> Result<boring::x509::X509, Error> {
+/// Read every PEM certificate in one root file, naming it when it fails.
+///
+/// A root is routinely a bundle of several CAs, and taking only the first
+/// would reject a peer chaining to any of the others while looking configured.
+/// A file holding none is an error rather than a store that trusts nothing.
+fn read_roots(path: &std::path::Path) -> Result<Vec<boring::x509::X509>, Error> {
 	let pem = std::fs::read(path).map_err(|err| Error::Tls(format!("{}: {err}", path.display())))?;
-	boring::x509::X509::from_pem(&pem).map_err(|err| Error::Tls(format!("{}: {err}", path.display())))
+	let certs =
+		boring::x509::X509::stack_from_pem(&pem).map_err(|err| Error::Tls(format!("{}: {err}", path.display())))?;
+	if certs.is_empty() {
+		return Err(Error::Tls(format!("{}: no certificates", path.display())));
+	}
+	Ok(certs)
 }
 
 /// Why a connection could not be set up or has ended.

--- a/rs/moq-uring/tests/endpoint.rs
+++ b/rs/moq-uring/tests/endpoint.rs
@@ -31,7 +31,7 @@ fn worker() -> Option<Worker> {
 const ALPN: &str = "moq-uring-test";
 
 fn server_config(certs: &support::Certs) -> quic::server::Config {
-	let mut config = quic::server::Config::new(quic::Identity::new(certs.cert.clone(), certs.key.clone()));
+	let mut config = quic::server::Config::new(quic::Identity::open(&certs.cert, &certs.key).expect("identity"));
 	config.alpn = vec![ALPN.to_string()];
 	config
 }
@@ -413,4 +413,58 @@ fn accept_needs_a_server_config() {
 
 	let result = worker.block_on(async move { endpoint.accept().await }).expect("worker");
 	assert!(matches!(result, Err(quic::Error::NotServer)), "got {result:?}");
+}
+
+/// One [`quic::Identity`] serves every endpoint built from it, without ever
+/// touching the files again.
+///
+/// A worker group builds its endpoints on the worker threads, so re-reading
+/// the certificate per endpoint means a certificate replaced on disk while
+/// those threads are starting leaves earlier and later workers presenting
+/// different identities, and a client pinning either one fails depending on
+/// which worker accepts it.
+#[test]
+fn an_identity_is_read_once() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let certs = support::certs().expect("certificates");
+	let config = server_config(&certs);
+
+	// Whatever the endpoints below present, it did not come from here.
+	std::fs::remove_file(&certs.cert).expect("remove cert");
+	std::fs::remove_file(&certs.key).expect("remove key");
+
+	let listener = |handle: &moq_uring::Handle| {
+		let sock = handle
+			.udp(UdpSocket::bind("127.0.0.1:0").expect("bind"), udp::Config::default())
+			.expect("socket");
+		quic::Endpoint::new(
+			handle,
+			sock,
+			quic::endpoint::Config::default().with_server(config.clone()),
+		)
+		.expect("endpoint")
+	};
+
+	// Two endpoints, as two workers would build them, then a real handshake
+	// against the second: the identity has to survive being cloned as well as
+	// being read.
+	let _first = listener(&handle);
+	let second = listener(&handle);
+	let server = second.local_addr();
+
+	worker
+		.block_on(async move {
+			let sock = handle
+				.udp(UdpSocket::bind("127.0.0.1:0").expect("bind"), udp::Config::default())
+				.expect("client socket");
+			let dial = handle.clone();
+			handle.spawn(async move {
+				quic::client::connect(&dial, sock, &dial_config(server))
+					.await
+					.expect("dial");
+			});
+			second.accept().await.expect("accepted connection");
+		})
+		.expect("worker");
 }

--- a/rs/moq-uring/tests/session.rs
+++ b/rs/moq-uring/tests/session.rs
@@ -389,3 +389,52 @@ fn required_client_auth_refuses_an_anonymous_client() {
 		"a server requiring a certificate must refuse an anonymous client"
 	);
 }
+
+/// A root file is routinely a bundle of several CAs, and it has to be loaded
+/// whole.
+///
+/// Only the second CA in the bundle below signed the server, so a loader that
+/// stops at the first certificate rejects a peer that is perfectly valid while
+/// still looking configured. The relay reaches this through `listen.tls.root`.
+#[test]
+fn a_root_bundle_is_loaded_whole() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+	let bundle = support::bundle().expect("bundle");
+
+	let mut server_config =
+		quic::server::Config::new(quic::Identity::open(&bundle.cert, &bundle.key).expect("identity"));
+	server_config.alpn = vec![ALPN.to_string()];
+
+	let server_sock = handle
+		.udp(UdpSocket::bind("127.0.0.1:0").expect("bind"), udp::Config::default())
+		.expect("server socket");
+	let server_addr = server_sock.local_addr().expect("server addr");
+	let client_sock = handle
+		.udp(UdpSocket::bind("127.0.0.1:0").expect("bind"), udp::Config::default())
+		.expect("client socket");
+	let mut dial = quic::client::Config::new(server_addr, "localhost");
+	dial.alpn = vec![ALPN.to_string()];
+	dial.system_roots = false;
+	dial.roots = vec![bundle.roots.clone()];
+
+	let server_handle = handle.clone();
+	handle.spawn(async move {
+		quic::server::accept(&server_handle, server_sock, &server_config)
+			.await
+			.expect("quic accept");
+	});
+
+	worker
+		.block_on(async move {
+			let conn = quic::client::connect(&handle, client_sock, &dial)
+				.await
+				.expect("quic connect");
+			assert_eq!(
+				web_transport_trait::poll::Session::protocol(&conn),
+				Some(ALPN),
+				"negotiated ALPN"
+			);
+		})
+		.expect("worker");
+}

--- a/rs/moq-uring/tests/session.rs
+++ b/rs/moq-uring/tests/session.rs
@@ -72,7 +72,7 @@ fn lite_session_over_the_worker() {
 	group.finish().expect("finish group");
 
 	let certs = support::certs().expect("certificates");
-	let mut server_config = quic::server::Config::new(quic::Identity::new(certs.cert.clone(), certs.key.clone()));
+	let mut server_config = quic::server::Config::new(quic::Identity::open(&certs.cert, &certs.key).expect("identity"));
 	server_config.alpn = vec![ALPN.to_string()];
 
 	let server_sock = handle
@@ -190,7 +190,7 @@ fn two_lite_sessions_share_the_server_socket() {
 	group.finish().expect("finish group");
 
 	let certs = support::certs().expect("certificates");
-	let mut server_config = quic::server::Config::new(quic::Identity::new(certs.cert.clone(), certs.key.clone()));
+	let mut server_config = quic::server::Config::new(quic::Identity::open(&certs.cert, &certs.key).expect("identity"));
 	server_config.alpn = vec![ALPN.to_string()];
 
 	let server_sock = handle
@@ -281,7 +281,7 @@ fn configured_roots_verify_the_server() {
 	let handle = worker.handle();
 	let certs = support::certs().expect("certificates");
 
-	let mut server_config = quic::server::Config::new(quic::Identity::new(certs.cert.clone(), certs.key.clone()));
+	let mut server_config = quic::server::Config::new(quic::Identity::open(&certs.cert, &certs.key).expect("identity"));
 	server_config.alpn = vec![ALPN.to_string()];
 
 	let server_sock = handle
@@ -337,7 +337,7 @@ fn required_client_auth_refuses_an_anonymous_client() {
 	let handle = worker.handle();
 	let certs = support::certs().expect("certificates");
 
-	let mut server_config = quic::server::Config::new(quic::Identity::new(certs.cert.clone(), certs.key.clone()));
+	let mut server_config = quic::server::Config::new(quic::Identity::open(&certs.cert, &certs.key).expect("identity"));
 	server_config.alpn = vec![ALPN.to_string()];
 	// Any root will do: the client presents nothing, so it fails before the
 	// chain is ever checked.

--- a/rs/moq-uring/tests/support/quiche.rs
+++ b/rs/moq-uring/tests/support/quiche.rs
@@ -81,6 +81,52 @@ pub fn certs() -> anyhow::Result<Certs> {
 	Ok(Certs { dir, cert, key })
 }
 
+/// A CA-signed server certificate plus a root file holding two CAs, only the
+/// second of which signed it.
+pub struct Bundle {
+	pub dir: tempfile::TempDir,
+	pub cert: std::path::PathBuf,
+	pub key: std::path::PathBuf,
+	/// Both CAs concatenated, in that order.
+	pub roots: std::path::PathBuf,
+}
+
+/// Build one, for a test that a root file is loaded whole rather than to its
+/// first certificate.
+pub fn bundle() -> anyhow::Result<Bundle> {
+	let ca = |name: &str| -> anyhow::Result<rcgen::CertifiedIssuer<'static, rcgen::KeyPair>> {
+		let key = rcgen::KeyPair::generate()?;
+		let mut params = rcgen::CertificateParams::new(Vec::new())?;
+		params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+		params.key_usages = vec![rcgen::KeyUsagePurpose::KeyCertSign, rcgen::KeyUsagePurpose::CrlSign];
+		params.distinguished_name.push(rcgen::DnType::CommonName, name);
+		Ok(rcgen::CertifiedIssuer::self_signed(params, key)?)
+	};
+	let unrelated = ca("moq unrelated ca")?;
+	let signer = ca("moq signing ca")?;
+
+	let key = rcgen::KeyPair::generate()?;
+	let mut params = rcgen::CertificateParams::new(vec!["localhost".into()])?;
+	params.use_authority_key_identifier_extension = true;
+	let cert = params.signed_by(&key, &signer)?;
+
+	let dir = tempfile::tempdir()?;
+	let cert_path = dir.path().join("cert.pem");
+	let key_path = dir.path().join("key.pem");
+	let roots_path = dir.path().join("roots.pem");
+	std::fs::write(&cert_path, cert.pem())?;
+	std::fs::write(&key_path, key.serialize_pem())?;
+	// The signer is second on purpose: reading only the first certificate
+	// leaves the store unable to verify anything this server presents.
+	std::fs::write(&roots_path, format!("{}{}", unrelated.pem(), signer.pem()))?;
+	Ok(Bundle {
+		dir,
+		cert: cert_path,
+		key: key_path,
+		roots: roots_path,
+	})
+}
+
 fn config(certs: Option<&Certs>, alpn: &[&[u8]]) -> anyhow::Result<quiche::Config> {
 	let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION)?;
 	if let Some(certs) = certs {

--- a/rs/moq-uring/tests/web.rs
+++ b/rs/moq-uring/tests/web.rs
@@ -36,7 +36,7 @@ const CLOSE_REASON: &str = "bye";
 
 /// Build the uring server endpoint serving `h3`.
 fn h3_endpoint(handle: &moq_uring::Handle, certs: &support::Certs) -> quic::Endpoint {
-	let mut server = quic::server::Config::new(quic::Identity::new(certs.cert.clone(), certs.key.clone()));
+	let mut server = quic::server::Config::new(quic::Identity::open(&certs.cert, &certs.key).expect("identity"));
 	server.alpn = vec!["h3".to_string()];
 	let sock = handle
 		.udp(UdpSocket::bind("127.0.0.1:0").expect("bind"), udp::Config::default())

--- a/rs/moq-uring/tests/workers.rs
+++ b/rs/moq-uring/tests/workers.rs
@@ -105,7 +105,7 @@ fn a_steered_group_serves_a_shared_port() {
 				let handle = worker.handle();
 				let socket = handle.udp(socket, udp::Config::default()).expect("socket");
 
-				let mut server = quic::server::Config::new(quic::Identity::new(cert, key));
+				let mut server = quic::server::Config::new(quic::Identity::open(cert, key).expect("identity"));
 				server.alpn = vec![ALPN.to_string()];
 				let endpoint = quic::Endpoint::new(
 					&handle,


### PR DESCRIPTION
The relay-side half of the io_uring review backlog. Closes #3097, closes #3108.

Independent of #3110 (the HTTP/3 layer half); both target `dev`.

## The certificate was read once per worker, not once per listener

`Workers::serve` builds each worker's `Endpoint` on the worker thread, and every `Endpoint::new` called `server.quiche()`, which re-read the certificate and key paths. If the files are replaced while the threads are starting, earlier and later workers end up serving different identities, and a client pinning either one fails depending on which worker accepts it. This contradicted the documented single startup read.

`quic::Identity` now holds PEM bytes rather than paths:

- `Identity::open(cert, key)` reads them, `Identity::from_pem` takes bytes already in hand, and `Identity::cert()` hands the chain back for a caller that publishes its fingerprint. There is no way to read the key back out, and `Debug` is hand-written so it cannot land in a log line.
- The old `Identity::new(cert_path, key_path)` is gone rather than repurposed. `&str: Into<Vec<u8>>`, so keeping the name would have let `Identity::new("cert.pem", "key.pem")` compile and treat the path as PEM.
- boring is configured from the bytes (`X509::stack_from_pem` + `PKey::private_key_from_pem`) instead of the file-based setters.

`Workers::bind` reads it once, before it binds a socket, so a bad path is an error there rather than on a worker thread.

## `/certificate.sha256` served nothing

The fingerprints came from either the tokio worker group or the shared server. Under io_uring `workers` is `None` and the shared server is stream-only, so the handle was empty and the endpoint 404'd while the workers were serving a certificate. A client that pins a self-signed relay through that endpoint stopped being able to connect the moment the flag was flipped.

New public constructor `moq_tokio::tls::Certificates::from_pem(chain)`, for a listener outside moq-tokio that serves TLS of its own and has to publish what it serves. Nothing hot reloads through it, which matches how these listeners work: they fix their TLS material when they are built. `Workers::certificates()` exposes it and `Relay::load` takes it from whichever worker group owns QUIC.

`tls::Info` loses its backend `cfg`, so the handle has storage regardless of which QUIC features are on. That also removes the cfg'd double body in `fingerprints()`.

## mTLS was refused, not implemented

`listen.tls.root` was a startup error here so the relay could not claim mTLS it would not enforce, but the capability was simply missing, and a peer mesh could not use this mode at all.

- `listen.tls.root` maps to `ClientAuth::Optional(roots)`, matching the tokio path's `allow_unauthenticated()`: a certificate stands in for a JWT, and a client that presents none still gets the token flow.
- `quic::Connection::peer_chain()` surfaces the validated chain. TLS checked it against the configured roots before the connection existed, so a `Some` is an authenticated peer.
- `moq_tokio::tls::PeerIdentity::from_chain` becomes public so the chain can be turned into the same type `Connection::authenticate` uses.
- `serve_connection` reads it before the handshake consumes the connection, calls `verify_mtls`, and sets `token.expires` from the certificate.

One deliberate difference from the shared path: it takes mTLS only for URL-bearing transports, because its URL-less transports (tcp/unix) have no TLS at all. Here raw QUIC is URL-less but does have a real TLS handshake, so mTLS applies there too, with the path coming from the SETUP. The certificate is the credential either way; the path only says where.

## `--quic-mtu-discovery` honored in name only

`quic::tls` enabled quiche's `discover_pmtu` while pinning both payload sizes to the 1350-byte `SEGMENT`, and the driver only ever hands `conn.send` slices of exactly that, so the ceiling never moved. Making it work means variable-size sends, which the pooled GSO path cannot express without a rewrite, so `quic::Transport::mtu_discovery` is removed rather than left inert. The relay already refuses `quic.mtu_discovery` in this mode and the docs already say so, so nothing changes for an operator; the knob was a lie to every other moq-uring caller.

## Testing

Three regression tests, each verified to fail without its own fix and to pass with it:

- `an_identity_is_read_once` (`rs/moq-uring/tests/endpoint.rs`) deletes the certificate and key from disk, then builds two endpoints from one `Identity` and completes a real handshake against the second. Reverting to per-config reads fails it.
- `uring_workers_publish_their_certificate_fingerprint` (`rs/moq-relay/tests/runtime_uring.rs`) serves `relay.web.routes()` on a local TCP listener and GETs `/certificate.sha256`, asserting it matches SHA-256 over the certificate's DER. Reverting `Relay::load` gives the reported 404.
- `an_mtls_client_authenticates_without_a_token` generates a CA, signs a client certificate with it, and configures the relay with no JWT keys and no public path, so `Auth::verify` refuses every connection. The client publishes on one connection and reads the frame back on another, both authenticated only by the certificate. The assertion is a completed round trip on purpose: an unauthorized session establishes and is *then* closed, so merely connecting proves nothing (an earlier version of this test passed with the mTLS branch disabled, which is how I found that out).

`http_get` is hand-rolled because moq-relay has no HTTP client among its dev dependencies and one GET does not justify adding one.

Run on real io_uring (kernel 6.19 container): `cargo test -p moq-uring` 39 green, `cargo test -p moq-relay --features io-uring --test runtime_uring` 3 green, `cargo clippy -p moq-uring -p moq-relay --features moq-relay/io-uring --all-targets -- -D warnings` clean. Locally: `cargo clippy -p moq-tokio -p moq-relay --all-targets` clean, `moq-tokio` 320 tests and `moq-relay` 263 tests green, `cargo fmt --check` clean.

`just check` and `just test` pass locally too, and CI is green.

The `doc/bin/relay/config.md` update is in this PR per the Cross-Package Sync table: the io_uring section no longer advertises the two gaps, and says what `tls.root` does here instead.

(Written by Claude Opus 5)
