### PR TITLE
perf(kio): lazily allocate waiter list IDs

### DIFF
--- a/rs/kio/benches/channel.rs
+++ b/rs/kio/benches/channel.rs
@@ -9,12 +9,37 @@
 
 use std::hint::black_box;
 use std::task::{Poll, Waker};
+use std::thread;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use kio::{Consumer, Producer, Waiter};
 
 /// Fanout sizes that cover a lone reader, a small room, and a busy broadcast.
 const FANOUT: [usize; 3] = [1, 8, 128];
+
+/// Concurrent constructors and channels per constructor in the contention case.
+const CONSTRUCTORS: usize = 8;
+const CHANNELS_PER_CONSTRUCTOR: usize = 1_024;
+
+/// Measure channel construction when several executor workers create state at once.
+fn bench_create_parallel(c: &mut Criterion) {
+	let mut group = c.benchmark_group("channel_create_parallel");
+	group.throughput(Throughput::Elements((CONSTRUCTORS * CHANNELS_PER_CONSTRUCTOR) as u64));
+	group.bench_function("workers", |b| {
+		b.iter(|| {
+			thread::scope(|scope| {
+				for _ in 0..CONSTRUCTORS {
+					scope.spawn(|| {
+						for _ in 0..CHANNELS_PER_CONSTRUCTOR {
+							black_box(Producer::new(black_box(0u64)));
+						}
+					});
+				}
+			});
+		});
+	});
+	group.finish();
+}
 
 /// One consumer and the cursor it has most recently observed.
 struct Reader {
@@ -102,5 +127,5 @@ fn bench_notify(c: &mut Criterion) {
 	group.finish();
 }
 
-criterion_group!(benches, bench_notify);
+criterion_group!(benches, bench_create_parallel, bench_notify);
 criterion_main!(benches);

--- a/rs/kio/benches/waiter.rs
+++ b/rs/kio/benches/waiter.rs
@@ -35,6 +35,21 @@ fn populated(n: usize) -> (WaiterList, Vec<Waiter>) {
 	(list, waiters)
 }
 
+/// Register the first waiter on a newly constructed list, including lazy list
+/// initialization in the measured path.
+fn bench_register_first(c: &mut Criterion) {
+	c.bench_function("waiter_register_first", |b| {
+		b.iter_batched(
+			|| (WaiterList::new(), Waiter::new(Waker::noop().clone())),
+			|(mut list, waiter)| {
+				waiter.register(&mut list);
+				(list, waiter)
+			},
+			BatchSize::SmallInput,
+		)
+	});
+}
+
 /// Register a fresh waiter into a list of N live entries: the dedup scan misses,
 /// the dead-slot probe finds nothing, and the entry is appended.
 fn bench_register(c: &mut Criterion) {
@@ -186,6 +201,7 @@ fn bench_fanout_cycle_parked(c: &mut Criterion) {
 
 criterion_group!(
 	benches,
+	bench_register_first,
 	bench_register,
 	bench_reregister,
 	bench_register_dead,

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -201,16 +201,16 @@ impl Clone for Waiter {
 }
 
 /// Source of unique [`WaiterList`] ids, so a waiter's recorded registrations can
-/// never confuse two lists (ids are handed out once and never reused). Exhausting
-/// it would take 2^64 list creations, centuries at one per nanosecond, so wraparound
-/// is unreachable in any process lifetime.
+/// never confuse two lists (ids are handed out once and never reused). IDs are
+/// assigned lazily on first registration: most channel lists never receive a waiter,
+/// so construction need not touch this process-wide cache line. Exhausting it would
+/// take 2^64 registered lists, centuries at one per nanosecond, so wraparound is
+/// unreachable in any process lifetime.
 static NEXT_LIST_ID: AtomicU64 = AtomicU64::new(1);
 
-/// The id of a list that opts out of record-keeping: [`WaiterList::take`] snapshots,
-/// which exist to be woken, not registered with. Never handed out by
-/// [`NEXT_LIST_ID`], so no record can ever match one, and registering into such a
-/// list just uses the scan fallback.
-const UNTRACKED: u64 = 0;
+/// A list that has not received a registration yet. Never handed out by
+/// [`NEXT_LIST_ID`].
+const UNASSIGNED: u64 = 0;
 
 /// A list of weak wakers waiting for notification.
 ///
@@ -223,6 +223,7 @@ pub struct WaiterList {
 	/// Rotating cursor for opportunistic GC on `register`.
 	cursor: usize,
 	/// Never-reused identity for this list, paired with `epoch` in waiter records.
+	/// Assigned lazily on the first registration.
 	id: u64,
 	/// Bumped on every drain. A waiter whose record carries the current epoch is
 	/// still registered: live entries only ever leave through a drain.
@@ -232,9 +233,23 @@ pub struct WaiterList {
 impl WaiterList {
 	/// Create an empty list, allocating nothing until the first [`register`](Self::register).
 	pub fn new() -> Self {
+		Self {
+			entries: SmallVec::new(),
+			cursor: 0,
+			id: UNASSIGNED,
+			epoch: 0,
+		}
+	}
+
+	/// Return this list's stable identity, assigning one on first registration.
+	fn id(&mut self) -> u64 {
+		if self.id != UNASSIGNED {
+			return self.id;
+		}
+
 		// A CAS loop rather than fetch_add, so exhaustion fails closed instead of
 		// wrapping into reissued ids (a reissued id could fake presence). List
-		// creation is cold, and the loop is contention-free in practice.
+		// registration is normally contention-free in practice.
 		let mut id = NEXT_LIST_ID.load(std::sync::atomic::Ordering::Relaxed);
 		loop {
 			assert_ne!(id, u64::MAX, "waiter list id space exhausted");
@@ -249,12 +264,8 @@ impl WaiterList {
 			}
 		}
 
-		Self {
-			entries: SmallVec::new(),
-			cursor: 0,
-			id,
-			epoch: 0,
-		}
+		self.id = id;
+		id
 	}
 
 	/// Register a waiter. Idempotent: a waiter already in the list stays as one entry.
@@ -273,11 +284,8 @@ impl WaiterList {
 	/// advances on each append so the probe window covers the whole list over time.
 	pub fn register(&mut self, waiter: &Waiter) {
 		let shared = waiter.shared();
-
-		let presence = match self.id {
-			UNTRACKED => Presence::Unknown,
-			id => shared.presume(id, self.epoch),
-		};
+		let id = self.id();
+		let presence = shared.presume(id, self.epoch);
 
 		match presence {
 			// Still registered since the last drain: nothing to do. This is what
@@ -324,10 +332,9 @@ impl WaiterList {
 			entries: std::mem::take(&mut self.entries),
 			cursor: 0,
 			// This runs on every notification, so the snapshot must not touch the
-			// global id counter (a shared cache line across all channels). It is
-			// untracked instead: it exists to be woken, and registering into it
-			// falls back to the scan rather than impersonating this list.
-			id: UNTRACKED,
+			// global id counter (a shared cache line across all channels). It exists
+			// to be woken and will assign its own id if it is registered with instead.
+			id: UNASSIGNED,
 			epoch: 0,
 		}
 	}
@@ -1013,14 +1020,14 @@ mod tests {
 		let mut list = WaiterList::new();
 		waiter.register(&mut list);
 
-		// The snapshot inherits the entries but no identity of its own, so a
-		// register against it must settle membership by scan: the entry moved with
-		// the snapshot, so this dedups rather than stacking.
+		// The snapshot inherits the entries but no identity of its own. Its first
+		// registration assigns a fresh identity, then settles the unknown membership
+		// by scan: the entry moved with the snapshot, so this dedups rather than stacking.
 		let mut taken = list.take();
 		waiter.register(&mut taken);
 		assert_eq!(taken.entries.len(), 1, "the snapshot register stacked a duplicate");
 
-		// And a second waiter still gets in; untracked means unproven, not closed.
+		// And a second waiter still gets in.
 		let other = Waiter::new(Waker::noop().clone());
 		other.register(&mut taken);
 		assert_eq!(taken.entries.len(), 2);


### PR DESCRIPTION
## Summary

- Assign waiter-list IDs on first registration instead of channel construction.
- Avoid three process-wide atomic ID claims for channels whose waiter lists are never used.
- Add concurrent channel-construction and first-registration benchmarks.
- Improve the 8-thread construction benchmark from 12.76M to 13.88M channels per second, about 8.8%.

## Public API changes

None.

## Test plan

- `just fix`
- `just check`
- `just test` (2,996 passed, 1 skipped)
- kio loom tests (16 passed)
- moq-net loom tests (5 passed)

(written by GPT-5)