### PR TITLE
test(uring): pin down what a send staged on the way out is owed

### DIFF
--- a/rs/moq-uring/src/quic/quiche/connection.rs
+++ b/rs/moq-uring/src/quic/quiche/connection.rs
@@ -270,6 +270,12 @@ impl Inner {
 /// driver itself keeps the connection alive until it ends; close explicitly
 /// with [`close`](web_transport_trait::poll::Session::close) (which moq's
 /// session machine does).
+///
+/// That close only records the code: the driver task is what frames the
+/// CONNECTION_CLOSE and hands it to the socket. Drive the worker until
+/// [`poll_closed`](web_transport_trait::poll::Session::poll_closed) resolves
+/// before stopping it, or the packet is never built and the peer idles out
+/// instead.
 pub struct Connection {
 	shared: Shared,
 	// Retains this clone's waiter registrations across polls.

--- a/rs/moq-uring/src/quic/quinn/connection.rs
+++ b/rs/moq-uring/src/quic/quinn/connection.rs
@@ -260,6 +260,12 @@ impl Inner {
 /// driver itself keeps the connection alive until it ends; close explicitly
 /// with [`close`](web_transport_trait::poll::Session::close) (which moq's
 /// session machine does).
+///
+/// That close only records the code: the driver task is what frames the
+/// CONNECTION_CLOSE and hands it to the socket. Drive the worker until
+/// [`poll_closed`](web_transport_trait::poll::Session::poll_closed) resolves
+/// before stopping it, or the packet is never built and the peer idles out
+/// instead.
 pub struct Connection {
 	shared: Shared,
 	// Retains this clone's waiter registrations across polls.

--- a/rs/moq-uring/src/udp.rs
+++ b/rs/moq-uring/src/udp.rs
@@ -689,6 +689,11 @@ impl TxBuf {
 	/// `segment` bytes (the last may be short). Fire-and-forget: the buffer
 	/// returns to the pool when the kernel completes, and a failed send
 	/// surfaces on the next pool acquire.
+	///
+	/// This only stages an SQE, so the datagram reaches the kernel when the
+	/// worker next enters the ring. Stopping the worker in between does not
+	/// lose it: [`crate::Worker`]'s drop submits whatever is still staged and
+	/// waits for the completions.
 	pub fn send(mut self, len: usize, to: SocketAddr, segment: usize) -> io::Result<()> {
 		// `UDP_SEGMENT` is a u16, so an oversized segment would silently
 		// truncate into a tiny stride and explode the implied segment count.

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -44,6 +44,13 @@ pub struct Config {}
 /// [`Handle`]: UDP sockets, timers, spawned tasks. Wakes from other threads
 /// (any `Waker` this worker minted) are an atomic store plus, only while the
 /// worker is parked, one futex syscall.
+///
+/// Dropping the worker submits the SQEs its last turn staged and waits for
+/// their completions, so a datagram already handed to a [`udp::Socket`] still
+/// goes out. It runs no tasks, though, so work a task has merely been asked
+/// for is not performed: a QUIC close is queued on its connection and framed
+/// by the driver task, so keep driving until the close is published rather
+/// than stopping the worker on the call that asked for it.
 pub struct Worker {
 	shared: Rc<Shared>,
 	tasks: kio::Tasks<Task>,

--- a/rs/moq-uring/tests/teardown.rs
+++ b/rs/moq-uring/tests/teardown.rs
@@ -1,0 +1,142 @@
+//! What survives a worker that stops the moment its work is handed over.
+//!
+//! Both halves of the send path stage rather than syscall: `TxBuf::send`
+//! stages an SQE and `Shared::push` only enters the ring when the submission
+//! queue fills, so a datagram handed to a socket can still be sitting in
+//! userspace when the caller returns from `block_on`. Dropping the worker is
+//! what has to close that window, and these pin it shut at both layers: a raw
+//! datagram, and a QUIC close whose CONNECTION_CLOSE is the last thing a
+//! one-shot client ever sends.
+//!
+//! Kernel-gated: skips loudly below the Linux 6.12 floor (GitHub-hosted CI),
+//! and runs everywhere else.
+
+#![cfg(target_os = "linux")]
+
+#[path = "support/quiche.rs"]
+mod support;
+
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use moq_uring::{Config, Error, Worker, quic, udp};
+use web_transport_trait::poll::Session as _;
+
+const ALPN: &str = "moq-uring-teardown";
+const CLOSE_CODE: u32 = 42;
+const CLOSE_REASON: &str = "done";
+
+fn worker() -> Option<Worker> {
+	match Worker::new(Config::default()) {
+		Ok(worker) => Some(worker),
+		Err(Error::Unsupported(reason)) => {
+			eprintln!("skipping io_uring teardown test: {reason}");
+			None
+		}
+		Err(err) => panic!("worker setup failed: {err}"),
+	}
+}
+
+/// A datagram staged by the last turn before `block_on` returns still reaches
+/// the wire: the worker's drop submits what is left staged and waits for the
+/// completions.
+#[test]
+fn a_send_staged_on_the_way_out_still_goes() {
+	let Some(mut worker) = worker() else { return };
+	let handle = worker.handle();
+
+	let peer = UdpSocket::bind("127.0.0.1:0").expect("bind peer");
+	peer.set_read_timeout(Some(Duration::from_secs(5)))
+		.expect("read timeout");
+	let peer_addr = peer.local_addr().expect("peer addr");
+
+	let sock = handle
+		.udp(UdpSocket::bind("127.0.0.1:0").expect("bind"), udp::Config::default())
+		.expect("socket");
+
+	// Nothing re-enters the ring after this: the future resolves on the same
+	// turn that stages the send, and `block_on` returns without pumping.
+	worker
+		.block_on(async {
+			let mut tx = sock.acquire().await.expect("acquire");
+			tx[..3].copy_from_slice(b"bye");
+			tx.send(3, peer_addr, 3).expect("send");
+		})
+		.expect("worker");
+	drop(sock);
+	drop(worker);
+
+	let mut buf = [0u8; 16];
+	let (len, _) = peer.recv_from(&mut buf).expect("the staged send reached the wire");
+	assert_eq!(&buf[..len], b"bye");
+}
+
+fn server_config(certs: &support::Certs) -> quic::server::Config {
+	let mut config = quic::server::Config::new(quic::Identity::open(&certs.cert, &certs.key).expect("identity"));
+	config.alpn = vec![ALPN.to_string()];
+	config
+}
+
+fn dial_config(peer: std::net::SocketAddr) -> quic::client::Config {
+	let mut config = quic::client::Config::new(peer, "localhost");
+	config.alpn = vec![ALPN.to_string()];
+	config.verify = false;
+	config
+}
+
+/// The one-shot client shape: dial, close, wait for the close to be published,
+/// then stop the runtime outright. The peer must learn the application code
+/// rather than idle out, which is what a lost CONNECTION_CLOSE would look
+/// like.
+#[test]
+fn a_published_close_has_already_left_the_client() {
+	let Some(mut client_worker) = worker() else { return };
+	let certs = support::certs().expect("certificates");
+
+	let server_sock = UdpSocket::bind("127.0.0.1:0").expect("bind server");
+	let server_addr = server_sock.local_addr().expect("server addr");
+
+	// The server outlives the client's teardown, so its verdict is only about
+	// what the client managed to send.
+	let server = std::thread::spawn(move || -> quic::Error {
+		let mut worker = Worker::new(Config::default()).expect("server worker");
+		let handle = worker.handle();
+		let sock = handle.udp(server_sock, udp::Config::default()).expect("server socket");
+		let endpoint = quic::Endpoint::new(
+			&handle,
+			sock,
+			quic::endpoint::Config::default().with_server(server_config(&certs)),
+		)
+		.expect("endpoint");
+		worker
+			.block_on(async move {
+				let mut conn = endpoint.accept().await.expect("accept");
+				std::future::poll_fn(|cx| conn.poll_closed(cx)).await
+			})
+			.expect("server worker")
+	});
+
+	let handle = client_worker.handle();
+	let sock = handle
+		.udp(
+			UdpSocket::bind("127.0.0.1:0").expect("bind client"),
+			udp::Config::default(),
+		)
+		.expect("client socket");
+	let endpoint = quic::Endpoint::new(&handle, sock, quic::endpoint::Config::default()).expect("client endpoint");
+
+	client_worker
+		.block_on(async move {
+			let mut conn = endpoint.connect(&dial_config(server_addr)).await.expect("dial");
+			conn.close(CLOSE_CODE, CLOSE_REASON);
+			std::future::poll_fn(|cx| conn.poll_closed(cx)).await;
+		})
+		.expect("client worker");
+	drop(client_worker);
+
+	let err = server.join().expect("server thread");
+	assert!(
+		matches!(&err, quic::Error::App { code, reason } if *code == u64::from(CLOSE_CODE) && reason == CLOSE_REASON),
+		"the server saw {err} instead of the application close"
+	);
+}


### PR DESCRIPTION
Closes #3141, by disproving it.

## Summary

- #3141 claims a datagram handed to `udp::Socket` on the last turn before `block_on` returns never reaches the kernel, so dropping the worker loses it. Measured on Linux 6.19 (podman, real io_uring): it does reach the kernel. `Worker`'s drop submits whatever SQEs are still staged (`pump` -> `submit`) and then waits for their completions before freeing anything the kernel may still read, so the packet goes out. The staging is real; the loss is not.
- End to end, the one-shot client shape the issue describes works: dial, `close(42, "done")`, wait for the close to be published, stop the runtime outright. The peer sees `App { code: 42, reason: "done" }` **26ms** after accepting, not the 10s idle timeout. It cannot lose the CONNECTION_CLOSE, because quiche only reports `is_closed()` a draining period after that packet was sent, so the close is published many turns after the send was submitted.
- A completion-aware `TxBuf::send` would therefore buy nothing, and it would put a per-send handle on the flush hot path.
- There **is** a real loss, but with a different mechanism, a layer above the socket: a `close` the worker is never driven past. `close` only records the code on the connection; the driver task is what frames the CONNECTION_CLOSE and hands it to a `TxBuf`. Stop the worker on the call that asked for the close and no packet is ever built, so the peer idles out (measured: 10.005s, `TimedOut`). No socket API change reaches that, since there is nothing staged to complete. The remedy is to drive until the close is published, which `moq_net`'s session machine already does.

So this lands as tests and a written-down contract rather than an API change: the guarantee `Worker`'s drop provides was accidental and undocumented, which is what made the bug look real.

- `tests/teardown.rs` pins both halves: a raw datagram staged by the last turn still reaches the wire, and a published close has already left a client that then stops.
- `udp::TxBuf::send`, `Worker`, and `quic::Connection` now say which half of the window each of them owns.

## Public API changes

None. Doc comments and a new integration test only.

## Wire behavior changes

None.

## Test plan

In the podman container on Linux 6.19 (real io_uring, no skips):

- `cargo test --locked -p moq-uring -j 1` -- 44 tests, all pass, including the two new ones.
- `cargo clippy --locked -p moq-uring --all-targets -j 1 -- -D warnings` -- clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked -p moq-uring --no-deps` -- clean.
- `cargo fmt -p moq-uring -- --check` -- clean.

On the host: `just check` and `just test` both pass (263 tests). macOS compiles `moq-uring` to nothing, so the container runs above are what actually covered this crate.

The two disproof runs, for the record:

```
staged_send_survives_worker_drop ... ok        (datagram delivered)
awaited close:   server saw application closed: code=42 reason="done" after 25.668524ms
unawaited close: server saw connection timed out after 10.005042693s
```

## Cross-package sync

No row applies: no wire format, no `moq-ffi` surface, no CLI flag.

(Written by Claude Opus 5)