### PR TITLE
fix(net): reject malformed protocol UTF-8

### DIFF
--- a/js/net/src/ietf/adapter.ts
+++ b/js/net/src/ietf/adapter.ts
@@ -1,5 +1,6 @@
 import { Mutex } from "async-mutex";
 import { Reader, Stream, type Writer } from "../stream.ts";
+import { decodeUtf8 } from "../util/utf8.ts";
 import * as Varint from "../varint.ts";
 import * as Namespace from "./namespace.ts";
 import { type IetfVersion, Version } from "./version.ts";
@@ -444,13 +445,12 @@ export class ControlStreamAdapter implements Session {
 	 * Parse a namespace from raw bytes and register it for reverse lookup.
 	 */
 	#parseAndRegisterNamespace(buf: Uint8Array, requestId: bigint) {
-		const decoder = new TextDecoder();
 		const [partCount, afterCount] = Varint.decode(buf);
 		let cursor = afterCount;
 		const parts: string[] = [];
 		for (let i = 0; i < partCount; i++) {
 			const [len, afterLen] = Varint.decode(cursor);
-			parts.push(decoder.decode(afterLen.subarray(0, len)));
+			parts.push(decodeUtf8(afterLen.subarray(0, len)));
 			cursor = afterLen.subarray(len);
 		}
 		const namespace = Namespace.fromTuple(parts);

--- a/js/net/src/lite/setup.test.ts
+++ b/js/net/src/lite/setup.test.ts
@@ -153,3 +153,7 @@ test("empty path decodes as the root", async () => {
 	const got = await decodeParam(PARAM_PATH, new Uint8Array());
 	expect(got.path).toBe("");
 });
+
+test("SETUP rejects a path with malformed UTF-8", async () => {
+	await expect(decodeParam(PARAM_PATH, new Uint8Array([0xc3, 0x28]))).rejects.toThrow();
+});

--- a/js/net/src/lite/setup.ts
+++ b/js/net/src/lite/setup.ts
@@ -7,6 +7,7 @@
 
 import { type Origin, OriginSchema } from "../origin.ts";
 import type { Reader, Writer } from "../stream.ts";
+import { decodeUtf8 } from "../util/utf8.ts";
 import * as Varint from "../varint.ts";
 import * as Message from "./message.ts";
 import { hasSetupStream, type Version } from "./version.ts";
@@ -249,7 +250,7 @@ export class Setup {
 		// An empty path is valid and means the same as omitting the parameter, so a
 		// client that wants the root doesn't have to special-case it.
 		const pathBytes = params.getBytes(PARAM_PATH);
-		const path = pathBytes === undefined ? undefined : new TextDecoder().decode(pathBytes);
+		const path = pathBytes === undefined ? undefined : decodeUtf8(pathBytes);
 
 		const roleCode = params.getVarint(PARAM_ROLE);
 		const role = roleCode === undefined ? Role.Both : roleFromCode(roleCode);

--- a/js/net/src/stream.test.ts
+++ b/js/net/src/stream.test.ts
@@ -104,6 +104,12 @@ test("Writer string", async () => {
 	expect(str2).toBe("🎉");
 });
 
+test("Reader string rejects malformed UTF-8", async () => {
+	const reader = new Reader(undefined, new Uint8Array([2, 0xc3, 0x28]));
+
+	await expect(reader.string()).rejects.toThrow();
+});
+
 test("Reader u8", async () => {
 	const data = new Uint8Array([42, 255, 0, 128]);
 	const reader = new Reader(undefined, data);

--- a/js/net/src/stream.ts
+++ b/js/net/src/stream.ts
@@ -2,6 +2,7 @@ import { fromTransport } from "./error.ts";
 import type { IetfVersion } from "./ietf/version.ts";
 import { Version } from "./ietf/version.ts";
 import { TimeoutError, withTimeout } from "./util/timeout.ts";
+import { decodeUtf8 } from "./util/utf8.ts";
 import * as Varint from "./varint.ts";
 
 const MAX_U31 = 2 ** 31 - 1;
@@ -259,7 +260,7 @@ export class Reader {
 	async string(): Promise<string> {
 		const length = await this.u53();
 		const buffer = await this.read(length);
-		return new TextDecoder().decode(buffer);
+		return decodeUtf8(buffer);
 	}
 
 	async bool(): Promise<boolean> {

--- a/js/net/src/util/utf8.ts
+++ b/js/net/src/util/utf8.ts
@@ -1,0 +1,6 @@
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+/** Decode a protocol string, rejecting bytes that are not valid UTF-8. */
+export function decodeUtf8(buffer: Uint8Array): string {
+	return decoder.decode(buffer);
+}


### PR DESCRIPTION
## Summary

- Reject malformed UTF-8 in every JavaScript protocol string decoded through Reader, matching Rust's String::from_utf8 behavior.
- Use the same fatal decoder for lite SETUP paths and the IETF adapter's raw namespace parsing.
- Root cause: TextDecoder is non-fatal by default, so invalid bytes were silently replaced with U+FFFD and accepted as a different identity-bearing string.

## Public API changes

- None. The decoder helper is package-internal.

## Test plan

- nix develop --command bun test js/net/src/stream.test.ts js/net/src/lite/setup.test.ts
- nix develop --command just fix
- nix develop --command just check
- nix develop --command just test

Closes #3218

(written by gpt-5.6-sol)
