### PR TITLE
feat: add quest planning system

### DIFF
--- a/.claude/skills/plan-quest/SKILL.md
+++ b/.claude/skills/plan-quest/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: plan-quest
+description: Scope, create, and publish a quest through an interactive grilling interview. Use when the user invokes /plan-quest, asks to plan a quest, or wants unsettled work split into quests.
+---
+
+Before you begin, read `quest/AGENTS.md` completely.
+
+Interview the user relentlessly until you reach a shared understanding.
+Begin the interview by scoping the goal: the observable outcome, why it matters, and its important boundaries and non-goals. Do not move on to implementation decisions until the goal is settled. If the goal contains independently completable outcomes, split them before planning.
+
+Then map the implementation plan as a design tree: every material decision branches into the decisions that hang off it.
+
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled: the questions you can ask *now* without guessing at answers you haven't heard yet. Ask the whole frontier in one round, interactively if supported: number each question, letter each answer, and prefix one answer with (recommended). Then wait for the user's answers before the next round.
+
+Each round the user answers reshapes the tree: settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a *later* round, not this one.
+
+Finding *facts* is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, etc.), dispatch a sub-agent to find it; don't ask the user for anything you could look up yourself. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for the sub-agent to report; ask the rest of the frontier now. The *decisions* are the user's: put each to them and wait.
+
+Search other quests and questlines to keep the larger plan consistent. When the frontier disagrees with a settled quest, challenge the user and ask whether to expand scope to resolve the conflict.
+
+The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed.
+The result may be one quest or multiple quests and questlines. Split outcomes that can be completed independently.
+Prefix each quest title with `[XS]`, `[S]`, `[M]`, `[L]`, or `[XL]`, including implementation, verification, and landing work.
+Once complete, create, update, or delete the relevant quests and questlines.
+Commit and make a PR, then offer to start working on the quest now if it is ready.

--- a/.claude/skills/plan-quest/agents/openai.yaml
+++ b/.claude/skills/plan-quest/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Plan Quest"
+  short_description: "Scope and publish a repository quest"
+  default_prompt: "Use $plan-quest to scope and publish a repository quest."

--- a/.claude/skills/start-quest/SKILL.md
+++ b/.claude/skills/start-quest/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: start-quest
+description: Find unblocked repository quests and start the user's choice. Use when the user invokes /start-quest, optionally with a base questline such as /start-quest vod, or asks what quest to work on next.
+---
+
+Before you begin, read `quest/AGENTS.md` completely.
+
+Resolve an optional argument to a base questline directory under `quest/`, defaulting to `quest/` itself.
+
+Find every ready quest: one with no `Required` section. Questline `README.md`s are never executed, so exclude them:
+
+```bash
+rg --files-without-match '^## Required$' <base> --glob '*.md' --glob '!README.md' --glob '!AGENTS.md'
+```
+
+No output (rg exits 1) means the questline has no ready work; say so.
+
+Drop candidates that are already claimed: a local or remote branch named after
+the quest path that is recent or has an open PR. A stale branch (old, no open
+PR) does not claim the quest; mention it so it can be reused or deleted. Also
+detect local and remote quest branches whose names are ancestors or descendants
+of the candidate branch. A recently moved quest may still be claimed by a
+branch at its former path; check the file's git history when a similar branch
+exists. Before creating the worktree, delete a conflicting ref
+only when it is confirmed stale, is not checked out, and has no unmerged
+commits; otherwise treat the candidate as claimed.
+
+Order the remaining candidates by a depth-first walk of the questline tree from
+the base `README.md` (`Quests` lists are priority-ordered, so the walk is too)
+and offer up to the first five. Append any ready quest the walk never reached
+and flag it as unlisted - that is a tree defect worth fixing.
+Include any relevant higher-level context, such as the goal, parent questline, and/or what completing it unblocks.
+Include each candidate's title size.
+
+After the user chooses, read the quest and the relevant repository guides.
+Decide the base branch, create a worktree on the quest's branch, and push an empty placeholder commit whose message contains a freshly generated UUID to claim it (skip the push without write access).
+Never force this push. A rejected push loses the claim race; stop and choose another quest.
+Start implementation when its scope is decision-complete; otherwise use `$plan-quest` to settle it first.

--- a/.claude/skills/start-quest/agents/openai.yaml
+++ b/.claude/skills/start-quest/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Start Quest"
+  short_description: "Find and start an unblocked repository quest"
+  default_prompt: "Use $start-quest to find unblocked repository quests and start my choice."

--- a/.remarkignore
+++ b/.remarkignore
@@ -12,3 +12,6 @@ pkg/
 # doc/.vitepress/drafts.ts.
 drafts/draft-*.md
 doc/draft/
+
+# Quests use a constrained Markdown dialect checked by the quest validator.
+quest/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,17 @@ Language-specific conventions, crate/package maps, and patterns live in nested `
 - **`rs/CLAUDE.md`** - Rust workspace: crate map, Producer/Consumer model, `poll_*` plumbing, error handling, config/TOML merge, Version matching, testing.
 - **`js/CLAUDE.md`** - TypeScript/JS workspace: package map, the signals + Effect reactivity model and its lifecycle rules, Web Components UI, `bun`/Biome tooling.
 - **`py/CLAUDE.md`** - Python wrappers: the `moq-ffi` (generated bindings) vs `moq-rs` (ergonomic) split and the `moq` public surface.
+- **`quest/AGENTS.md`** - long-term project memory: quests.
 
 The `swift/`, `kt/`, and `go/` directories are thin wrappers over `rs/moq-ffi`; see each directory's `README.md` rather than a dedicated guide.
 
 This root file holds only cross-cutting rules that apply everywhere (writing style, root-cause and maintainability rules, cross-package sync, public-API scrutiny, comment/doc conventions). When editing any of these guides, reference code by file path and symbol name, never by line number; line numbers rot with every edit. The mechanics of landing a change (branch targeting, commit messages, PR descriptions, reviews, releases) live in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+History belongs in commits and PRs; pending work belongs in a quest. Read
+[`quest/AGENTS.md`](quest/AGENTS.md) whenever work mentions a quest or
+questline, and use the `$plan-quest` or `$start-quest` skills when available.
+GitHub issues remain the public front door, while quests carry durable plans
+and dependency edges alongside the code.
 
 ## Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7216,6 +7216,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "qlog"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7274,6 +7285,16 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "pulldown-cmark",
+ "tempfile",
 ]
 
 [[package]]
@@ -9900,6 +9921,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "rs/moq-transcode",
     "rs/moq-video",
     "rs/moq-wasm",
+    "rs/quest",
 ]
 default-members = [
     "rs/kio",
@@ -58,6 +59,7 @@ default-members = [
     "rs/moq-transcode",
     "rs/moq-video",
     # "rs/moq-wasm",  # wasm32-unknown-unknown target only
+    "rs/quest",
 ]
 resolver = "2"
 
@@ -144,6 +146,7 @@ objc2-foundation = "0.3.2"
 objc2-screen-capture-kit = "0.3.2"
 percent-encoding = "2"
 pollster = "1.0"
+pulldown-cmark = { version = "0.13", default-features = false }
 qmux = { version = "0.5.1", default-features = false }
 rand = "0.10.1"
 # default-features off so each consumer picks its own TLS backend and body

--- a/justfile
+++ b/justfile
@@ -109,7 +109,7 @@ _tools $FILES="":
 
     # `_check-common` runs on every invocation, so its tools are unconditional.
     tools=(actionlint bun jq nix nixfmt shellcheck shfmt taplo)
-    scoped '^(rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo)
+    scoped '^(quest/|rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo)
     scoped '^(py/|pyproject\.toml$|uv\.lock$|rs/moq-ffi/)'     && tools+=(uv)
     scoped '^(kt/|rs/moq-ffi/)'                                && tools+=(gradle java)
     # cargo because `go check` builds moq-ffi for the host, and skips on a
@@ -163,12 +163,17 @@ check $BASE="":
     # An empty list means "force-run" to the per-lang recipes, which is the
     # wrong semantic here, so don't dispatch at all.
     if [[ -n "$files" ]]; then
-    	just js check "$files"
-    	just rs check-changed "$files"
-    	just py check "$files"
-    	just kt check "$files"
-    	just swift check "$files"
-    	just go check "$files"
+        just js check "$files"
+        just rs check-changed "$files"
+        # Quest documents form one graph, so validate the whole living tree when
+        # either a quest or its validator changes.
+        if echo "$files" | grep -qE '^(quest/|rs/quest/)'; then
+            cargo run --quiet --locked --package quest -- check
+        fi
+        just py check "$files"
+        just kt check "$files"
+        just swift check "$files"
+        just go check "$files"
     	# Type-checking the plugin needs only headers, so it runs here rather
     	# than waiting for obs.yml to link it on Linux. libmoq is in scope
     	# because the plugin calls through its generated C header, and flake.nix
@@ -200,6 +205,7 @@ check-all *args:
     just _tools ALL
     just js check
     just rs check --workspace {{ args }}
+    cargo run --quiet --locked --package quest -- check
     # Not covered by the line above: moq-wasm only exists on the wasm32 target.
     just rs wasm
     just py check

--- a/quest/AGENTS.md
+++ b/quest/AGENTS.md
@@ -1,0 +1,131 @@
+# Quests
+
+Read this file whenever work mentions a quest or questline.
+
+Quests are optional, versioned plans for work that needs durable scope, memory,
+or coordination. Think GitHub issues checked into the repository. GitHub issues
+remain the public front door, but prefer making a quest.
+
+## Model
+
+- A quest is a task that should be completed independently in a single PR. It
+  is a Markdown file such as `archive.md`.
+- A questline is an ordered collection of quests and/or other questlines. It is
+  a directory whose entrypoint is `README.md`. Questlines are never executed
+  directly; a questline is complete when all of its quests are complete.
+- Everything lives under `quest/`. [README.md](README.md) is the permanent root
+  questline.
+- The root's entries are milestones: questlines in directories named `m0`,
+  `m1`, ... that group work by priority horizon. Lower numbers matter more, and
+  a completed milestone's number is not reshuffled onto the survivors. A
+  milestone may open with a gate quest (the release rule under Creation) that
+  its later work requires.
+- Every `Quests` list is ordered by priority, most important first; ready
+  quests are taken in list order. Insert a new quest or questline at its rank
+  rather than appending - including the root, where new work joins the
+  milestone matching its priority.
+- Quests and questlines reference each other with root-absolute links.
+- Finished quests and questlines are deleted and remain accessible through git
+  history.
+- Merge conflicts are expected. Resolve them by aligning quests.
+
+## Format
+
+A quest:
+
+```markdown
+# [S] Short title
+
+## Goal
+
+The observable outcome and important boundaries.
+
+## Plan
+
+Current decisions, open questions, or implementation guidance.
+
+## Required
+
+- [Blocker](/quest/foo/bar.md) - work that must finish before this can start
+
+## Closes
+
+- [#701](https://github.com/moq-dev/moq.pro/issues/701) - close this issue when the quest finishes
+
+## Related
+
+- [Other](/quest/other/quest.md) - similar work that is not a blocker
+```
+
+`Goal` is required. Prefix the title with `[XS]`, `[S]`, `[M]`, `[L]`, or
+`[XL]`, estimating implementation, verification, and landing work. Every other
+section is optional. Use these exact headings: readiness checks grep for
+`## Required` literally.
+
+A questline uses `Quests` instead of `Required`, listing at least one entry in
+priority order, each with a one-line summary:
+
+```markdown
+## Quests
+
+- [Child quest](/quest/foo/bar.md) - the outcome, so the list reads without opening it
+- [Nested questline](/quest/foo/baz/README.md) - what the whole line delivers
+```
+
+- A quest's `Required` section lists its blockers. Its absence means the quest
+  is ready to start.
+- A quest may require a questline; that blocker clears only when the whole
+  questline is complete.
+- A `Required` bullet may be plain text naming a condition outside the
+  repository; remove it when the condition clears.
+- `Required` relationships must be acyclic. Before adding one, follow links
+  from the target and ensure they cannot reach the current file.
+- `quest check` (the `rs/quest` binary) enforces this section mechanically -
+  links resolve, the index matches the file tree, headings stay inside the set
+  above, and `Required` stays acyclic. `just check` runs it on any branch
+  touching `quest/`.
+
+## Creation
+
+- Quests are created in PRs and reviewed.
+- Size every quest in its title. Re-estimate it when scope changes materially.
+- Search the living tree and git history before creating a quest.
+- Split independently completable work into separate quests. Group them in a
+  questline only when they ship together; a one-off sits directly in its parent.
+- Represent a release or pin bump that unblocks repository work as its own
+  quest, holding the external condition as a plain-text `Required` bullet, and
+  make every dependent quest require it. When the condition clears, remove the
+  bullet, do the work, and complete the quest; one completion unblocks every
+  dependent.
+
+## Execution
+
+- Only quests are executed, and only when ready: no `Required` section means no
+  blockers.
+- The branch name is the quest path without the trailing `.md`, e.g.
+  `quest/foo/bar.md` becomes branch `quest/foo/bar`.
+- If a local or remote branch for the quest already exists, someone may be
+  working on it; continue only if it is stale (old, no open PR).
+- Push the branch immediately with an empty placeholder commit: the remote
+  branch is the claim that prevents duplicate work. Skip the push when you
+  lack write access to the repository.
+- Quests may be updated over time as the plan changes.
+- A quest is completed when the plan is executed and no further work is needed.
+  Follow-up work becomes a new quest.
+- Run `just check` before completing the change.
+- When the quest is complete, open a PR per
+  [CONTRIBUTING.md](../CONTRIBUTING.md), with a GitHub closing keyword for every
+  issue listed under `Closes` by the quest AND by any questline the same PR
+  completes - a parent's issues are usually where a line's tracking lives, and
+  its last child is the only PR that can close them.
+
+## Deletion
+
+- A quest that is no longer needed or cannot be completed is abandoned: delete
+  it and explain why in the PR.
+- The quest is deleted in the same PR that completes or abandons it.
+- When deleting a quest or questline, grep its absolute path and remove every
+  reference; this reveals every quest the finished work unblocks. If the
+  removed link was the last entry in a section, remove the heading too.
+- Deleting a questline's last quest deletes the questline directory in the
+  same change. The root questline is never deleted.

--- a/quest/CLAUDE.md
+++ b/quest/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/quest/README.md
+++ b/quest/README.md
@@ -1,0 +1,18 @@
+# MoQ questline
+
+## Goal
+
+Keep the repository's living work organized as visible, versioned quests. The
+initial milestone mirrors every open GitHub issue without changing issue state.
+
+## Plan
+
+The migration keeps one atomic quest per public issue and preserves the public
+issue body as its starting plan. The initial order is GitHub's newest-first
+backlog order because the issue tracker has no explicit priority metadata.
+Re-rank and split quests as the backlog is groomed.
+
+## Quests
+
+- [m0: open issue backlog](/quest/m0/README.md) - every GitHub issue that was
+  open when the quest system was introduced

--- a/quest/m0/1059-init-tracks-for-cmaf.md
+++ b/quest/m0/1059-init-tracks-for-cmaf.md
@@ -1,0 +1,20 @@
+# [XS] Init tracks for CMAF
+
+## Goal
+
+Implement and verify the behavior tracked in [#1059](https://github.com/moq-dev/moq/issues/1059)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+I was trying to be smart and put everything in the catalog, but there's a lot of issues with this approach. We should go back to a track per init segment.
+
+## Closes
+
+- [#1059](https://github.com/moq-dev/moq/issues/1059) - close this issue when the quest finishes

--- a/quest/m0/1073-make-origin-lifecycle-caller-driven.md
+++ b/quest/m0/1073-make-origin-lifecycle-caller-driven.md
@@ -1,0 +1,78 @@
+# [M] Make Origin lifecycle caller-driven
+
+## Goal
+
+Implement and verify the behavior tracked in [#1073](https://github.com/moq-dev/moq/issues/1073)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+Make Origin lifecycle caller-driven. Target `dev` because this intentionally breaks the published Rust API.
+
+Closed PR #2472 is prototype evidence, not an accepted implementation. This work is a prerequisite for the runtime-neutral goals in #2875.
+
+#### Public API
+
+- Make `origin::Producer::new(info) -> (Producer, origin::Driver)` the only public factory.
+- Remove `Origin::produce()` and `origin::Info::produce()`.
+- Expose `origin::Driver` as a `#[must_use]` future with `Output = ()` and a `poll(&Waiter)` API matching the session driver.
+- Add `moq_native::origin::spawn(info) -> Producer`, which constructs the pair and spawns the driver with Tokio. Calling it outside a Tokio runtime may panic.
+- Defer an explicit `origin::Producer::abort(err)` API.
+- Keep `web_async::time` timers. Runtime-independent time remains part of #2875.
+
+#### Lifecycle behavior
+
+- Replace origin-internal `web_async::spawn` calls with one driver-owned task set for source watchers, fronts, and track-serving tasks.
+- Perform eligible initial attachment, exact-path visibility, and announcement updates synchronously in `create_broadcast`.
+- Pass the already-attached state into the queued watcher so the first driver poll does not attach twice.
+- Require driver polling for route changes, track serving, linger timers, failover, and teardown.
+- The driver must hold no producer clone and finish after producers and submitted lifecycle work drain.
+- Dropping the driver cancels its work, immediately tears down the origin with `Error::Dropped`, rejects pending requests, unannounces active broadcasts, and ends announcement cursors.
+- Producer mutations after driver drop return `Error::Closed`.
+
+Immediate visibility deliberately preserves the current publication-readiness race. #2895 tracks an atomic readiness gate separately and does not block this issue.
+
+#### Migration
+
+- Migrate native applications, relay components, and libmoq to `moq_native::origin::spawn`.
+- Have `moq-wasm` spawn the returned driver with `web_async::spawn`.
+- Make direct `moq-net` users, tests, and examples retain and explicitly poll or spawn the driver.
+- Preserve all wire behavior, JavaScript APIs, and public FFI signatures.
+- Do not update drafts or bump package versions.
+- Update Rust API documentation and examples to show construction and the driver lifetime contract.
+
+#### Acceptance
+
+- Exact lookup and eligible announcement state update synchronously without polling the driver.
+- Route changes, track serving, and nested lifecycle work make no progress until the driver is polled.
+- Immediate and parked initial attachment do not duplicate sources or announcements.
+- Driver drop aborts active fronts with `Dropped`, rejects pending dynamic requests, emits unannounces, closes cursors, and makes later producer mutation fail with `Closed`.
+- The driver naturally finishes without retaining the origin.
+- `moq_native::origin::spawn` covers progression, teardown, and its outside-runtime panic.
+- `nix develop --command just fix`, `just check`, and `just test` pass.
+- Run `just test smoke-full` if the libmoq adaptation changes the exercised C/FFI path.
+
+#### Out of scope
+
+- The crate rename in #2875.
+- Directional producer/consumer naming.
+- Lookup ergonomics.
+- Timer abstraction.
+- Explicit custom-error abort.
+- The atomic readiness gate in #2895.
+
+## Closes
+
+- [#1073](https://github.com/moq-dev/moq/issues/1073) - close this issue when the quest finishes
+
+## Related
+
+- [#2895: Add an atomic readiness gate for Origin broadcasts](/quest/m0/2895-add-an-atomic-readiness-gate-for-origin-broadcasts.md) - related open work

--- a/quest/m0/1095-avoid-allocation-in-axum-tungstenite-websocket-message.md
+++ b/quest/m0/1095-avoid-allocation-in-axum-tungstenite-websocket-message.md
@@ -1,0 +1,40 @@
+# [S] Avoid allocation in axum/tungstenite WebSocket message conversion
+
+## Goal
+
+Implement and verify the behavior tracked in [#1095](https://github.com/moq-dev/moq/issues/1095)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+In `rs/moq-relay/src/websocket.rs`, converting between axum and tungstenite WebSocket messages requires going through `Vec<u8>` / `String`, which copies the underlying `Bytes` buffer:
+
+```rust
+tungstenite::Message::Binary(bin) => axum::extract::ws::Message::Binary(Vec::from(bin).into()),
+```
+
+This is because axum bundles its own version of tungstenite internally, so the `Bytes`/`Utf8Bytes` types are incompatible even though they're structurally identical. The conversion currently allocates and copies for every message.
+
+#### Cause
+
+axum 0.8 uses tungstenite 0.24 internally, while qmux 0.0.4 exports tungstenite 0.28. The `Utf8Bytes` and `Bytes` types across these versions are not directly convertible.
+
+#### Possible fixes
+
+- Upgrade axum to a version that uses tungstenite 0.28 (when available)
+- Use `unsafe` transmute between identical `Bytes` layouts (not recommended)
+- Bypass axum's WebSocket layer entirely and handle the upgrade manually with matching tungstenite version
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+## Closes
+
+- [#1095](https://github.com/moq-dev/moq/issues/1095) - close this issue when the quest finishes

--- a/quest/m0/1238-default-to-enabled-true.md
+++ b/quest/m0/1238-default-to-enabled-true.md
@@ -1,0 +1,63 @@
+# [M] Default to enabled: true
+
+## Goal
+
+Implement and verify the behavior tracked in [#1238](https://github.com/moq-dev/moq/issues/1238)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Standalone classes across `@moq/net`, `@moq/watch`, and `@moq/publish` accept an optional reactive `enabled` input, but most default it to `false`. Omitting the property therefore constructs a module that silently does nothing.
+
+The public contract should make the direct constructor useful by default while preserving explicit and reactive lifecycle control.
+
+#### Decision
+
+Keep the positive `enabled` input. Do not rename it to `disabled`.
+
+For standalone JavaScript components:
+
+- an omitted or `undefined` `enabled` input defaults to `true`;
+- explicit `false` keeps the component inactive;
+- changing a live input from `true` to `false` releases active resources;
+- changing it back to `true` restarts normally; and
+- this is the general convention for future standalone components unless an API explicitly documents an exception.
+
+Apply the change atomically to the current default-disabled public classes on `dev`:
+
+- `@moq/net`: `Connection.Reload`
+- `@moq/watch`: `Broadcast`, `Video.Decoder`, `Audio.Decoder`, `Text.Renderer`
+- `@moq/publish`: `Broadcast`, `Video.Encoder`, `Audio.Capture`, `Audio.Encoder`, `Source.Camera`, `Source.Microphone`, `Source.Screen`, `Source.File`
+
+Direct construction of camera, microphone, or screen capture authorizes the component to request capture immediately. Screen capture still has the browser's user-gesture requirement, which the public documentation must state.
+
+The `<moq-watch>` and `<moq-publish>` custom elements keep their existing behavior because they already supply explicit lifecycle-controlled signals. Connection pooling and publish preview already default enabled and remain unchanged.
+
+#### Acceptance criteria
+
+- \[ ] Each listed class treats omitted and explicit `undefined` `enabled` as `true`.
+- \[ ] Explicit `enabled: false` prevents connection, subscription, encoding, rendering, and permission requests.
+- \[ ] A live `enabled` input still tears down resources on `true -> false` and restarts on `false -> true`.
+- \[ ] High-level custom-element lifecycle behavior is unchanged.
+- \[ ] Redundant static `enabled: true` examples are removed; reactive and explicit-false examples remain where they communicate lifecycle policy.
+- \[ ] Public docs describe the default and call out the screen-capture user-gesture constraint.
+- \[ ] The change lands as one breaking PR targeting `dev`.
+
+#### Non-goals
+
+- Renaming `enabled` to `disabled` or adding a compatibility alias.
+- Redesigning capture error reporting, retry policy, or dismissal handling.
+- Changing custom-element activation behavior.
+- Changing connection-pool or publish-preview behavior.
+
+## Closes
+
+- [#1238](https://github.com/moq-dev/moq/issues/1238) - close this issue when the quest finishes

--- a/quest/m0/1310-why-use-the-worklet-plugin.md
+++ b/quest/m0/1310-why-use-the-worklet-plugin.md
@@ -1,0 +1,26 @@
+# [XS] why use the worklet plugin?
+
+## Goal
+
+Implement and verify the behavior tracked in [#1310](https://github.com/moq-dev/moq/issues/1310)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+i saw that you have a modified version of `vite-plugin-worklet` in the repo, but from my testing it does the same thing as importing the worklet code with [`?worker`](https://vite.dev/guide/assets#importing-script-as-a-worker).
+
+it's also [mentioned at one place](https://github.com/moq-dev/moq/blob/c28a7c10c2111f604fa6f763870732af28979bed/js/hang/src/vite-env.d.ts#L3) but then not used anywhere.
+
+is there a specific reason for inlining the code in base64 over importing it via Worker imports?
+
+i can open a pr replacing the worklet plugin, etc. with worker imports if you'd like
+
+## Closes
+
+- [#1310](https://github.com/moq-dev/moq/issues/1310) - close this issue when the quest finishes

--- a/quest/m0/1384-moq-signals-improvements.md
+++ b/quest/m0/1384-moq-signals-improvements.md
@@ -1,0 +1,24 @@
+# [XS] @moq/signals improvements
+
+## Goal
+
+Implement and verify the behavior tracked in [#1384](https://github.com/moq-dev/moq/issues/1384)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Warn on .set if we provide the same reference as before for non-primatives. Means we'll have to wrap references with a Signals.ref helper or something.
+
+Export functions instead of classes to improve tree shaking? Maybe as a `/lite` path.
+
+Use the TC39 or whatever Signal proposal.
+
+## Closes
+
+- [#1384](https://github.com/moq-dev/moq/issues/1384) - close this issue when the quest finishes

--- a/quest/m0/1837-moq-video-remaining-work-codecs-platforms-decode-hw.md
+++ b/quest/m0/1837-moq-video-remaining-work-codecs-platforms-decode-hw.md
@@ -1,0 +1,114 @@
+# [XL] moq-video: remaining work (codecs, platforms, decode, HW validation)
+
+## Goal
+
+Implement and verify the behavior tracked in [#1837](https://github.com/moq-dev/moq/issues/1837)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Tracking issue for the gaps in `moq-video` after the ffmpeg removal + native-codec rework on `dev`. Audit done against `rs/moq-video` on the `dev` branch.
+
+Current state:
+
+- **Encode**: H.264 via openh264 (software, all platforms), VideoToolbox (macOS), Media Foundation (Windows), NVENC + VAAPI (Linux, feature-gated; NVENC HW-validated on an RTX 3070 Ti, VAAPI still unverified). H.265 via VideoToolbox (macOS), Media Foundation (Windows), and NVENC (Linux, feature-gated, HW-validated).
+- **Decode**: H.264 via VideoToolbox (macOS), Media Foundation/DXVA (Windows), openh264 (software). H.265 via Media Foundation/DXVA (Windows) and VideoToolbox (macOS, #1859); no software fallback. H.264/H.265/AV1 via NVDEC (Linux, #2145 / #2178), with zero-copy NVDEC to NVENC transcode and GPU resize fanout (#2158, `moq transcode`). In `[Unreleased]`.
+- **Capture**: camera on all three platforms (AVFoundation / V4L2 / Media Foundation); screen capture on macOS (ScreenCaptureKit) and Windows (DXGI Desktop Duplication).
+
+#### Building on top of moq-video (renderer, mobile, universal zero-copy, public frame API)
+
+Motivation, from an audit of downstream consumers: n0's `iroh-live` (Rust, `wgpu` renderer, iroh P2P) and Software Mansion's `moq-kit` (native Swift/Kotlin mobile SDK on `moq-ffi`) both reimplement the raw-frame media layer `moq-video` already owns. They have to, because `moq-video` today exposes zero-copy *ingest* (capture -> encode on macOS/Windows) but no zero-copy *egress*: a decoded `Frame` can only leave as CPU I420 (`into_i420()`) or be fed back into our own encoder (the transcode path). There is no way to get the GPU handle out, and no renderer. So `decode -> render` forces a CPU download + re-upload (a double copy), which is the exact inverse of the ingest path.
+
+Closing the items below lets a consumer build a renderer or an alternate encoder/filter *on top of* `moq-video` instead of forking the whole native layer. It also gives us end-to-end zero-copy in one crate (we currently have only the front half; `iroh-live` has only the back half).
+
+##### Frame surface API (get the GPU handle out)
+
+- \[ ] **Expose a public, platform-tagged surface handle** on `decode::Frame` (and the shared internal `Frame`). Today `Frame.inner` is `pub(crate)`. Add a `#[non_exhaustive]` enum of *borrowed* handles: `CVPixelBuffer` (macOS/iOS), `ID3D11Texture2D` (Windows), CUDA device pointer (Linux/NVDEC), dmabuf FD (Linux/VAAPI), CPU I420. Codec- and backend-agnostic; asking for a handle the frame doesn't hold is a typed error, never UB. This is an insulated building block (Public API Scrutiny): a renderer or a third-party encoder snaps on without `moq-video` owning either.
+- \[ ] **Symmetric typed conversions**, mirroring `into_i420()`: `into_cuda()`, `to_cvpixelbuffer()` / `into_metal()`, `into_d3d11()`, `into_dmabuf()`. Each is a cheap borrow/wrap when the frame already lives on that device, and an explicit upload/download otherwise, so the copy cost is visible at the call site rather than hidden. Prefer consuming `self` where a copy would otherwise be implied.
+- \[ ] **Make decoded frames stay on the GPU first.** macOS/Windows decode currently lands as CPU I420 (the `resize` code even notes "capture-only surfaces never appear in decoded frames"), so there is nothing to expose yet: VideoToolbox / Media Foundation decode must produce a GPU `Frame` before the accessor above means anything. NVDEC already does (`Frame::Cuda`).
+- \[ ] **The handle API is still worth it even with an in-tree renderer.** The renderer lives in `moq-video` (see Rendering), but the public surface handle is what lets a consumer build its *own* encoder/filter/renderer on top without forking the native layer, so it is not redundant with the built-in renderer.
+
+##### Rendering
+
+`moq-video` stops at a decoded `Frame`; there is no present path, so every consumer downloads to I420 and re-uploads to its own texture. The renderer lives **in `moq-video`** as a `render` role module, symmetric with `capture` / `encode` / `decode` (the crate already owns the platform native layer on both ends, so rendering belongs here too, not in a sibling crate). External consumers that want their own present path still can, via the Frame surface API above.
+
+- \[ ] **`render` module**, mirroring `capture`: a `render::Config` + `render::Sink` (or similar) that takes decoded `Frame`s and presents them, picking the platform-native path.
+- \[ ] **Zero-copy present paths** built on the surface API above: `CVPixelBuffer` -> `CVMetalTextureCache` -> Metal (macOS/iOS); CUDA / dmabuf -> GL/Vulkan (Linux); D3D11 shared texture -> swapchain (Windows); `SurfaceTexture` -> GL/Vulkan (Android).
+- \[ ] **Portable `wgpu` fallback** that samples NV12/I420 -> RGB on the GPU (color-matrix aware, BT.601/709); one shader covers all four backends (cf. `iroh-live`'s `nv12_to_rgba.wgsl`), the same way `openh264` is the cross-platform encode fallback.
+- \[ ] **Color management** at sample time, not a CPU convert.
+
+##### Mobile capture + encode
+
+- \[ ] **iOS** - AVFoundation camera + ReplayKit screen. VideoToolbox encode/decode is already the macOS backend, so this is capture wiring + the permission / on-demand lifecycle flow, not a new codec backend. (Promoted from the footnote under Other platform coverage.)
+- \[ ] **Android** - Camera2/CameraX + MediaProjection screen + MediaCodec encode/decode (Surface in/out, natively zero-copy). A whole new backend family (NDK/JNI rather than objc2). Weigh this against the fact that `moq-kit` already does it in Kotlin and raw frames cannot cross the `moq-ffi` boundary zero-copy, so a Rust Android media path only pays off for Rust-native consumers.
+
+##### Universal zero-copy capture input
+
+Ingest is zero-copy on macOS (`CVPixelBuffer` -> VideoToolbox) and Windows (D3D11 NV12 -> Media Foundation), but not Linux.
+
+- \[ ] **Linux V4L2 / PipeWire** currently convert to I420 on the CPU (YUYV / BGRA). Add V4L2 `VIDIOC_EXPBUF` dmabuf export and PipeWire dmabuf negotiation, feeding a `Frame::DmaBuf` straight into VAAPI/NVENC. Pairs with the "VAAPI zero-copy dmabuf input path" item under Hardware validation.
+
+##### Decode
+
+- \[x] **H.264 hardware decode on Windows** (Media Foundation) - done in code (DXVA: NVDEC / Intel / AMD; GPU-less host falls back to openh264). In `[Unreleased]`; HW-validation pending.
+- \[x] **H.264 hardware decode on Linux** (NVDEC) - done in #2145 (dlopen'd cuvid; GPU-less host falls back to openh264); HW-validated on an RTX 3070 Ti (round-trip + resize tests). VAAPI / V4L2 decode not implemented, NVDEC only.
+- \[x] **H.265 hardware decode on macOS** (VideoToolbox) - done in #1859 (verified end-to-end on Apple M4).
+- \[x] **H.265 hardware decode on Windows** (Media Foundation) - done in code (DXVA). In `[Unreleased]`; HW-unverified (test box had no HEVC decoder MFT installed).
+- \[x] **H.265 hardware decode on Linux** (NVDEC) - done in #2145; HW-validated on an RTX 3070 Ti (NVENC encode to NVDEC decode round-trip). VAAPI decode still absent.
+- \[ ] **H.265 software decode** - only if a backend with acceptable real-time performance and no licensing concerns exists; otherwise skip (do NOT add software HEVC decode just to fill the matrix)
+
+##### Encode
+
+- \[x] **Linux NVENC H.265** - done in #1840 (codec GUID selected from `Codec`; HW-validated on an RTX 3070 Ti)
+- \[ ] **Linux VAAPI H.265** - VAAPI backend advertises H.264 only today. Update: `moq-vaapi` 0.0.2 vendors HEVC buffer types (`src/buffer/hevc.rs`) but its `Encoder` is hardcoded H.264 (`VAProfileH264Main` / `VAEntrypointEncSlice`), so exposing an HEVC encoder is a `moq-dev/vaapi` change, not just a moq-video flag.
+- \[ ] ~~Software H.265 encode~~ - explicitly out of scope (no software HEVC encode)
+
+##### Robustness
+
+- \[x] **NVENC driver-probe (avoid abort on GPU-less box)** - done in #1844. `Auto` aborted under `panic = "abort"` when libcuda was missing because cudarc/the SDK `panic!` on a failed dlopen instead of erroring; `Nvenc::open` now probes libcuda / libnvidia-encode first and falls back cleanly.
+- \[ ] **VAAPI: make `moq-vaapi` dlopen libva (not a driver-probe)** - the original premise was wrong. `moq-vaapi` 0.0.2 **links** libva (binary carries `NEEDED libva.so.2` / `libva-drm.so.2`, verified via `readelf`), it does **not** `dlopen` it, and its `Encoder::new` returns a `Result` rather than panicking. So unlike NVENC there is no panic-on-miss to guard: a libva-less box fails at process load (before any Rust probe could run), and the no-GPU case (libva present, no usable VA driver) already falls back cleanly via `Encoder::new` → `Err` → `backend::open` → openh264. A probe in `open()` can't help. **Mitigated in #1860 (merged):** corrected the docs that wrongly claimed dlopen, and made `nvenc`/`vaapi` default-on opt-out features so a self-compiler can drop the libva/CUDA deps (`cargo build -p moq-cli --no-default-features --features "iroh quinn websocket capture"`). **Still open:** the real fix is restoring the documented `vaapi_dlopen` design (no `cargo:rustc-link-lib`, no `DT_NEEDED`) in the separate `moq-dev/vaapi` crate, then adding the NVENC-style probe  -  only then does an always-on VAAPI binary load on a libva-less host.
+
+##### Hardware validation (written but never run on real HW)
+
+- \[x] **NVENC encode on a Linux + NVIDIA box** - done on an RTX 3070 Ti (driver 595.71.05): pitch alignment, periodic forced-IDR at the GOP boundary, and H.265 VPS/SPS/PPS inline ahead of each IDR all pass. Gotcha fixed en route: NVENC rejects stream-ordered pool memory (`cuMemAllocAsync`), so buffers registered with NVENC come from plain `cuMemAlloc`.
+- \[ ] **VAAPI encode on a Linux + Intel/AMD box** - low-power vs full entrypoint, NV12 upload round-trip, `cargo deny` license resolution
+- \[ ] **VAAPI zero-copy dmabuf input path** - currently uses an NV12 surface-upload; add the `Frame::DmaBuf` + V4L2 `VIDIOC_EXPBUF` path for NV12-capable sources
+- \[ ] **Windows Media Foundation capture on real HW** - on-demand open/close (LED off when unwatched), NV12 delivery for MJPEG/YUY2 cameras
+- \[ ] **Live camera run per platform** - capture needs device permission a headless/agent process can't get
+
+##### Capture
+
+- \[ ] **Screen/display capture on Linux** (PipeWire/portal, or X11/DRM)
+- \[x] **Screen/display capture on Windows** (Desktop Duplication) - done in code (DXGI Desktop Duplication, whole-monitor). In `[Unreleased]`; compile-verified, HW-validation pending.
+- \[ ] **Mobile capture** - see **Mobile capture + encode** above (iOS AVFoundation/ReplayKit; Android Camera2/MediaProjection).
+- \[ ] **Zero-copy capture input on Linux** - see **Universal zero-copy capture input** above (V4L2 `VIDIOC_EXPBUF` / PipeWire dmabuf).
+
+##### Codecs (new)
+
+- \[x] **AV1 hardware decode** (NVDEC) - done in #2178 (8-bit 4:2:0 only, hardware-only, catalog-shape gated).
+- \[ ] **AV1 encode** - returns when a hardware backend lands (NVENC/VAAPI AV1 on Linux). No software AV1 encode (rav1e too slow for real-time). Software AV1 decode only if perf + licensing are acceptable. `Codec` enum is `#[non_exhaustive]` so this is additive.
+- \[ ] VP8 / VP9 - the `hang` catalog models them but `moq-video` has no path either way; track here, low priority
+
+##### Other platform coverage (noted in DESIGN, lower priority)
+
+- \[ ] Intel QSV-specific encode path (Intel currently goes through VAAPI)
+- \[ ] Raspberry Pi `v4l2m2m` stateful encoder
+- \[ ] iOS / Android media path - promoted to **Mobile capture + encode** above (iOS reuses the VideoToolbox backend; Android is a new MediaCodec/NDK family)
+
+##### Docs
+
+- \[x] **Fix the stale `rs/moq-video/README.md`** - done in #1840 (removed the ffmpeg / system-FFmpeg / "decode not implemented" claims; added a capability matrix).
+
+---
+
+Constraints captured from the request: do **not** add software H.265/AV1 *encode* at all; only add software H.265/AV1 *decode* if a backend has good enough real-time performance and no licensing concerns.
+
+## Closes
+
+- [#1837](https://github.com/moq-dev/moq/issues/1837) - close this issue when the quest finishes

--- a/quest/m0/1838-tr-101-290-monitoring-requirements-broadcast-contribution.md
+++ b/quest/m0/1838-tr-101-290-monitoring-requirements-broadcast-contribution.md
@@ -1,0 +1,95 @@
+# [M] TR 101 290 monitoring: requirements (broadcast/contribution health metrics)
+
+## Goal
+
+Implement and verify the behavior tracked in [#1838](https://github.com/moq-dev/moq/issues/1838)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Goal
+
+For MoQ to replace satellite/contribution links and hand off to IRDs, it needs the
+stream-health telemetry operators expect from SRT / Zixi / RIST. ETSI TR 101 290 is the
+industry yardstick for MPEG-TS integrity. This issue specifies *what* to monitor and
+*where* to surface it, so we can agree scope before building a skeleton. Part of #1799.
+No implementation here, requirements only.
+
+#### Where monitoring runs (design question)
+
+The relay core is media-agnostic by design, so TS-level monitoring belongs at the **TS
+edges**, not in the relay:
+
+- **Ingest** (e.g. `moq-srt`, `moq-cli publish ts`): validate the incoming contribution
+  feed and expose its health.
+- **Egress** (e.g. `moq-srt` m=request, `moq-cli subscribe --format ts`): validate the
+  TS we hand downstream.
+  Important nuance from the two-lane model (#1799):
+- **Media-aware lane** (today): PAT/PMT/PCR/CC are *regenerated* by our muxer, so at
+  egress TR 101 290 mostly validates *our own output* (still valuable, catches muxer
+  regressions like the DTS issue #1836). SI tables beyond PAT/PMT don't exist in this
+  lane, so those checks are N/A.
+- **Opaque whole-mux lane** (future, Option B): the original PCR cadence, CC, and SI
+  survive, so TR 101 290 validates the *real* contribution feed faithfully. This is where
+  full P1/P2/P3 conformance is meaningful.
+  Proposed: implement the checks once over a TS byte/packet stream, run them at both edges,
+  and surface results through the existing stats plumbing (cf. #1783 connection stats,
+  \#1671 per-track stats; `moq-net`/`moq-relay` stats modules).
+
+#### Checks to implement (configurable thresholds; ETSI defaults)
+
+##### Priority 1 (loss of these = not decodable)
+
+- TS\_sync\_loss (loss of sync after N consecutive bad sync bytes; default 5)
+- Sync\_byte\_error (sync byte != 0x47)
+- PAT\_error / PAT\_error\_2 (PAT absent, repetition > 0.5 s, PID 0 wrong table\_id, scrambled)
+- Continuity\_count\_error (CC discontinuity / wrong increment / illegal duplicate)
+- PMT\_error / PMT\_error\_2 (PMT repetition > 0.5 s, scrambled)
+- PID\_error (a referenced PID not seen within a user-defined window)
+
+##### Priority 2 (recommended continuous monitoring)
+
+- Transport\_error (TEI bit set)
+- CRC\_error (PAT/PMT/CAT/NIT/EIT/BAT/SDT CRC)
+- PCR\_repetition\_error (PCR interval > 40 ms)
+- PCR\_discontinuity\_indicator\_error (> 100 ms jump w/o discontinuity\_indicator)
+- PCR\_accuracy\_error (PCR drift outside +/- 500 ns)
+- PTS\_error (PTS repetition interval > 700 ms)
+- CAT\_error (CAT required when scrambling present)
+
+##### Priority 3 (application dependent; mostly opaque-lane only)
+
+- NIT/SDT/EIT/TDT/RST\_error, SI\_repetition\_error, unreferenced\_PID
+
+#### Surfacing
+
+- Per-check counters + last-event timestamp, per PID where applicable.
+- Aggregate per-stream "health" suitable for an operator dashboard (green/amber/red per
+  priority, akin to an SRT/Zixi stats panel).
+- Exposed through the existing stats API so relay/CLI consumers can read it; no new
+  bespoke transport.
+
+#### Out of scope (for now)
+
+- Remediation (FEC, 2022-7) - separate egress work.
+- Full DVB SI semantic validation beyond presence/repetition/CRC.
+- A GUI; this is the metrics source, not a dashboard.
+
+#### Open questions for discussion
+
+1. Does monitoring live in a dedicated `moq-ts`/`moq-monitor` crate, or inside the
+   ingest/egress crates that already touch TS?
+2. Which subset is MVP, P1 + the PCR/CC/PTS parts of P2?
+3. Configuration surface (thresholds, which PIDs, sampling) - CLI flags vs config file.
+   A private reference implementation of these checks exists and can inform thresholds and
+   edge cases; happy to share it as background (not as a code drop).
+
+## Closes
+
+- [#1838](https://github.com/moq-dev/moq/issues/1838) - close this issue when the quest finishes

--- a/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md
+++ b/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md
@@ -1,0 +1,46 @@
+# [M] Test open-GOP H.264 tune-in end to end (leading-picture handling)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2067](https://github.com/moq-dev/moq/issues/2067)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Context
+
+[#2066](https://github.com/moq-dev/moq/pull/2066) fixes [#2050](https://github.com/moq-dev/moq/issues/2050): the H.264 splitter now recognizes recovery-point SEI random access, so open-GOP broadcast H.264 (non-IDR I-slice keyframes) resolves a video rendition and round-trips. That fix is about **catalog/rendition resolution and group boundaries**  -  it makes the group start at the recovery point.
+
+What it does **not** do is validate or smooth out playback behavior at a cold tune-in into an open GOP. This issue tracks that testing (and any follow-up work it surfaces).
+
+#### What needs testing
+
+Two distinct playback situations:
+
+1. **Continuous playback across a recovery point.** All reference frames are already decoded, so this should be clean. Confirm.
+2. **Cold tune-in at a recovery point** (fresh subscriber, first group received). This splits further:
+   - **Clean recovery point** (I-frame, `recovery_frame_cnt = 0`, no leading pictures  -  common for broadcast contribution). Expected to decode cleanly through WebCodecs.
+   - **True open GOP with leading pictures** (B-frames after the I in decode order that reference the *previous* GOP). The I-frame decodes, but those leading B-frames have missing references at tune-in. WebCodecs marks them `"delta"` and behavior is decoder-dependent (Chrome software path typically drops/garbles for a fraction of a GOP; a stricter hardware decoder could error). Neither the Rust splitter nor the JS consumer (`js/hang/src/container/consumer.ts`) identifies/drops leading pictures, so any glitch is exposed to the renderer.
+
+#### Concrete tasks
+
+- \[ ] Determine whether the reference open-GOP capture (`~/CNNiEMEA2.ts` from #2050) actually uses leading pictures  -  inspect POC / `frame_num` ordering around the recovery points  -  so we know which case is real in practice.
+- \[ ] Add an open-GOP source to the `test/ts` harness as a regression fixture (real capture or a synthetic clip with recovery-point SEI and no IDR). #2050 notes `test/ts` now has a `--via-srt` mode to build on.
+- \[ ] End-to-end browser playback of an open-GOP broadcast via `<moq-watch>` (Chrome + WebCodecs): verify continuous playback is clean, and characterize cold tune-in (clean recovery point vs leading-picture case)  -  glitch duration, dropped vs corrupt frames, any decoder error.
+- \[ ] If the leading-picture case causes a real problem, decide whether to drop leading pictures at tune-in (skip B-frames whose references precede the group start until the recovery point is reached), and where that logic should live (Rust ingest vs JS consumer).
+
+#### References
+
+- Splitter fix: `rs/moq-mux/src/codec/h264/split.rs` (recovery-point SEI keyframe detection).
+- JS keyframe/group invariant: `js/hang/src/container/consumer.ts` (forces group index 0 to `keyframe`), `js/watch/src/video/decoder.ts` (`type: frame.keyframe ? "key" : "delta"`).
+- Related: #2050, #2066, #1979.
+
+## Closes
+
+- [#2067](https://github.com/moq-dev/moq/issues/2067) - close this issue when the quest finishes

--- a/quest/m0/2075-mirror-catalog-reservation-gating-in-moq-hang-js-hang.md
+++ b/quest/m0/2075-mirror-catalog-reservation-gating-in-moq-hang-js-hang.md
@@ -1,0 +1,55 @@
+# [M] Mirror catalog reservation gating in @moq/hang (js/hang)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2075](https://github.com/moq-dev/moq/issues/2075)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Background
+
+[#2072](https://github.com/moq-dev/moq/pull/2072) added **publisher-side catalog reservation gating** to `moq-mux` (Rust), fixing the convergence race in #1979 where a one-shot muxer (fMP4, MPEG-TS) sees an incomplete, e.g. audio-only, catalog snapshot before a later rendition's config resolves.
+
+The mechanism, publisher-side only (wire and catalog schema unchanged):
+
+- `catalog::Producer::reserve()` returns a clonable `Reserved`.
+- An importer reserves its rendition via `Reserved::init` (`.video()` / `.audio()`), getting a `Rendition` guard that **holds its own `Reserved` clone until its config is `set()`** (or it's dropped).
+- The catalog is **withheld from the broadcast until every `Reserved` is gone**, so an unresolved rendition keeps the gate shut. When the last resolves, exactly one complete snapshot publishes. A `pending` flag avoids emitting an empty snapshot for an untouched catalog.
+- Container importers own a reservation across track discovery and drop it once their initial set is declared, which also lets several importers compose into one broadcast under a single shared gate.
+
+#### Why mirror it in JS
+
+`@moq/hang`'s catalog `Producer` ([`js/hang/src/catalog/producer.ts`](https://github.com/moq-dev/moq/blob/dev/js/hang/src/catalog/producer.ts)) publishes incrementally as tracks are added, with no gate. A browser publisher that adds video and audio in separate ticks emits a partial catalog first, so any consumer that can't reinitialize (or just wants a stable first snapshot) hits the same race the Rust side just fixed. Parity keeps the two producers behaviourally aligned even though the wire doesn't force it.
+
+#### Proposed direction
+
+Add an equivalent reservation to the JS catalog `Producer` so the first published snapshot is complete:
+
+- A `reserve()` returning a `Reserved` handle, and a per-rendition guard that holds the reservation until its config is set (or it's dropped).
+- Withhold the initial publish until all reservations resolve; publish incrementally afterwards.
+- Producers that don't reserve keep publishing incrementally (opt-in, non-breaking for existing callers that never call `reserve()`).
+
+#### Design decisions to settle (why this is an issue, not a mechanical port)
+
+- **TS shape.** Rust uses `Reserved` + `Rendition<K>` + a sealed `Kind`. TS has no importer-per-codec layer in the same shape, so decide the ergonomic surface: a `reserve()` + returned rendition handle, an options flag, or an explicit `producer.complete()` call. The `signals`/`Effect` lifecycle model may suggest a different idiom.
+- **Where the gate lives.** `@moq/hang`'s publish side (`js/hang/publish`) is structured differently from Rust's container/codec importers; identify the analogous "declare all tracks, then publish" point.
+- **Composition.** Whether JS needs the shared-gate-across-importers property at all, or only the single-producer complete-first-snapshot behaviour.
+
+#### Scope / logistics
+
+- Wire and catalog JSON schema **unchanged**  -  pure publisher-side timing.
+- API addition to `@moq/hang`; if it changes existing shapes, target **`dev`** per branch-targeting rules.
+- Cross-package sync: `demo/web` if it drives the catalog producer directly.
+
+*Follow-up to #2072 (Rust). Fixes the JS half of #1979-style convergence.*
+
+## Closes
+
+- [#2075](https://github.com/moq-dev/moq/issues/2075) - close this issue when the quest finishes

--- a/quest/m0/2143-moq-ffi-0-2-27-moqmediaconsumer-returns-moqframe.md
+++ b/quest/m0/2143-moq-ffi-0-2-27-moqmediaconsumer-returns-moqframe.md
@@ -1,0 +1,127 @@
+# [M] moq-ffi 0.2.27+: MoqMediaConsumer returns MoqFrame.timestampUs=0 for all frames after…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2143](https://github.com/moq-dev/moq/issues/2143)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+````markdown
+# `moq-ffi 0.2.27+`: `MoqMediaConsumer` returns `MoqFrame.timestampUs=0` for all frames after timeline-track migration (PR #2109)
+
+## Environment
+
+- **moq-ffi version:** `0.2.28` (regression first observed in `0.2.27`)
+- **Last working version:** `0.2.26`
+- **moq-relay version:** `0.13.3`
+- **Client:** Kotlin Android app via UniFFI bindings
+- **Protocol negotiated:** `moq-lite-04` (relay also supports `moq-lite-05`, but our stack currently negotiates `-04` with `0.2.26`)
+
+## What works vs. what is broken
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Web viewer (`@moq/net` 0.1.7) | Works | Reads timeline tracks (`0.hev1.timeline.z`) and rehydrates timestamps |
+| moq-relay `0.13.3` | Works | Forwards both media and timeline tracks correctly |
+| Android publisher (`moq-ffi 0.2.26`) | Works | Publishes media frames with inline timestamps |
+| Android viewer (`moq-ffi 0.2.28`) | **Broken** | `MoqMediaConsumer` returns `timestampUs=0` for every frame |
+| Android viewer (`moq-ffi 0.2.26`) | Works | Timestamps are present and playback is normal |
+
+## Why moq-lite-04 and not moq-lite-05
+
+`moq-ffi 0.2.26` negotiates `moq-lite-04` with our relay (`moq-relay 0.13.3`). Upgrading to `moq-ffi 0.2.28` shifts the protocol preference to `moq-lite-05`, but the protocol version itself is not the cause of the bug. The regression is caused by the **container format change** introduced in PR #2109, which moved frame timestamps from the media frame into a separate timeline track.
+
+Both protocol versions are capable of carrying timeline tracks, but the Android `MoqMediaConsumer` does not consume them in either case.
+
+## What changed in 0.2.28
+
+Release `moq-ffi v0.2.28` includes PR #2109  -  "Per-track timeline index for each media track". Frame timestamps moved from inline media frames into separate timeline tracks (e.g. `0.hev1.timeline.z`, `0.opus.timeline.z`).
+
+The catalog now advertises:
+
+```json
+{
+  "codec": "opus",
+  "sampleRate": 48000,
+  "numberOfChannels": 1,
+  "container": { "kind": "legacy" },
+  "timeline": { "track": "0.opus.timeline.z", "timescale": 1000 }
+}
+````
+
+#### Expected behavior
+
+`MoqMediaConsumer.next()` should return `MoqFrame` objects with meaningful `timestampUs` values, so the client can buffer and schedule playback correctly.
+
+#### Actual behavior
+
+Every frame consumed through `MoqMediaConsumer` has `timestampUs == 0`.
+
+#### Impact
+
+The Android video pipeline never leaves the `BUFFERING` state. The jitter buffer requires:
+
+```kotlin
+newest - oldest >= targetBuffering
+```
+
+With all frames at `pts=0`, the depth is always `0`, so no frames are ever forwarded to the MediaCodec decoder. The user sees a black screen while audio continues to play.
+
+#### Evidence
+
+Diagnostic logging from the Android consumer:
+
+```text
+video frame#1  pts=0us key=true  bytes=28425 bufState=BUFFERING bufDepth=0.0ms
+video frame#2  pts=0us key=false bytes=5791  bufState=BUFFERING bufDepth=0.0ms
+video frame#90  pts=0us key=false bytes=3926  bufState=BUFFERING bufDepth=0.0ms
+video frame#180 pts=0us key=false bytes=2788  bufState=BUFFERING bufDepth=0.0ms
+```
+
+#### Root cause
+
+The `MoqMediaConsumer` UniFFI path does not subscribe to the per-track timeline track, nor does it rehydrate frame timestamps from it. The `MoqFrame` schema is unchanged, but the `timestampUs` field is now empty because the timestamps were moved out of the media frame.
+
+#### Why this cannot be fixed in client Kotlin
+
+The `MoqMediaConsumer` API is unchanged between `0.2.26` and `0.2.28`:
+
+```kotlin
+subscribeMedia(name: String, container: Container, maxLatencyMs: ULong): MoqMediaConsumer
+MoqMediaConsumer.next(): MoqFrame
+MoqFrame { payload: ByteArray, timestampUs: Long, keyframe: Boolean }
+```
+
+The timeline track is not exposed to the caller, so the client cannot read timestamps itself. The fix belongs in the Rust `moq-ffi` layer.
+
+Also note: `software-mansion-labs/moq-kit` is still pinned to `moq-ffi 0.2.25`, so no higher-level Android/iOS SDK has yet been ported to the timeline API.
+
+#### Current workaround
+
+Pin `moq-ffi` to `0.2.26`. This restores inline timestamps and normal video playback.
+
+#### What needs to be done upstream
+
+Please implement one of the following:
+
+1. **Restore inline timestamps for the legacy consumer path**  -  make `MoqMediaConsumer` internally join the timeline track and populate `MoqFrame.timestampUs` before returning frames to callers.
+2. **Expose the timeline track through the FFI**  -  provide a way for callers to subscribe to `*.timeline.z` and correlate timeline entries with media frames.
+3. **Document the breaking change**  -  if `timestampUs` is intentionally no longer available via `MoqMediaConsumer`, update the FFI API and migration guide so client maintainers know how to adapt.
+
+#### Labels
+
+`moq-ffi`, `timeline`, `breaking change`, `media consumer`
+
+```
+
+## Closes
+
+- [#2143](https://github.com/moq-dev/moq/issues/2143) - close this issue when the quest finishes
+```

--- a/quest/m0/2147-moq-video-10-bit-hevc-and-av1-support-in-the-nvidia-codec.md
+++ b/quest/m0/2147-moq-video-10-bit-hevc-and-av1-support-in-the-nvidia-codec.md
@@ -1,0 +1,34 @@
+# [M] moq-video: 10-bit HEVC and AV1 support in the NVIDIA codec path
+
+## Goal
+
+Implement and verify the behavior tracked in [#2147](https://github.com/moq-dev/moq/issues/2147)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2145 (NVDEC hardware decode + zero-copy NVDEC -> NVENC transcode). The GPU pipeline currently supports 8-bit 4:2:0 H.264/H.265 only. Two extensions worth doing, probably as separate PRs:
+
+#### 10-bit HEVC (Main10)
+
+- The NVDEC backend rejects `bit_depth_luma_minus8 != 0` today (clean error in the sequence callback). Supporting it means decoding to P016 output surfaces and threading a pixel-format dimension through `frame::cuda::Frame` (pitch is in bytes, but plane layout and the CPU download path assume 8-bit NV12).
+- NVENC needs the matching Main10 profile + `NV_ENC_BUFFER_FORMAT_YUV420_10BIT` input, and the catalog codec string must advertise the right profile/level.
+- The CPU fallback story needs deciding: openh264 is 8-bit only, so a 10-bit source either has no software fallback (like H.265 already) or gets tonemapped down to 8-bit.
+
+#### AV1
+
+- Decode: NVDEC supports AV1 on Ampere+ (`cudaVideoCodec_AV1` is already in the vendored bindings). Needs a `Codec::Av1` in the decode backend seam, the catalog/container plumbing for AV1 tracks, and AV1 has no Annex-B: the parser takes OBUs directly, so the access-unit prep differs from H.264/H.265.
+- Encode: NVENC AV1 exists only on Ada+ (the RTX 3070 Ti dev box can decode AV1 but not encode it), so the first useful shape is AV1 *source* -> H.264/H.265 rungs in `moq-transcode`, not AV1 output.
+- The `hang` catalog and `moq-mux` need an AV1 codec entry (`av01.*` codec string, OBU framing) if they don't have one by then; that part rows through the js side per the cross-package sync table.
+
+Both are additive to the decode/encode `Codec` enums (`#[non_exhaustive]` already), so no breaking changes expected.
+
+## Closes
+
+- [#2147](https://github.com/moq-dev/moq/issues/2147) - close this issue when the quest finishes

--- a/quest/m0/2152-libmoq-c-abi-catch-up-with-the-moq-ffi-surface.md
+++ b/quest/m0/2152-libmoq-c-abi-catch-up-with-the-moq-ffi-surface.md
@@ -1,0 +1,32 @@
+# [S] libmoq: C ABI catch-up with the moq-ffi surface
+
+## Goal
+
+Implement and verify the behavior tracked in [#2152](https://github.com/moq-dev/moq/issues/2152)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+The libmoq C ABI (`rs/libmoq/src/api.rs`) has fallen well behind moq-ffi. All of these are additive (new symbols), so none block the dev->main merge, but the backlog is getting long:
+
+- **Subscription options**: `moq_consume_track` takes no options; no priority/ordered/stale/group-range equivalent of `MoqSubscription`, and no mid-stream update.
+- **Track info on publish**: `moq_publish_track` cannot set `timescale`/`priority`/`ordered`/`cache` (no `MoqTrackInfo` equivalent).
+- **Fetch**: no `fetch_group`, and no dynamic group serving (moq-ffi gains these in #2142; mirror the shape).
+- **Dynamic track/broadcast serving**: no `requested_track`/`requested_broadcast` path at all.
+- **abort with error code**: only clean close/finish exists; no abort(code) for tracks/groups.
+- **Server / two-phase accept**: no server-side API (moq-ffi has `MoqServer`/`MoqRequest` with the SETUP path); C embedders cannot accept sessions.
+- **Client TLS knobs**: roots/system-roots/fingerprints/disable-verify are env-only; moq-ffi exposes them as options.
+- **Datagrams**: tracked with the moq-ffi datagram issue; mirror whatever lands there.
+- **Raw-frame timestamps**: raw consume reports `timestamp_us = 0`; tracked with the raw-frame timestamps issue.
+
+Suggest splitting off pieces as they're picked up rather than one mega-PR. Each addition also touches `cpp/obs` consumers only if used, plus `doc/lib/c` per the Cross-Package Sync table.
+
+## Closes
+
+- [#2152](https://github.com/moq-dev/moq/issues/2152) - close this issue when the quest finishes

--- a/quest/m0/2153-go-moq-wrapper-catch-up-stats-hops-tls-options-media-on.md
+++ b/quest/m0/2153-go-moq-wrapper-catch-up-stats-hops-tls-options-media-on.md
@@ -1,0 +1,30 @@
+# [S] go/moq: wrapper catch-up (stats, hops, TLS options, media-on-track)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2153](https://github.com/moq-dev/moq/issues/2153)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+The hand-written Go wrapper (`go/wrapper/moq`) lags the generated moq-ffi surface more than the other wrappers. Missing today:
+
+- `Session.Stats()` (connection stats snapshot; py/swift/kt have it)
+- `Announcement.Hops()`
+- Client TLS options: roots, system roots, certificate fingerprints (only `WithTLSDisableVerify`/`WithBind` exist in `go/wrapper/moq/client.go`)
+- `PublishMediaOnTrack` and `MoqVideoHint` support
+- Datagrams / subscription update / track info once those land in moq-ffi (see their issues)
+
+Also, from the #2142 review: `FetchGroup` should take a `ctx` like `RecvGroup`/`RequestedGroup` (via `runCancellable`) so a fetch that misses the cache can be cancelled; that may need a cancel handle on the ffi fetch object.
+
+All additive. Update `doc/lib/go` alongside per the Cross-Package Sync table.
+
+## Closes
+
+- [#2153](https://github.com/moq-dev/moq/issues/2153) - close this issue when the quest finishes

--- a/quest/m0/2155-js-net-full-subscription-model-ordered-stale-range-and.md
+++ b/quest/m0/2155-js-net-full-subscription-model-ordered-stale-range-and.md
@@ -1,0 +1,27 @@
+# [L] js/net: full Subscription model (ordered/stale/range) and Subscriber.update()
+
+## Goal
+
+Implement and verify the behavior tracked in [#2155](https://github.com/moq-dev/moq/issues/2155)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+js/net only models `priority` on subscriptions, while Rust has the full `Subscription { priority, ordered, stale, group_start, group_end }` model with `Subscriber::update()`. The lite wire messages already round-trip all the fields (`js/net/src/lite/subscribe.ts`), so this is model/API work, not wire work:
+
+- `Broadcast.Producer.subscribe(name, priority)` / `Broadcast.Consumer.subscribe(name, priority)` take a positional `priority` (`js/net/src/broadcast.ts`); should take a Subscription-shaped options object like `Track.Consumer.subscribe(options?)` already does.
+- `Track.Subscriber.updatePriority(priority)` should become `update(subscription)` mirroring Rust; the name bakes in a single knob (`js/net/src/track.ts`).
+- `ordered`/`stale`/`group_start`/`group_end` need to be plumbed from the options object into the SUBSCRIBE message and applied on the publisher side.
+- Default alignment: the JS `Subscribe` message defaults `ordered ?? false` while `SubscribeUpdate` defaults `ordered ?? true` and Rust's `Subscription::default()` is `ordered: true` (`js/net/src/lite/subscribe.ts:21,103`). Pick one default (Rust's `true`) everywhere.
+
+**Timing note**: the *shape* items (options object instead of positional priority, `update()` instead of `updatePriority()`, the ordered default) are cheapest before the dev->main merge since renames after release are breaking; the full ordered/stale/range plumbing can follow additively.
+
+## Closes
+
+- [#2155](https://github.com/moq-dev/moq/issues/2155) - close this issue when the quest finishes

--- a/quest/m0/2216-js-net-expose-typed-announcement-status-instead-of-active.md
+++ b/quest/m0/2216-js-net-expose-typed-announcement-status-instead-of-active.md
@@ -1,0 +1,28 @@
+# [M] js/net: expose typed announcement status instead of active boolean (AI review)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2216](https://github.com/moq-dev/moq/issues/2216)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Rust models announcement updates as `Active`, `Restart`, and `Ended`, and the wire format carries all three states. The public JS API reduces this to `{ path, active: boolean }`, so `Restart` becomes indistinguishable from a normal active announcement.
+
+That loses protocol information and makes it hard to add restart-specific behavior later without another API change.
+
+#### Suggested direction
+
+Expose a discriminated status such as `"active" | "restart" | "ended"` in `Announced.Event`. This is a breaking shape change, so the dev merge is the inexpensive time to make it. Keep any boolean helper as derived convenience rather than the canonical event shape.
+
+## Closes
+
+- [#2216](https://github.com/moq-dev/moq/issues/2216) - close this issue when the quest finishes

--- a/quest/m0/2217-moq-ffi-preserve-active-restart-ended-announcement.md
+++ b/quest/m0/2217-moq-ffi-preserve-active-restart-ended-announcement.md
@@ -1,0 +1,33 @@
+# [S] moq-ffi: preserve Active/Restart/Ended announcement lifecycle (AI review)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2217](https://github.com/moq-dev/moq/issues/2217)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+`MoqAnnounced.next()` currently skips `Ended` events and converts both `Active` and `Restart` into `MoqAnnouncement`. All generated language wrappers therefore lose announcement lifecycle information.
+
+Its documentation suggests waiting for `broadcast.closed()` to learn that a broadcast was unannounced, but Rust intentionally keeps the announcement guard independent from the broadcast producer. A publisher can unannounce a still-live broadcast, so broadcast closure is not an equivalent signal.
+
+The FFI publisher API also retains the announcement guard internally until the broadcast closes, which prevents explicit unannounce while the broadcast remains usable. libmoq already exposes an origin publication handle and explicit unpublish behavior.
+
+#### Suggested direction
+
+- Return a typed UniFFI announcement event that preserves `Active`, `Restart`, and `Ended`.
+- Expose an owned announcement/publication handle, or an explicit unannounce operation, whose lifetime is independent from the broadcast.
+- Update Python, Swift, Kotlin, and Go wrappers and examples together.
+- Add tests for unannounce-without-close and restart delivery.
+
+## Closes
+
+- [#2217](https://github.com/moq-dev/moq/issues/2217) - close this issue when the quest finishes

--- a/quest/m0/2248-moq-mux-rebase-fmp4-export-timestamps-for-late-subscribers.md
+++ b/quest/m0/2248-moq-mux-rebase-fmp4-export-timestamps-for-late-subscribers.md
@@ -1,0 +1,34 @@
+# [S] moq-mux: rebase fMP4 export timestamps for late subscribers
+
+## Goal
+
+Implement and verify the behavior tracked in [#2248](https://github.com/moq-dev/moq/issues/2248)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+`moq_mux::container::fmp4::Export` preserves the source frame timestamp as each fragment TFDT. `encode_fragment` sets `base_media_decode_time` directly from `frames[0].timestamp`, with no export-local epoch.
+
+A subscriber that starts two hours into a long-running broadcast therefore emits its first fragment at roughly 02:00:00 even though its new HLS/VOD playlist begins at media sequence 0. Players can present a two-hour initial offset or stall while seeking the missing timeline.
+
+This is reproducible in moq.pro by creating a recording bucket after the broadcast is already live. It is not a playlist numbering issue; the absolute timestamp is already embedded in the first CMAF fragment.
+
+#### Suggested direction
+
+Give each exported track an explicit timestamp origin and subtract it when authoring TFDT/CTS. Define how that origin behaves across pause/resume discontinuities: either preserve one recording-local clock or start a new decode-time epoch at each discontinuity, but never inherit the publishers wall-clock-age offset.
+
+Add a regression test whose source frames start near 7200 seconds and assert the first exported fragment starts near zero while A/V relative timing remains intact.
+
+Found during the VOD/HLS lifecycle review in moq.pro#664.
+
+## Closes
+
+- [#2248](https://github.com/moq-dev/moq/issues/2248) - close this issue when the quest finishes

--- a/quest/m0/2272-moq-cli-remaining-work-for-capture-and-playback-window.md
+++ b/quest/m0/2272-moq-cli-remaining-work-for-capture-and-playback-window.md
@@ -1,0 +1,86 @@
+# [XL] moq-cli: remaining work for capture and playback (window/app capture, device enumeration, native…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2272](https://github.com/moq-dev/moq/issues/2272)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Tracking issue for the gaps in `moq import capture` and the (nonexistent) native playback path, in the same spirit as #1837 (which tracks the `moq-video` backend work this sits on top of). Audit done against `rs/moq-cli`, `rs/moq-video`, and `rs/moq-audio` on the `dev` branch.
+
+Goal: `moq` should be able to capture **a window / an app / a screen / a microphone or device**, and play a broadcast back **like `ffplay`**, without an external ffmpeg.
+
+Current state:
+
+- **Capture** (`moq import capture`, feature-gated): camera (AVFoundation / Media Foundation / V4L2) and whole-display (ScreenCaptureKit / DXGI Desktop Duplication / xdg-desktop-portal + PipeWire), encoded to H.264/H.265; microphone via cpal, encoded to Opus. Flags today are `--camera`, `--screen`, `--width/--height/--fps/--bitrate/--codec`, `--hardware/--software`, `--microphone`, `--audio-bitrate`, `--no-video/--no-audio`.
+- **Playback**: none. `moq export <container>` writes fmp4/mkv/ts/flv/h264/h265 to stdout; playing it means piping to ffplay (`doc/bin/cli.md:205`). `moq-video::decode` exists on `dev` but `moq-cli`'s export path never calls it.
+
+---
+
+##### Shipping: no released binary can capture at all
+
+- \[ ] **`capture` is off by default and no shipped artifact turns it on.** `rs/moq-cli/Cargo.toml` omits `capture` from `default`, and every distribution builds default features: Nix (`nix/overlay.nix:59`, `cargoExtraArgs = "-p moq-cli"`), Docker, winget, and `cargo install moq-cli`. So `moq import capture` is unreachable for every user who doesn't build from source with `--features capture`. The feature is off for good reasons (Linux `capture` pulls libclang + V4L2 headers via bindgen, and ALSA via cpal), so pick one: default-on with the existing trimmable sub-features, or a separate `moq-cli-capture` artifact. (`doc/bin/cli.md` does document the `--features capture` build, so this is a packaging gap, not a documentation one.)
+
+##### Capture sources
+
+- \[ ] **Window capture.** `capture::Source` is `Camera | Display` only (`rs/moq-video/src/capture/mod.rs:62`). Per platform: macOS already links `SCWindow` but only ever builds `SCContentFilter::initWithDisplay_excludingWindows` (`screencapture.rs:55-57`); Windows needs `Windows.Graphics.Capture` since Desktop Duplication is whole-monitor by construction (`desktopduplication.rs:5-7`); Linux asks the portal for `SourceType::Monitor` only (`pipewire.rs:162`), so the picker does not even offer windows. `Source` is `#[non_exhaustive]`, so adding a variant is additive.
+- \[ ] **Application capture** (every window of a process, follows new windows). macOS gets this nearly free from `SCShareableContent` applications + a content filter; Windows/Linux need per-window composition or a portal that supports it.
+- \[ ] **Region / crop capture.** No knob anywhere; `capture::Config` is `source`/`device`/`width`/`height`/`framerate`.
+- \[ ] **CLI cannot pick a display.** The macOS and Windows backends *do* support display selection by index (`screencapture.rs:41-52` accepts `N` or `display:N`; `desktopduplication.rs:281-292` via `EnumOutputs`), but `CaptureArgs::video_config` (`rs/moq-cli/src/publish.rs:326-332`) only sets `config.device` in the camera branch, and `--camera` `conflicts_with = "screen"`. So `--screen` always captures the main display and the library capability is unreachable. Needs a `--display <index>` (Linux would ignore it, see below).
+- \[ ] **Linux display selection.** The portal owns source selection and the device selector is explicitly ignored (`pipewire.rs:61-62`), so scripted/headless capture of a chosen monitor is not expressible. Related: the X11/DRM direct path tracked in #1837.
+- \[ ] **Cursor is hardcoded.** macOS forces `setShowsCursor(true)` (`screencapture.rs:66`), Linux forces `CursorMode::Embedded` (`pipewire.rs:161`), and Windows captures no cursor at all (no `PointerShape`/`PointerPosition` handling). Needs a `--cursor/--no-cursor` and a Windows implementation.
+
+##### Device enumeration
+
+- \[ ] **There is no way to list anything.** No public enumeration API exists in `moq-video` (`lib.rs` exports `capture`/`decode`/`encode`/`Error`) or `moq-audio`. You must already know the AVFoundation `uniqueID`, the `/dev/videoN` path, or the display index, with no way to discover them. The enumeration already happens internally and is thrown away: `SCShareableContent` (`screencapture.rs:139`), `MFEnumDeviceSources` (`mediafoundation.rs:351`), `EnumOutputs` (`desktopduplication.rs:295-302`), and cpal's `host.input_devices()` (`moq-audio/src/capture.rs:283`) each walk the list and index into it. Wants: a `list()` per source kind in the libraries, surfaced as something like `moq devices` (cameras, displays, windows, microphones), which is also the natural place to print the identifier `--camera`/`--display` expects.
+
+##### Audio capture
+
+- \[ ] **System / application audio loopback.** `moq-audio` capture is `Microphone` only (`capture.rs:43`); there is no loopback path anywhere in the workspace. This means `--screen` publishes a silent screen share, which is the single most surprising gap for the screen-capture use case. Needs ScreenCaptureKit audio (`SCStreamConfiguration::capturesAudio`, never set today) on macOS, WASAPI loopback on Windows, and a PipeWire monitor node on Linux.
+- \[ ] **Mixing / multiple devices.** One device, one track. No mic + system-audio mix, no multi-input.
+- \[ ] **Unvalidated format overrides.** `--sample-rate`-style config is applied without checking the device's supported ranges (`moq-audio/src/capture.rs:296-305`), so a bad combination fails inside cpal's `build_input_stream` instead of erroring with something actionable.
+- \[ ] Opus only on the encode side (probably fine; noting it).
+
+##### Playback (the `ffplay` equivalent)
+
+There is **no playback surface at all**. No crate in `rs/` depends on `winit`/`wgpu`/`softbuffer`/`sdl2`/`egui`/`minifb` (zero hits across every workspace `Cargo.toml`), and there is no audio output path (cpal is used for input only; `moq-audio::AudioConsumer` decodes to PCM and stops there). The pieces that *do* exist are decode-to-raw: `moq_video::decode::Frame` (`into_i420`, `resize`) and `moq_audio::codec::Decoder::decode_f32`.
+
+So this is a new subcommand, not a gap in an existing one. Proposed: `moq --client-connect <url> --broadcast <name> play`.
+
+- \[ ] **Video output window** (winit + wgpu or softbuffer), fed by `moq_video::decode`. Decode is done; presentation is not.
+- \[ ] **Audio output** via a cpal output stream, fed by `moq_audio::codec::Decoder`. `moq-audio`'s `capture` feature already pulls cpal, so this is mostly a `playback`/`output` sibling module.
+- \[ ] **A/V sync**: present against a common clock with a latency target, reusing the `--latency-max` semantics the export sinks already have, rather than inventing a second knob.
+- \[ ] **Zero-copy present**: the hardware decoders can hand back GPU surfaces; going through `into_i420` and back to the GPU wastes the whole point on 4K screen shares. Probably a follow-up, but the API shape should not preclude it.
+- \[ ] **Controls**: at minimum quit; likely pause, fullscreen, and a stats overlay (bitrate / fps / latency / dropped groups), which is the thing that actually makes it useful for debugging a relay.
+- \[ ] **Platform coverage** and the usual HW validation caveat from #1837: capture and presentation both need a real session, which a headless agent can't provide.
+- \[ ] **Decide the surface**: `play` as its own verb vs an `export` sink. `export` is defined as "MoQ out to one sink" and a window arguably is one, but every other `export` sink writes bytes somewhere, and playback needs its own clock/controls. My read is a separate `play` verb is the honest shape; worth a decision before anyone writes code.
+- \[ ] **Feature gating**: playback pulls a window system + GPU stack, which is exactly the dependency-weight problem `capture` already has. Whatever we decide above for shipping `capture` should cover this too.
+
+##### Related, if playback lands
+
+- \[ ] `moq-ffi` has no video decode at all (`moq-ffi/Cargo.toml` depends on `moq-audio` but not `moq-video`), so the UniFFI bindings only get raw encoded frames via `MoqFrame`. `libmoq` has `moq_consume_video_raw` (`libmoq/src/video.rs`), but it is H.264-only and its `moq_video_decoder_output` exposes only `latency_max_ms` (no format/resolution knob, per the docstring). Tracked loosely in #2152 / #2153; noting it here because a `play` implementation is the thing that would shake out the right shape.
+
+##### Docs
+
+- \[ ] **Keep `doc/bin/cli.md` in step with whatever lands above**, plus the Cross-Package Sync sweep for `moq-cli` examples across `doc/bin/`, `doc/lib/`, `doc/setup/`, and `doc/concept/`.
+
+  **Correction:** this issue originally claimed the page never mentions `import capture` ("zero hits for capture"). That was wrong: the grep ran against a `main` checkout, and the capture docs live on `dev` along with the code. `dev`'s `doc/bin/cli.md` documents the `capture` subcommand, its flags, and the `--features capture` build. Apologies for the noise.
+
+---
+
+Dependencies: the codec/platform backends this builds on are tracked in #1837 (notably Linux screen capture, Windows capture HW validation, and per-platform live camera runs). This issue covers the `moq-cli` surface: sources we can't name, devices we can't list, audio we can't capture, and playback we can't do.
+
+## Required
+
+- [#1837: moq-video: remaining work (codecs, platforms, decode, HW validation)](/quest/m0/1837-moq-video-remaining-work-codecs-platforms-decode-hw.md) - complete the prerequisite issue first
+
+## Closes
+
+- [#2272](https://github.com/moq-dev/moq/issues/2272) - close this issue when the quest finishes

--- a/quest/m0/2275-dvr-rewind-and-time-shift-a-live-broadcast-timeline-fetch.md
+++ b/quest/m0/2275-dvr-rewind-and-time-shift-a-live-broadcast-timeline-fetch.md
@@ -1,0 +1,66 @@
+# [L] DVR: rewind and time-shift a live broadcast (timeline + FETCH exist, durable storage doesn't)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2275](https://github.com/moq-dev/moq/issues/2275)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Rewind / time-shift / instant replay: let a viewer watch behind the live edge and scrub back. Every segmented protocol (HLS/DASH) gets this for free from segments on disk and pays seconds of latency for it. WebRTC and SRT cannot do it at all. MoQ could offer sub-second live *and* a scrubbable buffer on one connection, which nothing else does.
+
+The good news: the **addressing layer is done and shipping**. The gap is storage and the client read side.
+
+#### What exists today
+
+- **Timeline track** gives time → group. `hang::catalog::Timeline { track, timescale, wall }` (`rs/hang/src/catalog/timeline.rs`), records `hang::timeline::Record { group, pts }` (`rs/hang/src/timeline.rs`) on a `moq_json::stream` track, produced/consumed via `moq_mux::timeline::{Producer, Consumer, Entry}` (`rs/moq-mux/src/timeline.rs`). `DEFAULT_GRANULARITY` = 1s.
+- **FETCH** gives group → bytes. `track::Consumer::fetch_group(sequence, Option<group::Fetch>)` (`rs/moq-net/src/model/track.rs:1292`), served via `track::Producer::dynamic()` → `Dynamic::poll_requested_group` → `GroupRequest::accept`.
+- **`moq-hls` proves the pair end to end** (`rs/moq-hls/src/export/`): subscribe to catalog + timeline only, render playlists from timeline records, and FETCH the covering groups from the relay cache only when an HTTP client asks for a segment. Zero standing media traffic.
+
+So time → group → bytes already works. What's missing is that the bytes aren't there.
+
+#### What blocks it
+
+1. **No durable store. This is the fundamental one.** `cache::Pool` (`rs/moq-net/src/model/cache.rs`) is memory-only, and it is the *only* backing store in the tree. `Error::Evicted` (`rs/moq-net/src/error.rs:104`) correctly says an evicted group "can be re-fetched", but only from an upstream whose own retention is `track::Info.cache`  -  **`DEFAULT_CACHE` is 5 seconds** (`rs/moq-net/src/model/track.rs:31`). Past that it's `Error::NotFound`, permanently. 5s is the DVR depth of the entire system. `moq-hls`'s 16s `--window` is already a hostage to it.
+2. **LRU actively targets exactly the data a rewind wants.** `TrackState::pin_latest` (`track.rs:~490`) pins one group per track (the live edge). Everything behind it is evictable, and a rewinding viewer's reads are by definition the coldest in the pool.
+3. **`Info.cache` is publisher-fixed and immutable**, and `Info::clamp_stale` only clamps *down*. A subscriber cannot ask for deeper retention.
+4. **The subscription aggregate is a union across subscribers.** `Subscription::poll_combined` uses `min_some(group_start)`, so one viewer seeking to group 5 drags the whole upstream aggregate back to 5 for everyone. No per-subscriber window isolation.
+5. **JS has no read side at all.** No `Timeline.Consumer` in `js/hang` (producer only: `js/hang/src/container/timeline.ts`). No subscription `startGroup`/`endGroup` (Rust-only, `rs/moq-net/src/lite/subscribe.rs:21`). And the *local* `fetchGroup` fallback (`js/net/src/broadcast.ts:108`) is literally forward-only: it subscribes and scans forward, throwing `group not found` once it overshoots.
+6. **Consumers can't tell a seek from a restart.** `js/hang/src/container/consumer.ts:322` ("Only a group newer than the active one can rewind the timeline"), `:397`, `:499`; `rs/moq-hls/src/export/timeline.rs:~88` warns "timeline jumped backwards; resetting the playlist window". A seek looks identical to a publisher restart to every one of these.
+7. **FETCH is one whole group, no range and no frame offset.** `lite::Fetch { broadcast, track, priority, group }` (`rs/moq-net/src/lite/fetch.rs`). Seeking N seconds back is N/group\_duration serial round trips (`moq-hls`'s `for sequence in start..end` loop is exactly that). Note the IETF adapter's `FetchType::Standalone { start: Location, end: Location }` (`rs/moq-net/src/ietf/fetch.rs`) *does* carry a range  -  moq-lite doesn't.
+
+#### Proposed shape
+
+Roughly in dependency order; (1) is the only hard part.
+
+1. **A persistence tier behind the pool.** Some `Store` trait the origin can consult on a cache miss before returning `NotFound` (disk, then object storage). Decide whether it's a `cache::Pool` L2 (transparent, `fetch_group` just works and the existing `Evicted` → re-fetch path covers it) or a separate `moq-store` crate a publisher opts into. Retention becomes a duration/byte budget independent of `Info.cache`.
+2. **Let a subscriber discover the available window** rather than guessing. `Info.cache` advertises the live-edge TTL; a DVR window needs its own advertisement (earliest available group, per track), probably alongside the timeline.
+3. **Pinning/eviction policy that doesn't fight rewind**  -  at minimum, don't let a DVR read count as a cold LRU touch.
+4. **JS read side**: `Timeline.Consumer` in `js/hang`, `startGroup`/`endGroup` on the JS subscription, and a real `fetchGroup` that doesn't scan forward.
+5. **A seek vs restart distinction** in the container consumers, so a backward jump can be intentional.
+6. **Player API**: seek/scrub on `<moq-watch>`, plus the live-edge-relative position.
+
+Optional and separable: a **group range on FETCH** (mirror the IETF `start`/`end`) to collapse the N-round-trip seek. That's a wire change and can land later.
+
+#### Branch
+
+The store, the JS read side, and the player API are additive → `main`. A FETCH range is a moq-lite wire change → `dev`, and needs `drafts/draft-lcurley-moq-lite.md` in the same PR. Widening the retention advertisement is likely wire too.
+
+#### Cross-package sync
+
+`rs/moq-net` ↔ `js/net`; `rs/hang` ↔ `js/hang`; `doc/concept`. If FETCH changes shape, the moq-lite draft.
+
+#### Notes
+
+- Worth deciding up front whether DVR is a *relay* feature (the relay keeps a window for everyone) or a *publisher/origin* feature (the origin persists and serves FETCH from storage). The relay is supposed to stay media-agnostic, and it can: this is all group-level, no media parsing. But an unbounded relay-side window is a very different memory/cost story than an origin-side one.
+- `moq-hls` is the reference consumer. If DVR lands, `moq-hls` should get a real sliding-window-plus-history playlist off the same primitive rather than its own 16s cap.
+
+## Closes
+
+- [#2275](https://github.com/moq-dev/moq/issues/2275) - close this issue when the quest finishes

--- a/quest/m0/2276-moq-native-enable-quic-multipath-for-bonded-contribution.md
+++ b/quest/m0/2276-moq-native-enable-quic-multipath-for-bonded-contribution.md
@@ -1,0 +1,87 @@
+# [L] moq-native: enable QUIC multipath for bonded contribution (noq already implements it)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2276](https://github.com/moq-dev/moq/issues/2276)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Bonded contribution: send one broadcast over several network paths at once (cellular + cellular + wifi) so a field encoder survives any one link degrading. LiveU / Peplink / Zixi built an industry on proprietary bonding, and SRT has no native answer. Multipath QUIC is on the standards track, so MoQ could make this a config flag in an open protocol.
+
+I checked how hard it is to hook up. **Short version: noq already implements draft-ietf-quic-multipath in full, and moq never turns it on.** The protocol work is done. The blocker is the single-socket endpoint, which is exactly the thing cellular+wifi bonding needs.
+
+#### What exists today
+
+`noq` (the default backend: `default = ["noq", "aws-lc-rs", "websocket", "tcp", "uds"]` in `rs/moq-native/Cargo.toml`, via `web-transport-noq` 0.2.0) ships the whole multipath API:
+
+- `noq::Connection::open_path(FourTuple, PathStatus) -> OpenPath` (`noq-1.0.0/src/connection.rs:446`), `open_path_ensure` (`:391`)
+- `path_events() -> PathEvents` (`:484`), `path_stats(PathId) -> Option<PathStats>` (`:731`), `is_multipath_enabled()` (`:850`)
+- a full `Path` type (`noq-1.0.0/src/path.rs`) with `remote_address()`, `local_ip()`, `set_status`, `close`
+- negotiation knob: `TransportConfig::max_concurrent_multipath_paths(u32)` (`noq-proto-1.0.1/src/config/transport.rs:396`), which maps to the `initial_max_path_id` transport parameter. It's `NonZeroU32::new(max_concurrent)` on an `Option`, so the default is **None = disabled**. There's a substantial multipath test suite in `noq-1.0.0/src/tests.rs`.
+
+`apply_transport` (`rs/moq-native/src/noq.rs:15`) sets idle timeout, keep-alive, MTU, stream limits and GSO, and nothing else. So multipath is not negotiated on any moq connection today.
+
+There's already one acknowledgement of the upgrade in-tree, `rs/moq-native/src/noq.rs:469`:
+
+> `// The established Connection no longer exposes a single peer address (noq 1.0 supports multipath), so capture it from the Connecting before awaiting.`
+
+Other backends have nothing: quinn 0.11 has no multipath; quiche 0.29's `probe_path`/`migrate` is RFC 9000 migration (one active path), not the extension; iroh has its own path logic but not this.
+
+#### The layering is already right
+
+`web_transport_trait::Session` is deliberately address-free (open/accept streams, datagrams, stats, close), and `moq_net::Session` erases to `Box<dyn SessionInner>` with three methods (`rs/moq-net/src/session.rs:203`). Neither can see a path, and neither should  -  a browser WebTransport backend could never implement it.
+
+But `web_transport_noq::Session` implements `Deref<Target = noq::Connection>`, and `moq_net::Client::connect<S>(session: S)` takes the session **by value** while the trait requires `Clone`. So `rs/moq-native/src/noq.rs` can clone the session, hand one to moq-net, and keep a live `noq::Connection` to drive paths on. **Multipath rides entirely below the `web_transport_trait` line, invisible to moq-net.** No trait change, no moq-net change.
+
+#### Step 1: the cheap spike (multi-homed host)
+
+Plausibly ~200 lines, works today, no new concepts:
+
+1. `apply_transport` (`rs/moq-native/src/noq.rs:15`) → call `transport.max_concurrent_multipath_paths(n)`.
+2. A `--client-quic-max-paths` knob on `quic::Client` (`rs/moq-native/src/quic.rs`  -  note that file is clap/serde config only, not an abstraction).
+3. In `NoqClient::connect` (`rs/moq-native/src/noq.rs:172+`), clone the session and `conn.open_path(FourTuple::new(remote, Some(local_ip)), PathStatus::Available)`.
+
+That gets multipath negotiated and a second path open on a multi-homed box. It is **not** phone bonding yet.
+
+#### Step 2: the actual blocker
+
+**One endpoint = one UDP socket.** `bind::udp(addr) -> io::Result<UdpSocket>` (`rs/moq-native/src/bind.rs:26`) is singular, and `noq::Endpoint`'s own doc says "An endpoint corresponds to a single UDP socket". Every backend does this (`noq.rs:150`, `quinn.rs:149`, `quiche.rs:197`).
+
+`FourTuple` is `{ remote: SocketAddr, local_ip: Option<IpAddr> }` and is explicit about why (`noq-proto-1.0.1/src/lib.rs:371`):
+
+> "The socket is irrelevant for our intents and purposes: When we send, we can only specify the `src_ip`, not the source port."
+
+The only send-side lever is `Transmit.src_ip` (i.e. `IP_PKTINFO` on one wildcard socket). **Setting a source IP does not choose an egress interface.** On Linux the routing table might cooperate; on Android you must call `Network.bindSocket()` and on iOS you must bind to the interface to get packets onto the cellular radio at all. One socket cannot be bound to two networks. So cellular+wifi bonding is blocked by the socket model, not by the protocol.
+
+**The escape hatch** is `noq::Endpoint::new_with_abstract_socket(config, server_config, socket: Box<dyn AsyncUdpSocket>, runtime)` (`noq-1.0.0/src/endpoint.rs:162`), documented for exactly this ("useful when `socket` has additional state attached"). `AsyncUdpSocket` is a public trait. Implement a **fan-out socket** owning N interface-bound sockets, dispatching each `Transmit` by `src_ip` and merging the receive queues; noq sees one logical socket, the OS sees one per radio.
+
+Non-trivial: `local_addr()` has to return something coherent, `max_receive_segments()`/`may_fragment()` must be the conservative min across sockets, and interface binding is platform-specific (`SO_BINDTODEVICE`, Android `Network.bindSocket` via JNI  -  moq-native already has a JNI dep and `tls::init_android` doing this kind of reach-through).
+
+#### Also worth noting
+
+`ConnectionStats` (`rs/moq-net/src/session.rs:15`) is single-path shaped: one `rtt`, one `estimated_send_rate`. If per-path scheduling is ever to inform the publisher (and for contribution it should), that struct and `web_transport_trait::Stats` need a per-path story. That's probably the second real design problem after socket binding.
+
+**Naming trap**: `Path` is taken in moq-net (`rs/moq-net/src/path.rs`) and means the broadcast namespace path. Likewise `Client::with_path()` is the MoQ SETUP resource path. A network-path concept needs a different name.
+
+#### Branch
+
+`main`. It's additive and lives entirely in `rs/moq-native` behind `#[cfg(feature = "noq")]`. **Do not put paths in `web_transport_trait` or `moq-net`**  -  it's noq-only and must stay below the trait line.
+
+#### Suggested split
+
+- \[ ] Step 1 spike: negotiate multipath + a `--client-quic-max-paths` knob + `open_path` on a multi-homed host
+- \[ ] `AsyncUdpSocket` fan-out over N interface-bound sockets
+- \[ ] Platform interface binding (Linux `SO_BINDTODEVICE`, Android `Network.bindSocket`, iOS)
+- \[ ] Per-path stats (needs a `ConnectionStats` / `web_transport_trait::Stats` shape decision)
+- \[ ] Path scheduling policy for contribution (duplicate for redundancy vs. stripe for capacity)
+
+## Closes
+
+- [#2276](https://github.com/moq-dev/moq/issues/2276) - close this issue when the quest finishes

--- a/quest/m0/2277-hang-end-to-end-encryption-per-broadcast-key-relay.md
+++ b/quest/m0/2277-hang-end-to-end-encryption-per-broadcast-key-relay.md
@@ -1,0 +1,83 @@
+# [L] hang: end-to-end encryption (per-broadcast key, relay carries opaque payloads)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2277](https://github.com/moq-dev/moq/issues/2277)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+End-to-end encryption: configure a broadcast with a key so the relay carries bytes it cannot read.
+
+MoQ is unusually well placed for this. The central design rule is already "the CDN/relay does not know anything about media"  -  the relay treats payloads as opaque bytes and never parses them. Every other system fights its own architecture here: an SFU has to touch RTP headers, an HLS origin has to package. For MoQ, E2EE costs approximately nothing structurally. "Your CDN cannot watch your stream" is a claim nobody else can make credibly.
+
+#### What exists today
+
+**Nothing.** Security is hop-by-hop QUIC/TLS plus JWT authorization:
+
+- `rs/moq-token`  -  JWT signing/verification only (`Claims`, `Key`, `KeyType`, `Algorithm`: HS\*/ES256/384/EdDSA/RS\*). Deps: `aws-lc-rs` 1, `jsonwebtoken` 10, `p256`, `p384`, `rsa`. `KeyOperation::{Encrypt, Decrypt}` exist as JWK `key_ops` metadata values, but nothing encrypts.
+- No SFrame, no MLS, no per-frame/per-group AEAD anywhere in `rs/` or `js/`. The only `cipher`/`crypto` hits are `rs/moq-native/src/crypto.rs` (TLS `CryptoProvider` selection + a `sha256()` helper for cert fingerprinting) and the JWK `key_ops` enums.
+- aws-lc-rs is the de-facto provider; ring is a supported alternate.
+
+A relay sees plaintext media today.
+
+#### Where it attaches
+
+`moq_mux::container::Container` (`rs/moq-mux/src/container/mod.rs`) is the **sole seam** between media bytes and moq-net:
+
+```rust
+fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error>;
+fn poll_read(&self, group: &mut moq_net::group::Consumer, waiter: &kio::Waiter)
+    -> Poll<Result<Option<Vec<Frame>>, Self::Error>>;
+```
+
+Below it, `group::Producer::write_frame(timestamp, data)` / `create_frame(frame::Info)` (`rs/moq-net/src/model/group.rs:267`/`:302`) are the byte sink. Above it, `container::Producer<C: Container>` (`rs/moq-mux/src/container/producer.rs`) handles group boundaries and is generic over `C`, as are the catalog, timeline, and exporters.
+
+So the clean shape is a **decorator**: `struct Sframe<C: Container>(C)` whose `write` runs the inner container, encrypts, then writes; and inversely on `poll_read`. `moq_mux::catalog::hang::Container` (`rs/moq-mux/src/catalog/hang/container.rs`) is the runtime dispatch enum chosen per-track from the catalog, so that's the natural wiring point.
+
+Three wrinkles:
+
+1. `Container::write` takes `&mut group::Producer` directly instead of returning bytes, so a decorator must buffer into a scratch group or the trait needs a bytes-returning variant.
+2. `Container::Error` must be `From<moq_net::Error> + From<MissingKeyframe>`; encryption needs a third variant, so `Self::Error` widens.
+3. **Metadata leak**: encrypting at the `Container` layer leaves the catalog plaintext, including the CMAF init segment (`Container::Cmaf { init: Bytes }`, base64 in the catalog) which carries codec/resolution. Frame sizes, group boundaries, and timing all stay visible by construction. An E2EE design has to state its threat model rather than imply "the relay sees nothing".
+
+#### Catalog support
+
+None. `hang::catalog::Container` (`rs/hang/src/catalog/container.rs`) is:
+
+```rust
+#[serde(tag = "kind")]
+pub enum Container { Legacy, Cmaf { init: Bytes }, Loc }
+```
+
+No `kid`, no cipher suite, no key-exchange reference. And it is **not `#[non_exhaustive]`**, so adding a variant is breaking for external matchers  -  worth fixing regardless, since `VideoConfig`/`AudioConfig`/`Timeline` all are. Same for `hang::catalog::Catalog` itself (`rs/hang/src/catalog/root.rs:16`, pub `video`/`audio` fields, no `#[non_exhaustive]`).
+
+#### Open questions (the actual work is here)
+
+1. **Key distribution, and how far to go.** Three tiers, increasing cost:
+   - *Pre-shared key per broadcast*  -  a config knob, out-of-band distribution. Trivially shippable, covers "my relay shouldn't see my stream", no forward secrecy, no membership changes. Probably the right v1.
+   - *Sender key with rotation*  -  needs a key track and a rekey story on join/leave.
+   - *MLS* (RFC 9420)  -  real group key agreement, forward secrecy, membership. The right answer for conferencing; a large dependency and a big design.
+     Suggest shipping tier 1 and designing the catalog/track shape so tiers 2-3 are additive.
+2. **SFrame (RFC 9605) or bespoke AEAD?** SFrame is the standard, is designed for exactly this (per-frame AEAD over a media payload with a compact header), and would interop with WebRTC-adjacent tooling. Bespoke is less work and we control the container anyway. Leaning SFrame for the wire header even if the key schedule is simpler at first.
+3. **What's encrypted?** Frame payload only, or also the catalog? A plaintext catalog is a real leak but also what makes the relay useful (`announced()`, routing). Probably: payload encrypted, catalog plaintext, documented.
+4. **Which layer?** The `Container` decorator keeps moq-net untouched and is the right call. But note that means anything not going through `moq-mux` (raw tracks via FFI, `moq-json`) gets nothing.
+5. **Browser story.** `js/hang` needs the mirror, and WebCrypto AES-GCM per frame at 60fps needs a perf check.
+
+#### Branch
+
+`dev`. The catalog gains an encryption descriptor and `hang::catalog::Container` needs a new variant while not being `#[non_exhaustive]`  -  both are catalog-format/breaking changes. The `#[non_exhaustive]` fix on `Catalog`/`Container` is itself breaking and could land first on `dev` as a standalone.
+
+#### Cross-package sync
+
+`rs/hang` ↔ `js/hang`; `doc/concept`. If the catalog format changes, `drafts/draft-lcurley-moq-hang.md` in the same PR.
+
+## Closes
+
+- [#2277](https://github.com/moq-dev/moq/issues/2277) - close this issue when the quest finishes

--- a/quest/m0/2278-watch-absolute-wall-clock-latency-target-for-synchronized.md
+++ b/quest/m0/2278-watch-absolute-wall-clock-latency-target-for-synchronized.md
@@ -1,0 +1,92 @@
+# [L] watch: absolute wall-clock latency target for synchronized playback across viewers
+
+## Goal
+
+Implement and verify the behavior tracked in [#2278](https://github.com/moq-dev/moq/issues/2278)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Let every viewer render the same frame at the same instant. Watch parties, sports bars, betting, second-screen, and multi-camera sync all need it. HLS does it badly via `EXT-X-PROGRAM-DATE-TIME`; WebRTC doesn't try.
+
+The pieces are closer than they look: **the PTS → wall-clock mapping already exists in the catalog and the player just never reads it.**
+
+#### What exists today
+
+**`Timeline.wall` is the mapping, and it's already shipping.** `rs/hang/src/catalog/timeline.rs`:
+
+```rust
+pub struct Timeline {
+    pub track: String,
+    pub timescale: u32,          // default 1000 (ms)
+    pub wall: Option<u64>,       // wall-clock of pts 0, in timescale units since the MoQ epoch
+}
+pub const MOQ_EPOCH_UNIX_MILLIS: u64 = 1_577_836_800_000;  // 2020-01-01
+```
+
+Set via `moq_mux::timeline::Producer::set_wall(pts, wall)` (`rs/moq-mux/src/timeline.rs`), attached per-rendition on `VideoConfig.timeline` / `AudioConfig.timeline`. JS mirrors the schema (`js/hang/src/catalog/timeline.ts`) and the producer (`js/hang/src/container/timeline.ts`  -  `setWall(pts, wall)`).
+
+So `wall + pts` → Unix time, per rendition, today.
+
+**Frame timestamps are PTS, deliberately, and must not be repurposed.** Worth stating clearly because it's easy to get wrong:
+
+- `hang::container::Frame::timestamp` doc (`rs/hang/src/container/frame.rs:27`): "the presentation timestamp... This is NOT a wall clock time."
+- `rs/moq-net/src/model/time.rs:119`: "All timestamps within a track are relative, so zero for one track is not zero for another."
+- `Timestamp::now()` is a deliberately one-way bridge with **no inverse**, and the anchor is 2020-01-01 **minus a per-process random 0..69420ms jitter**, explicitly "to deter nerds trying to use timestamp as wall clock time" (`time.rs:412`).
+- The lite-05 wire field is a **zigzag delta of PTS at the track timescale** (`rs/moq-net/src/lite/publisher.rs:828` `encode_frame_timing`), not a wall-clock value.
+
+The codebase actively fights wall-clock interpretation of frame timestamps. `Timeline.wall` is the sanctioned channel and this issue should stay on it.
+
+#### What's missing
+
+**Latency is relative (buffer depth), never absolute.** `js/watch/src/sync.ts`:
+
+```ts
+export type Bound = "real-time" | Time.Milli;
+export type Latency = Bound | { min?: Bound; max?: Bound };
+```
+
+`Sync.received(timestamp)` computes `ref = Time.Milli.now() - timestamp`, and `Time.Milli.now()` is `performance.now()` (`js/net/src/time.ts:68`)  -  monotonic since page load, explicitly "not wall-clock time". So `reference` is an arbitrary local-clock↔PTS offset anchored by whichever frame happened to arrive first. Two viewers who tune in 3 seconds apart are 3 seconds apart forever, and nothing in the model can tell.
+
+`Sync` never reads `Timeline.wall`. There is no JS `Timeline.Consumer` at all (producer only).
+
+#### Proposed shape
+
+1. **A JS `Timeline.Consumer`** in `js/hang` (needed by the DVR work too).
+2. **A third `Bound` variant, or a new absolute mode**: something like `latency: { absolute: Time.Milli }` meaning "render pts P at wall time `wall + P + absolute`". `Sync` then anchors on `Timeline.wall` instead of first-frame arrival, and `now()` becomes a wall-clock computation rather than an offset.
+3. **Client clock sync.** This is the real work. `Timeline.wall` is the *publisher's* wall clock; the viewer's `Date.now()` can be off by seconds. Options, roughly in order of cost:
+   - trust `Date.now()` (fine for a watch party, useless for betting)
+   - estimate offset from the session RTT (we already track min RTT via PROBE in `#runJitter` for exactly this kind of anchoring)
+   - NTP-ish round trips over a MoQ track
+   - let the app inject a clock
+     Suggest: an injectable clock with an RTT-based default, so the app can bring its own.
+4. **Degrade honestly.** If the target wall time has already passed (viewer joined late, or clock skew is large) the player must either skip forward or admit it can't hit the target. Silently drifting back to relative is worse than an error.
+5. **Surface the achieved offset** so an app can show "you are 240ms behind the reference".
+
+#### Open questions
+
+- Absolute latency and the existing `min`/`max` bounds interact awkwardly: an absolute target is a *point*, the bounds are a *range*. Does absolute override the range, or clamp within it?
+- `Timeline.wall` is per-rendition. Are audio and video guaranteed consistent? A rendition switch must not re-anchor.
+- Does this need anything on the publisher, or is `set_wall` sufficient? Today nothing in `moq-video`/`js/publish` calls `set_wall` as far as I can tell  -  so step 0 might be "actually populate `wall`".
+
+#### Naming note
+
+`Latency` is already doubly overloaded: the `Bound | {min,max}` type (`js/watch/src/sync.ts:16`) and `class Latency` (`js/hang/src/util/latency.ts:21`, jitter+buffer). Different packages, both exported. Worth resolving before adding a third meaning.
+
+#### Branch
+
+`main`  -  additive on the player. Unless `Timeline` gains fields, in which case check `#[non_exhaustive]` (it has it) and the JS schema.
+
+#### Cross-package sync
+
+`js/watch`, `js/hang`, `rs/hang`; `demo/web` if it exposes the knob; `doc/concept`.
+
+## Closes
+
+- [#2278](https://github.com/moq-dev/moq/issues/2278) - close this issue when the quest finishes

--- a/quest/m0/2279-hang-typed-scte-35-ad-cue-signaling-carried-opaquely.md
+++ b/quest/m0/2279-hang-typed-scte-35-ad-cue-signaling-carried-opaquely.md
@@ -1,0 +1,66 @@
+# [L] hang: typed SCTE-35 / ad cue signaling (carried opaquely today, unreadable by players)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2279](https://github.com/moq-dev/moq/issues/2279)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Ad insertion: nobody streams commercially without it, and MoQ has no ad story. The pieces to signal a splice already exist but only as opaque MPEG-TS byte carriage, so a cue can ride *through* MoQ but nothing can *act* on one.
+
+MoQ should also be able to do this better than HLS: switching broadcasts is instant, so an ad transition needn't stall or re-buffer the way a discontinuity does.
+
+#### What exists today
+
+**SCTE-35 is carried, byte-faithfully, but never parsed.** It lives entirely in the `moq-mux` MPEG-TS container via the `mpegts` catalog extension:
+
+- `rs/moq-mux/src/container/ts/catalog.rs`  -  `Verbatim { stream_type: u8, framing: Framing, stream_id: Option<u8> }`, `enum Framing { Pes, Section }`. SCTE-35 is `Verbatim::new(0x86, Framing::Section)`. Plus `Descriptor { tag, data }` for the program-level `CUEI` registration.
+- **Import**: `rs/moq-mux/src/container/ts/import.rs:404` routes section-framed verbatim PIDs to one MoQ track per ES, each frame a complete `splice_info_section`, byte for byte. Cues are stamped with **video PTS** (`import.rs:2218`). Requires an extension catalog  -  a `Catalog<()>` routes the CUEI PID to `Stream::Ignored`.
+- **Export**: `rs/moq-mux/src/container/ts/export.rs:596-613` re-derives the `CUEI` registration; `:834` packetizes private sections. Note section-framed export **requires a video track** for the program clock.
+- Real coverage: `ts/import_test.rs:352` (6 real `splice_insert`s from `test_data/scte35/kyrion_dirtystart.ts`, TSDuck-verified), `ts/export_test.rs:565` (TS→MoQ→TS byte-identical round trip), `rs/moq-mux/examples/scte35_inject.rs`. PRs #1617, #1685, #1696.
+
+So: TS in → TS out preserves cues perfectly. But a **browser watching that same broadcast sees nothing**, because the cue is an undecoded private section on a TS-specific track that only the TS exporter understands.
+
+**No ID3, no `emsg`, no generic timed-metadata track type anywhere.** The `scte35` name in `rs/hang/src/catalog/root.rs:363`, `rs/moq-mux/src/catalog/hang/ext.rs:155`, and `rs/moq-json/src/snapshot.rs:667` is **test fixture / doc example only**  -  an illustrative extension, not a shipped schema.
+
+#### What's missing
+
+Three separable things:
+
+1. **A typed, container-independent cue model.** Parse `splice_info_section` into something an application can read (`splice_insert`, `time_signal`, segmentation descriptors, `out_of_network_indicator`, duration, `splice_time` → PTS). A cue should be readable by a browser without knowing MPEG-TS exists.
+2. **A catalog section describing where cues live**, so a consumer can find the track. The `mpegts` section is the worked example to copy: `rs/moq-mux/src/container/ts/catalog.rs` defines `struct Ext { mpegts: Mpegts }` + `impl CatalogExt for Ext`, plus a `trait Catalog: CatalogExt` composition hook implemented for `()`/`Extra`/`Ext`.
+3. **Something that acts on a cue.** Player-side (CSAI: fire an event, let the app swap sources) and/or server-side (SSAI: splice a different broadcast into the output). Relative broadcast refs (`VideoConfig.broadcast`, `RelativeBroadcastSchema`) already let a catalog point at another broadcast, which is most of the mechanism for a server-side splice.
+
+#### Proposed shape
+
+- A `moq-json::stream` track of typed cue records, mirroring the timeline track's shape (`hang::timeline::Record` on a `moq_json::stream`, one record per frame). Cues are sparse, self-contained, and want lossless ordered delivery  -  `stream` is exactly right, and `RecordExt` is the extension hook.
+- Records carry PTS in the same timescale as the timeline section, so cue → group resolution reuses the timeline machinery.
+- Prototype **out of tree as a `CatalogExt` first** (exactly like `ts::catalog::Ext`) before touching base `hang`. `rs/hang/src/catalog/root.rs:352` has an `extension_roundtrip` test showing the serde-flatten pattern; JS uses `z.extend(RootSchema, ...)` (`js/hang/src/catalog/root.test.ts:15`) and `RootSchema` is a `z.looseObject` so unknown sections pass through untouched.
+- The TS importer keeps its verbatim lane (contribution needs byte fidelity), and **additionally** emits typed cues. The two are complementary, not either/or.
+
+#### Open questions
+
+1. **Typed cues vs. verbatim, or both?** Both, I think: verbatim for TS→TS fidelity, typed for everything else. But then the TS exporter must not double-emit.
+2. **Which SCTE-35 subset?** `splice_insert` + `time_signal` + segmentation descriptors covers most real usage. Full SCTE-35 is large. Prefer a maintained crate over hand-rolling if one exists at acceptable quality.
+3. **Does this generalize to timed metadata?** ID3, `emsg`, and custom app cues want the same track shape. A generic "timed metadata track" with SCTE-35 as one record type may be the better primitive than an SCTE-35-specific section  -  cf. the Public API Scrutiny rule about composable building blocks over bespoke one-offs.
+4. **SSAI is a much bigger scope** (ad decision server, per-viewer manifests, tracking beacons). Suggest this issue covers signaling + a player-side event, and SSAI gets its own.
+5. Cue PTS is stamped from **video** PTS on import  -  check that's right for audio-only broadcasts.
+
+#### Branch
+
+`main` if it lands as a `CatalogExt` extension or a new optional section that doesn't break struct literals. Note `hang::catalog::Catalog` (`rs/hang/src/catalog/root.rs:16`) is **not `#[non_exhaustive]`** and has pub `video`/`audio` fields, so adding a field to base `hang` breaks struct-literal construction → that variant is `dev`.
+
+#### Cross-package sync
+
+`rs/hang` ↔ `js/hang`; `rs/moq-mux`; `doc/concept`. If a catalog section lands, `drafts/draft-lcurley-moq-hang.md` in the same PR.
+
+## Closes
+
+- [#2279](https://github.com/moq-dev/moq/issues/2279) - close this issue when the quest finishes

--- a/quest/m0/2280-hang-caption-and-subtitle-text-tracks.md
+++ b/quest/m0/2280-hang-caption-and-subtitle-text-tracks.md
@@ -1,0 +1,75 @@
+# [L] hang: caption and subtitle text tracks
+
+## Goal
+
+Implement and verify the behavior tracked in [#2280](https://github.com/moq-dev/moq/issues/2280)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Captions and subtitles: an accessibility and localization baseline that MoQ has no model for at all. Also a place where MoQ is structurally better than the incumbents rather than merely catching up.
+
+In HLS, captions are segment-bound: a caption can't land until its segment does, so live captioning inherits the whole segment latency. In MPEG-TS they're smuggled inside video SEI (CEA-608/708). In MoQ a caption is just **a track with timestamps**, delivered independently, at whatever cadence the source produces. Sub-second live captioning and real-time translation become natural rather than a hack, and per-language tracks are subscribed only when selected.
+
+#### What exists today
+
+**Nothing in the hang catalog.** No text/subtitle/caption/webvtt/cea608/cea708/ttml section, schema, or track type in `rs/hang` or `js/hang`. `hang::catalog::Catalog` (`rs/hang/src/catalog/root.rs:16`) is exactly two sections:
+
+```rust
+pub struct Catalog {
+    #[serde(default)] pub video: Video,
+    #[serde(default)] pub audio: Audio,
+}
+```
+
+Elsewhere in the tree, captions are modeled-then-dropped or carried-but-opaque:
+
+- **MSF** (the other, IETF catalog) has the roles: `moq_msf::Role::{Caption, Subtitle}` (`rs/moq-msf/src/lib.rs:455-457`), and JS mirrors them (`js/msf/src/catalog.ts:15`  -  `z.enum([..., "caption", "subtitle", "signlanguage"])`). But `rs/moq-mux/src/catalog/msf/consumer.rs:87` **drops** them: "Tracks with no role, with an unsupported role (caption, subtitle, ...)".
+- **fMP4 import rejects them**: `rs/moq-mux/src/container/fmp4/import.rs:207`  -  `b"sbtl" => Err(Error::UnsupportedSubtitle)`. MKV drops them (`mkv/import.rs:40`).
+- **TS carries teletext/DVB subs verbatim and undecoded** via the `mpegts` section  -  bytes ride through, nothing reads them.
+- **Aspirational only**: `doc/concept/use-case/ai.md:38` and `doc/concept/use-case/contribution.md:97` both describe a `captions` track (Whisper) as a use case. The docs promise something that doesn't exist.
+
+So today: a broadcast with captions loses them at every import boundary except opaque TS.
+
+#### Proposed shape
+
+A `text` (or `captions`) root section mirroring `Audio`:
+
+```rust
+pub struct Text { pub renditions: BTreeMap<String, TextConfig> }
+```
+
+with `TextConfig` reusing the existing per-rendition machinery: `broadcast` (relative refs), `container`, `timeline`, `jitter`, plus `language` (BCP-47) and a `kind` (caption vs subtitle vs description  -  MSF's `Role` already enumerates these; reuse rather than invent).
+
+Format: probably WebVTT cues or a simple typed JSON record. A `moq_json::stream` track is the obvious carrier (lossless, ordered, self-contained records  -  same shape as the timeline track), with each cue carrying its own start/end PTS. Note captions are sparse and bursty, unlike media, so the group/keyframe model needs thought: one cue per frame, one group per... what? Worth deciding explicitly.
+
+**Prototype out of tree as a `CatalogExt` first**, exactly like `ts::catalog::Ext` (`rs/moq-mux/src/container/ts/catalog.rs`), which is the worked example of adding a section: `struct Ext { mpegts: Mpegts }` + `impl CatalogExt for Ext` + a `trait Catalog: CatalogExt` composition hook implemented for `()`/`Extra`/`Ext`. `RootSchema` in JS is a `z.looseObject`, so unknown sections already pass through untouched, and `rs/hang/src/catalog/root.rs:352` (`extension_roundtrip`) shows the serde-flatten pattern.
+
+#### Open questions
+
+1. **Cue format**: WebVTT (browser-native, `TextTrackCue` for free) vs. a typed JSON record (language-agnostic, no parsing) vs. TTML/IMSC (broadcast-grade, heavy). WebVTT for the browser path is tempting but a native consumer then has to parse it. Leaning typed JSON records that trivially render to WebVTT.
+2. **CEA-608/708 extraction from SEI.** A huge amount of real content carries captions inside video SEI. Extracting them at import into a real text track is genuinely valuable, and genuinely fiddly. Probably a separate follow-up, but the catalog shape should anticipate it.
+3. **Do MSF's `Caption`/`Subtitle` roles map cleanly onto the new section?** They should, so the MSF consumer can stop dropping them.
+4. **Group/keyframe semantics for a sparse text track**  -  the container `Producer` requires a keyframe to open a group (`MissingKeyframe`, `rs/moq-mux/src/container/producer.rs:109`). A `moq_json::stream` sidesteps this; a `Container`-based text track wouldn't.
+5. **Player UI**: `<moq-watch>` needs to expose track selection and render cues. `js/watch` has no text surface at all today.
+6. Live translation and Whisper-style ASR are the interesting downstream use (and the docs already promise them), but they're applications on top of this, not part of it.
+
+#### Branch
+
+`dev` if it adds a field to base `hang::catalog::Catalog`: the struct has pub fields and is **not `#[non_exhaustive]`** (unlike `VideoConfig`/`AudioConfig`/`Timeline`, which are), so a new field breaks struct-literal construction. Adding `#[non_exhaustive]` to `Catalog` is itself breaking and could land first on `dev` as a standalone  -  worth doing regardless, since it's an inconsistency that will keep biting (E2EE hits the same wall on `catalog::Container`).
+
+`main` if it stays an out-of-tree `CatalogExt` prototype.
+
+#### Cross-package sync
+
+`rs/hang` ↔ `js/hang`; `js/watch` (selection + rendering); `rs/moq-mux` (MSF consumer, fMP4/MKV/TS import); `doc/concept`. Catalog format change → `drafts/draft-lcurley-moq-hang.md` in the same PR.
+
+## Closes
+
+- [#2280](https://github.com/moq-dev/moq/issues/2280) - close this issue when the quest finishes

--- a/quest/m0/2281-moq-cli-generic-broadcast-recording-and-paced-replay-all.md
+++ b/quest/m0/2281-moq-cli-generic-broadcast-recording-and-paced-replay-all.md
@@ -1,0 +1,79 @@
+# [L] moq-cli: generic broadcast recording and paced replay (all tracks + catalog)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2281](https://github.com/moq-dev/moq/issues/2281)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+"Where's my archive?" is the second question every broadcaster asks. There is no way to record a MoQ broadcast and no way to replay one.
+
+Everything that looks like recording today is really *transcoding to a media container*, which is lossy in the ways that matter for an archive: it picks one rendition, drops the catalog, and can't round-trip.
+
+#### What exists today
+
+**Export is media-specific and stdout-only.** `moq <side> export <sink>` (`rs/moq-cli/src/args.rs`, `export` aliases `subscribe`). Sinks: `fmp4`, `mkv`, `ts`, `flv`, `h264`, `h265`, plus gateways `hls`/`rtmp`/`srt`/`rtc`. There is **no `--format` flag** (the format is the subcommand) and **no `--output <path>`**  -  everything writes `tokio::io::stdout()` (`rs/moq-cli/src/subscribe.rs`, `run_fmp4`/`run_mkv`/`run_ts`/...).
+
+So `moq ... export fmp4 > out.mp4` works, but:
+
+- it's a fragmented CMAF stream dumped to a file (no seekable `moov`), not a finalized recording;
+- it's **one video + one audio rendition**, chosen via `--video-name`/`--audio-name`;
+- the catalog drives the muxing and is then thrown away  -  it's never archived;
+- nothing else on the broadcast survives (timeline, extra sections, non-media tracks, `mpegts` verbatim streams, future caption/cue tracks).
+
+**No import from a file, either.** `ImportSource` container variants (`Avc3`, `Fmp4`, `Ts`, `Flv`) are **stdin only** (`rs/moq-cli/src/publish.rs`). You can `cat file.mp4 | moq ... import fmp4`, but with **no pacing**  -  it blasts the file at line rate instead of replaying at wall-clock speed. `ImportSource::Hls` (`rs/moq-cli/src/hls.rs`) accepts a local playlist path and does pace, which makes it the only file-ish input that behaves. No seek, no loop.
+
+**Nothing persists groups to disk anywhere.** `cache::Pool` (`rs/moq-net/src/model/cache.rs`) is memory-only. Disk I/O in the tree is config, JWKS keys, and test fixtures.
+
+#### What's missing
+
+A **generic, media-agnostic broadcast archive**: all tracks, the catalog, group boundaries, and timestamps, such that replaying it reproduces the original broadcast. That's a different thing from an mp4, and it's the thing that matches MoQ's own design rule  -  a recorder shouldn't have to know what media is any more than a relay does.
+
+The primitives are all sitting there unused:
+
+- `rs/moq-json` has `stream` (lossless ordered append-log of self-contained records)  -  right shape for an index or a manifest.
+- `rs/moq-mux/src/timeline.rs`'s doc comment **explicitly names "a recorder index" as a use case**: one `Record { group, pts }` per group per track. It's a group index with no payload, and nothing consumes it for this.
+- `moq_mux::container::Producer::seek` / `pending_sequence` (`rs/moq-mux/src/container/producer.rs`) already exist, so replay can restore original group sequences rather than renumbering.
+
+#### Proposed shape
+
+An archive format that is essentially "the broadcast, on disk":
+
+- catalog snapshots over time (it mutates  -  a rendition can appear or drop mid-broadcast);
+- per track: group sequences, frame boundaries, timestamps, payload bytes, verbatim;
+- a timeline/index for seeking without a full scan (the existing timeline record shape is the obvious candidate);
+- no media parsing anywhere in the writer or reader.
+
+Then:
+
+- `moq ... export archive --output <path>` (and the missing `--output` for the existing sinks while we're here);
+- `moq ... import archive <path>` that replays **paced to the media clock**, with `--loop` and `--start-at`. Paced replay is independently useful for testing, demos, and CI  -  the smoke tests currently have no way to replay a fixture at real speed.
+
+Explicitly out of scope: turning an archive into an mp4. That's the existing exporters' job, and an archive should be losslessly convertible by piping it back through them.
+
+#### Open questions
+
+1. **Where does this live?** A `moq-archive` crate, or `moq-mux/src/container/archive`? It isn't really a media container  -  it's below that layer. Arguably it belongs closer to `moq-net`, since it only knows about tracks/groups/frames. But `moq-net` should probably not grow file I/O.
+2. **Relationship to DVR.** A DVR needs a durable store behind `cache::Pool` that serves FETCH; an archive needs a file that replays. These are the same bytes and possibly the same format  -  worth designing together, or at least deciding they're deliberately separate. If the DVR store lands first, "record" might just be "point the store at a directory and never evict".
+3. **Format**: a container-ish framing of our own, or reuse `moq-json` for the manifest plus opaque blobs for payloads? Prefer a maintained third-party container over hand-rolling if one fits, per the dependency rule  -  though "arbitrary tracks of timestamped opaque frames with group boundaries" may not map cleanly onto anything off the shelf. Matroska is the closest generic fit and would be worth a look before inventing one.
+4. **Live-to-VOD**: does a completed archive get served back as a broadcast (via `OriginDynamic`/`request_broadcast`, which already serves broadcasts on demand that are never announced), or only replayed by the CLI? The former is much more interesting and is most of a VOD origin.
+5. **Compaction**: an archive of a 24h broadcast is large. Does it drop non-selected renditions? That's a policy, not a format concern, but the format shouldn't preclude it.
+
+#### Branch
+
+`main`. New crate / new CLI subcommand / new sink are all additive. `--output` on the existing sinks is additive too.
+
+#### Cross-package sync
+
+`rs/moq-cli` → `doc/bin/cli.md`, and grep the repo for `moq ... export`/`import` examples per the CLI-docs rule. If it lands as a `moq-*` crate, `doc/lib/rs/`.
+
+## Closes
+
+- [#2281](https://github.com/moq-dev/moq/issues/2281) - close this issue when the quest finishes

--- a/quest/m0/2282-moq-audio-echo-cancellation-agc-noise-suppression-for.md
+++ b/quest/m0/2282-moq-audio-echo-cancellation-agc-noise-suppression-for.md
@@ -1,0 +1,74 @@
+# [L] moq-audio: echo cancellation / AGC / noise suppression for native capture
+
+## Goal
+
+Implement and verify the behavior tracked in [#2282](https://github.com/moq-dev/moq/issues/2282)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+You cannot build a native MoQ conferencing client today, because two participants on speakers will howl. The browser gets echo cancellation, noise suppression, and auto gain control free from getUserMedia; native gets nothing. That asymmetry blocks every native two-way use case.
+
+#### What exists today
+
+**`rs/moq-audio` does codec + format + resample, and no processing:**
+
+- `codec.rs`  -  Opus `Encoder`/`Decoder` via `unsafe-libopus` 0.2 (pure-Rust transpile of libopus 1.3.1)
+- `format.rs`  -  `AudioFormat` (mirrors WebCodecs `AudioData.format`), layout conversion to interleaved f32
+- `resample.rs`  -  `Resampler`, rubato 3.0, sinc only. **Sample-rate only**; channel up/downmix is rejected upstream.
+- `producer.rs` / `consumer.rs`, `frame.rs`, `error.rs`
+- `capture.rs` + `capture/permission.rs`
+
+No echo cancellation, no AGC, no noise suppression, no VAD, no mixer. The only signal-conditioning-adjacent knobs are Opus-internal (DTX, `signal=voice`), and those are **JS-side only** (`js/publish/src/audio/types.ts`, `Kind = "voice"|"music"|"auto"`)  -  the native encoder has no equivalent plumbing.
+
+**Native mic capture already exists**, which is what makes this gap actionable rather than theoretical: `rs/moq-audio/src/capture.rs` (behind the `capture` feature) uses **cpal 0.18** (CoreAudio/WASAPI/ALSA) with `capture::Config { device, sample_rate, channels }` and `capture::Microphone` (realtime callback → `mpsc` → interleaved-f32 `Frame`s). `capture/permission.rs` handles macOS TCC up front (objc2 + objc2-av-foundation), and `FIRST_BUFFER_TIMEOUT` = 5s surfaces a denial as an error instead of a silent hang. Wired to the CLI via `ImportSource::Capture` (`--microphone`, `--audio-bitrate`).
+
+So we can capture a mic natively. We just can't make it usable in a two-way call.
+
+**Browser**: `js/publish/src/source/microphone.ts:44` calls `getUserMedia({ audio: finalConstraints })` where constraints come from `MicrophoneProps.constraints` (`Audio.Constraints`, default `{}`). So `echoCancellation`/`noiseSuppression`/`autoGainControl` are *passable by the app* but **moq sets no defaults**  -  you get the browser's implicit behavior (Chrome defaults them on for `{audio: {...}}`, but that's the browser's choice, not ours). `TrackSettings` (`js/publish/src/audio/types.ts:44`) reads them back, all optional since Safari underreports.
+
+**No audio-processing crate is in the tree.** Grepping every `rs/*/Cargo.toml` for `webrtc-audio-processing`, `speexdsp`, `rnnoise`, `nnnoiseless`, `earshot`, `aec`, `agc` returns zero hits. `rs/moq-rtc` (str0m) has none either.
+
+#### The hard constraint
+
+`rs/moq-audio`'s stated stance in its `Cargo.toml`: pure-Rust, no CMake, no C linker hackery, "audio never touches ffmpeg". That's a good rule and it's load-bearing for cross-compilation (Android/iOS/Windows).
+
+It also rules out the obvious answer. `webrtc-audio-processing` is the industry-standard AEC and it's a C++ binding needing CMake and abseil. Adopting it would break the invariant hard.
+
+Rough state of the pure-Rust options:
+
+- **NS**: `nnnoiseless` (RNNoise port)  -  viable, pure Rust.
+- **VAD**: `earshot` (WebRTC VAD port)  -  viable, pure Rust.
+- **AGC**: simple enough to implement directly; it's a feedback loop over gain, not signal processing.
+- **AEC**: **no good pure-Rust option exists.** This is the real problem. AEC is also the one that actually matters for conferencing  -  NS and AGC are nice, AEC is the difference between "works" and "unusable".
+
+#### Open questions (the decision is question 1)
+
+1. **How much is the pure-Rust stance worth?** Three ways out:
+   - Take the C++ dep (`webrtc-audio-processing`) behind an **optional, off-by-default feature**, so the default build keeps the invariant and anyone who wants AEC opts in and eats CMake. This is probably the pragmatic answer and it's what the feature-gating in `moq-video` already does for NVENC/VAAPI.
+   - Write a pure-Rust AEC. Real work (adaptive filter, double-talk detection, nonlinear processing) and easy to do badly.
+   - Punt AEC and ship NS + AGC + VAD pure-Rust. Half a loaf, and it does not unblock conferencing.
+2. **Does this belong in `moq-audio` at all?** It's an audio *pipeline* concern, not a codec concern. Maybe a separate `moq-audio-dsp` crate, or a `processing` module gated behind a feature. Keeping `moq-audio` a clean pure-Rust codec crate has value.
+3. **AEC needs the far-end reference signal**, which means the *playback* path has to hand its samples to the *capture* path. `moq-audio` has no playback/output side at all today (no speaker output, no mixer)  -  so native conferencing needs that first, and this issue may be blocked on it. Worth checking before scoping.
+4. **Should `js/publish` set explicit defaults** rather than inheriting browser behavior? Probably yes for `echoCancellation`  -  silently depending on a browser default that Safari reports differently is a bug waiting to happen. Cheap and separable from all of the above.
+5. Platform AEC is an alternative worth pricing: macOS/iOS `kAUVoiceIOProperty_*` (Voice Processing I/O), Windows `AEC` DMO, Android `AcousticEchoCanceler`. Better quality than anything we'd write, no C++ dep, but three platform backends and cpal doesn't expose them  -  it'd mean bypassing cpal on those paths, mirroring how `moq-video/src/capture/` uses platform APIs directly.
+
+Option 5 is arguably the most in keeping with how `moq-video` already does capture/encode (platform-native backends, software fallback), and it dodges the C++ dependency entirely. It's also the most work.
+
+#### Branch
+
+`main`  -  additive (new feature flag / new module / new crate).
+
+#### Cross-package sync
+
+`rs/moq-audio` → `doc/`; if it reaches the FFI surface, the `moq-ffi` row (`rs/libmoq`, `{py,swift,kt}/`, `go/wrapper/moq/*.go`, `doc/lib/{py,swift,kt,go,c}`). The `js/publish` default-constraints piece is independent.
+
+## Closes
+
+- [#2282](https://github.com/moq-dev/moq/issues/2282) - close this issue when the quest finishes

--- a/quest/m0/2284-moq-net-keyframe-request-pli-equivalent-for-fast-tune-in.md
+++ b/quest/m0/2284-moq-net-keyframe-request-pli-equivalent-for-fast-tune-in.md
@@ -1,0 +1,99 @@
+# [L] moq-net: keyframe request (PLI equivalent) for fast tune-in
+
+## Goal
+
+Implement and verify the behavior tracked in [#2284](https://github.com/moq-dev/moq/issues/2284)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+A subscriber joining mid-stream waits up to a full GOP before it can decode anything  -  2 seconds by default. WebRTC solves this with a PLI: the receiver asks the sender for an IDR and gets one in ~1 RTT. MoQ has no upstream signal for it, so the only lever is a shorter GOP, which costs bitrate for every viewer to benefit the occasional joiner.
+
+This matters most exactly where MoQ wants to win: conferencing, and any direct publisher→subscriber path with no relay cache in between.
+
+**The encoder half is already done and tested. Only the signaling is missing.**
+
+#### What exists today
+
+**Group boundary == keyframe is a protocol invariant**, enforced on the write path in both languages:
+
+- `rs/moq-mux/src/container/producer.rs:93`  -  a keyframe closes the open group and starts a new one; a non-keyframe with no open group is `MissingKeyframe` (`:109`).
+- `js/hang/src/container/legacy.ts:63`  -  same, `throw new Error("must start with a keyframe")`.
+- The invariant is load-bearing enough that the legacy wire format **doesn't even transmit the keyframe flag**  -  `legacy.ts:15` and `rs/moq-mux/src/codec/h264/export.rs:250` hardcode `keyframe: false` on decode and reconstruct it from group position (`export.rs:292`: "the Consumer treats the first frame of every group as keyframe by protocol invariant").
+
+So a new subscriber waits for the next group. `encode::Config::gop` defaults to `framerate * 2` (~2s) and its doc says it plainly (`rs/moq-video/src/encode/encoder.rs:65`): "Subscribers joining mid-stream wait at most this many frames before they can start decoding." JS `keyframeInterval` defaults to 2000ms.
+
+**Forcing an IDR works on every backend, today:**
+
+```rust
+// rs/moq-video/src/encode/encoder.rs
+pub fn encode_rgba(&mut self, rgba, width, height, keyframe: bool) -> Result<Vec<Bytes>, Error>   // :155
+pub fn encode_i420(&mut self, data, width, height, keyframe: bool) -> ...                          // :189
+pub fn encode(&mut self, frame: &crate::decode::Frame, keyframe: bool) -> ...                      // :215
+// rs/moq-video/src/encode/backend/mod.rs:40
+fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error>;
+```
+
+`encode_rgba`'s doc even names this use case: "Set `keyframe` to force an IDR (e.g. on resume so a re-subscribing viewer can start decoding at once)."
+
+Backends: NVENC uses the `FORCEIDR` picture flag (`backend/nvenc.rs:168`)  -  deliberately not `pictureType`, since `enablePTD` makes NVENC ignore that  -  with `repeatSPSPPS` so every IDR carries in-band parameter sets; openh264 `:46`; VAAPI `:59`; VideoToolbox and MediaFoundation the same flag. Tested: `nvenc_h264_keyframes_carry_param_sets`, `nvenc_h265_keyframes_carry_param_sets`, `nvenc_h264_periodic_idr_at_gop`.
+
+`publish_capture` (`rs/moq-video/src/encode/producer.rs:147`) forces a keyframe on the first frame only and otherwise rides the backend's GOP cadence.
+
+JS: `js/publish/src/video/encoder.ts:216` already calls `encoder.encode(frame, { keyFrame })`, but `lastKeyframe` is a closure-local `let` inside `#encode` with **no external trigger**. `Config.keyframeInterval` is cadence, not on-demand.
+
+**There is no upstream request channel.** `ControlType` (`rs/moq-net/src/lite/stream.rs:9`) is fixed: `Session`, `Announce`, `Subscribe`, `Fetch`, `Probe`, `Goaway`, `Track`. The only subscriber→publisher feedback is **PROBE** (`rs/moq-net/src/lite/probe.rs:10`):
+
+```rust
+pub struct Probe { pub bitrate: u64, pub rtt: Option<u64> }
+```
+
+Two numeric fields, hard-wired to bandwidth/RTT, no extension point and no opaque payload. There is no seam for a subscriber request of any other kind.
+
+#### The counter-argument, which needs answering first
+
+**Behind a relay, the cache already solves this and does it better than a PLI.** The joiner doesn't need a *new* keyframe  -  the current group's keyframe is already in `cache::Pool`, and `fetch_group(latest)` retrieves it with no publisher involvement and no fan-out amplification. A relay serving 10k viewers must never forward 10k PLIs upstream; WebRTC SFUs spend real effort suppressing exactly this.
+
+So the honest scope is narrower than "MoQ needs PLI":
+
+- **Direct publisher↔subscriber** (conferencing, P2P-ish, no caching relay in path)  -  a PLI is straightforwardly correct here.
+- **Cold start at the origin**  -  first ever subscriber, nothing cached yet.
+- **Recovery** after a decoder error or an `Evicted` group.
+
+For the relay-fanout case the answer is probably "fetch the current group, don't ask for a keyframe". Worth confirming that `fetch_group(latest)` actually gives a joiner a decodable start today  -  if it does, that's the fix for the common case and it needs documenting rather than building.
+
+#### Proposed shape
+
+Assuming the direct case is worth serving:
+
+1. **An upstream request message.** Either a new `ControlType` variant or a field on the Subscribe stream. Prefer something **generic** over a PLI-specific message  -  the codebase has *no* seam for subscriber→publisher requests, and a keyframe request is unlikely to be the last one we want. But a generic escape hatch is also how protocols rot, so this needs a real decision, not a punt.
+2. **Relay policy**: coalesce/rate-limit, and prefer serving from cache over forwarding. A relay must never fan a PLI storm at an origin. This is the part that determines whether the feature is safe.
+3. **Rust**: a channel into the capture loop flipping the existing `keyframe` bool. No encoder work.
+4. **JS**: a Signal the encode effect reads instead of the closure-local `lastKeyframe`. Small.
+5. **Rate-limit at the publisher** too, independently of relays. A malicious or broken subscriber must not be able to pin the encoder at all-IDR.
+
+#### Open questions
+
+1. **Is the relay-cache path already sufficient for the common case?** If yes, scope this to direct sessions only and the priority drops a lot.
+2. **Generic feedback channel vs. a PLI-specific message.** Leaning generic-but-typed (an enum of request kinds, not an opaque blob), so the next one doesn't need another `ControlType`.
+3. **Does this deserve a wire slot at all**, versus just publishing shorter GOPs when a session is direct and interactive? A publisher that knows it's in a call could just use a 500ms GOP. Cheaper, no protocol change, worse steady-state efficiency.
+4. **Interaction with `moq-transcode`**, where output groups mirror source seq 1:1  -  a forced IDR mid-GOP breaks that alignment.
+5. **Alternative worth pricing**: a low-bitrate all-keyframe track for instant tune-in, then switch to the real rendition. Costs the publisher continuously instead of on demand, needs no protocol change, and composes with SVC.
+
+#### Branch
+
+`dev`  -  a new `ControlType` or a change to PROBE is a moq-lite wire change, needs a `Version` gate, and **must update `drafts/draft-lcurley-moq-lite.md` in the same PR**. The `moq-video`/`js/publish` trigger plumbing is additive and could land on `main` first behind an internal API.
+
+#### Cross-package sync
+
+`rs/moq-net` ↔ `js/net`; `rs/moq-video`, `js/publish`; `rs/moq-relay` (coalescing policy); `drafts/draft-lcurley-moq-lite.md`. Wire change → run `just test smoke-full`.
+
+## Closes
+
+- [#2284](https://github.com/moq-dev/moq/issues/2284) - close this issue when the quest finishes

--- a/quest/m0/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md
+++ b/quest/m0/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md
@@ -1,0 +1,112 @@
+# [L] moq-native: bring the quiche backend to quinn/noq feature parity
+
+## Goal
+
+Implement and verify the behavior tracked in [#2296](https://github.com/moq-dev/moq/issues/2296)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+Audit the quiche backend against the common quinn/noq behavior in `moq-native` and close the remaining gaps.
+
+Audited at `45217596f` with:
+
+- `web-transport-quiche` 0.4.2
+- `tokio-quiche` 0.19.1
+- `quiche` 0.29.3
+
+WebTransport over HTTP/3 already works. Raw QUIC also works now: `nix develop --command cargo test -p moq-native --all-features quiche_raw_quic -- --ignored --nocapture` passes, so its stale `#[ignore]` is now a coverage gap rather than a backend limitation.
+
+#### Missing parity
+
+##### Protocol coverage and lifecycle
+
+- \[ ] Remove the stale `#[ignore]` from `quiche_raw_quic` and keep raw `moqt://` / `moql://` in normal backend coverage.
+- \[ ] Make `Server::close` actually stop the quiche listener and close/drain active connections. `QuicheServer::close` is currently a no-op, while quinn/noq send an endpoint-wide close.
+
+##### TLS and certificates
+
+- \[ ] Support outbound mTLS with `--client-tls-cert` + `--client-tls-key`. The shared rustls config loads them, but the quiche connection path never passes them to `web_transport_quiche::ez::ClientBuilder::with_single_cert`.
+- \[ ] Support inbound optional mTLS with `--server-tls-root`, validate the client chain, and expose it through `Request::peer_identity`. The quiche server currently ignores the roots and always returns `None`.
+- \[ ] Support `--client-tls-host-name` by decoupling the dial target from TLS SNI/hostname verification. The current quiche builder uses one host for DNS and SNI, so initialization rejects the option.
+- \[ ] Match quinn/noq platform certificate verification, including mobile. The current quiche path snapshots `rustls-native-certs`; the in-tree comment notes that iOS/Android get no roots and fail closed, and it does not provide the same OS verifier behavior.
+- \[ ] Implement the complete `tls::Server` certificate semantics:
+
+  - load every configured cert/key pair instead of only index 0;
+  - include generated certificates alongside file-backed certificates instead of choosing one source;
+  - select the certificate by SNI;
+  - validate key/certificate matches up front;
+  - hot-reload file-backed certificates and update reported fingerprints.
+
+  `web-transport-quiche` now exposes `ServerBuilder::with_cert_resolver`, so SNI selection and reload can be integrated locally.
+- \[ ] Honor `SSLKEYLOGFILE` for quiche clients and servers, matching the rustls key logging installed by quinn/noq.
+
+##### QUIC transport controls and routing
+
+- \[ ] Honor `--client-quic-keep-alive` and `--server-quic-keep-alive`. They are currently ignored because the exposed quiche settings have no keep-alive interval.
+- \[ ] Allow `--client-quic-gso=false` and `--server-quic-gso=false`. Both currently fail initialization. Server-side capability selection may be possible with a custom `QuicListener`; the client builder currently enables maximum socket capabilities internally.
+- \[ ] Honor `--server-preferred-v4` / `--server-preferred-v6`. quiche still has TODOs for encoding/decoding the `preferred_address` transport parameter.
+- \[ ] Honor `--server-quic-lb-id` / `--server-quic-lb-nonce` with the same validation and connection-ID layout as quinn/noq. It is currently logged and ignored. `tokio-quiche::QuicListener` exposes a connection-ID generator, so this appears locally implementable.
+- \[ ] Use the shared dual-stack UDP binding behavior and address-family-aware DNS selection. The quiche builders currently bind through `std::net::UdpSocket` and select the first DNS result, bypassing `bind::udp` and `util::pick_addr`. This can regress `[::]` plus IPv4 connectivity, especially on Windows.
+
+#### Already at parity
+
+Do not duplicate work for behavior already wired up:
+
+- WebTransport over HTTP/3
+- raw QUIC functionality, after removing the stale test ignore
+- protocol-version ALPN negotiation
+- maximum bidi/uni stream counts
+- idle timeout
+- path MTU discovery
+- custom root certificates
+- explicit SHA-256 certificate pinning
+- `http://` fingerprint bootstrap
+- disabled certificate verification
+- terminal HTTP/auth rejection classification
+- connection/session statistics
+
+#### Suggested implementation split
+
+Likely local `moq-native` work with APIs already exposed:
+
+- raw-QUIC test coverage
+- outbound client certificates
+- dynamic SNI certificate resolver and hot reload
+- QUIC-LB CID generator
+- shared server socket binding
+- key logging
+
+Likely upstream `web-transport-quiche` / `tokio-quiche` / `quiche` work, or a local lower-level integration:
+
+- separate dial address and SNI hostname
+- server-side client-certificate verification and peer-chain access
+- full platform verifier support
+- preferred address
+- client-side GSO capability override
+- explicit listener/active-connection shutdown
+- keep-alive support
+
+#### Acceptance criteria
+
+- Every public `moq-native` option that quinn/noq share is either honored by quiche or rejected only for a documented upstream limitation.
+- Backend integration tests cover raw QUIC, WebTransport, mTLS/peer identity, hostname override, dual-stack binding, certificate selection/reload, and shutdown.
+- Quiche-only caveats can be removed from the public field docs once their corresponding checks pass.
+
+#### Related but not parity blockers
+
+- \#2276 is noq-only multipath, which quinn does not support.
+- \#686 tracks congestion control/BBR, where quinn and noq do not currently behave the same.
+- \#679 tracks multi-threaded UDP receive scaling, which is a reason to use quiche rather than a parity gap.
+
+## Closes
+
+- [#2296](https://github.com/moq-dev/moq/issues/2296) - close this issue when the quest finishes

--- a/quest/m0/2318-js-net-remaining-capability-gaps-vs-rs-moq-net-setup-role.md
+++ b/quest/m0/2318-js-net-remaining-capability-gaps-vs-rs-moq-net-setup-role.md
@@ -1,0 +1,29 @@
+# [M] js/net: remaining capability gaps vs rs/moq-net (SETUP role, finish_at and final sequence, range…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2318](https://github.com/moq-dev/moq/issues/2318)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Where js/net is a strict subset of the Rust model. The subscription-options model is tracked in #2155 and the announce Restart state in #2216; this covers the rest.
+
+- \[ ] **SETUP role parameter**: Rust encodes param 0x3 (Publisher/Subscriber/Both, derived from which origins the client wired up) and the draft documents it, but `js/net/src/lite/setup.ts` only implements probe and path. A JS client always presents as Both and a JS server cannot read a peer's role. `Established.publish/consume` usage can derive it just like Rust's `Role::from_origins`.
+- \[ ] **Track end semantics**: Rust distinguishes `finish()` (clean end at live edge), `finish_at(final_sequence)` (declare an end ahead of the live edge), and `abort(err)`, and consumers can await `finished() -> u64`. JS collapses everything into `close(abort?)`: no `finishAt`, and the SUBSCRIBE\_END group number is discarded on the consuming side, so the JS model cannot express or observe lite-05 clean-end semantics. (Interacts with the SUBSCRIBE\_END off-by-one bug, #2309, which should land first.)
+- \[ ] **Range/cursor controls**: `start_at`, `end_at`, `get_group` (wait for a live sequence), sync cache peek, and `latest()` have no JS equivalents. Some are relay-only and fine to omit, but `startAt`/`endAt` pair with the missing subscription range fields and a JS player implementing catch-up/DVR hits this wall.
+- \[ ] **Typed errors**: Rust has a `#[non_exhaustive]` enum with stable wire codes; JS throws bare `Error` with prose (only `CacheFull` is a class), so consumers string-match to distinguish `NotFound` from `Unauthorized`, and wire reset codes are not surfaced. At minimum add a stable `code` property before locking the API.
+- \[ ] **Delete the dead `SubscribeOptions` export** (`js/net/src/track.ts`): introduced by #2167, superseded by `Subscription` in #2170, identical field-for-field, referenced nowhere. Two exported names for one concept invites drift.
+- \[ ] **Frame field naming**: JS uses `payload` for `Datagram` but `data` for both Frame types, and `@moq/hang`'s container Frame is shaped differently from both `@moq/net`'s and Rust's. Pick `payload` consistently (JS `keyframe`/`duration` are genuine WebCodecs needs and fine as additive fields).
+
+Related: #2155, #2216, #2073.
+
+## Closes
+
+- [#2318](https://github.com/moq-dev/moq/issues/2318) - close this issue when the quest finishes

--- a/quest/m0/2388-safari-stops-delivering-new-incoming-unidirectional.md
+++ b/quest/m0/2388-safari-stops-delivering-new-incoming-unidirectional.md
@@ -1,0 +1,82 @@
+# [L] Safari stops delivering new incoming unidirectional streams after roughly 7000 on a session; one…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2388](https://github.com/moq-dev/moq/issues/2388)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+A Safari watcher permanently loses all media after roughly two minutes on a WebTransport session. The tile shows the recovering spinner forever, frame rate and byte counters freeze, and the RTT graph keeps updating. Every measured Safari session died after accepting roughly 6500 to 7200 incoming unidirectional streams, foreground or background. moq-lite delivers one group per unidirectional stream and audio is one group per 20 ms frame (50 streams per second, plus video groups), so that budget burns in about 1.5 to 2.5 minutes of playback. Nothing on the client or the relay reports an error, and nothing recovers short of a page reload.
+
+I first noticed it as "minimize the window and the stream dies shortly after restoring", but the foreground control below shows backgrounding only shifts the timing; a frontmost, never minimized, fully visible tab dies the same way.
+
+All measurements come from temporary local logging that I have since removed (an accepted-stream counter with a heartbeat in `js/net/src/lite/connection.ts` `#runUnis`, lifecycle event logging, and probe cadence logging), plus the relay's own debug log.
+
+#### Environment
+
+| | |
+|---|---|
+| branch | `dev` @ `c02796b4` |
+| browsers | Safari 26.5 (fails), Chrome 150 (control, no failure) |
+| OS | macOS (Darwin 25.5.0), Apple Silicon |
+| setup | `demo/web` + `demo/relay/localhost.toml`, relay debug logging |
+
+#### Steps to reproduce
+
+1. Start the relay and web demo, publish any live audio+video broadcast.
+2. Open `watch.html` in Safari and play the broadcast.
+3. Wait about two minutes. Media freezes for good while the page stays connected.
+
+The minimize variant (how I originally hit it): minimize the watch window for 90 s, restore. In my controlled run, `visibilitychange` fired to hidden on minimize (no `pagehide`), incoming stream delivery continued at the same ~50 per second rate all the way through the hidden window and across the restore, and the session died once the cumulative count reached the budget, which happened to land about 33 s after restoring. Minimizing does not even pause delivery on this Safari; it just moves where in the session the user is looking when the budget runs out, which is why it looks like a backgrounding bug at first.
+
+#### Observed
+
+Accepted incoming unidirectional streams at the permanent freeze, independent Safari sessions:
+
+| session | context | frozen accept count |
+|---|---|---|
+| controlled repro | minimized 90 s, died 33 s after restore | 7189 |
+| foreground control | frontmost and visible the whole time, died about 140 s in | 7069 |
+| long-lived tab A | mostly occluded | 6756 |
+| long-lived tab B | later hidden | 6474 (an earlier connection in the same tab reached 6853) |
+| long-lived tab C | still alive when measured | 5040 and counting |
+
+At the freeze in the controlled run, with the page foreground and `document.visibilityState === "visible"`:
+
+- The accepted-stream counter stopped advancing and the gap grew past 30 s, then forever. No JS error surfaced, `WebTransport.closed` never settled, no lifecycle event coincided with the freeze, and the `Connection` instance was unchanged (no reconnect happened).
+- The PROBE bidirectional stream (`js/net/src/lite/subscriber.ts` `runProbe`) kept delivering updates throughout and after. RTT had spiked intermittently up to 22 ms before the freeze against a ~1 ms baseline, and after the freeze it held elevated, climbing from 22 to 25 ms over the next 150 s; the reported bitrate estimate also changed character at the freeze, from noisy values spanning hundreds of Mbps to a smoothly declining 16.3 down to 14.4 Mbps.
+- The relay logged `serving group` attempts at a steady per-second cadence (127 to 158 per second across all active sessions) through and past the freeze, with zero warnings, errors, resets, or session terminations in the window. Note `serving group` is logged before the unidirectional stream open completes, so this shows the relay kept queueing groups without ever observing an error, not that the writes completed.
+
+The occluded variant: a watch tab left behind other windows for 44 minutes (macOS keeps occluded windows `visible`, and no `pagehide` or `visibilitychange` ever fired) accumulated six per-tile connections, each of which delivered for a while and then wedged at various totals while PROBE updates stayed seconds-fresh on the same connections. Refocusing the window never restored delivery on any of them.
+
+Chrome control: a headless Chrome watcher on the same relay and broadcast accepted 13026 unidirectional streams over 4.3 minutes and was still flowing at the end, so neither Chrome nor the relay has any such limit.
+
+#### Expected
+
+Media delivery continues for as long as the session is open and the relay is serving, on the order of hours, as it does on Chrome.
+
+#### What rules the alternatives out
+
+- Not backgrounding as the cause: the foreground control died at 7069 accepted streams without ever being hidden, minimized, or occluded. Backgrounding only pauses the accept loop (streams queue, then a catch-up burst on restore), which moves where in wall-clock time the budget runs out.
+- Not the page lifecycle handling in `js/net/src/connection/reload.ts`: no `pagehide` fired in any variant, the suspend flag never flipped, and no reconnect happened (same `Connection` instance across the freeze).
+- Not a relay-side cancel: the relay's log shows no resets, no errors, and uninterrupted serving attempts through the freeze; the same relay simultaneously fed the Chrome control past 13000 streams.
+- Not subscription state: the video tile's visibility gating unsubscribes and resubscribes as designed, and audio has no visibility gating at all; both die together at the freeze.
+
+#### Interpretation boundary
+
+The clustering of the freeze points around 6500 to 7200 accepted streams is consistent with the session's unidirectional stream credit (QUIC MAX\_STREAMS) being exhausted and not replenished by Safari, but I did not measure Safari's internal accounting. What is measured: the frozen accept counter at those totals, bidirectional traffic continuing on the same session, and an error-free relay.
+
+#### Why nothing self-heals today
+
+Stating the current shape, since it explains why the symptom is permanent: `js/net/src/lite/connection.ts` `#runUnis` awaits the incoming stream reader (`js/net/src/stream.ts` `Readers.next`) with no liveness cross-check against the still-flowing PROBE data; the `closed` promise of `js/net/src/connection/established.ts` `Established` only settles when the browser settles `WebTransport.closed`, which never happens here; and `js/net/src/connection/reload.ts` `#connect` re-runs only when its tracked signals change (a failed connect attempt, the suspend flag, the URL), none of which fire in this state. The client has no signal today from which it could detect the condition.
+
+## Closes
+
+- [#2388](https://github.com/moq-dev/moq/issues/2388) - close this issue when the quest finishes

--- a/quest/m0/2401-publisher-tab-reload-strands-watchers-on-the-stale.md
+++ b/quest/m0/2401-publisher-tab-reload-strands-watchers-on-the-stale.md
@@ -1,0 +1,179 @@
+# [L] Publisher tab reload strands watchers on the stale broadcast: ROUTE_LINGER (5s) expires before a…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2401](https://github.com/moq-dev/moq/issues/2401)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+### Publisher reload strands watchers: the 5s ROUTE\_LINGER expires before a real re-publish reconnects, forcing a full watcher teardown/rebuild (plus a missing `ended` UNANNOUNCE on close)
+
+#### Summary
+
+Reloading a publisher tab mid-broadcast and immediately re-publishing under the same name leaves watchers frozen on "recovering" for several seconds to ~15s before the stream resumes. Reloading the *watcher* recovers almost instantly.
+
+The stall is a timing interaction between two layers, confirmed on the wire:
+
+1. When a publisher's session drops, the relay treats it as a *dying session* (a non-graceful route detach) and holds the broadcast for `ROUTE_LINGER` (5s), serving from cache so a reconnecting session can resume transparently. During that window the watcher's tracks stall (no active route producing frames).
+2. If the re-publish re-attaches within 5s, the watcher resumes transparently (no visible offline, ~5s of stall). If reconnect takes longer than 5s (a real 1080p60 camera re-acquire + H.264 encoder warmup + first keyframe easily does), the linger expires, the broadcast **unannounces**, and the watcher performs a full teardown and rebuild of the whole subscription chain, then re-subscribes when the publisher returns. That teardown/rebuild is the ~15s the user sees.
+
+A distinct but related correctness gap sits underneath this: `Publisher.close()` (and the IETF publisher) never emit the `ended`/`endedId` ANNOUNCE retraction that the incremental-removal path already emits, so the relay can *only* learn a publisher stopped via transport-close/timeout detection, never via an application-level unannounce.
+
+#### Environment
+
+- moq-lite, ALPN `moq-lite-05`, local `moq-relay` (default `ROUTE_LINGER` 5s, `DEFAULT_IDLE_TIMEOUT` 30s, `DEFAULT_KEEP_ALIVE` 5s).
+- Reproduced manually across Safari->Chrome, Chrome->Safari, Chrome->Firefox (four reproductions). Both WebTransport and the qmux/WebSocket fallback are affected.
+
+#### Steps to reproduce
+
+1. Publish a broadcast (`me.hang`) from browser A; watch it from browser B. Confirm the watcher is live.
+2. Reload browser A's publisher tab and let it re-publish the same name.
+3. The watcher shows "recovering" (stalled, 0 fps / 0 kbps) for several seconds to ~15s before resuming.
+4. Contrast: reloading the *watcher* recovers near-instantly (a fresh subscriber attaches to the still-live producer and gets the next keyframe).
+
+The manual Firefox-watcher console for step 2 shows the tell: after the reload the watcher churns a video resubscribe, then
+
+```
+subscribe close: id=4 broadcast=me.hang track=video
+announced: broadcast=me.hang active=false          <- broadcast retracted (linger expired)
+subscribe close: id=0 broadcast=me.hang track=catalog.json
+subscribe close: id=2 broadcast=me.hang track=audio
+subscribe close: id=1 broadcast=me.hang track=meta.json
+```
+
+i.e. the whole subscription is torn down (`active=false`), then re-announced and re-subscribed from scratch.
+
+#### Mechanism
+
+##### 1. Publisher teardown never sends `ended` (`js/net`)
+
+`js/net/src/lite/publisher.ts` `runAnnounce()` keeps the announce stream current by diffing the broadcast map. Removing a *single* broadcast correctly retracts it:
+
+```ts
+// active.difference(newActive): removed broadcasts
+if (hasAnnounceId(this.version)) {
+    await encodeAnnounceBroadcast(stream.writer, { status: "endedId", id }, this.version);
+} else {
+    await encodeAnnounceBroadcast(stream.writer, { status: "ended", suffix: removed }, this.version);
+}
+```
+
+But `Publisher.close()` bypasses that diff, setting the whole map to `undefined`:
+
+```ts
+close() {
+    this.#broadcasts.update((broadcasts) => {
+        for (const broadcast of broadcasts?.values() ?? []) broadcast.close();
+        return undefined;
+    });
+    ...
+}
+```
+
+and the `runAnnounce()` loop just exits on that transition, writing nothing:
+
+```ts
+const broadcasts = await Promise.race([changed, stream.reader.closed]);
+if (!broadcasts) break; // no ended/endedId is ever written for the active broadcasts
+```
+
+`js/net/src/ietf/publisher.ts` has no `close()` at all; `js/net/src/ietf/connection.ts` `Connection.close()` only tears down the transport. `js/net/src/connection/reload.ts` is what invokes this on a reload: `pagehide`/`unload` -> `#suspended` -> the connect effect's cleanup -> `connection.close()` -> `Publisher.close()`. The transport close it then attempts is fire-and-forget and races page teardown, so even that is not guaranteed to arrive.
+
+##### 2. The relay treats the drop as non-graceful and lingers 5s (`rs/moq-net/src/model/origin.rs`)
+
+A publisher session feeds a broadcast through a `Route` (`Producer::attach_route` / `join_front`). Route teardown distinguishes a deliberate retraction from a dying session via a `graceful` flag:
+
+```rust
+// detach_route:
+if graceful && s.routes.is_empty() && !s.closed {
+    // Deliberate end: close now (synchronous unannounce, no linger).
+    s.closed = true;
+    close = true;
+} else {
+    // Dying session: requeue its tracks; the front lingers.
+    for (name, entry) in s.served.iter_mut() { ... }
+}
+```
+
+`graceful` is only set by `Route::unannounce()`, which is called when the peer *deliberately* retracts the path (sends an `ended`). The `Drop` impl uses `graceful = false`:
+
+```rust
+impl Drop for Route {
+    fn drop(&mut self) { detach_route(&self.state, &self.broadcast, self.id, self.graceful); }
+}
+```
+
+Because the publisher never sends `ended` (part 1), the reloaded publisher's `Route` always drops with `graceful = false`, so the broadcast takes the linger path: `run_front_janitor` holds it for `ROUTE_LINGER` (`const ROUTE_LINGER: Duration = Duration::from_secs(5)`) before unannouncing, serving from cache in the meantime.
+
+##### 3. Two regimes
+
+`join_front` re-attaches a re-publish to the *existing* front only while it is still live (`if s.closed { return None }`):
+
+- **Reconnect within 5s (fast regime):** the new session joins the lingering front as a new route, `reselect()` promotes it, and its tracks resume at the first missing group. The watcher never sees `active=false`; recovery is just the new publisher's startup-to-first-keyframe.
+- **Reconnect after 5s (slow regime):** the linger expires, the front closes, the broadcast unannounces. The watcher tears down its whole chain (broadcast consumer -> catalog -> video/audio decoders -> track subscribers). The subsequent re-publish is a *fresh* broadcast, so the watcher re-subscribes from scratch (fresh catalog snapshot, re-run `VideoDecoder.isConfigSupported` per rendition in `js/watch/src/video/source.ts`, new SUBSCRIBE handshake, wait for a keyframe). This is the ~15s path.
+
+#### Evidence
+
+Instrumented relay (`RUST_LOG=info,moq_net=debug`), headless drivers (publisher on Chrome via CDP or Firefox via Marionette; watcher on the other), fake capture devices. Numbers are from the harness, not hand-waved.
+
+**Fast regime (reload, reconnect ~1s).** Chrome publisher reload, Firefox watcher. Relay reaped the old session in 7ms; watcher `status` stayed `live` throughout (transparent resume); recovery 4.8s (fake-media startup):
+
+```
+23:10:40.362  driver: reload publisher
+23:10:40.369  WARN moq_relay: connection closed err=... closed: code=0 reason=
+23:10:40.369  INFO moq_net::lite::session: session terminated
+23:10:40.463  DEBUG moq_net::lite::publisher: reannounce broadcast=me.hang
+```
+
+The relay learns the broadcast is gone from `connection closed`, never from an `ended` message.
+
+**Slow regime (crash, republish deferred to 8s to cross the linger).** Watcher timeline (t = crash):
+
+```
+t+0.6s  status=live     stalled=true   frames frozen
+t+5.3s  status=offline  stalled=true   frames frozen   <- ROUTE_LINGER expired, broadcast unannounced
+t+8.3s  status=live     stalled=false  frames resume    <- republish; full re-subscribe
+recovery at +8.7s
+```
+
+The offline at +5.3s is the 5s linger; everything after is the teardown -> re-announce -> re-subscribe path. With a real camera whose reconnect exceeds 5s, recovery lands closer to the reported ~15s.
+
+**Dying session detected promptly, but still served for the linger.** SIGKILL of a publisher (OS sends TCP RST, so detection is prompt) still stranded the watcher for the full linger with zero frames delivered:
+
+```
+23:20:46.030  driver: kill publisher
+23:20:46.069  INFO moq_net::lite::session: session terminated   (+39ms)
+... watcher status "live", videoFrames frozen ...
+watcher offline at +5.3s; 0 frames delivered in the window
+```
+
+This isolates the linger: the relay knew the publisher was gone at +39ms, yet served the stale broadcast until +5.3s, because the drop was non-graceful. A deliberate `ended` (graceful) would have retracted it immediately.
+
+**Baseline / why headless understates the symptom.** Across all clean-disconnect configs (both transports, publisher or watcher, fake media), recovery is ~5s and the watcher-reload case is near-instant. Headless browsers always emit *some* close (a WebTransport `code=0`, or a TCP RST on process death) that the relay catches within milliseconds, so automation lands in the fast regime; the full ~15s needs reconnect to exceed the linger, which real capture (camera re-acquire + encoder warmup + keyframe) does but fake devices do not.
+
+#### Contributing watcher-side cost (`js/watch`)
+
+When the broadcast flaps `active=false` -> `active=true` (slow regime), `js/watch/src/broadcast.ts` `#runBroadcast` does a hard teardown and rebuild with no debounce, and `js/watch/src/video/source.ts` `#runSupported` re-runs `VideoDecoder.isConfigSupported` sequentially for every rendition on the new catalog. There is no incremental resume path, so the rebuild cost is paid in full each time.
+
+#### Secondary defect (likely separate ticket)
+
+`js/watch/src/sync.ts`: the shared `Sync.reference` is reset only on an in-track discontinuity (`DecoderTrack.#onDiscontinuity`), never on a broadcast-level teardown/rebuild. After a reload the new stream re-zeros its timestamps (`js/publish/src/video/polyfill.ts`), so frames are compared against a stale anchor and logged as `sync[video]: N late frame(s), max Xms behind` (visible in the manual repro logs). This corrupts the jitter readout during exactly the recovery window.
+
+#### Related defect (deliberate stop, distinct from reload)
+
+The missing `ended` UNANNOUNCE (part 1) has its own clear cost in the *non-reload* case: when a publisher deliberately stops (closes the tab, navigates away) and does **not** come back, the relay still lingers 5s serving the dead broadcast before retracting, instead of unannouncing immediately, because it never received a graceful `ended`. The SIGKILL evidence above is exactly this case.
+
+#### Scope
+
+Diagnosis only; no fix proposed. The load-bearing observations are: (a) the publisher's `close()` path drops the `ended` retraction its own incremental path already knows how to send; (b) every publisher disconnect is therefore treated as non-graceful, taking the 5s `ROUTE_LINGER` path; and (c) when a real re-publish exceeds that window the watcher does a full teardown/rebuild, which is the dominant cost in the reported stall.
+
+## Closes
+
+- [#2401](https://github.com/moq-dev/moq/issues/2401) - close this issue when the quest finishes

--- a/quest/m0/2405-js-net-connect-logs-on-every-connection-at-the-wrong.md
+++ b/quest/m0/2405-js-net-connect-logs-on-every-connection-at-the-wrong.md
@@ -1,0 +1,64 @@
+# [M] js/net: connect() logs on every connection at the wrong level and prints the JWT in the URL
+
+## Goal
+
+Implement and verify the behavior tracked in [#2405](https://github.com/moq-dev/moq/issues/2405)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+When embedding `@moq/net` in an application, every connection prints an unsolicited line to the browser console:
+
+```
+https://relay.example/path?jwt=<token>  connected via WebTransport
+```
+
+For a library consumer shipping MoQ inside a production app this reads as noise to their end users, and there is currently no way to silence it. Two smaller problems compound it:
+
+1. **The log level does not match its siblings.** The successful-connect line is `console.log` and the WebSocket-fallback line is `console.warn`, while the adjacent ALPN/SETUP diagnostics are already `console.debug`. So these two lines are the only connect diagnostics that surface at the default console level.
+2. **It prints the auth token.** The logged value is `url.toString()`, which includes the `?jwt=<token>` query parameter, so a live credential lands in the console (and in anything that captures console output) on every connect.
+
+#### Location
+
+`js/net/src/connection/connect.ts`, in `connect()` right after the transport race resolves:
+
+```ts
+if (session instanceof Session) {
+    console.warn(url.toString(), "connected via WebSocket");
+    websocketWon.add(url.toString());
+} else {
+    console.log(url.toString(), "connected via WebTransport");
+}
+```
+
+#### Impact
+
+- Consumers embedding MoQ see library log lines in their app console with no opt-out.
+- The relay URL is logged verbatim, exposing the JWT in the console and any log sink.
+
+#### Suggested direction (maintainer's call)
+
+The core ask: a consumer running a production build should not see this line at all.
+
+- **Gate the connect logs on dev vs production**, so they print only in development and are silent in prod builds. There is already a precedent to reuse: `js/signals/src/index.ts` defines
+
+  ```ts
+  const DEV = typeof import.meta.env !== "undefined" && import.meta.env?.MODE !== "production";
+  ```
+
+  and gates its leak-detection warnings on it. These connect logs (and the sibling ALPN/SETUP lines) could sit behind the same `DEV` check. Optionally also drop the level to `console.debug` so even in dev they stay out of the default console view.
+- **Redact the URL** wherever a relay URL is logged: log `url.origin + url.pathname` (dropping `search`) so the `?jwt=` token is never printed, in any mode. This applies to the other `console.*(url...)` sites in `connect.ts` and `reload.ts` too.
+
+A fuller future option (not required here) would be an opt-in `logging`/`verbose` flag on `ConnectProps` (which `ReloadProps` already extends) so consumers who want library logs in production can turn them back on. The two changes above are enough to fix the reported behavior.
+
+## Closes
+
+- [#2405](https://github.com/moq-dev/moq/issues/2405) - close this issue when the quest finishes

--- a/quest/m0/2481-merge-iroh-lives-native-media-stack-into-moq-video-moq.md
+++ b/quest/m0/2481-merge-iroh-lives-native-media-stack-into-moq-video-moq.md
@@ -1,0 +1,111 @@
+# [XL] Merge iroh-live's native media stack into moq-video/moq-audio (upstreaming plan)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2481](https://github.com/moq-dev/moq/issues/2481)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+n0-computer is winding down maintenance of [iroh-live](https://github.com/n0-computer/iroh-live) and has offered its native media stack upstream. Their side produced a detailed upstreaming plan ([overview](https://github.com/n0-computer/iroh-live/blob/plan-upstream/plans/upstream/overview.md), [comparison matrix](https://github.com/n0-computer/iroh-live/blob/plan-upstream/plans/upstream/comparison.md), [zero-copy analysis](https://github.com/n0-computer/iroh-live/blob/plan-upstream/plans/upstream/zerocopy.md)). This issue is an independent audit of that plan against moq's API principles, and the tracking plan for the moq side. The goal is a merge that lands as moq-shaped primitives, not a copy/paste of a parallel stack.
+
+Companion to #1837 (this plan lands several of its open boxes). The end state: iroh-live deletes its parallel media layer (`rusty-codecs`, `rusty-capture`, `moq-media` device/render code) and consumes `moq-video`/`moq-audio`; moq gains the capabilities below.
+
+#### What we gain
+
+Audited against their tree; the assets with no moq counterpart or a strictly weaker one:
+
+- **The only decode-to-render GPU path in either codebase**: a renderer with zero-copy surface import on three platforms and two graphics APIs (Vulkan DMA-BUF import incl. an Intel Y\_TILED re-tile blit, EGL/GLES DMA-BUF import, Metal `CVMetalTextureCache` aliasing), with a per-path fallback to CPU I420 and a three-strike path disable. ~3.5k LOC of the hardest hardware-specific code in either tree. This is the back half of the zero-copy story #1837 describes (we have ingest, they have egress).
+- **VAAPI, validated**: a DMA-BUF-importing H.264 encoder with VPP scale/convert, validated on Intel Meteor Lake (our `encode/backend/vaapi.rs` is a 111-line CPU-only adapter whose own header says it is not validated on hardware), plus a full VAAPI stateless decoder with PRIME export. We have no VAAPI decode at all.
+- **V4L2 M2M encode/decode**: the stateful hardware codec path for Pi/embedded. We have nothing there.
+- **PipeWire DMA-BUF capture**: our PipeWire screen capture is CPU-only; theirs negotiates DMA-BUF and feeds VAAPI without a download.
+- **Full-duplex audio**: a playback sink (device output, mixing, declicker fades, device switching, restart-with-backoff) and acoustic echo cancellation via `sonora` (a pure-Rust WebRTC audio-processing port on crates.io). This resolves the two blockers in #2282: moq-audio has no playback path, and we believed no pure-Rust AEC existed. Tracked in #2478.
+- **Opus control-surface deltas** (runtime bitrate, correct OpusHead pre-skip, FEC/DTX plumbing) and a **PCM codec** for latency isolation. The pre-skip item is a real RFC 7845 conformance bug on our side. Tracked in #2480.
+- Their comparison also surfaced a realtime-thread bug in our audio capture (unbounded channel from the cpal callback). Tracked in #2479.
+
+Everything else in their matrix resolves to "use moq's, delete theirs" (openh264, VideoToolbox encode, macOS/Windows capture, dispatch, Annex-B tooling, resampler, nokhwa/xcap fallbacks). Those are deletions on their side; nothing lands here.
+
+#### Where the two plans independently agree
+
+> **Update 2026-07-24**: #2467 merged and landed the surface-handle base with a different (better) shape than either sketch below: the internal frame enum is now the public `#[non_exhaustive]` `Surface` enum (`PixelBuffer` on macOS, `Texture` on Windows, `Cuda` on Linux, `I420` everywhere), `decode::Frame.surface` is a public field, and the exits are total consuming conversions (`Surface::into_i420()` always; `Surface::into_pixel_buffer()` on macOS, a retain for a GPU frame and an upload for a CPU one) rather than a partial `native() -> Option<_>` borrow. There is no separate `Native` vocabulary and no newtype veil: the objc2 coupling is opt-in-by-use and documented via version re-exports. VideoToolbox decode also stays GPU-resident (the macOS half of the retention item below). The checklists below are updated to the as-landed shape; new zero-copy work should extend `Surface` (new cfg-gated variants, new total conversions), not introduce a parallel handle enum.
+
+Their proposed base API is close to what #1837 already asks for, which is a good sign it is the right shape:
+
+- Their `Native` handle vocabulary is #1837's "public, platform-tagged surface handle" item. Landed in #2467 as the public `Surface` enum (see update above). Their refinement that still carries: mint-on-access `DmaBuf::export()` (an fd per buffered frame would exhaust the descriptor table) and a `dmabuf` cargo feature enabled by `vaapi`/`pipewire`, for the future `Surface::DmaBuf` variant.
+- Their `decode::Frame::native() -> Option<Native>` is #1837's "get the GPU handle out"; superseded by the public `decode::Frame.surface` field + total conversions, with `into_i420()` as the universal CPU fallback.
+- Their VideoToolbox/Media Foundation decode-surface retention is #1837's "make decoded frames stay on the GPU first", verbatim.
+- Their adaptation conventions (no ffmpeg, dlopen system libraries, crates.io only, `moq_net::Timestamp` at boundaries, hang catalog types, honest `set_bitrate`, `#[non_exhaustive]` configs) are our own house rules reflected back. Nothing to negotiate.
+
+One genuinely new base item we accept: **timestamps through encode**. `Backend::encode` gains a `timestamp` argument and returns `Vec<Packet>` where `Packet { payload: Bytes, timestamp: Timestamp }` (`#[non_exhaustive]`). Today the capture loop stamps every returned AU with the submission-time clock, which is only correct for zero-frame-delay backends; a queued M2M device (V4L2, MediaCodec) drains frame N-k while you submit frame N. This also makes encode symmetric with decode (`Decoded` already carries a per-picture timestamp) and lets `finish()` drain a stamped tail, which per-group transcode wants anyway. All five current backends echo the input timestamp, so behavior is unchanged until a pipelined backend lands.
+
+#### Where we deviate from their plan
+
+These are the rulings that keep the merge from importing shapes we would have to live with:
+
+1. **No backend registration API** (their B4: public `Backend` traits + `register_encoder`/`register_decoder` over a global `Mutex<Vec<Registration>>` of fn pointers). Rejected. The backend set is deliberately closed and `pub(crate)`; a public implementable trait freezes `Frame`/`Packet`/`Kind` interactions into semver surface for exactly one prospective consumer, and a process-global mutable registry is the callback-flavored indirection we keep out of this codebase. Android MediaCodec goes **in-tree** behind `cfg(target_os = "android")`, exactly like the objc2 and windows backend families. The NDK is a build-graph concern, not an API concern.
+2. **The renderer is a `render` role module in moq-video, not a `moq-video-render` sibling crate.** #1837 already takes this position: `capture`/`encode`/`decode`/`render` are symmetric roles and the crate owns the platform-native layer on both ends. Heavy deps (`wgpu`, `ash`, `glow`, EGL) sit behind non-default features (`render`, `render-gles`), the same pattern as `nvenc`/`vaapi`/`pipewire`, so default and relay builds stay graphics-free. Port their importers (the hardware knowledge) but reshape the surface: a `render::Config` options bag, a small renderer type that consumes `decode::Frame` and yields a texture the caller presents, errors in moq-video's `Error`. The public `Native` accessor keeps the door open for anyone who wants an out-of-tree renderer instead.
+3. **No `moq-egui` crate.** The renderer's texture-out seam (their `render_cached`) is the integration point for egui/bevy/dioxus; a published egui widget crate signs us up for egui's breaking-release cadence forever. An egui example can live under `demo/` or stay with iroh-live/community.
+4. **No bespoke `publish_preencoded` API for libcamera.** A pre-encoded source composes with what exists: `encode::Producer::publish(Vec<Bytes>, Timestamp)` is already the bring-your-own-Annex-B path, and `moq_mux::codec::h264::{Split, Import}` already handle framing. The rpicam-vid subprocess source is useful (Pi Zero hardware encode) but shelling out is an application concern; open question whether it lands as a feature-gated moq-video source or in moq-cli. Wave 3 either way.
+5. **PCM needs the spec, not just the code.** Their plan adds a PCM variant to the codec enum and the hang catalog but does not mention the draft. A catalog codec addition updates `hang` + `js/hang` + `draft-lcurley-moq-hang.md` in the same PR per the cross-package sync rule.
+6. **AV1 software codecs stay out** (their own verdict too): rav1e is too slow for real-time and rav1d is a git-fork dep. Matches the existing #1837 constraint. NVDEC AV1 decode already covers the hardware side.
+7. **X11 MIT-SHM capture is optional.** Portal/PipeWire covers modern desktops; take it last or not at all.
+
+#### Waves
+
+> **Update 2026-08-12**: The software and Windows work that was open in the July snapshot has landed: the renderer's wgpu/Metal/CPU half (#2552), playback (#2529), AEC (#2538, closing #2478), Media Foundation GPU decode retention (#2584), D3D11 GPU resize (#2601), and the crate documentation gate (#2567). The remaining campaign is now the Linux/embedded hardware chain. #2819 is the active leaf issue for the first producer-to-consumer slice: a safe `Surface::DmaBuf` contract, PipeWire buffer retention, and Vulkan import. Its hardware boxes stay open until an Intel/AMD Linux machine validates them.
+>
+> **Update 2026-07-27**: Wave 0 is done and Wave 2 is most of the way there. Landed since the last update: timestamps through encode (#2503), hardware resize for decoded pixel buffers (#2512, closing #2489), Opus pre-skip and encoder controls (#2492, closing #2480), the bounded realtime capture queue (#2487, closing #2479), and the PCM codec end to end including `js/hang` and the draft (#2493). The encode timestamp seam landed with a better shape than sketched: the timestamp rides on `Frame`, so the trait is `encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Encoded>, Error>` with no separate argument, and the output type is `Encoded { timestamp, payload }` rather than `Packet`. What is left on this list is now hardware-gated (DMA-BUF, VAAPI, PipeWire, V4L2, Media Foundation) plus the two pure-software items that unblock the native player #2272: the renderer and audio playback.
+
+Wave 0, the base API (moq-video, one small series): **done except the two items whose consumers have not landed yet.**
+
+- \[x] Public surface handles: landed in #2467 as the public `#[non_exhaustive]` `Surface` enum with `decode::Frame.surface` public, total `into_i420()` / `into_pixel_buffer()` conversions, and a validating public `I420::new`. (Replaced the `Native` vocabulary + `native()` accessor sketched originally; see the update note above.)
+- \[ ] `Surface::DmaBuf` variant + a DmaBuf payload type with descriptor accessors and mint-on-access `export() -> OwnedFd`, behind a new `dmabuf` feature enabled by `vaapi`/`pipewire`. Prerequisite for VAAPI decode and PipeWire DMA-BUF capture. **Deliberately not landing ahead of them**: a `#[non_exhaustive]` variant with neither a producer nor a consumer is dead public API, so this lands in the same series as its first producer (VAAPI/PipeWire) and its first consumer (the Vulkan importer), hardware-validated together.
+- \[ ] Egress accessors for the other GPU variants as their consumers land: public surface access on `d3d11::Texture` (Windows render/re-encode) and `cuda::Frame` (Linux), hardware-validated when added.
+- \[x] Timestamps through encode: landed in #2503. The timestamp rides on `Frame` rather than a parallel argument, so the seam is `Backend::encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Encoded>, Error>` plus `finish() -> Result<Vec<Encoded>, Error>`, and the output type is `Encoded { timestamp, payload }` (`Packet` in the original sketch). The producer publishes per-access-unit timestamps, so a pipelined backend can drain frame N-k while frame N is submitted.
+- \[ ] Additive `Error` variants as needed (`SurfaceExport`, `DmaBufImport`). Rolls in with the DMA-BUF and renderer work that needs them.
+
+Wave 1, zero-copy egress (carries the campaign; nothing on their side is deleted until these land):
+
+- \[x] VideoToolbox decode retains the GPU surface (macOS): done in #2467, hardware-validated (residency + zero-copy re-encode tests). The hardware-resize follow-up landed too: #2512 resizes decoded `CVPixelBuffer`s via `VTPixelTransferSession`, closing #2489 and the N-downloads-per-frame transcode fanout #2467 documented.
+- \[x] Media Foundation decode retains its DXVA texture (Windows): #2584 keeps decoded frames GPU-resident and fixes group-boundary drain; #2601 adds D3D11 GPU resize. The renderer still has no Direct3D11 zero-copy import, so Windows presentation downloads today.
+- \[ ] `render` module in moq-video: wgpu backend + NV12/I420 color-matrix-aware shader, Metal import (consuming `Surface::into_pixel_buffer()` / the `PixelBuffer` borrow), Vulkan DMA-BUF import (incl. VPP re-tile), GLES/EGL import, per-path fallback + disable. Non-default features. The renderer matches on `decode::Frame.surface` and falls back to `into_i420()`. **The wgpu, shader, Metal, and CPU half landed in #2552.** The Vulkan + `Surface::DmaBuf` slice is active in #2819; EGL follows after the Vulkan hardware gates.
+- \[ ] VAAPI encode replaced with their validated DMA-BUF + VPP implementation; VAAPI decode added. Spine work in the external `moq-dev/vaapi` crate: restore dlopen (#1837), add the decode half, VPP wrapper, HEVC entrypoints.
+- \[ ] PipeWire capture negotiates DMA-BUF (multi-fourcc) with CPU fallback.
+
+Wave 2, audio + remaining codecs:
+
+- \[x] moq-audio playback + AEC (#2478): playback landed in #2529; the post-mix render tap and pure-Rust `sonora` AEC landed in #2538, closing #2478. The dependency requires `sonora` 0.2 or newer because 0.1 could panic when the adaptive filter shrank.
+- \[x] Bounded realtime capture channel: #2487, closing #2479.
+- \[x] Opus pre-skip + runtime bitrate + FEC/DTX: #2492, closing #2480. The RFC 7845 pre-skip conformance bug is fixed.
+- \[x] PCM codec in moq-audio + hang catalog variant + `draft-lcurley-moq-hang.md`: #2493, with `js/hang` and the draft's `audio-pcm` section in the same PR.
+- \[ ] V4L2 M2M encode + decode backends. The encode timestamp seam they need now exists (#2503); the remaining blocker is embedded hardware to validate on.
+
+Wave 3, conditional:
+
+- \[ ] Android MediaCodec encode/decode in-tree (`cfg(target_os = "android")`), a `HardwareBuffer` variant on `Surface`. Weigh against moq-kit per #1837's mobile section before starting.
+- \[ ] libcamera/Pi sources (raw + pre-encoded via the existing publish path).
+- \[ ] X11 capture (optional).
+
+Release/adoption gates:
+
+- \[ ] Ordinary moq-video/moq-audio releases after each wave so iroh-live can pin and delete per their staged plan (they follow proof-before-deletion on their side; our side just needs published crates).
+- \[x] `doc/` pages for moq-video and moq-audio: #2567 covers render, playback, AEC, backend selection, and the per-platform zero-copy matrix. `moq-ffi` exposure remains explicitly out of scope.
+- \[x] Nix dev shell reaches ALSA's default device: #2529. It only searched its own store path, which has no `pipewire`/`pulse` PCM plugin, so opening the default device failed with ENXIO and device tests had to be pointed at a raw `hw:` node by hand. Affects the existing `capture` tests as much as the new playback ones.
+
+#### Constraints carried over unchanged
+
+- Zero-copy is never regressed: the decode-surface retention and the renderer land before iroh-live deletes its decoders, or the only decode-to-render path dies in the transition.
+- Every hardware backend keeps the dlopen-and-degrade rule; hardware-gated tests ship with each backend (`#[ignore]` + reason where CI lacks the device).
+- Licensing is compatible (both repos are MIT OR Apache-2.0); `sonora` and the cros-codecs-derived VAAPI code get a license check before their PRs.
+
+Related: #1837, #2272 (the renderer + audio sink unblock the native player), #2282, #2321, #2147. Sub-issues: #2478, #2479, #2480, and #2489 are closed. Active Linux slice: #2819.
+
+## Closes
+
+- [#2481](https://github.com/moq-dev/moq/issues/2481) - close this issue when the quest finishes

--- a/quest/m0/2517-net-splice-route-and-connection-changes-within-an-active.md
+++ b/quest/m0/2517-net-splice-route-and-connection-changes-within-an-active.md
@@ -1,0 +1,53 @@
+# [M] net: splice route and connection changes within an active group
+
+## Goal
+
+Implement and verify the behavior tracked in [#2517](https://github.com/moq-dev/moq/issues/2517)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Connection migration from #2241 splices per-session tracks at group boundaries. `resume::Producer::takeover` starts the replacement segment one sequence after the newest group produced by the old route.
+
+That works for segmented media, but not for tracks whose current group can remain open indefinitely:
+
+- `moq-json::stream` intentionally carries the entire append log in one group.
+- `moq-json::snapshot`, including catalog tracks, keeps a snapshot group open while appending deltas. A quiet catalog may never roll to another group.
+
+If the serving route or connection disappears after part of such a group has been delivered, the logical subscriber cannot make progress until a later group appears. For a single-group JSON stream that later group never exists. For a catalog it may not appear for a long time. Route migration therefore is not transparent for these tracks.
+
+This is separate from discovering and selecting an alternate route (#2461). Even when a replacement route is available and selected, the current splice granularity prevents it from continuing an active long-lived group.
+
+#### Goal
+
+Allow a logical track to switch routes or connections within an active group, resuming at a frame boundary instead of waiting for the next group sequence.
+
+The model should preserve the logical group sequence and continue from the first missing frame without surfacing duplicate frames or a route-change error to the application. The design also needs to account for compressed catalog and JSON tracks, whose DEFLATE state spans frames within the group.
+
+#### Acceptance criteria
+
+- A route or connection can fail after frame N of group G, and an existing logical subscriber continues group G from a replacement route.
+- Frames already surfaced before the switch are not surfaced again.
+- `moq-json::stream` continues after migration even though the track uses one group for its lifetime.
+- Catalog snapshot/delta tracks continue after migration without waiting for the publisher to roll the group.
+- Compressed `.json.z` variants preserve decoder continuity or resume from an explicit safe point.
+- Add model-level regression coverage for a mid-group takeover and end-to-end coverage that drops the serving connection while consuming a long-lived JSON or catalog group.
+
+#### References
+
+- \#2241 introduced transparent connection migration with group-boundary splicing.
+- `rs/moq-net/src/model/resume.rs` owns the current group-segment splice.
+- `rs/moq-json/src/stream.rs` keeps the whole log in one group.
+- `rs/moq-json/src/snapshot.rs` keeps snapshot groups open for deltas.
+
+## Closes
+
+- [#2517](https://github.com/moq-dev/moq/issues/2517) - close this issue when the quest finishes

--- a/quest/m0/2527-publish-video-breaks-when-the-publishers-window-is.md
+++ b/quest/m0/2527-publish-video-breaks-when-the-publishers-window-is.md
@@ -1,0 +1,143 @@
+# [L] Publish video breaks when the publisher's window is minimized, on every browser using the…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2527](https://github.com/moq-dev/moq/issues/2527)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+`js/publish/src/video/polyfill.ts` produces frames by calling `requestVideoFrameCallback` on a detached `<video>` element and snapshotting it with `new VideoFrame(video, ...)`. That element stops being composited when the publisher's window is minimized, and video publishing breaks. Both browsers that take this path are affected, in two different ways:
+
+- **Safari 26.5**: rVFC keeps firing at ~30/s but the element is paused, so the polyfill emits ~30 **pixel identical duplicate frames per second**. The encoder runs at full rate and full bitrate, the relay forwards video groups at the normal rate, and the viewer never enters a stalled state. The viewer just sees a still image while audio continues. Nothing anywhere reports a problem.
+- **Firefox 152.0.6**: rVFC stops firing altogether, so capture starves. Encoded output drops to 0 fps, the relay forwards 0 video groups per second, and the viewer sits in the buffering state.
+
+Chrome is unaffected because it has native `MediaStreamTrackProcessor` and never touches a `<video>` element.
+
+Restoring the window recovers within about a second in all cases.
+
+#### Reproduce
+
+1. `just dev`
+2. Open `publish.html` in Safari (or Firefox), start the camera, open `watch.html` in a second window.
+3. Leave both windows fully visible and confirm video is live.
+4. Minimize the publish window.
+5. Safari: the viewer's picture freezes, audio keeps playing, and no buffering spinner appears. Firefox: the picture freezes and the buffering spinner does appear.
+6. Restore the publish window. Video resumes on its own.
+
+#### Environment
+
+| | |
+|---|---|
+| OS | macOS 26.5.1 (25F80), Apple Silicon (arm64) |
+| Safari | 26.5 |
+| Firefox | 152.0.6 |
+| Chrome | 150.0.7871.184 |
+| moq | `46f1de8d` on `dev` |
+| Relay | local `moq-relay` with `demo/relay/localhost.toml`, default `[::]:4443` |
+| Pages | `demo/web` on `http://localhost:5174`, publisher and viewer both local |
+| Transport | Safari and Firefox on WebSocket/qmux (WebTransport is disabled on Safari since #2417, and Firefox has none). Chrome on WebTransport. |
+| Camera | Lenovo FHD Webcam (UVC), capture requested at the 1280x720 default |
+| Encoder | all demo encoder settings left on "auto", so no explicit `frameRate` and the default 2s keyframe interval |
+
+Both publisher and viewer windows were fully visible and side by side before the minimize, so the viewer's own `intersecting && !document.hidden` gate was never a factor. The viewer reported `document.hidden === false` for every sample in every phase.
+
+#### Mechanism
+
+Neither Safari nor Firefox has `MediaStreamTrackProcessor`, so `TrackProcessor()` takes the fallback. Verified at runtime in both: `self.MediaStreamTrackProcessor` is `undefined`.
+
+The fallback creates a `<video>` that is never appended to the DOM, calls `play()` once in `start()`, and then in `pull()` awaits `video.requestVideoFrameCallback` and builds each frame as `new VideoFrame(video, ...)`. Two properties of that design are what break:
+
+1. Frame production is driven by a **compositor callback**, so it inherits whatever the browser does to a window that is not on screen.
+2. The pixel source is "whatever the element is currently presenting", and nothing verifies that it advanced.
+
+Measured behaviour while minimized:
+
+| | Safari 26.5 | Firefox 152.0.6 |
+|---|---|---|
+| rVFC calls/s | 29.9 (unchanged) | 0.0 |
+| `video.paused` | **true** | false |
+| `video.currentTime` rate | 0.0 | 0.0 |
+| `metadata.presentedFrames`/s | 30.3 (still advancing) | 0.0 |
+| result | 30 duplicate frames/s | no frames |
+
+Safari is the more dangerous case: it pauses the element but keeps invoking rVFC *and* keeps advancing `metadata.presentedFrames`, so the callback metadata claims new frames are being presented when they are not. `video.paused` and `video.currentTime` are the only fields that reflect reality.
+
+Downstream, nothing can detect the Safari case:
+
+- `js/publish/src/video/encoder.ts` paces on timestamps only, and only when an explicit `frameRate` is configured, so every duplicate gets encoded.
+- The encoder runs `latencyMode: "realtime"` against a target bitrate, so it spends the **full** bitrate on the static image. There is no bitrate drop to notice.
+- `js/hang/src/container/legacy.ts` cuts groups on the keyframe flag, which still fires on the normal 2s cadence, so the group rate is unchanged.
+- On the viewer, frames keep arriving, so `Video.Decoder`'s `out.stalled` never trips and `<moq-watch-ui>`'s buffering indicator never appears.
+
+The camera track stays `live` and unmuted throughout in every arm.
+
+#### Measurements
+
+Instrumented build sampling twice a second. "uniq" counts distinct 32x32 pixel checksums of the frames leaving capture (`Capture.out.frame`), "mad" is the mean absolute pixel difference between consecutive samples. Both are measured on the publisher, on the frames going **into** the encoder. Relay counts come from `serving group` lines sliced by byte offset per phase.
+
+##### Safari publisher, 120s minimized (viewer: Safari)
+
+| phase | samples | uniq | mad | encoded fps | encoded kbps | relay video groups/s | viewer stalled |
+|---|---|---|---|---|---|---|---|
+| baseline 30s | 60 | 60 | live | 30.3 | 1842 | 0.50 | false |
+| **minimized 119s** | 120 | **1** | **0.00** | **29.9** | **1835** | **0.49** | **false** |
+| restored 31s | 62 | 62 | live | 30.0 | 1822 | 0.52 | false |
+
+Content froze 0.8s after the minimize and resumed 0.8s after the restore. Across the frozen window the encoder produced **3,558 frames of one identical image**. Frame timestamps advanced normally throughout (1,000,269 microseconds per second of wall clock), so these are genuinely new frames carrying duplicate content, not a stalled signal. Audio groups stayed at 50/s in all three phases.
+
+Repeated with a **Chrome** viewer for 70s: identical publisher result (uniq 1, mad 0.00, 29.8 fps, 1839 kbps) and the Chrome viewer also never stalled, with `document.hidden === false` throughout. So this is not a Safari viewer problem.
+
+##### Firefox publisher, 60s minimized (viewer: Chrome)
+
+| phase | samples | uniq | mad | encoded fps | encoded kbps | relay video groups/s | viewer stalled |
+|---|---|---|---|---|---|---|---|
+| baseline 35s | 70 | 68 | 5.75 | 29.8 | 1905 | 0.51 | false |
+| **minimized 60s** | 119 | **1** | **0.00** | **0.0** | **0** | **0.00** | **true** |
+| restored 16s | 33 | 32 | 5.13 | 29.1 | 1861 | 0.50 | false |
+
+A second Firefox run showed the same shape with a few stragglers getting through (0.1 rVFC calls/s, 0.1 encoded fps, 5 kbps). Audio groups stayed at 50/s throughout, so only video is affected.
+
+Note the probe's own `setInterval` kept sampling at the full 2/s while minimized in Firefox, so the page's timers were not throttled. Only rVFC delivery stopped. (Safari did throttle the probe interval to 1/s, which does not affect the rates above since they are computed from counter deltas.)
+
+##### Control: Chrome publisher, same minimize (70s, viewer: Safari)
+
+Chrome takes the native `MediaStreamTrackProcessor` path (`hasNative === true`), so no `<video>` element is involved:
+
+| phase | samples | uniq | mad | encoded fps | document.hidden |
+|---|---|---|---|---|---|
+| baseline | 50 | 50 | 8.67 | 30.3 | false |
+| **minimized** | 70 | **70** | **8.32** | 30.3 | **true** |
+| restored | 52 | 52 | 8.32 | 30.3 | false |
+
+Same minimize, same measurement, content keeps changing. The only difference between the arms is which branch of `TrackProcessor()` is taken.
+
+#### Summary of arms
+
+| publisher | capture path | minimized: distinct frames | encoded fps | relay video groups/s | viewer stalled |
+|---|---|---|---|---|---|
+| Safari 26.5 | polyfill (`<video>` + rVFC) | 1 | 29.9 | 0.49 | false |
+| Firefox 152.0.6 | polyfill (`<video>` + rVFC) | 1 | 0.0 | 0.00 | true |
+| Chrome | native `MediaStreamTrackProcessor` | 70 of 70 | 30.3 | 0.51 | false |
+
+#### Notes
+
+Audio is unaffected in every arm because publish audio runs on an `AudioWorkletProcessor` (`js/publish/src/audio/capture-worklet.ts`) on the real time audio thread, which minimizing does not touch. That asymmetry is what makes the Safari case look like "video froze but the stream is fine".
+
+The Safari variant is invisible to every health signal the stack currently has: encoded frame count, encoded bitrate, group rate, relay throughput, and viewer stall state all look completely normal. The only way we could detect it was by checksumming the pixels entering the encoder.
+
+There is arguably also a WebKit bug in reporting `metadata.presentedFrames` as advancing for a paused element whose `currentTime` is frozen, which rules out `presentedFrames` as a way to detect the condition.
+
+Raw beacon files, relay logs, and the analysis scripts for all five runs are available if useful.
+
+## Closes
+
+- [#2527](https://github.com/moq-dev/moq/issues/2527) - close this issue when the quest finishes

--- a/quest/m0/2532-publish-files-by-demuxing-and-decoding-them-not-by.md
+++ b/quest/m0/2532-publish-files-by-demuxing-and-decoding-them-not-by.md
@@ -1,0 +1,45 @@
+# [M] Publish files by demuxing and decoding them, not by capturing a MediaStreamTrack
+
+## Goal
+
+Implement and verify the behavior tracked in [#2532](https://github.com/moq-dev/moq/issues/2532)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+`js/publish/src/source/file.ts` publishes a local file by playing it in a `<video>` element and turning that back into a live capture track. On Chrome and Firefox it uses `HTMLMediaElement.captureStream`; WebKit doesn't implement that, so Safari draws each frame onto a canvas at 30fps and uses `canvas.captureStream(30)`. Images take the canvas path on every browser.
+
+Publishing a file is a transcode, not a capture, and forcing it through a capture pipe is what causes the problems below. We should demux the file and drive `VideoDecoder`/`AudioDecoder` directly, producing `VideoFrame`s with the container's own timestamps and no media element in the loop.
+
+#### Motivation
+
+Concrete things the current shape costs us, roughly in order of severity:
+
+- **No audio on Safari, at all.** `#decodeMedia` logs a warning and publishes video-only, because WebKit exposes a media element's audio only through Web Audio and only once microphone permission is granted. An audio-only file fails outright with a "this browser can't capture audio from files" error.
+- **No usable timestamps on Safari.** WebKit reports `timestamp: 0` for every frame off a canvas capture track. Measured in Safari 26.5, eight consecutive frames from `canvas.captureStream(30)` all carried `ts=0` while arriving on a correct ~36ms cadence. #2528 works around this by falling back to arrival time when the source clock never advances, which restores parity but throws away the file's real presentation timestamps.
+- **Frozen when the window isn't composited.** The canvas is redrawn by an `effect.interval` draw loop off a `<video>` element, so the frames stop changing when the publisher's window is minimized. This is the file-source half of #2527, and the worker pipeline from #2224 can't fix it: the track itself stops receiving new pictures. A decoder driven by a worker-side pacing loop is not compositor-bound.
+- **A wasted full-frame blit per frame** on the canvas path, plus a decode the media element already did.
+- **Playback rate is whatever the element does.** Frames are sampled at a fixed 30fps regardless of the file's real frame rate, so a 24fps or 60fps source is resampled by luck of the draw.
+
+#### Sketch
+
+- Demux the file into `EncodedVideoChunk`/`EncodedAudioChunk`. `js/hang/src/container/cmaf/decode.ts` only parses the CMAF we produce ourselves, not an arbitrary user-picked MP4/MOV/MKV, so this needs a real demuxer: mp4box.js, or libav.js which is already in the dependency tree via `@kixelated/libavjs-webcodecs-polyfill` (see `js/hang/src/util/libav.ts`).
+- Feed the chunks to `VideoDecoder`/`AudioDecoder` and pace the output against a wall clock, since decode runs far faster than realtime. Looping means restarting the demuxer and offsetting timestamps by the file duration.
+- Prerequisite shared with any non-track source: `Video.Source` is currently `StreamTrack`, so it has to widen to accept a stream of frames. That is the same prerequisite as feeding `<video>` frames directly via `requestVideoFrameCallback`, which is a reasonable intermediate step if this lands in stages.
+- Keep the media-element path around only if it turns out to be worth it; ideally one code path serves every browser.
+
+#### Notes
+
+Follow-up to #2224 and #2528. The workaround in #2528 keeps the file source working on Safari but does not make it good; this issue is the actual fix. The minimized-window behavior of the file source is out of scope for #2527, which is about camera capture.
+
+## Closes
+
+- [#2532](https://github.com/moq-dev/moq/issues/2532) - close this issue when the quest finishes

--- a/quest/m0/2609-moq-ffi-expose-moq-natives-reconnect-bindings-get-a-one.md
+++ b/quest/m0/2609-moq-ffi-expose-moq-natives-reconnect-bindings-get-a-one.md
@@ -1,0 +1,61 @@
+# [M] moq-ffi: expose moq-native's reconnect - bindings get a one-shot session that stalls silently
+
+## Goal
+
+Implement and verify the behavior tracked in [#2609](https://github.com/moq-dev/moq/issues/2609)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### What
+
+`moq-ffi` dials once and never reconnects. `Client::connect` in `rs/moq-ffi/src/session.rs` does:
+
+```rust
+let session = client
+    .with_publisher(&publish)
+    .with_subscriber(subscribe.clone())
+    .connect(url)
+    .await
+    .map_err(map_connect_error)?;
+```
+
+Meanwhile `moq-native` already has the machinery  -  `Client::reconnect(url)` (background loop, exponential backoff), plus `Client::publish` / `Client::consume`, and `consume` applies `origin.with_linger(...)` so broadcasts survive the gap. None of it is reachable from the FFI: `grep -rn "reconnect\|Reconnect" rs/moq-ffi/src/` returns nothing, and the Python `moq.Client` constructor exposes no such option.
+
+#### Why this can't be worked around above the FFI
+
+The obvious workaround  -  wrap the session in a retry loop in the binding language  -  doesn't work, because the failure that actually matters is a **silent stall**, not an error.
+
+Observed in a Python service that watches a prefix for announcements:
+
+- It ran `async for announcement in origin.consume().announced(prefix)` inside `async with moq.Client(...)`, wrapped in a `while True` that redials on exception or normal exit.
+- The host laptop slept, severing the QUIC path.
+- The iterator **never yielded, never returned, and never raised**  -  for 2h45m. Zero redial attempts, because there was nothing to react to.
+- Peers went on announcing under that prefix the whole time (confirmed from a browser on the same relay, which saw them). The service just never learned.
+- From the outside it looked healthy: process up, HTTP served, no errors logged.
+
+A retry loop above the FFI can only catch "ended or raised". Noticing a path that has gone quiet needs keepalive/timeout state inside the session  -  which is exactly where `Reconnect` already lives.
+
+For contrast, the JS side has `Connection.Reload` and rides out the same drops fine; the Rust side has `Client::reconnect`. The FFI is the odd one out, so Python/Kotlin/Swift consumers each end up hand-rolling something that structurally cannot work.
+
+#### Suggested shape
+
+Expose the reconnect path rather than the one-shot dial  -  roughly `Client::consume` / `Client::publish` semantics, returning something that keeps the origin alive across drops, with `Backoff` (`initial` / `multiplier` / `linger`) configurable through the FFI config. A `closed`-style handle would let callers distinguish "still retrying" from "gave up", which the one-shot API can't express either.
+
+Happy to take a pass at the binding if the shape is agreed.
+
+#### Pointers
+
+- `rs/moq-ffi/src/session.rs`  -  `Client::connect`, the one-shot dial
+- `rs/moq-native/src/client.rs`  -  `reconnect()`, `publish()`, `consume()`
+- `rs/moq-native/src/reconnect.rs`  -  `Backoff`
+
+## Closes
+
+- [#2609](https://github.com/moq-dev/moq/issues/2609) - close this issue when the quest finishes

--- a/quest/m0/2610-dynamic-announcements-broadcast-epochs-and-ended-vod.md
+++ b/quest/m0/2610-dynamic-announcements-broadcast-epochs-and-ended-vod.md
@@ -1,0 +1,79 @@
+# [XL] Dynamic announcements, broadcast epochs, and ended (VOD) broadcasts
+
+## Goal
+
+Implement and verify the behavior tracked in [#2610](https://github.com/moq-dev/moq/issues/2610)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Dynamic broadcasts are broken for everyone except the JS client. Only `Connection.consume(path)` sends a blind SUBSCRIBE for a non-announced path, which is what triggers `origin.dynamic()` on the relay. The Rust client is origin-mediated: its subscriber half only materializes broadcasts from announces, and `request_broadcast()` on the client's local origin has no handler, so it resolves to `Unroutable` immediately. `origin::Dynamic`'s own docs describe the session as "a fallback router, fetching a broadcast from upstream on demand", but no session ever registers one.
+
+Two more gaps compound it:
+
+- There is no way to answer announce interest dynamically. `recv_announce` streams `origin.announced()` (the static tree) and never surfaces the requested prefix to the application, so a VOD library or transcoder cannot advertise content on demand.
+- Broadcast identity is a hack. The first hop of the route chain stands in for content identity, so a restarting publisher with a stable origin id gets falsely spliced, a restarted process cannot resume content it legitimately could, and "newest announcement wins" races a stale generation arriving over a fresh connection.
+
+#### Design
+
+Spec'd in the moq-lite-06 WIP section of `drafts/draft-lcurley-moq-lite.md` (unpublished, so amended in place) plus a new `drafts/draft-lcurley-moq-broadcast.md` for the IETF side (EPOCH as a negotiated moq-transport parameter, mirroring relay-hops). Draft PR to follow from `claude/dynamic-broadcasts-api-97230b`.
+
+Wire summary (lite-06):
+
+- `ANNOUNCE_START` / `ANNOUNCE_UPDATE` (renamed from `ANNOUNCE_RESTART`) gain `Epoch (i)` and `Ended (i)`.
+- Epoch is the per-path content generation: publisher-minted, strictly increasing, forwarded unchanged, 0 = unspecified. Highest wins (non-zero outranks 0), replacement is decided by value rather than arrival order, equal non-zero epochs splice, first-entry identity survives only for zero-vs-zero. Wall clock is a seed, not a guarantee; receivers keep no high-water mark, which bounds the damage of a bad epoch to its advertisement's lifetime.
+- `Ended` splits live from complete/static content: ended broadcasts reject SUBSCRIBE, are read via FETCH, and are only announced on streams whose `ANNOUNCE_REQUEST` opted in via its new `Ended (i)` filter (the VOD enumeration path; moq.pro can store recordings at `<broadcast>/<epoch>` instead of UUID + API).
+- `SUBSCRIBE`, `FETCH`, and `TRACK` gain `Epoch (i)` (0 = current, mismatch = reset); `TRACK_INFO` returns the resolved epoch so metadata caches key by generation and requests cannot race a replacement.
+
+#### Implementation plan
+
+##### 1. Model: epoch replaces first-hop identity (`rs/moq-net`)
+
+- \[ ] Add `epoch` and `ended` to `broadcast::Route`; mint helper (max of wall clock and observed incumbent + 1).
+- \[ ] Replace `FrontState.publisher` and the `restart_announce` first-hop comparison with the epoch rules (equal non-zero = attach/splice, higher = takeover, lower = ignore, zero-vs-zero = existing first-hop behavior).
+- \[ ] Key the linger re-attach check by epoch.
+- \[ ] Reject SUBSCRIBE and gate announces for ended broadcasts; announce visibility of ended entries only to consumers that opted in.
+
+##### 2. Wire: lite-06 codecs and loops (`rs/moq-net`, `js/net`)
+
+- \[ ] Message structs and per-version decode arms for the new fields; rename `AnnounceRestart` to `AnnounceUpdate` (and the JS mirrors).
+- \[ ] Publisher/subscriber announce loops carry epoch/ended through; subscribe/fetch/track paths enforce epoch match and return resolved epoch in TRACK\_INFO.
+- \[ ] JS `Connection.consume` and friends expose epoch pinning and ended filtering.
+
+##### 3. Origin API: dynamic announce interest (`rs/moq-net`)
+
+- \[ ] New handle alongside `origin.dynamic()` (e.g. `requested_announce()`): yields `{prefix, ended}` interest events, refcounted per distinct prefix, delivered to every handler, released when the last matching announce stream closes. Handlers respond by creating real (possibly ended) broadcasts through a scoped producer.
+- \[ ] `recv_announce` registers interest for the requested prefix; `Consumer::announced()` raises it locally too so in-process consumers behave like wire peers.
+- \[ ] Keep `origin.dynamic()` as the exact-path fallback, unchanged.
+
+##### 4. Session wiring: Rust clients reach dynamic origins
+
+- \[ ] Opt-in: the subscriber half registers an `origin::Dynamic` handler and serves misses by wire-subscribing (create the broadcast with `announce: false` so it stays out of the tree's announce set but dedups repeat requests). This alone fixes the headline bug.
+- \[ ] Follow-up (separate PR): forward locally raised interest upstream as narrower ANNOUNCE\_REQUESTs, deduped against covering prefixes, so `announced_broadcast()` works end-to-end across hops.
+
+##### 5. IETF adapter and bindings
+
+- \[ ] `rs/moq-net` ietf module: EPOCH parameter per `draft-lcurley-moq-broadcast` (negotiated setup option, strip when not negotiated).
+- \[ ] Cross-package sync per the table: `moq-ffi` + libmoq + py/swift/kt/go wrappers, `js/net`, `doc/concept`, relay docs.
+- \[ ] `just test smoke-full` for the interop matrix.
+
+##### Tests to encode the root causes
+
+- \[ ] Stale generation arriving over a fresh connection must not displace the current one (the arrival-order race).
+- \[ ] SUBSCRIBE/FETCH/TRACK crossing an in-flight replacement resets instead of serving mixed generations.
+- \[ ] Rust client `request_broadcast` against a relay `origin.dynamic()` handler round-trips.
+- \[ ] Ended broadcast: SUBSCRIBE rejected, FETCH served, announced only to opted-in streams.
+
+Assumption worth confirming: moq-lite-06 has not shipped in any deployed relay/client, so its wire format can change in place. If anything already speaks the current lite-06 framing, these fields need a lite-07 instead.
+
+## Closes
+
+- [#2610](https://github.com/moq-dev/moq/issues/2610) - close this issue when the quest finishes

--- a/quest/m0/2624-moq-native-goaway-redirect-guard-classifies-hosts-by-name.md
+++ b/quest/m0/2624-moq-native-goaway-redirect-guard-classifies-hosts-by-name.md
@@ -1,0 +1,59 @@
+# [M] moq-native: GOAWAY redirect guard classifies hosts by name, not by resolved address
+
+## Goal
+
+Implement and verify the behavior tracked in [#2624](https://github.com/moq-dev/moq/issues/2624)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### What
+
+`Redirect::resolve` in `rs/moq-native/src/connection.rs` refuses a peer-supplied GOAWAY URI that "widens reachability", so an authenticated public upstream can't point us at loopback or a private range:
+
+```rust
+if is_local(&target) && !is_local(current) {
+    tracing::warn!(uri, "GOAWAY redirect widens reachability; redialing the current URL");
+    return current.clone();
+}
+```
+
+`is_local` decides that from the URL string alone:
+
+```rust
+Some(url::Host::Domain(host)) => host == "localhost" || host.ends_with(".localhost"),
+```
+
+Any other domain is classified as non-local without being resolved, so the check only catches redirects that name a literal IP or `localhost`. A peer that names a host it controls, with an A/AAAA record pointing at `127.0.0.1`, `10.0.0.0/8`, `169.254.169.254`, etc., passes the guard and the reconnect loop dials it. Resolving once at check time isn't sufficient either: the name is resolved again for the actual dial, so a short-TTL record can answer differently the second time (classic rebinding TOCTOU).
+
+The default policy is `Redirect::Follow`, so this is the out-of-the-box behavior.
+
+#### Why it matters
+
+`scheme_tier` already stops a redirect from *downgrading* the transport, which bounds this: an `https://` client can't be moved to `ws://`. The exposure is a redirect that keeps the tier. The sharpest case is a client already on a plaintext transport (`ws://`, `tcp://`, `http://`), where the redirect URI's path and query are attacker-chosen and the dial is a real HTTP upgrade against whatever the name resolves to. For encrypted schemes the peer still has to satisfy TLS at the target, unless verification is disabled.
+
+I'd rate this lower than a general SSRF primitive (no attacker-chosen body, and the tier check holds), but the guard exists specifically to prevent peer-directed dialing into the client's own network, and as written it's bypassable by anyone who can set a DNS record.
+
+#### Where
+
+- `rs/moq-native/src/connection.rs` (was `reconnect.rs`): `is_local`, `is_local_v4`, `Redirect::resolve`, `scheme_tier`
+- Introduced in #2542 (`refactor(net, relay): reshape the GOAWAY API and move migration into Reconnect`), currently on `dev`
+- Covered by `local_targets_are_recognized`, which only exercises literal-IP and `localhost` forms, so the gap is invisible to the existing tests
+
+#### Suggested direction
+
+- Resolve the redirect host before accepting it, reject when *any* returned address is loopback/private/link-local/ULA, and dial the addresses that were validated rather than re-resolving the name, so the check and the connection can't disagree.
+- Consider whether `Redirect::SameHost` is the better default: it sidesteps this entirely for the common deployment (a peer handing off to a sibling on another port) and makes cross-host redirects an explicit opt-in.
+- Extend `local_targets_are_recognized` with a domain case once resolution is in play.
+
+Noticed while reviewing #2614/#2618, which only moved this code between files.
+
+## Closes
+
+- [#2624](https://github.com/moq-dev/moq/issues/2624) - close this issue when the quest finishes

--- a/quest/m0/2627-the-moq-watch-re-insertion-grace-is-one-microtask-a.md
+++ b/quest/m0/2627-the-moq-watch-re-insertion-grace-is-one-microtask-a.md
@@ -1,0 +1,86 @@
+# [M] The moq-watch re-insertion grace is one microtask: a detach spanning any yield closes and…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2627](https://github.com/moq-dev/moq/issues/2627)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+`<moq-watch>` already tries to survive a DOM move. The source comment on `disconnectedCallback` says so: "Stop everything but don't actually cleanup just in case we get added back to the DOM." But the actual grace window is a single microtask checkpoint. Detach a playing element and re-insert it after any yield (an `await`, a timeout, a rAF, a framework that batches DOM ops) and the WebTransport session closes and redials: the tile goes black and rejoins.
+
+A fully synchronous move (`otherParent.appendChild(el)` on a connected element) survives, but only by accident: `@moq/signals` coalesces notifications onto a microtask and drops a net-zero change, so the enabled signal's true to false to true flip inside one job is never observed. That behavior is pinned by a test in the signals package ("no notification when the net value is unchanged"), but nothing in the element documents it as a contract. So whether a move costs you the session currently depends on whether anything yields between the remove and the insert, which is a fragile line to build a layout on.
+
+#### Environment
+
+- `@moq/watch` 0.4.0, `@moq/net` 0.2.2, `@moq/signals` 0.2.0 (npm), Chrome stable
+- The relay is not involved; the close originates client-side
+
+#### Steps to reproduce
+
+```html
+<script type="module">import "@moq/watch/element";</script>
+
+<div id="a">
+  <moq-watch url="https://RELAY/anon" name="demo/angle1"><canvas></canvas></moq-watch>
+</div>
+<div id="b"></div>
+<button id="move">move</button>
+<script type="module">
+  const el = document.querySelector("moq-watch");
+  document.getElementById("move").onclick = async () => {
+    el.remove();
+    await Promise.resolve(); // any yield here: an await, setTimeout, rAF
+    document.getElementById("b").appendChild(el);
+  };
+</script>
+```
+
+Press the button while the broadcast is playing. The session closes, a new one dials and rejoins. Replace the handler body with a bare `document.getElementById("b").appendChild(el)` and the session survives, per the coalescing above.
+
+#### Mechanism
+
+In `element.js`, the lifecycle callbacks only flip an enabled signal, and the connection is constructed with it:
+
+```js
+this.connection = new Moq.Connection.Reload({ enabled: this.#enabled });
+// ...
+connectedCallback()    { this.#enabled.set(true); /* re-applies display/position */ }
+disconnectedCallback() { this.#enabled.set(false); }
+```
+
+The same signal also gates `Broadcast`. In `connection/reload.js`, `#connect` is one long-lived effect that tracks `enabled`; a rerun first runs the previous run's cleanups, one of which is `connection.close()`, and then, if enabled, spawns a fresh `connect()`.
+
+In `@moq/signals`, `Signal.set` does not notify synchronously: it queues one flush on a microtask, and the flush returns early when the value is back to what it was at the start of the window. Hence: same-job flip means no rerun and no close; any yield between false and true means the flush observes false, the effect reruns, and the cleanup closes the session before the re-insert dials a new one.
+
+#### Possible fixes
+
+1. Make the grace deliberate instead of a coalescing accident: defer the disable to a task boundary, or a small linger, and cancel it if the element is connected again by then. A `queueMicrotask` guard is not enough, since the signal flush is already a microtask; something like a zero timeout checking `this.isConnected` would cover every same-frame reparent regardless of how the caller schedules it.
+
+2. Define `connectedMoveCallback()`. Since Chrome 133, `Element.moveBefore()` calls it instead of the disconnected/connected pair; without it the spec fallback still fires both. Today that pair happens to coalesce and survive, but a defined callback would make the guarantee explicit rather than emergent.
+
+3. Failing either, document the contract. "A synchronous move survives, anything async does not" is currently discoverable only by reading the signals package's flush logic.
+
+4. The bigger version is sharing the connection and letting it outlive a detach entirely, filed separately: #2628.
+
+#### Workaround
+
+We render all tiles once in a fixed DOM order and make every rearrange, resize, swap and maximize a style change (absolute positioning by percentage), so a live element never detaches at all. It works, but the whole layout system ends up built around this one behavior.
+
+I know the JS API is the intended path for apps that want this much control, and that may well be the answer here. Filing it anyway because the web component is the first thing people reach for, and the survival of a move depending on microtask timing is surprising.
+
+## Closes
+
+- [#2627](https://github.com/moq-dev/moq/issues/2627) - close this issue when the quest finishes
+
+## Related
+
+- [#2628: Every <moq-watch> dials its own session: reuse one WebTransport…](/quest/m0/2628-every-moq-watch-dials-its-own-session-reuse-one.md) - related open work

--- a/quest/m0/2628-every-moq-watch-dials-its-own-session-reuse-one.md
+++ b/quest/m0/2628-every-moq-watch-dials-its-own-session-reuse-one.md
@@ -1,0 +1,42 @@
+# [M] Every moq-watch dials its own session: reuse one WebTransport connection per relay URL and…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2628](https://github.com/moq-dev/moq/issues/2628)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+Every `<moq-watch>` constructs its own `Connection.Reload` in its constructor, so a page showing N tiles from one relay dials N WebTransport sessions to the same URL. `connect()` even passes `allowPooling: false` to `new WebTransport(...)`, so the browser's own HTTP/3 pooling is opted out too: one session per element is explicit, not incidental. And because each session's lifetime is tied to its element's connected state (#2627), a detach that outlives a microtask closes the session.
+
+> we could certainly make some easy changes, like reusing the WebTransport connection instead of dialing a separate one per component, and keeping it alive while not in the DOM.
+
+#### Proposal
+
+A shared connection pool keyed by relay URL:
+
+- The element (or `Connection.Reload` itself) looks up an existing session for its `url` and takes a reference instead of dialing. Last reference out closes it.
+- A short grace period before an unreferenced session actually closes, a second or two, or until `pagehide`. That makes DOM moves free as a side effect, since the moved element re-acquires the same session before the grace period ends, and it covers swapping one tile for another on the same relay without a re-handshake.
+- Broadcast subscriptions stay per element. Only the QUIC session is shared.
+
+#### Why multiview hits this
+
+A camera wall is the worst case for per-element sessions: 4 to 16 elements, one relay, and users constantly rearranging tiles. Sharing the session cuts the handshakes and the relay's per-connection cost, and it makes the element indifferent to reparenting without any lifecycle cleverness.
+
+We currently avoid all of this by never moving elements (fixed DOM order, layout as absolute positioning). I know the JS API is the recommended path for this level of control, but connection reuse seems to belong in the library either way: there is no supported way to do it from the outside. The element's `connection` field is public and writable, but `Broadcast` and `Sync` capture `connection.established` by reference at construction, so reassigning it does not rewire the pipeline, and there is no constructor argument or attribute for it either.
+
+## Closes
+
+- [#2628](https://github.com/moq-dev/moq/issues/2628) - close this issue when the quest finishes
+
+## Related
+
+- [#2627: The <moq-watch> re-insertion grace is one microtask: a detach spanning…](/quest/m0/2627-the-moq-watch-re-insertion-grace-is-one-microtask-a.md) - related open work

--- a/quest/m0/2676-libmoq-process-exit-can-abort-in-glibcs-pthread-tpp.md
+++ b/quest/m0/2676-libmoq-process-exit-can-abort-in-glibcs-pthread-tpp.md
@@ -1,0 +1,59 @@
+# [M] libmoq: process exit can abort in glibc's __pthread_tpp_change_priority
+
+## Goal
+
+Implement and verify the behavior tracked in [#2676](https://github.com/moq-dev/moq/issues/2676)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Symptom
+
+A C program that links `libmoq.a`, consumes a video track, and then exits normally (returning from `main`, or calling `exit`) can abort during atexit teardown with glibc's priority-protected-mutex assertion in `__pthread_tpp_change_priority`. The process dies with SIGABRT (exit 134) and a core dump *after* the MoQ data path has already worked correctly.
+
+This has only been observed on Linux/glibc.
+
+#### Where it bit us
+
+The C leg of the interop smoke test (`test/smoke/clients/c/subscribe.c`). 17bf0d950 worked around it by having the client `_exit(0)` the moment it has its frame, skipping atexit teardown entirely, with the commit message "Fixes the flaky rust -> c leg". The workaround was never accompanied by a diagnosis, so per CLAUDE.md's Root Cause First this should be treated as a real bug rather than a flake that's been made to go away.
+
+moq-dev/moq#2675 extends the same `_exit` to the client's failure paths, for a separate reason (a use-after-free on `user_data`). It does not touch this.
+
+#### Why this matters beyond the smoke test
+
+The smoke client is not the only C consumer. `cpp/obs` links `libmoq` the same way, and the C API's whole contract is "call `moq_session_close`, wait for the terminal `on_status`, exit". A consumer that follows that contract exactly should not abort. Right now the only thing keeping our own test green is that it skips the C runtime's exit path, which is not advice we can reasonably give an embedder.
+
+#### What is known
+
+- `libmoq.a` statically bundles `moq-video`, whose software H.264 fallback is openh264 (vendored C++; `stdc++` is in `rs/libmoq/native-libs/linux.txt` for exactly that reason).
+- Nothing in our Rust code creates a priority-protected mutex. `grep` for `PTHREAD_PRIO`/`pthread_mutexattr`/`SCHED_` across `rs/moq-video` and `rs/libmoq` comes back empty, so the mutex in question comes from a dependency or is not really a PRIO\_PROTECT mutex at all (see below).
+- libmoq runs its own tokio runtime on a `LazyLock` thread (`rs/libmoq/src/state.rs`), which is never shut down; its threads are still live when C's atexit handlers and static destructors run.
+
+#### Hypotheses, none confirmed
+
+1. **A `pthread_mutex_t` is used after free during teardown.** `__pthread_tpp_change_priority` is only reached when `m->__data.__kind` says PRIO\_PROTECT. If the mutex memory has already been freed, a garbage `__kind` can route an ordinary unlock/destroy down the TPP path with a nonsense priority, which is precisely what that assertion catches. This would make the assertion a *symptom* of a lifetime bug, not of anything priority-related.
+2. **A race between the still-running tokio/openh264 worker threads and C's static destructors.** We never stop the runtime, so a worker can touch state whose destructor already ran.
+3. **Something in the static-link arrangement**, e.g. openh264's C++ statics being destroyed while a thread is inside them.
+
+Hypothesis 1 is the one worth checking first, because it is the only one that would also be a live bug for a well-behaved embedder rather than a teardown-ordering nuisance.
+
+#### Suggested investigation
+
+- Reproduce with a minimal C program: connect, consume video, `moq_session_close`, wait for the terminal `on_status`, `return 0`. Loop it to get a hit rate.
+- Run it under ASan and under valgrind/helgrind. If hypothesis 1 is right, ASan should name the freed mutex directly.
+- Get a backtrace from the core: whether the abort comes from `pthread_mutex_destroy`, `pthread_mutex_unlock`, or a static destructor narrows this a lot.
+- Check whether it still reproduces with `moq-video`'s software H.264 fallback out of the link, which would implicate openh264 specifically.
+
+#### Definition of done
+
+A C consumer that returns from `main` after closing its session exits cleanly, and `test/smoke/clients/c/subscribe.c` no longer needs `_exit` to dodge teardown.
+
+## Closes
+
+- [#2676](https://github.com/moq-dev/moq/issues/2676) - close this issue when the quest finishes

--- a/quest/m0/2696-re-evaluate-the-client-server-split-in-cli-arguments.md
+++ b/quest/m0/2696-re-evaluate-the-client-server-split-in-cli-arguments.md
@@ -1,0 +1,67 @@
+# [L] Re-evaluate the client/server split in CLI arguments
+
+## Goal
+
+Implement and verify the behavior tracked in [#2696](https://github.com/moq-dev/moq/issues/2696)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+The CLI splits almost every transport knob into `--client-*` and `--server-*` variants, but a QUIC endpoint does both. The split is an artifact of `ClientConfig` and `ServerConfig` being separate Rust types, not something a user asked for, and it costs us a duplicated flag for every knob that isn't actually role-specific.
+
+Eleven knobs currently exist in both spellings, with identical meaning:
+
+| Duplicated | |
+|---|---|
+| `--client-bind` / `--server-bind` | the socket |
+| `--client-backend` / `--server-backend` | quinn / quiche / noq |
+| `--client-version` / `--server-version` | negotiated MoQ versions |
+| `--client-tls-root` / `--server-tls-root` | trust roots |
+| `--client-quic-*` / `--server-quic-*` | `congestion-control`, `gso`, `idle-timeout`, `keep-alive`, `max-streams`, `mtu-discovery`, `qlog` (7 pairs) |
+
+Genuinely role-specific ones are the minority: dialing (`--client-connect`, `--client-connect-timeout`, `--client-failover-delay`, `--client-reconnect`, client cert/verification) and listening (`--server-tcp*`, `--server-unix*`, `--server-quic-lb-*`).
+
+#### Why it's coming up now
+
+`moq --cluster-lan` needs an endpoint that dials peers *and* accepts from them. With the current split there's no way to express that, so it reaches into `--server-bind`, fills it in with an ephemeral port and a generated certificate when unset, and separately clones the `ClientConfig` per peer to dial out. That works, but it means a user who typed one flag silently gets a wildcard listener they never asked for, and the mesh's dial settings and accept settings are configured through two unrelated prefixes.
+
+That surfaced in review as a security concern. It isn't one (an unauthenticated `--cluster-lan` is the same exposure as a bare `--server-bind`, which is documented), but it is a real sign the flags no longer describe the thing being configured.
+
+#### Direction
+
+Roughly, in rough order of appetite:
+
+- **`--bind` applies to both.** One endpoint, one socket flag. Keep a way to bind separate client/server sockets if anyone needs it, but stop making that the default shape.
+- **`--connect` loses the `--client` prefix.** It's the URL to dial; nothing about it is client-role-specific in a way the prefix earns.
+- **Collapse the shared knobs** (`--quic-*`, `--version`, `--backend`, `--tls-root`) into one spelling, with role-specific overrides only where a real asymmetry exists.
+- **Keep prefixes only where the role genuinely differs**, e.g. accepting on a Unix socket, or presenting a client certificate.
+
+#### `--cluster-*` is tangled too
+
+Separate but related. There are now four ways to find a peer, and the names don't tell you they're alternatives:
+
+- `--cluster-connect` (static peer list)
+- `--cluster-connect-api` (dynamic peer list over HTTP/file)
+- `--cluster-mesh` (gossip, needs `--cluster-node`)
+- `--cluster-lan` (mDNS, needs `--cluster-node` and `--cluster-lan-secret`)
+
+plus `--cluster-node` (this relay's own URL, meaning something different again), `--cluster-token`, `--cluster-id`, `--cluster-tier`, `--cluster-linger`. Several combinations are invalid and only fail at startup with a hand-written `ensure!`. Worth reshaping alongside the client/server work, since "how do I find peers" and "how do I bind an endpoint" are the same question from two directions.
+
+#### Constraints
+
+- Every rename is user-facing, so the old spellings stay as hidden aliases per the deprecation rules in `CLAUDE.md`: no `--help` entry, no "deprecated, use X" note, `/doc` examples updated to the new names only.
+- The flags are also TOML keys, so a rename is a config-file migration, not just a CLI one.
+- `moq-relay`, `moq-cli`, and `moq-bench` all flatten these configs; a change lands in all three at once.
+- Sample invocations are scattered across `doc/bin/`, `doc/lib/`, `doc/setup/`, `doc/concept/`, and the `demo/` justfiles. `CLAUDE.md` already calls out grepping the binary name repo-wide and reconciling every hit against `--help`.
+
+## Closes
+
+- [#2696](https://github.com/moq-dev/moq/issues/2696) - close this issue when the quest finishes

--- a/quest/m0/2708-origin-open-the-announce-interest-lazily-on-first-consumer.md
+++ b/quest/m0/2708-origin-open-the-announce-interest-lazily-on-first-consumer.md
@@ -1,0 +1,24 @@
+# [S] origin: open the announce interest lazily, on first consumer
+
+## Goal
+
+Implement and verify the behavior tracked in [#2708](https://github.com/moq-dev/moq/issues/2708)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+A session wired to feed an origin (JS: the `subscribe` option in #2705; Rust: `Client::with_subscriber`) opens an announce-interest stream with an empty prefix as soon as it attaches, whether or not anything ever reads an announcement. On a large relay that is announce traffic and per-session announce state for every broadcast the session may see, paid even by an app that only publishes or only consumes known paths via requests.
+
+The origin knows whether anyone is interested: an open `announced()` stream, an announcement-gated watch handle, or (narrower) which prefixes they cover. The forwarder could open the wire announce stream only while interest exists, and scope it to the union of requested prefixes rather than the root.
+
+Applies to both implementations; neither is lazy today. The JS forwarder lives in `js/net/src/connection/forward.ts`; the Rust equivalent is the subscriber wiring in `rs/moq-net` session setup.
+
+## Closes
+
+- [#2708](https://github.com/moq-dev/moq/issues/2708) - close this issue when the quest finishes

--- a/quest/m0/2709-per-broadcast-bandwidth-estimates-and-reservation.md
+++ b/quest/m0/2709-per-broadcast-bandwidth-estimates-and-reservation.md
@@ -1,0 +1,24 @@
+# [S] per-broadcast bandwidth estimates and reservation
+
+## Goal
+
+Implement and verify the behavior tracked in [#2709](https://github.com/moq-dev/moq/issues/2709)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+The congestion controller's `estimatedSendRate` (and the PROBE receive estimate) are per-session. With #2705 sharing one session across every component on a page, that aggregate is the wrong number for any individual publisher: two publish components each cap their encoder at the full-session estimate and jointly overshoot, and a watcher's ABR reads a budget it shares with everything else on the connection.
+
+This is not a regression in kind (separate sessions just let congestion control arbitrate blindly), but sharing makes it structural. What is missing is a mechanism to split the session estimate across broadcasts: per-broadcast accounting at minimum, and ideally a way to reserve or prioritize bitrate so a publisher's encoder cap and a watcher's rendition selection each work against their own share rather than the whole pipe.
+
+Related: #2283 fed the session estimate into the encoder; catalog::Estimator (#2530) measures per-rendition receive rates. Neither divides the send budget.
+
+## Closes
+
+- [#2709](https://github.com/moq-dev/moq/issues/2709) - close this issue when the quest finishes

--- a/quest/m0/2714-per-subscriber-path-predicate-for-originconsumer-0-1-x.md
+++ b/quest/m0/2714-per-subscriber-path-predicate-for-originconsumer-0-1-x.md
@@ -1,0 +1,60 @@
+# [M] Per-subscriber path predicate for OriginConsumer (0.1.x) / AnnounceConsumer (0.2.x)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2714](https://github.com/moq-dev/moq/issues/2714)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Hi @kixelated 👋
+
+We're building [WolvaneSfu](https://github.com/postanteGames/WolvaneSfu)  -  a MoQ-primary SFU backend (Rust media-engine + Elixir signaling) using `moq-net` for the relay side. We need a per-subscriber dynamic path exclusion filter to implement server-authoritative moderation (deafen enforcement  -  audio path subscribes filtered per-user based on server state) that a malicious/forked client cannot bypass.
+
+Current `scope(&[Path])` is inclusion-only and immutable  -  it doesn't compose with a runtime-updated exclusion set. We'd like to add:
+
+**Proposed API (0.1.x)**  -  `src/model/origin.rs::OriginConsumer`:
+
+```rust
+impl OriginConsumer {
+    /// Returns a new consumer that drops paths from the announce stream when
+    /// the predicate returns false. Unannounce events pass unconditionally
+    /// (to preserve memory-cleanup semantics for previously announced paths).
+    pub fn subscribe_filter<F>(self, predicate: F) -> OriginConsumer
+    where F: FnMut(&Path) -> bool + Send + 'static;
+}
+```
+
+Injection point: `OriginConsumerState::apply_announce`  -  predicate gate at the top.
+
+**0.2.x equivalent** (`AnnounceConsumer`): a `with_filter(F)` chain builder after `Consumer::announced()`, applied inside `next() / poll_next()` drainage.
+
+**Questions before I open a PR:**
+
+1. Would you accept this API? Any alternative design you'd prefer (different predicate signature, or a fundamentally different approach)?
+2. Should the PR target the `0.1.x` maintenance branch (we're pinned to 0.1.18) or `0.2.x` main? Happy to backport both directions if maintenance branches are still cut.
+3. Is `0.1.x` still maintained, or should we be planning a `0.2.x` migration first?
+
+If you'd rather I just open the PR and discuss inline, that works too  -  just wanted to check intent first since a "please migrate to 0.2.x" answer changes our plan meaningfully.
+
+Test suite I'm planning (5 tests, matching the `#[tokio::test]` + `assert_next_wait` style in existing `origin.rs::tests`):
+
+- `filter_blocks_matching_path`  -  paths where predicate returns false don't appear in `announced()`
+- `filter_allows_unannounce_of_blocked`  -  unannounce passes unconditionally (memory cleanup)
+- `filter_composable_with_scope`  -  `scope(&paths).subscribe_filter(pred)` chains correctly
+- `filter_clone_independence`  -  filter is per-consumer, doesn't leak to siblings
+- `filter_late_announce_gate`  -  announces arriving after subscribe still pass through the filter
+
+Thanks  -  MoQ is finally starting to feel like it's ready for prod SFU work.
+
+- Mustafa (WolvaneSfu)
+
+## Closes
+
+- [#2714](https://github.com/moq-dev/moq/issues/2714) - close this issue when the quest finishes

--- a/quest/m0/2733-moq-net-stats-per-subscription-send-backlog-queued-vs.md
+++ b/quest/m0/2733-moq-net-stats-per-subscription-send-backlog-queued-vs.md
@@ -1,0 +1,60 @@
+# [M] moq-net stats: per-subscription send backlog (queued vs delivered) + skip counters
+
+## Goal
+
+Implement and verify the behavior tracked in [#2733](https://github.com/moq-dev/moq/issues/2733)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+### moq-net stats: per-subscription send backlog (queued vs delivered) + skip counters
+
+Design context: moq-dev/moq.pro#992 (per-broadcast QoS on the CDN dashboard), but the metric is generally useful to any moq-net consumer.
+
+#### The metric
+
+The strongest media-agnostic congestion signal a relay/publisher has is *queued outstanding data per subscription*: bytes produced for a subscriber that haven't been delivered yet. Defined per **active subscription**, so an unrequested track has no row - 0 Mb/s from lack of demand never reads as congestion.
+
+With `latency_max`, the queue is bounded and overflow becomes group skips. So congestion is a pair:
+
+- **queue level** (gauge) - pressure building; keyframe-burst spikes are normal, sustained level means the peer is slower than the media
+- **skips** (cumulative) - pressure that already cost quality
+
+#### Proposed `Traffic` additions
+
+`Traffic` is `#[non_exhaustive]` with `#[serde(default)]` everywhere, so these are additive. Per the existing `(tier, broadcast, role)` bucketing, the `role=Subscriber` rows aggregate over all of that broadcast's subscriptions on the node:
+
+- `queued_bytes` (gauge): sum over active subscriptions of produced-but-undelivered bytes
+- `queued_max_bytes` (gauge): worst single subscription, so one dying viewer isn't averaged away by fifty healthy ones
+- `subscriptions_congested` (gauge): count of subscriptions over a backlog threshold - "how many viewers are hurting" without per-viewer tracks
+- `skipped_bytes` / `skipped_groups` (cumulative): dropped due to the latency budget
+
+Gauges fit the shared-atomics `Meter` design: increment on produce, decrement on delivery/skip, O(1) snapshot. One correctness detail: a skipped/aborted group's bytes must leave the queue gauge (they were never delivered, but they're no longer queued either), or the gauge leaks upward on every skip.
+
+#### What "delivered" means, in two parts
+
+```
+total backlog = moq-layer lag    (produced into group cache - accepted by QUIC)
+              + QUIC-layer unacked (accepted by QUIC - acked by peer)
+```
+
+- The moq-layer term is measurable now at the model/wire seam: the model knows the producer offset, the session's writer task knows how far it has flushed into the stream.
+- The QUIC-layer term needs per-stream delivered-vs-queued from the transport, which nothing exposes publicly today (quinn/quinn-proto/quiche have the state internally; browser `WebTransportSendStream.getStats()` is spec'd but unimplemented - verified absent in Chrome 148). Tracked in moq-dev/web-transport#368. This term matters: QUIC accepts writes up to the peer's flow-control credit regardless of congestion, so with a generous receiver window most of the backlog sits inside the QUIC library, invisible at the moq seam.
+
+Ship the moq-layer term first with the gauge semantics designed so the QUIC term can be folded in per-backend as it becomes available (fields are already `Option`-shaped at the trait level; absence must read as "unknown", not zero-and-healthy... concretely: keep the moq-layer gauge always-on, and consider a separate field or a capability note for whether the QUIC term is included, so a consumer comparing two nodes doesn't compare different definitions).
+
+Because moq maps one group to one QUIC stream, every stream belongs to exactly one subscription - per-subscription attribution is structural.
+
+#### Publisher side
+
+The same gauge on the `role=Publisher` direction (bytes produced locally vs accepted/delivered toward the relay) is the publisher's uplink-health signal - "media bitrate exceeds what the network is draining" - and complements PROBE's peer-measured receive rate.
+
+## Closes
+
+- [#2733](https://github.com/moq-dev/moq/issues/2733) - close this issue when the quest finishes

--- a/quest/m0/2734-hang-publisher-reported-stats-track-catalog-stats-section.md
+++ b/quest/m0/2734-hang-publisher-reported-stats-track-catalog-stats-section.md
@@ -1,0 +1,51 @@
+# [M] hang: publisher-reported stats track (catalog stats section)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2734](https://github.com/moq-dev/moq/issues/2734)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+### hang: publisher-reported stats track (catalog `stats` section)
+
+Design context: moq-dev/moq.pro#992. The network layer (per-subscription send backlog, skip counters - see moq-dev/moq#2733) covers congestion; this issue is the *media* half: health signals only the publisher can know, published by the publisher into its own broadcast.
+
+#### Spec
+
+A new root catalog section following the pattern the draft already blesses ("a `chat` section should include the name of a chat track, not individual chat messages"; `Catalog` is `#[non_exhaustive]` / `z.looseObject` with a tested extension round-trip):
+
+```json
+{ "stats": { "track": "stats.json" } }
+```
+
+The track: one group per snapshot, JSON, cumulative counters (so a mid-stream joiner gets totals), ~1 update/second, optionally a deflate + merge-patch `.z` sibling like moq-stats. Section in `drafts/draft-lcurley-moq-hang.md` or a small companion draft.
+
+Proposed vocabulary (cumulative unless noted; per rendition where it matters):
+
+- `sourceFrames`, `sourceStalls`, `sourceStallMs` - capture layer
+- `encodedFrames`, `keyframes`, `encodeQueueDepth` (gauge) - encoder layer
+- `targetBitrate`, `encodedBitrate` (gauges) - what ABR is doing
+- `queuedBytes` (gauge), `sendRate`, `rtt` - uplink, from the local transport + PROBE
+- `active` (gauge) - whether encoding is currently demand-driven
+
+#### Implementation notes
+
+- `js/publish`: `Video.Encoder.out.stats` already folds `{frames, bytes, keyframes}` - extend in place. The capture reader loop (`Capture.#run`) is the chokepoint for source-stall watchdogging; `Epoch` already detects a stuck source clock but the detection is neither counted nor exported.
+- **Gate everything on demand** (`Encoder.out.active` / `Demand`): encoding is demand-driven and the camera is released when demand drops, so an ungated stall metric reports every idle broadcast as stalled.
+- Rust: same hooks in moq-video's encode/capture, so moq-cli and gateway-style ingest (RTMP/SRT) can publish the same track from ingest-side observations.
+- Consumers that don't know the section ignore it (tested); consumers that do can subscribe or not - the catalog only names the track.
+
+#### Related spec fix rolled in
+
+`Timeline.wall` is the sanctioned wall-clock anchor and is generally unset today. Publishers SHOULD set it: it turns every viewer's latency from "relative to my join" into a real end-to-end figure, and the JS publisher already rebases capture timestamps onto its own wall clock (`Epoch`), so setting it is nearly free.
+
+## Closes
+
+- [#2734](https://github.com/moq-dev/moq/issues/2734) - close this issue when the quest finishes

--- a/quest/m0/2735-hang-opt-in-viewer-feedback-broadcasts-sampled-per-viewer.md
+++ b/quest/m0/2735-hang-opt-in-viewer-feedback-broadcasts-sampled-per-viewer.md
@@ -1,0 +1,38 @@
+# [M] hang: opt-in viewer feedback broadcasts (sampled per-viewer QoS)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2735](https://github.com/moq-dev/moq/issues/2735)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+### hang: opt-in viewer feedback broadcasts (sampled per-viewer QoS)
+
+Design context: moq-dev/moq.pro#992. **Deliberately the last phase** - relay-side aggregation of per-subscription backlog covers congestion for 100% of viewers with zero client cooperation. What it can't cover is the per-viewer *experience* distribution: startup time, rebuffer ratio, e2e latency percentiles, decode/render stalls on a healthy network, device context. That's this issue - the mux-data half. Filed now so the design isn't lost.
+
+#### What this is not
+
+Not a congestion-control channel. Bandwidth adaptation in MoQ is per-hop by design (PROBE); there is no end-to-end REMB equivalent to build. And PLI is mostly obviated by group-per-keyframe + `group_start`/`fetch_group` - a viewer recovers at the next group boundary. Feedback carries *what happened*, low-rate, which is what makes sampling acceptable.
+
+#### Sketch
+
+- **Path**: a dotted sibling namespace rather than a child of the watched broadcast - e.g. `.feedback/<broadcast-path>/<viewer-id>` relative to the auth root. A child path (`room/name.hang/<rand>`) sits inside the publisher's prefix: anyone with `get` on the room reads every viewer's feedback, and viewer churn spams announces into the prefix everyone watches. A dotted namespace separates the ACL the way `.stats` already does.
+- **Opt-in is a token decision**: mint viewer tokens with `put: [".feedback/<path>/<viewer-id>"]` for a sampled fraction of viewers, and simply don't for the rest - handles both "optional" and "big broadcasts don't do this". The viewer id lives in the token so viewers can't clobber or impersonate each other. `Claims`/`Scope` express this today; the signing key's immutable `Scope` must cover the feedback prefix in the publish role (one prefix under the root, so scoped keys express it naturally).
+- **Discovery**: the catalog advertises it (`{ "feedback": { "prefix": "../.feedback/<path>" } }`) so players know to bother; also where sampling parameters could live if the publisher rather than the token should control rate.
+- **Content**: one small `feedback.json` snapshot track, ~1 update/5s. Everything to report already exists in `js/watch`, computed and discarded: `Sync.received()`'s `now - timestamp` (latency proxy; true e2e once publishers set `Timeline.wall`), the per-label late-frame tracking in `Sync.#late` (currently flushed to console.debug), `DecoderOutput.stalled` / audio ring-buffer stalls (booleans, integrable into rebuffer time), group skips decided in `container/consumer.ts` (counted nowhere), `connection.stats()` + the viewer's own PROBE for the last hop.
+- **Aggregation** is the consumer's problem (for the CDN: the edge slurps the prefix and folds distributions; per-viewer drill-down subscribes an individual feedback broadcast directly).
+
+#### Security considerations for the draft
+
+Feedback is a cardinality/amplification surface: relays MAY cap announced broadcasts per feedback prefix; tokens bound the writer set; snapshots are tiny and rate-limited by convention (and enforceable by the relay's usual means).
+
+## Closes
+
+- [#2735](https://github.com/moq-dev/moq/issues/2735) - close this issue when the quest finishes

--- a/quest/m0/2756-origin-announce-only-entries-advertise-on-demand-content.md
+++ b/quest/m0/2756-origin-announce-only-entries-advertise-on-demand-content.md
@@ -1,0 +1,46 @@
+# [M] origin: announce-only entries, advertise on-demand content without instantiating broadcasts
+
+## Goal
+
+Implement and verify the behavior tracked in [#2756](https://github.com/moq-dev/moq/issues/2756)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Announcing a path requires instantiating a broadcast. `origin.publish` / `create_broadcast` put a live `broadcast::Producer` behind every announced entry, while `origin.dynamic()` broadcasts are deliberately never announced (#1772). So "announced" implies "instantiated", and there is no way to advertise content we could create on demand without actually starting to create it.
+
+The concrete victim is any large on-demand catalog. A VOD library or transcoder that can serve 100k recordings must either instantiate 100k broadcast producers just to appear in announce streams, or stay invisible and force consumers to know paths out of band. #2610's dynamic announce interest (`requested_announce()`) surfaces the demand to the application, but its plan still has handlers respond by creating real broadcasts, which only moves the instantiation cost from attach time to interest time. Interest in a prefix should cost an enumeration, not a fleet of broadcasts.
+
+#### Design
+
+An **announce-only entry**: a path in the origin's announce tree with no front behind it.
+
+- It shows up in every announce consumer and on the wire like any other announcement. The wire genuinely cannot tell: announcements never carried broadcast state, and the epoch/ended fields planned in #2610 attach naturally (`ended: true` is the VOD enumeration case). No wire change.
+- A subscribe or request against it falls through to the existing dynamic/request machinery (`origin.dynamic()`, `request_broadcast`), which materializes the real broadcast on first demand. The materialized broadcast attaches at the same path and epoch and supersedes the placeholder; when it closes, the announce-only entry remains until its own handle is dropped.
+
+Two API flavors that compose:
+
+1. **Standing**: `Producer::announce(path, ...) -> guard` (JS: `origin.announce(path)`). Advertise regardless of interest; drop the guard to retract. For small known catalogs.
+2. **Interest-scoped**: the `requested_announce()` handle from #2610 gains an `announce(suffix, ...)` response method. Entries live only while the interest that solicited them does: the application enumerates its catalog when some peer opens an announce stream for the prefix, and the whole subtree of announce state evaporates when the last matching stream closes.
+
+Together with #2708 (lazy, prefix-scoped announce solicitation) this closes a fully demand-driven loop: interest flows upstream hop by hop as narrow ANNOUNCE\_REQUESTs, the application at the origin answers with cheap announce-only entries, and broadcasts only materialize when someone subscribes.
+
+#### Notes
+
+- The interest ledger proposed on #2708 is the shared foundation; flavor 2 depends on it and on #2610's `requested_announce()`. Flavor 1 is independent and could land first.
+- Model hazard to design around: announce consumers hand out `broadcast::Consumer` fronts today. An announce-only entry has none, so either the announce event carries a lazily-materializing front (resolving through the request machinery on first track subscribe), or announce events decouple from fronts. The former keeps the consumer API unchanged and is the likely shape.
+- Cross-package sync per the table: `js/net`, `moq-ffi` and wrappers if the surface reaches them, `doc/concept`, and `drafts/draft-lcurley-moq-lite.md` only if any wire clarification falls out (none expected).
+
+Related: #2610 (dynamic announce interest, epochs, ended broadcasts), #2708 (lazy announce solicitation), #2412 (moq-gst publish-on-demand), #1772 (dynamic broadcasts are never announced).
+
+## Closes
+
+- [#2756](https://github.com/moq-dev/moq/issues/2756) - close this issue when the quest finishes

--- a/quest/m0/2774-collapse-reload-and-shared-into-one-connection-class.md
+++ b/quest/m0/2774-collapse-reload-and-shared-into-one-connection-class.md
@@ -1,0 +1,45 @@
+# [L] Collapse Reload and Shared into one Connection class
+
+## Goal
+
+Implement and verify the behavior tracked in [#2774](https://github.com/moq-dev/moq/issues/2774)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2705, which added `Connection.Shared` (a reactive handle on a pooled `{origin, reconnect loop}` keyed by relay URL) alongside the existing `Connection.Reload`.
+
+#### The problem with the current names
+
+`Shared` names the mechanism, not the role. Sharing is how it works; what it is to a caller is "the connection to a relay". A caller writing `new Connection.Shared({ url })` is thinking "I want a connection", not "I want a shared one". Three consequences:
+
+- It marks the default. The only reasons not to share are a pinned certificate or a supplied transport, and both send you to `Reload` instead. A name that qualifies the thing everyone should use implies an `Unshared` peer that does not meaningfully exist.
+- Sharing is supposed to be invisible. Two `<moq-watch>` tiles becoming one QUIC session is the selling point precisely because nobody has to arrange it, so encoding it in the type name makes callers reason about something they should not have to.
+- It ages badly. The stated direction is reconnect and GOAWAY on by default with `Established`/`Reload` dropped from the published surface. At that point this class *is* the connection API and the qualifier is noise, plus a second breaking rename to remove it.
+
+The repo rule this trips is "name by role, not by today only implementation" (CLAUDE.md, Public API Scrutiny). Note there is no Rust counterpart to converge on: `moq_native::Reconnect` names the behavior and there is no pooling type at all.
+
+#### Proposal
+
+One `Connection` class, with reconnect and sharing as defaults rather than as separate types:
+
+- `new Connection({ url })` reconnects and shares by default.
+- `share: false` for the cases that cannot be shared honestly (pinned certificate, supplied transport).
+- `Established` and `Reload` drop off the published surface (`@internal` or unexported), leaving one entry point.
+- GOAWAY slots into the same loop: the redirect handler dials the new URI and attaches it to the same origin, and nothing above holds a session.
+
+#### The part that needs design, not just a rename
+
+`Reload.close()` closes the connection; `Shared.close()` releases one handle and lets the last one out tear it down. Collapsing them means one `close()` whose meaning depends on construction options, which could easily be worse than two honest types. Options worth weighing: always refcount (a lone holder closing is then the same thing), or keep the unshared path internal-only so the ambiguity never reaches a caller.
+
+Doing this while #2705 is already breaking would save consumers a second migration of the same call sites. Deferring is defensible; the cost is that migration happening twice.
+
+## Closes
+
+- [#2774](https://github.com/moq-dev/moq/issues/2774) - close this issue when the quest finishes

--- a/quest/m0/2779-moq-export-ts-continuity-counters-are-numbered-from.md
+++ b/quest/m0/2779-moq-export-ts-continuity-counters-are-numbered-from.md
@@ -1,0 +1,56 @@
+# [M] moq export ts: continuity counters are numbered from process state, so two exporters of the same…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2779](https://github.com/moq-dev/moq/issues/2779)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+Two `moq export ts` processes subscribed to the same broadcast reconstruct the same programme, but number each PID's continuity counter from their own state. If they did not start together the two outputs are offset by a constant  -  measured at **+2 on the video PID and +8 on PAT/PMT**, unchanging across a 60 s run  -  so every transport packet differs in byte 3 while the payload underneath is identical.
+
+Each output is internally correct: TSDuck reports 0 continuity errors on either. The divergence is only visible when the two are compared, which is exactly what a redundant pair does.
+
+Measured on `moq-cli` 0.9.9 / `moq-relay` 0.14.9 release binaries, `moq-lite-05`.
+
+#### Why it matters
+
+SMPTE ST 2022-7 seamless protection switching requires the two legs of a 1+1 pair to be *packet-identical*, so a receiver can merge them by RTP sequence number and take whichever leg delivered each packet. This is how broadcast primary distribution survives the loss of a whole path without a visible artefact.
+
+With continuity numbered per process, a MoQ-fed 1+1 pair works only while both legs have run continuously since the broadcast started. The moment one leg is restarted for maintenance, or recovers from an outage that outlived its subscription, it comes back carrying the right programme in the right place  -  and byte 3 of every packet disagrees with its partner. A receiver cannot repair this: rewriting a continuity counter at the receiver means changing a field the packet's own consistency depends on, in a stream it is merging from two sources.
+
+Measured with both legs groomed to a constant bitrate and all packet placement derived from stream position, so that everything except this field is a function of the broadcast:
+
+| Cell | Datagrams identical | Identical with CC masked |
+|---|---|---|
+| legs started together | 100.00 % | 100.00 % |
+| leg B joins 20 s late | 0.09 % | 97.10 % |
+| leg A blacked out 15 s, then recovers | 68.56 % | 98.22 % |
+
+The pair is otherwise aligned: same slots, same RTP sequence numbers, same payloads, and a leg that joined 20 s late sends each shared sequence number a median of 10 ms from its partner. The continuity counter is the whole of the remaining difference.
+
+#### Reproduction
+
+Two independent chains from one source  -  `tee` a CBR TS into two `moq import ts` publishers, each to its own relay  -  then two `moq export ts` subscribers, the second started 20 s after the first. Compare the two outputs packet by packet at the same stream position, first raw and then with byte 3's low nibble masked. The masked comparison is the whole argument: the payloads agree, the counters do not.
+
+#### Suggested direction
+
+Derive each PID's continuity counter from stream position rather than from how many packets *this process* has emitted for that PID  -  for instance from the group sequence number and the packet's index within the reconstructed group, so any two exporters of the same broadcast agree without having to co-ordinate, and a subscriber joining mid-stream lands on the same numbering as one that has been running since the start.
+
+The same argument applies to any other field the exporter mints per process rather than deriving from the stream.
+
+#### What this is not asking for
+
+Not a wire-format change, and not co-ordination between exporters. Only that a value carried in the emitted TS be a function of the broadcast rather than of the process that happened to render it.
+
+## Closes
+
+- [#2779](https://github.com/moq-dev/moq/issues/2779) - close this issue when the quest finishes

--- a/quest/m0/2788-moq-transcode-run-cant-bootstrap-from-a-demand-gated.md
+++ b/quest/m0/2788-moq-transcode-run-cant-bootstrap-from-a-demand-gated.md
@@ -1,0 +1,36 @@
+# [M] moq-transcode: run() can't bootstrap from a demand-gated source that doesn't advertise its…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2788](https://github.com/moq-dev/moq/issues/2788)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`moq_transcode::run` can't bootstrap from a publisher that only encodes while watched, unless that publisher advertises its geometry before encoding anything.
+
+The cycle:
+
+1. `run` waits for a catalog snapshot with a usable video rendition, and only subscribes to the source video track afterwards (`feed::Feed::new` is constructed after the `choose_source` loop, and even then the subscribe happens lazily in `Feed::listen`, when a rung is actually demanded).
+2. `resolve_rungs` needs `coded_width`/`coded_height` to size the ladder.
+3. A demand-gated publisher (`moq_video::encode::publish_capture`, moq-boy) doesn't open its encoder until something subscribes to its video track.
+
+So when the transcoder is the intended consumer, nobody subscribes, no keyframe is produced, the geometry never arrives, and `run` waits forever. This is the same shape as #2757: a consumer that needs the catalog first, and a publisher that won't produce until demanded.
+
+\#2768 fixes the case where the publisher's geometry *is* known up front (`moq capture --width 1920 --height 1080` now advertises it before the camera opens, so the ladder resolves, a viewer subscribes to a rung, and only then does the camera open). The case that remains stuck is a publisher that advertises its codec but not its picture, which is what capture does when you don't pin a size, because a camera's negotiated mode isn't knowable without opening it.
+
+Before #2768 this scenario hung too (capture published no video rendition at all until its first keyframe), so this isn't a regression from that PR. It's the part of the deadlock that publishing the rendition earlier doesn't reach.
+
+Fix direction: give `run` a bootstrap path that can create demand on the source before it has a ladder, so the source is allowed to produce the keyframe that reveals its geometry. Subscribing to the source video track up front (and dropping it if no rung is ever wanted) would do it, at the cost of opening the camera to learn its mode. Alternatively the ladder could resolve lazily, per rung, once the feed yields its first decoded frame.
+
+Found by Codex while reviewing #2768.
+
+## Closes
+
+- [#2788](https://github.com/moq-dev/moq/issues/2788) - close this issue when the quest finishes

--- a/quest/m0/2798-moq-import-ts-an-audio-resync-is-silent-no-log-no-counter.md
+++ b/quest/m0/2798-moq-import-ts-an-audio-resync-is-silent-no-log-no-counter.md
@@ -1,0 +1,57 @@
+# [L] moq import ts: an audio resync is silent - no log, no counter, no downstream signal
+
+## Goal
+
+Implement and verify the behavior tracked in [#2798](https://github.com/moq-dev/moq/issues/2798)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+##### First, the fix works
+
+Replicated #2751 against real content, building the merge commit (`36c3bbd73`, `moq-mux` 0.9.5) and its parent (`2b62488e5`, 0.9.4) so each arm has a before and an after. Source is a 20 s cut of a 9.95 Mbps DVB capture  -  H.264 1080i + MP2 + AC-3 + teletext + 3× SCTE-35  -  through a real relay to a real subscriber.
+
+| Arm | one-byte change | 0.9.4 | 0.9.5 |
+|---|---|---|---|
+| MP2 header | sync `0xFF` → `0xFE` (`cmp -l` = 1) | **died at 12 s**, `missing MP2 frame sync` | ran to end, rc=0 |
+| H.264 start code (control) | `0x01` → `0x00` | survived | survived |
+| Full A/V, `--infinite` | none | **died at the first wrap** | survived 2+ wraps |
+
+The looped arm is the production shape from the original report  -  the one that accumulated 216 publisher restarts  -  and it now runs through its wraps.
+
+The cost is as small as it could reasonably be. Comparing the damaged run against a clean control by PTS set on every elementary stream: **exactly one 24 ms MP2 frame dropped**, at the damage point; **nothing published that the clean run did not publish**, on any PID, so the damaged frame is discarded rather than emitted as mixed bytes; video, AC-3, teletext and all three SCTE-35 PIDs untouched; all eight tracks delivered. Thank you  -  that is exactly the right shape, and confirm-before-trust is a better answer than the naive scan suggested in #2729.
+
+##### The ask
+
+A resync currently leaves no trace anywhere. On the recovered stream:
+
+- **no log line**  -  the resync path has no `tracing` call at any level (the only new ones are `debug!` in `finish()` for a partial frame at end of stream);
+- **no counter or metric** exposed by the importer;
+- **no `container::Producer::discontinuity`**  -  that counter exists and is bumped on a timeline rewind, but a resync does not touch it;
+- **nothing in the emitted TS**  -  0 continuity errors, 0 `discontinuity_indicator`s, identical to the clean control. The audio timeline simply steps 24 ms → 48 ms.
+
+So a feed that is losing audio has no signal distinguishing it from a healthy one, at any layer.
+
+This is a trade worth naming: before the fix, sync loss was *maximally* visible  -  the process died. I only discovered my own source was wrapping mid-frame because of the 216 restarts it caused. After the fix the identical condition produces a stream that looks perfectly well-formed. The robustness is plainly the right call, but the diagnostic signal went with it, and for a 24/7 contribution feed "quietly dropping frames" is the failure mode you most want to be able to see.
+
+To be clear about what this is *not*. I checked whether two independent importers on the same damaged source resync differently, and they do not  -  both dropped precisely the same frame  -  so this is not a correctness or redundancy problem. And a PTS gap is arguably the right way for MPEG-TS to represent a lost access unit; `discontinuity_indicator` is about the timebase, not a missing frame. This is an observability request, not a claim that the output is wrong.
+
+The minimum that would help is a `tracing::warn!` on a completed resync carrying the PID and the bytes discarded  -  enough to correlate against a source. A counter surfaced with the other importer statistics would be better, because the thing worth alarming on is a *rate* of resyncs rather than any single one. Whether it should also reach consumers through `container::Producer::discontinuity` is a larger question and I have no strong view; the counter alone would cover the operational case.
+
+I appreciate the doc comment on `Resync` states the policy deliberately ("a few lost milliseconds of audio stay a gap in one track rather than an error that takes the whole session down")  -  this is not arguing with that policy, only asking that the gap be countable.
+
+##### Environment
+
+`moq-mux` 0.9.5 (`36c3bbd73`) against 0.9.4 (`2b62488e5`), macOS, `moq-relay` and `moq` built from the same tree, all on loopback. Source: real DVB capture, H.264 1080i25 + MP2 + AC-3 + teletext + 3× SCTE-35, 9.95 Mbps.
+
+Follow-up to #2729 / #2751.
+
+## Closes
+
+- [#2798](https://github.com/moq-dev/moq/issues/2798) - close this issue when the quest finishes

--- a/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md
+++ b/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md
@@ -1,0 +1,41 @@
+# [M] moq-video: capture negotiates twice, so a window resize between the probe and the first…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2799](https://github.com/moq-dev/moq/issues/2799)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`moq_video::encode::publish_capture` negotiates its source twice: once to learn the mode (so the catalog rendition can be exact before anything is encoded), and again when a subscriber arrives and the live encoder starts. Between those two opens the source can change.
+
+Camera capture picks a stable device mode, so the two agree in practice. macOS **window** capture does not: `screencapture.rs`'s `open_window` derives geometry from the window on every open, so a user resizing the window between the probe and the first subscriber gets a live encoder whose mode differs from the advertised one.
+
+The catalog itself recovers, because the importer republishes the SPS-derived dimensions and codec once real frames flow. What doesn't recover is a consumer that already committed to the first snapshot. `moq_transcode::run` is the concrete case, and it says so:
+
+```rust
+// The rung set is fixed at startup: a source that changes resolution
+// mid-stream keeps the ladder it started with, but the passthrough entries
+// track the source.
+```
+
+So a resize between the two opens leaves the ladder sized for a picture the stream no longer carries.
+
+This is not new. `origin/main` has the same two negotiations, just arranged differently: `catalog_ready` starts false, so the camera opens and encodes unprompted until the first keyframe (negotiation #1), then breaks on no-viewers, releases the camera, and reopens when demand arrives (negotiation #2). Its catalog dimensions come from #1 and are equally invalidated by #2. #2768 changes only how #1's geometry is learned (probe rather than encode), not that there are two.
+
+Two directions, either of which closes it:
+
+1. Hold the source open from the probe through to the first subscriber, so there's one negotiation. Costs a camera/window held open while idle, which is what the demand gating exists to avoid.
+2. Let the transcode ladder follow a source resolution change instead of fixing it at startup. That's the more general fix, since a source can change size mid-stream for reasons that have nothing to do with capture (a reconnecting publisher, a renegotiated screen share), and today's behavior is documented but still wrong for the consumer.
+
+Found by Codex while reviewing #2768.
+
+## Closes
+
+- [#2799](https://github.com/moq-dev/moq/issues/2799) - close this issue when the quest finishes

--- a/quest/m0/2806-js-net-the-draft-14-15-adapter-keeps-one-request-per.md
+++ b/quest/m0/2806-js-net-the-draft-14-15-adapter-keeps-one-request-per.md
@@ -1,0 +1,41 @@
+# [M] js/net: the draft-14/15 adapter keeps one request per namespace, so a duplicate strands the…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2806](https://github.com/moq-dev/moq/issues/2806)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`ControlStreamAdapter` keeps a namespace to request-ID map for the draft-14/15 messages that are keyed by name rather than by request ID ([`js/net/src/ietf/adapter.ts`](https://github.com/moq-dev/moq/blob/main/js/net/src/ietf/adapter.ts), `#namespaces`). It is written while decoding a `PUBLISH_NAMESPACE`, and a second request for the same namespace overwrites the first:
+
+```ts
+const namespace = await Namespace.decode(r);
+this.#namespaces.set(namespace, requestId);   // overwrites
+```
+
+The overwrite happens during decode, before the message is dispatched, so nothing at the subscriber layer can prevent it. `Subscriber.runPublishNamespace` does refuse the duplicate with 409, but by then the mapping already points at the request that is about to be closed:
+
+1. Request 0 registers `namespace -> 0`.
+2. The duplicate registers `namespace -> 2`, overwriting.
+3. The subscriber answers 409 and closes request 2. Cancelling it removes only its `#streams` entry, not the namespace mapping it clobbered.
+4. Request 0's `PUBLISH_NAMESPACE_DONE` resolves the namespace to request 2. `#closeStream` finds no such stream and returns.
+5. Request 0 stays open and its announcement is never withdrawn.
+
+`readNamespaceRequestId` also throws `unknown namespace` for a withdrawal it cannot resolve, which is fatal to the session.
+
+Pre-existing on `main`: the 409 has always been after the decode, so restoring or removing it changes nothing here. Found while reviewing #2803, which keeps the duplicate refusal for exactly draft-14/15 for a related reason (a second request there is never a legitimate second source, since inline `NAMESPACE` does not exist before draft-16).
+
+The fix belongs in the adapter: don't overwrite a live mapping (first wins while its request is open), or key the reverse lookup so concurrent requests for one namespace stay distinguishable. A regression test needs to go through `ControlStreamAdapter` rather than `NativeSession`, which bypasses it.
+
+Only reachable on draft-14/15 against a peer that sends a duplicate `PUBLISH_NAMESPACE`, so it is not urgent; we negotiate draft-19 by default.
+
+## Closes
+
+- [#2806](https://github.com/moq-dev/moq/issues/2806) - close this issue when the quest finishes

--- a/quest/m0/2807-js-net-a-frame-precise-raised-start-floor-is-not-honored.md
+++ b/quest/m0/2807-js-net-a-frame-precise-raised-start-floor-is-not-honored.md
@@ -1,0 +1,35 @@
+# [M] js/net: a frame-precise raised start floor is not honored for a group already in hand
+
+## Goal
+
+Implement and verify the behavior tracked in [#2807](https://github.com/moq-dev/moq/issues/2807)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+The lite publisher's floor rejection in `js/net/src/lite/publisher.ts` (`#runTrack`) compares `group.sequence` only, but on lite-06 the start floor is a `(startGroup, startFrame)` position. A SUBSCRIBE\_UPDATE that raises the floor to a frame *within* a group the serving loop already holds clears the sequence check, and the group is then served from the frame range snapshotted when it was taken.
+
+Reproduced against `claude/js-publisher-cap-race` with a draft-06 subscription (group 0 parks the serving loop, so the armed prefetch takes group 1):
+
+- initial `startGroup: 0`, group 1 written with frames `["a", "b", "c"]`
+- SUBSCRIBE\_UPDATE raises the floor to `startGroup: 1, startFrame: 2`
+- **served:** `frameStart: 0`, payloads `["a", "b", "c"]`
+- **requested:** `frameStart: 2`, payloads `["c"]`
+
+Pre-existing rather than introduced by #2796: the group-range check that PR removed was `sequence < bounds.startGroup`, also group-only. But it does bound that PR's rationale, which is why it is filed here. Raising the floor is destructive on the read cursor (`startAt` shifts and closes buffered groups below it), so dropping a below-floor group already in hand discards nothing the subscriber has not discarded itself. That argument holds for whole groups only, and the comment in `#runTrack` now says so.
+
+The fix is to compare the position rather than the sequence: when the raised floor names this group, lift the snapshotted `start` to the new `startFrame` instead of accepting it unchanged. Worth a draft-06 regression covering both a floor raised past a held group and one raised into it.
+
+Rust is not affected. `position_group` applies the offsets synchronously at the pop, with control polled first, so it never holds a group under stale bounds.
+
+Related: #2796
+
+## Closes
+
+- [#2807](https://github.com/moq-dev/moq/issues/2807) - close this issue when the quest finishes

--- a/quest/m0/2808-js-net-publisher-bounds-snapshot-is-not-atomic-with-the.md
+++ b/quest/m0/2808-js-net-publisher-bounds-snapshot-is-not-atomic-with-the.md
@@ -1,0 +1,40 @@
+# [M] js/net: publisher bounds snapshot is not atomic with the group pop (residual race)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2808](https://github.com/moq-dev/moq/issues/2808)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Filed for the record. My read is that this is **not worth fixing on its own** (reasoning at the bottom); it is here so the next person to touch `#runTrack` knows the window exists rather than rediscovering it.
+
+#### The window
+
+`js/net/src/lite/publisher.ts` runs two concurrent loops over a shared mutable `bounds`: `runSubscribe` decodes SUBSCRIBE\_UPDATE and mutates it, while `#runTrack` serves groups. #2796 moved the frame-bound read into the `.then()` of `recvGroup()` so a group carries the range it was taken under. That narrows the window a great deal but does not close it:
+
+- `track.Subscriber.recvGroup` removes the group **synchronously** (`groups.shift(); return group;`), and the `.then()` callback runs one microtask later.
+- `Reader.#fillTo` only awaits `#fill()` while the buffer is short, so a SUBSCRIBE\_UPDATE whose bytes are already buffered (two messages in one transport chunk) decodes through promise jobs with no further transport read.
+
+So an update continuation can still interleave between the removal and the snapshot, and the group is served under bounds it was not taken under. The blast radius is the same class as the bug #2796 fixed (frames outside the request reaching the wire), at a much lower probability.
+
+#### Candidate fixes
+
+1. Have the cursor hand the bounds back with the group, so the pop and the snapshot are one synchronous step. Closes it exactly, but reshapes a `track.Subscriber` primitive for one caller's internal need, which is the wrong direction per the public-API rules in CLAUDE.md.
+2. Stop sharing mutable state between the two loops: one control-first select over the update decode and the group pop, the way the Rust publisher does it (`poll_recv_next`, control polled before data, `position_group` applied synchronously at the pop). This is the actual root cause and would close the whole class, not this instance.
+
+#### Why I would leave it
+
+Triggering it needs a SUBSCRIBE\_UPDATE already buffered in the reader whose decode continuation lands in a one-microtask gap. Updates are rare (priority changes, cap moves), so this is a narrow slice of an already-narrow window. Option 1 buys the fix with public API surface, and option 2 is a restructure that should be motivated by more than this. If `#runTrack` is ever reworked for other reasons, option 2 is the shape to move toward.
+
+Related: #2796, #2807
+
+## Closes
+
+- [#2808](https://github.com/moq-dev/moq/issues/2808) - close this issue when the quest finishes

--- a/quest/m0/2812-watch-has-audio-stutter-on-ios-on-https-moq-dev-watch.md
+++ b/quest/m0/2812-watch-has-audio-stutter-on-ios-on-https-moq-dev-watch.md
@@ -1,0 +1,22 @@
+# [XS] Watch has Audio stutter on iOS on https://moq.dev/watch/
+
+## Goal
+
+Implement and verify the behavior tracked in [#2812](https://github.com/moq-dev/moq/issues/2812)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Audio stutter on https://moq.dev/watch/
+
+iOS 26.6 (23G71)
+
+## Closes
+
+- [#2812](https://github.com/moq-dev/moq/issues/2812) - close this issue when the quest finishes

--- a/quest/m0/2813-capture-on-ios-is-software-only-not-hardware.md
+++ b/quest/m0/2813-capture-on-ios-is-software-only-not-hardware.md
@@ -1,0 +1,24 @@
+# [XS] Capture on iOS is software only , not hardware
+
+## Goal
+
+Implement and verify the behavior tracked in [#2813](https://github.com/moq-dev/moq/issues/2813)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+<img width="1290" height="2796" alt="Image" src="https://github.com/user-attachments/assets/0b481728-fa5d-44d2-8b45-dc6b13048800" />
+
+https://moq.dev/publish/
+
+It also always asks for camera and audio access on browser refresh .
+
+## Closes
+
+- [#2813](https://github.com/moq-dev/moq/issues/2813) - close this issue when the quest finishes

--- a/quest/m0/2815-divide-the-connection-bandwidth-estimate-among-concurrent.md
+++ b/quest/m0/2815-divide-the-connection-bandwidth-estimate-among-concurrent.md
@@ -1,0 +1,56 @@
+# [M] Divide the connection bandwidth estimate among concurrent encoders
+
+## Goal
+
+Implement and verify the behavior tracked in [#2815](https://github.com/moq-dev/moq/issues/2815)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Found during the adversarial review of #2809.
+
+#### Problem
+
+`moq_net::bandwidth::Consumer` carries a **per-connection** send-bandwidth estimate, but rate control is applied **per-encoder**: `rate::Policy::headroom` (default `0.9`) makes each encoder target 90% of whatever estimate it is handed, and `rate.rs`'s own doctest shows a 2 Mbps estimate producing a 1.8 Mbps target.
+
+Nothing divides that estimate when several encoders share one connection. Two capture pipelines on the same session each target ~90% of the same uplink, or ~180% in aggregate, plus audio and transport overhead. The result is sustained queueing exactly when adaptive rate control should be preventing it.
+
+The `headroom` doc even states the assumption: it reserves room "for the other tracks sharing this connection (audio)", i.e. one video encoder per connection.
+
+#### Current mitigation
+
+\#2809 lets one `moq` process run several import stages, which is what makes multiple capture encoders on one connection reachable. It refuses the combination rather than oversubscribing:
+
+```
+only one stage can encode to fit the connection's bandwidth estimate, but 2 do;
+run them as separate processes, or publish over --server-bind, which has no estimate
+```
+
+Separate processes are unaffected: each gets its own connection and its own estimate. (Strictly, they then oversubscribe the *physical* uplink instead, which is the same underlying gap seen from one layer up.)
+
+#### What a fix needs
+
+Allocation across the encoders sharing a connection, so their targets sum to the estimate rather than each matching it. Roughly:
+
+- a way to split one `bandwidth::Consumer` into N shares (equal, or weighted by each encoder's configured ceiling), or
+- a `policy` knob on `moq_video::encode::Options` so a caller can set `headroom` itself, with moq-cli dividing by the number of adaptive stages.
+
+The first is better: weighting by ceiling handles a 1080p and a 360p rung sharing a link far better than an even split, and it keeps the policy in one place rather than making every caller reinvent it.
+
+Lifting the refusal in moq-cli, plus a regression test covering two capture stages, is the acceptance criterion.
+
+## Closes
+
+- [#2815](https://github.com/moq-dev/moq/issues/2815) - close this issue when the quest finishes
+
+## Related
+
+- [#2859: Passthrough imports reserve no bandwidth, so a co-resident encoder…](/quest/m0/2859-passthrough-imports-reserve-no-bandwidth-so-a-co-resident.md) - related open work
+- [#2848: Follow the bandwidth grant in moq-audio instead of holding a fixed…](/quest/m0/2848-follow-the-bandwidth-grant-in-moq-audio-instead-of.md) - related open work
+- [#2847: The quinn backend's send-bandwidth estimate is cwnd/rtt, not a rate](/quest/m0/2847-the-quinn-backends-send-bandwidth-estimate-is-cwnd-rtt.md) - related open work

--- a/quest/m0/2819-moq-video-carry-pipewire-dma-bufs-safely-into-the-vulkan.md
+++ b/quest/m0/2819-moq-video-carry-pipewire-dma-bufs-safely-into-the-vulkan.md
@@ -1,0 +1,73 @@
+# [XL] moq-video: carry PipeWire DMA-BUFs safely into the Vulkan renderer
+
+## Goal
+
+Implement and verify the behavior tracked in [#2819](https://github.com/moq-dev/moq/issues/2819)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Goal
+
+Complete the Linux zero-copy surface spine from #2481 as one producer-to-consumer series:
+
+`PipeWire DMA-BUF -> moq_video::Surface::DmaBuf -> Vulkan import -> render shader`
+
+This is the first Linux producer and consumer for the public DMA-BUF surface contract. VAAPI encode/decode and V4L2 M2M can reuse the same contract afterward.
+
+#### Required lifetime invariant
+
+Duplicating a DMA-BUF fd preserves the allocation, not the pixels. Returning a dequeued PipeWire buffer lets the compositor overwrite that allocation while a queued frame or GPU import still reads it.
+
+The PipeWire producer must therefore retain the dequeued buffer until the last `DmaBuf` clone drops, then return it to the stream on the PipeWire loop thread. The renderer must retain its clone until the GPU submission completes. An fd-only wrapper is racy and is not acceptable.
+
+#### Phase 1: surface and producer
+
+- \[x] Add the non-default `dmabuf` feature, enabled by `pipewire`, `vaapi`, and `render`.
+- \[x] Add `Surface::DmaBuf` with a concrete public payload, typed DRM format, modifier, dimensions, plane offsets/strides, and mint-on-access `export() -> OwnedFd`.
+- \[x] Keep backend export/download behavior private so no public implementable trait freezes backend internals.
+- \[x] Negotiate DMA-BUF plus shared-memory fallback in PipeWire, preferring packed RGB for the first complete Vulkan path and retaining NV12 support.
+- \[x] Retain the dequeued PipeWire buffer through the surface lifetime and return it on the loop thread.
+- \[x] Keep the universal I420 fallback for linear NV12 and RGB DMA-BUFs. Reject non-linear CPU mapping instead of interpreting tiled memory as rows.
+- \[x] Add unit coverage for descriptors, NV12 stride removal, buffer negotiation, and return-on-last-drop.
+
+#### Phase 2: renderer consumer
+
+- \[x] Add a Linux Vulkan DMA-BUF importer behind the non-default render feature.
+- \[x] Import single-plane XRGB/ARGB/XBGR/ABGR through wgpu 30's `VULKAN_EXTERNAL_MEMORY_DMA_BUF` HAL path.
+- \[x] Retain the producer surface until the GPU submission completes, so PipeWire cannot overwrite in-flight pixels.
+- \[x] Preserve the renderer's CPU fallback and three-strike fast-path retirement.
+- \[x] Document the wgpu device feature required for DMA-BUF import. A custom device-creation helper is unnecessary with wgpu 30.
+- \[ ] Import multi-plane NV12 with explicit DRM modifier plane layouts.
+- \[ ] Copy imported NV12 Y/UV planes into wgpu-sampleable R8/RG8 textures without touching the CPU.
+- \[ ] Handle unsupported Intel tiling with a VAAPI VPP re-tile path. The current `moq-vaapi` API does not expose VPP yet.
+
+#### Validation gates
+
+- \[x] macOS `moq-video --all-features` compile and tests remain green.
+- \[x] The wgpu 30 packed DMA-BUF HAL import compiles in an isolated Vulkan-enabled API check.
+- \[x] Linux renderer-only cross-build (`x86_64-unknown-linux-gnu`, `--features render`).
+- \[ ] Native Linux `--features pipewire,render` compile and tests.
+- \[ ] Shared-memory PipeWire fallback still captures.
+- \[ ] Intel or AMD desktop: packed DMA-BUF capture renders with zero CPU download.
+- \[ ] Modifier mismatch exercises VPP re-tiling on hardware that needs it.
+- \[ ] Holding several frames cannot produce torn/reused content or exhaust the pool permanently.
+- \[ ] Hardware tests ship ignored with a reason where CI lacks the device.
+
+The first packed-RGB vertical slice is implemented locally. Native Linux validation is still required before opening a PR, and the zero-copy tracker item stays open until the real hardware gates pass.
+
+Refs #2481, #1837.
+
+## Closes
+
+- [#2819](https://github.com/moq-dev/moq/issues/2819) - close this issue when the quest finishes
+
+## Related
+
+- [#2893: video: validate PipeWire DMA-BUF capture on KDE hardware](/quest/m0/2893-video-validate-pipewire-dma-buf-capture-on-kde-hardware.md) - related open work

--- a/quest/m0/2822-moq-wasm-bind-the-datagram-path-append-datagram-recv.md
+++ b/quest/m0/2822-moq-wasm-bind-the-datagram-path-append-datagram-recv.md
@@ -1,0 +1,38 @@
+# [S] moq-wasm: bind the datagram path (append_datagram / recv_datagram)
+
+## Goal
+
+Implement and verify the behavior tracked in [#2822](https://github.com/moq-dev/moq/issues/2822)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Split out of #2814, where the Codex reviewer raised it.
+
+\#2814 expands `rs/moq-wasm` to bind moq-net's model: publish, discovery, on-demand serving, fetch, subscription options, track properties, cursors, frame timestamps. Datagrams are the one part of the **track** model it leaves out.
+
+Unbound today:
+
+- `moq_net::track::Producer::append_datagram` / `write_datagram`
+- `moq_net::track::Subscriber::recv_datagram`
+- the `moq_net::Datagram` value type (`sequence`, `timestamp`, `payload`)
+
+So a browser publisher cannot emit datagrams and a browser subscriber has no way to observe them, even though `@moq/net` exposes `appendDatagram` / `writeDatagram` / `datagrams` and the browser transport carries them.
+
+This is reachable, not theoretical: datagrams flow on moq-lite-05 over a transport that supports them, and `rs/moq-wasm/src/transport.rs` already implements the datagram side of `web_transport_trait::Session`. They are dropped on IETF moq-transport, moq-lite before 05, and stream-only transports like WebSocket, so any binding should make that conditional obvious rather than looking like a silent no-op.
+
+Deliberately deferred out of #2814 rather than rushed in: everything else in that PR was verified in a browser against a relay, and shipping datagram bindings without the same treatment would be the one untested corner of a new public surface. A datagram round trip needs its own harness (publish a datagram, confirm it arrives, and confirm the documented drop on a version that can't carry it), which is more than a review pass should bolt on.
+
+`rs/moq-wasm/README.md` lists this under "Not covered" so the surface doesn't overclaim in the meantime.
+
+Related: #2816 (no browser test harness at all), which is what would make verifying this cheap.
+
+## Closes
+
+- [#2822](https://github.com/moq-dev/moq/issues/2822) - close this issue when the quest finishes

--- a/quest/m0/2829-moq-export-ts-the-audio-video-interleave-is-decided-by.md
+++ b/quest/m0/2829-moq-export-ts-the-audio-video-interleave-is-decided-by.md
@@ -1,0 +1,105 @@
+# [L] moq export ts: the audio/video interleave is decided by arrival timing, so two exporters of one…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2829](https://github.com/moq-dev/moq/issues/2829)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+Two `moq export ts` processes subscribed to the same broadcast do not emit the same frames in the
+same order. `pick_next_track` takes the smallest timestamp among tracks that *currently hold* a
+pending frame, and a track only holds one once its own `poll_read` has returned  -  so when audio for
+timestamp *t* has not yet arrived but video for *t+1* has, the exporter emits the video. Which frame
+leads is therefore a property of when bytes reached that process, not of the media.
+
+This is the last of three values the exporter mints from process state rather than from the
+broadcast. #2779 covers the continuity counters and #2825 the SI cadence; with both addressed, this
+is what remains, and unlike the other two it moves whole PES packets rather than renumbering a field.
+
+#### Measurement
+
+One publisher, one relay, two `export ts` subscribers of the same broadcast, each paced to a
+constant-rate RTP leg whose packet placement is derived from the stream position rather than the
+process clock. The two legs are then compared at equal stream slots with the continuity counter
+masked, so what is left is only what the exporters actually rendered differently.
+
+Single-track source (H.264, no B-frames, no audio, 2 Mb/s CBR), second subscriber joining 20 s late:
+
+| build | slots identical, counter masked |
+|---|---|
+| `main` | 96.43 % |
+| #2825 | **100.00 %** |
+
+Multi-track source (H.264 with B-frames, two audio renditions, SDT and NIT), same rig:
+
+| build | slots identical, counter masked |
+|---|---|
+| `main` | 87.75 % |
+| #2825 | 89.72 % |
+| #2825 with the monotonic `due` from the review | 95.62 % |
+
+The residual 4.4 % is not a late-join effect. With both subscribers started at the same instant it is
+4.82 %. Over 62 073 compared slots the two legs agree exactly on every table  -  PAT 111/111, PMT
+111/111, SDT 22/22, NIT 5/5  -  while rendering different numbers of media packets:
+
+```
+    0x006f (video):  263,264 / 263,283   (+19)
+    0x0079 (audio):    7,313 /   7,241   (-72)
+    0x007b (audio):    5,789 /   5,738   (-51)
+```
+
+That is the signature of an ordering difference rather than a numbering one: the same media, placed
+in different slots, so every byte after the first divergence lines up against something else.
+
+#### Mechanism
+
+`poll_next` fills `track.pending` for whichever tracks have a frame available right now:
+
+https://github.com/moq-dev/moq/blob/6d3c51d72/rs/moq-mux/src/container/ts/export.rs#L254-L283
+
+and then picks the minimum over exactly those:
+
+https://github.com/moq-dev/moq/blob/6d3c51d72/rs/moq-mux/src/container/ts/export.rs#L682-L688
+
+The pick itself is deterministic  -  `(timestamp, pid, name)` breaks every tie  -  but the *candidate set*
+is not. A track whose frame has not arrived is simply not considered, so the exporter emits the
+earliest available frame rather than the earliest frame. Two processes with different arrival timing
+therefore choose differently, and neither is wrong in isolation.
+
+#### Why it matters
+
+An MPEG-TS receiver does not care about the interleave. A *second* receiver does: SMPTE ST 2022-7
+seamless protection switching merges two copies of one stream by taking whichever arrives first,
+which requires the two copies to be the same bytes. With the counter and the cadence fixed, a pair of
+legs is already byte-identical on single-track content; on ordinary multi-track content the interleave
+is what stops it, and no amount of care downstream can put the frames back in a common order.
+
+It also affects anything that compares two renderings for equality  -  regression tests across runs, and
+checksums of an exported stream.
+
+#### Suggested direction
+
+Emit only once every unfinished track has a pending frame, so the minimum is taken over the whole
+candidate set rather than the arrived part of it. That is a bounded wait in practice  -  the tracks of
+one broadcast advance together  -  but it should be bounded explicitly so a stalled or genuinely idle
+track cannot hold the output: after a small window, emit what is in hand, as today.
+
+That makes the ordering a function of the media wherever the window is not exceeded, which is the
+condition under which two legs can be a redundant pair. It would fit naturally alongside the existing
+`--latency-max`.
+
+I am happy to put this behind a flag if a deterministic-rendering mode is preferable to changing the
+default.
+
+## Closes
+
+- [#2829](https://github.com/moq-dev/moq/issues/2829) - close this issue when the quest finishes

--- a/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md
+++ b/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md
@@ -1,0 +1,40 @@
+# [M] moq export ts: a rewound timeline stalls the SI table cadence until the media clock catches up
+
+## Goal
+
+Implement and verify the behavior tracked in [#2833](https://github.com/moq-dev/moq/issues/2833)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+`moq export ts` re-emits the standalone SI tables (SDT on 0x0011, NIT on 0x0010) on a repetition cadence driven by the media timestamp. When the publisher rewinds its timeline, the cadence stops firing until the media clock climbs back past the point it had already reached, which for a large rewind means the SI tables are absent for that entire span.
+
+PAT/PMT do not have this problem, because they are also re-emitted at every video keyframe and a rewind resumes at a keyframe. There is no equivalent trigger for the SI PIDs, and an audio-only program has no keyframe trigger for PAT/PMT either.
+
+#### Mechanism
+
+`due` in `rs/moq-mux/src/container/ts/export.rs` fires when a timestamp reaches a repetition slot later than the last emission's. The stored "last emission" only ever moves forward, so after a backwards jump every subsequent frame compares against a slot the stream has already left behind, and nothing is due until the timeline catches up.
+
+This is not a regression. Before #2825 the same comparison was `elapsed = timestamp - last`, which underflowed on a backwards timestamp and reported not-due, so a rewind stalled the cadence exactly the same way. #2825 changed how the cadence is anchored, not how it behaves across a rewind, and deliberately kept the existing behavior rather than widening scope.
+
+The reason the obvious fix is not simply "fire whenever the slot changes" is that video is emitted in decode order, so a reordered (B-frame) PTS steps backwards constantly. Treating that as a new slot re-emits the tables on every oscillation across a boundary, which was measured on real contribution content at roughly 25x the intended PSI rate (0.071% to 1.747% of the stream). See the discussion on #2825.
+
+#### Direction
+
+A rewind and a reorder are separable by magnitude: reorder depth is bounded by the codec's reorder buffer (the catalog records it as `jitter`, measured at 180 ms on the content above), where a rewind is a discontinuity of arbitrary size. Either a threshold comfortably above the reorder depth, or the existing rewind signal, would do:
+
+`container::Consumer` already detects the rewind that matters here (a newer group whose timestamps jump backwards past the live edge) and exposes it as `discontinuity()`. Reacting to that counter changing, rather than inferring a rewind from timestamp arithmetic, would need no threshold and would reuse a mechanism that already has the group-level context to tell a rewind from a reordered frame.
+
+Worth handling together with whatever the exporter should be doing about PCR and the `discontinuity_indicator` across a rewind, which is a related gap: the emitted PCR jumps backwards with no adaptation-field flag to say so.
+
+## Closes
+
+- [#2833](https://github.com/moq-dev/moq/issues/2833) - close this issue when the quest finishes

--- a/quest/m0/2835-moq-wasm-bind-track-dynamic-so-a-browser-publisher-can.md
+++ b/quest/m0/2835-moq-wasm-bind-track-dynamic-so-a-browser-publisher-can.md
@@ -1,0 +1,35 @@
+# [S] moq-wasm: bind track::Dynamic so a browser publisher can serve cache-miss fetches
+
+## Goal
+
+Implement and verify the behavior tracked in [#2835](https://github.com/moq-dev/moq/issues/2835)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Split out of #2814, where the Codex reviewer raised it.
+
+\#2814 binds `TrackConsumer.fetchGroup(sequence, options)`, the *requesting* side of a FETCH. The serving side is missing.
+
+When a browser publisher is asked for a group it no longer has cached, moq-net resolves the fetch only if the publisher holds a `moq_net::track::Dynamic` and answers its `requested_group()` with a `GroupRequest` (`accept(info)` / `reject(err)`). Otherwise the fetch fails with `NotFound`. `rs/moq-wasm` exposes neither, so from JavaScript every cache-miss fetch is unserveable.
+
+Note the asymmetry this leaves: #2814 *does* bind the broadcast-level equivalent, `BroadcastProducer.requestedTrack()` over `broadcast::Dynamic`, so on-demand serving works for tracks but not for groups within a track.
+
+Roughly what's needed:
+
+- a `TrackProducer.requestedGroup()` entry point over `track::Dynamic`, minted lazily like `requestedTrack` does for `broadcast::Dynamic` (creating a `Dynamic` registers an on-demand handler, so it shouldn't happen for callers who never serve)
+- a `GroupRequest` binding with `sequence`, `priority`, `accept(info)` -> `GroupProducer`, and `reject(code)`
+
+Deliberately deferred out of #2814 rather than rushed in: it is new public surface, and everything else in that PR was verified in a browser against a relay. Serving a cache-miss fetch needs a harness that evicts or never caches a group and then fetches it, which is more than a review pass should bolt on.
+
+Related: #2822 (datagrams, the other unbound part of the track model) and #2816 (no browser test harness, which is what would make verifying this cheap).
+
+## Closes
+
+- [#2835](https://github.com/moq-dev/moq/issues/2835) - close this issue when the quest finishes

--- a/quest/m0/2838-js-flate-codec-rejects-frames-that-inflate-past-the.md
+++ b/quest/m0/2838-js-flate-codec-rejects-frames-that-inflate-past-the.md
@@ -1,0 +1,54 @@
+# [M] js/flate: "codec rejects frames that inflate past the default cap" times out under parallel test…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2838](https://github.com/moq-dev/moq/issues/2838)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`just test` fails intermittently on `@moq/flate`, and it is a timeout rather than a logic failure:
+
+```
+@moq/flate test: (fail) codec rejects frames that inflate past the default cap [5273.79ms]
+@moq/flate test:  8 pass
+@moq/flate test:  1 fail
+```
+
+5273ms against bun's 5000ms default per-test timeout. It squeaks under the limit on an idle machine and blows it when the rest of the suite is competing for CPU.
+
+#### Why it's slow
+
+`js/flate/src/index.test.ts` builds a 64 MiB decompression bomb:
+
+```ts
+const slice = encoder.frame(enc.encode("a".repeat(64 * 1024 * 1024 + 1)));
+expect(() => decoder.frame(slice)).toThrow(/exceeded/);
+```
+
+That is a 64 MiB string allocation, a UTF-8 encode, a deflate, and a bounded inflate. Inherently CPU-bound, so it scales with machine contention rather than with anything the test is checking.
+
+#### Evidence it's load, not logic
+
+- In isolation the whole file runs in **1.99s, 9/9 pass**, repeatedly.
+- Under a full parallel `just test` (and again under `just js test`) it reproduces at ~5.3s.
+- The assertion itself is about the *cap* being enforced, which does not require the payload to be anywhere near 64 MiB.
+
+Observed while running `just test` for #2814, a PR touching only `rs/moq-wasm` and READMEs, with no path to `@moq/flate`. That PR's CI is green, so this appears to be a local/loaded-runner condition rather than something CI hits today, but it costs a full re-run every time it bites.
+
+#### Options
+
+- Drop the payload to just over the default cap instead of 64 MiB. The decoder bounds output *as it is produced*, so a payload slightly past the limit exercises the same path far more cheaply.
+- Or give this one test an explicit generous timeout, so it is deliberate rather than accidentally sitting 5% under the default.
+
+The first is better: it makes the test fast *and* keeps it honest, rather than making a slow test tolerated.
+
+## Closes
+
+- [#2838](https://github.com/moq-dev/moq/issues/2838) - close this issue when the quest finishes

--- a/quest/m0/2847-the-quinn-backends-send-bandwidth-estimate-is-cwnd-rtt.md
+++ b/quest/m0/2847-the-quinn-backends-send-bandwidth-estimate-is-cwnd-rtt.md
@@ -1,0 +1,77 @@
+# [M] The quinn backend's send-bandwidth estimate is cwnd/rtt, not a rate
+
+## Goal
+
+Implement and verify the behavior tracked in [#2847](https://github.com/moq-dev/moq/issues/2847)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+`estimated_send_rate()` is documented in `web-transport-trait` as "estimated available send bandwidth", but the two backends return fundamentally different quantities:
+
+- **quiche** (`web-transport-quiche`): `path.delivery_rate * 8`, i.e. the congestion controller's measured delivery rate. This is a rate.
+- **quinn** (`web-transport-quinn`): `cwnd * 8 / rtt`.
+
+```rust
+fn estimated_send_rate(&self) -> Option<u64> {
+    let rtt_secs = self.rtt.as_secs_f64();
+    if self.stats.path.cwnd > 0 && rtt_secs > 0.0 {
+        Some((self.stats.path.cwnd as f64 * 8.0 / rtt_secs) as u64)
+    } else {
+        None
+    }
+}
+```
+
+`cwnd / rtt` is not a bandwidth estimate. It's a window divided by a latency, which means:
+
+- **It only falls on loss or RTT inflation.** Under a loss-based controller, steady-state `cwnd` includes the standing queue, so the number reported is the bottleneck rate *plus* whatever is sitting in the buffer. A sender targeting a fraction of it maintains bufferbloat rather than avoiding it.
+- **It is stale-high when app-limited.** `cwnd` stops growing when you stop filling it, but it doesn't shrink either, so an idle-ish sender reads a ceiling from whenever the pipe was last full.
+- **It moves with RTT for reasons unrelated to capacity.** A route change or a cross-traffic latency spike rescales the estimate without the available bandwidth having changed.
+
+`moq_net::Session::send_bandwidth` samples this every 100ms and it is the input to `moq_video::encode::rate::Policy`, which is where it turns into a real encoder bitrate. It is also what the lite PROBE message reports to the peer (`lite/publisher.rs`), so a bad estimate propagates across the session rather than staying local.
+
+#### What's needed
+
+The BBR pacing rate. quinn already computes it and it is already exposed on a public, non-qlog-gated trait method:
+
+```rust
+// quinn_proto::congestion::Controller
+fn metrics(&self) -> ControllerMetrics { .. }
+
+pub struct ControllerMetrics {
+    pub congestion_window: u64,
+    pub ssthresh: Option<u64>,
+    pub pacing_rate: Option<u64>,   // bits/s
+}
+```
+
+`Bbr::metrics()` populates `pacing_rate: Some(self.pacing_rate * 8)`; `Cubic::metrics()` leaves it `None`, which is the correct signal for "this controller has no rate estimate". Today the only consumer is `qlog_recovery_metrics`, behind the `qlog` feature, so the value never reaches `ConnectionStats`.
+
+`moq-native` already defaults quinn to BBR (`congestion_control(quic)` -> `CongestionControl::Delay` -> `BbrConfig`), so the pacing rate would be populated on the default path.
+
+Fix chain, cheapest first:
+
+1. **quinn**: add `pacing_rate: Option<u64>` to `PathStats`, populated from `congestion.metrics().pacing_rate` without the qlog gate. The value is already computed on every ack; this is plumbing it into the stats snapshot.
+2. **web-transport-quinn**: return `path.pacing_rate` from `estimated_send_rate()`. Falling back to `cwnd / rtt` when it's `None` (CUBIC) is defensible, but returning `None` is more honest and lets a caller distinguish "no estimate" from "a bad one".
+3. **web-transport-trait**: tighten the doc on `estimated_send_rate` to say what the quantity is, so a third backend doesn't invent a fourth interpretation.
+
+#### Why now
+
+[#2815](https://github.com/moq-dev/moq/issues/2815) divides this estimate among concurrent encoders sharing a connection. That makes the arithmetic honest, but every share inherits whatever error is in the input, so the allocator is only as good as this number. Worth fixing independently: today a single encoder on the quinn backend is already rate-controlling against a window, not a rate.
+
+## Closes
+
+- [#2847](https://github.com/moq-dev/moq/issues/2847) - close this issue when the quest finishes
+
+## Related
+
+- [#2815: Divide the connection bandwidth estimate among concurrent encoders](/quest/m0/2815-divide-the-connection-bandwidth-estimate-among-concurrent.md) - related open work

--- a/quest/m0/2848-follow-the-bandwidth-grant-in-moq-audio-instead-of.md
+++ b/quest/m0/2848-follow-the-bandwidth-grant-in-moq-audio-instead-of.md
@@ -1,0 +1,44 @@
+# [M] Follow the bandwidth grant in moq-audio instead of holding a fixed reservation
+
+## Goal
+
+Implement and verify the behavior tracked in [#2848](https://github.com/moq-dev/moq/issues/2848)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to [#2815](https://github.com/moq-dev/moq/issues/2815), which divides a connection's send-bandwidth estimate among the tracks sharing it.
+
+In that first pass `moq-audio` registers a share at its configured bitrate and then ignores the grant: it reserves, but never follows. That keeps the video encoder's share honest (audio is no longer invisible to it), which is most of the value, but it means a link too small for the configured audio rate has no way to shed audio bits.
+
+#### What to add
+
+Opus can retune live. `moq_audio::encode::encoder` already has `set_opus_bitrate` (valid range 500 bps up to a per-channel-count max) and reads the value back with `OPUS_GET_BITRATE`, so following a grant is a matter of feeding it through a rate policy at the same point `moq-video` does, rather than any new codec work.
+
+Reuse `moq_video::encode::rate::Control` rather than writing a second policy, or lift it somewhere both crates can reach. Its attack/decay shape (drops apply at once, raises ramp) is codec-agnostic, and having two rate policies drift apart is exactly the problem [#2815](https://github.com/moq-dev/moq/issues/2815) was closing.
+
+#### What can't adapt
+
+PCM. `pcm::bitrate(codec_rate, codec_channels)` is fixed by sample rate and channel count, and `Config::bitrate` is rejected outright for it. So a "reserves but never follows" share has to remain expressible regardless; this issue is about Opus opting into following, not about removing the fixed case.
+
+#### Priority
+
+Low. `hang::catalog::PRIORITY` puts audio at 80 and video at 60, so the allocator satisfies audio's reservation before video sees a bit. Audio only gets squeezed once the link can't carry audio alone, at which point the picture is long gone. Worth doing for the tail case, not worth blocking on.
+
+## Required
+
+- [#2815: Divide the connection bandwidth estimate among concurrent encoders](/quest/m0/2815-divide-the-connection-bandwidth-estimate-among-concurrent.md) - complete the prerequisite issue first
+
+## Closes
+
+- [#2848](https://github.com/moq-dev/moq/issues/2848) - close this issue when the quest finishes
+
+## Related
+
+- [#2815: Divide the connection bandwidth estimate among concurrent encoders](/quest/m0/2815-divide-the-connection-bandwidth-estimate-among-concurrent.md) - related open work

--- a/quest/m0/2849-moq-import-ts-a-truncated-or-spliced-opus-pes-ends-the.md
+++ b/quest/m0/2849-moq-import-ts-a-truncated-or-spliced-opus-pes-ends-the.md
@@ -1,0 +1,63 @@
+# [M] moq import ts: a truncated or spliced Opus PES ends the session
+
+## Goal
+
+Implement and verify the behavior tracked in [#2849](https://github.com/moq-dev/moq/issues/2849)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+##### Summary
+
+A truncated or spliced Opus PES ends the whole session, the same way a damaged AC-3 header used to before #2751. Found while reviewing #2823; it predates that PR and is not introduced by it.
+
+##### Mechanism
+
+`OpusStream::write` treats any malformed packet as fatal, and the error travels up out of `Import::decode`, which the callers treat as terminal:
+
+```rust
+let (header_len, size) = parse_opus_control_header(&data[offset..])?;
+let start = offset + header_len;
+let end = start + size;
+anyhow::ensure!(end <= data.len(), "Opus access unit exceeds PES payload");
+```
+
+A PES does not have to be damaged in transit to reach this. `handle_pes_start` flushes whatever is pending whenever the next PES begins, so a PES left short by a wrap, a dropped packet, or a capture that starts mid-stream is handed to `write` as though it were complete.
+
+##### Reproduction
+
+Loop the in-tree fixture at each packet boundary and import each result:
+
+```rust
+let data = include_bytes!("test_data/opus.ts");
+for cut in (188..data.len()).step_by(188) {
+    let mut looped = data[..cut].to_vec();
+    looped.extend_from_slice(data);
+    // ... Import::new(...).decode(&looped) must not error
+}
+```
+
+Two distinct failures, both on `main`:
+
+- wrap at packet 21: `Opus access unit exceeds PES payload` (the `ensure!` above, a PES cut short of the length its control header promises)
+- wrap at packet 22: `invalid Opus control header sync (0x7d6a)` (the post-splice bytes are not a control header)
+
+##### Why it is not fixed in #2823
+
+That PR stops a continuity break from handing a spliced buffer to any codec, and excludes Opus from the salvage path so it adds no new abort. Neither addresses this, because the truncated PES arrives through the ordinary `handle_pes_start` flush with continuity intact.
+
+Making the first case graceful is a few lines (drop the truncated tail rather than erroring). The second is the harder half: it needs what #2751 built for the legacy codecs, a scan to the next plausible boundary with confirmation before publishing, and Opus has none of that machinery. Doing only the first leaves a half-fix that the reproduction above still fails, which is why #2823 ships neither.
+
+##### Worth deciding alongside
+
+The legacy path deliberately keeps a byte budget so that a PID whose payload never parses still fails loudly rather than publishing nothing forever. Opus should not simply swallow every parse error, or a PMT that mislabels a PID as Opus becomes a silent dead track. The budget in `Resync` is the precedent to follow.
+
+## Closes
+
+- [#2849](https://github.com/moq-dev/moq/issues/2849) - close this issue when the quest finishes

--- a/quest/m0/2850-js-net-give-reader-a-synchronous-decode-so-the-publisher.md
+++ b/quest/m0/2850-js-net-give-reader-a-synchronous-decode-so-the-publisher.md
@@ -1,0 +1,32 @@
+# [M] js/net: give Reader a synchronous decode so the publisher need not read controls ahead
+
+## Goal
+
+Implement and verify the behavior tracked in [#2850](https://github.com/moq-dev/moq/issues/2850)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Split out of the review on https://github.com/moq-dev/moq/pull/2820.
+
+The lite publisher's serving loop must apply every buffered control before it pops a group, or a group goes out under a subscription range the peer has already superseded. In Rust that falls out of `poll_decode_maybe` (`rs/moq-net/src/lite/publisher.rs`), which decodes a message straight out of the reader's buffer synchronously, so the loop can drain controls to exhaustion in one poll.
+
+Nothing on the JS side can decode synchronously: `Reader`'s primitives (`u62`, `u53`, `read`) are all async, so `SubscribeUpdate.decodeMaybe` yields microtasks even when every byte is already buffered. The publisher works around this by decoding ahead into a queue (`SubscriptionControls` in `js/net/src/lite/publisher.ts`), which the loop drains synchronously.
+
+That is correct but leaves the queue unbounded. It only grows while the serving loop is blocked in a control-stream write (SUBSCRIBE\_START / SUBSCRIBE\_END), and the loop drains it in one synchronous burst, so it stays small in practice. A peer that floods SUBSCRIBE\_UPDATE while such a write is stalled can still grow it without a ceiling, converting flow-controlled bytes into heap objects.
+
+Bounding it naively does not work: a single-message slot was tried in #2820 and broke control-first ordering, because `take()` cannot yield to the decoder without letting a group pop slip in between. The fix is to remove the read-ahead instead of capping it.
+
+Sketch: give `Reader` a way to attempt a decode using only buffered bytes, returning undefined when the message is incomplete rather than awaiting the transport (the `poll_decode_maybe` equivalent). The publisher then drains controls synchronously in its loop with no queue at all, bounded memory and exact ordering both. This needs a synchronous path through the message decoders, which today are written against the async reader, so it is not a small change.
+
+Not urgent: the current behavior is correct, and the unbounded case needs a hostile peer plus a stalled control write.
+
+## Closes
+
+- [#2850](https://github.com/moq-dev/moq/issues/2850) - close this issue when the quest finishes

--- a/quest/m0/2853-quiche-with-a-pinned-source-port-can-dial-only-a-broken.md
+++ b/quest/m0/2853-quiche-with-a-pinned-source-port-can-dial-only-a-broken.md
@@ -1,0 +1,40 @@
+# [M] quiche with a pinned source port can dial only a broken IPv4 address
+
+## Goal
+
+Implement and verify the behavior tracked in [#2853](https://github.com/moq-dev/moq/issues/2853)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+`rs/moq-native/src/quiche.rs` truncates its candidate list to one address when `--connect-bind` pins a non-zero source port, because a pinned port only fits one socket at a time:
+
+```rust
+if self.bind.port() != 0 {
+    candidates = candidates.with_limit(1);
+}
+```
+
+Since #2749, that single candidate can come from the speculative IPv4-only lookup rather than the authoritative all-family answer. `Candidates::next` already mitigates this per RFC 8305 section 3: for the first candidate it holds an IPv4-only answer back and waits up to `--connect-resolution-delay` (50ms) for the full lookup, so the platform's own RFC 6724 ranking usually wins.
+
+That bounds the window rather than closing it. If AAAA is more than the resolution delay slower than A, the wait times out and the IPv4 address is taken. With `limit(1)` there is no second attempt, so a host whose IPv4 path is broken and whose IPv6 path works now fails to connect, where before #2749 the dial waited for the complete resolver result and took its first (IPv6) address.
+
+Narrow by construction: it needs the quiche backend, a pinned non-zero `--connect-bind` port, a slow AAAA, and a broken IPv4 path. Every other backend races both families, so `limit(1)` is the only place a preference becomes an exclusion.
+
+#### Suggested direction
+
+For the `limit(1)` path specifically, wait for the authoritative answer rather than accepting the fast lane: the fast lane exists to start dialing sooner, which is worth nothing when only one attempt will ever be made.
+
+Found while reviewing #2852 (merging main into dev); the code is identical on `main`, so this is not a merge regression and was left out of that PR. Originally raised by the Codex connector bot as an inline comment there.
+
+## Closes
+
+- [#2853](https://github.com/moq-dev/moq/issues/2853) - close this issue when the quest finishes

--- a/quest/m0/2857-bindings-cant-reach-encoder-rate-control-so-every-non.md
+++ b/quest/m0/2857-bindings-cant-reach-encoder-rate-control-so-every-non.md
@@ -1,0 +1,43 @@
+# [M] Bindings can't reach encoder rate control, so every non-Rust publisher ignores congestion
+
+## Goal
+
+Implement and verify the behavior tracked in [#2857](https://github.com/moq-dev/moq/issues/2857)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Noticed while wiring [#2854](https://github.com/moq-dev/moq/pull/2854).
+
+#### Problem
+
+Every non-Rust publisher encodes at its configured bitrate regardless of congestion. There is no way to reach the encoder rate control from a binding:
+
+- `moq-ffi` and `libmoq` publish video (`moq_publish_video_raw`) and audio (`moq_audio::encode::Options::default()`), but never set `Options::bandwidth`.
+- The send estimate is exposed only as a **snapshot**, on `moq_connection_stats` / `Session::stats` (`send_rate_bps` + a `_valid` flag). A caller can read a number; it cannot hand a live handle to an encoder.
+
+So an OBS plugin, or a Python/Swift/Kotlin/Go publisher, overshoots a closing uplink exactly as far as its configured bitrate is above what the link can carry, and keeps overshooting until the operator changes the setting by hand. The Rust path has followed the estimate since `moq_video::encode::rate` landed.
+
+This predates the bandwidth allocator; [#2854](https://github.com/moq-dev/moq/pull/2854) didn't regress it, it just made the hole visible by giving the Rust side a second thing bindings can't reach.
+
+#### What a fix needs
+
+The awkward part is that both `bandwidth::Consumer` and `bandwidth::Allocator` are live handles with wakeups, which is not a shape UniFFI or a C ABI carries naturally. Options, roughly cheapest first:
+
+- **A flag on the publish call**: "follow this connection's estimate", with the binding creating the allocator and registering the track on the caller's behalf. No new handle type crosses the boundary, and it's the behavior nearly every caller wants. Loses the ability to share one allocator across separately-created publishers.
+- **An opaque allocator handle** (`moq_allocator_*` / a UniFFI object) minted from a session and passed into each publish call. Mirrors the Rust API exactly and composes across publishers, at the cost of a new object in five wrappers.
+- **A polled getter** returning the current target for a track, leaving the caller to drive their own encoder. Fits an application that owns its encoder (OBS does), useless for the built-in encode path.
+
+The first two are not exclusive: the flag can be the default and the handle an escape hatch.
+
+Whichever way, this touches `rs/moq-ffi`, `rs/libmoq`, `{py,swift,kt}/`, `go/wrapper/moq/`, and `doc/lib/{py,swift,kt,go,c}` per the Cross-Package Sync table, plus `cpp/obs` if the OBS plugin should adopt it.
+
+## Closes
+
+- [#2857](https://github.com/moq-dev/moq/issues/2857) - close this issue when the quest finishes

--- a/quest/m0/2858-transcode-ladders-encode-every-live-rung-at-full-bitrate.md
+++ b/quest/m0/2858-transcode-ladders-encode-every-live-rung-at-full-bitrate.md
@@ -1,0 +1,180 @@
+# [XL] Transcode ladders encode every live rung at full bitrate over one connection
+
+## Goal
+
+Implement and verify the behavior tracked in [#2858](https://github.com/moq-dev/moq/issues/2858)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+### Congestion-aware transcode ladders
+
+Follow-up to [#2854](https://github.com/moq-dev/moq/pull/2854), which divides a connection's send estimate among the tracks sharing it.
+
+#### Problem
+
+`moq-transcode` creates one encoder per demanded rung, opens each at its configured maximum bitrate, and publishes every rung over the same first-mile connection. It does not receive a bandwidth estimate or call live encoder rate control, so congestion makes every active rung continue producing at its ceiling.
+
+Simply assigning every rung an allocator share is not enough. A ladder also needs coherent answers for:
+
+- how far a rendition may adapt before it becomes worse than the next lower rendition;
+- how the catalog tells players to switch;
+- how lower renditions outrank higher renditions without overriding subscriber priority;
+- how FETCH, idle rungs, legacy players, and encoders without live rate control behave; and
+- which catalog changes actually require a decoder rebuild.
+
+This issue is the umbrella for the policy and its staged implementation.
+
+#### Resolved semantics
+
+##### One ladder controller per output bandwidth domain
+
+One central controller owns all generated rungs for one dedicated publisher uplink. The controller receives an optional connection bandwidth consumer and subdivides it across the ladder.
+
+- Supplying no bandwidth consumer preserves today's fixed-rate behavior and never publishes congestion-induced `stalled` state.
+- Only demanded rungs consume allocation. An idle rung remains known to the controller so its catalog state can recover without periodically encoding probe traffic.
+- The built-in CLI passes its publisher session's send-bandwidth handle. This is first-mile adaptation, not per-viewer adaptation.
+- Sharing one output broadcast across several independently constrained output sessions is outside this model because one encoder and one catalog bit cannot represent per-session state.
+
+##### Canonical ladder order and priority
+
+Resolve renditions into strictly ascending configured maximum bitrate. Reject duplicate ceilings and configurations whose coded resolutions decrease as bitrate increases when dimensions are available.
+
+The lower configured maximum receives the higher publisher-side transmission priority. Subscriber priority remains primary; rendition order only breaks ties among subscriptions at the same subscriber priority.
+
+This requires scheduler work beyond #2854. That PR uses publisher priority for allocation but explicitly does not yet align local transmission order with it.
+
+##### Adaptive bands
+
+`VideoConfig.bitrate` remains the configured maximum bitrate. It does not follow the instantaneous encoder target.
+
+For a rendition with configured maximum `max` and the next lower rendition's configured maximum `lower`, define:
+
+```text
+stall = (max + 2 * lower) / 3
+```
+
+The lowest rendition uses `lower = 0`, so its stall boundary is `max / 3`.
+
+A live-rate-control encoder may adapt within `[stall, max]`. When its allocation reaches the boundary, clamp the encoder at the boundary and publish `stalled: true`. Existing and direct subscribers may continue receiving it, but an updated player should move to a lower rendition. Clear `stalled` only after a target above the same boundary is successfully applied.
+
+Start with the existing rate controller's 5 percent movement hysteresis, immediate decreases, and gradual upward ramp. Do not add a second re-entry threshold or dwell timer until measurements show that catalog state flaps.
+
+Catalog state must follow the last target successfully accepted by the encoder, not merely the controller's requested target. Transient rate-control failures retain the last applied target and retry on a later material control movement.
+
+##### Encoders without live rate control
+
+`BitrateUnsupported` is an explicit best-effort fallback:
+
+- continue encoding at the configured maximum;
+- publish `stalled: true` whenever the allocation is below that fixed maximum;
+- clear it only when the full configured maximum fits again; and
+- rely on transmission priority and transport shedding to protect lower renditions.
+
+This preserves existing and legacy subscribers but deliberately does not reclaim encoder work. It must be visible in logs and tests rather than silently pretending the requested target was applied.
+
+##### Catalog signal
+
+Add optional `stalled: boolean` state to each HANG video rendition and the equivalent optional field to MSF video track entries.
+
+- Missing and `false` mean selectable.
+- `true` means the publisher's first-mile allocation cannot currently sustain this rendition's adaptive band.
+- It is advisory. The media track remains addressable and existing subscriptions are not closed merely because the bit changes.
+- It is current state only. Cumulative stall counts and durations belong in stats telemetry, tracked by [#2734](https://github.com/moq-dev/moq/issues/2734).
+- Publisher-originated rendition stall and receiver-observed playback stall must remain distinguishable in QoS metrics.
+
+The HANG draft, Rust and JavaScript schemas, MSF Rust and JavaScript schemas, generated/public catalog bindings, and user-facing catalog documentation must remain synchronized. MSF should document this as a non-standard extension unless it is adopted by the upstream draft. Do not grow `moq_video_config` in place if doing so would break its C ABI; expose the state through an additive accessor or a versioned shape.
+
+Catalog mutations currently publish full HANG, HANGZ, and MSF snapshots. Coalesce all rung state changes from one controller iteration into one publication. Later source catalog snapshots must compose with, rather than overwrite, current generated-rung state.
+
+A stalled rung that loses all updated-player demand must not become permanently stalled merely because it no longer receives an allocator share. The central controller should evaluate that idle rung's hypothetical share against the current connection estimate and active lower-priority reservations, without making the idle rung consume real allocation or encode probe traffic.
+
+##### Player selection and decoder lifecycle
+
+Updated players exclude stalled renditions whenever at least one decoder-supported unstalled rendition exists. If every decoder-supported rendition is stalled, select the lowest one. This keeps video alive while allowing an application to inspect the catalog and disable video according to its own policy.
+
+Separate three reactive identities in `@moq/watch`:
+
+1. Routing identity: resolved broadcast plus track name. A change requires a subscription handoff.
+2. Decoder/pipeline identity: container and only the effective inputs actually needed to construct the demuxer and configure WebCodecs, such as effective codec, description/init data, and latency mode.
+3. Selection and presentation metadata: bitrate, stalled state, coded/display dimensions, framerate, jitter, and timeline.
+
+Metadata-only changes must not create a second `DecoderTrack`, resubscribe locally, rebuild WebCodecs, or rerun codec support probing unnecessarily. Dimension changes are handled as selection/presentation metadata rather than decoder identity.
+
+The existing make-before-break handoff remains for a real routing or decoder/pipeline identity change.
+
+##### FETCH
+
+An uncached FETCH uses the rung's current shared applied target at request time and participates in the same allocation. A stalled rung remains manually fetchable. Cache hits remain unaffected.
+
+The FETCH path currently opens a fresh encoder at the configured maximum for every requested group, so it must consume controller state rather than maintain an independent bitrate policy.
+
+#### Delivery plan
+
+Keep this issue as the umbrella and land independently testable PRs.
+
+Phase 1 can target `main` if every public binding change remains additive. If a generated UniFFI record change is source-breaking, that binding portion targets `dev`. Phases 2 and 3 depend on #2854 and should stack on its `dev` line until that allocator work lands.
+
+##### Phase 1: catalog and player semantics
+
+- \[ ] Add optional HANG rendition `stalled` state in Rust and JavaScript.
+- \[ ] Update `draft-lcurley-moq-hang.md` and catalog documentation.
+- \[ ] Add the equivalent MSF track extension in Rust and JavaScript and document its extension status.
+- \[ ] Carry the field through public catalog consumers and language bindings without breaking the C ABI.
+- \[ ] Filter stalled renditions with the all-stalled lowest-rendition fallback.
+- \[ ] Split routing, decoder/pipeline, and metadata identities in `@moq/watch`.
+- \[ ] Prove bitrate, stalled state, and dimension-only updates do not rebuild the decoder or create a new subscription.
+- \[ ] Prove real codec, description/init, container, or track changes still perform the required handoff.
+
+##### Phase 2: publisher scheduling
+
+- \[ ] Define canonical rung ordering from configured maximum bitrate and validate custom ladders.
+- \[ ] Make lower renditions win the publisher-priority tie-break among equal subscriber priorities.
+- \[ ] Preserve subscriber priority as the primary scheduling authority.
+- \[ ] Test equal subscriber priority, conflicting subscriber priority, custom ladder order, and rejected ambiguous ladders.
+
+##### Phase 3: transcode controller
+
+- \[ ] Add an optional bandwidth input to the transcode configuration and wire the CLI publisher session into it.
+- \[ ] Give one controller ownership of all rung shares, targets, and catalog state.
+- \[ ] Apply the weighted boundary formula, including the lowest-rung `max / 3` case.
+- \[ ] Track requested and successfully applied targets separately.
+- \[ ] Implement and test the `BitrateUnsupported` fallback.
+- \[ ] Keep idle rungs allocation-free while allowing catalog recovery without encoder probes.
+- \[ ] Apply the shared target and allocation to live and uncached FETCH encoders.
+- \[ ] Coalesce catalog publications and prevent source updates from resetting rung state.
+
+#### Acceptance scenarios
+
+- \[ ] One demanded rung can use its configured maximum when the uplink permits it.
+- \[ ] Multiple demanded rungs share one uplink, with lower rungs protected before higher rungs at equal subscriber priority.
+- \[ ] A supported higher rung adapts down, clamps at its boundary, becomes stalled, and recovers without changing its advertised maximum.
+- \[ ] The 5 Mbps / 2.5 Mbps boundary is approximately 3.33 Mbps.
+- \[ ] The default 350 kbps lowest rung stalls at approximately 117 kbps.
+- \[ ] A stalled catalog update moves an updated player down without rebuilding WebCodecs for metadata alone.
+- \[ ] If every rendition is stalled, the updated player continues with the lowest decoder-supported rendition.
+- \[ ] A legacy or direct subscriber can continue requesting a stalled track.
+- \[ ] An unsupported encoder remains at its fixed maximum, reports stalled below that maximum, and does not recover early.
+- \[ ] A fresh FETCH uses the shared applied target; a cache hit performs no new encoding.
+- \[ ] No bandwidth input preserves existing fixed-rate catalog and encoding behavior.
+- \[ ] One source catalog refresh cannot erase current generated-rung stalled state.
+
+#### Explicit non-goals
+
+- Per-viewer or per-downstream-session rendition state.
+- Dynamically rewriting the catalog's advertised maximum bitrate.
+- Closing or removing stalled tracks from the catalog.
+- An application-level `unselectable` state when every rendition is stalled.
+- Stall counters or duration telemetry in the catalog.
+- Rebuilding unsupported encoders at every target change.
+- Additional stall/recovery dwell timers before real measurements justify them.
+
+## Closes
+
+- [#2858](https://github.com/moq-dev/moq/issues/2858) - close this issue when the quest finishes

--- a/quest/m0/2859-passthrough-imports-reserve-no-bandwidth-so-a-co-resident.md
+++ b/quest/m0/2859-passthrough-imports-reserve-no-bandwidth-so-a-co-resident.md
@@ -1,0 +1,47 @@
+# [M] Passthrough imports reserve no bandwidth, so a co-resident encoder over-targets
+
+## Goal
+
+Implement and verify the behavior tracked in [#2859](https://github.com/moq-dev/moq/issues/2859)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to [#2854](https://github.com/moq-dev/moq/pull/2854), which divides a connection's send estimate among the tracks sharing it.
+
+#### Problem
+
+Only tracks that *encode* register a reservation today: `moq-video` and `moq-audio`'s `publish_capture`. A passthrough import (`moq import rtmp`, `srt`, `hls`) republishes media that arrived already encoded, and those tracks are minted by the container importers, which register nothing.
+
+So a capture publish and an rtmp import sharing one connection are invisible to each other: the capture encoder targets the whole uplink while the rtmp stream independently consumes a chunk of it, and the encoder over-targets by exactly the rtmp stream's bitrate. It's [#2815](https://github.com/moq-dev/moq/issues/2815) one layer up, and [#2809](https://github.com/moq-dev/moq/pull/2809) is what makes running the two together routine.
+
+#### The wrinkle, and why it's resolvable
+
+A passthrough track has **no configured ceiling**. Nobody here chose its bitrate; the upstream encoder did. The only number available is measured, which normally fails the rule the allocator is built on: reserve the maximum a track can ever send, never what it happens to be sending. A VBR source sitting on a black screen at 1 Mbps can jump to 6 Mbps between one frame and the next, and a reservation that had followed it down would already have handed that room to somebody else.
+
+`moq_mux::catalog::Estimate::bitrate` is the exception. It is documented as *the maximum* bitrate, measured over a 1s window, so it's a peak-hold rather than an instantaneous rate, and it satisfies the ceiling rule as-is. The importers already feed it (`catalog::Estimator`), so the number is sitting there.
+
+#### What to build
+
+Register each passthrough track with its catalog-estimated bitrate, in the reserve-only mode `moq-audio` already uses: claim the budget, never follow the grant. A passthrough track can't be asked to back off, so its entry means "subtract this from everyone else's budget" rather than a ceiling anyone will respect. That's the same shape PCM audio needs, so no new mode.
+
+Two known limits, neither fatal:
+
+- **A peak-hold starts at zero.** Until the source's first peak, the reservation understates and a co-resident encoder over-targets by the difference. It converges within seconds, and it is strictly better than the reservation of zero these tracks hold today.
+- **The estimate updates as the source's peak grows**, so the reservation ratchets up over the life of the stream and never down. That's the conservative direction, which is the right one here.
+
+Priority falls out of [#2854](https://github.com/moq-dev/moq/pull/2854): the importers now stamp `hang::catalog::PRIORITY` per kind, so an imported audio track already outranks an imported video one.
+
+## Closes
+
+- [#2859](https://github.com/moq-dev/moq/issues/2859) - close this issue when the quest finishes
+
+## Related
+
+- [#2815: Divide the connection bandwidth estimate among concurrent encoders](/quest/m0/2815-divide-the-connection-bandwidth-estimate-among-concurrent.md) - related open work

--- a/quest/m0/2860-cpp-obs-moq-source-cpp-has-no-test-coverage.md
+++ b/quest/m0/2860-cpp-obs-moq-source-cpp-has-no-test-coverage.md
@@ -1,0 +1,39 @@
+# [M] cpp/obs: moq-source.cpp has no test coverage
+
+## Goal
+
+Implement and verify the behavior tracked in [#2860](https://github.com/moq-dev/moq/issues/2860)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+`cpp/obs/test/moq-output-test.cpp` covers the publish path only. Its libmoq stub implements `moq_origin_create`, `moq_origin_close`, and `moq_origin_publish`  -  nothing on the consume side  -  so `moq-source.cpp` is exercised by nothing. `just obs test` reports success without touching it.
+
+That matters more than usual for this file: PR CI never compiles the plugin at all (see `cpp/obs` in the root CLAUDE.md), so `just obs test` is the only automated gate the source path could have, and it currently isn't one.
+
+It bit us in #2856. That PR stopped `moq_net::Client::connect` blocking on the initial announce set, which left `moq_source_start_consume` calling `moq_origin_request` (resolve against what is announced *now*) off the session-connected callback. The announcement had not necessarily arrived, so `on_broadcast` got `Unroutable`, the source blanked, and because consumption is started only for connection epoch 1 nothing ever retried it: OBS stays blank until the user restarts the source. It was caught in adversarial review rather than by a test.
+
+#### Suggested coverage
+
+The stub set needs the consume half: `moq_origin_consume_announced` (+`_close`), `moq_origin_request` (+`_close`), `moq_consume_catalog`, `moq_consume_track`, `moq_consume_close`. The orderings worth pinning, all of which the current build cannot check:
+
+- Connected fires, the announcement arrives *later*, and the source still subscribes.
+- A broadcast that is never announced: the wait stays pending and `moq_source_disconnect` closes it, firing the terminal exactly once.
+- A reconnect (epoch 2) while an epoch-1 delivery is still in flight: the stale delivery is dropped on the generation check and its handle is closed, not leaked.
+- Terminal-callback refcounting: `refs` returns to zero on each of the delivered / errored / closed paths.
+
+The generation and `subscription_ref` bookkeeping in that file is exactly the kind of thing the comments say the build can't verify, which is the argument the existing output test already makes for itself.
+
+Found by the Codex adversarial review on https://github.com/moq-dev/moq/pull/2856.
+
+## Closes
+
+- [#2860](https://github.com/moq-dev/moq/issues/2860) - close this issue when the quest finishes

--- a/quest/m0/2868-obs-the-plugin-targets-obs-31-1-1-while-linux-ci-links.md
+++ b/quest/m0/2868-obs-the-plugin-targets-obs-31-1-1-while-linux-ci-links.md
@@ -1,0 +1,38 @@
+# [S] obs: the plugin targets OBS 31.1.1 while Linux CI links against nixpkgs' 32.1.2
+
+## Goal
+
+Implement and verify the behavior tracked in [#2868](https://github.com/moq-dev/moq/issues/2868)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Split out of a review finding on #2867 (CodeRabbit flagged the stale pin; the divergence below is what makes it worth its own issue).
+
+#### The two versions
+
+- `cpp/obs/buildspec.json` pins **obs-studio 31.1.1**. That's what the obs-deps download gives a macOS or Windows build, so it's the libobs the *released* plugin binaries link against.
+- nixpkgs currently carries **obs-studio 32.1.2**, which is what a Linux `just obs build` and the new `obs.yml` gate link against.
+- `flake.nix`'s `libobs-headers` also pins 31.1.1, matching buildspec.json (#2867 added a guard in `just obs check` that fails if those two drift).
+
+So the Linux compile gate and the shipped macOS/Windows binaries are a major OBS release apart. Nothing has broken yet, but that gap is exactly where a libobs API change gets through CI and shows up only in a release build, on the platforms with no compile gate at all.
+
+#### What to do
+
+Bump `cpp/obs/buildspec.json` to the current stable (32.2.2 at time of writing) and move `libobs-headers` in `flake.nix` in the same commit. Needs:
+
+- new hashes for the obs-studio, prebuilt obs-deps and Qt6 archives (macOS + Windows entries), and the nix `fetchzip` hash;
+- a check that `libobs/obsconfig.h.in` and `frontend/api/obs-frontend-api.h` are still where `libobs-headers` expects them;
+- a real `just obs build` on macOS, since that's the platform the release actually ships and the one PR CI never compiles.
+
+`just obs check` will fail until both pins move together, which is the intended tripwire rather than an obstacle.
+
+## Closes
+
+- [#2868](https://github.com/moq-dev/moq/issues/2868) - close this issue when the quest finishes

--- a/quest/m0/2870-moq-hls-a-named-sibling-rendition-is-pinned-too-late-to.md
+++ b/quest/m0/2870-moq-hls-a-named-sibling-rendition-is-pinned-too-late-to.md
@@ -1,0 +1,53 @@
+# [M] moq-hls: a named sibling rendition is pinned too late to survive a same-path republish
+
+## Goal
+
+Implement and verify the behavior tracked in [#2870](https://github.com/moq-dev/moq/issues/2870)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+\#2795 bound renditions to the broadcast their catalog came from, so a same-path republish (whose group numbering restarts) cannot have its media served under the replaced broadcast's segment numbers, durations, and PROGRAM-DATE-TIME. It closed this for both rendition shapes:
+
+- **inline** (`config.broadcast == None`, the catalog's own broadcast)  -  seeded at construction via `upstream.local(...)`.
+- **named sibling** (`config.broadcast == Some(path)`)  -  resolved at the per-rendition watcher's start, *before* the watcher pushed its first timeline row, so the timeline and the media it describes always agreed.
+
+On `dev` (after #2852 merges `main`), only the first half survives. `dev`'s HLS export is fetch-on-demand: there is one watcher per timeline *section* in `export/mod.rs` fanning entries out to every rendition, rather than main's watcher per *rendition*. The sibling resolution therefore has nowhere to hang, and `Rendition::track` resolves lazily on the first media request instead:
+
+```rust
+async fn track(&self) -> Option<moq_net::track::Consumer> {
+    if self.live.broadcast.get().is_none() {
+        let broadcast = self.source.resolve(self.sibling.as_ref()).await.ok()?;
+        let _ = self.live.broadcast.set(broadcast);
+    }
+    ...
+}
+```
+
+That leaves a window: the fanout can publish timeline rows for a sibling rendition while `live.broadcast` is still unset. A same-path republish landing in that window means the lazy `resolve` returns the *replacement* broadcast, whose restarted group numbers are then served under the old catalog's segment ranges, durations, and wall-clock metadata. This is exactly the failure #2795 describes, reachable only through the sibling path.
+
+The pin itself is correct once taken (`OnceLock::set`, so the first resolution wins). The problem is purely when it is taken.
+
+Note this is not a regression from the merge: `dev` always resolved lazily, and #2852 carries main's inline fix plus its regression test. It is main's sibling fix failing to carry across an architectural difference, so it should be closed deliberately rather than assumed handled.
+
+#### Why the test doesn't catch it
+
+`a_replacement_publisher_is_not_served_under_the_replaced_catalog` survived the merge and is not vacuous, but its rendition is built from a plain `VideoConfig::new(VideoCodec::VP8)` with no `broadcast` reference  -  an inline rendition. It exercises only the eagerly-seeded path.
+
+#### Suggested direction
+
+Resolve each rendition's sibling broadcast after construction but before the section watcher pushes any entry to it. Construction itself can't do it: `renditions::Producer::sync` runs synchronously under a write lock, which is why main used the watcher. Then add a regression that republishes a *named sibling* before the first media request and proves the replacement's bytes are not served under the old catalog.
+
+Found by Codex adversarial review of #2852, verified against `main`'s `export/rendition.rs::watch` and `dev`'s fanout in `export/mod.rs`.
+
+## Closes
+
+- [#2870](https://github.com/moq-dev/moq/issues/2870) - close this issue when the quest finishes

--- a/quest/m0/2873-moq-net-enumerate-and-resolve-historical-broadcast.md
+++ b/quest/m0/2873-moq-net-enumerate-and-resolve-historical-broadcast.md
@@ -1,0 +1,62 @@
+# [M] moq-net: enumerate and resolve historical broadcast generations by path and epoch
+
+## Goal
+
+Implement and verify the behavior tracked in [#2873](https://github.com/moq-dev/moq/issues/2873)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Ordinary broadcast discovery has one current advertisement per path. With broadcast epochs, an origin can retain multiple generations under that path, but a new consumer still has no way to discover an older or ended generation.
+
+This matters for recordings and offline VOD. A client should be able to enumerate historical generations without changing the ordinary live path into `<path>/<epoch>`, and without instantiating a broadcast front for every stored recording.
+
+#### Contract
+
+Add a separate history or VOD discovery surface that enumerates entries by:
+
+- broadcast path
+- non-zero epoch
+- whether the generation is live or ended
+
+Ordinary announcements remain unchanged in purpose and expose only the highest currently available epoch per path.
+
+Resolution rules:
+
+- `TRACK` and `FETCH` may explicitly resolve any retained generation.
+- `SUBSCRIBE` accepts only a live generation.
+- An explicit epoch never silently resolves to another generation.
+- Epoch `0` means the current highest generation. Resolution happens before validating whether the requested operation is allowed.
+- If the current generation is ended, `SUBSCRIBE(epoch=0)` fails rather than searching backward for an older live generation.
+- A generation may transition from live to ended, but not back to live. Publishing new live content at the path requires a greater epoch.
+
+Persistence, retention, and authorization remain application policy. The protocol and model only expose the retained generations that the application makes available.
+
+#### Architecture constraints
+
+This should build on the epoch model from #2610: path, then generation, then interchangeable routes. It should also compose with #2756 so a large offline catalog can advertise cheap entries without allocating a broadcast front per recording.
+
+Do not overload ordinary route selection with history. Historical generation enumeration is a distinct query/API and will need its own wire design before implementation.
+
+#### Acceptance cases
+
+- A path with one live generation and multiple ended generations is announced normally as only its highest epoch.
+- History enumeration returns each retained `(path, epoch, ended)` entry.
+- A client can fetch an explicitly selected ended generation.
+- A subscription to an ended generation is rejected.
+- An explicit unknown epoch fails without falling back to current.
+- An offline catalog can expose many historical generations without eagerly instantiating broadcasts.
+
+Related: #2610, #2756, #2281, #2275, #2846.
+
+## Closes
+
+- [#2873](https://github.com/moq-dev/moq/issues/2873) - close this issue when the quest finishes

--- a/quest/m0/2875-thread-per-core-relay-runtime-io-uring-quiche-ebpf.md
+++ b/quest/m0/2875-thread-per-core-relay-runtime-io-uring-quiche-ebpf.md
@@ -1,0 +1,160 @@
+# [XL] Thread-per-core relay runtime: io-uring + quiche, eBPF connection steering, rename moq-native to…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2875](https://github.com/moq-dev/moq/issues/2875)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+### Motivation
+
+The first big customer plans to use MoQ as a message bus for chat. Egress per connection is tiny, so the cost driver is CPU per connection and CPU per message, not bandwidth. The current relay runs one work-stealing tokio runtime: every packet potentially crosses threads, every wakeup is a candidate context switch, and every UDP datagram is a syscall. The goal is a thread-per-core mode where each connection is pinned to one thread for its whole life, I/O is batched via io-uring, and incoming packets are steered to the owning thread in the kernel.
+
+Media workloads (1:1 and 1:N) must not regress and should also benefit.
+
+#### What the codebase already gives us (verified)
+
+- **`moq-net` is already runtime-agnostic on `dev`.** #2736 (`refactor(net)!: require the poll-based transport interface`) drives transports purely through `web_transport_trait::poll::{Session, SendStream, RecvStream}` (v0.4). `moq-net` has no tokio dependency; every future is kio-based and a session `Driver` can be stepped with `kio::Waiter` from any executor. This part of the plan is confirmed, not speculative.
+- **The one remaining runtime tie is time.** `kio::time::Deadline` (and `moq-net`'s bandwidth sampling, control-stream timeout, and subscription linger) bottom out in `web_async::time`, which is tokio's time driver on native and panics outside a tokio runtime. A non-tokio runtime needs a pluggable timer backend in kio.
+- **Send bounds:** on native, `moq-net` boxes internal futures as `Send` (`MaybeSendBox` = `BoxFuture`); only wasm gets the `LocalBoxFuture` path. Thread-per-core does not require `!Send` (pinned `Send` types work; locks just become uncontended), but `!Send` internals (Rc, thread-local wakers) are off the table until that cfg split is widened.
+- **A quiche backend already exists** (`web-transport-quiche`, the `quiche` feature of `moq-native`), including raw QUIC. quiche is sans-IO by design: the application owns sockets, timers, and packet pacing, which is exactly the contract an io-uring driver wants.
+- **`moq-bench` exists** and its `F=0` mode (lone JSON keyframe groups) is nearly the chat workload already. It has no CPU-side measurement yet.
+- **No `SO_REUSEPORT` anywhere today**, only `SO_REUSEADDR`.
+
+#### Decisions taken (from design review)
+
+1. **Success bar:** baseline first. Milestone 0 measures where CPU actually goes today, then we commit to a concrete multiplier (e.g. Nx connections per core). No optimization is judged without a number from the rig.
+2. **QUIC stack: quiche.** Battle-tested at exactly this architecture (thread-per-core, SO\_REUSEPORT, eBPF steering) at Cloudflare. noq-proto and quinn-proto remain possible later since everything goes through `web-transport-trait`, but the io-uring driver is built around quiche.
+3. **Milestone 1 is thread-per-core tokio**, not io-uring. N pinned `current_thread` runtimes with per-thread `SO_REUSEPORT` sockets and eBPF steering validates the architecture, keeps timers and WebSocket working, and isolates how much win comes from pinning alone vs io-uring itself.
+4. **Scope: QUIC first, parity later.** The new runtime owns QUIC on :443/UDP only. WebSocket/WSS, TCP, UDS, iroh, and cert reload stay on a tokio runtime in the same process. The plan commits to eventually porting the fallbacks so tokio can be dropped from the relay, but not in v1.
+5. **Deployment floor: our own infra.** Modern kernels (6.x), CAP\_BPF available. The io-uring path hard-requires its features and refuses to start otherwise. Self-hosters keep the tokio relay; no fallback detection logic.
+6. **Send story: decided by data.** Ship Milestone 1 with `Send` types, profile atomic/lock overhead under the chat workload, and only widen the wasm `!Send` path to native (feature-gated) if it shows up as real CPU.
+7. **io-uring shape: direct implementation.** Monoio is rejected for this work because its public UDP API does not expose the ancillary-data and batching primitives we require. Build the spike directly on the `io-uring` crate.
+8. **WebTransport layer: `web-transport-proto` over quiche.** `web-transport-quiche` is coupled to `tokio-quiche` and spawns tokio tasks, so it is not the abstraction for the new runtime. Reuse the protocol state machine from `web-transport-proto` and implement its I/O against sans-I/O quiche.
+9. **UDP batching is required, not optional polish.** The tokio/control implementation must support `recvmmsg`; the io-uring implementation uses multishot `recvmsg` with provided buffers as its equivalent. Both must preserve ancillary data and UDP GRO. Egress must use `sendmsg` with `UDP_SEGMENT` GSO.
+10. **Time is an M3 prerequisite.** Replace the concrete tokio sleep inside `kio::time` with an executor-provided deadline backend. Tokio and wasm keep their existing behavior; the direct runtime drives deadlines with timeout SQEs or a measured local timer structure.
+
+#### Architecture sketch
+
+- N worker threads, each pinned to a core. Each binds its own UDP socket to :443 with `SO_REUSEPORT`, giving N sockets in one reuseport group.
+- An `sk_reuseport` eBPF program (`SK_REUSEPORT` + `BPF_MAP_TYPE_REUSEPORT_SOCKARRAY`) parses the QUIC header and steers by connection ID: server-chosen CIDs encode the owning socket index (a few plaintext bytes plus entropy, standard quiche-style routing).
+- Initial packets carry a client-chosen DCID we cannot decode, so they hash to an arbitrary socket. Whichever thread receives the Initial owns the connection forever and issues CIDs that encode its own index. No cross-thread handoff, no migration.
+- Retransmitted Initials must reach the same thread before our CID takes effect: steer them by hashing the client-chosen DCID consistently in the eBPF program, so retries land on the thread that saw the first packet.
+- Each thread runs: io-uring UDP rx (multishot `recvmsg` with a provided-buffer ring, the io-uring equivalent of `recvmmsg`, plus GRO) -> quiche packet processing -> `moq-net` `Driver`s polled on a local task queue -> quiche egress -> io-uring UDP tx (`sendmsg` + `UDP_SEGMENT` GSO, zerocopy only where it wins). Timers come from timeout SQEs or a measured local timer structure feeding quiche's `on_timeout` and kio deadlines.
+- Fanout (1:N) across threads goes through the existing shared `Origin` model: cross-thread wakeups are memory traffic, not syscalls. Measured, not assumed, in the benchmarks.
+- The same process keeps a small tokio runtime for WebSocket/TCP fallback, stats, signal handling, and cert hot-reload.
+
+#### Non-goals
+
+- **Routing Initials to threads with spare capacity.** Accept hash placement; revisit only if the benchmarks show real imbalance.
+- **Customer/tenant affinity (SNI, token root, path).** Invites hot keys; a busy tenant must be able to span cores.
+- **Full moq-native parity in the new crate for v1** (see decision 4).
+- **Fallback detection for hardened/exotic environments** (see decision 5).
+
+### Milestones
+
+Each milestone is a tracking issue with its own PRs; this issue is the epic. Every milestone ends with the same benchmark suite run on the same rig, so the deltas compose into one story.
+
+#### M0: Measure. Chat + media benchmark suite and the tokio baseline
+
+The whole project is gated on this: if profiling shows CPU goes to crypto or memcpy rather than syscalls and scheduling, the plan changes before we build anything.
+
+- Extend `moq-bench` with a chat profile: thousands of connections, tiny frames, low per-connection rate, `F=0` style groups, plus fanout matrices for 1:1 and 1:N (N spanning small rooms to large ones, e.g. 10 / 1k / 100k subscribers).
+- Keep/refresh the media profiles (video-sized frames, keyframe cadence) for 1:1 and 1:N.
+- Add CPU measurement to the harness: CPU per connection, CPU per message, context switches (`perf stat`), syscall share, flame graphs of the relay under each profile. Results in a machine-readable format so runs are diffable.
+- A `just` recipe to run the matrix against a relay; document the reference hardware.
+- **Exit criteria:** baseline numbers for the current multi-thread tokio relay are written down, the dominant CPU sinks are identified, and the target multiplier for the project is committed.
+
+#### M1: Thread-per-core tokio relay
+
+- Relay mode: N pinned threads, each a `current_thread` tokio runtime, each with its own `SO_REUSEPORT` UDP socket on :443.
+- The `sk_reuseport` eBPF steering program and its loader: CID-encoded socket index for established connections, consistent DCID hash for Initials. This program is runtime-agnostic and carries over unchanged to the io-uring milestones.
+- CID generation in the quiche backend encodes the thread index (quinn can follow later if we care).
+- Wire it behind a relay config flag; the default stays the multi-thread runtime.
+- Profile: how much did pinning + no work-stealing buy on the M0 suite? What share of remaining CPU is atomics/locks (decides the `!Send` question), syscalls (decides how much io-uring can still win), crypto?
+- **Exit criteria:** benchmark delta vs M0 recorded; Send/!Send decision made from the profile; go/no-go on the io-uring investment made from the syscall share.
+
+#### M2: Crate split. moq-native becomes moq-tokio
+
+- Rename `moq-native` to `moq-tokio` (semver break, lands on `dev` per branch targeting rules).
+- Extract the runtime-neutral pieces the new runtime will also need (TLS/cert plumbing, config types, address resolution, the CID codec and eBPF loader from M1) into a shared crate so `moq-tokio` and the future io-uring crate depend on common code instead of copying it.
+- Keep `moq-native` as a deprecated re-export shim only if it is cheap; otherwise a clean break on `dev` with migration notes in the PR.
+- Docs sweep per the cross-package sync table (`doc/lib/rs`, examples, justfiles).
+- **Exit criteria:** tree builds with `moq-tokio`; no behavior change; downstream crates in the workspace migrated.
+
+#### M3: Prove the direct io-uring data path and runtime prerequisites
+
+Time-boxed. This milestone answers whether the required Linux batching path works and improves the actual quiche workload before the relay integration grows around it. There is no Monoio candidate.
+
+##### M3a: Replace the native `kio::time` backend
+
+- Consolidate every `moq-net` timer and clock read behind `kio::time`. The initial audit found direct `web_async::time` use in bandwidth sampling, GOAWAY enforcement, and the lite PROBE interval in addition to existing `Deadline` users.
+- Replace `Deadline`'s concrete `web_async::time::Sleep` with an executor-selected timer registration. Selection must happen at runtime because tokio fallback work and io-uring QUIC coexist in one process.
+- Keep the public surface small: callers continue to own and poll a deadline. Do not pass a timer provider through every `moq-net` type.
+- Preserve tokio paused-clock tests and the wasm backend. Add a no-tokio test executor that proves a `moq-net` driver can arm, re-arm, cancel, and fire deadlines without entering a tokio runtime.
+- Compare timeout SQEs with a local heap/wheel for cancellation churn and pacing precision. The ring is not automatically the winner for thousands of short-lived timers.
+- **Exit criteria:** `kio::time::Deadline` and a representative `moq-net` driver run under the local executor with no tokio runtime; timer precision and cancellation behavior are measured and documented.
+
+##### M3b: UDP batching ablation benchmark
+
+- Build the direct per-thread loop on the `io-uring` crate. Receive with multishot `recvmsg` plus a provided-buffer ring, parse source/destination address, ECN, timestamps, and `UDP_GRO`, and re-arm cleanly after `IORING_CQE_F_MORE` clears or `ENOBUFS`.
+- Add a `recvmmsg` receive-batching control to the tokio path. Multishot `recvmsg` is the io-uring equivalent, but the control is needed to separate receive batching from executor effects.
+- Send quiche packet batches with `sendmsg` and a `UDP_SEGMENT` control message. Only coalesce packets with the same destination, source, ECN, pacing time, and segment size.
+- Run an ablation matrix at a fixed offered load: single receive/single send, receive batching only, GSO only, receive batching + GSO, then the direct io-uring path. Toggle GRO separately. Record actual batch sizes, packets/syscall, ring submissions/completions, drops, `ENOBUFS`, CPU/message, CPU/Gbps, and latency.
+- Test chat-sized datagrams and media-sized traffic. Treat zerocopy as a separate experiment because notification CQEs and buffer lifetime may cost more than the copy for small packets.
+- Use a dedicated transport benchmark first, then repeat the winning configuration with the M0 workload. The M0 harness speaks MoQ and cannot directly drive a raw echo server without a transport mode/client.
+- **Exit criteria:** all required socket features work on the deployment kernel and NIC; the ablation attributes the gain to receive batching and/or GSO; the direct path improves quiche CPU at the same offered load. If it does not improve end-to-end CPU, stop before M4.
+
+##### M3c: quiche plus WebTransport proof
+
+- Drive sans-I/O quiche directly from the M3b loop.
+- Put `web-transport-proto` on top for the HTTP/3 CONNECT handshake and WebTransport session state. Do not depend on `web-transport-quiche` or `tokio-quiche` in the new path.
+- Accept a session from an existing client and run bidirectional stream and datagram echo through it. Feed quiche timeout and pacing deadlines through the M3a backend.
+- Keep the adapter shaped toward `web_transport_trait::poll`, but do not build the complete public transport crate in the spike.
+- **Exit criteria:** the same benchmark client completes the WebTransport handshake and echo workload on tokio and direct io-uring; CPU, latency, loss, and syscall/ring-operation deltas are recorded on the same hardware.
+
+#### M4: Integrate the proven io-uring runtime
+
+- New crate (name TBD in the M4 PR, e.g. `moq-uring`): grow the M3 winner into the production runtime. It owns thread spawning/pinning, sockets, the ring, provided-buffer pools, the local executor, and the timer backend selected in M3a.
+- Extract the runtime-neutral TLS/cert configuration, CID codec, eBPF loader, and socket configuration that remain private in `moq-tokio`. The M2 rename landed, but these shared pieces were not extracted.
+- Implement the WebTransport-over-quiche adapter from M3c as `web_transport_trait::poll` session and stream types, then drive real `moq-net` `Driver`s.
+- Relay integration behind the same config flag as M1: io-uring threads own QUIC, while the tokio side keeps WebSocket/TCP/UDS, stats, signals, and cert reload. Cluster/upstream QUIC dials happen from the io-uring threads too.
+- **Exit criteria:** relay passes the existing integration and smoke tests in io-uring mode; the full M0 suite records deltas against M1; the required receive batching and send GSO remain enabled and observable.
+
+#### M5: Hardening and continuous benchmarks
+
+- Nightly benchmark runs on a dedicated box (rig details TBD; cloud CI runners are too noisy for CPU numbers), trended over time, regressions visible per commit range.
+- Soak: multi-hour chat + media mixed load, memory stability, CID rotation, connection churn.
+- Operational story: qlog in io-uring mode, `moq-stats` integration, graceful drain/shutdown of pinned threads.
+- Rollout on our fleet behind the flag, then default for our deployment. `moq-tokio` remains the default for everyone else.
+- If M1's profile said the `!Send` refactor pays: land it here (feature-gated `LocalBoxFuture` path in `moq-net`, Rc internals, thread-local kio wakers) and re-measure.
+- **Exit criteria:** the M0 target multiplier is met or the gap is explained with a profile; benchmarks run nightly; the chat customer's projected load fits the promised hardware.
+
+### Risks and open questions
+
+- **WebTransport adapter scope:** `web-transport-proto` supplies protocol state, but the new path still owns the quiche stream/datagram adapter and its `web_transport_trait::poll` lifecycle. Prove the minimal boundary in M3c before designing the production public API.
+- **Cross-thread fanout:** 1:N where subscribers live on many threads keeps the shared-memory origin model on the hot path. If M0/M1 show contention there, group fanout may need per-thread egress queues. Measured before designed.
+- **io\_uring security posture** is fine for our fleet (decision 5) but permanently excludes some self-host environments; the tokio relay remains the answer there.
+- **eBPF program lifecycle:** pinning, upgrade across relay restarts (reuseport group membership changes when threads restart), and observability when steering goes wrong.
+- **Timer precision and cancellation:** quiche pacing wants fine-grained timers, while a timeout SQE per logical deadline may create excessive submission and cancellation traffic. M3a compares the ring with a local timer structure under realistic churn.
+- **Provided-buffer ownership:** multishot receive depends on correct buffer-ring replenishment. Exhaustion, stale CQEs after cancellation, and GRO segment parsing need counters and stress tests.
+- **Benchmark interpretation:** loopback UDP microbenchmarks prove feature support and give directional data, but only the fixed-load quiche and M0 runs decide whether the runtime is better.
+- **Benchmark rig:** hardware not yet chosen (dedicated bare metal vs a fixed cloud metal instance). Owner input welcome on what we can dedicate.
+- Fanout matrix ceilings (is 100k subscribers per broadcast a real chat shape, or is 10k the honest max?).
+
+No wire format changes anywhere in this plan, so no `drafts/` updates are expected. Relay config/docs updates ride each milestone PR per the cross-package sync table.
+
+## Required
+
+- [#1073: Make Origin lifecycle caller-driven](/quest/m0/1073-make-origin-lifecycle-caller-driven.md) - complete the prerequisite issue first
+
+## Closes
+
+- [#2875](https://github.com/moq-dev/moq/issues/2875) - close this issue when the quest finishes

--- a/quest/m0/2892-js-net-enforce-the-subscriber-latency-budget.md
+++ b/quest/m0/2892-js-net-enforce-the-subscriber-latency-budget.md
@@ -1,0 +1,35 @@
+# [M] js/net: enforce the subscriber latency budget
+
+## Goal
+
+Implement and verify the behavior tracked in [#2892](https://github.com/moq-dev/moq/issues/2892)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+\#2890 makes `Subscription::latency` actually enforced in `rs/moq-net`, where it had been metadata that was forwarded on the wire and never acted on. `js/net` still has the same gap.
+
+`js/net/src/track.ts`'s `Subscriber.recvGroup`, `nextGroup`, and `readFrameSequence` hand back buffered groups without consulting `Subscription.latencyMax`, so a browser subscriber replays a backlog it declared it did not want. That is visible in practice whenever another subscriber widens the publisher's aggregate budget, since the aggregate is what reaches the publisher and the per-subscriber semantics only exist locally.
+
+What the Rust side settled on, for a mirror to match:
+
+- Drift is measured in **presentation time**: a group's first frame timestamp against the highest-*sequence* group above it that carries one. Both are stamped once, when the group's first frame is created, so a backlog delivered as a burst still reads as its true age.
+- The anchor must sit strictly **above** the candidate. Backfill and the tail of a rewound timeline can carry a high timestamp on a low sequence without being a live edge.
+- A group that has presented nothing is never stale, and neither is one with nothing newer stamped above it. Retention bounds those instead.
+- The budget is clamped to the publisher's `latencyMax` retention window, since waiting longer than a group is kept cannot produce it.
+- The anchor is bounded by what the subscriber could actually be handed (its read cursor's cap), **not** by the end it requested on the wire, which is a preference that does not filter the handle.
+- `start` is a filter, not an exemption: a subscriber that wants history raises its budget. A one-shot fetch stays exempt.
+
+Expect the same fallout the Rust side had: tests that write a batch of groups and then read them all back are asserting more than the default `REAL_TIME` budget promises, and each needs to declare the tolerance it was implicitly relying on.
+
+Same shape as the mirrors in #2772 and #2775.
+
+## Closes
+
+- [#2892](https://github.com/moq-dev/moq/issues/2892) - close this issue when the quest finishes

--- a/quest/m0/2893-video-validate-pipewire-dma-buf-capture-on-kde-hardware.md
+++ b/quest/m0/2893-video-validate-pipewire-dma-buf-capture-on-kde-hardware.md
@@ -1,0 +1,66 @@
+# [M] video: validate PipeWire DMA-BUF capture on KDE hardware
+
+## Goal
+
+Implement and verify the behavior tracked in [#2893](https://github.com/moq-dev/moq/issues/2893)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Hardware validation for #2839 did not complete on a KDE/Wayland desktop. The screen source was selected in the portal, but the ignored PipeWire capture test never received a frame and timed out after 120 seconds.
+
+This is a focused follow-up to the broader Linux zero-copy tracker in #2819.
+
+#### Environment
+
+- KDE desktop on Wayland
+- `XDG_CURRENT_DESKTOP=KDE`
+- `WAYLAND_DISPLAY=wayland-0`
+- `DISPLAY=:0`
+- `XDG_RUNTIME_DIR=/run/user/1000`
+- Active desktop D-Bus session
+
+#### Reproduction
+
+Run from the Nix development shell after #2839:
+
+```sh
+cargo nextest run --profile ci -p moq-video --all-features --run-ignored ignored-only portal_captures_frames --no-capture
+```
+
+During review, a temporary assertion also required captured frames to be `Surface::DmaBuf`. The run reached the test, the portal source was selected, then nextest reported the test as slow after 60 seconds and terminated it at 120 seconds without receiving a frame.
+
+#### Expected
+
+- Portal selection completes.
+- PipeWire format and buffer negotiation completes.
+- The first frame arrives within the existing capture timeout.
+- A DMA-BUF-capable compositor produces `Surface::DmaBuf`; shared memory remains a working fallback.
+
+#### Validation
+
+- \[ ] Reproduce the post-selection timeout on KDE/Wayland.
+- \[ ] Add tracing around portal completion, PipeWire connection, format fixation, buffer allocation, and first-frame delivery to locate the stall.
+- \[ ] Validate packed RGB DMA-BUF capture and Vulkan import on Intel or AMD hardware.
+- \[ ] Validate the linear DMA-BUF CPU fallback.
+- \[ ] Confirm shared-memory PipeWire capture still works when DMA-BUF is unavailable.
+- \[ ] Hold multiple frames long enough to exercise buffer leasing without pool exhaustion or reused content.
+- \[ ] Add or refine an ignored hardware test so the observed failure is distinguishable from a portal-selection timeout.
+
+Refs #2839 and #2819.
+
+## Closes
+
+- [#2893](https://github.com/moq-dev/moq/issues/2893) - close this issue when the quest finishes
+
+## Related
+
+- [#2819: moq-video: carry PipeWire DMA-BUFs safely into the Vulkan renderer](/quest/m0/2819-moq-video-carry-pipewire-dma-bufs-safely-into-the-vulkan.md) - related open work

--- a/quest/m0/2895-add-an-atomic-readiness-gate-for-origin-broadcasts.md
+++ b/quest/m0/2895-add-an-atomic-readiness-gate-for-origin-broadcasts.md
@@ -1,0 +1,46 @@
+# [S] Add an atomic readiness gate for Origin broadcasts
+
+## Goal
+
+Implement and verify the behavior tracked in [#2895](https://github.com/moq-dev/moq/issues/2895)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+`origin::Producer::create_broadcast` makes an eligible source visible by exact-path lookup, and may announce it, before the caller has installed all of its tracks or a `broadcast::Dynamic` handler. A concurrent consumer can therefore find the broadcast during a partially prepared state.
+
+`broadcast::Route::announce = false` is not a readiness gate. It suppresses announcement events, but the broadcast remains reachable through exact-path lookup.
+
+#### Goal
+
+Add an atomic readiness mechanism so callers can prepare a broadcast completely before it becomes discoverable by either announcements or exact-path lookup.
+
+The API should make the safe publication sequence clear and difficult to misuse. Decide whether readiness belongs in construction, a consuming terminal operation, or a small typestate/builder boundary before implementation.
+
+#### Scope
+
+- Define one atomic transition from hidden/preparing to visible.
+- Gate both exact-path lookup and announcements on that transition.
+- Cover local sources, replacements, and sources initially parked behind an incumbent.
+- Specify what dropping an uncommitted source does.
+- Add race-focused tests proving consumers never observe partial readiness.
+
+#### Relationship
+
+Related to #1073, but does not block it. #1073 deliberately preserves the current immediate-visibility behavior while making Origin lifecycle caller-driven.
+
+## Closes
+
+- [#2895](https://github.com/moq-dev/moq/issues/2895) - close this issue when the quest finishes
+
+## Related
+
+- [#1073: Make Origin lifecycle caller-driven](/quest/m0/1073-make-origin-lifecycle-caller-driven.md) - related open work

--- a/quest/m0/2907-bind-the-browser-through-moq-ffi-uniffi-instead-of-a.md
+++ b/quest/m0/2907-bind-the-browser-through-moq-ffi-uniffi-instead-of-a.md
@@ -1,0 +1,83 @@
+# [L] Bind the browser through moq-ffi/UniFFI instead of a second hand-written wasm API
+
+## Goal
+
+Implement and verify the behavior tracked in [#2907](https://github.com/moq-dev/moq/issues/2907)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Reach the browser through `moq-ffi` (UniFFI) instead of maintaining a second hand-written binding in `moq-wasm`.
+
+#### Why
+
+`rs/moq-ffi` already exports the model `moq-wasm` keeps trying to grow: `MoqBroadcast`/`MoqTrack`/`MoqGroup` producers and consumers, `MoqAnnounced`, `MoqTrackRequest`, `MoqSubscription`, `fetchGroup`, `requestedTrack`, `used`/`unused`. #2814 was a second hand-written copy of that surface, and it was closed for that reason.
+
+`moq-ffi` also already solved the lifecycle problem that sank #2814. `moq-ffi/src/ffi.rs::Task<T>` is `Arc<Mutex<T>>` plus a `cancel` watch channel: concurrent calls queue instead of erroring, `cancel()` interrupts a pending call, `Drop` cancels, and `SubscriberControl` and `info` live outside the lock so `update()` works while a `recv_group()` is in flight. That design has been through five language bindings.
+
+#### Spike results
+
+Measured, not estimated.
+
+**Baseline**: `cargo check --target wasm32-unknown-unknown -p moq-ffi` dies in `aws-lc-sys` C compilation (via `moq-native` to `rustls`) before type-checking a single line of `moq-ffi`. So the real cost was unknown.
+
+**After gating, both targets compile clean.** Roughly 594 insertions and 308 deletions over 10 files, mostly `#[cfg]`. Native `cargo check -p moq-ffi --all-targets` stays clean. **82 of 160 exported methods survive on wasm32.** What drops: the `video`/`audio`/`server`/`json` modules (43), media and catalog methods in `consumer`/`producer` (23), and the native TLS and bind knobs (12). The entire raw `moq-net` model survives.
+
+**What makes it viable**: uniffi 0.31 ships a `wasm-unstable-single-threaded` feature that drops `Send` from `UniffiCompatibleFuture` and `Send + Sync` from `FfiConverterArc`. Without it, moq-net's `LocalBoxFuture` wasm futures are a hard stop.
+
+**Generated TypeScript** (`uniffi-bindgen-js` 0.2.1, reading metadata straight out of the `.wasm`): 108 KB `moq.ts` across 21 classes, `tsc --strict` clean. It is better than the hand-written surface on the two points that sank #2814:
+
+- `u64` maps to `bigint`, not `number`. #2814's tsify mapping trapped on any value above 2^53.
+- Async calls clone the object handle (`cloneObjectHandle`) rather than borrowing the wrapper, so a pending call owns its own `Arc`. `free()` during a pending call is fine. wasm-bindgen's `async fn(&self)` instead takes a `LongRefFromWasmAbi` anchor that pins the whole wrapper, which is why #2814 could not free a handle or end a subscription while a read was pending.
+
+Also: idempotent `free()`, `Symbol.dispose`, a FinalizationRegistry backstop, `MoqError extends Error` with a discriminated tag union, Rust doc comments carried through, and loading by top-level await on `new URL('./moq.wasm', import.meta.url)`.
+
+**Size is not an argument against UniFFI.** Raw unoptimized wasm: `moq-ffi` 3.12 MB (594 KB brotli) carrying 82 exported methods, versus `moq-wasm` on `main` 2.83 MB (549 KB brotli) carrying 8. About 8% more bytes for roughly ten times the surface.
+
+#### Plan
+
+Steps 1 to 3 are worth doing regardless of which JS generator wins, and each is independently landable.
+
+##### 1. Gate `moq-ffi` for wasm32
+
+Move `moq-native`, `moq-video`, `moq-audio`, `pollster` and tokio's runtime features to `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`; add `getrandom`'s `wasm_js` backend and uniffi's `wasm-unstable-single-threaded`. Gate the `video`, `audio`, `server`, `json` and `log` modules. Give `Task<T>` a wasm variant and `session.rs` a browser `Client` backed by `web-transport-wasm`.
+
+Two things to decide rather than let happen:
+
+- **Task semantics differ per target.** Native `Task::run` spawns, so the work survives the caller dropping the promise. The wasm variant awaits in place, so a drop cancels mid-operation.
+- **The WebTransport adapter would be duplicated.** `moq-wasm/src/transport.rs` adapts `web-transport-wasm` to `web-transport-trait`. It should live in one crate rather than being copied a second time.
+
+One gotcha worth writing down, since it rhymes with the wasm-bindgen ident trap #2814 documented: **`#[cfg]` on a method inside a `#[uniffi::export] impl` block is ignored by the proc macro.** It still emits scaffolding, producing duplicate symbols and calls to methods that no longer exist. Use separate `#[cfg]`'d `#[uniffi::export] impl` blocks.
+
+##### 2. Fix the two `moq-mux` wasm blockers
+
+Both are latent bugs today, independent of any browser work.
+
+- `tokio::time::Instant` in `moq-mux/src/codec/{av1,h264,h265}/split.rs`. `moq-mux` declares tokio with only the `macros` feature, so this compiles natively purely through workspace feature unification. It should be `web_async::time`, the migration `moq-net` already did.
+- `pub trait Stream: Send + 'static` in `moq-mux/src/catalog/stream.rs`. moq-net's wasm stats types are `Rc<RefCell<..>>`, so the supertrait cannot be satisfied. Needs the `MaybeSend` treatment `moq-net` already has in `src/util.rs`.
+
+##### 3. Decouple `MoqBroadcastProducer` from the catalog
+
+`MoqBroadcastProducer::from_inner` always constructs a hang catalog track, so the publish path is structurally coupled to `moq-mux`. There is no raw-model publish without changing that. This is the deepest item and the only one that is not a `#[cfg]`.
+
+##### 4. Then pick a generator, with a browser harness in place
+
+The remaining unknown is generator maturity, not design. `uniffi-bindgen-js` 0.2.1 was first published 2026-03-03 and has 323 total downloads. `uniffi-bindgen-react-native` (npm only) still describes itself as early development and not for production. `uniffi_bindgen` 0.31 itself ships only the kotlin, python, ruby and swift backends.
+
+Nothing in this spike ran in a browser. Generated and type-checking is not working, which is why #2816 is the prerequisite for this step rather than a follow-up to it.
+
+#### Related
+
+- \#2814, closed in favor of this.
+- \#2816, no browser test harness. Blocks step 4 and is the root cause of #2814 needing four hand-verified review rounds.
+- \#2822 and #2835 are `moq-wasm` gaps that this approach would close by construction, since `moq-ffi` already binds datagrams and `track::Dynamic`.
+
+## Closes
+
+- [#2907](https://github.com/moq-dev/moq/issues/2907) - close this issue when the quest finishes

--- a/quest/m0/2924-moq-relay-tls-rotation-is-not-atomic-across-thread-per.md
+++ b/quest/m0/2924-moq-relay-tls-rotation-is-not-atomic-across-thread-per.md
@@ -1,0 +1,50 @@
+# [XL] moq-relay: TLS rotation is not atomic across thread-per-core QUIC workers
+
+## Goal
+
+Implement and verify the behavior tracked in [#2924](https://github.com/moq-dev/moq/issues/2924)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up from #2921 (M1 part 1 of #2875), which added `runtime.workers`. Documented there rather than fixed, because the fix needs an API `moq-tokio` does not have yet.
+
+#### Mechanism
+
+Each QUIC worker builds its own listener with `listen::Config::init`, so each independently:
+
+- loads the `listen.tls.cert` / `listen.tls.key` files,
+- spawns its own `tls::reload_certs` watcher,
+- snapshots its own mTLS client roots.
+
+`Workers` keeps the *first* worker's `Certificates` handle, and that is the one `/certificate.sha256` publishes.
+
+Three consequences:
+
+1. **Rotation is not atomic.** During a reload, workers can be serving different certificates. Both are valid, so TLS still completes, but the group is briefly inconsistent and the published fingerprint may match only some of them.
+2. **A failed watcher diverges permanently.** `tls::reload_certs` logs and continues when it cannot watch; that worker then serves the old certificate indefinitely while its siblings rotate, and nothing surfaces the split.
+3. **N redundant watchers** on the same files, one per worker.
+
+The mTLS roots have the same shape: `--listen-tls-root` is snapshotted per worker.
+
+#### Why it was not fixed in #2921
+
+Injecting one shared, already-loaded identity into every worker needs `moq-tokio` to accept in-memory certificate material. `tls::Listen` takes paths (`cert: Vec<PathBuf>`, `key`, `root`) and each backend loads them itself, so there is no way to hand N listeners one resolved, hot-reloadable identity today.
+
+\#2921 documents the divergence window instead of implying it is not there, and separately rejects `--listen-tls-generate` with workers, since that case is not merely inconsistent but actively broken (each worker would generate a *different* self-signed certificate while the fingerprint endpoint advertises one of them).
+
+#### Suggested direction
+
+Give `moq-tokio` a way to build a listener from resolved TLS material rather than paths, then have the relay load and watch once on the shared runtime and hand every worker the same handle. Rotations then apply to the group at once and `/certificate.sha256` is authoritative for every worker. That would also let `--listen-tls-generate` work with workers: generate once, share it.
+
+Reported by an adversarial review pass (Codex) on #2921.
+
+## Closes
+
+- [#2924](https://github.com/moq-dev/moq/issues/2924) - close this issue when the quest finishes

--- a/quest/m0/2933-moq-ffi-moqroute-round-trip-erases-a-routes-cold-cost.md
+++ b/quest/m0/2933-moq-ffi-moqroute-round-trip-erases-a-routes-cold-cost.md
@@ -1,0 +1,43 @@
+# [M] moq-ffi: MoqRoute round-trip erases a route's cold cost
+
+## Goal
+
+Implement and verify the behavior tracked in [#2933](https://github.com/moq-dev/moq/issues/2933)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Found by the Codex reviewer during [#2925](https://github.com/moq-dev/moq/pull/2925), which splits the route cost into `broadcast::Cost { warm, cold }`. Filing rather than fixing in that PR because it is a public-API decision spanning five language bindings.
+
+#### The gap
+
+`rs/moq-ffi/src/origin.rs` maps the pair onto one scalar in each direction:
+
+- `From<broadcast::Route> for MoqRoute` reports `route.cost.warm` and drops `cold`.
+- `TryFrom<MoqRoute> for broadcast::Route` calls `with_cost(u64)`, which sets *both* halves to that scalar.
+
+So a caller that observes a route through `MoqBroadcastConsumer::route_updates` and feeds it back into `MoqBroadcastProducer::set_route` converts a truthful `{warm: 0, cold: N}` into `{warm: 0, cold: 0}`. Cold 0 means "I am the publisher", so the republished route understates how far the content actually is, and a relay forwarding it advertises a cold cost lower than the truth.
+
+This was deliberately scoped out of #2925 to avoid rippling `cold` through `libmoq`, `py/`, `swift/`, `kt/`, `go/`, and `doc/lib/*` for a field no application routes on. The round-trip being silently lossy in the *unsafe* direction is what makes it worth revisiting.
+
+#### Severity is narrower than it first looks
+
+The handover gate only consults an advertised cold cost when `hops.len() >= 2` (see `FrontState::handover_allowed`). A route published by an application arrives at its relay with a one-hop chain, so it is treated as a direct publisher route and never enters the rank comparison. An application can also already misreport its production cost through the existing scalar, so this is not a new trust boundary  -  the relay mesh has always taken a publisher's seeded cost at face value.
+
+What is new is that the *observe then republish* path silently rewrites a value the app did not choose, rather than the app choosing to lie.
+
+#### Options
+
+1. Add `cold` to the `MoqRoute` uniffi record. Additive for the generated bindings (`rs/libmoq` does not expose routes over the C ABI, so no C break), but per the Cross-Package Sync table it touches `{py,swift,kt}/`, `go/wrapper/moq/*.go`, and `doc/lib/{py,swift,kt,go}`. An omitted cold could default to the supplied warm value, which is correct for a publisher seeding a production cost.
+2. Keep the surface scalar and make the asymmetry unrepresentable instead, e.g. by separating the seed-a-production-cost input from the observe-a-route output so an observed route cannot be passed to `set_route`.
+3. Accept it and document `MoqRoute.cost` as a production cost that is not meant to be echoed. Weakest option; `CLAUDE.md` prefers making misuse unrepresentable over documenting it.
+
+## Closes
+
+- [#2933](https://github.com/moq-dev/moq/issues/2933) - close this issue when the quest finishes

--- a/quest/m0/2934-export-ts-re-emits-a-stored-tdt-on-the-30-s-slot-grid-the.md
+++ b/quest/m0/2934-export-ts-re-emits-a-stored-tdt-on-the-30-s-slot-grid-the.md
@@ -1,0 +1,46 @@
+# [M] export ts re-emits a stored TDT on the 30 s slot grid: the clock arrives ~14 s late, and below…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2934](https://github.com/moq-dev/moq/issues/2934)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Pointed the #2914 rig at #2929's head as offered (`dev` `016fc09ae`).
+
+**Carriage is confirmed.** TDT and TOT both reach the egress, and TOT's `local_time_offset` descriptors arrive byte-identical to the source's  -  both regions, CRC recomputed around the re-stamped UTC field. The 0-packet gap is closed, and the descriptor result is the part of your argument for proxying that I could not have taken on trust.
+
+The clock those sections *assert* is a separate matter. Source re-stamped with `tsp -P timeref --start system`, so every TDT transmitted asserts the true UTC of its own transmission and any lateness downstream is the lane's. 300 s per arm; the arms differ only in how the source's cadence sits against `si_interval`'s 30 s for 0x70/0x73.
+
+| arm | source TDT | delivered | median late | max | re-sent a time already asserted |
+|---|---|---|---|---|---|
+| control  -  same publisher, no MoQ | 15.1 s | 20 × 0x70 | 470 ms | 916 ms |  -  |
+| base | 15.1 s | 11 × 0x70 | **14,385 ms** | 15,546 ms | no |
+| slow | 45 s | 11 × 0x70 | 23,894 ms | 38,861 ms | **4 of 11** |
+| TDT + TOT | 20 s | 11 × 0x70, 11 × 0x73 | 4,332 ms | 5,009 ms | no |
+
+**The defect is the slow arm**  -  a source ticking slower than the exporter emits. Seven distinct source values, eleven emissions:
+
+```text
+  0.01 s  asserts 09:54:50      19.21 s  asserts 09:54:50
+ 49.48 s  asserts 09:55:35      79.23 s  asserts 09:55:35
+```
+
+A receiver sets its clock from the first, advances it locally for 19 s, then reads the same time again and steps **backwards** by 19 s. A receiver of the original multiplex never sees that, because every TDT on that wire carries a new time  -  which is the sense in which the staleness here isn't quite the bound a TS receiver already lives with.
+
+**The cost, separately, is the base arm.** `due()` fires when a media timestamp crosses an *absolute* `si_interval` slot, so emission is a 30 s grid rather than a floor on repetition: a section arriving mid-slot waits for the boundary, and with a 15.1 s source half the ticks are dropped and the section sent is the older of the two held. Not drift  -  lateness is flat at 13.4–15.5 s across eight consecutive emissions, against ≤ 917 ms of total instrument slide over the same 300 s. And it is a phase rather than a constant: 4.3 / 14.4 / 23.9 s across the three arms on one build, so it is not an offset anything downstream could be told about and correct for.
+
+**Suggested fix, narrow.** For a latest-value slot, treat the interval as a floor on *repetition* and emit when the value changes, falling back to the grid only to satisfy the DVB maximum. Your reasoning that a source's observed cadence "means nothing downstream" is right for a static table, where any repetition carries the same information whenever it is sent; for a clock the cadence *is* the information. Suppressing a repeat that would assert an already-sent time would remove the backwards step on its own, but TDT is mandatory at ≤ 30 s, so emit-on-change is the option that satisfies both.
+
+Rig is `tdt-moq.sh` + `tdt-staleness.py`, three arms plus the no-MoQ control, and I am happy to re-run it against a fix.
+
+## Closes
+
+- [#2934](https://github.com/moq-dev/moq/issues/2934) - close this issue when the quest finishes

--- a/quest/m0/2964-quic-workers-dropping-one-split-server-resizes-the.md
+++ b/quest/m0/2964-quic-workers-dropping-one-split-server-resizes-the.md
@@ -1,0 +1,45 @@
+# [M] QUIC workers: dropping one split() Server resizes the reuseport group
+
+## Goal
+
+Implement and verify the behavior tracked in [#2964](https://github.com/moq-dev/moq/issues/2964)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Found in the second review round on #2921. The worker group is off by default and Linux-only, so this is not urgent, but it is the last unenforced part of the "bound once, in order, never resized" invariant that connection-ID steering rests on.
+
+#### Mechanism
+
+`moq_tokio::worker::Workers::split` returns `Vec<(Server, Spawner<'_>)>`. The `Spawner` borrows the group, so a caller cannot drop a worker's *thread* on its own. But `Server` owns the `quinn::Endpoint`, and therefore the socket, and `Server::listen(mut self)` consumes it  -  so the accept loop has to own it.
+
+That leaves two ways to take one socket out of the group:
+
+1. Drop a returned `Server` without running it.
+2. Let the future built from one `Server` return while its siblings keep serving.
+
+Either way Linux moves the last socket in the reuseport array into the vacated slot. The cBPF filter still reduces modulo the original count, and connection IDs encoding the moved member now select an index past the end of the array, so the kernel falls back to hashing the 4-tuple. Live sessions on a worker that never failed get misrouted.
+
+`moq-relay` does the right thing today  -  `Relay::run` ends on the first worker to finish and then calls `Workers::shutdown`  -  so its exposure is a shutdown that was already happening. An embedder gets no such guarantee.
+
+#### Why it is not fixed in #2921
+
+Making it unrepresentable means `Workers` owns the servers and drives them, so the caller passes something like `FnOnce(Server) -> impl Future` for the group to build each accept loop from. That is a callback parameter, which [CLAUDE.md](/CLAUDE.md) rules out of public APIs, and avoiding it is why the split/spawner shape exists at all. Worth a deliberate decision rather than a drive-by.
+
+#### Options
+
+- Accept a consumed `FnOnce(Server) -> Future` as a *builder* rather than a policy hook (no `Send + Sync + 'static` smuggling, no hidden timing), and have `run` wrap the future so the group stops when any member's future completes.
+- Leave the contract documented (where it is now) and rely on callers.
+- Fold it into the `SK_REUSEPORT` + `BPF_MAP_TYPE_REUSEPORT_SOCKARRAY` work from #2875. A map-based selector picks by slot rather than by position, so a member leaving stops being catastrophic and this whole class of problem goes away. Same place #2960 points.
+
+Related: #2960 (a restarting relay joining the old process's group), #2875 (the epic).
+
+## Closes
+
+- [#2964](https://github.com/moq-dev/moq/issues/2964) - close this issue when the quest finishes

--- a/quest/m0/2979-moq-tokio-does-not-compile-with-no-default-features-and.md
+++ b/quest/m0/2979-moq-tokio-does-not-compile-with-no-default-features-and.md
@@ -1,0 +1,40 @@
+# [S] moq-tokio does not compile with --no-default-features, and workspace feature unification hides…
+
+## Goal
+
+Implement and verify the behavior tracked in [#2979](https://github.com/moq-dev/moq/issues/2979)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`cargo check -p moq-tokio --no-default-features` fails on `dev`. Found while reviewing #2977; the breakage predates #2921.
+
+#### Errors
+
+At `ca2fd504f` (before #2921 merged), 4 errors:
+
+- 2x `E0004: non-exhaustive patterns: type &RequestKind is non-empty` (all variants cfg'd out by the missing backend features, so the remaining matches don't compile)
+- 2x `E0282: type annotations needed`
+
+`#2921` added a 5th: `E0433: cannot find util in crate` from `worker.rs`, which calls `crate::util::resolve` while `mod util` is gated on `any(noq, quinn, quiche)`. `worker::Workers::bind` now also references the equally-gated `crate::server::DEFAULT_BIND` (#2977), deepening the same dependency rather than introducing it.
+
+#### Why CI never sees it
+
+Nightly `just rs features` runs `--no-default-features` across the workspace, and cargo unifies features per crate: `moq-relay` (and everything else) depends on `moq-tokio` with a backend enabled, so `moq-tokio` never actually compiles with zero features in a workspace build. Only a `-p moq-tokio --no-default-features` invocation, or an external consumer with `default-features = false` and no backend feature, hits it.
+
+#### Options
+
+- Decide the backend-less configuration is unsupported and enforce it: `compile_error!` when no QUIC backend feature is enabled (a tcp/uds-only build would need its own thought), which turns 5 confusing errors into 1 honest one.
+- Or make it compile: ungate `util`/`DEFAULT_BIND` (both are dependency-free), gate `worker`/`steer` on a backend, and fix the pre-existing `RequestKind` matches.
+
+The first is less work and matches reality: `worker`, `steer`, and `server` all assume a backend exists.
+
+## Closes
+
+- [#2979](https://github.com/moq-dev/moq/issues/2979) - close this issue when the quest finishes

--- a/quest/m0/2980-moq-relay-nothing-guards-the-socket-capturing-acceptor.md
+++ b/quest/m0/2980-moq-relay-nothing-guards-the-socket-capturing-acceptor.md
@@ -1,0 +1,37 @@
+# [M] moq-relay: nothing guards the socket-capturing acceptor being installed on a listener
+
+## Goal
+
+Implement and verify the behavior tracked in [#2980](https://github.com/moq-dev/moq/issues/2980)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up from #2963, raised independently by two review passes and accepted there rather than blocking the merge.
+
+#### The gap
+
+`SocketAcceptor` (plain HTTP) and `MtlsAcceptor` (HTTPS) each capture the connection's descriptor so qmux can report an RTT at SETUP time. `web.rs` tests cover the capture itself and its propagation onto the request, but nothing covers the *installation*: deleting `.acceptor(SocketAcceptor)` from `Web::serve` leaves the whole suite green.
+
+That is not hypothetical. #2963 originally shipped exactly that bug  -  only the HTTPS listener installed an acceptor, so every `ws://` session silently advertised no Probe capability and stayed on the fallback jitter buffer. It looked correct in any TLS deployment and did nothing for local development and the demo.
+
+#### Why it was not fixed there
+
+Two obvious approaches were considered and rejected:
+
+- **Install the acceptor inside `listener::server()`** so no call site can forget. `internal.rs` shares that helper and serves only an ops router, so this would duplicate a descriptor on every health-check connection for nothing.
+- **Assert it end to end** in `tests/smoke.rs`, which does have a working `ws://` relay harness. `moq_net::ConnectionStats` exposes `estimated_recv_rate` from PROBE but not the PROBE's RTT, and the relay's send-rate estimate is `None` on macOS, so there is no cheap observable that proves the capture reached qmux.
+
+#### What would close it
+
+Surfacing the peer-reported PROBE RTT on `ConnectionStats` would make the smoke assertion straightforward, and is plausibly useful to consumers in its own right  -  an application on the adaptive-jitter path currently cannot see the RTT its buffer is derived from. That is a public API addition and deserves its own design pass rather than being bolted on to satisfy a test.
+
+## Closes
+
+- [#2980](https://github.com/moq-dev/moq/issues/2980) - close this issue when the quest finishes

--- a/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md
+++ b/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md
@@ -1,0 +1,45 @@
+# [M] moq-audio: nothing in the decode or playback path models a media gap
+
+## Goal
+
+Implement and verify the behavior tracked in [#2981](https://github.com/moq-dev/moq/issues/2981)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+A media gap (a discontinuity in frame timestamps) is treated as contiguous audio everywhere below the catalog. Two reviewers hit different faces of this on [#2968](https://github.com/moq-dev/moq/pull/2968), so filing the shared cause rather than either symptom.
+
+Gaps are routine, not exotic: `latency_max` skipping a stalled group is the common source and predates any of this. `moq play` dropping an undecodable packet (added in #2968) is a second source, and an ingest that resyncs is a third (compare #2798 for the TS side, and #2786 for the video analogue).
+
+#### Where it shows up
+
+**1. `resample::Resampler` concatenates across the gap.** `process` buffers whatever doesn't fill a chunk and prepends it to the next call's input, with no notion of whether that input continues it. Post-gap audio is spliced directly onto pre-gap audio, so the output is shorter than the media timeline it claims, and `decode::Consumer`'s `rewind` (which walks the emitted timestamp back over the buffered frames) is computing from a contiguity that no longer holds.
+
+**2. `moq play` writes to an untimestamped sink.** `play_audio` hands PCM to `playback::Sink`, which just appends. A gap therefore shortens the audio rather than leaving a hole in it. The presentation clock re-anchors from absolute media timestamps on every frame (`media: end - sink.buffered()`), so this self-corrects within one buffer length rather than accumulating, but video runs up to a packet ahead until the hole drains past the speaker.
+
+#### Why it wasn't fixed in #2968
+
+The correct behavior at a discontinuity is to stop carrying samples across it: flush or reset the resampler, and fill the hole with silence so the sink stays aligned with the media timeline. What makes that more than a few lines is deciding *when* a jump counts as a gap, and a too-tight rule is much worse than the bug.
+
+Exact contiguity can't be the test. RTMP carries millisecond timestamps, and an AAC-LC frame at 44.1 kHz is 23.2199… ms, so packets arrive stamped 23, 46, 70, 93 while the true tail advances 23.22, 46.44, 69.66, 92.88. Every packet on the most common ingest path would read as discontinuous, and resetting the resampler per packet destroys exactly the continuity it exists to provide.
+
+So this wants a stated discontinuity policy (tolerance derived from the track timescale and the codec's frame duration, rather than a constant), applied in one place, with tests for both a real gap and the rounding case above.
+
+#### Sketch
+
+- A contiguity test on `decode::Consumer`, comparing the incoming timestamp against the tail it already tracks, with a tolerance that comes from the timescale rather than a magic number.
+- On a gap: flush the resampler's pending samples as their own frame (they belong before the hole) or drop them, then reset, and stamp the next output from the new packet rather than by rewinding.
+- In `play_audio`: write silence for the missing duration so the sink's contents stay aligned with media time, which also covers `latency_max` skips.
+- Tests: packets at frames 0 and 2048 across the gap; and millisecond-stamped 1024-sample AAC packets asserting *no* discontinuity is detected.
+
+Reviewer comments this came from: https://github.com/moq-dev/moq/pull/2968#discussion\_r3826482602 and https://github.com/moq-dev/moq/pull/2968#discussion\_r3826315836
+
+## Closes
+
+- [#2981](https://github.com/moq-dev/moq/issues/2981) - close this issue when the quest finishes

--- a/quest/m0/2985-js-net-path-keyed-publisher-state-goes-stale-when-a.md
+++ b/quest/m0/2985-js-net-path-keyed-publisher-state-goes-stale-when-a.md
@@ -1,0 +1,62 @@
+# [M] js/net: path-keyed publisher state goes stale when a broadcast is replaced
+
+## Goal
+
+Implement and verify the behavior tracked in [#2985](https://github.com/moq-dev/moq/issues/2985)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Three pieces of publisher state in `js/net` are keyed by **path** and never reconciled when a path's producer is *replaced*. Replacement keeps the key present, so every one of them silently keeps serving the predecessor's generation.
+
+Surfaced while reviewing #2976, which fixes an adjacent race (a same-tick close + republish let the predecessor's close handler evict the live successor from the lookup). That fix is correct and these are **not** regressions from it: the diff there only changes the body of `broadcast.closed.then(...)`, so it is inert unless a broadcast closes. All three reproduce on `main` today with a plain replacement over a still-open predecessor, since `Publisher.publish` overwrites the map entry without closing its predecessor:
+
+```ts
+publisher.publish(path, first);
+publisher.publish(path, second); // first never closed; key unchanged, value swapped
+```
+
+##### 1. Same-path replacement is invisible to discovery
+
+`runAnnounce` builds its active set from `broadcasts.keys()` and diffs it with `Set.difference`, so a value swap under an existing key produces neither an `ended` nor a new `active` announcement. Discovery consumers stay attached to the predecessor's `Consumer`.
+
+- `js/net/src/lite/publisher.ts`  -  `runAnnounce`
+- the IETF advertisement loops reconcile the same way
+
+##### 2. `TRACK_INFO` is cached across generations
+
+`#trackInfo` is a `Map<string, Promise<TrackInfoMessage>>` keyed by path + track name and is never invalidated by `publish`. A successor with different immutable track properties (timescale, ordering) is answered with the predecessor's metadata. `FETCH` consumes the same cache, so successor frames can be interpreted against predecessor metadata.
+
+- `js/net/src/lite/publisher.ts`  -  `#trackInfo`, `runTrackInfo`
+
+##### 3. An IETF refusal permanently suppresses the successor
+
+The advertisement loop holds `refused` keyed by `Path.Valid` and clears an entry only when the path is absent from the live set (`if (!live.has(path)) refused.delete(path)`). Because replacement keeps the key present, a `PUBLISH_NAMESPACE` refusal against the predecessor is never cleared, and a live successor stays unadvertised for the rest of the session even though a direct `SUBSCRIBE` resolves it.
+
+- `js/net/src/ietf/publisher.ts`  -  the advertisement loop's `refused` map
+
+#### Suggested direction
+
+All three are the same root cause: no producer identity or generation is tracked, only the path. #2610 specs exactly this as the broadcast **epoch**, and already lists TRACK\_INFO epoch-keying ("`TRACK_INFO` returns the resolved epoch so metadata caches key by generation and requests cannot race a replacement"). This issue tracks the three concrete `js/net` sites that are reachable today, so they don't get lost if the epoch work lands wire-first or in stages.
+
+A local fix is possible ahead of the wire work: compare producer identity (not just the key) during announce reconciliation and emit the replacement transition, evict the path's `#trackInfo` entries in `publish`, and key `refused` by producer identity so it clears on replacement.
+
+#### Tests to encode the root cause
+
+- Replacing a path's producer (both same-tick-after-close and over a still-open predecessor) emits a replacement transition and `announcedBroadcast.active` becomes a distinct `Consumer`.
+- Republishing with a different timescale returns the successor's `TRACK_INFO`, not the predecessor's, over both `SUBSCRIBE` and `FETCH`.
+- A `PUBLISH_NAMESPACE` refusal followed by replacement advertises the successor.
+
+Found by Codex during the adversarial review on #2976, verified against the code.
+
+## Closes
+
+- [#2985](https://github.com/moq-dev/moq/issues/2985) - close this issue when the quest finishes

--- a/quest/m0/2991-net-coalesce-dynamic-tracks-and-preserve-sequences-across.md
+++ b/quest/m0/2991-net-coalesce-dynamic-tracks-and-preserve-sequences-across.md
@@ -1,0 +1,56 @@
+# [M] net: coalesce dynamic tracks and preserve sequences across replacements
+
+## Goal
+
+Implement and verify the behavior tracked in [#2991](https://github.com/moq-dev/moq/issues/2991)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Dynamic tracks should have one logical identity per broadcast and track name, but the Rust and JavaScript models currently violate different parts of that invariant.
+
+##### Rust resets sequences when a dynamic producer is replaced
+
+A closed dynamic track is removed from the broadcast's weak cache. The next subscription creates a fresh `track::Request`, and `Request::new` creates a fresh `TrackState`. Because `max_sequence` is empty, both `append_group` and `append_datagram` restart at sequence 0.
+
+That conflicts with the relay's logical track splicing. `resume::Producer::takeover` retains the previous live edge and starts a replacement at `latest + 1`. Groups from a restarted producer are therefore filtered until its counter catches up, causing the same playback stall fixed for JavaScript in #2953.
+
+The existing `test_linger_reconnect_splices` avoids the reset by explicitly creating replacement group 2 after the old producer emitted groups 0 and 1. Using `append_group()` there would create group 0 and leave the subscriber stalled. Explicit group or datagram writes can raise the old producer's shared sequence edge further, making the catch-up window longer.
+
+##### JavaScript permits concurrent same-name dynamic producers
+
+`BroadcastProducer.subscribe()` calls the internal subscribe path with `register = false`. Multiple publishing-side subscriptions for the same name therefore enqueue independent requests and create independent `track.Producer` instances.
+
+\#2953 made those concurrent producers share a sequence allocator. That prevents duplicate sequence allocation, but concurrent producers are the wrong model. Publishing-side subscriptions should coalesce like `BroadcastConsumer.subscribe()` and Rust's `broadcast::Consumer::track`: one pending or live producer per broadcast and name, one on-demand request, and multiple subscribers fanning out from it.
+
+#### Desired behavior
+
+- A broadcast has at most one pending or live dynamic track producer per track name.
+- Concurrent JavaScript publishing-side subscriptions for the same name emit one request and share its accepted producer.
+- Subscription options from all subscribers remain aggregated on that request.
+- After that producer closes, a later request creates a new producer but continues the group/datagram sequence namespace for that broadcast and name.
+- Explicit group and datagram writes advance the shared allocator.
+- A new broadcast generation starts each track at sequence 0.
+- Rust and JavaScript expose the same lifecycle and sequencing behavior.
+
+The sequence allocator should be shared across producer incarnations without sharing the closed producer's cache or terminal state.
+
+#### Regression coverage
+
+- JavaScript: two `BroadcastProducer.subscribe()` calls for one name produce one request and both subscribers receive from the accepted producer.
+- JavaScript: remove or replace #2953's concurrent-producer test, since concurrent same-name producers should not be representable.
+- Rust and JavaScript: close a dynamic producer after group/datagram sequences have advanced, re-request the same name, and verify the replacement appends at the next sequence.
+- Rust relay model: keep a logical subscriber live across replacement and verify the first replacement group is delivered immediately rather than filtered until catch-up.
+- Both implementations: verify a separate broadcast generation starts at 0.
+
+## Closes
+
+- [#2991](https://github.com/moq-dev/moq/issues/2991) - close this issue when the quest finishes

--- a/quest/m0/2999-js-net-cannot-send-a-stream-reset-code-so-every.md
+++ b/quest/m0/2999-js-net-cannot-send-a-stream-reset-code-so-every.md
@@ -1,0 +1,38 @@
+# [S] js/net cannot send a stream reset code, so every cancellation reads as INTERNAL_ERROR
+
+## Goal
+
+Implement and verify the behavior tracked in [#2999](https://github.com/moq-dev/moq/issues/2999)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Found during the adversarial review of #2993.
+
+`js/net` has no way to send an application stream error code. Every teardown passes a plain `Error`:
+
+- `Stream.close()` -> `writer.close()` + `reader.stop(new Error("cancel"))`
+- `Stream.abort(reason)` -> `writer.reset(reason)` + `reader.stop(reason)`
+- `Writer.reset(reason)` -> `WritableStreamDefaultWriter.abort(reason)`
+- `Reader.stop(reason)` -> `ReadableStreamDefaultReader.cancel(reason)`
+
+WebTransport only carries a code when the reason is a `WebTransportError` with `streamErrorCode` set; nothing in `js/net` ever constructs one. So every reset and STOP\_SENDING goes out as code `0`.
+
+On the IETF wire that matters: draft-19 section 3.3.4 assigns `INTERNAL_ERROR` to `0x0` and `CANCELLED` to `0x1`. A routine browser unsubscribe therefore reaches the publisher looking like a fault on our side, to be handled and counted as one. #2993 fixed this on the Rust side for the cancellation path (`STREAM_CANCELLED` via a raw-code `Reader::stop`), but the JS equivalent needs a code parameter threaded through `Writer.reset` and `Reader.stop` first.
+
+Two things make this bigger than a one-line change, which is why it was left out of #2993:
+
+- It changes a shared abstraction, so the moq-lite path is affected too and both error spaces have to be kept straight.
+- `WebTransportError` construction needs a compatibility story for non-browser test environments.
+
+The same widening was declined on the Rust side for the equivalent reason: other IETF paths (`run_uni_group`, for one) still reset with moq-lite codes, and untangling that means reworking `Error::from_transport`, where `0` decodes back to `Cancel`.
+
+## Closes
+
+- [#2999](https://github.com/moq-dev/moq/issues/2999) - close this issue when the quest finishes

--- a/quest/m0/3000-track-teardown-on-poll-unused-is-not-atomic-against-a.md
+++ b/quest/m0/3000-track-teardown-on-poll-unused-is-not-atomic-against-a.md
@@ -1,0 +1,42 @@
+# [S] Track teardown on poll_unused is not atomic against a consumer reattaching
+
+## Goal
+
+Implement and verify the behavior tracked in [#3000](https://github.com/moq-dev/moq/issues/3000)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Found during the adversarial review of #2993, but pre-existing on `main` rather than introduced there.
+
+`ietf::Subscriber::run_subscribe` treats an unused wake as an irrevocable terminal:
+
+```rust
+if track.poll_unused(waiter).is_ready() {
+    return Poll::Ready(End::Unused);
+}
+```
+
+followed by `track.abort(Error::Cancel)` and a cancellation upstream.
+
+`poll_unused` is a level snapshot. A consumer can be obtained from the still-live cached track after the poll observes zero consumers and before `abort` runs, and that healthy consumer is then closed with `Cancel` while the upstream subscription is cancelled underneath it. Reordering the polls does not help; the gap is between observing the count and committing the teardown.
+
+`js/net` partially guards the equivalent path by re-checking demand before breaking:
+
+```ts
+if (reason === idle && producer.closed.peek() === undefined && producer.used.peek()) continue;
+```
+
+Rust has no equivalent, and `track::Producer` exposes no `is_used()` to re-check with, so bringing it to parity means adding model API. The real fix is an atomic close-if-still-unused on the producer, coordinated with consumer creation, used by every unused-driven teardown. That is a model-layer change affecting the moq-lite path as well as the IETF one, which is why it was not folded into #2993.
+
+Worth a regression test that interleaves demand returning after the unused wake but before teardown commits.
+
+## Closes
+
+- [#3000](https://github.com/moq-dev/moq/issues/3000) - close this issue when the quest finishes

--- a/quest/m0/3001-ietf-stream-resets-send-moq-lite-error-codes-so-routine.md
+++ b/quest/m0/3001-ietf-stream-resets-send-moq-lite-error-codes-so-routine.md
@@ -1,0 +1,33 @@
+# [S] IETF stream resets send moq-lite error codes, so routine events read as INTERNAL_ERROR
+
+## Goal
+
+Implement and verify the behavior tracked in [#3001](https://github.com/moq-dev/moq/issues/3001)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Split out of #2993, where the cancellation path was fixed narrowly and the general case deliberately was not.
+
+`Error::to_code()` encodes the moq-lite space, where `Cancel` is `0`. On the moq-transport wire, draft-19 section 3.3.4 assigns `0x0` to `INTERNAL_ERROR` and `0x1` to `CANCELLED`. Every IETF stream reset that goes through `Reader::abort`/`Writer::abort` therefore sends a code from the wrong registry.
+
+The most visible case is `ietf/session.rs`, where a failed `run_uni_group` does `reader.abort(&err)`. A group arriving for an alias the subscriber retired by its own cancellation is an expected late object, and it stops the stream with `0` -- the publisher reads a routine event as an internal failure on our side.
+
+\#2993 fixed exactly one site (`cancel_subscribe`, via a named `STREAM_CANCELLED` and a raw-code `Reader::stop`) because it could be shown safe there: the publisher treats its request stream reader closing as `Ok(())` and never inspects the code.
+
+The general fix is not a matter of passing `1` at each remaining site, which is why it was not folded in:
+
+- `Error::from_transport` maps only `0` back to `Cancel`. Changing outgoing codes without it makes two moq-net IETF peers disagree, so a routine cancellation surfaces as `Remote(1)` and can move an expected event into error paths.
+- Both directions have to change together, and the mapping is shared with moq-lite, whose code space is unrelated.
+
+So this wants a per-protocol code mapping (outgoing and incoming) rather than a scattering of literals. The js/net counterpart is #2999: there the abstraction cannot express a code at all.
+
+## Closes
+
+- [#3001](https://github.com/moq-dev/moq/issues/3001) - close this issue when the quest finishes

--- a/quest/m0/3002-no-test-drives-a-late-group-through-the-ietf-dispatch-loop.md
+++ b/quest/m0/3002-no-test-drives-a-late-group-through-the-ietf-dispatch-loop.md
@@ -1,0 +1,35 @@
+# [S] No test drives a late group through the IETF dispatch loop
+
+## Goal
+
+Implement and verify the behavior tracked in [#3002](https://github.com/moq-dev/moq/issues/3002)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Raised by the adversarial review on #2993.
+
+`ietf::error::to_stream_code` decides the code a failed uni stream is stopped with, and `run_unis` in `ietf/session.rs` is the one line that applies it:
+
+```rust
+reader.stop(super::error::to_stream_code(&err));
+```
+
+Nothing exercises that line. The regression added in #2993 (`a_retired_alias_maps_to_the_cancelled_code`) proves the alias resolves to `Error::Cancel` and that `Cancel` maps to `CANCELLED`, but it never owns a receive stream and never observes `Log::stops()`. It would still pass if the dispatch loop stopped calling the mapper, or stopped calling `stop` at all.
+
+Driving it end to end needs two things that put it beyond the scope of that PR:
+
+- A test session whose `accept_uni` yields a scripted stream. `ScriptedSession::accept_uni` parks and `DeadStreamSession` hands out an already-dead stream, so neither can deliver a SUBGROUP\_HEADER.
+- Reach across a module boundary. `run_unis` is private to `session`, while retiring an alias touches state private to `subscriber`, so no single test module can set up the state and drive the loop.
+
+The shape worth having: script one uni stream carrying a subgroup header for a retired alias, run the dispatch loop over it, and assert the transport recorded a STOP\_SENDING of `0x1`. The uni-script support would be reusable for any other test that wants to drive that loop, of which there are currently none.
+
+## Closes
+
+- [#3002](https://github.com/moq-dev/moq/issues/3002) - close this issue when the quest finishes

--- a/quest/m0/3021-moq-gst-anchor-generated-media-timelines-to-wall-clock.md
+++ b/quest/m0/3021-moq-gst-anchor-generated-media-timelines-to-wall-clock.md
@@ -1,0 +1,92 @@
+# [M] moq-gst: anchor generated media timelines to wall clock
+
+## Goal
+
+Implement and verify the behavior tracked in [#3021](https://github.com/moq-dev/moq/issues/3021)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+`moqsink` already publishes a Hang companion timeline for each media rendition. The timeline maps media group sequence numbers to presentation timestamps, but its catalog section does not include the optional `wall` anchor.
+
+Without `wall`, consumers can seek by presentation time and locate the live edge, but they cannot translate those timestamps into the publisher's wall-clock domain.
+
+#### Protocol semantics
+
+This issue concerns the Hang companion timeline, not the transport-level TIMESTAMP property.
+
+The MoQ Object Timestamp extension defines:
+
+- A track-level `TIMESCALE`, fixed for the lifetime of the media track.
+- An object-level `TIMESTAMP`, containing an absolute presentation timestamp in that timescale.
+- Relative timestamp comparisons for relays. It does not define a UTC mapping.
+
+The Hang timeline has its own catalog representation:
+
+- `timescale` is the number of timeline units per second and defaults to 1000.
+- Each record's `pts` is the first frame's presentation timestamp, converted into the timeline timescale and rounded down.
+- `wall` is the wall-clock time of presentation timestamp zero, expressed in timeline units since the MoQ epoch at `2020-01-01T00:00:00Z`.
+- A consumer derives a group's wall-clock presentation time as `wall + pts`.
+
+The media-track and companion-timeline timescales are related by conversion, but they are not the same field and need not use the same units.
+
+#### Current behavior
+
+`moq-mux` already provides the required timeline machinery:
+
+- Generated `<track>.timeline.z` tracks.
+- Group-to-PTS records.
+- `timeline::Producer::set_wall`, which accepts a media timestamp and its corresponding `SystemTime`.
+- Catalog support for the resulting `wall` value.
+
+`moqsink` maps GStreamer PTS through the TIME segment before publishing, but it never supplies a corresponding wall-clock observation to the timeline producer. As a result, the advertised timeline has no `wall` value.
+
+#### Proposed behavior
+
+Establish a wall-clock anchor after receiving the first suitable timestamped media buffer:
+
+1. Use the same mapped media timestamp that is passed to the media importer.
+2. Prefer `GstReferenceTimestampMeta` when its reference clock represents an accepted absolute wall-clock domain.
+3. Otherwise estimate the corresponding wall time from the local system clock, pipeline clock, base time, running time, and the buffer's TIME-segment mapping.
+4. Pass the media timestamp and corresponding `SystemTime` to the existing timeline producer.
+5. Republish the rendition's catalog entry using the updated timeline section so consumers receive `wall`.
+
+A reference timestamp from an arbitrary or unidentified clock domain must not be treated as UTC.
+
+The design must also define behavior across timestamp discontinuities. A single `wall` value describes one linear mapping for the entire advertised timeline, so replacing it must not make previously published records resolve against a different epoch.
+
+#### Acceptance criteria
+
+- Existing group-to-PTS timeline records remain unchanged.
+- The catalog timeline section includes `wall` after a valid anchor is established.
+- For any timeline record, `(wall + pts) / timescale` resolves to the expected duration since the MoQ epoch.
+- `GstReferenceTimestampMeta` is preferred only for recognized absolute reference clocks.
+- A deterministic local-clock fallback works when no suitable reference metadata is available.
+- The implementation preserves the distinction between the media-track timescale and the companion-timeline timescale.
+- Timeline integers remain within the draft's `2^53 - 1` limit.
+- No transport-level `TIMESCALE` or `TIMESTAMP` semantics are changed.
+- Tests cover the reference-timestamp path, the local-clock fallback, catalog publication, and discontinuity behavior.
+
+When the reference timestamp represents capture time, receivers can estimate capture-to-arrival latency. Otherwise, the result is presentation-to-arrival latency.
+
+#### Out of scope
+
+- Changes to transport-level timestamp properties.
+- Opaque application tracks.
+- Shared timelines or aligned rendition groups.
+- Clock synchronization protocols or continuous drift correction.
+- Changes to the timeline wire format.
+
+(Co-written by GPT-5 Codex)
+
+## Closes
+
+- [#3021](https://github.com/moq-dev/moq/issues/3021) - close this issue when the quest finishes

--- a/quest/m0/3023-payloadprocessor-for-encryption-signing.md
+++ b/quest/m0/3023-payloadprocessor-for-encryption-signing.md
@@ -1,0 +1,24 @@
+# [M] PayloadProcessor for encryption/signing
+
+## Goal
+
+Implement and verify the behavior tracked in [#3023](https://github.com/moq-dev/moq/issues/3023)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+I've created a small encryption/signing lib for moq payloads, [moq-secure](https://github.com/cathode-ray-tube/moq-secure) but struggling to find a slot to implement it.
+
+In moq-net, there are multiple write\_frame/read\_frame functions across group.rs and track.rs.
+
+A PayloadProcessor (perhaps behind a feature flag) would be useful, alternatively any suggestions where to apply the encryption/signing?
+
+## Closes
+
+- [#3023](https://github.com/moq-dev/moq/issues/3023) - close this issue when the quest finishes

--- a/quest/m0/3046-fold-moq-token-into-moq-token-via-a-usage-executable-view.md
+++ b/quest/m0/3046-fold-moq-token-into-moq-token-via-a-usage-executable-view.md
@@ -1,0 +1,51 @@
+# [M] Fold moq-token into moq token via a Usage executable view
+
+## Goal
+
+Implement and verify the behavior tracked in [#3046](https://github.com/moq-dev/moq/issues/3046)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+Fold the standalone `moq-token` binary into `moq token`, so there is one binary and one command surface instead of two build artifacts sharing a library.
+
+#### Where we are
+
+`moq-token-cli` is a lib+bin. The command surface lives in `moq_token_cli::Args`, which the standalone `moq-token` binary wraps in its own `Root` spec root and `moq-cli` nests under `moq token`. The implementation is genuinely shared, so this is not about duplicated logic. What is duplicated is the *surface*: two spec roots, two help renderings, two completion trees, two release artifacts, and two places for a flag to drift.
+
+#### Why now
+
+If #3030 lands, Usage has the mechanism for exactly this: an **executable view**. A view is argv0 dispatch against a single binary's own spec, so one binary can present a different root depending on the name it was invoked under. `moq-token generate ...` and `moq token generate ...` become one spec with two surfaces, and help renders the right prefix for each (`page_view` / `render_failure_view` already exist for this).
+
+The blocker today is not the CLI plumbing, it is that they are separate build artifacts. Views cannot span two binaries.
+
+#### Sketch
+
+- `moq-cli` declares `#[usage(view("moq-token", bin = "moq-token", root = "token"))]`.
+- Ship `moq-token` as a symlink, hardlink, or a thin renamed copy of `moq`, rather than as its own compiled binary.
+- Drop `moq-token-cli`'s `Root` struct; the crate keeps exporting `Args` for `moq-cli` to nest.
+- `moq-token` (the library) is unaffected -- it stays free of CLI concerns either way.
+
+#### Things to decide
+
+- **Packaging.** `moq-token` is currently released as its own artifact with its own version. A symlink changes what the release workflow produces and what a package manager installs. This is the bulk of the work.
+- **Binary size.** `moq-token` today is a small binary; making it an alias of `moq` means anyone who wants only token tooling pulls the full media router.
+- **Whether the standalone name survives at all**, or whether `moq token` simply becomes the only spelling after a deprecation period. That is the simpler end state if nobody depends on the separate binary.
+
+The second point may be the one that kills it. Worth measuring `moq` vs `moq-token` stripped sizes before committing.
+
+#### Depends on
+
+\#3030 (Usage migration). Without it there is no view mechanism, and the shared-`Args` arrangement we have is about as good as clap allows.
+
+## Closes
+
+- [#3046](https://github.com/moq-dev/moq/issues/3046) - close this issue when the quest finishes

--- a/quest/m0/3049-moq-net-outbound-hop-path-construction-is-never-validated.md
+++ b/quest/m0/3049-moq-net-outbound-hop-path-construction-is-never-validated.md
@@ -1,0 +1,35 @@
+# [M] moq-net: outbound HOP_PATH construction is never validated
+
+## Goal
+
+Implement and verify the behavior tracked in [#3049](https://github.com/moq-dev/moq/issues/3049)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`HopPath::validate` runs only on decode, so nothing stops us building and sending an outbound HOP\_PATH that a conforming receiver must reject.
+
+`ietf::cluster::HopPath::validate` rejects an empty list and a repeated non-zero Hop ID, but it is only called from `param_decode`. `Advert::forward` appends our own Hop ID and wraps the result without revalidating, and the encode path does not check either. A `broadcast::Route` whose `hops` already carry a duplicate therefore goes out as-is.
+
+That matters because `draft-lcurley-moq-cluster` requires the receiver to treat it as fatal: "A receiver MUST close the session with a PROTOCOL\_VIOLATION if the entries do not exactly fill `Length`, if the list is empty, or if a non-zero Hop ID appears twice." So a malformed chain we construct does not degrade our own routing, it closes the downstream session.
+
+Routes reach the model from more than one place, and only the IETF decode path is checked:
+
+- The moq-lite ingress builds hop chains itself. `OriginList` caps length but does not reject duplicates, so a lite chain may legally carry one and, once shared through the origin, be forwarded to an IETF cluster peer.
+- `broadcast::Route` is public with a public `hops` field, so any in-process producer can attach one.
+
+moq-dev/moq#3042 closed the two reachable cases it introduced, both at ingress: `ietf::Subscriber::route` discards a chain already carrying the identity assigned to the peer, and `lite::Subscriber`'s two responder-append sites do the same. Those are per-path guards. The general gap is that validity is enforced where a chain is parsed rather than where one is emitted, so the next route source has to remember the rule again.
+
+Worth considering: validate in the outbound constructor (`Advert::forward`, or the encode path) and have publisher route selection skip a route that cannot be legally advertised, rather than emitting it. A route that is invalid to advertise may still be fine to serve locally, so dropping the route entirely is probably wrong.
+
+Found by Codex during adversarial review of #3042.
+
+## Closes
+
+- [#3049](https://github.com/moq-dev/moq/issues/3049) - close this issue when the quest finishes

--- a/quest/m0/3051-config-merge-empty-lists-lose-to-the-environment-and-the.md
+++ b/quest/m0/3051-config-merge-empty-lists-lose-to-the-environment-and-the.md
@@ -1,0 +1,60 @@
+# [M] Config merge: empty lists lose to the environment, and the file outranks it
+
+## Goal
+
+Implement and verify the behavior tracked in [#3051](https://github.com/moq-dev/moq/issues/3051)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+Two related defects in how `moq-relay` and `moq-bench` resolve configuration. Both predate the Usage migration (#3030); one of them that migration briefly widened, and #3030 fixes that part.
+
+#### 1. A bare `Vec<T>` loses to the environment
+
+The TOML merge parses CLI + env + defaults, overlays the file, then re-parses the CLI so explicit flags win. That last step fills any field the parser reads as *empty* -- from the environment and from declared defaults, not just from the command line.
+
+Emptiness is a property of the type. A `Vec<T>` reads empty when it has no items, so a config file that deliberately sets an empty list is refilled from the environment:
+
+```toml
+[connect]
+version = []     # "offer every supported version"
+```
+
+With `MOQ_CONNECT_VERSION=moq-lite-01` set, this resolves to `moq-lite-01` instead.
+
+Affects roughly fifteen env-bound list fields: TLS certificate/key/root lists, accepted versions on both the connect and listen sides, the Unix peer allowlists (`uid`/`gid`/`pid`), cluster peers, auth domains, and the web HTTPS material.
+
+Booleans had the same bug and are now `Option<bool>` with the default resolved in code. The same fix works for lists (`Option<Vec<T>>`) but multiplies a convention rather than removing the cause -- see below.
+
+#### 2. The file outranks the environment
+
+Precedence today is `CLI > TOML > env > defaults`. That ordering was never chosen: it falls out of the implementation, which folds env in during the parse and then overlays the file on top of everything. The sentence documenting it in `doc/bin/relay/config.md` was written to describe the behavior after the fact.
+
+Nearly every comparable tool does `CLI > env > file` (12-factor, Viper, and `usage-config`'s own default). The reasoning is deployment: the file ships inside the artifact and the environment varies per deployment, so file-wins means rebuilding an image to change one setting, and means a secret injected by an orchestrator cannot override a placeholder in a checked-in file.
+
+#### Why they are one issue
+
+Both come from the same missing thing: nothing records *which source set a value*. Presence is inferred from the value itself, so "set to false", "set to the empty list", and "never set" are indistinguishable -- and any fix built on comparing values inherits the same blind spot one level down ("set to the default value" vs "never set").
+
+`usage-config` exists for this. `CliLayer` is built from what the parser saw rather than from the parsed struct, `EnvLayer` reads variables against a registry that declares which key each one backs, and `Layers` takes the order from the caller, so the precedence flip in (2) becomes a declared line rather than an emergent property. It also yields provenance, so the relay could answer "where did this setting come from".
+
+The cost is real and worth stating: `usage::Cli` and `usage::Config` share the `#[usage(...)]` attribute namespace and each rejects the other's attributes, so one struct cannot carry both derives. A registry means declaring every merged setting a second time -- roughly 100 for the relay, 20 for the bench -- with `Registry::drift` as a test that the two declarations stay in step.
+
+#### Suggested order
+
+1. `Option<Vec<T>>` for the fifteen list fields, as a contained fix for (1) with a regression test.
+2. Then evaluate the registry for (2), where the duplication buys the precedence flip and provenance rather than just a bug fix.
+
+Doing (2) first would make (1) unnecessary, so it is worth deciding before spending on (1).
+
+## Closes
+
+- [#3051](https://github.com/moq-dev/moq/issues/3051) - close this issue when the quest finishes

--- a/quest/m0/3056-watch-video-decoder-captures-the-rewind-generation-at.md
+++ b/quest/m0/3056-watch-video-decoder-captures-the-rewind-generation-at.md
@@ -1,0 +1,50 @@
+# [M] watch: video decoder captures the rewind generation at output time, not submit time
+
+## Goal
+
+Implement and verify the behavior tracked in [#3056](https://github.com/moq-dev/moq/issues/3056)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Found during the review of #3048. Pre-existing on `main`; that PR does not introduce it.
+
+#### The bug
+
+`DecoderTrack`'s WebCodecs output callback guards against rewinds with a generation counter:
+
+```ts
+output: async (frame) => {
+    const generation = this.#discontinuity;   // read when the frame comes OUT
+```
+
+The counter is read when the frame is *decoded*, not when its chunk was *submitted*. A frame submitted before a rewind but decoded after it therefore reads the already-bumped value, so the later `generation !== this.#discontinuity` check compares the new value against itself and passes.
+
+The guard only catches frames that were already inside the callback and parked in `#park` when the rewind landed, which is why it sits after the await. Frames still queued inside the `VideoDecoder` are exactly the ones it misses.
+
+`#onDiscontinuity` clears `timestamp`, clears the buffered ranges, and calls `sync.reset()`, but never calls `decoder.reset()`, so the queued chunks keep decoding.
+
+#### Consequence
+
+A stale frame that survives the guard parks against the re-anchored clock for the full distance between the two timelines. With the old timeline at 60s and the rewind restarting at 0, `sync.wait()` computes a sleep of roughly 60s for it. It then paints long after it is meaningless, or gets released early by an unrelated change to the pacing input.
+
+#### Possible fixes
+
+- Call `decoder.reset()` (and re-`configure()`) in `#onDiscontinuity`, which is what the audio decoder already does for its own discontinuities. WebCodecs `reset()` discards queued outputs, so the stale frames never surface.
+- Or associate each submitted chunk with the generation it was submitted under and reject mismatches on output.
+
+Either wants a regression test where a pre-rewind output arrives after the reset. That needs a real WebCodecs `VideoDecoder`, which bun's test environment does not provide, so it likely belongs in `test/wasm/` or another browser harness rather than a unit test.
+
+#### Note
+
+The maintainer intends to remove rewind support, in which case deleting the path is the simpler resolution than fixing the generation plumbing. Filing it so the behavior is recorded either way.
+
+## Closes
+
+- [#3056](https://github.com/moq-dev/moq/issues/3056) - close this issue when the quest finishes

--- a/quest/m0/3058-moq-relay-a-revalidation-re-check-cannot-update-a.md
+++ b/quest/m0/3058-moq-relay-a-revalidation-re-check-cannot-update-a.md
@@ -1,0 +1,37 @@
+# [M] moq-relay: a revalidation re-check cannot update a session's tier, and changes its alias only by…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3058](https://github.com/moq-dev/moq/issues/3058)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Found while reviewing #3041, which merged as 7047347. Not a regression - it is what the new re-check does and does not do with a reply whose *non-scope* fields changed.
+
+`Auth::recheck` scores a reply by `Scope::covered_by`, which compares root, subscribe and publish. The resulting `AuthToken` is then dropped and only the `CacheHints` propagate:
+
+```rust
+Fetched::Ok { resp, hints } => match self.authorize(&grant.params, &resp) {
+    Ok(token) if grant.scope.covered_by(&token) => Recheck::Valid { hints },
+```
+
+So two fields the auth API can legitimately change behave inconsistently:
+
+**`tier` is silently ignored.** An endpoint that re-buckets a connection - moving it to a named billing tier, or off one - has no effect on a live session. The session keeps the tier it was admitted with until it reconnects. That matters because the tier decides which meter pays.
+
+**`alias` closes the session.** The alias becomes the token's `root`, so `covered_by`'s `self.root == token.root` fails and the session is revoked. That is arguably correct - the broadcast would otherwise keep announcing under a root the API no longer assigns - but it is a silent hard disconnect for what may be a benign rename, and it is not obviously the intended contract.
+
+The general question is what a re-check is allowed to *update in place* versus what forces a reconnect. Scope narrowing is settled (close, and the client reconnects into the narrower grant). `tier` and `alias` are not.
+
+`tier` looks the harder half: the session's stats handle is built from the admission token in `connection.rs`, so applying a new tier mid-session means rebuilding that handle, and usage already recorded under the old tier stays there. Worth deciding deliberately rather than inheriting whichever behaviour fell out.
+
+## Closes
+
+- [#3058](https://github.com/moq-dev/moq/issues/3058) - close this issue when the quest finishes

--- a/quest/m0/3060-moq-net-ban-hop-id-0-from-hop-chains.md
+++ b/quest/m0/3060-moq-net-ban-hop-id-0-from-hop-chains.md
@@ -1,0 +1,59 @@
+# [L] moq-net: ban Hop ID 0 from hop chains
+
+## Goal
+
+Implement and verify the behavior tracked in [#3060](https://github.com/moq-dev/moq/issues/3060)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`Origin::UNKNOWN` (Hop ID 0) is documented as "no identity", but it is currently legal *inside a hop chain*, and that is where every problem with it comes from. A chain entry that names nobody cannot be filtered on, cannot be loop-detected, and cannot be told apart from another entry that also names nobody. Ban it from chains and those problems stop being cases to handle.
+
+0 stays reserved and keeps its job as the absence marker in the fields that need one (`AnnounceInterest.exclude_hop`, `AnnounceOk.origin`, `RELAY_HOPS`). That reading is unambiguous precisely because no endpoint may adopt 0 as its identity, which `Origin::new` already enforces. What changes is that a chain names real hops only.
+
+#### What this closes
+
+moq-dev/moq#3053: a peer that declares 0 and sends its own HOP\_PATH cannot be filtered on the identity we assigned it. Substituting the assigned id into the chain was implemented during moq-dev/moq#3042 and reverted after producing four defects in four review rounds. With 0 illegal in a chain, a peer with no identity has nothing legal to write as its terminal entry, so that advertisement is a decode-time PROTOCOL\_VIOLATION rather than something to substitute into. The four defects were:
+
+1. Only the terminal entry may be substituted; earlier zeros belong to upstreams the receiver never spoke to.
+2. Substituting can construct an invalid chain: `[X, 0]` from a peer assigned `X` becomes `[X, X]`, a PROTOCOL\_VIOLATION for whoever we forward it to.
+3. The assigned identity must not be tested against a peer that declared one, or its ordinary traffic is discarded as a loop.
+4. The check and the substitution must be gated together, or a peer assigned `Y` that sent `[Y, 0]` bypasses the check and gets rewritten anyway.
+
+Each was a new conditional on the same decision. None of them exist if the chain cannot carry 0.
+
+It also removes the privacy question substitution raised: an assigned identity is indistinguishable on the wire from a declared one, so writing it into a forwarded chain publishes our private name for a peer that asked not to be named.
+
+#### Scope
+
+**Both wire dialects.** A non-zero Hop ID appearing twice is already a PROTOCOL\_VIOLATION in `draft-lcurley-moq-cluster`; moq-dev/moq#3049 mirrors that into `draft-lcurley-moq-lite` and moves it into `OriginList` so it holds at construction rather than only at decode. This issue is the next step on the same rule: `HopPath::validate` drops the duplicate-zeros exemption, and a zero entry becomes invalid on its own.
+
+**moq-lite-01/02/03.** These carry no real Hop IDs. Lite-03 sends a bare hop count that `announce.rs` expands into that many `UNKNOWN` placeholders, which is the only remaining source of zeros in a chain, and lite-01/02 send nothing at all. They stay supported: the count is read as the **route cost** instead, which is what it was for before it was also made to carry loop prevention, and which the lite draft already equates to it (`An absent parameter means the default cost of 1, under which the accumulated Route Cost equals the hop count`).
+
+That means the loop bound has to come from the cost, since the count no longer tracks chain length:
+
+- charge the configured link cost, with a **mandatory floor of 1** on lite-01/02/03 links. A link priced 0 is a supported config (two relays in one datacenter) and would otherwise stop the value growing, leaving the loop unbounded.
+- reject a received value above `MAX_HOPS`, reproducing today's 32-hop ceiling.
+- emit the accumulated cost where `encode_hops` currently emits `hops.len()`.
+
+Behavior change worth calling out: a lite-03 route's stored chain drops from N entries to one (`[assigned_upstream_id]`), so cost carries the distance and hop length stops standing in for it. That shifts how lite-03 routes rank against others, and the tie-break key in `model/origin.rs` is computed over the chain.
+
+**Drafts.** `draft-lcurley-moq-cluster` section "The Reserved Hop ID 0" is deleted rather than amended. The rules it anchors change with it: HOP\_PATH validity becomes "no Hop ID appears twice" with no exemption, "an advertisement whose first entry is 0 has an unknown origin" goes away because every first entry now names a real publisher, and "Assigned Identities" shifts from MAY to mandatory, since a receiver has no way to spell an unnamed upstream in a chain. `RELAY_HOPS` keeps meaning "no identity" when it carries 0; what a peer may no longer do is put 0 in a HOP\_PATH. `draft-lcurley-moq-lite` gets the matching chain rule alongside the Hop Count rule.
+
+The section's honest summary today, `Declaring 0 therefore trades loop detection and failover for anonymity`, becomes false rather than merely narrower: a peer that declares 0 is assigned an identity and filtered on it, and gets no anonymity from the chain because it can no longer write into one.
+
+#### Done when
+
+Every `== Origin::UNKNOWN` / `!= Origin::UNKNOWN` test that exists to ask "does this chain entry name anybody" is gone, across `lite/subscriber.rs`, `ietf/{subscriber,publisher,cluster}.rs`, and `model/{origin,broadcast}.rs`. The marker survives only where it means "this field is absent". Any survivor in the first category means 0 is still special somewhere and the change is incomplete.
+
+Targets `dev`: it changes published `moq-net` API alongside moq-dev/moq#3049, and lands on top of it.
+
+## Closes
+
+- [#3060](https://github.com/moq-dev/moq/issues/3060) - close this issue when the quest finishes

--- a/quest/m0/3072-js-net-a-lite-announce-ok-with-hop-id-0-is-rejected-but.md
+++ b/quest/m0/3072-js-net-a-lite-announce-ok-with-hop-id-0-is-rejected-but.md
@@ -1,0 +1,45 @@
+# [M] js/net: a lite ANNOUNCE_OK with Hop ID 0 is rejected, but the draft permits it
+
+## Goal
+
+Implement and verify the behavior tracked in [#3072](https://github.com/moq-dev/moq/issues/3072)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+js `AnnounceOk.#decode` refuses a Hop ID of 0:
+
+```ts
+const raw = await r.u62();
+// A zero responder id is never legitimate; it would stamp a placeholder onto chains.
+if (raw === 0n) throw new Error("announce ok origin must be non-zero");
+```
+
+`draft-lcurley-moq-lite` says the opposite in the ANNOUNCE\_OK Hop ID field:
+
+> The value 0 is reserved to mean "unknown": either no Hop ID was assigned (e.g. when bridging from an older protocol version) or the endpoint deliberately withholds it to obscure the underlying routing.
+
+So a conforming publisher that withholds its identity, or one bridging from a version with no Hop IDs, has its announce stream torn down by a js subscriber. The comment justifying the throw ("it would stamp a placeholder onto chains") describes a real hazard, but the resolution the draft and the Rust subscriber use is to substitute an assigned identity rather than to reject:
+
+```rust
+let origin = match ok.origin.id() {
+    0 => self.peer_origin.unwrap_or(ok.origin),
+    _ => ok.origin,
+};
+```
+
+`rs/moq-net/src/lite/subscriber.rs`, in `run_announce_prefix`. A route stamped with 0 stays loop-blind, which is the documented cost of withholding an identity, not a reason to drop the session.
+
+The js side has no `peer_origin` equivalent on the lite `Subscriber` (`Client::with_peer_origin` / `Request::with_peer_origin` are Rust-only), so closing this properly is either plumbing an assigned identity through to js or accepting 0 and living with the loop-blind route the draft already describes.
+
+Found while reviewing moq-dev/moq#3065, where an automated reviewer proposed escalating this throw to a `ProtocolViolation` so it would close the session. That would have made it strictly worse: it turns rejecting a legal message into killing the session over one. Not fixed there, since it is pre-existing, in `announce.ts`, and unrelated to that PRs announce bookkeeping.
+
+## Closes
+
+- [#3072](https://github.com/moq-dev/moq/issues/3072) - close this issue when the quest finishes

--- a/quest/m0/3076-moq-relay-publish-is-unimplemented-by-design-make-the.md
+++ b/quest/m0/3076-moq-relay-publish-is-unimplemented-by-design-make-the.md
@@ -1,0 +1,66 @@
+# [M] moq-relay: PUBLISH is unimplemented by design - make the rejection fail fast for clients that…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3076](https://github.com/moq-dev/moq/issues/3076)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Observation (interop pre-run, 2026-08-26)
+
+Running the interop client matrix against a relay built from the #3025 release, with moq-go's draft-19 client  -  the first client in the registry to exercise PUBLISH:
+
+- The PUBLISH itself is rejected crisply: `moqt request rejected: PUBLISH is not supported (code 0x3)`, in ~263 ms. That rejection is fine and deliberate.
+- But the client's announce-wait case then hangs to its own timeout: after the rejected PUBLISH, its `subscribe-before-announce` test waits for the broadcast to appear and dies 8 s later on `context deadline exceeded`.
+
+So interop matrices read "broken relay" when the truth is "deliberate posture, slow failure shape".
+
+<details>
+<summary>moq-go client vs moq-relay (#3025 release)  -  TAP excerpt (trimmed)</summary>
+
+```
+  Client: ghcr.io/englishm/moq-interop-runner-moq-go-client:latest
+TAP version 14
+# moq interop-client
+1..6
+ok 1 - setup-only
+ok 2 - announce-only
+ok 3 - publish-namespace-done
+ok 4 - subscribe-error
+not ok 5 - announce-subscribe
+  ---
+  duration_ms: 263
+  message: "publisher PUBLISH: moqt request rejected: PUBLISH is not supported (code 0x3)"
+  ...
+not ok 6 - subscribe-before-announce
+  ---
+  duration_ms: 8002
+  message: "timeout waiting for announcement: context deadline exceeded"
+  ...
+```
+
+</details>
+
+#### The posture (paraphrasing Luke's remarks on the MoQ Slack today)
+
+- The relay has never supported PUBLISH at any version  -  this is not a draft-19 gap.
+- The WG clarified that PUBLISH is not an implicit PUBLISH\_NAMESPACE, so rejecting it does not take the announce path down with it.
+- N-way downstream push has no clear CDN use case: supporting PUBLISH would mean forwarding it to every node in the cluster, burning backbone bandwidth on data nobody asked for. He'd rather the WG adopt "wait for the peer to ask for something", and draws the analogy to HTTP/2 server push  -  which failed and was removed for the same reason.
+
+#### What this issue tracks
+
+1. **Fail fast in moq-relay**: keep rejecting PUBLISH, but make the rejection path crisp at every draft version the relay speaks, so a client that waits on a consequence of its PUBLISH (e.g. the broadcast becoming visible to its own subscription) gets a prompt, unambiguous signal instead of running out a multi-second timeout. The rejection is the feature; the hang is the bug.
+2. **Implementation-experience feedback for draft-20 / the Seattle interim**: anchor this thread as a relay/CDN operator position  -  unsolicited-data fan-out is economically unviable at CDN scale, and HTTP/2 server push is the precedent for how that story ends (shipped, unused, removed). The useful protocol posture is pull-based: a relay should be able to decline PUBLISH cleanly, and clients should be able to tell "declined by design" from "broken" without waiting.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+## Closes
+
+- [#3076](https://github.com/moq-dev/moq/issues/3076) - close this issue when the quest finishes

--- a/quest/m0/3080-fix-watch-audio-ring-truncate-can-race-the-worklet-reader.md
+++ b/quest/m0/3080-fix-watch-audio-ring-truncate-can-race-the-worklet-reader.md
@@ -1,0 +1,50 @@
+# [M] fix(watch): audio ring truncate can race the worklet reader for one quantum
+
+## Goal
+
+Implement and verify the behavior tracked in [#3080](https://github.com/moq-dev/moq/issues/3080)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up from #3067, which merged with this known and documented.
+
+#### Summary
+
+`SharedRingBuffer.truncate()` (`js/watch/src/audio/shared-ring-buffer.ts`) retreats `WRITE` from the main thread to drop a superseded subscription's write-ahead tail. The AudioWorklet's `read()` runs concurrently and snapshots `WRITE` at the top of the call, so a truncate landing mid-quantum is invisible to the render pass already in flight.
+
+The interleaving, reproduced during review:
+
+1. `read()` loads `WRITE = 3000` with `READ = 2100` and starts copying a 128-sample quantum.
+2. `truncate()` retreats `WRITE` to 2200.
+3. `read()` finishes, having emitted 128 samples from `[2100, 2228)`  -  the last 28 of which are the stale tail truncate meant to drop  -  and advances `READ` to 2228.
+
+`READ` is now ahead of `WRITE`. The replacement's next `insert()` at 2200 has its first 28 samples trimmed as already played, because they were.
+
+#### Impact
+
+Bounded and self-healing, which is why #3067 shipped without it:
+
+- At most one render quantum of stale audio plays (2.7ms at 48kHz), against the seconds of stale tail #3067 fixes.
+- The transient `READ > WRITE` is tolerated everywhere: `read()` returns 0 on a non-positive count, `insert()` restores `WRITE` via `i32Max`, and `resize()` clamps `copyCount` to 0.
+- It heals on the first inserted sample past the playhead.
+
+Trimming samples whose slots the worklet already rendered is arguably the correct outcome, since that audio cannot be unplayed. The defect is the stale quantum that reaches the speakers, not the trim.
+
+#### Possible fix
+
+Give the ring an epoch (a new control slot) that `truncate()` bumps. `read()` samples it before and after copying and discards the quantum if it changed, so an invalidated snapshot never reaches the output. That trades a discarded quantum (silence) for a stale one, which is the better failure. Serializing truncation onto the worklet instead would also close it, at the cost of moving the truncate off the main thread and into the message path, which the `SharedArrayBuffer` transport otherwise avoids entirely.
+
+The `postMessage` transport (`AudioRingBuffer`) has no such race: `truncate` and `write` are both ordered on the worklet's message queue.
+
+Whichever way it goes, it wants a deterministic interleaving test that drives `truncate()` between `read()`'s `WRITE` snapshot and its `READ` advance. The current tests are single-threaded and cannot reach it.
+
+## Closes
+
+- [#3080](https://github.com/moq-dev/moq/issues/3080) - close this issue when the quest finishes

--- a/quest/m0/3086-refactor-net-make-group-delivery-order-a-handle-and-move.md
+++ b/quest/m0/3086-refactor-net-make-group-delivery-order-a-handle-and-move.md
@@ -1,0 +1,45 @@
+# [M] refactor(net): make group delivery order a handle, and move timestamp-based skipping into…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3086](https://github.com/moq-dev/moq/issues/3086)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`track::Subscriber` exposes two delivery orders as two methods on one handle:
+
+- `recv_group` / `read_frame` walk an arrival index (`PlainSubscriber::index`)
+- `next_group` seeks by sequence (`PlainSubscriber::next_sequence`)
+
+The cursors are not independent. `recv_datagram` bumps `next_sequence`, and `read_frame` bumps both `index` and `next_sequence`. Interleaving the two orders on one subscriber is expressible today and the result is hard to reason about, so the rule lives in doc comments rather than in the type.
+
+Proposal: make the order a handle rather than a method choice, e.g. `track::Consumer::ordered()` returning a cursor that only yields groups in sequence order, with the arrival-order cursor keeping the plain path. That makes mixing the two unrepresentable instead of merely discouraged, per the Public API Scrutiny rules in `CLAUDE.md`.
+
+##### Timestamp-based group skipping
+
+The longer-term goal is to move the group-skipping logic out of `moq-mux` and into `moq-net`. Today it lives in `rs/moq-mux/src/container/consumer.rs` (`poll_read`), which decides whether to abandon a stalled group by comparing `poll_min_timestamp` / `poll_max_timestamp` across buffered groups against a latency budget.
+
+The reason it lives in `moq-mux` is that those timestamps come from parsing the container format through `F: Format`. That constraint has weakened: on Lite05+ the wire carries per-frame timestamps at the track's own timescale (TRACK\_INFO plus zigzag-delta frame timestamps), so `moq-net` can read them without knowing anything about the media. That keeps the "the relay does not know anything about media" rule intact.
+
+Open questions before this is designed:
+
+- What happens on wires that cannot carry the timescale (pre-Lite05 moq-lite, IETF moq-transport), where timestamps fall back to local monotonic milliseconds? A skip policy keyed on those means something different than one keyed on author timestamps.
+- Does the skip policy belong on the ordered cursor itself, on `Subscription` (so the publisher's aggregate sees it), or both?
+- What does `moq-mux` keep? Discontinuity marking and the empty-group boundary handling in `poll_read` are container concerns even if the skip decision moves down.
+
+##### Context
+
+Split out of the `poll_next_in_range` fix, which made the sequence-ordered path a `BTreeMap` seek instead of a full cache scan. That removed the performance argument for treating sequence order as the slower opt-in path; the API argument above stands on its own.
+
+---
+
+## Closes
+
+- [#3086](https://github.com/moq-dev/moq/issues/3086) - close this issue when the quest finishes

--- a/quest/m0/3087-relay-mtls-peers-bypass-auth-api-mode-so-proxy-grants.md
+++ b/quest/m0/3087-relay-mtls-peers-bypass-auth-api-mode-so-proxy-grants.md
@@ -1,0 +1,35 @@
+# [M] relay: mTLS peers bypass --auth-api-mode, so proxy grants can't refuse or scope them
+
+## Goal
+
+Implement and verify the behavior tracked in [#3087](https://github.com/moq-dev/moq/issues/3087)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`--auth-api-mode proxy` (#3044) lets an auth endpoint decide every connection - except mTLS ones, which bypass the mode entirely.
+
+`Auth::verify_mtls` calls `resolve_mtls`, which builds its own request and reads only `alias` and `tier` off the reply. A `200 {}`, or a reply carrying a deliberately narrow `grant`, still becomes an unrestricted publish-and-subscribe token. So an operator delegating authorization to their endpoint cannot refuse or scope an mTLS client through the documented grant response. `resolve_mtls` also hardcodes `host: None`, so host-routed tenants dialing the same path produce indistinguishable lookups.
+
+#### Shape
+
+Stop special-casing mTLS in the authorization path. It should build its request through `api_request` (sending `mtls=true`, and `host` in proxy mode) and resolve through `authorize`, like any other connection:
+
+- **token mode**: `mtls=true` satisfies "has a credential" without a JWT or `key` - the cert *is* the token. Absent a grant the peer stays unrestricted, exactly as today, so existing deployments returning `{alias, tier}` are unaffected.
+- **proxy mode**: the endpoint returns a `grant` like anyone else, and no grant is a refusal - consistent with the rest of the mode.
+
+#### Deliberately NOT in scope: revalidation
+
+mTLS peers keep `revalidate: None`. Not because mTLS is precious, but because a deployed endpoint sending a blanket `Cache-Control: max-age` on every reply would silently arm revalidation on a production relay mesh the moment the relay ships - gating fleet interconnect on that endpoint staying reachable, with no one having chosen it.
+
+If mesh revalidation is wanted later it should be its own change, with the endpoint opting in deliberately for `mtls=true`, and a **relay-side floor** on the staleness window for those requests so an operator who forgets the header doesn't get a fleet that partitions on the first auth blip. Note `stale-if-error` alone is not sufficient protection: it only applies when the endpoint *errors*, so an endpoint that successfully answers "no" still partitions the mesh instantly.
+
+## Closes
+
+- [#3087](https://github.com/moq-dev/moq/issues/3087) - close this issue when the quest finishes

--- a/quest/m0/3092-moq-sock-make-the-reuseport-groups-invariants.md
+++ b/quest/m0/3092-moq-sock-make-the-reuseport-groups-invariants.md
@@ -1,0 +1,47 @@
+# [M] moq-sock: make the reuseport group's invariants unrepresentable, not documented
+
+## Goal
+
+Implement and verify the behavior tracked in [#3092](https://github.com/moq-dev/moq/issues/3092)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`moq-sock` (added in #3078) exposes `shard::{Shard, bind, Lock, MAX_SHARDS}` as four independent public items, and correct use requires holding three rules in your head at once:
+
+1. Acquire a `Lock` on a named port *before* the first member binds, and hold it until the group is gone.
+2. Call `bind` for every member in index order, with nothing else in between.
+3. Never resize the group.
+
+None of them are enforced by a type. Rule 1 is the sharpest: `bind`'s probe only refuses a group that is already bound, so two same-UID processes constructing at once each pass the probe before either holds the port, then interleave into one reuseport group whose positional BPF filter routes one process's connection ids to the other's sockets. That is silent, and it happens exactly during a rolling restart.
+
+Not a live bug today: both in-tree callers (`moq_tokio::worker::Workers::new` and `moq_relay::uring::Workers::bind`) acquire the lock first. #3078 documents the precondition on `bind` so an outside caller can at least read it. But the invariant used to be crate-private and is now prose, which is the shape [CLAUDE.md](https://github.com/moq-dev/moq/blob/dev/CLAUDE.md) argues against ("make misuse unrepresentable rather than merely documented").
+
+##### Shape worth considering
+
+A `shard::Group` that owns the lock, validates the count once, and hands out members in order:
+
+```rust
+let mut group = shard::Group::acquire(addr, count)?;  // holds Option<Lock>
+let (shard, socket) = group.bind()?;                  // index order, enforced
+```
+
+That subsumes the count bound, the ordering rule, and the lock lifetime, and it deletes duplication that already exists in both callers (the `count > MAX_SHARDS` check, the `Lock::acquire` dance, and `Shard::new(..).expect(..)`).
+
+##### Why it is not a small change
+
+`moq-tokio` never calls `shard::bind` from its construction loop. It calls `Worker::spawn`, and the bind happens on the worker thread inside the quinn and noq backends. A `Group` that returns sockets would mean moving where moq-tokio creates its sockets, across both backends. That deserves its own PR and its own testing rather than riding along with the extraction.
+
+`moq-sock` is at 0.0.1 and is not being published for a while, so the reshape stays cheap until then.
+
+Found by Codex reviewing #3078 (P1, `rs/moq-sock/src/shard.rs`); verified against the code and deliberately deferred.
+
+## Closes
+
+- [#3092](https://github.com/moq-dev/moq/issues/3092) - close this issue when the quest finishes

--- a/quest/m0/3094-ci-cargo-doc-collides-on-target-doc-moq-between-libmoq.md
+++ b/quest/m0/3094-ci-cargo-doc-collides-on-target-doc-moq-between-libmoq.md
@@ -1,0 +1,51 @@
+# [M] CI: cargo doc collides on target/doc/moq between libmoq and moq-cli
+
+## Goal
+
+Implement and verify the behavior tracked in [#3094](https://github.com/moq-dev/moq/issues/3094)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+The `Check` job fails intermittently in `cargo doc` with an error that names an unrelated crate, most recently on moq-dev/moq#3091 and moq-dev/moq#3066:
+
+```
+warning: output filename collision at /home/runner/work/moq/moq/target/doc/moq/index.html
+error: failed to remove directory `/home/runner/work/moq/moq/target/doc/moq`
+    No such file or directory (os error 2)
+```
+
+#### Cause
+
+Two crates declare a doc target named `moq`:
+
+- `rs/libmoq`  -  package `libmoq`, `[lib] name = "moq"`
+- `rs/moq-cli`  -  package `moq-cli`, `[[bin]] name = "moq"`
+
+Both render to `target/doc/moq/`, so `just check`'s `cargo doc --locked --no-deps` writes them to the same path. Reproduces on demand:
+
+```
+cargo doc --no-deps -p libmoq -p moq-cli
+warning: output filename collision at .../target/doc/moq/index.html
+```
+
+The collision is deterministic; whether it escalates from a warning to the hard error depends on which target cleans the directory first, which is why it only sometimes fails. `RUSTDOCFLAGS="-D warnings"` does not catch it, since cargo emits the collision, not rustdoc.
+
+It surfaces on any PR whose diff selects both crates. `just check` is diff-aware, so a change to `moq-net` pulls in both as dependents, which is why this shows up on unrelated networking PRs and points at `moq-cli` internals (`moq/args/enum.ExportSink.html`) that the PR never touched. A re-run usually passes, which makes it easy to write off as a flake.
+
+#### Options
+
+- Give one of them a distinct doc target: `moq-cli`'s binary is the user-facing `moq` command, so renaming `libmoq`'s `[lib] name` is the less disruptive side, though it is a published C staticlib and the name is load-bearing for consumers.
+- Or document them in separate `cargo doc` invocations in `just check`, which keeps both names and costs one more pass.
+
+Filing rather than fixing: which name gives way is a call about the published surface, not a mechanical fix.
+
+## Closes
+
+- [#3094](https://github.com/moq-dev/moq/issues/3094) - close this issue when the quest finishes

--- a/quest/m0/3100-dart-flutter-bindings-via-uniffi.md
+++ b/quest/m0/3100-dart-flutter-bindings-via-uniffi.md
@@ -1,0 +1,108 @@
+# [L] Dart/Flutter bindings via UniFFI
+
+## Goal
+
+Implement and verify the behavior tracked in [#3100](https://github.com/moq-dev/moq/issues/3100)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`rs/moq-ffi` is already the single UniFFI core behind five wrappers (`py/`, `swift/`, `kt/`, `go/`, `rs/libmoq`). Dart/Flutter would be a sixth of the same shape. It is viable, but it carries the same cost Go does: the Dart frontend is a third-party bindgen that lags uniffi-rs, so we would own a pinned fork.
+
+#### Landscape (Aug 2026)
+
+Two generators exist, neither maintained by Mozilla:
+
+| | [Uniffi-Dart/uniffi-dart](https://github.com/Uniffi-Dart/uniffi-dart) (ex-acterglobal) | [nchapman/uniffi-bindgen-dart](https://github.com/nchapman/uniffi-bindgen-dart) |
+|---|---|---|
+| Activity | commits 2026-08-22, 43 stars, 25 open issues | last push 2026-03-04, 3 stars, 199 downloads |
+| uniffi target | 0.31.2 (`v0.2.1+v0.31.2`) | 0.31.0 |
+| CLI | none, `src/bin.rs` is a placeholder stub | real CLI with library mode + `doctor` |
+| Library loading | `@Native(assetId:)`, so Dart native assets | `DynamicLibrary.open` + `configureDefaultBindings()` |
+| Coverage | 30 fixtures: proc-macros, async, objects, records, enums, errors, maps, bytes, traits, callbacks | similar claims, no fixture suite |
+
+Proposal: **uniffi-dart**, on maintenance grounds. Its README's "5 critical blockers" list is stale. `MapCodeType` is implemented in `src/gen/compounds.rs` and `fixtures/proc-macro/` exists, so `HashMap` and proc-macros both work.
+
+#### Fit against the actual `moq-ffi` surface
+
+33 `uniffi::Object`, 25 `Record`, 6 `Enum`, one `flat_error` enum, 45 `pub async fn`, `HashMap<String, V>` in `MoqCatalog`, `Vec<u8>` frames. All covered. We use **zero** callback interfaces and zero trait interfaces, which avoids uniffi-dart's weakest area entirely.
+
+Async works across threads: `src/gen/types.rs` emits `NativeCallable<UniffiRustFutureContinuationCallback>.listener(...)`, so completions from the dedicated `moq-ffi` tokio thread land correctly on the Dart isolate. That was the main technical risk and it is already handled upstream.
+
+Flutter packaging is no longer the obstacle it once was. Build hooks (`hook/build.dart`) and code assets are stable as of Dart 3.10 / Flutter 3.38; link hooks and tree-shaking landed in 3.13. Cargokit was archived 2026-03-26 in favor of exactly this, and `native_toolchain_rust` drives cargo from a build hook.
+
+#### The blocker
+
+`moq-ffi` is on uniffi **0.32**; uniffi-dart targets **0.31.2**. Per #2946 / #2949, `UNIFFI_CONTRACT_VERSION` stayed at 30 while the metadata encoding changed, so a 0.31 bindgen dies on the first symbol. Upstream [#149](https://github.com/Uniffi-Dart/uniffi-dart/pull/149) (uniffi 0.32) and [#152](https://github.com/Uniffi-Dart/uniffi-dart/pull/152) (library-mode CLI) are open, both by DenisovAV, both `mergeable_state: unstable`, last updated 2026-08-23.
+
+The library API `gen::generate_dart_bindings(..., library_mode: true)` already works on `main`; only the *binary* is missing. Worst case we write a 30-line bin like `rs/moq-ffi/uniffi-bindgen.rs`.
+
+#### Plan
+
+##### Phase 0: spike, gate everything else on it (~1 day)
+
+Cherry-pick #149 + #152 + #151 onto a branch, build `moq-ffi` with `--no-default-features`, generate against `libmoq_ffi.dylib`, run `dart analyze` on the output, and drive one connect + announce + subscribe round-trip against a local relay from a plain Dart CLI. If the generated Dart does not analyze clean or async deadlocks, stop and reconsider.
+
+##### Phase 1: the generator
+
+Publish `kixelated/uniffi-dart` tag `v0.3.0+v0.32.0`, mirroring the `kixelated/uniffi-bindgen-go` arrangement. Add a `buildRustPackage` derivation next to `uniffi-bindgen-go` in `flake.nix`. The repo + tag will need naming in the same handful of places: `flake.nix`, `dart/scripts/check.sh`, the release workflow env, `dart/README.md`, `doc/lib/dart/`.
+
+Test the *unlocked* `cargo install --git` resolve explicitly. That is where the `toml = ">=0.9, <2"` range bit us on #2949, and no local path (cargo build, nix vendoring, the fixture suite) exercises it.
+
+##### Phase 2: `dart/` layout
+
+Mirror the `kt/` two-package split:
+
+```
+dart/
+  moq_ffi/    # generated bindings + hook/build.dart, version tracks the crate
+  moq/        # ergonomic wrapper, versioned independently
+  scripts/{check,package,publish}.sh
+  justfile    # `mod dart` in the root justfile
+```
+
+Open decision: does `hook/build.dart` **compile** Rust on the consumer's machine (requires their Rust toolchain, ~5 min first build) or **download** a prebuilt from the existing `moq-ffi-v*` release assets? Leaning download-with-cargo-fallback, matching how Swift ships an XCFramework and Kotlin a Maven `.so`.
+
+Ship `--no-default-features` first. `audio` / `video` drag in ~40 crates plus openh264's vendored C++.
+
+##### Phase 3: ergonomic `moq` package
+
+Port `kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt`: `Moq.connect()`, announcements as a Dart `Stream` rather than a poll loop, `Future`-based everything, `close()`. Plus a Flutter example app.
+
+##### Phase 4: CI and release
+
+`just dart check` skipping unless the diff touches `dart/` or `rs/moq-ffi/`, a `_tools` entry for `MOQ_STRICT`, `dart` + `flutter` in the devShell, and `release-dart-ffi.yml` / `release-dart.yml` modeled on the `release-kt-*` pair. pub.dev accepts GitHub Actions OIDC publishing, so there is no token to manage.
+
+##### Phase 5: docs
+
+`doc/lib/dart/`, a `dart/` entry in the CLAUDE.md Cross-Package Sync row for `rs/moq-ffi`, and `doc/lib/index.md`.
+
+#### Explicitly out of scope for phase 1
+
+- **Flutter Web.** uniffi-dart has no wasm support ([PR #126](https://github.com/Uniffi-Dart/uniffi-dart/pull/126) is dirty and stalled since May). Point web users at the JS packages.
+- **Video rendering.** `moq-ffi` hands back decoded frames, not a Flutter `Texture`. A texture bridge is per-platform plugin work and a separate project. Phase 1 is data-plane only: connect, announce, publish/subscribe, catalog, raw frames.
+
+#### Costs
+
+We would own a second bindgen fork, on a repo badged "experimental" with 43 stars and effectively one maintainer plus two drive-by contributors. Every `moq-ffi` change would then ripple to six wrappers instead of five.
+
+The alternative generator, flutter\_rust\_bridge, is worse for us specifically: it wants its own Rust-side API definition, so it duplicates `moq-ffi` rather than reusing it, which cuts against the single-core rule.
+
+#### References
+
+- [Uniffi-Dart/uniffi-dart](https://github.com/Uniffi-Dart/uniffi-dart)
+- [nchapman/uniffi-bindgen-dart](https://github.com/nchapman/uniffi-bindgen-dart)
+- [Dart hooks](https://dart.dev/tools/hooks)
+- [code\_assets](https://pub.dev/packages/code_assets)
+- [native\_toolchain\_rust](https://pub.dev/packages/native_toolchain_rust)
+- [flutter\_rust\_bridge: migrate from Cargokit to native assets](https://cjycode.com/flutter_rust_bridge/manual/integrate/migrate-cargokit-to-native-assets)
+
+## Closes
+
+- [#3100](https://github.com/moq-dev/moq/issues/3100) - close this issue when the quest finishes

--- a/quest/m0/3107-moq-relay-certificate-sha256-is-empty-when-io-uring-owns.md
+++ b/quest/m0/3107-moq-relay-certificate-sha256-is-empty-when-io-uring-owns.md
@@ -1,0 +1,36 @@
+# [S] moq-relay: /certificate.sha256 is empty when io_uring owns QUIC
+
+## Goal
+
+Implement and verify the behavior tracked in [#3107](https://github.com/moq-dev/moq/issues/3107)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+In `Relay::load` (`rs/moq-relay/src/relay.rs`) the certificate handle the web endpoint serves is chosen from the tokio workers or the shared server:
+
+```rust
+// The workers hold the certificates when they own QUIC; the server has none.
+let certificates = match &workers {
+    Some(workers) => workers.certificates(),
+    None => server.certificates(),
+};
+```
+
+When `runtime.io_uring` is set, `workers` is `None` (the io\_uring workers live in `uring` instead) and the shared server was made stream-only, so this falls through to an empty `server.certificates()`. `/certificate.sha256` then returns nothing, and a browser that pins a self-signed relay certificate through that endpoint cannot connect.
+
+`crate::uring::Workers` has no `certificates()` at all today, and `moq_tokio::tls::Certificates::new` is `pub(crate)`, so exposing this needs a public constructor in moq-tokio plus the fingerprints of the chain the io\_uring workers actually loaded.
+
+Note that the io\_uring path refuses `listen.tls.generate` and requires a certificate file, so this only bites a file-provided self-signed certificate, which is exactly the case the endpoint exists for.
+
+Found by Codex review on #3082, deferred because `rs/moq-relay/src/uring.rs` sits behind the non-default `io-uring` feature and is not compiled by PR CI.
+
+## Closes
+
+- [#3107](https://github.com/moq-dev/moq/issues/3107) - close this issue when the quest finishes

--- a/quest/m0/3111-moq-uring-unmap-err-reports-unmappable-http-3-codes-as.md
+++ b/quest/m0/3111-moq-uring-unmap-err-reports-unmappable-http-3-codes-as.md
@@ -1,0 +1,60 @@
+# [M] moq-uring: unmap_err reports unmappable HTTP/3 codes as MoQ application errors
+
+## Goal
+
+Implement and verify the behavior tracked in [#3111](https://github.com/moq-dev/moq/issues/3111)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`unmap_err` in `rs/moq-uring/src/quic/web.rs` falls back to the original code when `error_from_http3` returns `None`, but keeps the variant it came in as:
+
+```rust
+fn unmap_err(err: Error) -> Error {
+	let unmap = |code: u64| proto::error_from_http3(code).map(u64::from).unwrap_or(code);
+	match err {
+		Error::Reset(code) => Error::Reset(unmap(code)),
+		Error::Stop(code) => Error::Stop(unmap(code)),
+		Error::App { code, reason } => Error::App { code: unmap(code), reason },
+		other => other,
+	}
+}
+```
+
+`App`, `Reset`, and `Stop` are exactly the variants that `web_transport_trait::Error` reports through its accessors:
+
+```rust
+fn session_error(&self) -> Option<(u32, String)> {
+	match self {
+		Self::App { code, reason } => Some((u32::try_from(*code).unwrap_or(u32::MAX), reason.clone())),
+		_ => None,
+	}
+}
+
+fn stream_error(&self) -> Option<u32> {
+	match self {
+		Self::Reset(code) | Self::Stop(code) => Some(u32::try_from(*code).unwrap_or(u32::MAX)),
+		_ => None,
+	}
+}
+```
+
+So an HTTP/3 *connection* error such as `H3_NO_ERROR` (0x100) reaches `moq_net::Error::from_transport` looking like an application code the peer chose, and a RESET\_STREAM code with no WebTransport preimage looks like a valid MoQ stream error. That conflates "HTTP/3 failed" with "the peer sent you this WebTransport code", which is the distinction the mapping exists to preserve.
+
+#### Shape
+
+`Error` already has a `Transport { code, reason }` variant whose accessors both return `None`, which is the honest landing spot for a code that has no WebTransport meaning. Making an unmapped code fall into a transport-flavored variant is a contract change rather than a local fix, which is why it was left out of #3081.
+
+Worth settling before the layer ships: once a consumer is reading these codes, changing which variant an unmappable code arrives as is a behavior break.
+
+Split out of #3096 (finding 1), which is otherwise covered by #3103, #3105, and #3106. Raised by Codex reviewing #3081 and verified against `dev`.
+
+## Closes
+
+- [#3111](https://github.com/moq-dev/moq/issues/3111) - close this issue when the quest finishes

--- a/quest/m0/3112-moq-relay-io-uring-listener-cannot-authenticate-mtls-peers.md
+++ b/quest/m0/3112-moq-relay-io-uring-listener-cannot-authenticate-mtls-peers.md
@@ -1,0 +1,67 @@
+# [M] moq-relay: io_uring listener cannot authenticate mTLS peers
+
+## Goal
+
+Implement and verify the behavior tracked in [#3112](https://github.com/moq-dev/moq/issues/3112)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`--runtime-io-uring` (#3082) cannot authenticate mTLS peers. The capability is refused at startup rather than silently ignored, so nothing is wrong today, but it is missing.
+
+#### What exists
+
+`moq_uring::quic::server::Config` already carries the knob:
+
+```rust
+pub enum ClientAuth {
+	None,
+	Optional(Vec<X509>),
+	Required(Vec<X509>),
+}
+```
+
+and maps it onto `SslVerifyMode::{PEER, FAIL_IF_NO_PEER_CERT}`. The relay never sets it. `rs/moq-relay/src/uring.rs` refuses the config instead:
+
+```rust
+if !listen.tls.root.is_empty() {
+	anyhow::bail!(
+		"io_uring workers do not implement mTLS client roots (listen.tls.root); ..."
+	);
+}
+```
+
+#### What is missing
+
+`serve_connection` in `rs/moq-relay/src/uring.rs` has no peer-identity branch. Both the `h3` and raw-QUIC arms fall through to the shared auth API:
+
+```rust
+let mut params = match &url {
+	Some(url) => serve.auth.params_from_url(url),
+	None => { /* path + ?jwt= off the SETUP */ }
+};
+```
+
+There is no equivalent of the `verify_mtls` branch that `Connection::authenticate` takes on the shared tokio path.
+
+Wiring it up means three things:
+
+1. pass `listen.tls.root` into `server::Config::client_auth` instead of bailing;
+2. surface the verified peer identity out of `moq_uring::quic::Connection` (the connection is consumed by the handshake today, so this needs new API);
+3. take the mTLS branch in `serve_connection` the way the tokio path does.
+
+Note this interacts with #3087: mTLS peers bypass `--auth-api-mode` on the tokio path already, so whichever lands second should not reintroduce the gap on the io\_uring path.
+
+Behind the non-default `io-uring` feature, which PR CI does not compile, so this needs verifying in the moquring container rather than on a PR run.
+
+Split out of #3097 (section 2); section 1 of that issue is #3107. Raised by Codex reviewing #3082 and verified against `dev`.
+
+## Closes
+
+- [#3112](https://github.com/moq-dev/moq/issues/3112) - close this issue when the quest finishes

--- a/quest/m0/3115-moqsink-the-publication-has-no-generation-so-a-flush.md
+++ b/quest/m0/3115-moqsink-the-publication-has-no-generation-so-a-flush.md
@@ -1,0 +1,46 @@
+# [M] moqsink: the publication has no generation, so a flush after EOS cannot restart it
+
+## Goal
+
+Implement and verify the behavior tracked in [#3115](https://github.com/moq-dev/moq/issues/3115)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Split out of the adversarial reviews on #3101, #3102 and #3104. Each of those fixes a concrete `moqsink` lifecycle bug, and each one stops at the same wall: **a `moqsink` publication has no notion of a generation.** Once it ends, the only way back is a cycle through `READY`.
+
+Three findings across those PRs are all the same root cause.
+
+##### 1. A flushing seek after the element completed EOS is broken
+
+Once the last pad sends EOS, `maybe_post_eos` finalizes every producer and takes the catalog. There is no way to reopen them. #3104 makes a post-EOS buffer answer `FlowError::Eos` instead of writing into finalized producers, which is an improvement over silently dropping it, but GStreamer specifies that `FLUSH_STOP` clears EOS and data flow resumes. We cannot honour that today.
+
+A correct fix creates a new publication generation on a flushing restart (new broadcast/catalog/producers) rather than treating the first EOS as terminal for the element.
+
+##### 2. `eos_posted` conflates two facts
+
+It answers both "the producers were finalized" and "the EOS message was posted". #3104 gates the flush reset on it and therefore inherits the conflation. #2998 separates the two, which is what its per-pad lifecycle rewrite buys, but that separation does not reproduce standalone.
+
+##### 3. The identity check and the bus post are not atomic
+
+`post_session_error` (#3102) checks whether a session is still current, releases the element lock, then posts. A `PAUSED -> READY -> PAUSED` completing inside `post_message` still lands a stale error on the replacement's bus. The lock cannot be held across the post: `post_message` runs bus sync handlers inline on the calling thread, and a handler that reads an element or pad property would deadlock on it.
+
+The natural remedy (an in-flight posting permit that teardown waits on) has the same problem in a different place: a sync handler calling `set_state(READY)` re-enters teardown on the thread already holding the permit. #2998 hits this too and accepts the window explicitly.
+
+Deferring the post to a main-loop idle source would decouple it, at the cost of changing when the error is delivered and requiring a running main loop.
+
+##### Why this is filed rather than fixed
+
+Each PR is a strict improvement over `main` and none of them can close these without redesigning the publication lifecycle. That redesign overlaps heavily with #2998, so it should be settled once rather than three times.
+
+@arielmol  -  flagging you since #2998 is the closest thing to a design for this, and its `Completion` state machine is most of the way to a generation. Worth deciding whether generations belong in that PR or in a follow-up on top of it.
+
+## Closes
+
+- [#3115](https://github.com/moq-dev/moq/issues/3115) - close this issue when the quest finishes

--- a/quest/m0/3119-moq-uring-p50-latency-collapses-at-high-connections-per.md
+++ b/quest/m0/3119-moq-uring-p50-latency-collapses-at-high-connections-per.md
@@ -1,0 +1,64 @@
+# [M] moq-uring: p50 latency collapses at high connections per worker; the UDP pools are fixed at 64…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3119](https://github.com/moq-dev/moq/issues/3119)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Benchmarking the io\_uring relay against the tokio one on `dev` (`fc57e0175`), the io\_uring path holds latency parity up to ~100 connections per worker and then falls off a cliff, while the tokio worker path degrades gracefully.
+
+Video fan-out (1 publisher, N-1 subscribers, 60fps, 4 KB frames, 60-frame groups), `--runtime-workers 4`, loopback, AMD Ryzen 7 5800X, relay pinned to cores 0-3:
+
+| connections | mode | relay cores | Mbps | p50 ms | p90 ms | RSS MB |
+|---|---|---|---|---|---|---|
+| 401 | tokio workers | 1.246 | 768.0 | 4 | 6 | 494 |
+| 401 | io\_uring | 1.239 | 767.9 | 4 | 6 | 85 |
+| 801 | tokio workers | 2.451 | 1535.9 | 14 | 18 | 961 |
+| 801 | io\_uring | 2.776 | 1535.9 | 27 | 33 | 149 |
+| 1601 | tokio workers | 3.511 | 2449.6 | **122** | **181** | 1933 |
+| 1601 | io\_uring | 3.791 | 2378.7 | **566** | **893** | 811 |
+
+At 1601 connections over 4 workers (400 per worker) io\_uring's p50 is 4.6x the tokio path's.
+
+#### Mechanism
+
+`udp::Config::default()` fixes the per-socket pools at `tx_buffers: 64` and `rx_buffers: 16`, and there is one socket per worker. `Connection::flush` acquires exactly one `TxBuf`, stages at most one GSO train into it, and returns `Poll::Pending` when `poll_acquire` finds the pool empty. So a worker's entire send concurrency is 64 buffers no matter how many connections it serves: at 400 connections per worker, connections serialize behind the pool and the wait shows up as queueing delay.
+
+`rs/moq-relay/src/uring.rs` builds that config and only ever sets `gso`:
+
+```rust
+let mut udp = moq_uring::udp::Config::default();
+udp.gso = quic.gso.unwrap_or(true);
+```
+
+The fields are `pub` on `udp::Config`, but nothing in the relay scales them with the expected connection count and no operator flag reaches them.
+
+#### Confirmation
+
+Raising the pools to `tx_buffers: 1024, rx_buffers: 256` and re-running restores latency parity, and delivery goes from 1583 to the full 1600 groups/s:
+
+| 1601 connections | Mbps | p50 ms | p90 ms | groups/s | RSS MB |
+|---|---|---|---|---|---|
+| io\_uring, default pools | 2378.7 | 566 | 893 | 1583.1 | 811 |
+| io\_uring, 1024/256 | 1475.2 | **117** | **180** | **1600.1** | 470 |
+| tokio workers | 2449.6 | 122 | 181 | 1600.0 | 1933 |
+
+So the pool depth is the knob, but it is not a free win: deeper pools cost throughput here (1475 vs 2379 Mbps) and 4 x 64 KB x 1024 is 256 MB of send staging across the group. At 801 connections the same change is roughly neutral (p50 27 -> 26 ms, 1536 -> 1533 Mbps).
+
+#### Suggestion
+
+The defaults are a reasonable floor for a handful of connections and clearly wrong for hundreds. Some scaling policy tied to expected connections per worker, plus a way for an operator to set it, would let the mode hold its latency at the connection counts a relay actually sees. The throughput regression above suggests the right answer is not simply a bigger constant.
+
+Numbers are single runs per cell (the 201-connection rows elsewhere were n=2 and repeatable to ~1%), same host for relay and load generator with the generator pinned to the other cores, `net.core.{r,w}mem_max` at 4 MiB (the relay warns it wanted more, equally in both modes).
+
+## Closes
+
+- [#3119](https://github.com/moq-dev/moq/issues/3119) - close this issue when the quest finishes

--- a/quest/m0/3120-moq-uring-the-connection-driver-self-wakes-after-every.md
+++ b/quest/m0/3120-moq-uring-the-connection-driver-self-wakes-after-every.md
@@ -1,0 +1,77 @@
+# [M] moq-uring: the connection driver self-wakes after every GSO train, re-walking every ready stream…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3120](https://github.com/moq-dev/moq/issues/3120)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Profiling the io\_uring relay under load (`dev` @ `fc57e0175`, `perf record -F 499` on the relay process only, steady state), `kio::waiter::WaiterList::register` is the single hottest symbol in both workloads, at roughly 2-3x its share on the tokio worker path:
+
+| symbol | video, io\_uring | video, tokio workers | chat, io\_uring |
+|---|---|---|---|
+| `kio::waiter::WaiterList::register` | **4.59%** | 2.22% | **6.73%** |
+| `moq_uring::quic::connection::Driver::poll` | 3.02% | - | 2.86% |
+| `kio::task::Tasks<T>::poll` | 1.50% + 1.09% | 1.72% + 1.11% | 2.76% + 1.23% |
+| `SlotWaker::wake_by_ref` | 1.28% | 0.75% | 1.24% |
+
+(video = 1:200 fan-out, 60fps, 4 KB frames; chat = 1:500 fan-out, 10 msg/s, one group per message; `--runtime-workers 4`.)
+
+#### Mechanism
+
+`Connection::flush` ends every successful send by waking itself:
+
+```rust
+if let Err(err) = tx.send(filled, to, SEGMENT) {
+    return Poll::Ready(Error::Io(err.to_string()));
+}
+// Requeue behind the other ready tasks. If quiche is drained, the next
+// poll costs one empty acquire and then parks normally.
+waiter.waker().wake_by_ref();
+Poll::Pending
+```
+
+The self-wake is deliberate (it yields the transmit pool to other connections between trains), but it re-runs the *whole* of `Driver::poll`, not just the send. Each of those turns walks quiche's readiness iterators and touches a map entry per ready stream:
+
+```rust
+for id in conn.readable() {
+    queue_accept(&mut state, id);
+    if let Some(mut waiters) = state.readable.remove(&id) {
+        waiters.wake();
+    }
+}
+for id in conn.writable() {
+    if let Some(mut waiters) = state.writable.remove(&id) {
+        waiters.wake();
+    }
+}
+```
+
+Waking removes the entry, so every still-interested stream task re-registers on its next poll. In a fan-out most streams are writable most of the time, so the cost is O(ready streams) of map-remove plus waiter register/wake **per GSO train**, where it should be per ingress event. That is the amplifier behind both the `WaiterList::register` share above and the SipHash cost filed separately.
+
+`state.finishing.retain(...)` compounds it: it calls `conn.stream_capacity(*id)` for every finishing stream on every one of those turns, and allocates a fresh `Vec` (`let mut collected = Vec::new()`) each time.
+
+#### Impact
+
+CPU per delivered frame is at parity with the tokio worker path at low connection counts and regresses as connections grow, which is the shape you would expect if per-turn work scales with streams per connection:
+
+| connections | tokio workers | io\_uring |
+|---|---|---|
+| 401 | 59.77 us/frame | 59.41 us/frame |
+| 801 | 58.80 us/frame | **66.56 us/frame** |
+| 1601 | 52.81 us/frame | **58.72 us/frame** |
+
+#### Suggestion
+
+Keep the fairness yield but stop paying for a full driver poll to get it: separate "there is more to send" from "readiness changed", so a requeue for the transmit pool does not re-walk `readable()`/`writable()`. Failing that, only wake the waiters whose readiness actually changed since the last turn rather than removing and re-registering every ready stream.
+
+## Closes
+
+- [#3120](https://github.com/moq-dev/moq/issues/3120) - close this issue when the quest finishes

--- a/quest/m0/3122-moq-uring-2-5-of-relay-cpu-is-vdso-clock-reads-the-drive.md
+++ b/quest/m0/3122-moq-uring-2-5-of-relay-cpu-is-vdso-clock-reads-the-drive.md
@@ -1,0 +1,57 @@
+# [M] moq-uring: ~2.5% of relay CPU is vdso clock reads; the drive loop and its callers each re-read…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3122](https://github.com/moq-dev/moq/issues/3122)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Profiling the io\_uring relay (`dev` @ `fc57e0175`, `perf record -F 499`, relay process only) shows `[vdso]` as a top-5 DSO, at roughly 3x its share on the tokio worker path:
+
+| DSO | video, io\_uring | video, tokio workers | chat, io\_uring |
+|---|---|---|---|
+| `moq-relay` | 65.89% | 68.61% | 68.96% |
+| `[kernel.kallsyms]` | 22.64% | 22.97% | 20.49% |
+| `libc.so.6` | 5.74% | 4.48% | 6.03% |
+| **`[vdso]`** | **2.95%** | **0.72%** | **2.55%** |
+
+That is `clock_gettime`. Roughly 2.5% of relay CPU spent reading the clock.
+
+#### Where
+
+The drive loop reads it once per turn:
+
+```rust
+// rs/moq-uring/src/worker.rs, block_on
+self.shared.timers.borrow_mut().fire(Instant::now());
+```
+
+and then callers read it again independently on the same turn, e.g.:
+
+```rust
+// rs/moq-uring/src/quic/connection.rs
+fn arm_keep_alive(&mut self) {
+    let at = self.keep_alive_every
+        .and_then(|every| std::time::Instant::now().checked_add(every));
+    self.keep_alive.set(at);
+}
+```
+
+plus quiche's own `Instant::now()` calls inside `on_timeout` / `timeout`. Because the driver re-polls per GSO train rather than per ingress event (#3120), each of those turns pays for its own clock reads.
+
+The same profile also shows the timer heap itself at ~1.6%: `<moq_uring::timer::Timer as moq_net::runtime::Timer>::set` 0.92% plus `btree::search::search_tree` 0.65%. `timer::Heap` is a `BTreeMap<(Instant, u64), Rc<Slot>>`, so every QUIC timeout re-arm is an O(log n) map removal and insertion with `Rc` traffic. The design note in #2875 called for a timer wheel here; the landed implementation is the BTreeMap. Not urgent at these connection counts, but it is on the same hot path and grows with it.
+
+#### Suggestion
+
+`moq_net::runtime::Runtime` already carries a defaulted `now()`, which is a natural place to hand the current turn's instant down instead of having each layer re-read it. Sampling once per drive turn and passing it through `fire`, the keep-alive arming, and the quiche timeout calls should recover most of that 2.5%.
+
+## Closes
+
+- [#3122](https://github.com/moq-dev/moq/issues/3122) - close this issue when the quest finishes

--- a/quest/m0/3123-moq-bench-a-lagged-group-permanently-ends-the.md
+++ b/quest/m0/3123-moq-bench-a-lagged-group-permanently-ends-the.md
@@ -1,0 +1,75 @@
+# [M] moq-bench: a lagged group permanently ends the subscription, so offered load silently decays…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3123](https://github.com/moq-dev/moq/issues/3123)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`moq-bench` loses subscriptions permanently over the course of a run, so the load it offers decays and the numbers it reports are not the numbers the config asked for. Worse, the decay is load-dependent: a relay that struggles sheds more subscribers, which makes it look better on every per-connection metric.
+
+Observed on a 1:200 video fan-out (`--fanout v --connections 201 --fps 60 --frame-size 4000 --group-size 59`) against `dev` @ `fc57e0175`: the `subscriptions` gauge falls from 200 to ~150 within a minute, and delivered groups/s settle well under the configured rate:
+
+| relay mode | groups/s (200 expected) |
+|---|---|
+| tokio, shared runtime | 155.6 |
+| tokio, 4 workers | 193.5 |
+| io\_uring, 4 workers | 199.0 |
+
+The relay logs `no route can serve the rest of this group err=cancelled` and the generator logs `subscribe canceled (idle)` alongside it.
+
+#### Mechanism
+
+The relay signals a subscriber that fell behind by failing the group with `Error::Lagged` (`rs/moq-net/src/model/resume.rs`, `give_up`). In `rs/moq-bench/src/connection.rs`, `drain` propagates that out of both loops with `?`:
+
+```rust
+while let Some(mut group) = track.recv_group().await? {
+    gaps.observe(group.sequence);
+    let mut first = true;
+    while let Some(frame) = group.read_frame().await? {
+```
+
+The inner `?` is the problem: a mid-group `Lagged` ends the whole `drain`. `spawn_drain` then just logs it at debug and lets the task finish:
+
+```rust
+tasks.spawn(async move {
+    if let Err(err) = drain(broadcast, &stats).await {
+        tracing::debug!(%path, %err, "subscription ended");
+    }
+});
+```
+
+Nothing re-subscribes, so that connection is out of the run for good. A real player skips a lagged group and keeps watching; it does not hang up.
+
+#### Fix
+
+Treating a group-level error as the end of *that group* rather than of the subscription is enough to hold the load steady. I ran the matrix with this applied and the group counts held at the configured rate (1600.1 of 1600 groups/s at 1601 connections, versus 1583 before):
+
+```rust
+let mut first = true;
+// A live subscriber skips a group it fell behind on; it does not hang up. The
+// relay reports that as `Lagged` mid-group, so treat any group-level error as
+// the end of *this* group and keep the subscription for the next one.
+while let Some(frame) = match group.read_frame().await {
+    Ok(frame) => frame,
+    Err(err) => {
+        tracing::debug!(sequence = group.sequence, %err, "group ended early");
+        None
+    }
+} {
+```
+
+The outer `recv_group()` error is more genuinely terminal (the track or session is gone), though re-establishing the subscription there would make long runs more honest too. Happy to open a PR for the inner-loop change if that shape looks right.
+
+Until this is fixed, any `moq-bench` comparison of two relay builds should be read with the caveat that throughput differences partly reflect how many subscribers each build kept, not how much each could carry.
+
+## Closes
+
+- [#3123](https://github.com/moq-dev/moq/issues/3123) - close this issue when the quest finishes

--- a/quest/m0/3124-moq-tokio-the-quiche-backend-cannot-serve-per-core.md
+++ b/quest/m0/3124-moq-tokio-the-quiche-backend-cannot-serve-per-core.md
@@ -1,0 +1,62 @@
+# [M] moq-tokio: the quiche backend cannot serve per-core workers, so io_uring has no matched control…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3124](https://github.com/moq-dev/moq/issues/3124)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Trying to measure what `--runtime-io-uring` actually buys, there is no way to hold the QUIC stack constant across the comparison, because the two axes are welded together:
+
+- `--runtime-workers N` on tokio requires the **quinn** backend.
+- `--runtime-io-uring` is **quiche** (sans-IO quiche on the ring).
+
+`--runtime-workers 4 --listen-backend quiche` is refused outright:
+
+```
+Error: failed to start the QUIC workers
+
+Caused by:
+    the quiche backend cannot serve per-core workers; use the quinn backend
+```
+
+from `rs/moq-tokio/src/quiche.rs`:
+
+```rust
+/// This backend cannot encode the owning worker in its connection IDs, so a
+/// reuseport group built on it would have no way to steer packets back.
+#[error("the quiche backend cannot serve per-core workers; use the quinn backend")]
+ShardUnsupported,
+```
+
+So every io\_uring-vs-tokio number confounds the runtime with the QUIC implementation, and there is no fourth cell to separate them.
+
+#### Why it matters
+
+The confound is not small. Measuring the one control that *is* available (both backends on the shared runtime, 1:200 video fan-out, 60fps, 4 KB frames, `dev` @ `fc57e0175`, n=2):
+
+| shared runtime | relay cores | Mbps | us/frame | RSS MB |
+|---|---|---|---|---|
+| quinn | 0.622 | 298.8 | **76.69** | **259.2** |
+| quiche | 1.182 | 339.1 | **128.36** | **65.6** |
+
+The two backends differ by 67% on CPU per frame and 4x on memory, in opposite directions. Which means the headline result people will quote from the io\_uring work - that it uses a fraction of the memory - is mostly quiche's doing, not io\_uring's: quiche on the plain shared tokio runtime already gets RSS to 65.6 MB, against 55.0 MB for io\_uring. Meanwhile the *runtime* is what rescues quiche's CPU cost: 128.36 us/frame on shared tokio versus 58.37 on the io\_uring workers.
+
+Both of those are worth knowing separately, and right now the tree cannot express either.
+
+#### Suggestion
+
+`moq-uring`'s `quic::Endpoint` already solves exactly this problem - `endpoint::Config::shard` makes every issued connection ID lead with the steering byte so a `SO_REUSEPORT` group routes back to the owning worker (#3078). Teaching the tokio quiche backend the same trick would both remove an arbitrary restriction and give the io\_uring work a matched control to be evaluated against.
+
+If that is more than it is worth, it would at least help to say plainly in `doc/bin/relay/config.md` that the io\_uring and tokio worker modes are not the same QUIC stack, so the comparison is read correctly.
+
+## Closes
+
+- [#3124](https://github.com/moq-dev/moq/issues/3124) - close this issue when the quest finishes

--- a/quest/m0/3126-moq-bench-every-readme-example-fails-to-parse-and.md
+++ b/quest/m0/3126-moq-bench-every-readme-example-fails-to-parse-and.md
@@ -1,0 +1,48 @@
+# [M] moq-bench: every README example fails to parse, and cumulative latency percentiles cannot be…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3126](https://github.com/moq-dev/moq/issues/3126)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Two smaller things that got in the way of running a relay comparison with `moq-bench` (`dev` @ `fc57e0175`).
+
+#### The README's flag names do not exist
+
+`rs/moq-bench/README.md` documents the target flag as `--client-connect` throughout:
+
+```bash
+moq-bench --client-connect https://relay.example.com
+
+moq-bench --file rs/moq-bench/config/hd.toml \
+  --client-connect https://relay.example.com \
+  --connections 500
+```
+
+The binary takes `--connect`; `--client-connect` is not accepted. The client TLS flags in the same section are `--connect-tls-*` (e.g. `--connect-tls-insecure`), not `--client-tls-*`. `--file` is also wrong: the config file is a positional argument, so `moq-bench --file foo.toml` fails with `unexpected argument '--file' found`, matching `moq-relay`'s positional `[FILE]`.
+
+Every example invocation in the README currently fails to parse.
+
+#### Latency percentiles are cumulative, so a steady-state window cannot be measured
+
+The JSONL that `--output` writes carries the counters as cumulative and monotonic, which is documented and is exactly right - a consumer diffs successive lines to get rates. But `latency_p50_ms` / `p90` / `p99` / `max` are cumulative too: they summarize the whole run to date, and there is no way to recover the distribution for a window from two lines.
+
+That matters because the intended methodology is to skip the ramp:
+
+> Run the load from one machine and the sampler on the relay's host, then join the two JSONL files on `timestamp_ms` over the same steady-state window. Skip the `--startup` window while connections ramp.
+
+You can do that for every rate in the file, but not for latency: the `--startup` ramp's samples are permanently baked into the percentiles. In practice this shows up as a p99 that is pure ramp artifact - I was seeing `latency_p99_ms` of 589-826 ms on runs whose steady-state p50/p90 were 1-2 ms, purely because a handful of connections' first groups landed while the swarm was still connecting.
+
+Emitting the per-interval histogram (or resettable per-interval percentiles alongside the cumulative ones) would make latency as windowable as the counters already are. `latency_samples` is already per-line, so the shape is half there.
+
+## Closes
+
+- [#3126](https://github.com/moq-dev/moq/issues/3126) - close this issue when the quest finishes

--- a/quest/m0/3129-moq-uring-write-the-webtransport-stream-header-at-open.md
+++ b/quest/m0/3129-moq-uring-write-the-webtransport-stream-header-at-open.md
@@ -1,0 +1,41 @@
+# [M] moq-uring: write the WebTransport stream header at open time, so finish() never owes one
+
+## Goal
+
+Implement and verify the behavior tracked in [#3129](https://github.com/moq-dev/moq/issues/3129)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #3105 (item 4), deliberately left out of #3110. Raised by Codex reviewing that PR and verified against the code.
+
+##### Where it stands
+
+A web-mode `SendStream` carries its WebTransport header as an owed `prefix` and writes it lazily on the first `poll_write`. #3110 stopped `finish()` from reporting connection-level backpressure as a terminal `Error::Web`: it now records that the header is still owed and returns `Ok`, and the FIN goes out on a later `poll_closed`, or on `Drop` if credit has returned by then.
+
+That covers every in-tree caller, because moq-net always pairs `finish()` with `poll_closed`. What it does not cover is a direct consumer that finishes and drops in the same breath:
+
+```rust
+send.finish()?;   // no credit: the header is owed, returns Ok
+drop(send);       // no ingress in between, so try_write still returns 0
+```
+
+There is no moment for credit to return between those two calls, so `Drop` falls through to the mapped reset and the peer sees a cancellation despite `finish()` having reported success. This is not a regression (before #3110 the same situation returned `Err` and callers dropped, resetting with a worse code), and #3110 documents it on `SendStream`, but `finish()` reporting success on a stream that ends up cancelled is still a wart.
+
+##### The fix
+
+Option 1 from #3105: queue the prefix before handing the opened stream back, so nothing is ever owed at finish time and the whole `finishing` state machine goes away. A WebTransport stream is arguably not open until its header is on the wire, so this is also the more honest shape.
+
+The reason it is not a small change: `poll_open_uni` would have to hold a half-open stream across polls while the header drains, and `Session` clones share one `Rc<Web>`. A single slot for the in-flight open would have concurrent openers fighting over it, so this needs a queue of half-open streams in `Web::state`, plus a decision about what `poll_open_uni` returning `Pending` on flow control means for callers that open before they read.
+
+Worth confirming the trade too: making `open` block on credit moves the backpressure earlier, which is more correct but changes when a caller learns about it.
+
+## Closes
+
+- [#3129](https://github.com/moq-dev/moq/issues/3129) - close this issue when the quest finishes

--- a/quest/m0/3137-moqsrc-bound-the-pending-rendition-subscriptions-a.md
+++ b/quest/m0/3137-moqsrc-bound-the-pending-rendition-subscriptions-a.md
@@ -1,0 +1,32 @@
+# [M] moqsrc: bound the pending rendition subscriptions a catalog can open
+
+## Goal
+
+Implement and verify the behavior tracked in [#3137](https://github.com/moq-dev/moq/issues/3137)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Raised by CodeRabbit during review of [#3130](https://github.com/moq-dev/moq/pull/3130), and out of scope there.
+
+`moqsrc` spawns one pump per rendition the catalog announces, and each pump holds a subscription until it resolves, is cancelled, or the session ends. A rendition the publisher never serves parks indefinitely by design (that is what #3130 makes safe for the *other* renditions). Nothing bounds how many such renditions a catalog may announce, so a hostile or broken publisher can make a subscriber hold an arbitrary number of pending subscriptions and tasks.
+
+Worth being precise about the exposure, because it is smaller than it first looks:
+
+- It is not new in #3130. Before it, `reconcile` parked on the first unserved rendition, so the session was wedged rather than resource-hungry. The change trades one failure mode for a milder one; it does not create the unbounded input.
+- The catalog is already parsed into a map of every announced rendition before any of this runs, so memory is proportional to the catalog either way. The pumps add a task and a subscription registration per entry on top.
+- It applies to a broadcast the user explicitly pointed the element at, not to arbitrary remote input.
+
+A cap is a policy decision (what limit, and what a consumer does when a catalog exceeds it: refuse the rendition, refuse the catalog, or fail the session), and every catalog consumer has the same exposure, not just `moqsrc`. That suggests the bound belongs at the catalog layer in `hang`/`moq-mux` rather than being reinvented per element, so `js/hang` and the `moq-cli` exporters inherit the same answer.
+
+Deliberately not fixed in #3130: that PR is a bug fix with regression tests, and adding an admission-control policy on top would be unreviewable scope creep.
+
+## Closes
+
+- [#3137](https://github.com/moq-dev/moq/issues/3137) - close this issue when the quest finishes

--- a/quest/m0/3139-moqsrc-a-rendition-nobody-answers-keeps-the-session-alive.md
+++ b/quest/m0/3139-moqsrc-a-rendition-nobody-answers-keeps-the-session-alive.md
@@ -1,0 +1,34 @@
+# [M] moqsrc: a rendition nobody answers keeps the session alive after the catalog closes
+
+## Goal
+
+Implement and verify the behavior tracked in [#3139](https://github.com/moq-dev/moq/issues/3139)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Split out of [#3130](https://github.com/moq-dev/moq/pull/3130), where two attempts at this traded one bug for a worse one.
+
+`moqsrc`'s pumps each wait for their subscription to resolve. If a catalog names a rendition the publisher never serves, that pump waits forever. When the catalog track then closes, the session loop has nothing left to make progress on: it waits for the remaining pumps to drain, and that one never does. The session holds its connection open and never delivers a terminal EOS until the broadcast ends or the element is stopped.
+
+Cancelling the not-yet-live pumps on catalog close is the obvious fix and it is wrong. "Has not taken a pad yet" does not mean "will never take one" -- it also describes a pump that was spawned microseconds ago and has not been polled. A publisher that names its tracks and then finishes the catalog produces exactly that: the snapshot and the close arrive back to back, so the close is routinely observed before the freshly spawned pumps run at all, and every rendition it just announced gets cancelled before it can subscribe. That drops the entire broadcast instead of one bad rendition, which is far worse than the hang. #3130 tried it, reproduced the media loss in a test, and reverted; `a_closing_catalog_keeps_the_renditions_it_named` guards against re-introducing it.
+
+Separating the two needs a signal the catalog does not carry today. Some options, none obviously right:
+
+- A bounded grace period after the catalog closes, before giving up on a still-unresolved subscription. Simple, but it is a timeout standing in for information, and picking the number is guesswork.
+- Ask the moq layer whether a track can still be served: a subscription with no producer and no `Dynamic` that could ever answer it is already knowable inside `broadcast::Consumer`, and surfacing it would make this decidable rather than timed.
+- Treat catalog closure as a promise that the announced set is final, and have the publisher side finish tracks it never intends to serve, so the subscription resolves rather than parking.
+
+The middle option looks the most principled, since it fixes the class rather than this element, but it widens `moq-net`'s surface.
+
+Note this is not a regression from #3130: before it, the same input parked `reconcile` inside the catalog loop, so the session hung there instead.
+
+## Closes
+
+- [#3139](https://github.com/moq-dev/moq/issues/3139) - close this issue when the quest finishes

--- a/quest/m0/3141-uring-a-close-can-be-lost-when-the-worker-is-torn-down.md
+++ b/quest/m0/3141-uring-a-close-can-be-lost-when-the-worker-is-torn-down.md
@@ -1,0 +1,34 @@
+# [M] uring: a close can be lost when the worker is torn down before its send completes
+
+## Goal
+
+Implement and verify the behavior tracked in [#3141](https://github.com/moq-dev/moq/issues/3141)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Surfaced by the adversarial review of #3131. It applies to both QUIC backends, so it is filed separately rather than folded into that PR.
+
+`udp::TxBuf::send` is fire-and-forget: it stages an SQE, and `Shared::push` only calls `ring.submit()` when the submission queue is full. So a packet handed to the socket has not necessarily reached the kernel, let alone the wire, until the worker enters the ring again.
+
+The connection drivers rely on that ordering when they publish a terminal error for a close the application asked for: the driver flushes the CONNECTION\_CLOSE and then reports the close, so a caller waiting on `poll_closed` learns about it only after the packet is staged. If that caller then returns from `Worker::block_on` and drops the worker, the ring goes with it and the peer never hears the close, waiting out its idle timeout instead.
+
+The window is narrow and the relay does not hit it (its workers outlive their sessions by design), but a one-shot client or a test that closes and immediately stops the runtime does.
+
+Fixing it properly means a completion-aware send: something like `TxBuf::send` returning a handle the caller can await, or the socket tracking outstanding sends so a driver can wait for the one carrying its close. That is a `udp::Socket` API change, which is why it is not in #3131.
+
+Related shape: the same property means any final flush (not just a close) can be lost on an immediate teardown, so a fix here should be about the socket's contract rather than the close path specifically.
+
+## Closes
+
+- [#3141](https://github.com/moq-dev/moq/issues/3141) - close this issue when the quest finishes
+
+## Related
+
+- [#3173: moq-uring: Worker drop submits an uncancelled receive and stalls for…](/quest/m0/3173-moq-uring-worker-drop-submits-an-uncancelled-receive-and.md) - related open work

--- a/quest/m0/3160-moq-tokio-a-noq-only-build-fails-on-three-unrelated.md
+++ b/quest/m0/3160-moq-tokio-a-noq-only-build-fails-on-three-unrelated.md
@@ -1,0 +1,54 @@
+# [M] moq-tokio: a noq-only build fails on three unrelated errors, because no crypto provider is…
+
+## Goal
+
+Implement and verify the behavior tracked in [#3160](https://github.com/moq-dev/moq/issues/3160)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+`cargo check -p moq-tokio --no-default-features --features noq` fails on `dev` with three errors that never name the cause:
+
+```
+error[E0599]: no function or associated item named `default` found for struct `EndpointConfig`
+  --> rs/moq-tokio/src/noq.rs:275:46
+error[E0599]: no function or associated item named `with_crypto` found for struct `web_transport_noq::noq::ServerConfig`
+  --> rs/moq-tokio/src/noq.rs:518:36
+error[E0599]: no function or associated item named `default` found for struct `EndpointConfig`
+  --> rs/moq-tokio/src/noq.rs:537:50
+```
+
+#### Cause
+
+`noq` alone selects no crypto provider. The manifest routes providers into the backends through separate features, with default features off on each backend dependency:
+
+```toml
+aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs", "web-transport-noq?/aws-lc-rs"]
+```
+
+Without `aws-lc-rs` or `ring`, `web-transport-noq` is built without its own provider and the constructors `noq.rs` calls stop existing. `--features noq,aws-lc-rs` is clean.
+
+Unlike `quinn`, this is not a runtime question. `quinn` compiles either way and `crypto::provider()` accepts a provider the application installed with `CryptoProvider::install_default()`, which is a supported path and must keep working. `noq` cannot get that far: the build fails before any application code runs, so nothing installed later can rescue it. `quiche` needs neither, bringing its own through boringssl.
+
+#### Why the matrix misses it
+
+`just rs tokio-features` (added in #3150) checks `--no-default-features` and `--all-features`. Neither selects a lone backend, and workspace builds never do either, since cargo unifies features per crate and any dependent enabling a provider enables it for everyone. So only an explicit `-p moq-tokio --features noq`, or an external consumer picking that combination with `default-features = false`, reaches it.
+
+#### Options
+
+- A `compile_error!` gated on `all(feature = "noq", not(any(feature = "aws-lc-rs", feature = "ring")))`, naming the two features. One honest error instead of three unrelated ones. It rejects nothing that currently builds, since the build already fails.
+- Or have the `noq` feature pull a default provider itself, which makes the combination work rather than explaining it, at the cost of a provider choice the consumer did not make.
+
+Either way it is worth extending `tokio-features` to cover each backend on its own, since the same shape can appear for any of them.
+
+Found while preparing #3152, which is closed as superseded by #3150; this is the part of it that still applies. Verified against `dev` at 1c02995.
+
+## Closes
+
+- [#3160](https://github.com/moq-dev/moq/issues/3160) - close this issue when the quest finishes

--- a/quest/m0/3161-retention-should-reclaim-idle-open-groups-now-that-expiry.md
+++ b/quest/m0/3161-retention-should-reclaim-idle-open-groups-now-that-expiry.md
@@ -1,0 +1,29 @@
+# [S] Retention should reclaim idle open groups now that expiry is timestamp-only
+
+## Goal
+
+Implement and verify the behavior tracked in [#3161](https://github.com/moq-dev/moq/issues/3161)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+\#3099 split group lifetime into two rules: subscription expiry is timestamp-only (a group is stale once its reach falls a full max-age budget behind the newest frame of the latest group), and wall-clock reclamation of idle content belongs to the retention/cache layer.
+
+The expiry half landed in #3099. This issue tracks the reclamation half, which currently has gaps at the model layer:
+
+- The Rust `cache::Pool` ages by last access, but an in-process track without a pool has no wall-clock reclamation at all, and a group held open by a stalled publisher pins its buffer until something else closes it.
+- The JS track retention prune deliberately retains open groups, so an abandoned open group survives `Publisher Max Age` indefinitely.
+
+Concrete symptom (from Codex's adversarial review of #3099): a reader drains an open group whose successor starts less than the budget ahead in media time, production goes quiet, and the pending read stays parked forever. Timestamp expiry is correct to keep the group (nothing proves it is useless), so the bound has to come from retention: an idle open group past the retention window should be reclaimed (aborted), which surfaces to a parked reader as the gap it is.
+
+Needs a decision on what "idle" means for an open group (no producer writes for the retention window is the obvious candidate), a timer/wakeup to arm it, and coverage in both Rust and JS. The draft's Expiration section already frames retention as the publisher's own policy, so this is implementation work, not a wire change.
+
+## Closes
+
+- [#3161](https://github.com/moq-dev/moq/issues/3161) - close this issue when the quest finishes

--- a/quest/m0/3164-moq-audio-remove-heap-activity-and-blocking-locks-from.md
+++ b/quest/m0/3164-moq-audio-remove-heap-activity-and-blocking-locks-from.md
@@ -1,0 +1,50 @@
+# [M] moq-audio: remove heap activity and blocking locks from the capture callback
+
+## Goal
+
+Implement and verify the behavior tracked in [#3164](https://github.com/moq-dev/moq/issues/3164)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2479, found while confirming the full-duplex audio parity tracked by #2481. #2487 bounded the callback-to-encoder queue, but #2479 explicitly left the per-callback allocation for later. The capture path is bounded now, but it is not yet real-time safe in the sense the iroh-live source path was.
+
+#### Current failure mechanism
+
+Every cpal callback allocates a new `Vec<f32>`:
+
+- F32 uses [`data.to_vec()`](https://github.com/moq-dev/moq/blob/85c9f489195dde93fc1d4619c7ec00864975fc3a/rs/moq-audio/src/capture.rs#L219-L224).
+- I16 and U16 use [`collect()`](https://github.com/moq-dev/moq/blob/85c9f489195dde93fc1d4619c7ec00864975fc3a/rs/moq-audio/src/capture.rs#L225-L234).
+
+When the depth-8 queue is full, `Sender::push` drops the rejected `Vec` on the same callback thread, which can run the allocator again:
+
+- [`capture/channel.rs::Sender::push`](https://github.com/moq-dev/moq/blob/85c9f489195dde93fc1d4619c7ec00864975fc3a/rs/moq-audio/src/capture/channel.rs#L53-L65)
+
+With AEC enabled, the callback also takes a blocking `std::sync::Mutex` in [`Canceller::process`](https://github.com/moq-dev/moq/blob/85c9f489195dde93fc1d4619c7ec00864975fc3a/rs/moq-audio/src/aec.rs#L218-L228). The playback driver takes the same state lock when it replaces the render-reference channel. Callback buffers above the pre-sized threshold can also grow AEC scratch storage on that thread.
+
+Heap contention or lock contention can delay the cpal callback long enough to cause the underrun or overrun that these queues are meant to prevent. Bounded memory alone does not make the callback path real-time safe.
+
+#### Required behavior
+
+- Move microphone samples through preallocated bounded storage. A fixed-resample SPSC endpoint or a buffer pool are both plausible, as long as callback push never allocates, frees, waits, or logs.
+- Convert non-f32 device formats in fixed preallocated chunks rather than collecting a new buffer.
+- Preserve the current drop and gap semantics. Overflow must remain observable so the producer re-anchors its timeline.
+- Make AEC callback-owned state exclusive to the callback. Device-switch updates should cross a bounded nonblocking handoff rather than contend on its state lock.
+- Size scratch storage before `stream.play()`, or process oversized callbacks in bounded chunks, so callback size cannot trigger a one-time allocation.
+- Keep allocations on the async consumer side acceptable. That side is not the real-time thread.
+
+#### Tests
+
+Factor the callback adapter so hardware-free tests can feed F32, I16, and U16 buffers through it. Assert bounded overflow and gap reporting, chunk sizes above the normal host period, and AEC reference replacement. Add an allocation-counting test or equivalent instrumentation proving the callback adapter performs no allocation or free after construction.
+
+Refs #2479, #2481.
+
+## Closes
+
+- [#3164](https://github.com/moq-dev/moq/issues/3164) - close this issue when the quest finishes

--- a/quest/m0/3165-moq-audio-bound-and-coalesce-playback-driver-commands.md
+++ b/quest/m0/3165-moq-audio-bound-and-coalesce-playback-driver-commands.md
@@ -1,0 +1,51 @@
+# [M] moq-audio: bound and coalesce playback driver commands
+
+## Goal
+
+Implement and verify the behavior tracked in [#3165](https://github.com/moq-dev/moq/issues/3165)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Part of the full-duplex audio parity audit from #2481. #2478 called for a bounded driver command channel, matching iroh-live's bounded device-control path. The landed playback mixer and sample rings are bounded, but the device driver's outer command queue is not.
+
+#### Current failure mechanism
+
+[`Engine::open`](https://github.com/moq-dev/moq/blob/85c9f489195dde93fc1d4619c7ec00864975fc3a/rs/moq-audio/src/playback.rs#L98-L126) creates the driver channel with `std::sync::mpsc::channel()`. This queue is unbounded. Clones of its sender are used for:
+
+- output-device switches,
+- sink and AEC synchronization wakes,
+- shutdown,
+- cpal error notifications from every stream generation.
+
+The driver performs blocking host operations while opening or switching devices. During one of those stalls, repeated cpal errors or caller commands can continue allocating queue nodes without a memory bound. The cpal error callback also uses the allocating `send` path before returning.
+
+The inner mixer queue is correctly bounded and retried, so the unbounded outer queue is now the only control-plane exception in the playback engine.
+
+#### Required behavior
+
+- Give the driver command path a fixed memory bound and never block a cpal callback on capacity.
+- Coalesce idempotent `Sync` wakes instead of queueing one per event.
+- Coalesce or otherwise bound failure notifications by live stream generation. A stale generation must not evict the signal for the current stream.
+- Preserve reliable switch completion. A switch request must either enter the bounded driver path or return a clear overload or stopped error to its awaiting caller.
+- Preserve reliable last-handle shutdown without requiring an unbounded emergency lane.
+- Keep the existing mixer retry invariant. A dropped wake must not leave a sink or AEC tap permanently unattached.
+
+#### Tests
+
+- Flood each notification class while the driver receiver is paused and assert storage never exceeds the fixed bound.
+- Confirm a saturated path cannot strand an awaiting switch response.
+- Confirm a live-generation failure still schedules restart when stale failures and sync wakes are already pending.
+- Confirm dropping the final engine or sink shuts the driver down under saturation.
+
+Refs #2478, #2481.
+
+## Closes
+
+- [#3165](https://github.com/moq-dev/moq/issues/3165) - close this issue when the quest finishes

--- a/quest/m0/3171-js-publish-fanout-with-a-zero-queue-spins-forever.md
+++ b/quest/m0/3171-js-publish-fanout-with-a-zero-queue-spins-forever.md
@@ -1,0 +1,52 @@
+# [S] js/publish: Fanout with a zero queue spins forever
+
+## Goal
+
+Implement and verify the behavior tracked in [#3171](https://github.com/moq-dev/moq/issues/3171)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+On `dev` at `7494084a`, `Fanout.subscribe(effect, queue)` accepts a queue size without validating it. In `Fanout.#push`, the eviction loop is:
+
+```ts
+while (reader.queue.length >= reader.limit) {
+    const dropped = reader.queue.shift();
+    if (dropped !== undefined) this.#release?.(dropped);
+}
+```
+
+With a limit of zero, an empty queue satisfies `0 >= 0`. `shift()` keeps returning `undefined`, so the loop never makes progress and the JavaScript event loop is permanently blocked. Negative limits behave the same way, and `NaN` silently disables the bound.
+
+`Fanout` is reachable through the public audio and video capture outputs, while the API only describes the queue as a buffer count and does not require it to be positive.
+
+Code: https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/js/publish/src/fanout.ts#L63-L64 and https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/js/publish/src/fanout.ts#L167-L174
+
+#### Reproduction
+
+```ts
+const effect = new Effect();
+const fanout = new Fanout(source);
+fanout.subscribe(effect, 0);
+sourceController.enqueue(1);
+```
+
+A bounded reproducer run under `timeout 2s` exited with status 124. The event loop never reached a timer scheduled for 10 ms later.
+
+#### Expected
+
+Either reject any non-finite, non-integer, or non-positive queue size at construction/subscription, or define and implement explicit zero-buffer behavior. Invalid input must not hard-lock the page.
+
+Add a regression test for both the default constructor queue and the per-subscriber override.
+
+## Closes
+
+- [#3171](https://github.com/moq-dev/moq/issues/3171) - close this issue when the quest finishes

--- a/quest/m0/3172-js-net-a-terminal-reload-failure-can-reconnect-after.md
+++ b/quest/m0/3172-js-net-a-terminal-reload-failure-can-reconnect-after.md
@@ -1,0 +1,56 @@
+# [S] js/net: a terminal Reload failure can reconnect after closed rejects
+
+## Goal
+
+Implement and verify the behavior tracked in [#3172](https://github.com/moq-dev/moq/issues/3172)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+On `dev` at `7494084a`, `Reload.#retry` treats an authorization rejection or an expired retry window as terminal by rejecting `Reload.closed` and releasing the subscribe origin's expectation. It does not stop `#signals` or mark the loop terminal.
+
+The connection effect remains subscribed to `url`, `enabled`, `#suspended`, and `#tick`. A later URL update, enabled toggle, or browser resume therefore runs `#connect` again after `closed` has permanently rejected.
+
+Code: https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/js/net/src/connection/reload.ts#L309-L325
+
+#### Reproduction
+
+A focused test used a WebTransport stub that rejects every dial, a 1 ms retry timeout, and then changed the URL after awaiting the terminal rejection:
+
+```ts
+const reload = new Reload({
+    url: new URL("https://example.com/one"),
+    websocket: { enabled: false },
+    delay: { initial: 1, max: 1, timeout: 1 },
+});
+
+await expect(reload.closed).rejects.toThrow();
+const terminalDials = dials;
+
+reload.url.set(new URL("https://example.com/two"));
+await settle();
+
+expect(dials).toBe(terminalDials);
+```
+
+Observed: `terminalDials` was 2, then the URL change caused a third dial. The assertion received 3.
+
+#### Impact
+
+The documented terminal lifecycle is false: work resumes after callers have observed that the loop is closed. With a subscribe origin, `#expected` has already been released, so the origin can report requests as unroutable while the resurrected session is connecting or active. Shared connections can also be retriggered by page lifecycle signals after an authorization rejection.
+
+#### Expected
+
+A terminal path should permanently stop the reactive connection effect before settling `closed`, while preserving idempotent cleanup and the terminal error. Add regression coverage for URL updates, enabled toggles, and browser resume after both authorization rejection and retry timeout.
+
+## Closes
+
+- [#3172](https://github.com/moq-dev/moq/issues/3172) - close this issue when the quest finishes

--- a/quest/m0/3173-moq-uring-worker-drop-submits-an-uncancelled-receive-and.md
+++ b/quest/m0/3173-moq-uring-worker-drop-submits-an-uncancelled-receive-and.md
@@ -1,0 +1,65 @@
+# [S] moq-uring: Worker drop submits an uncancelled receive and stalls for 3.2 seconds
+
+## Goal
+
+Implement and verify the behavior tracked in [#3173](https://github.com/moq-dev/moq/issues/3173)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+On `dev` at `7494084a`, dropping a worker with a newly created UDP socket can take about 3.2 seconds and leak the receive operation.
+
+`Handle::udp` arms the socket by writing its initial receive SQE into the submission queue. `Worker::drop` then calls `register_sync_cancel` before `pump()` submits staged entries:
+
+https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-uring/src/worker.rs#L309-L340
+
+The io-uring API only considers requests already submitted to the ring for synchronous cancellation. The staged receive is therefore not matched. The first `pump()` submits it after cancellation has finished, leaving a live receive with no future cancellation request. Teardown waits through 64 iterations of 50 ms and then deliberately leaks the operation.
+
+The initial receive is staged here:
+
+https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-uring/src/udp.rs#L486-L509
+
+#### Reproduction
+
+On Linux 7.1.3, a minimal `moq-uring` build without a QUIC backend ran:
+
+```rust
+let worker = moq_uring::Worker::new(Default::default()).unwrap();
+let handle = worker.handle();
+let io = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+let _socket = handle.udp(io, Default::default()).unwrap();
+
+let start = std::time::Instant::now();
+drop(worker);
+println!("{:?}", start.elapsed());
+```
+
+Observed:
+
+```
+worker drop took 3.202129467s
+```
+
+The retained-socket path in `dropped_worker_rejects_operations` already creates this state, but the test has no bound on drop duration and does not detect the leak.
+
+#### Expected
+
+Worker teardown should submit or safely remove every staged operation before issuing the cancellation that is meant to cover it, then drain terminal completions without the fixed 3.2 second stall or leak. The ordering also needs to preserve the final-send guarantee being developed in #3141.
+
+Add a regression that retains a socket across worker drop, asserts teardown completes promptly, and verifies the operation slab drains.
+
+## Closes
+
+- [#3173](https://github.com/moq-dev/moq/issues/3173) - close this issue when the quest finishes
+
+## Related
+
+- [#3141: uring: a close can be lost when the worker is torn down before its…](/quest/m0/3141-uring-a-close-can-be-lost-when-the-worker-is-torn-down.md) - related open work

--- a/quest/m0/3174-js-publish-audio-encoder-processes-the-first-frame-before.md
+++ b/quest/m0/3174-js-publish-audio-encoder-processes-the-first-frame-before.md
@@ -1,0 +1,51 @@
+# [S] js/publish: Audio Encoder processes the first frame before applying mute or volume
+
+## Goal
+
+Implement and verify the behavior tracked in [#3174](https://github.com/moq-dev/moq/issues/3174)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+On `dev` at `7494084a`, the audio capture loop applies gain to a frame before updating the gain target from the encoder's `muted` and `volume` signals:
+
+https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/js/publish/src/audio/encoder.ts#L204-L222
+
+```ts
+const gain = new Gain();
+
+const frame = gain.apply(next.value, format.sampleRate);
+gain.set(this.muted.peek() ? 0 : this.volume.peek());
+```
+
+`Gain` starts with both its current and target levels at unity:
+
+https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/js/publish/src/audio/gain.ts#L13-L20
+
+An encoder constructed with `muted: true` or `volume: 0` therefore emits the entire first captured frame at unity. Every later mute or volume update is also observed one frame late because the previous target is applied before the new signal value is read.
+
+#### Impact
+
+The `muted` property is documented as silencing encoded audio, but initial muted construction leaks one frame. A mute transition also carries one additional frame at the previous target before the configured fade begins. At a typical 48 kHz capture quantum of 128 samples, that is about 2.7 ms of fully unmodified audio before the 200 ms fade.
+
+#### Expected
+
+Seed the gain state from the encoder's current mute/volume values before processing the first frame, and update the target before applying each later frame. Preserve the intended click-free ramp for live changes, while making an initially muted encoder start silent.
+
+Add encoder-level regression coverage for:
+
+- `muted: true` before the first captured frame
+- an initial non-unity volume
+- a mute or volume change between frames
+
+## Closes
+
+- [#3174](https://github.com/moq-dev/moq/issues/3174) - close this issue when the quest finishes

--- a/quest/m0/3187-preserve-structured-protocol-error-codes-across-ffi-and-c.md
+++ b/quest/m0/3187-preserve-structured-protocol-error-codes-across-ffi-and-c.md
@@ -1,0 +1,51 @@
+# [M] Preserve structured protocol error codes across FFI and C bindings
+
+## Goal
+
+Implement and verify the behavior tracked in [#3187](https://github.com/moq-dev/moq/issues/3187)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Rust preserves structured session and stream failures, including known protocol variants, application codes, and unknown future codes:
+
+- [`SessionError::App(u16)` and `Unknown(u32)`](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-net/src/error.rs#L60-L108)
+- [TypeScript session and stream code types](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/js/net/src/error.ts#L10-L145)
+
+The UniFFI boundary flattens every `moq_net::Error` into the broad `MoqError::Protocol` variant:
+
+- [FFI error mapping](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-ffi/src/error.rs#L1-L8)
+
+The C facade similarly reports a broad status with textual detail. Python, Swift, Kotlin, Go, and C callers can send application error codes through abort and cancel APIs, but cannot reliably inspect a received code. This prevents applications from implementing protocol-defined recovery or policy.
+
+#### Proposed direction
+
+Expose a portable structured protocol error shape that preserves:
+
+- session versus stream scope
+- the exact numeric code
+- a known semantic kind when recognized
+- unknown future codes without lossy conversion
+- a human-readable message for diagnostics
+
+Keep transport and internal failures separate from protocol failures. C should expose equivalent getters or an output record rather than requiring callers to parse `moq_error()`.
+
+#### Acceptance criteria
+
+- Every binding can recover the exact received session or stream code.
+- Application-defined and unknown codes round-trip without loss.
+- Callers can still match broad error categories ergonomically.
+- Cross-language tests cover a known code, an application code, and an unknown code.
+- The public shape is designed on `dev` before the next binding compatibility release.
+
+## Closes
+
+- [#3187](https://github.com/moq-dev/moq/issues/3187) - close this issue when the quest finishes

--- a/quest/m0/3188-make-every-blocking-go-operation-cancellable-with-context.md
+++ b/quest/m0/3188-make-every-blocking-go-operation-cancellable-with-context.md
@@ -1,0 +1,51 @@
+# [S] Make every blocking Go operation cancellable with context.Context
+
+## Goal
+
+Implement and verify the behavior tracked in [#3188](https://github.com/moq-dev/moq/issues/3188)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+The Go package contract says blocking calls accept `context.Context` so callers can cancel them:
+
+- [Package concurrency documentation](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/go/wrapper/doc.go#L14-L27)
+
+Several operations backed by async UniFFI methods are nevertheless exposed as contextless, synchronous Go calls:
+
+- [`OriginConsumer.RequestBroadcast`](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/go/wrapper/origin.go#L126-L136)
+- [catalog, track, fetch, resolve, and decode operations](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/go/wrapper/subscribe.go#L43-L130)
+- [JSON subscriptions](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/go/wrapper/json.go#L160-L184)
+
+These can wait on remote producer behavior or network progress without any caller-controlled deadline.
+
+#### Root cause
+
+The generated async UniFFI calls block the calling Go goroutine. The handwritten wrapper applies cancellation adapters to only part of that surface, so the documented rule and actual API have drifted apart.
+
+#### Proposed direction
+
+Make every potentially blocking public Go operation accept `context.Context`.
+
+Prefer cancellable FFI operation handles for long-running construction and resolution. Wrapping the current synchronous call in an abandoned goroutine returns control to Go but leaves the native operation alive until it eventually completes.
+
+#### Acceptance criteria
+
+- Every potentially blocking Go method accepts a context.
+- Cancellation and deadlines return promptly.
+- Cancellation does not leak an unbounded native task or goroutine.
+- Package documentation accurately describes any remaining cancellation limitations.
+- Tests cover cancellation while waiting for a dynamic broadcast and track resolution.
+- Breaking signature changes target `dev`.
+
+## Closes
+
+- [#3188](https://github.com/moq-dev/moq/issues/3188) - close this issue when the quest finishes

--- a/quest/m0/3189-add-uniffi-defaults-to-caller-constructed-configuration.md
+++ b/quest/m0/3189-add-uniffi-defaults-to-caller-constructed-configuration.md
@@ -1,0 +1,54 @@
+# [S] Add UniFFI defaults to caller-constructed configuration records
+
+## Goal
+
+Implement and verify the behavior tracked in [#3189](https://github.com/moq-dev/moq/issues/3189)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Several caller-constructed UniFFI records describe fields as optional or defaultable but do not declare UniFFI defaults:
+
+- [`MoqAudioEncoderOutput` and `MoqAudioDecoderOutput`](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-ffi/src/audio.rs#L68-L100)
+- [`MoqVideoHint`, whose documentation says every field is optional](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-ffi/src/media.rs#L159-L176)
+
+The video encoder and decoder output records already use `#[uniffi(default = None)]` consistently:
+
+- [Video output record defaults](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-ffi/src/video.rs#L97-L114)
+- [Video decoder defaults](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-ffi/src/video.rs#L375-L388)
+
+Python, Swift, Kotlin, and Go publicly expose or alias the generated records. Without generated-language defaults, callers must spell every optional field, and adding a new field can become a source compatibility break.
+
+#### Proposed direction
+
+Audit every caller-constructed UniFFI record and declare defaults for all fields whose omission has defined behavior. At minimum:
+
+- optional values should default to `None`
+- audio encoder frame duration should use its documented 20 ms default
+- enum defaults should be declared where the API already defines a canonical automatic choice
+
+Keep returned data records distinct from caller-constructed options. Returned records do not need construction defaults.
+
+#### Acceptance criteria
+
+- Optional configuration fields can be omitted in Python, Swift, and Kotlin.
+- Generated signatures expose the intended defaults rather than only documenting them.
+- Adding a new optional field to these records remains source-compatible where UniFFI supports it.
+- Binding tests construct each options record with only its required fields.
+- The audit covers all public records in `moq-ffi`, not only the three known examples.
+
+## Closes
+
+- [#3189](https://github.com/moq-dev/moq/issues/3189) - close this issue when the quest finishes
+
+## Related
+
+- [#3208: Make 2.5 ms Opus frame durations work across bindings](/quest/m0/3208-make-2-5-ms-opus-frame-durations-work-across-bindings.md) - related open work

--- a/quest/m0/3190-align-origin-broadcast-creation-naming-across-language.md
+++ b/quest/m0/3190-align-origin-broadcast-creation-naming-across-language.md
@@ -1,0 +1,49 @@
+# [L] Align origin broadcast creation naming across language bindings
+
+## Goal
+
+Implement and verify the behavior tracked in [#3190](https://github.com/moq-dev/moq/issues/3190)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+The operation that allocates and owns a new broadcast has different names across public surfaces:
+
+- Rust FFI uses [`create_broadcast`](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-ffi/src/origin.rs#L251-L267)
+- Python, Swift, and Go expose `create_broadcast` or `CreateBroadcast`, for example [Go](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/go/wrapper/origin.go#L38-L51)
+- TypeScript uses [`publish(path)`](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/js/net/src/origin.ts#L106-L107)
+- C uses [`moq_origin_publish`](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/libmoq/src/api.rs#L1102-L1123)
+
+`publish` suggests announcement or transmission. The operation actually creates a broadcast, while announcement visibility is controlled separately through `setAnnounce` or its equivalent.
+
+Issue #1073 changes Origin lifecycle but explicitly leaves naming outside its scope.
+
+#### Proposed direction
+
+Use the role-accurate creation verb consistently:
+
+- Rust and Python: `create_broadcast`
+- TypeScript, Swift, and Kotlin: `createBroadcast`
+- Go: `CreateBroadcast`
+- C: `moq_origin_create_broadcast`
+
+If compatibility aliases are retained, keep deprecated names hidden from user-facing documentation according to the repository deprecation policy.
+
+#### Acceptance criteria
+
+- Every language uses its idiomatic spelling of the same `create broadcast` operation.
+- Announcement APIs retain separate announce terminology.
+- Examples and generated documentation use only the canonical name.
+- Breaking renames target `dev`.
+
+## Closes
+
+- [#3190](https://github.com/moq-dev/moq/issues/3190) - close this issue when the quest finishes

--- a/quest/m0/3193-expose-a-cancellable-route-watch-api-in-python.md
+++ b/quest/m0/3193-expose-a-cancellable-route-watch-api-in-python.md
@@ -1,0 +1,50 @@
+# [M] Expose a cancellable route watch API in Python
+
+## Goal
+
+Implement and verify the behavior tracked in [#3193](https://github.com/moq-dev/moq/issues/3193)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Python handles route changes differently from the other bindings. `BroadcastConsumer.route_changed()` lazily creates a route watch, caches it in a private field, and awaits its next value:
+
+- [Python `BroadcastConsumer` route handling](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/py/moq-rs/moq/subscribe.py#L376-L405)
+
+The watch handle is not public and has no deterministic cancellation path. A caller that abandons route observation must rely on garbage collection or broadcast shutdown to release the native watch.
+
+Other wrappers expose explicit lifetime ownership:
+
+- [Go `RouteWatch.Next(ctx)` and `Cancel`](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/go/wrapper/subscribe.go#L15-L40)
+- Swift exposes a cancellable asynchronous sequence.
+- Kotlin exposes a `Flow` that cancels the watch in `finally`.
+
+#### Proposed direction
+
+Expose a public Python route watch abstraction with deterministic cleanup, following the existing wrapper conventions. Suitable shapes include:
+
+- an async iterator returned by `routes()`
+- an async context-managed `RouteWatch`
+- both, with `route_changed()` retained only as a convenience over the owned watch
+
+The owner should be able to cancel a pending wait and release the native resource without waiting for garbage collection.
+
+#### Acceptance criteria
+
+- Python callers can explicitly own and close a route watch.
+- Abandoning iteration deterministically cancels the native watch.
+- A pending route wait is cancellable by normal asyncio task cancellation.
+- Tests cover early iterator exit and cancellation while waiting.
+- Lifecycle documentation matches the Go, Swift, and Kotlin ownership contract.
+
+## Closes
+
+- [#3193](https://github.com/moq-dev/moq/issues/3193) - close this issue when the quest finishes

--- a/quest/m0/3199-moq-uring-remove-sq-indirection-and-per-enter-ring-fd.md
+++ b/quest/m0/3199-moq-uring-remove-sq-indirection-and-per-enter-ring-fd.md
@@ -1,0 +1,38 @@
+# [S] moq-uring: remove SQ indirection and per-enter ring fd lookup
+
+## Goal
+
+Implement and verify the behavior tracked in [#3199](https://github.com/moq-dev/moq/issues/3199)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2875.
+
+`Worker::new` enables `SINGLE_ISSUER`, `DEFER_TASKRUN`, and `COOP_TASKRUN`, but the ring still has an SQ array and each `io_uring_enter` resolves the normal ring fd. Both costs are avoidable below the existing Linux 6.12 floor.
+
+#### Mechanism
+
+- `IORING_SETUP_NO_SQARRAY` makes SQ indexes map directly to SQEs, removing the redundant SQ-array write and lookup. The worker is a single issuer and submits in order, which is the intended shape.
+- `IORING_REGISTER_RING_FDS` lets subsequent enters use the registered-ring path, avoiding normal fd lookup and reference traffic on every enter.
+
+#### Proposal
+
+- Add `setup_no_sqarray()` when constructing the worker ring.
+- Register the ring fd immediately after construction with `register_ring_fd()`.
+- Treat failure as unsupported startup, consistent with the deliberate kernel-feature floor.
+- Add a kernel-gated construction test so either optimization cannot silently disappear.
+
+#### Acceptance
+
+Run the existing io-uring echo and relay workloads before and after. Record relay CPU, cycles, cache misses, `io_uring_enter` calls, and throughput at fixed load. Keep each optimization independently ablatable and retain it only if the measured result is neutral or positive.
+
+## Closes
+
+- [#3199](https://github.com/moq-dev/moq/issues/3199) - close this issue when the quest finishes

--- a/quest/m0/3200-moq-uring-batch-completion-wakeups-with-min-timeout.md
+++ b/quest/m0/3200-moq-uring-batch-completion-wakeups-with-min-timeout.md
@@ -1,0 +1,44 @@
+# [S] moq-uring: batch completion wakeups with MIN_TIMEOUT
+
+## Goal
+
+Implement and verify the behavior tracked in [#3200](https://github.com/moq-dev/moq/issues/3200)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2875.
+
+The worker requires `IORING_FEAT_MIN_TIMEOUT`, but `maybe_park` currently waits for one completion and does not set `min_wait_usec`. The kernel therefore wakes the thread for each first CQE even when a few microseconds of coalescing could amortize enter, CQ, and task-dispatch overhead.
+
+#### Mechanism
+
+A timed `io_uring_enter` can combine:
+
+- a CQE batch target `N`
+- a short minimum wait `t` once at least one CQE exists
+- the next application timer `T` as the absolute maximum wait
+
+The kernel returns when `N` CQEs arrive, when `t` expires after partial progress, or when `T` expires with no progress. This should trade a bounded amount of latency for fewer wakeups and larger batches.
+
+#### Proposal
+
+- Add benchmark knobs for the CQE batch target and minimum wait.
+- Apply them only when the worker is otherwise ready to park. Preserve the next timer as the hard deadline.
+- Measure a small static matrix first, then consider an adaptive target based on recent CQ batch occupancy.
+- Keep remote futex wakes and handshake/control traffic bounded by the configured minimum wait.
+- Test all three return paths: batch target reached, partial batch released by the minimum wait, and empty ring released by the application deadline.
+
+#### Acceptance
+
+Benchmark chat, 1:1 video, and fanout workloads with `N = 1/4/8/16` and `t = 0/5/10/20 us`. Record CQEs per wake, enters per second, CPU per message, p50, p99, and p999 latency. Pick no production default until the latency budget and CPU win are both demonstrated.
+
+## Closes
+
+- [#3200](https://github.com/moq-dev/moq/issues/3200) - close this issue when the quest finishes

--- a/quest/m0/3201-moq-uring-use-sendmsg-zc-for-large-udp-gso-trains.md
+++ b/quest/m0/3201-moq-uring-use-sendmsg-zc-for-large-udp-gso-trains.md
@@ -1,0 +1,39 @@
+# [S] moq-uring: use SENDMSG_ZC for large UDP GSO trains
+
+## Goal
+
+Implement and verify the behavior tracked in [#3201](https://github.com/moq-dev/moq/issues/3201)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2875.
+
+The UDP path already assembles up to 64 KiB GSO trains in stable pool buffers, then submits `SendMsg` and recycles the buffer at the first CQE. Large trains are the promising case for `SENDMSG_ZC`; individual QUIC datagrams are likely below the copy-avoidance crossover.
+
+#### Mechanism
+
+`IORING_OP_SENDMSG_ZC` can avoid copying payload pages into kernel memory. A successful request normally produces a normal send completion and a later notification CQE. The source buffer must remain untouched until the notification arrives. `IORING_SEND_ZC_REPORT_USAGE` can report when the kernel copied instead.
+
+#### Proposal
+
+- Use `SendMsgZc` only above a measured GSO-train byte threshold. Keep `SendMsg` for small sends.
+- Extend the send operation state to track both completion phases and retain the TX lease until the notification CQE.
+- Enable usage reporting and expose counters for zero-copy success, copy fallback, and notification latency.
+- Include the extra notification CQEs in CQ sizing and teardown accounting.
+- Preserve the staged-send teardown guarantee from #3141.
+- Add tests proving buffers cannot be reused after the send CQE but before the notification, including error, cancellation, and worker-drop paths.
+
+#### Acceptance
+
+Sweep the threshold across realistic chat and media packet trains. Record relay CPU, goodput, CQEs per send, copy-fallback rate, TX-pool pressure, p99 latency, and memory residency at fixed offered load. Enable it by default only where the end-to-end result beats regular `SendMsg`.
+
+## Closes
+
+- [#3201](https://github.com/moq-dev/moq/issues/3201) - close this issue when the quest finishes

--- a/quest/m0/3202-moq-uring-use-fixed-file-slots-for-worker-udp-sockets.md
+++ b/quest/m0/3202-moq-uring-use-fixed-file-slots-for-worker-udp-sockets.md
@@ -1,0 +1,39 @@
+# [S] moq-uring: use fixed-file slots for worker UDP sockets
+
+## Goal
+
+Implement and verify the behavior tracked in [#3202](https://github.com/moq-dev/moq/issues/3202)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2875.
+
+Every UDP SQE currently uses `types::Fd`, so the kernel resolves and takes references on the socket fd for each receive, send, and cancellation path. Worker sockets are long-lived and naturally fit a ring-owned fixed-file table.
+
+#### Mechanism
+
+Registered files let SQEs address a stable table slot with `types::Fixed`. This removes repeated fd-table lookup and reference work from the hot path.
+
+#### Proposal
+
+- Create a sparse fixed-file table owned by the worker ring.
+- Allocate and update one slot when `Handle::udp` binds a socket.
+- Use the fixed index for receive, send, and related socket SQEs.
+- Keep slot ownership in one socket state object. Do not clear a slot until multishot receives, sends, and cancellations have reached terminal CQEs.
+- Define teardown ordering explicitly so OS fd reuse cannot make a stale SQE target a different socket.
+- Add stress tests for rapid bind/drop cycles, numeric fd reuse, cancellation races, and worker drop with operations in flight.
+
+#### Acceptance
+
+Benchmark steady-state send/receive traffic and high socket-churn workloads. Record CPU, cycles, instructions, throughput, and socket lifetime cost. Keep the implementation only if the hot-path win justifies the slot-lifecycle complexity.
+
+## Closes
+
+- [#3202](https://github.com/moq-dev/moq/issues/3202) - close this issue when the quest finishes

--- a/quest/m0/3203-moq-uring-add-opt-in-napi-busy-polling.md
+++ b/quest/m0/3203-moq-uring-add-opt-in-napi-busy-polling.md
@@ -1,0 +1,35 @@
+# [S] moq-uring: add opt-in NAPI busy polling
+
+## Goal
+
+Implement and verify the behavior tracked in [#3203](https://github.com/moq-dev/moq/issues/3203)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2875.
+
+The relay already pins one worker and one ring per core. io\_uring NAPI busy polling can keep a worker close to the NIC receive path and reduce wakeup latency, at the cost of continuously consuming CPU and power while it polls.
+
+#### Proposal
+
+- Add an explicit worker-level NAPI configuration with disabled as the default.
+- Start with dynamic NAPI-ID tracking through `register_napi`. Add static IDs only if deployment can discover and maintain the correct queue IDs reliably.
+- Make busy-poll duration and preferred-busy-poll behavior observable in relay configuration and stats.
+- Report unsupported registration clearly. Do not silently claim the mode is active.
+- Ensure unregister and worker teardown are safe.
+- Document that this mode is for dedicated, latency-sensitive cores, not general self-hosting.
+
+#### Acceptance
+
+Measure on bare metal with the deployment NIC and queue affinity configured, not loopback. Compare disabled and several busy-poll durations under low, medium, and saturated load. Record p50, p99, and p999 packet latency, relay CPU, CPU idle residency, interrupts, drops, goodput, and power if available. Ship only as opt-in unless fleet-level data shows an acceptable idle-cost tradeoff.
+
+## Closes
+
+- [#3203](https://github.com/moq-dev/moq/issues/3203) - close this issue when the quest finishes

--- a/quest/m0/3204-moq-uring-register-tx-pool-buffers-for-zero-copy-sends.md
+++ b/quest/m0/3204-moq-uring-register-tx-pool-buffers-for-zero-copy-sends.md
@@ -1,0 +1,39 @@
+# [S] moq-uring: register TX-pool buffers for zero-copy sends
+
+## Goal
+
+Implement and verify the behavior tracked in [#3204](https://github.com/moq-dev/moq/issues/3204)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2875 and dependent on the `SENDMSG_ZC` experiment in #3201.
+
+The TX pool already owns stable `Box<[u8]>` allocations and grows lazily. If zero-copy send wins, registering those allocations lets send SQEs reference fixed buffers and can reduce repeated page accounting on the large-train path.
+
+#### Proposal
+
+- Register a sparse buffer table once per worker.
+- Give each lazily allocated TX buffer a stable ring-wide buffer index and populate it with `register_buffers_update`.
+- Submit eligible zero-copy sends with the fixed-buffer flag and index.
+- Keep allocation, registration, and TX lease ownership in one type so a buffer cannot move, unregister, or free while the kernel can reference it.
+- Preserve lazy pool growth. Account for locked-memory limits and expose registration failures rather than silently growing unbounded pinned memory.
+- Define worker teardown ordering and add tests for growth, partial registration failure, reuse after notification, and drop with sends in flight.
+
+#### Acceptance
+
+Compare #3201 with and without registered buffers using the same threshold and workload matrix. Record CPU, cycles, registration cost, locked memory, pool starvation, throughput, and latency. Do not add the complexity unless it improves the winning zero-copy range beyond ordinary `SendMsgZc`.
+
+## Required
+
+- [#3201: moq-uring: use SENDMSG\_ZC for large UDP GSO trains](/quest/m0/3201-moq-uring-use-sendmsg-zc-for-large-udp-gso-trains.md) - complete the prerequisite issue first
+
+## Closes
+
+- [#3204](https://github.com/moq-dev/moq/issues/3204) - close this issue when the quest finishes

--- a/quest/m0/3205-moq-uring-register-reusable-io-uring-enter-wait-arguments.md
+++ b/quest/m0/3205-moq-uring-register-reusable-io-uring-enter-wait-arguments.md
@@ -1,0 +1,39 @@
+# [S] moq-uring: register reusable io_uring_enter wait arguments
+
+## Goal
+
+Implement and verify the behavior tracked in [#3205](https://github.com/moq-dev/moq/issues/3205)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Follow-up to #2875 and the CQ batching experiment in #3200.
+
+Timed parking currently builds a `Timespec` and `SubmitArgs` for each wait, then asks the kernel to copy the extended enter arguments. Linux 6.13 added registered wait regions and `IORING_ENTER_EXT_ARG_REG`, allowing a ring to reuse kernel-known wait storage.
+
+#### Proposal
+
+- After #3200 fixes the wait shape, register one stable `io_uring_reg_wait` entry per worker.
+- Update its absolute deadline, batch target, and minimum wait before each enter, then use `IORING_ENTER_EXT_ARG_REG`.
+- Keep the current extended-argument path as the Linux 6.12 fallback. Do not raise the kernel floor for this micro-optimization without benchmark evidence.
+- Prefer safe upstream support in the `io-uring` crate. If the current release lacks the registration API, contribute or upgrade that support instead of spreading raw ABI calls through the worker.
+- Keep registration ownership and unregistration in one worker-owned type.
+- Test repeated deadline changes, no-deadline waits, interrupted enters, and teardown.
+
+#### Acceptance
+
+Measure this after the winning #3200 configuration, where enter frequency and argument shape are known. Record cycles and instructions per enter, enters per second, relay CPU, and latency. Retain the 6.13 fast path only if the end-to-end CPU change is measurable.
+
+## Required
+
+- [#3200: moq-uring: batch completion wakeups with MIN\_TIMEOUT](/quest/m0/3200-moq-uring-batch-completion-wakeups-with-min-timeout.md) - complete the prerequisite issue first
+
+## Closes
+
+- [#3205](https://github.com/moq-dev/moq/issues/3205) - close this issue when the quest finishes

--- a/quest/m0/3207-send-valid-publish-done-statuses-for-every-supported-ietf.md
+++ b/quest/m0/3207-send-valid-publish-done-statuses-for-every-supported-ietf.md
@@ -1,0 +1,43 @@
+# [M] Send valid PUBLISH_DONE statuses for every supported IETF draft
+
+## Goal
+
+Implement and verify the behavior tracked in [#3207](https://github.com/moq-dev/moq/issues/3207)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+The Rust and TypeScript IETF adapters diverge from draft-19 when terminating ordinary subscriptions:
+
+- Rust sends HTTP-like `200` and `500` PUBLISH\_DONE status codes, which are not registered PUBLISH\_DONE codes: [publisher.rs](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-net/src/ietf/publisher.rs#L603-L640)
+- TypeScript sends PUBLISH\_DONE only for drafts 14 through 16, even though drafts 17 through 19 also require it: [publisher.ts](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/js/net/src/ietf/publisher.ts#L226-L249)
+
+PUBLISH\_DONE is not limited to publisher-initiated PUBLISH. It is the final control message for an ordinary subscriber-initiated SUBSCRIBE as well. Removing or omitting it breaks normal subscription termination semantics. See [draft-19 section 10.11 and the section 15.11.3 registry](https://www.ietf.org/archive/id/draft-ietf-moq-transport-19.txt).
+
+Inbound PUBLISH may remain unsupported, but it should continue to be decoded and rejected with REQUEST\_ERROR NOT\_SUPPORTED rather than becoming a session-fatal unknown message.
+
+#### Implementation plan
+
+1. Define a typed internal PUBLISH\_DONE status mapping for every supported IETF draft.
+2. Replace Rust's `200` and `500` values with the relevant registered completion or failure codes.
+3. Make TypeScript emit PUBLISH\_DONE for drafts 17 through 19 as well as earlier supported drafts.
+4. Keep inbound PUBLISH decoding and graceful NOT\_SUPPORTED rejection unchanged.
+5. Preserve unknown received status codes internally rather than coercing them to a known value.
+6. Add Rust and TypeScript interop tests for clean completion, failure completion, and unknown received codes across the supported version matrix.
+7. Update the matching IETF implementation documentation or draft notes if repository behavior documentation needs correction.
+
+#### Branch targeting
+
+This corrects existing wire behavior without breaking a published source API, so it targets `main`.
+
+## Closes
+
+- [#3207](https://github.com/moq-dev/moq/issues/3207) - close this issue when the quest finishes

--- a/quest/m0/3208-make-2-5-ms-opus-frame-durations-work-across-bindings.md
+++ b/quest/m0/3208-make-2-5-ms-opus-frame-durations-work-across-bindings.md
@@ -1,0 +1,58 @@
+# [L] Make 2.5 ms Opus frame durations work across bindings
+
+## Goal
+
+Implement and verify the behavior tracked in [#3208](https://github.com/moq-dev/moq/issues/3208)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Native Rust supports every Opus frame duration, including 2.5 ms, and tests it. Public binding surfaces advertise the same support but cannot represent or carry it correctly:
+
+- UniFFI exposes `frame_duration_ms: u32` and converts with integer milliseconds, so 2.5 is unrepresentable: [audio.rs](https://github.com/moq-dev/moq/blob/7494084aaf7e2fa6abe553ac83101ac4ef19f33a/rs/moq-ffi/src/audio.rs#L68-L79)
+- C has the same integer representation and conversion.
+- JavaScript accepts a floating-point millisecond value, then routes it through an integer catalog field and rejects 2.5.
+- The native encoder validates exact durations of 2.5, 5, 10, 20, 40, and 60 ms.
+
+Rounding to 2 or 3 ms is not valid because the Opus backend rejects both.
+
+This overlaps #3189 only at the 20 ms default. The representational bug is cross-surface and should be fixed independently.
+
+#### Settled API
+
+Keep the concise `frame_duration_ms` spelling:
+
+- UniFFI: `f64`, default `20.0`
+- C: `double`, with zero selecting the 20 ms default
+- JavaScript: retain floating-point `Time.Milli`
+
+Validate that the value is exactly one of `2.5, 5, 10, 20, 40, 60`.
+
+#### Implementation plan
+
+1. Change the FFI and C scalar types to floating-point milliseconds and perform exact supported-value validation before converting to `Duration`.
+2. Add the UniFFI 20 ms default in coordination with #3189 so the field is changed once.
+3. Preserve the exact JavaScript frame duration separately from catalog metadata.
+4. Encode catalog jitter as the ceiling of the duration because jitter is an integer upper-bound hint, not the exact encoder cadence.
+5. Update Python, Swift, Kotlin, Go, and C documentation and examples generated or wrapped from these types.
+6. Add 2.5 ms regression tests for FFI, C, and JavaScript, plus default-construction coverage.
+
+#### Branch targeting
+
+Changing the published FFI and C field types is source-breaking, so this targets `dev`.
+
+## Closes
+
+- [#3208](https://github.com/moq-dev/moq/issues/3208) - close this issue when the quest finishes
+
+## Related
+
+- [#3189: Add UniFFI defaults to caller-constructed configuration records](/quest/m0/3189-add-uniffi-defaults-to-caller-constructed-configuration.md) - related open work

--- a/quest/m0/3221-config-stop-cli-defaults-from-clobbering-toml-values.md
+++ b/quest/m0/3221-config-stop-cli-defaults-from-clobbering-toml-values.md
@@ -1,0 +1,71 @@
+# [M] config: stop CLI defaults from clobbering TOML values
+
+## Goal
+
+Implement and verify the behavior tracked in [#3221](https://github.com/moq-dev/moq/issues/3221)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Problem
+
+Target branch: `dev`.
+
+`rs/moq-relay/src/config.rs::Config::parse_and_merge` parses the CLI, loads the selected TOML file, then calls `config.update_from(&args)` so explicit CLI and environment values win. The final clap parse also reapplies `default_value` and `default_value_t` entries when the user did not supply those arguments, so defaults silently overwrite file values.
+
+Known affected fields include:
+
+- `moq_native::ClientConfig::bind`
+- `moq_native::Backoff::{initial, multiplier, max, timeout}`
+- `moq_native::websocket::Client::{enabled, delay}`
+- `moq_native::Log::level`
+- `moq_relay::WebConfig::ws`
+
+The existing `Option<T>` convention only protects fields whose clap declaration has no default. For example, `websocket.delay` is optional but still has `default_value = "200ms"`, so a TOML value is replaced during `update_from`.
+
+#### Failure example
+
+Given a TOML file with values such as:
+
+```toml
+[web]
+ws = false
+
+[client]
+bind = "127.0.0.1:12345"
+
+[client.websocket]
+enabled = false
+delay = "3s"
+
+[client.backoff]
+initial = "7s"
+multiplier = 3
+max = "30s"
+timeout = "2m"
+
+[log]
+level = "debug"
+```
+
+running `moq-relay <file>` without matching CLI overrides resets those fields to clap defaults. The most serious example is `web.ws = false` becoming `true`, which can expose a listener mode the operator explicitly disabled.
+
+#### Expected
+
+Only values explicitly supplied through CLI arguments or environment variables should override TOML. Parser defaults should fill fields only when no source provided a value.
+
+#### Suggested direction
+
+Fix the merge centrally instead of relying on every flattened config field to use a particular Rust type. Possible shapes are an all-optional CLI overlay, or using clap value-source metadata so only command-line and environment values are applied after TOML deserialization.
+
+Add table-driven regression coverage for nested flattened structs, bare scalar defaults, optional fields with clap defaults, environment overrides, and explicit CLI overrides.
+
+## Closes
+
+- [#3221](https://github.com/moq-dev/moq/issues/3221) - close this issue when the quest finishes

--- a/quest/m0/679-multi-threaded-udp-receiver.md
+++ b/quest/m0/679-multi-threaded-udp-receiver.md
@@ -1,0 +1,29 @@
+# [S] Multi-threaded UDP Receiver
+
+## Goal
+
+Implement and verify the behavior tracked in [#679](https://github.com/moq-dev/moq/issues/679)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Quinn has a quite annoying limitation. It uses a single thread to receive all UDP packets.
+
+This means `moq-relay` won't scale to multiple threads without significant packet loss. The same applies to a client if it's downloading/uploading a ton of media.
+
+There's a few potential approaches:
+
+1. Fix [quinn](https://docs.rs/quinn/latest/quinn/) (they want it)
+2. Try using tokio-quiche (seems to support multi-sockets?)
+
+I started on the 2nd approach with [web-transport-quiche](https://github.com/kixelated/web-transport/tree/main/web-transport-quiche) but I haven't tested it. It has some annoying limitations that might require rewriting `tokio-quiche`...
+
+## Closes
+
+- [#679](https://github.com/moq-dev/moq/issues/679) - close this issue when the quest finishes

--- a/quest/m0/685-moq-relay-simultaneously-serve-hls-dash-and-hang.md
+++ b/quest/m0/685-moq-relay-simultaneously-serve-hls-dash-and-hang.md
@@ -1,0 +1,107 @@
+# [XL] moq-relay: Simultaneously serve HLS, DASH, and HANG
+
+## Goal
+
+Implement and verify the behavior tracked in [#685](https://github.com/moq-dev/moq/issues/685)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+The goal is to serve multiple protocols over the same MoQ relay, reusing the cache and allowing for gradual adoption. Any standard HLS/DASH player should work out of the box if given a correct URL. This way companies can experiment with MoQ without upgrading every single client (ex. smart TVs).
+
+The hang publisher could create multiple tracks:
+
+- `audio.m4s` (requires #682)
+- `video.m4s`
+- `init.mp4`
+- `catalog.json`
+- `main.m3u8` (static, lists all renditions)
+- `playlist.m3u8`
+- `playlist.mpd` (optional)
+
+Each segment would be a MoQ group, and each sub-segment (aka fMP4 fragment) would be a MoQ frame. We would start with fragmenting every 250ms or something.
+
+`catalog.json` would point to `audio.fmp4` and `video.fmp4`. The hang player would treat them like normal MoQ tracks, with the exception that I'll need to add 250ms to the jitter buffer size (add a new field to the catalog).
+
+#### HLS Playlist
+
+`playlist.m3u8` is where the magic happens. With #684 we could serve the playlist and segments via HTTP. We would generate a playlist that looks like:
+
+```
+#EXT-X-MAP:URI="init.mp4"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=69&frame=0"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=69&frame=1"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=69&frame=2"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=69&frame=3"
+#EXTINF:1.0,
+video.m4s?group=69
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=70&frame=0"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=70&frame=1"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=70&frame=2"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=70&frame=3"
+#EXTINF:1.0,
+video.m4s?group=70
+```
+
+This will work out of the box for HLS since moq-relay concatenates frames in the same group. The `?frame` parameter would be used for LL-HLS to specify a single sub-segment instead of concatenating them.
+
+So yeah, just point a HLS player to `https://relay.moq.dev/fetch/<broadcast>/main.m3u8`
+
+#### HLS Playlist Updates
+
+The only gotcha is how to actually serve this LL-HLS playlist because we want to avoid the usual F5 refresh storm that HLS is famous for.
+
+So the idea is that the `playlist.m3u8` is split into groups/frames in such a way that we can efficiently serve it over the same (generic) moq-relay HTTP endpoint. Unfortunately, HLS players are hard-coded to send `?_HLS_msn` and `?_HLS_part` but we can reintepret them as `?group_min` and `?frame_min` respectively (to keep things generic).
+
+The publisher could produce the playlist like this:
+
+**group=70, frame=0:**
+
+```
+#EXT-X-MAP:URI="init.mp4"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=69&frame=0"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=69&frame=1"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=69&frame=2"
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=69&frame=3"
+#EXTINF:1.0,
+video.m4s?group=69
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=70&frame=0"
+```
+
+**group=70, frame=1:**
+
+```
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=70&frame=1"
+```
+
+**group=70, frame=2:**
+
+```
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=70&frame=2"
+```
+
+**group=70, frame=3:**
+
+```
+#EXT-X-PART:DURATION=0.25,URI="video.m4s?group=70&frame=3"
+#EXTINF:1.0,
+video.m4s?group=70
+```
+
+When the next subsegment is generated, group 71 is created and the process repeats.
+
+#### Conclusion
+
+If this seems overly complicated then you're right. The goal is to make `moq-relay` generic enough that it doesn't actually understand HLS, nor does it parse the playlist. This is the type of thing that *could* be deployed as a generic MoQ CDN.
+
+A proper media server would just parse the HLS playlist of course. That's still an option if we want to add a specialized `/hls` endpoint.
+
+## Closes
+
+- [#685](https://github.com/moq-dev/moq/issues/685) - close this issue when the quest finishes

--- a/quest/m0/686-fix-bbr.md
+++ b/quest/m0/686-fix-bbr.md
@@ -1,0 +1,29 @@
+# [M] Fix BBR
+
+## Goal
+
+Implement and verify the behavior tracked in [#686](https://github.com/moq-dev/moq/issues/686)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+BBR is a congestion controller that is used extensively for TCP traffic. It provides lower latency than the QUIC default of Cubic/Reno because it monitors RTT to avoid bufferbloat. It's also just better on crappy networks.
+
+Quinn has BBR support but it's horribly broken from every indication I've seen. Quiche has better BBR because it is actually tested in production.
+
+We could either:
+
+1. Switch to Quiche
+2. Port Quiche's BBR to Quinn
+
+Option 1 is possible, but it would require rewriting `tokio_quiche` at this point.
+
+## Closes
+
+- [#686](https://github.com/moq-dev/moq/issues/686) - close this issue when the quest finishes

--- a/quest/m0/697-conferencing-demo.md
+++ b/quest/m0/697-conferencing-demo.md
@@ -1,0 +1,22 @@
+# [M] Conferencing Demo
+
+## Goal
+
+Implement and verify the behavior tracked in [#697](https://github.com/moq-dev/moq/issues/697)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+There is a [hang-meet](https://github.com/kixelated/moq/tree/main/js/hang/src/meet) web component but it's extremely simple.
+
+We should steal the best, generic stuff from `hang.live` to create a proper conferencing demo. I could set up the rendering but I would want some help on the rest, especially the UI. Let me know if you're interested and I can set up the base.
+
+## Closes
+
+- [#697](https://github.com/moq-dev/moq/issues/697) - close this issue when the quest finishes

--- a/quest/m0/699-better-prioritize-ties.md
+++ b/quest/m0/699-better-prioritize-ties.md
@@ -1,0 +1,25 @@
+# [S] Better prioritize ties
+
+## Goal
+
+Implement and verify the behavior tracked in [#699](https://github.com/moq-dev/moq/issues/699)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+The way QUIC libraries provide stream prioritization is extremely limited. You can basically set an integer priority for each stream.
+
+This makes it very difficult to do things like interleave equal priorities. For example, suppose we request audio from Alice and Bob at priority 5.
+Ideally, we should prioritize the latest group for both equally, then equally deprioritize older groups.
+
+However the current implementation will break the tie based on the group number, so basically it will prioritize whoever has been live for longer. This is especially broken in the current relay implementation, because every track *should* be requested with the same priority over the backbone. Since they all tie, all data gets prioritized according to group ID.
+
+## Closes
+
+- [#699](https://github.com/moq-dev/moq/issues/699) - close this issue when the quest finishes

--- a/quest/m0/700-native-and-mobile-support.md
+++ b/quest/m0/700-native-and-mobile-support.md
@@ -1,0 +1,24 @@
+# [XL] Native and Mobile Support
+
+## Goal
+
+Implement and verify the behavior tracked in [#700](https://github.com/moq-dev/moq/issues/700)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+It's great that MoQ works on browsers. However, by primarily targeting the web, we make it harder to run MoQ natively.
+
+Obviously, we could get the Rust code working on native platforms but it lacks a lot of functionality that only exists in the JS code. We would also need a replacement for WebCodecs and rendering.
+
+Alternatively, we could figure out how to get something like React Native running using the JS code? We would need WebTransport and WebCodecs support of course so it might be the same issue.
+
+## Closes
+
+- [#700](https://github.com/moq-dev/moq/issues/700) - close this issue when the quest finishes

--- a/quest/m0/703-experimental-webgpu-renderer.md
+++ b/quest/m0/703-experimental-webgpu-renderer.md
@@ -1,0 +1,26 @@
+# [M] Experimental WebGPU renderer
+
+## Goal
+
+Implement and verify the behavior tracked in [#703](https://github.com/moq-dev/moq/issues/703)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+**WARNING** This is a pre-mature optimization or gimmick at best.
+
+We currently use [Canvas2D](https://github.com/kixelated/moq/blob/ff7cf92679e16c1d18ca5862aa4c7f73417e3c36/js/hang/src/watch/video/renderer.ts#L97) to render individual frames. This is pretty basic but works.
+
+All major browsers support WebGPU now. It has a [copyExternalImageToTexture](https://developer.mozilla.org/en-US/docs/Web/API/GPUQueue/copyExternalImageToTexture) method that apparently copies a `VideoFrame` to a renderable texture. This apparently avoids a copy so it might be faster than Canvas2D but probably not.
+
+The main benefit of WebGPU is being able to do *other* stuff, like run AI models on pixel data without copying to the CPU. Or rendering a person's face on a teapot. Or using shaders for gimmicky effects. None of this is really generic enough for a MoQ library but maybe somebody wants to have some fun.
+
+## Closes
+
+- [#703](https://github.com/moq-dev/moq/issues/703) - close this issue when the quest finishes

--- a/quest/m0/709-automatic-letsencrypt-support.md
+++ b/quest/m0/709-automatic-letsencrypt-support.md
@@ -1,0 +1,24 @@
+# [M] Automatic LetsEncrypt support
+
+## Goal
+
+Implement and verify the behavior tracked in [#709](https://github.com/moq-dev/moq/issues/709)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+One of the biggest hurdles to running `moq-relay` is getting a certificate. We could simplify the setup process by using a Acme library to automatically provision and rotate TLS certificates.
+
+LetsEncrypt has an API that performs a HTTP/TLS challenge to prove that you own a given domain name. `moq-relay` already requires a public IP address and listening on UDP, optionally listening on TCP too. We could leverage that to perform the challenge in-process without an external `certbot` process. I would use [instant-acme](https://crates.io/crates/instant-acme).
+
+Bonus points for saving the certificate to disk and only performing the challenge if it's missing or about to expire. This will avoid making LetsEncrypt a startup blocker and potentially avoid being rate limited.
+
+## Closes
+
+- [#709](https://github.com/moq-dev/moq/issues/709) - close this issue when the quest finishes

--- a/quest/m0/744-obs-hook-up-track-bitrate.md
+++ b/quest/m0/744-obs-hook-up-track-bitrate.md
@@ -1,0 +1,20 @@
+# [XS] OBS: Hook up track bitrate
+
+## Goal
+
+Implement and verify the behavior tracked in [#744](https://github.com/moq-dev/moq/issues/744)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+The simple C API will need some additions to provide stuff like the maximum bitrate. Maybe some other stuff too, like the display resolution, but I don't know what's available.
+
+## Closes
+
+- [#744](https://github.com/moq-dev/moq/issues/744) - close this issue when the quest finishes

--- a/quest/m0/816-expose-transportconfig.md
+++ b/quest/m0/816-expose-transportconfig.md
@@ -1,0 +1,26 @@
+# [M] Expose TransportConfig
+
+## Goal
+
+Implement and verify the behavior tracked in [#816](https://github.com/moq-dev/moq/issues/816)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+hello,
+
+It would be nice to be able to adjust transport window sizes, idle timeout, keep alive etc and also congestion controller used by quinn without needing to patch moq-native
+
+would that be possible?
+
+thanks
+
+## Closes
+
+- [#816](https://github.com/moq-dev/moq/issues/816) - close this issue when the quest finishes

--- a/quest/m0/823-svc-support.md
+++ b/quest/m0/823-svc-support.md
@@ -1,0 +1,22 @@
+# [M] SVC support?
+
+## Goal
+
+Implement and verify the behavior tracked in [#823](https://github.com/moq-dev/moq/issues/823)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+WebCodecs supports SVC, but somebody should actually test it out.
+
+If it works, we could add a field to the catalog indicating `layer`. The media download logic will get more complicated but it should be possible to support.
+
+## Closes
+
+- [#823](https://github.com/moq-dev/moq/issues/823) - close this issue when the quest finishes

--- a/quest/m0/863-hls-playlist-tracks.md
+++ b/quest/m0/863-hls-playlist-tracks.md
@@ -1,0 +1,44 @@
+# [M] HLS Playlist Tracks
+
+## Goal
+
+Implement and verify the behavior tracked in [#863](https://github.com/moq-dev/moq/issues/863)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+In order to get my dream of a HLS player working while pointed at `moq-relay`, we need some playlists.
+
+Can someone modify the HLS import code such that:
+
+1. Make sure any tracks we create have a reasonable extension, like `.m3u8` or `.m4s`
+2. We create a `playlist.m3u8` track for the main playlist, with a single group/frame.
+3. We create a playlist track for each rendition, for example `audio.m3u8` and `video.m3u8`.
+   - Each (unique) playlist update would be written as a new group/frame.
+4. Rewrite the playlists to be relative:
+   - The main playlist would point to `./audio.m3u8` and `./video.m3u8` or whatever the playlist tracks are called.
+   - The media playlists would point to `./audio.m4s?group=x`, or whatever the media tracks are called.
+
+With all this in place, we should be able to start a HLS import and visit:
+
+```
+http://localhost:4443/fetch/bbb/playlist.m3u8
+http://localhost:4443/fetch/bbb/audio.m3u8
+http://localhost:4443/fetch/bbb/video.m3u8
+http://localhost:4443/fetch/bbb/audio.m4s?group=xxx
+http://localhost:4443/fetch/bbb/video.m4s?group=xxx
+```
+
+The only thing that should not work yet is the `?group=` query parameter. It will instead fetch the latest group.
+
+With all of this in place, we could point a HLS player to the first URL and it should just work TM.
+
+## Closes
+
+- [#863](https://github.com/moq-dev/moq/issues/863) - close this issue when the quest finishes

--- a/quest/m0/933-video-rotation-metadata-not-propagated-from-mobile-camera.md
+++ b/quest/m0/933-video-rotation-metadata-not-propagated-from-mobile-camera.md
@@ -1,0 +1,58 @@
+# [M] Video rotation metadata not propagated from mobile camera publish to watch renderer
+
+## Goal
+
+Implement and verify the behavior tracked in [#933](https://github.com/moq-dev/moq/issues/933)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+#### Summary
+
+When publishing from a mobile device (e.g. iPhone camera via `<hang-publish>`), the video orientation is incorrect on the watch side. The phone captures in landscape natively (e.g. 640x480) even when held in portrait, but no `rotation` metadata is included in the catalog, and the watch-side renderer doesn't apply rotation even if it were present.
+
+#### Steps to Reproduce
+
+1. Open a `<hang-publish>` page on an iPhone (using WebSocket fallback via `@moq/web-transport-ws`)
+2. Select camera source, hold phone in portrait orientation
+3. Open the corresponding `<hang-watch>` page in another browser
+4. Video appears rotated 90 degrees  -  the viewer sees the image sideways
+
+#### Observed Behavior
+
+- Catalog contains `640x480` coded dimensions with no `rotation` field
+- The watch-side canvas renderer (`watch/video/renderer.js`) handles `flip` but not `rotation`
+- The publish side (`publish/video/index.d.ts`) exposes `flip` as a Signal but has no `rotation` Signal
+
+#### Expected Behavior
+
+- The publish side should detect device orientation (e.g. via `VideoFrame.rotation`, `window.screen.orientation`, or MediaStreamTrack settings) and include `rotation` in the catalog
+- The watch-side renderer should read `catalog.rotation` and apply the appropriate transform when drawing frames to canvas
+
+#### Analysis
+
+The catalog schema already supports `rotation` (it appears in the type definitions for both publish and watch catalog types). The gap is:
+
+1. **Publish**: `Video.Root` has a `flip: Signal<boolean>` but no corresponding `rotation` signal, so rotation is never set in the catalog
+2. **Watch**: `renderer.js` lines 100-105 check `catalog.flip` and apply `ctx.scale(-1, 1)` but have no corresponding rotation logic
+
+#### Environment
+
+- `@moq/hang` v0.1.2
+- `@moq/web-transport-ws` (WebSocket fallback)
+- Publishing from iPhone Safari (portrait), watching in Chrome desktop
+- Relay: `cdn.moq.dev`
+
+#### Workaround
+
+For now we're applying a CSS rotation on the watch side based on aspect ratio heuristics, but this is fragile and doesn't handle all cases correctly.
+
+## Closes
+
+- [#933](https://github.com/moq-dev/moq/issues/933) - close this issue when the quest finishes

--- a/quest/m0/980-add-support-for-dual-sockets-ipv4-ipv6.md
+++ b/quest/m0/980-add-support-for-dual-sockets-ipv4-ipv6.md
@@ -1,0 +1,24 @@
+# [M] Add support for dual-sockets (IPv4 + IPv6)
+
+## Goal
+
+Implement and verify the behavior tracked in [#980](https://github.com/moq-dev/moq/issues/980)
+within the issue's stated scope and boundaries.
+
+## Plan
+
+Use the public issue's scope, implementation notes, and acceptance criteria
+below as the starting plan. Reconcile paths and assumptions with the current
+tree before implementation.
+
+### Issue context
+
+Linux will let you bind to IPv6 and automatically translate any IPv4 packets. However, Windows doesn't?
+
+Additionally, the client currently dials DNS and chooses the first entry. Not only might it be the wrong protocol (we should check), but the server might not actually be listening on that IP.
+
+Unfortunately, I think we should implement happy-eyeballs. Race the IPv4 and IPv6 connections over separate IPv4/IPv6 sockets.
+
+## Closes
+
+- [#980](https://github.com/moq-dev/moq/issues/980) - close this issue when the quest finishes

--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -1,0 +1,181 @@
+# m0: open issue backlog
+
+## Goal
+
+Resolve every public issue represented here while keeping issue discussion on
+GitHub and durable implementation plans beside the code.
+
+## Plan
+
+Each entry is an independently completable quest. The list starts in GitHub's
+newest-first order because no explicit issue priority exists. Re-rank entries as
+priorities are decided, split oversized quests before implementation, and delete
+each quest in the PR that completes or abandons it.
+
+## Quests
+
+- [#3221](/quest/m0/3221-config-stop-cli-defaults-from-clobbering-toml-values.md) - config: stop CLI defaults from clobbering TOML values
+- [#3208](/quest/m0/3208-make-2-5-ms-opus-frame-durations-work-across-bindings.md) - Make 2.5 ms Opus frame durations work across bindings
+- [#3207](/quest/m0/3207-send-valid-publish-done-statuses-for-every-supported-ietf.md) - Send valid PUBLISH_DONE statuses for every supported IETF draft
+- [#3205](/quest/m0/3205-moq-uring-register-reusable-io-uring-enter-wait-arguments.md) - moq-uring: register reusable io_uring_enter wait arguments
+- [#3204](/quest/m0/3204-moq-uring-register-tx-pool-buffers-for-zero-copy-sends.md) - moq-uring: register TX-pool buffers for zero-copy sends
+- [#3203](/quest/m0/3203-moq-uring-add-opt-in-napi-busy-polling.md) - moq-uring: add opt-in NAPI busy polling
+- [#3202](/quest/m0/3202-moq-uring-use-fixed-file-slots-for-worker-udp-sockets.md) - moq-uring: use fixed-file slots for worker UDP sockets
+- [#3201](/quest/m0/3201-moq-uring-use-sendmsg-zc-for-large-udp-gso-trains.md) - moq-uring: use SENDMSG_ZC for large UDP GSO trains
+- [#3200](/quest/m0/3200-moq-uring-batch-completion-wakeups-with-min-timeout.md) - moq-uring: batch completion wakeups with MIN_TIMEOUT
+- [#3199](/quest/m0/3199-moq-uring-remove-sq-indirection-and-per-enter-ring-fd.md) - moq-uring: remove SQ indirection and per-enter ring fd lookup
+- [#3193](/quest/m0/3193-expose-a-cancellable-route-watch-api-in-python.md) - Expose a cancellable route watch API in Python
+- [#3190](/quest/m0/3190-align-origin-broadcast-creation-naming-across-language.md) - Align origin broadcast creation naming across language bindings
+- [#3189](/quest/m0/3189-add-uniffi-defaults-to-caller-constructed-configuration.md) - Add UniFFI defaults to caller-constructed configuration records
+- [#3188](/quest/m0/3188-make-every-blocking-go-operation-cancellable-with-context.md) - Make every blocking Go operation cancellable with context.Context
+- [#3187](/quest/m0/3187-preserve-structured-protocol-error-codes-across-ffi-and-c.md) - Preserve structured protocol error codes across FFI and C bindings
+- [#3174](/quest/m0/3174-js-publish-audio-encoder-processes-the-first-frame-before.md) - js/publish: Audio Encoder processes the first frame before applying mute or volume
+- [#3173](/quest/m0/3173-moq-uring-worker-drop-submits-an-uncancelled-receive-and.md) - moq-uring: Worker drop submits an uncancelled receive and stalls for 3.2 seconds
+- [#3172](/quest/m0/3172-js-net-a-terminal-reload-failure-can-reconnect-after.md) - js/net: a terminal Reload failure can reconnect after closed rejects
+- [#3171](/quest/m0/3171-js-publish-fanout-with-a-zero-queue-spins-forever.md) - js/publish: Fanout with a zero queue spins forever
+- [#3165](/quest/m0/3165-moq-audio-bound-and-coalesce-playback-driver-commands.md) - moq-audio: bound and coalesce playback driver commands
+- [#3164](/quest/m0/3164-moq-audio-remove-heap-activity-and-blocking-locks-from.md) - moq-audio: remove heap activity and blocking locks from the capture callback
+- [#3161](/quest/m0/3161-retention-should-reclaim-idle-open-groups-now-that-expiry.md) - Retention should reclaim idle open groups now that expiry is timestamp-only
+- [#3160](/quest/m0/3160-moq-tokio-a-noq-only-build-fails-on-three-unrelated.md) - moq-tokio: a noq-only build fails on three unrelated errors, because no crypto provider is selected
+- [#3141](/quest/m0/3141-uring-a-close-can-be-lost-when-the-worker-is-torn-down.md) - uring: a close can be lost when the worker is torn down before its send completes
+- [#3139](/quest/m0/3139-moqsrc-a-rendition-nobody-answers-keeps-the-session-alive.md) - moqsrc: a rendition nobody answers keeps the session alive after the catalog closes
+- [#3137](/quest/m0/3137-moqsrc-bound-the-pending-rendition-subscriptions-a.md) - moqsrc: bound the pending rendition subscriptions a catalog can open
+- [#3129](/quest/m0/3129-moq-uring-write-the-webtransport-stream-header-at-open.md) - moq-uring: write the WebTransport stream header at open time, so finish() never owes one
+- [#3126](/quest/m0/3126-moq-bench-every-readme-example-fails-to-parse-and.md) - moq-bench: every README example fails to parse, and cumulative latency percentiles cannot be windowed to steady state
+- [#3124](/quest/m0/3124-moq-tokio-the-quiche-backend-cannot-serve-per-core.md) - moq-tokio: the quiche backend cannot serve per-core workers, so io_uring has no matched control to be measured against
+- [#3123](/quest/m0/3123-moq-bench-a-lagged-group-permanently-ends-the.md) - moq-bench: a lagged group permanently ends the subscription, so offered load silently decays mid-run
+- [#3122](/quest/m0/3122-moq-uring-2-5-of-relay-cpu-is-vdso-clock-reads-the-drive.md) - moq-uring: ~2.5% of relay CPU is vdso clock reads; the drive loop and its callers each re-read Instant::now()
+- [#3120](/quest/m0/3120-moq-uring-the-connection-driver-self-wakes-after-every.md) - moq-uring: the connection driver self-wakes after every GSO train, re-walking every ready stream per turn
+- [#3119](/quest/m0/3119-moq-uring-p50-latency-collapses-at-high-connections-per.md) - moq-uring: p50 latency collapses at high connections per worker; the UDP pools are fixed at 64 tx / 16 rx and the relay never scales them
+- [#3115](/quest/m0/3115-moqsink-the-publication-has-no-generation-so-a-flush.md) - moqsink: the publication has no generation, so a flush after EOS cannot restart it
+- [#3112](/quest/m0/3112-moq-relay-io-uring-listener-cannot-authenticate-mtls-peers.md) - moq-relay: io_uring listener cannot authenticate mTLS peers
+- [#3111](/quest/m0/3111-moq-uring-unmap-err-reports-unmappable-http-3-codes-as.md) - moq-uring: unmap_err reports unmappable HTTP/3 codes as MoQ application errors
+- [#3107](/quest/m0/3107-moq-relay-certificate-sha256-is-empty-when-io-uring-owns.md) - moq-relay: /certificate.sha256 is empty when io_uring owns QUIC
+- [#3100](/quest/m0/3100-dart-flutter-bindings-via-uniffi.md) - Dart/Flutter bindings via UniFFI
+- [#3094](/quest/m0/3094-ci-cargo-doc-collides-on-target-doc-moq-between-libmoq.md) - CI: cargo doc collides on target/doc/moq between libmoq and moq-cli
+- [#3092](/quest/m0/3092-moq-sock-make-the-reuseport-groups-invariants.md) - moq-sock: make the reuseport group's invariants unrepresentable, not documented
+- [#3087](/quest/m0/3087-relay-mtls-peers-bypass-auth-api-mode-so-proxy-grants.md) - relay: mTLS peers bypass --auth-api-mode, so proxy grants can't refuse or scope them
+- [#3086](/quest/m0/3086-refactor-net-make-group-delivery-order-a-handle-and-move.md) - refactor(net): make group delivery order a handle, and move timestamp-based skipping into moq-net
+- [#3080](/quest/m0/3080-fix-watch-audio-ring-truncate-can-race-the-worklet-reader.md) - fix(watch): audio ring truncate can race the worklet reader for one quantum
+- [#3076](/quest/m0/3076-moq-relay-publish-is-unimplemented-by-design-make-the.md) - moq-relay: PUBLISH is unimplemented by design - make the rejection fail fast for clients that wait
+- [#3072](/quest/m0/3072-js-net-a-lite-announce-ok-with-hop-id-0-is-rejected-but.md) - js/net: a lite ANNOUNCE_OK with Hop ID 0 is rejected, but the draft permits it
+- [#3060](/quest/m0/3060-moq-net-ban-hop-id-0-from-hop-chains.md) - moq-net: ban Hop ID 0 from hop chains
+- [#3058](/quest/m0/3058-moq-relay-a-revalidation-re-check-cannot-update-a.md) - moq-relay: a revalidation re-check cannot update a session's tier, and changes its alias only by closing it
+- [#3056](/quest/m0/3056-watch-video-decoder-captures-the-rewind-generation-at.md) - watch: video decoder captures the rewind generation at output time, not submit time
+- [#3051](/quest/m0/3051-config-merge-empty-lists-lose-to-the-environment-and-the.md) - Config merge: empty lists lose to the environment, and the file outranks it
+- [#3049](/quest/m0/3049-moq-net-outbound-hop-path-construction-is-never-validated.md) - moq-net: outbound HOP_PATH construction is never validated
+- [#3046](/quest/m0/3046-fold-moq-token-into-moq-token-via-a-usage-executable-view.md) - Fold moq-token into moq token via a Usage executable view
+- [#3023](/quest/m0/3023-payloadprocessor-for-encryption-signing.md) - PayloadProcessor for encryption/signing
+- [#3021](/quest/m0/3021-moq-gst-anchor-generated-media-timelines-to-wall-clock.md) - moq-gst: anchor generated media timelines to wall clock
+- [#3002](/quest/m0/3002-no-test-drives-a-late-group-through-the-ietf-dispatch-loop.md) - No test drives a late group through the IETF dispatch loop
+- [#3001](/quest/m0/3001-ietf-stream-resets-send-moq-lite-error-codes-so-routine.md) - IETF stream resets send moq-lite error codes, so routine events read as INTERNAL_ERROR
+- [#3000](/quest/m0/3000-track-teardown-on-poll-unused-is-not-atomic-against-a.md) - Track teardown on poll_unused is not atomic against a consumer reattaching
+- [#2999](/quest/m0/2999-js-net-cannot-send-a-stream-reset-code-so-every.md) - js/net cannot send a stream reset code, so every cancellation reads as INTERNAL_ERROR
+- [#2991](/quest/m0/2991-net-coalesce-dynamic-tracks-and-preserve-sequences-across.md) - net: coalesce dynamic tracks and preserve sequences across replacements
+- [#2985](/quest/m0/2985-js-net-path-keyed-publisher-state-goes-stale-when-a.md) - js/net: path-keyed publisher state goes stale when a broadcast is replaced
+- [#2981](/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md) - moq-audio: nothing in the decode or playback path models a media gap
+- [#2980](/quest/m0/2980-moq-relay-nothing-guards-the-socket-capturing-acceptor.md) - moq-relay: nothing guards the socket-capturing acceptor being installed on a listener
+- [#2979](/quest/m0/2979-moq-tokio-does-not-compile-with-no-default-features-and.md) - moq-tokio does not compile with --no-default-features, and workspace feature unification hides it
+- [#2964](/quest/m0/2964-quic-workers-dropping-one-split-server-resizes-the.md) - QUIC workers: dropping one split() Server resizes the reuseport group
+- [#2934](/quest/m0/2934-export-ts-re-emits-a-stored-tdt-on-the-30-s-slot-grid-the.md) - export ts re-emits a stored TDT on the 30 s slot grid: the clock arrives ~14 s late, and below that rate it steps a receiver backwards
+- [#2933](/quest/m0/2933-moq-ffi-moqroute-round-trip-erases-a-routes-cold-cost.md) - moq-ffi: MoqRoute round-trip erases a route's cold cost
+- [#2924](/quest/m0/2924-moq-relay-tls-rotation-is-not-atomic-across-thread-per.md) - moq-relay: TLS rotation is not atomic across thread-per-core QUIC workers
+- [#2907](/quest/m0/2907-bind-the-browser-through-moq-ffi-uniffi-instead-of-a.md) - Bind the browser through moq-ffi/UniFFI instead of a second hand-written wasm API
+- [#2895](/quest/m0/2895-add-an-atomic-readiness-gate-for-origin-broadcasts.md) - Add an atomic readiness gate for Origin broadcasts
+- [#2893](/quest/m0/2893-video-validate-pipewire-dma-buf-capture-on-kde-hardware.md) - video: validate PipeWire DMA-BUF capture on KDE hardware
+- [#2892](/quest/m0/2892-js-net-enforce-the-subscriber-latency-budget.md) - js/net: enforce the subscriber latency budget
+- [#2875](/quest/m0/2875-thread-per-core-relay-runtime-io-uring-quiche-ebpf.md) - Thread-per-core relay runtime: io-uring + quiche, eBPF connection steering, rename moq-native to moq-tokio
+- [#2873](/quest/m0/2873-moq-net-enumerate-and-resolve-historical-broadcast.md) - moq-net: enumerate and resolve historical broadcast generations by path and epoch
+- [#2870](/quest/m0/2870-moq-hls-a-named-sibling-rendition-is-pinned-too-late-to.md) - moq-hls: a named sibling rendition is pinned too late to survive a same-path republish
+- [#2868](/quest/m0/2868-obs-the-plugin-targets-obs-31-1-1-while-linux-ci-links.md) - obs: the plugin targets OBS 31.1.1 while Linux CI links against nixpkgs' 32.1.2
+- [#2860](/quest/m0/2860-cpp-obs-moq-source-cpp-has-no-test-coverage.md) - cpp/obs: moq-source.cpp has no test coverage
+- [#2859](/quest/m0/2859-passthrough-imports-reserve-no-bandwidth-so-a-co-resident.md) - Passthrough imports reserve no bandwidth, so a co-resident encoder over-targets
+- [#2858](/quest/m0/2858-transcode-ladders-encode-every-live-rung-at-full-bitrate.md) - Transcode ladders encode every live rung at full bitrate over one connection
+- [#2857](/quest/m0/2857-bindings-cant-reach-encoder-rate-control-so-every-non.md) - Bindings can't reach encoder rate control, so every non-Rust publisher ignores congestion
+- [#2853](/quest/m0/2853-quiche-with-a-pinned-source-port-can-dial-only-a-broken.md) - quiche with a pinned source port can dial only a broken IPv4 address
+- [#2850](/quest/m0/2850-js-net-give-reader-a-synchronous-decode-so-the-publisher.md) - js/net: give Reader a synchronous decode so the publisher need not read controls ahead
+- [#2849](/quest/m0/2849-moq-import-ts-a-truncated-or-spliced-opus-pes-ends-the.md) - moq import ts: a truncated or spliced Opus PES ends the session
+- [#2848](/quest/m0/2848-follow-the-bandwidth-grant-in-moq-audio-instead-of.md) - Follow the bandwidth grant in moq-audio instead of holding a fixed reservation
+- [#2847](/quest/m0/2847-the-quinn-backends-send-bandwidth-estimate-is-cwnd-rtt.md) - The quinn backend's send-bandwidth estimate is cwnd/rtt, not a rate
+- [#2838](/quest/m0/2838-js-flate-codec-rejects-frames-that-inflate-past-the.md) - js/flate: "codec rejects frames that inflate past the default cap" times out under parallel test load
+- [#2835](/quest/m0/2835-moq-wasm-bind-track-dynamic-so-a-browser-publisher-can.md) - moq-wasm: bind track::Dynamic so a browser publisher can serve cache-miss fetches
+- [#2833](/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md) - moq export ts: a rewound timeline stalls the SI table cadence until the media clock catches up
+- [#2829](/quest/m0/2829-moq-export-ts-the-audio-video-interleave-is-decided-by.md) - moq export ts: the audio/video interleave is decided by arrival timing, so two exporters of one broadcast render the same media in different orders
+- [#2822](/quest/m0/2822-moq-wasm-bind-the-datagram-path-append-datagram-recv.md) - moq-wasm: bind the datagram path (append_datagram / recv_datagram)
+- [#2819](/quest/m0/2819-moq-video-carry-pipewire-dma-bufs-safely-into-the-vulkan.md) - moq-video: carry PipeWire DMA-BUFs safely into the Vulkan renderer
+- [#2815](/quest/m0/2815-divide-the-connection-bandwidth-estimate-among-concurrent.md) - Divide the connection bandwidth estimate among concurrent encoders
+- [#2813](/quest/m0/2813-capture-on-ios-is-software-only-not-hardware.md) - Capture on iOS is software only , not hardware
+- [#2812](/quest/m0/2812-watch-has-audio-stutter-on-ios-on-https-moq-dev-watch.md) - Watch has Audio stutter on iOS on https://moq.dev/watch/
+- [#2808](/quest/m0/2808-js-net-publisher-bounds-snapshot-is-not-atomic-with-the.md) - js/net: publisher bounds snapshot is not atomic with the group pop (residual race)
+- [#2807](/quest/m0/2807-js-net-a-frame-precise-raised-start-floor-is-not-honored.md) - js/net: a frame-precise raised start floor is not honored for a group already in hand
+- [#2806](/quest/m0/2806-js-net-the-draft-14-15-adapter-keeps-one-request-per.md) - js/net: the draft-14/15 adapter keeps one request per namespace, so a duplicate strands the first
+- [#2799](/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md) - moq-video: capture negotiates twice, so a window resize between the probe and the first subscriber strands consumers that fixed on the first snapshot
+- [#2798](/quest/m0/2798-moq-import-ts-an-audio-resync-is-silent-no-log-no-counter.md) - moq import ts: an audio resync is silent - no log, no counter, no downstream signal
+- [#2788](/quest/m0/2788-moq-transcode-run-cant-bootstrap-from-a-demand-gated.md) - moq-transcode: run() can't bootstrap from a demand-gated source that doesn't advertise its geometry
+- [#2779](/quest/m0/2779-moq-export-ts-continuity-counters-are-numbered-from.md) - moq export ts: continuity counters are numbered from process state, so two exporters of the same broadcast emit streams that can never be compared
+- [#2774](/quest/m0/2774-collapse-reload-and-shared-into-one-connection-class.md) - Collapse Reload and Shared into one Connection class
+- [#2756](/quest/m0/2756-origin-announce-only-entries-advertise-on-demand-content.md) - origin: announce-only entries, advertise on-demand content without instantiating broadcasts
+- [#2735](/quest/m0/2735-hang-opt-in-viewer-feedback-broadcasts-sampled-per-viewer.md) - hang: opt-in viewer feedback broadcasts (sampled per-viewer QoS)
+- [#2734](/quest/m0/2734-hang-publisher-reported-stats-track-catalog-stats-section.md) - hang: publisher-reported stats track (catalog stats section)
+- [#2733](/quest/m0/2733-moq-net-stats-per-subscription-send-backlog-queued-vs.md) - moq-net stats: per-subscription send backlog (queued vs delivered) + skip counters
+- [#2714](/quest/m0/2714-per-subscriber-path-predicate-for-originconsumer-0-1-x.md) - Per-subscriber path predicate for OriginConsumer (0.1.x) / AnnounceConsumer (0.2.x)
+- [#2709](/quest/m0/2709-per-broadcast-bandwidth-estimates-and-reservation.md) - per-broadcast bandwidth estimates and reservation
+- [#2708](/quest/m0/2708-origin-open-the-announce-interest-lazily-on-first-consumer.md) - origin: open the announce interest lazily, on first consumer
+- [#2696](/quest/m0/2696-re-evaluate-the-client-server-split-in-cli-arguments.md) - Re-evaluate the client/server split in CLI arguments
+- [#2676](/quest/m0/2676-libmoq-process-exit-can-abort-in-glibcs-pthread-tpp.md) - libmoq: process exit can abort in glibc's __pthread_tpp_change_priority
+- [#2628](/quest/m0/2628-every-moq-watch-dials-its-own-session-reuse-one.md) - Every <moq-watch> dials its own session: reuse one WebTransport connection per relay URL and keep it alive briefly while detached
+- [#2627](/quest/m0/2627-the-moq-watch-re-insertion-grace-is-one-microtask-a.md) - The <moq-watch> re-insertion grace is one microtask: a detach spanning any yield closes and redials the WebTransport session
+- [#2624](/quest/m0/2624-moq-native-goaway-redirect-guard-classifies-hosts-by-name.md) - moq-native: GOAWAY redirect guard classifies hosts by name, not by resolved address
+- [#2610](/quest/m0/2610-dynamic-announcements-broadcast-epochs-and-ended-vod.md) - Dynamic announcements, broadcast epochs, and ended (VOD) broadcasts
+- [#2609](/quest/m0/2609-moq-ffi-expose-moq-natives-reconnect-bindings-get-a-one.md) - moq-ffi: expose moq-native's reconnect - bindings get a one-shot session that stalls silently
+- [#2532](/quest/m0/2532-publish-files-by-demuxing-and-decoding-them-not-by.md) - Publish files by demuxing and decoding them, not by capturing a MediaStreamTrack
+- [#2527](/quest/m0/2527-publish-video-breaks-when-the-publishers-window-is.md) - Publish video breaks when the publisher's window is minimized, on every browser using the MediaStreamTrackProcessor polyfill
+- [#2517](/quest/m0/2517-net-splice-route-and-connection-changes-within-an-active.md) - net: splice route and connection changes within an active group
+- [#2481](/quest/m0/2481-merge-iroh-lives-native-media-stack-into-moq-video-moq.md) - Merge iroh-live's native media stack into moq-video/moq-audio (upstreaming plan)
+- [#2405](/quest/m0/2405-js-net-connect-logs-on-every-connection-at-the-wrong.md) - js/net: connect() logs on every connection at the wrong level and prints the JWT in the URL
+- [#2401](/quest/m0/2401-publisher-tab-reload-strands-watchers-on-the-stale.md) - Publisher tab reload strands watchers on the stale broadcast: ROUTE_LINGER (5s) expires before a real re-publish reconnects
+- [#2388](/quest/m0/2388-safari-stops-delivering-new-incoming-unidirectional.md) - Safari stops delivering new incoming unidirectional streams after roughly 7000 on a session; one stream per group exhausts that in about two minutes of playback
+- [#2318](/quest/m0/2318-js-net-remaining-capability-gaps-vs-rs-moq-net-setup-role.md) - js/net: remaining capability gaps vs rs/moq-net (SETUP role, finish_at and final sequence, range controls, typed errors)
+- [#2296](/quest/m0/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md) - moq-native: bring the quiche backend to quinn/noq feature parity
+- [#2284](/quest/m0/2284-moq-net-keyframe-request-pli-equivalent-for-fast-tune-in.md) - moq-net: keyframe request (PLI equivalent) for fast tune-in
+- [#2282](/quest/m0/2282-moq-audio-echo-cancellation-agc-noise-suppression-for.md) - moq-audio: echo cancellation / AGC / noise suppression for native capture
+- [#2281](/quest/m0/2281-moq-cli-generic-broadcast-recording-and-paced-replay-all.md) - moq-cli: generic broadcast recording and paced replay (all tracks + catalog)
+- [#2280](/quest/m0/2280-hang-caption-and-subtitle-text-tracks.md) - hang: caption and subtitle text tracks
+- [#2279](/quest/m0/2279-hang-typed-scte-35-ad-cue-signaling-carried-opaquely.md) - hang: typed SCTE-35 / ad cue signaling (carried opaquely today, unreadable by players)
+- [#2278](/quest/m0/2278-watch-absolute-wall-clock-latency-target-for-synchronized.md) - watch: absolute wall-clock latency target for synchronized playback across viewers
+- [#2277](/quest/m0/2277-hang-end-to-end-encryption-per-broadcast-key-relay.md) - hang: end-to-end encryption (per-broadcast key, relay carries opaque payloads)
+- [#2276](/quest/m0/2276-moq-native-enable-quic-multipath-for-bonded-contribution.md) - moq-native: enable QUIC multipath for bonded contribution (noq already implements it)
+- [#2275](/quest/m0/2275-dvr-rewind-and-time-shift-a-live-broadcast-timeline-fetch.md) - DVR: rewind and time-shift a live broadcast (timeline + FETCH exist, durable storage doesn't)
+- [#2272](/quest/m0/2272-moq-cli-remaining-work-for-capture-and-playback-window.md) - moq-cli: remaining work for capture and playback (window/app capture, device enumeration, native player)
+- [#2248](/quest/m0/2248-moq-mux-rebase-fmp4-export-timestamps-for-late-subscribers.md) - moq-mux: rebase fMP4 export timestamps for late subscribers
+- [#2217](/quest/m0/2217-moq-ffi-preserve-active-restart-ended-announcement.md) - moq-ffi: preserve Active/Restart/Ended announcement lifecycle (AI review)
+- [#2216](/quest/m0/2216-js-net-expose-typed-announcement-status-instead-of-active.md) - js/net: expose typed announcement status instead of active boolean (AI review)
+- [#2155](/quest/m0/2155-js-net-full-subscription-model-ordered-stale-range-and.md) - js/net: full Subscription model (ordered/stale/range) and Subscriber.update()
+- [#2153](/quest/m0/2153-go-moq-wrapper-catch-up-stats-hops-tls-options-media-on.md) - go/moq: wrapper catch-up (stats, hops, TLS options, media-on-track)
+- [#2152](/quest/m0/2152-libmoq-c-abi-catch-up-with-the-moq-ffi-surface.md) - libmoq: C ABI catch-up with the moq-ffi surface
+- [#2147](/quest/m0/2147-moq-video-10-bit-hevc-and-av1-support-in-the-nvidia-codec.md) - moq-video: 10-bit HEVC and AV1 support in the NVIDIA codec path
+- [#2143](/quest/m0/2143-moq-ffi-0-2-27-moqmediaconsumer-returns-moqframe.md) - moq-ffi 0.2.27+: MoqMediaConsumer returns MoqFrame.timestampUs=0 for all frames after timeline-track migration (PR #2109)
+- [#2075](/quest/m0/2075-mirror-catalog-reservation-gating-in-moq-hang-js-hang.md) - Mirror catalog reservation gating in @moq/hang (js/hang)
+- [#2067](/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md) - Test open-GOP H.264 tune-in end to end (leading-picture handling)
+- [#1838](/quest/m0/1838-tr-101-290-monitoring-requirements-broadcast-contribution.md) - TR 101 290 monitoring: requirements (broadcast/contribution health metrics)
+- [#1837](/quest/m0/1837-moq-video-remaining-work-codecs-platforms-decode-hw.md) - moq-video: remaining work (codecs, platforms, decode, HW validation)
+- [#1384](/quest/m0/1384-moq-signals-improvements.md) - @moq/signals improvements
+- [#1310](/quest/m0/1310-why-use-the-worklet-plugin.md) - why use the worklet plugin?
+- [#1238](/quest/m0/1238-default-to-enabled-true.md) - Default to enabled: true
+- [#1095](/quest/m0/1095-avoid-allocation-in-axum-tungstenite-websocket-message.md) - Avoid allocation in axum/tungstenite WebSocket message conversion
+- [#1073](/quest/m0/1073-make-origin-lifecycle-caller-driven.md) - Make Origin lifecycle caller-driven
+- [#1059](/quest/m0/1059-init-tracks-for-cmaf.md) - Init tracks for CMAF
+- [#980](/quest/m0/980-add-support-for-dual-sockets-ipv4-ipv6.md) - Add support for dual-sockets (IPv4 + IPv6)
+- [#933](/quest/m0/933-video-rotation-metadata-not-propagated-from-mobile-camera.md) - Video rotation metadata not propagated from mobile camera publish to watch renderer
+- [#863](/quest/m0/863-hls-playlist-tracks.md) - HLS Playlist Tracks
+- [#823](/quest/m0/823-svc-support.md) - SVC support?
+- [#816](/quest/m0/816-expose-transportconfig.md) - Expose TransportConfig
+- [#744](/quest/m0/744-obs-hook-up-track-bitrate.md) - OBS: Hook up track bitrate
+- [#709](/quest/m0/709-automatic-letsencrypt-support.md) - Automatic LetsEncrypt support
+- [#703](/quest/m0/703-experimental-webgpu-renderer.md) - Experimental WebGPU renderer
+- [#700](/quest/m0/700-native-and-mobile-support.md) - Native and Mobile Support
+- [#699](/quest/m0/699-better-prioritize-ties.md) - Better prioritize ties
+- [#697](/quest/m0/697-conferencing-demo.md) - Conferencing Demo
+- [#686](/quest/m0/686-fix-bbr.md) - Fix BBR
+- [#685](/quest/m0/685-moq-relay-simultaneously-serve-hls-dash-and-hang.md) - moq-relay: Simultaneously serve HLS, DASH, and HANG
+- [#679](/quest/m0/679-multi-threaded-udp-receiver.md) - Multi-threaded UDP Receiver

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -42,6 +42,7 @@ Layered roughly transport -> container/format -> media -> apps/bindings.
 - `moq-boy` (bin): crowd-controlled Game Boy emulator publisher (blocking emulator thread + async monitor tasks).
 - `moq-token` (lib): JWT auth. `Claims`, `Algorithm`, `KeyMaterial` (EC/RSA/OCT/OKP), JWKS. No clap, no anyhow: the command surface lives a layer up.
 - `moq-token-cli` (lib+bin, `moq-token`): the generate/sign/verify commands, as `moq_token_cli::Args`. The `moq-token` binary flattens it and `moq token` (moq-cli) nests it, so there's one implementation and two entry points. It's a lib so moq-cli can reuse it without pulling clap and anyhow into the `moq-token` library's API.
+- `quest` (lib+bin): validates the interlinked Markdown plans under `quest/`, including links, questline indexes, allowed headings, and acyclic blockers.
 
 **Bindings**
 

--- a/rs/quest/Cargo.toml
+++ b/rs/quest/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "quest"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+authors = ["Luke Curley"]
+license = "MIT OR Apache-2.0"
+publish = false
+description = "Structural validator for the quest tree: the interlinked Markdown plans under quest/, whose contract is quest/AGENTS.md. Enforces link resolution, the questline index, the heading vocabulary, and an acyclic Required graph, so a structural mistake fails the PR instead of the next reader."
+
+[[bin]]
+name = "quest"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+pulldown-cmark.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/rs/quest/src/doc.rs
+++ b/rs/quest/src/doc.rs
@@ -1,0 +1,242 @@
+//! Parsing one quest document into the facts every rule reads.
+//!
+//! This is a real Markdown AST rather than line matching. The shell version
+//! that came before it was defeated by a fence longer than three backticks
+//! (which inverted its fence tracking and silently skipped the rest of the
+//! file), by a `Required` bullet that wrapped onto a second line (which moved
+//! the link out of reach of the check that exists to catch it), and by
+//! reference-style links (which produced a rendered dependency with no edge).
+//! None of those are special cases here; the parser simply reports the
+//! structure that Markdown actually has.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+
+/// Where a link sits inside its `## Section`, which is what separates a
+/// dependency edge from prose that merely mentions one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Position {
+	/// The link opens a list item, ignoring any emphasis around it. This is the
+	/// shape every `Required` blocker and every `Quests` entry must have.
+	Entry,
+	/// Somewhere else inside a list item: a sentence that happens to link.
+	Inside,
+	/// Outside any list item.
+	Prose,
+}
+
+#[derive(Clone, Debug)]
+pub struct Link {
+	pub line: usize,
+	/// The enclosing `## Heading`, or `None` above the first one.
+	pub section: Option<String>,
+	pub target: String,
+	pub position: Position,
+}
+
+#[derive(Clone, Debug)]
+pub struct Heading {
+	pub line: usize,
+	pub text: String,
+	/// The source really is `# Text` or `## Text` on its own line. Setext and
+	/// decorated headings render the same, but literal syntax is the contract.
+	pub literal: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct Doc {
+	/// Repository-relative, e.g. `quest/m0/one.md`.
+	pub path: PathBuf,
+	/// The document's `# ` title, used for a quest's t-shirt size.
+	pub title: Option<Heading>,
+	/// `## ` headings only. Deeper levels are free-form prose structure.
+	pub headings: Vec<Heading>,
+	pub links: Vec<Link>,
+	/// Sections holding at least one top-level list item, so a heading left
+	/// behind by its last entry can be told from one that still has entries.
+	pub sections_with_entries: Vec<String>,
+}
+
+impl Doc {
+	pub fn has(&self, heading: &str) -> bool {
+		self.headings.iter().any(|h| h.text == heading)
+	}
+
+	pub fn is_questline(&self) -> bool {
+		self.path.file_name().is_some_and(|n| n == "README.md")
+	}
+
+	/// The questline directory this document belongs to. A questline is a
+	/// DIRECTORY, so its own entry sits one level further out than a quest's:
+	/// `quest/m2/drain/README.md` belongs to `quest/m2`, not to `quest/m2/drain`.
+	pub fn owner(path: &Path) -> PathBuf {
+		let parent = path.parent().unwrap_or(Path::new(""));
+		if path.file_name().is_some_and(|n| n == "README.md") {
+			parent.parent().unwrap_or(Path::new("")).to_path_buf()
+		} else {
+			parent.to_path_buf()
+		}
+	}
+
+	pub fn parse(root: &Path, path: PathBuf) -> Result<Doc> {
+		let text = std::fs::read_to_string(root.join(&path)).with_context(|| format!("reading {}", path.display()))?;
+		Ok(Self::from_str(path, &text))
+	}
+
+	pub fn from_str(path: PathBuf, text: &str) -> Doc {
+		let lines = LineIndex::new(text);
+		let text_src = text;
+
+		let mut title = None;
+		let mut headings = Vec::new();
+		let mut links = Vec::new();
+		let mut sections_with_entries = Vec::new();
+		let mut section: Option<String> = None;
+
+		// Depth of nesting, so a sub-list inside an entry does not read as a
+		// second entry, and so `fresh` tracks the innermost item.
+		let mut item_depth = 0usize;
+		// Entries are the flat, top-level list. A bullet nested under a prose
+		// lead-in, or one inside a block quote, is illustration - counting it
+		// would let `- evidence:` + an indented link become a real blocker.
+		let mut quote_depth = 0usize;
+		// Nothing but emphasis has been seen since the current item opened, so a
+		// link here is the item's opening link. `**[Blocker](/quest/b.md)**` is
+		// still an opener; `A customer who justifies [b](/quest/b.md)` is not.
+		let mut fresh = false;
+		let mut heading: Option<(HeadingLevel, usize, String)> = None;
+
+		let mut options = Options::empty();
+		options.insert(Options::ENABLE_STRIKETHROUGH);
+		options.insert(Options::ENABLE_TABLES);
+
+		for (event, range) in Parser::new_ext(text, options).into_offset_iter() {
+			match event {
+				Event::Start(Tag::Heading { level, .. }) if matches!(level, HeadingLevel::H1 | HeadingLevel::H2) => {
+					heading = Some((level, lines.line_of(range.start), String::new()));
+				}
+				Event::End(TagEnd::Heading(level)) if matches!(level, HeadingLevel::H1 | HeadingLevel::H2) => {
+					if let Some((start_level, line, text)) = heading.take() {
+						debug_assert_eq!(start_level, level);
+						let text = text.trim().to_string();
+						// Exact, not trimmed: `rg '^## Required$'` does not match a
+						// line with trailing spaces either, and this rule exists
+						// precisely so the two can never disagree.
+						let prefix = if level == HeadingLevel::H1 { "#" } else { "##" };
+						let parsed = Heading {
+							line,
+							literal: lines.text_of(text_src, line) == format!("{prefix} {text}"),
+							text: text.clone(),
+						};
+						if level == HeadingLevel::H1 {
+							title = Some(parsed);
+						} else {
+							section = Some(text);
+							headings.push(parsed);
+						}
+					}
+					item_depth = 0;
+					fresh = false;
+				}
+				Event::Start(Tag::BlockQuote(..)) => {
+					quote_depth += 1;
+					fresh = false;
+				}
+				Event::End(TagEnd::BlockQuote(..)) => {
+					quote_depth = quote_depth.saturating_sub(1);
+					fresh = false;
+				}
+				Event::Start(Tag::Item) => {
+					item_depth += 1;
+					fresh = true;
+					if item_depth == 1
+						&& quote_depth == 0
+						&& let Some(name) = &section
+						&& !sections_with_entries.iter().any(|s| s == name)
+					{
+						sections_with_entries.push(name.clone());
+					}
+				}
+				Event::End(TagEnd::Item) => {
+					item_depth = item_depth.saturating_sub(1);
+					fresh = false;
+				}
+				Event::Start(Tag::Link { dest_url, .. }) => {
+					// Reference-style links arrive here already resolved to their
+					// destination, so they carry an edge like any other link.
+					// Only a top-level, unquoted item can hold an entry.
+					let position = if item_depth == 0 {
+						Position::Prose
+					} else if fresh && item_depth == 1 && quote_depth == 0 {
+						Position::Entry
+					} else {
+						Position::Inside
+					};
+					fresh = false;
+					links.push(Link {
+						line: lines.line_of(range.start),
+						section: section.clone(),
+						target: dest_url.to_string(),
+						position,
+					});
+				}
+				// Emphasis wraps an opening link without displacing it, and so does
+				// the paragraph a LOOSE list puts around every item: clearing on
+				// its START would classify every entry in a blank-line-separated
+				// list as mid-sentence prose. Its END does clear, so a link that
+				// opens a SECOND paragraph is inside the item, not opening it.
+				Event::Text(ref t) | Event::Code(ref t) => {
+					if let Some((_, _, buf)) = heading.as_mut() {
+						buf.push_str(t);
+					}
+					if !t.trim().is_empty() {
+						fresh = false;
+					}
+				}
+				Event::Start(Tag::Emphasis | Tag::Strong | Tag::Paragraph)
+				| Event::End(TagEnd::Emphasis | TagEnd::Strong) => {}
+				Event::End(TagEnd::Paragraph) => fresh = false,
+				Event::SoftBreak | Event::HardBreak => {}
+				_ => {
+					if item_depth > 0 {
+						fresh = false;
+					}
+				}
+			}
+		}
+
+		Doc {
+			path,
+			title,
+			headings,
+			links,
+			sections_with_entries,
+		}
+	}
+}
+
+/// Byte offset -> 1-based line number, so findings can name a line.
+struct LineIndex {
+	starts: Vec<usize>,
+}
+
+impl LineIndex {
+	fn new(text: &str) -> LineIndex {
+		let mut starts = vec![0];
+		starts.extend(text.match_indices('\n').map(|(i, _)| i + 1));
+		LineIndex { starts }
+	}
+
+	fn line_of(&self, offset: usize) -> usize {
+		self.starts.partition_point(|&start| start <= offset)
+	}
+
+	/// The source of a 1-based line, without its newline.
+	fn text_of<'a>(&self, text: &'a str, line: usize) -> &'a str {
+		let start = self.starts.get(line - 1).copied().unwrap_or(text.len());
+		let end = self.starts.get(line).copied().unwrap_or(text.len());
+		text[start..end].trim_end_matches('\n')
+	}
+}

--- a/rs/quest/src/lib.rs
+++ b/rs/quest/src/lib.rs
@@ -1,0 +1,62 @@
+//! Structural validation of the quest tree, whose contract is quest/AGENTS.md.
+//!
+//! The whole tree is validated on every run, never just the changed files: the
+//! link graph and the questline index are global, so completing one quest
+//! breaks files the diff never mentions. That is not hypothetical - it is how
+//! the index entry for a completed quest survived a rebase that produced no
+//! conflict at all.
+
+pub mod doc;
+pub mod rules;
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+pub use doc::Doc;
+pub use rules::Finding;
+
+/// AGENTS.md is the contract rather than a quest, and CLAUDE.md is a symlink to
+/// it; neither is executable work, so neither is indexed or validated.
+const NOT_QUESTS: [&str; 2] = ["AGENTS.md", "CLAUDE.md"];
+
+/// Every quest document under `<root>/quest`, sorted, repository-relative.
+pub fn collect(root: &Path) -> Result<Vec<PathBuf>> {
+	let mut out = Vec::new();
+	walk(root, &root.join("quest"), &mut out).with_context(|| format!("scanning {}", root.join("quest").display()))?;
+	out.sort();
+	Ok(out)
+}
+
+fn walk(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+	for entry in std::fs::read_dir(dir)? {
+		let entry = entry?;
+		let path = entry.path();
+		// `file_type` does not follow symlinks, so quest/CLAUDE.md is a file
+		// here and a directory symlink can never make this recurse forever.
+		let kind = entry.file_type()?;
+		if kind.is_dir() {
+			walk(root, &path, out)?;
+		} else if path.extension().is_some_and(|e| e == "md")
+			&& !path
+				.file_name()
+				.is_some_and(|n| NOT_QUESTS.iter().any(|skip| n == *skip))
+		{
+			out.push(path.strip_prefix(root).unwrap_or(&path).to_path_buf());
+		}
+	}
+	Ok(())
+}
+
+/// Parse and validate the tree. Returns every finding, worst-case empty.
+pub fn check(root: &Path) -> Result<Vec<Finding>> {
+	let paths = collect(root)?;
+	if paths.is_empty() {
+		bail!("no quest documents found under {}", root.join("quest").display());
+	}
+	let docs = paths
+		.into_iter()
+		.map(|p| Doc::parse(root, p))
+		.collect::<Result<Vec<_>>>()?;
+	Ok(rules::check(root, &docs))
+}

--- a/rs/quest/src/main.rs
+++ b/rs/quest/src/main.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Validate the quest tree: the interlinked Markdown plans under quest/, whose
+/// contract is quest/AGENTS.md.
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+	/// Repository root holding the quest/ directory.
+	#[arg(long, default_value = ".", global = true)]
+	root: PathBuf,
+
+	#[command(subcommand)]
+	command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+	/// Report every structural mistake in the tree; exit non-zero if any.
+	Check,
+}
+
+fn main() -> Result<ExitCode> {
+	let cli = Cli::parse();
+	match cli.command {
+		Command::Check => {
+			let findings = quest::check(&cli.root)?;
+			if findings.is_empty() {
+				let total = quest::collect(&cli.root)?.len();
+				println!("quest: {total} documents ok");
+				return Ok(ExitCode::SUCCESS);
+			}
+			for finding in &findings {
+				eprintln!("quest: {finding}");
+			}
+			Ok(ExitCode::FAILURE)
+		}
+	}
+}

--- a/rs/quest/src/rules.rs
+++ b/rs/quest/src/rules.rs
@@ -1,0 +1,388 @@
+//! The rules, and the findings they produce.
+//!
+//! The contract is quest/AGENTS.md. Every rule here is one that has already
+//! been broken by hand, and the expensive failure is a rule that stops firing:
+//! a validator that quietly enforces nothing looks exactly like a clean tree.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use crate::doc::{Doc, Position};
+
+/// The `## ` headings a quest document may use. Readiness greps `## Required`
+/// literally, so a typo turns a blocked quest ready and fails nowhere else:
+/// the closed vocabulary is what catches it.
+const HEADINGS: [&str; 6] = ["Goal", "Plan", "Required", "Closes", "Related", "Quests"];
+const SIZES: [&str; 5] = ["XS", "S", "M", "L", "XL"];
+
+/// Sections whose whole content is a list. A heading left standing after its
+/// last entry was removed is a bug in both directions: an empty `Required`
+/// blocks its quest forever, and an empty `Quests` leaves a questline that
+/// should have been deleted with its last quest.
+/// `Quests` is deliberately absent: a bullet is not an entry (`- TBD` is a list
+/// item with no quest in it), so its emptiness is decided by counting valid
+/// entries in `index` instead.
+const LIST_SECTIONS: [&str; 3] = ["Required", "Closes", "Related"];
+
+pub const ROOT: &str = "quest/README.md";
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Finding {
+	pub path: PathBuf,
+	pub line: Option<usize>,
+	pub message: String,
+}
+
+impl std::fmt::Display for Finding {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self.line {
+			Some(line) => write!(f, "{}:{}: {}", self.path.display(), line, self.message),
+			None => write!(f, "{}: {}", self.path.display(), self.message),
+		}
+	}
+}
+
+struct Findings(Vec<Finding>);
+
+impl Findings {
+	fn at(&mut self, path: &Path, line: usize, message: impl Into<String>) {
+		self.0.push(Finding {
+			path: path.to_path_buf(),
+			line: Some(line),
+			message: message.into(),
+		});
+	}
+
+	fn on(&mut self, path: &Path, message: impl Into<String>) {
+		self.0.push(Finding {
+			path: path.to_path_buf(),
+			line: None,
+			message: message.into(),
+		});
+	}
+}
+
+/// `root` is the repository root; every path in `docs` is relative to it.
+pub fn check(root: &Path, docs: &[Doc]) -> Vec<Finding> {
+	let mut found = Findings(Vec::new());
+	let known: BTreeSet<&Path> = docs.iter().map(|d| d.path.as_path()).collect();
+
+	for doc in docs {
+		headings(&mut found, doc);
+		links(&mut found, root, &known, doc);
+	}
+
+	let index = index(&mut found, &known, docs);
+	cycles(&mut found, docs, &index);
+
+	found.0.sort();
+	found.0
+}
+
+fn headings(found: &mut Findings, doc: &Doc) {
+	if !doc.is_questline() {
+		let valid = doc.title.as_ref().is_some_and(|title| {
+			let Some((size, name)) = title.text.strip_prefix('[').and_then(|s| s.split_once("] ")) else {
+				return false;
+			};
+			title.literal && SIZES.contains(&size) && !name.is_empty()
+		});
+		if !valid {
+			found.on(&doc.path, "quest title must be '# [XS|S|M|L|XL] Title'");
+		}
+	}
+
+	if !doc.has("Goal") {
+		found.on(&doc.path, "missing '## Goal'");
+	}
+
+	for heading in &doc.headings {
+		// A setext underline and a decorated ``## `Required` `` both render as
+		// the same heading, and this validator would treat the quest as blocked.
+		// Readiness greps `^## Required$` literally and would call it READY.
+		if HEADINGS.contains(&heading.text.as_str()) && !heading.literal {
+			found.at(
+				&doc.path,
+				heading.line,
+				format!(
+					"'{}' must be written literally as '## {}'; readiness greps that form and would not see this one",
+					heading.text, heading.text
+				),
+			);
+		}
+		if !HEADINGS.contains(&heading.text.as_str()) {
+			found.at(
+				&doc.path,
+				heading.line,
+				format!("unknown '## {}' (allowed: {})", heading.text, HEADINGS.join(", ")),
+			);
+		}
+	}
+
+	// A questline is a README with `## Quests`; a quest is everything else and
+	// must not have one. Only quests are executed, so the distinction decides
+	// what a reader is allowed to pick up.
+	match (doc.is_questline(), doc.has("Quests")) {
+		(true, false) => found.on(&doc.path, "a questline needs '## Quests'"),
+		(false, true) => found.on(&doc.path, "only a questline README may have '## Quests'"),
+		_ => {}
+	}
+	for heading in &doc.headings {
+		if LIST_SECTIONS.contains(&heading.text.as_str()) && !doc.sections_with_entries.contains(&heading.text) {
+			let why = match heading.text.as_str() {
+				"Required" => "; an empty one blocks the quest forever, so remove the heading with its last entry",
+				"Quests" => "; a questline with no quests left should be deleted",
+				_ => "; remove the heading with its last entry",
+			};
+			found.at(&doc.path, heading.line, format!("'## {}' is empty{why}", heading.text));
+		}
+	}
+}
+
+/// Strip a `#fragment`, which addresses a place inside a file rather than a
+/// different file. Leaving it on made a phantom graph node that no quest could
+/// ever match, so a cycle through an anchored link went unreported.
+fn without_fragment(target: &str) -> &str {
+	target.split('#').next().unwrap_or(target)
+}
+
+/// A root-absolute target as a repository-relative path, or `None` if it is not
+/// root-absolute. Fragment-stripped AND normalized: the index and the cycle walk
+/// both key on this, and a `..` left in one of them is a node nothing matches.
+fn rooted(target: &str) -> Option<PathBuf> {
+	target
+		.strip_prefix('/')
+		.map(|r| normalize(Path::new(without_fragment(r))))
+}
+
+fn resolve(doc_path: &Path, target: &str) -> PathBuf {
+	match target.strip_prefix('/') {
+		Some(rooted) => normalize(Path::new(rooted)),
+		None => normalize(&doc_path.parent().unwrap_or(Path::new("")).join(target)),
+	}
+}
+
+/// Collapse `..` textually. `Path::canonicalize` would need the file to exist,
+/// which is the very thing being tested.
+fn normalize(path: &Path) -> PathBuf {
+	let mut out = PathBuf::new();
+	for part in path.components() {
+		match part {
+			std::path::Component::ParentDir => {
+				// Popping unconditionally let `../..` cancel itself, so a link
+				// with too many `..` climbed above the root and then walked back
+				// down to a real file.
+				if out.components().next_back() == Some(std::path::Component::ParentDir) || !out.pop() {
+					out.push("..");
+				}
+			}
+			std::path::Component::CurDir => {}
+			other => out.push(other.as_os_str()),
+		}
+	}
+	out
+}
+
+fn links(found: &mut Findings, root: &Path, known: &BTreeSet<&Path>, doc: &Doc) {
+	for link in &doc.links {
+		if link.target.contains("://") || link.target.starts_with("mailto:") {
+			continue;
+		}
+		let target = without_fragment(&link.target);
+		if target.is_empty() {
+			continue;
+		}
+
+		let path = resolve(&doc.path, target);
+		if !root.join(&path).exists() {
+			found.at(&doc.path, link.line, format!("link does not resolve: {}", link.target));
+			continue;
+		}
+
+		// Quests and questlines reference each other with root-absolute links.
+		// A relative one still renders, so nothing else would notice - but it is
+		// invisible to the dependency graph below, which only speaks /quest/...
+		if known.contains(path.as_path()) && !link.target.starts_with('/') {
+			found.at(
+				&doc.path,
+				link.line,
+				format!(
+					"link to a quest must be root-absolute: {} (write /{})",
+					link.target,
+					path.display()
+				),
+			);
+		}
+
+		// A `Required` bullet is either a dependency edge (the link opens it) or
+		// a plain-text external condition (no quest link at all).
+		// moq-dev/moq.pro#1170 shipped the third shape: a customer-gate sentence
+		// mentioning a questline mid-line, which reads as context but IS a
+		// blocker, and so silently required all of m2.
+		if link.section.as_deref() == Some("Required")
+			&& known.contains(path.as_path())
+			&& link.position != Position::Entry
+		{
+			found.at(
+				&doc.path,
+				link.line,
+				format!(
+					"Required links {} mid-sentence; that reads as prose but IS a blocker - open the bullet with the link, or drop the link",
+					link.target
+				),
+			);
+		}
+	}
+}
+
+/// Which questline lists each document. The index must be exactly the file
+/// tree: every document is listed by the questline it sits under, and a
+/// questline lists nothing but its own children - together these also give
+/// "listed by exactly one questline".
+fn index<'a>(found: &mut Findings, known: &BTreeSet<&Path>, docs: &'a [Doc]) -> BTreeMap<PathBuf, &'a Path> {
+	let mut listed: BTreeMap<PathBuf, &Path> = BTreeMap::new();
+	let mut entries: BTreeMap<&Path, usize> = BTreeMap::new();
+
+	for doc in docs {
+		for link in &doc.links {
+			if link.section.as_deref() != Some("Quests") {
+				continue;
+			}
+			// The index is a list of entries, not prose that happens to link:
+			// `See [One](/quest/m0/one.md)` must not make One look indexed.
+			if link.position != Position::Entry {
+				found.at(
+					&doc.path,
+					link.line,
+					format!("a Quests entry must open its bullet: {}", link.target),
+				);
+				continue;
+			}
+			let Some(child) = rooted(&link.target) else {
+				found.at(
+					&doc.path,
+					link.line,
+					format!(
+						"a Quests entry must be a root-absolute /quest/... link: {}",
+						link.target
+					),
+				);
+				continue;
+			};
+			// Existence is not enough: the index points readers at work to pick
+			// up, and quest/AGENTS.md is a file under quest/ that is not a quest.
+			if !known.contains(child.as_path()) {
+				found.at(
+					&doc.path,
+					link.line,
+					format!("lists {}, which is not a quest document", link.target),
+				);
+				continue;
+			}
+			if Doc::owner(&child) != doc.path.parent().unwrap_or(Path::new("")) {
+				found.at(
+					&doc.path,
+					link.line,
+					format!("lists {}, which does not sit under this questline", link.target),
+				);
+				continue;
+			}
+			if listed.insert(child, doc.path.as_path()).is_some() {
+				found.at(&doc.path, link.line, format!("lists {} twice", link.target));
+			}
+			*entries.entry(doc.path.as_path()).or_default() += 1;
+		}
+	}
+
+	for doc in docs {
+		// A questline lists at least one quest. Completing its last one is
+		// supposed to delete the directory; a heading holding a bullet with no
+		// quest in it (`- TBD`) leaves the husk standing just as well as a bare
+		// one does.
+		if doc.is_questline() && doc.has("Quests") && entries.get(doc.path.as_path()).copied().unwrap_or(0) == 0 {
+			found.on(
+				&doc.path,
+				"'## Quests' lists no quest; a questline with none left should be deleted",
+			);
+		}
+
+		// The root questline is permanent and has nothing above it to list it.
+		if doc.path == Path::new(ROOT) || listed.contains_key(&doc.path) {
+			continue;
+		}
+		let owner = Doc::owner(&doc.path).join("README.md");
+		found.on(
+			&doc.path,
+			format!(
+				"not listed in {}'s '## Quests'; an unlisted quest is unreachable",
+				owner.display()
+			),
+		);
+	}
+
+	listed
+}
+
+/// `Required` must be acyclic. A cycle is a set of quests none of which can
+/// ever start, and walking the links to rule one out is exactly the manual step
+/// AGENTS.md asks of an author before adding a blocker.
+fn cycles(found: &mut Findings, docs: &[Doc], listed: &BTreeMap<PathBuf, &Path>) {
+	let mut blockers: BTreeMap<&Path, Vec<PathBuf>> = BTreeMap::new();
+
+	for doc in docs {
+		let edges: Vec<PathBuf> = doc
+			.links
+			.iter()
+			.filter(|l| l.section.as_deref() == Some("Required") && l.position == Position::Entry)
+			.filter_map(|l| rooted(&l.target))
+			.collect();
+		blockers.entry(doc.path.as_path()).or_default().extend(edges);
+	}
+
+	// A quest may require a whole QUESTLINE, and a questline is complete only
+	// when all of its quests are, so a questline waits on its own children.
+	// Without these edges the walk stops at the README and misses the deadlock
+	// that spans it: a quest requiring the questline that holds the quest
+	// requiring it back.
+	for (child, questline) in listed {
+		blockers.entry(questline).or_default().push(child.clone());
+	}
+
+	#[derive(Clone, Copy, PartialEq)]
+	enum State {
+		Open,
+		Done,
+	}
+
+	fn walk(
+		node: &Path,
+		blockers: &BTreeMap<&Path, Vec<PathBuf>>,
+		state: &mut BTreeMap<PathBuf, State>,
+		stack: &mut Vec<PathBuf>,
+		found: &mut Findings,
+	) {
+		match state.get(node) {
+			Some(State::Done) => return,
+			Some(State::Open) => {
+				let from = stack.iter().position(|p| p == node).unwrap_or(0);
+				let mut path: Vec<String> = stack[from..].iter().map(|p| p.display().to_string()).collect();
+				path.push(node.display().to_string());
+				found.on(node, format!("Required cycle: {}", path.join(" -> ")));
+				return;
+			}
+			None => {}
+		}
+		state.insert(node.to_path_buf(), State::Open);
+		stack.push(node.to_path_buf());
+		for next in blockers.get(node).map(Vec::as_slice).unwrap_or_default() {
+			walk(next, blockers, state, stack, found);
+		}
+		stack.pop();
+		state.insert(node.to_path_buf(), State::Done);
+	}
+
+	let mut state = BTreeMap::new();
+	for doc in docs {
+		walk(&doc.path, &blockers, &mut state, &mut Vec::new(), found);
+	}
+}

--- a/rs/quest/tests/tree.rs
+++ b/rs/quest/tests/tree.rs
@@ -1,0 +1,605 @@
+//! Every rule, each proven to actually fail.
+//!
+//! A validator that silently stopped enforcing a rule is indistinguishable from
+//! a clean tree, so each case starts from the same valid fixture and breaks
+//! exactly one thing. The cases that must still PASS matter just as much: the
+//! shell version this replaced was rewritten precisely because it rejected
+//! legitimate Markdown and accepted the shapes it was written to catch.
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+const ROOT_README: &str = "\
+# Quests
+
+## Goal
+
+The permanent root questline.
+
+## Quests
+
+- [M0](/quest/m0/README.md)
+";
+
+const M0_README: &str = "\
+# M0
+
+## Goal
+
+A milestone.
+
+## Quests
+
+- [Line](/quest/m0/line/README.md)
+";
+
+const LINE_README: &str = "\
+# Line
+
+## Goal
+
+A questline.
+
+## Quests
+
+- [One](/quest/m0/line/one.md)
+- [Two](/quest/m0/line/two.md)
+";
+
+const ONE: &str = "\
+# [S] One
+
+## Goal
+
+A quest.
+";
+
+const TWO: &str = "\
+# [S] Two
+
+## Goal
+
+Another quest.
+
+## Required
+
+- [One](/quest/m0/line/one.md) - must finish first
+";
+
+/// A minimal but complete tree: root questline -> milestone -> questline -> two
+/// quests, one blocking the other.
+struct Tree(TempDir);
+
+impl Tree {
+	fn new() -> Tree {
+		let tree = Tree(TempDir::new().expect("tempdir"));
+		tree.write("quest/README.md", ROOT_README);
+		tree.write("quest/m0/README.md", M0_README);
+		tree.write("quest/m0/line/README.md", LINE_README);
+		tree.write("quest/m0/line/one.md", ONE);
+		tree.write("quest/m0/line/two.md", TWO);
+		tree
+	}
+
+	fn path(&self) -> &Path {
+		self.0.path()
+	}
+
+	fn write(&self, rel: &str, body: &str) -> &Tree {
+		let path = self.path().join(rel);
+		std::fs::create_dir_all(path.parent().unwrap()).expect("mkdir");
+		std::fs::write(path, body).expect("write");
+		self
+	}
+
+	fn append(&self, rel: &str, body: &str) -> &Tree {
+		let path = self.path().join(rel);
+		let existing = std::fs::read_to_string(&path).expect("read");
+		std::fs::write(path, format!("{existing}{body}")).expect("write");
+		self
+	}
+
+	fn findings(&self) -> Vec<String> {
+		quest::check(self.path())
+			.expect("check")
+			.iter()
+			.map(ToString::to_string)
+			.collect()
+	}
+
+	#[track_caller]
+	fn accepts(&self) {
+		let findings = self.findings();
+		assert!(findings.is_empty(), "expected the tree to pass, got: {findings:#?}");
+	}
+
+	#[track_caller]
+	fn without(&self, unexpected: &str) {
+		let findings = self.findings();
+		assert!(
+			!findings.iter().any(|f| f.contains(unexpected)),
+			"expected NO finding containing {unexpected:?}, got: {findings:#?}"
+		);
+	}
+
+	#[track_caller]
+	fn rejects(&self, expected: &str) {
+		let findings = self.findings();
+		assert!(
+			findings.iter().any(|f| f.contains(expected)),
+			"expected a finding containing {expected:?}, got: {findings:#?}"
+		);
+	}
+}
+
+/// The fixture itself has to pass, or every case below proves nothing.
+#[test]
+fn baseline_is_valid() {
+	Tree::new().accepts();
+}
+
+#[test]
+fn dangling_absolute_link() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Related\n\n- [Gone](/quest/m0/line/gone.md) - completed and deleted\n",
+	);
+	tree.rejects("link does not resolve: /quest/m0/line/gone.md");
+}
+
+/// Relative links escape the tree (AGENTS.md points at ../CONTRIBUTING.md), so
+/// they resolve against the LINKING FILE's directory. The pair of cases pins the
+/// direction: resolving against the wrong base would flip both verdicts.
+#[test]
+fn relative_link_resolves_against_the_linking_file() {
+	let tree = Tree::new();
+	tree.write("CLAUDE.md", "# Guide\n");
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Plan\n\nSee [the guide](../../../CLAUDE.md).\n",
+	);
+	tree.accepts();
+}
+
+#[test]
+fn relative_link_above_the_repository_root() {
+	let tree = Tree::new();
+	tree.write("CLAUDE.md", "# Guide\n");
+	// One `..` too many, which is exactly what a file flattened up a level
+	// keeps: it still renders, and points at nothing.
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Plan\n\nSee [the guide](../../../../CLAUDE.md).\n",
+	);
+	tree.rejects("link does not resolve: ../../../../CLAUDE.md");
+}
+
+/// Quests reference each other root-absolutely. A relative one renders fine, so
+/// nothing else would notice - but it is invisible to the dependency graph.
+#[test]
+fn relative_link_to_a_quest() {
+	let tree = Tree::new();
+	tree.append("quest/m0/line/one.md", "\n## Related\n\n- [Two](two.md) - a sibling\n");
+	tree.rejects("link to a quest must be root-absolute: two.md (write /quest/m0/line/two.md)");
+}
+
+/// Templates inside fenced blocks are illustrations. Flagging AGENTS.md's own
+/// example would make this a check everyone learns to skip.
+#[test]
+fn fenced_templates_are_not_links() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Plan\n\n```markdown\n## Required\n\n- [Blocker](/quest/foo/bar.md) - must finish first\n```\n",
+	);
+	tree.accepts();
+}
+
+/// A fence longer than three backticks may contain shorter ones, and `~~~` is a
+/// fence too. Miscounting either inverts the fence state and silently skips the
+/// REST OF THE FILE - the worst failure this tool has, because it looks clean.
+#[test]
+fn nested_and_tilde_fences_do_not_leak() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Plan\n\n````markdown\n```bash\njust check\n```\n````\n\n~~~text\n```\n~~~\n\n## Requires\n\n- [Gone](/quest/m0/line/gone.md) - typo'd heading and a dangling link\n",
+	);
+	tree.rejects("unknown '## Requires'");
+	tree.rejects("link does not resolve: /quest/m0/line/gone.md");
+}
+
+#[test]
+fn missing_goal() {
+	let tree = Tree::new();
+	tree.write(
+		"quest/m0/line/one.md",
+		"# [S] One\n\n## Plan\n\nA quest with no stated outcome.\n",
+	);
+	tree.rejects("missing '## Goal'");
+}
+
+#[test]
+fn quest_title_needs_a_size() {
+	let tree = Tree::new();
+	tree.write("quest/m0/line/one.md", &ONE.replace("# [S] One", "# One"));
+	tree.rejects("quest title must be '# [XS|S|M|L|XL] Title'");
+}
+
+#[test]
+fn quest_title_accepts_xl() {
+	let tree = Tree::new();
+	tree.write("quest/m0/line/one.md", &ONE.replace("# [S] One", "# [XL] One"));
+	tree.accepts();
+}
+
+#[test]
+fn quest_title_rejects_xxl() {
+	let tree = Tree::new();
+	tree.write("quest/m0/line/one.md", &ONE.replace("# [S] One", "# [XXL] One"));
+	tree.rejects("quest title must be '# [XS|S|M|L|XL] Title'");
+}
+
+/// The closed vocabulary exists for this: readiness greps `## Required`
+/// literally, so a typo makes a blocked quest read as ready and fails nowhere.
+#[test]
+fn typo_in_a_heading() {
+	let tree = Tree::new();
+	tree.write("quest/m0/line/two.md", &TWO.replace("## Required", "## Requires"));
+	tree.rejects("unknown '## Requires'");
+}
+
+#[test]
+fn quest_with_a_questline_index() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Quests\n\n- [Two](/quest/m0/line/two.md)\n",
+	);
+	tree.rejects("only a questline README may have '## Quests'");
+}
+
+#[test]
+fn questline_without_an_index() {
+	let tree = Tree::new();
+	tree.write(
+		"quest/m0/line/sub/README.md",
+		"# Sub\n\n## Goal\n\nA questline that indexes nothing.\n",
+	);
+	tree.rejects("a questline needs '## Quests'");
+}
+
+/// Completing a questline's last quest deletes the directory. A bare `## Quests`
+/// heading otherwise satisfies the questline rule and leaves the husk standing.
+/// (The other direction - a heading holding a non-quest bullet - is
+/// `questline_listing_no_quest`; one rule, both shapes.)
+#[test]
+fn empty_questline_index() {
+	let tree = Tree::new();
+	tree.write(
+		"quest/m0/husk/README.md",
+		"# Husk\n\n## Goal\n\nIts last quest was completed.\n\n## Quests\n",
+	);
+	tree.append("quest/m0/README.md", "- [Husk](/quest/m0/husk/README.md)\n");
+	tree.rejects("lists no quest");
+}
+
+/// The absence of `## Required` means ready. A heading left behind by its last
+/// blocker reads as blocked to every readiness check, forever.
+#[test]
+fn empty_required_section() {
+	let tree = Tree::new();
+	tree.append("quest/m0/line/one.md", "\n## Required\n");
+	tree.rejects("'## Required' is empty");
+}
+
+#[test]
+fn unlisted_quest() {
+	let tree = Tree::new();
+	tree.write(
+		"quest/m0/line/three.md",
+		"# [S] Three\n\n## Goal\n\nA quest nobody indexed.\n",
+	);
+	tree.rejects("not listed in quest/m0/line/README.md's '## Quests'");
+}
+
+/// Quests are indexed where they sit, so a milestone cannot reach past its own
+/// questlines to list a grandchild.
+#[test]
+fn questline_listing_a_grandchild() {
+	let tree = Tree::new();
+	tree.append("quest/m0/README.md", "- [One](/quest/m0/line/one.md)\n");
+	tree.rejects("does not sit under this questline");
+}
+
+#[test]
+fn quest_listed_twice() {
+	let tree = Tree::new();
+	tree.append("quest/m0/line/README.md", "- [One again](/quest/m0/line/one.md)\n");
+	tree.rejects("lists /quest/m0/line/one.md twice");
+}
+
+#[test]
+fn relative_index_entry() {
+	let tree = Tree::new();
+	tree.write(
+		"quest/m0/line/README.md",
+		&LINE_README.replace("(/quest/m0/line/one.md)", "(one.md)"),
+	);
+	tree.rejects("must be a root-absolute /quest/... link: one.md");
+}
+
+/// The index points readers at work to pick up, so a target that merely exists
+/// is not enough: quest/AGENTS.md is a file under quest/ that is not a quest.
+#[test]
+fn index_entry_that_is_not_a_quest() {
+	let tree = Tree::new();
+	tree.write("quest/AGENTS.md", "# Contract\n");
+	tree.append("quest/README.md", "- [Contract](/quest/AGENTS.md)\n");
+	tree.rejects("lists /quest/AGENTS.md, which is not a quest document");
+}
+
+/// The index is a list of entries, not prose that happens to link.
+#[test]
+fn prose_under_the_index() {
+	let tree = Tree::new();
+	tree.append("quest/m0/line/README.md", "\nSee also [One](/quest/m0/line/one.md).\n");
+	tree.rejects("a Quests entry must open its bullet");
+}
+
+#[test]
+fn direct_required_cycle() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- [Two](/quest/m0/line/two.md) - must finish first\n",
+	);
+	tree.rejects("Required cycle:");
+}
+
+/// A quest may require a whole questline, so the deadlock can span the README.
+/// The cycle here runs strictly OUTSIDE-IN: `outer` (in m0) requires the line
+/// questline, and `three` inside that questline requires `outer` back. No quest
+/// requires its own questline, so containment edges are the only thing that can
+/// close it.
+#[test]
+fn cycle_through_a_questline() {
+	let tree = Tree::new();
+	tree.append("quest/m0/README.md", "- [Outer](/quest/m0/outer.md)\n");
+	tree.write(
+		"quest/m0/outer.md",
+		"# [S] Outer\n\n## Goal\n\nBlocked on a whole questline.\n\n## Required\n\n- [Line](/quest/m0/line/README.md) - the whole questline must finish\n",
+	);
+	tree.append("quest/m0/line/README.md", "- [Three](/quest/m0/line/three.md)\n");
+	tree.write(
+		"quest/m0/line/three.md",
+		"# [S] Three\n\n## Goal\n\nInside the questline that blocks it.\n\n## Required\n\n- [Outer](/quest/m0/outer.md) - must finish first\n",
+	);
+	tree.rejects(
+		"Required cycle: quest/m0/line/README.md -> quest/m0/line/three.md -> quest/m0/outer.md -> quest/m0/line/README.md",
+	);
+}
+
+/// A `#fragment` addresses a place inside a file, not a different file. Keeping
+/// it on made a phantom graph node that no quest could match, so a cycle through
+/// an anchored link went unreported.
+#[test]
+fn cycle_through_an_anchored_link() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- [Two](/quest/m0/line/two.md#plan) - must finish first\n",
+	);
+	tree.rejects("Required cycle:");
+}
+
+/// Reference-style links render as real dependencies, so they must carry real
+/// edges. A line-oriented parser saw no `](` here and produced none.
+#[test]
+fn cycle_through_a_reference_style_link() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- [Two][two] - must finish first\n\n[two]: /quest/m0/line/two.md\n",
+	);
+	tree.rejects("Required cycle:");
+}
+
+/// moq-dev/moq.pro#1170: a plain-text external condition that happens to link a
+/// questline mid-sentence reads as context but IS a dependency edge.
+#[test]
+fn required_link_mid_sentence() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- A customer who also justifies [the line](/quest/m0/line/README.md).\n",
+	);
+	tree.rejects("mid-sentence");
+}
+
+/// The same failure, reflowed onto a second line. The link is no longer on the
+/// bullet's first line, which is all it took to slip past the shell version.
+#[test]
+fn required_link_on_a_wrapped_bullet() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- A customer who also justifies\n  [the line](/quest/m0/line/README.md).\n",
+	);
+	tree.rejects("mid-sentence");
+}
+
+/// The other half of that rule: an external condition with no link at all is the
+/// shape AGENTS.md prescribes, and must stay legal.
+#[test]
+fn required_external_condition() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- A customer who justifies the work.\n",
+	);
+	tree.accepts();
+}
+
+/// A LOOSE list - blank lines between entries - wraps every item in a paragraph.
+/// Treating that paragraph as text would classify every entry in the list as
+/// mid-sentence prose, which is a false positive on ordinary Markdown and would
+/// fire on every blocker and every index entry at once.
+#[test]
+fn loose_index_list() {
+	let tree = Tree::new();
+	tree.write(
+		"quest/m0/line/README.md",
+		"# Line\n\n## Goal\n\nA questline.\n\n## Quests\n\n- [One](/quest/m0/line/one.md)\n\n- [Two](/quest/m0/line/two.md)\n",
+	);
+	tree.accepts();
+}
+
+#[test]
+fn loose_required_list() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- [Two](/quest/m0/line/two.md) - must finish first\n\n- A customer who justifies the work.\n",
+	);
+	// The edge registered (hence the cycle) without reading as prose.
+	tree.rejects("Required cycle:");
+	tree.without("mid-sentence");
+}
+
+/// The other side of the same seam: a link opening a SECOND paragraph is inside
+/// the item, not opening it.
+#[test]
+fn required_link_in_a_later_paragraph() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- A customer who justifies the work.\n\n  [The line](/quest/m0/line/README.md) would follow.\n",
+	);
+	tree.rejects("mid-sentence");
+}
+
+/// A blocker written with emphasis still opens its bullet. Rejecting it would
+/// be a false positive on legitimate Markdown.
+#[test]
+fn required_link_with_emphasis() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- **[Two](/quest/m0/line/two.md)** - must finish first\n",
+	);
+	tree.rejects("Required cycle:");
+}
+
+/// A setext underline renders as an H2 and this validator would read the quest
+/// as blocked - but readiness greps `^## Required$` and would call it READY.
+/// Two tools disagreeing about the same file is the whole failure.
+#[test]
+fn setext_heading() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\nRequired\n--------\n\n- [Two](/quest/m0/line/two.md) - must finish first\n",
+	);
+	tree.rejects("must be written literally as '## Required'");
+}
+
+#[test]
+fn decorated_heading() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## `Required`\n\n- [Two](/quest/m0/line/two.md) - must finish first\n",
+	);
+	tree.rejects("must be written literally as '## Required'");
+}
+
+/// A bullet nested under a prose lead-in is illustration, not a blocker. Reading
+/// it as one is #1170 again, wearing an indent.
+#[test]
+fn nested_required_entry() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- Customer evidence:\n  - [The line](/quest/m0/line/README.md)\n",
+	);
+	tree.rejects("mid-sentence");
+}
+
+#[test]
+fn blockquoted_required_entry() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- Quoting the old plan:\n\n  > - [The line](/quest/m0/line/README.md)\n",
+	);
+	tree.rejects("mid-sentence");
+}
+
+/// Repeated `..` must not cancel each other on the way up. Popping
+/// unconditionally let a link climb above the root and walk back down to a real
+/// file, so a badly flattened path resolved and reported nothing.
+#[test]
+fn repeated_parent_components() {
+	let tree = Tree::new();
+	tree.write("CLAUDE.md", "# Guide\n");
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Plan\n\nSee [the guide](../../../../../CLAUDE.md).\n",
+	);
+	tree.rejects("link does not resolve: ../../../../../CLAUDE.md");
+}
+
+/// A bullet is not an entry. `- TBD` satisfies "the heading has a list" while
+/// leaving a questline that should have been deleted with its last quest.
+#[test]
+fn questline_listing_no_quest() {
+	let tree = Tree::new();
+	tree.write(
+		"quest/m0/husk/README.md",
+		"# Husk\n\n## Goal\n\nIts last quest was completed.\n\n## Quests\n\n- TBD\n",
+	);
+	tree.append("quest/m0/README.md", "- [Husk](/quest/m0/husk/README.md)\n");
+	tree.rejects("lists no quest");
+}
+
+#[test]
+fn empty_related_section() {
+	let tree = Tree::new();
+	tree.append("quest/m0/line/one.md", "\n## Related\n");
+	tree.rejects("'## Related' is empty");
+}
+
+#[test]
+fn empty_closes_section() {
+	let tree = Tree::new();
+	tree.append("quest/m0/line/one.md", "\n## Closes\n");
+	tree.rejects("'## Closes' is empty");
+}
+
+/// Trailing whitespace is invisible in a diff and `rg '^## Required$'` does not
+/// match it either, so accepting it recreates the same disagreement a setext
+/// heading does.
+#[test]
+fn heading_with_trailing_space() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required  \n\n- [Two](/quest/m0/line/two.md) - must finish first\n",
+	);
+	tree.rejects("must be written literally as '## Required'");
+}
+
+/// The index and the cycle walk key on the same normalized path. A `..` left in
+/// either makes a node nothing can match, so the cycle through it disappears.
+#[test]
+fn cycle_through_an_unnormalized_link() {
+	let tree = Tree::new();
+	tree.append(
+		"quest/m0/line/one.md",
+		"\n## Required\n\n- [Two](/quest/m0/line/../line/two.md) - must finish first\n",
+	);
+	tree.rejects("Required cycle:");
+}


### PR DESCRIPTION
## Summary

- migrate the repository quest validator, guidance, and agent workflows from `moq.pro`
- seed `quest/m0` with one atomic quest for each of the 165 currently open GitHub issues, without changing issue state
- validate the quest graph from repository checks

## Public API changes

- None. The new `quest` crate is unpublished repository tooling.

## Test plan

- `nix develop --command just check`
- `nix develop --command just test`
- verified exact live parity between open issues and atomic quests: 165/165
- validated both migrated quest skills

Cross-package sync is not applicable because this adds repository tooling and planning documents only.

(written by GPT-5)
