### PR TITLE
fix(cli): serve TCP and Unix listeners without QUIC

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -84,8 +84,12 @@ moq <MoQ side>  play [playback options]
   - `--client-connect <url>` dials a relay. The URL path is the relay auth path
     (e.g. `/anon`), `?jwt=<token>` supplies a token, and `--broadcast` names the
     broadcast.
-  - `--server-bind <addr>` hosts MoQ sessions directly (with `--tls-generate` /
-    `--tls-cert` + `--tls-key`).
+  - `--server-bind <addr>` hosts encrypted QUIC/WebTransport sessions directly
+    (with `--tls-generate` / `--tls-cert` + `--tls-key`).
+  - `--server-tcp-bind <addr>` hosts plaintext qmux over TCP. Bind it only to
+    loopback or a trusted private network.
+  - `--server-unix-bind <path>` hosts qmux over a Unix socket. Restrict access
+    through its parent directory or an explicit peer-credential allowlist.
 
   Both may be given at once (dial a relay *and* accept incoming sessions).
   `--origin <id>` pins the process's origin id (default: fresh and random per

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -80,7 +80,8 @@ moq-audio = { workspace = true, optional = true }
 # `server` enables the HTTP egress server for `moq export hls`; the importer is always available.
 moq-hls = { workspace = true, features = ["server"] }
 moq-mux = { workspace = true }
-moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
+# Raw qmux listeners are part of the CLI surface. `uds` compiles only on Unix.
+moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs", "tcp", "uds"] }
 moq-rtc = { workspace = true }
 moq-rtmp = { workspace = true }
 moq-srt = { workspace = true }

--- a/rs/moq-cli/README.md
+++ b/rs/moq-cli/README.md
@@ -19,7 +19,7 @@ Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub
 
 ## Usage
 
-`moq-cli` routes endpoints onto a shared MoQ Origin: `moq <MoQ side> <import|export> <endpoint>`. The MoQ side (before the verb) is either `--client-connect <url>` (dial a relay) or `--server-bind <addr>` (self-host). `import` moves media into MoQ, `export` moves it out. The endpoint is a container format (`fmp4`, `ts`, `flv`, ... read from stdin / written to stdout), or a gateway (`hls`, `rtmp`, `srt`, `rtc`). A build with the `play` feature can also render a broadcast locally with `moq <MoQ side> play`.
+`moq-cli` routes endpoints onto a shared MoQ Origin: `moq <MoQ side> <import|export> <endpoint>`. The MoQ side (before the verb) dials with `--client-connect <url>`, self-hosts QUIC/WebTransport with `--server-bind <addr>`, or self-hosts raw qmux with `--server-tcp-bind <addr>` / `--server-unix-bind <path>` (Unix only). `import` moves media into MoQ, `export` moves it out. The endpoint is a container format (`fmp4`, `ts`, `flv`, ... read from stdin / written to stdout), or a gateway (`hls`, `rtmp`, `srt`, `rtc`). A build with the `play` feature can also render a broadcast locally with `moq <MoQ side> play`.
 
 Separate additional stages with `--` to bridge several broadcasts (or both directions) over one connection, each naming its own `--broadcast`:
 

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -4,9 +4,10 @@
 //! `<import|export> <endpoint> [endpoint opts]`, plus `moq <MoQ side> play` for
 //! native playback.
 //!
-//! - The MoQ side (`--client-connect` / `--server-bind`, both optional, at least
-//!   one) attaches the shared Origin to the MoQ network, and comes before the
-//!   first stage. Both may be given: dial a relay *and* accept incoming sessions.
+//! - The MoQ side (`--client-connect` or one of the `--server-*-bind` options,
+//!   all optional, at least one) attaches the shared Origin to the MoQ network,
+//!   and comes before the first stage. They may be combined to dial a relay and
+//!   accept incoming sessions.
 //! - `import` routes media INTO MoQ from one source; `export` routes it OUT to
 //!   one sink. The verb fixes the data direction (and thus, for the
 //!   bidirectional gateways, whether `--connect`/`--listen` push or pull).
@@ -173,7 +174,7 @@ impl Invocation {
 	}
 }
 
-/// The MoQ attachment. At least one of `--client-connect` / `--server-bind`;
+/// The MoQ attachment. At least one client or server transport must be configured;
 /// both may be given at once.
 ///
 /// The group is not `required`, because the local verbs (`token`, `devices`) run
