### PR TITLE
chore(js): consume Zod Mini via the dedicated @zod/mini package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,7 +108,7 @@
         "@moq/signals": "workspace:^",
         "@svta/cml-iso-bmff": "^1.0.5",
         "@svta/cml-utils": "1.6.0",
-        "zod": "^4.4.3",
+        "@zod/mini": "^4.5.4",
       },
       "devDependencies": {
         "@types/audioworklet": "^0.0.100",
@@ -133,7 +133,7 @@
         "typescript": "7.0.2",
       },
       "peerDependencies": {
-        "zod": "^4.0.0",
+        "@zod/mini": "^4.5.0",
       },
     },
     "js/loc": {
@@ -156,7 +156,7 @@
         "@moq/net": "workspace:^",
         "@moq/signals": "workspace:^",
         "@moq/watch": "workspace:^",
-        "zod": "^4.4.3",
+        "@zod/mini": "^4.5.4",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -173,7 +173,7 @@
       "version": "0.2.1",
       "dependencies": {
         "@moq/net": "workspace:^",
-        "zod": "^4.4.3",
+        "@zod/mini": "^4.5.4",
       },
       "devDependencies": {
         "rimraf": "^6.1.3",
@@ -198,7 +198,7 @@
         "vite-plugin-html": "^3.2.2",
       },
       "peerDependencies": {
-        "zod": "^4.0.0",
+        "@zod/mini": "^4.5.0",
       },
     },
     "js/publish": {
@@ -249,9 +249,9 @@
       },
       "dependencies": {
         "@hexagon/base64": "^2.0.4",
+        "@zod/mini": "^4.5.4",
         "commander": "^15.0.0",
         "jose": "^6.2.9",
-        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -302,7 +302,7 @@
         "@moq/json": "workspace:*",
         "@moq/net": "workspace:*",
         "@moq/web-transport": "^0.1.4",
-        "zod": "^4.0.0",
+        "@zod/mini": "^4.5.0",
       },
       "devDependencies": {
         "tsx": "^4.23.12",
@@ -920,6 +920,8 @@
     "@vueuse/metadata": ["@vueuse/metadata@12.8.2", "", {}, "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A=="],
 
     "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
+
+    "@zod/mini": ["@zod/mini@4.5.4", "", { "peerDependencies": { "zod": "^4.5.0" } }, "sha512-/LFQsBM2q92NTOozWQRmun1NfqMDEiNVf52P0znYSHItcyr7HzFW5hJC1y8+x2o0A3D4PZilwoP8DfJ5f5QTiQ=="],
 
     "abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
 
@@ -1791,7 +1793,7 @@
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -109,6 +109,7 @@
         "@svta/cml-iso-bmff": "^1.0.5",
         "@svta/cml-utils": "1.6.0",
         "@zod/mini": "^4.5.4",
+        "zod": "^4.5.4",
       },
       "devDependencies": {
         "@types/audioworklet": "^0.0.100",
@@ -134,6 +135,7 @@
       },
       "peerDependencies": {
         "@zod/mini": "^4.5.0",
+        "zod": "^4.5.0",
       },
     },
     "js/loc": {
@@ -157,6 +159,7 @@
         "@moq/signals": "workspace:^",
         "@moq/watch": "workspace:^",
         "@zod/mini": "^4.5.4",
+        "zod": "^4.5.4",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -174,6 +177,7 @@
       "dependencies": {
         "@moq/net": "workspace:^",
         "@zod/mini": "^4.5.4",
+        "zod": "^4.5.4",
       },
       "devDependencies": {
         "rimraf": "^6.1.3",
@@ -199,6 +203,7 @@
       },
       "peerDependencies": {
         "@zod/mini": "^4.5.0",
+        "zod": "^4.5.0",
       },
     },
     "js/publish": {
@@ -252,6 +257,7 @@
         "@zod/mini": "^4.5.4",
         "commander": "^15.0.0",
         "jose": "^6.2.9",
+        "zod": "^4.5.4",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -303,6 +309,7 @@
         "@moq/net": "workspace:*",
         "@moq/web-transport": "^0.1.4",
         "@zod/mini": "^4.5.0",
+        "zod": "^4.5.0",
       },
       "devDependencies": {
         "tsx": "^4.23.12",

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -12,7 +12,7 @@ Bun workspaces; members listed in the repo-root `package.json` (not in `js/`). D
 
 **Transport / protocol**
 
-- `@moq/net` (`net/`): browser networking. Connect to a relay, then publish/consume broadcasts/tracks/groups/frames over WebTransport (WebSocket fallback). Negotiates `moq-lite` (`lite/`) or IETF `moq-transport` (`ietf/`). Mirror of `rs/moq-net`. Optional `@zod/mini` peer dep for `./zod` JSON-frame helpers.
+- `@moq/net` (`net/`): browser networking. Connect to a relay, then publish/consume broadcasts/tracks/groups/frames over WebTransport (WebSocket fallback). Negotiates `moq-lite` (`lite/`) or IETF `moq-transport` (`ietf/`). Mirror of `rs/moq-net`. Optional `zod` + `@zod/mini` peer deps for `./zod` JSON-frame helpers.
 - `@moq/wasm` (`wasm/`): experimental browser bindings for `rs/moq-wasm` (wasm-bindgen over `moq-net`); typed npm wrapper built via `just wasm`.
 
 **Container / catalog formats**

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -12,7 +12,7 @@ Bun workspaces; members listed in the repo-root `package.json` (not in `js/`). D
 
 **Transport / protocol**
 
-- `@moq/net` (`net/`): browser networking. Connect to a relay, then publish/consume broadcasts/tracks/groups/frames over WebTransport (WebSocket fallback). Negotiates `moq-lite` (`lite/`) or IETF `moq-transport` (`ietf/`). Mirror of `rs/moq-net`. Optional `zod` peer dep for `./zod` JSON-frame helpers.
+- `@moq/net` (`net/`): browser networking. Connect to a relay, then publish/consume broadcasts/tracks/groups/frames over WebTransport (WebSocket fallback). Negotiates `moq-lite` (`lite/`) or IETF `moq-transport` (`ietf/`). Mirror of `rs/moq-net`. Optional `@zod/mini` peer dep for `./zod` JSON-frame helpers.
 - `@moq/wasm` (`wasm/`): experimental browser bindings for `rs/moq-wasm` (wasm-bindgen over `moq-net`); typed npm wrapper built via `just wasm`.
 
 **Container / catalog formats**

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -27,7 +27,8 @@
 		"@moq/signals": "workspace:^",
 		"@svta/cml-iso-bmff": "^1.0.5",
 		"@svta/cml-utils": "1.6.0",
-		"@zod/mini": "^4.5.4"
+		"@zod/mini": "^4.5.4",
+		"zod": "^4.5.4"
 	},
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.100",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -27,7 +27,7 @@
 		"@moq/signals": "workspace:^",
 		"@svta/cml-iso-bmff": "^1.0.5",
 		"@svta/cml-utils": "1.6.0",
