### PR TITLE
docs: name the moq binary, not the moq-cli package

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -51,10 +51,10 @@ Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub
 ```bash
 git clone https://github.com/moq-dev/moq
 cd moq
-cargo build --release --bin moq-cli
+cargo build --release -p moq-cli --bin moq
 ```
 
-The binary will be in `target/release/moq-cli`.
+The binary will be in `target/release/moq`.
 
 ### Heap profiling
 

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -145,7 +145,7 @@ Opinionated helpers to configure a Quinn QUIC endpoint.
 
 ### moq-cli
 
-Command-line tool for media operations (binary name: `moq-cli`).
+Command-line tool for media operations (binary name: `moq`).
 
 **Features:**
 

--- a/doc/setup/windows.md
+++ b/doc/setup/windows.md
@@ -102,7 +102,7 @@ leftover process and rebuild:
 
 ```bat
 taskkill /IM moq-relay.exe /F
-taskkill /IM moq-cli.exe /F
+taskkill /IM moq.exe /F
 ```
 
 :::


### PR DESCRIPTION
## What

Four docs lines named `moq-cli` where they meant the *binary*. The crate declares `[[bin]] name = "moq"`, so each was wrong in a way a reader would hit immediately:

| File | Was | Now |
|---|---|---|
| `doc/bin/cli.md` | `cargo build --release --bin moq-cli` | `cargo build --release -p moq-cli --bin moq` |
| `doc/bin/cli.md` | ``The binary will be in `target/release/moq-cli` `` | ``... `target/release/moq` `` |
| `doc/setup/windows.md` | `taskkill /IM moq-cli.exe /F` | `taskkill /IM moq.exe /F` |
| `doc/lib/rs/index.md` | "binary name: `moq-cli`" | "binary name: `moq`" |

## Why

The From Source build command doesn't just point at the wrong path, it fails to run at all: `cargo build --bin moq-cli` errors with `no bin target named 'moq-cli'`, so the documented path to a source build is a dead end.

The Windows one is the same bug wearing different clothes. That `taskkill` is the fix offered for "Access is denied (os error 5)" on rebuild, and since `rs/scripts/package-windows.sh` ships the crate's binary as `moq.exe`, it silently matches no process. The reader is left with the orphan still holding the file and no signal that the remedy missed.

`doc/lib/rs/index.md` contradicted itself: it advertised the binary as `moq-cli` and then used `moq ...` in the usage block directly below it.

## What was deliberately left alone

Every remaining `moq-cli` in `doc/`, `demo/`, and `README.md` names the *package*, which is correct: `cargo install moq-cli`, `nix run/build …#moq-cli` (a real flake output), `docker pull moqdev/moq-cli`, the apt/dnf/brew/winget packages, and the `-p moq-cli` selectors already used elsewhere in `cli.md`. `demo/` already invokes `cargo run --bin moq` throughout; its one `echo ">>> Importing HLS via moq-cli"` names the tool in prose rather than a binary.

## Verification

- `just check` passes, including the docs site build over the edited pages.
- Ran the corrected command rather than just eyeballing it: `cargo build --release -p moq-cli --bin moq` finishes clean and puts a 38 MB binary at `target/release/moq`; `./target/release/moq --help` reports `Usage: moq [OPTIONS] <COMMAND>`.

Docs-only, so no Cross-Package Sync rows apply.

(Written by claude-opus-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)