### PR TITLE
fix(signals): close the effect before running its cleanups

### DIFF
--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -395,6 +395,33 @@ describe("Effect", () => {
 		}
 	});
 
+	test("cancelling a nested run during teardown does not skip the next cleanup", async () => {
+		// The disposer `run` hands back removes itself from the parent. Doing that by splicing
+		// shifts every later entry down, stepping the drain's cursor over a cleanup that has not
+		// run yet, so it never fires and leaks whatever it owned.
+		const sig = new Signal(0);
+		const ran: string[] = [];
+		const effect = new Effect((inner) => {
+			inner.get(sig);
+			const dispose = inner.run(() => {});
+			inner.cleanup(() => {
+				ran.push("middle");
+				dispose();
+			});
+			inner.cleanup(() => ran.push("last"));
+		});
+
+		try {
+			await settle();
+			sig.set(1);
+			await settle();
+
+			expect(ran).toEqual(["middle", "last"]);
+		} finally {
+			effect.close();
+		}
+	});
+
 	test("cleanup from a spawn that outlived its run fires immediately", async () => {
 		// A rerun drains the dispose list before it awaits in-flight spawns, so a task resuming
 		// after that point used to register teardown against the NEXT run: the resource it owned

--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -309,24 +309,90 @@ describe("Effect", () => {
 		expect(count).toBe(100_001);
 	});
 
-	test("a throwing cleanup does not strand later teardown on a dead queue", async () => {
-		// The drain list is only valid while close() is draining it. Leaving it set after a throw
-		// would make every later cleanup() append to a list nothing reads, silently dropping it.
+	test("a throwing cleanup does not abandon the rest of teardown", async () => {
+		// Teardown that stops half way leaks whatever the remaining callbacks owned, so the drain
+		// reports a failure and keeps going.
+		const error = spyOn(console, "error").mockImplementation(() => {});
 		const effect = new Effect();
+		const ran: string[] = [];
 		let late = false;
 
-		expect(() => {
+		try {
 			effect.cleanup(() => {
 				throw new Error("boom");
 			});
+			effect.cleanup(() => ran.push("after"));
 			effect.close();
-		}).toThrow("boom");
 
-		effect.cleanup(() => {
-			late = true;
+			expect(ran).toEqual(["after"]);
+			expect(error).toHaveBeenCalled();
+
+			// And the effect is left properly closed, not mid-drain.
+			effect.cleanup(() => {
+				late = true;
+			});
+			expect(late).toBe(true);
+		} finally {
+			error.mockRestore();
+		}
+	});
+
+	test("closing from a rerun cleanup runs each teardown once", async () => {
+		// `#run` and `close` share one drain, so a cleanup that closes the effect hands off at the
+		// cursor rather than starting a second pass over callbacks that already ran.
+		const sig = new Signal(0);
+		const ran: string[] = [];
+		const effect = new Effect((inner) => {
+			inner.get(sig);
+			inner.cleanup(() => {
+				ran.push("a");
+				inner.close();
+			});
+			inner.cleanup(() => ran.push("b"));
 		});
 
-		expect(late).toBe(true);
+		try {
+			await settle();
+			sig.set(1);
+			await settle();
+
+			expect(ran).toEqual(["a", "b"]);
+
+			// Closed, not left mid-drain: teardown registered now runs immediately.
+			let late = false;
+			effect.cleanup(() => {
+				late = true;
+			});
+			expect(late).toBe(true);
+		} finally {
+			effect.close();
+		}
+	});
+
+	test("a deep cleanup cascade during a rerun drains without recursing", async () => {
+		// The rerun path shares the drain, so a chain registered during its teardown stays flat.
+		const sig = new Signal(0);
+		let count = 0;
+		const effect = new Effect((inner) => {
+			inner.get(sig);
+			inner.cleanup(() => {
+				const chain = (depth: number) => {
+					count++;
+					if (depth > 0) inner.cleanup(() => chain(depth - 1));
+				};
+				chain(100_000);
+			});
+		});
+
+		try {
+			await settle();
+			sig.set(1);
+			await settle();
+
+			expect(count).toBe(100_001);
+		} finally {
+			effect.close();
+		}
 	});
 
 	test("cleanup from a spawn that outlived its run fires immediately", async () => {

--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -309,6 +309,26 @@ describe("Effect", () => {
 		expect(count).toBe(100_001);
 	});
 
+	test("a throwing cleanup does not strand later teardown on a dead queue", async () => {
+		// The drain list is only valid while close() is draining it. Leaving it set after a throw
+		// would make every later cleanup() append to a list nothing reads, silently dropping it.
+		const effect = new Effect();
+		let late = false;
+
+		expect(() => {
+			effect.cleanup(() => {
+				throw new Error("boom");
+			});
+			effect.close();
+		}).toThrow("boom");
+
+		effect.cleanup(() => {
+			late = true;
+		});
+
+		expect(late).toBe(true);
+	});
+
 	test("cleanup from a spawn that outlived its run fires immediately", async () => {
 		// A rerun drains the dispose list before it awaits in-flight spawns, so a task resuming
 		// after that point used to register teardown against the NEXT run: the resource it owned

--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -245,6 +245,52 @@ describe("Effect", () => {
 		}
 	});
 
+	test("a cleanup that spawns during close cannot start work", async () => {
+		// close() used to run the cleanups while #dispose was still defined, so a cleanup calling
+		// back into the effect passed every guard. The task then outlived the close that cleared
+		// #async, with no rerun left to drain it.
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const effect = new Effect();
+		let started = false;
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		try {
+			effect.cleanup(() => {
+				effect.spawn(async () => {
+					started = true;
+					await gate;
+				});
+			});
+
+			effect.close();
+			await settle();
+
+			expect(started).toBe(false);
+		} finally {
+			release();
+			warn.mockRestore();
+		}
+	});
+
+	test("a cleanup registered during close still runs", async () => {
+		// The closed guard makes `cleanup` run its callback immediately rather than appending to
+		// a list nothing will drain, so teardown that cascades still completes.
+		const effect = new Effect();
+		const order: string[] = [];
+
+		effect.cleanup(() => {
+			order.push("outer");
+			effect.cleanup(() => order.push("inner"));
+		});
+
+		effect.close();
+
+		expect(order).toEqual(["outer", "inner"]);
+	});
+
 	test("cleanup from a spawn that outlived its run fires immediately", async () => {
 		// A rerun drains the dispose list before it awaits in-flight spawns, so a task resuming
 		// after that point used to register teardown against the NEXT run: the resource it owned

--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -276,8 +276,8 @@ describe("Effect", () => {
 	});
 
 	test("a cleanup registered during close still runs", async () => {
-		// The closed guard makes `cleanup` run its callback immediately rather than appending to
-		// a list nothing will drain, so teardown that cascades still completes.
+		// Teardown that cascades still completes: `cleanup` appends onto the list close() is
+		// draining rather than dropping it on the floor.
 		const effect = new Effect();
 		const order: string[] = [];
 
@@ -289,6 +289,24 @@ describe("Effect", () => {
 		effect.close();
 
 		expect(order).toEqual(["outer", "inner"]);
+	});
+
+	test("a deep cleanup cascade during close drains without recursing", async () => {
+		// close() drains its list by index, so a chain of any depth stays flat. Running each
+		// cascading cleanup nested inside its parent overflows the stack around 19k and abandons
+		// every cleanup after it.
+		const effect = new Effect();
+		let count = 0;
+
+		const chain = (depth: number) => {
+			count++;
+			if (depth > 0) effect.cleanup(() => chain(depth - 1));
+		};
+
+		effect.cleanup(() => chain(100_000));
+		effect.close();
+
+		expect(count).toBe(100_001);
 	});
 
 	test("cleanup from a spawn that outlived its run fires immediately", async () => {

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -847,9 +847,13 @@ export class Effect {
 		this.#abort.abort();
 
 		// Indexed, not `for...of`: `cleanup` appends cascading teardown onto this same list, and
-		// draining it here keeps a chain of any depth flat.
-		for (let i = 0; i < dispose.length; i++) dispose[i]();
-		this.#closing = undefined;
+		// draining it here keeps a chain of any depth flat. Clear `#closing` even if a callback
+		// throws, or later `cleanup` calls would queue onto a list nothing is draining any more.
+		try {
+			for (let i = 0; i < dispose.length; i++) dispose[i]();
+		} finally {
+			this.#closing = undefined;
+		}
 
 		for (const signal of this.#unwatch) signal();
 		this.#unwatch.length = 0;

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -371,9 +371,11 @@ export class Effect {
 	#fn?: (effect: Effect) => void;
 	#dispose?: Dispose[] = [];
 
-	// The list `close` is draining, while it is running. Cascading teardown is appended here so it
-	// drains iteratively instead of nesting inside the callback that registered it.
-	#closing?: Dispose[];
+	// The teardown list a drain is walking, and how far it has got. Shared by the rerun and close
+	// paths so a `close` landing inside a rerun's drain continues that pass instead of starting a
+	// second one over callbacks that already ran. Set only while a drain is running.
+	#draining?: Dispose[];
+	#drained = 0;
 	#unwatch: Dispose[] = [];
 	#async: Promise<void>[] = [];
 
@@ -437,8 +439,13 @@ export class Effect {
 		this.#unwatch.length = 0;
 
 		// Run the cleanup functions for the previous run.
-		for (const fn of this.#dispose) fn();
-		this.#dispose.length = 0;
+		const dispose = this.#dispose;
+		this.#drain(dispose);
+
+		// A cleanup may have closed the effect, which drained the rest of the list and finished
+		// teardown already. There is no next run to open.
+		if (this.#dispose === undefined) return;
+		dispose.length = 0;
 
 		// Wait for every task this run spawned. Opening the next run while one is still in flight
 		// would hand that task's cleanup registrations, and its `abort` signal, to a run it never
@@ -812,13 +819,41 @@ export class Effect {
 	 * {@link spawn} task resuming after a rerun or close sees. Registering teardown is
 	 * therefore enough to own a resource, with no staleness check needed first.
 	 */
+	/**
+	 * Run every callback in `list` exactly once, including ones registered while draining.
+	 *
+	 * Iterative, so a cascade of any depth stays flat rather than nesting a stack frame per link.
+	 * Re-entrant: a `close` from inside a rerun's teardown resumes this pass at the cursor instead
+	 * of replaying it. A callback that throws is reported and the rest still run, since teardown
+	 * that stops half way leaks whatever the remaining callbacks owned.
+	 */
+	#drain(list: Dispose[]): void {
+		const owner = this.#draining !== list;
+		if (owner) {
+			this.#draining = list;
+			this.#drained = 0;
+		}
+
+		try {
+			while (this.#drained < list.length) {
+				const fn = list[this.#drained++];
+				try {
+					fn();
+				} catch (error) {
+					console.error("cleanup error", error, this.#stack);
+				}
+			}
+		} finally {
+			if (owner) this.#draining = undefined;
+		}
+	}
+
 	cleanup(fn: Dispose): void {
 		if (this.#dispose === undefined || this.#stale) {
-			// Teardown that cascades goes on the queue `close` is draining rather than running
-			// nested inside its parent, which would turn a long chain into a stack overflow and
-			// abandon the cleanups after it.
-			if (this.#closing !== undefined) {
-				this.#closing.push(fn);
+			// Teardown that cascades joins the drain in progress rather than running nested inside
+			// the callback that registered it, which would turn a long chain into a stack overflow.
+			if (this.#draining !== undefined) {
+				this.#draining.push(fn);
 				return;
 			}
 
@@ -840,20 +875,12 @@ export class Effect {
 		// hit the closed guard: otherwise `spawn`/`timer`/`animate` register work against a list
 		// this call is about to discard, and the task keeps running with nothing tracking it.
 		this.#dispose = undefined;
-		this.#closing = dispose;
 
 		this.#closed.resolve();
 		this.#stopped.resolve();
 		this.#abort.abort();
 
-		// Indexed, not `for...of`: `cleanup` appends cascading teardown onto this same list, and
-		// draining it here keeps a chain of any depth flat. Clear `#closing` even if a callback
-		// throws, or later `cleanup` calls would queue onto a list nothing is draining any more.
-		try {
-			for (let i = 0; i < dispose.length; i++) dispose[i]();
-		} finally {
-			this.#closing = undefined;
-		}
+		this.#drain(dispose);
 
 		for (const signal of this.#unwatch) signal();
 		this.#unwatch.length = 0;

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -370,6 +370,10 @@ export class Effect {
 
 	#fn?: (effect: Effect) => void;
 	#dispose?: Dispose[] = [];
+
+	// The list `close` is draining, while it is running. Cascading teardown is appended here so it
+	// drains iteratively instead of nesting inside the callback that registered it.
+	#closing?: Dispose[];
 	#unwatch: Dispose[] = [];
 	#async: Promise<void>[] = [];
 
@@ -810,6 +814,14 @@ export class Effect {
 	 */
 	cleanup(fn: Dispose): void {
 		if (this.#dispose === undefined || this.#stale) {
+			// Teardown that cascades goes on the queue `close` is draining rather than running
+			// nested inside its parent, which would turn a long chain into a stack overflow and
+			// abandon the cleanups after it.
+			if (this.#closing !== undefined) {
+				this.#closing.push(fn);
+				return;
+			}
+
 			fn();
 			return;
 		}
@@ -827,14 +839,17 @@ export class Effect {
 		// Mark closed before running teardown. A cleanup that calls back into this effect has to
 		// hit the closed guard: otherwise `spawn`/`timer`/`animate` register work against a list
 		// this call is about to discard, and the task keeps running with nothing tracking it.
-		// `cleanup` itself still works, running immediately rather than appending.
 		this.#dispose = undefined;
+		this.#closing = dispose;
 
 		this.#closed.resolve();
 		this.#stopped.resolve();
 		this.#abort.abort();
 
-		for (const fn of dispose) fn();
+		// Indexed, not `for...of`: `cleanup` appends cascading teardown onto this same list, and
+		// draining it here keeps a chain of any depth flat.
+		for (let i = 0; i < dispose.length; i++) dispose[i]();
+		this.#closing = undefined;
 
 		for (const signal of this.#unwatch) signal();
 		this.#unwatch.length = 0;

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -819,16 +819,22 @@ export class Effect {
 
 	/** Stops the effect permanently, running all cleanup and unsubscribing from every signal. */
 	close(): void {
-		if (this.#dispose === undefined) {
+		const dispose = this.#dispose;
+		if (dispose === undefined) {
 			return;
 		}
+
+		// Mark closed before running teardown. A cleanup that calls back into this effect has to
+		// hit the closed guard: otherwise `spawn`/`timer`/`animate` register work against a list
+		// this call is about to discard, and the task keeps running with nothing tracking it.
+		// `cleanup` itself still works, running immediately rather than appending.
+		this.#dispose = undefined;
 
 		this.#closed.resolve();
 		this.#stopped.resolve();
 		this.#abort.abort();
 
-		for (const fn of this.#dispose) fn();
-		this.#dispose = undefined;
+		for (const fn of dispose) fn();
 
 		for (const signal of this.#unwatch) signal();
 		this.#unwatch.length = 0;

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -8,6 +8,9 @@
 /** Cancels a subscription, effect, or other registration when called. */
 export type Dispose = () => void;
 
+/** Placeholder for a teardown slot that was cancelled while it was being drained. */
+const noop: Dispose = () => {};
+
 type Subscriber<T> = (value: T) => void;
 
 // @ts-ignore - Some environments don't recognize import.meta.env
@@ -683,10 +686,17 @@ export class Effect {
 
 		return () => {
 			effect.close();
+
 			// Drop our disposer from the parent so repeated run()/dispose() cycles don't pile up.
 			const disposers = this.#dispose;
 			const index = disposers?.indexOf(dispose) ?? -1;
-			if (index !== -1) disposers?.splice(index, 1);
+			if (disposers === undefined || index === -1) return;
+
+			// Removing shifts every later entry down, which would step an active drain's cursor
+			// straight over a cleanup that has not run yet. Blank the slot while one is running
+			// and let the drain skip it; the list is cleared when that drain finishes anyway.
+			if (this.#draining === disposers) disposers[index] = noop;
+			else disposers.splice(index, 1);
 		};
 	}
 


### PR DESCRIPTION
Closes #3246, found by Codex while reviewing [#3234](https://github.com/moq-dev/moq/pull/3234) and confirmed pre-existing on `main`.

> [!NOTE]
> Two follow-up findings from review are filed separately rather than fixed here. See **Known gaps** below.

## Root cause

`close()` ran the cleanup callbacks while `#dispose` was still defined:

```ts
for (const fn of this.#dispose) fn();   // <-- still defined
this.#dispose = undefined;
...
this.#async.length = 0;
```

So a cleanup that called back into its own effect passed every guard. A `spawn` from a cleanup started its task and pushed the promise onto `#async`, which `close()` then emptied, leaving the task running with nothing tracking it and no rerun left to drain it. The same window let `timer`, `timeout`, `animate`, `interval`, and `set` register work that the rest of `close()` immediately discarded.

The fix marks the effect closed before running teardown, so those guards fire.

## Keeping cascading teardown flat

Marking closed first makes `cleanup` take its "already closed" branch, which runs the callback immediately. Done naively that turns a cascading chain into recursion: the previous `for...of` over the live list drained those iteratively, and a 100k chain overflowed the stack around 19k deep, aborting `close()` before the remaining cleanups and signal unsubscriptions ran.

So `close()` hands its list to `#closing` and drains it by index, and `cleanup` appends there instead of recursing. `#closing` is cleared in a `finally`, since leaving it set after a throw would make every later `cleanup` queue onto a list nothing reads.

## Known gaps

Both are pre-existing and both want the teardown redesign in #3257, not a patch here:

- **`close()` from a *rerun* cleanup double-runs teardown.** `rerun` and `close` each drain `#dispose` with their own loop. On `main` this is an infinite loop (logs `"a"` thousands of times, hangs); on this branch it is bounded but still wrong (`["a","a","b","b"]` then a `TypeError`). This branch changes the failure mode on an already-broken path rather than fixing it.
- **Cascades still recurse during a rerun.** `cleanup` runs immediately when `#stale` is true, so a chain registered during rerun teardown still overflows around 21k. The queue added here only covers `close()`.
- **Teardown still stops at a throwing cleanup.** The remaining cleanups, unwatch callbacks, and async clearing are skipped, as they are today.

## Test plan

- `nix develop --command just js check`
- `nix develop --command just js test` (all packages, 0 fail)

Four tests, each verified to fail without its fix: the spawn-during-close regression, cascading teardown still completing, a 100k cascade draining flat, and a throwing cleanup not stranding the queue.

The full JS suite emits **zero** `called when closed` warnings, so nothing in the workspace depended on the old ordering.

Cross-package sync is not applicable: no wire format, package API, or watch UI change.

(written by Claude Opus 5)