### PR TITLE
fix(watch): give the shared audio ring a wrap epoch

### DIFF
--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -47,12 +47,20 @@ function read(buffer: SharedRingBuffer, samples: number, channelCount?: number):
 
 describe("initialization", () => {
 	it("should allocate correct SAB sizes", () => {
-		const init = allocSharedRingBuffer(2, 100, 1000);
+		const init = allocSharedRingBuffer(2, 128, 1000);
 		expect(init.channels).toBe(2);
-		expect(init.capacity).toBe(100);
+		expect(init.capacity).toBe(128);
 		expect(init.rate).toBe(1000);
-		expect(init.samples.byteLength).toBe(2 * 100 * 4); // 2 channels * 100 samples * Float32
+		expect(init.samples.byteLength).toBe(2 * 128 * 4); // 2 channels * 128 samples * Float32
 		expect(init.control.byteLength).toBe(4 * 4); // 4 control slots * Int32
+	});
+
+	it("rounds capacity up to a power of two", () => {
+		// slot() masks rather than taking a remainder, which is what keeps it wrap-invariant.
+		expect(allocSharedRingBuffer(1, 100, 1000).capacity).toBe(128);
+		expect(allocSharedRingBuffer(1, 128, 1000).capacity).toBe(128);
+		expect(allocSharedRingBuffer(1, 129, 1000).capacity).toBe(256);
+		expect(allocSharedRingBuffer(1, 1, 1000).capacity).toBe(1);
 	});
 
 	it("should start stalled", () => {
@@ -283,30 +291,30 @@ describe("stall behavior", () => {
 
 describe("ring wrapping", () => {
 	it("should wrap around when buffer is full", () => {
-		const buffer = create({ rate: 1000, channels: 1, capacity: 100, latency: 100 });
+		const buffer = create({ rate: 1000, channels: 1, capacity: 128, latency: 128 });
 
 		// Fill buffer
-		insert(buffer, 0, 100, { channels: 1, value: 1.0 });
+		insert(buffer, 0, 128, { channels: 1, value: 1.0 });
 		expect(buffer.stalled).toBe(false);
 
-		// Read 50 to make room
-		read(buffer, 50, 1);
+		// Read 64 to make room
+		read(buffer, 64, 1);
 
-		// Write 50 more
-		insert(buffer, 100, 50, { channels: 1, value: 2.0 });
-		expect(buffer.length).toBe(100);
+		// Write 64 more
+		insert(buffer, 128, 64, { channels: 1, value: 2.0 });
+		expect(buffer.length).toBe(128);
 
-		// Write 50 more — wraps around
-		insert(buffer, 150, 50, { channels: 1, value: 3.0 });
-		expect(buffer.length).toBe(100);
+		// Write 64 more — wraps around
+		insert(buffer, 192, 64, { channels: 1, value: 3.0 });
+		expect(buffer.length).toBe(128);
 
-		const output = read(buffer, 100, 1);
-		expect(output[0].length).toBe(100);
+		const output = read(buffer, 128, 1);
+		expect(output[0].length).toBe(128);
 
-		for (let i = 0; i < 50; i++) {
+		for (let i = 0; i < 64; i++) {
 			expect(output[0][i]).toBe(2.0);
 		}
-		for (let i = 50; i < 100; i++) {
+		for (let i = 64; i < 128; i++) {
 			expect(output[0][i]).toBe(3.0);
 		}
 	});
@@ -371,27 +379,27 @@ describe("edge cases", () => {
 
 describe("overflow", () => {
 	it("should advance READ when exceeding capacity", () => {
-		const buffer = create({ rate: 1000, channels: 1, capacity: 100, latency: 50 });
+		const buffer = create({ rate: 1000, channels: 1, capacity: 128, latency: 64 });
 
-		// Fill buffer to 50 (LATENCY) to un-stall
-		insert(buffer, 0, 50, { channels: 1, value: 1.0 });
+		// Fill buffer to 64 (LATENCY) to un-stall
+		insert(buffer, 0, 64, { channels: 1, value: 1.0 });
 		expect(buffer.stalled).toBe(false);
 
 		// Write way past capacity — should advance READ
-		insert(buffer, 0, 200, { channels: 1, value: 2.0 });
+		insert(buffer, 0, 256, { channels: 1, value: 2.0 });
 
 		// Buffer should still have <= capacity samples
-		expect(buffer.length).toBeLessThanOrEqual(100);
+		expect(buffer.length).toBeLessThanOrEqual(buffer.capacity);
 		expect(buffer.stalled).toBe(false);
 	});
 
 	it("should handle oversized frames", () => {
-		const buffer = create({ rate: 1000, channels: 1, capacity: 100, latency: 50 });
+		const buffer = create({ rate: 1000, channels: 1, capacity: 128, latency: 64 });
 
 		// Write a frame larger than the buffer capacity
-		insert(buffer, 0, 150, { channels: 1, value: 1.0 });
+		insert(buffer, 0, 192, { channels: 1, value: 1.0 });
 
-		expect(buffer.length).toBeLessThanOrEqual(100);
+		expect(buffer.length).toBeLessThanOrEqual(buffer.capacity);
 		// Should un-stall due to overflow advancing READ
 		expect(buffer.stalled).toBe(false);
 	});
@@ -495,6 +503,68 @@ describe("length getter", () => {
 	});
 });
 
+describe("i32 wrap epoch", () => {
+	// READ/WRITE live in an Int32Array because they are shared with the worklet, so they wrap
+	// every ~13.5h at 44.1kHz. The modular comparisons cope; these cover the two places that
+	// used to read the raw signed value as a magnitude.
+	const WRITE = 0;
+	const READ = 1;
+
+	it("keeps the playhead advancing across the i32 wrap", () => {
+		const init = allocSharedRingBuffer(1, 64, 1000);
+		const control = new Int32Array(init.control);
+		const buffer = new SharedRingBuffer(init);
+		buffer.setLatency(32);
+
+		insert(buffer, 0, 32, { channels: 1, value: 0.5 });
+		expect(Time.Milli.fromMicro(buffer.timestamp)).toBe(0 as Time.Milli);
+
+		// Step READ up to the boundary and over it, observing each time. Production gets these
+		// observations from the 50ms poll in `buffer.ts`.
+		control[READ] = (0x7fffffff - 1) | 0;
+		const before = buffer.timestamp;
+		control[READ] = 0x7fffffff | 0;
+		const at = buffer.timestamp;
+		control[READ] = -0x80000000;
+		const after = buffer.timestamp;
+
+		// One sample at 1000Hz is 1ms. Reading the negative half as a magnitude used to report
+		// the playhead jumping back 2^32 samples here. The loose tolerance is double rounding
+		// in the micro/second conversion at this magnitude, not drift in the position.
+		expect(at - before).toBeCloseTo(1000, 2);
+		expect(after - at).toBeCloseTo(1000, 2);
+		expect(after).toBeGreaterThan(0);
+	});
+
+	it("reads back a frame that straddles the i32 wrap", () => {
+		// Ask for 100, get 128: a power-of-two capacity divides 2^32, so the slot mapping stays
+		// continuous across the boundary. At 100 the frame below aliased onto unread slots.
+		const init = allocSharedRingBuffer(1, 100, 1000);
+		expect(init.capacity).toBe(128);
+
+		const control = new Int32Array(init.control);
+		const buffer = new SharedRingBuffer(init);
+		buffer.setLatency(16);
+
+		insert(buffer, 0, 16, { channels: 1, value: 0.25 });
+		read(buffer, 16, 1);
+
+		// Park both cursors 8 samples below the boundary so the next frame straddles it.
+		const edge = 0x7fffffff - 8;
+		control[READ] = edge | 0;
+		control[WRITE] = edge | 0;
+
+		insert(buffer, edge, 16, { channels: 1, value: 0.75 });
+		expect(buffer.length).toBe(16);
+
+		const out = read(buffer, 16, 1);
+		expect(out[0].length).toBe(16);
+		for (let i = 0; i < 16; i++) {
+			expect(out[0][i]).toBe(0.75);
+		}
+	});
+});
+
 describe("i32 wrapping", () => {
 	it("should handle modular arithmetic with large sample indices", () => {
 		const buffer = create({ rate: 1000, channels: 1, capacity: 100, latency: 100 });
@@ -549,12 +619,12 @@ describe("i32 wrapping", () => {
 
 describe("SharedRingBuffer.resize", () => {
 	it("preserves the unread window when growing capacity", () => {
-		const src = create({ rate: 1000, channels: 2, capacity: 50, latency: 30 });
+		const src = create({ rate: 1000, channels: 2, capacity: 64, latency: 30 });
 		insert(src, 0, 30, { value: 3.5 });
 		expect(src.stalled).toBe(false);
 
-		const dst = src.resize(200);
-		expect(dst.capacity).toBe(200);
+		const dst = src.resize(256);
+		expect(dst.capacity).toBe(256);
 		expect(dst.channels).toBe(2);
 		expect(dst.rate).toBe(1000);
 
@@ -570,17 +640,17 @@ describe("SharedRingBuffer.resize", () => {
 	});
 
 	it("truncates to the newest samples when shrinking below the unread span", () => {
-		const src = create({ rate: 1000, channels: 1, capacity: 50, latency: 40 });
-		// Fill [0, 30) with value 1, then [30, 40) with value 2.
-		insert(src, 0, 30, { channels: 1, value: 1.0 });
-		insert(src, 30, 10, { channels: 1, value: 2.0 });
+		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+		// Fill [0, 48) with value 1, then [48, 64) with value 2.
+		insert(src, 0, 48, { channels: 1, value: 1.0 });
+		insert(src, 48, 16, { channels: 1, value: 2.0 });
 
-		const dst = src.resize(10);
-		expect(dst.capacity).toBe(10);
+		const dst = src.resize(16);
+		expect(dst.capacity).toBe(16);
 
-		// Only the most recent 10 samples fit.
-		const out = read(dst, 10, 1);
-		for (let i = 0; i < 10; i++) {
+		// Only the most recent 16 samples fit.
+		const out = read(dst, 16, 1);
+		for (let i = 0; i < 16; i++) {
 			expect(out[0][i]).toBe(2.0);
 		}
 	});
@@ -636,19 +706,19 @@ describe("buffered mode", () => {
 	});
 
 	it("drops the oldest samples once the buffer exceeds the cap", () => {
-		// 200-sample capacity at 1000Hz = a 200ms cap.
-		const init = allocSharedRingBuffer(1, 200, 1000, true);
+		// 256-sample capacity at 1000Hz = a 256ms cap.
+		const init = allocSharedRingBuffer(1, 256, 1000, true);
 		const buffer = new SharedRingBuffer(init);
 		buffer.setLatency(50);
 
-		insert(buffer, 0, 100, { channels: 1, value: 0.1 }); // [0, 100)
-		insert(buffer, 100, 100, { channels: 1, value: 0.2 }); // [100, 200)
-		insert(buffer, 200, 100, { channels: 1, value: 0.3 }); // exceeds cap; drops [0, 100)
+		insert(buffer, 0, 128, { channels: 1, value: 0.1 }); // [0, 128)
+		insert(buffer, 128, 128, { channels: 1, value: 0.2 }); // [128, 256)
+		insert(buffer, 256, 128, { channels: 1, value: 0.3 }); // exceeds cap; drops [0, 128)
 
 		// READ skipped forward to stay within the cap; oldest frame is gone.
-		expect(Time.Milli.fromMicro(buffer.timestamp)).toBe(100 as Time.Milli);
-		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.2, 5);
-		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.3, 5);
+		expect(Time.Milli.fromMicro(buffer.timestamp)).toBe(128 as Time.Milli);
+		expect(read(buffer, 128, 1)[0][0]).toBeCloseTo(0.2, 5);
+		expect(read(buffer, 128, 1)[0][0]).toBeCloseTo(0.3, 5);
 	});
 
 	it("truncate drops the write-ahead tail a successor supersedes", () => {

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -9,7 +9,7 @@ const CONTROL_SLOTS = 4;
 
 export interface SharedRingBufferInit {
 	channels: number;
-	capacity: number; // samples per channel
+	capacity: number; // samples per channel, always a power of two
 	rate: number;
 	samples: SharedArrayBuffer; // channels * capacity * Float32Array.BYTES_PER_ELEMENT bytes
 	control: SharedArrayBuffer; // CONTROL_SLOTS * Int32Array.BYTES_PER_ELEMENT bytes
@@ -17,6 +17,17 @@ export interface SharedRingBufferInit {
 	buffered: boolean;
 }
 
+/** Rounds up to a power of two, which is what makes `slot` wrap-invariant. */
+function ceilPow2(n: number): number {
+	return n <= 1 ? 1 : 1 << (32 - Math.clz32(n - 1));
+}
+
+/**
+ * Allocate the shared memory for a ring holding at least `capacity` samples per channel.
+ *
+ * The capacity is rounded up to a power of two so `slot` can mask instead of taking a
+ * remainder; read `init.capacity` back rather than assuming the requested value.
+ */
 export function allocSharedRingBuffer(
 	channels: number,
 	capacity: number,
@@ -24,8 +35,10 @@ export function allocSharedRingBuffer(
 	buffered = false,
 ): SharedRingBufferInit {
 	if (channels <= 0) throw new Error("invalid channels");
-	if (capacity <= 0) throw new Error("invalid capacity");
+	if (capacity <= 0 || capacity > 2 ** 30) throw new Error("invalid capacity");
 	if (rate <= 0) throw new Error("invalid sample rate");
+
+	capacity = ceilPow2(capacity);
 
 	const samples = new SharedArrayBuffer(channels * capacity * Float32Array.BYTES_PER_ELEMENT);
 	const control = new SharedArrayBuffer(CONTROL_SLOTS * Int32Array.BYTES_PER_ELEMENT);
@@ -42,9 +55,15 @@ function i32Max(a: number, b: number): number {
 	return ((a - b) | 0) > 0 ? a : b;
 }
 
-/** Maps an absolute sample index to a [0, capacity) array slot. */
+/**
+ * Maps a sample index to a [0, capacity) array slot.
+ *
+ * `capacity` is a power of two, so masking is exact for negative indexes and, unlike a
+ * remainder, survives the i32 wrap: consecutive indexes stay consecutive slots across
+ * 0x7fffffff -> 0x80000000, which is what keeps unread samples from aliasing there.
+ */
 function slot(idx: number, capacity: number): number {
-	return ((idx % capacity) + capacity) % capacity;
+	return idx & (capacity - 1);
 }
 
 /**
@@ -78,6 +97,15 @@ export class SharedRingBuffer {
 	// `timestamp` adds it back to recover media time. Main-thread only: the worklet reads by
 	// difference and never needs an absolute position.
 	#anchor = 0;
+
+	// Unwrapped READ, in anchor-relative samples, plus the raw i32 it was last derived from.
+	// READ is Int32 and wraps every ~13.5h at 44.1kHz. That is harmless for the modular
+	// comparisons the ring runs on, but reading the negative half as a magnitude would report
+	// the playhead jumping back 2^32 samples, so accumulate deltas here instead. Main-thread
+	// only, and only accurate while `timestamp` is observed more often than READ can advance
+	// 2^31 samples, which the 50ms poll in `buffer.ts` satisfies by six orders of magnitude.
+	#position = 0;
+	#lastRead = 0;
 
 	constructor(init: SharedRingBufferInit) {
 		this.channels = init.channels;
@@ -113,15 +141,16 @@ export class SharedRingBuffer {
 			Atomics.store(this.#control, READ, 0);
 			Atomics.store(this.#control, WRITE, 0);
 			this.#anchored = true;
+			this.#position = 0;
+			this.#lastRead = 0;
 		}
 
 		// Positions are relative to the anchor. READ/WRITE are Int32, so an absolute sample index
 		// wraps once a stream has been broadcasting a while, and the wrapped value reads as far
-		// ahead of READ, so every insert is discarded as too old and the ring goes silent for good.
-		// Relative positions start at 0 instead, moving that from ~13.5h of stream age at 44.1kHz to
-		// ~13.5h of one continuous session. Crossing even that still breaks: `slot()` maps the two
-		// sides of the wrap to non-adjacent slots, and `timestamp` reads the negative half as a
-		// backwards jump. See #3132.
+		// ahead of READ, so every insert would be discarded as too old and the ring would go
+		// silent for good. Relative positions start at 0 instead. They still wrap, after ~13.5h at
+		// 44.1kHz, but nothing here reads them as magnitudes: the comparisons are modular, `slot`
+		// masks a power-of-two capacity, and `timestamp` keeps its own unwrapped position.
 		start = (start - this.#anchor) | 0;
 
 		const end = (start + originalLength) | 0;
@@ -299,13 +328,38 @@ export class SharedRingBuffer {
 		Atomics.store(dst.#control, LATENCY, latency);
 		Atomics.store(dst.#control, STALLED, stalled);
 
+		// Carry the unwrapped playhead over, rebased onto dst's READ. Fold the same `read`
+		// snapshot the copy used so both sides agree on one observation; `copyStart` is at or
+		// ahead of it whenever the copy dropped the oldest samples.
+		dst.#position = this.#foldRead(read) + ((copyStart - read) | 0);
+		dst.#lastRead = copyStart;
+
 		return dst;
 	}
 
-	/** Current playback timestamp derived from READ position. */
+	/**
+	 * Fold an observed READ into `#position`, so the returned offset keeps counting up across
+	 * the i32 wrap. Idempotent: folding the same value twice adds a zero delta.
+	 */
+	#foldRead(read: number): number {
+		this.#position += (read - this.#lastRead) | 0;
+		this.#lastRead = read;
+		return this.#position;
+	}
+
+	/** `#foldRead` against the current READ. */
+	#unwrapRead(): number {
+		return this.#foldRead(Atomics.load(this.#control, READ));
+	}
+
+	/**
+	 * Current playback timestamp derived from READ position.
+	 *
+	 * Main thread only, and stateful: it advances the unwrapped read position, so it has to be
+	 * polled rather than sampled once. See `#position`.
+	 */
 	get timestamp(): Time.Micro {
-		const read = Atomics.load(this.#control, READ);
-		return Time.Micro.fromSecond(((this.#anchor + read) / this.rate) as Time.Second);
+		return Time.Micro.fromSecond(((this.#anchor + this.#unwrapRead()) / this.rate) as Time.Second);
 	}
 
 	/** Whether the buffer is stalled (waiting to fill). */


### PR DESCRIPTION
Fixes #3132.

> **Stacked on #3138.** Base is `fix/audio-ring-fallback-anchor`, not `main`, because both branches rewrite the same comment block in `shared-ring-buffer.ts`. Merge #3138 first and I'll rebase; retarget to `main` instead if you'd rather take the conflict.

## Summary

READ/WRITE live in an `Int32Array` because they are shared with the AudioWorklet, so they wrap every ~13.5h at 44.1kHz (~12.4h at 48kHz). Every comparison in the ring is modular (`(a - b) | 0`) and copes with that fine. Two places read the raw signed value as a *magnitude*, and those are what broke.

#3127 moved the trigger from stream age to session length, which is why this needs a real fix rather than being reachable on day one.

## Root cause 1: `slot()` aliased across the boundary

`slot()` took a remainder against an arbitrary capacity. Capacities in use do not divide 2^32, so consecutive indexes stopped mapping to consecutive slots exactly at the wrap:

```
capacity=44100  slots=34144,34145,34146,34147,9952,9953   consecutive=false
capacity=48000  slots=11644,11645,11646,11647,36352,36353 consecutive=false
```

A window straddling the boundary therefore landed on slots still holding unread pre-wrap samples, and played corrupted audio.

**Fix:** round the allocation up to a power of two and mask. Any power of two divides 2^32, so the mapping stays continuous across the wrap by construction. The worklet's per-sample copy loops lose a modulo as a side benefit.

## Root cause 2: `timestamp` lost the wrap epoch

The getter added `#anchor` to READ directly, so crossing into the negative half reported the playhead jumping backwards by 2^32 samples. At 48kHz:

```
READ=0x7fffffff ->  44739242645.83 us
READ=0x80000000 -> -44739242666.67 us   (logical position: +44739242666.67)
```

`SharedAudioBuffer` publishes this as the playback position, so the bogus value reached A/V sync and the backpressure decisions in `buffer.ts`.

**Fix:** track an unwrapped position on the main thread by accumulating READ's modular deltas, carried through `resize()` and rebased when `insert()` re-anchors. This is the same layering `#anchor` already uses: shared state stays modular, the epoch lives on the side that needs it.

## Considered and rejected: 64-bit counters

`Atomics` supports `BigInt64Array`, and widening READ/WRITE to i64 would remove both problems outright, no epoch tracking and no capacity constraint. It puts BigInt allocation in the realtime audio thread, though, which is exactly what an AudioWorklet most needs to avoid. Keeping the counters i32 leaves the worklet path allocation-free and slightly faster than before.

## Public API changes

None escaping the package, but one internal contract changed: `allocSharedRingBuffer` now returns a capacity rounded up to a power of two, and rejects a request above 2^30. Callers should read `init.capacity` back rather than assume the requested value. `buffer.ts` already does.

## Test plan

Three new tests, each confirmed to fail without the fix:

- capacity rounds up to a power of two;
- the playhead keeps advancing across the wrap (fails at `-4294967295000`, the 2^32-sample jump);
- a frame straddling the wrap reads back intact.

Seven existing tests assumed an exact capacity. They are rescaled to power-of-two values (100→128, 200→256, 50→64) rather than re-derived against the rounded numbers, so their arithmetic still reads meaningfully.

`just fix`, `just check`, `just test` all clean. `@moq/watch`: 139 pass.

(Written by Opus 5)