### PR TITLE
fix(nix): resolve third-party kio from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,6 +4303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kio"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d64d03bab237df643a5013adcf07764e4bd3265117e4c4f69e856d37928e69"
+dependencies = [
+ "loom",
+ "smallvec",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4763,7 +4773,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "hang",
- "kio",
+ "kio 0.5.6",
  "moq-audio",
  "moq-json",
  "moq-mux",
@@ -4817,7 +4827,7 @@ dependencies = [
  "bytes",
  "hang",
  "humantime",
- "kio",
+ "kio 0.5.6",
  "m3u8-rs",
  "moq-mux",
  "moq-net",
@@ -4839,7 +4849,7 @@ dependencies = [
  "bytes",
  "criterion",
  "json-patch",
- "kio",
+ "kio 0.5.6",
  "moq-flate",
  "moq-net",
  "serde",
@@ -4877,7 +4887,7 @@ dependencies = [
  "futures",
  "h264-parser",
  "hang",
- "kio",
+ "kio 0.5.6",
  "memchr",
  "moq-json",
  "moq-loc",
@@ -4913,7 +4923,7 @@ dependencies = [
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "kio",
+ "kio 0.5.6",
  "loom",
  "moq-net",
  "num_enum",
@@ -5165,7 +5175,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "hang",
- "kio",
+ "kio 0.5.6",
  "moq-mux",
  "moq-net",
  "moq-tokio",
@@ -5187,7 +5197,7 @@ dependencies = [
  "criterion",
  "http",
  "io-uring",
- "kio",
+ "kio 0.5.6",
  "libc",
  "moq-net",
  "moq-sock",
@@ -10590,7 +10600,7 @@ dependencies = [
  "bytes",
  "http",
  "iroh",
- "kio",
+ "kio 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-error",
  "n0-future",
  "tokio",
@@ -10609,7 +10619,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio",
+ "kio 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -10646,7 +10656,7 @@ dependencies = [
  "flume",
  "futures",
  "http",
- "kio",
+ "kio 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-pki-types",
  "thiserror 2.0.20",
  "tokio",
@@ -10666,7 +10676,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio",
+ "kio 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quinn",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,10 +245,3 @@ opt-level = "z"
 lto = "fat"
 codegen-units = 1
 strip = true
-
-# External crates (web-transport-iroh) depend on the published kio, which
-# otherwise coexists with the workspace copy at the same version and makes
-# `--package kio` ambiguous the moment the crate changes. Point everyone at the
-# workspace copy so exactly one kio is built.
-[patch.crates-io]
-kio = { path = "rs/kio" }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -24,6 +24,32 @@ let
     filter = filterCargoSources;
   };
 
+  # The root manifest's `[patch.crates-io]` points `kio` at the workspace copy,
+  # because the published kio and this one share version 0.5.6 with diverged
+  # contents. That patch applies to THIRD-PARTY crates too: the vendored
+  # web-transport-quinn and web-transport-iroh resolve `kio` to rs/kio rather
+  # than to the registry.
+  #
+  # crane's dependency-only build replaces every workspace member with a stub, so
+  # those vendored crates end up compiling against an empty kio and fail on the
+  # `Park`/`Waiter`/`wait` they expect. Cargo is unaffected -- it never stubs
+  # anything -- which is why `cargo build` succeeds while `nix build` does not.
+  #
+  # Restore the real kio in the dummy tree. It is a leaf crate with no build
+  # script, so the dependency cache still keys on every other member's stub and
+  # only rebuilds when kio itself changes.
+  kioSource = final.lib.cleanSourceWith {
+    src = ../rs/kio;
+    name = "kio-source";
+    filter = filterCargoSources;
+  };
+  restoreRealKio = ''
+    rm -rf "$out/rs/kio/src"
+    cp -R ${kioSource}/src "$out/rs/kio/src"
+  '';
+  # Every package below vendors the same workspace, so they all need it.
+  withRealKio = args: args // { extraDummyScript = restoreRealKio; };
+
   moqRelayArgs = crateInfo ../rs/moq-relay/Cargo.toml // {
     src = cleanCargoSource;
     cargoExtraArgs = "-p moq-relay --features jemalloc";
@@ -69,7 +95,7 @@ let
     # The crate is `moq-token-cli`, but its `[[bin]]` ships as `moq-token`.
     meta.mainProgram = "moq-token";
   };
-  moqTokenPackage = craneLib.buildPackage moqTokenCliArgs;
+  moqTokenPackage = craneLib.buildPackage (withRealKio moqTokenCliArgs);
 
   moqBenchArgs = crateInfo ../rs/moq-bench/Cargo.toml // {
     src = cleanCargoSource;
@@ -267,37 +293,39 @@ let
   # Release artifacts still build via crane `buildPackage` below.
 in
 {
-  moq-relay = craneLib.buildPackage moqRelayArgs;
+  moq-relay = craneLib.buildPackage (withRealKio moqRelayArgs);
 
-  moq-cli = craneLib.buildPackage moqCliArgs;
+  moq-cli = craneLib.buildPackage (withRealKio moqCliArgs);
 
-  moq-bench = craneLib.buildPackage moqBenchArgs;
+  moq-bench = craneLib.buildPackage (withRealKio moqBenchArgs);
 
   moq-token = moqTokenPackage;
   moq-token-cli = moqTokenPackage;
 
   moq-boy = craneLib.buildPackage (
-    crateInfo ../rs/moq-boy/Cargo.toml
-    // {
-      src = cleanCargoSource;
-      cargoExtraArgs = "-p moq-boy --features jemalloc";
-      nativeBuildInputs = with final; [
-        pkg-config
-        clang
-      ];
-      buildInputs = with final; [ ffmpeg ];
-      LIBCLANG_PATH = "${final.libclang.lib}/lib";
-      # Enable frame pointers for profiling support (negligible overhead on x86_64).
-      RUSTFLAGS = "-C force-frame-pointers=yes";
-      # jemalloc's configure uses -O0 test builds, which conflict with
-      # Nix's _FORTIFY_SOURCE hardening (requires -O).
-      hardeningDisable = [ "fortify" ];
-    }
+    withRealKio (
+      crateInfo ../rs/moq-boy/Cargo.toml
+      // {
+        src = cleanCargoSource;
+        cargoExtraArgs = "-p moq-boy --features jemalloc";
+        nativeBuildInputs = with final; [
+          pkg-config
+          clang
+        ];
+        buildInputs = with final; [ ffmpeg ];
+        LIBCLANG_PATH = "${final.libclang.lib}/lib";
+        # Enable frame pointers for profiling support (negligible overhead on x86_64).
+        RUSTFLAGS = "-C force-frame-pointers=yes";
+        # jemalloc's configure uses -O0 test builds, which conflict with
+        # Nix's _FORTIFY_SOURCE hardening (requires -O).
+        hardeningDisable = [ "fortify" ];
+      }
+    )
   );
 
-  libmoq = craneLib.buildPackage libmoqArgs;
+  libmoq = craneLib.buildPackage (withRealKio libmoqArgs);
 
-  moq-gst-plugin = craneLib.buildPackage moqGstPluginArgs;
+  moq-gst-plugin = craneLib.buildPackage (withRealKio moqGstPluginArgs);
 
   # User-facing flake output. Bundles the plugin with wrapped gstreamer
   # tools so a single `nix shell .#moq-gst` gives you gst-inspect-1.0 /

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -24,32 +24,6 @@ let
     filter = filterCargoSources;
   };
 
-  # The root manifest's `[patch.crates-io]` points `kio` at the workspace copy,
-  # because the published kio and this one share version 0.5.6 with diverged
-  # contents. That patch applies to THIRD-PARTY crates too: the vendored
-  # web-transport-quinn and web-transport-iroh resolve `kio` to rs/kio rather
-  # than to the registry.
-  #
-  # crane's dependency-only build replaces every workspace member with a stub, so
-  # those vendored crates end up compiling against an empty kio and fail on the
-  # `Park`/`Waiter`/`wait` they expect. Cargo is unaffected -- it never stubs
-  # anything -- which is why `cargo build` succeeds while `nix build` does not.
-  #
-  # Restore the real kio in the dummy tree. It is a leaf crate with no build
-  # script, so the dependency cache still keys on every other member's stub and
-  # only rebuilds when kio itself changes.
-  kioSource = final.lib.cleanSourceWith {
-    src = ../rs/kio;
-    name = "kio-source";
-    filter = filterCargoSources;
-  };
-  restoreRealKio = ''
-    rm -rf "$out/rs/kio/src"
-    cp -R ${kioSource}/src "$out/rs/kio/src"
-  '';
-  # Every package below vendors the same workspace, so they all need it.
-  withRealKio = args: args // { extraDummyScript = restoreRealKio; };
-
   moqRelayArgs = crateInfo ../rs/moq-relay/Cargo.toml // {
     src = cleanCargoSource;
     cargoExtraArgs = "-p moq-relay --features jemalloc";
@@ -95,7 +69,7 @@ let
     # The crate is `moq-token-cli`, but its `[[bin]]` ships as `moq-token`.
     meta.mainProgram = "moq-token";
   };
-  moqTokenPackage = craneLib.buildPackage (withRealKio moqTokenCliArgs);
+  moqTokenPackage = craneLib.buildPackage moqTokenCliArgs;
 
   moqBenchArgs = crateInfo ../rs/moq-bench/Cargo.toml // {
     src = cleanCargoSource;
@@ -293,39 +267,37 @@ let
   # Release artifacts still build via crane `buildPackage` below.
 in
 {
-  moq-relay = craneLib.buildPackage (withRealKio moqRelayArgs);
+  moq-relay = craneLib.buildPackage moqRelayArgs;
 
-  moq-cli = craneLib.buildPackage (withRealKio moqCliArgs);
+  moq-cli = craneLib.buildPackage moqCliArgs;
 
-  moq-bench = craneLib.buildPackage (withRealKio moqBenchArgs);
+  moq-bench = craneLib.buildPackage moqBenchArgs;
 
   moq-token = moqTokenPackage;
   moq-token-cli = moqTokenPackage;
 
   moq-boy = craneLib.buildPackage (
-    withRealKio (
-      crateInfo ../rs/moq-boy/Cargo.toml
-      // {
-        src = cleanCargoSource;
-        cargoExtraArgs = "-p moq-boy --features jemalloc";
-        nativeBuildInputs = with final; [
-          pkg-config
-          clang
-        ];
-        buildInputs = with final; [ ffmpeg ];
-        LIBCLANG_PATH = "${final.libclang.lib}/lib";
-        # Enable frame pointers for profiling support (negligible overhead on x86_64).
-        RUSTFLAGS = "-C force-frame-pointers=yes";
-        # jemalloc's configure uses -O0 test builds, which conflict with
-        # Nix's _FORTIFY_SOURCE hardening (requires -O).
-        hardeningDisable = [ "fortify" ];
-      }
-    )
+    crateInfo ../rs/moq-boy/Cargo.toml
+    // {
+      src = cleanCargoSource;
+      cargoExtraArgs = "-p moq-boy --features jemalloc";
+      nativeBuildInputs = with final; [
+        pkg-config
+        clang
+      ];
+      buildInputs = with final; [ ffmpeg ];
+      LIBCLANG_PATH = "${final.libclang.lib}/lib";
+      # Enable frame pointers for profiling support (negligible overhead on x86_64).
+      RUSTFLAGS = "-C force-frame-pointers=yes";
+      # jemalloc's configure uses -O0 test builds, which conflict with
+      # Nix's _FORTIFY_SOURCE hardening (requires -O).
+      hardeningDisable = [ "fortify" ];
+    }
   );
 
-  libmoq = craneLib.buildPackage (withRealKio libmoqArgs);
+  libmoq = craneLib.buildPackage libmoqArgs;
 
-  moq-gst-plugin = craneLib.buildPackage (withRealKio moqGstPluginArgs);
+  moq-gst-plugin = craneLib.buildPackage moqGstPluginArgs;
 
   # User-facing flake output. Bundles the plugin with wrapped gstreamer
   # tools so a single `nix shell .#moq-gst` gives you gst-inspect-1.0 /


### PR DESCRIPTION
## Summary

- Remove the workspace-wide `[patch.crates-io]` override for `kio`.
- Keep workspace consumers on `rs/kio` while third-party `web-transport-*` crates use the published `kio` API they declared.
- The override originally avoided ambiguous bare Cargo package selectors, but #2989 replaced those with source-qualified package IDs. The now-redundant override redirected third-party crates into the workspace, where crane replaces members with stubs during dependency-only builds. Removing it fixes the Nix build without a crane special case.

## Public API changes

None.

## Wire behavior changes

None.

## Test plan

- `nix build --no-link .#moq-cli .#moq-relay .#moq-token-cli`
- `just fix`
- `just check`
- `just test` (3,838 passed, 2 skipped)

(written by GPT-5)