### PR TITLE
fix(publish): scope media device test mocks

### DIFF
--- a/js/publish/src/source/device.test.ts
+++ b/js/publish/src/source/device.test.ts
@@ -51,13 +51,20 @@ class FakeMediaDevices extends EventTarget {
 	}
 }
 
-function install(devices: MediaDeviceInfo[], settled?: string): FakeMediaDevices {
+function install(devices: MediaDeviceInfo[], settled?: string): FakeMediaDevices & Disposable {
 	const fake = new FakeMediaDevices(devices, settled);
-	Object.defineProperty(globalThis, "navigator", {
+	const original = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
+	Object.defineProperty(navigator, "mediaDevices", {
 		configurable: true,
-		value: { mediaDevices: fake },
+		value: fake,
 	});
-	return fake;
+
+	return Object.assign(fake, {
+		[Symbol.dispose]() {
+			if (original) Object.defineProperty(navigator, "mediaDevices", original);
+			else Reflect.deleteProperty(navigator, "mediaDevices");
+		},
+	});
 }
 
 const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
@@ -66,7 +73,7 @@ async function settle(times = 10): Promise<void> {
 }
 
 test("an unresolvable default pins nothing", async () => {
-	install(ANDROID);
+	using _media = install(ANDROID);
 
 	const device = new Device("audio");
 	await settle();
@@ -80,7 +87,7 @@ test("an unresolvable default pins nothing", async () => {
 });
 
 test("the platform default is reported but never pinned", async () => {
-	install(DESKTOP);
+	using _media = install(DESKTOP);
 
 	const device = new Device("audio");
 	await settle();
@@ -92,7 +99,7 @@ test("the platform default is reported but never pinned", async () => {
 });
 
 test("a preferred device is pinned once it is known to exist", async () => {
-	install(DESKTOP);
+	using _media = install(DESKTOP);
 
 	const device = new Device("audio", { preferred: "bbb" });
 	await settle();
@@ -107,7 +114,7 @@ test("a preferred device is pinned once it is known to exist", async () => {
 });
 
 test("a capture without a preference stays unpinned", async () => {
-	const media = install(ANDROID);
+	using media = install(ANDROID);
 
 	const mic = new Microphone({ enabled: true });
 	await settle();
@@ -124,4 +131,9 @@ test("a capture without a preference stays unpinned", async () => {
 	expect(mic.device.out.requested.peek()).toBeUndefined();
 
 	mic.close();
+});
+
+test("installing media devices preserves browser identity", () => {
+	using _media = install(DESKTOP);
+	expect(typeof navigator.userAgent).toBe("string");
 });

--- a/js/publish/src/source/retry.test.ts
+++ b/js/publish/src/source/retry.test.ts
@@ -101,12 +101,23 @@ function device(deviceId: string): MediaDeviceInfo {
 	return { deviceId, label: deviceId, groupId: deviceId, kind: "videoinput", toJSON: () => ({}) };
 }
 
-function install<T extends EventTarget>(media: T): T {
-	Object.defineProperty(globalThis, "navigator", { configurable: true, value: { mediaDevices: media } });
+function install<T extends EventTarget>(media: T): T & Disposable {
+	const originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
+	Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: media });
 
 	// Screen capture probes self.CaptureController.
+	const originalSelf = Object.getOwnPropertyDescriptor(globalThis, "self");
 	Object.defineProperty(globalThis, "self", { configurable: true, value: globalThis });
-	return media;
+
+	return Object.assign(media, {
+		[Symbol.dispose]() {
+			if (originalMediaDevices) Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
+			else Reflect.deleteProperty(navigator, "mediaDevices");
+
+			if (originalSelf) Object.defineProperty(globalThis, "self", originalSelf);
+			else Reflect.deleteProperty(globalThis, "self");
+		},
+	});
 }
 
 const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
@@ -163,7 +174,7 @@ function published(source: { track: MediaStreamTrack } | MediaStreamTrack | unde
 }
 
 test("a microphone re-opens when its track dies", async () => {
-	const media = install(new FakeMediaDevices());
+	using media = install(new FakeMediaDevices());
 
 	const mic = new Microphone({ enabled: true });
 	await settle();
@@ -180,7 +191,7 @@ test("a microphone re-opens when its track dies", async () => {
 });
 
 test("a camera re-opens when its track dies", async () => {
-	const media = install(new FakeMediaDevices());
+	using media = install(new FakeMediaDevices());
 
 	const camera = new Camera({ enabled: true });
 	await settle();
@@ -196,7 +207,7 @@ test("a camera re-opens when its track dies", async () => {
 });
 
 test("running out of retries clears the source instead of publishing a corpse", async () => {
-	const media = install(new FakeMediaDevices());
+	using media = install(new FakeMediaDevices());
 
 	const mic = new Microphone({ enabled: true });
 	await settle();
@@ -224,7 +235,7 @@ test("running out of retries clears the source instead of publishing a corpse", 
 });
 
 test("a track that arrives dead is not published", async () => {
-	const media = install(new FakeMediaDevices());
+	using media = install(new FakeMediaDevices());
 	media.bornDead = true;
 
 	const mic = new Microphone({ enabled: true });
@@ -238,7 +249,7 @@ test("a track that arrives dead is not published", async () => {
 test(
 	"a replug recovers a capture whose retries all failed",
 	async () => {
-		const media = install(new FakeMediaDevices());
+		using media = install(new FakeMediaDevices());
 
 		const camera = new Camera({ enabled: true });
 		await settle();
@@ -271,7 +282,7 @@ test(
 test(
 	"picking a different device revives a capture whose retries all failed",
 	async () => {
-		const media = install(new FakeMediaDevices());
+		using media = install(new FakeMediaDevices());
 		media.devices = [device("cam"), device("cam2")];
 
 		const camera = new Camera({ enabled: true });
@@ -303,7 +314,7 @@ test(
 test(
 	"changing the constraints revives a capture whose retries all failed",
 	async () => {
-		const media = install(new FakeMediaDevices());
+		using media = install(new FakeMediaDevices());
 
 		const mic = new Microphone({ enabled: true, constraints: { channelCount: 99 } });
 		await settle();
@@ -333,7 +344,7 @@ test(
 );
 
 test("unrelated device churn does not disturb a healthy capture", async () => {
-	const media = install(new FakeMediaDevices());
+	using media = install(new FakeMediaDevices());
 
 	const camera = new Camera({ enabled: true });
 	await settle();
@@ -350,7 +361,7 @@ test("unrelated device churn does not disturb a healthy capture", async () => {
 });
 
 test("screen capture releases every track when the video ends", async () => {
-	const media = install(new FakeScreenDevices());
+	using media = install(new FakeScreenDevices());
 
 	const screen = new Screen({ enabled: true });
 	await settle();
@@ -372,7 +383,7 @@ test("screen capture releases every track when the video ends", async () => {
 });
 
 test("screen capture releases every track when the audio ends", async () => {
-	const media = install(new FakeScreenDevices());
+	using media = install(new FakeScreenDevices());
 
 	const screen = new Screen({ enabled: true });
 	await settle();
@@ -388,7 +399,7 @@ test("screen capture releases every track when the audio ends", async () => {
 });
 
 test("screen capture releases a share whose track arrives dead", async () => {
-	const media = install(new FakeScreenDevices(true));
+	using media = install(new FakeScreenDevices(true));
 
 	const screen = new Screen({ enabled: true });
 	await settle();
@@ -403,7 +414,7 @@ test("screen capture releases a share whose track arrives dead", async () => {
 });
 
 test("screen capture prompts again after being switched off and on", async () => {
-	const media = install(new FakeScreenDevices());
+	using media = install(new FakeScreenDevices());
 	const enabled = new Signal(true);
 
 	const screen = new Screen({ enabled });


### PR DESCRIPTION
## Summary

- Fix an order-dependent `@moq/publish` test failure caused by media-device tests replacing the entire global `navigator` with a partial object and leaking it into later video tests.
- Scope the mocks to `navigator.mediaDevices` and restore the original `mediaDevices` and `self` descriptors after each test.
- Add a regression assertion that installing the media-device fake preserves browser identity.

## Public API changes

None. This is test-only.

## Test plan

- `nix develop --command just fix`
- Focused CI-order reproduction: 22 passed, 0 failed
- `nix develop --command just check`
- `nix develop --command just test`

Cross-package sync is not applicable to this test-only change.

(Written by GPT-5.6)