### PR TITLE
fix(net): reject lossy u53 wire integers

### DIFF
--- a/js/net/src/stream.test.ts
+++ b/js/net/src/stream.test.ts
@@ -160,7 +160,7 @@ test("Reader readAll", async () => {
 
 test("Reader u53 varint decoding", async () => {
 	// Test various varint sizes
-	const testValues = [0, 63, 64, 16383, 16384, 1073741823, 1073741824];
+	const testValues = [0, 63, 64, 16383, 16384, 1073741823, 1073741824, Number.MAX_SAFE_INTEGER];
 
 	const { stream, written } = createTestWritableStream();
 	const testWriter = new Writer(stream);
@@ -178,6 +178,29 @@ test("Reader u53 varint decoding", async () => {
 	for (const expectedValue of testValues) {
 		const actualValue = await reader.u53();
 		expect(actualValue).toBe(expectedValue);
+	}
+
+	expect(await reader.done()).toBe(true);
+});
+
+test("Reader u53 rejects integers that cannot be represented exactly", async () => {
+	const firstUnsafe = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+	const wireValues = [firstUnsafe, firstUnsafe + 1n];
+	expect(Number(wireValues[0])).toBe(Number(wireValues[1]));
+
+	const { stream, written } = createTestWritableStream();
+	const writer = new Writer(stream);
+
+	for (const value of wireValues) {
+		await writer.u62(value);
+	}
+
+	writer.close();
+	await writer.closed;
+
+	const reader = new Reader(undefined, concatChunks(written));
+	for (const value of wireValues) {
+		await expect(reader.u53()).rejects.toThrow(`value larger than 53-bits: ${value}`);
 	}
 
 	expect(await reader.done()).toBe(true);

--- a/js/net/src/stream.ts
+++ b/js/net/src/stream.ts
@@ -283,13 +283,10 @@ export class Reader {
 	}
 
 	// Returns a Number using 53-bits, the max Javascript can use for integer math.
-	// Values > 2^53-1 are coerced to a Number (precision is lost) and logged. We
-	// downgrade overflow from throw to warn so a stray u64 field on the wire (e.g.
-	// a peer's session-level Origin id) doesn't tear down the whole stream/session.
 	async u53(): Promise<number> {
 		const v = await this.u62();
 		if (v > Varint.MAX_U53) {
-			console.warn(`value larger than 53-bits; use u62 instead (precision lost): ${v.toString()}`);
+			throw new Error(`value larger than 53-bits: ${v.toString()}`);
 		}
 
 		return Number(v);


### PR DESCRIPTION
## Summary

- Reject `u53` wire values above `Number.MAX_SAFE_INTEGER` before converting them to `number`.
- Fix the root cause where exact `bigint` decoding was followed by a lossy conversion, allowing distinct peer-controlled values such as `2^53` and `2^53 + 1` to collide.
- Keep the existing public `number` identifier types; fields that need the full wire range continue to use `u62`.

## Public API changes

- None. Method signatures and identifier types are unchanged. Out-of-range peer values now fail decoding instead of being rounded.

## Test plan

- `nix develop --command bun test js/net/src/stream.test.ts`
- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test`

No cross-package update is needed because this does not change the wire format or public API shape.

Closes #3217

(written by gpt-5.6-sol)
