### PR TITLE
docs: organize guides around common tasks

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -72,9 +72,9 @@ export default defineConfig({
 					items: [
 						{ text: "Development", link: "/setup/dev" },
 						{ text: "Production", link: "/setup/prod" },
-						{ text: "AI Agents", link: "/setup/agent" },
-						{ text: "Linux Packages", link: "/setup/linux" },
+						{ text: "Linux", link: "/setup/linux" },
 						{ text: "Windows", link: "/setup/windows" },
+						{ text: "Coding agents", link: "/setup/agent" },
 					],
 				},
 				{
@@ -121,7 +121,6 @@ export default defineConfig({
 								{ text: "Distribution", link: "/concept/use-case/distribution" },
 								{ text: "Conferencing", link: "/concept/use-case/conferencing" },
 								{ text: "AI", link: "/concept/use-case/ai" },
-								{ text: "Other", link: "/concept/use-case/other" },
 							],
 						},
 					],
@@ -149,16 +148,26 @@ export default defineConfig({
 								{ text: "Authentication", link: "/bin/relay/auth" },
 								{ text: "Clustering", link: "/bin/relay/cluster" },
 								{ text: "HTTP", link: "/bin/relay/http" },
-								{ text: "Production", link: "/bin/relay/prod" },
+								{ text: "Deployment", link: "/setup/prod" },
 							],
 						},
 						{ text: "CLI", link: "/bin/cli" },
-						{ text: "WebRTC", link: "/bin/rtc" },
-						{ text: "RTMP", link: "/bin/rtmp" },
-						{ text: "OBS", link: "/bin/obs" },
-						{ text: "GStreamer", link: "/bin/gstreamer" },
-						{ text: "HLS", link: "/bin/hls" },
-						{ text: "Web", link: "/bin/web" },
+						{
+							text: "Gateways",
+							items: [
+								{ text: "HLS", link: "/bin/hls" },
+								{ text: "RTMP", link: "/bin/rtmp" },
+								{ text: "WebRTC", link: "/bin/rtc" },
+							],
+						},
+						{
+							text: "Integrations",
+							items: [
+								{ text: "OBS", link: "/bin/obs" },
+								{ text: "GStreamer", link: "/bin/gstreamer" },
+								{ text: "Web demo", link: "/bin/web" },
+							],
+						},
 					],
 				},
 			],
