### PR TITLE
build(deps): bump chacha20 to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,9 +1171,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
Closes #3219.

## Root cause

The committed lockfile selected chacha20 0.10.1 through rand 0.10.2. That chacha20 release was yanked, so the nightly cargo-deny audit rejected the otherwise normal relay and CLI dependency graph.

## Fix

Refresh only the compatible chacha20 lock entry to non-yanked 0.10.2. No manifests, first-party package versions, or unrelated transitive dependencies change.

## Tests

- cargo tree --locked -i chacha20@0.10.2
- nix develop --command just rs audit
- nix develop --command just test (3,299 passed, 1 skipped)
- Rust and WASM clippy, formatting, dependency pruning, and manifest sorting through just fix

(written by gpt-5.6-sol)