### PR TITLE
feat(py): add ergonomic route update iterator

### DIFF
--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -336,7 +336,15 @@ broadcast = await client.request_broadcast("live/cam1")
 
 Announcements arrive over the session after it connects, so `request_broadcast` on its own races them: right after connecting it can raise for a broadcast that is live but not reachable locally yet. Await `announced_broadcast(path)` first when you know the path you want; use `request_broadcast` for a path already reachable locally, whether announced or not, or one a dynamic handler serves.
 
-Each broadcast carries a `Route`: `route.hops` is the chain of relay origin ids (as `list[int]`) the broadcast passed through to reach you, oldest first, and `route.cost` is the publisher's advertised preference (lower wins). The route is dynamic; `await broadcast.route_changed()` returns the current route first, then blocks for each change (e.g. an upstream failover), and returns `None` once the broadcast ends. A publisher advertises its own route with `producer.set_route(moq.Route(hops=[], cost=10))`, for example a standby transcoder that lowers its cost to 0 once it is warm.
+Each broadcast carries a `Route`: `route.hops` is the chain of relay origin ids (as `list[int]`) the broadcast passed through to reach you, oldest first, and `route.cost` is the publisher's advertised preference (lower wins). The route is dynamic. Iterate `broadcast.route_updates()` to receive the current route first, then each change (e.g. an upstream failover), until the broadcast ends:
+
+```python
+async with broadcast.route_updates() as routes:
+    async for route in routes:
+        print(route.hops, route.cost)
+```
+
+For one-at-a-time compatibility, `await broadcast.route_changed()` uses one cached watch and returns `None` once the broadcast ends. A publisher advertises its own route with `producer.set_route(moq.Route(hops=[], cost=10))`, for example a standby transcoder that lowers its cost to 0 once it is warm.
 
 ## Examples
 

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -157,10 +157,12 @@ client = moq.Client(
 ### Subscribing
 
 - **`BroadcastConsumer`**. Subscribe to tracks within a broadcast.
+  - `.route_updates() → RouteWatch` (async iterator; current route, then changes)
   - `await .subscribe_catalog() → CatalogConsumer`
   - `await .subscribe_track(name, subscription=None) → TrackConsumer`
   - `await .subscribe_media(name, track, subscription=None) → MediaConsumer`. `track` is the catalog record (e.g. `catalog.video[name]`); its container tells the decoder how to parse the bitstream.
   - `await .catalog() → Catalog` (convenience)
+- **`RouteWatch`**. Async iterator of `Route` that ends with the broadcast.
 - **`CatalogConsumer`**. Async iterator of `Catalog`.
 - **`MediaConsumer`**. Async iterator of `MediaFrame`.
 - **`TrackConsumer`**. Async iterator of raw groups, in sequence order.
@@ -174,7 +176,7 @@ client = moq.Client(
 - **`GroupConsumer`**. Async iterator of timestamped `Frame`s.
   - `.read_frame() -> Frame | None` returns a timestamped raw frame.
 
-All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsumer`, `GroupConsumer`) are async context managers; exiting `async with` cancels the subscription.
+All consumers and route watches (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsumer`, `GroupConsumer`, `RouteWatch`) are async context managers; exiting `async with` cancels the subscription or watch.
 
 ### Origin (advanced)
 

--- a/py/moq-rs/docs/index.md
+++ b/py/moq-rs/docs/index.md
@@ -76,6 +76,7 @@ asyncio.run(main())
    :nosignatures:
 
    BroadcastConsumer
+   RouteWatch
    TrackConsumer
    GroupConsumer
    MediaConsumer

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -43,6 +43,7 @@ from .subscribe import (
     JsonStreamConsumer,
     MediaConsumer,
     MediaGroupConsumer,
+    RouteWatch,
     TrackConsumer,
 )
 from .types import (
@@ -119,6 +120,7 @@ __all__ = [
     "OriginProducer",
     "Request",
     "Route",
+    "RouteWatch",
     "Server",
     "Session",
     "Subscription",

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -17,6 +17,7 @@ from moq_ffi import (
     MoqJsonStreamConsumer,
     MoqMediaConsumer,
     MoqMediaGroupConsumer,
+    MoqRouteWatch,
     MoqTrackConsumer,
 )
 
@@ -338,6 +339,37 @@ class CatalogConsumer:
         self._inner.cancel()
 
 
+class RouteWatch:
+    """Async iterator of a broadcast's route changes.
+
+    Created by :meth:`BroadcastConsumer.route_updates`. The first item is the
+    current route, followed by each update. Iteration ends when the broadcast
+    ends. Usable as an async context manager that cancels on exit.
+    """
+
+    def __init__(self, inner: MoqRouteWatch) -> None:
+        self._inner = inner
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        self.cancel()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> Route:
+        route = await self._inner.next()
+        if route is None:
+            raise StopAsyncIteration
+        return route
+
+    def cancel(self) -> None:
+        """Cancel this watch and stop delivering route updates."""
+        self._inner.cancel()
+
+
 class BroadcastConsumer:
     """The consume side of one broadcast: subscribe to its tracks, catalog, and media.
 
@@ -347,7 +379,7 @@ class BroadcastConsumer:
 
     def __init__(self, inner: MoqBroadcastConsumer) -> None:
         self._inner = inner
-        self._route_watch = None
+        self._route_watch: RouteWatch | None = None
 
     @property
     def route(self) -> Route:
@@ -358,6 +390,14 @@ class BroadcastConsumer:
         """
         return self._inner.route()
 
+    def route_updates(self) -> RouteWatch:
+        """Watch the current route and each later update.
+
+        The returned async iterator has its own cursor. Cancel it directly or
+        use it as an async context manager to stop a pending wait.
+        """
+        return RouteWatch(self._inner.route_updates())
+
     async def route_changed(self) -> Route | None:
         """Wait for the broadcast's route to change.
 
@@ -366,8 +406,11 @@ class BroadcastConsumer:
         ``None`` once the broadcast ends.
         """
         if self._route_watch is None:
-            self._route_watch = self._inner.route_updates()
-        return await self._route_watch.next()
+            self._route_watch = self.route_updates()
+        try:
+            return await anext(self._route_watch)
+        except StopAsyncIteration:
+            return None
 
     async def subscribe_catalog(self) -> CatalogConsumer:
         """Subscribe to the broadcast's catalog, async-iterating snapshots as it changes."""

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -133,6 +133,103 @@ async def test_local_publish_consume_audio():
         break
 
 
+async def test_route_updates_yields_current_changes_and_clean_end():
+    producer = moq.BroadcastProducer()
+    producer.set_route(moq.Route(hops=[1], cost=10, announce=True))
+    consumer = producer.consume()
+
+    async with consumer.route_updates() as routes:
+        assert isinstance(routes, moq.RouteWatch)
+        assert await asyncio.wait_for(anext(routes), timeout=5.0) == moq.Route(
+            hops=[1], cost=10, announce=True
+        )
+
+        for expected in (
+            moq.Route(hops=[1, 2], cost=5, announce=True),
+            moq.Route(hops=[1, 2, 3], cost=0, announce=True),
+        ):
+            pending = asyncio.create_task(anext(routes))
+            await asyncio.sleep(0)
+            producer.set_route(expected)
+            assert await asyncio.wait_for(pending, timeout=5.0) == expected
+
+        producer.finish()
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(anext(routes), timeout=5.0)
+
+
+async def test_route_watch_context_exit_cancels_future_calls():
+    producer = moq.BroadcastProducer()
+    routes = producer.consume().route_updates()
+
+    async with routes:
+        await asyncio.wait_for(anext(routes), timeout=5.0)
+
+    with pytest.raises(moq.Error) as cancelled:  # type: ignore[arg-type]
+        await asyncio.wait_for(anext(routes), timeout=5.0)
+    assert moq.is_shutdown(cancelled.value)
+    producer.finish()
+
+
+async def test_route_watch_cancel_stops_pending_and_future_calls():
+    producer = moq.BroadcastProducer()
+    routes = producer.consume().route_updates()
+    await asyncio.wait_for(anext(routes), timeout=5.0)
+
+    pending = asyncio.create_task(anext(routes))
+    await asyncio.sleep(0)
+    assert not pending.done()
+    routes.cancel()
+
+    with pytest.raises(moq.Error) as cancelled:  # type: ignore[arg-type]
+        await asyncio.wait_for(pending, timeout=5.0)
+    assert moq.is_shutdown(cancelled.value)
+    with pytest.raises(moq.Error) as terminal:  # type: ignore[arg-type]
+        await asyncio.wait_for(anext(routes), timeout=5.0)
+    assert moq.is_shutdown(terminal.value)
+    producer.finish()
+
+
+async def test_route_watch_remains_usable_after_cancelled_or_timed_out_next():
+    producer = moq.BroadcastProducer()
+    routes = producer.consume().route_updates()
+    await asyncio.wait_for(anext(routes), timeout=5.0)
+
+    cancelled = asyncio.create_task(anext(routes))
+    await asyncio.sleep(0)
+    assert not cancelled.done()
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled
+
+    after_cancel = moq.Route(hops=[10], cost=1, announce=False)
+    producer.set_route(after_cancel)
+    assert await asyncio.wait_for(anext(routes), timeout=5.0) == after_cancel
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(anext(routes), timeout=0.01)
+
+    after_timeout = moq.Route(hops=[10, 20], cost=2, announce=False)
+    producer.set_route(after_timeout)
+    assert await asyncio.wait_for(anext(routes), timeout=5.0) == after_timeout
+    producer.finish()
+
+
+async def test_route_changed_uses_one_compatible_cursor():
+    producer = moq.BroadcastProducer()
+    consumer = producer.consume()
+
+    first = await asyncio.wait_for(consumer.route_changed(), timeout=5.0)
+    assert first is not None
+
+    expected = moq.Route(hops=[7], cost=3, announce=False)
+    producer.set_route(expected)
+    assert await asyncio.wait_for(consumer.route_changed(), timeout=5.0) == expected
+
+    producer.finish()
+    assert await asyncio.wait_for(consumer.route_changed(), timeout=5.0) is None
+
+
 async def test_video_publish_consume():
     origin = moq.OriginProducer()
     broadcast = origin.create_broadcast("video-test")

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -140,9 +140,7 @@ async def test_route_updates_yields_current_changes_and_clean_end():
 
     async with consumer.route_updates() as routes:
         assert isinstance(routes, moq.RouteWatch)
-        assert await asyncio.wait_for(anext(routes), timeout=5.0) == moq.Route(
-            hops=[1], cost=10, announce=True
-        )
+        assert await asyncio.wait_for(anext(routes), timeout=5.0) == moq.Route(hops=[1], cost=10, announce=True)
 
         for expected in (
             moq.Route(hops=[1, 2], cost=5, announce=True),

--- a/rs/moq-ffi/src/ffi.rs
+++ b/rs/moq-ffi/src/ffi.rs
@@ -3,6 +3,16 @@ use std::sync::Arc;
 
 use crate::error::MoqError;
 
+#[cfg(not(target_arch = "wasm32"))]
+struct AbortOnDrop(tokio::task::AbortHandle);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for AbortOnDrop {
+	fn drop(&mut self) {
+		self.0.abort();
+	}
+}
+
 /// A dedicated runtime thread, so a foreign caller's thread never has to drive our futures.
 ///
 /// wasm32 has neither threads nor a tokio driver. uniffi's `RustFuture` is polled by the
@@ -50,14 +60,6 @@ where
 	T: Send + 'static,
 	E: Into<MoqError> + Send + 'static,
 {
-	struct AbortOnDrop(tokio::task::AbortHandle);
-
-	impl Drop for AbortOnDrop {
-		fn drop(&mut self) {
-			self.0.abort();
-		}
-	}
-
 	let task = RUNTIME.spawn(future);
 	let _abort = AbortOnDrop(task.abort_handle());
 	match task.await {
@@ -111,6 +113,7 @@ impl<T: kio::MaybeSend + 'static> Task<T> {
 		let state = self.state.clone();
 
 		let handle = RUNTIME.spawn(async move { Self::drive(cancel, state, f).await });
+		let _abort = AbortOnDrop(handle.abort_handle());
 
 		match handle.await {
 			Ok(result) => result,
@@ -165,5 +168,41 @@ impl<T: kio::MaybeSend + 'static> Task<T> {
 impl<T: kio::MaybeSend + 'static> Drop for Task<T> {
 	fn drop(&mut self) {
 		self.cancel();
+	}
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+	use std::sync::Arc;
+	use std::time::Duration;
+
+	use super::*;
+
+	#[tokio::test]
+	async fn dropping_run_releases_the_state() {
+		let task = Arc::new(Task::new(()));
+		let running = task.clone();
+		let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+		let outer = tokio::spawn(async move {
+			running
+				.run(move |_state| async move {
+					started_tx.send(()).unwrap();
+					std::future::pending::<Result<(), MoqError>>().await
+				})
+				.await
+		});
+
+		tokio::time::timeout(Duration::from_secs(5), started_rx)
+			.await
+			.expect("run did not start")
+			.unwrap();
+		outer.abort();
+		assert!(outer.await.unwrap_err().is_cancelled());
+
+		tokio::time::timeout(Duration::from_secs(5), task.run(|_state| async { Ok(()) }))
+			.await
+			.expect("cancelled run retained the state")
+			.unwrap();
 	}
 }

--- a/rs/moq-ffi/src/ffi.rs
+++ b/rs/moq-ffi/src/ffi.rs
@@ -161,7 +161,7 @@ impl<T: kio::MaybeSend + 'static> Task<T> {
 
 	/// Cancel all current and future [Self::run] calls, causing them to return [MoqError::Cancelled].
 	pub fn cancel(&self) {
-		let _ = self.cancel.send(true);
+		self.cancel.send_replace(true);
 	}
 }
 
@@ -174,6 +174,7 @@ impl<T: kio::MaybeSend + 'static> Drop for Task<T> {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
 	use std::sync::Arc;
+	use std::sync::atomic::{AtomicBool, Ordering};
 	use std::time::Duration;
 
 	use super::*;
@@ -204,5 +205,24 @@ mod tests {
 			.await
 			.expect("cancelled run retained the state")
 			.unwrap();
+	}
+
+	#[tokio::test]
+	async fn cancel_before_run_is_terminal() {
+		let task = Task::new(());
+		let called = Arc::new(AtomicBool::new(false));
+		let closure_called = called.clone();
+
+		task.cancel();
+		let error = task
+			.run(move |_state| {
+				closure_called.store(true, Ordering::SeqCst);
+				async { Ok(()) }
+			})
+			.await
+			.expect_err("run after cancel should fail");
+
+		assert!(matches!(error, MoqError::Cancelled));
+		assert!(!called.load(Ordering::SeqCst));
 	}
 }


### PR DESCRIPTION
Closes #3193.

## Summary

- Add `RouteWatch`, an async iterator and async context manager for the current broadcast route and subsequent updates.
- Keep `route_changed()` compatible by backing it with one cached watch cursor.
- Fix dropped foreign async calls so they abort the exact detached Rust task. Previously, cancelling or timing out `anext()` could leave that task holding the watch state forever, causing the next call to hang.
- Make explicit watch cancellation terminal even when it occurs before the first wait.

## Public API changes

- Add Python `BroadcastConsumer.route_updates() -> RouteWatch`.
- Add Python `RouteWatch` with async iteration, async context management, and `cancel()`.
- Existing `route_changed()` behavior remains available.

The `moq-ffi` changes are internal task-lifecycle fixes; no generated FFI, C, Swift, Kotlin, or Go surface changes are required.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test`
- 55 Python tests pass, including current value, ordered updates, clean end, context cleanup, pending cancellation, timeout reuse, and `route_changed()` compatibility.
- 67 `moq-ffi` tests pass, including dropped-run state release and cancel-before-run terminal behavior.

(Written by GPT-5.6)