### PR TITLE
fix(watch): preserve the audio read position across a shared-ring resize

### DIFF
--- a/js/watch/src/audio/render-worklet.ts
+++ b/js/watch/src/audio/render-worklet.ts
@@ -15,7 +15,8 @@ class Render extends AudioWorkletProcessor {
 			const msg = event.data;
 			if (msg.type === "init-shared") {
 				console.log("[audio-worklet] init-shared: using SharedArrayBuffer path");
-				this.#backend = new SharedRingBuffer(msg);
+				const previous = this.#backend instanceof SharedRingBuffer ? this.#backend : undefined;
+				this.#backend = new SharedRingBuffer(msg, previous);
 				this.#underflow = 0;
 			} else if (msg.type === "init-post") {
 				console.log("[audio-worklet] init-post: using postMessage path");

--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -52,7 +52,7 @@ describe("initialization", () => {
 		expect(init.capacity).toBe(128);
 		expect(init.rate).toBe(1000);
 		expect(init.samples.byteLength).toBe(2 * 128 * 4); // 2 channels * 128 samples * Float32
-		expect(init.control.byteLength).toBe(4 * 4); // 4 control slots * Int32
+		expect(init.control.byteLength).toBe(5 * 4); // 5 control slots * Int32
 	});
 
 	it("rounds capacity up to a power of two", () => {
@@ -618,6 +618,112 @@ describe("i32 wrapping", () => {
 });
 
 describe("SharedRingBuffer.resize", () => {
+	it("does not replay samples consumed while the replacement message is in flight", () => {
+		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+		insert(src, 0, 64, { channels: 1, value: 1 });
+
+		// resize() snapshots READ=0, but the worklet keeps using src until the replacement
+		// message arrives and consumes another 16 samples in that window.
+		const dst = src.resize(256);
+		read(src, 16, 1);
+
+		// The worklet's view: both wrappers are built from the message, so neither knows the anchor.
+		const replacement = new SharedRingBuffer(dst.init, new SharedRingBuffer(src.init));
+
+		expect(replacement.length).toBe(48);
+		expect(Time.Milli.fromMicro(dst.timestamp)).toBe(16 as Time.Milli);
+		expect(read(replacement, 64, 1)[0].length).toBe(48);
+	});
+
+	it("does not carry the playhead across a re-anchor in flight", () => {
+		// A discontinuity can reset() and re-anchor the replacement while its message is still
+		// queued. The old READ is measured against the old anchor, so folding it into the new
+		// timeline would park the playhead ahead of WRITE and swallow the whole next utterance.
+		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+		insert(src, 10_000, 64, { channels: 1, value: 1 });
+		const worklet = new SharedRingBuffer(src.init);
+		read(worklet, 64, 1);
+
+		const dst = src.resize(256);
+		dst.setLatency(64);
+		dst.reset();
+		insert(dst, 30_000, 64, { channels: 1, value: 2 });
+
+		const replacement = new SharedRingBuffer(dst.init, worklet);
+
+		expect(replacement.length).toBe(64);
+		expect(read(replacement, 64, 1)[0]).toEqual(new Float32Array(64).fill(2));
+	});
+
+	it("never advances the replacement past its own WRITE", () => {
+		// A re-anchor racing the reconcile rebases the replacement under it. The advance is
+		// clamped so the worst case is an empty ring, not a playhead parked seconds ahead of
+		// WRITE where read() returns nothing and insert() drops everything as too old.
+		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+		insert(src, 10_000, 64, { channels: 1, value: 1 });
+		const worklet = new SharedRingBuffer(src.init);
+		read(worklet, 64, 1);
+
+		const dst = src.resize(256);
+		dst.setLatency(16);
+		dst.reset();
+		insert(dst, 30_000, 16, { channels: 1, value: 2 });
+
+		// Force the generations to match, standing in for a re-anchor that lands after the
+		// check but before the exchange.
+		const control = new Int32Array(dst.init.control);
+		Atomics.store(control, 4, Atomics.load(new Int32Array(src.init.control), 4));
+
+		const replacement = new SharedRingBuffer(dst.init, worklet);
+
+		expect(replacement.length).toBe(0);
+		expect(dst.length).toBeGreaterThanOrEqual(0);
+
+		// The ring heals: the next insert lands at the playhead rather than being dropped.
+		insert(dst, 30_016, 16, { channels: 1, value: 3 });
+		expect(dst.length).toBeGreaterThan(0);
+	});
+
+	// The reconcile runs on the audio thread while the main thread may be part-way through a
+	// re-anchor. Replays `insert`'s re-anchor as its individual atomic stores and drops the
+	// reconcile between each pair, which is the interleaving no single-threaded test would
+	// otherwise reach. Every pause point has to leave the new utterance playable.
+	for (let pause = 0; pause <= 3; pause++) {
+		it(`survives a reconcile landing at step ${pause} of a re-anchor`, () => {
+			const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+			insert(src, 10_000, 64, { channels: 1, value: 1 });
+			const worklet = new SharedRingBuffer(src.init);
+			read(worklet, 64, 1);
+
+			const dst = src.resize(256);
+			dst.setLatency(64);
+
+			// `insert`'s re-anchor, store by store, in source order.
+			const control = new Int32Array(dst.init.control);
+			const steps = [
+				() => Atomics.add(control, 4, 1), // GENERATION, bumped first
+				() => Atomics.store(control, 1, 0), // READ
+				() => Atomics.store(control, 0, 0), // WRITE
+			];
+
+			for (let i = 0; i < pause; i++) steps[i]();
+			const replacement = new SharedRingBuffer(dst.init, worklet);
+			for (let i = pause; i < steps.length; i++) steps[i]();
+
+			// The new utterance arrives on the rebased timeline and must be readable in full.
+			const samples = new Float32Array(64).fill(2);
+			for (let i = 0; i < 64; i++) control[0] = 0; // WRITE stays at the new origin
+			Atomics.store(control, 0, 0);
+			Atomics.store(control, 3, 0); // un-stall
+			const dstSamples = new Float32Array(dst.init.samples, 0, 256);
+			for (let i = 0; i < 64; i++) dstSamples[i] = 2;
+			Atomics.store(control, 0, 64);
+
+			expect(Atomics.load(control, 1)).toBeLessThanOrEqual(Atomics.load(control, 0));
+			expect(read(replacement, 64, 1)[0]).toEqual(samples);
+		});
+	}
+
 	it("preserves the unread window when growing capacity", () => {
 		const src = create({ rate: 1000, channels: 2, capacity: 64, latency: 30 });
 		insert(src, 0, 30, { value: 3.5 });

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -5,7 +5,10 @@ const WRITE = 0;
 const READ = 1;
 const LATENCY = 2;
 const STALLED = 3;
-const CONTROL_SLOTS = 4;
+// Bumped every time `insert` re-anchors, so a replacement ring can tell whether it still
+// shares an index space with the ring it is replacing. See the `SharedRingBuffer` constructor.
+const GENERATION = 4;
+const CONTROL_SLOTS = 5;
 
 export interface SharedRingBufferInit {
 	channels: number;
@@ -107,7 +110,16 @@ export class SharedRingBuffer {
 	#position = 0;
 	#lastRead = 0;
 
-	constructor(init: SharedRingBufferInit) {
+	/**
+	 * Wrap the shared memory described by `init`.
+	 *
+	 * Pass `previous` in the worklet when this ring replaces one already being read. `resize`
+	 * snapshots READ on the main thread and then hands the replacement over by message, so the
+	 * worklet keeps draining the old ring in the meantime. Reconciling here advances past those
+	 * samples instead of replaying them, and is skipped when the rings no longer share an index
+	 * space (a re-anchor, or a different stream entirely).
+	 */
+	constructor(init: SharedRingBufferInit, previous?: SharedRingBuffer) {
 		this.channels = init.channels;
 		this.capacity = init.capacity;
 		this.rate = init.rate;
@@ -121,6 +133,72 @@ export class SharedRingBuffer {
 				new Float32Array(init.samples, i * this.capacity * Float32Array.BYTES_PER_ELEMENT, this.capacity),
 			);
 		}
+
+		if (previous !== undefined) this.#reconcile(previous);
+	}
+
+	/**
+	 * Advance past samples the reader consumed from `source` after `resize` snapshotted READ.
+	 *
+	 * Only valid while both rings share an index space, which is what the generation counter
+	 * proves. `#anchor` is main-thread state that never crosses the message boundary, so both
+	 * worklet-side wrappers read it as 0 and comparing it cannot tell a re-anchor apart. Copying
+	 * READ across a re-anchor parks the new timeline behind a playhead measured against the old
+	 * one, swallowing however much of the next utterance the previous one had played. A mismatch
+	 * skips the reconcile rather than throwing: there is nothing to carry over, and the caller is
+	 * mid-swap with no way to recover from an exception.
+	 *
+	 * This runs on the audio thread while the main thread may be re-anchoring, so the generation
+	 * cannot merely be checked once up front: single-word atomics can't read it together with
+	 * READ and WRITE. The loop below closes that in three ways, none of which blocks the audio
+	 * thread. See `#advanceRead`. All three rest on `insert` bumping the generation before it
+	 * rebases the cursors, so no reconcile can complete inside a re-anchor without noticing.
+	 */
+	#reconcile(source: SharedRingBuffer): void {
+		if (source.channels !== this.channels || source.rate !== this.rate) return;
+
+		const candidate = Atomics.load(source.#control, READ);
+
+		for (;;) {
+			const generation = Atomics.load(this.#control, GENERATION);
+			if (Atomics.load(source.#control, GENERATION) !== generation) return;
+			if (this.#advanceRead(candidate, generation)) return;
+		}
+	}
+
+	/**
+	 * One attempt at moving READ to `candidate`, valid only while GENERATION is still
+	 * `generation`. Returns false if a concurrent writer moved READ and the caller should retry.
+	 *
+	 * A re-anchor rebases READ and WRITE and bumps GENERATION, and can land anywhere in here:
+	 *
+	 * - Clamping to a freshly loaded WRITE keeps an advance from parking READ seconds beyond the
+	 *   new timeline, where `read` returns nothing and `insert` drops everything as too old. The
+	 *   clamp never binds on the normal path, since `candidate` came from the same index space.
+	 * - Exchanging from an exact observed READ, rather than advancing unconditionally, fails
+	 *   against the re-anchor's store and retries against the new generation.
+	 * - Re-reading GENERATION after a successful exchange catches the case the exchange cannot:
+	 *   a re-anchor stores READ back to 0, so an observed 0 is indistinguishable from the 0 a
+	 *   fresh ring starts on. Undoing is itself an exchange, so a writer that moved READ in the
+	 *   meantime keeps its value.
+	 *
+	 * What survives is bounded: READ at most at WRITE, which is the empty ring `truncate`
+	 * already documents, costing a quantum of silence that heals on the next insert.
+	 */
+	#advanceRead(candidate: number, generation: number): boolean {
+		const current = Atomics.load(this.#control, READ);
+		const write = Atomics.load(this.#control, WRITE);
+
+		const target = ((candidate - write) | 0) > 0 ? write : candidate;
+		if (((target - current) | 0) <= 0) return true;
+
+		if (Atomics.compareExchange(this.#control, READ, current, target) !== current) return false;
+
+		if (Atomics.load(this.#control, GENERATION) !== generation) {
+			Atomics.compareExchange(this.#control, READ, target, current);
+		}
+
+		return true;
 	}
 
 	/**
@@ -137,6 +215,13 @@ export class SharedRingBuffer {
 		// Anchor to the first sample so playback starts at its timestamp rather than gap-filling
 		// from index 0.
 		if (!this.#anchored) {
+			// Invalidate the generation before rebasing the cursors, never after. A reconcile on
+			// the audio thread that observes a stale generation and a rebased READ would commit an
+			// old-timeline cursor and escape every check it makes, since nothing it reads has
+			// changed yet. Bumping first means such a reconcile either sees the mismatch outright
+			// or catches it on the re-read after its exchange.
+			Atomics.add(this.#control, GENERATION, 1);
+
 			this.#anchor = start;
 			Atomics.store(this.#control, READ, 0);
 			Atomics.store(this.#control, WRITE, 0);
@@ -309,6 +394,7 @@ export class SharedRingBuffer {
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 		const stalled = Atomics.load(this.#control, STALLED);
+		const generation = Atomics.load(this.#control, GENERATION);
 
 		const available = (write - read) | 0;
 		const copyCount = Math.max(0, Math.min(available, dst.capacity));
@@ -327,6 +413,7 @@ export class SharedRingBuffer {
 		Atomics.store(dst.#control, WRITE, write);
 		Atomics.store(dst.#control, LATENCY, latency);
 		Atomics.store(dst.#control, STALLED, stalled);
+		Atomics.store(dst.#control, GENERATION, generation);
 
 		// Carry the unwrapped playhead over, rebased onto dst's READ. Fold the same `read`
 		// snapshot the copy used so both sides agree on one observation; `copyStart` is at or


### PR DESCRIPTION
Rebased onto `main` now that [#3234](https://github.com/moq-dev/moq/pull/3234) (the signals half of the original PR) has landed.

## The bug

`resize()` snapshots READ on the main thread and hands the replacement to the worklet by `postMessage`, so the worklet keeps draining the old ring until it processes the swap. It then starts the replacement at the stale READ and replays whatever it consumed in that window (up to one render quantum, ~3ms). The replacement now advances past those samples on construction.

## Why the reconcile needs a generation counter

That reconcile is only sound while both rings share an index space, and `#anchor` cannot prove it: the anchor is main-thread state that never crosses the message boundary, so both worklet-side wrappers read it as 0. If `reset()` plus a re-anchoring `insert()` land between the post and the worklet draining the port (a discontinuity via `Decoder#onNext`, which is undebounced), copying READ parks the new timeline behind a playhead measured against the *old* anchor. The ring then reads as empty and every insert is discarded as too old until WRITE catches up, swallowing however much of the next utterance the previous one had played:

```
utterance 1 (10s) played out
utterance 2 buffered: 256 samples
after reconcile: length = -9696
utterance 2: fed 12000 samples, worklet played 1984
```

A generation counter in the shared control array, bumped on re-anchor and carried across `resize`, gates the reconcile. Reconciling happens in the constructor so the swap cannot be written without it, and so a failure cannot strand the worklet on the stale backend. A mismatch skips rather than throws: there is nothing to carry over, and the caller is mid-swap with no way to recover from an exception.

## Making the gate atomic

An earlier revision of this PR checked the generation once and then advanced, which is a TOCTOU: the reconcile runs on the audio thread while the main thread may be re-anchoring, and single-word atomics cannot read GENERATION together with READ and WRITE. Three guards close it, none of which blocks the audio thread:

- **Clamp to a freshly loaded WRITE.** A racing advance can no longer park READ beyond the new timeline. The clamp never binds on the normal path, since `candidate` came from the same index space.
- **Exchange from an exact observed READ** rather than advancing unconditionally. A re-anchor stores `READ = 0`, so the exchange fails against it and retries against the new generation.
- **Re-read GENERATION after a successful exchange.** This catches what the exchange cannot: a re-anchor stores READ back to 0, so an observed 0 is indistinguishable from the 0 a fresh ring starts on. The undo is itself an exchange, so a writer that moved READ meanwhile keeps its value.

What survives is bounded to READ at most at WRITE, which is the empty-ring condition `truncate()` already documents: a quantum of silence that heals on the next insert, rather than a multi-second dropout.

A lock was considered and rejected. Serializing the reconcile against the re-anchor would put the audio render path behind a lock the main thread can hold, which is the priority inversion this protocol is lock-free to avoid.

## Test plan

- `nix develop --command just js check`
- `nix develop --command just js test` (all packages, 0 fail)

`js/watch/src/audio/shared-ring-buffer.test.ts` covers three cases: the replay this fixes, the re-anchor (fails without the generation check), and the clamp (fails without the clamp). The cross-thread interleaving itself is not synchronously testable in bun, so the guards above are argued rather than covered.

## Public API changes

- `SharedRingBuffer`'s constructor takes an optional `previous` ring. Additive, and internal to the watch audio worklet.
- `CONTROL_SLOTS` grows from 4 to 5. Both ends of the message are built from the same `SharedRingBufferInit`, so there is no compatibility surface.

Cross-package sync is not applicable: no wire format, package API, or watch UI change.

(written by Claude Opus 5)