### PR TITLE
fix: restore upstream quiche dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6456,7 +6456,8 @@ dependencies = [
 [[package]]
 name = "octets"
 version = "0.3.6"
-source = "git+https://github.com/moq-dev/quiche?rev=55e12064f384aa024a0d340599e1b4485cbfe5a9#55e12064f384aa024a0d340599e1b4485cbfe5a9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "866cb5af6f3aa3c1b44c3c2d79d22165fbb1b102e1b3fb499864bfe34736ec4b"
 
 [[package]]
 name = "oid-registry"
@@ -7282,7 +7283,8 @@ dependencies = [
 [[package]]
 name = "qlog"
 version = "0.18.0"
-source = "git+https://github.com/moq-dev/quiche?rev=55e12064f384aa024a0d340599e1b4485cbfe5a9#55e12064f384aa024a0d340599e1b4485cbfe5a9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65c0ae39cba4538fd935d376ba17f858046b386dc4597e3fa5c1aedb919ef30"
 dependencies = [
  "flate2",
  "foundations",
@@ -7330,7 +7332,8 @@ dependencies = [
 [[package]]
 name = "quiche"
 version = "0.29.3"
-source = "git+https://github.com/moq-dev/quiche?rev=55e12064f384aa024a0d340599e1b4485cbfe5a9#55e12064f384aa024a0d340599e1b4485cbfe5a9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61166d27591eb7cb1310eec2b8fc6ae0e0686e9e4ed742a3ffc6317171175e7d"
 dependencies = [
  "boring",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,14 +211,3 @@ strip = true
 # workspace copy so exactly one kio is built.
 [patch.crates-io]
 kio = { path = "rs/kio" }
-# Every quiche consumer builds from moq-dev/quiche's `moq` branch: raw sans-IO
-# quiche in moq-uring, and tokio-quiche (external, via web-transport-quiche)
-# compiled against whatever this patch supplies. The fork stays API-compatible
-# with the crates-io release it forks; see its README for the rebase policy.
-# octets and qlog ride along: quiche's git copy path-depends on its in-repo
-# octets/qlog, so without these patches tokio-quiche would compile against the
-# registry octets while quiche's error types use the git one, and the two
-# don't unify.
-quiche = { git = "https://github.com/moq-dev/quiche", rev = "55e12064f384aa024a0d340599e1b4485cbfe5a9" }
-octets = { git = "https://github.com/moq-dev/quiche", rev = "55e12064f384aa024a0d340599e1b4485cbfe5a9" }
-qlog = { git = "https://github.com/moq-dev/quiche", rev = "55e12064f384aa024a0d340599e1b4485cbfe5a9" }


### PR DESCRIPTION
## Summary

- Remove the workspace patches added in #3117 so `dev` does not commit every quiche consumer to the `moq-dev/quiche` fork.
- Restore the crates.io sources and checksums for `quiche` 0.29.3, `octets` 0.3.6, and `qlog` 0.18.0.

## Public API changes

None.

## Wire behavior changes

None.

## Test plan

- `just fix`
- `just check`
- `just test` (3,733 passed, 2 skipped)

No cross-package sync row applies because this only changes dependency sources.

(written by GPT-5)