### PR TITLE
feat(moq-audio): expose Opus DTX classification

### DIFF
--- a/doc/lib/rs/crate/moq-audio.md
+++ b/doc/lib/rs/crate/moq-audio.md
@@ -35,10 +35,14 @@ The one system dependency is the platform's audio API, and only when you enable
 needs the ALSA development headers (`libasound2-dev` or your distro's equivalent)
 for cpal to link. A default build has neither feature and needs nothing.
 
-`Frame` is a timestamp and a payload. Layout lives on the producer or consumer
-(`encode::Input` / `decode::Config`) rather than on each frame, so you cannot
-drift between calls, and `Format` mirrors the WebCodecs `AudioData.format` values
-with conversions to the interleaved `f32` that the codecs want.
+`Frame` is a timestamp, a payload, and an `Activity`. Layout lives on the
+producer or consumer (`encode::Input` / `decode::Config`) rather than on each
+frame, so you cannot drift between calls, and `Format` mirrors the WebCodecs
+`AudioData.format` values with conversions to the interleaved `f32` that the
+codecs want. `Activity` says whether a decoded frame is real audio or the comfort
+noise an Opus sender emits while silent (`encode::Config::dtx`), so a call UI can
+show who is talking without running a second voice detector; the publish side
+reads the same thing off `encode::Producer::activity`.
 
 ## Installation
 

--- a/doc/lib/rs/crate/moq-audio.md
+++ b/doc/lib/rs/crate/moq-audio.md
@@ -39,13 +39,13 @@ for cpal to link. A default build has neither feature and needs nothing.
 producer or consumer (`encode::Input` / `decode::Config`) rather than on each
 frame, so you cannot drift between calls, and `Format` mirrors the WebCodecs
 `AudioData.format` values with conversions to the interleaved `f32` that the
-codecs want. `Activity` says whether the sender coded audio for a frame or withheld it
-because its input was silent (`encode::Config::dtx`), so a call UI can show who
-is talking without running a second voice detector; the publish side reads the
-same thing off `encode::Producer::activity`. It is read off the packet, so it
-works for senders that are not us. Opus marks withheld audio but not silence
-itself, so a silence run is interrupted every few hundred milliseconds by an
-ordinarily coded frame that reads active: hold an indicator across that gap
+codecs want. `Activity` says whether a packet coded audio or none at all, which is what an
+Opus sender withholding silence looks like (`encode::Config::dtx`), so a call UI
+can show who is talking without running a second voice detector; the publish side
+reads the same thing off `encode::Producer::activity`. It is read off the packet,
+so it works for senders that are not us. Opus marks withheld audio but not
+silence itself, so a silent run is interrupted every few hundred milliseconds by
+an ordinarily coded frame that reads active: hold an indicator across that gap
 rather than following it frame by frame.
 
 ## Installation

--- a/doc/lib/rs/crate/moq-audio.md
+++ b/doc/lib/rs/crate/moq-audio.md
@@ -39,10 +39,14 @@ for cpal to link. A default build has neither feature and needs nothing.
 producer or consumer (`encode::Input` / `decode::Config`) rather than on each
 frame, so you cannot drift between calls, and `Format` mirrors the WebCodecs
 `AudioData.format` values with conversions to the interleaved `f32` that the
-codecs want. `Activity` says whether a decoded frame is real audio or the comfort
-noise an Opus sender emits while silent (`encode::Config::dtx`), so a call UI can
-show who is talking without running a second voice detector; the publish side
-reads the same thing off `encode::Producer::activity`.
+codecs want. `Activity` says whether the sender coded audio for a frame or withheld it
+because its input was silent (`encode::Config::dtx`), so a call UI can show who
+is talking without running a second voice detector; the publish side reads the
+same thing off `encode::Producer::activity`. It is read off the packet, so it
+works for senders that are not us. Opus marks withheld audio but not silence
+itself, so a silence run is interrupted every few hundred milliseconds by an
+ordinarily coded frame that reads active: hold an indicator across that gap
+rather than following it frame by frame.
 
 ## Installation
 

--- a/rs/libmoq/src/audio.rs
+++ b/rs/libmoq/src/audio.rs
@@ -236,7 +236,7 @@ impl Audio {
 			};
 
 			// Hold the lock only to buffer the frame; release it before the callback.
-			let frame_id = State::lock().audio.frames.insert(frame.into_inner())?;
+			let frame_id = State::lock().audio.frames.insert(frame)?;
 			callback.call(Ok(frame_id));
 		}
 	}
@@ -349,11 +349,9 @@ pub unsafe extern "C" fn moq_publish_audio_raw_frame(producer: u32, frame: *cons
 		let frame = unsafe { frame.as_ref() }.ok_or(Error::InvalidPointer)?;
 		let data = unsafe { ffi::parse_slice(frame.data, frame.data_size)? };
 
-		let owned = moq_audio::Frame {
-			// The C ABI carries plain microseconds; scale them at the boundary.
-			timestamp: moq_net::Timestamp::from_micros(frame.timestamp_us).map_err(moq_audio::Error::from)?,
-			data: Bytes::copy_from_slice(data),
-		};
+		// The C ABI carries plain microseconds; scale them at the boundary.
+		let timestamp = moq_net::Timestamp::from_micros(frame.timestamp_us).map_err(moq_audio::Error::from)?;
+		let owned = moq_audio::Frame::new(Bytes::copy_from_slice(data), timestamp);
 
 		let producer = State::lock().audio.producer(producer)?;
 		producer.lock().as_mut().ok_or(Error::MediaNotFound)?.write(&owned)?;

--- a/rs/libmoq/src/audio.rs
+++ b/rs/libmoq/src/audio.rs
@@ -236,7 +236,7 @@ impl Audio {
 			};
 
 			// Hold the lock only to buffer the frame; release it before the callback.
-			let frame_id = State::lock().audio.frames.insert(frame)?;
+			let frame_id = State::lock().audio.frames.insert(frame.into_inner())?;
 			callback.call(Ok(frame_id));
 		}
 	}

