### PR TITLE
fix(ffi): default optional record fields

### DIFF
--- a/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
+++ b/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
@@ -63,7 +63,6 @@ class SmokeTest {
     fun `all public ffi records and handles have aliases`() {
         val hint: VideoHint = VideoHint(
             coded = Dimensions(1920u, 1080u),
-            displayAspect = null,
             bitrate = 4_000_000uL,
             framerate = 60.0,
             optimizeForLatency = true,

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -840,3 +840,26 @@ async def test_read_frame_returns_none_when_track_finished():
     assert frame is not None
     assert frame.payload == b"only"
     assert await consumer.read_frame() is None
+
+
+def test_optional_binding_records_use_none_defaults():
+    """Optional UniFFI record fields are optional in generated constructors."""
+    hint = moq.VideoHint()
+    assert hint.coded is None
+    assert hint.display_aspect is None
+    assert hint.bitrate is None
+    assert hint.framerate is None
+    assert hint.optimize_for_latency is None
+
+    encoder = moq.AudioEncoderOutput(
+        codec=moq.AudioCodec.OPUS,
+        frame_duration_ms=20,
+    )
+    assert encoder.sample_rate is None
+    assert encoder.channels is None
+    assert encoder.bitrate is None
+
+    decoder = moq.AudioDecoderOutput(format=moq.AudioFormat.F32)
+    assert decoder.sample_rate is None
+    assert decoder.channels is None
+    assert decoder.latency_max_ms is None

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -71,8 +71,11 @@ pub struct MoqAudioEncoderInput {
 #[derive(uniffi::Record)]
 pub struct MoqAudioEncoderOutput {
 	pub codec: MoqAudioCodec,
+	#[uniffi(default = None)]
 	pub sample_rate: Option<u32>,
+	#[uniffi(default = None)]
 	pub channels: Option<u32>,
+	#[uniffi(default = None)]
 	pub bitrate: Option<u32>,
 	/// Encoded frame duration in milliseconds. Opus accepts
 	/// 2.5/5/10/20/40/60 ms; pass 20 to match the JS publish path.
@@ -84,8 +87,10 @@ pub struct MoqAudioEncoderOutput {
 pub struct MoqAudioDecoderOutput {
 	pub format: MoqAudioFormat,
 	/// `None` delivers samples at the codec's native rate.
+	#[uniffi(default = None)]
 	pub sample_rate: Option<u32>,
 	/// `None` delivers samples at the codec's native channel count.
+	#[uniffi(default = None)]
 	pub channels: Option<u32>,
 	/// Upper bound on buffering before skipping a stalled group, in
 	/// milliseconds. Same congestion-control knob as
@@ -94,6 +99,7 @@ pub struct MoqAudioDecoderOutput {
 	/// the consumer skips. `None` keeps the moq-mux default of zero (skip
 	/// aggressively). Named `_max` to leave room for a future
 	/// `latency_min_ms` (jitter buffer).
+	#[uniffi(default = None)]
 	pub latency_max_ms: Option<u64>,
 }
 

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -150,14 +150,19 @@ pub struct MoqDatagram {
 #[derive(Clone, Default, uniffi::Record)]
 pub struct MoqVideoHint {
 	/// The encoded pixel dimensions.
+	#[uniffi(default = None)]
 	pub coded: Option<MoqDimensions>,
 	/// The display aspect ratio.
+	#[uniffi(default = None)]
 	pub display_aspect: Option<MoqDimensions>,
 	/// The maximum bitrate in bits per second.
+	#[uniffi(default = None)]
 	pub bitrate: Option<u64>,
 	/// The frame rate in frames per second.
+	#[uniffi(default = None)]
 	pub framerate: Option<f64>,
 	/// Whether the decoder should optimize for latency.
+	#[uniffi(default = None)]
 	pub optimize_for_latency: Option<bool>,
 }
 
@@ -175,6 +180,7 @@ pub struct MoqInit {
 	/// Codec init bytes. Required for audio; may be empty for a video format that resolves in band.
 	pub data: Vec<u8>,
 	/// Caller-provided fields for a video track.
+	#[uniffi(default = None)]
 	pub video: Option<MoqVideoHint>,
 }
 

--- a/swift/Tests/MoqTests/SmokeTests.swift
+++ b/swift/Tests/MoqTests/SmokeTests.swift
@@ -49,7 +49,6 @@ final class SmokeTests: XCTestCase {
         let broadcast = try BroadcastProducer()
         let hint = VideoHint(
             coded: Dimensions(width: 1920, height: 1080),
-            displayAspect: nil,
             bitrate: 4_000_000,
             framerate: 60,
             optimizeForLatency: true


### PR DESCRIPTION
Closes #3189.

UniFFI records exposed `Option` fields as required constructor arguments because the Rust records lacked UniFFI default metadata. This adds `None` defaults to the optional audio encoder, audio decoder, video hint, and media-init fields. Required codec, format, and frame-duration choices remain required.

The Python regression test constructs these records without spelling the optional fields. The Swift and Kotlin smoke tests also omit one newly defaulted field so their generated constructors are compile-checked.

Cross-package sync:
- Python: regression coverage added.
- Kotlin: generated constructor default compiled by `just check`.
- Swift: smoke call site updated; no Swift toolchain is available locally, so the macOS workflow remains its compile gate.
- Go: generated bindings, vet, build, and race tests passed through `just check`.
- C/libmoq: unchanged because this only affects UniFFI constructor metadata.

Checks:
- `nix develop --command just fix origin/main`
- `nix develop --command just check origin/main`
- `nix develop --command just test default origin/main` (65 Rust tests and 51 Python tests passed)

(Written by GPT-5.6)