### PR TITLE
fix(uring): cancel staged receives on worker drop

### DIFF
--- a/rs/moq-uring/src/shared.rs
+++ b/rs/moq-uring/src/shared.rs
@@ -10,8 +10,9 @@ use std::collections::VecDeque;
 use std::io;
 use std::rc::Rc;
 use std::task::Poll;
+use std::time::Instant;
 
-use io_uring::{IoUring, squeue};
+use io_uring::{IoUring, opcode, squeue};
 
 use crate::park::Unpark;
 use crate::{timer, udp};
@@ -76,8 +77,23 @@ impl Shared {
 
 	/// Stage one SQE, submitting inline to make room when the queue is full.
 	pub fn push(&self, entry: &squeue::Entry) -> io::Result<()> {
+		self.push_inner(entry, None)
+	}
+
+	/// Stage one SQE before `deadline`, submitting inline to make room.
+	fn push_until(&self, entry: &squeue::Entry, deadline: Instant) -> io::Result<()> {
+		self.push_inner(entry, Some(deadline))
+	}
+
+	fn push_inner(&self, entry: &squeue::Entry, deadline: Option<Instant>) -> io::Result<()> {
 		let mut ring = self.ring.borrow_mut();
 		loop {
+			if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+				return Err(io::Error::new(
+					io::ErrorKind::TimedOut,
+					"io_uring submission deadline elapsed",
+				));
+			}
 			{
 				let mut sq = ring.submission();
 				// SAFETY: every entry's referenced memory (headers, buffers,
@@ -88,6 +104,11 @@ impl Shared {
 				}
 			}
 			if let Err(err) = ring.submit() {
+				// A deadline-bounded teardown can safely retry an interrupted
+				// enter; ordinary callers surface it to their worker.
+				if deadline.is_some() && err.raw_os_error() == Some(libc::EINTR) {
+					continue;
+				}
 				// EBUSY: the CQ is full, the kernel could not flush its
 				// overflow backlog into it, and it consumed none of our SQEs.
 				// Only kernels before 5.13 report this (newer ones just grow
@@ -114,6 +135,30 @@ impl Shared {
 				}
 			}
 		}
+	}
+
+	/// Stage a cancellation after the operation it targets.
+	pub fn cancel(&self, target: u64) -> io::Result<()> {
+		self.cancel_inner(target, None)
+	}
+
+	/// Stage a cancellation after its target before `deadline`.
+	pub fn cancel_until(&self, target: u64, deadline: Instant) -> io::Result<()> {
+		self.cancel_inner(target, Some(deadline))
+	}
+
+	fn cancel_inner(&self, target: u64, deadline: Option<Instant>) -> io::Result<()> {
+		let key = self.insert(Op::Cancel);
+		let entry = opcode::AsyncCancel::new(target).build().user_data(key);
+		let result = match deadline {
+			Some(deadline) => self.push_until(&entry, deadline),
+			None => self.push(&entry),
+		};
+		if let Err(err) = result {
+			self.ops.borrow_mut().remove(key as usize);
+			return Err(err);
+		}
+		Ok(())
 	}
 
 	/// Insert an op and return its `user_data` key.

--- a/rs/moq-uring/src/udp.rs
+++ b/rs/moq-uring/src/udp.rs
@@ -601,11 +601,7 @@ impl Drop for Socket {
 			drop(rx);
 			// Fire-and-forget: the cancel's own CQE is consumed by the worker,
 			// and the receive's terminal CQE releases the socket state.
-			let cancel_key = shared.insert(Op::Cancel);
-			let entry = opcode::AsyncCancel::new(key).build().user_data(cancel_key);
-			if shared.push(&entry).is_err() {
-				shared.ops.borrow_mut().remove(cancel_key as usize);
-			}
+			let _ = shared.cancel(key);
 		}
 	}
 }

