### PR TITLE
feat: build every quiche consumer from the moq-dev/quiche fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1885,7 +1885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2429,7 +2429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2927,7 +2927,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3577,7 +3577,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -4043,7 +4043,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5665,7 +5665,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
@@ -5712,7 +5712,7 @@ checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5759,7 +5759,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6454,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "octets"
 version = "0.3.6"
-source = "git+https://github.com/moq-dev/quiche?rev=2d2c2af7aefdcfc2b2cd08bfd872809459db088e#2d2c2af7aefdcfc2b2cd08bfd872809459db088e"
+source = "git+https://github.com/moq-dev/quiche?rev=55e12064f384aa024a0d340599e1b4485cbfe5a9#55e12064f384aa024a0d340599e1b4485cbfe5a9"
 
 [[package]]
 name = "oid-registry"
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "qlog"
 version = "0.18.0"
-source = "git+https://github.com/moq-dev/quiche?rev=2d2c2af7aefdcfc2b2cd08bfd872809459db088e#2d2c2af7aefdcfc2b2cd08bfd872809459db088e"
+source = "git+https://github.com/moq-dev/quiche?rev=55e12064f384aa024a0d340599e1b4485cbfe5a9#55e12064f384aa024a0d340599e1b4485cbfe5a9"
 dependencies = [
  "flate2",
  "foundations",
@@ -7328,7 +7328,7 @@ dependencies = [
 [[package]]
 name = "quiche"
 version = "0.29.3"
-source = "git+https://github.com/moq-dev/quiche?rev=2d2c2af7aefdcfc2b2cd08bfd872809459db088e#2d2c2af7aefdcfc2b2cd08bfd872809459db088e"
+source = "git+https://github.com/moq-dev/quiche?rev=55e12064f384aa024a0d340599e1b4485cbfe5a9#55e12064f384aa024a0d340599e1b4485cbfe5a9"
 dependencies = [
  "boring",
  "bytes",
@@ -7372,7 +7372,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7414,9 +7414,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7883,7 +7883,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7896,7 +7896,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7955,7 +7955,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8219,7 +8219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8713,7 +8713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9203,10 +9203,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9215,7 +9215,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9955,7 +9955,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10953,7 +10953,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1885,7 +1885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2429,7 +2429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2927,7 +2927,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3577,7 +3577,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4043,7 +4043,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5665,7 +5665,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
@@ -5712,7 +5712,7 @@ checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5759,7 +5759,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6454,8 +6454,7 @@ dependencies = [
 [[package]]
 name = "octets"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866cb5af6f3aa3c1b44c3c2d79d22165fbb1b102e1b3fb499864bfe34736ec4b"
+source = "git+https://github.com/moq-dev/quiche?rev=2d2c2af7aefdcfc2b2cd08bfd872809459db088e#2d2c2af7aefdcfc2b2cd08bfd872809459db088e"
 
 [[package]]
 name = "oid-registry"
@@ -7281,8 +7280,7 @@ dependencies = [
 [[package]]
 name = "qlog"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65c0ae39cba4538fd935d376ba17f858046b386dc4597e3fa5c1aedb919ef30"
+source = "git+https://github.com/moq-dev/quiche?rev=2d2c2af7aefdcfc2b2cd08bfd872809459db088e#2d2c2af7aefdcfc2b2cd08bfd872809459db088e"
 dependencies = [
  "flate2",
  "foundations",
@@ -7330,8 +7328,7 @@ dependencies = [
 [[package]]
 name = "quiche"
 version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61166d27591eb7cb1310eec2b8fc6ae0e0686e9e4ed742a3ffc6317171175e7d"
+source = "git+https://github.com/moq-dev/quiche?rev=2d2c2af7aefdcfc2b2cd08bfd872809459db088e#2d2c2af7aefdcfc2b2cd08bfd872809459db088e"
 dependencies = [
  "boring",
  "bytes",
@@ -7375,7 +7372,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7417,9 +7414,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7886,7 +7883,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7899,7 +7896,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7958,7 +7955,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8222,7 +8219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8716,7 +8713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9206,10 +9203,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9218,7 +9215,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9958,7 +9955,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10956,7 +10953,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,3 +208,14 @@ strip = true
 # workspace copy so exactly one kio is built.
 [patch.crates-io]
 kio = { path = "rs/kio" }
+# Every quiche consumer builds from moq-dev/quiche's `moq` branch: raw sans-IO
+# quiche in moq-uring, and tokio-quiche (external, via web-transport-quiche)
+# compiled against whatever this patch supplies. The fork stays API-compatible
+# with the crates-io release it forks; see its README for the rebase policy.
+# octets and qlog ride along: quiche's git copy path-depends on its in-repo
+# octets/qlog, so without these patches tokio-quiche would compile against the
+# registry octets while quiche's error types use the git one, and the two
+# don't unify.
+quiche = { git = "https://github.com/moq-dev/quiche", rev = "2d2c2af7aefdcfc2b2cd08bfd872809459db088e" }
+octets = { git = "https://github.com/moq-dev/quiche", rev = "2d2c2af7aefdcfc2b2cd08bfd872809459db088e" }
+qlog = { git = "https://github.com/moq-dev/quiche", rev = "2d2c2af7aefdcfc2b2cd08bfd872809459db088e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,6 @@ kio = { path = "rs/kio" }
 # octets/qlog, so without these patches tokio-quiche would compile against the
 # registry octets while quiche's error types use the git one, and the two
 # don't unify.
-quiche = { git = "https://github.com/moq-dev/quiche", rev = "2d2c2af7aefdcfc2b2cd08bfd872809459db088e" }
-octets = { git = "https://github.com/moq-dev/quiche", rev = "2d2c2af7aefdcfc2b2cd08bfd872809459db088e" }
-qlog = { git = "https://github.com/moq-dev/quiche", rev = "2d2c2af7aefdcfc2b2cd08bfd872809459db088e" }
+quiche = { git = "https://github.com/moq-dev/quiche", rev = "55e12064f384aa024a0d340599e1b4485cbfe5a9" }
+octets = { git = "https://github.com/moq-dev/quiche", rev = "55e12064f384aa024a0d340599e1b4485cbfe5a9" }
+qlog = { git = "https://github.com/moq-dev/quiche", rev = "55e12064f384aa024a0d340599e1b4485cbfe5a9" }


### PR DESCRIPTION
Bootstraps the custom-QUIC questline's fork (moq.pro quest/m2/quiche/fork.md): [moq-dev/quiche](https://github.com/moq-dev/quiche) now exists as a maintained fork of cloudflare/quiche, and this PR points the workspace at it.

## What

- `[patch.crates-io]` pins `quiche` to the fork's `moq` branch at one rev. The branch is the upstream `0.29.3` release tag plus fork patches (currently: the README policy, plus upstream's `dc3f7b3b` cherry-pick that fixes tokio-quiche under current nightly).
- `octets` and `qlog` are patched alongside: quiche's git copy path-depends on its in-repo octets/qlog, so without these two patches tokio-quiche compiles against the *registry* octets while the patched quiche's error types use the *git* one, and rustc treats them as different crates (`From<octets::BufferTooShortError>` stops lining up).

## Fork policy (in the fork's README)

- `moq` is the default branch: latest upstream release tag + our patches; `master` mirrors upstream untouched.
- API-compatible with upstream: additive capability only, never a changed signature, so crates built against crates-io quiche (tokio-quiche) build against the fork unchanged.
- Rebase per upstream release, one rebase PR each.
- Upstreaming is opportunistic; nothing waits on cloudflare review.
- CI: upstream's own Stable + Nightly workflows run on the `moq` branch (semgrep dropped; it needs Cloudflare's token).

## Verification

- `cargo tree -i quiche --target x86_64-unknown-linux-gnu --features moq-tokio/quiche` shows exactly the two intended consumers (moq-uring, tokio-quiche→web-transport-quiche→moq-tokio), all on the fork rev.
- `cargo test -p moq-tokio --features quiche,quinn,aws-lc-rs --test backend`: 11 passed, 1 ignored (the pre-existing `quiche_webtransport` teardown ignore).
- moq-uring's suite is Linux-only; CI on this PR is its gate.

Next in the questline: the rustls crypto backend lands in the fork (port of the declined upstream [quiche#2045](https://github.com/cloudflare/quiche/pull/2045), which cloudflare turned down on maintenance grounds), then moq-uring adopts it.

(written by Fable 5)