### PR TITLE
fix(net): bound lite message sizes

### DIFF
--- a/rs/moq-net/src/coding/decode.rs
+++ b/rs/moq-net/src/coding/decode.rs
@@ -49,6 +49,15 @@ pub enum DecodeError {
 	#[error("expected end")]
 	ExpectedEnd,
 
+	/// A length-prefixed message exceeded the receiver's byte limit.
+	#[error("message too large: {size} bytes exceeds {max} byte limit")]
+	MessageTooLarge {
+		/// The byte length declared by the peer.
+		size: usize,
+		/// The largest message this receiver accepts.
+		max: usize,
+	},
+
 	/// The stream ended where a payload was required.
 	#[error("expected data")]
 	ExpectedData,

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -3,7 +3,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{Origin, OriginList, Path, coding::*};
 
-use super::{Message, Version};
+use super::{Message, Version, message::decode_size};
 
 // lite-06 announce message types: an outer discriminator carried before the length
 // prefix, so each announcement is an independently-typed, length-delimited message
@@ -161,7 +161,7 @@ impl Decode<Version> for AnnounceBroadcast<'_> {
 		if version.has_announce_id() {
 			// Lite06+: outer type, then a size-prefixed body decoded within its bounds.
 			let typ = u64::decode(buf, version)?;
-			let size = usize::decode(buf, version)?;
+			let size = decode_size(buf, version)?;
 			if buf.remaining() < size {
 				return Err(DecodeError::Short);
 			}
@@ -189,7 +189,7 @@ impl Decode<Version> for AnnounceBroadcast<'_> {
 		}
 
 		// Older versions: a single size-prefixed ANNOUNCE_BROADCAST with an inner status.
-		let size = usize::decode(buf, version)?;
+		let size = decode_size(buf, version)?;
 		if buf.remaining() < size {
 			return Err(DecodeError::Short);
 		}

--- a/rs/moq-net/src/lite/message.rs
+++ b/rs/moq-net/src/lite/message.rs
@@ -4,6 +4,21 @@ use crate::coding::{Decode, DecodeError, Encode, EncodeError, Sizer};
 
 use super::Version;
 
+// Match the JavaScript reader's ceiling. Lite control messages are buffered before
+// decoding, so the limit must be checked as soon as their length prefix arrives.
+pub(super) const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+
+pub(super) fn decode_size<B: Buf>(buf: &mut B, version: Version) -> Result<usize, DecodeError> {
+	let size = usize::decode(buf, version)?;
+	if size > MAX_MESSAGE_SIZE {
+		return Err(DecodeError::MessageTooLarge {
+			size,
+			max: MAX_MESSAGE_SIZE,
+		});
+	}
+	Ok(size)
+}
+
 /// A trait for lite messages that are automatically size-prefixed during encoding/decoding.
 ///
 /// Lite messages use a varint size prefix.
@@ -27,7 +42,7 @@ impl<T: Message> Encode<Version> for T {
 
 impl<T: Message> Decode<Version> for T {
 	fn decode<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
-		let size = usize::decode(buf, version)?;
+		let size = decode_size(buf, version)?;
 
 		if tracing::enabled!(tracing::Level::TRACE) {
 			if buf.remaining() < size {
@@ -66,5 +81,49 @@ impl<T: Message> Decode<Version> for T {
 				}
 			}
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[derive(Debug)]
+	struct Empty;
+
+	impl Message for Empty {
+		fn encode_msg<W: BufMut>(&self, _: &mut W, _: Version) -> Result<(), EncodeError> {
+			Ok(())
+		}
+
+		fn decode_msg<B: Buf>(_: &mut B, _: Version) -> Result<Self, DecodeError> {
+			Ok(Self)
+		}
+	}
+
+	#[test]
+	fn rejects_oversized_message_before_reading_the_body() {
+		let mut wire = Vec::new();
+		((MAX_MESSAGE_SIZE + 1) as u64)
+			.encode(&mut wire, Version::Lite06Wip)
+			.unwrap();
+
+		let err = Empty::decode(&mut wire.as_slice(), Version::Lite06Wip).unwrap_err();
+		assert!(matches!(
+			err,
+			DecodeError::MessageTooLarge {
+				size,
+				max: MAX_MESSAGE_SIZE,
+			} if size == MAX_MESSAGE_SIZE + 1
+		));
+	}
+
+	#[test]
+	fn accepts_message_at_the_limit() {
+		let mut wire = Vec::new();
+		(MAX_MESSAGE_SIZE as u64).encode(&mut wire, Version::Lite06Wip).unwrap();
+
+		let err = Empty::decode(&mut wire.as_slice(), Version::Lite06Wip).unwrap_err();
+		assert!(matches!(err, DecodeError::Short));
 	}
 }


### PR DESCRIPTION
## Summary

- Reject moq-lite control messages larger than 64 MiB immediately after decoding their length prefix.
- Apply the same limit to custom announcement framing, preventing unbounded buffer growth from peer-controlled input.
- Add regression coverage for oversized and exactly-at-limit prefixes.

Root cause: the decoder returned `Short` for any declared message length until the full body arrived. The read loop then kept appending to an unbounded buffer, so a peer could force memory growth without sending a complete message.

## Public API changes

- Add the additive `DecodeError::MessageTooLarge { size, max }` variant.
- No wire-format change. Draft synchronization is not needed, and the JavaScript implementation already enforces the same 64 MiB limit.

## Test plan

- `just rs test -p moq-net`: 873 passed
- Branch-scoped `just check`
- `cargo fmt --all --check`
- `git diff --check`
- Branch-scoped `just test` did not complete because a fresh target directory exhausted local disk during downstream compilation. No test binary failed.

Closes #3220

(written by GPT-5.6)