### PR TITLE
fix(js): don't let Effect.spawn start or retain work on a closed effect

### DIFF
--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -226,6 +226,25 @@ describe("Effect", () => {
 		}
 	});
 
+	test("spawn does not start work after close", async () => {
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const effect = new Effect();
+		let started = false;
+
+		try {
+			effect.close();
+			effect.spawn(async () => {
+				started = true;
+			});
+			await settle();
+
+			expect(started).toBe(false);
+		} finally {
+			effect.close();
+			warn.mockRestore();
+		}
+	});
+
 	test("cleanup from a spawn that outlived its run fires immediately", async () => {
 		// A rerun drains the dispose list before it awaits in-flight spawns, so a task resuming
 		// after that point used to register teardown against the NEXT run: the resource it owned

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -549,10 +549,6 @@ export class Effect {
 	 */
 	// TODO: Add effect for another layer of nesting
 	spawn(fn: () => Promise<void>) {
-		const promise = fn().catch((error) => {
-			console.error("spawn error", error);
-		});
-
 		if (this.#dispose === undefined) {
 			if (DEV) {
 				console.warn("Effect.spawn called when closed");
@@ -560,6 +556,14 @@ export class Effect {
 
 			return;
 		}
+
+		const promise = fn().catch((error) => {
+			console.error("spawn error", error);
+		});
+
+		// `fn` can close the effect before it first awaits. `close()` empties `#async` and only the
+		// rerun path drains it, so pushing now would pin the task on an effect that can never rerun.
+		if (this.#dispose === undefined) return;
 
 		this.#async.push(promise);
 	}
@@ -578,7 +582,7 @@ export class Effect {
 			timeout = undefined;
 			fn();
 		}, ms);
-		this.cleanup(() => timeout && clearTimeout(timeout));
+		this.cleanup(() => timeout !== undefined && clearTimeout(timeout));
 	}
 
 	/**
@@ -603,7 +607,7 @@ export class Effect {
 		}, ms);
 
 		this.#dispose.push(() => {
-			if (timeout) {
+			if (timeout !== undefined) {
 				clearTimeout(timeout);
 				effect.close();
 			}
@@ -624,7 +628,7 @@ export class Effect {
 			animate = undefined;
 		});
 		this.cleanup(() => {
-			if (animate) cancelAnimationFrame(animate);
+			if (animate !== undefined) cancelAnimationFrame(animate);
 		});
 	}
 

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -167,7 +167,7 @@ export class Renderer {
 
 		// Clean up any pending animation request.
 		effect.cleanup(() => {
-			if (animate) cancelAnimationFrame(animate);
+			if (animate !== undefined) cancelAnimationFrame(animate);
 		});
 	}
 


### PR DESCRIPTION
Split out of [#3197](https://github.com/moq-dev/moq/pull/3197), which keeps the shared audio ring buffer work. These two are independent, and the ring-buffer change still has an open race to resolve.

## Summary

- `Effect.spawn` invoked its callback before checking whether the effect was already closed, so a task could start with nothing owning its lifecycle. It now checks first, matching `set`/`timer`/`timeout`/`animate`/`interval`.
- An async function runs synchronously until its first `await`, so `fn` can also close the effect before returning. `close()` empties `#async` and only the rerun path drains it, so the push that follows would pin the task on an effect that can never rerun. The pre-existing check caught this by running *after* `fn()`; moving it before is what lost the coverage, so keep a second check there.
- Guard the scheduler handles with `!== undefined` rather than truthiness.

## On the zero handle

This one is a latent trap, not a live bug, and the description shouldn't oversell it: no conformant browser returns handle 0. The HTML spec requires `setTimeout` ids to be greater than zero, and the animation frame identifier is incremented before use, so the first `requestAnimationFrame` handle is 1. Node and Bun return objects.

It is still the wrong test for a `T | undefined`, and `index.ts` already used `!== undefined` for the dev-warning timer, so this is consistency rather than a fix. No test: pinning a scenario no browser produces would mean monkeypatching globals to fake it.

## Test plan

- `nix develop --command just check`
- `nix develop --command just test`

The `spawn` retention fix has no regression test. It isn't observable through the public API (`#async` is private, and the rerun path that drains it is gated on the effect being open), so there is nothing to assert on. The guard restores the pre-existing invariant that a closed effect's `#async` stays empty.

Cross-package sync is not applicable: no wire format, package API, or watch UI change.

(written by Claude Opus 5)