### PR TITLE
moq-uring: prototype fixed-buffer SENDMSG_ZC

### DIFF
--- a/rs/moq-uring/README.md
+++ b/rs/moq-uring/README.md
@@ -13,8 +13,9 @@ the UDP sockets bound through it.
   `recvmsg`: the kernel faults the receive once a buffer's leftover tail is
   smaller than the recvmsg header.
 - **Send**: `sendmsg` with an explicit `UDP_SEGMENT` control message per call,
-  staged in a fixed pool of buffers owned by id and released on completion
-  (the shape a later `SENDMSG_ZC` needs).
+  staged in a growable pool of stable buffers owned by id. An opt-in path
+  lazily registers larger buffers for fixed-buffer `SENDMSG_ZC` on Linux 6.15
+  and newer, retaining each buffer until its notification CQE.
 - **Timers**: a heap the worker sweeps; the earliest deadline rides
   `io_uring_enter` as an absolute timeout. Zero timeout SQEs. The worker's
   `Handle` implements `moq_net::Timers`.
@@ -89,9 +90,11 @@ includes GitHub-hosted CI runners.
 
 `udp_tokio` and `udp_uring` are the disposable syscall-level matrices from the
 first spike (recv batching x GRO x GSO, epoll vs io\_uring); see git history
-for their methodology. `echo_quiche` is the ablation matrix over the real
-worker: the same quiche echo with receive batching, GRO, and GSO toggled one
-at a time.
+for their methodology. `echo_quiche` and `session_lite` are ablation matrices
+over the real worker: the same workloads with receive batching, GRO, GSO, and
+fixed-buffer `SENDMSG_ZC` toggled one at a time. The zero-copy result is
+meaningful only when the peer is reached through a physical NIC; loopback
+reports copy fallback through `udp::Socket::send_stats`.
 
 ```bash
 just rs bench-udp --sample-size 20 --measurement-time 2 --warm-up-time 1

--- a/rs/moq-uring/benches/echo_quiche.rs
+++ b/rs/moq-uring/benches/echo_quiche.rs
@@ -20,6 +20,8 @@ mod linux {
 
 	/// Bytes echoed per iteration (each direction).
 	const PAYLOAD: usize = 1024 * 1024;
+	/// Keep small ACK/control packets on ordinary `SENDMSG`.
+	const SEND_ZC_THRESHOLD: usize = 4 * 1024;
 
 	struct Ablation {
 		name: &'static str,
@@ -28,6 +30,8 @@ mod linux {
 
 	fn ablations() -> Vec<Ablation> {
 		let all = udp::Config::default();
+		let mut send_zc = all.clone();
+		send_zc.send_zc_threshold = Some(SEND_ZC_THRESHOLD);
 		let mut no_gso = all.clone();
 		no_gso.gso = false;
 		let mut no_gro = all.clone();
@@ -42,6 +46,10 @@ mod linux {
 			Ablation {
 				name: "all-on",
 				config: all,
+			},
+			Ablation {
+				name: "send-zc-4k",
+				config: send_zc,
 			},
 			Ablation {
 				name: "no-gso",

--- a/rs/moq-uring/benches/session_lite.rs
+++ b/rs/moq-uring/benches/session_lite.rs
@@ -30,6 +30,8 @@ mod linux {
 	/// unit as the echo matrix.
 	const FRAMES: usize = 32;
 	const FRAME_SIZE: usize = 32 * 1024;
+	/// Keep small ACK/control packets on ordinary `SENDMSG`.
+	const SEND_ZC_THRESHOLD: usize = 4 * 1024;
 
 	const ALPN: &str = "moq-lite-05";
 
@@ -82,6 +84,8 @@ mod linux {
 
 	fn ablations() -> Vec<Ablation> {
 		let all = udp::Config::default();
+		let mut send_zc = all.clone();
+		send_zc.send_zc_threshold = Some(SEND_ZC_THRESHOLD);
 		let mut no_gso = all.clone();
 		no_gso.gso = false;
 		let mut no_gro = all.clone();
@@ -96,6 +100,10 @@ mod linux {
 			Ablation {
 				name: "all-on",
 				config: all,
+			},
+			Ablation {
+				name: "send-zc-4k",
+				config: send_zc,
 			},
 			Ablation {
 				name: "no-gso",

--- a/rs/moq-uring/src/lib.rs
+++ b/rs/moq-uring/src/lib.rs
@@ -10,7 +10,8 @@
 //! UDP is the point: [`udp::Socket`] receives through one multishot `recvmsg`
 //! with a registered provided-buffer ring (one whole buffer per completion,
 //! `UDP_GRO` coalesced) and sends with an explicit `UDP_SEGMENT` control
-//! message per `sendmsg` from a growable pool of staging buffers.
+//! message from a growable pool of staging buffers. An opt-in path registers
+//! larger send buffers for fixed-buffer `SENDMSG_ZC` on Linux 6.15 and newer.
 //!
 //! [`quic`] stacks a sans-IO QUIC stack on that path: a [`quic::Endpoint`]
 //! serves many connections on one socket (demuxed by connection id, dials

--- a/rs/moq-uring/src/shared.rs
+++ b/rs/moq-uring/src/shared.rs
@@ -49,9 +49,24 @@ pub(crate) enum Op {
 	Cancel,
 }
 
+/// The kernel caps one ring's registered-buffer table at 16384 entries.
+const MAX_REGISTERED_BUFFERS: u16 = 1 << 14;
+
+/// Ring-global allocation state for sparse registered-buffer slots.
+#[derive(Default)]
+pub(crate) struct RegisteredBuffers {
+	initialized: bool,
+	next: u16,
+	free: Vec<u16>,
+}
+
 /// The worker's shared core, `Rc`ed into every handle.
 pub(crate) struct Shared {
 	pub ring: RefCell<IoUring>,
+	pub registered_buffers: RefCell<RegisteredBuffers>,
+	/// Cleared after a kernel rejects fixed-buffer `SENDMSG_ZC`; later sends
+	/// use ordinary `SENDMSG` without repeating the failed experiment.
+	pub sendmsg_zc_fixed: Cell<bool>,
 	pub ops: RefCell<slab::Slab<Op>>,
 	/// Its own `Rc` so a [`crate::Timer`] holds just the heap, not the ring.
 	pub timers: Rc<RefCell<timer::Heap>>,
@@ -73,6 +88,59 @@ impl Shared {
 	/// The error every operation reports once the worker has been dropped.
 	pub fn gone_error() -> io::Error {
 		io::Error::new(io::ErrorKind::NotConnected, "the worker was dropped")
+	}
+
+	/// Register one stable allocation and return its ring-global buffer index.
+	pub fn register_buffer(&self, data: &mut [u8]) -> io::Result<u16> {
+		let mut registered = self.registered_buffers.borrow_mut();
+		let ring = self.ring.borrow();
+		if !registered.initialized {
+			ring.submitter()
+				.register_buffers_sparse(u32::from(MAX_REGISTERED_BUFFERS))?;
+			registered.initialized = true;
+		}
+
+		let (index, fresh) = match registered.free.pop() {
+			Some(index) => (index, false),
+			None if registered.next < MAX_REGISTERED_BUFFERS => (registered.next, true),
+			None => return Err(io::Error::from_raw_os_error(libc::ENOBUFS)),
+		};
+		let iov = libc::iovec {
+			iov_base: data.as_mut_ptr().cast(),
+			iov_len: data.len(),
+		};
+		// SAFETY: the socket owns `data` until it clears this slot, after every
+		// send and zero-copy notification referencing it has completed.
+		if let Err(err) = unsafe { ring.submitter().register_buffers_update(u32::from(index), &[iov], None) } {
+			if !fresh {
+				registered.free.push(index);
+			}
+			return Err(err);
+		}
+		if fresh {
+			registered.next += 1;
+		}
+		Ok(index)
+	}
+
+	/// Clear a registered-buffer slot, returning it to the ring-global pool.
+	pub fn unregister_buffer(&self, index: u16) {
+		let empty = libc::iovec {
+			iov_base: std::ptr::null_mut(),
+			iov_len: 0,
+		};
+		let ring = self.ring.borrow();
+		// SAFETY: a zero-length iovec clears this sparse slot. The socket only
+		// reaches drop after every operation holding its buffers has completed.
+		match unsafe {
+			ring.submitter()
+				.register_buffers_update(u32::from(index), &[empty], None)
+		} {
+			Ok(_) => self.registered_buffers.borrow_mut().free.push(index),
+			// Quarantine the index rather than ever reuse a slot the kernel may
+			// still associate with the old allocation.
+			Err(err) => tracing::error!(index, %err, "failed to clear registered send buffer"),
+		}
 	}
 
 	/// Stage one SQE, submitting inline to make room when the queue is full.

--- a/rs/moq-uring/src/udp.rs
+++ b/rs/moq-uring/src/udp.rs
@@ -11,9 +11,10 @@
 //! A completed buffer is handed out as a [`Packet`] and returns to the kernel
 //! once every packet borrowing it drops.
 //!
-//! Send stages datagrams in a pool of buffers owned by id and released
-//! explicitly on completion, the shape `SENDMSG_ZC`'s deferred-reclaim NOTIF
-//! model needs later. Every GSO `sendmsg` carries its `UDP_SEGMENT` control
+//! Send stages datagrams in a pool of stable buffers owned by id. Optionally,
+//! larger sends lazily register those buffers and use fixed-buffer
+//! `SENDMSG_ZC`; its notification CQE, rather than the initial result, returns
+//! the buffer to the pool. Every GSO send carries its `UDP_SEGMENT` control
 //! message explicitly; the socket default is never relied on.
 //!
 //! Both pools are queues of concurrent operations, not byte budgets: one send
@@ -24,8 +25,8 @@
 //! the ceilings in [`Config`]; a pool never shrinks, so it settles at the
 //! socket's high-water concurrency and the memory comes back when it drops.
 //!
-//! The `gro`/`gso`/`multishot` toggles in [`Config`] exist for the ablation
-//! benchmarks; production callers keep the defaults (all on).
+//! The `gro`/`gso`/`multishot` toggles and zero-copy threshold in [`Config`]
+//! exist for ablation benchmarks; production callers keep the defaults.
 
 use std::alloc::{Layout, alloc_zeroed, dealloc, handle_alloc_error};
 use std::cell::{Cell, RefCell};
@@ -38,7 +39,7 @@ use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::task::Poll;
 
-use io_uring::{cqueue, opcode, types};
+use io_uring::{cqueue, opcode, squeue, types};
 
 use crate::Error;
 use crate::shared::{Cqe, Op, Shared};
@@ -61,6 +62,12 @@ const MAX_RX_BUFFERS: u16 = 1 << 15;
 const INITIAL_RX_BUFFERS: u16 = 16;
 /// Send buffers allocated before any starvation.
 const INITIAL_TX_BUFFERS: u16 = 64;
+/// `sqe->ioprio`: payload iovecs point into `sqe->buf_index`.
+const IORING_RECVSEND_FIXED_BUF: u16 = 1 << 2;
+/// `sqe->ioprio`: report whether a zero-copy request was copied.
+const IORING_SEND_ZC_REPORT_USAGE: u16 = 1 << 3;
+/// Notification `cqe->res`: at least part of the payload was copied.
+const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 1 << 31;
 
 /// Double a pool, bounded by its ceiling.
 fn grown(len: usize, max: u16) -> Option<u16> {
@@ -101,6 +108,11 @@ pub struct Config {
 	pub tx_buffers_max: u16,
 	/// Send pool: bytes per buffer, the ceiling for one GSO train.
 	pub tx_buffer_len: usize,
+	/// Use fixed-buffer `SENDMSG_ZC` at or above this payload size.
+	///
+	/// `None` keeps ordinary `SENDMSG`. Linux 6.12 through 6.14 also fall
+	/// back automatically because fixed-buffer `SENDMSG_ZC` arrived in 6.15.
+	pub send_zc_threshold: Option<usize>,
 }
 
 impl Default for Config {
@@ -115,6 +127,7 @@ impl Default for Config {
 			rx_buffer_len: MAX_RECV + RECV_OVERHEAD,
 			tx_buffers_max: 1024,
 			tx_buffer_len: 64 * 1024,
+			send_zc_threshold: None,
 		}
 	}
 }
@@ -226,7 +239,10 @@ fn grow_tx(tx: &mut Tx, config: &Config) -> bool {
 	};
 	while tx.bufs.len() < usize::from(target) {
 		tx.free.push(tx.bufs.len() as u16);
-		tx.bufs.push(vec![0u8; config.tx_buffer_len].into_boxed_slice());
+		tx.bufs.push(TxSlot {
+			data: vec![0u8; config.tx_buffer_len].into_boxed_slice(),
+			fixed: None,
+		});
 	}
 	true
 }
@@ -301,11 +317,32 @@ struct Rx {
 
 /// Send-side state.
 struct Tx {
-	bufs: Vec<Box<[u8]>>,
+	bufs: Vec<TxSlot>,
 	free: Vec<u16>,
 	waiters: kio::WaiterList,
+	stats: SendStats,
 	/// Terminal failure, surfaced by `poll_acquire`.
 	error: Option<i32>,
+}
+
+/// One stable send allocation and its lazily assigned ring-global index.
+struct TxSlot {
+	data: Box<[u8]>,
+	fixed: Option<u16>,
+}
+
+/// Zero-copy send counters for a socket.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct SendStats {
+	/// Fixed-buffer `SENDMSG_ZC` operations submitted.
+	pub zc_submitted: u64,
+	/// Zero-copy notification CQEs received.
+	pub zc_notifications: u64,
+	/// Notifications reporting that at least part of the payload was copied.
+	pub zc_copied: u64,
+	/// Requests sent normally because registration or the opcode was rejected.
+	pub zc_fallbacks: u64,
 }
 
 /// Everything both the [`Socket`] handle and in-flight ops keep alive.
@@ -351,6 +388,28 @@ impl SockShared {
 		tx.waiters.wake();
 	}
 
+	/// Lazily register a checked-out send buffer for zero-copy use.
+	fn fixed_buffer(&self, shared: &Shared, id: u16) -> Option<u16> {
+		let mut tx = self.tx.borrow_mut();
+		let slot = &mut tx.bufs[id as usize];
+		if let Some(index) = slot.fixed {
+			return Some(index);
+		}
+		match shared.register_buffer(&mut slot.data) {
+			Ok(index) => {
+				slot.fixed = Some(index);
+				Some(index)
+			}
+			Err(err) => {
+				tx.stats.zc_fallbacks += 1;
+				if shared.sendmsg_zc_fixed.replace(false) {
+					tracing::warn!(%err, "registered send buffers unavailable; falling back to SENDMSG");
+				}
+				None
+			}
+		}
+	}
+
 	fn fail_rx(&self, code: i32) {
 		let mut rx = self.rx.borrow_mut();
 		rx.error.get_or_insert(code);
@@ -367,10 +426,14 @@ impl SockShared {
 impl Drop for SockShared {
 	fn drop(&mut self) {
 		// Every op referencing our buffers has completed (ops own an `Rc` of
-		// us), so the kernel is done; give the buffer group id back.
-		if self.rx.borrow().ring.is_some()
-			&& let Some(shared) = self.worker.upgrade()
-		{
+		// us), so the kernel is done; give registered resources back.
+		if let Some(shared) = self.worker.upgrade() {
+			for index in self.tx.get_mut().bufs.iter().filter_map(|slot| slot.fixed) {
+				shared.unregister_buffer(index);
+			}
+			if self.rx.get_mut().ring.is_none() {
+				return;
+			}
 			let ring = shared.ring.borrow_mut();
 			let _ = ring.submitter().unregister_buf_ring(self.bgid);
 		}
@@ -482,10 +545,14 @@ impl Socket {
 		let tx_count = INITIAL_TX_BUFFERS.min(config.tx_buffers_max);
 		let tx = Tx {
 			bufs: (0..tx_count)
-				.map(|_| vec![0u8; config.tx_buffer_len].into_boxed_slice())
+				.map(|_| TxSlot {
+					data: vec![0u8; config.tx_buffer_len].into_boxed_slice(),
+					fixed: None,
+				})
 				.collect(),
 			free: (0..tx_count).collect(),
 			waiters: kio::WaiterList::new(),
+			stats: SendStats::default(),
 			error: None,
 		};
 
@@ -518,6 +585,11 @@ impl Socket {
 	/// The bound local address.
 	pub fn local_addr(&self) -> io::Result<SocketAddr> {
 		self.shared.io.local_addr()
+	}
+
+	/// Current zero-copy send counters.
+	pub fn send_stats(&self) -> SendStats {
+		self.shared.tx.borrow().stats
 	}
 
 	/// A received packet, or the socket's terminal error, registering `waiter`
@@ -570,7 +642,7 @@ impl Socket {
 			grow_tx(&mut tx, &self.shared.config);
 		}
 		if let Some(id) = tx.free.pop() {
-			let buf = &mut tx.bufs[id as usize];
+			let buf = &mut tx.bufs[id as usize].data;
 			// SAFETY: `id` was exclusively checked out of the free list; the
 			// allocation is stable (see TxBuf).
 			let ptr = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
@@ -687,6 +759,22 @@ pub struct TxBuf {
 }
 
 impl TxBuf {
+	/// Build an unsubmitted fixed-buffer operation for completion routing tests.
+	#[cfg(test)]
+	pub(crate) fn test_send_op(mut self) -> SendOp {
+		self.armed = true;
+		SendOp {
+			lease: Rc::new(TxLease {
+				sock: self.sock.clone(),
+				id: self.id,
+			}),
+			// SAFETY: the routing test never submits this header to the kernel.
+			_hdr: Box::new(unsafe { std::mem::zeroed() }),
+			expect: 1,
+			mode: SendMode::FixedZeroCopy(0),
+		}
+	}
+
 	/// Send `self[..len]` on the owning socket, to `to`, as datagrams of
 	/// `segment` bytes (the last may be short). Fire-and-forget: the buffer
 	/// returns to the pool when the kernel completes, and a failed send
@@ -737,15 +825,19 @@ impl TxBuf {
 			id: self.id,
 		});
 		let base = self.ptr.as_ptr();
+		let fixed = match sock.config.send_zc_threshold {
+			Some(threshold) if len >= threshold && shared.sendmsg_zc_fixed.get() => sock.fixed_buffer(&shared, self.id),
+			_ => None,
+		};
 
 		if sock.config.gso {
-			send_one(&shared, &sock, &lease, base, len, to, Some(segment as u16))?;
+			send_one(&shared, &lease, base, len, to, Some(segment as u16), fixed)?;
 		} else {
 			let mut offset = 0;
 			while offset < len {
 				let chunk = segment.min(len - offset);
 				// SAFETY: offset stays within the leased buffer.
-				send_one(&shared, &sock, &lease, unsafe { base.add(offset) }, chunk, to, None)?;
+				send_one(&shared, &lease, unsafe { base.add(offset) }, chunk, to, None, fixed)?;
 				offset += chunk;
 			}
 		}
@@ -814,16 +906,102 @@ pub(crate) struct SendOp {
 	/// Boxed so the pointers inside stay put; referenced by the SQE.
 	_hdr: Box<SendHdr>,
 	expect: usize,
+	mode: SendMode,
+}
+
+impl SendOp {
+	/// A successful zero-copy result with `MORE` retains the operation until
+	/// its notification CQE says the kernel has released the buffer.
+	pub(crate) fn live_after(&self, cqe: Cqe) -> bool {
+		matches!(self.mode, SendMode::FixedZeroCopy(_))
+			&& !cqueue::notif(cqe.flags)
+			&& cqe.result >= 0
+			&& cqueue::more(cqe.flags)
+	}
+
+	/// Clone the state needed to validate a nonterminal result CQE.
+	pub(crate) fn result_target(&self) -> (Rc<SockShared>, usize) {
+		(self.lease.sock.clone(), self.expect)
+	}
+}
+
+#[derive(Clone, Copy)]
+enum SendMode {
+	Plain,
+	FixedZeroCopy(u16),
+}
+
+/// Stable prefix of `struct io_uring_sqe` through its `buf_index` union.
+///
+/// io-uring 0.7.14 exposes `SendMsgZc::ioprio` but not `sqe->buf_index`, so
+/// this private adapter fills the one missing UAPI field.
+#[repr(C)]
+struct SendMsgSqePrefix {
+	_opcode: u8,
+	_flags: u8,
+	_ioprio: u16,
+	_fd: i32,
+	_off: u64,
+	_addr: u64,
+	_len: u32,
+	_op_flags: u32,
+	_user_data: u64,
+	buf_index: u16,
+}
+
+const _: () = assert!(std::mem::size_of::<squeue::Entry>() == 64);
+const _: () = assert!(std::mem::offset_of!(SendMsgSqePrefix, buf_index) == 40);
+
+fn sendmsg_zc_fixed(fd: i32, hdr: *const libc::msghdr, index: u16) -> squeue::Entry {
+	let mut entry = opcode::SendMsgZc::new(types::Fd(fd), hdr)
+		.ioprio(IORING_RECVSEND_FIXED_BUF | IORING_SEND_ZC_REPORT_USAGE)
+		.build();
+	// SAFETY: `squeue::Entry` is a repr(C) wrapper around the 64-byte UAPI
+	// SQE. The compile-time assertions pin the wrapper size and union offset.
+	unsafe {
+		(*(&raw mut entry).cast::<SendMsgSqePrefix>()).buf_index = index;
+	}
+	entry
+}
+
+/// Put a fully-owned send operation in the slab before its SQE is visible.
+fn stage_send(shared: &Rc<Shared>, op: SendOp) -> io::Result<()> {
+	let zero_copy = matches!(op.mode, SendMode::FixedZeroCopy(_));
+	let key = shared.insert(Op::Send(op));
+	let entry = {
+		let ops = shared.ops.borrow();
+		let Op::Send(op) = &ops[key as usize] else {
+			unreachable!()
+		};
+		let hdr = &raw const op._hdr.hdr;
+		match op.mode {
+			SendMode::Plain => opcode::SendMsg::new(types::Fd(op.lease.sock.io.as_raw_fd()), hdr).build(),
+			SendMode::FixedZeroCopy(index) => sendmsg_zc_fixed(op.lease.sock.io.as_raw_fd(), hdr, index),
+		}
+	}
+	.user_data(key);
+	if let Err(err) = shared.push(&entry) {
+		shared.ops.borrow_mut().remove(key as usize);
+		return Err(err);
+	}
+	if zero_copy {
+		let sock = match &shared.ops.borrow()[key as usize] {
+			Op::Send(op) => op.lease.sock.clone(),
+			_ => unreachable!(),
+		};
+		sock.tx.borrow_mut().stats.zc_submitted += 1;
+	}
+	Ok(())
 }
 
 fn send_one(
 	shared: &Rc<Shared>,
-	sock: &Rc<SockShared>,
 	lease: &Rc<TxLease>,
 	base: *mut u8,
 	len: usize,
 	to: SocketAddr,
 	segment: Option<u16>,
+	fixed: Option<u16>,
 ) -> io::Result<()> {
 	// SAFETY: all-zero is valid for these C structs.
 	let mut hdr: Box<SendHdr> = Box::new(unsafe { std::mem::zeroed() });
@@ -851,26 +1029,15 @@ fn send_one(
 		}
 	}
 
-	let key = shared.insert(Op::Send(SendOp {
-		lease: lease.clone(),
-		expect: len,
-		_hdr: hdr,
-	}));
-	let hdr_ptr = {
-		let ops = shared.ops.borrow();
-		match &ops[key as usize] {
-			Op::Send(op) => &raw const op._hdr.hdr,
-			_ => unreachable!(),
-		}
-	};
-	let entry = opcode::SendMsg::new(types::Fd(sock.io.as_raw_fd()), hdr_ptr)
-		.build()
-		.user_data(key);
-	if let Err(err) = shared.push(&entry) {
-		shared.ops.borrow_mut().remove(key as usize);
-		return Err(err);
-	}
-	Ok(())
+	stage_send(
+		shared,
+		SendOp {
+			lease: lease.clone(),
+			expect: len,
+			_hdr: hdr,
+			mode: fixed.map_or(SendMode::Plain, SendMode::FixedZeroCopy),
+		},
+	)
 }
 
 /// Arm (or re-arm) the socket's receive. Failure is recorded on the socket.
@@ -1107,9 +1274,8 @@ fn on_recv_oneshot(one: OneshotRecv, cqe: Cqe) -> Result<(u16, Option<Queued>), 
 	))
 }
 
-/// Handle one send completion; the buffer lease releases when the last
-/// completion drops its `SendOp`.
-pub(crate) fn on_send(op: SendOp, cqe: Cqe) {
+/// Validate a send's ordinary result CQE.
+pub(crate) fn on_send_result(sock: &SockShared, expect: usize, cqe: Cqe) {
 	if cqe.result < 0 {
 		let code = -cqe.result;
 		if code == libc::ECONNREFUSED {
@@ -1118,12 +1284,43 @@ pub(crate) fn on_send(op: SendOp, cqe: Cqe) {
 			return;
 		}
 		if code != libc::ECANCELED {
-			op.lease.sock.fail_tx(code);
+			sock.fail_tx(code);
 		}
-	} else if cqe.result as usize != op.expect {
-		tracing::warn!(sent = cqe.result, expected = op.expect, "short UDP send");
-		op.lease.sock.fail_tx(libc::EIO);
+	} else if cqe.result as usize != expect {
+		tracing::warn!(sent = cqe.result, expected = expect, "short UDP send");
+		sock.fail_tx(libc::EIO);
 	}
+}
+
+fn fixed_send_unsupported(result: i32) -> bool {
+	matches!(-result, libc::EINVAL | libc::EOPNOTSUPP)
+}
+
+/// Handle a terminal send CQE. A zero-copy notification releases the lease;
+/// an unsupported fixed-buffer request is retried as ordinary `SENDMSG`.
+pub(crate) fn on_send(shared: &Rc<Shared>, mut op: SendOp, cqe: Cqe) {
+	if cqueue::notif(cqe.flags) {
+		let mut tx = op.lease.sock.tx.borrow_mut();
+		tx.stats.zc_notifications += 1;
+		if cqe.result as u32 & IORING_NOTIF_USAGE_ZC_COPIED != 0 {
+			tx.stats.zc_copied += 1;
+		}
+		return;
+	}
+
+	if fixed_send_unsupported(cqe.result) && matches!(op.mode, SendMode::FixedZeroCopy(_)) {
+		shared.sendmsg_zc_fixed.set(false);
+		op.lease.sock.tx.borrow_mut().stats.zc_fallbacks += 1;
+		tracing::warn!("kernel rejected fixed-buffer SENDMSG_ZC; falling back to SENDMSG");
+		op.mode = SendMode::Plain;
+		let sock = op.lease.sock.clone();
+		if let Err(err) = stage_send(shared, op) {
+			sock.fail_tx(err.raw_os_error().unwrap_or(libc::EIO));
+		}
+		return;
+	}
+
+	on_send_result(&op.lease.sock, op.expect, cqe);
 }
 
 /// The `UDP_GRO` segment size in a received control buffer, if present.
@@ -1244,6 +1441,14 @@ mod tests {
 	fn addr_roundtrip_v4() {
 		let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 7), 4443));
 		assert_eq!(roundtrip(addr), Some(addr));
+	}
+
+	#[test]
+	fn fixed_send_rejection_codes_fall_back() {
+		assert!(fixed_send_unsupported(-libc::EINVAL));
+		assert!(fixed_send_unsupported(-libc::EOPNOTSUPP));
+		assert!(!fixed_send_unsupported(-libc::EFAULT));
+		assert!(!fixed_send_unsupported(1));
 	}
 
 	#[test]

--- a/rs/moq-uring/src/worker.rs
+++ b/rs/moq-uring/src/worker.rs
@@ -110,6 +110,8 @@ impl Worker {
 		Ok(Self {
 			shared: Rc::new(Shared {
 				ring: RefCell::new(ring),
+				registered_buffers: RefCell::new(Default::default()),
+				sendmsg_zc_fixed: std::cell::Cell::new(true),
 				ops: RefCell::new(slab::Slab::new()),
 				timers: Rc::new(RefCell::new(timer::Heap::default())),
 				spawns: RefCell::new(Vec::new()),
@@ -293,7 +295,8 @@ impl Worker {
 		// nothing for a key after its terminal CQE, so reusing the slot for
 		// an op armed during dispatch is sound.
 		enum Route {
-			Live(Rc<udp::SockShared>),
+			LiveRecv(Rc<udp::SockShared>),
+			LiveSend(Rc<udp::SockShared>, usize),
 			Done(Op),
 		}
 
@@ -305,22 +308,28 @@ impl Worker {
 			};
 			let terminal = match op {
 				Op::Recv { .. } => cqe.result < 0 || !io_uring::cqueue::more(cqe.flags),
+				Op::Send(op) => !op.live_after(cqe),
 				_ => true,
 			};
 			if terminal {
 				Route::Done(ops.remove(key))
 			} else {
 				match op {
-					Op::Recv { sock, .. } => Route::Live(sock.clone()),
-					_ => unreachable!("only receives are non-terminal"),
+					Op::Recv { sock, .. } => Route::LiveRecv(sock.clone()),
+					Op::Send(op) => {
+						let (sock, expect) = op.result_target();
+						Route::LiveSend(sock, expect)
+					}
+					_ => unreachable!("only receives and zero-copy sends are non-terminal"),
 				}
 			}
 		};
 
 		match route {
-			Route::Live(sock) => udp::on_recv(&self.shared, &sock, None, cqe, false),
+			Route::LiveRecv(sock) => udp::on_recv(&self.shared, &sock, None, cqe, false),
+			Route::LiveSend(sock, expect) => udp::on_send_result(&sock, expect, cqe),
 			Route::Done(Op::Recv { sock, one }) => udp::on_recv(&self.shared, &sock, one, cqe, true),
-			Route::Done(Op::Send(op)) => udp::on_send(op, cqe),
+			Route::Done(Op::Send(op)) => udp::on_send(&self.shared, op, cqe),
 			Route::Done(Op::FutexWait) => self.futex_armed = false,
 			Route::Done(Op::Cancel) => {}
 		}
@@ -684,6 +693,99 @@ mod tests {
 	}
 
 	#[test]
+	fn zero_copy_buffer_waits_for_notification() {
+		let Some(mut worker) = worker() else { return };
+		let handle = worker.handle();
+		let config = udp::Config {
+			tx_buffers_max: 1,
+			..Default::default()
+		};
+		let sock = handle
+			.udp(std::net::UdpSocket::bind("127.0.0.1:0").expect("bind"), config)
+			.expect("socket");
+		let Poll::Ready(Ok(tx)) = sock.poll_acquire(&kio::Waiter::noop()) else {
+			panic!("no tx buffer");
+		};
+		let key = worker.shared.insert(Op::Send(tx.test_send_op()));
+
+		// The result CQE reports the byte count but MORE promises a later NOTIF,
+		// so the operation and its only buffer must remain checked out.
+		worker.dispatch(Cqe {
+			user_data: key,
+			result: 1,
+			flags: 1 << 1,
+		});
+		assert!(worker.shared.ops.borrow().contains(key as usize));
+		assert!(sock.poll_acquire(&kio::Waiter::noop()).is_pending());
+
+		// NOTIF's result is a usage bit mask, not a negative errno. It is the
+		// terminal CQE that finally permits buffer reuse.
+		worker.dispatch(Cqe {
+			user_data: key,
+			result: i32::MIN,
+			flags: 1 << 3,
+		});
+		assert!(!worker.shared.ops.borrow().contains(key as usize));
+		assert!(matches!(sock.poll_acquire(&kio::Waiter::noop()), Poll::Ready(Ok(_))));
+		assert_eq!(
+			sock.send_stats(),
+			udp::SendStats {
+				zc_notifications: 1,
+				zc_copied: 1,
+				..Default::default()
+			}
+		);
+	}
+
+	#[test]
+	fn fixed_buffer_sendmsg_zc_reaches_the_peer() {
+		let Some(mut worker) = worker() else { return };
+		let handle = worker.handle();
+		let config = udp::Config {
+			tx_buffers_max: 1,
+			send_zc_threshold: Some(1),
+			..Default::default()
+		};
+		let sender = handle
+			.udp(
+				std::net::UdpSocket::bind("127.0.0.1:0").expect("bind sender"),
+				config.clone(),
+			)
+			.expect("sender");
+		let receiver = handle
+			.udp(std::net::UdpSocket::bind("127.0.0.1:0").expect("bind receiver"), config)
+			.expect("receiver");
+		let to = receiver.local_addr().expect("receiver addr");
+
+		let stats = worker
+			.block_on(async {
+				let mut tx = sender.acquire().await.expect("tx buffer");
+				let len = 32 * 1200;
+				tx[..len].fill(0x5a);
+				tx.send(len, to, 1200).expect("send");
+				let packet = receiver.recv().await.expect("receive");
+				assert_eq!(packet.payload().len(), len);
+				assert!(packet.payload().iter().all(|byte| *byte == 0x5a));
+
+				let deadline = Instant::now() + Duration::from_secs(5);
+				loop {
+					let stats = sender.send_stats();
+					if stats.zc_notifications + stats.zc_fallbacks > 0 {
+						break stats;
+					}
+					assert!(Instant::now() < deadline, "zero-copy send never terminated");
+					Deadline::after(&handle, Duration::from_millis(1)).wait().await;
+				}
+			})
+			.expect("worker");
+
+		assert_eq!(stats.zc_submitted, 1);
+		assert_eq!(stats.zc_notifications + stats.zc_fallbacks, 1);
+		assert!(stats.zc_copied <= stats.zc_notifications);
+		assert!(matches!(sender.poll_acquire(&kio::Waiter::noop()), Poll::Ready(Ok(_))));
+	}
+
+	#[test]
 	fn teardown_stops_between_completions_at_the_deadline() {
 		let Some(mut worker) = worker() else { return };
 		let first = worker.shared.insert(Op::Cancel);
@@ -748,6 +850,7 @@ mod tests {
 			rx_buffer_len: 2048,
 			tx_buffers_max: 1,
 			tx_buffer_len: 2048,
+			send_zc_threshold: None,
 		};
 		let mut sockets = Vec::new();
 		let mut shared = Vec::new();


### PR DESCRIPTION
Refs #3204.

## Root cause

Linux 6.15 added vectored registered-buffer support to `IORING_OP_SENDMSG_ZC`, so the earlier conclusion that the kernel still rejected this combination was based on stale source. The locked `io-uring` 0.7.14 crate exposes `SendMsgZc` and sparse buffer registration, but it does not expose the SQE `buf_index` field for this opcode.

## Change

- Lazily register stable TX-pool allocations in a ring-global sparse table.
- Submit eligible GSO trains with fixed-buffer `SENDMSG_ZC` while preserving the per-send `UDP_SEGMENT` control message.
- Retain each TX lease through the notification CQE and report copied usage.
- Retry with ordinary `SENDMSG` after `EINVAL` or `EOPNOTSUPP` and disable later zero-copy attempts on that ring.
- Quarantine a registered-buffer index if clearing it fails.
- Keep the path opt-in through `udp::Config::send_zc_threshold`; the default remains ordinary `SENDMSG`.
- Add echo and session ablation variants plus documentation.

The private raw-SQE adapter only fills the missing `buf_index` field and pins the expected 64-byte SQE size and offset at compile time.

## Validation

- `nix develop --command just fix origin/dev`
- `nix develop --command just check origin/dev`
- `nix develop --command just test default origin/dev`: 357 passed, 1 skipped
- Actual Linux 7.1 kernel test: one fixed-buffer `SENDMSG_ZC` submission, one notification, zero opcode fallbacks, correct 38.4 KiB GSO payload, and safe buffer reuse after the notification.
- Synthetic completion test proves the TX buffer remains leased after the result CQE with `MORE` and is released only by `NOTIF`.

## Benchmark status

CPU-pinned loopback Criterion runs, 30 samples each:

- echo: 3.7985 ms ordinary versus 4.0370 ms fixed-buffer zero-copy, +6.3% mean
- session: 3.3376 ms ordinary versus 3.6306 ms fixed-buffer zero-copy, +8.8% mean

`IORING_SEND_ZC_REPORT_USAGE` reports copied payloads on loopback, so these numbers measure the forced-copy overhead and are not evidence against the physical-NIC path. This remains a draft until a controlled remote peer can drive traffic through the physical NIC and show actual zero-copy usage, then compare CPU, cycles, throughput, latency, pool pressure, and locked memory across a threshold sweep.

(written by GPT-5.6)