### PR TITLE
feat(video): complete native screen capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,6 +5177,7 @@ dependencies = [
  "v4l",
  "wgpu",
  "windows",
+ "x11rb 0.14.0",
  "yuv",
  "zune-jpeg",
 ]
@@ -11310,7 +11311,7 @@ dependencies = [
  "web-time",
  "windows-sys 0.52.0",
  "x11-dl",
- "x11rb",
+ "x11rb 0.13.2",
  "xkbcommon-dl",
 ]
 
@@ -11435,7 +11436,18 @@ dependencies = [
  "libloading 0.8.9",
  "once_cell",
  "rustix 1.1.4",
- "x11rb-protocol",
+ "x11rb-protocol 0.13.2",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8885a854a8bfdf87a301e53e41b17c5f8f33639903131338b997b1eb614f44"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol 0.14.0",
 ]
 
 [[package]]
@@ -11443,6 +11455,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf4d1bc32aa46eec18caa634ec3cf4c05bfa151f12b93b510b15190f69a1ca8"
 
 [[package]]
 name = "x509-cert"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ web-transport-quiche = "0.6"
 web-transport-quinn = "0.12"
 web-transport-trait = "0.4.0"
 web-transport-wasm = "0.5"
-x11rb = { version = "0.14.0", features = ["randr"] }
+x11rb = { version = "0.14.0", features = ["randr", "xfixes"] }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ web-transport-quiche = "0.6"
 web-transport-quinn = "0.12"
 web-transport-trait = "0.4.0"
 web-transport-wasm = "0.5"
+x11rb = { version = "0.14.0", features = ["randr"] }
 
 [profile.dev]
 panic = "abort"

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -387,7 +387,8 @@ Linux, Media Foundation on Windows). `--display` captures a screen instead:
 ScreenCaptureKit on macOS, DXGI Desktop Duplication on Windows, and
 xdg-desktop-portal + PipeWire on Linux (Wayland and X11), where the desktop's
 picker dialog chooses the screen (so the display id is ignored there).
-`--window` and `--app` are macOS-only, and `--no-cursor` applies to all three.
+`--window` works on macOS, Windows, and X11. `--app` is macOS-only, and
+`--no-cursor` applies to all three screen-source forms.
 On macOS these capture at the logical resolution, i.e. what the screen looks like
 to its owner rather than its native pixels: a 2x retina display shares as
 1710x1106, not 3420x2214, which keeps the derived bitrate sane. Pass

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -346,7 +346,7 @@ Microphones:
 ```
 
 ```bash
-# A single window, followed as it moves and resizes (macOS only):
+# Capture a single window (macOS, Windows, or X11):
 moq --client-connect https://relay.example.com/anon --broadcast win.hang \
     import capture --window 39193 --no-audio
 
@@ -385,8 +385,11 @@ cargo build --release -p moq-cli --no-default-features \
 Video capture uses a native per-platform backend (AVFoundation on macOS, V4L2 on
 Linux, Media Foundation on Windows). `--display` captures a screen instead:
 ScreenCaptureKit on macOS, DXGI Desktop Duplication on Windows, and
-xdg-desktop-portal + PipeWire on Linux (Wayland and X11), where the desktop's
-picker dialog chooses the screen (so the display id is ignored there).
+xdg-desktop-portal + PipeWire on Wayland, where the desktop's picker dialog
+chooses the screen (so the display id is ignored). X11 uses native capture and
+the listed `x11:<index>` monitor id. XWayland windows and monitors are listed
+with the same native ids, while an unqualified `--display` still uses the
+Wayland portal.
 `--window` works on macOS, Windows, and X11. `--app` is macOS-only, and
 `--no-cursor` applies to all three screen-source forms.
 On macOS these capture at the logical resolution, i.e. what the screen looks like

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -236,9 +236,11 @@ while let Some(surface) = capture.read().await? {
 }
 ```
 
-`Error::PermissionDenied` reports an operating-system capture denial.
-`Error::SourceUnavailable` reports a selected source that is missing or was
-removed while the stream was live.
+`read` ends with `None` when the source stopped for a benign reason, such as a
+window resize or a compositor format renegotiation; reopen to follow it. An
+error is terminal for that selection: `Error::PermissionDenied` reports an
+operating-system capture denial, and `Error::SourceUnavailable` reports a
+selected source that is missing or was removed while the stream was live.
 
 ## API Reference
 

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -215,12 +215,30 @@ Each enumerator returns ids that go straight back into `capture::Config::source`
 ```rust
 moq_video::capture::cameras().await?;   // webcams
 moq_video::capture::displays().await?;  // monitors
-moq_video::capture::windows().await?;   // single windows (macOS)
+moq_video::capture::windows().await?;   // single windows (macOS, Windows, X11)
 moq_video::capture::apps().await?;      // every window of an app (macOS)
 ```
 
 The [`moq devices`](/bin/cli) subcommand prints the same lists from the command
 line.
+
+An embedded application can open the selected source directly. Capture keeps
+one unconsumed frame, replacing it when the application is slower than the
+source, so latency stays bounded:
+
+```rust
+let mut config = moq_video::capture::Config::default();
+config.source = moq_video::capture::Source::Display(None);
+
+let mut capture = moq_video::capture::open(&config).await?;
+while let Some(surface) = capture.read().await? {
+    // Encode, render, or process `surface`.
+}
+```
+
+`Error::PermissionDenied` reports an operating-system capture denial.
+`Error::SourceUnavailable` reports a selected source that is missing or was
+removed while the stream was live.
 
 ## API Reference
 

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -25,7 +25,7 @@ Four role modules, symmetric on both ends of the wire:
 
 | Module | Does | Platform |
 | --- | --- | --- |
-| `capture` | Camera, display, window, or application frames | AVFoundation + ScreenCaptureKit (macOS), V4L2 + PipeWire (Linux), Media Foundation + DXGI (Windows) |
+| `capture` | Camera, display, window, or application frames | AVFoundation + ScreenCaptureKit (macOS), V4L2 + X11/portal + PipeWire (Linux), Media Foundation + DXGI/GDI (Windows) |
 | `encode` | Raw frames to H.264/H.265, published through `moq-mux` | VideoToolbox, Media Foundation, NVENC, VAAPI, openh264 |
 | `decode` | A subscribed track back to raw frames | VideoToolbox, Media Foundation/DXVA, NVDEC, openh264 |
 | `render` | A frame drawn on the GPU, handed back as a `wgpu` texture | wgpu, with zero-copy Metal and Vulkan imports |
@@ -70,7 +70,7 @@ cargo add moq-video --features render,pipewire
 | `nvidia` | yes | NVENC encode and NVDEC decode on Linux (`cudarc`, `moq-nvenc`) |
 | `vaapi` | no | Intel/AMD encode on Linux (`moq-vaapi`), unvalidated on hardware |
 | `render` | no | `wgpu`, the GPU renderer, and Linux DMA-BUF support |
-| `pipewire` | no | Wayland/X11 screen capture via xdg-desktop-portal and DMA-BUF |
+| `pipewire` | no | Wayland screen capture via xdg-desktop-portal and DMA-BUF |
 
 `--no-default-features` gives a codec-only build that still encodes and decodes
 H.264 with openh264 but omits native capture and the Linux GPU dependencies. A

--- a/rs/moq-cli/src/devices.rs
+++ b/rs/moq-cli/src/devices.rs
@@ -9,8 +9,8 @@ use std::fmt::Write;
 /// Print every capture source this platform can enumerate.
 ///
 /// A source that this platform doesn't implement is reported inline rather than
-/// failing the whole listing: a Linux box with no window enumeration should
-/// still get its cameras.
+/// failing the whole listing: a Wayland session with portal-owned selection
+/// should still get its cameras.
 pub async fn run() -> anyhow::Result<()> {
 	let mut out = String::new();
 

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -55,12 +55,13 @@ pub struct CaptureArgs {
 	pub camera: Option<Option<String>>,
 
 	/// Capture a whole display, by the id `moq devices` reports. Bare
-	/// `--display` captures the main display. On Linux the desktop portal opens a
-	/// picker dialog and the id is ignored.
+	/// `--display` captures the main display. On Wayland the desktop portal opens
+	/// a picker dialog; X11 accepts the listed monitor id.
 	#[arg(long, num_args = 0..=1, group = "video-source", alias = "screen")]
 	pub display: Option<Option<String>>,
 
-	/// Capture a single window, by the id `moq devices` reports. macOS only.
+	/// Capture a single window, by the id `moq devices` reports. Supported on
+	/// macOS, Windows, and X11.
 	#[arg(long, group = "video-source")]
 	pub window: Option<String>,
 

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -177,9 +177,10 @@ windows = { version = "0.62", features = [
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
     "Win32_Graphics_Gdi",
-    "Win32_Storage_Xps",
     "Win32_System_Ole",
+    "Win32_System_Threading",
     "Win32_System_Variant",
+    "Win32_UI_HiDpi",
     "Win32_UI_WindowsAndMessaging",
 ] }
 

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -21,7 +21,7 @@ default = ["capture", "nvidia"]
 # Native camera and screen capture. Enabled by default for direct consumers,
 # but workspace consumers opt in so codec-only bindings avoid device build
 # dependencies such as V4L2 and libclang.
-capture = ["dep:v4l", "dep:zune-jpeg"]
+capture = ["dep:v4l", "dep:x11rb", "dep:zune-jpeg"]
 # The NVIDIA codecs on Linux: the NVENC encoder and the NVDEC decoder. One
 # feature because they are one dependency stack (cudarc + moq-nvenc, plus a
 # libloading probe for the driver libs) and one code path: NVDEC hands NVENC a
@@ -137,6 +137,10 @@ pipewire = { version = "0.10", optional = true }
 # Native V4L2 webcam capture (replaces nokhwa). `v4l` streams MMAP buffers;
 # MJPEG cameras are decoded with the pure-Rust `zune-jpeg` (no libjpeg/IJG).
 v4l = { version = "0.14", optional = true }
+# X11 display/window enumeration and capture. Pure Rust and used when no
+# Wayland session is active, so Linux screen capture still works without a
+# portal and callers can select a stable monitor or window id.
+x11rb = { workspace = true, optional = true }
 zune-jpeg = { version = "0.5", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
@@ -173,8 +177,10 @@ windows = { version = "0.62", features = [
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
     "Win32_Graphics_Gdi",
+    "Win32_Storage_Xps",
     "Win32_System_Ole",
     "Win32_System_Variant",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 
 [dev-dependencies]

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -50,8 +50,10 @@ while let Some(surface) = capture.read().await? {
 ```
 
 The stream retains only the newest unconsumed frame, so a slow encoder adds
-drops rather than latency. Permission denial and a source disappearing are
-reported as `Error::PermissionDenied` and `Error::SourceUnavailable`.
+drops rather than latency. `read` ends with `None` when the source stopped for
+a benign reason, such as a window resize, so reopen to follow it. Permission
+denial and a source disappearing are terminal, reported as
+`Error::PermissionDenied` and `Error::SourceUnavailable`.
 
 ## Encode
 

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -18,21 +18,40 @@ caller without pulling Linux V4L2 and libclang build dependencies.
 
 Per-platform, picked at compile time:
 
-- **macOS**: AVFoundation (camera) and ScreenCaptureKit (display), yielding
-  zero-copy `CVPixelBuffer` surfaces straight to VideoToolbox.
+- **macOS**: AVFoundation (camera) and ScreenCaptureKit (display, window, or
+  application), yielding zero-copy `CVPixelBuffer` surfaces straight to
+  VideoToolbox.
 - **Linux**: native V4L2 (camera; YUYV resampled, MJPEG via `zune-jpeg`) and
-  xdg-desktop-portal + PipeWire (display; RGB -> CPU I420, behind the `pipewire`
-  feature since it links libpipewire). Works on Wayland and X11; the desktop's
-  picker dialog chooses the screen, and the portal's restore token is reused so
-  demand-driven reopens don't re-prompt.
+  xdg-desktop-portal + PipeWire on Wayland (display; behind the `pipewire`
+  feature), with native X11 monitor/window selection and capture as the X11
+  fallback. The Wayland picker dialog chooses the screen, and the portal's
+  restore token is reused so demand-driven reopens don't re-prompt.
 - **Windows**: native Media Foundation (camera; `IMFSourceReader`) and DXGI
-  Desktop Duplication (display; BGRA -> CPU I420). Display capture is
-  whole-monitor; select one with a bare index or `display:{index}`.
+  Desktop Duplication (display), plus GDI single-window capture. Both convert
+  BGRA to CPU I420 and use the ids returned by the enumerators.
 
 `capture::cameras()` lists AVFoundation, V4L2, or Media Foundation cameras with
 identifiers accepted by `capture::Source::Camera`. `capture::displays()` does
-the same for macOS and Windows displays. Linux display selection stays in the
-desktop portal picker, which does not expose a stable display identifier.
+the same for macOS, Windows, and X11 displays. `capture::windows()` lists macOS,
+Windows, and X11 windows. Wayland display selection stays in the desktop portal
+picker, which does not expose a stable display identifier.
+
+Embedded applications can consume raw capture without creating a MoQ
+broadcast:
+
+```rust
+let mut config = moq_video::capture::Config::default();
+config.source = moq_video::capture::Source::Display(None);
+
+let mut capture = moq_video::capture::open(&config).await?;
+while let Some(surface) = capture.read().await? {
+    // Encode, render, or inspect the newest captured surface.
+}
+```
+
+The stream retains only the newest unconsumed frame, so a slow encoder adds
+drops rather than latency. Permission denial and a source disappearing are
+reported as `Error::PermissionDenied` and `Error::SourceUnavailable`.
 
 ## Encode
 

--- a/rs/moq-video/src/capture/avfoundation.rs
+++ b/rs/moq-video/src/capture/avfoundation.rs
@@ -22,7 +22,7 @@ use objc2_core_media::CMSampleBuffer;
 use objc2_foundation::{NSObject, NSObjectProtocol, NSString};
 
 use super::surface::surface_frame;
-use super::{Camera, Config, FrameChannel, FrameStream};
+use super::{Camera, Config, FrameChannel, Stream};
 use crate::Error;
 
 /// How long `open` waits for the first frame before assuming the camera never
@@ -54,7 +54,7 @@ pub(super) fn cameras() -> Result<Vec<Camera>, Error> {
 }
 
 /// Open the default (or requested) camera and stream its frames.
-pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream, Error> {
 	let media = unsafe { AVMediaTypeVideo }.ok_or_else(|| Error::Codec(anyhow::anyhow!("AVMediaTypeVideo")))?;
 
 	// Gate on camera authorization before opening the device, so an unauthorized
@@ -66,10 +66,10 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 		Some(id) => {
 			let id = NSString::from_str(id);
 			unsafe { AVCaptureDevice::deviceWithUniqueID(&id) }
-				.ok_or_else(|| Error::Codec(anyhow::anyhow!("no camera with id {id}")))?
+				.ok_or_else(|| Error::SourceUnavailable(format!("no camera with id {id}")))?
 		}
 		None => unsafe { AVCaptureDevice::defaultDeviceWithMediaType(media) }
-			.ok_or_else(|| Error::Codec(anyhow::anyhow!("no default camera")))?,
+			.ok_or_else(|| Error::SourceUnavailable("no default camera".to_string()))?,
 	};
 
 	// Honoring these means picking an `activeFormat` and locking a frame
@@ -111,7 +111,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 	}
 
 	// The session keeps capturing until dropped; this guard stops it and closes
