### PR TITLE
fix(tokio): require explicit QUIC crypto providers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ web-transport-iroh = "0.7"
 web-transport-noq = { version = "0.3", default-features = false }
 web-transport-proto = "0.6"
 web-transport-quiche = "0.6"
-web-transport-quinn = "0.12"
+web-transport-quinn = { version = "0.12", default-features = false }
 web-transport-trait = "0.4"
 web-transport-wasm = "0.6"
 

--- a/doc/lib/rs/crate/moq-tokio.md
+++ b/doc/lib/rs/crate/moq-tokio.md
@@ -28,8 +28,8 @@ moq-tokio = "0.19"
 ```
 
 The default features select Quinn with the AWS-LC crypto provider. With
-`default-features = false`, the `noq` backend must be paired with the `aws-lc-rs`
-or `ring` feature.
+`default-features = false`, the `quinn` and `noq` backends must be paired with
+the `aws-lc-rs` or `ring` feature.
 
 ## API Reference
 

--- a/doc/lib/rs/crate/moq-tokio.md
+++ b/doc/lib/rs/crate/moq-tokio.md
@@ -27,6 +27,10 @@ Tokio-based connection helpers for native Rust applications. Provides TLS config
 moq-tokio = "0.19"
 ```
 
+The default features select Quinn with the AWS-LC crypto provider. With
+`default-features = false`, the `noq` backend must be paired with the `aws-lc-rs`
+or `ring` feature.
+
 ## API Reference
 
 Full API documentation: [docs.rs/moq-tokio](https://docs.rs/moq-tokio)

--- a/rs/justfile
+++ b/rs/justfile
@@ -356,11 +356,28 @@ check-changed $FILES:
     	just rs wasm
     fi
 
-# Compile moq-tokio by itself at the two feature extremes. Its default-feature
-# build is already part of the ordinary clippy pass above.
+# Compile moq-tokio by itself at the feature extremes and with each QUIC backend.
+# Its default-feature build is already part of the ordinary clippy pass above.
 tokio-features:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
     cargo check --locked -p moq-tokio --no-default-features
     cargo check --locked -p moq-tokio --all-features
+    cargo check --locked -p moq-tokio --no-default-features --features quinn
+    cargo check --locked -p moq-tokio --no-default-features --features quiche
+    cargo check --locked -p moq-tokio --no-default-features --features noq,aws-lc-rs
+
+    want='the `noq` backend requires a crypto provider: enable either the `aws-lc-rs` or `ring` feature'
+    if output=$(cargo check --locked -p moq-tokio --no-default-features --features noq 2>&1); then
+        echo "rs: moq-tokio with only noq should reject its missing crypto provider" >&2
+        exit 1
+    fi
+    if ! grep -qF "$want" <<< "$output"; then
+        echo "rs: moq-tokio with only noq should fail on: $want" >&2
+        echo "$output" | grep -E '^error' >&2 || true
+        exit 1
+    fi
 
 # Same as `fix`, but scoped the same way as `check-changed`.
 fix-changed $FILES:

--- a/rs/justfile
+++ b/rs/justfile
@@ -364,20 +364,24 @@ tokio-features:
 
     cargo check --locked -p moq-tokio --no-default-features
     cargo check --locked -p moq-tokio --all-features
-    cargo check --locked -p moq-tokio --no-default-features --features quinn
     cargo check --locked -p moq-tokio --no-default-features --features quiche
+    cargo check --locked -p moq-tokio --no-default-features --features quinn,aws-lc-rs
+    cargo check --locked -p moq-tokio --no-default-features --features quinn,ring
     cargo check --locked -p moq-tokio --no-default-features --features noq,aws-lc-rs
+    cargo check --locked -p moq-tokio --no-default-features --features noq,ring
 
-    want='the `noq` backend requires a crypto provider: enable either the `aws-lc-rs` or `ring` feature'
-    if output=$(cargo check --locked -p moq-tokio --no-default-features --features noq 2>&1); then
-        echo "rs: moq-tokio with only noq should reject its missing crypto provider" >&2
-        exit 1
-    fi
-    if ! grep -qF "$want" <<< "$output"; then
-        echo "rs: moq-tokio with only noq should fail on: $want" >&2
-        echo "$output" | grep -E '^error' >&2 || true
-        exit 1
-    fi
+    want='a rustls QUIC backend requires a crypto provider: enable either the `aws-lc-rs` or `ring` feature'
+    for backend in quinn noq; do
+        if output=$(cargo check --locked -p moq-tokio --no-default-features --features "$backend" 2>&1); then
+            echo "rs: moq-tokio with only $backend should reject its missing crypto provider" >&2
+            exit 1
+        fi
+        if ! grep -qF "$want" <<< "$output"; then
+            echo "rs: moq-tokio with only $backend should fail on: $want" >&2
+            echo "$output" | grep -E '^error' >&2 || true
+            exit 1
+        fi
+    done
 
 # Same as `fix`, but scoped the same way as `check-changed`.
 fix-changed $FILES:

--- a/rs/moq-tokio/Cargo.toml
+++ b/rs/moq-tokio/Cargo.toml
@@ -27,7 +27,7 @@ watch = ["dep:notify"]
 qlog = ["quinn?/qlog", "web-transport-noq?/qlog"]
 # The QUIC backends pull in their crypto provider from these features (default-features
 # are off on each backend dep), so a backend without aws-lc-rs/ring has no initial cipher.
-aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs", "web-transport-noq?/aws-lc-rs"]
+aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs", "web-transport-noq?/aws-lc-rs", "web-transport-quinn?/aws-lc-rs"]
 iroh = ["dep:web-transport-iroh", "dep:web-transport-proto", "dep:noq-proto"]
 # LAN peer discovery over mDNS (the `mdns` module).
 mdns = ["dep:mdns-sd", "dep:hmac", "dep:sha2", "dep:subtle"]
@@ -38,7 +38,7 @@ tcp = ["dep:qmux", "dep:dns-lookup"]
 # Unix-domain-socket qmux transport (`unix://`), unix-only. Adds peer-credential
 # inspection on accept. Pulls in `tcp` (shares qmux's stream transport).
 uds = ["tcp", "qmux/uds"]
-ring = ["rustls/ring", "rcgen?/ring", "quinn?/rustls-ring", "web-transport-noq?/ring"]
+ring = ["rustls/ring", "rcgen?/ring", "quinn?/rustls-ring", "web-transport-noq?/ring", "web-transport-quinn?/ring"]
 android-logcat = ["dep:tracing-android"]
 
 [dependencies]

--- a/rs/moq-tokio/src/lib.rs
+++ b/rs/moq-tokio/src/lib.rs
@@ -11,15 +11,18 @@
 //! See [`Client`] for connecting to relays and [`Server`] for accepting
 //! connections. The `mdns` feature finds peers to connect to on the local network.
 //!
-//! With `default-features = false`, the `noq` backend must be paired with the
-//! `aws-lc-rs` or `ring` crypto-provider feature.
+//! With `default-features = false`, the `quinn` and `noq` backends must be paired
+//! with the `aws-lc-rs` or `ring` crypto-provider feature.
 
 #![warn(missing_docs)]
 
-// Noq's provider-specific endpoint constructors are not compiled without one of these features.
-// Unlike Quinn, it cannot use a rustls provider the application installs at runtime.
-#[cfg(all(feature = "noq", not(any(feature = "aws-lc-rs", feature = "ring"))))]
-compile_error!("the `noq` backend requires a crypto provider: enable either the `aws-lc-rs` or `ring` feature");
+// The protocol crates need a compiled provider for reset and retry-token keys. A rustls provider
+// installed at runtime cannot supply constructors removed by their compile-time feature gates.
+#[cfg(all(
+	any(feature = "quinn", feature = "noq"),
+	not(any(feature = "aws-lc-rs", feature = "ring"))
+))]
+compile_error!("a rustls QUIC backend requires a crypto provider: enable either the `aws-lc-rs` or `ring` feature");
 
 pub mod accept;
 pub use moq_sock::bind;

