### PR TITLE
fix(audio): recover microphone capture after device errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4633,6 +4633,7 @@ dependencies = [
  "dispatch2",
  "fixed-resample",
  "hang",
+ "kio 0.5.6",
  "moq-mux",
  "moq-net",
  "objc2 0.6.4",

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -28,6 +28,7 @@ default = ["aac"]
 # is a no-op elsewhere).
 capture = [
     "dep:cpal",
+    "dep:kio",
     "dep:tokio",
     "dep:tracing",
     "dep:block2",
@@ -63,6 +64,7 @@ cpal = { version = "0.18", optional = true }
 # `fft-resampler` stays off, matching the sinc-only stance below.
 fixed-resample = { version = "0.12", optional = true, default-features = false, features = ["channel", "resampler"] }
 hang = { workspace = true }
+kio = { workspace = true, optional = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
 # We only use the sinc resampler (Async::new_sinc), so skip the default

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -17,6 +17,7 @@
 //! [`aec::Canceller`](crate::aec::Canceller) through [`Config::aec`], which runs
 //! in that same callback so the buffers leaving here are already clean.
 
+use std::task::Poll;
 use std::time::Duration;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -99,6 +100,43 @@ pub(crate) struct Samples {
 	pub gap: bool,
 }
 
+/// A capture failure plus whether reopening can succeed without caller action.
+#[derive(Debug)]
+pub(crate) enum Failure {
+	Retry(Error),
+	Fatal(Error),
+}
+
+impl Failure {
+	pub(crate) fn retry(error: Error) -> Self {
+		Self::Retry(error)
+	}
+
+	pub(crate) fn fatal(error: Error) -> Self {
+		Self::Fatal(error)
+	}
+
+	fn cpal(error: cpal::Error) -> Self {
+		let retryable = retryable(error.kind());
+		let error = capture_err(error);
+		if retryable {
+			Self::Retry(error)
+		} else {
+			Self::Fatal(error)
+		}
+	}
+
+	pub(crate) fn is_retryable(&self) -> bool {
+		matches!(self, Self::Retry(_))
+	}
+
+	pub(crate) fn into_error(self) -> Error {
+		match self {
+			Self::Retry(error) | Self::Fatal(error) => error,
+		}
+	}
+}
+
 /// An open capture source, read buffer-by-buffer via [`read`](Self::read).
 ///
 /// `pub(crate)`: [`encode::publish_capture`](crate::encode::publish_capture) is
@@ -113,7 +151,7 @@ impl Stream {
 	/// Await the next buffer, or `None` once the source stops. A microphone stream
 	/// error is returned immediately even if the device delivers no more samples.
 	/// Cancel-safe: drop the future to release the device.
-	pub(crate) async fn read(&mut self) -> Result<Option<Samples>, Error> {
+	pub(crate) async fn read(&mut self) -> Result<Option<Samples>, Failure> {
 		match self {
 			Self::Microphone(mic) => mic.read().await,
 			#[cfg(target_os = "macos")]
@@ -131,7 +169,7 @@ pub(crate) async fn format(config: &Config) -> Result<(u32, u32), Error> {
 			// cpal enumerates devices with blocking host I/O, so keep it off the
 			// runtime's worker threads.
 			blocking(move || {
-				let (_, _, stream_config) = resolve(device.as_deref(), &config)?;
+				let (_, _, stream_config) = resolve(device.as_deref(), &config).map_err(Failure::into_error)?;
 				Ok((stream_config.sample_rate, stream_config.channels as u32))
 			})
 			.await
@@ -146,17 +184,19 @@ pub(crate) async fn format(config: &Config) -> Result<(u32, u32), Error> {
 }
 
 /// Open the capture source described by `config`.
-pub(crate) async fn open(config: &Config) -> Result<Stream, Error> {
+pub(crate) async fn open(config: &Config) -> Result<Stream, Failure> {
 	match &config.source {
 		Source::Microphone(device) => Ok(Stream::Microphone(Microphone::open(device.as_deref(), config).await?)),
 		#[cfg(target_os = "macos")]
 		Source::System => Ok(Stream::System(
-			screencapture::SystemAudio::open(config.sample_rate, config.channels).await?,
+			screencapture::SystemAudio::open(config.sample_rate, config.channels)
+				.await
+				.map_err(Failure::fatal)?,
 		)),
 		#[cfg(not(target_os = "macos"))]
-		Source::System => Err(Error::Unsupported(
+		Source::System => Err(Failure::fatal(Error::Unsupported(
 			"system audio capture is only supported on macOS".into(),
-		)),
+		))),
 	}
 }
 
@@ -178,32 +218,46 @@ pub(crate) struct Microphone {
 /// hardware.
 struct MicrophoneReader {
 	rx: channel::Receiver<Vec<f32>>,
-	errors: tokio::sync::mpsc::UnboundedReceiver<Error>,
+	errors: kio::Consumer<Option<cpal::Error>>,
 }
 
 impl MicrophoneReader {
 	/// Return the buffer consumed during open unless a stream error arrived in
 	/// the meantime.
-	async fn pending(&mut self, samples: Samples) -> Result<Option<Samples>, Error> {
+	async fn pending(&mut self, samples: Samples) -> Result<Option<Samples>, Failure> {
 		tokio::select! {
 			biased;
-			Some(err) = self.errors.recv() => Err(err),
+			Some(err) = failure(&self.errors) => Err(err),
 			_ = std::future::ready(()) => Ok(Some(samples)),
 		}
 	}
 
 	/// Race samples against cpal's error callback. Errors win if both are ready so
 	/// a dead device is never kept alive just to drain already-buffered audio.
-	async fn read(&mut self) -> Result<Option<Samples>, Error> {
-		tokio::select! {
+	async fn read(&mut self) -> Result<Option<Samples>, Failure> {
+		let data = tokio::select! {
 			biased;
-			Some(err) = self.errors.recv() => Err(err),
-			data = self.rx.recv() => Ok(data.map(|data| Samples {
-				data,
-				gap: self.rx.gap(),
-			})),
-		}
+			Some(err) = failure(&self.errors) => return Err(err),
+			data = self.rx.recv() => data,
+		};
+
+		Ok(data.map(|data| Samples {
+			data,
+			gap: self.rx.gap(),
+		}))
 	}
+}
+
+/// Await the first terminal cpal error for this stream generation.
+async fn failure(errors: &kio::Consumer<Option<cpal::Error>>) -> Option<Failure> {
+	errors
+		.wait(|error| match error.as_ref() {
+			Some(error) => Poll::Ready(error.clone()),
+			None => Poll::Pending,
+		})
+		.await
+		.ok()
+		.map(Failure::cpal)
 }
 
 impl Microphone {
@@ -213,10 +267,10 @@ impl Microphone {
 	/// `cpal::Stream` is `!Send` and so can't be built on another thread and
 	/// moved here. They return as soon as the device starts; the await is the
 	/// first-buffer wait below.
-	async fn open(selector: Option<&str>, config: &Config) -> Result<Self, Error> {
+	async fn open(selector: Option<&str>, config: &Config) -> Result<Self, Failure> {
 		// Fail fast on a denied/restricted mic (macOS TCC) instead of opening a
 		// stream that silently delivers nothing. A no-op on other platforms.
-		permission::ensure_microphone_access().await?;
+		permission::ensure_microphone_access().await.map_err(Failure::fatal)?;
 
 		let (device, sample_format, stream_config) = resolve(selector, config)?;
 		let sample_rate = stream_config.sample_rate;
@@ -226,11 +280,12 @@ impl Microphone {
 		// arrives, so the buffers it needs are allocated off the audio thread.
 		#[cfg(feature = "aec")]
 		if let Some(aec) = &config.aec {
-			aec.open(sample_rate, channels)?;
+			aec.open(sample_rate, channels).map_err(Failure::fatal)?;
 		}
 
 		let (tx, rx) = channel::bounded::<Vec<f32>>();
-		let (error_tx, errors) = tokio::sync::mpsc::unbounded_channel();
+		let error_tx = kio::Producer::new(None);
+		let errors = error_tx.consume();
 		let mut reader = MicrophoneReader { rx, errors };
 
 		// What every sample format funnels into once it is interleaved `f32`.
@@ -280,27 +335,29 @@ impl Microphone {
 				)
 			}
 			other => {
-				return Err(Error::Unsupported(format!("unsupported input sample format {other:?}")));
+				return Err(Failure::fatal(Error::Unsupported(format!(
+					"unsupported input sample format {other:?}"
+				))));
 			}
 		}
-		.map_err(capture_err)?;
+		.map_err(Failure::cpal)?;
 
-		stream.play().map_err(capture_err)?;
+		stream.play().map_err(Failure::cpal)?;
 
 		// Await the first buffer to surface a permission failure (or dead device)
 		// as an error rather than a silent hang in the capture loop.
 		let pending = match tokio::time::timeout(FIRST_BUFFER_TIMEOUT, reader.read()).await {
 			Ok(Ok(Some(samples))) => samples,
 			Ok(Ok(None)) => {
-				return Err(Error::Capture(format!(
+				return Err(Failure::retry(Error::Capture(format!(
 					"microphone {device} stopped before any samples"
-				)));
+				))));
 			}
 			Ok(Err(err)) => return Err(err),
 			Err(_) => {
-				return Err(Error::Capture(format!(
+				return Err(Failure::fatal(Error::Capture(format!(
 					"no samples from microphone {device} within {FIRST_BUFFER_TIMEOUT:?} (permission denied?)"
-				)));
+				))));
 			}
 		};
 
@@ -315,7 +372,7 @@ impl Microphone {
 
 	/// Await the next buffer or stream error. Cancel-safe: drop the future to stop
 	/// reading.
-	async fn read(&mut self) -> Result<Option<Samples>, Error> {
+	async fn read(&mut self) -> Result<Option<Samples>, Failure> {
 		if let Some(samples) = self.pending.take() {
 			return self.reader.pending(samples).await;
 		}
@@ -385,20 +442,20 @@ where
 fn resolve(
 	selector: Option<&str>,
 	config: &Config,
-) -> Result<(cpal::Device, cpal::SampleFormat, cpal::StreamConfig), Error> {
+) -> Result<(cpal::Device, cpal::SampleFormat, cpal::StreamConfig), Failure> {
 	let host = cpal::default_host();
 	let device = match selector {
 		Some(name) => host
 			.input_devices()
-			.map_err(capture_err)?
+			.map_err(Failure::cpal)?
 			.find(|d| d.to_string() == name)
-			.ok_or_else(|| Error::Device(format!("input device {name:?} not found")))?,
+			.ok_or_else(|| Failure::retry(Error::Device(format!("input device {name:?} not found"))))?,
 		None => host
 			.default_input_device()
-			.ok_or_else(|| Error::Device("no default input device".into()))?,
+			.ok_or_else(|| Failure::retry(Error::Device("no default input device".into())))?,
 	};
 
-	let supported = device.default_input_config().map_err(capture_err)?;
+	let supported = device.default_input_config().map_err(Failure::cpal)?;
 	let sample_format = supported.sample_format();
 	let mut stream_config = supported.config();
 	if let Some(rate) = config.sample_rate {
@@ -410,9 +467,40 @@ fn resolve(
 	Ok((device, sample_format, stream_config))
 }
 
-fn stream_err(errors: &tokio::sync::mpsc::UnboundedSender<Error>, err: cpal::Error) {
+fn stream_err(errors: &kio::Producer<Option<cpal::Error>>, err: cpal::Error) {
+	if survivable(err.kind()) {
+		tracing::warn!(error = %err, "microphone stream error does not require a restart");
+		return;
+	}
+
 	tracing::error!(error = %err, "microphone stream error");
-	let _ = errors.send(capture_err(err));
+	let Ok(mut failure) = errors.write() else { return };
+	if failure.is_some() {
+		return;
+	}
+	*failure = Some(err);
+	failure.close();
+}
+
+/// Errors for which cpal documents that the live stream remains usable.
+fn survivable(kind: cpal::ErrorKind) -> bool {
+	matches!(
+		kind,
+		cpal::ErrorKind::DeviceChanged | cpal::ErrorKind::RealtimeDenied | cpal::ErrorKind::Xrun
+	)
+}
+
+/// Errors that can clear after the device or host state changes by itself.
+fn retryable(kind: cpal::ErrorKind) -> bool {
+	matches!(
+		kind,
+		cpal::ErrorKind::DeviceBusy
+			| cpal::ErrorKind::DeviceNotAvailable
+			| cpal::ErrorKind::HostUnavailable
+			| cpal::ErrorKind::ResourceExhausted
+			| cpal::ErrorKind::StreamInvalidated
+			| cpal::ErrorKind::BackendError
+	)
 }
 
 fn capture_err(err: impl std::fmt::Display) -> Error {
@@ -425,21 +513,29 @@ mod tests {
 
 	fn reader() -> (
 		channel::Sender<Vec<f32>>,
-		tokio::sync::mpsc::UnboundedSender<Error>,
+		kio::Producer<Option<cpal::Error>>,
 		MicrophoneReader,
 	) {
 		let (tx, rx) = channel::bounded();
-		let (error_tx, errors) = tokio::sync::mpsc::unbounded_channel();
-		(tx, error_tx, MicrophoneReader { rx, errors })
+		let failures = kio::Producer::new(None);
+		let errors = failures.consume();
+		(tx, failures, MicrophoneReader { rx, errors })
+	}
+
+	fn fail(errors: &kio::Producer<Option<cpal::Error>>, message: &'static str) {
+		stream_err(
+			errors,
+			cpal::Error::with_message(cpal::ErrorKind::DeviceNotAvailable, message),
+		);
 	}
 
 	#[tokio::test]
 	async fn stream_error_wakes_a_reader_without_samples() {
 		let (_samples, errors, mut reader) = reader();
-		errors.send(Error::Capture("device lost".into())).unwrap();
+		fail(&errors, "device lost");
 
 		let err = match reader.read().await {
-			Err(err) => err,
+			Err(err) => err.into_error(),
 			Ok(_) => panic!("the reader ignored its stream error"),
 		};
 		assert!(matches!(err, Error::Capture(message) if message == "device lost"));
@@ -451,7 +547,7 @@ mod tests {
 		let (new_samples, _new_errors, mut new_reader) = reader();
 		drop(old_reader);
 
-		assert!(old_errors.send(Error::Capture("stale".into())).is_err());
+		fail(&old_errors, "stale");
 		new_samples.push(vec![1.0]);
 		let samples = new_reader.read().await.unwrap().unwrap();
 		assert_eq!(samples.data, vec![1.0]);
@@ -460,7 +556,7 @@ mod tests {
 	#[tokio::test]
 	async fn stream_error_wins_over_the_buffer_saved_during_open() {
 		let (_samples, errors, mut reader) = reader();
-		errors.send(Error::Capture("device lost".into())).unwrap();
+		fail(&errors, "device lost");
 
 		let result = reader
 			.pending(Samples {
@@ -469,9 +565,23 @@ mod tests {
 			})
 			.await;
 		let err = match result {
-			Err(err) => err,
+			Err(err) => err.into_error(),
 			Ok(_) => panic!("the pending sample hid a stream error"),
 		};
 		assert!(matches!(err, Error::Capture(message) if message == "device lost"));
+	}
+
+	#[test]
+	fn survivable_errors_do_not_end_the_stream() {
+		let (_samples, errors, _reader) = reader();
+		stream_err(&errors, cpal::Error::new(cpal::ErrorKind::DeviceChanged));
+
+		assert!(errors.read().is_none());
+	}
+
+	#[test]
+	fn permission_errors_are_not_retryable() {
+		let failure = Failure::cpal(cpal::Error::new(cpal::ErrorKind::PermissionDenied));
+		assert!(!failure.is_retryable());
 	}
 }

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -499,7 +499,6 @@ fn retryable(kind: cpal::ErrorKind) -> bool {
 			| cpal::ErrorKind::HostUnavailable
 			| cpal::ErrorKind::ResourceExhausted
 			| cpal::ErrorKind::StreamInvalidated
-			| cpal::ErrorKind::BackendError
 	)
 }
 
@@ -582,6 +581,12 @@ mod tests {
 	#[test]
 	fn permission_errors_are_not_retryable() {
 		let failure = Failure::cpal(cpal::Error::new(cpal::ErrorKind::PermissionDenied));
+		assert!(!failure.is_retryable());
+	}
+
+	#[test]
+	fn opaque_backend_errors_are_not_retryable() {
+		let failure = Failure::cpal(cpal::Error::new(cpal::ErrorKind::BackendError));
 		assert!(!failure.is_retryable());
 	}
 }

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -110,13 +110,14 @@ pub(crate) enum Stream {
 }
 
 impl Stream {
-	/// Await the next buffer, or `None` once the source stops. Cancel-safe: drop
-	/// the future to release the device.
-	pub(crate) async fn read(&mut self) -> Option<Samples> {
+	/// Await the next buffer, or `None` once the source stops. A microphone stream
+	/// error is returned immediately even if the device delivers no more samples.
+	/// Cancel-safe: drop the future to release the device.
+	pub(crate) async fn read(&mut self) -> Result<Option<Samples>, Error> {
 		match self {
 			Self::Microphone(mic) => mic.read().await,
 			#[cfg(target_os = "macos")]
-			Self::System(system) => system.read().await,
+			Self::System(system) => Ok(system.read().await),
 		}
 	}
 }
@@ -166,10 +167,43 @@ pub(crate) async fn open(config: &Config) -> Result<Stream, Error> {
 pub(crate) struct Microphone {
 	// Kept alive to keep capturing; dropping it stops the stream.
 	_stream: cpal::Stream,
-	rx: channel::Receiver<Vec<f32>>,
+	reader: MicrophoneReader,
 	/// The first buffer, captured during `open` to surface a permission failure
 	/// as an error rather than a silent hang.
-	pending: Option<Vec<f32>>,
+	pending: Option<Samples>,
+}
+
+/// The async half of a microphone stream, separate from the cpal handle so its
+/// failure wakeup and stream-generation isolation can be tested without audio
+/// hardware.
+struct MicrophoneReader {
+	rx: channel::Receiver<Vec<f32>>,
+	errors: tokio::sync::mpsc::UnboundedReceiver<Error>,
+}
+
+impl MicrophoneReader {
+	/// Return the buffer consumed during open unless a stream error arrived in
+	/// the meantime.
+	async fn pending(&mut self, samples: Samples) -> Result<Option<Samples>, Error> {
+		tokio::select! {
+			biased;
+			Some(err) = self.errors.recv() => Err(err),
+			_ = std::future::ready(()) => Ok(Some(samples)),
+		}
+	}
+
+	/// Race samples against cpal's error callback. Errors win if both are ready so
+	/// a dead device is never kept alive just to drain already-buffered audio.
+	async fn read(&mut self) -> Result<Option<Samples>, Error> {
+		tokio::select! {
+			biased;
+			Some(err) = self.errors.recv() => Err(err),
+			data = self.rx.recv() => Ok(data.map(|data| Samples {
+				data,
+				gap: self.rx.gap(),
+			})),
+		}
+	}
 }
 
 impl Microphone {
@@ -195,7 +229,9 @@ impl Microphone {
 			aec.open(sample_rate, channels)?;
 		}
 
-		let (tx, mut rx) = channel::bounded::<Vec<f32>>();
+		let (tx, rx) = channel::bounded::<Vec<f32>>();
+		let (error_tx, errors) = tokio::sync::mpsc::unbounded_channel();
+		let mut reader = MicrophoneReader { rx, errors };
 
 		// What every sample format funnels into once it is interleaved `f32`.
 		// Echo cancellation edits the buffer in place, so it costs no allocation
@@ -216,24 +252,33 @@ impl Microphone {
 		// The callback runs on cpal's realtime audio thread. Sample conversion
 		// allocates one Vec per callback; the bounded handoff never blocks.
 		let stream = match sample_format {
-			cpal::SampleFormat::F32 => device.build_input_stream(
-				stream_config,
-				move |data: &[f32], _: &_| deliver(data.to_vec()),
-				stream_err,
-				None,
-			),
-			cpal::SampleFormat::I16 => device.build_input_stream(
-				stream_config,
-				move |data: &[i16], _: &_| deliver(data.iter().map(|&s| s as f32 / 32768.0).collect()),
-				stream_err,
-				None,
-			),
-			cpal::SampleFormat::U16 => device.build_input_stream(
-				stream_config,
-				move |data: &[u16], _: &_| deliver(data.iter().map(|&s| (s as f32 - 32768.0) / 32768.0).collect()),
-				stream_err,
-				None,
-			),
+			cpal::SampleFormat::F32 => {
+				let errors = error_tx.clone();
+				device.build_input_stream(
+					stream_config,
+					move |data: &[f32], _: &_| deliver(data.to_vec()),
+					move |err| stream_err(&errors, err),
+					None,
+				)
+			}
+			cpal::SampleFormat::I16 => {
+				let errors = error_tx.clone();
+				device.build_input_stream(
+					stream_config,
+					move |data: &[i16], _: &_| deliver(data.iter().map(|&s| s as f32 / 32768.0).collect()),
+					move |err| stream_err(&errors, err),
+					None,
+				)
+			}
+			cpal::SampleFormat::U16 => {
+				let errors = error_tx.clone();
+				device.build_input_stream(
+					stream_config,
+					move |data: &[u16], _: &_| deliver(data.iter().map(|&s| (s as f32 - 32768.0) / 32768.0).collect()),
+					move |err| stream_err(&errors, err),
+					None,
+				)
+			}
 			other => {
 				return Err(Error::Unsupported(format!("unsupported input sample format {other:?}")));
 			}
@@ -244,13 +289,14 @@ impl Microphone {
 
 		// Await the first buffer to surface a permission failure (or dead device)
 		// as an error rather than a silent hang in the capture loop.
-		let pending = match tokio::time::timeout(FIRST_BUFFER_TIMEOUT, rx.recv()).await {
-			Ok(Some(samples)) => samples,
-			Ok(None) => {
+		let pending = match tokio::time::timeout(FIRST_BUFFER_TIMEOUT, reader.read()).await {
+			Ok(Ok(Some(samples))) => samples,
+			Ok(Ok(None)) => {
 				return Err(Error::Capture(format!(
 					"microphone {device} stopped before any samples"
 				)));
 			}
+			Ok(Err(err)) => return Err(err),
 			Err(_) => {
 				return Err(Error::Capture(format!(
 					"no samples from microphone {device} within {FIRST_BUFFER_TIMEOUT:?} (permission denied?)"
@@ -262,23 +308,19 @@ impl Microphone {
 
 		Ok(Self {
 			_stream: stream,
-			rx,
+			reader,
 			pending: Some(pending),
 		})
 	}
 
-	/// Await the next buffer, or `None` once the stream stops. Cancel-safe: drop
-	/// the future to stop reading.
-	async fn read(&mut self) -> Option<Samples> {
-		if let Some(data) = self.pending.take() {
-			return Some(Samples { data, gap: false });
+	/// Await the next buffer or stream error. Cancel-safe: drop the future to stop
+	/// reading.
+	async fn read(&mut self) -> Result<Option<Samples>, Error> {
+		if let Some(samples) = self.pending.take() {
+			return self.reader.pending(samples).await;
 		}
 
-		let data = self.rx.recv().await?; // stream dropped / device gone
-		Some(Samples {
-			data,
-			gap: self.rx.gap(),
-		})
+		self.reader.read().await
 	}
 }
 
@@ -368,10 +410,68 @@ fn resolve(
 	Ok((device, sample_format, stream_config))
 }
 
-fn stream_err(err: cpal::Error) {
+fn stream_err(errors: &tokio::sync::mpsc::UnboundedSender<Error>, err: cpal::Error) {
 	tracing::error!(error = %err, "microphone stream error");
+	let _ = errors.send(capture_err(err));
 }
 
 fn capture_err(err: impl std::fmt::Display) -> Error {
 	Error::Capture(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn reader() -> (
+		channel::Sender<Vec<f32>>,
+		tokio::sync::mpsc::UnboundedSender<Error>,
+		MicrophoneReader,
+	) {
+		let (tx, rx) = channel::bounded();
+		let (error_tx, errors) = tokio::sync::mpsc::unbounded_channel();
+		(tx, error_tx, MicrophoneReader { rx, errors })
+	}
+
+	#[tokio::test]
+	async fn stream_error_wakes_a_reader_without_samples() {
+		let (_samples, errors, mut reader) = reader();
+		errors.send(Error::Capture("device lost".into())).unwrap();
+
+		let err = match reader.read().await {
+			Err(err) => err,
+			Ok(_) => panic!("the reader ignored its stream error"),
+		};
+		assert!(matches!(err, Error::Capture(message) if message == "device lost"));
+	}
+
+	#[tokio::test]
+	async fn replaced_stream_cannot_fail_its_replacement() {
+		let (_old_samples, old_errors, old_reader) = reader();
+		let (new_samples, _new_errors, mut new_reader) = reader();
+		drop(old_reader);
+
+		assert!(old_errors.send(Error::Capture("stale".into())).is_err());
+		new_samples.push(vec![1.0]);
+		let samples = new_reader.read().await.unwrap().unwrap();
+		assert_eq!(samples.data, vec![1.0]);
+	}
+
+	#[tokio::test]
+	async fn stream_error_wins_over_the_buffer_saved_during_open() {
+		let (_samples, errors, mut reader) = reader();
+		errors.send(Error::Capture("device lost".into())).unwrap();
+
+		let result = reader
+			.pending(Samples {
+				data: vec![1.0],
+				gap: false,
+			})
+			.await;
+		let err = match result {
+			Err(err) => err,
+			Ok(_) => panic!("the pending sample hid a stream error"),
+		};
+		assert!(matches!(err, Error::Capture(message) if message == "device lost"));
+	}
 }

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -100,6 +100,13 @@ pub(crate) struct Samples {
 	pub gap: bool,
 }
 
+/// The PCM layout delivered by one capture stream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Layout {
+	pub sample_rate: u32,
+	pub channels: u32,
+}
+
 /// A capture failure plus whether reopening can succeed without caller action.
 #[derive(Debug)]
 pub(crate) enum Failure {
@@ -148,6 +155,15 @@ pub(crate) enum Stream {
 }
 
 impl Stream {
+	/// The PCM layout this opened stream actually delivers.
+	pub(crate) fn layout(&self) -> Layout {
+		match self {
+			Self::Microphone(mic) => mic.layout,
+			#[cfg(target_os = "macos")]
+			Self::System(system) => system.layout(),
+		}
+	}
+
 	/// Await the next buffer, or `None` once the source stops. A microphone stream
 	/// error is returned immediately even if the device delivers no more samples.
 	/// Cancel-safe: drop the future to release the device.
@@ -162,7 +178,7 @@ impl Stream {
 
 /// The format `config` will capture at, without opening the device, so the
 /// catalog can be populated before anything turns on.
-pub(crate) async fn format(config: &Config) -> Result<(u32, u32), Failure> {
+pub(crate) async fn format(config: &Config) -> Result<Layout, Failure> {
 	match &config.source {
 		Source::Microphone(device) => {
 			let (device, config) = (device.clone(), config.clone());
@@ -170,7 +186,10 @@ pub(crate) async fn format(config: &Config) -> Result<(u32, u32), Failure> {
 			// runtime's worker threads.
 			tokio::task::spawn_blocking(move || {
 				let (_, _, stream_config) = resolve(device.as_deref(), &config)?;
-				Ok((stream_config.sample_rate, stream_config.channels as u32))
+				Ok(Layout {
+					sample_rate: stream_config.sample_rate,
+					channels: stream_config.channels as u32,
+				})
 			})
 			.await
 			.map_err(|err| Failure::fatal(Error::Capture(format!("audio host thread failed: {err}"))))?
@@ -212,6 +231,8 @@ pub(crate) struct Microphone {
 	/// The first buffer, captured during `open` to surface a permission failure
 	/// as an error rather than a silent hang.
 	pending: Option<Samples>,
+	/// The format cpal negotiated for this stream generation.
+	layout: Layout,
 }
 
 /// The async half of a microphone stream, separate from the cpal handle so its
@@ -368,6 +389,7 @@ impl Microphone {
 			_stream: stream,
 			reader,
 			pending: Some(pending),
+			layout: Layout { sample_rate, channels },
 		})
 	}
 

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -162,24 +162,25 @@ impl Stream {
 
 /// The format `config` will capture at, without opening the device, so the
 /// catalog can be populated before anything turns on.
-pub(crate) async fn format(config: &Config) -> Result<(u32, u32), Error> {
+pub(crate) async fn format(config: &Config) -> Result<(u32, u32), Failure> {
 	match &config.source {
 		Source::Microphone(device) => {
 			let (device, config) = (device.clone(), config.clone());
 			// cpal enumerates devices with blocking host I/O, so keep it off the
 			// runtime's worker threads.
-			blocking(move || {
-				let (_, _, stream_config) = resolve(device.as_deref(), &config).map_err(Failure::into_error)?;
+			tokio::task::spawn_blocking(move || {
+				let (_, _, stream_config) = resolve(device.as_deref(), &config)?;
 				Ok((stream_config.sample_rate, stream_config.channels as u32))
 			})
 			.await
+			.map_err(|err| Failure::fatal(Error::Capture(format!("audio host thread failed: {err}"))))?
 		}
 		#[cfg(target_os = "macos")]
 		Source::System => Ok(screencapture::SystemAudio::format(config.sample_rate, config.channels)),
 		#[cfg(not(target_os = "macos"))]
-		Source::System => Err(Error::Unsupported(
+		Source::System => Err(Failure::fatal(Error::Unsupported(
 			"system audio capture is only supported on macOS".into(),
-		)),
+		))),
 	}
 }
 

--- a/rs/moq-audio/src/capture/screencapture.rs
+++ b/rs/moq-audio/src/capture/screencapture.rs
@@ -31,7 +31,7 @@ use tokio::sync::oneshot;
 
 use crate::Error;
 
-use super::{Samples, channel};
+use super::{Layout, Samples, channel};
 
 /// SCK's audio defaults, used when the caller doesn't pin a format.
 const DEFAULT_SAMPLE_RATE: u32 = 48_000;
@@ -58,6 +58,7 @@ pub(crate) struct SystemAudio {
 	/// The first buffer, captured during [`open`](Self::open) so a missing screen
 	/// recording grant is an error rather than a silent hang.
 	pending: Option<Vec<f32>>,
+	layout: Layout,
 	_guard: StreamGuard,
 }
 
@@ -65,16 +66,17 @@ impl SystemAudio {
 	/// The format system audio will be captured at. SCK resamples to whatever we
 	/// ask for, so this is exactly what `config` requested (or the defaults), and
 	/// needs no open.
-	pub(super) fn format(sample_rate: Option<u32>, channels: Option<u32>) -> (u32, u32) {
-		(
-			sample_rate.unwrap_or(DEFAULT_SAMPLE_RATE),
-			channels.unwrap_or(DEFAULT_CHANNELS),
-		)
+	pub(super) fn format(sample_rate: Option<u32>, channels: Option<u32>) -> Layout {
+		Layout {
+			sample_rate: sample_rate.unwrap_or(DEFAULT_SAMPLE_RATE),
+			channels: channels.unwrap_or(DEFAULT_CHANNELS),
+		}
 	}
 
 	/// Open (and start) system audio capture.
 	pub(super) async fn open(sample_rate: Option<u32>, channels: Option<u32>) -> Result<Self, Error> {
-		let (sample_rate, channels) = Self::format(sample_rate, channels);
+		let layout = Self::format(sample_rate, channels);
+		let (sample_rate, channels) = (layout.sample_rate, layout.channels);
 
 		// The filter picks which audio is captured; a display filter means
 		// "everything playing on that screen", i.e. the whole system.
@@ -149,8 +151,14 @@ impl SystemAudio {
 		Ok(Self {
 			rx,
 			pending: Some(pending.samples),
+			layout,
 			_guard: guard,
 		})
+	}
+
+	/// The PCM layout requested from ScreenCaptureKit.
+	pub(super) fn layout(&self) -> Layout {
+		self.layout
 	}
 
 	/// Await the next buffer, or `None` once the stream stops. Cancel-safe: drop

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -80,8 +80,8 @@ pub async fn publish_capture(
 trait CaptureSource {
 	type Stream;
 
-	async fn open(&mut self) -> Result<Self::Stream, Error>;
-	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, Error>;
+	async fn open(&mut self) -> Result<Self::Stream, capture::Failure>;
+	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, capture::Failure>;
 }
 
 struct DeviceSource<'a> {
@@ -91,11 +91,11 @@ struct DeviceSource<'a> {
 impl CaptureSource for DeviceSource<'_> {
 	type Stream = capture::Stream;
 
-	async fn open(&mut self) -> Result<Self::Stream, Error> {
+	async fn open(&mut self) -> Result<Self::Stream, capture::Failure> {
 		capture::open(self.config).await
 	}
 
-	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, Error> {
+	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, capture::Failure> {
 		stream.read().await
 	}
 }
@@ -226,12 +226,6 @@ impl Supervisor {
 
 				let failure = match opened {
 					Ok(mut input) => {
-						let recovered = last_error.take().is_some();
-						self.reset();
-						if recovered {
-							tracing::info!("audio capture recovered");
-						}
-
 						loop {
 							// Demand wins over a simultaneous buffer or error, so an unused
 							// track releases the device without starting a retry sequence.
@@ -241,7 +235,10 @@ impl Supervisor {
 									drop(input);
 									output.reset_epoch();
 									if !unused {
-										return Ok(());
+										return match last_error {
+											Some(err) => Err(err),
+											None => Ok(()),
+										};
 									}
 									tracing::info!("no listeners: released audio capture");
 									continue 'demand;
@@ -251,20 +248,34 @@ impl Supervisor {
 
 							match samples {
 								Ok(Some(samples)) => {
+									// An open is not a recovery until it actually delivers audio.
+									// Otherwise a flapping device would reset its backoff after each
+									// empty stream and retry at the minimum delay forever.
+									if last_error.take().is_some() {
+										self.reset();
+										tracing::info!("audio capture recovered");
+									}
 									// A bounded-queue drop is a real hole in the timeline.
 									if samples.gap {
 										output.reset_epoch();
 									}
 									output.write(samples)?;
 								}
-								Ok(None) => break Error::Capture("audio capture stream stopped".into()),
+								Ok(None) => {
+									break capture::Failure::retry(Error::Capture(
+										"audio capture stream stopped".into(),
+									));
+								}
 								Err(err) => break err,
 							}
 						}
 					}
-					Err(err) if retryable(&err) => err,
-					Err(err) => return Err(err),
+					Err(err) => err,
 				};
+				if !failure.is_retryable() {
+					return Err(failure.into_error());
+				}
+				let failure = failure.into_error();
 
 				// The failed stream was dropped by the match above. Reset before waiting
 				// so a publication that ends during recovery cannot flush stale samples.
@@ -286,10 +297,6 @@ impl Supervisor {
 			}
 		}
 	}
-}
-
-fn retryable(err: &Error) -> bool {
-	matches!(err, Error::Capture(_) | Error::Device(_))
 }
 
 /// A dropped or closed track is the normal end of a publish; any other cause is
@@ -325,13 +332,12 @@ mod tests {
 		Arc,
 		atomic::{AtomicUsize, Ordering},
 	};
-
-	use tokio::sync::{mpsc, watch};
+	use std::task::Poll;
 
 	use super::*;
 
 	struct MockStream {
-		events: mpsc::UnboundedReceiver<Result<capture::Samples, Error>>,
+		events: kio::Queue<Result<capture::Samples, capture::Failure>>,
 		drops: Option<Arc<AtomicUsize>>,
 	}
 
@@ -345,6 +351,7 @@ mod tests {
 
 	enum Open {
 		Error(&'static str),
+		Fatal(&'static str),
 		Stream(MockStream),
 	}
 
@@ -357,39 +364,42 @@ mod tests {
 	impl CaptureSource for MockSource {
 		type Stream = MockStream;
 
-		async fn open(&mut self) -> Result<Self::Stream, Error> {
+		async fn open(&mut self) -> Result<Self::Stream, capture::Failure> {
 			self.attempts.fetch_add(1, Ordering::SeqCst);
 			match self.opens.pop_front() {
-				Some(Open::Error(message)) => Err(Error::Capture(message.into())),
+				Some(Open::Error(message)) => Err(capture::Failure::retry(Error::Capture(message.into()))),
+				Some(Open::Fatal(message)) => Err(capture::Failure::fatal(Error::Capture(message.into()))),
 				Some(Open::Stream(stream)) => Ok(stream),
-				None if self.fallback_error => Err(Error::Capture("still unavailable".into())),
+				None if self.fallback_error => Err(capture::Failure::retry(Error::Capture("still unavailable".into()))),
 				None => std::future::pending().await,
 			}
 		}
 
-		async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, Error> {
-			match stream.events.recv().await {
-				Some(Ok(samples)) => Ok(Some(samples)),
-				Some(Err(err)) => Err(err),
-				None => Ok(None),
+		async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, capture::Failure> {
+			match stream.events.pop().await {
+				Ok(Ok(samples)) => Ok(Some(samples)),
+				Ok(Err(err)) => Err(err),
+				Err(_) => Ok(None),
 			}
 		}
 	}
 
 	struct MockDemand {
-		rx: watch::Receiver<bool>,
+		state: kio::Consumer<bool>,
 	}
 
 	impl MockDemand {
 		async fn wait(&mut self, value: bool) -> bool {
-			loop {
-				if *self.rx.borrow() == value {
-					return true;
-				}
-				if self.rx.changed().await.is_err() {
-					return false;
-				}
-			}
+			self.state
+				.wait(|state| {
+					if **state == value {
+						Poll::Ready(())
+					} else {
+						Poll::Pending
+					}
+				})
+				.await
+				.is_ok()
 		}
 	}
 
@@ -434,9 +444,26 @@ mod tests {
 		}
 	}
 
-	fn stream(drops: Option<Arc<AtomicUsize>>) -> (mpsc::UnboundedSender<Result<capture::Samples, Error>>, MockStream) {
-		let (events, rx) = mpsc::unbounded_channel();
-		(events, MockStream { events: rx, drops })
+	fn demand(value: bool) -> (kio::Producer<bool>, MockDemand) {
+		let state = kio::Producer::new(value);
+		let demand = MockDemand { state: state.consume() };
+		(state, demand)
+	}
+
+	fn set_demand(state: &kio::Producer<bool>, value: bool) {
+		let Ok(mut state) = state.write() else {
+			panic!("demand state closed");
+		};
+		*state = value;
+	}
+
+	fn stream(drops: Option<Arc<AtomicUsize>>) -> (kio::Queue<Result<capture::Samples, capture::Failure>>, MockStream) {
+		let events = kio::Queue::new();
+		let stream = MockStream {
+			events: events.clone(),
+			drops,
+		};
+		(events, stream)
 	}
 
 	/// Poll `future` through all immediately-ready work until its next real wait.
@@ -452,8 +479,7 @@ mod tests {
 	async fn failed_reopens_back_off_to_the_cap() {
 		let mut source = source([], true);
 		let attempts = source.attempts.clone();
-		let (demand_tx, demand_rx) = watch::channel(true);
-		let mut demand = MockDemand { rx: demand_rx };
+		let (demand_tx, mut demand) = demand(true);
 		let mut output = MockOutput::default();
 		let mut supervisor = Supervisor::exact();
 		let future = supervisor.run(&mut source, &mut demand, &mut output);
@@ -479,10 +505,89 @@ mod tests {
 		assert!(matches!(err, Error::Capture(message) if message == "still unavailable"));
 	}
 
+	#[tokio::test]
+	async fn permanent_open_error_is_not_retried() {
+		let mut source = source([Open::Fatal("permission denied")], true);
+		let attempts = source.attempts.clone();
+		let (_demand_tx, mut demand) = demand(true);
+		let mut output = MockOutput::default();
+
+		let err = Supervisor::exact()
+			.run(&mut source, &mut demand, &mut output)
+			.await
+			.expect_err("permanent failure was ignored");
+
+		assert_eq!(attempts.load(Ordering::SeqCst), 1);
+		assert!(matches!(err, Error::Capture(message) if message == "permission denied"));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn empty_reopens_do_not_reset_the_backoff() {
+		let (first_tx, first) = stream(None);
+		first_tx
+			.try_push(Err(capture::Failure::retry(Error::Capture("first lost".into()))))
+			.unwrap();
+		let (second_tx, second) = stream(None);
+		second_tx
+			.try_push(Err(capture::Failure::retry(Error::Capture("second lost".into()))))
+			.unwrap();
+		let mut source = source([Open::Stream(first), Open::Stream(second)], true);
+		let attempts = source.attempts.clone();
+		let (demand_tx, mut demand) = demand(true);
+		let mut output = MockOutput::default();
+		let mut supervisor = Supervisor::exact();
+		let future = supervisor.run(&mut source, &mut demand, &mut output);
+		tokio::pin!(future);
+
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 1);
+		tokio::time::advance(Duration::from_millis(500)).await;
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+		tokio::time::advance(Duration::from_millis(999)).await;
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 2);
+		tokio::time::advance(Duration::from_millis(1)).await;
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 3);
+
+		drop(demand_tx);
+		let err = future.await.expect_err("recovery ended without its device error");
+		assert!(matches!(err, Error::Capture(message) if message == "still unavailable"));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn track_end_after_empty_reopen_returns_the_last_error() {
+		let (failed_tx, failed) = stream(None);
+		failed_tx
+			.try_push(Err(capture::Failure::retry(Error::Capture("lost".into()))))
+			.unwrap();
+		let (_recovered_tx, recovered) = stream(None);
+		let mut source = source([Open::Stream(failed), Open::Stream(recovered)], false);
+		let attempts = source.attempts.clone();
+		let (demand_tx, mut demand) = demand(true);
+		let mut output = MockOutput::default();
+		let mut supervisor = Supervisor::exact();
+		let future = supervisor.run(&mut source, &mut demand, &mut output);
+		tokio::pin!(future);
+
+		poll_pending(future.as_mut()).await;
+		tokio::time::advance(Duration::from_millis(500)).await;
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+		drop(demand_tx);
+		let err = future.await.expect_err("track end hid the pending device error");
+		assert!(matches!(err, Error::Capture(message) if message == "lost"));
+	}
+
 	#[tokio::test(start_paused = true)]
 	async fn successful_reopen_resumes_the_same_output_after_an_epoch_reset() {
 		let (failed_tx, failed) = stream(None);
-		failed_tx.send(Err(Error::Capture("lost".into()))).unwrap();
+		failed_tx
+			.try_push(Err(capture::Failure::retry(Error::Capture("lost".into()))))
+			.unwrap();
 		let (recovered_tx, recovered) = stream(None);
 		let mut source = source(
 			[
@@ -493,8 +598,7 @@ mod tests {
 			false,
 		);
 		let attempts = source.attempts.clone();
-		let (demand_tx, demand_rx) = watch::channel(true);
-		let mut demand = MockDemand { rx: demand_rx };
+		let (demand_tx, mut demand) = demand(true);
 		let mut output = MockOutput::default();
 		let mut supervisor = Supervisor::exact();
 		{
@@ -511,14 +615,14 @@ mod tests {
 			assert_eq!(attempts.load(Ordering::SeqCst), 3);
 
 			recovered_tx
-				.send(Ok(capture::Samples {
+				.try_push(Ok(capture::Samples {
 					data: vec![0.25],
 					gap: false,
 				}))
 				.unwrap();
 			poll_pending(future.as_mut()).await;
 
-			demand_tx.send(false).unwrap();
+			set_demand(&demand_tx, false);
 			poll_pending(future.as_mut()).await;
 			drop(demand_tx);
 			future.await.unwrap();
@@ -538,8 +642,7 @@ mod tests {
 	async fn demand_loss_stops_a_pending_retry() {
 		let mut source = source([Open::Error("lost")], true);
 		let attempts = source.attempts.clone();
-		let (demand_tx, demand_rx) = watch::channel(true);
-		let mut demand = MockDemand { rx: demand_rx };
+		let (demand_tx, mut demand) = demand(true);
 		let mut output = MockOutput::default();
 		let mut supervisor = Supervisor::exact();
 		let future = supervisor.run(&mut source, &mut demand, &mut output);
@@ -547,7 +650,7 @@ mod tests {
 
 		poll_pending(future.as_mut()).await;
 		assert_eq!(attempts.load(Ordering::SeqCst), 1);
-		demand_tx.send(false).unwrap();
+		set_demand(&demand_tx, false);
 		poll_pending(future.as_mut()).await;
 		tokio::time::advance(Duration::from_secs(60)).await;
 		poll_pending(future.as_mut()).await;
@@ -562,8 +665,7 @@ mod tests {
 		let drops = Arc::new(AtomicUsize::new(0));
 		let (_events, live) = stream(Some(drops.clone()));
 		let mut source = source([Open::Stream(live)], false);
-		let (_demand_tx, demand_rx) = watch::channel(true);
-		let mut demand = MockDemand { rx: demand_rx };
+		let (_demand_tx, mut demand) = demand(true);
 		let mut output = MockOutput::default();
 		let mut supervisor = Supervisor::exact();
 

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -5,9 +5,18 @@
 //! the encode-side settings from [`Options`], and the input PCM layout is read
 //! off the source rather than declared by the caller.
 
+use std::time::Duration;
+
+use rand::RngExt;
+
 use super::{Input, Options, Producer};
 use crate::capture;
 use crate::{Error, Format, Frame};
+
+/// Backoff bounds for reopening a capture source. The quick first retry covers
+/// a USB device re-enumerating; the ceiling keeps a missing device from spinning.
+const RETRY_MIN: Duration = Duration::from_millis(500);
+const RETRY_MAX: Duration = Duration::from_secs(4);
 
 /// Capture audio on demand and publish it as an encoded moq track.
 ///
@@ -18,6 +27,10 @@ use crate::{Error, Format, Frame};
 /// keeping audio aligned with a wall-clock video track. A buffer dropped because
 /// the encoder fell behind re-anchors the same way, so the loss surfaces as a
 /// skip rather than as drift.
+///
+/// If an active device fails, it is dropped and reopened behind the same track
+/// with capped jittered backoff. A default microphone is resolved again on every
+/// attempt, and recovery stops as soon as the track becomes unused.
 ///
 /// Frames are stamped from `clock`, so passing the same [`Clock`](moq_mux::Clock)
 /// to a concurrent video publish keeps the two tracks aligned. Returns when the
@@ -36,10 +49,22 @@ pub async fn publish_capture(
 		channels,
 	};
 
+	// The producer's input layout is fixed in the catalog. Re-resolve the device
+	// itself on every open, but keep asking replacements for that same layout.
+	let mut capture = capture;
+	capture.sample_rate = Some(sample_rate);
+	capture.channels = Some(channels);
+
 	let mut producer = Producer::new(&mut broadcast, catalog, input, &encode)?;
 	let track = producer.track().clone();
 
-	let result = capture_loop(&mut producer, &track, &capture, &clock).await;
+	let mut source = DeviceSource { config: &capture };
+	let mut demand = TrackDemand { track: &track };
+	let mut output = EncoderOutput {
+		producer: &mut producer,
+		clock: &clock,
+	};
+	let result = Supervisor::default().run(&mut source, &mut demand, &mut output).await;
 
 	// Best-effort clean close: flush the trailing sub-frame and finalize the
 	// track. Runs only when the loop ends on its own; a Ctrl+C cancels the future
@@ -50,64 +75,221 @@ pub async fn publish_capture(
 	result
 }
 
-/// Async capture/encode loop: open the source while a listener is subscribed,
-/// release it when the last one leaves, and re-anchor the timeline on resume so
-/// the idle gap lands in the PTS.
-///
-/// Cancel safety: every wait is a real `.await` (a buffer read or a demand
-/// transition), so dropping this future (e.g. on Ctrl+C) drops the input and
-/// stops the underlying stream. No blocking thread is left behind.
-async fn capture_loop(
-	producer: &mut Producer,
-	track: &moq_net::track::Producer,
-	config: &capture::Config,
-	clock: &moq_mux::Clock,
-) -> Result<(), Error> {
-	loop {
-		// Idle until a listener subscribes; the track ending is a clean exit.
-		if let Err(err) = track.used().await {
-			log_track_ended(err);
-			return Ok(());
+/// A capture backend as the supervisor sees it. Kept separate from cpal so the
+/// retry and cancellation lifecycle can be tested without audio hardware.
+trait CaptureSource {
+	type Stream;
+
+	async fn open(&mut self) -> Result<Self::Stream, Error>;
+	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, Error>;
+}
+
+struct DeviceSource<'a> {
+	config: &'a capture::Config,
+}
+
+impl CaptureSource for DeviceSource<'_> {
+	type Stream = capture::Stream;
+
+	async fn open(&mut self) -> Result<Self::Stream, Error> {
+		capture::open(self.config).await
+	}
+
+	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, Error> {
+		stream.read().await
+	}
+}
+
+/// Demand for the published track. `false` means the track itself ended.
+trait Demand {
+	async fn used(&mut self) -> bool;
+	async fn unused(&mut self) -> bool;
+}
+
+struct TrackDemand<'a> {
+	track: &'a moq_net::track::Producer,
+}
+
+impl Demand for TrackDemand<'_> {
+	async fn used(&mut self) -> bool {
+		match self.track.used().await {
+			Ok(()) => true,
+			Err(err) => {
+				log_track_ended(err);
+				false
+			}
 		}
+	}
 
-		let mut input = capture::open(config).await?;
+	async fn unused(&mut self) -> bool {
+		match self.track.unused().await {
+			Ok(()) => true,
+			Err(err) => {
+				log_track_ended(err);
+				false
+			}
+		}
+	}
+}
 
-		loop {
-			// Race the next buffer against the last listener leaving so we release
-			// the device promptly. `biased` checks demand first so an unwatched track
-			// stops before reading another buffer.
-			let samples = tokio::select! {
-				biased;
-				res = track.unused() => {
-					if let Err(err) = res {
-						log_track_ended(err);
-						return Ok(());
-					}
-					break; // no listeners: release the device, then wait for one
-				}
-				samples = input.read() => samples,
-			};
+/// The stable producer the supervisor writes through across device replacements.
+trait Output {
+	fn reset_epoch(&mut self);
+	fn write(&mut self, samples: capture::Samples) -> Result<(), Error>;
+}
 
-			let Some(samples) = samples else { break }; // device stopped producing samples
+struct EncoderOutput<'a> {
+	producer: &'a mut Producer,
+	clock: &'a moq_mux::Clock,
+}
 
-			// A dropped capture buffer is a real hole in the timeline. PTS advances
-			// by sample count, so writing straight across it would compress the hole
-			// out and leave audio permanently behind the video clock; re-anchor to
-			// spend it as a one-time discontinuity instead.
-			if samples.gap {
-				producer.reset_epoch();
+impl Output for EncoderOutput<'_> {
+	fn reset_epoch(&mut self) {
+		self.producer.reset_epoch();
+	}
+
+	fn write(&mut self, samples: capture::Samples) -> Result<(), Error> {
+		self.producer.write(&frame(samples.data, self.clock.micros())?)
+	}
+}
+
+struct Supervisor {
+	next: Duration,
+	jitter: fn(Duration) -> Duration,
+}
+
+impl Default for Supervisor {
+	fn default() -> Self {
+		Self {
+			next: RETRY_MIN,
+			jitter: |delay| delay.mul_f64(0.5 + rand::rng().random::<f64>() / 2.0),
+		}
+	}
+}
+
+impl Supervisor {
+	#[cfg(test)]
+	fn exact() -> Self {
+		Self {
+			next: RETRY_MIN,
+			jitter: std::convert::identity,
+		}
+	}
+
+	fn reset(&mut self) {
+		self.next = RETRY_MIN;
+	}
+
+	fn advance(&mut self) -> Duration {
+		let wait = (self.jitter)(self.next);
+		self.next = (self.next * 2).min(RETRY_MAX);
+		wait
+	}
+
+	/// Open the source while a listener is subscribed, release it when the last
+	/// one leaves, and rebuild a failed source behind the same producer.
+	///
+	/// Cancel safety: every wait is a real `.await` (a buffer read or a demand
+	/// transition), so dropping this future (e.g. on Ctrl+C) drops the input and
+	/// stops the underlying stream. No blocking thread is left behind.
+	async fn run<S, D, O>(&mut self, source: &mut S, demand: &mut D, output: &mut O) -> Result<(), Error>
+	where
+		S: CaptureSource,
+		D: Demand,
+		O: Output,
+	{
+		'demand: loop {
+			// Idle until a listener subscribes; the track ending is a clean exit.
+			if !demand.used().await {
+				return Ok(());
 			}
 
-			// Stamp from the shared clock (including any idle gap) so the producer's
-			// epoch re-anchors and audio stays aligned with the video track.
-			producer.write(&frame(samples.data, clock.micros())?)?;
-		}
+			let mut last_error = None;
+			self.reset();
 
-		// Release the device and re-anchor so the next frame after resume reflects the gap.
-		drop(input);
-		producer.reset_epoch();
-		tracing::info!("no listeners: released audio capture");
+			loop {
+				// Opening waits for the first buffer, so race it against demand too. A
+				// cancelled open drops the half-built stream and its callback closures.
+				let opened = tokio::select! {
+					biased;
+					unused = demand.unused() => {
+						if !unused {
+							return match last_error {
+								Some(err) => Err(err),
+								None => Ok(()),
+							};
+						}
+						continue 'demand;
+					}
+					opened = source.open() => opened,
+				};
+
+				let failure = match opened {
+					Ok(mut input) => {
+						let recovered = last_error.take().is_some();
+						self.reset();
+						if recovered {
+							tracing::info!("audio capture recovered");
+						}
+
+						loop {
+							// Demand wins over a simultaneous buffer or error, so an unused
+							// track releases the device without starting a retry sequence.
+							let samples = tokio::select! {
+								biased;
+								unused = demand.unused() => {
+									drop(input);
+									output.reset_epoch();
+									if !unused {
+										return Ok(());
+									}
+									tracing::info!("no listeners: released audio capture");
+									continue 'demand;
+								}
+								samples = source.read(&mut input) => samples,
+							};
+
+							match samples {
+								Ok(Some(samples)) => {
+									// A bounded-queue drop is a real hole in the timeline.
+									if samples.gap {
+										output.reset_epoch();
+									}
+									output.write(samples)?;
+								}
+								Ok(None) => break Error::Capture("audio capture stream stopped".into()),
+								Err(err) => break err,
+							}
+						}
+					}
+					Err(err) if retryable(&err) => err,
+					Err(err) => return Err(err),
+				};
+
+				// The failed stream was dropped by the match above. Reset before waiting
+				// so a publication that ends during recovery cannot flush stale samples.
+				output.reset_epoch();
+				tracing::warn!(error = %failure, "audio capture unavailable");
+				last_error = Some(failure);
+
+				let wait = self.advance();
+				tokio::select! {
+					biased;
+					unused = demand.unused() => {
+						if !unused {
+							return Err(last_error.expect("a failed capture has an error"));
+						}
+						continue 'demand;
+					}
+					_ = tokio::time::sleep(wait) => {}
+				}
+			}
+		}
 	}
+}
+
+fn retryable(err: &Error) -> bool {
+	matches!(err, Error::Capture(_) | Error::Device(_))
 }
 
 /// A dropped or closed track is the normal end of a publish; any other cause is
@@ -132,4 +314,266 @@ fn frame(samples: Vec<f32>, timestamp_us: u64) -> Result<Frame, Error> {
 		timestamp: moq_net::Timestamp::from_micros(timestamp_us)?,
 		data: bytes.into(),
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::VecDeque;
+	use std::future::Future;
+	use std::pin::Pin;
+	use std::sync::{
+		Arc,
+		atomic::{AtomicUsize, Ordering},
+	};
+
+	use tokio::sync::{mpsc, watch};
+
+	use super::*;
+
+	struct MockStream {
+		events: mpsc::UnboundedReceiver<Result<capture::Samples, Error>>,
+		drops: Option<Arc<AtomicUsize>>,
+	}
+
+	impl Drop for MockStream {
+		fn drop(&mut self) {
+			if let Some(drops) = &self.drops {
+				drops.fetch_add(1, Ordering::SeqCst);
+			}
+		}
+	}
+
+	enum Open {
+		Error(&'static str),
+		Stream(MockStream),
+	}
+
+	struct MockSource {
+		opens: VecDeque<Open>,
+		attempts: Arc<AtomicUsize>,
+		fallback_error: bool,
+	}
+
+	impl CaptureSource for MockSource {
+		type Stream = MockStream;
+
+		async fn open(&mut self) -> Result<Self::Stream, Error> {
+			self.attempts.fetch_add(1, Ordering::SeqCst);
+			match self.opens.pop_front() {
+				Some(Open::Error(message)) => Err(Error::Capture(message.into())),
+				Some(Open::Stream(stream)) => Ok(stream),
+				None if self.fallback_error => Err(Error::Capture("still unavailable".into())),
+				None => std::future::pending().await,
+			}
+		}
+
+		async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, Error> {
+			match stream.events.recv().await {
+				Some(Ok(samples)) => Ok(Some(samples)),
+				Some(Err(err)) => Err(err),
+				None => Ok(None),
+			}
+		}
+	}
+
+	struct MockDemand {
+		rx: watch::Receiver<bool>,
+	}
+
+	impl MockDemand {
+		async fn wait(&mut self, value: bool) -> bool {
+			loop {
+				if *self.rx.borrow() == value {
+					return true;
+				}
+				if self.rx.changed().await.is_err() {
+					return false;
+				}
+			}
+		}
+	}
+
+	impl Demand for MockDemand {
+		async fn used(&mut self) -> bool {
+			self.wait(true).await
+		}
+
+		async fn unused(&mut self) -> bool {
+			self.wait(false).await
+		}
+	}
+
+	#[derive(Debug, PartialEq, Eq)]
+	enum OutputEvent {
+		Reset,
+		Write(Vec<u32>),
+	}
+
+	#[derive(Default)]
+	struct MockOutput {
+		events: Vec<OutputEvent>,
+	}
+
+	impl Output for MockOutput {
+		fn reset_epoch(&mut self) {
+			self.events.push(OutputEvent::Reset);
+		}
+
+		fn write(&mut self, samples: capture::Samples) -> Result<(), Error> {
+			self.events
+				.push(OutputEvent::Write(samples.data.into_iter().map(f32::to_bits).collect()));
+			Ok(())
+		}
+	}
+
+	fn source(opens: impl IntoIterator<Item = Open>, fallback_error: bool) -> MockSource {
+		MockSource {
+			opens: opens.into_iter().collect(),
+			attempts: Arc::new(AtomicUsize::new(0)),
+			fallback_error,
+		}
+	}
+
+	fn stream(drops: Option<Arc<AtomicUsize>>) -> (mpsc::UnboundedSender<Result<capture::Samples, Error>>, MockStream) {
+		let (events, rx) = mpsc::unbounded_channel();
+		(events, MockStream { events: rx, drops })
+	}
+
+	/// Poll `future` through all immediately-ready work until its next real wait.
+	async fn poll_pending<F: Future>(future: Pin<&mut F>) {
+		tokio::select! {
+			biased;
+			_ = future => panic!("capture supervisor ended unexpectedly"),
+			_ = tokio::task::yield_now() => {}
+		}
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn failed_reopens_back_off_to_the_cap() {
+		let mut source = source([], true);
+		let attempts = source.attempts.clone();
+		let (demand_tx, demand_rx) = watch::channel(true);
+		let mut demand = MockDemand { rx: demand_rx };
+		let mut output = MockOutput::default();
+		let mut supervisor = Supervisor::exact();
+		let future = supervisor.run(&mut source, &mut demand, &mut output);
+		tokio::pin!(future);
+
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+		for (wait, expected) in [
+			(Duration::from_millis(500), 2),
+			(Duration::from_secs(1), 3),
+			(Duration::from_secs(2), 4),
+			(Duration::from_secs(4), 5),
+			(Duration::from_secs(4), 6),
+		] {
+			tokio::time::advance(wait).await;
+			poll_pending(future.as_mut()).await;
+			assert_eq!(attempts.load(Ordering::SeqCst), expected);
+		}
+
+		drop(demand_tx);
+		let err = future.await.expect_err("recovery ended without its device error");
+		assert!(matches!(err, Error::Capture(message) if message == "still unavailable"));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn successful_reopen_resumes_the_same_output_after_an_epoch_reset() {
+		let (failed_tx, failed) = stream(None);
+		failed_tx.send(Err(Error::Capture("lost".into()))).unwrap();
+		let (recovered_tx, recovered) = stream(None);
+		let mut source = source(
+			[
+				Open::Stream(failed),
+				Open::Error("reopen failed"),
+				Open::Stream(recovered),
+			],
+			false,
+		);
+		let attempts = source.attempts.clone();
+		let (demand_tx, demand_rx) = watch::channel(true);
+		let mut demand = MockDemand { rx: demand_rx };
+		let mut output = MockOutput::default();
+		let mut supervisor = Supervisor::exact();
+		{
+			let future = supervisor.run(&mut source, &mut demand, &mut output);
+			tokio::pin!(future);
+
+			poll_pending(future.as_mut()).await;
+			assert_eq!(attempts.load(Ordering::SeqCst), 1);
+			tokio::time::advance(Duration::from_millis(500)).await;
+			poll_pending(future.as_mut()).await;
+			assert_eq!(attempts.load(Ordering::SeqCst), 2);
+			tokio::time::advance(Duration::from_secs(1)).await;
+			poll_pending(future.as_mut()).await;
+			assert_eq!(attempts.load(Ordering::SeqCst), 3);
+
+			recovered_tx
+				.send(Ok(capture::Samples {
+					data: vec![0.25],
+					gap: false,
+				}))
+				.unwrap();
+			poll_pending(future.as_mut()).await;
+
+			demand_tx.send(false).unwrap();
+			poll_pending(future.as_mut()).await;
+			drop(demand_tx);
+			future.await.unwrap();
+		}
+		assert_eq!(
+			output.events,
+			[
+				OutputEvent::Reset,
+				OutputEvent::Reset,
+				OutputEvent::Write(vec![0.25f32.to_bits()]),
+				OutputEvent::Reset,
+			]
+		);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn demand_loss_stops_a_pending_retry() {
+		let mut source = source([Open::Error("lost")], true);
+		let attempts = source.attempts.clone();
+		let (demand_tx, demand_rx) = watch::channel(true);
+		let mut demand = MockDemand { rx: demand_rx };
+		let mut output = MockOutput::default();
+		let mut supervisor = Supervisor::exact();
+		let future = supervisor.run(&mut source, &mut demand, &mut output);
+		tokio::pin!(future);
+
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 1);
+		demand_tx.send(false).unwrap();
+		poll_pending(future.as_mut()).await;
+		tokio::time::advance(Duration::from_secs(60)).await;
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+		drop(demand_tx);
+		future.await.unwrap();
+	}
+
+	#[tokio::test]
+	async fn cancellation_drops_the_live_stream() {
+		let drops = Arc::new(AtomicUsize::new(0));
+		let (_events, live) = stream(Some(drops.clone()));
+		let mut source = source([Open::Stream(live)], false);
+		let (_demand_tx, demand_rx) = watch::channel(true);
+		let mut demand = MockDemand { rx: demand_rx };
+		let mut output = MockOutput::default();
+		let mut supervisor = Supervisor::exact();
+
+		{
+			let future = supervisor.run(&mut source, &mut demand, &mut output);
+			tokio::pin!(future);
+			poll_pending(future.as_mut()).await;
+			assert_eq!(drops.load(Ordering::SeqCst), 0);
+		}
+
+		assert_eq!(drops.load(Ordering::SeqCst), 1);
+	}
 }

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -11,6 +11,7 @@ use rand::RngExt;
 
 use super::{Input, Options, Producer};
 use crate::capture;
+use crate::resample::{Resampler, remix, validate_channels};
 use crate::{Error, Format, Frame};
 
 /// Backoff bounds for reopening a capture source. The quick first retry covers
@@ -30,7 +31,8 @@ const RETRY_MAX: Duration = Duration::from_secs(4);
 ///
 /// If an active device fails, it is dropped and reopened behind the same track
 /// with capped jittered backoff. A default microphone is resolved again on every
-/// attempt, and recovery stops as soon as the track becomes unused.
+/// attempt, and each replacement's native layout is converted to the layout
+/// already registered in the catalog. Recovery stops as soon as the track becomes unused.
 /// Transient failures during initial format discovery use the same retry policy
 /// before the catalog track is registered.
 ///
@@ -45,18 +47,12 @@ pub async fn publish_capture(
 	clock: moq_mux::Clock,
 ) -> Result<(), Error> {
 	let mut supervisor = Supervisor::default();
-	let (sample_rate, channels) = supervisor.discover(&mut DeviceSource { config: &capture }).await?;
+	let layout = supervisor.discover(&mut DeviceSource { config: &capture }).await?;
 	let input = Input {
 		format: Format::F32,
-		sample_rate,
-		channels,
+		sample_rate: layout.sample_rate,
+		channels: layout.channels,
 	};
-
-	// The producer's input layout is fixed in the catalog. Re-resolve the device
-	// itself on every open, but keep asking replacements for that same layout.
-	let mut capture = capture;
-	capture.sample_rate = Some(sample_rate);
-	capture.channels = Some(channels);
 
 	let mut producer = Producer::new(&mut broadcast, catalog, input, &encode)?;
 	let track = producer.track().clone();
@@ -83,8 +79,9 @@ pub async fn publish_capture(
 trait CaptureSource {
 	type Stream;
 
-	async fn format(&mut self) -> Result<(u32, u32), capture::Failure>;
+	async fn format(&mut self) -> Result<capture::Layout, capture::Failure>;
 	async fn open(&mut self) -> Result<Self::Stream, capture::Failure>;
+	fn layout(&self, stream: &Self::Stream) -> capture::Layout;
 	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, capture::Failure>;
 }
 
@@ -95,12 +92,16 @@ struct DeviceSource<'a> {
 impl CaptureSource for DeviceSource<'_> {
 	type Stream = capture::Stream;
 
-	async fn format(&mut self) -> Result<(u32, u32), capture::Failure> {
+	async fn format(&mut self) -> Result<capture::Layout, capture::Failure> {
 		capture::format(self.config).await
 	}
 
 	async fn open(&mut self) -> Result<Self::Stream, capture::Failure> {
 		capture::open(self.config).await
+	}
+
+	fn layout(&self, stream: &Self::Stream) -> capture::Layout {
+		stream.layout()
 	}
 
 	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, capture::Failure> {
@@ -143,7 +144,8 @@ impl Demand for TrackDemand<'_> {
 /// The stable producer the supervisor writes through across device replacements.
 trait Output {
 	fn reset_epoch(&mut self);
-	fn write(&mut self, samples: capture::Samples) -> Result<(), Error>;
+	fn now(&self) -> u64;
+	fn write(&mut self, samples: capture::Samples, timestamp_us: u64) -> Result<(), Error>;
 }
 
 struct EncoderOutput<'a> {
@@ -156,14 +158,93 @@ impl Output for EncoderOutput<'_> {
 		self.producer.reset_epoch();
 	}
 
-	fn write(&mut self, samples: capture::Samples) -> Result<(), Error> {
-		self.producer.write(&frame(samples.data, self.clock.micros())?)
+	fn now(&self) -> u64 {
+		self.clock.micros()
+	}
+
+	fn write(&mut self, samples: capture::Samples, timestamp_us: u64) -> Result<(), Error> {
+		self.producer.write(&frame(samples.data, timestamp_us)?)
+	}
+}
+
+/// Converts one opened stream's native layout into the producer's fixed input
+/// layout. A new instance per open keeps filter state out of recovery gaps.
+struct Converter {
+	input: capture::Layout,
+	output: capture::Layout,
+	resampler: Option<Resampler>,
+	anchor_us: Option<u64>,
+}
+
+impl Converter {
+	fn new(input: capture::Layout, output: capture::Layout) -> Result<Self, Error> {
+		if input.channels != output.channels {
+			validate_channels(input.channels)?;
+			validate_channels(output.channels)?;
+		}
+
+		let resampler = if input.sample_rate == output.sample_rate {
+			None
+		} else {
+			// Ten milliseconds bounds recovery buffering while giving rubato a
+			// useful window independent of the device callback size.
+			let chunk_frames = (input.sample_rate as usize / 100).max(1);
+			Some(Resampler::new(
+				input.sample_rate,
+				output.sample_rate,
+				input.channels,
+				chunk_frames,
+			)?)
+		};
+
+		Ok(Self {
+			input,
+			output,
+			resampler,
+			anchor_us: None,
+		})
+	}
+
+	fn reset(&mut self) {
+		if let Some(resampler) = self.resampler.as_mut() {
+			resampler.reset();
+		}
+		self.anchor_us = None;
+	}
+
+	/// Return converted samples plus the timestamp of the first input buffered
+	/// into them. The timestamp preserves the epoch when resampling spans reads.
+	fn process(
+		&mut self,
+		mut samples: capture::Samples,
+		timestamp_us: u64,
+	) -> Result<Option<(capture::Samples, u64)>, Error> {
+		if samples.gap {
+			self.reset();
+		}
+		if self.anchor_us.is_none() && !samples.data.is_empty() {
+			self.anchor_us = Some(timestamp_us);
+		}
+
+		samples.data = match self.resampler.as_mut() {
+			Some(resampler) => resampler.process(&samples.data)?,
+			None => samples.data,
+		};
+		if self.input.channels != self.output.channels {
+			samples.data = remix(&samples.data, self.input.channels, self.output.channels)?;
+		}
+		if samples.data.is_empty() {
+			return Ok(None);
+		}
+
+		Ok(Some((samples, self.anchor_us.take().unwrap_or(timestamp_us))))
 	}
 }
 
 struct Supervisor {
 	next: Duration,
 	jitter: fn(Duration) -> Duration,
+	layout: Option<capture::Layout>,
 }
 
 impl Default for Supervisor {
@@ -171,6 +252,7 @@ impl Default for Supervisor {
 		Self {
 			next: RETRY_MIN,
 			jitter: |delay| delay.mul_f64(0.5 + rand::rng().random::<f64>() / 2.0),
+			layout: None,
 		}
 	}
 }
@@ -181,6 +263,10 @@ impl Supervisor {
 		Self {
 			next: RETRY_MIN,
 			jitter: std::convert::identity,
+			layout: Some(capture::Layout {
+				sample_rate: 48_000,
+				channels: 2,
+			}),
 		}
 	}
 
@@ -196,11 +282,12 @@ impl Supervisor {
 
 	/// Discover the source format, retrying failures that can clear when the
 	/// device or host state changes.
-	async fn discover<S: CaptureSource>(&mut self, source: &mut S) -> Result<(u32, u32), Error> {
+	async fn discover<S: CaptureSource>(&mut self, source: &mut S) -> Result<capture::Layout, Error> {
 		loop {
 			let failure = match source.format().await {
 				Ok(format) => {
 					self.reset();
+					self.layout = Some(format);
 					return Ok(format);
 				}
 				Err(failure) if failure.is_retryable() => failure.into_error(),
@@ -224,6 +311,7 @@ impl Supervisor {
 		D: Demand,
 		O: Output,
 	{
+		let output_layout = self.layout.expect("capture format must be discovered before running");
 		'demand: loop {
 			// Idle until a listener subscribes; the track ending is a clean exit.
 			if !demand.used().await {
@@ -252,6 +340,7 @@ impl Supervisor {
 
 				let failure = match opened {
 					Ok(mut input) => {
+						let mut converter = Converter::new(source.layout(&input), output_layout)?;
 						loop {
 							// Demand wins over a simultaneous buffer or error, so an unused
 							// track releases the device without starting a retry sequence.
@@ -285,7 +374,9 @@ impl Supervisor {
 									if samples.gap {
 										output.reset_epoch();
 									}
-									output.write(samples)?;
+									if let Some((samples, timestamp_us)) = converter.process(samples, output.now())? {
+										output.write(samples, timestamp_us)?;
+									}
 								}
 								Ok(None) => {
 									break capture::Failure::retry(Error::Capture(
@@ -365,6 +456,7 @@ mod tests {
 	struct MockStream {
 		events: kio::Queue<Result<capture::Samples, capture::Failure>>,
 		drops: Option<Arc<AtomicUsize>>,
+		layout: capture::Layout,
 	}
 
 	impl Drop for MockStream {
@@ -398,12 +490,12 @@ mod tests {
 	impl CaptureSource for MockSource {
 		type Stream = MockStream;
 
-		async fn format(&mut self) -> Result<(u32, u32), capture::Failure> {
+		async fn format(&mut self) -> Result<capture::Layout, capture::Failure> {
 			self.format_attempts.fetch_add(1, Ordering::SeqCst);
 			match self.formats.pop_front() {
 				Some(Discovery::Error(message)) => Err(capture::Failure::retry(Error::Capture(message.into()))),
 				Some(Discovery::Fatal(message)) => Err(capture::Failure::fatal(Error::Capture(message.into()))),
-				Some(Discovery::Format(sample_rate, channels)) => Ok((sample_rate, channels)),
+				Some(Discovery::Format(sample_rate, channels)) => Ok(capture::Layout { sample_rate, channels }),
 				None => std::future::pending().await,
 			}
 		}
@@ -417,6 +509,10 @@ mod tests {
 				None if self.fallback_error => Err(capture::Failure::retry(Error::Capture("still unavailable".into()))),
 				None => std::future::pending().await,
 			}
+		}
+
+		fn layout(&self, stream: &Self::Stream) -> capture::Layout {
+			stream.layout
 		}
 
 		async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, capture::Failure> {
@@ -473,7 +569,11 @@ mod tests {
 			self.events.push(OutputEvent::Reset);
 		}
 
-		fn write(&mut self, samples: capture::Samples) -> Result<(), Error> {
+		fn now(&self) -> u64 {
+			0
+		}
+
+		fn write(&mut self, samples: capture::Samples, _timestamp_us: u64) -> Result<(), Error> {
 			self.events
 				.push(OutputEvent::Write(samples.data.into_iter().map(f32::to_bits).collect()));
 			Ok(())
@@ -508,7 +608,13 @@ mod tests {
 		assert_eq!(attempts.load(Ordering::SeqCst), 1);
 		tokio::time::advance(Duration::from_millis(500)).await;
 
-		assert_eq!(future.await.unwrap(), (48_000, 2));
+		assert_eq!(
+			future.await.unwrap(),
+			capture::Layout {
+				sample_rate: 48_000,
+				channels: 2,
+			}
+		);
 		assert_eq!(attempts.load(Ordering::SeqCst), 2);
 	}
 
@@ -545,8 +651,17 @@ mod tests {
 		let stream = MockStream {
 			events: events.clone(),
 			drops,
+			layout: capture::Layout {
+				sample_rate: 48_000,
+				channels: 2,
+			},
 		};
 		(events, stream)
+	}
+
+	fn with_layout(mut stream: MockStream, sample_rate: u32, channels: u32) -> MockStream {
+		stream.layout = capture::Layout { sample_rate, channels };
+		stream
 	}
 
 	/// Poll `future` through all immediately-ready work until its next real wait.
@@ -716,6 +831,56 @@ mod tests {
 				OutputEvent::Reset,
 				OutputEvent::Reset,
 				OutputEvent::Write(vec![0.25f32.to_bits()]),
+				OutputEvent::Reset,
+			]
+		);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn replacement_device_is_converted_to_the_catalog_layout() {
+		let (failed_tx, failed) = stream(None);
+		let failed = with_layout(failed, 48_000, 1);
+		failed_tx
+			.try_push(Err(capture::Failure::retry(Error::Capture("lost".into()))))
+			.unwrap();
+		let (recovered_tx, recovered) = stream(None);
+		let recovered = with_layout(recovered, 48_000, 2);
+		let mut source = source([Open::Stream(failed), Open::Stream(recovered)], false);
+		let (demand_tx, mut demand) = demand(true);
+		let mut output = MockOutput::default();
+		let mut supervisor = Supervisor::exact();
+		supervisor.layout = Some(capture::Layout {
+			sample_rate: 48_000,
+			channels: 1,
+		});
+
+		{
+			let future = supervisor.run(&mut source, &mut demand, &mut output);
+			tokio::pin!(future);
+
+			poll_pending(future.as_mut()).await;
+			tokio::time::advance(RETRY_MIN).await;
+			poll_pending(future.as_mut()).await;
+
+			recovered_tx
+				.try_push(Ok(capture::Samples {
+					data: vec![1.0, 3.0, 2.0, 4.0],
+					gap: false,
+				}))
+				.unwrap();
+			poll_pending(future.as_mut()).await;
+
+			set_demand(&demand_tx, false);
+			poll_pending(future.as_mut()).await;
+			drop(demand_tx);
+			future.await.unwrap();
+		}
+
+		assert_eq!(
+			output.events,
+			[
+				OutputEvent::Reset,
+				OutputEvent::Write(vec![2.0f32.to_bits(), 3.0f32.to_bits()]),
 				OutputEvent::Reset,
 			]
 		);

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -31,6 +31,8 @@ const RETRY_MAX: Duration = Duration::from_secs(4);
 /// If an active device fails, it is dropped and reopened behind the same track
 /// with capped jittered backoff. A default microphone is resolved again on every
 /// attempt, and recovery stops as soon as the track becomes unused.
+/// Transient failures during initial format discovery use the same retry policy
+/// before the catalog track is registered.
 ///
 /// Frames are stamped from `clock`, so passing the same [`Clock`](moq_mux::Clock)
 /// to a concurrent video publish keeps the two tracks aligned. Returns when the
@@ -42,7 +44,8 @@ pub async fn publish_capture(
 	encode: Options,
 	clock: moq_mux::Clock,
 ) -> Result<(), Error> {
-	let (sample_rate, channels) = capture::format(&capture).await?;
+	let mut supervisor = Supervisor::default();
+	let (sample_rate, channels) = supervisor.discover(&mut DeviceSource { config: &capture }).await?;
 	let input = Input {
 		format: Format::F32,
 		sample_rate,
@@ -64,7 +67,7 @@ pub async fn publish_capture(
 		producer: &mut producer,
 		clock: &clock,
 	};
-	let result = Supervisor::default().run(&mut source, &mut demand, &mut output).await;
+	let result = supervisor.run(&mut source, &mut demand, &mut output).await;
 
 	// Best-effort clean close: flush the trailing sub-frame and finalize the
 	// track. Runs only when the loop ends on its own; a Ctrl+C cancels the future
@@ -80,6 +83,7 @@ pub async fn publish_capture(
 trait CaptureSource {
 	type Stream;
 
+	async fn format(&mut self) -> Result<(u32, u32), capture::Failure>;
 	async fn open(&mut self) -> Result<Self::Stream, capture::Failure>;
 	async fn read(&mut self, stream: &mut Self::Stream) -> Result<Option<capture::Samples>, capture::Failure>;
 }
@@ -90,6 +94,10 @@ struct DeviceSource<'a> {
 
 impl CaptureSource for DeviceSource<'_> {
 	type Stream = capture::Stream;
+
+	async fn format(&mut self) -> Result<(u32, u32), capture::Failure> {
+		capture::format(self.config).await
+	}
 
 	async fn open(&mut self) -> Result<Self::Stream, capture::Failure> {
 		capture::open(self.config).await
@@ -184,6 +192,24 @@ impl Supervisor {
 		let wait = (self.jitter)(self.next);
 		self.next = (self.next * 2).min(RETRY_MAX);
 		wait
+	}
+
+	/// Discover the source format, retrying failures that can clear when the
+	/// device or host state changes.
+	async fn discover<S: CaptureSource>(&mut self, source: &mut S) -> Result<(u32, u32), Error> {
+		loop {
+			let failure = match source.format().await {
+				Ok(format) => {
+					self.reset();
+					return Ok(format);
+				}
+				Err(failure) if failure.is_retryable() => failure.into_error(),
+				Err(failure) => return Err(failure.into_error()),
+			};
+
+			tracing::warn!(error = %failure, "audio capture format unavailable");
+			tokio::time::sleep(self.advance()).await;
+		}
 	}
 
 	/// Open the source while a listener is subscribed, release it when the last
@@ -355,7 +381,15 @@ mod tests {
 		Stream(MockStream),
 	}
 
+	enum Discovery {
+		Error(&'static str),
+		Fatal(&'static str),
+		Format(u32, u32),
+	}
+
 	struct MockSource {
+		formats: VecDeque<Discovery>,
+		format_attempts: Arc<AtomicUsize>,
 		opens: VecDeque<Open>,
 		attempts: Arc<AtomicUsize>,
 		fallback_error: bool,
@@ -363,6 +397,16 @@ mod tests {
 
 	impl CaptureSource for MockSource {
 		type Stream = MockStream;
+
+		async fn format(&mut self) -> Result<(u32, u32), capture::Failure> {
+			self.format_attempts.fetch_add(1, Ordering::SeqCst);
+			match self.formats.pop_front() {
+				Some(Discovery::Error(message)) => Err(capture::Failure::retry(Error::Capture(message.into()))),
+				Some(Discovery::Fatal(message)) => Err(capture::Failure::fatal(Error::Capture(message.into()))),
+				Some(Discovery::Format(sample_rate, channels)) => Ok((sample_rate, channels)),
+				None => std::future::pending().await,
+			}
+		}
 
 		async fn open(&mut self) -> Result<Self::Stream, capture::Failure> {
 			self.attempts.fetch_add(1, Ordering::SeqCst);
@@ -438,10 +482,49 @@ mod tests {
 
 	fn source(opens: impl IntoIterator<Item = Open>, fallback_error: bool) -> MockSource {
 		MockSource {
+			formats: [Discovery::Format(48_000, 2)].into_iter().collect(),
+			format_attempts: Arc::new(AtomicUsize::new(0)),
 			opens: opens.into_iter().collect(),
 			attempts: Arc::new(AtomicUsize::new(0)),
 			fallback_error,
 		}
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn initial_discovery_retries_a_missing_device() {
+		let mut source = source([], false);
+		source.formats = [
+			Discovery::Error("no default input device"),
+			Discovery::Format(48_000, 2),
+		]
+		.into_iter()
+		.collect();
+		let attempts = source.format_attempts.clone();
+		let mut supervisor = Supervisor::exact();
+		let future = supervisor.discover(&mut source);
+		tokio::pin!(future);
+
+		poll_pending(future.as_mut()).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 1);
+		tokio::time::advance(Duration::from_millis(500)).await;
+
+		assert_eq!(future.await.unwrap(), (48_000, 2));
+		assert_eq!(attempts.load(Ordering::SeqCst), 2);
+	}
+
+	#[tokio::test]
+	async fn initial_discovery_returns_a_permanent_failure() {
+		let mut source = source([], false);
+		source.formats = [Discovery::Fatal("permission denied")].into_iter().collect();
+		let attempts = source.format_attempts.clone();
+
+		let err = Supervisor::exact()
+			.discover(&mut source)
+			.await
+			.expect_err("permanent discovery failure was ignored");
+
+		assert_eq!(attempts.load(Ordering::SeqCst), 1);
+		assert!(matches!(err, Error::Capture(message) if message == "permission denied"));
 	}
 
 	fn demand(value: bool) -> (kio::Producer<bool>, MockDemand) {


### PR DESCRIPTION
## Summary

- Deliver terminal CPAL stream errors to the capture loop so a failed microphone is reopened.
- Retry only explicit device, host, and resource failures. Return permission, configuration, unsupported-format, first-buffer timeout, and opaque backend errors immediately.
- Preserve retryable failures during initial format discovery, so publishing can recover when a microphone appears after startup.
- Keep exponential backoff active until a replacement stream produces audio, and preserve the last device error if the track ends during recovery.
- Re-resolve an unpinned default device on every open and convert each replacement's native layout to the fixed catalog layout.
- Isolate stream generations so a late error from an old stream cannot interrupt its replacement.
- Use `kio` for capture error signaling, demand state, and supervisor test streams.
- Add hardware-independent regression coverage for discovery, fatal errors, retry backoff, replacement layouts, stale stream generations, pending-buffer priority, and track termination during recovery.

## Root cause

The capture loop listened only for audio buffers. CPAL delivers terminal device failures through a separate error callback, so an unplugged or otherwise failed microphone could leave the capture task waiting forever. Treating every callback error, including CPAL's opaque `BackendError`, as retryable would also loop forever on permanent failures. Initial format discovery discarded retry classification before the supervisor started, so a temporarily missing microphone failed immediately instead of joining the same recovery sequence. Resetting backoff when a stream merely opened allowed a replacement that never produced audio to flap at the minimum delay. Finally, pinning the first device's native sample rate and channel count onto every reopen prevented a different default device from negotiating its own supported layout.

## Public API changes

None. Recovery classification, stream layouts, and conversion remain internal to `moq-audio`.

## Test plan

- `just fix`
- `just check`
- `just test` (3,291 passed, 1 skipped)
- `cargo test --locked -p moq-audio --features capture` (87 passed)

The macOS-only permission and system-audio paths were reviewed but not compiled locally. `just rs macos` requires a macOS host.

Cross-package sync is not needed because this changes neither the public API nor the wire format.

Closes #3163.

(written by GPT-5.6)
