### PR TITLE
fix(watch): anchor the fallback audio ring in live mode too

### DIFF
--- a/js/watch/src/audio/ring-buffer.test.ts
+++ b/js/watch/src/audio/ring-buffer.test.ts
@@ -661,6 +661,30 @@ describe("decoded rate must match the ring (#2352)", () => {
 	});
 });
 
+describe("live anchoring", () => {
+	// The SharedArrayBuffer ring anchors in both modes; this keeps the postMessage fallback
+	// in step. Without anchoring, a first frame at a large timestamp gap-filled the whole ring
+	// with zeros, un-stalled on that overflow, and left the playhead a floor before the frame.
+	it("anchors a live ring to the first frame instead of gap-filling from zero", () => {
+		const buffer = new AudioRingBuffer({ rate: 1000, channels: 1, latency: 100 as Time.Milli });
+		expect(buffer.capacity).toBe(100);
+
+		write(buffer, 2000 as Time.Milli, 40, { channels: 1, value: 0.5 });
+		// Still short of the floor, so nothing plays yet and the ring holds only real samples.
+		expect(buffer.stalled).toBe(true);
+		expect(buffer.length).toBe(40);
+		expect(Time.Milli.fromMicro(buffer.timestamp)).toBe(2000 as Time.Milli);
+
+		write(buffer, 2040 as Time.Milli, 60, { channels: 1, value: 0.5 });
+		expect(buffer.stalled).toBe(false);
+
+		// Playback starts on the first real sample, not on gap-filled silence.
+		const output = read(buffer, 40, 1);
+		expect(output[0].length).toBe(40);
+		expect(output[0][0]).toBeCloseTo(0.5, 5);
+	});
+});
+
 describe("buffered mode", () => {
 	function createBuffered(latency: number) {
 		return new AudioRingBuffer({ rate: 1000, channels: 1, latency: latency as Time.Milli, buffered: true });

--- a/js/watch/src/audio/ring-buffer.ts
+++ b/js/watch/src/audio/ring-buffer.ts
@@ -9,7 +9,7 @@ export class AudioRingBuffer {
 	readonly channels: number;
 	#stalled = true;
 
-	// Buffered mode: anchor to the first sample, play through without skipping ahead.
+	// Buffered mode: play through everything buffered without skipping ahead.
 	readonly #buffered: boolean;
 	// Un-stall threshold in samples (how much to buffer before playback starts).
 	#latencySamples: number;
@@ -104,9 +104,10 @@ export class AudioRingBuffer {
 		let start = Math.round(Time.Second.fromMicro(timestamp) * this.rate);
 		let samples = data[0].length;
 
-		// Buffered mode: anchor both indices to the first sample so we play from its
-		// timestamp instead of gap-filling silence from index 0 to a large timestamp.
-		if (this.#buffered && !this.#anchored) {
+		// Anchor both indices to the first sample so we play from its timestamp instead of
+		// gap-filling silence from index 0 to a large timestamp, which would both waste the
+		// ring on zeros and report a playhead a floor behind the first real sample.
+		if (!this.#anchored) {
 			this.#readIndex = start;
 			this.#writeIndex = start;
 			this.#anchored = true;

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -13,7 +13,7 @@ export interface SharedRingBufferInit {
 	rate: number;
 	samples: SharedArrayBuffer; // channels * capacity * Float32Array.BYTES_PER_ELEMENT bytes
 	control: SharedArrayBuffer; // CONTROL_SLOTS * Int32Array.BYTES_PER_ELEMENT bytes
-	// Buffered mode: anchor to the first sample and never skip ahead on read.
+	// Buffered mode: never skip ahead on read, so we play through everything buffered.
 	buffered: boolean;
 }
 
@@ -116,9 +116,12 @@ export class SharedRingBuffer {
 		}
 
 		// Positions are relative to the anchor. READ/WRITE are Int32, so an absolute sample index
-		// overflows on a stream that has been broadcasting a while, and a negative one pins WRITE
-		// at 0 so the ring never un-stalls. Relative positions instead start at 0, which leaves
-		// the ~13.5h at 44.1kHz to a single continuous playback session.
+		// wraps once a stream has been broadcasting a while, and the wrapped value reads as far
+		// ahead of READ, so every insert is discarded as too old and the ring goes silent for good.
+		// Relative positions start at 0 instead, moving that from ~13.5h of stream age at 44.1kHz to
+		// ~13.5h of one continuous session. Crossing even that still breaks: `slot()` maps the two
+		// sides of the wrap to non-adjacent slots, and `timestamp` reads the negative half as a
+		// backwards jump. See #3132.
 		start = (start - this.#anchor) | 0;
 
 		const end = (start + originalLength) | 0;


### PR DESCRIPTION
## Summary

Follow-up to #3127, which made the `SharedArrayBuffer` ring anchor READ/WRITE to the first inserted sample in **both** live and buffered mode. `AudioRingBuffer` (the postMessage fallback, used when the page isn't cross-origin isolated) still gated anchoring on buffered mode, so the two backends started live playback differently.

## Root cause

Without anchoring, the first frame of a live stream arrives at a large absolute sample index while `#writeIndex` is still 0. So `write()`:

1. gap-fills `min(start, capacity)` = the **entire ring** with zeros,
2. un-stalls via the overflow branch, because `end - readIndex - capacity` is now hugely positive,
3. leaves `#readIndex = end - capacity`.

Two consequences. Playback opens on a full latency floor of silence instead of waiting for real audio. And the playhead starts at roughly `first_frame_ts - latency`, a media time that never existed in the stream. `AudioBuffer` publishes `timestamp` as the playback position, so that bogus value reached A/V sync and the backpressure decisions in `buffer.ts`.

## Fix

Drop the `#buffered &&` guard so anchoring is unconditional, matching the shared ring. Capacity equals the latency floor in live mode (`#capacityFor`), so the existing overflow branch un-stalls at exactly the threshold the shared ring uses (`length >= latencySamples`); no second change is needed to keep the un-stall points aligned.

Also corrects two comments on the shared ring that #3127 left stale:

- the `buffered` init flag no longer selects anchoring, only whether reads skip ahead;
- the wrap comment described the wrong mechanism. A wrapped absolute index reads as *far ahead of* READ, so `insert()` discards every frame as too old and the ring goes silent for good. It does not pin WRITE at 0. The comment now also records what crossing the *relative* wrap still costs, tracked in #3132.

## Public API changes

None. Both ring buffers are internal to `@moq/watch`.

## Test plan

- New regression test in `ring-buffer.test.ts`: confirmed it fails on `main` (the ring un-stalls immediately instead of waiting for the floor) and passes with the fix.
- `just fix`, `just check`, `just test`. Full `@moq/watch` suite: 136 pass.

## Not included

#3132 is untouched: `SharedRingBuffer` positions still carry no wrap epoch, so a ~13.5h continuous session corrupts one window of samples and inverts the playhead. That needs an unwrapped position accumulator and a wrap-invariant slot mapping, which is a coordination change with the worklet reader rather than a comment fix.

(Written by Opus 5)