-	// the channel when the FrameStream goes away.
+	// the channel when the Stream goes away.
 	let guard = SessionGuard {
 		session,
 		chan: chan.clone(),
@@ -122,8 +122,9 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 	// Await the first frame to learn the negotiated resolution (and to surface a
 	// permission failure as an error rather than a silent hang).
 	let first = match tokio::time::timeout(FIRST_FRAME_TIMEOUT, chan.recv()).await {
-		Ok(Some(frame)) => frame,
-		Ok(None) | Err(_) => {
+		Ok(Ok(Some(frame))) => frame,
+		Ok(Err(error)) => return Err(error),
+		Ok(Ok(None)) | Err(_) => {
 			return Err(Error::Codec(anyhow::anyhow!(
 				"no frames from camera {device_id} within {FIRST_FRAME_TIMEOUT:?} (permission denied?)"
 			)));
@@ -133,7 +134,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 
 	tracing::info!(device = %device_id, width, height, "opened camera (AVFoundation)");
 
-	Ok(FrameStream::new(
+	Ok(Stream::new(
 		chan,
 		width,
 		height,
@@ -175,22 +176,22 @@ async fn ensure_camera_access(media: &AVMediaType) -> Result<(), Error> {
 
 		return match tokio::time::timeout(ACCESS_TIMEOUT, rx).await {
 			Ok(Ok(true)) => Ok(()),
-			Ok(Ok(false)) => Err(Error::Codec(anyhow::anyhow!(
-				"camera access denied; enable it in System Settings > Privacy & Security > Camera"
-			))),
-			Ok(Err(_)) => Err(Error::Codec(anyhow::anyhow!(
-				"camera-permission prompt dismissed without a decision"
-			))),
-			Err(_) => Err(Error::Codec(anyhow::anyhow!(
+			Ok(Ok(false)) => Err(Error::PermissionDenied(
+				"camera access; enable it in System Settings > Privacy & Security > Camera".to_string(),
+			)),
+			Ok(Err(_)) => Err(Error::PermissionDenied(
+				"camera-permission prompt dismissed without a decision".to_string(),
+			)),
+			Err(_) => Err(Error::PermissionDenied(format!(
 				"timed out after {ACCESS_TIMEOUT:?} waiting for the camera-permission prompt"
 			))),
 		};
 	}
 
 	// Denied or restricted: no prompt will appear, so fail fast with a fix.
-	Err(Error::Codec(anyhow::anyhow!(
-		"camera access not authorized (denied or restricted); enable it in System Settings > Privacy & Security > Camera"
-	)))
+	Err(Error::PermissionDenied(
+		"camera access is denied or restricted; enable it in System Settings > Privacy & Security > Camera".to_string(),
+	))
 }
 
 /// Keeps the capture session (and its delegate) alive; stops it on drop, which

--- a/rs/moq-video/src/capture/channel.rs
+++ b/rs/moq-video/src/capture/channel.rs
@@ -1,22 +1,19 @@
-//! An async, bounded frame channel shared by every capture backend.
+//! An async, latest-frame channel shared by every capture backend.
 //!
 //! Backends produce frames from a foreign thread (the macOS delegate dispatch
 //! queue, or the V4L2 / Media Foundation pump thread) via the synchronous
 //! [`push`](FrameChannel::push); the encode loop consumes them with the async
 //! [`recv`](FrameChannel::recv). Because `recv` is a real `.await`, dropping the
 //! capture future cancels it promptly, which is what makes capture cancel-safe:
-//! the [`FrameStream`](super::FrameStream) drops, the device is released, and no
+//! the [`Stream`](super::Stream) drops, the device is released, and no
 //! blocking thread is left pinned.
 
-use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::Notify;
 
+use crate::Error;
 use crate::frame::Surface;
-
-/// Bounded depth; the oldest frame is dropped to favor latency over completeness.
-const DEPTH: usize = 4;
 
 /// The producer/consumer rendezvous for a single capture session.
 pub(super) struct FrameChannel {
@@ -25,56 +22,74 @@ pub(super) struct FrameChannel {
 }
 
 struct State {
-	frames: VecDeque<Surface>,
+	frame: Option<Surface>,
 	closed: bool,
+	error: Option<Error>,
 }
 
 impl FrameChannel {
 	pub(super) fn new() -> Arc<Self> {
 		Arc::new(Self {
 			state: Mutex::new(State {
-				frames: VecDeque::new(),
+				frame: None,
 				closed: false,
+				error: None,
 			}),
 			notify: Notify::new(),
 		})
 	}
 
-	/// Enqueue a frame, dropping the oldest if the buffer is full. Safe to call
-	/// from the foreign producer thread; a no-op once closed.
+	/// Publish the latest frame, replacing one the consumer has not reached. Safe
+	/// to call from the foreign producer thread; a no-op once closed.
 	pub(super) fn push(&self, frame: Surface) {
 		{
 			let mut state = self.state.lock().unwrap();
 			if state.closed {
 				return;
 			}
-			if state.frames.len() >= DEPTH {
-				state.frames.pop_front();
-			}
-			state.frames.push_back(frame);
+			state.frame = Some(frame);
 		}
 		self.notify.notify_one();
 	}
 
 	/// Mark the source ended, so a parked [`recv`](Self::recv) returns `None`.
 	pub(super) fn close(&self) {
-		self.state.lock().unwrap().closed = true;
+		let mut state = self.state.lock().unwrap();
+		state.closed = true;
+		drop(state);
 		self.notify.notify_waiters();
 	}
 
-	/// Await the next frame, or `None` once the channel is closed and drained.
-	pub(super) async fn recv(&self) -> Option<Surface> {
+	/// End the source with an error. Any pending frame is discarded so source
+	/// removal or revoked permission reaches the consumer immediately.
+	pub(super) fn fail(&self, error: Error) {
+		let mut state = self.state.lock().unwrap();
+		if state.closed {
+			return;
+		}
+		state.frame = None;
+		state.error = Some(error);
+		state.closed = true;
+		drop(state);
+		self.notify.notify_waiters();
+	}
+
+	/// Await the latest frame, the terminal backend error, or `None` once closed.
+	pub(super) async fn recv(&self) -> Result<Option<Surface>, Error> {
 		loop {
 			// Register for a wakeup before checking, so a `push` that races the
 			// check still wakes this future (tokio's documented Notify pattern).
 			let notified = self.notify.notified();
 			{
 				let mut state = self.state.lock().unwrap();
-				if let Some(frame) = state.frames.pop_front() {
-					return Some(frame);
+				if let Some(error) = state.error.take() {
+					return Err(error);
+				}
+				if let Some(frame) = state.frame.take() {
+					return Ok(Some(frame));
 				}
 				if state.closed {
-					return None;
+					return Ok(None);
 				}
 			}
 			notified.await;
@@ -102,31 +117,40 @@ mod tests {
 	async fn recv_returns_frames_in_order() {
 		let chan = FrameChannel::new();
 		chan.push(frame(1));
+		assert_eq!(chan.recv().await.unwrap().unwrap().width(), 1);
 		chan.push(frame(2));
-		assert_eq!(chan.recv().await.unwrap().width(), 1);
-		assert_eq!(chan.recv().await.unwrap().width(), 2);
+		assert_eq!(chan.recv().await.unwrap().unwrap().width(), 2);
 	}
 
 	#[tokio::test]
-	async fn drops_oldest_when_full() {
+	async fn slow_consumer_receives_only_the_latest_frame() {
 		let chan = FrameChannel::new();
-		// DEPTH + 2 frames pushed: only the newest DEPTH survive, favoring latency.
-		for id in 1..=(DEPTH as u32 + 2) {
+		for id in 1..=6 {
 			chan.push(frame(id));
 		}
-		for id in 3..=(DEPTH as u32 + 2) {
-			assert_eq!(chan.recv().await.unwrap().width(), id);
-		}
+		assert_eq!(chan.recv().await.unwrap().unwrap().width(), 6);
 	}
 
 	#[tokio::test]
-	async fn close_returns_none_after_draining() {
+	async fn close_returns_none_after_the_pending_frame() {
 		let chan = FrameChannel::new();
 		chan.push(frame(1));
 		chan.close();
-		// Buffered frames drain first, then `None` signals the source ended.
-		assert_eq!(chan.recv().await.unwrap().width(), 1);
-		assert!(chan.recv().await.is_none());
+		assert_eq!(chan.recv().await.unwrap().unwrap().width(), 1);
+		assert!(chan.recv().await.unwrap().is_none());
+	}
+
+	#[tokio::test]
+	async fn failure_discards_a_pending_frame_and_surfaces_the_cause() {
+		let chan = FrameChannel::new();
+		chan.push(frame(1));
+		chan.fail(Error::SourceUnavailable("window closed".to_string()));
+
+		assert!(matches!(
+			chan.recv().await,
+			Err(Error::SourceUnavailable(reason)) if reason == "window closed"
+		));
+		assert!(chan.recv().await.unwrap().is_none());
 	}
 
 	/// Cancelling a parked `recv` (as the encode loop's `select!` does each time a
@@ -141,6 +165,6 @@ mod tests {
 			_ = std::future::ready(()) => {}
 		}
 		chan.push(frame(7));
-		assert_eq!(chan.recv().await.unwrap().width(), 7);
+		assert_eq!(chan.recv().await.unwrap().unwrap().width(), 7);
 	}
 }

--- a/rs/moq-video/src/capture/channel.rs
+++ b/rs/moq-video/src/capture/channel.rs
@@ -57,7 +57,7 @@ impl FrameChannel {
 		let mut state = self.state.lock().unwrap();
 		state.closed = true;
 		drop(state);
-		self.notify.notify_waiters();
+		self.wake();
 	}
 
 	/// End the source with an error. Any pending frame is discarded so source
@@ -71,7 +71,17 @@ impl FrameChannel {
 		state.error = Some(error);
 		state.closed = true;
 		drop(state);
-		self.notify.notify_waiters();
+		self.wake();
+	}
+
+	/// Wake the single consumer, retaining a permit if it has not parked yet.
+	///
+	/// `notify_waiters` would drop the wakeup on the floor here: `recv` builds
+	/// its `Notified` before taking the lock but only registers it when the
+	/// future is first polled, so a terminal state set from the producer thread
+	/// in that window would leave the consumer asleep forever.
+	fn wake(&self) {
+		self.notify.notify_one();
 	}
 
 	/// Await the latest frame, the terminal backend error, or `None` once closed.
@@ -151,6 +161,21 @@ mod tests {
 			Err(Error::SourceUnavailable(reason)) if reason == "window closed"
 		));
 		assert!(chan.recv().await.unwrap().is_none());
+	}
+
+	/// A terminal state set while the consumer is between building its `Notified`
+	/// and registering it must still wake that consumer, so the wakeup has to
+	/// leave a permit behind rather than only signalling registered waiters.
+	#[tokio::test]
+	async fn closing_retains_a_wakeup_for_a_consumer_that_has_not_parked() {
+		let chan = FrameChannel::new();
+		// A permit consumed by nobody stands in for the unregistered consumer.
+		chan.close();
+		chan.notify.notified().await;
+
+		let chan = FrameChannel::new();
+		chan.fail(Error::SourceUnavailable("stream stopped".to_string()));
+		chan.notify.notified().await;
 	}
 
 	/// Cancelling a parked `recv` (as the encode loop's `select!` does each time a

--- a/rs/moq-video/src/capture/desktopduplication.rs
+++ b/rs/moq-video/src/capture/desktopduplication.rs
@@ -88,7 +88,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream
 				width: cap.width,
 				height: cap.height,
 				framerate: Some(cap.framerate),
-				device: cap.device_name.clone(),
+				label: cap.device_name.clone(),
 			};
 			Ok((cap, geometry))
 		},
@@ -101,7 +101,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream
 		geo.width,
 		geo.height,
 		geo.framerate,
-		geo.device,
+		geo.label,
 		None,
 		Box::new(guard),
 	))
@@ -196,8 +196,10 @@ impl Duplicator {
 	/// Rebuild the duplication after `DXGI_ERROR_ACCESS_LOST` (e.g. a resolution
 	/// change or a fullscreen exclusive app grabbing/releasing the output).
 	fn reduplicate(&mut self) -> Result<(), Error> {
-		self.dupl = duplicate(&self.output, &self.device)
-			.map_err(|error| Error::SourceUnavailable(format!("{}: {error}", self.device_name)))?;
+		self.dupl = duplicate(&self.output, &self.device).map_err(|error| match error {
+			Error::PermissionDenied(_) => error,
+			error => Error::SourceUnavailable(format!("{}: {error}", self.device_name)),
+		})?;
 		self.staging = None;
 		Ok(())
 	}

--- a/rs/moq-video/src/capture/desktopduplication.rs
+++ b/rs/moq-video/src/capture/desktopduplication.rs
@@ -15,6 +15,7 @@
 
 use std::time::{Duration, Instant};
 
+use windows::Win32::Foundation::E_ACCESSDENIED;
 use windows::Win32::Graphics::Direct3D11::{
 	D3D11_CPU_ACCESS_READ, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING,
 	ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D,
@@ -27,7 +28,7 @@ use windows::core::Interface;
 
 use super::channel::FrameChannel;
 use super::pump::{self, Geometry};
-use super::{Config, FrameStream};
+use super::{Config, Stream};
 use crate::Error;
 use crate::frame::{I420, Surface, d3d11};
 
@@ -74,7 +75,7 @@ pub(super) fn displays() -> Result<Vec<super::Display>, Error> {
 }
 
 /// Open a display capture and stream its frames over a pump thread.
-pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream, Error> {
 	let config = config.clone();
 	// The device opens on the pump thread, so the selector has to be owned.
 	let device = device.map(str::to_string);
@@ -95,7 +96,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 	)
 	.await?;
 
-	Ok(FrameStream::new(
+	Ok(Stream::new(
 		chan,
 		geo.width,
 		geo.height,
@@ -195,7 +196,8 @@ impl Duplicator {
 	/// Rebuild the duplication after `DXGI_ERROR_ACCESS_LOST` (e.g. a resolution
 	/// change or a fullscreen exclusive app grabbing/releasing the output).
 	fn reduplicate(&mut self) -> Result<(), Error> {
-		self.dupl = duplicate(&self.output, &self.device)?;
+		self.dupl = duplicate(&self.output, &self.device)
+			.map_err(|error| Error::SourceUnavailable(format!("{}: {error}", self.device_name)))?;
 		self.staging = None;
 		Ok(())
 	}
@@ -212,7 +214,12 @@ impl Duplicator {
 				self.reduplicate()?;
 				return Ok(false);
 			}
-			Err(e) => return Err(err("AcquireNextFrame", e)),
+			Err(e) => {
+				return Err(Error::SourceUnavailable(format!(
+					"{}: AcquireNextFrame: {e}",
+					self.device_name
+				)));
+			}
 		}
 
 		let resource = resource.ok_or_else(|| Error::Codec(anyhow::anyhow!("AcquireNextFrame returned no surface")))?;
@@ -317,7 +324,7 @@ impl Drop for UnmapGuard<'_> {
 }
 
 /// Which monitor to capture: a bare index or the `display:{index}` form that
-/// [`FrameStream::device`](super::FrameStream) reports; `None` is the first one.
+/// [`Stream::device`](super::Stream) reports; `None` is the first one.
 fn select_output(selector: Option<&str>) -> Result<u32, Error> {
 	match selector {
 		None => Ok(0),
@@ -335,7 +342,7 @@ fn enumerate_output(device: &ID3D11Device, index: u32) -> Result<IDXGIOutput1, E
 	let output = unsafe {
 		adapter
 			.EnumOutputs(index)
-			.map_err(|_| Error::Codec(anyhow::anyhow!("no display at index {index}")))?
+			.map_err(|_| Error::SourceUnavailable(format!("no display at index {index}")))?
 	};
 	output
 		.cast::<IDXGIOutput1>()
@@ -352,7 +359,13 @@ fn adapter(device: &ID3D11Device) -> Result<IDXGIAdapter, Error> {
 
 /// Start duplicating `output` on `device`.
 fn duplicate(output: &IDXGIOutput1, device: &ID3D11Device) -> Result<IDXGIOutputDuplication, Error> {
-	unsafe { output.DuplicateOutput(device) }.map_err(|e| err("DuplicateOutput", e))
+	unsafe { output.DuplicateOutput(device) }.map_err(|error| {
+		if error.code() == E_ACCESSDENIED {
+			Error::PermissionDenied(format!("display capture: {error}"))
+		} else {
+			err("DuplicateOutput", error)
+		}
+	})
 }
 
 #[cfg(test)]

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -60,7 +60,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream
 				width: camera.width,
 				height: camera.height,
 				framerate: camera.framerate,
-				device: camera.device_name.clone(),
+				label: camera.device_name.clone(),
 			};
 			Ok((camera, geometry))
 		},
@@ -73,7 +73,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream
 		geo.width,
 		geo.height,
 		geo.framerate,
-		geo.device,
+		geo.label,
 		None,
 		Box::new(guard),
 	))

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -13,6 +13,7 @@ use std::ffi::c_void;
 use std::ptr;
 use std::slice;
 
+use windows::Win32::Foundation::E_ACCESSDENIED;
 use windows::Win32::Graphics::Direct3D11::ID3D11Device;
 use windows::Win32::Media::MediaFoundation::{
 	IMF2DBuffer, IMFActivate, IMFAttributes, IMFDXGIDeviceManager, IMFMediaSource, IMFSample, IMFSourceReader,
@@ -28,7 +29,7 @@ use windows::core::{GUID, Interface, PWSTR};
 
 use super::channel::FrameChannel;
 use super::pump::{self, Geometry};
-use super::{Config, FrameStream};
+use super::{Config, Stream};
 use crate::Error;
 use crate::frame::d3d11::Texture;
 use crate::frame::{I420, Surface};
@@ -46,7 +47,7 @@ pub(super) fn cameras() -> Result<Vec<super::Camera>, Error> {
 }
 
 /// Open a Media Foundation camera and stream its frames over a pump thread.
-pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream, Error> {
 	let config = config.clone();
 	// The device opens on the pump thread, so the selector has to be owned.
 	let device = device.map(str::to_string);
@@ -67,7 +68,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 	)
 	.await?;
 
-	Ok(FrameStream::new(
+	Ok(Stream::new(
 		chan,
 		geo.width,
 		geo.height,
@@ -279,7 +280,7 @@ impl Camera {
 						None,
 						Some(&mut sample),
 					)
-					.map_err(|e| mf_err("read sample", e))?;
+					.map_err(|error| capture_error(&format!("camera {}: read sample", self.device_name), error))?;
 			}
 
 			if flags & MF_SOURCE_READERF_ENDOFSTREAM.0 as u32 != 0 {
@@ -349,17 +350,25 @@ fn open_source(selector: Option<&str>) -> Result<(IMFMediaSource, String), Error
 		.map(|(_, source)| source);
 
 	let source = chosen.ok_or_else(|| match &selector {
-		Selector::Index(i) => Error::Codec(anyhow::anyhow!("camera index {i} out of range ({count} found)")),
-		Selector::IdOrName(value) => Error::Codec(anyhow::anyhow!("no camera matching {value:?} ({count} found)")),
+		Selector::Index(i) => Error::SourceUnavailable(format!("camera index {i} out of range ({count} found)")),
+		Selector::IdOrName(value) => Error::SourceUnavailable(format!("no camera matching {value:?} ({count} found)")),
 	})?;
 
 	let media: IMFMediaSource = unsafe {
 		source
 			.activate
 			.ActivateObject()
-			.map_err(|e| mf_err("activate device", e))?
+			.map_err(|error| capture_error("activate camera", error))?
 	};
 	Ok((media, source.name))
+}
+
+fn capture_error(context: &str, error: windows::core::Error) -> Error {
+	if error.code() == E_ACCESSDENIED {
+		Error::PermissionDenied(format!("{context}: {error}"))
+	} else {
+		Error::SourceUnavailable(format!("{context}: {error}"))
+	}
 }
 
 /// One Media Foundation capture source and the metadata exposed publicly.

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -39,6 +39,9 @@ mod surface;
 // Native V4L2 camera capture on Linux.
 #[cfg(target_os = "linux")]
 mod v4l2;
+// Native X11 display and window capture, including the portal fallback.
+#[cfg(target_os = "linux")]
+mod x11;
 
 // Portal + PipeWire screen capture on Linux.
 #[cfg(all(target_os = "linux", feature = "pipewire"))]
@@ -51,6 +54,9 @@ mod mediafoundation;
 // DXGI Desktop Duplication screen capture on Windows.
 #[cfg(target_os = "windows")]
 mod desktopduplication;
+// Native GDI window enumeration and capture on Windows.
+#[cfg(target_os = "windows")]
+mod window;
 
 // Blocking-device -> async-channel bridge used by V4L2 / Media Foundation.
 #[cfg(any(target_os = "linux", target_os = "windows"))]
@@ -74,11 +80,12 @@ pub enum Source {
 
 	/// A whole display. `None` opens the main display.
 	///
-	/// The id is a bare display index. macOS and Windows honor it; on Linux the
-	/// xdg-desktop-portal picker owns selection and the id is ignored.
+	/// The id is the opaque value [`displays`] reports. On Wayland the
+	/// xdg-desktop-portal picker owns selection and no stable id is available.
 	Display(Option<String>),
 
-	/// A single window, by the id [`windows`] reports. macOS only.
+	/// A single window, by the id [`windows`] reports. Supported on macOS,
+	/// Windows, and X11.
 	Window(String),
 
 	/// Every window belonging to one application, by the id [`apps`] reports
@@ -200,8 +207,11 @@ impl App {
 pub struct Config {
 	/// What to capture.
 	pub source: Source,
+	/// Preferred output width in pixels.
 	pub width: Option<u32>,
+	/// Preferred output height in pixels.
 	pub height: Option<u32>,
+	/// Preferred frame rate in frames per second.
 	pub framerate: Option<u32>,
 	/// Draw the mouse cursor into captured frames. Screen/window/app sources
 	/// only; ignored by cameras. Defaults to `true`.
@@ -222,17 +232,18 @@ impl Default for Config {
 
 /// A live, async frame source opened via [`open`].
 ///
-/// Every backend delivers frames through a shared [`FrameChannel`], so the
-/// encode loop just `read().await`s regardless of platform. Dropping the stream
+/// Every backend delivers frames through the same latest-frame channel, so the
+/// consumer just `read().await`s regardless of platform. Dropping the stream
 /// releases the device (stops the macOS `AVCaptureSession`, joins the V4L2 /
 /// Media Foundation pump thread). That is the whole point: because `read` is a
 /// real await, cancelling the capture future drops this and the camera turns off
 /// promptly, with no blocking task left pinned to the runtime.
-pub(crate) struct FrameStream {
+pub struct Stream {
 	chan: Arc<FrameChannel>,
 	width: u32,
 	height: u32,
 	framerate: Option<u32>,
+	color: Option<crate::Color>,
 	device: String,
 	/// First frame captured during [`open`] (some backends learn their geometry
 	/// only from a frame); returned by the first [`read`](Self::read).
@@ -242,7 +253,7 @@ pub(crate) struct FrameStream {
 	_backend: Keepalive,
 }
 
-impl FrameStream {
+impl Stream {
 	/// Build a stream from a backend's channel, geometry, and keep-alive guard.
 	fn new(
 		chan: Arc<FrameChannel>,
@@ -253,11 +264,13 @@ impl FrameStream {
 		pending: Option<Surface>,
 		backend: Keepalive,
 	) -> Self {
+		let color = pending.as_ref().and_then(Surface::color);
 		Self {
 			chan,
 			width,
 			height,
 			framerate,
+			color,
 			device,
 			pending,
 			_backend: backend,
@@ -266,38 +279,41 @@ impl FrameStream {
 
 	/// Await the next frame, or `None` once the source ends. Cancel-safe: drop
 	/// the future to stop reading and release the device.
-	pub(crate) async fn read(&mut self) -> Option<Surface> {
+	pub async fn read(&mut self) -> Result<Option<Surface>, Error> {
 		if let Some(frame) = self.pending.take() {
-			return Some(frame);
+			return Ok(Some(frame));
 		}
 		self.chan.recv().await
 	}
 
-	pub(crate) fn width(&self) -> u32 {
+	/// Width of the captured frames in pixels.
+	pub fn width(&self) -> u32 {
 		self.width
 	}
 
-	pub(crate) fn height(&self) -> u32 {
+	/// Height of the captured frames in pixels.
+	pub fn height(&self) -> u32 {
 		self.height
 	}
 
 	/// The negotiated frame rate, or `None` if the source doesn't report one.
-	pub(crate) fn framerate(&self) -> Option<u32> {
+	pub fn framerate(&self) -> Option<u32> {
 		self.framerate
 	}
 
 	/// The first frame's declared color space, when its capture backend knows it.
-	pub(crate) fn color(&self) -> Option<crate::Color> {
-		self.pending.as_ref().and_then(Surface::color)
+	pub fn color(&self) -> Option<crate::Color> {
+		self.color
 	}
 
-	pub(crate) fn device(&self) -> &str {
+	/// Platform source identifier selected by the backend.
+	pub fn device(&self) -> &str {
 		&self.device
 	}
 }
 
 /// Open the capture source described by `config`.
-pub(crate) async fn open(config: &Config) -> Result<FrameStream, Error> {
+pub async fn open(config: &Config) -> Result<Stream, Error> {
 	match &config.source {
 		Source::Camera(device) => {
 			let _ = device;
@@ -330,13 +346,15 @@ pub(crate) async fn open(config: &Config) -> Result<FrameStream, Error> {
 			}
 			#[cfg(all(target_os = "linux", feature = "pipewire"))]
 			{
-				pipewire::open(config, device.as_deref()).await
+				if x11::selected(device.as_deref()) {
+					x11::open_display(config, device.as_deref()).await
+				} else {
+					pipewire::open(config, device.as_deref()).await
+				}
 			}
 			#[cfg(all(target_os = "linux", not(feature = "pipewire")))]
 			{
-				Err(Error::Unsupported(
-					"screen capture on Linux without the `pipewire` feature".to_string(),
-				))
+				x11::open_display(config, device.as_deref()).await
 			}
 			#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 			{
@@ -349,7 +367,15 @@ pub(crate) async fn open(config: &Config) -> Result<FrameStream, Error> {
 			{
 				screencapture::open_window(config, id).await
 			}
-			#[cfg(not(target_os = "macos"))]
+			#[cfg(target_os = "linux")]
+			{
+				x11::open_window(config, id).await
+			}
+			#[cfg(target_os = "windows")]
+			{
+				window::open(config, id).await
+			}
+			#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 			{
 				Err(Error::Unsupported("window capture".to_string()))
 			}
@@ -390,8 +416,8 @@ pub async fn cameras() -> Result<Vec<Camera>, Error> {
 
 /// List the available displays and the identifiers [`Source::Display`] accepts.
 ///
-/// On Linux the xdg-desktop-portal picker owns display selection, so there is no
-/// list or stable identifier to expose.
+/// On Wayland the xdg-desktop-portal picker owns display selection, so there is
+/// no list or stable identifier to expose. X11 displays have stable ids.
 pub async fn displays() -> Result<Vec<Display>, Error> {
 	#[cfg(target_os = "macos")]
 	{
@@ -401,19 +427,31 @@ pub async fn displays() -> Result<Vec<Display>, Error> {
 	{
 		blocking(desktopduplication::displays).await
 	}
-	#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+	#[cfg(target_os = "linux")]
+	{
+		blocking(x11::displays).await
+	}
+	#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 	{
 		Err(Error::Unsupported("listing displays".to_string()))
 	}
 }
 
-/// List the on-screen windows. macOS only.
+/// List the on-screen windows.
 pub async fn windows() -> Result<Vec<Window>, Error> {
 	#[cfg(target_os = "macos")]
 	{
 		screencapture::windows().await
 	}
-	#[cfg(not(target_os = "macos"))]
+	#[cfg(target_os = "linux")]
+	{
+		blocking(x11::windows).await
+	}
+	#[cfg(target_os = "windows")]
+	{
+		blocking(window::windows).await
+	}
+	#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 	{
 		Err(Error::Unsupported("listing windows".to_string()))
 	}

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -2,10 +2,11 @@
 //! per-source:
 //! - macOS camera -> AVFoundation, screen -> ScreenCaptureKit, both yielding
 //!   zero-copy `CVPixelBuffer` surfaces straight to VideoToolbox.
-//! - Linux camera -> native V4L2 (YUYV / MJPEG -> CPU I420), screen ->
-//!   xdg-desktop-portal + PipeWire (RGB -> CPU I420, `pipewire` feature).
+//! - Linux camera -> native V4L2 (YUYV / MJPEG -> CPU I420), X11 display and
+//!   window -> X11, Wayland display -> xdg-desktop-portal + PipeWire
+//!   (`pipewire` feature).
 //! - Windows camera -> native Media Foundation (`IMFSourceReader`), screen ->
-//!   DXGI Desktop Duplication (BGRA -> CPU I420).
+//!   DXGI Desktop Duplication, window -> GDI (BGRA -> CPU I420).
 //!
 //! [`encode::publish_capture`](crate::encode::publish_capture) consumes [`Config`].
 
@@ -13,6 +14,8 @@ use std::sync::Arc;
 
 use crate::Error;
 use crate::frame::Surface;
+
+const MAX_FRAMERATE: u32 = 1_000_000;
 
 mod channel;
 use channel::FrameChannel;
@@ -144,10 +147,11 @@ pub struct Display {
 	pub id: String,
 	/// Human-readable name, e.g. "Display 1".
 	pub name: String,
-	/// Width in the platform's desktop coordinate space. This is points on
-	/// macOS and desktop pixels on Windows.
+	/// Width in the platform's desktop coordinate space: points on macOS and
+	/// desktop pixels on Windows and X11.
 	pub width: u32,
-	/// Height in the platform's desktop coordinate space.
+	/// Height in the platform's desktop coordinate space: points on macOS and
+	/// desktop pixels on Windows and X11.
 	pub height: u32,
 }
 
@@ -167,10 +171,11 @@ pub struct Window {
 	pub title: String,
 	/// The name of the application owning the window.
 	pub app: String,
-	/// Width in points, i.e. the logical size, which is what capture defaults to.
-	/// A window on a 2x retina display reports half its native pixel width.
+	/// Width in platform window coordinates: points on macOS and pixels on
+	/// Windows and X11.
 	pub width: u32,
-	/// Height in points. See [`width`](Self::width).
+	/// Height in platform window coordinates: points on macOS and pixels on
+	/// Windows and X11.
 	pub height: u32,
 }
 
@@ -211,7 +216,7 @@ pub struct Config {
 	pub width: Option<u32>,
 	/// Preferred output height in pixels.
 	pub height: Option<u32>,
-	/// Preferred frame rate in frames per second.
+	/// Preferred frame rate in frames per second, from 1 through 1,000,000.
 	pub framerate: Option<u32>,
 	/// Draw the mouse cursor into captured frames. Screen/window/app sources
 	/// only; ignored by cameras. Defaults to `true`.
@@ -244,7 +249,7 @@ pub struct Stream {
 	height: u32,
 	framerate: Option<u32>,
 	color: Option<crate::Color>,
-	device: String,
+	label: String,
 	/// First frame captured during [`open`] (some backends learn their geometry
 	/// only from a frame); returned by the first [`read`](Self::read).
 	pending: Option<Surface>,
@@ -260,7 +265,7 @@ impl Stream {
 		width: u32,
 		height: u32,
 		framerate: Option<u32>,
-		device: String,
+		label: String,
 		pending: Option<Surface>,
 		backend: Keepalive,
 	) -> Self {
@@ -271,14 +276,17 @@ impl Stream {
 			height,
 			framerate,
 			color,
-			device,
+			label,
 			pending,
 			_backend: backend,
 		}
 	}
 
-	/// Await the next frame, or `None` once the source ends. Cancel-safe: drop
-	/// the future to stop reading and release the device.
+	/// Await the next frame, or `None` once the source ends.
+	///
+	/// Dropping this future cancels only the pending read. Dropping the stream
+	/// releases the capture source. A geometry change returns
+	/// [`Error::SourceChanged`], after which the stream must be reopened.
 	pub async fn read(&mut self) -> Result<Option<Surface>, Error> {
 		if let Some(frame) = self.pending.take() {
 			return Ok(Some(frame));
@@ -306,14 +314,15 @@ impl Stream {
 		self.color
 	}
 
-	/// Platform source identifier selected by the backend.
-	pub fn device(&self) -> &str {
-		&self.device
+	/// Human-readable label for the selected capture source.
+	pub fn label(&self) -> &str {
+		&self.label
 	}
 }
 
 /// Open the capture source described by `config`.
 pub async fn open(config: &Config) -> Result<Stream, Error> {
+	validate(config)?;
 	match &config.source {
 		Source::Camera(device) => {
 			let _ = device;
@@ -394,6 +403,13 @@ pub async fn open(config: &Config) -> Result<Stream, Error> {
 	}
 }
 
+fn validate(config: &Config) -> Result<(), Error> {
+	match config.framerate {
+		Some(value) if value == 0 || value > MAX_FRAMERATE => Err(Error::InvalidFramerate(value)),
+		_ => Ok(()),
+	}
+}
+
 /// List the available cameras and the identifiers [`Source::Camera`] accepts.
 pub async fn cameras() -> Result<Vec<Camera>, Error> {
 	#[cfg(target_os = "macos")]
@@ -417,7 +433,8 @@ pub async fn cameras() -> Result<Vec<Camera>, Error> {
 /// List the available displays and the identifiers [`Source::Display`] accepts.
 ///
 /// On Wayland the xdg-desktop-portal picker owns display selection, so there is
-/// no list or stable identifier to expose. X11 displays have stable ids.
+/// no portal list or stable identifier to expose. When XWayland is available,
+/// its native displays are listed with stable X11 ids.
 pub async fn displays() -> Result<Vec<Display>, Error> {
 	#[cfg(target_os = "macos")]
 	{
@@ -479,4 +496,25 @@ where
 	tokio::task::spawn_blocking(f)
 		.await
 		.map_err(|err| Error::Codec(anyhow::anyhow!("capture enumeration thread failed: {err}")))?
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn validates_framerate_range() {
+		let mut config = Config::default();
+		assert!(validate(&config).is_ok());
+
+		config.framerate = Some(1);
+		assert!(validate(&config).is_ok());
+		config.framerate = Some(MAX_FRAMERATE);
+		assert!(validate(&config).is_ok());
+
+		config.framerate = Some(0);
+		assert!(matches!(validate(&config), Err(Error::InvalidFramerate(0))));
+		config.framerate = Some(MAX_FRAMERATE + 1);
+		assert!(matches!(validate(&config), Err(Error::InvalidFramerate(value)) if value == MAX_FRAMERATE + 1));
+	}
 }

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -284,9 +284,13 @@ impl Stream {
 
 	/// Await the next frame, or `None` once the source ends.
 	///
+	/// `None` is recoverable: the source stopped for a benign reason (it
+	/// resized, the compositor renegotiated the format, the device went idle)
+	/// and reopening is expected to work. An `Err` is terminal for this
+	/// selection: the source is gone or was refused.
+	///
 	/// Dropping this future cancels only the pending read. Dropping the stream
-	/// releases the capture source. A geometry change returns
-	/// [`Error::SourceChanged`], after which the stream must be reopened.
+	/// releases the capture source.
 	pub async fn read(&mut self) -> Result<Option<Surface>, Error> {
 		if let Some(frame) = self.pending.take() {
 			return Ok(Some(frame));

--- a/rs/moq-video/src/capture/pipewire.rs
+++ b/rs/moq-video/src/capture/pipewire.rs
@@ -158,7 +158,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream
 		geo.width,
 		geo.height,
 		geo.framerate,
-		geo.device,
+		geo.label,
 		Some(first),
 		Box::new(guard),
 	))
@@ -836,6 +836,7 @@ fn run_loop(args: CaptureLoop) -> Result<(), Error> {
 							Some(tx) => drop(tx.send(Err(e))),
 							None => {
 								tracing::warn!(error = %e, "unsupported pipewire video color space");
+								state.terminal = Some(e);
 								if let Some(mainloop) = mainloop.upgrade() {
 									mainloop.quit();
 								}
@@ -856,7 +857,7 @@ fn run_loop(args: CaptureLoop) -> Result<(), Error> {
 						width,
 						height,
 						framerate,
-						device: format!("pipewire:{node_id}"),
+						label: format!("pipewire:{node_id}"),
 					}));
 				} else if format_requires_restart(state.geometry, state.color, width, height, color) {
 					// The encoder's geometry and VUI are fixed when it opens. End the
@@ -1035,6 +1036,9 @@ fn run_loop(args: CaptureLoop) -> Result<(), Error> {
 				// means the producer forced an unsupported buffer representation.
 				let Some(bytes) = data.data() else {
 					tracing::warn!("pipewire buffer is not CPU-mapped; stopping capture");
+					state.terminal = Some(Error::SourceUnavailable(
+						"PipeWire buffer is not CPU-mapped".to_string(),
+					));
 					if let Some(mainloop) = mainloop.upgrade() {
 						mainloop.quit();
 					}
@@ -1055,6 +1059,7 @@ fn run_loop(args: CaptureLoop) -> Result<(), Error> {
 					Err(e) => {
 						// Persistent (bad format), not per-frame; stop rather than spam.
 						tracing::warn!(error = %e, "screen frame conversion failed; stopping capture");
+						state.terminal = Some(e);
 						if let Some(mainloop) = mainloop.upgrade() {
 							mainloop.quit();
 						}
@@ -1948,7 +1953,11 @@ mod tests {
 		assert!(stream.height() >= 2 && stream.height().is_multiple_of(2), "bad height");
 
 		for i in 0..5 {
-			let frame = stream.read().await.unwrap_or_else(|| panic!("no frame {i}"));
+			let frame = stream
+				.read()
+				.await
+				.unwrap_or_else(|error| panic!("read frame {i}: {error}"))
+				.unwrap_or_else(|| panic!("no frame {i}"));
 			assert_eq!(frame.width(), stream.width());
 			assert_eq!(frame.height(), stream.height());
 		}

--- a/rs/moq-video/src/capture/pipewire.rs
+++ b/rs/moq-video/src/capture/pipewire.rs
@@ -37,7 +37,7 @@ use spa::param::video::{VideoFormat, VideoInfoRaw};
 
 use super::channel::FrameChannel;
 use super::pump::Geometry;
-use super::{Config, FrameStream};
+use super::{Config, Stream};
 use crate::frame::{DmaBuf, DmaBufFrame, DmaBufPlane, DrmFormat, I420, Surface, wait_dma_buf_readable};
 use crate::{Color, Error, Size};
 
@@ -55,7 +55,7 @@ const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The portal restore token from the last grant, replayed on the next [`open`]
 /// so a demand-driven reopen skips the picker dialog. Process-wide because the
-/// capture session (and its `FrameStream`) is torn down between opens.
+/// capture session (and its `Stream`) is torn down between opens.
 static RESTORE_TOKEN: Mutex<Option<String>> = Mutex::new(None);
 
 fn err(ctx: &str, e: impl std::fmt::Display) -> Error {
@@ -63,7 +63,7 @@ fn err(ctx: &str, e: impl std::fmt::Display) -> Error {
 }
 
 /// Open a portal screen capture and stream its frames from a PipeWire loop thread.
-pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream, Error> {
 	if let Some(device) = device {
 		tracing::debug!(%device, "portal screen capture ignores the device selector; the picker owns selection");
 	}
@@ -88,6 +88,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 				fresh: false,
 				generation: 0,
 				dmabuf_modifier: None,
+				terminal: None,
 			}));
 			if let Err(e) = run_loop(CaptureLoop {
 				fd,
@@ -103,7 +104,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 				// failure just ends the stream (the encode loop reopens on demand).
 				match state.borrow_mut().geo_tx.take() {
 					Some(tx) => drop(tx.send(Err(e))),
-					None => tracing::warn!(error = %e, "screen capture stream failed"),
+					None => chan.fail(e),
 				}
 			}
 			chan.close();
@@ -136,8 +137,9 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 	};
 
 	let first = match tokio::time::timeout(FIRST_FRAME_TIMEOUT, chan.recv()).await {
-		Ok(Some(frame)) => frame,
-		Ok(None) | Err(_) => {
+		Ok(Ok(Some(frame))) => frame,
+		Ok(Err(error)) => return Err(error),
+		Ok(Ok(None)) | Err(_) => {
 			return Err(Error::Codec(anyhow::anyhow!(
 				"no frames from the compositor within {FIRST_FRAME_TIMEOUT:?}"
 			)));
@@ -151,7 +153,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 		"opened screen capture (PipeWire)"
 	);
 
-	Ok(FrameStream::new(
+	Ok(Stream::new(
 		chan,
 		geo.width,
 		geo.height,
@@ -197,7 +199,7 @@ async fn portal_negotiate(cursor: bool) -> Result<(u32, OwnedFd, SessionGuard), 
 		.await
 		.map_err(|e| err("portal start", e))?
 		.response()
-		.map_err(|e| err("screen capture request denied", e))?;
+		.map_err(|e| Error::PermissionDenied(format!("screen capture request: {e}")))?;
 	*RESTORE_TOKEN.lock().unwrap() = response.restore_token().map(str::to_string);
 
 	let stream = response
@@ -271,6 +273,8 @@ struct State {
 	generation: u64,
 	/// Explicit DRM modifier from the negotiated DMA-BUF format.
 	dmabuf_modifier: Option<u64>,
+	/// Why a live stream ended, if it was not an intentional restart or teardown.
+	terminal: Option<Error>,
 }
 
 /// A retained frame for the static-screen pacing tick.
@@ -735,6 +739,7 @@ fn run_loop(args: CaptureLoop) -> Result<(), Error> {
 		.add_local_listener::<()>()
 		.state_changed({
 			let mainloop = mainloop.downgrade();
+			let state = state.clone();
 			move |_, _, _, new| {
 				// Error is fatal; Unconnected after setup means the user stopped
 				// sharing from the compositor. Either way the stream is over.
@@ -750,6 +755,10 @@ fn run_loop(args: CaptureLoop) -> Result<(), Error> {
 					// teardown quits the loop before anything disconnects, so it
 					// never reaches this path.
 					*RESTORE_TOKEN.lock().unwrap() = None;
+					state.borrow_mut().terminal = Some(Error::SourceUnavailable(match &new {
+						pw::stream::StreamState::Error(error) => format!("PipeWire stream failed: {error}"),
+						_ => "the selected screen is no longer available".to_string(),
+					}));
 					tracing::debug!(state = ?new, "screen capture stream ended");
 					if let Some(mainloop) = mainloop.upgrade() {
 						mainloop.quit();
@@ -1096,7 +1105,7 @@ fn run_loop(args: CaptureLoop) -> Result<(), Error> {
 		.into_result()
 		.map_err(|e| err("pipewire timer", e))?;
 
-	// Quit when the FrameStream drops.
+	// Quit when the Stream drops.
 	let _quit = quit_rx.attach(mainloop.loop_(), {
 		let mainloop = mainloop.downgrade();
 		move |_| {
@@ -1107,7 +1116,11 @@ fn run_loop(args: CaptureLoop) -> Result<(), Error> {
 	});
 
 	mainloop.run();
-	Ok(())
+	let terminal = state.borrow_mut().terminal.take();
+	match terminal {
+		Some(error) => Err(error),
+		None => Ok(()),
+	}
 }
 
 fn normalize_chunk_offset(offset: u32, maxsize: u32) -> Option<usize> {

--- a/rs/moq-video/src/capture/pump.rs
+++ b/rs/moq-video/src/capture/pump.rs
@@ -26,7 +26,7 @@ pub(super) struct Geometry {
 	pub width: u32,
 	pub height: u32,
 	pub framerate: Option<u32>,
-	pub device: String,
+	pub label: String,
 }
 
 /// Stops and joins the pump thread on drop, releasing the device.

--- a/rs/moq-video/src/capture/pump.rs
+++ b/rs/moq-video/src/capture/pump.rs
@@ -5,7 +5,7 @@
 //! dedicated thread that pushes frames into the channel; the encode loop awaits
 //! them like any other backend. The device is built on the thread (so a `!Send`
 //! handle such as `IMFSourceReader` is fine) and dropped when the thread exits.
-//! [`PumpGuard`] stops and joins the thread when the [`FrameStream`](super::FrameStream)
+//! [`PumpGuard`] stops and joins the thread when the [`Stream`](super::Stream)
 //! drops, releasing the device. The stop flag is checked between reads, so on a
 //! live device (which delivers a frame per interval) shutdown is prompt; the join
 //! is what guarantees the device fd is closed before a subsequent reopen, so we
@@ -83,7 +83,7 @@ where
 					Ok(Some(frame)) => chan.push(frame),
 					Ok(None) => break, // device stopped producing frames
 					Err(err) => {
-						tracing::warn!(error = %err, "capture read failed; stopping");
+						chan.fail(err);
 						break;
 					}
 				}

--- a/rs/moq-video/src/capture/screencapture.rs
+++ b/rs/moq-video/src/capture/screencapture.rs
@@ -30,7 +30,7 @@ use objc2_screen_capture_kit::{
 };
 
 use super::surface::surface_frame;
-use super::{App, Config, Display, FrameChannel, FrameStream, Window};
+use super::{App, Config, Display, FrameChannel, Stream, Window};
 use crate::Error;
 
 const DEFAULT_FRAMERATE: i32 = 30;
@@ -43,8 +43,9 @@ const ASYNC_TIMEOUT: Duration = Duration::from_secs(5);
 const NORMAL_WINDOW_LAYER: isize = 0;
 
 /// Open a whole-display capture. `device` is a display index (`None` = main).
-pub(super) async fn open_display(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
+pub(super) async fn open_display(config: &Config, device: Option<&str>) -> Result<Stream, Error> {
 	init_core_graphics();
+	ensure_screen_access().await?;
 	let content = shareable_content().await?;
 	let display = find_display(&content, device)?;
 
@@ -60,8 +61,9 @@ pub(super) async fn open_display(config: &Config, device: Option<&str>) -> Resul
 }
 
 /// Open a single-window capture. Follows the window as it moves and resizes.
-pub(super) async fn open_window(config: &Config, id: &str) -> Result<FrameStream, Error> {
+pub(super) async fn open_window(config: &Config, id: &str) -> Result<Stream, Error> {
 	init_core_graphics();
+	ensure_screen_access().await?;
 	let content = shareable_content().await?;
 	let window = find_window(&content, id)?;
 
@@ -74,8 +76,9 @@ pub(super) async fn open_window(config: &Config, id: &str) -> Result<FrameStream
 
 /// Open an application capture: every window owned by `id` (a bundle
 /// identifier), including ones opened later.
-pub(super) async fn open_app(config: &Config, id: &str) -> Result<FrameStream, Error> {
+pub(super) async fn open_app(config: &Config, id: &str) -> Result<Stream, Error> {
 	init_core_graphics();
+	ensure_screen_access().await?;
 	let content = shareable_content().await?;
 	let app = find_app(&content, id)?;
 
@@ -118,9 +121,29 @@ fn init_core_graphics() {
 	});
 }
 
+/// Request Screen Recording access before building a stream, so denial is a
+/// typed error rather than an empty source list or first-frame timeout.
+async fn ensure_screen_access() -> Result<(), Error> {
+	if objc2_core_graphics::CGPreflightScreenCaptureAccess() {
+		return Ok(());
+	}
+
+	let granted = tokio::task::spawn_blocking(|| objc2_core_graphics::CGRequestScreenCaptureAccess())
+		.await
+		.map_err(|error| Error::Codec(anyhow::anyhow!("screen permission request failed: {error}")))?;
+	if granted {
+		Ok(())
+	} else {
+		Err(Error::PermissionDenied(
+			"screen recording access; enable it in System Settings > Privacy & Security > Screen & System Audio Recording"
+				.to_string(),
+		))
+	}
+}
+
 /// Start a stream for `filter`. `size` is the source's native pixel size, used
 /// unless the caller overrode width/height.
-async fn open(config: &Config, filter: &SCContentFilter, size: (u32, u32)) -> Result<FrameStream, Error> {
+async fn open(config: &Config, filter: &SCContentFilter, size: (u32, u32)) -> Result<Stream, Error> {
 	let fps = config.framerate.map(|f| f as i32).unwrap_or(DEFAULT_FRAMERATE).max(1);
 	let configuration = unsafe { SCStreamConfiguration::new() };
 	// `size` is already even; an override might not be.
@@ -155,7 +178,7 @@ async fn open(config: &Config, filter: &SCContentFilter, size: (u32, u32)) -> Re
 	start_capture(&stream).await?;
 
 	// The stream keeps capturing until dropped; this guard stops it and closes
-	// the channel when the FrameStream goes away.
+	// the channel when the Stream goes away.
 	let guard = StreamGuard {
 		stream,
 		chan: chan.clone(),
@@ -165,8 +188,9 @@ async fn open(config: &Config, filter: &SCContentFilter, size: (u32, u32)) -> Re
 
 	let label = config.source.label();
 	let first = match tokio::time::timeout(FIRST_FRAME_TIMEOUT, chan.recv()).await {
-		Ok(Some(frame)) => frame,
-		Ok(None) | Err(_) => {
+		Ok(Ok(Some(frame))) => frame,
+		Ok(Err(error)) => return Err(error),
+		Ok(Ok(None)) | Err(_) => {
 			return Err(Error::Codec(anyhow::anyhow!(
 				"no frames from {label} within {FIRST_FRAME_TIMEOUT:?} (screen recording permission?)"
 			)));
@@ -176,7 +200,7 @@ async fn open(config: &Config, filter: &SCContentFilter, size: (u32, u32)) -> Re
 
 	tracing::info!(source = %label, width, height, "opened screen capture (ScreenCaptureKit)");
 
-	Ok(FrameStream::new(
+	Ok(Stream::new(
 		chan,
 		width,
 		height,
@@ -270,7 +294,7 @@ fn find_display(content: &SCShareableContent, device: Option<&str>) -> Result<Re
 			.map_err(|_| Error::Codec(anyhow::anyhow!("invalid display selector {spec:?}")))?,
 	};
 	if index >= displays.count() {
-		return Err(Error::Codec(anyhow::anyhow!("no display at index {index}")));
+		return Err(Error::SourceUnavailable(format!("no display at index {index}")));
 	}
 	Ok(displays.objectAtIndex(index))
 }
@@ -285,7 +309,7 @@ fn find_window(content: &SCShareableContent, id: &str) -> Result<Retained<SCWind
 	(0..windows.count())
 		.map(|index| windows.objectAtIndex(index))
 		.find(|window| unsafe { window.windowID() } == wanted)
-		.ok_or_else(|| Error::Codec(anyhow::anyhow!("no window with id {id} (did it close?)")))
+		.ok_or_else(|| Error::SourceUnavailable(format!("no window with id {id} (did it close?)")))
 }
 
 /// Resolve an application by bundle identifier.
@@ -294,7 +318,7 @@ fn find_app(content: &SCShareableContent, id: &str) -> Result<Retained<SCRunning
 	(0..apps.count())
 		.map(|index| apps.objectAtIndex(index))
 		.find(|app| unsafe { app.bundleIdentifier() }.to_string() == id)
-		.ok_or_else(|| Error::Codec(anyhow::anyhow!("no running application with bundle id {id:?}")))
+		.ok_or_else(|| Error::SourceUnavailable(format!("no running application with bundle id {id:?}")))
 }
 
 /// Capture size for a source measured in points.
@@ -405,9 +429,9 @@ define_class!(
 	unsafe impl SCStreamDelegate for Delegate {
 		#[unsafe(method(stream:didStopWithError:))]
 		unsafe fn did_stop(&self, _stream: &SCStream, error: &NSError) {
-			tracing::warn!(error = %error.localizedDescription(), "screen capture stopped");
-			// Unblocks a parked read; the encode loop then reopens on demand.
-			self.ivars().chan.close();
+			self.ivars()
+				.chan
+				.fail(Error::SourceUnavailable(error.localizedDescription().to_string()));
 		}
 	}
 

--- a/rs/moq-video/src/capture/v4l2.rs
+++ b/rs/moq-video/src/capture/v4l2.rs
@@ -17,7 +17,7 @@ use zune_jpeg::zune_core::bytestream::ZCursor;
 
 use super::channel::FrameChannel;
 use super::pump::{self, Geometry};
-use super::{Config, FrameStream};
+use super::{Config, Stream};
 use crate::Error;
 use crate::frame::{I420, Surface};
 
@@ -58,7 +58,7 @@ pub(super) fn cameras() -> Result<Vec<super::Camera>, Error> {
 }
 
 /// Open a V4L2 camera and stream its frames over a pump thread.
-pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream, Error> {
 	let config = config.clone();
 	// The camera opens on the pump thread, so the selector has to be owned.
 	let device = device.map(str::to_string);
@@ -79,7 +79,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameS
 	)
 	.await?;
 
-	Ok(FrameStream::new(
+	Ok(Stream::new(
 		chan,
 		geo.width,
 		geo.height,
@@ -176,8 +176,8 @@ impl Camera {
 	/// Pull the next frame. Blocks one frame interval; the pump thread calls this
 	/// in a loop and checks its stop flag between calls.
 	fn read(&mut self) -> Result<Option<Surface>, Error> {
-		let (buf, meta) =
-			CaptureStream::next(&mut self.stream).map_err(|e| Error::Codec(anyhow::anyhow!("V4L2 capture: {e}")))?;
+		let (buf, meta) = CaptureStream::next(&mut self.stream)
+			.map_err(|error| Error::SourceUnavailable(format!("V4L2 camera {}: {error}", self.name)))?;
 
 		let i420 = match self.source {
 			Source::Yuyv => I420::from_yuyv(buf, self.stride, self.width, self.height)?,
@@ -204,20 +204,27 @@ impl Camera {
 fn open_device(device: Option<&str>) -> Result<(Device, String), Error> {
 	match device {
 		None => {
-			let device = Device::new(0).map_err(|e| Error::Codec(anyhow::anyhow!("open /dev/video0: {e}")))?;
+			let device = Device::new(0).map_err(|error| open_error("/dev/video0", error))?;
 			Ok((device, "/dev/video0".to_string()))
 		}
 		Some(spec) => match spec.parse::<usize>() {
 			Ok(index) => {
-				let device =
-					Device::new(index).map_err(|e| Error::Codec(anyhow::anyhow!("open /dev/video{index}: {e}")))?;
+				let name = format!("/dev/video{index}");
+				let device = Device::new(index).map_err(|error| open_error(&name, error))?;
 				Ok((device, format!("/dev/video{index}")))
 			}
 			Err(_) => {
-				let device = Device::with_path(spec).map_err(|e| Error::Codec(anyhow::anyhow!("open {spec}: {e}")))?;
+				let device = Device::with_path(spec).map_err(|error| open_error(spec, error))?;
 				Ok((device, spec.to_string()))
 			}
 		},
+	}
+}
+
+fn open_error(device: &str, error: std::io::Error) -> Error {
+	match error.kind() {
+		std::io::ErrorKind::PermissionDenied => Error::PermissionDenied(format!("{device}: {error}")),
+		_ => Error::SourceUnavailable(format!("{device}: {error}")),
 	}
 }
 

--- a/rs/moq-video/src/capture/v4l2.rs
+++ b/rs/moq-video/src/capture/v4l2.rs
@@ -71,7 +71,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream
 				width: camera.width,
 				height: camera.height,
 				framerate: camera.framerate,
-				device: camera.name.clone(),
+				label: camera.name.clone(),
 			};
 			Ok((camera, geometry))
 		},
@@ -84,7 +84,7 @@ pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<Stream
 		geo.width,
 		geo.height,
 		geo.framerate,
-		geo.device,
+		geo.label,
 		None,
 		Box::new(guard),
 	))

--- a/rs/moq-video/src/capture/window.rs
+++ b/rs/moq-video/src/capture/window.rs
@@ -185,10 +185,15 @@ impl Capture {
 		let width = ((rect.right - rect.left).max(0) as u32) & !1;
 		let height = ((rect.bottom - rect.top).max(0) as u32) & !1;
 		if (width, height) != (self.width, self.height) {
-			return Err(Error::SourceChanged(format!(
-				"{} resized from {}x{} to {width}x{height}",
-				self.name, self.width, self.height
-			)));
+			// The encoder's geometry is fixed at open, so end the stream and let
+			// the caller reopen against the new size.
+			tracing::info!(
+				source = %self.name,
+				from = %format_args!("{}x{}", self.width, self.height),
+				to = %format_args!("{width}x{height}"),
+				"window resized; ending capture"
+			);
+			return Ok(None);
 		}
 		let (bgra, printed) = snapshot(self.handle, self.width, self.height, self.wm_print, self.cursor)?;
 		if !self.identity.matches() {

--- a/rs/moq-video/src/capture/window.rs
+++ b/rs/moq-video/src/capture/window.rs
@@ -7,19 +7,27 @@
 
 use std::ffi::c_void;
 use std::mem::size_of;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use windows::Win32::Foundation::{E_ACCESSDENIED, HWND, LPARAM, RECT};
+use windows::Win32::Foundation::{CloseHandle, E_ACCESSDENIED, HANDLE, HWND, LPARAM, RECT, WPARAM};
 use windows::Win32::Graphics::Gdi::{
-	BI_RGB, BITMAPINFO, BITMAPINFOHEADER, BitBlt, CAPTUREBLT, CreateCompatibleBitmap, CreateCompatibleDC,
-	DIB_RGB_COLORS, DeleteDC, DeleteObject, GetDIBits, GetWindowDC, HBITMAP, HDC, HGDIOBJ, ReleaseDC, SRCCOPY,
-	SelectObject,
+	BI_RGB, BITMAPINFO, BITMAPINFOHEADER, BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DIB_RGB_COLORS, DeleteDC,
+	DeleteObject, GetDIBits, GetWindowDC, HBITMAP, HDC, HGDIOBJ, ReleaseDC, SRCCOPY, SelectObject,
 };
-use windows::Win32::Storage::Xps::{PRINT_WINDOW_FLAGS, PrintWindow};
+use windows::Win32::System::Threading::{
+	OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+};
+use windows::Win32::UI::HiDpi::{
+	DPI_AWARENESS_CONTEXT, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE, SetThreadDpiAwarenessContext,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
-	EnumWindows, GetClassNameW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW, IsWindow, IsWindowVisible,
+	CURSOR_SHOWING, CURSORINFO, DI_NORMAL, DrawIconEx, EnumWindows, GetCursorInfo, GetIconInfo, GetPropW,
+	GetWindowRect, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId, HICON, ICONINFO, IsWindow,
+	IsWindowVisible, PRF_CHILDREN, PRF_CLIENT, PRF_ERASEBKGND, PRF_NONCLIENT, RemovePropW, SMTO_ABORTIFHUNG,
+	SMTO_BLOCK, SendMessageTimeoutW, SetPropW, WM_PRINT,
 };
-use windows::core::BOOL;
+use windows::core::{BOOL, PCWSTR, PWSTR};
 
 use super::channel::FrameChannel;
 use super::pump::{self, Geometry};
@@ -28,9 +36,12 @@ use crate::Error;
 use crate::frame::{I420, Surface};
 
 const DEFAULT_FRAMERATE: u32 = 30;
+const PRINT_TIMEOUT_MS: u32 = 50;
+static NEXT_WINDOW_IDENTITY: AtomicUsize = AtomicUsize::new(1);
 
 /// List visible, titled top-level windows by native HWND.
 pub(super) fn windows() -> Result<Vec<Window>, Error> {
+	let _dpi = DpiContext::enter()?;
 	let mut handles = Vec::<HWND>::new();
 	unsafe {
 		EnumWindows(
@@ -58,7 +69,7 @@ pub(super) fn windows() -> Result<Vec<Window>, Error> {
 		result.push(Window {
 			id: format!("window:{}", handle.0 as usize),
 			title,
-			app: class_name(handle),
+			app: app_name(handle),
 			width,
 			height,
 		});
@@ -88,7 +99,7 @@ pub(super) async fn open(config: &Config, selector: &str) -> Result<Stream, Erro
 				width: capture.width,
 				height: capture.height,
 				framerate: Some(capture.framerate),
-				device: capture.name.clone(),
+				label: capture.name.clone(),
 			};
 			Ok((capture, geometry))
 		},
@@ -101,7 +112,7 @@ pub(super) async fn open(config: &Config, selector: &str) -> Result<Stream, Erro
 		geometry.width,
 		geometry.height,
 		geometry.framerate,
-		geometry.device,
+		geometry.label,
 		None,
 		Box::new(guard),
 	))
@@ -109,19 +120,21 @@ pub(super) async fn open(config: &Config, selector: &str) -> Result<Stream, Erro
 
 struct Capture {
 	handle: HWND,
+	identity: WindowIdentity,
 	width: u32,
 	height: u32,
 	framerate: u32,
 	interval: Duration,
 	next: Instant,
 	name: String,
+	wm_print: bool,
+	cursor: bool,
+	_dpi: DpiContext,
 }
-
-// HWND is only dereferenced through user32 on the pump thread.
-unsafe impl Send for Capture {}
 
 impl Capture {
 	fn open(config: &Config, handle: HWND) -> Result<Self, Error> {
+		let dpi = DpiContext::enter()?;
 		if !unsafe { IsWindow(Some(handle)) }.as_bool() {
 			return Err(Error::SourceUnavailable(format!(
 				"window {} no longer exists",
@@ -136,15 +149,20 @@ impl Capture {
 		if width == 0 || height == 0 {
 			return Err(Error::SourceUnavailable("window has no capturable area".to_string()));
 		}
+		let identity = WindowIdentity::new(handle)?;
 		let framerate = config.framerate.unwrap_or(DEFAULT_FRAMERATE).max(1);
 		Ok(Self {
 			handle,
+			identity,
 			width,
 			height,
 			framerate,
 			interval: Duration::from_micros(1_000_000 / u64::from(framerate)),
 			next: Instant::now(),
 			name: format!("window:{}", handle.0 as usize),
+			wm_print: true,
+			cursor: config.cursor,
+			_dpi: dpi,
 		})
 	}
 
@@ -155,10 +173,31 @@ impl Capture {
 		}
 		self.next = Instant::now() + self.interval;
 
-		if !unsafe { IsWindow(Some(self.handle)) }.as_bool() {
-			return Err(Error::SourceUnavailable(format!("{} was closed", self.name)));
+		if !self.identity.matches() {
+			return Err(Error::SourceUnavailable(format!(
+				"{} was closed or replaced",
+				self.name
+			)));
 		}
-		let bgra = snapshot(self.handle, self.width, self.height)?;
+		let mut rect = RECT::default();
+		unsafe { GetWindowRect(self.handle, &mut rect) }
+			.map_err(|error| Error::SourceUnavailable(format!("read window geometry: {error}")))?;
+		let width = ((rect.right - rect.left).max(0) as u32) & !1;
+		let height = ((rect.bottom - rect.top).max(0) as u32) & !1;
+		if (width, height) != (self.width, self.height) {
+			return Err(Error::SourceChanged(format!(
+				"{} resized from {}x{} to {width}x{height}",
+				self.name, self.width, self.height
+			)));
+		}
+		let (bgra, printed) = snapshot(self.handle, self.width, self.height, self.wm_print, self.cursor)?;
+		if !self.identity.matches() {
+			return Err(Error::SourceUnavailable(format!(
+				"{} was closed or replaced",
+				self.name
+			)));
+		}
+		self.wm_print &= printed;
 		Ok(Some(Surface::I420(I420::from_bgra(
 			&bgra,
 			self.width * 4,
@@ -168,7 +207,56 @@ impl Capture {
 	}
 }
 
-fn snapshot(handle: HWND, width: u32, height: u32) -> Result<Vec<u8>, Error> {
+struct DpiContext(DPI_AWARENESS_CONTEXT);
+
+impl DpiContext {
+	fn enter() -> Result<Self, Error> {
+		let previous = unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE) };
+		if previous.0.is_null() {
+			return Err(last_capture_error("enable per-monitor DPI awareness"));
+		}
+		Ok(Self(previous))
+	}
+}
+
+impl Drop for DpiContext {
+	fn drop(&mut self) {
+		unsafe { SetThreadDpiAwarenessContext(self.0) };
+	}
+}
+
+struct WindowIdentity {
+	handle: HWND,
+	name: Vec<u16>,
+	token: HANDLE,
+}
+
+impl WindowIdentity {
+	fn new(handle: HWND) -> Result<Self, Error> {
+		let value = NEXT_WINDOW_IDENTITY.fetch_add(1, Ordering::Relaxed).max(1);
+		let token = HANDLE(value as *mut c_void);
+		let name = format!("moq.capture.identity.{}.{value}\0", std::process::id())
+			.encode_utf16()
+			.collect::<Vec<_>>();
+		unsafe { SetPropW(handle, PCWSTR(name.as_ptr()), Some(token)) }
+			.map_err(|error| capture_error("mark window identity", error))?;
+		Ok(Self { handle, name, token })
+	}
+
+	fn matches(&self) -> bool {
+		unsafe { GetPropW(self.handle, PCWSTR(self.name.as_ptr())).0 == self.token.0 }
+	}
+}
+
+impl Drop for WindowIdentity {
+	fn drop(&mut self) {
+		if self.matches() {
+			let _ = unsafe { RemovePropW(self.handle, PCWSTR(self.name.as_ptr())) };
+		}
+	}
+}
+
+fn snapshot(handle: HWND, width: u32, height: u32, print: bool, cursor: bool) -> Result<(Vec<u8>, bool), Error> {
 	let source = unsafe { GetWindowDC(Some(handle)) };
 	if source.is_invalid() {
 		return Err(last_capture_error("get window device context"));
@@ -189,24 +277,27 @@ fn snapshot(handle: HWND, width: u32, height: u32) -> Result<Vec<u8>, Error> {
 		return Err(last_capture_error("select window bitmap"));
 	}
 	let selected = Selected { dc: memory.0, previous };
-	// Ask the window to draw itself first, which works while it is occluded. Some
-	// applications do not implement PrintWindow, so fall back to copying its DC.
-	if !unsafe { PrintWindow(handle, memory.0, PRINT_WINDOW_FLAGS(2)) }.as_bool() {
-		unsafe {
-			BitBlt(
-				memory.0,
-				0,
-				0,
-				width as i32,
-				height as i32,
-				Some(source.1),
-				0,
-				0,
-				SRCCOPY | CAPTUREBLT,
-			)
-			.map_err(|error| capture_error("copy window pixels", error))?;
-		}
+	unsafe {
+		BitBlt(
+			memory.0,
+			0,
+			0,
+			width as i32,
+			height as i32,
+			Some(source.1),
+			0,
+			0,
+			SRCCOPY,
+		)
+		.map_err(|error| capture_error("copy window pixels", error))?;
 	}
+	// WM_PRINT keeps occluded windows useful but runs on the target UI thread.
+	// Bound that request, then keep using the copied DC if the target times out.
+	let printed = !print || print_window(handle, memory.0);
+	if cursor {
+		draw_cursor(handle, memory.0);
+	}
+	drop(selected);
 
 	let mut info = BITMAPINFO {
 		bmiHeader: BITMAPINFOHEADER {
@@ -232,11 +323,52 @@ fn snapshot(handle: HWND, width: u32, height: u32) -> Result<Vec<u8>, Error> {
 			DIB_RGB_COLORS,
 		)
 	};
-	drop(selected);
 	if rows != height as i32 {
 		return Err(last_capture_error("read window bitmap"));
 	}
-	Ok(pixels)
+	Ok((pixels, printed))
+}
+
+fn draw_cursor(handle: HWND, target: HDC) {
+	let mut cursor = CURSORINFO {
+		cbSize: size_of::<CURSORINFO>() as u32,
+		..Default::default()
+	};
+	if unsafe { GetCursorInfo(&mut cursor) }.is_err() || cursor.flags != CURSOR_SHOWING {
+		return;
+	}
+
+	let icon = HICON(cursor.hCursor.0);
+	let mut info = ICONINFO::default();
+	if unsafe { GetIconInfo(icon, &mut info) }.is_err() {
+		return;
+	}
+	let _mask = (!info.hbmMask.is_invalid()).then(|| Bitmap(info.hbmMask));
+	let _color = (!info.hbmColor.is_invalid()).then(|| Bitmap(info.hbmColor));
+
+	let mut rect = RECT::default();
+	if unsafe { GetWindowRect(handle, &mut rect) }.is_err() {
+		return;
+	}
+	let x = cursor.ptScreenPos.x - rect.left - info.xHotspot as i32;
+	let y = cursor.ptScreenPos.y - rect.top - info.yHotspot as i32;
+	let _ = unsafe { DrawIconEx(target, x, y, icon, 0, 0, 0, None, DI_NORMAL) };
+}
+
+fn print_window(handle: HWND, target: HDC) -> bool {
+	let flags = PRF_CLIENT | PRF_NONCLIENT | PRF_ERASEBKGND | PRF_CHILDREN;
+	unsafe {
+		SendMessageTimeoutW(
+			handle,
+			WM_PRINT,
+			WPARAM(target.0 as usize),
+			LPARAM(flags as isize),
+			SMTO_BLOCK | SMTO_ABORTIFHUNG,
+			PRINT_TIMEOUT_MS,
+			None,
+		)
+		.0 != 0
+	}
 }
 
 fn title(handle: HWND) -> String {
@@ -249,10 +381,37 @@ fn title(handle: HWND) -> String {
 	String::from_utf16_lossy(&buffer[..copied])
 }
 
-fn class_name(handle: HWND) -> String {
-	let mut buffer = vec![0u16; 256];
-	let copied = unsafe { GetClassNameW(handle, &mut buffer) }.max(0) as usize;
-	String::from_utf16_lossy(&buffer[..copied])
+fn app_name(handle: HWND) -> String {
+	let mut process_id = 0;
+	unsafe { GetWindowThreadProcessId(handle, Some(&mut process_id)) };
+	if process_id == 0 {
+		return String::new();
+	}
+	let Ok(process) = (unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_id) }) else {
+		return String::new();
+	};
+	let process = ProcessHandle(process);
+	let mut path = vec![0u16; 32_768];
+	let mut length = path.len() as u32;
+	if unsafe { QueryFullProcessImageNameW(process.0, PROCESS_NAME_WIN32, PWSTR(path.as_mut_ptr()), &mut length) }
+		.is_err()
+	{
+		return String::new();
+	}
+	let path = String::from_utf16_lossy(&path[..length as usize]);
+	std::path::Path::new(&path)
+		.file_stem()
+		.and_then(|name| name.to_str())
+		.unwrap_or_default()
+		.to_string()
+}
+
+struct ProcessHandle(HANDLE);
+
+impl Drop for ProcessHandle {
+	fn drop(&mut self) {
+		let _ = unsafe { CloseHandle(self.0) };
+	}
 }
 
 fn parse(selector: &str) -> Result<HWND, Error> {

--- a/rs/moq-video/src/capture/window.rs
+++ b/rs/moq-video/src/capture/window.rs
@@ -1,0 +1,320 @@
+//! Native Windows single-window capture.
+//!
+//! Desktop Duplication is monitor-scoped, so selected windows use GDI. The
+//! backend enumerates visible top-level windows, copies the selected window DC
+//! at the requested frame rate, and converts BGRA to I420. The shared
+//! latest-frame channel keeps the GDI loop independent from encoder latency.
+
+use std::ffi::c_void;
+use std::mem::size_of;
+use std::time::{Duration, Instant};
+
+use windows::Win32::Foundation::{E_ACCESSDENIED, HWND, LPARAM, RECT};
+use windows::Win32::Graphics::Gdi::{
+	BI_RGB, BITMAPINFO, BITMAPINFOHEADER, BitBlt, CAPTUREBLT, CreateCompatibleBitmap, CreateCompatibleDC,
+	DIB_RGB_COLORS, DeleteDC, DeleteObject, GetDIBits, GetWindowDC, HBITMAP, HDC, HGDIOBJ, ReleaseDC, SRCCOPY,
+	SelectObject,
+};
+use windows::Win32::Storage::Xps::{PRINT_WINDOW_FLAGS, PrintWindow};
+use windows::Win32::UI::WindowsAndMessaging::{
+	EnumWindows, GetClassNameW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW, IsWindow, IsWindowVisible,
+};
+use windows::core::BOOL;
+
+use super::channel::FrameChannel;
+use super::pump::{self, Geometry};
+use super::{Config, Stream, Window};
+use crate::Error;
+use crate::frame::{I420, Surface};
+
+const DEFAULT_FRAMERATE: u32 = 30;
+
+/// List visible, titled top-level windows by native HWND.
+pub(super) fn windows() -> Result<Vec<Window>, Error> {
+	let mut handles = Vec::<HWND>::new();
+	unsafe {
+		EnumWindows(
+			Some(collect_window),
+			LPARAM((&mut handles as *mut Vec<HWND>).cast::<c_void>() as isize),
+		)
+		.map_err(|error| Error::Codec(anyhow::anyhow!("enumerate Windows windows: {error}")))?;
+	}
+
+	let mut result = Vec::new();
+	for handle in handles {
+		let mut rect = RECT::default();
+		if unsafe { GetWindowRect(handle, &mut rect) }.is_err() {
+			continue;
+		}
+		let width = (rect.right - rect.left).max(0) as u32;
+		let height = (rect.bottom - rect.top).max(0) as u32;
+		if width < 2 || height < 2 {
+			continue;
+		}
+		let title = title(handle);
+		if title.is_empty() {
+			continue;
+		}
+		result.push(Window {
+			id: format!("window:{}", handle.0 as usize),
+			title,
+			app: class_name(handle),
+			width,
+			height,
+		});
+	}
+	Ok(result)
+}
+
+unsafe extern "system" fn collect_window(handle: HWND, data: LPARAM) -> BOOL {
+	if unsafe { IsWindowVisible(handle) }.as_bool() && unsafe { GetWindowTextLengthW(handle) } > 0 {
+		let handles = unsafe { &mut *(data.0 as *mut Vec<HWND>) };
+		handles.push(handle);
+	}
+	true.into()
+}
+
+pub(super) async fn open(config: &Config, selector: &str) -> Result<Stream, Error> {
+	let handle = parse(selector)?;
+	let handle = handle.0 as usize;
+	let config = config.clone();
+	let chan = FrameChannel::new();
+	let (geometry, guard) = pump::spawn(
+		chan.clone(),
+		move || {
+			let handle = HWND(handle as *mut c_void);
+			let capture = Capture::open(&config, handle)?;
+			let geometry = Geometry {
+				width: capture.width,
+				height: capture.height,
+				framerate: Some(capture.framerate),
+				device: capture.name.clone(),
+			};
+			Ok((capture, geometry))
+		},
+		Capture::read,
+	)
+	.await?;
+
+	Ok(Stream::new(
+		chan,
+		geometry.width,
+		geometry.height,
+		geometry.framerate,
+		geometry.device,
+		None,
+		Box::new(guard),
+	))
+}
+
+struct Capture {
+	handle: HWND,
+	width: u32,
+	height: u32,
+	framerate: u32,
+	interval: Duration,
+	next: Instant,
+	name: String,
+}
+
+// HWND is only dereferenced through user32 on the pump thread.
+unsafe impl Send for Capture {}
+
+impl Capture {
+	fn open(config: &Config, handle: HWND) -> Result<Self, Error> {
+		if !unsafe { IsWindow(Some(handle)) }.as_bool() {
+			return Err(Error::SourceUnavailable(format!(
+				"window {} no longer exists",
+				handle.0 as usize
+			)));
+		}
+		let mut rect = RECT::default();
+		unsafe { GetWindowRect(handle, &mut rect) }
+			.map_err(|error| Error::SourceUnavailable(format!("read window geometry: {error}")))?;
+		let width = ((rect.right - rect.left).max(0) as u32) & !1;
+		let height = ((rect.bottom - rect.top).max(0) as u32) & !1;
+		if width == 0 || height == 0 {
+			return Err(Error::SourceUnavailable("window has no capturable area".to_string()));
+		}
+		let framerate = config.framerate.unwrap_or(DEFAULT_FRAMERATE).max(1);
+		Ok(Self {
+			handle,
+			width,
+			height,
+			framerate,
+			interval: Duration::from_micros(1_000_000 / u64::from(framerate)),
+			next: Instant::now(),
+			name: format!("window:{}", handle.0 as usize),
+		})
+	}
+
+	fn read(&mut self) -> Result<Option<Surface>, Error> {
+		let now = Instant::now();
+		if self.next > now {
+			std::thread::sleep(self.next - now);
+		}
+		self.next = Instant::now() + self.interval;
+
+		if !unsafe { IsWindow(Some(self.handle)) }.as_bool() {
+			return Err(Error::SourceUnavailable(format!("{} was closed", self.name)));
+		}
+		let bgra = snapshot(self.handle, self.width, self.height)?;
+		Ok(Some(Surface::I420(I420::from_bgra(
+			&bgra,
+			self.width * 4,
+			self.width,
+			self.height,
+		)?)))
+	}
+}
+
+fn snapshot(handle: HWND, width: u32, height: u32) -> Result<Vec<u8>, Error> {
+	let source = unsafe { GetWindowDC(Some(handle)) };
+	if source.is_invalid() {
+		return Err(last_capture_error("get window device context"));
+	}
+	let source = WindowDc(handle, source);
+	let memory = unsafe { CreateCompatibleDC(Some(source.1)) };
+	if memory.is_invalid() {
+		return Err(last_capture_error("create memory device context"));
+	}
+	let memory = MemoryDc(memory);
+	let bitmap = unsafe { CreateCompatibleBitmap(source.1, width as i32, height as i32) };
+	if bitmap.is_invalid() {
+		return Err(last_capture_error("create window bitmap"));
+	}
+	let bitmap = Bitmap(bitmap);
+	let previous = unsafe { SelectObject(memory.0, HGDIOBJ(bitmap.0.0)) };
+	if previous.is_invalid() {
+		return Err(last_capture_error("select window bitmap"));
+	}
+	let selected = Selected { dc: memory.0, previous };
+	// Ask the window to draw itself first, which works while it is occluded. Some
+	// applications do not implement PrintWindow, so fall back to copying its DC.
+	if !unsafe { PrintWindow(handle, memory.0, PRINT_WINDOW_FLAGS(2)) }.as_bool() {
+		unsafe {
+			BitBlt(
+				memory.0,
+				0,
+				0,
+				width as i32,
+				height as i32,
+				Some(source.1),
+				0,
+				0,
+				SRCCOPY | CAPTUREBLT,
+			)
+			.map_err(|error| capture_error("copy window pixels", error))?;
+		}
+	}
+
+	let mut info = BITMAPINFO {
+		bmiHeader: BITMAPINFOHEADER {
+			biSize: size_of::<BITMAPINFOHEADER>() as u32,
+			biWidth: width as i32,
+			biHeight: -(height as i32),
+			biPlanes: 1,
+			biBitCount: 32,
+			biCompression: BI_RGB.0,
+			..Default::default()
+		},
+		..Default::default()
+	};
+	let mut pixels = vec![0u8; width as usize * height as usize * 4];
+	let rows = unsafe {
+		GetDIBits(
+			memory.0,
+			bitmap.0,
+			0,
+			height,
+			Some(pixels.as_mut_ptr().cast()),
+			&mut info,
+			DIB_RGB_COLORS,
+		)
+	};
+	drop(selected);
+	if rows != height as i32 {
+		return Err(last_capture_error("read window bitmap"));
+	}
+	Ok(pixels)
+}
+
+fn title(handle: HWND) -> String {
+	let length = unsafe { GetWindowTextLengthW(handle) };
+	if length <= 0 {
+		return String::new();
+	}
+	let mut buffer = vec![0u16; length as usize + 1];
+	let copied = unsafe { GetWindowTextW(handle, &mut buffer) }.max(0) as usize;
+	String::from_utf16_lossy(&buffer[..copied])
+}
+
+fn class_name(handle: HWND) -> String {
+	let mut buffer = vec![0u16; 256];
+	let copied = unsafe { GetClassNameW(handle, &mut buffer) }.max(0) as usize;
+	String::from_utf16_lossy(&buffer[..copied])
+}
+
+fn parse(selector: &str) -> Result<HWND, Error> {
+	let value = selector
+		.strip_prefix("window:")
+		.unwrap_or(selector)
+		.parse::<usize>()
+		.map_err(|_| Error::SourceUnavailable(format!("invalid Windows window selector {selector:?}")))?;
+	Ok(HWND(value as *mut c_void))
+}
+
+fn last_capture_error(context: &str) -> Error {
+	capture_error(context, windows::core::Error::from_thread())
+}
+
+fn capture_error(context: &str, error: windows::core::Error) -> Error {
+	if error.code() == E_ACCESSDENIED {
+		Error::PermissionDenied(format!("{context}: {error}"))
+	} else {
+		Error::SourceUnavailable(format!("{context}: {error}"))
+	}
+}
+
+struct WindowDc(HWND, HDC);
+
+impl Drop for WindowDc {
+	fn drop(&mut self) {
+		unsafe {
+			ReleaseDC(Some(self.0), self.1);
+		}
+	}
+}
+
+struct MemoryDc(HDC);
+
+impl Drop for MemoryDc {
+	fn drop(&mut self) {
+		unsafe {
+			let _ = DeleteDC(self.0);
+		}
+	}
+}
+
+struct Bitmap(HBITMAP);
+
+impl Drop for Bitmap {
+	fn drop(&mut self) {
+		unsafe {
+			let _ = DeleteObject(HGDIOBJ(self.0.0));
+		}
+	}
+}
+
+struct Selected {
+	dc: HDC,
+	previous: HGDIOBJ,
+}
+
+impl Drop for Selected {
+	fn drop(&mut self) {
+		unsafe {
+			SelectObject(self.dc, self.previous);
+		}
+	}
+}

--- a/rs/moq-video/src/capture/x11.rs
+++ b/rs/moq-video/src/capture/x11.rs
@@ -306,7 +306,11 @@ impl Capture {
 		let width = u16::try_from(self.width).map_err(|_| Error::Codec(anyhow::anyhow!("X11 width is too large")))?;
 		let height =
 			u16::try_from(self.height).map_err(|_| Error::Codec(anyhow::anyhow!("X11 height is too large")))?;
-		let image = self
+		// The geometry check above and this request are separate round trips, so
+		// an interactive resize lands between them often enough to matter. The
+		// stale rectangle then fails the request, which is an ordinary transition
+		// rather than a lost source.
+		let image = match self
 			.connection
 			.get_image(
 				ImageFormat::Z_PIXMAP,
@@ -319,7 +323,10 @@ impl Capture {
 			)
 			.map_err(source)?
 			.reply()
-			.map_err(source)?;
+		{
+			Ok(image) => image,
+			Err(error) => return self.changed_or_lost(error),
+		};
 		let mut rgb = self.format.rgb(&image.data, self.width, self.height)?;
 		if self.cursor
 			&& let Some(cursor) = self
@@ -332,6 +339,22 @@ impl Capture {
 			blend_cursor(&mut rgb, self.width, self.height, x, y, &cursor);
 		}
 		Ok(Some(Surface::I420(I420::from_rgb(&rgb, self.width, self.height)?)))
+	}
+
+	/// Classify a failed read: a drawable that still answers changed under us and
+	/// the caller should reopen, while one that is gone is terminal.
+	fn changed_or_lost(&self, error: impl std::fmt::Display) -> Result<Option<Surface>, Error> {
+		let alive = self
+			.connection
+			.get_geometry(self.drawable)
+			.ok()
+			.and_then(|cookie| cookie.reply().ok())
+			.is_some();
+		if !alive {
+			return Err(Error::SourceUnavailable(format!("X11 source: {error}")));
+		}
+		tracing::info!(source = %self.name, %error, "X11 source changed mid-frame; ending capture");
+		Ok(None)
 	}
 
 	fn origin(&self) -> Result<(i32, i32), Error> {

--- a/rs/moq-video/src/capture/x11.rs
+++ b/rs/moq-video/src/capture/x11.rs
@@ -79,11 +79,10 @@ pub(super) fn windows() -> Result<Vec<Window>, Error> {
 
 	let mut result = Vec::new();
 	for id in client_windows(&connection, root)? {
-		let attributes = match connection.get_window_attributes(id).map_err(codec)?.reply() {
-			Ok(attributes) if attributes.map_state == MapState::VIEWABLE => attributes,
+		match connection.get_window_attributes(id).map_err(codec)?.reply() {
+			Ok(attributes) if attributes.map_state == MapState::VIEWABLE => {}
 			_ => continue,
-		};
-		let _ = attributes;
+		}
 		let geometry = match connection.get_geometry(id).map_err(codec)?.reply() {
 			Ok(geometry) if geometry.width > 1 && geometry.height > 1 => geometry,
 			_ => continue,
@@ -95,7 +94,7 @@ pub(super) fn windows() -> Result<Vec<Window>, Error> {
 			continue;
 		}
 		let app = property(&connection, id, AtomEnum::WM_CLASS.into(), AtomEnum::STRING.into())
-			.map(|value| value.replace('\0', " ").trim().to_string())
+			.map(|value| wm_class(&value))
 			.unwrap_or_default();
 		result.push(Window {
 			id: format!("x11:{id}"),
@@ -189,8 +188,12 @@ impl Capture {
 		let (drawable, x, y, width, height, depth, visual, name, display) = match target {
 			Target::Display(selector) => {
 				let monitors = monitors(&connection, root)?;
-				let index = select_monitor(&monitors, selector)
-					.ok_or_else(|| Error::SourceUnavailable(format!("no X11 display at index {selector:?}")))?;
+				let index = select_monitor(&monitors, selector).ok_or_else(|| match selector {
+					Some(index) => {
+						Error::SourceUnavailable(format!("no X11 display at index {index} ({} found)", monitors.len()))
+					}
+					None => Error::SourceUnavailable("no X11 displays".to_string()),
+				})?;
 				let monitor = &monitors[index];
 				(
 					root,
@@ -275,10 +278,10 @@ impl Capture {
 		if let Some(display) = &self.display {
 			let monitors = monitors(&self.connection, self.root)?;
 			if !display.matches(&monitors) {
-				return Err(Error::SourceChanged(format!(
-					"{} geometry or monitor layout changed",
-					self.name
-				)));
+				// The encoder's geometry is fixed at open, so end the stream and
+				// let the caller reopen against the new layout.
+				tracing::info!(source = %self.name, "X11 monitor layout changed; ending capture");
+				return Ok(None);
 			}
 		} else {
 			let geometry = self
@@ -290,10 +293,13 @@ impl Capture {
 			let width = u32::from(geometry.width) & !1;
 			let height = u32::from(geometry.height) & !1;
 			if (width, height) != (self.width, self.height) {
-				return Err(Error::SourceChanged(format!(
-					"{} resized from {}x{} to {width}x{height}",
-					self.name, self.width, self.height
-				)));
+				tracing::info!(
+					source = %self.name,
+					from = %format_args!("{}x{}", self.width, self.height),
+					to = %format_args!("{width}x{height}"),
+					"X11 window resized; ending capture"
+				);
+				return Ok(None);
 			}
 		}
 
@@ -615,6 +621,14 @@ fn property(connection: &RustConnection, window: XWindow, property: u32, kind: u
 		.map(|reply| String::from_utf8_lossy(&reply.value).into_owned())
 }
 
+/// `WM_CLASS` is `instance\0class\0`; the class is the application name, which
+/// is what the other platforms report.
+fn wm_class(value: &str) -> String {
+	let mut parts = value.split('\0').filter(|part| !part.is_empty());
+	let instance = parts.next().unwrap_or_default();
+	parts.next().unwrap_or(instance).to_string()
+}
+
 fn codec(error: impl std::fmt::Display) -> Error {
 	Error::Codec(anyhow::anyhow!("X11: {error}"))
 }
@@ -689,6 +703,13 @@ mod tests {
 		assert_eq!(&rgb[..3], &[100; 3]);
 		assert_eq!(&rgb[6..9], &[178, 50, 50]);
 		assert_eq!(&rgb[9..12], &[0, 0, 255]);
+	}
+
+	#[test]
+	fn wm_class_reports_the_application_class() {
+		assert_eq!(wm_class("navigator\0Firefox\0"), "Firefox");
+		assert_eq!(wm_class("xterm\0"), "xterm");
+		assert_eq!(wm_class(""), "");
 	}
 
 	#[test]

--- a/rs/moq-video/src/capture/x11.rs
+++ b/rs/moq-video/src/capture/x11.rs
@@ -1,0 +1,424 @@
+//! Native X11 display and window capture.
+//!
+//! Wayland capture goes through the desktop portal because direct global
+//! capture is intentionally forbidden there. An X11 session does expose stable
+//! monitor and window ids, so this backend enumerates them with RandR and pulls
+//! pixels with `GetImage`. It is also the fallback when the `pipewire` feature
+//! is disabled on an X11 desktop.
+
+use std::time::{Duration, Instant};
+
+use x11rb::connection::Connection;
+use x11rb::protocol::randr::ConnectionExt as _;
+use x11rb::protocol::xproto::{
+	AtomEnum, ConnectionExt as _, Drawable, ImageFormat, ImageOrder, MapState, Window as XWindow,
+};
+use x11rb::rust_connection::RustConnection;
+
+use super::channel::FrameChannel;
+use super::pump::{self, Geometry};
+use super::{Config, Display, Stream, Window};
+use crate::Error;
+use crate::frame::{I420, Surface};
+
+const DEFAULT_FRAMERATE: u32 = 30;
+
+/// Whether a display selector belongs to X11. A desktop without Wayland also
+/// selects X11 by default, making it the no-portal fallback.
+pub(super) fn selected(selector: Option<&str>) -> bool {
+	selector.is_some_and(|selector| selector.starts_with("x11:")) || std::env::var_os("WAYLAND_DISPLAY").is_none()
+}
+
+pub(super) fn displays() -> Result<Vec<Display>, Error> {
+	if !selected(None) {
+		return Err(Error::Unsupported(
+			"listing displays on Wayland; the desktop portal owns selection".to_string(),
+		));
+	}
+	let (connection, screen) = connect()?;
+	let root = connection.setup().roots[screen].root;
+	let monitors = monitors(&connection, root)?;
+	Ok(monitors
+		.into_iter()
+		.enumerate()
+		.map(|(index, monitor)| Display {
+			id: format!("x11:{index}"),
+			name: monitor.name,
+			width: monitor.width,
+			height: monitor.height,
+		})
+		.collect())
+}
+
+pub(super) fn windows() -> Result<Vec<Window>, Error> {
+	if !selected(None) {
+		return Err(Error::Unsupported(
+			"listing windows on Wayland; the desktop portal does not expose them".to_string(),
+		));
+	}
+	let (connection, screen) = connect()?;
+	let root = connection.setup().roots[screen].root;
+	let tree = connection.query_tree(root).map_err(codec)?.reply().map_err(codec)?;
+	let name_atom = intern(&connection, b"_NET_WM_NAME")?;
+	let utf8_atom = intern(&connection, b"UTF8_STRING")?;
+
+	let mut result = Vec::new();
+	for id in tree.children {
+		let attributes = match connection.get_window_attributes(id).map_err(codec)?.reply() {
+			Ok(attributes) if attributes.map_state == MapState::VIEWABLE => attributes,
+			_ => continue,
+		};
+		let _ = attributes;
+		let geometry = match connection.get_geometry(id).map_err(codec)?.reply() {
+			Ok(geometry) if geometry.width > 1 && geometry.height > 1 => geometry,
+			_ => continue,
+		};
+		let title = property(&connection, id, name_atom, utf8_atom)
+			.or_else(|| property(&connection, id, AtomEnum::WM_NAME.into(), AtomEnum::STRING.into()))
+			.unwrap_or_default();
+		if title.is_empty() {
+			continue;
+		}
+		let app = property(&connection, id, AtomEnum::WM_CLASS.into(), AtomEnum::STRING.into())
+			.map(|value| value.replace('\0', " ").trim().to_string())
+			.unwrap_or_default();
+		result.push(Window {
+			id: format!("x11:{id}"),
+			title,
+			app,
+			width: geometry.width.into(),
+			height: geometry.height.into(),
+		});
+	}
+	Ok(result)
+}
+
+pub(super) async fn open_display(config: &Config, selector: Option<&str>) -> Result<Stream, Error> {
+	if !selected(selector) {
+		return Err(Error::Unsupported(
+			"screen capture on Wayland without the `pipewire` feature".to_string(),
+		));
+	}
+	open(config, Target::Display(parse_selector(selector, "x11:")?)).await
+}
+
+pub(super) async fn open_window(config: &Config, selector: &str) -> Result<Stream, Error> {
+	if !selected(Some(selector)) {
+		return Err(Error::Unsupported("window capture on Wayland".to_string()));
+	}
+	let id = parse_selector(Some(selector), "x11:")?;
+	open(config, Target::Window(id)).await
+}
+
+async fn open(config: &Config, target: Target) -> Result<Stream, Error> {
+	let config = config.clone();
+	let chan = FrameChannel::new();
+	let (geometry, guard) = pump::spawn(
+		chan.clone(),
+		move || {
+			let capture = Capture::open(&config, target)?;
+			let geometry = Geometry {
+				width: capture.width,
+				height: capture.height,
+				framerate: Some(capture.framerate),
+				device: capture.name.clone(),
+			};
+			Ok((capture, geometry))
+		},
+		Capture::read,
+	)
+	.await?;
+
+	Ok(Stream::new(
+		chan,
+		geometry.width,
+		geometry.height,
+		geometry.framerate,
+		geometry.device,
+		None,
+		Box::new(guard),
+	))
+}
+
+#[derive(Clone, Copy)]
+enum Target {
+	Display(usize),
+	Window(usize),
+}
+
+struct Capture {
+	connection: RustConnection,
+	drawable: Drawable,
+	x: i16,
+	y: i16,
+	width: u32,
+	height: u32,
+	format: PixelFormat,
+	framerate: u32,
+	interval: Duration,
+	next: Instant,
+	name: String,
+}
+
+impl Capture {
+	fn open(config: &Config, target: Target) -> Result<Self, Error> {
+		let (connection, screen_index) = connect()?;
+		let screen = &connection.setup().roots[screen_index];
+		let (drawable, x, y, width, height, name) = match target {
+			Target::Display(index) => {
+				let monitor = monitors(&connection, screen.root)?
+					.into_iter()
+					.nth(index)
+					.ok_or_else(|| Error::SourceUnavailable(format!("no X11 display at index {index}")))?;
+				(
+					screen.root,
+					monitor.x,
+					monitor.y,
+					monitor.width,
+					monitor.height,
+					format!("x11:{index}"),
+				)
+			}
+			Target::Window(id) => {
+				let drawable =
+					u32::try_from(id).map_err(|_| Error::SourceUnavailable(format!("invalid X11 window id {id}")))?;
+				let geometry = connection
+					.get_geometry(drawable)
+					.map_err(source)?
+					.reply()
+					.map_err(source)?;
+				(
+					drawable,
+					0,
+					0,
+					geometry.width.into(),
+					geometry.height.into(),
+					format!("x11:{id}"),
+				)
+			}
+		};
+		let width = width & !1;
+		let height = height & !1;
+		if width == 0 || height == 0 {
+			return Err(Error::SourceUnavailable(format!("{name} has no capturable area")));
+		}
+		let format = PixelFormat::new(connection.setup(), screen.root_depth, screen.root_visual)?;
+		let framerate = config.framerate.unwrap_or(DEFAULT_FRAMERATE).max(1);
+		let interval = Duration::from_micros(1_000_000 / u64::from(framerate));
+		Ok(Self {
+			connection,
+			drawable,
+			x,
+			y,
+			width,
+			height,
+			format,
+			framerate,
+			interval,
+			next: Instant::now(),
+			name,
+		})
+	}
+
+	fn read(&mut self) -> Result<Option<Surface>, Error> {
+		let now = Instant::now();
+		if self.next > now {
+			std::thread::sleep(self.next - now);
+		}
+		self.next = Instant::now() + self.interval;
+
+		let width = u16::try_from(self.width).map_err(|_| Error::Codec(anyhow::anyhow!("X11 width is too large")))?;
+		let height =
+			u16::try_from(self.height).map_err(|_| Error::Codec(anyhow::anyhow!("X11 height is too large")))?;
+		let image = self
+			.connection
+			.get_image(
+				ImageFormat::Z_PIXMAP,
+				self.drawable,
+				self.x,
+				self.y,
+				width,
+				height,
+				u32::MAX,
+			)
+			.map_err(source)?
+			.reply()
+			.map_err(source)?;
+		let rgb = self.format.rgb(&image.data, self.width, self.height)?;
+		Ok(Some(Surface::I420(I420::from_rgb(&rgb, self.width, self.height)?)))
+	}
+}
+
+struct Monitor {
+	x: i16,
+	y: i16,
+	width: u32,
+	height: u32,
+	name: String,
+}
+
+fn monitors(connection: &RustConnection, root: XWindow) -> Result<Vec<Monitor>, Error> {
+	let reply = connection.randr_get_monitors(root, true).map_err(codec)?.reply();
+	if let Ok(reply) = reply {
+		let mut result = Vec::new();
+		for monitor in reply.monitors {
+			let name = connection
+				.get_atom_name(monitor.name)
+				.map_err(codec)?
+				.reply()
+				.map_err(codec)
+				.map(|reply| String::from_utf8_lossy(&reply.name).into_owned())
+				.unwrap_or_else(|_| format!("Monitor {}", result.len() + 1));
+			result.push(Monitor {
+				x: monitor.x,
+				y: monitor.y,
+				width: monitor.width.into(),
+				height: monitor.height.into(),
+				name,
+			});
+		}
+		if !result.is_empty() {
+			return Ok(result);
+		}
+	}
+
+	let geometry = connection.get_geometry(root).map_err(codec)?.reply().map_err(codec)?;
+	Ok(vec![Monitor {
+		x: 0,
+		y: 0,
+		width: geometry.width.into(),
+		height: geometry.height.into(),
+		name: "X11 display".to_string(),
+	}])
+}
+
+struct PixelFormat {
+	byte_order: ImageOrder,
+	bits_per_pixel: u8,
+	scanline_pad: u8,
+	red_mask: u32,
+	green_mask: u32,
+	blue_mask: u32,
+}
+
+impl PixelFormat {
+	fn new(setup: &x11rb::protocol::xproto::Setup, depth: u8, visual_id: u32) -> Result<Self, Error> {
+		let visual = setup
+			.roots
+			.iter()
+			.flat_map(|screen| &screen.allowed_depths)
+			.flat_map(|depth| &depth.visuals)
+			.find(|visual| visual.visual_id == visual_id)
+			.ok_or_else(|| Error::Codec(anyhow::anyhow!("X11 root visual is missing")))?;
+		let format = setup
+			.pixmap_formats
+			.iter()
+			.find(|format| format.depth == depth)
+			.ok_or_else(|| Error::Codec(anyhow::anyhow!("X11 pixel format for depth {depth} is missing")))?;
+		Ok(Self {
+			byte_order: setup.image_byte_order,
+			bits_per_pixel: format.bits_per_pixel,
+			scanline_pad: format.scanline_pad,
+			red_mask: visual.red_mask,
+			green_mask: visual.green_mask,
+			blue_mask: visual.blue_mask,
+		})
+	}
+
+	fn rgb(&self, data: &[u8], width: u32, height: u32) -> Result<Vec<u8>, Error> {
+		let pixel_bytes = usize::from(self.bits_per_pixel.div_ceil(8));
+		if !(3..=4).contains(&pixel_bytes) {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"unsupported X11 pixel depth: {} bits per pixel",
+				self.bits_per_pixel
+			)));
+		}
+		let row_bits = usize::try_from(width)
+			.ok()
+			.and_then(|width| width.checked_mul(usize::from(self.bits_per_pixel)))
+			.ok_or_else(|| Error::Codec(anyhow::anyhow!("X11 row size overflow")))?;
+		let pad = usize::from(self.scanline_pad);
+		let stride = row_bits.div_ceil(pad) * pad / 8;
+		let required = stride
+			.checked_mul(height as usize)
+			.ok_or_else(|| Error::Codec(anyhow::anyhow!("X11 frame size overflow")))?;
+		if data.len() < required {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"short X11 frame: got {} bytes, need {required}",
+				data.len()
+			)));
+		}
+
+		let mut rgb = Vec::with_capacity(width as usize * height as usize * 3);
+		for row in data[..required].chunks_exact(stride) {
+			for bytes in row[..width as usize * pixel_bytes].chunks_exact(pixel_bytes) {
+				let mut pixel = 0u32;
+				match self.byte_order {
+					ImageOrder::LSB_FIRST => {
+						for (shift, byte) in bytes.iter().enumerate() {
+							pixel |= u32::from(*byte) << (shift * 8);
+						}
+					}
+					_ => {
+						for byte in bytes {
+							pixel = (pixel << 8) | u32::from(*byte);
+						}
+					}
+				}
+				rgb.push(component(pixel, self.red_mask));
+				rgb.push(component(pixel, self.green_mask));
+				rgb.push(component(pixel, self.blue_mask));
+			}
+		}
+		Ok(rgb)
+	}
+}
+
+fn component(pixel: u32, mask: u32) -> u8 {
+	if mask == 0 {
+		return 0;
+	}
+	let shift = mask.trailing_zeros();
+	let maximum = mask >> shift;
+	let value = (pixel & mask) >> shift;
+	((u64::from(value) * 255 + u64::from(maximum) / 2) / u64::from(maximum)) as u8
+}
+
+fn connect() -> Result<(RustConnection, usize), Error> {
+	x11rb::connect(None).map_err(|error| Error::SourceUnavailable(format!("X11 display: {error}")))
+}
+
+fn parse_selector(selector: Option<&str>, prefix: &str) -> Result<usize, Error> {
+	selector
+		.unwrap_or("0")
+		.strip_prefix(prefix)
+		.unwrap_or(selector.unwrap_or("0"))
+		.parse()
+		.map_err(|_| Error::SourceUnavailable(format!("invalid X11 selector {:?}", selector.unwrap_or("0"))))
+}
+
+fn intern(connection: &RustConnection, name: &[u8]) -> Result<u32, Error> {
+	Ok(connection
+		.intern_atom(false, name)
+		.map_err(codec)?
+		.reply()
+		.map_err(codec)?
+		.atom)
+}
+
+fn property(connection: &RustConnection, window: XWindow, property: u32, kind: u32) -> Option<String> {
+	connection
+		.get_property(false, window, property, kind, 0, 4096)
+		.ok()?
+		.reply()
+		.ok()
+		.map(|reply| String::from_utf8_lossy(&reply.value).into_owned())
+}
+
+fn codec(error: impl std::fmt::Display) -> Error {
+	Error::Codec(anyhow::anyhow!("X11: {error}"))
+}
+
+fn source(error: impl std::fmt::Display) -> Error {
+	Error::SourceUnavailable(format!("X11 source: {error}"))
+}

--- a/rs/moq-video/src/capture/x11.rs
+++ b/rs/moq-video/src/capture/x11.rs
@@ -275,41 +275,16 @@ impl Capture {
 			std::thread::sleep(self.next - now);
 		}
 		self.next = Instant::now() + self.interval;
-		if let Some(display) = &self.display {
-			let monitors = monitors(&self.connection, self.root)?;
-			if !display.matches(&monitors) {
-				// The encoder's geometry is fixed at open, so end the stream and
-				// let the caller reopen against the new layout.
-				tracing::info!(source = %self.name, "X11 monitor layout changed; ending capture");
-				return Ok(None);
-			}
-		} else {
-			let geometry = self
-				.connection
-				.get_geometry(self.drawable)
-				.map_err(source)?
-				.reply()
-				.map_err(source)?;
-			let width = u32::from(geometry.width) & !1;
-			let height = u32::from(geometry.height) & !1;
-			if (width, height) != (self.width, self.height) {
-				tracing::info!(
-					source = %self.name,
-					from = %format_args!("{}x{}", self.width, self.height),
-					to = %format_args!("{width}x{height}"),
-					"X11 window resized; ending capture"
-				);
-				return Ok(None);
-			}
+		// The encoder's geometry is fixed at open, so a change ends the stream and
+		// the caller reopens against the new size.
+		if let Some(reason) = self.changed()? {
+			tracing::info!(source = %self.name, %reason, "X11 source changed; ending capture");
+			return Ok(None);
 		}
 
 		let width = u16::try_from(self.width).map_err(|_| Error::Codec(anyhow::anyhow!("X11 width is too large")))?;
 		let height =
 			u16::try_from(self.height).map_err(|_| Error::Codec(anyhow::anyhow!("X11 height is too large")))?;
-		// The geometry check above and this request are separate round trips, so
-		// an interactive resize lands between them often enough to matter. The
-		// stale rectangle then fails the request, which is an ordinary transition
-		// rather than a lost source.
 		let image = match self
 			.connection
 			.get_image(
@@ -325,7 +300,20 @@ impl Capture {
 			.reply()
 		{
 			Ok(image) => image,
-			Err(error) => return self.changed_or_lost(error),
+			// The check above and this request are separate round trips, so an
+			// interactive resize lands between them often enough to matter. Only a
+			// geometry change that we can still confirm is recoverable: anything
+			// else stays terminal, so a persistent failure surfaces instead of
+			// spinning the caller's reopen loop.
+			Err(error) => {
+				return match self.changed() {
+					Ok(Some(reason)) => {
+						tracing::info!(source = %self.name, %reason, "X11 source changed mid-frame; ending capture");
+						Ok(None)
+					}
+					_ => Err(Error::SourceUnavailable(format!("X11 source: {error}"))),
+				};
+			}
 		};
 		let mut rgb = self.format.rgb(&image.data, self.width, self.height)?;
 		if self.cursor
@@ -341,20 +329,27 @@ impl Capture {
 		Ok(Some(Surface::I420(I420::from_rgb(&rgb, self.width, self.height)?)))
 	}
 
-	/// Classify a failed read: a drawable that still answers changed under us and
-	/// the caller should reopen, while one that is gone is terminal.
-	fn changed_or_lost(&self, error: impl std::fmt::Display) -> Result<Option<Surface>, Error> {
-		let alive = self
-			.connection
-			.get_geometry(self.drawable)
-			.ok()
-			.and_then(|cookie| cookie.reply().ok())
-			.is_some();
-		if !alive {
-			return Err(Error::SourceUnavailable(format!("X11 source: {error}")));
+	/// How the source's geometry moved out from under the open stream, if it
+	/// did. Checked before each frame and again when a read fails.
+	fn changed(&self) -> Result<Option<String>, Error> {
+		match &self.display {
+			Some(display) => {
+				let monitors = monitors(&self.connection, self.root)?;
+				Ok((!display.matches(&monitors)).then(|| "monitor layout changed".to_string()))
+			}
+			None => {
+				let geometry = self
+					.connection
+					.get_geometry(self.drawable)
+					.map_err(source)?
+					.reply()
+					.map_err(source)?;
+				let width = u32::from(geometry.width) & !1;
+				let height = u32::from(geometry.height) & !1;
+				Ok(((width, height) != (self.width, self.height))
+					.then(|| format!("resized from {}x{} to {width}x{height}", self.width, self.height)))
+			}
 		}
-		tracing::info!(source = %self.name, %error, "X11 source changed mid-frame; ending capture");
-		Ok(None)
 	}
 
 	fn origin(&self) -> Result<(i32, i32), Error> {

--- a/rs/moq-video/src/capture/x11.rs
+++ b/rs/moq-video/src/capture/x11.rs
@@ -10,8 +10,9 @@ use std::time::{Duration, Instant};
 
 use x11rb::connection::Connection;
 use x11rb::protocol::randr::ConnectionExt as _;
+use x11rb::protocol::xfixes::{ConnectionExt as _, GetCursorImageReply};
 use x11rb::protocol::xproto::{
-	AtomEnum, ConnectionExt as _, Drawable, ImageFormat, ImageOrder, MapState, Window as XWindow,
+	AtomEnum, ConnectionExt as _, Drawable, ImageFormat, ImageOrder, MapState, VisualClass, Window as XWindow,
 };
 use x11rb::rust_connection::RustConnection;
 
@@ -26,13 +27,28 @@ const DEFAULT_FRAMERATE: u32 = 30;
 /// Whether a display selector belongs to X11. A desktop without Wayland also
 /// selects X11 by default, making it the no-portal fallback.
 pub(super) fn selected(selector: Option<&str>) -> bool {
-	selector.is_some_and(|selector| selector.starts_with("x11:")) || std::env::var_os("WAYLAND_DISPLAY").is_none()
+	selects_x11(selector, std::env::var_os("WAYLAND_DISPLAY").is_some())
+}
+
+fn selects_x11(selector: Option<&str>, wayland: bool) -> bool {
+	selector.is_some_and(|selector| selector.starts_with("x11:")) || !wayland
+}
+
+fn available() -> bool {
+	is_available(
+		std::env::var_os("WAYLAND_DISPLAY").is_some(),
+		std::env::var_os("DISPLAY").is_some(),
+	)
+}
+
+fn is_available(wayland: bool, x11: bool) -> bool {
+	x11 || !wayland
 }
 
 pub(super) fn displays() -> Result<Vec<Display>, Error> {
-	if !selected(None) {
+	if !available() {
 		return Err(Error::Unsupported(
-			"listing displays on Wayland; the desktop portal owns selection".to_string(),
+			"listing displays on Wayland without XWayland; the desktop portal owns selection".to_string(),
 		));
 	}
 	let (connection, screen) = connect()?;
@@ -51,19 +67,18 @@ pub(super) fn displays() -> Result<Vec<Display>, Error> {
 }
 
 pub(super) fn windows() -> Result<Vec<Window>, Error> {
-	if !selected(None) {
+	if !available() {
 		return Err(Error::Unsupported(
-			"listing windows on Wayland; the desktop portal does not expose them".to_string(),
+			"listing windows on Wayland without XWayland; the desktop portal does not expose them".to_string(),
 		));
 	}
 	let (connection, screen) = connect()?;
 	let root = connection.setup().roots[screen].root;
-	let tree = connection.query_tree(root).map_err(codec)?.reply().map_err(codec)?;
 	let name_atom = intern(&connection, b"_NET_WM_NAME")?;
 	let utf8_atom = intern(&connection, b"UTF8_STRING")?;
 
 	let mut result = Vec::new();
-	for id in tree.children {
+	for id in client_windows(&connection, root)? {
 		let attributes = match connection.get_window_attributes(id).map_err(codec)?.reply() {
 			Ok(attributes) if attributes.map_state == MapState::VIEWABLE => attributes,
 			_ => continue,
@@ -99,14 +114,15 @@ pub(super) async fn open_display(config: &Config, selector: Option<&str>) -> Res
 			"screen capture on Wayland without the `pipewire` feature".to_string(),
 		));
 	}
-	open(config, Target::Display(parse_selector(selector, "x11:")?)).await
+	let selector = selector.map(|selector| parse_selector(selector, "x11:")).transpose()?;
+	open(config, Target::Display(selector)).await
 }
 
 pub(super) async fn open_window(config: &Config, selector: &str) -> Result<Stream, Error> {
 	if !selected(Some(selector)) {
 		return Err(Error::Unsupported("window capture on Wayland".to_string()));
 	}
-	let id = parse_selector(Some(selector), "x11:")?;
+	let id = parse_selector(selector, "x11:")?;
 	open(config, Target::Window(id)).await
 }
 
@@ -121,7 +137,7 @@ async fn open(config: &Config, target: Target) -> Result<Stream, Error> {
 				width: capture.width,
 				height: capture.height,
 				framerate: Some(capture.framerate),
-				device: capture.name.clone(),
+				label: capture.name.clone(),
 			};
 			Ok((capture, geometry))
 		},
@@ -134,7 +150,7 @@ async fn open(config: &Config, target: Target) -> Result<Stream, Error> {
 		geometry.width,
 		geometry.height,
 		geometry.framerate,
-		geometry.device,
+		geometry.label,
 		None,
 		Box::new(guard),
 	))
@@ -142,7 +158,7 @@ async fn open(config: &Config, target: Target) -> Result<Stream, Error> {
 
 #[derive(Clone, Copy)]
 enum Target {
-	Display(usize),
+	Display(Option<usize>),
 	Window(usize),
 }
 
@@ -158,30 +174,48 @@ struct Capture {
 	interval: Duration,
 	next: Instant,
 	name: String,
+	root: XWindow,
+	cursor: bool,
+	display: Option<DisplayTarget>,
 }
 
 impl Capture {
 	fn open(config: &Config, target: Target) -> Result<Self, Error> {
 		let (connection, screen_index) = connect()?;
-		let screen = &connection.setup().roots[screen_index];
-		let (drawable, x, y, width, height, name) = match target {
-			Target::Display(index) => {
-				let monitor = monitors(&connection, screen.root)?
-					.into_iter()
-					.nth(index)
-					.ok_or_else(|| Error::SourceUnavailable(format!("no X11 display at index {index}")))?;
+		let (root, root_depth, root_visual) = {
+			let screen = &connection.setup().roots[screen_index];
+			(screen.root, screen.root_depth, screen.root_visual)
+		};
+		let (drawable, x, y, width, height, depth, visual, name, display) = match target {
+			Target::Display(selector) => {
+				let monitors = monitors(&connection, root)?;
+				let index = select_monitor(&monitors, selector)
+					.ok_or_else(|| Error::SourceUnavailable(format!("no X11 display at index {selector:?}")))?;
+				let monitor = &monitors[index];
 				(
-					screen.root,
+					root,
 					monitor.x,
 					monitor.y,
 					monitor.width,
 					monitor.height,
+					root_depth,
+					root_visual,
 					format!("x11:{index}"),
+					Some(DisplayTarget {
+						selector,
+						index,
+						monitor: monitor.clone(),
+					}),
 				)
 			}
 			Target::Window(id) => {
 				let drawable =
 					u32::try_from(id).map_err(|_| Error::SourceUnavailable(format!("invalid X11 window id {id}")))?;
+				let attributes = connection
+					.get_window_attributes(drawable)
+					.map_err(source)?
+					.reply()
+					.map_err(source)?;
 				let geometry = connection
 					.get_geometry(drawable)
 					.map_err(source)?
@@ -193,7 +227,10 @@ impl Capture {
 					0,
 					geometry.width.into(),
 					geometry.height.into(),
+					geometry.depth,
+					attributes.visual,
 					format!("x11:{id}"),
+					None,
 				)
 			}
 		};
@@ -202,9 +239,15 @@ impl Capture {
 		if width == 0 || height == 0 {
 			return Err(Error::SourceUnavailable(format!("{name} has no capturable area")));
 		}
-		let format = PixelFormat::new(connection.setup(), screen.root_depth, screen.root_visual)?;
+		let format = PixelFormat::new(connection.setup(), depth, visual)?;
 		let framerate = config.framerate.unwrap_or(DEFAULT_FRAMERATE).max(1);
 		let interval = Duration::from_micros(1_000_000 / u64::from(framerate));
+		let cursor = config.cursor
+			&& connection
+				.xfixes_query_version(5, 0)
+				.ok()
+				.and_then(|cookie| cookie.reply().ok())
+				.is_some();
 		Ok(Self {
 			connection,
 			drawable,
@@ -217,6 +260,9 @@ impl Capture {
 			interval,
 			next: Instant::now(),
 			name,
+			root,
+			cursor,
+			display,
 		})
 	}
 
@@ -226,6 +272,30 @@ impl Capture {
 			std::thread::sleep(self.next - now);
 		}
 		self.next = Instant::now() + self.interval;
+		if let Some(display) = &self.display {
+			let monitors = monitors(&self.connection, self.root)?;
+			if !display.matches(&monitors) {
+				return Err(Error::SourceChanged(format!(
+					"{} geometry or monitor layout changed",
+					self.name
+				)));
+			}
+		} else {
+			let geometry = self
+				.connection
+				.get_geometry(self.drawable)
+				.map_err(source)?
+				.reply()
+				.map_err(source)?;
+			let width = u32::from(geometry.width) & !1;
+			let height = u32::from(geometry.height) & !1;
+			if (width, height) != (self.width, self.height) {
+				return Err(Error::SourceChanged(format!(
+					"{} resized from {}x{} to {width}x{height}",
+					self.name, self.width, self.height
+				)));
+			}
+		}
 
 		let width = u16::try_from(self.width).map_err(|_| Error::Codec(anyhow::anyhow!("X11 width is too large")))?;
 		let height =
@@ -244,17 +314,67 @@ impl Capture {
 			.map_err(source)?
 			.reply()
 			.map_err(source)?;
-		let rgb = self.format.rgb(&image.data, self.width, self.height)?;
+		let mut rgb = self.format.rgb(&image.data, self.width, self.height)?;
+		if self.cursor
+			&& let Some(cursor) = self
+				.connection
+				.xfixes_get_cursor_image()
+				.ok()
+				.and_then(|cookie| cookie.reply().ok())
+		{
+			let (x, y) = self.origin()?;
+			blend_cursor(&mut rgb, self.width, self.height, x, y, &cursor);
+		}
 		Ok(Some(Surface::I420(I420::from_rgb(&rgb, self.width, self.height)?)))
+	}
+
+	fn origin(&self) -> Result<(i32, i32), Error> {
+		if self.drawable == self.root {
+			return Ok((self.x.into(), self.y.into()));
+		}
+		let translated = self
+			.connection
+			.translate_coordinates(self.drawable, self.root, self.x, self.y)
+			.map_err(source)?
+			.reply()
+			.map_err(source)?;
+		Ok((translated.dst_x.into(), translated.dst_y.into()))
 	}
 }
 
+struct DisplayTarget {
+	selector: Option<usize>,
+	index: usize,
+	monitor: Monitor,
+}
+
+impl DisplayTarget {
+	fn matches(&self, monitors: &[Monitor]) -> bool {
+		let Some(index) = select_monitor(monitors, self.selector) else {
+			return false;
+		};
+		index == self.index
+			&& monitors
+				.get(index)
+				.is_some_and(|monitor| self.monitor.same_region(monitor))
+	}
+}
+
+#[derive(Clone)]
 struct Monitor {
 	x: i16,
 	y: i16,
 	width: u32,
 	height: u32,
 	name: String,
+	primary: bool,
+}
+
+impl Monitor {
+	fn same_region(&self, other: &Self) -> bool {
+		(self.x, self.y, self.width, self.height, &self.name)
+			== (other.x, other.y, other.width, other.height, &other.name)
+	}
 }
 
 fn monitors(connection: &RustConnection, root: XWindow) -> Result<Vec<Monitor>, Error> {
@@ -275,6 +395,7 @@ fn monitors(connection: &RustConnection, root: XWindow) -> Result<Vec<Monitor>, 
 				width: monitor.width.into(),
 				height: monitor.height.into(),
 				name,
+				primary: monitor.primary,
 			});
 		}
 		if !result.is_empty() {
@@ -289,7 +410,81 @@ fn monitors(connection: &RustConnection, root: XWindow) -> Result<Vec<Monitor>, 
 		width: geometry.width.into(),
 		height: geometry.height.into(),
 		name: "X11 display".to_string(),
+		primary: true,
 	}])
+}
+
+fn select_monitor(monitors: &[Monitor], selector: Option<usize>) -> Option<usize> {
+	selector
+		.filter(|index| *index < monitors.len())
+		.or_else(|| {
+			selector
+				.is_none()
+				.then(|| monitors.iter().position(|monitor| monitor.primary))
+				.flatten()
+		})
+		.or_else(|| selector.is_none().then_some(0).filter(|_| !monitors.is_empty()))
+}
+
+fn client_windows(connection: &RustConnection, root: XWindow) -> Result<Vec<XWindow>, Error> {
+	let clients_atom = intern(connection, b"_NET_CLIENT_LIST")?;
+	let clients = connection
+		.get_property(false, root, clients_atom, AtomEnum::WINDOW, 0, u32::MAX)
+		.map_err(codec)?
+		.reply()
+		.map_err(codec)?
+		.value32()
+		.map(|windows| windows.collect::<Vec<_>>())
+		.unwrap_or_default();
+	if !clients.is_empty() {
+		return Ok(clients);
+	}
+
+	let mut windows = Vec::new();
+	let mut pending = connection
+		.query_tree(root)
+		.map_err(codec)?
+		.reply()
+		.map_err(codec)?
+		.children;
+	while let Some(window) = pending.pop() {
+		windows.push(window);
+		if let Ok(cookie) = connection.query_tree(window)
+			&& let Ok(tree) = cookie.reply()
+		{
+			pending.extend(tree.children);
+		}
+	}
+	Ok(windows)
+}
+
+fn blend_cursor(rgb: &mut [u8], width: u32, height: u32, origin_x: i32, origin_y: i32, cursor: &GetCursorImageReply) {
+	let cursor_x = i32::from(cursor.x) - i32::from(cursor.xhot);
+	let cursor_y = i32::from(cursor.y) - i32::from(cursor.yhot);
+	for (index, pixel) in cursor.cursor_image.iter().copied().enumerate() {
+		let x = cursor_x + (index % usize::from(cursor.width)) as i32 - origin_x;
+		let y = cursor_y + (index / usize::from(cursor.width)) as i32 - origin_y;
+		if x < 0 || y < 0 || x >= width as i32 || y >= height as i32 {
+			continue;
+		}
+		let alpha = (pixel >> 24) as u8;
+		if alpha == 0 {
+			continue;
+		}
+		let offset = (y as usize * width as usize + x as usize) * 3;
+		let source = [
+			((pixel >> 16) & 0xff) as u8,
+			((pixel >> 8) & 0xff) as u8,
+			(pixel & 0xff) as u8,
+		];
+		for (target, source) in rgb[offset..offset + 3].iter_mut().zip(source) {
+			*target = source.saturating_add(blend_background(*target, alpha));
+		}
+	}
+}
+
+fn blend_background(value: u8, alpha: u8) -> u8 {
+	((u16::from(value) * u16::from(255 - alpha) + 127) / 255) as u8
 }
 
 struct PixelFormat {
@@ -310,6 +505,12 @@ impl PixelFormat {
 			.flat_map(|depth| &depth.visuals)
 			.find(|visual| visual.visual_id == visual_id)
 			.ok_or_else(|| Error::Codec(anyhow::anyhow!("X11 root visual is missing")))?;
+		if visual.class != VisualClass::TRUE_COLOR {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"unsupported X11 visual class: {:?}",
+				visual.class
+			)));
+		}
 		let format = setup
 			.pixmap_formats
 			.iter()
@@ -327,7 +528,7 @@ impl PixelFormat {
 
 	fn rgb(&self, data: &[u8], width: u32, height: u32) -> Result<Vec<u8>, Error> {
 		let pixel_bytes = usize::from(self.bits_per_pixel.div_ceil(8));
-		if !(3..=4).contains(&pixel_bytes) {
+		if !(2..=4).contains(&pixel_bytes) {
 			return Err(Error::Codec(anyhow::anyhow!(
 				"unsupported X11 pixel depth: {} bits per pixel",
 				self.bits_per_pixel
@@ -388,13 +589,12 @@ fn connect() -> Result<(RustConnection, usize), Error> {
 	x11rb::connect(None).map_err(|error| Error::SourceUnavailable(format!("X11 display: {error}")))
 }
 
-fn parse_selector(selector: Option<&str>, prefix: &str) -> Result<usize, Error> {
+fn parse_selector(selector: &str, prefix: &str) -> Result<usize, Error> {
 	selector
-		.unwrap_or("0")
 		.strip_prefix(prefix)
-		.unwrap_or(selector.unwrap_or("0"))
+		.unwrap_or(selector)
 		.parse()
-		.map_err(|_| Error::SourceUnavailable(format!("invalid X11 selector {:?}", selector.unwrap_or("0"))))
+		.map_err(|_| Error::SourceUnavailable(format!("invalid X11 selector {selector:?}")))
 }
 
 fn intern(connection: &RustConnection, name: &[u8]) -> Result<u32, Error> {
@@ -421,4 +621,87 @@ fn codec(error: impl std::fmt::Display) -> Error {
 
 fn source(error: impl std::fmt::Display) -> Error {
 	Error::SourceUnavailable(format!("X11 source: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn monitor(primary: bool) -> Monitor {
+		Monitor {
+			x: 0,
+			y: 0,
+			width: 1920,
+			height: 1080,
+			name: String::new(),
+			primary,
+		}
+	}
+
+	#[test]
+	fn default_display_uses_primary_monitor() {
+		let monitors = [monitor(false), monitor(true), monitor(false)];
+		assert_eq!(select_monitor(&monitors, None), Some(1));
+		assert_eq!(select_monitor(&monitors, Some(0)), Some(0));
+	}
+
+	#[test]
+	fn display_target_detects_geometry_and_selection_changes() {
+		let initial = [monitor(true), monitor(false)];
+		let target = DisplayTarget {
+			selector: None,
+			index: 0,
+			monitor: initial[0].clone(),
+		};
+		assert!(target.matches(&initial));
+
+		let mut resized = initial.clone();
+		resized[0].width = 1280;
+		assert!(!target.matches(&resized));
+
+		let mut primary_changed = initial;
+		primary_changed[0].primary = false;
+		primary_changed[1].primary = true;
+		assert!(!target.matches(&primary_changed));
+	}
+
+	#[test]
+	fn xwayland_is_available_without_becoming_the_default() {
+		assert!(is_available(true, true));
+		assert!(!selects_x11(None, true));
+		assert!(selects_x11(Some("x11:0"), true));
+	}
+
+	#[test]
+	fn cursor_is_cropped_and_alpha_blended() {
+		let mut rgb = vec![100; 2 * 2 * 3];
+		let cursor = GetCursorImageReply {
+			x: 1,
+			y: 1,
+			width: 3,
+			height: 1,
+			xhot: 1,
+			yhot: 0,
+			cursor_image: vec![0, 0x8080_0000, 0xff00_00ff],
+			..Default::default()
+		};
+		blend_cursor(&mut rgb, 2, 2, 1, 0, &cursor);
+		assert_eq!(&rgb[..3], &[100; 3]);
+		assert_eq!(&rgb[6..9], &[178, 50, 50]);
+		assert_eq!(&rgb[9..12], &[0, 0, 255]);
+	}
+
+	#[test]
+	fn rgb_decodes_sixteen_bit_true_color() {
+		let format = PixelFormat {
+			byte_order: ImageOrder::LSB_FIRST,
+			bits_per_pixel: 16,
+			scanline_pad: 32,
+			red_mask: 0xf800,
+			green_mask: 0x07e0,
+			blue_mask: 0x001f,
+		};
+		let rgb = format.rgb(&[0x00, 0xf8, 0xe0, 0x07], 2, 1).unwrap();
+		assert_eq!(rgb, [255, 0, 0, 0, 255, 0]);
+	}
 }

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -420,6 +420,21 @@ fn capture_stopped<E: CatalogExt>(producer: &mut Producer<E>) -> Result<(), Erro
 	producer.discontinuity()
 }
 
+#[cfg(feature = "capture")]
+enum CaptureEvent<T> {
+	Value(T),
+	Changed(String),
+}
+
+#[cfg(feature = "capture")]
+fn capture_event<T>(result: Result<T, Error>) -> Result<CaptureEvent<T>, Error> {
+	match result {
+		Ok(value) => Ok(CaptureEvent::Value(value)),
+		Err(Error::SourceChanged(reason)) => Ok(CaptureEvent::Changed(reason)),
+		Err(err) => Err(err),
+	}
+}
+
 /// Async capture/encode loop. Opens the camera while at least one viewer is
 /// watching and releases it when the last one leaves.
 ///
@@ -464,7 +479,7 @@ async fn capture_loop<E: CatalogExt>(
 		// Force an IDR on the first frame of each (re)open so a viewer subscribing
 		// after an idle gap can start decoding immediately.
 		let mut force_keyframe = true;
-		tracing::info!(encoder = encoder.name(), device = camera.device(), "capturing");
+		tracing::info!(encoder = encoder.name(), device = camera.label(), "capturing");
 
 		// Rate control is per encoder: this one opened at the configured bitrate,
 		// so the policy's ceiling is that rate and the target starts there. A
@@ -475,7 +490,7 @@ async fn capture_loop<E: CatalogExt>(
 			.clone()
 			.map(|bandwidth| (bandwidth, Control::new(Policy::new(encoder_config.resolved_bitrate()))));
 
-		loop {
+		let changed = loop {
 			// Race the next frame against the last viewer leaving so we release the
 			// camera promptly when demand drops. `biased` checks demand first so an
 			// unwatched track stops before reading another frame.
@@ -486,7 +501,7 @@ async fn capture_loop<E: CatalogExt>(
 						log_track_ended(err);
 						return Ok(());
 					}
-					break; // no viewers: release the camera, then wait for one
+					break None; // no viewers: release the camera, then wait for one
 				}
 				// Retune between frames rather than mid-encode, and only when
 				// the policy says the target actually moved.
@@ -494,10 +509,14 @@ async fn capture_loop<E: CatalogExt>(
 					apply_estimate(&mut encoder, &mut rate, estimate).await;
 					continue;
 				}
-				frame = camera.read() => frame?,
+				frame = camera.read() => capture_event(frame)?,
 			};
 
-			let Some(surface) = frame else { break }; // device stopped producing frames
+			let surface = match frame {
+				CaptureEvent::Value(Some(surface)) => surface,
+				CaptureEvent::Value(None) => break None,
+				CaptureEvent::Changed(reason) => break Some(reason),
+			};
 
 			// Stamp at capture, so a backend that buffers still publishes each
 			// access unit at the time the picture was grabbed.
@@ -507,13 +526,17 @@ async fn capture_loop<E: CatalogExt>(
 				force_keyframe = false;
 			}
 			producer.publish(&encoder.encode(frame).await?)?;
-		}
+		};
 
 		// Drop the camera (LED off) and encoder before waiting for the next viewer.
 		drop(camera);
 		drop(encoder);
 		capture_stopped(producer)?;
-		tracing::info!("no viewers: released camera");
+		if let Some(reason) = changed {
+			tracing::info!(%reason, "capture source changed; reopening");
+		} else {
+			tracing::info!("capture stopped; released source");
+		}
 	}
 }
 
@@ -523,6 +546,19 @@ mod tests {
 
 	use super::*;
 	use crate::encode::{Config, Encoder};
+
+	#[cfg(feature = "capture")]
+	#[test]
+	fn only_source_changes_reopen_capture() {
+		assert!(matches!(
+			capture_event::<()>(Err(Error::SourceChanged("resized".to_string()))),
+			Ok(CaptureEvent::Changed(reason)) if reason == "resized"
+		));
+		assert!(matches!(
+			capture_event::<()>(Err(Error::SourceUnavailable("closed".to_string()))),
+			Err(Error::SourceUnavailable(reason)) if reason == "closed"
+		));
+	}
 
 	/// Encode a handful of synthetic frames for `codec` and publish them through a real
 	/// [`Producer`], returning the catalog rendition's track name and config.
@@ -614,6 +650,31 @@ mod tests {
 		producer.finish().unwrap();
 
 		assert_eq!(collect_groups(consumer).await, vec![1, 0, 1]);
+	}
+
+	#[tokio::test]
+	async fn source_resize_updates_the_published_rendition() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut initial = Config::new(320, 240, 30);
+		initial.kind = encoder::Kind::Software;
+		let mut producer = Producer::new(broadcast, catalog.clone(), initial.probe().await.unwrap()).unwrap();
+
+		for (timestamp, config) in [(0, initial), (33_333, Config::new(640, 360, 30))] {
+			let mut config = config;
+			config.kind = encoder::Kind::Software;
+			let mut encoder = Encoder::new(&config).unwrap();
+			encoder.keyframe();
+			let rgba = vec![0x80u8; usize::try_from(config.width * config.height * 4).unwrap()];
+			let surface = crate::Surface::rgba(&rgba, crate::Size::new(config.width, config.height)).unwrap();
+			let frame = Frame::new(surface, Timestamp::from_micros(timestamp).unwrap());
+			producer.publish(&encoder.encode(&frame).unwrap()).unwrap();
+			capture_stopped(&mut producer).unwrap();
+		}
+
+		let (_, rendition) = rendition(&catalog).expect("the resized rendition should be published");
+		assert_eq!(rendition.coded_width, Some(640));
+		assert_eq!(rendition.coded_height, Some(360));
 	}
 
 	/// Regression: a caller's container selection has to survive the config -> hint conversion.

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -494,7 +494,7 @@ async fn capture_loop<E: CatalogExt>(
 					apply_estimate(&mut encoder, &mut rate, estimate).await;
 					continue;
 				}
-				frame = camera.read() => frame,
+				frame = camera.read() => frame?,
 			};
 
 			let Some(surface) = frame else { break }; // device stopped producing frames

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -420,21 +420,6 @@ fn capture_stopped<E: CatalogExt>(producer: &mut Producer<E>) -> Result<(), Erro
 	producer.discontinuity()
 }
 
-#[cfg(feature = "capture")]
-enum CaptureEvent<T> {
-	Value(T),
-	Changed(String),
-}
-
-#[cfg(feature = "capture")]
-fn capture_event<T>(result: Result<T, Error>) -> Result<CaptureEvent<T>, Error> {
-	match result {
-		Ok(value) => Ok(CaptureEvent::Value(value)),
-		Err(Error::SourceChanged(reason)) => Ok(CaptureEvent::Changed(reason)),
-		Err(err) => Err(err),
-	}
-}
-
 /// Async capture/encode loop. Opens the camera while at least one viewer is
 /// watching and releases it when the last one leaves.
 ///
@@ -490,7 +475,7 @@ async fn capture_loop<E: CatalogExt>(
 			.clone()
 			.map(|bandwidth| (bandwidth, Control::new(Policy::new(encoder_config.resolved_bitrate()))));
 
-		let changed = loop {
+		loop {
 			// Race the next frame against the last viewer leaving so we release the
 			// camera promptly when demand drops. `biased` checks demand first so an
 			// unwatched track stops before reading another frame.
@@ -501,7 +486,7 @@ async fn capture_loop<E: CatalogExt>(
 						log_track_ended(err);
 						return Ok(());
 					}
-					break None; // no viewers: release the camera, then wait for one
+					break; // no viewers: release the camera, then wait for one
 				}
 				// Retune between frames rather than mid-encode, and only when
 				// the policy says the target actually moved.
@@ -509,14 +494,12 @@ async fn capture_loop<E: CatalogExt>(
 					apply_estimate(&mut encoder, &mut rate, estimate).await;
 					continue;
 				}
-				frame = camera.read() => capture_event(frame)?,
+				// A read error is terminal for this selection (the source is gone
+				// or was refused); `None` just ends the stream, so reopen below.
+				frame = camera.read() => frame?,
 			};
 
-			let surface = match frame {
-				CaptureEvent::Value(Some(surface)) => surface,
-				CaptureEvent::Value(None) => break None,
-				CaptureEvent::Changed(reason) => break Some(reason),
-			};
+			let Some(surface) = frame else { break };
 
 			// Stamp at capture, so a backend that buffers still publishes each
 			// access unit at the time the picture was grabbed.
@@ -526,17 +509,13 @@ async fn capture_loop<E: CatalogExt>(
 				force_keyframe = false;
 			}
 			producer.publish(&encoder.encode(frame).await?)?;
-		};
+		}
 
 		// Drop the camera (LED off) and encoder before waiting for the next viewer.
 		drop(camera);
 		drop(encoder);
 		capture_stopped(producer)?;
-		if let Some(reason) = changed {
-			tracing::info!(%reason, "capture source changed; reopening");
-		} else {
-			tracing::info!("capture stopped; released source");
-		}
+		tracing::info!("capture stopped; released source");
 	}
 }
 
@@ -546,19 +525,6 @@ mod tests {
 
 	use super::*;
 	use crate::encode::{Config, Encoder};
-
-	#[cfg(feature = "capture")]
-	#[test]
-	fn only_source_changes_reopen_capture() {
-		assert!(matches!(
-			capture_event::<()>(Err(Error::SourceChanged("resized".to_string()))),
-			Ok(CaptureEvent::Changed(reason)) if reason == "resized"
-		));
-		assert!(matches!(
-			capture_event::<()>(Err(Error::SourceUnavailable("closed".to_string()))),
-			Err(Error::SourceUnavailable(reason)) if reason == "closed"
-		));
-	}
 
 	/// Encode a handful of synthetic frames for `codec` and publish them through a real
 	/// [`Producer`], returning the catalog rendition's track name and config.

--- a/rs/moq-video/src/error.rs
+++ b/rs/moq-video/src/error.rs
@@ -29,9 +29,12 @@ pub enum Error {
 	#[error("capture source unavailable: {0}")]
 	SourceUnavailable(String),
 
-	/// The configured framerate was zero (would divide by zero / produce a
-	/// degenerate codec time base).
-	#[error("invalid framerate: {0} (must be non-zero)")]
+	/// The capture source changed geometry and must be reopened.
+	#[error("capture source changed: {0}")]
+	SourceChanged(String),
+
+	/// The configured framerate is outside the supported range.
+	#[error("invalid framerate: {0} (must be between 1 and 1,000,000)")]
 	InvalidFramerate(u32),
 
 	/// This encoder can't change its bitrate once open, so it can't follow a

--- a/rs/moq-video/src/error.rs
+++ b/rs/moq-video/src/error.rs
@@ -21,6 +21,14 @@ pub enum Error {
 	#[error("not supported on this platform: {0}")]
 	Unsupported(String),
 
+	/// The operating system denied access to a capture source.
+	#[error("capture permission denied: {0}")]
+	PermissionDenied(String),
+
+	/// A requested capture source does not exist or disappeared while capturing.
+	#[error("capture source unavailable: {0}")]
+	SourceUnavailable(String),
+
 	/// The configured framerate was zero (would divide by zero / produce a
 	/// degenerate codec time base).
 	#[error("invalid framerate: {0} (must be non-zero)")]

--- a/rs/moq-video/src/error.rs
+++ b/rs/moq-video/src/error.rs
@@ -29,10 +29,6 @@ pub enum Error {
 	#[error("capture source unavailable: {0}")]
 	SourceUnavailable(String),
 
-	/// The capture source changed geometry and must be reopened.
-	#[error("capture source changed: {0}")]
-	SourceChanged(String),
-
 	/// The configured framerate is outside the supported range.
 	#[error("invalid framerate: {0} (must be between 1 and 1,000,000)")]
 	InvalidFramerate(u32),

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -15,8 +15,11 @@
 //!
 //! - `capture` describes a frame source and grabs frames per platform:
 //!   AVFoundation/ScreenCaptureKit on macOS, native V4L2 on Linux, native Media
-//!   Foundation (camera) and DXGI Desktop Duplication (screen) on Windows. It
-//!   requires the default-on `capture` feature.
+//!   Foundation (camera), DXGI Desktop Duplication (screen), and GDI (window) on
+//!   Windows, plus portal/PipeWire on Wayland and X11 capture on Linux. Use
+//!   [`capture::open`] for an embeddable raw-frame stream or
+//!   [`encode::publish_capture`] for turnkey publication. It requires the
+//!   default-on `capture` feature.
 //! - [`encode`] encodes frames with a native backend and publishes them through
 //!   the matching `moq_mux::codec` importer, which handles catalog registration
 //!   and framing. The codec is chosen via [`encode::Codec`]: H.264 (openh264 /
@@ -48,10 +51,10 @@
 //! ## API stability
 //!
 //! The public API is codec-agnostic: no public type, signature, or error
-//! variant names a backend (openh264 / VideoToolbox / NVENC / NVDEC) or a
-//! capture implementation. [`encode::Encoder`] takes a [`Frame`],
+//! variant names a backend (openh264 / VideoToolbox / NVENC / NVDEC) or a codec
+//! implementation. [`encode::Encoder`] takes a [`Frame`],
 //! [`decode::Consumer`] returns one (CPU I420 on demand, GPU-resident when
-//! hardware decoded), and the camera capture path stays internal. So swapping or bumping any backend crate is not a breaking change
+//! hardware decoded), and [`capture::Stream`] returns a [`Surface`]. So swapping or bumping any backend crate is not a breaking change
 //! for consumers. Config structs are `#[non_exhaustive]`: build them via
 //! `default()`/`new()` and set fields, so new options stay additive.
 //!

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -54,9 +54,10 @@
 //! variant names a backend (openh264 / VideoToolbox / NVENC / NVDEC) or a codec
 //! implementation. [`encode::Encoder`] takes a [`Frame`],
 //! [`decode::Consumer`] returns one (CPU I420 on demand, GPU-resident when
-//! hardware decoded), and [`capture::Stream`] returns a [`Surface`]. So swapping or bumping any backend crate is not a breaking change
-//! for consumers. Config structs are `#[non_exhaustive]`: build them via
-//! `default()`/`new()` and set fields, so new options stay additive.
+//! hardware decoded), and [`capture::Stream`] returns a [`Surface`]. So swapping
+//! or bumping any backend crate is not a breaking change for consumers. Config
+//! structs are `#[non_exhaustive]`: build them via `default()`/`new()` and set
+//! fields, so new options stay additive.
 //!
 //! The one deliberate exception is [`Surface`], the enum behind every frame.
 //! Its variants name platform representations (`CVPixelBuffer`, Direct3D11,


### PR DESCRIPTION
## Summary

- add native display and window selection across macOS, Windows, Wayland/PipeWire, and X11
- propagate permission denial, source removal, and source geometry changes as typed capture errors
- make capture buffering latest-frame-wins so slow encoders do not accumulate stale frames
- expose `capture::open` and `capture::Stream` for embedded applications

## Public API changes

- add `capture::open(&capture::Config)`
- add public `capture::Stream` accessors, including the human-readable `label()`, and frame reads
- add `Error::PermissionDenied` and `Error::SourceUnavailable`

`Stream::read` has a two-state contract: `Ok(None)` means the source stopped for
a benign reason (a resize, a compositor format renegotiation, a device going
idle) and reopening is expected to work, while an error is terminal for that
selection.

These additions target `main`; `moq-video` remains a 0.0.x package.

## Review fixes

- bound Windows target-thread rendering to 50 ms with `SendMessageTimeoutW`, retain a `BitBlt` fallback, and disable later `WM_PRINT` attempts after a timeout
- restrict the Windows `BitBlt` fallback to `SRCCOPY` so layered overlays are not copied into selected-window frames
- composite the system cursor for Windows window capture when requested
- revalidate Windows window dimensions before each frame and report a typed source change rather than copying with stale geometry
- pin Windows window identity with a per-capture property token checked before and after each snapshot
- keep Windows window enumeration and capture under a scoped per-monitor DPI context so geometry and GDI buffers use physical pixels
- deselect the GDI bitmap before calling `GetDIBits`
- report the owning process image rather than the Win32 class as `Window::app`
- preserve typed permission denial when rebuilding Desktop Duplication
- enumerate X11 windows through `_NET_CLIENT_LIST`, with recursive tree traversal when EWMH data is unavailable
- expose XWayland windows and monitors without changing the Wayland portal as the unqualified display default
- composite the XFixes cursor for X11 capture when requested
- preserve the absent display selector and resolve it through RandR's primary monitor flag
- re-resolve X11 monitor identity and geometry before each frame so RandR layout changes report a typed source change
- use each X11 window's own depth and visual when decoding pixels
- decode 16-bit X11 TrueColor visuals through their component masks and reject visual classes that require colormap handling
- report X11 window geometry changes through the typed source-change path
- reopen capture and encoding only for `SourceChanged`, publish a discontinuity, force the first new frame to be a keyframe, and update catalog dimensions
- validate capture frame rates centrally so no backend can construct a zero-duration interval
- document native X11 display selection separately from the Wayland portal flow
- preserve fatal PipeWire callback errors so `Stream::read` receives the typed failure
- update the ignored PipeWire portal test for the new fallible `Stream::read` API

The Windows shutdown issue came from synchronously asking an arbitrary target UI thread to render, then joining that pump thread during `Stream` drop. The bounded request removes that unbounded join path.

## Takeover changes

Taken over by Claude. Two commits on top:

- **Drop `Error::SourceChanged`.** It put a control-flow signal in the error
  type, and the consumer had to reclassify it back out: `capture_loop` carried a
  `CaptureEvent<T>` enum and a `capture_event()` adapter whose two arms did
  exactly the same thing, differing only in a log line. PipeWire never grew the
  variant, so a Wayland renegotiation already ended with `Ok(None)` and behaved
  correctly. A geometry change now ends the stream instead. That is one fewer
  public error variant, no consumer-side adapter, and PipeWire consistent by
  construction. `Stream::width`/`height` also stay valid for the whole stream.
- **Retain a wakeup permit when the frame channel ends.** `recv` builds its
  `Notified` before taking the lock and tokio registers the waiter only on first
  poll, so `notify_waiters` in `close`/`fail` could wake nobody and store
  nothing, parking the consumer forever. Both terminal paths now use
  `notify_one`, as `push` already did. Latent in `close` before this PR; `fail`
  ending a live stream from the producer thread is what made it reachable.
- Three X11 papercuts: an out-of-range selector reported `no X11 display at
  index Some(3)`, `Window::app` rendered `WM_CLASS` as `"navigator Firefox"`
  rather than the class macOS and Windows report, and a dead `let _ =
  attributes;` binding.

### Not verified

**None of the 479 new lines in `capture/window.rs` has been compiled by
anything.** PR CI is Linux-only and `just rs windows` must run on a Windows
host, so the Windows backend compiles for the first time in a tag-triggered
release build unless someone runs it by hand. The X11 backend compiles on CI
but has not been run against a real X session.

### Follow-ups

Filed as quests rather than fixed here, since three of the four need a Windows
or X11 host to verify:

- Windows window capture returns black for GPU-composited windows. `BitBlt` plus
  a cross-process `WM_PRINT` reaches nothing rendered through DirectComposition,
  so `--window` is a black rectangle for Chrome, Edge, Electron, and UWP.
  `PrintWindow(hwnd, hdc, PW_RENDERFULLCONTENT)` is the supported API; WGC is the
  longer-term path. Also covers `SetPropW` on a foreign window being UIPI-blocked
  for elevated windows, and the timed-out `WM_PRINT` GDI hazard Codex raised.
- A minimized or resizing window ends capture instead of riding it out.
  Minimizing on Windows makes `GetWindowRect` report an off-screen rect, so the
  reopen fails with "no capturable area" and the broadcast dies; a drag-resize
  rebuilds the encoder once per mouse-move.
- Both new backends rebuild a full frame buffer every tick (a DC, a bitmap, and
  a W*H*4 `Vec` on Windows; a W*H*3 `Vec` filled byte-by-byte on X11).
- X11 capture copies the framebuffer over the socket every frame and re-polls
  RandR to notice layout changes, where MIT-SHM and `SCREEN_CHANGE_NOTIFY` are
  the intended mechanisms.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test` (3,357 Rust tests passed, 1 skipped; all JavaScript tests passed)
- targeted `moq-video` tests with `pipewire` enabled (100 passed, 1 ignored; doc tests passed)
- targeted `moq-video` Clippy and default-feature unit tests (83 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

Live Windows, X11, and Wayland capture was not available on the local validation host.

(written by GPT-5.6 Sol, amended by Claude Opus 5)
