### PR TITLE
perf(net): bound group expiry scans

### DIFF
--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -2740,11 +2740,15 @@ impl group::Expiry for GroupExpiry {
 						timestamp_raced = true;
 					}
 				}
-				for slot in state.lookup.values() {
+				for (_, slot) in state
+					.lookup
+					.range((std::ops::Bound::Excluded(self.sequence), std::ops::Bound::Unbounded))
+				{
 					let group = &slot.group;
+					if cap.is_some_and(|cap| group.sequence > cap) {
+						break;
+					}
 					if slot.visible
-						&& group.sequence > self.sequence
-						&& cap.is_none_or(|cap| group.sequence <= cap)
 						&& !group.is_aborted()
 						&& group.timestamp().is_none()
 						&& group.poll_timestamp(waiter).is_ready()


### PR DESCRIPTION
## Summary

- Start expiry timestamp watches directly above the candidate group instead of scanning every retained group.
- Stop the ordered scan as soon as it passes the subscription cap.
- Preserve the existing expiration and wakeup behavior, including the `u64::MAX` boundary.
- Profiling found the old scan consuming 8.71% self CPU in the session benchmark. The focused Criterion comparison measured 26.5% lower time, and the re-profile reduced that path to 0.15% self CPU.

The root cause was that `GroupExpiry::is_expired` traversed the full `BTreeMap` on every pending expiration check even though groups at or below the candidate can never change its verdict.

## Public API changes

None.

## Wire behavior changes

None. The same candidate and later servable groups are watched; the ordered lookup only skips groups that cannot affect expiration.

## Cross-package sync

Not applicable because this changes neither the public API nor wire behavior.

## Test plan

- `nix develop --command just fix origin/dev`
- `nix develop --command just check origin/dev`
- `nix develop --command just test default origin/dev` (3,480 passed, 2 skipped)
- Criterion session benchmark and `perf record` before and after the change

(Written by GPT-5)