### PR TITLE
feat(tokio): reject an unsupported feature build with one honest error

### DIFF
--- a/doc/lib/rs/crate/moq-tokio.md
+++ b/doc/lib/rs/crate/moq-tokio.md
@@ -27,7 +27,7 @@ Tokio-based connection helpers for native Rust applications. Provides TLS config
 moq-tokio = "0.19"
 ```
 
-The default features cover a working build. If you set `default-features = false`, pick a QUIC backend (`quinn`, `quiche`, or `noq`) plus, for `quinn` or `noq`, a crypto provider (`aws-lc-rs` or `ring`); `quiche` brings its own. A build missing either fails with a message naming what to enable.
+The default features cover a working build. If you set `default-features = false`, pick a QUIC backend (`quinn`, `quiche`, or `noq`); a build without one fails with a message naming them. `noq` also needs a crypto provider (`aws-lc-rs` or `ring`) to compile. `quinn` takes one from either feature or from a provider you install yourself with `CryptoProvider::install_default()`, and `quiche` brings its own.
 
 ## API Reference
 

--- a/doc/lib/rs/crate/moq-tokio.md
+++ b/doc/lib/rs/crate/moq-tokio.md
@@ -27,6 +27,8 @@ Tokio-based connection helpers for native Rust applications. Provides TLS config
 moq-tokio = "0.19"
 ```
 
+The default features cover a working build. If you set `default-features = false`, pick a QUIC backend (`quinn`, `quiche`, or `noq`) plus, for `quinn` or `noq`, a crypto provider (`aws-lc-rs` or `ring`); `quiche` brings its own. A build missing either fails with a message naming what to enable.
+
 ## API Reference
 
 Full API documentation: [docs.rs/moq-tokio](https://docs.rs/moq-tokio)

--- a/rs/justfile
+++ b/rs/justfile
@@ -389,6 +389,9 @@ features:
 # everyone. Only a per-crate invocation selects the shapes an external consumer with
 # `default-features = false` can land on, so assert those still fail on their own
 # `compile_error!` rather than on whatever breaks first inside the modules.
+#
+# `--features quinn` is deliberately absent: it compiles without a provider feature and
+# takes one from `CryptoProvider::install_default()` at runtime, which is supported.
 _unsupported-features:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -406,8 +409,7 @@ _unsupported-features:
 
     expect "requires a QUIC backend"
     expect "requires a QUIC backend" --features tcp
-    expect "require a crypto provider" --features quinn
-    expect "require a crypto provider" --features noq
+    expect "requires a crypto provider" --features noq
 
 # nextest, not `cargo test`, so a wedged test is killed instead of pinning a core
 # until someone notices (`.config/nextest.toml` sets the timeout). The trade is

--- a/rs/justfile
+++ b/rs/justfile
@@ -382,6 +382,32 @@ features:
     cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
     RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --all-features --no-deps
     cargo nextest run --locked --workspace --all-targets --all-features
+    just rs _unsupported-features
+
+# The workspace compiles above can't reach a backend-less moq-tokio: cargo unifies
+# features per crate, so a member depending on it with a backend enables one for
+# everyone. Only a per-crate invocation selects the shapes an external consumer with
+# `default-features = false` can land on, so assert those still fail on their own
+# `compile_error!` rather than on whatever breaks first inside the modules.
+_unsupported-features:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    expect() {
+        local want="$1"; shift
+        local got
+        got=$(cargo check --locked -p moq-tokio --no-default-features "$@" 2>&1 || true)
+        if ! grep -qF "$want" <<< "$got"; then
+            echo "rs: moq-tokio ${*:-(no features)} should fail on: $want" >&2
+            echo "$got" | grep -E '^error' >&2 || true
+            exit 1
+        fi
+    }
+
+    expect "requires a QUIC backend"
+    expect "requires a QUIC backend" --features tcp
+    expect "require a crypto provider" --features quinn
+    expect "require a crypto provider" --features noq
 
 # nextest, not `cargo test`, so a wedged test is killed instead of pinning a core
 # until someone notices (`.config/nextest.toml` sets the timeout). The trade is

--- a/rs/moq-tokio/src/lib.rs
+++ b/rs/moq-tokio/src/lib.rs
@@ -14,10 +14,11 @@
 //!
 //! # Required features
 //!
-//! A build needs a QUIC backend (`quinn`, `quiche`, or `noq`), and `quinn`/`noq`
-//! additionally need a crypto provider (`aws-lc-rs` or `ring`) since their rustls
-//! dependency is built with default features off. The `default` feature set covers
-//! both; a consumer using `default-features = false` has to pick them itself.
+//! A build needs a QUIC backend (`quinn`, `quiche`, or `noq`). `noq` additionally
+//! needs a crypto provider (`aws-lc-rs` or `ring`) to compile at all. `quinn` takes
+//! one from either feature or from a provider the application installed with
+//! `CryptoProvider::install_default()`, and `quiche` brings its own. The `default`
+//! set covers all of this; `default-features = false` means picking them yourself.
 
 #![warn(missing_docs)]
 
@@ -35,16 +36,18 @@ compile_error!(
 	 A tcp/uds-only build is not supported (see moq-dev/moq#2834)."
 );
 
-// `quinn` is the sharper half: unlike `noq` it still compiles, then has no initial cipher at
-// runtime, so the failure lands on a connection attempt rather than the build. `quiche` needs
-// neither, since boringssl brings its own.
-#[cfg(all(
-	any(feature = "quinn", feature = "noq"),
-	not(any(feature = "aws-lc-rs", feature = "ring"))
-))]
+// Without a provider feature, `web-transport-noq` is built without its own, and the endpoint
+// constructors this crate calls stop existing: the build fails with three unrelated E0599s
+// about `EndpointConfig::default` and `ServerConfig::with_crypto`. Say which feature is
+// missing instead.
+//
+// Only `noq` gets this. `quinn` compiles either way and resolves its provider at runtime
+// through `crypto::provider()`, which accepts one the application installed with
+// `CryptoProvider::install_default()`; refusing that build would remove a supported path.
+// `quiche` needs neither, since boringssl brings its own.
+#[cfg(all(feature = "noq", not(any(feature = "aws-lc-rs", feature = "ring"))))]
 compile_error!(
-	"the `quinn` and `noq` backends require a crypto provider: enable `aws-lc-rs` or `ring`. \
-	 Their rustls dependency is built with default-features off, so there is no cipher without one."
+	"the `noq` backend requires a crypto provider: enable `aws-lc-rs` or `ring`."
 );
 
 pub mod accept;

