### PR TITLE
fix(net): send registered PUBLISH_DONE statuses

### DIFF
--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -277,6 +277,30 @@ test("PublishDone: with error", async () => {
 	expect(decoded.reasonPhrase).toBe("error");
 });
 
+test("PublishDone: preserves unknown statuses across supported versions", async () => {
+	const versions = [
+		Version.DRAFT_14,
+		Version.DRAFT_15,
+		Version.DRAFT_16,
+		Version.DRAFT_17,
+		Version.DRAFT_18,
+		Version.DRAFT_19,
+	] as const;
+
+	for (const version of versions) {
+		const legacy = version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16;
+		const msg = new PublishDone({
+			requestId: legacy ? 10n : undefined,
+			statusCode: 0xface,
+			reasonPhrase: "extension",
+		});
+
+		const encoded = await encodeVersioned(msg, version);
+		const decoded = await decodeVersioned(encoded, PublishDone.decode, version);
+		expect(decoded.statusCode).toBe(0xface);
+	}
+});
+
 // Announce/PublishNamespace tests
 test("PublishNamespace: round trip", async () => {
 	const msg = new Announce.PublishNamespace({ requestId: 1n, trackNamespace: Path.from("test/broadcast") });
@@ -1154,14 +1178,14 @@ test("Publish v18: round trip", async () => {
 });
 
 test("PublishDone v18: no requestId", async () => {
-	const msg = new PublishDone({ statusCode: 200, reasonPhrase: "OK" });
+	const msg = new PublishDone({ statusCode: 2, reasonPhrase: "track ended" });
 
 	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
 	const decoded = await decodeVersioned(encoded, PublishDone.decode, Version.DRAFT_18);
 
 	expect(decoded.requestId).toBe(undefined);
-	expect(decoded.statusCode).toBe(200);
-	expect(decoded.reasonPhrase).toBe("OK");
+	expect(decoded.statusCode).toBe(2);
+	expect(decoded.reasonPhrase).toBe("track ended");
 });
 
 test("RequestOk v18: no requestId (regression: don't treat Draft18 as legacy)", async () => {

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -6,6 +6,7 @@ import * as Path from "../path.ts";
 import { Stream } from "../stream.ts";
 import { NativeSession, type Session } from "./adapter.ts";
 import type * as Cluster from "./cluster.ts";
+import { PublishDone } from "./publish.ts";
 import { PublishNamespace } from "./publish_namespace.ts";
 import { Publisher } from "./publisher.ts";
 import { RequestError, RequestOk } from "./request.ts";
@@ -403,5 +404,51 @@ test("a same-tick republish survives its predecessor closing", async () => {
 	} finally {
 		pub.close();
 		client.close();
+	}
+});
+
+test("subscription completion sends PUBLISH_DONE on every supported draft", async () => {
+	const versions = [
+		Version.DRAFT_14,
+		Version.DRAFT_15,
+		Version.DRAFT_16,
+		Version.DRAFT_17,
+		Version.DRAFT_18,
+		Version.DRAFT_19,
+	] as const;
+
+	for (const version of versions) {
+		for (const abort of [undefined, new Error("failed")]) {
+			const pair = createMockTransportPair(ALPN.DRAFT_19);
+			const session = new NativeSession(pair.server, version, true);
+			const pub = new Publisher({ quic: pair.server, session, requiresSolicitation: false });
+			const broadcast = new BroadcastProducer();
+			const track = broadcast.createTrack("video");
+			const path = Path.from("test");
+			pub.publish(path, broadcast);
+
+			const client = await Stream.open(pair.client, { version });
+			const server = await Stream.accept(pair.server, version);
+			if (!server) throw new Error("publisher never accepted the subscribe stream");
+
+			const requestId = 7n;
+			const running = pub.runSubscribe(
+				new Subscribe({ requestId, trackNamespace: path, trackName: "video", subscriberPriority: 0 }),
+				server,
+			);
+
+			expect(await client.reader.u53()).toBe(SubscribeOk.id);
+			await SubscribeOk.decode(client.reader, version);
+			track.close(abort);
+
+			expect(await client.reader.u53()).toBe(PublishDone.id);
+			const done = await PublishDone.decode(client.reader, version);
+			expect(done.requestId).toBe(version <= Version.DRAFT_16 ? requestId : undefined);
+			expect(done.statusCode).toBe(abort ? 0x0 : 0x2);
+
+			await running;
+			pub.close();
+			client.close();
+		}
 	}
 });

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -29,6 +29,12 @@ const RETRY_BASE = 100;
 /** Ceiling on that wait. The loop retries for the life of the session, so it must not spin. */
 const RETRY_MAX = 5000;
 
+/** PUBLISH_DONE statuses this implementation emits. Stable across drafts 14 through 19. */
+const PUBLISH_DONE_STATUS = {
+	INTERNAL_ERROR: 0x0,
+	TRACK_ENDED: 0x2,
+} as const;
+
 /**
  * How long one advertisement may take to be answered. Matches the Rust publisher, and the
  * peer accepting the stream is only half the exchange: one it never answers on holds the
@@ -212,23 +218,33 @@ export class Publisher {
 				}
 			})();
 
-			await Promise.race([serving, stream.reader.closed]);
+			let publishError: Error | undefined;
+			try {
+				await Promise.race([serving, stream.reader.closed]);
+			} catch (err: unknown) {
+				publishError = error(err);
+			}
 
 			console.debug(`publish done: broadcast=${name} track=${track.name}`);
+			if (publishError) {
+				console.warn(`publish error: broadcast=${name} track=${track.name} error=${reason(publishError)}`);
+			}
 
-			// v14-v16: send PublishDone before closing
-			if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
-				try {
-					await stream.writer.u53(PublishDone.id);
-					const done = new PublishDone({
-						requestId: msg.requestId,
-						statusCode: 200,
-						reasonPhrase: "OK",
-					});
-					await done.encode(stream.writer, version);
-				} catch {
-					// Stream might already be closed by peer
-				}
+			// PUBLISH_DONE is required for every supported draft. The peer may have already
+			// closed its side to unsubscribe, in which case there is nowhere to send it.
+			try {
+				await stream.writer.u53(PublishDone.id);
+				const done = new PublishDone({
+					requestId:
+						version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16
+							? msg.requestId
+							: undefined,
+					statusCode: publishError ? PUBLISH_DONE_STATUS.INTERNAL_ERROR : PUBLISH_DONE_STATUS.TRACK_ENDED,
+					reasonPhrase: publishError ? "internal error" : "track ended",
+				});
+				await done.encode(stream.writer, version);
+			} catch {
+				// Stream might already be closed by peer.
 			}
 
 			// Only now is the close below ours. Claiming it any earlier would read a peer FIN

--- a/rs/moq-net/src/ietf/publish.rs
+++ b/rs/moq-net/src/ietf/publish.rs
@@ -119,6 +119,32 @@ use super::Message;
 
 use super::Version;
 
+/// PUBLISH_DONE statuses emitted by this implementation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PublishDoneStatus {
+	/// An implementation-specific failure ended the subscription.
+	InternalError,
+	/// The track is no longer being published.
+	TrackEnded,
+}
+
+impl PublishDoneStatus {
+	/// Return the registered wire code for every supported draft.
+	pub(crate) const fn code(self, version: Version) -> u64 {
+		match version {
+			Version::Draft14
+			| Version::Draft15
+			| Version::Draft16
+			| Version::Draft17
+			| Version::Draft18
+			| Version::Draft19 => match self {
+				Self::InternalError => 0x0,
+				Self::TrackEnded => 0x2,
+			},
+		}
+	}
+}
+
 /// Used to be called SubscribeDone
 #[derive(Clone, Debug)]
 pub struct PublishDone<'a> {
@@ -579,21 +605,36 @@ mod tests {
 	}
 
 	#[test]
-	fn test_publish_done_v17_round_trip() {
-		let msg = PublishDone {
-			request_id: None,
-			status_code: 200,
-			stream_count: 5,
-			reason_phrase: "OK".into(),
-		};
+	fn test_publish_done_registered_statuses_all_versions() {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+			Version::Draft19,
+		] {
+			for (status, expected) in [
+				(PublishDoneStatus::InternalError, 0x0),
+				(PublishDoneStatus::TrackEnded, 0x2),
+			] {
+				assert_eq!(status.code(version), expected);
 
-		let encoded = encode_message(&msg, Version::Draft17);
-		let decoded: PublishDone = decode_message(&encoded, Version::Draft17).unwrap();
+				let msg = PublishDone {
+					request_id: matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16)
+						.then_some(RequestId(7)),
+					status_code: status.code(version),
+					stream_count: 5,
+					reason_phrase: "done".into(),
+				};
+				let encoded = encode_message(&msg, version);
+				let decoded: PublishDone = decode_message(&encoded, version).unwrap();
 
-		assert_eq!(decoded.request_id, None);
-		assert_eq!(decoded.status_code, 200);
-		assert_eq!(decoded.stream_count, 5);
-		assert_eq!(decoded.reason_phrase, "OK");
+				assert_eq!(decoded.status_code, expected);
+				assert_eq!(decoded.stream_count, 5);
+				assert_eq!(decoded.reason_phrase, "done");
+			}
+		}
 	}
 
 	#[test]
@@ -733,20 +774,18 @@ mod tests {
 	}
 
 	#[test]
-	fn test_publish_done_v18_round_trip() {
+	fn test_publish_done_preserves_unknown_status() {
+		const UNKNOWN: u64 = 0xface;
 		let msg = PublishDone {
 			request_id: None,
-			status_code: 200,
+			status_code: UNKNOWN,
 			stream_count: 5,
-			reason_phrase: "OK".into(),
+			reason_phrase: "extension".into(),
 		};
 
-		let encoded = encode_message(&msg, Version::Draft18);
-		let decoded: PublishDone = decode_message(&encoded, Version::Draft18).unwrap();
+		let encoded = encode_message(&msg, Version::Draft19);
+		let decoded: PublishDone = decode_message(&encoded, Version::Draft19).unwrap();
 
-		assert_eq!(decoded.request_id, None);
-		assert_eq!(decoded.status_code, 200);
-		assert_eq!(decoded.stream_count, 5);
-		assert_eq!(decoded.reason_phrase, "OK");
+		assert_eq!(decoded.status_code, UNKNOWN);
 	}
 }

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -602,9 +602,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		};
 
 		// Send PublishDone
-		let (status_code, reason) = match &res {
-			Ok(()) => (200, "OK"),
-			Err(_) => (500, "error"),
+		let (status, reason) = match &res {
+			Ok(()) => (ietf::PublishDoneStatus::TrackEnded, "track ended"),
+			Err(_) => (ietf::PublishDoneStatus::InternalError, "internal error"),
 		};
 		let _ = stream.writer.encode(&ietf::PublishDone::ID).await;
 		let _ = stream
@@ -614,7 +614,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					Version::Draft14 | Version::Draft15 | Version::Draft16 => Some(request_id),
 					_ => None,
 				},
-				status_code,
+				status_code: status.code(self.version),
 				stream_count: 0,
 				reason_phrase: reason.into(),
 			})


### PR DESCRIPTION
Closes #3207.

## Root cause

The Rust IETF publisher treated PUBLISH_DONE like an HTTP response and emitted unregistered `200`/`500` status codes. The TypeScript publisher had kept a draft-14-through-16 guard after PUBLISH_DONE moved onto the request stream, so it emitted no terminal message for drafts 17 through 19. A rejected TypeScript track also reset the request instead of reporting a PUBLISH_DONE failure.

## Change

- Define typed internal Rust statuses for the two outcomes this implementation emits.
- Send registered `TRACK_ENDED` (`0x2`) and `INTERNAL_ERROR` (`0x0`) codes.
- Send PUBLISH_DONE from TypeScript for every supported draft, including failure completion.
- Preserve legacy request IDs only for drafts 14 through 16.
- Keep received status codes as raw integers so unknown extensions survive decoding.
- Leave inbound unsupported PUBLISH handling unchanged.

This follows [draft-19 sections 10.11 and 15.11.3](https://www.ietf.org/archive/id/draft-ietf-moq-transport-19.txt). No repository draft changes are needed because this corrects our implementation of the external IETF draft without changing a moq-dev wire format.

## Checks

- `nix develop --command just fix origin/main`
- `nix develop --command just check origin/main`
- `nix develop --command just test default origin/main` (all JavaScript suites and 2,933 Rust tests passed)
- `nix develop --command just test smoke-full` (all 21 Rust/Python/JS to Rust/Python/JS/native/C/GStreamer paths passed)
- Focused Rust PUBLISH_DONE tests across drafts 14 through 19
- Focused TypeScript codec and publisher tests: 104 passed

(Written by GPT-5.6)