### PR TITLE
fix(moq-gst): keep one rendition's subscribe off the catalog loop

### DIFF
--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -337,7 +337,10 @@ struct ActiveTrack {
 impl ActiveTrack {
 	/// Tear the pump down whatever stage it reached: one still subscribing never takes a pad,
 	/// one that has drops it when it sees the watch.
-	fn cancel(&self) {
+	///
+	/// Terminal, so it consumes the handle: a cancelled rendition is removed from the session's
+	/// active set, and respawns as a fresh pump if the catalog names it again.
+	fn cancel(self) {
 		self.state.cancel_before_live();
 		let _ = self.cancel.send(true);
 	}
@@ -1121,7 +1124,9 @@ mod session_tests {
 			guard.video.renditions.clear();
 		}
 
-		// Only now answer it. The pump was torn down, so nothing may reach a pad.
+		// Only now answer it. The pump was torn down, so nothing may reach a pad. Proving a pad
+		// never appears has no edge to wait on, unlike `await_pad`, so this gives the runtime a
+		// window in which the un-cancelled version reliably creates one.
 		let _serving = request.accept(moq_net::track::Info::default());
 		std::thread::sleep(Duration::from_millis(500));
 		assert!(pads(&element, "video_").is_empty(), "a cancelled pump still took a pad");

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
@@ -287,6 +287,38 @@ struct Shape {
 	container: hang::catalog::Container,
 }
 
+/// A pump's progress, shared with its [`ActiveTrack`] so teardown and pad creation can't both
+/// win. A pump is torn down two different ways depending on how far it got: before it owns a pad,
+/// stopping it means it must never create one; after, it owns a pad and has to drop it. One
+/// compare-exchange settles which of the two happened, so a pad can't slip out between a
+/// teardown's check and the pump's creation.
+struct PumpState(AtomicU8);
+
+impl PumpState {
+	const SUBSCRIBING: u8 = 0;
+	const LIVE: u8 = 1;
+	const CANCELLED: u8 = 2;
+
+	fn new() -> Self {
+		Self(AtomicU8::new(Self::SUBSCRIBING))
+	}
+
+	/// Claim the right to create a pad, false once a teardown got here first.
+	fn go_live(&self) -> bool {
+		self.0
+			.compare_exchange(Self::SUBSCRIBING, Self::LIVE, Ordering::AcqRel, Ordering::Acquire)
+			.is_ok()
+	}
+
+	/// Stop a pump that hasn't taken a pad, false if it already has one and must be torn down
+	/// through its cancel watch instead.
+	fn cancel_before_live(&self) -> bool {
+		self.0
+			.compare_exchange(Self::SUBSCRIBING, Self::CANCELLED, Ordering::AcqRel, Ordering::Acquire)
+			.is_ok()
+	}
+}
+
 /// A rendition we're currently serving, keyed in the session by moq track name.
 struct ActiveTrack {
 	/// Identity we diff against on each catalog update; a change recreates the pad.
@@ -298,9 +330,25 @@ struct ActiveTrack {
 	/// `is_finished()` to prune this entry once the pump ends (the `JoinSet` owns
 	/// the task and reaps it); teardown goes through `cancel`, never `abort()`.
 	task: tokio::task::AbortHandle,
-	/// Set by the pump once it owns a pad. Until then it is still awaiting its subscription,
-	/// which is the one state a closing catalog has to break it out of.
-	live: Arc<AtomicBool>,
+	/// Shared with the pump, so teardown and pad creation agree on which of them happened.
+	state: Arc<PumpState>,
+}
+
+impl ActiveTrack {
+	/// Tear the pump down whatever stage it reached: one still subscribing never takes a pad,
+	/// one that has drops it when it sees the watch.
+	fn cancel(&self) {
+		self.state.cancel_before_live();
+		let _ = self.cancel.send(true);
+	}
+
+	/// Tear the pump down only if it is still waiting on its subscription, leaving a streaming
+	/// one to reach its own EOS.
+	fn cancel_if_subscribing(&self) {
+		if self.state.cancel_before_live() {
+			let _ = self.cancel.send(true);
+		}
+	}
 }
 
 async fn run_session(
@@ -384,9 +432,7 @@ async fn follow_catalog(
 					None => {
 						catalog_closed = true;
 						for track in active.values() {
-							if !track.live.load(Ordering::Relaxed) {
-								let _ = track.cancel.send(true);
-							}
+							track.cancel_if_subscribing();
 						}
 					}
 				}
@@ -399,7 +445,7 @@ async fn follow_catalog(
 	// while we await the rest.
 	// On the clean catalog-closed exit `active`/`pumps` are already drained, so this is a no-op.
 	for (_, track) in active.drain() {
-		let _ = track.cancel.send(true);
+		track.cancel();
 	}
 	while pumps.join_next().await.is_some() {}
 
@@ -461,7 +507,7 @@ fn reconcile(
 	// Changed renditions also land in `plan.add`, so they respawn below under a fresh pad id.
 	for name in plan.remove {
 		if let Some(track) = active.remove(&name) {
-			let _ = track.cancel.send(true);
+			track.cancel();
 		}
 	}
 
@@ -492,7 +538,7 @@ fn reconcile(
 		};
 
 		let (cancel_tx, cancel_rx) = watch::channel(false);
-		let live = Arc::new(AtomicBool::new(false));
+		let state = Arc::new(PumpState::new());
 		let task = pumps.spawn_on(
 			Pump {
 				element: element.clone(),
@@ -501,7 +547,7 @@ fn reconcile(
 				caps: d.shape.caps.clone(),
 				track,
 				container,
-				live: live.clone(),
+				state: state.clone(),
 				cancel: cancel_rx,
 			}
 			.run(),
@@ -514,7 +560,7 @@ fn reconcile(
 				shape: d.shape.clone(),
 				cancel: cancel_tx,
 				task,
-				live,
+				state,
 			},
 		);
 	}
@@ -585,8 +631,8 @@ struct Pump {
 	caps: gst::Caps,
 	track: moq_net::track::Consumer,
 	container: moq_mux::catalog::hang::Container,
-	/// Shared with this rendition's [`ActiveTrack::live`].
-	live: Arc<AtomicBool>,
+	/// Shared with this rendition's [`ActiveTrack::state`].
+	state: Arc<PumpState>,
 	cancel: watch::Receiver<bool>,
 }
 
@@ -602,7 +648,7 @@ impl Pump {
 			caps,
 			track,
 			container,
-			live,
+			state,
 			mut cancel,
 		} = self;
 		// Resolves once the publisher answers with the track info. A catalog can name a track its
@@ -621,10 +667,12 @@ impl Pump {
 		};
 		let mut track = moq_mux::container::Consumer::new(subscriber, container).with_latency(Duration::from_secs(1));
 
-		// `select!` polls its ready branches in random order, so a cancel that landed while the
-		// subscription was resolving can lose that race. Re-read it before taking a pad: a
-		// rendition reconcile has already removed or reshaped must never publish one.
-		if *cancel.borrow() {
+		// Winning this is what earns a pad. Losing means a teardown got here while the
+		// subscription was still resolving (this rendition was removed, reshaped, or outlived by
+		// a closing catalog), and it must not publish a pad at all: the watch alone can't say
+		// that, since a cancel landing just after we read it would leave a pad exposed and then
+		// yanked without an EOS.
+		if !state.go_live() {
 			return;
 		}
 
@@ -635,7 +683,6 @@ impl Pump {
 		let Some(pad) = create_pad(&element, &descriptor, &caps) else {
 			return;
 		};
-		live.store(true, Ordering::Relaxed);
 
 		let mut reference_ts = None;
 		loop {
@@ -955,6 +1002,15 @@ mod session_tests {
 			.collect()
 	}
 
+	/// Block until a consumer asks the broadcast for a track, returning the request unanswered so
+	/// its subscriber stays parked. Bounded so a session that never subscribes fails the test.
+	fn await_request(dynamic: &mut moq_net::broadcast::Dynamic) -> moq_net::track::Request {
+		super::RUNTIME
+			.block_on(async { tokio::time::timeout(Duration::from_secs(10), dynamic.requested_track()).await })
+			.expect("no track was ever requested")
+			.expect("broadcast closed")
+	}
+
 	/// Poll for a pad rather than sleeping a fixed beat: the pumps run on another runtime, so
 	/// the only ordering we have is "eventually". Fails the test if it never shows up.
 	fn await_pad(element: &super::super::MoqSrc, kind: &str) -> gst::Pad {
@@ -979,7 +1035,7 @@ mod session_tests {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		// A live handler is what makes an unserved name park rather than resolve `NotFound`,
 		// which is how it behaves over the wire: the publisher just never answers.
-		let _dynamic = broadcast.dynamic();
+		let mut dynamic = broadcast.dynamic();
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		// First update announces audio only, and no producer ever answers for it.
@@ -992,6 +1048,13 @@ mod session_tests {
 		let consumer = broadcast.consume();
 		let weak = element.downgrade();
 		let session = super::RUNTIME.spawn(async move { follow_catalog(consumer, weak, &mut shutdown_rx).await });
+
+		// Wait for the audio subscription before announcing video, and hold the request
+		// unanswered. A catalog consumer skips to the newest snapshot, so without this the
+		// session could read one update carrying both renditions, and then whether it reached
+		// video before parking on audio would come down to `plan.add` ordering.
+		let pending = await_request(&mut dynamic);
+		assert_eq!(pending.name(), "audio");
 
 		// Second update adds video, backed by a real track so its subscription resolves.
 		let _video = broadcast.create_track("video", None).unwrap();
@@ -1018,21 +1081,21 @@ mod session_tests {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
+		// Both renditions in one snapshot, so the result can't hinge on which update the
+		// session read: with no handler alive, `audio` resolves `NotFound` rather than parking,
+		// and whichever order `plan.add` visits them in, `video` still has to reach a pad and
+		// the session still has to end cleanly.
+		let _video = broadcast.create_track("video", None).unwrap();
 		{
 			let mut guard = catalog.lock();
 			guard.audio.renditions = BTreeMap::from([("audio".to_string(), audio_rendition())]);
+			guard.video.renditions = BTreeMap::from([("video".to_string(), video_rendition())]);
 		}
 
 		let (shutdown, mut shutdown_rx) = watch::channel(false);
 		let consumer = broadcast.consume();
 		let weak = element.downgrade();
 		let session = super::RUNTIME.spawn(async move { follow_catalog(consumer, weak, &mut shutdown_rx).await });
-
-		let _video = broadcast.create_track("video", None).unwrap();
-		{
-			let mut guard = catalog.lock();
-			guard.video.renditions = BTreeMap::from([("video".to_string(), video_rendition())]);
-		}
 
 		await_pad(&element, "video_");
 
@@ -1073,6 +1136,44 @@ mod session_tests {
 		});
 		ended.expect("session never ended").unwrap();
 		assert!(pads(&element, "video_").is_empty(), "the unserved rendition got a pad");
+	}
+
+	/// A subscription can resolve after its pump was already torn down. The pump has to stay
+	/// dead: exposing a pad at that point publishes a rendition the session has finished with,
+	/// and then yanks it without an EOS.
+	#[test]
+	fn a_subscription_resolving_after_cancellation_creates_no_pad() {
+		let _pad_ids = pad_ids();
+		let element = element();
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let mut dynamic = broadcast.dynamic();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		{
+			let mut guard = catalog.lock();
+			guard.video.renditions = BTreeMap::from([("stalled".to_string(), video_rendition())]);
+		}
+
+		let (_shutdown, mut shutdown_rx) = watch::channel(false);
+		let consumer = broadcast.consume();
+		let weak = element.downgrade();
+		let session = super::RUNTIME.spawn(async move { follow_catalog(consumer, weak, &mut shutdown_rx).await });
+
+		// Hold the subscription pending, then close the catalog so the pump is cancelled while
+		// it is still waiting.
+		let request = await_request(&mut dynamic);
+		catalog.finish().unwrap();
+		super::RUNTIME
+			.block_on(async { tokio::time::timeout(Duration::from_secs(10), session).await })
+			.expect("session never ended")
+			.unwrap()
+			.unwrap();
+
+		// Only now answer it. The pump is gone, so nothing may reach a pad.
+		let _serving = request.accept(moq_net::track::Info::default());
+		std::thread::sleep(Duration::from_millis(200));
+		assert!(pads(&element, "video_").is_empty(), "a cancelled pump still took a pad");
 	}
 
 	/// Pipelines link `moqsrc`'s pads by name, so the first video rendition that actually

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{LazyLock, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -29,6 +29,10 @@ static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
 /// made the first pad's number depend on catalog arrival order (audio could claim `0`),
 /// silently breaking those pipelines. Counters only ever increment, so a mid-stream reshape
 /// still gets a fresh, collision-free id.
+///
+/// An id is claimed where the pad is created, not where its pump is spawned. A rendition whose
+/// subscription never resolves therefore reserves nothing, so it can't leave `video_0` pointing
+/// at a pad that will never exist while the rendition that does arrive lands on `video_1`.
 static NEXT_VIDEO_PAD_ID: AtomicU64 = AtomicU64::new(0);
 static NEXT_AUDIO_PAD_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -78,7 +82,7 @@ impl TrackKind {
 }
 
 /// The session task drives everything: it connects, follows the catalog, and
-/// runs one [pump](run_pump) per active rendition. The element just starts and
+/// runs one [`Pump`] per active rendition. The element just starts and
 /// stops it. No control-plane channel is needed because pumps push to their pads
 /// directly from their own task (a source pad's push *is* its streaming thread),
 /// so there's nothing to marshal back onto the element.
@@ -294,6 +298,9 @@ struct ActiveTrack {
 	/// `is_finished()` to prune this entry once the pump ends (the `JoinSet` owns
 	/// the task and reaps it); teardown goes through `cancel`, never `abort()`.
 	task: tokio::task::AbortHandle,
+	/// Set by the pump once it owns a pad. Until then it is still awaiting its subscription,
+	/// which is the one state a closing catalog has to break it out of.
+	live: Arc<AtomicBool>,
 }
 
 async fn run_session(
@@ -322,7 +329,7 @@ async fn run_session(
 	follow_catalog(broadcast, element, shutdown).await
 }
 
-/// Follow the broadcast's catalog for the whole session, keeping one [pump](run_pump) per
+/// Follow the broadcast's catalog for the whole session, keeping one [`Pump`] per
 /// announced rendition in sync with it. Returns once the catalog closes and the last pump
 /// drains, or `shutdown` fires.
 async fn follow_catalog(
@@ -365,10 +372,23 @@ async fn follow_catalog(
 			next = catalog_consumer.next(), if !catalog_closed => {
 				match next? {
 					Some(catalog) => reconcile(&catalog, &mut active, &mut pumps, &broadcast, &element),
-					// Catalog track closed. Don't cancel the pumps: let each reach its
-					// natural Ok(None) -> EOS end so downstream sees a clean EOS rather than a
-					// bare pad drop. We just stop reconciling and wait for them to drain.
-					None => catalog_closed = true,
+					// Catalog track closed. Don't cancel the streaming pumps: let each reach
+					// its natural Ok(None) -> EOS end so downstream sees a clean EOS rather
+					// than a bare pad drop. We just stop reconciling and wait for them to
+					// drain.
+					//
+					// A pump still awaiting its subscription is the exception. No further
+					// catalog update can arrive to release it and the publisher has stopped
+					// describing the broadcast, so it would park forever and hold the session
+					// open with it. It has no pad, so there is no EOS for downstream to miss.
+					None => {
+						catalog_closed = true;
+						for track in active.values() {
+							if !track.live.load(Ordering::Relaxed) {
+								let _ = track.cancel.send(true);
+							}
+						}
+					}
 				}
 			}
 		}
@@ -458,12 +478,6 @@ fn reconcile(
 			}
 		};
 
-		let id = match d.kind {
-			TrackKind::Video => &NEXT_VIDEO_PAD_ID,
-			TrackKind::Audio => &NEXT_AUDIO_PAD_ID,
-		}
-		.fetch_add(1, Ordering::Relaxed);
-
 		// Only the handle is resolved here; the pump awaits the subscription itself. That wait
 		// ends when the publisher answers with the track info, which for a rendition nobody
 		// serves is never, so doing it here would park the catalog loop and leave every other
@@ -477,21 +491,20 @@ fn reconcile(
 			}
 		};
 
-		let descriptor = TrackDescriptor {
-			kind: d.kind,
-			name: name.clone(),
-			id,
-		};
 		let (cancel_tx, cancel_rx) = watch::channel(false);
+		let live = Arc::new(AtomicBool::new(false));
 		let task = pumps.spawn_on(
-			run_pump(
-				element.clone(),
-				descriptor,
-				d.shape.caps.clone(),
+			Pump {
+				element: element.clone(),
+				kind: d.kind,
+				name: name.clone(),
+				caps: d.shape.caps.clone(),
 				track,
 				container,
-				cancel_rx,
-			),
+				live: live.clone(),
+				cancel: cancel_rx,
+			}
+			.run(),
 			RUNTIME.handle(),
 		);
 
@@ -501,6 +514,7 @@ fn reconcile(
 				shape: d.shape.clone(),
 				cancel: cancel_tx,
 				task,
+				live,
 			},
 		);
 	}
@@ -532,8 +546,9 @@ fn plan_reconcile<S: PartialEq>(desired: &HashMap<String, S>, active: &HashMap<S
 /// per-kind, process-unique counter (matching the `%u` templates) rather than after
 /// the track name, so a rendition can be torn down and recreated (when its
 /// codec/resolution changes mid-stream) without two pads ever sharing a name. The
-/// first pad of each kind is `video_0` / `audio_0`, so `gst-launch` can link them by
-/// name regardless of which rendition the catalog announces first.
+/// first *live* pad of each kind is `video_0` / `audio_0`, so `gst-launch` can link them by
+/// name regardless of which rendition the catalog announces first, or how many it announces
+/// that never arrive.
 struct TrackDescriptor {
 	kind: TrackKind,
 	name: String,
@@ -541,6 +556,17 @@ struct TrackDescriptor {
 }
 
 impl TrackDescriptor {
+	/// Claim the next id of this kind, naming the pad about to be created.
+	fn claim(kind: TrackKind, name: String) -> Self {
+		let id = match kind {
+			TrackKind::Video => &NEXT_VIDEO_PAD_ID,
+			TrackKind::Audio => &NEXT_AUDIO_PAD_ID,
+		}
+		.fetch_add(1, Ordering::Relaxed);
+
+		Self { kind, name, id }
+	}
+
 	fn pad_name(&self) -> String {
 		match self.kind {
 			TrackKind::Video => format!("video_{}", self.id),
@@ -549,70 +575,100 @@ impl TrackDescriptor {
 	}
 }
 
-/// Subscribes to one track, then reads its frames and pushes them to a pad it owns for the rest
-/// of its lifetime: it creates the pad, streams buffers, and removes the pad on exit. Runs until
-/// the track ends (EOS), errors, or `cancel` fires.
-async fn run_pump(
+/// One rendition's pump: everything [`reconcile`] hands a task it spawns.
+struct Pump {
 	element: glib::WeakRef<super::MoqSrc>,
-	descriptor: TrackDescriptor,
+	kind: TrackKind,
+	/// The moq track name, which is also the pad's stream id. The pad's own name comes from
+	/// [`TrackDescriptor`] instead, and isn't known until the subscription resolves.
+	name: String,
 	caps: gst::Caps,
 	track: moq_net::track::Consumer,
 	container: moq_mux::catalog::hang::Container,
-	mut cancel: watch::Receiver<bool>,
-) {
-	// Resolves once the publisher answers with the track info. A catalog can name a track its
-	// publisher never serves, so this can wait forever; racing `cancel` keeps such a pump
-	// reapable, and holding the wait here rather than in `reconcile` keeps it off every other
-	// rendition.
-	let subscriber = tokio::select! {
-		_ = cancel.changed() => return,
-		subscriber = track.subscribe(None) => match subscriber {
-			Ok(subscriber) => subscriber,
-			Err(err) => {
-				gst::warning!(CAT, "track {} failed to subscribe: {err:?}", descriptor.name);
-				return;
+	/// Shared with this rendition's [`ActiveTrack::live`].
+	live: Arc<AtomicBool>,
+	cancel: watch::Receiver<bool>,
+}
+
+impl Pump {
+	/// Subscribe to the track, then read its frames and push them to a pad owned for the rest of
+	/// this pump's lifetime: create the pad, stream buffers, and remove the pad on exit. Runs
+	/// until the track ends (EOS), errors, or `cancel` fires.
+	async fn run(self) {
+		let Pump {
+			element,
+			kind,
+			name,
+			caps,
+			track,
+			container,
+			live,
+			mut cancel,
+		} = self;
+		// Resolves once the publisher answers with the track info. A catalog can name a track its
+		// publisher never serves, so this can wait forever; racing `cancel` keeps such a pump
+		// reapable, and holding the wait here rather than in `reconcile` keeps it off every other
+		// rendition.
+		let subscriber = tokio::select! {
+			_ = cancel.changed() => return,
+			subscriber = track.subscribe(None) => match subscriber {
+				Ok(subscriber) => subscriber,
+				Err(err) => {
+					gst::warning!(CAT, "track {name} failed to subscribe: {err:?}");
+					return;
+				}
 			}
+		};
+		let mut track = moq_mux::container::Consumer::new(subscriber, container).with_latency(Duration::from_secs(1));
+
+		// `select!` polls its ready branches in random order, so a cancel that landed while the
+		// subscription was resolving can lose that race. Re-read it before taking a pad: a
+		// rendition reconcile has already removed or reshaped must never publish one.
+		if *cancel.borrow() {
+			return;
 		}
-	};
-	let mut track = moq_mux::container::Consumer::new(subscriber, container).with_latency(Duration::from_secs(1));
 
-	// The pad appears only once the track is live, so a pad downstream can link to is a promise
-	// that the rendition is actually flowing.
-	let Some(pad) = create_pad(&element, &descriptor, &caps) else {
-		return;
-	};
+		// The pad appears only once the track is live, so a pad downstream can link to is a promise
+		// that the rendition is actually flowing, and only a rendition that gets this far claims a
+		// pad id.
+		let descriptor = TrackDescriptor::claim(kind, name);
+		let Some(pad) = create_pad(&element, &descriptor, &caps) else {
+			return;
+		};
+		live.store(true, Ordering::Relaxed);
 
-	let mut reference_ts = None;
-	loop {
-		tokio::select! {
-			// This rendition is being torn down (shutdown, or replaced by a catalog update).
-			_ = cancel.changed() => break,
-			frame = track.read() => match frame {
-				Ok(Some(frame)) => {
-					let buffer = build_buffer(frame, &mut reference_ts, descriptor.kind);
-					// pad.push() blocks until downstream accepts the buffer (full queues, a
-					// clock-synced sink). block_in_place hands our sibling tasks to another
-					// worker so a stalled downstream can't pin a runtime thread and starve
-					// the session loop or other pumps.
-					if tokio::task::block_in_place(|| pad.push(buffer)).is_err() {
+		let mut reference_ts = None;
+		loop {
+			tokio::select! {
+				// This rendition is being torn down (shutdown, or replaced by a catalog update).
+				_ = cancel.changed() => break,
+				frame = track.read() => match frame {
+					Ok(Some(frame)) => {
+						let buffer = build_buffer(frame, &mut reference_ts, descriptor.kind);
+						// pad.push() blocks until downstream accepts the buffer (full queues, a
+						// clock-synced sink). block_in_place hands our sibling tasks to another
+						// worker so a stalled downstream can't pin a runtime thread and starve
+						// the session loop or other pumps.
+						if tokio::task::block_in_place(|| pad.push(buffer)).is_err() {
+							break;
+						}
+					}
+					Ok(None) => {
+						let _ = tokio::task::block_in_place(|| pad.push_event(gst::event::Eos::builder().build()));
+						break;
+					}
+					Err(err) => {
+						gst::warning!(CAT, "track {} failed: {err:?}", descriptor.name);
 						break;
 					}
 				}
-				Ok(None) => {
-					let _ = tokio::task::block_in_place(|| pad.push_event(gst::event::Eos::builder().build()));
-					break;
-				}
-				Err(err) => {
-					gst::warning!(CAT, "track {} failed: {err:?}", descriptor.name);
-					break;
-				}
 			}
 		}
-	}
 
-	let _ = pad.set_active(false);
-	if let Some(obj) = element.upgrade() {
-		let _ = obj.remove_pad(&pad);
+		let _ = pad.set_active(false);
+		if let Some(obj) = element.upgrade() {
+			let _ = obj.remove_pad(&pad);
+		}
 	}
 }
 
@@ -846,6 +902,8 @@ mod tests {
 #[cfg(test)]
 mod session_tests {
 	use std::collections::BTreeMap;
+	use std::sync::Mutex;
+	use std::sync::atomic::Ordering;
 	use std::time::Duration;
 
 	use gst::glib;
@@ -853,7 +911,16 @@ mod session_tests {
 	use hang::catalog::{AudioCodec, AudioConfig, Container, H264, VideoConfig};
 	use tokio::sync::watch;
 
-	use super::follow_catalog;
+	use super::{NEXT_VIDEO_PAD_ID, follow_catalog};
+
+	/// The pad-id counters are process-global, so a test reading one has to be the only test
+	/// allocating while it runs. `cargo test` shares a process across tests (nextest doesn't),
+	/// and a panic elsewhere shouldn't cascade, hence the poison recovery.
+	static PAD_IDS: Mutex<()> = Mutex::new(());
+
+	fn pad_ids() -> std::sync::MutexGuard<'static, ()> {
+		PAD_IDS.lock().unwrap_or_else(|err| err.into_inner())
+	}
 
 	/// The pumps push from their own tasks, so the element only has to exist and own pads.
 	fn element() -> super::super::MoqSrc {
@@ -906,6 +973,7 @@ mod session_tests {
 	/// updates that announce them.
 	#[test]
 	fn a_rendition_nobody_serves_does_not_block_the_others() {
+		let _pad_ids = pad_ids();
 		let element = element();
 
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
@@ -944,6 +1012,7 @@ mod session_tests {
 	/// serve it) rather than one that merely never answers.
 	#[test]
 	fn a_refused_rendition_does_not_end_the_session() {
+		let _pad_ids = pad_ids();
 		let element = element();
 
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
@@ -966,6 +1035,84 @@ mod session_tests {
 		}
 
 		await_pad(&element, "video_");
+
+		let _ = shutdown.send(true);
+		super::RUNTIME.block_on(session).unwrap().unwrap();
+	}
+
+	/// A publisher can finish its catalog while a rendition it announced was never served. The
+	/// pump awaiting that subscription can no longer be released by a catalog update, so the
+	/// session has to break it out rather than wait on it forever.
+	#[test]
+	fn a_closing_catalog_releases_a_pump_still_subscribing() {
+		let _pad_ids = pad_ids();
+		let element = element();
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let _dynamic = broadcast.dynamic();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		{
+			let mut guard = catalog.lock();
+			guard.video.renditions = BTreeMap::from([("stalled".to_string(), video_rendition())]);
+		}
+		catalog.finish().unwrap();
+
+		let (_shutdown, mut shutdown_rx) = watch::channel(false);
+		let consumer = broadcast.consume();
+		let weak = element.downgrade();
+
+		// The session must end on the catalog closing alone. Shutdown is never signalled, so a
+		// pump left parked on its subscription hangs this instead of failing it.
+		let ended = super::RUNTIME.block_on(async move {
+			tokio::time::timeout(
+				Duration::from_secs(10),
+				follow_catalog(consumer, weak, &mut shutdown_rx),
+			)
+			.await
+		});
+		ended.expect("session never ended").unwrap();
+		assert!(pads(&element, "video_").is_empty(), "the unserved rendition got a pad");
+	}
+
+	/// Pipelines link `moqsrc`'s pads by name, so the first video rendition that actually
+	/// arrives has to be `video_0`. A rendition announced but never served must not claim that
+	/// name and leave the real one on `video_1`, where `s.video_0 ! ...` never links.
+	#[test]
+	fn an_unserved_rendition_does_not_claim_the_first_pad_name() {
+		let _pad_ids = pad_ids();
+		let element = element();
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let _dynamic = broadcast.dynamic();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		// A video rendition nobody serves, alongside an audio one that arrives. The audio pad
+		// is the signal that this update was reconciled, so the second update below is a
+		// separate one and the stalled rendition had its chance to claim an id first.
+		let _audio = broadcast.create_track("audio", None).unwrap();
+		{
+			let mut guard = catalog.lock();
+			guard.video.renditions = BTreeMap::from([("stalled".to_string(), video_rendition())]);
+			guard.audio.renditions = BTreeMap::from([("audio".to_string(), audio_rendition())]);
+		}
+
+		let first = NEXT_VIDEO_PAD_ID.load(Ordering::Relaxed);
+		let (shutdown, mut shutdown_rx) = watch::channel(false);
+		let consumer = broadcast.consume();
+		let weak = element.downgrade();
+		let session = super::RUNTIME.spawn(async move { follow_catalog(consumer, weak, &mut shutdown_rx).await });
+
+		await_pad(&element, "audio_");
+
+		let _video = broadcast.create_track("video", None).unwrap();
+		{
+			let mut guard = catalog.lock();
+			guard.video.renditions.insert("video".to_string(), video_rendition());
+		}
+
+		let pad = await_pad(&element, "video_");
+		assert_eq!(pad.name(), format!("video_{first}"));
 
 		let _ = shutdown.send(true);
 		super::RUNTIME.block_on(session).unwrap().unwrap();

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -341,14 +341,6 @@ impl ActiveTrack {
 		self.state.cancel_before_live();
 		let _ = self.cancel.send(true);
 	}
-
-	/// Tear the pump down only if it is still waiting on its subscription, leaving a streaming
-	/// one to reach its own EOS.
-	fn cancel_if_subscribing(&self) {
-		if self.state.cancel_before_live() {
-			let _ = self.cancel.send(true);
-		}
-	}
 }
 
 async fn run_session(
@@ -420,21 +412,17 @@ async fn follow_catalog(
 			next = catalog_consumer.next(), if !catalog_closed => {
 				match next? {
 					Some(catalog) => reconcile(&catalog, &mut active, &mut pumps, &broadcast, &element),
-					// Catalog track closed. Don't cancel the streaming pumps: let each reach
-					// its natural Ok(None) -> EOS end so downstream sees a clean EOS rather
-					// than a bare pad drop. We just stop reconciling and wait for them to
-					// drain.
+					// Catalog track closed. Don't cancel the pumps: let each reach its
+					// natural Ok(None) -> EOS end so downstream sees a clean EOS rather than a
+					// bare pad drop. We just stop reconciling and wait for them to drain.
 					//
-					// A pump still awaiting its subscription is the exception. No further
-					// catalog update can arrive to release it and the publisher has stopped
-					// describing the broadcast, so it would park forever and hold the session
-					// open with it. It has no pad, so there is no EOS for downstream to miss.
-					None => {
-						catalog_closed = true;
-						for track in active.values() {
-							track.cancel_if_subscribing();
-						}
-					}
+					// That includes a pump still resolving its subscription, which is
+					// indistinguishable here from one that has simply not been polled yet:
+					// a final snapshot naming a track the publisher does serve arrives this
+					// way, and cancelling on "not live yet" would drop it. A rendition nobody
+					// ever answers therefore keeps the session alive until the broadcast ends
+					// or the element is stopped.
+					None => catalog_closed = true,
 				}
 			}
 		}
@@ -1103,41 +1091,6 @@ mod session_tests {
 		super::RUNTIME.block_on(session).unwrap().unwrap();
 	}
 
-	/// A publisher can finish its catalog while a rendition it announced was never served. The
-	/// pump awaiting that subscription can no longer be released by a catalog update, so the
-	/// session has to break it out rather than wait on it forever.
-	#[test]
-	fn a_closing_catalog_releases_a_pump_still_subscribing() {
-		let _pad_ids = pad_ids();
-		let element = element();
-
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let _dynamic = broadcast.dynamic();
-		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
-
-		{
-			let mut guard = catalog.lock();
-			guard.video.renditions = BTreeMap::from([("stalled".to_string(), video_rendition())]);
-		}
-		catalog.finish().unwrap();
-
-		let (_shutdown, mut shutdown_rx) = watch::channel(false);
-		let consumer = broadcast.consume();
-		let weak = element.downgrade();
-
-		// The session must end on the catalog closing alone. Shutdown is never signalled, so a
-		// pump left parked on its subscription hangs this instead of failing it.
-		let ended = super::RUNTIME.block_on(async move {
-			tokio::time::timeout(
-				Duration::from_secs(10),
-				follow_catalog(consumer, weak, &mut shutdown_rx),
-			)
-			.await
-		});
-		ended.expect("session never ended").unwrap();
-		assert!(pads(&element, "video_").is_empty(), "the unserved rendition got a pad");
-	}
-
 	/// A subscription can resolve after its pump was already torn down. The pump has to stay
 	/// dead: exposing a pad at that point publishes a rendition the session has finished with,
 	/// and then yanks it without an EOS.
@@ -1155,25 +1108,56 @@ mod session_tests {
 			guard.video.renditions = BTreeMap::from([("stalled".to_string(), video_rendition())]);
 		}
 
-		let (_shutdown, mut shutdown_rx) = watch::channel(false);
+		let (shutdown, mut shutdown_rx) = watch::channel(false);
 		let consumer = broadcast.consume();
 		let weak = element.downgrade();
 		let session = super::RUNTIME.spawn(async move { follow_catalog(consumer, weak, &mut shutdown_rx).await });
 
-		// Hold the subscription pending, then close the catalog so the pump is cancelled while
-		// it is still waiting.
+		// Hold the subscription pending, then drop the rendition from the catalog so its pump
+		// is cancelled while it is still waiting.
 		let request = await_request(&mut dynamic);
-		catalog.finish().unwrap();
-		super::RUNTIME
-			.block_on(async { tokio::time::timeout(Duration::from_secs(10), session).await })
-			.expect("session never ended")
-			.unwrap()
-			.unwrap();
+		{
+			let mut guard = catalog.lock();
+			guard.video.renditions.clear();
+		}
 
-		// Only now answer it. The pump is gone, so nothing may reach a pad.
+		// Only now answer it. The pump was torn down, so nothing may reach a pad.
 		let _serving = request.accept(moq_net::track::Info::default());
-		std::thread::sleep(Duration::from_millis(200));
+		std::thread::sleep(Duration::from_millis(500));
 		assert!(pads(&element, "video_").is_empty(), "a cancelled pump still took a pad");
+
+		let _ = shutdown.send(true);
+		super::RUNTIME.block_on(session).unwrap().unwrap();
+	}
+
+	/// A publisher can name its tracks and then finish the catalog, which reaches the session as
+	/// a snapshot immediately followed by the track closing. The renditions that snapshot named
+	/// still have to stream: "hasn't taken a pad yet" says nothing about whether a subscription
+	/// is about to resolve, so a closing catalog must not be read as a reason to drop them.
+	#[test]
+	fn a_closing_catalog_keeps_the_renditions_it_named() {
+		let _pad_ids = pad_ids();
+		let element = element();
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		let _video = broadcast.create_track("video", None).unwrap();
+		{
+			let mut guard = catalog.lock();
+			guard.video.renditions = BTreeMap::from([("video".to_string(), video_rendition())]);
+		}
+		catalog.finish().unwrap();
+
+		let (shutdown, mut shutdown_rx) = watch::channel(false);
+		let consumer = broadcast.consume();
+		let weak = element.downgrade();
+		let session = super::RUNTIME.spawn(async move { follow_catalog(consumer, weak, &mut shutdown_rx).await });
+
+		await_pad(&element, "video_");
+
+		let _ = shutdown.send(true);
+		super::RUNTIME.block_on(session).unwrap().unwrap();
 	}
 
 	/// Pipelines link `moqsrc`'s pads by name, so the first video rendition that actually

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -319,6 +319,17 @@ async fn run_session(
 		_ = shutdown.changed() => return Ok(()),
 	};
 
+	follow_catalog(broadcast, element, shutdown).await
+}
+
+/// Follow the broadcast's catalog for the whole session, keeping one [pump](run_pump) per
+/// announced rendition in sync with it. Returns once the catalog closes and the last pump
+/// drains, or `shutdown` fires.
+async fn follow_catalog(
+	broadcast: moq_net::broadcast::Consumer,
+	element: glib::WeakRef<super::MoqSrc>,
+	shutdown: &mut watch::Receiver<bool>,
+) -> Result<()> {
 	let catalog_track = broadcast
 		.track(hang::catalog::Catalog::DEFAULT_NAME)?
 		.subscribe(hang::catalog::Catalog::default_subscription())
@@ -353,14 +364,7 @@ async fn run_session(
 			// returning None) while we wait for the remaining pumps to drain.
 			next = catalog_consumer.next(), if !catalog_closed => {
 				match next? {
-					// Race reconcile against shutdown. It awaits a per-rendition `subscribe`
-					// that only resolves once track info arrives, so a catalog naming a track
-					// the publisher never accepts would otherwise park here and make the whole
-					// session deaf to shutdown, leaking the connection and pads.
-					Some(catalog) => tokio::select! {
-						result = reconcile(&catalog, &mut active, &mut pumps, &broadcast, &element) => result?,
-						_ = shutdown.changed() => break,
-					},
+					Some(catalog) => reconcile(&catalog, &mut active, &mut pumps, &broadcast, &element),
 					// Catalog track closed. Don't cancel the pumps: let each reach its
 					// natural Ok(None) -> EOS end so downstream sees a clean EOS rather than a
 					// bare pad drop. We just stop reconciling and wait for them to drain.
@@ -370,9 +374,9 @@ async fn run_session(
 		}
 	}
 
-	// Shutdown, including a shutdown that interrupted a reconcile: cancel every pump, then
-	// wait for them all to drop their pads. Cancel all up front (pumps only exit on their own
-	// `cancel`), or the not-yet-cancelled ones would keep streaming while we await the rest.
+	// Shutdown: cancel every pump, then wait for them all to drop their pads. Cancel all up front
+	// (pumps only exit on their own `cancel`), or the not-yet-cancelled ones would keep streaming
+	// while we await the rest.
 	// On the clean catalog-closed exit `active`/`pumps` are already drained, so this is a no-op.
 	for (_, track) in active.drain() {
 		let _ = track.cancel.send(true);
@@ -384,13 +388,17 @@ async fn run_session(
 
 /// Bring the live set of pumps in line with `catalog`: spawn pumps for newly announced
 /// renditions, tear down ones that vanished, and recreate any whose caps or container changed.
-async fn reconcile(
+///
+/// Infallible by design: every way a single rendition can be unusable (unsupported codec,
+/// malformed init, a name the broadcast refuses) skips just that rendition, so one bad entry in
+/// the catalog can never tear down the ones already streaming.
+fn reconcile(
 	catalog: &moq_mux::catalog::hang::Catalog,
 	active: &mut HashMap<String, ActiveTrack>,
 	pumps: &mut tokio::task::JoinSet<()>,
 	broadcast: &moq_net::broadcast::Consumer,
 	element: &glib::WeakRef<super::MoqSrc>,
-) -> Result<()> {
+) {
 	struct Desired {
 		kind: TrackKind,
 		shape: Shape,
@@ -456,8 +464,18 @@ async fn reconcile(
 		}
 		.fetch_add(1, Ordering::Relaxed);
 
-		let track_subscriber = broadcast.track(&name)?.subscribe(None).await?;
-		let track = moq_mux::container::Consumer::new(track_subscriber, container).with_latency(Duration::from_secs(1));
+		// Only the handle is resolved here; the pump awaits the subscription itself. That wait
+		// ends when the publisher answers with the track info, which for a rendition nobody
+		// serves is never, so doing it here would park the catalog loop and leave every other
+		// rendition unstarted. A name the broadcast refuses outright skips just this rendition,
+		// same as an unsupported codec or a malformed init above.
+		let track = match broadcast.track(&name) {
+			Ok(track) => track,
+			Err(err) => {
+				gst::warning!(CAT, "ignoring rendition {name}: {err:?}");
+				continue;
+			}
+		};
 
 		let descriptor = TrackDescriptor {
 			kind: d.kind,
@@ -466,7 +484,14 @@ async fn reconcile(
 		};
 		let (cancel_tx, cancel_rx) = watch::channel(false);
 		let task = pumps.spawn_on(
-			run_pump(element.clone(), descriptor, d.shape.caps.clone(), track, cancel_rx),
+			run_pump(
+				element.clone(),
+				descriptor,
+				d.shape.caps.clone(),
+				track,
+				container,
+				cancel_rx,
+			),
 			RUNTIME.handle(),
 		);
 
@@ -479,8 +504,6 @@ async fn reconcile(
 			},
 		);
 	}
-
-	Ok(())
 }
 
 /// Tear-down / spawn decisions for one catalog update, computed purely from the desired and
@@ -526,16 +549,35 @@ impl TrackDescriptor {
 	}
 }
 
-/// Reads frames from one track and pushes them to a pad it owns for its whole lifetime:
-/// it creates the pad, streams buffers, and removes the pad on exit. Runs until the track
-/// ends (EOS), errors, or `cancel` fires.
+/// Subscribes to one track, then reads its frames and pushes them to a pad it owns for the rest
+/// of its lifetime: it creates the pad, streams buffers, and removes the pad on exit. Runs until
+/// the track ends (EOS), errors, or `cancel` fires.
 async fn run_pump(
 	element: glib::WeakRef<super::MoqSrc>,
 	descriptor: TrackDescriptor,
 	caps: gst::Caps,
-	mut track: moq_mux::container::Consumer<moq_mux::catalog::hang::Container>,
+	track: moq_net::track::Consumer,
+	container: moq_mux::catalog::hang::Container,
 	mut cancel: watch::Receiver<bool>,
 ) {
+	// Resolves once the publisher answers with the track info. A catalog can name a track its
+	// publisher never serves, so this can wait forever; racing `cancel` keeps such a pump
+	// reapable, and holding the wait here rather than in `reconcile` keeps it off every other
+	// rendition.
+	let subscriber = tokio::select! {
+		_ = cancel.changed() => return,
+		subscriber = track.subscribe(None) => match subscriber {
+			Ok(subscriber) => subscriber,
+			Err(err) => {
+				gst::warning!(CAT, "track {} failed to subscribe: {err:?}", descriptor.name);
+				return;
+			}
+		}
+	};
+	let mut track = moq_mux::container::Consumer::new(subscriber, container).with_latency(Duration::from_secs(1));
+
+	// The pad appears only once the track is live, so a pad downstream can link to is a promise
+	// that the rendition is actually flowing.
 	let Some(pad) = create_pad(&element, &descriptor, &caps) else {
 		return;
 	};
@@ -798,5 +840,134 @@ mod tests {
 			relative_pts(Timestamp::from_millis(2500).unwrap(), reference),
 			gst::ClockTime::from_mseconds(500)
 		);
+	}
+}
+
+#[cfg(test)]
+mod session_tests {
+	use std::collections::BTreeMap;
+	use std::time::Duration;
+
+	use gst::glib;
+	use gst::prelude::*;
+	use hang::catalog::{AudioCodec, AudioConfig, Container, H264, VideoConfig};
+	use tokio::sync::watch;
+
+	use super::follow_catalog;
+
+	/// The pumps push from their own tasks, so the element only has to exist and own pads.
+	fn element() -> super::super::MoqSrc {
+		gst::init().unwrap();
+		glib::Object::new()
+	}
+
+	fn video_rendition() -> VideoConfig {
+		let mut config = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0x00,
+			level: 0x1f,
+			inline: false,
+		});
+		config.container = Container::Legacy;
+		config
+	}
+
+	fn audio_rendition() -> AudioConfig {
+		let mut config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		config.container = Container::Legacy;
+		config
+	}
+
+	/// The element's pads of one kind. Matched by prefix because the `%u` suffix comes from a
+	/// process-global counter, so a pad's number depends on what else the test binary has run.
+	fn pads(element: &super::super::MoqSrc, kind: &str) -> Vec<gst::Pad> {
+		element
+			.pads()
+			.into_iter()
+			.filter(|pad| pad.name().starts_with(kind))
+			.collect()
+	}
+
+	/// Poll for a pad rather than sleeping a fixed beat: the pumps run on another runtime, so
+	/// the only ordering we have is "eventually". Fails the test if it never shows up.
+	fn await_pad(element: &super::super::MoqSrc, kind: &str) -> gst::Pad {
+		for _ in 0..100 {
+			if let Some(pad) = pads(element, kind).into_iter().next() {
+				return pad;
+			}
+			std::thread::sleep(Duration::from_millis(50));
+		}
+		panic!("no {kind} pad ever appeared");
+	}
+
+	/// A catalog can name a rendition its publisher never serves: the browser announces audio a
+	/// beat before its video encoder configures, and a subscription only resolves once the track
+	/// info arrives. Such a rendition must not hold up the ones that do arrive, nor the catalog
+	/// updates that announce them.
+	#[test]
+	fn a_rendition_nobody_serves_does_not_block_the_others() {
+		let element = element();
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		// A live handler is what makes an unserved name park rather than resolve `NotFound`,
+		// which is how it behaves over the wire: the publisher just never answers.
+		let _dynamic = broadcast.dynamic();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		// First update announces audio only, and no producer ever answers for it.
+		{
+			let mut guard = catalog.lock();
+			guard.audio.renditions = BTreeMap::from([("audio".to_string(), audio_rendition())]);
+		}
+
+		let (shutdown, mut shutdown_rx) = watch::channel(false);
+		let consumer = broadcast.consume();
+		let weak = element.downgrade();
+		let session = super::RUNTIME.spawn(async move { follow_catalog(consumer, weak, &mut shutdown_rx).await });
+
+		// Second update adds video, backed by a real track so its subscription resolves.
+		let _video = broadcast.create_track("video", None).unwrap();
+		{
+			let mut guard = catalog.lock();
+			guard.video.renditions = BTreeMap::from([("video".to_string(), video_rendition())]);
+		}
+
+		let pad = await_pad(&element, "video_");
+		assert!(pads(&element, "audio_").is_empty(), "the unserved rendition got a pad");
+
+		let _ = shutdown.send(true);
+		super::RUNTIME.block_on(session).unwrap().unwrap();
+		assert!(pad.parent().is_none(), "the pad outlived the session");
+	}
+
+	/// The same isolation for a rendition the broadcast refuses by name (no handler will ever
+	/// serve it) rather than one that merely never answers.
+	#[test]
+	fn a_refused_rendition_does_not_end_the_session() {
+		let element = element();
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		{
+			let mut guard = catalog.lock();
+			guard.audio.renditions = BTreeMap::from([("audio".to_string(), audio_rendition())]);
+		}
+
+		let (shutdown, mut shutdown_rx) = watch::channel(false);
+		let consumer = broadcast.consume();
+		let weak = element.downgrade();
+		let session = super::RUNTIME.spawn(async move { follow_catalog(consumer, weak, &mut shutdown_rx).await });
+
+		let _video = broadcast.create_track("video", None).unwrap();
+		{
+			let mut guard = catalog.lock();
+			guard.video.renditions = BTreeMap::from([("video".to_string(), video_rendition())]);
+		}
+
+		await_pad(&element, "video_");
+
+		let _ = shutdown.send(true);
+		super::RUNTIME.block_on(session).unwrap().unwrap();
 	}
 }

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -415,18 +415,22 @@ run_subscriber() {
             "$C_SMOKE" subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
             ;;
         gst)
-            # moqsrc exposes the broadcast's video as a Sometimes pad (video_%u);
-            # gst-launch links it to filesink once it appears. We grab one byte,
-            # the same "bytes moved" bar as the rust subscriber (no decode). head
-            # closing the pipe SIGPIPEs gst-launch, so success returns at once; no
-            # data just runs out the timeout. Our plugin dir rides on top of the
-            # system path (which provides filesink); a private registry keeps the
-            # scan off the user's cache. buffer-mode=2 makes filesink unbuffered so
-            # the first frame reaches head immediately.
+            # moqsrc exposes each rendition as a Sometimes pad (video_%u / audio_%u),
+            # named so the first of each kind is always video_0 / audio_0. Link
+            # video_0 by name: a bare `moqsrc ! filesink` would take whichever pad
+            # appears first, so a publisher with audio (the browser) could pass this
+            # cell on audio bytes without video ever flowing. We grab one byte, the
+            # same "bytes moved" bar as the rust subscriber (no decode). head closing
+            # the pipe SIGPIPEs gst-launch, so success returns at once; no data just
+            # runs out the timeout. Our plugin dir rides on top of the system path
+            # (which provides filesink); a private registry keeps the scan off the
+            # user's cache. buffer-mode=2 makes filesink unbuffered so the first frame
+            # reaches head immediately.
             local n
             n=$(GST_PLUGIN_PATH_1_0="$GST_PLUGIN_DIR" GST_REGISTRY_1_0="$TMP/gst-run-registry.bin" \
                 timeout -k 3 "$TIMEOUT" gst-launch-1.0 -q \
-                moqsrc url="$URL" broadcast="$broadcast" ! filesink location=/dev/stdout buffer-mode=2 \
+                moqsrc name=s url="$URL" broadcast="$broadcast" \
+                s.video_0 ! filesink location=/dev/stdout buffer-mode=2 \
                 2>/dev/null | head -c 1 | wc -c | tr -d ' ' || true)
             [[ "${n:-0}" -ge 1 ]]
             ;;
@@ -471,7 +475,20 @@ run_round() {
             overall=1
             continue
         fi
-        (run_subscriber "$sub" "$broadcast" "$pub") >"$TMP/$pub-$sub.log" 2>&1 &
+        # Record how long each cell took. Every subscriber shares one budget, so the
+        # spread is the diagnostic: a cell that burns the whole timeout while its
+        # siblings finish in a couple of seconds is stalled, not merely slow, and one
+        # creeping up on $TIMEOUT is a near-miss worth seeing before it fails.
+        (
+            started=$SECONDS
+            # `|| status=$?` rather than a bare call: under `set -e` a failing subscriber
+            # would exit the subshell before it recorded anything, and a failure is exactly
+            # when the duration is worth reading.
+            status=0
+            run_subscriber "$sub" "$broadcast" "$pub" || status=$?
+            echo "$((SECONDS - started))" >"$TMP/$pub-$sub.secs"
+            exit "$status"
+        ) >"$TMP/$pub-$sub.log" 2>&1 &
         pids+=("$!")
         names+=("$sub")
     done
@@ -481,17 +498,18 @@ run_round() {
         echo "  WARN  publisher '$pub' exited early:"
         sed 's/^/        /' "$TMP/pub-$pub.log" 2>/dev/null || true
     fi
-    local want_pass=1 got round_pass=0
+    local want_pass=1 got round_pass=0 elapsed
     [[ "$NEGATIVE" -eq 1 ]] && want_pass=0
     # ${arr[@]+...} guard: a round may have no live subscribers (all broken),
     # and bash 3.2 (macOS) errors on "${!pids[@]}" for an empty array under `set -u`.
     for i in ${pids[@]+"${!pids[@]}"}; do
         if wait "${pids[$i]}"; then got=1; else got=0; fi
+        elapsed=$(cat "$TMP/$pub-${names[$i]}.secs" 2>/dev/null || echo "?")
         if [[ "$got" -eq "$want_pass" ]]; then
-            echo "  PASS  $pub -> ${names[$i]}"
+            echo "  PASS  $pub -> ${names[$i]} (${elapsed}s)"
             round_pass=1
         else
-            echo "  FAIL  $pub -> ${names[$i]}"
+            echo "  FAIL  $pub -> ${names[$i]} (${elapsed}s of ${TIMEOUT}s)"
             sed 's/^/        /' "$TMP/$pub-${names[$i]}.log" 2>/dev/null || true
             overall=1
         fi


### PR DESCRIPTION
## Summary

- **Root cause**: `reconcile` awaited `broadcast.track(name)?.subscribe(None)` serially *inside* the catalog-follow loop. That await resolves only once the track info arrives, so a rendition nobody serves parked the whole loop: no other rendition started and no later catalog update was ever read.
- The browser publisher announces an audio-only catalog a beat before its video encoder configures, so `moqsrc` subscribed `audio`, parked, and never saw the update that added `video`. That is the intermittent `FAIL js -> gst` in the smoke matrix (run [33124111425](https://github.com/moq-dev/moq/actions/runs/33124111425)): the cell burned its full 30s while every other subscriber finished within 4s, and the relay log shows that session subscribing `catalog.json` then `audio` and never `video`.
- `reconcile` is now synchronous and infallible; each pump awaits its own subscription and creates its pad only once the track is live, so a pad downstream can link to is a promise the rendition is flowing.

Everything below came out of review, all the same defect class: one rendition that never arrives must not degrade the ones that do.

- **A rendition the broadcast refuses** propagated out of `reconcile` and ended the session. It now skips just that rendition, matching how an unsupported codec or a malformed init were already handled.
- **Pad ids were claimed when a pump was spawned**, so an unserved video rendition reserved `video_0` and parked while the rendition that arrived became `video_1` — breaking the documented `moqsrc name=s s.video_0 ! ...` link, including the smoke pipeline this PR moves onto it. The id is claimed at pad creation instead.
- **Teardown and pad creation could both win.** A `PumpState` compare-exchange settles `SUBSCRIBING -> LIVE` against `SUBSCRIBING -> CANCELLED`, so a cancel landing mid-subscription can't leave a pad exposed and then yanked without an EOS.
- `run_pump` reached eight arguments, so its inputs moved into a `Pump` struct with a `run` method.

**Harness** (`test/smoke/smoke.sh`), two fixes: `moqsrc ! filesink` linked whichever Sometimes pad appeared first, so an audio-carrying publisher could pass the gst cell on **audio** bytes with video never flowing; it now links `s.video_0` by name, the form `doc/bin/gstreamer.md` and `demo/sub/justfile` already prescribe. Each cell also reports its elapsed seconds, which is what separates a stall from a slow start — the failing run would have read `FAIL js -> gst (30s of 30s)` beside `PASS js -> rust (2s)`.

Deliberately **not** done: no timeout bump and no cell retry. The budget was never the constraint, and a retry would have hidden a bug that also affects anyone pointing `moqsrc` at a browser publisher.

## Public API changes

None. Everything is private to `rs/moq-gst`: `reconcile` (now sync, infallible), the new `follow_catalog` extracted from `run_session`, and `run_pump` becoming `Pump::run`. No pad names, properties, or element behaviour visible to a pipeline changed.

## Test plan

Five hermetic regression tests in `source::imp::session_tests`, driving `follow_catalog` against an in-process `broadcast::Producer` with no relay:

- `a_rendition_nobody_serves_does_not_block_the_others` — waits for the pending subscription through the broadcast's `Dynamic` before announcing video, so it can't pass by reading a combined snapshot in a lucky `plan.add` order.
- `a_refused_rendition_does_not_end_the_session` — both renditions in one snapshot, so neither outcome depends on ordering.
- `an_unserved_rendition_does_not_claim_the_first_pad_name` — same-kind: an unanswered video, then a live one, asserting the live pad takes the first name.
- `a_subscription_resolving_after_cancellation_creates_no_pad`.
- `a_closing_catalog_keeps_the_renditions_it_named` — guards the reverted attempt below.

Re-created the previous behaviour and ran the suite 5x: the four that target it fail on every run.

Also `just check`, `just test` (120 passed), `just test smoke-full` (21/21, gst cells 0–2s), and `just test smoke-negative`. A forced failure reports `FAIL js -> gst (2s of 2s)`.

Known gap: the `PumpState` race needs `cancel` and `subscribe` ready in the same poll, which can't be forced without test hooks in production code. Covered indirectly by the late-resolution test.

## Attempted and reverted

An earlier commit cancelled not-yet-live pumps when the catalog closed, to stop an unanswered rendition holding the session open. That is wrong: "hasn't taken a pad yet" is indistinguishable from "hasn't been polled yet", and a publisher that names its tracks and then finishes the catalog delivers the snapshot and the close back to back — so it dropped the entire broadcast. Reverted in 2a67f0731, with the reproduction kept as a regression test. The termination problem it was aimed at is #3139; it is not a regression from this PR, since the same input previously parked `reconcile` inside the loop.

## Cross-package sync

`rs/moq-gst` -> `doc/bin/gstreamer.md` not updated: no flag, property, or pad-naming change, and the docs already teach the `moqsrc name=s s.video_0 ! ...` form this PR moves the harness onto.

## Follow-ups

- #3137 — bound how many pending rendition subscriptions a catalog can open.
- #3139 — a rendition nobody answers keeps the session alive after the catalog closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)