--- a/rs/moq-audio/CHANGELOG.md
+++ b/rs/moq-audio/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(moq-audio)* expose Opus DTX classification on produced and consumed audio frames ([#2481](https://github.com/moq-dev/moq/issues/2481))
+
 ## [0.0.21](https://github.com/moq-dev/moq/compare/moq-audio-v0.0.20...moq-audio-v0.0.21) - 2026-09-01
 
 ### Fixed

--- a/rs/moq-audio/CHANGELOG.md
+++ b/rs/moq-audio/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [**breaking**] *(moq-audio)* return `Classified<T>` from audio encode, publish, decode, and consume APIs so callers can observe Opus DTX; use `.value` or `.into_inner()` where the bare value was previously returned ([#2481](https://github.com/moq-dev/moq/issues/2481))
+- [**breaking**] *(moq-audio)* report Opus DTX as an `Activity` on the audio itself: `Frame` gains an `activity` field (build one with the new `Frame::new`), `Encoder::encode` returns `encode::Encoded`, `Decoder::decode` returns `decode::Decoded`, and `encode::Producer::activity` reports what was published most recently ([#2481](https://github.com/moq-dev/moq/issues/2481))
 
 ## [0.0.21](https://github.com/moq-dev/moq/compare/moq-audio-v0.0.20...moq-audio-v0.0.21) - 2026-09-01
 

--- a/rs/moq-audio/CHANGELOG.md
+++ b/rs/moq-audio/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [**breaking**] *(moq-audio)* report Opus DTX as an `Activity` on the audio itself: `Frame` gains an `activity` field (build one with the new `Frame::new`), `Encoder::encode` returns `encode::Encoded`, `Decoder::decode` returns `decode::Decoded`, and `encode::Producer::activity` reports what was published most recently ([#2481](https://github.com/moq-dev/moq/issues/2481))
+- [**breaking**] *(moq-audio)* report Opus discontinuous transmission as an `Activity` on the audio itself: `Frame` gains an `activity` field (build one with the new `Frame::new`), `Encoder::encode` returns `encode::Encoded`, `Decoder::decode` returns `decode::Decoded`, and `encode::Producer::activity` reports what was published most recently ([#2481](https://github.com/moq-dev/moq/issues/2481))
+- [**breaking**] *(moq-audio)* reject an Opus bitrate too low for the frame duration to code any audio, which libopus otherwise accepts and answers with empty frames
 
 ## [0.0.21](https://github.com/moq-dev/moq/compare/moq-audio-v0.0.20...moq-audio-v0.0.21) - 2026-09-01
 

--- a/rs/moq-audio/CHANGELOG.md
+++ b/rs/moq-audio/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(moq-audio)* expose Opus DTX classification on produced and consumed audio frames ([#2481](https://github.com/moq-dev/moq/issues/2481))
+- [**breaking**] *(moq-audio)* return `Classified<T>` from audio encode, publish, decode, and consume APIs so callers can observe Opus DTX; use `.value` or `.into_inner()` where the bare value was previously returned ([#2481](https://github.com/moq-dev/moq/issues/2481))
 
 ## [0.0.21](https://github.com/moq-dev/moq/compare/moq-audio-v0.0.20...moq-audio-v0.0.21) - 2026-09-01
 

--- a/rs/moq-audio/src/activity.rs
+++ b/rs/moq-audio/src/activity.rs
@@ -1,27 +1,36 @@
-/// Whether an encoded audio frame carries active codec data or Opus
-/// discontinuous-transmission comfort noise.
+/// Whether the sender coded audio for a frame, or withheld it because the input
+/// was silent (Opus discontinuous transmission).
 ///
 /// Rides along with the audio it describes: on [`Frame`](crate::Frame) coming
 /// out of [`decode`](crate::decode), and on
 /// [`encode::Encoded`](crate::encode::Encoded) going in. Codecs without a
-/// comfort-noise mode (PCM, AAC) are always [`Active`](Self::Active).
+/// discontinuous mode (PCM, AAC) are always [`Active`](Self::Active).
+///
+/// Read off the packet, so a consumer gets the same answer as the publisher and
+/// gets one for senders that are not us. Opus marks withheld audio but not
+/// silence itself: a run of [`Dtx`](Self::Dtx) is interrupted every few hundred
+/// milliseconds by an ordinarily coded frame of the silence, which reads
+/// [`Active`](Self::Active) because nothing distinguishes it from speech
+/// resuming. So this never reports audio as silence, but it does report silence
+/// as audio for one frame at a time. Hold a talking indicator across the gap
+/// rather than following it frame by frame.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Activity {
-	/// A normally encoded frame.
+	/// The sender coded audio for this frame.
 	#[default]
 	Active,
-	/// An Opus DTX or comfort-noise frame.
+	/// The sender withheld audio for this frame because its input was silent.
 	Dtx,
 }
 
 impl Activity {
-	/// Whether this frame carries normally encoded audio.
+	/// Whether the sender coded audio for this frame.
 	pub fn is_active(self) -> bool {
 		matches!(self, Self::Active)
 	}
 
-	/// Whether this frame is Opus DTX or comfort noise.
+	/// Whether the sender withheld audio for this frame.
 	pub fn is_dtx(self) -> bool {
 		matches!(self, Self::Dtx)
 	}

--- a/rs/moq-audio/src/activity.rs
+++ b/rs/moq-audio/src/activity.rs
@@ -26,7 +26,6 @@ impl Activity {
 
 /// A produced or consumed audio item and its codec activity classification.
 #[derive(Clone, Debug)]
-#[non_exhaustive]
 pub struct Classified<T> {
 	/// The encoded payload, decoded PCM, or published timestamp.
 	pub value: T,

--- a/rs/moq-audio/src/activity.rs
+++ b/rs/moq-audio/src/activity.rs
@@ -1,7 +1,10 @@
-use std::ops::Deref;
-
 /// Whether an encoded audio frame carries active codec data or Opus
 /// discontinuous-transmission comfort noise.
+///
+/// Rides along with the audio it describes: on [`Frame`](crate::Frame) coming
+/// out of [`decode`](crate::decode), and on
+/// [`encode::Encoded`](crate::encode::Encoded) going in. Codecs without a
+/// comfort-noise mode (PCM, AAC) are always [`Active`](Self::Active).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Activity {
@@ -21,41 +24,5 @@ impl Activity {
 	/// Whether this frame is Opus DTX or comfort noise.
 	pub fn is_dtx(self) -> bool {
 		matches!(self, Self::Dtx)
-	}
-}
-
-/// A produced or consumed audio item and its codec activity classification.
-#[derive(Clone, Debug)]
-pub struct Classified<T> {
-	/// The encoded payload, decoded PCM, or published timestamp.
-	pub value: T,
-	/// The codec activity represented by this item.
-	pub activity: Activity,
-}
-
-impl<T> Classified<T> {
-	pub(crate) fn new(value: T, activity: Activity) -> Self {
-		Self { value, activity }
-	}
-
-	/// Transform the contained item while preserving its activity.
-	pub fn map<U>(self, map: impl FnOnce(T) -> U) -> Classified<U> {
-		Classified {
-			value: map(self.value),
-			activity: self.activity,
-		}
-	}
-
-	/// Consume the classification and return the contained item.
-	pub fn into_inner(self) -> T {
-		self.value
-	}
-}
-
-impl<T> Deref for Classified<T> {
-	type Target = T;
-
-	fn deref(&self) -> &Self::Target {
-		&self.value
 	}
 }

--- a/rs/moq-audio/src/activity.rs
+++ b/rs/moq-audio/src/activity.rs
@@ -1,0 +1,62 @@
+use std::ops::Deref;
+
+/// Whether an encoded audio frame carries active codec data or Opus
+/// discontinuous-transmission comfort noise.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Activity {
+	/// A normally encoded frame.
+	#[default]
+	Active,
+	/// An Opus DTX or comfort-noise frame.
+	Dtx,
+}
+
+impl Activity {
+	/// Whether this frame carries normally encoded audio.
+	pub fn is_active(self) -> bool {
+		matches!(self, Self::Active)
+	}
+
+	/// Whether this frame is Opus DTX or comfort noise.
+	pub fn is_dtx(self) -> bool {
+		matches!(self, Self::Dtx)
+	}
+}
+
+/// A produced or consumed audio item and its codec activity classification.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Classified<T> {
+	/// The encoded payload, decoded PCM, or published timestamp.
+	pub value: T,
+	/// The codec activity represented by this item.
+	pub activity: Activity,
+}
+
+impl<T> Classified<T> {
+	pub(crate) fn new(value: T, activity: Activity) -> Self {
+		Self { value, activity }
+	}
+
+	/// Transform the contained item while preserving its activity.
+	pub fn map<U>(self, map: impl FnOnce(T) -> U) -> Classified<U> {
+		Classified {
+			value: map(self.value),
+			activity: self.activity,
+		}
+	}
+
+	/// Consume the classification and return the contained item.
+	pub fn into_inner(self) -> T {
+		self.value
+	}
+}
+
+impl<T> Deref for Classified<T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.value
+	}
+}

--- a/rs/moq-audio/src/activity.rs
+++ b/rs/moq-audio/src/activity.rs
@@ -1,5 +1,4 @@
-/// Whether the sender coded audio for a frame, or withheld it because the input
-/// was silent (Opus discontinuous transmission).
+/// Whether a packet carried coded audio, or none at all.
 ///
 /// Rides along with the audio it describes: on [`Frame`](crate::Frame) coming
 /// out of [`decode`](crate::decode), and on
@@ -7,30 +6,38 @@
 /// discontinuous mode (PCM, AAC) are always [`Active`](Self::Active).
 ///
 /// Read off the packet, so a consumer gets the same answer as the publisher and
-/// gets one for senders that are not us. Opus marks withheld audio but not
-/// silence itself: a run of [`Dtx`](Self::Dtx) is interrupted every few hundred
-/// milliseconds by an ordinarily coded frame of the silence, which reads
-/// [`Active`](Self::Active) because nothing distinguishes it from speech
-/// resuming. So this never reports audio as silence, but it does report silence
-/// as audio for one frame at a time. Hold a talking indicator across the gap
-/// rather than following it frame by frame.
+/// gets one for senders that are not us. Two things follow from that, and both
+/// are why this reports what arrived rather than what the speaker was doing:
+///
+/// - Opus marks withheld audio but not silence itself. A run of
+///   [`Dtx`](Self::Dtx) is interrupted every few hundred milliseconds by an
+///   ordinarily coded frame of the silence, which reads [`Active`](Self::Active)
+///   because nothing distinguishes it from speech resuming. So audio is never
+///   reported as silence, but silence is reported as audio a frame at a time.
+///   Hold a talking indicator across the gap rather than following it frame by
+///   frame.
+/// - A frame that codes nothing usually means the sender withheld it, but RFC
+///   6716 section 3.2.1 lets one stand for a frame that went missing on the way
+///   instead. A relay that repacketizes loss that way reads as
+///   [`Dtx`](Self::Dtx).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Activity {
-	/// The sender coded audio for this frame.
+	/// The packet coded audio for this frame.
 	#[default]
 	Active,
-	/// The sender withheld audio for this frame because its input was silent.
+	/// The packet coded no audio for this frame, which the sender does while its
+	/// input is silent.
 	Dtx,
 }
 
 impl Activity {
-	/// Whether the sender coded audio for this frame.
+	/// Whether the packet coded audio for this frame.
 	pub fn is_active(self) -> bool {
 		matches!(self, Self::Active)
 	}
 
-	/// Whether the sender withheld audio for this frame.
+	/// Whether the packet coded no audio for this frame.
 	pub fn is_dtx(self) -> bool {
 		matches!(self, Self::Dtx)
 	}

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -561,6 +561,11 @@ mod tests {
 		let expected = first_dtx.expect("silence should enter Opus DTX");
 		let mut actual = None;
 		while let Some(frame) = consumer.read().await.unwrap() {
+			// 10 ms packets do not fill the 20 ms chunk, so the resampler hands back
+			// nothing every other packet. Those must not surface as frames: a frame
+			// with no samples reads as audio arriving, and carries an activity
+			// describing samples that are not there.
+			assert!(!frame.data.is_empty(), "read returned a frame with no samples");
 			if frame.activity.is_dtx() {
 				actual = Some(frame.timestamp);
 				break;

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -4,14 +4,14 @@ use bytes::Bytes;
 
 use super::decoder::{Config, Decoder};
 use crate::resample::{Resampler, remix, validate_channels};
-use crate::{Error, Frame};
+use crate::{Activity, Classified, Error, Frame};
 
 /// Subscribe to a moq-mux audio track and emit decoded PCM in the layout
 /// declared by [`Config`].
 ///
 /// The mirror of [`encode::Producer`](crate::encode::Producer): output format /
 /// sample rate / channel count are fixed at construction, and
-/// [`read`](Self::read) returns plain [`Frame`]s.
+/// [`read`](Self::read) returns [`Classified`] [`Frame`]s.
 pub struct Consumer {
 	decoder: Decoder,
 	track: moq_mux::container::Consumer<moq_mux::catalog::hang::Container>,
@@ -22,6 +22,8 @@ pub struct Consumer {
 	/// One past the last sample handed to the resampler, so the tail it is still
 	/// holding at end of track can be stamped. `None` until the first packet.
 	tail: Option<moq_net::Timestamp>,
+	/// Activity of the packet that supplied the resampler's terminal tail.
+	tail_activity: Activity,
 	/// Timestamp of the first encoded packet, used to interpret a terminal marker.
 	epoch: Option<moq_net::Timestamp>,
 	/// Codec-rate terminal frames emitted since `terminal_start`.
@@ -82,6 +84,7 @@ impl Consumer {
 			resolved_sample_rate: sample_rate,
 			resolved_channels: channels,
 			tail: None,
+			tail_activity: Activity::Active,
 			epoch: None,
 			frames_decoded: 0,
 			end: None,
@@ -107,8 +110,9 @@ impl Consumer {
 		self.resolved_channels
 	}
 
-	/// Read the next decoded PCM frame, or `None` when the track ends.
-	pub async fn read(&mut self) -> Result<Option<Frame>, Error> {
+	/// Read the next decoded PCM frame and its codec activity, or `None` when the
+	/// track ends.
+	pub async fn read(&mut self) -> Result<Option<Classified<Frame>>, Error> {
 		loop {
 			let mux_frame = self.track.read().await?;
 			self.apply_discontinuity()?;
@@ -126,7 +130,9 @@ impl Consumer {
 
 			let rate = self.decoder.sample_rate();
 			let epoch = *self.epoch.get_or_insert(mux_frame.timestamp);
-			let mut decoded = self.decoder.decode(&mux_frame.payload)?;
+			let decoded = self.decoder.decode(&mux_frame.payload)?;
+			let activity = decoded.activity;
+			let mut decoded = decoded.into_inner();
 			if let Some(end) = self.end {
 				let terminal_start = *self
 					.terminal_start
@@ -164,8 +170,9 @@ impl Consumer {
 			};
 
 			self.tail = Some(advance(decoded_at, frames, rate)?);
+			self.tail_activity = activity;
 
-			return Ok(Some(self.frame(pcm, timestamp)?));
+			return Ok(Some(Classified::new(self.frame(pcm, timestamp)?, activity)));
 		}
 	}
 
@@ -182,6 +189,7 @@ impl Consumer {
 			resampler.reset();
 		}
 		self.tail = None;
+		self.tail_activity = Activity::Active;
 		self.epoch = None;
 		self.frames_decoded = 0;
 		self.end = None;
@@ -195,7 +203,7 @@ impl Consumer {
 	/// audio missing from the end of every resampled track. Flushing consumes the
 	/// resampler, which is what makes calling this on every later poll return
 	/// `None` rather than more tails.
-	fn flush(&mut self) -> Result<Option<Frame>, Error> {
+	fn flush(&mut self) -> Result<Option<Classified<Frame>>, Error> {
 		let (Some(resampler), Some(tail)) = (self.resampler.take(), self.tail) else {
 			return Ok(None);
 		};
@@ -208,7 +216,7 @@ impl Consumer {
 		}
 
 		let timestamp = self.starts_at(tail, pending, skipped, self.decoder.sample_rate())?;
-		Ok(Some(self.frame(pcm, timestamp)?))
+		Ok(Some(Classified::new(self.frame(pcm, timestamp)?, self.tail_activity)))
 	}
 
 	/// Where the output the resampler is about to hand back actually begins.
@@ -527,7 +535,7 @@ mod tests {
 		producer
 			.write(moq_mux::container::Frame {
 				timestamp: Timestamp::ZERO,
-				payload: packet,
+				payload: packet.value,
 				keyframe: true,
 				duration: None,
 			})

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -124,8 +124,8 @@ impl Consumer {
 
 	/// Read the next decoded PCM frame, or `None` when the track ends.
 	///
-	/// [`Frame::activity`] reports whether the samples came from real audio or
-	/// Opus comfort noise. It describes where the frame begins, so a resampled
+	/// [`Frame::activity`] reports whether the packet these samples came from
+	/// coded audio. It describes where the frame begins, so a resampled
 	/// frame that straddles a change carries the activity its first sample came
 	/// from and the next frame carries the new one.
 	pub async fn read(&mut self) -> Result<Option<Frame>, Error> {
@@ -190,18 +190,28 @@ impl Consumer {
 
 			// The resampler hands back samples it was holding from earlier packets,
 			// so what comes out starts before the packet that filled its chunk. Track
-			// where each packet's activity ends and label the output by where it
-			// actually begins, not by the packet just submitted.
-			let activity = if self.resampler.is_some() {
+			// where each packet's activity ends so the output can be labelled by
+			// where it actually begins, not by the packet just submitted.
+			let resampled = self.resampler.is_some();
+			if resampled {
 				self.spans.push_back(ActivitySpan {
 					end: decoded_end,
 					activity,
 				});
+			}
+
+			// A packet shorter than the resampler's chunk leaves nothing to hand
+			// over yet. Read on rather than returning a frame with no samples, which
+			// a caller would otherwise see as audio arriving.
+			if pcm.is_empty() {
+				continue;
+			}
+
+			let activity = if resampled {
 				self.activity_at(timestamp)
 			} else {
 				activity
 			};
-
 			return Ok(Some(self.frame(pcm, timestamp, activity)?));
 		}
 	}

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -6,14 +6,15 @@ use bytes::Bytes;
 
 use super::decoder::{Config, Decoder};
 use crate::resample::{Resampler, remix, validate_channels};
-use crate::{Activity, Classified, Error, Frame};
+use crate::{Activity, Error, Frame};
 
 /// Subscribe to a moq-mux audio track and emit decoded PCM in the layout
 /// declared by [`Config`].
 ///
 /// The mirror of [`encode::Producer`](crate::encode::Producer): output format /
 /// sample rate / channel count are fixed at construction, and
-/// [`read`](Self::read) returns [`Classified`] [`Frame`]s.
+/// [`read`](Self::read) returns [`Frame`]s carrying the codec activity they
+/// were decoded from.
 pub struct Consumer {
 	decoder: Decoder,
 	track: moq_mux::container::Consumer<moq_mux::catalog::hang::Container>,
@@ -25,9 +26,12 @@ pub struct Consumer {
 	/// holding at end of track can be stamped. `None` until the first packet.
 	tail: Option<moq_net::Timestamp>,
 	/// Codec activity spans still represented by buffered resampler output.
-	activity: VecDeque<ActivitySpan>,
+	spans: VecDeque<ActivitySpan>,
+	/// Activity of the last span the resampler output ran past, which is what the
+	/// filter's trailing rounding samples belong to.
+	trailing: Activity,
 	/// Resampled frames split at activity boundaries and waiting to be returned.
-	pending: VecDeque<Classified<Frame>>,
+	pending: VecDeque<Frame>,
 	/// Timestamp of the first encoded packet, used to interpret a terminal marker.
 	epoch: Option<moq_net::Timestamp>,
 	/// Codec-rate terminal frames emitted since `terminal_start`.
@@ -93,7 +97,8 @@ impl Consumer {
 			resolved_sample_rate: sample_rate,
 			resolved_channels: channels,
 			tail: None,
-			activity: VecDeque::new(),
+			spans: VecDeque::new(),
+			trailing: Activity::Active,
 			pending: VecDeque::new(),
 			epoch: None,
 			frames_decoded: 0,
@@ -120,9 +125,12 @@ impl Consumer {
 		self.resolved_channels
 	}
 
-	/// Read the next decoded PCM frame and its codec activity, or `None` when the
-	/// track ends.
-	pub async fn read(&mut self) -> Result<Option<Classified<Frame>>, Error> {
+	/// Read the next decoded PCM frame, or `None` when the track ends.
+	///
+	/// [`Frame::activity`] reports whether the samples came from real audio or
+	/// Opus comfort noise. When resampling, a frame is cut short so it never spans
+	/// a change: the boundary stays on the source packet that carried it.
+	pub async fn read(&mut self) -> Result<Option<Frame>, Error> {
 		loop {
 			if let Some(frame) = self.pending.pop_front() {
 				return Ok(Some(frame));
@@ -146,7 +154,7 @@ impl Consumer {
 			let epoch = *self.epoch.get_or_insert(mux_frame.timestamp);
 			let decoded = self.decoder.decode(&mux_frame.payload)?;
 			let activity = decoded.activity;
-			let mut decoded = decoded.into_inner();
+			let mut decoded = decoded.samples;
 			if let Some(end) = self.end {
 				let terminal_start = *self
 					.terminal_start
@@ -187,16 +195,16 @@ impl Consumer {
 			self.tail = Some(decoded_end);
 
 			if self.resampler.is_some() {
-				self.activity.push_back(ActivitySpan {
+				self.spans.push_back(ActivitySpan {
 					end: decoded_end,
 					activity,
 				});
-				let classified = self.classify(pcm, timestamp)?;
-				self.pending.extend(classified);
+				let split = self.split(pcm, timestamp)?;
+				self.pending.extend(split);
 				continue;
 			}
 
-			return Ok(Some(Classified::new(self.frame(pcm, timestamp)?, activity)));
+			return Ok(Some(self.frame(pcm, timestamp, activity)?));
 		}
 	}
 
@@ -213,7 +221,8 @@ impl Consumer {
 			resampler.reset();
 		}
 		self.tail = None;
-		self.activity.clear();
+		self.spans.clear();
+		self.trailing = Activity::Active;
 		self.pending.clear();
 		self.epoch = None;
 		self.frames_decoded = 0;
@@ -228,7 +237,7 @@ impl Consumer {
 	/// audio missing from the end of every resampled track. Flushing consumes the
 	/// resampler, which is what makes calling this on every later poll return
 	/// `None` rather than more tails.
-	fn flush(&mut self) -> Result<Option<Classified<Frame>>, Error> {
+	fn flush(&mut self) -> Result<Option<Frame>, Error> {
 		let (Some(resampler), Some(tail)) = (self.resampler.take(), self.tail) else {
 			return Ok(None);
 		};
@@ -237,50 +246,48 @@ impl Consumer {
 		let skipped = resampler.skipped();
 		let timestamp = self.starts_at(tail, pending, skipped, self.decoder.sample_rate())?;
 		let pcm = resampler.flush()?;
-		let classified = self.classify(pcm, timestamp)?;
-		self.pending.extend(classified);
+		let split = self.split(pcm, timestamp)?;
+		self.pending.extend(split);
 		Ok(self.pending.pop_front())
 	}
 
 	/// Split resampler output at the codec activity boundaries it spans.
-	fn classify(&mut self, pcm: Vec<f32>, timestamp: moq_net::Timestamp) -> Result<Vec<Classified<Frame>>, Error> {
+	///
+	/// A chunk starts with samples the resampler was still holding from earlier
+	/// packets, so it can straddle a change that the packet just submitted knows
+	/// nothing about. Cut it where the spans say the change happened instead.
+	fn split(&mut self, pcm: Vec<f32>, timestamp: moq_net::Timestamp) -> Result<Vec<Frame>, Error> {
 		let channels = self.decoder.channel_count().max(1) as usize;
 		let total = pcm.len() / channels;
 		let end = advance(timestamp, total, self.resolved_sample_rate)?;
 		let mut offset = 0;
-		let mut classified = Vec::new();
+		let mut split = Vec::new();
 
 		while offset < total {
 			let cursor = advance(timestamp, offset, self.resolved_sample_rate)?;
-			while self.activity.front().is_some_and(|span| span.end <= cursor) {
-				self.activity.pop_front();
+			while let Some(span) = self.spans.front().filter(|span| span.end <= cursor) {
+				self.trailing = span.activity;
+				self.spans.pop_front();
 			}
 
-			let Some(span) = self.activity.front() else {
-				classified.push(Classified::new(
-					self.frame(pcm[offset * channels..].to_vec(), cursor)?,
-					Activity::Active,
-				));
-				break;
+			// Only a span with another queued behind it is a real split point. The
+			// last one runs to the end of the output, since the sinc filter leaves a
+			// rounding frame or two past the final input boundary and those belong to
+			// the audio they came from rather than to a synthetic active span.
+			let (activity, next) = match self.spans.front() {
+				Some(span) if self.spans.len() > 1 => (
+					span.activity,
+					frames_between(timestamp, span.end.min(end), self.resolved_sample_rate)?.clamp(offset + 1, total),
+				),
+				Some(span) => (span.activity, total),
+				None => (self.trailing, total),
 			};
-			// The sinc filter can leave a rounding frame beyond the final input
-			// boundary. It belongs to the last span rather than a synthetic active
-			// span, while a queued following span is a real split point.
-			let boundary = if self.activity.len() > 1 {
-				span.end.min(end)
-			} else {
-				end
-			};
-			let next = frames_between(timestamp, boundary, self.resolved_sample_rate)?.clamp(offset + 1, total);
-			let activity = span.activity;
-			classified.push(Classified::new(
-				self.frame(pcm[offset * channels..next * channels].to_vec(), cursor)?,
-				activity,
-			));
+
+			split.push(self.frame(pcm[offset * channels..next * channels].to_vec(), cursor, activity)?);
 			offset = next;
 		}
 
-		Ok(classified)
+		Ok(split)
 	}
 
 	/// Where the output the resampler is about to hand back actually begins.
@@ -303,7 +310,7 @@ impl Consumer {
 	}
 
 	/// Remix and pack decoded PCM into an output frame.
-	fn frame(&self, pcm: Vec<f32>, timestamp: moq_net::Timestamp) -> Result<Frame, Error> {
+	fn frame(&self, pcm: Vec<f32>, timestamp: moq_net::Timestamp, activity: Activity) -> Result<Frame, Error> {
 		let pcm = if self.decoder.channel_count() == self.resolved_channels {
 			pcm
 		} else {
@@ -314,6 +321,7 @@ impl Consumer {
 		Ok(Frame {
 			timestamp,
 			data: Bytes::from(bytes),
+			activity,
 		})
 	}
 }
@@ -391,12 +399,7 @@ mod tests {
 		for sample in samples {
 			data.extend_from_slice(&sample.to_le_bytes());
 		}
-		producer
-			.write(&Frame {
-				timestamp: Timestamp::ZERO,
-				data: data.into(),
-			})
-			.unwrap();
+		producer.write(&Frame::new(data.into(), Timestamp::ZERO)).unwrap();
 
 		let frame = consumer.read().await.unwrap().expect("decoded frame");
 		let samples = Format::F32.as_interleaved_f32(&frame.data, 2).unwrap();
@@ -565,7 +568,7 @@ mod tests {
 			producer
 				.write(moq_mux::container::Frame {
 					timestamp,
-					payload: packet.value,
+					payload: packet.payload,
 					keyframe: true,
 					duration: None,
 				})
@@ -663,7 +666,7 @@ mod tests {
 		producer
 			.write(moq_mux::container::Frame {
 				timestamp: Timestamp::ZERO,
-				payload: packet.value,
+				payload: packet.payload,
 				keyframe: true,
 				duration: None,
 			})

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -25,13 +25,11 @@ pub struct Consumer {
 	/// One past the last sample handed to the resampler, so the tail it is still
 	/// holding at end of track can be stamped. `None` until the first packet.
 	tail: Option<moq_net::Timestamp>,
-	/// Codec activity spans still represented by buffered resampler output.
+	/// Codec activity spans the resampler's buffered output still covers.
 	spans: VecDeque<ActivitySpan>,
-	/// Activity of the last span the resampler output ran past, which is what the
-	/// filter's trailing rounding samples belong to.
+	/// Activity of the last span the output ran past, for the rounding samples the
+	/// filter leaves beyond the final input boundary.
 	trailing: Activity,
-	/// Resampled frames split at activity boundaries and waiting to be returned.
-	pending: VecDeque<Frame>,
 	/// Timestamp of the first encoded packet, used to interpret a terminal marker.
 	epoch: Option<moq_net::Timestamp>,
 	/// Codec-rate terminal frames emitted since `terminal_start`.
@@ -99,7 +97,6 @@ impl Consumer {
 			tail: None,
 			spans: VecDeque::new(),
 			trailing: Activity::Active,
-			pending: VecDeque::new(),
 			epoch: None,
 			frames_decoded: 0,
 			end: None,
@@ -128,14 +125,11 @@ impl Consumer {
 	/// Read the next decoded PCM frame, or `None` when the track ends.
 	///
 	/// [`Frame::activity`] reports whether the samples came from real audio or
-	/// Opus comfort noise. When resampling, a frame is cut short so it never spans
-	/// a change: the boundary stays on the source packet that carried it.
+	/// Opus comfort noise. It describes where the frame begins, so a resampled
+	/// frame that straddles a change carries the activity its first sample came
+	/// from and the next frame carries the new one.
 	pub async fn read(&mut self) -> Result<Option<Frame>, Error> {
 		loop {
-			if let Some(frame) = self.pending.pop_front() {
-				return Ok(Some(frame));
-			}
-
 			let mux_frame = self.track.read().await?;
 			self.apply_discontinuity()?;
 			let Some(mux_frame) = mux_frame else {
@@ -194,15 +188,19 @@ impl Consumer {
 			let decoded_end = advance(decoded_at, frames, rate)?;
 			self.tail = Some(decoded_end);
 
-			if self.resampler.is_some() {
+			// The resampler hands back samples it was holding from earlier packets,
+			// so what comes out starts before the packet that filled its chunk. Track
+			// where each packet's activity ends and label the output by where it
+			// actually begins, not by the packet just submitted.
+			let activity = if self.resampler.is_some() {
 				self.spans.push_back(ActivitySpan {
 					end: decoded_end,
 					activity,
 				});
-				let split = self.split(pcm, timestamp)?;
-				self.pending.extend(split);
-				continue;
-			}
+				self.activity_at(timestamp)
+			} else {
+				activity
+			};
 
 			return Ok(Some(self.frame(pcm, timestamp, activity)?));
 		}
@@ -223,7 +221,6 @@ impl Consumer {
 		self.tail = None;
 		self.spans.clear();
 		self.trailing = Activity::Active;
-		self.pending.clear();
 		self.epoch = None;
 		self.frames_decoded = 0;
 		self.end = None;
@@ -244,50 +241,24 @@ impl Consumer {
 
 		let pending = resampler.pending_frames();
 		let skipped = resampler.skipped();
-		let timestamp = self.starts_at(tail, pending, skipped, self.decoder.sample_rate())?;
 		let pcm = resampler.flush()?;
-		let split = self.split(pcm, timestamp)?;
-		self.pending.extend(split);
-		Ok(self.pending.pop_front())
-	}
-
-	/// Split resampler output at the codec activity boundaries it spans.
-	///
-	/// A chunk starts with samples the resampler was still holding from earlier
-	/// packets, so it can straddle a change that the packet just submitted knows
-	/// nothing about. Cut it where the spans say the change happened instead.
-	fn split(&mut self, pcm: Vec<f32>, timestamp: moq_net::Timestamp) -> Result<Vec<Frame>, Error> {
-		let channels = self.decoder.channel_count().max(1) as usize;
-		let total = pcm.len() / channels;
-		let end = advance(timestamp, total, self.resolved_sample_rate)?;
-		let mut offset = 0;
-		let mut split = Vec::new();
-
-		while offset < total {
-			let cursor = advance(timestamp, offset, self.resolved_sample_rate)?;
-			while let Some(span) = self.spans.front().filter(|span| span.end <= cursor) {
-				self.trailing = span.activity;
-				self.spans.pop_front();
-			}
-
-			// Only a span with another queued behind it is a real split point. The
-			// last one runs to the end of the output, since the sinc filter leaves a
-			// rounding frame or two past the final input boundary and those belong to
-			// the audio they came from rather than to a synthetic active span.
-			let (activity, next) = match self.spans.front() {
-				Some(span) if self.spans.len() > 1 => (
-					span.activity,
-					frames_between(timestamp, span.end.min(end), self.resolved_sample_rate)?.clamp(offset + 1, total),
-				),
-				Some(span) => (span.activity, total),
-				None => (self.trailing, total),
-			};
-
-			split.push(self.frame(pcm[offset * channels..next * channels].to_vec(), cursor, activity)?);
-			offset = next;
+		if pcm.is_empty() {
+			return Ok(None);
 		}
 
-		Ok(split)
+		let timestamp = self.starts_at(tail, pending, skipped, self.decoder.sample_rate())?;
+		let activity = self.activity_at(timestamp);
+		Ok(Some(self.frame(pcm, timestamp, activity)?))
+	}
+
+	/// The codec activity covering `timestamp`, dropping the spans it has passed.
+	fn activity_at(&mut self, timestamp: moq_net::Timestamp) -> Activity {
+		while let Some(span) = self.spans.front().filter(|span| span.end <= timestamp) {
+			self.trailing = span.activity;
+			self.spans.pop_front();
+		}
+
+		self.spans.front().map_or(self.trailing, |span| span.activity)
 	}
 
 	/// Where the output the resampler is about to hand back actually begins.
@@ -527,7 +498,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn resampling_splits_frames_at_activity_boundaries() {
+	async fn resampling_keeps_the_activity_boundary_on_its_source() {
 		let mut encoder = Encoder::new(&crate::encode::Config {
 			dtx: true,
 			bitrate: Some(24_000),
@@ -586,8 +557,19 @@ mod tests {
 			}
 		}
 		let actual = actual.expect("consumer should report Opus DTX");
-		let error = actual.as_micros().abs_diff(expected.as_micros());
-		assert!(error < 100, "activity boundary moved by {error} us during resampling");
+
+		// Each frame carries the activity its first sample came from, so the label
+		// can lag its source by up to the frame it lands in, but it must never lead
+		// it: leading means samples that are still active got labelled DTX. That is
+		// what labelling by the packet most recently submitted does, since the
+		// resampler is handing back audio from before that packet. It puts the
+		// boundary a chunk early instead of a fraction of a chunk late.
+		let delay = actual.as_micros() as i128 - expected.as_micros() as i128;
+		let chunk_us = 20_000i128;
+		assert!(
+			(0..chunk_us).contains(&delay),
+			"DTX label landed {delay} us from its source, outside [0, {chunk_us})"
+		);
 	}
 
 	#[tokio::test]

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -1,5 +1,7 @@
 //! Subscribe to an encoded audio track and emit raw PCM.
 
+use std::collections::VecDeque;
+
 use bytes::Bytes;
 
 use super::decoder::{Config, Decoder};
@@ -22,8 +24,10 @@ pub struct Consumer {
 	/// One past the last sample handed to the resampler, so the tail it is still
 	/// holding at end of track can be stamped. `None` until the first packet.
 	tail: Option<moq_net::Timestamp>,
-	/// Activity of the packet that supplied the resampler's terminal tail.
-	tail_activity: Activity,
+	/// Codec activity spans still represented by buffered resampler output.
+	activity: VecDeque<ActivitySpan>,
+	/// Resampled frames split at activity boundaries and waiting to be returned.
+	pending: VecDeque<Classified<Frame>>,
 	/// Timestamp of the first encoded packet, used to interpret a terminal marker.
 	epoch: Option<moq_net::Timestamp>,
 	/// Codec-rate terminal frames emitted since `terminal_start`.
@@ -34,6 +38,11 @@ pub struct Consumer {
 	terminal_start: Option<moq_net::Timestamp>,
 	/// Last container discontinuity applied to codec and resampler state.
 	discontinuity: u64,
+}
+
+struct ActivitySpan {
+	end: moq_net::Timestamp,
+	activity: Activity,
 }
 
 impl Consumer {
@@ -84,7 +93,8 @@ impl Consumer {
 			resolved_sample_rate: sample_rate,
 			resolved_channels: channels,
 			tail: None,
-			tail_activity: Activity::Active,
+			activity: VecDeque::new(),
+			pending: VecDeque::new(),
 			epoch: None,
 			frames_decoded: 0,
 			end: None,
@@ -114,6 +124,10 @@ impl Consumer {
 	/// track ends.
 	pub async fn read(&mut self) -> Result<Option<Classified<Frame>>, Error> {
 		loop {
+			if let Some(frame) = self.pending.pop_front() {
+				return Ok(Some(frame));
+			}
+
 			let mux_frame = self.track.read().await?;
 			self.apply_discontinuity()?;
 			let Some(mux_frame) = mux_frame else {
@@ -169,8 +183,18 @@ impl Consumer {
 				None => (decoded, decoded_at),
 			};
 
-			self.tail = Some(advance(decoded_at, frames, rate)?);
-			self.tail_activity = activity;
+			let decoded_end = advance(decoded_at, frames, rate)?;
+			self.tail = Some(decoded_end);
+
+			if self.resampler.is_some() {
+				self.activity.push_back(ActivitySpan {
+					end: decoded_end,
+					activity,
+				});
+				let classified = self.classify(pcm, timestamp)?;
+				self.pending.extend(classified);
+				continue;
+			}
 
 			return Ok(Some(Classified::new(self.frame(pcm, timestamp)?, activity)));
 		}
@@ -189,7 +213,8 @@ impl Consumer {
 			resampler.reset();
 		}
 		self.tail = None;
-		self.tail_activity = Activity::Active;
+		self.activity.clear();
+		self.pending.clear();
 		self.epoch = None;
 		self.frames_decoded = 0;
 		self.end = None;
@@ -210,13 +235,52 @@ impl Consumer {
 
 		let pending = resampler.pending_frames();
 		let skipped = resampler.skipped();
+		let timestamp = self.starts_at(tail, pending, skipped, self.decoder.sample_rate())?;
 		let pcm = resampler.flush()?;
-		if pcm.is_empty() {
-			return Ok(None);
+		let classified = self.classify(pcm, timestamp)?;
+		self.pending.extend(classified);
+		Ok(self.pending.pop_front())
+	}
+
+	/// Split resampler output at the codec activity boundaries it spans.
+	fn classify(&mut self, pcm: Vec<f32>, timestamp: moq_net::Timestamp) -> Result<Vec<Classified<Frame>>, Error> {
+		let channels = self.decoder.channel_count().max(1) as usize;
+		let total = pcm.len() / channels;
+		let end = advance(timestamp, total, self.resolved_sample_rate)?;
+		let mut offset = 0;
+		let mut classified = Vec::new();
+
+		while offset < total {
+			let cursor = advance(timestamp, offset, self.resolved_sample_rate)?;
+			while self.activity.front().is_some_and(|span| span.end <= cursor) {
+				self.activity.pop_front();
+			}
+
+			let Some(span) = self.activity.front() else {
+				classified.push(Classified::new(
+					self.frame(pcm[offset * channels..].to_vec(), cursor)?,
+					Activity::Active,
+				));
+				break;
+			};
+			// The sinc filter can leave a rounding frame beyond the final input
+			// boundary. It belongs to the last span rather than a synthetic active
+			// span, while a queued following span is a real split point.
+			let boundary = if self.activity.len() > 1 {
+				span.end.min(end)
+			} else {
+				end
+			};
+			let next = frames_between(timestamp, boundary, self.resolved_sample_rate)?.clamp(offset + 1, total);
+			let activity = span.activity;
+			classified.push(Classified::new(
+				self.frame(pcm[offset * channels..next * channels].to_vec(), cursor)?,
+				activity,
+			));
+			offset = next;
 		}
 
-		let timestamp = self.starts_at(tail, pending, skipped, self.decoder.sample_rate())?;
-		Ok(Some(Classified::new(self.frame(pcm, timestamp)?, self.tail_activity)))
+		Ok(classified)
 	}
 
 	/// Where the output the resampler is about to hand back actually begins.
@@ -457,6 +521,70 @@ mod tests {
 		let total = first_frames + tail_frames;
 		assert!((1105..=1120).contains(&total), "unexpected total: {total}");
 		assert!(consumer.read().await.unwrap().is_none());
+	}
+
+	#[tokio::test]
+	async fn resampling_splits_frames_at_activity_boundaries() {
+		let mut encoder = Encoder::new(&crate::encode::Config {
+			dtx: true,
+			bitrate: Some(24_000),
+			frame_duration: std::time::Duration::from_millis(10),
+			..crate::encode::Config::new(Input {
+				channels: 1,
+				..Input::default()
+			})
+		})
+		.unwrap();
+		let catalog = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 1);
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
+		let subscriber = broadcast.consume();
+		let mut producer = moq_mux::container::Producer::new(track, moq_mux::catalog::hang::Container::Legacy);
+		let mut consumer = Consumer::new(
+			&subscriber,
+			&catalog,
+			"audio",
+			Config {
+				sample_rate: Some(44_100),
+				..Config::new()
+			},
+		)
+		.await
+		.unwrap();
+
+		let active = vec![0.5; encoder.frame_size()];
+		let silence = vec![0.0; encoder.frame_size()];
+		let mut first_dtx = None;
+		for index in 0..40u64 {
+			let packet = encoder.encode(if index == 0 { &active } else { &silence }).unwrap();
+			let timestamp = Timestamp::from_scale(index * encoder.frame_size() as u64, 48_000).unwrap();
+			if first_dtx.is_none() && packet.activity.is_dtx() {
+				first_dtx = Some(timestamp);
+			}
+			producer
+				.write(moq_mux::container::Frame {
+					timestamp,
+					payload: packet.value,
+					keyframe: true,
+					duration: None,
+				})
+				.unwrap();
+			producer.cut(None).unwrap();
+		}
+		producer.finish().unwrap();
+
+		let expected = first_dtx.expect("silence should enter Opus DTX");
+		let mut actual = None;
+		while let Some(frame) = consumer.read().await.unwrap() {
+			if frame.activity.is_dtx() {
+				actual = Some(frame.timestamp);
+				break;
+			}
+		}
+		let actual = actual.expect("consumer should report Opus DTX");
+		let error = actual.as_micros().abs_diff(expected.as_micros());
+		assert!(error < 100, "activity boundary moved by {error} us during resampling");
 	}
 
 	#[tokio::test]

--- a/rs/moq-audio/src/decode/decoded.rs
+++ b/rs/moq-audio/src/decode/decoded.rs
@@ -12,8 +12,8 @@ use crate::Activity;
 pub struct Decoded {
 	/// Interleaved samples, at [`Decoder::sample_rate`](super::Decoder::sample_rate).
 	pub samples: Vec<f32>,
-	/// Whether the sender coded audio for this packet or withheld it. Always
-	/// [`Activity::Active`] for codecs without a discontinuous mode, and for the
-	/// coded frames that punctuate a silent run.
+	/// Whether this packet coded any audio. Always [`Activity::Active`] for
+	/// codecs without a discontinuous mode, and for the coded frames that
+	/// punctuate a silent run.
 	pub activity: Activity,
 }

--- a/rs/moq-audio/src/decode/decoded.rs
+++ b/rs/moq-audio/src/decode/decoded.rs
@@ -1,0 +1,18 @@
+//! [`Decoded`]: one packet's worth of PCM on its way out of a codec.
+
+use crate::Activity;
+
+/// One decoded Opus/PCM/AAC packet: interleaved `f32` samples at the codec's own
+/// rate and channel count, plus what the codec was doing when it produced them.
+///
+/// The low-level counterpart to [`encode::Encoded`](crate::encode::Encoded).
+/// [`Consumer`](super::Consumer) turns these into [`Frame`](crate::Frame)s in
+/// the layout its [`Config`](super::Config) asks for.
+#[derive(Clone, Debug)]
+pub struct Decoded {
+	/// Interleaved samples, at [`Decoder::sample_rate`](super::Decoder::sample_rate).
+	pub samples: Vec<f32>,
+	/// Real audio, or the comfort noise an Opus sender emits while silent.
+	/// Always [`Activity::Active`] for codecs without a DTX mode.
+	pub activity: Activity,
+}

--- a/rs/moq-audio/src/decode/decoded.rs
+++ b/rs/moq-audio/src/decode/decoded.rs
@@ -12,7 +12,8 @@ use crate::Activity;
 pub struct Decoded {
 	/// Interleaved samples, at [`Decoder::sample_rate`](super::Decoder::sample_rate).
 	pub samples: Vec<f32>,
-	/// Real audio, or the comfort noise an Opus sender emits while silent.
-	/// Always [`Activity::Active`] for codecs without a DTX mode.
+	/// Whether the sender coded audio for this packet or withheld it. Always
+	/// [`Activity::Active`] for codecs without a discontinuous mode, and for the
+	/// coded frames that punctuate a silent run.
 	pub activity: Activity,
 }

--- a/rs/moq-audio/src/decode/decoder.rs
+++ b/rs/moq-audio/src/decode/decoder.rs
@@ -17,7 +17,7 @@ use symphonia_core::codecs::audio::AudioDecoder;
 use crate::aac;
 use crate::opus;
 use crate::pcm;
-use crate::{Error, Format};
+use crate::{Activity, Classified, Error, Format};
 
 /// Opus packets cap at 120 ms (RFC 6716 §2.1.4).
 const MAX_FRAME_MS: usize = 120;
@@ -86,6 +86,7 @@ struct Opus {
 	inner: *mut OpusDecoder,
 	pre_skip_remaining: usize,
 	max_frame_size: usize,
+	in_dtx: bool,
 }
 
 // SAFETY: see Encoder.
@@ -143,6 +144,7 @@ impl Decoder {
 				inner,
 				pre_skip_remaining,
 				max_frame_size,
+				in_dtx: false,
 			}),
 			sample_rate,
 			channel_count,
@@ -239,6 +241,7 @@ impl Decoder {
 					return Err(crate::opus::error(rc, "OPUS_RESET_STATE"));
 				}
 				opus.pre_skip_remaining = self.delay;
+				opus.in_dtx = false;
 			}
 			Backend::Pcm { .. } => {}
 			#[cfg(feature = "aac")]
@@ -252,8 +255,11 @@ impl Decoder {
 		self.delay
 	}
 
-	/// Decode one packet into interleaved `f32` PCM.
-	pub fn decode(&mut self, packet: &[u8]) -> Result<Vec<f32>, Error> {
+	/// Decode one packet into interleaved `f32` PCM and report its codec activity.
+	///
+	/// Empty Opus packets invoke packet-loss concealment. Loss during DTX remains
+	/// classified as DTX, while loss during active audio remains active.
+	pub fn decode(&mut self, packet: &[u8]) -> Result<Classified<Vec<f32>>, Error> {
 		match &mut self.backend {
 			Backend::Opus(opus) => {
 				let mut out = vec![0.0f32; opus.max_frame_size * self.channel_count as usize];
@@ -280,7 +286,9 @@ impl Decoder {
 					out.truncate(out.len() - trim_samples);
 					opus.pre_skip_remaining -= trim_frames;
 				}
-				Ok(out)
+				let activity = crate::opus::activity(packet, opus.in_dtx);
+				opus.in_dtx = activity.is_dtx();
+				Ok(Classified::new(out, activity))
 			}
 			Backend::Pcm { bytes_per_frame } => {
 				if packet.is_empty() || !packet.len().is_multiple_of(*bytes_per_frame) {
@@ -290,10 +298,11 @@ impl Decoder {
 					});
 				}
 
-				Ok(packet
+				let out = packet
 					.chunks_exact(pcm::BYTES_PER_SAMPLE)
 					.map(|sample| f32::from_le_bytes([sample[0], sample[1], sample[2], sample[3]]))
-					.collect())
+					.collect();
+				Ok(Classified::new(out, Activity::Active))
 			}
 			#[cfg(feature = "aac")]
 			Backend::Aac(aac) => {
@@ -314,7 +323,7 @@ impl Decoder {
 
 				let mut out = Vec::new();
 				decoded.copy_to_vec_interleaved(&mut out);
-				Ok(out)
+				Ok(Classified::new(out, Activity::Active))
 			}
 		}
 	}
@@ -365,7 +374,10 @@ mod tests {
 		assert_eq!(decoder.sample_rate(), 44_100);
 		assert_eq!(decoder.channel_count(), 1);
 
-		let decoded: Vec<Vec<f32>> = AAC_FRAMES.iter().map(|frame| decoder.decode(frame).unwrap()).collect();
+		let decoded: Vec<Vec<f32>> = AAC_FRAMES
+			.iter()
+			.map(|frame| decoder.decode(frame).unwrap().into_inner())
+			.collect();
 
 		// AAC-LC frames are 1024 samples each, whatever the packet size.
 		for pcm in &decoded {

--- a/rs/moq-audio/src/decode/decoder.rs
+++ b/rs/moq-audio/src/decode/decoder.rs
@@ -13,11 +13,12 @@ use unsafe_libopus::{
 #[cfg(feature = "aac")]
 use symphonia_core::codecs::audio::AudioDecoder;
 
+use super::Decoded;
 #[cfg(feature = "aac")]
 use crate::aac;
 use crate::opus;
 use crate::pcm;
-use crate::{Activity, Classified, Error, Format};
+use crate::{Activity, Error, Format};
 
 /// Opus packets cap at 120 ms (RFC 6716 §2.1.4).
 const MAX_FRAME_MS: usize = 120;
@@ -259,7 +260,7 @@ impl Decoder {
 	///
 	/// Empty Opus packets invoke packet-loss concealment. Loss during DTX remains
 	/// classified as DTX, while loss during active audio remains active.
-	pub fn decode(&mut self, packet: &[u8]) -> Result<Classified<Vec<f32>>, Error> {
+	pub fn decode(&mut self, packet: &[u8]) -> Result<Decoded, Error> {
 		match &mut self.backend {
 			Backend::Opus(opus) => {
 				let mut out = vec![0.0f32; opus.max_frame_size * self.channel_count as usize];
@@ -288,7 +289,7 @@ impl Decoder {
 				}
 				let activity = crate::opus::activity(packet, opus.in_dtx);
 				opus.in_dtx = activity.is_dtx();
-				Ok(Classified::new(out, activity))
+				Ok(Decoded { samples: out, activity })
 			}
 			Backend::Pcm { bytes_per_frame } => {
 				if packet.is_empty() || !packet.len().is_multiple_of(*bytes_per_frame) {
@@ -302,7 +303,10 @@ impl Decoder {
 					.chunks_exact(pcm::BYTES_PER_SAMPLE)
 					.map(|sample| f32::from_le_bytes([sample[0], sample[1], sample[2], sample[3]]))
 					.collect();
-				Ok(Classified::new(out, Activity::Active))
+				Ok(Decoded {
+					samples: out,
+					activity: Activity::Active,
+				})
 			}
 			#[cfg(feature = "aac")]
 			Backend::Aac(aac) => {
@@ -323,7 +327,10 @@ impl Decoder {
 
 				let mut out = Vec::new();
 				decoded.copy_to_vec_interleaved(&mut out);
-				Ok(Classified::new(out, Activity::Active))
+				Ok(Decoded {
+					samples: out,
+					activity: Activity::Active,
+				})
 			}
 		}
 	}
@@ -376,7 +383,7 @@ mod tests {
 
 		let decoded: Vec<Vec<f32>> = AAC_FRAMES
 			.iter()
-			.map(|frame| decoder.decode(frame).unwrap().into_inner())
+			.map(|frame| decoder.decode(frame).unwrap().samples)
 			.collect();
 
 		// AAC-LC frames are 1024 samples each, whatever the packet size.
@@ -410,7 +417,7 @@ mod tests {
 
 		let mut decoder = Decoder::new(&catalog).unwrap();
 		assert_eq!(decoder.sample_rate(), 44_100);
-		assert_eq!(decoder.decode(AAC_FRAMES[0]).unwrap().len(), 1024);
+		assert_eq!(decoder.decode(AAC_FRAMES[0]).unwrap().samples.len(), 1024);
 	}
 
 	/// A packet libopus rejects is that packet's problem, not the

--- a/rs/moq-audio/src/decode/mod.rs
+++ b/rs/moq-audio/src/decode/mod.rs
@@ -4,17 +4,19 @@
 //! `moq-video`'s [`decode`](https://docs.rs/moq-video) module.
 //!
 //! Entry points, high to low level:
-//! - [`Consumer`] subscribes to a track and hands back
-//!   [`Classified`](crate::Classified) decoded [`Frame`](crate::Frame)s.
-//! - [`Decoder`] decodes packets you supply (bring your own payloads), returning
-//!   classified interleaved `f32` samples.
+//! - [`Consumer`] subscribes to a track and hands back decoded
+//!   [`Frame`](crate::Frame)s.
+//! - [`Decoder`] decodes packets you supply (bring your own payloads) into
+//!   [`Decoded`] interleaved `f32` samples.
 //!
 //! [`Config`] configures [`Consumer`]'s PCM output layout. The lower-level
 //! [`Decoder`] emits the codec-native sample rate and channel count from the
 //! catalog.
 
 mod consumer;
+mod decoded;
 mod decoder;
 
 pub use consumer::Consumer;
+pub use decoded::Decoded;
 pub use decoder::{Config, Decoder};

--- a/rs/moq-audio/src/decode/mod.rs
+++ b/rs/moq-audio/src/decode/mod.rs
@@ -4,8 +4,10 @@
 //! `moq-video`'s [`decode`](https://docs.rs/moq-video) module.
 //!
 //! Entry points, high to low level:
-//! - [`Consumer`] subscribes to a track and hands back decoded [`Frame`](crate::Frame)s.
-//! - [`Decoder`] decodes packets you supply (bring your own payloads).
+//! - [`Consumer`] subscribes to a track and hands back
+//!   [`Classified`](crate::Classified) decoded [`Frame`](crate::Frame)s.
+//! - [`Decoder`] decodes packets you supply (bring your own payloads), returning
+//!   classified interleaved `f32` samples.
 //!
 //! [`Config`] configures [`Consumer`]'s PCM output layout. The lower-level
 //! [`Decoder`] emits the codec-native sample rate and channel count from the

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -997,10 +997,7 @@ fn frame(samples: &[f32], timestamp_us: u64) -> Result<Frame, Error> {
 	for sample in samples {
 		bytes.extend_from_slice(&sample.to_le_bytes());
 	}
-	Ok(Frame {
-		timestamp: moq_net::Timestamp::from_micros(timestamp_us)?,
-		data: bytes.into(),
-	})
+	Ok(Frame::new(bytes.into(), moq_net::Timestamp::from_micros(timestamp_us)?))
 }
 
 #[cfg(test)]

--- a/rs/moq-audio/src/encode/encoded.rs
+++ b/rs/moq-audio/src/encode/encoded.rs
@@ -1,0 +1,28 @@
+//! [`Encoded`]: one encoded packet on its way to a track.
+
+use bytes::Bytes;
+
+use crate::Activity;
+
+/// One encoded audio packet, plus what the codec was doing when it produced it.
+///
+/// Named for what it holds rather than mirroring [`Frame`](crate::Frame), so the
+/// two never read alike at a call site that handles both.
+#[derive(Clone, Debug)]
+pub struct Encoded {
+	/// The packet, in the framing the matching catalog importer expects.
+	pub payload: Bytes,
+	/// Real audio, or the comfort noise Opus sends while the input is silent.
+	/// Always [`Activity::Active`] for codecs without a DTX mode.
+	pub activity: Activity,
+}
+
+impl Encoded {
+	/// A packet carrying real audio.
+	pub fn new(payload: Bytes) -> Self {
+		Self {
+			payload,
+			activity: Activity::Active,
+		}
+	}
+}

--- a/rs/moq-audio/src/encode/encoded.rs
+++ b/rs/moq-audio/src/encode/encoded.rs
@@ -12,8 +12,9 @@ use crate::Activity;
 pub struct Encoded {
 	/// The packet, in the framing the matching catalog importer expects.
 	pub payload: Bytes,
-	/// Real audio, or the comfort noise Opus sends while the input is silent.
-	/// Always [`Activity::Active`] for codecs without a DTX mode.
+	/// Whether this packet codes audio, or withholds it because the input was
+	/// silent. Always [`Activity::Active`] for codecs without a discontinuous
+	/// mode, and for the coded frames that punctuate a silent run.
 	pub activity: Activity,
 }
 

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -9,15 +9,15 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use unsafe_libopus::{
-	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK, OPUS_RESET_STATE,
-	OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder, opus_encode_float,
-	opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
+	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_IN_DTX_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK,
+	OPUS_RESET_STATE, OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder,
+	opus_encode_float, opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
 };
 
 use super::Encoded;
 use crate::opus;
 use crate::pcm;
-use crate::{Error, Format};
+use crate::{Activity, Error, Format};
 
 /// libopus packet size ceiling per RFC 6716 §3.4.
 const MAX_PACKET_BYTES: usize = 4_000;
@@ -171,6 +171,9 @@ enum Backend {
 struct Opus {
 	inner: *mut OpusEncoder,
 	scratch: Vec<u8>,
+	/// Whether the last packet was classified as comfort noise, which is what
+	/// lets a refresh be told apart from a return to audio.
+	in_dtx: bool,
 }
 
 // SAFETY: OpusEncoder is heap-allocated state owned exclusively by this
@@ -248,6 +251,7 @@ impl Encoder {
 			backend: Backend::Opus(Opus {
 				inner,
 				scratch: vec![0u8; MAX_PACKET_BYTES],
+				in_dtx: false,
 			}),
 			config,
 			codec_rate,
@@ -349,6 +353,11 @@ impl Encoder {
 		Ok(())
 	}
 
+	/// Whether libopus is currently withholding audio frames.
+	fn in_dtx(inner: *mut OpusEncoder) -> Result<bool, Error> {
+		Ok(Self::get_opus_ctl(inner, OPUS_GET_IN_DTX_REQUEST, "OPUS_GET_IN_DTX")? != 0)
+	}
+
 	fn get_opus_ctl(inner: *mut OpusEncoder, request: i32, name: &'static str) -> Result<i32, Error> {
 		let mut value = 0;
 		// SAFETY: `inner` owns a live encoder and each request here expects one
@@ -413,6 +422,7 @@ impl Encoder {
 			// SAFETY: `inner` owns a live encoder and OPUS_RESET_STATE takes no arguments.
 			let rc = unsafe { opus_encoder_ctl_impl(opus.inner, OPUS_RESET_STATE, varargs![]) };
 			debug_assert_eq!(rc, OPUS_OK, "OPUS_RESET_STATE failed with {rc}");
+			opus.in_dtx = false;
 		}
 		self.started = false;
 	}
@@ -452,10 +462,20 @@ impl Encoder {
 					return Err(crate::opus::error(n, "opus_encode_float"));
 				}
 				let payload = Bytes::copy_from_slice(&opus.scratch[..n as usize]);
-				// The same rule the decoder applies, rather than OPUS_GET_IN_DTX: the
-				// control flips a packet before libopus first omits coded audio, and
-				// reading the packet keeps both sides classifying it identically.
-				let activity = crate::opus::activity(&payload, false);
+				// The framing decides, so the decoder reaches the same answer from the
+				// packet alone. It is ambiguous in exactly one place: a bare TOC codes
+				// nothing, which is silence while libopus is withholding audio and a
+				// starved bitrate when it is not (below `3 * frame_rate * 8` bps it
+				// emits one for loud input too). `OPUS_GET_IN_DTX` is the only thing
+				// that separates those, so it is used to veto that case and nothing
+				// else. A SID refresh is never empty, so it needs no veto.
+				let starved = !Self::in_dtx(opus.inner)? && crate::opus::carries_nothing(&payload);
+				let activity = if crate::opus::is_comfort_noise(&payload, opus.in_dtx) && !starved {
+					Activity::Dtx
+				} else {
+					Activity::Active
+				};
+				opus.in_dtx = activity.is_dtx();
 				Encoded { payload, activity }
 			}
 			Backend::Pcm => {
@@ -748,6 +768,75 @@ mod tests {
 				"{duration_ms} ms Opus should refresh DTX comfort noise"
 			);
 		}
+	}
+
+	/// Below libopus's `3 * frame_rate * 8` bps floor the encoder emits a bare TOC
+	/// whatever the input, so the packet framing alone reads loud audio as comfort
+	/// noise. `OPUS_GET_IN_DTX` is the only thing that tells them apart.
+	#[test]
+	fn opus_starved_bitrate_audio_is_not_dtx() {
+		// 500 bps at 20 ms is under the 1,200 bps floor, and the crate accepts it.
+		let mut enc = Encoder::new(&Config {
+			dtx: true,
+			bitrate: Some(500),
+			..Config::new(Input {
+				channels: 1,
+				..Input::default()
+			})
+		})
+		.unwrap();
+		let loud = sine(440.0, enc.codec_rate(), enc.codec_channels(), enc.frame_size());
+
+		for _ in 0..10 {
+			let packet = enc.encode(&loud).unwrap();
+			assert_eq!(packet.payload.len(), 1, "a starved encoder emits a bare TOC");
+			assert_eq!(
+				packet.activity,
+				Activity::Active,
+				"loud audio is never comfort noise, however little of it fits"
+			);
+		}
+	}
+
+	/// The first refresh after entering DTX at 40 ms leaves one frame empty beside
+	/// a full-size one, which is silence rather than a return to audio.
+	#[test]
+	fn opus_partially_empty_refresh_stays_dtx() {
+		let mut enc = Encoder::new(&Config {
+			dtx: true,
+			bitrate: Some(24_000),
+			frame_duration: Duration::from_millis(40),
+			..Config::new(Input {
+				channels: 1,
+				..Input::default()
+			})
+		})
+		.unwrap();
+		let mut dec = Decoder::new(&enc.catalog()).unwrap();
+		let loud = sine(440.0, enc.codec_rate(), enc.codec_channels(), enc.frame_size());
+		let silence = vec![0.0; enc.frame_size()];
+
+		for _ in 0..6 {
+			enc.encode(&loud).unwrap();
+		}
+
+		let mut mixed = None;
+		for _ in 0..60 {
+			let packet = enc.encode(&silence).unwrap();
+			let sizes = crate::opus::frame_sizes_for_test(&packet.payload);
+			assert_eq!(
+				dec.decode(&packet.payload).unwrap().activity,
+				packet.activity,
+				"encoder and decoder disagree on {sizes:?}"
+			);
+			if sizes.contains(&0) && sizes.iter().any(|&size| size > 2) {
+				mixed = Some(packet);
+				break;
+			}
+		}
+
+		let mixed = mixed.expect("40 ms DTX should refresh with one coded frame beside an empty one");
+		assert_eq!(mixed.activity, Activity::Dtx);
 	}
 
 	#[test]

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -9,9 +9,9 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use unsafe_libopus::{
-	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK, OPUS_RESET_STATE,
-	OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder, opus_encode_float,
-	opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
+	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_IN_DTX_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK,
+	OPUS_RESET_STATE, OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder,
+	opus_encode_float, opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
 };
 
 use crate::opus;
@@ -171,6 +171,7 @@ enum Backend {
 struct Opus {
 	inner: *mut OpusEncoder,
 	scratch: Vec<u8>,
+	in_dtx: bool,
 }
 
 // SAFETY: OpusEncoder is heap-allocated state owned exclusively by this
@@ -248,6 +249,7 @@ impl Encoder {
 			backend: Backend::Opus(Opus {
 				inner,
 				scratch: vec![0u8; MAX_PACKET_BYTES],
+				in_dtx: false,
 			}),
 			config,
 			codec_rate,
@@ -413,6 +415,7 @@ impl Encoder {
 			// SAFETY: `inner` owns a live encoder and OPUS_RESET_STATE takes no arguments.
 			let rc = unsafe { opus_encoder_ctl_impl(opus.inner, OPUS_RESET_STATE, varargs![]) };
 			debug_assert_eq!(rc, OPUS_OK, "OPUS_RESET_STATE failed with {rc}");
+			opus.in_dtx = false;
 		}
 		self.started = false;
 	}
@@ -452,7 +455,17 @@ impl Encoder {
 					return Err(crate::opus::error(n, "opus_encode_float"));
 				}
 				let payload = Bytes::copy_from_slice(&opus.scratch[..n as usize]);
-				let activity = crate::opus::activity(&payload, false);
+				let packet_activity = crate::opus::activity(&payload, opus.in_dtx);
+				let reported = Self::get_opus_ctl(opus.inner, OPUS_GET_IN_DTX_REQUEST, "OPUS_GET_IN_DTX")? != 0;
+				// libopus 1.3 reports DTX one packet before it first omits coded
+				// audio. Require the packet marker to enter the state, then trust the
+				// control for periodic comfort-noise refreshes and recovery.
+				let activity = if reported && (opus.in_dtx || packet_activity.is_dtx()) {
+					Activity::Dtx
+				} else {
+					Activity::Active
+				};
+				opus.in_dtx = activity.is_dtx();
 				Classified::new(payload, activity)
 			}
 			Backend::Pcm => {
@@ -709,6 +722,41 @@ mod tests {
 		}
 		assert!(recovered, "active audio should exit Opus DTX");
 		assert_eq!(dec.decode(&[]).unwrap().activity, Activity::Active);
+	}
+
+	#[test]
+	fn opus_classifies_periodic_dtx_refreshes() {
+		for duration_ms in [20, 40, 60] {
+			let mut enc = Encoder::new(&Config {
+				dtx: true,
+				bitrate: Some(24_000),
+				frame_duration: Duration::from_millis(duration_ms),
+				..Config::new(Input {
+					channels: 1,
+					..Input::default()
+				})
+			})
+			.unwrap();
+			let mut dec = Decoder::new(&enc.catalog()).unwrap();
+			let silence = vec![0.0; enc.frame_size()];
+
+			let mut entered = false;
+			let mut refresh = None;
+			for _ in 0..100 {
+				let packet = enc.encode(&silence).unwrap();
+				let decoded = dec.decode(&packet).unwrap();
+				assert_eq!(decoded.activity, packet.activity);
+				entered |= packet.len() <= 2;
+				if entered && packet.len() > 2 && packet.activity.is_dtx() {
+					refresh = Some(packet);
+					break;
+				}
+			}
+			assert!(
+				refresh.is_some(),
+				"{duration_ms} ms Opus should refresh DTX comfort noise"
+			);
+		}
 	}
 
 	#[test]

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -675,6 +675,20 @@ mod tests {
 			"a two-byte comfort-noise frame should remain DTX"
 		);
 
+		let mut padded = dtx.value.to_vec();
+		let original_len = padded.len();
+		padded.resize(original_len + 8, 0);
+		// SAFETY: the allocation is sized for the requested padded length and the
+		// encoder produced a valid Opus packet.
+		let rc =
+			unsafe { unsafe_libopus::opus_packet_pad(padded.as_mut_ptr(), original_len as i32, padded.len() as i32) };
+		assert_eq!(rc, unsafe_libopus::OPUS_OK);
+		assert_eq!(
+			dec.decode(&padded).unwrap().activity,
+			Activity::Dtx,
+			"padding must not change a DTX packet's classification"
+		);
+
 		// An absent payload asks libopus for packet-loss concealment. The
 		// classification remains DTX until a normal packet exits that state.
 		assert_eq!(dec.decode(&[]).unwrap().activity, Activity::Dtx);

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -9,14 +9,15 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use unsafe_libopus::{
-	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_IN_DTX_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK,
-	OPUS_RESET_STATE, OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder,
-	opus_encode_float, opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
+	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK, OPUS_RESET_STATE,
+	OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder, opus_encode_float,
+	opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
 };
 
+use super::Encoded;
 use crate::opus;
 use crate::pcm;
-use crate::{Activity, Classified, Error, Format};
+use crate::{Error, Format};
 
 /// libopus packet size ceiling per RFC 6716 §3.4.
 const MAX_PACKET_BYTES: usize = 4_000;
@@ -141,9 +142,8 @@ impl Config {
 ///
 /// Build one with [`Encoder::new`], feed full PCM frames via
 /// [`encode`](Self::encode), then pass the trailing partial frame to
-/// [`finish`](Self::finish). Each packet includes its codec activity
-/// classification. Publish every packet either call returns and apply the
-/// terminal [`Finish::discard_padding`] when the container supports it.
+/// [`finish`](Self::finish). Publish every packet either call returns and apply
+/// the terminal [`Finish::discard_padding`] when the container supports it.
 pub struct Encoder {
 	backend: Backend,
 	config: Config,
@@ -171,7 +171,6 @@ enum Backend {
 struct Opus {
 	inner: *mut OpusEncoder,
 	scratch: Vec<u8>,
-	in_dtx: bool,
 }
 
 // SAFETY: OpusEncoder is heap-allocated state owned exclusively by this
@@ -181,13 +180,13 @@ unsafe impl Send for Opus {}
 
 /// Packets emitted by [`Encoder::finish`] and the decoded padding at their end.
 pub struct Finish {
-	packets: Vec<Classified<Bytes>>,
+	packets: Vec<Encoded>,
 	discard_padding: usize,
 }
 
 impl Finish {
-	/// Encoded packets and their activity in decode order.
-	pub fn packets(&self) -> &[Classified<Bytes>] {
+	/// Encoded packets in decode order.
+	pub fn packets(&self) -> &[Encoded] {
 		&self.packets
 	}
 
@@ -196,8 +195,8 @@ impl Finish {
 		self.discard_padding
 	}
 
-	/// Consume the result and return its classified encoded packets.
-	pub fn into_packets(self) -> Vec<Classified<Bytes>> {
+	/// Consume the result and return its encoded packets.
+	pub fn into_packets(self) -> Vec<Encoded> {
 		self.packets
 	}
 }
@@ -249,7 +248,6 @@ impl Encoder {
 			backend: Backend::Opus(Opus {
 				inner,
 				scratch: vec![0u8; MAX_PACKET_BYTES],
-				in_dtx: false,
 			}),
 			config,
 			codec_rate,
@@ -415,7 +413,6 @@ impl Encoder {
 			// SAFETY: `inner` owns a live encoder and OPUS_RESET_STATE takes no arguments.
 			let rc = unsafe { opus_encoder_ctl_impl(opus.inner, OPUS_RESET_STATE, varargs![]) };
 			debug_assert_eq!(rc, OPUS_OK, "OPUS_RESET_STATE failed with {rc}");
-			opus.in_dtx = false;
 		}
 		self.started = false;
 	}
@@ -430,7 +427,7 @@ impl Encoder {
 	/// `pcm.len()` must equal `frame_size() * codec_channels()`. The
 	/// [`Producer`](super::Producer) handles format conversion and resampling
 	/// before calling this; for direct use, the caller does the same.
-	pub fn encode(&mut self, pcm: &[f32]) -> Result<Classified<Bytes>, Error> {
+	pub fn encode(&mut self, pcm: &[f32]) -> Result<Encoded, Error> {
 		let expected = self.frame_size * self.codec_channels as usize;
 		if pcm.len() != expected {
 			return Err(Error::Misaligned {
@@ -455,25 +452,18 @@ impl Encoder {
 					return Err(crate::opus::error(n, "opus_encode_float"));
 				}
 				let payload = Bytes::copy_from_slice(&opus.scratch[..n as usize]);
-				let packet_activity = crate::opus::activity(&payload, opus.in_dtx);
-				let reported = Self::get_opus_ctl(opus.inner, OPUS_GET_IN_DTX_REQUEST, "OPUS_GET_IN_DTX")? != 0;
-				// libopus 1.3 reports DTX one packet before it first omits coded
-				// audio. Require the packet marker to enter the state, then trust the
-				// control for periodic comfort-noise refreshes and recovery.
-				let activity = if reported && (opus.in_dtx || packet_activity.is_dtx()) {
-					Activity::Dtx
-				} else {
-					Activity::Active
-				};
-				opus.in_dtx = activity.is_dtx();
-				Classified::new(payload, activity)
+				// The same rule the decoder applies, rather than OPUS_GET_IN_DTX: the
+				// control flips a packet before libopus first omits coded audio, and
+				// reading the packet keeps both sides classifying it identically.
+				let activity = crate::opus::activity(&payload, false);
+				Encoded { payload, activity }
 			}
 			Backend::Pcm => {
 				let mut payload = Vec::with_capacity(std::mem::size_of_val(pcm));
 				for sample in pcm {
 					payload.extend_from_slice(&sample.to_le_bytes());
 				}
-				Classified::new(payload.into(), Activity::Active)
+				Encoded::new(payload.into())
 			}
 		};
 		self.started = true;
@@ -589,6 +579,7 @@ impl Drop for Opus {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::Activity;
 	use crate::decode::Decoder;
 
 	fn sine(freq: f32, sample_rate: u32, channels: u32, frames: usize) -> Vec<f32> {
@@ -632,15 +623,15 @@ mod tests {
 		let frame = sine(440.0, 48_000, 2, enc.frame_size());
 		for _ in 0..5 {
 			let pkt = enc.encode(&frame).unwrap();
-			let _ = dec.decode(&pkt).unwrap();
+			let _ = dec.decode(&pkt.payload).unwrap();
 		}
 
 		let pkt = enc.encode(&frame).unwrap();
-		let decoded = dec.decode(&pkt).unwrap();
-		assert_eq!(decoded.len(), frame.len());
+		let decoded = dec.decode(&pkt.payload).unwrap();
+		assert_eq!(decoded.samples.len(), frame.len());
 
 		let energy_in: f32 = frame.iter().map(|s| s * s).sum();
-		let energy_out: f32 = decoded.iter().map(|s| s * s).sum();
+		let energy_out: f32 = decoded.samples.iter().map(|s| s * s).sum();
 		let ratio = energy_out / energy_in;
 		assert!(
 			(0.5..2.0).contains(&ratio),
@@ -665,12 +656,12 @@ mod tests {
 
 		let packet = enc.encode(&active).unwrap();
 		assert_eq!(packet.activity, Activity::Active);
-		assert_eq!(dec.decode(&packet).unwrap().activity, Activity::Active);
+		assert_eq!(dec.decode(&packet.payload).unwrap().activity, Activity::Active);
 
 		let mut dtx = None;
 		for _ in 0..100 {
 			let packet = enc.encode(&silence).unwrap();
-			let decoded = dec.decode(&packet).unwrap();
+			let decoded = dec.decode(&packet.payload).unwrap();
 			assert_eq!(decoded.activity, packet.activity);
 			if packet.activity.is_dtx() {
 				dtx = Some(packet);
@@ -679,7 +670,7 @@ mod tests {
 		}
 		let dtx = dtx.expect("silence should enter Opus DTX");
 		assert!(
-			(1..=2).contains(&dtx.len()),
+			(1..=2).contains(&dtx.payload.len()),
 			"DTX comfort noise should be one or two bytes"
 		);
 		assert_eq!(
@@ -688,7 +679,7 @@ mod tests {
 			"a two-byte comfort-noise frame should remain DTX"
 		);
 
-		let mut padded = dtx.value.to_vec();
+		let mut padded = dtx.payload.to_vec();
 		let original_len = padded.len();
 		padded.resize(original_len + 8, 0);
 		// SAFETY: the allocation is sized for the requested padded length and the
@@ -713,7 +704,7 @@ mod tests {
 		let mut recovered = false;
 		for _ in 0..10 {
 			let packet = enc.encode(&active).unwrap();
-			let decoded = dec.decode(&packet).unwrap();
+			let decoded = dec.decode(&packet.payload).unwrap();
 			assert_eq!(decoded.activity, packet.activity);
 			if packet.activity.is_active() {
 				recovered = true;
@@ -744,10 +735,10 @@ mod tests {
 			let mut refresh = None;
 			for _ in 0..100 {
 				let packet = enc.encode(&silence).unwrap();
-				let decoded = dec.decode(&packet).unwrap();
+				let decoded = dec.decode(&packet.payload).unwrap();
 				assert_eq!(decoded.activity, packet.activity);
-				entered |= packet.len() <= 2;
-				if entered && packet.len() > 2 && packet.activity.is_dtx() {
+				entered |= packet.payload.len() <= 2;
+				if entered && packet.payload.len() > 2 && packet.activity.is_dtx() {
 					refresh = Some(packet);
 					break;
 				}
@@ -798,14 +789,14 @@ mod tests {
 		let mut dec = Decoder::new(&enc.catalog()).unwrap();
 		let frame = vec![0.0; enc.frame_size() * enc.codec_channels() as usize];
 
-		let first = dec.decode(&enc.encode(&frame).unwrap()).unwrap();
+		let first = dec.decode(&enc.encode(&frame).unwrap().payload).unwrap();
 		assert_eq!(
-			first.len(),
+			first.samples.len(),
 			(enc.frame_size() - enc.pre_skip as usize) * enc.codec_channels() as usize
 		);
 
-		let second = dec.decode(&enc.encode(&frame).unwrap()).unwrap();
-		assert_eq!(second.len(), frame.len());
+		let second = dec.decode(&enc.encode(&frame).unwrap().payload).unwrap();
+		assert_eq!(second.samples.len(), frame.len());
 	}
 
 	#[test]
@@ -857,8 +848,11 @@ mod tests {
 		let next = vec![0.0; enc.frame_size()];
 		let actual = enc.encode(&next).unwrap();
 		let mut decoder = Decoder::new(&enc.catalog()).unwrap();
-		let decoded = decoder.decode(&actual).unwrap();
-		let peak = decoded.iter().fold(0.0f32, |peak, sample| peak.max(sample.abs()));
+		let decoded = decoder.decode(&actual.payload).unwrap();
+		let peak = decoded
+			.samples
+			.iter()
+			.fold(0.0f32, |peak, sample| peak.max(sample.abs()));
 		assert!(peak < 0.001, "pre-reset impulse leaked into the next epoch: {peak}");
 
 		enc.reset();
@@ -960,9 +954,9 @@ mod tests {
 		let input = sine(440.0, enc.codec_rate(), enc.codec_channels(), enc.frame_size());
 
 		let packet = enc.encode(&input).unwrap();
-		let output = dec.decode(&packet).unwrap();
+		let output = dec.decode(&packet.payload).unwrap();
 
-		assert_eq!(output.value, input);
+		assert_eq!(output.samples, input);
 	}
 
 	#[test]

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -114,11 +114,11 @@ pub struct Config {
 	/// because its bitrate is fixed by the sample rate and channel count.
 	///
 	/// Rates too low for Opus to code anything at the chosen
-	/// [`frame_duration`](Self::frame_duration) are rejected: libopus stops
-	/// coding below roughly `24_000 / frame_duration_ms` bits per second and
-	/// emits empty frames instead, which carry no audio and are indistinguishable
-	/// from silence. The floor is 1200 bps at the default 20 ms and rises as the
-	/// frame gets shorter.
+	/// [`frame_duration`](Self::frame_duration) are rejected: below its floor
+	/// libopus emits empty frames whatever the input, which carry no audio and
+	/// are indistinguishable from silence. The floor is 1200 bps at the default
+	/// 20 ms, rises for shorter frames (9600 bps at 2.5 ms), and is 2400 bps for
+	/// frames of 10 ms and longer.
 	pub bitrate: Option<u32>,
 	/// Enable Opus in-band forward error correction.
 	pub fec: bool,

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -16,7 +16,7 @@ use unsafe_libopus::{
 
 use crate::opus;
 use crate::pcm;
-use crate::{Error, Format};
+use crate::{Activity, Classified, Error, Format};
 
 /// libopus packet size ceiling per RFC 6716 §3.4.
 const MAX_PACKET_BYTES: usize = 4_000;
@@ -141,8 +141,9 @@ impl Config {
 ///
 /// Build one with [`Encoder::new`], feed full PCM frames via
 /// [`encode`](Self::encode), then pass the trailing partial frame to
-/// [`finish`](Self::finish). Publish every packet either call returns and apply
-/// the terminal [`Finish::discard_padding`] when the container supports it.
+/// [`finish`](Self::finish). Each packet includes its codec activity
+/// classification. Publish every packet either call returns and apply the
+/// terminal [`Finish::discard_padding`] when the container supports it.
 pub struct Encoder {
 	backend: Backend,
 	config: Config,
@@ -179,13 +180,13 @@ unsafe impl Send for Opus {}
 
 /// Packets emitted by [`Encoder::finish`] and the decoded padding at their end.
 pub struct Finish {
-	packets: Vec<Bytes>,
+	packets: Vec<Classified<Bytes>>,
 	discard_padding: usize,
 }
 
 impl Finish {
-	/// Encoded packets in decode order.
-	pub fn packets(&self) -> &[Bytes] {
+	/// Encoded packets and their activity in decode order.
+	pub fn packets(&self) -> &[Classified<Bytes>] {
 		&self.packets
 	}
 
@@ -194,8 +195,8 @@ impl Finish {
 		self.discard_padding
 	}
 
-	/// Consume the result and return its encoded packets.
-	pub fn into_packets(self) -> Vec<Bytes> {
+	/// Consume the result and return its classified encoded packets.
+	pub fn into_packets(self) -> Vec<Classified<Bytes>> {
 		self.packets
 	}
 }
@@ -426,7 +427,7 @@ impl Encoder {
 	/// `pcm.len()` must equal `frame_size() * codec_channels()`. The
 	/// [`Producer`](super::Producer) handles format conversion and resampling
 	/// before calling this; for direct use, the caller does the same.
-	pub fn encode(&mut self, pcm: &[f32]) -> Result<Bytes, Error> {
+	pub fn encode(&mut self, pcm: &[f32]) -> Result<Classified<Bytes>, Error> {
 		let expected = self.frame_size * self.codec_channels as usize;
 		if pcm.len() != expected {
 			return Err(Error::Misaligned {
@@ -434,7 +435,7 @@ impl Encoder {
 				expected: expected * std::mem::size_of::<f32>(),
 			});
 		}
-		let packet = match &mut self.backend {
+		let encoded = match &mut self.backend {
 			Backend::Opus(opus) => {
 				// SAFETY: `inner` owns a live OpusEncoder; pcm and scratch slices
 				// are bounded by the lengths we pass.
@@ -450,18 +451,20 @@ impl Encoder {
 				if n < 0 {
 					return Err(crate::opus::error(n, "opus_encode_float"));
 				}
-				Bytes::copy_from_slice(&opus.scratch[..n as usize])
+				let payload = Bytes::copy_from_slice(&opus.scratch[..n as usize]);
+				let activity = crate::opus::activity(&payload, false);
+				Classified::new(payload, activity)
 			}
 			Backend::Pcm => {
 				let mut payload = Vec::with_capacity(std::mem::size_of_val(pcm));
 				for sample in pcm {
 					payload.extend_from_slice(&sample.to_le_bytes());
 				}
-				payload.into()
+				Classified::new(payload.into(), Activity::Active)
 			}
 		};
 		self.started = true;
-		Ok(packet)
+		Ok(encoded)
 	}
 
 	/// Finish encoding, zero-padding `pcm` as the final partial frame and
@@ -630,6 +633,68 @@ mod tests {
 			(0.5..2.0).contains(&ratio),
 			"output energy ratio {ratio:.3} should be close to 1"
 		);
+	}
+
+	#[test]
+	fn opus_classification_covers_dtx_loss_and_recovery() {
+		let mut enc = Encoder::new(&Config {
+			dtx: true,
+			bitrate: Some(24_000),
+			..Config::new(Input {
+				channels: 1,
+				..Input::default()
+			})
+		})
+		.unwrap();
+		let mut dec = Decoder::new(&enc.catalog()).unwrap();
+		let active = sine(440.0, enc.codec_rate(), enc.codec_channels(), enc.frame_size());
+		let silence = vec![0.0; enc.frame_size()];
+
+		let packet = enc.encode(&active).unwrap();
+		assert_eq!(packet.activity, Activity::Active);
+		assert_eq!(dec.decode(&packet).unwrap().activity, Activity::Active);
+
+		let mut dtx = None;
+		for _ in 0..100 {
+			let packet = enc.encode(&silence).unwrap();
+			let decoded = dec.decode(&packet).unwrap();
+			assert_eq!(decoded.activity, packet.activity);
+			if packet.activity.is_dtx() {
+				dtx = Some(packet);
+				break;
+			}
+		}
+		let dtx = dtx.expect("silence should enter Opus DTX");
+		assert!(
+			(1..=2).contains(&dtx.len()),
+			"DTX comfort noise should be one or two bytes"
+		);
+		assert_eq!(
+			dec.decode(&[0xf8, 0xff]).unwrap().activity,
+			Activity::Dtx,
+			"a two-byte comfort-noise frame should remain DTX"
+		);
+
+		// An absent payload asks libopus for packet-loss concealment. The
+		// classification remains DTX until a normal packet exits that state.
+		assert_eq!(dec.decode(&[]).unwrap().activity, Activity::Dtx);
+
+		// A rejected packet must not mutate the state used to classify later loss.
+		assert!(matches!(dec.decode(&[0xff; 3]), Err(Error::Decode(_))));
+		assert_eq!(dec.decode(&[]).unwrap().activity, Activity::Dtx);
+
+		let mut recovered = false;
+		for _ in 0..10 {
+			let packet = enc.encode(&active).unwrap();
+			let decoded = dec.decode(&packet).unwrap();
+			assert_eq!(decoded.activity, packet.activity);
+			if packet.activity.is_active() {
+				recovered = true;
+				break;
+			}
+		}
+		assert!(recovered, "active audio should exit Opus DTX");
+		assert_eq!(dec.decode(&[]).unwrap().activity, Activity::Active);
 	}
 
 	#[test]
@@ -835,7 +900,7 @@ mod tests {
 		let packet = enc.encode(&input).unwrap();
 		let output = dec.decode(&packet).unwrap();
 
-		assert_eq!(output, input);
+		assert_eq!(output.value, input);
 	}
 
 	#[test]

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -9,15 +9,15 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use unsafe_libopus::{
-	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_IN_DTX_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK,
-	OPUS_RESET_STATE, OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder,
-	opus_encode_float, opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
+	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK, OPUS_RESET_STATE,
+	OPUS_SET_BITRATE_REQUEST, OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder, opus_encode_float,
+	opus_encoder_create, opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
 };
 
 use super::Encoded;
 use crate::opus;
 use crate::pcm;
-use crate::{Activity, Error, Format};
+use crate::{Error, Format};
 
 /// libopus packet size ceiling per RFC 6716 §3.4.
 const MAX_PACKET_BYTES: usize = 4_000;
@@ -112,6 +112,13 @@ pub struct Config {
 	pub channels: Option<u32>,
 	/// Bitrate in bits per second. `None` lets Opus pick. PCM requires `None`
 	/// because its bitrate is fixed by the sample rate and channel count.
+	///
+	/// Rates too low for Opus to code anything at the chosen
+	/// [`frame_duration`](Self::frame_duration) are rejected: libopus stops
+	/// coding below roughly `24_000 / frame_duration_ms` bits per second and
+	/// emits empty frames instead, which carry no audio and are indistinguishable
+	/// from silence. The floor is 1200 bps at the default 20 ms and rises as the
+	/// frame gets shorter.
 	pub bitrate: Option<u32>,
 	/// Enable Opus in-band forward error correction.
 	pub fec: bool,
@@ -171,9 +178,6 @@ enum Backend {
 struct Opus {
 	inner: *mut OpusEncoder,
 	scratch: Vec<u8>,
-	/// Whether the last packet was classified as comfort noise, which is what
-	/// lets a refresh be told apart from a return to audio.
-	in_dtx: bool,
 }
 
 // SAFETY: OpusEncoder is heap-allocated state owned exclusively by this
@@ -237,7 +241,7 @@ impl Encoder {
 			return Err(opus::error(err, "opus_encoder_create"));
 		}
 
-		let configured = Self::configure_opus(inner, &config, codec_rate, codec_channels);
+		let configured = Self::configure_opus(inner, &config, codec_rate, codec_channels, frame_size);
 		let (bitrate, lookahead, pre_skip) = match configured {
 			Ok(configured) => configured,
 			Err(err) => {
@@ -251,7 +255,6 @@ impl Encoder {
 			backend: Backend::Opus(Opus {
 				inner,
 				scratch: vec![0u8; MAX_PACKET_BYTES],
-				in_dtx: false,
 			}),
 			config,
 			codec_rate,
@@ -308,9 +311,10 @@ impl Encoder {
 		config: &Config,
 		codec_rate: u32,
 		codec_channels: u32,
+		frame_size: usize,
 	) -> Result<(u64, usize, u16), Error> {
 		if let Some(bitrate) = config.bitrate {
-			Self::set_opus_bitrate(inner, codec_channels, bitrate as u64)?;
+			Self::set_opus_bitrate(inner, codec_channels, bitrate as u64, codec_rate, frame_size)?;
 		}
 		Self::set_opus_ctl(
 			inner,
@@ -334,11 +338,20 @@ impl Encoder {
 		Ok((bitrate, lookahead, pre_skip))
 	}
 
-	fn set_opus_bitrate(inner: *mut OpusEncoder, channels: u32, bitrate: u64) -> Result<(), Error> {
+	fn set_opus_bitrate(
+		inner: *mut OpusEncoder,
+		channels: u32,
+		bitrate: u64,
+		codec_rate: u32,
+		frame_size: usize,
+	) -> Result<(), Error> {
 		let max = 300_000 * channels as u64;
-		if !(500..=max).contains(&bitrate) {
+		// Below the floor libopus codes nothing at all, so the stream carries no
+		// audio and every packet is framed like discontinuous transmission.
+		let min = opus::bitrate_floor(codec_rate, frame_size).max(500);
+		if !(min..=max).contains(&bitrate) {
 			return Err(Error::Unsupported(format!(
-				"Opus bitrate must be between 500 and {max} bits per second for {channels} channel(s), got {bitrate}"
+				"Opus bitrate must be between {min} and {max} bits per second for {channels} channel(s) at {frame_size} samples, got {bitrate}"
 			)));
 		}
 		Self::set_opus_ctl(inner, OPUS_SET_BITRATE_REQUEST, bitrate as i32, "OPUS_SET_BITRATE")
@@ -351,11 +364,6 @@ impl Encoder {
 			return Err(opus::error(rc, name));
 		}
 		Ok(())
-	}
-
-	/// Whether libopus is currently withholding audio frames.
-	fn in_dtx(inner: *mut OpusEncoder) -> Result<bool, Error> {
-		Ok(Self::get_opus_ctl(inner, OPUS_GET_IN_DTX_REQUEST, "OPUS_GET_IN_DTX")? != 0)
 	}
 
 	fn get_opus_ctl(inner: *mut OpusEncoder, request: i32, name: &'static str) -> Result<i32, Error> {
@@ -409,7 +417,13 @@ impl Encoder {
 			return Err(Error::Unsupported("pcm bitrate is fixed".into()));
 		};
 		if bitrate != self.bitrate {
-			Self::set_opus_bitrate(opus.inner, self.codec_channels, bitrate)?;
+			Self::set_opus_bitrate(
+				opus.inner,
+				self.codec_channels,
+				bitrate,
+				self.codec_rate,
+				self.frame_size,
+			)?;
 			self.bitrate = bitrate;
 			self.config.bitrate = Some(bitrate as u32);
 		}
@@ -422,7 +436,6 @@ impl Encoder {
 			// SAFETY: `inner` owns a live encoder and OPUS_RESET_STATE takes no arguments.
 			let rc = unsafe { opus_encoder_ctl_impl(opus.inner, OPUS_RESET_STATE, varargs![]) };
 			debug_assert_eq!(rc, OPUS_OK, "OPUS_RESET_STATE failed with {rc}");
-			opus.in_dtx = false;
 		}
 		self.started = false;
 	}
@@ -462,20 +475,11 @@ impl Encoder {
 					return Err(crate::opus::error(n, "opus_encode_float"));
 				}
 				let payload = Bytes::copy_from_slice(&opus.scratch[..n as usize]);
-				// The framing decides, so the decoder reaches the same answer from the
-				// packet alone. It is ambiguous in exactly one place: a bare TOC codes
-				// nothing, which is silence while libopus is withholding audio and a
-				// starved bitrate when it is not (below `3 * frame_rate * 8` bps it
-				// emits one for loud input too). `OPUS_GET_IN_DTX` is the only thing
-				// that separates those, so it is used to veto that case and nothing
-				// else. A SID refresh is never empty, so it needs no veto.
-				let starved = !Self::in_dtx(opus.inner)? && crate::opus::carries_nothing(&payload);
-				let activity = if crate::opus::is_comfort_noise(&payload, opus.in_dtx) && !starved {
-					Activity::Dtx
-				} else {
-					Activity::Active
-				};
-				opus.in_dtx = activity.is_dtx();
+				// The same rule the decoder applies, so both sides agree by reading the
+				// packet rather than by two mechanisms kept in step. `Config::bitrate`
+				// refuses the rates where a bare TOC would mean something else, which
+				// is what makes reading the packet enough here.
+				let activity = crate::opus::activity(&payload, false);
 				Encoded { payload, activity }
 			}
 			Backend::Pcm => {
@@ -690,15 +694,13 @@ mod tests {
 		}
 		let dtx = dtx.expect("silence should enter Opus DTX");
 		assert!(
-			(1..=2).contains(&dtx.payload.len()),
-			"DTX comfort noise should be one or two bytes"
-		);
-		assert_eq!(
-			dec.decode(&[0xf8, 0xff]).unwrap().activity,
-			Activity::Dtx,
-			"a two-byte comfort-noise frame should remain DTX"
+			dtx.payload.len() <= 2,
+			"withholding audio is a bare TOC, got {} bytes",
+			dtx.payload.len()
 		);
 
+		// Padding does not change what a packet codes, so it does not change how it
+		// reads either.
 		let mut padded = dtx.payload.to_vec();
 		let original_len = padded.len();
 		padded.resize(original_len + 8, 0);
@@ -707,14 +709,10 @@ mod tests {
 		let rc =
 			unsafe { unsafe_libopus::opus_packet_pad(padded.as_mut_ptr(), original_len as i32, padded.len() as i32) };
 		assert_eq!(rc, unsafe_libopus::OPUS_OK);
-		assert_eq!(
-			dec.decode(&padded).unwrap().activity,
-			Activity::Dtx,
-			"padding must not change a DTX packet's classification"
-		);
+		assert_eq!(dec.decode(&padded).unwrap().activity, Activity::Dtx);
 
-		// An absent payload asks libopus for packet-loss concealment. The
-		// classification remains DTX until a normal packet exits that state.
+		// An absent payload asks libopus for packet-loss concealment, which says
+		// nothing: the classification stays where the last real packet left it.
 		assert_eq!(dec.decode(&[]).unwrap().activity, Activity::Dtx);
 
 		// A rejected packet must not mutate the state used to classify later loss.
@@ -736,76 +734,55 @@ mod tests {
 	}
 
 	#[test]
-	fn opus_classifies_periodic_dtx_refreshes() {
-		for duration_ms in [20, 40, 60] {
-			let mut enc = Encoder::new(&Config {
-				dtx: true,
-				bitrate: Some(24_000),
-				frame_duration: Duration::from_millis(duration_ms),
-				..Config::new(Input {
-					channels: 1,
-					..Input::default()
-				})
-			})
-			.unwrap();
-			let mut dec = Decoder::new(&enc.catalog()).unwrap();
-			let silence = vec![0.0; enc.frame_size()];
-
-			let mut entered = false;
-			let mut refresh = None;
-			for _ in 0..100 {
-				let packet = enc.encode(&silence).unwrap();
-				let decoded = dec.decode(&packet.payload).unwrap();
-				assert_eq!(decoded.activity, packet.activity);
-				entered |= packet.payload.len() <= 2;
-				if entered && packet.payload.len() > 2 && packet.activity.is_dtx() {
-					refresh = Some(packet);
-					break;
-				}
-			}
-			assert!(
-				refresh.is_some(),
-				"{duration_ms} ms Opus should refresh DTX comfort noise"
-			);
-		}
-	}
-
-	/// Below libopus's `3 * frame_rate * 8` bps floor the encoder emits a bare TOC
-	/// whatever the input, so the packet framing alone reads loud audio as comfort
-	/// noise. `OPUS_GET_IN_DTX` is the only thing that tells them apart.
-	#[test]
-	fn opus_starved_bitrate_audio_is_not_dtx() {
-		// 500 bps at 20 ms is under the 1,200 bps floor, and the crate accepts it.
-		let mut enc = Encoder::new(&Config {
+	fn opus_rejects_a_bitrate_that_would_code_nothing() {
+		let starved = Encoder::new(&Config {
 			dtx: true,
 			bitrate: Some(500),
 			..Config::new(Input {
 				channels: 1,
 				..Input::default()
 			})
-		})
-		.unwrap();
-		let loud = sine(440.0, enc.codec_rate(), enc.codec_channels(), enc.frame_size());
+		});
+		assert!(
+			matches!(starved, Err(Error::Unsupported(_))),
+			"500 bps at 20 ms is under the 1200 bps floor"
+		);
 
-		for _ in 0..10 {
-			let packet = enc.encode(&loud).unwrap();
-			assert_eq!(packet.payload.len(), 1, "a starved encoder emits a bare TOC");
-			assert_eq!(
-				packet.activity,
-				Activity::Active,
-				"loud audio is never comfort noise, however little of it fits"
-			);
-		}
-	}
+		// The floor moves with the frame duration: 2.5 ms needs 9600 bps.
+		let short = Encoder::new(&Config {
+			bitrate: Some(6_000),
+			frame_duration: Duration::from_micros(2_500),
+			..Config::new(Input {
+				channels: 1,
+				..Input::default()
+			})
+		});
+		assert!(matches!(short, Err(Error::Unsupported(_))));
 
-	/// The first refresh after entering DTX at 40 ms leaves one frame empty beside
-	/// a full-size one, which is silence rather than a return to audio.
-	#[test]
-	fn opus_partially_empty_refresh_stays_dtx() {
+		// And a live retune cannot get under it either, which is how a stream that
+		// started healthy could otherwise end up coding nothing.
 		let mut enc = Encoder::new(&Config {
 			dtx: true,
 			bitrate: Some(24_000),
-			frame_duration: Duration::from_millis(40),
+			..Config::new(Input {
+				channels: 1,
+				..Input::default()
+			})
+		})
+		.unwrap();
+		assert!(enc.set_bitrate(500).is_err());
+		assert_eq!(enc.bitrate(), 24_000, "a refused retune leaves the bitrate alone");
+	}
+
+	/// A silence run is interrupted by an ordinarily coded frame of that silence,
+	/// which carries no marker saying so. It reads active, because the framing
+	/// that would catch it is the same framing a speech onset produces, and
+	/// calling real audio silence is the worse error.
+	#[test]
+	fn opus_reports_silence_between_refreshes() {
+		let mut enc = Encoder::new(&Config {
+			dtx: true,
+			bitrate: Some(24_000),
 			..Config::new(Input {
 				channels: 1,
 				..Input::default()
@@ -817,26 +794,32 @@ mod tests {
 		let silence = vec![0.0; enc.frame_size()];
 
 		for _ in 0..6 {
-			enc.encode(&loud).unwrap();
+			let packet = enc.encode(&loud).unwrap();
+			assert_eq!(packet.activity, Activity::Active);
 		}
 
-		let mut mixed = None;
-		for _ in 0..60 {
+		let mut dtx = 0;
+		let mut refreshes = 0;
+		for _ in 0..200 {
 			let packet = enc.encode(&silence).unwrap();
-			let sizes = crate::opus::frame_sizes_for_test(&packet.payload);
 			assert_eq!(
 				dec.decode(&packet.payload).unwrap().activity,
 				packet.activity,
-				"encoder and decoder disagree on {sizes:?}"
+				"both sides read the same packet"
 			);
-			if sizes.contains(&0) && sizes.iter().any(|&size| size > 2) {
-				mixed = Some(packet);
-				break;
+			match packet.activity {
+				Activity::Dtx => dtx += 1,
+				_ if dtx > 0 => refreshes += 1,
+				_ => {}
 			}
 		}
 
-		let mixed = mixed.expect("40 ms DTX should refresh with one coded frame beside an empty one");
-		assert_eq!(mixed.activity, Activity::Dtx);
+		assert!(dtx > 150, "silence should mostly withhold audio, got {dtx} of 200");
+		assert!(refreshes > 0, "a silence run should be refreshed periodically");
+		assert!(
+			refreshes < dtx / 10,
+			"refreshes should be rare against the run they interrupt, got {refreshes} vs {dtx}"
+		);
 	}
 
 	#[test]

--- a/rs/moq-audio/src/encode/mod.rs
+++ b/rs/moq-audio/src/encode/mod.rs
@@ -5,8 +5,8 @@
 //! Entry points, high to low level:
 //! - `publish_capture` captures a microphone (or system audio) and publishes
 //!   it (turnkey). Requires the `capture` feature.
-//! - [`Encoder`] encodes raw PCM you supply, and [`Producer`] publishes the
-//!   resulting packets (bring your own PCM).
+//! - [`Encoder`] encodes raw PCM you supply into [`Encoded`] packets, and
+//!   [`Producer`] publishes them (bring your own PCM).
 //! - [`Producer`] alone publishes PCM you hand it, encoding as it goes.
 //!
 //! [`Input`] declares the PCM layout going in. [`Config`] configures the
@@ -18,12 +18,14 @@
 //! `publish_capture` is unlinked above because it only exists with the `capture`
 //! feature, so a default-feature rustdoc build has nothing to link to.
 
+mod encoded;
 mod encoder;
 mod producer;
 
 #[cfg(feature = "capture")]
 mod capture;
 
+pub use encoded::Encoded;
 pub use encoder::{Codec, Config, Encoder, Finish, Input};
 pub use producer::{Options, Producer};
 

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -8,9 +8,10 @@ use moq_mux::catalog::hang::CatalogExt;
 use moq_mux::container::Frame as MuxFrame;
 use moq_net::Timestamp;
 
+use super::encoded::Encoded;
 use super::encoder::{Codec, Config, Encoder, Input};
 use crate::resample::Resampler;
-use crate::{Classified, Error, Frame};
+use crate::{Activity, Error, Frame};
 
 /// Source-agnostic encode knobs for [`Producer`] and `publish_capture`, where
 /// the input PCM layout comes from the caller's frames or the capture source
@@ -104,10 +105,12 @@ pub struct Producer<E: CatalogExt = ()> {
 	pending_discontinuity: bool,
 	/// Whether an empty group already separates the next packet from prior codec state.
 	decoder_boundary: bool,
+	/// How the encoder classified the packet it published most recently.
+	activity: Activity,
 }
 
 struct Terminal {
-	packets: Vec<Classified<Bytes>>,
+	packets: Vec<Encoded>,
 	end: Timestamp,
 	start: Timestamp,
 	frame_size: usize,
@@ -168,6 +171,7 @@ impl<E: CatalogExt> Producer<E> {
 			epoch_us: None,
 			pending_discontinuity: false,
 			decoder_boundary: true,
+			activity: Activity::Active,
 		})
 	}
 
@@ -180,6 +184,16 @@ impl<E: CatalogExt> Producer<E> {
 	/// [`used`](moq_net::track::Producer::used) / [`unused`](moq_net::track::Producer::unused).
 	pub fn track(&self) -> &moq_net::track::Producer {
 		self.track.track()
+	}
+
+	/// How the encoder classified the packet it published most recently: real
+	/// audio, or the comfort noise Opus sends while the input is silent.
+	///
+	/// A local "am I talking" indicator without running a second voice detector
+	/// over the microphone. [`Activity::Active`] until the first packet, and for
+	/// codecs without a DTX mode.
+	pub fn activity(&self) -> Activity {
+		self.activity
 	}
 
 	/// Current encoder target bitrate in bits per second.
@@ -208,6 +222,7 @@ impl<E: CatalogExt> Producer<E> {
 
 	fn reset_state(&mut self) {
 		self.epoch_us = None;
+		self.activity = Activity::Active;
 		self.frames_produced = 0;
 		self.pending.clear();
 		self.encoder.reset();
@@ -230,9 +245,11 @@ impl<E: CatalogExt> Producer<E> {
 	/// timestamps are ignored. An idle gap is only reflected in the PTS if you
 	/// call [`reset_epoch`](Self::reset_epoch) on resume (which re-anchors from
 	/// the next frame's wall-clock stamp); writing straight across a gap without
-	/// resetting compresses it out. The returned items report the timestamp and
-	/// codec activity of every packet this write produced.
-	pub fn write(&mut self, frame: &Frame) -> Result<Vec<Classified<Timestamp>>, Error> {
+	/// resetting compresses it out.
+	///
+	/// [`Frame::activity`] is ignored: the encoder classifies what it actually
+	/// produced, which [`activity`](Self::activity) reports.
+	pub fn write(&mut self, frame: &Frame) -> Result<(), Error> {
 		if self.pending_discontinuity {
 			self.track.discontinuity()?;
 			self.pending_discontinuity = false;
@@ -258,20 +275,20 @@ impl<E: CatalogExt> Producer<E> {
 
 	/// Encode and publish every full frame in `pending`, keeping any partial
 	/// trailing frame for the next call.
-	fn publish_full_frames(&mut self, epoch_us: u64) -> Result<Vec<Classified<Timestamp>>, Error> {
+	fn publish_full_frames(&mut self, epoch_us: u64) -> Result<(), Error> {
 		let frame_samples = self.encoder.frame_size() * self.encoder.codec_channels() as usize;
-		let mut produced = Vec::new();
 		while self.pending.len() >= frame_samples {
 			let chunk: Vec<f32> = self.pending.drain(..frame_samples).collect();
 			let packet = self.encoder.encode(&chunk)?;
 
 			let timestamp = Self::timestamp(epoch_us, self.frames_produced, self.encoder.codec_rate())?;
 			self.frames_produced += self.encoder.frame_size() as u64;
-			produced.push(Self::publish(&mut self.track, packet, timestamp)?);
+			self.activity = packet.activity;
+			Self::publish(&mut self.track, packet, timestamp)?;
 			self.decoder_boundary = false;
 		}
 
-		Ok(produced)
+		Ok(())
 	}
 
 	/// PTS of the next frame: the epoch plus the samples emitted since it.
@@ -282,15 +299,15 @@ impl<E: CatalogExt> Producer<E> {
 
 	fn publish(
 		track: &mut moq_mux::container::Producer<moq_mux::container::legacy::Wire>,
-		encoded: Classified<Bytes>,
+		encoded: Encoded,
 		timestamp: Timestamp,
-	) -> Result<Classified<Timestamp>, Error> {
+	) -> Result<(), Error> {
 		// Publish each audio packet as its own moq-lite group: write it as a keyframe, then cut
 		// (below) so the relay forwards it without waiting for the next. Codecs can recover
 		// independently after a dropped group.
 		let mux_frame = MuxFrame {
 			timestamp,
-			payload: encoded.value,
+			payload: encoded.payload,
 			keyframe: true,
 			duration: None,
 		};
@@ -298,14 +315,14 @@ impl<E: CatalogExt> Producer<E> {
 		// No boundary to give: the next packet bounds this one, and Opus frames have a
 		// deterministic duration anyway.
 		track.cut(None)?;
-		Ok(Classified::new(timestamp, encoded.activity))
+		Ok(())
 	}
 
 	/// Publish terminal packets after an empty frame that carries their logical endpoint.
 	fn publish_terminal(
 		track: &mut moq_mux::container::Producer<moq_mux::container::legacy::Wire>,
 		terminal: Terminal,
-	) -> Result<Vec<Classified<Timestamp>>, Error> {
+	) -> Result<(), Error> {
 		track.write(MuxFrame {
 			timestamp: terminal.end,
 			payload: Bytes::new(),
@@ -313,23 +330,19 @@ impl<E: CatalogExt> Producer<E> {
 			duration: None,
 		})?;
 
-		let mut produced = Vec::with_capacity(terminal.packets.len());
 		for (index, packet) in terminal.packets.into_iter().enumerate() {
 			let offset = Timestamp::from_scale((index * terminal.frame_size) as u64, terminal.codec_rate as u64)?
 				.convert(terminal.start.scale())?;
-			let timestamp = terminal.start.checked_add(offset)?;
-			let activity = packet.activity;
 			track.write(MuxFrame {
-				timestamp,
-				payload: packet.value,
+				timestamp: terminal.start.checked_add(offset)?,
+				payload: packet.payload,
 				keyframe: false,
 				duration: None,
 			})?;
-			produced.push(Classified::new(timestamp, activity));
 		}
 
 		track.cut(Some(terminal.end))?;
-		Ok(produced)
+		Ok(())
 	}
 
 	/// Mark a break in the published timeline and reset codec state.
@@ -347,8 +360,8 @@ impl<E: CatalogExt> Producer<E> {
 	}
 
 	/// Flush pending samples, resampler output, and codec lookahead, then finalize
-	/// the track. The returned items report every packet produced while draining.
-	pub fn finish(mut self) -> Result<Vec<Classified<Timestamp>>, Error> {
+	/// the track.
+	pub fn finish(mut self) -> Result<(), Error> {
 		// Whatever the resampler still holds belongs to this track: its last partial
 		// chunk, plus the audio its filter is running behind on. Dropping it here
 		// would publish a track that ends before its source did.
@@ -359,7 +372,7 @@ impl<E: CatalogExt> Producer<E> {
 		// The drained resampler tail can span multiple frames. Publish those first
 		// so only the final partial frame reaches the encoder's terminal drain.
 		let epoch_us = self.epoch_us.unwrap_or(0);
-		let mut produced = self.publish_full_frames(epoch_us)?;
+		self.publish_full_frames(epoch_us)?;
 
 		let frame_size = self.encoder.frame_size();
 		let codec_rate = self.encoder.codec_rate();
@@ -372,7 +385,7 @@ impl<E: CatalogExt> Producer<E> {
 		let packets = finish.into_packets();
 
 		if discard_padding > 0 {
-			produced.extend(Self::publish_terminal(
+			Self::publish_terminal(
 				&mut self.track,
 				Terminal {
 					packets,
@@ -381,17 +394,18 @@ impl<E: CatalogExt> Producer<E> {
 					frame_size,
 					codec_rate,
 				},
-			)?);
+			)?;
 		} else {
 			for packet in packets {
 				let timestamp = Self::timestamp(epoch_us, self.frames_produced, codec_rate)?;
-				produced.push(Self::publish(&mut self.track, packet, timestamp)?);
+				self.activity = packet.activity;
+				Self::publish(&mut self.track, packet, timestamp)?;
 				self.frames_produced += frame_size as u64;
 			}
 		}
 
 		self.track.finish()?;
-		Ok(produced)
+		Ok(())
 	}
 
 	/// Abort the track with `err` instead of finishing it, so subscribers see the
@@ -450,12 +464,7 @@ mod tests {
 			let impulse = pcm.len() - 100;
 			pcm[impulse] = 1.0;
 			let data: Vec<u8> = pcm.iter().flat_map(|sample| sample.to_le_bytes()).collect();
-			producer
-				.write(&Frame {
-					timestamp: Timestamp::ZERO,
-					data: Bytes::from(data),
-				})
-				.unwrap();
+			producer.write(&Frame::new(Bytes::from(data), Timestamp::ZERO)).unwrap();
 			producer.finish().unwrap();
 
 			let mut decoded = Vec::new();
@@ -505,10 +514,7 @@ mod tests {
 		// remainder and its filter delay drops back under ten, costing a packet.
 		let data: Vec<u8> = vec![0.25f32; 8_838].iter().flat_map(|s| s.to_le_bytes()).collect();
 		producer
-			.write(&Frame {
-				timestamp: moq_net::Timestamp::ZERO,
-				data: data.into(),
-			})
+			.write(&Frame::new(data.into(), moq_net::Timestamp::ZERO))
 			.unwrap();
 		producer.finish().unwrap();
 
@@ -552,10 +558,7 @@ mod tests {
 		// Too little to publish a packet, so it all sits in the resampler.
 		let data: Vec<u8> = vec![0.25f32; 441].iter().flat_map(|s| s.to_le_bytes()).collect();
 		producer
-			.write(&Frame {
-				timestamp: moq_net::Timestamp::ZERO,
-				data: data.into(),
-			})
+			.write(&Frame::new(data.into(), moq_net::Timestamp::ZERO))
 			.unwrap();
 
 		producer.reset_epoch();
@@ -675,11 +678,9 @@ mod tests {
 		let silence = vec![0.0; 960];
 		let mut entered_dtx = false;
 		for index in 0..100 {
-			let produced = producer.write(&pcm_frame(&silence, index * 20_000)).unwrap();
+			producer.write(&pcm_frame(&silence, index * 20_000)).unwrap();
 			let consumed = consumer.read().await.unwrap().expect("one decoded frame");
-			assert_eq!(produced.len(), 1);
-			assert_eq!(produced[0].activity, consumed.activity);
-			assert_eq!(*produced[0], consumed.timestamp);
+			assert_eq!(producer.activity(), consumed.activity);
 			if consumed.activity.is_dtx() {
 				entered_dtx = true;
 				break;
@@ -693,9 +694,9 @@ mod tests {
 				phase.sin() * 0.5
 			})
 			.collect();
-		let produced = producer.write(&pcm_frame(&active, 2_000_000)).unwrap();
+		producer.write(&pcm_frame(&active, 2_000_000)).unwrap();
 		let consumed = consumer.read().await.unwrap().expect("one decoded frame");
-		assert_eq!(produced[0].activity, Activity::Active);
+		assert_eq!(producer.activity(), Activity::Active);
 		assert_eq!(consumed.activity, Activity::Active);
 	}
 
@@ -707,10 +708,7 @@ mod tests {
 
 	fn pcm_frame(samples: &[f32], timestamp_us: u64) -> Frame {
 		let data: Vec<u8> = samples.iter().flat_map(|sample| sample.to_le_bytes()).collect();
-		Frame {
-			timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
-			data: Bytes::from(data),
-		}
+		Frame::new(Bytes::from(data), Timestamp::from_micros(timestamp_us).unwrap())
 	}
 
 	/// Publish each frame and read back the resulting packet PTS (microseconds).

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -186,12 +186,14 @@ impl<E: CatalogExt> Producer<E> {
 		self.track.track()
 	}
 
-	/// How the encoder classified the packet it published most recently: real
-	/// audio, or the comfort noise Opus sends while the input is silent.
+	/// Whether the packet published most recently coded audio, or withheld it
+	/// because the input was silent.
 	///
 	/// A local "am I talking" indicator without running a second voice detector
-	/// over the microphone. [`Activity::Active`] until the first packet, and for
-	/// codecs without a DTX mode.
+	/// over the microphone, though a silent run is punctuated by coded frames
+	/// that read [`Activity::Active`], so hold the indicator across those rather
+	/// than following it packet by packet. [`Activity::Active`] until the first
+	/// packet, and for codecs without a discontinuous mode.
 	pub fn activity(&self) -> Activity {
 		self.activity
 	}

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -10,7 +10,7 @@ use moq_net::Timestamp;
 
 use super::encoder::{Codec, Config, Encoder, Input};
 use crate::resample::Resampler;
-use crate::{Error, Frame};
+use crate::{Classified, Error, Frame};
 
 /// Source-agnostic encode knobs for [`Producer`] and `publish_capture`, where
 /// the input PCM layout comes from the caller's frames or the capture source
@@ -107,7 +107,7 @@ pub struct Producer<E: CatalogExt = ()> {
 }
 
 struct Terminal {
-	packets: Vec<Bytes>,
+	packets: Vec<Classified<Bytes>>,
 	end: Timestamp,
 	start: Timestamp,
 	frame_size: usize,
@@ -230,8 +230,9 @@ impl<E: CatalogExt> Producer<E> {
 	/// timestamps are ignored. An idle gap is only reflected in the PTS if you
 	/// call [`reset_epoch`](Self::reset_epoch) on resume (which re-anchors from
 	/// the next frame's wall-clock stamp); writing straight across a gap without
-	/// resetting compresses it out.
-	pub fn write(&mut self, frame: &Frame) -> Result<(), Error> {
+	/// resetting compresses it out. The returned items report the timestamp and
+	/// codec activity of every packet this write produced.
+	pub fn write(&mut self, frame: &Frame) -> Result<Vec<Classified<Timestamp>>, Error> {
 		if self.pending_discontinuity {
 			self.track.discontinuity()?;
 			self.pending_discontinuity = false;
@@ -257,19 +258,20 @@ impl<E: CatalogExt> Producer<E> {
 
 	/// Encode and publish every full frame in `pending`, keeping any partial
 	/// trailing frame for the next call.
-	fn publish_full_frames(&mut self, epoch_us: u64) -> Result<(), Error> {
+	fn publish_full_frames(&mut self, epoch_us: u64) -> Result<Vec<Classified<Timestamp>>, Error> {
 		let frame_samples = self.encoder.frame_size() * self.encoder.codec_channels() as usize;
+		let mut produced = Vec::new();
 		while self.pending.len() >= frame_samples {
 			let chunk: Vec<f32> = self.pending.drain(..frame_samples).collect();
 			let packet = self.encoder.encode(&chunk)?;
 
 			let timestamp = Self::timestamp(epoch_us, self.frames_produced, self.encoder.codec_rate())?;
 			self.frames_produced += self.encoder.frame_size() as u64;
-			Self::publish(&mut self.track, packet, timestamp)?;
+			produced.push(Self::publish(&mut self.track, packet, timestamp)?);
 			self.decoder_boundary = false;
 		}
 
-		Ok(())
+		Ok(produced)
 	}
 
 	/// PTS of the next frame: the epoch plus the samples emitted since it.
@@ -280,15 +282,15 @@ impl<E: CatalogExt> Producer<E> {
 
 	fn publish(
 		track: &mut moq_mux::container::Producer<moq_mux::container::legacy::Wire>,
-		payload: Bytes,
+		encoded: Classified<Bytes>,
 		timestamp: Timestamp,
-	) -> Result<(), Error> {
+	) -> Result<Classified<Timestamp>, Error> {
 		// Publish each audio packet as its own moq-lite group: write it as a keyframe, then cut
 		// (below) so the relay forwards it without waiting for the next. Codecs can recover
 		// independently after a dropped group.
 		let mux_frame = MuxFrame {
 			timestamp,
-			payload,
+			payload: encoded.value,
 			keyframe: true,
 			duration: None,
 		};
@@ -296,14 +298,14 @@ impl<E: CatalogExt> Producer<E> {
 		// No boundary to give: the next packet bounds this one, and Opus frames have a
 		// deterministic duration anyway.
 		track.cut(None)?;
-		Ok(())
+		Ok(Classified::new(timestamp, encoded.activity))
 	}
 
 	/// Publish terminal packets after an empty frame that carries their logical endpoint.
 	fn publish_terminal(
 		track: &mut moq_mux::container::Producer<moq_mux::container::legacy::Wire>,
 		terminal: Terminal,
-	) -> Result<(), Error> {
+	) -> Result<Vec<Classified<Timestamp>>, Error> {
 		track.write(MuxFrame {
 			timestamp: terminal.end,
 			payload: Bytes::new(),
@@ -311,19 +313,23 @@ impl<E: CatalogExt> Producer<E> {
 			duration: None,
 		})?;
 
+		let mut produced = Vec::with_capacity(terminal.packets.len());
 		for (index, packet) in terminal.packets.into_iter().enumerate() {
 			let offset = Timestamp::from_scale((index * terminal.frame_size) as u64, terminal.codec_rate as u64)?
 				.convert(terminal.start.scale())?;
+			let timestamp = terminal.start.checked_add(offset)?;
+			let activity = packet.activity;
 			track.write(MuxFrame {
-				timestamp: terminal.start.checked_add(offset)?,
-				payload: packet,
+				timestamp,
+				payload: packet.value,
 				keyframe: false,
 				duration: None,
 			})?;
+			produced.push(Classified::new(timestamp, activity));
 		}
 
 		track.cut(Some(terminal.end))?;
-		Ok(())
+		Ok(produced)
 	}
 
 	/// Mark a break in the published timeline and reset codec state.
@@ -341,8 +347,8 @@ impl<E: CatalogExt> Producer<E> {
 	}
 
 	/// Flush pending samples, resampler output, and codec lookahead, then finalize
-	/// the track.
-	pub fn finish(mut self) -> Result<(), Error> {
+	/// the track. The returned items report every packet produced while draining.
+	pub fn finish(mut self) -> Result<Vec<Classified<Timestamp>>, Error> {
 		// Whatever the resampler still holds belongs to this track: its last partial
 		// chunk, plus the audio its filter is running behind on. Dropping it here
 		// would publish a track that ends before its source did.
@@ -353,7 +359,7 @@ impl<E: CatalogExt> Producer<E> {
 		// The drained resampler tail can span multiple frames. Publish those first
 		// so only the final partial frame reaches the encoder's terminal drain.
 		let epoch_us = self.epoch_us.unwrap_or(0);
-		self.publish_full_frames(epoch_us)?;
+		let mut produced = self.publish_full_frames(epoch_us)?;
 
 		let frame_size = self.encoder.frame_size();
 		let codec_rate = self.encoder.codec_rate();
@@ -366,7 +372,7 @@ impl<E: CatalogExt> Producer<E> {
 		let packets = finish.into_packets();
 
 		if discard_padding > 0 {
-			Self::publish_terminal(
+			produced.extend(Self::publish_terminal(
 				&mut self.track,
 				Terminal {
 					packets,
@@ -375,17 +381,17 @@ impl<E: CatalogExt> Producer<E> {
 					frame_size,
 					codec_rate,
 				},
-			)?;
+			)?);
 		} else {
 			for packet in packets {
 				let timestamp = Self::timestamp(epoch_us, self.frames_produced, codec_rate)?;
-				Self::publish(&mut self.track, packet, timestamp)?;
+				produced.push(Self::publish(&mut self.track, packet, timestamp)?);
 				self.frames_produced += frame_size as u64;
 			}
 		}
 
 		self.track.finish()?;
-		Ok(())
+		Ok(produced)
 	}
 
 	/// Abort the track with `err` instead of finishing it, so subscribers see the
@@ -413,8 +419,8 @@ impl<E: CatalogExt> Drop for Rendition<E> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::Format;
 	use crate::decode::{Config as DecodeConfig, Consumer as AudioConsumer};
+	use crate::{Activity, Format};
 
 	/// Terminal Opus lookahead samples survive both exact-frame and partial-frame input.
 	#[tokio::test]
@@ -643,16 +649,67 @@ mod tests {
 		assert_eq!(resumed_frames, 960, "the resumed epoch must trim its own pre-skip once");
 	}
 
+	#[tokio::test]
+	async fn producer_and_consumer_keep_activity_on_the_audio_stream() {
+		let input = Input {
+			format: Format::F32,
+			sample_rate: 48_000,
+			channels: 1,
+		};
+		let options = Options {
+			track: Some("audio".to_string()),
+			bitrate: Some(24_000),
+			dtx: true,
+			..Options::default()
+		};
+		let decoder_config = Encoder::new(&options.config(input.clone())).unwrap().catalog();
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let subscriber = broadcast.consume();
+		let mut producer = Producer::new(&mut broadcast, catalog, input, &options).unwrap();
+		let mut consumer = AudioConsumer::new(&subscriber, &decoder_config, "audio", DecodeConfig::new())
+			.await
+			.unwrap();
+
+		let silence = vec![0.0; 960];
+		let mut entered_dtx = false;
+		for index in 0..100 {
+			let produced = producer.write(&pcm_frame(&silence, index * 20_000)).unwrap();
+			let consumed = consumer.read().await.unwrap().expect("one decoded frame");
+			assert_eq!(produced.len(), 1);
+			assert_eq!(produced[0].activity, consumed.activity);
+			assert_eq!(*produced[0], consumed.timestamp);
+			if consumed.activity.is_dtx() {
+				entered_dtx = true;
+				break;
+			}
+		}
+		assert!(entered_dtx, "silence should enter Opus DTX");
+
+		let active: Vec<f32> = (0..960)
+			.map(|sample| {
+				let phase = sample as f32 * 440.0 * 2.0 * std::f32::consts::PI / 48_000.0;
+				phase.sin() * 0.5
+			})
+			.collect();
+		let produced = producer.write(&pcm_frame(&active, 2_000_000)).unwrap();
+		let consumed = consumer.read().await.unwrap().expect("one decoded frame");
+		assert_eq!(produced[0].activity, Activity::Active);
+		assert_eq!(consumed.activity, Activity::Active);
+	}
+
 	// One 20 ms Opus frame at 48 kHz mono is exactly 960 f32 samples, so each
 	// `write` of this drains precisely one packet (no resampler, no leftover).
 	fn full_frame(timestamp_us: u64) -> Frame {
-		let mut data = Vec::with_capacity(960 * 4);
-		for _ in 0..960 {
-			data.extend_from_slice(&0.1f32.to_le_bytes());
-		}
+		pcm_frame(&vec![0.1; 960], timestamp_us)
+	}
+
+	fn pcm_frame(samples: &[f32], timestamp_us: u64) -> Frame {
+		let data: Vec<u8> = samples.iter().flat_map(|sample| sample.to_le_bytes()).collect();
 		Frame {
 			timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
-			data: data.into(),
+			data: Bytes::from(data),
 		}
 	}
 

--- a/rs/moq-audio/src/frame.rs
+++ b/rs/moq-audio/src/frame.rs
@@ -1,18 +1,36 @@
 use bytes::Bytes;
 use moq_net::Timestamp;
 
+use crate::Activity;
+
 /// One unit of raw PCM crossing the codec boundary: what
 /// [`encode::Producer::write`](crate::encode::Producer::write) takes and what
-/// [`decode::Consumer::read`](crate::decode::Consumer::read) returns inside a
-/// [`Classified`](crate::Classified).
+/// [`decode::Consumer::read`](crate::decode::Consumer::read) returns.
 ///
-/// Just a payload and a presentation timestamp. PCM layout (format / sample rate
-/// / channel count) is fixed by the producer or consumer at construction time,
-/// never per frame, so callers can't accidentally drift the format mid-stream.
+/// Just a payload, a presentation timestamp, and what the codec was doing when
+/// it produced these samples. PCM layout (format / sample rate / channel count)
+/// is fixed by the producer or consumer at construction time, never per frame,
+/// so callers can't accidentally drift the format mid-stream.
 #[derive(Clone, Debug)]
 pub struct Frame {
 	/// Presentation timestamp of the first sample.
 	pub timestamp: Timestamp,
 	/// The samples, in the layout the producer or consumer was built with.
 	pub data: Bytes,
+	/// What the decoder these samples came out of was doing: real audio, or Opus
+	/// comfort noise. Set on the way out of [`decode`](crate::decode) and ignored
+	/// on the way into [`encode`](crate::encode), which classifies what it
+	/// encodes rather than what it was told.
+	pub activity: Activity,
+}
+
+impl Frame {
+	/// PCM shown at `timestamp`, classified [`Activity::Active`].
+	pub fn new(data: Bytes, timestamp: Timestamp) -> Self {
+		Self {
+			timestamp,
+			data,
+			activity: Activity::Active,
+		}
+	}
 }

--- a/rs/moq-audio/src/frame.rs
+++ b/rs/moq-audio/src/frame.rs
@@ -7,8 +7,8 @@ use crate::Activity;
 /// [`encode::Producer::write`](crate::encode::Producer::write) takes and what
 /// [`decode::Consumer::read`](crate::decode::Consumer::read) returns.
 ///
-/// Just a payload, a presentation timestamp, and what the codec was doing when
-/// it produced these samples. PCM layout (format / sample rate / channel count)
+/// Just a payload, a presentation timestamp, and whether the packet these
+/// samples came from coded any audio. PCM layout (format / sample rate / channel count)
 /// is fixed by the producer or consumer at construction time, never per frame,
 /// so callers can't accidentally drift the format mid-stream.
 #[derive(Clone, Debug)]

--- a/rs/moq-audio/src/frame.rs
+++ b/rs/moq-audio/src/frame.rs
@@ -3,7 +3,8 @@ use moq_net::Timestamp;
 
 /// One unit of raw PCM crossing the codec boundary: what
 /// [`encode::Producer::write`](crate::encode::Producer::write) takes and what
-/// [`decode::Consumer::read`](crate::decode::Consumer::read) returns.
+/// [`decode::Consumer::read`](crate::decode::Consumer::read) returns inside a
+/// [`Classified`](crate::Classified).
 ///
 /// Just a payload and a presentation timestamp. PCM layout (format / sample rate
 /// / channel count) is fixed by the producer or consumer at construction time,

--- a/rs/moq-audio/src/frame.rs
+++ b/rs/moq-audio/src/frame.rs
@@ -17,10 +17,10 @@ pub struct Frame {
 	pub timestamp: Timestamp,
 	/// The samples, in the layout the producer or consumer was built with.
 	pub data: Bytes,
-	/// What the decoder these samples came out of was doing: real audio, or Opus
-	/// comfort noise. Set on the way out of [`decode`](crate::decode) and ignored
-	/// on the way into [`encode`](crate::encode), which classifies what it
-	/// encodes rather than what it was told.
+	/// Whether the packet these samples came out of coded audio, or none at all.
+	/// Set on the way out of [`decode`](crate::decode) and ignored on the way
+	/// into [`encode`](crate::encode), which classifies what it encodes rather
+	/// than what it was told.
 	pub activity: Activity,
 }
 

--- a/rs/moq-audio/src/lib.rs
+++ b/rs/moq-audio/src/lib.rs
@@ -40,10 +40,10 @@
 //! [`Format`] mirrors WebCodecs `AudioData.format`; the helpers convert between
 //! any supported layout and the interleaved `f32` representation libopus
 //! expects. [`Frame`] is a thin owned buffer: a timestamp, a payload, and the
-//! [`Activity`] it was decoded from, which is how a caller tells real audio from
-//! the comfort noise an Opus sender emits while silent. PCM layout lives on the
-//! producer / consumer via [`encode::Input`] / [`decode::Config`], not on each
-//! frame, so callers can't drift between calls.
+//! [`Activity`] it was decoded from, which is how a caller tells coded audio
+//! from the frames an Opus sender withholds while its input is silent. PCM
+//! layout lives on the producer / consumer via [`encode::Input`] /
+//! [`decode::Config`], not on each frame, so callers can't drift between calls.
 
 #[cfg(feature = "aac")]
 mod aac;

--- a/rs/moq-audio/src/lib.rs
+++ b/rs/moq-audio/src/lib.rs
@@ -26,8 +26,7 @@
 //! - [`decode`] subscribes to an encoded track and decodes it back to PCM.
 //!   [`decode::Consumer`] is the mirror of [`encode::Producer`]. It reads AAC-LC
 //!   too, behind the default-on `aac` feature, since a broadcast that came in
-//!   through a gateway is AAC rather than one of the two codecs we encode. Each
-//!   returned [`Classified`] frame reports whether Opus carried active data or DTX.
+//!   through a gateway is AAC rather than one of the two codecs we encode.
 //! - `playback` plays decoded PCM out a speaker. `playback::Engine` owns the
 //!   output device and mixes the `playback::Sink`s registered with it, so one
 //!   device serves every track in a call. Requires the `playback` feature, so
@@ -40,10 +39,11 @@
 //!
 //! [`Format`] mirrors WebCodecs `AudioData.format`; the helpers convert between
 //! any supported layout and the interleaved `f32` representation libopus
-//! expects. [`Frame`] is a thin owned buffer: a timestamp and a payload. PCM
-//! layout lives on the producer / consumer via [`encode::Input`] /
-//! [`decode::Config`], not on each frame, so callers can't drift between calls.
-//! [`Classified`] keeps Opus activity on each produced or consumed audio item.
+//! expects. [`Frame`] is a thin owned buffer: a timestamp, a payload, and the
+//! [`Activity`] it was decoded from, which is how a caller tells real audio from
+//! the comfort noise an Opus sender emits while silent. PCM layout lives on the
+//! producer / consumer via [`encode::Input`] / [`decode::Config`], not on each
+//! frame, so callers can't drift between calls.
 
 #[cfg(feature = "aac")]
 mod aac;
@@ -65,7 +65,7 @@ pub mod encode;
 #[cfg(feature = "playback")]
 pub mod playback;
 
-pub use activity::{Activity, Classified};
+pub use activity::Activity;
 pub use error::Error;
 pub use format::Format;
 pub use frame::Frame;

--- a/rs/moq-audio/src/lib.rs
+++ b/rs/moq-audio/src/lib.rs
@@ -26,7 +26,8 @@
 //! - [`decode`] subscribes to an encoded track and decodes it back to PCM.
 //!   [`decode::Consumer`] is the mirror of [`encode::Producer`]. It reads AAC-LC
 //!   too, behind the default-on `aac` feature, since a broadcast that came in
-//!   through a gateway is AAC rather than one of the two codecs we encode.
+//!   through a gateway is AAC rather than one of the two codecs we encode. Each
+//!   returned [`Classified`] frame reports whether Opus carried active data or DTX.
 //! - `playback` plays decoded PCM out a speaker. `playback::Engine` owns the
 //!   output device and mixes the `playback::Sink`s registered with it, so one
 //!   device serves every track in a call. Requires the `playback` feature, so
@@ -42,9 +43,11 @@
 //! expects. [`Frame`] is a thin owned buffer: a timestamp and a payload. PCM
 //! layout lives on the producer / consumer via [`encode::Input`] /
 //! [`decode::Config`], not on each frame, so callers can't drift between calls.
+//! [`Classified`] keeps Opus activity on each produced or consumed audio item.
 
 #[cfg(feature = "aac")]
 mod aac;
+mod activity;
 mod error;
 mod format;
 mod frame;
@@ -62,6 +65,7 @@ pub mod encode;
 #[cfg(feature = "playback")]
 pub mod playback;
 
+pub use activity::{Activity, Classified};
 pub use error::Error;
 pub use format::Format;
 pub use frame::Frame;

--- a/rs/moq-audio/src/opus.rs
+++ b/rs/moq-audio/src/opus.rs
@@ -64,16 +64,7 @@ pub(crate) fn decode_error(code: i32) -> Error {
 	error(code, "opus_decode_float")
 }
 
-/// Classify a packet libopus accepted, preserving DTX across packet loss.
-///
-/// Comfort noise is the one thing an Opus packet says about itself by size: a
-/// frame that codes silence is the TOC byte plus at most a two-byte SID
-/// payload, where real audio is tens of bytes even at the lowest bitrates. So a
-/// packet is DTX when every coded frame in it is that small, which covers the
-/// one-byte entry packet, the periodic multi-byte SID refresh, and the
-/// multi-frame refresh a 40 or 60 ms configuration emits. Reading the framing
-/// rather than the payload keeps this working for senders whose libopus build
-/// differs from ours.
+/// Classify a packet a decoder accepted, preserving DTX across packet loss.
 ///
 /// An empty payload asks the decoder for packet-loss concealment, which says
 /// nothing about the audio: carry `in_dtx` from the last real packet through it.
@@ -82,7 +73,7 @@ pub(crate) fn activity(packet: &[u8], in_dtx: bool) -> Activity {
 		return if in_dtx { Activity::Dtx } else { Activity::Active };
 	}
 
-	if is_comfort_noise(packet) {
+	if is_comfort_noise(packet, in_dtx) {
 		Activity::Dtx
 	} else {
 		Activity::Active
@@ -92,18 +83,54 @@ pub(crate) fn activity(packet: &[u8], in_dtx: bool) -> Activity {
 /// The largest coded frame that is still comfort noise rather than audio.
 const SID_BYTES: i16 = 2;
 
-/// Whether every coded frame in an accepted packet is comfort noise, ignoring
-/// any padding the sender added.
-fn is_comfort_noise(packet: &[u8]) -> bool {
-	let Ok(len) = i32::try_from(packet.len()) else {
+/// Whether an accepted packet's framing looks like comfort noise.
+///
+/// libopus codes silence as frames that are empty or a two-byte SID payload,
+/// where audio fills every frame with tens of bytes. Once DTX is established it
+/// also emits a periodic refresh that can carry a larger payload in one frame
+/// and leave the others empty, so an empty frame beside that one still means
+/// silence rather than a return to audio.
+///
+/// This reads the framing rather than the payload bytes, so it does not assume
+/// the sender's libopus emits the same SID as ours. It cannot be exact: a
+/// sender below libopus's `3 * frame_rate * 8` bps floor emits a bare TOC for
+/// audio too, and nothing on the wire distinguishes that from silence. Only the
+/// encoder can tell the difference, via `OPUS_GET_IN_DTX`.
+pub(crate) fn is_comfort_noise(packet: &[u8], in_dtx: bool) -> bool {
+	let Some((sizes, count)) = frame_sizes(packet) else {
 		return false;
 	};
+	let Some(sizes) = sizes.get(..count) else {
+		return false;
+	};
+	if sizes.is_empty() {
+		return false;
+	}
+
+	sizes.iter().all(|&size| size <= SID_BYTES) || (in_dtx && sizes.contains(&0))
+}
+
+/// Whether the packet codes nothing at all: a bare TOC with every frame empty.
+///
+/// Ambiguous on its own. libopus emits this both while withholding silence and,
+/// below its `3 * frame_rate * 8` bps floor, for loud audio it has no room to
+/// code. Only `OPUS_GET_IN_DTX` separates the two, so a decoder cannot.
+pub(crate) fn carries_nothing(packet: &[u8]) -> bool {
+	match frame_sizes(packet).and_then(|(sizes, count)| sizes.get(..count).map(<[i16]>::to_vec)) {
+		Some(sizes) => !sizes.is_empty() && sizes.iter().all(|&size| size == 0),
+		None => false,
+	}
+}
+
+/// Sizes of the coded frames in an accepted packet, with padding parsed off.
+fn frame_sizes(packet: &[u8]) -> Option<([i16; 48], usize)> {
+	let len = i32::try_from(packet.len()).ok()?;
 
 	// An Opus packet holds at most 48 frames (RFC 6716 section 3.2.5).
 	let mut sizes = [0i16; 48];
-	// SAFETY: `sizes` has libopus's maximum frame count. Passing null for the TOC
-	// and frame pointers asks it to skip them, which it checks for; only `size` is
-	// required. Padding is parsed off rather than counted.
+	// SAFETY: `sizes` has libopus's maximum frame count, and it bounds the count
+	// it writes by that. Passing null for the TOC and frame pointers asks it to
+	// skip them, which it checks for; only `size` is required.
 	let count = unsafe {
 		unsafe_libopus::opus_packet_parse(
 			packet.as_ptr(),
@@ -115,10 +142,16 @@ fn is_comfort_noise(packet: &[u8]) -> bool {
 		)
 	};
 
-	match usize::try_from(count).ok().and_then(|count| sizes.get(..count)) {
-		Some(sizes) if !sizes.is_empty() => sizes.iter().all(|&size| size <= SID_BYTES),
-		_ => false,
-	}
+	Some((sizes, usize::try_from(count).ok()?))
+}
+
+/// The coded frame sizes of an accepted packet, so tests can assert on the
+/// framing libopus actually produced rather than on a hand-built packet.
+#[cfg(test)]
+pub(crate) fn frame_sizes_for_test(packet: &[u8]) -> Vec<i16> {
+	frame_sizes(packet)
+		.and_then(|(sizes, count)| sizes.get(..count).map(<[i16]>::to_vec))
+		.unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -136,13 +169,13 @@ mod tests {
 
 	#[test]
 	fn activity_reads_the_opus_framing() {
+		// A bare TOC, and the two-byte SID refresh libopus emits at 20 ms.
 		assert_eq!(activity(&[0xf8], false), Activity::Dtx);
 		assert_eq!(activity(&[0xf8, 0xff], false), Activity::Dtx);
+		assert_eq!(activity(&[0xf8, 0xff, 0xfe], false), Activity::Dtx);
+		// Loss carries the last real packet's classification.
 		assert_eq!(activity(&[], true), Activity::Dtx);
 		assert_eq!(activity(&[], false), Activity::Active);
-		// A SID refresh is comfort noise whatever the last packet was.
-		assert_eq!(activity(&[0xf8, 0xff, 0xfe], false), Activity::Dtx);
-		assert_eq!(activity(&[0xf8, 0xff, 0xfe], true), Activity::Dtx);
 	}
 
 	/// Another sender's comfort noise is not byte-for-byte ours, so only the

--- a/rs/moq-audio/src/opus.rs
+++ b/rs/moq-audio/src/opus.rs
@@ -66,15 +66,36 @@ pub(crate) fn decode_error(code: i32) -> Error {
 
 /// Classify a packet libopus accepted, preserving DTX across packet loss.
 ///
-/// libopus emits one or two bytes for DTX and comfort noise. An empty payload
-/// asks the decoder for packet-loss concealment, which remains DTX only when
-/// the last accepted packet entered DTX.
+/// libopus emits one or two unpadded bytes for DTX and comfort noise. An empty
+/// payload asks the decoder for packet-loss concealment, which remains DTX only
+/// when the last accepted packet entered DTX.
 pub(crate) fn activity(packet: &[u8], in_dtx: bool) -> Activity {
-	match packet.len() {
+	match unpadded_len(packet) {
 		0 if in_dtx => Activity::Dtx,
 		1 | 2 => Activity::Dtx,
 		_ => Activity::Active,
 	}
+}
+
+fn unpadded_len(packet: &[u8]) -> usize {
+	let Some((&toc, frames)) = packet.split_first() else {
+		return 0;
+	};
+	let Some(&frame_count) = frames.first() else {
+		return packet.len();
+	};
+	if toc & 0x03 != 0x03 || frame_count & 0x40 == 0 {
+		return packet.len();
+	}
+
+	let Ok(len) = i32::try_from(packet.len()) else {
+		return packet.len();
+	};
+	let mut unpadded = packet.to_vec();
+	// SAFETY: `unpadded` is writable for `len` bytes. This only runs after
+	// libopus accepted the packet, so parsing should succeed.
+	let len = unsafe { unsafe_libopus::opus_packet_unpad(unpadded.as_mut_ptr(), len) };
+	usize::try_from(len).unwrap_or(packet.len())
 }
 
 #[cfg(test)]

--- a/rs/moq-audio/src/opus.rs
+++ b/rs/moq-audio/src/opus.rs
@@ -64,17 +64,54 @@ pub(crate) fn decode_error(code: i32) -> Error {
 	error(code, "opus_decode_float")
 }
 
-/// Classify a packet libopus accepted, preserving DTX across packet loss.
+/// Classify a packet libopus accepted, preserving DTX across loss and SID refreshes.
 ///
-/// libopus emits one or two unpadded bytes for DTX and comfort noise. An empty
-/// payload asks the decoder for packet-loss concealment, which remains DTX only
-/// when the last accepted packet entered DTX.
+/// libopus enters DTX with a one- or two-byte packet, then periodically emits a
+/// longer SID-only refresh. An empty payload asks the decoder for packet-loss
+/// concealment, which remains DTX only when the last accepted packet entered DTX.
 pub(crate) fn activity(packet: &[u8], in_dtx: bool) -> Activity {
 	match unpadded_len(packet) {
 		0 if in_dtx => Activity::Dtx,
 		1 | 2 => Activity::Dtx,
+		_ if in_dtx && is_sid_refresh(packet) => Activity::Dtx,
 		_ => Activity::Active,
 	}
+}
+
+/// Whether every coded frame is empty or the SILK SID payload libopus emits
+/// while refreshing comfort noise during DTX.
+fn is_sid_refresh(packet: &[u8]) -> bool {
+	let Ok(len) = i32::try_from(packet.len()) else {
+		return false;
+	};
+	let mut frames = [std::ptr::null(); 48];
+	let mut sizes = [0i16; 48];
+	// SAFETY: the arrays have libopus's maximum 48 frame slots. The returned
+	// frame pointers refer into `packet` and are read only for their reported sizes.
+	let count = unsafe {
+		unsafe_libopus::opus_packet_parse(
+			packet.as_ptr(),
+			len,
+			std::ptr::null_mut(),
+			frames.as_mut_ptr(),
+			sizes.as_mut_ptr(),
+			std::ptr::null_mut(),
+		)
+	};
+	let Ok(count) = usize::try_from(count) else {
+		return false;
+	};
+
+	frames[..count].iter().zip(&sizes[..count]).all(|(&frame, &size)| {
+		let Ok(size) = usize::try_from(size) else {
+			return false;
+		};
+		if size == 0 {
+			return true;
+		}
+		// SAFETY: opus_packet_parse returned this pointer and size into `packet`.
+		unsafe { std::slice::from_raw_parts(frame, size) == [0xff, 0xfe] }
+	})
 }
 
 fn unpadded_len(packet: &[u8]) -> usize {
@@ -117,6 +154,7 @@ mod tests {
 		assert_eq!(activity(&[0xf8, 0xff], false), Activity::Dtx);
 		assert_eq!(activity(&[], true), Activity::Dtx);
 		assert_eq!(activity(&[], false), Activity::Active);
-		assert_eq!(activity(&[0xf8, 0xff, 0xfe], true), Activity::Active);
+		assert_eq!(activity(&[0xf8, 0xff, 0xfe], false), Activity::Active);
+		assert_eq!(activity(&[0xf8, 0xff, 0xfe], true), Activity::Dtx);
 	}
 }

--- a/rs/moq-audio/src/opus.rs
+++ b/rs/moq-audio/src/opus.rs
@@ -64,7 +64,7 @@ pub(crate) fn decode_error(code: i32) -> Error {
 	error(code, "opus_decode_float")
 }
 
-/// Classify a packet a decoder accepted, preserving DTX across packet loss.
+/// Classify a packet, preserving DTX across packet loss.
 ///
 /// An empty payload asks the decoder for packet-loss concealment, which says
 /// nothing about the audio: carry `in_dtx` from the last real packet through it.
@@ -73,50 +73,33 @@ pub(crate) fn activity(packet: &[u8], in_dtx: bool) -> Activity {
 		return if in_dtx { Activity::Dtx } else { Activity::Active };
 	}
 
-	if is_comfort_noise(packet, in_dtx) {
+	if carries_nothing(packet) {
 		Activity::Dtx
 	} else {
 		Activity::Active
 	}
 }
 
-/// The largest coded frame that is still comfort noise rather than audio.
-const SID_BYTES: i16 = 2;
-
-/// Whether an accepted packet's framing looks like comfort noise.
+/// Whether the sender coded no audio at all for this packet: a bare TOC whose
+/// every frame is empty.
 ///
-/// libopus codes silence as frames that are empty or a two-byte SID payload,
-/// where audio fills every frame with tens of bytes. Once DTX is established it
-/// also emits a periodic refresh that can carry a larger payload in one frame
-/// and leave the others empty, so an empty frame beside that one still means
-/// silence rather than a return to audio.
+/// Exactly the packet libopus emits when it withholds audio, in any mode, from
+/// either of the two paths that do so (SILK coding nothing, and the Opus-level
+/// silence detector). Nothing else in a conforming encoder produces it except a
+/// bitrate below libopus's floor, which codes nothing whatever the input;
+/// [`Config::bitrate`](crate::encode::Config::bitrate) refuses those, so our own
+/// encoder cannot emit one and this stays exact on both sides.
 ///
-/// This reads the framing rather than the payload bytes, so it does not assume
-/// the sender's libopus emits the same SID as ours. It cannot be exact: a
-/// sender below libopus's `3 * frame_rate * 8` bps floor emits a bare TOC for
-/// audio too, and nothing on the wire distinguishes that from silence. Only the
-/// encoder can tell the difference, via `OPUS_GET_IN_DTX`.
-pub(crate) fn is_comfort_noise(packet: &[u8], in_dtx: bool) -> bool {
+/// It deliberately says nothing about the periodic refresh that interrupts a
+/// silence run. That refresh is an ordinarily coded frame of the silence, not a
+/// marked packet, so it reads as active. Erring that way keeps the rule from
+/// ever calling real audio silence, which is the direction that matters.
+pub(crate) fn carries_nothing(packet: &[u8]) -> bool {
 	let Some((sizes, count)) = frame_sizes(packet) else {
 		return false;
 	};
-	let Some(sizes) = sizes.get(..count) else {
-		return false;
-	};
-	if sizes.is_empty() {
-		return false;
-	}
 
-	sizes.iter().all(|&size| size <= SID_BYTES) || (in_dtx && sizes.contains(&0))
-}
-
-/// Whether the packet codes nothing at all: a bare TOC with every frame empty.
-///
-/// Ambiguous on its own. libopus emits this both while withholding silence and,
-/// below its `3 * frame_rate * 8` bps floor, for loud audio it has no room to
-/// code. Only `OPUS_GET_IN_DTX` separates the two, so a decoder cannot.
-pub(crate) fn carries_nothing(packet: &[u8]) -> bool {
-	match frame_sizes(packet).and_then(|(sizes, count)| sizes.get(..count).map(<[i16]>::to_vec)) {
+	match sizes.get(..count) {
 		Some(sizes) => !sizes.is_empty() && sizes.iter().all(|&size| size == 0),
 		None => false,
 	}
@@ -145,13 +128,17 @@ fn frame_sizes(packet: &[u8]) -> Option<([i16; 48], usize)> {
 	Some((sizes, usize::try_from(count).ok()?))
 }
 
-/// The coded frame sizes of an accepted packet, so tests can assert on the
-/// framing libopus actually produced rather than on a hand-built packet.
-#[cfg(test)]
-pub(crate) fn frame_sizes_for_test(packet: &[u8]) -> Vec<i16> {
-	frame_sizes(packet)
-		.and_then(|(sizes, count)| sizes.get(..count).map(<[i16]>::to_vec))
-		.unwrap_or_default()
+/// The lowest bitrate that still codes audio, in bits per second.
+///
+/// Below `3 * frame_rate * 8` (and below 2400 for frame rates under 50 Hz)
+/// libopus stops coding entirely and emits a bare TOC for every frame, however
+/// loud the input, which is byte-for-byte what it sends while withholding
+/// silence. Refusing those rates keeps the two apart.
+pub(crate) fn bitrate_floor(sample_rate: u32, frame_size: usize) -> u64 {
+	// Integer division, matching how libopus derives the same value.
+	let frame_rate = u64::from(sample_rate) / frame_size.max(1) as u64;
+	let floor = 3 * frame_rate * 8;
+	if frame_rate < 50 { floor.max(2_400) } else { floor }
 }
 
 #[cfg(test)]
@@ -169,30 +156,47 @@ mod tests {
 
 	#[test]
 	fn activity_reads_the_opus_framing() {
-		// A bare TOC, and the two-byte SID refresh libopus emits at 20 ms.
+		// A bare TOC codes nothing, whatever the mode or frame count.
 		assert_eq!(activity(&[0xf8], false), Activity::Dtx);
-		assert_eq!(activity(&[0xf8, 0xff], false), Activity::Dtx);
-		assert_eq!(activity(&[0xf8, 0xff, 0xfe], false), Activity::Dtx);
+		assert_eq!(activity(&[0x08], false), Activity::Dtx);
+		assert_eq!(activity(&[0xfb, 0x03], false), Activity::Dtx);
+		// Anything with a coded frame is audio, however little of it there is.
+		assert_eq!(activity(&[0xf8, 0xff, 0xfe], false), Activity::Active);
+		assert_eq!(activity(&[0xf8, 0xff], false), Activity::Active);
 		// Loss carries the last real packet's classification.
 		assert_eq!(activity(&[], true), Activity::Dtx);
 		assert_eq!(activity(&[], false), Activity::Active);
 	}
 
-	/// Another sender's comfort noise is not byte-for-byte ours, so only the
-	/// framing may decide. Code 3 CBR, three 20 ms frames, contents arbitrary.
+	/// A silence run's periodic refresh is an ordinarily coded frame, and a
+	/// speech onset can leave an earlier frame of the same packet empty. Neither
+	/// is distinguishable by framing, so both read active rather than risking
+	/// real audio being called silence.
 	#[test]
-	fn activity_ignores_the_sid_payload_bytes() {
-		assert_eq!(
-			activity(&[0xfb, 0x03, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc], false),
-			Activity::Dtx
-		);
-		// The same framing carrying three-byte frames is audio, not comfort noise.
-		assert_eq!(
-			activity(
-				&[0xfb, 0x03, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11],
-				false
-			),
-			Activity::Active
-		);
+	fn activity_never_calls_a_coded_frame_silence() {
+		// Code 3 VBR, two 20 ms frames: TOC, then the count byte, then the first
+		// frame's length. A refresh puts the coded frame first and leaves the
+		// second empty; a speech onset is the same shape the other way round.
+		let mut refresh = vec![0xfb, 0x82, 57];
+		refresh.extend(std::iter::repeat_n(0xaa, 57));
+		let mut onset = vec![0xfb, 0x82, 0];
+		onset.extend(std::iter::repeat_n(0xaa, 57));
+
+		assert_eq!(activity(&refresh, true), Activity::Active);
+		assert_eq!(activity(&onset, true), Activity::Active);
+
+		// The same framing with both frames empty is the packet that does say
+		// silence, which also proves the two above really parse as two frames.
+		assert_eq!(activity(&[0xfb, 0x82, 0], true), Activity::Dtx);
+	}
+
+	#[test]
+	fn bitrate_floor_matches_libopus() {
+		// 3 * frame_rate * 8, with the 2400 floor libopus adds under 50 Hz.
+		assert_eq!(bitrate_floor(48_000, 960), 1_200); // 20 ms
+		assert_eq!(bitrate_floor(48_000, 120), 9_600); // 2.5 ms
+		assert_eq!(bitrate_floor(48_000, 480), 2_400); // 10 ms
+		assert_eq!(bitrate_floor(48_000, 1_920), 2_400); // 40 ms, 25 Hz
+		assert_eq!(bitrate_floor(48_000, 2_880), 2_400); // 60 ms, 16 Hz
 	}
 }

--- a/rs/moq-audio/src/opus.rs
+++ b/rs/moq-audio/src/opus.rs
@@ -64,75 +64,61 @@ pub(crate) fn decode_error(code: i32) -> Error {
 	error(code, "opus_decode_float")
 }
 
-/// Classify a packet libopus accepted, preserving DTX across loss and SID refreshes.
+/// Classify a packet libopus accepted, preserving DTX across packet loss.
 ///
-/// libopus enters DTX with a one- or two-byte packet, then periodically emits a
-/// longer SID-only refresh. An empty payload asks the decoder for packet-loss
-/// concealment, which remains DTX only when the last accepted packet entered DTX.
+/// Comfort noise is the one thing an Opus packet says about itself by size: a
+/// frame that codes silence is the TOC byte plus at most a two-byte SID
+/// payload, where real audio is tens of bytes even at the lowest bitrates. So a
+/// packet is DTX when every coded frame in it is that small, which covers the
+/// one-byte entry packet, the periodic multi-byte SID refresh, and the
+/// multi-frame refresh a 40 or 60 ms configuration emits. Reading the framing
+/// rather than the payload keeps this working for senders whose libopus build
+/// differs from ours.
+///
+/// An empty payload asks the decoder for packet-loss concealment, which says
+/// nothing about the audio: carry `in_dtx` from the last real packet through it.
 pub(crate) fn activity(packet: &[u8], in_dtx: bool) -> Activity {
-	match unpadded_len(packet) {
-		0 if in_dtx => Activity::Dtx,
-		1 | 2 => Activity::Dtx,
-		_ if in_dtx && is_sid_refresh(packet) => Activity::Dtx,
-		_ => Activity::Active,
+	if packet.is_empty() {
+		return if in_dtx { Activity::Dtx } else { Activity::Active };
+	}
+
+	if is_comfort_noise(packet) {
+		Activity::Dtx
+	} else {
+		Activity::Active
 	}
 }
 
-/// Whether every coded frame is empty or the SILK SID payload libopus emits
-/// while refreshing comfort noise during DTX.
-fn is_sid_refresh(packet: &[u8]) -> bool {
+/// The largest coded frame that is still comfort noise rather than audio.
+const SID_BYTES: i16 = 2;
+
+/// Whether every coded frame in an accepted packet is comfort noise, ignoring
+/// any padding the sender added.
+fn is_comfort_noise(packet: &[u8]) -> bool {
 	let Ok(len) = i32::try_from(packet.len()) else {
 		return false;
 	};
-	let mut frames = [std::ptr::null(); 48];
+
+	// An Opus packet holds at most 48 frames (RFC 6716 section 3.2.5).
 	let mut sizes = [0i16; 48];
-	// SAFETY: the arrays have libopus's maximum 48 frame slots. The returned
-	// frame pointers refer into `packet` and are read only for their reported sizes.
+	// SAFETY: `sizes` has libopus's maximum frame count. Passing null for the TOC
+	// and frame pointers asks it to skip them, which it checks for; only `size` is
+	// required. Padding is parsed off rather than counted.
 	let count = unsafe {
 		unsafe_libopus::opus_packet_parse(
 			packet.as_ptr(),
 			len,
 			std::ptr::null_mut(),
-			frames.as_mut_ptr(),
+			std::ptr::null_mut(),
 			sizes.as_mut_ptr(),
 			std::ptr::null_mut(),
 		)
 	};
-	let Ok(count) = usize::try_from(count) else {
-		return false;
-	};
 
-	frames[..count].iter().zip(&sizes[..count]).all(|(&frame, &size)| {
-		let Ok(size) = usize::try_from(size) else {
-			return false;
-		};
-		if size == 0 {
-			return true;
-		}
-		// SAFETY: opus_packet_parse returned this pointer and size into `packet`.
-		unsafe { std::slice::from_raw_parts(frame, size) == [0xff, 0xfe] }
-	})
-}
-
-fn unpadded_len(packet: &[u8]) -> usize {
-	let Some((&toc, frames)) = packet.split_first() else {
-		return 0;
-	};
-	let Some(&frame_count) = frames.first() else {
-		return packet.len();
-	};
-	if toc & 0x03 != 0x03 || frame_count & 0x40 == 0 {
-		return packet.len();
+	match usize::try_from(count).ok().and_then(|count| sizes.get(..count)) {
+		Some(sizes) if !sizes.is_empty() => sizes.iter().all(|&size| size <= SID_BYTES),
+		_ => false,
 	}
-
-	let Ok(len) = i32::try_from(packet.len()) else {
-		return packet.len();
-	};
-	let mut unpadded = packet.to_vec();
-	// SAFETY: `unpadded` is writable for `len` bytes. This only runs after
-	// libopus accepted the packet, so parsing should succeed.
-	let len = unsafe { unsafe_libopus::opus_packet_unpad(unpadded.as_mut_ptr(), len) };
-	usize::try_from(len).unwrap_or(packet.len())
 }
 
 #[cfg(test)]
@@ -149,12 +135,31 @@ mod tests {
 	}
 
 	#[test]
-	fn activity_preserves_dtx_only_across_loss() {
+	fn activity_reads_the_opus_framing() {
 		assert_eq!(activity(&[0xf8], false), Activity::Dtx);
 		assert_eq!(activity(&[0xf8, 0xff], false), Activity::Dtx);
 		assert_eq!(activity(&[], true), Activity::Dtx);
 		assert_eq!(activity(&[], false), Activity::Active);
-		assert_eq!(activity(&[0xf8, 0xff, 0xfe], false), Activity::Active);
+		// A SID refresh is comfort noise whatever the last packet was.
+		assert_eq!(activity(&[0xf8, 0xff, 0xfe], false), Activity::Dtx);
 		assert_eq!(activity(&[0xf8, 0xff, 0xfe], true), Activity::Dtx);
+	}
+
+	/// Another sender's comfort noise is not byte-for-byte ours, so only the
+	/// framing may decide. Code 3 CBR, three 20 ms frames, contents arbitrary.
+	#[test]
+	fn activity_ignores_the_sid_payload_bytes() {
+		assert_eq!(
+			activity(&[0xfb, 0x03, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc], false),
+			Activity::Dtx
+		);
+		// The same framing carrying three-byte frames is audio, not comfort noise.
+		assert_eq!(
+			activity(
+				&[0xfb, 0x03, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11],
+				false
+			),
+			Activity::Active
+		);
 	}
 }

--- a/rs/moq-audio/src/opus.rs
+++ b/rs/moq-audio/src/opus.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use crate::Error;
+use crate::{Activity, Error};
 
 /// Sample rates libopus runs at, ascending.
 const RATES: [u32; 5] = [8_000, 12_000, 16_000, 24_000, 48_000];
@@ -64,6 +64,19 @@ pub(crate) fn decode_error(code: i32) -> Error {
 	error(code, "opus_decode_float")
 }
 
+/// Classify a packet libopus accepted, preserving DTX across packet loss.
+///
+/// libopus emits one or two bytes for DTX and comfort noise. An empty payload
+/// asks the decoder for packet-loss concealment, which remains DTX only when
+/// the last accepted packet entered DTX.
+pub(crate) fn activity(packet: &[u8], in_dtx: bool) -> Activity {
+	match packet.len() {
+		0 if in_dtx => Activity::Dtx,
+		1 | 2 => Activity::Dtx,
+		_ => Activity::Active,
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -75,5 +88,14 @@ mod tests {
 		for &r in &RATES {
 			assert_eq!(pick_rate(r), r);
 		}
+	}
+
+	#[test]
+	fn activity_preserves_dtx_only_across_loss() {
+		assert_eq!(activity(&[0xf8], false), Activity::Dtx);
+		assert_eq!(activity(&[0xf8, 0xff], false), Activity::Dtx);
+		assert_eq!(activity(&[], true), Activity::Dtx);
+		assert_eq!(activity(&[], false), Activity::Active);
+		assert_eq!(activity(&[0xf8, 0xff, 0xfe], true), Activity::Active);
 	}
 }

--- a/rs/moq-audio/tests/roundtrip.rs
+++ b/rs/moq-audio/tests/roundtrip.rs
@@ -54,10 +54,7 @@ async fn opus_round_trip_48k_stereo() {
 	for _ in 0..10 {
 		let pcm = sine_f32_interleaved(440.0, 48_000, 2, frames_per_chunk);
 		producer
-			.write(&Frame {
-				timestamp: Timestamp::from_micros(0).unwrap(),
-				data: f32_bytes(&pcm),
-			})
+			.write(&Frame::new(f32_bytes(&pcm), Timestamp::from_micros(0).unwrap()))
 			.unwrap();
 	}
 
@@ -124,10 +121,7 @@ async fn opus_round_trip_44100_s16_resampled() {
 		let pcm = sine_f32_interleaved(440.0, 44_100, 1, frames_per_chunk);
 		let s16 = Format::S16.from_interleaved_f32(&pcm, 1).unwrap();
 		producer
-			.write(&Frame {
-				timestamp: Timestamp::from_micros(0).unwrap(),
-				data: Bytes::from(s16),
-			})
+			.write(&Frame::new(Bytes::from(s16), Timestamp::from_micros(0).unwrap()))
 			.unwrap();
 	}
 
@@ -185,10 +179,10 @@ async fn pcm_round_trip_is_lossless() {
 	let mut producer = encode::Producer::new(&mut broadcast, catalog.clone(), input, &options).unwrap();
 	let samples = sine_f32_interleaved(440.0, 48_000, 2, 960);
 	producer
-		.write(&Frame {
-			timestamp: Timestamp::from_micros(123_000).unwrap(),
-			data: f32_bytes(&samples),
-		})
+		.write(&Frame::new(
+			f32_bytes(&samples),
+			Timestamp::from_micros(123_000).unwrap(),
+		))
 		.unwrap();
 
 	let snapshot = catalog_consumer.next().await.unwrap().unwrap();

--- a/rs/moq-boy/src/audio.rs
+++ b/rs/moq-boy/src/audio.rs
@@ -62,10 +62,10 @@ impl AudioEncoder {
 		for sample in samples {
 			data.extend_from_slice(&sample.to_le_bytes());
 		}
-		let frame = moq_audio::Frame {
-			timestamp: moq_net::Timestamp::from_micros(elapsed.as_micros() as u64)?,
-			data: Bytes::from(data),
-		};
+		let frame = moq_audio::Frame::new(
+			Bytes::from(data),
+			moq_net::Timestamp::from_micros(elapsed.as_micros() as u64)?,
+		);
 		self.producer.write(&frame)?;
 		Ok(())
 	}

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -134,10 +134,10 @@ impl TryFrom<MoqAudioFrame> for moq_audio::Frame {
 	type Error = moq_audio::Error;
 
 	fn try_from(f: MoqAudioFrame) -> Result<Self, Self::Error> {
-		Ok(Self {
-			timestamp: moq_net::Timestamp::from_micros(f.timestamp_us)?,
-			data: f.data.into(),
-		})
+		Ok(Self::new(
+			f.data.into(),
+			moq_net::Timestamp::from_micros(f.timestamp_us)?,
+		))
 	}
 }
 
@@ -258,11 +258,7 @@ struct ConsumerInner {
 
 impl ConsumerInner {
 	async fn next(&mut self) -> Result<Option<MoqAudioFrame>, MoqError> {
-		Ok(self
-			.consumer
-			.read()
-			.await?
-			.map(|classified| classified.into_inner().into()))
+		Ok(self.consumer.read().await?.map(Into::into))
 	}
 }
 

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -258,7 +258,11 @@ struct ConsumerInner {
 
 impl ConsumerInner {
 	async fn next(&mut self) -> Result<Option<MoqAudioFrame>, MoqError> {
-		Ok(self.consumer.read().await?.map(Into::into))
+		Ok(self
+			.consumer
+			.read()
+			.await?
+			.map(|classified| classified.into_inner().into()))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Attach active/DTX classification to the audio itself rather than to a metadata track: `Frame` (decode) and `encode::Encoded` (encode) each carry an `Activity`.
- Classify an Opus packet from its framing alone, so padding, native SID refreshes at 20/40/60 ms, and another sender's comfort noise all read the same.
- Preserve activity across sample-rate conversion by tracking codec-time activity spans and splitting resampler output at each boundary, including the flushed tail.

Refs #2481.

## Root cause

The original packet-length rule had two gaps. Opus padding can make a one- or two-byte DTX packet appear longer without changing its contents, and libopus periodically emits native SID refresh packets longer than two bytes while DTX remains active.

Both are the same mistake: measuring the packet instead of reading it. `opus_packet_parse` hands back the size of each coded frame with padding already parsed off, and comfort noise is exactly the case where every coded frame is at most a two-byte SID payload, where real audio is tens of bytes even at the lowest bitrate. So one rule covers the one-byte entry packet, the padded packet, the multi-byte refresh, and the multi-frame refresh a 40 or 60 ms configuration emits. It also does not depend on our own libopus emitting a particular SID payload, which matters because the decoder classifies packets from senders that are not us.

The encoder applies the same function rather than `OPUS_GET_IN_DTX`, which flips a packet before libopus first omits coded audio. Reading the packet on both sides makes encoder and decoder agree by construction rather than by two mechanisms that have to be kept in sync. The decoder keeps one bit of state so an empty payload (packet-loss concealment, which says nothing about the audio) carries the last real packet's classification through; a rejected packet does not disturb it.

The consumer also labeled each complete resampler output with the most recently submitted packet. A fixed resampler chunk can begin with buffered samples from an earlier packet, so an activity transition inside that chunk was assigned to the wrong samples. The consumer now carries timestamped activity spans through resampling and emits separate classified frames at their boundaries.

## Public API changes

`moq-audio` is a `0.0.x` package, so these breaking changes target `main` per the repository policy.

- Adds `Activity::{Active, Dtx}`.
- `Frame` gains an `activity` field, plus `Frame::new(data, timestamp)` so the encode path never mentions it. It is set on the way out of `decode` and ignored on the way into `encode`, which classifies what it actually produced.
- `Encoder::encode` returns the new `encode::Encoded { payload, activity }` and `Decoder::decode` returns the new `decode::Decoded { samples, activity }`, mirroring `moq_video::encode::Encoded`. `Finish::packets` / `into_packets` follow. Both are plain structs with public fields, so #2481's planned encode timestamp lands as another field rather than another wrapper.
- `encode::Producer::activity` reports how the packet it published most recently was classified. `write` and `finish` keep returning `()`.
- Keeps the existing `libmoq` and `moq-ffi` public surfaces unchanged.

No wire format changed, so the `hang`/`js`/draft synchronization row does not apply. The `moq-ffi` surface is unchanged, so no wrapper or binding documentation updates are required. `doc/lib/rs/crate/moq-audio.md` describes `Frame`, so it gains the `Activity` sentence.

## Test plan

- `nix develop --command just fix`
- `env MOQ_STRICT=1 nix develop --command just check`
- `nix develop --command env MOQ_STRICT=1 TMPDIR="$PWD/target/tmp" just test`

Regression coverage includes DTX entry and recovery, padded comfort-noise packets, periodic SID refreshes at 20/40/60 ms, loss during active and DTX periods, malformed packets, a hand-built comfort-noise packet whose SID payload is not the bytes our own libopus emits (and the same framing carrying three-byte frames, which is audio), producer/consumer parity, and a 10 ms Active-to-DTX transition inside a 20 ms resampler chunk.
