### PR TITLE
feat(json): let a snapshot publisher cut a group

### DIFF
--- a/js/json/src/snapshot/index.ts
+++ b/js/json/src/snapshot/index.ts
@@ -12,6 +12,11 @@
  * following frames are RFC 7396 JSON Merge Patch deltas applied in order. Interoperable with the
  * Rust `moq_json::snapshot`.
  *
+ * The encoder rolls a group on its own budget, but a caller can roll one for its own reasons with
+ * {@link Producer.cut}: it closes the open group and leaves the next update to open the replacement
+ * with a full snapshot, so the deltas already written stop being provisional without publishing an
+ * empty group.
+ *
  * {@link Producer} and {@link Consumer} own a track: hand one a track and it manages the groups for
  * you. {@link Encoder} and {@link Decoder} are the same logic without the track. The encoder turns
  * values into {@link Encoded} frame payloads and says where the group boundaries fall; the decoder

--- a/js/json/src/snapshot/producer.ts
+++ b/js/json/src/snapshot/producer.ts
@@ -31,6 +31,29 @@ export class Producer<T> {
 		this.#deltas = (config.deltaRatio ?? DEFAULT_DELTA_RATIO) !== 0;
 	}
 
+	/**
+	 * Finish the open group, so the deltas already written stop being provisional.
+	 *
+	 * No replacement group opens until the next {@link update}, which emits a full snapshot as its
+	 * first frame even when the value is unchanged. A consumer joining at that group therefore reads
+	 * the whole value without the deltas that preceded it.
+	 *
+	 * Idempotent: cutting when no group is open does nothing, so a caller can cut on its own schedule
+	 * without tracking what has been published since the last one. Inert when deltas are disabled,
+	 * where every frame already gets its own group.
+	 */
+	cut(): void {
+		if (!this.#group) return;
+
+		// Reset first: the group closes either way below, and a throw must not leave the encoder
+		// emitting deltas against a snapshot whose group is gone.
+		this.#encoder.reset();
+
+		const group = this.#group;
+		this.#group = undefined;
+		group.close();
+	}
+
 	/** Publish a new value, emitting a snapshot or delta automatically. No-op if unchanged. */
 	update(value: T): void {
 		const frame = this.#encoder.update(value);

--- a/js/json/src/snapshot/snapshot.test.ts
+++ b/js/json/src/snapshot/snapshot.test.ts
@@ -31,6 +31,77 @@ async function structure(track: Track.Subscriber): Promise<number[]> {
 	return counts;
 }
 
+test("a cut makes the next update a snapshot group", async () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<Value>({ track, deltaRatio: 100 });
+	producer.update({ a: 1, b: 1 });
+	producer.update({ a: 1, b: 2 });
+	producer.cut();
+	producer.update({ a: 1, b: 3 });
+	producer.finish();
+
+	// The ratio would have kept every update in one group; the cut rolled it anyway. The replacement
+	// opens with a full snapshot, so it is one frame rather than a delta appended to the first group.
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([2, 1]);
+	expect((await drain(track.subscribe({ maxAge: REPLAY_LATENCY }))).at(-1)).toEqual({ a: 1, b: 3 });
+});
+
+test("a cut republishes an unchanged value", async () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<Value>({ track, deltaRatio: 100 });
+	producer.update({ a: 1 });
+	producer.cut();
+
+	// An unchanged value normally writes nothing. After a cut it must still open the replacement
+	// group, or the value would only exist in a group no new consumer reads.
+	producer.update({ a: 1 });
+	producer.finish();
+
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([1, 1]);
+});
+
+test("a cut opens no replacement group", async () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<Value>({ track, deltaRatio: 100 });
+	producer.update({ a: 1 });
+	producer.cut();
+	producer.finish();
+
+	// Cutting closes the open group and stops there: no empty group for a consumer to advance into.
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([1]);
+});
+
+test("a cut is idempotent", async () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<Value>({ track, deltaRatio: 100 });
+
+	// Nothing published yet, so there is no group to cut.
+	producer.cut();
+	producer.cut();
+	producer.update({ a: 1 });
+
+	// And a repeated cut rolls once, not once per call.
+	producer.cut();
+	producer.cut();
+	producer.update({ a: 2 });
+	producer.finish();
+
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([1, 1]);
+});
+
+test("a cut is inert without deltas", async () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<Value>({ track, deltaRatio: 0 });
+	producer.update({ a: 1 });
+
+	// With deltas off every frame already closes its own group, so there is never one to cut.
+	producer.cut();
+	producer.update({ a: 2 });
+	producer.finish();
+
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([1, 1]);
+});
+
 test("deltas off: a snapshot group per change", async () => {
 	const track = new Track.Producer("test");
 	const producer = new Producer<Value>({ track, deltaRatio: 0 });

--- a/rs/moq-json/src/snapshot/mod.rs
+++ b/rs/moq-json/src/snapshot/mod.rs
@@ -16,6 +16,11 @@
 //! Deltas are controlled by [`ProducerConfig::delta_ratio`]. A ratio of `0` disables them, so every
 //! change is a fresh snapshot group, matching a plain "one JSON blob per group" track.
 //!
+//! The encoder rolls a group on its own budget, but a caller can roll one for its own reasons with
+//! [`Producer::cut`]: it closes the open group and leaves the next update to open the replacement
+//! with a full snapshot, so the deltas already written stop being provisional without publishing an
+//! empty group.
+//!
 //! # Choosing a layer
 //!
 //! [`Producer`] and [`Consumer`] own a track: hand one a
@@ -88,6 +93,84 @@ mod test {
 			out.push(value);
 		}
 		out
+	}
+
+	#[test]
+	fn a_cut_makes_the_next_update_a_snapshot_group() {
+		let (mut producer, track) = producer(cfg(100));
+		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
+		producer.update(&json!({ "a": 1, "b": 2 })).unwrap();
+		producer.cut().unwrap();
+		producer.update(&json!({ "a": 1, "b": 3 })).unwrap();
+		producer.finish().unwrap();
+
+		// The ratio would have kept every update in one group; the cut rolled it anyway. A consumer
+		// joining at the new group reads the whole value from its first frame, with none of the deltas
+		// that preceded the cut.
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track).last().unwrap(), &json!({ "a": 1, "b": 3 }));
+	}
+
+	#[test]
+	fn a_cut_republishes_an_unchanged_value() {
+		let (mut producer, track) = producer(cfg(100));
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.cut().unwrap();
+
+		// An unchanged value normally writes nothing. After a cut it must still open the replacement
+		// group, or the value would only exist in a group no new consumer reads.
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track), vec![json!({ "a": 1 })]);
+	}
+
+	#[test]
+	fn a_cut_opens_no_replacement_group() {
+		let (mut producer, track) = producer(cfg(100));
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.cut().unwrap();
+		producer.finish().unwrap();
+
+		// Cutting closes the open group and stops there: no empty group for a consumer to advance into
+		// and wait on.
+		assert_eq!(track.latest(), Some(0));
+		assert_eq!(drain(track), vec![json!({ "a": 1 })]);
+	}
+
+	#[test]
+	fn a_cut_is_idempotent() {
+		let (mut producer, track) = producer(cfg(100));
+
+		// Nothing published yet, so there is no group to cut.
+		producer.cut().unwrap();
+		producer.cut().unwrap();
+		producer.update(&json!({ "a": 1 })).unwrap();
+		assert_eq!(track.latest(), Some(0));
+
+		// And a repeated cut rolls once, not once per call.
+		producer.cut().unwrap();
+		producer.cut().unwrap();
+		producer.update(&json!({ "a": 2 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track), vec![json!({ "a": 2 })]);
+	}
+
+	#[test]
+	fn a_cut_is_inert_without_deltas() {
+		let (mut producer, track) = producer(cfg(0));
+		producer.update(&json!({ "a": 1 })).unwrap();
+
+		// With deltas off every frame already closes its own group, so there is never one to cut.
+		producer.cut().unwrap();
+		producer.update(&json!({ "a": 2 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track), vec![json!({ "a": 2 })]);
 	}
 
 	#[test]

--- a/rs/moq-json/src/snapshot/producer.rs
+++ b/rs/moq-json/src/snapshot/producer.rs
@@ -115,6 +115,19 @@ impl<T: Serialize> Producer<T> {
 		}
 	}
 
+	/// Finish the open group, so the deltas already written stop being provisional.
+	///
+	/// No replacement group opens until the next [`update`](Self::update), which emits a full
+	/// snapshot as its first frame even when the value is unchanged. A consumer joining at that group
+	/// therefore reads the whole value without the deltas that preceded it.
+	///
+	/// Idempotent: cutting when no group is open does nothing, so a caller can cut on its own
+	/// schedule without tracking what has been published since the last one. Inert when deltas are
+	/// disabled, where every frame already gets its own group.
+	pub fn cut(&mut self) -> Result<()> {
+		self.inner.lock().unwrap().cut()
+	}
+
 	/// Finish the track, closing any open group.
 	pub fn finish(&mut self) -> Result<()> {
 		self.inner.lock().unwrap().finish()
@@ -188,6 +201,20 @@ struct Inner<T> {
 	encoder: Encoder<T>,
 }
 
+impl<T> Inner<T> {
+	/// Finish the open group, leaving the next update to open a replacement with a full snapshot.
+	fn cut(&mut self) -> Result<()> {
+		if self.track.group.is_none() {
+			return Ok(());
+		}
+
+		// The group closes either way below, so reset first: a `finish` error must not leave the
+		// encoder emitting deltas against a snapshot whose group is gone.
+		self.encoder.reset();
+		self.track.cut()
+	}
+}
+
 impl<T: Serialize> Inner<T> {
 	fn update(&mut self, value: &T) -> Result<()> {
 		// Split the borrow so `frame` can hold the encoder while `track` is written through.
@@ -228,6 +255,14 @@ struct Track {
 }
 
 impl Track {
+	/// Finish the open group without opening a replacement.
+	fn cut(&mut self) -> Result<()> {
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+		Ok(())
+	}
+
 	/// Write one encoded frame, rolling a group when it's a snapshot.
 	fn write(&mut self, encoded: &Encoded) -> Result<()> {
 		match encoded.keyframe {


### PR DESCRIPTION
## Summary

A `moq-json` snapshot publisher had no way to force a group boundary. The encoder rolls on its own delta budget and frame cap, so a caller that knows the deltas already written should stop being provisional — because it is about to store them, or because a joiner should not have to replay them — had no way to say so.

`snapshot::Producer::cut()` FINs the open group and opens no replacement. The next `update` does, emitting a full snapshot as frame 0 even when the value is unchanged, so a consumer joining there reads the whole value and none of the deltas that preceded the cut. Cutting with no group open is a no-op, so a caller can cut on its own schedule without tracking what it has published, and it is inert with `deltaRatio` at 0, where every frame already gets its own group.

## Deliberately not included

This PR originally also carried an age-based bound (`max_age`) and the same method on `stream`. Both are dropped.

A cut cannot express a sliding window on an append-only log. Re-seeding a new group with the retained records is indistinguishable from new data on the wire — a `stream` consumer yields every frame in order across group boundaries — so a live consumer receives them twice. In this repo that is worse than a duplicate: `moq-hls` reads a non-increasing `segment` as "the publisher restarted" and clears its whole playlist window (`export/segments.rs:137`, `export/renditions.rs:185`).

Since the broadcast timeline is the only `stream` user in either language, a cut there would have shipped with no consumer and a real footgun. The timeline gets a windowed log with tagged reset/push/pop ops instead, tracked separately.

## Public API changes

Additive; nothing renamed, removed, or signature-changed.

- `moq_json::snapshot::Producer::cut()` (new)
- `@moq/json` `Snapshot.Producer.cut()` (new)

## Wire behavior changes

No encoding change, and no change at all unless a caller opts in by calling `cut()`. When one does, a peer sees a group boundary it would not otherwise see, and the next frame is a full snapshot rather than a merge patch. Both are shapes the format already produces whenever the encoder's own budget rolls a group, so nothing new has to be understood by a consumer. No draft update needed.

## Test plan

- `just check` and `just test` (1933 tests, 1 skipped) green.
- 5 new Rust tests and 5 new TS tests: the forced roll, republishing an unchanged value, the no-empty-group guarantee, idempotency (including before anything is published), and inertness with deltas disabled.

(written by claude-opus-5)