### PR TITLE
Discover MSF broadcasts in the watch demo

### DIFF
--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -191,9 +191,9 @@ discovery.run((effect) => {
 			const entry = await Promise.race([effect.cancel, announced.next()]);
 			if (!entry) break;
 			const path = Net.Path.join(prefix, entry.path);
-			// Only `.hang` broadcasts are watchable streams; this skips the relay's
+			// Only catalog-backed broadcasts are watchable streams; this skips the relay's
 			// `.stats` broadcast (see the stats dashboard demo for that one).
-			if (!path.endsWith(".hang")) continue;
+			if (!path.endsWith(".hang") && !path.endsWith(".msf")) continue;
 			if (entry.active) live.add(path);
 			else live.delete(path);
 			broadcasts.set([...live].sort());

--- a/demo/web/src/watch.html
+++ b/demo/web/src/watch.html
@@ -119,7 +119,7 @@
 				href="https://developer.mozilla.org/en-US/docs/Web/API/Web_components">Web Component</a>.
 			A single connection discovers broadcasts via MoQ announcements
 			(<code class="language-typescript">connection.announced(prefix)</code>) and we reconcile one
-			tile per live <code>.hang</code> broadcast, adding and removing them as publishers come and go.
+			tile per live <code>.hang</code> or <code>.msf</code> broadcast, adding and removing them as publishers come and go.
 			No F5 needed; restart a publisher and its tile reconnects on its own.
 		</p>
 		<p>


### PR DESCRIPTION
Summary:
- include .msf announcements in the watch demo's live broadcast discovery
- update the demo copy to describe both supported catalog-backed formats

Verification:
- just check
- just test
- browser smoke test confirmed an announced openmoq.msf broadcast appears as a watch tile

(written by GPT-5.6-sol)