### PR TITLE
fix(publish): apply audio gain before the first frame

### DIFF
--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -201,7 +201,7 @@ export class Encoder {
 			reader.cancel().catch(() => {});
 		});
 
-		const gain = new Gain();
+		const gain = new Gain(this.muted.peek() ? 0 : this.volume.peek());
 
 		effect.spawn(async () => {
 			for (;;) {
@@ -213,8 +213,8 @@ export class Encoder {
 
 				// Every rendition shares the captured frame, so gain returns a copy rather than
 				// scaling in place; muting one rendition must not silence the rest.
-				const frame = gain.apply(next.value, format.sampleRate);
 				gain.set(this.muted.peek() ? 0 : this.volume.peek());
+				const frame = gain.apply(next.value, format.sampleRate);
 
 				// The config rebuilds when the channel count moves, so skip anything that arrives
 				// mid-swap rather than framing it wrong.

--- a/js/publish/src/audio/gain.test.ts
+++ b/js/publish/src/audio/gain.test.ts
@@ -16,6 +16,14 @@ function ones(samples: number, channels = 1): AudioFrame {
 }
 
 describe("Gain", () => {
+	test("starts at the requested level", () => {
+		const muted = new Gain(0);
+		const quiet = new Gain(0.25);
+
+		expect([...muted.apply(ones(128), RATE).channels[0]]).toEqual(Array.from({ length: 128 }, () => 0));
+		expect([...quiet.apply(ones(128), RATE).channels[0]]).toEqual(Array.from({ length: 128 }, () => 0.25));
+	});
+
 	test("leaves audio untouched at unity", () => {
 		const gain = new Gain();
 		const frame = ones(128);

--- a/js/publish/src/audio/gain.ts
+++ b/js/publish/src/audio/gain.ts
@@ -11,8 +11,14 @@ const FADE = 0.2; // seconds
  * audio came from.
  */
 export class Gain {
-	#current = 1;
-	#target = 1;
+	#current: number;
+	#target: number;
+
+	/** Start at `initial`, avoiding a ramp from unity before the first frame. */
+	constructor(initial = 1) {
+		this.#current = initial;
+		this.#target = initial;
+	}
 
 	/** Set the level to ramp toward, where 1 is unity and 0 is silence. */
 	set(value: number): void {


### PR DESCRIPTION
## Summary

- Seed each audio rendition's gain from its current mute and volume controls.
- Update the gain target before scaling each captured frame.
- Add regression coverage for muted and attenuated initial levels.

## Root cause

The encoder applied gain before setting the current target, and `Gain` always started at unity. An initially muted or attenuated rendition therefore emitted its first frame at unity and remained one frame behind control changes.

## Public API changes

None. `Gain` is an internal implementation detail of `@moq/publish`.

## Test plan

- Focused gain suite (6 passed)
- Complete `js/publish/src` suite (90 passed)
- `@moq/publish` package check
- Biome check for the changed files
- `git diff --check`

Closes #3174

(Written by GPT-5)