### PR TITLE
fix(moq-audio): bound playback driver commands

### DIFF
--- a/rs/moq-audio/src/playback.rs
+++ b/rs/moq-audio/src/playback.rs
@@ -40,7 +40,6 @@ mod mixer;
 mod sink;
 
 use std::sync::Arc;
-use std::sync::mpsc::Sender;
 
 pub use device::{Device, devices};
 pub use sink::{Control, Input, Sink};
@@ -78,20 +77,20 @@ pub struct Engine {
 /// [`Sink`]. Dropping the last one shuts the thread down and closes the device,
 /// which is why a `Sink` outliving its `Engine` still plays.
 pub(crate) struct Handle {
-	commands: Sender<driver::Command>,
+	commands: driver::Commands,
 }
 
 impl Handle {
 	/// Nudge the driver to collect retired sinks and retry anything the mixer's
 	/// command queue was too full to take.
 	pub(crate) fn wake(&self) {
-		let _ = self.commands.send(driver::Command::Sync);
+		self.commands.sync();
 	}
 }
 
 impl Drop for Handle {
 	fn drop(&mut self) {
-		let _ = self.commands.send(driver::Command::Shutdown);
+		self.commands.shutdown();
 	}
 }
 
@@ -102,7 +101,7 @@ impl Engine {
 	/// driver's problem, not the caller's: it reopens the device with backoff
 	/// and existing sinks pick up where they left off.
 	pub async fn open(config: Config) -> Result<Self, Error> {
-		let (commands, requests) = std::sync::mpsc::channel();
+		let (commands, requests) = driver::channel();
 		let (opened, ready) = tokio::sync::oneshot::channel();
 
 		let shared = Arc::new(driver::Shared::default());
@@ -172,16 +171,11 @@ impl Engine {
 	///
 	/// Sinks survive the move: they keep the same handles and resample to the
 	/// new device's rate. Returns an error, and stays on no device, if the
-	/// requested one can't be opened.
+	/// requested one can't be opened. Also returns immediately with an error if
+	/// the driver already has its bounded maximum of switches waiting.
 	pub async fn switch(&self, config: Config) -> Result<(), Error> {
 		let (reply, response) = tokio::sync::oneshot::channel();
-		self.handle
-			.commands
-			.send(driver::Command::Switch {
-				device: config.device,
-				reply,
-			})
-			.map_err(|_| Error::Playback("the playback thread stopped".into()))?;
+		self.handle.commands.switch(config.device, reply)?;
 
 		response
 			.await

--- a/rs/moq-audio/src/playback/driver.rs
+++ b/rs/moq-audio/src/playback/driver.rs
@@ -6,9 +6,11 @@
 //! the hot path; they register themselves in [`Shared`] and hand their consumer
 //! straight to the mixer.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError, sync_channel};
-use std::sync::{Arc, Mutex};
+use std::collections::VecDeque;
+#[cfg(feature = "aec")]
+use std::sync::mpsc::TrySendError;
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 
 use cpal::traits::{DeviceTrait, StreamTrait};
@@ -37,11 +39,11 @@ const UNDERRUN_LIMIT: u32 = 20;
 const ERROR_LIMIT: u32 = 3;
 const ERROR_WINDOW: Duration = Duration::from_secs(5);
 
-/// Driver commands waiting while the thread is inside a host operation.
+/// Device switches waiting while the driver is inside a host operation.
 ///
-/// Only device switches consume one slot apiece. Notifications share one wake
-/// and keep their durable state outside the queue, so this is a hard bound on
-/// both storage and the number of callers awaiting a switch.
+/// Switches are the only work with a payload, so this is a hard bound on both
+/// the mailbox's storage and the number of callers awaiting a reply. Everything
+/// else the driver waits on is a flag that coalesces.
 const DRIVER_QUEUE: usize = 16;
 
 /// Sink updates the mixer's command queue holds. Preallocated, since draining it
@@ -319,200 +321,218 @@ fn attach_reference(reference: &mut crate::aec::Reference, mixer: &SyncSender<mi
 	}
 }
 
-/// The bounded payload queue the driver thread waits on.
-enum Command {
+/// What the driver thread waits on.
+///
+/// Not a queue of messages. Everything but a switch coalesces into a flag, so
+/// the mailbox derives one of these from whatever state is pending.
+enum Work {
 	/// Move to another output device, or back to the system default with `None`.
 	Switch {
 		device: Option<String>,
 		reply: tokio::sync::oneshot::Sender<Result<(), Error>>,
 	},
-	/// Coalesced notification state is ready to inspect.
-	Wake,
+	/// The live stream reported problems worth inspecting.
+	Failed,
+	/// A sink was added or dropped. Drops whatever the mixer retired and retries
+	/// anything its command queue was too full to take.
+	Sync,
+	/// A failed start's backoff has run out.
+	Retry,
+	/// The last [`Engine`](super::Engine) and [`Sink`](super::Sink) are gone.
+	Shutdown,
+}
+
+/// The driver's mailbox.
+///
+/// A mutex and a condvar rather than a channel, because the only unbounded
+/// thing a channel would buy us is a queue of duplicate notifications. Flags
+/// collapse a flood into one wake for free, and the lock is what makes a wake
+/// impossible to lose: a sender marks its flag under the lock, and the driver
+/// re-checks every flag under the same lock before it goes back to waiting.
+#[derive(Default)]
+struct Mailbox {
+	pending: Mutex<Pending>,
+	woken: Condvar,
+}
+
+/// A caller waiting to be moved to another output device.
+struct Switch {
+	/// The device to open, or the system default with `None`.
+	device: Option<String>,
+	/// Dropped rather than answered if the driver stops first, which is how the
+	/// caller learns the thread is gone.
+	reply: tokio::sync::oneshot::Sender<Result<(), Error>>,
 }
 
 #[derive(Default)]
-struct Signals {
-	sync: AtomicBool,
-	shutdown: AtomicBool,
-	wake_queued: AtomicBool,
+struct Pending {
+	/// Callers waiting on a device switch, capped at [`DRIVER_QUEUE`].
+	switches: VecDeque<Switch>,
+	/// The live stream's error callback has recorded something.
+	failed: bool,
+	/// A sink was added or dropped, or the mixer refused a registration.
+	sync: bool,
+	/// The last handle is gone. Latched: nothing un-shuts-down a driver.
+	shutdown: bool,
 }
 
-/// The sending half of the bounded driver mailbox.
+/// The sending half of the driver's mailbox.
 #[derive(Clone)]
 pub(super) struct Commands {
-	commands: SyncSender<Command>,
-	signals: Arc<Signals>,
+	mailbox: Arc<Mailbox>,
 }
 
 impl Commands {
-	/// Queue a device switch, returning before the caller awaits if the driver is
-	/// already carrying its fixed maximum of requests.
+	/// Queue a device switch, or refuse it if the driver is already carrying its
+	/// fixed maximum.
+	///
+	/// Refusing before the caller awaits is the point: a queue deep enough to
+	/// never say no is a queue with no memory bound.
 	pub(super) fn switch(
 		&self,
 		device: Option<String>,
 		reply: tokio::sync::oneshot::Sender<Result<(), Error>>,
 	) -> Result<(), Error> {
-		self.commands
-			.try_send(Command::Switch { device, reply })
-			.map_err(|err| match err {
-				TrySendError::Full(_) => Error::Playback("the playback thread is busy".into()),
-				TrySendError::Disconnected(_) => Error::Playback("the playback thread stopped".into()),
-			})
+		let mut pending = self.mailbox.pending.lock().unwrap();
+
+		if pending.shutdown {
+			return Err(Error::Playback("the playback thread stopped".into()));
+		} else if pending.switches.len() >= DRIVER_QUEUE {
+			return Err(Error::Playback("the playback thread is busy".into()));
+		}
+
+		pending.switches.push_back(Switch { device, reply });
+		drop(pending);
+
+		self.mailbox.woken.notify_one();
+		Ok(())
 	}
 
-	/// Coalesce a mixer retry while ensuring some queued command wakes the
-	/// driver to observe it.
+	/// Ask the driver to collect retired sinks and retry anything the mixer's
+	/// command queue was too full to take.
 	pub(super) fn sync(&self) {
-		self.signals.sync.store(true, Ordering::Release);
-		self.notify();
+		self.mailbox.pending.lock().unwrap().sync = true;
+		self.mailbox.woken.notify_one();
 	}
 
-	/// Reliably stop the driver even when every payload slot is occupied.
+	/// Stop the driver. Reliable however saturated the switch queue is, since
+	/// this is a flag rather than something that needs a slot.
 	pub(super) fn shutdown(&self) {
-		self.signals.shutdown.store(true, Ordering::Release);
-		self.notify();
+		let mut pending = self.mailbox.pending.lock().unwrap();
+		pending.shutdown = true;
+		// The driver stops serving these, so drop the replies here. Otherwise a
+		// caller waits out the process on a switch that will never be answered.
+		pending.switches.clear();
+		drop(pending);
+
+		self.mailbox.woken.notify_one();
 	}
 
-	/// Wake the driver without waiting for queue capacity. If the queue is full,
-	/// one of its existing commands is already guaranteed to wake the receiver,
-	/// which checks all notification state after every command.
-	fn notify(&self) {
-		if self.signals.wake_queued.swap(true, Ordering::AcqRel) {
-			return;
-		}
-
-		if self.commands.try_send(Command::Wake).is_err() {
-			// No wake was queued. The command that occupied the last slot will
-			// observe the pending state, and a later notification may try again.
-			self.signals.wake_queued.store(false, Ordering::Release);
-		}
+	/// Tell the driver its live stream has failures waiting.
+	fn failed(&self) {
+		self.mailbox.pending.lock().unwrap().failed = true;
+		self.mailbox.woken.notify_one();
 	}
 }
 
-/// The receiving half of the bounded driver mailbox.
+/// The receiving half of the driver's mailbox. Only the driver thread holds one.
 pub(super) struct Requests {
-	commands: Receiver<Command>,
-	signals: Arc<Signals>,
+	mailbox: Arc<Mailbox>,
 }
 
 impl Requests {
-	fn recv(&self) -> Result<Command, Timeout> {
-		self.received(self.commands.recv().map_err(|_| Timeout::Disconnected))
-	}
+	/// Block until there is something to do, or until `deadline` passes.
+	///
+	/// Shutdown wins over everything: once the last handle is gone there is no
+	/// point opening a device. Nothing is stranded by that, since a shutdown
+	/// answers the switches it overtakes and refuses any that follow.
+	fn wait(&self, deadline: Option<Instant>) -> Work {
+		let mut pending = self.mailbox.pending.lock().unwrap();
 
-	fn recv_until(&self, at: Instant) -> Result<Command, Timeout> {
-		let command = match self.commands.recv_timeout(at.saturating_duration_since(Instant::now())) {
-			Ok(command) => Ok(command),
-			Err(RecvTimeoutError::Timeout) => Err(Timeout::Elapsed),
-			Err(RecvTimeoutError::Disconnected) => Err(Timeout::Disconnected),
-		};
-		self.received(command)
-	}
+		loop {
+			if pending.shutdown {
+				return Work::Shutdown;
+			} else if let Some(Switch { device, reply }) = pending.switches.pop_front() {
+				return Work::Switch { device, reply };
+			} else if std::mem::take(&mut pending.failed) {
+				return Work::Failed;
+			} else if std::mem::take(&mut pending.sync) {
+				return Work::Sync;
+			}
 
-	fn received(&self, command: Result<Command, Timeout>) -> Result<Command, Timeout> {
-		if matches!(command, Ok(Command::Wake)) {
-			self.signals.wake_queued.store(false, Ordering::Release);
+			let Some(at) = deadline else {
+				pending = self.mailbox.woken.wait(pending).unwrap();
+				continue;
+			};
+
+			// Real work outranks the backoff, so the deadline is only reported
+			// once the loop above has found nothing else to do.
+			let wait = at.saturating_duration_since(Instant::now());
+			if wait.is_zero() {
+				return Work::Retry;
+			}
+
+			pending = self.mailbox.woken.wait_timeout(pending, wait).unwrap().0;
 		}
-		command
-	}
-
-	fn take_sync(&self) -> bool {
-		self.signals.sync.swap(false, Ordering::AcqRel)
-	}
-
-	fn shutdown(&self) -> bool {
-		self.signals.shutdown.load(Ordering::Acquire)
-	}
-
-	#[cfg(test)]
-	fn try_recv(&self) -> Result<Command, std::sync::mpsc::TryRecvError> {
-		let command = self.commands.try_recv();
-		if matches!(command, Ok(Command::Wake)) {
-			self.signals.wake_queued.store(false, Ordering::Release);
-		}
-		command
 	}
 }
 
-/// Build the driver's fixed-capacity mailbox.
+/// Build the driver's mailbox.
 pub(super) fn channel() -> (Commands, Requests) {
-	let (commands, requests) = sync_channel(DRIVER_QUEUE);
-	let signals = Arc::new(Signals::default());
+	let mailbox = Arc::new(Mailbox::default());
 	(
 		Commands {
-			commands,
-			signals: signals.clone(),
+			mailbox: mailbox.clone(),
 		},
-		Requests {
-			commands: requests,
-			signals,
-		},
+		Requests { mailbox },
 	)
 }
 
-/// Fixed-size failure state owned by one stream generation.
+/// Failures the live stream has reported since the driver last looked.
 ///
-/// The callback only updates atomics, then posts a non-blocking coalesced wake.
-/// Replacing a stream replaces this entire state, so a retired callback cannot
-/// occupy or overwrite any part of the live generation's signal.
+/// Fixed size: the counters saturate at the limits that act on them and only
+/// the most recent unclassified error is kept, so a flood costs no more storage
+/// than a single failure. Replacing a stream replaces this state, so a retired
+/// callback can only write somewhere the driver never reads again.
 #[derive(Default)]
 struct Failures {
-	unavailable: AtomicBool,
-	invalidated: AtomicBool,
-	changed: AtomicBool,
-	realtime_denied: AtomicBool,
-	xruns: AtomicU32,
-	unclassified: AtomicU32,
-}
-
-impl Failures {
-	fn record(&self, kind: cpal::ErrorKind) {
-		match kind {
-			cpal::ErrorKind::DeviceNotAvailable => self.unavailable.store(true, Ordering::Release),
-			cpal::ErrorKind::StreamInvalidated => self.invalidated.store(true, Ordering::Release),
-			cpal::ErrorKind::DeviceChanged => self.changed.store(true, Ordering::Release),
-			cpal::ErrorKind::RealtimeDenied => self.realtime_denied.store(true, Ordering::Release),
-			cpal::ErrorKind::Xrun => increment(&self.xruns, UNDERRUN_LIMIT + 1),
-			_ => increment(&self.unclassified, ERROR_LIMIT),
-		}
-	}
-
-	fn take(&self) -> FailureBatch {
-		FailureBatch {
-			unavailable: self.unavailable.swap(false, Ordering::AcqRel),
-			invalidated: self.invalidated.swap(false, Ordering::AcqRel),
-			changed: self.changed.swap(false, Ordering::AcqRel),
-			realtime_denied: self.realtime_denied.swap(false, Ordering::AcqRel),
-			xruns: self.xruns.swap(0, Ordering::AcqRel),
-			unclassified: self.unclassified.swap(0, Ordering::AcqRel),
-		}
-	}
-}
-
-fn increment(counter: &AtomicU32, limit: u32) {
-	let _ = counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-		Some(current.saturating_add(1).min(limit))
-	});
-}
-
-struct FailureBatch {
 	unavailable: bool,
 	invalidated: bool,
 	changed: bool,
 	realtime_denied: bool,
 	xruns: u32,
 	unclassified: u32,
+	/// The most recent unclassified error, so the warning names something.
+	last: Option<cpal::Error>,
 }
 
+impl Failures {
+	fn record(&mut self, error: cpal::Error) {
+		match error.kind() {
+			cpal::ErrorKind::DeviceNotAvailable => self.unavailable = true,
+			cpal::ErrorKind::StreamInvalidated => self.invalidated = true,
+			cpal::ErrorKind::DeviceChanged => self.changed = true,
+			cpal::ErrorKind::RealtimeDenied => self.realtime_denied = true,
+			cpal::ErrorKind::Xrun => self.xruns = self.xruns.saturating_add(1).min(UNDERRUN_LIMIT + 1),
+			_ => {
+				self.unclassified = self.unclassified.saturating_add(1).min(ERROR_LIMIT);
+				self.last = Some(error);
+			}
+		}
+	}
+}
+
+/// Handed to one stream's error callback, which is a plain thread rather than
+/// the audio callback, so taking a lock here is fine.
 struct FailureReporter {
-	failures: Arc<Failures>,
+	failures: Arc<Mutex<Failures>>,
 	commands: Commands,
 }
 
 impl FailureReporter {
 	fn report(&self, error: cpal::Error) {
-		self.failures.record(error.kind());
-		self.commands.notify();
+		self.failures.lock().unwrap().record(error);
+		self.commands.failed();
 	}
 }
 
@@ -553,41 +573,25 @@ pub(super) fn run(
 
 	loop {
 		// A failed start leaves a deadline to wake on; otherwise just block.
-		let command = match driver.retry_at {
-			Some(at) => requests.recv_until(at),
-			None => requests.recv(),
-		};
-
-		if requests.shutdown() {
-			break;
-		}
-
-		match command {
-			Ok(Command::Switch { device, reply }) => {
+		match requests.wait(driver.retry_at) {
+			Work::Switch { device, reply } => {
 				driver.device = device;
 				let _ = reply.send(driver.restart());
 			}
-			Ok(Command::Wake) => {}
-			Err(Timeout::Elapsed) => {
+			Work::Failed => {
+				if driver.should_restart() {
+					let _ = driver.restart();
+				}
+			}
+			Work::Sync => driver.sync(),
+			Work::Retry => {
 				if driver.restart().is_ok() {
 					tracing::info!("audio output recovered");
 				}
 			}
-			Err(Timeout::Disconnected) => break,
-		}
-
-		if driver.should_restart() {
-			let _ = driver.restart();
-		}
-		if requests.take_sync() {
-			driver.sync();
+			Work::Shutdown => break,
 		}
 	}
-}
-
-enum Timeout {
-	Elapsed,
-	Disconnected,
 }
 
 struct Driver {
@@ -600,8 +604,9 @@ struct Driver {
 	/// Sinks the mixer has finished with, dropped here so the audio thread never
 	/// has to free one.
 	retired: Option<Receiver<mixer::Retired>>,
-	/// Failure counters for the live stream only.
-	failures: Option<Arc<Failures>>,
+	/// Failure state for the live stream only. Replaced with the stream, so a
+	/// retired callback's writes are never read.
+	failures: Option<Arc<Mutex<Failures>>>,
 	/// Delay before reopening a device that would not start, doubling per failure.
 	retry: Duration,
 	/// When a failed start may be retried, and what the command wait times out
@@ -642,7 +647,7 @@ impl Driver {
 		let (retired_tx, retired_rx) = sync_channel(COMMAND_QUEUE);
 		let mixer = Mixer::new(rx, retired_tx, rate, channels);
 
-		let failures = Arc::new(Failures::default());
+		let failures = Arc::new(Mutex::new(Failures::default()));
 		let reporter = FailureReporter {
 			failures: failures.clone(),
 			commands: self.commands.clone(),
@@ -783,15 +788,18 @@ impl Driver {
 		Instant::now() + wait
 	}
 
-	/// Whether the live stream's accumulated failures require a rebuild.
+	/// Whether the failures the live stream has reported require a rebuild.
 	fn should_restart(&mut self) -> bool {
 		let Some(failures) = &self.failures else { return false };
-		let failures = failures.take();
+		let failures = std::mem::take(&mut *failures.lock().unwrap());
 		self.roll_window();
 
+		// cpal documents both as survivable: the stream keeps running and needs
+		// no rebuild.
 		if failures.changed || failures.realtime_denied {
 			tracing::debug!("audio output changed underneath us");
 		}
+
 		if failures.unavailable || failures.invalidated {
 			tracing::warn!("audio output lost");
 			return true;
@@ -806,8 +814,8 @@ impl Driver {
 			return true;
 		}
 
-		if failures.unclassified > 0 {
-			tracing::warn!(count = failures.unclassified, "audio output error");
+		if let Some(err) = &failures.last {
+			tracing::warn!(%err, count = failures.unclassified, "audio output error");
 		}
 		self.unclassified = self.unclassified.saturating_add(failures.unclassified);
 		if self.unclassified >= ERROR_LIMIT {
@@ -864,10 +872,16 @@ mod tests {
 		shared.add(|id, rate| sink::new(id, rate, Input::default(), shared.clone(), handle.clone()))
 	}
 
-	fn syncs(driver: &Requests) -> usize {
-		std::iter::from_fn(|| driver.try_recv().ok())
-			.filter(|c| matches!(c, Command::Wake))
-			.count()
+	/// Long enough that only a lost wake, rather than a loaded machine, trips a
+	/// test that waits this out.
+	const PATIENCE: Duration = Duration::from_secs(5);
+
+	/// What the driver would find without blocking, or `None` if it would wait.
+	fn poll(driver: &Requests) -> Option<Work> {
+		match driver.wait(Some(Instant::now())) {
+			Work::Retry => None,
+			work => Some(work),
+		}
 	}
 
 	fn queue_switch(commands: &Commands) -> tokio::sync::oneshot::Receiver<Result<(), Error>> {
@@ -910,10 +924,16 @@ mod tests {
 		};
 
 		let sink = engine.sink(Input::default()).unwrap();
-		assert_eq!(syncs(&w.driver), 1, "adding a sink did not wake the driver");
+		assert!(
+			matches!(poll(&w.driver), Some(Work::Sync)),
+			"adding a sink did not wake the driver"
+		);
 
 		drop(sink);
-		assert_eq!(syncs(&w.driver), 1, "dropping a sink did not wake the driver");
+		assert!(
+			matches!(poll(&w.driver), Some(Work::Sync)),
+			"dropping a sink did not wake the driver"
+		);
 	}
 
 	/// Same for removals. Dropping one would leave the mixer reading a sink
@@ -953,12 +973,12 @@ mod tests {
 		add(&w.shared, &w.handle).expect("a slot freed by the dropped sink");
 	}
 
-	/// Every notification class has fixed storage even when the receiver stops
-	/// draining entirely.
+	/// Every notification class has fixed storage however hard it is hit, and a
+	/// flood collapses into the single wake the driver acts on.
 	#[test]
 	fn notification_floods_are_coalesced() {
 		let (commands, requests) = channel();
-		let failures = Arc::new(Failures::default());
+		let failures = Arc::new(Mutex::new(Failures::default()));
 		let reporter = FailureReporter {
 			failures: failures.clone(),
 			commands: commands.clone(),
@@ -978,11 +998,12 @@ mod tests {
 			}
 		}
 
-		assert!(matches!(requests.try_recv(), Ok(Command::Wake)));
-		assert!(requests.try_recv().is_err(), "more than one wake was queued");
-		assert!(requests.take_sync());
+		assert!(requests.mailbox.pending.lock().unwrap().switches.is_empty());
+		assert!(matches!(poll(&requests), Some(Work::Failed)));
+		assert!(matches!(poll(&requests), Some(Work::Sync)));
+		assert!(poll(&requests).is_none(), "a flood outlived its coalesced wakes");
 
-		let failures = failures.take();
+		let failures = std::mem::take(&mut *failures.lock().unwrap());
 		assert!(failures.unavailable);
 		assert!(failures.invalidated);
 		assert!(failures.changed);
@@ -991,7 +1012,7 @@ mod tests {
 		assert_eq!(failures.unclassified, ERROR_LIMIT);
 	}
 
-	/// A switch either occupies one of the fixed slots or reports overload before
+	/// A switch either takes one of the fixed slots or reports overload before
 	/// its caller starts awaiting a response.
 	#[test]
 	fn switches_complete_or_reject_overload() {
@@ -1003,55 +1024,109 @@ mod tests {
 		assert!(matches!(error, Error::Playback(message) if message.contains("busy")));
 
 		for response in responses {
-			let Command::Switch { reply, .. } = requests.try_recv().unwrap() else {
-				panic!("a switch slot held a wake");
+			let Some(Work::Switch { reply, .. }) = poll(&requests) else {
+				panic!("a switch went missing");
 			};
 			reply.send(Ok(())).unwrap();
 			assert!(matches!(response.blocking_recv(), Ok(Ok(()))));
 		}
 	}
 
-	/// A sync remains durable when the payload queue is saturated and its wake
-	/// cannot claim a slot.
+	/// A sync raised while every switch slot is taken still reaches the driver.
+	/// It has no slot to compete for, so saturation cannot drop it.
 	#[test]
-	fn sync_survives_a_full_driver_queue() {
+	fn sync_survives_a_saturated_driver() {
 		let (commands, requests) = channel();
 		let _responses: Vec<_> = (0..DRIVER_QUEUE).map(|_| queue_switch(&commands)).collect();
 
 		commands.sync();
-		assert!(requests.take_sync(), "the dropped wake lost the mixer retry");
+
+		for _ in 0..DRIVER_QUEUE {
+			assert!(matches!(poll(&requests), Some(Work::Switch { .. })));
+		}
+		assert!(matches!(poll(&requests), Some(Work::Sync)), "saturation lost a sync");
 	}
 
-	/// The last handle sets shutdown outside the saturated payload queue, so the
-	/// driver exits as soon as it receives any already-queued command.
+	/// The last handle must stop a saturated driver rather than leaking the
+	/// thread and the device with it.
 	#[test]
 	fn final_handle_shuts_down_a_saturated_driver() {
 		let (commands, requests) = channel();
 		let handle = Arc::new(super::super::Handle {
 			commands: commands.clone(),
 		});
-		let _responses: Vec<_> = (0..DRIVER_QUEUE).map(|_| queue_switch(&commands)).collect();
+		let responses: Vec<_> = (0..DRIVER_QUEUE).map(|_| queue_switch(&commands)).collect();
 
 		drop(handle);
-		assert!(requests.shutdown(), "the full queue lost shutdown");
-		assert!(matches!(requests.try_recv(), Ok(Command::Switch { .. })));
+		assert!(
+			matches!(poll(&requests), Some(Work::Shutdown)),
+			"saturation lost shutdown"
+		);
+
+		// The driver returns rather than serving the backlog, so every waiting
+		// caller learns the thread stopped instead of hanging on its reply.
+		for response in responses {
+			assert!(response.blocking_recv().is_err());
+		}
+		let (reply, _response) = tokio::sync::oneshot::channel();
+		let error = commands.switch(None, reply).unwrap_err();
+		assert!(matches!(error, Error::Playback(message) if message.contains("stopped")));
 	}
 
-	/// A stream that has already been replaced can still have an error queued.
-	/// Its fixed state must not displace the live generation's failure, even when
-	/// both it and a sync share the one pending wake.
+	/// A driver blocked with nothing queued has to be woken by the next
+	/// notification, whatever else raced with it. Losing this wake stranded a
+	/// sink registration, or the shutdown that closes the device.
 	#[test]
-	fn live_failure_survives_stale_and_sync_notifications() {
-		let w = wired(8);
+	fn a_blocked_driver_is_woken() {
 		let (commands, requests) = channel();
-		let stale = Arc::new(Failures::default());
-		let current = Arc::new(Failures::default());
+		let (sent, arrived) = std::sync::mpsc::channel();
+
+		let waker = commands.clone();
+		let driver = std::thread::spawn(move || {
+			// Deadlines rather than a plain block, so a lost wake fails the test
+			// instead of hanging it.
+			let woken = matches!(requests.wait(Some(Instant::now() + PATIENCE)), Work::Sync);
+			sent.send(()).unwrap();
+
+			// Syncs racing in behind the first are fine; only silence is not.
+			let deadline = Instant::now() + PATIENCE;
+			let stopped = loop {
+				match requests.wait(Some(deadline)) {
+					Work::Shutdown => break true,
+					Work::Retry => break false,
+					_ => continue,
+				}
+			};
+			(woken, stopped)
+		});
+
+		// Let the driver reach `wait` with an empty mailbox, then race a flood
+		// of notifications against it.
+		std::thread::sleep(Duration::from_millis(10));
+		std::thread::scope(|s| {
+			for _ in 0..8 {
+				s.spawn(|| waker.sync());
+			}
+		});
+
+		arrived.recv_timeout(PATIENCE).expect("a sync never woke the driver");
+		commands.shutdown();
+
+		let (woken, stopped) = driver.join().unwrap();
+		assert!(woken, "a sync never woke the driver");
+		assert!(stopped, "a shutdown never woke the driver");
+	}
+
+	/// A stream that has already been replaced can still report an error. Acting
+	/// on it tears down the healthy stream that replaced it.
+	#[test]
+	fn ignores_errors_from_a_replaced_stream() {
+		let w = wired(8);
+		let (commands, _requests) = channel();
+		let stale = Arc::new(Mutex::new(Failures::default()));
+		let current = Arc::new(Mutex::new(Failures::default()));
 		let stale_reporter = FailureReporter {
 			failures: stale,
-			commands: commands.clone(),
-		};
-		let current_reporter = FailureReporter {
-			failures: current.clone(),
 			commands: commands.clone(),
 		};
 
@@ -1069,13 +1144,11 @@ mod tests {
 			window: Instant::now(),
 		};
 
-		stale_reporter.report(cpal::Error::new(cpal::ErrorKind::DeviceNotAvailable));
-		commands.sync();
-		current_reporter.report(cpal::Error::new(cpal::ErrorKind::DeviceNotAvailable));
+		let lost = cpal::Error::new(cpal::ErrorKind::DeviceNotAvailable);
+		stale_reporter.report(lost.clone());
+		assert!(!driver.should_restart(), "acted on a retired stream's error");
 
-		assert!(matches!(requests.try_recv(), Ok(Command::Wake)));
-		assert!(requests.try_recv().is_err(), "notifications were not coalesced");
-		assert!(requests.take_sync());
+		current.lock().unwrap().record(lost);
 		assert!(driver.should_restart(), "ignored the live stream's error");
 	}
 }

--- a/rs/moq-audio/src/playback/driver.rs
+++ b/rs/moq-audio/src/playback/driver.rs
@@ -10,7 +10,9 @@ use std::collections::VecDeque;
 #[cfg(feature = "aec")]
 use std::sync::mpsc::TrySendError;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::Thread;
 use std::time::{Duration, Instant};
 
 use cpal::traits::{DeviceTrait, StreamTrait};
@@ -323,8 +325,9 @@ fn attach_reference(reference: &mut crate::aec::Reference, mixer: &SyncSender<mi
 
 /// What the driver thread waits on.
 ///
-/// Not a queue of messages. Everything but a switch coalesces into a flag, so
-/// the mailbox derives one of these from whatever state is pending.
+/// Not a queue of messages. Only a switch carries a payload; everything else
+/// coalesces into a flag, so the mailbox derives one of these from whatever is
+/// pending.
 enum Work {
 	/// Move to another output device, or back to the system default with `None`.
 	Switch {
@@ -342,19 +345,6 @@ enum Work {
 	Shutdown,
 }
 
-/// The driver's mailbox.
-///
-/// A mutex and a condvar rather than a channel, because the only unbounded
-/// thing a channel would buy us is a queue of duplicate notifications. Flags
-/// collapse a flood into one wake for free, and the lock is what makes a wake
-/// impossible to lose: a sender marks its flag under the lock, and the driver
-/// re-checks every flag under the same lock before it goes back to waiting.
-#[derive(Default)]
-struct Mailbox {
-	pending: Mutex<Pending>,
-	woken: Condvar,
-}
-
 /// A caller waiting to be moved to another output device.
 struct Switch {
 	/// The device to open, or the system default with `None`.
@@ -364,20 +354,49 @@ struct Switch {
 	reply: tokio::sync::oneshot::Sender<Result<(), Error>>,
 }
 
+/// The driver's mailbox, split by who is allowed to write which half.
+///
+/// cpal's error callback is not a normal thread. On CoreAudio it *is* the
+/// render callback, and JACK, PipeWire, WASAPI and AAudio all raise it from
+/// their process threads; cpal hands those paths `try_emit_error` precisely so
+/// they never block. So everything reachable from a failure report is an atomic
+/// plus [`Thread::unpark`], which allocates nothing and cannot wait on another
+/// thread. Only a switch takes a lock, and no callback ever raises one.
+///
+/// `unpark` is also what makes a wake impossible to lose. It leaves a permit
+/// behind, so a signal raised between the driver's last check and its `park`
+/// makes that `park` return at once rather than sleeping through it.
 #[derive(Default)]
-struct Pending {
-	/// Callers waiting on a device switch, capped at [`DRIVER_QUEUE`].
-	switches: VecDeque<Switch>,
-	/// The live stream's error callback has recorded something.
-	failed: bool,
-	/// A sink was added or dropped, or the mixer refused a registration.
-	sync: bool,
-	/// The last handle is gone. Latched: nothing un-shuts-down a driver.
-	shutdown: bool,
+struct Mailbox {
+	/// Callers waiting on a device switch.
+	switches: Mutex<Switches>,
+	signals: Signals,
+	/// The driver thread, so a sender can wake it. Registered before the driver
+	/// can park, so a signal raised before it lands is still caught by the
+	/// first check rather than slept through.
+	driver: OnceLock<Thread>,
+}
+
+#[derive(Default)]
+struct Switches {
+	/// Capped at [`DRIVER_QUEUE`].
+	waiting: VecDeque<Switch>,
+	/// Latched under this lock together with the drain in
+	/// [`Commands::shutdown`], so a switch cannot slip into a queue the driver
+	/// has already stopped serving.
+	closed: bool,
+}
+
+#[derive(Default)]
+struct Signals {
+	/// Written from cpal's error callback, which is why this is an atomic.
+	failed: AtomicBool,
+	sync: AtomicBool,
+	shutdown: AtomicBool,
 }
 
 /// The sending half of the driver's mailbox.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(super) struct Commands {
 	mailbox: Arc<Mailbox>,
 }
@@ -393,45 +412,61 @@ impl Commands {
 		device: Option<String>,
 		reply: tokio::sync::oneshot::Sender<Result<(), Error>>,
 	) -> Result<(), Error> {
-		let mut pending = self.mailbox.pending.lock().unwrap();
+		let mut switches = self.mailbox.switches.lock().unwrap();
 
-		if pending.shutdown {
+		if switches.closed {
 			return Err(Error::Playback("the playback thread stopped".into()));
-		} else if pending.switches.len() >= DRIVER_QUEUE {
+		} else if switches.waiting.len() >= DRIVER_QUEUE {
 			return Err(Error::Playback("the playback thread is busy".into()));
 		}
 
-		pending.switches.push_back(Switch { device, reply });
-		drop(pending);
+		switches.waiting.push_back(Switch { device, reply });
+		drop(switches);
 
-		self.mailbox.woken.notify_one();
+		self.mailbox.wake();
 		Ok(())
 	}
 
 	/// Ask the driver to collect retired sinks and retry anything the mixer's
 	/// command queue was too full to take.
 	pub(super) fn sync(&self) {
-		self.mailbox.pending.lock().unwrap().sync = true;
-		self.mailbox.woken.notify_one();
+		self.mailbox.signals.sync.store(true, Ordering::Release);
+		self.mailbox.wake();
 	}
 
-	/// Stop the driver. Reliable however saturated the switch queue is, since
-	/// this is a flag rather than something that needs a slot.
+	/// Stop the driver. A flag rather than a queued message, so saturation
+	/// cannot delay or drop it.
 	pub(super) fn shutdown(&self) {
-		let mut pending = self.mailbox.pending.lock().unwrap();
-		pending.shutdown = true;
-		// The driver stops serving these, so drop the replies here. Otherwise a
-		// caller waits out the process on a switch that will never be answered.
-		pending.switches.clear();
-		drop(pending);
+		self.mailbox.signals.shutdown.store(true, Ordering::Release);
 
-		self.mailbox.woken.notify_one();
+		// Answer everyone still waiting. The driver stops serving these, so
+		// dropping the replies here is what tells those callers the thread is
+		// gone instead of leaving them parked forever.
+		let mut switches = self.mailbox.switches.lock().unwrap();
+		switches.closed = true;
+		switches.waiting.clear();
+		drop(switches);
+
+		self.mailbox.wake();
 	}
 
 	/// Tell the driver its live stream has failures waiting.
+	///
+	/// Reached from cpal's error callback, so this must stay lock-free.
 	fn failed(&self) {
-		self.mailbox.pending.lock().unwrap().failed = true;
-		self.mailbox.woken.notify_one();
+		self.mailbox.signals.failed.store(true, Ordering::Release);
+		self.mailbox.wake();
+	}
+}
+
+impl Mailbox {
+	/// Wake the driver, or leave a permit if it has not parked yet.
+	///
+	/// Lock-free and allocation-free: safe to call from an audio callback.
+	fn wake(&self) {
+		if let Some(driver) = self.driver.get() {
+			driver.unpark();
+		}
 	}
 }
 
@@ -441,38 +476,51 @@ pub(super) struct Requests {
 }
 
 impl Requests {
+	/// Let senders wake this thread.
+	///
+	/// Called before the driver can park. A signal raised before this lands
+	/// wakes nobody, which is harmless only because the wait below always
+	/// re-checks every signal before parking.
+	fn attach(&self) {
+		let _ = self.mailbox.driver.set(std::thread::current());
+	}
+
 	/// Block until there is something to do, or until `deadline` passes.
 	///
 	/// Shutdown wins over everything: once the last handle is gone there is no
 	/// point opening a device. Nothing is stranded by that, since a shutdown
 	/// answers the switches it overtakes and refuses any that follow.
 	fn wait(&self, deadline: Option<Instant>) -> Work {
-		let mut pending = self.mailbox.pending.lock().unwrap();
+		let signals = &self.mailbox.signals;
 
 		loop {
-			if pending.shutdown {
+			if signals.shutdown.load(Ordering::Acquire) {
 				return Work::Shutdown;
-			} else if let Some(Switch { device, reply }) = pending.switches.pop_front() {
+			} else if let Some(Switch { device, reply }) = self.mailbox.switches.lock().unwrap().waiting.pop_front() {
 				return Work::Switch { device, reply };
-			} else if std::mem::take(&mut pending.failed) {
+			} else if signals.failed.swap(false, Ordering::AcqRel) {
 				return Work::Failed;
-			} else if std::mem::take(&mut pending.sync) {
+			} else if signals.sync.swap(false, Ordering::AcqRel) {
 				return Work::Sync;
 			}
 
+			// Nothing pending. A sender that raced the checks above either
+			// unparked us already, leaving a permit that returns from the park
+			// below at once, or has yet to signal and will unpark us after it
+			// does. Either way the loop re-checks before sleeping again.
 			let Some(at) = deadline else {
-				pending = self.mailbox.woken.wait(pending).unwrap();
+				std::thread::park();
 				continue;
 			};
 
 			// Real work outranks the backoff, so the deadline is only reported
-			// once the loop above has found nothing else to do.
+			// once the checks above have found nothing else to do.
 			let wait = at.saturating_duration_since(Instant::now());
 			if wait.is_zero() {
 				return Work::Retry;
 			}
 
-			pending = self.mailbox.woken.wait_timeout(pending, wait).unwrap().0;
+			std::thread::park_timeout(wait);
 		}
 	}
 }
@@ -488,50 +536,108 @@ pub(super) fn channel() -> (Commands, Requests) {
 	)
 }
 
+/// Unclassified error kinds worth naming in a log, indexed by the code
+/// [`Failures::last`] holds. Zero means nothing recorded.
+///
+/// A code rather than the `cpal::Error` itself: the error owns a message, so
+/// keeping one would mean freeing the previous one on the audio thread.
+const UNCLASSIFIED: [cpal::ErrorKind; 9] = [
+	cpal::ErrorKind::DeviceBusy,
+	cpal::ErrorKind::HostUnavailable,
+	cpal::ErrorKind::InvalidInput,
+	cpal::ErrorKind::PermissionDenied,
+	cpal::ErrorKind::ResourceExhausted,
+	cpal::ErrorKind::UnsupportedConfig,
+	cpal::ErrorKind::UnsupportedOperation,
+	cpal::ErrorKind::BackendError,
+	cpal::ErrorKind::Other,
+];
+
+fn code(kind: cpal::ErrorKind) -> u8 {
+	// `ErrorKind` is `#[non_exhaustive]`, so a kind added upstream simply has no
+	// code and logs as the count alone.
+	UNCLASSIFIED.iter().position(|k| *k == kind).map_or(0, |i| i as u8 + 1)
+}
+
+fn named(code: u8) -> Option<cpal::ErrorKind> {
+	UNCLASSIFIED.get(usize::from(code.checked_sub(1)?)).copied()
+}
+
 /// Failures the live stream has reported since the driver last looked.
 ///
-/// Fixed size: the counters saturate at the limits that act on them and only
-/// the most recent unclassified error is kept, so a flood costs no more storage
-/// than a single failure. Replacing a stream replaces this state, so a retired
-/// callback can only write somewhere the driver never reads again.
+/// Every field is an atomic because cpal's error callback writes them from the
+/// audio thread. Fixed size too: the counters saturate at the limits that act
+/// on them and only the latest unclassified kind is kept, so a storm costs no
+/// more storage than one failure. Replacing a stream replaces this state, so a
+/// retired callback can only write somewhere the driver never reads again.
 #[derive(Default)]
 struct Failures {
+	unavailable: AtomicBool,
+	invalidated: AtomicBool,
+	changed: AtomicBool,
+	realtime_denied: AtomicBool,
+	xruns: AtomicU32,
+	unclassified: AtomicU32,
+	last: AtomicU8,
+}
+
+impl Failures {
+	fn record(&self, kind: cpal::ErrorKind) {
+		match kind {
+			cpal::ErrorKind::DeviceNotAvailable => self.unavailable.store(true, Ordering::Release),
+			cpal::ErrorKind::StreamInvalidated => self.invalidated.store(true, Ordering::Release),
+			cpal::ErrorKind::DeviceChanged => self.changed.store(true, Ordering::Release),
+			cpal::ErrorKind::RealtimeDenied => self.realtime_denied.store(true, Ordering::Release),
+			cpal::ErrorKind::Xrun => increment(&self.xruns, UNDERRUN_LIMIT + 1),
+			_ => {
+				increment(&self.unclassified, ERROR_LIMIT);
+				self.last.store(code(kind), Ordering::Release);
+			}
+		}
+	}
+
+	fn take(&self) -> FailureBatch {
+		FailureBatch {
+			unavailable: self.unavailable.swap(false, Ordering::AcqRel),
+			invalidated: self.invalidated.swap(false, Ordering::AcqRel),
+			changed: self.changed.swap(false, Ordering::AcqRel),
+			realtime_denied: self.realtime_denied.swap(false, Ordering::AcqRel),
+			xruns: self.xruns.swap(0, Ordering::AcqRel),
+			unclassified: self.unclassified.swap(0, Ordering::AcqRel),
+			last: named(self.last.swap(0, Ordering::AcqRel)),
+		}
+	}
+}
+
+fn increment(counter: &AtomicU32, limit: u32) {
+	let _ = counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+		Some(current.saturating_add(1).min(limit))
+	});
+}
+
+struct FailureBatch {
 	unavailable: bool,
 	invalidated: bool,
 	changed: bool,
 	realtime_denied: bool,
 	xruns: u32,
 	unclassified: u32,
-	/// The most recent unclassified error, so the warning names something.
-	last: Option<cpal::Error>,
+	last: Option<cpal::ErrorKind>,
 }
 
-impl Failures {
-	fn record(&mut self, error: cpal::Error) {
-		match error.kind() {
-			cpal::ErrorKind::DeviceNotAvailable => self.unavailable = true,
-			cpal::ErrorKind::StreamInvalidated => self.invalidated = true,
-			cpal::ErrorKind::DeviceChanged => self.changed = true,
-			cpal::ErrorKind::RealtimeDenied => self.realtime_denied = true,
-			cpal::ErrorKind::Xrun => self.xruns = self.xruns.saturating_add(1).min(UNDERRUN_LIMIT + 1),
-			_ => {
-				self.unclassified = self.unclassified.saturating_add(1).min(ERROR_LIMIT);
-				self.last = Some(error);
-			}
-		}
-	}
-}
-
-/// Handed to one stream's error callback, which is a plain thread rather than
-/// the audio callback, so taking a lock here is fine.
+/// Handed to one stream's error callback.
 struct FailureReporter {
-	failures: Arc<Mutex<Failures>>,
+	failures: Arc<Failures>,
 	commands: Commands,
 }
 
 impl FailureReporter {
-	fn report(&self, error: cpal::Error) {
-		self.failures.lock().unwrap().record(error);
+	/// Record a failure and wake the driver.
+	///
+	/// cpal raises this from the audio thread on most backends, so nothing here
+	/// may allocate, lock, or block.
+	fn report(&self, error: &cpal::Error) {
+		self.failures.record(error.kind());
 		self.commands.failed();
 	}
 }
@@ -562,6 +668,8 @@ pub(super) fn run(
 		unclassified: 0,
 		window: Instant::now(),
 	};
+
+	requests.attach();
 
 	let first = driver.start();
 	let started = first.is_ok();
@@ -606,7 +714,7 @@ struct Driver {
 	retired: Option<Receiver<mixer::Retired>>,
 	/// Failure state for the live stream only. Replaced with the stream, so a
 	/// retired callback's writes are never read.
-	failures: Option<Arc<Mutex<Failures>>>,
+	failures: Option<Arc<Failures>>,
 	/// Delay before reopening a device that would not start, doubling per failure.
 	retry: Duration,
 	/// When a failed start may be retried, and what the command wait times out
@@ -647,7 +755,7 @@ impl Driver {
 		let (retired_tx, retired_rx) = sync_channel(COMMAND_QUEUE);
 		let mixer = Mixer::new(rx, retired_tx, rate, channels);
 
-		let failures = Arc::new(Mutex::new(Failures::default()));
+		let failures = Arc::new(Failures::default());
 		let reporter = FailureReporter {
 			failures: failures.clone(),
 			commands: self.commands.clone(),
@@ -718,7 +826,7 @@ impl Driver {
 					}
 				},
 				move |error| {
-					failures.report(error);
+					failures.report(&error);
 				},
 				None,
 			)
@@ -791,7 +899,7 @@ impl Driver {
 	/// Whether the failures the live stream has reported require a rebuild.
 	fn should_restart(&mut self) -> bool {
 		let Some(failures) = &self.failures else { return false };
-		let failures = std::mem::take(&mut *failures.lock().unwrap());
+		let failures = failures.take();
 		self.roll_window();
 
 		// cpal documents both as survivable: the stream keeps running and needs
@@ -814,8 +922,8 @@ impl Driver {
 			return true;
 		}
 
-		if let Some(err) = &failures.last {
-			tracing::warn!(%err, count = failures.unclassified, "audio output error");
+		if let Some(kind) = failures.last {
+			tracing::warn!(%kind, count = failures.unclassified, "audio output error");
 		}
 		self.unclassified = self.unclassified.saturating_add(failures.unclassified);
 		if self.unclassified >= ERROR_LIMIT {
@@ -974,11 +1082,11 @@ mod tests {
 	}
 
 	/// Every notification class has fixed storage however hard it is hit, and a
-	/// flood collapses into the single wake the driver acts on.
+	/// flood collapses into one wake per class.
 	#[test]
 	fn notification_floods_are_coalesced() {
 		let (commands, requests) = channel();
-		let failures = Arc::new(Mutex::new(Failures::default()));
+		let failures = Arc::new(Failures::default());
 		let reporter = FailureReporter {
 			failures: failures.clone(),
 			commands: commands.clone(),
@@ -994,22 +1102,47 @@ mod tests {
 				cpal::ErrorKind::Xrun,
 				cpal::ErrorKind::BackendError,
 			] {
-				reporter.report(cpal::Error::new(kind));
+				reporter.report(&cpal::Error::new(kind));
 			}
 		}
 
-		assert!(requests.mailbox.pending.lock().unwrap().switches.is_empty());
+		assert!(requests.mailbox.switches.lock().unwrap().waiting.is_empty());
 		assert!(matches!(poll(&requests), Some(Work::Failed)));
 		assert!(matches!(poll(&requests), Some(Work::Sync)));
 		assert!(poll(&requests).is_none(), "a flood outlived its coalesced wakes");
 
-		let failures = std::mem::take(&mut *failures.lock().unwrap());
+		let failures = failures.take();
 		assert!(failures.unavailable);
 		assert!(failures.invalidated);
 		assert!(failures.changed);
 		assert!(failures.realtime_denied);
 		assert_eq!(failures.xruns, UNDERRUN_LIMIT + 1);
 		assert_eq!(failures.unclassified, ERROR_LIMIT);
+		assert_eq!(failures.last, Some(cpal::ErrorKind::BackendError));
+	}
+
+	/// cpal raises the error callback from the audio thread on most backends, so
+	/// a report must never wait on a lock another thread is holding. Reporting
+	/// while the switch queue is locked would deadlock the audio thread if the
+	/// failure path touched it.
+	#[test]
+	fn reporting_a_failure_never_waits_on_the_mailbox() {
+		let (commands, requests) = channel();
+		let failures = Arc::new(Failures::default());
+		let reporter = FailureReporter {
+			failures: failures.clone(),
+			commands: commands.clone(),
+		};
+
+		// Held for the whole report. If the failure path took this lock, the
+		// audio thread would be stuck here until another thread let go.
+		let held = requests.mailbox.switches.lock().unwrap();
+		reporter.report(&cpal::Error::new(cpal::ErrorKind::DeviceNotAvailable));
+		commands.sync();
+		drop(held);
+
+		assert!(failures.take().unavailable, "the failure never landed");
+		assert!(requests.mailbox.signals.sync.load(Ordering::Acquire));
 	}
 
 	/// A switch either takes one of the fixed slots or reports overload before
@@ -1058,10 +1191,7 @@ mod tests {
 		let responses: Vec<_> = (0..DRIVER_QUEUE).map(|_| queue_switch(&commands)).collect();
 
 		drop(handle);
-		assert!(
-			matches!(poll(&requests), Some(Work::Shutdown)),
-			"saturation lost shutdown"
-		);
+		assert!(matches!(poll(&requests), Some(Work::Shutdown)), "saturation lost shutdown");
 
 		// The driver returns rather than serving the backlog, so every waiting
 		// caller learns the thread stopped instead of hanging on its reply.
@@ -1073,17 +1203,19 @@ mod tests {
 		assert!(matches!(error, Error::Playback(message) if message.contains("stopped")));
 	}
 
-	/// A driver blocked with nothing queued has to be woken by the next
+	/// A driver parked with nothing pending has to be woken by the next
 	/// notification, whatever else raced with it. Losing this wake stranded a
 	/// sink registration, or the shutdown that closes the device.
 	#[test]
-	fn a_blocked_driver_is_woken() {
+	fn a_parked_driver_is_woken() {
 		let (commands, requests) = channel();
 		let (sent, arrived) = std::sync::mpsc::channel();
 
 		let waker = commands.clone();
 		let driver = std::thread::spawn(move || {
-			// Deadlines rather than a plain block, so a lost wake fails the test
+			requests.attach();
+
+			// Deadlines rather than a plain park, so a lost wake fails the test
 			// instead of hanging it.
 			let woken = matches!(requests.wait(Some(Instant::now() + PATIENCE)), Work::Sync);
 			sent.send(()).unwrap();
@@ -1100,7 +1232,7 @@ mod tests {
 			(woken, stopped)
 		});
 
-		// Let the driver reach `wait` with an empty mailbox, then race a flood
+		// Let the driver reach `park` with an empty mailbox, then race a flood
 		// of notifications against it.
 		std::thread::sleep(Duration::from_millis(10));
 		std::thread::scope(|s| {
@@ -1117,14 +1249,32 @@ mod tests {
 		assert!(stopped, "a shutdown never woke the driver");
 	}
 
+	/// A signal raised before the driver registers itself wakes nobody, so the
+	/// first check has to find it rather than parking through it.
+	#[test]
+	fn a_signal_racing_startup_is_not_slept_through() {
+		let (commands, requests) = channel();
+		commands.sync();
+
+		let driver = std::thread::spawn(move || {
+			requests.attach();
+			requests.wait(Some(Instant::now() + PATIENCE))
+		});
+
+		assert!(
+			matches!(driver.join().unwrap(), Work::Sync),
+			"a signal raised before attach was slept through"
+		);
+	}
+
 	/// A stream that has already been replaced can still report an error. Acting
 	/// on it tears down the healthy stream that replaced it.
 	#[test]
 	fn ignores_errors_from_a_replaced_stream() {
 		let w = wired(8);
 		let (commands, _requests) = channel();
-		let stale = Arc::new(Mutex::new(Failures::default()));
-		let current = Arc::new(Mutex::new(Failures::default()));
+		let stale = Arc::new(Failures::default());
+		let current = Arc::new(Failures::default());
 		let stale_reporter = FailureReporter {
 			failures: stale,
 			commands: commands.clone(),
@@ -1145,10 +1295,10 @@ mod tests {
 		};
 
 		let lost = cpal::Error::new(cpal::ErrorKind::DeviceNotAvailable);
-		stale_reporter.report(lost.clone());
+		stale_reporter.report(&lost);
 		assert!(!driver.should_restart(), "acted on a retired stream's error");
 
-		current.lock().unwrap().record(lost);
+		current.record(lost.kind());
 		assert!(driver.should_restart(), "ignored the live stream's error");
 	}
 }

--- a/rs/moq-audio/src/playback/driver.rs
+++ b/rs/moq-audio/src/playback/driver.rs
@@ -6,9 +6,8 @@
 //! the hot path; they register themselves in [`Shared`] and hand their consumer
 //! straight to the mixer.
 
-#[cfg(feature = "aec")]
-use std::sync::mpsc::TrySendError;
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, SyncSender, sync_channel};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -37,6 +36,13 @@ const RETRY_MAX: Duration = Duration::from_secs(4);
 const UNDERRUN_LIMIT: u32 = 20;
 const ERROR_LIMIT: u32 = 3;
 const ERROR_WINDOW: Duration = Duration::from_secs(5);
+
+/// Driver commands waiting while the thread is inside a host operation.
+///
+/// Only device switches consume one slot apiece. Notifications share one wake
+/// and keep their durable state outside the queue, so this is a hard bound on
+/// both storage and the number of callers awaiting a switch.
+const DRIVER_QUEUE: usize = 16;
 
 /// Sink updates the mixer's command queue holds. Preallocated, since draining it
 /// happens on the audio thread. Deep enough that only a burst of registrations
@@ -87,13 +93,13 @@ struct State {
 	/// command queue was full. Retried by [`Shared::sync`].
 	#[cfg(feature = "aec")]
 	detaching_reference: bool,
-	/// Posts [`Command::Sync`] so a retry actually happens. A plain sender, not
+	/// Posts a driver sync so a retry actually happens. A plain sender, not
 	/// a [`Handle`](super::Handle): a canceller must not keep the output device
-	/// open, and shutdown is an explicit message rather than a disconnect.
+	/// open, and shutdown is explicit state rather than a disconnect.
 	///
 	/// `None` in tests that drive [`Shared`] without a driver behind it.
 	#[cfg(feature = "aec")]
-	waker: Option<Sender<Command>>,
+	waker: Option<Commands>,
 }
 
 impl Shared {
@@ -146,10 +152,10 @@ impl Shared {
 		}
 	}
 
-	/// Remember the channel that posts [`Command::Sync`], so a send the mixer's
+	/// Remember the channel that posts a driver sync, so a send the mixer's
 	/// command queue was too full to take gets retried.
 	#[cfg(feature = "aec")]
-	pub(super) fn wake_with(&self, waker: Sender<Command>) {
+	pub(super) fn wake_with(&self, waker: Commands) {
 		self.state.lock().unwrap().waker = Some(waker);
 	}
 
@@ -161,7 +167,7 @@ impl Shared {
 	#[cfg(feature = "aec")]
 	fn wake(state: &State) {
 		if let Some(waker) = &state.waker {
-			let _ = waker.send(Command::Sync);
+			waker.sync();
 		}
 	}
 
@@ -313,29 +319,201 @@ fn attach_reference(reference: &mut crate::aec::Reference, mixer: &SyncSender<mi
 	}
 }
 
-/// What the driver thread waits on.
-pub(super) enum Command {
+/// The bounded payload queue the driver thread waits on.
+enum Command {
 	/// Move to another output device, or back to the system default with `None`.
 	Switch {
 		device: Option<String>,
 		reply: tokio::sync::oneshot::Sender<Result<(), Error>>,
 	},
-	/// The audio thread reported a problem. Sent from cpal's error callback,
-	/// which is why the driver wakes on it instead of polling.
-	///
-	/// `generation` is the stream that raised it. A stream that has already been
-	/// replaced can still have an error sitting in this queue, and acting on it
-	/// would tear down the healthy stream that replaced it.
-	Failed { generation: u64, error: cpal::Error },
-	/// A sink was added or dropped. Drops whatever the mixer retired and retries
-	/// anything its command queue was too full to take.
-	Sync,
-	/// The last [`Engine`](super::Engine) and [`Sink`] are gone.
-	///
-	/// An explicit message rather than watching the channel disconnect: every
-	/// live stream's error callback holds a sender of its own, so the channel
-	/// only closes once the driver has already dropped the device.
-	Shutdown,
+	/// Coalesced notification state is ready to inspect.
+	Wake,
+}
+
+#[derive(Default)]
+struct Signals {
+	sync: AtomicBool,
+	shutdown: AtomicBool,
+	wake_queued: AtomicBool,
+}
+
+/// The sending half of the bounded driver mailbox.
+#[derive(Clone)]
+pub(super) struct Commands {
+	commands: SyncSender<Command>,
+	signals: Arc<Signals>,
+}
+
+impl Commands {
+	/// Queue a device switch, returning before the caller awaits if the driver is
+	/// already carrying its fixed maximum of requests.
+	pub(super) fn switch(
+		&self,
+		device: Option<String>,
+		reply: tokio::sync::oneshot::Sender<Result<(), Error>>,
+	) -> Result<(), Error> {
+		self.commands
+			.try_send(Command::Switch { device, reply })
+			.map_err(|err| match err {
+				TrySendError::Full(_) => Error::Playback("the playback thread is busy".into()),
+				TrySendError::Disconnected(_) => Error::Playback("the playback thread stopped".into()),
+			})
+	}
+
+	/// Coalesce a mixer retry while ensuring some queued command wakes the
+	/// driver to observe it.
+	pub(super) fn sync(&self) {
+		self.signals.sync.store(true, Ordering::Release);
+		self.notify();
+	}
+
+	/// Reliably stop the driver even when every payload slot is occupied.
+	pub(super) fn shutdown(&self) {
+		self.signals.shutdown.store(true, Ordering::Release);
+		self.notify();
+	}
+
+	/// Wake the driver without waiting for queue capacity. If the queue is full,
+	/// one of its existing commands is already guaranteed to wake the receiver,
+	/// which checks all notification state after every command.
+	fn notify(&self) {
+		if self.signals.wake_queued.swap(true, Ordering::AcqRel) {
+			return;
+		}
+
+		if self.commands.try_send(Command::Wake).is_err() {
+			// No wake was queued. The command that occupied the last slot will
+			// observe the pending state, and a later notification may try again.
+			self.signals.wake_queued.store(false, Ordering::Release);
+		}
+	}
+}
+
+/// The receiving half of the bounded driver mailbox.
+pub(super) struct Requests {
+	commands: Receiver<Command>,
+	signals: Arc<Signals>,
+}
+
+impl Requests {
+	fn recv(&self) -> Result<Command, Timeout> {
+		self.received(self.commands.recv().map_err(|_| Timeout::Disconnected))
+	}
+
+	fn recv_until(&self, at: Instant) -> Result<Command, Timeout> {
+		let command = match self.commands.recv_timeout(at.saturating_duration_since(Instant::now())) {
+			Ok(command) => Ok(command),
+			Err(RecvTimeoutError::Timeout) => Err(Timeout::Elapsed),
+			Err(RecvTimeoutError::Disconnected) => Err(Timeout::Disconnected),
+		};
+		self.received(command)
+	}
+
+	fn received(&self, command: Result<Command, Timeout>) -> Result<Command, Timeout> {
+		if matches!(command, Ok(Command::Wake)) {
+			self.signals.wake_queued.store(false, Ordering::Release);
+		}
+		command
+	}
+
+	fn take_sync(&self) -> bool {
+		self.signals.sync.swap(false, Ordering::AcqRel)
+	}
+
+	fn shutdown(&self) -> bool {
+		self.signals.shutdown.load(Ordering::Acquire)
+	}
+
+	#[cfg(test)]
+	fn try_recv(&self) -> Result<Command, std::sync::mpsc::TryRecvError> {
+		let command = self.commands.try_recv();
+		if matches!(command, Ok(Command::Wake)) {
+			self.signals.wake_queued.store(false, Ordering::Release);
+		}
+		command
+	}
+}
+
+/// Build the driver's fixed-capacity mailbox.
+pub(super) fn channel() -> (Commands, Requests) {
+	let (commands, requests) = sync_channel(DRIVER_QUEUE);
+	let signals = Arc::new(Signals::default());
+	(
+		Commands {
+			commands,
+			signals: signals.clone(),
+		},
+		Requests {
+			commands: requests,
+			signals,
+		},
+	)
+}
+
+/// Fixed-size failure state owned by one stream generation.
+///
+/// The callback only updates atomics, then posts a non-blocking coalesced wake.
+/// Replacing a stream replaces this entire state, so a retired callback cannot
+/// occupy or overwrite any part of the live generation's signal.
+#[derive(Default)]
+struct Failures {
+	unavailable: AtomicBool,
+	invalidated: AtomicBool,
+	changed: AtomicBool,
+	realtime_denied: AtomicBool,
+	xruns: AtomicU32,
+	unclassified: AtomicU32,
+}
+
+impl Failures {
+	fn record(&self, kind: cpal::ErrorKind) {
+		match kind {
+			cpal::ErrorKind::DeviceNotAvailable => self.unavailable.store(true, Ordering::Release),
+			cpal::ErrorKind::StreamInvalidated => self.invalidated.store(true, Ordering::Release),
+			cpal::ErrorKind::DeviceChanged => self.changed.store(true, Ordering::Release),
+			cpal::ErrorKind::RealtimeDenied => self.realtime_denied.store(true, Ordering::Release),
+			cpal::ErrorKind::Xrun => increment(&self.xruns, UNDERRUN_LIMIT + 1),
+			_ => increment(&self.unclassified, ERROR_LIMIT),
+		}
+	}
+
+	fn take(&self) -> FailureBatch {
+		FailureBatch {
+			unavailable: self.unavailable.swap(false, Ordering::AcqRel),
+			invalidated: self.invalidated.swap(false, Ordering::AcqRel),
+			changed: self.changed.swap(false, Ordering::AcqRel),
+			realtime_denied: self.realtime_denied.swap(false, Ordering::AcqRel),
+			xruns: self.xruns.swap(0, Ordering::AcqRel),
+			unclassified: self.unclassified.swap(0, Ordering::AcqRel),
+		}
+	}
+}
+
+fn increment(counter: &AtomicU32, limit: u32) {
+	let _ = counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+		Some(current.saturating_add(1).min(limit))
+	});
+}
+
+struct FailureBatch {
+	unavailable: bool,
+	invalidated: bool,
+	changed: bool,
+	realtime_denied: bool,
+	xruns: u32,
+	unclassified: u32,
+}
+
+struct FailureReporter {
+	failures: Arc<Failures>,
+	commands: Commands,
+}
+
+impl FailureReporter {
+	fn report(&self, error: cpal::Error) {
+		self.failures.record(error.kind());
+		self.commands.notify();
+	}
 }
 
 /// Run the output device until every [`Engine`](super::Engine) and
@@ -345,19 +523,19 @@ pub(super) enum Command {
 /// [`Engine::open`](super::Engine::open) can fail fast on a machine with no
 /// output rather than handing back a handle that plays into nothing.
 pub(super) fn run(
-	commands: Receiver<Command>,
-	failures: Sender<Command>,
+	requests: Requests,
+	commands: Commands,
 	shared: Arc<Shared>,
 	device: Option<String>,
 	opened: tokio::sync::oneshot::Sender<Result<(), Error>>,
 ) {
 	let mut driver = Driver {
 		shared,
-		failures,
+		commands,
 		device,
 		stream: None,
 		retired: None,
-		generation: 0,
+		failures: None,
 		retry: RETRY_MIN,
 		retry_at: None,
 		underruns: 0,
@@ -376,28 +554,33 @@ pub(super) fn run(
 	loop {
 		// A failed start leaves a deadline to wake on; otherwise just block.
 		let command = match driver.retry_at {
-			Some(at) => driver.commands_until(&commands, at),
-			None => commands.recv().map_err(|_| Timeout::Disconnected),
+			Some(at) => requests.recv_until(at),
+			None => requests.recv(),
 		};
+
+		if requests.shutdown() {
+			break;
+		}
 
 		match command {
 			Ok(Command::Switch { device, reply }) => {
 				driver.device = device;
 				let _ = reply.send(driver.restart());
 			}
-			Ok(Command::Failed { generation, error }) => {
-				if driver.should_restart(generation, &error) {
-					let _ = driver.restart();
-				}
-			}
-			Ok(Command::Sync) => driver.sync(),
-			Ok(Command::Shutdown) => break,
+			Ok(Command::Wake) => {}
 			Err(Timeout::Elapsed) => {
 				if driver.restart().is_ok() {
 					tracing::info!("audio output recovered");
 				}
 			}
 			Err(Timeout::Disconnected) => break,
+		}
+
+		if driver.should_restart() {
+			let _ = driver.restart();
+		}
+		if requests.take_sync() {
+			driver.sync();
 		}
 	}
 }
@@ -409,17 +592,16 @@ enum Timeout {
 
 struct Driver {
 	shared: Arc<Shared>,
-	/// Handed to each stream's error callback so failures arrive as commands.
-	failures: Sender<Command>,
+	/// Posts coalesced wakes for failures from the live stream.
+	commands: Commands,
 	device: Option<String>,
 	/// The live stream. Dropping it stops the audio thread.
 	stream: Option<cpal::Stream>,
 	/// Sinks the mixer has finished with, dropped here so the audio thread never
 	/// has to free one.
 	retired: Option<Receiver<mixer::Retired>>,
-	/// Bumped on every stream, so an error from a retired one can be told apart
-	/// from one the live stream raised.
-	generation: u64,
+	/// Failure counters for the live stream only.
+	failures: Option<Arc<Failures>>,
 	/// Delay before reopening a device that would not start, doubling per failure.
 	retry: Duration,
 	/// When a failed start may be retried, and what the command wait times out
@@ -432,14 +614,6 @@ struct Driver {
 }
 
 impl Driver {
-	fn commands_until(&self, commands: &Receiver<Command>, at: Instant) -> Result<Command, Timeout> {
-		match commands.recv_timeout(at.saturating_duration_since(Instant::now())) {
-			Ok(command) => Ok(command),
-			Err(RecvTimeoutError::Timeout) => Err(Timeout::Elapsed),
-			Err(RecvTimeoutError::Disconnected) => Err(Timeout::Disconnected),
-		}
-	}
-
 	/// Open the device, start mixing into it, and move every sink onto it.
 	fn start(&mut self) -> Result<(), Error> {
 		let device = super::device::open(self.device.as_deref())?;
@@ -468,14 +642,19 @@ impl Driver {
 		let (retired_tx, retired_rx) = sync_channel(COMMAND_QUEUE);
 		let mixer = Mixer::new(rx, retired_tx, rate, channels);
 
-		self.generation += 1;
-		let stream = self.build(&device, config, format, mixer)?;
+		let failures = Arc::new(Failures::default());
+		let reporter = FailureReporter {
+			failures: failures.clone(),
+			commands: self.commands.clone(),
+		};
+		let stream = self.build(&device, config, format, mixer, reporter)?;
 		stream
 			.play()
 			.map_err(|err| Error::Playback(format!("cannot start output stream: {err}")))?;
 
 		self.shared.rebind(rate, tx);
 		self.stream = Some(stream);
+		self.failures = Some(failures);
 		// Replaces the previous receiver, dropping anything the old stream
 		// retired and never got drained.
 		self.retired = Some(retired_rx);
@@ -493,12 +672,13 @@ impl Driver {
 		config: cpal::StreamConfig,
 		format: cpal::SampleFormat,
 		mixer: Mixer,
+		failures: FailureReporter,
 	) -> Result<cpal::Stream, Error> {
 		match format {
-			cpal::SampleFormat::F32 => self.build_as::<f32>(device, config, mixer),
-			cpal::SampleFormat::I16 => self.build_as::<i16>(device, config, mixer),
-			cpal::SampleFormat::U16 => self.build_as::<u16>(device, config, mixer),
-			cpal::SampleFormat::I32 => self.build_as::<i32>(device, config, mixer),
+			cpal::SampleFormat::F32 => self.build_as::<f32>(device, config, mixer, failures),
+			cpal::SampleFormat::I16 => self.build_as::<i16>(device, config, mixer, failures),
+			cpal::SampleFormat::U16 => self.build_as::<u16>(device, config, mixer, failures),
+			cpal::SampleFormat::I32 => self.build_as::<i32>(device, config, mixer, failures),
 			other => Err(Error::Unsupported(format!("output sample format {other:?}"))),
 		}
 	}
@@ -508,13 +688,11 @@ impl Driver {
 		device: &cpal::Device,
 		config: cpal::StreamConfig,
 		mut mixer: Mixer,
+		failures: FailureReporter,
 	) -> Result<cpal::Stream, Error>
 	where
 		T: cpal::SizedSample + cpal::FromSample<f32>,
 	{
-		let failures = self.failures.clone();
-		let generation = self.generation;
-
 		// The mixer works in `f32`, so anything else needs a staging buffer.
 		// Allocated once and a whole number of frames long, so however big a
 		// buffer the device asks for, the callback loops over this rather than
@@ -535,9 +713,7 @@ impl Driver {
 					}
 				},
 				move |error| {
-					// This is cpal's error callback, not the audio callback, so
-					// an allocating send is fine here.
-					let _ = failures.send(Command::Failed { generation, error });
+					failures.report(error);
 				},
 				None,
 			)
@@ -570,6 +746,7 @@ impl Driver {
 	/// Tear the stream down and detach every sink from it.
 	fn stop(&mut self) {
 		self.shared.unbind();
+		self.failures = None;
 		self.stream = None;
 		// Dropping the receiver drops whatever the mixer retired, here rather
 		// than on the audio thread.
@@ -606,59 +783,40 @@ impl Driver {
 		Instant::now() + wait
 	}
 
-	/// Whether a failure reported by stream `generation` should rebuild the
-	/// stream.
-	///
-	/// Errors outlive the stream that raised them: cpal's error callback posts
-	/// into the same queue the driver reads, so a switch or a restart can leave
-	/// one behind. Acting on it would tear down the healthy stream that replaced
-	/// it, which is a dropout caused entirely by our own bookkeeping.
-	fn should_restart(&mut self, generation: u64, error: &cpal::Error) -> bool {
-		if generation != self.generation {
-			tracing::debug!(%error, generation, "ignoring an error from a replaced audio output");
-			return false;
-		}
-
-		self.fatal(error)
-	}
-
-	/// Whether this error means the stream has to be rebuilt.
-	fn fatal(&mut self, err: &cpal::Error) -> bool {
+	/// Whether the live stream's accumulated failures require a rebuild.
+	fn should_restart(&mut self) -> bool {
+		let Some(failures) = &self.failures else { return false };
+		let failures = failures.take();
 		self.roll_window();
 
-		match err.kind() {
-			cpal::ErrorKind::DeviceNotAvailable | cpal::ErrorKind::StreamInvalidated => {
-				tracing::warn!(%err, "audio output lost");
-				true
-			}
-			// cpal documents both as survivable: the stream keeps running and
-			// needs no rebuild.
-			cpal::ErrorKind::DeviceChanged | cpal::ErrorKind::RealtimeDenied => {
-				tracing::debug!(%err, "audio output changed underneath us");
-				false
-			}
-			// One underrun is a glitch, not a broken device. Only a sustained
-			// run of them is worth interrupting playback to fix.
-			cpal::ErrorKind::Xrun => {
-				self.underruns += 1;
-				let restart = self.underruns > UNDERRUN_LIMIT;
-				if restart {
-					self.underruns = 0;
-					tracing::warn!("restarting audio output after repeated underruns");
-				}
-				restart
-			}
-			_ => {
-				tracing::warn!(%err, "audio output error");
-				self.unclassified += 1;
-				let restart = self.unclassified >= ERROR_LIMIT;
-				if restart {
-					self.unclassified = 0;
-					tracing::warn!("restarting audio output after repeated unclassified errors");
-				}
-				restart
-			}
+		if failures.changed || failures.realtime_denied {
+			tracing::debug!("audio output changed underneath us");
 		}
+		if failures.unavailable || failures.invalidated {
+			tracing::warn!("audio output lost");
+			return true;
+		}
+
+		// One underrun is a glitch, not a broken device. Only a sustained run
+		// of them is worth interrupting playback to fix.
+		self.underruns = self.underruns.saturating_add(failures.xruns);
+		if self.underruns > UNDERRUN_LIMIT {
+			self.underruns = 0;
+			tracing::warn!("restarting audio output after repeated underruns");
+			return true;
+		}
+
+		if failures.unclassified > 0 {
+			tracing::warn!(count = failures.unclassified, "audio output error");
+		}
+		self.unclassified = self.unclassified.saturating_add(failures.unclassified);
+		if self.unclassified >= ERROR_LIMIT {
+			self.unclassified = 0;
+			tracing::warn!("restarting audio output after repeated unclassified errors");
+			return true;
+		}
+
+		false
 	}
 
 	/// Start a fresh counting window once the old one has run out.
@@ -673,8 +831,6 @@ impl Driver {
 
 #[cfg(test)]
 mod tests {
-	use std::sync::mpsc::channel;
-
 	use super::*;
 	use crate::playback::sink::{self, Input};
 
@@ -685,7 +841,7 @@ mod tests {
 		shared: Arc<Shared>,
 		handle: Arc<super::super::Handle>,
 		mixer: Receiver<mixer::Command>,
-		driver: Receiver<Command>,
+		driver: Requests,
 	}
 
 	fn wired(depth: usize) -> Wired {
@@ -708,10 +864,16 @@ mod tests {
 		shared.add(|id, rate| sink::new(id, rate, Input::default(), shared.clone(), handle.clone()))
 	}
 
-	fn syncs(driver: &Receiver<Command>) -> usize {
+	fn syncs(driver: &Requests) -> usize {
 		std::iter::from_fn(|| driver.try_recv().ok())
-			.filter(|c| matches!(c, Command::Sync))
+			.filter(|c| matches!(c, Command::Wake))
 			.count()
+	}
+
+	fn queue_switch(commands: &Commands) -> tokio::sync::oneshot::Receiver<Result<(), Error>> {
+		let (reply, response) = tokio::sync::oneshot::channel();
+		commands.switch(None, reply).unwrap();
+		response
 	}
 
 	/// A registration the mixer's queue was too full to take must not be
@@ -791,20 +953,115 @@ mod tests {
 		add(&w.shared, &w.handle).expect("a slot freed by the dropped sink");
 	}
 
-	/// A stream that has already been replaced can still have an error queued.
-	/// Acting on it tears down the healthy stream that replaced it.
+	/// Every notification class has fixed storage even when the receiver stops
+	/// draining entirely.
 	#[test]
-	fn ignores_errors_from_a_replaced_stream() {
+	fn notification_floods_are_coalesced() {
+		let (commands, requests) = channel();
+		let failures = Arc::new(Failures::default());
+		let reporter = FailureReporter {
+			failures: failures.clone(),
+			commands: commands.clone(),
+		};
+
+		for _ in 0..1_000 {
+			commands.sync();
+			for kind in [
+				cpal::ErrorKind::DeviceNotAvailable,
+				cpal::ErrorKind::StreamInvalidated,
+				cpal::ErrorKind::DeviceChanged,
+				cpal::ErrorKind::RealtimeDenied,
+				cpal::ErrorKind::Xrun,
+				cpal::ErrorKind::BackendError,
+			] {
+				reporter.report(cpal::Error::new(kind));
+			}
+		}
+
+		assert!(matches!(requests.try_recv(), Ok(Command::Wake)));
+		assert!(requests.try_recv().is_err(), "more than one wake was queued");
+		assert!(requests.take_sync());
+
+		let failures = failures.take();
+		assert!(failures.unavailable);
+		assert!(failures.invalidated);
+		assert!(failures.changed);
+		assert!(failures.realtime_denied);
+		assert_eq!(failures.xruns, UNDERRUN_LIMIT + 1);
+		assert_eq!(failures.unclassified, ERROR_LIMIT);
+	}
+
+	/// A switch either occupies one of the fixed slots or reports overload before
+	/// its caller starts awaiting a response.
+	#[test]
+	fn switches_complete_or_reject_overload() {
+		let (commands, requests) = channel();
+		let responses: Vec<_> = (0..DRIVER_QUEUE).map(|_| queue_switch(&commands)).collect();
+
+		let (reply, _response) = tokio::sync::oneshot::channel();
+		let error = commands.switch(None, reply).unwrap_err();
+		assert!(matches!(error, Error::Playback(message) if message.contains("busy")));
+
+		for response in responses {
+			let Command::Switch { reply, .. } = requests.try_recv().unwrap() else {
+				panic!("a switch slot held a wake");
+			};
+			reply.send(Ok(())).unwrap();
+			assert!(matches!(response.blocking_recv(), Ok(Ok(()))));
+		}
+	}
+
+	/// A sync remains durable when the payload queue is saturated and its wake
+	/// cannot claim a slot.
+	#[test]
+	fn sync_survives_a_full_driver_queue() {
+		let (commands, requests) = channel();
+		let _responses: Vec<_> = (0..DRIVER_QUEUE).map(|_| queue_switch(&commands)).collect();
+
+		commands.sync();
+		assert!(requests.take_sync(), "the dropped wake lost the mixer retry");
+	}
+
+	/// The last handle sets shutdown outside the saturated payload queue, so the
+	/// driver exits as soon as it receives any already-queued command.
+	#[test]
+	fn final_handle_shuts_down_a_saturated_driver() {
+		let (commands, requests) = channel();
+		let handle = Arc::new(super::super::Handle {
+			commands: commands.clone(),
+		});
+		let _responses: Vec<_> = (0..DRIVER_QUEUE).map(|_| queue_switch(&commands)).collect();
+
+		drop(handle);
+		assert!(requests.shutdown(), "the full queue lost shutdown");
+		assert!(matches!(requests.try_recv(), Ok(Command::Switch { .. })));
+	}
+
+	/// A stream that has already been replaced can still have an error queued.
+	/// Its fixed state must not displace the live generation's failure, even when
+	/// both it and a sync share the one pending wake.
+	#[test]
+	fn live_failure_survives_stale_and_sync_notifications() {
 		let w = wired(8);
-		let (failures, _requests) = channel();
+		let (commands, requests) = channel();
+		let stale = Arc::new(Failures::default());
+		let current = Arc::new(Failures::default());
+		let stale_reporter = FailureReporter {
+			failures: stale,
+			commands: commands.clone(),
+		};
+		let current_reporter = FailureReporter {
+			failures: current.clone(),
+			commands: commands.clone(),
+		};
 
 		let mut driver = Driver {
 			shared: w.shared,
-			failures,
+			commands: commands.clone(),
 			device: None,
 			stream: None,
 			retired: None,
-			generation: 7,
+			failures: Some(current.clone()),
 			retry: RETRY_MIN,
 			retry_at: None,
 			underruns: 0,
@@ -812,8 +1069,13 @@ mod tests {
 			window: Instant::now(),
 		};
 
-		let lost = cpal::Error::new(cpal::ErrorKind::DeviceNotAvailable);
-		assert!(!driver.should_restart(6, &lost), "acted on a retired stream's error");
-		assert!(driver.should_restart(7, &lost), "ignored the live stream's error");
+		stale_reporter.report(cpal::Error::new(cpal::ErrorKind::DeviceNotAvailable));
+		commands.sync();
+		current_reporter.report(cpal::Error::new(cpal::ErrorKind::DeviceNotAvailable));
+
+		assert!(matches!(requests.try_recv(), Ok(Command::Wake)));
+		assert!(requests.try_recv().is_err(), "notifications were not coalesced");
+		assert!(requests.take_sync());
+		assert!(driver.should_restart(), "ignored the live stream's error");
 	}
 }

--- a/rs/moq-audio/src/playback/driver.rs
+++ b/rs/moq-audio/src/playback/driver.rs
@@ -7,10 +7,10 @@
 //! straight to the mixer.
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 #[cfg(feature = "aec")]
 use std::sync::mpsc::TrySendError;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::Thread;
 use std::time::{Duration, Instant};
@@ -485,43 +485,76 @@ impl Requests {
 		let _ = self.mailbox.driver.set(std::thread::current());
 	}
 
-	/// Block until there is something to do, or until `deadline` passes.
+	/// Whatever is pending right now, or `None` if the driver would have to wait.
 	///
-	/// Shutdown wins over everything: once the last handle is gone there is no
-	/// point opening a device. Nothing is stranded by that, since a shutdown
-	/// answers the switches it overtakes and refuses any that follow.
-	fn wait(&self, deadline: Option<Instant>) -> Work {
+	/// The order here is the driver's whole priority policy, in one place so a
+	/// probe and a blocking wait cannot disagree about it.
+	fn poll(&self, deadline: Option<Instant>) -> Option<Work> {
 		let signals = &self.mailbox.signals;
 
+		// Shutdown wins over everything: once the last handle is gone there is
+		// no point opening a device. Nothing is stranded by that, since a
+		// shutdown answers the switches it overtakes and refuses any that follow.
+		if signals.shutdown.load(Ordering::Acquire) {
+			return Some(Work::Shutdown);
+		}
+
+		// Ahead of the retry: a switch reopens the device itself, which is what
+		// the retry was waiting to do anyway. Switches are capped and
+		// caller-driven, so they cannot crowd it out.
+		if let Some(Switch { device, reply }) = self.mailbox.switches.lock().unwrap().waiting.pop_front() {
+			return Some(Work::Switch { device, reply });
+		}
+
+		// A due retry outranks the signals below, which re-arm themselves.
+		// Serving those first would let steady sink churn keep a dead device
+		// from ever being reopened.
+		if deadline.is_some_and(|at| Instant::now() >= at) {
+			return Some(Work::Retry);
+		}
+
+		if signals.failed.swap(false, Ordering::AcqRel) {
+			return Some(Work::Failed);
+		}
+		if signals.sync.swap(false, Ordering::AcqRel) {
+			return Some(Work::Sync);
+		}
+
+		None
+	}
+
+	/// Block until there is something to do, or until `deadline` passes.
+	fn wait(&self, deadline: Option<Instant>) -> Work {
 		loop {
-			if signals.shutdown.load(Ordering::Acquire) {
-				return Work::Shutdown;
-			} else if let Some(Switch { device, reply }) = self.mailbox.switches.lock().unwrap().waiting.pop_front() {
-				return Work::Switch { device, reply };
-			} else if signals.failed.swap(false, Ordering::AcqRel) {
-				return Work::Failed;
-			} else if signals.sync.swap(false, Ordering::AcqRel) {
-				return Work::Sync;
+			if let Some(work) = self.poll(deadline) {
+				return work;
 			}
 
-			// Nothing pending. A sender that raced the checks above either
+			// Nothing pending. A sender that raced the poll above either
 			// unparked us already, leaving a permit that returns from the park
 			// below at once, or has yet to signal and will unpark us after it
-			// does. Either way the loop re-checks before sleeping again.
-			let Some(at) = deadline else {
-				std::thread::park();
-				continue;
-			};
-
-			// Real work outranks the backoff, so the deadline is only reported
-			// once the checks above have found nothing else to do.
-			let wait = at.saturating_duration_since(Instant::now());
-			if wait.is_zero() {
-				return Work::Retry;
+			// does. Either way the loop polls again before sleeping, so an
+			// early wake costs a lap rather than a spurious retry.
+			match deadline {
+				Some(at) => std::thread::park_timeout(at.saturating_duration_since(Instant::now())),
+				None => std::thread::park(),
 			}
-
-			std::thread::park_timeout(wait);
 		}
+	}
+}
+
+/// Closing the mailbox behind a driver that is gone, so a caller gets the
+/// stopped error instead of awaiting a reply nobody is left to send.
+///
+/// Covers an unexpected exit as much as an orderly one: only [`Commands::shutdown`]
+/// closes the queue on the way out, and a driver that unwound never called it.
+impl Drop for Requests {
+	fn drop(&mut self) {
+		// The driver may have unwound while holding this, and a panic inside a
+		// drop would abort.
+		let mut switches = self.mailbox.switches.lock().unwrap_or_else(|err| err.into_inner());
+		switches.closed = true;
+		switches.waiting.clear();
 	}
 }
 
@@ -588,9 +621,11 @@ impl Failures {
 			cpal::ErrorKind::StreamInvalidated => self.invalidated.store(true, Ordering::Release),
 			cpal::ErrorKind::DeviceChanged => self.changed.store(true, Ordering::Release),
 			cpal::ErrorKind::RealtimeDenied => self.realtime_denied.store(true, Ordering::Release),
-			cpal::ErrorKind::Xrun => increment(&self.xruns, UNDERRUN_LIMIT + 1),
+			cpal::ErrorKind::Xrun => {
+				self.xruns.fetch_add(1, Ordering::AcqRel);
+			}
 			_ => {
-				increment(&self.unclassified, ERROR_LIMIT);
+				self.unclassified.fetch_add(1, Ordering::AcqRel);
 				self.last.store(code(kind), Ordering::Release);
 			}
 		}
@@ -602,17 +637,14 @@ impl Failures {
 			invalidated: self.invalidated.swap(false, Ordering::AcqRel),
 			changed: self.changed.swap(false, Ordering::AcqRel),
 			realtime_denied: self.realtime_denied.swap(false, Ordering::AcqRel),
-			xruns: self.xruns.swap(0, Ordering::AcqRel),
-			unclassified: self.unclassified.swap(0, Ordering::AcqRel),
+			// Clamped here rather than on the way in: `fetch_add` is one
+			// instruction, where a saturating compare-exchange loop could spin
+			// on the audio thread.
+			xruns: self.xruns.swap(0, Ordering::AcqRel).min(UNDERRUN_LIMIT + 1),
+			unclassified: self.unclassified.swap(0, Ordering::AcqRel).min(ERROR_LIMIT),
 			last: named(self.last.swap(0, Ordering::AcqRel)),
 		}
 	}
-}
-
-fn increment(counter: &AtomicU32, limit: u32) {
-	let _ = counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-		Some(current.saturating_add(1).min(limit))
-	});
 }
 
 struct FailureBatch {
@@ -984,14 +1016,6 @@ mod tests {
 	/// test that waits this out.
 	const PATIENCE: Duration = Duration::from_secs(5);
 
-	/// What the driver would find without blocking, or `None` if it would wait.
-	fn poll(driver: &Requests) -> Option<Work> {
-		match driver.wait(Some(Instant::now())) {
-			Work::Retry => None,
-			work => Some(work),
-		}
-	}
-
 	fn queue_switch(commands: &Commands) -> tokio::sync::oneshot::Receiver<Result<(), Error>> {
 		let (reply, response) = tokio::sync::oneshot::channel();
 		commands.switch(None, reply).unwrap();
@@ -1033,13 +1057,13 @@ mod tests {
 
 		let sink = engine.sink(Input::default()).unwrap();
 		assert!(
-			matches!(poll(&w.driver), Some(Work::Sync)),
+			matches!(w.driver.poll(None), Some(Work::Sync)),
 			"adding a sink did not wake the driver"
 		);
 
 		drop(sink);
 		assert!(
-			matches!(poll(&w.driver), Some(Work::Sync)),
+			matches!(w.driver.poll(None), Some(Work::Sync)),
 			"dropping a sink did not wake the driver"
 		);
 	}
@@ -1107,9 +1131,9 @@ mod tests {
 		}
 
 		assert!(requests.mailbox.switches.lock().unwrap().waiting.is_empty());
-		assert!(matches!(poll(&requests), Some(Work::Failed)));
-		assert!(matches!(poll(&requests), Some(Work::Sync)));
-		assert!(poll(&requests).is_none(), "a flood outlived its coalesced wakes");
+		assert!(matches!(requests.poll(None), Some(Work::Failed)));
+		assert!(matches!(requests.poll(None), Some(Work::Sync)));
+		assert!(requests.poll(None).is_none(), "a flood outlived its coalesced wakes");
 
 		let failures = failures.take();
 		assert!(failures.unavailable);
@@ -1157,7 +1181,7 @@ mod tests {
 		assert!(matches!(error, Error::Playback(message) if message.contains("busy")));
 
 		for response in responses {
-			let Some(Work::Switch { reply, .. }) = poll(&requests) else {
+			let Some(Work::Switch { reply, .. }) = requests.poll(None) else {
 				panic!("a switch went missing");
 			};
 			reply.send(Ok(())).unwrap();
@@ -1175,9 +1199,12 @@ mod tests {
 		commands.sync();
 
 		for _ in 0..DRIVER_QUEUE {
-			assert!(matches!(poll(&requests), Some(Work::Switch { .. })));
+			assert!(matches!(requests.poll(None), Some(Work::Switch { .. })));
 		}
-		assert!(matches!(poll(&requests), Some(Work::Sync)), "saturation lost a sync");
+		assert!(
+			matches!(requests.poll(None), Some(Work::Sync)),
+			"saturation lost a sync"
+		);
 	}
 
 	/// The last handle must stop a saturated driver rather than leaking the
@@ -1191,7 +1218,10 @@ mod tests {
 		let responses: Vec<_> = (0..DRIVER_QUEUE).map(|_| queue_switch(&commands)).collect();
 
 		drop(handle);
-		assert!(matches!(poll(&requests), Some(Work::Shutdown)), "saturation lost shutdown");
+		assert!(
+			matches!(requests.poll(None), Some(Work::Shutdown)),
+			"saturation lost shutdown"
+		);
 
 		// The driver returns rather than serving the backlog, so every waiting
 		// caller learns the thread stopped instead of hanging on its reply.
@@ -1265,6 +1295,63 @@ mod tests {
 			matches!(driver.join().unwrap(), Work::Sync),
 			"a signal raised before attach was slept through"
 		);
+	}
+
+	/// A device that failed to open has to get its retry even while sinks churn.
+	/// Sync and failure re-arm themselves, so serving them first would leave
+	/// playback down for as long as the churn lasted.
+	#[test]
+	fn a_due_retry_outranks_reasserted_signals() {
+		let (commands, requests) = channel();
+		let due = Instant::now();
+
+		for _ in 0..8 {
+			commands.sync();
+			assert!(
+				matches!(requests.wait(Some(due)), Work::Retry),
+				"steady sink churn starved the device retry"
+			);
+		}
+	}
+
+	/// An early wake costs a lap, not a retry: the deadline is what decides,
+	/// not the fact that the park returned.
+	#[test]
+	fn an_early_wake_does_not_fake_a_retry() {
+		let (commands, requests) = channel();
+
+		let waker = commands.clone();
+		let driver = std::thread::spawn(move || {
+			requests.attach();
+			// A deadline far enough out that only the unpark below can end the
+			// park, so a Retry here would mean the deadline was misread.
+			requests.wait(Some(Instant::now() + PATIENCE))
+		});
+
+		std::thread::sleep(Duration::from_millis(10));
+		waker.sync();
+
+		assert!(
+			matches!(driver.join().unwrap(), Work::Sync),
+			"an early wake was reported as a retry"
+		);
+	}
+
+	/// A driver that unwinds takes the mailbox down with it. Without that, a
+	/// switch is queued for a receiver that no longer exists and its caller
+	/// awaits a reply forever.
+	#[test]
+	fn losing_the_driver_releases_switch_callers() {
+		let (commands, requests) = channel();
+		let queued = queue_switch(&commands);
+
+		drop(requests);
+
+		assert!(queued.blocking_recv().is_err(), "a queued switch outlived its driver");
+
+		let (reply, _response) = tokio::sync::oneshot::channel();
+		let error = commands.switch(None, reply).unwrap_err();
+		assert!(matches!(error, Error::Playback(message) if message.contains("stopped")));
 	}
 
 	/// A stream that has already been replaced can still report an error. Acting

--- a/rs/moq-audio/src/playback/driver.rs
+++ b/rs/moq-audio/src/playback/driver.rs
@@ -934,10 +934,20 @@ impl Driver {
 		let failures = failures.take();
 		self.roll_window();
 
+		// Count everything before deciding anything. One batch can hold errors
+		// that arrived before a fatal one, and those still belong to the
+		// escalation window: dropping them lets a stream that keeps failing
+		// after the rebuild sit dead longer than it otherwise would.
+		self.underruns = self.underruns.saturating_add(failures.xruns);
+		self.unclassified = self.unclassified.saturating_add(failures.unclassified);
+
 		// cpal documents both as survivable: the stream keeps running and needs
 		// no rebuild.
 		if failures.changed || failures.realtime_denied {
 			tracing::debug!("audio output changed underneath us");
+		}
+		if let Some(kind) = failures.last {
+			tracing::warn!(%kind, count = failures.unclassified, "audio output error");
 		}
 
 		if failures.unavailable || failures.invalidated {
@@ -947,17 +957,12 @@ impl Driver {
 
 		// One underrun is a glitch, not a broken device. Only a sustained run
 		// of them is worth interrupting playback to fix.
-		self.underruns = self.underruns.saturating_add(failures.xruns);
 		if self.underruns > UNDERRUN_LIMIT {
 			self.underruns = 0;
 			tracing::warn!("restarting audio output after repeated underruns");
 			return true;
 		}
 
-		if let Some(kind) = failures.last {
-			tracing::warn!(%kind, count = failures.unclassified, "audio output error");
-		}
-		self.unclassified = self.unclassified.saturating_add(failures.unclassified);
 		if self.unclassified >= ERROR_LIMIT {
 			self.unclassified = 0;
 			tracing::warn!("restarting audio output after repeated unclassified errors");
@@ -1352,6 +1357,45 @@ mod tests {
 		let (reply, _response) = tokio::sync::oneshot::channel();
 		let error = commands.switch(None, reply).unwrap_err();
 		assert!(matches!(error, Error::Playback(message) if message.contains("stopped")));
+	}
+
+	/// Errors that arrive before a fatal one in the same batch still count.
+	/// Coalescing must not reset the escalation window that a stream failing
+	/// again after the rebuild depends on.
+	#[test]
+	fn a_fatal_batch_keeps_the_counts_that_preceded_it() {
+		let (commands, _requests) = channel();
+		let failures = Arc::new(Failures::default());
+
+		let mut driver = Driver {
+			shared: Arc::new(Shared::default()),
+			commands,
+			device: None,
+			stream: None,
+			retired: None,
+			failures: Some(failures.clone()),
+			retry: RETRY_MIN,
+			retry_at: None,
+			underruns: 0,
+			unclassified: 0,
+			window: Instant::now(),
+		};
+
+		// Two survivable errors, then the fatal one, all in one batch.
+		failures.record(cpal::ErrorKind::BackendError);
+		failures.record(cpal::ErrorKind::BackendError);
+		failures.record(cpal::ErrorKind::DeviceNotAvailable);
+		assert!(driver.should_restart(), "a lost device did not restart the stream");
+
+		// The replacement fails once more. That is the third unclassified error
+		// in the window, so it has to escalate rather than start over.
+		let replacement = Arc::new(Failures::default());
+		driver.failures = Some(replacement.clone());
+		replacement.record(cpal::ErrorKind::BackendError);
+		assert!(
+			driver.should_restart(),
+			"the fatal restart threw away the errors before it"
+		);
 	}
 
 	/// A stream that has already been replaced can still report an error. Acting


### PR DESCRIPTION
## Summary

The playback driver's command channel was `std::sync::mpsc::channel()`, which is unbounded. Every stream generation's cpal error callback holds a sender, so a device failing while the driver is blocked in a host operation allocates a queue node per error with no memory bound.

Replace it with a mailbox split by who is allowed to write each half:

- **Device switches** keep a `Mutex<Switches>` capped at 16 waiting callers, with a busy error past that. No callback ever raises a switch, so a lock is safe here.
- **Failures, syncs and shutdown** are coalesced flags: an `AtomicBool` plus `Thread::unpark`. They need no queue slot, so saturation cannot drop or delay them, and a storm collapses into one wake.

Failure state is a per-stream `Arc<Failures>` of atomics, replaced with the stream. A retired callback writes somewhere the driver never reads again, which is sturdier than the generation counter that filtered stale errors after the fact.

Closes #3165.

## Why the callback path is lock-free and allocation-free

cpal's error callback is not a normal thread. On macOS it is raised from inside `set_render_callback` in `build_output_stream_raw`, so for an output stream the error callback *is* the render callback; JACK, PipeWire, WASAPI and AAudio raise it from their process threads too. cpal states the contract in `src/host/error_emit.rs`:

> Pick the helper based on what you need:
> - Must not block (RT process callback): `try_emit_error`

So `FailureReporter::report` touches only atomics and `unpark`. It takes no lock, so a descheduled sender cannot priority-invert the audio thread during the very error storm this queue exists to survive. Counters use `fetch_add` rather than a `fetch_update` compare-exchange loop, because an unbounded retry there is a missed deadline; the driver clamps on the consuming side instead. The latest unclassified error is kept as an `AtomicU8` code into a const table rather than the `cpal::Error`, since the error owns a message and holding one would mean freeing the previous one on the audio thread.

A comment in the code this replaces claimed the opposite ("this is cpal's error callback, not the audio callback, so an allocating send is fine here"). It was wrong, and it is gone.

One allocator entry on that thread remains and is not fixable from this repo: cpal's own `From<coreaudio::Error>` runs `format!` on the render path, and its `FnMut(Error)` signature makes the callback the owner that must drop the result. Filed as #3247. This is not a regression, since the unbounded `send` it replaces allocated a queue node on the same thread.

## Why the wake cannot be lost

`unpark` leaves a permit behind. A signal raised between the driver's last check and its `park` makes that `park` return immediately rather than sleeping through it, so there is no window to lose one. The driver registers itself before it can park, so a signal that beats registration is still found by the first check.

`Requests::poll` holds the entire priority order in one place (shutdown > switch > due retry > failed > sync) and `wait` loops on it, so a probe and a blocking wait cannot disagree. A due retry outranks the coalesced signals because those re-arm themselves: ranking them first let steady sink churn keep a device that failed to open from ever being retried. Switches still come first, since a switch reopens the device itself and cannot re-arm on its own.

Dropping `Requests` closes and drains the switch queue, so a driver that unwinds does not leave callers awaiting a reply nobody is left to send. That restores what the channel's receiver-disconnect used to report.

## Public API changes

None. `Engine::switch` keeps its signature and may now return a playback busy error when 16 switches are already waiting, or a stopped error once the driver is shutting down.

## Cross-package sync

Not applicable. Internal to the native playback control path: no wire format, FFI surface, or command-line change.

## Test plan

`cargo fmt --check`, `cargo clippy --locked --all-targets --all-features -p moq-audio -- -D warnings`, and `cargo test -p moq-audio --all-features --lib` (115 tests).

New tests:

- `reporting_a_failure_never_waits_on_the_mailbox`: a report lands while the switch queue is locked, which would hang the audio thread if the failure path touched that lock.
- `a_parked_driver_is_woken`: a driver parked on an empty mailbox is woken by eight concurrent syncs and then by shutdown, both on deadlines so a lost wake fails rather than hangs.
- `a_signal_racing_startup_is_not_slept_through`: a signal raised before the driver registers itself is still found.
- `an_early_wake_does_not_fake_a_retry`: an unpark before the deadline reports the real work, not a retry.
- `a_due_retry_outranks_reasserted_signals`: continuous sync churn cannot starve a due device retry.
- `losing_the_driver_releases_switch_callers`: dropping `Requests` releases a queued switch and refuses later ones.
- `a_fatal_batch_keeps_the_counts_that_preceded_it`: coalescing does not reset the escalation window that a stream failing again after a rebuild depends on.
- `notification_floods_are_coalesced`, `switches_complete_or_reject_overload`, `sync_survives_a_saturated_driver`, `final_handle_shuts_down_a_saturated_driver`: the bounds and the saturation behavior.

(Written by Claude Opus 5)
