### PR TITLE
fix(net): bound reach by the immediate successor, and collapse snapshots mid-roll

### DIFF
--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -500,7 +500,7 @@ A subscriber MUST support gaps and out-of-order delivery regardless.
 
 ## Expiration
 Expiration governs when an older group is dropped.
-The publisher SHOULD reset Group Streams for non-latest groups whose age relative to the latest group exceeds `Subscriber Max Age` (see [SUBSCRIBE](#subscribe)); the subscriber MAY also locally drop such groups.
+The publisher SHOULD reset Group Streams for non-latest groups whose age relative to the latest group reaches `Subscriber Max Age` (see [SUBSCRIBE](#subscribe), and the age definition below); the subscriber MAY also locally drop such groups.
 Expiration only removes the group from live delivery; the publisher MAY still retain it for FETCH or new subscriptions until its age exceeds `Publisher Max Age` (see [TRACK_INFO](#track-info)).
 
 It is not crucial to aggressively expire groups thanks to [prioritization](#prioritization), but a lower priority group still consumes RAM, bandwidth, and potentially flow control.
@@ -978,7 +978,7 @@ See the [Expiration](#expiration) section for more information.
 The minimum group sequence to deliver: an absolute floor, defaulting to 0 (no floor).
 
 A floor is not a request; `Subscriber Max Age` is the only thing that asks for data.
-The publisher SHOULD start at the oldest group at or above the floor whose age (relative to the latest group, measured from its first frame) is within `Subscriber Max Age`, and MUST NOT deliver an older one.
+The publisher SHOULD start at the oldest group at or above the floor that [Expiration](#expiration) has not expired, and MUST NOT deliver an older one.
 A `Subscriber Max Age` of 0 therefore starts at the latest group, since every older group is already stale.
 A subscriber that buffers is then handed the head of what it can still play instead of only the live edge, and is never sent history it would discard on arrival: the same bound decides what to start at and what to expire, so the two cannot disagree.
 A floor above the latest group simply waits there: that is a resumed subscription naming where it left off.

--- a/js/json/src/snapshot/consumer.ts
+++ b/js/json/src/snapshot/consumer.ts
@@ -35,10 +35,20 @@ export class Consumer<T> {
 	 */
 	async next(): Promise<T | undefined> {
 		for (;;) {
+			// A newer group supersedes everything the current one still holds: it restarts
+			// from a full snapshot, so switching mid-group loses nothing but stale state
+			// (mirrors the Rust consumer, which drains to the newest group every poll).
+			if (this.#group !== undefined) {
+				const latest = this.#track.latest();
+				if (latest !== undefined && latest > this.#group.sequence) {
+					this.#group.close();
+					this.#group = undefined;
+				}
+			}
+
 			if (!this.#group) {
-				// Collapse the retained backlog: every group restarts from a full snapshot, so
-				// older groups only hold superseded state. Jump the cursor to the newest
-				// buffered group instead of replaying each one (mirrors the Rust consumer).
+				// Collapse the retained backlog: older groups only hold superseded state, so
+				// jump the cursor to the newest buffered group instead of replaying each one.
 				const latest = this.#track.latest();
 				if (latest !== undefined) this.#track.startAt(latest);
 				// Advance to the next group with a higher sequence number (skipping late arrivals).

--- a/js/json/src/snapshot/snapshot.test.ts
+++ b/js/json/src/snapshot/snapshot.test.ts
@@ -127,6 +127,27 @@ test("deltaRatio 0 disables deltas, like off", async () => {
 	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }).ordered())).toEqual([1, 1]);
 });
 
+// A consumer holding a group must jump when a newer snapshot group rolls: the
+// buffered deltas in the held group only reconstruct superseded state, and every
+// group restarts from a full snapshot (mirrors the Rust consumer, which drains to
+// the newest group on every poll).
+test("a held group is abandoned when a newer snapshot group rolls", async () => {
+	const track = new Track.Producer("test");
+	// A tiny ratio forces the update after any delta to roll a fresh snapshot group.
+	const producer = new Producer<Value>({ track, deltaRatio: 0.001 });
+	const consumer = new Consumer<Value>(track.subscribe({ maxAge: REPLAY_LATENCY }));
+
+	producer.update({ a: 1 });
+	expect(await consumer.next()).toEqual({ a: 1 });
+
+	// A delta lands in the held group, then the ratio rolls a new snapshot group.
+	producer.update({ a: 2 });
+	producer.update({ a: 3 });
+	producer.finish();
+
+	expect(await consumer.next()).toEqual({ a: 3 });
+});
+
 test("live consumer sees each update", async () => {
 	const track = new Track.Producer("test");
 	const producer = new Producer<Value>({ track });

--- a/js/json/src/snapshot/snapshot.test.ts
+++ b/js/json/src/snapshot/snapshot.test.ts
@@ -42,7 +42,7 @@ test("a cut makes the next update a snapshot group", async () => {
 
 	// The ratio would have kept every update in one group; the cut rolled it anyway. The replacement
 	// opens with a full snapshot, so it is one frame rather than a delta appended to the first group.
-	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([2, 1]);
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }).ordered())).toEqual([2, 1]);
 	expect((await drain(track.subscribe({ maxAge: REPLAY_LATENCY }))).at(-1)).toEqual({ a: 1, b: 3 });
 });
 
@@ -57,7 +57,7 @@ test("a cut republishes an unchanged value", async () => {
 	producer.update({ a: 1 });
 	producer.finish();
 
-	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([1, 1]);
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }).ordered())).toEqual([1, 1]);
 });
 
 test("a cut opens no replacement group", async () => {
@@ -68,7 +68,7 @@ test("a cut opens no replacement group", async () => {
 	producer.finish();
 
 	// Cutting closes the open group and stops there: no empty group for a consumer to advance into.
-	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([1]);
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }).ordered())).toEqual([1]);
 });
 
 test("a cut is idempotent", async () => {
@@ -86,7 +86,7 @@ test("a cut is idempotent", async () => {
 	producer.update({ a: 2 });
 	producer.finish();
 
-	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([1, 1]);
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }).ordered())).toEqual([1, 1]);
 });
 
 test("a cut is inert without deltas", async () => {
@@ -99,7 +99,7 @@ test("a cut is inert without deltas", async () => {
 	producer.update({ a: 2 });
 	producer.finish();
 
-	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }))).toEqual([1, 1]);
+	expect(await structure(track.subscribe({ maxAge: REPLAY_LATENCY }).ordered())).toEqual([1, 1]);
 });
 
 test("deltas off: a snapshot group per change", async () => {

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -300,6 +300,23 @@ test("the latency budget skips a buffered timeline only on the arrival cursor", 
 	expect((await ordered.nextGroup())?.sequence).toBe(2);
 });
 
+// An unstamped immediate successor leaves a group's reach unbounded: a later stamped
+// group proves nothing about where the successor will begin, and shrinking the bound
+// is the unsafe direction.
+test("an unstamped immediate successor leaves reach unbounded", async () => {
+	const producer = new TrackProducer("test").accept({ maxAge: 5000 });
+	const track = producer.subscribe();
+
+	producer.writeFrame({ payload: enc.encode("0"), timestamp: Timestamp.fromMillis(0) });
+	producer.appendGroup(); // seq 1 stalls before its first frame
+	producer.writeFrame({ payload: enc.encode("2"), timestamp: Timestamp.fromMillis(10_000) });
+
+	// Group 1's reach is group 2's start, a full edge behind: stale at zero budget.
+	// Group 0's reach is unknown until group 1 presents its first frame, so it is kept.
+	expect((await track.recvGroup())?.sequence).toBe(0);
+	expect((await track.recvGroup())?.sequence).toBe(2);
+});
+
 // The ordered frame helpers share the burst contract: a buffered backlog is drained
 // in full rather than discarded for age.
 test("ordered frame reads drain a stale backlog", async () => {

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -722,31 +722,20 @@ export class Subscriber {
 	#drift(): {
 		budget: number;
 		presentation?: { sequence: number; timestamp: Timestamp };
-		suffix: { sequence: number; reach: number }[];
+		end?: number;
 	} {
 		const { end } = this.#cursor.peek();
 		let presentation: { sequence: number; timestamp: Timestamp } | undefined;
-		const suffix: { sequence: number; reach: number }[] = [];
 		for (const { group } of this.#state.timeline.values()) {
 			if (end !== undefined && group.sequence > end) continue;
 			if (group.closed.peek() instanceof Error) continue;
+			// The edge wants the newest content that exists, so it takes the newest
+			// stamped group's latest frame.
 			const timestamp = hooks.groupTimestamp(group);
-			if (timestamp !== undefined) {
-				// The table bounds a candidate's reach, so it wants where each group
-				// begins; the edge wants the newest content that exists, so it takes the
-				// newest group's latest frame.
-				suffix.push({ sequence: group.sequence, reach: timestamp.asMillis() });
-				if (!presentation || group.sequence > presentation.sequence) {
-					presentation = { sequence: group.sequence, timestamp: hooks.groupLatest(group) ?? timestamp };
-				}
+			if (timestamp !== undefined && (!presentation || group.sequence > presentation.sequence)) {
+				presentation = { sequence: group.sequence, timestamp: hooks.groupLatest(group) ?? timestamp };
 			}
 		}
-
-		// Sequence order, so a candidate's immediate successor is one lookup away.
-		// Deliberately not a minimum over later groups: timestamps need not rise with
-		// sequence, and taking the minimum would shrink the bound, which is the unsafe
-		// direction. Only the immediate successor bounds a group.
-		suffix.sort((a, b) => a.sequence - b.sequence);
 
 		const requested = this.#state.update.peek()?.maxAge ?? 0;
 		const retained = this.#state.info.peek()?.maxAge;
@@ -757,24 +746,28 @@ export class Subscriber {
 					: Math.min(requested, retained)
 				: Number.POSITIVE_INFINITY,
 			presentation,
-			suffix,
+			end,
 		};
 	}
 
 	// The furthest presentation time the group at `sequence` could still reach: where its
-	// immediate successor begins, or undefined when nothing follows it yet. An upper bound,
-	// deliberately: a frame's duration is not on the wire, so a group's own last timestamp
-	// says where it starts presenting, not where it ends. Only a successor's start proves
-	// the predecessor cannot run past it.
-	static #reach(suffix: { sequence: number; reach: number }[], sequence: number): number | undefined {
-		let lo = 0;
-		let hi = suffix.length;
-		while (lo < hi) {
-			const mid = (lo + hi) >> 1;
-			if (suffix[mid].sequence <= sequence) lo = mid + 1;
-			else hi = mid;
+	// immediate servable successor begins, or undefined when nothing proves where it
+	// stops. An upper bound, deliberately: a frame's duration is not on the wire, so a
+	// group's own last timestamp says where it starts presenting, not where it ends.
+	// Only the *immediate* successor counts: timestamps need not rise with sequence (a
+	// rewind reorders them), so a later stamped group proves nothing about where an
+	// unstamped successor will begin, and shrinking the bound is the unsafe direction.
+	// An unstamped successor leaves the reach unbounded until it presents a frame.
+	#reach(sequence: number, end?: number): number | undefined {
+		let successor: GroupConsumer | undefined;
+		for (const { group } of this.#state.timeline.values()) {
+			if (group.sequence <= sequence) continue;
+			if (end !== undefined && group.sequence > end) continue;
+			if (group.closed.peek() instanceof Error) continue;
+			if (!successor || group.sequence < successor.sequence) successor = group;
 		}
-		return suffix[lo]?.reach;
+		if (!successor) return undefined;
+		return hooks.groupTimestamp(successor)?.asMillis();
 	}
 
 	// Whether the drift budget says to give up on `group`.
@@ -798,13 +791,13 @@ export class Subscriber {
 		drift: {
 			budget: number;
 			presentation?: { sequence: number; timestamp: Timestamp };
-			suffix: { sequence: number; reach: number }[];
+			end?: number;
 		},
 	): boolean {
 		const candidate = this.#state.timeline.get(group.sequence);
 		if (candidate?.group !== group) return false;
 
-		const reach = Subscriber.#reach(drift.suffix, group.sequence);
+		const reach = this.#reach(group.sequence, drift.end);
 		return (
 			drift.presentation !== undefined &&
 			drift.presentation.sequence > group.sequence &&
@@ -1267,7 +1260,12 @@ export class Ordered {
 	}
 
 	/**
-	 * Read the next frame across groups, discarding older groups.
+	 * Read the next frame across groups, in sequence order.
+	 *
+	 * Rides the same cursor as {@link nextGroup} and shares this handle's contract: a
+	 * buffered backlog is drained in full, however old it is, never discarded for age.
+	 * A consumer that wants only the freshest content should jump via {@link latest}
+	 * and {@link startAt} rather than expect frame reads to skip ahead.
 	 * Treat the returned frame bytes as read-only; they are shared with other consumers.
 	 */
 	readFrame(): Promise<Frame | undefined> {

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -1533,10 +1533,16 @@ impl Subscriber {
 	/// rather than read, so a candidate a poll does not deliver stays where it was,
 	/// and a cap lowered between polls never strands a group behind a segment cursor
 	/// that had already stepped past it.
+	///
+	/// `deliver` marks the caller as the one handing the group out, which stamps the
+	/// winner's cache entry. A nested seek passes `false`: its candidate may lose at
+	/// the level above, and a loser re-seeked every poll must not be shielded from
+	/// eviction.
 	fn poll_seek(
 		&mut self,
 		floor: u64,
 		end: Option<u64>,
+		deliver: bool,
 		waiter: &kio::Waiter,
 	) -> Poll<Result<Option<group::Consumer>>> {
 		self.poll_sync(waiter);
@@ -1562,16 +1568,12 @@ impl Subscriber {
 				}
 
 				let seg = &mut self.segments[index];
-				// A boundary behind the floor can never serve this cursor again;
-				// release its inner subscription rather than holding demand open.
-				if seg.last_group().is_some_and(|last| last < floor)
-					&& let SubState::Active(sub) = &mut seg.sub
-				{
-					let count = match sub.poll_finished(waiter) {
-						Poll::Ready(count) => count.ok(),
-						Poll::Pending => None,
-					};
-					seg.complete(count);
+				// A boundary behind the floor has nothing to serve this poll. A pure
+				// skip, deliberately: the floor can come back down (a lowered
+				// `start_at` with nothing delivered yet), so the segment must not be
+				// completed or otherwise committed past its cache.
+				if seg.last_group().is_some_and(|last| last < floor) {
+					continue;
 				}
 
 				let cap = min_some(end, seg.last_group());
@@ -1605,6 +1607,10 @@ impl Subscriber {
 
 			if let Some((index, group)) = best {
 				let sequence = group.sequence;
+				// Delivery is a cache access; a candidate merely considered is not.
+				if deliver {
+					group.cache_refresh();
+				}
 				// A copy continuing a group already handed out splices into it rather
 				// than surfacing again; step past it and look for the next sequence.
 				match self.hand_out(index, group) {
@@ -1780,7 +1786,7 @@ impl Subscriber {
 	/// handed-out group's reads may block. See [`Self::poll_seek`].
 	pub fn poll_next_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
 		let floor = self.next_sequence.max(self.min_sequence);
-		let Some(group) = ready!(self.poll_seek(floor, self.end_sequence, waiter))? else {
+		let Some(group) = ready!(self.poll_seek(floor, self.end_sequence, true, waiter))? else {
 			return Poll::Ready(Ok(None));
 		};
 		self.next_sequence = self.next_sequence.max(group.sequence.saturating_add(1));
@@ -1798,7 +1804,7 @@ impl Subscriber {
 	) -> Poll<Result<Option<group::Consumer>>> {
 		let floor = floor.max(self.min_sequence);
 		let end = min_some(end, self.end_sequence);
-		self.poll_seek(floor, end, waiter)
+		self.poll_seek(floor, end, false, waiter)
 	}
 
 	/// Return the next group with a higher sequence than any previously returned.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -373,8 +373,9 @@ impl TrackState {
 			.find(|group| !group.is_aborted());
 
 		if let Some(group) = best {
-			// Delivery is a cache access, same as the arrival-order path.
-			group.cache_refresh();
+			// Deliberately no cache refresh here: this is a pure seek, and the spliced
+			// merge consults candidates it may not deliver. The deliverer stamps the
+			// winner; a loser re-seeked every poll must not be shielded from eviction.
 			return Poll::Ready(Ok(Some(group.consume())));
 		}
 
@@ -441,7 +442,6 @@ impl TrackState {
 	/// as though it were a live replacement.
 	fn live_edge(&self, cap: Option<u64>) -> Option<Edge> {
 		let mut presentation: Option<PresentationEdge> = None;
-		let mut stamped: Vec<(u64, Timestamp)> = Vec::new();
 		for slot in self.lookup.values() {
 			if !slot.visible {
 				continue;
@@ -450,28 +450,40 @@ impl TrackState {
 			if cap.is_some_and(|cap| group.sequence > cap) || group.is_aborted() {
 				continue;
 			}
-			if let Some(timestamp) = group.timestamp() {
-				// The suffix table bounds a candidate's reach, so it wants where each group
-				// *begins*; the edge wants the newest content that exists, so it takes the
-				// newest group's latest frame.
-				stamped.push((group.sequence, timestamp));
-				if presentation.is_none_or(|edge| group.sequence > edge.sequence) {
-					presentation = Some(PresentationEdge {
-						sequence: group.sequence,
-						stamp: slot.stamp,
-						timestamp: group.latest().unwrap_or(timestamp),
-					});
-				}
+			// The edge wants the newest content that exists, so it takes the newest
+			// stamped group's latest frame.
+			if let Some(timestamp) = group.timestamp()
+				&& presentation.is_none_or(|edge| group.sequence > edge.sequence)
+			{
+				presentation = Some(PresentationEdge {
+					sequence: group.sequence,
+					stamp: slot.stamp,
+					timestamp: group.latest().unwrap_or(timestamp),
+				});
 			}
 		}
 
-		// Sequence order, so a candidate's immediate successor is one lookup away.
-		stamped.sort_unstable_by_key(|(sequence, _)| *sequence);
+		presentation.map(|presentation| Edge { presentation, cap })
+	}
 
-		presentation.map(|presentation| Edge {
-			presentation,
-			suffix: stamped.into(),
-		})
+	/// The furthest presentation time the group at `sequence` could still reach: where
+	/// its immediate successor begins, or `None` when nothing proves where it stops.
+	///
+	/// An upper bound, deliberately. A frame's duration is not on the wire, so a group's
+	/// own last timestamp says where it *starts* presenting, not where it ends; only its
+	/// successor's start proves it cannot run past it. And only the *immediate* servable
+	/// successor counts: timestamps need not rise with sequence (a rewind reorders them),
+	/// so a later stamped group proves nothing about where an unstamped successor will
+	/// begin, and shrinking the bound is the unsafe direction. An unstamped successor
+	/// therefore leaves the reach unbounded until it presents its first frame.
+	fn reach(&self, sequence: u64, cap: Option<u64>) -> Option<Timestamp> {
+		let successor = self
+			.lookup
+			.range(sequence.saturating_add(1)..)
+			.map(|(_, slot)| slot)
+			.take_while(|slot| cap.is_none_or(|cap| slot.group.sequence <= cap))
+			.find(|slot| slot.visible && !slot.group.is_aborted())?;
+		successor.group.timestamp()
 	}
 
 	/// Whether the group at `sequence` has drifted further behind `edge` than `budget`
@@ -484,12 +496,11 @@ impl TrackState {
 	/// delivering, so a group is abandoned only once everything it could still present
 	/// falls outside the budget.
 	///
-	/// A group's reach is bounded by its nearest successor: it cannot present past where
-	/// the next group begins. Its own frames say nothing, since a frame's duration is not
-	/// on the wire and its last timestamp is where that frame *starts*. The candidate
-	/// itself needs no timestamp: an empty group is bounded by its stamped successor the
-	/// same way. Only timestamps drive expiry; wall-clock reclamation of idle content is
-	/// the cache's own policy, not the budget's.
+	/// A group's reach is bounded by its immediate successor (see [`Self::reach`]): it
+	/// cannot present past where the next group begins. The candidate itself needs no
+	/// timestamp: an empty group is bounded by its stamped successor the same way. Only
+	/// timestamps drive expiry; wall-clock reclamation of idle content is the cache's
+	/// own policy, not the budget's.
 	///
 	/// The bound is exclusive, so the comparison is `>=` rather than `>`: the freshest frame
 	/// a group could still hold sits just *below* its reach, so an age equal to the budget
@@ -511,7 +522,7 @@ impl TrackState {
 		// the same servable incarnation before it convicts a candidate. Failing safe
 		// (delivering) is right, since the next poll resolves fresh anchors.
 		let live_edge = &edge.presentation;
-		let reach = edge.reach(sequence);
+		let reach = self.reach(sequence, edge.cap);
 		live_edge.sequence > sequence
 			&& self
 				.lookup
@@ -2651,10 +2662,11 @@ impl group::Expiry for GroupExpiry {
 					break;
 				}
 
-				// A first timestamp can change the presentation-time verdict without
-				// mutating the track. Register on the candidate and every unstamped
-				// group that could supersede the current presentation edge. If one
-				// raced this scan, resolve the edge again before returning Pending.
+				// A first timestamp can change the verdict without mutating the track:
+				// on a group past the edge (a new edge), or on the candidate's
+				// unstamped immediate successor (a reach where there was none).
+				// Register on the candidate and every unstamped servable group above
+				// it. If one raced this scan, resolve the edge again before Pending.
 				let mut timestamp_raced = false;
 				if let Some(slot) = state.lookup.get(&self.sequence) {
 					let group = &slot.group;
@@ -2665,15 +2677,13 @@ impl group::Expiry for GroupExpiry {
 						timestamp_raced = true;
 					}
 				}
-				let presentation_sequence = edge
-					.as_ref()
-					.map_or(self.sequence, |edge| edge.presentation.sequence.max(self.sequence));
 				for slot in state.lookup.values() {
 					let group = &slot.group;
 					if slot.visible
-						&& group.sequence > presentation_sequence
+						&& group.sequence > self.sequence
 						&& cap.is_none_or(|cap| group.sequence <= cap)
 						&& !group.is_aborted()
+						&& group.timestamp().is_none()
 						&& group.poll_timestamp(waiter).is_ready()
 						&& group.timestamp().is_some()
 					{
@@ -2700,33 +2710,9 @@ impl group::Expiry for GroupExpiry {
 #[derive(Clone)]
 struct Edge {
 	presentation: PresentationEdge,
-	/// Every servable stamped group, sorted by sequence, paired with its own first frame
-	/// timestamp. A candidate's reach is where its immediate successor begins, so `reach()`
-	/// finds that one entry rather than rescanning, keeping a backlog walk linear.
-	///
-	/// Deliberately *not* a minimum over later groups. Timestamps need not rise with
-	/// sequence (a rewind reorders them), and a distant group starting earlier proves
-	/// nothing about where the candidate's own successor begins. Taking the minimum would
-	/// shrink the bound, which is the unsafe direction: it discards content that might
-	/// still be inside the budget. Only the immediate successor bounds a group.
-	///
-	/// Once `lookup` becomes a `BTreeMap` (it already is on main) this collapses to a
-	/// `range(sequence + 1..).next()` and the table goes away.
-	suffix: Arc<[(u64, Timestamp)]>,
-}
-
-impl Edge {
-	/// The furthest presentation time the group at `sequence` could still reach: where its
-	/// immediate successor begins, or `None` when nothing follows it yet.
-	///
-	/// An upper bound, deliberately. A frame's duration is not on the wire, so a group's
-	/// own last timestamp says where it *starts* presenting, not where it ends; only a
-	/// successor's start proves the predecessor cannot run past it. Overestimating keeps a
-	/// group longer, which is the safe direction: we abort only what is provably useless.
-	fn reach(&self, sequence: u64) -> Option<Timestamp> {
-		let index = self.suffix.partition_point(|(seq, _)| *seq <= sequence);
-		self.suffix.get(index).map(|(_, timestamp)| *timestamp)
-	}
+	/// The cap the edge was resolved under, so per-candidate reach lookups measure
+	/// against the same servable window.
+	cap: Option<u64>,
 }
 
 /// The newest servable group that has presented at least one frame.
@@ -2942,6 +2928,8 @@ impl PlainSubscriber {
 			return Poll::Ready(Ok(None));
 		};
 		self.next_sequence = group.sequence.saturating_add(1);
+		// Delivery is a cache access, same as the arrival-order path.
+		group.cache_refresh();
 		Poll::Ready(Ok(Some(self.with_expiry(group))))
 	}
 
@@ -4892,6 +4880,24 @@ mod test {
 
 		let mut sub = producer.subscribe(Subscription::default().with_max_age(Duration::from_millis(500)));
 		assert_eq!(drain(&mut sub), vec![1, 2]);
+	}
+
+	/// An unstamped immediate successor leaves a group's reach unbounded: a later
+	/// stamped group proves nothing about where the successor will begin, and
+	/// shrinking the bound is the unsafe direction.
+	#[tokio::test]
+	async fn an_unstamped_immediate_successor_leaves_reach_unbounded() {
+		let mut producer = track_producer("test", None);
+		let mut subscriber = producer.subscribe(None);
+
+		append_at(&mut producer, 0); // seq 0
+		producer.append_group().unwrap(); // seq 1 stalls before its first frame
+		append_at(&mut producer, 10_000); // seq 2
+
+		// Group 1's reach is group 2's start, a full edge behind: stale at zero budget.
+		// Group 0's reach is unknown until group 1 presents its first frame, so it is
+		// kept rather than convicted on a bound that could shrink the wrong way.
+		assert_eq!(drain(&mut subscriber), vec![0, 2]);
 	}
 
 	/// Reach is the *immediate* successor's start, never a minimum across later groups.


### PR DESCRIPTION
Follow-ups from the post-merge review round of #3099 (these fixes were verified locally but not yet pushed when that PR merged).

## Fixes

- **Reach is bounded by the immediate servable successor only.** It previously resolved to the next *stamped* group, so an unstamped immediate successor let a later group's timestamp stand in for it. Timestamps need not rise with sequence, so that shrank the bound in the unsafe direction: a rewind could expire a group whose content was still inside the budget. An unstamped successor now leaves the reach unbounded until it presents its first frame, in Rust (`TrackState::reach`, replacing the per-poll suffix table) and JS (`Subscriber.#reach`). A held group's expiry also registers on every unstamped servable group above it, so the verdict re-evaluates when the immediate successor gains its first timestamp.
- **The JS snapshot consumer collapses across a roll, not just on acquire.** A consumer holding a group with buffered deltas replayed superseded state when the producer rolled a newer snapshot group; `next()` now abandons the held group whenever a newer one exists, mirroring the Rust consumer's drain-to-newest poll.
- **Draft consistency** (`draft-lcurley-moq-lite`): the Expiration summary said age must *exceed* Max Age where the reach rule is an exclusive bound (`>=`), and the SUBSCRIBE section still told publishers to resolve `Group Start` from a group's first frame. Both now defer to the Expiration rule, keeping the promise that start selection and expiry cannot disagree.
- **`Ordered.readFrame` doc**: no longer claims it discards older groups; it rides the sequence cursor and drains the backlog like every other ordered read.

## Regression tests

- `an_unstamped_immediate_successor_leaves_reach_unbounded` (rs) / `an unstamped immediate successor leaves reach unbounded` (js)
- `a held group is abandoned when a newer snapshot group rolls` (js/json)

## Test plan

- `cargo nextest run -p moq-net`: 1014 passed. `bun test` in js/net and js/json: green. `just drafts check` passes. The full `just check` / `just test` sweep is running; CI on this PR is the gate either way.

(Written by Claude Fable 5)