### PR TITLE
test(net): cover subscriber catch-up lifecycle

### DIFF
--- a/rs/moq-net/benches/group.rs
+++ b/rs/moq-net/benches/group.rs
@@ -9,6 +9,7 @@
 //!
 //! `track_recv_groups` covers the layer above: how much it costs to hand out one
 //! cached group, swept over cache depth so a per-delivery scan shows up as a slope.
+//! It also covers the steady-state path after a subscriber has reached the edge.
 //!
 //! Run with `cargo bench -p moq-net`.
 
@@ -33,6 +34,9 @@ const COUNTS: [usize; 3] = [512, 8_192, 32_768];
 /// so the top end is deliberately past anything realistic: a per-delivery scan over
 /// the cache shows up as a slope here, while a seek stays flat.
 const DEPTHS: [usize; 3] = [64, 512, 4_096];
+
+/// Groups appended and received in one caught-up benchmark iteration.
+const LIVE_BATCH: usize = 128;
 
 /// Keeps the broadcast/track producers alive alongside the group so the group
 /// isn't torn down mid-benchmark. Only `group` is written to.
@@ -250,6 +254,29 @@ fn bench_track_recv(c: &mut Criterion) {
 				|(ctx, mut subscriber)| {
 					for _ in 0..n {
 						let group = subscriber.next_group().now_or_never().unwrap().unwrap().unwrap();
+						black_box(group);
+					}
+					(ctx, subscriber)
+				},
+				BatchSize::SmallInput,
+			);
+		});
+		g.throughput(Throughput::Elements(LIVE_BATCH as u64));
+		g.bench_with_input(BenchmarkId::new("caught_up", n), &n, |b, &n| {
+			b.iter_batched(
+				|| {
+					let ctx = filled_track(n, &payload);
+					let mut subscriber = ctx.track.subscribe(None);
+					let edge = subscriber.recv_group().now_or_never().unwrap().unwrap().unwrap();
+					assert_eq!(edge.sequence, n as u64 - 1);
+					(ctx, subscriber)
+				},
+				|(mut ctx, mut subscriber)| {
+					for _ in 0..LIVE_BATCH {
+						let mut group = ctx.track.append_group().unwrap();
+						group.write_frame(Timestamp::ZERO, payload.clone()).unwrap();
+						group.finish().unwrap();
+						let group = subscriber.recv_group().now_or_never().unwrap().unwrap().unwrap();
 						black_box(group);
 					}
 					(ctx, subscriber)

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -4386,6 +4386,74 @@ mod test {
 	}
 
 	#[test]
+	fn real_time_skips_a_backlog_after_catching_up() {
+		let mut producer = track_producer("test", None);
+		append_at(&mut producer, 0);
+		let mut subscriber = producer.subscribe(None);
+		assert_eq!(drain(&mut subscriber), vec![0]);
+
+		// Catch-up is a subscriber state, not a startup-only choice. A reader can pause
+		// between groups and still needs to shed the backlog that accumulated meanwhile.
+		for second in 1..6 {
+			append_at(&mut producer, second * 1000);
+		}
+		assert_eq!(drain(&mut subscriber), vec![5]);
+	}
+
+	#[test]
+	fn a_newer_edge_changes_an_active_catch_up() {
+		let mut producer = track_producer("test", None);
+		for second in 0..5 {
+			append_at(&mut producer, second * 1000);
+		}
+		let mut subscriber = producer.subscribe(Subscription::default().with_max_age(Duration::from_secs(1)));
+		assert_eq!(
+			subscriber
+				.recv_group()
+				.now_or_never()
+				.unwrap()
+				.unwrap()
+				.unwrap()
+				.sequence,
+			3
+		);
+
+		// Group 4 was the edge at the first delivery. Advancing twice puts it outside
+		// the budget before the subscriber asks for another group.
+		append_at(&mut producer, 5000);
+		append_at(&mut producer, 10000);
+		assert_eq!(drain(&mut subscriber), vec![5, 6]);
+	}
+
+	#[test]
+	fn a_growing_edge_changes_an_active_catch_up() {
+		let mut producer = track_producer("test", None);
+		append_at(&mut producer, 0);
+		append_at(&mut producer, 1000);
+		let mut edge = producer.append_group().unwrap();
+		edge.write_frame(Timestamp::from_millis(2000).unwrap(), bytes::Bytes::from_static(b"a"))
+			.unwrap();
+
+		let mut subscriber = producer.subscribe(Subscription::default().with_max_age(Duration::from_secs(2)));
+		assert_eq!(
+			subscriber
+				.recv_group()
+				.now_or_never()
+				.unwrap()
+				.unwrap()
+				.unwrap()
+				.sequence,
+			0
+		);
+
+		// The edge is still the same group, but its newest presentation moved far
+		// enough that group 1 has fallen out of range.
+		edge.write_frame(Timestamp::from_millis(5000).unwrap(), bytes::Bytes::from_static(b"b"))
+			.unwrap();
+		assert_eq!(drain(&mut subscriber), vec![2]);
+	}
+
+	#[test]
 	fn a_budget_admits_groups_within_it() {
 		let mut producer = track_producer("test", None);
 		for second in 0..5 {


### PR DESCRIPTION
## Summary

- Add a caught-up subscriber benchmark that appends and receives live groups after cache depths of 64, 512, and 4,096.
- Cover backlog formation after initial catch-up, a newer edge between reads, and an open edge whose latest timestamp grows.
- Prototype subscriber-local edge caching, then reject it because it produced no repeatable gain. At depth 4,096, unchanged dev measured 162.46 us and the candidate measured 165.26 us; Criterion reported no change (p = 0.13).

## Public API changes

None.

## Wire behavior changes

None. These tests preserve the existing rule that max age is reevaluated whenever a subscriber has a newer alternative, including after initial catch-up.

## Test plan

- `MOQ_STRICT=1 nix develop --command just check origin/dev`
- `MOQ_STRICT=1 nix develop --command just test default origin/dev` (3,466 passed, 2 skipped)
- `cargo bench -p moq-net --bench group -- track_recv_groups/caught_up/4096`

(written by GPT-5)