@@ -206,7 +207,8 @@ pub struct MoqSide {
 	#[command(flatten)]
 	pub client: moq_native::ClientConfig,
 
-	/// MoQ server transport config (`--server-bind`, `--server-tls-*`, `--tls-*`).
+	/// MoQ server transport config (`--server-bind`, `--server-tcp-bind`,
+	/// `--server-unix-bind`, `--server-tls-*`, `--tls-*`).
 	#[command(flatten)]
 	pub server: moq_native::ServerConfig,
 
@@ -228,13 +230,18 @@ impl MoqSide {
 		.produce())
 	}
 
+	/// Whether any inbound server transport is explicitly configured.
+	pub fn serves(&self) -> bool {
+		self.server.has_explicit_bind()
+	}
+
 	/// Reject a verb that needs the MoQ network but was given no way to reach it.
 	/// Stands in for the clap `required` the `moq` group can't carry, since
 	/// `devices` is exempt.
 	pub fn validate(&self) -> anyhow::Result<()> {
 		anyhow::ensure!(
-			self.client.connect.is_some() || self.server.bind.is_some(),
-			"a MoQ side is required: pass --client-connect <url> to dial a relay, or --server-bind <addr> to self-host"
+			self.client.connect.is_some() || self.serves(),
+			"a MoQ side is required: pass --client-connect <url> to dial a relay, or a --server-*-bind option to self-host"
 		);
 		Ok(())
 	}
