### PR TITLE
fix(net): shed a stale backlog on the ordered cursor, not just a blocking read

### DIFF
--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -281,10 +281,9 @@ test("the ordered handle carries datagrams", async () => {
 	expect((await track.nextGroup())?.sequence).toBe(3);
 });
 
-// The arrival cursor writes a backlog off; the ordered cursor does not. A group already
-// buffered costs nothing to deliver, and dropping it would put a hole in the sequence a
-// decoder is reading. The budget bounds how long a *blocking* group may stall instead.
-test("the latency budget skips a buffered timeline only on the arrival cursor", async () => {
+// Both cursors write a backlog off: a buffered group is not free to deliver, since a
+// consumer reading one that is already too old plays it at 1x and never catches up.
+test("the latency budget skips a buffered timeline on either cursor", async () => {
 	const producer = new TrackProducer("test").accept({ maxAge: 5000 });
 	const arrival = producer.subscribe();
 	const ordered = producer.subscribe().ordered();
@@ -294,10 +293,13 @@ test("the latency budget skips a buffered timeline only on the arrival cursor", 
 	}
 
 	expect((await arrival.recvGroup())?.sequence).toBe(2);
-
-	expect((await ordered.nextGroup())?.sequence).toBe(0);
-	expect((await ordered.nextGroup())?.sequence).toBe(1);
 	expect((await ordered.nextGroup())?.sequence).toBe(2);
+
+	// The budget is the only gate: one that spans the backlog bursts it in order.
+	const replay = producer.subscribe({ maxAge: 30_000 }).ordered();
+	expect((await replay.nextGroup())?.sequence).toBe(0);
+	expect((await replay.nextGroup())?.sequence).toBe(1);
+	expect((await replay.nextGroup())?.sequence).toBe(2);
 });
 
 // An unstamped immediate successor leaves a group's reach unbounded: a later stamped
@@ -317,11 +319,12 @@ test("an unstamped immediate successor leaves reach unbounded", async () => {
 	expect((await track.recvGroup())?.sequence).toBe(2);
 });
 
-// The ordered frame helpers share the burst contract: a buffered backlog is drained
-// in full rather than discarded for age.
-test("ordered frame reads drain a stale backlog", async () => {
+// The ordered frame helpers ride the same cursor, so they see the same budget: a
+// backlog inside it is drained in full, and what is past it is skipped.
+test("ordered frame reads follow the budget", async () => {
 	const producer = new TrackProducer("test").accept({ maxAge: 5000 });
-	const ordered = producer.subscribe().ordered();
+	const ordered = producer.subscribe({ maxAge: 5000 }).ordered();
+	const live = producer.subscribe().ordered();
 
 	for (const timestamp of [0, 1000, 2000]) {
 		producer.writeFrame({ payload: enc.encode(`${timestamp}`), timestamp: Timestamp.fromMillis(timestamp) });
@@ -330,6 +333,8 @@ test("ordered frame reads drain a stale backlog", async () => {
 	expect(await ordered.readString()).toBe("0");
 	expect(await ordered.readString()).toBe("1000");
 	expect(await ordered.readString()).toBe("2000");
+
+	expect(await live.readString()).toBe("2000");
 });
 
 // Interleaving nextGroup with the frame helpers is still one cursor: a nextGroup that
@@ -465,6 +470,31 @@ test("a named start is a floor, not a request", async () => {
 	// calls everything older stale.
 	const named = producer.subscribe({ startGroup: 1 });
 	expect((await named.recvGroup())?.sequence).toBe(4);
+});
+
+test("the ordered cursor sheds a stale backlog", async () => {
+	const producer = new TrackProducer("test").accept({ maxAge: 30_000 });
+	for (const timestamp of [0, 1000, 2000, 3000]) {
+		producer.writeFrame({ payload: enc.encode(`${timestamp}`), timestamp: Timestamp.fromMillis(timestamp) });
+	}
+
+	// The whole backlog is already buffered, so no read ever blocks on it: without the
+	// budget here the cursor would replay four seconds of history at 1x and stay behind.
+	const live = producer.subscribe().ordered();
+	expect((await live.nextGroup())?.sequence).toBe(3);
+
+	// Only what is provably too old goes. Group 0 reaches 1s, a full 2s behind the 3s
+	// edge; group 1 reaches 2s and could still present inside a 1.5s budget.
+	const bounded = producer.subscribe({ maxAge: 1500 }).ordered();
+	expect((await bounded.nextGroup())?.sequence).toBe(1);
+	expect((await bounded.nextGroup())?.sequence).toBe(2);
+	expect((await bounded.nextGroup())?.sequence).toBe(3);
+
+	// A budget spanning the history still bursts it in full, gap-free.
+	const replay = producer.subscribe({ maxAge: 30_000 }).ordered();
+	for (const sequence of [0, 1, 2, 3]) {
+		expect((await replay.nextGroup())?.sequence).toBe(sequence);
+	}
 });
 
 test("the budget is clamped to the publisher's window", async () => {

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1091,10 +1091,10 @@ export class Subscriber {
 	 * Treat the returned frame bytes as read-only; they are shared with other consumers.
 	 *
 	 * Groups are acquired through the same sequence cursor as {@link Ordered.nextGroup},
-	 * so frames never run backwards: a late lower-sequence group is skipped, and a
-	 * buffered backlog is drained in full rather than discarded for age. A group the
-	 * `maxAge` budget abandons mid-stall ends cleanly and the cursor resyncs from the
-	 * next group; an eviction gap inside a group still surfaces as {@link Lagged}.
+	 * so frames never run backwards: a late lower-sequence group is skipped, and so is
+	 * one every frame of which `maxAge` proves is too old. A group the budget abandons
+	 * mid-stall ends cleanly and the cursor resyncs from the next group; an eviction gap
+	 * inside a group still surfaces as {@link Lagged}.
 	 */
 	async #readFrameSequence(): Promise<({ group: number; frame: number } & Frame) | undefined> {
 		for (;;) {

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1043,10 +1043,20 @@ export class Subscriber {
 			const cursor = this.#cursor.peek();
 			const start = Math.max(cursor.start, this.#nextSequence);
 			while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
-			const group = groups[0];
-			if (group && (cursor.end === undefined || group.sequence <= cursor.end)) {
+			// One anchor for the whole pass, so walking a backlog off stays linear.
+			const drift = this.#drift();
+
+			for (;;) {
+				const group = groups[0];
+				if (!group || (cursor.end !== undefined && group.sequence > cursor.end)) break;
 				groups.shift();
 				this.#nextSequence = group.sequence + 1;
+				// Every frame this group could still hold is past the budget, so keep
+				// scanning: one pass walks a whole backlog off rather than replaying it.
+				if (this.#isStale(group, drift)) {
+					group.close();
+					continue;
+				}
 				// One cursor: the frame helpers must not keep draining a group this
 				// read just moved past, or interleaved reads would run backwards.
 				if (this.#frameGroup && this.#frameGroup.sequence < group.sequence) {
@@ -1061,7 +1071,7 @@ export class Subscriber {
 			// A group parked above the cap stays deliverable even after a clean close
 			// (its frames remain buffered), so keep waiting for a cap raise. Only a
 			// drained track reports finished.
-			if (closed !== undefined && !group) return undefined;
+			if (closed !== undefined && !groups[0]) return undefined;
 
 			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}
@@ -1181,9 +1191,12 @@ export class Subscriber {
  * Every group this returns has a higher sequence than the last, so a late arrival is
  * skipped rather than delivered out of turn.
  *
- * This cursor never drops a group it can already serve: a backlog is delivered as a
- * burst, in order, however old it is. `maxAge` instead bounds how long a group already
- * handed out may block, so a stalled group's pending frame read rejects once newer
+ * `maxAge` applies as this cursor reads, exactly as it does on the arrival cursor: a
+ * group is skipped once its reach, where its immediate successor begins, is that far
+ * behind the newest frame on the track. Nothing weaker convicts it, since the reach is
+ * the only proof that every frame it could still hold is past the budget, so a backlog
+ * inside the budget is still delivered whole, as a burst in order. The budget follows a
+ * group already handed out too: a stalled group's pending frame read rejects once newer
  * content has pulled that far ahead.
  */
 export class Ordered {
@@ -1252,8 +1265,10 @@ export class Ordered {
 	/**
 	 * Return the next group with a strictly-greater sequence number than the last returned.
 	 *
-	 * Late arrivals (sequence at or below the last returned) are silently skipped. Honors
-	 * the bounds set by {@link startAt} and {@link endAt}.
+	 * Late arrivals (sequence at or below the last returned) are silently skipped, as is a
+	 * group whose every frame is further behind the live edge than `maxAge` (the default of
+	 * zero keeps only what nothing newer has superseded). Honors the bounds set by
+	 * {@link startAt} and {@link endAt}.
 	 */
 	nextGroup(): Promise<GroupConsumer | undefined> {
 		return ordered_.nextGroup(this.#subscriber);
@@ -1263,9 +1278,7 @@ export class Ordered {
 	 * Read the next frame across groups, in sequence order.
 	 *
 	 * Rides the same cursor as {@link nextGroup} and shares this handle's contract: a
-	 * buffered backlog is drained in full, however old it is, never discarded for age.
-	 * A consumer that wants only the freshest content should jump via {@link latest}
-	 * and {@link startAt} rather than expect frame reads to skip ahead.
+	 * buffered backlog is drained in full up to the point `maxAge` proves it useless.
 	 * Treat the returned frame bytes as read-only; they are shared with other consumers.
 	 */
 	readFrame(): Promise<Frame | undefined> {

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -1520,12 +1520,12 @@ impl Subscriber {
 	/// `end`, inclusive), without advancing any cursor. The shared engine behind
 	/// [`Self::poll_next_group`] and [`Self::poll_seek_group`].
 	///
-	/// Unlike [`Self::poll_segment`], nothing is discarded for age: the spliced
-	/// sequence path inherits the [`track::Ordered`] contract of bursting a backlog
-	/// instead of skipping it. Nothing is consumed either: each segment is *seeked*
-	/// rather than read, so a candidate a poll does not deliver stays where it was,
-	/// and a cap lowered between polls never strands a group behind a segment cursor
-	/// that had already stepped past it.
+	/// Each segment's own cursor applies the drift budget as it seeks, so a group the
+	/// budget has convicted is stepped over here exactly as [`Self::poll_segment`]
+	/// steps over one. Nothing is *consumed*, though: each segment is seeked rather
+	/// than read, so a candidate a poll does not deliver stays where it was, and a cap
+	/// lowered between polls never strands a group behind a segment cursor that had
+	/// already stepped past it.
 	///
 	/// `deliver` marks the caller as the one handing the group out, which stamps the
 	/// winner's cache entry. A nested seek passes `false`: its candidate may lose at

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -461,6 +461,7 @@ impl Consumer {
 			next_sequence: 0,
 			min_sequence: 0,
 			end_sequence: None,
+			stale_cap: None,
 			drift_cap: kio::Producer::new(None),
 		}
 	}
@@ -1132,7 +1133,7 @@ impl SegmentSub {
 	/// already completed.
 	fn stale_sub_mut(&mut self) -> Option<&mut track::Subscriber> {
 		match &mut self.sub {
-			SubState::Active(sub) => Some(sub),
+			SubState::Active(sub) => Some(sub.as_mut()),
 			_ => self.terminal.as_mut(),
 		}
 	}
@@ -1141,7 +1142,7 @@ impl SegmentSub {
 	fn complete(&mut self, count: Option<u64>) {
 		let previous = std::mem::replace(&mut self.sub, SubState::Done(count));
 		if let SubState::Active(sub) = previous {
-			self.terminal = Some(sub);
+			self.terminal = Some(*sub);
 		}
 	}
 
@@ -1179,8 +1180,9 @@ impl SegmentSub {
 enum SubState {
 	/// Waiting for the underlying track's info (it may not be accepted yet).
 	Pending(kio::Pending<track::Subscribing>),
-	/// Live cursor over the underlying track.
-	Active(track::Subscriber),
+	/// Live cursor over the underlying track. Boxed: the subscriber dwarfs the other
+	/// variants, and every segment holds this enum.
+	Active(Box<track::Subscriber>),
 	/// The underlying track ended: `Some` with the group count when it finished
 	/// cleanly, `None` when it aborted or was dropped. An abort is deliberately
 	/// not surfaced: a dead route stalls the logical track until the next switch
@@ -1223,7 +1225,13 @@ pub struct Subscriber {
 	min_sequence: u64,
 	/// Inclusive cap for [`Self::next_group`], set by [`Self::end_at`].
 	end_sequence: Option<u64>,
-	/// Shared copy of [`Self::end_sequence`] for groups that outlive this cursor poll.
+	/// A cap imposed by a reader wrapping this subscriber (a nested splice segment),
+	/// folded into every drift anchor pushed onto the segments. Never bounds delivery:
+	/// the outer reader enforces its own window, and an inner cap would hide a
+	/// segment's completion from it.
+	stale_cap: Option<u64>,
+	/// Shared copy of the effective cap ([`Self::end_sequence`] and [`Self::stale_cap`]
+	/// combined) for groups that outlive this cursor poll.
 	drift_cap: kio::Producer<Option<u64>>,
 }
 
@@ -1351,12 +1359,13 @@ impl Subscriber {
 		}
 		self.segments.retain(|s| !s.retired());
 
+		let anchor = self.anchor_end();
 		for segment in segments {
 			match self.segments.iter_mut().find(|s| s.id == segment.id) {
 				Some(existing) => {
 					if existing.end != segment.end {
 						existing.end = segment.end;
-						let cap = Self::stale_cap(existing, self.end_sequence);
+						let cap = Self::stale_cap(existing, anchor);
 						if let Some(sub) = existing.stale_sub_mut() {
 							// The boundary bounds the drift anchor as well as the demand.
 							sub.set_stale_cap(cap);
@@ -1426,9 +1435,77 @@ impl Subscriber {
 	/// park boundary-crossing groups where its completion can't be seen), so this is how
 	/// both bounds reach the drift anchor. Without them a segment measures staleness
 	/// against groups it will never surface: the route running past the boundary, or the
-	/// reader's own cap holding content back.
-	fn stale_cap(seg: &SegmentSub, end_sequence: Option<u64>) -> Option<u64> {
-		min_some(end_sequence, seg.last_group())
+	/// reader's own cap holding content back. `anchor_end` is [`Self::anchor_end`], so a
+	/// cap imposed on this subscriber from outside is included.
+	fn stale_cap(seg: &SegmentSub, anchor_end: Option<u64>) -> Option<u64> {
+		min_some(anchor_end, seg.last_group())
+	}
+
+	/// The tightest cap any reader of this subscriber imposes: its own [`Self::end_at`]
+	/// and whatever a wrapping splice pushed down. What every segment's drift anchor is
+	/// bounded by.
+	fn anchor_end(&self) -> Option<u64> {
+		min_some(self.stale_cap, self.end_sequence)
+	}
+
+	/// Bound every segment's drift anchor from outside; the spliced arm of
+	/// [`track::Subscriber::set_stale_cap`], for this subscriber nested as a segment of
+	/// another splice.
+	pub(crate) fn set_stale_cap(&mut self, cap: Option<u64>) {
+		self.stale_cap = cap;
+		self.update_drift_cap();
+		let anchor = self.anchor_end();
+		for seg in &mut self.segments {
+			let cap = Self::stale_cap(seg, anchor);
+			if let Some(sub) = seg.stale_sub_mut() {
+				sub.set_stale_cap(cap);
+			}
+		}
+	}
+
+	/// Count each segment's seek convictions behind the deliverer's `committed`
+	/// watermark; the spliced arm of [`track::Subscriber::commit_seek_stale`].
+	pub(crate) fn commit_seek_stale(&mut self, committed: u64) {
+		for seg in &mut self.segments {
+			if let Some(sub) = seg.stale_sub_mut() {
+				sub.commit_seek_stale(committed);
+			}
+		}
+	}
+
+	/// Drop every segment's conviction for `sequence` without counting it; the
+	/// spliced arm of [`track::Subscriber::discard_seek_conviction`].
+	pub(crate) fn discard_seek_conviction(&mut self, sequence: u64) {
+		for seg in &mut self.segments {
+			if let Some(sub) = seg.stale_sub_mut() {
+				sub.discard_seek_conviction(sequence);
+			}
+		}
+	}
+
+	/// Whether the drift budget says to skip `group`, asked of the segment whose
+	/// window covers it; the spliced arm of [`track::Subscriber::poll_stale`], for a
+	/// nested splice's parked group being re-offered after a cap rise.
+	///
+	/// A group no current segment covers gets a `false`: with no cursor left that
+	/// could judge it, delivering is the safe direction.
+	pub(crate) fn poll_stale(&mut self, group: &group::Consumer, waiter: &kio::Waiter) -> Poll<Result<bool>> {
+		for seg in &mut self.segments {
+			if seg.first_group() <= group.sequence
+				&& seg.last_group().is_none_or(|last| group.sequence <= last)
+				&& let Some(sub) = seg.stale_sub_mut()
+			{
+				return sub.poll_stale(group, waiter);
+			}
+		}
+		Poll::Ready(Ok(false))
+	}
+
+	/// Publish the effective cap for groups that outlive this cursor poll.
+	fn update_drift_cap(&mut self) {
+		if let Ok(mut cap) = self.drift_cap.write() {
+			*cap = self.anchor_end();
+		}
 	}
 
 	/// Resolve a segment's pending subscription, if any. Ready once the segment is
@@ -1438,7 +1515,7 @@ impl Subscriber {
 		seg: &mut SegmentSub,
 		prefs: &Subscription,
 		min_sequence: u64,
-		end_sequence: Option<u64>,
+		anchor_end: Option<u64>,
 		waiter: &kio::Waiter,
 	) -> Poll<()> {
 		if let SubState::Pending(pending) = &mut seg.sub {
@@ -1452,9 +1529,9 @@ impl Subscriber {
 					// assigned: the inner subscription resolved its own start from its
 					// budget and floor, and this must not rewind past it.
 					sub.raise_start_to(seg.first_group().max(min_sequence));
-					sub.set_stale_cap(Self::stale_cap(seg, end_sequence));
+					sub.set_stale_cap(Self::stale_cap(seg, anchor_end));
 					let _ = sub.update(slice(prefs, seg.start, seg.end));
-					seg.sub = SubState::Active(sub);
+					seg.sub = SubState::Active(Box::new(sub));
 				}
 				// The underlying track was rejected or closed: stall, not error.
 				Poll::Ready(Err(_)) => seg.sub = SubState::Done(None),
@@ -1470,13 +1547,13 @@ impl Subscriber {
 		seg: &mut SegmentSub,
 		prefs: &Subscription,
 		min_sequence: u64,
-		end_sequence: Option<u64>,
+		anchor_end: Option<u64>,
 		waiter: &kio::Waiter,
 	) -> Poll<Option<group::Consumer>> {
 		loop {
 			match &mut seg.sub {
 				SubState::Pending(_) => {
-					ready!(Self::poll_activate(seg, prefs, min_sequence, end_sequence, waiter));
+					ready!(Self::poll_activate(seg, prefs, min_sequence, anchor_end, waiter));
 				}
 				SubState::Active(sub) => match sub.poll_recv_group(waiter) {
 					Poll::Ready(Ok(Some(group))) => {
@@ -1540,6 +1617,17 @@ impl Subscriber {
 	) -> Poll<Result<Option<group::Consumer>>> {
 		self.poll_sync(waiter);
 
+		// Delivery is the only irrevocable signal: the sequence cursor never returns
+		// below `next_sequence`, so every segment's convictions behind it are final.
+		// The floor is no substitute; it includes `start_at`, which can be lowered
+		// again. A nested seek (`deliver` false) commits nothing: the outer deliverer
+		// reaches these segments through its own commit recursion.
+		if deliver {
+			let committed = self.next_sequence;
+			self.commit_seek_stale(committed);
+		}
+
+		let anchor = self.anchor_end();
 		let mut floor = floor;
 		'retry: loop {
 			let mut all_done = true;
@@ -1551,7 +1639,7 @@ impl Subscriber {
 						&mut self.segments[index],
 						&self.last_prefs,
 						self.min_sequence,
-						end,
+						anchor,
 						waiter,
 					)
 					.is_pending()
@@ -1646,6 +1734,7 @@ impl Subscriber {
 		self.poll_sync(waiter);
 
 		let end_sequence = self.end_sequence;
+		let anchor = self.anchor_end();
 		let min_sequence = self.min_sequence;
 		let beyond_cap = |sequence: u64| end_sequence.is_some_and(|end| sequence > end);
 
@@ -1704,7 +1793,7 @@ impl Subscriber {
 					&mut self.segments[index],
 					&self.last_prefs,
 					min_sequence,
-					end_sequence,
+					anchor,
 					waiter,
 				);
 				match polled {
@@ -1783,6 +1872,12 @@ impl Subscriber {
 			return Poll::Ready(Ok(None));
 		};
 		self.next_sequence = self.next_sequence.max(group.sequence.saturating_add(1));
+		// A boundary inside the delivered group leaves a copy of this sequence in the
+		// next segment, which may have convicted it; the delivery splices into that
+		// copy, so its content is served and must not be counted.
+		self.discard_seek_conviction(group.sequence);
+		// The delivery commits every segment's convictions the cursor just passed.
+		self.commit_seek_stale(self.next_sequence);
 		Poll::Ready(Ok(Some(group)))
 	}
 
@@ -1815,8 +1910,9 @@ impl Subscriber {
 		// datagrams must still resolve the subscription (registering demand) and
 		// be woken when it activates.
 		let mut pending_activation = false;
+		let anchor = self.anchor_end();
 		if let Some(seg) = self.segments.last_mut() {
-			if Self::poll_activate(seg, &self.last_prefs, self.min_sequence, self.end_sequence, waiter).is_pending() {
+			if Self::poll_activate(seg, &self.last_prefs, self.min_sequence, anchor, waiter).is_pending() {
 				pending_activation = true;
 			} else if let SubState::Active(sub) = &mut seg.sub {
 				match sub.poll_recv_datagram(waiter) {
@@ -1875,7 +1971,7 @@ impl Subscriber {
 			seg,
 			&self.last_prefs,
 			self.min_sequence,
-			self.end_sequence,
+			min_some(self.stale_cap, self.end_sequence),
 			waiter
 		));
 		match &mut seg.sub {
@@ -1930,14 +2026,12 @@ impl Subscriber {
 	/// re-offers it.
 	pub fn end_at(&mut self, sequence: impl Into<Option<u64>>) {
 		self.end_sequence = sequence.into();
-		if let Ok(mut cap) = self.drift_cap.write() {
-			*cap = self.end_sequence;
-		}
+		self.update_drift_cap();
 		// The cap bounds each segment's drift anchor as well as this reader's own
 		// delivery: a segment must not measure against groups this cap hides.
-		let end_sequence = self.end_sequence;
+		let anchor = self.anchor_end();
 		for seg in &mut self.segments {
-			let cap = Self::stale_cap(seg, end_sequence);
+			let cap = Self::stale_cap(seg, anchor);
 			if let Some(sub) = seg.stale_sub_mut() {
 				sub.set_stale_cap(cap);
 			}
@@ -2769,6 +2863,300 @@ mod test {
 		})
 		.collect();
 		assert_eq!(replayed, vec![0, 1, 2, 3], "a backlog inside the budget crosses whole");
+	}
+
+	/// A nested splice's leaves are judged within the *outer* boundary. The outer
+	/// window reaches them two ways, through the seek's own `end` and through
+	/// [`track::Subscriber::set_stale_cap`] recursing into the spliced segment; without
+	/// either, a leaf anchors drift on a group past the outer boundary and convicts
+	/// everything the outer segment still owes its reader.
+	#[tokio::test]
+	async fn nested_splice_judges_within_the_outer_boundary() {
+		let stamp = |sequence: u64| Duration::from_secs(10 * sequence);
+
+		// Inner splice: one segment carrying groups 0..=2. Group 2 sits past the
+		// outer boundary below, so it is exactly the anchor the outer window must
+		// hide from the inner leaves.
+		let (mut track_a, consumer_a) = track_pair("a");
+		let mut inner = Producer::new();
+		inner.switch(&consumer_a, None).unwrap();
+		write_group_at(&mut track_a, 0, "a0", stamp(0));
+		write_group_at(&mut track_a, 1, "a1", stamp(1));
+		write_group_at(&mut track_a, 2, "a2", stamp(2));
+
+		// Outer splice: the inner spliced track up to group 2, then a plain track.
+		let inner_track =
+			track::Consumer::spliced("inner".into(), Arc::new(broadcast::Info::default()), inner.consume());
+		let (mut track_b, consumer_b) = track_pair("b");
+		let mut outer = Producer::new();
+		outer.switch(&inner_track, None).unwrap();
+		outer.switch(&consumer_b, Position::group(2)).unwrap();
+		write_group_at(&mut track_b, 2, "b2", stamp(2));
+		write_group_at(&mut track_b, 3, "b3", stamp(3));
+
+		// Group 1 is the newest group the outer window can serve from the nested
+		// segment, so it is its own live edge there and survives a zero budget.
+		let mut sub = outer.consume().subscribe(None);
+		let sequences: Vec<u64> = std::iter::from_fn(|| {
+			kio::wait(|waiter| sub.poll_next_group(waiter))
+				.now_or_never()?
+				.expect("should not error")
+				.map(|group| group.sequence)
+		})
+		.collect();
+		assert_eq!(
+			sequences,
+			vec![1, 3],
+			"the nested segment is judged within the outer boundary"
+		);
+
+		let mut arrival = outer.consume().subscribe(None);
+		let arrival: Vec<u64> = std::iter::from_fn(|| {
+			kio::wait(|waiter| arrival.poll_recv_group(waiter))
+				.now_or_never()?
+				.expect("should not error")
+				.map(|group| group.sequence)
+		})
+		.collect();
+		assert_eq!(arrival, sequences, "the arrival path sheds the same backlog");
+	}
+
+	/// A seek's conviction is speculative: the spliced path seeks every segment and
+	/// delivers from one, so a losing segment's conviction must not reach the stale
+	/// count until the cursor commits past it. A budget that widens in between delivers
+	/// the group after all, and delivered content never counts.
+	#[tokio::test]
+	async fn seek_conviction_counts_only_once_committed() {
+		let stamp = |sequence: u64| Duration::from_secs(10 * sequence);
+
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+		let mut producer = Producer::new();
+		producer.switch(&consumer_a, None).unwrap();
+		producer.switch(&consumer_b, Position::group(2)).unwrap();
+		write_group_at(&mut track_a, 0, "a0", stamp(0));
+		write_group_at(&mut track_a, 1, "a1", stamp(1));
+		write_group_at(&mut track_b, 2, "b2", stamp(2));
+		write_group_at(&mut track_b, 3, "b3", stamp(3));
+
+		let mut sub = producer.consume().subscribe(None);
+		let next = |sub: &mut Subscriber| {
+			kio::wait(|waiter| sub.poll_next_group(waiter))
+				.now_or_never()
+				.expect("should not block")
+				.expect("should not error")
+				.expect("should not be finished")
+				.sequence
+		};
+
+		// The zero budget delivers group 1 (segment A's newest) and convicts group 0
+		// there and group 2 in segment B, which loses this round: group 1 is lower.
+		// The delivery commits past group 0, so it counts; group 2 stays speculative.
+		assert_eq!(next(&mut sub), 1);
+		assert_eq!(
+			sub.take_stale().groups,
+			1,
+			"only the conviction the delivery passed counts"
+		);
+
+		// Widen the budget: the convicted-but-uncommitted group 2 is delivered after
+		// all, so it must never reach the stale count.
+		sub.update(Subscription::default().with_max_age(Duration::from_secs(60)));
+		assert_eq!(next(&mut sub), 2);
+		assert_eq!(next(&mut sub), 3);
+		assert_eq!(sub.take_stale().groups, 0, "delivered content never counts as stale");
+	}
+
+	/// The seek floor is not a commit signal: `start_at` can raise it and lower it
+	/// again, so a losing segment's conviction must survive a floor that briefly
+	/// jumped past it, and still be deliverable (uncounted) once the budget widens.
+	#[tokio::test]
+	async fn a_reversible_floor_does_not_commit_a_conviction() {
+		let stamp = |sequence: u64| Duration::from_secs(10 * sequence);
+
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+		let mut producer = Producer::new();
+		producer.switch(&consumer_a, None).unwrap();
+		producer.switch(&consumer_b, Position::group(2)).unwrap();
+		write_group_at(&mut track_a, 0, "a0", stamp(0));
+		write_group_at(&mut track_a, 1, "a1", stamp(1));
+		write_group_at(&mut track_b, 2, "b2", stamp(2));
+		write_group_at(&mut track_b, 3, "b3", stamp(3));
+
+		let mut sub = producer.consume().subscribe(None);
+		let next = |sub: &mut Subscriber| {
+			kio::wait(|waiter| sub.poll_next_group(waiter))
+				.now_or_never()
+				.expect("should not block")
+				.expect("should not error")
+				.expect("should not be finished")
+				.sequence
+		};
+
+		// Group 1 wins; group 2's conviction in segment B stays speculative.
+		assert_eq!(next(&mut sub), 1);
+		assert_eq!(sub.take_stale().groups, 1, "the delivery commits past group 0 only");
+
+		// Jump the floor past the conviction without delivering anything, then bring
+		// it back. Nothing was delivered, so nothing was committed.
+		sub.start_at(10);
+		assert!(
+			kio::wait(|waiter| sub.poll_next_group(waiter)).now_or_never().is_none(),
+			"nothing at or above the raised floor"
+		);
+		sub.start_at(0);
+
+		// The widened budget delivers the convicted group; it must not have been
+		// counted while the floor sat above it.
+		sub.update(Subscription::default().with_max_age(Duration::from_secs(60)));
+		assert_eq!(next(&mut sub), 2);
+		assert_eq!(next(&mut sub), 3);
+		assert_eq!(sub.take_stale().groups, 0, "a floor jump commits nothing");
+	}
+
+	/// A boundary inside a group leaves a copy of the same sequence in two segments:
+	/// the earlier serves the head, the later the continuation the delivery splices
+	/// into. The later segment's cursor can convict its copy, but the delivery serves
+	/// that content, so the conviction must be discarded rather than counted.
+	#[tokio::test]
+	async fn a_delivered_continuation_is_not_counted_stale() {
+		let stamp = |sequence: u64| Duration::from_secs(10 * sequence);
+
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+		let mut producer = Producer::new();
+		producer.switch(&consumer_a, None).unwrap();
+		// Mid-group boundary: group 1's head lives in segment A, its tail in B.
+		producer.switch(&consumer_b, Position { group: 1, frame: 1 }).unwrap();
+		write_group_at(&mut track_a, 0, "a0", stamp(0));
+		write_group_at(&mut track_a, 1, "a1", stamp(1));
+		write_group_at(&mut track_b, 1, "b1", stamp(1));
+		write_group_at(&mut track_b, 2, "b2", stamp(2));
+		write_group_at(&mut track_b, 3, "b3", stamp(3));
+
+		let mut sub = producer.consume().subscribe(None);
+		let next = |sub: &mut Subscriber| {
+			kio::wait(|waiter| sub.poll_next_group(waiter))
+				.now_or_never()
+				.expect("should not block")
+				.expect("should not error")
+				.expect("should not be finished")
+				.sequence
+		};
+
+		// Group 1 wins from segment A (it holds the head copy) while segment B has
+		// convicted both its continuation copy of 1 and group 2. Delivering 1 must
+		// discard B's copy, not count it.
+		assert_eq!(next(&mut sub), 1);
+		assert_eq!(next(&mut sub), 3);
+		assert_eq!(
+			sub.take_stale().groups,
+			2,
+			"groups 0 and 2 are stale; the delivered continuation of 1 is not"
+		);
+	}
+
+	/// A finalized losing segment's convictions must not be counted when its cursor
+	/// runs out: a mid-group boundary leaves the convicted sequence servable through
+	/// the *previous* segment (whose delivery splices into this segment's copy), and a
+	/// raised floor that forced the `None` can be lowered again. Only a delivery
+	/// commit may count; a conviction never committed is dropped with the cursor.
+	#[tokio::test]
+	async fn a_finalized_segment_flushes_nothing_without_a_delivery() {
+		let stamp = |sequence: u64| Duration::from_secs(10 * sequence);
+
+		// C owns group 0, A owns group 1's head, finalized B owns its tail onward.
+		let (mut track_c, consumer_c) = track_pair("c");
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+		let mut producer = Producer::new();
+		producer.switch(&consumer_c, None).unwrap();
+		producer.switch(&consumer_a, Position::group(1)).unwrap();
+		producer.switch(&consumer_b, Position { group: 1, frame: 1 }).unwrap();
+		write_group_at(&mut track_c, 0, "c0", stamp(0));
+		write_group_at(&mut track_a, 1, "a1", stamp(1));
+		write_group_at(&mut track_b, 1, "b1", stamp(1));
+		write_group_at(&mut track_b, 2, "b2", stamp(2));
+		write_group_at(&mut track_b, 3, "b3", stamp(3));
+		track_b.finish().unwrap();
+
+		let mut sub = producer.consume().subscribe(None);
+		let next = |sub: &mut Subscriber| {
+			kio::wait(|waiter| sub.poll_next_group(waiter))
+				.now_or_never()
+				.expect("should not block")
+				.expect("should not error")
+				.expect("should not be finished")
+				.sequence
+		};
+
+		// Delivering 0 leaves B's convictions of its copy of 1 (and of 2) pending.
+		assert_eq!(next(&mut sub), 0);
+
+		// A floor past B's final sequence runs its cursor out and completes the
+		// segment; the pending convictions must be dropped, not counted, because...
+		sub.start_at(10);
+		assert!(
+			kio::wait(|waiter| sub.poll_next_group(waiter)).now_or_never().is_none(),
+			"nothing at or above the raised floor"
+		);
+
+		// ...group 1 is still deliverable: A holds its head, and the delivery splices
+		// into the copy B's cursor convicted. Counted-and-delivered is the one thing
+		// the stale stat must never say.
+		sub.start_at(0);
+		sub.update(Subscription::default().with_max_age(Duration::from_secs(60)));
+		assert_eq!(next(&mut sub), 1);
+		assert_eq!(
+			sub.take_stale().groups,
+			0,
+			"no delivery ever committed past a conviction"
+		);
+	}
+
+	/// A parked group re-offered through a *nested* splice is re-checked against the
+	/// drift budget exactly as a plain segment's would be: the cap rising widened the
+	/// live edge too, and the covering segment's leaf is the cursor that can judge it.
+	#[tokio::test]
+	async fn nested_parked_group_is_rechecked_when_the_cap_rises() {
+		let stamp = |sequence: u64| Duration::from_secs(10 * sequence);
+
+		// Inner splice over one plain track holding groups 0..=2.
+		let (mut track_a, consumer_a) = track_pair("a");
+		let mut inner = Producer::new();
+		inner.switch(&consumer_a, None).unwrap();
+		write_group_at(&mut track_a, 0, "a0", stamp(0));
+		write_group_at(&mut track_a, 1, "a1", stamp(1));
+		write_group_at(&mut track_a, 2, "a2", stamp(2));
+
+		let inner_track =
+			track::Consumer::spliced("inner".into(), Arc::new(broadcast::Info::default()), inner.consume());
+		let mut outer = Producer::new();
+		outer.switch(&inner_track, None).unwrap();
+
+		// Capped at group 0: group 0 is the whole window (and so its own live edge),
+		// while groups 1 and 2 park above the cap.
+		let mut sub = outer.consume().subscribe(None);
+		sub.end_at(0);
+		let recv = |sub: &mut Subscriber| {
+			kio::wait(|waiter| sub.poll_recv_group(waiter))
+				.now_or_never()
+				.map(|group| {
+					group
+						.expect("should not error")
+						.expect("should not be finished")
+						.sequence
+				})
+		};
+		assert_eq!(recv(&mut sub), Some(0));
+		assert_eq!(recv(&mut sub), None, "groups beyond the cap park");
+
+		// Raising the cap re-offers the parked groups, but it also widened the live
+		// edge to group 2, so group 1 is stale now and must be skipped, not served.
+		sub.end_at(None);
+		assert_eq!(recv(&mut sub), Some(2), "the re-offered backlog is re-checked");
+		assert_eq!(sub.take_stale().groups, 1, "the skipped park is counted once");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -1774,9 +1774,9 @@ impl Subscriber {
 	/// Poll for the next group with a higher sequence than any previously
 	/// returned, skipping late arrivals, across the segments.
 	///
-	/// Mirrors [`track::Ordered`]: segments are seeked rather than read, no group is
-	/// discarded for age, and [`Subscription::max_age`] only bounds how long a
-	/// handed-out group's reads may block. See [`Self::poll_seek`].
+	/// Mirrors [`track::Ordered`]: segments are seeked rather than read, and each
+	/// segment's own cursor applies [`Subscription::max_age`] as it seeks, so a group
+	/// the budget has convicted is stepped over here too. See [`Self::poll_seek`].
 	pub fn poll_next_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
 		let floor = self.next_sequence.max(self.min_sequence);
 		let Some(group) = ready!(self.poll_seek(floor, self.end_sequence, true, waiter))? else {
@@ -2687,11 +2687,11 @@ mod test {
 		assert_eq!(next(&mut sub), 2);
 	}
 
-	/// The spliced sequence path inherits the [`track::Ordered`] contract: a backlog
-	/// the drift budget would discard on the arrival path is still delivered whole,
-	/// in order, exactly as a plain track's sequence cursor delivers it.
+	/// The spliced sequence path inherits the [`track::Ordered`] contract: the drift
+	/// budget applies as it reads, and a backlog inside the budget still crosses a
+	/// takeover boundary whole, exactly as a plain track's sequence cursor delivers it.
 	#[tokio::test]
-	async fn next_group_bursts_a_stale_backlog_like_a_plain_track() {
+	async fn next_group_sheds_a_stale_backlog_like_a_plain_track() {
 		// Groups spaced 10s apart on the media timeline, so with the default (zero)
 		// max age budget every group behind the newest one's reach is stale.
 		let stamp = |sequence: u64| Duration::from_secs(10 * sequence);
@@ -2710,9 +2710,9 @@ mod test {
 				.map(|group| group.sequence)
 		})
 		.collect();
-		assert_eq!(baseline, vec![0, 1, 2, 3], "a plain sequence cursor bursts the backlog");
+		assert_eq!(baseline, vec![3], "a plain sequence cursor sheds the backlog");
 
-		// The arrival path on the same content discards the backlog instead.
+		// The arrival path on the same content lands in the same place.
 		let mut arrival = plain.subscribe(None);
 		assert_eq!(
 			arrival.recv_group().now_or_never().unwrap().unwrap().unwrap().sequence,
@@ -2740,10 +2740,35 @@ mod test {
 				.map(|group| group.sequence)
 		})
 		.collect();
-		assert_eq!(
-			spliced, baseline,
-			"spliced and plain sequence cursors deliver the same backlog"
-		);
+
+		// Group 1 survives where the plain cursor drops it: each segment measures drift
+		// against its own boundary, since a segment cannot serve content past it, and
+		// group 1 is the newest thing segment A has. The sequence path inherits that
+		// from the arrival path rather than inventing its own anchor, so the two agree.
+		assert_eq!(spliced, vec![1, 3], "each segment is judged within its own boundary");
+
+		let mut arrival = producer.consume().subscribe(None);
+		let arrival: Vec<u64> = std::iter::from_fn(|| {
+			kio::wait(|waiter| arrival.poll_recv_group(waiter))
+				.now_or_never()?
+				.expect("should not error")
+				.map(|group| group.sequence)
+		})
+		.collect();
+		assert_eq!(arrival, spliced, "both spliced cursors shed the same backlog");
+
+		// A budget spanning the history bursts it in full across the boundary.
+		let mut replay = producer
+			.consume()
+			.subscribe(Subscription::default().with_max_age(Duration::from_secs(60)));
+		let replayed: Vec<u64> = std::iter::from_fn(|| {
+			kio::wait(|waiter| replay.poll_next_group(waiter))
+				.now_or_never()?
+				.expect("should not error")
+				.map(|group| group.sequence)
+		})
+		.collect();
+		assert_eq!(replayed, vec![0, 1, 2, 3], "a backlog inside the budget crosses whole");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1420,7 +1420,7 @@ impl Producer {
 				stale_cap: None,
 				drift_cap,
 				stale: stats::Content::default(),
-				seek_stale: 0,
+				seek_pending: BTreeMap::new(),
 			}),
 			// A producer-side (in-process) subscribe is not egress: stay untagged.
 			stats: stats::Scope::default(),
@@ -2373,7 +2373,7 @@ impl Subscribing {
 						stale_cap: None,
 						drift_cap,
 						stale: stats::Content::default(),
-						seek_stale: 0,
+						seek_pending: BTreeMap::new(),
 					}),
 					stats: self.stats.clone(),
 					_stats_sub: self.stats.subscribe(),
@@ -2834,9 +2834,9 @@ struct PlainSubscriber {
 	/// [`super::resume::Subscriber`] segment (untagged, so the outer wrapper is the
 	/// only place attribution happens once).
 	stale: stats::Content,
-	/// One past the highest sequence the seek path has counted into [`Self::stale`];
-	/// see [`Self::note_seek_stale`].
-	seek_stale: u64,
+	/// Groups the seek path has convicted but whose sequences no caller has committed
+	/// past yet, keyed by sequence; see [`Self::commit_seek_stale`].
+	seek_pending: BTreeMap<u64, stats::Content>,
 }
 
 impl PlainSubscriber {
@@ -2872,18 +2872,19 @@ impl PlainSubscriber {
 	/// This subscriber's clamped drift budget and the live edge to measure against,
 	/// resolved once per poll.
 	///
-	/// Read fresh each poll, so a mid-stream [`SubscriberControl::update`] applies to the
-	/// very next group, and shared across every candidate that poll walks off, so
+	/// `cap` bounds the anchor: the caller passes the same window it reads from, so a
+	/// group is only ever judged against content that could actually be served in its
+	/// place. Read fresh each poll, so a mid-stream [`SubscriberControl::update`] applies
+	/// to the very next group, and shared across every candidate that poll walks off, so
 	/// discarding a backlog of N groups costs one scan rather than N. Only ever
 	/// [`Poll::Ready`]; the track ending surfaces as the error the caller was going to
 	/// get anyway.
-	fn poll_drift(&self, waiter: &kio::Waiter) -> Poll<Result<Drift>> {
+	fn poll_drift(&self, cap: Option<u64>, waiter: &kio::Waiter) -> Poll<Result<Drift>> {
 		let mut max_age = Duration::default();
 		let _ = self.subscription.poll(waiter, |subscription| {
 			max_age = subscription.max_age;
 			Poll::<()>::Pending
 		});
-		let cap = servable_cap(self.end_sequence, self.stale_cap);
 		self.poll(waiter, move |state| {
 			Poll::Ready(Ok(Drift {
 				budget: clamp_max_age(max_age, state.max_age_bound()),
@@ -2933,7 +2934,7 @@ impl PlainSubscriber {
 			.retain(|sequence, group| *sequence >= min_sequence && watch(group));
 
 		// One scan for the whole poll, so walking a backlog off stays linear in its size.
-		let drift = ready!(self.poll_drift(waiter))?;
+		let drift = ready!(self.poll_drift(servable_cap(self.end_sequence, self.stale_cap), waiter))?;
 
 		loop {
 			// Re-offer the lowest parked group back inside the cap once it rises,
@@ -3000,6 +3001,8 @@ impl PlainSubscriber {
 			return Poll::Ready(Ok(None));
 		};
 		self.next_sequence = group.sequence.saturating_add(1);
+		// The delivery commits everything the seek stepped over to reach this group.
+		self.commit_seek_stale(self.next_sequence);
 		// Delivery is a cache access, same as the arrival-order path.
 		group.cache_refresh();
 		Poll::Ready(Ok(Some(group)))
@@ -3007,6 +3010,12 @@ impl PlainSubscriber {
 
 	/// Seek the lowest servable group in `floor..=end` without advancing any cursor,
 	/// walking off everything the drift budget has convicted on the way.
+	///
+	/// The drift anchor is built from the same window the seek reads (`end` folded into
+	/// the cap), so a candidate is only judged against content that could be served in
+	/// its place. A nested splice depends on this: its outer boundary arrives only as
+	/// this call's `end`, and an anchor past it would convict groups the caller still
+	/// owes its reader.
 	///
 	/// Repeated polls return the same group until the caller's own floor passes it,
 	/// which is the point: the spliced sequence path picks the lowest candidate across
@@ -3020,36 +3029,60 @@ impl PlainSubscriber {
 		let mut floor = floor.max(self.min_sequence);
 		let end = super::subscription::min_some(end, self.end_sequence);
 		// One scan for the whole poll, so walking a backlog off stays linear in its size.
-		let drift = ready!(self.poll_drift(waiter))?;
+		let drift = ready!(self.poll_drift(servable_cap(end, self.stale_cap), waiter))?;
 
 		loop {
 			let Some(group) = ready!(self.poll(waiter, |state| state.poll_next_in_range(floor, end))?) else {
+				// Deliberately no flush of `seek_pending` here: only a delivery commit
+				// may count a conviction. This `None` can be an artifact of a floor
+				// that will lower again, and a mid-group boundary can serve a
+				// convicted sequence through another segment even after this cursor
+				// retires. A conviction never committed is dropped uncounted with the
+				// cursor, the same tail bound a retired segment already has.
 				return Poll::Ready(Ok(None));
 			};
 
 			// Skip a group the budget has given up on and keep scanning, so one poll
 			// walks a whole backlog off rather than handing it out group by group.
 			if ready!(self.poll_stale(&group, &drift, waiter))? {
-				self.note_seek_stale(&group);
+				// Not counted yet: a seek advances no cursor, and a conviction is not
+				// permanent (the budget can widen, the edge can be evicted), so the
+				// group may still be delivered. Re-snapshot on every re-examination so
+				// the eventual count reflects the group's latest observed content.
+				self.seek_pending.insert(group.sequence, group.content());
 				floor = group.sequence.saturating_add(1);
 				continue;
 			}
 
+			// A conviction the budget walked back: the group is handed over after all,
+			// so it must never reach the stale count.
+			self.seek_pending.remove(&group.sequence);
 			return Poll::Ready(Ok(Some(self.with_expiry(group))));
 		}
 	}
 
-	/// Count a group the seek path skipped, at most once per sequence.
+	/// Count the seek path's convictions below `committed` into [`Self::stale`],
+	/// exactly once each.
 	///
-	/// A seek advances no cursor, so a convicted group it steps over is re-examined on
-	/// every later poll (the spliced path seeks each segment and delivers from one). The
-	/// watermark is what keeps those repeats out of the stats.
-	fn note_seek_stale(&mut self, group: &group::Consumer) {
-		if group.sequence < self.seek_stale {
-			return;
+	/// A seek is speculative: the spliced path seeks every segment and delivers from
+	/// one, so a conviction only becomes a real skip once a delivery commits past it.
+	/// Until then the entry waits in [`Self::seek_pending`], where a delivered group
+	/// removes itself (see [`Self::poll_seek_group`]). `committed` must be the
+	/// deliverer's sequence watermark (one past its last delivery), which only rises.
+	/// The seek's floor is NOT that: it includes `start_at`, which can be lowered
+	/// again, and a conviction it flushed could then be delivered after all.
+	fn commit_seek_stale(&mut self, committed: u64) {
+		let keep = self.seek_pending.split_off(&committed);
+		for (_, content) in std::mem::replace(&mut self.seek_pending, keep) {
+			self.stale.add(content);
 		}
-		self.seek_stale = group.sequence.saturating_add(1);
-		self.stale.add(group.content());
+	}
+
+	/// Drop a conviction for `sequence` without counting it: the sequence was
+	/// delivered by another cursor over the same content (a splice boundary inside
+	/// the group leaves a copy in two segments), so its content is not stale.
+	fn discard_seek_conviction(&mut self, sequence: u64) {
+		self.seek_pending.remove(&sequence);
 	}
 }
 
@@ -3131,22 +3164,54 @@ impl Subscriber {
 	/// A [`super::resume::Subscriber`] segment is deliberately left uncapped
 	/// ([`Self::end_at`] would park boundary-crossing groups where its completion can't
 	/// be seen), so its own cap has to reach the anchor this way or the segment measures
-	/// drift against groups its reader will never be served.
+	/// drift against groups its reader will never be served. A spliced segment folds the
+	/// cap into what it pushes onto its own segments, so the bound reaches the plain
+	/// cursors at the leaves however deep the splices nest.
 	pub(crate) fn set_stale_cap(&mut self, cap: Option<u64>) {
-		if let SubscriberKind::Plain(plain) = &mut self.inner {
-			plain.stale_cap = cap;
-			plain.update_drift_cap();
+		match &mut self.inner {
+			SubscriberKind::Plain(plain) => {
+				plain.stale_cap = cap;
+				plain.update_drift_cap();
+			}
+			SubscriberKind::Spliced(spliced) => spliced.set_stale_cap(cap),
+		}
+	}
+
+	/// Count the seek path's convictions below the deliverer's `committed` watermark
+	/// as stale, exactly once each; see [`PlainSubscriber::commit_seek_stale`].
+	///
+	/// The spliced seek calls this on every segment before it delivers, so a losing
+	/// segment's convictions are counted once the winning delivery moves the cursor
+	/// past them, and never before.
+	pub(crate) fn commit_seek_stale(&mut self, committed: u64) {
+		match &mut self.inner {
+			SubscriberKind::Plain(plain) => plain.commit_seek_stale(committed),
+			SubscriberKind::Spliced(spliced) => spliced.commit_seek_stale(committed),
+		}
+	}
+
+	/// Drop any conviction for `sequence` without counting it; see
+	/// [`PlainSubscriber::discard_seek_conviction`]. The spliced deliverer calls this
+	/// for the sequence it just handed out, since a boundary inside that group leaves
+	/// a convictable copy in the next segment that the delivery splices into.
+	pub(crate) fn discard_seek_conviction(&mut self, sequence: u64) {
+		match &mut self.inner {
+			SubscriberKind::Plain(plain) => plain.discard_seek_conviction(sequence),
+			SubscriberKind::Spliced(spliced) => spliced.discard_seek_conviction(sequence),
 		}
 	}
 
 	/// Whether the drift budget says to skip `group`, for a reader holding a group this
 	/// subscriber handed it earlier (a parked one, re-offered once a cap rose). Counts
-	/// the skip here so it reaches the stats with the rest.
+	/// the skip here so it reaches the stats with the rest. A spliced subscriber asks
+	/// the segment whose window covers the group, so a nested park is re-checked
+	/// against the same anchor a fresh read would use.
 	pub(crate) fn poll_stale(&mut self, group: &group::Consumer, waiter: &kio::Waiter) -> Poll<Result<bool>> {
-		let SubscriberKind::Plain(plain) = &mut self.inner else {
-			return Poll::Ready(Ok(false));
+		let plain = match &mut self.inner {
+			SubscriberKind::Plain(plain) => plain,
+			SubscriberKind::Spliced(spliced) => return spliced.poll_stale(group, waiter),
 		};
-		let drift = ready!(plain.poll_drift(waiter))?;
+		let drift = ready!(plain.poll_drift(servable_cap(plain.end_sequence, plain.stale_cap), waiter))?;
 		let stale = ready!(plain.poll_stale(group, &drift, waiter))?;
 		if stale {
 			plain.note_stale(group);

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1420,6 +1420,7 @@ impl Producer {
 				stale_cap: None,
 				drift_cap,
 				stale: stats::Content::default(),
+				seek_stale: 0,
 			}),
 			// A producer-side (in-process) subscribe is not egress: stay untagged.
 			stats: stats::Scope::default(),
@@ -2372,6 +2373,7 @@ impl Subscribing {
 						stale_cap: None,
 						drift_cap,
 						stale: stats::Content::default(),
+						seek_stale: 0,
 					}),
 					stats: self.stats.clone(),
 					_stats_sub: self.stats.subscribe(),
@@ -2832,6 +2834,9 @@ struct PlainSubscriber {
 	/// [`super::resume::Subscriber`] segment (untagged, so the outer wrapper is the
 	/// only place attribution happens once).
 	stale: stats::Content,
+	/// One past the highest sequence the seek path has counted into [`Self::stale`];
+	/// see [`Self::note_seek_stale`].
+	seek_stale: u64,
 }
 
 impl PlainSubscriber {
@@ -2991,16 +2996,17 @@ impl PlainSubscriber {
 
 	fn poll_next_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
 		let floor = self.next_sequence.max(self.min_sequence);
-		let Some(group) = ready!(self.poll(waiter, |state| state.poll_next_in_range(floor, self.end_sequence))?) else {
+		let Some(group) = ready!(self.poll_seek_group(floor, self.end_sequence, waiter))? else {
 			return Poll::Ready(Ok(None));
 		};
 		self.next_sequence = group.sequence.saturating_add(1);
 		// Delivery is a cache access, same as the arrival-order path.
 		group.cache_refresh();
-		Poll::Ready(Ok(Some(self.with_expiry(group))))
+		Poll::Ready(Ok(Some(group)))
 	}
 
-	/// Seek the lowest cached group in `floor..=end` without advancing any cursor.
+	/// Seek the lowest servable group in `floor..=end` without advancing any cursor,
+	/// walking off everything the drift budget has convicted on the way.
 	///
 	/// Repeated polls return the same group until the caller's own floor passes it,
 	/// which is the point: the spliced sequence path picks the lowest candidate across
@@ -3011,12 +3017,39 @@ impl PlainSubscriber {
 		end: Option<u64>,
 		waiter: &kio::Waiter,
 	) -> Poll<Result<Option<group::Consumer>>> {
-		let floor = floor.max(self.min_sequence);
+		let mut floor = floor.max(self.min_sequence);
 		let end = super::subscription::min_some(end, self.end_sequence);
-		let Some(group) = ready!(self.poll(waiter, |state| state.poll_next_in_range(floor, end))?) else {
-			return Poll::Ready(Ok(None));
-		};
-		Poll::Ready(Ok(Some(self.with_expiry(group))))
+		// One scan for the whole poll, so walking a backlog off stays linear in its size.
+		let drift = ready!(self.poll_drift(waiter))?;
+
+		loop {
+			let Some(group) = ready!(self.poll(waiter, |state| state.poll_next_in_range(floor, end))?) else {
+				return Poll::Ready(Ok(None));
+			};
+
+			// Skip a group the budget has given up on and keep scanning, so one poll
+			// walks a whole backlog off rather than handing it out group by group.
+			if ready!(self.poll_stale(&group, &drift, waiter))? {
+				self.note_seek_stale(&group);
+				floor = group.sequence.saturating_add(1);
+				continue;
+			}
+
+			return Poll::Ready(Ok(Some(self.with_expiry(group))));
+		}
+	}
+
+	/// Count a group the seek path skipped, at most once per sequence.
+	///
+	/// A seek advances no cursor, so a convicted group it steps over is re-examined on
+	/// every later poll (the spliced path seeks each segment and delivers from one). The
+	/// watermark is what keeps those repeats out of the stats.
+	fn note_seek_stale(&mut self, group: &group::Consumer) {
+		if group.sequence < self.seek_stale {
+			return;
+		}
+		self.seek_stale = group.sequence.saturating_add(1);
+		self.stale.add(group.content());
 	}
 }
 
@@ -3370,16 +3403,23 @@ impl Subscriber {
 ///
 /// # Age and skipping
 ///
-/// This cursor never discards a group it can already serve. A backlog is delivered as a
-/// burst, in order, however old it is. [`Subscription::max_age`] instead bounds how long
-/// a *handed-out* group may block: once newer content has pulled that far ahead, a read
-/// that is still waiting on it ends with [`Error::Old`] and the cursor moves on. A gap
-/// costs nothing either way, since the cursor seeks to the lowest cached group in range
-/// rather than waiting for the sequence it would have read next.
+/// [`Subscription::max_age`] applies as this cursor reads, exactly as it does on the
+/// arrival cursor: a group is skipped once its *reach*, where its immediate successor
+/// begins, is that far behind the newest frame on the track. Nothing weaker convicts it,
+/// because the reach is the only proof that *every* frame it could still hold is past the
+/// budget: a group's own timestamps say where it starts presenting, not where it stops,
+/// and an unstamped successor leaves it unbounded and therefore kept. A backlog inside
+/// the budget is still delivered whole, as a burst in order, which is what a decoder
+/// reading a gap-free sequence needs.
 ///
-/// The budget is [`Subscription::max_age`], updatable mid-stream through
-/// [`Self::control`]. [`Duration::ZERO`] (the default) gives up on a blocking group as
-/// soon as anything newer exists.
+/// The same budget follows a group already handed out: once newer content pulls that far
+/// ahead, a read still waiting on it ends with [`Error::Old`] and the cursor moves on. A
+/// gap costs nothing either way, since the cursor seeks to the lowest cached group in
+/// range rather than waiting for the sequence it would have read next.
+///
+/// The budget is updatable mid-stream through [`Self::control`]. [`Duration::ZERO`] (the
+/// default) keeps only what nothing newer has superseded, so a consumer that stalls and
+/// resumes rejoins the live edge instead of replaying at 1x.
 pub struct Ordered {
 	inner: Subscriber,
 }
@@ -5222,23 +5262,68 @@ mod test {
 		assert_eq!(group.sequence, 3);
 	}
 
+	/// Every group the ordered cursor can read right now, in sequence order.
+	fn drain_ordered(subscriber: &mut Ordered) -> Vec<u64> {
+		let mut sequences = Vec::new();
+		while let Some(Ok(Some(group))) = subscriber.next_group().now_or_never() {
+			sequences.push(group.sequence);
+		}
+		sequences
+	}
+
+	/// A cached backlog is not free to deliver: a consumer that stalls and resumes would
+	/// otherwise replay it at 1x and stay behind forever, since nothing it reads ever
+	/// blocks. The budget applies as the cursor reads, exactly as on the arrival cursor.
 	#[test]
-	fn next_group_bursts_a_stale_backlog() {
+	fn next_group_sheds_a_stale_backlog() {
 		let mut producer = track_producer("test", None);
 		for second in 0..4 {
 			append_at(&mut producer, second * 1000);
 		}
 
 		let mut subscriber = producer.subscribe(None).ordered();
-		let mut seen = Vec::new();
-		while let Some(Ok(Some(group))) = subscriber.next_group().now_or_never() {
-			seen.push(group.sequence);
-		}
-		assert_eq!(seen, vec![0, 1, 2, 3]);
+		assert_eq!(drain_ordered(&mut subscriber), vec![3]);
 
-		// The arrival cursor, which the relay forwarders use, still sheds it.
+		// The arrival cursor, which the relay forwarders use, sheds the same backlog.
 		let mut arrival = producer.subscribe(None);
 		assert_eq!(drain(&mut arrival), vec![3]);
+	}
+
+	/// Only what is provably too old goes. A group is convicted by its *reach* (where its
+	/// successor begins), so a budget spanning part of the backlog keeps every group that
+	/// could still present something inside it, and the burst is delivered gap-free.
+	#[test]
+	fn next_group_keeps_a_backlog_inside_the_budget() {
+		let mut producer = track_producer("test", None);
+		for second in 0..4 {
+			append_at(&mut producer, second * 1000);
+		}
+
+		// Group 0 reaches 1s, a full 2s behind the 3s edge, so it is gone. Group 1
+		// reaches 2s and could still present up to it: inside a 1.5s budget.
+		let mut subscriber = producer
+			.subscribe(Subscription::default().with_max_age(Duration::from_millis(1500)))
+			.ordered();
+		assert_eq!(drain_ordered(&mut subscriber), vec![1, 2, 3]);
+
+		// A budget covering the whole history still bursts it in full.
+		let mut replay = producer.subscribe(replay()).ordered();
+		assert_eq!(drain_ordered(&mut replay), vec![0, 1, 2, 3]);
+	}
+
+	/// A group whose immediate successor has not presented a frame has no proven reach,
+	/// so nothing says its frames are too old and the ordered cursor keeps it.
+	#[test]
+	fn next_group_keeps_a_group_with_no_proven_reach() {
+		let mut producer = track_producer("test", None);
+		append_at(&mut producer, 0); // seq 0
+		producer.append_group().unwrap(); // seq 1 stalls before its first frame
+		append_at(&mut producer, 10_000); // seq 2
+
+		// Group 1 reaches 10s, a full edge behind: convicted. Group 0 is bounded only by
+		// group 1, which has yet to say where it begins.
+		let mut subscriber = producer.subscribe(None).ordered();
+		assert_eq!(drain_ordered(&mut subscriber), vec![0, 2]);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -5136,10 +5136,6 @@ mod test {
 		assert_eq!(drain(&mut patient), vec![0, 1, 2, 3]);
 	}
 
-	/// The arrival cursor writes a backlog off; the ordered cursor does not. A group
-	/// that is already cached costs nothing to deliver, and dropping it would put a
-	/// hole in the sequence a decoder is reading. The budget bounds how long a
-	/// *blocking* group may stall, which is what group expiry enforces.
 	/// A group's age is where its content *ends*, not where it began. A long group whose
 	/// tail is level with the live edge still owes the reader every frame in it, so
 	/// judging it by its first timestamp would discard exactly the group being filled.

--- a/rs/moq-transcode/src/feed.rs
+++ b/rs/moq-transcode/src/feed.rs
@@ -176,10 +176,9 @@ async fn decode(inner: &Inner, sender: &broadcast::Sender<Item>) -> Result<(), E
 
 	// The feed serves whichever rungs are active, so there is no single
 	// downstream subscription to mirror; live-edge defaults fit every rung.
-	// Arrival order on purpose: its drift budget keeps dropping whatever falls
-	// behind the live edge, where a sequence cursor would burst the backlog
-	// through the codecs. Group order doesn't matter here, since every group
-	// decodes independently from its own keyframe.
+	// Arrival order on purpose: group order doesn't matter here, since every group
+	// decodes independently from its own keyframe, so there is nothing for a sequence
+	// cursor to buy. Either one drops whatever falls behind the live edge.
 	let mut subscriber = inner.source.subscribe(None).await?;
 
 	while let Some(mut group) = subscriber.recv_group().await? {


### PR DESCRIPTION
## Summary

- **Root cause**: `Subscription::max_age` only ever convicted a read that went `Pending`, and group expiry is what enforced it. A consumer that stalls and then resumes finds every group already cached, so no read pends, the budget never fires, and it plays the whole backlog at 1x and stays permanently behind. `moq-mux`'s container consumer carries its own gate on timestamps, but a raw `moq-net` or FFI consumer looping `next_group()` had none.
- The budget now applies as the ordered cursor reads, by the same **reach** rule the arrival cursor already uses: a group is skipped only once its immediate successor's first timestamp is a full budget behind the newest frame on the track. That is the only bound that proves *every* frame the group could still hold is too old, since a group's own timestamps say where it starts presenting, not where it stops. An unstamped successor leaves the reach unbounded, so that group is kept rather than dropped on a bound that could shrink, and a backlog inside the budget is still delivered whole, in order, which is what a decoder reading a gap-free sequence needs.
- The skip lives in `PlainSubscriber::poll_seek_group`, the one primitive both the plain `next_group` and the spliced `resume::poll_seek` go through, so the spliced path inherits it and nested splices compose. `poll_next_group` is now a thin wrapper over it (seek, bump the cursor, refresh the cache).
- A seek advances no cursor, so the spliced path re-examines a convicted group on every poll. `seek_stale` watermarks what has already been counted into `stats.stale` so the repeats stay out of it.
- `js/net` mirrors the same skip in `#nextGroup`, per Cross-Package Sync.

**Targets `dev`, not `main`**: no `pub` item is renamed, removed, or resignatured, so this is a `main`-shaped change by the rules. But `track::Ordered` and `Subscription::max_age` only exist on `dev` (d4a746106), so there is nothing on `main` for it to apply to.

## Behavior worth knowing

**A spliced track keeps one group per takeover boundary.** Each segment's drift anchor is capped at its own boundary (`set_stale_cap`), so the newest group *in that segment* is its own live edge and can never be convicted: a backlog split at group 2 yields `[1, 3]`, not `[3]`. This is not new, and not specific to the sequence cursor: the arrival path has always done exactly this, and the test now asserts the two agree rather than pinning the sequence path on its own. It also means a segment can never shed everything it holds, which is why no segment stalls waiting on a group it already skipped.

## Public API changes

None. No signature, name, or field moved on either side; `poll_seek_group` is `pub(crate)`.

## Wire behavior changes

None. `max_age` is already on the wire and the publisher already enforces it before putting a group on it; this is the subscriber-side half of the same budget, which `Subscription::max_age`'s own docs ("the subscriber applies the same budget again as it reads") already promised and only the arrival cursor delivered. `doc/concept/layer/moq-lite.md` likewise already documents both ends applying it. No `drafts/` update: nothing about the encoding changed.

What a *reader* observes differently: `Ordered::next_group` / `Ordered.nextGroup` now skip a provably-too-old group instead of replaying it. With the default `Duration::ZERO` budget, a cursor that falls behind rejoins the live edge. Over a real session this mostly aligns local reads with what the wire already did, since the publisher had already skipped those groups rather than sending them; it changes what an in-process or relay-cached backlog yields.

## Test plan

- `cargo nextest run` over `moq-net`, `moq-mux`, `hang`, `moq-json`, `moq-stats`, `moq-relay`, `moq-ffi`, `moq-hls`: **2332 passed**.
- All **1241** JS tests pass. `clippy -D warnings`, `cargo fmt`, `biome`, and `tsc` clean on the touched packages.
- Three tests encoded the old "never discards" policy and were rewritten (two JS, one Rust). New coverage on both sides: a backlog inside the budget still bursts gap-free; a group whose successor has not presented a frame is kept; the spliced path sheds the same backlog as the plain one and agrees with its own arrival cursor.
- `just check` / `just test` did not complete locally: both died on the shared `target/` dir (`failed to write .../fingerprint/aws-lc-sys-...`, then SIGTERM while blocked on the build lock) with several worktrees building at once. The scoped runs above cover the same ground; CI is the real gate.

## Performance

No new per-delivery scan over the cache, so nothing quadratic: drift is resolved once per poll rather than per candidate, `live_edge` stops at the newest stamped group, and `reach` stops at the immediate successor. Per delivered group the change adds two uncontended `kio` locks and two `O(log n)` map lookups, which is exactly what `recv_group` already pays on the hot relay path and well under the `Arc::new(GroupExpiry)` allocation already on that line. Shedding a backlog also got cheaper: one poll walks it off instead of N polls each handing over a group the consumer then discards.

Criterion numbers from this machine are not usable (load 100+ from concurrent worktree builds; the *untouched* `arrival` arm swung +137% at n=64 and −31% at n=4096). The load-immune read is the in-run `sequence` vs `arrival` ratio, since criterion interleaves them: `sequence` stays cheaper than `arrival` at every depth (13.6 ms vs 18.2 ms at n=4096) and stays linear in cache depth, which is the property `benches/group.rs` exists to guard.

## Follow-up: nested windows and speculative-seek accounting

The two review findings on this PR's own change (nested drift caps, premature stale accounting) are fixed here rather than as follow-ups, plus three more found by a second adversarial pass over the fix itself.

**Nested drift anchors ignored the outer window.** When a `resume::Subscriber` is itself a segment of another spliced track, the outer caller's window never reached the leaves: `poll_drift` built its anchor from the leaf's own `end_sequence`/`stale_cap`, and `set_stale_cap` was a no-op on a `Spliced` subscriber. A nested cursor capped at group 1 could judge groups 0 and 1 against a group 2 outside the outer segment and convict both, stalling the segment with content still owed. Fixed at both ends: the seek folds its own `end` into the drift anchor it resolves, and `set_stale_cap` recurses through a spliced subscriber into its segments' leaves, which also fixes the arrival path's version of the same gap. The parked re-offer recheck (`poll_stale`) recurses the same way, so a nested park is re-judged when the cap rises instead of being served stale. Regressions: `nested_splice_judges_within_the_outer_boundary`, `nested_parked_group_is_rechecked_when_the_cap_rises`.

**Seek convictions were counted before anything committed past them.** A seek is speculative: `resume::poll_seek` seeks every segment and delivers from one, so a losing segment's conviction could land in `stats.stale` and later be delivered anyway (a widened budget), contradicting the field's "skipped content is never handed over" contract. Convictions now wait in a per-leaf pending set and are counted only when a delivery commits the cursor past them. Nothing weaker counts, because every weaker signal turned out reversible: the seek floor includes `start_at`, which can be lowered again; and a terminal `None` can be a raised-floor artifact whose convicted sequence another segment still serves through a mid-group splice. A delivered sequence is discarded uncounted from every segment (a mid-group boundary leaves a convictable copy of the delivered group in the next segment, which the delivery splices into), and a conviction never committed is dropped uncounted with its cursor, the same tail bound a retired segment already had. Regressions: `seek_conviction_counts_only_once_committed`, `a_reversible_floor_does_not_commit_a_conviction`, `a_delivered_continuation_is_not_counted_stale`, `a_finalized_segment_flushes_nothing_without_a_delivery`; each fails without its fix.

`SubState` boxes its `Active` cursor (the subscriber outgrew the other variants; clippy `large_enum_variant`).

No public API or wire change; everything above is `pub(crate)` or private. JS needs no mirror: `#nextGroup`'s skip advances the cursor in the same step (a commit, not a speculative seek) and js/net has no spliced segments.

(Written by Claude Opus 5; follow-up fixes by Claude Fable 5)

