### PR TITLE
fix(rs): gate doc output-name collisions instead of hitting them in CI

### DIFF
--- a/rs/justfile
+++ b/rs/justfile
@@ -30,6 +30,7 @@ default:
 check *args:
     just rs _select-test
     just rs _publish-test
+    just rs _doc-names-test
     cargo clippy --locked --all-targets {{ args }} -- -D warnings
     cargo fmt --all --check
     just rs _doc-names
@@ -43,27 +44,19 @@ check *args:
 # which rustdoc process gets there first. That reads as a flake, and because the doc
 # pass above is diff-scoped it surfaces on whichever unrelated PR happens to select
 # both crates. Resolve a pair by setting `doc = false` on whichever target has no
-# published API to render (usually the binary), which is what `.doc` reads here.
+# published API to render (usually the binary).
 #
-# Metadata only, so this costs no compilation and can sit in the PR gate.
-_doc-names:
+# Metadata only, so this costs no compilation and can sit in the PR gate. Takes an
+# optional metadata file so `_doc-names-test` can feed it synthetic workspaces.
+_doc-names metadata="":
     #!/usr/bin/env bash
     set -euo pipefail
 
-    collisions=$(cargo metadata --locked --no-deps --format-version 1 | jq -r '
-        [ .packages[]
-          | .name as $package
-          | .targets[]
-          | select(.doc)
-          | select([.kind[]] | any(. == "lib" or . == "rlib" or . == "dylib"
-              or . == "cdylib" or . == "staticlib" or . == "proc-macro" or . == "bin"))
-          | { dir: (.name | gsub("-"; "_")), package: $package, target: .name, kind: .kind[0] }
-        ]
-        | group_by(.dir)
-        | map(select(length > 1))
-        | .[]
-        | "  target/doc/\(.[0].dir) <- " + (map("\(.package) [\(.kind)] \(.target)") | join(" and "))
-    ')
+    if [[ -n "{{ metadata }}" ]]; then
+        collisions=$(jq -r -f rs/scripts/doc-names.jq < "{{ metadata }}")
+    else
+        collisions=$(cargo metadata --locked --no-deps --format-version 1 | jq -r -f rs/scripts/doc-names.jq)
+    fi
 
     if [[ -n "$collisions" ]]; then
         echo "rs: these targets render to the same doc directory:" >&2
@@ -71,6 +64,45 @@ _doc-names:
         echo "set doc = false on whichever has no published API." >&2
         exit 1
     fi
+
+# Both directions of `_doc-names`, since the interesting half is what it must NOT
+# report: cargo documents only the library when a binary shares its own package's
+# name, so flagging that would reject the conventional src/lib.rs + src/main.rs layout.
+_doc-names-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    scratch=$(mktemp -d)
+    trap 'rm -rf "$scratch"' EXIT
+
+    # Same package, same name: cargo suppresses the bin, so this must pass.
+    cat > "$scratch/ok.json" <<'JSON'
+    {"packages":[{"name":"solo","targets":[
+      {"name":"solo","kind":["lib"],"doc":true},
+      {"name":"solo","kind":["bin"],"doc":true}]}]}
+    JSON
+    just rs _doc-names "$scratch/ok.json"
+
+    # Different packages: a real collision, must be reported.
+    cat > "$scratch/bad.json" <<'JSON'
+    {"packages":[
+      {"name":"a-lib","targets":[{"name":"shared_name","kind":["lib"],"doc":true}]},
+      {"name":"b-cli","targets":[{"name":"shared-name","kind":["bin"],"doc":true}]}]}
+    JSON
+    if just rs _doc-names "$scratch/bad.json" 2>/dev/null; then
+        echo "rs: _doc-names missed a cross-package collision" >&2
+        exit 1
+    fi
+
+    # `doc = false` is how a pair gets resolved, so it must stop being reported.
+    cat > "$scratch/fixed.json" <<'JSON'
+    {"packages":[
+      {"name":"a-lib","targets":[{"name":"shared_name","kind":["lib"],"doc":true}]},
+      {"name":"b-cli","targets":[{"name":"shared-name","kind":["bin"],"doc":false}]}]}
+    JSON
+    just rs _doc-names "$scratch/fixed.json"
+
+    echo "rs: _doc-names ok"
 
 # Auto-fix clippy/format/shear/sort.
 fix *args:

--- a/rs/justfile
+++ b/rs/justfile
@@ -32,9 +32,45 @@ check *args:
     just rs _publish-test
     cargo clippy --locked --all-targets {{ args }} -- -D warnings
     cargo fmt --all --check
+    just rs _doc-names
     RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps {{ args }}
     cargo shear
     cargo sort --workspace --check --no-format
+
+# Two targets whose names differ only by `-` vs `_` render to the same
+# `target/doc/<name>`, and a `cargo doc` that selects both races to clean it: the
+# collision warning escalates to `error: failed to remove directory` depending on
+# which rustdoc process gets there first. That reads as a flake, and because the doc
+# pass above is diff-scoped it surfaces on whichever unrelated PR happens to select
+# both crates. Resolve a pair by setting `doc = false` on whichever target has no
+# published API to render (usually the binary), which is what `.doc` reads here.
+#
+# Metadata only, so this costs no compilation and can sit in the PR gate.
+_doc-names:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    collisions=$(cargo metadata --locked --no-deps --format-version 1 | jq -r '
+        [ .packages[]
+          | .name as $package
+          | .targets[]
+          | select(.doc)
+          | select([.kind[]] | any(. == "lib" or . == "rlib" or . == "dylib"
+              or . == "cdylib" or . == "staticlib" or . == "proc-macro" or . == "bin"))
+          | { dir: (.name | gsub("-"; "_")), package: $package, target: .name, kind: .kind[0] }
+        ]
+        | group_by(.dir)
+        | map(select(length > 1))
+        | .[]
+        | "  target/doc/\(.[0].dir) <- " + (map("\(.package) [\(.kind)] \(.target)") | join(" and "))
+    ')
+
+    if [[ -n "$collisions" ]]; then
+        echo "rs: these targets render to the same doc directory:" >&2
+        echo "$collisions" >&2
+        echo "set doc = false on whichever has no published API." >&2
+        exit 1
+    fi
 
 # Auto-fix clippy/format/shear/sort.
 fix *args:

--- a/rs/justfile
+++ b/rs/justfile
@@ -83,6 +83,15 @@ _doc-names-test:
     JSON
     just rs _doc-names "$scratch/ok.json"
 
+    # Same package, differing only by `-` vs `_`: cargo folds before suppressing, so
+    # this must pass too. Comparing the names as spelled would report it.
+    cat > "$scratch/folded.json" <<'JSON'
+    {"packages":[{"name":"folded","targets":[
+      {"name":"foo_bar","kind":["lib"],"doc":true},
+      {"name":"foo-bar","kind":["bin"],"doc":true}]}]}
+    JSON
+    just rs _doc-names "$scratch/folded.json"
+
     # Different packages: a real collision, must be reported.
     cat > "$scratch/bad.json" <<'JSON'
     {"packages":[

--- a/rs/moq-token-cli/Cargo.toml
+++ b/rs/moq-token-cli/Cargo.toml
@@ -20,6 +20,11 @@ path = "src/lib.rs"
 [[bin]]
 name = "moq-token"
 path = "src/main.rs"
+# The `moq-token` library renders to the same `target/doc/moq_token`, and the two
+# rustdoc processes race to clean it. The library is the published API consumers
+# read; this binary has none, so it is the page to give up. `just rs _doc-names`
+# fails if a new pair ever collides.
+doc = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/rs/scripts/doc-names.jq
+++ b/rs/scripts/doc-names.jq
@@ -1,0 +1,31 @@
+# Find workspace targets that would render to the same `target/doc/<dir>`.
+#
+# `cargo doc` writes each documented target to a directory named after the target with
+# dashes folded to underscores, so two targets that differ only there collide: both
+# rustdoc processes race to clean it, and the warning escalates to a hard error
+# depending on which wins.
+#
+# Reads `cargo metadata --no-deps` and prints one line per colliding group.
+[ .packages[]
+  | . as $pkg
+  # Cargo skips a binary whose name matches a library in its own package, documenting
+  # only the library, so such a pair never actually collides. Names are compared as
+  # spelled: a `foo_bar` lib beside a `foo-bar` bin is not suppressed by cargo and does
+  # collide, so it has to stay reportable.
+  | [ $pkg.targets[]
+      | select([.kind[]] | any(. == "lib" or . == "rlib" or . == "dylib"
+          or . == "cdylib" or . == "staticlib" or . == "proc-macro"))
+      | .name
+    ] as $libs
+  | $pkg.targets[]
+  # `doc = false` in the manifest, which is how a reported pair gets resolved.
+  | select(.doc)
+  | select([.kind[]] | any(. == "lib" or . == "rlib" or . == "dylib"
+      or . == "cdylib" or . == "staticlib" or . == "proc-macro" or . == "bin"))
+  | select((([.kind[]] | any(. == "bin")) and (.name | IN($libs[]))) | not)
+  | { dir: (.name | gsub("-"; "_")), package: $pkg.name, target: .name, kind: .kind[0] }
+]
+| group_by(.dir)
+| map(select(length > 1))
+| .[]
+| "  target/doc/\(.[0].dir) <- " + (map("\(.package) [\(.kind)] \(.target)") | join(" and "))

--- a/rs/scripts/doc-names.jq
+++ b/rs/scripts/doc-names.jq
@@ -8,21 +8,21 @@
 # Reads `cargo metadata --no-deps` and prints one line per colliding group.
 [ .packages[]
   | . as $pkg
-  # Cargo skips a binary whose name matches a library in its own package, documenting
-  # only the library, so such a pair never actually collides. Names are compared as
-  # spelled: a `foo_bar` lib beside a `foo-bar` bin is not suppressed by cargo and does
-  # collide, so it has to stay reportable.
+  # Cargo skips a binary that would land on the same directory as a library in its own
+  # package, documenting only the library, so such a pair never actually collides.
+  # Compared after folding, matching cargo: a `foo_bar` lib beside a `foo-bar` bin is
+  # suppressed too (verified against cargo 1.95). Only cross-package pairs collide.
   | [ $pkg.targets[]
       | select([.kind[]] | any(. == "lib" or . == "rlib" or . == "dylib"
           or . == "cdylib" or . == "staticlib" or . == "proc-macro"))
-      | .name
+      | (.name | gsub("-"; "_"))
     ] as $libs
   | $pkg.targets[]
   # `doc = false` in the manifest, which is how a reported pair gets resolved.
   | select(.doc)
   | select([.kind[]] | any(. == "lib" or . == "rlib" or . == "dylib"
       or . == "cdylib" or . == "staticlib" or . == "proc-macro" or . == "bin"))
-  | select((([.kind[]] | any(. == "bin")) and (.name | IN($libs[]))) | not)
+  | select((([.kind[]] | any(. == "bin")) and ((.name | gsub("-"; "_")) | IN($libs[]))) | not)
   | { dir: (.name | gsub("-"; "_")), package: $pkg.name, target: .name, kind: .kind[0] }
 ]
 | group_by(.dir)


### PR DESCRIPTION
Follow-up to #3113, which fixed one instance of a problem that turned out to have another.

## There was a second collision

A workspace-wide doc build finds two pairs of targets rendering to the same `target/doc/<name>`, not one:

```
target/doc/moq       <- libmoq [staticlib] moq        and moq-cli [bin] moq          (fixed in #3113)
target/doc/moq_token <- moq-token [lib] moq_token     and moq-token-cli [bin] moq-token
```

Both are the same failure. Two rustdoc processes within a single `cargo doc` race to clean the shared directory, so the deterministic collision *warning* escalates to `error: failed to remove directory` depending on which gets there first. `RUSTDOCFLAGS="-D warnings"` does not catch it, because cargo emits the collision rather than rustdoc. And since `just check`'s doc pass is diff-scoped, it fires on whichever unrelated PR happens to select both crates, which is why it kept reading as a flake (#3091, #3066).

## The gate, not another one-off

Fixing these one at a time as they surface is the wrong shape, so `check` gains `just rs _doc-names`. It groups every documented lib/bin target by the directory it renders to and fails on any group larger than one, naming both sides and the remedy:

```
rs: these targets render to the same doc directory:
  target/doc/moq <- libmoq [staticlib] moq and moq-cli [bin] moq
  target/doc/moq_token <- moq-token-cli [bin] moq-token and moq-token [lib] moq_token
set doc = false on whichever has no published API.
```

Two properties make it worth putting in the PR gate rather than nightly:

- It reads `.doc` from `cargo metadata`, so a pair resolved with `doc = false` stays resolved and does not need re-suppressing.
- It runs on metadata alone, so it costs no compilation. The whole check is a `cargo metadata` call and a `jq` expression.

It would have caught the original pair instantly, before #3091 and #3066 ever failed.

Verified by reverting each `doc = false` in turn: the gate reports that pair and exits 1. With both in place it passes, and `cargo doc -p moq-token -p moq-token-cli -p libmoq -p moq-cli` emits zero collision warnings while still generating both `target/doc/moq` and `target/doc/moq_token`.

## Resolving the new pair

Same reasoning as #3113: `moq-token` is the published library whose docs.rs page is linked from `doc/lib/rs/crate/moq-token.md` and `doc/lib/rs/index.md`, whereas nothing links `docs.rs/moq-token-cli` and a bin target has no public API to render. So `doc = false` goes on the binary. `moq-token-cli`'s own library target (`moq_token_cli`) is untouched and still documented.

## What this does not cover

There is a second, narrower blind spot that this gate does not close, found while investigating: because cargo unifies features per crate, a crate's doc build can succeed under `--workspace` and fail when selected alone, since the selection changes which features are on. That is how the `mdns` intra-doc link in #3152 broke every branch touching `moq-tokio` while nightly stayed green.

Catching that class needs a per-crate doc invocation for every package, which is a real nightly cost rather than a metadata query, so it is deliberately left out here. Worth its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)


---

## Review follow-ups

Codex's adversarial review found a false-positive path, and chasing it turned up a real bug in the query.

It observed that cargo skips a binary whose name matches a library in its own package, so grouping every `doc: true` target would reject the conventional `src/lib.rs` + `src/main.rs` layout. Confirmed against cargo with a scratch package: both targets report `doc: true`, and `cargo doc` emits no collision.

The review believed the suppression compares names as spelled, so a `foo_bar` lib beside a `foo-bar` bin would still collide. Testing that against the repo's pinned cargo 1.95.0 showed the opposite: cargo folds dashes to underscores first and suppresses that pair too, generating a single page. The as-spelled comparison in the first fix was therefore a false positive on the very layout the suppression exists for, with a comment asserting the wrong rule. Corrected in e7ec155e, and Codex withdrew the claim on re-review.

The query now lives in `rs/scripts/doc-names.jq` and `_doc-names` takes an optional metadata file, so `_doc-names-test` drives it with synthetic workspaces covering all four directions: same-package identical names pass, same-package folded names pass, a cross-package pair fails, and `doc = false` resolves it. It runs in `check` beside `_select-test` and `_publish-test`. Reverting either the suppression or the folding fails a fixture.