@@ -250,10 +257,25 @@ impl MoqSide {
 		let ignored = [
 			("--client-connect", self.client.connect.is_some()),
 			("--server-bind", self.server.bind.is_some()),
+			("--server-tcp-bind", self.server.tcp.bind.is_some()),
 			("--broadcast", self.broadcast.is_some()),
 		];
+		let ignored = ignored.into_iter().find(|(_, given)| *given).map(|(flag, _)| flag);
+		#[cfg(unix)]
+		let ignored = ignored
+			.or_else(|| self.server.unix.bind.is_some().then_some("--server-unix-bind"))
+			.or_else(|| {
+				let allow = self.server.unix.allow.as_ref()?;
+				[
+					("--server-unix-allow-uid", !allow.uid.is_empty()),
+					("--server-unix-allow-gid", !allow.gid.is_empty()),
+					("--server-unix-allow-pid", !allow.pid.is_empty()),
+				]
+				.into_iter()
+				.find_map(|(flag, given)| given.then_some(flag))
+			});
 
-		if let Some((flag, _)) = ignored.into_iter().find(|(_, given)| *given) {
+		if let Some(flag) = ignored {
 			anyhow::bail!("`{command}` runs locally and takes no MoQ side; drop {flag}");
 		}
 
@@ -537,6 +559,28 @@ mod tests {
 		assert_eq!(cli.stages.len(), 1);
 		assert_eq!(cli.stages[0].name(), "import");
 		assert!(cli.validate().is_ok());
+	}
+
+	#[test]
+	fn tcp_only_listener_is_a_moq_side() {
+		let cli =
+			Invocation::try_parse_from(["moq", "--server-tcp-bind", "127.0.0.1:0", "import", "ts"]).expect("parse");
+		assert!(cli.moq.validate().is_ok());
+		assert!(cli.moq.serves());
+		assert_eq!(cli.moq.server.tcp.bind, Some("127.0.0.1:0".parse().unwrap()));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn unix_only_listener_is_a_moq_side() {
+		let cli = Invocation::try_parse_from(["moq", "--server-unix-bind", "/tmp/moq-cli.sock", "export", "ts"])
+			.expect("parse");
+		assert!(cli.moq.validate().is_ok());
+		assert!(cli.moq.serves());
+		assert_eq!(
+			cli.moq.server.unix.bind.as_deref(),
+			Some(std::path::Path::new("/tmp/moq-cli.sock"))
+		);
 	}
 
 	/// The grammar clap can't express: one connection, several endpoints.
@@ -868,7 +912,20 @@ mod tests {
 		// ...these it refuses, rather than accepting the flag and ignoring it.
 		for flag in [
 			["--client-connect", "https://relay.example.com"],
+			["--server-tcp-bind", "127.0.0.1:0"],
 			["--broadcast", "room"],
+		] {
+			let cli = Cli::try_parse_from(["moq", flag[0], flag[1], "token", "generate"]).unwrap();
+			let err = cli.moq.reject("token").unwrap_err().to_string();
+			assert!(err.contains(flag[0]), "{err}");
+		}
+
+		#[cfg(unix)]
+		for flag in [
+			["--server-unix-bind", "/tmp/moq-cli.sock"],
+			["--server-unix-allow-uid", "1000"],
+			["--server-unix-allow-gid", "1000"],
+			["--server-unix-allow-pid", "1000"],
 		] {
 			let cli = Cli::try_parse_from(["moq", flag[0], flag[1], "token", "generate"]).unwrap();
 			let err = cli.moq.reject("token").unwrap_err().to_string();

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -191,7 +191,8 @@ fn spawn_moq(
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
 
-	if let Some(web_bind) = moq.server.bind.clone() {
+	if moq.serves() {
+		let web_bind = moq.server.bind.clone();
 		let server = net.server(moq.server.clone())?;
 		let certificates = server.certificates();
 		moq::notify_ready();
@@ -219,7 +220,9 @@ fn spawn_moq(
 			};
 			Ok(())
 		});
-		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
+		if let Some(web_bind) = web_bind {
+			tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
+		}
 	}
 
 	Ok(bandwidth)
@@ -594,5 +597,38 @@ mod tests {
 		supervise(&local, pipelines, &mut tasks);
 
 		local.run_until(drive(tasks)).await.unwrap();
+	}
+
+	/// A raw TCP bind is a complete server side even when no QUIC bind is set.
+	#[tokio::test]
+	async fn tcp_only_moq_side_starts_a_server() {
+		let invocation = Invocation::try_parse_from(["moq", "--server-tcp-bind", "127.0.0.1:0", "import", "ts"])
+			.expect("parse TCP-only invocation");
+		let origin = invocation.moq.origin().expect("create origin");
+		let net = Net {
+			#[cfg(feature = "iroh")]
+			iroh: None,
+		};
+		let mut tasks = JoinSet::new();
+
+		spawn_moq(
+			&invocation.moq,
+			&net,
+			&origin,
+			Directions {
+				publish: true,
+				consume: false,
+			},
+			&mut tasks,
+		)
+		.expect("start TCP-only server");
+
+		assert!(
+			tokio::time::timeout(std::time::Duration::from_millis(50), tasks.join_next())
+				.await
+				.is_err(),
+			"the server task should still be accepting connections"
+		);
+		tasks.abort_all();
 	}
 }

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -99,6 +99,11 @@ impl ServerConfig {
 		}
 	}
 
+	/// Whether a QUIC, TCP, or Unix bind is explicitly configured.
+	pub fn has_explicit_bind(&self) -> bool {
+		self.bind.is_some() || self.has_stream_listener()
+	}
+
 	/// Whether a `tcp`/`unix` stream listener is configured.
 	///
 	/// When true and [`bind`](Self::bind) is unset, the server runs stream-only
@@ -1515,6 +1520,7 @@ uid = [1001, 1002]
 		assert_eq!(config.unix.bind.as_deref(), Some(std::path::Path::new("/run/moq.sock")));
 		assert_eq!(config.unix.allow.as_ref().expect("allow").uid, vec![1001, 1002]);
 		assert!(config.has_stream_listener());
+		assert!(config.has_explicit_bind());
 	}
 
 	#[cfg(all(feature = "uds", unix))]
@@ -1524,9 +1530,11 @@ uid = [1001, 1002]
 		let mut config = ServerConfig::default();
 		config.unix.bind = Some(PathBuf::from("/run/moq.sock"));
 		assert!(config.has_stream_listener());
+		assert!(config.has_explicit_bind());
 		assert!(config.bind.is_none());
 
 		// The default (nothing configured) still runs QUIC.
 		assert!(!ServerConfig::default().has_stream_listener());
+		assert!(!ServerConfig::default().has_explicit_bind());
 	}
 }


### PR DESCRIPTION
## Summary

- Accept TCP-only and Unix-only native listener configurations in moq-cli.
- Start the native server whenever any listener is configured, while keeping the web endpoint conditional on a QUIC bind.
- Enable the TCP and Unix transport features in moq-cli and document raw-listener self-hosting.
- Root cause: validation and startup both checked only the QUIC bind, so raw listener flags were rejected or configured without ever being served.

Closes #2834.

## Public API changes

- Adds `moq_native::ServerConfig::has_explicit_bind()` to report whether any QUIC, TCP, or Unix listener was configured.

## Test plan

- `just check origin/main`
- `just test default origin/main` (1,831 passed, 1 skipped)
- Parser and startup regressions cover TCP-only and Unix-only configurations.

The matching moq-cli documentation was updated. No wire format changed.

(written by GPT-5)
