### PR TITLE
fix(go): export every FFI error sentinel

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -179,7 +179,7 @@ err := broadcast.SetVideoProperties(moq.VideoProperties{
 
 ## Error handling
 
-A server can reject the connection on auth grounds: `ErrMoqErrorUnauthorized` (HTTP 401) or `ErrMoqErrorForbidden` (HTTP 403). These are terminal: retrying without new credentials won't help, so handle them separately from a transient transport failure. The `moq.IsAuthError` helper catches both:
+A server can reject the connection on auth grounds: `moq.ErrUnauthorized` (HTTP 401) or `moq.ErrForbidden` (HTTP 403). These are terminal: retrying without new credentials won't help, so handle them separately from a transient transport failure. The `moq.IsAuthError` helper catches both:
 
 ```go
 session, err := client.Connect("https://relay.example.com")

--- a/go/scripts/check.sh
+++ b/go/scripts/check.sh
@@ -111,6 +111,18 @@ if [[ -d "$STAGE_BINDINGS/uniffi/moq" && ! -d "$STAGE_BINDINGS/moq" ]]; then
     cp -R "$STAGE_BINDINGS/uniffi/moq" "$STAGE_BINDINGS/moq"
 fi
 
+# Every generated flat-error sentinel gets a shorter wrapper alias. Comparing
+# the generated output makes a new Rust variant fail this check instead of
+# silently shipping without errors.Is support in the ergonomic package.
+GENERATED_ERRORS=$(grep -hoE 'ErrMoqError[A-Za-z0-9_]+' "$STAGE_BINDINGS/moq/"*.go | sort -u)
+WRAPPED_ERRORS=$(grep -hoE 'ffi\.ErrMoqError[A-Za-z0-9_]+' "$GO_DIR/wrapper/moq/errors.go" | sed 's/^ffi\.//' | sort -u)
+MISSING_ERRORS=$(comm -23 <(printf '%s\n' "$GENERATED_ERRORS") <(printf '%s\n' "$WRAPPED_ERRORS"))
+if [[ -n "$MISSING_ERRORS" ]]; then
+    echo "go check: wrapper is missing generated error sentinels:" >&2
+    echo "$MISSING_ERRORS" >&2
+    exit 1
+fi
+
 echo "go check: assembling ffi module..."
 # --skip-size-check because the lib above is a plain host build, unrelated to
 # what the mirror publishes. It is a debug build by default now, so it carries

--- a/go/wrapper/moq/errors.go
+++ b/go/wrapper/moq/errors.go
@@ -30,8 +30,12 @@ var (
 	ErrMedia = ffi.ErrMoqErrorMedia
 	// ErrMux matches a muxing or demuxing failure from moq-mux.
 	ErrMux = ffi.ErrMoqErrorMux
+	// ErrJSONTrack matches a JSON track encoding or decoding failure.
+	ErrJSONTrack = ffi.ErrMoqErrorJsonTrack
 	// ErrAudio matches a raw-audio encode or decode failure.
 	ErrAudio = ffi.ErrMoqErrorAudio
+	// ErrVideo matches a raw-video encode or decode failure.
+	ErrVideo = ffi.ErrMoqErrorVideo
 	// ErrURL matches a malformed URL passed when connecting or publishing.
 	ErrURL = ffi.ErrMoqErrorUrl
 	// ErrTimeOverflow matches a timestamp that overflowed its timescale.
@@ -40,6 +44,8 @@ var (
 	ErrLogLevel = ffi.ErrMoqErrorLogLevel
 	// ErrTask matches a panic or cancellation in a background native task.
 	ErrTask = ffi.ErrMoqErrorTask
+	// ErrJSON matches malformed JSON supplied to a binding API.
+	ErrJSON = ffi.ErrMoqErrorJson
 	// ErrCancelled is returned when an operation is cancelled, e.g. via a cancelled context; IsShutdown treats it as a graceful stop.
 	ErrCancelled = ffi.ErrMoqErrorCancelled
 	// ErrClosed is returned when the session or stream has closed; IsShutdown treats it as a graceful stop.
@@ -62,6 +68,8 @@ var (
 	ErrNotFound = ffi.ErrMoqErrorNotFound
 	// ErrUnsupported is returned when the requested operation is not supported.
 	ErrUnsupported = ffi.ErrMoqErrorUnsupported
+	// ErrInvalidRoute is returned when a route has an invalid hop id or too many hops.
+	ErrInvalidRoute = ffi.ErrMoqErrorInvalidRoute
 	// ErrLog is returned when installing or configuring the native log subscriber fails.
 	ErrLog = ffi.ErrMoqErrorLog
 )


### PR DESCRIPTION
## Summary

- re-export every generated `MoqError` sentinel from the ergonomic Go wrapper
- compare generated error sentinels with wrapper aliases during `just go check`
- correct stale authentication sentinel names in the Go documentation

The root cause was a manually maintained alias list with no exhaustiveness check, so new FFI variants could ship without matching `errors.Is` sentinels.

## Public API changes

Additive Go exports:

- `ErrJSONTrack`
- `ErrVideo`
- `ErrJSON`
- `ErrInvalidRoute`

## Test plan

- `gofmt -w go/wrapper/moq/errors.go`
- `shfmt -w go/scripts/check.sh`
- `just go check`, including generated binding comparison, Go vet/build, and `go test -race ./...`

Closes #3192.

(Written by GPT-5.6)