### PR TITLE
feat(cli): complete broadcast, track, and capture-source names at the prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4735,6 +4735,7 @@ dependencies = [
  "hang",
  "moq-audio",
  "moq-hls",
+ "moq-msf",
  "moq-mux",
  "moq-rtc",
  "moq-rtmp",

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -56,6 +56,38 @@ cargo build --release --bin moq-cli
 
 The binary will be in `target/release/moq-cli`.
 
+### Shell completions
+
+`moq completion <shell>` writes the script that makes a shell ask `moq` what fits
+at the cursor. `--install` puts it where that shell looks, and prints any line you
+still have to add yourself for a shell that can't autoload one:
+
+```bash
+# bash, elvish, fish, nu, powershell, zsh
+moq completion zsh --install
+
+# or write it wherever you keep them
+moq completion bash > ~/.local/share/bash-completion/completions/moq
+```
+
+Most of what completes is static: verbs, flags, codecs, and the file paths a flag
+takes. These are looked up when you press Tab:
+
+| Flag | Completes from |
+|---|---|
+| `--broadcast` | the broadcasts announced on the `--connect` relay |
+| `--video-name` / `--audio-name` | the renditions in that broadcast's catalog |
+| `--camera`, `--display`, `--window`, `--app`, `--microphone` | this machine's capture sources |
+
+The first two rows open a short subscribe-only connection, and **only** when a
+`--connect` URL is already on the line, so Tab never dials a relay you have not
+named. The whole exchange is capped at half a second and stays silent about
+failure: an unreachable relay means no candidates, never an error in your prompt.
+
+`--camera`, `--display`, and `--microphone` take an optional value (bare
+`--camera` opens the default), so a shell can't tell whether the next word belongs
+to them. Write those attached to complete them: `--camera=<TAB>`.
+
 ### Heap profiling
 
 The Nix package includes jemalloc profiling support. Source builds can opt in

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -81,8 +81,10 @@ takes. These are looked up when you press Tab:
 
 The first two rows open a short subscribe-only connection, and **only** when a
 `--connect` URL is already on the line, so Tab never dials a relay you have not
-named. The whole exchange is capped at half a second and stays silent about
-failure: an unreachable relay means no candidates, never an error in your prompt.
+named. An exported `MOQ_CONNECT` deliberately does not count: it configures a dial
+but does not authorize one, and that URL can carry a `?jwt=` credential. Every
+lookup is capped at half a second and stays silent about failure: an unreachable
+relay means no candidates, never an error in your prompt.
 
 `--camera`, `--display`, and `--microphone` take an optional value (bare
 `--camera` opens the default), so a shell can't tell whether the next word belongs

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -35,7 +35,7 @@ Layered roughly transport -> container/format -> media -> apps/bindings.
 **Apps / binaries**
 
 - `moq-relay` (lib+bin): clusterable, media-agnostic relay. axum HTTP API, JWT auth, WebSocket fallback, clustering. Config/TOML merge pattern lives here (see below).
-- `moq-cli` (bin, `moq`): the unified media router (`moq <MoQ side> <import|export> <endpoint>`, plus the feature-gated `transcode` verb); stdin/stdout media piping. The CLI surface for the gateway library crates below lives here. `token` and `devices` are the local verbs: they run before any transport is bound and reject a MoQ side rather than ignoring it.
+- `moq-cli` (bin, `moq`): the unified media router (`moq <MoQ side> <import|export> <endpoint>`, plus the feature-gated `transcode` verb); stdin/stdout media piping. The CLI surface for the gateway library crates below lives here. `token`, `devices`, and `completion` are the local verbs: they run before any transport is bound and reject a MoQ side rather than ignoring it. Shell completion lives in `src/complete.rs`, which owns both the `__complete_word__` plumbing (the root grammar answers a cursor before the first `--`, the stage grammar after one) and the runtime completers that dial the relay `--connect` already names.
 - `moq-rtc` (lib): WebRTC (WHIP/WHEP) gateway. Bridges browser WebRTC ingest/playback to MoQ broadcasts (str0m ICE/DTLS, A/V sync, NACK). Embeddable axum routers / `Client`; the CLI surface lives in `moq-cli`.
 - `moq-rtmp` (lib): RTMP / enhanced-RTMP gateway (ingest + egress, `rml_rtmp`, FLV via `moq-mux`). RTMPS (rustls + tokio-rustls) is the optional `tls` feature.
 - `moq-srt` (lib): bidirectional SRT gateway (MPEG-TS via `srt-tokio` + `moq-mux`).

--- a/rs/moq-bench/src/host.rs
+++ b/rs/moq-bench/src/host.rs
@@ -64,7 +64,7 @@ mod linux {
 		pub duration: Option<moq_tokio::Duration>,
 
 		/// Write JSON lines to this file instead of stdout. Truncates on start.
-		#[usage(long)]
+		#[usage(long, value_hint = usage::ValueHint::FilePath, extensions("jsonl", "json"))]
 		pub output: Option<std::path::PathBuf>,
 
 		/// Include a per-thread breakdown in every sample. Costs one /proc read per

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -48,7 +48,7 @@ mod video;
 #[usage(completion)]
 pub struct Config {
 	/// Path to the Game Boy ROM file.
-	#[usage(long)]
+	#[usage(long, value_hint = usage::ValueHint::FilePath, extensions("gb", "gbc"))]
 	pub rom: PathBuf,
 
 	/// Session name (used in broadcast path). Defaults to ROM filename.

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -101,6 +101,10 @@ winit = { version = "0.30.13", optional = true }
 sd-notify = { workspace = true }
 
 [dev-dependencies]
+# Authors an MSF-only catalog, which is the one shape that tells a completer reading
+# the wrong catalog track apart from one reading the right one: `moq-mux`'s producer
+# publishes hang and MSF from the same source, so both answer for an ordinary broadcast.
+moq-msf = { workspace = true }
 tempfile = { workspace = true }
 # `test-util` enables `tokio::time::pause` so the TS round-trip test simulates the
 # exporter drain timeouts instantly instead of waiting on the wall clock.

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -146,18 +146,16 @@ impl std::error::Error for ParseError {}
 
 impl Invocation {
 	/// Parse the process arguments, exiting with Usage's rendered message on error.
-	pub fn parse() -> Self {
+	///
+	/// Async because a completion request is answered first, and some completers
+	/// dial the relay the line already names (see [`crate::complete`]).
+	pub async fn parse() -> Self {
 		let args: Vec<OsString> = std::env::args_os().collect();
 		// `#[usage(completion)]` installs the `__complete_word__` interception in the
 		// generated `Cli::parse()`, which the stage grammar cannot use: without this
 		// the request reaches the ordinary grammar and is refused. Recognized before
 		// the split on `--`, because a completion is not a command this binary runs.
-		//
-		// Answered against the root, so a cursor inside a later stage is completed
-		// against a grammar that also carries the process-wide flags a stage refuses.
-		// Narrowing that needs the request's own line and cursor rewritten to the last
-		// stage, which is not done here.
-		if let Some(reply) = completion_request(args.get(1..).unwrap_or_default()) {
+		if let Some(reply) = crate::complete::answer(args.get(1..).unwrap_or_default()).await {
 			print!("{reply}");
 			std::process::exit(0);
 		}
@@ -267,98 +265,6 @@ impl Invocation {
 
 		Ok(())
 	}
-}
-
-/// Answer a shell's completion request, against the grammar the cursor is actually in.
-///
-/// `#[usage(completion)]` installs the `__complete_word__` interception in the
-/// generated `Cli::parse()`, which the stage grammar cannot use: this binary splits
-/// argv on `--` and parses each chunk itself, so without this the request reaches
-/// the ordinary grammar and is refused.
-///
-/// The root spec is the globals plus the *first* stage. A cursor in a later chunk
-/// answered against it offers `--connect` and the other process-wide flags, which a
-/// stage refuses, so the request is rewritten to the active chunk and handed to
-/// [`Stage`]. Both request shapes normalize to a word list first: elvish sends one
-/// already, and everything else sends a line and a cursor that Usage's own splitter
-/// turns into the same thing.
-fn completion_request(argv: &[OsString]) -> Option<String> {
-	if argv.first()?.to_str()? != "__complete_word__" {
-		return None;
-	}
-
-	let mut shell_name = "bash".to_string();
-	let mut candidates: Option<String> = None;
-	let mut line = String::new();
-	let mut cursor = None;
-	let mut words: Option<Vec<String>> = None;
-
-	let mut rest = argv[1..].iter();
-	while let Some(arg) = rest.next() {
-		match arg.to_str().unwrap_or_default() {
-			"--shell" => {
-				if let Some(name) = rest.next() {
-					shell_name = name.to_string_lossy().into_owned();
-				}
-			}
-			"--line" => {
-				if let Some(value) = rest.next() {
-					line = value.to_string_lossy().into_owned();
-				}
-			}
-			"--cursor" => cursor = rest.next().and_then(|v| v.to_str()).and_then(|v| v.parse().ok()),
-			"--candidates" => candidates = rest.next().map(|v| v.to_string_lossy().into_owned()),
-			// Terminal, as it is for Usage: the rest of argv is the word list.
-			"--words" => {
-				words = Some(rest.map(|w| w.to_string_lossy().into_owned()).collect());
-				break;
-			}
-			// An unknown flag is a shell passing something this version does not know
-			// about. Ignored rather than refused, the way Usage ignores it.
-			_ => {}
-		}
-	}
-
-	let shell = usage::complete::Shell::from_name(&shell_name).unwrap_or(usage::complete::Shell::Bash);
-	let (mut words, cword) = match words {
-		Some(mut words) => {
-			if words.is_empty() {
-				words.push(String::new());
-			}
-			let cword = words.len() - 1;
-			(words, cword)
-		}
-		None => {
-			let split = usage::complete::split(&line, cursor.unwrap_or(line.len()), shell);
-			(split.words, split.cword)
-		}
-	};
-
-	// Everything past the cursor says nothing about the word being completed, and
-	// dropping it leaves that word last, which is the shape `--words` describes.
-	words.truncate(cword + 1);
-
-	// Strictly before the cursor: a cursor sitting *on* a `--` is typing the
-	// separator itself, which is the root's business rather than a stage's.
-	let stage_start = words[..cword].iter().rposition(|word| word == "--").map(|at| at + 1);
-	let Some(start) = stage_start else {
-		return Cli::completion_request(argv);
-	};
-
-	// `words[0]` is read as the program name, so the chunk gets one of its own.
-	let mut rewritten: Vec<OsString> = vec![
-		OsString::from("__complete_word__"),
-		OsString::from("--shell"),
-		OsString::from(&shell_name),
-	];
-	if let Some(name) = candidates {
-		rewritten.push(OsString::from("--candidates"));
-		rewritten.push(OsString::from(name));
-	}
-	rewritten.push(OsString::from("--words"));
-	rewritten.push(OsString::from("moq"));
-	rewritten.extend(words[start..].iter().map(OsString::from));
-	Stage::completion_request(&rewritten)
 }
 
 /// Turn a Usage parse result into a [`ParseError`].
@@ -576,6 +482,8 @@ pub enum Command {
 	Transcode(crate::transcode::Args),
 	/// Generate, sign, and verify the JWT tokens a relay authenticates with.
 	Token(moq_token_cli::Args),
+	/// Write the shell script that completes this command line.
+	Completion(crate::complete::Args),
 	/// List the capture devices `import capture` can name.
 	#[cfg(feature = "capture")]
 	Devices,
@@ -609,6 +517,7 @@ impl Command {
 			#[cfg(feature = "transcode")]
 			Self::Transcode(_) => "transcode",
 			Self::Token(_) => "token",
+			Self::Completion(_) => "completion",
 			#[cfg(feature = "capture")]
 			Self::Devices => "devices",
 		}
@@ -1594,42 +1503,5 @@ mod tests {
 			choices.sort_unstable();
 			assert_eq!(choices, &expected, "--{long} is out of step with Version::names()");
 		}
-	}
-
-	/// A cursor in a later stage is completed against the stage grammar.
-	///
-	/// The root spec is the globals plus the first stage, so answering a later chunk
-	/// against it offers process-wide flags that the chunk refuses.
-	#[test]
-	fn completion_retargets_to_the_active_stage() {
-		fn complete(line: &str) -> Vec<String> {
-			let argv: Vec<OsString> = ["__complete_word__", "--shell", "bash", "--line", line, "--cursor"]
-				.iter()
-				.map(OsString::from)
-				.chain(std::iter::once(OsString::from(line.len().to_string())))
-				.collect();
-			completion_request(&argv)
-				.unwrap_or_default()
-				.lines()
-				.map(str::to_string)
-				.collect()
-		}
-
-		// A stage offers its own flags, and none of the globals it would refuse.
-		let staged = complete("moq --connect http://x/y import fmp4 -- export fmp4 --");
-		assert!(!staged.is_empty(), "a later stage completed nothing");
-		for global in ["--connect", "--origin", "--broadcast"] {
-			assert!(
-				!staged.iter().any(|c| c == global),
-				"{global} leaked into a stage that refuses it: {staged:?}"
-			);
-		}
-
-		// The root still answers for itself.
-		let root = complete("moq --conn");
-		assert!(root.iter().any(|c| c == "--connect"), "root lost its globals: {root:?}");
-
-		// A cursor sitting on the separator is typing `--`, not inside a stage.
-		assert!(complete("moq import fmp4 --").is_empty());
 	}
 }

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -173,6 +173,14 @@ impl Invocation {
 		}
 	}
 
+	/// Refuse a MoQ side on a verb that runs locally and takes none.
+	///
+	/// Answered from what the command line said, never from the environment; see
+	/// [`Self::typed`] and `MoqSide::reject`.
+	pub fn reject(&self, command: &str) -> anyhow::Result<()> {
+		self.typed.reject(command)
+	}
+
 	/// Split `argv` on `--` and run each chunk through a real parser.
 	pub fn try_parse_from<I, T>(argv: I) -> Result<Self, ParseError>
 	where
@@ -463,12 +471,14 @@ impl MoqSide {
 	/// silently ignoring them. `--broadcast` counts: a local verb has no content, and
 	/// next to `token generate` it reads like it scopes the key, which `--root` does.
 	///
-	/// Call it on [`Invocation::typed`], not on the resolved side: every one of these
-	/// flags has a `MOQ_*` variable, and a shell that exports one for the publishing it
-	/// usually does has not asked this verb for anything. `--origin` is in the list for
+	/// Private, and reached only through [`Invocation::reject`], so it cannot be asked
+	/// of the resolved side: every one of these flags has a `MOQ_*` variable, and a
+	/// shell that exports one for the publishing it usually does has not asked this
+	/// verb for anything. A call site that picked the wrong view would read correctly
+	/// and be wrong, so there is only one view to pick. `--origin` is in the list for
 	/// the same reason it used to be out of it -- an ambient `MOQ_ORIGIN` no longer
 	/// reaches here, so a typed one can be refused like the rest.
-	pub fn reject(&self, command: &str) -> anyhow::Result<()> {
+	fn reject(&self, command: &str) -> anyhow::Result<()> {
 		#[cfg(feature = "cluster-lan")]
 		let cluster_secret = self.cluster.secret.is_some();
 		#[cfg(not(feature = "cluster-lan"))]
@@ -1552,32 +1562,5 @@ mod tests {
 			choices.sort_unstable();
 			assert_eq!(choices, &expected, "--{long} is out of step with Version::names()");
 		}
-	}
-
-	/// A local verb refuses a MoQ side the user asked for, not one the shell exports.
-	///
-	/// Every one of these flags has a `MOQ_*` variable, so reading the resolved side
-	/// made `moq token` and `moq completion` fail outright in any shell that exports
-	/// `MOQ_CONNECT` for the publishing it usually does. The ask is what was typed.
-	#[test]
-	fn a_local_verb_refuses_only_a_typed_moq_side() {
-		let _env = crate::test_env::EnvGuard::set(&[("MOQ_CONNECT", "https://relay.example/room")]);
-
-		let ambient = Invocation::try_parse_from(["moq", "token", "generate"]).expect("parse");
-		assert!(
-			ambient.moq.client.url.is_some(),
-			"the resolved side should still pick the variable up"
-		);
-		assert!(
-			ambient.typed.reject("token").is_ok(),
-			"an exported MOQ_CONNECT was treated as a request"
-		);
-
-		let typed = Invocation::try_parse_from(["moq", "--connect", "https://relay.example/room", "token", "generate"])
-			.expect("parse");
-		assert!(
-			typed.typed.reject("token").is_err(),
-			"a typed --connect stopped being refused"
-		);
 	}
 }

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -84,6 +84,14 @@ pub struct Invocation {
 	/// The MoQ attachment, shared by every stage.
 	pub moq: MoqSide,
 
+	/// The same attachment, built without consulting the environment.
+	///
+	/// Only [`MoqSide::reject`] reads it. A local verb refuses a MoQ side the user
+	/// asked for, and an exported `MOQ_CONNECT` is not an ask: it is a standing
+	/// setting for the publishing this shell usually does, and it would otherwise
+	/// make `moq token` and `moq completion` fail for everyone who has one.
+	pub typed: MoqSide,
+
 	/// The stages, in the order given. Never empty.
 	pub stages: Vec<Command>,
 }
@@ -179,6 +187,7 @@ impl Invocation {
 		let first = chunks.next().unwrap_or_default();
 		let first = first.iter().skip(1).map(OsString::as_os_str).collect::<Vec<_>>();
 		let cli = Cli::parse_from(&first).map_err(|err| parse_error(Cli::spec(), Cli::command(), &first, err))?;
+		let typed = MoqSide::from_argv(&first, Environment::Ignore).unwrap_or_else(|| cli.moq.clone());
 
 		let mut stages = vec![cli.command];
 		for chunk in chunks {
@@ -217,6 +226,7 @@ impl Invocation {
 		Ok(Self {
 			log: cli.log,
 			moq: cli.moq,
+			typed,
 			stages,
 		})
 	}
@@ -287,6 +297,15 @@ fn parse_error(
 		_ => ParseErrorKind::Other,
 	};
 	ParseError::new(kind, moq_tokio::cli::answer(spec, root, argv, err).message())
+}
+
+/// Whether [`MoqSide::from_argv`] lets the environment fill what the words left out.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum Environment {
+	/// Apply the `MOQ_*` variables, as an ordinary parse does.
+	Read,
+	/// Read only what the words say, which is what "the user asked for this" means.
+	Ignore,
 }
 
 /// The MoQ attachment: a relay dial, a server listener, a LAN mesh, or any
@@ -413,13 +432,42 @@ impl MoqSide {
 		Ok(())
 	}
 
+	/// Build a [`MoqSide`] from one chunk of a command line, leniently.
+	///
+	/// Stops at the first thing the grammar cannot take, because the two callers are
+	/// both looking at an incomplete line: a half-typed one being completed, and (via
+	/// [`Environment::Ignore`]) a real one whose typed values are being separated from
+	/// its ambient ones. Whatever was understood before that point is the answer.
+	pub(crate) fn from_argv(argv: &[&OsStr], environment: Environment) -> Option<Self> {
+		use usage::spec::CommandArgs;
+
+		let mut partial = <Self as CommandArgs>::start();
+		let mut parser = usage::Parser::new(Cli::command(), argv);
+		while let Some(event) = parser.next_event() {
+			match event {
+				Ok(event) => {
+					<Self as CommandArgs>::apply(&mut partial, &event);
+				}
+				Err(_) => break,
+			}
+		}
+
+		if environment == Environment::Read {
+			<Self as CommandArgs>::apply_env(&mut partial);
+		}
+		<Self as CommandArgs>::apply_defaults(&mut partial);
+		<Self as CommandArgs>::build(partial).ok()
+	}
+
 	/// Reject the MoQ flags on a verb that never touches the network, rather than
 	/// silently ignoring them. `--broadcast` counts: a local verb has no content, and
 	/// next to `token generate` it reads like it scopes the key, which `--root` does.
 	///
-	/// `--origin` is left out on purpose. It reads `MOQ_ORIGIN`, so rejecting it would
-	/// fail `moq token` in any shell that exports the variable for a publisher, and an
-	/// ambient env value is not the deliberate request this is meant to catch.
+	/// Call it on [`Invocation::typed`], not on the resolved side: every one of these
+	/// flags has a `MOQ_*` variable, and a shell that exports one for the publishing it
+	/// usually does has not asked this verb for anything. `--origin` is in the list for
+	/// the same reason it used to be out of it -- an ambient `MOQ_ORIGIN` no longer
+	/// reaches here, so a typed one can be refused like the rest.
 	pub fn reject(&self, command: &str) -> anyhow::Result<()> {
 		#[cfg(feature = "cluster-lan")]
 		let cluster_secret = self.cluster.secret.is_some();
@@ -435,6 +483,7 @@ impl MoqSide {
 			("--cluster-lan", self.lan()),
 			("--cluster-lan-secret", cluster_secret),
 			("--broadcast", self.broadcast.is_some()),
+			("--origin", self.origin.is_some()),
 		];
 		let ignored = ignored.into_iter().find(|(_, given)| *given).map(|(flag, _)| flag);
 		#[cfg(unix)]
@@ -1503,5 +1552,32 @@ mod tests {
 			choices.sort_unstable();
 			assert_eq!(choices, &expected, "--{long} is out of step with Version::names()");
 		}
+	}
+
+	/// A local verb refuses a MoQ side the user asked for, not one the shell exports.
+	///
+	/// Every one of these flags has a `MOQ_*` variable, so reading the resolved side
+	/// made `moq token` and `moq completion` fail outright in any shell that exports
+	/// `MOQ_CONNECT` for the publishing it usually does. The ask is what was typed.
+	#[test]
+	fn a_local_verb_refuses_only_a_typed_moq_side() {
+		let _env = crate::test_env::EnvGuard::set(&[("MOQ_CONNECT", "https://relay.example/room")]);
+
+		let ambient = Invocation::try_parse_from(["moq", "token", "generate"]).expect("parse");
+		assert!(
+			ambient.moq.client.url.is_some(),
+			"the resolved side should still pick the variable up"
+		);
+		assert!(
+			ambient.typed.reject("token").is_ok(),
+			"an exported MOQ_CONNECT was treated as a request"
+		);
+
+		let typed = Invocation::try_parse_from(["moq", "--connect", "https://relay.example/room", "token", "generate"])
+			.expect("parse");
+		assert!(
+			typed.typed.reject("token").is_err(),
+			"a typed --connect stopped being refused"
+		);
 	}
 }

--- a/rs/moq-cli/src/complete.rs
+++ b/rs/moq-cli/src/complete.rs
@@ -763,14 +763,15 @@ mod tests {
 		}
 	}
 
-	/// The environment may configure a dial, but it may not authorize one.
+	/// The environment may configure a MoQ side, but it may not ask for one.
 	///
-	/// `--connect` reads `MOQ_CONNECT`, so building the globals in one pass let an
-	/// exported variable turn a keystroke into a session with a relay the user never
-	/// typed, and that URL can carry a `?jwt=` credential. The gate is what the line
-	/// says, not what the environment says.
+	/// Two consumers of that distinction, tested together because both need the
+	/// variable set and this module is where every test holds the lock for it.
+	/// Completion must not turn a keystroke into a session with a relay the user never
+	/// typed (that URL can carry a `?jwt=`), and a local verb must not refuse to run
+	/// because the shell exports a relay for the publishing it usually does.
 	#[tokio::test]
-	async fn the_environment_cannot_authorize_a_dial() {
+	async fn the_environment_cannot_ask_for_a_moq_side() {
 		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 		let _alpha = origin.create_broadcast("alpha", route).expect("alpha");
@@ -791,6 +792,25 @@ mod tests {
 			complete(&format!("moq {connect} --broadcast ")).await,
 			["alpha"],
 			"a typed --connect stopped working"
+		);
+
+		// The other reader of the typed view: `moq token` / `devices` / `completion`
+		// refuse a MoQ side, and an exported variable is not one being asked for.
+		let ambient = crate::args::Invocation::try_parse_from(["moq", "token", "generate"]).expect("parse");
+		assert!(
+			ambient.moq.client.url.is_some(),
+			"the resolved side should still pick the variable up"
+		);
+		assert!(
+			ambient.reject("token").is_ok(),
+			"an exported MOQ_CONNECT was treated as a request"
+		);
+
+		let typed =
+			crate::args::Invocation::try_parse_from(["moq", "--connect", &url, "token", "generate"]).expect("parse");
+		assert!(
+			typed.reject("token").is_err(),
+			"a typed --connect stopped being refused"
 		);
 	}
 

--- a/rs/moq-cli/src/complete.rs
+++ b/rs/moq-cli/src/complete.rs
@@ -27,7 +27,7 @@ use tokio::time::{Instant, timeout_at};
 use usage::complete::{Candidate, CompleteCtx, CompletionFuture, CompletionOverlay, CompletionRequest, Shell, render};
 use usage::spec::{CommandArgs, ValueEnum};
 
-use crate::args::{Cli, Export, MoqSide, Stage};
+use crate::args::{Cli, Environment, Export, MoqSide, Stage};
 use crate::subscribe::CatalogFormatArg;
 
 /// The wall-clock budget one network-backed completer gets, handshake included.
@@ -214,41 +214,12 @@ fn globals(request: &CompletionRequest) -> Option<MoqSide> {
 	let chunk = request.split.argv().split(|word| word == "--").next()?;
 	let argv: Vec<&OsStr> = chunk.iter().map(OsStr::new).collect();
 
-	let typed = side(&argv, Environment::Ignore)?;
-	let mut side = side(&argv, Environment::Read)?;
+	let typed = MoqSide::from_argv(&argv, Environment::Ignore)?;
+	let mut side = MoqSide::from_argv(&argv, Environment::Read)?;
 	if typed.client.url.is_none() {
 		side.client.url = None;
 	}
 	Some(side)
-}
-
-/// Whether [`side`] lets the environment fill what the words left out.
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum Environment {
-	Read,
-	Ignore,
-}
-
-/// Build [`MoqSide`] from one chunk of a line being completed.
-fn side(argv: &[&OsStr], environment: Environment) -> Option<MoqSide> {
-	let mut partial = <MoqSide as CommandArgs>::start();
-	let mut parser = usage::Parser::new(Cli::command(), argv);
-	while let Some(event) = parser.next_event() {
-		match event {
-			Ok(event) => {
-				<MoqSide as CommandArgs>::apply(&mut partial, &event);
-			}
-			// A line being completed is unfinished by definition, so an error means the
-			// grammar ran out here; the partial holds what was understood before that.
-			Err(_) => break,
-		}
-	}
-
-	if environment == Environment::Read {
-		<MoqSide as CommandArgs>::apply_env(&mut partial);
-	}
-	<MoqSide as CommandArgs>::apply_defaults(&mut partial);
-	<MoqSide as CommandArgs>::build(partial).ok()
 }
 
 /// `T`'s own flags, as far as the words the cursor's command was given go.
@@ -654,6 +625,7 @@ async fn dial(side: &MoqSide, deadline: Instant) -> Option<(moq_net::origin::Pro
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::test_env::EnvGuard;
 
 	/// Answer a whole line, with the cursor at its end.
 	async fn complete(line: &str) -> Vec<String> {
@@ -696,7 +668,7 @@ mod tests {
 	/// against it offers process-wide flags that the chunk refuses.
 	#[tokio::test]
 	async fn retargets_to_the_active_stage() {
-		let _env = EnvGuard::lock();
+		let _env = EnvGuard::clear(&["MOQ_CONNECT"]);
 		// A stage offers its own flags, and none of the globals it would refuse.
 		let staged = complete("moq --connect http://x/y import fmp4 -- export fmp4 --").await;
 		assert!(!staged.is_empty(), "a later stage completed nothing");
@@ -791,56 +763,6 @@ mod tests {
 		}
 	}
 
-	/// One lock for every test that touches the process environment.
-	///
-	/// `set_var`'s safety contract is that no other thread reads the environment while
-	/// it runs, and completion reads it on every call: `globals` goes through
-	/// `CommandArgs::apply_env`. So the lock is not only for the test that writes.
-	/// Every test that calls [`complete`] takes it too, which is what makes the write
-	/// sound under a threaded runner, and which also stops a developer's own exported
-	/// `MOQ_CONNECT` from deciding whether an assertion passes.
-	static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-	/// Holds [`ENV_LOCK`], and restores `MOQ_CONNECT` on the way out.
-	struct EnvGuard {
-		_lock: std::sync::MutexGuard<'static, ()>,
-		saved: Option<OsString>,
-	}
-
-	impl EnvGuard {
-		/// Take the lock and clear `MOQ_CONNECT`, for a test that only reads it.
-		fn lock() -> Self {
-			Self::set(None)
-		}
-
-		fn set(value: Option<&str>) -> Self {
-			let lock = ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-			let saved = std::env::var_os("MOQ_CONNECT");
-			// SAFETY: ENV_LOCK is held, and every test that reads or writes the
-			// environment takes it first.
-			unsafe {
-				match value {
-					Some(value) => std::env::set_var("MOQ_CONNECT", value),
-					None => std::env::remove_var("MOQ_CONNECT"),
-				}
-			}
-			Self { _lock: lock, saved }
-		}
-	}
-
-	impl Drop for EnvGuard {
-		fn drop(&mut self) {
-			// Runs before `_lock`, so the restore is still serialized.
-			// SAFETY: see `set`.
-			unsafe {
-				match &self.saved {
-					Some(value) => std::env::set_var("MOQ_CONNECT", value),
-					None => std::env::remove_var("MOQ_CONNECT"),
-				}
-			}
-		}
-	}
-
 	/// The environment may configure a dial, but it may not authorize one.
 	///
 	/// `--connect` reads `MOQ_CONNECT`, so building the globals in one pass let an
@@ -856,7 +778,7 @@ mod tests {
 
 		// The same reachable relay, named only by the environment.
 		let url = connect.split_whitespace().nth(1).expect("a --connect url").to_string();
-		let _env = EnvGuard::set(Some(&url));
+		let _env = EnvGuard::set(&[("MOQ_CONNECT", &url)]);
 
 		assert!(
 			complete("moq --connect-tls-insecure --broadcast ").await.is_empty(),
@@ -881,7 +803,7 @@ mod tests {
 	/// that the completer fired at all.
 	#[tokio::test]
 	async fn no_relay_on_the_line_means_no_dial() {
-		let _env = EnvGuard::lock();
+		let _env = EnvGuard::clear(&["MOQ_CONNECT"]);
 		for line in [
 			"moq --broadcast ",
 			"moq export --broadcast ",
@@ -924,7 +846,7 @@ mod tests {
 	/// `--broadcast` is answered from what the relay on the line announces.
 	#[tokio::test]
 	async fn a_relay_on_the_line_answers_broadcast() {
-		let _env = EnvGuard::lock();
+		let _env = EnvGuard::clear(&["MOQ_CONNECT"]);
 		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 		let _alpha = origin.create_broadcast("alpha", route.clone()).expect("alpha");
@@ -946,7 +868,7 @@ mod tests {
 	/// broadcast the stage names, which overrides the process-wide one.
 	#[tokio::test]
 	async fn a_stage_broadcast_picks_the_catalog_to_read() {
-		let _env = EnvGuard::lock();
+		let _env = EnvGuard::clear(&["MOQ_CONNECT"]);
 		use hang::catalog::{AudioCodec, AudioConfig, H264, VideoConfig};
 
 		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
@@ -994,7 +916,7 @@ mod tests {
 	/// answers either way and hides the bug.
 	#[tokio::test]
 	async fn the_catalog_format_on_the_line_is_honored() {
-		let _env = EnvGuard::lock();
+		let _env = EnvGuard::clear(&["MOQ_CONNECT"]);
 		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 		let mut broadcast = origin.create_broadcast("room", route).expect("broadcast");

--- a/rs/moq-cli/src/complete.rs
+++ b/rs/moq-cli/src/complete.rs
@@ -58,8 +58,8 @@ const SETTLE: Duration = Duration::from_millis(30);
 ///
 /// The value name, not the flag: that is what Usage matches an overlay on, and the
 /// derive spells it in screaming snake case (`--video-name <VIDEO_NAME>`), so a key
-/// of `video-name` silently never fires. `every_overlay_names_a_declared_value` is
-/// what keeps this table honest.
+/// of `video-name` silently never fires. `every_overlay_matches_only_what_it_answers_for`
+/// is what keeps this table honest.
 ///
 /// [`CommandSelector::Any`](usage::spec::CommandSelector::Any) throughout: every one
 /// of these names means the same thing wherever it appears, and `--broadcast`
@@ -70,14 +70,22 @@ static NETWORK: &[CompletionOverlay<'static>] = &[
 	CompletionOverlay::async_any("AUDIO_NAME", audio_names),
 ];
 
+/// The command whose source flags [`CAPTURE`] answers for.
+#[cfg(feature = "capture")]
+const CAPTURE_PATH: &str = "import capture";
+
 /// The completers for `import capture`'s sources, which only that feature declares.
+///
+/// Scoped to the one command, unlike [`NETWORK`]: these names are generic enough to
+/// collide. `export hls --window <DURATION>` is a playlist window, and an `Any`
+/// overlay answered it with this machine's macOS window ids.
 #[cfg(feature = "capture")]
 static CAPTURE: &[CompletionOverlay<'static>] = &[
-	CompletionOverlay::async_any("CAMERA", cameras),
-	CompletionOverlay::async_any("DISPLAY", displays),
-	CompletionOverlay::async_any("WINDOW", windows),
-	CompletionOverlay::async_any("APP", apps),
-	CompletionOverlay::async_any("MICROPHONE", microphones),
+	CompletionOverlay::asynchronous(CAPTURE_PATH, "CAMERA", cameras),
+	CompletionOverlay::asynchronous(CAPTURE_PATH, "DISPLAY", displays),
+	CompletionOverlay::asynchronous(CAPTURE_PATH, "WINDOW", windows),
+	CompletionOverlay::asynchronous(CAPTURE_PATH, "APP", apps),
+	CompletionOverlay::asynchronous(CAPTURE_PATH, "MICROPHONE", microphones),
 ];
 
 /// See [`CAPTURE`].
@@ -619,12 +627,19 @@ async fn dial(side: &MoqSide, deadline: Instant) -> Option<(moq_net::origin::Pro
 	let url = side.client.url.clone()?;
 	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
 
-	// No iroh endpoint: binding one is more setup than a keystroke should pay for,
-	// so an `iroh://` peer completes nothing rather than completing slowly.
-	let client = side
-		.client
-		.clone()
-		.init(side.quic.clone())
+	// Building the client reads the TLS material off disk synchronously, so it goes on
+	// the blocking pool and under the deadline like everything else: a `--connect-tls-root`
+	// on a stalled mount (or a FIFO) would otherwise hang the prompt before the first
+	// timeout is even entered. Dropping the timeout cannot cancel the read, but it does
+	// let the process answer and exit.
+	//
+	// No iroh endpoint: binding one is more setup than a keystroke should pay for, so an
+	// `iroh://` peer completes nothing rather than completing slowly.
+	let (connect, quic) = (side.client.clone(), side.quic.clone());
+	let client = timeout_at(deadline, tokio::task::spawn_blocking(move || connect.init(quic)))
+		.await
+		.ok()?
+		.ok()?
 		.ok()?
 		.with_subscriber(origin.clone())
 		.with_reconnect(false);
@@ -702,29 +717,74 @@ mod tests {
 		assert!(complete("moq import fmp4 --").await.is_empty());
 	}
 
-	/// Every overlay names a value some command actually declares.
+	/// Every overlay names a value that only the commands it is meant for declare.
 	///
-	/// An overlay is matched by the value name, which the derive spells for itself, so
-	/// a renamed field silently stops firing its completer. Nothing else would notice:
-	/// a completer that never runs looks exactly like one that found nothing.
+	/// Two ways this goes wrong, and neither is visible at runtime. A renamed field
+	/// leaves an overlay matching nothing, and a completer that never runs looks
+	/// exactly like one that found nothing. A *new* flag that happens to reuse the
+	/// name captures an unrelated value: `export hls --window <DURATION>` was answered
+	/// with this machine's macOS window ids until the capture overlays were scoped.
 	#[test]
-	fn every_overlay_names_a_declared_value() {
-		fn declares(command: &usage::spec::CommandMeta<'_>, value: &str) -> bool {
-			command
+	fn every_overlay_matches_only_what_it_answers_for() {
+		// Where each `Any`-scoped value name is allowed to appear. These are the names
+		// whose meaning really is the same wherever they are written: a broadcast before
+		// the verb and on a stage are one relay path, and a rendition is a rendition.
+		// Anything scoped to a command is checked against that command instead.
+		//
+		// Built rather than declared, because which commands exist depends on the build:
+		// `play` is a feature, and the root itself is the empty path.
+		let renditions = match cfg!(feature = "play") {
+			true => vec!["export", "play"],
+			false => vec!["export"],
+		};
+		let shared = [
+			("BROADCAST", vec!["", "import", "export"]),
+			("VIDEO_NAME", renditions.clone()),
+			("AUDIO_NAME", renditions),
+		];
+
+		/// Every command path that declares a value by this name.
+		fn declaring(command: &usage::spec::CommandMeta<'_>, value: &str, at: &str, found: &mut Vec<String>) {
+			let declares = command
 				.flags
 				.iter()
 				.any(|field| field.value_name.unwrap_or(field.flag.name).eq_ignore_ascii_case(value))
 				|| command
 					.args
 					.iter()
-					.any(|field| field.arg.name.eq_ignore_ascii_case(value))
-				|| command.subcommands.iter().any(|sub| declares(sub, value))
+					.any(|field| field.arg.name.eq_ignore_ascii_case(value));
+			if declares {
+				found.push(at.to_string());
+			}
+			for sub in command.subcommands {
+				let deeper = match at.is_empty() {
+					true => sub.cmd.name.to_string(),
+					false => format!("{at} {}", sub.cmd.name),
+				};
+				declaring(sub, value, &deeper, found);
+			}
 		}
 
 		for overlay in overlays() {
+			let mut found = Vec::new();
+			declaring(Cli::spec().root, overlay.value, "", &mut found);
 			assert!(
-				declares(Cli::spec().root, overlay.value),
+				!found.is_empty(),
 				"no flag or argument takes a value named `{}`, so its completer never runs",
+				overlay.value
+			);
+
+			// A scoped overlay only fires on its own command, so a name reused elsewhere
+			// is harmless; an `Any` one answers everywhere the name appears.
+			let Some((_, allowed)) = shared.iter().find(|(name, _)| *name == overlay.value) else {
+				continue;
+			};
+			found.sort();
+			let mut allowed: Vec<String> = allowed.iter().map(|path| path.to_string()).collect();
+			allowed.sort();
+			assert_eq!(
+				found, allowed,
+				"`{}` is answered everywhere it appears, and the set of commands declaring it changed",
 				overlay.value
 			);
 		}
@@ -777,7 +837,7 @@ mod tests {
 	///
 	/// `--connect` reads `MOQ_CONNECT`, so building the globals in one pass let an
 	/// exported variable turn a keystroke into a session with a relay the user never
-	/// typed -- and that URL can carry a `?jwt=` credential. The gate is what the line
+	/// typed, and that URL can carry a `?jwt=` credential. The gate is what the line
 	/// says, not what the environment says.
 	#[tokio::test]
 	async fn the_environment_cannot_authorize_a_dial() {

--- a/rs/moq-cli/src/complete.rs
+++ b/rs/moq-cli/src/complete.rs
@@ -696,6 +696,7 @@ mod tests {
 	/// against it offers process-wide flags that the chunk refuses.
 	#[tokio::test]
 	async fn retargets_to_the_active_stage() {
+		let _env = EnvGuard::lock();
 		// A stage offers its own flags, and none of the globals it would refuse.
 		let staged = complete("moq --connect http://x/y import fmp4 -- export fmp4 --").await;
 		assert!(!staged.is_empty(), "a later stage completed nothing");
@@ -792,23 +793,30 @@ mod tests {
 
 	/// One lock for every test that touches the process environment.
 	///
-	/// `set_var` is not thread-safe against a concurrent read, and Usage reads the
-	/// `MOQ_*` vars while it parses. Clearing on entry also stops a developer's own
-	/// exported `MOQ_CONNECT` from making a no-dial assertion pass for the wrong
-	/// reason, or fail for one.
+	/// `set_var`'s safety contract is that no other thread reads the environment while
+	/// it runs, and completion reads it on every call: `globals` goes through
+	/// `CommandArgs::apply_env`. So the lock is not only for the test that writes.
+	/// Every test that calls [`complete`] takes it too, which is what makes the write
+	/// sound under a threaded runner, and which also stops a developer's own exported
+	/// `MOQ_CONNECT` from deciding whether an assertion passes.
 	static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-	/// Holds [`ENV_LOCK`] and restores `MOQ_CONNECT` on the way out.
+	/// Holds [`ENV_LOCK`], and restores `MOQ_CONNECT` on the way out.
 	struct EnvGuard {
 		_lock: std::sync::MutexGuard<'static, ()>,
 		saved: Option<OsString>,
 	}
 
 	impl EnvGuard {
+		/// Take the lock and clear `MOQ_CONNECT`, for a test that only reads it.
+		fn lock() -> Self {
+			Self::set(None)
+		}
+
 		fn set(value: Option<&str>) -> Self {
 			let lock = ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
 			let saved = std::env::var_os("MOQ_CONNECT");
-			// SAFETY: ENV_LOCK is held, and every test here that reads or writes the
+			// SAFETY: ENV_LOCK is held, and every test that reads or writes the
 			// environment takes it first.
 			unsafe {
 				match value {
@@ -873,7 +881,7 @@ mod tests {
 	/// that the completer fired at all.
 	#[tokio::test]
 	async fn no_relay_on_the_line_means_no_dial() {
-		let _env = EnvGuard::set(None);
+		let _env = EnvGuard::lock();
 		for line in [
 			"moq --broadcast ",
 			"moq export --broadcast ",
@@ -916,6 +924,7 @@ mod tests {
 	/// `--broadcast` is answered from what the relay on the line announces.
 	#[tokio::test]
 	async fn a_relay_on_the_line_answers_broadcast() {
+		let _env = EnvGuard::lock();
 		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 		let _alpha = origin.create_broadcast("alpha", route.clone()).expect("alpha");
@@ -937,6 +946,7 @@ mod tests {
 	/// broadcast the stage names, which overrides the process-wide one.
 	#[tokio::test]
 	async fn a_stage_broadcast_picks_the_catalog_to_read() {
+		let _env = EnvGuard::lock();
 		use hang::catalog::{AudioCodec, AudioConfig, H264, VideoConfig};
 
 		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
@@ -984,6 +994,7 @@ mod tests {
 	/// answers either way and hides the bug.
 	#[tokio::test]
 	async fn the_catalog_format_on_the_line_is_honored() {
+		let _env = EnvGuard::lock();
 		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 		let mut broadcast = origin.create_broadcast("room", route).expect("broadcast");

--- a/rs/moq-cli/src/complete.rs
+++ b/rs/moq-cli/src/complete.rs
@@ -1,0 +1,749 @@
+//! Shell completion: which grammar answers the cursor, and the runtime completers
+//! that answer values the static tables cannot know.
+//!
+//! Two halves. The plumbing decides whether a cursor belongs to the root grammar
+//! or to a `--`-separated stage, because this binary splits argv itself (see
+//! [`crate::args`]) and Usage's own interception only knows the root. The
+//! completers answer the values that are only knowable at the prompt: the capture
+//! sources this machine has, and the broadcasts and renditions the relay on the
+//! line is carrying.
+//!
+//! A completion is not a command anybody ran, so nothing here reports a failure.
+//! An unreachable relay, a refused session, or a budget that runs out all mean
+//! "no candidates": a message in the prompt would be worse than a short list.
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::ffi::{OsStr, OsString};
+use std::time::Duration;
+
+use anyhow::Context;
+use hang::moq_net;
+use moq_mux::catalog::{CatalogFormat, Stream};
+use tokio::time::{Instant, timeout_at};
+use usage::complete::{Candidate, CompleteCtx, CompletionFuture, CompletionOverlay, CompletionRequest, Shell, render};
+use usage::spec::{CommandArgs, ValueEnum};
+
+use crate::args::{Cli, Export, MoqSide, Stage};
+use crate::subscribe::CatalogFormatArg;
+
+/// The wall-clock budget one network-backed completer gets, handshake included.
+///
+/// A ceiling on the whole exchange rather than a timeout per step: whatever has
+/// arrived when it expires is the answer. Tab is pressed between keystrokes, so a
+/// completer that outlives the user's patience is a shell that appears to hang,
+/// and half a list now beats the whole list later.
+const BUDGET: Duration = Duration::from_millis(500);
+
+/// How long the announce sweep waits for a sibling after an announcement lands.
+///
+/// A relay sends its whole announced set back to back, so the gap between the
+/// first and the last is a round trip, not a budget. Without this the sweep would
+/// always cost [`BUDGET`], even when the answer arrived in a few milliseconds.
+const SETTLE: Duration = Duration::from_millis(30);
+
+/// The completers every build has, keyed by the *value* name they answer for.
+///
+/// The value name, not the flag: that is what Usage matches an overlay on, and the
+/// derive spells it in screaming snake case (`--video-name <VIDEO_NAME>`), so a key
+/// of `video-name` silently never fires. `every_overlay_names_a_declared_value` is
+/// what keeps this table honest.
+///
+/// [`CommandSelector::Any`](usage::spec::CommandSelector::Any) throughout: every one
+/// of these names means the same thing wherever it appears, and `--broadcast`
+/// deliberately appears both before the verb and on a stage.
+static NETWORK: &[CompletionOverlay<'static>] = &[
+	CompletionOverlay::async_any("BROADCAST", broadcasts),
+	CompletionOverlay::async_any("VIDEO_NAME", video_names),
+	CompletionOverlay::async_any("AUDIO_NAME", audio_names),
+];
+
+/// The completers for `import capture`'s sources, which only that feature declares.
+#[cfg(feature = "capture")]
+static CAPTURE: &[CompletionOverlay<'static>] = &[
+	CompletionOverlay::async_any("CAMERA", cameras),
+	CompletionOverlay::async_any("DISPLAY", displays),
+	CompletionOverlay::async_any("WINDOW", windows),
+	CompletionOverlay::async_any("APP", apps),
+	CompletionOverlay::async_any("MICROPHONE", microphones),
+];
+
+/// See [`CAPTURE`].
+#[cfg(not(feature = "capture"))]
+static CAPTURE: &[CompletionOverlay<'static>] = &[];
+
+/// Every completer this build has. One allocation on the completion path only.
+fn overlays() -> Vec<CompletionOverlay<'static>> {
+	NETWORK.iter().chain(CAPTURE).copied().collect()
+}
+
+thread_local! {
+	/// The process-wide MoQ flags of the line being completed.
+	///
+	/// A completer is a bare `fn` in a table Usage owns, so it cannot capture the
+	/// request; and a cursor past a `--` is answered against the stage grammar,
+	/// whose chunk has no `--connect` in it by construction. Parsing the globals
+	/// once, here, is what lets a completer in either grammar reach them.
+	///
+	/// Thread-local rather than a process global because this is per-request state:
+	/// [`answer`]'s future is `!Send` (Usage's completion futures are), so it can
+	/// only ever be driven on the thread that started it.
+	static GLOBALS: RefCell<Option<MoqSide>> = const { RefCell::new(None) };
+}
+
+/// Holds [`GLOBALS`] for one request and clears it on the way out.
+struct Globals;
+
+impl Globals {
+	fn set(side: Option<MoqSide>) -> Self {
+		GLOBALS.with_borrow_mut(|slot| *slot = side);
+		Self
+	}
+
+	/// The globals this request parsed, or `None` when the line has none yet.
+	fn get() -> Option<MoqSide> {
+		GLOBALS.with_borrow(Clone::clone)
+	}
+}
+
+impl Drop for Globals {
+	fn drop(&mut self) {
+		GLOBALS.with_borrow_mut(|slot| *slot = None);
+	}
+}
+
+/// Answer a shell's completion request, against the grammar the cursor is in.
+///
+/// `None` for ordinary argv, which is what tells [`crate::args::Invocation::parse`]
+/// that this is a real invocation.
+///
+/// The root spec is the globals plus the *first* stage. A cursor in a later chunk
+/// answered against it offers `--connect` and the other process-wide flags, which a
+/// stage refuses, so the request is rewritten to the active chunk and handed to
+/// [`Stage`].
+pub async fn answer(argv: &[OsString]) -> Option<String> {
+	let request = CompletionRequest::parse(argv)?;
+	// Dropped at the end of this call, so a second request cannot read the first's.
+	let _globals = Globals::set(globals(&request));
+	let overlays = overlays();
+
+	// Everything past the cursor says nothing about the word being completed.
+	let words = request.split.walked();
+	// Strictly before the cursor: a cursor sitting *on* a `--` is typing the
+	// separator itself, which is the root's business rather than a stage's.
+	let staged = words[..request.split.cword]
+		.iter()
+		.rposition(|word| word == "--")
+		.map(|at| at + 1);
+
+	let answer = match staged {
+		None => {
+			Cli::app()
+				.completion_app()
+				.completions(&overlays)
+				.complete_request(&request)
+				.await
+		}
+		Some(start) => {
+			// `words[0]` is read as the program name, so the chunk gets one of its own.
+			let mut chunk = vec![words.first().cloned().unwrap_or_default()];
+			chunk.extend_from_slice(&words[start..]);
+
+			let mut request = request.clone();
+			request.split.cword = chunk.len() - 1;
+			request.split.words = chunk;
+			Stage::app()
+				.completion_app()
+				.completions(&overlays)
+				.complete_request(&request)
+				.await
+		}
+	};
+
+	Some(render(&answer, request.shell))
+}
+
+/// The process-wide MoQ flags, as far as the words before the cursor go.
+///
+/// Read from the first chunk, which is the only one that can carry them, and
+/// through the real tables rather than by scanning for `--connect`: what a
+/// completer dials has to be what an invocation would have dialed, TLS roots and
+/// environment variables included.
+fn globals(request: &CompletionRequest) -> Option<MoqSide> {
+	let chunk = request.split.argv().split(|word| word == "--").next()?;
+	let argv: Vec<&OsStr> = chunk.iter().map(OsStr::new).collect();
+
+	let mut partial = <MoqSide as CommandArgs>::start();
+	let mut parser = usage::Parser::new(Cli::command(), &argv);
+	while let Some(event) = parser.next_event() {
+		match event {
+			Ok(event) => {
+				<MoqSide as CommandArgs>::apply(&mut partial, &event);
+			}
+			// A line being completed is unfinished by definition, so an error means the
+			// grammar ran out here; the partial holds what was understood before that.
+			Err(_) => break,
+		}
+	}
+
+	<MoqSide as CommandArgs>::apply_env(&mut partial);
+	<MoqSide as CommandArgs>::apply_defaults(&mut partial);
+	<MoqSide as CommandArgs>::build(partial).ok()
+}
+
+/// The `export` stage the cursor is in, as far as the line goes.
+///
+/// A stage's own `--broadcast` overrides the process-wide one, and `--video-name`
+/// is only ever declared beside it, so a rendition completer has to read the stage
+/// it was typed in rather than the globals alone.
+fn export(ctx: &CompleteCtx<'_>) -> Option<<Export as CommandArgs>::Partial> {
+	let declaration = <Export as CommandArgs>::COMMAND;
+	let (command, words) = ctx.command_for(declaration)?;
+	let argv: Vec<&OsStr> = words.iter().map(OsStr::new).collect();
+
+	let mut partial = <Export as CommandArgs>::start();
+	let mut parser = usage::Parser::new(command, &argv);
+	while let Some(event) = parser.next_event() {
+		match event {
+			Ok(event) => {
+				<Export as CommandArgs>::apply(&mut partial, &event);
+			}
+			Err(_) => break,
+		}
+	}
+	Some(partial)
+}
+
+/// One raw partial value as text, or `None` when it was never given.
+fn given(value: &Option<Vec<u8>>) -> Option<&str> {
+	std::str::from_utf8(value.as_deref()?).ok()
+}
+
+// ------------------------------------------------------------------ script
+
+/// `Usage` adapter for [`Shell`], which is a foreign type and so can't derive
+/// `ValueEnum` itself.
+#[derive(usage::ValueEnum, Clone, Copy)]
+pub enum ShellArg {
+	Bash,
+	Elvish,
+	Fish,
+	Nu,
+	#[usage(name = "powershell")]
+	PowerShell,
+	Zsh,
+}
+
+impl From<ShellArg> for Shell {
+	fn from(shell: ShellArg) -> Self {
+		match shell {
+			ShellArg::Bash => Self::Bash,
+			ShellArg::Elvish => Self::Elvish,
+			ShellArg::Fish => Self::Fish,
+			ShellArg::Nu => Self::Nu,
+			ShellArg::PowerShell => Self::PowerShell,
+			ShellArg::Zsh => Self::Zsh,
+		}
+	}
+}
+
+/// `moq completion`: the script that makes a shell ask this binary what fits at
+/// the cursor.
+#[derive(usage::Args, Clone)]
+#[usage(unknown_flags = "error", args_override_self = false)]
+pub struct Args {
+	/// The shell to write the script for.
+	#[usage(arg, value_enum)]
+	pub shell: ShellArg,
+
+	/// Write it where this shell looks for completions, instead of to stdout.
+	#[usage(long)]
+	pub install: bool,
+
+	/// Replace a file already at that path that this binary did not write.
+	#[usage(long, requires = "--install")]
+	pub force: bool,
+}
+
+impl Args {
+	/// Write the script to stdout, or install it and report where it went.
+	///
+	/// The script goes to stdout so it can be redirected; everything about the
+	/// install goes to stderr, so `moq completion zsh > _moq` stays a script and not
+	/// a script with a report on the end of it.
+	pub fn run(self) -> anyhow::Result<()> {
+		let shell = self.shell.into();
+		if !self.install {
+			print!("{}", Cli::completion_script(shell));
+			return Ok(());
+		}
+
+		let on_foreign = match self.force {
+			true => usage::install::OnForeign::Overwrite,
+			false => usage::install::OnForeign::Refuse,
+		};
+
+		let installed = Cli::install_completion(shell, &usage::install::Env::from_process(), on_foreign)
+			.context("failed to install the completion script")?;
+
+		let wrote = match installed.wrote {
+			usage::install::Wrote::Created => "wrote",
+			usage::install::Wrote::Unchanged => "already current",
+			usage::install::Wrote::Updated => "updated",
+			usage::install::Wrote::Replaced => "replaced",
+			_ => "installed",
+		};
+		eprintln!("{wrote} {}", installed.plan.path.display());
+
+		// A shell that can't autoload the file needs a line in its own config, which
+		// this never edits. Say it, rather than reporting success on an install that
+		// does nothing yet. The snippet comes first and the reason after it, because
+		// Usage's `why` is a paragraph and what you have to paste is one line.
+		if let usage::install::Loading::Manual { line, file, why } = &installed.plan.loading {
+			eprintln!("\nadd this to {file}:");
+			for line in line.lines() {
+				eprintln!("    {line}");
+			}
+			eprintln!("\n{why}");
+		}
+
+		Ok(())
+	}
+}
+
+// ------------------------------------------------------------------ capture
+
+/// Turn a capture enumeration into candidates, or nothing when the platform
+/// cannot list that kind of source.
+#[cfg(feature = "capture")]
+fn sources<T, E>(found: Result<Vec<T>, E>, describe: impl Fn(&T) -> Candidate<'static>) -> Vec<Candidate<'static>> {
+	found
+		.map(|items| items.iter().map(describe).collect())
+		.unwrap_or_default()
+}
+
+/// Complete `--camera` from the cameras this machine has.
+///
+/// Only the attached `--camera=<TAB>` form reaches this: the flag's value is
+/// optional (bare `--camera` opens the default), so a detached word after it is
+/// as likely to be the next flag, and Usage will not guess.
+#[cfg(feature = "capture")]
+fn cameras(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
+	Box::pin(async move {
+		sources(moq_video::capture::cameras().await, |camera| {
+			Candidate::described(camera.id.clone(), camera.name.clone())
+		})
+	})
+}
+
+/// Complete `--display` from the displays this machine has.
+#[cfg(feature = "capture")]
+fn displays(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
+	Box::pin(async move {
+		sources(moq_video::capture::displays().await, |display| {
+			Candidate::described(
+				display.id.clone(),
+				format!("{} ({}x{})", display.name, display.width, display.height),
+			)
+		})
+	})
+}
+
+/// Complete `--window` from the windows this machine has open.
+#[cfg(feature = "capture")]
+fn windows(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
+	Box::pin(async move {
+		sources(moq_video::capture::windows().await, |window| {
+			let title = if window.title.is_empty() {
+				"(untitled)"
+			} else {
+				&window.title
+			};
+			Candidate::described(window.id.clone(), format!("{} - {title}", window.app))
+		})
+	})
+}
+
+/// Complete `--app` from the applications this machine is running.
+#[cfg(feature = "capture")]
+fn apps(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
+	Box::pin(async move {
+		sources(moq_video::capture::apps().await, |app| {
+			Candidate::described(app.id.clone(), app.name.clone())
+		})
+	})
+}
+
+/// Complete `--microphone` from the audio inputs this machine has.
+#[cfg(feature = "capture")]
+fn microphones(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
+	Box::pin(async move {
+		sources(moq_audio::capture::devices().await, |device| match device.default {
+			true => Candidate::described(device.id.clone(), "the default input"),
+			false => Candidate::new(device.id.clone()),
+		})
+	})
+}
+
+// ------------------------------------------------------------------ network
+
+/// Complete `--broadcast` from what the relay on the line announces.
+///
+/// Offered on an `import` as well as an `export`, even though an import is naming a
+/// broadcast it is about to publish rather than one that exists: a redundant (1+1)
+/// publisher deliberately reuses the name, and seeing what is already there is how
+/// you avoid colliding with it by accident.
+fn broadcasts(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
+	Box::pin(async move {
+		let Some(side) = Globals::get() else {
+			return Vec::new();
+		};
+		let deadline = Instant::now() + BUDGET;
+		let Some((origin, connection)) = dial(&side, deadline).await else {
+			return Vec::new();
+		};
+
+		// Announce and unannounce arrive as separate updates for the same path, so
+		// this tracks a set rather than appending: a broadcast that ends while the
+		// sweep is running is one the user cannot name by the time they press enter.
+		let mut announced = origin.consume().announced();
+		let mut live = BTreeSet::new();
+		// The first announcement gets the whole remaining budget; each one after it
+		// only has to beat its siblings, which are already on the wire.
+		let mut until = deadline;
+		while let Ok(Some(update)) = timeout_at(until, announced.next()).await {
+			until = deadline.min(Instant::now() + SETTLE);
+			let path = update.path.to_string();
+			// The root broadcast is the connection path itself, which an unset
+			// `--broadcast` already names; there is no word to insert for it.
+			if path.is_empty() {
+				continue;
+			}
+			match update.broadcast.is_some() {
+				true => live.insert(path),
+				false => live.remove(&path),
+			};
+		}
+		connection.close();
+
+		live.into_iter().map(Candidate::new).collect()
+	})
+}
+
+/// Complete `--video-name` from the broadcast's catalog.
+fn video_names(ctx: CompleteCtx<'_>) -> CompletionFuture<'_> {
+	Box::pin(async move {
+		let Some(catalog) = renditions(&ctx).await else {
+			return Vec::new();
+		};
+		catalog
+			.video
+			.renditions
+			.iter()
+			.map(|(name, config)| {
+				let size = match (config.coded_width, config.coded_height) {
+					(Some(width), Some(height)) => format!(" {width}x{height}"),
+					_ => String::new(),
+				};
+				Candidate::described(name.clone(), format!("{}{size}", config.codec))
+			})
+			.collect()
+	})
+}
+
+/// Complete `--audio-name` from the broadcast's catalog.
+fn audio_names(ctx: CompleteCtx<'_>) -> CompletionFuture<'_> {
+	Box::pin(async move {
+		let Some(catalog) = renditions(&ctx).await else {
+			return Vec::new();
+		};
+		catalog
+			.audio
+			.renditions
+			.iter()
+			.map(|(name, config)| {
+				Candidate::described(
+					name.clone(),
+					format!("{} {} Hz {}ch", config.codec, config.sample_rate, config.channel_count),
+				)
+			})
+			.collect()
+	})
+}
+
+/// Dial the relay and read one catalog snapshot for the broadcast on the line.
+async fn renditions(ctx: &CompleteCtx<'_>) -> Option<moq_mux::catalog::hang::Catalog> {
+	let side = Globals::get()?;
+	let stage = export(ctx);
+	let stage = stage.as_ref();
+
+	// A stage's own `--broadcast` wins over the process-wide one, exactly as it does
+	// for the invocation this line is on its way to becoming.
+	let path = stage
+		.and_then(|stage| given(&stage.broadcast))
+		.or(side.broadcast.as_deref())
+		.unwrap_or_default()
+		.to_string();
+
+	let format = stage
+		.and_then(|stage| given(&stage.catalog_format))
+		.and_then(CatalogFormatArg::from_choice)
+		.map(CatalogFormat::from)
+		.or_else(|| CatalogFormat::detect(&path))
+		.unwrap_or_default();
+
+	let deadline = Instant::now() + BUDGET;
+	let (origin, connection) = dial(&side, deadline).await?;
+	let catalog = timeout_at(deadline, catalog(&origin, &path, format))
+		.await
+		.ok()
+		.flatten();
+	connection.close();
+	catalog
+}
+
+/// Subscribe to a broadcast's catalog and return its first snapshot.
+async fn catalog(
+	origin: &moq_net::origin::Producer,
+	path: &str,
+	format: CatalogFormat,
+) -> Option<moq_mux::catalog::hang::Catalog> {
+	// `announced_broadcast` rather than a plain lookup: the announcement is still in
+	// flight right after connecting, and asking on the spot reports a live broadcast
+	// as unroutable.
+	let consumer = origin.consume();
+	consumer.announced_broadcast(path).await?;
+
+	let mut stream = moq_mux::Source::new(consumer, path).catalog(format).await.ok()?;
+	stream.next().await.ok()?
+}
+
+/// Open a throwaway subscribe-only session to the relay `--connect` names.
+///
+/// The origin id is fresh and random rather than the pinned `--origin`: this
+/// session is not the publisher the user is about to start, and a shared id is
+/// what tells a relay two sessions carry the same content.
+async fn dial(side: &MoqSide, deadline: Instant) -> Option<(moq_net::origin::Producer, moq_tokio::Connection)> {
+	let url = side.client.url.clone()?;
+	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+
+	// No iroh endpoint: binding one is more setup than a keystroke should pay for,
+	// so an `iroh://` peer completes nothing rather than completing slowly.
+	let client = side
+		.client
+		.clone()
+		.init(side.quic.clone())
+		.ok()?
+		.with_subscriber(origin.clone())
+		.with_reconnect(false);
+
+	let connection = timeout_at(deadline, client.connect(url).established())
+		.await
+		.ok()?
+		.ok()?;
+	Some((origin, connection))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Answer a whole line, with the cursor at its end.
+	async fn complete(line: &str) -> Vec<String> {
+		let argv: Vec<OsString> = ["__complete_word__", "--shell", "bash", "--line", line, "--cursor"]
+			.iter()
+			.map(OsString::from)
+			.chain(std::iter::once(OsString::from(line.len().to_string())))
+			.collect();
+
+		answer(&argv)
+			.await
+			.unwrap_or_default()
+			.lines()
+			.map(str::to_string)
+			.collect()
+	}
+
+	/// A relay serving `origin`, and the `--connect` flags that reach it.
+	///
+	/// Self-signed, so the line has to say `--connect-tls-insecure`. That is also the
+	/// point: the completer builds its client from the same flags the invocation would
+	/// have, so a line that can connect completes and one that cannot does not.
+	fn relay(origin: &moq_net::origin::Producer) -> String {
+		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+		let mut config = moq_tokio::listen::Config::default();
+		config.bind = Some("127.0.0.1:0".to_string());
+		config.tls.generate = vec!["localhost".to_string()];
+
+		let server = config.init(Default::default()).expect("failed to bind listener");
+		let port = server.local_addr().expect("no local addr").port();
+		tokio::spawn(server.serve_publish(origin.consume()));
+
+		format!("--connect moqt://127.0.0.1:{port} --connect-tls-insecure")
+	}
+
+	/// A cursor in a later stage is completed against the stage grammar.
+	///
+	/// The root spec is the globals plus the first stage, so answering a later chunk
+	/// against it offers process-wide flags that the chunk refuses.
+	#[tokio::test]
+	async fn retargets_to_the_active_stage() {
+		// A stage offers its own flags, and none of the globals it would refuse.
+		let staged = complete("moq --connect http://x/y import fmp4 -- export fmp4 --").await;
+		assert!(!staged.is_empty(), "a later stage completed nothing");
+		for global in ["--connect", "--origin", "--broadcast"] {
+			assert!(
+				!staged.iter().any(|candidate| candidate == global),
+				"{global} leaked into a stage that refuses it: {staged:?}"
+			);
+		}
+
+		// The root still answers for itself.
+		let root = complete("moq --conn").await;
+		assert!(
+			root.iter().any(|candidate| candidate == "--connect"),
+			"root lost its globals: {root:?}"
+		);
+
+		// A cursor sitting on the separator is typing `--`, not inside a stage.
+		assert!(complete("moq import fmp4 --").await.is_empty());
+	}
+
+	/// Every overlay names a value some command actually declares.
+	///
+	/// An overlay is matched by the value name, which the derive spells for itself, so
+	/// a renamed field silently stops firing its completer. Nothing else would notice:
+	/// a completer that never runs looks exactly like one that found nothing.
+	#[test]
+	fn every_overlay_names_a_declared_value() {
+		fn declares(command: &usage::spec::CommandMeta<'_>, value: &str) -> bool {
+			command
+				.flags
+				.iter()
+				.any(|field| field.value_name.unwrap_or(field.flag.name).eq_ignore_ascii_case(value))
+				|| command
+					.args
+					.iter()
+					.any(|field| field.arg.name.eq_ignore_ascii_case(value))
+				|| command.subcommands.iter().any(|sub| declares(sub, value))
+		}
+
+		for overlay in overlays() {
+			assert!(
+				declares(Cli::spec().root, overlay.value),
+				"no flag or argument takes a value named `{}`, so its completer never runs",
+				overlay.value
+			);
+		}
+	}
+
+	/// A completer that needs the network answers nothing when the line names no relay.
+	///
+	/// The gate is the whole reason tab-completion may dial at all: without a
+	/// `--connect` on the line there is nothing to ask, and a keystroke must not open a
+	/// connection the user did not name. An overlay that runs and finds nothing still
+	/// suppresses the shell's path fallback, so an empty answer here is also evidence
+	/// that the completer fired at all.
+	#[tokio::test]
+	async fn no_relay_on_the_line_means_no_dial() {
+		for line in [
+			"moq --broadcast ",
+			"moq export --broadcast ",
+			"moq export --video-name ",
+			"moq export --audio-name ",
+		] {
+			assert!(complete(line).await.is_empty(), "{line:?} completed without a relay");
+		}
+	}
+
+	/// Every shell this verb offers is one Usage can write a script for, spelled the
+	/// way Usage spells it.
+	///
+	/// The adapter exists because [`Shell`] is foreign, so nothing but this ties the
+	/// two spellings together: `powershell` is one word here and two variants apart.
+	#[test]
+	fn every_shell_choice_names_a_real_shell() {
+		for choice in <ShellArg as ValueEnum>::CHOICES {
+			let arg = ShellArg::from_choice(choice).expect("a declared choice");
+			assert_eq!(
+				Shell::from(arg).as_str(),
+				*choice,
+				"`{choice}` is not what Usage calls it"
+			);
+		}
+	}
+
+	/// The generated script asks this binary, under the name it ships as.
+	#[test]
+	fn the_script_registers_this_binary() {
+		let script = Cli::completion_script(Shell::Zsh);
+		assert!(
+			script.starts_with("#compdef moq"),
+			"{}",
+			&script[..40.min(script.len())]
+		);
+		assert!(script.contains("__complete_word__"), "the script asks nothing");
+	}
+
+	/// `--broadcast` is answered from what the relay on the line announces.
+	#[tokio::test]
+	async fn a_relay_on_the_line_answers_broadcast() {
+		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let route = moq_net::broadcast::Route::new().with_announce(true);
+		let _alpha = origin.create_broadcast("alpha", route.clone()).expect("alpha");
+		let _nested = origin.create_broadcast("room/beta", route).expect("beta");
+
+		let connect = relay(&origin);
+		let found = complete(&format!("moq {connect} --broadcast ")).await;
+		assert!(found.contains(&"alpha".to_string()), "{found:?}");
+		assert!(found.contains(&"room/beta".to_string()), "{found:?}");
+
+		// A cursor past a `--` is answered against the stage grammar, whose chunk holds
+		// no `--connect`: the completer still has to reach the relay the line named
+		// before the separator.
+		let staged = complete(&format!("moq {connect} import fmp4 -- export --broadcast ")).await;
+		assert_eq!(staged, found, "a later stage lost the relay the globals named");
+	}
+
+	/// `--video-name` and `--audio-name` are answered from the catalog of the
+	/// broadcast the stage names, which overrides the process-wide one.
+	#[tokio::test]
+	async fn a_stage_broadcast_picks_the_catalog_to_read() {
+		use hang::catalog::{AudioCodec, AudioConfig, H264, VideoConfig};
+
+		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let route = moq_net::broadcast::Route::new().with_announce(true);
+
+		// Two broadcasts with different renditions, so a completer reading the wrong
+		// one fails loudly instead of matching by luck.
+		let mut keep = Vec::new();
+		for (path, video, audio) in [("wanted", "hd", "stereo"), ("other", "sd", "mono")] {
+			let mut broadcast = origin.create_broadcast(path, route.clone()).expect("broadcast");
+			let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).expect("catalog");
+			let mut edit = catalog.lock();
+			edit.video.renditions.insert(
+				video.to_string(),
+				VideoConfig::new(H264 {
+					profile: 0x42,
+					constraints: 0,
+					level: 0x1e,
+					inline: false,
+				}),
+			);
+			edit.audio
+				.renditions
+				.insert(audio.to_string(), AudioConfig::new(AudioCodec::Opus, 48_000, 2));
+			edit.commit().expect("publish the catalog");
+			keep.push((broadcast, catalog));
+		}
+
+		// The global names `other`; the stage overrides it, exactly as the invocation
+		// this line is on its way to becoming would.
+		let connect = relay(&origin);
+		let line = format!("moq {connect} --broadcast other export --broadcast wanted");
+
+		assert_eq!(complete(&format!("{line} --video-name ")).await, ["hd"]);
+		assert_eq!(complete(&format!("{line} --audio-name ")).await, ["stereo"]);
+	}
+}

--- a/rs/moq-cli/src/complete.rs
+++ b/rs/moq-cli/src/complete.rs
@@ -15,6 +15,9 @@
 use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::ffi::{OsStr, OsString};
+// Only the capture completers name a future by type; the rest are `async` blocks.
+#[cfg(feature = "capture")]
+use std::future::Future;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -34,6 +37,15 @@ use crate::subscribe::CatalogFormatArg;
 /// completer that outlives the user's patience is a shell that appears to hang,
 /// and half a list now beats the whole list later.
 const BUDGET: Duration = Duration::from_millis(500);
+
+/// The ceiling on a whole completion request, whatever it is answering.
+///
+/// A backstop, not the working budget: every completer bounds its own lookup by
+/// [`BUDGET`], and this is deliberately looser so that theirs always fires first and
+/// their partial answer survives. It exists so a completer added later cannot hang a
+/// prompt by forgetting to bound itself, and so work that ignores cancellation
+/// (a blocking device enumeration) still cannot hold the answer back.
+const CEILING: Duration = Duration::from_millis(1_500);
 
 /// How long the announce sweep waits for a sibling after an announcement lands.
 ///
@@ -136,12 +148,29 @@ pub async fn answer(argv: &[OsString]) -> Option<String> {
 		.rposition(|word| word == "--")
 		.map(|at| at + 1);
 
-	let answer = match staged {
+	// Whatever happens below, the shell gets an answer. `render` of an empty result
+	// is a well-formed "no candidates", which is the right thing to say when a
+	// lookup has outlived the keystroke that asked for it.
+	let answer = timeout_at(Instant::now() + CEILING, complete(&request, staged, &overlays))
+		.await
+		.unwrap_or_default();
+
+	Some(render(&answer, request.shell))
+}
+
+/// Answer one request against the grammar its cursor is in.
+async fn complete<'a>(
+	request: &CompletionRequest,
+	staged: Option<usize>,
+	overlays: &'a [CompletionOverlay<'a>],
+) -> usage::complete::Completions<'a> {
+	let words = request.split.walked();
+	match staged {
 		None => {
 			Cli::app()
 				.completion_app()
-				.completions(&overlays)
-				.complete_request(&request)
+				.completions(overlays)
+				.complete_request(request)
 				.await
 		}
 		Some(start) => {
@@ -154,27 +183,48 @@ pub async fn answer(argv: &[OsString]) -> Option<String> {
 			request.split.words = chunk;
 			Stage::app()
 				.completion_app()
-				.completions(&overlays)
+				.completions(overlays)
 				.complete_request(&request)
 				.await
 		}
-	};
-
-	Some(render(&answer, request.shell))
+	}
 }
 
 /// The process-wide MoQ flags, as far as the words before the cursor go.
 ///
 /// Read from the first chunk, which is the only one that can carry them, and
-/// through the real tables rather than by scanning for `--connect`: what a
-/// completer dials has to be what an invocation would have dialed, TLS roots and
-/// environment variables included.
+/// through the real tables rather than by scanning for `--connect`: what a completer
+/// dials has to be what an invocation would have dialed, TLS roots included.
+///
+/// Built twice, because the environment is allowed to configure the dial but not to
+/// authorize it. `--connect` has an env var (`MOQ_CONNECT`), so a single pass would
+/// let an exported one turn a keystroke into a session with a relay the user never
+/// typed, and that URL can carry a `?jwt=` credential. The first pass never reads the
+/// environment and its `--connect` is the gate; the second is the one that dials, so
+/// everything else an invocation would have picked up still applies.
 fn globals(request: &CompletionRequest) -> Option<MoqSide> {
 	let chunk = request.split.argv().split(|word| word == "--").next()?;
 	let argv: Vec<&OsStr> = chunk.iter().map(OsStr::new).collect();
 
+	let typed = side(&argv, Environment::Ignore)?;
+	let mut side = side(&argv, Environment::Read)?;
+	if typed.client.url.is_none() {
+		side.client.url = None;
+	}
+	Some(side)
+}
+
+/// Whether [`side`] lets the environment fill what the words left out.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum Environment {
+	Read,
+	Ignore,
+}
+
+/// Build [`MoqSide`] from one chunk of a line being completed.
+fn side(argv: &[&OsStr], environment: Environment) -> Option<MoqSide> {
 	let mut partial = <MoqSide as CommandArgs>::start();
-	let mut parser = usage::Parser::new(Cli::command(), &argv);
+	let mut parser = usage::Parser::new(Cli::command(), argv);
 	while let Some(event) = parser.next_event() {
 		match event {
 			Ok(event) => {
@@ -186,28 +236,31 @@ fn globals(request: &CompletionRequest) -> Option<MoqSide> {
 		}
 	}
 
-	<MoqSide as CommandArgs>::apply_env(&mut partial);
+	if environment == Environment::Read {
+		<MoqSide as CommandArgs>::apply_env(&mut partial);
+	}
 	<MoqSide as CommandArgs>::apply_defaults(&mut partial);
 	<MoqSide as CommandArgs>::build(partial).ok()
 }
 
-/// The `export` stage the cursor is in, as far as the line goes.
+/// `T`'s own flags, as far as the words the cursor's command was given go.
 ///
-/// A stage's own `--broadcast` overrides the process-wide one, and `--video-name`
-/// is only ever declared beside it, so a rendition completer has to read the stage
-/// it was typed in rather than the globals alone.
-fn export(ctx: &CompleteCtx<'_>) -> Option<<Export as CommandArgs>::Partial> {
-	let declaration = <Export as CommandArgs>::COMMAND;
-	let (command, words) = ctx.command_for(declaration)?;
+/// `None` when the cursor is not inside `T`. A stage's own `--broadcast` and
+/// `--catalog-format` override the process-wide ones, so a rendition completer has
+/// to read the command it was typed in rather than the globals alone.
+fn partial<T: CommandArgs>(ctx: &CompleteCtx<'_>) -> Option<T::Partial> {
+	let (command, words) = ctx.command_for(T::COMMAND)?;
 	let argv: Vec<&OsStr> = words.iter().map(OsStr::new).collect();
 
-	let mut partial = <Export as CommandArgs>::start();
+	let mut partial = T::start();
 	let mut parser = usage::Parser::new(command, &argv);
 	while let Some(event) = parser.next_event() {
 		match event {
 			Ok(event) => {
-				<Export as CommandArgs>::apply(&mut partial, &event);
+				T::apply(&mut partial, &event);
 			}
+			// A line being completed is unfinished by definition, so an error means the
+			// grammar ran out here; the partial holds what was understood before that.
 			Err(_) => break,
 		}
 	}
@@ -217,6 +270,30 @@ fn export(ctx: &CompleteCtx<'_>) -> Option<<Export as CommandArgs>::Partial> {
 /// One raw partial value as text, or `None` when it was never given.
 fn given(value: &Option<Vec<u8>>) -> Option<&str> {
 	std::str::from_utf8(value.as_deref()?).ok()
+}
+
+/// One raw partial value read back through its `ValueEnum`.
+fn choice<T: ValueEnum>(value: &Option<Vec<u8>>) -> Option<T> {
+	T::from_choice(given(value)?)
+}
+
+/// The catalog format the command under the cursor named, if it named one.
+///
+/// `export` and `play` each declare their own `--catalog-format`, and the cursor is
+/// inside exactly one of them. Reading only `export`'s would leave a
+/// `play --catalog-format msf` completer subscribing to the Hang track that
+/// invocation is never going to read.
+fn catalog_format(ctx: &CompleteCtx<'_>, export: Option<&<Export as CommandArgs>::Partial>) -> Option<CatalogFormat> {
+	let named = export.and_then(|export| choice::<CatalogFormatArg>(&export.catalog_format));
+
+	#[cfg(feature = "play")]
+	let named = named.or_else(|| {
+		partial::<crate::play::Args>(ctx).and_then(|play| choice::<CatalogFormatArg>(&play.catalog_format))
+	});
+	#[cfg(not(feature = "play"))]
+	let _ = ctx;
+
+	named.map(Into::into)
 }
 
 // ------------------------------------------------------------------ script
@@ -313,13 +390,25 @@ impl Args {
 
 // ------------------------------------------------------------------ capture
 
-/// Turn a capture enumeration into candidates, or nothing when the platform
-/// cannot list that kind of source.
+/// Enumerate one kind of capture source, under [`BUDGET`], into candidates.
+///
+/// Bounded because enumeration is not the quick local lookup it reads as: several
+/// backends (V4L2, Media Foundation, CPAL) do blocking work on a pool thread, and
+/// ScreenCaptureKit already waits seconds for its own permission callback. Dropping
+/// the future cannot cancel a blocking call, but it does let the process answer and
+/// exit, which is what keeps a stuck driver from freezing the prompt.
+///
+/// A platform that cannot list this kind of source, and a lookup that runs out of
+/// time, are the same answer: no candidates.
 #[cfg(feature = "capture")]
-fn sources<T, E>(found: Result<Vec<T>, E>, describe: impl Fn(&T) -> Candidate<'static>) -> Vec<Candidate<'static>> {
-	found
-		.map(|items| items.iter().map(describe).collect())
-		.unwrap_or_default()
+async fn sources<T, E>(
+	found: impl Future<Output = Result<Vec<T>, E>>,
+	describe: impl Fn(&T) -> Candidate<'static>,
+) -> Vec<Candidate<'static>> {
+	match timeout_at(Instant::now() + BUDGET, found).await {
+		Ok(Ok(items)) => items.iter().map(describe).collect(),
+		Ok(Err(_)) | Err(_) => Vec::new(),
+	}
 }
 
 /// Complete `--camera` from the cameras this machine has.
@@ -330,9 +419,10 @@ fn sources<T, E>(found: Result<Vec<T>, E>, describe: impl Fn(&T) -> Candidate<'s
 #[cfg(feature = "capture")]
 fn cameras(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 	Box::pin(async move {
-		sources(moq_video::capture::cameras().await, |camera| {
+		sources(moq_video::capture::cameras(), |camera| {
 			Candidate::described(camera.id.clone(), camera.name.clone())
 		})
+		.await
 	})
 }
 
@@ -340,12 +430,13 @@ fn cameras(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 #[cfg(feature = "capture")]
 fn displays(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 	Box::pin(async move {
-		sources(moq_video::capture::displays().await, |display| {
+		sources(moq_video::capture::displays(), |display| {
 			Candidate::described(
 				display.id.clone(),
 				format!("{} ({}x{})", display.name, display.width, display.height),
 			)
 		})
+		.await
 	})
 }
 
@@ -353,7 +444,7 @@ fn displays(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 #[cfg(feature = "capture")]
 fn windows(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 	Box::pin(async move {
-		sources(moq_video::capture::windows().await, |window| {
+		sources(moq_video::capture::windows(), |window| {
 			let title = if window.title.is_empty() {
 				"(untitled)"
 			} else {
@@ -361,6 +452,7 @@ fn windows(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 			};
 			Candidate::described(window.id.clone(), format!("{} - {title}", window.app))
 		})
+		.await
 	})
 }
 
@@ -368,9 +460,10 @@ fn windows(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 #[cfg(feature = "capture")]
 fn apps(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 	Box::pin(async move {
-		sources(moq_video::capture::apps().await, |app| {
+		sources(moq_video::capture::apps(), |app| {
 			Candidate::described(app.id.clone(), app.name.clone())
 		})
+		.await
 	})
 }
 
@@ -378,10 +471,11 @@ fn apps(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 #[cfg(feature = "capture")]
 fn microphones(_ctx: CompleteCtx<'_>) -> CompletionFuture<'static> {
 	Box::pin(async move {
-		sources(moq_audio::capture::devices().await, |device| match device.default {
+		sources(moq_audio::capture::devices(), |device| match device.default {
 			true => Candidate::described(device.id.clone(), "the default input"),
 			false => Candidate::new(device.id.clone()),
 		})
+		.await
 	})
 }
 
@@ -474,21 +568,19 @@ fn audio_names(ctx: CompleteCtx<'_>) -> CompletionFuture<'_> {
 /// Dial the relay and read one catalog snapshot for the broadcast on the line.
 async fn renditions(ctx: &CompleteCtx<'_>) -> Option<moq_mux::catalog::hang::Catalog> {
 	let side = Globals::get()?;
-	let stage = export(ctx);
-	let stage = stage.as_ref();
+	let export = partial::<Export>(ctx);
+	let export = export.as_ref();
 
 	// A stage's own `--broadcast` wins over the process-wide one, exactly as it does
-	// for the invocation this line is on its way to becoming.
-	let path = stage
-		.and_then(|stage| given(&stage.broadcast))
+	// for the invocation this line is on its way to becoming. `play` declares no
+	// `--broadcast`, so there it is the global or nothing.
+	let path = export
+		.and_then(|export| given(&export.broadcast))
 		.or(side.broadcast.as_deref())
 		.unwrap_or_default()
 		.to_string();
 
-	let format = stage
-		.and_then(|stage| given(&stage.catalog_format))
-		.and_then(CatalogFormatArg::from_choice)
-		.map(CatalogFormat::from)
+	let format = catalog_format(ctx, export)
 		.or_else(|| CatalogFormat::detect(&path))
 		.unwrap_or_default();
 
@@ -638,6 +730,80 @@ mod tests {
 		}
 	}
 
+	/// One lock for every test that touches the process environment.
+	///
+	/// `set_var` is not thread-safe against a concurrent read, and Usage reads the
+	/// `MOQ_*` vars while it parses. Clearing on entry also stops a developer's own
+	/// exported `MOQ_CONNECT` from making a no-dial assertion pass for the wrong
+	/// reason, or fail for one.
+	static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+	/// Holds [`ENV_LOCK`] and restores `MOQ_CONNECT` on the way out.
+	struct EnvGuard {
+		_lock: std::sync::MutexGuard<'static, ()>,
+		saved: Option<OsString>,
+	}
+
+	impl EnvGuard {
+		fn set(value: Option<&str>) -> Self {
+			let lock = ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+			let saved = std::env::var_os("MOQ_CONNECT");
+			// SAFETY: ENV_LOCK is held, and every test here that reads or writes the
+			// environment takes it first.
+			unsafe {
+				match value {
+					Some(value) => std::env::set_var("MOQ_CONNECT", value),
+					None => std::env::remove_var("MOQ_CONNECT"),
+				}
+			}
+			Self { _lock: lock, saved }
+		}
+	}
+
+	impl Drop for EnvGuard {
+		fn drop(&mut self) {
+			// Runs before `_lock`, so the restore is still serialized.
+			// SAFETY: see `set`.
+			unsafe {
+				match &self.saved {
+					Some(value) => std::env::set_var("MOQ_CONNECT", value),
+					None => std::env::remove_var("MOQ_CONNECT"),
+				}
+			}
+		}
+	}
+
+	/// The environment may configure a dial, but it may not authorize one.
+	///
+	/// `--connect` reads `MOQ_CONNECT`, so building the globals in one pass let an
+	/// exported variable turn a keystroke into a session with a relay the user never
+	/// typed -- and that URL can carry a `?jwt=` credential. The gate is what the line
+	/// says, not what the environment says.
+	#[tokio::test]
+	async fn the_environment_cannot_authorize_a_dial() {
+		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let route = moq_net::broadcast::Route::new().with_announce(true);
+		let _alpha = origin.create_broadcast("alpha", route).expect("alpha");
+		let connect = relay(&origin);
+
+		// The same reachable relay, named only by the environment.
+		let url = connect.split_whitespace().nth(1).expect("a --connect url").to_string();
+		let _env = EnvGuard::set(Some(&url));
+
+		assert!(
+			complete("moq --connect-tls-insecure --broadcast ").await.is_empty(),
+			"MOQ_CONNECT authorized a dial the line never asked for"
+		);
+
+		// The same relay named on the line still completes, so the gate is the URL's
+		// source and not the dial itself.
+		assert_eq!(
+			complete(&format!("moq {connect} --broadcast ")).await,
+			["alpha"],
+			"a typed --connect stopped working"
+		);
+	}
+
 	/// A completer that needs the network answers nothing when the line names no relay.
 	///
 	/// The gate is the whole reason tab-completion may dial at all: without a
@@ -647,6 +813,7 @@ mod tests {
 	/// that the completer fired at all.
 	#[tokio::test]
 	async fn no_relay_on_the_line_means_no_dial() {
+		let _env = EnvGuard::set(None);
 		for line in [
 			"moq --broadcast ",
 			"moq export --broadcast ",
@@ -745,5 +912,53 @@ mod tests {
 
 		assert_eq!(complete(&format!("{line} --video-name ")).await, ["hd"]);
 		assert_eq!(complete(&format!("{line} --audio-name ")).await, ["stereo"]);
+	}
+
+	/// The `--catalog-format` on the line decides which catalog track is read.
+	///
+	/// `export` and `play` each declare their own, and reading only `export`'s left a
+	/// `play --catalog-format msf` completer subscribing to a Hang track that
+	/// invocation is never going to read. The broadcast here publishes MSF and nothing
+	/// else, which is the one shape that tells the two apart: `moq-mux`'s catalog
+	/// producer emits hang and MSF from the same source, so an ordinary broadcast
+	/// answers either way and hides the bug.
+	#[tokio::test]
+	async fn the_catalog_format_on_the_line_is_honored() {
+		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let route = moq_net::broadcast::Route::new().with_announce(true);
+		let mut broadcast = origin.create_broadcast("room", route).expect("broadcast");
+
+		let mut track = broadcast
+			.create_track(moq_msf::DEFAULT_NAME, moq_net::track::Info::default())
+			.expect("msf track");
+		let mut msf = moq_msf::Track::new("hd", moq_msf::Packaging::Loc);
+		msf.role = Some(moq_msf::Role::Video);
+		// A video track without one is a hard error in the MSF reader, not a skip.
+		msf.codec = Some("avc1.42001e".to_string());
+		let catalog = moq_msf::Catalog::new(vec![msf]).to_json().expect("msf json");
+		let mut group = track.append_group().expect("group");
+		group.write_frame(moq_net::Timestamp::now(), catalog).expect("frame");
+
+		let connect = relay(&origin);
+		let line = format!("moq {connect} --broadcast room");
+
+		// Nothing publishes a Hang catalog here, so the default finds no renditions.
+		assert!(complete(&format!("{line} export --video-name ")).await.is_empty());
+		assert_eq!(
+			complete(&format!("{line} export --catalog-format msf --video-name ")).await,
+			["hd"],
+			"export ignored its own --catalog-format"
+		);
+
+		// `play` declares a `--catalog-format` of its own, on a different command.
+		#[cfg(feature = "play")]
+		{
+			assert!(complete(&format!("{line} play --video-name ")).await.is_empty());
+			assert_eq!(
+				complete(&format!("{line} play --catalog-format msf --video-name ")).await,
+				["hd"],
+				"play ignored its own --catalog-format"
+			);
+		}
 	}
 }

--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -15,6 +15,7 @@ use crate::moq::notify_ready;
 #[usage(unknown_flags = "error", args_override_self = false)]
 pub struct ImportArgs {
 	/// Playlist URL (http/https) or local file path.
+	#[usage(value_hint = usage::ValueHint::AnyPath, extensions("m3u8", "m3u"))]
 	pub playlist: String,
 }
 

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -183,27 +183,29 @@ async fn main() -> anyhow::Result<()> {
 		.install_default()
 		.expect("failed to install default crypto provider");
 
-	let cli = Invocation::parse().await;
+	let mut cli = Invocation::parse().await;
 	cli.log.init()?;
 	cli.validate()?;
 
 	// The local verbs never touch the network, so answer them before binding any
 	// transport. `validate` has already refused to pair them with another stage, so
 	// the single stage here is the whole invocation.
-	let mut stages = cli.stages;
+	// Taken rather than moved out: the local verbs below still ask `cli` whether the
+	// command line named a MoQ side.
+	let mut stages = std::mem::take(&mut cli.stages);
 	if stages.len() == 1 {
 		match stages.remove(0) {
 			Command::Token(token) => {
-				cli.typed.reject("token")?;
+				cli.reject("token")?;
 				return token.run();
 			}
 			Command::Completion(completion) => {
-				cli.typed.reject("completion")?;
+				cli.reject("completion")?;
 				return completion.run();
 			}
 			#[cfg(feature = "capture")]
 			Command::Devices => {
-				cli.typed.reject("devices")?;
+				cli.reject("devices")?;
 				return devices::run().await;
 			}
 			// Put it back: it needs the transport bound below.

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -19,6 +19,8 @@ mod rtc;
 mod rtmp;
 mod srt;
 mod subscribe;
+#[cfg(test)]
+mod test_env;
 #[cfg(feature = "transcode")]
 mod transcode;
 mod web;
@@ -192,16 +194,16 @@ async fn main() -> anyhow::Result<()> {
 	if stages.len() == 1 {
 		match stages.remove(0) {
 			Command::Token(token) => {
-				cli.moq.reject("token")?;
+				cli.typed.reject("token")?;
 				return token.run();
 			}
 			Command::Completion(completion) => {
-				cli.moq.reject("completion")?;
+				cli.typed.reject("completion")?;
 				return completion.run();
 			}
 			#[cfg(feature = "capture")]
 			Command::Devices => {
-				cli.moq.reject("devices")?;
+				cli.typed.reject("devices")?;
 				return devices::run().await;
 			}
 			// Put it back: it needs the transport bound below.

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -7,6 +7,7 @@
 mod args;
 #[cfg(feature = "cluster-lan")]
 mod cluster;
+mod complete;
 #[cfg(feature = "capture")]
 mod devices;
 mod hls;
@@ -180,7 +181,7 @@ async fn main() -> anyhow::Result<()> {
 		.install_default()
 		.expect("failed to install default crypto provider");
 
-	let cli = Invocation::parse();
+	let cli = Invocation::parse().await;
 	cli.log.init()?;
 	cli.validate()?;
 
@@ -193,6 +194,10 @@ async fn main() -> anyhow::Result<()> {
 			Command::Token(token) => {
 				cli.moq.reject("token")?;
 				return token.run();
+			}
+			Command::Completion(completion) => {
+				cli.moq.reject("completion")?;
+				return completion.run();
 			}
 			#[cfg(feature = "capture")]
 			Command::Devices => {

--- a/rs/moq-cli/src/test_env.rs
+++ b/rs/moq-cli/src/test_env.rs
@@ -1,0 +1,70 @@
+//! Serializes the tests that touch the process environment.
+
+use std::ffi::OsString;
+use std::sync::{Mutex, MutexGuard};
+
+/// One lock for every test that reads or writes the process environment.
+///
+/// `set_var`'s safety contract is that no other thread reads the environment while it
+/// runs, and this crate reads it all over: Usage consults the `MOQ_*` variables on
+/// every parse, which both the argument tests and the completion tests trigger. So the
+/// lock is not only for the tests that write. A single lock rather than one per
+/// variable, because the hazard is a reader racing a writer, not two writers.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Holds [`ENV_LOCK`] for as long as a test needs the environment to itself, restoring
+/// whatever it changed on drop.
+///
+/// Tests clear the `MOQ_*` variables so a value in the developer's own shell cannot
+/// decide whether an assertion passes.
+pub(crate) struct EnvGuard {
+	_lock: MutexGuard<'static, ()>,
+	saved: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+	/// Take the lock and clear `vars`, for a test that only reads them.
+	pub(crate) fn clear(vars: &[&'static str]) -> Self {
+		Self::apply(vars.iter().map(|&name| (name, None)))
+	}
+
+	/// Take the lock and set each variable, remembering what it held.
+	pub(crate) fn set(vars: &[(&'static str, &str)]) -> Self {
+		Self::apply(vars.iter().map(|&(name, value)| (name, Some(value))))
+	}
+
+	fn apply<'a>(vars: impl Iterator<Item = (&'static str, Option<&'a str>)>) -> Self {
+		let lock = ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+		let saved = vars
+			.map(|(name, value)| {
+				let previous = std::env::var_os(name);
+				// SAFETY: ENV_LOCK is held, and every test that reads or writes the
+				// environment takes it first.
+				unsafe {
+					match value {
+						Some(value) => std::env::set_var(name, value),
+						None => std::env::remove_var(name),
+					}
+				}
+				(name, previous)
+			})
+			.collect();
+
+		Self { _lock: lock, saved }
+	}
+}
+
+impl Drop for EnvGuard {
+	fn drop(&mut self) {
+		// Runs before `_lock`, so the restore is still serialized.
+		for (name, previous) in &self.saved {
+			// SAFETY: see `apply`.
+			unsafe {
+				match previous {
+					Some(value) => std::env::set_var(name, value),
+					None => std::env::remove_var(name),
+				}
+			}
+		}
+	}
+}

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -87,6 +87,7 @@ pub struct Config {
 
 	/// If provided, load the configuration from this file.
 	#[serde(default)]
+	#[usage(value_hint = usage::ValueHint::FilePath, extensions("toml"))]
 	pub file: Option<String>,
 
 	/// Iroh specific configuration, used for both a client and server.

--- a/rs/moq-token-cli/src/lib.rs
+++ b/rs/moq-token-cli/src/lib.rs
@@ -144,19 +144,19 @@ enum Command {
 		id: Option<String>,
 
 		/// Write the key to a file path. Use `-` for stdout.
-		#[usage(long)]
+		#[usage(long, value_hint = usage::ValueHint::FilePath, extensions("jwk", "json"))]
 		out: Option<PathBuf>,
 
 		/// Write the key to a directory as {kid}.jwk.
-		#[usage(long, conflicts = "--out")]
+		#[usage(long, conflicts = "--out", value_hint = usage::ValueHint::DirPath)]
 		out_dir: Option<PathBuf>,
 
 		/// Write the public key to a file path (asymmetric algorithms only). Use `-` for stdout.
-		#[usage(long)]
+		#[usage(long, value_hint = usage::ValueHint::FilePath, extensions("jwk", "json"))]
 		public: Option<PathBuf>,
 
 		/// Write the public key to a directory as {kid}.jwk (asymmetric algorithms only).
-		#[usage(long, conflicts = "--public")]
+		#[usage(long, conflicts = "--public", value_hint = usage::ValueHint::DirPath)]
 		public_dir: Option<PathBuf>,
 
 		/// Root path for the optional key scope. Only applied alongside --publish or --subscribe.
@@ -175,7 +175,7 @@ enum Command {
 	/// Sign a token, writing it to stdout.
 	Sign {
 		/// Path to the signing key file. Use `-` for stdin.
-		#[usage(long)]
+		#[usage(long, value_hint = usage::ValueHint::FilePath, extensions("jwk", "json"))]
 		key: PathBuf,
 
 		/// The root path for the token.
@@ -202,11 +202,11 @@ enum Command {
 	/// Verify a token, writing the payload to stdout.
 	Verify {
 		/// Path to the key file. Use `-` for stdin (requires `--in` to be a file).
-		#[usage(long)]
+		#[usage(long, value_hint = usage::ValueHint::FilePath, extensions("jwk", "json"))]
 		key: PathBuf,
 
 		/// Path to read the token from. Use `-` for stdin.
-		#[usage(long = "in", default = "-")]
+		#[usage(long = "in", default = "-", value_hint = usage::ValueHint::FilePath)]
 		token: PathBuf,
 	},
 }

--- a/rs/moq-tokio/src/quic.rs
+++ b/rs/moq-tokio/src/quic.rs
@@ -160,6 +160,7 @@ pub struct Config {
 	/// Requires the `qlog` feature; setting it errors at init otherwise.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[usage(name = "quic-qlog", long = "quic-qlog", env = "MOQ_QUIC_QLOG")]
+	#[usage(value_hint = usage::ValueHint::DirPath)]
 	pub qlog: Option<PathBuf>,
 
 	/// The old role-prefixed spellings, kept parsing but hidden. Never read as

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -362,6 +362,7 @@ pub struct Connect {
 	/// if a rotation is temporarily missing or malformed.
 	#[serde(skip_serializing_if = "Vec::is_empty")]
 	#[usage(name = "connect-tls-root", long = "connect-tls-root", env = "MOQ_CONNECT_TLS_ROOT")]
+	#[usage(value_hint = usage::ValueHint::FilePath, extensions("pem", "crt", "cer"))]
 	#[serde_as(as = "serde_with::OneOrMany<_>")]
 	pub root: Vec<PathBuf>,
 
@@ -418,6 +419,7 @@ pub struct Connect {
 	/// Must be paired with `--connect-tls-key`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[usage(name = "connect-tls-cert", long = "connect-tls-cert", env = "MOQ_CONNECT_TLS_CERT")]
+	#[usage(value_hint = usage::ValueHint::FilePath, extensions("pem", "crt", "cer"))]
 	pub cert: Option<PathBuf>,
 
 	/// PEM file containing the private key for mTLS.
@@ -426,6 +428,7 @@ pub struct Connect {
 	/// Must be paired with `--connect-tls-cert`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[usage(name = "connect-tls-key", long = "connect-tls-key", env = "MOQ_CONNECT_TLS_KEY")]
+	#[usage(value_hint = usage::ValueHint::FilePath, extensions("pem", "key"))]
 	pub key: Option<PathBuf>,
 
 	/// Danger: Disable TLS certificate verification.
@@ -1131,12 +1134,14 @@ pub fn init_android(env: &mut jni::Env, context: jni::objects::JObject) -> Resul
 pub struct Listen {
 	/// Load the given certificate from disk.
 	#[usage(long = "listen-tls-cert", name = "listen-tls-cert", env = "MOQ_LISTEN_TLS_CERT")]
+	#[usage(value_hint = usage::ValueHint::FilePath, extensions("pem", "crt", "cer"))]
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	#[serde_as(as = "serde_with::OneOrMany<_>")]
 	pub cert: Vec<PathBuf>,
 
 	/// Load the given key from disk.
 	#[usage(long = "listen-tls-key", name = "listen-tls-key", env = "MOQ_LISTEN_TLS_KEY")]
+	#[usage(value_hint = usage::ValueHint::FilePath, extensions("pem", "key"))]
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	#[serde_as(as = "serde_with::OneOrMany<_>")]
 	pub key: Vec<PathBuf>,
@@ -1195,6 +1200,7 @@ pub struct Listen {
 		delimiter = ',',
 		env = "MOQ_LISTEN_TLS_ROOT"
 	)]
+	#[usage(value_hint = usage::ValueHint::FilePath, extensions("pem", "crt", "cer"))]
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	#[serde_as(as = "serde_with::OneOrMany<_>")]
 	pub root: Vec<PathBuf>,

--- a/rs/moq-tokio/src/unix.rs
+++ b/rs/moq-tokio/src/unix.rs
@@ -28,6 +28,7 @@ const WIRE_VERSION: qmux::Version = qmux::Version::QMux01;
 pub struct Config {
 	/// Bind a plaintext qmux Unix-socket listener at this path.
 	#[usage(long = "listen-unix-bind", name = "listen-unix-bind", env = "MOQ_LISTEN_UNIX_BIND")]
+	#[usage(value_hint = usage::ValueHint::AnyPath)]
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub bind: Option<PathBuf>,
 


### PR DESCRIPTION
## Summary

- Grow each io_uring socket's UDP send and receive pools on demand instead of fixing them at 64 and 16 buffers.
- Turn `udp::Config`'s `rx_buffers`/`tx_buffers` into the ceilings `rx_buffers_max`/`tx_buffers_max`; the pools start where they used to and each doubles when it starves.
- No new operator knob, in the relay or anywhere else.

## Root cause

A worker's whole send concurrency was 64 buffers and its receive queue 16, however many connections it served. At 400 connections per worker they serialized behind those pools, which showed up as queueing delay: p50 4.6x the tokio path's, and delivery short of the offered groups (#3119).

Neither pool is a byte budget. One send buffer stages one GSO train and one receive buffer absorbs one completion, however little either carries, so both are counts of concurrent operations rather than bytes. GSO and GRO batching also collapse as connections multiply: 400 interleaved flows put one segment in a train that a handful of flows would fill 48 of. So the depth a socket needs tracks its connection concurrency, not its bitrate, and the caller binding the socket knows neither at bind time.

That is why this doesn't expose the sizing as configuration. The socket is the only thing that can observe the number, so it measures it: `poll_acquire` grows the send pool rather than parking the caller, and the receive pool grows when the provided ring runs dry rather than waiting on a live packet to be released. Each doubles, bounded by the ceiling, and neither shrinks, so a socket settles at its high-water concurrency and the memory returns when it drops.

The provided buffer ring is registered at the ceiling because the kernel fixes its entry count at registration, but the buffers behind it are allocated on demand, so an idle socket costs what it did before this change.

## Branch targeting

`dev`, not `main`, and not because of the semver rule: nothing here breaks a
published API. The Usage migration (#3030) it builds on is only on `dev`, so this
does not compile against `main`, where `moq-cli` still parses with clap.

## Also in here, from review

`MoqSide::reject` read the resolved MoQ side, and every flag it checks has a `MOQ_*`
variable, so a shell exporting `MOQ_CONNECT` could not run `moq token` or `moq
devices` at all -- each failed telling the user to drop a flag they never typed. The
new `moq completion` inherited it, which is worse, since that is the command you run
to set completions up. `Invocation` now carries the env-free build of the same chunk
and `reject` reads that, so the check asks what was *asked for* rather than what was
configured. It sits behind `Invocation::reject`, so the resolved side cannot be asked
at all: a call site that picked the wrong view read correctly and was wrong. `--origin` rejoins the list: it was excluded only because `MOQ_ORIGIN`
reached it, which no longer happens.

This changes `moq token` and `moq devices`, which the title does not claim. It is the
same bug the new verb has, in shared code, and fixing it only for `completion` would
have meant silently ignoring a flag the repo deliberately refuses elsewhere.

## Public API changes

- `udp::Config::rx_buffers` -> `rx_buffers_max`, `tx_buffers` -> `tx_buffers_max`, both now ceilings rather than allocation counts. Defaults 256 and 1024 (16 MiB and 64 MiB of headroom at the default buffer lengths), reached only by a socket that starves for them.

## Wire behavior changes

- None.

## Test plan

Run in a privileged Linux container (kernel 6.19, aarch64) so `io_uring_setup` is actually available; without `--privileged` the worker-backed tests skip themselves and report green without executing:

- `cargo fmt -p moq-uring -- --check`
- `cargo clippy -p moq-uring -p moq-relay --features moq-relay/io-uring --all-targets -- -D warnings`
- `cargo test -p moq-uring --lib --tests`: 50 passed, 0 failed, all executing rather than skipping.
- New: `udp::tests::the_receive_pool_doubles_to_its_ceiling` (the pool doubles into its ceiling and publishes each new buffer to the ring exactly once) and `worker::tests::the_send_pool_grows_to_its_ceiling` (a starved pool grows past its floor to the ceiling, and a `u16::MAX` ceiling is not allocated up front). Both were mutation-checked: breaking the expected count fails the test, so they are not silently skipping.

Not done here: the 1601-connection fan-out benchmark from #3119 is not re-run, so the latency numbers in that issue are not reconfirmed against this patch. That needs the bare-metal rig, not this container.

## Notes

Two things asked for during review are deliberately not in this PR:

- Folding `runtime.io_uring` into `listen.backend = quiche-uring` (and `quinn-uring` after #3131). That touches `moq_tokio::QuicBackend`, the relay bind path, docs and demo configs, and is worth its own review.
- Shrinking the pools back down. There is no clock on the socket to drive a decay policy, and the ceiling already bounds the memory.

Fixes #3119

(Written by Claude Opus 5)

(Written by Claude Opus 5)
