### PR TITLE
fix(js): validate fanout queue limits

### DIFF
--- a/js/publish/src/fanout.test.ts
+++ b/js/publish/src/fanout.test.ts
@@ -21,6 +21,16 @@ function pushable<T>(): { stream: ReadableStream<T>; push: (value: T) => void; c
 // contents isn't racing it.
 const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
 
+const INVALID_QUEUES = [
+	0,
+	-1,
+	1.5,
+	Number.NaN,
+	Number.POSITIVE_INFINITY,
+	Number.NEGATIVE_INFINITY,
+	Number.MAX_SAFE_INTEGER + 1,
+];
+
 // Read up to `count` values, giving up once the stream goes quiet.
 async function take<T>(stream: ReadableStream<T>, count: number): Promise<T[]> {
 	const reader = stream.getReader();
@@ -40,6 +50,28 @@ async function take<T>(stream: ReadableStream<T>, count: number): Promise<T[]> {
 }
 
 describe("Fanout", () => {
+	test("rejects invalid default queue limits before locking the source", () => {
+		for (const queue of INVALID_QUEUES) {
+			const source = new ReadableStream<number>();
+
+			expect(() => new Fanout(source, { queue })).toThrow(RangeError);
+			expect(source.locked).toBe(false);
+		}
+	});
+
+	test("rejects invalid per-reader queue limits", () => {
+		const source = pushable<number>();
+		const fanout = new Fanout(source.stream);
+		const effect = new Effect();
+
+		for (const queue of INVALID_QUEUES) {
+			expect(() => fanout.subscribe(effect, queue)).toThrow(RangeError);
+		}
+
+		effect.close();
+		fanout.close();
+	});
+
 	// The whole point: one source, several encoders, none of them stealing from the others.
 	test("delivers every value to every reader", async () => {
 		const source = pushable<number>();

--- a/js/publish/src/fanout.ts
+++ b/js/publish/src/fanout.ts
@@ -5,7 +5,7 @@ const QUEUE = 4;
 
 /** Constructor options for {@link Fanout}. */
 export interface FanoutProps<T> {
-	/** How many values each reader may buffer before its oldest is dropped. Defaults to 4. */
+	/** Positive safe integer of values each reader may buffer before its oldest is dropped. Defaults to 4. */
 	queue?: number;
 
 	/**
@@ -46,7 +46,7 @@ export class Fanout<T> {
 	#failure: { error: unknown } | undefined;
 
 	constructor(source: ReadableStream<T>, props?: FanoutProps<T>) {
-		this.#queue = props?.queue ?? QUEUE;
+		this.#queue = validateQueue(props?.queue ?? QUEUE);
 		this.#clone = props?.clone;
 		this.#release = props?.release;
 		this.#reader = source.getReader();
@@ -57,11 +57,17 @@ export class Fanout<T> {
 	/**
 	 * A stream of everything published from now on, cancelled when `effect` is torn down.
 	 *
-	 * `queue` overrides how far this reader may fall behind before it loses its oldest. Pass 1 for a
-	 * consumer that only wants the newest, like a preview that draws one frame per paint.
+	 * `queue` is a positive safe integer overriding how far this reader may fall behind before it
+	 * loses its oldest. Pass 1 for a consumer that only wants the newest, like a preview that draws
+	 * one frame per paint.
 	 */
 	subscribe(effect: Effect, queue = this.#queue): ReadableStream<T> {
-		const reader: Reader<T> = { queue: [], limit: queue, waiting: undefined, done: this.#closed };
+		const reader: Reader<T> = {
+			queue: [],
+			limit: validateQueue(queue),
+			waiting: undefined,
+			done: this.#closed,
+		};
 		this.#readers.add(reader);
 
 		effect.cleanup(() => {
@@ -181,6 +187,14 @@ export class Fanout<T> {
 		for (const value of reader.queue) this.#release?.(value);
 		reader.queue.length = 0;
 	}
+}
+
+function validateQueue(queue: number): number {
+	if (!Number.isSafeInteger(queue) || queue <= 0) {
+		throw new RangeError(`fanout queue must be a positive safe integer, got ${queue}`);
+	}
+
+	return queue;
 }
 
 // One attached reader: what it hasn't consumed yet, plus a resolver parked on an empty queue.


### PR DESCRIPTION
## Summary

- Validate the default and per-subscriber fanout queue limits before locking the source or registering a reader.
- Require a positive safe integer so the overflow drop loop always makes progress.
- Add regressions for zero, negative, fractional, non-finite, and unsafe integer limits.

## Public API changes

`Fanout` now throws `RangeError` for invalid queue limits. There are no symbol or signature changes.

## Test plan

- `nix develop --command bun test js/publish/src/fanout.test.ts` (12 passed)
- Biome check for the changed files
- `@moq/publish` TypeScript check
- `git diff --check`

Closes #3171

(Written by GPT-5)