### PR TITLE
fix(watch): anchor the audio ring so long-running stream indexes don't overflow

### DIFF
--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -525,6 +525,8 @@ describe("i32 wrapping", () => {
 		insert(buffer, startMs + 100, 4410, { channels: 1, value: 0.5 });
 
 		expect(buffer.stalled).toBe(false);
+		// The anchor is preserved, so media time survives the wrap rather than reading negative.
+		expect(buffer.timestamp).toBe(Time.Micro.fromMilli(startMs as Time.Milli));
 		const output = read(buffer, 128, 1);
 		expect(output[0].length).toBe(128);
 		expect(output[0][0]).toBeCloseTo(0.5, 5);

--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -511,6 +511,25 @@ describe("i32 wrapping", () => {
 		}
 	});
 
+	it("plays a stream whose sample index truncates to a negative i32", () => {
+		// Regression: an unanchored index from a long-running stream truncates to a negative
+		// Int32, which pinned WRITE at 0 and left the ring silent forever.
+		const rate = 44100;
+		const buffer = create({ rate, channels: 1, capacity: rate, latency: 4410 });
+
+		// 743975s in: sample 32_809_297_500, negative as an i32.
+		const startMs = 743_975_000;
+		expect(Math.round((startMs / 1000) * rate) | 0).toBeLessThan(0);
+
+		insert(buffer, startMs, 4410, { channels: 1, value: 0.5 });
+		insert(buffer, startMs + 100, 4410, { channels: 1, value: 0.5 });
+
+		expect(buffer.stalled).toBe(false);
+		const output = read(buffer, 128, 1);
+		expect(output[0].length).toBe(128);
+		expect(output[0][0]).toBeCloseTo(0.5, 5);
+	});
+
 	it("should handle slot indexing past capacity boundary", () => {
 		// capacity=10, start at sample 97 → wraps across boundary
 		const buffer = create({ rate: 1000, channels: 1, capacity: 10, latency: 10 });

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -74,6 +74,11 @@ export class SharedRingBuffer {
 	// Whether READ/WRITE have been anchored to the first inserted sample.
 	#anchored = false;
 
+	// Absolute sample index of that first sample. READ/WRITE are stored relative to it, so
+	// `timestamp` adds it back to recover media time. Main-thread only: the worklet reads by
+	// difference and never needs an absolute position.
+	#anchor = 0;
+
 	constructor(init: SharedRingBufferInit) {
 		this.channels = init.channels;
 		this.capacity = init.capacity;
@@ -102,14 +107,19 @@ export class SharedRingBuffer {
 		let offset = 0;
 
 		// Anchor to the first sample so playback starts at its timestamp rather than gap-filling
-		// from index 0. Also keeps the indices small: READ/WRITE are Int32, so an absolute sample
-		// index wraps after ~13.5h at 44.1kHz, and a negative one pins WRITE at 0 so the ring
-		// never un-stalls.
+		// from index 0.
 		if (!this.#anchored) {
-			Atomics.store(this.#control, READ, start | 0);
-			Atomics.store(this.#control, WRITE, start | 0);
+			this.#anchor = start;
+			Atomics.store(this.#control, READ, 0);
+			Atomics.store(this.#control, WRITE, 0);
 			this.#anchored = true;
 		}
+
+		// Positions are relative to the anchor. READ/WRITE are Int32, so an absolute sample index
+		// overflows on a stream that has been broadcasting a while, and a negative one pins WRITE
+		// at 0 so the ring never un-stalls. Relative positions instead start at 0, which leaves
+		// the ~13.5h at 44.1kHz to a single continuous playback session.
+		start = (start - this.#anchor) | 0;
 
 		const end = (start + originalLength) | 0;
 
@@ -219,7 +229,7 @@ export class SharedRingBuffer {
 	 * track wrote beyond them would otherwise still play once the successor runs out.
 	 */
 	truncate(timestamp: Time.Micro): void {
-		const target = Math.round(Time.Second.fromMicro(timestamp) * this.rate) | 0;
+		const target = (Math.round(Time.Second.fromMicro(timestamp) * this.rate) - this.#anchor) | 0;
 		for (;;) {
 			const write = Atomics.load(this.#control, WRITE);
 			if (((write - target) | 0) <= 0) return; // nothing buffered past the new timeline
@@ -261,6 +271,7 @@ export class SharedRingBuffer {
 		const init = allocSharedRingBuffer(this.channels, newCapacity, this.rate, this.buffered);
 		const dst = new SharedRingBuffer(init);
 		dst.#anchored = this.#anchored;
+		dst.#anchor = this.#anchor;
 
 		const read = Atomics.load(this.#control, READ);
 		const write = Atomics.load(this.#control, WRITE);
@@ -291,7 +302,7 @@ export class SharedRingBuffer {
 	/** Current playback timestamp derived from READ position. */
 	get timestamp(): Time.Micro {
 		const read = Atomics.load(this.#control, READ);
-		return Time.Micro.fromSecond((read / this.rate) as Time.Second);
+		return Time.Micro.fromSecond(((this.#anchor + read) / this.rate) as Time.Second);
 	}
 
 	/** Whether the buffer is stalled (waiting to fill). */

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -71,7 +71,7 @@ export class SharedRingBuffer {
 	#control: Int32Array;
 	#samples: Float32Array[];
 
-	// Whether READ/WRITE have been anchored to the first inserted sample (buffered mode).
+	// Whether READ/WRITE have been anchored to the first inserted sample.
 	#anchored = false;
 
 	constructor(init: SharedRingBufferInit) {
@@ -101,9 +101,11 @@ export class SharedRingBuffer {
 		const originalLength = data[0].length;
 		let offset = 0;
 
-		// Buffered mode: anchor READ/WRITE to the first sample so playback starts at its
-		// timestamp, instead of skipping ahead or gap-filling silence from index 0.
-		if (this.buffered && !this.#anchored) {
+		// Anchor to the first sample so playback starts at its timestamp rather than gap-filling
+		// from index 0. Also keeps the indices small: READ/WRITE are Int32, so an absolute sample
+		// index wraps after ~13.5h at 44.1kHz, and a negative one pins WRITE at 0 so the ring
+		// never un-stalls.
+		if (!this.#anchored) {
 			Atomics.store(this.#control, READ, start | 0);
 			Atomics.store(this.#control, WRITE, start | 0);
 			this.#anchored = true;


### PR DESCRIPTION
## Summary

Audio is currently silent on web players using `SharedArrayBuffer`, for streams that have been broadcasting a long time. The audio ring buffer tracks its read and write positions as i32, which overflow on a long-running stream. As a negative write position never reads as ahead of the read position, the buffer thinks it has nothing to play and outputs silence.

The counter wraps every ~27 hours and is negative for half of that, so playback alternates between broken and fine in ~13.5 hour windows.

The fix anchors read and write positions to the first sample the buffer receives, so they stay small and
relative instead of tracking absolute media time.

This has a small side effect to be aware of: live playback now starts once the latency floor is buffered, where before it started only when the ring was completely full. I don't expect it to be an issue.

## Public API changes

None. `SharedRingBuffer` is internal to `@moq/watch` and not exported from the package.

## Test plan

- New regression test for a sample index that truncates to a negative 32-bit value; confirmed it
  fails without the fix and passes with it.
- `just check`, `just test`.
- Chrome and Firefox against `cdn.moq.pro/demo` with COOP/COEP set on the dev server: Big Buck Bunny had silent audio before, and is audible after.

(Co-written by Opus 5)
