### PR TITLE
perf(uring): reuse the worker turn timestamp

### DIFF
--- a/rs/moq-uring/src/quic/connection.rs
+++ b/rs/moq-uring/src/quic/connection.rs
@@ -292,6 +292,7 @@ pub(crate) fn launch(
 	let mut driver = Driver {
 		shared: shared.clone(),
 		socket,
+		runtime: handle.clone(),
 		deadline: moq_net::runtime::Deadline::new(handle),
 		keep_alive: match keep_alive {
 			Some(every) => moq_net::runtime::Deadline::after(handle, every),
@@ -565,6 +566,8 @@ impl web_transport_trait::Stats for Stats {
 struct Driver {
 	shared: Shared,
 	socket: Rc<udp::Socket>,
+	/// Read for the turn's instant when re-arming the keep-alive.
+	runtime: Handle,
 	deadline: moq_net::runtime::Deadline<Handle>,
 	/// Fires when the connection owes the peer an ack-eliciting packet, so an
 	/// idle path (and whatever NAT sits on it) stays open. Disarmed when the
@@ -767,7 +770,7 @@ impl Driver {
 	fn arm_keep_alive(&mut self) {
 		let at = self
 			.keep_alive_every
-			.and_then(|every| std::time::Instant::now().checked_add(every));
+			.and_then(|every| moq_net::Timers::now(&self.runtime).checked_add(every));
 		self.keep_alive.set(at);
 	}
 

--- a/rs/moq-uring/src/shared.rs
+++ b/rs/moq-uring/src/shared.rs
@@ -11,9 +11,47 @@ use std::rc::Rc;
 use std::task::Poll;
 
 use io_uring::{IoUring, squeue};
+use moq_net::runtime::Instant;
 
 use crate::park::Unpark;
 use crate::{timer, udp};
+
+/// One instant shared by everything the worker polls in a turn.
+///
+/// `Instant::now` is a vDSO `clock_gettime`, and a busy turn polls a deadline
+/// per connection plus whatever those arm, all wanting the same answer. The
+/// worker samples once and freezes the clock for the turn, so the whole pass
+/// agrees on the time instead of paying for its own read.
+#[derive(Default)]
+pub(crate) struct Clock {
+	/// The frozen instant, or `None` outside a turn.
+	now: Cell<Option<Instant>>,
+}
+
+impl Clock {
+	/// Freeze the clock at `now` until the returned guard drops.
+	pub fn turn(&self, now: Instant) -> Turn<'_> {
+		self.now.set(Some(now));
+		Turn(self)
+	}
+
+	/// The turn's instant, or the real clock outside one.
+	///
+	/// Reads before the first turn and while the worker is parked hit the real
+	/// clock, so a snapshot is never served past the turn that took it.
+	pub fn now(&self) -> Instant {
+		self.now.get().unwrap_or_else(Instant::now)
+	}
+}
+
+/// Holds a [`Clock`] frozen; dropping it, including on unwind, thaws it.
+pub(crate) struct Turn<'a>(&'a Clock);
+
+impl Drop for Turn<'_> {
+	fn drop(&mut self) {
+		self.0.now.set(None);
+	}
+}
 
 /// A spawned task: the plain poll-closure shape `kio::Tasks` drives.
 pub(crate) type Task = Box<dyn FnMut(&kio::Waiter) -> Poll<()>>;
@@ -51,6 +89,8 @@ pub(crate) enum Op {
 pub(crate) struct Shared {
 	pub ring: RefCell<IoUring>,
 	pub ops: RefCell<slab::Slab<Op>>,
+	/// The monotonic clock sampled once at the start of each worker turn.
+	pub clock: Rc<Clock>,
 	/// Its own `Rc` so a [`crate::Timer`] holds just the heap, not the ring.
 	pub timers: Rc<RefCell<timer::Heap>>,
 	/// Tasks handed to [`crate::Handle::spawn`], drained by the worker loop.
@@ -89,5 +129,25 @@ impl Shared {
 	/// Insert an op and return its `user_data` key.
 	pub fn insert(&self, op: Op) -> u64 {
 		self.ops.borrow_mut().insert(op) as u64
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::time::Duration;
+
+	#[test]
+	fn the_turn_freezes_and_the_guard_thaws() {
+		let clock = Clock::default();
+		let start = Instant::now() - Duration::from_secs(60);
+
+		let turn = clock.turn(start);
+		assert_eq!(clock.now(), start);
+		assert_eq!(clock.now(), start);
+		drop(turn);
+
+		// A minute-old snapshot must not outlive the turn that took it.
+		assert!(clock.now() > start);
 	}
 }

--- a/rs/moq-uring/src/timer.rs
+++ b/rs/moq-uring/src/timer.rs
@@ -70,13 +70,15 @@ impl Heap {
 /// [`crate::Handle`].
 pub struct Timer {
 	heap: Rc<RefCell<Heap>>,
+	clock: Rc<crate::shared::Clock>,
 	slot: Rc<Slot>,
 }
 
 impl Timer {
-	pub(crate) fn new(heap: Rc<RefCell<Heap>>) -> Self {
+	pub(crate) fn new(heap: Rc<RefCell<Heap>>, clock: Rc<crate::shared::Clock>) -> Self {
 		Self {
 			heap,
+			clock,
 			slot: Rc::new(Slot {
 				key: Cell::new(None),
 				elapsed: Cell::new(false),
@@ -109,7 +111,7 @@ impl moq_net::runtime::Timer for Timer {
 		let Some((at, _)) = self.slot.key.get() else {
 			return Poll::Pending;
 		};
-		if at <= Instant::now() {
+		if at <= self.clock.now() {
 			// Fire eagerly rather than waiting for the sweep, and drop the
 			// heap entry so the sweep doesn't wake anyone spuriously.
 			self.heap.borrow_mut().remove(self.slot.key.take().expect("armed"));
@@ -135,5 +137,30 @@ impl std::fmt::Debug for Timer {
 			.field("at", &self.slot.key.get().map(|key| key.0))
 			.field("elapsed", &self.slot.elapsed.get())
 			.finish()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use moq_net::runtime::Timer as _;
+	use std::time::Duration;
+
+	#[test]
+	fn poll_uses_the_worker_turn_clock() {
+		let start = Instant::now();
+		let clock = Rc::new(crate::shared::Clock::default());
+		let mut timer = Timer::new(Rc::new(RefCell::new(Heap::default())), clock.clone());
+		timer.set(Some(start + Duration::from_secs(1)));
+
+		let turn = clock.turn(start);
+		assert!(timer.poll(&kio::Waiter::noop()).is_pending());
+		drop(turn);
+
+		// The deadline is still a second out in real time, so a `Ready` here
+		// can only come from the turn's instant.
+		let turn = clock.turn(start + Duration::from_secs(2));
+		assert!(timer.poll(&kio::Waiter::noop()).is_ready());
+		drop(turn);
 	}
 }

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -94,6 +94,7 @@ impl Worker {
 			shared: Rc::new(Shared {
 				ring: RefCell::new(ring),
 				ops: RefCell::new(slab::Slab::new()),
+				clock: Rc::new(crate::shared::Clock::default()),
 				timers: Rc::new(RefCell::new(timer::Heap::default())),
 				spawns: RefCell::new(Vec::new()),
 				unpark: Unpark::new(),
@@ -122,6 +123,13 @@ impl Worker {
 		let mut future = std::pin::pin!(future);
 		let waker = self.shared.unpark.waker();
 		loop {
+			// One clock read per turn: every deadline polled below reads this
+			// snapshot instead of the vDSO. A timer that comes due mid-turn
+			// therefore fires on the next one, which is also what keeps the
+			// sweep and the eager `Timer::poll` path agreeing on the time.
+			let now = Instant::now();
+			let turn = self.shared.clock.turn(now);
+
 			// Adopt tasks spawned since the last turn (spawning wakes us).
 			let spawns = std::mem::take(&mut *self.shared.spawns.borrow_mut());
 			for task in spawns {
@@ -137,7 +145,8 @@ impl Worker {
 			// registered for the next push.
 			let _ = self.tasks.poll(waiter);
 
-			self.shared.timers.borrow_mut().fire(Instant::now());
+			self.shared.timers.borrow_mut().fire(now);
+			drop(turn);
 			self.pump()?;
 			self.maybe_park()?;
 		}
@@ -398,7 +407,11 @@ impl moq_net::Timers for Handle {
 	type Timer = crate::Timer;
 
 	fn timer(&self) -> Self::Timer {
-		crate::Timer::new(self.shared.timers.clone())
+		crate::Timer::new(self.shared.timers.clone(), self.shared.clock.clone())
+	}
+
+	fn now(&self) -> moq_net::runtime::Instant {
+		self.shared.clock.now()
 	}
 }
 
@@ -511,6 +524,30 @@ mod tests {
 		let elapsed = start.elapsed();
 		assert!(elapsed >= Duration::from_millis(50), "woke early: {elapsed:?}");
 		assert!(elapsed < Duration::from_secs(5), "woke far too late: {elapsed:?}");
+	}
+
+	#[test]
+	fn the_clock_is_frozen_for_a_turn() {
+		let Some(mut worker) = worker() else { return };
+		let handle = worker.handle();
+
+		// Outside a turn the handle reads the real clock.
+		let before = handle.now();
+		std::thread::sleep(Duration::from_millis(5));
+		assert!(handle.now() > before);
+
+		let handle2 = handle.clone();
+		let during = worker
+			.block_on(async move {
+				let first = handle2.now();
+				std::thread::sleep(Duration::from_millis(5));
+				// Every read in the turn is the one instant the worker sampled.
+				assert_eq!(handle2.now(), first);
+				first
+			})
+			.unwrap();
+
+		assert!(handle.now() > during);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

Sample the monotonic clock once at the start of each io_uring worker turn and share that instant with the timer sweep, `Timer::poll`, and keep-alive re-arming.

Root cause: `block_on` read `Instant::now()` for its sweep, and then every deadline polled in that same turn read it again independently. `Timer::poll` is the volume: the connection driver polls its quiche timeout and its keep-alive on every pass, so a busy turn paid a vDSO `clock_gettime` per connection per poll to learn a time the loop had just measured. #3122 measured `[vdso]` at 2.95% of relay CPU on the io_uring path against 0.72% on tokio.

The snapshot lives behind an RAII guard. `Clock::turn(now)` freezes the clock and dropping the guard, including on unwind, thaws it, so reads before the first turn or while the worker is parked still hit the real clock and a stale instant is never served past the turn that took it. `Handle` publishes it as `moq_net::Timers::now`, which is the clock the trait doc already tells callers arming a relative deadline (`now + interval`) to read, so the keep-alive re-arm goes through the trait rather than a bespoke accessor.

One deliberate behavior change: a timer that comes due *during* a turn's polling now fires on the next turn rather than in that turn's sweep. That is what keeps the sweep and the eager `Timer::poll` path agreeing on the time instead of one calling a deadline due while the other calls it pending. It costs at most one extra loop iteration, since `maybe_park` hands an already-past deadline to `io_uring_enter`, which returns immediately rather than blocking.

## What this does not cover

quiche reads the clock itself, once inside `recv` and once inside `send` (`quiche/src/lib.rs:2963` and `:3968`), and again in `on_timeout`. Those are per packet batch and are not reachable from here, so this recovers the timer and keep-alive share of that 2.95%, not all of it. Filed as a follow-up rather than claimed here.

## Public API changes

- None. `Timer` gains a private field; `Timers::now` is a defaulted trait method now overridden for `Handle`.

## Wire behavior changes

- None.

## Test plan

moq-uring is `cfg(linux)`-gated, so it was verified in a container on real io_uring (kernel 6.19), not just cross-compiled:

- `cargo clippy -p moq-uring --all-targets -- -D warnings`: clean.
- `cargo fmt -p moq-uring -- --check`: clean. macOS `cargo fmt` skips this crate entirely, so it has to run on Linux.
- `cargo test -p moq-uring`: 47 tests pass (21 lib + echo/session/endpoint/workers/web), no `skipping io_uring` lines, so these ran against the real ring.
- `cargo clippy -p moq-uring --target x86_64-unknown-linux-gnu --all-targets -- -D warnings` from macOS: clean.

Both new tests were mutation-verified in isolation:

- `worker::the_clock_is_frozen_for_a_turn` asserts `Handle::now()` is stable across a 5ms sleep inside `block_on` and moves outside it. Removing the `Timers::now` override fails it.
- `shared::the_turn_freezes_and_the_guard_thaws` asserts the guard restores the real clock. Making `Turn::drop` a no-op fails it.
- `timer::poll_uses_the_worker_turn_clock` arms a deadline a second out in real time, so its `Ready` can only come from the turn's instant.

Fixes #3122

(Written by Claude Opus 5, taking over Codex's original patch)
