### PR TITLE
fix(native): remove deadlock detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,12 +2509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4890,7 +4884,6 @@ dependencies = [
  "moq-net",
  "noq-proto",
  "notify",
- "parking_lot",
  "qmux",
  "quinn",
  "rand 0.10.2",
@@ -6639,10 +6632,8 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "backtrace",
  "cfg-if",
  "libc",
- "petgraph",
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
@@ -6708,16 +6699,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.14.0",
-]
 
 [[package]]
 name = "pharos"

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -54,7 +54,6 @@ moq-net = { workspace = true }
 # congestion configs. Version matched to the copy iroh pulls in.
 noq-proto = { version = "1", default-features = false, optional = true }
 notify = { version = "8", optional = true }
-parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 qmux = { workspace = true, features = ["wss", "tls", "tcp"], optional = true }
 quinn = { version = "0.11", default-features = false, features = ["platform-verifier", "runtime-tokio", "bloom"], optional = true }
 rand = { workspace = true }

--- a/rs/moq-native/src/accept.rs
+++ b/rs/moq-native/src/accept.rs
@@ -26,7 +26,7 @@
 use std::{
 	io,
 	sync::{
-		Arc,
+		Arc, Mutex,
 		atomic::{AtomicU64, Ordering},
 	},
 	time::{Duration, Instant},
@@ -214,7 +214,7 @@ struct Inner {
 	connection: AtomicU64,
 	exhausted: AtomicU64,
 	unknown: AtomicU64,
-	state: parking_lot::Mutex<State>,
+	state: Mutex<State>,
 }
 
 struct State {
@@ -235,7 +235,7 @@ impl Health {
 			connection: AtomicU64::new(0),
 			exhausted: AtomicU64::new(0),
 			unknown: AtomicU64::new(0),
-			state: parking_lot::Mutex::new(State {
+			state: Mutex::new(State {
 				stall: None,
 				consecutive: 0,
 				delay: RETRY_MIN,
@@ -251,7 +251,7 @@ impl Health {
 	/// An accept succeeded: the listener is serving, so any stall is over and the
 	/// next failure starts from the shortest delay again.
 	pub fn accepted(&self) {
-		let mut state = self.0.state.lock();
+		let mut state = self.0.state.lock().unwrap();
 		if state.stall.take().is_some() {
 			tracing::info!(listener = self.0.listener, "listener is accepting again");
 		}
@@ -276,7 +276,7 @@ impl Health {
 			return None;
 		}
 
-		let mut state = self.0.state.lock();
+		let mut state = self.0.state.lock().unwrap();
 		state.consecutive += 1;
 		let delay = jitter(state.delay);
 		state.delay = (state.delay * 2).min(RETRY_MAX);
@@ -316,7 +316,7 @@ impl Health {
 	/// Only a successful accept clears it, so a listener with no traffic holds its
 	/// last value rather than claiming a recovery it has no evidence for.
 	pub fn stalled(&self) -> Option<Duration> {
-		self.0.state.lock().stall.map(|since| since.elapsed())
+		self.0.state.lock().unwrap().stall.map(|since| since.elapsed())
 	}
 
 	fn counter(&self, failure: Failure) -> &AtomicU64 {

--- a/rs/moq-native/src/log.rs
+++ b/rs/moq-native/src/log.rs
@@ -79,34 +79,6 @@ impl Log {
 			.try_init()
 			.map_err(|e| crate::Error::SetSubscriber(std::sync::Arc::new(e)))?;
 
-		// Start deadlock detection thread (only in debug builds)
-		#[cfg(debug_assertions)]
-		std::thread::spawn(Self::deadlock_detector);
-
 		Ok(())
-	}
-
-	#[cfg(debug_assertions)]
-	fn deadlock_detector() {
-		loop {
-			std::thread::sleep(std::time::Duration::from_secs(1));
-
-			let deadlocks = parking_lot::deadlock::check_deadlock();
-			if deadlocks.is_empty() {
-				continue;
-			}
-
-			tracing::error!("DEADLOCK DETECTED");
-
-			for (i, threads) in deadlocks.iter().enumerate() {
-				tracing::error!("Deadlock #{}", i);
-				for t in threads {
-					tracing::error!("Thread Id {:#?}", t.thread_id());
-					tracing::error!("{:#?}", t.backtrace());
-				}
-			}
-
-			// Optionally: std::process::abort() to get a core dump
-		}
 	}
 }


### PR DESCRIPTION
## Summary

- remove the debug-only deadlock checker and its process-lifetime thread
- replace the remaining low-frequency `parking_lot::Mutex` with `std::sync::Mutex`, removing `moq-native`’s direct `parking_lot` dependency
- stop enabling `parking_lot/deadlock_detection` across release builds; Cargo feature unification compiled its per-lock tracking even though `#[cfg(debug_assertions)]` prevented the checker from running

Fixes #3125.

## Public API changes

None.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (3264 passed, 1 skipped)
- inspected `cargo tree --locked -p moq-relay -e features -i parking_lot_core` to confirm only `parking_lot_core/default` remains enabled

Cross-package sync is not applicable because this changes neither a public API nor a wire format.

(Written by Codex)