@@ -202,7 +211,6 @@ export default defineConfig({
 							items: [
 								{
 									text: "Environments",
-									link: "/lib/js/env/",
 									items: [
 										{ text: "Web", link: "/lib/js/env/web" },
 										{ text: "Native", link: "/lib/js/env/native" },
@@ -210,7 +218,6 @@ export default defineConfig({
 								},
 								{
 									text: "Packages",
-									link: "/lib/js/@moq",
 									items: [
 										{ text: "@moq/net", link: "/lib/js/@moq/net" },
 										{ text: "@moq/hang", link: "/lib/js/@moq/hang" },

--- a/doc/.vitepress/theme/Banner.vue
+++ b/doc/.vitepress/theme/Banner.vue
@@ -2,17 +2,15 @@
 /**
  * Site-wide notice shown at the top of every page.
  *
- * Reminds readers that MoQ is pre-1.0, so both the APIs/protocols and these
- * (mostly AI-generated) docs are still in flux.
+ * Reminds readers that MoQ is pre-1.0 and its public surfaces may change.
  */
 </script>
 
 <template>
 	<div class="moq-banner">
 		<p>
-			<strong>btw:</strong> MoQ is under active development. The APIs and
-			protocols are still evolving and will change. Most of this documentation
-			is AI generated until things get more stable.
+			<strong>MoQ is under active development.</strong> APIs and protocols may
+			change between releases.
 		</p>
 	</div>
 </template>

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -758,7 +758,7 @@ curl http://relay.example.com:4443/announced/
 
 - The relay needs a valid TLS certificate
 - For development, use the fingerprint method
-- See [TLS Setup](/bin/relay/#tls-setup)
+- See [Production TLS setup](/setup/prod#networking-and-tls)
 
 ### "Permission denied"
 

--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -7,11 +7,11 @@ description: GStreamer plugin for MoQ
 
 A GStreamer plugin for publishing and consuming MoQ streams.
 
-::: warning Work in Progress
-This plugin is currently under development, but it works okay.
+::: warning Active development
+The plugin is usable, but its API may still change.
 :::
 
-## Overview
+## Elements and properties
 
 The GStreamer plugin provides two elements:
 
@@ -160,7 +160,7 @@ nix shell github:moq-dev/moq#moq-gst --command gst-launch-1.0 -v -e \
 cargo build -p moq-gst
 ```
 
-This produces a shared library (cdylib) in `target/debug/`. GStreamer needs to find this plugin via the `GST_PLUGIN_PATH_1_0` environment variable — the `just` commands below handle this automatically.
+This produces a shared library (cdylib) in `target/debug/`. GStreamer needs to find this plugin via the `GST_PLUGIN_PATH_1_0` environment variable; the `just` commands below handle this automatically.
 
 ## Running Locally
 

--- a/doc/bin/index.md
+++ b/doc/bin/index.md
@@ -23,9 +23,8 @@ Use these tools to operate MoQ or bridge it to an existing media workflow.
 | [moq-rtmp](/bin/rtmp) | Accept RTMP and enhanced RTMP publishers and forward them into MoQ. |
 | [moq-rtc](/bin/rtc) | Bridge WHIP/WHEP and MoQ in either client or server roles. |
 
-The same gateway endpoints are available through `moq-cli` when one process
-only needs to bridge a specific broadcast. The standalone gateways are better
-suited to services that route multiple sessions.
+These pages document gateway endpoints exposed by `moq-cli` and the libraries
+that implement them.
 
 ## Media integrations
 

--- a/doc/bin/index.md
+++ b/doc/bin/index.md
@@ -5,58 +5,33 @@ description: Ready-to-use tools built on MoQ
 
 # Applications
 
-These are the applications you can run today.
-Some are servers, some are command-line tools, and some are web apps.
+Use these tools to operate MoQ or bridge it to an existing media workflow.
 
-## [moq-relay](/bin/relay/)
+## Core tools
 
-The relay server that routes broadcasts between publishers and subscribers.
-This is the heart of any MoQ deployment that relies on fanout.
-Run it yourself, or pay for an external service (ex. Cloudflare).
+| Tool | Use it to |
+| --- | --- |
+| [moq-relay](/bin/relay/) | Route, cache, and fan out broadcasts. Relays can also form multi-region clusters. |
+| [moq-cli](/bin/cli) | Publish, subscribe, play, transcode, or convert media from the command line. |
+| [Web demo](/bin/web) | Publish and watch from a browser with the project web components. |
 
-- [Configuration](/bin/relay/config) - TOML reference and examples
-- [Authentication](/bin/relay/auth) - JWT-based access control
-- [HTTP Endpoints](/bin/relay/http) - Debugging and diagnostics
-- [Clustering](/bin/relay/cluster) - Multi-region deployment
+## Protocol gateways
 
-## [moq-cli](/bin/cli)
+| Gateway | Direction |
+| --- | --- |
+| [moq-hls](/bin/hls) | Import HLS into MoQ or serve a MoQ broadcast as HLS. |
+| [moq-rtmp](/bin/rtmp) | Accept RTMP and enhanced RTMP publishers and forward them into MoQ. |
+| [moq-rtc](/bin/rtc) | Bridge WHIP/WHEP and MoQ in either client or server roles. |
 
-A CLI for publishing to media streams.
-Another tool does the encoding (ex. ffmpeg), making it easy to pipe any media into MoQ.
+The same gateway endpoints are available through `moq-cli` when one process
+only needs to bridge a specific broadcast. The standalone gateways are better
+suited to services that route multiple sessions.
 
-```bash
-# Publish your webcam
-ffmpeg -f avfoundation -i "0" -f mpegts - | moq --client-connect https://relay.example.com/anon --broadcast my-stream import ts
-```
+## Media integrations
 
-## [moq-rtc](/bin/rtc)
+| Integration | Use it to |
+| --- | --- |
+| [OBS plugin](/bin/obs) | Publish a scene to MoQ or use a MoQ broadcast as an OBS source. |
+| [GStreamer plugin](/bin/gstreamer) | Add MoQ source and sink elements to a GStreamer pipeline. |
 
-A WebRTC <-> MoQ gateway. Speaks WHIP (publish) and WHEP (subscribe) in either
-HTTP role, so it can accept incoming peers (OBS, browsers) or dial out to a
-remote WebRTC server. Ingest and egress both work for H.264, VP8, VP9, and Opus.
-
-## [moq-hls](/bin/hls)
-
-An HLS <-> MoQ gateway. Serves a MoQ broadcast as HLS (fetching media on demand) and
-Low-Latency HLS over HTTP, or imports a remote HLS playlist into MoQ.
-
-## [moq-rtmp](/bin/rtmp)
-
-An RTMP / enhanced-RTMP -> MoQ ingest gateway. Accepts RTMP from any encoder
-(OBS, ffmpeg) and publishes it into MoQ, supporting H.264/HEVC/AV1/VP9 and
-AAC/Opus/AC-3.
-
-## [OBS Plugin](/bin/obs)
-
-Real-time latency with the familiar OBS interface.
-Supports both publishing and subscribing.
-
-## [GStreamer Plugin](/bin/gstreamer)
-
-Integrate MoQ into GStreamer pipelines for advanced media workflows.
-Supports both publishing and subscribing.
-
-## [Web Demo](/bin/web)
-
-A demo web application showcasing MoQ in the browser.
-Watch streams, publish from your camera, and explore the API.
+To embed MoQ directly in another application, choose a [library](/lib/) instead.

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -138,6 +138,6 @@ peer stays loudly visible in the logs and a returning one is picked up within se
 
 ## Next steps
 
-- Deploy to [Production](/bin/relay/prod)
+- Review [Production deployment](/setup/prod)
 - Set up [Authentication](/bin/relay/auth)
 - Learn about [Protocol concepts](/concept/layer/)

--- a/doc/bin/relay/index.md
+++ b/doc/bin/relay/index.md
@@ -1,195 +1,94 @@
 ---
 title: moq-relay
-description: A server that connects MoQ publishers and subscribers.
+description: Route MoQ broadcasts between publishers and subscribers
 ---
 
 # moq-relay
 
-A server that routes broadcasts between publishers and subscribers, performing caching, deduplication, and fan-out.
+`moq-relay` routes, caches, and fans out broadcasts without parsing their media
+payloads. Run one relay for a small deployment or connect several relays into a
+cluster.
 
-## Overview
+## Install
 
-`moq-relay` is designed to run in datacenters, relaying media across multiple hops to improve quality of service and enable massive scale.
-
-**Features:**
-
-- Fan-out to multiple subscribers
-- Caching and deduplication
-- Cross-region clustering
-- JWT-based authentication
-- HTTP debugging endpoints
-
-## Installation
-
-### From Source
+Choose one installation method:
 
 ```bash
-git clone https://github.com/moq-dev/moq
-cd moq
-cargo build --release --bin moq-relay
-```
-
-The binary will be in `target/release/moq-relay`.
-
-### Using Cargo
-
-```bash
+# Cargo
 cargo install moq-relay
-```
 
-### Using winget (Windows)
+# Nix
+nix run github:moq-dev/moq#moq-relay -- relay.toml
 
-```powershell
+# Windows
 winget install moq-dev.moq-relay
 ```
 
-### Using Nix
+Container images for `linux/amd64` and `linux/arm64` are published on
+[Docker Hub](https://hub.docker.com/r/moqdev/moq-relay):
 
 ```bash
-# Run directly
-nix run github:moq-dev/moq#moq-relay
-
-# Or build and find the binary in ./result/bin/
-nix build github:moq-dev/moq#moq-relay
+docker run -p 4443:4443/udp \
+  -v "$(pwd)/relay.toml:/app/relay.toml:ro" \
+  moqdev/moq-relay -- /app/relay.toml
 ```
 
-### Using Docker
+To build from source, clone the repository and run
+`cargo build --release --bin moq-relay`.
 
-```bash
-docker pull moqdev/moq-relay
-docker run -p 4443:4443/udp -v "$(pwd)/relay.toml:/app/relay.toml:ro" moqdev/moq-relay -- /app/relay.toml
-```
+## Configure and run
 
-Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub](https://hub.docker.com/r/moqdev/moq-relay).
-
-## Configuration
-
-Create a `relay.toml` configuration file:
-
-```toml
-[server]
-bind = "[::]:4443"  # Listen on all interfaces, port 4443
-
-[server.tls]
-cert = "/path/to/cert.pem"  # TLS certificate
-key = "/path/to/key.pem"    # TLS private key
-
-[auth]
-public = "anon"     # Allow anonymous access to anon/**
-key = "root.jwk"    # JWT key for authenticated paths
-```
-
-See [localhost.toml](https://github.com/moq-dev/moq/blob/main/demo/relay/localhost.toml) for a complete example.
-
-## Running
-
-Pass the config path as the only positional argument:
+The relay takes one TOML configuration path:
 
 ```bash
 moq-relay relay.toml
 ```
 
-## HTTP Endpoints
-
-The relay exposes HTTP/HTTPS endpoints for debugging, health checks, and late-join. See [HTTP](/bin/relay/http) for details.
-
-## TLS Setup
-
-The relay requires TLS certificates. Use [Let's Encrypt](https://letsencrypt.org/):
-
-```bash
-# Install certbot
-sudo apt install certbot  # Ubuntu/Debian
-brew install certbot      # macOS
-
-# Generate certificate
-sudo certbot certonly --standalone -d relay.example.com
-```
-
-Update `relay.toml`:
+A local-only configuration can use a generated certificate and anonymous access:
 
 ```toml
-[server.tls]
-cert = "/etc/letsencrypt/live/relay.example.com/fullchain.pem"
-key = "/etc/letsencrypt/live/relay.example.com/privkey.pem"
+[server]
+listen = "[::]:4443"
+tls.generate = ["localhost"]
+
+[web.http]
+listen = "[::]:4443"
+
+[auth]
+public = ""
 ```
 
-## Monitoring
+The HTTP listener serves the certificate fingerprint used to verify the local
+QUIC endpoint. Do not use generated certificates or unrestricted anonymous
+access for a public deployment.
 
-### Logging
+See the [configuration reference](/bin/relay/config) for every option and the
+[`demo/relay`](https://github.com/moq-dev/moq/tree/main/demo/relay) directory for
+working configurations.
 
-Set log level via environment variable:
+## Operate a relay
+
+| Task | Guide |
+| --- | --- |
+| Restrict publish and subscribe paths | [Authentication](/bin/relay/auth) |
+| Connect multiple relays | [Clustering](/bin/relay/cluster) |
+| Inspect broadcasts, health, and metrics | [HTTP endpoints](/bin/relay/http) |
+| Configure TLS, networking, and host tuning | [Production deployment](/setup/prod) |
+
+Set `RUST_LOG` to adjust logging without changing the configuration:
 
 ```bash
 RUST_LOG=info moq-relay relay.toml
-RUST_LOG=debug moq-relay relay.toml
 RUST_LOG=moq_relay=trace moq-relay relay.toml
 ```
 
-### Metrics
-
-Metrics (Prometheus format) are planned but not yet implemented.
-
-Current visibility:
-
-- Check logs for connection count
-- Use [HTTP endpoints](/bin/relay/http) for track inspection
-- Monitor system resources (CPU, memory, bandwidth)
-
-## Performance
-
-### Current Status
-
-- **Single-threaded** - Quinn uses one UDP receive thread
-- **In-memory caching** - Recent groups stored in RAM
-- **Mesh clustering** - All relays connect to all others
-
-### Scaling
-
-- **Vertical** - Fast CPU matters more than core count
-- **Horizontal** - Deploy multiple relays in different regions
-- **Cluster size** - 3-5 nodes optimal with current implementation
-
-### Future Improvements
-
-- Multi-threaded UDP processing
-- Tree-based clustering topology
-- Improved memory management
-- Metrics and observability
-
 ## Troubleshooting
 
-### Port Already in Use
-
-```bash
-# Check what's using port 4443
-lsof -i :4443
-
-# Kill the process or use a different port
-```
-
-### Certificate Errors
-
-Ensure:
-
-- Certificate is valid and not expired
-- Certificate matches domain name
-- Private key has correct permissions
-- Certificate includes full chain
-
-### Connection Timeouts
-
-Check:
-
-- UDP port is open in firewall
-- Cloud provider allows UDP traffic
-- TLS certificate is valid
-- Relay is actually running
-
-## Next Steps
-
-- Set up [Authentication](/bin/relay/auth)
-- Configure [Clustering](/bin/relay/cluster)
-- Deploy to [Production](/bin/relay/prod)
-- Use [moq-net](/lib/rs/crate/moq-net) client library
-- Build media apps with [hang](/lib/rs/crate/hang)
+- **Address already in use:** check that no other process is listening on the
+  configured UDP or TCP port.
+- **Certificate failure:** verify the hostname, certificate chain, private key,
+  and file permissions.
+- **Connection timeout:** verify that UDP reaches the relay and that the client
+  URL uses the configured hostname and port.
+- **Authorization failure:** inspect the connection path and token permissions
+  using the [authentication guide](/bin/relay/auth).

--- a/doc/bin/relay/index.md
+++ b/doc/bin/relay/index.md
@@ -28,7 +28,7 @@ Container images for `linux/amd64` and `linux/arm64` are published on
 [Docker Hub](https://hub.docker.com/r/moqdev/moq-relay):
 
 ```bash
-docker run -p 4443:4443/udp \
+docker run -p 4443:4443/udp -p 4443:4443/tcp \
   -v "$(pwd)/relay.toml:/app/relay.toml:ro" \
   moqdev/moq-relay -- /app/relay.toml
 ```

--- a/doc/bin/relay/index.md
+++ b/doc/bin/relay/index.md
@@ -48,11 +48,11 @@ A local-only configuration can use a generated certificate and anonymous access:
 
 ```toml
 [server]
-listen = "[::]:4443"
+listen = "127.0.0.1:4443"
 tls.generate = ["localhost"]
 
 [web.http]
-listen = "[::]:4443"
+listen = "127.0.0.1:4443"
 
 [auth]
 public = ""

--- a/doc/concept/index.md
+++ b/doc/concept/index.md
@@ -1,30 +1,25 @@
 ---
 title: Concepts
-description: Understanding MoQ's fundamental concepts
+description: Architecture, standards, and use cases for MoQ
 ---
 
 # Concepts
 
-Welcome to my favorite section.
-MoQ has been a multi-year journey to solve some very real problems in the industry and now it's time to flex the design.
+MoQ separates network transport, live pub/sub, media packaging, and application
+behavior. That separation lets relays remain media-agnostic while applications
+choose the formats and features they need.
 
-## Layers
+## [Layers](/concept/layer/)
 
-MoQ is carefully broken into layers to make it simple, composable, and customizable.
-We don't want you to hit a brick wall if you deviate from the standard path (*ahem* WebRTC).
+How QUIC, WebTransport, moq-lite, hang, and application tracks fit together.
+Start here if you are new to the protocol or deciding which library layer to use.
 
-See [Layers](/concept/layer/) for more information.
+## [Standards](/concept/standard/)
 
-## Standards
+How this implementation relates to the IETF MoQ work, including MoqTransport,
+MSF, LOC, and the specifications maintained by moq.dev.
 
-MoQ is built on open standards and protocol specifications.
-We're in this together, even if we disagree on some details.
+## [Use cases](/concept/use-case/)
 
-See [Standards](/concept/standard/) for more information.
-
-## Use Cases
-
-MoQ is designed to be used in a variety of use-cases.
-Distribution, contribution, conferencing, and more.
-
-See [Use Cases](/concept/use-case/) for more information.
+The requirements and tradeoffs for contribution, distribution, conferencing,
+and real-time AI workloads.

--- a/doc/concept/layer/index.md
+++ b/doc/concept/layer/index.md
@@ -1,99 +1,60 @@
 ---
-title: Layering
-description: It's like a cake; you choose if you want frosting.
+title: Layers
+description: How the MoQ protocol stack fits together
 ---
 
 # Layers
 
-The design philosophy of MoQ is to make things simple, composable, and customizable.
-We don't want you to hit a brick wall if you deviate from the standard path (*ahem* WebRTC).
-We also want to benefit from economies of scale (like HTTP), utilizing generic libraries and tools whenever possible.
+MoQ separates transport, live data delivery, media packaging, and application
+behavior. A relay only needs the delivery layer, while media clients use the
+whole stack.
 
-To accomplish this, MoQ is broken into layers stacked on top of each other.
-It's like a cake; you choose whether you want frosting or not.
+| Layer | Role |
+| --- | --- |
+| Application | Defines product behavior and any custom tracks. |
+| [hang](/concept/layer/hang) | Describes media tracks, codecs, and frame timestamps. |
+| [moq-lite](/concept/layer/moq-lite) | Publishes and subscribes to generic broadcasts, tracks, groups, and frames. |
+| Transport | Carries independent streams over QUIC, WebTransport, WebSocket, or iroh. |
 
-## QUIC
+## Transport
 
-[QUIC](/concept/layer/quic) is the core protocol that powers HTTP/3, designed to fix the head-of-line blocking that plagues TCP.
+[QUIC](/concept/layer/quic) provides encrypted connections, independent streams,
+congestion control, and connection migration. Avoiding connection-wide
+head-of-line blocking is the main reason MoQ uses QUIC.
 
-Think of it like:
+Browsers access QUIC through [WebTransport](/concept/layer/web-transport).
+Clients can race it against the [WebSocket fallback](/concept/layer/web-socket)
+when UDP or WebTransport is unavailable. Native peers can use QUIC directly or
+connect through [iroh](/concept/layer/iroh) on a local network.
 
-- **TCP 2.0**: connections with congestion control, flow control, and retransmissions. But now with independent streams and prioritization to avoid head-of-line blocking.
-- **UDP 2.0**: optional reliability and datagrams, allowing stuff to get dropped during congestion.
+## Live delivery
 
-It's a web standard, available in all major browsers, battle-tested by huge CDNs, and with great open-source implementations from every major tech company.
+[moq-lite](/concept/layer/moq-lite) is the generic pub/sub layer. It is a
+forward-compatible subset of [MoqTransport](/concept/standard/moq-transport)
+and does not assign media meaning to payloads.
 
-## WebTransport (optional)
+A session can publish and subscribe at the same time:
 
-[WebTransport](/concept/layer/web-transport) is a small layer that shares a QUIC connection with HTTP/3.
+- A **broadcast** contains one or more named **tracks**.
+- A **track** is an ordered sequence of independently delivered **groups**.
+- A **group** contains reliably ordered **frames** and can be canceled without
+  blocking other groups.
 
-Basically it's like WebSocket but for QUIC instead of TCP.
-Browsers need it because not using HTTP would be some cardinal sin or something.
-Everybody else can use QUIC directly instead.
+Relays use these boundaries for caching, fan-out, and prioritization without
+parsing codecs or application data.
 
-## WebSocket (optional)
+## Media
 
-[WebSocket](/concept/layer/web-socket) is a TCP fallback for when QUIC is blocked (corporate firewalls) or unsupported (Safari).
+[hang](/concept/layer/hang) defines the media information endpoints need to
+share: a track catalog, codec configuration, timestamps, and frame containers.
+The relay remains unaware of those details.
 
-MoQ clients will automatically race the QUIC and WebSocket connections in parallel, using whatever wins the race.
-It sucks but sometimes *media over QUIC* isn't actually an option.
+## Application data
 
-## iroh (optional)
+Applications can add tracks for control messages, metadata, telemetry, or other
+live data. Unknown tracks do not change relay behavior or interfere with media
+tracks.
 
-[iroh](/concept/layer/iroh) is a peer-to-peer alternative to dialing a server.
-
-You dial a public key instead of a hostname, and iroh handles discovery and hole punching.
-It's still QUIC underneath, so nothing above this layer changes.
-Native only, since a browser can't hole punch.
-
-Reach for it on a local network, where two peers can talk without anything in the middle.
-Across the internet, run a [MoQ relay](/bin/relay/) instead: iroh's own relay forwards opaque
-packets like WebRTC's TURN, so it costs you a hop without the caching and fanout that hop
-should be buying.
-
-Note that only the media path can be kept local. An endpoint publishes its address to n0's
-discovery servers whichever way it's configured.
-
-## MoQ Transport
-
-[moq-lite](/concept/layer/moq-lite) is a forwards-compatible subset of the [MoqTransport](/concept/standard/moq-transport) specification.
-moq-lite clients work with any moq-transport CDN, so you're not locked in.
-
-The goal is a generic pub/sub protocol that can be scaled up via a CDN (see [moq-relay](/bin/relay/)).
-The CDN doesn't know anything about media, it just knows track/group/frame boundaries and what it should do during congestion.
-Think of it like HTTP but for live content.
-
-MoQ is bidirectional, so a **session** can be both a **publisher** and a **subscriber**:
-
-- A publisher produces **broadcasts**, split into one or more **tracks**.
-- A subscriber discovers available broadcasts and can choose to subscribe to tracks.
-
-Each subscription is split into QUIC streams:
-
-- A **group** is a QUIC stream (independent, unordered) that can be closed or reset (congestion).
-- A **frame** is a chunk of bytes with an upfront size, delivered reliably and in order *within a group*.
-
-## Media Format
-
-[hang](/concept/layer/hang) is a simple media format running on top of moq-lite.
-The relay doesn't care about media details, but the end clients need to agree on something: a catalog of tracks, a container for each frame, and codec configuration.
-
-The IETF is working on a [suite of drafts](/concept/standard/msf) but the ideas are similar.
-
-## Application
-
-MoQ tracks are additive.
-You can create new tracks for whatever purpose and it doesn't interfere with the function of a relay or media client.
-Go ahead, create a `controller` track to stream button presses and it will be treated like any other opaque sequence of bytes.
-
-MoQ is implemented in application space, not built into the browser like WebRTC.
-If you don't like something, fork it and ship your own web and native apps.
-
-## More Info
-
-I'd recommend starting with the minimal:
-
-- [moq-lite](/concept/layer/moq-lite)
-- [hang](/concept/layer/hang)
-
-Then read more about the various [IETF standards](/concept/standard/).
+Start with [moq-lite](/concept/layer/moq-lite) and
+[hang](/concept/layer/hang), then use the [standards overview](/concept/standard/)
+to understand the wider protocol ecosystem.

--- a/doc/concept/layer/web-socket.md
+++ b/doc/concept/layer/web-socket.md
@@ -1,123 +1,40 @@
 ---
 title: WebSocket
-description: A TCP fallback for corporate nerds who block QUIC, and Safari users.
+description: A TCP fallback when QUIC or WebTransport is unavailable
 ---
 
 # WebSocket
 
-I'm bored of writing so much documentation.
-Check out the next page on [moq-lite](/concept/layer/moq-lite) instead; it's way more interesting.
+WebSocket is the compatibility transport for networks or clients that cannot
+use QUIC. It keeps the same stream-oriented interface as WebTransport, so the
+moq-lite layer does not need a separate protocol path.
 
-Here's some AI slop for now:
+## Connection behavior
 
-## AI SLOP
+The client can race WebTransport and WebSocket connections and keep the first
+one that succeeds. The WebSocket path changes `https://` to `wss://` (or
+`http://` to `ws://`) and negotiates the `webtransport` subprotocol.
 
-WebSocket is a TCP fallback for when QUIC/WebTransport isn't available.
-This happens more often than you'd think: corporate firewalls love blocking UDP, and Safari didn't support WebTransport until 26.4.
+The [web-transport-ws](https://github.com/moq-dev/web-transport/tree/main/rs/web-transport-ws)
+polyfill multiplexes bidirectional and unidirectional logical streams over the
+WebSocket connection. Its frame types cover stream data, stream completion,
+reset, stop-sending, and connection close.
 
-We use a thin polyfill called [web-transport-ws](https://github.com/moq-dev/web-transport/tree/main/rs/web-transport-ws) that emulates the WebTransport API over a WebSocket connection.
-It multiplexes streams using a simple binary framing protocol, so the rest of the stack doesn't need to know or care that it's running over TCP.
+## Tradeoffs
 
-### How It Works
+WebSocket improves reach, but it cannot reproduce QUIC's behavior under loss:
 
-When establishing a connection, the client races QUIC/WebTransport against WebSocket in parallel.
-WebSocket wins the race when UDP is blocked or WebTransport isn't supported.
+- TCP loss blocks every logical stream behind the missing bytes.
+- Stream priority cannot change the order of bytes already queued in TCP.
+- Resetting a logical stream does not remove its buffered bytes from the TCP
+  connection.
 
-The polyfill converts the URL scheme (`https://` → `wss://`, `http://` → `ws://`) and connects with the `webtransport` subprotocol.
-Once connected, it provides the same API as WebTransport: bidirectional streams, unidirectional streams, and connection management.
+These differences matter most during congestion, when a delayed old media
+group can block newer groups. Prefer WebTransport when it is available and keep
+WebSocket as a fallback.
 
-Obviously it won't perform as well as QUIC during congestion — everything gets head-of-line blocked over TCP.
-But it's better than not working at all.
+## Related
 
-### Streams
-
-Stream IDs are encoded as variable-length integers with the lower 2 bits indicating the stream type:
-
-| Bit 0 | Bit 1 | Type |
-|-------|-------|------|
-| 0 | 0 | Client-initiated bidirectional |
-| 1 | 0 | Server-initiated bidirectional |
-| 0 | 1 | Client-initiated unidirectional |
-| 1 | 1 | Server-initiated unidirectional |
-
-This matches the [QUIC stream ID scheme](https://datatracker.ietf.org/doc/html/rfc9000#section-2.1).
-
-### Framing
-
-Each WebSocket binary message contains a single frame.
-The frame type is identified by the first byte, borrowing values from the QUIC spec:
-
-#### `STREAM` (0x08) / `STREAM_FIN` (0x09)
-
-Carries data for a stream. `STREAM_FIN` indicates the final data on the stream.
-
-```text
-+--------+-----------+---------+
-| Type   | Stream ID | Payload |
-| 1 byte | VarInt    | ...     |
-+--------+-----------+---------+
-```
-
-No length field is needed since WebSocket already provides message boundaries.
-
-#### `RESET_STREAM` (0x04)
-
-Abruptly terminates the sending side of a stream with an error code.
-
-```text
-+--------+-----------+------------+
-| Type   | Stream ID | Error Code |
-| 1 byte | VarInt    | VarInt     |
-+--------+-----------+------------+
-```
-
-#### `STOP_SENDING` (0x05)
-
-Requests the peer stop sending on a stream. The peer should respond with a `RESET_STREAM`.
-
-```text
-+--------+-----------+------------+
-| Type   | Stream ID | Error Code |
-| 1 byte | VarInt    | VarInt     |
-+--------+-----------+------------+
-```
-
-#### `APPLICATION_CLOSE` (0x1d)
-
-Gracefully closes the connection with an error code and reason.
-
-```text
-+--------+------------+--------+
-| Type   | Error Code | Reason |
-| 1 byte | VarInt     | UTF-8  |
-+--------+------------+--------+
-```
-
-### VarInt Encoding
-
-Variable-length integers use the [QUIC VarInt encoding](https://datatracker.ietf.org/doc/html/rfc9000#section-16).
-The first two bits indicate the length:
-
-| Prefix | Length | Max Value |
-|--------|--------|-----------|
-| `00`   | 1 byte | 63 |
-| `01`   | 2 bytes | 16,383 |
-| `10`   | 4 bytes | 1,073,741,823 |
-| `11`   | 8 bytes | 4,611,686,018,427,387,903 |
-
-### Limitations
-
-Let's be real: this is a polyfill, not a replacement.
-
-- **Head-of-line blocking**: TCP delivers bytes in order, so a lost packet stalls everything. The whole point of QUIC streams is to avoid this.
-- **No prioritization**: The sender can't choose which stream gets bandwidth first. With QUIC, we prioritize new video over old video — over WebSocket, they're all stuck in line.
-- **No partial reliability**: You can reset a logical stream, but the bytes already in the TCP buffer will still be delivered (and block everything behind them).
-
-It's good enough for low-congestion scenarios and ensures your app works everywhere.
-For the best experience, use a browser that supports WebTransport.
-
-### Future
-
-There is a [WebTransport over HTTP/2 draft](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http2-13) that could replace this WebSocket polyfill.
-It's too little, too late for now, but maybe one day.
-In the meantime, WebSocket is the only reliable fallback for Safari and older iOS devices.
+- [QUIC](/concept/layer/quic)
+- [WebTransport](/concept/layer/web-transport)
+- [moq-lite](/concept/layer/moq-lite)

--- a/doc/concept/layer/web-socket.md
+++ b/doc/concept/layer/web-socket.md
@@ -13,12 +13,12 @@ moq-lite layer does not need a separate protocol path.
 
 The client can race WebTransport and WebSocket connections and keep the first
 one that succeeds. The WebSocket path changes `https://` to `wss://` (or
-`http://` to `ws://`) and negotiates the `webtransport` subprotocol.
+`http://` to `ws://`) and negotiates a QMux subprotocol for the MoQ version.
 
-The [web-transport-ws](https://github.com/moq-dev/web-transport/tree/main/rs/web-transport-ws)
-polyfill multiplexes bidirectional and unidirectional logical streams over the
-WebSocket connection. Its frame types cover stream data, stream completion,
-reset, stop-sending, and connection close.
+The [QMux implementation](https://github.com/moq-dev/web-transport/tree/main/rs/qmux)
+multiplexes bidirectional and unidirectional logical streams over the WebSocket
+connection. Its frame types cover stream data, stream completion, reset,
+stop-sending, and connection close.
 
 ## Tradeoffs
 

--- a/doc/concept/standard/cmaf.md
+++ b/doc/concept/standard/cmaf.md
@@ -1,6 +1,0 @@
----
-title: CMAF
-description: Common Media Application Format (CMAF) for streaming media
----
-
-TODO

--- a/doc/concept/standard/index.md
+++ b/doc/concept/standard/index.md
@@ -1,49 +1,32 @@
 ---
 title: Standards
-description: IETF drafts and protocol specifications
+description: IETF drafts and protocol specifications used by MoQ
 ---
 
 # Standards
 
-MoQ is a big tent, full of many different opinions and ideas.
-I consider any media protocol that uses QUIC to be part of MoQ, even if it's part of a standards body or organization.
-
-Additionally, MoQ is experimental and not yet battle-tested, so expect all of these standards to change.
-If you're interested in participating, join any of these communities and get involved.
+MoQ is still evolving. This project implements a focused protocol stack while
+remaining compatible with the broader IETF work where practical.
 
 ## IETF MoQ Working Group
 
-The IETF MoQ Working Group is the official standardization body for MoQ.
-The group is primarily focusing on the [MoqTransport](/concept/standard/moq-transport) specification, but there's a number of other drafts too.
+The [IETF MoQ Working Group](https://datatracker.ietf.org/group/moq/about/)
+develops the MoqTransport protocol and related media specifications.
 
-There's no membership fee or criteria to join.
-If you want to participate, you should show up to the regular online (and in-person) meetings.
-Once you get more involved, jump into the excessive number of [GitHub issues](https://github.com/moq-wg/moq-transport/issues) and join the [mailing list](https://mailarchive.ietf.org/arch/browse/moq/).
+- [Working group documents](https://datatracker.ietf.org/group/moq/documents/)
+- [MoqTransport repository](https://github.com/moq-wg/moq-transport)
+- [Working group mailing list](https://mailarchive.ietf.org/arch/browse/moq/)
 
-- [Working Group](https://datatracker.ietf.org/group/moq/about/)
-- [Documents](https://datatracker.ietf.org/group/moq/documents/)
-- [GitHub](https://github.com/moq-wg/moq-transport)
+The main specifications described in this documentation are
+[MoqTransport](/concept/standard/moq-transport),
+[MSF](/concept/standard/msf), and [LOC](/concept/standard/loc).
 
-## moq.dev
+## moq.dev specifications
 
-[moq.dev](https://moq.dev) is an open-source implementation of MoQ primarily focused on production usage.
+The primary moq.dev stack uses [moq-lite](/concept/layer/moq-lite), a smaller
+forward-compatible transport profile, and [hang](/concept/layer/hang), its media
+catalog and container format. The normative specifications are maintained as
+[Internet-Drafts](/draft/) alongside the implementation.
 
-The goal is to support compatibility with the IETF drafts, but not a full implementation.
-The IETF process is slow and involves a lot of debate, discussion, and negotiation.
-All of this is *on purpose* and produces a better standard in the end.
-
-But the standard is too immature, full of bloat, and there's too much churn.
-If we had to gate every change behind IETF approval, it would take months to make even the smallest change.
-
-To that end, we've created a forwards-compatible subset of [MoqTransport](/concept/standard/moq-transport) called [moq-lite](/concept/layer/moq-lite).
-moq-lite is forwards compatible with moq-transport, so it works with any moq-transport CDN (ex. [Cloudflare](https://moq.dev/blog/first-cdn)).
-
-On the media side, there are the [MSF](/concept/standard/msf) (catalog) and [LOC](/concept/standard/loc) (container) drafts.
-They are too early/unstable to be useful, so we're using a custom [hang](/concept/layer/hang) media format instead.
-
-Our own specifications are written as Internet-Drafts and rendered under [Drafts](/draft/).
-
-- [Website](https://moq.dev)
-- [GitHub](https://github.com/moq-dev/moq)
-- [Documentation](https://doc.moq.dev)
-- [Discord](https://discord.moq.dev)
+See [interoperability](/concept/standard/interop) for commands and current
+compatibility notes.

--- a/doc/concept/use-case/distribution.md
+++ b/doc/concept/use-case/distribution.md
@@ -151,5 +151,6 @@ HTTP/3 is a new kid on the block, and MoQ can ride that momentum, but it's going
 I think the most crucial feature for MoQ is backwards compatibility with HLS/DASH.
 The ability to serve HLS/DASH content via MoQ and HTTP is necessary for the industry to adopt MoQ.
 
-That's why [hang](/concept/layer/hang) can support CMAF and [moq-relay](/bin/relay/) can serve tracks via HTTP.
-More documentation coming soon.
+That is why [hang](/concept/layer/hang) can carry CMAF and
+[moq-relay](/bin/relay/) can serve cached tracks over HTTP for compatible
+clients.

--- a/doc/concept/use-case/index.md
+++ b/doc/concept/use-case/index.md
@@ -1,12 +1,13 @@
 ---
 title: Use Cases
-description: How MoQ should be used in the wild
+description: Where MoQ fits in live media systems
 ---
 
 # Use Cases
 
-- [Contribution](/concept/use-case/contribution): A publisher (ex. OBS) sends data to a service (ex. Twitch).
-- [Distribution](/concept/use-case/distribution): A service (ex. Twitch) distributes data to viewers.
-- [Conferencing](/concept/use-case/conferencing): A service (ex. Zoom) facilitates a conference between multiple participants.
-- [AI](/concept/use-case/ai): Generative AI, overlays, voice agents, and more.
-- [Other](/concept/use-case/other): Some ideas for other use cases that might be viable.
+| Use case | Typical flow | Why MoQ fits |
+| --- | --- | --- |
+| [Contribution](/concept/use-case/contribution) | Encoder to media service | Low latency ingest without a separate protocol stack. |
+| [Distribution](/concept/use-case/distribution) | Media service to viewers | Cacheable fan-out with independent delivery of media groups. |
+| [Conferencing](/concept/use-case/conferencing) | Participants through a service | Bidirectional publishing and subscription on one session. |
+| [AI](/concept/use-case/ai) | Media and data through an inference service | On-demand tracks, low latency, and non-media data alongside audio and video. |

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,141 +2,71 @@
 layout: home
 
 hero:
+  name: Media over QUIC
+  text: Live media without latency buildup
+  tagline: A composable protocol stack for real-time media and data at scale.
   actions:
     - theme: brand
-      text: Setup
+      text: Quick start
       link: /setup/
     - theme: alt
-      text: Concepts
-      link: /concept/
-    - theme: alt
-      text: Apps
-      link: /bin/
-    - theme: alt
-      text: Libraries
-      link: /lib/
-    - theme: alt
-      text: Demo
+      text: Try the demo
       link: https://moq.dev/
+    - theme: alt
+      text: Understand MoQ
+      link: /concept/
 
 features:
   - icon:
       src: /emoji/rocket.svg
-    title: Adaptive
-    details: MoQ supports the entire latency spectrum. Simultaneously support real-time, interactive, or lean-back experiences with a unified stack.
+    title: Low latency
+    details: Independent streams prevent old media from delaying the live edge during congestion.
 
   - icon:
       src: /emoji/stonk.svg
     title: Scalable
-    details: All content can be cached and fanned-out via a CDN. Serve millions of concurrent viewers across the globe, including via Cloudflare.
+    details: Generic relays cache and fan out content without understanding its media format.
 
   - icon:
       src: /emoji/puzzle.svg
-    title: Extensible
-    details: Supports contribution, distribution, conferencing, and whatever you can dream up. Extend the protocol with custom tracks for any live content.
+    title: Composable
+    details: Protocol, media, and application layers can evolve independently and carry custom tracks.
 
   - icon:
       src: /emoji/globe.svg
-    title: Modern Web
-    details: Utilizes WebTransport, WebCodecs, and WebAudio APIs for modern browser support without hacks.
-
-  - icon:
-      src: /emoji/box.svg
-    title: Cross-Platform
-    details: Libraries for Rust (native) and TypeScript (web), plus FFI bindings for C, Python, Kotlin, Swift, and Go. Integrations with ffmpeg, OBS, GStreamer, and more to come.
-
-  - icon:
-      src: /emoji/battery.svg
-    title: Efficient
-    details: Save resources by only encoding or transmitting data when needed. Built on top of production-ready QUIC libraries.
-
-  - icon:
-      src: /emoji/lock.svg
-    title: Secure
-    details: Encrypted via TLS and authenticated via JWT. You can optionally self-host a private CDN or end-to-end encrypt your content.
-
-  - icon:
-      src: /emoji/back.svg
-    title: Backwards Compatible
-    details: Supports CMAF and HLS for legacy device support. Migrate legacy devices at your own pace.
-
-  - icon:
-      src: /emoji/link.svg
-    title: Decentralized
-    details: Host your own CDN, use a 3rd party service, and/or connect P2P via Iroh (native only). Broadcasts are automatically discovered and gossiped.
+    title: Cross-platform
+    details: Native and browser implementations, language bindings, gateways, and production tools share one protocol.
 ---
 
 ## What is MoQ?
 
-**Media over QUIC** (MoQ) is a next-generation live media protocol.
-As the name implies, we use QUIC to concurrently transmit media and avoid latency build-up during congestion.
-The protocol is being standardized by the [IETF](https://datatracker.ietf.org/group/moq/about/) and backed by some of the largest tech companies: Google, Cisco, Akamai, Cloudflare, etc.
+Media over QUIC (MoQ) is a family of protocols for live media and data. It uses
+independent QUIC streams so congestion on one part of a broadcast does not block
+newer content on another.
 
-[moq.dev](https://moq.dev) is an open source implementation written in Rust (native) and Typescript (web).
-We support compatibility with the *official* [IETF drafts](https://datatracker.ietf.org/group/moq/documents/), but the main focus is a subset called [moq-lite](/concept/layer/moq-lite) and [hang](/concept/layer/hang).
-The idea is to [build first, argue later](/concept/standard/).
+This project provides a production-oriented implementation in Rust and
+TypeScript. Its primary protocol stack is [moq-lite](/concept/layer/moq-lite)
+for transport and [hang](/concept/layer/hang) for media, with compatibility for
+the [IETF MoQ specifications](/concept/standard/).
 
-See the [concepts](/concept/) page for a breakdown of the layering, rationale, and comparison to other protocols.
+## Choose a path
 
-## Setup
+| Goal | Start here |
+| --- | --- |
+| Run the local demo | [Quick start](/setup/) |
+| Publish, play, or convert media | [Applications](/bin/) |
+| Add MoQ to an application | [Libraries](/lib/) |
+| Operate a relay | [moq-relay](/bin/relay/) |
+| Learn the architecture and tradeoffs | [Concepts](/concept/) |
+| Read the protocol specifications | [Internet-Drafts](/draft/) |
 
-Get up and running in seconds with [Nix](https://nixos.org/download.html) ([+Flakes](https://nixos.wiki/wiki/Flakes)), or be lame and [install stuff manually](/setup/):
+The main implementations are [Rust](/lib/rs/) for native applications and
+[TypeScript](/lib/js/) for browsers and JavaScript runtimes. C, Python, Kotlin,
+Swift, and Go bindings wrap the Rust core.
 
-```bash
-# Runs a relay, media publisher, and the web server
-nix develop -c just
-```
+## Project links
 
-If everything works, a browser window will pop up demoing how to both publish and watch content via the web.
-
-- Keep reading the [development guide](/setup/dev) to run more advanced demos.
-- Skip ahead to the [production guide](/setup/prod) to see what it takes to deploy this bad boy.
-- Using an AI coding agent? [Teach it MoQ](/setup/agent) with a one-line prompt.
-
-## Applications
-
-There are a bunch of MoQ binaries and plugins.
-
-Some highlights:
-
-- [moq-relay](/bin/relay/) - A server connecting publishers to subscribers, able to form a [self-hosted CDN cluster](/bin/relay/cluster).
-- [moq-cli](/bin/cli) - A CLI that can import and publish MoQ broadcasts from a variety of formats (fMP4, HLS, MPEG-TS, FLV, etc), including via ffmpeg.
-- [obs](/bin/obs) - An OBS plugin, able to publish a MoQ broadcast and/or use MoQ broadcasts as sources.
-- [gstreamer](/bin/gstreamer) - A gstreamer plugin, split into a source and a sink.
-- [web](/bin/web) - A web component you can slap on your website to watch and publish MoQ broadcasts.
-- [...and more](/bin/)
-
-## Rust Crates 🦀
-
-Integrate MoQ into your application without fear. Focused on [native](/lib/rs/env/native) but has token [WASM](/lib/rs/env/wasm) support.
-
-Some highlights:
-
-- [moq-net](/lib/rs/crate/moq-net) - Real-time pub/sub with built-in caching, fan-out, and prioritization.
-- [moq-mux](/lib/rs/crate/moq-mux) - Media muxers/demuxers for fMP4, CMAF, MPEG-TS, and FLV.
-- [libmoq](/lib/rs/crate/libmoq) - C bindings for the above, no finagling Rust into your build system.
-- [web-transport](/lib/rs/crate/web-transport) - A suite of crates required to get QUIC access in the browser, plus some polyfills.
-- [...and more](/lib/rs/)
-
-## TypeScript Packages
-
-Run MoQ in a [web browser](/lib/js/env/web) utilizing the latest Web tech.
-Or run on [native](/lib/js/env/native) with polyfills via Node/Bun/Deno.
-
-Some highlights:
-
-- [@moq/net](/lib/js/@moq/net) - Real-time pub/sub with built-in caching, fan-out, and prioritization.
-- [@moq/hang](/lib/js/@moq/hang/) - Performs any media stuff: capture, encode, transmux, decode, render.
-- [@moq/watch](/lib/js/@moq/watch) - Subscribe to and render MoQ broadcasts.
-- [@moq/publish](/lib/js/@moq/publish) - Publish media to MoQ broadcasts.
-- [...and more](/lib/js/)
-
-## Other Languages
-
-FFI bindings around the Rust core, with idiomatic APIs in each language:
-
-- [C](/lib/c/) - `libmoq` static + shared library with an auto-generated header.
-- [Python](/lib/py/) - `asyncio`-friendly bindings, published to PyPI.
-- [Kotlin](/lib/kt/) - Coroutines and `Flow` for Android and the JVM.
-- [Swift](/lib/swift/) - Async sequences for iOS, iPadOS, and macOS.
-- [Go](/lib/go/) - cgo bindings resolved via `go get`.
+- [Live demo](https://moq.dev/)
+- [GitHub repository](https://github.com/moq-dev/moq)
+- [Discord](https://discord.moq.dev)
+- [IETF MoQ Working Group](https://datatracker.ietf.org/group/moq/about/)

--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -345,7 +345,9 @@ For production, you'll want to:
 3. Use a bundler, see [examples](https://github.com/moq-dev/web) for Vite, Webpack, esbuild, and more.
 
 **NOTE** both of these libraries are intended for client-side.
-However, `@moq/net` can run on the server side using [Deno](https://deno.com/) or a [WebTransport polyfill](https://github.com/moq-dev/web-transport/tree/main/rs/web-transport-ws).
+However, `@moq/net` can run on the server side using [Deno](https://deno.com/),
+the WebSocket-based [`@moq/qmux`](https://github.com/moq-dev/web-transport/tree/main/js/qmux),
+or the native [`@moq/web-transport`](https://github.com/moq-dev/web-transport/tree/main/js/web-transport) package.
 Don't even try to run `@moq/hang` on the server side or you'll run into a ton of issues, *especially* with Next.js.
 
 ## Next Steps

--- a/doc/lib/rs/crate/web-transport.md
+++ b/doc/lib/rs/crate/web-transport.md
@@ -32,7 +32,7 @@ The repository contains multiple crates:
 |-------|-------------|
 | `web-transport` | Core WebTransport implementation |
 | `web-transport-quinn` | Quinn-based QUIC transport |
-| `web-transport-ws` | WebSocket polyfill for non-WebTransport browsers |
+| `qmux` | QMux over TCP, TLS, Unix sockets, and WebSocket |
 
 ## Installation
 
@@ -58,7 +58,7 @@ For a real-world example of using `web-transport` with MoQ, see the [`rs/moq-nat
 - **Datagrams** - Unreliable, unordered data
 - **Session Management** - Peer/local addresses, graceful close
 - **TLS** - Self-signed certificates (dev), Let's Encrypt (production), certificate fingerprints
-- **WebSocket Polyfill** - See [web-transport-ws](https://github.com/moq-dev/web-transport/tree/main/rs/web-transport-ws)
+- **WebSocket fallback** - See [qmux](https://github.com/moq-dev/web-transport/tree/main/rs/qmux)
 
 ## Integration with MoQ
 

--- a/doc/setup/dev.md
+++ b/doc/setup/dev.md
@@ -1,132 +1,93 @@
 ---
-title: Development Guide
-description: Set up the rest of the stuff.
+title: Development
+description: Run, test, and debug the MoQ workspace
 ---
 
 # Development
 
-Still here? You must be a Big Buck Bunny fan.
+The repository uses [Just](https://github.com/casey/just) as its command runner.
+Run commands inside the Nix development shell when possible so your tools match
+CI.
 
-This guide covers the rest of the stuff you can run locally.
+## Common commands
 
-## Just
+| Command | Purpose |
+| --- | --- |
+| `just` | Start the local relay, test publisher, and web demo. |
+| `just --list` | List available recipes. |
+| `just fix` | Format and lint changed packages and their dependents. |
+| `just check` | Compile and lint the same changed-package scope. |
+| `just test` | Run tests for the same changed-package scope. |
+| `just fix-all` | Format and lint every package. |
+| `just check-all` | Compile and lint every package. |
+| `just test all` | Test every package. |
 
-We use [Just](https://github.com/casey/just) to run helper commands.
-It's *just* a fancier `Makefile` so you don't have to remember all the commands.
-
-### Common Commands
+For example, publish the Tears of Steel HLS fixture over MoQ with:
 
 ```bash
-# Run the demo (default)
-just
-
-# List all available commands
-just --list
-
-# This is equivalent to 3 terminal tabs:
-# just relay
-# just web
-# just pub bbb
-
-# Make sure the code you changed compiles and passes linting
-just check
-
-# Run the tests for the code you changed
-just test
-
-# Auto-fix linting errors, same scope
-just fix
-
-# Same as the above, over every package
-just check-all
-just test all
-just fix-all
-
-# Publish a HLS broadcast (CMAF) over MoQ
 just pub hls tos
 ```
 
-Want more? See the [justfile](https://github.com/moq-dev/moq/blob/main/justfile) for all commands.
+The root [justfile](https://github.com/moq-dev/moq/blob/main/justfile) and
+`just --list` show the remaining recipes.
 
-### The Internet
+## Test over the internet
 
-Most of the commands default to `http://localhost:4443`.
-That's pretty lame.
+Most demo commands use the local relay at `http://localhost:4443`. The public
+test relay is available at `https://cdn.moq.dev/anon`:
 
-If you want to do a real test of how MoQ works over the internet, you're going to need a remote server.
-Fortunately I'm hosting a small cluster on Linode for just the occasion: `https://cdn.moq.dev`
-
-::: warning
-All of these commands are unauthenticated, hence the `/anon`.
-Anything you publish is public and discoverable... so be careful and don't abuse it.
-[Setup your own relay](/setup/prod) or contact `@kixelated` for an auth token.
+::: warning Public namespace
+The `/anon` path is unauthenticated. Broadcasts published there are public and
+discoverable. Do not publish private media or rely on a name remaining reserved.
 :::
 
 ```bash
-# Run the web server, pointing to the public relay
-# NOTE: The `bbb` demo on moq.dev uses a different path so it won't show up.
+# Run the local web client against the public relay.
 just web serve https://cdn.moq.dev/anon
 
-# Publish Tears of Steel, watch it via https://moq.dev/watch?name=tos
+# Publish Tears of Steel, then open https://moq.dev/watch?name=tos.
 just pub tos https://cdn.moq.dev/anon
 
-# Publish a clock broadcast
+# Publish and subscribe to a data-only clock broadcast in separate terminals.
 just pub clock publish https://cdn.moq.dev/anon
-
-# Subscribe to said clock broadcast (different tab)
 just pub clock subscribe https://cdn.moq.dev/anon
-
-# Publish an authentication broadcast
-just pub bbb https://cdn.moq.dev/?jwt=not_a_real_token_ask_for_one
 ```
 
-## Debugging
+For private paths, deploy a relay and configure
+[authentication](/bin/relay/auth).
 
-### Rust
+## Debug Rust
 
-You can set the logging level with the `RUST_LOG` environment variable.
+Use `RUST_LOG` for structured logs and `RUST_BACKTRACE` for panic backtraces:
 
 ```bash
-# Print the most verbose logs
 RUST_LOG=trace just
-```
-
-If you're getting a panic, use `RUST_BACKTRACE=1` to get a backtrace.
-
-```bash
-# Print a backtrace on panic.
 RUST_BACKTRACE=1 just
 ```
 
-## IDE Setup
+## Editor setup
 
-I use [Cursor](https://www.cursor.com/), but anything works.
-
-Recommended extensions:
+Any editor with standard Rust and TypeScript support works. Useful extensions
+include:
 
 - [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
 - [Biome](https://marketplace.visualstudio.com/items?itemName=biomejs.biome)
 - [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
 - [direnv](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv)
 
-## Contributing
+## Before opening a pull request
 
-Run `just fix` before pushing your changes, otherwise CI will yell at you.
-CI runs `just check` and then `just test`, so running those two locally is the easiest way to debug any issues.
-All three only touch the packages your branch changed (plus anything depending on them), measured against the branch's upstream; `just check-all`, `just test all`, and `just fix-all` cover everything.
+Run the same checks used by CI:
 
-Please don't submit a vibe coded PR unless you understand it.
-`You're absolutely right!` is not always good enough.
+```bash
+just fix
+just check
+just test
+```
 
-## Onwards
+These commands scope work to packages changed from the branch's configured
+upstream and include their dependents. Use the `-all` variants when changing
+shared tooling or configuration that the package diff cannot attribute.
 
-`just` runs three processes that normally, should run on separate hosts.
-Learn how to run them [in production](/setup/prod).
-
-Or take a detour and:
-
-- Brush up on the [concepts](/concept/).
-- Discover the other [apps](/bin/).
-- `use` the [Rust crates](/lib/rs/).
-- `import` the [Typescript packages](/lib/js/).
-- or IDK, go take a shower or something while Claude parses the docs.
+See [CONTRIBUTING.md](https://github.com/moq-dev/moq/blob/main/CONTRIBUTING.md)
+for branch targeting, commits, and pull requests.

--- a/doc/setup/dev.md
+++ b/doc/setup/dev.md
@@ -18,9 +18,9 @@ CI.
 | `just fix` | Format and lint changed packages and their dependents. |
 | `just check` | Compile and lint the same changed-package scope. |
 | `just test` | Run tests for the same changed-package scope. |
-| `just fix-all` | Format and lint every package. |
+| `just fix-all` | Format and lint every Rust, TypeScript, and Python package. |
 | `just check-all` | Compile and lint every package. |
-| `just test all` | Test every package. |
+| `just test all` | Test every Rust, TypeScript, and Python package. |
 
 For example, publish the Tears of Steel HLS fixture over MoQ with:
 
@@ -86,8 +86,10 @@ just test
 ```
 
 These commands scope work to packages changed from the branch's configured
-upstream and include their dependents. Use the `-all` variants when changing
-shared tooling or configuration that the package diff cannot attribute.
+upstream and include their dependents. Use `just fix-all`, `just check-all`, and
+`just test all` when changing shared tooling or configuration that the package
+diff cannot attribute. `just check-all` also covers language wrappers whose
+tests are part of their check recipe.
 
 See [CONTRIBUTING.md](https://github.com/moq-dev/moq/blob/main/CONTRIBUTING.md)
 for branch targeting, commits, and pull requests.

--- a/doc/setup/index.md
+++ b/doc/setup/index.md
@@ -1,101 +1,71 @@
 ---
 title: Quick Start
-description: Get started with MoQ in seconds
+description: Run the MoQ demo locally
 ---
 
 # Quick Start
 
-We've got a few demos to show off MoQ in action.
-Everything runs on localhost in development, but in production of course you'll run these components across multiple hosts.
+The default demo starts a relay, publishes a test video, and opens the web client.
+Everything runs on your machine.
 
-Start by cloning the repo:
+First, clone the repository:
 
 ```bash
 git clone https://github.com/moq-dev/moq
 cd moq
 ```
 
-Then pick your poison: Nix or not.
+## With Nix
 
-## Option 1: Using Nix (Recommended)
-
-The recommended approach is to use [Nix](https://nixos.org/download.html).
-It's like Docker but without the VM; all dependencies are pinned to specific versions.
-
-Install the following:
-
-- [Nix](https://nixos.org/download.html)
-- [Nix Flakes](https://nixos.wiki/wiki/Flakes)
-- (optional) [Nix Direnv](https://github.com/nix-community/nix-direnv)
-
-Then run the demo:
+Nix is the recommended setup because it uses the tool versions pinned by the
+repository. Install [Nix](https://nixos.org/download.html) with flakes enabled,
+then run:
 
 ```bash
-# Runs the demo using pinned dependencies
-nix develop -c just
+nix develop --command just
 ```
 
-If you install `direnv`, then the Nix shell will be loaded whenever you `cd` into the repo:
+With [nix-direnv](https://github.com/nix-community/nix-direnv), entering the
+repository loads the development shell and the command becomes `just`.
 
-```bash
-# Run the demo... in 9 keystrokes
-just
-```
+## Without Nix
 
-## Option 2: Manual Installation
-
-::: tip On Windows?
-See [Windows Setup](/setup/windows) for a `winget`-based `setup.bat` and the `just` PATH caveats.
-:::
-
-If you don't like Nix or enjoy suffering with Windows, then you can manually install the dependencies:
+Install these tools first:
 
 - [Just](https://github.com/casey/just)
 - [Rust](https://www.rust-lang.org/tools/install)
 - [Bun](https://bun.sh/)
 - [FFmpeg](https://ffmpeg.org/download.html)
-- ...more?
 
-Some workspace crates have additional system dependencies and are excluded from the default build:
-
-- **moq-gst** — requires [GStreamer](https://gstreamer.freedesktop.org/) development libraries
-- **libmoq** — requires a C toolchain
-- **moq-ffi** — requires Python and [maturin](https://www.maturin.rs/)
-
-These are all included in the Nix dev shell. To build them manually, install the deps and use `cargo build -p <crate>`.
-
-Then run:
+Then install the workspace tools and start the demo:
 
 ```bash
-# Install additional dependencies, usually linters
 just install
-
-# Run the demo
 just
 ```
 
-When in doubt, check the [Nix Flake](https://github.com/moq-dev/moq/blob/main/flake.nix) for the full list of dependencies.
+Some optional targets need additional system libraries. GStreamer development
+packages are required for `moq-gst`; a C toolchain is required for `libmoq`;
+and the language bindings need their respective toolchains. The Nix development
+shell includes these dependencies.
 
-## What's Happening?
+Windows users should follow the [Windows setup](/setup/windows). Linux packages
+for running released binaries are covered in the [Linux guide](/setup/linux).
 
-The `just` command starts three components:
+## What starts
 
-- [moq-relay](/bin/relay/): A server that routes live data between publishers and subscribers.
-- [moq-cli](/bin/cli): A CLI that publishes video content piped from `ffmpeg`.
-- [demo](/lib/js/@moq/demo): A web page with various demos.
+The default recipe runs three components:
 
-Once everything compiles, it should open [localhost:5173](http://localhost:5173) in your browser.
+1. [moq-relay](/bin/relay/) routes broadcasts between publishers and subscribers.
+2. [moq-cli](/bin/cli) publishes a test video through the relay.
+3. The [web demo](/setup/demo/web) opens at [localhost:5173](http://localhost:5173).
 
-::: warning
-The demo uses an insecure HTTP fetch for local development only. In production, you'll need a proper domain and TLS certificate via [LetsEncrypt](https://letsencrypt.org/docs/) or similar.
-:::
+The local relay uses a generated certificate and fingerprint verification. A
+public deployment needs a stable hostname, trusted TLS certificate, and an open
+UDP port. See [production deployment](/setup/prod).
 
-### More Demos
+## Next steps
 
-- [Web Demo](/setup/demo/web) — watch and publish live streams from a browser
-- [MoQ Boy](/setup/demo/boy) — crowd-controlled Game Boy Color streaming with live video, audio, and anarchy-mode input
-
-Check out the full [development guide](/setup/dev) for more commands, or try publishing to the public relay:
-
-- [OBS](/bin/obs)
-- [GStreamer](/bin/gstreamer)
+- Use the [development guide](/setup/dev) for tests, debugging, and more demos.
+- Try publishing with [OBS](/bin/obs) or [GStreamer](/bin/gstreamer).
+- Explore the [applications](/bin/) and [libraries](/lib/).

--- a/doc/setup/prod.md
+++ b/doc/setup/prod.md
@@ -1,74 +1,79 @@
 ---
 title: Production Deployment
-description: Deploying moq-relay to production
+description: Deploy moq-relay with production networking, TLS, and authentication
 ---
 
 # Production Deployment
 
-Here's a guide on how to get moq-relay running in production.
+A production relay needs a reachable QUIC endpoint, a trusted TLS certificate,
+and an explicit access policy. Start with a working local configuration, then
+make each of these changes before exposing it publicly.
 
-## Overview
+## Deployment checklist
 
-[moq-relay](/bin/relay/) is the core of the MoQ stack.
-It's responsible for routing live tracks (payload agnostic) from 1 client to N clients.
-The relay accepts WebTransport connections from clients, but it can also connect to other relays to fetch upstream.
-Think of the relay as a HTTP web server like [Nginx](https://nginx.org/), but for live content.
+1. Assign the relay a stable hostname.
+2. Route the configured UDP port to the relay for QUIC and WebTransport.
+3. Route TCP if the relay also serves HTTPS, WebSocket, or HTTP endpoints.
+4. Install a certificate whose names include the public hostname.
+5. Configure [authentication](/bin/relay/auth); do not leave the entire path
+   tree anonymous unless that is intentional.
+6. Bind operational endpoints only where trusted monitoring systems can reach
+   them.
+7. Raise UDP socket limits on Linux and monitor startup warnings.
 
-There are multiple companies working on MoQ CDNs (like [Cloudflare](https://moq.dev/blog/first-cdn)) so eventually it won't be necessary to self-host.
-However, you do unlock some powerful features by self-hosting, such as running relays within your internal network.
+The [relay configuration reference](/bin/relay/config) documents the relevant
+`server`, `server.tls`, `web`, `internal`, and `auth` sections.
 
-## QUIC Requirements
+## Networking and TLS
 
-Before we get carried away, we need to cover the QUIC requirements:
+QUIC uses UDP and performs TLS in the relay process. Network infrastructure must
+forward UDP to a relay that can terminate the QUIC connection. If HTTPS or the
+WebSocket fallback is enabled, forward the corresponding TCP port as well.
 
-1. QUIC is a client-server protocol, so you **MUST** have a server with a static IP address.
-2. QUIC requires TLS, so you **MUST** have a TLS certificate, even if it's self-signed.
-3. QUIC uses UDP, so you **MUST** configure your firewall to allow UDP traffic.
-4. QUIC load balancers don't exist yet, so you **MUST** design your own load balancer.
+Use a certificate from a CA trusted by your clients. Configure its certificate
+chain and private key under `server.tls`; the same files can be used for the
+HTTPS listener. Generated certificates and disabled verification are intended
+for development.
 
-These make it a bit more difficult to deploy, but don't worry we have you covered.
+Browser clients can use certificate fingerprint verification for short-lived
+self-signed development certificates. Native clients can use custom root CAs,
+but a public service should normally use a publicly trusted certificate.
 
-## Self-Hosting
+## Access and topology
 
-MoQ should work just fine inside your own network or infrastructure provided you understand the QUIC requirements.
+Use JWT authentication to scope which paths a client can publish or subscribe
+to. Keep operational HTTP endpoints on the `internal` listener when they should
+not be public.
 
-You need at least one server with some way to discover its IP address.
-DNS is the easiest way to do this, but some other way of getting an IP address should also work.
-QUIC also has really awesome anycast support but that's a bit more advanced; reach out if you're interested.
+For multiple regions or failure domains, connect relays with the
+[clustering configuration](/bin/relay/cluster). Each relay should have a stable
+external URL and a topology chosen for the deployment. Clustering complements
+load distribution; it does not decide how clients discover or select an entry
+relay.
 
-TLS is where most people get stuck.
-[See my blog post](https://moq.dev/blog/tls-and-quic) for more details, but here's the important bits:
+## Linux socket buffers
 
-- QUIC uses the same TLS certificate as HTTPS.
-- However, TLS load balancers currently don't support QUIC, so you need to provision your own TLS certificates.
-- You can disable TLS verification if you don't care about MITM attacks, but only for native clients.
-- Web browsers can support self-signed certificates via [fingerprint verification](https://developer.mozilla.org/en-US/docs/Web/API/WebTransport/WebTransport#servercertificatehashes), but it's limited to ephemeral certificates (<2 weeks).
+A relay multiplexes connections over UDP sockets. If an incoming burst exceeds
+the kernel socket buffer, packets are dropped before the relay can process them.
 
-And of course, make sure UDP is allowed on your firewall.
-The default WebTransport port is UDP/443 but anything will work if you put it in the URL.
-
-## Tuning
-
-A relay multiplexes every connection over a single UDP socket, so a burst that doesn't fit in the kernel's socket buffer is dropped before the relay ever sees it, and QUIC congestion control reads those drops as congestion.
-
-`moq-relay` and `moq-cli` request an 8 MiB socket buffer in each direction, but Linux silently clamps the request to `net.core.rmem_max` and `net.core.wmem_max`, which default to 208 KiB.
-You'll get a warning on startup when that happens:
-
-```text
-WARN moq_native::bind: UDP receive buffer is smaller than requested; raise `net.core.rmem_max` or expect packet loss under load wanted=8388608 granted=212992
-```
-
-Raise both limits, persisting them across reboots:
+`moq-relay` requests an 8 MiB buffer in each direction. Linux may clamp that
+request to `net.core.rmem_max` and `net.core.wmem_max`; the relay logs a warning
+when the granted size is too small. Raise both limits and persist them across
+reboots:
 
 ```bash
-printf 'net.core.rmem_max = 8388608\nnet.core.wmem_max = 8388608\n' | sudo tee /etc/sysctl.d/60-moq.conf
+printf 'net.core.rmem_max = 8388608\nnet.core.wmem_max = 8388608\n' | \
+  sudo tee /etc/sysctl.d/60-moq.conf
 sudo sysctl --system
 ```
 
-macOS caps both directions with `kern.ipc.maxsockbuf` instead, and Windows sizes each socket on its own so there's nothing to raise.
+macOS uses `kern.ipc.maxsockbuf`. Windows sizes each socket directly and does
+not use these Linux limits.
 
-## Next Steps
+## Verify the deployment
 
-- Set up [Authentication](/bin/relay/auth)
-- Configure [Clustering](/bin/relay/cluster)
-- Learn about [Concepts](/concept/)
+- Connect with [moq-cli](/bin/cli) from outside the relay network.
+- Publish and subscribe through the paths allowed by a test token.
+- Check the [health and metrics endpoints](/bin/relay/http).
+- Confirm startup logs show the expected certificate, listeners, and socket
+  buffer sizes.

--- a/doc/setup/prod.md
+++ b/doc/setup/prod.md
@@ -30,10 +30,21 @@ QUIC uses UDP and performs TLS in the relay process. Network infrastructure must
 forward UDP to a relay that can terminate the QUIC connection. If HTTPS or the
 WebSocket fallback is enabled, forward the corresponding TCP port as well.
 
-Use a certificate from a CA trusted by your clients. Configure its certificate
-chain and private key under `server.tls`; the same files can be used for the
-HTTPS listener. Generated certificates and disabled verification are intended
-for development.
+Use a certificate from a CA trusted by your clients. QUIC and HTTPS/WSS have
+separate TLS sections, although they can reuse the same certificate files:
+
+```toml
+[server.tls]
+cert = "/etc/letsencrypt/live/relay.example.com/fullchain.pem"
+key = "/etc/letsencrypt/live/relay.example.com/privkey.pem"
+
+[web.https]
+listen = "[::]:443"
+cert = "/etc/letsencrypt/live/relay.example.com/fullchain.pem"
+key = "/etc/letsencrypt/live/relay.example.com/privkey.pem"
+```
+
+Generated certificates and disabled verification are intended for development.
 
 Browser clients can use certificate fingerprint verification for short-lived
 self-signed development certificates. Native clients can use custom root CAs,


### PR DESCRIPTION
## Summary

- Reorganize the main landing, setup, concepts, applications, and relay pages around common user goals.
- Group gateways and integrations in navigation, consolidate deployment guidance, and remove empty or speculative pages.
- Replace placeholder and AI-oriented copy with concise technical guidance, and align WebSocket documentation with the current QMux implementation.
- Correct relay Docker/TLS examples and document the exact scope of repository test recipes.

## Public API changes

None. This PR changes documentation and navigation only.

## Test plan

- just fix
- just check
- Documentation TypeScript checks and 31 draft-rendering tests
- VitePress production build
- Local visual review of the home page and applications sidebar

(Written by GPT-5)