--- a/rs/moq-tokio/src/lib.rs
+++ b/rs/moq-tokio/src/lib.rs
@@ -10,8 +10,16 @@
 //!
 //! See [`Client`] for connecting to relays and [`Server`] for accepting
 //! connections. The `mdns` feature finds peers to connect to on the local network.
+//!
+//! With `default-features = false`, the `noq` backend must be paired with the
+//! `aws-lc-rs` or `ring` crypto-provider feature.
 
 #![warn(missing_docs)]
+
+// Noq's provider-specific endpoint constructors are not compiled without one of these features.
+// Unlike Quinn, it cannot use a rustls provider the application installs at runtime.
+#[cfg(all(feature = "noq", not(any(feature = "aws-lc-rs", feature = "ring"))))]
+compile_error!("the `noq` backend requires a crypto provider: enable either the `aws-lc-rs` or `ring` feature");
 
 pub mod accept;
 pub use moq_sock::bind;


### PR DESCRIPTION
## Summary

- Disable `web-transport-quinn` default features so Quinn and Noq follow the same explicit provider policy.
- Forward `aws-lc-rs` and `ring` through both WebTransport backends.
- Reject either rustls-backed QUIC backend without a provider using one direct compile error.
- Exercise every supported provider/backend pairing and both rejected provider-free builds.
- Document the provider requirement in the crate and user guide.

## Root cause

`web-transport-noq` already had default features disabled, while `web-transport-quinn` silently enabled its default AWS-LC provider. That made Quinn appear not to require a provider even though both protocol implementations compile provider-specific endpoint key constructors only when AWS-LC or Ring is enabled.

Installing a rustls provider at runtime cannot restore constructors removed by compile-time feature gates. The provider therefore needs to be selected through `moq-tokio` for either backend. Quiche remains unaffected because it supplies its own crypto implementation.

## Validation

- `nix develop --command just rs tokio-features`
- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (3,743 Rust tests passed; scoped JS tests passed)
- `cargo nextest run --locked -p moq-cli cluster::tests::session_shares_origin_bidirectionally`
- `git diff --check`

## Base

This targets `dev` because `moq-tokio` exists only on that branch. `origin/main` does not contain the crate. There are no public API shape or package-version changes.

Closes #3160

(written by GPT-5.6)