-		"zod": "^4.4.3"
+		"@zod/mini": "^4.5.4"
 	},
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.100",

--- a/js/hang/src/catalog/audio.ts
+++ b/js/hang/src/catalog/audio.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 import { ContainerSchema } from "./container";
 import { hexSchema } from "./hex";
 import { u53Schema } from "./integers";

--- a/js/hang/src/catalog/container.ts
+++ b/js/hang/src/catalog/container.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 /** The container kinds this build knows how to decode. */
 const KNOWN_KINDS = ["legacy", "cmaf", "loc"];

--- a/js/hang/src/catalog/hex.ts
+++ b/js/hang/src/catalog/hex.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 /**
  * A hex-encoded byte string, the catalog's encoding for WebCodecs `Uint8Array` fields.

--- a/js/hang/src/catalog/integers.ts
+++ b/js/hang/src/catalog/integers.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 /**
  * Branded type for 8-bit unsigned integers (0-255)

--- a/js/hang/src/catalog/path.ts
+++ b/js/hang/src/catalog/path.ts
@@ -1,5 +1,5 @@
 import { Path } from "@moq/net";
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 /**
  * Zod schema for a relative broadcast reference stored in a catalog (a rendition's

--- a/js/hang/src/catalog/root.test.ts
+++ b/js/hang/src/catalog/root.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 import { RootSchema } from "./root.ts";
 
 // The base catalog is generic: only `video`/`audio`. Applications add their own root sections

--- a/js/hang/src/catalog/root.ts
+++ b/js/hang/src/catalog/root.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 import { AudioSchema } from "./audio";
 import { VideoSchema } from "./video";

--- a/js/hang/src/catalog/timeline.ts
+++ b/js/hang/src/catalog/timeline.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 import { u53, u53Schema } from "./integers";
 
 /**

--- a/js/hang/src/catalog/track.ts
+++ b/js/hang/src/catalog/track.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 /** Schema for a catalog track reference, identified by name. */
 export const TrackSchema = z.object({

--- a/js/hang/src/catalog/video.ts
+++ b/js/hang/src/catalog/video.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 import { ContainerSchema } from "./container";
 import { hexSchema } from "./hex";
 import { u53Schema } from "./integers";

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -21,7 +21,8 @@
 		"@moq/signals": "workspace:^"
 	},
 	"peerDependencies": {
-		"@zod/mini": "^4.5.0"
+		"@zod/mini": "^4.5.0",
+		"zod": "^4.5.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.14",

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -21,7 +21,7 @@
 		"@moq/signals": "workspace:^"
 	},
 	"peerDependencies": {
-		"zod": "^4.0.0"
+		"@zod/mini": "^4.5.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.14",

--- a/js/json/src/snapshot/encoder.ts
+++ b/js/json/src/snapshot/encoder.ts
@@ -1,5 +1,5 @@
 import { Encoder as Flate } from "@moq/flate";
-import type * as z from "zod/mini";
+import type * as z from "@zod/mini";
 
 import { deepEqual, diff } from "../diff.ts";
 

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -27,7 +27,8 @@
 		"@moq/net": "workspace:^",
 		"@moq/watch": "workspace:^",
 		"@moq/signals": "workspace:^",
-		"@zod/mini": "^4.5.4"
+		"@zod/mini": "^4.5.4",
+		"zod": "^4.5.4"
 	},
 	"//devDependencies": "These are only needed for local development with workspace packages. They are NOT needed when using the published npm packages.",
 	"devDependencies": {

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -27,7 +27,7 @@
 		"@moq/net": "workspace:^",
 		"@moq/watch": "workspace:^",
 		"@moq/signals": "workspace:^",
-		"zod": "^4.4.3"
+		"@zod/mini": "^4.5.4"
 	},
 	"//devDependencies": "These are only needed for local development with workspace packages. They are NOT needed when using the published npm packages.",
 	"devDependencies": {

--- a/js/moq-boy/src/schemas.ts
+++ b/js/moq-boy/src/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/mini";
+import { z } from "@zod/mini";
 
 /** Server-reported encoding/emulation performance stats. */
 export const GameStatsSchema = z.object({

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -17,7 +17,7 @@
 	},
 	"dependencies": {
 		"@moq/net": "workspace:^",
-		"zod": "^4.4.3"
+		"@zod/mini": "^4.5.4"
 	},
 	"devDependencies": {
 		"rimraf": "^6.1.3",

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -17,7 +17,8 @@
 	},
 	"dependencies": {
 		"@moq/net": "workspace:^",
-		"@zod/mini": "^4.5.4"
+		"@zod/mini": "^4.5.4",
+		"zod": "^4.5.4"
 	},
 	"devDependencies": {
 		"rimraf": "^6.1.3",

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -1,5 +1,5 @@
 import type * as Moq from "@moq/net";
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 /** Zod schema for a track's wire packaging. Accepts known values or any future string. */
 export const PackagingSchema = z.union([

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -23,7 +23,8 @@
 		"bowser": "^2.14.1"
 	},
 	"peerDependencies": {
-		"@zod/mini": "^4.5.0"
+		"@zod/mini": "^4.5.0",
+		"zod": "^4.5.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.14",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -23,7 +23,7 @@
 		"bowser": "^2.14.1"
 	},
 	"peerDependencies": {
-		"zod": "^4.0.0"
+		"@zod/mini": "^4.5.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.14",

--- a/js/net/src/origin.ts
+++ b/js/net/src/origin.ts
@@ -7,7 +7,7 @@
  *
  * @module
  */
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 /**
  * A relay origin id, encoded as a 62-bit varint on the wire.

--- a/js/net/src/zod.ts
+++ b/js/net/src/zod.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import type * as z from "zod/mini";
+import type * as z from "@zod/mini";
 import type * as group from "./group.ts";
 import type * as track from "./track.ts";
 

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -20,9 +20,9 @@
 	},
 	"dependencies": {
 		"@hexagon/base64": "^2.0.4",
+		"@zod/mini": "^4.5.4",
 		"commander": "^15.0.0",
-		"jose": "^6.2.9",
-		"zod": "^4.4.3"
+		"jose": "^6.2.9"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.14",

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -22,7 +22,8 @@
 		"@hexagon/base64": "^2.0.4",
 		"@zod/mini": "^4.5.4",
 		"commander": "^15.0.0",
-		"jose": "^6.2.9"
+		"jose": "^6.2.9",
+		"zod": "^4.5.4"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.14",

--- a/js/token/src/algorithm.ts
+++ b/js/token/src/algorithm.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 
 /**
  * Supported JWT algorithms.

--- a/js/token/src/claims.ts
+++ b/js/token/src/claims.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import * as z from "zod/mini";
+import * as z from "@zod/mini";
 import * as Path from "./path.ts";
 
 /** A `put`/`get` claim is one path or many; normalize it to a list. */

--- a/js/token/src/key.ts
+++ b/js/token/src/key.ts
@@ -1,6 +1,6 @@
 import * as base64 from "@hexagon/base64";
+import * as z from "@zod/mini";
 import * as jose from "jose";
-import * as z from "zod/mini";
 import { type Algorithm, AlgorithmSchema } from "./algorithm.ts";
 import { type Claims, ClaimsSchema, ScopeSchema, scopeAllows } from "./claims.ts";
 

--- a/js/token/src/set.ts
+++ b/js/token/src/set.ts
@@ -7,8 +7,8 @@
  * @module
  */
 
+import * as z from "@zod/mini";
 import * as jose from "jose";
-import * as z from "zod/mini";
 import type { Claims } from "./claims.ts";
 import { type Key, KeySchema, type PublicKey, sign, toPublicKey, verify } from "./key.ts";
 

--- a/test/smoke/clients/js-native/package.json
+++ b/test/smoke/clients/js-native/package.json
@@ -7,7 +7,8 @@
 		"@moq/json": "workspace:*",
 		"@moq/net": "workspace:*",
 		"@moq/web-transport": "^0.1.4",
-		"@zod/mini": "^4.5.0"
+		"@zod/mini": "^4.5.0",
+		"zod": "^4.5.0"
 	},
 	"devDependencies": {
 		"tsx": "^4.23.12"

--- a/test/smoke/clients/js-native/package.json
+++ b/test/smoke/clients/js-native/package.json
@@ -7,7 +7,7 @@
 		"@moq/json": "workspace:*",
 		"@moq/net": "workspace:*",
 		"@moq/web-transport": "^0.1.4",
-		"zod": "^4.0.0"
+		"@zod/mini": "^4.5.0"
 	},
 	"devDependencies": {
 		"tsx": "^4.23.12"


### PR DESCRIPTION
## Summary

- Zod 4.5 ships `@zod/mini` as a standalone package alongside the `zod/mini` subpath export. Every import moves from `zod/mini` to `@zod/mini` (19 files across `js/{net,json,msf,token,hang,moq-boy}`).
- Manifests now declare **both** `@zod/mini` and `zod`, in whichever section `zod` was in before: peer in `js/{net,json}` (`^4.5.0`), direct in `js/{msf,token,hang,moq-boy}` and `test/smoke/clients/js-native` (`^4.5.4`). The two aren't redundant. `@zod/mini` is a re-export shim (`export * from "zod/mini"`) that declares `zod` as a peer, so both names have to be declared for the import to resolve. See the root cause below.
- Why bother, beyond following upstream: the subpath form made the generated JSR import maps route Zod Mini through a trailing-slash `zod/` → `npm:/zod@.../` mapping. `@zod/mini` now resolves as a plain bare specifier.
- Ranges are `^4.5.x` rather than the old permissive `^4.0.0` because `@zod/mini` has no stable release before 4.5.0 (published versions are 4.5.0 through 4.5.4 only). The resolved `zod` in `bun.lock` moves 4.4.3 → 4.5.4 to satisfy that. Root `package.json` is unchanged.

## Root cause (efaa331, fixing a P1 Codex caught on a392cf3)

The first commit dropped `zod` from the manifests, leaving only `@zod/mini`. That resolves under npm, pnpm, and bun, which auto-install transitive peers — so the whole workspace check suite stayed green while the *published* packages were broken for Yarn consumers, and `yarn add @moq/hang` / `yarn add @moq/net` are both documented install flows.

Reproduced with a bare `@zod/mini` install under each manager, importing the package:

```
yarn 1.22.22  FAIL: ERR_MODULE_NOT_FOUND Cannot find package 'zod'
                    imported from node_modules/@zod/mini/index.js
npm 10.9.7    OK
pnpm 10.33.0  OK
```

Yarn only warns (`has unmet peer dependency "zod@^4.5.0"`) and leaves `node_modules` without `zod`. Declaring both names fixes it; re-ran the same install under yarn with both present and the import resolves with no warning.

No regression test: this is a manifest-resolution bug in published output, which the workspace's own install can't observe (bun auto-installs the peer, so the failing state is unreachable from inside the repo).

## Public API changes

None. No exported item is added, renamed, removed, or signature-changed.

`@moq/net`'s `./zod` subpath still exports `read`/`write` taking `z.ZodMiniType<T>`, and `@zod/mini` re-exports `zod/mini` verbatim, so it is the same declaration — a consumer already importing from `zod/mini` keeps typechecking against these signatures.

The one contract change is the peer range: `@moq/net` and `@moq/json` want `zod ^4.5.0` where they wanted `^4.0.0`, plus the new `@zod/mini` peer. A consumer pinned below Zod 4.5 has to bump, and a Yarn consumer using the optional `./zod` helpers now installs two names instead of one. That's a dependency-range narrowing rather than a semver break in an exported item, which is why this targets `main` — happy to retarget `dev` if you read it the other way.

## Cross-Package Sync

No row applies: no wire format, catalog/container format, FFI surface, or CLI interface changed. `js/CLAUDE.md` is updated for the `@moq/net` peer-dep note it carried.

## Test plan

`just` / `nix` were unavailable in this environment, so the recipes' underlying commands were run directly, and re-run after the fix commit:

- `bun install --frozen-lockfile` — clean, no peer warnings.
- Peer resolution verified out-of-tree against yarn 1.22.22 / npm 10.9.7 / pnpm 10.33.0, before and after the fix (results above).
- `bun run check` (`tsc --noEmit`, plus `tsc -b examples/` where present) in `js/{net,json,msf,token,hang,moq-boy}` — all pass.
- `bun test --only-failures` in `js/{hang,token,net,json,msf}` — 762 pass, 0 fail.
- `bun biome check js/ test/smoke/ package.json` — clean (import ordering shifted, since `@zod/mini` sorts ahead of bare specifiers).
- `bun run --filter='*' build` — all packages build, including declaration emit and `publint`. Spot-checked each publishing package's generated `dist/package.json` and `jsr.json`: deps land in the right section and the JSR import maps carry both `@zod/mini` and `zod`.

(Written by Claude Opus 5)