### PR TITLE
fix(js/net): stop Reload after terminal failure

### DIFF
--- a/js/net/src/connection/reload.test.ts
+++ b/js/net/src/connection/reload.test.ts
@@ -117,7 +117,9 @@ test("closing mid-connect aborts the pending attempt", async () => {
 test("a peer that severs immediately keeps escalating the backoff", async () => {
 	const original = globalThis.WebTransport;
 	const url = new URL("https://example.com/");
+	let attempts = 0;
 	const stub = function StubWebTransport() {
+		attempts++;
 		const pair = createMockTransportPair(Lite.ALPN_06_WIP);
 		// Sever the session as soon as the server side finishes the handshake.
 		void accept(pair.server, url).then((server) => server.close());
@@ -139,6 +141,14 @@ test("a peer that severs immediately keeps escalating the backoff", async () => 
 	});
 	try {
 		await expect(reload.closed).rejects.toThrow();
+
+		// A terminal loop ignores later reactive edits instead of opening another session.
+		const terminalAttempts = attempts;
+		reload.enabled.set(false);
+		await settle();
+		reload.enabled.set(true);
+		await settle();
+		expect(attempts).toBe(terminalAttempts);
 	} finally {
 		reload.close();
 		globalThis.WebTransport = original;
@@ -371,6 +381,11 @@ test("an unauthorized session close during setup stops retrying", async () => {
 		]);
 		expect(err).toBeInstanceOf(SessionError);
 		expect((err as SessionError).code).toBe(SessionCode.Unauthorized);
+		expect(attempts).toBe(1);
+
+		// The terminal authorization result survives a URL edit that would normally reconnect.
+		reload.url.set(new URL("https://example.com/changed"));
+		await settle();
 		expect(attempts).toBe(1);
 	} finally {
 		reload.close();

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -1,4 +1,4 @@
-import { type Dispose, Effect, type Getter, Signal } from "@moq/signals";
+import { Effect, type Getter, Signal } from "@moq/signals";
 import * as Announce from "../announced.ts";
 import { error, SessionCode, SessionError } from "../error.ts";
 import type { Consumer as OriginConsumer, Producer as OriginProducer } from "../origin.ts";
@@ -141,10 +141,6 @@ export class Reload {
 	#closedResolve!: () => void;
 	#closedReject!: (err: Error) => void;
 
-	// Releases the subscribe origin's expectation. Idempotent, so the terminal paths and the
-	// close cleanup can both call it.
-	#expected?: Dispose;
-
 	// The current wait between attempts, doubling per failure, and when the retry window expires.
 	// Both are undefined between sequences, so a later edit to `delay` applies to the next one.
 	#delay: DOMHighResTimeStamp | undefined;
@@ -175,8 +171,7 @@ export class Reload {
 		// terminal failure: a reconnect loop that has given up must stop claiming it will
 		// answer, or every request on the origin waits forever on a connection that is done.
 		if (this.subscribe) {
-			this.#expected = this.subscribe.expect();
-			this.#signals.cleanup(this.#expected);
+			this.#signals.cleanup(this.subscribe.expect());
 		}
 
 		this.closed = new Promise((resolve, reject) => {
@@ -308,8 +303,7 @@ export class Reload {
 		// for good.
 		if (cause instanceof SessionError && cause.code === SessionCode.Unauthorized) {
 			console.warn("session rejected as unauthorized, not retrying");
-			this.#expected?.();
-			this.#closedReject(cause);
+			this.#terminate(cause);
 			return;
 		}
 
@@ -320,8 +314,7 @@ export class Reload {
 		if (now >= this.#deadline) {
 			console.warn("reconnect timed out");
 			// A graceful close has no error, so report the timeout itself.
-			this.#expected?.();
-			this.#closedReject(cause === undefined ? new Error("reconnect timed out") : error(cause));
+			this.#terminate(cause === undefined ? new Error("reconnect timed out") : error(cause));
 			return;
 		}
 
@@ -332,6 +325,11 @@ export class Reload {
 
 		const tick = this.#tick.peek() + 1;
 		effect.timer(() => this.#tick.update((prev) => Math.max(prev, tick)), wait);
+	}
+
+	#terminate(cause: Error): void {
+		this.#signals.close();
+		this.#closedReject(cause);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Close the reactive effect when `Reload` reaches a terminal authorization failure or exhausts its retry window.
- Keep origin expectation cleanup owned by that effect, making terminal cleanup idempotent.
- Verify later URL, enabled, and lifecycle changes cannot resurrect the reconnect loop.

## Root cause

Terminal paths rejected `Reload.closed` but left the owning reactive effect active. A later signal change reran the effect and created another connection after the loop had reported that it stopped.

## Public API changes

None.

## Test plan

- Focused reload suite (13 passed)
- Complete `js/net` suite (604 passed)
- `js/net` source and examples TypeScript checks
- Biome check
- `git diff --check`

Closes #3172

(Written by GPT-5)