### PR TITLE
perf(uring): use fast hashes for the quinn backend's trusted maps

### DIFF
--- a/rs/moq-uring/src/quic/quinn/connection.rs
+++ b/rs/moq-uring/src/quic/quinn/connection.rs
@@ -1,13 +1,13 @@
 //! The connection: shared state, the driver task, and the session handle.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 use std::task::{Context, Poll};
 use std::time::Instant;
 
 use bytes::Bytes;
 use quinn_proto::{ConnectionHandle, Dir, StreamId, VarInt};
+use rustc_hash::FxHashMap;
 
 use super::super::{Error, SEGMENT};
 use super::endpoint;
@@ -47,11 +47,14 @@ pub(crate) struct State {
 	open_waiters: kio::WaiterList,
 
 	/// Per-stream read/write parking, keyed by stream id.
-	readable: HashMap<StreamId, kio::WaiterList>,
-	writable: HashMap<StreamId, kio::WaiterList>,
+	///
+	/// FxHash rather than SipHash on all four of these: they sit on the
+	/// driver's per-event path, and quinn-proto assigns the ids.
+	readable: FxHashMap<StreamId, kio::WaiterList>,
+	writable: FxHashMap<StreamId, kio::WaiterList>,
 	/// Send streams waiting for their end: a FIN the peer acknowledged, or a
 	/// `STOP_SENDING`.
-	finishing: HashMap<StreamId, kio::WaiterList>,
+	finishing: FxHashMap<StreamId, kio::WaiterList>,
 	/// Every send stream a handle still holds, and how it ended once the
 	/// driver has seen that happen. That is what makes a later close mean
 	/// "already delivered" rather than "we never found out".
@@ -60,7 +63,7 @@ pub(crate) struct State {
 	/// stream finished and then dropped before its FIN was acknowledged would
 	/// otherwise leave an entry nobody can ever remove, one per group, for as
 	/// long as the connection lives.
-	sends: HashMap<StreamId, Option<End>>,
+	sends: FxHashMap<StreamId, Option<End>>,
 
 	datagram_recv_waiters: kio::WaiterList,
 	datagram_send_waiters: kio::WaiterList,
@@ -88,10 +91,10 @@ impl State {
 			accept_bi_waiters: kio::WaiterList::new(),
 			accept_uni_waiters: kio::WaiterList::new(),
 			open_waiters: kio::WaiterList::new(),
-			readable: HashMap::new(),
-			writable: HashMap::new(),
-			finishing: HashMap::new(),
-			sends: HashMap::new(),
+			readable: FxHashMap::default(),
+			writable: FxHashMap::default(),
+			finishing: FxHashMap::default(),
+			sends: FxHashMap::default(),
 			datagram_recv_waiters: kio::WaiterList::new(),
 			datagram_send_waiters: kio::WaiterList::new(),
 			closed: None,

--- a/rs/moq-uring/src/quic/quinn/endpoint.rs
+++ b/rs/moq-uring/src/quic/quinn/endpoint.rs
@@ -9,7 +9,7 @@
 //! shared with the other backend.
 
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -18,6 +18,7 @@ use std::time::Instant;
 
 use bytes::BytesMut;
 use quinn_proto::{ConnectionHandle, DatagramEvent, Incoming, Transmit};
+use rustc_hash::FxHashMap;
 
 use super::super::{Error, endpoint::Config};
 use super::connection;
@@ -39,7 +40,12 @@ pub(crate) struct Inner {
 	/// The routing table, and the server configuration it accepts with.
 	endpoint: RefCell<quinn_proto::Endpoint>,
 	accepting: RefCell<Option<Accepting>>,
-	conns: RefCell<HashMap<ConnectionHandle, connection::Shared>>,
+	/// Every live connection, looked up per received datagram.
+	///
+	/// FxHash rather than SipHash: quinn-proto hands out the handle, and it
+	/// owns connection-id routing (and its hasher choices) itself, so nothing
+	/// a peer picks reaches this map.
+	conns: RefCell<FxHashMap<ConnectionHandle, connection::Shared>>,
 	/// Incoming handshakes in flight. Together with the accept queue this is
 	/// bounded by [`Config::backlog`].
 	pending: Cell<usize>,
@@ -89,7 +95,7 @@ impl Endpoint {
 			local,
 			endpoint: RefCell::new(endpoint),
 			accepting: RefCell::new(accepting),
-			conns: RefCell::new(HashMap::new()),
+			conns: RefCell::new(FxHashMap::default()),
 			pending: Cell::new(0),
 			backlog: config.backlog,
 			handles: Cell::new(1),


### PR DESCRIPTION
## Summary

- Move the quinn backend's four per-stream maps (`readable`, `writable`, `finishing`, `sends`) to `FxHashMap`.
- Move the endpoint's `conns` table, looked up once per received datagram, to `FxHashMap`.

Root cause: #3135 took the quiche backend off SipHash for the reasons #3121 measured (~3-4% of relay CPU on the io_uring path), but #3131 had just added a second backend with the same maps on the same paths, and it did not get the same treatment. So `--quic-backend quinn` still hashes ids it assigned itself with SipHash.

Every key here is locally assigned: the stream maps are keyed by ids quinn-proto hands out, and `conns` is keyed by its `ConnectionHandle`, a local index. Unlike the quiche backend there is no peer-chosen key to split off, because quinn-proto owns connection-id routing (and makes the same hasher choices internally, `FxHashMap` for `StreamId`-keyed maps and std `HashMap` for its peer-facing endpoint maps).

## Public API changes

- None.

## Wire behavior changes

- None.

## Test plan

- `cargo fmt` / `cargo clippy --locked -p moq-uring --all-targets --all-features -- -D warnings`, clean.
- `cargo test --locked -p moq-uring` on real io_uring (kernel 6.19), both feature sets: 51 passed under the default quiche backend, 47 under `--all-features` (quinn), 0 failed.
- `just check`.

No new tests: this is a hasher swap with no behavior change, and the existing quinn suite (`--all-features`) already covers these maps end to end.

Fixes #3154

(Written by Claude Opus 5)