### PR TITLE
feat(demo): serve the demos cross-origin isolated

### DIFF
--- a/demo/boy/vite.config.ts
+++ b/demo/boy/vite.config.ts
@@ -1,12 +1,13 @@
 import { resolve } from "path";
 import { defineConfig } from "vite";
 import solidPlugin from "vite-plugin-solid";
+import { crossOriginIsolation } from "../../js/common/vite-plugin-isolate";
 import { workletInline } from "../../js/common/vite-plugin-worklet";
 
 export default defineConfig({
 	root: "src",
 	envDir: resolve(__dirname),
-	plugins: [solidPlugin(), workletInline()],
+	plugins: [solidPlugin(), workletInline(), crossOriginIsolation()],
 	build: {
 		target: "esnext",
 		rollupOptions: {

--- a/demo/web/vite.config.ts
+++ b/demo/web/vite.config.ts
@@ -2,6 +2,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "path";
 import { defineConfig } from "vite";
 import solidPlugin from "vite-plugin-solid";
+import { crossOriginIsolation } from "../../js/common/vite-plugin-isolate";
 import { workletInline } from "../../js/common/vite-plugin-worklet";
 import { consoleOverlay } from "./console-overlay";
 import { openTabs } from "./open-tabs";
@@ -13,6 +14,7 @@ export default defineConfig({
 		tailwindcss(),
 		solidPlugin(),
 		workletInline(),
+		crossOriginIsolation(),
 		consoleOverlay(),
 		// Open the stats, publish, and watch demos each in their own tab.
 		// Order matters: the browser focuses the last tab, so watch ends up in front.

--- a/js/common/vite-plugin-isolate.ts
+++ b/js/common/vite-plugin-isolate.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from "vite";
+
+const HEADERS = {
+	"Cross-Origin-Opener-Policy": "same-origin",
+	"Cross-Origin-Embedder-Policy": "require-corp",
+};
+
+/**
+ * A Vite plugin that serves dev and preview pages cross-origin isolated.
+ *
+ * SharedArrayBuffer is gated behind cross-origin isolation, and without it the audio
+ * renderer falls back to shipping samples over postMessage, which is both higher latency
+ * and a different code path than a deployed site gets. Every asset the demos load is
+ * same-origin, so `require-corp` costs nothing here and unlike `credentialless` it also
+ * works in Safari.
+ */
+export function crossOriginIsolation(): Plugin {
+	return {
+		name: "moq-cross-origin-isolation",
+		config: () => ({ server: { headers: HEADERS }, preview: { headers: HEADERS } }),
+	};
+}

--- a/js/watch/src/audio/buffer.ts
+++ b/js/watch/src/audio/buffer.ts
@@ -128,7 +128,10 @@ export function createAudioBuffer(
 		console.log("[audio] using SharedArrayBuffer audio buffer");
 		return new SharedAudioBuffer(worklet, channels, rate, latencySamples, buffered);
 	}
-	console.log("[audio] using postMessage audio buffer (SharedArrayBuffer unavailable)");
+	console.warn(
+		"[audio] SharedArrayBuffer unavailable, falling back to the higher latency postMessage audio buffer. " +
+			"Serve the page cross-origin isolated (Cross-Origin-Opener-Policy: same-origin, Cross-Origin-Embedder-Policy: require-corp) to avoid this.",
+	);
 	return new PostAudioBuffer(worklet, channels, rate, latencySamples, buffered);
 }
 


### PR DESCRIPTION
## Summary

- `SharedArrayBuffer` is gated behind cross-origin isolation, so the local dev server silently took the postMessage audio path while a deployed site takes the shared one. Fallback-only bugs (like the one #3138 just fixed) stayed invisible locally.
- New `crossOriginIsolation()` Vite plugin in `js/common/vite-plugin-isolate.ts` sets `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on the dev and preview servers. Wired into `demo/web` and `demo/boy`, the only two dev servers; the `js/*` configs are library builds with no server.
- `require-corp` rather than `credentialless`: every asset the demos load is same-origin, so it costs nothing, and Safari doesn't support `credentialless`.
- `createAudioBuffer` now `console.warn`s (instead of `console.log`) when it falls back, naming the two headers. The demo's `<moq-console>` overlay shows warn and above, so the slower path is visible wherever it still happens.

This only covers local dev. If the deployed pages aren't served with the same headers, production still runs the postMessage path.

## Public API changes

None. The new plugin lives in `js/common/`, which isn't a published package. `supportsSharedArrayBuffer()` and `createAudioBuffer()` are unchanged apart from the log level.

## Test plan

- `just js check` passes.
- Ran the full local stack (`just dev`: relay + bbb publisher + demo web) and loaded `watch.html`:
  - `crossOriginIsolated === true`, `SharedArrayBuffer` defined.
  - The cross-origin `fetch("http://localhost:4443/certificate.sha256")` still succeeds under `require-corp` (CORP is only enforced on `no-cors` requests) and WebTransport connected, negotiating `moq-lite-05`.
  - Console on playback: `[audio] using SharedArrayBuffer audio buffer` and `[audio-worklet] init-shared: using SharedArrayBuffer path`, where it previously took the postMessage path.
- Verified the headers directly: `curl -sI http://localhost:5173/watch.html` returns both COOP and COEP.

(Written by Claude Opus 5)