### PR TITLE
test(video): exercise PipeWire DMA-BUF rendering

### DIFF
--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -527,6 +527,85 @@ mod tests {
 		assert!(!dma_buf_import_timed_out(&other));
 	}
 
+	/// Capture packed PipeWire DMA-BUFs, import them through Vulkan, and turn
+	/// over enough frames to exercise the producer lease and completion worker.
+	/// Ignored because it needs a Linux desktop, PipeWire, a Vulkan GPU, and a
+	/// human selecting a screen in the portal picker. Run with
+	/// `cargo test -p moq-video --no-default-features --features pipewire,render packed_dmabuf_renders_through_vulkan -- --ignored`.
+	#[cfg(all(target_os = "linux", feature = "pipewire"))]
+	#[tokio::test]
+	#[ignore = "needs a PipeWire desktop and Vulkan GPU"]
+	async fn packed_dmabuf_renders_through_vulkan() {
+		let instance = wgpu::Instance::default();
+		let adapter = instance
+			.request_adapter(&wgpu::RequestAdapterOptions::default())
+			.await
+			.expect("a GPU adapter");
+		assert_eq!(
+			adapter.get_info().backend,
+			wgpu::Backend::Vulkan,
+			"DMA-BUF import needs Vulkan"
+		);
+
+		let external_memory = wgpu::Features::VULKAN_EXTERNAL_MEMORY_DMA_BUF;
+		assert!(
+			adapter.features().contains(external_memory),
+			"Vulkan adapter does not support DMA-BUF external memory"
+		);
+		let (device, queue) = adapter
+			.request_device(&wgpu::DeviceDescriptor {
+				required_features: external_memory,
+				..Default::default()
+			})
+			.await
+			.expect("a DMA-BUF-capable GPU device");
+		let mut renderer = Renderer::new(&device, &queue, Config::new()).expect("a renderer");
+
+		let capture = crate::capture::Config {
+			source: crate::capture::Source::Display(None),
+			..Default::default()
+		};
+		let mut stream = crate::capture::open(&capture).await.expect("portal screen capture");
+
+		for index in 0..16 {
+			let surface = tokio::time::timeout(std::time::Duration::from_secs(5), stream.read())
+				.await
+				.unwrap_or_else(|_| panic!("timed out waiting for frame {index}"))
+				.unwrap_or_else(|| panic!("capture ended before frame {index}"));
+			let Surface::DmaBuf(buffer) = &surface else {
+				panic!("frame {index} used shared memory instead of DMA-BUF");
+			};
+			assert!(
+				matches!(
+					buffer.format(),
+					crate::DrmFormat::XRGB8888
+						| crate::DrmFormat::ARGB8888
+						| crate::DrmFormat::XBGR8888
+						| crate::DrmFormat::ABGR8888
+				),
+				"frame {index} negotiated unsupported DMA-BUF format {:#x}",
+				buffer.format().as_raw()
+			);
+
+			let frame = Frame::new(surface, Timestamp::ZERO);
+			let imported = renderer
+				.source
+				.import(&device, &frame.surface)
+				.expect("Vulkan DMA-BUF import")
+				.expect("a DMA-BUF import path");
+			assert_eq!(imported.layout, Layout::Rgba);
+			drop(imported);
+
+			let texture = renderer.render(&frame).expect("a zero-copy rendered frame");
+			assert_eq!((texture.width(), texture.height()), (stream.width(), stream.height()));
+		}
+
+		drop(renderer);
+		device
+			.poll(wgpu::PollType::wait_indefinitely())
+			.expect("all imported frame reads completed");
+	}
+
 	/// Every test here draws on a real GPU, which a headless CI runner does not
 	/// have (wgpu finds no adapter and `Renderer::new` never gets built). The
 	/// color math itself is covered by [`super::super::color`]'s tests, which

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -597,6 +597,8 @@ mod tests {
 			drop(imported);
 
 			let texture = renderer.render(&frame).expect("a zero-copy rendered frame");
+			assert_eq!(renderer.strikes, 0, "frame {index} fell back to the CPU");
+			assert!(!renderer.retired, "frame {index} retired the zero-copy path");
 			assert_eq!((texture.width(), texture.height()), (stream.width(), stream.height()));
 		}
 


### PR DESCRIPTION
## Summary

- Add an ignored Linux hardware test that captures real PipeWire DMA-BUF frames and imports them through Vulkan.
- Require packed RGB DMA-BUFs and call the Vulkan import path directly, so shared-memory and CPU fallbacks cannot make the test pass.
- Render 16 frames and wait for GPU completion to exercise producer leases and completion-worker turnover.
- Add the missing repeatable hardware validation gate for #2819, under the #2481 native media work.

## Public API changes

None.

## Test plan

- `nix develop --command just check`
- `nix develop --command just test` (264 passed)
- `cargo test -p moq-video --no-default-features --features pipewire,render --lib` (88 passed, 5 ignored)
- `cargo clippy -p moq-video --no-default-features --features pipewire,render --all-targets -- -D warnings`
- The ignored hardware test reached the desktop portal on an NVIDIA RTX 3070 Ti, but the picker could not be completed from this noninteractive session. It remains an explicit manual gate for a developer with a PipeWire desktop and Vulkan GPU.

Cross-package sync does not apply because this is a private, test-only change.

(written by GPT-5.6)