### PR TITLE
fix(net): escape slashes in IETF namespaces

### DIFF
--- a/js/net/src/ietf/adapter.ts
+++ b/js/net/src/ietf/adapter.ts
@@ -453,7 +453,7 @@ export class ControlStreamAdapter implements Session {
 			parts.push(decoder.decode(afterLen.subarray(0, len)));
 			cursor = afterLen.subarray(len);
 		}
-		const namespace = parts.join("/");
+		const namespace = Namespace.fromTuple(parts);
 		this.#namespaces.set(namespace, requestId);
 		this.#namespacesByRequestId.set(requestId, namespace);
 	}

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -914,6 +914,17 @@ async function decodeNamespace(bytes: Uint8Array): Promise<Path.Valid> {
 	return await Namespace.decode(reader);
 }
 
+// Helper to encode raw IETF namespace tuple fields
+async function encodeNamespaceTuple(parts: string[]): Promise<Uint8Array> {
+	const { stream, written } = createTestWritableStream();
+	const writer = new Writer(stream);
+	await writer.u53(parts.length);
+	for (const part of parts) await writer.string(part);
+	writer.close();
+	await writer.closed;
+	return concatChunks(written);
+}
+
 test("Namespace: empty encodes as zero-length tuple", async () => {
 	const bytes = await encodeNamespace(Path.empty());
 
@@ -954,6 +965,30 @@ test("Namespace: multi-part encodes correct count", async () => {
 
 	// First byte should be varint 3 (three parts)
 	expect(bytes[0]).toBe(0x03);
+});
+
+test("Namespace: slash in tuple part is escaped", async () => {
+	const tuple = await encodeNamespaceTuple(["foo/bar", "baz"]);
+	const decoded = await decodeNamespace(tuple);
+
+	expect(decoded).toBe("foo\\/bar/baz" as Path.Valid);
+	expect(await encodeNamespace(decoded)).toEqual(tuple);
+});
+
+test("Namespace: literal backslash round trips", async () => {
+	const tuple = await encodeNamespaceTuple(["foo\\bar/baz", "qux"]);
+	const decoded = await decodeNamespace(tuple);
+
+	expect(decoded).toBe("foo\\\\bar\\/baz/qux" as Path.Valid);
+	expect(await encodeNamespace(decoded)).toEqual(tuple);
+});
+
+test("Namespace: slashes at tuple part boundaries round trip", async () => {
+	const tuple = await encodeNamespaceTuple(["/foo", "bar/", "/baz/"]);
+	const decoded = await decodeNamespace(tuple);
+
+	expect(decoded).toBe("\\/foo/bar\\//\\/baz\\/" as Path.Valid);
+	expect(await encodeNamespace(decoded)).toEqual(tuple);
 });
 
 test("Namespace: Subscribe with empty namespace round trip", async () => {

--- a/js/net/src/ietf/namespace.ts
+++ b/js/net/src/ietf/namespace.ts
@@ -1,8 +1,32 @@
 import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 
+/** Convert the escaped moq-net path representation into IETF namespace tuple fields. */
+export function toTuple(namespace: Path.Valid): string[] {
+	if (namespace === "") return [];
+
+	const parts = [""];
+	for (let i = 0; i < namespace.length; i++) {
+		const ch = namespace[i];
+		if (ch === "/") {
+			parts.push("");
+		} else if (ch === "\\" && (namespace[i + 1] === "/" || namespace[i + 1] === "\\")) {
+			parts[parts.length - 1] += namespace[++i];
+		} else {
+			parts[parts.length - 1] += ch;
+		}
+	}
+	return parts;
+}
+
+/** Convert IETF namespace tuple fields into the escaped moq-net path representation. */
+export function fromTuple(parts: string[]): Path.Valid {
+	return parts.map((part) => part.replaceAll("\\", "\\\\").replaceAll("/", "\\/")).join("/") as Path.Valid;
+}
+
+/** Encode a moq-net namespace as an IETF namespace tuple. */
 export async function encode(w: Writer, namespace: Path.Valid): Promise<void> {
-	const parts = Path.parts(namespace);
+	const parts = toTuple(namespace);
 
 	// The IETF draft limits namespaces to 32 parts.
 	if (parts.length > Path.MAX_PARTS) {
@@ -15,6 +39,7 @@ export async function encode(w: Writer, namespace: Path.Valid): Promise<void> {
 	}
 }
 
+/** Decode an IETF namespace tuple into an escaped moq-net namespace. */
 export async function decode(r: Reader): Promise<Path.Valid> {
 	const count = await r.u53();
 
@@ -28,5 +53,5 @@ export async function decode(r: Reader): Promise<Path.Valid> {
 	for (let i = 0; i < count; i++) {
 		parts.push(await r.string());
 	}
-	return Path.from(...parts);
+	return fromTuple(parts);
 }

--- a/rs/moq-net/src/ietf/namespace.rs
+++ b/rs/moq-net/src/ietf/namespace.rs
@@ -2,9 +2,55 @@ use crate::{Path, coding::*};
 
 use super::Version;
 
+fn to_tuple(namespace: &Path) -> Vec<String> {
+	let path = namespace.as_str();
+	if path.is_empty() {
+		return Vec::new();
+	}
+
+	let mut parts = Vec::new();
+	let mut part = String::new();
+	let mut chars = path.chars();
+	while let Some(ch) = chars.next() {
+		match ch {
+			'/' => parts.push(std::mem::take(&mut part)),
+			'\\' => match chars.next() {
+				Some(next @ ('/' | '\\')) => part.push(next),
+				Some(next) => {
+					part.push('\\');
+					part.push(next);
+				}
+				None => part.push('\\'),
+			},
+			_ => part.push(ch),
+		}
+	}
+	parts.push(part);
+
+	parts
+}
+
+fn from_tuple(parts: &[String]) -> Path<'static> {
+	let mut path = String::new();
+	for (i, part) in parts.iter().enumerate() {
+		if i > 0 {
+			path.push('/');
+		}
+
+		for ch in part.chars() {
+			if matches!(ch, '/' | '\\') {
+				path.push('\\');
+			}
+			path.push(ch);
+		}
+	}
+
+	Path::from_escaped(path)
+}
+
 /// Helper function to encode namespace as tuple of strings
 pub fn encode_namespace<W: bytes::BufMut>(w: &mut W, namespace: &Path, version: Version) -> Result<(), EncodeError> {
-	let parts: Vec<&str> = namespace.parts().collect();
+	let parts = to_tuple(namespace);
 
 	// The IETF draft limits namespaces to 32 parts.
 	if parts.len() > Path::MAX_PARTS {
@@ -38,7 +84,7 @@ pub fn decode_namespace<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Pa
 		parts.push(part);
 	}
 
-	Ok(Path::from(parts.join("/")))
+	Ok(from_tuple(&parts))
 }
 
 #[cfg(test)]
@@ -47,14 +93,27 @@ mod tests {
 	use bytes::BytesMut;
 
 	fn encode_ns(path: &str) -> Vec<u8> {
+		encode_path(&Path::from(path.to_string()))
+	}
+
+	fn encode_path(path: &Path<'_>) -> Vec<u8> {
 		let mut buf = BytesMut::new();
-		encode_namespace(&mut buf, &Path::from(path.to_string()), Version::Draft17).unwrap();
+		encode_namespace(&mut buf, path, Version::Draft17).unwrap();
 		buf.to_vec()
 	}
 
 	fn decode_ns(bytes: &[u8]) -> Path<'static> {
 		let mut buf = bytes::Bytes::from(bytes.to_vec());
 		decode_namespace(&mut buf, Version::Draft17).unwrap()
+	}
+
+	fn encode_tuple(parts: &[&str]) -> Vec<u8> {
+		let mut buf = BytesMut::new();
+		(parts.len() as u64).encode(&mut buf, Version::Draft17).unwrap();
+		for part in parts {
+			(*part).encode(&mut buf, Version::Draft17).unwrap();
+		}
+		buf.to_vec()
 	}
 
 	#[test]
@@ -95,5 +154,29 @@ mod tests {
 	fn multi_part_encodes_correct_count() {
 		let bytes = encode_ns("a/b/c");
 		assert_eq!(bytes[0], 0x03);
+	}
+
+	#[test]
+	fn slash_in_tuple_part_is_escaped() {
+		let tuple = encode_tuple(&["foo/bar", "baz"]);
+		let decoded = decode_ns(&tuple);
+		assert_eq!(decoded.as_str(), r"foo\/bar/baz");
+		assert_eq!(encode_path(&decoded), tuple);
+	}
+
+	#[test]
+	fn literal_backslash_round_trips() {
+		let tuple = encode_tuple(&[r"foo\bar/baz", "qux"]);
+		let decoded = decode_ns(&tuple);
+		assert_eq!(decoded.as_str(), r"foo\\bar\/baz/qux");
+		assert_eq!(encode_path(&decoded), tuple);
+	}
+
+	#[test]
+	fn slashes_at_part_boundaries_round_trip() {
+		let tuple = encode_tuple(&["/foo", "bar/", "/baz/"]);
+		let decoded = decode_ns(&tuple);
+		assert_eq!(decoded.as_str(), r"\/foo/bar\//\/baz\/");
+		assert_eq!(encode_path(&decoded), tuple);
 	}
 }

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -124,6 +124,17 @@ impl<'a> Path<'a> {
 		}
 	}
 
+	pub(crate) fn from_escaped(s: String) -> PathOwned {
+		if s.is_empty() {
+			Path::empty()
+		} else {
+			Path(Repr::Shared {
+				buf: s.into(),
+				start: 0,
+			})
+		}
+	}
+
 	// A copy of this path skipping the first `n` bytes, reusing the shared buffer when possible.
 	fn slice_from(&'a self, n: usize) -> Path<'a> {
 		match &self.0 {


### PR DESCRIPTION
## Summary

- Escape slashes inside IETF namespace tuple fields as `\/` when flattening them into moq-net paths.
- Escape literal backslashes as `\\` so conversion remains reversible.
- Apply the same mapping in Rust, TypeScript, and the legacy TypeScript control-stream adapter.
- Root cause: the compatibility codecs joined and split tuple fields with `/` without distinguishing a field-local slash from a tuple boundary.

## Public API changes

- None. The Rust path constructor is crate-private, and the TypeScript tuple helpers remain inside the private IETF namespace module.

## Test plan

- `just fix`
- `just check`
- `just test` (2,932 Rust tests passed; all scoped TypeScript tests passed)

The Rust and TypeScript compatibility implementations were updated together. No draft change is needed because neither wire format changed.

(written by GPT-5)