### PR TITLE
feat(json): add a sliding-window mode

### DIFF
--- a/js/json/src/index.ts
+++ b/js/json/src/index.ts
@@ -5,9 +5,13 @@
  *   recent value. Intermediate updates are collapsed and older groups are dropped.
  * - {@link Stream}: **lossless**. An ordered append-log of self-contained records; every record
  *   is preserved and delivered in order, nothing is ever superseded.
+ * - {@link Window}: a **bounded** run of records, appended to the back and dropped from the front,
+ *   that a reader can join at any point.
  *
  * Pick {@link Snapshot} when consumers care about "what is the value now" (a catalog, a status
- * document) and {@link Stream} when they care about every record (an event log, a media timeline).
+ * document), {@link Stream} when they care about every record of an unbounded log, and
+ * {@link Window} when the publisher retires old records and a late reader should start from what is
+ * still retained (a media timeline).
  *
  * Each mode comes in two layers. `Producer`/`Consumer` own a track and manage its groups.
  * `Encoder`/`Decoder` are the same logic without the track: values in, frame payloads out (and
@@ -20,3 +24,4 @@
 export { type Diff, deepEqual, diff, merge } from "./diff.ts";
 export * as Snapshot from "./snapshot/index.ts";
 export * as Stream from "./stream/index.ts";
+export * as Window from "./window/index.ts";

--- a/js/json/src/index.ts
+++ b/js/json/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * JSON publishing over MoQ tracks, in two modes:
+ * JSON publishing over MoQ tracks, in three modes:
  *
  * - {@link Snapshot}: **lossy**. One JSON value updated over time; a consumer only gets the most
  *   recent value. Intermediate updates are collapsed and older groups are dropped.

--- a/js/json/src/window/consumer.ts
+++ b/js/json/src/window/consumer.ts
@@ -1,6 +1,6 @@
 import type * as Moq from "@moq/net";
 
-import { type ConsumerConfig, Decoder, type Event } from "./decoder.ts";
+import { type ConsumerConfig, Decoder, type Event, type Group } from "./decoder.ts";
 
 /**
  * Consumes a sliding window of JSON records from a track, yielding one event per change.
@@ -18,6 +18,7 @@ export class Consumer<T> {
 	#decoder: Decoder<T>;
 
 	#group?: Moq.Group.Consumer;
+	#codec?: Group;
 
 	constructor(track: Moq.Track.Subscriber, config: ConsumerConfig = {}) {
 		this.#track = track;
@@ -39,9 +40,7 @@ export class Consumer<T> {
 			if (!this.#group) {
 				this.#group = await this.#track.nextGroup();
 				if (!this.#group) return undefined;
-				// Each group is its own compressed stream, so the window starts cold. The index cursor
-				// deliberately survives, which is what makes the header report only what this reader missed.
-				this.#decoder.startGroup();
+				this.#codec = this.#decoder.group();
 			}
 
 			const frame = await this.#group.readFrame();
@@ -49,10 +48,12 @@ export class Consumer<T> {
 				// This group is exhausted. Wait for a later one, which restates the window; the stream
 				// ends only when the track does.
 				this.#group = undefined;
+				this.#codec = undefined;
 				continue;
 			}
 
-			this.#decoder.decode(frame.payload);
+			if (!this.#codec) throw new Error("an open MoQ group has a window codec");
+			this.#codec.decode(frame.payload);
 		}
 	}
 

--- a/js/json/src/window/consumer.ts
+++ b/js/json/src/window/consumer.ts
@@ -6,10 +6,10 @@ import { type ConsumerConfig, Decoder, type Event } from "./decoder.ts";
  * Consumes a sliding window of JSON records from a track, yielding one event per change.
  *
  * A {@link Decoder} that owns its track: it reads groups, starts a cold DEFLATE window at each
- * boundary, and turns each group's reset into just the changes this reader has not been told about.
+ * boundary, and turns each group's header into just the changes this reader has not been told about.
  * When something else already owns the track, use the {@link Decoder} directly.
  *
- * Group rolls never surface. A publisher rolls for compression's sake, and a reset restating the
+ * Group rolls never surface. A publisher rolls for compression's sake, and a header restating the
  * window yields nothing for records already delivered, so this reads as one continuous stream of
  * {@link Event}s regardless of how the publisher framed them.
  */
@@ -40,7 +40,7 @@ export class Consumer<T> {
 				this.#group = await this.#track.nextGroup();
 				if (!this.#group) return undefined;
 				// Each group is its own compressed stream, so the window starts cold. The index cursor
-				// deliberately survives, which is what makes the reset report only what this reader missed.
+				// deliberately survives, which is what makes the header report only what this reader missed.
 				this.#decoder.reset();
 			}
 

--- a/js/json/src/window/consumer.ts
+++ b/js/json/src/window/consumer.ts
@@ -41,7 +41,7 @@ export class Consumer<T> {
 				if (!this.#group) return undefined;
 				// Each group is its own compressed stream, so the window starts cold. The index cursor
 				// deliberately survives, which is what makes the header report only what this reader missed.
-				this.#decoder.reset();
+				this.#decoder.startGroup();
 			}
 
 			const frame = await this.#group.readFrame();

--- a/js/json/src/window/consumer.ts
+++ b/js/json/src/window/consumer.ts
@@ -1,0 +1,66 @@
+import type * as Moq from "@moq/net";
+
+import { type ConsumerConfig, Decoder, type Event } from "./decoder.ts";
+
+/**
+ * Consumes a sliding window of JSON records from a track, yielding one event per change.
+ *
+ * A {@link Decoder} that owns its track: it reads groups, starts a cold DEFLATE window at each
+ * boundary, and turns each group's reset into just the changes this reader has not been told about.
+ * When something else already owns the track, use the {@link Decoder} directly.
+ *
+ * Group rolls never surface. A publisher rolls for compression's sake, and a reset restating the
+ * window yields nothing for records already delivered, so this reads as one continuous stream of
+ * {@link Event}s regardless of how the publisher framed them.
+ */
+export class Consumer<T> {
+	#track: Moq.Track.Subscriber;
+	#decoder: Decoder<T>;
+
+	#group?: Moq.Group.Consumer;
+
+	constructor(track: Moq.Track.Subscriber, config: ConsumerConfig = {}) {
+		this.#track = track;
+		this.#decoder = new Decoder(config);
+	}
+
+	/** Absolute index of the oldest record in the window. */
+	get offset(): number {
+		return this.#decoder.offset;
+	}
+
+	/** Get the next event, or `undefined` once the track ends. */
+	async next(): Promise<Event<T> | undefined> {
+		for (;;) {
+			// Drain what the frames already decoded produced before reading more.
+			const event = this.#decoder.next();
+			if (event) return event;
+
+			if (!this.#group) {
+				this.#group = await this.#track.nextGroup();
+				if (!this.#group) return undefined;
+				// Each group is its own compressed stream, so the window starts cold. The index cursor
+				// deliberately survives, which is what makes the reset report only what this reader missed.
+				this.#decoder.reset();
+			}
+
+			const frame = await this.#group.readFrame();
+			if (frame === undefined) {
+				// This group is exhausted. Wait for a later one, which restates the window; the stream
+				// ends only when the track does.
+				this.#group = undefined;
+				continue;
+			}
+
+			this.#decoder.decode(frame.payload);
+		}
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<Event<T>> {
+		for (;;) {
+			const event = await this.next();
+			if (event === undefined) return;
+			yield event;
+		}
+	}
+}

--- a/js/json/src/window/consumer.ts
+++ b/js/json/src/window/consumer.ts
@@ -12,6 +12,8 @@ import { type ConsumerConfig, Decoder, type Event, type Group } from "./decoder.
  * Group rolls never surface. A publisher rolls for compression's sake, and a header restating the
  * window yields nothing for records already delivered, so this reads as one continuous stream of
  * {@link Event}s regardless of how the publisher framed them.
+ *
+ * @public
  */
 export class Consumer<T> {
 	#track: Moq.Track.Subscriber;
@@ -19,6 +21,7 @@ export class Consumer<T> {
 
 	#group?: Moq.Group.Consumer;
 	#codec?: Group;
+	#reading = false;
 
 	constructor(track: Moq.Track.Subscriber, config: ConsumerConfig = {}) {
 		this.#track = track;
@@ -31,7 +34,15 @@ export class Consumer<T> {
 	}
 
 	/** Get the next event, or `undefined` once the track ends. */
-	async next(): Promise<Event<T> | undefined> {
+	next(): Promise<Event<T> | undefined> {
+		if (this.#reading) throw new Error("multiple calls to next not supported");
+		this.#reading = true;
+		return this.#read().finally(() => {
+			this.#reading = false;
+		});
+	}
+
+	async #read(): Promise<Event<T> | undefined> {
 		for (;;) {
 			// Drain what the frames already decoded produced before reading more.
 			const event = this.#decoder.next();
@@ -57,6 +68,7 @@ export class Consumer<T> {
 		}
 	}
 
+	/** Iterate over events until the track ends. */
 	async *[Symbol.asyncIterator](): AsyncIterator<Event<T>> {
 		for (;;) {
 			const event = await this.next();

--- a/js/json/src/window/decoder.ts
+++ b/js/json/src/window/decoder.ts
@@ -74,7 +74,7 @@ export class Decoder<T> {
 	 * Only the group-local state resets. The index cursor deliberately survives: it is what lets the
 	 * next group's header report just the records this reader has not seen.
 	 */
-	reset(): void {
+	startGroup(): void {
 		this.#flate = undefined;
 		this.#positioned = false;
 	}

--- a/js/json/src/window/decoder.ts
+++ b/js/json/src/window/decoder.ts
@@ -28,6 +28,8 @@ export interface ConsumerConfig {
  */
 export type Event<T> = { push: { index: number; value: T } } | { pop: Span } | { skip: Span };
 
+type Queued<T> = Event<T> | { offset: number; records: T[]; next: number };
+
 /** A half-open range of absolute record indices. */
 export interface Span {
 	/** First index in the span. */
@@ -53,6 +55,8 @@ export interface Group {
  * Group rolls are invisible here on purpose. A header restates the window, and this decoder emits
  * only what is new, so a reader sees one continuous stream of edits no matter how often the
  * publisher rolled for compression's sake.
+ *
+ * @public
  */
 export class Decoder<T> {
 	#compress: boolean;
@@ -64,7 +68,7 @@ export class Decoder<T> {
 	// Next index to deliver, or undefined before the first header. A fresh consumer adopts the first
 	// header's offset rather than skipping everything that came before it.
 	#delivered?: number;
-	#events: Event<T>[] = [];
+	#events: Queued<T>[] = [];
 	#nextEvent = 0;
 
 	constructor(config: ConsumerConfig = {}) {
@@ -115,12 +119,31 @@ export class Decoder<T> {
 
 	/** Take the next event produced by the frames decoded so far. */
 	next(): Event<T> | undefined {
-		const event = this.#events[this.#nextEvent++];
-		if (this.#nextEvent >= this.#events.length) {
-			this.#events = [];
-			this.#nextEvent = 0;
+		const queued = this.#events[this.#nextEvent];
+		if (!queued) {
+			this.#clearEvents();
+			return undefined;
 		}
-		return event;
+
+		if ("records" in queued) {
+			const next = queued.next++;
+			const event = { push: { index: queued.offset + next, value: queued.records[next] as T } };
+			if (queued.next >= queued.records.length) this.#advanceEvent();
+			return event;
+		}
+
+		this.#advanceEvent();
+		return queued;
+	}
+
+	#advanceEvent(): void {
+		this.#nextEvent += 1;
+		if (this.#nextEvent >= this.#events.length) this.#clearEvents();
+	}
+
+	#clearEvents(): void {
+		this.#events = [];
+		this.#nextEvent = 0;
 	}
 
 	/** The window is exactly these records. Report what this reader missed, then what is new. */
@@ -142,10 +165,10 @@ export class Decoder<T> {
 			this.#range("skip", delivered, offset);
 		}
 
-		// Deliver only the tail this reader has not seen; a header that merely restates what it holds
-		// yields nothing at all.
-		for (let index = Math.max(delivered, offset); index < end; index++) {
-			this.#events.push({ push: { index, value: records[index - offset] as T } });
+		// Keep the unseen tail as one batch and materialize each push only when the caller asks for it.
+		const next = Math.max(delivered - offset, 0);
+		if (next < records.length) {
+			this.#events.push({ offset, records, next });
 		}
 
 		this.#front = offset;

--- a/js/json/src/window/decoder.ts
+++ b/js/json/src/window/decoder.ts
@@ -37,6 +37,12 @@ export interface Span {
 	end: number;
 }
 
+/** Decodes the frames in one MoQ group, requiring a header at frame zero. */
+export interface Group {
+	/** Decode the next frame in this group. */
+	decode(payload: Uint8Array): void;
+}
+
 /**
  * Reconstructs window events from frame payloads.
  *
@@ -50,7 +56,7 @@ export interface Span {
  */
 export class Decoder<T> {
 	#compress: boolean;
-	#flate?: Flate;
+	#generation = 0;
 
 	// Absolute index of the window's front, once a group header has positioned us.
 	#front = 0;
@@ -58,9 +64,6 @@ export class Decoder<T> {
 	// Next index to deliver, or undefined before the first header. A fresh consumer adopts the first
 	// header's offset rather than skipping everything that came before it.
 	#delivered?: number;
-	// Whether the current group header has been decoded.
-	#positioned = false;
-
 	#events: Event<T>[] = [];
 	#nextEvent = 0;
 
@@ -68,15 +71,41 @@ export class Decoder<T> {
 		this.#compress = config.compression ?? false;
 	}
 
-	/**
-	 * Start a cold DEFLATE window, for a reader that has just moved to a new group.
-	 *
-	 * Only the group-local state resets. The index cursor deliberately survives: it is what lets the
-	 * next group's header report just the records this reader has not seen.
-	 */
-	startGroup(): void {
-		this.#flate = undefined;
-		this.#positioned = false;
+	/** Create the decoder for one MoQ group. */
+	group(): Group {
+		const generation = ++this.#generation;
+		let flate: Flate | undefined;
+		let positioned = false;
+
+		return {
+			decode: (payload) => {
+				if (generation !== this.#generation) throw new Error("stale window group");
+				if (this.#compress) flate ??= new Flate();
+				const bytes = flate ? flate.frame(payload) : payload;
+				const frame = object(JSON.parse(new TextDecoder().decode(bytes)) as unknown, "window frame");
+
+				if (!positioned) {
+					if (!Array.isArray(frame.records)) throw new Error("window header records must be an array");
+					this.#applyHeader(index(frame.offset, "window offset"), frame.records as T[]);
+					positioned = true;
+					return;
+				}
+
+				const keys = Object.keys(frame);
+				if (keys.length !== 1) throw new Error("window op must contain exactly one operation");
+
+				switch (keys[0]) {
+					case "push":
+						this.#applyPush(frame.push as T);
+						break;
+					case "pop":
+						this.#applyPop(index(frame.pop, "window pop count"));
+						break;
+					default:
+						throw new Error("unrecognized window op");
+				}
+			},
+		};
 	}
 
 	/** Absolute index of the oldest record in the window. */
@@ -92,33 +121,6 @@ export class Decoder<T> {
 			this.#nextEvent = 0;
 		}
 		return event;
-	}
-
-	/** Decode one frame, queueing the events it implies. */
-	decode(payload: Uint8Array): void {
-		if (this.#compress) this.#flate ??= new Flate();
-		const bytes = this.#flate ? this.#flate.frame(payload) : payload;
-		const frame = object(JSON.parse(new TextDecoder().decode(bytes)) as unknown, "window frame");
-
-		if (!this.#positioned) {
-			if (!Array.isArray(frame.records)) throw new Error("window header records must be an array");
-			this.#applyHeader(index(frame.offset, "window offset"), frame.records as T[]);
-			return;
-		}
-
-		const keys = Object.keys(frame);
-		if (keys.length !== 1) throw new Error("window op must contain exactly one operation");
-
-		switch (keys[0]) {
-			case "push":
-				this.#applyPush(frame.push as T);
-				break;
-			case "pop":
-				this.#applyPop(index(frame.pop, "window pop count"));
-				break;
-			default:
-				throw new Error("unrecognized window op");
-		}
 	}
 
 	/** The window is exactly these records. Report what this reader missed, then what is new. */
@@ -149,7 +151,6 @@ export class Decoder<T> {
 		this.#front = offset;
 		this.#len = end - offset;
 		this.#delivered = Math.max(delivered, end);
-		this.#positioned = true;
 	}
 
 	/** One record joined the back. */

--- a/js/json/src/window/decoder.ts
+++ b/js/json/src/window/decoder.ts
@@ -41,10 +41,10 @@ export interface Span {
  * Reconstructs window events from frame payloads.
  *
  * The track-free core of {@link Consumer}. It tracks indices, not contents: it knows where the
- * window starts and how far it has delivered, which is all it needs to turn a reset into the
+ * window starts and how far it has delivered, which is all it needs to turn a header into the
  * pushes, pops, and skips the reader has not already been told about.
  *
- * Group rolls are invisible here on purpose. A reset restates the window, and this decoder emits
+ * Group rolls are invisible here on purpose. A header restates the window, and this decoder emits
  * only what is new, so a reader sees one continuous stream of edits no matter how often the
  * publisher rolled for compression's sake.
  */
@@ -52,13 +52,13 @@ export class Decoder<T> {
 	#compress: boolean;
 	#flate?: Flate;
 
-	// Absolute index of the window's front, once a reset has positioned us.
+	// Absolute index of the window's front, once a group header has positioned us.
 	#front = 0;
 	#len = 0;
-	// Next index to deliver, or undefined before the first reset. A fresh consumer adopts the first
-	// reset's offset rather than skipping everything that came before it.
+	// Next index to deliver, or undefined before the first header. A fresh consumer adopts the first
+	// header's offset rather than skipping everything that came before it.
 	#delivered?: number;
-	// Whether the current group has opened with its required reset.
+	// Whether the current group header has been decoded.
 	#positioned = false;
 
 	#events: Event<T>[] = [];
@@ -71,8 +71,8 @@ export class Decoder<T> {
 	/**
 	 * Start a cold DEFLATE window, for a reader that has just moved to a new group.
 	 *
-	 * Only the compression state resets. The index cursor deliberately survives: it is what lets the
-	 * next group's reset report just the records this reader has not seen.
+	 * Only the group-local state resets. The index cursor deliberately survives: it is what lets the
+	 * next group's header report just the records this reader has not seen.
 	 */
 	reset(): void {
 		this.#flate = undefined;
@@ -98,22 +98,23 @@ export class Decoder<T> {
 	decode(payload: Uint8Array): void {
 		if (this.#compress) this.#flate ??= new Flate();
 		const bytes = this.#flate ? this.#flate.frame(payload) : payload;
-		const op = object(JSON.parse(new TextDecoder().decode(bytes)) as unknown, "window op");
-		const keys = Object.keys(op);
+		const frame = object(JSON.parse(new TextDecoder().decode(bytes)) as unknown, "window frame");
+
+		if (!this.#positioned) {
+			if (!Array.isArray(frame.records)) throw new Error("window header records must be an array");
+			this.#applyHeader(index(frame.offset, "window offset"), frame.records as T[]);
+			return;
+		}
+
+		const keys = Object.keys(frame);
 		if (keys.length !== 1) throw new Error("window op must contain exactly one operation");
 
 		switch (keys[0]) {
-			case "reset": {
-				const reset = object(op.reset, "window reset");
-				if (!Array.isArray(reset.records)) throw new Error("window reset records must be an array");
-				this.#applyReset(index(reset.offset, "window offset"), reset.records as T[]);
-				break;
-			}
 			case "push":
-				this.#applyPush(op.push as T);
+				this.#applyPush(frame.push as T);
 				break;
 			case "pop":
-				this.#applyPop(index(op.pop, "window pop count"));
+				this.#applyPop(index(frame.pop, "window pop count"));
 				break;
 			default:
 				throw new Error("unrecognized window op");
@@ -121,8 +122,7 @@ export class Decoder<T> {
 	}
 
 	/** The window is exactly these records. Report what this reader missed, then what is new. */
-	#applyReset(offset: number, records: T[]): void {
-		if (this.#positioned) throw new Error("duplicate window reset in one group");
+	#applyHeader(offset: number, records: T[]): void {
 		const end = offset + records.length;
 		if (!Number.isSafeInteger(end)) throw new Error("window range exceeds the safe integer range");
 		let delivered = this.#delivered;
@@ -131,7 +131,7 @@ export class Decoder<T> {
 			// First position: adopt the publisher's offset rather than skipping all of history.
 			delivered = offset;
 		} else {
-			if (offset < this.#front || end < delivered) throw new Error("window reset moved backwards");
+			if (offset < this.#front || end < delivered) throw new Error("window header moved backwards");
 
 			// Records that left the window while we were away. Those we had delivered are pops; those we
 			// never saw are skips. Keep each gap compact: the offset is untrusted and may jump by far
@@ -140,7 +140,7 @@ export class Decoder<T> {
 			this.#range("skip", delivered, offset);
 		}
 
-		// Deliver only the tail this reader has not seen; a reset that merely restates what it holds
+		// Deliver only the tail this reader has not seen; a header that merely restates what it holds
 		// yields nothing at all.
 		for (let index = Math.max(delivered, offset); index < end; index++) {
 			this.#events.push({ push: { index, value: records[index - offset] as T } });
@@ -154,8 +154,7 @@ export class Decoder<T> {
 
 	/** One record joined the back. */
 	#applyPush(value: T): void {
-		// A group always opens with a reset, so a push before one means we started mid-group.
-		if (!this.#positioned || this.#delivered === undefined) throw new Error("window op before reset");
+		if (this.#delivered === undefined) throw new Error("window op before group header");
 
 		const index = this.#front + this.#len;
 		if (!Number.isSafeInteger(index + 1)) throw new Error("window range exceeds the safe integer range");
@@ -169,7 +168,7 @@ export class Decoder<T> {
 
 	/** Records left the front. */
 	#applyPop(count: number): void {
-		if (!this.#positioned || this.#delivered === undefined) throw new Error("window op before reset");
+		if (this.#delivered === undefined) throw new Error("window op before group header");
 		if (count > this.#len) {
 			throw new Error(`pop of ${count} exceeds the ${this.#len} record(s) in the window`);
 		}

--- a/js/json/src/window/decoder.ts
+++ b/js/json/src/window/decoder.ts
@@ -1,6 +1,18 @@
 import { Decoder as Flate } from "@moq/flate";
 
-import type { Op } from "./encoder.ts";
+function object(value: unknown, label: string): Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`${label} must be an object`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function index(value: unknown, label: string): number {
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+		throw new Error(`${label} must be a nonnegative safe integer`);
+	}
+	return value;
+}
 
 /** Options for a {@link Decoder}, and so for the {@link Consumer} wrapping one. */
 export interface ConsumerConfig {
@@ -11,11 +23,19 @@ export interface ConsumerConfig {
 /**
  * One change to the window, as the consumer sees it.
  *
- * Every index is reported exactly once: `push` when a record first reaches this consumer, `pop`
- * when it leaves the window, and `skip` when it existed but was dropped before this consumer ever
- * saw it.
+ * A record is `push`ed when it first reaches this consumer. Contiguous spans are `pop`ped when they
+ * leave the window or `skip`ped when they were dropped before this consumer saw them.
  */
-export type Event<T> = { push: { index: number; value: T } } | { pop: number } | { skip: number };
+export type Event<T> = { push: { index: number; value: T } } | { pop: Span } | { skip: Span };
+
+/** A half-open range of absolute record indices. */
+export interface Span {
+	/** First index in the span. */
+	start: number;
+
+	/** One past the last index in the span. */
+	end: number;
+}
 
 /**
  * Reconstructs window events from frame payloads.
@@ -38,8 +58,11 @@ export class Decoder<T> {
 	// Next index to deliver, or undefined before the first reset. A fresh consumer adopts the first
 	// reset's offset rather than skipping everything that came before it.
 	#delivered?: number;
+	// Whether the current group has opened with its required reset.
+	#positioned = false;
 
 	#events: Event<T>[] = [];
+	#nextEvent = 0;
 
 	constructor(config: ConsumerConfig = {}) {
 		this.#compress = config.compression ?? false;
@@ -53,6 +76,7 @@ export class Decoder<T> {
 	 */
 	reset(): void {
 		this.#flate = undefined;
+		this.#positioned = false;
 	}
 
 	/** Absolute index of the oldest record in the window. */
@@ -62,44 +86,58 @@ export class Decoder<T> {
 
 	/** Take the next event produced by the frames decoded so far. */
 	next(): Event<T> | undefined {
-		return this.#events.shift();
+		const event = this.#events[this.#nextEvent++];
+		if (this.#nextEvent >= this.#events.length) {
+			this.#events = [];
+			this.#nextEvent = 0;
+		}
+		return event;
 	}
 
 	/** Decode one frame, queueing the events it implies. */
 	decode(payload: Uint8Array): void {
 		if (this.#compress) this.#flate ??= new Flate();
 		const bytes = this.#flate ? this.#flate.frame(payload) : payload;
-		const op = JSON.parse(new TextDecoder().decode(bytes)) as Op<T>;
+		const op = object(JSON.parse(new TextDecoder().decode(bytes)) as unknown, "window op");
+		const keys = Object.keys(op);
+		if (keys.length !== 1) throw new Error("window op must contain exactly one operation");
 
-		if ("reset" in op) {
-			this.#applyReset(op.reset.offset, op.reset.records);
-		} else if ("push" in op) {
-			this.#applyPush(op.push);
-		} else if ("pop" in op) {
-			this.#applyPop(op.pop);
-		} else {
-			throw new Error("unrecognized window op");
+		switch (keys[0]) {
+			case "reset": {
+				const reset = object(op.reset, "window reset");
+				if (!Array.isArray(reset.records)) throw new Error("window reset records must be an array");
+				this.#applyReset(index(reset.offset, "window offset"), reset.records as T[]);
+				break;
+			}
+			case "push":
+				this.#applyPush(op.push as T);
+				break;
+			case "pop":
+				this.#applyPop(index(op.pop, "window pop count"));
+				break;
+			default:
+				throw new Error("unrecognized window op");
 		}
 	}
 
 	/** The window is exactly these records. Report what this reader missed, then what is new. */
 	#applyReset(offset: number, records: T[]): void {
+		if (this.#positioned) throw new Error("duplicate window reset in one group");
 		const end = offset + records.length;
+		if (!Number.isSafeInteger(end)) throw new Error("window range exceeds the safe integer range");
 		let delivered = this.#delivered;
 
 		if (delivered === undefined) {
 			// First position: adopt the publisher's offset rather than skipping all of history.
 			delivered = offset;
 		} else {
+			if (offset < this.#front || end < delivered) throw new Error("window reset moved backwards");
+
 			// Records that left the window while we were away. Those we had delivered are pops; those we
-			// never saw are skips. The ranges are disjoint and together cover everything that left, so
-			// every index is still reported exactly once.
-			for (let index = this.#front; index < Math.min(delivered, offset); index++) {
-				this.#events.push({ pop: index });
-			}
-			for (let index = delivered; index < offset; index++) {
-				this.#events.push({ skip: index });
-			}
+			// never saw are skips. Keep each gap compact: the offset is untrusted and may jump by far
+			// more indices than a consumer could materialize individually.
+			this.#range("pop", this.#front, Math.min(delivered, offset));
+			this.#range("skip", delivered, offset);
 		}
 
 		// Deliver only the tail this reader has not seen; a reset that merely restates what it holds
@@ -111,14 +149,16 @@ export class Decoder<T> {
 		this.#front = offset;
 		this.#len = end - offset;
 		this.#delivered = Math.max(delivered, end);
+		this.#positioned = true;
 	}
 
 	/** One record joined the back. */
 	#applyPush(value: T): void {
 		// A group always opens with a reset, so a push before one means we started mid-group.
-		if (this.#delivered === undefined) throw new Error("window op before reset");
+		if (!this.#positioned || this.#delivered === undefined) throw new Error("window op before reset");
 
 		const index = this.#front + this.#len;
+		if (!Number.isSafeInteger(index + 1)) throw new Error("window range exceeds the safe integer range");
 		this.#len += 1;
 
 		if (index >= this.#delivered) {
@@ -129,19 +169,22 @@ export class Decoder<T> {
 
 	/** Records left the front. */
 	#applyPop(count: number): void {
-		if (this.#delivered === undefined) throw new Error("window op before reset");
+		if (!this.#positioned || this.#delivered === undefined) throw new Error("window op before reset");
 		if (count > this.#len) {
 			throw new Error(`pop of ${count} exceeds the ${this.#len} record(s) in the window`);
 		}
 
-		for (let index = this.#front; index < this.#front + count; index++) {
-			// Within a group every frame is seen, so these were delivered; the skip arm only matters for
-			// a window that was already ahead of this reader.
-			this.#events.push(index < this.#delivered ? { pop: index } : { skip: index });
-		}
+		const end = this.#front + count;
+		this.#range("pop", this.#front, Math.min(this.#delivered, end));
+		this.#range("skip", Math.max(this.#delivered, this.#front), end);
 
-		this.#front += count;
+		this.#front = end;
 		this.#len -= count;
 		this.#delivered = Math.max(this.#delivered, this.#front);
+	}
+
+	#range(kind: "pop" | "skip", start: number, end: number): void {
+		if (start >= end) return;
+		this.#events.push(kind === "pop" ? { pop: { start, end } } : { skip: { start, end } });
 	}
 }

--- a/js/json/src/window/decoder.ts
+++ b/js/json/src/window/decoder.ts
@@ -1,0 +1,147 @@
+import { Decoder as Flate } from "@moq/flate";
+
+import type { Op } from "./encoder.ts";
+
+/** Options for a {@link Decoder}, and so for the {@link Consumer} wrapping one. */
+export interface ConsumerConfig {
+	/** Read frames written with `ProducerConfig.compression` on. Defaults to `false`. */
+	compression?: boolean;
+}
+
+/**
+ * One change to the window, as the consumer sees it.
+ *
+ * Every index is reported exactly once: `push` when a record first reaches this consumer, `pop`
+ * when it leaves the window, and `skip` when it existed but was dropped before this consumer ever
+ * saw it.
+ */
+export type Event<T> = { push: { index: number; value: T } } | { pop: number } | { skip: number };
+
+/**
+ * Reconstructs window events from frame payloads.
+ *
+ * The track-free core of {@link Consumer}. It tracks indices, not contents: it knows where the
+ * window starts and how far it has delivered, which is all it needs to turn a reset into the
+ * pushes, pops, and skips the reader has not already been told about.
+ *
+ * Group rolls are invisible here on purpose. A reset restates the window, and this decoder emits
+ * only what is new, so a reader sees one continuous stream of edits no matter how often the
+ * publisher rolled for compression's sake.
+ */
+export class Decoder<T> {
+	#compress: boolean;
+	#flate?: Flate;
+
+	// Absolute index of the window's front, once a reset has positioned us.
+	#front = 0;
+	#len = 0;
+	// Next index to deliver, or undefined before the first reset. A fresh consumer adopts the first
+	// reset's offset rather than skipping everything that came before it.
+	#delivered?: number;
+
+	#events: Event<T>[] = [];
+
+	constructor(config: ConsumerConfig = {}) {
+		this.#compress = config.compression ?? false;
+	}
+
+	/**
+	 * Start a cold DEFLATE window, for a reader that has just moved to a new group.
+	 *
+	 * Only the compression state resets. The index cursor deliberately survives: it is what lets the
+	 * next group's reset report just the records this reader has not seen.
+	 */
+	reset(): void {
+		this.#flate = undefined;
+	}
+
+	/** Absolute index of the oldest record in the window. */
+	get offset(): number {
+		return this.#front;
+	}
+
+	/** Take the next event produced by the frames decoded so far. */
+	next(): Event<T> | undefined {
+		return this.#events.shift();
+	}
+
+	/** Decode one frame, queueing the events it implies. */
+	decode(payload: Uint8Array): void {
+		if (this.#compress) this.#flate ??= new Flate();
+		const bytes = this.#flate ? this.#flate.frame(payload) : payload;
+		const op = JSON.parse(new TextDecoder().decode(bytes)) as Op<T>;
+
+		if ("reset" in op) {
+			this.#applyReset(op.reset.offset, op.reset.records);
+		} else if ("push" in op) {
+			this.#applyPush(op.push);
+		} else if ("pop" in op) {
+			this.#applyPop(op.pop);
+		} else {
+			throw new Error("unrecognized window op");
+		}
+	}
+
+	/** The window is exactly these records. Report what this reader missed, then what is new. */
+	#applyReset(offset: number, records: T[]): void {
+		const end = offset + records.length;
+		let delivered = this.#delivered;
+
+		if (delivered === undefined) {
+			// First position: adopt the publisher's offset rather than skipping all of history.
+			delivered = offset;
+		} else {
+			// Records that left the window while we were away. Those we had delivered are pops; those we
+			// never saw are skips. The ranges are disjoint and together cover everything that left, so
+			// every index is still reported exactly once.
+			for (let index = this.#front; index < Math.min(delivered, offset); index++) {
+				this.#events.push({ pop: index });
+			}
+			for (let index = delivered; index < offset; index++) {
+				this.#events.push({ skip: index });
+			}
+		}
+
+		// Deliver only the tail this reader has not seen; a reset that merely restates what it holds
+		// yields nothing at all.
+		for (let index = Math.max(delivered, offset); index < end; index++) {
+			this.#events.push({ push: { index, value: records[index - offset] as T } });
+		}
+
+		this.#front = offset;
+		this.#len = end - offset;
+		this.#delivered = Math.max(delivered, end);
+	}
+
+	/** One record joined the back. */
+	#applyPush(value: T): void {
+		// A group always opens with a reset, so a push before one means we started mid-group.
+		if (this.#delivered === undefined) throw new Error("window op before reset");
+
+		const index = this.#front + this.#len;
+		this.#len += 1;
+
+		if (index >= this.#delivered) {
+			this.#events.push({ push: { index, value } });
+			this.#delivered = index + 1;
+		}
+	}
+
+	/** Records left the front. */
+	#applyPop(count: number): void {
+		if (this.#delivered === undefined) throw new Error("window op before reset");
+		if (count > this.#len) {
+			throw new Error(`pop of ${count} exceeds the ${this.#len} record(s) in the window`);
+		}
+
+		for (let index = this.#front; index < this.#front + count; index++) {
+			// Within a group every frame is seen, so these were delivered; the skip arm only matters for
+			// a window that was already ahead of this reader.
+			this.#events.push(index < this.#delivered ? { pop: index } : { skip: index });
+		}
+
+		this.#front += count;
+		this.#len -= count;
+		this.#delivered = Math.max(this.#delivered, this.#front);
+	}
+}

--- a/js/json/src/window/encoder.ts
+++ b/js/json/src/window/encoder.ts
@@ -7,8 +7,7 @@ const MAX_GROUP_FRAMES = 256;
 /** Op ratio used when {@link ProducerConfig.opRatio} is left unset. */
 export const DEFAULT_OP_RATIO = 8;
 
-/** An incremental frame after the group header. */
-export type Op<T> = { push: T } | { pop: number };
+type Edit = { push: string } | { pop: number };
 
 /** Options shared by an {@link Encoder} and the {@link Producer} that wraps one. */
 export interface ProducerConfig {
@@ -48,15 +47,11 @@ export interface Encoded {
 /**
  * An encoded frame the caller has not yet acknowledged writing.
  *
- * Write the frame, then {@link commit}. A frame that never reaches the wire leaves the consumer's
- * view behind the publisher's window, so leaving it uncommitted starts a new group and the next
- * frame restates the whole window.
- *
- * The window itself is not rolled back. It is the publisher's truth and the edit really happened;
- * only the consumer's knowledge of it is lost, which the next group header repairs.
+ * Write the frame, then {@link commit}. The edit is staged until commit, so leaving the frame
+ * uncommitted keeps the window unchanged and makes the next frame open a new group.
  */
 export interface Pending extends Encoded {
-	/** Acknowledge that the frame reached the wire, keeping the encoder's state. */
+	/** Acknowledge that the frame reached the wire, applying its edit to the retained window. */
 	commit(): void;
 }
 
@@ -115,23 +110,24 @@ export class Encoder<T> {
 	}
 
 	/**
-	 * Force the next frame to open a new group with a header.
+	 * Make the next frame open a new group with a header.
 	 *
 	 * Call this whenever the caller closes the current group behind the encoder's back. The window
 	 * survives: the group header restates it in full anyway.
 	 */
-	reset(): void {
+	startGroup(): void {
 		this.#flate = undefined;
 		this.#opBytes = 0;
 		this.#headerLen = 0;
 		this.#groupFrames = 0;
 		this.#resync = true;
 		this.#pending = false;
+		this.#generation += 1;
 	}
 
 	/** Append one record to the back of the window. */
 	push(value: T): Pending {
-		this.#resync ||= this.#lost();
+		if (this.#pending) this.startGroup();
 		if (this.end >= Number.MAX_SAFE_INTEGER) throw new Error("window index exceeds the safe integer range");
 
 		// Encode before touching the window, so a value that can't be serialized leaves the encoder
@@ -141,10 +137,11 @@ export class Encoder<T> {
 			throw new Error("record is not representable as JSON");
 		}
 
-		this.#window.push(text);
-		if (this.#resync || !this.#opAllowed()) return this.#emitHeader();
+		const window = [...this.#window, text];
+		const edit: Edit = { push: text };
+		if (this.#resync || !this.#opAllowed()) return this.#emitHeader(this.#offset, window, edit);
 
-		return this.#emitOp(`{"push":${text}}`);
+		return this.#emitOp(`{"push":${text}}`, this.#offset, window, edit);
 	}
 
 	/**
@@ -157,16 +154,16 @@ export class Encoder<T> {
 		if (!Number.isSafeInteger(count) || count < 0) {
 			throw new Error("pop count must be a nonnegative safe integer");
 		}
-		this.#resync ||= this.#lost();
+		if (this.#pending) this.startGroup();
 
 		const dropped = Math.min(count, this.#window.length);
 		if (dropped <= 0) return undefined;
 
-		this.#window.splice(0, dropped);
-		this.#offset += dropped;
-
-		if (this.#resync || !this.#opAllowed()) return this.#emitHeader();
-		return this.#emitOp(`{"pop":${dropped}}`);
+		const offset = this.#offset + dropped;
+		const window = this.#window.slice(dropped);
+		const edit: Edit = { pop: dropped };
+		if (this.#resync || !this.#opAllowed()) return this.#emitHeader(offset, window, edit);
+		return this.#emitOp(`{"pop":${dropped}}`, offset, window, edit);
 	}
 
 	/** Whether the pending edit may ride as an op in the open group. */
@@ -180,22 +177,24 @@ export class Encoder<T> {
 	}
 
 	/** Compress an already-serialized op into the open group, charging it to the budget. */
-	#emitOp(text: string): Pending {
+	#emitOp(text: string, offset: number, window: string[], edit: Edit): Pending {
 		const bytes = new TextEncoder().encode(text);
 		const payload = this.#flate ? this.#flate.frame(bytes) : bytes;
 
 		this.#opBytes += payload.length;
 		this.#groupFrames += 1;
-		if (this.#headerLen + this.#opBytes > Group.MAX_GROUP_CACHE_BYTES) return this.#emitHeader();
+		if (this.#headerLen + this.#opBytes > Group.MAX_GROUP_CACHE_BYTES) {
+			return this.#emitHeader(offset, window, edit);
+		}
 
-		return this.#pendingFrame(payload, false);
+		return this.#pendingFrame(payload, false, edit);
 	}
 
 	/** Emit the header restating the whole window and opening a new group. */
-	#emitHeader(): Pending {
+	#emitHeader(offset: number, window: string[], edit: Edit): Pending {
 		// The records are already JSON text, so splice them in rather than re-encoding each one; the
 		// bytes a reader sees are then identical to what the matching push carried.
-		const text = `{"offset":${this.#offset},"records":[${this.#window.join(",")}]}`;
+		const text = `{"offset":${offset},"records":[${window.join(",")}]}`;
 		const bytes = new TextEncoder().encode(text);
 
 		// A fresh per-group encoder (cold window), with the header as frame 0.
@@ -207,10 +206,10 @@ export class Encoder<T> {
 		this.#groupFrames = 1;
 		this.#resync = false;
 
-		return this.#pendingFrame(payload, true);
+		return this.#pendingFrame(payload, true, edit);
 	}
 
-	#pendingFrame(payload: Uint8Array, keyframe: boolean): Pending {
+	#pendingFrame(payload: Uint8Array, keyframe: boolean, edit: Edit): Pending {
 		this.#pending = true;
 		const generation = ++this.#generation;
 		const encoder = this;
@@ -219,19 +218,20 @@ export class Encoder<T> {
 			payload,
 			keyframe,
 			commit() {
-				if (encoder.#generation === generation) encoder.#pending = false;
+				if (encoder.#generation !== generation || !encoder.#pending) return;
+				encoder.#commit(edit);
+				encoder.#pending = false;
 			},
 		};
 	}
 
-	/**
-	 * Whether the previous frame was handed out and never committed.
-	 *
-	 * Clears the flag, since the caller is about to be given a group header that repairs it.
-	 */
-	#lost(): boolean {
-		const lost = this.#pending;
-		this.#pending = false;
-		return lost;
+	/** Apply an edit after its encoded frame reached the wire. */
+	#commit(edit: Edit): void {
+		if ("push" in edit) {
+			this.#window.push(edit.push);
+		} else {
+			this.#window.splice(0, edit.pop);
+			this.#offset += edit.pop;
+		}
 	}
 }

--- a/js/json/src/window/encoder.ts
+++ b/js/json/src/window/encoder.ts
@@ -1,30 +1,30 @@
 import { Encoder as Flate } from "@moq/flate";
 import { Group } from "@moq/net";
 
-/** Frames (reset included) in one group before a reset is forced, matching the Snapshot cap. */
+/** Frames (header included) in one group before a new group is forced, matching the Snapshot cap. */
 const MAX_GROUP_FRAMES = 256;
 
 /** Op ratio used when {@link ProducerConfig.opRatio} is left unset. */
 export const DEFAULT_OP_RATIO = 8;
 
-/** One frame: what the publisher did to its window. */
-export type Op<T> = { reset: { offset: number; records: T[] } } | { push: T } | { pop: number };
+/** An incremental frame after the group header. */
+export type Op<T> = { push: T } | { pop: number };
 
 /** Options shared by an {@link Encoder} and the {@link Producer} that wraps one. */
 export interface ProducerConfig {
 	/**
-	 * How much the ops in a group may cost before a fresh reset is emitted.
+	 * How much the ops in a group may cost before a fresh group is emitted.
 	 *
 	 * A new group opens once the pushes and pops *already written* exceed `opRatio` times the size of
-	 * the group's reset frame. The pending op is excluded, so the one that tips the group over budget
-	 * still lands. `0` disables ops entirely, so every edit is its own single-frame reset.
+	 * the group's header frame. The pending op is excluded, so the one that tips the group over budget
+	 * still lands. `0` disables ops entirely, so every edit is its own single-frame group.
 	 *
 	 * The window's counterpart to Snapshot's `deltaRatio`. Defaults to `8`.
 	 */
 	opRatio?: number;
 
 	/**
-	 * Compress each group as one sync-flushed `deflate-raw` stream, so every op reuses the reset and
+	 * Compress each group as one sync-flushed `deflate-raw` stream, so every op reuses the header and
 	 * the ops before it as context. A {@link Decoder} reading the frames must set the same flag.
 	 * Defaults to `false`.
 	 */
@@ -37,9 +37,9 @@ export interface Encoded {
 	payload: Uint8Array;
 
 	/**
-	 * Whether this frame is a reset, which must open a new group.
+	 * Whether this frame is a group header, which must open a new group.
 	 *
-	 * The encoder decides this, never the caller: the op budget and the frame cap force a reset
+	 * The encoder decides this, never the caller: the op budget and the frame cap force a new group
 	 * independently of which edit was requested.
 	 */
 	keyframe: boolean;
@@ -49,11 +49,11 @@ export interface Encoded {
  * An encoded frame the caller has not yet acknowledged writing.
  *
  * Write the frame, then {@link commit}. A frame that never reaches the wire leaves the consumer's
- * view behind the publisher's window, so leaving it uncommitted resets the encoder and the next
+ * view behind the publisher's window, so leaving it uncommitted starts a new group and the next
  * frame restates the whole window.
  *
  * The window itself is not rolled back. It is the publisher's truth and the edit really happened;
- * only the consumer's knowledge of it is lost, which the next reset repairs.
+ * only the consumer's knowledge of it is lost, which the next group header repairs.
  */
 export interface Pending extends Encoded {
 	/** Acknowledge that the frame reached the wire, keeping the encoder's state. */
@@ -71,19 +71,19 @@ export class Encoder<T> {
 	#opRatio: number;
 	#compress: boolean;
 
-	// The retained window. Records are stored as encoded JSON text so a reset restates exactly the
+	// The retained window. Records are stored as encoded JSON text so a header restates exactly the
 	// bytes a push would have carried, and so re-encoding never re-visits the caller's value.
 	#window: string[] = [];
-	// Absolute index of #window[0]. Only a reset puts this on the wire.
+	// Absolute index of #window[0]. Only a group header puts this on the wire.
 	#offset = 0;
 
 	#flate?: Flate;
-	// Bytes of pushes and pops in this group, excluding its reset frame.
+	// Bytes of pushes and pops in this group, excluding its header frame.
 	#opBytes = 0;
-	// Reference size the op budget is measured against: this group's reset frame.
-	#resetLen = 0;
+	// Reference size the op budget is measured against: this group's header frame.
+	#headerLen = 0;
 	#groupFrames = 0;
-	// Whether the next frame must be a reset, after a lost frame or a caller-driven roll.
+	// Whether the next frame must be a header, after a lost frame or a caller-driven roll.
 	#resync = true;
 	// Whether the frame from the last push/pop is still unacknowledged.
 	#pending = false;
@@ -115,15 +115,15 @@ export class Encoder<T> {
 	}
 
 	/**
-	 * Force the next frame to be a reset.
+	 * Force the next frame to open a new group with a header.
 	 *
 	 * Call this whenever the caller closes the current group behind the encoder's back. The window
-	 * survives: the reset restates it in full anyway.
+	 * survives: the group header restates it in full anyway.
 	 */
 	reset(): void {
 		this.#flate = undefined;
 		this.#opBytes = 0;
-		this.#resetLen = 0;
+		this.#headerLen = 0;
 		this.#groupFrames = 0;
 		this.#resync = true;
 		this.#pending = false;
@@ -142,7 +142,7 @@ export class Encoder<T> {
 		}
 
 		this.#window.push(text);
-		if (this.#resync || !this.#opAllowed()) return this.#emitReset();
+		if (this.#resync || !this.#opAllowed()) return this.#emitHeader();
 
 		return this.#emitOp(`{"push":${text}}`);
 	}
@@ -165,7 +165,7 @@ export class Encoder<T> {
 		this.#window.splice(0, dropped);
 		this.#offset += dropped;
 
-		if (this.#resync || !this.#opAllowed()) return this.#emitReset();
+		if (this.#resync || !this.#opAllowed()) return this.#emitHeader();
 		return this.#emitOp(`{"pop":${dropped}}`);
 	}
 
@@ -175,7 +175,7 @@ export class Encoder<T> {
 			this.#opRatio !== 0 &&
 			this.#groupFrames > 0 &&
 			this.#groupFrames < MAX_GROUP_FRAMES &&
-			this.#opBytes <= this.#opRatio * this.#resetLen
+			this.#opBytes <= this.#opRatio * this.#headerLen
 		);
 	}
 
@@ -186,23 +186,23 @@ export class Encoder<T> {
 
 		this.#opBytes += payload.length;
 		this.#groupFrames += 1;
-		if (this.#resetLen + this.#opBytes > Group.MAX_GROUP_CACHE_BYTES) return this.#emitReset();
+		if (this.#headerLen + this.#opBytes > Group.MAX_GROUP_CACHE_BYTES) return this.#emitHeader();
 
 		return this.#pendingFrame(payload, false);
 	}
 
-	/** Emit a reset restating the whole window, opening a new group. */
-	#emitReset(): Pending {
+	/** Emit the header restating the whole window and opening a new group. */
+	#emitHeader(): Pending {
 		// The records are already JSON text, so splice them in rather than re-encoding each one; the
 		// bytes a reader sees are then identical to what the matching push carried.
-		const text = `{"reset":{"offset":${this.#offset},"records":[${this.#window.join(",")}]}}`;
+		const text = `{"offset":${this.#offset},"records":[${this.#window.join(",")}]}`;
 		const bytes = new TextEncoder().encode(text);
 
-		// A fresh per-group encoder (cold window), with the reset as frame 0.
+		// A fresh per-group encoder (cold window), with the header as frame 0.
 		this.#flate = this.#compress ? new Flate() : undefined;
 		const payload = this.#flate ? this.#flate.frame(bytes) : bytes;
 
-		this.#resetLen = payload.length;
+		this.#headerLen = payload.length;
 		this.#opBytes = 0;
 		this.#groupFrames = 1;
 		this.#resync = false;
@@ -227,7 +227,7 @@ export class Encoder<T> {
 	/**
 	 * Whether the previous frame was handed out and never committed.
 	 *
-	 * Clears the flag, since the caller is about to be given a reset that repairs it.
+	 * Clears the flag, since the caller is about to be given a group header that repairs it.
 	 */
 	#lost(): boolean {
 		const lost = this.#pending;

--- a/js/json/src/window/encoder.ts
+++ b/js/json/src/window/encoder.ts
@@ -1,4 +1,5 @@
 import { Encoder as Flate } from "@moq/flate";
+import { Group } from "@moq/net";
 
 /** Frames (reset included) in one group before a reset is forced, matching the Snapshot cap. */
 const MAX_GROUP_FRAMES = 256;
@@ -92,6 +93,9 @@ export class Encoder<T> {
 
 	constructor(config: ProducerConfig = {}) {
 		this.#opRatio = config.opRatio ?? DEFAULT_OP_RATIO;
+		if (!Number.isSafeInteger(this.#opRatio) || this.#opRatio < 0 || this.#opRatio > 0xffffffff) {
+			throw new Error("opRatio must be an unsigned 32-bit integer");
+		}
 		this.#compress = config.compression ?? false;
 	}
 
@@ -128,6 +132,7 @@ export class Encoder<T> {
 	/** Append one record to the back of the window. */
 	push(value: T): Pending {
 		this.#resync ||= this.#lost();
+		if (this.end >= Number.MAX_SAFE_INTEGER) throw new Error("window index exceeds the safe integer range");
 
 		// Encode before touching the window, so a value that can't be serialized leaves the encoder
 		// exactly as it was.
@@ -149,6 +154,9 @@ export class Encoder<T> {
 	 * Clamped to what the window holds.
 	 */
 	pop(count: number): Pending | undefined {
+		if (!Number.isSafeInteger(count) || count < 0) {
+			throw new Error("pop count must be a nonnegative safe integer");
+		}
 		this.#resync ||= this.#lost();
 
 		const dropped = Math.min(count, this.#window.length);
@@ -178,6 +186,7 @@ export class Encoder<T> {
 
 		this.#opBytes += payload.length;
 		this.#groupFrames += 1;
+		if (this.#resetLen + this.#opBytes > Group.MAX_GROUP_CACHE_BYTES) return this.#emitReset();
 
 		return this.#pendingFrame(payload, false);
 	}

--- a/js/json/src/window/encoder.ts
+++ b/js/json/src/window/encoder.ts
@@ -1,4 +1,4 @@
-import { Encoder as Flate } from "@moq/flate";
+import { DEFAULT_MAX_FRAME_SIZE, Encoder as Flate } from "@moq/flate";
 import { Group } from "@moq/net";
 
 /** Frames (header included) in one group before a new group is forced, matching the Snapshot cap. */
@@ -61,6 +61,8 @@ export interface Pending extends Encoded {
  * The track-free core of {@link Producer}. It owns the retained window, so it can restate it
  * whenever a group rolls; that restatement is the whole point of the mode, and is what an
  * append-only log cannot do.
+ *
+ * @public
  */
 export class Encoder<T> {
 	#opRatio: number;
@@ -127,16 +129,19 @@ export class Encoder<T> {
 
 		// Encode before touching the window, so a value that can't be serialized leaves the encoder
 		// exactly as it was.
-		const text = JSON.stringify(value);
+		const text: string | undefined = JSON.stringify(value);
 		if (text === undefined) {
 			throw new Error("record is not representable as JSON");
 		}
 
-		const window = [...this.#window, text];
 		const edit: Edit = { push: text };
-		if (this.#resync || !this.#opAllowed()) return this.#emitHeader(this.#offset, window, edit);
+		if (this.#resync || !this.#opAllowed()) {
+			return this.#emitHeader(this.#offset, [...this.#window, text], edit);
+		}
 
-		return this.#emitOp(`{"push":${text}}`, this.#offset, window, edit);
+		const payload = this.#emitOp(`{"push":${text}}`);
+		if (payload) return this.#pendingFrame(payload, false, edit);
+		return this.#emitHeader(this.#offset, [...this.#window, text], edit);
 	}
 
 	/**
@@ -155,10 +160,14 @@ export class Encoder<T> {
 		if (dropped <= 0) return undefined;
 
 		const offset = this.#offset + dropped;
-		const window = this.#window.slice(dropped);
 		const edit: Edit = { pop: dropped };
-		if (this.#resync || !this.#opAllowed()) return this.#emitHeader(offset, window, edit);
-		return this.#emitOp(`{"pop":${dropped}}`, offset, window, edit);
+		if (this.#resync || !this.#opAllowed()) {
+			return this.#emitHeader(offset, this.#window.slice(dropped), edit);
+		}
+
+		const payload = this.#emitOp(`{"pop":${dropped}}`);
+		if (payload) return this.#pendingFrame(payload, false, edit);
+		return this.#emitHeader(offset, this.#window.slice(dropped), edit);
 	}
 
 	/** Whether the pending edit may ride as an op in the open group. */
@@ -171,18 +180,22 @@ export class Encoder<T> {
 		);
 	}
 
-	/** Compress an already-serialized op into the open group, charging it to the budget. */
-	#emitOp(text: string, offset: number, window: string[], edit: Edit): Pending {
+	/** Compress an already-serialized op into the open group, if its header remains cached. */
+	#emitOp(text: string): Uint8Array | undefined {
 		const bytes = new TextEncoder().encode(text);
+		if (bytes.length > DEFAULT_MAX_FRAME_SIZE) {
+			throw new Error("window frame exceeds the decoder's decompressed size limit");
+		}
 		const payload = this.#flate ? this.#flate.frame(bytes) : bytes;
 
 		this.#opBytes += payload.length;
 		this.#groupFrames += 1;
 		if (this.#headerLen + this.#opBytes > Group.MAX_GROUP_CACHE_BYTES) {
-			return this.#emitHeader(offset, window, edit);
+			this.#resyncGroup();
+			return undefined;
 		}
 
-		return this.#pendingFrame(payload, false, edit);
+		return payload;
 	}
 
 	/** Emit the header restating the whole window and opening a new group. */
@@ -191,11 +204,18 @@ export class Encoder<T> {
 		// bytes a reader sees are then identical to what the matching push carried.
 		const text = `{"offset":${offset},"records":[${window.join(",")}]}`;
 		const bytes = new TextEncoder().encode(text);
+		if (bytes.length > DEFAULT_MAX_FRAME_SIZE) {
+			throw new Error("window header exceeds the decoder's decompressed size limit");
+		}
 
 		// A fresh per-group encoder (cold window), with the header as frame 0.
-		this.#flate = this.#compress ? new Flate() : undefined;
-		const payload = this.#flate ? this.#flate.frame(bytes) : bytes;
+		const flate = this.#compress ? new Flate() : undefined;
+		const payload = flate ? flate.frame(bytes) : bytes;
+		if (payload.length > Group.MAX_GROUP_CACHE_BYTES) {
+			throw new Error("window header exceeds the group cache limit");
+		}
 
+		this.#flate = flate;
 		this.#headerLen = payload.length;
 		this.#opBytes = 0;
 		this.#groupFrames = 1;

--- a/js/json/src/window/encoder.ts
+++ b/js/json/src/window/encoder.ts
@@ -78,7 +78,7 @@ export class Encoder<T> {
 	// Reference size the op budget is measured against: this group's header frame.
 	#headerLen = 0;
 	#groupFrames = 0;
-	// Whether the next frame must be a header, after a lost frame or a caller-driven roll.
+	// Whether the next frame must be a header after a lost frame.
 	#resync = true;
 	// Whether the frame from the last push/pop is still unacknowledged.
 	#pending = false;
@@ -109,13 +109,8 @@ export class Encoder<T> {
 		return this.#offset + this.#window.length;
 	}
 
-	/**
-	 * Make the next frame open a new group with a header.
-	 *
-	 * Call this whenever the caller closes the current group behind the encoder's back. The window
-	 * survives: the group header restates it in full anyway.
-	 */
-	startGroup(): void {
+	/** Discard group-local state after an encoded frame did not reach the wire. */
+	#resyncGroup(): void {
 		this.#flate = undefined;
 		this.#opBytes = 0;
 		this.#headerLen = 0;
@@ -127,7 +122,7 @@ export class Encoder<T> {
 
 	/** Append one record to the back of the window. */
 	push(value: T): Pending {
-		if (this.#pending) this.startGroup();
+		if (this.#pending) this.#resyncGroup();
 		if (this.end >= Number.MAX_SAFE_INTEGER) throw new Error("window index exceeds the safe integer range");
 
 		// Encode before touching the window, so a value that can't be serialized leaves the encoder
@@ -154,7 +149,7 @@ export class Encoder<T> {
 		if (!Number.isSafeInteger(count) || count < 0) {
 			throw new Error("pop count must be a nonnegative safe integer");
 		}
-		if (this.#pending) this.startGroup();
+		if (this.#pending) this.#resyncGroup();
 
 		const dropped = Math.min(count, this.#window.length);
 		if (dropped <= 0) return undefined;

--- a/js/json/src/window/encoder.ts
+++ b/js/json/src/window/encoder.ts
@@ -1,0 +1,228 @@
+import { Encoder as Flate } from "@moq/flate";
+
+/** Frames (reset included) in one group before a reset is forced, matching the Snapshot cap. */
+const MAX_GROUP_FRAMES = 256;
+
+/** Op ratio used when {@link ProducerConfig.opRatio} is left unset. */
+export const DEFAULT_OP_RATIO = 8;
+
+/** One frame: what the publisher did to its window. */
+export type Op<T> = { reset: { offset: number; records: T[] } } | { push: T } | { pop: number };
+
+/** Options shared by an {@link Encoder} and the {@link Producer} that wraps one. */
+export interface ProducerConfig {
+	/**
+	 * How much the ops in a group may cost before a fresh reset is emitted.
+	 *
+	 * A new group opens once the pushes and pops *already written* exceed `opRatio` times the size of
+	 * the group's reset frame. The pending op is excluded, so the one that tips the group over budget
+	 * still lands. `0` disables ops entirely, so every edit is its own single-frame reset.
+	 *
+	 * The window's counterpart to Snapshot's `deltaRatio`. Defaults to `8`.
+	 */
+	opRatio?: number;
+
+	/**
+	 * Compress each group as one sync-flushed `deflate-raw` stream, so every op reuses the reset and
+	 * the ops before it as context. A {@link Decoder} reading the frames must set the same flag.
+	 * Defaults to `false`.
+	 */
+	compression?: boolean;
+}
+
+/** One encoded frame, and the group boundary it implies. */
+export interface Encoded {
+	/** The frame payload. */
+	payload: Uint8Array;
+
+	/**
+	 * Whether this frame is a reset, which must open a new group.
+	 *
+	 * The encoder decides this, never the caller: the op budget and the frame cap force a reset
+	 * independently of which edit was requested.
+	 */
+	keyframe: boolean;
+}
+
+/**
+ * An encoded frame the caller has not yet acknowledged writing.
+ *
+ * Write the frame, then {@link commit}. A frame that never reaches the wire leaves the consumer's
+ * view behind the publisher's window, so leaving it uncommitted resets the encoder and the next
+ * frame restates the whole window.
+ *
+ * The window itself is not rolled back. It is the publisher's truth and the edit really happened;
+ * only the consumer's knowledge of it is lost, which the next reset repairs.
+ */
+export interface Pending extends Encoded {
+	/** Acknowledge that the frame reached the wire, keeping the encoder's state. */
+	commit(): void;
+}
+
+/**
+ * Encodes window edits into frame payloads, deciding where the group boundaries fall.
+ *
+ * The track-free core of {@link Producer}. It owns the retained window, so it can restate it
+ * whenever a group rolls; that restatement is the whole point of the mode, and is what an
+ * append-only log cannot do.
+ */
+export class Encoder<T> {
+	#opRatio: number;
+	#compress: boolean;
+
+	// The retained window. Records are stored as encoded JSON text so a reset restates exactly the
+	// bytes a push would have carried, and so re-encoding never re-visits the caller's value.
+	#window: string[] = [];
+	// Absolute index of #window[0]. Only a reset puts this on the wire.
+	#offset = 0;
+
+	#flate?: Flate;
+	// Bytes of pushes and pops in this group, excluding its reset frame.
+	#opBytes = 0;
+	// Reference size the op budget is measured against: this group's reset frame.
+	#resetLen = 0;
+	#groupFrames = 0;
+	// Whether the next frame must be a reset, after a lost frame or a caller-driven roll.
+	#resync = true;
+	// Whether the frame from the last push/pop is still unacknowledged.
+	#pending = false;
+	// Bumped per frame handed out, so a commit arriving after the encoder moved on cannot clear the
+	// flag belonging to a newer frame.
+	#generation = 0;
+
+	constructor(config: ProducerConfig = {}) {
+		this.#opRatio = config.opRatio ?? DEFAULT_OP_RATIO;
+		this.#compress = config.compression ?? false;
+	}
+
+	/** The retained window, oldest first. */
+	get window(): T[] {
+		return this.#window.map((text) => JSON.parse(text) as T);
+	}
+
+	/** Absolute index of the oldest retained record. */
+	get offset(): number {
+		return this.#offset;
+	}
+
+	/** Absolute index the next pushed record will take. */
+	get end(): number {
+		return this.#offset + this.#window.length;
+	}
+
+	/**
+	 * Force the next frame to be a reset.
+	 *
+	 * Call this whenever the caller closes the current group behind the encoder's back. The window
+	 * survives: the reset restates it in full anyway.
+	 */
+	reset(): void {
+		this.#flate = undefined;
+		this.#opBytes = 0;
+		this.#resetLen = 0;
+		this.#groupFrames = 0;
+		this.#resync = true;
+		this.#pending = false;
+	}
+
+	/** Append one record to the back of the window. */
+	push(value: T): Pending {
+		this.#resync ||= this.#lost();
+
+		// Encode before touching the window, so a value that can't be serialized leaves the encoder
+		// exactly as it was.
+		const text = JSON.stringify(value);
+		if (text === undefined) {
+			throw new Error("record is not representable as JSON");
+		}
+
+		this.#window.push(text);
+		if (this.#resync || !this.#opAllowed()) return this.#emitReset();
+
+		return this.#emitOp(`{"push":${text}}`);
+	}
+
+	/**
+	 * Drop `count` records from the front of the window.
+	 *
+	 * Returns `undefined` when there is nothing to drop, so a caller can trim unconditionally.
+	 * Clamped to what the window holds.
+	 */
+	pop(count: number): Pending | undefined {
+		this.#resync ||= this.#lost();
+
+		const dropped = Math.min(count, this.#window.length);
+		if (dropped <= 0) return undefined;
+
+		this.#window.splice(0, dropped);
+		this.#offset += dropped;
+
+		if (this.#resync || !this.#opAllowed()) return this.#emitReset();
+		return this.#emitOp(`{"pop":${dropped}}`);
+	}
+
+	/** Whether the pending edit may ride as an op in the open group. */
+	#opAllowed(): boolean {
+		return (
+			this.#opRatio !== 0 &&
+			this.#groupFrames > 0 &&
+			this.#groupFrames < MAX_GROUP_FRAMES &&
+			this.#opBytes <= this.#opRatio * this.#resetLen
+		);
+	}
+
+	/** Compress an already-serialized op into the open group, charging it to the budget. */
+	#emitOp(text: string): Pending {
+		const bytes = new TextEncoder().encode(text);
+		const payload = this.#flate ? this.#flate.frame(bytes) : bytes;
+
+		this.#opBytes += payload.length;
+		this.#groupFrames += 1;
+
+		return this.#pendingFrame(payload, false);
+	}
+
+	/** Emit a reset restating the whole window, opening a new group. */
+	#emitReset(): Pending {
+		// The records are already JSON text, so splice them in rather than re-encoding each one; the
+		// bytes a reader sees are then identical to what the matching push carried.
+		const text = `{"reset":{"offset":${this.#offset},"records":[${this.#window.join(",")}]}}`;
+		const bytes = new TextEncoder().encode(text);
+
+		// A fresh per-group encoder (cold window), with the reset as frame 0.
+		this.#flate = this.#compress ? new Flate() : undefined;
+		const payload = this.#flate ? this.#flate.frame(bytes) : bytes;
+
+		this.#resetLen = payload.length;
+		this.#opBytes = 0;
+		this.#groupFrames = 1;
+		this.#resync = false;
+
+		return this.#pendingFrame(payload, true);
+	}
+
+	#pendingFrame(payload: Uint8Array, keyframe: boolean): Pending {
+		this.#pending = true;
+		const generation = ++this.#generation;
+		const encoder = this;
+
+		return {
+			payload,
+			keyframe,
+			commit() {
+				if (encoder.#generation === generation) encoder.#pending = false;
+			},
+		};
+	}
+
+	/**
+	 * Whether the previous frame was handed out and never committed.
+	 *
+	 * Clears the flag, since the caller is about to be given a reset that repairs it.
+	 */
+	#lost(): boolean {
+		const lost = this.#pending;
+		this.#pending = false;
+		return lost;
+	}
+}

--- a/js/json/src/window/index.ts
+++ b/js/json/src/window/index.ts
@@ -11,20 +11,19 @@
  * new ones, so a reader that was keeping up receives them twice. This mode exists to make the
  * restatement explicit, so a reader can tell "you already have these" from "here is another one".
  *
- * Every frame is a tagged op. Each group opens with a `reset` naming the retained records and the
- * absolute `offset` of the first, followed by `push` and `pop` ops. Only the reset carries an index:
- * a push takes the next one and a pop drops from the front, both positional against the reset, which
- * is sound because the group-scoped DEFLATE window already makes a mid-group join undecodable.
+ * The first frame of every group names the retained `records` and the absolute `offset` of the
+ * first. Later frames are tagged `push` and `pop` ops. A push takes the next index and a pop drops
+ * from the front, both positional against the group header.
  * Trimming is therefore an op, not a group boundary, so dropping a record costs one small frame
  * inside the shared compression window instead of a roll that would throw that window away.
  *
  * The publisher rolls a group when the ops in it outgrow {@link ProducerConfig.opRatio} times the
- * reset that opened it. That is purely a compression decision: there is no caller-driven cut and no
+ * header that opened it. That is purely a compression decision: there is no caller-driven cut and no
  * age bound, and a {@link Consumer} never surfaces it.
  *
  * A reader gets a `push` event when a record arrives, `pop` when a contiguous span leaves, and
  * `skip` when a span was dropped before this reader saw it. A reader that keeps up sees pushes and
- * pops; one that falls a group behind learns from the reset's offset which records it will never
+ * pops; one that falls a group behind learns from the header's offset which records it will never
  * get rather than silently missing them.
  *
  * {@link Producer} and {@link Consumer} own a track. {@link Encoder} and {@link Decoder} are the

--- a/js/json/src/window/index.ts
+++ b/js/json/src/window/index.ts
@@ -22,10 +22,10 @@
  * reset that opened it. That is purely a compression decision: there is no caller-driven cut and no
  * age bound, and a {@link Consumer} never surfaces it.
  *
- * Every index is reported exactly once: a `push` event when a record arrives, `pop` when it leaves,
- * and `skip` when it existed but was dropped before this reader saw it. A reader that keeps up sees
- * pushes and pops; one that joins late, or falls a group behind, learns from the reset's offset
- * which records it will never get rather than silently missing them.
+ * A reader gets a `push` event when a record arrives, `pop` when a contiguous span leaves, and
+ * `skip` when a span was dropped before this reader saw it. A reader that keeps up sees pushes and
+ * pops; one that falls a group behind learns from the reset's offset which records it will never
+ * get rather than silently missing them.
  *
  * {@link Producer} and {@link Consumer} own a track. {@link Encoder} and {@link Decoder} are the
  * same logic without it, for when something else is already in charge of the track.
@@ -34,6 +34,6 @@
  */
 
 export { Consumer } from "./consumer.ts";
-export { type ConsumerConfig, Decoder, type Event } from "./decoder.ts";
+export { type ConsumerConfig, Decoder, type Event, type Span } from "./decoder.ts";
 export { type Encoded, Encoder, type Op, type Pending, type ProducerConfig } from "./encoder.ts";
 export { Producer } from "./producer.ts";

--- a/js/json/src/window/index.ts
+++ b/js/json/src/window/index.ts
@@ -34,6 +34,6 @@
  */
 
 export { Consumer } from "./consumer.ts";
-export { type ConsumerConfig, Decoder, type Event, type Span } from "./decoder.ts";
+export { type ConsumerConfig, Decoder, type Event, type Group, type Span } from "./decoder.ts";
 export { type Encoded, Encoder, type Pending, type ProducerConfig } from "./encoder.ts";
 export { Producer } from "./producer.ts";

--- a/js/json/src/window/index.ts
+++ b/js/json/src/window/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Sliding-window JSON publishing over MoQ tracks.
+ *
+ * A window is an ordered run of records the publisher appends to the back of and drops from the
+ * front of. Unlike the `Stream` module, which preserves a log forever in one group, and `Snapshot`,
+ * which keeps only the latest value, a window keeps a bounded stretch of records and lets a reader
+ * join it at any point. Interoperable on the wire with the Rust `moq_json::window`.
+ *
+ * The obvious alternative is an append-only log that rolls its group and re-seeds the new one with
+ * the records it still holds. That breaks the reader: re-seeded records are indistinguishable from
+ * new ones, so a reader that was keeping up receives them twice. This mode exists to make the
+ * restatement explicit, so a reader can tell "you already have these" from "here is another one".
+ *
+ * Every frame is a tagged op. Each group opens with a `reset` naming the retained records and the
+ * absolute `offset` of the first, followed by `push` and `pop` ops. Only the reset carries an index:
+ * a push takes the next one and a pop drops from the front, both positional against the reset, which
+ * is sound because the group-scoped DEFLATE window already makes a mid-group join undecodable.
+ * Trimming is therefore an op, not a group boundary, so dropping a record costs one small frame
+ * inside the shared compression window instead of a roll that would throw that window away.
+ *
+ * The publisher rolls a group when the ops in it outgrow {@link ProducerConfig.opRatio} times the
+ * reset that opened it. That is purely a compression decision: there is no caller-driven cut and no
+ * age bound, and a {@link Consumer} never surfaces it.
+ *
+ * Every index is reported exactly once: a `push` event when a record arrives, `pop` when it leaves,
+ * and `skip` when it existed but was dropped before this reader saw it. A reader that keeps up sees
+ * pushes and pops; one that joins late, or falls a group behind, learns from the reset's offset
+ * which records it will never get rather than silently missing them.
+ *
+ * {@link Producer} and {@link Consumer} own a track. {@link Encoder} and {@link Decoder} are the
+ * same logic without it, for when something else is already in charge of the track.
+ *
+ * @module
+ */
+
+export { Consumer } from "./consumer.ts";
+export { type ConsumerConfig, Decoder, type Event } from "./decoder.ts";
+export { type Encoded, Encoder, type Op, type Pending, type ProducerConfig } from "./encoder.ts";
+export { Producer } from "./producer.ts";

--- a/js/json/src/window/index.ts
+++ b/js/json/src/window/index.ts
@@ -14,6 +14,7 @@
  * The first frame of every group names the retained `records` and the absolute `offset` of the
  * first. Later frames are tagged `push` and `pop` ops. A push takes the next index and a pop drops
  * from the front, both positional against the group header.
+ * Indices stop at `Number.MAX_SAFE_INTEGER`, matching the Rust implementation's wire domain.
  * Trimming is therefore an op, not a group boundary, so dropping a record costs one small frame
  * inside the shared compression window instead of a roll that would throw that window away.
  *
@@ -34,5 +35,5 @@
 
 export { Consumer } from "./consumer.ts";
 export { type ConsumerConfig, Decoder, type Event, type Span } from "./decoder.ts";
-export { type Encoded, Encoder, type Op, type Pending, type ProducerConfig } from "./encoder.ts";
+export { type Encoded, Encoder, type Pending, type ProducerConfig } from "./encoder.ts";
 export { Producer } from "./producer.ts";

--- a/js/json/src/window/producer.ts
+++ b/js/json/src/window/producer.ts
@@ -7,14 +7,14 @@ import { type Encoded, Encoder, type ProducerConfig } from "./encoder.ts";
  * Publishes a sliding window of JSON records to a track.
  *
  * An {@link Encoder} that owns its track: it writes each encoded frame and rolls a group whenever
- * the encoder emits a reset. When something else already owns the track, use the {@link Encoder}
+ * the encoder emits a header. When something else already owns the track, use the {@link Encoder}
  * directly.
  */
 export class Producer<T> {
 	#track: Moq.Track.Producer;
 	#encoder: Encoder<T>;
 
-	// The group an op would be appended to, open between resets.
+	// The group an op would be appended to, open after a header.
 	#group?: Moq.Group.Producer;
 
 	/** Wrap a track to publish a window into it. */

--- a/js/json/src/window/producer.ts
+++ b/js/json/src/window/producer.ts
@@ -9,6 +9,8 @@ import { type Encoded, Encoder, type ProducerConfig } from "./encoder.ts";
  * An {@link Encoder} that owns its track: it writes each encoded frame and rolls a group whenever
  * the encoder emits a header. When something else already owns the track, use the {@link Encoder}
  * directly.
+ *
+ * @public
  */
 export class Producer<T> {
 	#track: Moq.Track.Producer;

--- a/js/json/src/window/producer.ts
+++ b/js/json/src/window/producer.ts
@@ -1,0 +1,93 @@
+import type * as Moq from "@moq/net";
+import { Time } from "@moq/net";
+
+import { type Encoded, Encoder, type ProducerConfig } from "./encoder.ts";
+
+/**
+ * Publishes a sliding window of JSON records to a track.
+ *
+ * An {@link Encoder} that owns its track: it writes each encoded frame and rolls a group whenever
+ * the encoder emits a reset. When something else already owns the track, use the {@link Encoder}
+ * directly.
+ */
+export class Producer<T> {
+	#track: Moq.Track.Producer;
+	#encoder: Encoder<T>;
+
+	// The group an op would be appended to, open between resets.
+	#group?: Moq.Group.Producer;
+
+	/** Wrap a track to publish a window into it. */
+	constructor(track: Moq.Track.Producer, config: ProducerConfig = {}) {
+		this.#track = track;
+		this.#encoder = new Encoder(config);
+	}
+
+	/** The retained window, oldest first. */
+	get window(): T[] {
+		return this.#encoder.window;
+	}
+
+	/** Absolute index of the oldest retained record. */
+	get offset(): number {
+		return this.#encoder.offset;
+	}
+
+	/** Append one record to the back of the window. */
+	push(value: T): void {
+		this.#write(this.#encoder.push(value));
+	}
+
+	/**
+	 * Drop `count` records from the front of the window.
+	 *
+	 * A no-op when the window is already empty, and clamped to what it holds, so a caller can trim
+	 * unconditionally.
+	 */
+	pop(count: number): void {
+		const frame = this.#encoder.pop(count);
+		if (frame) this.#write(frame);
+	}
+
+	#write(encoded: Encoded & { commit(): void }): void {
+		// A throw here leaves the frame uncommitted, so the next edit restates the whole window. The
+		// edit itself stands: the publisher's window really did change, and only the consumer's
+		// knowledge of it is lost.
+		if (encoded.keyframe) {
+			// The previous group is complete; no more frames will be appended to it. Drop the handle
+			// before opening the next one, so a failure below doesn't leave a closed group behind.
+			this.#group?.close();
+			this.#group = undefined;
+
+			const group = this.#track.appendGroup();
+			try {
+				group.writeFrame({ payload: encoded.payload, timestamp: Time.Timestamp.now() });
+			} catch (err) {
+				// The group carries no frames, so close it rather than leaving it open on the track. A
+				// consumer that already advanced into it would otherwise block with nothing to read.
+				group.close();
+				throw err;
+			}
+
+			this.#group = group;
+			encoded.commit();
+			return;
+		}
+
+		if (!this.#group) throw new Error("op with no open group");
+		this.#group.writeFrame({ payload: encoded.payload, timestamp: Time.Timestamp.now() });
+		encoded.commit();
+	}
+
+	/** Finish the track, closing any open group. */
+	finish(): void {
+		this.#group?.close();
+		this.#group = undefined;
+
+		// The open group goes with the track, so the encoder must not keep emitting ops into it. Any
+		// further edit fails on the closed track, but it has to fail as a track error rather than as an
+		// op with nowhere to put it.
+		this.#encoder.reset();
+		this.#track.close();
+	}
+}

--- a/js/json/src/window/producer.ts
+++ b/js/json/src/window/producer.ts
@@ -50,9 +50,8 @@ export class Producer<T> {
 	}
 
 	#write(encoded: Encoded & { commit(): void }): void {
-		// A throw here leaves the frame uncommitted, so the next edit restates the whole window. The
-		// edit itself stands: the publisher's window really did change, and only the consumer's
-		// knowledge of it is lost.
+		// A throw leaves the edit uncommitted and the retained window unchanged. The next edit opens a
+		// new group because the attempted frame advanced the group-local compression state.
 		if (encoded.keyframe) {
 			// The previous group is complete; no more frames will be appended to it. Drop the handle
 			// before opening the next one, so a failure below doesn't leave a closed group behind.
@@ -87,7 +86,7 @@ export class Producer<T> {
 		// The open group goes with the track, so the encoder must not keep emitting ops into it. Any
 		// further edit fails on the closed track, but it has to fail as a track error rather than as an
 		// op with nowhere to put it.
-		this.#encoder.reset();
+		this.#encoder.startGroup();
 		this.#track.close();
 	}
 }

--- a/js/json/src/window/producer.ts
+++ b/js/json/src/window/producer.ts
@@ -15,6 +15,7 @@ import { type Encoded, Encoder, type ProducerConfig } from "./encoder.ts";
 export class Producer<T> {
 	#track: Moq.Track.Producer;
 	#encoder: Encoder<T>;
+	#finished = false;
 
 	// The group an op would be appended to, open after a header.
 	#group?: Moq.Group.Producer;
@@ -37,6 +38,7 @@ export class Producer<T> {
 
 	/** Append one record to the back of the window. */
 	push(value: T): void {
+		this.#assertOpen();
 		this.#write(this.#encoder.push(value));
 	}
 
@@ -47,8 +49,13 @@ export class Producer<T> {
 	 * unconditionally.
 	 */
 	pop(count: number): void {
+		this.#assertOpen();
 		const frame = this.#encoder.pop(count);
 		if (frame) this.#write(frame);
+	}
+
+	#assertOpen(): void {
+		if (this.#finished) throw new Error("track is closed");
 	}
 
 	#write(encoded: Encoded & { commit(): void }): void {
@@ -82,6 +89,9 @@ export class Producer<T> {
 
 	/** Finish the track, closing any open group. */
 	finish(): void {
+		if (this.#finished) return;
+		this.#finished = true;
+
 		this.#group?.close();
 		this.#group = undefined;
 

--- a/js/json/src/window/producer.ts
+++ b/js/json/src/window/producer.ts
@@ -83,10 +83,6 @@ export class Producer<T> {
 		this.#group?.close();
 		this.#group = undefined;
 
-		// The open group goes with the track, so the encoder must not keep emitting ops into it. Any
-		// further edit fails on the closed track, but it has to fail as a track error rather than as an
-		// op with nowhere to put it.
-		this.#encoder.startGroup();
 		this.#track.close();
 	}
 }

--- a/js/json/src/window/vectors.test.ts
+++ b/js/json/src/window/vectors.test.ts
@@ -44,12 +44,13 @@ test("the encoder emits the shared group header bytes", () => {
 for (const vector of vectors) {
 	test(`vector decodes: ${vector.name}`, () => {
 		const decoder = new Decoder<unknown>();
+		const group = decoder.group();
 		// Every group opens with a header, so position the decoder before a bare op.
 		if (!vector.first) {
-			decoder.decode(new TextEncoder().encode('{"offset":0,"records":[{"n":0},{"n":1},{"n":2}]}'));
+			group.decode(new TextEncoder().encode('{"offset":0,"records":[{"n":0},{"n":1},{"n":2}]}'));
 			while (decoder.next());
 		}
 
-		expect(() => decoder.decode(new TextEncoder().encode(vector.frame))).not.toThrow();
+		expect(() => group.decode(new TextEncoder().encode(vector.frame))).not.toThrow();
 	});
 }

--- a/js/json/src/window/vectors.test.ts
+++ b/js/json/src/window/vectors.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { Decoder } from "./decoder.ts";
+import { Encoder } from "./encoder.ts";
+
+// Shared cross-impl fixture, owned by the reference Rust crate. This file is the wire contract
+// between the two implementations, so a change here is a format change and both suites move together.
+const url = new URL("../../../../rs/moq-json/tests/window-vectors.json", import.meta.url);
+const vectors = (await Bun.file(url).json()) as Array<{ name: string; frame: string }>;
+
+const frames = new Map(vectors.map((v) => [v.name, v.frame]));
+const text = (payload: Uint8Array) => new TextDecoder().decode(payload);
+
+// Look up a vector by name, failing loudly rather than comparing against undefined if it is renamed.
+function frame(name: string): string {
+	const found = frames.get(name);
+	if (found === undefined) throw new Error(`no vector named "${name}"`);
+	return found;
+}
+
+// Encode one frame and acknowledge it, so the encoder does not resync on the next edit.
+function commit(frame: { payload: Uint8Array; commit(): void } | undefined): string {
+	if (!frame) throw new Error("expected a frame");
+	const encoded = text(frame.payload);
+	frame.commit();
+	return encoded;
+}
+
+test("the encoder emits the shared frame bytes", () => {
+	const encoder = new Encoder<{ n: number }>();
+
+	// A fresh encoder resyncs, so the first push is a reset restating the window.
+	expect(commit(encoder.push({ n: 0 }))).toBe('{"reset":{"offset":0,"records":[{"n":0}]}}');
+	expect(commit(encoder.push({ n: 2 }))).toBe(frame("push"));
+	expect(commit(encoder.pop(1))).toBe(frame("pop one"));
+});
+
+test("the encoder emits the shared reset bytes", () => {
+	// opRatio 0 forces every edit to restate the window, which is how the reset shapes are reached.
+	const encoder = new Encoder<{ n: number }>({ opRatio: 0 });
+	commit(encoder.push({ n: 0 }));
+	expect(commit(encoder.push({ n: 1 }))).toBe(frame("reset from zero"));
+});
+
+for (const vector of vectors) {
+	test(`vector decodes: ${vector.name}`, () => {
+		const decoder = new Decoder<unknown>();
+		// Every group opens with a reset, so position the decoder before a bare op.
+		if (!vector.frame.startsWith('{"reset"')) {
+			decoder.decode(new TextEncoder().encode('{"reset":{"offset":0,"records":[{"n":0},{"n":1},{"n":2}]}}'));
+			while (decoder.next());
+		}
+
+		expect(() => decoder.decode(new TextEncoder().encode(vector.frame))).not.toThrow();
+	});
+}

--- a/js/json/src/window/vectors.test.ts
+++ b/js/json/src/window/vectors.test.ts
@@ -5,7 +5,7 @@ import { Encoder } from "./encoder.ts";
 // Shared cross-impl fixture, owned by the reference Rust crate. This file is the wire contract
 // between the two implementations, so a change here is a format change and both suites move together.
 const url = new URL("../../../../rs/moq-json/tests/window-vectors.json", import.meta.url);
-const vectors = (await Bun.file(url).json()) as Array<{ name: string; frame: string }>;
+const vectors = (await Bun.file(url).json()) as Array<{ name: string; first: boolean; frame: string }>;
 
 const frames = new Map(vectors.map((v) => [v.name, v.frame]));
 const text = (payload: Uint8Array) => new TextDecoder().decode(payload);
@@ -28,25 +28,25 @@ function commit(frame: { payload: Uint8Array; commit(): void } | undefined): str
 test("the encoder emits the shared frame bytes", () => {
 	const encoder = new Encoder<{ n: number }>();
 
-	// A fresh encoder resyncs, so the first push is a reset restating the window.
-	expect(commit(encoder.push({ n: 0 }))).toBe('{"reset":{"offset":0,"records":[{"n":0}]}}');
+	// A fresh encoder opens a group with a header restating the window.
+	expect(commit(encoder.push({ n: 0 }))).toBe('{"offset":0,"records":[{"n":0}]}');
 	expect(commit(encoder.push({ n: 2 }))).toBe(frame("push"));
 	expect(commit(encoder.pop(1))).toBe(frame("pop one"));
 });
 
-test("the encoder emits the shared reset bytes", () => {
-	// opRatio 0 forces every edit to restate the window, which is how the reset shapes are reached.
+test("the encoder emits the shared group header bytes", () => {
+	// opRatio 0 forces every edit to restate the window in a new group.
 	const encoder = new Encoder<{ n: number }>({ opRatio: 0 });
 	commit(encoder.push({ n: 0 }));
-	expect(commit(encoder.push({ n: 1 }))).toBe(frame("reset from zero"));
+	expect(commit(encoder.push({ n: 1 }))).toBe(frame("group header from zero"));
 });
 
 for (const vector of vectors) {
 	test(`vector decodes: ${vector.name}`, () => {
 		const decoder = new Decoder<unknown>();
-		// Every group opens with a reset, so position the decoder before a bare op.
-		if (!vector.frame.startsWith('{"reset"')) {
-			decoder.decode(new TextEncoder().encode('{"reset":{"offset":0,"records":[{"n":0},{"n":1},{"n":2}]}}'));
+		// Every group opens with a header, so position the decoder before a bare op.
+		if (!vector.first) {
+			decoder.decode(new TextEncoder().encode('{"offset":0,"records":[{"n":0},{"n":1},{"n":2}]}'));
 			while (decoder.next());
 		}
 

--- a/js/json/src/window/window.test.ts
+++ b/js/json/src/window/window.test.ts
@@ -204,17 +204,28 @@ test("a fresh consumer adopts the current offset", async () => {
 test("a large gap is one skip event", () => {
 	const decoder = new Decoder<unknown>();
 	decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
-	decoder.reset();
+	decoder.startGroup();
 	decoder.decode(new TextEncoder().encode(`{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}`));
 
 	expect(decoder.next()).toEqual({ skip: { start: 0, end: Number.MAX_SAFE_INTEGER } });
 	expect(decoder.next()).toBeUndefined();
 });
 
+test("indices must fit the shared safe integer range", () => {
+	let decoder = new Decoder<unknown>();
+	expect(() => decoder.decode(new TextEncoder().encode('{"offset":9007199254740992,"records":[]}'))).toThrow(
+		"nonnegative safe integer",
+	);
+
+	decoder = new Decoder<unknown>();
+	decoder.decode(new TextEncoder().encode(`{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}`));
+	expect(() => decoder.decode(new TextEncoder().encode('{"push":null}'))).toThrow("safe integer range");
+});
+
 test("every group requires a header", () => {
 	const decoder = new Decoder<unknown>();
 	decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
-	decoder.reset();
+	decoder.startGroup();
 
 	expect(() => decoder.decode(new TextEncoder().encode('{"push":null}'))).toThrow("window header records");
 });
@@ -259,4 +270,24 @@ test("an op that would evict the header rolls first", () => {
 	frame = encoder.push(next);
 	expect(frame.keyframe).toBeTrue();
 	frame.commit();
+});
+
+test("an uncommitted edit leaves the window unchanged", () => {
+	const encoder = new Encoder<number>();
+
+	const abandoned = encoder.push(1);
+	expect(encoder.window).toEqual([]);
+
+	const frame = encoder.push(2);
+	expect(frame.keyframe).toBeTrue();
+	frame.commit();
+	expect(encoder.window).toEqual([2]);
+
+	abandoned.commit();
+	expect(encoder.window).toEqual([2]);
+
+	const popped = encoder.pop(1);
+	if (!popped) throw new Error("expected a pop frame");
+	encoder.startGroup();
+	expect(encoder.window).toEqual([2]);
 });

--- a/js/json/src/window/window.test.ts
+++ b/js/json/src/window/window.test.ts
@@ -203,9 +203,8 @@ test("a fresh consumer adopts the current offset", async () => {
 
 test("a large gap is one skip event", () => {
 	const decoder = new Decoder<unknown>();
-	decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
-	decoder.startGroup();
-	decoder.decode(new TextEncoder().encode(`{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}`));
+	decoder.group().decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
+	decoder.group().decode(new TextEncoder().encode(`{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}`));
 
 	expect(decoder.next()).toEqual({ skip: { start: 0, end: Number.MAX_SAFE_INTEGER } });
 	expect(decoder.next()).toBeUndefined();
@@ -213,30 +212,37 @@ test("a large gap is one skip event", () => {
 
 test("indices must fit the shared safe integer range", () => {
 	let decoder = new Decoder<unknown>();
-	expect(() => decoder.decode(new TextEncoder().encode('{"offset":9007199254740992,"records":[]}'))).toThrow(
+	expect(() => decoder.group().decode(new TextEncoder().encode('{"offset":9007199254740992,"records":[]}'))).toThrow(
 		"nonnegative safe integer",
 	);
 
 	decoder = new Decoder<unknown>();
-	decoder.decode(new TextEncoder().encode(`{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}`));
-	expect(() => decoder.decode(new TextEncoder().encode('{"push":null}'))).toThrow("safe integer range");
+	const group = decoder.group();
+	group.decode(new TextEncoder().encode(`{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}`));
+	expect(() => group.decode(new TextEncoder().encode('{"push":null}'))).toThrow("safe integer range");
 });
 
 test("every group requires a header", () => {
 	const decoder = new Decoder<unknown>();
-	decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
-	decoder.startGroup();
+	decoder.group().decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
 
-	expect(() => decoder.decode(new TextEncoder().encode('{"push":null}'))).toThrow("window header records");
+	expect(() => decoder.group().decode(new TextEncoder().encode('{"push":null}'))).toThrow("window header records");
 });
 
 test("a header is only valid as frame zero", () => {
 	const decoder = new Decoder<unknown>();
-	decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
+	const group = decoder.group();
+	group.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
 
-	expect(() => decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'))).toThrow(
-		"exactly one operation",
-	);
+	expect(() => group.decode(new TextEncoder().encode('{"offset":0,"records":[]}'))).toThrow("exactly one operation");
+});
+
+test("an old group cannot decode after a new one starts", () => {
+	const decoder = new Decoder<unknown>();
+	const old = decoder.group();
+	decoder.group();
+
+	expect(() => old.decode(new TextEncoder().encode('{"offset":0,"records":[]}'))).toThrow("stale window group");
 });
 
 test("pop counts are nonnegative safe integers", () => {
@@ -288,6 +294,9 @@ test("an uncommitted edit leaves the window unchanged", () => {
 
 	const popped = encoder.pop(1);
 	if (!popped) throw new Error("expected a pop frame");
-	encoder.startGroup();
-	expect(encoder.window).toEqual([2]);
+	const next = encoder.push(3);
+	expect(next.keyframe).toBeTrue();
+	next.commit();
+	popped.commit();
+	expect(encoder.window).toEqual([2, 3]);
 });

--- a/js/json/src/window/window.test.ts
+++ b/js/json/src/window/window.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { Track } from "@moq/net";
 import { Consumer } from "./consumer.ts";
-import { type Event, Producer } from "./index.ts";
+import { Decoder, Encoder, type Event, Producer, type Span } from "./index.ts";
 
 type Rec = { n: number };
 
@@ -55,6 +55,7 @@ class Live {
 }
 
 const pushed = (events: Event<Rec>[]): number[] => events.flatMap((e) => ("push" in e ? [e.push.index] : []));
+const span = ({ start, end }: Span): number[] => Array.from({ length: end - start }, (_, i) => start + i);
 
 test("push and pop round-trip", async () => {
 	const live = new Live();
@@ -66,7 +67,7 @@ test("push and pop round-trip", async () => {
 	expect(await live.finish()).toEqual([
 		{ push: { index: 0, value: { n: 0 } } },
 		{ push: { index: 1, value: { n: 1 } } },
-		{ pop: 0 },
+		{ pop: { start: 0, end: 1 } },
 		{ push: { index: 2, value: { n: 2 } } },
 	]);
 });
@@ -84,7 +85,7 @@ test("a popped record is never restated", async () => {
 	expect(await live.finish()).toEqual([
 		{ push: { index: 0, value: { n: 0 } } },
 		{ push: { index: 1, value: { n: 1 } } },
-		{ pop: 0 },
+		{ pop: { start: 0, end: 1 } },
 		{ push: { index: 2, value: { n: 2 } } },
 	]);
 });
@@ -134,7 +135,7 @@ test("a pop is clamped to the window", async () => {
 
 	expect(await live.finish()).toEqual([
 		{ push: { index: 0, value: { n: 0 } } },
-		{ pop: 0 },
+		{ pop: { start: 0, end: 1 } },
 		{ push: { index: 1, value: { n: 1 } } },
 	]);
 });
@@ -155,7 +156,8 @@ test("a lagging consumer is told what it missed", async () => {
 	const producer = new Producer<Rec>(track, { opRatio: 0 });
 	const live = new Live();
 	live.producer = producer;
-	live.consumer = new Consumer<Rec>(track.subscribe());
+	const subscriber = track.subscribe();
+	live.consumer = new Consumer<Rec>(subscriber);
 
 	await live.push(0);
 	await live.push(1);
@@ -166,15 +168,83 @@ test("a lagging consumer is told what it missed", async () => {
 		producer.push({ n });
 		producer.pop(1);
 	}
+	subscriber.startAt(subscriber.latest() as number);
 	const events = await live.finish();
 
-	const skipped = events.flatMap((e) => ("skip" in e ? [e.skip] : []));
+	const skipped = events.flatMap((e) => ("skip" in e ? span(e.skip) : []));
 	expect(skipped.length).toBeGreaterThan(0);
 	expect(skipped[0]).toBe(2);
 
 	// Every index is still accounted for exactly once, in order.
-	const reported = events.flatMap((e) => ("push" in e ? [e.push.index] : "skip" in e ? [e.skip] : []));
+	const reported = events.flatMap((e) => ("push" in e ? [e.push.index] : "skip" in e ? span(e.skip) : []));
 	for (let i = 1; i < reported.length; i++) {
 		expect(reported[i]).toBe((reported[i - 1] as number) + 1);
 	}
+});
+
+test("a fresh consumer adopts the current offset", async () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<Rec>(track, { opRatio: 0 });
+	for (let n = 0; n < 5; n++) producer.push({ n });
+	producer.pop(3);
+
+	const subscriber = track.subscribe();
+	subscriber.startAt(subscriber.latest() as number);
+	const consumer = new Consumer<Rec>(subscriber);
+	producer.finish();
+	const events: Event<Rec>[] = [];
+	for await (const event of consumer) events.push(event);
+
+	expect(events).toEqual([{ push: { index: 3, value: { n: 3 } } }, { push: { index: 4, value: { n: 4 } } }]);
+});
+
+test("a large gap is one skip event", () => {
+	const decoder = new Decoder<unknown>();
+	decoder.decode(new TextEncoder().encode('{"reset":{"offset":0,"records":[]}}'));
+	decoder.reset();
+	decoder.decode(new TextEncoder().encode(`{"reset":{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}}`));
+
+	expect(decoder.next()).toEqual({ skip: { start: 0, end: Number.MAX_SAFE_INTEGER } });
+	expect(decoder.next()).toBeUndefined();
+});
+
+test("every group requires a reset", () => {
+	const decoder = new Decoder<unknown>();
+	decoder.decode(new TextEncoder().encode('{"reset":{"offset":0,"records":[]}}'));
+	decoder.reset();
+
+	expect(() => decoder.decode(new TextEncoder().encode('{"push":null}'))).toThrow("window op before reset");
+});
+
+test("pop counts are nonnegative safe integers", () => {
+	const encoder = new Encoder<unknown>();
+	for (const count of [-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+		expect(() => encoder.pop(count)).toThrow("pop count must be a nonnegative safe integer");
+	}
+	expect(encoder.offset).toBe(0);
+	expect(encoder.window).toEqual([]);
+});
+
+test("an op that would evict the reset rolls first", () => {
+	const encoder = new Encoder<string>({ opRatio: 0xffffffff });
+	const first = "a".repeat(16 * 1024 * 1024);
+	const next = "b".repeat(15 * 1024 * 1024);
+
+	let frame = encoder.push(first);
+	expect(frame.keyframe).toBeTrue();
+	frame.commit();
+
+	frame = encoder.push(next);
+	expect(frame.keyframe).toBeFalse();
+	frame.commit();
+
+	const popped = encoder.pop(1);
+	if (!popped) throw new Error("expected a pop frame");
+	frame = popped;
+	expect(frame.keyframe).toBeFalse();
+	frame.commit();
+
+	frame = encoder.push(next);
+	expect(frame.keyframe).toBeTrue();
+	frame.commit();
 });

--- a/js/json/src/window/window.test.ts
+++ b/js/json/src/window/window.test.ts
@@ -1,0 +1,180 @@
+import { expect, test } from "bun:test";
+import { Track } from "@moq/net";
+import { Consumer } from "./consumer.ts";
+import { type Event, Producer } from "./index.ts";
+
+type Rec = { n: number };
+
+/**
+ * A producer and a consumer that reads after every edit.
+ *
+ * Polling as the publisher goes is what "keeping up" means: a consumer left until the end is a whole
+ * group behind, and the default subscription abandons a group as soon as a newer one exists, so it
+ * would resume at the newest reset instead of reading the rolls in between.
+ */
+class Live {
+	producer: Producer<Rec>;
+	consumer: Consumer<Rec>;
+	events: Event<Rec>[] = [];
+
+	constructor(config: { opRatio?: number; compression?: boolean } = {}) {
+		const track = new Track.Producer("test");
+		this.producer = new Producer<Rec>(track, config);
+		this.consumer = new Consumer<Rec>(track.subscribe(), { compression: config.compression });
+	}
+
+	async push(n: number): Promise<void> {
+		this.producer.push({ n });
+		await this.read();
+	}
+
+	async pop(count: number): Promise<void> {
+		this.producer.pop(count);
+		await this.read();
+	}
+
+	// Drain whatever is decodable right now. `next()` blocks once the queue is empty, so race it
+	// against a turn of the event loop rather than awaiting it directly.
+	async read(): Promise<void> {
+		for (;;) {
+			const idle = Symbol("idle");
+			const event = await Promise.race([
+				this.consumer.next(),
+				new Promise<typeof idle>((resolve) => setTimeout(() => resolve(idle), 0)),
+			]);
+			if (event === idle || event === undefined) return;
+			this.events.push(event);
+		}
+	}
+
+	async finish(): Promise<Event<Rec>[]> {
+		this.producer.finish();
+		await this.read();
+		return this.events;
+	}
+}
+
+const pushed = (events: Event<Rec>[]): number[] => events.flatMap((e) => ("push" in e ? [e.push.index] : []));
+
+test("push and pop round-trip", async () => {
+	const live = new Live();
+	await live.push(0);
+	await live.push(1);
+	await live.pop(1);
+	await live.push(2);
+
+	expect(await live.finish()).toEqual([
+		{ push: { index: 0, value: { n: 0 } } },
+		{ push: { index: 1, value: { n: 1 } } },
+		{ pop: 0 },
+		{ push: { index: 2, value: { n: 2 } } },
+	]);
+});
+
+test("a popped record is never restated", async () => {
+	// Ops disabled, so every single edit is its own reset restating the whole window.
+	const live = new Live({ opRatio: 0 });
+	await live.push(0);
+	await live.push(1);
+	await live.pop(1);
+	await live.push(2);
+
+	// Every edit restates the window, yet a record already delivered is never pushed twice. That is
+	// the property an append-only log cannot provide.
+	expect(await live.finish()).toEqual([
+		{ push: { index: 0, value: { n: 0 } } },
+		{ push: { index: 1, value: { n: 1 } } },
+		{ pop: 0 },
+		{ push: { index: 2, value: { n: 2 } } },
+	]);
+});
+
+test("rolling is invisible to the consumer", async () => {
+	// The same edits, framed two ways: one group for everything, versus a roll per edit.
+	const edits = async (opRatio: number) => {
+		const live = new Live({ opRatio });
+		for (let n = 0; n < 6; n++) {
+			await live.push(n);
+			if (n >= 3) await live.pop(1);
+		}
+		return live.finish();
+	};
+
+	expect(await edits(1000)).toEqual(await edits(0));
+});
+
+test("compressed round-trip across rolls", async () => {
+	const live = new Live({ compression: true, opRatio: 1 });
+	for (let n = 0; n < 40; n++) {
+		await live.push(n);
+		if (n >= 10) await live.pop(1);
+	}
+
+	// A tight ratio rolls many times; every record still arrives exactly once, in order.
+	expect(pushed(await live.finish())).toEqual(Array.from({ length: 40 }, (_, n) => n));
+});
+
+test("the window slides", async () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<Rec>(track);
+	for (let n = 0; n < 5; n++) {
+		producer.push({ n });
+		if (n >= 2) producer.pop(1);
+	}
+
+	expect(producer.offset).toBe(3);
+	expect(producer.window).toEqual([{ n: 3 }, { n: 4 }]);
+});
+
+test("a pop is clamped to the window", async () => {
+	const live = new Live();
+	await live.push(0);
+	await live.pop(9);
+	await live.push(1);
+
+	expect(await live.finish()).toEqual([
+		{ push: { index: 0, value: { n: 0 } } },
+		{ pop: 0 },
+		{ push: { index: 1, value: { n: 1 } } },
+	]);
+});
+
+test("an empty pop writes nothing", async () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<Rec>(track);
+	producer.pop(5);
+	producer.finish();
+
+	// Nothing was ever pushed, so there is nothing to drop and no group to publish.
+	expect(track.subscribe().latest()).toBeUndefined();
+});
+
+test("a lagging consumer is told what it missed", async () => {
+	// Ops disabled, so every edit rolls: a reader that stops polling really does lose groups.
+	const track = new Track.Producer("test");
+	const producer = new Producer<Rec>(track, { opRatio: 0 });
+	const live = new Live();
+	live.producer = producer;
+	live.consumer = new Consumer<Rec>(track.subscribe());
+
+	await live.push(0);
+	await live.push(1);
+	expect(live.events).toEqual([{ push: { index: 0, value: { n: 0 } } }, { push: { index: 1, value: { n: 1 } } }]);
+
+	// The consumer stops reading while the window slides past everything it holds.
+	for (let n = 2; n < 8; n++) {
+		producer.push({ n });
+		producer.pop(1);
+	}
+	const events = await live.finish();
+
+	const skipped = events.flatMap((e) => ("skip" in e ? [e.skip] : []));
+	expect(skipped.length).toBeGreaterThan(0);
+	expect(skipped[0]).toBe(2);
+
+	// Every index is still accounted for exactly once, in order.
+	const reported = events.flatMap((e) => ("push" in e ? [e.push.index] : "skip" in e ? [e.skip] : []));
+	for (let i = 1; i < reported.length; i++) {
+		expect(reported[i]).toBe((reported[i - 1] as number) + 1);
+	}
+});

--- a/js/json/src/window/window.test.ts
+++ b/js/json/src/window/window.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Track } from "@moq/net";
+import { Group, Track } from "@moq/net";
 import { Consumer } from "./consumer.ts";
 import { Decoder, Encoder, type Event, Producer, type Span } from "./index.ts";
 
@@ -73,6 +73,16 @@ test("push and pop round-trip", async () => {
 		{ pop: { start: 0, end: 1 } },
 		{ push: { index: 2, value: { n: 2 } } },
 	]);
+});
+
+test("concurrent consumer reads are rejected", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer<Rec>(track.subscribe());
+	const first = consumer.next();
+
+	expect(() => consumer.next()).toThrow("multiple calls to next not supported");
+	track.close();
+	expect(await first).toBeUndefined();
 });
 
 test("a popped record is never restated", async () => {
@@ -276,6 +286,16 @@ test("an op that would evict the header rolls first", () => {
 	frame = encoder.push(next);
 	expect(frame.keyframe).toBeTrue();
 	frame.commit();
+});
+
+test("a header larger than the group cache is rejected", () => {
+	const encoder = new Encoder<string>();
+
+	expect(() => encoder.push("x".repeat(Group.MAX_GROUP_CACHE_BYTES))).toThrow("group cache limit");
+	expect(encoder.window).toEqual([]);
+
+	const frame = encoder.push("ok");
+	expect(frame.keyframe).toBeTrue();
 });
 
 test("an uncommitted edit leaves the window unchanged", () => {

--- a/js/json/src/window/window.test.ts
+++ b/js/json/src/window/window.test.ts
@@ -85,6 +85,17 @@ test("concurrent consumer reads are rejected", async () => {
 	expect(await first).toBeUndefined();
 });
 
+test("writes after finish are rejected before encoding", () => {
+	const track = new Track.Producer("test");
+	const producer = new Producer<number>(track);
+	producer.push(1);
+	producer.finish();
+
+	expect(() => producer.push(2)).toThrow("track is closed");
+	expect(() => producer.pop(1)).toThrow("track is closed");
+	expect(producer.window).toEqual([1]);
+});
+
 test("a popped record is never restated", async () => {
 	// Ops disabled, so every single edit is its own group restating the whole window.
 	const live = new Live({ opRatio: 0 });

--- a/js/json/src/window/window.test.ts
+++ b/js/json/src/window/window.test.ts
@@ -10,12 +10,13 @@ type Rec = { n: number };
  *
  * Polling as the publisher goes is what "keeping up" means: a consumer left until the end is a whole
  * group behind, and the default subscription abandons a group as soon as a newer one exists, so it
- * would resume at the newest reset instead of reading the rolls in between.
+ * would resume at the newest header instead of reading the rolls in between.
  */
 class Live {
 	producer: Producer<Rec>;
 	consumer: Consumer<Rec>;
 	events: Event<Rec>[] = [];
+	#next?: Promise<Event<Rec> | undefined>;
 
 	constructor(config: { opRatio?: number; compression?: boolean } = {}) {
 		const track = new Track.Producer("test");
@@ -33,16 +34,18 @@ class Live {
 		await this.read();
 	}
 
-	// Drain whatever is decodable right now. `next()` blocks once the queue is empty, so race it
-	// against a turn of the event loop rather than awaiting it directly.
+	// Drain whatever is decodable right now. Keep the pending read when the timer wins, since an
+	// abandoned `next()` would still consume a later event with nobody left to observe its result.
 	async read(): Promise<void> {
 		for (;;) {
 			const idle = Symbol("idle");
+			this.#next ??= this.consumer.next();
 			const event = await Promise.race([
-				this.consumer.next(),
+				this.#next,
 				new Promise<typeof idle>((resolve) => setTimeout(() => resolve(idle), 0)),
 			]);
 			if (event === idle || event === undefined) return;
+			this.#next = undefined;
 			this.events.push(event);
 		}
 	}
@@ -73,7 +76,7 @@ test("push and pop round-trip", async () => {
 });
 
 test("a popped record is never restated", async () => {
-	// Ops disabled, so every single edit is its own reset restating the whole window.
+	// Ops disabled, so every single edit is its own group restating the whole window.
 	const live = new Live({ opRatio: 0 });
 	await live.push(0);
 	await live.push(1);
@@ -200,20 +203,29 @@ test("a fresh consumer adopts the current offset", async () => {
 
 test("a large gap is one skip event", () => {
 	const decoder = new Decoder<unknown>();
-	decoder.decode(new TextEncoder().encode('{"reset":{"offset":0,"records":[]}}'));
+	decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
 	decoder.reset();
-	decoder.decode(new TextEncoder().encode(`{"reset":{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}}`));
+	decoder.decode(new TextEncoder().encode(`{"offset":${Number.MAX_SAFE_INTEGER},"records":[]}`));
 
 	expect(decoder.next()).toEqual({ skip: { start: 0, end: Number.MAX_SAFE_INTEGER } });
 	expect(decoder.next()).toBeUndefined();
 });
 
-test("every group requires a reset", () => {
+test("every group requires a header", () => {
 	const decoder = new Decoder<unknown>();
-	decoder.decode(new TextEncoder().encode('{"reset":{"offset":0,"records":[]}}'));
+	decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
 	decoder.reset();
 
-	expect(() => decoder.decode(new TextEncoder().encode('{"push":null}'))).toThrow("window op before reset");
+	expect(() => decoder.decode(new TextEncoder().encode('{"push":null}'))).toThrow("window header records");
+});
+
+test("a header is only valid as frame zero", () => {
+	const decoder = new Decoder<unknown>();
+	decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'));
+
+	expect(() => decoder.decode(new TextEncoder().encode('{"offset":0,"records":[]}'))).toThrow(
+		"exactly one operation",
+	);
 });
 
 test("pop counts are nonnegative safe integers", () => {
@@ -225,7 +237,7 @@ test("pop counts are nonnegative safe integers", () => {
 	expect(encoder.window).toEqual([]);
 });
 
-test("an op that would evict the reset rolls first", () => {
+test("an op that would evict the header rolls first", () => {
 	const encoder = new Encoder<string>({ opRatio: 0xffffffff });
 	const first = "a".repeat(16 * 1024 * 1024);
 	const next = "b".repeat(15 * 1024 * 1024);

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -1,12 +1,15 @@
-//! JSON publishing over [`moq-net`](moq_net) tracks, in two modes:
+//! JSON publishing over [`moq-net`](moq_net) tracks, in three modes:
 //!
 //! - [`snapshot`]: **lossy**. One JSON value updated over time; a consumer only gets the most
 //!   recent value. Intermediate updates are collapsed and older groups are dropped.
 //! - [`stream`]: **lossless**. An ordered append-log of self-contained records; every record is
 //!   preserved and delivered in order, nothing is ever superseded.
+//! - [`window`]: **bounded**. An ordered run of records appended to the back and dropped from the
+//!   front, which a reader can join at any point.
 //!
 //! Pick [`snapshot`] when consumers care about "what is the value now" (a catalog, a status
-//! document) and [`stream`] when they care about every record (an event log, a media timeline).
+//! document), [`stream`] when they care about every record of an unbounded log, and [`window`] when
+//! the publisher retires old records and a late reader should start from what is still retained.
 //!
 //! Each mode comes in two layers. `Producer`/`Consumer` own a [`moq_net`] track and manage its
 //! groups. `Encoder`/`Decoder` are the same logic without the track: values in, frame payloads out
@@ -45,13 +48,6 @@ pub enum Error {
 	/// [`snapshot::Decoder`] out of order, or a group's first frame was routed as a delta.
 	#[error("delta before snapshot")]
 	MissingSnapshot,
-
-	/// A [`window`] push or pop arrived with no reset to apply it to.
-	///
-	/// Every group opens with a reset naming the window and its offset, so this means frames reached
-	/// [`window::Decoder`] out of order, or a reader started mid-group.
-	#[error("window op before reset")]
-	MissingReset,
 
 	/// A compressed [`stream`] frame was encoded but never written, so the shared DEFLATE window is
 	/// ahead of what the consumer holds and nothing later in this group can be decoded.

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -17,6 +17,7 @@
 mod diff;
 pub mod snapshot;
 pub mod stream;
+pub mod window;
 
 pub use crate::diff::{Diff, diff};
 
@@ -44,6 +45,13 @@ pub enum Error {
 	/// [`snapshot::Decoder`] out of order, or a group's first frame was routed as a delta.
 	#[error("delta before snapshot")]
 	MissingSnapshot,
+
+	/// A [`window`] push or pop arrived with no reset to apply it to.
+	///
+	/// Every group opens with a reset naming the window and its offset, so this means frames reached
+	/// [`window::Decoder`] out of order, or a reader started mid-group.
+	#[error("window op before reset")]
+	MissingReset,
 
 	/// A compressed [`stream`] frame was encoded but never written, so the shared DEFLATE window is
 	/// ahead of what the consumer holds and nothing later in this group can be decoded.

--- a/rs/moq-json/src/window/consumer.rs
+++ b/rs/moq-json/src/window/consumer.rs
@@ -4,6 +4,7 @@ use std::task::Poll;
 
 use serde::de::DeserializeOwned;
 
+use super::decoder::Codec;
 use super::{ConsumerConfig, Decoder, Event};
 use crate::Result;
 
@@ -19,6 +20,7 @@ use crate::Result;
 pub struct Consumer<T> {
 	track: moq_net::track::Subscriber,
 	group: Option<moq_net::group::Consumer>,
+	codec: Option<Codec>,
 	decoder: Decoder<T>,
 }
 
@@ -28,6 +30,7 @@ impl<T: DeserializeOwned> Consumer<T> {
 		Self {
 			track,
 			group: None,
+			codec: None,
 			decoder: Decoder::new(config),
 		}
 	}
@@ -56,10 +59,7 @@ impl<T: DeserializeOwned> Consumer<T> {
 			let Some(group) = &mut self.group else {
 				match self.track.poll_next_group(waiter)? {
 					Poll::Ready(Some(group)) => {
-						// Each group is its own compressed stream, so the window starts cold. The index
-						// cursor deliberately survives, which is what makes the header report only what this
-						// reader is missing.
-						self.decoder.start_group();
+						self.codec = Some(Codec::new());
 						self.group = Some(group);
 						continue;
 					}
@@ -69,11 +69,15 @@ impl<T: DeserializeOwned> Consumer<T> {
 			};
 
 			match group.poll_read_frame(waiter)? {
-				Poll::Ready(Some(frame)) => self.decoder.decode(&frame.payload)?,
+				Poll::Ready(Some(frame)) => {
+					let codec = self.codec.as_mut().expect("an open MoQ group has a window codec");
+					self.decoder.decode(codec, &frame.payload)?;
+				}
 				Poll::Ready(None) => {
 					// This group is exhausted. Clear it and poll for a later one, which restates the
 					// window; the stream ends only when the track does.
 					self.group = None;
+					self.codec = None;
 				}
 				Poll::Pending => return Poll::Pending,
 			}

--- a/rs/moq-json/src/window/consumer.rs
+++ b/rs/moq-json/src/window/consumer.rs
@@ -59,7 +59,7 @@ impl<T: DeserializeOwned> Consumer<T> {
 						// Each group is its own compressed stream, so the window starts cold. The index
 						// cursor deliberately survives, which is what makes the header report only what this
 						// reader is missing.
-						self.decoder.reset();
+						self.decoder.start_group();
 						self.group = Some(group);
 						continue;
 					}

--- a/rs/moq-json/src/window/consumer.rs
+++ b/rs/moq-json/src/window/consumer.rs
@@ -1,0 +1,82 @@
+//! Consuming a window from a track: a [`Decoder`] plus the track it reads from.
+
+use std::task::Poll;
+
+use serde::de::DeserializeOwned;
+
+use super::{ConsumerConfig, Decoder, Event};
+use crate::Result;
+
+/// Consumes a sliding window of JSON records from a track, yielding one event per change.
+///
+/// A [`Decoder`] that owns its track: it reads groups, starts a cold DEFLATE window at each
+/// boundary, and turns each group's reset into just the changes this reader has not been told
+/// about. When something else already owns the track, use the [`Decoder`] directly.
+///
+/// Group rolls never surface. A publisher rolls for compression's sake, and a reset restating the
+/// window yields nothing for records already delivered, so this reads as one continuous stream of
+/// [`Event`]s regardless of how the publisher framed them.
+pub struct Consumer<T> {
+	track: moq_net::track::Subscriber,
+	group: Option<moq_net::group::Consumer>,
+	decoder: Decoder<T>,
+}
+
+impl<T: DeserializeOwned> Consumer<T> {
+	/// Create a consumer reading from the given track subscriber.
+	pub fn new(track: moq_net::track::Subscriber, config: ConsumerConfig) -> Self {
+		Self {
+			track,
+			group: None,
+			decoder: Decoder::new(config),
+		}
+	}
+
+	/// Absolute index of the oldest record in the window, and of the next to arrive.
+	pub fn range(&self) -> std::ops::Range<u64> {
+		self.decoder.range()
+	}
+
+	/// Get the next event, or `None` once the track ends.
+	pub async fn next(&mut self) -> Result<Option<Event<T>>>
+	where
+		T: Unpin,
+	{
+		kio::wait(|waiter| self.poll_next(waiter)).await
+	}
+
+	/// Poll for the next event, without blocking.
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Event<T>>>> {
+		loop {
+			// Drain what the frames already decoded produced before reading more.
+			if let Some(event) = self.decoder.next_event() {
+				return Poll::Ready(Ok(Some(event)));
+			}
+
+			let Some(group) = &mut self.group else {
+				match self.track.poll_next_group(waiter)? {
+					Poll::Ready(Some(group)) => {
+						// Each group is its own compressed stream, so the window starts cold. The index
+						// cursor deliberately survives, which is what makes the reset report only what this
+						// reader is missing.
+						self.decoder.reset();
+						self.group = Some(group);
+						continue;
+					}
+					Poll::Ready(None) => return Poll::Ready(Ok(None)),
+					Poll::Pending => return Poll::Pending,
+				}
+			};
+
+			match group.poll_read_frame(waiter)? {
+				Poll::Ready(Some(frame)) => self.decoder.decode(&frame.payload)?,
+				Poll::Ready(None) => {
+					// This group is exhausted. Clear it and poll for a later one, which restates the
+					// window; the stream ends only when the track does.
+					self.group = None;
+				}
+				Poll::Pending => return Poll::Pending,
+			}
+		}
+	}
+}

--- a/rs/moq-json/src/window/consumer.rs
+++ b/rs/moq-json/src/window/consumer.rs
@@ -10,10 +10,10 @@ use crate::Result;
 /// Consumes a sliding window of JSON records from a track, yielding one event per change.
 ///
 /// A [`Decoder`] that owns its track: it reads groups, starts a cold DEFLATE window at each
-/// boundary, and turns each group's reset into just the changes this reader has not been told
+/// boundary, and turns each group's header into just the changes this reader has not been told
 /// about. When something else already owns the track, use the [`Decoder`] directly.
 ///
-/// Group rolls never surface. A publisher rolls for compression's sake, and a reset restating the
+/// Group rolls never surface. A publisher rolls for compression's sake, and a header restating the
 /// window yields nothing for records already delivered, so this reads as one continuous stream of
 /// [`Event`]s regardless of how the publisher framed them.
 pub struct Consumer<T> {
@@ -57,7 +57,7 @@ impl<T: DeserializeOwned> Consumer<T> {
 				match self.track.poll_next_group(waiter)? {
 					Poll::Ready(Some(group)) => {
 						// Each group is its own compressed stream, so the window starts cold. The index
-						// cursor deliberately survives, which is what makes the reset report only what this
+						// cursor deliberately survives, which is what makes the header report only what this
 						// reader is missing.
 						self.decoder.reset();
 						self.group = Some(group);

--- a/rs/moq-json/src/window/decoder.rs
+++ b/rs/moq-json/src/window/decoder.rs
@@ -48,6 +48,12 @@ pub enum Event<T> {
 	Skip(std::ops::Range<u64>),
 }
 
+/// An event ready to return, or a header's unseen records waiting to become push events.
+enum Queued<T> {
+	Event(Event<T>),
+	Push { index: u64, records: std::vec::IntoIter<T> },
+}
+
 /// Decodes one MoQ group's frames while borrowing the continuous window state.
 pub struct Group<'a, T> {
 	decoder: &'a mut Decoder<T>,
@@ -95,7 +101,7 @@ pub struct Decoder<T> {
 	delivered: Option<u64>,
 
 	/// Events produced by the frames decoded so far, oldest first.
-	events: VecDeque<Event<T>>,
+	events: VecDeque<Queued<T>>,
 }
 
 impl<T> Decoder<T> {
@@ -124,7 +130,19 @@ impl<T> Decoder<T> {
 	/// end of anything: [`Group::decode`] refills it. Deliberately not [`Iterator`], whose
 	/// `None` a caller would reasonably read as exhausted.
 	pub fn next_event(&mut self) -> Option<Event<T>> {
-		self.events.pop_front()
+		match self.events.pop_front()? {
+			Queued::Event(event) => Some(event),
+			Queued::Push { index, mut records } => {
+				let value = records.next().expect("queued push batch is not empty");
+				if !records.as_slice().is_empty() {
+					self.events.push_front(Queued::Push {
+						index: index + 1,
+						records,
+					});
+				}
+				Some(Event::Push { index, value })
+			}
+		}
 	}
 
 	/// Absolute index of the oldest record in the window, and of the next to arrive.
@@ -136,20 +154,21 @@ impl<T> Decoder<T> {
 impl<T: DeserializeOwned> Decoder<T> {
 	/// Decode one frame, queueing the events it implies.
 	pub(super) fn decode(&mut self, group: &mut Codec, payload: &[u8]) -> Result<()> {
-		let bytes = match self.config.compression {
-			true => group.flate.get_or_insert_with(moq_flate::Decoder::new).frame(payload)?,
-			false => bytes::Bytes::copy_from_slice(payload),
+		let inflated = match self.config.compression {
+			true => Some(group.flate.get_or_insert_with(moq_flate::Decoder::new).frame(payload)?),
+			false => None,
 		};
+		let bytes = inflated.as_deref().unwrap_or(payload);
 
 		if !group.positioned {
-			let header: Header<T> = serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(&bytes))
+			let header: Header<T> = serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(bytes))
 				.map_err(|err| Error::Json(err.to_string()))?;
 			self.apply_header(header.offset, header.records)?;
 			group.positioned = true;
 			return Ok(());
 		}
 
-		match serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(&bytes))
+		match serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(bytes))
 			.map_err(|err| Error::Json(err.to_string()))?
 		{
 			Op::Push(record) => self.apply_push(record),
@@ -181,22 +200,28 @@ impl<T: DeserializeOwned> Decoder<T> {
 				// far more indices than a consumer could materialize individually.
 				let popped = self.front..delivered.min(offset);
 				if !popped.is_empty() {
-					self.events.push_back(Event::Pop(popped));
+					self.events.push_back(Queued::Event(Event::Pop(popped)));
 				}
 				let skipped = delivered..offset;
 				if !skipped.is_empty() {
-					self.events.push_back(Event::Skip(skipped));
+					self.events.push_back(Queued::Event(Event::Skip(skipped)));
 				}
 				delivered
 			}
 		};
 
-		// Deliver only the tail this reader has not seen; a header that merely restates what it holds
-		// yields nothing at all.
-		for (index, record) in (offset..end).zip(records) {
-			if index >= delivered {
-				self.events.push_back(Event::Push { index, value: record });
-			}
+		// Keep the unseen tail as one batch and materialize each push only when the caller asks for it.
+		let skip = usize::try_from(delivered.saturating_sub(offset))
+			.map_err(|_| Error::Json("window length exceeds usize".into()))?;
+		let mut records = records.into_iter();
+		if skip > 0 {
+			records.nth(skip - 1);
+		}
+		if !records.as_slice().is_empty() {
+			self.events.push_back(Queued::Push {
+				index: offset + skip as u64,
+				records,
+			});
 		}
 
 		self.front = offset;
@@ -220,7 +245,8 @@ impl<T: DeserializeOwned> Decoder<T> {
 		self.len = end - self.front;
 
 		if index >= delivered {
-			self.events.push_back(Event::Push { index, value: record });
+			self.events
+				.push_back(Queued::Event(Event::Push { index, value: record }));
 			self.delivered = Some(end);
 		}
 
@@ -243,11 +269,11 @@ impl<T: DeserializeOwned> Decoder<T> {
 			.ok_or_else(|| Error::Json("window range exceeds u64".into()))?;
 		let popped = self.front..delivered.min(end);
 		if !popped.is_empty() {
-			self.events.push_back(Event::Pop(popped));
+			self.events.push_back(Queued::Event(Event::Pop(popped)));
 		}
 		let skipped = delivered.max(self.front)..end;
 		if !skipped.is_empty() {
-			self.events.push_back(Event::Skip(skipped));
+			self.events.push_back(Queued::Event(Event::Skip(skipped)));
 		}
 
 		self.front = end;

--- a/rs/moq-json/src/window/decoder.rs
+++ b/rs/moq-json/src/window/decoder.rs
@@ -26,20 +26,20 @@ impl ConsumerConfig {
 
 /// One change to the window, as the consumer sees it.
 ///
-/// Every index is reported exactly once, as one of these three. A record is `Push`ed when it first
-/// reaches this consumer, `Pop`ped when it leaves the window, and `Skip`ped when it existed but was
-/// dropped before this consumer ever saw it.
+/// A record is `Push`ed when it first reaches this consumer. Contiguous ranges are `Pop`ped when
+/// they leave the window or `Skip`ped when they were dropped before this consumer saw them.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Event<T> {
 	/// This record joined the window, at this absolute index.
 	Push(u64, T),
 
-	/// The record at this index left the window.
-	Pop(u64),
+	/// These records left the window.
+	Pop(std::ops::Range<u64>),
 
-	/// The record at this index existed but will never be delivered: it was pushed and dropped
-	/// while this consumer was behind, or before it joined mid-stream.
-	Skip(u64),
+	/// These records existed but will never be delivered: they were pushed and dropped while this
+	/// consumer was behind.
+	Skip(std::ops::Range<u64>),
 }
 
 /// Reconstructs window events from frame payloads.
@@ -67,6 +67,9 @@ pub struct Decoder<T> {
 	/// reset's offset rather than skipping everything that came before it.
 	delivered: Option<u64>,
 
+	/// Whether the current group has opened with its required reset.
+	positioned: bool,
+
 	/// Events produced by the frames decoded so far, oldest first.
 	events: VecDeque<Event<T>>,
 }
@@ -80,6 +83,7 @@ impl<T> Decoder<T> {
 			front: 0,
 			len: 0,
 			delivered: None,
+			positioned: false,
 			events: VecDeque::new(),
 		}
 	}
@@ -90,6 +94,7 @@ impl<T> Decoder<T> {
 	/// the next group's reset report just the records this reader has not seen.
 	pub fn reset(&mut self) {
 		self.flate = None;
+		self.positioned = false;
 	}
 
 	/// Take the next event produced by the frames decoded so far.
@@ -126,20 +131,33 @@ impl<T: DeserializeOwned> Decoder<T> {
 
 	/// The window is exactly these records. Report what this reader missed, then what is new.
 	fn apply_reset(&mut self, offset: u64, records: Vec<T>) -> Result<()> {
-		let end = offset + records.len() as u64;
+		if self.positioned {
+			return Err(Error::Json("duplicate window reset in one group".into()));
+		}
+
+		let len = u64::try_from(records.len()).map_err(|_| Error::Json("window length exceeds u64".into()))?;
+		let end = offset
+			.checked_add(len)
+			.ok_or_else(|| Error::Json("window range exceeds u64".into()))?;
 
 		let delivered = match self.delivered {
 			// First position: adopt the publisher's offset rather than skipping all of history.
 			None => offset,
 			Some(delivered) => {
-				// Records that left the window while we were away. Those we had delivered are pops; those
-				// we never saw are skips. The two ranges are disjoint and together cover everything that
-				// left, so every index is still reported exactly once.
-				for index in self.front..delivered.min(offset) {
-					self.events.push_back(Event::Pop(index));
+				if offset < self.front || end < delivered {
+					return Err(Error::Json("window reset moved backwards".into()));
 				}
-				for index in delivered..offset {
-					self.events.push_back(Event::Skip(index));
+
+				// Records that left the window while we were away. Those we had delivered are pops; those
+				// we never saw are skips. Keep each gap compact: the offset is untrusted and may jump by
+				// far more indices than a consumer could materialize individually.
+				let popped = self.front..delivered.min(offset);
+				if !popped.is_empty() {
+					self.events.push_back(Event::Pop(popped));
+				}
+				let skipped = delivered..offset;
+				if !skipped.is_empty() {
+					self.events.push_back(Event::Skip(skipped));
 				}
 				delivered
 			}
@@ -156,6 +174,7 @@ impl<T: DeserializeOwned> Decoder<T> {
 		self.front = offset;
 		self.len = end - offset;
 		self.delivered = Some(delivered.max(end));
+		self.positioned = true;
 
 		Ok(())
 	}
@@ -163,14 +182,23 @@ impl<T: DeserializeOwned> Decoder<T> {
 	/// One record joined the back.
 	fn apply_push(&mut self, record: T) -> Result<()> {
 		// A group always opens with a reset, so a push before one means we started mid-group.
+		if !self.positioned {
+			return Err(Error::MissingReset);
+		}
 		let delivered = self.delivered.ok_or(Error::MissingReset)?;
 
-		let index = self.front + self.len;
-		self.len += 1;
+		let index = self
+			.front
+			.checked_add(self.len)
+			.ok_or_else(|| Error::Json("window range exceeds u64".into()))?;
+		let end = index
+			.checked_add(1)
+			.ok_or_else(|| Error::Json("window range exceeds u64".into()))?;
+		self.len = end - self.front;
 
 		if index >= delivered {
 			self.events.push_back(Event::Push(index, record));
-			self.delivered = Some(index + 1);
+			self.delivered = Some(end);
 		}
 
 		Ok(())
@@ -178,6 +206,9 @@ impl<T: DeserializeOwned> Decoder<T> {
 
 	/// Records left the front.
 	fn apply_pop(&mut self, count: u64) -> Result<()> {
+		if !self.positioned {
+			return Err(Error::MissingReset);
+		}
 		let delivered = self.delivered.ok_or(Error::MissingReset)?;
 		if count > self.len {
 			return Err(Error::Json(format!(
@@ -186,16 +217,20 @@ impl<T: DeserializeOwned> Decoder<T> {
 			)));
 		}
 
-		for index in self.front..self.front + count {
-			// Within a group every frame is seen, so these were delivered; the skip arm only matters
-			// for a window that was already ahead of this reader.
-			self.events.push_back(match index < delivered {
-				true => Event::Pop(index),
-				false => Event::Skip(index),
-			});
+		let end = self
+			.front
+			.checked_add(count)
+			.ok_or_else(|| Error::Json("window range exceeds u64".into()))?;
+		let popped = self.front..delivered.min(end);
+		if !popped.is_empty() {
+			self.events.push_back(Event::Pop(popped));
+		}
+		let skipped = delivered.max(self.front)..end;
+		if !skipped.is_empty() {
+			self.events.push_back(Event::Skip(skipped));
 		}
 
-		self.front += count;
+		self.front = end;
 		self.len -= count;
 		self.delivered = Some(delivered.max(self.front));
 

--- a/rs/moq-json/src/window/decoder.rs
+++ b/rs/moq-json/src/window/decoder.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 
 use serde::de::DeserializeOwned;
 
-use super::op::Op;
+use super::op::{Header, Op};
 use crate::{Error, Result};
 
 /// Configuration for a [`Decoder`], and so for the [`Consumer`](super::Consumer) wrapping one.
@@ -45,10 +45,10 @@ pub enum Event<T> {
 /// Reconstructs window events from frame payloads.
 ///
 /// The track-free core of [`Consumer`](super::Consumer). It tracks indices, not contents: it knows
-/// where the window starts and how far it has delivered, which is all it needs to turn a reset into
+/// where the window starts and how far it has delivered, which is all it needs to turn a header into
 /// the pushes, pops, and skips the reader has not already been told about.
 ///
-/// Group rolls are invisible here on purpose. A reset restates the window, and this decoder emits
+/// Group rolls are invisible here on purpose. A header restates the window, and this decoder emits
 /// only what is new, so a reader sees one continuous stream of edits no matter how often the
 /// publisher rolled for compression's sake.
 pub struct Decoder<T> {
@@ -57,17 +57,17 @@ pub struct Decoder<T> {
 	/// The current group's DEFLATE decoder, `Some` while compressing.
 	flate: Option<moq_flate::Decoder>,
 
-	/// Absolute index of the window's front, once a reset has positioned us.
+	/// Absolute index of the window's front, once a group header has positioned us.
 	front: u64,
 
 	/// Records currently in the window.
 	len: u64,
 
-	/// Next index to deliver, or `None` before the first reset. A fresh consumer adopts the first
-	/// reset's offset rather than skipping everything that came before it.
+	/// Next index to deliver, or `None` before the first header. A fresh consumer adopts the first
+	/// header's offset rather than skipping everything that came before it.
 	delivered: Option<u64>,
 
-	/// Whether the current group has opened with its required reset.
+	/// Whether the current group header has been decoded.
 	positioned: bool,
 
 	/// Events produced by the frames decoded so far, oldest first.
@@ -75,7 +75,7 @@ pub struct Decoder<T> {
 }
 
 impl<T> Decoder<T> {
-	/// Create a decoder that has not yet been positioned by a reset.
+	/// Create a decoder that has not yet been positioned by a group header.
 	pub fn new(config: ConsumerConfig) -> Self {
 		Self {
 			config,
@@ -90,8 +90,8 @@ impl<T> Decoder<T> {
 
 	/// Start a cold DEFLATE window, for a reader that has just moved to a new group.
 	///
-	/// Only the compression state resets. The index cursor deliberately survives: it is what lets
-	/// the next group's reset report just the records this reader has not seen.
+	/// Only the group-local state resets. The index cursor deliberately survives: it is what lets
+	/// the next group's header report just the records this reader has not seen.
 	pub fn reset(&mut self) {
 		self.flate = None;
 		self.positioned = false;
@@ -120,21 +120,22 @@ impl<T: DeserializeOwned> Decoder<T> {
 			false => bytes::Bytes::copy_from_slice(payload),
 		};
 
+		if !self.positioned {
+			let header: Header<T> = serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(&bytes))
+				.map_err(|err| Error::Json(err.to_string()))?;
+			return self.apply_header(header.offset, header.records);
+		}
+
 		match serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(&bytes))
 			.map_err(|err| Error::Json(err.to_string()))?
 		{
-			Op::Reset { offset, records } => self.apply_reset(offset, records),
 			Op::Push(record) => self.apply_push(record),
 			Op::Pop(count) => self.apply_pop(count),
 		}
 	}
 
 	/// The window is exactly these records. Report what this reader missed, then what is new.
-	fn apply_reset(&mut self, offset: u64, records: Vec<T>) -> Result<()> {
-		if self.positioned {
-			return Err(Error::Json("duplicate window reset in one group".into()));
-		}
-
+	fn apply_header(&mut self, offset: u64, records: Vec<T>) -> Result<()> {
 		let len = u64::try_from(records.len()).map_err(|_| Error::Json("window length exceeds u64".into()))?;
 		let end = offset
 			.checked_add(len)
@@ -145,7 +146,7 @@ impl<T: DeserializeOwned> Decoder<T> {
 			None => offset,
 			Some(delivered) => {
 				if offset < self.front || end < delivered {
-					return Err(Error::Json("window reset moved backwards".into()));
+					return Err(Error::Json("window header moved backwards".into()));
 				}
 
 				// Records that left the window while we were away. Those we had delivered are pops; those
@@ -163,7 +164,7 @@ impl<T: DeserializeOwned> Decoder<T> {
 			}
 		};
 
-		// Deliver only the tail this reader has not seen; a reset that merely restates what it holds
+		// Deliver only the tail this reader has not seen; a header that merely restates what it holds
 		// yields nothing at all.
 		for (index, record) in (offset..end).zip(records) {
 			if index >= delivered {
@@ -181,11 +182,7 @@ impl<T: DeserializeOwned> Decoder<T> {
 
 	/// One record joined the back.
 	fn apply_push(&mut self, record: T) -> Result<()> {
-		// A group always opens with a reset, so a push before one means we started mid-group.
-		if !self.positioned {
-			return Err(Error::MissingReset);
-		}
-		let delivered = self.delivered.ok_or(Error::MissingReset)?;
+		let delivered = self.delivered.expect("group header positioned the decoder");
 
 		let index = self
 			.front
@@ -206,10 +203,7 @@ impl<T: DeserializeOwned> Decoder<T> {
 
 	/// Records left the front.
 	fn apply_pop(&mut self, count: u64) -> Result<()> {
-		if !self.positioned {
-			return Err(Error::MissingReset);
-		}
-		let delivered = self.delivered.ok_or(Error::MissingReset)?;
+		let delivered = self.delivered.expect("group header positioned the decoder");
 		if count > self.len {
 			return Err(Error::Json(format!(
 				"pop of {count} exceeds the {} record(s) in the window",

--- a/rs/moq-json/src/window/decoder.rs
+++ b/rs/moq-json/src/window/decoder.rs
@@ -1,0 +1,204 @@
+//! The track-free half of window consumption: frame payloads in, window events out.
+
+use std::collections::VecDeque;
+
+use serde::de::DeserializeOwned;
+
+use super::op::Op;
+use crate::{Error, Result};
+
+/// Configuration for a [`Decoder`], and so for the [`Consumer`](super::Consumer) wrapping one.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ConsumerConfig {
+	/// Read frames written with
+	/// [`ProducerConfig::compression`](super::ProducerConfig::compression) on.
+	pub compression: bool,
+}
+
+impl ConsumerConfig {
+	/// Set [`compression`](Self::compression) (a builder, since the struct is `#[non_exhaustive]`).
+	pub fn with_compression(mut self, compression: bool) -> Self {
+		self.compression = compression;
+		self
+	}
+}
+
+/// One change to the window, as the consumer sees it.
+///
+/// Every index is reported exactly once, as one of these three. A record is `Push`ed when it first
+/// reaches this consumer, `Pop`ped when it leaves the window, and `Skip`ped when it existed but was
+/// dropped before this consumer ever saw it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event<T> {
+	/// This record joined the window, at this absolute index.
+	Push(u64, T),
+
+	/// The record at this index left the window.
+	Pop(u64),
+
+	/// The record at this index existed but will never be delivered: it was pushed and dropped
+	/// while this consumer was behind, or before it joined mid-stream.
+	Skip(u64),
+}
+
+/// Reconstructs window events from frame payloads.
+///
+/// The track-free core of [`Consumer`](super::Consumer). It tracks indices, not contents: it knows
+/// where the window starts and how far it has delivered, which is all it needs to turn a reset into
+/// the pushes, pops, and skips the reader has not already been told about.
+///
+/// Group rolls are invisible here on purpose. A reset restates the window, and this decoder emits
+/// only what is new, so a reader sees one continuous stream of edits no matter how often the
+/// publisher rolled for compression's sake.
+pub struct Decoder<T> {
+	config: ConsumerConfig,
+
+	/// The current group's DEFLATE decoder, `Some` while compressing.
+	flate: Option<moq_flate::Decoder>,
+
+	/// Absolute index of the window's front, once a reset has positioned us.
+	front: u64,
+
+	/// Records currently in the window.
+	len: u64,
+
+	/// Next index to deliver, or `None` before the first reset. A fresh consumer adopts the first
+	/// reset's offset rather than skipping everything that came before it.
+	delivered: Option<u64>,
+
+	/// Events produced by the frames decoded so far, oldest first.
+	events: VecDeque<Event<T>>,
+}
+
+impl<T> Decoder<T> {
+	/// Create a decoder that has not yet been positioned by a reset.
+	pub fn new(config: ConsumerConfig) -> Self {
+		Self {
+			config,
+			flate: None,
+			front: 0,
+			len: 0,
+			delivered: None,
+			events: VecDeque::new(),
+		}
+	}
+
+	/// Start a cold DEFLATE window, for a reader that has just moved to a new group.
+	///
+	/// Only the compression state resets. The index cursor deliberately survives: it is what lets
+	/// the next group's reset report just the records this reader has not seen.
+	pub fn reset(&mut self) {
+		self.flate = None;
+	}
+
+	/// Take the next event produced by the frames decoded so far.
+	///
+	/// Returns `None` once the queue is drained, which is a request for more frames rather than the
+	/// end of anything: [`decode`](Self::decode) refills it. Deliberately not [`Iterator`], whose
+	/// `None` a caller would reasonably read as exhausted.
+	pub fn next_event(&mut self) -> Option<Event<T>> {
+		self.events.pop_front()
+	}
+
+	/// Absolute index of the oldest record in the window, and of the next to arrive.
+	pub fn range(&self) -> std::ops::Range<u64> {
+		self.front..self.front + self.len
+	}
+}
+
+impl<T: DeserializeOwned> Decoder<T> {
+	/// Decode one frame, queueing the events it implies.
+	pub fn decode(&mut self, payload: &[u8]) -> Result<()> {
+		let bytes = match self.config.compression {
+			true => self.flate.get_or_insert_with(moq_flate::Decoder::new).frame(payload)?,
+			false => bytes::Bytes::copy_from_slice(payload),
+		};
+
+		match serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(&bytes))
+			.map_err(|err| Error::Json(err.to_string()))?
+		{
+			Op::Reset { offset, records } => self.apply_reset(offset, records),
+			Op::Push(record) => self.apply_push(record),
+			Op::Pop(count) => self.apply_pop(count),
+		}
+	}
+
+	/// The window is exactly these records. Report what this reader missed, then what is new.
+	fn apply_reset(&mut self, offset: u64, records: Vec<T>) -> Result<()> {
+		let end = offset + records.len() as u64;
+
+		let delivered = match self.delivered {
+			// First position: adopt the publisher's offset rather than skipping all of history.
+			None => offset,
+			Some(delivered) => {
+				// Records that left the window while we were away. Those we had delivered are pops; those
+				// we never saw are skips. The two ranges are disjoint and together cover everything that
+				// left, so every index is still reported exactly once.
+				for index in self.front..delivered.min(offset) {
+					self.events.push_back(Event::Pop(index));
+				}
+				for index in delivered..offset {
+					self.events.push_back(Event::Skip(index));
+				}
+				delivered
+			}
+		};
+
+		// Deliver only the tail this reader has not seen; a reset that merely restates what it holds
+		// yields nothing at all.
+		for (index, record) in (offset..end).zip(records) {
+			if index >= delivered {
+				self.events.push_back(Event::Push(index, record));
+			}
+		}
+
+		self.front = offset;
+		self.len = end - offset;
+		self.delivered = Some(delivered.max(end));
+
+		Ok(())
+	}
+
+	/// One record joined the back.
+	fn apply_push(&mut self, record: T) -> Result<()> {
+		// A group always opens with a reset, so a push before one means we started mid-group.
+		let delivered = self.delivered.ok_or(Error::MissingReset)?;
+
+		let index = self.front + self.len;
+		self.len += 1;
+
+		if index >= delivered {
+			self.events.push_back(Event::Push(index, record));
+			self.delivered = Some(index + 1);
+		}
+
+		Ok(())
+	}
+
+	/// Records left the front.
+	fn apply_pop(&mut self, count: u64) -> Result<()> {
+		let delivered = self.delivered.ok_or(Error::MissingReset)?;
+		if count > self.len {
+			return Err(Error::Json(format!(
+				"pop of {count} exceeds the {} record(s) in the window",
+				self.len
+			)));
+		}
+
+		for index in self.front..self.front + count {
+			// Within a group every frame is seen, so these were delivered; the skip arm only matters
+			// for a window that was already ahead of this reader.
+			self.events.push_back(match index < delivered {
+				true => Event::Pop(index),
+				false => Event::Skip(index),
+			});
+		}
+
+		self.front += count;
+		self.len -= count;
+		self.delivered = Some(delivered.max(self.front));
+
+		Ok(())
+	}
+}

--- a/rs/moq-json/src/window/decoder.rs
+++ b/rs/moq-json/src/window/decoder.rs
@@ -4,6 +4,7 @@ use std::collections::VecDeque;
 
 use serde::de::DeserializeOwned;
 
+use super::encoder::MAX_INDEX;
 use super::op::{Header, Op};
 use crate::{Error, Result};
 
@@ -32,7 +33,12 @@ impl ConsumerConfig {
 #[non_exhaustive]
 pub enum Event<T> {
 	/// This record joined the window, at this absolute index.
-	Push(u64, T),
+	Push {
+		/// Absolute index assigned to the record.
+		index: u64,
+		/// The decoded record.
+		value: T,
+	},
 
 	/// These records left the window.
 	Pop(std::ops::Range<u64>),
@@ -92,7 +98,7 @@ impl<T> Decoder<T> {
 	///
 	/// Only the group-local state resets. The index cursor deliberately survives: it is what lets
 	/// the next group's header report just the records this reader has not seen.
-	pub fn reset(&mut self) {
+	pub fn start_group(&mut self) {
 		self.flate = None;
 		self.positioned = false;
 	}
@@ -136,10 +142,14 @@ impl<T: DeserializeOwned> Decoder<T> {
 
 	/// The window is exactly these records. Report what this reader missed, then what is new.
 	fn apply_header(&mut self, offset: u64, records: Vec<T>) -> Result<()> {
+		if offset > MAX_INDEX {
+			return Err(Error::Json("window offset exceeds the safe integer range".into()));
+		}
 		let len = u64::try_from(records.len()).map_err(|_| Error::Json("window length exceeds u64".into()))?;
 		let end = offset
 			.checked_add(len)
-			.ok_or_else(|| Error::Json("window range exceeds u64".into()))?;
+			.filter(|end| *end <= MAX_INDEX)
+			.ok_or_else(|| Error::Json("window range exceeds the safe integer range".into()))?;
 
 		let delivered = match self.delivered {
 			// First position: adopt the publisher's offset rather than skipping all of history.
@@ -168,7 +178,7 @@ impl<T: DeserializeOwned> Decoder<T> {
 		// yields nothing at all.
 		for (index, record) in (offset..end).zip(records) {
 			if index >= delivered {
-				self.events.push_back(Event::Push(index, record));
+				self.events.push_back(Event::Push { index, value: record });
 			}
 		}
 
@@ -190,11 +200,12 @@ impl<T: DeserializeOwned> Decoder<T> {
 			.ok_or_else(|| Error::Json("window range exceeds u64".into()))?;
 		let end = index
 			.checked_add(1)
-			.ok_or_else(|| Error::Json("window range exceeds u64".into()))?;
+			.filter(|end| *end <= MAX_INDEX)
+			.ok_or_else(|| Error::Json("window range exceeds the safe integer range".into()))?;
 		self.len = end - self.front;
 
 		if index >= delivered {
-			self.events.push_back(Event::Push(index, record));
+			self.events.push_back(Event::Push { index, value: record });
 			self.delivered = Some(end);
 		}
 

--- a/rs/moq-json/src/window/decoder.rs
+++ b/rs/moq-json/src/window/decoder.rs
@@ -48,6 +48,30 @@ pub enum Event<T> {
 	Skip(std::ops::Range<u64>),
 }
 
+/// Decodes one MoQ group's frames while borrowing the continuous window state.
+pub struct Group<'a, T> {
+	decoder: &'a mut Decoder<T>,
+	codec: Codec,
+}
+
+/// Group-local decoding state used by both [`Group`] and [`Consumer`](super::Consumer).
+pub(super) struct Codec {
+	/// The group's DEFLATE decoder, `Some` while reading compressed frames.
+	flate: Option<moq_flate::Decoder>,
+
+	/// Whether the required frame-zero header has been decoded.
+	positioned: bool,
+}
+
+impl Codec {
+	pub(super) fn new() -> Self {
+		Self {
+			flate: None,
+			positioned: false,
+		}
+	}
+}
+
 /// Reconstructs window events from frame payloads.
 ///
 /// The track-free core of [`Consumer`](super::Consumer). It tracks indices, not contents: it knows
@@ -60,9 +84,6 @@ pub enum Event<T> {
 pub struct Decoder<T> {
 	config: ConsumerConfig,
 
-	/// The current group's DEFLATE decoder, `Some` while compressing.
-	flate: Option<moq_flate::Decoder>,
-
 	/// Absolute index of the window's front, once a group header has positioned us.
 	front: u64,
 
@@ -73,9 +94,6 @@ pub struct Decoder<T> {
 	/// header's offset rather than skipping everything that came before it.
 	delivered: Option<u64>,
 
-	/// Whether the current group header has been decoded.
-	positioned: bool,
-
 	/// Events produced by the frames decoded so far, oldest first.
 	events: VecDeque<Event<T>>,
 }
@@ -85,28 +103,25 @@ impl<T> Decoder<T> {
 	pub fn new(config: ConsumerConfig) -> Self {
 		Self {
 			config,
-			flate: None,
 			front: 0,
 			len: 0,
 			delivered: None,
-			positioned: false,
 			events: VecDeque::new(),
 		}
 	}
 
-	/// Start a cold DEFLATE window, for a reader that has just moved to a new group.
-	///
-	/// Only the group-local state resets. The index cursor deliberately survives: it is what lets
-	/// the next group's header report just the records this reader has not seen.
-	pub fn start_group(&mut self) {
-		self.flate = None;
-		self.positioned = false;
+	/// Borrow this decoder for one MoQ group.
+	pub fn group(&mut self) -> Group<'_, T> {
+		Group {
+			decoder: self,
+			codec: Codec::new(),
+		}
 	}
 
 	/// Take the next event produced by the frames decoded so far.
 	///
 	/// Returns `None` once the queue is drained, which is a request for more frames rather than the
-	/// end of anything: [`decode`](Self::decode) refills it. Deliberately not [`Iterator`], whose
+	/// end of anything: [`Group::decode`] refills it. Deliberately not [`Iterator`], whose
 	/// `None` a caller would reasonably read as exhausted.
 	pub fn next_event(&mut self) -> Option<Event<T>> {
 		self.events.pop_front()
@@ -120,16 +135,18 @@ impl<T> Decoder<T> {
 
 impl<T: DeserializeOwned> Decoder<T> {
 	/// Decode one frame, queueing the events it implies.
-	pub fn decode(&mut self, payload: &[u8]) -> Result<()> {
+	pub(super) fn decode(&mut self, group: &mut Codec, payload: &[u8]) -> Result<()> {
 		let bytes = match self.config.compression {
-			true => self.flate.get_or_insert_with(moq_flate::Decoder::new).frame(payload)?,
+			true => group.flate.get_or_insert_with(moq_flate::Decoder::new).frame(payload)?,
 			false => bytes::Bytes::copy_from_slice(payload),
 		};
 
-		if !self.positioned {
+		if !group.positioned {
 			let header: Header<T> = serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(&bytes))
 				.map_err(|err| Error::Json(err.to_string()))?;
-			return self.apply_header(header.offset, header.records);
+			self.apply_header(header.offset, header.records)?;
+			group.positioned = true;
+			return Ok(());
 		}
 
 		match serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(&bytes))
@@ -185,8 +202,6 @@ impl<T: DeserializeOwned> Decoder<T> {
 		self.front = offset;
 		self.len = end - offset;
 		self.delivered = Some(delivered.max(end));
-		self.positioned = true;
-
 		Ok(())
 	}
 
@@ -240,5 +255,24 @@ impl<T: DeserializeOwned> Decoder<T> {
 		self.delivered = Some(delivered.max(self.front));
 
 		Ok(())
+	}
+}
+
+impl<T> Group<'_, T> {
+	/// Take the next event produced by this group's frames so far.
+	pub fn next_event(&mut self) -> Option<Event<T>> {
+		self.decoder.next_event()
+	}
+
+	/// Absolute index of the oldest record in the window, and of the next to arrive.
+	pub fn range(&self) -> std::ops::Range<u64> {
+		self.decoder.range()
+	}
+}
+
+impl<T: DeserializeOwned> Group<'_, T> {
+	/// Decode the next frame in this group.
+	pub fn decode(&mut self, payload: &[u8]) -> Result<()> {
+		self.decoder.decode(&mut self.codec, payload)
 	}
 }

--- a/rs/moq-json/src/window/encoder.rs
+++ b/rs/moq-json/src/window/encoder.rs
@@ -1,0 +1,320 @@
+//! The track-free half of window publishing: window edits in, frame payloads out.
+
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+
+use bytes::Bytes;
+use serde::Serialize;
+use serde_json::Value;
+
+use super::op::Op;
+use crate::Result;
+
+/// Frames (reset included) in one group before a reset is forced, matching
+/// [`snapshot`](crate::snapshot)'s cap. Kept well below moq-net's per-group frame cap so a late
+/// joiner can always read the reset at frame 0.
+pub(super) const MAX_GROUP_FRAMES: usize = 256;
+
+/// Configuration for an [`Encoder`] and the [`Producer`](super::Producer) wrapping one.
+///
+/// Build from [`Default`] and override fields (the struct is `#[non_exhaustive]`, so new options
+/// stay additive), or chain the `with_*` setters.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ProducerConfig {
+	/// How much the ops in a group may cost before a fresh reset is emitted.
+	///
+	/// A new group opens once the pushes and pops *already written* exceed `op_ratio` times the
+	/// size of the group's reset frame. The pending op is excluded from that check, so the one that
+	/// tips the group over budget still lands: a group overshoots by at most one op before rolling.
+	/// `0` disables ops entirely, so every edit is its own single-frame reset.
+	///
+	/// This is the window's counterpart to
+	/// [`snapshot::ProducerConfig::delta_ratio`](crate::snapshot::ProducerConfig::delta_ratio), and
+	/// the same trade: a bigger ratio spends less on resets and makes a late joiner read more ops.
+	///
+	/// Defaults to `8`.
+	pub op_ratio: u32,
+
+	/// Compress each group as one sync-flushed DEFLATE stream, so every op reuses the reset and the
+	/// ops before it as context.
+	///
+	/// `false` (the default) emits plaintext JSON frames. A [`Decoder`](super::Decoder) reading them
+	/// must set [`ConsumerConfig::compression`](super::ConsumerConfig::compression) to match.
+	pub compression: bool,
+}
+
+impl Default for ProducerConfig {
+	fn default() -> Self {
+		Self {
+			op_ratio: 8,
+			compression: false,
+		}
+	}
+}
+
+impl ProducerConfig {
+	/// Set [`op_ratio`](Self::op_ratio) (a builder, since the struct is `#[non_exhaustive]`).
+	pub fn with_op_ratio(mut self, op_ratio: u32) -> Self {
+		self.op_ratio = op_ratio;
+		self
+	}
+
+	/// Set [`compression`](Self::compression) (a builder, since the struct is `#[non_exhaustive]`).
+	pub fn with_compression(mut self, compression: bool) -> Self {
+		self.compression = compression;
+		self
+	}
+}
+
+/// One encoded frame, and the group boundary it implies.
+#[derive(Clone, Debug)]
+pub struct Encoded {
+	/// The frame payload, DEFLATE-compressed when [`ProducerConfig::compression`] is set.
+	pub payload: Bytes,
+
+	/// Whether this frame is a reset, which must open a new group.
+	///
+	/// The encoder decides this, never the caller: the op budget and the frame cap force a reset
+	/// independently of which edit was requested.
+	pub keyframe: bool,
+}
+
+/// An encoded frame the caller has not yet acknowledged writing.
+///
+/// Write the frame, then [`commit`](Self::commit). A frame that never reaches the wire leaves the
+/// consumer's view behind the producer's window, so dropping it uncommitted
+/// [`reset`](Encoder::reset)s the encoder and the next frame restates the whole window.
+///
+/// The window itself is not rolled back. It is the producer's truth, and the edit really happened;
+/// only the consumer's knowledge of it is lost, which the next reset repairs.
+#[must_use = "write the frame, then commit it"]
+pub struct Pending<'a, T> {
+	encoder: &'a mut Encoder<T>,
+	encoded: Encoded,
+	committed: bool,
+}
+
+impl<T> std::ops::Deref for Pending<'_, T> {
+	type Target = Encoded;
+
+	fn deref(&self) -> &Encoded {
+		&self.encoded
+	}
+}
+
+impl<T> Pending<'_, T> {
+	/// Acknowledge that the frame reached the wire, keeping the encoder's state.
+	///
+	/// Only call this once the write has actually succeeded.
+	pub fn commit(mut self) {
+		self.committed = true;
+	}
+}
+
+impl<T> Drop for Pending<'_, T> {
+	fn drop(&mut self) {
+		if !self.committed {
+			self.encoder.reset();
+		}
+	}
+}
+
+/// Encodes window edits into frame payloads, deciding where the group boundaries fall.
+///
+/// The track-free core of [`Producer`](super::Producer). It owns the retained window, so it can
+/// restate it whenever a group rolls; that restatement is the whole point of the mode, and is what
+/// an append-only log cannot do.
+///
+/// Frames must reach the wire in the order they were encoded, and a frame with
+/// [`keyframe`](Encoded::keyframe) set must open a new group: both the positional indices and the
+/// group-scoped DEFLATE window depend on it.
+pub struct Encoder<T> {
+	config: ProducerConfig,
+
+	/// The retained window. Records are stored decoded so a reset can restate them, and so a record
+	/// serializes identically whether it reaches a reader as a push or in a later reset.
+	window: VecDeque<Value>,
+
+	/// Absolute index of `window.front()`. Only a reset puts this on the wire.
+	offset: u64,
+
+	/// The current group's DEFLATE encoder (one window per group), `Some` while compressing.
+	flate: Option<moq_flate::Encoder>,
+
+	/// Bytes of pushes and pops emitted into the current group, excluding its reset frame.
+	op_bytes: u64,
+
+	/// Reference size the op budget is measured against: the current group's reset frame.
+	reset_len: u64,
+
+	/// Frames emitted into the current group, reset included.
+	group_frames: usize,
+
+	/// Whether the next frame must be a reset, because a frame was lost or the caller rolled the
+	/// group. Kept separate from the window, which a resync must never discard.
+	resync: bool,
+
+	_marker: PhantomData<fn(T)>,
+}
+
+impl<T> Encoder<T> {
+	/// Create an encoder with an empty window, so the first edit emits a reset.
+	pub fn new(config: ProducerConfig) -> Self {
+		Self {
+			config,
+			window: VecDeque::new(),
+			offset: 0,
+			flate: None,
+			op_bytes: 0,
+			reset_len: 0,
+			group_frames: 0,
+			resync: true,
+			_marker: PhantomData,
+		}
+	}
+
+	/// The retained window, oldest first.
+	///
+	/// The encoder holds this to restate it on a roll, so a caller needs no parallel copy.
+	pub fn window(&self) -> impl ExactSizeIterator<Item = &Value> {
+		self.window.iter()
+	}
+
+	/// Absolute index of the oldest retained record, and of the next one to be pushed.
+	pub fn range(&self) -> std::ops::Range<u64> {
+		self.offset..self.offset + self.window.len() as u64
+	}
+
+	/// Force the next frame to be a reset.
+	///
+	/// Call this whenever the caller closes the current group behind the encoder's back. Without it
+	/// the next frame may be a push against a DEFLATE window and an index base the new group does
+	/// not carry.
+	///
+	/// The window survives: the reset restates it in full anyway.
+	pub fn reset(&mut self) {
+		self.flate = None;
+		self.op_bytes = 0;
+		self.reset_len = 0;
+		self.group_frames = 0;
+		self.resync = true;
+	}
+
+	/// Whether the pending edit may ride as an op in the open group.
+	fn op_allowed(&self) -> bool {
+		let ratio = u64::from(self.config.op_ratio);
+		ratio != 0
+			&& self.group_frames > 0
+			&& self.group_frames < MAX_GROUP_FRAMES
+			&& self.op_bytes <= ratio * self.reset_len
+	}
+
+	/// Compress an already-serialized op into the open group, charging it to the budget.
+	fn frame(&mut self, bytes: Vec<u8>) -> Encoded {
+		let payload = match self.flate.as_mut() {
+			Some(flate) => flate.frame(&bytes),
+			None => Bytes::from(bytes),
+		};
+
+		self.op_bytes += payload.len() as u64;
+		self.group_frames += 1;
+
+		Encoded {
+			payload,
+			keyframe: false,
+		}
+	}
+
+	/// Encode a reset restating the whole window, opening a new group.
+	fn emit_reset(&mut self) -> Result<Encoded> {
+		let records: Vec<&Value> = self.window.iter().collect();
+		let bytes = serde_json::to_vec(&Op::Reset {
+			offset: self.offset,
+			records,
+		})?;
+
+		// Open a fresh per-group encoder (cold window) and compress the reset as frame 0, recording
+		// its wire size as the op budget's anchor.
+		let (payload, flate) = match self.config.compression {
+			true => {
+				let mut flate = moq_flate::Encoder::new();
+				let payload = flate.frame(&bytes);
+				(payload, Some(flate))
+			}
+			false => (Bytes::from(bytes), None),
+		};
+
+		self.reset_len = payload.len() as u64;
+		self.op_bytes = 0;
+		self.group_frames = 1;
+		self.flate = flate;
+		self.resync = false;
+
+		Ok(Encoded {
+			payload,
+			keyframe: true,
+		})
+	}
+
+	/// Drop `count` records from the front of the window.
+	///
+	/// Returns `None` when there is nothing to drop, so a caller can trim unconditionally. Emits a
+	/// pop into the open group, or a reset restating what is left.
+	pub fn pop(&mut self, count: u64) -> Result<Option<Pending<'_, T>>> {
+		let count = count.min(self.window.len() as u64);
+		if count == 0 {
+			return Ok(None);
+		}
+
+		self.window.drain(..count as usize);
+		self.offset += count;
+
+		let encoded = match self.resync || !self.op_allowed() {
+			true => self.emit_reset()?,
+			false => {
+				let bytes = serde_json::to_vec(&Op::<&Value>::Pop(count))?;
+				self.frame(bytes)
+			}
+		};
+
+		Ok(Some(self.pending(encoded)))
+	}
+
+	/// Wrap an encoded frame so the caller has to say whether it reached the wire.
+	fn pending(&mut self, encoded: Encoded) -> Pending<'_, T> {
+		Pending {
+			encoder: self,
+			encoded,
+			committed: false,
+		}
+	}
+}
+
+impl<T: Serialize> Encoder<T> {
+	/// Append one record to the back of the window.
+	///
+	/// Emits a push into the open group, or a reset restating the window (the new record included)
+	/// when the op budget is spent or a frame was lost.
+	pub fn push(&mut self, value: &T) -> Result<Pending<'_, T>> {
+		// Serialize before touching the window, so a value that can't be encoded leaves the encoder
+		// exactly as it was. Reading the record back out of its own bytes keeps the stored copy
+		// identical to what a push would have put on the wire.
+		let bytes = serde_json::to_vec(value)?;
+		let record: Value = serde_json::from_slice(&bytes)?;
+
+		self.window.push_back(record);
+
+		let encoded = match self.resync || !self.op_allowed() {
+			true => self.emit_reset()?,
+			false => {
+				// Serialize the record out of the window rather than the caller's value, so its bytes
+				// match what a later reset would restate.
+				let bytes = serde_json::to_vec(&Op::Push(self.window.back().expect("just pushed")))?;
+				self.frame(bytes)
+			}
+		};
+
+		Ok(self.pending(encoded))
+	}
+}

--- a/rs/moq-json/src/window/encoder.rs
+++ b/rs/moq-json/src/window/encoder.rs
@@ -15,6 +15,9 @@ use crate::Result;
 /// joiner can always read the header at frame 0.
 pub(super) const MAX_GROUP_FRAMES: usize = 256;
 
+/// Largest index represented exactly by both Rust and JavaScript implementations.
+pub(super) const MAX_INDEX: u64 = (1 << 53) - 1;
+
 /// Configuration for an [`Encoder`] and the [`Producer`](super::Producer) wrapping one.
 ///
 /// Build from [`Default`] and override fields (the struct is `#[non_exhaustive]`, so new options
@@ -83,17 +86,19 @@ pub struct Encoded {
 
 /// An encoded frame the caller has not yet acknowledged writing.
 ///
-/// Write the frame, then [`commit`](Self::commit). A frame that never reaches the wire leaves the
-/// consumer's view behind the producer's window, so dropping it uncommitted starts a new group and
-/// the next frame restates the whole window.
-///
-/// The window itself is not rolled back. It is the producer's truth, and the edit really happened;
-/// only the consumer's knowledge of it is lost, which the next group header repairs.
+/// Write the frame, then [`commit`](Self::commit). The edit is staged until commit, so dropping the
+/// frame leaves the window unchanged and makes the next frame open a new group.
 #[must_use = "write the frame, then commit it"]
 pub struct Pending<'a, T> {
 	encoder: &'a mut Encoder<T>,
 	encoded: Encoded,
-	committed: bool,
+	edit: Option<Edit>,
+}
+
+/// The window mutation staged behind a [`Pending`] frame.
+enum Edit {
+	Push(Value),
+	Pop(u64),
 }
 
 impl<T> std::ops::Deref for Pending<'_, T> {
@@ -105,18 +110,19 @@ impl<T> std::ops::Deref for Pending<'_, T> {
 }
 
 impl<T> Pending<'_, T> {
-	/// Acknowledge that the frame reached the wire, keeping the encoder's state.
+	/// Acknowledge that the frame reached the wire, applying its edit to the retained window.
 	///
 	/// Only call this once the write has actually succeeded.
 	pub fn commit(mut self) {
-		self.committed = true;
+		let edit = self.edit.take().expect("pending edit");
+		self.encoder.commit(edit);
 	}
 }
 
 impl<T> Drop for Pending<'_, T> {
 	fn drop(&mut self) {
-		if !self.committed {
-			self.encoder.reset();
+		if self.edit.is_some() {
+			self.encoder.start_group();
 		}
 	}
 }
@@ -187,19 +193,30 @@ impl<T> Encoder<T> {
 		self.offset..self.offset + self.window.len() as u64
 	}
 
-	/// Force the next frame to open a new group with a header.
+	/// Make the next frame open a new group with a header.
 	///
 	/// Call this whenever the caller closes the current group behind the encoder's back. Without it
 	/// the next frame may be a push against a DEFLATE window and an index base the new group does
 	/// not carry.
 	///
 	/// The window survives: the group header restates it in full anyway.
-	pub fn reset(&mut self) {
+	pub fn start_group(&mut self) {
 		self.flate = None;
 		self.op_bytes = 0;
 		self.header_len = 0;
 		self.group_frames = 0;
 		self.resync = true;
+	}
+
+	/// Apply an edit after its encoded frame reached the wire.
+	fn commit(&mut self, edit: Edit) {
+		match edit {
+			Edit::Push(record) => self.window.push_back(record),
+			Edit::Pop(count) => {
+				self.window.drain(..count as usize);
+				self.offset += count;
+			}
+		}
 	}
 
 	/// Whether the pending edit may ride as an op in the open group.
@@ -228,24 +245,23 @@ impl<T> Encoder<T> {
 	}
 
 	/// Emit an op when the header will remain cached, otherwise restate the window in a new group.
-	fn emit_op(&mut self, bytes: Vec<u8>) -> Result<Encoded> {
+	fn emit_op(&mut self, bytes: Vec<u8>) -> Option<Encoded> {
 		let encoded = self.frame(bytes);
 		let group_bytes = self.header_len.saturating_add(self.op_bytes);
 		if group_bytes > moq_net::group::MAX_CACHE_BYTES {
-			self.emit_header()
+			None
 		} else {
-			Ok(encoded)
+			Some(encoded)
 		}
 	}
 
-	/// Encode the header restating the whole window and opening a new group.
-	fn emit_header(&mut self) -> Result<Encoded> {
-		let records: Vec<&Value> = self.window.iter().collect();
-		let bytes = serde_json::to_vec(&Header {
-			offset: self.offset,
-			records,
-		})?;
+	/// Serialize a header before mutably borrowing the compression state.
+	fn header(offset: u64, records: Vec<&Value>) -> Result<Vec<u8>> {
+		Ok(serde_json::to_vec(&Header { offset, records })?)
+	}
 
+	/// Encode the header restating the whole window and opening a new group.
+	fn emit_header(&mut self, bytes: Vec<u8>) -> Encoded {
 		// Open a fresh per-group encoder (cold window) and compress the header as frame 0, recording
 		// its wire size as the op budget's anchor.
 		let (payload, flate) = match self.config.compression {
@@ -263,10 +279,10 @@ impl<T> Encoder<T> {
 		self.flate = flate;
 		self.resync = false;
 
-		Ok(Encoded {
+		Encoded {
 			payload,
 			keyframe: true,
-		})
+		}
 	}
 
 	/// Drop `count` records from the front of the window.
@@ -279,26 +295,33 @@ impl<T> Encoder<T> {
 			return Ok(None);
 		}
 
-		self.window.drain(..count as usize);
-		self.offset += count;
-
+		let offset = self.offset + count;
 		let encoded = match self.resync || !self.op_allowed() {
-			true => self.emit_header()?,
+			true => {
+				let bytes = Self::header(offset, self.window.iter().skip(count as usize).collect())?;
+				self.emit_header(bytes)
+			}
 			false => {
 				let bytes = serde_json::to_vec(&Op::<&Value>::Pop(count))?;
-				self.emit_op(bytes)?
+				match self.emit_op(bytes) {
+					Some(encoded) => encoded,
+					None => {
+						let bytes = Self::header(offset, self.window.iter().skip(count as usize).collect())?;
+						self.emit_header(bytes)
+					}
+				}
 			}
 		};
 
-		Ok(Some(self.pending(encoded)))
+		Ok(Some(self.pending(encoded, Edit::Pop(count))))
 	}
 
 	/// Wrap an encoded frame so the caller has to say whether it reached the wire.
-	fn pending(&mut self, encoded: Encoded) -> Pending<'_, T> {
+	fn pending(&mut self, encoded: Encoded, edit: Edit) -> Pending<'_, T> {
 		Pending {
 			encoder: self,
 			encoded,
-			committed: false,
+			edit: Some(edit),
 		}
 	}
 }
@@ -314,20 +337,34 @@ impl<T: Serialize> Encoder<T> {
 		// identical to what a push would have put on the wire.
 		let bytes = serde_json::to_vec(value)?;
 		let record: Value = serde_json::from_slice(&bytes)?;
-
-		self.window.push_back(record);
+		if self.range().end >= MAX_INDEX {
+			return Err(crate::Error::Json("window index exceeds the safe integer range".into()));
+		}
 
 		let encoded = match self.resync || !self.op_allowed() {
-			true => self.emit_header()?,
+			true => {
+				let bytes = Self::header(
+					self.offset,
+					self.window.iter().chain(std::iter::once(&record)).collect(),
+				)?;
+				self.emit_header(bytes)
+			}
 			false => {
-				// Serialize the record out of the window rather than the caller's value, so its bytes
-				// match what a later group header would restate.
-				let bytes = serde_json::to_vec(&Op::Push(self.window.back().expect("just pushed")))?;
-				self.emit_op(bytes)?
+				let bytes = serde_json::to_vec(&Op::Push(&record))?;
+				match self.emit_op(bytes) {
+					Some(encoded) => encoded,
+					None => {
+						let bytes = Self::header(
+							self.offset,
+							self.window.iter().chain(std::iter::once(&record)).collect(),
+						)?;
+						self.emit_header(bytes)
+					}
+				}
 			}
 		};
 
-		Ok(self.pending(encoded))
+		Ok(self.pending(encoded, Edit::Push(record)))
 	}
 }
 
@@ -357,5 +394,21 @@ mod test {
 		assert!(frame.keyframe);
 		assert!(frame.payload.len() < moq_net::group::MAX_CACHE_BYTES as usize);
 		frame.commit();
+	}
+
+	#[test]
+	fn an_uncommitted_edit_leaves_the_window_unchanged() {
+		let mut encoder = Encoder::<u64>::new(ProducerConfig::default());
+
+		drop(encoder.push(&1).unwrap());
+		assert!(encoder.window().next().is_none());
+
+		let frame = encoder.push(&2).unwrap();
+		assert!(frame.keyframe);
+		frame.commit();
+		assert_eq!(encoder.window().collect::<Vec<_>>(), vec![&Value::from(2)]);
+
+		drop(encoder.pop(1).unwrap().unwrap());
+		assert_eq!(encoder.window().collect::<Vec<_>>(), vec![&Value::from(2)]);
 	}
 }

--- a/rs/moq-json/src/window/encoder.rs
+++ b/rs/moq-json/src/window/encoder.rs
@@ -69,6 +69,7 @@ impl ProducerConfig {
 
 /// One encoded frame, and the group boundary it implies.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Encoded {
 	/// The frame payload, DEFLATE-compressed when [`ProducerConfig::compression`] is set.
 	pub payload: Bytes,
@@ -226,6 +227,17 @@ impl<T> Encoder<T> {
 		}
 	}
 
+	/// Emit an op when the reset will remain cached, otherwise restate the window in a new group.
+	fn emit_op(&mut self, bytes: Vec<u8>) -> Result<Encoded> {
+		let encoded = self.frame(bytes);
+		let group_bytes = self.reset_len.saturating_add(self.op_bytes);
+		if group_bytes > moq_net::group::MAX_CACHE_BYTES {
+			self.emit_reset()
+		} else {
+			Ok(encoded)
+		}
+	}
+
 	/// Encode a reset restating the whole window, opening a new group.
 	fn emit_reset(&mut self) -> Result<Encoded> {
 		let records: Vec<&Value> = self.window.iter().collect();
@@ -274,7 +286,7 @@ impl<T> Encoder<T> {
 			true => self.emit_reset()?,
 			false => {
 				let bytes = serde_json::to_vec(&Op::<&Value>::Pop(count))?;
-				self.frame(bytes)
+				self.emit_op(bytes)?
 			}
 		};
 
@@ -311,10 +323,39 @@ impl<T: Serialize> Encoder<T> {
 				// Serialize the record out of the window rather than the caller's value, so its bytes
 				// match what a later reset would restate.
 				let bytes = serde_json::to_vec(&Op::Push(self.window.back().expect("just pushed")))?;
-				self.frame(bytes)
+				self.emit_op(bytes)?
 			}
 		};
 
 		Ok(self.pending(encoded))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn an_op_that_would_evict_the_reset_rolls_first() {
+		let mut encoder = Encoder::<String>::new(ProducerConfig::default().with_op_ratio(u32::MAX));
+		let first = "a".repeat(16 * 1024 * 1024);
+		let next = "b".repeat(15 * 1024 * 1024);
+
+		let frame = encoder.push(&first).unwrap();
+		assert!(frame.keyframe);
+		frame.commit();
+
+		let frame = encoder.push(&next).unwrap();
+		assert!(!frame.keyframe);
+		frame.commit();
+
+		let frame = encoder.pop(1).unwrap().unwrap();
+		assert!(!frame.keyframe);
+		frame.commit();
+
+		let frame = encoder.push(&next).unwrap();
+		assert!(frame.keyframe);
+		assert!(frame.payload.len() < moq_net::group::MAX_CACHE_BYTES as usize);
+		frame.commit();
 	}
 }

--- a/rs/moq-json/src/window/encoder.rs
+++ b/rs/moq-json/src/window/encoder.rs
@@ -7,12 +7,12 @@ use bytes::Bytes;
 use serde::Serialize;
 use serde_json::Value;
 
-use super::op::Op;
+use super::op::{Header, Op};
 use crate::Result;
 
-/// Frames (reset included) in one group before a reset is forced, matching
+/// Frames (header included) in one group before a new group is forced, matching
 /// [`snapshot`](crate::snapshot)'s cap. Kept well below moq-net's per-group frame cap so a late
-/// joiner can always read the reset at frame 0.
+/// joiner can always read the header at frame 0.
 pub(super) const MAX_GROUP_FRAMES: usize = 256;
 
 /// Configuration for an [`Encoder`] and the [`Producer`](super::Producer) wrapping one.
@@ -22,21 +22,21 @@ pub(super) const MAX_GROUP_FRAMES: usize = 256;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ProducerConfig {
-	/// How much the ops in a group may cost before a fresh reset is emitted.
+	/// How much the ops in a group may cost before a fresh group is emitted.
 	///
 	/// A new group opens once the pushes and pops *already written* exceed `op_ratio` times the
-	/// size of the group's reset frame. The pending op is excluded from that check, so the one that
+	/// size of the group's header frame. The pending op is excluded from that check, so the one that
 	/// tips the group over budget still lands: a group overshoots by at most one op before rolling.
-	/// `0` disables ops entirely, so every edit is its own single-frame reset.
+	/// `0` disables ops entirely, so every edit is its own single-frame group.
 	///
 	/// This is the window's counterpart to
 	/// [`snapshot::ProducerConfig::delta_ratio`](crate::snapshot::ProducerConfig::delta_ratio), and
-	/// the same trade: a bigger ratio spends less on resets and makes a late joiner read more ops.
+	/// the same trade: a bigger ratio spends less on headers and makes a late joiner read more ops.
 	///
 	/// Defaults to `8`.
 	pub op_ratio: u32,
 
-	/// Compress each group as one sync-flushed DEFLATE stream, so every op reuses the reset and the
+	/// Compress each group as one sync-flushed DEFLATE stream, so every op reuses the header and the
 	/// ops before it as context.
 	///
 	/// `false` (the default) emits plaintext JSON frames. A [`Decoder`](super::Decoder) reading them
@@ -74,9 +74,9 @@ pub struct Encoded {
 	/// The frame payload, DEFLATE-compressed when [`ProducerConfig::compression`] is set.
 	pub payload: Bytes,
 
-	/// Whether this frame is a reset, which must open a new group.
+	/// Whether this frame is a group header, which must open a new group.
 	///
-	/// The encoder decides this, never the caller: the op budget and the frame cap force a reset
+	/// The encoder decides this, never the caller: the op budget and the frame cap force a new group
 	/// independently of which edit was requested.
 	pub keyframe: bool,
 }
@@ -84,11 +84,11 @@ pub struct Encoded {
 /// An encoded frame the caller has not yet acknowledged writing.
 ///
 /// Write the frame, then [`commit`](Self::commit). A frame that never reaches the wire leaves the
-/// consumer's view behind the producer's window, so dropping it uncommitted
-/// [`reset`](Encoder::reset)s the encoder and the next frame restates the whole window.
+/// consumer's view behind the producer's window, so dropping it uncommitted starts a new group and
+/// the next frame restates the whole window.
 ///
 /// The window itself is not rolled back. It is the producer's truth, and the edit really happened;
-/// only the consumer's knowledge of it is lost, which the next reset repairs.
+/// only the consumer's knowledge of it is lost, which the next group header repairs.
 #[must_use = "write the frame, then commit it"]
 pub struct Pending<'a, T> {
 	encoder: &'a mut Encoder<T>,
@@ -133,26 +133,26 @@ impl<T> Drop for Pending<'_, T> {
 pub struct Encoder<T> {
 	config: ProducerConfig,
 
-	/// The retained window. Records are stored decoded so a reset can restate them, and so a record
-	/// serializes identically whether it reaches a reader as a push or in a later reset.
+	/// The retained window. Records are stored decoded so a header can restate them, and so a record
+	/// serializes identically whether it reaches a reader as a push or in a later header.
 	window: VecDeque<Value>,
 
-	/// Absolute index of `window.front()`. Only a reset puts this on the wire.
+	/// Absolute index of `window.front()`. Only a group header puts this on the wire.
 	offset: u64,
 
 	/// The current group's DEFLATE encoder (one window per group), `Some` while compressing.
 	flate: Option<moq_flate::Encoder>,
 
-	/// Bytes of pushes and pops emitted into the current group, excluding its reset frame.
+	/// Bytes of pushes and pops emitted into the current group, excluding its header frame.
 	op_bytes: u64,
 
-	/// Reference size the op budget is measured against: the current group's reset frame.
-	reset_len: u64,
+	/// Reference size the op budget is measured against: the current group's header frame.
+	header_len: u64,
 
-	/// Frames emitted into the current group, reset included.
+	/// Frames emitted into the current group, header included.
 	group_frames: usize,
 
-	/// Whether the next frame must be a reset, because a frame was lost or the caller rolled the
+	/// Whether the next frame must be a header, because a frame was lost or the caller rolled the
 	/// group. Kept separate from the window, which a resync must never discard.
 	resync: bool,
 
@@ -160,7 +160,7 @@ pub struct Encoder<T> {
 }
 
 impl<T> Encoder<T> {
-	/// Create an encoder with an empty window, so the first edit emits a reset.
+	/// Create an encoder with an empty window, so the first edit opens a group.
 	pub fn new(config: ProducerConfig) -> Self {
 		Self {
 			config,
@@ -168,7 +168,7 @@ impl<T> Encoder<T> {
 			offset: 0,
 			flate: None,
 			op_bytes: 0,
-			reset_len: 0,
+			header_len: 0,
 			group_frames: 0,
 			resync: true,
 			_marker: PhantomData,
@@ -187,17 +187,17 @@ impl<T> Encoder<T> {
 		self.offset..self.offset + self.window.len() as u64
 	}
 
-	/// Force the next frame to be a reset.
+	/// Force the next frame to open a new group with a header.
 	///
 	/// Call this whenever the caller closes the current group behind the encoder's back. Without it
 	/// the next frame may be a push against a DEFLATE window and an index base the new group does
 	/// not carry.
 	///
-	/// The window survives: the reset restates it in full anyway.
+	/// The window survives: the group header restates it in full anyway.
 	pub fn reset(&mut self) {
 		self.flate = None;
 		self.op_bytes = 0;
-		self.reset_len = 0;
+		self.header_len = 0;
 		self.group_frames = 0;
 		self.resync = true;
 	}
@@ -208,7 +208,7 @@ impl<T> Encoder<T> {
 		ratio != 0
 			&& self.group_frames > 0
 			&& self.group_frames < MAX_GROUP_FRAMES
-			&& self.op_bytes <= ratio * self.reset_len
+			&& self.op_bytes <= ratio * self.header_len
 	}
 
 	/// Compress an already-serialized op into the open group, charging it to the budget.
@@ -227,26 +227,26 @@ impl<T> Encoder<T> {
 		}
 	}
 
-	/// Emit an op when the reset will remain cached, otherwise restate the window in a new group.
+	/// Emit an op when the header will remain cached, otherwise restate the window in a new group.
 	fn emit_op(&mut self, bytes: Vec<u8>) -> Result<Encoded> {
 		let encoded = self.frame(bytes);
-		let group_bytes = self.reset_len.saturating_add(self.op_bytes);
+		let group_bytes = self.header_len.saturating_add(self.op_bytes);
 		if group_bytes > moq_net::group::MAX_CACHE_BYTES {
-			self.emit_reset()
+			self.emit_header()
 		} else {
 			Ok(encoded)
 		}
 	}
 
-	/// Encode a reset restating the whole window, opening a new group.
-	fn emit_reset(&mut self) -> Result<Encoded> {
+	/// Encode the header restating the whole window and opening a new group.
+	fn emit_header(&mut self) -> Result<Encoded> {
 		let records: Vec<&Value> = self.window.iter().collect();
-		let bytes = serde_json::to_vec(&Op::Reset {
+		let bytes = serde_json::to_vec(&Header {
 			offset: self.offset,
 			records,
 		})?;
 
-		// Open a fresh per-group encoder (cold window) and compress the reset as frame 0, recording
+		// Open a fresh per-group encoder (cold window) and compress the header as frame 0, recording
 		// its wire size as the op budget's anchor.
 		let (payload, flate) = match self.config.compression {
 			true => {
@@ -257,7 +257,7 @@ impl<T> Encoder<T> {
 			false => (Bytes::from(bytes), None),
 		};
 
-		self.reset_len = payload.len() as u64;
+		self.header_len = payload.len() as u64;
 		self.op_bytes = 0;
 		self.group_frames = 1;
 		self.flate = flate;
@@ -272,7 +272,7 @@ impl<T> Encoder<T> {
 	/// Drop `count` records from the front of the window.
 	///
 	/// Returns `None` when there is nothing to drop, so a caller can trim unconditionally. Emits a
-	/// pop into the open group, or a reset restating what is left.
+	/// pop into the open group, or a header restating what is left in a new group.
 	pub fn pop(&mut self, count: u64) -> Result<Option<Pending<'_, T>>> {
 		let count = count.min(self.window.len() as u64);
 		if count == 0 {
@@ -283,7 +283,7 @@ impl<T> Encoder<T> {
 		self.offset += count;
 
 		let encoded = match self.resync || !self.op_allowed() {
-			true => self.emit_reset()?,
+			true => self.emit_header()?,
 			false => {
 				let bytes = serde_json::to_vec(&Op::<&Value>::Pop(count))?;
 				self.emit_op(bytes)?
@@ -306,7 +306,7 @@ impl<T> Encoder<T> {
 impl<T: Serialize> Encoder<T> {
 	/// Append one record to the back of the window.
 	///
-	/// Emits a push into the open group, or a reset restating the window (the new record included)
+	/// Emits a push into the open group, or a header restating the window (the new record included)
 	/// when the op budget is spent or a frame was lost.
 	pub fn push(&mut self, value: &T) -> Result<Pending<'_, T>> {
 		// Serialize before touching the window, so a value that can't be encoded leaves the encoder
@@ -318,10 +318,10 @@ impl<T: Serialize> Encoder<T> {
 		self.window.push_back(record);
 
 		let encoded = match self.resync || !self.op_allowed() {
-			true => self.emit_reset()?,
+			true => self.emit_header()?,
 			false => {
 				// Serialize the record out of the window rather than the caller's value, so its bytes
-				// match what a later reset would restate.
+				// match what a later group header would restate.
 				let bytes = serde_json::to_vec(&Op::Push(self.window.back().expect("just pushed")))?;
 				self.emit_op(bytes)?
 			}
@@ -336,7 +336,7 @@ mod test {
 	use super::*;
 
 	#[test]
-	fn an_op_that_would_evict_the_reset_rolls_first() {
+	fn an_op_that_would_evict_the_header_rolls_first() {
 		let mut encoder = Encoder::<String>::new(ProducerConfig::default().with_op_ratio(u32::MAX));
 		let first = "a".repeat(16 * 1024 * 1024);
 		let next = "b".repeat(15 * 1024 * 1024);

--- a/rs/moq-json/src/window/encoder.rs
+++ b/rs/moq-json/src/window/encoder.rs
@@ -122,7 +122,7 @@ impl<T> Pending<'_, T> {
 impl<T> Drop for Pending<'_, T> {
 	fn drop(&mut self) {
 		if self.edit.is_some() {
-			self.encoder.start_group();
+			self.encoder.resync();
 		}
 	}
 }
@@ -158,8 +158,8 @@ pub struct Encoder<T> {
 	/// Frames emitted into the current group, header included.
 	group_frames: usize,
 
-	/// Whether the next frame must be a header, because a frame was lost or the caller rolled the
-	/// group. Kept separate from the window, which a resync must never discard.
+	/// Whether the next frame must be a header because a frame was lost. Kept separate from the
+	/// window, which a resync must never discard.
 	resync: bool,
 
 	_marker: PhantomData<fn(T)>,
@@ -193,14 +193,8 @@ impl<T> Encoder<T> {
 		self.offset..self.offset + self.window.len() as u64
 	}
 
-	/// Make the next frame open a new group with a header.
-	///
-	/// Call this whenever the caller closes the current group behind the encoder's back. Without it
-	/// the next frame may be a push against a DEFLATE window and an index base the new group does
-	/// not carry.
-	///
-	/// The window survives: the group header restates it in full anyway.
-	pub fn start_group(&mut self) {
+	/// Discard group-local state after an encoded frame did not reach the wire.
+	fn resync(&mut self) {
 		self.flate = None;
 		self.op_bytes = 0;
 		self.header_len = 0;

--- a/rs/moq-json/src/window/encoder.rs
+++ b/rs/moq-json/src/window/encoder.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::op::{Header, Op};
-use crate::Result;
+use crate::{Error, Result};
 
 /// Frames (header included) in one group before a new group is forced, matching
 /// [`snapshot`](crate::snapshot)'s cap. Kept well below moq-net's per-group frame cap so a late
@@ -184,8 +184,8 @@ impl<T> Encoder<T> {
 	/// The retained window, oldest first.
 	///
 	/// The encoder holds this to restate it on a roll, so a caller needs no parallel copy.
-	pub fn window(&self) -> impl ExactSizeIterator<Item = &Value> {
-		self.window.iter()
+	pub fn window(&self) -> Vec<Value> {
+		self.window.iter().cloned().collect()
 	}
 
 	/// Absolute index of the oldest retained record, and of the next one to be pushed.
@@ -222,8 +222,19 @@ impl<T> Encoder<T> {
 			&& self.op_bytes <= ratio * self.header_len
 	}
 
+	/// Reject plaintext that the paired DEFLATE decoder could not produce.
+	fn validate_plaintext(len: usize, kind: &str) -> Result<()> {
+		if u64::try_from(len).unwrap_or(u64::MAX) > moq_flate::DEFAULT_MAX_FRAME_SIZE {
+			return Err(Error::Json(format!(
+				"window {kind} exceeds the decoder's decompressed size limit"
+			)));
+		}
+		Ok(())
+	}
+
 	/// Compress an already-serialized op into the open group, charging it to the budget.
-	fn frame(&mut self, bytes: Vec<u8>) -> Encoded {
+	fn frame(&mut self, bytes: Vec<u8>) -> Result<Encoded> {
+		Self::validate_plaintext(bytes.len(), "frame")?;
 		let payload = match self.flate.as_mut() {
 			Some(flate) => flate.frame(&bytes),
 			None => Bytes::from(bytes),
@@ -232,20 +243,21 @@ impl<T> Encoder<T> {
 		self.op_bytes += payload.len() as u64;
 		self.group_frames += 1;
 
-		Encoded {
+		Ok(Encoded {
 			payload,
 			keyframe: false,
-		}
+		})
 	}
 
 	/// Emit an op when the header will remain cached, otherwise restate the window in a new group.
-	fn emit_op(&mut self, bytes: Vec<u8>) -> Option<Encoded> {
-		let encoded = self.frame(bytes);
+	fn emit_op(&mut self, bytes: Vec<u8>) -> Result<Option<Encoded>> {
+		let encoded = self.frame(bytes)?;
 		let group_bytes = self.header_len.saturating_add(self.op_bytes);
 		if group_bytes > moq_net::group::MAX_CACHE_BYTES {
-			None
+			self.resync();
+			Ok(None)
 		} else {
-			Some(encoded)
+			Ok(Some(encoded))
 		}
 	}
 
@@ -255,7 +267,9 @@ impl<T> Encoder<T> {
 	}
 
 	/// Encode the header restating the whole window and opening a new group.
-	fn emit_header(&mut self, bytes: Vec<u8>) -> Encoded {
+	fn emit_header(&mut self, bytes: Vec<u8>) -> Result<Encoded> {
+		Self::validate_plaintext(bytes.len(), "header")?;
+
 		// Open a fresh per-group encoder (cold window) and compress the header as frame 0, recording
 		// its wire size as the op budget's anchor.
 		let (payload, flate) = match self.config.compression {
@@ -266,6 +280,9 @@ impl<T> Encoder<T> {
 			}
 			false => (Bytes::from(bytes), None),
 		};
+		if payload.len() as u64 > moq_net::group::MAX_CACHE_BYTES {
+			return Err(Error::Json("window header exceeds the group cache limit".into()));
+		}
 
 		self.header_len = payload.len() as u64;
 		self.op_bytes = 0;
@@ -273,10 +290,10 @@ impl<T> Encoder<T> {
 		self.flate = flate;
 		self.resync = false;
 
-		Encoded {
+		Ok(Encoded {
 			payload,
 			keyframe: true,
-		}
+		})
 	}
 
 	/// Drop `count` records from the front of the window.
@@ -293,15 +310,15 @@ impl<T> Encoder<T> {
 		let encoded = match self.resync || !self.op_allowed() {
 			true => {
 				let bytes = Self::header(offset, self.window.iter().skip(count as usize).collect())?;
-				self.emit_header(bytes)
+				self.emit_header(bytes)?
 			}
 			false => {
 				let bytes = serde_json::to_vec(&Op::<&Value>::Pop(count))?;
-				match self.emit_op(bytes) {
+				match self.emit_op(bytes)? {
 					Some(encoded) => encoded,
 					None => {
 						let bytes = Self::header(offset, self.window.iter().skip(count as usize).collect())?;
-						self.emit_header(bytes)
+						self.emit_header(bytes)?
 					}
 				}
 			}
@@ -341,18 +358,18 @@ impl<T: Serialize> Encoder<T> {
 					self.offset,
 					self.window.iter().chain(std::iter::once(&record)).collect(),
 				)?;
-				self.emit_header(bytes)
+				self.emit_header(bytes)?
 			}
 			false => {
 				let bytes = serde_json::to_vec(&Op::Push(&record))?;
-				match self.emit_op(bytes) {
+				match self.emit_op(bytes)? {
 					Some(encoded) => encoded,
 					None => {
 						let bytes = Self::header(
 							self.offset,
 							self.window.iter().chain(std::iter::once(&record)).collect(),
 						)?;
-						self.emit_header(bytes)
+						self.emit_header(bytes)?
 					}
 				}
 			}
@@ -395,14 +412,33 @@ mod test {
 		let mut encoder = Encoder::<u64>::new(ProducerConfig::default());
 
 		drop(encoder.push(&1).unwrap());
-		assert!(encoder.window().next().is_none());
+		assert!(encoder.window().is_empty());
 
 		let frame = encoder.push(&2).unwrap();
 		assert!(frame.keyframe);
 		frame.commit();
-		assert_eq!(encoder.window().collect::<Vec<_>>(), vec![&Value::from(2)]);
+		assert_eq!(encoder.window(), vec![Value::from(2)]);
 
 		drop(encoder.pop(1).unwrap().unwrap());
-		assert_eq!(encoder.window().collect::<Vec<_>>(), vec![&Value::from(2)]);
+		assert_eq!(encoder.window(), vec![Value::from(2)]);
+	}
+
+	#[test]
+	fn a_header_larger_than_the_group_cache_is_rejected() {
+		let mut encoder = Encoder::<String>::new(ProducerConfig::default());
+		let record = "x".repeat(moq_net::group::MAX_CACHE_BYTES as usize);
+
+		let err = encoder.push(&record).err().expect("oversized header should fail");
+		assert!(err.to_string().contains("group cache limit"));
+		assert!(encoder.window().is_empty());
+
+		let frame = encoder.push(&"ok".to_string()).unwrap();
+		assert!(frame.keyframe);
+	}
+
+	#[test]
+	fn plaintext_is_bounded_by_the_decoder_limit() {
+		let len = usize::try_from(moq_flate::DEFAULT_MAX_FRAME_SIZE + 1).unwrap();
+		assert!(Encoder::<()>::validate_plaintext(len, "frame").is_err());
 	}
 }

--- a/rs/moq-json/src/window/mod.rs
+++ b/rs/moq-json/src/window/mod.rs
@@ -52,7 +52,7 @@ mod op;
 mod producer;
 
 pub use consumer::Consumer;
-pub use decoder::{ConsumerConfig, Decoder, Event};
+pub use decoder::{ConsumerConfig, Decoder, Event, Group};
 pub use encoder::{Encoded, Encoder, Pending, ProducerConfig};
 pub use producer::Producer;
 
@@ -280,8 +280,8 @@ mod test {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
 		for n in 0..2 {
 			let frame = encoder.push(&rec(n)).unwrap();
-			decoder.start_group();
-			decoder.decode(&frame.payload).unwrap();
+			let mut group = decoder.group();
+			group.decode(&frame.payload).unwrap();
 			frame.commit();
 		}
 		assert_eq!(
@@ -307,8 +307,8 @@ mod test {
 			latest = Some(frame.payload.clone());
 			frame.commit();
 		}
-		decoder.start_group();
-		decoder.decode(&latest.unwrap()).unwrap();
+		let mut group = decoder.group();
+		group.decode(&latest.unwrap()).unwrap();
 
 		let events = std::iter::from_fn(|| decoder.next_event()).collect::<Vec<_>>();
 		let skipped: Vec<std::ops::Range<u64>> = events
@@ -403,9 +403,10 @@ mod test {
 	#[test]
 	fn a_large_gap_is_one_skip_event() {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
-		decoder.decode(br#"{"offset":0,"records":[]}"#).unwrap();
-		decoder.start_group();
-		decoder.decode(br#"{"offset":9007199254740991,"records":[]}"#).unwrap();
+		let mut group = decoder.group();
+		group.decode(br#"{"offset":0,"records":[]}"#).unwrap();
+		let mut group = decoder.group();
+		group.decode(br#"{"offset":9007199254740991,"records":[]}"#).unwrap();
 
 		assert_eq!(decoder.next_event(), Some(Event::Skip(0..super::encoder::MAX_INDEX)));
 		assert_eq!(decoder.next_event(), None);
@@ -414,28 +415,32 @@ mod test {
 	#[test]
 	fn indices_must_fit_the_shared_safe_integer_range() {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
-		assert!(decoder.decode(br#"{"offset":9007199254740992,"records":[]}"#).is_err());
+		let mut group = decoder.group();
+		assert!(group.decode(br#"{"offset":9007199254740992,"records":[]}"#).is_err());
 
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
-		decoder.decode(br#"{"offset":9007199254740991,"records":[]}"#).unwrap();
-		assert!(decoder.decode(br#"{"push":null}"#).is_err());
+		let mut group = decoder.group();
+		group.decode(br#"{"offset":9007199254740991,"records":[]}"#).unwrap();
+		assert!(group.decode(br#"{"push":null}"#).is_err());
 	}
 
 	#[test]
 	fn every_group_requires_a_header() {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
-		decoder.decode(br#"{"offset":0,"records":[]}"#).unwrap();
-		decoder.start_group();
+		let mut group = decoder.group();
+		group.decode(br#"{"offset":0,"records":[]}"#).unwrap();
+		let mut group = decoder.group();
 
-		assert!(decoder.decode(br#"{"push":null}"#).is_err());
+		assert!(group.decode(br#"{"push":null}"#).is_err());
 	}
 
 	#[test]
 	fn a_header_is_only_valid_as_frame_zero() {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
-		decoder.decode(br#"{"offset":0,"records":[]}"#).unwrap();
+		let mut group = decoder.group();
+		group.decode(br#"{"offset":0,"records":[]}"#).unwrap();
 
-		assert!(decoder.decode(br#"{"offset":0,"records":[]}"#).is_err());
+		assert!(group.decode(br#"{"offset":0,"records":[]}"#).is_err());
 	}
 
 	#[test]

--- a/rs/moq-json/src/window/mod.rs
+++ b/rs/moq-json/src/window/mod.rs
@@ -199,7 +199,7 @@ mod test {
 			}
 		}
 
-		// Three pushes past the first pop, so the window holds the last three and starts at 2.
+		// Three pops leave the two newest records, at indices 3 and 4.
 		assert_eq!(producer.range(), 3..5);
 		assert_eq!(producer.window(), vec![rec(3), rec(4)]);
 	}

--- a/rs/moq-json/src/window/mod.rs
+++ b/rs/moq-json/src/window/mod.rs
@@ -378,6 +378,23 @@ mod test {
 	}
 
 	#[test]
+	fn writes_after_another_clone_finishes_are_rejected() {
+		let (mut producer, _track) = producer(ProducerConfig::default());
+		producer.push(&rec(1)).unwrap();
+		producer.clone().finish().unwrap();
+
+		assert!(matches!(
+			producer.push(&rec(2)),
+			Err(crate::Error::Net(moq_net::Error::Closed))
+		));
+		assert!(matches!(
+			producer.pop(1),
+			Err(crate::Error::Net(moq_net::Error::Closed))
+		));
+		assert_eq!(producer.window(), vec![rec(1)]);
+	}
+
+	#[test]
 	fn a_pop_is_clamped_to_the_window() {
 		let mut live = Live::new(ProducerConfig::default());
 		live.push(0);

--- a/rs/moq-json/src/window/mod.rs
+++ b/rs/moq-json/src/window/mod.rs
@@ -34,10 +34,10 @@
 //!
 //! # What a reader is told
 //!
-//! Every index is reported exactly once: [`Event::Push`] when a record arrives, [`Event::Pop`] when
-//! it leaves, and [`Event::Skip`] when it existed but was dropped before this reader saw it. A
-//! reader that keeps up sees pushes and pops; one that joins late, or falls a group behind, learns
-//! from the reset's offset which records it will never get, rather than silently missing them.
+//! A reader gets [`Event::Push`] when a record arrives, [`Event::Pop`] when a contiguous range
+//! leaves, and [`Event::Skip`] when a range was dropped before this reader saw it. A reader that
+//! keeps up sees pushes and pops; one that falls a group behind learns from the reset's offset which
+//! records it will never get, rather than silently missing them.
 //!
 //! # Choosing a layer
 //!
@@ -72,11 +72,6 @@ mod test {
 			.unwrap();
 		let consumer = track.subscribe(None);
 		(Producer::new(track, config), consumer)
-	}
-
-	/// A subscription patient enough to read every group of a finished track.
-	fn replay(track: &moq_net::track::Producer) -> moq_net::track::Subscriber {
-		track.subscribe(moq_net::track::Subscription::default().with_max_age(std::time::Duration::from_secs(30)))
 	}
 
 	fn consumer(track: moq_net::track::Subscriber, compression: bool) -> Consumer<Value> {
@@ -164,7 +159,7 @@ mod test {
 			vec![
 				Event::Push(0, rec(0)),
 				Event::Push(1, rec(1)),
-				Event::Pop(0),
+				Event::Pop(0..1),
 				Event::Push(2, rec(2)),
 			]
 		);
@@ -201,7 +196,7 @@ mod test {
 			vec![
 				Event::Push(0, rec(0)),
 				Event::Push(1, rec(1)),
-				Event::Pop(0),
+				Event::Pop(0..1),
 				Event::Push(2, rec(2)),
 			]
 		);
@@ -213,48 +208,59 @@ mod test {
 			.produce()
 			.create_track("test", None)
 			.unwrap();
-		let replay = replay(&track);
-		let mut producer = Producer::<Value>::new(track, ProducerConfig::default());
+		let mut producer = Producer::<Value>::new(track, ProducerConfig::default().with_op_ratio(0));
 
 		for n in 0..5 {
 			producer.push(&rec(n)).unwrap();
 		}
 		producer.pop(3).unwrap();
+		let mut subscriber = producer.consume();
+		subscriber.start_at(subscriber.latest().unwrap());
+		let mut fresh = consumer(subscriber, false);
 		producer.finish().unwrap();
 
 		// Joining at offset 3 must not report 3 skips for records that were never this reader's to
 		// miss: it simply starts where the window starts.
-		let events = drain(&mut consumer(replay, false));
-		assert_eq!(events.first(), Some(&Event::Push(0, rec(0))));
+		let events = drain(&mut fresh);
+		assert_eq!(events, vec![Event::Push(3, rec(3)), Event::Push(4, rec(4))]);
 		assert!(!events.iter().any(|e| matches!(e, Event::Skip(_))));
 	}
 
 	#[test]
 	fn a_lagging_consumer_is_told_what_it_missed() {
-		// Ops disabled, so every edit rolls: a reader that stops polling really does lose groups.
-		let (mut producer, track) = producer(ProducerConfig::default().with_op_ratio(0));
-		let mut consumer = consumer(track, false);
-
-		producer.push(&rec(0)).unwrap();
-		producer.push(&rec(1)).unwrap();
+		// Ops are disabled, so every edit is a reset in a new group. Feed the first two groups to the
+		// decoder, skip the middle groups as a lagging track subscriber would, then resume at the
+		// latest reset.
+		let mut encoder = Encoder::<Value>::new(ProducerConfig::default().with_op_ratio(0));
+		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
+		for n in 0..2 {
+			let frame = encoder.push(&rec(n)).unwrap();
+			decoder.reset();
+			decoder.decode(&frame.payload).unwrap();
+			frame.commit();
+		}
 		assert_eq!(
-			drain(&mut consumer),
+			std::iter::from_fn(|| decoder.next_event()).collect::<Vec<_>>(),
 			vec![Event::Push(0, rec(0)), Event::Push(1, rec(1))]
 		);
 
-		// The consumer stops reading. The window slides past everything it holds, and the publisher
-		// rolls, so the groups it would have read are gone.
+		let mut latest = None;
 		for n in 2..8 {
-			producer.push(&rec(n)).unwrap();
-			producer.pop(1).unwrap();
-		}
-		producer.finish().unwrap();
+			let frame = encoder.push(&rec(n)).unwrap();
+			frame.commit();
 
-		let events = drain(&mut consumer);
-		let skipped: Vec<u64> = events
+			let frame = encoder.pop(1).unwrap().unwrap();
+			latest = Some(frame.payload.clone());
+			frame.commit();
+		}
+		decoder.reset();
+		decoder.decode(&latest.unwrap()).unwrap();
+
+		let events = std::iter::from_fn(|| decoder.next_event()).collect::<Vec<_>>();
+		let skipped: Vec<std::ops::Range<u64>> = events
 			.iter()
 			.filter_map(|e| match e {
-				Event::Skip(i) => Some(*i),
+				Event::Skip(range) => Some(range.clone()),
 				_ => None,
 			})
 			.collect();
@@ -262,14 +268,15 @@ mod test {
 		// Records 2..=5 existed but this reader will never receive them, and it is told so rather than
 		// silently jumping from 1 to 6.
 		assert!(!skipped.is_empty(), "expected skips, got {events:?}");
-		assert_eq!(skipped.first(), Some(&2));
+		assert_eq!(skipped.first().map(|range| range.start), Some(2));
 
 		// Every index is still accounted for exactly once, in order.
 		let reported: Vec<u64> = events
 			.iter()
-			.filter_map(|e| match e {
-				Event::Push(i, _) | Event::Skip(i) => Some(*i),
-				Event::Pop(_) => None,
+			.flat_map(|e| match e {
+				Event::Push(i, _) => vec![*i],
+				Event::Skip(range) => range.clone().collect(),
+				Event::Pop(_) => Vec::new(),
 			})
 			.collect();
 		assert!(reported.windows(2).all(|w| w[1] == w[0] + 1), "gaps in {reported:?}");
@@ -308,8 +315,33 @@ mod test {
 
 		assert_eq!(
 			live.finish(),
-			vec![Event::Push(0, rec(0)), Event::Pop(0), Event::Push(1, rec(1))]
+			vec![Event::Push(0, rec(0)), Event::Pop(0..1), Event::Push(1, rec(1))]
 		);
+	}
+
+	#[test]
+	fn a_large_gap_is_one_skip_event() {
+		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
+		decoder.decode(br#"{"reset":{"offset":0,"records":[]}}"#).unwrap();
+		decoder.reset();
+		decoder
+			.decode(br#"{"reset":{"offset":18446744073709551615,"records":[]}}"#)
+			.unwrap();
+
+		assert_eq!(decoder.next_event(), Some(Event::Skip(0..u64::MAX)));
+		assert_eq!(decoder.next_event(), None);
+	}
+
+	#[test]
+	fn every_group_requires_a_reset() {
+		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
+		decoder.decode(br#"{"reset":{"offset":0,"records":[]}}"#).unwrap();
+		decoder.reset();
+
+		assert!(matches!(
+			decoder.decode(br#"{"push":null}"#),
+			Err(crate::Error::MissingReset)
+		));
 	}
 
 	#[test]

--- a/rs/moq-json/src/window/mod.rs
+++ b/rs/moq-json/src/window/mod.rs
@@ -14,11 +14,9 @@
 //!
 //! # On the wire
 //!
-//! Every frame is a tagged op. Each group opens with a `reset` naming the retained records and the
-//! absolute `offset` of the first, followed by `push` and `pop` ops. Only the reset carries an
-//! index: a push takes the next one and a pop drops from the front, both positional against the
-//! reset, which is sound because the group-scoped DEFLATE window already makes a mid-group join
-//! undecodable.
+//! The first frame of every group names the retained `records` and the absolute `offset` of the
+//! first. Later frames are tagged `push` and `pop` ops. A push takes the next index and a pop drops
+//! from the front, both positional against the group header.
 //!
 //! Trimming is therefore an op, not a group boundary. Dropping a record costs one small frame
 //! inside the shared compression window instead of a roll that would throw that window away.
@@ -26,9 +24,9 @@
 //! # Group boundaries are invisible
 //!
 //! The publisher rolls a group when the ops in it outgrow
-//! [`ProducerConfig::op_ratio`](ProducerConfig::op_ratio) times the reset that opened it, exactly as
+//! [`ProducerConfig::op_ratio`](ProducerConfig::op_ratio) times the header that opened it, exactly as
 //! [`snapshot`](crate::snapshot) rolls on its delta budget. That is purely a compression decision:
-//! there is no caller-driven cut and no age bound, and a [`Consumer`] never surfaces it. A reset
+//! there is no caller-driven cut and no age bound, and a [`Consumer`] never surfaces it. A header
 //! restating records a reader already has yields nothing, so however often the publisher rolls, the
 //! reader sees one continuous stream of [`Event`]s.
 //!
@@ -36,7 +34,7 @@
 //!
 //! A reader gets [`Event::Push`] when a record arrives, [`Event::Pop`] when a contiguous range
 //! leaves, and [`Event::Skip`] when a range was dropped before this reader saw it. A reader that
-//! keeps up sees pushes and pops; one that falls a group behind learns from the reset's offset which
+//! keeps up sees pushes and pops; one that falls a group behind learns from the header's offset which
 //! records it will never get, rather than silently missing them.
 //!
 //! # Choosing a layer
@@ -96,7 +94,7 @@ mod test {
 	///
 	/// Polling as the publisher goes is what "keeping up" means: a consumer left until the end is a
 	/// whole group behind, and the default subscription abandons a group as soon as a newer one
-	/// exists, so it would resume at the newest reset instead of reading the rolls in between.
+	/// exists, so it would resume at the newest header instead of reading the rolls in between.
 	struct Live {
 		producer: Producer<Value>,
 		consumer: Consumer<Value>,
@@ -182,7 +180,7 @@ mod test {
 
 	#[test]
 	fn a_popped_record_is_never_restated() {
-		// Ops disabled, so every single edit is its own reset restating the whole window.
+		// Ops disabled, so every single edit is its own group restating the whole window.
 		let mut live = Live::new(ProducerConfig::default().with_op_ratio(0));
 		live.push(0);
 		live.push(1);
@@ -228,9 +226,9 @@ mod test {
 
 	#[test]
 	fn a_lagging_consumer_is_told_what_it_missed() {
-		// Ops are disabled, so every edit is a reset in a new group. Feed the first two groups to the
+		// Ops are disabled, so every edit opens a new group. Feed the first two groups to the
 		// decoder, skip the middle groups as a lagging track subscriber would, then resume at the
-		// latest reset.
+		// latest header.
 		let mut encoder = Encoder::<Value>::new(ProducerConfig::default().with_op_ratio(0));
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
 		for n in 0..2 {
@@ -322,10 +320,10 @@ mod test {
 	#[test]
 	fn a_large_gap_is_one_skip_event() {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
-		decoder.decode(br#"{"reset":{"offset":0,"records":[]}}"#).unwrap();
+		decoder.decode(br#"{"offset":0,"records":[]}"#).unwrap();
 		decoder.reset();
 		decoder
-			.decode(br#"{"reset":{"offset":18446744073709551615,"records":[]}}"#)
+			.decode(br#"{"offset":18446744073709551615,"records":[]}"#)
 			.unwrap();
 
 		assert_eq!(decoder.next_event(), Some(Event::Skip(0..u64::MAX)));
@@ -333,15 +331,20 @@ mod test {
 	}
 
 	#[test]
-	fn every_group_requires_a_reset() {
+	fn every_group_requires_a_header() {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
-		decoder.decode(br#"{"reset":{"offset":0,"records":[]}}"#).unwrap();
+		decoder.decode(br#"{"offset":0,"records":[]}"#).unwrap();
 		decoder.reset();
 
-		assert!(matches!(
-			decoder.decode(br#"{"push":null}"#),
-			Err(crate::Error::MissingReset)
-		));
+		assert!(decoder.decode(br#"{"push":null}"#).is_err());
+	}
+
+	#[test]
+	fn a_header_is_only_valid_as_frame_zero() {
+		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
+		decoder.decode(br#"{"offset":0,"records":[]}"#).unwrap();
+
+		assert!(decoder.decode(br#"{"offset":0,"records":[]}"#).is_err());
 	}
 
 	#[test]

--- a/rs/moq-json/src/window/mod.rs
+++ b/rs/moq-json/src/window/mod.rs
@@ -17,6 +17,7 @@
 //! The first frame of every group names the retained `records` and the absolute `offset` of the
 //! first. Later frames are tagged `push` and `pop` ops. A push takes the next index and a pop drops
 //! from the front, both positional against the group header.
+//! Indices stop at 2^53 - 1, the largest integer represented exactly by both implementations.
 //!
 //! Trimming is therefore an op, not a group boundary. Dropping a record costs one small frame
 //! inside the shared compression window instead of a roll that would throw that window away.
@@ -76,6 +77,17 @@ mod test {
 		Consumer::new(track, ConsumerConfig::default().with_compression(compression))
 	}
 
+	/// A track whose timestamp conversion rejects every frame after its group is published.
+	fn rejecting_track() -> moq_net::track::Producer {
+		let mut info = moq_net::track::Info::default();
+		info.timescale = moq_net::Timescale::new((1u64 << 62) - 1).unwrap();
+
+		moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", Some(info))
+			.unwrap()
+	}
+
 	/// Drain every event currently available without blocking.
 	fn drain(consumer: &mut Consumer<Value>) -> Vec<Event<Value>> {
 		let waiter = kio::Waiter::noop();
@@ -126,10 +138,15 @@ mod test {
 			self.events.extend(drain(&mut self.consumer));
 		}
 
-		fn finish(mut self) -> Vec<Event<Value>> {
-			self.producer.finish().unwrap();
-			self.read();
-			self.events
+		fn finish(self) -> Vec<Event<Value>> {
+			let Live {
+				producer,
+				mut consumer,
+				mut events,
+			} = self;
+			producer.finish().unwrap();
+			events.extend(drain(&mut consumer));
+			events
 		}
 
 		/// Just the indices pushed, in order.
@@ -137,7 +154,7 @@ mod test {
 			events
 				.iter()
 				.filter_map(|e| match e {
-					Event::Push(i, _) => Some(*i),
+					Event::Push { index, .. } => Some(*index),
 					_ => None,
 				})
 				.collect()
@@ -155,10 +172,19 @@ mod test {
 		assert_eq!(
 			live.finish(),
 			vec![
-				Event::Push(0, rec(0)),
-				Event::Push(1, rec(1)),
+				Event::Push {
+					index: 0,
+					value: rec(0)
+				},
+				Event::Push {
+					index: 1,
+					value: rec(1)
+				},
 				Event::Pop(0..1),
-				Event::Push(2, rec(2)),
+				Event::Push {
+					index: 2,
+					value: rec(2)
+				},
 			]
 		);
 	}
@@ -192,10 +218,19 @@ mod test {
 		assert_eq!(
 			live.finish(),
 			vec![
-				Event::Push(0, rec(0)),
-				Event::Push(1, rec(1)),
+				Event::Push {
+					index: 0,
+					value: rec(0)
+				},
+				Event::Push {
+					index: 1,
+					value: rec(1)
+				},
 				Event::Pop(0..1),
-				Event::Push(2, rec(2)),
+				Event::Push {
+					index: 2,
+					value: rec(2)
+				},
 			]
 		);
 	}
@@ -220,7 +255,19 @@ mod test {
 		// Joining at offset 3 must not report 3 skips for records that were never this reader's to
 		// miss: it simply starts where the window starts.
 		let events = drain(&mut fresh);
-		assert_eq!(events, vec![Event::Push(3, rec(3)), Event::Push(4, rec(4))]);
+		assert_eq!(
+			events,
+			vec![
+				Event::Push {
+					index: 3,
+					value: rec(3)
+				},
+				Event::Push {
+					index: 4,
+					value: rec(4)
+				}
+			]
+		);
 		assert!(!events.iter().any(|e| matches!(e, Event::Skip(_))));
 	}
 
@@ -233,13 +280,22 @@ mod test {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
 		for n in 0..2 {
 			let frame = encoder.push(&rec(n)).unwrap();
-			decoder.reset();
+			decoder.start_group();
 			decoder.decode(&frame.payload).unwrap();
 			frame.commit();
 		}
 		assert_eq!(
 			std::iter::from_fn(|| decoder.next_event()).collect::<Vec<_>>(),
-			vec![Event::Push(0, rec(0)), Event::Push(1, rec(1))]
+			vec![
+				Event::Push {
+					index: 0,
+					value: rec(0)
+				},
+				Event::Push {
+					index: 1,
+					value: rec(1)
+				}
+			]
 		);
 
 		let mut latest = None;
@@ -251,7 +307,7 @@ mod test {
 			latest = Some(frame.payload.clone());
 			frame.commit();
 		}
-		decoder.reset();
+		decoder.start_group();
 		decoder.decode(&latest.unwrap()).unwrap();
 
 		let events = std::iter::from_fn(|| decoder.next_event()).collect::<Vec<_>>();
@@ -272,7 +328,7 @@ mod test {
 		let reported: Vec<u64> = events
 			.iter()
 			.flat_map(|e| match e {
-				Event::Push(i, _) => vec![*i],
+				Event::Push { index, .. } => vec![*index],
 				Event::Skip(range) => range.clone().collect(),
 				Event::Pop(_) => Vec::new(),
 			})
@@ -305,6 +361,23 @@ mod test {
 	}
 
 	#[test]
+	fn a_rejected_edit_leaves_the_window_unchanged() {
+		let track = rejecting_track();
+		let mut subscriber = track.subscribe(None);
+		let mut producer = Producer::<Value>::new(track, ProducerConfig::default());
+
+		assert!(producer.push(&rec(1)).is_err());
+		assert_eq!(producer.range(), 0..0);
+		assert!(producer.window().is_empty());
+
+		let waiter = kio::Waiter::noop();
+		let Poll::Ready(Ok(Some(mut group))) = subscriber.poll_next_group(&waiter) else {
+			panic!("the rejected group's header was published");
+		};
+		assert!(matches!(group.poll_read_frame(&waiter), Poll::Ready(Ok(None))));
+	}
+
+	#[test]
 	fn a_pop_is_clamped_to_the_window() {
 		let mut live = Live::new(ProducerConfig::default());
 		live.push(0);
@@ -313,7 +386,17 @@ mod test {
 
 		assert_eq!(
 			live.finish(),
-			vec![Event::Push(0, rec(0)), Event::Pop(0..1), Event::Push(1, rec(1))]
+			vec![
+				Event::Push {
+					index: 0,
+					value: rec(0)
+				},
+				Event::Pop(0..1),
+				Event::Push {
+					index: 1,
+					value: rec(1)
+				},
+			]
 		);
 	}
 
@@ -321,20 +404,28 @@ mod test {
 	fn a_large_gap_is_one_skip_event() {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
 		decoder.decode(br#"{"offset":0,"records":[]}"#).unwrap();
-		decoder.reset();
-		decoder
-			.decode(br#"{"offset":18446744073709551615,"records":[]}"#)
-			.unwrap();
+		decoder.start_group();
+		decoder.decode(br#"{"offset":9007199254740991,"records":[]}"#).unwrap();
 
-		assert_eq!(decoder.next_event(), Some(Event::Skip(0..u64::MAX)));
+		assert_eq!(decoder.next_event(), Some(Event::Skip(0..super::encoder::MAX_INDEX)));
 		assert_eq!(decoder.next_event(), None);
+	}
+
+	#[test]
+	fn indices_must_fit_the_shared_safe_integer_range() {
+		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
+		assert!(decoder.decode(br#"{"offset":9007199254740992,"records":[]}"#).is_err());
+
+		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
+		decoder.decode(br#"{"offset":9007199254740991,"records":[]}"#).unwrap();
+		assert!(decoder.decode(br#"{"push":null}"#).is_err());
 	}
 
 	#[test]
 	fn every_group_requires_a_header() {
 		let mut decoder = Decoder::<Value>::new(ConsumerConfig::default());
 		decoder.decode(br#"{"offset":0,"records":[]}"#).unwrap();
-		decoder.reset();
+		decoder.start_group();
 
 		assert!(decoder.decode(br#"{"push":null}"#).is_err());
 	}

--- a/rs/moq-json/src/window/mod.rs
+++ b/rs/moq-json/src/window/mod.rs
@@ -1,0 +1,331 @@
+//! Sliding-window JSON publishing over [`moq-net`](moq_net) tracks.
+//!
+//! A window is an ordered run of records the publisher appends to the back of and drops from the
+//! front of. Unlike [`stream`](crate::stream), which preserves a log forever in one group, and
+//! [`snapshot`](crate::snapshot), which keeps only the latest value, a window keeps a bounded
+//! stretch of records and lets a reader join it at any point.
+//!
+//! # Why a log can't do this
+//!
+//! The obvious alternative is an append-only log that rolls its group and re-seeds the new one with
+//! the records it still holds. That breaks the reader: re-seeded records are indistinguishable from
+//! new ones, so a reader that was keeping up receives them twice. This mode exists to make the
+//! restatement explicit, so a reader can tell "you already have these" from "here is another one".
+//!
+//! # On the wire
+//!
+//! Every frame is a tagged op. Each group opens with a `reset` naming the retained records and the
+//! absolute `offset` of the first, followed by `push` and `pop` ops. Only the reset carries an
+//! index: a push takes the next one and a pop drops from the front, both positional against the
+//! reset, which is sound because the group-scoped DEFLATE window already makes a mid-group join
+//! undecodable.
+//!
+//! Trimming is therefore an op, not a group boundary. Dropping a record costs one small frame
+//! inside the shared compression window instead of a roll that would throw that window away.
+//!
+//! # Group boundaries are invisible
+//!
+//! The publisher rolls a group when the ops in it outgrow
+//! [`ProducerConfig::op_ratio`](ProducerConfig::op_ratio) times the reset that opened it, exactly as
+//! [`snapshot`](crate::snapshot) rolls on its delta budget. That is purely a compression decision:
+//! there is no caller-driven cut and no age bound, and a [`Consumer`] never surfaces it. A reset
+//! restating records a reader already has yields nothing, so however often the publisher rolls, the
+//! reader sees one continuous stream of [`Event`]s.
+//!
+//! # What a reader is told
+//!
+//! Every index is reported exactly once: [`Event::Push`] when a record arrives, [`Event::Pop`] when
+//! it leaves, and [`Event::Skip`] when it existed but was dropped before this reader saw it. A
+//! reader that keeps up sees pushes and pops; one that joins late, or falls a group behind, learns
+//! from the reset's offset which records it will never get, rather than silently missing them.
+//!
+//! # Choosing a layer
+//!
+//! [`Producer`] and [`Consumer`] own a track. [`Encoder`] and [`Decoder`] are the same logic
+//! without it, for when something else is already in charge of the track; the encoder owns the
+//! retained window and says where the group boundaries fall, and the decoder turns frames into
+//! events.
+
+mod consumer;
+mod decoder;
+mod encoder;
+mod op;
+mod producer;
+
+pub use consumer::Consumer;
+pub use decoder::{ConsumerConfig, Decoder, Event};
+pub use encoder::{Encoded, Encoder, Pending, ProducerConfig};
+pub use producer::Producer;
+
+#[cfg(test)]
+mod test {
+	use std::task::Poll;
+
+	use serde_json::{Value, json};
+
+	use super::*;
+
+	fn producer(config: ProducerConfig) -> (Producer<Value>, moq_net::track::Subscriber) {
+		let track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let consumer = track.subscribe(None);
+		(Producer::new(track, config), consumer)
+	}
+
+	/// A subscription patient enough to read every group of a finished track.
+	fn replay(track: &moq_net::track::Producer) -> moq_net::track::Subscriber {
+		track.subscribe(moq_net::track::Subscription::default().with_max_age(std::time::Duration::from_secs(30)))
+	}
+
+	fn consumer(track: moq_net::track::Subscriber, compression: bool) -> Consumer<Value> {
+		Consumer::new(track, ConsumerConfig::default().with_compression(compression))
+	}
+
+	/// Drain every event currently available without blocking.
+	fn drain(consumer: &mut Consumer<Value>) -> Vec<Event<Value>> {
+		let waiter = kio::Waiter::noop();
+		let mut out = Vec::new();
+		while let Poll::Ready(Ok(Some(event))) = consumer.poll_next(&waiter) {
+			out.push(event);
+		}
+		out
+	}
+
+	fn rec(n: u64) -> Value {
+		json!({ "n": n })
+	}
+
+	/// A producer and a consumer that reads after every edit.
+	///
+	/// Polling as the publisher goes is what "keeping up" means: a consumer left until the end is a
+	/// whole group behind, and the default subscription abandons a group as soon as a newer one
+	/// exists, so it would resume at the newest reset instead of reading the rolls in between.
+	struct Live {
+		producer: Producer<Value>,
+		consumer: Consumer<Value>,
+		events: Vec<Event<Value>>,
+	}
+
+	impl Live {
+		fn new(config: ProducerConfig) -> Self {
+			let compression = config.compression;
+			let (producer, track) = producer(config);
+			Self {
+				producer,
+				consumer: consumer(track, compression),
+				events: Vec::new(),
+			}
+		}
+
+		fn push(&mut self, n: u64) {
+			self.producer.push(&rec(n)).unwrap();
+			self.read();
+		}
+
+		fn pop(&mut self, count: u64) {
+			self.producer.pop(count).unwrap();
+			self.read();
+		}
+
+		fn read(&mut self) {
+			self.events.extend(drain(&mut self.consumer));
+		}
+
+		fn finish(mut self) -> Vec<Event<Value>> {
+			self.producer.finish().unwrap();
+			self.read();
+			self.events
+		}
+
+		/// Just the indices pushed, in order.
+		fn pushed(events: &[Event<Value>]) -> Vec<u64> {
+			events
+				.iter()
+				.filter_map(|e| match e {
+					Event::Push(i, _) => Some(*i),
+					_ => None,
+				})
+				.collect()
+		}
+	}
+
+	#[test]
+	fn push_and_pop_round_trip() {
+		let mut live = Live::new(ProducerConfig::default());
+		live.push(0);
+		live.push(1);
+		live.pop(1);
+		live.push(2);
+
+		assert_eq!(
+			live.finish(),
+			vec![
+				Event::Push(0, rec(0)),
+				Event::Push(1, rec(1)),
+				Event::Pop(0),
+				Event::Push(2, rec(2)),
+			]
+		);
+	}
+
+	#[test]
+	fn the_window_slides() {
+		let (mut producer, _track) = producer(ProducerConfig::default());
+		for n in 0..5 {
+			producer.push(&rec(n)).unwrap();
+			if n >= 2 {
+				producer.pop(1).unwrap();
+			}
+		}
+
+		// Three pushes past the first pop, so the window holds the last three and starts at 2.
+		assert_eq!(producer.range(), 3..5);
+		assert_eq!(producer.window(), vec![rec(3), rec(4)]);
+	}
+
+	#[test]
+	fn a_popped_record_is_never_restated() {
+		// Ops disabled, so every single edit is its own reset restating the whole window.
+		let mut live = Live::new(ProducerConfig::default().with_op_ratio(0));
+		live.push(0);
+		live.push(1);
+		live.pop(1);
+		live.push(2);
+
+		// Every edit restates the window, yet a record already delivered is never pushed twice. That
+		// is the property an append-only log cannot provide.
+		assert_eq!(
+			live.finish(),
+			vec![
+				Event::Push(0, rec(0)),
+				Event::Push(1, rec(1)),
+				Event::Pop(0),
+				Event::Push(2, rec(2)),
+			]
+		);
+	}
+
+	#[test]
+	fn a_fresh_consumer_adopts_the_offset_without_skipping_history() {
+		let track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let replay = replay(&track);
+		let mut producer = Producer::<Value>::new(track, ProducerConfig::default());
+
+		for n in 0..5 {
+			producer.push(&rec(n)).unwrap();
+		}
+		producer.pop(3).unwrap();
+		producer.finish().unwrap();
+
+		// Joining at offset 3 must not report 3 skips for records that were never this reader's to
+		// miss: it simply starts where the window starts.
+		let events = drain(&mut consumer(replay, false));
+		assert_eq!(events.first(), Some(&Event::Push(0, rec(0))));
+		assert!(!events.iter().any(|e| matches!(e, Event::Skip(_))));
+	}
+
+	#[test]
+	fn a_lagging_consumer_is_told_what_it_missed() {
+		// Ops disabled, so every edit rolls: a reader that stops polling really does lose groups.
+		let (mut producer, track) = producer(ProducerConfig::default().with_op_ratio(0));
+		let mut consumer = consumer(track, false);
+
+		producer.push(&rec(0)).unwrap();
+		producer.push(&rec(1)).unwrap();
+		assert_eq!(
+			drain(&mut consumer),
+			vec![Event::Push(0, rec(0)), Event::Push(1, rec(1))]
+		);
+
+		// The consumer stops reading. The window slides past everything it holds, and the publisher
+		// rolls, so the groups it would have read are gone.
+		for n in 2..8 {
+			producer.push(&rec(n)).unwrap();
+			producer.pop(1).unwrap();
+		}
+		producer.finish().unwrap();
+
+		let events = drain(&mut consumer);
+		let skipped: Vec<u64> = events
+			.iter()
+			.filter_map(|e| match e {
+				Event::Skip(i) => Some(*i),
+				_ => None,
+			})
+			.collect();
+
+		// Records 2..=5 existed but this reader will never receive them, and it is told so rather than
+		// silently jumping from 1 to 6.
+		assert!(!skipped.is_empty(), "expected skips, got {events:?}");
+		assert_eq!(skipped.first(), Some(&2));
+
+		// Every index is still accounted for exactly once, in order.
+		let reported: Vec<u64> = events
+			.iter()
+			.filter_map(|e| match e {
+				Event::Push(i, _) | Event::Skip(i) => Some(*i),
+				Event::Pop(_) => None,
+			})
+			.collect();
+		assert!(reported.windows(2).all(|w| w[1] == w[0] + 1), "gaps in {reported:?}");
+	}
+
+	#[test]
+	fn compressed_round_trip_across_rolls() {
+		let mut live = Live::new(ProducerConfig::default().with_compression(true).with_op_ratio(1));
+		for n in 0..40 {
+			live.push(n);
+			if n >= 10 {
+				live.pop(1);
+			}
+		}
+
+		// A tight ratio rolls many times; every record still arrives exactly once, in order.
+		assert_eq!(Live::pushed(&live.finish()), (0..40).collect::<Vec<_>>());
+	}
+
+	#[test]
+	fn an_empty_pop_writes_nothing() {
+		let (mut producer, track) = producer(ProducerConfig::default());
+		producer.pop(5).unwrap();
+		producer.finish().unwrap();
+
+		// Nothing was ever pushed, so there is nothing to drop and no group to publish.
+		assert_eq!(track.latest(), None);
+	}
+
+	#[test]
+	fn a_pop_is_clamped_to_the_window() {
+		let mut live = Live::new(ProducerConfig::default());
+		live.push(0);
+		live.pop(9);
+		live.push(1);
+
+		assert_eq!(
+			live.finish(),
+			vec![Event::Push(0, rec(0)), Event::Pop(0), Event::Push(1, rec(1))]
+		);
+	}
+
+	#[test]
+	fn rolling_is_invisible_to_the_consumer() {
+		// The same edits, framed two ways: one group for everything, versus a roll per edit.
+		let edits = |ratio: u32| {
+			let mut live = Live::new(ProducerConfig::default().with_op_ratio(ratio));
+			for n in 0..6 {
+				live.push(n);
+				if n >= 3 {
+					live.pop(1);
+				}
+			}
+			live.finish()
+		};
+
+		assert_eq!(edits(1_000), edits(0));
+	}
+}

--- a/rs/moq-json/src/window/op.rs
+++ b/rs/moq-json/src/window/op.rs
@@ -1,23 +1,24 @@
-//! The wire ops, shared by the encoder and decoder.
+//! The group header and wire ops, shared by the encoder and decoder.
 
 use serde::{Deserialize, Serialize};
 
-/// One frame: what the publisher did to its window.
+/// The first frame in every group, naming the complete retained window.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Header<T> {
+	/// Absolute index of `records[0]`, so a reader knows which records it missed.
+	pub offset: u64,
+	/// The retained records, oldest first.
+	pub records: Vec<T>,
+}
+
+/// An incremental frame after the group header.
 ///
-/// Externally tagged, so a frame is `{"reset":{...}}`, `{"push":...}`, or `{"pop":n}` and a reader
-/// can tell them apart without position. Only [`Reset`](Self::Reset) carries an index; a `push`
-/// takes the next one and a `pop` drops from the front, both positional against the reset that
-/// opened the group. That is sound because the group-scoped DEFLATE window already makes a
-/// mid-group join undecodable, so a reader never sees a subset of a group's frames.
+/// A `push` takes the next index and a `pop` drops from the front, both positional against the
+/// header that opened the group. That is sound because a reader never sees a subset of a group.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(super) enum Op<T> {
-	/// The window is exactly these records, the first at `offset`. Opens every group.
-	Reset {
-		/// Absolute index of `records[0]`, so a reader knows which records it missed.
-		offset: u64,
-		records: Vec<T>,
-	},
 	/// Append one record to the back.
 	Push(T),
 	/// Drop this many records from the front.
@@ -33,6 +34,7 @@ mod test {
 	#[derive(serde::Deserialize)]
 	struct Vector {
 		name: String,
+		first: bool,
 		frame: String,
 	}
 
@@ -45,24 +47,33 @@ mod test {
 		let vectors: Vec<Vector> = serde_json::from_str(include_str!("../../tests/window-vectors.json")).unwrap();
 
 		for vector in vectors {
-			let op: Op<Value> =
-				serde_json::from_str(&vector.frame).unwrap_or_else(|err| panic!("{}: {err}", vector.name));
-			let encoded = serde_json::to_string(&op).unwrap();
+			let encoded = match vector.first {
+				true => {
+					let header: Header<Value> =
+						serde_json::from_str(&vector.frame).unwrap_or_else(|err| panic!("{}: {err}", vector.name));
+					serde_json::to_string(&header).unwrap()
+				}
+				false => {
+					let op: Op<Value> =
+						serde_json::from_str(&vector.frame).unwrap_or_else(|err| panic!("{}: {err}", vector.name));
+					serde_json::to_string(&op).unwrap()
+				}
+			};
 			assert_eq!(encoded, vector.frame, "{}", vector.name);
 		}
 	}
 
 	#[test]
-	fn ops_are_externally_tagged() {
+	fn frames_have_the_expected_shapes() {
 		// Pinning the shapes the vectors encode, so a rename of a variant or field is a visible break
 		// rather than a silently different wire.
-		let reset = Op::Reset {
+		let header = Header {
 			offset: 4,
 			records: vec![json!({ "a": 1 })],
 		};
 		assert_eq!(
-			serde_json::to_value(&reset).unwrap(),
-			json!({ "reset": { "offset": 4, "records": [{ "a": 1 }] } })
+			serde_json::to_value(&header).unwrap(),
+			json!({ "offset": 4, "records": [{ "a": 1 }] })
 		);
 		assert_eq!(
 			serde_json::to_value(Op::Push(json!({ "a": 1 }))).unwrap(),

--- a/rs/moq-json/src/window/op.rs
+++ b/rs/moq-json/src/window/op.rs
@@ -1,0 +1,73 @@
+//! The wire ops, shared by the encoder and decoder.
+
+use serde::{Deserialize, Serialize};
+
+/// One frame: what the publisher did to its window.
+///
+/// Externally tagged, so a frame is `{"reset":{...}}`, `{"push":...}`, or `{"pop":n}` and a reader
+/// can tell them apart without position. Only [`Reset`](Self::Reset) carries an index; a `push`
+/// takes the next one and a `pop` drops from the front, both positional against the reset that
+/// opened the group. That is sound because the group-scoped DEFLATE window already makes a
+/// mid-group join undecodable, so a reader never sees a subset of a group's frames.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(super) enum Op<T> {
+	/// The window is exactly these records, the first at `offset`. Opens every group.
+	Reset {
+		/// Absolute index of `records[0]`, so a reader knows which records it missed.
+		offset: u64,
+		records: Vec<T>,
+	},
+	/// Append one record to the back.
+	Push(T),
+	/// Drop this many records from the front.
+	Pop(u64),
+}
+
+#[cfg(test)]
+mod test {
+	use serde_json::{Value, json};
+
+	use super::*;
+
+	#[derive(serde::Deserialize)]
+	struct Vector {
+		name: String,
+		frame: String,
+	}
+
+	/// The exact frame bytes for each op, shared with the TypeScript suite.
+	///
+	/// This file is the wire contract between the two implementations. A change here is a format
+	/// change, so both suites have to move together.
+	#[test]
+	fn vectors_round_trip() {
+		let vectors: Vec<Vector> = serde_json::from_str(include_str!("../../tests/window-vectors.json")).unwrap();
+
+		for vector in vectors {
+			let op: Op<Value> =
+				serde_json::from_str(&vector.frame).unwrap_or_else(|err| panic!("{}: {err}", vector.name));
+			let encoded = serde_json::to_string(&op).unwrap();
+			assert_eq!(encoded, vector.frame, "{}", vector.name);
+		}
+	}
+
+	#[test]
+	fn ops_are_externally_tagged() {
+		// Pinning the shapes the vectors encode, so a rename of a variant or field is a visible break
+		// rather than a silently different wire.
+		let reset = Op::Reset {
+			offset: 4,
+			records: vec![json!({ "a": 1 })],
+		};
+		assert_eq!(
+			serde_json::to_value(&reset).unwrap(),
+			json!({ "reset": { "offset": 4, "records": [{ "a": 1 }] } })
+		);
+		assert_eq!(
+			serde_json::to_value(Op::Push(json!({ "a": 1 }))).unwrap(),
+			json!({ "push": { "a": 1 } })
+		);
+		assert_eq!(serde_json::to_value(Op::<Value>::Pop(2)).unwrap(), json!({ "pop": 2 }));
+	}
+}

--- a/rs/moq-json/src/window/producer.rs
+++ b/rs/moq-json/src/window/producer.rs
@@ -68,7 +68,7 @@ impl<T> Producer<T> {
 	}
 
 	/// Finish the track, closing any open group.
-	pub fn finish(&mut self) -> Result<()> {
+	pub fn finish(self) -> Result<()> {
 		self.inner.lock().unwrap().finish()
 	}
 }
@@ -98,9 +98,8 @@ impl<T> Inner<T> {
 			return Ok(());
 		};
 
-		// A failed write drops the frame uncommitted, which makes the next edit open a new group and
-		// restates the whole window. The pop itself stands: the record really is gone from the
-		// publisher's window, and only the consumer's knowledge of that is lost.
+		// A failed write drops the frame uncommitted. The pop is discarded, and the next edit opens a
+		// new group because the attempted frame advanced the group-local compression state.
 		track.write(&frame)?;
 		frame.commit();
 
@@ -111,7 +110,7 @@ impl<T> Inner<T> {
 		// The open group goes with the track, so the encoder must not keep emitting ops into it. Any
 		// further edit fails on the closed track, but it has to fail as a track error rather than by
 		// writing an op with no group to hold it.
-		self.encoder.reset();
+		self.encoder.start_group();
 		self.track.finish()
 	}
 }

--- a/rs/moq-json/src/window/producer.rs
+++ b/rs/moq-json/src/window/producer.rs
@@ -12,7 +12,7 @@ use crate::Result;
 /// Publishes a sliding window of JSON records over a track.
 ///
 /// An [`Encoder`] that owns its track: it writes each encoded frame and rolls a group whenever the
-/// encoder emits a reset. When something else already owns the track, use the [`Encoder`] directly.
+/// encoder emits a header. When something else already owns the track, use the [`Encoder`] directly.
 ///
 /// Cheaply clonable: clones share one underlying track and window, like other MoQ producers.
 pub struct Producer<T> {
@@ -98,7 +98,7 @@ impl<T> Inner<T> {
 			return Ok(());
 		};
 
-		// A failed write drops the frame uncommitted, which resets the encoder so the next edit
+		// A failed write drops the frame uncommitted, which makes the next edit open a new group and
 		// restates the whole window. The pop itself stands: the record really is gone from the
 		// publisher's window, and only the consumer's knowledge of that is lost.
 		track.write(&frame)?;
@@ -132,21 +132,21 @@ impl<T: Serialize> Inner<T> {
 struct Track {
 	inner: moq_net::track::Producer,
 
-	/// The group an op would be appended to, open between resets.
+	/// The group an op would be appended to, open after a header.
 	group: Option<moq_net::group::Producer>,
 }
 
 impl Track {
-	/// Write one encoded frame, rolling a group when it's a reset.
+	/// Write one encoded frame, rolling a group when it is a header.
 	fn write(&mut self, encoded: &Encoded) -> Result<()> {
 		match encoded.keyframe {
-			true => self.write_reset(encoded.payload.clone()),
+			true => self.write_header(encoded.payload.clone()),
 			false => self.write_op(encoded.payload.clone()),
 		}
 	}
 
-	/// Close the open group and write a reset as the first frame of a new one.
-	fn write_reset(&mut self, payload: bytes::Bytes) -> Result<()> {
+	/// Close the open group and write the header as the first frame of a new one.
+	fn write_header(&mut self, payload: bytes::Bytes) -> Result<()> {
 		// The previous group is complete; no more frames will be appended to it.
 		if let Some(mut group) = self.group.take() {
 			group.finish()?;
@@ -165,11 +165,11 @@ impl Track {
 		Ok(())
 	}
 
-	/// Append an op to the group the last reset opened.
+	/// Append an op to the group the last header opened.
 	fn write_op(&mut self, payload: bytes::Bytes) -> Result<()> {
 		self.group
 			.as_mut()
-			.expect("the encoder only emits an op after a reset opened a group")
+			.expect("the encoder only emits an op after a header opened a group")
 			.write_frame(moq_net::Timestamp::now(), payload)?;
 		Ok(())
 	}

--- a/rs/moq-json/src/window/producer.rs
+++ b/rs/moq-json/src/window/producer.rs
@@ -39,6 +39,7 @@ impl<T> Producer<T> {
 					group: None,
 				},
 				encoder: Encoder::new(config),
+				finished: false,
 			})),
 			_marker: PhantomData,
 		}
@@ -88,11 +89,13 @@ impl<T: Serialize> Producer<T> {
 struct Inner<T> {
 	track: Track,
 	encoder: Encoder<T>,
+	finished: bool,
 }
 
 impl<T> Inner<T> {
 	fn pop(&mut self, count: u64) -> Result<()> {
-		let Inner { track, encoder } = self;
+		self.ensure_open()?;
+		let Inner { track, encoder, .. } = self;
 
 		let Some(frame) = encoder.pop(count)? else {
 			return Ok(());
@@ -107,13 +110,25 @@ impl<T> Inner<T> {
 	}
 
 	fn finish(&mut self) -> Result<()> {
+		if self.finished {
+			return Ok(());
+		}
+		self.finished = true;
 		self.track.finish()
+	}
+
+	fn ensure_open(&self) -> Result<()> {
+		if self.finished {
+			return Err(moq_net::Error::Closed.into());
+		}
+		Ok(())
 	}
 }
 
 impl<T: Serialize> Inner<T> {
 	fn push(&mut self, value: &T) -> Result<()> {
-		let Inner { track, encoder } = self;
+		self.ensure_open()?;
+		let Inner { track, encoder, .. } = self;
 
 		let frame = encoder.push(value)?;
 		track.write(&frame)?;

--- a/rs/moq-json/src/window/producer.rs
+++ b/rs/moq-json/src/window/producer.rs
@@ -1,0 +1,184 @@
+//! Publishing a window over a track: an [`Encoder`] plus the track it writes to.
+
+use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use super::{Encoded, Encoder, ProducerConfig};
+use crate::Result;
+
+/// Publishes a sliding window of JSON records over a track.
+///
+/// An [`Encoder`] that owns its track: it writes each encoded frame and rolls a group whenever the
+/// encoder emits a reset. When something else already owns the track, use the [`Encoder`] directly.
+///
+/// Cheaply clonable: clones share one underlying track and window, like other MoQ producers.
+pub struct Producer<T> {
+	inner: Arc<Mutex<Inner<T>>>,
+	_marker: PhantomData<fn(T)>,
+}
+
+impl<T> Clone for Producer<T> {
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<T> Producer<T> {
+	/// Create a producer that publishes to the given track.
+	pub fn new(track: moq_net::track::Producer, config: ProducerConfig) -> Self {
+		Self {
+			inner: Arc::new(Mutex::new(Inner {
+				track: Track {
+					inner: track,
+					group: None,
+				},
+				encoder: Encoder::new(config),
+			})),
+			_marker: PhantomData,
+		}
+	}
+
+	/// Create a subscriber for the underlying track.
+	pub fn consume(&self) -> moq_net::track::Subscriber {
+		self.inner.lock().unwrap().track.inner.subscribe(None)
+	}
+
+	/// The retained window, oldest first.
+	pub fn window(&self) -> Vec<Value> {
+		self.inner.lock().unwrap().encoder.window().cloned().collect()
+	}
+
+	/// Absolute index of the oldest retained record, and of the next to be pushed.
+	pub fn range(&self) -> std::ops::Range<u64> {
+		self.inner.lock().unwrap().encoder.range()
+	}
+
+	/// Drop `count` records from the front of the window.
+	///
+	/// A no-op when the window is already empty, and clamped to what it holds, so a caller can trim
+	/// unconditionally.
+	pub fn pop(&mut self, count: u64) -> Result<()> {
+		self.inner.lock().unwrap().pop(count)
+	}
+
+	/// Finish the track, closing any open group.
+	pub fn finish(&mut self) -> Result<()> {
+		self.inner.lock().unwrap().finish()
+	}
+}
+
+impl<T: Serialize> Producer<T> {
+	/// Append one record to the back of the window.
+	pub fn push(&mut self, value: &T) -> Result<()> {
+		self.inner.lock().unwrap().push(value)
+	}
+}
+
+/// Shared publishing state behind [`Producer`]'s `Arc<Mutex>`.
+///
+/// The track and the encoder are separate fields so a [`Pending`](super::Pending) frame (which
+/// borrows the encoder) and the write that consumes it (which borrows the track) don't contend for
+/// one `&mut self`.
+struct Inner<T> {
+	track: Track,
+	encoder: Encoder<T>,
+}
+
+impl<T> Inner<T> {
+	fn pop(&mut self, count: u64) -> Result<()> {
+		let Inner { track, encoder } = self;
+
+		let Some(frame) = encoder.pop(count)? else {
+			return Ok(());
+		};
+
+		// A failed write drops the frame uncommitted, which resets the encoder so the next edit
+		// restates the whole window. The pop itself stands: the record really is gone from the
+		// publisher's window, and only the consumer's knowledge of that is lost.
+		track.write(&frame)?;
+		frame.commit();
+
+		Ok(())
+	}
+
+	fn finish(&mut self) -> Result<()> {
+		// The open group goes with the track, so the encoder must not keep emitting ops into it. Any
+		// further edit fails on the closed track, but it has to fail as a track error rather than by
+		// writing an op with no group to hold it.
+		self.encoder.reset();
+		self.track.finish()
+	}
+}
+
+impl<T: Serialize> Inner<T> {
+	fn push(&mut self, value: &T) -> Result<()> {
+		let Inner { track, encoder } = self;
+
+		let frame = encoder.push(value)?;
+		track.write(&frame)?;
+		frame.commit();
+
+		Ok(())
+	}
+}
+
+/// The track half of [`Inner`]: where an encoded frame goes and how groups are rolled.
+struct Track {
+	inner: moq_net::track::Producer,
+
+	/// The group an op would be appended to, open between resets.
+	group: Option<moq_net::group::Producer>,
+}
+
+impl Track {
+	/// Write one encoded frame, rolling a group when it's a reset.
+	fn write(&mut self, encoded: &Encoded) -> Result<()> {
+		match encoded.keyframe {
+			true => self.write_reset(encoded.payload.clone()),
+			false => self.write_op(encoded.payload.clone()),
+		}
+	}
+
+	/// Close the open group and write a reset as the first frame of a new one.
+	fn write_reset(&mut self, payload: bytes::Bytes) -> Result<()> {
+		// The previous group is complete; no more frames will be appended to it.
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+
+		let mut group = self.inner.append_group()?;
+		if let Err(err) = group.write_frame(moq_net::Timestamp::now(), payload) {
+			// `append_group` already published this group, and a rejected frame (too large) doesn't
+			// close the track. Dropping the handle does NOT close the group, so leaving it would strand
+			// any subscriber that advanced into it with nothing to read and no end.
+			let _ = group.finish();
+			return Err(err.into());
+		}
+
+		self.group = Some(group);
+		Ok(())
+	}
+
+	/// Append an op to the group the last reset opened.
+	fn write_op(&mut self, payload: bytes::Bytes) -> Result<()> {
+		self.group
+			.as_mut()
+			.expect("the encoder only emits an op after a reset opened a group")
+			.write_frame(moq_net::Timestamp::now(), payload)?;
+		Ok(())
+	}
+
+	fn finish(&mut self) -> Result<()> {
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+		self.inner.finish()?;
+		Ok(())
+	}
+}

--- a/rs/moq-json/src/window/producer.rs
+++ b/rs/moq-json/src/window/producer.rs
@@ -51,7 +51,7 @@ impl<T> Producer<T> {
 
 	/// The retained window, oldest first.
 	pub fn window(&self) -> Vec<Value> {
-		self.inner.lock().unwrap().encoder.window().cloned().collect()
+		self.inner.lock().unwrap().encoder.window()
 	}
 
 	/// Absolute index of the oldest retained record, and of the next to be pushed.

--- a/rs/moq-json/src/window/producer.rs
+++ b/rs/moq-json/src/window/producer.rs
@@ -107,10 +107,6 @@ impl<T> Inner<T> {
 	}
 
 	fn finish(&mut self) -> Result<()> {
-		// The open group goes with the track, so the encoder must not keep emitting ops into it. Any
-		// further edit fails on the closed track, but it has to fail as a track error rather than by
-		// writing an op with no group to hold it.
-		self.encoder.start_group();
 		self.track.finish()
 	}
 }

--- a/rs/moq-json/tests/window-vectors.json
+++ b/rs/moq-json/tests/window-vectors.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "reset of an empty window",
+    "frame": "{\"reset\":{\"offset\":0,\"records\":[]}}"
+  },
+  {
+    "name": "reset from zero",
+    "frame": "{\"reset\":{\"offset\":0,\"records\":[{\"n\":0},{\"n\":1}]}}"
+  },
+  {
+    "name": "reset with a non-zero offset",
+    "frame": "{\"reset\":{\"offset\":7,\"records\":[{\"n\":7}]}}"
+  },
+  {
+    "name": "push",
+    "frame": "{\"push\":{\"n\":2}}"
+  },
+  {
+    "name": "pop one",
+    "frame": "{\"pop\":1}"
+  },
+  {
+    "name": "pop several",
+    "frame": "{\"pop\":3}"
+  }
+]

--- a/rs/moq-json/tests/window-vectors.json
+++ b/rs/moq-json/tests/window-vectors.json
@@ -1,26 +1,32 @@
 [
   {
-    "name": "reset of an empty window",
-    "frame": "{\"reset\":{\"offset\":0,\"records\":[]}}"
+    "name": "empty group header",
+    "first": true,
+    "frame": "{\"offset\":0,\"records\":[]}"
   },
   {
-    "name": "reset from zero",
-    "frame": "{\"reset\":{\"offset\":0,\"records\":[{\"n\":0},{\"n\":1}]}}"
+    "name": "group header from zero",
+    "first": true,
+    "frame": "{\"offset\":0,\"records\":[{\"n\":0},{\"n\":1}]}"
   },
   {
-    "name": "reset with a non-zero offset",
-    "frame": "{\"reset\":{\"offset\":7,\"records\":[{\"n\":7}]}}"
+    "name": "group header with a non-zero offset",
+    "first": true,
+    "frame": "{\"offset\":7,\"records\":[{\"n\":7}]}"
   },
   {
     "name": "push",
+    "first": false,
     "frame": "{\"push\":{\"n\":2}}"
   },
   {
     "name": "pop one",
+    "first": false,
     "frame": "{\"pop\":1}"
   },
   {
     "name": "pop several",
+    "first": false,
     "frame": "{\"pop\":3}"
   }
 ]

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -22,7 +22,7 @@ use crate::{Error, IntoBytes, Result, Timestamp};
 /// Doubles as the per-frame size cap: a single frame can be at most this large (a
 /// larger declared size is refused before allocating), so one maximum-size frame can
 /// fill a group's cache.
-pub(super) const MAX_GROUP_CACHE: u64 = 32 * 1024 * 1024; // 32 MB
+pub const MAX_CACHE_BYTES: u64 = 32 * 1024 * 1024; // 32 MB
 
 /// A group contains a sequence number because they can arrive out of order.
 ///
@@ -173,7 +173,7 @@ impl GroupState {
 
 	/// Evict completed frames from the front until within the byte budget.
 	fn evict(&mut self) {
-		while self.cache > MAX_GROUP_CACHE {
+		while self.cache > MAX_CACHE_BYTES {
 			let Some(frame) = self.frames.pop_front() else {
 				break;
 			};
@@ -339,7 +339,7 @@ impl Producer {
 			.convert(self.track.timescale)
 			.map_err(|_| Error::TimestampMismatch)?;
 		let payload = data.into_bytes();
-		if payload.len() as u64 > MAX_GROUP_CACHE {
+		if payload.len() as u64 > MAX_CACHE_BYTES {
 			return Err(Error::FrameTooLarge);
 		}
 
@@ -398,7 +398,7 @@ impl Producer {
 				.timestamp
 				.convert(self.track.timescale)
 				.map_err(|_| Error::TimestampMismatch)?;
-			if frame.payload.len() as u64 > MAX_GROUP_CACHE {
+			if frame.payload.len() as u64 > MAX_CACHE_BYTES {
 				return Err(Error::FrameTooLarge);
 			}
 		}
@@ -446,7 +446,7 @@ impl Producer {
 			.timestamp
 			.convert(self.track.timescale)
 			.map_err(|_| Error::TimestampMismatch)?;
-		if frame.size > MAX_GROUP_CACHE {
+		if frame.size > MAX_CACHE_BYTES {
 			return Err(Error::FrameTooLarge);
 		}
 		let buf = FrameBuf::new(frame.size as usize);
@@ -1061,7 +1061,7 @@ mod test {
 		// Larger than the group's whole byte budget.
 		buf.push(frame::Frame {
 			timestamp: Timestamp::ZERO,
-			payload: Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize + 1]),
+			payload: Bytes::from(vec![0u8; MAX_CACHE_BYTES as usize + 1]),
 		})
 		.unwrap();
 
@@ -1095,7 +1095,7 @@ mod test {
 		// Refused after the first frame would already have been converted in place.
 		buf.push(frame::Frame {
 			timestamp: Timestamp::from_millis(2).unwrap(),
-			payload: Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize + 1]),
+			payload: Bytes::from(vec![0u8; MAX_CACHE_BYTES as usize + 1]),
 		})
 		.unwrap();
 
@@ -1472,8 +1472,8 @@ mod test {
 	fn eviction_drops_old_frames() {
 		let mut producer = Info { sequence: 0 }.produce();
 
-		// Write frames that total more than MAX_GROUP_CACHE.
-		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
+		// Write frames that total more than MAX_CACHE_BYTES.
+		let big = Bytes::from(vec![0u8; MAX_CACHE_BYTES as usize]);
 		producer.write_frame(Timestamp::ZERO, big.clone()).unwrap();
 		producer.write_frame(Timestamp::ZERO, big).unwrap();
 
@@ -1481,14 +1481,14 @@ mod test {
 		let state = producer.state.read();
 		assert_eq!(state.offset, 1);
 		assert_eq!(state.frames.len(), 1);
-		assert_eq!(state.frames[0].payload.len(), MAX_GROUP_CACHE as usize);
+		assert_eq!(state.frames[0].payload.len(), MAX_CACHE_BYTES as usize);
 	}
 
 	#[test]
 	fn next_frame_returns_cache_full_on_tombstone() {
 		let mut producer = Info { sequence: 0 }.produce();
 
-		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
+		let big = Bytes::from(vec![0u8; MAX_CACHE_BYTES as usize]);
 		producer.write_frame(Timestamp::ZERO, big.clone()).unwrap();
 		producer.write_frame(Timestamp::ZERO, big).unwrap();
 
@@ -1742,7 +1742,7 @@ mod test {
 	fn create_frame_rejects_oversized() {
 		let mut producer = Info { sequence: 0 }.produce();
 		let result = producer.create_frame(frame::Info {
-			size: MAX_GROUP_CACHE + 1,
+			size: MAX_CACHE_BYTES + 1,
 			timestamp: Timestamp::ZERO,
 		});
 		assert!(matches!(result, Err(Error::FrameTooLarge)));

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1037,7 +1037,7 @@ impl Producer {
 	/// a presentation time, pass [`Timestamp::now`] explicitly.
 	pub fn write_frame<B: crate::IntoBytes>(&mut self, timestamp: Timestamp, frame: B) -> Result<()> {
 		let frame = crate::IntoBytes::into_bytes(frame);
-		if frame.len() as u64 > group::MAX_GROUP_CACHE {
+		if frame.len() as u64 > group::MAX_CACHE_BYTES {
 			return Err(Error::FrameTooLarge);
 		}
 		let mut group = self.append_group()?;
@@ -4296,7 +4296,7 @@ mod test {
 	#[test]
 	fn write_frame_rejects_an_oversized_frame_before_appending_its_group() {
 		let mut producer = track_producer("test", None);
-		let frame = bytes::Bytes::from(vec![0; group::MAX_GROUP_CACHE as usize + 1]);
+		let frame = bytes::Bytes::from(vec![0; group::MAX_CACHE_BYTES as usize + 1]);
 
 		assert!(matches!(
 			producer.write_frame(Timestamp::ZERO, frame),


### PR DESCRIPTION
## Summary

- Adds matching Rust and TypeScript sliding-window JSON modes for a bounded, late-joinable ordered record set.
- Uses frame 0 of every group as the complete `{offset, records}` header, followed only by incremental `push` and `pop` frames.
- Stages each edit until its frame is committed, so a failed write leaves the retained window unchanged.
- Reports skipped and popped indices as compact half-open ranges, validates the shared safe-integer domain, and rolls before cache eviction.
- Rejects frames the paired decoder or MoQ group cannot accept, lazily delivers large header batches, and prevents concurrent TypeScript consumer reads.

## Root cause

The existing stream mode is one append-only group. Long-running publishers eventually evict that group's prefix, so a late joiner cannot reconstruct the log. Snapshot mode remains joinable but retains only one value. A bounded window needs both a restartable snapshot and incremental operations.

The initial window API also mutated its retained state before the caller confirmed that a frame reached the wire. A write could therefore return an error while still applying the edit locally. Pending frames now stage their edit and apply it only on `commit()`.

## Public API changes

This adds `moq_json::window` and matching `@moq/json` window exports. Low-level decoding is group-scoped: call `decoder.group()` for each MoQ group and feed that group's frames through the returned decoder. Its first frame must be the `{offset, records}` header. Rust makes the group an exclusive borrow of its parent decoder, while TypeScript invalidates an older group when a new one is created.

Encoders own group boundaries and expose only the `keyframe` signal on each output frame. There is no public reset or `startGroup` transition. `Producer` and `Consumer` manage grouping automatically. Rust `Event::Push` uses named `index` and `value` fields, matching the TypeScript event shape. Rust `Producer::finish` consumes the producer, and the TypeScript wire-op type remains internal.

Both implementations accept indices through 2^53 - 1, the largest integer represented exactly by JavaScript. The PR also exposes the existing MoQ group cache budget as `moq_net::group::MAX_CACHE_BYTES`, matching the already-public TypeScript constant. All changes are additive relative to `main`.

## Wire behavior

This is a new opt-in JSON frame format. Frame 0 is `{"offset":N,"records":[...]}`. Later frames are `{"push":record}` or `{"pop":N}`. Group position determines the schema, so an operation at frame 0 and a second header in one group are both invalid.

The encoder rolls before a group's 32 MiB cache could evict its header. It also rejects a header larger than that cache and plaintext frames beyond the paired decoder's 64 MiB output limit. Existing JSON modes are unchanged. No in-tree track uses this format yet, so timeline integration and any corresponding Hang draft update remain separate work.

## Test plan

- `MOQ_STRICT=1 nix develop --command just check`
- `MOQ_STRICT=1 nix develop --command just test`
- Cross-language vectors and regressions for late joining, lag, maximum offsets, failed writes, pending commits, concurrent reads, per-group header position, invalid counts, oversized frames, and the group cache boundary

(written by GPT-5)