--- a/rs/moq-uring/src/udp.rs
+++ b/rs/moq-uring/src/udp.rs
@@ -386,6 +386,12 @@ pub struct Socket {
 }
 
 impl Socket {
+	/// A test-only observer for whether every kernel operation released this socket.
+	#[cfg(test)]
+	pub(crate) fn downgrade(&self) -> Weak<SockShared> {
+		Rc::downgrade(&self.shared)
+	}
+
 	pub(crate) fn bind(shared: &Rc<Shared>, io: UdpSocket, config: Config) -> Result<Self, Error> {
 		let floor = if config.gro { MAX_RECV + RECV_OVERHEAD } else { 2048 };
 		if config.rx_buffer_len < floor || config.rx_buffers_max == 0 || config.tx_buffers_max == 0 {

--- a/rs/moq-uring/src/udp.rs
+++ b/rs/moq-uring/src/udp.rs
@@ -693,9 +693,9 @@ impl TxBuf {
 	/// surfaces on the next pool acquire.
 	///
 	/// This only stages an SQE, so the datagram reaches the kernel when the
-	/// worker next enters the ring. Stopping the worker in between does not
-	/// lose it: [`crate::Worker`]'s drop submits whatever is still staged and
-	/// waits for the completions.
+	/// worker next enters the ring. Dropping the worker makes a bounded attempt
+	/// to submit staged datagrams and drain their completions, but does not
+	/// guarantee kernel completion or delivery.
 	pub fn send(mut self, len: usize, to: SocketAddr, segment: usize) -> io::Result<()> {
 		// `UDP_SEGMENT` is a u16, so an oversized segment would silently
 		// truncate into a tiny stride and explode the implied segment count.

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -312,14 +312,26 @@ impl Drop for Worker {
 		// instead of pending on a loop that will never run again.
 		self.shared.stopped.set(true);
 		// The kernel may still write into provided buffers and read send
-		// headers owned by the ops slab. Cancel everything and wait for the
-		// terminal completions before any of that memory frees.
+		// headers owned by the ops slab. Submit first so cancellation covers
+		// receives that were only staged. Cancel only operations that can wait
+		// forever: sends still have to complete so a datagram staged by the
+		// final worker turn reaches the wire.
+		let _ = self.submit();
+		let cancel: Vec<u64> = self
+			.shared
+			.ops
+			.borrow()
+			.iter()
+			.filter_map(|(key, op)| matches!(op, Op::Recv { .. } | Op::FutexWait).then_some(key as u64))
+			.collect();
 		{
 			let ring = self.shared.ring.borrow_mut();
 			let timeout = types::Timespec::new().sec(1);
-			let _ = ring
-				.submitter()
-				.register_sync_cancel(Some(timeout), types::CancelBuilder::any());
+			for key in cancel {
+				let _ = ring
+					.submitter()
+					.register_sync_cancel(Some(timeout), types::CancelBuilder::user_data(key));
+			}
 		}
 		for _ in 0..64 {
 			if self.pump().is_err() {
@@ -337,7 +349,7 @@ impl Drop for Worker {
 			// Leak the operations (and what they own) rather than free memory
 			// the kernel may still touch.
 			tracing::error!("dropping an io_uring worker with operations stuck in flight; leaking them");
-			std::mem::forget(std::mem::replace(&mut *self.shared.ops.borrow_mut(), slab::Slab::new()));
+			std::mem::forget(std::mem::take(&mut *self.shared.ops.borrow_mut()));
 		}
 	}
 }
@@ -565,6 +577,7 @@ mod tests {
 		let handle = worker.handle();
 		let bind = || std::net::UdpSocket::bind("127.0.0.1:0").expect("bind");
 		let sock = handle.udp(bind(), udp::Config::default()).expect("socket");
+		let shared = sock.downgrade();
 		let to = sock.local_addr().expect("addr");
 		let Poll::Ready(Ok(tx)) = sock.poll_acquire(&kio::Waiter::noop()) else {
 			panic!("no tx buffer");
@@ -579,6 +592,8 @@ mod tests {
 		assert!(tx.send(1200, to, 1200).is_err());
 		// And a late spawn is dropped rather than parked forever.
 		handle.spawn(async {});
+		drop(sock);
+		assert!(shared.upgrade().is_none(), "the worker leaked its staged receive");
 	}
 
 	#[test]

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -152,8 +152,20 @@ impl Worker {
 
 	/// Submit staged SQEs and dispatch every pending completion.
 	fn pump(&mut self) -> Result<(), Error> {
+		self.pump_inner(None)
+	}
+
+	/// Pump submission and completion batches until `deadline`.
+	fn pump_until(&mut self, deadline: Instant) -> Result<(), Error> {
+		self.pump_inner(Some(deadline))
+	}
+
+	fn pump_inner(&mut self, deadline: Option<Instant>) -> Result<(), Error> {
 		self.submit()?;
 		loop {
+			if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+				return Ok(());
+			}
 			// Copy the completions out so dispatch can borrow the ring (to
 			// re-arm receives, push cancels, and so on). Completions spilled
 			// by `Shared::push` predate the CQ's, so they dispatch first.
@@ -184,7 +196,11 @@ impl Worker {
 			return Ok(());
 		}
 		match ring.submit() {
+			// A partial submit leaves the rest staged for the next pump.
 			Ok(_) => Ok(()),
+			// A signal interrupted the enter before it consumed anything. The
+			// next worker turn retries the same staged SQEs.
+			Err(err) if err.raw_os_error() == Some(libc::EINTR) => Ok(()),
 			// The completion queue overflowed; the caller reaps and retries.
 			Err(err) if err.raw_os_error() == Some(libc::EBUSY) => Ok(()),
 			Err(err) => Err(err.into()),
@@ -311,12 +327,13 @@ impl Drop for Worker {
 		// Handles may outlive us; everything they try from here on fails
 		// instead of pending on a loop that will never run again.
 		self.shared.stopped.set(true);
+		// One deadline bounds cancellation staging and draining together.
+		let deadline = Instant::now() + std::time::Duration::from_millis(3200);
 		// The kernel may still write into provided buffers and read send
-		// headers owned by the ops slab. Submit first so cancellation covers
-		// receives that were only staged. Cancel only operations that can wait
-		// forever: sends still have to complete so a datagram staged by the
-		// final worker turn reaches the wire.
-		let _ = self.submit();
+		// headers owned by the ops slab. Queue cancels behind every staged
+		// receive and the futex, so partial submissions cannot strand an
+		// uncancelled operation. Sends are deliberately left alone: a datagram
+		// staged by the final worker turn still has to reach the wire.
 		let cancel: Vec<u64> = self
 			.shared
 			.ops
@@ -324,24 +341,30 @@ impl Drop for Worker {
 			.iter()
 			.filter_map(|(key, op)| matches!(op, Op::Recv { .. } | Op::FutexWait).then_some(key as u64))
 			.collect();
-		{
-			let ring = self.shared.ring.borrow_mut();
-			let timeout = types::Timespec::new().sec(1);
-			for key in cancel {
-				let _ = ring
-					.submitter()
-					.register_sync_cancel(Some(timeout), types::CancelBuilder::user_data(key));
+		let mut cancellation_failed = false;
+		for key in cancel {
+			if Instant::now() >= deadline {
+				cancellation_failed = true;
+				break;
 			}
+			cancellation_failed |= self.shared.cancel_until(key, deadline).is_err();
 		}
-		for _ in 0..64 {
-			if self.pump().is_err() {
+		if cancellation_failed {
+			tracing::error!("failed to queue one or more io_uring teardown cancellations");
+		}
+		loop {
+			if Instant::now() >= deadline || self.pump_until(deadline).is_err() {
 				break;
 			}
 			if self.shared.ops.borrow().is_empty() {
 				return;
 			}
+			let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+				break;
+			};
 			let ring = self.shared.ring.borrow_mut();
-			let ts = types::Timespec::new().nsec(50_000_000);
+			let wait = remaining.min(std::time::Duration::from_millis(50));
+			let ts = types::Timespec::from(wait);
 			let args = types::SubmitArgs::new().timespec(&ts);
 			let _ = ring.submitter().submit_with_args(1, &args);
 		}
@@ -594,6 +617,37 @@ mod tests {
 		handle.spawn(async {});
 		drop(sock);
 		assert!(shared.upgrade().is_none(), "the worker leaked its staged receive");
+	}
+
+	#[test]
+	fn dropped_worker_drains_more_receives_than_the_submission_queue() {
+		let Some(worker) = worker() else { return };
+		let handle = worker.handle();
+		let config = udp::Config {
+			gro: false,
+			gso: false,
+			multishot: false,
+			rx_buffers_max: 1,
+			rx_buffer_len: 2048,
+			tx_buffers_max: 1,
+			tx_buffer_len: 2048,
+		};
+		let mut sockets = Vec::new();
+		let mut shared = Vec::new();
+		for _ in 0..=SQ_ENTRIES {
+			let sock = handle
+				.udp(std::net::UdpSocket::bind("127.0.0.1:0").expect("bind"), config.clone())
+				.expect("socket");
+			shared.push(sock.downgrade());
+			sockets.push(sock);
+		}
+
+		drop(worker);
+		drop(sockets);
+		assert!(
+			shared.iter().all(|shared| shared.upgrade().is_none()),
+			"the worker leaked a receive staged across submission batches"
+		);
 	}
 
 	#[test]

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -27,6 +27,9 @@ const SQ_ENTRIES: u32 = 256;
 /// state.
 const CQ_ENTRIES: u32 = 4096;
 
+/// Maximum completions copied at once while teardown is deadline-bounded.
+const TEARDOWN_CQE_BATCH: usize = 64;
+
 /// Worker construction knobs.
 ///
 /// Currently empty: the worker sizes its ring internally, with a completion
@@ -172,22 +175,36 @@ impl Worker {
 			let cqes: Vec<Cqe> = {
 				let mut ring = self.shared.ring.borrow_mut();
 				let mut spill = self.shared.spill.borrow_mut();
-				spill
-					.drain(..)
-					.chain(ring.completion().map(|entry| Cqe {
-						user_data: entry.user_data(),
-						result: entry.result(),
-						flags: entry.flags(),
-					}))
-					.collect()
+				let limit = deadline.map_or(usize::MAX, |_| TEARDOWN_CQE_BATCH);
+				let spilled = spill.len().min(limit);
+				let mut cqes: Vec<_> = spill.drain(..spilled).collect();
+				cqes.extend(ring.completion().take(limit - spilled).map(|entry| Cqe {
+					user_data: entry.user_data(),
+					result: entry.result(),
+					flags: entry.flags(),
+				}));
+				cqes
 			};
 			if cqes.is_empty() {
 				return Ok(());
 			}
-			for cqe in cqes {
-				self.dispatch(cqe);
+			if !self.dispatch_batch(cqes, deadline, Instant::now) {
+				return Ok(());
 			}
 		}
+	}
+
+	/// Dispatch a completion batch while its teardown budget remains.
+	fn dispatch_batch(&mut self, cqes: Vec<Cqe>, deadline: Option<Instant>, mut now: impl FnMut() -> Instant) -> bool {
+		for cqe in cqes {
+			if deadline.is_some_and(|deadline| now() >= deadline) {
+				// Drop this batch's remaining CQEs. Worker::drop will leak their
+				// op state, which is safe even if the kernel already finished it.
+				return false;
+			}
+			self.dispatch(cqe);
+		}
+		true
 	}
 
 	fn submit(&mut self) -> Result<(), Error> {
@@ -617,6 +634,30 @@ mod tests {
 		handle.spawn(async {});
 		drop(sock);
 		assert!(shared.upgrade().is_none(), "the worker leaked its staged receive");
+	}
+
+	#[test]
+	fn teardown_stops_between_completions_at_the_deadline() {
+		let Some(mut worker) = worker() else { return };
+		let first = worker.shared.insert(Op::Cancel);
+		let second = worker.shared.insert(Op::Cancel);
+		let cqe = |user_data| Cqe {
+			user_data,
+			result: 0,
+			flags: 0,
+		};
+		let before = Instant::now();
+		let deadline = before + Duration::from_millis(1);
+		let mut now = [before, deadline].into_iter();
+
+		assert!(
+			!worker.dispatch_batch(vec![cqe(first), cqe(second)], Some(deadline), || {
+				now.next().expect("one deadline check per completion")
+			})
+		);
+		assert!(!worker.shared.ops.borrow().contains(first as usize));
+		assert!(worker.shared.ops.borrow().contains(second as usize));
+		worker.shared.ops.borrow_mut().remove(second as usize);
 	}
 
 	#[test]

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -224,11 +224,31 @@ impl Worker {
 		}
 	}
 
-	/// Submit residual SQEs once, then drain completions within `deadline`.
+	/// Submit every residual SQE without waiting for completions.
+	fn submit_teardown(&mut self) -> Result<(), Error> {
+		let mut ring = self.shared.ring.borrow_mut();
+		loop {
+			if ring.submission().is_empty() {
+				return Ok(());
+			}
+			match ring.submit() {
+				// Keep submitting after partial progress. Returning zero while SQEs
+				// remain would otherwise spin forever.
+				Ok(0) => {
+					return Err(std::io::Error::other("io_uring teardown submission made no progress").into());
+				}
+				Ok(_) => {}
+				Err(err) if err.raw_os_error() == Some(libc::EINTR) => {}
+				Err(err) => return Err(err.into()),
+			}
+		}
+	}
+
+	/// Submit residual SQEs, then drain completions within `deadline`.
 	fn drain_teardown(&mut self, deadline: Instant) {
 		// Cancellation staging can consume the whole deadline. Existing SQEs,
-		// especially sends, are still owed one non-waiting submission attempt.
-		let submission_failed = self.submit().is_err();
+		// especially sends, must still reach the kernel before it gates draining.
+		let submission_failed = self.submit_teardown().is_err();
 		if !submission_failed {
 			loop {
 				if self.shared.ops.borrow().is_empty() {
@@ -674,8 +694,10 @@ mod tests {
 	fn expired_teardown_submits_residual_sqes() {
 		let Some(mut worker) = worker() else { return };
 		// A NOP needs no slab-owned memory, so it can observe the SQ directly.
-		worker.shared.push(&opcode::Nop::new().build()).expect("stage NOP");
-		assert_eq!(worker.shared.ring.borrow_mut().submission().len(), 1);
+		for _ in 0..SQ_ENTRIES {
+			worker.shared.push(&opcode::Nop::new().build()).expect("stage NOP");
+		}
+		assert_eq!(worker.shared.ring.borrow_mut().submission().len(), SQ_ENTRIES as usize);
 
 		worker.drain_teardown(Instant::now());
 		assert!(worker.shared.ring.borrow_mut().submission().is_empty());

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -30,6 +30,9 @@ const CQ_ENTRIES: u32 = 4096;
 /// Maximum completions copied at once while teardown is deadline-bounded.
 const TEARDOWN_CQE_BATCH: usize = 64;
 
+/// Extra mandatory submit attempts allowed after interrupted enters.
+const TEARDOWN_EINTR_RETRIES: usize = 8;
+
 /// Worker construction knobs.
 ///
 /// Currently empty: the worker sizes its ring internally, with a completion
@@ -227,6 +230,7 @@ impl Worker {
 	/// Submit every residual SQE without waiting for completions.
 	fn submit_teardown(&mut self) -> Result<(), Error> {
 		let mut ring = self.shared.ring.borrow_mut();
+		let mut interruptions = 0;
 		loop {
 			if ring.submission().is_empty() {
 				return Ok(());
@@ -238,8 +242,7 @@ impl Worker {
 					return Err(std::io::Error::other("io_uring teardown submission made no progress").into());
 				}
 				Ok(_) => {}
-				Err(err) if err.raw_os_error() == Some(libc::EINTR) => {}
-				Err(err) => return Err(err.into()),
+				Err(err) => retry_teardown_submit(&mut interruptions, err)?,
 			}
 		}
 	}
@@ -542,6 +545,15 @@ fn abs_timespec(at: Instant) -> types::Timespec {
 	types::Timespec::new().sec(secs).nsec((nanos % 1_000_000_000) as u32)
 }
 
+/// Accept a bounded number of interrupted teardown submissions.
+fn retry_teardown_submit(interruptions: &mut usize, err: std::io::Error) -> std::io::Result<()> {
+	if err.raw_os_error() != Some(libc::EINTR) || *interruptions >= TEARDOWN_EINTR_RETRIES {
+		return Err(err);
+	}
+	*interruptions += 1;
+	Ok(())
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -701,6 +713,22 @@ mod tests {
 
 		worker.drain_teardown(Instant::now());
 		assert!(worker.shared.ring.borrow_mut().submission().is_empty());
+	}
+
+	#[test]
+	fn teardown_submit_interrupt_budget_is_finite() {
+		let interrupted = || std::io::Error::from_raw_os_error(libc::EINTR);
+		let mut interruptions = 0;
+		for _ in 0..TEARDOWN_EINTR_RETRIES {
+			retry_teardown_submit(&mut interruptions, interrupted()).expect("retry interrupted submit");
+		}
+		assert_eq!(interruptions, TEARDOWN_EINTR_RETRIES);
+		assert_eq!(
+			retry_teardown_submit(&mut interruptions, interrupted())
+				.expect_err("interrupt budget must be finite")
+				.raw_os_error(),
+			Some(libc::EINTR)
+		);
 	}
 
 	#[test]

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -224,6 +224,37 @@ impl Worker {
 		}
 	}
 
+	/// Submit residual SQEs once, then drain completions within `deadline`.
+	fn drain_teardown(&mut self, deadline: Instant) {
+		// Cancellation staging can consume the whole deadline. Existing SQEs,
+		// especially sends, are still owed one non-waiting submission attempt.
+		let submission_failed = self.submit().is_err();
+		if !submission_failed {
+			loop {
+				if self.shared.ops.borrow().is_empty() {
+					return;
+				}
+				if Instant::now() >= deadline || self.pump_until(deadline).is_err() {
+					break;
+				}
+				let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+					break;
+				};
+				let ring = self.shared.ring.borrow_mut();
+				let wait = remaining.min(std::time::Duration::from_millis(50));
+				let ts = types::Timespec::from(wait);
+				let args = types::SubmitArgs::new().timespec(&ts);
+				let _ = ring.submitter().submit_with_args(1, &args);
+			}
+		}
+		if !self.shared.ops.borrow().is_empty() {
+			// Leak the operations (and what they own) rather than free memory
+			// the kernel may still touch.
+			tracing::error!("dropping an io_uring worker with operations stuck in flight; leaking them");
+			std::mem::forget(std::mem::take(&mut *self.shared.ops.borrow_mut()));
+		}
+	}
+
 	/// Route one completion to its operation.
 	fn dispatch(&mut self, cqe: Cqe) {
 		let key = cqe.user_data as usize;
@@ -369,28 +400,7 @@ impl Drop for Worker {
 		if cancellation_failed {
 			tracing::error!("failed to queue one or more io_uring teardown cancellations");
 		}
-		loop {
-			if Instant::now() >= deadline || self.pump_until(deadline).is_err() {
-				break;
-			}
-			if self.shared.ops.borrow().is_empty() {
-				return;
-			}
-			let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
-				break;
-			};
-			let ring = self.shared.ring.borrow_mut();
-			let wait = remaining.min(std::time::Duration::from_millis(50));
-			let ts = types::Timespec::from(wait);
-			let args = types::SubmitArgs::new().timespec(&ts);
-			let _ = ring.submitter().submit_with_args(1, &args);
-		}
-		if !self.shared.ops.borrow().is_empty() {
-			// Leak the operations (and what they own) rather than free memory
-			// the kernel may still touch.
-			tracing::error!("dropping an io_uring worker with operations stuck in flight; leaking them");
-			std::mem::forget(std::mem::take(&mut *self.shared.ops.borrow_mut()));
-		}
+		self.drain_teardown(deadline);
 	}
 }
 
@@ -658,6 +668,17 @@ mod tests {
 		assert!(!worker.shared.ops.borrow().contains(first as usize));
 		assert!(worker.shared.ops.borrow().contains(second as usize));
 		worker.shared.ops.borrow_mut().remove(second as usize);
+	}
+
+	#[test]
+	fn expired_teardown_submits_residual_sqes() {
+		let Some(mut worker) = worker() else { return };
+		// A NOP needs no slab-owned memory, so it can observe the SQ directly.
+		worker.shared.push(&opcode::Nop::new().build()).expect("stage NOP");
+		assert_eq!(worker.shared.ring.borrow_mut().submission().len(), 1);
+
+		worker.drain_teardown(Instant::now());
+		assert!(worker.shared.ring.borrow_mut().submission().is_empty());
 	}
 
 	#[test]

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::task::{Context, Poll};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use io_uring::{EnterFlags, IoUring, opcode, types};
 
@@ -33,6 +33,9 @@ const TEARDOWN_CQE_BATCH: usize = 64;
 /// Extra mandatory submit attempts allowed after interrupted enters.
 const TEARDOWN_EINTR_RETRIES: usize = 8;
 
+/// Maximum time spent staging cancellations and draining completions.
+const TEARDOWN_TIMEOUT: Duration = Duration::from_millis(3200);
+
 /// Worker construction knobs.
 ///
 /// Currently empty: the worker sizes its ring internally, with a completion
@@ -51,12 +54,14 @@ pub struct Config {}
 /// (any `Waker` this worker minted) are an atomic store plus, only while the
 /// worker is parked, one futex syscall.
 ///
-/// Dropping the worker submits the SQEs its last turn staged and waits for
-/// their completions, so a datagram already handed to a [`udp::Socket`] still
-/// goes out. It runs no tasks, though, so work a task has merely been asked
-/// for is not performed: a QUIC close is queued on its connection and framed
-/// by the driver task, so keep driving until the close is published rather
-/// than stopping the worker on the call that asked for it.
+/// Dropping the worker makes a bounded attempt to submit the SQEs its last
+/// turn staged and drain their completions. A datagram already handed to a
+/// [`udp::Socket`] is included in that submission attempt, while operation
+/// storage that the kernel might still access is safely leaked if teardown
+/// cannot finish. It runs no tasks, though, so work a task has merely been
+/// asked for is not performed: a QUIC close is queued on its connection and
+/// framed by the driver task, so keep driving until the close is published
+/// rather than stopping the worker on the call that asked for it.
 pub struct Worker {
 	shared: Rc<Shared>,
 	tasks: kio::Tasks<Task>,
@@ -399,7 +404,7 @@ impl Drop for Worker {
 		// instead of pending on a loop that will never run again.
 		self.shared.stopped.set(true);
 		// One deadline bounds cancellation staging and draining together.
-		let deadline = Instant::now() + std::time::Duration::from_millis(3200);
+		let deadline = Instant::now() + TEARDOWN_TIMEOUT;
 		// The kernel may still write into provided buffers and read send
 		// headers owned by the ops slab. Queue cancels behind every staged
 		// receive and the futex, so partial submissions cannot strand an


### PR DESCRIPTION
## Summary

- Append targeted asynchronous cancellation SQEs behind every staged receive and futex operation, preserving FIFO coverage across partial submissions.
- Retry non-waiting submissions after partial progress and use a finite `EINTR` retry budget until the residual SQ is empty or a real error occurs, so staged sends get bounded best-effort delivery.
- Bound cancellation staging, batched completion dispatch, and completion waits with one teardown deadline.
- Add structural regressions for retained sockets, SQ-capacity pressure, deadline expiry, residual submission, and interrupted-submit budget exhaustion.

## Root cause

Worker teardown issued synchronous cancellation before submitting the SQ. A receive staged in the SQ was therefore invisible to cancellation, then submitted by the teardown pump and left pending until the safety timeout. Cancelling every operation after submission would regress #3141 by dropping staged sends. FIFO asynchronous cancels target only operations that can remain pending indefinitely and stay ordered after their targets even across partial submissions.

## Public API changes

None.

## Test plan

- `just rs fix -p moq-uring`
- `just rs check -p moq-uring`
- `just rs test -p moq-uring teardown_submit_interrupt_budget_is_finite` (1 passed)
- `just rs test -p moq-uring expired_teardown_submits_residual_sqes` (1 passed)
- `just rs test -p moq-uring teardown_stops_between_completions_at_the_deadline` (1 passed)
- `just rs test -p moq-uring dropped_worker` (2 passed)
- `just rs test -p moq-uring a_send_staged_on_the_way_out_still_goes` (1 passed)
- Reverted the original cancellation ordering locally and confirmed the retained-socket regression fails with the staged receive still alive

Closes #3173

(Written by GPT-5)