--- a/rs/moq-tokio/src/lib.rs
+++ b/rs/moq-tokio/src/lib.rs
@@ -9,9 +9,43 @@
 //! - Iroh P2P (requires `iroh` feature)
 //!
 //! See [`Client`] for connecting to relays and [`Server`] for accepting
-//! connections. [`mdns`] finds peers to connect to on the local network.
+//! connections. The `mdns` module, behind the feature of the same name, finds
+//! peers to connect to on the local network.
+//!
+//! # Required features
+//!
+//! A build needs a QUIC backend (`quinn`, `quiche`, or `noq`), and `quinn`/`noq`
+//! additionally need a crypto provider (`aws-lc-rs` or `ring`) since their rustls
+//! dependency is built with default features off. The `default` feature set covers
+//! both; a consumer using `default-features = false` has to pick them itself.
 
 #![warn(missing_docs)]
+
+// A backend-less build is not a supported configuration, and without these it fails deep in
+// the modules that assume one: `QuicBackend` becomes an empty enum, `RequestKind` an empty
+// match, and `worker`/`server` reference items their own gates removed. Say so once here
+// instead of letting the caller read eight errors that never name the cause.
+//
+// Workspace builds never reach these: cargo unifies features per crate, so a member that
+// depends on moq-tokio with a backend enables it for everyone. Only `-p moq-tokio` or an
+// external consumer with `default-features = false` can select the broken shapes.
+#[cfg(not(any(feature = "quinn", feature = "quiche", feature = "noq")))]
+compile_error!(
+	"moq-tokio requires a QUIC backend: enable one of the `quinn`, `quiche`, or `noq` features. \
+	 A tcp/uds-only build is not supported (see moq-dev/moq#2834)."
+);
+
+// `quinn` is the sharper half: unlike `noq` it still compiles, then has no initial cipher at
+// runtime, so the failure lands on a connection attempt rather than the build. `quiche` needs
+// neither, since boringssl brings its own.
+#[cfg(all(
+	any(feature = "quinn", feature = "noq"),
+	not(any(feature = "aws-lc-rs", feature = "ring"))
+))]
+compile_error!(
+	"the `quinn` and `noq` backends require a crypto provider: enable `aws-lc-rs` or `ring`. \
+	 Their rustls dependency is built with default-features off, so there is no cipher without one."
+);
 
 pub mod accept;
 pub use moq_sock::bind;


### PR DESCRIPTION
Closes #2979.

