### PR TITLE
perf(uring): grow the UDP pools when a socket starves

### DIFF
--- a/rs/moq-uring/src/lib.rs
+++ b/rs/moq-uring/src/lib.rs
@@ -10,7 +10,7 @@
 //! UDP is the point: [`udp::Socket`] receives through one multishot `recvmsg`
 //! with a registered provided-buffer ring (one whole buffer per completion,
 //! `UDP_GRO` coalesced) and sends with an explicit `UDP_SEGMENT` control
-//! message per `sendmsg` from a fixed pool of staging buffers.
+//! message per `sendmsg` from a growable pool of staging buffers.
 //!
 //! [`quic`] stacks a sans-IO QUIC stack on that path: a [`quic::Endpoint`]
 //! serves many connections on one socket (demuxed by connection id, dials

--- a/rs/moq-uring/src/shared.rs
+++ b/rs/moq-uring/src/shared.rs
@@ -6,6 +6,7 @@
 //! reaped by the worker loop.
 
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::io;
 use std::rc::Rc;
 use std::task::Poll;
@@ -61,6 +62,10 @@ pub(crate) struct Shared {
 	/// Set by [`crate::Worker`]'s drop: handles outlive the loop that would
 	/// drive them, so operations must fail instead of pending forever.
 	pub stopped: Cell<bool>,
+	/// Completions copied out of the CQ by [`push`](Self::push) when the
+	/// kernel reported it full mid-submit. [`crate::Worker`]'s pump dispatches
+	/// these before anything newer in the CQ.
+	pub spill: RefCell<VecDeque<Cqe>>,
 }
 
 impl Shared {
@@ -82,7 +87,32 @@ impl Shared {
 					return Ok(());
 				}
 			}
-			ring.submit()?;
+			if let Err(err) = ring.submit() {
+				// EBUSY: the CQ is full, the kernel could not flush its
+				// overflow backlog into it, and it consumed none of our SQEs.
+				// Only kernels before 5.13 report this (newer ones just grow
+				// the backlog), but it must never surface as an error: it is
+				// ring pressure, not a failure of the operation. Acting on the
+				// completions here would re-enter dispatch (receive re-arms,
+				// cancels) under our ring borrow, so copy them aside for the
+				// worker's pump instead; the freed CQ slots let the next
+				// submit flush the backlog and take our SQEs.
+				if err.raw_os_error() != Some(libc::EBUSY) {
+					return Err(err);
+				}
+				let mut spill = self.spill.borrow_mut();
+				let before = spill.len();
+				spill.extend(ring.completion().map(|entry| Cqe {
+					user_data: entry.user_data(),
+					result: entry.result(),
+					flags: entry.flags(),
+				}));
+				if spill.len() == before {
+					// EBUSY with an empty CQ breaks the kernel's contract;
+					// bail out rather than spin on it.
+					return Err(err);
+				}
+			}
 		}
 	}
 

--- a/rs/moq-uring/src/udp.rs
+++ b/rs/moq-uring/src/udp.rs
@@ -168,6 +168,23 @@ fn recycle_if_idle(rx: &mut Rx, bid: u16) -> bool {
 	true
 }
 
+/// Whether the receive pool has proven too shallow to arm against as it is.
+///
+/// A recorded starvation counts on its own: a buffer recycled between the
+/// kernel's `ENOBUFS` and this re-arm masks the shortfall without answering
+/// it, and arming into that one buffer just starves again.
+fn should_grow(rx: &Rx, multishot: bool) -> bool {
+	if rx.starved {
+		return true;
+	}
+	match multishot {
+		// Nothing left in the provided ring for the kernel to receive into.
+		true => !rx.bufs.iter().any(|buf| !buf.kernel_done),
+		// Every buffer is claimed by a receive or borrowed by a packet.
+		false => !rx.bufs.iter().any(|buf| !buf.claimed && buf.outstanding == 0),
+	}
+}
+
 /// Allocate more receive buffers and hand them straight to the kernel, up to
 /// [`Config::rx_buffers_max`]. Returns whether the pool grew.
 ///
@@ -275,6 +292,9 @@ struct Rx {
 	waiters: kio::WaiterList,
 	/// The slab key of the armed receive, if one is in flight.
 	armed: Option<u64>,
+	/// The kernel ran the pool dry since the last arm. Held rather than acted
+	/// on immediately because the re-arm is what can grow the pool.
+	starved: bool,
 	/// Terminal failure, surfaced by `poll_recv` once the queue drains.
 	error: Option<i32>,
 }
@@ -476,6 +496,7 @@ impl Socket {
 				queue: VecDeque::new(),
 				waiters: kio::WaiterList::new(),
 				armed: None,
+				starved: false,
 				error: None,
 			}),
 			tx: RefCell::new(tx),
@@ -855,14 +876,19 @@ pub(crate) fn arm_recv(shared: &Rc<Shared>, sock: &Rc<SockShared>) {
 		return;
 	}
 
