### PR TITLE
perf(uring): use fast hashes for trusted packet maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5195,6 +5195,7 @@ dependencies = [
  "quinn-proto",
  "rand 0.10.2",
  "rcgen",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-platform-verifier",
  "slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ nix = { version = "0.30.1", features = ["net", "socket", "uio"] }
 noq-udp = "1.1.1"
 percent-encoding = "2"
 qmux = { version = "0.5.1", default-features = false }
+rustc-hash = "2.1.3"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
 subtle = "2.6"

--- a/rs/moq-uring/Cargo.toml
+++ b/rs/moq-uring/Cargo.toml
@@ -37,6 +37,7 @@ quiche = { version = "0.29", optional = true }
 # moq-tokio wires its quinn dependency.
 quinn-proto = { version = "0.11", default-features = false, features = ["bloom", "log", "rustls-aws-lc-rs"], optional = true }
 rand = "0.10"
+rustc-hash = { workspace = true }
 rustls = { version = "0.23", optional = true }
 # OS-native server-cert verifier for the quinn backend. Version matched to the
 # copy moq-tokio pulls in, to avoid duplication.

--- a/rs/moq-uring/src/quic/quiche/connection.rs
+++ b/rs/moq-uring/src/quic/quiche/connection.rs
@@ -1,12 +1,13 @@
 //! The connection: shared state, the driver task, and the session handle.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
 use bytes::Bytes;
+use rustc_hash::FxHashMap;
 
 use super::{Error, SEGMENT};
 use crate::{Handle, udp};
@@ -64,18 +65,24 @@ pub(crate) struct State {
 	open_waiters: kio::WaiterList,
 
 	/// Per-stream read/write parking, keyed by stream id.
-	readable: HashMap<u64, kio::WaiterList>,
-	writable: HashMap<u64, kio::WaiterList>,
+	///
+	/// FxHash rather than SipHash on all four of these: they sit on the
+	/// driver's per-event path. A peer does shape which of its ids stay parked
+	/// here, but only by opening them in order, so clustering enough of them
+	/// into one bucket costs millions of stream opens for a cluster the
+	/// stream limit caps anyway.
+	readable: FxHashMap<u64, kio::WaiterList>,
+	writable: FxHashMap<u64, kio::WaiterList>,
 	/// Send streams waiting for their end (FIN acknowledged, a STOP, or a
 	/// reset); the driver probes these after connection events since quiche has
 	/// no event for stream collection.
-	finishing: HashMap<u64, kio::WaiterList>,
+	finishing: FxHashMap<u64, kio::WaiterList>,
 	/// How each send stream ended, for the ones the driver saw collected while
 	/// the connection was still up: `None` for a FIN the peer acknowledged,
 	/// `Some(code)` for a `STOP_SENDING` the probe consumed on our behalf.
 	/// That is what makes a later close mean "already delivered" rather than
 	/// "we never found out". Cleared when the stream drops.
-	pub(crate) collected: HashMap<u64, Option<u64>>,
+	pub(crate) collected: FxHashMap<u64, Option<u64>>,
 
 	/// Received datagrams, oldest first; over [`DGRAM_QUEUE`] the oldest drop.
 	datagrams: VecDeque<Bytes>,
@@ -112,10 +119,10 @@ impl State {
 			next_open_bi,
 			next_open_uni,
 			open_waiters: kio::WaiterList::new(),
-			readable: HashMap::new(),
-			writable: HashMap::new(),
-			finishing: HashMap::new(),
-			collected: HashMap::new(),
+			readable: FxHashMap::default(),
+			writable: FxHashMap::default(),
+			finishing: FxHashMap::default(),
+			collected: FxHashMap::default(),
 			datagrams: VecDeque::new(),
 			datagram_recv_waiters: kio::WaiterList::new(),
 			datagram_send_waiters: kio::WaiterList::new(),

--- a/rs/moq-uring/src/quic/quiche/endpoint.rs
+++ b/rs/moq-uring/src/quic/quiche/endpoint.rs
@@ -13,6 +13,8 @@ use std::net::SocketAddr;
 use std::rc::Rc;
 use std::task::Poll;
 
+use rustc_hash::FxHashMap;
+
 use super::{Connection, Error, connection};
 use crate::quic::endpoint::{CID_LEN, Config, cid};
 use crate::{Handle, udp};
@@ -29,9 +31,83 @@ struct Accepting {
 /// One live connection: its shared state and the routes pointing at it.
 struct Conn {
 	shared: connection::Shared,
-	/// Every id in [`Inner::routes`] naming this connection, so teardown can
-	/// remove exactly them.
-	cids: Vec<Vec<u8>>,
+	ids: ConnectionIds,
+}
+
+/// Every destination connection id routing to one connection.
+struct ConnectionIds {
+	/// The ids this endpoint issued, each [`CID_LEN`] bytes.
+	issued: Vec<[u8; CID_LEN]>,
+	/// The destination id the client chose for its Initial, for a connection
+	/// that arrived rather than one we dialed.
+	initial: Option<Vec<u8>>,
+}
+
+impl ConnectionIds {
+	/// The ids for a connection we dialed: just the one we issued.
+	fn issued(cid: [u8; CID_LEN]) -> Self {
+		Self {
+			issued: vec![cid],
+			initial: None,
+		}
+	}
+}
+
+/// Destination connection id -> the connection it belongs to, split by who
+/// chose the id.
+///
+/// The ids we issued are random and fixed width, so FxHash is enough: a peer
+/// cannot pick them, so it cannot aim at a bucket. A client picks its own
+/// Initial destination id, so those keep SipHash and its per-process seed.
+/// Otherwise a peer could open connections whose Initial ids all hash alike
+/// and turn a per-packet lookup into a scan of them.
+#[derive(Default)]
+struct Routes {
+	issued: FxHashMap<[u8; CID_LEN], usize>,
+	initial: HashMap<Vec<u8>, usize>,
+}
+
+impl Routes {
+	/// The connection `cid` names. Ids we issued win, so a client cannot
+	/// steal a live route by naming it as its Initial destination.
+	fn get(&self, cid: &[u8]) -> Option<usize> {
+		if let Ok(cid) = <[u8; CID_LEN]>::try_from(cid)
+			&& let Some(key) = self.issued.get(&cid)
+		{
+			return Some(*key);
+		}
+		self.initial.get(cid).copied()
+	}
+
+	fn insert(&mut self, key: usize, ids: &ConnectionIds) {
+		for cid in &ids.issued {
+			self.issued.insert(*cid, key);
+		}
+		if let Some(cid) = &ids.initial {
+			self.initial.insert(cid.clone(), key);
+		}
+	}
+
+	/// Drop `key`'s routes. Two clients may pick the same Initial destination
+	/// id, so only the entries still naming `key` go: the other connection
+	/// keeps the one it won.
+	fn remove(&mut self, key: usize, ids: &ConnectionIds) {
+		for cid in &ids.issued {
+			self.remove_issued(cid, key);
+		}
+		if let Some(cid) = &ids.initial
+			&& self.initial.get(cid) == Some(&key)
+		{
+			self.initial.remove(cid);
+		}
+	}
+
+	/// Drop `key`'s route for an id it issued and has now retired.
+	fn remove_issued(&mut self, cid: &[u8; CID_LEN], key: usize) {
+		if self.issued.get(cid) == Some(&key) {
+			self.issued.remove(cid);
+		}
+	}
 }
 
 /// State shared by the handles, the demux task, and the per-connection
@@ -43,7 +119,7 @@ struct Inner {
 	accepting: RefCell<Option<Accepting>>,
 	conns: RefCell<slab::Slab<Conn>>,
 	/// Destination connection id -> the connection it belongs to.
-	routes: RefCell<HashMap<Vec<u8>, usize>>,
+	routes: RefCell<Routes>,
 	/// Incoming handshakes in flight. Together with the accept queue this is
 	/// bounded by [`Config::backlog`].
 	pending: Cell<usize>,
@@ -88,7 +164,7 @@ impl Endpoint {
 			local,
 			accepting: RefCell::new(accepting),
 			conns: RefCell::new(slab::Slab::new()),
-			routes: RefCell::new(HashMap::new()),
+			routes: RefCell::new(Routes::default()),
 			pending: Cell::new(0),
 			backlog: config.backlog,
 			shard: config.shard,
@@ -139,7 +215,7 @@ impl Endpoint {
 			return Err(err.clone());
 		}
 		let mut quiche_config = super::client_config(config)?;
-		let scid = cid(self.inner.shard);
+		let scid = self.inner.cid();
 		let conn = quiche::connect(
 			Some(&config.server_name),
 			&quiche::ConnectionId::from_ref(&scid),
@@ -149,7 +225,7 @@ impl Endpoint {
 		)?;
 		let (shared, _key) = self
 			.inner
-			.launch(conn, vec![scid.to_vec()], config.transport.keep_alive);
+			.launch(conn, ConnectionIds::issued(scid), config.transport.keep_alive);
 		// Flush the Initial flight; the demux task takes it from here.
 		shared.kick();
 		connection::establish(shared).await
@@ -232,7 +308,7 @@ impl Inner {
 					continue;
 				}
 			};
-			let key = self.routes.borrow().get(hdr.dcid.as_ref()).copied();
+			let key = self.routes.borrow().get(hdr.dcid.as_ref());
 			match key {
 				Some(key) => {
 					let conn = self.conns.borrow()[key].shared.clone();
@@ -287,7 +363,7 @@ impl Inner {
 			return None;
 		}
 
-		let scid = cid(self.shard);
+		let scid = self.cid();
 		let keep_alive = self.accepting.borrow().as_ref().expect("checked above").keep_alive;
 		let mut conn = {
 			let mut accepting = self.accepting.borrow_mut();
@@ -314,7 +390,11 @@ impl Inner {
 
 		// Route our chosen id, and the client's Initial id: retransmitted
 		// Initials (and 0-RTT) keep carrying it until our id takes effect.
-		let (shared, key) = self.launch(conn, vec![scid.to_vec(), hdr.dcid.to_vec()], keep_alive);
+		let ids = ConnectionIds {
+			issued: vec![scid],
+			initial: Some(hdr.dcid.to_vec()),
+		};
+		let (shared, key) = self.launch(conn, ids, keep_alive);
 		shared.mark_ingested();
 
 		// Hand the connection over once (if) its handshake completes.
@@ -367,20 +447,18 @@ impl Inner {
 	fn launch(
 		self: &Rc<Self>,
 		conn: quiche::Connection,
-		cids: Vec<Vec<u8>>,
+		ids: ConnectionIds,
 		keep_alive: Option<std::time::Duration>,
 	) -> (connection::Shared, usize) {
 		let (shared, driver) = connection::launch(&self.handle, self.socket.clone(), conn, keep_alive);
-		let key = self.conns.borrow_mut().insert(Conn {
+		let mut conns = self.conns.borrow_mut();
+		let key = conns.vacant_key();
+		self.routes.borrow_mut().insert(key, &ids);
+		conns.insert(Conn {
 			shared: shared.clone(),
-			cids: cids.clone(),
+			ids,
 		});
-		{
-			let mut routes = self.routes.borrow_mut();
-			for cid in cids {
-				routes.insert(cid, key);
-			}
-		}
+		drop(conns);
 
 		let inner = self.clone();
 		self.handle.spawn(async move {
@@ -401,19 +479,21 @@ impl Inner {
 			// The peer's active_connection_id_limit is the credit; keep it
 			// spent so a migration always has a fresh id to switch to.
 			while conn.scids_left() > 0 {
-				let cid = cid(self.shard);
+				let cid = self.cid();
 				if conn
 					.new_scid(&quiche::ConnectionId::from_ref(&cid), rand::random(), false)
 					.is_err()
 				{
 					break;
 				}
-				self.routes.borrow_mut().insert(cid.to_vec(), key);
-				self.conns.borrow_mut()[key].cids.push(cid.to_vec());
+				self.routes.borrow_mut().issued.insert(cid, key);
+				self.conns.borrow_mut()[key].ids.issued.push(cid);
 			}
 			while let Some(retired) = conn.retired_scid_next() {
-				self.routes.borrow_mut().remove(retired.as_ref());
-				self.conns.borrow_mut()[key].cids.retain(|cid| cid != retired.as_ref());
+				// We only ever issue CID_LEN ids, so this is what we pushed.
+				let retired: [u8; CID_LEN] = retired.as_ref().try_into().expect("retired a foreign id");
+				self.routes.borrow_mut().remove_issued(&retired, key);
+				self.conns.borrow_mut()[key].ids.issued.retain(|cid| cid != &retired);
 			}
 		}
 		shared.kick();
@@ -422,13 +502,24 @@ impl Inner {
 	/// A connection's driver ended; forget it and its routes.
 	fn release(&self, key: usize) {
 		let conn = self.conns.borrow_mut().remove(key);
-		let mut routes = self.routes.borrow_mut();
-		for cid in conn.cids {
-			routes.remove(&cid);
-		}
-		drop(routes);
+		self.routes.borrow_mut().remove(key, &conn.ids);
 		// The demux task may be waiting on us to exit.
 		self.task_waiters.borrow_mut().wake();
+	}
+
+	/// A fresh connection id no live connection already answers to.
+	///
+	/// A sharded endpoint spends a byte on steering, so the draw is 56 bits
+	/// rather than 64. Rerolling a duplicate keeps "one id, one connection" an
+	/// invariant instead of a probability, since a collision would otherwise
+	/// hand one connection's packets to another.
+	fn cid(&self) -> [u8; CID_LEN] {
+		loop {
+			let cid = cid(self.shard);
+			if self.routes.borrow().get(&cid).is_none() {
+				return cid;
+			}
+		}
 	}
 
 	/// The socket died: everything on it fails with `err`.
@@ -444,5 +535,74 @@ impl Inner {
 			conn.fail(err.clone());
 		}
 		self.accept_waiters.borrow_mut().wake();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn routes_register_and_remove_issued_and_initial_ids() {
+		let issued = [1; CID_LEN];
+		// A client's Initial destination id is any width it likes.
+		let initial = vec![2; CID_LEN * 2];
+		let ids = ConnectionIds {
+			issued: vec![issued],
+			initial: Some(initial.clone()),
+		};
+		let mut routes = Routes::default();
+
+		routes.insert(7, &ids);
+		assert_eq!(routes.get(&issued), Some(7));
+		assert_eq!(routes.get(&initial), Some(7));
+
+		routes.remove(7, &ids);
+		assert_eq!(routes.get(&issued), None);
+		assert_eq!(routes.get(&initial), None);
+	}
+
+	#[test]
+	fn an_initial_id_cannot_capture_an_issued_route() {
+		let cid = [3; CID_LEN];
+		let mut routes = Routes::default();
+		routes.insert(1, &ConnectionIds::issued(cid));
+
+		// A second client names the first connection's id as its Initial
+		// destination: it must neither take the route nor take it away.
+		let squatter = ConnectionIds {
+			issued: vec![[4; CID_LEN]],
+			initial: Some(cid.to_vec()),
+		};
+		routes.insert(2, &squatter);
+		assert_eq!(routes.get(&cid), Some(1));
+
+		routes.remove(2, &squatter);
+		assert_eq!(routes.get(&cid), Some(1));
+	}
+
+	#[test]
+	fn releasing_a_connection_leaves_a_shared_initial_id_alone() {
+		// Nothing stops two clients picking the same Initial destination id.
+		let shared = vec![5; CID_LEN * 2];
+		let first = ConnectionIds {
+			issued: vec![[6; CID_LEN]],
+			initial: Some(shared.clone()),
+		};
+		let second = ConnectionIds {
+			issued: vec![[7; CID_LEN]],
+			initial: Some(shared.clone()),
+		};
+		let mut routes = Routes::default();
+		routes.insert(1, &first);
+		routes.insert(2, &second);
+		assert_eq!(routes.get(&shared), Some(2));
+
+		// The loser going away must not strand the winner's retransmits.
+		routes.remove(1, &first);
+		assert_eq!(routes.get(&shared), Some(2));
+
+		routes.remove(2, &second);
+		assert_eq!(routes.get(&shared), None);
 	}
 }


### PR DESCRIPTION
## Summary

- Use `FxHashMap` for the driver's per-stream maps (`readable`, `writable`, `finishing`, `collected`) and for the connection routes keyed by ids this endpoint issued.
- Split the route table by who chose the id: ids we issued key an `FxHashMap<[u8; CID_LEN], usize>`, while the destination id a client picked for its Initial keeps the default SipHash.
- Look the issued map up first, and make route removal ownership-checked.

Root cause: SipHash ran on every packet's connection-id lookup and on the hot per-stream maps even though those keys are either stream ids quiche assigns or connection ids this endpoint generated. #3121 measured that at ~3-4% of relay CPU on the io_uring path.

The route map is the one that needed care, because #3121's safety note was wrong about it. An accepted connection also registers the client's Initial destination id, so the map does take a key the peer chooses. Those stay on SipHash: a peer could otherwise open connections whose Initial ids all hash alike and turn a per-packet lookup into a scan of them. quinn-proto splits the same two maps for the same reason (`connection_ids_initial` on `HashMap`, `connection_ids` on `FxHashMap`).

Keying the issued map by `[u8; CID_LEN]` rather than `Vec<u8>` also drops the heap allocation per route entry that #3121 called out, and hashes one word instead of a length-prefixed slice.

### Route ownership

Preferring the issued map on lookup closes a route-capture hole: with one map, a client naming a live connection's issued id as its Initial destination id overwrote that route, and releasing the squatting connection removed it.

Teardown had the matching bug, which the split alone does not fix. It removed entries by id without checking who owned them, so a connection releasing an id another one had taken over erased the survivor's route, and two clients picking the same Initial destination id is enough to reach that. Removal now only drops entries still naming the releasing connection, and `cid` rerolls a duplicate draw so "one issued id, one connection" is an invariant rather than a 56-bit probability on a sharded endpoint.

## Public API changes

- None.

## Wire behavior changes

- None.

## Test plan

- Rebased onto `dev` after #3131 split `rs/moq-uring/src/quic` into `quiche/` and `quinn/` backends; this change lives in the quiche backend, which is the default feature set.
- `cargo fmt` / `cargo clippy --locked -p moq-uring --all-targets -- -D warnings`, clean.
- `cargo test --locked -p moq-uring` on real io_uring (kernel 6.19): 51 passed, 0 failed, including three new `Routes` tests covering registration, an Initial id failing to capture an issued route, and a shared Initial id surviving the other connection's release. `--all-features` (quinn backend) also passes.
- `just check`.

## Follow-up

`quinn/connection.rs` from #3131 has the same four `HashMap<StreamId, _>` maps on its driver path and would take the same treatment. Left out of scope here; its endpoint needs nothing, since it keys on quinn's own `ConnectionHandle` and quinn-proto does connection-id routing internally.

Fixes #3121

(Written by GPT-5, taken over and extended by Claude Opus 5)