## The reported bug

`cargo check -p moq-tokio --no-default-features` fails with **8 errors**, none naming the cause:

```
error: an enum with no variants accepts no value at all
error[E0433]: cannot find `util` in `crate`
error[E0425]: cannot find value `DEFAULT_BIND` in module `crate::server`
error[E0282]: type annotations needed                        (x2)
error[E0277]: the trait bound `QuicBackend: ValueEnum` is not satisfied
error[E0004]: non-exhaustive patterns: type `&RequestKind` is non-empty   (x2)
```

`QuicBackend` becomes an empty enum, `RequestKind` an empty match, and `worker`/`server` reference items their own gates removed. The count was 5 when the issue was filed and grows as the crate does, which is itself the argument against making this configuration work.

The issue offered two options; this takes the first. `worker`, `steer`, and `server` all assume a backend exists, so a `compile_error!` matches reality and names the features to enable.

## A second unsupported shape, not in the issue

Auditing the feature space rather than just the reported case turned up another one. `quinn` and `noq` take their crypto provider from `aws-lc-rs`/`ring`, since their rustls dependency is built with default features off (the manifest already says so: *"a backend without aws-lc-rs/ring has no initial cipher"*).

| features | before | after |
|---|---|---|
| *(none)* | 8 errors, cause unnamed | names the backend requirement first |
| `tcp` | 5 errors, cause unnamed | names the backend requirement first |
| `noq` | 3 unrelated `E0599`s about `EndpointConfig::default` / `ServerConfig::with_crypto` | names the provider requirement |
| `quinn` | clean | clean (unchanged, see below) |
| `quiche` | clean | clean (boringssl brings its own) |
| `quinn,aws-lc-rs`, `noq,aws-lc-rs` | clean | clean |
| default | clean | clean |

`noq` is the only backend that gets this guard, and the reason is that it is not a runtime question there: without a provider feature `web-transport-noq` is built without its own and the constructors this crate calls stop existing, so the build fails whatever the application does later.

**An earlier revision of this PR also guarded `quinn`, and that was wrong.** `crypto::provider()` resolves the provider at runtime and checks `CryptoProvider::get_default()` first, so an application that calls `install_default()` works with `quinn` and no provider feature. The function's own panic names that as the equal alternative:

```
"no CryptoProvider available; install_default() or enable either the aws-lc-rs or ring feature"
```

Refusing the build made a supported configuration unreachable. Caught by the Codex review on this PR (P2), verified against `crypto.rs`, and reverted in 530014e; `--features quinn` compiles clean again.

## Why CI never saw any of this, and still passes

Cargo unifies features per crate, so in a workspace build a member that depends on moq-tokio with a backend enables one for everyone. Nightly's `cargo check --locked --workspace --no-default-features` therefore never compiles moq-tokio backend-less, which is why it stayed green over a broken configuration. I ran that exact command with these guards in place and it still passes unchanged.

Only `-p moq-tokio` or an external consumer with `default-features = false` selects the broken shapes, so `just rs _unsupported-features` (added to the nightly `features` recipe) asserts each still fails on its own message rather than on whatever breaks first inside the modules. Verified it catches a regression: neutering either guard makes the recipe fail with `moq-tokio --features quinn should fail on: require a crypto provider`.

This is also why adding `--all-features`/`--no-default-features` to `just check` would not have fixed the issue: two extra full workspace compiles per PR, and feature unification means neither would compile moq-tokio backend-less anyway.

**Note:** `compile_error!` does not halt compilation, so the downstream errors still follow it. The change is that the first error names the cause and the fix.

## Drive-by: a doc link that breaks any moq-tokio PR

Separate first commit, kept apart so it can be reverted on its own.

`cargo doc -p moq-tokio` with default features already fails on `dev`:

```
error: unresolved link to `mdns`
  --> rs/moq-tokio/src/lib.rs:12:20
```

`mdns` is behind a non-default feature, so rustdoc has no item to resolve, and `RUSTDOCFLAGS="-D warnings"` makes it a hard error. `just check`'s doc pass is diff-scoped, so this fires on any branch whose diff selects moq-tokio, including this one. Nightly missed it because it documents with `--all-features`, which compiles the module in.

Confirmed pre-existing by stashing this branch's changes and reproducing on clean `dev`. Same class as the `target/doc/moq` collision in #3113: a doc-pass failure that only fires on certain package selections.

## Base

Targets `dev` because `moq-tokio` only exists there. No published API changes shape: the guards reject builds that already did not work, and the doc fix is prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)