+	// Grow before arming when the pool has proven too shallow, so the next
+	// receive has somewhere to land instead of waiting on a live packet to be
+	// released and dropping every datagram until then.
+	if should_grow(&rx, sock.config.multishot) {
+		rx.starved = false;
+		grow_rx(&mut rx, &sock.config);
+	}
+
 	let entry = if sock.config.multishot {
 		// Only arm with buffers in the provided ring (`!kernel_done`), or the
 		// receive would die on ENOBUFS immediately and re-arming here would
-		// spin. An empty ring is the kernel telling us the pool is too shallow
-		// for this socket's packet rate, so grow before giving up: otherwise
-		// the re-arm waits on a live packet dropping and every datagram that
-		// arrives meanwhile is lost.
-		if !rx.bufs.iter().any(|buf| !buf.kernel_done) && !grow_rx(&mut rx, &sock.config) {
+		// spin.
+		if !rx.bufs.iter().any(|buf| !buf.kernel_done) {
 			return;
 		}
 		let key = shared.insert(Op::Recv {
@@ -875,17 +901,12 @@ pub(crate) fn arm_recv(shared: &Rc<Shared>, sock: &Rc<SockShared>) {
 			.user_data(key)
 	} else {
 		// Claim a whole free buffer for this one receive.
-		let free = |rx: &Rx| {
-			rx.bufs
-				.iter()
-				.position(|buf| !buf.claimed && buf.outstanding == 0)
-				.map(|bid| bid as u16)
-		};
-		let mut bid = free(&rx);
-		if bid.is_none() && grow_rx(&mut rx, &sock.config) {
-			bid = free(&rx);
-		}
-		let Some(bid) = bid else {
+		let Some(bid) = rx
+			.bufs
+			.iter()
+			.position(|buf| !buf.claimed && buf.outstanding == 0)
+			.map(|bid| bid as u16)
+		else {
 			// Every buffer is borrowed and the pool is at its ceiling; a
 			// release re-arms us.
 			return;
@@ -954,8 +975,9 @@ pub(crate) fn on_recv(
 			rx.bufs[one.bid as usize].claimed = false;
 		}
 		match code {
-			// The receive pool is exhausted; a packet release re-arms.
-			libc::ENOBUFS => {}
+			// The receive pool is exhausted. Record it: by the time the re-arm
+			// looks, a recycled buffer may hide that the kernel ran dry.
+			libc::ENOBUFS => sock.rx.borrow_mut().starved = true,
 			// Socket teardown; nothing to surface.
 			libc::ECANCELED => return,
 			_ => {
@@ -1224,15 +1246,9 @@ mod tests {
 		assert_eq!(roundtrip(addr), Some(addr));
 	}
 
-	/// A starved receive pool doubles into its ceiling, offering every new
-	/// buffer to the kernel as it goes.
-	#[test]
-	fn the_receive_pool_doubles_to_its_ceiling() {
-		let config = Config {
-			rx_buffers_max: 40,
-			..Default::default()
-		};
-		let mut rx = Rx {
+	/// A receive pool with nothing allocated yet and a ring of its own.
+	fn empty_rx() -> Rx {
+		Rx {
 			bufs: Vec::new(),
 			// Never registered, so this one is ours alone to publish into.
 			ring: Some(BufRing::new(64)),
@@ -1241,8 +1257,36 @@ mod tests {
 			queue: VecDeque::new(),
 			waiters: kio::WaiterList::new(),
 			armed: None,
+			starved: false,
 			error: None,
+		}
+	}
+
+	/// A recorded `ENOBUFS` outlives the buffer that recycled after it: the
+	/// kernel ran the pool dry, so the pool is too shallow however full the
+	/// ring looks by the time the re-arm gets to it. Growing off the ring's
+	/// state alone leaves a bursting socket re-arming at its floor forever.
+	#[test]
+	fn a_recycled_buffer_does_not_mask_a_recorded_starvation() {
+		let config = Config::default();
+		let mut rx = empty_rx();
+		grow_rx(&mut rx, &config);
+		assert!(!should_grow(&rx, true), "a buffer is in the ring");
+
+		rx.starved = true;
+		assert!(should_grow(&rx, true), "the kernel ran dry, recycle or not");
+		assert!(should_grow(&rx, false), "and the oneshot path reads it too");
+	}
+
+	/// A starved receive pool doubles into its ceiling, offering every new
+	/// buffer to the kernel as it goes.
+	#[test]
+	fn the_receive_pool_doubles_to_its_ceiling() {
+		let config = Config {
+			rx_buffers_max: 40,
+			..Default::default()
 		};
+		let mut rx = empty_rx();
 
 		for expected in [1u16, 2, 4, 8, 16, 32, 40] {
 			assert!(grow_rx(&mut rx, &config), "growth stopped short of {expected}");

--- a/rs/moq-uring/src/udp.rs
+++ b/rs/moq-uring/src/udp.rs
@@ -11,10 +11,18 @@
 //! A completed buffer is handed out as a [`Packet`] and returns to the kernel
 //! once every packet borrowing it drops.
 //!
-//! Send stages datagrams in a fixed pool of buffers owned by id and released
+//! Send stages datagrams in a pool of buffers owned by id and released
 //! explicitly on completion, the shape `SENDMSG_ZC`'s deferred-reclaim NOTIF
 //! model needs later. Every GSO `sendmsg` carries its `UDP_SEGMENT` control
 //! message explicitly; the socket default is never relied on.
+//!
+//! Both pools are queues of concurrent operations, not byte budgets: one send
+//! buffer holds one GSO train and one receive buffer holds one completion,
+//! however little either carries. So the depth a socket needs is set by how
+//! many of its connections want the socket at once, which no caller can
+//! predict. Both start small and grow on demand when they starve, bounded by
+//! the ceilings in [`Config`]; a pool never shrinks, so it settles at the
+//! socket's high-water concurrency and the memory comes back when it drops.
 //!
 //! The `gro`/`gso`/`multishot` toggles in [`Config`] exist for the ablation
 //! benchmarks; production callers keep the defaults (all on).
@@ -48,6 +56,20 @@ const MAX_GSO_SEGMENTS: usize = 64;
 /// The largest receive pool: the provided-buffer ring holds a power-of-two
 /// number of entries and the kernel caps it here.
 const MAX_RX_BUFFERS: u16 = 1 << 15;
+/// Receive buffers allocated before any starvation. Enough for an idle socket;
+/// the pool grows from here.
+const INITIAL_RX_BUFFERS: u16 = 16;
+/// Send buffers allocated before any starvation.
+const INITIAL_TX_BUFFERS: u16 = 64;
+
+/// Double a pool, bounded by its ceiling.
+fn grown(len: usize, max: u16) -> Option<u16> {
+	let max = usize::from(max);
+	match len < max {
+		true => Some(len.saturating_mul(2).clamp(1, max) as u16),
+		false => None,
+	}
+}
 
 /// How a socket uses the ring. The defaults are the production path; the
 /// toggles exist so the benchmarks can ablate one mechanism at a time.
@@ -62,14 +84,21 @@ pub struct Config {
 	/// Receive through one persistent multishot `recvmsg` and the provided
 	/// buffer ring, instead of re-armed oneshot receives.
 	pub multishot: bool,
-	/// Receive pool: buffer count (rounded up to a power of two, at most
-	/// 32768). Each receive completion consumes one buffer, so this is the
-	/// queue depth.
-	pub rx_buffers: u16,
+	/// Receive pool ceiling: at most this many buffers, and at most 32768.
+	///
+	/// Each receive completion consumes one buffer whatever its size, so the
+	/// pool is a queue depth in packets rather than in bytes: GRO coalescing
+	/// collapses as connections multiply, and the depth a socket needs follows
+	/// that, not its bitrate. Buffers are allocated on demand, so this bounds
+	/// the memory rather than reserving it.
+	pub rx_buffers_max: u16,
 	/// Receive pool: bytes per buffer. Must hold one worst-case receive.
 	pub rx_buffer_len: usize,
-	/// Send pool: buffer count.
-	pub tx_buffers: u16,
+	/// Send pool ceiling: at most this many buffers, allocated on demand.
+	///
+	/// One buffer stages one GSO train, so the pool is the socket's in-flight
+	/// send concurrency. Set it to 1 to serialize sends.
+	pub tx_buffers_max: u16,
 	/// Send pool: bytes per buffer, the ceiling for one GSO train.
 	pub tx_buffer_len: usize,
 }
@@ -80,9 +109,11 @@ impl Default for Config {
 			gro: true,
 			gso: true,
 			multishot: true,
-			rx_buffers: 16,
+			// 16 MiB and 64 MiB of headroom at the default buffer lengths,
+			// reached only by a socket that actually starves for them.
+			rx_buffers_max: 256,
 			rx_buffer_len: MAX_RECV + RECV_OVERHEAD,
-			tx_buffers: 64,
+			tx_buffers_max: 1024,
 			tx_buffer_len: 64 * 1024,
 		}
 	}
@@ -133,6 +164,52 @@ fn recycle_if_idle(rx: &mut Rx, bid: u16) -> bool {
 	if let Some(ring) = &mut rx.ring {
 		ring.add(bid, addr, len);
 		ring.publish();
+	}
+	true
+}
+
+/// Allocate more receive buffers and hand them straight to the kernel, up to
+/// [`Config::rx_buffers_max`]. Returns whether the pool grew.
+///
+/// Only the `RxBuf` structs move; [`Packet`] and the provided ring both point
+/// at the `Box<[u8]>` allocations, which stay put.
+fn grow_rx(rx: &mut Rx, config: &Config) -> bool {
+	let Some(target) = grown(rx.bufs.len(), config.rx_buffers_max) else {
+		return false;
+	};
+	while rx.bufs.len() < usize::from(target) {
+		let bid = rx.bufs.len() as u16;
+		rx.bufs.push(RxBuf {
+			data: vec![0u8; config.rx_buffer_len].into_boxed_slice(),
+			outstanding: 0,
+			kernel_done: false,
+			claimed: false,
+		});
+		if let Some(ring) = &mut rx.ring {
+			let buf = &mut rx.bufs[bid as usize];
+			let addr = buf.data.as_mut_ptr();
+			let len = buf.data.len();
+			ring.add(bid, addr, len);
+		}
+	}
+	if let Some(ring) = &mut rx.ring {
+		ring.publish();
+	}
+	true
+}
+
+/// Allocate more send buffers, up to [`Config::tx_buffers_max`]. Returns
+/// whether the pool grew.
+///
+/// The `Box<[u8]>` allocations are stable across the `Vec` growth, which is
+/// what lets a live [`TxBuf`] keep a raw pointer into one.
+fn grow_tx(tx: &mut Tx, config: &Config) -> bool {
+	let Some(target) = grown(tx.bufs.len(), config.tx_buffers_max) else {
+		return false;
+	};
+	while tx.bufs.len() < usize::from(target) {
+		tx.free.push(tx.bufs.len() as u16);
+		tx.bufs.push(vec![0u8; config.tx_buffer_len].into_boxed_slice());
 	}
 	true
 }
@@ -291,7 +368,7 @@ pub struct Socket {
 impl Socket {
 	pub(crate) fn bind(shared: &Rc<Shared>, io: UdpSocket, config: Config) -> Result<Self, Error> {
 		let floor = if config.gro { MAX_RECV + RECV_OVERHEAD } else { 2048 };
-		if config.rx_buffer_len < floor || config.rx_buffers == 0 || config.tx_buffers == 0 {
+		if config.rx_buffer_len < floor || config.rx_buffers_max == 0 || config.tx_buffers_max == 0 {
 			return Err(io::Error::new(
 				io::ErrorKind::InvalidInput,
 				format!(
@@ -301,12 +378,12 @@ impl Socket {
 			.into());
 		}
 		// Rounding up past `u16::MAX` would wrap to a zero-entry ring.
-		if config.rx_buffers > MAX_RX_BUFFERS {
+		if config.rx_buffers_max > MAX_RX_BUFFERS {
 			return Err(io::Error::new(
 				io::ErrorKind::InvalidInput,
 				format!(
 					"receive pool holds at most {MAX_RX_BUFFERS} buffers, got {}",
-					config.rx_buffers
+					config.rx_buffers_max
 				),
 			)
 			.into());
@@ -329,7 +406,10 @@ impl Socket {
 			}
 		}
 
-		let rx_count = config.rx_buffers.next_power_of_two();
+		// The ring's entry count is fixed at registration, so it is sized for
+		// the ceiling; the buffers behind it are allocated as the pool grows.
+		let rx_cap = config.rx_buffers_max.next_power_of_two();
+		let rx_count = INITIAL_RX_BUFFERS.min(config.rx_buffers_max);
 		let mut bufs = Vec::with_capacity(rx_count as usize);
 		for _ in 0..rx_count {
 			bufs.push(RxBuf {
@@ -346,7 +426,7 @@ impl Socket {
 			.set(bgid.checked_add(1).expect("buffer group ids exhausted"));
 
 		let ring = if config.multishot {
-			let mut ring = BufRing::new(rx_count);
+			let mut ring = BufRing::new(rx_cap);
 			{
 				let io_ring = shared.ring.borrow_mut();
 				// SAFETY: the ring allocation lives in `SockShared`, which the
@@ -355,7 +435,7 @@ impl Socket {
 				unsafe {
 					io_ring
 						.submitter()
-						.register_buf_ring_with_flags(ring.ptr.as_ptr() as u64, rx_count, bgid, 0)?;
+						.register_buf_ring_with_flags(ring.ptr.as_ptr() as u64, rx_cap, bgid, 0)?;
 				}
 			}
 			for (bid, buf) in bufs.iter_mut().enumerate() {
@@ -373,7 +453,7 @@ impl Socket {
 		hdr.msg_namelen = NAME_LEN as libc::socklen_t;
 		hdr.msg_controllen = CONTROL_LEN;
 
-		let tx_count = config.tx_buffers;
+		let tx_count = INITIAL_TX_BUFFERS.min(config.tx_buffers_max);
 		let tx = Tx {
 			bufs: (0..tx_count)
 				.map(|_| vec![0u8; config.tx_buffer_len].into_boxed_slice())
@@ -456,6 +536,11 @@ impl Socket {
 		}
 		if self.shared.worker_gone() {
 			return Poll::Ready(Err(Shared::gone_error()));
+		}
+		if tx.free.is_empty() {
+			// Starved: every buffer is in flight, so the socket needs a deeper
+			// send window than it has. Grow rather than serialize behind it.
+			grow_tx(&mut tx, &self.shared.config);
 		}
 		if let Some(id) = tx.free.pop() {
 			let buf = &mut tx.bufs[id as usize];
@@ -773,8 +858,11 @@ pub(crate) fn arm_recv(shared: &Rc<Shared>, sock: &Rc<SockShared>) {
 	let entry = if sock.config.multishot {
 		// Only arm with buffers in the provided ring (`!kernel_done`), or the
 		// receive would die on ENOBUFS immediately and re-arming here would
-		// spin.
-		if !rx.bufs.iter().any(|buf| !buf.kernel_done) {
+		// spin. An empty ring is the kernel telling us the pool is too shallow
+		// for this socket's packet rate, so grow before giving up: otherwise
+		// the re-arm waits on a live packet dropping and every datagram that
+		// arrives meanwhile is lost.
+		if !rx.bufs.iter().any(|buf| !buf.kernel_done) && !grow_rx(&mut rx, &sock.config) {
 			return;
 		}
 		let key = shared.insert(Op::Recv {
@@ -787,13 +875,19 @@ pub(crate) fn arm_recv(shared: &Rc<Shared>, sock: &Rc<SockShared>) {
 			.user_data(key)
 	} else {
 		// Claim a whole free buffer for this one receive.
-		let Some(bid) = rx
-			.bufs
-			.iter()
-			.position(|buf| !buf.claimed && buf.outstanding == 0)
-			.map(|bid| bid as u16)
-		else {
-			// Every buffer is borrowed; a release re-arms us.
+		let free = |rx: &Rx| {
+			rx.bufs
+				.iter()
+				.position(|buf| !buf.claimed && buf.outstanding == 0)
+				.map(|bid| bid as u16)
+		};
+		let mut bid = free(&rx);
+		if bid.is_none() && grow_rx(&mut rx, &sock.config) {
+			bid = free(&rx);
+		}
+		let Some(bid) = bid else {
+			// Every buffer is borrowed and the pool is at its ceiling; a
+			// release re-arms us.
 			return;
 		};
 		rx.bufs[bid as usize].claimed = true;
@@ -1128,5 +1222,34 @@ mod tests {
 		let ip = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
 		let addr = SocketAddr::V6(SocketAddrV6::new(ip, 4443, 0x12345, 3));
 		assert_eq!(roundtrip(addr), Some(addr));
+	}
+
+	/// A starved receive pool doubles into its ceiling, offering every new
+	/// buffer to the kernel as it goes.
+	#[test]
+	fn the_receive_pool_doubles_to_its_ceiling() {
+		let config = Config {
+			rx_buffers_max: 40,
+			..Default::default()
+		};
+		let mut rx = Rx {
+			bufs: Vec::new(),
+			// Never registered, so this one is ours alone to publish into.
+			ring: Some(BufRing::new(64)),
+			// SAFETY: all-zero is valid for `msghdr`, and nothing reads it here.
+			hdr: Box::new(unsafe { std::mem::zeroed() }),
+			queue: VecDeque::new(),
+			waiters: kio::WaiterList::new(),
+			armed: None,
+			error: None,
+		};
+
+		for expected in [1u16, 2, 4, 8, 16, 32, 40] {
+			assert!(grow_rx(&mut rx, &config), "growth stopped short of {expected}");
+			assert_eq!(rx.bufs.len(), usize::from(expected));
+			// Every buffer reaches the kernel exactly once.
+			assert_eq!(rx.ring.as_ref().expect("ring").tail, expected);
+		}
+		assert!(!grow_rx(&mut rx, &config), "grew past the ceiling");
 	}
 }

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -587,6 +587,17 @@ mod tests {
 	}
 
 	#[test]
+	fn the_ring_honors_the_requested_cq_depth() {
+		// The kernel-reported geometry, not the constant: dropping the
+		// `setup_cqsize` call would silently fall back to a CQ of twice the SQ
+		// (512), and the overflow test below cannot catch that because it
+		// expects overflow. This one pins the operative fix.
+		let Some(worker) = worker() else { return };
+		let cq = worker.shared.ring.borrow().params().cq_entries();
+		assert!(cq >= CQ_ENTRIES, "kernel granted a {cq}-entry CQ, wanted {CQ_ENTRIES}");
+	}
+
+	#[test]
 	fn completion_overflow_is_survivable() {
 		let Some(mut worker) = worker() else { return };
 		let handle = worker.handle();

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -588,13 +588,48 @@ mod tests {
 		// Without validation the power-of-two rounding wraps to a zero-entry
 		// ring, which allocates nothing and underflows its mask.
 		let config = udp::Config {
-			rx_buffers: u16::MAX,
+			rx_buffers_max: u16::MAX,
 			..Default::default()
 		};
 		let err = handle
 			.udp(std::net::UdpSocket::bind("127.0.0.1:0").expect("bind"), config)
 			.expect_err("oversized pool");
 		assert!(matches!(err, Error::Io(err) if err.kind() == std::io::ErrorKind::InvalidInput));
+	}
+
+	#[test]
+	fn the_send_pool_grows_to_its_ceiling() {
+		let Some(worker) = worker() else { return };
+		let handle = worker.handle();
+		// A ceiling is a bound, not a reservation: 65535 default-length buffers
+		// would be 4 GiB if the pool were allocated up front.
+		let config = udp::Config {
+			tx_buffers_max: u16::MAX,
+			..Default::default()
+		};
+		handle
+			.udp(std::net::UdpSocket::bind("127.0.0.1:0").expect("bind"), config)
+			.expect("socket");
+
+		// Short buffers so the whole ceiling fits in a test.
+		let config = udp::Config {
+			tx_buffers_max: 200,
+			tx_buffer_len: 4096,
+			..Default::default()
+		};
+		let sock = handle
+			.udp(std::net::UdpSocket::bind("127.0.0.1:0").expect("bind"), config)
+			.expect("socket");
+
+		// Holding every buffer starves the pool, which grows past its initial
+		// floor rather than serializing the caller behind it, and stops at the
+		// ceiling.
+		let mut held = Vec::new();
+		while let Poll::Ready(Ok(tx)) = sock.poll_acquire(&kio::Waiter::noop()) {
+			held.push(tx);
+		}
+		assert_eq!(held.len(), 200);
+		drop(worker);
 	}
 
 	#[test]

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -12,23 +12,29 @@ use crate::park::{FUTEX_BITSET_MATCH_ANY, FUTEX2_PRIVATE, FUTEX2_SIZE_U32, PARKE
 use crate::shared::{Cqe, Op, Shared, Task};
 use crate::{Error, timer, udp};
 
-/// The largest submission queue io_uring will set up.
-const MAX_ENTRIES: u32 = 32768;
+/// Submission queue depth. The SQ only holds SQEs staged between submits,
+/// never in-flight operations, so it needs no relation to the socket pools;
+/// [`Shared::push`] submits inline whenever it fills.
+const SQ_ENTRIES: u32 = 256;
+
+/// Completion queue depth. Every in-flight operation can post a completion
+/// (one per send buffer with GSO on, one per provided receive buffer, the
+/// park futex, transient cancels), so this covers a few sockets at the
+/// default pool ceilings in [`udp::Config`]. Running past it is not fatal:
+/// the kernel backlogs completions (`IORING_FEAT_NODROP`) rather than drop
+/// them. But the backlog is an allocation-per-CQE slow path and it ends any
+/// armed multishot receive, so the CQ is sized to keep it out of steady
+/// state.
+const CQ_ENTRIES: u32 = 4096;
 
 /// Worker construction knobs.
-#[derive(Clone, Debug)]
+///
+/// Currently empty: the worker sizes its ring internally, with a completion
+/// queue that comfortably covers the per-socket pool ceilings in
+/// [`udp::Config`]. The struct exists so future knobs stay additive.
+#[derive(Clone, Debug, Default)]
 #[non_exhaustive]
-pub struct Config {
-	/// Submission queue depth, from 1 to 32768 (the kernel rounds it up to a
-	/// power of two and sizes the completion queue at twice this).
-	pub entries: u32,
-}
-
-impl Default for Config {
-	fn default() -> Self {
-		Self { entries: 256 }
-	}
-}
+pub struct Config {}
 
 /// A thread-pinned io_uring executor: the ring, a timer heap, and a local
 /// (`!Send`) task set, driven by a caller-owned loop.
@@ -53,24 +59,17 @@ impl Worker {
 	/// park timeout, and batched minimum waits with one code path; there is
 	/// deliberately no fallback (use the tokio stack instead).
 	pub fn new(config: Config) -> Result<Self, Error> {
-		// Checked here so the `EINVAL` below can only mean the kernel refused
-		// one of the setup flags, not that the caller asked for a bad depth.
-		if config.entries == 0 || config.entries > MAX_ENTRIES {
-			return Err(Error::Io(std::io::Error::new(
-				std::io::ErrorKind::InvalidInput,
-				format!("ring depth must be 1 to {MAX_ENTRIES}, got {}", config.entries),
-			)));
-		}
-
+		let Config {} = config;
 		let ring = IoUring::builder()
 			.setup_single_issuer()
 			.setup_defer_taskrun()
 			.setup_coop_taskrun()
-			.build(config.entries)
+			.setup_cqsize(CQ_ENTRIES)
+			.build(SQ_ENTRIES)
 			.map_err(|err| match err.raw_os_error() {
 				// EINVAL from setup means the kernel predates one of the
-				// requested flags (the depth is already validated), so it never
-				// reaches the feature check below.
+				// requested flags (the ring geometry is compile-time valid),
+				// so it never reaches the feature check below.
 				Some(libc::ENOSYS) | Some(libc::EPERM) | Some(libc::EACCES) | Some(libc::EINVAL) => {
 					Error::Unsupported(format!(
 						"io_uring is unavailable ({err}); kernel {} (Linux 6.12+ required, and container seccomp \
@@ -99,6 +98,7 @@ impl Worker {
 				unpark: Unpark::new(),
 				next_bgid: std::cell::Cell::new(0),
 				stopped: std::cell::Cell::new(false),
+				spill: RefCell::new(std::collections::VecDeque::new()),
 			}),
 			tasks: kio::Tasks::new(),
 			park: kio::Park::default(),
@@ -148,15 +148,18 @@ impl Worker {
 		self.submit()?;
 		loop {
 			// Copy the completions out so dispatch can borrow the ring (to
-			// re-arm receives, push cancels, and so on).
+			// re-arm receives, push cancels, and so on). Completions spilled
+			// by `Shared::push` predate the CQ's, so they dispatch first.
 			let cqes: Vec<Cqe> = {
 				let mut ring = self.shared.ring.borrow_mut();
-				ring.completion()
-					.map(|entry| Cqe {
+				let mut spill = self.shared.spill.borrow_mut();
+				spill
+					.drain(..)
+					.chain(ring.completion().map(|entry| Cqe {
 						user_data: entry.user_data(),
 						result: entry.result(),
 						flags: entry.flags(),
-					})
+					}))
 					.collect()
 			};
 			if cqes.is_empty() {
@@ -572,12 +575,84 @@ mod tests {
 	}
 
 	#[test]
-	fn invalid_ring_depth_is_not_unsupported() {
-		// A caller's bad depth must not read as "this kernel cannot run the
-		// worker", which is the signal to fall back to the tokio stack.
-		for entries in [0, MAX_ENTRIES + 1] {
-			let err = Worker::new(Config { entries }).expect_err("invalid depth");
-			assert!(matches!(err, Error::Io(_)), "classified as {err:?}");
+	fn cq_covers_the_default_pool_ceilings() {
+		// The completion queue must cover at least two sockets at their
+		// default pool ceilings (plus the futex), or the kernel's overflow
+		// slow path becomes steady state for the workload the ceilings exist
+		// to serve. Fails when someone raises the udp defaults without
+		// revisiting CQ_ENTRIES.
+		let config = udp::Config::default();
+		let per_socket = u32::from(config.tx_buffers_max) + u32::from(config.rx_buffers_max);
+		assert!(CQ_ENTRIES > 2 * per_socket, "CQ_ENTRIES fell behind the pool defaults");
+	}
+
+	#[test]
+	fn completion_overflow_is_survivable() {
+		let Some(mut worker) = worker() else { return };
+		let handle = worker.handle();
+		// Twice the CQ's worth of sends, staged synchronously so nothing
+		// reaps while they complete: the kernel must backlog the completions
+		// (`IORING_FEAT_NODROP`) and the worker must drain them without any
+		// operation, socket, or the worker itself failing.
+		let ceiling = (CQ_ENTRIES * 2) as u16;
+		let config = udp::Config {
+			tx_buffers_max: ceiling,
+			tx_buffer_len: 2048,
+			..Default::default()
+		};
+		let sock = handle
+			.udp(std::net::UdpSocket::bind("127.0.0.1:0").expect("bind"), config)
+			.expect("socket");
+		let to = sock.local_addr().expect("addr");
+
+		let mut held = Vec::new();
+		while let Poll::Ready(Ok(tx)) = sock.poll_acquire(&kio::Waiter::noop()) {
+			held.push(tx);
+		}
+		assert_eq!(held.len(), usize::from(ceiling));
+		for tx in held.drain(..) {
+			tx.send(1200, to, 1200).expect("send");
+		}
+
+		// The point of the test is the overflow, so prove it happened: the
+		// kernel raises this flag while completions sit in its backlog. It
+		// clears once the backlog flushes, so sample it before each sweep.
+		let saw_overflow = |worker: &Worker| worker.shared.ring.borrow_mut().submission().cq_overflow();
+		let mut overflowed = saw_overflow(&worker);
+
+		// Drive the worker until every completion, backlog included, has been
+		// reaped and released its buffer back to the pool.
+		let deadline = Instant::now() + Duration::from_secs(10);
+		loop {
+			overflowed = overflowed || saw_overflow(&worker);
+			let h = handle.clone();
+			worker
+				.block_on(async move {
+					Deadline::after(&h, Duration::from_millis(10)).wait().await;
+				})
+				.unwrap();
+			let mut free = Vec::new();
+			loop {
+				match sock.poll_acquire(&kio::Waiter::noop()) {
+					Poll::Ready(Ok(tx)) => free.push(tx),
+					Poll::Ready(Err(err)) => panic!("send path failed: {err}"),
+					Poll::Pending => break,
+				}
+			}
+			if free.len() == usize::from(ceiling) {
+				break;
+			}
+			assert!(
+				Instant::now() < deadline,
+				"buffers stuck in flight: {} of {ceiling} free",
+				free.len()
+			);
+		}
+		assert!(overflowed, "the burst never overflowed the CQ; it proves nothing");
+		// The receive side rode out the same storm: whatever the loopback
+		// delivered drains without a terminal error.
+		while let Poll::Ready(result) = sock.poll_recv(&kio::Waiter::noop()) {
+			result.expect("receive path failed");
 		}
 	}
 

--- a/rs/moq-uring/tests/endpoint.rs
+++ b/rs/moq-uring/tests/endpoint.rs
@@ -449,7 +449,7 @@ fn connections_share_one_tx_buffer_fairly() {
 	let certs = support::certs().expect("certificates");
 
 	let mut udp_config = udp::Config::default();
-	udp_config.tx_buffers = 1;
+	udp_config.tx_buffers_max = 1;
 	let sock = handle
 		.udp(UdpSocket::bind("127.0.0.1:0").expect("bind"), udp_config)
 		.expect("socket");


### PR DESCRIPTION
## Summary

- Grow each io_uring socket's UDP send and receive pools on demand instead of fixing them at 64 and 16 buffers.
- Turn `udp::Config`'s `rx_buffers`/`tx_buffers` into the ceilings `rx_buffers_max`/`tx_buffers_max`; the pools start where they used to and each doubles when it starves.
- Size the completion queue for those ceilings (`IORING_SETUP_CQSIZE`, 4096 slots) instead of inheriting the kernel default (2x a 256-entry SQ = 512), which the grown pools would now run into overflow.
- Make `Shared::push` absorb CQ pressure (EBUSY) into a userspace spill queue instead of surfacing it as an operation error.
- No new operator knob anywhere, and one fewer: `worker::Config::entries` is gone, ring geometry is derived.

## Root cause

A worker's whole send concurrency was 64 buffers and its receive queue 16, however many connections it served. At 400 connections per worker they serialized behind those pools, which showed up as queueing delay: p50 4.6x the tokio path's, and delivery short of the offered groups (#3119).

Neither pool is a byte budget. One send buffer stages one GSO train and one receive buffer absorbs one completion, however little either carries, so both are counts of concurrent operations rather than bytes. GSO and GRO batching also collapse as connections multiply: 400 interleaved flows put one segment in a train that a handful of flows would fill 48 of. So the depth a socket needs tracks its connection concurrency, not its bitrate, and the caller binding the socket knows neither at bind time.

That is why this doesn't expose the sizing as configuration. The socket is the only thing that can observe the number, so it measures it: `poll_acquire` grows the send pool rather than parking the caller, and the receive pool grows when the provided ring runs dry rather than waiting on a live packet to be released. Each doubles, bounded by the ceiling, and neither shrinks, so a socket settles at its high-water concurrency and the memory returns when it drops.

The provided buffer ring is registered at the ceiling because the kernel fixes its entry count at registration, but the buffers behind it are allocated on demand, so an idle socket costs what it did before this change.

### The completion queue

Review flagged that the deeper pools let in-flight operations (up to 1024 sends + 256 receives per socket) exceed the CQ's 512 slots, and that `Shared::push` propagates the overflow EBUSY as an error that a connection's `flush` treats as terminal. Half of that holds up; the half that motivated a backpressure design does not:

- **The EBUSY kill is unreachable on any kernel this crate runs on.** Submit-path EBUSY on CQ overflow existed in kernels 5.5 to 5.12; the last overflow EBUSY was removed around 6.2 (commit `1b346e4aa8e7`, "io_uring: don't check overflow flush failures"). `Worker::new` refuses anything below 6.12. The `io_uring_enter(2)` man page still documents the old behavior, which is where the concern came from.
- **What actually happens on 6.12+ is silent and costly.** With `IORING_FEAT_NODROP` the kernel backlogs each overflowed completion in a GFP_ATOMIC allocation (the documented slow path `io_uring_queue_init(3)` says to avoid by sizing the CQ), and an overflow terminates any armed multishot receive, forcing re-arm churn. Both land exactly in the high-concurrency regime the pool growth serves.

So the fix is sizing, not backpressure machinery: `setup_cqsize` decouples the CQ from the SQ (the SQ only holds SQEs staged between submits and stays at 256), and 4096 CQ slots (~64 KiB) cover a few sockets at the default ceilings. A unit test pins `CQ_ENTRIES` against the `udp::Config` defaults so raising the pools without revisiting the CQ fails loudly.

The EBUSY misclassification is still fixed, as hygiene: it had four reachable call sites (send, `arm_recv` which would fail the whole socket, cancel, and the park futex arm which would kill the whole worker), so the fix lives in `Shared::push` itself. On EBUSY it copies the blocking completions into a userspace spill queue and retries; the worker's pump dispatches the spill ahead of newer CQEs. Copying is safe where reaping is not: dispatching mid-push would re-enter receive re-arms and cancels under the ring borrow, but the pump already separates "copy CQEs out" from "act on them", and the spill only moves the copy point. This matches every surveyed runtime (monoio, tokio-uring, glommio, compio, msquic, TigerBeetle): all of them absorb ring-full in the driver; none surfaces it to a caller.

## Public API changes

- `udp::Config::rx_buffers` -> `rx_buffers_max`, `tx_buffers` -> `tx_buffers_max`, both now ceilings rather than allocation counts. Defaults 256 and 1024 (16 MiB and 64 MiB of headroom at the default buffer lengths), reached only by a socket that starves for them.
- `worker::Config::entries` is removed; the struct is an empty `#[non_exhaustive]` options bag for now. Every caller in tree already used `Config::default()`. Configuring a worker requires no io_uring knowledge: the tunables that matter are the per-socket pool ceilings, and the ring is sized to fit them.

## Wire behavior changes

- None.

## Test plan

Run in a privileged Linux container (kernel 6.19, aarch64) so `io_uring_setup` is actually available; without `--privileged` the worker-backed tests skip themselves and report green without executing:

- `cargo fmt -p moq-uring -- --check`
- `cargo clippy -p moq-uring --all-targets -- -D warnings`, plus the `--no-default-features --features quinn` lib tests for the quinn backend.
- `cargo test -p moq-uring --lib --tests`: all passing and executing rather than skipping.
- New: `udp::tests::the_receive_pool_doubles_to_its_ceiling`, `worker::tests::the_send_pool_grows_to_its_ceiling`, `worker::tests::cq_covers_the_default_pool_ceilings`, and `worker::tests::completion_overflow_is_survivable`. The last stages twice the CQ's worth of sends with nothing reaping, asserts the kernel actually raised `IORING_SQ_CQ_OVERFLOW` (so the test proves it exercised overflow instead of silently passing), and asserts every buffer returns with no operation, socket, or worker failure. Mutation-checked both ways: leaking `release_tx` fails it with "buffers stuck in flight", and shrinking the burst below the CQ fails the overflow assertion.
- The overflow test doubles as an empirical check of the kernel claim above: the CQ demonstrably overflows and nothing sees an EBUSY.

Not done here: the 1601-connection fan-out benchmark from #3119 is not re-run, so the latency numbers in that issue are not reconfirmed against this patch. That needs the bare-metal rig, not this container.

## Notes

Things asked about during review that are deliberately not in this PR:

- Folding `runtime.io_uring` into `listen.backend = quiche-uring` (and `quinn-uring` after #3131). That touches `moq_tokio::QuicBackend`, the relay bind path, docs and demo configs, and is worth its own review.
- Shrinking the pools back down. There is no clock on the socket to drive a decay policy, and the ceiling already bounds the memory.
- Growing or replacing the ring at runtime. No runtime anywhere does two-live-rings migration; the kernel's own answer is `IORING_REGISTER_RESIZE_RINGS` (6.13+, requires `DEFER_TASKRUN`, illegal once already in overflow), which the `io-uring` crate does not expose yet. Worth revisiting only if the fixed CQ turns out to keep being wrong, and the floor reaches 6.13.

Fixes #3119

(Written by Claude Fable 5)